### PR TITLE
feat: make CDP protocol timeout configurable via env var

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -361,7 +361,7 @@ export class CDPClient {
           puppeteer.connect({
             browserWSEndpoint: instance.wsEndpoint,
             defaultViewport: null,
-            protocolTimeout: DEFAULT_PROTOCOL_TIMEOUT_MS,
+            protocolTimeout: parseInt(process.env.OPENCHROME_PROTOCOL_TIMEOUT_MS || '', 10) || DEFAULT_PROTOCOL_TIMEOUT_MS,
           }).finally(() => clearTimeout(wsConnectTid)),
           new Promise<never>((_, reject) => {
             wsConnectTid = setTimeout(

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -20,7 +20,8 @@ export const DEFAULT_NAVIGATION_TIMEOUT_MS = 30000;
 /** Maximum number of candidate elements returned by element-finding queries. */
 export const MAX_SEARCH_CANDIDATES = 30;
 
-/** CDP protocol timeout in milliseconds. Prevents 180s default hangs. */
+/** CDP protocol timeout in milliseconds. Prevents 180s default hangs.
+ *  Override with OPENCHROME_PROTOCOL_TIMEOUT_MS environment variable. */
 export const DEFAULT_PROTOCOL_TIMEOUT_MS = 30000;
 
 /** Screenshot-specific timeout. Shorter than protocol timeout for fast fallback. */


### PR DESCRIPTION
## Summary

- Add `OPENCHROME_PROTOCOL_TIMEOUT_MS` environment variable to override the default 30s CDP protocol timeout
- Follows existing pattern used by `CHROME_LAUNCH_TIMEOUT_MS`
- Useful for slow networks or heavy Chrome instances that need longer timeouts

## Changes

| File | Change |
|------|--------|
| `src/cdp/client.ts` | Read env var with fallback to `DEFAULT_PROTOCOL_TIMEOUT_MS` |
| `src/config/defaults.ts` | Update doc comment to mention env var override |

**Priority:** P2
**Risk:** Minimal (additive, env var override with safe default)

Fixes #190
Part of #186

## Test plan

- [ ] `npm run build` passes
- [ ] Default behavior unchanged (30s timeout)
- [ ] `OPENCHROME_PROTOCOL_TIMEOUT_MS=60000 oc serve` uses 60s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)