### PR TITLE
feat: add blocking page hint rules for CAPTCHA human-in-the-loop flow

### DIFF
--- a/src/hints/hint-engine.ts
+++ b/src/hints/hint-engine.ts
@@ -19,6 +19,7 @@ import type { ActivityTracker } from '../dashboard/activity-tracker';
 import { PatternLearner } from './pattern-learner';
 import { ProgressTracker } from './progress-tracker.js';
 import { errorRecoveryRules } from './rules/error-recovery';
+import { blockingPageRules } from './rules/blocking-page';
 import { compositeSuggestionRules } from './rules/composite-suggestions';
 import { sequenceDetectionRules } from './rules/sequence-detection';
 import { repetitionDetectionRules } from './rules/repetition-detection';
@@ -95,6 +96,7 @@ export class HintEngine {
     this.rules = [
       ...setupHintRules,             // priority 90
       ...errorRecoveryRules,         // priority 100-108
+      ...blockingPageRules,          // priority 120-122
       ...paginationDetectionRules,   // priority 190-192
       ...compositeSuggestionRules,   // priority 200-203
       ...repetitionDetectionRules,   // priority 245-252

--- a/src/hints/rules/blocking-page.ts
+++ b/src/hints/rules/blocking-page.ts
@@ -1,0 +1,63 @@
+/**
+ * Blocking Page Rules — detect CAPTCHAs, bot-checks, and access-denied pages.
+ * Fires on successful navigate results that contain a blockingPage field,
+ * providing immediate guidance instead of waiting for the progress tracker.
+ */
+
+import type { HintRule } from '../hint-engine';
+
+export const blockingPageRules: HintRule[] = [
+  {
+    name: 'captcha-detected',
+    priority: 120, // Higher than error-recovery (100-108), lower than navigate-to-login (150)
+    match(ctx) {
+      if (ctx.toolName !== 'navigate') return null;
+      if (ctx.isError) return null;
+
+      // Check for structured blockingPage field in navigate response
+      if (/"blockingPage"\s*:\s*\{[^}]*"type"\s*:\s*"captcha"/i.test(ctx.resultText)) {
+        return (
+          'Hint: CAPTCHA detected on this page. OpenChrome cannot solve CAPTCHAs programmatically. ' +
+          'STOP all interaction attempts with this page. ' +
+          'Ask the user to solve the CAPTCHA in their Chrome browser, then use wait_for to detect when the page changes, and resume automation.'
+        );
+      }
+
+      return null;
+    },
+  },
+  {
+    name: 'bot-check-detected',
+    priority: 121,
+    match(ctx) {
+      if (ctx.toolName !== 'navigate') return null;
+      if (ctx.isError) return null;
+
+      if (/"blockingPage"\s*:\s*\{[^}]*"type"\s*:\s*"bot-check"/i.test(ctx.resultText)) {
+        return (
+          'Hint: Bot verification detected. OpenChrome cannot bypass bot checks. ' +
+          'Ask the user to complete the verification in their Chrome browser, then retry navigation.'
+        );
+      }
+
+      return null;
+    },
+  },
+  {
+    name: 'access-denied-detected',
+    priority: 122,
+    match(ctx) {
+      if (ctx.toolName !== 'navigate') return null;
+      if (ctx.isError) return null;
+
+      if (/"blockingPage"\s*:\s*\{[^}]*"type"\s*:\s*"access-denied"/i.test(ctx.resultText)) {
+        return (
+          'Hint: Access denied (403/Forbidden). The site may be blocking automated access. ' +
+          'Ask the user to verify they have permission to access this URL, or try navigating in their Chrome browser first.'
+        );
+      }
+
+      return null;
+    },
+  },
+];

--- a/tests/hints/blocking-page.test.ts
+++ b/tests/hints/blocking-page.test.ts
@@ -1,0 +1,87 @@
+/// <reference types="jest" />
+
+import { blockingPageRules } from '../../src/hints/rules/blocking-page';
+import type { HintContext } from '../../src/hints/hint-engine';
+
+function makeCtx(overrides: Partial<HintContext>): HintContext {
+  return {
+    toolName: 'navigate',
+    resultText: '',
+    isError: false,
+    recentCalls: [],
+    fireCounts: new Map(),
+    ...overrides,
+  };
+}
+
+describe('Blocking Page Rules', () => {
+  const captchaRule = blockingPageRules.find(r => r.name === 'captcha-detected')!;
+  const botCheckRule = blockingPageRules.find(r => r.name === 'bot-check-detected')!;
+  const accessDeniedRule = blockingPageRules.find(r => r.name === 'access-denied-detected')!;
+
+  describe('captcha-detected', () => {
+    it('should fire when blockingPage type is captcha', () => {
+      const ctx = makeCtx({
+        resultText: JSON.stringify({
+          action: 'navigate',
+          url: 'https://example.com',
+          blockingPage: { type: 'captcha', detail: 'Cloudflare Turnstile' },
+        }),
+      });
+      expect(captchaRule.match(ctx)).toContain('CAPTCHA detected');
+    });
+
+    it('should not fire on normal navigate results', () => {
+      const ctx = makeCtx({
+        resultText: JSON.stringify({
+          action: 'navigate',
+          url: 'https://example.com',
+          title: 'Example',
+        }),
+      });
+      expect(captchaRule.match(ctx)).toBeNull();
+    });
+
+    it('should not fire on error results', () => {
+      const ctx = makeCtx({
+        isError: true,
+        resultText: JSON.stringify({
+          blockingPage: { type: 'captcha' },
+        }),
+      });
+      expect(captchaRule.match(ctx)).toBeNull();
+    });
+
+    it('should not fire on non-navigate tools', () => {
+      const ctx = makeCtx({
+        toolName: 'read_page',
+        resultText: JSON.stringify({
+          blockingPage: { type: 'captcha' },
+        }),
+      });
+      expect(captchaRule.match(ctx)).toBeNull();
+    });
+  });
+
+  describe('bot-check-detected', () => {
+    it('should fire when blockingPage type is bot-check', () => {
+      const ctx = makeCtx({
+        resultText: JSON.stringify({
+          blockingPage: { type: 'bot-check', detail: 'Verify you are human' },
+        }),
+      });
+      expect(botCheckRule.match(ctx)).toContain('Bot verification');
+    });
+  });
+
+  describe('access-denied-detected', () => {
+    it('should fire when blockingPage type is access-denied', () => {
+      const ctx = makeCtx({
+        resultText: JSON.stringify({
+          blockingPage: { type: 'access-denied', detail: '403 Forbidden' },
+        }),
+      });
+      expect(accessDeniedRule.match(ctx)).toContain('Access denied');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #221.

When OpenChrome encounters a CAPTCHA (e.g., Cloudflare Turnstile), the progress tracker only kicked in after 3-5 wasted tool calls. This PR adds immediate hint rules that fire on first detection, telling the LLM to stop and ask the user to solve the CAPTCHA in their browser.

## Design Philosophy: Human-in-the-Loop

Unlike headless automation tools, OpenChrome connects to the **user's real browser**. The user and OpenChrome share the same Chrome window. This enables a unique pattern:

```
CAPTCHA detected → Notify LLM immediately → LLM asks user to solve in browser → User solves → Automation resumes
```

This is analogous to autonomous driving: the car doesn't shut down at a construction zone — it asks the driver to take over, then resumes once through.

## Changes

### New file: `src/hints/rules/blocking-page.ts`
Three hint rules (priority 120-122):
- **`captcha-detected`**: Fires when `blockingPage.type === "captcha"` — instructs LLM to ask user to solve CAPTCHA in browser, then use `wait_for` to detect resolution
- **`bot-check-detected`**: Fires when `blockingPage.type === "bot-check"` — instructs LLM to ask user to complete verification
- **`access-denied-detected`**: Fires when `blockingPage.type === "access-denied"` — instructs LLM to verify URL access

### `src/hints/hint-engine.ts`
- Import and register `blockingPageRules` in the rules array

### New file: `tests/hints/blocking-page.test.ts`
- 6 tests covering all three rules with positive matches and negative guards

## Test plan

- [x] `npm run build` passes
- [x] 6/6 new tests passing
- [x] Rules correctly fire only on `navigate` tool results with `blockingPage` field
- [x] Rules correctly skip error results and non-navigate tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)