### PR TITLE
fix: add maxSeverity caps to sequence-detection rules, remove duplicate

### DIFF
--- a/src/hints/rules/sequence-detection.ts
+++ b/src/hints/rules/sequence-detection.ts
@@ -8,19 +8,11 @@ function lastToolWas(ctx: HintContext, name: string): boolean {
   return ctx.recentCalls.length > 0 && ctx.recentCalls[0].toolName === name;
 }
 
-function consecutiveCount(ctx: HintContext, name: string): number {
-  let count = 0;
-  for (const call of ctx.recentCalls) {
-    if (call.toolName === name) count++;
-    else break;
-  }
-  return count;
-}
-
 export const sequenceDetectionRules: HintRule[] = [
   {
     name: 'post-scroll-click',
     priority: 299, // Just before existing sequence rules (300-304)
+    maxSeverity: 'warning',
     match(ctx) {
       if (ctx.toolName !== 'computer') return null;
 
@@ -47,6 +39,7 @@ export const sequenceDetectionRules: HintRule[] = [
   {
     name: 'navigate-to-login',
     priority: 150,  // Between error-recovery (100-108) and pagination (190)
+    // No maxSeverity cap — genuine auth detection, critical escalation is appropriate
     match(ctx) {
       if (ctx.toolName !== 'navigate') return null;
       if (ctx.isError) return null;  // isError paths already carry inline guidance
@@ -63,19 +56,9 @@ export const sequenceDetectionRules: HintRule[] = [
     },
   },
   {
-    name: 'repeated-read-page',
-    priority: 301,
-    match(ctx) {
-      if (ctx.toolName !== 'read_page') return null;
-      if (consecutiveCount(ctx, 'read_page') >= 2) {
-        return 'Hint: Use find(query) or javascript_tool for specific elements.';
-      }
-      return null;
-    },
-  },
-  {
     name: 'navigate-then-screenshot',
     priority: 302,
+    maxSeverity: 'info',
     match(ctx) {
       if (ctx.toolName !== 'computer') return null;
       if (!ctx.resultText.includes('screenshot')) return null;
@@ -86,6 +69,7 @@ export const sequenceDetectionRules: HintRule[] = [
   {
     name: 'modal-close-failure',
     priority: 303,
+    maxSeverity: 'warning',
     match(ctx) {
       if (ctx.toolName !== 'find' && ctx.toolName !== 'read_page') return null;
       if (!lastToolWas(ctx, 'click_element')) return null;
@@ -98,6 +82,7 @@ export const sequenceDetectionRules: HintRule[] = [
   {
     name: 'navigate-to-demo',
     priority: 304,
+    maxSeverity: 'info',
     match(ctx) {
       if (ctx.toolName !== 'navigate') return null;
       if (ctx.isError) return null;

--- a/tests/hints/hint-engine.test.ts
+++ b/tests/hints/hint-engine.test.ts
@@ -678,16 +678,10 @@ describe('HintEngine', () => {
     });
 
     it('should not escalate beyond maxSeverity cap', () => {
-      // The getSeverity method with maxSeverity='warning' should cap at warning.
-      // We test this by checking that rules with maxSeverity exist in the interface.
-      // The actual rule-level caps are added in subsequent PRs per rule file.
       const engine = new HintEngine(new ActivityTracker());
       const rules = engine.getRules();
 
-      // Verify the HintRule interface supports maxSeverity
-      // All existing rules currently have maxSeverity undefined
       for (const rule of rules) {
-        // maxSeverity is optional — undefined means no cap (defaults to critical)
         expect(rule.maxSeverity === undefined || ['info', 'warning', 'critical'].includes(rule.maxSeverity)).toBe(true);
       }
     });
@@ -712,6 +706,31 @@ describe('HintEngine', () => {
       expect(lastHint!.fireCount).toBeGreaterThanOrEqual(5);
       expect(lastHint!.severity).toBe('warning');
       expect(lastHint!.hint).not.toContain('CRITICAL');
+    });
+
+    it('should cap navigate-to-demo at info severity', () => {
+      const tracker = makeTracker([]);
+      const engine = new HintEngine(tracker);
+      const result = makeResult('{"url":"http://localhost:3000/page","title":"Dev App"}');
+
+      let lastHint;
+      for (let i = 0; i < 10; i++) {
+        lastHint = engine.getHint('navigate', result, false);
+      }
+
+      if (lastHint && lastHint.rule === 'navigate-to-demo') {
+        expect(lastHint.severity).toBe('info');
+        expect(lastHint.hint).not.toContain('WARNING');
+        expect(lastHint.hint).not.toContain('CRITICAL');
+      }
+    });
+
+    it('should not have duplicate repeated-read-page rules', () => {
+      const engine = new HintEngine(new ActivityTracker());
+      const rules = engine.getRules();
+      const readPageRules = rules.filter(r => r.name === 'repeated-read-page');
+      expect(readPageRules).toHaveLength(1);
+      expect(readPageRules[0].priority).toBe(207);
     });
   });
 


### PR DESCRIPTION
## Summary

- **Remove duplicate `repeated-read-page` rule** (priority 301) that shared fire counts with the composite-suggestions version (priority 207), doubling escalation rate
- Remove unused `consecutiveCount` helper function
- Add `maxSeverity` caps to advisory rules:
  - `info`: navigate-to-demo, navigate-then-screenshot (one-time awareness)
  - `warning`: post-scroll-click, modal-close-failure (pattern advisory)
  - No cap: navigate-to-login (genuine auth detection, CRITICAL appropriate)

Depends on #238. Closes #230, #235.

## Test plan
- [x] `npm run build` passes
- [x] 64 tests pass
- [x] New test: `should cap navigate-to-demo at info severity`
- [x] New test: `should not have duplicate repeated-read-page rules`

🤖 Generated with [Claude Code](https://claude.com/claude-code)