### PR TITLE
feat: session state disk persistence for restart recovery (#347)

### DIFF
--- a/src/session-state-persistence.ts
+++ b/src/session-state-persistence.ts
@@ -2,6 +2,14 @@
  * Session State Persistence — serializes session/worker/target mappings to disk.
  * Enables recovery of MCP server state after process restart.
  * Part of #347 Layer 2: Session State Persistence.
+ *
+ * Integration plan:
+ * SessionManager should instantiate SessionStatePersistence and call:
+ *   - scheduleSave(createSnapshot(this.sessions)) on every mutation
+ *     (worker/target created or deleted)
+ *   - restore() on startup to reload prior state
+ *   - clear() on clean shutdown (e.g., SIGTERM handler)
+ * Until that wiring lands this module is compiled but not invoked at runtime.
  */
 
 import * as path from 'path';
@@ -35,6 +43,8 @@ export class SessionStatePersistence {
   private readonly debounceMs: number;
   private readonly filePath: string;
   private saving = false;
+  private pendingSave = false;
+  private lastState: PersistedSessionState | null = null;
 
   constructor(opts?: { dir?: string; debounceMs?: number }) {
     this.debounceMs = opts?.debounceMs ?? 5000;
@@ -61,18 +71,26 @@ export class SessionStatePersistence {
 
   /**
    * Immediately save state to disk.
+   * If a save is already in progress, the latest state is queued and written
+   * once the current write completes — no state is silently dropped.
    */
   async save(state: PersistedSessionState): Promise<void> {
-    if (this.saving) return;
+    if (this.saving) {
+      this.pendingSave = true;
+      this.lastState = state;
+      return;
+    }
     this.saving = true;
     try {
-      const stateWithTimestamp: PersistedSessionState = {
-        ...state,
-        timestamp: Date.now(),
-      };
-      await writeFileAtomicSafe(this.filePath, stateWithTimestamp);
+      await writeFileAtomicSafe(this.filePath, { ...state, timestamp: Date.now() });
     } finally {
       this.saving = false;
+      if (this.pendingSave && this.lastState) {
+        this.pendingSave = false;
+        const next = this.lastState;
+        this.lastState = null;
+        await this.save(next);
+      }
     }
   }
 
@@ -105,13 +123,16 @@ export class SessionStatePersistence {
 
   /**
    * Delete persisted state file (e.g., on clean shutdown).
+   * Only ENOENT is swallowed; other errors (e.g., permission failures) are logged.
    */
   async clear(): Promise<void> {
     const fs = await import('fs/promises');
     try {
       await fs.unlink(this.filePath);
-    } catch {
-      // File may not exist — that's fine
+    } catch (error: any) {
+      if (error?.code !== 'ENOENT') {
+        console.error(`[SessionStatePersistence] Failed to clear state: ${error.message}`);
+      }
     }
   }
 
@@ -142,9 +163,12 @@ export class SessionStatePersistence {
   /**
    * Helper: extract session state from SessionManager's in-memory structures.
    * This is a pure function that converts the internal format to persisted format.
+   *
+   * Workers hold targets as Set<string> (bare CDP target IDs). URLs are not
+   * tracked in memory — persisted entries use 'about:blank' as a placeholder.
    */
   static createSnapshot(sessions: Map<string, {
-    workers: Map<string, { id: string; targets: Map<string, { url?: string }> }>;
+    workers: Map<string, { id: string; targets: Set<string> }>;
     lastActivityAt: number;
   }>): PersistedSessionState {
     const persistedSessions: PersistedSession[] = [];
@@ -153,11 +177,8 @@ export class SessionStatePersistence {
       const workers: PersistedWorker[] = [];
       for (const [, worker] of session.workers) {
         const targets: PersistedTarget[] = [];
-        for (const [targetId, targetInfo] of worker.targets) {
-          targets.push({
-            targetId,
-            url: targetInfo.url || 'about:blank',
-          });
+        for (const targetId of worker.targets) {
+          targets.push({ targetId, url: 'about:blank' });
         }
         workers.push({ id: worker.id, targets });
       }

--- a/src/session-state-persistence.ts
+++ b/src/session-state-persistence.ts
@@ -1,0 +1,177 @@
+/**
+ * Session State Persistence — serializes session/worker/target mappings to disk.
+ * Enables recovery of MCP server state after process restart.
+ * Part of #347 Layer 2: Session State Persistence.
+ */
+
+import * as path from 'path';
+import * as os from 'os';
+import { writeFileAtomicSafe, readFileSafe } from './utils/atomic-file';
+
+export interface PersistedTarget {
+  targetId: string;
+  url: string;
+}
+
+export interface PersistedWorker {
+  id: string;
+  targets: PersistedTarget[];
+}
+
+export interface PersistedSession {
+  id: string;
+  workers: PersistedWorker[];
+  lastActivityAt: number;
+}
+
+export interface PersistedSessionState {
+  version: 1;
+  timestamp: number;
+  sessions: PersistedSession[];
+}
+
+export class SessionStatePersistence {
+  private saveDebounceTimer: NodeJS.Timeout | null = null;
+  private readonly debounceMs: number;
+  private readonly filePath: string;
+  private saving = false;
+
+  constructor(opts?: { dir?: string; debounceMs?: number }) {
+    this.debounceMs = opts?.debounceMs ?? 5000;
+    const dir = opts?.dir || path.join(os.homedir(), '.openchrome');
+    this.filePath = path.join(dir, 'session-state.json');
+  }
+
+  /**
+   * Schedule a debounced save. Multiple calls within debounceMs are coalesced.
+   */
+  scheduleSave(state: PersistedSessionState): void {
+    if (this.saveDebounceTimer) {
+      clearTimeout(this.saveDebounceTimer);
+    }
+    this.saveDebounceTimer = setTimeout(async () => {
+      this.saveDebounceTimer = null;
+      await this.save(state);
+    }, this.debounceMs);
+    // Don't prevent process exit
+    if (this.saveDebounceTimer.unref) {
+      this.saveDebounceTimer.unref();
+    }
+  }
+
+  /**
+   * Immediately save state to disk.
+   */
+  async save(state: PersistedSessionState): Promise<void> {
+    if (this.saving) return;
+    this.saving = true;
+    try {
+      const stateWithTimestamp: PersistedSessionState = {
+        ...state,
+        timestamp: Date.now(),
+      };
+      await writeFileAtomicSafe(this.filePath, stateWithTimestamp);
+    } finally {
+      this.saving = false;
+    }
+  }
+
+  /**
+   * Restore state from disk.
+   * Returns null if file doesn't exist, is corrupted, or has wrong version.
+   */
+  async restore(): Promise<PersistedSessionState | null> {
+    const result = await readFileSafe<PersistedSessionState>(this.filePath);
+    if (!result.success || !result.data) {
+      return null;
+    }
+
+    const state = result.data;
+
+    // Validate version
+    if (state.version !== 1) {
+      console.error(`[SessionStatePersistence] Unknown version: ${state.version}, ignoring`);
+      return null;
+    }
+
+    // Validate structure
+    if (!Array.isArray(state.sessions)) {
+      console.error('[SessionStatePersistence] Invalid state: sessions is not an array');
+      return null;
+    }
+
+    return state;
+  }
+
+  /**
+   * Delete persisted state file (e.g., on clean shutdown).
+   */
+  async clear(): Promise<void> {
+    const fs = await import('fs/promises');
+    try {
+      await fs.unlink(this.filePath);
+    } catch {
+      // File may not exist — that's fine
+    }
+  }
+
+  /**
+   * Cancel any pending debounced save.
+   */
+  cancelPendingSave(): void {
+    if (this.saveDebounceTimer) {
+      clearTimeout(this.saveDebounceTimer);
+      this.saveDebounceTimer = null;
+    }
+  }
+
+  /**
+   * Whether a save is currently in progress.
+   */
+  isSaving(): boolean {
+    return this.saving;
+  }
+
+  /**
+   * Get the file path where state is persisted.
+   */
+  getFilePath(): string {
+    return this.filePath;
+  }
+
+  /**
+   * Helper: extract session state from SessionManager's in-memory structures.
+   * This is a pure function that converts the internal format to persisted format.
+   */
+  static createSnapshot(sessions: Map<string, {
+    workers: Map<string, { id: string; targets: Map<string, { url?: string }> }>;
+    lastActivityAt: number;
+  }>): PersistedSessionState {
+    const persistedSessions: PersistedSession[] = [];
+
+    for (const [sessionId, session] of sessions) {
+      const workers: PersistedWorker[] = [];
+      for (const [, worker] of session.workers) {
+        const targets: PersistedTarget[] = [];
+        for (const [targetId, targetInfo] of worker.targets) {
+          targets.push({
+            targetId,
+            url: targetInfo.url || 'about:blank',
+          });
+        }
+        workers.push({ id: worker.id, targets });
+      }
+      persistedSessions.push({
+        id: sessionId,
+        workers,
+        lastActivityAt: session.lastActivityAt,
+      });
+    }
+
+    return {
+      version: 1,
+      timestamp: Date.now(),
+      sessions: persistedSessions,
+    };
+  }
+}

--- a/tests/session-state-persistence.test.ts
+++ b/tests/session-state-persistence.test.ts
@@ -1,0 +1,185 @@
+/// <reference types="jest" />
+
+import { SessionStatePersistence, PersistedSessionState } from '../src/session-state-persistence';
+import { writeFileAtomicSafe, readFileSafe } from '../src/utils/atomic-file';
+
+jest.mock('../src/utils/atomic-file', () => ({
+  writeFileAtomicSafe: jest.fn().mockResolvedValue(undefined),
+  readFileSafe: jest.fn(),
+}));
+
+const mockWriteFileAtomicSafe = writeFileAtomicSafe as jest.MockedFunction<typeof writeFileAtomicSafe>;
+const mockReadFileSafe = readFileSafe as jest.MockedFunction<typeof readFileSafe>;
+
+const SAMPLE_STATE: PersistedSessionState = {
+  version: 1,
+  timestamp: Date.now(),
+  sessions: [
+    {
+      id: 'default',
+      workers: [
+        {
+          id: 'default',
+          targets: [
+            { targetId: 'ABC123', url: 'https://example.com' },
+            { targetId: 'DEF456', url: 'https://github.com' },
+          ],
+        },
+      ],
+      lastActivityAt: Date.now(),
+    },
+  ],
+};
+
+describe('SessionStatePersistence', () => {
+  let persistence: SessionStatePersistence;
+
+  beforeEach(() => {
+    persistence = new SessionStatePersistence({ dir: '/tmp', debounceMs: 50 });
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    persistence.cancelPendingSave();
+  });
+
+  describe('save', () => {
+    test('writes state to disk with atomic write', async () => {
+      await persistence.save(SAMPLE_STATE);
+
+      expect(mockWriteFileAtomicSafe).toHaveBeenCalledWith(
+        expect.stringContaining('session-state.json'),
+        expect.objectContaining({
+          version: 1,
+          sessions: SAMPLE_STATE.sessions,
+        })
+      );
+    });
+
+    test('prevents concurrent saves', async () => {
+      let resolveFirst!: () => void;
+      mockWriteFileAtomicSafe.mockImplementationOnce(
+        () => new Promise(resolve => { resolveFirst = () => resolve(undefined); })
+      );
+
+      const p1 = persistence.save(SAMPLE_STATE);
+      const p2 = persistence.save(SAMPLE_STATE);
+
+      resolveFirst();
+      await Promise.all([p1, p2]);
+
+      expect(mockWriteFileAtomicSafe).toHaveBeenCalledTimes(1);
+    });
+
+    test('updates timestamp on save', async () => {
+      const before = Date.now();
+      await persistence.save(SAMPLE_STATE);
+      const after = Date.now();
+
+      const [, written] = mockWriteFileAtomicSafe.mock.calls[0];
+      const state = written as PersistedSessionState;
+      expect(state.timestamp).toBeGreaterThanOrEqual(before);
+      expect(state.timestamp).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe('restore', () => {
+    test('restores valid state from disk', async () => {
+      mockReadFileSafe.mockResolvedValue({ success: true, data: SAMPLE_STATE });
+
+      const result = await persistence.restore();
+
+      expect(result).toEqual(SAMPLE_STATE);
+    });
+
+    test('returns null for missing file', async () => {
+      mockReadFileSafe.mockResolvedValue({ success: false, error: 'not found' });
+
+      const result = await persistence.restore();
+      expect(result).toBeNull();
+    });
+
+    test('returns null for wrong version', async () => {
+      mockReadFileSafe.mockResolvedValue({
+        success: true,
+        data: { ...SAMPLE_STATE, version: 99 },
+      });
+
+      const result = await persistence.restore();
+      expect(result).toBeNull();
+    });
+
+    test('returns null for invalid structure', async () => {
+      mockReadFileSafe.mockResolvedValue({
+        success: true,
+        data: { version: 1, timestamp: Date.now(), sessions: 'not-an-array' },
+      });
+
+      const result = await persistence.restore();
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('scheduleSave', () => {
+    test('debounces multiple save calls', async () => {
+      persistence.scheduleSave(SAMPLE_STATE);
+      persistence.scheduleSave(SAMPLE_STATE);
+      persistence.scheduleSave(SAMPLE_STATE);
+
+      // Wait for debounce
+      await new Promise(r => setTimeout(r, 100));
+
+      expect(mockWriteFileAtomicSafe).toHaveBeenCalledTimes(1);
+    });
+
+    test('cancelPendingSave prevents write', async () => {
+      persistence.scheduleSave(SAMPLE_STATE);
+      persistence.cancelPendingSave();
+
+      await new Promise(r => setTimeout(r, 100));
+
+      expect(mockWriteFileAtomicSafe).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createSnapshot', () => {
+    test('converts in-memory session structure to persisted format', () => {
+      const sessions = new Map();
+      const targets = new Map();
+      targets.set('T1', { url: 'https://example.com' });
+      targets.set('T2', { url: 'https://github.com' });
+
+      const workers = new Map();
+      workers.set('default', { id: 'default', targets });
+
+      sessions.set('default', { workers, lastActivityAt: 1000 });
+
+      const snapshot = SessionStatePersistence.createSnapshot(sessions);
+
+      expect(snapshot.version).toBe(1);
+      expect(snapshot.sessions).toHaveLength(1);
+      expect(snapshot.sessions[0].id).toBe('default');
+      expect(snapshot.sessions[0].workers[0].targets).toHaveLength(2);
+      expect(snapshot.sessions[0].workers[0].targets[0].url).toBe('https://example.com');
+    });
+
+    test('handles empty sessions', () => {
+      const sessions = new Map();
+      const snapshot = SessionStatePersistence.createSnapshot(sessions);
+
+      expect(snapshot.sessions).toHaveLength(0);
+    });
+  });
+
+  describe('clear', () => {
+    test('does not throw when file does not exist', async () => {
+      await expect(persistence.clear()).resolves.not.toThrow();
+    });
+  });
+
+  describe('getFilePath', () => {
+    test('returns correct file path', () => {
+      expect(persistence.getFilePath()).toContain('session-state.json');
+    });
+  });
+});

--- a/tests/session-state-persistence.test.ts
+++ b/tests/session-state-persistence.test.ts
@@ -56,7 +56,7 @@ describe('SessionStatePersistence', () => {
       );
     });
 
-    test('prevents concurrent saves', async () => {
+    test('queues concurrent save so state is not dropped', async () => {
       let resolveFirst!: () => void;
       mockWriteFileAtomicSafe.mockImplementationOnce(
         () => new Promise(resolve => { resolveFirst = () => resolve(undefined); })
@@ -68,7 +68,8 @@ describe('SessionStatePersistence', () => {
       resolveFirst();
       await Promise.all([p1, p2]);
 
-      expect(mockWriteFileAtomicSafe).toHaveBeenCalledTimes(1);
+      // p2 was queued and runs after p1 completes — two writes total
+      expect(mockWriteFileAtomicSafe).toHaveBeenCalledTimes(2);
     });
 
     test('updates timestamp on save', async () => {
@@ -145,9 +146,8 @@ describe('SessionStatePersistence', () => {
   describe('createSnapshot', () => {
     test('converts in-memory session structure to persisted format', () => {
       const sessions = new Map();
-      const targets = new Map();
-      targets.set('T1', { url: 'https://example.com' });
-      targets.set('T2', { url: 'https://github.com' });
+      // targets is Set<string> of bare CDP target IDs — no URL stored in memory
+      const targets = new Set(['T1', 'T2']);
 
       const workers = new Map();
       workers.set('default', { id: 'default', targets });
@@ -160,7 +160,8 @@ describe('SessionStatePersistence', () => {
       expect(snapshot.sessions).toHaveLength(1);
       expect(snapshot.sessions[0].id).toBe('default');
       expect(snapshot.sessions[0].workers[0].targets).toHaveLength(2);
-      expect(snapshot.sessions[0].workers[0].targets[0].url).toBe('https://example.com');
+      // URLs are not tracked in memory; persisted as placeholder
+      expect(snapshot.sessions[0].workers[0].targets[0].url).toBe('about:blank');
     });
 
     test('handles empty sessions', () => {


### PR DESCRIPTION
## Summary

- New `SessionStatePersistence` class serializes session/worker/target mappings to `~/.openchrome/session-state.json`
- Debounced saves (5s) prevent excessive disk writes during rapid session changes
- Atomic writes via `writeFileAtomicSafe` prevent corruption on crash
- Version-validated restore with structural checks
- Static `createSnapshot()` helper for SessionManager integration

## Motivation

Part of #347 Phase 2B (Layer 2). Currently all session state is in-memory — if the MCP server restarts, all tab mappings are lost. This module persists state to disk for recovery.

## Changes

| File | Change |
|------|--------|
| `src/session-state-persistence.ts` | New persistence class |
| `tests/session-state-persistence.test.ts` | 13 tests |

## Test plan

- [x] `npx jest tests/session-state-persistence.test.ts` — 13/13 pass
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)