### PR TITLE
fix: add transparent retry and fallback to scroll operations

### DIFF
--- a/src/tools/computer.ts
+++ b/src/tools/computer.ts
@@ -12,6 +12,7 @@ import { withDomDelta } from '../utils/dom-delta';
 import { generateVisualSummary } from '../utils/visual-summary';
 import { AdaptiveScreenshot } from '../utils/adaptive-screenshot';
 import { withTimeout } from '../utils/with-timeout';
+import { retryWithFallback } from '../utils/retry-with-fallback';
 
 const definition: MCPToolDefinition = {
   name: 'computer',
@@ -568,14 +569,29 @@ const handler: ToolHandler = async (
             break;
         }
 
-        await page.mouse.wheel({ deltaX, deltaY });
+        // Primary: CDP mouse wheel scroll
+        const primaryWheel = () => page.mouse.wheel({ deltaX, deltaY });
+
+        // Fallback: JS window.scrollBy (works even when CDP input is busy)
+        const fallbackWheel = () => withTimeout(
+          page.evaluate((dx: number, dy: number) => window.scrollBy(dx, dy), deltaX, deltaY),
+          5000,
+          'scroll-fallback'
+        );
+
+        const { recovered: scrollRecovered, method: scrollMethod } = await retryWithFallback(
+          primaryWheel,
+          [fallbackWheel],
+          { label: 'computer_scroll', retryDelayMs: 500 }
+        );
 
         const centerNote = usedViewportCenter ? ' [viewport center]' : '';
+        const recoveryNote = scrollRecovered ? ` [recovered:${scrollMethod}]` : '';
         return {
           content: [
             {
               type: 'text',
-              text: `Scrolled ${direction} at (${scrollCoord[0]}, ${scrollCoord[1]})${centerNote}`,
+              text: `Scrolled ${direction} at (${scrollCoord[0]}, ${scrollCoord[1]})${centerNote}${recoveryNote}`,
             },
           ],
         };

--- a/src/tools/lightweight-scroll.ts
+++ b/src/tools/lightweight-scroll.ts
@@ -11,6 +11,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
 import { withTimeout } from '../utils/with-timeout';
+import { retryWithFallback } from '../utils/retry-with-fallback';
 
 const definition: MCPToolDefinition = {
   name: 'lightweight_scroll',
@@ -89,7 +90,20 @@ const handler: ToolHandler = async (
       };
     }
 
-    const scrollResult = await withTimeout(page.evaluate(
+    type ScrollResult = {
+      success: boolean;
+      scrollX: number;
+      scrollY: number;
+      scrollHeight: number;
+      scrollWidth: number;
+      clientHeight: number;
+      clientWidth: number;
+      atEnd: boolean;
+      error?: string;
+    };
+
+    // Primary: page.evaluate scroll (JS-based, fast path)
+    const primaryScroll = (): Promise<ScrollResult> => withTimeout(page.evaluate(
       (params: {
         direction: string;
         amount: number;
@@ -97,17 +111,7 @@ const handler: ToolHandler = async (
         selector: string | null;
         scrollToEnd: boolean;
         waitAfterMs: number;
-      }): Promise<{
-        success: boolean;
-        scrollX: number;
-        scrollY: number;
-        scrollHeight: number;
-        scrollWidth: number;
-        clientHeight: number;
-        clientWidth: number;
-        atEnd: boolean;
-        error?: string;
-      }> => {
+      }): Promise<ScrollResult> => {
         return new Promise((resolve) => {
           try {
             const target = params.selector
@@ -248,6 +252,58 @@ const handler: ToolHandler = async (
       }
     ), 10000, 'lightweight_scroll');
 
+    // Fallback: Input.dispatchMouseEvent mouseWheel via CDP
+    const fallbackScroll = async (): Promise<ScrollResult> => {
+      const cdpClient = sessionManager.getCDPClient();
+      const viewport = page.viewport();
+      const x = viewport ? viewport.width / 2 : 512;
+      const y = viewport ? viewport.height / 2 : 384;
+
+      let deltaX = 0;
+      let deltaY = 0;
+      switch (direction) {
+        case 'down': deltaY = amount; break;
+        case 'up': deltaY = -amount; break;
+        case 'right': deltaX = amount; break;
+        case 'left': deltaX = -amount; break;
+      }
+
+      await withTimeout(
+        cdpClient.send(page, 'Input.dispatchMouseEvent', {
+          type: 'mouseWheel',
+          x, y,
+          deltaX, deltaY,
+        }),
+        5000,
+        'scroll-fallback'
+      );
+
+      // Wait briefly for scroll to take effect
+      await new Promise(r => setTimeout(r, 100));
+
+      // Read back scroll position
+      const positions = await withTimeout(page.evaluate(() => ({
+        scrollX: window.scrollX,
+        scrollY: window.scrollY,
+        scrollHeight: document.documentElement.scrollHeight,
+        scrollWidth: document.documentElement.scrollWidth,
+        clientHeight: document.documentElement.clientHeight,
+        clientWidth: document.documentElement.clientWidth,
+      })), 5000, 'scroll-position-read');
+
+      return {
+        success: true,
+        ...positions,
+        atEnd: false, // approximate — position read is accurate but atEnd calc is skipped
+      };
+    };
+
+    const { result: scrollResult, recovered, method: recoveryMethod } = await retryWithFallback(
+      primaryScroll,
+      [fallbackScroll],
+      { label: 'lightweight_scroll', retryDelayMs: 500 }
+    );
+
     if (!scrollResult.success) {
       return {
         content: [{ type: 'text', text: `Scroll error: ${scrollResult.error}` }],
@@ -257,13 +313,14 @@ const handler: ToolHandler = async (
 
     const targetDesc = selector ? ` (${selector})` : '';
     const endIndicator = scrollResult.atEnd ? ' [END REACHED]' : '';
+    const recoveryNote = recovered ? ` [recovered:${recoveryMethod}]` : '';
 
     return {
       content: [
         {
           type: 'text',
           text: JSON.stringify({
-            scrolled: `${direction} ${scrollToEnd ? 'to end' : amount + 'px'}${targetDesc}${endIndicator}`,
+            scrolled: `${direction} ${scrollToEnd ? 'to end' : amount + 'px'}${targetDesc}${endIndicator}${recoveryNote}`,
             position: {
               x: scrollResult.scrollX,
               y: scrollResult.scrollY,

--- a/src/utils/retry-with-fallback.ts
+++ b/src/utils/retry-with-fallback.ts
@@ -1,0 +1,50 @@
+/**
+ * Retry with fallback utility.
+ * Retries the primary operation, then tries fallback methods before giving up.
+ */
+
+export interface RetryOptions {
+  /** Maximum retry attempts for primary method (default: 1) */
+  maxRetries?: number;
+  /** Delay between retries in ms (default: 500) */
+  retryDelayMs?: number;
+  /** Label for logging (default: 'operation') */
+  label?: string;
+}
+
+export async function retryWithFallback<T>(
+  primary: () => Promise<T>,
+  fallbacks: Array<() => Promise<T>>,
+  options: RetryOptions = {}
+): Promise<{ result: T; recovered: boolean; method: string }> {
+  const { maxRetries = 1, retryDelayMs = 500, label = 'operation' } = options;
+
+  // Try primary with retries
+  let lastError: Error | undefined;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const result = await primary();
+      return { result, recovered: attempt > 0, method: 'primary' };
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      if (attempt < maxRetries) {
+        console.error(`[retry] ${label} attempt ${attempt + 1} failed, retrying in ${retryDelayMs}ms...`);
+        await new Promise(r => setTimeout(r, retryDelayMs));
+      }
+    }
+  }
+
+  // Try fallbacks
+  for (let i = 0; i < fallbacks.length; i++) {
+    try {
+      console.error(`[retry] ${label} trying fallback ${i + 1}...`);
+      const result = await fallbacks[i]();
+      return { result, recovered: true, method: `fallback-${i + 1}` };
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+    }
+  }
+
+  // All methods exhausted
+  throw lastError || new Error(`${label}: all recovery methods exhausted`);
+}

--- a/tests/utils/retry-with-fallback.test.ts
+++ b/tests/utils/retry-with-fallback.test.ts
@@ -1,0 +1,132 @@
+/// <reference types="jest" />
+/**
+ * Tests for retryWithFallback utility
+ */
+
+import { retryWithFallback } from '../../src/utils/retry-with-fallback';
+
+describe('retryWithFallback', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('primary succeeds on first try — returns result with recovered: false', async () => {
+    const primary = jest.fn().mockResolvedValue('ok');
+
+    const { result, recovered, method } = await retryWithFallback(primary, []);
+
+    expect(result).toBe('ok');
+    expect(recovered).toBe(false);
+    expect(method).toBe('primary');
+    expect(primary).toHaveBeenCalledTimes(1);
+  });
+
+  test('primary fails once then retry succeeds — returns result with recovered: true', async () => {
+    const primary = jest.fn()
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValue('retried-ok');
+
+    const { result, recovered, method } = await retryWithFallback(
+      primary,
+      [],
+      { maxRetries: 1, retryDelayMs: 0 }
+    );
+
+    expect(result).toBe('retried-ok');
+    expect(recovered).toBe(true);
+    expect(method).toBe('primary');
+    expect(primary).toHaveBeenCalledTimes(2);
+  });
+
+  test('primary fails all attempts, fallback succeeds — returns recovered: true, method: fallback-1', async () => {
+    const primary = jest.fn().mockRejectedValue(new Error('always fails'));
+    const fallback = jest.fn().mockResolvedValue('fallback-ok');
+
+    const { result, recovered, method } = await retryWithFallback(
+      primary,
+      [fallback],
+      { maxRetries: 1, retryDelayMs: 0 }
+    );
+
+    expect(result).toBe('fallback-ok');
+    expect(recovered).toBe(true);
+    expect(method).toBe('fallback-1');
+    expect(primary).toHaveBeenCalledTimes(2); // initial + 1 retry
+    expect(fallback).toHaveBeenCalledTimes(1);
+  });
+
+  test('all methods fail — throws the last error', async () => {
+    const primary = jest.fn().mockRejectedValue(new Error('primary error'));
+    const fallback1 = jest.fn().mockRejectedValue(new Error('fallback-1 error'));
+    const fallback2 = jest.fn().mockRejectedValue(new Error('fallback-2 error'));
+
+    await expect(
+      retryWithFallback(primary, [fallback1, fallback2], { maxRetries: 1, retryDelayMs: 0 })
+    ).rejects.toThrow('fallback-2 error');
+
+    expect(primary).toHaveBeenCalledTimes(2);
+    expect(fallback1).toHaveBeenCalledTimes(1);
+    expect(fallback2).toHaveBeenCalledTimes(1);
+  });
+
+  test('respects retryDelayMs between attempts', async () => {
+    const primary = jest.fn()
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValue('ok');
+
+    const delayMs = 50;
+    const start = Date.now();
+
+    await retryWithFallback(primary, [], { maxRetries: 1, retryDelayMs: delayMs });
+
+    const elapsed = Date.now() - start;
+    // Allow generous margin for CI timing variance
+    expect(elapsed).toBeGreaterThanOrEqual(delayMs - 10);
+  });
+
+  test('uses default options when none provided', async () => {
+    // Default: maxRetries=1
+    // Provide a primary that always fails and a fallback that succeeds
+    const primary = jest.fn().mockRejectedValue(new Error('fail'));
+    const fallback = jest.fn().mockResolvedValue('default-ok');
+
+    // Use retryDelayMs: 0 to avoid real timer waits in test
+    const { result, recovered, method } = await retryWithFallback(
+      primary, [fallback], { retryDelayMs: 0 }
+    );
+
+    expect(result).toBe('default-ok');
+    expect(recovered).toBe(true);
+    expect(method).toBe('fallback-1');
+    // primary called twice: initial attempt + 1 default retry
+    expect(primary).toHaveBeenCalledTimes(2);
+  });
+
+  test('logs retry attempts to console.error', async () => {
+    const primary = jest.fn()
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValue('ok');
+
+    await retryWithFallback(primary, [], { maxRetries: 1, retryDelayMs: 0, label: 'test-op' });
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('[retry] test-op attempt 1 failed')
+    );
+  });
+
+  test('logs fallback attempts to console.error', async () => {
+    const primary = jest.fn().mockRejectedValue(new Error('fail'));
+    const fallback = jest.fn().mockResolvedValue('ok');
+
+    await retryWithFallback(primary, [fallback], { maxRetries: 0, retryDelayMs: 0, label: 'test-op' });
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('[retry] test-op trying fallback 1')
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add `retryWithFallback` utility for internal retry + fallback chain
- `lightweight_scroll`: retry `page.evaluate`, fallback to `Input.dispatchMouseEvent`
- `computer(scroll)`: retry `dispatchMouseEvent`, fallback to `page.evaluate(scrollBy)`
- Response includes recovery metadata when retry succeeds

When scroll operations timeout on busy pages (SPA rendering, GC pauses), the tool now retries internally before returning an error to the LLM. This prevents workflow interruptions from transient failures.

## Design

```
LLM → scroll → timeout → [internal retry 500ms later] → success → result returned
                        → [retry fails] → [fallback method] → success → result returned
                        → [all fail] → error returned (unavoidable)
```

The LLM never sees transient errors — only persistent failures reach the caller.

## Test plan

- [x] `retryWithFallback` utility: 8 unit tests (primary success, retry success, fallback success, all fail, delay, defaults, logging)
- [x] `npm run build` passes
- [x] Existing tests unaffected

Refs #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)