### PR TITLE
fix: clear ChromeLauncher.instance on Chrome process exit

### DIFF
--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -429,6 +429,8 @@ export class ChromeLauncher {
     // Log Chrome process exit for immediate diagnostics
     chromeProcess.once('exit', (code, signal) => {
       console.error(`[ChromeLauncher] Chrome process exited (code: ${code}, signal: ${signal})`);
+      // Clear cached instance so next ensureChrome() knows Chrome is gone
+      this.instance = null;
       // Clear pendingProcess if this was the one we were tracking
       if (this.pendingProcess === chromeProcess) {
         this.pendingProcess = null;


### PR DESCRIPTION
## Summary

- Clear `this.instance = null` in the Chrome process exit handler so the next `ensureChrome()` call immediately knows Chrome is gone
- Previously, the stale cached instance caused `checkDebugPort()` to waste time and produce confusing logs before eventually clearing it

## Changes

| File | Change |
|------|--------|
| `src/chrome/launcher.ts` | Add `this.instance = null` in `chromeProcess.once('exit')` handler |

**Priority:** P0 (one-line fix)
**Risk:** Minimal

Fixes #187
Part of #186

## Test plan

- [ ] `npm run build` passes
- [ ] Kill Chrome while OpenChrome is connected → next tool call reconnects immediately without stale instance log

🤖 Generated with [Claude Code](https://claude.com/claude-code)