### PR TITLE
fix: propagate navigation failure in workflow init instead of swallowing

### DIFF
--- a/src/orchestration/workflow-engine.ts
+++ b/src/orchestration/workflow-engine.ts
@@ -216,9 +216,22 @@ export class WorkflowEngine {
             // Cookie bridging failure is non-fatal — page navigates without cookies
           }
 
-          await page.goto(step.url, { waitUntil: 'domcontentloaded', timeout: DEFAULT_NAVIGATION_TIMEOUT_MS }).catch((err) => {
-            console.error(`[WorkflowEngine] Navigation to ${step.url} failed: ${err instanceof Error ? err.message : String(err)}`);
-          });
+          try {
+            await page.goto(step.url, { waitUntil: 'domcontentloaded', timeout: DEFAULT_NAVIGATION_TIMEOUT_MS });
+          } catch (navErr) {
+            const msg = navErr instanceof Error ? navErr.message : String(navErr);
+            console.error(`[WorkflowEngine] Navigation to ${step.url} failed for worker "${step.workerName}": ${msg}`);
+            const pool = getCDPConnectionPool();
+            await pool.releasePage(page).catch(() => {});
+            return {
+              workerId: worker.id,
+              workerName: step.workerName,
+              tabId: '',
+              task: step.task,
+              navigationFailed: true,
+              navigationError: msg,
+            };
+          }
         }
 
         // Register the page as a target in the session manager
@@ -230,9 +243,21 @@ export class WorkflowEngine {
           workerName: step.workerName,
           tabId: targetId,
           task: step.task,
+          navigationFailed: false,
         };
       })
     );
+
+    // Separate successfully navigated workers from navigation failures
+    const successfulWorkers = workers.filter(w => !w.navigationFailed);
+    const failedNavWorkers = workers.filter(w => w.navigationFailed);
+
+    if (failedNavWorkers.length > 0) {
+      console.error(
+        `[WorkflowEngine] ${failedNavWorkers.length}/${workers.length} workers failed navigation: ` +
+        failedNavWorkers.map(w => `${w.workerName} (${(w as any).navigationError})`).join(', ')
+      );
+    }
 
     // Initialize file-based orchestration state (for scratchpads / debugging)
     await this.stateManager.initOrchestration(
@@ -244,7 +269,14 @@ export class WorkflowEngine {
     // Initialize in-memory state — this is the authoritative source for completion tracking
     const workerStatuses = new Map<string, { status: WorkerState['status']; resultSummary: string }>();
     for (const w of workers) {
-      workerStatuses.set(w.workerName, { status: 'INIT', resultSummary: '' });
+      if (w.navigationFailed) {
+        workerStatuses.set(w.workerName, {
+          status: 'FAIL',
+          resultSummary: `Navigation failed: ${(w as any).navigationError}`,
+        });
+      } else {
+        workerStatuses.set(w.workerName, { status: 'INIT', resultSummary: '' });
+      }
     }
 
     const workerTimeoutMs = workflow.timeout || 60_000;
@@ -256,7 +288,7 @@ export class WorkflowEngine {
       createdAt: Date.now(),
       totalWorkers: workers.length,
       completedWorkers: 0,
-      failedWorkers: 0,
+      failedWorkers: failedNavWorkers.length,
       workerStatuses,
       overallStatus: 'INIT',
       allDone: false,
@@ -266,8 +298,8 @@ export class WorkflowEngine {
     };
     this.workflowStates.set(orchestrationId, memState);
 
-    // Initialize per-worker runtime state and set up timeouts
-    for (const w of workers) {
+    // Initialize per-worker runtime state and set up timeouts (only for successful workers)
+    for (const w of successfulWorkers) {
       const runtimeState: WorkerRuntimeState = {
         workerName: w.workerName,
         startTime: Date.now(),
@@ -295,7 +327,10 @@ export class WorkflowEngine {
     globalHandle.unref();
     this.globalTimeoutHandles.set(orchestrationId, globalHandle);
 
-    console.error(`[WorkflowEngine] Initialized workflow ${orchestrationId} with ${workers.length} workers (timeout: ${workerTimeoutMs}ms/worker, ${memState.globalTimeoutMs}ms global)`);
+    const navFailNote = failedNavWorkers.length > 0
+      ? ` (${failedNavWorkers.length} failed navigation)`
+      : '';
+    console.error(`[WorkflowEngine] Initialized workflow ${orchestrationId} with ${workers.length} workers${navFailNote} (timeout: ${workerTimeoutMs}ms/worker, ${memState.globalTimeoutMs}ms global)`);
 
     return {
       orchestrationId,
@@ -303,6 +338,7 @@ export class WorkflowEngine {
         workerId: w.workerId,
         workerName: w.workerName,
         tabId: w.tabId,
+        ...(w.navigationFailed ? { navigationFailed: true, navigationError: (w as any).navigationError } : {}),
       })),
     };
   }

--- a/tests/orchestration/workflow-engine.test.ts
+++ b/tests/orchestration/workflow-engine.test.ts
@@ -726,6 +726,182 @@ describe('WorkflowEngine', () => {
     });
   });
 
+  describe('navigation failure handling', () => {
+    test('should mark worker as navigationFailed when page.goto rejects', async () => {
+      const { getCDPConnectionPool } = require('../../src/cdp/connection-pool');
+      const mockPool = getCDPConnectionPool();
+
+      mockPool.acquireBatch.mockImplementationOnce((count: number) => {
+        return Promise.resolve(
+          Array.from({ length: count }, () => {
+            const id = `nav-fail-${++batchPageCounter}`;
+            return {
+              target: () => ({ _targetId: id }),
+              goto: jest.fn().mockRejectedValue(new Error('net::ERR_NAME_NOT_RESOLVED')),
+              close: jest.fn().mockResolvedValue(undefined),
+              url: jest.fn().mockReturnValue('about:blank'),
+              on: jest.fn(),
+              off: jest.fn(),
+            };
+          })
+        );
+      });
+
+      const workflow: WorkflowDefinition = {
+        id: 'wf-nav-fail',
+        name: 'Nav Fail Test',
+        steps: [
+          { workerId: 'w1', workerName: 'fail-worker', url: 'https://nonexistent.invalid', task: 'Task', successCriteria: 'Done' },
+        ],
+        parallel: true,
+        maxRetries: 3,
+        timeout: 300000,
+      };
+
+      const result = await engine.initWorkflow(testSessionId, workflow);
+
+      expect(result.workers[0].workerName).toBe('fail-worker');
+      expect((result.workers[0] as any).navigationFailed).toBe(true);
+      expect((result.workers[0] as any).navigationError).toContain('net::ERR_NAME_NOT_RESOLVED');
+      expect(result.workers[0].tabId).toBe('');
+      expect(mockPool.releasePage).toHaveBeenCalled();
+    });
+
+    test('should mark failed worker as FAIL in orchestration state', async () => {
+      const { getCDPConnectionPool } = require('../../src/cdp/connection-pool');
+      const mockPool = getCDPConnectionPool();
+
+      mockPool.acquireBatch.mockImplementationOnce((count: number) => {
+        return Promise.resolve(
+          Array.from({ length: count }, () => {
+            const id = `nav-fail-state-${++batchPageCounter}`;
+            return {
+              target: () => ({ _targetId: id }),
+              goto: jest.fn().mockRejectedValue(new Error('Navigation timeout')),
+              close: jest.fn().mockResolvedValue(undefined),
+              url: jest.fn().mockReturnValue('about:blank'),
+              on: jest.fn(),
+              off: jest.fn(),
+            };
+          })
+        );
+      });
+
+      const workflow: WorkflowDefinition = {
+        id: 'wf-nav-fail-state',
+        name: 'Nav Fail State Test',
+        steps: [
+          { workerId: 'w1', workerName: 'state-fail-worker', url: 'https://timeout.invalid', task: 'Task', successCriteria: 'Done' },
+        ],
+        parallel: true,
+        maxRetries: 3,
+        timeout: 300000,
+      };
+
+      await engine.initWorkflow(testSessionId, workflow);
+
+      const orch = await engine.getOrchestrationStatus();
+      expect(orch).not.toBeNull();
+      expect(orch?.failedWorkers).toBe(1);
+      const workerStatus = orch?.workers.find(w => w.workerName === 'state-fail-worker');
+      expect(workerStatus?.status).toBe('FAIL');
+      expect(workerStatus?.resultSummary).toContain('Navigation failed');
+    });
+
+    test('should not register failed worker as target in session manager', async () => {
+      const { getCDPConnectionPool } = require('../../src/cdp/connection-pool');
+      const mockPool = getCDPConnectionPool();
+
+      mockPool.acquireBatch.mockImplementationOnce((count: number) => {
+        return Promise.resolve(
+          Array.from({ length: count }, () => {
+            const id = `nav-fail-noreg-${++batchPageCounter}`;
+            return {
+              target: () => ({ _targetId: id }),
+              goto: jest.fn().mockRejectedValue(new Error('Connection refused')),
+              close: jest.fn().mockResolvedValue(undefined),
+              url: jest.fn().mockReturnValue('about:blank'),
+              on: jest.fn(),
+              off: jest.fn(),
+            };
+          })
+        );
+      });
+
+      mockSessionManager.registerExistingTarget.mockClear();
+
+      const workflow: WorkflowDefinition = {
+        id: 'wf-nav-fail-noreg',
+        name: 'Nav Fail No Register',
+        steps: [
+          { workerId: 'w1', workerName: 'noreg-worker', url: 'https://fail.invalid', task: 'Task', successCriteria: 'Done' },
+        ],
+        parallel: true,
+        maxRetries: 3,
+        timeout: 300000,
+      };
+
+      await engine.initWorkflow(testSessionId, workflow);
+
+      expect(mockSessionManager.registerExistingTarget).not.toHaveBeenCalled();
+    });
+
+    test('should handle mixed success and failure workers', async () => {
+      const { getCDPConnectionPool } = require('../../src/cdp/connection-pool');
+      const mockPool = getCDPConnectionPool();
+
+      let callCount = 0;
+      mockPool.acquireBatch.mockImplementationOnce((count: number) => {
+        return Promise.resolve(
+          Array.from({ length: count }, () => {
+            callCount++;
+            const id = `mixed-${++batchPageCounter}`;
+            return {
+              target: () => ({ _targetId: id }),
+              goto: callCount === 1
+                ? jest.fn().mockResolvedValue(null)
+                : jest.fn().mockRejectedValue(new Error('Timeout')),
+              close: jest.fn().mockResolvedValue(undefined),
+              url: jest.fn().mockReturnValue('about:blank'),
+              on: jest.fn(),
+              off: jest.fn(),
+            };
+          })
+        );
+      });
+
+      mockSessionManager.registerExistingTarget.mockClear();
+
+      const workflow: WorkflowDefinition = {
+        id: 'wf-mixed',
+        name: 'Mixed Test',
+        steps: [
+          { workerId: 'w1', workerName: 'ok-worker', url: 'https://good.com', task: 'Task 1', successCriteria: 'Done' },
+          { workerId: 'w2', workerName: 'bad-worker', url: 'https://bad.invalid', task: 'Task 2', successCriteria: 'Done' },
+        ],
+        parallel: true,
+        maxRetries: 3,
+        timeout: 300000,
+      };
+
+      const result = await engine.initWorkflow(testSessionId, workflow);
+
+      const okWorker = result.workers.find(w => w.workerName === 'ok-worker');
+      const badWorker = result.workers.find(w => w.workerName === 'bad-worker');
+
+      expect((okWorker as any).navigationFailed).toBeUndefined();
+      expect(okWorker?.tabId).not.toBe('');
+
+      expect((badWorker as any).navigationFailed).toBe(true);
+      expect(badWorker?.tabId).toBe('');
+
+      expect(mockSessionManager.registerExistingTarget).toHaveBeenCalledTimes(1);
+
+      const orch = await engine.getOrchestrationStatus();
+      expect(orch?.failedWorkers).toBe(1);
+    });
+  });
+
   describe('getWorkflowEngine singleton', () => {
     test('should return the same instance', () => {
       const instance1 = getWorkflowEngine();


### PR DESCRIPTION
## Summary

Supersedes #313 (rebased on top of #312).

- Stop silently swallowing `page.goto()` failures in `WorkflowEngine.initWorkflow()`
- Failed workers are now marked with `navigationFailed: true`, `FAIL` status, and empty `tabId`
- Failed pages are released back to the connection pool instead of being orphaned
- `registerExistingTarget()` is skipped for failed workers, preventing stale tab tracking

Closes #303

## Test plan

- [x] 4 new navigation failure tests + all existing tests pass (60 total in workflow-engine)
- [x] Build succeeds (`tsc` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)