### PR TITLE
fix: add per-call timeout to CDP send() — eliminate last indefinite hang path

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -21,7 +21,9 @@ import {
   DEFAULT_PUPPETEER_CONNECT_TIMEOUT_MS,
   DEFAULT_HEARTBEAT_PING_TIMEOUT_MS,
   DEFAULT_CONNECT_VERIFY_STALENESS_MS,
+  DEFAULT_CDP_SEND_TIMEOUT_MS,
 } from '../config/defaults';
+import { withTimeout } from '../utils/with-timeout';
 
 // Cookie type shared across methods
 type CookieEntry = {
@@ -1427,7 +1429,8 @@ export class CDPClient {
   }
 
   /**
-   * Execute CDP command on a page
+   * Execute CDP command on a page.
+   * Wrapped with per-call timeout to prevent hung renderers from blocking indefinitely.
    */
   async send<T = unknown>(
     page: Page,
@@ -1435,7 +1438,11 @@ export class CDPClient {
     params?: Record<string, unknown>
   ): Promise<T> {
     const session = await this.getCDPSession(page);
-    return session.send(method as any, params as any) as Promise<T>;
+    return withTimeout(
+      session.send(method as any, params as any) as Promise<T>,
+      DEFAULT_CDP_SEND_TIMEOUT_MS,
+      `CDP ${method}`
+    );
   }
 
   /**

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -135,6 +135,12 @@ export const DEFAULT_VERBOSITY = 'normal';
 /** Minimum response size in bytes before compression is applied. */
 export const COMPRESSION_MIN_BYTES = 500;
 
+/** Per-call timeout for CDPClient.send() in milliseconds.
+ *  Prevents a hung Chrome renderer from blocking indefinitely.
+ *  The 120s tool execution timeout is the outer safety net, but this
+ *  catches hangs at the individual CDP command level (15s). */
+export const DEFAULT_CDP_SEND_TIMEOUT_MS = 15000;
+
 /** Completion lock acquisition timeout in milliseconds.
  *  Safety net for the promise-based mutex in WorkflowEngine.
  *  If a previous lock holder's release() is never called (e.g. due to an


### PR DESCRIPTION
## Summary

Wrap `CDPClient.send()` with a 15s per-call timeout to prevent hung Chrome renderers from blocking indefinitely. This is the **last identified path** where operations could hang without any per-call timeout.

Closes #332. Part of Ralph Engine (#336).

## Problem

`CDPClient.send()` relied solely on Puppeteer's `protocolTimeout` (30s) set during connection. If the renderer is frozen (infinite JS loop, GPU hang, unresponsive tab), the CDP command may never receive a response. The only safety net was the 120s tool execution timeout — **2 full minutes of silence**.

## Fix (5 lines)

```typescript
// BEFORE: no per-call timeout
return session.send(method, params) as Promise<T>;

// AFTER: 15s per-call timeout
return withTimeout(
  session.send(method, params) as Promise<T>,
  DEFAULT_CDP_SEND_TIMEOUT_MS,  // 15s
  \`CDP \${method}\`
);
```

## Changes

| File | Change |
|------|--------|
| `src/config/defaults.ts` | Add `DEFAULT_CDP_SEND_TIMEOUT_MS = 15000` |
| `src/cdp/client.ts` | Import `withTimeout`, wrap `send()` |

## Why 15s

- Normal CDP calls complete in <100ms
- Generous enough for heavy operations (AX tree fetch, screenshot)
- The 120s tool execution timeout remains as the outer safety net
- Matches `DEFAULT_PUPPETEER_CONNECT_TIMEOUT_MS` already used elsewhere

## Test plan

- [x] All 1798 tests pass (no behavioral change for normal operations)
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)