### PR TITLE
fix: always use persistent profile for auto-launched Chrome (Chrome 136+)

### DIFF
--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -355,7 +355,10 @@ export class ChromeLauncher {
     // Priority: explicit > temp/headless > real unlocked > persistent (with sync) > persistent (no sync)
     const realProfileDir = this.getRealChromeProfileDir();
     const explicitUserDataDir = options.userDataDir || globalConfig.userDataDir;
-    // Skip expensive isProfileLocked check when result won't be used
+    // Skip expensive isProfileLocked check when result won't be used:
+    // explicit dir, temp profile, headless-shell, or no real profile.
+    // Note: isAutoLaunch routes to persistent profile regardless of lock state,
+    // but the lock check is still useful for cookie sync decisions in resolveProfile.
     const isLocked = (!explicitUserDataDir && !options.useTempProfile && !usingHeadlessShell && realProfileDir)
       ? this.isProfileLocked(realProfileDir)
       : false;

--- a/src/chrome/profile-manager.ts
+++ b/src/chrome/profile-manager.ts
@@ -432,9 +432,10 @@ export class ProfileManager {
    * Priority order:
    * 1. `explicitUserDataDir` — caller has specified an exact directory.
    * 2. `useTempProfile` or `usingHeadlessShell` — create a fresh temp dir.
-   * 3. `realProfileDir` exists and **not** locked — use real profile directly.
-   * 4. `realProfileDir` exists and **is** locked — use persistent profile,
-   *    syncing cookies from the real profile when stale.
+   * 3. `realProfileDir` exists, **not** locked, and `isAutoLaunch` is false —
+   *    use real profile directly.
+   * 4. `realProfileDir` exists and is **locked**, OR `isAutoLaunch` is true —
+   *    use persistent profile, syncing cookies from the real profile when stale.
    * 5. No `realProfileDir` — use persistent profile without a sync.
    */
   resolveProfile(options: {

--- a/tests/chrome/persistent-profile.test.ts
+++ b/tests/chrome/persistent-profile.test.ts
@@ -626,6 +626,21 @@ describe('ProfileManager', () => {
       expect(result.profileType).toBe('explicit');
       expect(result.userDataDir).toBe('/my/custom/dir');
     });
+
+    it('should return persistent profile when isAutoLaunch is true and profile is also locked', () => {
+      const manager = new ProfileManager();
+      jest.spyOn(manager, 'needsSync').mockReturnValue(false);
+      jest.spyOn(manager, 'getOrCreatePersistentProfile').mockReturnValue('/mock/persistent');
+
+      const result = manager.resolveProfile({
+        realProfileDir: '/real/chrome/profile',
+        isProfileLocked: true,
+        isAutoLaunch: true,
+      });
+
+      expect(result.profileType).toBe('persistent');
+      expect(result.userDataDir).toBe('/mock/persistent');
+    });
   });
 
   // =========================================================================


### PR DESCRIPTION
## Summary

- When OpenChrome auto-launches Chrome, always use the persistent profile (`~/.openchrome/profile/`) instead of the user's default Chrome profile directory
- Chrome 136+ rejects `--remote-debugging-port` when `--user-data-dir` points to the default data directory — this ensures a non-default path is always used
- Cookie sync from the real profile is performed automatically, preserving authentication

## Root Cause

Chrome 136 introduced a security restriction: remote debugging requires a **non-default** `--user-data-dir`. When the real profile was not locked, OpenChrome passed the default Chrome directory, which Chrome 136+ silently rejected — the debug port never opened, causing a 60-second timeout.

## Changes

- `ProfileManager.resolveProfile()`: Added `isAutoLaunch` option. When true, skips using the real profile directly and falls through to persistent profile with cookie sync
- `ChromeLauncher.launchChrome()`: Passes `isAutoLaunch: true` to `resolveProfile()`
- Backward compatible: attaching to user-started Chrome (non-auto-launch) still uses real profile when available

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 39 persistent-profile tests pass
- [x] New tests verify: auto-launch → persistent, non-auto-launch → real (backward compat), explicit `--user-data-dir` takes priority
- [ ] Manual: verify Chrome 136+ auto-launch no longer times out

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)