### PR TITLE
refactor: replace AX scoring system with cascading filter — zero magic numbers

### DIFF
--- a/src/tools/click-element.ts
+++ b/src/tools/click-element.ts
@@ -13,7 +13,7 @@ import { withDomDelta } from '../utils/dom-delta';
 import { AdaptiveScreenshot } from '../utils/adaptive-screenshot';
 import { FoundElement, scoreElement, tokenizeQuery } from '../utils/element-finder';
 import { discoverElements, getTaggedElementRect, cleanupTags, DISCOVERY_TAG } from '../utils/element-discovery';
-import { resolveElementsByAXTree, invalidateAXCache } from '../utils/ax-element-resolver';
+import { resolveElementsByAXTree, invalidateAXCache, MATCH_LEVEL_LABELS } from '../utils/ax-element-resolver';
 import { getTargetId } from '../utils/puppeteer-helpers';
 
 const definition: MCPToolDefinition = {
@@ -107,7 +107,7 @@ const handler: ToolHandler = async (
       const axMatches = await resolveElementsByAXTree(page, cdpClient, query, {
         useCenter: true, maxResults: 3,
       });
-      if (axMatches.length > 0 && axMatches[0].axScore >= 60) {
+      if (axMatches.length > 0) {
         const ax = axMatches[0];
 
         // Scroll into view and re-resolve coordinates
@@ -138,7 +138,7 @@ const handler: ToolHandler = async (
         AdaptiveScreenshot.getInstance().reset(tabId);
 
         const axVerb = doubleClick ? 'Double-clicked' : 'Clicked';
-        const resultText = `\u2713 ${axVerb} ${ax.role} "${ax.name}" [${axRef}] [via AX tree, score: ${ax.axScore}/100]${axDelta}`;
+        const resultText = `\u2713 ${axVerb} ${ax.role} "${ax.name}" [${axRef}] [${MATCH_LEVEL_LABELS[ax.matchLevel]} via AX tree]${axDelta}`;
 
         if (verify) {
           try {

--- a/src/tools/find.ts
+++ b/src/tools/find.ts
@@ -9,7 +9,7 @@ import { getRefIdManager } from '../utils/ref-id-manager';
 import { withTimeout } from '../utils/with-timeout';
 import { discoverElements, cleanupTags, DISCOVERY_TAG } from '../utils/element-discovery';
 import { FoundElement, scoreElement, tokenizeQuery } from '../utils/element-finder';
-import { resolveElementsByAXTree } from '../utils/ax-element-resolver';
+import { resolveElementsByAXTree, MATCH_LEVEL_LABELS } from '../utils/ax-element-resolver';
 
 const definition: MCPToolDefinition = {
   name: 'find',
@@ -89,14 +89,14 @@ const handler: ToolHandler = async (
         maxResults: 20,
       });
 
-      if (axMatches.length > 0 && axMatches[0].axScore >= 60) {
+      if (axMatches.length > 0) {
         const axOutput: string[] = [];
         for (const el of axMatches) {
           const refId = refIdManager.generateRef(
             sessionId, tabId, el.backendDOMNodeId,
             el.role, el.name, undefined, undefined
           );
-          const scoreLabel = el.axScore >= 90 ? '\u2605\u2605\u2605' : el.axScore >= 60 ? '\u2605\u2605' : '\u2605';
+          const scoreLabel = el.matchLevel === 1 ? '\u2605\u2605\u2605' : el.matchLevel === 2 ? '\u2605\u2605' : '\u2605';
           axOutput.push(
             `[${refId}] ${el.role}: "${el.name}" at (${Math.round(el.rect.x)}, ${Math.round(el.rect.y)}) ${scoreLabel} [AX]`
           );

--- a/src/tools/interact.ts
+++ b/src/tools/interact.ts
@@ -14,7 +14,7 @@ import { DEFAULT_DOM_SETTLE_DELAY_MS, DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS, DEFAUL
 import { FoundElement, scoreElement, tokenizeQuery } from '../utils/element-finder';
 import { discoverElements, getTaggedElementRect, cleanupTags, DISCOVERY_TAG } from '../utils/element-discovery';
 import { withTimeout } from '../utils/with-timeout';
-import { resolveElementsByAXTree, invalidateAXCache } from '../utils/ax-element-resolver';
+import { resolveElementsByAXTree, invalidateAXCache, MATCH_LEVEL_LABELS } from '../utils/ax-element-resolver';
 import { getTargetId } from '../utils/puppeteer-helpers';
 
 const definition: MCPToolDefinition = {
@@ -117,7 +117,7 @@ const handler: ToolHandler = async (
         useCenter: true,
         maxResults: 3,
       });
-      if (axMatches.length > 0 && axMatches[0].axScore >= 60) {
+      if (axMatches.length > 0) {
         const ax = axMatches[0];
 
         // Scroll into view
@@ -163,7 +163,7 @@ const handler: ToolHandler = async (
 
         // Build response with AX provenance + confidence score
         const axVerb = action === 'double_click' ? 'Double-clicked' : action === 'hover' ? 'Hovered' : 'Clicked';
-        const axLine = `\u2713 ${axVerb} ${ax.role} "${ax.name}" [${axRef}] [via AX tree, score: ${ax.axScore}/100]`;
+        const axLine = `\u2713 ${axVerb} ${ax.role} "${ax.name}" [${axRef}] [${MATCH_LEVEL_LABELS[ax.matchLevel]} via AX tree]`;
 
         // Gather state summary (same as CSS path)
         const axState = await withTimeout(page.evaluate(() => {

--- a/src/tools/wait-and-click.ts
+++ b/src/tools/wait-and-click.ts
@@ -12,7 +12,7 @@ import { DEFAULT_DOM_SETTLE_DELAY_MS } from '../config/defaults';
 import { withDomDelta } from '../utils/dom-delta';
 import { discoverElements, getTaggedElementRect, cleanupTags, DISCOVERY_TAG } from '../utils/element-discovery';
 import { FoundElement, scoreElement, tokenizeQuery } from '../utils/element-finder';
-import { resolveElementsByAXTree, invalidateAXCache, AXResolvedElement } from '../utils/ax-element-resolver';
+import { resolveElementsByAXTree, invalidateAXCache, AXResolvedElement, MATCH_LEVEL_LABELS } from '../utils/ax-element-resolver';
 import { getTargetId } from '../utils/puppeteer-helpers';
 
 const definition: MCPToolDefinition = {
@@ -93,7 +93,7 @@ const handler: ToolHandler = async (
         const axMatches = await resolveElementsByAXTree(page, cdpClient, query, {
           useCenter: true, maxResults: 1,
         });
-        if (axMatches.length > 0 && axMatches[0].axScore >= 60) {
+        if (axMatches.length > 0) {
           axMatch = axMatches[0];
           break;
         }
@@ -150,7 +150,7 @@ const handler: ToolHandler = async (
       return {
         content: [{
           type: 'text' as const,
-          text: `\u2713 Clicked ${axMatch.role} "${axMatch.name}" [${axRef}] [via AX tree, score: ${axMatch.axScore}/100] (waited ${waitTime}ms)${axDelta}`,
+          text: `\u2713 Clicked ${axMatch.role} "${axMatch.name}" [${axRef}] [${MATCH_LEVEL_LABELS[axMatch.matchLevel]} via AX tree] (waited ${waitTime}ms)${axDelta}`,
         }],
       };
     }

--- a/src/utils/ax-element-resolver.ts
+++ b/src/utils/ax-element-resolver.ts
@@ -4,7 +4,8 @@
  * Uses the browser's built-in accessibility engine (which already understands all UI frameworks:
  * Angular Material, React MUI, Vue Vuetify, etc.) to resolve elements by role + name.
  *
- * Flow: query → parseQueryForAX → getCachedAXTree → scoreAXNode → DOM.getBoxModel → coordinates
+ * Architecture: Cascading filter — no scoring, no magic numbers, fully deterministic.
+ * Flow: query → parseQueryForAX → getCachedAXTree → cascading filter → DOM.getBoxModel → coordinates
  * Fallback: if AX resolution fails, callers fall back to existing CSS-based discoverElements().
  */
 
@@ -35,12 +36,25 @@ export interface AXNodeFlat {
   properties: Record<string, unknown>;
 }
 
+/**
+ * Match level from cascading filter (1 = most precise, 4 = least precise).
+ * Used instead of numeric scores — each level has a clear semantic meaning.
+ */
+export type MatchLevel = 1 | 2 | 3 | 4;
+
+export const MATCH_LEVEL_LABELS: Record<MatchLevel, string> = {
+  1: 'exact match',
+  2: 'role match',
+  3: 'name match',
+  4: 'partial match',
+};
+
 /** Result of AX-based element resolution */
 export interface AXResolvedElement {
   backendDOMNodeId: number;
   role: string;
   name: string;
-  axScore: number;
+  matchLevel: MatchLevel;
   rect: { x: number; y: number; width: number; height: number };
   properties: Record<string, unknown>;
   source: 'ax';
@@ -57,7 +71,6 @@ export interface AXResolveOptions {
 export interface ParsedAXQuery {
   roleHint: string | null;
   nameHint: string;
-  nameTokens: string[];
 }
 
 // ─── Role Keyword Map ───
@@ -120,119 +133,91 @@ const INTERACTIVE_ROLES = new Set([
  * Examples:
  *   "외부 radio button"  → { roleHint: "radio", nameHint: "외부" }
  *   "Submit button"      → { roleHint: "button", nameHint: "submit" }
- *   "search input"       → { roleHint: "textbox", nameHint: "search" }
  *   "로그인"              → { roleHint: null, nameHint: "로그인" }
  */
 export function parseQueryForAX(query: string): ParsedAXQuery {
   const queryLower = query.toLowerCase().trim();
 
-  // Try longest-match-first to extract role hint
   for (const [keyword, role] of ROLE_KEYWORDS) {
     const idx = queryLower.indexOf(keyword);
     if (idx !== -1) {
-      // Remove the role keyword from the query to get the name hint
       const before = query.slice(0, idx).trim();
       const after = query.slice(idx + keyword.length).trim();
       const nameHint = [before, after].filter(Boolean).join(' ').trim();
 
       return {
         roleHint: role,
-        nameHint: nameHint || query.trim(), // if only role keyword, use full query as name
-        nameTokens: tokenize(nameHint || query.trim()),
+        nameHint: nameHint || query.trim(),
       };
     }
   }
 
-  // No role keyword found
   return {
     roleHint: null,
     nameHint: query.trim(),
-    nameTokens: tokenize(query.trim()),
   };
 }
 
-function tokenize(text: string): string[] {
-  return text.toLowerCase().split(/\s+/).filter(t => t.length > 0);
-}
-
-// ─── AX Node Scoring ───
+// ─── Cascading Filter ───
 
 /**
- * Score an AX node against parsed query hints.
+ * Filter AX nodes through a prioritized cascade.
+ * Returns the first match at the highest (strictest) level.
  *
- * Scoring rubric:
- *   Exact role + exact name:     100
- *   Exact role + name contains:   80
- *   Exact name, no role hint:     75
- *   Name contains, no role hint:  50
- *   Role match only:              30
- *   Per-token overlap:           +15 each
- *   Interactive role bonus:      +10
- *   Disabled penalty:            -50
+ * Level 1: exact role + exact name
+ * Level 2: exact role + name contains
+ * Level 3: exact name (any interactive role)
+ * Level 4: name contains (any interactive role)
+ *
+ * No scoring, no magic numbers, fully deterministic.
  */
-export function scoreAXNode(
-  node: AXNodeFlat,
+export function cascadeFilter(
+  nodes: AXNodeFlat[],
   roleHint: string | null,
   nameHint: string,
-  nameTokens: string[],
-): number {
-  const nodeName = node.name.toLowerCase().trim();
-  const nodeRole = node.role.toLowerCase();
-  const nameHintLower = nameHint.toLowerCase().trim();
+  maxResults: number = 5,
+): Array<{ node: AXNodeFlat; matchLevel: MatchLevel }> {
+  // Pre-filter: remove disabled and non-interactive nodes
+  const candidates = nodes.filter(n =>
+    n.properties['disabled'] !== true &&
+    INTERACTIVE_ROLES.has(n.role.toLowerCase())
+  );
 
-  if (!nodeName && !roleHint) return 0;
+  const nameLower = nameHint.toLowerCase().trim();
+  if (!nameLower) return [];
 
-  let score = 0;
-  const roleMatches = roleHint ? nodeRole === roleHint : false;
-  const exactNameMatch = nodeName === nameHintLower;
-  const nameContains = nameHintLower.length > 0 && nodeName.includes(nameHintLower);
-  const nameContainedBy = nameHintLower.length > 0 && nameHintLower.includes(nodeName);
+  const eq = (nodeName: string) => nodeName.toLowerCase().trim() === nameLower;
+  const includes = (nodeName: string) => nodeName.toLowerCase().trim().includes(nameLower);
 
-  // Primary scoring
-  if (roleMatches && exactNameMatch) {
-    score = 100;
-  } else if (roleMatches && nameContains) {
-    score = 80;
-  } else if (roleMatches && nameContainedBy && nodeName.length > 0) {
-    score = 70;
-  } else if (exactNameMatch && !roleHint) {
-    score = 75;
-  } else if (nameContains && !roleHint) {
-    score = 50;
-  } else if (roleMatches && !nameHintLower) {
-    score = 30;
-  } else if (roleMatches) {
-    // Role matches but name doesn't — check token overlap
-    score = 25;
-  } else {
-    // No role match — check token overlap only
-    score = 0;
-  }
-
-  // Token overlap bonus (for partial matches)
-  if (score < 80) {
-    let tokenMatches = 0;
-    for (const token of nameTokens) {
-      if (token.length >= 2 && nodeName.includes(token)) {
-        tokenMatches++;
-      }
-    }
-    if (nameTokens.length > 0) {
-      score += tokenMatches * 15;
+  // Level 1: exact role + exact name
+  if (roleHint) {
+    const level1 = candidates.filter(n => n.role.toLowerCase() === roleHint && eq(n.name));
+    if (level1.length > 0) {
+      return level1.slice(0, maxResults).map(node => ({ node, matchLevel: 1 as MatchLevel }));
     }
   }
 
-  // Interactive role bonus
-  if (INTERACTIVE_ROLES.has(nodeRole)) {
-    score += 10;
+  // Level 2: exact role + name contains
+  if (roleHint) {
+    const level2 = candidates.filter(n => n.role.toLowerCase() === roleHint && includes(n.name));
+    if (level2.length > 0) {
+      return level2.slice(0, maxResults).map(node => ({ node, matchLevel: 2 as MatchLevel }));
+    }
   }
 
-  // Disabled penalty
-  if (node.properties['disabled'] === true) {
-    score -= 50;
+  // Level 3: exact name (any interactive role)
+  const level3 = candidates.filter(n => eq(n.name));
+  if (level3.length > 0) {
+    return level3.slice(0, maxResults).map(node => ({ node, matchLevel: 3 as MatchLevel }));
   }
 
-  return Math.max(0, score);
+  // Level 4: name contains (any interactive role)
+  const level4 = candidates.filter(n => includes(n.name));
+  if (level4.length > 0) {
+    return level4.slice(0, maxResults).map(node => ({ node, matchLevel: 4 as MatchLevel }));
+  }
+
+  return [];
 }
 
 // ─── AX Tree Cache ───
@@ -290,16 +275,12 @@ export async function getCachedAXTree(
   return flat;
 }
 
-/**
- * Invalidate AX cache for a page (call after interactions that mutate DOM).
- */
+/** Invalidate AX cache for a page (call after interactions that mutate DOM). */
 export function invalidateAXCache(pageTargetId: string): void {
   axCache.delete(pageTargetId);
 }
 
-/**
- * Clear entire AX cache (for testing or shutdown).
- */
+/** Clear entire AX cache (for testing or shutdown). */
 export function clearAXCache(): void {
   axCache.clear();
 }
@@ -309,13 +290,11 @@ export function clearAXCache(): void {
 /**
  * Resolve elements by querying the Chrome Accessibility Tree.
  *
- * 1. Fetch (or use cached) AX tree
- * 2. Parse query into role hint + name hint
- * 3. Match and score AX nodes
- * 4. Resolve coordinates via DOM.getBoxModel for top matches
+ * Uses a cascading filter (not scoring) to find elements:
+ * Level 1: exact role + exact name → Level 2: role + contains → Level 3: exact name → Level 4: contains
  *
- * Returns sorted array of matches (highest score first), or empty array
- * if no matches meet the minimum threshold (score >= 20).
+ * Returns array of matches at the highest (strictest) cascade level that produced results.
+ * Empty array if no matches found (caller should fall back to CSS discovery).
  */
 export async function resolveElementsByAXTree(
   page: Page,
@@ -332,23 +311,13 @@ export async function resolveElementsByAXTree(
   const nodes = await getCachedAXTree(page, cdpClient, depth);
   if (nodes.length === 0) return [];
 
-  // 3. Score all nodes
-  const scored: Array<{ node: AXNodeFlat; score: number }> = [];
-  for (const node of nodes) {
-    const score = scoreAXNode(node, parsed.roleHint, parsed.nameHint, parsed.nameTokens);
-    if (score >= 20) {
-      scored.push({ node, score });
-    }
-  }
+  // 3. Cascading filter
+  const matches = cascadeFilter(nodes, parsed.roleHint, parsed.nameHint, maxResults);
+  if (matches.length === 0) return [];
 
-  if (scored.length === 0) return [];
-
-  // Sort by score descending
-  scored.sort((a, b) => b.score - a.score);
-
-  // 4. Resolve coordinates for top matches
+  // 4. Resolve coordinates for matches
   const resolved: AXResolvedElement[] = [];
-  for (const { node, score } of scored.slice(0, maxResults * 2)) { // fetch extra in case some fail
+  for (const { node, matchLevel } of matches) {
     if (resolved.length >= maxResults) break;
 
     try {
@@ -371,7 +340,7 @@ export async function resolveElementsByAXTree(
         backendDOMNodeId: node.backendDOMNodeId,
         role: node.role,
         name: node.name,
-        axScore: score,
+        matchLevel,
         rect: {
           x: useCenter ? x + width / 2 : x,
           y: useCenter ? y + height / 2 : y,
@@ -382,7 +351,6 @@ export async function resolveElementsByAXTree(
         source: 'ax',
       });
     } catch {
-      // Element may not have layout — skip
       continue;
     }
   }

--- a/tests/utils/ax-element-resolver.test.ts
+++ b/tests/utils/ax-element-resolver.test.ts
@@ -1,12 +1,13 @@
 /// <reference types="jest" />
 /**
- * Unit tests for AX-First Element Resolution
+ * Unit tests for AX-First Element Resolution (cascading filter architecture)
  */
 
 import {
   parseQueryForAX,
-  scoreAXNode,
+  cascadeFilter,
   AXNodeFlat,
+  MATCH_LEVEL_LABELS,
 } from '../../src/utils/ax-element-resolver';
 
 describe('AX Element Resolver', () => {
@@ -15,7 +16,6 @@ describe('AX Element Resolver', () => {
       const result = parseQueryForAX('외부 radio button');
       expect(result.roleHint).toBe('radio');
       expect(result.nameHint).toBe('외부');
-      expect(result.nameTokens).toEqual(['외부']);
     });
 
     test('should extract role and name from "Submit button"', () => {
@@ -27,15 +27,7 @@ describe('AX Element Resolver', () => {
     test('should prefer longest match: "radio button" over "radio"', () => {
       const result = parseQueryForAX('외부 radio button');
       expect(result.roleHint).toBe('radio');
-      // "radio button" extracted, not just "radio" leaving "button" in name
       expect(result.nameHint).not.toContain('button');
-    });
-
-    test('should extract role from "search input"', () => {
-      const result = parseQueryForAX('search input');
-      // "input" matches before "search" in ROLE_KEYWORDS → textbox
-      expect(result.roleHint).toBe('textbox');
-      expect(result.nameHint).toBe('search');
     });
 
     test('should handle query with no role keyword', () => {
@@ -62,16 +54,10 @@ describe('AX Element Resolver', () => {
       expect(result.nameHint).toBe('Agree');
     });
 
-    test('should handle role keyword at beginning of query', () => {
+    test('should handle role keyword at beginning', () => {
       const result = parseQueryForAX('button Submit');
       expect(result.roleHint).toBe('button');
       expect(result.nameHint).toBe('Submit');
-    });
-
-    test('should return full query as name when only role keyword', () => {
-      const result = parseQueryForAX('button');
-      expect(result.roleHint).toBe('button');
-      expect(result.nameHint).toBe('button');
     });
 
     test('should handle link keyword', () => {
@@ -79,119 +65,123 @@ describe('AX Element Resolver', () => {
       expect(result.roleHint).toBe('link');
       expect(result.nameHint).toBe('Learn more');
     });
-
-    test('should generate name tokens', () => {
-      const result = parseQueryForAX('first name text field');
-      expect(result.roleHint).toBe('textbox');
-      expect(result.nameTokens).toEqual(['first', 'name']);
-    });
   });
 
-  describe('scoreAXNode', () => {
+  describe('cascadeFilter', () => {
+    let nodeId = 100;
     const makeNode = (role: string, name: string, props: Record<string, unknown> = {}): AXNodeFlat => ({
-      nodeId: 1,
-      backendDOMNodeId: 100,
+      nodeId: nodeId++,
+      backendDOMNodeId: nodeId,
       role,
       name,
       properties: props,
     });
 
-    test('should give 100 for exact role + exact name match', () => {
-      const node = makeNode('radio', '외부');
-      const score = scoreAXNode(node, 'radio', '외부', ['외부']);
-      expect(score).toBe(110); // 100 + 10 interactive bonus
+    const nodes = [
+      makeNode('radio', '외부'),
+      makeNode('radio', '내부', { disabled: true }),
+      makeNode('button', '외부 사용자 유형 도움말'),
+      makeNode('radiogroup', '대상'),
+      makeNode('button', 'Submit'),
+      makeNode('link', 'Learn more'),
+      makeNode('textbox', 'Search'),
+      makeNode('radio', '외부 고급 설정'),
+    ];
+
+    test('Level 1: exact role + exact name', () => {
+      const results = cascadeFilter(nodes, 'radio', '외부');
+      expect(results.length).toBe(1);
+      expect(results[0].node.role).toBe('radio');
+      expect(results[0].node.name).toBe('외부');
+      expect(results[0].matchLevel).toBe(1);
     });
 
-    test('should give 80+ for exact role + name contains match', () => {
-      const node = makeNode('radio', '외부 사용자');
-      const score = scoreAXNode(node, 'radio', '외부', ['외부']);
-      expect(score).toBeGreaterThanOrEqual(80);
+    test('Level 2: exact role + name contains', () => {
+      const results = cascadeFilter(nodes, 'radio', '고급');
+      expect(results.length).toBe(1);
+      expect(results[0].node.name).toBe('외부 고급 설정');
+      expect(results[0].matchLevel).toBe(2);
     });
 
-    test('should give low score for role mismatch and name mismatch', () => {
-      const node = makeNode('button', '도움말');
-      const score = scoreAXNode(node, 'radio', '외부', ['외부']);
-      // Score is only the interactive bonus (10) — no role or name match
-      expect(score).toBeLessThanOrEqual(10);
+    test('Level 3: exact name without role hint', () => {
+      const results = cascadeFilter(nodes, null, 'Submit');
+      expect(results.length).toBe(1);
+      expect(results[0].node.role).toBe('button');
+      expect(results[0].node.name).toBe('Submit');
+      expect(results[0].matchLevel).toBe(3);
     });
 
-    test('should give 75+ for exact name match without role hint', () => {
-      const node = makeNode('radio', '외부');
-      const score = scoreAXNode(node, null, '외부', ['외부']);
-      expect(score).toBeGreaterThanOrEqual(75);
+    test('Level 4: name contains without role hint', () => {
+      const results = cascadeFilter(nodes, null, 'Learn');
+      expect(results.length).toBe(1);
+      expect(results[0].node.name).toBe('Learn more');
+      expect(results[0].matchLevel).toBe(4);
     });
 
-    test('should give 50+ for name contains without role hint', () => {
-      const node = makeNode('button', 'Submit 외부');
-      const score = scoreAXNode(node, null, '외부', ['외부']);
-      expect(score).toBeGreaterThanOrEqual(50);
+    test('should filter out disabled elements', () => {
+      const results = cascadeFilter(nodes, 'radio', '내부');
+      expect(results.length).toBe(0);
     });
 
-    test('should give role-match-only score of 30+ when name empty', () => {
-      const node = makeNode('button', '');
-      const score = scoreAXNode(node, 'button', '', []);
-      expect(score).toBeGreaterThanOrEqual(30);
+    test('should filter out non-interactive roles', () => {
+      const results = cascadeFilter(nodes, 'radiogroup', '대상');
+      expect(results.length).toBe(0);
     });
 
-    test('should add interactive role bonus', () => {
-      const interactive = makeNode('button', 'Click');
-      const nonInteractive = makeNode('heading', 'Click');
-      const scoreI = scoreAXNode(interactive, null, 'Click', ['click']);
-      const scoreN = scoreAXNode(nonInteractive, null, 'Click', ['click']);
-      expect(scoreI).toBeGreaterThan(scoreN);
+    test('should return empty array when no match', () => {
+      const results = cascadeFilter(nodes, 'slider', 'Volume');
+      expect(results.length).toBe(0);
     });
 
-    test('should penalize disabled elements', () => {
-      const enabled = makeNode('radio', '내부');
-      const disabled = makeNode('radio', '내부', { disabled: true });
-      const scoreE = scoreAXNode(enabled, 'radio', '내부', ['내부']);
-      const scoreD = scoreAXNode(disabled, 'radio', '내부', ['내부']);
-      expect(scoreE).toBeGreaterThan(scoreD);
+    test('should return empty array for empty name hint', () => {
+      const results = cascadeFilter(nodes, 'button', '');
+      expect(results.length).toBe(0);
     });
 
-    test('should handle token overlap scoring', () => {
-      const node = makeNode('generic', 'first name label');
-      const score = scoreAXNode(node, null, 'first name', ['first', 'name']);
-      expect(score).toBeGreaterThan(0);
+    test('should be case insensitive', () => {
+      const results = cascadeFilter(nodes, 'button', 'submit');
+      expect(results.length).toBe(1);
+      expect(results[0].node.name).toBe('Submit');
     });
 
-    test('should return 0 for empty name and no role hint', () => {
-      const node = makeNode('generic', '');
-      const score = scoreAXNode(node, null, 'test', ['test']);
-      expect(score).toBe(0);
+    test('should respect maxResults', () => {
+      const manyNodes = [
+        makeNode('button', 'Action 1'),
+        makeNode('button', 'Action 2'),
+        makeNode('button', 'Action 3'),
+        makeNode('button', 'Action 4'),
+        makeNode('button', 'Action 5'),
+      ];
+      const results = cascadeFilter(manyNodes, null, 'Action', 2);
+      expect(results.length).toBe(2);
     });
 
-    test('should handle case insensitivity', () => {
-      const node = makeNode('Button', 'SUBMIT');
-      const score = scoreAXNode(node, 'button', 'submit', ['submit']);
-      expect(score).toBeGreaterThanOrEqual(100);
+    test('should stop at first matching level (not mix levels)', () => {
+      const results = cascadeFilter(nodes, 'radio', '외부');
+      expect(results.every(r => r.matchLevel === 1)).toBe(true);
     });
 
     describe('real-world Angular Material radio button scenario', () => {
-      test('should score radio "외부" highest for query "외부 radio button"', () => {
-        const radio = makeNode('radio', '외부');
-        const helpButton = makeNode('button', '외부 사용자 유형 도움말');
-        const container = makeNode('radiogroup', '대상');
-
-        const radioScore = scoreAXNode(radio, 'radio', '외부', ['외부']);
-        const helpScore = scoreAXNode(helpButton, 'radio', '외부', ['외부']);
-        const containerScore = scoreAXNode(container, 'radio', '외부', ['외부']);
-
-        // Radio should win decisively
-        expect(radioScore).toBeGreaterThan(helpScore);
-        expect(radioScore).toBeGreaterThan(containerScore);
-        expect(radioScore).toBeGreaterThanOrEqual(100);
+      test('should pick radio "외부" over button "외부 사용자 유형 도움말"', () => {
+        const results = cascadeFilter(nodes, 'radio', '외부');
+        expect(results.length).toBe(1);
+        expect(results[0].node.role).toBe('radio');
+        expect(results[0].node.name).toBe('외부');
       });
 
-      test('should handle disabled "내부" radio with penalty', () => {
-        const internal = makeNode('radio', '내부', { disabled: true });
-        const external = makeNode('radio', '외부');
-
-        const internalScore = scoreAXNode(internal, 'radio', '외부', ['외부']);
-        const externalScore = scoreAXNode(external, 'radio', '외부', ['외부']);
-
-        expect(externalScore).toBeGreaterThan(internalScore);
+      test('should not return disabled "내부" radio', () => {
+        const results = cascadeFilter(nodes, 'radio', '내부');
+        expect(results.length).toBe(0);
       });
+    });
+  });
+
+  describe('MATCH_LEVEL_LABELS', () => {
+    test('should have labels for all 4 levels', () => {
+      expect(MATCH_LEVEL_LABELS[1]).toBe('exact match');
+      expect(MATCH_LEVEL_LABELS[2]).toBe('role match');
+      expect(MATCH_LEVEL_LABELS[3]).toBe('name match');
+      expect(MATCH_LEVEL_LABELS[4]).toBe('partial match');
     });
   });
 });


### PR DESCRIPTION
## Summary

Replace the score-based `scoreAXNode()` (7 magic numbers, 80+ lines) with a cascading filter approach (0 magic numbers, ~20 lines of filter logic). The AX tree has structured `role` + `name` fields — element resolution is a **filtering** problem, not a **scoring** problem.

Closes #327

## Before vs After

```
BEFORE (scoring):                    AFTER (cascading filter):
scoreAXNode() → 80+ lines           cascadeFilter() → ~20 lines
7 magic numbers                      0 magic numbers
score >= 60 threshold                cascade returns match or nothing
disabled: -50 penalty (boundary)     disabled: pre-filtered out
response: [score: 85/100] (opaque)   response: [exact match] (clear)
```

## Cascade Levels

| Level | Filter | Label | Example |
|-------|--------|-------|---------|
| 1 | exact role + exact name | `exact match` | radio "외부" for query "외부 radio button" |
| 2 | exact role + name contains | `role match` | radio "외부 고급" for query "고급 radio" |
| 3 | exact name (any role) | `name match` | button "Submit" for query "Submit" |
| 4 | name contains (any role) | `partial match` | link "Learn more" for query "Learn" |

First level to produce results wins. No mixing of levels.

## Changes

| File | Before | After |
|------|--------|-------|
| `ax-element-resolver.ts` | `scoreAXNode()` + `axScore` field | `cascadeFilter()` + `matchLevel` field |
| `interact.ts` | `axScore >= 60` check, `score: N/100` | Always use AX if match found, `[exact match via AX tree]` |
| `click-element.ts` | Same | Same |
| `find.ts` | Same | Star rating based on `matchLevel` |
| `wait-and-click.ts` | Same | Same |
| `ax-element-resolver.test.ts` | 25 score-based tests | 23 cascade-based tests |

**Net: -215 lines, +173 lines = 42 lines shorter**

## Test plan

- [x] 23 cascadeFilter tests (all 4 levels, disabled filtering, case insensitivity, maxResults, Angular Material scenario)
- [x] All 1769 tests pass
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)