### PR TITLE
fix: clear stale refs instead of migrating invalid backendDOMNodeIds

### DIFF
--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -1316,8 +1316,9 @@ export class SessionManager {
           }
         }
 
-        // Migrate ref IDs from old target to new target
-        getRefIdManager().migrateTarget(ownerInfo.sessionId, targetId, newTargetId);
+        // Clear refs for old target — backendDOMNodeIds are invalidated after Chrome restart.
+        // The LLM will get fresh refs on the next read_page call.
+        getRefIdManager().clearTargetRefs(ownerInfo.sessionId, targetId);
 
         console.error(`[SessionManager] Re-mapped target ${targetId} → ${newTargetId} (URL: ${lastUrl})`);
         remapped++;


### PR DESCRIPTION
## Summary
- Replace `getRefIdManager().migrateTarget()` with `clearTargetRefs()` in `validateTargetsAfterReconnect()`
- After Chrome restart, ALL backendDOMNodeIds are process-local and invalid — migrating them silently preserves broken refs

## Problem
`validateTargetsAfterReconnect()` called `migrateTarget(oldId, newId)` for URL-matched tabs after Chrome restart. This moved RefEntry objects with stale backendDOMNodeId values to the new targetId, causing silent CDP `DOM.resolveNode` failures when workers tried to use migrated refs.

## Fix
Clear refs for the old target instead of migrating. The LLM will get "ref not found" and re-read the page via `read_page`, which is faster than the current silent stale-node failure → retry loop path.

## Files changed
- `src/session-manager.ts` — 3 lines changed in `validateTargetsAfterReconnect()`

## Test plan
- [x] `npm run build` passes
- [x] `npx jest tests/mcp-server.test.ts` — 31/31 pass
- [ ] CI green

Closes part of #211 (Gap 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)