### PR TITLE
fix: add concurrency guards to session creation and Chrome launch

### DIFF
--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -193,6 +193,7 @@ export interface ProfileState {
 export class ChromeLauncher {
   private instance: ChromeInstance | null = null;
   private pendingProcess: ChildProcess | null = null;
+  private launchInFlight: Promise<ChromeInstance> | null = null;
   private port: number;
   private profileManager = new ProfileManager();
   private currentProfileType: ProfileType | undefined;
@@ -222,6 +223,27 @@ export class ChromeLauncher {
       console.error('[ChromeLauncher] Cached instance is stale, refreshing...');
       this.instance = null;
     }
+
+    // Deduplicate concurrent ensureChrome() calls — return in-flight promise if one exists
+    if (this.launchInFlight) {
+      return this.launchInFlight;
+    }
+
+    this.launchInFlight = this.launchChrome(options).finally(() => {
+      this.launchInFlight = null;
+    });
+    try {
+      return await this.launchInFlight;
+    } finally {
+      this.launchInFlight = null;
+    }
+  }
+
+  /**
+   * Internal launch logic — called by ensureChrome() once the in-flight guard is acquired.
+   */
+  private async launchChrome(options: LaunchOptions = {}): Promise<ChromeInstance> {
+    const port = options.port || this.port;
 
     // Check if Chrome is already running with debug port.
     // Use a brief retry window (5s) instead of a single-shot check, because Chrome

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -88,6 +88,7 @@ export class SessionManager {
   private browserRouter: BrowserRouter | null = null;
   private storageStateManagers = new Map<string, StorageStateManager>();
   private storageStateConfig: StorageStateConfig | null = null;
+  private pendingCreations = new Map<string, Promise<Session>>();
 
   // TTL & Stats
   private config: Required<SessionManagerConfig>;
@@ -319,14 +320,23 @@ export class SessionManager {
    * Get or create a session
    */
   async getOrCreateSession(sessionId: string): Promise<Session> {
-    let session = this.sessions.get(sessionId);
-    if (!session) {
-      session = await this.createSession({ id: sessionId });
-    } else {
-      // Refresh TTL for existing sessions on every access
+    const existing = this.sessions.get(sessionId);
+    if (existing) {
       this.touchSession(sessionId);
+      return existing;
     }
-    return session;
+
+    // Deduplicate concurrent creation requests for the same sessionId
+    const pending = this.pendingCreations.get(sessionId);
+    if (pending) {
+      return pending;
+    }
+
+    const creation = this.createSession({ id: sessionId }).finally(() => {
+      this.pendingCreations.delete(sessionId);
+    });
+    this.pendingCreations.set(sessionId, creation);
+    return creation;
   }
 
   /**


### PR DESCRIPTION
## Summary

- **D1**: Add in-flight promise map to `getOrCreateSession()` to prevent TOCTOU race where concurrent calls create duplicate sessions
- **D4**: Extract `launchChrome()` from `ensureChrome()` and guard with in-flight promise to prevent duplicate Chrome process spawns

## Changes

| File | Change |
|------|--------|
| `src/session-manager.ts` | Add `pendingCreations` map, rewrite `getOrCreateSession()` to deduplicate |
| `src/chrome/launcher.ts` | Add `launchInFlight` guard, extract `launchChrome()` private method |

**Priority:** P1
**Risk:** Low (additive change, no behavior change for single-caller paths)

Fixes #188
Part of #186

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Rapid concurrent tool calls don't create duplicate sessions
- [ ] Multiple agents starting simultaneously don't spawn duplicate Chrome processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)