### PR TITLE
feat: add for attr to DOM serializer and ARIA role selectors to fill_form

### DIFF
--- a/src/dom/dom-serializer.ts
+++ b/src/dom/dom-serializer.ts
@@ -64,7 +64,7 @@ const SKIP_TAGS = new Set([
 const KEEP_ATTRS = new Set([
   'id', 'name', 'type', 'value', 'placeholder', 'aria-label', 'role',
   'href', 'src', 'alt', 'title', 'data-testid', 'disabled', 'checked',
-  'selected', 'required', 'class',
+  'selected', 'required', 'class', 'for',
   // Common data attributes for testing and automation
   'data-cy', 'data-qa', 'data-id', 'data-value', 'data-state',
   'tabindex',

--- a/src/utils/element-discovery.ts
+++ b/src/utils/element-discovery.ts
@@ -359,6 +359,10 @@ export async function discoverFormFields(
         '[contenteditable="true"]',
         '[role="textbox"]',
         '[role="combobox"]',
+        '[role="radio"]',
+        '[role="checkbox"]',
+        '[role="switch"]',
+        '[role="slider"]',
       ];
 
       let index = 0;


### PR DESCRIPTION
## Summary

- Add `for` to `KEEP_ATTRS` in `src/dom/dom-serializer.ts` so that label-input relationships (`<label for="...">`) are preserved in serialized DOM output, giving the LLM the context it needs to associate labels with their controls.
- Add `[role="radio"]`, `[role="checkbox"]`, `[role="switch"]`, and `[role="slider"]` to the `discoverFormFields` selector list in `src/utils/element-discovery.ts` so `fill_form` can interact with custom UI framework components that use ARIA roles instead of native HTML input elements.

Part of #322.

## Test plan

- [x] `npm run build` passes (both CLI and main tsconfigs)
- [x] `npm test` passes — 1746 tests across 87 suites, 0 failures
- [ ] Manual smoke test: verify serialized DOM for a page with `<label for="email">` includes the `for` attribute
- [ ] Manual smoke test: verify `fill_form` targets a `[role="checkbox"]` component on a custom component library page

🤖 Generated with [Claude Code](https://claude.com/claude-code)