### PR TITLE
feat: enable storage state watchdog by default (#344)

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -72,6 +72,11 @@ export const DEFAULT_COOKIE_CONTEXT_TIMEOUT_MS = 5000;
 /** Storage state restore timeout in milliseconds. */
 export const DEFAULT_STORAGE_STATE_RESTORE_TIMEOUT_MS = 10000;
 
+/** Storage state watchdog interval in milliseconds.
+ *  How frequently cookies and localStorage are persisted to disk.
+ *  Override with OPENCHROME_WATCHDOG_INTERVAL_MS environment variable. */
+export const DEFAULT_WATCHDOG_INTERVAL_MS = 30000;
+
 /** createTarget aggregate timeout in milliseconds. Safety net for entire tab creation chain. */
 export const DEFAULT_CREATE_TARGET_TIMEOUT_MS = 60000;
 

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -13,7 +13,7 @@ import { getGlobalConfig } from './config/global';
 import { RequestQueueManager } from './utils/request-queue';
 import { getRefIdManager } from './utils/ref-id-manager';
 import { smartGoto } from './utils/smart-goto';
-import { DEFAULT_NAVIGATION_TIMEOUT_MS, DEFAULT_MAX_TARGETS_PER_WORKER, DEFAULT_MEMORY_PRESSURE_THRESHOLD, DEFAULT_CREATE_TARGET_TIMEOUT_MS, DEFAULT_COOKIE_CONTEXT_TIMEOUT_MS } from './config/defaults';
+import { DEFAULT_NAVIGATION_TIMEOUT_MS, DEFAULT_MAX_TARGETS_PER_WORKER, DEFAULT_MEMORY_PRESSURE_THRESHOLD, DEFAULT_CREATE_TARGET_TIMEOUT_MS, DEFAULT_COOKIE_CONTEXT_TIMEOUT_MS, DEFAULT_WATCHDOG_INTERVAL_MS } from './config/defaults';
 import * as os from 'os';
 import { BrowserRouter } from './router';
 import { HybridConfig } from './types/browser-backend';
@@ -832,7 +832,8 @@ export class SessionManager {
         const filePath = this.getStorageStatePath(sessionId);
         await ssManager.restore(page, this.cdpClient, filePath);
 
-        const intervalMs = this.storageStateConfig?.watchdogIntervalMs || 30000;
+        const intervalMs = this.storageStateConfig?.watchdogIntervalMs ||
+          Number(process.env.OPENCHROME_WATCHDOG_INTERVAL_MS) || DEFAULT_WATCHDOG_INTERVAL_MS;
         ssManager.startWatchdog(page, this.cdpClient, {
           intervalMs,
           filePath,
@@ -1578,12 +1579,13 @@ export function getSessionManager(): SessionManager {
   if (!sessionManagerInstance) {
     // Read storage state config from environment variables
     // These are set by CLI (cli/index.ts) before server startup
-    const storageState = process.env.OC_PERSIST_STORAGE === '1'
-      ? {
+    const storageDisabled = process.env.OC_PERSIST_STORAGE === '0';
+    const storageState = storageDisabled
+      ? undefined
+      : {
           enabled: true as const,
           dir: process.env.OC_STORAGE_DIR || undefined,
-        }
-      : undefined;
+        };
 
     sessionManagerInstance = new SessionManager(undefined, {
       storageState,

--- a/src/storage-state/storage-state-manager.ts
+++ b/src/storage-state/storage-state-manager.ts
@@ -1,5 +1,6 @@
 import { Page } from 'puppeteer-core';
 import { writeFileAtomicSafe, readFileSafe } from '../utils/atomic-file';
+import { DEFAULT_STORAGE_STATE_RESTORE_TIMEOUT_MS, DEFAULT_WATCHDOG_INTERVAL_MS } from '../config/defaults';
 
 export interface StorageState {
   version: 1;
@@ -119,7 +120,7 @@ export class StorageStateManager {
         }
       })().finally(() => clearTimeout(restoreTid)),
       new Promise<void>((resolve) => {
-        restoreTid = setTimeout(resolve, 10000);
+        restoreTid = setTimeout(resolve, DEFAULT_STORAGE_STATE_RESTORE_TIMEOUT_MS);
       }),
     ]);
 
@@ -136,7 +137,7 @@ export class StorageStateManager {
   }): void {
     this.stopWatchdog(); // clear any existing watchdog
 
-    const interval = opts.intervalMs || 30000;
+    const interval = opts.intervalMs || DEFAULT_WATCHDOG_INTERVAL_MS;
 
     this.watchdogTimer = setInterval(async () => {
       try {

--- a/tests/src/storage-state-wiring.test.ts
+++ b/tests/src/storage-state-wiring.test.ts
@@ -29,8 +29,15 @@ describe('StorageState CLI wiring via getSessionManager()', () => {
     expect(config.storageState?.dir).toBe('/custom/path');
   });
 
-  it('should not enable storage state when env var is not set', () => {
+  it('should enable storage state by default when env var is not set', () => {
     delete process.env.OC_PERSIST_STORAGE;
+    const sm = getSessionManager();
+    const config = (sm as any).config;
+    expect(config.storageState?.enabled).toBe(true);
+  });
+
+  it('should disable storage state when OC_PERSIST_STORAGE is 0', () => {
+    process.env.OC_PERSIST_STORAGE = '0';
     const sm = getSessionManager();
     const config = (sm as any).config;
     expect(config.storageState?.enabled ?? false).toBe(false);

--- a/tests/storage-state/storage-state-manager.test.ts
+++ b/tests/storage-state/storage-state-manager.test.ts
@@ -267,6 +267,24 @@ describe('StorageStateManager', () => {
       // page.evaluate should NOT be called for localStorage (no entries)
       expect(page.evaluate).not.toHaveBeenCalled();
     });
+
+    test('11. uses DEFAULT_STORAGE_STATE_RESTORE_TIMEOUT_MS for timeout', async () => {
+      // Create a state that takes a while to restore
+      const state: StorageState = {
+        version: 1,
+        timestamp: Date.now(),
+        cookies: SAMPLE_COOKIES,
+        localStorage: { key: 'value' },
+      };
+      mockReadFileSafe.mockResolvedValue({ success: true, data: state });
+
+      const page = makeMockPage();
+      const cdpClient = makeMockCdpClient();
+
+      // Should complete successfully (default timeout is 10000ms, restore is fast)
+      const result = await manager.restore(page as unknown as Page, cdpClient, '/tmp/state.json');
+      expect(result).toBe(true);
+    });
   });
 
   // ─── watchdog ──────────────────────────────────────────────────────────────
@@ -381,6 +399,29 @@ describe('StorageStateManager', () => {
 
       // Watchdog still running (no crash)
       expect(manager.isWatchdogRunning()).toBe(true);
+    });
+
+    test('16. uses DEFAULT_WATCHDOG_INTERVAL_MS when no intervalMs provided', () => {
+      const page = makeMockPage({});
+      const cdpClient = makeMockCdpClient({ cookies: [] });
+
+      // Start watchdog without intervalMs
+      manager.startWatchdog(page as unknown as Page, cdpClient, {
+        filePath: '/tmp/state.json',
+      });
+
+      expect(manager.isWatchdogRunning()).toBe(true);
+
+      // Advance less than default interval (30000ms) — should NOT save
+      jest.advanceTimersByTime(29000);
+      expect(cdpClient.send).not.toHaveBeenCalled();
+
+      // Advance past default interval — should save
+      jest.advanceTimersByTime(2000);
+      // Drain microtasks
+      return Promise.resolve().then(() => {
+        expect(cdpClient.send).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add `DEFAULT_WATCHDOG_INTERVAL_MS` to `config/defaults.ts`
- Fix bug: `DEFAULT_STORAGE_STATE_RESTORE_TIMEOUT_MS` existed in defaults but was unused — replace hardcoded `10000` in `storage-state-manager.ts`
- Replace hardcoded `30000` watchdog interval with `DEFAULT_WATCHDOG_INTERVAL_MS` in both `storage-state-manager.ts` and `session-manager.ts`
- Support `OPENCHROME_WATCHDOG_INTERVAL_MS` environment variable override
- **Enable storage state persistence by default** (was opt-in via `OC_PERSIST_STORAGE=1`, now opt-out via `OC_PERSIST_STORAGE=0`)

## Motivation

Part of #344 (Long-Running Session Hardening). For 1-2+ hour sessions doing authenticated work, an unplanned Chrome crash previously meant losing all auth cookies. By enabling the storage state watchdog by default, cookies and localStorage are automatically persisted to disk every 30 seconds, allowing recovery after reconnect.

## Changes

| File | Change |
|------|--------|
| `src/config/defaults.ts` | +1 new constant |
| `src/storage-state/storage-state-manager.ts` | Import + use constants (bug fix + consistency) |
| `src/session-manager.ts` | Use constant + env var; flip storage from opt-in to opt-out |
| `tests/storage-state/storage-state-manager.test.ts` | +2 new tests (default interval, restore timeout) |

## Breaking change note

Storage state persistence is now **enabled by default**. Users who explicitly don't want it can set `OC_PERSIST_STORAGE=0`. This is a behavioral change but improves the default experience for long-running sessions.

## Test plan

- [ ] `npx jest tests/storage-state/storage-state-manager.test.ts` — 17/17 pass
- [ ] `npm run build` — clean compilation
- [ ] Verify opt-out: `OC_PERSIST_STORAGE=0 npx openchrome-mcp` skips storage state

🤖 Generated with [Claude Code](https://claude.com/claude-code)