### PR TITLE
fix: add timeouts to Lightpanda launcher connect() and healthCheck()

### DIFF
--- a/src/lightpanda/launcher.ts
+++ b/src/lightpanda/launcher.ts
@@ -5,6 +5,7 @@
 import { spawn, ChildProcess } from 'child_process';
 import * as puppeteer from 'puppeteer-core';
 import type { Browser } from 'puppeteer-core';
+import { DEFAULT_PUPPETEER_CONNECT_TIMEOUT_MS } from '../config/defaults';
 
 export interface LightpandaLauncherConfig {
   port: number;
@@ -114,12 +115,25 @@ export class LightpandaLauncher {
   }
 
   /**
-   * Connect via puppeteer-core and return Browser instance
+   * Connect via puppeteer-core and return Browser instance.
+   * Includes a timeout to prevent hanging if Lightpanda is listening but unresponsive
+   * (mirrors the timeout pattern used in CDPClient.connectInternal()).
    */
   async connect(): Promise<Browser> {
-    this.browser = await puppeteer.connect({
-      browserWSEndpoint: `ws://localhost:${this.port}`,
-    });
+    let connectTimeout: ReturnType<typeof setTimeout> | undefined;
+    this.browser = await Promise.race([
+      puppeteer.connect({
+        browserWSEndpoint: `ws://localhost:${this.port}`,
+      }).finally(() => {
+        if (connectTimeout !== undefined) clearTimeout(connectTimeout);
+      }),
+      new Promise<never>((_, reject) => {
+        connectTimeout = setTimeout(
+          () => reject(new Error(`Lightpanda puppeteer.connect() timed out after ${DEFAULT_PUPPETEER_CONNECT_TIMEOUT_MS}ms`)),
+          DEFAULT_PUPPETEER_CONNECT_TIMEOUT_MS
+        );
+      }),
+    ]);
     return this.browser;
   }
 
@@ -141,11 +155,14 @@ export class LightpandaLauncher {
   }
 
   /**
-   * Health check - verify Lightpanda is responsive
+   * Health check - verify Lightpanda is responsive.
+   * Uses AbortSignal.timeout to prevent hanging on unresponsive processes.
    */
   private async healthCheck(): Promise<boolean> {
     try {
-      await fetch(`http://localhost:${this.port}/json/version`);
+      await fetch(`http://localhost:${this.port}/json/version`, {
+        signal: AbortSignal.timeout(5000),
+      });
       return true;
     } catch {
       return false;

--- a/tests/src/lightpanda/launcher.test.ts
+++ b/tests/src/lightpanda/launcher.test.ts
@@ -137,7 +137,7 @@ describe('LightpandaLauncher', () => {
 
       await startPromise;
 
-      expect(mockFetch).toHaveBeenCalledWith('http://localhost:9333/json/version');
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost:9333/json/version', expect.objectContaining({ signal: expect.anything() }));
       expect(launcher.isRunning()).toBe(true);
     });
 


### PR DESCRIPTION
## Summary

- Add 15s timeout to `puppeteer.connect()` in Lightpanda launcher (matches Chrome CDPClient pattern)
- Add 5s `AbortSignal.timeout` to `fetch()` healthcheck
- Update test to accept the new `signal` option in fetch calls

Closes #305

## Problem

The Lightpanda launcher had two bare network calls without timeouts:

```typescript
// connect() — no timeout. Hangs 60-120s if Lightpanda is unresponsive.
this.browser = await puppeteer.connect({ browserWSEndpoint: ... });

// healthCheck() — no AbortController. Same OS TCP timeout issue.
await fetch(`http://localhost:${this.port}/json/version`);
```

The Chrome CDPClient wraps its `puppeteer.connect()` with `DEFAULT_PUPPETEER_CONNECT_TIMEOUT_MS` (15s), but the Lightpanda launcher was missing this pattern. Hybrid mode users experienced unexplained long hangs when Lightpanda was unresponsive.

## Changes

| File | Change |
|------|--------|
| `src/lightpanda/launcher.ts` | `connect()`: wrap in `Promise.race` with 15s timeout; `healthCheck()`: add `AbortSignal.timeout(5000)` |
| `tests/src/lightpanda/launcher.test.ts` | Update fetch assertion to accept the new `signal` option |

## Test plan

- [x] All 8 Lightpanda launcher tests pass
- [x] All 1724 existing tests pass
- [x] Build succeeds (`tsc` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout protection to Lightpanda connection attempts to prevent indefinite hangs and enable faster failure detection
  * Added timeout protection to health checks with a 5-second limit
  * Improved error messaging for timeout scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->