### PR TITLE
fix: add input type attribute as tie-breaker in fill_form field matching (#252)

### DIFF
--- a/src/tools/fill-form.ts
+++ b/src/tools/fill-form.ts
@@ -255,6 +255,13 @@ const handler: ToolHandler = async (
           if (keyLower.includes(labelLower) && labelLower.length > 2) score += 30;
           if (keyLower.includes(nameLower) && nameLower.length > 2) score += 25;
 
+          // Type attribute tie-breaker (lower priority than label/name/placeholder)
+          const typeLower = field.type?.toLowerCase() || '';
+          if (typeLower && typeLower !== 'text') { // 'text' is too generic to match
+            if (typeLower === keyLower) score += 20;
+            else if (keyLower.includes(typeLower) || typeLower.includes(keyLower)) score += 10;
+          }
+
           if (score > bestScore) {
             bestScore = score;
             bestMatch = field;
@@ -262,7 +269,7 @@ const handler: ToolHandler = async (
         }
 
         if (!bestMatch || bestScore < 20) {
-          const foundFieldNames = formFields.map(f => f.label || f.name || f.placeholder || f.ariaLabel).filter(Boolean) as string[];
+          const foundFieldNames = formFields.map(f => f.label || f.name || f.placeholder || f.ariaLabel || (f.type && f.type !== 'text' ? `[type=${f.type}]` : null)).filter(Boolean) as string[];
           errors.push(`Could not find field matching "${fieldKey}". Available fields: [${foundFieldNames.join(', ')}]`);
           continue;
         }


### PR DESCRIPTION
## Summary

- `fill_form` scored fields on label (100), name (90), placeholder (80), aria-label (80) but ignored the `type` attribute entirely
- When a login page has `<input type="email">` with no label/name/placeholder, the field couldn't be matched to "email"
- Add type attribute as a low-priority tie-breaker (+20 exact, +10 contains) that doesn't override explicit labels but catches edge cases
- Skip `type="text"` as too generic to be a useful match signal
- Include `[type=X]` in the error message's available fields list for better diagnostics

## Changes

- `src/tools/fill-form.ts`: Add type attribute scoring after existing reverse-contains section, update error message field list

## Test plan

- [ ] Verify `npm run build` passes
- [ ] Verify `npm test` passes
- [ ] `fill_form` with `fields: { "email": "test@example.com" }` matches `<input type="email">` even without label
- [ ] `fill_form` with `fields: { "password": "secret" }` matches `<input type="password">` even without label
- [ ] Existing label/name/placeholder matches are unaffected (higher score)
- [ ] Error message shows `[type=email]` when field has no other identifiers

Closes #252 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)