### PR TITLE
feat: proactive context in read_page output

### DIFF
--- a/src/dom/dom-serializer.ts
+++ b/src/dom/dom-serializer.ts
@@ -58,6 +58,9 @@ const KEEP_ATTRS = new Set([
   'id', 'name', 'type', 'value', 'placeholder', 'aria-label', 'role',
   'href', 'src', 'alt', 'title', 'data-testid', 'disabled', 'checked',
   'selected', 'required', 'class',
+  // Common data attributes for testing and automation
+  'data-cy', 'data-qa', 'data-id', 'data-value', 'data-state',
+  'tabindex',
 ]);
 
 // Interactive tag names
@@ -117,6 +120,7 @@ function formatElement(
   attrMap: Map<string, string>,
   indent: string,
   textContent: string,
+  interactive: boolean,
 ): string {
   const tagName = node.localName || node.nodeName.toLowerCase();
 
@@ -129,7 +133,8 @@ function formatElement(
   }
   const attrStr = attrParts.length > 0 ? ' ' + attrParts.join(' ') : '';
 
-  const line = `${indent}[${node.backendNodeId}]<${tagName}${attrStr}/>${textContent}`;
+  const interactiveMarker = interactive ? ' ★' : '';
+  const line = `${indent}[${node.backendNodeId}]<${tagName}${attrStr}/>${textContent}${interactiveMarker}`;
   return line;
 }
 
@@ -183,7 +188,7 @@ function serializeNode(
 
   if (!ctx.interactiveOnly || interactive) {
     const textContent = getDirectTextContent(node);
-    const line = formatElement(node, attrMap, indent, textContent);
+    const line = formatElement(node, attrMap, indent, textContent, interactive);
     const lineWithNewline = line + '\n';
 
     if (ctx.totalChars + lineWithNewline.length > ctx.maxOutputChars) {
@@ -256,7 +261,7 @@ export async function serializeDOM(
 
   // Add page stats header
   if (includePageStats) {
-    const statsLine = `[page_stats] url: ${pageStats.url} | title: ${pageStats.title} | scroll: ${pageStats.scrollX},${pageStats.scrollY} | viewport: ${pageStats.viewportWidth}x${pageStats.viewportHeight}\n\n`;
+    const statsLine = `[page_stats] url: ${pageStats.url} | title: ${pageStats.title} | scroll: ${pageStats.scrollX},${pageStats.scrollY} | viewport: ${pageStats.viewportWidth}x${pageStats.viewportHeight} | docSize: ${pageStats.scrollWidth}x${pageStats.scrollHeight}\n\n`;
     lines.push(statsLine);
   }
 

--- a/src/tools/read-page.ts
+++ b/src/tools/read-page.ts
@@ -313,6 +313,19 @@ const handler: ToolHandler = async (
       }
     }
 
+    // Add page stats header for AX mode (matching DOM mode format)
+    const axPageStats = await page.evaluate(() => ({
+      url: window.location.href,
+      title: document.title,
+      scrollX: Math.round(window.scrollX),
+      scrollY: Math.round(window.scrollY),
+      scrollWidth: document.documentElement.scrollWidth,
+      scrollHeight: document.documentElement.scrollHeight,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    }));
+    const pageStatsLine = `[page_stats] url: ${axPageStats.url} | title: ${axPageStats.title} | scroll: ${axPageStats.scrollX},${axPageStats.scrollY} | viewport: ${axPageStats.viewportWidth}x${axPageStats.viewportHeight} | docSize: ${axPageStats.scrollWidth}x${axPageStats.scrollHeight}\n\n`;
+
     // Get the accessibility tree
     const { nodes } = await cdpClient.send<{ nodes: AXNode[] }>(
       page,
@@ -450,6 +463,7 @@ const handler: ToolHandler = async (
           {
             type: 'text',
             text:
+              pageStatsLine +
               output +
               '\n\n[Output truncated. Try mode: "dom" for ~5-10x fewer tokens, or use smaller depth / ref_id to focus on specific element.]' +
               axPaginationSection,
@@ -459,7 +473,7 @@ const handler: ToolHandler = async (
     }
 
     return {
-      content: [{ type: 'text', text: output + axPaginationSection }],
+      content: [{ type: 'text', text: pageStatsLine + output + axPaginationSection }],
     };
   } catch (error) {
     return {


### PR DESCRIPTION
## Summary

- **Interactivity markers**: DOM mode now appends `★` to interactive elements (button, input, select, textarea, a, [role=button], etc.), letting the LLM instantly identify clickable targets
- **Expanded data attributes**: `KEEP_ATTRS` now includes `data-cy`, `data-qa`, `data-id`, `data-value`, `data-state`, and `tabindex` for better element identification in test-attributed codebases
- **Document size in page_stats**: Adds `docSize: {scrollWidth}x{scrollHeight}` to help LLM understand if content extends beyond viewport
- **Page stats in AX mode**: AX mode now includes the same `[page_stats]` header as DOM mode, providing consistent URL, title, scroll position, viewport, and document size context

**Why**: LLM wandering often starts because the model lacks upfront context — it doesn't know which elements are interactive, can't see testing attributes, and has no sense of page dimensions. These changes provide that context proactively, before the LLM makes decisions.

**Example DOM output**:
```
[page_stats] url: https://example.com | title: Example | scroll: 0,0 | viewport: 1920x1080 | docSize: 1920x3000

[142]<input type="search" placeholder="Search..." data-cy="search-input"/> ★
[156]<button type="submit" data-qa="search-btn"/>Search ★
[289]<a href="/home"/>Home ★
[352]<h1/>Welcome to Example
```

## Test plan

- [x] `★` marker appears on interactive elements (button, input, a)
- [x] Non-interactive elements (h1, div) do NOT have `★`
- [x] New data-* attributes appear in DOM output
- [x] `docSize` appears in page_stats header
- [x] AX mode includes `[page_stats]` header
- [x] Backward compatibility: default mode still returns AX tree with `ref_N`
- [x] Build passes (0 errors), 1051 tests passing

Closes #52 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)