### PR TITLE
fix: update read-page test for tagName parameter

### DIFF
--- a/tests/tools/read-page.test.ts
+++ b/tests/tools/read-page.test.ts
@@ -502,13 +502,15 @@ describe('ReadPageTool', () => {
       });
 
       // Check that refs were generated with correct session and target
-      expect(mockRefIdManager.generateRef).toHaveBeenCalledWith(
-        testSessionId,
-        testTargetId,
-        expect.any(Number),
-        expect.any(String),
-        expect.anything()
+      // generateRef is called with (sessionId, targetId, backendDOMNodeId, role, name, tagName)
+      // tagName may be string or undefined depending on the AX role mapping
+      const calls = mockRefIdManager.generateRef.mock.calls;
+      const matchingCall = calls.find(
+        (c: unknown[]) => c[0] === testSessionId && c[1] === testTargetId
       );
+      expect(matchingCall).toBeDefined();
+      expect(typeof matchingCall![2]).toBe('number');
+      expect(typeof matchingCall![3]).toBe('string');
     });
   });
 


### PR DESCRIPTION
## Summary
- Update `tests/tools/read-page.test.ts` RefIdManager Integration test to match the new `generateRef` signature that includes a `tagName` parameter (added in PR #209)
- The test was asserting 5 args but `generateRef` now receives 6 (with optional `tagName`)

## Context
PR #209 added AX role→tagName mapping that passes `tagName` as a 6th argument to `generateRef`. The test wasn't updated, causing CI failure on all 9 matrix jobs (3 OS × 3 Node versions).

## Test plan
- [x] `npx jest tests/tools/read-page.test.ts` — 27/27 pass
- [x] `npm run build` — passes
- [ ] CI should go green on all 9 jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)