### PR TITLE
feat: auto-configure tool permissions in oc setup + first-run hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ The hint engine watches every tool call across 6 layers — error recovery, comp
 npx openchrome-mcp setup
 ```
 
-That's it. Say `oc` to your AI agent.
+One command. Configures MCP server + auto-approves tool permissions.
+Restart Claude Code, then say `oc`.
 
 <details>
 <summary>Manual config</summary>

--- a/src/hints/hint-engine.ts
+++ b/src/hints/hint-engine.ts
@@ -24,6 +24,7 @@ import { repetitionDetectionRules } from './rules/repetition-detection';
 import { paginationDetectionRules } from './rules/pagination-detection';
 import { createLearnedRules } from './rules/learned-rules';
 import { successHintRules } from './rules/success-hints';
+import { setupHintRules } from './rules/setup-hints';
 
 export interface HintContext {
   toolName: string;
@@ -87,7 +88,8 @@ export class HintEngine {
     // Collect all rules and sort by priority (ascending = highest priority first)
     // Learned rules (350) sit between repetition (250) and success hints (400)
     this.rules = [
-      ...errorRecoveryRules,        // priority 100-108
+      ...setupHintRules,             // priority 90
+      ...errorRecoveryRules,         // priority 100-108
       ...paginationDetectionRules,   // priority 190-192
       ...compositeSuggestionRules,   // priority 200-203
       ...repetitionDetectionRules,   // priority 245-252

--- a/src/hints/rules/setup-hints.ts
+++ b/src/hints/rules/setup-hints.ts
@@ -1,0 +1,22 @@
+/**
+ * Setup Hints — fires once on first successful tool call to suggest running setup.
+ */
+
+import type { HintRule } from '../hint-engine';
+
+let hasFired = false;
+
+export const setupHintRules: HintRule[] = [
+  {
+    name: 'setup-permission-hint',
+    priority: 90,
+    match(ctx) {
+      // Fire only once per session
+      if (hasFired) return null;
+      // Only on non-error tool calls
+      if (ctx.isError) return null;
+      hasFired = true;
+      return 'Hint: To skip permission prompts for OpenChrome tools, run: npx openchrome-mcp setup';
+    },
+  },
+];


### PR DESCRIPTION
## Summary

- `npx openchrome-mcp setup` now auto-configures `~/.claude/settings.json` to add `mcp__openchrome__*` to `permissions.allow`, eliminating manual permission approval for every tool call
- New first-run hint fires once on the first successful tool call, suggesting users run setup if they haven't
- README Quick Start updated to mention permissions auto-config

## Changes

| File | Change |
|------|--------|
| `cli/index.ts` | Add permission config step after `claude mcp add` in setup command |
| `src/hints/rules/setup-hints.ts` | New file — first-run permission hint rule (priority 90, fires once) |
| `src/hints/hint-engine.ts` | Import and register setup hint rules |
| `README.md` | Update Quick Start to mention permissions |

## Edge cases handled

- `settings.json` doesn't exist → creates with proper structure
- File exists but no `permissions` key → adds it
- `permissions.allow` exists but no openchrome entry → appends
- Entry already exists → skips, prints "already configured"
- JSON parse/write error → warns user with manual instructions

## Test plan

- [ ] Run `npx openchrome-mcp setup --scope user` → verify `~/.claude/settings.json` contains `mcp__openchrome__*`
- [ ] Run setup again → verify "already configured" message (idempotent)
- [ ] Start MCP server without permissions → verify hint appears once
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)