### PR TITLE
fix: include available tabIds in stale target error

### DIFF
--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -905,7 +905,7 @@ export class SessionManager {
       // (we skip targetcreated indexing to prevent ghost tabs).
       const recovered = await this.tryRecoverTarget(sessionId, targetId, workerId);
       if (recovered) return recovered;
-      throw new Error(`Target ${targetId} not found in session ${sessionId}. Chrome may have been restarted. Use list_tabs or navigate to get fresh tab IDs.`);
+      throw new Error(this.buildStaleTargetError(sessionId, targetId));
     }
 
     if (workerId && ownerInfo.workerId !== workerId) {
@@ -1185,7 +1185,7 @@ export class SessionManager {
     params?: Record<string, unknown>
   ): Promise<T> {
     if (!this.validateTargetOwnership(sessionId, targetId)) {
-      throw new Error(`Target ${targetId} not found in session ${sessionId}. Chrome may have been restarted. Use list_tabs or navigate to get fresh tab IDs.`);
+      throw new Error(this.buildStaleTargetError(sessionId, targetId));
     }
 
     this.touchSession(sessionId);
@@ -1232,6 +1232,29 @@ export class SessionManager {
         });
       }
     }
+  }
+
+  /**
+   * Build an enriched error message for stale target IDs, including available tab IDs
+   * so the LLM can select the correct one without an extra tabs_context round trip.
+   */
+  private buildStaleTargetError(sessionId: string, targetId: string): string {
+    const session = this.sessions.get(sessionId);
+    const availableTabIds: string[] = [];
+
+    if (session) {
+      for (const worker of session.workers.values()) {
+        for (const tid of worker.targets) {
+          availableTabIds.push(tid);
+        }
+      }
+    }
+
+    const tabInfo = availableTabIds.length > 0
+      ? ` Available tabIds: [${availableTabIds.map(id => `"${id}"`).join(', ')}]. Use tabs_context to see their URLs and titles.`
+      : ' No tabs available in this session. Use navigate to open a new page.';
+
+    return `Target ${targetId} not found in session ${sessionId}. The tab may have been closed or Chrome may have been restarted.${tabInfo}`;
   }
 
   /**


### PR DESCRIPTION
## Summary
- When a tool call fails with "Target not found in session", the error now includes available tabIds
- LLM can select the correct tab without an extra `tabs_context` round trip
- Replaces the old generic error message at both `getPage()` and `executeCDP()` throw sites

## Before
```
Error: Target ABC123 not found in session default. Chrome may have been restarted.
Use list_tabs or navigate to get fresh tab IDs.
```

## After
```
Error: Target ABC123 not found in session default. The tab may have been closed
or Chrome may have been restarted. Available tabIds: ["DEF456", "GHI789"].
Use tabs_context to see their URLs and titles.
```

## Why not auto-retry with a new tabId?
Auto-rewriting tabId arguments is unsafe for mutating tools (click, form_input, js_eval) — the new tab may contain completely different content. This approach lets the LLM make an informed decision.

## Files changed
- `src/session-manager.ts` — New `buildStaleTargetError()` method, used at `getPage()` and `executeCDP()` error paths

## Test plan
- [x] `npm run build` passes
- [x] `npx jest tests/mcp-server.test.ts tests/tools/read-page.test.ts` — 58/58 pass
- [ ] CI green

Refs #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)