### PR TITLE
refactor: compress tool descriptions for token efficiency (#140)

### DIFF
--- a/src/tools/batch-execute.ts
+++ b/src/tools/batch-execute.ts
@@ -13,9 +13,7 @@ import { getSessionManager } from '../session-manager';
 
 const definition: MCPToolDefinition = {
   name: 'batch_execute',
-  description:
-    'Execute JavaScript code across multiple tabs in parallel. Returns results from all tabs. ' +
-    'Each task specifies a tabId and a JavaScript snippet to execute.',
+  description: 'Execute JavaScript across multiple tabs in parallel.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -31,17 +29,15 @@ const definition: MCPToolDefinition = {
             },
             workerId: {
               type: 'string',
-              description: 'Optional worker ID for identification in results',
+              description: 'Worker ID for result identification',
             },
             script: {
               type: 'string',
-              description:
-                'JavaScript code to execute in the tab. The result of the last expression is returned. ' +
-                'Promises are automatically awaited.',
+              description: 'JS code to execute. Promises auto-awaited.',
             },
             timeout: {
               type: 'number',
-              description: 'Timeout in milliseconds for this task (default: 30000)',
+              description: 'Timeout in ms. Default: 30000',
             },
           },
           required: ['tabId', 'script'],
@@ -49,14 +45,11 @@ const definition: MCPToolDefinition = {
       },
       concurrency: {
         type: 'number',
-        description:
-          'Maximum number of tasks to execute simultaneously (default: 10). ' +
-          'Higher values increase parallelism but may cause resource contention.',
+        description: 'Max parallel tasks. Default: 10',
       },
       failFast: {
         type: 'boolean',
-        description:
-          'If true, stop executing remaining tasks when one fails (default: false)',
+        description: 'Stop on first failure. Default: false',
       },
     },
     required: ['tasks'],

--- a/src/tools/batch-paginate.ts
+++ b/src/tools/batch-paginate.ts
@@ -14,9 +14,7 @@ import { DEFAULT_SCREENSHOT_QUALITY, MAX_OUTPUT_CHARS } from '../config/defaults
 
 const definition: MCPToolDefinition = {
   name: 'batch_paginate',
-  description:
-    'Extract content from multiple pages of a paginated viewer (PDF, slides, articles) in a single call. ' +
-    'Supports keyboard navigation, click-based pagination, URL-based parallel extraction, and infinite scroll.',
+  description: 'Extract content from paginated viewers (PDF, slides, articles) in a single call.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -27,49 +25,44 @@ const definition: MCPToolDefinition = {
       strategy: {
         type: 'string',
         enum: ['keyboard', 'click', 'url', 'scroll'],
-        description:
-          'Pagination strategy: "keyboard" (ArrowRight/ArrowDown), "click" (CSS selector), "url" (parallel multi-tab), "scroll" (infinite scroll)',
+        description: 'Pagination strategy',
       },
       totalPages: {
         type: 'number',
-        description: 'Total number of pages to capture. Required for keyboard/click strategies.',
+        description: 'Pages to capture. Required for keyboard/click',
       },
       startPage: {
         type: 'number',
-        description:
-          'Starting page number (default: 1). Useful when resuming from a specific page.',
+        description: 'Starting page number. Default: 1',
       },
       captureMode: {
         type: 'string',
         enum: ['screenshot', 'text', 'dom', 'both'],
-        description:
-          'What to capture per page: "screenshot" (base64 image), "text" (accessibility text), "dom" (compact DOM), "both" (screenshot + text). Default: "text".',
+        description: 'Capture format per page. Default: text',
       },
       keyAction: {
         type: 'string',
-        description: '(keyboard strategy) Key to press for next page. Default: "ArrowRight".',
+        description: 'Key for next page (keyboard). Default: ArrowRight',
       },
       nextSelector: {
         type: 'string',
-        description: '(click strategy) CSS selector for the "next page" button.',
+        description: 'Next-page button selector (click strategy)',
       },
       urlTemplate: {
         type: 'string',
-        description:
-          '(url strategy) URL template with {N}, {page}, or {offset} placeholder for page number, e.g. "https://example.com/page/{N}".',
+        description: 'URL with {N}/{page}/{offset} placeholder (url strategy)',
       },
       waitBetweenPages: {
         type: 'number',
-        description:
-          'Milliseconds to wait between page transitions for rendering. Default: 500.',
+        description: 'Wait between pages in ms. Default: 500',
       },
       scrollAmount: {
         type: 'number',
-        description: '(scroll strategy) Viewport heights to scroll per step. Default: 1.',
+        description: 'Viewport heights per scroll step. Default: 1',
       },
       maxScrolls: {
         type: 'number',
-        description: '(scroll strategy) Maximum number of scroll steps. Default: 50.',
+        description: 'Max scroll steps. Default: 50',
       },
     },
     required: ['tabId', 'strategy'],

--- a/src/tools/click-element.ts
+++ b/src/tools/click-element.ts
@@ -16,7 +16,7 @@ import { FoundElement, scoreElement, tokenizeQuery } from '../utils/element-find
 
 const definition: MCPToolDefinition = {
   name: 'click_element',
-  description: 'Find an element by natural language query and click it in one operation. Returns the clicked element info and optionally a verification screenshot.',
+  description: 'Find and click an element by natural language query in one call.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -26,19 +26,19 @@ const definition: MCPToolDefinition = {
       },
       query: {
         type: 'string',
-        description: 'Natural language description of the element to click (e.g., "Login button", "Save Changes")',
+        description: 'Element to click, e.g. "Login button"',
       },
       wait_after: {
         type: 'number',
-        description: 'Milliseconds to wait after clicking (default: 100, max: 5000)',
+        description: 'Wait after click in ms. Default: 100, max: 5000',
       },
       verify: {
         type: 'boolean',
-        description: 'If true, returns a screenshot after clicking to verify the action',
+        description: 'Return screenshot after click for verification',
       },
       double_click: {
         type: 'boolean',
-        description: 'If true, performs a double-click instead of single click',
+        description: 'Perform double-click instead of single',
       },
     },
     required: ['tabId', 'query'],

--- a/src/tools/computer.ts
+++ b/src/tools/computer.ts
@@ -14,7 +14,7 @@ import { AdaptiveScreenshot } from '../utils/adaptive-screenshot';
 
 const definition: MCPToolDefinition = {
   name: 'computer',
-  description: 'Use mouse and keyboard to interact with a web browser, and take screenshots.',
+  description: 'Perform mouse, keyboard, and screenshot actions on a browser tab.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -37,7 +37,7 @@ const definition: MCPToolDefinition = {
           'scroll_to',
           'hover',
         ],
-        description: 'The action to perform',
+        description: 'Action to perform',
       },
       coordinate: {
         type: 'array',
@@ -63,7 +63,7 @@ const definition: MCPToolDefinition = {
       },
       ref: {
         type: 'string',
-        description: 'Element reference ID (ref_N from read_page) or backendNodeId (number from DOM mode)',
+        description: 'ref_N from read_page or backendNodeId from DOM mode',
       },
     },
     required: ['action', 'tabId'],

--- a/src/tools/console-capture.ts
+++ b/src/tools/console-capture.ts
@@ -50,15 +50,15 @@ const definition: MCPToolDefinition = {
       filter: {
         type: 'array',
         items: { type: 'string' },
-        description: 'Log types to capture: log, warn, error, info, debug (default: all)',
+        description: 'Log types to capture. Default: all',
       },
       limit: {
         type: 'number',
-        description: 'Maximum number of logs to return (for "get" action)',
+        description: 'Max logs to return (get action)',
       },
       maxLogs: {
         type: 'number',
-        description: 'Maximum logs to store (for "start" action, default: 1000)',
+        description: 'Max logs to store. Default: 1000',
       },
     },
     required: ['tabId', 'action'],

--- a/src/tools/cookies.ts
+++ b/src/tools/cookies.ts
@@ -20,40 +20,40 @@ const definition: MCPToolDefinition = {
       action: {
         type: 'string',
         enum: ['get', 'set', 'delete', 'clear'],
-        description: 'Action to perform: get, set, delete, or clear',
+        description: 'Action to perform',
       },
       name: {
         type: 'string',
-        description: 'Cookie name (required for set and delete, optional for get)',
+        description: 'Cookie name',
       },
       value: {
         type: 'string',
-        description: 'Cookie value (required for set action)',
+        description: 'Cookie value',
       },
       domain: {
         type: 'string',
-        description: 'Cookie domain (optional for set, defaults to current domain)',
+        description: 'Cookie domain. Default: current domain',
       },
       path: {
         type: 'string',
-        description: 'Cookie path (optional for set, defaults to "/")',
+        description: 'Cookie path. Default: /',
       },
       secure: {
         type: 'boolean',
-        description: 'Whether cookie is secure (optional for set)',
+        description: 'Secure flag',
       },
       httpOnly: {
         type: 'boolean',
-        description: 'Whether cookie is HTTP only (optional for set)',
+        description: 'HTTP-only flag',
       },
       sameSite: {
         type: 'string',
         enum: ['Strict', 'Lax', 'None'],
-        description: 'SameSite attribute (optional for set)',
+        description: 'SameSite attribute',
       },
       expires: {
         type: 'number',
-        description: 'Cookie expiration as Unix timestamp in seconds (optional for set)',
+        description: 'Expiration as Unix timestamp in seconds',
       },
     },
     required: ['tabId', 'action'],

--- a/src/tools/drag-drop.ts
+++ b/src/tools/drag-drop.ts
@@ -13,8 +13,7 @@ interface Position {
 
 const definition: MCPToolDefinition = {
   name: 'drag_drop',
-  description: `Perform drag and drop operations on the page.
-Supports dragging from/to elements by selector or coordinates.`,
+  description: 'Drag and drop by selector or coordinates.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -24,35 +23,35 @@ Supports dragging from/to elements by selector or coordinates.`,
       },
       sourceSelector: {
         type: 'string',
-        description: 'CSS selector for the source element to drag',
+        description: 'Source element CSS selector',
       },
       sourceX: {
         type: 'number',
-        description: 'X coordinate of source position (alternative to selector)',
+        description: 'Source X (alternative to selector)',
       },
       sourceY: {
         type: 'number',
-        description: 'Y coordinate of source position (alternative to selector)',
+        description: 'Source Y (alternative to selector)',
       },
       targetSelector: {
         type: 'string',
-        description: 'CSS selector for the target drop zone',
+        description: 'Target drop zone CSS selector',
       },
       targetX: {
         type: 'number',
-        description: 'X coordinate of target position (alternative to selector)',
+        description: 'Target X (alternative to selector)',
       },
       targetY: {
         type: 'number',
-        description: 'Y coordinate of target position (alternative to selector)',
+        description: 'Target Y (alternative to selector)',
       },
       steps: {
         type: 'number',
-        description: 'Number of intermediate steps for the drag (default: 10)',
+        description: 'Intermediate drag steps. Default: 10',
       },
       delay: {
         type: 'number',
-        description: 'Delay in ms between steps (default: 10)',
+        description: 'Delay in ms between steps. Default: 10',
       },
     },
     required: ['tabId'],

--- a/src/tools/emulate-device.ts
+++ b/src/tools/emulate-device.ts
@@ -83,7 +83,7 @@ const DEVICE_PRESETS: Record<string, DevicePreset> = {
 
 const definition: MCPToolDefinition = {
   name: 'emulate_device',
-  description: 'Emulate a device with specific viewport and user agent settings. Use a preset or provide custom dimensions.',
+  description: 'Emulate device viewport and user agent via preset or custom dimensions.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -93,7 +93,7 @@ const definition: MCPToolDefinition = {
       },
       preset: {
         type: 'string',
-        description: `Device preset: ${Object.keys(DEVICE_PRESETS).join(', ')}`,
+        description: `Device preset`,
         enum: Object.keys(DEVICE_PRESETS),
       },
       width: {
@@ -106,15 +106,15 @@ const definition: MCPToolDefinition = {
       },
       deviceScaleFactor: {
         type: 'number',
-        description: 'Device scale factor (default: 1)',
+        description: 'Device scale factor. Default: 1',
       },
       isMobile: {
         type: 'boolean',
-        description: 'Whether to emulate mobile device (default: false)',
+        description: 'Emulate mobile device. Default: false',
       },
       hasTouch: {
         type: 'boolean',
-        description: 'Whether to emulate touch events (default: false)',
+        description: 'Emulate touch events. Default: false',
       },
       userAgent: {
         type: 'string',

--- a/src/tools/file-upload.ts
+++ b/src/tools/file-upload.ts
@@ -11,8 +11,7 @@ import { getSessionManager } from '../session-manager';
 
 const definition: MCPToolDefinition = {
   name: 'file_upload',
-  description: `Upload files to a file input element on the page.
-Supports single or multiple file uploads.`,
+  description: 'Upload files to a file input element on the page.',
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/fill-form.ts
+++ b/src/tools/fill-form.ts
@@ -11,7 +11,7 @@ import { withDomDelta } from '../utils/dom-delta';
 
 const definition: MCPToolDefinition = {
   name: 'fill_form',
-  description: 'Fill multiple form fields at once and optionally submit the form. The fields parameter maps field identifiers (label, name, placeholder, or aria-label) to values.',
+  description: 'Fill multiple form fields at once and optionally submit.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -21,7 +21,7 @@ const definition: MCPToolDefinition = {
       },
       fields: {
         type: 'object',
-        description: 'Object mapping field names/labels to values. Keys can be labels, names, placeholders, or aria-labels.',
+        description: 'Map of field labels/names/placeholders to values',
         additionalProperties: {
           oneOf: [
             { type: 'string' },
@@ -32,11 +32,11 @@ const definition: MCPToolDefinition = {
       },
       submit: {
         type: 'string',
-        description: 'Optional: Natural language query for the submit button to click after filling (e.g., "Login", "Submit", "Save")',
+        description: 'Submit button query, e.g. "Login", "Save"',
       },
       clear_first: {
         type: 'boolean',
-        description: 'If true, clears existing field values before entering new values (default: true)',
+        description: 'Clear fields before filling. Default: true',
       },
     },
     required: ['tabId', 'fields'],

--- a/src/tools/find.ts
+++ b/src/tools/find.ts
@@ -9,8 +9,7 @@ import { getRefIdManager } from '../utils/ref-id-manager';
 
 const definition: MCPToolDefinition = {
   name: 'find',
-  description:
-    'Find elements on the page using natural language. Returns up to 20 matching elements with references.',
+  description: 'Find elements by natural language query. Returns up to 20 matches with refs.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -20,7 +19,7 @@ const definition: MCPToolDefinition = {
       },
       query: {
         type: 'string',
-        description: 'Natural language description of what to find (e.g., "search bar", "login button")',
+        description: 'What to find, e.g. "search bar", "login button"',
       },
     },
     required: ['query', 'tabId'],

--- a/src/tools/form-input.ts
+++ b/src/tools/form-input.ts
@@ -10,7 +10,7 @@ import { withDomDelta } from '../utils/dom-delta';
 
 const definition: MCPToolDefinition = {
   name: 'form_input',
-  description: 'Set values in form elements using element reference ID from read_page or find tools.',
+  description: 'Set form element value using ref from read_page or find.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -20,12 +20,12 @@ const definition: MCPToolDefinition = {
       },
       ref: {
         type: 'string',
-        description: 'Element reference ID (ref_N from read_page) or backendNodeId (number from DOM mode)',
+        description: 'ref_N from read_page or backendNodeId from DOM mode',
       },
       value: {
         oneOf: [{ type: 'string' }, { type: 'boolean' }, { type: 'number' }],
         description:
-          'The value to set. For checkboxes use boolean, for selects use option value or text',
+          'Value to set. Boolean for checkboxes, string for selects',
       },
     },
     required: ['ref', 'value', 'tabId'],

--- a/src/tools/geolocation.ts
+++ b/src/tools/geolocation.ts
@@ -25,7 +25,7 @@ const LOCATION_PRESETS: Record<
 
 const definition: MCPToolDefinition = {
   name: 'geolocation',
-  description: 'Set or clear geolocation coordinates. Use a preset city or provide custom latitude/longitude.',
+  description: 'Set or clear geolocation via preset city or custom coordinates.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -35,7 +35,7 @@ const definition: MCPToolDefinition = {
       },
       preset: {
         type: 'string',
-        description: `Preset location: ${Object.keys(LOCATION_PRESETS).join(', ')}`,
+        description: 'Preset city',
         enum: Object.keys(LOCATION_PRESETS),
       },
       latitude: {
@@ -48,7 +48,7 @@ const definition: MCPToolDefinition = {
       },
       accuracy: {
         type: 'number',
-        description: 'Accuracy in meters (default: 100)',
+        description: 'Accuracy in meters. Default: 100',
       },
     },
     required: ['tabId'],

--- a/src/tools/http-auth.ts
+++ b/src/tools/http-auth.ts
@@ -8,26 +8,26 @@ import { getSessionManager } from '../session-manager';
 
 const definition: MCPToolDefinition = {
   name: 'http_auth',
-  description: 'Manage HTTP Basic/Digest authentication credentials (set, clear, status).',
+  description: 'Manage HTTP Basic/Digest authentication credentials.',
   inputSchema: {
     type: 'object',
     properties: {
       tabId: {
         type: 'string',
-        description: 'Tab ID to set authentication for',
+        description: 'Tab ID to set auth for',
       },
       action: {
         type: 'string',
         enum: ['set', 'clear'],
-        description: 'Action: set or clear credentials',
+        description: 'Set or clear credentials',
       },
       username: {
         type: 'string',
-        description: 'Username for HTTP authentication (required for "set" action)',
+        description: 'Username for HTTP auth',
       },
       password: {
         type: 'string',
-        description: 'Password for HTTP authentication (required for "set" action)',
+        description: 'Password for HTTP auth',
       },
     },
     required: ['tabId', 'action'],

--- a/src/tools/inspect.ts
+++ b/src/tools/inspect.ts
@@ -14,8 +14,7 @@ import { getSessionManager } from '../session-manager';
 
 const definition: MCPToolDefinition = {
   name: 'inspect',
-  description:
-    'Query-focused page state extraction. Returns only data relevant to your query instead of the full DOM tree. Use this instead of read_page + screenshot combos for targeted questions like "what tabs are active", "form field values", "visible error messages".',
+  description: 'Extract focused page state by query. Use instead of read_page + screenshot for targeted questions.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -25,13 +24,12 @@ const definition: MCPToolDefinition = {
       },
       query: {
         type: 'string',
-        description:
-          'What to inspect, e.g. "what tabs are active", "form field values", "visible error messages", "page structure"',
+        description: 'What to inspect, e.g. "active tabs", "form values"',
       },
       scope: {
         type: 'string',
         enum: ['interactive', 'all', 'visible'],
-        description: 'Scope of elements to inspect (default: "visible")',
+        description: 'Element scope. Default: visible',
       },
     },
     required: ['tabId', 'query'],

--- a/src/tools/interact.ts
+++ b/src/tools/interact.ts
@@ -14,8 +14,7 @@ import { FoundElement, scoreElement, tokenizeQuery } from '../utils/element-find
 
 const definition: MCPToolDefinition = {
   name: 'interact',
-  description:
-    'Find an element, perform an action, wait for stability, and return a comprehensive state summary. Reduces multi-step find→click→screenshot sequences to a single call.',
+  description: 'Find element, act, wait for stability, return state summary in one call.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -25,21 +24,21 @@ const definition: MCPToolDefinition = {
       },
       query: {
         type: 'string',
-        description: 'Natural language description of the element to interact with',
+        description: 'Element to interact with (natural language)',
       },
       action: {
         type: 'string',
         enum: ['click', 'double_click', 'hover'],
-        description: 'Action to perform on the element (default: "click")',
+        description: 'Action to perform. Default: click',
       },
       waitAfter: {
         type: 'number',
-        description: 'Milliseconds to wait after action for DOM to settle (default: 500)',
+        description: 'Wait for DOM settle in ms. Default: 500',
       },
       returnFormat: {
         type: 'string',
         enum: ['state_summary', 'dom_delta', 'both'],
-        description: 'What to include in the response (default: "both")',
+        description: 'Response content. Default: both',
       },
     },
     required: ['tabId', 'query'],

--- a/src/tools/javascript.ts
+++ b/src/tools/javascript.ts
@@ -9,23 +9,21 @@ import { assertDomainAllowed } from '../security/domain-guard';
 
 const definition: MCPToolDefinition = {
   name: 'javascript_tool',
-  description:
-    'Execute JavaScript code in the context of the current page. Supports top-level await. Returns the result of the last expression.',
+  description: 'Execute JavaScript in page context. Supports top-level await.',
   inputSchema: {
     type: 'object',
     properties: {
       tabId: {
         type: 'string',
-        description: 'Tab ID to execute the code in',
+        description: 'Tab ID to execute code in',
       },
       text: {
         type: 'string',
-        description:
-          'The JavaScript code to execute. The result of the last expression will be returned.',
+        description: 'JS code to execute. Last expression returned.',
       },
       timeout: {
         type: 'number',
-        description: 'Timeout in milliseconds for JavaScript execution (default: 30000)',
+        description: 'Timeout in ms. Default: 30000',
       },
     },
     required: ['text', 'tabId'],

--- a/src/tools/lightweight-scroll.ts
+++ b/src/tools/lightweight-scroll.ts
@@ -13,8 +13,7 @@ import { getSessionManager } from '../session-manager';
 
 const definition: MCPToolDefinition = {
   name: 'lightweight_scroll',
-  description:
-    'Scroll a page using JavaScript without taking a screenshot. Returns the new scroll position and metrics. Suitable for infinite scroll and lazy loading scenarios.',
+  description: 'Scroll page via JS without screenshot. Returns new scroll position.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -29,29 +28,23 @@ const definition: MCPToolDefinition = {
       },
       amount: {
         type: 'number',
-        description: 'Scroll amount in pixels (default: 300)',
+        description: 'Scroll amount in pixels. Default: 300',
       },
       smooth: {
         type: 'boolean',
-        description: 'Use smooth scrolling animation (default: false)',
+        description: 'Smooth scrolling animation. Default: false',
       },
       selector: {
         type: 'string',
-        description:
-          'CSS selector of a specific element to scroll (default: window). ' +
-          'Use for scrollable containers like chat panels or sidebars.',
+        description: 'Element to scroll (CSS selector). Default: window',
       },
       scrollToEnd: {
         type: 'boolean',
-        description:
-          'Scroll to the very end in the given direction (default: false). ' +
-          'Useful for reaching the bottom of a page or container.',
+        description: 'Scroll to end in given direction. Default: false',
       },
       waitAfterMs: {
         type: 'number',
-        description:
-          'Milliseconds to wait after scrolling for content to load (default: 0). ' +
-          'Useful for infinite scroll pages that need time to fetch new content.',
+        description: 'Wait after scroll for lazy content in ms. Default: 0',
       },
     },
     required: ['tabId', 'direction'],

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -16,36 +16,36 @@ import { getDomainMemory } from '../memory/domain-memory';
 const definition: MCPToolDefinition = {
   name: 'memory',
   description:
-    'Manage domain knowledge for future reuse. Actions: "record" (store knowledge), "query" (retrieve by domain), "validate" (report success/failure to adjust confidence).',
+    'Manage domain knowledge. Actions: "record" (store), "query" (retrieve by domain), "validate" (adjust confidence). Key convention: "selector:X", "tip:X", "avoid:X".',
   inputSchema: {
     type: 'object',
     properties: {
       action: {
         type: 'string',
         enum: ['record', 'query', 'validate'],
-        description: 'Action to perform: record, query, or validate domain knowledge',
+        description: 'Action: record, query, or validate',
       },
       domain: {
         type: 'string',
-        description: '(record, query) Website domain (e.g., "x.com", "amazon.com")',
+        description: '(record, query) Domain, e.g. "x.com"',
       },
       key: {
         type: 'string',
         description:
-          '(record) Knowledge key, e.g. "selector:tweet_container". (query) Optional key prefix to filter.',
+          '(record) Key, e.g. "selector:tweet". (query) Key prefix filter.',
       },
       value: {
         type: 'string',
-        description: '(record) The knowledge value (e.g., "article[data-testid=\'tweet\']")',
+        description: '(record) Knowledge value, e.g. a CSS selector string',
       },
       id: {
         type: 'string',
-        description: '(validate) The knowledge entry ID to validate',
+        description: '(validate) Knowledge entry ID',
       },
       success: {
         type: 'boolean',
         description:
-          '(validate) Whether the knowledge was accurate (true) or outdated/broken (false)',
+          '(validate) true = accurate, false = outdated/broken',
       },
     },
     required: ['action'],

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -14,22 +14,21 @@ import { assertDomainAllowed } from '../security/domain-guard';
 
 const definition: MCPToolDefinition = {
   name: 'navigate',
-  description: 'Navigate to a URL, or go forward/back in browser history. If tabId is not provided, creates a new tab with the URL. Use workerId to specify which worker context to use for parallel operations.',
+  description: 'Navigate to URL or go forward/back. No tabId = new tab. workerId for parallel ops.',
   inputSchema: {
     type: 'object',
     properties: {
       tabId: {
         type: 'string',
-        description: 'Tab ID to navigate. If not provided, a new tab will be created.',
+        description: 'Tab ID to navigate. No tabId = new tab',
       },
       url: {
         type: 'string',
-        description:
-          'The URL to navigate to. Use "forward" to go forward in history or "back" to go back.',
+        description: 'URL, "forward", or "back"',
       },
       workerId: {
         type: 'string',
-        description: 'Worker ID for parallel operations. Uses default worker if not specified.',
+        description: 'Worker ID for parallel ops. Default: default',
       },
     },
     required: ['url'],

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -45,31 +45,30 @@ const NETWORK_PRESETS: Record<
 
 const definition: MCPToolDefinition = {
   name: 'network',
-  description: 'Simulate network conditions like throttling, latency, and offline mode. Use a preset or provide custom settings.',
+  description: 'Simulate network conditions (throttling, latency, offline).',
   inputSchema: {
     type: 'object',
     properties: {
       tabId: {
         type: 'string',
-        description: 'Tab ID to apply network conditions to',
+        description: 'Tab ID to apply conditions to',
       },
       preset: {
         type: 'string',
-        description:
-          'Network preset: offline, slow-2g, 2g, 3g, 4g, fast-wifi, custom, or clear',
+        description: 'Network preset',
         enum: ['offline', 'slow-2g', '2g', '3g', '4g', 'fast-wifi', 'custom', 'clear'],
       },
       downloadKbps: {
         type: 'number',
-        description: 'Custom download speed in Kbps (only for preset=custom)',
+        description: 'Download Kbps (preset=custom only)',
       },
       uploadKbps: {
         type: 'number',
-        description: 'Custom upload speed in Kbps (only for preset=custom)',
+        description: 'Upload Kbps (preset=custom only)',
       },
       latencyMs: {
         type: 'number',
-        description: 'Custom latency in milliseconds (only for preset=custom)',
+        description: 'Latency in ms (preset=custom only)',
       },
     },
     required: ['tabId', 'preset'],

--- a/src/tools/orchestration.ts
+++ b/src/tools/orchestration.ts
@@ -20,16 +20,13 @@ const dnsResolve = promisify(dns.resolve);
 
 const workflowInitDefinition: MCPToolDefinition = {
   name: 'workflow_init',
-  description: `Initialize a Chrome-Sisyphus workflow with multiple workers.
-Creates isolated browser contexts for each worker and sets up scratchpad files.
-
-Use this to prepare parallel browser operations before launching worker agents.`,
+  description: 'Initialize a workflow with multiple isolated workers for parallel browser ops.',
   inputSchema: {
     type: 'object',
     properties: {
       name: {
         type: 'string',
-        description: 'Name of the workflow (e.g., "Price comparison")',
+        description: 'Workflow name',
       },
       workers: {
         type: 'array',
@@ -39,7 +36,7 @@ Use this to prepare parallel browser operations before launching worker agents.`
           properties: {
             name: {
               type: 'string',
-              description: 'Worker name (e.g., "coupang", "11st")',
+              description: 'Worker name',
             },
             url: {
               type: 'string',
@@ -55,7 +52,7 @@ Use this to prepare parallel browser operations before launching worker agents.`
             },
             shareCookies: {
               type: 'boolean',
-              description: 'If true, worker shares cookies from existing Chrome session instead of isolated context (default: false)',
+              description: 'Share cookies from Chrome session. Default: false',
             },
           },
           required: ['name', 'url', 'task'],
@@ -63,15 +60,15 @@ Use this to prepare parallel browser operations before launching worker agents.`
       },
       workerTimeoutMs: {
         type: 'number',
-        description: 'Maximum execution time per worker in milliseconds (default: 60000). Workers exceeding this limit are force-completed with PARTIAL status.',
+        description: 'Per-worker timeout in ms. Default: 60000',
       },
       maxStaleIterations: {
         type: 'number',
-        description: 'Maximum consecutive worker updates with no data change before circuit breaker triggers (default: 5). Prevents runaway workers stuck in retry loops.',
+        description: 'Stale update limit before circuit break. Default: 5',
       },
       globalTimeoutMs: {
         type: 'number',
-        description: 'Maximum total workflow execution time in milliseconds (default: 300000). All running workers are force-completed when exceeded.',
+        description: 'Global workflow timeout in ms. Default: 300000',
       },
     },
     required: ['name', 'workers'],
@@ -216,14 +213,13 @@ const workflowInitHandler: ToolHandler = async (
 
 const workflowStatusDefinition: MCPToolDefinition = {
   name: 'workflow_status',
-  description: `Get the current status of a Chrome-Sisyphus workflow.
-Returns orchestration state and all worker states.`,
+  description: 'Get current workflow status and worker states.',
   inputSchema: {
     type: 'object',
     properties: {
       includeWorkerDetails: {
         type: 'boolean',
-        description: 'Include full worker scratchpad details (default: false)',
+        description: 'Include worker scratchpad details. Default: false',
       },
     },
     required: [],
@@ -299,8 +295,7 @@ const workflowStatusHandler: ToolHandler = async (
 
 const workflowCollectDefinition: MCPToolDefinition = {
   name: 'workflow_collect',
-  description: `Collect and aggregate results from all workers in the workflow.
-Use this after all worker Background Tasks have completed.`,
+  description: 'Collect and aggregate results from all workers after completion.',
   inputSchema: {
     type: 'object',
     properties: {},
@@ -354,8 +349,7 @@ const workflowCollectHandler: ToolHandler = async (
 
 const workflowCleanupDefinition: MCPToolDefinition = {
   name: 'workflow_cleanup',
-  description: `Clean up workflow resources including workers, tabs, and scratchpad files.
-Use this after workflow completion or to abort a workflow.`,
+  description: 'Clean up workflow resources (workers, tabs, scratchpads).',
   inputSchema: {
     type: 'object',
     properties: {},
@@ -402,8 +396,7 @@ const workflowCleanupHandler: ToolHandler = async (
 
 const workerUpdateDefinition: MCPToolDefinition = {
   name: 'worker_update',
-  description: `Update a worker's progress in the orchestration scratchpad.
-Call this from worker agents to report progress.`,
+  description: 'Report worker progress to the orchestration scratchpad.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -490,8 +483,7 @@ const workerUpdateHandler: ToolHandler = async (
 
 const workerCompleteDefinition: MCPToolDefinition = {
   name: 'worker_complete',
-  description: `Mark a worker as complete with final results.
-Call this from worker agents when task is done.`,
+  description: 'Mark a worker as complete with final results.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -506,7 +498,7 @@ Call this from worker agents when task is done.`,
       },
       resultSummary: {
         type: 'string',
-        description: 'Brief summary of results (max 100 chars)',
+        description: 'Result summary (max 100 chars)',
       },
       extractedData: {
         type: 'object',
@@ -562,15 +554,13 @@ const workerCompleteHandler: ToolHandler = async (
 
 const workflowCollectPartialDefinition: MCPToolDefinition = {
   name: 'workflow_collect_partial',
-  description: `Collect results from completed workers without waiting for all workers to finish.
-Returns only workers that have already reported SUCCESS, PARTIAL, or FAIL status.
-Use this to stream results as they become available instead of waiting for the slowest worker.`,
+  description: 'Collect results from completed workers without waiting for all. Use to stream results as available.',
   inputSchema: {
     type: 'object',
     properties: {
       onlySuccessful: {
         type: 'boolean',
-        description: 'If true, only return workers with SUCCESS or PARTIAL status (default: false)',
+        description: 'Only return successful workers. Default: false',
       },
     },
     required: [],
@@ -660,16 +650,13 @@ const workflowCollectPartialHandler: ToolHandler = async (
 
 const executePlanDefinition: MCPToolDefinition = {
   name: 'execute_plan',
-  description: `Execute a cached compiled plan by ID, bypassing per-step agent LLM round-trips.
-The plan's tool calls are chained internally on the server side.
-Use this for repeated task patterns (e.g., tweet extraction) where the tool sequence is known.
-Falls back gracefully — returns an error result if the plan fails, allowing the agent to retry manually.`,
+  description: 'Execute a cached plan by ID, bypassing per-step LLM calls. Falls back gracefully on failure for manual retry.',
   inputSchema: {
     type: 'object',
     properties: {
       planId: {
         type: 'string',
-        description: 'ID of the compiled plan to execute (e.g., "x-tweet-extraction-v1")',
+        description: 'Plan ID, e.g. "x-tweet-extraction-v1"',
       },
       tabId: {
         type: 'string',
@@ -677,7 +664,7 @@ Falls back gracefully — returns an error result if the plan fails, allowing th
       },
       params: {
         type: 'object',
-        description: 'Additional runtime parameters to pass to the plan (merged with plan defaults)',
+        description: 'Runtime params merged with plan defaults',
       },
     },
     required: ['planId', 'tabId'],

--- a/src/tools/page-content.ts
+++ b/src/tools/page-content.ts
@@ -9,9 +9,7 @@ import { MAX_OUTPUT_CHARS } from '../config/defaults';
 
 const definition: MCPToolDefinition = {
   name: 'page_content',
-  description: `Get HTML content from the current page.
-Returns the full page HTML or content from a specific element using a CSS selector.
-Useful for scraping and extracting page structure.`,
+  description: 'Get HTML content from page or a specific element.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -21,11 +19,11 @@ Useful for scraping and extracting page structure.`,
       },
       selector: {
         type: 'string',
-        description: 'Optional CSS selector to get content from a specific element. If not provided, returns full page HTML.',
+        description: 'CSS selector for specific element. Omit for full page',
       },
       outerHTML: {
         type: 'boolean',
-        description: 'If true, returns outerHTML (includes the element itself). If false, returns innerHTML. Default: true',
+        description: 'Return outerHTML vs innerHTML. Default: true',
       },
     },
     required: ['tabId'],

--- a/src/tools/page-pdf.ts
+++ b/src/tools/page-pdf.ts
@@ -11,9 +11,7 @@ import { getSessionManager } from '../session-manager';
 
 const definition: MCPToolDefinition = {
   name: 'page_pdf',
-  description: `Generate a PDF from the current page.
-If path is provided, saves to file. Otherwise returns base64-encoded PDF.
-Supports various paper formats and options.`,
+  description: 'Generate PDF from page. Saves to path or returns base64.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -23,56 +21,56 @@ Supports various paper formats and options.`,
       },
       path: {
         type: 'string',
-        description: 'File path to save PDF (absolute or relative to home). If not provided, returns base64.',
+        description: 'Save path (absolute/relative to home). Omit for base64',
       },
       format: {
         type: 'string',
         enum: ['A4', 'Letter', 'Legal', 'Tabloid', 'A3', 'A5'],
-        description: 'Paper format (default: A4)',
+        description: 'Paper format. Default: A4',
       },
       landscape: {
         type: 'boolean',
-        description: 'Whether to print in landscape mode (default: false)',
+        description: 'Landscape mode. Default: false',
       },
       printBackground: {
         type: 'boolean',
-        description: 'Whether to print background graphics (default: true)',
+        description: 'Print background graphics. Default: true',
       },
       scale: {
         type: 'number',
-        description: 'Scale of the webpage rendering (0.1-2.0, default: 1)',
+        description: 'Render scale (0.1-2.0). Default: 1',
       },
       marginTop: {
         type: 'string',
-        description: 'Top margin (e.g., "1cm", "0.5in")',
+        description: 'Top margin, e.g. "1cm"',
       },
       marginRight: {
         type: 'string',
-        description: 'Right margin (e.g., "1cm", "0.5in")',
+        description: 'Right margin, e.g. "1cm"',
       },
       marginBottom: {
         type: 'string',
-        description: 'Bottom margin (e.g., "1cm", "0.5in")',
+        description: 'Bottom margin, e.g. "1cm"',
       },
       marginLeft: {
         type: 'string',
-        description: 'Left margin (e.g., "1cm", "0.5in")',
+        description: 'Left margin, e.g. "1cm"',
       },
       pageRanges: {
         type: 'string',
-        description: 'Page ranges to print (e.g., "1-5, 8, 11-13")',
+        description: 'Page ranges, e.g. "1-5, 8, 11-13"',
       },
       displayHeaderFooter: {
         type: 'boolean',
-        description: 'Whether to display header and footer (default: false)',
+        description: 'Show header/footer. Default: false',
       },
       headerTemplate: {
         type: 'string',
-        description: 'HTML template for the header (requires displayHeaderFooter: true)',
+        description: 'Header HTML (needs displayHeaderFooter)',
       },
       footerTemplate: {
         type: 'string',
-        description: 'HTML template for the footer (requires displayHeaderFooter: true)',
+        description: 'Footer HTML (needs displayHeaderFooter)',
       },
     },
     required: ['tabId'],

--- a/src/tools/page-reload.ts
+++ b/src/tools/page-reload.ts
@@ -10,7 +10,7 @@ import { DEFAULT_NAVIGATION_TIMEOUT_MS } from '../config/defaults';
 
 const definition: MCPToolDefinition = {
   name: 'page_reload',
-  description: 'Reload the current page. Optionally bypass cache for a hard refresh.',
+  description: 'Reload the current page.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -20,7 +20,7 @@ const definition: MCPToolDefinition = {
       },
       ignoreCache: {
         type: 'boolean',
-        description: 'If true, bypasses the browser cache (hard refresh). Default: false',
+        description: 'Bypass cache (hard refresh). Default: false',
       },
     },
     required: ['tabId'],

--- a/src/tools/performance-metrics.ts
+++ b/src/tools/performance-metrics.ts
@@ -8,12 +8,7 @@ import { getSessionManager } from '../session-manager';
 
 const definition: MCPToolDefinition = {
   name: 'performance_metrics',
-  description: `Get performance metrics for the current page.
-Collects various metrics including:
-- Puppeteer metrics (JS heap, layout counts, etc.)
-- Navigation timing (page load, DOM content loaded)
-- Paint timing (first paint, first contentful paint)
-- Resource timing (optional)`,
+  description: 'Get page performance metrics (timing, paint, heap, resources).',
   inputSchema: {
     type: 'object',
     properties: {
@@ -24,11 +19,11 @@ Collects various metrics including:
       type: {
         type: 'string',
         enum: ['all', 'puppeteer', 'navigation', 'paint', 'resource'],
-        description: 'Type of metrics to retrieve (default: all)',
+        description: 'Metrics type. Default: all',
       },
       includeResources: {
         type: 'boolean',
-        description: 'Whether to include resource timing data (can be large)',
+        description: 'Include resource timing (can be large)',
       },
     },
     required: ['tabId'],

--- a/src/tools/profile-status.ts
+++ b/src/tools/profile-status.ts
@@ -13,12 +13,7 @@ import { formatAge } from '../utils/format-age';
 
 const definition: MCPToolDefinition = {
   name: 'oc_profile_status',
-  description:
-    'Check the current browser profile type and capabilities. ' +
-    'Returns whether the browser is using the real Chrome profile (full capability), ' +
-    'a persistent OpenChrome profile (synced cookies, persistent storage), ' +
-    'or a temporary profile (no user data). ' +
-    'Use this to diagnose authentication failures or missing browser features.',
+  description: 'Check browser profile type (real/persistent/temporary) and capabilities. Use to diagnose auth failures.',
   inputSchema: {
     type: 'object',
     properties: {},

--- a/src/tools/query-dom.ts
+++ b/src/tools/query-dom.ts
@@ -40,7 +40,7 @@ interface XPathElementInfo {
 const definition: MCPToolDefinition = {
   name: 'query_dom',
   description:
-    'Query DOM elements using CSS selectors or XPath expressions. Returns element information including tag, attributes, text, and position.',
+    'Query DOM elements via CSS selectors or XPath. Returns tag, attributes, text, and position.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -51,24 +51,23 @@ const definition: MCPToolDefinition = {
       method: {
         type: 'string',
         enum: ['css', 'xpath'],
-        description: 'Query method: "css" for CSS selectors, "xpath" for XPath expressions',
+        description: 'Query method: css or xpath',
       },
       selector: {
         type: 'string',
-        description: '(css) CSS selector to query (e.g., "#search", ".button", "input[type=text]")',
+        description: '(css) CSS selector, e.g. "#search", ".button"',
       },
       xpath: {
         type: 'string',
-        description: '(xpath) XPath expression to evaluate',
+        description: '(xpath) XPath expression',
       },
       multiple: {
         type: 'boolean',
-        description:
-          'If true, returns all matching elements. If false, returns only the first match. Default: false',
+        description: 'Return all matches. Default: false',
       },
       limit: {
         type: 'number',
-        description: '(xpath, multiple: true) Maximum number of results to return',
+        description: '(xpath, multiple) Max results to return',
       },
     },
     required: ['tabId', 'method'],

--- a/src/tools/read-page.ts
+++ b/src/tools/read-page.ts
@@ -25,8 +25,7 @@ function formatPaginationSection(pagination: PaginationInfo): string {
 
 const definition: MCPToolDefinition = {
   name: 'read_page',
-  description:
-    'Get page content. Default mode "dom" returns compact DOM (~5-10x fewer tokens) with stable backendNodeId identifiers. Mode "ax" returns accessibility tree with ref_N identifiers for ARIA/accessibility auditing. Mode "css" returns CSS diagnostic info (variables, computed styles, framework detection) — use this BEFORE javascript_tool for style inspection or visual debugging.',
+  description: 'Get page content as compact DOM (default), accessibility tree (ax), or CSS diagnostics (css). Use css mode BEFORE javascript_tool for style inspection.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -36,29 +35,29 @@ const definition: MCPToolDefinition = {
       },
       depth: {
         type: 'number',
-        description: 'Maximum depth of the tree to traverse (default: 8 for "all", 5 for "interactive")',
+        description: 'Max tree depth. Default: 8 (all), 5 (interactive)',
       },
       filter: {
         type: 'string',
         enum: ['interactive', 'all'],
-        description: 'Filter elements: "interactive" for buttons/links/inputs only',
+        description: 'Filter: "interactive" for buttons/links/inputs only',
       },
       ref_id: {
         type: 'string',
-        description: 'Reference ID of a parent element to read from',
+        description: 'Parent element ref for subtree scoping',
       },
       selector: {
         type: 'string',
-        description: '(css mode only) CSS selector to inspect specific elements. If omitted, inspects all elements with visual properties.',
+        description: 'CSS selector to inspect (css mode only)',
       },
       mode: {
         type: 'string',
         enum: ['ax', 'dom', 'css'],
-        description: 'Output mode: "dom" for compact DOM (default), "ax" for accessibility tree, "css" for CSS diagnostics (variables, computed styles, framework detection)',
+        description: 'Output mode: dom (default), ax, or css',
       },
       includePagination: {
         type: 'boolean',
-        description: 'Whether to detect and include pagination info in the output (default: true)',
+        description: 'Include pagination info. Default: true',
       },
     },
     required: ['tabId'],

--- a/src/tools/request-intercept.ts
+++ b/src/tools/request-intercept.ts
@@ -59,7 +59,7 @@ function matchesPattern(url: string, pattern: string): boolean {
 
 const definition: MCPToolDefinition = {
   name: 'request_intercept',
-  description: 'Intercept and monitor network requests. Supports logging, blocking, modifying, and mocking responses.',
+  description: 'Intercept and monitor network requests (log, block, modify).',
   inputSchema: {
     type: 'object',
     properties: {
@@ -74,25 +74,25 @@ const definition: MCPToolDefinition = {
       },
       rule: {
         type: 'object',
-        description: 'Rule definition for addRule action',
+        description: 'Rule for addRule action',
         properties: {
           pattern: {
             type: 'string',
-            description: 'URL pattern to match (glob-like, e.g., "*://example.com/*")',
+            description: 'URL glob pattern, e.g. "*://example.com/*"',
           },
           resourceTypes: {
             type: 'array',
             items: { type: 'string' },
-            description: 'Resource types: document, stylesheet, image, font, script, xhr, fetch',
+            description: 'Filter by resource type',
           },
           action: {
             type: 'string',
             enum: ['block', 'modify', 'log'],
-            description: 'What to do with matched requests',
+            description: 'Action for matched requests',
           },
           modifyOptions: {
             type: 'object',
-            description: 'Options for modify action',
+            description: 'Modify action options',
             properties: {
               status: { type: 'number' },
               headers: { type: 'object' },

--- a/src/tools/shutdown.ts
+++ b/src/tools/shutdown.ts
@@ -17,18 +17,13 @@ import { getChromeLauncher } from '../chrome/launcher';
 
 const definition: MCPToolDefinition = {
   name: 'oc_stop',
-  description:
-    'Gracefully shut down OpenChrome: close all browser sessions, tabs, and the Chrome process. ' +
-    'Use this when you are done with browser automation. Chrome will be re-launched ' +
-    'automatically on the next OpenChrome tool call.',
+  description: 'Shut down OpenChrome and close Chrome. Auto-relaunched on next tool call.',
   inputSchema: {
     type: 'object',
     properties: {
       keepChrome: {
         type: 'boolean',
-        description:
-          'If true, keep Chrome running but disconnect OpenChrome from it (default: false). ' +
-          'When false, Chrome is killed if OpenChrome launched it.',
+        description: 'Keep Chrome running, just disconnect. Default: false',
       },
     },
     required: [],

--- a/src/tools/storage.ts
+++ b/src/tools/storage.ts
@@ -9,7 +9,7 @@ import { assertDomainAllowed } from '../security/domain-guard';
 
 const definition: MCPToolDefinition = {
   name: 'storage',
-  description: 'Manage browser localStorage and sessionStorage (get, set, delete, clear, keys).',
+  description: 'Manage browser localStorage and sessionStorage.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -20,7 +20,7 @@ const definition: MCPToolDefinition = {
       storageType: {
         type: 'string',
         enum: ['local', 'session'],
-        description: 'Storage type: "local" for localStorage, "session" for sessionStorage',
+        description: 'local or session storage',
       },
       action: {
         type: 'string',
@@ -29,11 +29,11 @@ const definition: MCPToolDefinition = {
       },
       key: {
         type: 'string',
-        description: 'Storage key (required for set and remove, optional for get)',
+        description: 'Storage key',
       },
       value: {
         type: 'string',
-        description: 'Value to store (required for set action). Objects should be JSON stringified.',
+        description: 'Value to store. JSON-stringify objects',
       },
     },
     required: ['tabId', 'storageType', 'action'],

--- a/src/tools/tabs-close.ts
+++ b/src/tools/tabs-close.ts
@@ -8,8 +8,7 @@ import { getSessionManager } from '../session-manager';
 
 const definition: MCPToolDefinition = {
   name: 'tabs_close',
-  description:
-    'Close one or more tabs. Use tabId to close a specific tab, or workerId to close all tabs in a worker.',
+  description: 'Close one or more tabs by tabId, tabIds, or workerId.',
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/tabs-context.ts
+++ b/src/tools/tabs-context.ts
@@ -9,18 +9,17 @@ import { safeTitle } from '../utils/safe-title';
 
 const definition: MCPToolDefinition = {
   name: 'tabs_context_mcp',
-  description:
-    'Get context information about the current MCP session tabs and workers. Returns all tab IDs grouped by worker.',
+  description: 'Get session tab IDs grouped by worker.',
   inputSchema: {
     type: 'object',
     properties: {
       workerId: {
         type: 'string',
-        description: 'Optional: Get tabs for a specific worker only.',
+        description: 'Filter to a specific worker',
       },
       summary: {
         type: 'boolean',
-        description: 'If true, return only worker/tab counts without full tab details.',
+        description: 'Return counts only, no tab details',
       },
     },
     required: [],

--- a/src/tools/tabs-create.ts
+++ b/src/tools/tabs-create.ts
@@ -10,17 +10,17 @@ import { assertDomainAllowed } from '../security/domain-guard';
 
 const definition: MCPToolDefinition = {
   name: 'tabs_create_mcp',
-  description: 'Creates a new tab with the specified URL. Use workerId for parallel browser operations.',
+  description: 'Create a new tab with URL. workerId for parallel ops.',
   inputSchema: {
     type: 'object',
     properties: {
       url: {
         type: 'string',
-        description: 'URL to open in the new tab (required)',
+        description: 'URL to open in the new tab',
       },
       workerId: {
         type: 'string',
-        description: 'Worker ID for parallel operations. Uses default worker if not specified.',
+        description: 'Worker ID for parallel ops. Default: default',
       },
     },
     required: ['url'],

--- a/src/tools/user-agent.ts
+++ b/src/tools/user-agent.ts
@@ -32,7 +32,7 @@ const USER_AGENT_PRESETS: Record<string, string> = {
 
 const definition: MCPToolDefinition = {
   name: 'user_agent',
-  description: 'Set or reset the browser user agent string. Use a preset or provide a custom string.',
+  description: 'Set or reset browser user agent via preset or custom string.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -42,12 +42,12 @@ const definition: MCPToolDefinition = {
       },
       preset: {
         type: 'string',
-        description: `Preset name: ${Object.keys(USER_AGENT_PRESETS).join(', ')}`,
+        description: 'UA preset',
         enum: Object.keys(USER_AGENT_PRESETS),
       },
       custom: {
         type: 'string',
-        description: 'Custom user agent string (overrides preset if provided)',
+        description: 'Custom UA string (overrides preset)',
       },
     },
     required: ['tabId'],

--- a/src/tools/wait-and-click.ts
+++ b/src/tools/wait-and-click.ts
@@ -12,7 +12,7 @@ import { withDomDelta } from '../utils/dom-delta';
 
 const definition: MCPToolDefinition = {
   name: 'wait_and_click',
-  description: 'Wait for an element matching the query to appear, then click it. Useful for clicking elements that appear after page load or after other interactions.',
+  description: 'Wait for an element to appear, then click it. For dynamic/lazy content.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -22,15 +22,15 @@ const definition: MCPToolDefinition = {
       },
       query: {
         type: 'string',
-        description: 'Natural language description of the element to wait for and click',
+        description: 'Element to wait for and click (natural language)',
       },
       timeout: {
         type: 'number',
-        description: 'Maximum time to wait in milliseconds (default: 5000, max: 30000)',
+        description: 'Max wait in ms. Default: 5000, max: 30000',
       },
       poll_interval: {
         type: 'number',
-        description: 'How often to check for the element in milliseconds (default: 200)',
+        description: 'Poll interval in ms. Default: 200',
       },
     },
     required: ['tabId', 'query'],

--- a/src/tools/wait-for.ts
+++ b/src/tools/wait-for.ts
@@ -9,7 +9,7 @@ import { safeTitle } from '../utils/safe-title';
 
 const definition: MCPToolDefinition = {
   name: 'wait_for',
-  description: 'Wait for a condition to be met before proceeding. Supports waiting for selectors, text, functions, URL changes, URL pattern matching, and network idle.',
+  description: 'Wait for a condition (selector, function, navigation, timeout) before proceeding.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -20,19 +20,19 @@ const definition: MCPToolDefinition = {
       type: {
         type: 'string',
         enum: ['selector', 'selector_hidden', 'function', 'navigation', 'url_match', 'timeout'],
-        description: 'Type of condition to wait for',
+        description: 'Condition type to wait for',
       },
       value: {
         type: 'string',
-        description: 'For "selector"/"selector_hidden": CSS selector. For "function": JavaScript code returning boolean. For "url_match": URL pattern (string or regex). For "timeout": milliseconds as string.',
+        description: 'CSS selector, JS function, URL pattern, or ms as string',
       },
       timeout: {
         type: 'number',
-        description: 'Maximum time to wait in milliseconds. Default: 30000 (30 seconds)',
+        description: 'Max wait in ms. Default: 30000',
       },
       visible: {
         type: 'boolean',
-        description: 'For "selector" type: if true, waits for element to be visible. Default: false',
+        description: 'Wait for visibility (selector type). Default: false',
       },
     },
     required: ['tabId', 'type'],

--- a/src/tools/worker.ts
+++ b/src/tools/worker.ts
@@ -11,26 +11,26 @@ import { getSessionManager } from '../session-manager';
 const definition: MCPToolDefinition = {
   name: 'worker',
   description:
-    'Manage workers within the session. Actions: "create" (new isolated browser context), "list" (show all workers), "delete" (remove worker and close its tabs).',
+    'Manage workers. Actions: "create" (isolated context), "list" (show all), "delete" (remove and close tabs).',
   inputSchema: {
     type: 'object',
     properties: {
       action: {
         type: 'string',
         enum: ['create', 'list', 'delete'],
-        description: 'Action to perform: create, list, or delete a worker',
+        description: 'Action: create, list, or delete',
       },
       name: {
         type: 'string',
-        description: '(create) Optional name for the worker (e.g., "login-worker", "search-worker")',
+        description: '(create) Worker name, e.g. "login-worker"',
       },
       id: {
         type: 'string',
-        description: '(create) Optional custom ID for the worker. Auto-generated if not provided.',
+        description: '(create) Custom ID. Auto-generated if omitted',
       },
       workerId: {
         type: 'string',
-        description: '(delete) The ID of the worker to delete',
+        description: '(delete) Worker ID to delete',
       },
     },
     required: ['action'],


### PR DESCRIPTION
## Summary

Compress every MCP tool `description` and parameter `description` across all 42 tool files in `src/tools/`.

### Guidelines applied

| # | Guideline | Example |
|---|-----------|---------|
| 1 | Lead with verb | "Navigate to URL…" |
| 2 | Don't repeat enum values | removed enum lists from description text |
| 3 | Remove "(optional)"/"(required)" | schema `required` array handles this |
| 4 | Compress boolean phrasing | "Include X" not "Whether to include X" |
| 5 | Standardize defaults | `Default: X` at end |
| 6 | Preserve behavioral directives | e.g. read_page css-before-js routing signal kept |
| 7 | One sentence per tool desc | two max for tools with routing signals |
| 8 | Max 60 chars for param descs | all param descriptions ≤60 chars |

### Behavioral directives preserved

- `read_page`: "Use css mode BEFORE javascript_tool for style inspection."
- `shutdown`: "Auto-relaunched on next tool call."
- `inspect`: "Use instead of read_page + screenshot for targeted questions."
- `execute_plan`: "Falls back gracefully on failure for manual retry."
- `workflow_collect_partial`: "Use to stream results as available."
- `memory_record`: Key convention `"selector:X", "tip:X", "avoid:X"` kept.

### Stats

- **Files changed**: 42
- **Lines removed**: ~266
- **Lines added**: ~198
- **Net reduction**: ~68 lines of description text

## Test plan

- [x] `npm run build` passes (tsc clean)
- [x] `npm test` — 1 pre-existing failure in `hint-engine.test.ts` (unrelated `setup-permission-hint` rule); verified same failure on clean `develop`
- [ ] Spot-check MCP tool listing in Claude Code to confirm descriptions render correctly