### PR TITLE
fix: prevent page leak in connection pool when goto about:blank fails

### DIFF
--- a/src/cdp/connection-pool.ts
+++ b/src/cdp/connection-pool.ts
@@ -302,8 +302,18 @@ export class CDPConnectionPool {
       // Ignore URL parsing errors
     }
 
-    // Navigate to blank page to clear state
-    await page.goto('about:blank', { waitUntil: 'domcontentloaded', timeout: 5000 });
+    // Navigate to blank page to clear state.
+    // If this fails (page being torn down, Chrome under pressure), the page is
+    // unusable — close it and don't return it to the pool. Without this try/catch
+    // the page becomes orphaned: removed from inUsePages but never added to
+    // availablePages, causing a slow memory leak over many release cycles.
+    try {
+      await page.goto('about:blank', { waitUntil: 'domcontentloaded', timeout: 5000 });
+    } catch (err) {
+      console.error(`[ConnectionPool] goto about:blank failed during cleanup, discarding page: ${err instanceof Error ? err.message : String(err)}`);
+      await page.close().catch(() => {});
+      return;
+    }
 
     // Clear cookies and storage via CDP session (with proper cleanup in finally)
     const client = await page.createCDPSession();


### PR DESCRIPTION
## Summary

- Wrap `page.goto('about:blank')` in try/catch in `cleanAndReturnToPool()`
- On failure, close the page and discard it instead of leaving it orphaned
- Prevents slow memory leak over many page release cycles

Closes #308

## Problem

```typescript
// releasePage():
this.inUsePages.delete(page);  // removed from tracking BEFORE cleanup
this.cleanAndReturnToPool(page, pooledPage).catch((err) => {
  page.close().catch(() => {});  // may also fail
});

// cleanAndReturnToPool():
await page.goto('about:blank', ...);  // NOT in try/catch — if this throws:
// page is not in inUsePages (already deleted)
// page is not in availablePages (never added)
// → ORPHAN: Chrome holds it, pool doesn't know about it
```

Over many release cycles, orphaned pages accumulate as Chrome tabs, causing unbounded memory growth → OOM → connection loss → hang.

## Fix

```typescript
try {
  await page.goto('about:blank', { waitUntil: 'domcontentloaded', timeout: 5000 });
} catch (err) {
  console.error(`[ConnectionPool] goto about:blank failed, discarding page: ${err.message}`);
  await page.close().catch(() => {});
  return;  // don't return to pool
}
```

## Changes

| File | Change |
|------|--------|
| `src/cdp/connection-pool.ts:306` | Wrap `goto` in try/catch; close and discard on failure |

## Test plan

- [x] All 1724 existing tests pass
- [x] Build succeeds (`tsc` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)