### PR TITLE
fix: wrap javascript_tool code in async IIFE to prevent syntax errors

### DIFF
--- a/src/tools/javascript.ts
+++ b/src/tools/javascript.ts
@@ -48,6 +48,58 @@ interface CDPEvalResult {
   };
 }
 
+export function wrapInIIFE(code: string): string {
+  const trimmed = code.trim();
+
+  // Single expression without semicolons, newlines, or return: evaluate as-is
+  // so the expression value is returned naturally by Runtime.evaluate.
+  if (!trimmed.includes('\n') && !trimmed.includes(';') && !/\breturn\b/.test(trimmed)) {
+    return trimmed;
+  }
+
+  // Multi-statement code or code with explicit return: wrap in async IIFE.
+  // This fixes two common LLM errors:
+  //   1. SyntaxError: Illegal return statement  (return outside a function)
+  //   2. SyntaxError: Identifier 'x' has already been declared  (let/const redeclaration)
+  //
+  // If there is no explicit `return`, try to auto-return the last expression so
+  // that `let x = 5;\nx` still returns 5 instead of undefined.
+  if (!/\breturn\b/.test(trimmed)) {
+    const lines = trimmed.split('\n').filter((l) => l.trim());
+    const lastLine = lines[lines.length - 1]?.trim() ?? '';
+
+    // Auto-return the last line if it looks like an expression (not a
+    // declaration, control-flow statement, closing brace, or comment).
+    const isAutoReturnable =
+      lastLine.length > 0 &&
+      !lastLine.startsWith('let ') &&
+      !lastLine.startsWith('const ') &&
+      !lastLine.startsWith('var ') &&
+      !lastLine.startsWith('function ') &&
+      !lastLine.startsWith('class ') &&
+      !lastLine.startsWith('if') &&
+      !lastLine.startsWith('else') &&
+      !lastLine.startsWith('for') &&
+      !lastLine.startsWith('while') &&
+      !lastLine.startsWith('do') &&
+      !lastLine.startsWith('switch') &&
+      !lastLine.startsWith('try') &&
+      !lastLine.startsWith('catch') &&
+      !lastLine.startsWith('finally') &&
+      !lastLine.startsWith('//') &&
+      !lastLine.startsWith('/*') &&
+      !lastLine.startsWith('}');
+
+    if (isAutoReturnable) {
+      const bodyLines = lines.slice(0, -1).join('\n');
+      const body = bodyLines ? `${bodyLines}\nreturn ${lastLine}` : `return ${lastLine}`;
+      return `(async () => { ${body}\n})()`;
+    }
+  }
+
+  return `(async () => { ${code}\n})()`;
+}
+
 function formatCDPResult(evalResult: CDPEvalResult['result']): string {
   const { type, subtype, value, description, className } = evalResult;
 
@@ -160,7 +212,7 @@ const handler: ToolHandler = async (
     const cdpResult = await Promise.race([
       cdpClient
         .send<CDPEvalResult>(page, 'Runtime.evaluate', {
-          expression: code,
+          expression: wrapInIIFE(code),
           returnByValue: true,
           awaitPromise: true,
           userGesture: true,

--- a/tests/tools/javascript-iife.test.ts
+++ b/tests/tools/javascript-iife.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for the wrapInIIFE helper in javascript.ts.
+ */
+
+import { wrapInIIFE } from '../../src/tools/javascript';
+
+describe('wrapInIIFE', () => {
+  // --- simple expressions — must NOT be wrapped ---
+
+  test('simple property access stays unwrapped', () => {
+    expect(wrapInIIFE('document.title')).toBe('document.title');
+  });
+
+  test('arithmetic expression stays unwrapped', () => {
+    expect(wrapInIIFE('1 + 2')).toBe('1 + 2');
+  });
+
+  test('function call without semicolon stays unwrapped', () => {
+    expect(wrapInIIFE('window.location.href')).toBe('window.location.href');
+  });
+
+  test('leading/trailing whitespace is trimmed for simple expressions', () => {
+    expect(wrapInIIFE('  document.title  ')).toBe('document.title');
+  });
+
+  // --- code with explicit return — must be wrapped ---
+
+  test('bare return statement gets wrapped', () => {
+    const code = "return 'hello'";
+    const wrapped = wrapInIIFE(code);
+    expect(wrapped).toContain('(async () =>');
+    expect(wrapped).toContain("return 'hello'");
+  });
+
+  test('multi-line code with explicit return gets wrapped', () => {
+    const code = 'const x = 5;\nreturn x;';
+    const wrapped = wrapInIIFE(code);
+    expect(wrapped).toContain('(async () =>');
+    expect(wrapped).toContain('return x');
+  });
+
+  test('code with explicit return is not double-returned', () => {
+    const code = 'const x = 5;\nreturn x;';
+    const wrapped = wrapInIIFE(code);
+    // Only the one return written by the LLM should be present
+    expect((wrapped.match(/\breturn\b/g) ?? []).length).toBe(1);
+  });
+
+  // --- multi-statement without explicit return — wrapped with auto-return ---
+
+  test('multi-line expression auto-returns last line', () => {
+    const code = 'const x = 5;\nx';
+    const wrapped = wrapInIIFE(code);
+    expect(wrapped).toContain('(async () =>');
+    expect(wrapped).toContain('return x');
+  });
+
+  test('let declaration followed by identifier auto-returns identifier', () => {
+    const code = "let result = 'test';\nresult";
+    const wrapped = wrapInIIFE(code);
+    expect(wrapped).toContain('(async () =>');
+    expect(wrapped).toContain('return result');
+  });
+
+  test('semicolon-separated single-line code gets wrapped', () => {
+    const code = "const a = 1; a + 2";
+    const wrapped = wrapInIIFE(code);
+    expect(wrapped).toContain('(async () =>');
+  });
+
+  // --- last line is a declaration — wrapped but no spurious auto-return ---
+
+  test('code ending with a declaration is wrapped without auto-return', () => {
+    const code = 'let x = 5;\nconst y = x + 1';
+    const wrapped = wrapInIIFE(code);
+    expect(wrapped).toContain('(async () =>');
+    // No auto-return injected before a const line
+    expect(wrapped).not.toMatch(/return const/);
+  });
+
+  test('code ending with a closing brace is wrapped without auto-return', () => {
+    const code = 'function f() { return 1; }\nf()';
+    // last non-empty line is "f()" which IS auto-returnable
+    const wrapped = wrapInIIFE(code);
+    expect(wrapped).toContain('(async () =>');
+  });
+
+  // --- IIFE structure correctness ---
+
+  test('IIFE uses async arrow function', () => {
+    const wrapped = wrapInIIFE("return 42");
+    expect(wrapped).toMatch(/^\(async \(\) => \{/);
+  });
+
+  test('wrapped code ends with })()', () => {
+    const wrapped = wrapInIIFE("return 42");
+    expect(wrapped.trimEnd()).toMatch(/\}\)\(\)$/);
+  });
+
+  test('original code is preserved inside IIFE', () => {
+    const code = "const x = 'world';\nreturn 'hello ' + x;";
+    const wrapped = wrapInIIFE(code);
+    expect(wrapped).toContain(code);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `wrapInIIFE()` helper in `src/tools/javascript.ts` that wraps user-supplied code in an `async IIFE` before passing it to `Runtime.evaluate`
- Fixes two recurring LLM-generated code errors:
  - `SyntaxError: Illegal return statement` — `return` used outside a function body
  - `SyntaxError: Identifier 'x' has already been declared` — `let`/`const` redeclared across sequential evaluations
- Simple single expressions (e.g. `document.title`, `1 + 2`) are passed through unchanged so their value is returned naturally by `Runtime.evaluate`
- Multi-statement code without an explicit `return` has its last expression auto-returned, preserving the current REPL-like behaviour (e.g. `let x = 5;\nx` still returns `5`)

## Test plan

- [x] `npm run build` — passes with zero TypeScript errors
- [x] `npm test -- tests/tools/javascript-iife.test.ts` — 15/15 tests pass
- [x] Unit tests cover: simple expressions (no wrap), bare `return`, multi-line with explicit `return`, no-double-return guard, auto-return of last expression, declarations not auto-returned, IIFE structure correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)