### PR TITLE
feat: improve tool reliability with polling, diagnostics, and scroll fixes

### DIFF
--- a/extension/src/tools/computer.ts
+++ b/extension/src/tools/computer.ts
@@ -368,19 +368,54 @@ export function createComputerTool(sessionManager: SessionManager) {
           }
 
           case 'scroll': {
-            if (!coordinate) {
-              return {
-                content: [{ type: 'text', text: 'Error: coordinate is required for scroll' }],
-                isError: true,
-              };
+            let scrollX: number;
+            let scrollY: number;
+            let usedViewportCenter = false;
+
+            if (coordinate) {
+              [scrollX, scrollY] = coordinate;
+            } else if (ref) {
+              // Resolve ref to coordinates via DOM box model
+              const refEntry = refIdManager.getRef(sessionId, tabId, ref);
+              if (!refEntry) {
+                return {
+                  content: [{ type: 'text', text: `Error: Element reference ${ref} not found. Please call read_page first to get current element references.` }],
+                  isError: true,
+                };
+              }
+              try {
+                await sessionManager.executeCDP(sessionId, tabId, 'DOM.scrollIntoViewIfNeeded', {
+                  backendNodeId: refEntry.backendDOMNodeId,
+                });
+                const boxResult = await sessionManager.executeCDP<{ model: { content: number[] } }>(
+                  sessionId, tabId, 'DOM.getBoxModel', { backendNodeId: refEntry.backendDOMNodeId }
+                );
+                scrollX = Math.round((boxResult.model.content[0] + boxResult.model.content[2]) / 2);
+                scrollY = Math.round((boxResult.model.content[1] + boxResult.model.content[5]) / 2);
+              } catch (e) {
+                return {
+                  content: [{ type: 'text', text: `Error: Could not get position for ${ref}: ${e instanceof Error ? e.message : String(e)}` }],
+                  isError: true,
+                };
+              }
+            } else {
+              // Fall back to viewport center
+              const layoutResult = await sessionManager.executeCDP<{ cssLayoutViewport: { clientWidth: number; clientHeight: number } }>(
+                sessionId, tabId, 'Page.getLayoutMetrics', {}
+              ).catch(() => null);
+              const w = layoutResult?.cssLayoutViewport?.clientWidth ?? 1280;
+              const h = layoutResult?.cssLayoutViewport?.clientHeight ?? 800;
+              scrollX = Math.floor(w / 2);
+              scrollY = Math.floor(h / 2);
+              usedViewportCenter = true;
             }
 
-            const [x, y] = coordinate;
+            const direction = scroll_direction || 'down';
             const amount = scroll_amount || 3;
             let deltaX = 0;
             let deltaY = 0;
 
-            switch (scroll_direction) {
+            switch (direction) {
               case 'up':
                 deltaY = -100 * amount;
                 break;
@@ -397,17 +432,18 @@ export function createComputerTool(sessionManager: SessionManager) {
 
             await sessionManager.executeCDP(sessionId, tabId, 'Input.dispatchMouseEvent', {
               type: 'mouseWheel',
-              x,
-              y,
+              x: scrollX,
+              y: scrollY,
               deltaX,
               deltaY,
             });
 
+            const centerNote = usedViewportCenter ? ' [viewport center]' : '';
             return {
               content: [
                 {
                   type: 'text',
-                  text: `Scrolled ${scroll_direction} at (${x}, ${y})`,
+                  text: `Scrolled ${direction} at (${scrollX}, ${scrollY})${centerNote}`,
                 },
               ],
             };

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -104,7 +104,7 @@ export const DEFAULT_CONNECT_VERIFY_STALENESS_MS = 10000;
 /** Screenshot race timeout in milliseconds.
  *  Used in computer/interact/click-element/batch-paginate as a safety net
  *  when racing screenshot capture against a timeout. */
-export const DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS = 10000;
+export const DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS = 7000;
 
 /** Post-action DOM settle delay in milliseconds.
  *  Brief pause after clicks/interactions to let the DOM update before reading state. */
@@ -113,3 +113,9 @@ export const DEFAULT_DOM_SETTLE_DELAY_MS = 50;
 /** Form submit settle delay in milliseconds.
  *  Longer pause after form submission to allow for potential navigation or re-render. */
 export const DEFAULT_FORM_SUBMIT_SETTLE_MS = 100;
+
+/** fill_form: Max time to poll for form fields on SPA pages (ms). */
+export const DEFAULT_FILL_FORM_POLL_MS = 1500;
+
+/** fill_form: Interval between polls when waiting for form fields (ms). */
+export const DEFAULT_FILL_FORM_POLL_INTERVAL_MS = 300;

--- a/src/hints/progress-tracker.ts
+++ b/src/hints/progress-tracker.ts
@@ -30,6 +30,9 @@ const NON_PROGRESS_SIGNALS = [
   'net::ERR_',                       // Chromium network errors
   'Navigation timeout',              // Puppeteer navigation timeout
   'Protocol error',                  // CDP-level failures
+  'bot-check',                       // Bot verification page detected
+  'captcha detected',                // CAPTCHA page detected
+  'Blocking page detected',          // Any blocking page warning from navigate
 ];
 
 export class ProgressTracker {

--- a/src/hints/rules/error-recovery.ts
+++ b/src/hints/rules/error-recovery.ts
@@ -15,7 +15,7 @@ const patterns: Array<{ test: RegExp; hint: string }> = [
     hint: 'Hint: Use tabs_context to list valid tabIds.',
   },
   {
-    test: /selector[^a-z]*(failed|not found|no match)|querySelectorAll.*returned 0|no elements? match/i,
+    test: /selector[^a-z]*(failed|not found|no match)|querySelectorAll.*returned 0|no elements? (found )?match/i,
     hint: 'Hint: Try find(query) with natural language instead.',
   },
   {

--- a/src/tools/click-element.ts
+++ b/src/tools/click-element.ts
@@ -40,6 +40,14 @@ const definition: MCPToolDefinition = {
         type: 'boolean',
         description: 'Perform double-click instead of single',
       },
+      waitForMs: {
+        type: 'number',
+        description: 'Max time to wait for element to appear. 0 = no waiting (default). Max 30000.',
+      },
+      pollInterval: {
+        type: 'number',
+        description: 'How often to retry while waiting, in ms. Default 200, range 50-2000.',
+      },
     },
     required: ['tabId', 'query'],
   },
@@ -54,6 +62,8 @@ const handler: ToolHandler = async (
   const waitAfter = Math.min(Math.max((args.wait_after as number) || 100, 0), 5000);
   const verify = args.verify as boolean | undefined;
   const doubleClick = args.double_click as boolean | undefined;
+  const waitForMs = args.waitForMs as number | undefined;
+  const pollInterval = Math.min(Math.max((args.pollInterval as number) || 200, 50), 2000);
 
   const sessionManager = getSessionManager();
   const refIdManager = getRefIdManager();
@@ -84,6 +94,13 @@ const handler: ToolHandler = async (
     const queryLower = query.toLowerCase();
     const queryTokens = tokenizeQuery(query);
 
+    // Optional polling for dynamic/lazy content
+    const maxWait = waitForMs ? Math.min(Math.max(waitForMs, 100), 30000) : 0;
+    let bestMatch: FoundElement | null = null;
+    const startTime = Date.now();
+    const cdpClient = sessionManager.getCDPClient();
+
+    do { // --- polling loop start ---
     // Find elements matching the query
     const results = await page.evaluate((searchQuery: string): Omit<FoundElement, 'score'>[] => {
       const elements: Omit<FoundElement, 'score'>[] = [];
@@ -219,11 +236,16 @@ const handler: ToolHandler = async (
     }, queryLower);
 
     if (results.length === 0) {
+      if (maxWait > 0 && Date.now() - startTime < maxWait) {
+        await new Promise(resolve => setTimeout(resolve, pollInterval));
+        continue;
+      }
+      const pageUrl = page.url();
       return {
         content: [
           {
             type: 'text',
-            text: `No clickable elements found matching "${query}"`,
+            text: `No clickable elements found matching "${query}" on ${pageUrl}`,
           },
         ],
         isError: true,
@@ -232,7 +254,6 @@ const handler: ToolHandler = async (
 
     // Get backend DOM node IDs — batched approach (single DOM walk + parallel DOM.describeNode)
     // Replaces per-candidate querySelectorAll('*').find() which is O(n) × candidates = O(30n)
-    const cdpClient = sessionManager.getCDPClient();
 
     // Step 1: Single Runtime.evaluate to collect all tagged elements in index order
     const { result: batchResult } = await cdpClient.send<{
@@ -290,8 +311,21 @@ const handler: ToolHandler = async (
       .map(el => ({ ...el, score: scoreElement(el as FoundElement, queryLower, queryTokens) }))
       .sort((a, b) => b.score - a.score);
 
-    // Get the best match
-    const bestMatch = scoredResults[0];
+    if (scoredResults.length > 0 && scoredResults[0].score >= 10) {
+      bestMatch = scoredResults[0];
+      break;
+    }
+
+    if (maxWait > 0 && Date.now() - startTime < maxWait) {
+      await new Promise(resolve => setTimeout(resolve, pollInterval));
+    } else {
+      // No polling or timeout reached — use best available even if low score
+      if (scoredResults.length > 0) {
+        bestMatch = scoredResults[0];
+      }
+      break;
+    }
+    } while (Date.now() - startTime < maxWait); // --- polling loop end ---
 
     if (!bestMatch || bestMatch.score < 10) {
       return {

--- a/src/tools/computer.ts
+++ b/src/tools/computer.ts
@@ -107,7 +107,7 @@ const handler: ToolHandler = async (
         try {
           const readyState = await page.evaluate(() => document.readyState);
           if (readyState !== 'complete') {
-            await page.waitForFunction(() => document.readyState === 'complete', { timeout: 5000 }).catch(() => {});
+            await page.waitForFunction(() => document.readyState === 'complete', { timeout: 3000 }).catch(() => {});
           }
         } catch {
           // Page may be navigating — proceed anyway
@@ -159,9 +159,9 @@ const handler: ToolHandler = async (
         // First attempt
         let screenshot = await attemptScreenshot();
 
-        // Retry once after 2s if failed
+        // Retry once after 500ms if failed
         if (!screenshot) {
-          await new Promise(r => setTimeout(r, 2000));
+          await new Promise(r => setTimeout(r, 500));
           screenshot = await attemptScreenshot();
         }
 
@@ -514,36 +514,45 @@ const handler: ToolHandler = async (
       }
 
       case 'scroll': {
-        if (!coordinate) {
-          return {
-            content: [{ type: 'text', text: 'Error: coordinate is required for scroll' }],
-            isError: true,
-          };
-        }
-        if (!scrollDirection) {
-          return {
-            content: [
-              { type: 'text', text: 'Error: scroll_direction is required for scroll' },
-            ],
-            isError: true,
-          };
+        let scrollCoord: [number, number] | undefined = coordinate;
+
+        if (ref && !coordinate) {
+          const resolved = await resolveRefToCoordinates(sessionId, tabId, ref, page, sessionManager);
+          if (resolved.error) return resolved.error;
+          scrollCoord = resolved.coord;
         }
 
-        const scrollValidation = await validateCoordinates(page, coordinate[0], coordinate[1]);
-        if (!scrollValidation.valid) {
-          return {
-            content: [{ type: 'text', text: `Error: ${scrollValidation.warning}` }],
-            isError: true,
-          };
+        let usedViewportCenter = false;
+        if (!scrollCoord) {
+          // Fall back to viewport center
+          const viewport = page.viewport();
+          scrollCoord = [
+            Math.floor((viewport?.width ?? 1280) / 2),
+            Math.floor((viewport?.height ?? 800) / 2),
+          ];
+          usedViewportCenter = true;
         }
 
-        await page.mouse.move(coordinate[0], coordinate[1]);
+        const direction = scrollDirection || 'down';
+
+        // Skip validation for viewport center fallback — it's always within bounds
+        if (!usedViewportCenter) {
+          const scrollValidation = await validateCoordinates(page, scrollCoord[0], scrollCoord[1]);
+          if (!scrollValidation.valid) {
+            return {
+              content: [{ type: 'text', text: `Error: ${scrollValidation.warning}` }],
+              isError: true,
+            };
+          }
+        }
+
+        await page.mouse.move(scrollCoord[0], scrollCoord[1]);
 
         const deltaMultiplier = 100;
         let deltaX = 0;
         let deltaY = 0;
 
-        switch (scrollDirection) {
+        switch (direction) {
           case 'up':
             deltaY = -scrollAmount * deltaMultiplier;
             break;
@@ -560,11 +569,12 @@ const handler: ToolHandler = async (
 
         await page.mouse.wheel({ deltaX, deltaY });
 
+        const centerNote = usedViewportCenter ? ' [viewport center]' : '';
         return {
           content: [
             {
               type: 'text',
-              text: `Scrolled ${scrollDirection} at (${coordinate[0]}, ${coordinate[1]})`,
+              text: `Scrolled ${direction} at (${scrollCoord[0]}, ${scrollCoord[1]})${centerNote}`,
             },
           ],
         };

--- a/src/tools/fill-form.ts
+++ b/src/tools/fill-form.ts
@@ -35,6 +35,14 @@ const definition: MCPToolDefinition = {
         type: 'boolean',
         description: 'Clear fields before filling. Default: true',
       },
+      waitForMs: {
+        type: 'number',
+        description: 'Max time to wait for form fields to appear (useful for SPAs). Default: 0 (no polling). Set to 1500 for SPA support.',
+      },
+      pollInterval: {
+        type: 'number',
+        description: 'Interval between polls in ms when waiting for fields (50-2000). Default: 300',
+      },
     },
     required: ['tabId', 'fields'],
   },
@@ -60,6 +68,8 @@ const handler: ToolHandler = async (
   const fields = args.fields as Record<string, string | boolean | number>;
   const submit = args.submit as string | undefined;
   const clearFirst = args.clear_first !== false; // Default to true
+  const waitForMs = args.waitForMs as number | undefined;
+  const pollInterval = Math.min(Math.max((args.pollInterval as number) || 300, 50), 2000);
 
   const sessionManager = getSessionManager();
 
@@ -86,82 +96,94 @@ const handler: ToolHandler = async (
       };
     }
 
-    // Get all form fields on the page
-    const formFields = await page.evaluate((): FormField[] => {
-      const fields: FormField[] = [];
+    // Get all form fields on the page, with optional polling for SPAs
+    const maxWait = waitForMs ? Math.min(Math.max(waitForMs, 100), 30000) : 0;
+    const startTime = Date.now();
 
-      // Helper to get associated label
-      function getLabel(el: Element): string | undefined {
-        const inputEl = el as HTMLInputElement;
-        // Check for explicit label
-        if (inputEl.id) {
-          const label = document.querySelector(`label[for="${inputEl.id}"]`);
-          if (label) return label.textContent?.trim();
-        }
-        // Check for wrapping label
-        const parent = el.closest('label');
-        if (parent) {
-          const labelText = parent.textContent?.trim() || '';
-          const inputText = el.textContent?.trim() || '';
-          return labelText.replace(inputText, '').trim();
-        }
-        // Check for preceding label sibling
-        const prev = el.previousElementSibling;
-        if (prev?.tagName === 'LABEL') {
-          return prev.textContent?.trim();
-        }
-        return undefined;
-      }
+    let formFields: FormField[] = [];
+    do {
+      formFields = await page.evaluate((): FormField[] => {
+        const fields: FormField[] = [];
 
-      // Find all input-like elements
-      const selectors = [
-        'input:not([type="hidden"]):not([type="submit"]):not([type="button"]):not([type="image"])',
-        'textarea',
-        'select',
-        '[contenteditable="true"]',
-        '[role="textbox"]',
-        '[role="combobox"]',
-      ];
-
-      let index = 0;
-      for (const selector of selectors) {
-        try {
-          for (const el of document.querySelectorAll(selector)) {
-            const rect = el.getBoundingClientRect();
-            if (rect.width === 0 || rect.height === 0) continue;
-
-            const style = window.getComputedStyle(el);
-            if (style.visibility === 'hidden' || style.display === 'none' || style.opacity === '0') continue;
-
-            const inputEl = el as HTMLInputElement;
-
-            fields.push({
-              backendDOMNodeId: 0,
-              fieldName: getLabel(el) || inputEl.name || inputEl.placeholder || inputEl.getAttribute('aria-label') || `field_${index}`,
-              tagName: el.tagName.toLowerCase(),
-              type: inputEl.type,
-              name: inputEl.name,
-              placeholder: inputEl.placeholder,
-              ariaLabel: el.getAttribute('aria-label') || undefined,
-              label: getLabel(el),
-              rect: {
-                x: rect.x + rect.width / 2,
-                y: rect.y + rect.height / 2,
-                width: rect.width,
-                height: rect.height,
-              },
-            });
-
-            // Tag element for later reference
-            (el as unknown as { __formFieldIndex: number }).__formFieldIndex = index++;
+        // Helper to get associated label
+        function getLabel(el: Element): string | undefined {
+          const inputEl = el as HTMLInputElement;
+          // Check for explicit label
+          if (inputEl.id) {
+            const label = document.querySelector(`label[for="${inputEl.id}"]`);
+            if (label) return label.textContent?.trim();
           }
-        } catch {
-          // Invalid selector
+          // Check for wrapping label
+          const parent = el.closest('label');
+          if (parent) {
+            const labelText = parent.textContent?.trim() || '';
+            const inputText = el.textContent?.trim() || '';
+            return labelText.replace(inputText, '').trim();
+          }
+          // Check for preceding label sibling
+          const prev = el.previousElementSibling;
+          if (prev?.tagName === 'LABEL') {
+            return prev.textContent?.trim();
+          }
+          return undefined;
         }
-      }
 
-      return fields;
-    });
+        // Find all input-like elements
+        const selectors = [
+          'input:not([type="hidden"]):not([type="submit"]):not([type="button"]):not([type="image"])',
+          'textarea',
+          'select',
+          '[contenteditable="true"]',
+          '[role="textbox"]',
+          '[role="combobox"]',
+        ];
+
+        let index = 0;
+        for (const selector of selectors) {
+          try {
+            for (const el of document.querySelectorAll(selector)) {
+              const rect = el.getBoundingClientRect();
+              if (rect.width === 0 || rect.height === 0) continue;
+
+              const style = window.getComputedStyle(el);
+              if (style.visibility === 'hidden' || style.display === 'none' || style.opacity === '0') continue;
+
+              const inputEl = el as HTMLInputElement;
+
+              fields.push({
+                backendDOMNodeId: 0,
+                fieldName: getLabel(el) || inputEl.name || inputEl.placeholder || inputEl.getAttribute('aria-label') || `field_${index}`,
+                tagName: el.tagName.toLowerCase(),
+                type: inputEl.type,
+                name: inputEl.name,
+                placeholder: inputEl.placeholder,
+                ariaLabel: el.getAttribute('aria-label') || undefined,
+                label: getLabel(el),
+                rect: {
+                  x: rect.x + rect.width / 2,
+                  y: rect.y + rect.height / 2,
+                  width: rect.width,
+                  height: rect.height,
+                },
+              });
+
+              // Tag element for later reference
+              (el as unknown as { __formFieldIndex: number }).__formFieldIndex = index++;
+            }
+          } catch {
+            // Invalid selector
+          }
+        }
+
+        return fields;
+      });
+
+      if (formFields.length === 0 && maxWait > 0 && Date.now() - startTime < maxWait) {
+        await new Promise(resolve => setTimeout(resolve, pollInterval));
+        continue;
+      }
+      break;
+    } while (Date.now() - startTime < maxWait);
 
     const filledFields: string[] = [];
     const errors: string[] = [];
@@ -230,7 +252,8 @@ const handler: ToolHandler = async (
         }
 
         if (!bestMatch || bestScore < 20) {
-          errors.push(`Could not find field matching "${fieldKey}"`);
+          const foundFieldNames = formFields.map(f => f.label || f.name || f.placeholder || f.ariaLabel).filter(Boolean) as string[];
+          errors.push(`Could not find field matching "${fieldKey}". Available fields: [${foundFieldNames.join(', ')}]`);
           continue;
         }
 

--- a/src/tools/find.ts
+++ b/src/tools/find.ts
@@ -21,6 +21,14 @@ const definition: MCPToolDefinition = {
         type: 'string',
         description: 'What to find, e.g. "search bar", "login button"',
       },
+      waitForMs: {
+        type: 'number',
+        description: 'Max time to wait for element to appear. 0 = no waiting (default). Max 30000.',
+      },
+      pollInterval: {
+        type: 'number',
+        description: 'How often to retry while waiting, in ms. Default 200, range 50-2000.',
+      },
     },
     required: ['query', 'tabId'],
   },
@@ -32,6 +40,8 @@ const handler: ToolHandler = async (
 ): Promise<MCPResult> => {
   const tabId = args.tabId as string;
   const query = args.query as string;
+  const waitForMs = args.waitForMs as number | undefined;
+  const pollInterval = Math.min(Math.max((args.pollInterval as number) || 200, 50), 2000);
 
   const sessionManager = getSessionManager();
   const refIdManager = getRefIdManager();
@@ -75,6 +85,12 @@ const handler: ToolHandler = async (
       score: number;
     }
 
+    // Optional polling for dynamic/lazy content
+    const maxWait = waitForMs ? Math.min(Math.max(waitForMs, 100), 30000) : 0;
+    const startTime = Date.now();
+    let output: string[] = [];
+
+    do { // --- polling loop start ---
     const results = await page.evaluate((searchQuery: string): FoundElement[] => {
       const elements: FoundElement[] = [];
       const domElements: Element[] = []; // Parallel array of DOM references for re-indexing
@@ -351,7 +367,7 @@ const handler: ToolHandler = async (
     }
 
     // Generate refs for found elements (already sorted by score)
-    const output: string[] = [];
+    output = [];
     for (const el of results) {
       if (el.backendDOMNodeId) {
         const refId = refIdManager.generateRef(
@@ -372,12 +388,33 @@ const handler: ToolHandler = async (
       }
     }
 
+    if (output.length > 0) {
+      break;
+    }
+
+    if (maxWait > 0 && Date.now() - startTime < maxWait) {
+      await new Promise(resolve => setTimeout(resolve, pollInterval));
+    } else {
+      break;
+    }
+    } while (Date.now() - startTime < maxWait); // --- polling loop end ---
+
     if (output.length === 0) {
+      let url = 'unknown', readyState = 'unknown', totalElements = 0;
+      try {
+        ({ url, readyState, totalElements } = await page.evaluate(() => ({
+          url: document.location.href,
+          readyState: document.readyState,
+          totalElements: document.querySelectorAll('*').length,
+        })));
+      } catch {
+        // Page may have navigated — use defaults
+      }
       return {
         content: [
           {
             type: 'text',
-            text: `No elements found matching "${query}"`,
+            text: `No elements found matching "${query}". Page: ${url} (${readyState}), ${totalElements} elements.`,
           },
         ],
         isError: true,

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -11,6 +11,7 @@ import { DEFAULT_NAVIGATION_TIMEOUT_MS } from '../config/defaults';
 import { generateVisualSummary } from '../utils/visual-summary';
 import { AdaptiveScreenshot } from '../utils/adaptive-screenshot';
 import { assertDomainAllowed } from '../security/domain-guard';
+import { detectBlockingPage } from '../utils/page-diagnostics';
 
 const definition: MCPToolDefinition = {
   name: 'navigate',
@@ -39,7 +40,7 @@ const handler: ToolHandler = async (
   sessionId: string,
   args: Record<string, unknown>
 ): Promise<MCPResult> => {
-  let tabId = args.tabId as string | undefined;
+  const tabId = args.tabId as string | undefined;
   const url = args.url as string;
   const workerId = args.workerId as string | undefined;
   const sessionManager = getSessionManager();
@@ -127,22 +128,22 @@ const handler: ToolHandler = async (
               };
             }
             AdaptiveScreenshot.getInstance().reset(existingTabId);
-            const summary = await generateVisualSummary(page);
+            const [summary, reuseBlocking] = await Promise.all([
+              generateVisualSummary(page),
+              detectBlockingPage(page).catch(e => { console.error('[navigate] detectBlockingPage error (tab-reuse):', e); return null; }),
+            ]);
+            const reuseResultText = JSON.stringify({
+              action: 'navigate',
+              url: page.url(),
+              title: await safeTitle(page),
+              tabId: existingTabId,
+              workerId: resolvedWorkerId,
+              reused: true,
+              ...(summary && { visualSummary: summary }),
+              ...(reuseBlocking && { blockingPage: reuseBlocking }),
+            });
             return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify({
-                    action: 'navigate',
-                    url: page.url(),
-                    title: await safeTitle(page),
-                    tabId: existingTabId,
-                    workerId: resolvedWorkerId,
-                    reused: true,
-                    ...(summary && { visualSummary: summary }),
-                  }),
-                },
-              ],
+              content: [{ type: 'text', text: reuseResultText }],
             };
           }
         }
@@ -152,22 +153,22 @@ const handler: ToolHandler = async (
       const { targetId, page, workerId: assignedWorkerId } = await sessionManager.createTarget(sessionId, targetUrl, workerId);
 
       AdaptiveScreenshot.getInstance().reset(targetId);
-      const summary = await generateVisualSummary(page);
+      const [newTabSummary, newTabBlocking] = await Promise.all([
+        generateVisualSummary(page),
+        detectBlockingPage(page).catch(e => { console.error('[navigate] detectBlockingPage error (new-tab):', e); return null; }),
+      ]);
+      const newTabResultText = JSON.stringify({
+        action: 'navigate',
+        url: page.url(),
+        title: await safeTitle(page),
+        tabId: targetId,
+        workerId: assignedWorkerId,
+        created: true,
+        ...(newTabSummary && { visualSummary: newTabSummary }),
+        ...(newTabBlocking && { blockingPage: newTabBlocking }),
+      });
       return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify({
-              action: 'navigate',
-              url: page.url(),
-              title: await safeTitle(page),
-              tabId: targetId,
-              workerId: assignedWorkerId,
-              created: true,
-              ...(summary && { visualSummary: summary }),
-            }),
-          },
-        ],
+        content: [{ type: 'text', text: newTabResultText }],
       };
     } catch (error) {
       return {
@@ -211,38 +212,38 @@ const handler: ToolHandler = async (
     if (url === 'back') {
       await page.goBack({ waitUntil: 'domcontentloaded', timeout: DEFAULT_NAVIGATION_TIMEOUT_MS });
       AdaptiveScreenshot.getInstance().reset(tabId);
-      const backSummary = await generateVisualSummary(page);
+      const [backSummary, backBlocking] = await Promise.all([
+        generateVisualSummary(page),
+        detectBlockingPage(page).catch(e => { console.error('[navigate] detectBlockingPage error (back):', e); return null; }),
+      ]);
+      const backResultText = JSON.stringify({
+        action: 'back',
+        url: page.url(),
+        title: await safeTitle(page),
+        ...(backSummary && { visualSummary: backSummary }),
+        ...(backBlocking && { blockingPage: backBlocking }),
+      });
       return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify({
-              action: 'back',
-              url: page.url(),
-              title: await safeTitle(page),
-              ...(backSummary && { visualSummary: backSummary }),
-            }),
-          },
-        ],
+        content: [{ type: 'text', text: backResultText }],
       };
     }
 
     if (url === 'forward') {
       await page.goForward({ waitUntil: 'domcontentloaded', timeout: DEFAULT_NAVIGATION_TIMEOUT_MS });
       AdaptiveScreenshot.getInstance().reset(tabId);
-      const fwdSummary = await generateVisualSummary(page);
+      const [fwdSummary, fwdBlocking] = await Promise.all([
+        generateVisualSummary(page),
+        detectBlockingPage(page).catch(e => { console.error('[navigate] detectBlockingPage error (forward):', e); return null; }),
+      ]);
+      const fwdResultText = JSON.stringify({
+        action: 'forward',
+        url: page.url(),
+        title: await safeTitle(page),
+        ...(fwdSummary && { visualSummary: fwdSummary }),
+        ...(fwdBlocking && { blockingPage: fwdBlocking }),
+      });
       return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify({
-              action: 'forward',
-              url: page.url(),
-              title: await safeTitle(page),
-              ...(fwdSummary && { visualSummary: fwdSummary }),
-            }),
-          },
-        ],
+        content: [{ type: 'text', text: fwdResultText }],
       };
     }
 
@@ -322,19 +323,19 @@ const handler: ToolHandler = async (
     }
 
     AdaptiveScreenshot.getInstance().reset(tabId);
-    const navSummary = await generateVisualSummary(page);
+    const [navSummary, navBlocking] = await Promise.all([
+      generateVisualSummary(page),
+      detectBlockingPage(page).catch(e => { console.error('[navigate] detectBlockingPage error (existing-tab):', e); return null; }),
+    ]);
+    const navResultText = JSON.stringify({
+      action: 'navigate',
+      url: page.url(),
+      title: await safeTitle(page),
+      ...(navSummary && { visualSummary: navSummary }),
+      ...(navBlocking && { blockingPage: navBlocking }),
+    });
     return {
-      content: [
-        {
-          type: 'text',
-          text: JSON.stringify({
-            action: 'navigate',
-            url: page.url(),
-            title: await safeTitle(page),
-            ...(navSummary && { visualSummary: navSummary }),
-          }),
-        },
-      ],
+      content: [{ type: 'text', text: navResultText }],
     };
   } catch (error) {
     return {

--- a/src/tools/query-dom.ts
+++ b/src/tools/query-dom.ts
@@ -75,6 +75,82 @@ const definition: MCPToolDefinition = {
 };
 
 // ---------------------------------------------------------------------------
+// Diagnostics helper (reuses getPageDiagnostics from page-diagnostics.ts)
+// ---------------------------------------------------------------------------
+
+interface QueryDomDiagnostics {
+  url: string;
+  readyState: string;
+  totalElements: number;
+  framework: string | null;
+  closestMatch: string | null;
+}
+
+async function gatherDiagnostics(
+  page: import('puppeteer-core').Page,
+  selector: string
+): Promise<QueryDomDiagnostics | null> {
+  try {
+    // Single atomic evaluate to avoid race conditions if page navigates between calls
+    return await page.evaluate((sel: string) => {
+      const total = document.querySelectorAll('*').length;
+
+      let framework: string | null = null;
+      if (document.querySelector('[data-reactroot], #__next, #root[data-reactroot]')) framework = 'react';
+      else if (document.querySelector('[data-v-], #app[data-v-]')) framework = 'vue';
+      else if (document.querySelector('[ng-version], [_nghost]')) framework = 'angular';
+
+      // CSS-specific: find closest partial match for compound selectors
+      let closestMatch: string | null = null;
+      const parts = sel.split(' ');
+      if (parts.length > 1) {
+        for (let i = parts.length - 1; i >= 0; i--) {
+          const partial = parts.slice(0, i).join(' ');
+          if (partial) {
+            try {
+              const count = document.querySelectorAll(partial).length;
+              if (count > 0) {
+                closestMatch = `"${partial}" (${count} matches)`;
+                break;
+              }
+            } catch {
+              // ignore invalid partial selectors
+            }
+          }
+        }
+      }
+
+      return {
+        url: location.href,
+        readyState: document.readyState,
+        totalElements: total,
+        framework,
+        closestMatch,
+      };
+    }, selector);
+  } catch (err) {
+    console.error('[query_dom] diagnostics failed:', err);
+    return null;
+  }
+}
+
+function formatDiagnosticsMessage(selector: string, diag: QueryDomDiagnostics | null, plural: boolean): string {
+  const base = plural
+    ? `No elements found matching "${selector}"`
+    : `No element found matching "${selector}"`;
+  if (!diag) return base;
+
+  const hostname = (() => {
+    try { return new URL(diag.url).hostname; } catch { return diag.url; }
+  })();
+  const frameworkPart = diag.framework ? `, ${diag.framework}` : '';
+  const statePart = `${hostname} (${diag.readyState}${frameworkPart}), ${diag.totalElements} elements`;
+  const closestPart = diag.closestMatch ? `. Closest: ${diag.closestMatch}` : '';
+
+  return `${base}. Page: ${statePart}${closestPart}`;
+}
+
+// ---------------------------------------------------------------------------
 // CSS handler
 // ---------------------------------------------------------------------------
 
@@ -106,6 +182,7 @@ async function handleCSS(
     const elements = await page.$$(selector);
 
     if (elements.length === 0) {
+      const diag = await gatherDiagnostics(page, selector);
       return {
         content: [
           {
@@ -117,7 +194,8 @@ async function handleCSS(
               multiple: true,
               elements: [],
               count: 0,
-              message: `No elements found matching "${selector}"`,
+              message: formatDiagnosticsMessage(selector, diag, true),
+              ...(diag && { diagnostics: diag }),
             }),
           },
         ],
@@ -191,6 +269,7 @@ async function handleCSS(
     const element = await page.$(selector);
 
     if (!element) {
+      const diag = await gatherDiagnostics(page, selector);
       return {
         content: [
           {
@@ -201,7 +280,8 @@ async function handleCSS(
               selector,
               multiple: false,
               element: null,
-              message: `No element found matching "${selector}"`,
+              message: formatDiagnosticsMessage(selector, diag, false),
+              ...(diag && { diagnostics: diag }),
             }),
           },
         ],
@@ -435,7 +515,7 @@ async function handleXPath(
               xpath,
               multiple: false,
               result: null,
-              message: 'No element found matching XPath',
+              message: `No element found matching XPath: ${xpath}`,
             }),
           },
         ],

--- a/src/utils/page-diagnostics.ts
+++ b/src/utils/page-diagnostics.ts
@@ -1,0 +1,96 @@
+import type { Page } from 'puppeteer-core';
+
+export interface PageDiagnostics {
+  url: string;
+  readyState: string;
+  totalElements: number;
+  framework: string | null;
+  title: string;
+}
+
+export interface BlockingInfo {
+  type: 'captcha' | 'bot-check' | 'access-denied' | 'js-required';
+  detail: string;
+}
+
+/**
+ * Get basic page diagnostics for failure reporting.
+ * Lightweight - single evaluate call.
+ */
+export async function getPageDiagnostics(page: Page): Promise<PageDiagnostics> {
+  try {
+    return await page.evaluate(() => {
+      let framework: string | null = null;
+      if (document.querySelector('[data-reactroot], #__next, #root[data-reactroot]')) framework = 'react';
+      else if (document.querySelector('[data-v-], #app[data-v-]')) framework = 'vue';
+      else if (document.querySelector('[ng-version], [_nghost]')) framework = 'angular';
+
+      return {
+        url: location.href,
+        readyState: document.readyState,
+        totalElements: document.querySelectorAll('*').length,
+        framework,
+        title: document.title.substring(0, 100),
+      };
+    });
+  } catch {
+    return {
+      url: 'unknown',
+      readyState: 'unknown',
+      totalElements: 0,
+      framework: null,
+      title: 'unknown',
+    };
+  }
+}
+
+/**
+ * Detect if the page is showing a blocking verification/captcha/access-denied page.
+ * Returns null if page appears normal.
+ */
+export async function detectBlockingPage(page: Page): Promise<BlockingInfo | null> {
+  try {
+    return await page.evaluate(() => {
+      const title = document.title.toLowerCase();
+      const bodyText = document.body?.innerText?.substring(0, 1000).toLowerCase() || '';
+
+      // CAPTCHA detection (includes Cloudflare Turnstile)
+      if (bodyText.includes('captcha') ||
+          bodyText.includes('recaptcha') ||
+          document.querySelector('iframe[src*="captcha"], iframe[src*="recaptcha"], iframe[src*="challenges.cloudflare.com"], .g-recaptcha, .h-captcha, .cf-turnstile')) {
+        return { type: 'captcha' as const, detail: document.title };
+      }
+
+      // Bot verification
+      if (bodyText.includes('verify you are human') ||
+          bodyText.includes('are you a robot') ||
+          bodyText.includes('bot protection') ||
+          bodyText.includes('automated access') ||
+          bodyText.includes('please verify') ||
+          title.includes('robot check') ||
+          title.includes('security check') ||
+          title.includes('just a moment')) {  // Cloudflare
+        return { type: 'bot-check' as const, detail: document.title };
+      }
+
+      // Access denied
+      if (title.includes('access denied') ||
+          title.includes('403 forbidden') ||
+          title.includes('forbidden') ||
+          (bodyText.includes('access denied') && bodyText.length < 500)) {
+        return { type: 'access-denied' as const, detail: document.title };
+      }
+
+      // JS required
+      if (bodyText.includes('please enable javascript') ||
+          bodyText.includes('javascript is required') ||
+          bodyText.includes('this site requires javascript')) {
+        return { type: 'js-required' as const, detail: 'Page requires JavaScript' };
+      }
+
+      return null;
+    });
+  } catch {
+    return null;
+  }
+}

--- a/tests/tools/computer.test.ts
+++ b/tests/tools/computer.test.ts
@@ -484,7 +484,7 @@ describe('ComputerTool', () => {
       });
     });
 
-    test('rejects scroll without coordinates', async () => {
+    test('scroll without coordinates falls back to viewport center', async () => {
       const handler = await getComputerHandler();
 
       const result = await handler(testSessionId, {
@@ -493,11 +493,11 @@ describe('ComputerTool', () => {
         scroll_direction: 'down',
       }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
 
-      expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('coordinate is required');
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Scrolled down');
     });
 
-    test('rejects scroll without direction', async () => {
+    test('scroll without direction defaults to down', async () => {
       const handler = await getComputerHandler();
 
       const result = await handler(testSessionId, {
@@ -506,8 +506,8 @@ describe('ComputerTool', () => {
         coordinate: [500, 500],
       }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
 
-      expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('scroll_direction is required');
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Scrolled down');
     });
   });
 


### PR DESCRIPTION
## Summary

- Add ref-based coordinate resolution and viewport center fallback for `scroll` action, fixing "coordinate is required for scroll" bug
- Add SPA hydration polling (`waitForMs`/`pollInterval`) to `fill_form`, `click_element`, `find` tools
- Enrich failure diagnostics with page URL, readyState, element count, framework detection
- Add bot/captcha detection to `navigate` success path via new `page-diagnostics.ts` utility
- Reduce screenshot timeout worst-case from ~27s to ~17.5s
- Fix error-recovery hint regex to match actual tool output
- Embed blocking page info as JSON field in navigate response (preserves JSON.parse compatibility)

## Design philosophy

All changes follow OpenChrome's core principle: "The bottleneck isn't the browser—it's the LLM thinking between steps." Tools succeed more often on first attempt, reducing LLM round-trips. Failure responses provide diagnostic facts (not instructions), preserving LLM autonomy.

## Backward compatibility

All new parameters default to values preserving existing behavior (`waitForMs=0` = no polling). No breaking changes to tool interfaces or response formats.

## Files changed (12)

| File | Change |
|------|--------|
| `src/tools/computer.ts` | Scroll ref resolution + viewport center fallback |
| `extension/src/tools/computer.ts` | Same scroll fixes for extension variant |
| `src/tools/fill-form.ts` | SPA polling + enhanced error messages |
| `src/tools/click-element.ts` | Polling support + failure diagnostics |
| `src/tools/find.ts` | Polling support + failure diagnostics |
| `src/tools/navigate.ts` | Bot detection integration + parallel Promise.all |
| `src/tools/query-dom.ts` | Rich diagnostics on 0-result response |
| `src/utils/page-diagnostics.ts` | New utility: diagnostics + bot/captcha detection |
| `src/config/defaults.ts` | Reduced screenshot timeout (10s→7s) |
| `src/hints/rules/error-recovery.ts` | Fixed regex to match actual output |
| `src/hints/progress-tracker.ts` | Added bot-check/captcha signals |
| `tests/tools/computer.test.ts` | Updated scroll tests for new behavior |

## Test plan

- [x] All 89 relevant tool tests pass
- [x] All 11 scroll-specific tests pass
- [x] Build clean (0 errors)
- [x] Lint clean (0 errors, pre-existing warnings only)
- [x] 4-agent parallel review passed (philosophy, backward compat, performance, code quality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)