### PR TITLE
fix: add CDP fallback for closed shadow roots in fill_form and inspect

### DIFF
--- a/src/tools/inspect.ts
+++ b/src/tools/inspect.ts
@@ -12,6 +12,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
 import { withTimeout } from '../utils/with-timeout';
+import { getAllShadowRoots, querySelectorInShadowRoots } from '../utils/shadow-dom';
 
 const definition: MCPToolDefinition = {
   name: 'inspect',
@@ -371,6 +372,84 @@ const handler: ToolHandler = async (
       scope,
       categoryFlags
     ), 10000, 'inspect');
+
+    // CDP pass: supplement with closed shadow root elements
+    try {
+      const cdpClient = sessionManager.getCDPClient();
+      const { shadowRoots } = await getAllShadowRoots(page, cdpClient);
+      const closedRoots = shadowRoots.filter(sr => sr.shadowRootType !== 'open');
+
+      if (closedRoots.length > 0) {
+        // Supplement interactive counts from closed shadow roots
+        if (categories.has('interactive')) {
+          const selectorToLabel: [string, string][] = [
+            ['button', 'button'],
+            ['[role="button"]', 'button'],
+            ['a[href]', 'link'],
+            ['input', 'input'],
+            ['textarea', 'textarea'],
+            ['select', 'select'],
+            ['[role="combobox"]', 'combobox'],
+            ['[role="listbox"]', 'listbox'],
+            ['[role="checkbox"]', 'checkbox'],
+            ['[role="radio"]', 'radio'],
+            ['[role="switch"]', 'switch'],
+            ['[role="slider"]', 'slider'],
+            ['[role="tab"]', 'tab'],
+            ['[role="menuitem"]', 'menuitem'],
+          ];
+          for (const [selector, label] of selectorToLabel) {
+            const ids = await querySelectorInShadowRoots(page, cdpClient, selector, closedRoots);
+            if (ids.length > 0) {
+              inspectResult.interactiveCounts[label] = (inspectResult.interactiveCounts[label] || 0) + ids.length;
+            }
+          }
+        }
+
+        // Supplement form fields from closed shadow roots
+        if (categories.has('form') && scope !== 'interactive') {
+          const formSelectors = [
+            'input:not([type="hidden"]):not([type="submit"]):not([type="button"])',
+            'textarea',
+            'select',
+          ];
+          for (const selector of formSelectors) {
+            const ids = await querySelectorInShadowRoots(page, cdpClient, selector, closedRoots);
+            for (const backendNodeId of ids) {
+              try {
+                const { node } = await cdpClient.send<{
+                  node: { localName: string; nodeName: string; attributes?: string[] };
+                }>(page, 'DOM.describeNode', { backendNodeId, depth: 0 });
+
+                const { model } = await cdpClient.send<{
+                  model: { content: number[] };
+                }>(page, 'DOM.getBoxModel', { backendNodeId });
+
+                if (!model?.content || model.content.length < 8) continue;
+
+                const attrs = new Map<string, string>();
+                const rawAttrs = node.attributes || [];
+                for (let i = 0; i < rawAttrs.length - 1; i += 2) {
+                  attrs.set(rawAttrs[i], rawAttrs[i + 1]);
+                }
+
+                const tagName = node.localName || node.nodeName.toLowerCase();
+                const type = attrs.get('type') || tagName;
+                if (type === 'hidden' || type === 'password') continue;
+                const name = attrs.get('placeholder') || attrs.get('aria-label') || attrs.get('name') || attrs.get('id') || '';
+                const id = attrs.get('id') || '';
+
+                inspectResult.formFields.push({ type, name: name.slice(0, 40), value: '', id });
+              } catch {
+                // non-fatal — stale node or no box model
+              }
+            }
+          }
+        }
+      }
+    } catch (cdpErr) {
+      console.error('[inspect] CDP shadow pass error (non-fatal):', cdpErr);
+    }
 
     // Format the output — only include sections for requested categories
     const lines: string[] = [`[Inspect: "${query}"]`];

--- a/src/utils/element-discovery.ts
+++ b/src/utils/element-discovery.ts
@@ -10,7 +10,7 @@
 import { Page } from 'puppeteer-core';
 import { CDPClient } from '../cdp/client';
 import { FoundElement } from './element-finder';
-import { discoverShadowElements, DEEP_WALK_ELEMENTS_JS } from './shadow-dom';
+import { discoverShadowElements, DEEP_WALK_ELEMENTS_JS, getAllShadowRoots, querySelectorInShadowRoots } from './shadow-dom';
 import { withTimeout } from './with-timeout';
 
 /**
@@ -410,6 +410,71 @@ export async function discoverFormFields(
 
   // Resolve backend node IDs via batched CDP
   await resolveBackendNodeIds(page, cdpClient, FORM_FIELD_TAG, results);
+
+  // CDP shadow root form field discovery (handles closed shadow roots)
+  try {
+    const jsBackendIds = new Set(
+      results.filter(r => r.backendDOMNodeId > 0).map(r => r.backendDOMNodeId),
+    );
+    const { shadowRoots } = await getAllShadowRoots(page, cdpClient);
+    const formSelectors = [
+      'input:not([type="hidden"]):not([type="submit"]):not([type="button"]):not([type="image"])',
+      'textarea',
+      'select',
+      '[contenteditable="true"]',
+      '[role="textbox"]',
+      '[role="combobox"]',
+    ];
+    for (const selector of formSelectors) {
+      const shadowMatches = await querySelectorInShadowRoots(page, cdpClient, selector, shadowRoots);
+      for (const backendId of shadowMatches) {
+        if (jsBackendIds.has(backendId)) continue;
+        try {
+          const { node } = await cdpClient.send<{
+            node: { localName: string; nodeName: string; attributes?: string[] };
+          }>(page, 'DOM.describeNode', { backendNodeId: backendId, depth: 0 });
+          const { model } = await cdpClient.send<{
+            model: { content: number[] };
+          }>(page, 'DOM.getBoxModel', { backendNodeId: backendId });
+          const x = model.content[0];
+          const y = model.content[1];
+          const width = model.content[2] - x;
+          const height = model.content[5] - y;
+          if (width <= 0 || height <= 0) continue;
+          const attrs = new Map<string, string>();
+          const rawAttrs = node.attributes ?? [];
+          for (let i = 0; i < rawAttrs.length - 1; i += 2) {
+            attrs.set(rawAttrs[i], rawAttrs[i + 1]);
+          }
+          jsBackendIds.add(backendId);
+          results.push({
+            backendDOMNodeId: backendId,
+            fieldName:
+              attrs.get('aria-label') ||
+              attrs.get('name') ||
+              attrs.get('placeholder') ||
+              `field_${results.length}`,
+            tagName: node.localName || node.nodeName.toLowerCase(),
+            type: attrs.get('type'),
+            name: attrs.get('name'),
+            placeholder: attrs.get('placeholder'),
+            ariaLabel: attrs.get('aria-label') || undefined,
+            label: undefined,
+            rect: {
+              x: x + width / 2,
+              y: y + height / 2,
+              width,
+              height,
+            },
+          });
+        } catch {
+          // Individual node resolution failure is non-fatal
+        }
+      }
+    }
+  } catch {
+    // Shadow discovery is non-fatal — JS results are still valid
+  }
 
   return results;
 }

--- a/tests/fixtures/shadow-dom-test.html
+++ b/tests/fixtures/shadow-dom-test.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Shadow DOM E2E Test</title>
+  <style>
+    body { font-family: sans-serif; padding: 20px; }
+    .section { margin: 20px 0; padding: 16px; border: 1px solid #ccc; border-radius: 8px; }
+    h2 { margin-top: 0; }
+    #results { margin-top: 20px; padding: 12px; background: #f0f0f0; min-height: 40px; }
+  </style>
+</head>
+<body>
+  <h1>Shadow DOM E2E Test Page</h1>
+
+  <!-- Section 1: Light DOM (baseline) -->
+  <div class="section" id="light-dom-section">
+    <h2>Light DOM</h2>
+    <button id="light-button">Light Button</button>
+    <input id="light-input" type="text" placeholder="Light input field">
+  </div>
+
+  <!-- Section 2: Open Shadow DOM -->
+  <div class="section" id="open-shadow-section">
+    <h2>Open Shadow DOM</h2>
+    <div id="open-shadow-host"></div>
+  </div>
+
+  <!-- Section 3: Closed Shadow DOM -->
+  <div class="section" id="closed-shadow-section">
+    <h2>Closed Shadow DOM</h2>
+    <div id="closed-shadow-host"></div>
+  </div>
+
+  <!-- Section 4: Nested Shadow DOM -->
+  <div class="section" id="nested-shadow-section">
+    <h2>Nested Shadow DOM</h2>
+    <div id="nested-shadow-host"></div>
+  </div>
+
+  <!-- Result display -->
+  <div id="results">Click results appear here</div>
+
+  <script>
+    const results = document.getElementById('results');
+    function logResult(msg) {
+      results.textContent = msg;
+    }
+
+    // === Open Shadow DOM ===
+    const openHost = document.getElementById('open-shadow-host');
+    const openShadow = openHost.attachShadow({ mode: 'open' });
+    openShadow.innerHTML = `
+      <style>button { background: #4CAF50; color: white; padding: 8px 16px; border: none; border-radius: 4px; cursor: pointer; margin: 4px; }</style>
+      <button id="open-shadow-btn" onclick="document.getElementById('results').textContent = 'Open shadow button clicked!'">Open Shadow Button</button>
+      <input id="open-shadow-input" type="text" placeholder="Open shadow input">
+      <p id="open-shadow-text">This text is inside an open shadow root</p>
+    `;
+
+    // === Closed Shadow DOM ===
+    const closedHost = document.getElementById('closed-shadow-host');
+    const closedShadow = closedHost.attachShadow({ mode: 'closed' });
+    closedShadow.innerHTML = `
+      <style>button { background: #f44336; color: white; padding: 8px 16px; border: none; border-radius: 4px; cursor: pointer; margin: 4px; }</style>
+      <button id="closed-shadow-btn" onclick="document.getElementById('results').textContent = 'Closed shadow button clicked!'">Closed Shadow Button</button>
+      <input id="closed-shadow-input" type="text" placeholder="Closed shadow input">
+      <p id="closed-shadow-text">This text is inside a closed shadow root</p>
+    `;
+
+    // === Nested Shadow DOM (shadow inside shadow) ===
+    const nestedHost = document.getElementById('nested-shadow-host');
+    const outerShadow = nestedHost.attachShadow({ mode: 'open' });
+    outerShadow.innerHTML = `
+      <style>div { padding: 8px; border: 1px dashed #999; margin: 4px; }</style>
+      <p id="outer-shadow-text">Outer shadow level</p>
+      <div id="inner-shadow-host"></div>
+    `;
+    const innerHost = outerShadow.getElementById('inner-shadow-host');
+    const innerShadow = innerHost.attachShadow({ mode: 'closed' });
+    innerShadow.innerHTML = `
+      <style>button { background: #FF9800; color: white; padding: 8px 16px; border: none; border-radius: 4px; cursor: pointer; }</style>
+      <button id="nested-inner-btn" onclick="document.getElementById('results').textContent = 'Nested inner button clicked!'">Nested Inner Button</button>
+      <p id="nested-inner-text">This is deeply nested (open > closed)</p>
+    `;
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Closes #287 (follow-up to #262 Shadow DOM support)

- **`element-discovery.ts`**: Add CDP shadow pass to `discoverFormFields()` — after JS-based open shadow root discovery, queries all shadow roots via `getAllShadowRoots` + `querySelectorInShadowRoots` with form selectors, resolves properties via `DOM.describeNode` + `DOM.getBoxModel`, deduplicates against already-found elements
- **`inspect.ts`**: Add CDP pass for closed shadow roots — supplements interactive element counts and form field extraction by querying only closed/user-agent shadow roots (open roots already handled by JS `deepQSA`)
- **`tests/fixtures/shadow-dom-test.html`**: E2E test fixture with open, closed, and nested (open>closed) shadow DOM sections

## E2E Test Results (before fix)

| Tool | Open Shadow | Closed Shadow | Nested (open>closed) |
|------|:-----------:|:-------------:|:--------------------:|
| `fill_form` | PASS | **FAIL** | - |
| `inspect` | PASS | **FAIL** | **FAIL** |

## Design

Both fixes follow the established pattern from `discoverElements()` (lines 265-296):
1. JS-based discovery runs first (handles open shadow roots)
2. CDP fallback runs second (handles all shadow root types including closed)
3. Deduplication via `backendDOMNodeId` set
4. Entire CDP block is non-fatal (try/catch)

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 1533 existing tests pass (`npm test`)
- [x] Shadow DOM tests pass (82/82)
- [ ] E2E verification with MCP server restart (requires new Claude Code session to reload Node.js module cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)