### PR TITLE
fix: evict pool pages when tabs are externally closed

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -122,6 +122,16 @@ export class CDPClient {
   }
 
   /**
+   * Remove target destroyed listener
+   */
+  removeTargetDestroyedListener(listener: (targetId: string, page?: Page) => void): void {
+    const index = this.targetDestroyedListeners.indexOf(listener);
+    if (index !== -1) {
+      this.targetDestroyedListeners.splice(index, 1);
+    }
+  }
+
+  /**
    * Handle target destroyed event
    */
   private onTargetDestroyed(targetId: string): void {


### PR DESCRIPTION
## Summary
- When a user manually closes a Chrome tab, `ConnectionPool.inUsePages` retained a zombie Page reference, causing inaccurate pool stats and potential memory leaks
- `CDPClient.onTargetDestroyed()` now passes the Page reference to listeners before deleting from `targetIdIndex`
- `ConnectionPool` registers a `targetDestroyedListener` to auto-evict dead pages from `inUsePages`

## Test plan
- [x] `npm run build` passes
- [ ] Open a tab via `navigate`, manually close it in Chrome, verify `getStats().inUsePages` decrements
- [ ] Run parallel workflow, close worker tabs manually, verify no zombie entries in pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)