### PR TITLE
fix: add error logging to session manager silent failure points

### DIFF
--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -837,8 +837,10 @@ export class SessionManager {
           intervalMs,
           filePath,
         });
-      } catch {
-        // Best-effort: don't block session creation on storage state errors
+      } catch (err) {
+        console.error(`[SessionManager] Storage state restore failed for session ${sessionId}: ${err instanceof Error ? err.message : String(err)}`);
+        // Clean up the inconsistent manager entry so deleteSession doesn't operate on an uninitialized manager
+        this.storageStateManagers.delete(sessionId);
       }
     }
 
@@ -996,6 +998,7 @@ export class SessionManager {
       )) {
         throw error;
       }
+      console.error(`[SessionManager] getPage failed for target ${targetId.slice(0, 8)}: ${error instanceof Error ? error.message : String(error)}`);
       this.onTargetClosed(targetId);
       return null;
     }
@@ -1039,7 +1042,8 @@ export class SessionManager {
       console.error(`[SessionManager] Recovered untracked target ${targetId.slice(0, 8)} (${pageUrl.slice(0, 50)}) into session ${sessionId} worker ${resolvedWorkerId}`);
 
       return page;
-    } catch {
+    } catch (err) {
+      console.error(`[SessionManager] tryRecoverTarget failed for ${targetId.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`);
       return null;
     }
   }


### PR DESCRIPTION
## Summary

- Add `console.error` logging to 3 silent catch blocks in SessionManager
- Clean up inconsistent StorageStateManager on restore failure
- Enable diagnosis of previously invisible target eviction and recovery failures

Closes #307

## Problem

Three catch blocks silently swallowed errors, creating invisible state corruption:

### 1. `getPage()` (line 991)
```typescript
// BEFORE: permanent target eviction with no log
} catch (error) {
  if (/* domain guard */) throw error;
  this.onTargetClosed(targetId);  // silent eviction
  return null;
}

// AFTER: log before evicting
console.error(`[SessionManager] getPage failed for target ${targetId}: ${error.message}`);
this.onTargetClosed(targetId);
```

### 2. `tryRecoverTarget()` (line 1042)
```typescript
// BEFORE: zero diagnostics
} catch { return null; }

// AFTER: log root cause
} catch (err) {
  console.error(`[SessionManager] tryRecoverTarget failed for ${targetId}: ${err.message}`);
  return null;
}
```

### 3. `StorageStateManager restore` (line 840)
```typescript
// BEFORE: manager left in map in inconsistent state
} catch { /* best-effort */ }

// AFTER: log and clean up
} catch (err) {
  console.error(`[SessionManager] Storage state restore failed: ${err.message}`);
  this.storageStateManagers.delete(sessionId);  // remove inconsistent entry
}
```

## Impact

These silent failures were identified as **precursors to hang scenarios**:
1. `getPage()` silently evicts target → LLM retries with stale tab ID → repeated failures
2. `tryRecoverTarget()` silently fails → target permanently lost with no diagnosis possible
3. StorageStateManager left inconsistent → session cleanup operates on uninitialized manager

With logging in place, these failures become visible in stderr for debugging.

## Changes

| File | Change |
|------|--------|
| `src/session-manager.ts:991` | Add error logging before `onTargetClosed()` |
| `src/session-manager.ts:1042` | Add error logging to `tryRecoverTarget()` catch |
| `src/session-manager.ts:840` | Add error logging + `storageStateManagers.delete()` on restore failure |

## Test plan

- [x] All 1724 existing tests pass
- [x] Build succeeds (`tsc` clean)
- [x] No behavioral change — only adds logging and cleanup of inconsistent state

🤖 Generated with [Claude Code](https://claude.com/claude-code)