### PR TITLE
fix: improve Windows profile lock detection with process verification

### DIFF
--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -675,8 +675,8 @@ export class ChromeLauncher {
    * On Unix, validates SingletonLock symlink targets by checking if the PID is alive,
    * so stale lock files from crashed Chrome instances are correctly ignored.
    */
-  private isProfileLocked(profileDir: string, _platform?: string): boolean {
-    const platform = _platform || os.platform();
+  private isProfileLocked(profileDir: string, platformOverride?: string): boolean {
+    const platform = platformOverride || os.platform();
     if (platform === 'win32') {
       // Windows Chrome uses a 'lockfile' in the user data directory
       const lockFile = path.join(profileDir, 'lockfile');
@@ -693,9 +693,10 @@ export class ChromeLauncher {
           'wmic process where "name=\'chrome.exe\'" get CommandLine 2>nul',
           { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 5000 }
         );
-        // Normalize path separators for comparison
-        const normalizedProfileDir = profileDir.replace(/\\/g, '\\\\').toLowerCase();
-        if (output.toLowerCase().includes(normalizedProfileDir)) {
+        // Normalize path separators for comparison (forward-slash on both sides)
+        const normalizedProfileDir = profileDir.replace(/\\/g, '/').toLowerCase();
+        const normalizedOutput = output.replace(/\\/g, '/').toLowerCase();
+        if (normalizedOutput.includes(normalizedProfileDir)) {
           console.error(`[ChromeLauncher] Profile locked: chrome.exe running with ${profileDir}`);
           return true;
         }

--- a/tests/chrome/launcher-port-race.test.ts
+++ b/tests/chrome/launcher-port-race.test.ts
@@ -163,7 +163,7 @@ describe('ChromeLauncher port race condition fixes', () => {
   });
 
   describe('Windows isProfileLocked() process verification', () => {
-    // isProfileLocked accepts an optional _platform parameter for testing,
+    // isProfileLocked accepts an optional platformOverride parameter for testing,
     // since os.platform is a non-configurable getter that cannot be mocked.
 
     afterEach(() => {


### PR DESCRIPTION
## Summary

- Windows `isProfileLocked()` now cross-checks running `chrome.exe` processes when `lockfile` is absent
- Uses a 3-tier fallback strategy: `wmic` (Win10) → PowerShell `Get-CimInstance` (Win11) → `tasklist` (universal)
- For the `tasklist` fallback (can't determine specific profile), assumes locked only when `profileDir` is the default Chrome directory

## Root Cause

The Windows lock detection previously only checked for `lockfile` existence in the user data directory. Chrome on Windows may not always create this file reliably, or it may be in a subdirectory. This caused `isProfileLocked()` to return `false` even when Chrome was running with the same profile, leading to profile conflicts.

## Changes

- `ChromeLauncher.isProfileLocked()`: Added optional `_platform` parameter for testability. After lockfile check, queries process command lines via `wmic` → PowerShell → `tasklist` fallback chain
- All `execSync` calls use `stdio: ['ignore', 'pipe', 'ignore']` and timeouts (5-8s) to prevent hanging
- 7 new tests covering all fallback paths, mocked with real temp directories

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 15 launcher-port-race tests pass (7 new)
- [x] Tests run cross-platform (use `_platform` param instead of mocking `os.platform()`)
- [ ] Manual: verify on Windows 10 (wmic) and Windows 11 (PowerShell fallback)

Ref #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)