### PR TITLE
feat: event loop monitor and health endpoint (#347)

### DIFF
--- a/src/watchdog/event-loop-monitor.ts
+++ b/src/watchdog/event-loop-monitor.ts
@@ -11,7 +11,12 @@ export interface EventLoopMonitorOptions {
   checkIntervalMs?: number;
   /** Warn threshold in ms. Default: 2000 (2s) */
   warnThresholdMs?: number;
-  /** Fatal threshold in ms — triggers process exit. Default: 0 (disabled) */
+  /**
+   * Fatal threshold in ms. Default: 0 (disabled).
+   * Emits 'fatal' event when threshold exceeded.
+   * Callers MUST attach a 'fatal' listener to handle recovery (e.g., process.exit(1)).
+   * No automatic process termination — this is intentional for testability.
+   */
   fatalThresholdMs?: number;
 }
 
@@ -54,9 +59,9 @@ export class EventLoopMonitor extends EventEmitter {
 
       if (this.fatalThresholdMs > 0 && drift > this.fatalThresholdMs) {
         console.error(`[EventLoopMonitor] FATAL: Event loop blocked for ${drift}ms (threshold: ${this.fatalThresholdMs}ms)`);
+        // Emits 'fatal' event — callers MUST attach a listener to handle recovery (e.g., process.exit(1)).
+        // No automatic termination: intentional for testability and caller control.
         this.emit('fatal', { driftMs: drift, timestamp: now } as BlockEvent);
-        // In production, this would trigger process.exit(1) for PM2/systemd restart
-        // We emit an event instead of exiting directly, for testability
       } else if (drift > this.warnThresholdMs) {
         this.warnCount++;
         console.error(`[EventLoopMonitor] WARN: Event loop blocked for ${drift}ms (warn #${this.warnCount})`);

--- a/src/watchdog/event-loop-monitor.ts
+++ b/src/watchdog/event-loop-monitor.ts
@@ -1,0 +1,108 @@
+/**
+ * Event Loop Monitor — detects Node.js event loop blocking.
+ * Uses timer drift detection (lightweight, ~0.5% CPU overhead).
+ * Part of #347 Layer 4: Application Watchdog.
+ */
+
+import { EventEmitter } from 'events';
+
+export interface EventLoopMonitorOptions {
+  /** Check interval in ms. Default: 200 */
+  checkIntervalMs?: number;
+  /** Warn threshold in ms. Default: 2000 (2s) */
+  warnThresholdMs?: number;
+  /** Fatal threshold in ms — triggers process exit. Default: 0 (disabled) */
+  fatalThresholdMs?: number;
+}
+
+export interface BlockEvent {
+  driftMs: number;
+  timestamp: number;
+}
+
+export class EventLoopMonitor extends EventEmitter {
+  private timer: NodeJS.Timeout | null = null;
+  private readonly checkIntervalMs: number;
+  private readonly warnThresholdMs: number;
+  private readonly fatalThresholdMs: number;
+  private lastCheckAt = 0;
+  private maxDriftObserved = 0;
+  private warnCount = 0;
+
+  constructor(opts?: EventLoopMonitorOptions) {
+    super();
+    this.checkIntervalMs = opts?.checkIntervalMs ?? 200;
+    this.warnThresholdMs = opts?.warnThresholdMs ?? 2000;
+    this.fatalThresholdMs = opts?.fatalThresholdMs ?? 0; // disabled by default
+  }
+
+  /**
+   * Start monitoring the event loop.
+   */
+  start(): void {
+    this.stop();
+    this.lastCheckAt = Date.now();
+
+    this.timer = setInterval(() => {
+      const now = Date.now();
+      const drift = now - this.lastCheckAt - this.checkIntervalMs;
+      this.lastCheckAt = now;
+
+      if (drift > this.maxDriftObserved) {
+        this.maxDriftObserved = drift;
+      }
+
+      if (this.fatalThresholdMs > 0 && drift > this.fatalThresholdMs) {
+        console.error(`[EventLoopMonitor] FATAL: Event loop blocked for ${drift}ms (threshold: ${this.fatalThresholdMs}ms)`);
+        this.emit('fatal', { driftMs: drift, timestamp: now } as BlockEvent);
+        // In production, this would trigger process.exit(1) for PM2/systemd restart
+        // We emit an event instead of exiting directly, for testability
+      } else if (drift > this.warnThresholdMs) {
+        this.warnCount++;
+        console.error(`[EventLoopMonitor] WARN: Event loop blocked for ${drift}ms (warn #${this.warnCount})`);
+        this.emit('warn', { driftMs: drift, timestamp: now } as BlockEvent);
+      }
+    }, this.checkIntervalMs);
+    this.timer.unref();
+  }
+
+  /**
+   * Stop monitoring.
+   */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * Whether monitoring is active.
+   */
+  isRunning(): boolean {
+    return this.timer !== null;
+  }
+
+  /**
+   * Get monitoring statistics.
+   */
+  getStats(): {
+    maxDriftMs: number;
+    warnCount: number;
+    isRunning: boolean;
+  } {
+    return {
+      maxDriftMs: this.maxDriftObserved,
+      warnCount: this.warnCount,
+      isRunning: this.isRunning(),
+    };
+  }
+
+  /**
+   * Reset statistics.
+   */
+  resetStats(): void {
+    this.maxDriftObserved = 0;
+    this.warnCount = 0;
+  }
+}

--- a/src/watchdog/health-endpoint.ts
+++ b/src/watchdog/health-endpoint.ts
@@ -1,0 +1,102 @@
+/**
+ * Health Endpoint — optional HTTP health check server.
+ * Runs on a separate port from the MCP server for external monitoring.
+ * Part of #347 Layer 4: Application Watchdog.
+ */
+
+import * as http from 'http';
+
+export interface HealthData {
+  status: 'ok' | 'degraded' | 'error';
+  uptime: number;
+  memory: NodeJS.MemoryUsage;
+  eventLoop: {
+    maxDriftMs: number;
+    warnCount: number;
+  };
+  chrome?: {
+    connected: boolean;
+    reconnectCount: number;
+  };
+  tabs?: {
+    total: number;
+    healthy: number;
+    unhealthy: number;
+  };
+}
+
+export type HealthDataProvider = () => HealthData;
+
+export class HealthEndpoint {
+  private server: http.Server | null = null;
+  private readonly port: number;
+  private readonly provider: HealthDataProvider;
+
+  constructor(provider: HealthDataProvider, port = 9229) {
+    this.port = port;
+    this.provider = provider;
+  }
+
+  /**
+   * Start the health HTTP server.
+   * Binds to 127.0.0.1 only (not exposed externally).
+   */
+  start(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.server = http.createServer((req, res) => {
+        if (req.url === '/health' && req.method === 'GET') {
+          try {
+            const data = this.provider();
+            const statusCode = data.status === 'ok' ? 200 : data.status === 'degraded' ? 200 : 503;
+            res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify(data));
+          } catch (error) {
+            res.writeHead(500, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ status: 'error', error: String(error) }));
+          }
+        } else {
+          res.writeHead(404);
+          res.end('Not Found');
+        }
+      });
+
+      this.server.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EADDRINUSE') {
+          console.error(`[HealthEndpoint] Port ${this.port} already in use, health endpoint disabled`);
+          this.server = null;
+          resolve(); // Don't fail — health endpoint is optional
+        } else {
+          reject(err);
+        }
+      });
+
+      this.server.listen(this.port, '127.0.0.1', () => {
+        console.error(`[HealthEndpoint] Health check available at http://127.0.0.1:${this.port}/health`);
+        resolve();
+      });
+
+      // Don't prevent process exit
+      this.server.unref();
+    });
+  }
+
+  /**
+   * Stop the health server.
+   */
+  stop(): Promise<void> {
+    return new Promise((resolve) => {
+      if (this.server) {
+        this.server.close(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  /**
+   * Whether the server is running.
+   */
+  isRunning(): boolean {
+    return this.server !== null && this.server.listening;
+  }
+}

--- a/src/watchdog/health-endpoint.ts
+++ b/src/watchdog/health-endpoint.ts
@@ -32,7 +32,8 @@ export class HealthEndpoint {
   private readonly port: number;
   private readonly provider: HealthDataProvider;
 
-  constructor(provider: HealthDataProvider, port = 9229) {
+  // 9090 avoids conflict with Node.js inspector (9229), Chrome DevTools (9222)
+  constructor(provider: HealthDataProvider, port = 9090) {
     this.port = port;
     this.provider = provider;
   }
@@ -51,8 +52,9 @@ export class HealthEndpoint {
             res.writeHead(statusCode, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify(data));
           } catch (error) {
-            res.writeHead(500, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ status: 'error', error: String(error) }));
+            console.error('[HealthEndpoint] Provider error:', error);
+            res.writeHead(503, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ status: 'error', error: 'Internal health check failure' }));
           }
         } else {
           res.writeHead(404);
@@ -86,7 +88,10 @@ export class HealthEndpoint {
   stop(): Promise<void> {
     return new Promise((resolve) => {
       if (this.server) {
-        this.server.close(() => resolve());
+        this.server.close(() => {
+          this.server = null;
+          resolve();
+        });
       } else {
         resolve();
       }

--- a/tests/watchdog/event-loop-monitor.test.ts
+++ b/tests/watchdog/event-loop-monitor.test.ts
@@ -1,0 +1,208 @@
+/// <reference types="jest" />
+
+import { EventLoopMonitor } from '../../src/watchdog/event-loop-monitor';
+import { HealthEndpoint, HealthData } from '../../src/watchdog/health-endpoint';
+
+describe('EventLoopMonitor', () => {
+  let monitor: EventLoopMonitor;
+
+  afterEach(() => {
+    if (monitor) monitor.stop();
+  });
+
+  test('starts and stops without errors', () => {
+    monitor = new EventLoopMonitor({ checkIntervalMs: 50 });
+
+    monitor.start();
+    expect(monitor.isRunning()).toBe(true);
+
+    monitor.stop();
+    expect(monitor.isRunning()).toBe(false);
+  });
+
+  test('does not emit warn for normal operation', async () => {
+    monitor = new EventLoopMonitor({
+      checkIntervalMs: 50,
+      warnThresholdMs: 5000,
+    });
+    const warnHandler = jest.fn();
+    monitor.on('warn', warnHandler);
+
+    monitor.start();
+    await new Promise(r => setTimeout(r, 200));
+    monitor.stop();
+
+    expect(warnHandler).not.toHaveBeenCalled();
+  });
+
+  test('reports stats correctly', () => {
+    monitor = new EventLoopMonitor({ checkIntervalMs: 50 });
+
+    const stats = monitor.getStats();
+    expect(stats.maxDriftMs).toBe(0);
+    expect(stats.warnCount).toBe(0);
+    expect(stats.isRunning).toBe(false);
+  });
+
+  test('resetStats clears counters', async () => {
+    monitor = new EventLoopMonitor({ checkIntervalMs: 50 });
+
+    monitor.start();
+    await new Promise(r => setTimeout(r, 150));
+    monitor.stop();
+
+    // maxDrift should be > 0 after running
+    const statsBefore = monitor.getStats();
+    expect(statsBefore.maxDriftMs).toBeGreaterThanOrEqual(0);
+
+    monitor.resetStats();
+    const statsAfter = monitor.getStats();
+    expect(statsAfter.maxDriftMs).toBe(0);
+    expect(statsAfter.warnCount).toBe(0);
+  });
+
+  test('start() is idempotent — clears previous timer', () => {
+    monitor = new EventLoopMonitor({ checkIntervalMs: 50 });
+
+    monitor.start();
+    monitor.start(); // should not create duplicate timers
+
+    expect(monitor.isRunning()).toBe(true);
+    monitor.stop();
+    expect(monitor.isRunning()).toBe(false);
+  });
+
+  test('emits warn event when event loop is blocked', async () => {
+    monitor = new EventLoopMonitor({
+      checkIntervalMs: 20,
+      warnThresholdMs: 50, // low threshold for testing
+    });
+    const warnHandler = jest.fn();
+    monitor.on('warn', warnHandler);
+
+    monitor.start();
+
+    // Block the event loop for ~80ms
+    const start = Date.now();
+    while (Date.now() - start < 80) {
+      // busy wait
+    }
+
+    // Wait for the next check to fire
+    await new Promise(r => setTimeout(r, 50));
+    monitor.stop();
+
+    expect(warnHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        driftMs: expect.any(Number),
+        timestamp: expect.any(Number),
+      })
+    );
+  });
+
+  test('emits fatal event when threshold exceeded', async () => {
+    monitor = new EventLoopMonitor({
+      checkIntervalMs: 20,
+      warnThresholdMs: 30,
+      fatalThresholdMs: 60,
+    });
+    const fatalHandler = jest.fn();
+    monitor.on('fatal', fatalHandler);
+
+    monitor.start();
+
+    // Block for ~100ms to exceed fatal threshold
+    const start = Date.now();
+    while (Date.now() - start < 100) {
+      // busy wait
+    }
+
+    await new Promise(r => setTimeout(r, 50));
+    monitor.stop();
+
+    expect(fatalHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        driftMs: expect.any(Number),
+      })
+    );
+  });
+});
+
+describe('HealthEndpoint', () => {
+  let endpoint: HealthEndpoint;
+
+  afterEach(async () => {
+    if (endpoint) await endpoint.stop();
+  });
+
+  test('starts and responds to /health', async () => {
+    const provider = () => ({
+      status: 'ok' as const,
+      uptime: 100,
+      memory: process.memoryUsage(),
+      eventLoop: { maxDriftMs: 5, warnCount: 0 },
+    });
+
+    // Use a random high port to avoid conflicts
+    const port = 19200 + Math.floor(Math.random() * 800);
+    endpoint = new HealthEndpoint(provider, port);
+    await endpoint.start();
+
+    expect(endpoint.isRunning()).toBe(true);
+
+    // Make HTTP request
+    const response = await new Promise<{ statusCode: number; body: string }>((resolve) => {
+      const http = require('http');
+      http.get(`http://127.0.0.1:${port}/health`, (res: any) => {
+        let body = '';
+        res.on('data', (chunk: string) => { body += chunk; });
+        res.on('end', () => resolve({ statusCode: res.statusCode, body }));
+      });
+    });
+
+    expect(response.statusCode).toBe(200);
+    const data = JSON.parse(response.body);
+    expect(data.status).toBe('ok');
+    expect(data.uptime).toBe(100);
+  });
+
+  test('returns 404 for unknown paths', async () => {
+    const provider = () => ({ status: 'ok' as const, uptime: 0, memory: process.memoryUsage(), eventLoop: { maxDriftMs: 0, warnCount: 0 } });
+    const port = 19200 + Math.floor(Math.random() * 800);
+    endpoint = new HealthEndpoint(provider, port);
+    await endpoint.start();
+
+    const response = await new Promise<{ statusCode: number }>((resolve) => {
+      const http = require('http');
+      http.get(`http://127.0.0.1:${port}/unknown`, (res: any) => {
+        res.on('data', () => {});
+        res.on('end', () => resolve({ statusCode: res.statusCode }));
+      });
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  test('handles port in use gracefully', async () => {
+    const provider = () => ({ status: 'ok' as const, uptime: 0, memory: process.memoryUsage(), eventLoop: { maxDriftMs: 0, warnCount: 0 } });
+    const port = 19200 + Math.floor(Math.random() * 800);
+
+    // Occupy the port
+    const http = require('http');
+    const blocker = http.createServer();
+    await new Promise<void>(resolve => blocker.listen(port, '127.0.0.1', resolve));
+
+    // Should not throw — just logs and resolves
+    endpoint = new HealthEndpoint(provider, port);
+    await expect(endpoint.start()).resolves.not.toThrow();
+    expect(endpoint.isRunning()).toBe(false);
+
+    blocker.close();
+  });
+
+  test('stop resolves when server is not running', async () => {
+    const provider = () => ({ status: 'ok' as const, uptime: 0, memory: process.memoryUsage(), eventLoop: { maxDriftMs: 0, warnCount: 0 } });
+    endpoint = new HealthEndpoint(provider);
+    await expect(endpoint.stop()).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- New `EventLoopMonitor` detects Node.js event loop blocking via timer drift detection (~0.5% CPU overhead)
- Configurable warn (2s default) and fatal (disabled by default) thresholds
- Emits `warn`/`fatal` events for integration with process supervisors (PM2/systemd)
- New `HealthEndpoint` provides HTTP health check on `http://127.0.0.1:9229/health`
- Health endpoint binds to localhost only — not externally exposed
- Gracefully handles port-in-use (logs warning, continues without health endpoint)

## Motivation

Part of #347 Phase 3A (Layer 4). In long-running sessions, a blocking operation in the Node.js event loop can cause the entire MCP server to hang. This monitor detects blocks and can trigger process restart via the supervisor layer.

## Changes

| File | Change |
|------|--------|
| `src/watchdog/event-loop-monitor.ts` | New EventLoopMonitor class |
| `src/watchdog/health-endpoint.ts` | New HealthEndpoint HTTP server |
| `tests/watchdog/event-loop-monitor.test.ts` | 11 tests |

## Test plan

- [x] `npx jest tests/watchdog/event-loop-monitor.test.ts` — 11/11 pass
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)