### PR TITLE
feat: add Outcome Classifier — detect silent clicks and wrong-element interactions

### DIFF
--- a/src/tools/click-element.ts
+++ b/src/tools/click-element.ts
@@ -14,6 +14,7 @@ import { AdaptiveScreenshot } from '../utils/adaptive-screenshot';
 import { FoundElement, scoreElement, tokenizeQuery } from '../utils/element-finder';
 import { discoverElements, getTaggedElementRect, cleanupTags, DISCOVERY_TAG } from '../utils/element-discovery';
 import { resolveElementsByAXTree, invalidateAXCache, MATCH_LEVEL_LABELS } from '../utils/ax-element-resolver';
+import { classifyOutcome, formatOutcomeLine } from '../utils/ralph/outcome-classifier';
 import { getTargetId } from '../utils/puppeteer-helpers';
 
 const definition: MCPToolDefinition = {
@@ -138,7 +139,8 @@ const handler: ToolHandler = async (
         AdaptiveScreenshot.getInstance().reset(tabId);
 
         const axVerb = doubleClick ? 'Double-clicked' : 'Clicked';
-        const resultText = `\u2713 ${axVerb} ${ax.role} "${ax.name}" [${axRef}] [${MATCH_LEVEL_LABELS[ax.matchLevel]} via AX tree]${axDelta}`;
+        const axOutcome = classifyOutcome(axDelta, ax.role);
+        const resultText = formatOutcomeLine(axOutcome, axVerb, `${ax.role} "${ax.name}"`, `[${axRef}]`, `[${MATCH_LEVEL_LABELS[ax.matchLevel]} via AX tree]`) + (axDelta || '');
 
         if (verify) {
           try {
@@ -288,8 +290,9 @@ const handler: ToolHandler = async (
     const textSample = bestMatch.textContent?.slice(0, 50) || bestMatch.name.slice(0, 50);
     const textPart = textSample ? ` "${textSample}"` : '';
     const refPart = refId ? ` [${refId}]` : '';
-    const confidenceNote = bestMatch.score < 50 ? ` (low confidence: ${bestMatch.score}/100)` : '';
-    const resultText = `\u2713 ${clickType} ${bestMatch.tagName}${textPart}${refPart}${confidenceNote}${delta}`;
+    const confidencePart = bestMatch.score < 50 ? ' [via CSS, LOW CONFIDENCE]' : ' [via CSS]';
+    const cssOutcome = classifyOutcome(delta, bestMatch.role);
+    const resultText = formatOutcomeLine(cssOutcome, clickType, `${bestMatch.tagName}${textPart}`, refPart, confidencePart) + (delta || '');
 
     // Optional verification screenshot — WebP via CDP for speed and consistency
     if (verify) {

--- a/src/tools/interact.ts
+++ b/src/tools/interact.ts
@@ -16,6 +16,7 @@ import { discoverElements, getTaggedElementRect, cleanupTags, DISCOVERY_TAG } fr
 import { withTimeout } from '../utils/with-timeout';
 import { resolveElementsByAXTree, invalidateAXCache, MATCH_LEVEL_LABELS } from '../utils/ax-element-resolver';
 import { getTargetId } from '../utils/puppeteer-helpers';
+import { classifyOutcome, formatOutcomeLine } from '../utils/ralph/outcome-classifier';
 
 const definition: MCPToolDefinition = {
   name: 'interact',
@@ -161,9 +162,10 @@ const handler: ToolHandler = async (
         // Clean up any leftover tags
         await cleanupTags(page, DISCOVERY_TAG).catch(() => {});
 
-        // Build response with AX provenance + confidence score
+        // Classify outcome and build response
         const axVerb = action === 'double_click' ? 'Double-clicked' : action === 'hover' ? 'Hovered' : 'Clicked';
-        const axLine = `\u2713 ${axVerb} ${ax.role} "${ax.name}" [${axRef}] [${MATCH_LEVEL_LABELS[ax.matchLevel]} via AX tree]`;
+        const axOutcome = classifyOutcome(axDelta, ax.role);
+        const axLine = formatOutcomeLine(axOutcome, axVerb, `${ax.role} "${ax.name}"`, `[${axRef}]`, `[${MATCH_LEVEL_LABELS[ax.matchLevel]} via AX tree]`);
 
         // Gather state summary (same as CSS path)
         const axState = await withTimeout(page.evaluate(() => {
@@ -334,8 +336,9 @@ const handler: ToolHandler = async (
     const textSample = bestMatch.textContent?.slice(0, 50) || bestMatch.name.slice(0, 50);
     const textPart = textSample ? ` "${textSample}"` : '';
     const refPart = refId ? ` [${refId}]` : '';
-    const confidencePart = bestMatch.score < 50 ? ` \u26a0 LOW CONFIDENCE [via CSS, score: ${bestMatch.score}/100]` : ` [via CSS, score: ${bestMatch.score}/100]`;
-    const interactedLine = `\u2713 ${actionVerb} ${bestMatch.tagName}${textPart}${refPart}${confidencePart}`;
+    const confidencePart = bestMatch.score < 50 ? ` [via CSS, LOW CONFIDENCE]` : ` [via CSS]`;
+    const cssOutcome = classifyOutcome(delta, bestMatch.role);
+    const interactedLine = formatOutcomeLine(cssOutcome, actionVerb, `${bestMatch.tagName}${textPart}`, refPart, confidencePart);
 
     // Gather state summary via page.evaluate
     const stateSummary = await withTimeout(page.evaluate(() => {

--- a/src/tools/wait-and-click.ts
+++ b/src/tools/wait-and-click.ts
@@ -13,6 +13,7 @@ import { withDomDelta } from '../utils/dom-delta';
 import { discoverElements, getTaggedElementRect, cleanupTags, DISCOVERY_TAG } from '../utils/element-discovery';
 import { FoundElement, scoreElement, tokenizeQuery } from '../utils/element-finder';
 import { resolveElementsByAXTree, invalidateAXCache, AXResolvedElement, MATCH_LEVEL_LABELS } from '../utils/ax-element-resolver';
+import { classifyOutcome, formatOutcomeLine } from '../utils/ralph/outcome-classifier';
 import { getTargetId } from '../utils/puppeteer-helpers';
 
 const definition: MCPToolDefinition = {
@@ -147,10 +148,12 @@ const handler: ToolHandler = async (
 
       const axRef = refIdManager.generateRef(sessionId, tabId, axMatch.backendDOMNodeId, axMatch.role, axMatch.name, undefined, undefined);
 
+      const axOutcome = classifyOutcome(axDelta, axMatch.role);
+      const axLine = formatOutcomeLine(axOutcome, 'Clicked', `${axMatch.role} "${axMatch.name}"`, `[${axRef}]`, `[${MATCH_LEVEL_LABELS[axMatch.matchLevel]} via AX tree]`);
       return {
         content: [{
           type: 'text' as const,
-          text: `\u2713 Clicked ${axMatch.role} "${axMatch.name}" [${axRef}] [${MATCH_LEVEL_LABELS[axMatch.matchLevel]} via AX tree] (waited ${waitTime}ms)${axDelta}`,
+          text: `${axLine} (waited ${waitTime}ms)${axDelta || ''}`,
         }],
       };
     }

--- a/src/utils/ralph/outcome-classifier.ts
+++ b/src/utils/ralph/outcome-classifier.ts
@@ -1,0 +1,151 @@
+/**
+ * Outcome Classifier — Analyzes DOM delta after interactions to determine
+ * what actually happened, not just whether a click was delivered.
+ *
+ * This is observation-only: it adds information to responses without
+ * restricting any existing behavior.
+ *
+ * The dominant failure mode in browser automation is not "click threw an error"
+ * but "click succeeded but nothing happened" (silent failure). Skyvern proved
+ * that adding outcome validation alone drove WebVoyager from 68.7% to 85.85%.
+ */
+
+/**
+ * Classification of what happened after an interaction.
+ */
+export type InteractionOutcome =
+  | 'SUCCESS'           // DOM changed in a way consistent with the interaction
+  | 'SILENT_CLICK'      // Click delivered but zero meaningful DOM mutations
+  | 'WRONG_ELEMENT'     // DOM changed but in an unexpected way (e.g., tooltip instead of selection)
+  | 'ELEMENT_NOT_FOUND' // No candidates from any discovery strategy
+  | 'TIMEOUT'           // Budget exhausted before action completed
+  | 'EXCEPTION';        // Hard CDP/browser error
+
+/**
+ * Human-readable labels for each outcome.
+ */
+export const OUTCOME_LABELS: Record<InteractionOutcome, string> = {
+  SUCCESS: 'action confirmed',
+  SILENT_CLICK: 'no DOM change detected — element may not have responded',
+  WRONG_ELEMENT: 'unexpected DOM change — may have interacted with wrong element',
+  ELEMENT_NOT_FOUND: 'no matching element found',
+  TIMEOUT: 'operation timed out',
+  EXCEPTION: 'browser error occurred',
+};
+
+/**
+ * Outcome symbols for compact response display.
+ */
+export const OUTCOME_SYMBOLS: Record<InteractionOutcome, string> = {
+  SUCCESS: '\u2713',           // ✓
+  SILENT_CLICK: '\u26a0',     // ⚠
+  WRONG_ELEMENT: '\u26a0',   // ⚠
+  ELEMENT_NOT_FOUND: '\u2717', // ✗
+  TIMEOUT: '\u23f1',          // ⏱
+  EXCEPTION: '\u2717',        // ✗
+};
+
+// ─── Patterns for classification ───
+
+/**
+ * DOM delta patterns that indicate a successful state change.
+ * These are ARIA state changes and structural mutations consistent with
+ * standard interactive element behavior.
+ */
+const SUCCESS_PATTERNS = [
+  /aria-checked.*(?:true|false|mixed)/i,
+  /aria-selected.*(?:true|false)/i,
+  /aria-expanded.*(?:true|false)/i,
+  /aria-pressed.*(?:true|false)/i,
+  /aria-disabled.*(?:true|false)/i,
+  /class.*(?:active|selected|checked|open|expanded|focused|disabled)/i,
+  /\bURL changed\b/i,
+  /\bnavigat/i,
+  /\bnew page\b/i,
+  /\btitle changed\b/i,
+  /\+ .*(?:dialog|modal|drawer|panel|menu(?!item)|dropdown|popover)/i,
+  /\- .*(?:dialog|modal|drawer|panel|menu(?!item)|dropdown|popover)/i,
+  /\+ .*\binput\b/i,
+  /\bform\b.*\bsubmit/i,
+  /\bscroll\b/i,
+];
+
+/**
+ * DOM delta patterns that suggest a tooltip or help popup opened
+ * (common wrong-element indicator when targeting radio/checkbox/switch).
+ */
+const TOOLTIP_PATTERNS = [
+  /\+ .*(?:tooltip|popover|help|hint)/i,
+  /role="tooltip"/i,
+  /mattooltip/i,
+  /aria-describedby.*tooltip/i,
+  /cdk-overlay/i,
+];
+
+// ─── Main Classification Function ───
+
+/**
+ * Classify the outcome of an interaction by analyzing the DOM delta.
+ *
+ * @param delta - The DOM delta string from withDomDelta(), or undefined/empty
+ * @param targetRole - The intended element role (e.g., 'radio', 'button') for
+ *                     wrong-element detection. Optional.
+ * @returns The classified outcome
+ */
+export function classifyOutcome(
+  delta: string | undefined,
+  targetRole?: string,
+): InteractionOutcome {
+  // No delta at all — silent click
+  if (!delta || delta.trim().length === 0) {
+    return 'SILENT_CLICK';
+  }
+
+  const deltaLower = delta.toLowerCase();
+
+  // Check for tooltip/popover-only changes when targeting non-tooltip elements
+  if (targetRole && targetRole !== 'button') {
+    const hasTooltipOnly = TOOLTIP_PATTERNS.some(p => p.test(delta));
+    const hasOtherChanges = SUCCESS_PATTERNS.some(p => p.test(delta));
+
+    if (hasTooltipOnly && !hasOtherChanges) {
+      return 'WRONG_ELEMENT';
+    }
+  }
+
+  // Check for success patterns
+  if (SUCCESS_PATTERNS.some(p => p.test(delta))) {
+    return 'SUCCESS';
+  }
+
+  // Delta exists but contains no recognized success patterns
+  // If there are added/removed elements, consider it a success (some DOM change happened)
+  if (/^[+\-~] /m.test(delta)) {
+    return 'SUCCESS';
+  }
+
+  // Delta has only whitespace/formatting changes — treat as silent click
+  return 'SILENT_CLICK';
+}
+
+/**
+ * Format the outcome for inclusion in a tool response.
+ *
+ * @param outcome - The classified outcome
+ * @param verb - The action verb (e.g., 'Clicked', 'Double-clicked')
+ * @param elementDesc - Element description (e.g., 'radio "외부"')
+ * @param refPart - Ref string (e.g., '[ref_42]')
+ * @param sourcePart - Source string (e.g., '[exact match via AX tree]')
+ * @returns Formatted response line
+ */
+export function formatOutcomeLine(
+  outcome: InteractionOutcome,
+  verb: string,
+  elementDesc: string,
+  refPart: string,
+  sourcePart: string,
+): string {
+  const symbol = OUTCOME_SYMBOLS[outcome];
+  const label = outcome !== 'SUCCESS' ? ` — ${OUTCOME_LABELS[outcome]}` : '';
+  return `${symbol} ${verb} ${elementDesc} ${refPart} ${sourcePart}${label}`.trim();
+}

--- a/tests/utils/ralph/outcome-classifier.test.ts
+++ b/tests/utils/ralph/outcome-classifier.test.ts
@@ -1,0 +1,187 @@
+/// <reference types="jest" />
+/**
+ * Unit tests for Outcome Classifier
+ */
+
+import {
+  classifyOutcome,
+  formatOutcomeLine,
+  OUTCOME_LABELS,
+  OUTCOME_SYMBOLS,
+  InteractionOutcome,
+} from '../../../src/utils/ralph/outcome-classifier';
+
+describe('Outcome Classifier', () => {
+  describe('classifyOutcome', () => {
+    describe('SILENT_CLICK detection', () => {
+      test('should return SILENT_CLICK for undefined delta', () => {
+        expect(classifyOutcome(undefined)).toBe('SILENT_CLICK');
+      });
+
+      test('should return SILENT_CLICK for empty string delta', () => {
+        expect(classifyOutcome('')).toBe('SILENT_CLICK');
+      });
+
+      test('should return SILENT_CLICK for whitespace-only delta', () => {
+        expect(classifyOutcome('   \n  \t  ')).toBe('SILENT_CLICK');
+      });
+    });
+
+    describe('SUCCESS detection', () => {
+      test('should detect aria-checked change as SUCCESS', () => {
+        const delta = '~ mat-radio-button: aria-checked null→true';
+        expect(classifyOutcome(delta)).toBe('SUCCESS');
+      });
+
+      test('should detect aria-expanded change as SUCCESS', () => {
+        const delta = '~ button: aria-expanded false→true';
+        expect(classifyOutcome(delta)).toBe('SUCCESS');
+      });
+
+      test('should detect aria-selected change as SUCCESS', () => {
+        const delta = '~ tab: aria-selected false→true';
+        expect(classifyOutcome(delta)).toBe('SUCCESS');
+      });
+
+      test('should detect URL change as SUCCESS', () => {
+        const delta = 'URL changed: /page1 → /page2';
+        expect(classifyOutcome(delta)).toBe('SUCCESS');
+      });
+
+      test('should detect navigation as SUCCESS', () => {
+        const delta = 'Navigated to https://example.com/new-page';
+        expect(classifyOutcome(delta)).toBe('SUCCESS');
+      });
+
+      test('should detect title change as SUCCESS', () => {
+        const delta = 'Title changed: "Old" → "New"';
+        expect(classifyOutcome(delta)).toBe('SUCCESS');
+      });
+
+      test('should detect dialog/modal opening as SUCCESS', () => {
+        const delta = '+ div[role="dialog"]: "Confirm action"';
+        expect(classifyOutcome(delta)).toBe('SUCCESS');
+      });
+
+      test('should detect dialog closing as SUCCESS', () => {
+        const delta = '- div[role="dialog"]: "Confirm action"';
+        expect(classifyOutcome(delta)).toBe('SUCCESS');
+      });
+
+      test('should detect class change with active/selected as SUCCESS', () => {
+        const delta = '~ div: class "tab" → "tab active selected"';
+        expect(classifyOutcome(delta)).toBe('SUCCESS');
+      });
+
+      test('should detect scroll as SUCCESS', () => {
+        const delta = 'scroll: 0→500';
+        expect(classifyOutcome(delta)).toBe('SUCCESS');
+      });
+
+      test('should detect added/removed elements as SUCCESS', () => {
+        const delta = '+ li: "New item added"\n- span: "Loading..."';
+        expect(classifyOutcome(delta)).toBe('SUCCESS');
+      });
+
+      test('should detect form submit as SUCCESS', () => {
+        const delta = 'form submit triggered';
+        expect(classifyOutcome(delta)).toBe('SUCCESS');
+      });
+    });
+
+    describe('WRONG_ELEMENT detection', () => {
+      test('should detect tooltip-only change when targeting radio as WRONG_ELEMENT', () => {
+        const delta = '+ div[role="tooltip"]: "사용자 유형에 대한 설명"';
+        expect(classifyOutcome(delta, 'radio')).toBe('WRONG_ELEMENT');
+      });
+
+      test('should detect mattooltip as WRONG_ELEMENT when targeting checkbox', () => {
+        const delta = '+ div.matTooltip: "Help text"';
+        expect(classifyOutcome(delta, 'checkbox')).toBe('WRONG_ELEMENT');
+      });
+
+      test('should detect cdk-overlay as WRONG_ELEMENT when targeting radio', () => {
+        const delta = '+ div.cdk-overlay-pane: "Tooltip content"';
+        expect(classifyOutcome(delta, 'radio')).toBe('WRONG_ELEMENT');
+      });
+
+      test('should NOT flag tooltip as WRONG_ELEMENT when targeting button', () => {
+        // Buttons legitimately trigger tooltips
+        const delta = '+ div[role="tooltip"]: "Button description"';
+        expect(classifyOutcome(delta, 'button')).not.toBe('WRONG_ELEMENT');
+      });
+
+      test('should NOT flag tooltip as WRONG_ELEMENT when no target role', () => {
+        const delta = '+ div[role="tooltip"]: "Some help text"';
+        expect(classifyOutcome(delta)).not.toBe('WRONG_ELEMENT');
+      });
+
+      test('should detect tooltip + real change as SUCCESS (not WRONG_ELEMENT)', () => {
+        const delta = '+ div[role="tooltip"]: "Help"\n~ radio: aria-checked null→true';
+        expect(classifyOutcome(delta, 'radio')).toBe('SUCCESS');
+      });
+    });
+
+    describe('edge cases', () => {
+      test('should handle delta with only structural markers', () => {
+        const delta = '+ div: "some content"';
+        expect(classifyOutcome(delta)).toBe('SUCCESS');
+      });
+
+      test('should handle multiline deltas', () => {
+        const delta = [
+          '~ button: aria-expanded false→true',
+          '+ ul[role="menu"]: "Option 1, Option 2"',
+          '+ li: "Option 1"',
+        ].join('\n');
+        expect(classifyOutcome(delta)).toBe('SUCCESS');
+      });
+    });
+  });
+
+  describe('formatOutcomeLine', () => {
+    test('should format SUCCESS without label suffix', () => {
+      const line = formatOutcomeLine('SUCCESS', 'Clicked', 'radio "외부"', '[ref_42]', '[exact match via AX tree]');
+      expect(line).toContain('\u2713');
+      expect(line).toContain('Clicked');
+      expect(line).toContain('radio "외부"');
+      expect(line).toContain('[ref_42]');
+      expect(line).not.toContain('—');
+    });
+
+    test('should format SILENT_CLICK with warning label', () => {
+      const line = formatOutcomeLine('SILENT_CLICK', 'Clicked', 'button "Submit"', '[ref_1]', '[via CSS]');
+      expect(line).toContain('\u26a0');
+      expect(line).toContain('no DOM change detected');
+    });
+
+    test('should format WRONG_ELEMENT with warning label', () => {
+      const line = formatOutcomeLine('WRONG_ELEMENT', 'Clicked', 'radio "외부"', '[ref_2]', '[via AX tree]');
+      expect(line).toContain('\u26a0');
+      expect(line).toContain('unexpected DOM change');
+    });
+
+    test('should format ELEMENT_NOT_FOUND with error symbol', () => {
+      const line = formatOutcomeLine('ELEMENT_NOT_FOUND', 'Clicked', '"missing"', '', '');
+      expect(line).toContain('\u2717');
+      expect(line).toContain('no matching element found');
+    });
+  });
+
+  describe('constants', () => {
+    test('OUTCOME_LABELS should have entries for all outcomes', () => {
+      const outcomes: InteractionOutcome[] = ['SUCCESS', 'SILENT_CLICK', 'WRONG_ELEMENT', 'ELEMENT_NOT_FOUND', 'TIMEOUT', 'EXCEPTION'];
+      for (const o of outcomes) {
+        expect(OUTCOME_LABELS[o]).toBeDefined();
+        expect(typeof OUTCOME_LABELS[o]).toBe('string');
+      }
+    });
+
+    test('OUTCOME_SYMBOLS should have entries for all outcomes', () => {
+      const outcomes: InteractionOutcome[] = ['SUCCESS', 'SILENT_CLICK', 'WRONG_ELEMENT', 'ELEMENT_NOT_FOUND', 'TIMEOUT', 'EXCEPTION'];
+      for (const o of outcomes) {
+        expect(OUTCOME_SYMBOLS[o]).toBeDefined();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add an Outcome Classifier that analyzes DOM delta after every click to classify what actually happened — not just whether a click was delivered.

Closes #329. Part of Ralph Engine (#336).

## Why This Matters

The dominant failure mode in browser automation is not "click threw an error" but **"click succeeded but nothing happened"** (silent failure). Skyvern proved that adding outcome validation alone drove WebVoyager from 68.7% to 85.85% (+17pp).

## How It Works

After every click, the existing `withDomDelta` captures DOM mutations. The Outcome Classifier analyzes these mutations:

| Delta Content | Classification | Meaning |
|---------------|---------------|---------|
| Empty / whitespace only | `SILENT_CLICK` | Element didn't respond to click |
| ARIA state change (`aria-checked`, `aria-expanded`) | `SUCCESS` | Interaction worked |
| URL/title/navigation change | `SUCCESS` | Page transition |
| Dialog/modal/menu open/close | `SUCCESS` | UI state change |
| Tooltip-only when targeting radio/checkbox | `WRONG_ELEMENT` | Clicked adjacent help button |
| Structural DOM mutation (`+ element`) | `SUCCESS` | Content changed |

## Response Examples

```
SUCCESS:       ✓ Clicked radio "외부" [ref_42] [exact match via AX tree]
SILENT_CLICK:  ⚠ Clicked radio "외부" [ref_42] [via AX tree] — no DOM change detected
WRONG_ELEMENT: ⚠ Clicked radio "외부" [ref_42] [via AX tree] — unexpected DOM change
```

The LLM now has the signal to self-correct on the very first attempt.

## Changes

| File | Change |
|------|--------|
| `src/utils/ralph/outcome-classifier.ts` | **New** — classification logic (6 outcome types) |
| `tests/utils/ralph/outcome-classifier.test.ts` | **New** — 29 tests |
| `src/tools/interact.ts` | AX + CSS paths use `formatOutcomeLine()` |
| `src/tools/click-element.ts` | AX + CSS paths use `formatOutcomeLine()` |
| `src/tools/wait-and-click.ts` | AX path uses `formatOutcomeLine()` |

## Design: Observation-Only

The classifier **adds information** to responses — it doesn't restrict, block, or retry anything. All existing click behavior is 100% preserved. The LLM decides what to do with the classification.

## Test plan

- [x] 29 unit tests: SILENT_CLICK (3), SUCCESS (12), WRONG_ELEMENT (6), formatOutcomeLine (4), constants (2), edge cases (2)
- [x] All 1798 tests pass (29 new + 1769 existing)
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)