### PR TITLE
feat(dom-serializer): add shadow DOM traversal and rendering

### DIFF
--- a/src/dom/dom-serializer.ts
+++ b/src/dom/dom-serializer.ts
@@ -16,6 +16,7 @@ export interface DOMSerializerOptions {
   // none: no sibling dedup or container collapse (backward compat)
   // light (default): sibling dedup threshold=4, container collapse enabled
   // aggressive: sibling dedup threshold=3
+  includeUserAgentShadowDOM?: boolean;  // default: false
 }
 
 export interface PageStats {
@@ -45,6 +46,8 @@ interface DOMNode {
   children?: DOMNode[];
   contentDocument?: DOMNode;
   nodeValue?: string;
+  shadowRoots?: DOMNode[];
+  shadowRootType?: 'open' | 'closed' | 'user-agent';
 }
 
 // Node types
@@ -271,6 +274,7 @@ interface SerializeContext {
   pierceIframes: boolean;
   interactiveOnly: boolean;
   compression: 'none' | 'light' | 'aggressive';
+  includeUserAgentShadowDOM: boolean;
 }
 
 /**
@@ -440,6 +444,39 @@ function serializeNode(
       if (ctx.truncated) return;
     }
   }
+
+  // Traverse shadow roots (CDP returns these separately from children)
+  if (node.shadowRoots && node.shadowRoots.length > 0) {
+    for (const shadowRoot of node.shadowRoots) {
+      if (ctx.truncated) return;
+
+      // Skip user-agent shadow roots unless explicitly included
+      if (!ctx.includeUserAgentShadowDOM && shadowRoot.shadowRootType === 'user-agent') continue;
+
+      // Add shadow root boundary marker (similar to --page-separator-- for iframes)
+      const shadowIndent = '  '.repeat(depth + 1);
+      const rootType = shadowRoot.shadowRootType || 'open';
+      const marker = `${shadowIndent}--shadow-root-- (${rootType})\n`;
+
+      if (ctx.totalChars + marker.length > ctx.maxOutputChars) {
+        const truncationMsg = `\n\n[Output truncated at ${ctx.maxOutputChars} chars. Use depth parameter to limit scope.]`;
+        ctx.lines.push(truncationMsg);
+        ctx.truncated = true;
+        return;
+      }
+
+      ctx.lines.push(marker);
+      ctx.totalChars += marker.length;
+
+      // Serialize shadow root children at increased depth
+      if (shadowRoot.children) {
+        for (const child of shadowRoot.children) {
+          serializeNode(child, depth + 2, ctx);
+          if (ctx.truncated) return;
+        }
+      }
+    }
+  }
 }
 
 /**
@@ -456,6 +493,7 @@ export async function serializeDOM(
   const pierceIframes = options?.pierceIframes ?? true;
   const interactiveOnly = (options?.interactiveOnly ?? false) || options?.filter === 'interactive';
   const compression = options?.compression ?? 'light';  // default to 'light'
+  const includeUserAgentShadowDOM = options?.includeUserAgentShadowDOM ?? false;
 
   // Get page stats via page.evaluate
   const pageStats = await page.evaluate(() => ({
@@ -493,6 +531,7 @@ export async function serializeDOM(
     pierceIframes,
     interactiveOnly,
     compression,
+    includeUserAgentShadowDOM,
   };
 
   // Serialize from root

--- a/tests/dom/dom-serializer.test.ts
+++ b/tests/dom/dom-serializer.test.ts
@@ -613,3 +613,282 @@ describe('DOM Serializer', () => {
     );
   });
 });
+
+// ─── Shadow DOM Tests ─────────────────────────────────────────────────────────
+
+describe('DOM Serializer - Shadow DOM', () => {
+  // Shadow DOM tree: <body> -> <div#host> -> shadowRoot(open) -> <button>Click</button>
+  const shadowDoc = {
+    nodeId: 1, backendNodeId: 1, nodeType: 9, nodeName: '#document', localName: '',
+    children: [{
+      nodeId: 2, backendNodeId: 2, nodeType: 1, nodeName: 'BODY', localName: 'body',
+      attributes: [],
+      children: [{
+        nodeId: 3, backendNodeId: 300, nodeType: 1, nodeName: 'DIV', localName: 'div',
+        attributes: ['id', 'host'],
+        shadowRoots: [{
+          nodeId: 10, backendNodeId: 10, nodeType: 11, nodeName: '#document-fragment', localName: '',
+          shadowRootType: 'open',
+          children: [{
+            nodeId: 11, backendNodeId: 301, nodeType: 1, nodeName: 'BUTTON', localName: 'button',
+            attributes: [],
+            children: [{
+              nodeId: 12, backendNodeId: 12, nodeType: 3, nodeName: '#text', localName: '',
+              nodeValue: 'Shadow Click',
+            }],
+          }],
+        }],
+        children: [],
+      }],
+    }],
+  };
+
+  test('renders open shadow root with boundary marker', async () => {
+    const page = createMockPageForDOM();
+    const cdpClient = createMockCDPClientForDOM(shadowDoc);
+
+    const result = await serializeDOM(page as never, cdpClient as never, { includePageStats: false });
+
+    expect(result.content).toContain('--shadow-root-- (open)');
+    expect(result.content).toContain('[301]<button');
+    expect(result.content).toContain('Shadow Click');
+  });
+
+  test('renders closed shadow root with boundary marker', async () => {
+    const closedShadowDoc = {
+      nodeId: 1, backendNodeId: 1, nodeType: 9, nodeName: '#document', localName: '',
+      children: [{
+        nodeId: 2, backendNodeId: 2, nodeType: 1, nodeName: 'BODY', localName: 'body',
+        attributes: [],
+        children: [{
+          nodeId: 3, backendNodeId: 400, nodeType: 1, nodeName: 'DIV', localName: 'div',
+          attributes: ['id', 'closed-host'],
+          shadowRoots: [{
+            nodeId: 10, backendNodeId: 10, nodeType: 11, nodeName: '#document-fragment', localName: '',
+            shadowRootType: 'closed',
+            children: [{
+              nodeId: 11, backendNodeId: 401, nodeType: 1, nodeName: 'SPAN', localName: 'span',
+              attributes: [],
+              children: [{
+                nodeId: 12, backendNodeId: 12, nodeType: 3, nodeName: '#text', localName: '',
+                nodeValue: 'Hidden content',
+              }],
+            }],
+          }],
+          children: [],
+        }],
+      }],
+    };
+
+    const page = createMockPageForDOM();
+    const cdpClient = createMockCDPClientForDOM(closedShadowDoc);
+
+    const result = await serializeDOM(page as never, cdpClient as never, { includePageStats: false });
+
+    expect(result.content).toContain('--shadow-root-- (closed)');
+    expect(result.content).toContain('[401]<span');
+    expect(result.content).toContain('Hidden content');
+  });
+
+  test('skips user-agent shadow roots by default', async () => {
+    const uaShadowDoc = {
+      nodeId: 1, backendNodeId: 1, nodeType: 9, nodeName: '#document', localName: '',
+      children: [{
+        nodeId: 2, backendNodeId: 2, nodeType: 1, nodeName: 'BODY', localName: 'body',
+        attributes: [],
+        children: [{
+          nodeId: 3, backendNodeId: 500, nodeType: 1, nodeName: 'INPUT', localName: 'input',
+          attributes: ['type', 'text'],
+          shadowRoots: [{
+            nodeId: 10, backendNodeId: 10, nodeType: 11, nodeName: '#document-fragment', localName: '',
+            shadowRootType: 'user-agent',
+            children: [{
+              nodeId: 11, backendNodeId: 501, nodeType: 1, nodeName: 'DIV', localName: 'div',
+              attributes: [],
+              children: [],
+            }],
+          }],
+          children: [],
+        }],
+      }],
+    };
+
+    const page = createMockPageForDOM();
+    const cdpClient = createMockCDPClientForDOM(uaShadowDoc);
+
+    const result = await serializeDOM(page as never, cdpClient as never, { includePageStats: false });
+
+    expect(result.content).toContain('[500]<input');
+    expect(result.content).not.toContain('--shadow-root--');
+    expect(result.content).not.toContain('[501]');
+  });
+
+  test('includes user-agent shadow roots when includeUserAgentShadowDOM is true', async () => {
+    const uaShadowDoc = {
+      nodeId: 1, backendNodeId: 1, nodeType: 9, nodeName: '#document', localName: '',
+      children: [{
+        nodeId: 2, backendNodeId: 2, nodeType: 1, nodeName: 'BODY', localName: 'body',
+        attributes: [],
+        children: [{
+          nodeId: 3, backendNodeId: 600, nodeType: 1, nodeName: 'INPUT', localName: 'input',
+          attributes: ['type', 'text'],
+          shadowRoots: [{
+            nodeId: 10, backendNodeId: 10, nodeType: 11, nodeName: '#document-fragment', localName: '',
+            shadowRootType: 'user-agent',
+            children: [{
+              nodeId: 11, backendNodeId: 601, nodeType: 1, nodeName: 'DIV', localName: 'div',
+              attributes: ['id', 'inner-input'],
+              children: [],
+            }],
+          }],
+          children: [],
+        }],
+      }],
+    };
+
+    const page = createMockPageForDOM();
+    const cdpClient = createMockCDPClientForDOM(uaShadowDoc);
+
+    const result = await serializeDOM(page as never, cdpClient as never, {
+      includePageStats: false,
+      includeUserAgentShadowDOM: true,
+    });
+
+    expect(result.content).toContain('--shadow-root-- (user-agent)');
+    expect(result.content).toContain('[601]<div');
+  });
+
+  test('renders nested shadow roots correctly', async () => {
+    const nestedShadowDoc = {
+      nodeId: 1, backendNodeId: 1, nodeType: 9, nodeName: '#document', localName: '',
+      children: [{
+        nodeId: 2, backendNodeId: 2, nodeType: 1, nodeName: 'BODY', localName: 'body',
+        attributes: [],
+        children: [{
+          nodeId: 3, backendNodeId: 700, nodeType: 1, nodeName: 'DIV', localName: 'div',
+          attributes: ['id', 'outer-host'],
+          shadowRoots: [{
+            nodeId: 10, backendNodeId: 10, nodeType: 11, nodeName: '#document-fragment', localName: '',
+            shadowRootType: 'open',
+            children: [{
+              nodeId: 11, backendNodeId: 701, nodeType: 1, nodeName: 'DIV', localName: 'div',
+              attributes: ['id', 'inner-host'],
+              shadowRoots: [{
+                nodeId: 20, backendNodeId: 20, nodeType: 11, nodeName: '#document-fragment', localName: '',
+                shadowRootType: 'open',
+                children: [{
+                  nodeId: 21, backendNodeId: 702, nodeType: 1, nodeName: 'P', localName: 'p',
+                  attributes: [],
+                  children: [{
+                    nodeId: 22, backendNodeId: 22, nodeType: 3, nodeName: '#text', localName: '',
+                    nodeValue: 'Deeply nested',
+                  }],
+                }],
+              }],
+              children: [],
+            }],
+          }],
+          children: [],
+        }],
+      }],
+    };
+
+    const page = createMockPageForDOM();
+    const cdpClient = createMockCDPClientForDOM(nestedShadowDoc);
+
+    const result = await serializeDOM(page as never, cdpClient as never, { includePageStats: false });
+
+    // Both shadow root markers should appear
+    const shadowMarkers = result.content.match(/--shadow-root--/g) || [];
+    expect(shadowMarkers.length).toBe(2);
+
+    // Nested content should be present
+    expect(result.content).toContain('[701]<div');
+    expect(result.content).toContain('[702]<p');
+    expect(result.content).toContain('Deeply nested');
+  });
+
+  test('shadow root content respects depth limiting', async () => {
+    const page = createMockPageForDOM();
+    const cdpClient = createMockCDPClientForDOM(shadowDoc);
+
+    // host div is at depth 1, shadow marker at depth 2, button at depth 3
+    // maxDepth=1 should only show body(0) and host div(1), no shadow content
+    const result = await serializeDOM(page as never, cdpClient as never, {
+      includePageStats: false,
+      maxDepth: 1,
+    });
+
+    expect(result.content).toContain('[300]<div');
+    // Shadow root content should not appear due to depth limit
+    expect(result.content).not.toContain('[301]');
+  });
+
+  test('shadow root content respects output truncation', async () => {
+    const page = createMockPageForDOM();
+    const cdpClient = createMockCDPClientForDOM(shadowDoc);
+
+    // Very small limit to trigger truncation
+    const result = await serializeDOM(page as never, cdpClient as never, {
+      includePageStats: false,
+      maxOutputChars: 50,
+    });
+
+    expect(result.truncated).toBe(true);
+  });
+
+  test('host element with both shadow root and light DOM children', async () => {
+    const mixedDoc = {
+      nodeId: 1, backendNodeId: 1, nodeType: 9, nodeName: '#document', localName: '',
+      children: [{
+        nodeId: 2, backendNodeId: 2, nodeType: 1, nodeName: 'BODY', localName: 'body',
+        attributes: [],
+        children: [{
+          nodeId: 3, backendNodeId: 800, nodeType: 1, nodeName: 'DIV', localName: 'div',
+          attributes: ['id', 'mixed-host'],
+          shadowRoots: [{
+            nodeId: 10, backendNodeId: 10, nodeType: 11, nodeName: '#document-fragment', localName: '',
+            shadowRootType: 'open',
+            children: [{
+              nodeId: 11, backendNodeId: 801, nodeType: 1, nodeName: 'SPAN', localName: 'span',
+              attributes: [],
+              children: [{
+                nodeId: 12, backendNodeId: 12, nodeType: 3, nodeName: '#text', localName: '',
+                nodeValue: 'Shadow content',
+              }],
+            }],
+          }],
+          children: [{
+            nodeId: 13, backendNodeId: 802, nodeType: 1, nodeName: 'P', localName: 'p',
+            attributes: [],
+            children: [{
+              nodeId: 14, backendNodeId: 14, nodeType: 3, nodeName: '#text', localName: '',
+              nodeValue: 'Light content',
+            }],
+          }],
+        }],
+      }],
+    };
+
+    const page = createMockPageForDOM();
+    const cdpClient = createMockCDPClientForDOM(mixedDoc);
+
+    const result = await serializeDOM(page as never, cdpClient as never, { includePageStats: false });
+
+    // Both light DOM and shadow DOM content should appear
+    expect(result.content).toContain('[801]<span');
+    expect(result.content).toContain('Shadow content');
+    expect(result.content).toContain('[802]<p');
+    expect(result.content).toContain('Light content');
+    expect(result.content).toContain('--shadow-root-- (open)');
+  });
+
+  test('element without shadow roots has no shadow markers', async () => {
+    const page = createMockPageForDOM();
+    const cdpClient = createMockCDPClientForDOM(simpleDoc);
+
+    const result = await serializeDOM(page as never, cdpClient as never, { includePageStats: false });
+
+    expect(result.content).not.toContain('--shadow-root--');
+  });
+});


### PR DESCRIPTION
## Summary

- Add shadow root traversal to the DOM serializer, enabling visibility into open and closed shadow DOM trees via CDP's `pierce: true` mode
- Extend `DOMNode` interface with `shadowRoots[]` and `shadowRootType` fields matching CDP's `DOM.Node` structure
- Add `includeUserAgentShadowDOM` option (default: `false`) to filter out noisy browser-internal shadow roots
- Render shadow root boundaries with `--shadow-root-- (open|closed|user-agent)` markers, consistent with existing `--page-separator--` pattern for iframes
- Shadow root children are serialized at `depth+2` inside the boundary marker

## Changes

**`src/dom/dom-serializer.ts`:**
- `DOMNode` interface: added `shadowRoots?: DOMNode[]` and `shadowRootType?: 'open' | 'closed' | 'user-agent'`
- `DOMSerializerOptions`: added `includeUserAgentShadowDOM?: boolean`
- `SerializeContext`: added `includeUserAgentShadowDOM: boolean`
- `serializeNode()`: new shadow root traversal block after children recursion
- `serializeDOM()`: extract and pass through the new option

**`tests/dom/dom-serializer.test.ts`:**
- 9 new tests: open shadow root, closed shadow root, user-agent filtering (default off + opt-in), nested shadow roots, depth limiting, truncation, mixed light/shadow DOM, no-shadow-root baseline

## Test plan

- [x] `npm run build` passes with zero errors
- [x] All 21 existing DOM serializer tests pass (no regressions)
- [x] 9 new shadow DOM tests pass
- [x] Full test suite: 1459/1460 pass (1 pre-existing unrelated failure in update-check.test.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)