### PR TITLE
fix: add timeout to workflow engine completion lock to prevent deadlock

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -134,3 +134,9 @@ export const DEFAULT_VERBOSITY = 'normal';
 
 /** Minimum response size in bytes before compression is applied. */
 export const COMPRESSION_MIN_BYTES = 500;
+
+/** Completion lock acquisition timeout in milliseconds.
+ *  Safety net for the promise-based mutex in WorkflowEngine.
+ *  If a previous lock holder's release() is never called (e.g. due to an
+ *  unhandled exception outside the try/finally), this prevents permanent deadlock. */
+export const DEFAULT_COMPLETION_LOCK_TIMEOUT_MS = 30000;

--- a/src/orchestration/workflow-engine.ts
+++ b/src/orchestration/workflow-engine.ts
@@ -9,7 +9,7 @@ import { getCDPConnectionPool } from '../cdp/connection-pool';
 import { getCDPClient } from '../cdp/client';
 import { ToolEntry } from '../types/tool-manifest';
 import { getDomainMemory, extractDomainFromUrl } from '../memory/domain-memory';
-import { DEFAULT_NAVIGATION_TIMEOUT_MS } from '../config/defaults';
+import { DEFAULT_NAVIGATION_TIMEOUT_MS, DEFAULT_COMPLETION_LOCK_TIMEOUT_MS } from '../config/defaults';
 import { getGlobalConfig } from '../config/global';
 import { getTargetId } from '../utils/puppeteer-helpers';
 
@@ -124,6 +124,12 @@ export class WorkflowEngine {
   /**
    * Acquire the completion lock. Returns a release function.
    * All completeWorker calls are serialized through this lock.
+   *
+   * Includes a timeout safety net: if the previous lock holder never calls
+   * release() (e.g. due to an unhandled exception bypassing the finally block),
+   * the await will reject after DEFAULT_COMPLETION_LOCK_TIMEOUT_MS instead of
+   * hanging forever. On timeout, the lock chain is reset to prevent permanent
+   * deadlock of all subsequent completeWorker calls.
    */
   private async acquireLock(): Promise<() => void> {
     let release!: () => void;
@@ -132,7 +138,30 @@ export class WorkflowEngine {
     });
     const prev = this.completionLock;
     this.completionLock = next;
-    await prev;
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        prev,
+        new Promise<void>((_, reject) => {
+          timeoutId = setTimeout(() => {
+            reject(new Error(
+              `Completion lock acquisition timed out after ${DEFAULT_COMPLETION_LOCK_TIMEOUT_MS}ms — ` +
+              `previous lock holder may have failed without calling release()`
+            ));
+          }, DEFAULT_COMPLETION_LOCK_TIMEOUT_MS);
+        }),
+      ]);
+    } catch (err) {
+      // Lock timed out — the previous holder is presumed dead.
+      // Reset the lock chain so future acquireLock() calls don't pile up
+      // behind the same dead promise.
+      console.error(`[WorkflowEngine] ${err instanceof Error ? err.message : String(err)}`);
+      this.completionLock = next;
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+    }
+
     return release;
   }
 

--- a/tests/orchestration/workflow-engine.test.ts
+++ b/tests/orchestration/workflow-engine.test.ts
@@ -603,6 +603,129 @@ describe('WorkflowEngine', () => {
     });
   });
 
+  describe('acquireLock deadlock prevention', () => {
+    test('should recover from a stuck lock via timeout', async () => {
+      // Simulate a stuck lock by setting completionLock to a promise that never resolves
+      // @ts-expect-error - accessing private property for testing
+      engine.completionLock = new Promise<void>(() => {
+        // intentionally never resolves
+      });
+
+      // Override the timeout to something short for testing
+      const originalTimeout = require('../../src/config/defaults').DEFAULT_COMPLETION_LOCK_TIMEOUT_MS;
+      jest.replaceProperty(
+        require('../../src/config/defaults'),
+        'DEFAULT_COMPLETION_LOCK_TIMEOUT_MS',
+        500
+      );
+
+      const startTime = Date.now();
+
+      // This should NOT hang forever — it should time out and recover
+      const release = await (engine as any).acquireLock();
+      const elapsed = Date.now() - startTime;
+
+      // Should have waited approximately the timeout duration
+      expect(elapsed).toBeGreaterThanOrEqual(400);
+      expect(elapsed).toBeLessThan(5000);
+
+      // Release should still be a callable function
+      expect(typeof release).toBe('function');
+      release();
+
+      // Restore original timeout
+      jest.replaceProperty(
+        require('../../src/config/defaults'),
+        'DEFAULT_COMPLETION_LOCK_TIMEOUT_MS',
+        originalTimeout
+      );
+    });
+
+    test('should allow subsequent lock acquisitions after timeout recovery', async () => {
+      // Simulate a stuck lock
+      // @ts-expect-error - accessing private property for testing
+      engine.completionLock = new Promise<void>(() => {});
+
+      jest.replaceProperty(
+        require('../../src/config/defaults'),
+        'DEFAULT_COMPLETION_LOCK_TIMEOUT_MS',
+        200
+      );
+
+      // First acquisition: times out and recovers
+      const release1 = await (engine as any).acquireLock();
+      release1();
+
+      // Second acquisition: should succeed immediately (lock chain was reset)
+      const startTime = Date.now();
+      const release2 = await (engine as any).acquireLock();
+      const elapsed = Date.now() - startTime;
+
+      // Should be near-instant since the previous lock was properly released
+      expect(elapsed).toBeLessThan(100);
+      release2();
+
+      // Restore
+      jest.replaceProperty(
+        require('../../src/config/defaults'),
+        'DEFAULT_COMPLETION_LOCK_TIMEOUT_MS',
+        30000
+      );
+    });
+
+    test('completeWorker should succeed after lock timeout recovery', async () => {
+      const workflow: WorkflowDefinition = {
+        id: 'wf-lock-test',
+        name: 'Lock Test',
+        steps: [
+          { workerId: 'w1', workerName: 'lock-worker', url: 'https://example.com', task: 'Test', successCriteria: 'Done' },
+        ],
+        parallel: true,
+        maxRetries: 3,
+        timeout: 300000,
+      };
+      await engine.initWorkflow(testSessionId, workflow);
+
+      // Poison the lock
+      // @ts-expect-error - accessing private property for testing
+      engine.completionLock = new Promise<void>(() => {});
+
+      jest.replaceProperty(
+        require('../../src/config/defaults'),
+        'DEFAULT_COMPLETION_LOCK_TIMEOUT_MS',
+        200
+      );
+
+      // completeWorker should recover via timeout, not hang
+      await engine.completeWorker('lock-worker', 'SUCCESS', 'Done after lock recovery', { result: 'ok' });
+
+      const orch = await engine.getOrchestrationStatus();
+      expect(orch?.status).toBe('COMPLETED');
+
+      const workerStatus = orch?.workers.find(w => w.workerName === 'lock-worker');
+      expect(workerStatus?.status).toBe('SUCCESS');
+
+      // Restore
+      jest.replaceProperty(
+        require('../../src/config/defaults'),
+        'DEFAULT_COMPLETION_LOCK_TIMEOUT_MS',
+        30000
+      );
+    });
+
+    test('normal lock acquisition should not be affected by timeout', async () => {
+      // Normal flow: lock is free (resolved promise)
+      const startTime = Date.now();
+      const release = await (engine as any).acquireLock();
+      const elapsed = Date.now() - startTime;
+
+      // Should acquire near-instantly
+      expect(elapsed).toBeLessThan(50);
+      expect(typeof release).toBe('function');
+      release();
+    });
+  });
+
   describe('getWorkflowEngine singleton', () => {
     test('should return the same instance', () => {
       const instance1 = getWorkflowEngine();


### PR DESCRIPTION
## Summary

- Add 30s timeout to `WorkflowEngine.acquireLock()` to prevent permanent deadlock when a lock holder fails without calling `release()`
- On timeout, reset the lock chain so subsequent `completeWorker()` calls succeed instead of piling up behind a dead promise
- Add `DEFAULT_COMPLETION_LOCK_TIMEOUT_MS` constant to centralized defaults

Closes #302

## Problem

The promise-based mutex in `acquireLock()` had **no timeout**. If a previous lock holder's `release()` was never called (e.g., due to an unhandled exception bypassing the `finally` block), all subsequent `completeWorker()` calls would hang **permanently**.

This was the **only identified deadlock path with no external timeout safety net** — it sits inside the orchestration layer, outside the 120s tool execution timeout.

```typescript
// BEFORE: hangs forever if prev never resolves
await prev;

// AFTER: times out and recovers
await Promise.race([
  prev,
  new Promise((_, reject) => setTimeout(() => reject(...), 30_000)),
]);
```

## Changes

| File | Change |
|------|--------|
| `src/config/defaults.ts` | Add `DEFAULT_COMPLETION_LOCK_TIMEOUT_MS = 30000` |
| `src/orchestration/workflow-engine.ts` | Wrap `await prev` in `Promise.race` with timeout; reset lock chain on timeout |
| `tests/orchestration/workflow-engine.test.ts` | Add 4 tests for deadlock prevention and recovery |

## Test plan

- [x] `should recover from a stuck lock via timeout` — poisoned lock recovers after timeout
- [x] `should allow subsequent lock acquisitions after timeout recovery` — lock chain reset works
- [x] `completeWorker should succeed after lock timeout recovery` — full end-to-end recovery
- [x] `normal lock acquisition should not be affected by timeout` — no regression on happy path
- [x] All 1728 existing tests pass
- [x] Build succeeds (`tsc` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout mechanism for workflow engine lock operations to prevent system hangs.

* **Tests**
  * Added comprehensive test suite covering lock timeout recovery, subsequent acquisitions, and normal operation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->