### PR TITLE
fix: exempt batch-oriented tools from same-tool-same-result hint rule

### DIFF
--- a/src/hints/rules/repetition-detection.ts
+++ b/src/hints/rules/repetition-detection.ts
@@ -33,9 +33,20 @@ function detectOscillation(ctx: HintContext): boolean {
 }
 
 /**
+ * Tools where sequential repeated calls are expected batch behavior,
+ * not a sign of being stuck. These are exempt from same-tool-same-result.
+ */
+const BATCH_EXEMPT_TOOLS = new Set([
+  'tabs_create',
+  'tabs_close',
+  'navigate',
+]);
+
+/**
  * Detect same tool called repeatedly with same result (non-error).
  */
 function sameToolSameResult(ctx: HintContext): boolean {
+  if (BATCH_EXEMPT_TOOLS.has(ctx.toolName)) return false;
   if (ctx.recentCalls.length < 2) return false;
   const prev = ctx.recentCalls[0];
   const prevPrev = ctx.recentCalls[1];

--- a/tests/hints/hint-engine.test.ts
+++ b/tests/hints/hint-engine.test.ts
@@ -291,6 +291,24 @@ describe('HintEngine', () => {
       expect(hint).not.toBeNull();
     });
 
+    it('should NOT trigger same-tool-same-result for batch-exempt tools (tabs_create, navigate, tabs_close)', () => {
+      for (const tool of ['tabs_create', 'navigate', 'tabs_close']) {
+        const tracker = makeTracker([
+          { toolName: tool },
+          { toolName: tool },
+          { toolName: tool },
+          { toolName: tool },
+        ]);
+        const engine = new HintEngine(tracker);
+        const result = makeResult(`{"tabId":"abc","url":"https://example.com"}`);
+        const hint = engine.getHint(tool, result, false);
+        // Should not match same-tool-same-result; may match other rules (e.g. pagination for navigate)
+        if (hint) {
+          expect(hint.rule).not.toBe('same-tool-same-result');
+        }
+      }
+    });
+
     it('should not trigger on mixed tool calls', () => {
       // makeTracker reverses input, so first element becomes most recent in getRecentCalls.
       // Put 'find' first so recentCalls[0]='find' — not an action trigger for state-check-after-action.


### PR DESCRIPTION
## Summary

- The `same-tool-same-result` hint rule (priority 252) incorrectly fires on **legitimate batch operations** like `tabs_create`, `navigate`, and `tabs_close`
- Combined with the escalation system (#71), fire counts accumulate to 69x+ `🛑 CRITICAL` across the session, completely blocking normal parallel browser workflows (e.g., opening 20 tabs for batch scraping)
- Add `BATCH_EXEMPT_TOOLS` set to exempt these tools from the repetition rule
- Add test verifying all three batch-exempt tools are excluded

### Root cause
`same-tool-same-result` matches when the same tool succeeds 3+ times in a row. This was designed for stuck-detection, but `tabs_create × 20` is the expected pattern for parallel scraping. The miss-count decay (10 consecutive misses → reset) never triggers during batch ops because every call matches.

Closes #227

## Test plan
- [x] `npx jest tests/hints/hint-engine.test.ts` — 61 tests pass
- [x] New test: `should NOT trigger same-tool-same-result for batch-exempt tools`
- [x] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)