### PR TITLE
feat: graceful Chrome restart with debug port

### DIFF
--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -557,7 +557,7 @@ export class ChromeLauncher {
   /**
    * Check if Chrome is currently running (regardless of debug port)
    */
-  isChromeRunning(): boolean {
+  private isChromeRunning(): boolean {
     const platform = os.platform();
     try {
       if (platform === 'darwin') {
@@ -588,7 +588,7 @@ export class ChromeLauncher {
    * Gracefully quit running Chrome using platform-specific commands.
    * Returns true if Chrome exited within the timeout.
    */
-  async quitRunningChrome(timeout = 10000): Promise<boolean> {
+  private async quitRunningChrome(timeout = 10000): Promise<boolean> {
     const platform = os.platform();
     try {
       if (platform === 'darwin') {
@@ -626,7 +626,7 @@ export class ChromeLauncher {
    * Quit Chrome and wait for the profile lock to be released.
    * Returns true if the profile was successfully unlocked.
    */
-  async quitAndUnlockProfile(profileDir: string, quitTimeout = 10000, unlockTimeout = 5000): Promise<boolean> {
+  private async quitAndUnlockProfile(profileDir: string, quitTimeout = 10000, unlockTimeout = 5000): Promise<boolean> {
     const chromeExited = await this.quitRunningChrome(quitTimeout);
     if (!chromeExited) {
       return false;

--- a/tests/chrome/launcher-restart.test.ts
+++ b/tests/chrome/launcher-restart.test.ts
@@ -55,7 +55,7 @@ describe('ChromeLauncher graceful restart', () => {
       // pgrep exits 0 → Chrome is running
       mockExecSync.mockReturnValue(Buffer.from('12345'));
 
-      expect(launcher.isChromeRunning()).toBe(true);
+      expect((launcher as any).isChromeRunning()).toBe(true);
       expect(mockExecSync).toHaveBeenCalledWith(
         'pgrep -x "Google Chrome"',
         { stdio: 'ignore' }
@@ -68,7 +68,7 @@ describe('ChromeLauncher graceful restart', () => {
         throw new Error('No matching processes');
       });
 
-      expect(launcher.isChromeRunning()).toBe(false);
+      expect((launcher as any).isChromeRunning()).toBe(false);
     });
 
     it('should return false on unexpected errors', () => {
@@ -76,7 +76,7 @@ describe('ChromeLauncher graceful restart', () => {
         throw new Error('Command not found');
       });
 
-      expect(launcher.isChromeRunning()).toBe(false);
+      expect((launcher as any).isChromeRunning()).toBe(false);
     });
   });
 
@@ -99,7 +99,7 @@ describe('ChromeLauncher graceful restart', () => {
         return Buffer.from('');
       });
 
-      const result = await launcher.quitRunningChrome(5000);
+      const result = await (launcher as any).quitRunningChrome(5000);
 
       expect(result).toBe(true);
       expect(quitCalled).toBe(true);
@@ -115,7 +115,7 @@ describe('ChromeLauncher graceful restart', () => {
         return Buffer.from('12345');
       });
 
-      const result = await launcher.quitRunningChrome(1000);
+      const result = await (launcher as any).quitRunningChrome(1000);
       expect(result).toBe(false);
     });
 
@@ -129,7 +129,7 @@ describe('ChromeLauncher graceful restart', () => {
         throw new Error('No matching processes');
       });
 
-      const result = await launcher.quitRunningChrome(2000);
+      const result = await (launcher as any).quitRunningChrome(2000);
       // Chrome ended up not running, so returns true
       expect(result).toBe(true);
     });
@@ -156,7 +156,7 @@ describe('ChromeLauncher graceful restart', () => {
         return Buffer.from('');
       });
 
-      const result = await launcher.quitAndUnlockProfile(tmpDir, 5000, 5000);
+      const result = await (launcher as any).quitAndUnlockProfile(tmpDir, 5000, 5000);
       expect(result).toBe(true);
 
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -169,7 +169,7 @@ describe('ChromeLauncher graceful restart', () => {
       // pgrep always succeeds → Chrome never quits
       mockExecSync.mockReturnValue(Buffer.from('12345'));
 
-      const result = await launcher.quitAndUnlockProfile(tmpDir, 1000, 1000);
+      const result = await (launcher as any).quitAndUnlockProfile(tmpDir, 1000, 1000);
       expect(result).toBe(false);
 
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -194,7 +194,7 @@ describe('ChromeLauncher graceful restart', () => {
         return Buffer.from('');
       });
 
-      const result = await launcher.quitAndUnlockProfile(tmpDir, 5000, 1000);
+      const result = await (launcher as any).quitAndUnlockProfile(tmpDir, 5000, 1000);
       expect(result).toBe(false);
 
       fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Closes #42

- When Chrome is running without a debug port and the profile is locked, gracefully quit Chrome (saving session state), wait for profile unlock, then relaunch with `--remote-debugging-port`
- Preserves authenticated sessions and open tabs instead of falling back to a temporary profile
- Platform-specific implementations: macOS (`osascript`), Windows (`taskkill`), Linux (`pkill -TERM`)
- Falls back to existing temp profile behavior if graceful restart fails

## Changes

- `src/chrome/launcher.ts`: Add `isChromeRunning()`, `quitRunningChrome()`, `quitAndUnlockProfile()` methods + restart branch in `ensureChrome()`
- `tests/chrome/launcher-restart.test.ts`: 10 tests covering all new methods and edge cases

## Test plan

- [x] `npm run build` passes
- [x] All 10 new tests pass (isChromeRunning, quitRunningChrome, quitAndUnlockProfile, ensureChrome skip)
- [ ] Manual: with Chrome running, `oc serve --auto-launch` → Chrome restarts with debug port + tabs restored
- [ ] Manual: without Chrome running, `oc serve --auto-launch` → normal launch (no regression)
- [ ] Manual: `oc serve --auto-launch --headless-shell` → headless mode unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)