### PR TITLE
fix: add --prefer-online to prevent stale MCP versions after publish

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -113,9 +113,10 @@ program
       // Ignore if not exists
     }
 
-    // Use npx @latest for auto-updates: every server start fetches the latest version.
-    // Without @latest, npx may serve a stale cached version indefinitely.
-    const fullCommand = `claude mcp add openchrome -s ${scope} -- npx -y openchrome-mcp@latest ${serveArgs.join(' ')}`;
+    // Use npx @latest with --prefer-online for reliable auto-updates.
+    // Without --prefer-online, npx caches a semver range (e.g. ^1.4.0) in ~/.npm/_npx/
+    // and never re-checks the registry, so @latest effectively becomes @cached.
+    const fullCommand = `claude mcp add openchrome -s ${scope} -- npx --prefer-online -y openchrome-mcp@latest ${serveArgs.join(' ')}`;
 
     console.log(`Running: claude mcp add openchrome (scope: ${scope})...`);
 


### PR DESCRIPTION
## Summary
- **Root cause**: `npx` caches a semver range (e.g. `^1.4.0`) in `~/.npm/_npx/<hash>/package-lock.json`. Even with `@latest`, npx satisfies the range from its local cache without checking the registry, serving stale versions indefinitely after `npm publish`.
- **Fix**: Add `--prefer-online` flag to the `npx` command written by `oc setup`, forcing a registry check on every MCP server startup (~1-2s latency, ensures actual latest)
- **Release workflow**: Expanded Step 8b with npx cache cleanup, improved zombie kill patterns (kills both npm parent and node child processes), and guidance for existing users

## Changes
| File | Change |
|------|--------|
| `cli/index.ts` | Add `--prefer-online` to npx command in setup |
| `.claude/commands/release-oc.md` | Expanded Step 8b post-publish checklist |

## Why this matters
After `npm publish`, users (including the maintainer) would get stale MCP server versions because:
1. npx cache at `~/.npm/_npx/<hash>/` locks `"openchrome-mcp": "^1.4.0"` 
2. `package-lock.json` in cache resolves to exact old version
3. `npm install` within cache satisfies range without network fetch
4. Old zombie processes persist across Claude Code restarts

## Test plan
- [ ] `npm run build` passes
- [ ] After publish: verify `npx --prefer-online openchrome-mcp@latest --version` returns new version
- [ ] Existing users: re-run `npx openchrome-mcp@latest setup` to get the flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)