### PR TITLE
fix: suggest mode "dom" in AX tree truncation message

### DIFF
--- a/src/tools/read-page.ts
+++ b/src/tools/read-page.ts
@@ -259,7 +259,7 @@ const handler: ToolHandler = async (
             type: 'text',
             text:
               output +
-              '\n\n[Output truncated. Use smaller depth or ref_id to focus on specific element.]',
+              '\n\n[Output truncated. Try mode: "dom" for ~5-10x fewer tokens, or use smaller depth / ref_id to focus on specific element.]',
           },
         ],
       };


### PR DESCRIPTION
## Summary

- Updates the AX tree truncation message in `src/tools/read-page.ts` to mention `mode: "dom"` as the most effective solution for reducing token usage (~5-10x fewer tokens)
- No test changes needed — no existing tests assert on this specific message string

## Changes

**`src/tools/read-page.ts`** (line 262): Updated truncation hint from:
```
[Output truncated. Use smaller depth or ref_id to focus on specific element.]
```
to:
```
[Output truncated. Try mode: "dom" for ~5-10x fewer tokens, or use smaller depth / ref_id to focus on specific element.]
```

## Test plan

- [x] `npm run build` — passes
- [x] `npx jest --testPathPattern read-page` — 29 tests pass
- [x] `npm test` — 1015 tests pass across 49 test suites

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)