### PR TITLE
feat(read-page): change default mode from ax to dom for token efficiency (#133)

### DIFF
--- a/src/tools/read-page.ts
+++ b/src/tools/read-page.ts
@@ -26,7 +26,7 @@ function formatPaginationSection(pagination: PaginationInfo): string {
 const definition: MCPToolDefinition = {
   name: 'read_page',
   description:
-    'Get page content. Default mode "ax" returns accessibility tree with ref_N identifiers. Mode "dom" returns compact DOM (~5-10x fewer tokens). Mode "css" returns CSS diagnostic info (variables, computed styles, framework detection) — use this BEFORE javascript_tool for style inspection or visual debugging.',
+    'Get page content. Default mode "dom" returns compact DOM (~5-10x fewer tokens) with stable backendNodeId identifiers. Mode "ax" returns accessibility tree with ref_N identifiers for ARIA/accessibility auditing. Mode "css" returns CSS diagnostic info (variables, computed styles, framework detection) — use this BEFORE javascript_tool for style inspection or visual debugging.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -54,7 +54,7 @@ const definition: MCPToolDefinition = {
       mode: {
         type: 'string',
         enum: ['ax', 'dom', 'css'],
-        description: 'Output mode: "ax" for accessibility tree (default), "dom" for compact DOM, "css" for CSS diagnostics (variables, computed styles, framework detection)',
+        description: 'Output mode: "dom" for compact DOM (default), "ax" for accessibility tree, "css" for CSS diagnostics (variables, computed styles, framework detection)',
       },
       includePagination: {
         type: 'boolean',
@@ -107,7 +107,7 @@ const handler: ToolHandler = async (
     const cdpClient = sessionManager.getCDPClient();
 
     // Mode dispatch
-    const mode = (args.mode as string) || 'ax';
+    const mode = (args.mode as string) || 'dom';
     if (mode !== 'ax' && mode !== 'dom' && mode !== 'css') {
       return {
         content: [{ type: 'text', text: `Error: Invalid mode "${mode}". Must be "ax", "dom", or "css".` }],

--- a/tests/tools/read-page-dom.test.ts
+++ b/tests/tools/read-page-dom.test.ts
@@ -283,18 +283,18 @@ describe('ReadPageTool - DOM Mode', () => {
   });
 
   describe('Backward Compatibility', () => {
-    test('default mode (no mode param) returns AX tree with ref_N', async () => {
+    test('default mode (no mode param) returns compact DOM output', async () => {
       const handler = await getReadPageHandler();
       const result = await handler(testSessionId, { tabId: testTargetId }) as any;
       const text = result.content[0].text;
 
-      // Default should be AX tree mode
-      expect(text).toContain('ref_');
-      // AX mode now includes page_stats (added for LLM context)
+      // Default should now be DOM mode
       expect(text).toContain('[page_stats]');
+      // DOM mode uses backendNodeId identifiers, not ref_N
+      expect(text).not.toContain('ref_');
 
-      // clearTargetRefs SHOULD be called in AX mode
-      expect(mockRefIdManager.clearTargetRefs).toHaveBeenCalled();
+      // clearTargetRefs should NOT be called in DOM mode
+      expect(mockRefIdManager.clearTargetRefs).not.toHaveBeenCalled();
     });
 
     test('mode=ax explicitly returns AX tree', async () => {

--- a/tests/tools/read-page.test.ts
+++ b/tests/tools/read-page.test.ts
@@ -76,6 +76,32 @@ describe('ReadPageTool', () => {
       sampleAccessibilityTree
     );
 
+    // Set up DOM.getDocument response for DOM mode (now the default)
+    mockSessionManager.mockCDPClient.setCDPResponse(
+      'DOM.getDocument',
+      { depth: -1, pierce: true },
+      {
+        root: {
+          nodeId: 1, backendNodeId: 1, nodeType: 9, nodeName: '#document', localName: '',
+          children: [{
+            nodeId: 2, backendNodeId: 2, nodeType: 1, nodeName: 'HTML', localName: 'html',
+            attributes: [],
+            children: [{
+              nodeId: 3, backendNodeId: 3, nodeType: 1, nodeName: 'BODY', localName: 'body',
+              attributes: [],
+              children: [
+                {
+                  nodeId: 4, backendNodeId: 100, nodeType: 1, nodeName: 'BUTTON', localName: 'button',
+                  attributes: ['type', 'submit'],
+                  children: [{ nodeId: 5, backendNodeId: 5, nodeType: 3, nodeName: '#text', localName: '', nodeValue: 'Submit' }],
+                },
+              ],
+            }],
+          }],
+        },
+      }
+    );
+
     // Set up page.evaluate for page stats (AX mode now calls evaluate for page metadata)
     const page = mockSessionManager.pages.get(testTargetId);
     if (page) {
@@ -102,6 +128,7 @@ describe('ReadPageTool', () => {
 
       const result = await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
       }) as { content: Array<{ type: string; text: string }> };
 
       expect(mockSessionManager.mockCDPClient.send).toHaveBeenCalledWith(
@@ -122,6 +149,7 @@ describe('ReadPageTool', () => {
 
       await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
         depth: 5,
       });
 
@@ -143,6 +171,7 @@ describe('ReadPageTool', () => {
 
       await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
         filter: 'interactive',
       });
 
@@ -164,6 +193,7 @@ describe('ReadPageTool', () => {
 
       await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
         filter: 'interactive',
         depth: 3,
       });
@@ -180,6 +210,7 @@ describe('ReadPageTool', () => {
 
       await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
       });
 
       // Should have generated refs for elements with backendDOMNodeId
@@ -191,6 +222,7 @@ describe('ReadPageTool', () => {
 
       await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
       });
 
       expect(mockRefIdManager.clearTargetRefs).toHaveBeenCalledWith(testSessionId, testTargetId);
@@ -207,6 +239,7 @@ describe('ReadPageTool', () => {
 
       const result = await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
       }) as { content: Array<{ type: string; text: string }> };
 
       // Should return without error
@@ -220,6 +253,7 @@ describe('ReadPageTool', () => {
 
       const result = await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
         filter: 'all',
       }) as { content: Array<{ type: string; text: string }> };
 
@@ -232,6 +266,7 @@ describe('ReadPageTool', () => {
 
       const result = await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
         filter: 'interactive',
       }) as { content: Array<{ type: string; text: string }> };
 
@@ -253,6 +288,7 @@ describe('ReadPageTool', () => {
       // The sample tree has button, textbox, link which are all interactive
       const result = await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
         filter: 'interactive',
       }) as { content: Array<{ type: string; text: string }> };
 
@@ -274,6 +310,7 @@ describe('ReadPageTool', () => {
 
       const result = await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
       }) as { content: Array<{ type: string; text: string }> };
 
       const text = result.content[0].text;
@@ -286,6 +323,7 @@ describe('ReadPageTool', () => {
 
       const result = await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
       }) as { content: Array<{ type: string; text: string }> };
 
       const text = result.content[0].text;
@@ -298,6 +336,7 @@ describe('ReadPageTool', () => {
 
       const result = await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
       }) as { content: Array<{ type: string; text: string }> };
 
       const text = result.content[0].text;
@@ -327,6 +366,7 @@ describe('ReadPageTool', () => {
 
       const result = await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
       }) as { content: Array<{ type: string; text: string }> };
 
       // Should handle without error
@@ -354,6 +394,7 @@ describe('ReadPageTool', () => {
 
       const result = await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
       }) as { content: Array<{ type: string; text: string }> };
 
       const text = result.content[0].text;
@@ -382,6 +423,7 @@ describe('ReadPageTool', () => {
 
       await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
       });
 
       // Check that refs were generated with correct session and target
@@ -436,6 +478,7 @@ describe('ReadPageTool', () => {
 
       const result = await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
       }) as { content: Array<{ type: string; text: string }> };
 
       const text = result.content[0].text;
@@ -447,6 +490,7 @@ describe('ReadPageTool', () => {
 
       const result = await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
       }) as { content: Array<{ type: string; text: string }> };
 
       const text = result.content[0].text;
@@ -459,6 +503,7 @@ describe('ReadPageTool', () => {
 
       const result = await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
       }) as { content: Array<{ type: string; text: string }> };
 
       const text = result.content[0].text;
@@ -470,6 +515,7 @@ describe('ReadPageTool', () => {
 
       const result = await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
       }) as { content: Array<{ type: string; text: string }> };
 
       const text = result.content[0].text;


### PR DESCRIPTION
## Summary

- Changes `read_page` default mode from `ax` to `dom` for ~5-10x token savings when no mode is specified
- Updates tool description and inputSchema mode description to reflect `dom` as the new default
- Updates tests: all AX-specific tests now pass `mode: 'ax'` explicitly; backward-compat test updated to assert DOM is the default

## Test plan

- [x] `npm run build` passes (TypeScript clean)
- [x] `npx jest tests/tools/read-page --no-coverage` — all 39 tests pass across both `read-page.test.ts` and `read-page-dom.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)