### PR TITLE
fix: platform-aware sqlite3 .backup quoting for Windows

### DIFF
--- a/src/chrome/profile-manager.ts
+++ b/src/chrome/profile-manager.ts
@@ -177,8 +177,11 @@ export class ProfileManager {
           // Atomic backup using the SQLite .backup command.
           // This works even when Chrome is actively writing to the DB.
           // Uses execFileSync (no shell) to prevent injection via path characters.
+          if (process.platform === 'win32' && destCookiesPath.includes('"')) {
+            throw new Error('sqlite3 .backup: destination path contains \'"\', cannot quote safely on Windows');
+          }
           const backupCmd = process.platform === 'win32'
-            ? `.backup "${destCookiesPath.replace(/"/g, '')}"`
+            ? `.backup "${destCookiesPath}"`
             : `.backup '${destCookiesPath.replace(/'/g, "''")}'`;
           execFileSync('sqlite3', [
             sourceCookiesPath,

--- a/src/chrome/sqlite-cookie-copy.ts
+++ b/src/chrome/sqlite-cookie-copy.ts
@@ -95,8 +95,11 @@ export function copyCookiesAtomic(
   // Tier 2: sqlite3 CLI — .backup command
   // -------------------------------------------------------------------------
   try {
+    if (process.platform === 'win32' && destPath.includes('"')) {
+      throw new Error('sqlite3 .backup: destination path contains \'"\', cannot quote safely on Windows');
+    }
     const backupCmd = process.platform === 'win32'
-      ? `.backup "${destPath.replace(/"/g, '')}"`
+      ? `.backup "${destPath}"`
       : `.backup '${destPath.replace(/'/g, "''")}'`;
     execFileSync('sqlite3', [sourcePath, backupCmd], {
       timeout: 5000,


### PR DESCRIPTION
## Summary
- Windows sqlite3 CLI does not honor Unix single-quote syntax in dot-commands
- Use double quotes on Windows, single quotes on Unix for `.backup` command argument
- Prevents silent fallback to non-atomic file copy on Windows

## Files Changed
- `src/chrome/sqlite-cookie-copy.ts` (+4/-1)
- `src/chrome/profile-manager.ts` (+4/-1)

## Test plan
- [ ] Verify cookie sync via sqlite3 `.backup` works on Windows with paths containing spaces
- [ ] Verify existing Unix behavior unchanged

Closes #114 (partial — 2/4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)