### PR TITLE
fix: check authRedirect field instead of broad regex for login hint

### DIFF
--- a/src/hints/rules/sequence-detection.ts
+++ b/src/hints/rules/sequence-detection.ts
@@ -50,7 +50,10 @@ export const sequenceDetectionRules: HintRule[] = [
     match(ctx) {
       if (ctx.toolName !== 'navigate') return null;
       if (ctx.isError) return null;  // isError paths already carry inline guidance
-      if (/login|sign.?in|log.?in|auth|oauth/i.test(ctx.resultText)) {
+      // Check for the structured authRedirect field from navigate response,
+      // not broad regex matching which causes false positives on pages
+      // containing "auth" keywords (e.g., Cloudflare Turnstile, OAuth docs).
+      if (/"authRedirect"\s*:\s*true/i.test(ctx.resultText)) {
         return 'Hint: Authentication required — login page detected. ' +
           'The user must be logged in via their Chrome profile. ' +
           'STOP trying to authenticate programmatically. ' +

--- a/tests/hints/hint-engine.test.ts
+++ b/tests/hints/hint-engine.test.ts
@@ -172,7 +172,7 @@ describe('HintEngine', () => {
   describe('sequence detection rules', () => {
     it('should detect login page after navigate', () => {
       const engine = new HintEngine(new ActivityTracker());
-      const result = makeResult('{"action":"navigate","url":"https://app.com/login","title":"Login - App"}');
+      const result = makeResult('{"action":"navigate","url":"https://app.com/dashboard","title":"App","authRedirect":true}');
       const hint = engine.getHint('navigate', result, false);
       expect(hint?.hint).toContain('login');
       expect(hint?.hint).toContain('Chrome profile');
@@ -561,7 +561,7 @@ describe('HintEngine', () => {
       const engine = new HintEngine(new ActivityTracker());
       engine.enableLogging(tmpDir);
 
-      engine.getHint('navigate', makeResult('login page'), false);
+      engine.getHint('navigate', makeResult('{"action":"navigate","url":"https://app.com","authRedirect":true}'), false);
       engine.getHint('find', makeResult('0 results'), false);
       engine.getHint('some_tool', makeResult('ok'), false);
 
@@ -628,7 +628,7 @@ describe('HintEngine', () => {
       const hint2 = engine.getHint('click_element', errResult, true);
       expect(hint2!.fireCount).toBe(2);
 
-      const navResult = makeResult('{"action":"navigate","url":"https://app.com/login","title":"Login - App"}');
+      const navResult = makeResult('{"action":"navigate","url":"https://app.com/dashboard","title":"App","authRedirect":true}');
       const loginHint = engine.getHint('navigate', navResult, false);
       expect(loginHint!.fireCount).toBe(1);
 


### PR DESCRIPTION
## Summary

Closes #223.

- The `navigate-to-login` hint rule used a broad regex `/login|sign.?in|auth|oauth/i` against the entire result text, causing false positives on pages containing "auth" keywords (e.g., Cloudflare Turnstile demos, OAuth documentation)
- Now checks for the structured `"authRedirect": true` field that the navigate tool already sets on real authentication redirects
- Updated test assertions to match the new detection pattern

## Changes

- `src/hints/rules/sequence-detection.ts`: Replace broad regex with `"authRedirect"` JSON field check
- `tests/hints/hint-engine.test.ts`: Update test cases to use `authRedirect` field

## Test plan

- [x] `npm run build` passes
- [x] Existing hint-engine tests updated and passing
- [x] Verified: Cloudflare Turnstile page no longer triggers auth hint
- [x] Verified: Real auth redirects (with `"authRedirect": true`) still trigger hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)