### PR TITLE
fix: partition ActivityTracker and HintEngine by sessionId

### DIFF
--- a/src/dashboard/activity-tracker.ts
+++ b/src/dashboard/activity-tracker.ts
@@ -114,9 +114,21 @@ export class ActivityTracker extends EventEmitter {
   }
 
   /**
-   * Get recent completed calls
+   * Get recent completed calls.
+   * When sessionId is provided, only returns calls matching that session,
+   * preventing cross-session pollution in parallel worker scenarios.
    */
-  getRecentCalls(limit: number = 20): ToolCallEvent[] {
+  getRecentCalls(limit: number = 20, sessionId?: string): ToolCallEvent[] {
+    if (sessionId !== undefined) {
+      const filtered: ToolCallEvent[] = [];
+      for (const call of this.completedCalls) {
+        if (call.sessionId === sessionId) {
+          filtered.push(call);
+          if (filtered.length >= limit) break;
+        }
+      }
+      return filtered;
+    }
     return this.completedCalls.slice(0, limit);
   }
 

--- a/src/hints/hint-engine.ts
+++ b/src/hints/hint-engine.ts
@@ -138,9 +138,9 @@ export class HintEngine {
    * - 3-4 firings: warning (⚠️ WARNING prefix)
    * - 5+ firings:  critical (🛑 CRITICAL prefix + action history)
    */
-  getHint(toolName: string, result: Record<string, unknown>, isError: boolean): HintResult | null {
+  getHint(toolName: string, result: Record<string, unknown>, isError: boolean, sessionId?: string): HintResult | null {
     const resultText = this.extractText(result);
-    const recentCalls = this.activityTracker.getRecentCalls(5);
+    const recentCalls = this.activityTracker.getRecentCalls(5, sessionId);
 
     // Priority 50: Progress tracking (highest priority, runs before all rules)
     // NOTE: ProgressTracker returns early before the rule loop. Miss-count decay
@@ -149,9 +149,14 @@ export class HintEngine {
     // agent is not making progress.
     const status = this.progressTracker.evaluate(recentCalls, toolName, resultText, isError);
 
+    // Scope escalation keys by sessionId when available to prevent cross-session pollution
+    const escalationKey = (ruleName: string) =>
+      sessionId !== undefined ? `${sessionId}:${ruleName}` : ruleName;
+
     if (status === 'stuck') {
-      const fireCount = (this.hintEscalation.get('progress-tracker-stuck') || 0) + 1;
-      this.hintEscalation.set('progress-tracker-stuck', fireCount);
+      const key = escalationKey('progress-tracker-stuck');
+      const fireCount = (this.hintEscalation.get(key) || 0) + 1;
+      this.hintEscalation.set(key, fireCount);
       const rawHintText = 'STOP — you are stuck. The last several tool calls made no meaningful progress ' +
         '(errors, stale refs, auth redirects, or timeouts). ' +
         'Step back and try a completely different approach, or ask the user for help.';
@@ -167,8 +172,9 @@ export class HintEngine {
     }
 
     if (status === 'stalling') {
-      const fireCount = (this.hintEscalation.get('progress-tracker-stalling') || 0) + 1;
-      this.hintEscalation.set('progress-tracker-stalling', fireCount);
+      const key = escalationKey('progress-tracker-stalling');
+      const fireCount = (this.hintEscalation.get(key) || 0) + 1;
+      this.hintEscalation.set(key, fireCount);
       const rawHintText = 'Warning: recent tool calls are not making progress. ' +
         'Consider trying a different approach before getting stuck.';
       const severity = this.getSeverity(fireCount);
@@ -200,7 +206,7 @@ export class HintEngine {
         const misses = (this.missCounts.get(rule.name) || 0) + 1;
         this.missCounts.set(rule.name, misses);
         if (misses >= 10) {
-          this.hintEscalation.set(rule.name, 0);
+          this.hintEscalation.set(escalationKey(rule.name), 0);
           this.missCounts.set(rule.name, 0);
         }
       }
@@ -216,9 +222,10 @@ export class HintEngine {
       return null;
     }
 
-    // Track fire count per rule (accumulates across session, never resets)
-    const fireCount = (this.hintEscalation.get(matchedRule) || 0) + 1;
-    this.hintEscalation.set(matchedRule, fireCount);
+    // Track fire count per rule, scoped by sessionId when available
+    const matchedKey = escalationKey(matchedRule);
+    const fireCount = (this.hintEscalation.get(matchedKey) || 0) + 1;
+    this.hintEscalation.set(matchedKey, fireCount);
 
     const severity = this.getSeverity(fireCount);
     let formattedHint = this.formatHintMessage(severity, rawHint, fireCount);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -639,7 +639,7 @@ export class MCPServer {
 
       // Inject proactive hint into both _hint (backward compat) and content[] (guaranteed MCP delivery)
       if (this.hintEngine) {
-        const hintResult = this.hintEngine.getHint(toolName, result as Record<string, unknown>, false);
+        const hintResult = this.hintEngine.getHint(toolName, result as Record<string, unknown>, false, sessionId);
         if (hintResult) {
           (result as Record<string, unknown>)._hint = hintResult.hint;
           (result as Record<string, unknown>)._hintMeta = {
@@ -693,7 +693,7 @@ export class MCPServer {
 
       // Inject proactive hint for errors into both _hint and content[]
       if (this.hintEngine) {
-        const hintResult = this.hintEngine.getHint(toolName, errResult as Record<string, unknown>, true);
+        const hintResult = this.hintEngine.getHint(toolName, errResult as Record<string, unknown>, true, sessionId);
         if (hintResult) {
           (errResult as Record<string, unknown>)._hint = hintResult.hint;
           (errResult as Record<string, unknown>)._hintMeta = {


### PR DESCRIPTION
## Summary
- Add optional `sessionId` parameter to `ActivityTracker.getRecentCalls()`
- Pass `sessionId` through `HintEngine.getHint()` for session-scoped progress detection
- Key `hintEscalation` by `${sessionId}:${ruleName}` to prevent cross-session accumulation
- Wire `sessionId` from MCPServer to HintEngine on both success and error paths

## Problem
All parallel workers share one global `ActivityTracker` and one `HintEngine`. Worker A's stale-ref errors appear in Worker B's `getRecentCalls(5)` history, causing false "STOP — you are stuck" hints. `hintEscalation` counts accumulate across all workers, triggering premature critical-level hints.

## Fix
Scope activity history and escalation counters by sessionId when available. Backward compatible — when sessionId is not provided, existing behavior is preserved.

## Files changed
- `src/dashboard/activity-tracker.ts` — Add sessionId filter to `getRecentCalls()`
- `src/hints/hint-engine.ts` — Add sessionId to `getHint()`, scope escalation keys
- `src/mcp-server.ts` — Pass sessionId to `getHint()` calls

## Test plan
- [x] `npm run build` passes
- [x] Existing tests pass (backward compatible)
- [ ] CI green

Closes part of #211 (Gap 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)