### PR TITLE
fix: register SIGTERM/SIGINT handlers to prevent zombie MCP server processes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { Command } from 'commander';
 import { getMCPServer } from './mcp-server';
 import { registerAllTools } from './tools';
 import { setGlobalConfig } from './config/global';
+import { writePidFile } from './utils/pid-manager';
 
 const program = new Command();
 
@@ -76,6 +77,18 @@ program
 
     const server = getMCPServer();
     registerAllTools(server);
+
+    // Write PID file for zombie process detection
+    writePidFile(port);
+
+    // Register signal handlers for graceful shutdown
+    const shutdown = async (signal: string) => {
+      console.error(`[openchrome] Received ${signal}, shutting down...`);
+      await server.stop();
+      process.exit(0);
+    };
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
+    process.on('SIGINT', () => shutdown('SIGINT'));
     server.start();
   });
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,4 @@
 
 export * from './atomic-file';
 export * from './json-validator';
+export * from './pid-manager';

--- a/src/utils/pid-manager.ts
+++ b/src/utils/pid-manager.ts
@@ -1,0 +1,91 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const LOG_PREFIX = "[openchrome:pid]";
+
+export function getPidFilePath(port: number): string {
+  return path.join(os.tmpdir(), `openchrome-${port}.pid`);
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readPids(filePath: string): number[] {
+  try {
+    const content = fs.readFileSync(filePath, "utf8");
+    return content.split("\n").map(l => l.trim()).filter(l => l.length > 0).map(l => parseInt(l, 10)).filter(p => !isNaN(p) && p > 0);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.error(`${LOG_PREFIX} Failed to read PID file at ${filePath}:`, err);
+    }
+    return [];
+  }
+}
+
+function writePids(filePath: string, pids: number[]): void {
+  const tmpPath = `${filePath}.${process.pid}.tmp`;
+  const content = pids.join("\n") + (pids.length > 0 ? "\n" : "");
+  try {
+    fs.writeFileSync(tmpPath, content, { encoding: "utf8", flag: "w" });
+    fs.renameSync(tmpPath, filePath);
+  } catch (err) {
+    console.error(`${LOG_PREFIX} Failed to write PID file at ${filePath}:`, err);
+    try { fs.unlinkSync(tmpPath); } catch { /* ignore */ }
+  }
+}
+
+export function cleanStalePids(port: number): number {
+  const filePath = getPidFilePath(port);
+  const pids = readPids(filePath);
+  if (pids.length === 0) return 0;
+  const alivePids = pids.filter(pid => isPidAlive(pid));
+  const removedCount = pids.length - alivePids.length;
+  if (removedCount > 0) {
+    console.error(`${LOG_PREFIX} Cleaning ${removedCount} stale PID(s) from ${filePath}`);
+    writePids(filePath, alivePids);
+  }
+  return removedCount;
+}
+
+export function writePidFile(port: number): void {
+  const filePath = getPidFilePath(port);
+  cleanStalePids(port);
+  const pids = readPids(filePath);
+  if (!pids.includes(process.pid)) {
+    pids.push(process.pid);
+    writePids(filePath, pids);
+    console.error(`${LOG_PREFIX} Registered PID ${process.pid} in ${filePath}`);
+  }
+  process.once("exit", () => { removePidFile(port); });
+}
+
+export function removePidFile(port: number): void {
+  const filePath = getPidFilePath(port);
+  const pids = readPids(filePath);
+  const remaining = pids.filter(pid => pid !== process.pid);
+  if (remaining.length === 0) {
+    try {
+      fs.unlinkSync(filePath);
+      console.error(`${LOG_PREFIX} Removed PID file ${filePath} (no active PIDs remain)`);
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        console.error(`${LOG_PREFIX} Failed to delete PID file at ${filePath}:`, err);
+      }
+    }
+  } else {
+    writePids(filePath, remaining);
+    console.error(`${LOG_PREFIX} Deregistered PID ${process.pid} from ${filePath}`);
+  }
+}
+
+export function listActivePids(port: number): number[] {
+  const filePath = getPidFilePath(port);
+  return readPids(filePath).filter(pid => isPidAlive(pid));
+}


### PR DESCRIPTION
## Summary

Fixes #64 — When Claude Code sessions end abnormally (SIGKILL, crash, hang), spawned `openchrome serve` MCP server processes were not cleaned up. Over time, 10+ zombie processes accumulate holding open CDP WebSocket connections, causing navigate timeouts (17+ minutes observed).

### Root Causes Fixed

1. **No signal handlers** — `SIGTERM`/`SIGINT` were not caught anywhere, so Node.js died immediately without cleanup
2. **`stop()` → `cleanup()` race** — `stop()` was synchronous but `cleanup()` is async; `process.exit(0)` ran before cleanup completed
3. **No PID tracking** — No way to identify/kill individual zombie instances

### Changes

- **`src/index.ts`** — Register `SIGTERM`/`SIGINT` signal handlers that await `server.stop()` before exiting; call `writePidFile(port)` on startup
- **`src/mcp-server.ts`** — Make `stop()` async, await `cleanup()` with 5-second safety timeout; fix `rl.on('close')` and dashboard quit handlers to await `stop()` before `process.exit()`
- **`src/utils/pid-manager.ts`** *(new)* — PID file lifecycle management: write on startup, clean on shutdown, purge stale PIDs from dead processes. Uses atomic write-then-rename to handle concurrent access
- **`src/utils/index.ts`** — Export new pid-manager module

### Acceptance Criteria

- [x] `SIGTERM` triggers graceful cleanup (CDP disconnect, Chrome cleanup if owned)
- [x] `SIGINT` triggers graceful cleanup
- [x] `stop()` awaits `cleanup()` before `process.exit()`
- [x] PID file written/cleaned on startup/shutdown
- [x] Build passes, all 30 mcp-server tests pass

## Test plan

- [ ] Start `openchrome serve`, send `SIGTERM` → verify clean shutdown log and PID file removal
- [ ] Start `openchrome serve`, send `SIGINT` (Ctrl+C) → verify clean shutdown
- [ ] Start multiple instances, kill one → verify PID file only removes killed PID
- [ ] Kill process with `SIGKILL` → restart and verify stale PID cleanup on startup
- [ ] Verify no zombie processes after Claude Code session ends normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)