### PR TITLE
fix: move session init inside try/catch to prevent JSON-RPC -32603 errors

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -525,27 +525,27 @@ export class MCPServer {
       this.expandToolTier(toolTier);
     }
 
-    // Ensure session exists.
-    // Use a longer timeout when autoLaunch is enabled because Chrome launch (up to 30s)
-    // + puppeteer.connect (up to 15s) can exceed the default 30s session init timeout.
-    if (sessionId && !SKIP_SESSION_INIT_TOOLS.has(toolName)) {
-      const globalConfig = getGlobalConfig();
-      const sessionInitTimeout = globalConfig.autoLaunch
-        ? DEFAULT_SESSION_INIT_TIMEOUT_AUTO_LAUNCH_MS
-        : DEFAULT_SESSION_INIT_TIMEOUT_MS;
-      let sessionInitTid: ReturnType<typeof setTimeout>;
-      await Promise.race([
-        this.sessionManager.getOrCreateSession(sessionId).finally(() => clearTimeout(sessionInitTid)),
-        new Promise<never>((_, reject) => {
-          sessionInitTid = setTimeout(() => reject(new Error(`Session initialization timed out after ${sessionInitTimeout}ms`)), sessionInitTimeout);
-        }),
-      ]);
-    }
-
     // Start activity tracking
     const callId = this.activityTracker!.startCall(toolName, sessionId || 'default', toolArgs, requestId);
 
     try {
+      // Ensure session exists.
+      // Use a longer timeout when autoLaunch is enabled because Chrome launch (up to 30s)
+      // + puppeteer.connect (up to 15s) can exceed the default 30s session init timeout.
+      if (sessionId && !SKIP_SESSION_INIT_TOOLS.has(toolName)) {
+        const globalConfig = getGlobalConfig();
+        const sessionInitTimeout = globalConfig.autoLaunch
+          ? DEFAULT_SESSION_INIT_TIMEOUT_AUTO_LAUNCH_MS
+          : DEFAULT_SESSION_INIT_TIMEOUT_MS;
+        let sessionInitTid: ReturnType<typeof setTimeout>;
+        await Promise.race([
+          this.sessionManager.getOrCreateSession(sessionId).finally(() => clearTimeout(sessionInitTid)),
+          new Promise<never>((_, reject) => {
+            sessionInitTid = setTimeout(() => reject(new Error(`Session initialization timed out after ${sessionInitTimeout}ms`)), sessionInitTimeout);
+          }),
+        ]);
+      }
+
       // Wait at gate if paused
       if (this.operationController) {
         let gateTid: ReturnType<typeof setTimeout>;


### PR DESCRIPTION
## Summary

- **P0 structural fix**: Session initialization (`getOrCreateSession` + timeout race) was outside the tool-level try/catch block in `handleToolsCall()`. When `puppeteer.connect()` or session init timed out, the error propagated to `handleRequest()` which wrapped it as a JSON-RPC `-32603` protocol error instead of an `MCPResult`.
- Protocol-level `-32603` errors may cause Claude Code to cancel parallel sibling tool calls, creating cascade failures.
- Moving session init inside the try block ensures these errors are caught by the existing error handler and returned as `MCPResult` with `isError:true` and reconnection guidance.

## Changes

- `src/mcp-server.ts`: Move session init block (lines 528-543) inside the try/catch at line 548, before the operation gate check. Activity tracking (`startCall`) stays before the try block so errors are still tracked.

## Test plan

- [ ] Verify `npm run build` passes
- [ ] Verify `npm test` passes (1411/1412, 1 pre-existing skip)
- [ ] Test with Chrome not running: tool call should return MCPResult error, not JSON-RPC -32603
- [ ] Test parallel tool calls: one session init timeout should not cancel siblings

Closes #252 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)