### PR TITLE
feat: add ProgressTracker class for LLM wandering prevention

### DIFF
--- a/src/hints/progress-tracker.ts
+++ b/src/hints/progress-tracker.ts
@@ -20,13 +20,16 @@ const NON_PROGRESS_SIGNALS = [
   'is stale',                        // Stale ref
   'timed out',                       // Timeout
   'No significant visual change',    // Screenshot unchanged
-  'not found',                       // Element not found
+  'element not found',               // Element not found (tightened from 'not found')
   'no longer available',             // Tab gone
   'Login page detected',             // Login redirect (from hint)
   'CAPTCHA',                         // CAPTCHA blocked
   '404',                             // Page not found
   'Access Denied',                   // Access denied
   'Forbidden',                       // 403
+  'net::ERR_',                       // Chromium network errors
+  'Navigation timeout',              // Puppeteer navigation timeout
+  'Protocol error',                  // CDP-level failures
 ];
 
 export class ProgressTracker {
@@ -41,7 +44,7 @@ export class ProgressTracker {
    */
   evaluate(
     recentCalls: ToolCallEvent[],
-    currentToolName: string,
+    _currentToolName: string,
     currentResultText: string,
     currentIsError: boolean,
   ): ProgressStatus {
@@ -62,10 +65,12 @@ export class ProgressTracker {
         const wasProgress = this.isLikelyProgressCall(call);
         if (!wasProgress) {
           consecutiveNonProgress++;
+          // Do NOT reset consecutiveErrors — a non-progress success
+          // is not evidence that the error streak ended
         } else {
+          consecutiveErrors = 0; // Only reset on genuine progress
           break; // Found progress, stop counting
         }
-        consecutiveErrors = 0; // Reset error streak on success
       }
     }
 
@@ -87,16 +92,20 @@ export class ProgressTracker {
    * Used for the CURRENT tool call where we have the full result text.
    */
   isProgressResult(resultText: string): boolean {
-    return !NON_PROGRESS_SIGNALS.some(signal => resultText.includes(signal));
+    if (!resultText || resultText.trim().length === 0) return false;
+    const lower = resultText.toLowerCase();
+    return !NON_PROGRESS_SIGNALS.some(signal => lower.includes(signal.toLowerCase()));
   }
 
   /**
    * Check if a completed tool call was likely progress-producing.
    * Used for PAST calls where we only have ToolCallEvent metadata.
    *
-   * Heuristic: successful calls are progress unless they errored,
-   * had very short duration (likely a non-progress response), or
-   * are known non-progress patterns.
+   * LIMITATION: For past calls with result='success' and no error field,
+   * this method returns true (progress) even if the actual result text
+   * contained non-progress signals. Only the CURRENT call's full result
+   * text is inspected by isProgressResult(). Past call evaluation is
+   * limited to the error field and tool metadata.
    */
   private isLikelyProgressCall(call: ToolCallEvent): boolean {
     // Errors are never progress

--- a/tests/hints/progress-tracker.test.ts
+++ b/tests/hints/progress-tracker.test.ts
@@ -73,17 +73,17 @@ describe('ProgressTracker', () => {
 
     it('returns stalling on 3 non-progress calls (mix of errors and non-progress successes)', () => {
       const recent = [
-        mockCall('computer', 'error', 'not found'),
+        mockCall('computer', 'error', 'element not found'),
         mockCall('find', 'success'), // success but no error field → counts as progress, breaks streak
       ];
       // recent[1] is a successful call → breaks streak, so current + recent[0] = 2 non-progress → progressing
       // To get stalling we need 3 consecutive without a progress break
       const recent2 = [
-        mockCall('computer', 'error', 'not found'),
+        mockCall('computer', 'error', 'element not found'),
         mockCall('navigate', 'error', 'timed out'),
       ];
-      const status = tracker.evaluate(recent2, 'find', '0 results not found', false);
-      // current: isProgressResult('0 results not found') → 'not found' in signals → non-progress
+      const status = tracker.evaluate(recent2, 'find', '0 results element not found', false);
+      // current: isProgressResult('0 results element not found') → 'element not found' in signals → non-progress
       // recent2[0]: error → non-progress
       // recent2[1]: error → non-progress
       // total consecutive non-progress = 3
@@ -97,7 +97,7 @@ describe('ProgressTracker', () => {
       ];
       // current: non-progress success (Login page detected) → nonProgress=1, errors=0
       // recent[0]: error → nonProgress=2, errors=1
-      // recent[1]: success with Login signal → nonProgress=3, errors reset to 0
+      // recent[1]: success with Login signal → nonProgress=3, errors NOT reset (non-progress success)
       // consecutiveErrors=1 (<3), consecutiveNonProgress=3 → stalling
       const status = tracker.evaluate(recent, 'navigate', 'Login page detected', false);
       expect(status).toBe('stalling');
@@ -117,13 +117,13 @@ describe('ProgressTracker', () => {
 
     it('returns stuck on 5+ non-progress calls', () => {
       const recent = [
-        mockCall('computer', 'error', 'not found'),
-        mockCall('computer', 'error', 'not found'),
-        mockCall('computer', 'error', 'not found'),
-        mockCall('computer', 'error', 'not found'),
+        mockCall('computer', 'error', 'element not found'),
+        mockCall('computer', 'error', 'element not found'),
+        mockCall('computer', 'error', 'element not found'),
+        mockCall('computer', 'error', 'element not found'),
       ];
       // current is also non-progress → total 5 consecutiveNonProgress
-      const status = tracker.evaluate(recent, 'computer', 'not found', true);
+      const status = tracker.evaluate(recent, 'computer', 'element not found', true);
       expect(status).toBe('stuck');
     });
 
@@ -149,14 +149,41 @@ describe('ProgressTracker', () => {
       const status = tracker.evaluate(recent, 'navigate', 'Login page detected', false);
       expect(status).toBe('stuck');
     });
+
+    it('returns stuck when errors are separated by non-progress successes', () => {
+      const recent = [
+        mockCall('navigate', 'error', 'timed out'),
+        mockCall('navigate', 'error', 'timed out'),
+      ];
+      // current: non-progress success (Login page detected) → nonProgress=1, errors=0
+      // recent[0]: error → nonProgress=2, errors=1
+      // recent[1]: error → nonProgress=3, errors=2
+      // Then we need errors not reset by non-progress success — verify P0 fix
+      const recentP0 = [
+        mockCall('navigate', 'success', 'Login page detected'),
+        mockCall('navigate', 'error', 'timed out'),
+        mockCall('navigate', 'error', 'timed out'),
+      ];
+      const status = tracker.evaluate(recentP0, 'navigate', 'timed out', true);
+      // current: error → errors=1, nonProgress=1
+      // recentP0[0]: error → errors=2, nonProgress=2
+      // recentP0[1]: error → errors=3, nonProgress=3
+      // recentP0[2]: non-progress success → nonProgress=4, errors NOT reset
+      // consecutiveErrors=3 → stuck
+      expect(status).toBe('stuck');
+    });
   });
 
   describe('isProgressResult()', () => {
+    it('returns false for empty result text', () => {
+      expect(tracker.isProgressResult('')).toBe(false);
+      expect(tracker.isProgressResult('   ')).toBe(false);
+    });
+
     it('returns true for clean result text', () => {
       expect(tracker.isProgressResult('Navigated to https://example.com')).toBe(true);
       expect(tracker.isProgressResult('Clicked the submit button')).toBe(true);
       expect(tracker.isProgressResult('Page content extracted successfully')).toBe(true);
-      expect(tracker.isProgressResult('')).toBe(true);
     });
 
     it('returns false for authRedirect signal', () => {
@@ -179,7 +206,7 @@ describe('ProgressTracker', () => {
       expect(tracker.isProgressResult('No significant visual change detected')).toBe(false);
     });
 
-    it('returns false for not found signal', () => {
+    it('returns false for element not found signal', () => {
       expect(tracker.isProgressResult('element not found in DOM')).toBe(false);
     });
 
@@ -205,6 +232,24 @@ describe('ProgressTracker', () => {
 
     it('returns false for Forbidden signal', () => {
       expect(tracker.isProgressResult('Forbidden resource')).toBe(false);
+    });
+
+    it('returns false for net::ERR_ signal', () => {
+      expect(tracker.isProgressResult('net::ERR_CONNECTION_REFUSED')).toBe(false);
+    });
+
+    it('returns false for Navigation timeout signal', () => {
+      expect(tracker.isProgressResult('Navigation timeout exceeded')).toBe(false);
+    });
+
+    it('returns false for Protocol error signal', () => {
+      expect(tracker.isProgressResult('Protocol error: Target closed')).toBe(false);
+    });
+
+    it('handles case-insensitive matching', () => {
+      expect(tracker.isProgressResult('access denied')).toBe(false);
+      expect(tracker.isProgressResult('ACCESS DENIED')).toBe(false);
+      expect(tracker.isProgressResult('captcha')).toBe(false);
     });
 
     it('checks all NON_PROGRESS_SIGNALS are covered', () => {
@@ -260,7 +305,7 @@ describe('ProgressTracker', () => {
       const recent = [
         mockCall('navigate', 'error', 'timed out'),
         mockCall('read_page', 'success'), // progress → breaks streak
-        mockCall('find', 'error', 'not found'),
+        mockCall('find', 'error', 'element not found'),
       ];
       // current: success, clean → nonProgress = 0
       // recent[0]: error → nonProgress = 1
@@ -276,8 +321,8 @@ describe('ProgressTracker', () => {
         mockCall('navigate', 'error', 'timed out'),             // error
       ];
       // current: non-progress (error) → nonProgress = 1, errors = 1
-      // recent[0]: success with error='Login page detected' → isLikelyProgressCall = false → nonProgress = 2, errors reset to 0
-      // recent[1]: error → errors = 1, nonProgress = 3
+      // recent[0]: success with error='Login page detected' → isLikelyProgressCall = false → nonProgress = 2, errors NOT reset
+      // recent[1]: error → errors = 2, nonProgress = 3
       // nonProgress = 3 → stalling
       const status = tracker.evaluate(recent, 'navigate', 'Access Denied', true);
       expect(status).toBe('stalling');
@@ -291,12 +336,12 @@ describe('ProgressTracker', () => {
         mockCall('navigate', 'error', 'timed out'),
       ];
       // current: non-progress error → errors=1, nonProgress=1
-      // recent[0]: success with Login signal → nonProgress=2, errors reset=0
-      // recent[1]: success with Login signal → nonProgress=3, errors reset=0
-      // recent[2]: success with Login signal → nonProgress=4, errors reset=0
-      // recent[3]: error → errors=1, nonProgress=5
+      // recent[0]: success with Login signal → nonProgress=2, errors NOT reset
+      // recent[1]: success with Login signal → nonProgress=3, errors NOT reset
+      // recent[2]: success with Login signal → nonProgress=4, errors NOT reset
+      // recent[3]: error → errors=2, nonProgress=5
       // nonProgress=5 → stuck
-      const status = tracker.evaluate(recent, 'navigate', 'not found', true);
+      const status = tracker.evaluate(recent, 'navigate', 'element not found', true);
       expect(status).toBe('stuck');
     });
   });
@@ -310,9 +355,12 @@ describe('ProgressTracker', () => {
     it('contains expected key signals', () => {
       expect(NON_PROGRESS_SIGNALS).toContain('authRedirect');
       expect(NON_PROGRESS_SIGNALS).toContain('timed out');
-      expect(NON_PROGRESS_SIGNALS).toContain('not found');
+      expect(NON_PROGRESS_SIGNALS).toContain('element not found');
       expect(NON_PROGRESS_SIGNALS).toContain('CAPTCHA');
       expect(NON_PROGRESS_SIGNALS).toContain('Login page detected');
+      expect(NON_PROGRESS_SIGNALS).toContain('net::ERR_');
+      expect(NON_PROGRESS_SIGNALS).toContain('Navigation timeout');
+      expect(NON_PROGRESS_SIGNALS).toContain('Protocol error');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Introduces `ProgressTracker` class (`src/hints/progress-tracker.ts`) that detects when the LLM agent is not making meaningful progress
- Analyzes consecutive non-progress signals (auth redirects, stale refs, timeouts, CAPTCHA, 404, Access Denied, etc.) across recent tool calls
- Returns `'progressing' | 'stalling' | 'stuck'` status based on configurable thresholds (3+ errors → stuck, 5+ non-progress → stuck, 3+ non-progress → stalling)
- 34 comprehensive tests covering all status transitions, signal detection, recovery, and edge cases

Part 1 of 3 for #165

## Test plan
- [x] 34/34 unit tests pass (`tests/hints/progress-tracker.test.ts`)
- [x] Full test suite passes (pre-existing failures only)
- [x] Build clean (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)