### PR TITLE
fix: stop killing user's Chrome — use temp profile by default

### DIFF
--- a/src/config/global.ts
+++ b/src/config/global.ts
@@ -15,6 +15,8 @@ export interface GlobalConfig {
   useHeadlessShell?: boolean;
   /** Run Chrome in headless mode (default: true when auto-launch is enabled) */
   headless?: boolean;
+  /** If true, quit running Chrome to reuse the real profile instead of using temp profile (default: false) */
+  restartChrome?: boolean;
   /** Chrome Pool settings for managing multiple Chrome instances */
   pool?: {
     /** Enable the Chrome pool (default: true) */

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,14 +28,16 @@ program
   .option('--chrome-binary <path>', 'Path to Chrome binary (e.g., chrome-headless-shell)')
   .option('--headless-shell', 'Use chrome-headless-shell if available (default: false)')
   .option('--visible', 'Show Chrome window (default: headless when auto-launch)')
+  .option('--restart-chrome', 'Quit running Chrome to reuse real profile (default: uses temp profile)')
   .option('--hybrid', 'Enable hybrid mode (Lightpanda + Chrome routing)')
   .option('--lp-port <port>', 'Lightpanda debugging port (default: 9223)', '9223')
-  .action(async (options: { port: string; autoLaunch?: boolean; userDataDir?: string; chromeBinary?: string; headlessShell?: boolean; visible?: boolean; hybrid?: boolean; lpPort?: string }) => {
+  .action(async (options: { port: string; autoLaunch?: boolean; userDataDir?: string; chromeBinary?: string; headlessShell?: boolean; visible?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string }) => {
     const port = parseInt(options.port, 10);
     const autoLaunch = options.autoLaunch || false;
     const userDataDir = options.userDataDir || process.env.CHROME_USER_DATA_DIR || undefined;
     const chromeBinary = options.chromeBinary || process.env.CHROME_BINARY || undefined;
     const useHeadlessShell = options.headlessShell || false;
+    const restartChrome = options.restartChrome || false;
 
     console.error(`[openchrome] Starting MCP server`);
     console.error(`[openchrome] Chrome debugging port: ${port}`);
@@ -57,7 +59,10 @@ program
     }
 
     // Set global config before initializing anything
-    setGlobalConfig({ port, autoLaunch, userDataDir, chromeBinary, useHeadlessShell, headless });
+    setGlobalConfig({ port, autoLaunch, userDataDir, chromeBinary, useHeadlessShell, headless, restartChrome });
+    if (restartChrome) {
+      console.error(`[openchrome] Restart Chrome mode: enabled (will quit existing Chrome)`);
+    }
 
     // Configure hybrid mode if enabled
     const hybrid = options.hybrid || false;


### PR DESCRIPTION
## Summary

Closes #62

- **Default behavior changed**: When Chrome is running without a debug port, OpenChrome now uses a temp profile with cookie copy instead of killing the user's Chrome
- **Opt-in restart**: Added `--restart-chrome` CLI flag for users who want the old behavior (quit Chrome to reuse real profile)
- **No breaking changes**: Users who don't pass `--restart-chrome` get the safe default automatically

## Changes

| File | Change |
|------|--------|
| `src/chrome/launcher.ts` | Guard restart branch behind `restartChrome` opt-in flag |
| `src/config/global.ts` | Add `restartChrome` to `GlobalConfig` interface |
| `src/index.ts` | Add `--restart-chrome` CLI option to `serve` command |
| `tests/chrome/launcher-restart.test.ts` | 4 new tests for default/opt-in behavior + robust mocking |

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Chrome running, no debug port | Kills Chrome, reuses real profile | Uses temp profile + cookie copy |
| Chrome running + `--restart-chrome` | N/A | Kills Chrome, reuses real profile (old behavior) |
| Chrome not running | Uses real profile | Uses real profile (unchanged) |

## Test plan

- [x] Build passes (0 errors)
- [x] All 1066 tests pass (51 suites)
- [x] 13 launcher-restart tests pass (including 4 new)
- [ ] Manual: `openchrome serve --auto-launch` with Chrome open — Chrome should NOT be killed
- [ ] Manual: `openchrome serve --auto-launch --restart-chrome` with Chrome open — Chrome restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)