### PR TITLE
feat: per-tab renderer health monitor (#347)

### DIFF
--- a/src/cdp/tab-health-monitor.ts
+++ b/src/cdp/tab-health-monitor.ts
@@ -1,0 +1,161 @@
+/**
+ * Per-Tab Health Monitor — detects frozen/crashed renderer tabs.
+ * Runs independently of the global CDPClient heartbeat.
+ * Part of #347 Layer 1: CDP Connection Resilience.
+ */
+
+import { EventEmitter } from 'events';
+import { Page } from 'puppeteer-core';
+
+export type TabHealthStatus = 'healthy' | 'unhealthy' | 'unknown';
+
+export interface TabHealthInfo {
+  targetId: string;
+  status: TabHealthStatus;
+  consecutiveFailures: number;
+  lastCheckedAt: number;
+  lastHealthyAt: number;
+}
+
+export interface TabHealthMonitorOptions {
+  /** How often to probe idle tabs (ms). Default: 60000 (60s) */
+  probeIntervalMs?: number;
+  /** Timeout for each probe (ms). Default: 5000 (5s) */
+  probeTimeoutMs?: number;
+  /** Consecutive failures before marking unhealthy. Default: 3 */
+  unhealthyThreshold?: number;
+  /** Consecutive failures before auto-eviction. Default: 5 */
+  evictionThreshold?: number;
+}
+
+export class TabHealthMonitor extends EventEmitter {
+  private timers: Map<string, NodeJS.Timeout> = new Map();
+  private health: Map<string, TabHealthInfo> = new Map();
+  private readonly probeIntervalMs: number;
+  private readonly probeTimeoutMs: number;
+  private readonly unhealthyThreshold: number;
+  private readonly evictionThreshold: number;
+
+  constructor(opts?: TabHealthMonitorOptions) {
+    super();
+    this.probeIntervalMs = opts?.probeIntervalMs ?? 60000;
+    this.probeTimeoutMs = opts?.probeTimeoutMs ?? 5000;
+    this.unhealthyThreshold = opts?.unhealthyThreshold ?? 3;
+    this.evictionThreshold = opts?.evictionThreshold ?? 5;
+  }
+
+  /**
+   * Start monitoring a tab's renderer health.
+   */
+  monitorTab(targetId: string, page: Page): void {
+    // Remove existing monitor if any
+    this.unmonitorTab(targetId);
+
+    const now = Date.now();
+    this.health.set(targetId, {
+      targetId,
+      status: 'healthy',
+      consecutiveFailures: 0,
+      lastCheckedAt: now,
+      lastHealthyAt: now,
+    });
+
+    const timer = setInterval(async () => {
+      await this.probeTab(targetId, page);
+    }, this.probeIntervalMs);
+    timer.unref();
+    this.timers.set(targetId, timer);
+  }
+
+  /**
+   * Stop monitoring a tab.
+   */
+  unmonitorTab(targetId: string): void {
+    const timer = this.timers.get(targetId);
+    if (timer) {
+      clearInterval(timer);
+      this.timers.delete(targetId);
+    }
+    this.health.delete(targetId);
+  }
+
+  /**
+   * Probe a tab's renderer by executing minimal JavaScript.
+   */
+  private async probeTab(targetId: string, page: Page): Promise<void> {
+    const info = this.health.get(targetId);
+    if (!info) return;
+
+    const now = Date.now();
+    info.lastCheckedAt = now;
+
+    try {
+      // Race: lightweight JS execution vs timeout
+      let probeTid: ReturnType<typeof setTimeout>;
+      await Promise.race([
+        page.evaluate('1').finally(() => clearTimeout(probeTid)),
+        new Promise<never>((_, reject) => {
+          probeTid = setTimeout(
+            () => reject(new Error('tab health probe timeout')),
+            this.probeTimeoutMs,
+          );
+        }),
+      ]);
+
+      // Success — tab is healthy
+      if (info.status !== 'healthy') {
+        console.error(`[TabHealthMonitor] Tab ${targetId} recovered (was ${info.status})`);
+      }
+      info.status = 'healthy';
+      info.consecutiveFailures = 0;
+      info.lastHealthyAt = now;
+      this.emit('tab-healthy', { targetId });
+    } catch (error) {
+      info.consecutiveFailures++;
+
+      if (info.consecutiveFailures >= this.evictionThreshold) {
+        info.status = 'unhealthy';
+        console.error(`[TabHealthMonitor] Tab ${targetId} eviction threshold reached (${info.consecutiveFailures} failures)`);
+        this.emit('tab-evict', { targetId, failures: info.consecutiveFailures });
+        this.unmonitorTab(targetId); // stop monitoring evicted tab
+      } else if (info.consecutiveFailures >= this.unhealthyThreshold) {
+        info.status = 'unhealthy';
+        console.error(`[TabHealthMonitor] Tab ${targetId} marked unhealthy (${info.consecutiveFailures} failures)`);
+        this.emit('tab-unhealthy', { targetId, failures: info.consecutiveFailures });
+      } else {
+        console.error(`[TabHealthMonitor] Tab ${targetId} probe failed (strike ${info.consecutiveFailures}/${this.unhealthyThreshold}):`,
+          error instanceof Error ? error.message : String(error));
+      }
+    }
+  }
+
+  /**
+   * Get health status of a specific tab.
+   */
+  getTabHealth(targetId: string): TabHealthInfo | undefined {
+    return this.health.get(targetId);
+  }
+
+  /**
+   * Get health status of all monitored tabs.
+   */
+  getAllHealth(): Map<string, TabHealthInfo> {
+    return new Map(this.health);
+  }
+
+  /**
+   * Get count of monitored tabs.
+   */
+  getMonitoredTabCount(): number {
+    return this.timers.size;
+  }
+
+  /**
+   * Stop monitoring all tabs.
+   */
+  stopAll(): void {
+    for (const [targetId] of this.timers) {
+      this.unmonitorTab(targetId);
+    }
+  }
+}

--- a/src/cdp/tab-health-monitor.ts
+++ b/src/cdp/tab-health-monitor.ts
@@ -91,9 +91,9 @@ export class TabHealthMonitor extends EventEmitter {
 
     try {
       // Race: lightweight JS execution vs timeout
-      let probeTid: ReturnType<typeof setTimeout>;
+      let probeTid: ReturnType<typeof setTimeout> | undefined;
       await Promise.race([
-        page.evaluate('1').finally(() => clearTimeout(probeTid)),
+        page.evaluate('1').finally(() => { if (probeTid) clearTimeout(probeTid); }),
         new Promise<never>((_, reject) => {
           probeTid = setTimeout(
             () => reject(new Error('tab health probe timeout')),
@@ -116,7 +116,9 @@ export class TabHealthMonitor extends EventEmitter {
       if (info.consecutiveFailures >= this.evictionThreshold) {
         info.status = 'unhealthy';
         console.error(`[TabHealthMonitor] Tab ${targetId} eviction threshold reached (${info.consecutiveFailures} failures)`);
-        this.emit('tab-evict', { targetId, failures: info.consecutiveFailures });
+        // Consumers MUST listen for 'tab-evict' and close the evicted page
+        // to prevent zombie renderer processes in Chrome.
+        this.emit('tab-evict', { targetId, consecutiveFailures: info.consecutiveFailures });
         this.unmonitorTab(targetId); // stop monitoring evicted tab
       } else if (info.consecutiveFailures >= this.unhealthyThreshold) {
         info.status = 'unhealthy';
@@ -154,7 +156,7 @@ export class TabHealthMonitor extends EventEmitter {
    * Stop monitoring all tabs.
    */
   stopAll(): void {
-    for (const [targetId] of this.timers) {
+    for (const targetId of [...this.timers.keys()]) {
       this.unmonitorTab(targetId);
     }
   }

--- a/tests/cdp/tab-health-monitor.test.ts
+++ b/tests/cdp/tab-health-monitor.test.ts
@@ -1,0 +1,192 @@
+/// <reference types="jest" />
+
+import { TabHealthMonitor } from '../../src/cdp/tab-health-monitor';
+import { Page } from 'puppeteer-core';
+
+function createMockPage(opts: {
+  evaluateResult?: unknown;
+  evaluateError?: Error;
+  evaluateDelay?: number;
+} = {}): jest.Mocked<Pick<Page, 'evaluate'>> {
+  const evaluate = jest.fn().mockImplementation(async () => {
+    if (opts.evaluateDelay) {
+      await new Promise(r => setTimeout(r, opts.evaluateDelay));
+    }
+    if (opts.evaluateError) throw opts.evaluateError;
+    return opts.evaluateResult ?? 1;
+  });
+  return { evaluate } as unknown as jest.Mocked<Pick<Page, 'evaluate'>>;
+}
+
+describe('TabHealthMonitor', () => {
+  let monitor: TabHealthMonitor;
+
+  afterEach(() => {
+    if (monitor) monitor.stopAll();
+  });
+
+  test('monitors and unmonitors tabs', () => {
+    monitor = new TabHealthMonitor({ probeIntervalMs: 100 });
+    const page = createMockPage();
+
+    monitor.monitorTab('tab1', page as unknown as Page);
+    expect(monitor.getMonitoredTabCount()).toBe(1);
+
+    monitor.unmonitorTab('tab1');
+    expect(monitor.getMonitoredTabCount()).toBe(0);
+  });
+
+  test('reports healthy tab after successful probe', async () => {
+    monitor = new TabHealthMonitor({ probeIntervalMs: 50, probeTimeoutMs: 1000 });
+    const page = createMockPage();
+    const healthyHandler = jest.fn();
+    monitor.on('tab-healthy', healthyHandler);
+
+    monitor.monitorTab('tab1', page as unknown as Page);
+
+    await new Promise(r => setTimeout(r, 120));
+
+    const health = monitor.getTabHealth('tab1');
+    expect(health?.status).toBe('healthy');
+    expect(health?.consecutiveFailures).toBe(0);
+
+    monitor.stopAll();
+  });
+
+  test('marks tab unhealthy after threshold failures', async () => {
+    monitor = new TabHealthMonitor({
+      probeIntervalMs: 30,
+      probeTimeoutMs: 10,
+      unhealthyThreshold: 2,
+      evictionThreshold: 5,
+    });
+    const page = createMockPage({ evaluateError: new Error('renderer crashed') });
+    const unhealthyHandler = jest.fn();
+    monitor.on('tab-unhealthy', unhealthyHandler);
+
+    monitor.monitorTab('tab1', page as unknown as Page);
+
+    // Wait for enough probes to exceed threshold
+    await new Promise(r => setTimeout(r, 150));
+
+    expect(unhealthyHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ targetId: 'tab1' })
+    );
+
+    monitor.stopAll();
+  });
+
+  test('emits tab-evict after eviction threshold', async () => {
+    monitor = new TabHealthMonitor({
+      probeIntervalMs: 20,
+      probeTimeoutMs: 10,
+      unhealthyThreshold: 1,
+      evictionThreshold: 2,
+    });
+    const page = createMockPage({ evaluateError: new Error('dead') });
+    const evictHandler = jest.fn();
+    monitor.on('tab-evict', evictHandler);
+
+    monitor.monitorTab('tab1', page as unknown as Page);
+
+    await new Promise(r => setTimeout(r, 150));
+
+    expect(evictHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ targetId: 'tab1' })
+    );
+    // Tab should be unmonitored after eviction
+    expect(monitor.getMonitoredTabCount()).toBe(0);
+
+    monitor.stopAll();
+  });
+
+  test('tab recovers after transient failure', async () => {
+    monitor = new TabHealthMonitor({
+      probeIntervalMs: 30,
+      probeTimeoutMs: 100,
+      unhealthyThreshold: 3,
+    });
+
+    let callCount = 0;
+    const page = {
+      evaluate: jest.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount <= 1) throw new Error('transient');
+        return 1;
+      }),
+    } as unknown as Page;
+
+    monitor.monitorTab('tab1', page);
+
+    await new Promise(r => setTimeout(r, 150));
+
+    const health = monitor.getTabHealth('tab1');
+    expect(health?.status).toBe('healthy');
+    expect(health?.consecutiveFailures).toBe(0);
+
+    monitor.stopAll();
+  });
+
+  test('getAllHealth returns copy of health map', () => {
+    monitor = new TabHealthMonitor({ probeIntervalMs: 1000 });
+    const page = createMockPage();
+
+    monitor.monitorTab('tab1', page as unknown as Page);
+    monitor.monitorTab('tab2', page as unknown as Page);
+
+    const allHealth = monitor.getAllHealth();
+    expect(allHealth.size).toBe(2);
+    expect(allHealth.get('tab1')?.status).toBe('healthy');
+    expect(allHealth.get('tab2')?.status).toBe('healthy');
+
+    monitor.stopAll();
+  });
+
+  test('stopAll clears all monitors', () => {
+    monitor = new TabHealthMonitor({ probeIntervalMs: 1000 });
+    const page = createMockPage();
+
+    monitor.monitorTab('tab1', page as unknown as Page);
+    monitor.monitorTab('tab2', page as unknown as Page);
+    monitor.monitorTab('tab3', page as unknown as Page);
+
+    expect(monitor.getMonitoredTabCount()).toBe(3);
+
+    monitor.stopAll();
+
+    expect(monitor.getMonitoredTabCount()).toBe(0);
+  });
+
+  test('monitorTab replaces existing monitor for same targetId', () => {
+    monitor = new TabHealthMonitor({ probeIntervalMs: 1000 });
+    const page1 = createMockPage();
+    const page2 = createMockPage();
+
+    monitor.monitorTab('tab1', page1 as unknown as Page);
+    monitor.monitorTab('tab1', page2 as unknown as Page);
+
+    expect(monitor.getMonitoredTabCount()).toBe(1);
+
+    monitor.stopAll();
+  });
+
+  test('probe timeout detects hanging renderer', async () => {
+    monitor = new TabHealthMonitor({
+      probeIntervalMs: 30,
+      probeTimeoutMs: 20, // very short timeout
+      unhealthyThreshold: 2,
+    });
+    // Page that takes too long to respond
+    const page = createMockPage({ evaluateDelay: 500 });
+    const unhealthyHandler = jest.fn();
+    monitor.on('tab-unhealthy', unhealthyHandler);
+
+    monitor.monitorTab('tab1', page as unknown as Page);
+
+    await new Promise(r => setTimeout(r, 200));
+
+    expect(unhealthyHandler).toHaveBeenCalled();
+
+    monitor.stopAll();
+  });
+});


### PR DESCRIPTION
## Summary

- New `TabHealthMonitor` class probes individual tab renderers via `page.evaluate('1')`
- Three-state health tracking: healthy → unhealthy → evicted
- Configurable thresholds: `unhealthyThreshold` (3 failures), `evictionThreshold` (5 failures)
- Events: `tab-healthy`, `tab-unhealthy`, `tab-evict` for integration with session manager
- Transient failure tolerance — single probe failures don't trigger alerts

## Motivation

Part of #347 Phase 2C (Layer 1). The global heartbeat (`Browser.getVersion()`) only checks the browser process. If a single tab's renderer freezes/crashes, the heartbeat still passes. This monitor detects per-tab failures independently.

## Changes

| File | Change |
|------|--------|
| `src/cdp/tab-health-monitor.ts` | New monitor class (EventEmitter) |
| `tests/cdp/tab-health-monitor.test.ts` | 9 tests |

## Test plan

- [x] `npx jest tests/cdp/tab-health-monitor.test.ts` — 9/9 pass
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)