### PR TITLE
fix: make expand_tools work on all MCP clients

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,10 @@
  */
 
 import { Command } from 'commander';
-import { getMCPServer } from './mcp-server';
+import { getMCPServer, setMCPServerOptions } from './mcp-server';
 import { registerAllTools } from './tools';
 import { getGlobalConfig, setGlobalConfig } from './config/global';
+import { ToolTier } from './config/tool-tiers';
 import { writePidFile } from './utils/pid-manager';
 import { getVersion } from './version';
 
@@ -45,8 +46,9 @@ program
   .option('--lp-port <port>', 'Lightpanda debugging port (default: 9223)', '9223')
   .option('--blocked-domains <domains>', 'Comma-separated list of blocked domains (e.g., "*.bank.com,mail.google.com")')
   .option('--audit-log', 'Enable security audit logging (default: false)')
+  .option('--all-tools', 'Expose all tools from startup (bypass progressive disclosure)')
   .option('--server-mode', 'Server/headless mode: auto-launch headless Chrome, skip cookie bridge')
-  .action(async (options: { port: string; autoLaunch?: boolean; userDataDir?: string; chromeBinary?: string; headlessShell?: boolean; visible?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; serverMode?: boolean }) => {
+  .action(async (options: { port: string; autoLaunch?: boolean; userDataDir?: string; chromeBinary?: string; headlessShell?: boolean; visible?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; allTools?: boolean; serverMode?: boolean }) => {
     const port = parseInt(options.port, 10);
     let autoLaunch = options.autoLaunch || false;
 
@@ -126,6 +128,16 @@ program
         security: { ...existing, audit_log: true },
       });
       console.error('[openchrome] Audit logging: enabled');
+    }
+
+    // Tool tier configuration
+    const envTier = parseInt(process.env.OPENCHROME_TOOL_TIER || '', 10);
+    if (options.allTools || envTier >= 3) {
+      setMCPServerOptions({ initialToolTier: 3 as ToolTier });
+      console.error('[openchrome] All tools exposed from startup');
+    } else if (envTier === 2) {
+      setMCPServerOptions({ initialToolTier: 2 as ToolTier });
+      console.error('[openchrome] Tier 2 tools exposed from startup');
     }
 
     const server = getMCPServer();

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -69,6 +69,7 @@ const RECONNECTION_GUIDANCE =
 export interface MCPServerOptions {
   dashboard?: boolean;
   dashboardRefreshInterval?: number;
+  initialToolTier?: ToolTier;
 }
 
 export class MCPServer {
@@ -88,6 +89,10 @@ export class MCPServer {
   constructor(sessionManager?: SessionManager, options: MCPServerOptions = {}) {
     this.sessionManager = sessionManager || getSessionManager();
     this.options = options;
+
+    if (options.initialToolTier) {
+      this.exposedTier = options.initialToolTier;
+    }
 
     // Register built-in resources
     this.registerResource(usageGuideResource);
@@ -480,13 +485,29 @@ export class MCPServer {
 
     // Handle the expand_tools meta-tool before normal tool lookup
     if (toolName === 'expand_tools') {
+      const oldTier = this.exposedTier;
       const tier = parseInt(String(toolArgs?.tier ?? '2'), 10) || 2;
       this.expandToolTier(Math.min(tier, 3) as ToolTier);
+
+      // Collect newly-exposed tool definitions for clients that don't support list_changed
+      const newTools = Array.from(this.tools.values())
+        .filter(r => {
+          const t = getToolTier(r.definition.name);
+          return t <= this.exposedTier && t > oldTier;
+        })
+        .map(r => r.definition);
+
       const toolCount = Array.from(this.tools.values()).filter(
         r => getToolTier(r.definition.name) <= this.exposedTier
       ).length;
+
+      let text = `Tool tier expanded to ${this.exposedTier}. Now exposing ${toolCount} tools.`;
+      if (newTools.length > 0) {
+        text += `\n\nNewly available tools:\n${JSON.stringify(newTools, null, 2)}\n\nYou can now call these tools directly by name.`;
+      }
+
       return {
-        content: [{ type: 'text', text: `Tool tier expanded to ${this.exposedTier}. Now exposing ${toolCount} tools. Call tools/list to see the updated list.` }],
+        content: [{ type: 'text', text }],
       };
     }
 

--- a/tests/mcp/expand-tools-schema.test.ts
+++ b/tests/mcp/expand-tools-schema.test.ts
@@ -97,4 +97,35 @@ describe('expand_tools schema (Gemini compatibility)', () => {
     const text = (result as any).content?.[0]?.text;
     expect(text).toContain('Tool tier expanded');
   });
+
+  test('expand_tools response includes newly available tool definitions', async () => {
+    // Register a tool that is mapped to tier 2 in TOOL_TIERS
+    server.registerTool('click_element', jest.fn(), {
+      name: 'click_element',
+      description: 'Click an element by selector',
+      inputSchema: { type: 'object', properties: {} },
+    });
+
+    // @ts-expect-error - accessing private method for testing
+    const result = await server.handleToolsCall({ name: 'expand_tools', arguments: { tier: '2' } });
+
+    const text = (result as any).content?.[0]?.text;
+    expect(text).toContain('Tool tier expanded');
+    expect(text).toContain('Newly available tools:');
+    expect(text).toContain('You can now call these tools directly by name.');
+  });
+
+  test('expand_tools response omits newly available section when no new tools', async () => {
+    // Expand to tier 2 first
+    // @ts-expect-error - accessing private method for testing
+    await server.handleToolsCall({ name: 'expand_tools', arguments: { tier: '2' } });
+
+    // Expand to tier 2 again (no change)
+    // @ts-expect-error - accessing private method for testing
+    const result = await server.handleToolsCall({ name: 'expand_tools', arguments: { tier: '2' } });
+
+    const text = (result as any).content?.[0]?.text;
+    expect(text).toContain('Tool tier expanded');
+    expect(text).not.toContain('Newly available tools:');
+  });
 });


### PR DESCRIPTION
## Summary

Most MCP clients (including Claude Code, Antigravity IDE, Gemini CLI, GitHub Copilot, and 20+ others) don't support `notifications/tools/list_changed`. The `expand_tools` meta-tool relied entirely on this notification, causing it to silently fail on the majority of clients.

### Changes

- **Inline tool definitions in `expand_tools` response** — When tier is expanded, the full JSON definitions of newly-available tools are included in the response text. The LLM can then call these tools directly, regardless of client `list_changed` support.
- **`--all-tools` CLI flag** — `oc serve --all-tools` exposes all 46 tools from startup, bypassing progressive disclosure entirely.
- **`OPENCHROME_TOOL_TIER` env var** — Set default tier (2 or 3) via environment variable for MCP config files that don't support CLI flags.
- **Existing `list_changed` notification preserved** — Clients that do support it continue to work as before.

### Why

The [apify/mcp-client-capabilities matrix](https://github.com/apify/mcp-client-capabilities) shows that `tools.listChanged` is only supported by a minority of clients (Cursor, Cline, Windsurf, VS Code). The majority — including Claude Code, Antigravity IDE, Gemini CLI, and ChatGPT — don't support it. See [PulseMCP analysis](https://www.pulsemcp.com/posts/mcp-client-capabilities-gap).

| File | Change |
|------|--------|
| `src/mcp-server.ts` | Inline tool defs in response + `initialToolTier` option |
| `src/index.ts` | `--all-tools` flag + `OPENCHROME_TOOL_TIER` env var |
| `tests/mcp/expand-tools-schema.test.ts` | 2 new tests for inline definitions |

Fixes #195

## Test plan

- [x] `npm run build` passes
- [x] `npx jest tests/mcp/expand-tools-schema.test.ts` — 7/7 pass (5 existing + 2 new)
- [ ] Manual: `oc serve --all-tools` shows all tools on first `tools/list`
- [ ] Manual: `OPENCHROME_TOOL_TIER=3 oc serve` same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)