### PR TITLE
fix(tools): simplify inputSchema for strict MCP client compatibility

### DIFF
--- a/src/tools/fill-form.ts
+++ b/src/tools/fill-form.ts
@@ -21,13 +21,9 @@ const definition: MCPToolDefinition = {
       },
       fields: {
         type: 'object',
-        description: 'Map of field labels/names/placeholders to values',
+        description: 'Map of field labels/names/placeholders to values (string). For checkboxes use "true"/"false".',
         additionalProperties: {
-          oneOf: [
-            { type: 'string' },
-            { type: 'boolean' },
-            { type: 'number' },
-          ],
+          type: 'string',
         },
       },
       submit: {

--- a/src/tools/form-input.ts
+++ b/src/tools/form-input.ts
@@ -23,9 +23,8 @@ const definition: MCPToolDefinition = {
         description: 'ref_N from read_page or backendNodeId from DOM mode',
       },
       value: {
-        oneOf: [{ type: 'string' }, { type: 'boolean' }, { type: 'number' }],
-        description:
-          'Value to set. Boolean for checkboxes, string for selects',
+        type: 'string',
+        description: 'Value to set. For checkboxes use "true"/"false", for number inputs use the numeric string.',
       },
     },
     required: ['ref', 'value', 'tabId'],

--- a/src/tools/orchestration.ts
+++ b/src/tools/orchestration.ts
@@ -425,6 +425,8 @@ const workerUpdateDefinition: MCPToolDefinition = {
       extractedData: {
         type: 'object',
         description: 'Data extracted so far',
+        properties: {},
+        additionalProperties: true,
       },
       error: {
         type: 'string',
@@ -503,6 +505,8 @@ const workerCompleteDefinition: MCPToolDefinition = {
       extractedData: {
         type: 'object',
         description: 'Final extracted data',
+        properties: {},
+        additionalProperties: true,
       },
     },
     required: ['workerName', 'status', 'resultSummary'],
@@ -665,6 +669,8 @@ const executePlanDefinition: MCPToolDefinition = {
       params: {
         type: 'object',
         description: 'Runtime params merged with plan defaults',
+        properties: {},
+        additionalProperties: true,
       },
     },
     required: ['planId', 'tabId'],


### PR DESCRIPTION
## Summary

- `form-input`: replace `oneOf` with simple `type:'string'` for `value` field
- `fill-form`: replace `additionalProperties.oneOf` with `type:'string'`
- `orchestration`: add `properties:{}` and `additionalProperties:true` to bare object schemas (`extractedData`, `params`)

## Context

Strict MCP clients (Antigravity IDE, Azure AI Foundry, GitHub Copilot) reject tool definitions with advanced JSON Schema constructs like `oneOf`/`anyOf`/`allOf`. The MCP spec only guarantees support for a basic JSON Schema subset. Using simple type definitions ensures cross-client compatibility.

Handler logic is unchanged — all three tools already handle type coercion internally.

## Test plan

- [ ] `npm run build` passes
- [ ] Verify no tool `inputSchema` properties contain `oneOf`/`anyOf`/`allOf`
- [ ] Verify `form_input` still accepts string/boolean/number values at runtime
- [ ] Verify `fill_form` still handles mixed-type field values

Fixes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)