### PR TITLE
fix: propagate navigation failure in workflow init instead of swallowing

### DIFF
--- a/src/orchestration/workflow-engine.ts
+++ b/src/orchestration/workflow-engine.ts
@@ -187,9 +187,24 @@ export class WorkflowEngine {
             // Cookie bridging failure is non-fatal — page navigates without cookies
           }
 
-          await page.goto(step.url, { waitUntil: 'domcontentloaded', timeout: DEFAULT_NAVIGATION_TIMEOUT_MS }).catch((err) => {
-            console.error(`[WorkflowEngine] Navigation to ${step.url} failed: ${err instanceof Error ? err.message : String(err)}`);
-          });
+          try {
+            await page.goto(step.url, { waitUntil: 'domcontentloaded', timeout: DEFAULT_NAVIGATION_TIMEOUT_MS });
+          } catch (navErr) {
+            const msg = navErr instanceof Error ? navErr.message : String(navErr);
+            console.error(`[WorkflowEngine] Navigation to ${step.url} failed for worker "${step.workerName}": ${msg}`);
+            // Release the page back to the pool — don't leave it orphaned
+            const pool = getCDPConnectionPool();
+            await pool.releasePage(page).catch(() => {});
+            // Return a failed entry so initWorkflow can report which workers failed to start
+            return {
+              workerId: worker.id,
+              workerName: step.workerName,
+              tabId: '',
+              task: step.task,
+              navigationFailed: true,
+              navigationError: msg,
+            };
+          }
         }
 
         // Register the page as a target in the session manager
@@ -201,9 +216,21 @@ export class WorkflowEngine {
           workerName: step.workerName,
           tabId: targetId,
           task: step.task,
+          navigationFailed: false,
         };
       })
     );
+
+    // Separate successfully navigated workers from navigation failures
+    const successfulWorkers = workers.filter(w => !w.navigationFailed);
+    const failedWorkers = workers.filter(w => w.navigationFailed);
+
+    if (failedWorkers.length > 0) {
+      console.error(
+        `[WorkflowEngine] ${failedWorkers.length}/${workers.length} workers failed navigation: ` +
+        failedWorkers.map(w => `${w.workerName} (${(w as any).navigationError})`).join(', ')
+      );
+    }
 
     // Initialize file-based orchestration state (for scratchpads / debugging)
     await this.stateManager.initOrchestration(
@@ -215,7 +242,14 @@ export class WorkflowEngine {
     // Initialize in-memory state — this is the authoritative source for completion tracking
     const workerStatuses = new Map<string, { status: WorkerState['status']; resultSummary: string }>();
     for (const w of workers) {
-      workerStatuses.set(w.workerName, { status: 'INIT', resultSummary: '' });
+      if (w.navigationFailed) {
+        workerStatuses.set(w.workerName, {
+          status: 'FAIL',
+          resultSummary: `Navigation failed: ${(w as any).navigationError}`,
+        });
+      } else {
+        workerStatuses.set(w.workerName, { status: 'INIT', resultSummary: '' });
+      }
     }
 
     const workerTimeoutMs = workflow.timeout || 60_000;
@@ -227,7 +261,7 @@ export class WorkflowEngine {
       createdAt: Date.now(),
       totalWorkers: workers.length,
       completedWorkers: 0,
-      failedWorkers: 0,
+      failedWorkers: failedWorkers.length,
       workerStatuses,
       overallStatus: 'INIT',
       allDone: false,
@@ -237,8 +271,8 @@ export class WorkflowEngine {
     };
     this.workflowStates.set(orchestrationId, memState);
 
-    // Initialize per-worker runtime state and set up timeouts
-    for (const w of workers) {
+    // Initialize per-worker runtime state and set up timeouts (only for successful workers)
+    for (const w of successfulWorkers) {
       const runtimeState: WorkerRuntimeState = {
         workerName: w.workerName,
         startTime: Date.now(),
@@ -266,7 +300,10 @@ export class WorkflowEngine {
     globalHandle.unref();
     this.globalTimeoutHandles.set(orchestrationId, globalHandle);
 
-    console.error(`[WorkflowEngine] Initialized workflow ${orchestrationId} with ${workers.length} workers (timeout: ${workerTimeoutMs}ms/worker, ${memState.globalTimeoutMs}ms global)`);
+    const navFailNote = failedWorkers.length > 0
+      ? ` (${failedWorkers.length} failed navigation)`
+      : '';
+    console.error(`[WorkflowEngine] Initialized workflow ${orchestrationId} with ${workers.length} workers${navFailNote} (timeout: ${workerTimeoutMs}ms/worker, ${memState.globalTimeoutMs}ms global)`);
 
     return {
       orchestrationId,
@@ -274,6 +311,7 @@ export class WorkflowEngine {
         workerId: w.workerId,
         workerName: w.workerName,
         tabId: w.tabId,
+        ...(w.navigationFailed ? { navigationFailed: true, navigationError: (w as any).navigationError } : {}),
       })),
     };
   }

--- a/tests/orchestration/workflow-engine.test.ts
+++ b/tests/orchestration/workflow-engine.test.ts
@@ -603,6 +603,194 @@ describe('WorkflowEngine', () => {
     });
   });
 
+  describe('navigation failure handling', () => {
+    test('should mark worker as navigationFailed when page.goto rejects', async () => {
+      // Get mock pool to provide a page whose goto will fail
+      const { getCDPConnectionPool } = require('../../src/cdp/connection-pool');
+      const mockPool = getCDPConnectionPool();
+      const originalAcquireBatch = mockPool.acquireBatch;
+
+      mockPool.acquireBatch.mockImplementationOnce((count: number) => {
+        return Promise.resolve(
+          Array.from({ length: count }, () => {
+            const id = `nav-fail-${++batchPageCounter}`;
+            return {
+              target: () => ({ _targetId: id }),
+              goto: jest.fn().mockRejectedValue(new Error('net::ERR_NAME_NOT_RESOLVED')),
+              close: jest.fn().mockResolvedValue(undefined),
+              url: jest.fn().mockReturnValue('about:blank'),
+              on: jest.fn(),
+              off: jest.fn(),
+            };
+          })
+        );
+      });
+
+      const workflow: WorkflowDefinition = {
+        id: 'wf-nav-fail',
+        name: 'Nav Fail Test',
+        steps: [
+          { workerId: 'w1', workerName: 'fail-worker', url: 'https://nonexistent.invalid', task: 'Task', successCriteria: 'Done' },
+        ],
+        parallel: true,
+        maxRetries: 3,
+        timeout: 300000,
+      };
+
+      const result = await engine.initWorkflow(testSessionId, workflow);
+
+      // Worker should be returned with navigationFailed flag
+      expect(result.workers[0].workerName).toBe('fail-worker');
+      expect((result.workers[0] as any).navigationFailed).toBe(true);
+      expect((result.workers[0] as any).navigationError).toContain('net::ERR_NAME_NOT_RESOLVED');
+      // tabId should be empty since navigation failed
+      expect(result.workers[0].tabId).toBe('');
+
+      // releasePage should have been called to return the page to pool
+      expect(mockPool.releasePage).toHaveBeenCalled();
+    });
+
+    test('should mark failed worker as FAIL in orchestration state', async () => {
+      const { getCDPConnectionPool } = require('../../src/cdp/connection-pool');
+      const mockPool = getCDPConnectionPool();
+
+      mockPool.acquireBatch.mockImplementationOnce((count: number) => {
+        return Promise.resolve(
+          Array.from({ length: count }, () => {
+            const id = `nav-fail-state-${++batchPageCounter}`;
+            return {
+              target: () => ({ _targetId: id }),
+              goto: jest.fn().mockRejectedValue(new Error('Navigation timeout')),
+              close: jest.fn().mockResolvedValue(undefined),
+              url: jest.fn().mockReturnValue('about:blank'),
+              on: jest.fn(),
+              off: jest.fn(),
+            };
+          })
+        );
+      });
+
+      const workflow: WorkflowDefinition = {
+        id: 'wf-nav-fail-state',
+        name: 'Nav Fail State Test',
+        steps: [
+          { workerId: 'w1', workerName: 'state-fail-worker', url: 'https://timeout.invalid', task: 'Task', successCriteria: 'Done' },
+        ],
+        parallel: true,
+        maxRetries: 3,
+        timeout: 300000,
+      };
+
+      await engine.initWorkflow(testSessionId, workflow);
+
+      // In-memory state should show the worker as FAIL
+      const orch = await engine.getOrchestrationStatus();
+      expect(orch).not.toBeNull();
+      expect(orch?.failedWorkers).toBe(1);
+      const workerStatus = orch?.workers.find(w => w.workerName === 'state-fail-worker');
+      expect(workerStatus?.status).toBe('FAIL');
+      expect(workerStatus?.resultSummary).toContain('Navigation failed');
+    });
+
+    test('should not register failed worker as target in session manager', async () => {
+      const { getCDPConnectionPool } = require('../../src/cdp/connection-pool');
+      const mockPool = getCDPConnectionPool();
+
+      mockPool.acquireBatch.mockImplementationOnce((count: number) => {
+        return Promise.resolve(
+          Array.from({ length: count }, () => {
+            const id = `nav-fail-noreg-${++batchPageCounter}`;
+            return {
+              target: () => ({ _targetId: id }),
+              goto: jest.fn().mockRejectedValue(new Error('Connection refused')),
+              close: jest.fn().mockResolvedValue(undefined),
+              url: jest.fn().mockReturnValue('about:blank'),
+              on: jest.fn(),
+              off: jest.fn(),
+            };
+          })
+        );
+      });
+
+      mockSessionManager.registerExistingTarget.mockClear();
+
+      const workflow: WorkflowDefinition = {
+        id: 'wf-nav-fail-noreg',
+        name: 'Nav Fail No Register',
+        steps: [
+          { workerId: 'w1', workerName: 'noreg-worker', url: 'https://fail.invalid', task: 'Task', successCriteria: 'Done' },
+        ],
+        parallel: true,
+        maxRetries: 3,
+        timeout: 300000,
+      };
+
+      await engine.initWorkflow(testSessionId, workflow);
+
+      // registerExistingTarget should NOT have been called for the failed worker
+      expect(mockSessionManager.registerExistingTarget).not.toHaveBeenCalled();
+    });
+
+    test('should handle mixed success and failure workers', async () => {
+      const { getCDPConnectionPool } = require('../../src/cdp/connection-pool');
+      const mockPool = getCDPConnectionPool();
+
+      let callCount = 0;
+      mockPool.acquireBatch.mockImplementationOnce((count: number) => {
+        return Promise.resolve(
+          Array.from({ length: count }, () => {
+            callCount++;
+            const id = `mixed-${++batchPageCounter}`;
+            return {
+              target: () => ({ _targetId: id }),
+              // First page succeeds, second fails
+              goto: callCount === 1
+                ? jest.fn().mockResolvedValue(null)
+                : jest.fn().mockRejectedValue(new Error('Timeout')),
+              close: jest.fn().mockResolvedValue(undefined),
+              url: jest.fn().mockReturnValue('about:blank'),
+              on: jest.fn(),
+              off: jest.fn(),
+            };
+          })
+        );
+      });
+
+      mockSessionManager.registerExistingTarget.mockClear();
+
+      const workflow: WorkflowDefinition = {
+        id: 'wf-mixed',
+        name: 'Mixed Test',
+        steps: [
+          { workerId: 'w1', workerName: 'ok-worker', url: 'https://good.com', task: 'Task 1', successCriteria: 'Done' },
+          { workerId: 'w2', workerName: 'bad-worker', url: 'https://bad.invalid', task: 'Task 2', successCriteria: 'Done' },
+        ],
+        parallel: true,
+        maxRetries: 3,
+        timeout: 300000,
+      };
+
+      const result = await engine.initWorkflow(testSessionId, workflow);
+
+      // One worker succeeded, one failed
+      const okWorker = result.workers.find(w => w.workerName === 'ok-worker');
+      const badWorker = result.workers.find(w => w.workerName === 'bad-worker');
+
+      expect((okWorker as any).navigationFailed).toBeUndefined();
+      expect(okWorker?.tabId).not.toBe('');
+
+      expect((badWorker as any).navigationFailed).toBe(true);
+      expect(badWorker?.tabId).toBe('');
+
+      // Only the successful worker should be registered
+      expect(mockSessionManager.registerExistingTarget).toHaveBeenCalledTimes(1);
+
+      // In-memory state: 1 failed
+      const orch = await engine.getOrchestrationStatus();
+      expect(orch?.failedWorkers).toBe(1);
+    });
+  });
+
   describe('getWorkflowEngine singleton', () => {
     test('should return the same instance', () => {
       const instance1 = getWorkflowEngine();


### PR DESCRIPTION
## Summary

- Stop silently swallowing `page.goto()` failures in `WorkflowEngine.initWorkflow()`
- Failed workers are now marked with `navigationFailed: true`, `FAIL` status, and empty `tabId`
- Failed pages are released back to the connection pool instead of being orphaned
- `registerExistingTarget()` is skipped for failed workers, preventing stale tab tracking

Closes #303

## Problem

When `page.goto()` failed during workflow initialization, the error was caught and logged but execution continued unconditionally to `registerExistingTarget()`. The worker was registered as if navigation succeeded, pointing to a tab still on `about:blank`.

The LLM would then operate on a blank page — reading empty DOM, executing JS in the wrong context — producing silently corrupted results. This was also identified as a **precursor to the deadlock in #302**, since corrupted worker state could trigger unexpected code paths in `completeWorker()`.

```typescript
// BEFORE: error swallowed, worker registered on about:blank
await page.goto(step.url, { ... }).catch((err) => {
  console.error(...);  // logged but not propagated
});
// Unconditional — runs even after navigation failure:
this.sessionManager.registerExistingTarget(sessionId, worker.id, targetId);

// AFTER: error caught, page released, worker marked as FAIL
try {
  await page.goto(step.url, { ... });
} catch (navErr) {
  await pool.releasePage(page).catch(() => {});
  return { ...worker, tabId: '', navigationFailed: true, navigationError: msg };
}
```

## Changes

| File | Change |
|------|--------|
| `src/orchestration/workflow-engine.ts` | Replace `.catch()` with try/catch; release page on failure; return `navigationFailed` flag; mark failed workers as FAIL in in-memory state; skip timeout setup for failed workers |
| `tests/orchestration/workflow-engine.test.ts` | Add 4 tests covering navigation failure propagation |

## Test plan

- [x] `should mark worker as navigationFailed when page.goto rejects` — flag and error message propagated
- [x] `should mark failed worker as FAIL in orchestration state` — in-memory state correctly reflects failure
- [x] `should not register failed worker as target in session manager` — no stale tab tracking
- [x] `should handle mixed success and failure workers` — partial workflow initialization works correctly
- [x] All 1728 existing tests pass
- [x] Build succeeds (`tsc` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced navigation failure detection and error reporting during worker initialization.
  * Failed workers are now properly tracked in workflow status with detailed error information for diagnostics.

* **Tests**
  * Added comprehensive test coverage for worker navigation failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->