### PR TITLE
fix: clear RefIdManager refs in onTargetClosed

### DIFF
--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -1217,6 +1217,10 @@ export class SessionManager {
         if (worker) {
           worker.targets.delete(targetId);
         }
+
+        // Clean up ref IDs before removing from targetToWorker mapping
+        getRefIdManager().clearTargetRefs(ownerInfo.sessionId, targetId);
+
         this.targetToWorker.delete(targetId);
 
         this.emitEvent({


### PR DESCRIPTION
## Summary
- Add `getRefIdManager().clearTargetRefs()` call to `onTargetClosed()` in session-manager.ts
- Makes `onTargetClosed()` consistent with `closeTarget()`, `deleteWorker()`, and `deleteSession()` which all clear refs

## Problem
When a target is destroyed externally (Chrome crash, user closes tab, renderer crash), `onTargetClosed()` removed from `targetToWorker` but did NOT clear RefIdManager refs. This left orphaned RefEntry objects with invalid `backendDOMNodeId` values.

## Files changed
- `src/session-manager.ts` — 4 lines added to `onTargetClosed()`

## Test plan
- [x] `npm run build` passes
- [x] Existing tests pass
- [ ] CI green

Closes part of #211 (Gap 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)