### PR TITLE
feat: integrate AX-First resolution into interact, click_element, find, wait_and_click

### DIFF
--- a/src/tools/click-element.ts
+++ b/src/tools/click-element.ts
@@ -13,6 +13,8 @@ import { withDomDelta } from '../utils/dom-delta';
 import { AdaptiveScreenshot } from '../utils/adaptive-screenshot';
 import { FoundElement, scoreElement, tokenizeQuery } from '../utils/element-finder';
 import { discoverElements, getTaggedElementRect, cleanupTags, DISCOVERY_TAG } from '../utils/element-discovery';
+import { resolveElementsByAXTree, invalidateAXCache } from '../utils/ax-element-resolver';
+import { getTargetId } from '../utils/puppeteer-helpers';
 
 const definition: MCPToolDefinition = {
   name: 'click_element',
@@ -100,6 +102,63 @@ const handler: ToolHandler = async (
     const startTime = Date.now();
     const cdpClient = sessionManager.getCDPClient();
 
+    // ─── AX-First Resolution ───
+    try {
+      const axMatches = await resolveElementsByAXTree(page, cdpClient, query, {
+        useCenter: true, maxResults: 3,
+      });
+      if (axMatches.length > 0 && axMatches[0].axScore >= 60) {
+        const ax = axMatches[0];
+
+        // Scroll into view and re-resolve coordinates
+        try {
+          await cdpClient.send(page, 'DOM.scrollIntoViewIfNeeded', { backendNodeId: ax.backendDOMNodeId });
+          await new Promise(resolve => setTimeout(resolve, DEFAULT_DOM_SETTLE_DELAY_MS));
+          const { model } = await cdpClient.send<{ model: { content: number[] } }>(
+            page, 'DOM.getBoxModel', { backendNodeId: ax.backendDOMNodeId }
+          );
+          if (model?.content && model.content.length >= 8) {
+            const bx = model.content[0], by = model.content[1];
+            const bw = model.content[2] - bx, bh = model.content[5] - by;
+            if (bw > 0 && bh > 0) ax.rect = { x: bx + bw / 2, y: by + bh / 2, width: bw, height: bh };
+          }
+        } catch { /* use original coords */ }
+
+        const axX = Math.round(ax.rect.x), axY = Math.round(ax.rect.y);
+
+        const { delta: axDelta } = await withDomDelta(page, async () => {
+          if (doubleClick) await page.mouse.click(axX, axY, { clickCount: 2 });
+          else await page.mouse.click(axX, axY);
+        }, { settleMs: Math.max(150, waitAfter) });
+
+        invalidateAXCache(getTargetId(page.target()));
+
+        const axRef = refIdManager.generateRef(sessionId, tabId, ax.backendDOMNodeId, ax.role, ax.name, undefined, undefined);
+        await cleanupTags(page, DISCOVERY_TAG).catch(() => {});
+        AdaptiveScreenshot.getInstance().reset(tabId);
+
+        const axVerb = doubleClick ? 'Double-clicked' : 'Clicked';
+        const resultText = `\u2713 ${axVerb} ${ax.role} "${ax.name}" [${axRef}] [via AX tree, score: ${ax.axScore}/100]${axDelta}`;
+
+        if (verify) {
+          try {
+            const buf = await page.screenshot({ type: 'webp', quality: DEFAULT_SCREENSHOT_QUALITY, encoding: 'base64' }) as string;
+            return {
+              content: [
+                { type: 'text' as const, text: resultText },
+                { type: 'image' as const, data: buf, mimeType: 'image/webp' },
+              ],
+            };
+          } catch { /* screenshot failed */ }
+        }
+
+        return { content: [{ type: 'text' as const, text: resultText }] };
+      }
+    } catch {
+      // AX non-fatal — fall through to CSS
+    }
+
+    // ─── CSS Fallback ───
     do { // --- polling loop start ---
     // Find elements matching the query
     let rawResults: Omit<FoundElement, 'score'>[];

--- a/src/tools/find.ts
+++ b/src/tools/find.ts
@@ -9,6 +9,7 @@ import { getRefIdManager } from '../utils/ref-id-manager';
 import { withTimeout } from '../utils/with-timeout';
 import { discoverElements, cleanupTags, DISCOVERY_TAG } from '../utils/element-discovery';
 import { FoundElement, scoreElement, tokenizeQuery } from '../utils/element-finder';
+import { resolveElementsByAXTree } from '../utils/ax-element-resolver';
 
 const definition: MCPToolDefinition = {
   name: 'find',
@@ -81,6 +82,40 @@ const handler: ToolHandler = async (
 
     const cdpClient = sessionManager.getCDPClient();
 
+    // ─── AX-First Resolution ───
+    try {
+      const axMatches = await resolveElementsByAXTree(page, cdpClient, query, {
+        useCenter: false,
+        maxResults: 20,
+      });
+
+      if (axMatches.length > 0 && axMatches[0].axScore >= 60) {
+        const axOutput: string[] = [];
+        for (const el of axMatches) {
+          const refId = refIdManager.generateRef(
+            sessionId, tabId, el.backendDOMNodeId,
+            el.role, el.name, undefined, undefined
+          );
+          const scoreLabel = el.axScore >= 90 ? '\u2605\u2605\u2605' : el.axScore >= 60 ? '\u2605\u2605' : '\u2605';
+          axOutput.push(
+            `[${refId}] ${el.role}: "${el.name}" at (${Math.round(el.rect.x)}, ${Math.round(el.rect.y)}) ${scoreLabel} [AX]`
+          );
+        }
+
+        await cleanupTags(page, DISCOVERY_TAG).catch(() => {});
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Found ${axOutput.length} elements matching "${query}" [via AX tree]:\n\n${axOutput.join('\n')}`,
+          }],
+        };
+      }
+    } catch {
+      // AX non-fatal — fall through to CSS
+    }
+
+    // ─── CSS Fallback ───
     do { // --- polling loop start ---
     let scored: FoundElement[];
     try {

--- a/src/tools/interact.ts
+++ b/src/tools/interact.ts
@@ -14,6 +14,8 @@ import { DEFAULT_DOM_SETTLE_DELAY_MS, DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS, DEFAUL
 import { FoundElement, scoreElement, tokenizeQuery } from '../utils/element-finder';
 import { discoverElements, getTaggedElementRect, cleanupTags, DISCOVERY_TAG } from '../utils/element-discovery';
 import { withTimeout } from '../utils/with-timeout';
+import { resolveElementsByAXTree, invalidateAXCache } from '../utils/ax-element-resolver';
+import { getTargetId } from '../utils/puppeteer-helpers';
 
 const definition: MCPToolDefinition = {
   name: 'interact',
@@ -108,6 +110,103 @@ const handler: ToolHandler = async (
     const startTime = Date.now();
     const cdpClient = sessionManager.getCDPClient();
 
+    // ─── AX-First Resolution ───
+    // Try AX tree first — the browser's accessibility engine understands all UI frameworks
+    try {
+      const axMatches = await resolveElementsByAXTree(page, cdpClient, query, {
+        useCenter: true,
+        maxResults: 3,
+      });
+      if (axMatches.length > 0 && axMatches[0].axScore >= 60) {
+        const ax = axMatches[0];
+
+        // Scroll into view
+        try {
+          await cdpClient.send(page, 'DOM.scrollIntoViewIfNeeded', {
+            backendNodeId: ax.backendDOMNodeId,
+          });
+          await new Promise(resolve => setTimeout(resolve, DEFAULT_DOM_SETTLE_DELAY_MS));
+          // Re-resolve coordinates after scroll
+          const { model } = await cdpClient.send<{ model: { content: number[] } }>(
+            page, 'DOM.getBoxModel', { backendNodeId: ax.backendDOMNodeId }
+          );
+          if (model?.content && model.content.length >= 8) {
+            const bx = model.content[0], by = model.content[1];
+            const bw = model.content[2] - bx, bh = model.content[5] - by;
+            if (bw > 0 && bh > 0) {
+              ax.rect = { x: bx + bw / 2, y: by + bh / 2, width: bw, height: bh };
+            }
+          }
+        } catch { /* use original coordinates */ }
+
+        const axX = Math.round(ax.rect.x);
+        const axY = Math.round(ax.rect.y);
+
+        // Perform action with DOM delta
+        const { delta: axDelta } = await withDomDelta(page, async () => {
+          if (action === 'double_click') await page.mouse.click(axX, axY, { clickCount: 2 });
+          else if (action === 'hover') await page.mouse.move(axX, axY);
+          else await page.mouse.click(axX, axY);
+        }, { settleMs: Math.max(150, waitAfter) });
+
+        // Invalidate AX cache after interaction
+        invalidateAXCache(getTargetId(page.target()));
+
+        // Generate ref
+        const axRef = refIdManager.generateRef(
+          sessionId, tabId, ax.backendDOMNodeId,
+          ax.role, ax.name, undefined, undefined
+        );
+
+        // Clean up any leftover tags
+        await cleanupTags(page, DISCOVERY_TAG).catch(() => {});
+
+        // Build response with AX provenance + confidence score
+        const axVerb = action === 'double_click' ? 'Double-clicked' : action === 'hover' ? 'Hovered' : 'Clicked';
+        const axLine = `\u2713 ${axVerb} ${ax.role} "${ax.name}" [${axRef}] [via AX tree, score: ${ax.axScore}/100]`;
+
+        // Gather state summary (same as CSS path)
+        const axState = await withTimeout(page.evaluate(() => {
+          const url = window.location.href;
+          const title = document.title;
+          const active = document.activeElement;
+          let activeInfo = 'none';
+          if (active && active !== document.body) {
+            const tag = active.tagName.toLowerCase();
+            const role = active.getAttribute('role') || tag;
+            const name = active.getAttribute('aria-label') || (active as HTMLInputElement).value?.slice(0, 30) || active.textContent?.slice(0, 30) || '';
+            activeInfo = `${role}: "${name}"`;
+          }
+          return { url, title, activeInfo };
+        }), 3000, 'state-summary').catch(() => ({ url: '', title: '', activeInfo: 'unknown' }));
+
+        const lines: string[] = [axLine];
+        if (axDelta) lines.push('', '[DOM Delta]', axDelta);
+        if (axState.activeInfo !== 'none') lines.push('', `[Focused] ${axState.activeInfo}`);
+
+        const resultContent: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }> = [
+          { type: 'text' as const, text: lines.join('\n') },
+        ];
+
+        // Optional screenshot (verify mode)
+        if (verify) {
+          try {
+            const screenshotBuf = await withTimeout(
+              page.screenshot({ type: 'webp', quality: 60, encoding: 'base64' }),
+              DEFAULT_SCREENSHOT_TIMEOUT_MS,
+              'verify-screenshot'
+            ) as string;
+            resultContent.push({ type: 'image' as const, data: screenshotBuf, mimeType: 'image/webp' });
+          } catch { /* screenshot failed, non-fatal */ }
+        }
+
+        return { content: resultContent };
+      }
+    } catch {
+      // AX resolution failed — fall through to CSS discovery
+    }
+
+    // ─── CSS Fallback (existing logic) ───
     do {
     // Find elements matching the query using the shared discovery module
     let results: Omit<FoundElement, 'score'>[];
@@ -227,12 +326,16 @@ const handler: ToolHandler = async (
     // Clean up discovery tags to prevent stale properties
     await cleanupTags(page, DISCOVERY_TAG).catch(() => {});
 
-    // Build compact action label
+    // Invalidate AX cache after CSS-path interaction too
+    invalidateAXCache(getTargetId(page.target()));
+
+    // Build compact action label with confidence score
     const actionVerb = action === 'double_click' ? 'Double-clicked' : action === 'hover' ? 'Hovered' : 'Clicked';
     const textSample = bestMatch.textContent?.slice(0, 50) || bestMatch.name.slice(0, 50);
     const textPart = textSample ? ` "${textSample}"` : '';
     const refPart = refId ? ` [${refId}]` : '';
-    const interactedLine = `\u2713 ${actionVerb} ${bestMatch.tagName}${textPart}${refPart}`;
+    const confidencePart = bestMatch.score < 50 ? ` \u26a0 LOW CONFIDENCE [via CSS, score: ${bestMatch.score}/100]` : ` [via CSS, score: ${bestMatch.score}/100]`;
+    const interactedLine = `\u2713 ${actionVerb} ${bestMatch.tagName}${textPart}${refPart}${confidencePart}`;
 
     // Gather state summary via page.evaluate
     const stateSummary = await withTimeout(page.evaluate(() => {

--- a/src/tools/wait-and-click.ts
+++ b/src/tools/wait-and-click.ts
@@ -12,6 +12,8 @@ import { DEFAULT_DOM_SETTLE_DELAY_MS } from '../config/defaults';
 import { withDomDelta } from '../utils/dom-delta';
 import { discoverElements, getTaggedElementRect, cleanupTags, DISCOVERY_TAG } from '../utils/element-discovery';
 import { FoundElement, scoreElement, tokenizeQuery } from '../utils/element-finder';
+import { resolveElementsByAXTree, invalidateAXCache, AXResolvedElement } from '../utils/ax-element-resolver';
+import { getTargetId } from '../utils/puppeteer-helpers';
 
 const definition: MCPToolDefinition = {
   name: 'wait_and_click',
@@ -83,8 +85,21 @@ const handler: ToolHandler = async (
 
     const cdpClient = sessionManager.getCDPClient();
 
-    // Poll for the element
+    // Poll for the element (AX-first, CSS fallback)
+    let axMatch: AXResolvedElement | null = null;
     while (Date.now() - startTime < timeout) {
+      // Try AX tree first
+      try {
+        const axMatches = await resolveElementsByAXTree(page, cdpClient, query, {
+          useCenter: true, maxResults: 1,
+        });
+        if (axMatches.length > 0 && axMatches[0].axScore >= 60) {
+          axMatch = axMatches[0];
+          break;
+        }
+      } catch { /* AX non-fatal */ }
+
+      // CSS fallback
       try {
         const results = await discoverElements(page, cdpClient, queryLower, {
           maxResults: 30,
@@ -93,7 +108,6 @@ const handler: ToolHandler = async (
           toolName: 'wait_and_click',
         });
 
-        // Score and find best match
         const scored = results
           .map((el, i) => ({ ...el, score: scoreElement(el as FoundElement, queryLower, queryTokens), _origIdx: i }))
           .sort((a, b) => b.score - a.score);
@@ -103,11 +117,42 @@ const handler: ToolHandler = async (
           break;
         }
       } catch {
-        // CDP evaluate timed out (e.g. dialog blocked) — retry on next poll iteration
+        // CDP evaluate timed out — retry on next poll iteration
       }
 
-      // Wait before next poll
       await new Promise(resolve => setTimeout(resolve, pollInterval));
+    }
+
+    // ─── AX Match Path ───
+    if (axMatch) {
+      const waitTime = Date.now() - startTime;
+      try {
+        await cdpClient.send(page, 'DOM.scrollIntoViewIfNeeded', { backendNodeId: axMatch.backendDOMNodeId });
+        await new Promise(resolve => setTimeout(resolve, DEFAULT_DOM_SETTLE_DELAY_MS));
+        const { model } = await cdpClient.send<{ model: { content: number[] } }>(
+          page, 'DOM.getBoxModel', { backendNodeId: axMatch.backendDOMNodeId }
+        );
+        if (model?.content && model.content.length >= 8) {
+          const bx = model.content[0], by = model.content[1];
+          const bw = model.content[2] - bx, bh = model.content[5] - by;
+          if (bw > 0 && bh > 0) axMatch.rect = { x: bx + bw / 2, y: by + bh / 2, width: bw, height: bh };
+        }
+      } catch { /* use original coords */ }
+
+      const axX = Math.round(axMatch.rect.x), axY = Math.round(axMatch.rect.y);
+      const { delta: axDelta } = await withDomDelta(page, () => page.mouse.click(axX, axY));
+
+      invalidateAXCache(getTargetId(page.target()));
+      await cleanupTags(page, DISCOVERY_TAG).catch(() => {});
+
+      const axRef = refIdManager.generateRef(sessionId, tabId, axMatch.backendDOMNodeId, axMatch.role, axMatch.name, undefined, undefined);
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: `\u2713 Clicked ${axMatch.role} "${axMatch.name}" [${axRef}] [via AX tree, score: ${axMatch.axScore}/100] (waited ${waitTime}ms)${axDelta}`,
+        }],
+      };
     }
 
     if (!bestMatch) {

--- a/tests/tools/find.test.ts
+++ b/tests/tools/find.test.ts
@@ -13,6 +13,12 @@ jest.mock('../../src/utils/ref-id-manager', () => ({
   getRefIdManager: jest.fn(),
 }));
 
+jest.mock('../../src/utils/ax-element-resolver', () => ({
+  resolveElementsByAXTree: jest.fn().mockResolvedValue([]),
+  invalidateAXCache: jest.fn(),
+  clearAXCache: jest.fn(),
+}));
+
 import { getSessionManager } from '../../src/session-manager';
 import { getRefIdManager } from '../../src/utils/ref-id-manager';
 


### PR DESCRIPTION
## Summary

Integrate AX-First Element Resolution into all 4 element-targeting tools. Each tool now tries the Chrome Accessibility Tree before CSS-based discovery.

Part of #322 (PR 3 of 3). Builds on #324 (merged).

## Changes

| File | Change |
|------|--------|
| `src/tools/interact.ts` | AX pre-pass + CSS confidence score in response |
| `src/tools/click-element.ts` | AX pre-pass with scroll, click, delta, verify |
| `src/tools/find.ts` | AX pre-pass returns matches tagged [AX] |
| `src/tools/wait-and-click.ts` | AX tried each poll iteration |
| `tests/tools/find.test.ts` | Mock ax-element-resolver |

## Test plan
- [x] Build clean
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)