### PR TITLE
fix: add withTimeout to page.content() and improve error logging

### DIFF
--- a/src/orchestration/workflow-engine.ts
+++ b/src/orchestration/workflow-engine.ts
@@ -187,8 +187,8 @@ export class WorkflowEngine {
             // Cookie bridging failure is non-fatal — page navigates without cookies
           }
 
-          await page.goto(step.url, { waitUntil: 'domcontentloaded', timeout: DEFAULT_NAVIGATION_TIMEOUT_MS }).catch(() => {
-            // Navigation may fail for some URLs; worker will retry
+          await page.goto(step.url, { waitUntil: 'domcontentloaded', timeout: DEFAULT_NAVIGATION_TIMEOUT_MS }).catch((err) => {
+            console.error(`[WorkflowEngine] Navigation to ${step.url} failed: ${err instanceof Error ? err.message : String(err)}`);
           });
         }
 

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -738,8 +738,8 @@ export class SessionManager {
             })(),
             new Promise<void>((resolve) => setTimeout(resolve, DEFAULT_COOKIE_CONTEXT_TIMEOUT_MS)),
           ]);
-        } catch {
-          console.error('[SessionManager] Cookie context copy timed out, continuing without cookies');
+        } catch (err) {
+          console.error(`[SessionManager] Cookie context copy failed, continuing without cookies: ${err instanceof Error ? err.message : String(err)}`);
         }
         page = poolPage;
         console.error(`[SessionManager] Acquired page from pool for session ${sessionId}`);

--- a/src/tools/page-content.ts
+++ b/src/tools/page-content.ts
@@ -5,7 +5,7 @@
 import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
-import { MAX_OUTPUT_CHARS } from '../config/defaults';
+import { MAX_OUTPUT_CHARS, DEFAULT_NAVIGATION_TIMEOUT_MS } from '../config/defaults';
 import { withTimeout } from '../utils/with-timeout';
 
 const definition: MCPToolDefinition = {
@@ -107,7 +107,7 @@ const handler: ToolHandler = async (
       };
     } else {
       // Get full page content
-      let html = await page.content();
+      let html = await withTimeout(page.content(), DEFAULT_NAVIGATION_TIMEOUT_MS, 'page.content()');
 
       const originalLength = html.length;
       if (html.length > MAX_OUTPUT_CHARS) {


### PR DESCRIPTION
## Summary

- **A2**: Wrap `page.content()` with `withTimeout(30s)` — was the last major unguarded CDP call that could hang indefinitely
- **C1**: Log navigation errors in workflow-engine instead of silently swallowing them with empty `.catch(() => {})`
- **C2**: Fix misleading "Cookie context copy timed out" message to say "failed" and include actual error

## Changes

| File | Change |
|------|--------|
| `src/tools/page-content.ts` | Add `withTimeout` wrapper on `page.content()` |
| `src/orchestration/workflow-engine.ts` | Log navigation error with URL and message |
| `src/session-manager.ts` | Fix cookie context error log to include actual error |

**Priority:** P1
**Risk:** Minimal

Fixes #189
Part of #186

## Test plan

- [ ] `npm run build` passes
- [ ] `page_content` tool on a frozen tab times out after 30s instead of hanging
- [ ] Workflow navigation failures appear in logs with URL
- [ ] Cookie context errors show actual error, not always "timed out"

🤖 Generated with [Claude Code](https://claude.com/claude-code)