### PR TITLE
feat: add benchmark CLI entry point and npm script (#21)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "dev": "tsc -p tsconfig.cli.json --watch",
     "start": "node dist/cli/index.js serve",
     "check": "node dist/cli/index.js check",
+    "benchmark": "ts-node tests/benchmark/run.ts",
+    "benchmark:ci": "ts-node tests/benchmark/run.ts --ci",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "lint": "eslint src --ext .ts",

--- a/tests/benchmark/run.ts
+++ b/tests/benchmark/run.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env ts-node
+/**
+ * Benchmark CLI entry point
+ * Usage:
+ *   npm run benchmark          # Interactive mode with formatted report
+ *   npm run benchmark:ci       # CI mode with JSON output and regression check
+ */
+
+import { BenchmarkRunner, BenchmarkReport } from './benchmark-runner';
+import { OpenChromeAdapter } from './adapters/openchrome-adapter';
+import { createNavigationTask } from './tasks/navigation';
+import { createReadingTask } from './tasks/reading';
+import { createFormFillTask } from './tasks/form-fill';
+import { createClickSequenceTask } from './tasks/click-sequence';
+import { createSearchTask } from './tasks/search';
+import { createAllParallelTasks } from './tasks/parallel';
+
+async function main(): Promise<void> {
+  const ciMode = process.argv.includes('--ci');
+
+  const runner = new BenchmarkRunner({
+    runsPerTask: ciMode ? 3 : 5,
+    ciMode,
+  });
+
+  // Register all benchmark tasks
+  runner.addTask(createNavigationTask());
+  runner.addTask(createReadingTask());
+  runner.addTask(createFormFillTask());
+  runner.addTask(createClickSequenceTask());
+  runner.addTask(createSearchTask());
+  for (const task of createAllParallelTasks()) {
+    runner.addTask(task);
+  }
+
+  // Run with both AX and DOM adapters
+  const axAdapter = new OpenChromeAdapter({ mode: 'ax' });
+  const domAdapter = new OpenChromeAdapter({ mode: 'dom' });
+
+  console.log('Running benchmarks in AX mode...');
+  const axReport = await runner.run(axAdapter);
+
+  console.log('Running benchmarks in DOM mode...');
+  const domReport = await runner.run(domAdapter);
+
+  const reports: BenchmarkReport[] = [axReport, domReport];
+
+  if (ciMode) {
+    // CI mode: JSON output + regression check
+    console.log(JSON.stringify(reports, null, 2));
+
+    // Check for regressions (DOM vs AX baseline)
+    const regression = BenchmarkRunner.checkRegression(axReport, domReport, 0.1);
+    if (!regression.passed) {
+      console.error('\nRegression detected:');
+      for (const r of regression.regressions) {
+        console.error(`  - ${r}`);
+      }
+      process.exit(1);
+    }
+
+    console.log('\nNo regressions detected.');
+  } else {
+    // Interactive mode: formatted report
+    console.log(BenchmarkRunner.formatReport(reports));
+  }
+}
+
+main().catch((err) => {
+  console.error('Benchmark failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add `tests/benchmark/run.ts` as a CLI entry point for running benchmarks from the command line
- Register all benchmark tasks (navigation, reading, form-fill, click-sequence, search, and all parallel scale tasks via `createAllParallelTasks()`)
- Run benchmarks with both AX and DOM adapters and compare results
- Support interactive mode (formatted report) and CI mode (`--ci` flag: JSON output + regression check with `process.exit(1)` on failure)
- Add `benchmark` and `benchmark:ci` npm scripts to `package.json`

## Test plan

- [x] `npm run build` passes with no compilation errors
- [x] `npx jest tests/benchmark/ --no-coverage` — all 34 existing benchmark tests pass
- [ ] `npm run benchmark` — runs interactive mode with formatted report
- [ ] `npm run benchmark:ci` — runs CI mode with JSON output and regression check

🤖 Generated with [Claude Code](https://claude.com/claude-code)