### PR TITLE
fix(launcher): only apply --disable-gpu in headless mode (#138)

### DIFF
--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -349,8 +349,6 @@ export class ChromeLauncher {
       // Fallback window size if maximize doesn't work
       `--window-size=${DEFAULT_VIEWPORT.width},${DEFAULT_VIEWPORT.height}`,
       // Memory-saving flags (applies to all profile types)
-      '--disable-gpu',
-      '--disable-dev-shm-usage',
       '--renderer-process-limit=16',
       '--js-flags=--max-old-space-size=1024',
       '--disable-backgrounding-occluded-windows',
@@ -373,7 +371,7 @@ export class ChromeLauncher {
     // Headless mode: explicit option > global config (default when auto-launch)
     const headless = options.headless ?? globalConfig.headless ?? false;
     if (headless) {
-      args.push('--headless=new');
+      args.push('--headless=new', '--disable-gpu', '--disable-dev-shm-usage');
       console.error('[ChromeLauncher] Running in headless mode (no visible window)');
     }
 


### PR DESCRIPTION
## Summary

- Move `--disable-gpu` and `--disable-dev-shm-usage` from unconditional Chrome launch args to headless-only block
- These flags are only needed in headless/CI environments and actively harm visible mode by disabling WebGL and hardware acceleration

## Problem

OpenChrome shares the user's real Chrome profile. When launching in visible mode (non-headless), `--disable-gpu` unnecessarily disables hardware acceleration, breaking WebGL content and degrading rendering performance. `--disable-dev-shm-usage` is similarly only relevant in containerized/CI environments.

## Changes

- `src/chrome/launcher.ts`: Moved `--disable-gpu` and `--disable-dev-shm-usage` into the `if (headless)` block alongside `--headless=new`

## Test plan

- [x] `npm run build` passes
- [ ] Verify WebGL sites render correctly in visible mode
- [ ] Verify headless mode still works correctly with GPU disabled

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)