### PR TITLE
ci: add develop branch to CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   build-and-test:


### PR DESCRIPTION
## Summary

- Add `develop` branch to CI push and pull_request triggers
- PRs target the `develop` branch (per CLAUDE.md), but CI only triggered on `main`
- This caused regressions (like the read-page DOM fallback bug in v1.6.1) to go undetected until the develop-to-main release merge

## Changes

- `.github/workflows/ci.yml`: Added `develop` to both `push.branches` and `pull_request.branches`

## Test plan

- [ ] Verify CI triggers on next push to develop
- [ ] Verify CI triggers on PRs targeting develop

Refs #146 (Phase 1.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)