### PR TITLE
feat: screenshot resilience with auto-retry and DOM fallback

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -6,7 +6,7 @@ import puppeteer, { Browser, BrowserContext, Page, Target, CDPSession } from 'pu
 import { getChromeLauncher } from '../chrome/launcher';
 import { getGlobalConfig } from '../config/global';
 import { smartGoto } from '../utils/smart-goto';
-import { DEFAULT_VIEWPORT, DEFAULT_NAVIGATION_TIMEOUT_MS } from '../config/defaults';
+import { DEFAULT_VIEWPORT, DEFAULT_NAVIGATION_TIMEOUT_MS, DEFAULT_PROTOCOL_TIMEOUT_MS } from '../config/defaults';
 
 // Cookie type shared across methods
 type CookieEntry = {
@@ -250,6 +250,7 @@ export class CDPClient {
     this.browser = await puppeteer.connect({
       browserWSEndpoint: instance.wsEndpoint,
       defaultViewport: null,
+      protocolTimeout: DEFAULT_PROTOCOL_TIMEOUT_MS,
     });
 
     // Set up disconnect handler

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -19,3 +19,9 @@ export const DEFAULT_NAVIGATION_TIMEOUT_MS = 30000;
 
 /** Maximum number of candidate elements returned by element-finding queries. */
 export const MAX_SEARCH_CANDIDATES = 30;
+
+/** CDP protocol timeout in milliseconds. Prevents 180s default hangs. */
+export const DEFAULT_PROTOCOL_TIMEOUT_MS = 30000;
+
+/** Screenshot-specific timeout. Shorter than protocol timeout for fast fallback. */
+export const DEFAULT_SCREENSHOT_TIMEOUT_MS = 15000;

--- a/src/hints/rules/error-recovery.ts
+++ b/src/hints/rules/error-recovery.ts
@@ -23,8 +23,12 @@ const patterns: Array<{ test: RegExp; hint: string }> = [
     hint: 'Hint: Element may not be loaded. Try wait_and_click or read_page mode="dom" to verify.',
   },
   {
+    test: /captureScreenshot.*timed?\s*out|screenshot.*timed?\s*out|screenshot failed/i,
+    hint: 'Hint: Screenshot timed out on a slow page. Use read_page mode="dom" for instant page state without rendering. For heavy pages (Next.js dev, SPAs), always prefer read_page over screenshot.',
+  },
+  {
     test: /timeout|timed?\s*out|navigation timeout/i,
-    hint: 'Hint: Page may require login or different navigation.',
+    hint: 'Hint: Page timed out. Try wait_for with type "selector" to wait for specific content, or navigate to a simpler URL first.',
   },
   {
     test: /cannot read propert|null is not|undefined is not|is null|is undefined/i,

--- a/tests/utils/mock-cdp.ts
+++ b/tests/utils/mock-cdp.ts
@@ -22,18 +22,19 @@ export interface MockCDPResponse {
 export function createMockPage(options: MockPageOptions = {}): jest.Mocked<Page> {
   const { url = 'about:blank', title = 'Test Page', targetId = 'mock-target-id' } = options;
 
+  const mockCDPSession = {
+    send: jest.fn().mockResolvedValue({ data: 'base64-screenshot-data' }),
+    detach: jest.fn().mockResolvedValue(undefined),
+    on: jest.fn(),
+    off: jest.fn(),
+  } as unknown as jest.Mocked<CDPSession>;
+
   const mockTarget = {
     _targetId: targetId,
     type: () => 'page',
     page: jest.fn(),
+    createCDPSession: jest.fn().mockResolvedValue(mockCDPSession),
   } as unknown as Target;
-
-  const mockCDPSession = {
-    send: jest.fn(),
-    detach: jest.fn(),
-    on: jest.fn(),
-    off: jest.fn(),
-  } as unknown as jest.Mocked<CDPSession>;
 
   const mockPage = {
     url: jest.fn().mockReturnValue(url),
@@ -70,6 +71,7 @@ export function createMockPage(options: MockPageOptions = {}): jest.Mocked<Page>
     $$: jest.fn(),
     waitForSelector: jest.fn(),
     waitForNavigation: jest.fn(),
+    waitForFunction: jest.fn().mockResolvedValue(undefined),
   } as unknown as jest.Mocked<Page>;
 
   (mockTarget as any).page = jest.fn().mockResolvedValue(mockPage);


### PR DESCRIPTION
## Summary

Screenshot timeouts (`Page.captureScreenshot timed out`) were the #1 cause of session death in real-world OpenChrome usage. A single timeout would block for **180 seconds**, return an unhelpful error, and force user intervention ("마저 진행해줘"). This PR makes screenshots resilient so they never kill a session.

### Changes

- **CDP timeout reduced**: `protocolTimeout: 30000` (was 180s default) — prevents 3-minute hangs
- **Page readiness guard**: Checks `document.readyState === 'complete'` before screenshot, waits up to 5s if not ready
- **Auto-retry**: On CDP failure, retries once after 2s delay
- **DOM fallback**: On double failure, returns text-based page state (URL, title, readyState, text preview) instead of error — LLM can continue working
- **Screenshot-specific timeout hint**: "Use `read_page mode='dom'` for instant page state on slow pages"
- **Slow-page proactive detection**: New hint rule fires when `ToolCallEvent.duration > 5s`, warning before the next screenshot
- **Mock fix**: `createCDPSession` routed through `target()` in test mocks (matches production code path)

### Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Screenshot on slow page | 180s hang → error → session death | 30s max → DOM fallback → LLM continues |
| Heavy SPA (Next.js dev) | Immediate timeout → user intervention | Readiness guard waits for load → screenshot succeeds |
| CDP renderer crash | Single attempt → error | Retry after 2s → likely succeeds |
| All retries fail | "Page may still be loading" (no actionable info) | DOM text preview with URL, title, content |

### Key design: DOM fallback does NOT set `isError`

When screenshot fails but DOM fallback succeeds, the response is treated as **usable content** (not an error). This prevents the LLM from entering error recovery mode and allows it to continue with the text-based page state.

## Test plan

- [x] Screenshot retries once on CDP failure (2s delay)
- [x] DOM fallback returned when both attempts fail
- [x] Page readiness checked before screenshot
- [x] DOM fallback does NOT set `isError: true`
- [x] Completely unresponsive page sets `isError: true`
- [x] Screenshot-specific timeout hint fires on screenshot errors
- [x] Generic timeout hint updated with actionable guidance
- [x] Slow-page proactive hint fires when recent call > 5s
- [x] Slow-page hint does NOT fire for fast pages
- [x] Existing screenshot/click/scroll tests unaffected
- [x] Build: 0 errors, Tests: 51 suites, 1063 passing

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)