### PR TITLE
feat: add elementCount to navigate response for SPA readiness

### DIFF
--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -12,6 +12,7 @@ import { generateVisualSummary } from '../utils/visual-summary';
 import { AdaptiveScreenshot } from '../utils/adaptive-screenshot';
 import { assertDomainAllowed } from '../security/domain-guard';
 import { detectBlockingPage } from '../utils/page-diagnostics';
+import { withTimeout } from '../utils/with-timeout';
 
 const definition: MCPToolDefinition = {
   name: 'navigate',
@@ -136,6 +137,16 @@ const handler: ToolHandler = async (
                 new Promise<null>(resolve => setTimeout(() => resolve(null), 5000)),
               ]).catch(e => { console.error('[navigate] detectBlockingPage error (tab-reuse):', e); return null; }),
             ]);
+            // Get element count for SPA readiness visibility
+            let reuseElementCount = 0;
+            try {
+              reuseElementCount = await withTimeout(
+                page.evaluate(() => document.querySelectorAll('*').length),
+                3000, 'elementCount'
+              );
+            } catch {
+              // Non-critical — proceed without count
+            }
             const reuseResultText = JSON.stringify({
               action: 'navigate',
               url: page.url(),
@@ -143,6 +154,7 @@ const handler: ToolHandler = async (
               tabId: existingTabId,
               workerId: resolvedWorkerId,
               reused: true,
+              elementCount: reuseElementCount,
               ...(summary && { visualSummary: summary }),
               ...(reuseBlocking && { blockingPage: reuseBlocking }),
             });
@@ -164,6 +176,16 @@ const handler: ToolHandler = async (
           new Promise<null>(resolve => setTimeout(() => resolve(null), 5000)),
         ]).catch(e => { console.error('[navigate] detectBlockingPage error (new-tab):', e); return null; }),
       ]);
+      // Get element count for SPA readiness visibility
+      let newTabElementCount = 0;
+      try {
+        newTabElementCount = await withTimeout(
+          page.evaluate(() => document.querySelectorAll('*').length),
+          3000, 'elementCount'
+        );
+      } catch {
+        // Non-critical — proceed without count
+      }
       const newTabResultText = JSON.stringify({
         action: 'navigate',
         url: page.url(),
@@ -171,6 +193,7 @@ const handler: ToolHandler = async (
         tabId: targetId,
         workerId: assignedWorkerId,
         created: true,
+        elementCount: newTabElementCount,
         ...(newTabSummary && { visualSummary: newTabSummary }),
         ...(newTabBlocking && { blockingPage: newTabBlocking }),
       });
@@ -230,10 +253,21 @@ const handler: ToolHandler = async (
           new Promise<null>(resolve => setTimeout(() => resolve(null), 5000)),
         ]).catch(e => { console.error('[navigate] detectBlockingPage error (back):', e); return null; }),
       ]);
+      // Get element count for SPA readiness visibility
+      let backElementCount = 0;
+      try {
+        backElementCount = await withTimeout(
+          page.evaluate(() => document.querySelectorAll('*').length),
+          3000, 'elementCount'
+        );
+      } catch {
+        // Non-critical — proceed without count
+      }
       const backResultText = JSON.stringify({
         action: 'back',
         url: page.url(),
         title: await safeTitle(page),
+        elementCount: backElementCount,
         ...(backSummary && { visualSummary: backSummary }),
         ...(backBlocking && { blockingPage: backBlocking }),
       });
@@ -252,10 +286,21 @@ const handler: ToolHandler = async (
           new Promise<null>(resolve => setTimeout(() => resolve(null), 5000)),
         ]).catch(e => { console.error('[navigate] detectBlockingPage error (forward):', e); return null; }),
       ]);
+      // Get element count for SPA readiness visibility
+      let fwdElementCount = 0;
+      try {
+        fwdElementCount = await withTimeout(
+          page.evaluate(() => document.querySelectorAll('*').length),
+          3000, 'elementCount'
+        );
+      } catch {
+        // Non-critical — proceed without count
+      }
       const fwdResultText = JSON.stringify({
         action: 'forward',
         url: page.url(),
         title: await safeTitle(page),
+        elementCount: fwdElementCount,
         ...(fwdSummary && { visualSummary: fwdSummary }),
         ...(fwdBlocking && { blockingPage: fwdBlocking }),
       });
@@ -348,10 +393,21 @@ const handler: ToolHandler = async (
         new Promise<null>(resolve => setTimeout(() => resolve(null), 5000)),
       ]).catch(e => { console.error('[navigate] detectBlockingPage error (existing-tab):', e); return null; }),
     ]);
+    // Get element count for SPA readiness visibility
+    let navElementCount = 0;
+    try {
+      navElementCount = await withTimeout(
+        page.evaluate(() => document.querySelectorAll('*').length),
+        3000, 'elementCount'
+      );
+    } catch {
+      // Non-critical — proceed without count
+    }
     const navResultText = JSON.stringify({
       action: 'navigate',
       url: page.url(),
       title: await safeTitle(page),
+      elementCount: navElementCount,
       ...(navSummary && { visualSummary: navSummary }),
       ...(navBlocking && { blockingPage: navBlocking }),
     });

--- a/tests/tools/navigate.test.ts
+++ b/tests/tools/navigate.test.ts
@@ -522,4 +522,99 @@ describe('NavigateTool', () => {
       expect(parsed.message).toContain('accounts.google.com');
     });
   });
+
+  describe('Element Count (SPA Readiness)', () => {
+    beforeEach(() => {
+      mockSmartGotoFn.mockResolvedValue({ response: null });
+    });
+
+    test('navigate response includes elementCount field', async () => {
+      const handler = await getNavigateHandler();
+      const page = (await mockSessionManager.getPage(testSessionId, testTargetId))!;
+      (page.url as jest.Mock).mockReturnValue('https://example.com');
+      (page.title as jest.Mock).mockResolvedValue('Example');
+      (page.evaluate as jest.Mock).mockResolvedValue(42);
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        url: 'https://example.com',
+      }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.elementCount).toBeDefined();
+      expect(typeof parsed.elementCount).toBe('number');
+    });
+
+    test('elementCount value appears in response text', async () => {
+      const handler = await getNavigateHandler();
+      const page = (await mockSessionManager.getPage(testSessionId, testTargetId))!;
+      (page.url as jest.Mock).mockReturnValue('https://example.com');
+      (page.title as jest.Mock).mockResolvedValue('Example');
+      (page.evaluate as jest.Mock).mockResolvedValue(1234);
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        url: 'https://example.com',
+      }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.elementCount).toBe(1234);
+      expect(result.content[0].text).toContain('1234');
+    });
+
+    test('navigate succeeds even when page.evaluate throws for elementCount', async () => {
+      const handler = await getNavigateHandler();
+      const page = (await mockSessionManager.getPage(testSessionId, testTargetId))!;
+      (page.url as jest.Mock).mockReturnValue('https://example.com');
+      (page.title as jest.Mock).mockResolvedValue('Example');
+      (page.evaluate as jest.Mock).mockRejectedValue(new Error('Execution context was destroyed'));
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        url: 'https://example.com',
+      }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      // Navigation must still succeed
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.action).toBe('navigate');
+      // elementCount falls back to 0 on failure
+      expect(parsed.elementCount).toBe(0);
+    });
+
+    test('back navigation response includes elementCount', async () => {
+      const handler = await getNavigateHandler();
+      const page = (await mockSessionManager.getPage(testSessionId, testTargetId))!;
+      (page.url as jest.Mock).mockReturnValue('https://previous.example.com');
+      (page.title as jest.Mock).mockResolvedValue('Previous');
+      (page.evaluate as jest.Mock).mockResolvedValue(55);
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        url: 'back',
+      }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.action).toBe('back');
+      expect(parsed.elementCount).toBe(55);
+    });
+
+    test('forward navigation response includes elementCount', async () => {
+      const handler = await getNavigateHandler();
+      const page = (await mockSessionManager.getPage(testSessionId, testTargetId))!;
+      (page.url as jest.Mock).mockReturnValue('https://next.example.com');
+      (page.title as jest.Mock).mockResolvedValue('Next');
+      (page.evaluate as jest.Mock).mockResolvedValue(77);
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        url: 'forward',
+      }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.action).toBe('forward');
+      expect(parsed.elementCount).toBe(77);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #258.

- Add `elementCount` field to navigate response across all 5 navigation paths (new tab, reuse, existing, back, forward)
- Uses `page.evaluate(() => document.querySelectorAll('*').length)` with `withTimeout` safety
- Non-critical: navigate succeeds even if element count fails (falls back to 0)
- 5 new tests

## Why

When navigate returns "complete" with only 9 elements on a Swagger page, the LLM has no signal that the SPA hasn't rendered yet. With `elementCount` visible in the response, the LLM can detect low counts and use `wait_for` before proceeding.

## Test plan

- [x] `npm run build` passes
- [x] 40/40 navigate tests passing (5 new + 35 existing)
- [x] Full test suite: 1428/1429 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)