### PR TITLE
fix: prevent ref namespace collision between query_dom and RefIdManager (#205)

### DIFF
--- a/src/tools/query-dom.ts
+++ b/src/tools/query-dom.ts
@@ -41,7 +41,7 @@ interface XPathElementInfo {
 const definition: MCPToolDefinition = {
   name: 'query_dom',
   description:
-    'Query DOM elements via CSS selectors or XPath. Returns tag, attributes, text, and position.',
+    'Query DOM elements via CSS selectors or XPath. Returns tag, attributes, text, and position. CSS results include a ref field (el_0, el_1, ...) for referencing elements in subsequent tool calls.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -227,7 +227,7 @@ async function handleCSS(
           }
 
           return {
-            ref: `ref_${index}`,
+            ref: `el_${index}`,
             tagName: el.tagName.toLowerCase(),
             id: el.id || null,
             className: el.className,
@@ -306,7 +306,7 @@ async function handleCSS(
       }
 
       return {
-        ref: 'ref_0',
+        ref: 'el_0',
         tagName: el.tagName.toLowerCase(),
         id: el.id || null,
         className: el.className,


### PR DESCRIPTION
## Summary

- `query_dom` was generating element refs using the `ref_N` prefix (e.g. `ref_0`, `ref_1`), which collided with `RefIdManager`'s own `ref_N` namespace
- When an LLM passed a `ref` returned by `query_dom` to a tool like `form_input`, `RefIdManager` resolved it to a completely different element — causing silent, hard-to-debug misbehavior
- Changed the `query_dom` ref prefix from `ref_` to `el_` (e.g. `el_0`, `el_1`) to eliminate the collision entirely
- Updated the tool description to document the `el_` ref format

## Changes

- `src/tools/query-dom.ts` line 230: `ref_${index}` → `el_${index}` (multiple CSS results)
- `src/tools/query-dom.ts` line 309: `'ref_0'` → `'el_0'` (single CSS result)
- `src/tools/query-dom.ts`: Updated tool description to note the `el_N` ref format

## Test plan

- [x] `npm run build` — passes with no type errors
- [x] `npm test` — all tests pass (no query-dom-specific test file exists; no regressions in full suite)

Fixes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)