### PR TITLE
fix: add timeouts to prevent 10+ minute hangs in parallel sessions

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -31,3 +31,21 @@ export const DEFAULT_MAX_TARGETS_PER_WORKER = 5;
 
 /** Memory pressure threshold in bytes (500MB). Below this free memory, aggressive cleanup triggers. */
 export const DEFAULT_MEMORY_PRESSURE_THRESHOLD = 500 * 1024 * 1024;
+
+/** Cookie scan overall timeout in milliseconds. Prevents N×30s cascading hangs in parallel sessions. */
+export const DEFAULT_COOKIE_SCAN_TIMEOUT_MS = 5000;
+
+/** Per-candidate cookie probe timeout in milliseconds. Skips unresponsive tabs quickly. */
+export const DEFAULT_COOKIE_SCAN_PER_TARGET_TIMEOUT_MS = 2000;
+
+/** Maximum candidates to probe during cookie source scan. */
+export const DEFAULT_COOKIE_SCAN_MAX_CANDIDATES = 5;
+
+/** Overall cookie copy timeout in milliseconds. */
+export const DEFAULT_COOKIE_COPY_TIMEOUT_MS = 10000;
+
+/** Safe page.title() timeout in milliseconds. Prevents hangs on frozen renderers. */
+export const DEFAULT_SAFE_TITLE_TIMEOUT_MS = 3000;
+
+/** Per-item timeout in request queue (ms). Safety net against indefinitely hung CDP commands. */
+export const DEFAULT_QUEUE_ITEM_TIMEOUT_MS = 120000;

--- a/src/orchestration/workflow-engine.ts
+++ b/src/orchestration/workflow-engine.ts
@@ -9,6 +9,7 @@ import { getCDPConnectionPool } from '../cdp/connection-pool';
 import { getCDPClient } from '../cdp/client';
 import { ToolEntry } from '../types/tool-manifest';
 import { getDomainMemory, extractDomainFromUrl } from '../memory/domain-memory';
+import { DEFAULT_NAVIGATION_TIMEOUT_MS } from '../config/defaults';
 
 export interface WorkflowStep {
   workerId: string;
@@ -184,7 +185,7 @@ export class WorkflowEngine {
             // Cookie bridging failure is non-fatal — page navigates without cookies
           }
 
-          await page.goto(step.url, { waitUntil: 'domcontentloaded' }).catch(() => {
+          await page.goto(step.url, { waitUntil: 'domcontentloaded', timeout: DEFAULT_NAVIGATION_TIMEOUT_MS }).catch(() => {
             // Navigation may fail for some URLs; worker will retry
           });
         }

--- a/src/router/browser-router.ts
+++ b/src/router/browser-router.ts
@@ -8,6 +8,7 @@ import {
 import { ToolRoutingRegistry } from './tool-routing-registry';
 import { LightpandaLauncher } from '../lightpanda/launcher';
 import { CookieSync } from './cookie-sync';
+import { DEFAULT_NAVIGATION_TIMEOUT_MS } from '../config/defaults';
 
 export interface RouteResult {
   backend: BrowserBackend;
@@ -124,7 +125,7 @@ export class BrowserRouter {
     }
 
     try {
-      await chromePage.goto(url);
+      await chromePage.goto(url, { waitUntil: 'domcontentloaded', timeout: DEFAULT_NAVIGATION_TIMEOUT_MS });
     } catch {
       // best-effort navigation
     }

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -6,6 +6,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
 import { smartGoto } from '../utils/smart-goto';
+import { safeTitle } from '../utils/safe-title';
 import { DEFAULT_NAVIGATION_TIMEOUT_MS } from '../config/defaults';
 
 const definition: MCPToolDefinition = {
@@ -105,7 +106,7 @@ const handler: ToolHandler = async (
                   text: JSON.stringify({
                     action: 'navigate',
                     url: page.url(),
-                    title: await page.title(),
+                    title: await safeTitle(page),
                     tabId: existingTabId,
                     workerId: resolvedWorkerId,
                     reused: true,
@@ -127,7 +128,7 @@ const handler: ToolHandler = async (
             text: JSON.stringify({
               action: 'navigate',
               url: page.url(),
-              title: await page.title(),
+              title: await safeTitle(page),
               tabId: targetId,
               workerId: assignedWorkerId,
               created: true,
@@ -183,7 +184,7 @@ const handler: ToolHandler = async (
             text: JSON.stringify({
               action: 'back',
               url: page.url(),
-              title: await page.title(),
+              title: await safeTitle(page),
             }),
           },
         ],
@@ -199,7 +200,7 @@ const handler: ToolHandler = async (
             text: JSON.stringify({
               action: 'forward',
               url: page.url(),
-              title: await page.title(),
+              title: await safeTitle(page),
             }),
           },
         ],
@@ -263,7 +264,7 @@ const handler: ToolHandler = async (
           text: JSON.stringify({
             action: 'navigate',
             url: page.url(),
-            title: await page.title(),
+            title: await safeTitle(page),
             ...(authRedirect && { redirectedFrom: authRedirect.from, authRedirect: true }),
           }),
         },

--- a/src/tools/page-reload.ts
+++ b/src/tools/page-reload.ts
@@ -5,6 +5,7 @@
 import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
+import { safeTitle } from '../utils/safe-title';
 import { DEFAULT_NAVIGATION_TIMEOUT_MS } from '../config/defaults';
 
 const definition: MCPToolDefinition = {
@@ -74,7 +75,7 @@ const handler: ToolHandler = async (
           text: JSON.stringify({
             action: 'reload',
             url: page.url(),
-            title: await page.title(),
+            title: await safeTitle(page),
             ignoreCache,
             message: ignoreCache ? 'Page reloaded (cache bypassed)' : 'Page reloaded',
           }),

--- a/src/tools/tabs-create.ts
+++ b/src/tools/tabs-create.ts
@@ -5,6 +5,7 @@
 import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
+import { safeTitle } from '../utils/safe-title';
 
 const definition: MCPToolDefinition = {
   name: 'tabs_create_mcp',
@@ -58,7 +59,7 @@ const handler: ToolHandler = async (
               tabId: targetId,
               workerId: assignedWorkerId,
               url: page.url(),
-              title: await page.title(),
+              title: await safeTitle(page),
             },
             null,
             2

--- a/src/tools/wait-for.ts
+++ b/src/tools/wait-for.ts
@@ -5,6 +5,7 @@
 import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
+import { safeTitle } from '../utils/safe-title';
 
 const definition: MCPToolDefinition = {
   name: 'wait_for',
@@ -182,7 +183,7 @@ const handler: ToolHandler = async (
                 action: 'wait_for',
                 type: 'navigation',
                 url: page.url(),
-                title: await page.title(),
+                title: await safeTitle(page),
                 elapsed,
                 message: `Navigation completed after ${elapsed}ms`,
               }),

--- a/src/utils/safe-title.ts
+++ b/src/utils/safe-title.ts
@@ -1,0 +1,27 @@
+/**
+ * Safe page.title() wrapper with timeout.
+ *
+ * page.title() internally calls page.evaluate(() => document.title),
+ * which can hang for up to 30s if the renderer is frozen or mid-navigation.
+ * This wrapper adds a short timeout and returns '' on failure.
+ */
+
+import type { Page } from 'puppeteer-core';
+import { DEFAULT_SAFE_TITLE_TIMEOUT_MS } from '../config/defaults';
+
+export async function safeTitle(
+  page: Page,
+  timeoutMs: number = DEFAULT_SAFE_TITLE_TIMEOUT_MS,
+): Promise<string> {
+  try {
+    const result = await Promise.race([
+      page.title(),
+      new Promise<string>((_, reject) =>
+        setTimeout(() => reject(new Error('title timeout')), timeoutMs),
+      ),
+    ]);
+    return result;
+  } catch {
+    return '';
+  }
+}

--- a/tests/src/router/browser-router.test.ts
+++ b/tests/src/router/browser-router.test.ts
@@ -268,7 +268,7 @@ describe('BrowserRouter', () => {
 
       const result: EscalationResult = await router.escalate(lightpandaPage as any, chromePage as any);
 
-      expect(chromePage.goto).toHaveBeenCalledWith(url);
+      expect(chromePage.goto).toHaveBeenCalledWith(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
       expect(result.url).toBe(url);
     });
   });


### PR DESCRIPTION
## Summary

- **Root cause**: Cookie bridging scan in `_doFindAuthenticatedPageTargetId()` iterated ALL browser tabs with 30s CDP timeout each, causing up to `N × 30s` (600s with 20 tabs) hangs when any tab was unresponsive. Parallel sessions compound this by accumulating tabs across sessions.
- Add bounded timeouts to all previously-unbounded CDP operations that caused MCP tool calls (`tabs_create_mcp`, `navigate`, etc.) to hang indefinitely
- Worst-case cookie scan time reduced from **600s → 5s**

## Changes (11 files)

| Priority | Change | Files |
|----------|--------|-------|
| **P0** | Cookie scan: 5s overall timeout, 2s per-candidate timeout, max 5 candidates | `src/cdp/client.ts` |
| **P0** | Cookie copy: 10s overall timeout wrapper | `src/cdp/client.ts` |
| **P1** | `safeTitle()` utility (3s timeout) replacing all bare `page.title()` calls | `src/utils/safe-title.ts` (new), `tabs-create.ts`, `navigate.ts`, `page-reload.ts`, `wait-for.ts` |
| **P1** | Explicit `timeout` + `waitUntil` on `page.goto()` in escalation and workflow init | `src/router/browser-router.ts`, `src/orchestration/workflow-engine.ts` |
| **P2** | 120s per-item timeout on request queue as safety net | `src/utils/request-queue.ts` |
| **Infra** | New timeout constants centralized in defaults | `src/config/defaults.ts` |

## Why this works

Before this fix, creating a single tab triggered:
1. `findAuthenticatedPageTargetId()` → scan ALL tabs (20 tabs × 30s = 600s worst case)
2. `copyCookiesViaCDP()` → 4 sequential CDP ops (4 × 30s = 120s worst case)
3. `page.title()` → evaluate on possibly frozen renderer (30s)

**Total worst case before: ~750s (12+ minutes)**
**Total worst case after: ~18s** (5s scan + 10s copy + 3s title)

All timeouts fail gracefully — cookies are best-effort, titles fall back to empty string.

## Test plan

- [x] Build compiles cleanly (`npm run build`)
- [x] All 1175 tests pass (`npm test`)
- [x] Updated `browser-router.test.ts` to match new `goto()` signature
- [ ] Manual: Start 3+ parallel Claude Code sessions, call `tabs_create_mcp` with 10+ Chrome tabs open
- [ ] Manual: Verify cookie bridging still works for normal (responsive) tabs
- [ ] Manual: Verify `navigate` returns within ~30s even with frozen tabs

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)