### PR TITLE
fix: address e2e verification gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Measure token efficiency and parallel performance:
 ```bash
 npm run benchmark                                    # AX vs DOM token efficiency (interactive)
 npm run benchmark:ci                                 # AX vs DOM with JSON + regression detection
-npx ts-node tests/benchmark/run-parallel.ts          # 7 parallel benchmark categories
+npx ts-node tests/benchmark/run-parallel.ts          # All parallel benchmark categories
 ```
 
 **Parallel benchmark categories:**
@@ -273,6 +273,7 @@ npx ts-node tests/benchmark/run-parallel.ts          # 7 parallel benchmark cate
 |----------|-----------------|
 | Multi-step interaction | Form fill + click sequences across N parallel pages |
 | Batch JS execution | N × `javascript_tool` vs 1 × `batch_execute` |
+| Compiled plan execution | Sequential agent tool calls vs single `execute_plan` |
 | Streaming collection | Blocking vs `workflow_collect_partial` |
 | Init overhead | Sequential `tabs_create` vs batch `workflow_init` |
 | Fault tolerance | Circuit breaker recovery speed |


### PR DESCRIPTION
## Summary
- Add test assertion verifying AX truncation message suggests `mode: "dom"` (closes V2 gap from #36)
- Add missing "Compiled plan execution" row to README benchmark table — was listing 6 of 7 categories (closes V3 inaccuracy from #36)

## Test plan
- [x] `npm run build` passes (0 errors)
- [x] `npm test` passes (50 suites, 1019 tests — +1 new test)
- [x] New test `truncation message suggests DOM mode` specifically verifies the fix
- [x] README benchmark table now lists all 7 parallel benchmark categories

Addresses verification gaps found in Issue #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)