### PR TITLE
fix: return isError: true for navigation timeouts

### DIFF
--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -222,11 +222,11 @@ const handler: ToolHandler = async (
           {
             type: 'text',
             text: isTimeout
-              ? `Navigation timed out — the page at ${url} did not finish loading within 30s. The page may still be loading. Try read_page to check if content is available, or retry navigation.`
+              ? `Navigation timed out — the page at ${url} did not finish loading within 30s. The page may still be partially loaded. Try read_page to check if content is available, or retry navigation.`
               : `Error creating tab: ${errMsg}`,
           },
         ],
-        isError: !isTimeout,
+        isError: true,
       };
     }
   }
@@ -439,11 +439,11 @@ const handler: ToolHandler = async (
         {
           type: 'text',
           text: isTimeout
-            ? `Navigation timed out — the page did not finish loading within 30s. The page may still be loading or the server may be unresponsive. Try read_page to check if content is available, or retry navigation.`
+            ? `Navigation timed out — the page did not finish loading within 30s. The page may still be partially loaded or the server may be unresponsive. Try read_page to check if content is available, or retry navigation.`
             : `Navigation error: ${errMsg}`,
         },
       ],
-      isError: !isTimeout,
+      isError: true,
     };
   }
 };

--- a/tests/tools/navigate.test.ts
+++ b/tests/tools/navigate.test.ts
@@ -312,7 +312,8 @@ describe('NavigateTool', () => {
         url: 'https://slow-site.com',
       }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
 
-      expect(result.isError).toBe(false);
+      // Timeouts should report isError: true so the LLM knows the page state is indeterminate
+      expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('Navigation timed out');
       expect(result.content[0].text).toContain('read_page');
     });


### PR DESCRIPTION
## Summary

- Change `isError: !isTimeout` to `isError: true` in both navigation code paths (new-tab and existing-tab)
- Navigation timeouts now correctly signal error state to the LLM
- Update existing test expectation to match the new behavior

Closes #304

## Problem

Both navigation error handlers returned `isError: !isTimeout`, meaning timeouts produced `isError: false`. The LLM interpreted this as a successful navigation and proceeded to call `read_page` or `interact` on an indeterminate page state.

This caused a "slow hang" pattern: the LLM would try to interact with elements that hadn't rendered → enter polling loops → eventually timeout after 30-120s per failed interaction — all on a page that was already known to be broken.

```typescript
// BEFORE: timeout → isError: false → LLM sees success
isError: !isTimeout,

// AFTER: timeout → isError: true → LLM knows page state is unreliable
isError: true,
```

## Design Decision

The timeout message still suggests `read_page` as a recovery option ("The page may still be partially loaded. Try read_page to check if content is available"). The difference is that `isError: true` tells the LLM to **treat this as a failure** and make a conscious decision about recovery, rather than blindly proceeding as if the page loaded successfully.

The navigate tool is already registered with `timeoutRecoverable: true` (line 452), so `mcp-server.ts` can apply protocol-level partial-state semantics if needed.

## Changes

| File | Change |
|------|--------|
| `src/tools/navigate.ts:229` | `isError: !isTimeout` → `isError: true` (new-tab path) |
| `src/tools/navigate.ts:446` | `isError: !isTimeout` → `isError: true` (existing-tab path) |
| `tests/tools/navigate.test.ts:315` | Update test expectation to `isError: true` |

## Test plan

- [x] `handles navigation timeout` — updated to expect `isError: true`
- [x] All 1724 existing tests pass
- [x] Build succeeds (`tsc` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved navigation timeout messaging to indicate the page may be partially loaded
  * Navigation timeouts are now treated as error states for clearer user feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->