### PR TITLE
feat: exponential backoff and configurable reconnection (#344)

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -59,6 +59,17 @@ export interface ConnectionEvent {
 }
 
 
+function parseEnvInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    console.error(`[CDPClient] Invalid value for ${name}="${raw}", using default ${fallback}`);
+    return fallback;
+  }
+  return parsed;
+}
+
 export class CDPClient {
   private browser: Browser | null = null;
   private sessions: Map<string, CDPSession> = new Map();
@@ -87,12 +98,9 @@ export class CDPClient {
   constructor(options: CDPClientOptions = {}) {
     const globalConfig = getGlobalConfig();
     this.port = options.port || globalConfig.port;
-    this.maxReconnectAttempts = options.maxReconnectAttempts ||
-      Number(process.env.OPENCHROME_MAX_RECONNECT_ATTEMPTS) || DEFAULT_MAX_RECONNECT_ATTEMPTS;
-    this.reconnectDelayMs = options.reconnectDelayMs ||
-      Number(process.env.OPENCHROME_RECONNECT_DELAY_MS) || DEFAULT_RECONNECT_DELAY_MS;
-    this.heartbeatIntervalMs = options.heartbeatIntervalMs ||
-      Number(process.env.OPENCHROME_HEARTBEAT_INTERVAL_MS) || DEFAULT_HEARTBEAT_INTERVAL_MS;
+    this.maxReconnectAttempts = options.maxReconnectAttempts ?? parseEnvInt('OPENCHROME_MAX_RECONNECT_ATTEMPTS', DEFAULT_MAX_RECONNECT_ATTEMPTS);
+    this.reconnectDelayMs = options.reconnectDelayMs ?? parseEnvInt('OPENCHROME_RECONNECT_DELAY_MS', DEFAULT_RECONNECT_DELAY_MS);
+    this.heartbeatIntervalMs = options.heartbeatIntervalMs ?? parseEnvInt('OPENCHROME_HEARTBEAT_INTERVAL_MS', DEFAULT_HEARTBEAT_INTERVAL_MS);
     // Use explicit option if provided, otherwise use global config
     this.autoLaunch = options.autoLaunch !== undefined ? options.autoLaunch : globalConfig.autoLaunch;
   }

--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -22,6 +22,9 @@ import {
   DEFAULT_HEARTBEAT_PING_TIMEOUT_MS,
   DEFAULT_CONNECT_VERIFY_STALENESS_MS,
   DEFAULT_CDP_SEND_TIMEOUT_MS,
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
+  DEFAULT_MAX_RECONNECT_ATTEMPTS,
+  DEFAULT_RECONNECT_DELAY_MS,
 } from '../config/defaults';
 import { withTimeout } from '../utils/with-timeout';
 
@@ -84,9 +87,12 @@ export class CDPClient {
   constructor(options: CDPClientOptions = {}) {
     const globalConfig = getGlobalConfig();
     this.port = options.port || globalConfig.port;
-    this.maxReconnectAttempts = options.maxReconnectAttempts || 3;
-    this.reconnectDelayMs = options.reconnectDelayMs || 1000;
-    this.heartbeatIntervalMs = options.heartbeatIntervalMs || 5000;
+    this.maxReconnectAttempts = options.maxReconnectAttempts ||
+      Number(process.env.OPENCHROME_MAX_RECONNECT_ATTEMPTS) || DEFAULT_MAX_RECONNECT_ATTEMPTS;
+    this.reconnectDelayMs = options.reconnectDelayMs ||
+      Number(process.env.OPENCHROME_RECONNECT_DELAY_MS) || DEFAULT_RECONNECT_DELAY_MS;
+    this.heartbeatIntervalMs = options.heartbeatIntervalMs ||
+      Number(process.env.OPENCHROME_HEARTBEAT_INTERVAL_MS) || DEFAULT_HEARTBEAT_INTERVAL_MS;
     // Use explicit option if provided, otherwise use global config
     this.autoLaunch = options.autoLaunch !== undefined ? options.autoLaunch : globalConfig.autoLaunch;
   }
@@ -321,7 +327,13 @@ export class CDPClient {
         console.error(`[CDPClient] Reconnect attempt ${this.reconnectAttempts} failed:`, error);
 
         if (this.reconnectAttempts < this.maxReconnectAttempts) {
-          await new Promise(resolve => setTimeout(resolve, this.reconnectDelayMs));
+          // Exponential backoff with jitter: baseDelay * 2^(attempt-1) + random(0..baseDelay/2)
+          const backoffDelay = Math.min(
+            this.reconnectDelayMs * Math.pow(2, this.reconnectAttempts - 1) + Math.floor(Math.random() * this.reconnectDelayMs / 2),
+            30000, // Cap at 30 seconds
+          );
+          console.error(`[CDPClient] Waiting ${backoffDelay}ms before next attempt (exponential backoff)...`);
+          await new Promise(resolve => setTimeout(resolve, backoffDelay));
         }
       }
     }

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -95,6 +95,21 @@ export const DEFAULT_CHROME_LAUNCH_TIMEOUT_MS = 60000;
  *  own error (with stderr diagnostics) to propagate instead of a generic timeout. */
 export const DEFAULT_SESSION_INIT_TIMEOUT_AUTO_LAUNCH_MS = 75000;
 
+/** Heartbeat interval in milliseconds. How frequently the CDP connection health is probed.
+ *  Override with OPENCHROME_HEARTBEAT_INTERVAL_MS environment variable.
+ *  Lower values detect disconnects faster but increase Chrome CPU overhead. */
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 5000;
+
+/** Maximum number of reconnection attempts after a disconnect.
+ *  Override with OPENCHROME_MAX_RECONNECT_ATTEMPTS environment variable.
+ *  Set higher for long-running sessions where transient failures are expected. */
+export const DEFAULT_MAX_RECONNECT_ATTEMPTS = 5;
+
+/** Base delay between reconnection attempts in milliseconds.
+ *  Actual delay uses exponential backoff: baseDelay * 2^(attempt-1) + jitter.
+ *  Override with OPENCHROME_RECONNECT_DELAY_MS environment variable. */
+export const DEFAULT_RECONNECT_DELAY_MS = 1000;
+
 /** Heartbeat active ping timeout in milliseconds.
  *  Sends Browser.getVersion to detect half-open WebSocket connections
  *  (e.g., after macOS sleep/wake) that browser.isConnected() misses.

--- a/tests/src/cdp-active-probe.test.ts
+++ b/tests/src/cdp-active-probe.test.ts
@@ -388,7 +388,7 @@ describe('CDPClient – handleDisconnect resets lastVerifiedAt', () => {
   });
 
   test('handleDisconnect resets lastVerifiedAt to 0', async () => {
-    const client = new CDPClient({ port: 9222 });
+    const client = new CDPClient({ port: 9222, maxReconnectAttempts: 1, reconnectDelayMs: 10 });
     const mockBrowser = createMockBrowser();
     (client as any).browser = mockBrowser;
     (client as any).connectionState = 'connected';

--- a/tests/src/cdp-reconnect.test.ts
+++ b/tests/src/cdp-reconnect.test.ts
@@ -170,6 +170,77 @@ describe('CDPClient – handleDisconnect reconnection fixes', () => {
     // Should return immediately without attempting reconnection
     expect(connectSpy).not.toHaveBeenCalled();
   });
+
+  test('uses exponential backoff between reconnection attempts', async () => {
+    const client = createConnectedClient({ maxReconnectAttempts: 4, reconnectDelayMs: 100 });
+
+    const delays: number[] = [];
+    const originalSetTimeout = global.setTimeout;
+    jest.spyOn(global, 'setTimeout').mockImplementation((fn: any, ms?: number) => {
+      if (ms && ms > 0) delays.push(ms);
+      return originalSetTimeout(fn, 1); // Execute immediately for test speed
+    });
+
+    jest.spyOn(client as any, 'connectInternal')
+      .mockRejectedValue(new Error('Chrome not available'));
+
+    await (client as any).handleDisconnect();
+
+    // Should have 3 delays (between 4 attempts)
+    expect(delays.length).toBe(3);
+    // Each delay should be larger than the previous (exponential)
+    for (let i = 1; i < delays.length; i++) {
+      expect(delays[i]).toBeGreaterThan(delays[i - 1]);
+    }
+    // First delay should be close to base (100ms + jitter)
+    expect(delays[0]).toBeGreaterThanOrEqual(100);
+    expect(delays[0]).toBeLessThan(200); // 100 * 2^0 + jitter(0..50)
+    // All delays capped at 30000ms
+    delays.forEach(d => expect(d).toBeLessThanOrEqual(30000));
+
+    jest.restoreAllMocks();
+  });
+
+  test('defaults to 5 max reconnect attempts from DEFAULT_MAX_RECONNECT_ATTEMPTS', () => {
+    const client = new CDPClient({ port: 9222 });
+    expect((client as any).maxReconnectAttempts).toBe(5);
+  });
+
+  test('respects OPENCHROME_MAX_RECONNECT_ATTEMPTS environment variable', () => {
+    process.env.OPENCHROME_MAX_RECONNECT_ATTEMPTS = '8';
+    const client = new CDPClient({ port: 9222 });
+    expect((client as any).maxReconnectAttempts).toBe(8);
+    delete process.env.OPENCHROME_MAX_RECONNECT_ATTEMPTS;
+  });
+
+  test('respects OPENCHROME_HEARTBEAT_INTERVAL_MS environment variable', () => {
+    process.env.OPENCHROME_HEARTBEAT_INTERVAL_MS = '10000';
+    const client = new CDPClient({ port: 9222 });
+    expect((client as any).heartbeatIntervalMs).toBe(10000);
+    delete process.env.OPENCHROME_HEARTBEAT_INTERVAL_MS;
+  });
+
+  test('caps exponential backoff at 30 seconds', async () => {
+    const client = createConnectedClient({ maxReconnectAttempts: 10, reconnectDelayMs: 5000 });
+
+    const delays: number[] = [];
+    const originalSetTimeout = global.setTimeout;
+    jest.spyOn(global, 'setTimeout').mockImplementation((fn: any, ms?: number) => {
+      if (ms && ms > 0) delays.push(ms);
+      return originalSetTimeout(fn, 1);
+    });
+
+    jest.spyOn(client as any, 'connectInternal')
+      .mockRejectedValue(new Error('Chrome not available'));
+
+    await (client as any).handleDisconnect();
+
+    // Later delays should be capped at 30000
+    const laterDelays = delays.filter(d => d >= 30000);
+    laterDelays.forEach(d => expect(d).toBeLessThanOrEqual(30000));
+
+    jest.restoreAllMocks();
+  });
 });
 
 // ─── getChromeLauncher – port validation ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `DEFAULT_HEARTBEAT_INTERVAL_MS`, `DEFAULT_MAX_RECONNECT_ATTEMPTS`, `DEFAULT_RECONNECT_DELAY_MS` to `config/defaults.ts`
- Replace hardcoded values in `CDPClient` constructor with named constants + env var overrides (`OPENCHROME_HEARTBEAT_INTERVAL_MS`, `OPENCHROME_MAX_RECONNECT_ATTEMPTS`, `OPENCHROME_RECONNECT_DELAY_MS`)
- Implement **exponential backoff with jitter** in `handleDisconnect()` reconnect loop, capped at 30s
- Increase default max reconnect attempts from 3 → 5 for better resilience in long-running sessions

## Motivation

Part of #344 (Long-Running Session Hardening). The previous flat 1s delay between reconnect attempts was insufficient — if Chrome needs 5-10 seconds to recover after a heavy GC pause, all 3 attempts would fail within 3 seconds. Exponential backoff spreads attempts over a wider window, and increasing to 5 attempts provides more chances for recovery.

## Changes

| File | Change |
|------|--------|
| `src/config/defaults.ts` | +3 new constants |
| `src/cdp/client.ts` | Constructor uses constants + env vars; `handleDisconnect()` uses exponential backoff |
| `tests/src/cdp-reconnect.test.ts` | +5 new tests (backoff ordering, default 5 attempts, env vars, 30s cap) |

## Test plan

- [ ] `npx jest tests/src/cdp-reconnect.test.ts` — 13/13 pass
- [ ] `npm run build` — clean compilation
- [ ] Verify env var overrides work: `OPENCHROME_MAX_RECONNECT_ATTEMPTS=8 npx openchrome-mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)