### PR TITLE
feat: AI agent continuity tools and task journal

### DIFF
--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -33,6 +33,9 @@ export const TOOL_TIERS: Record<string, ToolTier> = {
   lightweight_scroll: 1,
   oc_stop: 1,
   oc_profile_status: 1,
+  oc_session_snapshot: 1,
+  oc_session_resume: 1,
+  oc_journal: 1,
 
   // Tier 2: Specialist (on demand)
   click_element: 2,

--- a/src/journal/task-journal.ts
+++ b/src/journal/task-journal.ts
@@ -1,0 +1,245 @@
+/**
+ * Task Journal — automatic MCP tool call tracking for context recovery.
+ * Records every tool call to daily JSONL files.
+ * Part of #356: AI Agent Continuity.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+export interface JournalEntry {
+  ts: number;                    // Unix ms timestamp
+  tool: string;                  // Tool name (e.g., "navigate", "read_page")
+  sessionId: string;             // MCP session identifier
+  tabId?: string;                // Target tab if applicable
+  args: Record<string, unknown>; // Sanitized tool arguments
+  durationMs: number;            // Execution time
+  ok: boolean;                   // Success/failure
+  summary: string;               // Human-readable 1-line summary
+  milestone?: boolean;           // True for significant actions
+}
+
+/** Tools whose entire args are redacted */
+const REDACT_TOOLS = new Set(['http_auth', 'cookies']);
+
+/** Arg keys that are always redacted */
+const REDACT_KEYS = /password|token|secret|credential|api[_-]?key/i;
+
+/** Tools marked as milestones for priority in resume summaries */
+const MILESTONE_TOOLS = new Set([
+  'navigate', 'fill_form', 'workflow_init', 'execute_plan',
+  'oc_session_snapshot', 'oc_stop', 'tabs_create', 'tabs_close',
+]);
+
+export class TaskJournal {
+  private readonly dir: string;
+  private readonly maxAgeDays: number;
+
+  constructor(opts?: { dir?: string; maxAgeDays?: number }) {
+    this.dir = opts?.dir || path.join(os.homedir(), '.openchrome', 'journal');
+    this.maxAgeDays = opts?.maxAgeDays ?? 7;
+  }
+
+  /**
+   * Initialize journal directory and prune old files.
+   */
+  async init(): Promise<void> {
+    await fs.promises.mkdir(this.dir, { recursive: true });
+    await this.pruneOldFiles();
+  }
+
+  /**
+   * Record a tool call. Called from mcp-server.ts after each tool execution.
+   * Uses appendFileSync for crash safety (each line is self-contained).
+   */
+  record(entry: JournalEntry): void {
+    try {
+      const filename = `journal-${this.dateString()}.jsonl`;
+      const filepath = path.join(this.dir, filename);
+      fs.appendFileSync(filepath, JSON.stringify(entry) + '\n');
+    } catch (err) {
+      // Best-effort — don't crash the server if journal write fails
+      console.error('[TaskJournal] Write failed:', err instanceof Error ? err.message : err);
+    }
+  }
+
+  /**
+   * Create a JournalEntry from a tool call.
+   */
+  createEntry(
+    tool: string,
+    sessionId: string,
+    args: Record<string, unknown>,
+    durationMs: number,
+    ok: boolean,
+  ): JournalEntry {
+    return {
+      ts: Date.now(),
+      tool,
+      sessionId,
+      tabId: (args.tabId as string) || undefined,
+      args: this.sanitizeArgs(tool, args),
+      durationMs,
+      ok,
+      summary: this.generateSummary(tool, args, ok),
+      milestone: MILESTONE_TOOLS.has(tool) || undefined,
+    };
+  }
+
+  /**
+   * Read recent entries from today and optionally yesterday.
+   */
+  getRecent(count: number = 20): JournalEntry[] {
+    const entries: JournalEntry[] = [];
+    const today = this.dateString();
+    const yesterday = this.dateString(new Date(Date.now() - 86400000));
+
+    for (const dateStr of [yesterday, today]) {
+      const filepath = path.join(this.dir, `journal-${dateStr}.jsonl`);
+      try {
+        const content = fs.readFileSync(filepath, 'utf-8');
+        for (const line of content.split('\n')) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          try {
+            entries.push(JSON.parse(trimmed) as JournalEntry);
+          } catch {
+            // Skip malformed lines
+          }
+        }
+      } catch {
+        // File doesn't exist — skip
+      }
+    }
+
+    return entries.slice(-count);
+  }
+
+  /**
+   * Get milestone entries for resume summaries.
+   */
+  getMilestones(opts?: { since?: number; limit?: number }): JournalEntry[] {
+    const entries = this.getRecent(500);
+    let milestones = entries.filter(e => e.milestone);
+    if (opts?.since) {
+      milestones = milestones.filter(e => e.ts > opts.since!);
+    }
+    return milestones.slice(-(opts?.limit ?? 20));
+  }
+
+  /**
+   * Get summary statistics.
+   */
+  getSummary(opts?: { since?: number }): {
+    total: number;
+    succeeded: number;
+    failed: number;
+    toolCounts: Record<string, number>;
+    milestones: JournalEntry[];
+    period: { start: number; end: number };
+  } {
+    let entries = this.getRecent(1000);
+    if (opts?.since) {
+      entries = entries.filter(e => e.ts > opts.since!);
+    }
+
+    const toolCounts: Record<string, number> = {};
+    let succeeded = 0;
+    let failed = 0;
+
+    for (const e of entries) {
+      toolCounts[e.tool] = (toolCounts[e.tool] || 0) + 1;
+      if (e.ok) succeeded++; else failed++;
+    }
+
+    return {
+      total: entries.length,
+      succeeded,
+      failed,
+      toolCounts,
+      milestones: entries.filter(e => e.milestone),
+      period: {
+        start: entries[0]?.ts || Date.now(),
+        end: entries[entries.length - 1]?.ts || Date.now(),
+      },
+    };
+  }
+
+  /**
+   * Sanitize tool arguments — redact sensitive fields.
+   */
+  sanitizeArgs(tool: string, args: Record<string, unknown>): Record<string, unknown> {
+    if (REDACT_TOOLS.has(tool)) return { _redacted: true };
+    const sanitized: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(args)) {
+      if (REDACT_KEYS.test(k)) {
+        sanitized[k] = '[REDACTED]';
+      } else {
+        sanitized[k] = v;
+      }
+    }
+    return sanitized;
+  }
+
+  /**
+   * Generate human-readable 1-line summary.
+   */
+  generateSummary(tool: string, args: Record<string, unknown>, ok: boolean): string {
+    const s = ok ? '✓' : '✗';
+    switch (tool) {
+      case 'navigate': return `${s} → ${args.url || 'unknown'}`;
+      case 'read_page': return `${s} Read page`;
+      case 'interact': return `${s} Click "${args.description || args.selector || ''}"`;
+      case 'fill_form': {
+        const fields = args.fields as Record<string, unknown> | undefined;
+        return `${s} Fill form (${fields ? Object.keys(fields).length : 0} fields)`;
+      }
+      case 'find': return `${s} Find "${args.description || args.selector || ''}"`;
+      case 'javascript_tool': return `${s} JS eval`;
+      case 'tabs_create': return `${s} New tab${args.url ? ` → ${args.url}` : ''}`;
+      case 'tabs_close': return `${s} Close tab`;
+      case 'oc_stop': return `${s} Stop OpenChrome`;
+      case 'oc_session_snapshot': return `${s} Snapshot saved`;
+      case 'workflow_init': return `${s} Workflow started`;
+      default: return `${s} ${tool}`;
+    }
+  }
+
+  /**
+   * Delete journal files older than maxAgeDays.
+   */
+  private async pruneOldFiles(): Promise<void> {
+    try {
+      const files = await fs.promises.readdir(this.dir);
+      const cutoff = Date.now() - (this.maxAgeDays * 86400000);
+
+      for (const file of files) {
+        if (!file.startsWith('journal-') || !file.endsWith('.jsonl')) continue;
+        const dateStr = file.slice(8, 18); // journal-YYYY-MM-DD.jsonl
+        const fileDate = new Date(dateStr).getTime();
+        if (fileDate && fileDate < cutoff) {
+          await fs.promises.unlink(path.join(this.dir, file));
+          console.error(`[TaskJournal] Pruned old journal: ${file}`);
+        }
+      }
+    } catch {
+      // Best-effort pruning
+    }
+  }
+
+  private dateString(date?: Date): string {
+    const d = date || new Date();
+    return d.toISOString().slice(0, 10); // YYYY-MM-DD
+  }
+}
+
+/** Singleton */
+let instance: TaskJournal | null = null;
+
+export function getTaskJournal(): TaskJournal {
+  if (!instance) {
+    instance = new TaskJournal();
+  }
+  return instance;
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -31,6 +31,7 @@ import { getToolTier, ToolTier } from './config/tool-tiers';
 import { logAuditEntry } from './security/audit-logger';
 import { getVersion } from './version';
 import { isTimeoutError } from './errors/timeout';
+import { getTaskJournal } from './journal/task-journal';
 
 /**
  * Detect if an error is a Chrome/CDP connection error that may be recoverable
@@ -62,7 +63,7 @@ export function isConnectionError(error: unknown): boolean {
 
 /** Lifecycle tools that must work even when the CDP connection is broken (e.g., after
  *  sleep/wake). Skip session initialization so oc_stop can always reach its handler. */
-const SKIP_SESSION_INIT_TOOLS = new Set(['oc_stop', 'oc_profile_status']);
+const SKIP_SESSION_INIT_TOOLS = new Set(['oc_stop', 'oc_profile_status', 'oc_session_snapshot', 'oc_session_resume', 'oc_journal']);
 
 const RECONNECTION_GUIDANCE =
   '\n\nNote: The browser connection was lost and auto-reconnect was attempted. ' +
@@ -119,6 +120,11 @@ export class MCPServer {
     this.hintEngine = new HintEngine(this.activityTracker);
     this.hintEngine.enableLogging(hintsDir);
     this.hintEngine.enableLearning(hintsDir);
+
+    // Initialize task journal
+    getTaskJournal().init().catch((err: unknown) => {
+      console.error('[MCPServer] Task journal init failed:', err);
+    });
   }
 
   /**
@@ -530,6 +536,7 @@ export class MCPServer {
 
     // Start activity tracking
     const callId = this.activityTracker!.startCall(toolName, sessionId || 'default', toolArgs, requestId);
+    const toolStartTime = Date.now();
 
     // Adaptive heartbeat: switch to active mode during tool execution
     try {
@@ -631,6 +638,15 @@ export class MCPServer {
       // End activity tracking (success)
       this.activityTracker!.endCall(callId, 'success');
 
+      // Record to task journal
+      try {
+        const journal = getTaskJournal();
+        const entry = journal.createEntry(toolName, sessionId, toolArgs, Date.now() - toolStartTime, true);
+        journal.record(entry);
+      } catch {
+        // Best-effort journal recording
+      }
+
       // Schedule heartbeat idle mode transition
       if (this.heartbeatIdleTimer) {
         clearTimeout(this.heartbeatIdleTimer);
@@ -723,6 +739,15 @@ export class MCPServer {
 
       // End activity tracking (error)
       this.activityTracker!.endCall(callId, 'error', message);
+
+      // Record to task journal
+      try {
+        const journal = getTaskJournal();
+        const entry = journal.createEntry(toolName, sessionId, toolArgs, Date.now() - toolStartTime, false);
+        journal.record(entry);
+      } catch {
+        // Best-effort journal recording
+      }
 
       // Schedule heartbeat idle mode transition
       if (this.heartbeatIdleTimer) {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -60,6 +60,11 @@ import { registerShutdownTool } from './shutdown';
 import { registerProfileStatusTool } from './profile-status';
 import { registerListProfilesTool } from './list-profiles';
 
+// AI Agent Continuity tools (#355, #356)
+import { registerSessionSnapshotTool } from './session-snapshot';
+import { registerSessionResumeTool } from './session-resume';
+import { registerJournalTool } from './journal';
+
 export function registerAllTools(server: MCPServer): void {
   // Core browser tools
   registerNavigateTool(server);
@@ -122,6 +127,11 @@ export function registerAllTools(server: MCPServer): void {
   registerShutdownTool(server);
   registerProfileStatusTool(server);
   registerListProfilesTool(server);
+
+  // AI Agent Continuity tools (#355, #356)
+  registerSessionSnapshotTool(server);
+  registerSessionResumeTool(server);
+  registerJournalTool(server);
 
   console.error(`[Tools] Registered ${server.getToolNames().length} tools`);
 }

--- a/src/tools/journal.ts
+++ b/src/tools/journal.ts
@@ -1,0 +1,132 @@
+/**
+ * Journal Query Tool — query recorded MCP tool call history.
+ * Part of #356: Task Journal.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import { getTaskJournal } from '../journal/task-journal';
+
+const definition: MCPToolDefinition = {
+  name: 'oc_journal',
+  description:
+    'Query the tool call journal. Actions: ' +
+    '"summary" (milestone-based overview for context restoration), ' +
+    '"recent" (last N entries with full detail).',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      action: {
+        type: 'string',
+        enum: ['summary', 'recent'],
+        description: 'Query type',
+      },
+      count: {
+        type: 'number',
+        description: '(recent) Number of entries to return. Default: 20, max: 100',
+      },
+      tool: {
+        type: 'string',
+        description: 'Filter by tool name',
+      },
+      since: {
+        type: 'string',
+        description: 'ISO timestamp or relative ("1h", "30m")',
+      },
+    },
+    required: ['action'],
+  },
+};
+
+export function parseSince(since?: string): number | undefined {
+  if (!since) return undefined;
+
+  // Relative time
+  const relMatch = since.match(/^(\d+)(m|h|d)$/);
+  if (relMatch) {
+    const value = parseInt(relMatch[1], 10);
+    const unit = relMatch[2];
+    const multipliers: Record<string, number> = { m: 60000, h: 3600000, d: 86400000 };
+    return Date.now() - (value * (multipliers[unit] || 60000));
+  }
+
+  // ISO timestamp
+  const ts = new Date(since).getTime();
+  return isNaN(ts) ? undefined : ts;
+}
+
+const handler: ToolHandler = async (
+  _sessionId: string,
+  args: Record<string, unknown>,
+): Promise<MCPResult> => {
+  const action = args.action as string;
+  const journal = getTaskJournal();
+  const since = parseSince(args.since as string | undefined);
+
+  if (action === 'summary') {
+    const summary = journal.getSummary({ since });
+
+    const lines: string[] = [];
+    const periodStart = new Date(summary.period.start).toLocaleTimeString();
+    const periodEnd = new Date(summary.period.end).toLocaleTimeString();
+    const durationMin = Math.round((summary.period.end - summary.period.start) / 60000);
+
+    lines.push(`\u2550\u2550\u2550 SESSION JOURNAL SUMMARY \u2550\u2550\u2550`);
+    lines.push(`Period: ${periodStart} \u2192 ${periodEnd} (${durationMin}m)`);
+    lines.push(`Total calls: ${summary.total} (${summary.succeeded} success, ${summary.failed} failed)`);
+
+    if (summary.milestones.length > 0) {
+      lines.push('');
+      lines.push('Milestones:');
+      for (const m of summary.milestones) {
+        const time = new Date(m.ts).toLocaleTimeString();
+        lines.push(`  ${time} ${m.summary}`);
+      }
+    }
+
+    if (Object.keys(summary.toolCounts).length > 0) {
+      lines.push('');
+      const sorted = Object.entries(summary.toolCounts).sort((a, b) => b[1] - a[1]);
+      lines.push(`Tools: ${sorted.map(([t, c]) => `${t}(${c})`).join(', ')}`);
+    }
+
+    if (summary.total > 0) {
+      const failRate = ((summary.failed / summary.total) * 100).toFixed(1);
+      lines.push(`Failure rate: ${failRate}%`);
+    }
+
+    return { content: [{ type: 'text', text: lines.join('\n') }] };
+  }
+
+  if (action === 'recent') {
+    const count = Math.min(Math.max((args.count as number) || 20, 1), 100);
+    let entries = journal.getRecent(count);
+
+    // Apply filters
+    if (args.tool) {
+      entries = entries.filter(e => e.tool === args.tool);
+    }
+    if (since) {
+      entries = entries.filter(e => e.ts >= since);
+    }
+
+    if (entries.length === 0) {
+      return { content: [{ type: 'text', text: 'No journal entries found.' }] };
+    }
+
+    const lines = entries.map(e => {
+      const time = new Date(e.ts).toLocaleTimeString();
+      const dur = `${e.durationMs}ms`;
+      const milestone = e.milestone ? ' \u2605' : '';
+      return `${time} [${dur}] ${e.summary}${milestone}`;
+    });
+
+    return { content: [{ type: 'text', text: lines.join('\n') }] };
+  }
+
+  return { content: [{ type: 'text', text: `Unknown action: ${action}. Use "summary" or "recent".` }] };
+};
+
+export function registerJournalTool(server: MCPServer): void {
+  server.registerTool(definition.name, handler, definition);
+}

--- a/src/tools/session-resume.ts
+++ b/src/tools/session-resume.ts
@@ -1,0 +1,279 @@
+/**
+ * Session Resume Tool — restores browser context after compaction.
+ * Reads a snapshot, cross-references with live state, generates resume guide.
+ * Part of #355: AI Agent Continuity.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import { getSessionManager } from '../session-manager';
+
+// ─── Shared Types (same as session-snapshot.ts) ────────────────────────────
+
+interface SnapshotTab {
+  targetId: string;
+  workerId: string;
+  sessionId: string;
+  url: string;
+  title: string;
+}
+
+interface SnapshotMemo {
+  objective: string;
+  currentStep: string;
+  nextActions: string[];
+  completedSteps?: string[];
+  notes?: string;
+}
+
+interface SessionSnapshot {
+  version: 1;
+  id: string;
+  timestamp: number;
+  tabs: SnapshotTab[];
+  memo: SnapshotMemo;
+  label?: string;
+}
+
+// ─── Tab Status Analysis ───────────────────────────────────────────────────
+
+type TabStatus = 'LIVE' | 'REMAPPED' | 'CLOSED';
+
+interface TabAnalysis {
+  saved: SnapshotTab;
+  status: TabStatus;
+  currentTargetId?: string;  // For REMAPPED tabs
+  currentUrl?: string;       // Current URL if different
+}
+
+// ─── Tool Definition ───────────────────────────────────────────────────────
+
+const definition: MCPToolDefinition = {
+  name: 'oc_session_resume',
+  description:
+    'Restore working context after context compaction. ' +
+    'Reads the last oc_session_snapshot, checks which tabs are still alive, ' +
+    'and returns a resume guide with your objective, progress, and tab status. ' +
+    'Call this after compaction to continue where you left off.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      snapshotId: {
+        type: 'string',
+        description: 'Specific snapshot ID to restore (default: latest)',
+      },
+    },
+    required: [],
+  },
+};
+
+// ─── Snapshot Loading ──────────────────────────────────────────────────────
+
+export const SNAPSHOT_DIR = path.join(os.homedir(), '.openchrome', 'snapshots');
+
+export function loadSnapshot(snapshotId?: string): SessionSnapshot | null {
+  try {
+    const filename = snapshotId ? `${snapshotId}.json` : 'latest.json';
+    const filepath = path.join(SNAPSHOT_DIR, filename);
+    const content = fs.readFileSync(filepath, 'utf-8');
+    const snapshot = JSON.parse(content) as SessionSnapshot;
+
+    if (snapshot.version !== 1) return null;
+    return snapshot;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Tab Analysis ──────────────────────────────────────────────────────────
+
+export async function analyzeTabs(savedTabs: SnapshotTab[]): Promise<TabAnalysis[]> {
+  const results: TabAnalysis[] = [];
+  const sessionManager = getSessionManager();
+
+  for (const saved of savedTabs) {
+    // Step 1: Try exact targetId match using the saved sessionId
+    let foundLive = false;
+    try {
+      const page = await sessionManager.getPage(saved.sessionId, saved.targetId, saved.workerId);
+      if (page) {
+        const currentUrl = page.url() || 'about:blank';
+        results.push({
+          saved,
+          status: 'LIVE',
+          currentTargetId: saved.targetId,
+          currentUrl,
+        });
+        foundLive = true;
+      }
+    } catch {
+      // Target not found or session mismatch — try URL remapping below
+    }
+
+    if (foundLive) continue;
+
+    // Step 2: Try URL-based remapping across all sessions/workers/targets
+    let remapped = false;
+    try {
+      const allSessionInfos = sessionManager.getAllSessionInfos();
+
+      outer:
+      for (const sessionInfo of allSessionInfos) {
+        for (const workerInfo of sessionInfo.workers) {
+          const targetIds = sessionManager.getWorkerTargetIds(sessionInfo.id, workerInfo.id);
+          for (const targetId of targetIds) {
+            try {
+              const page = await sessionManager.getPage(sessionInfo.id, targetId);
+              if (page && page.url() === saved.url) {
+                results.push({
+                  saved,
+                  status: 'REMAPPED',
+                  currentTargetId: targetId,
+                  currentUrl: page.url(),
+                });
+                remapped = true;
+                break outer;
+              }
+            } catch {
+              // Skip unreachable targets
+            }
+          }
+        }
+      }
+    } catch {
+      // Session manager error during URL scan — fall through to CLOSED
+    }
+
+    if (remapped) continue;
+
+    // Step 3: Tab is gone
+    results.push({
+      saved,
+      status: 'CLOSED',
+    });
+  }
+
+  return results;
+}
+
+// ─── Resume Guide Generation ───────────────────────────────────────────────
+
+export function generateResumeGuide(snapshot: SessionSnapshot, tabAnalysis: TabAnalysis[]): string {
+  const lines: string[] = [];
+
+  const age = Date.now() - snapshot.timestamp;
+  const ageStr = age < 60000 ? `${Math.round(age / 1000)}s` :
+                 age < 3600000 ? `${Math.round(age / 60000)}m` :
+                 `${Math.round(age / 3600000)}h`;
+
+  lines.push('=== CONTEXT RESTORED ===');
+  lines.push('');
+  lines.push(`Objective: ${snapshot.memo.objective}`);
+  lines.push(`Last step: ${snapshot.memo.currentStep}`);
+  lines.push(`Snapshot age: ${ageStr}${snapshot.label ? ` (${snapshot.label})` : ''}`);
+
+  if (age > 24 * 3600000) {
+    lines.push('WARNING: Snapshot is over 24 hours old. Tab states may be inaccurate.');
+  }
+
+  // Tab status
+  const live = tabAnalysis.filter(t => t.status === 'LIVE');
+  const remapped = tabAnalysis.filter(t => t.status === 'REMAPPED');
+  const closed = tabAnalysis.filter(t => t.status === 'CLOSED');
+
+  lines.push('');
+  lines.push(`Tabs: ${live.length} LIVE, ${remapped.length} REMAPPED, ${closed.length} CLOSED`);
+
+  if (tabAnalysis.length > 0) {
+    lines.push('');
+    for (const tab of tabAnalysis) {
+      const statusLabel = tab.status === 'LIVE' ? 'LIVE    ' :
+                          tab.status === 'REMAPPED' ? 'REMAPPED' :
+                          'CLOSED  ';
+      const url = tab.saved.url;
+      const title = tab.saved.title ? ` "${tab.saved.title}"` : '';
+
+      if (tab.status === 'REMAPPED') {
+        lines.push(`  [${statusLabel}] ${tab.saved.targetId} -> ${tab.currentTargetId} ${url}${title}`);
+      } else if (tab.status === 'CLOSED') {
+        lines.push(`  [${statusLabel}] ${url}${title}`);
+      } else {
+        lines.push(`  [${statusLabel}] ${tab.currentTargetId} ${url}${title}`);
+      }
+    }
+  }
+
+  // Completed steps
+  if (snapshot.memo.completedSteps && snapshot.memo.completedSteps.length > 0) {
+    lines.push('');
+    lines.push('Completed:');
+    for (const step of snapshot.memo.completedSteps) {
+      lines.push(`  - ${step}`);
+    }
+  }
+
+  // Next actions
+  if (snapshot.memo.nextActions.length > 0) {
+    lines.push('');
+    lines.push('Next actions:');
+    snapshot.memo.nextActions.forEach((action, i) => {
+      lines.push(`  ${i + 1}. ${action}`);
+    });
+  }
+
+  // Notes
+  if (snapshot.memo.notes) {
+    lines.push('');
+    lines.push(`Notes: ${snapshot.memo.notes}`);
+  }
+
+  return lines.join('\n');
+}
+
+// ─── Handler ───────────────────────────────────────────────────────────────
+
+const handler: ToolHandler = async (
+  _sessionId: string,
+  args: Record<string, unknown>,
+): Promise<MCPResult> => {
+  const snapshotId = args.snapshotId as string | undefined;
+
+  const snapshot = loadSnapshot(snapshotId);
+  if (!snapshot) {
+    return {
+      content: [{
+        type: 'text',
+        text: 'No snapshot found.' +
+          (snapshotId ? ` Snapshot "${snapshotId}" does not exist.` : '') +
+          ' Use oc_session_snapshot to save state before long operations.',
+      }],
+    };
+  }
+
+  let tabAnalysis: TabAnalysis[];
+  try {
+    tabAnalysis = await analyzeTabs(snapshot.tabs);
+  } catch {
+    // Can't analyze tabs (Chrome disconnected) — return snapshot data as-is
+    tabAnalysis = snapshot.tabs.map(tab => ({
+      saved: tab,
+      status: 'CLOSED' as TabStatus,
+    }));
+  }
+
+  const guide = generateResumeGuide(snapshot, tabAnalysis);
+
+  return {
+    content: [{ type: 'text', text: guide }],
+    _snapshotId: snapshot.id,
+  };
+};
+
+// ─── Registration ──────────────────────────────────────────────────────────
+
+export function registerSessionResumeTool(server: MCPServer): void {
+  server.registerTool(definition.name, handler, definition);
+}

--- a/src/tools/session-snapshot.ts
+++ b/src/tools/session-snapshot.ts
@@ -1,0 +1,251 @@
+/**
+ * Session Snapshot Tool — captures browser state for context recovery.
+ * Part of #355: AI Agent Continuity.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import { getSessionManager } from '../session-manager';
+import { writeFileAtomicSafe } from '../utils/atomic-file';
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+export interface SnapshotTab {
+  targetId: string;
+  workerId: string;
+  sessionId: string;
+  url: string;
+  title: string;
+}
+
+export interface SnapshotMemo {
+  objective: string;
+  currentStep: string;
+  nextActions: string[];
+  completedSteps?: string[];
+  notes?: string;
+}
+
+export interface SessionSnapshot {
+  version: 1;
+  id: string;
+  timestamp: number;
+  tabs: SnapshotTab[];
+  memo: SnapshotMemo;
+  label?: string;
+}
+
+// ─── Tool Definition ───────────────────────────────────────────────────────
+
+const definition: MCPToolDefinition = {
+  name: 'oc_session_snapshot',
+  description:
+    'Save browser state snapshot for context recovery after compaction. ' +
+    'Captures open tabs, worker state, and your task memo. ' +
+    'Use before long operations or periodically during multi-step tasks. ' +
+    'Restore with oc_session_resume.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      objective: {
+        type: 'string',
+        description: 'What you are trying to accomplish',
+      },
+      currentStep: {
+        type: 'string',
+        description: 'What step you are currently on',
+      },
+      nextActions: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Planned next actions',
+      },
+      completedSteps: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Steps already completed',
+      },
+      notes: {
+        type: 'string',
+        description: 'Additional context or notes',
+      },
+      label: {
+        type: 'string',
+        description: 'Optional label for this snapshot',
+      },
+    },
+    required: ['objective', 'currentStep', 'nextActions'],
+  },
+};
+
+// ─── Snapshot Directory ────────────────────────────────────────────────────
+
+export const SNAPSHOT_DIR = path.join(os.homedir(), '.openchrome', 'snapshots');
+export const MAX_SNAPSHOTS = 10;
+const MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+export function generateSnapshotId(): string {
+  const now = new Date();
+  const ts = now.toISOString().replace(/[-:]/g, '').replace('T', '-').slice(0, 15);
+  const hex = Math.random().toString(16).slice(2, 6);
+  return `snap-${ts}-${hex}`;
+}
+
+// ─── Tab Collection ────────────────────────────────────────────────────────
+
+export async function collectTabs(): Promise<SnapshotTab[]> {
+  const tabs: SnapshotTab[] = [];
+
+  try {
+    const sessionManager = getSessionManager();
+    const allSessionInfos = sessionManager.getAllSessionInfos();
+
+    for (const sessionInfo of allSessionInfos) {
+      const sessionId = sessionInfo.id;
+
+      for (const workerInfo of sessionInfo.workers) {
+        const workerId = workerInfo.id;
+        const targetIds = sessionManager.getWorkerTargetIds(sessionId, workerId);
+
+        for (const targetId of targetIds) {
+          let url = 'about:blank';
+          let title = '';
+
+          try {
+            const page = await sessionManager.getPage(sessionId, targetId, workerId);
+            if (page) {
+              url = page.url() || 'about:blank';
+              try {
+                title = await page.title();
+              } catch {
+                title = '';
+              }
+            }
+          } catch {
+            // Page may be closed or crashed
+          }
+
+          tabs.push({
+            targetId,
+            workerId,
+            sessionId,
+            url,
+            title,
+          });
+        }
+      }
+    }
+  } catch (err) {
+    // Session manager may not be initialized or Chrome not connected
+    console.error('[SessionSnapshot] collectTabs error (graceful fallback):', err instanceof Error ? err.message : String(err));
+  }
+
+  return tabs;
+}
+
+// ─── File Management ───────────────────────────────────────────────────────
+
+async function ensureDir(): Promise<void> {
+  await fs.promises.mkdir(SNAPSHOT_DIR, { recursive: true });
+}
+
+export async function saveSnapshot(snapshot: SessionSnapshot): Promise<void> {
+  await ensureDir();
+
+  // Save as latest.json (atomic overwrite)
+  const latestPath = path.join(SNAPSHOT_DIR, 'latest.json');
+  await writeFileAtomicSafe(latestPath, snapshot);
+
+  // Save history copy
+  const historyPath = path.join(SNAPSHOT_DIR, `${snapshot.id}.json`);
+  await writeFileAtomicSafe(historyPath, snapshot);
+
+  // Prune old snapshots
+  await pruneSnapshots();
+}
+
+export async function pruneSnapshots(): Promise<void> {
+  try {
+    const files = await fs.promises.readdir(SNAPSHOT_DIR);
+    const snapFiles = files
+      .filter(f => f.startsWith('snap-') && f.endsWith('.json'))
+      .sort(); // Lexicographic sort = chronological for our ID format
+
+    // Remove excess snapshots (keep MAX_SNAPSHOTS most recent)
+    if (snapFiles.length > MAX_SNAPSHOTS) {
+      const toRemove = snapFiles.slice(0, snapFiles.length - MAX_SNAPSHOTS);
+      for (const file of toRemove) {
+        await fs.promises.unlink(path.join(SNAPSHOT_DIR, file)).catch(() => {});
+      }
+    }
+
+    // Remove snapshots older than MAX_AGE_MS
+    const cutoff = Date.now() - MAX_AGE_MS;
+    for (const file of snapFiles) {
+      const filePath = path.join(SNAPSHOT_DIR, file);
+      try {
+        const stat = await fs.promises.stat(filePath);
+        if (stat.mtimeMs < cutoff) {
+          await fs.promises.unlink(filePath);
+        }
+      } catch {
+        // Skip
+      }
+    }
+  } catch {
+    // Best-effort pruning
+  }
+}
+
+// ─── Handler ───────────────────────────────────────────────────────────────
+
+const handler: ToolHandler = async (
+  _sessionId: string,
+  args: Record<string, unknown>,
+): Promise<MCPResult> => {
+  const memo: SnapshotMemo = {
+    objective: args.objective as string,
+    currentStep: args.currentStep as string,
+    nextActions: (args.nextActions as string[]) || [],
+    completedSteps: (args.completedSteps as string[]) || undefined,
+    notes: (args.notes as string) || undefined,
+  };
+
+  const tabs = await collectTabs();
+  const snapshotId = generateSnapshotId();
+
+  const snapshot: SessionSnapshot = {
+    version: 1,
+    id: snapshotId,
+    timestamp: Date.now(),
+    tabs,
+    memo,
+    label: (args.label as string) || undefined,
+  };
+
+  await saveSnapshot(snapshot);
+
+  const text = [
+    `Snapshot saved: ${snapshotId}`,
+    `Tabs: ${tabs.length}`,
+    `Objective: ${memo.objective}`,
+    `Step: ${memo.currentStep}`,
+    `Next: ${memo.nextActions.join(', ')}`,
+    '',
+    'Use oc_session_resume to restore this context after compaction.',
+  ].join('\n');
+
+  return {
+    content: [{ type: 'text', text }],
+    _snapshotId: snapshotId,
+  };
+};
+
+// ─── Registration ──────────────────────────────────────────────────────────
+
+export function registerSessionSnapshotTool(server: MCPServer): void {
+  server.registerTool(definition.name, handler, definition);
+}

--- a/tests/journal/task-journal.test.ts
+++ b/tests/journal/task-journal.test.ts
@@ -1,0 +1,504 @@
+/**
+ * Tests for TaskJournal — core MCP tool call tracking module.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { TaskJournal, JournalEntry, getTaskJournal } from '../../src/journal/task-journal';
+
+function makeTmpDir(): string {
+  const dir = path.join(os.tmpdir(), `task-journal-test-${Math.random().toString(36).slice(2)}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function cleanupDir(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+}
+
+describe('TaskJournal', () => {
+  let dir: string;
+  let journal: TaskJournal;
+
+  beforeEach(() => {
+    dir = makeTmpDir();
+    journal = new TaskJournal({ dir });
+  });
+
+  afterEach(() => {
+    cleanupDir(dir);
+  });
+
+  // -------------------------------------------------------------------------
+  // createEntry()
+  // -------------------------------------------------------------------------
+  describe('createEntry()', () => {
+    it('returns an entry with correct base fields', () => {
+      const before = Date.now();
+      const entry = journal.createEntry('navigate', 'sess-1', { url: 'https://example.com' }, 120, true);
+      const after = Date.now();
+
+      expect(entry.tool).toBe('navigate');
+      expect(entry.sessionId).toBe('sess-1');
+      expect(entry.durationMs).toBe(120);
+      expect(entry.ok).toBe(true);
+      expect(entry.ts).toBeGreaterThanOrEqual(before);
+      expect(entry.ts).toBeLessThanOrEqual(after);
+    });
+
+    it('extracts tabId from args when present', () => {
+      const entry = journal.createEntry('read_page', 'sess-2', { tabId: 'tab-42' }, 50, true);
+      expect(entry.tabId).toBe('tab-42');
+    });
+
+    it('leaves tabId undefined when not in args', () => {
+      const entry = journal.createEntry('read_page', 'sess-2', {}, 50, true);
+      expect(entry.tabId).toBeUndefined();
+    });
+
+    it('marks navigate as a milestone', () => {
+      const entry = journal.createEntry('navigate', 'sess-1', { url: 'https://example.com' }, 10, true);
+      expect(entry.milestone).toBe(true);
+    });
+
+    it('marks fill_form as a milestone', () => {
+      const entry = journal.createEntry('fill_form', 'sess-1', {}, 10, true);
+      expect(entry.milestone).toBe(true);
+    });
+
+    it('marks tabs_create as a milestone', () => {
+      const entry = journal.createEntry('tabs_create', 'sess-1', {}, 10, true);
+      expect(entry.milestone).toBe(true);
+    });
+
+    it('marks tabs_close as a milestone', () => {
+      const entry = journal.createEntry('tabs_close', 'sess-1', {}, 10, true);
+      expect(entry.milestone).toBe(true);
+    });
+
+    it('does not mark non-milestone tools', () => {
+      const entry = journal.createEntry('read_page', 'sess-1', {}, 10, true);
+      expect(entry.milestone).toBeUndefined();
+    });
+
+    it('includes sanitized args in the entry', () => {
+      const entry = journal.createEntry('navigate', 'sess-1', { url: 'https://example.com', password: 'secret' }, 10, true);
+      expect(entry.args.url).toBe('https://example.com');
+      expect(entry.args.password).toBe('[REDACTED]');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // sanitizeArgs()
+  // -------------------------------------------------------------------------
+  describe('sanitizeArgs()', () => {
+    it('redacts entire args for REDACT_TOOLS (cookies)', () => {
+      const result = journal.sanitizeArgs('cookies', { name: 'session', value: 'abc123' });
+      expect(result).toEqual({ _redacted: true });
+    });
+
+    it('redacts entire args for REDACT_TOOLS (http_auth)', () => {
+      const result = journal.sanitizeArgs('http_auth', { username: 'admin', password: 'pass' });
+      expect(result).toEqual({ _redacted: true });
+    });
+
+    it('redacts keys matching REDACT_KEYS pattern — password', () => {
+      const result = journal.sanitizeArgs('navigate', { password: 'hunter2' });
+      expect(result.password).toBe('[REDACTED]');
+    });
+
+    it('redacts keys matching REDACT_KEYS pattern — token', () => {
+      const result = journal.sanitizeArgs('navigate', { token: 'abc' });
+      expect(result.token).toBe('[REDACTED]');
+    });
+
+    it('redacts keys matching REDACT_KEYS pattern — secret', () => {
+      const result = journal.sanitizeArgs('navigate', { secret: 'xyz' });
+      expect(result.secret).toBe('[REDACTED]');
+    });
+
+    it('redacts keys matching REDACT_KEYS pattern — credential', () => {
+      const result = journal.sanitizeArgs('navigate', { credential: 'cred' });
+      expect(result.credential).toBe('[REDACTED]');
+    });
+
+    it('redacts keys matching REDACT_KEYS pattern — api_key', () => {
+      const result = journal.sanitizeArgs('navigate', { api_key: 'key123' });
+      expect(result.api_key).toBe('[REDACTED]');
+    });
+
+    it('redacts keys matching REDACT_KEYS pattern — apiKey (camelCase)', () => {
+      const result = journal.sanitizeArgs('navigate', { apiKey: 'key456' });
+      expect(result.apiKey).toBe('[REDACTED]');
+    });
+
+    it('passes through non-sensitive keys unchanged', () => {
+      const result = journal.sanitizeArgs('navigate', { url: 'https://example.com', tabId: 'tab-1' });
+      expect(result.url).toBe('https://example.com');
+      expect(result.tabId).toBe('tab-1');
+    });
+
+    it('handles empty args', () => {
+      const result = journal.sanitizeArgs('navigate', {});
+      expect(result).toEqual({});
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // generateSummary()
+  // -------------------------------------------------------------------------
+  describe('generateSummary()', () => {
+    it('formats navigate with url', () => {
+      expect(journal.generateSummary('navigate', { url: 'https://example.com' }, true))
+        .toBe('✓ → https://example.com');
+    });
+
+    it('formats navigate without url', () => {
+      expect(journal.generateSummary('navigate', {}, true)).toBe('✓ → unknown');
+    });
+
+    it('formats read_page', () => {
+      expect(journal.generateSummary('read_page', {}, true)).toBe('✓ Read page');
+    });
+
+    it('formats interact with description', () => {
+      expect(journal.generateSummary('interact', { description: 'Submit button' }, true))
+        .toBe('✓ Click "Submit button"');
+    });
+
+    it('formats interact with selector fallback', () => {
+      expect(journal.generateSummary('interact', { selector: '#btn' }, true))
+        .toBe('✓ Click "#btn"');
+    });
+
+    it('formats fill_form with fields count', () => {
+      expect(journal.generateSummary('fill_form', { fields: { email: 'a@b.com', name: 'Alice' } }, true))
+        .toBe('✓ Fill form (2 fields)');
+    });
+
+    it('formats fill_form without fields', () => {
+      expect(journal.generateSummary('fill_form', {}, true)).toBe('✓ Fill form (0 fields)');
+    });
+
+    it('formats javascript_tool', () => {
+      expect(journal.generateSummary('javascript_tool', { code: 'document.title' }, true))
+        .toBe('✓ JS eval');
+    });
+
+    it('formats tabs_create with url', () => {
+      expect(journal.generateSummary('tabs_create', { url: 'https://example.com' }, true))
+        .toBe('✓ New tab → https://example.com');
+    });
+
+    it('formats tabs_create without url', () => {
+      expect(journal.generateSummary('tabs_create', {}, true)).toBe('✓ New tab');
+    });
+
+    it('formats tabs_close', () => {
+      expect(journal.generateSummary('tabs_close', {}, true)).toBe('✓ Close tab');
+    });
+
+    it('formats oc_stop', () => {
+      expect(journal.generateSummary('oc_stop', {}, true)).toBe('✓ Stop OpenChrome');
+    });
+
+    it('formats oc_session_snapshot', () => {
+      expect(journal.generateSummary('oc_session_snapshot', {}, true)).toBe('✓ Snapshot saved');
+    });
+
+    it('formats workflow_init', () => {
+      expect(journal.generateSummary('workflow_init', {}, true)).toBe('✓ Workflow started');
+    });
+
+    it('uses default format for unknown tools', () => {
+      expect(journal.generateSummary('some_unknown_tool', {}, true)).toBe('✓ some_unknown_tool');
+    });
+
+    it('uses ✗ for failed calls', () => {
+      expect(journal.generateSummary('navigate', { url: 'https://example.com' }, false))
+        .toBe('✗ → https://example.com');
+    });
+
+    it('uses ✗ for failed read_page', () => {
+      expect(journal.generateSummary('read_page', {}, false)).toBe('✗ Read page');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // record() + getRecent()
+  // -------------------------------------------------------------------------
+  describe('record() + getRecent()', () => {
+    it('writes entries that can be read back', () => {
+      const entry = journal.createEntry('navigate', 'sess-1', { url: 'https://example.com' }, 100, true);
+      journal.record(entry);
+
+      const recent = journal.getRecent(10);
+      expect(recent).toHaveLength(1);
+      expect(recent[0].tool).toBe('navigate');
+      expect(recent[0].sessionId).toBe('sess-1');
+    });
+
+    it('writes multiple entries and reads them all back', () => {
+      for (let i = 0; i < 5; i++) {
+        const entry = journal.createEntry('read_page', `sess-${i}`, {}, 50, true);
+        journal.record(entry);
+      }
+
+      const recent = journal.getRecent(10);
+      expect(recent).toHaveLength(5);
+    });
+
+    it('respects count limit in getRecent()', () => {
+      for (let i = 0; i < 10; i++) {
+        journal.record(journal.createEntry('read_page', 'sess', {}, 10, true));
+      }
+      const recent = journal.getRecent(3);
+      expect(recent).toHaveLength(3);
+    });
+
+    it('returns last N entries (most recent)', () => {
+      const urls = ['https://a.com', 'https://b.com', 'https://c.com'];
+      for (const url of urls) {
+        journal.record(journal.createEntry('navigate', 'sess', { url }, 10, true));
+      }
+
+      const recent = journal.getRecent(2);
+      expect(recent).toHaveLength(2);
+      // Should be the last 2
+      expect(recent[0].args.url).toBe('https://b.com');
+      expect(recent[1].args.url).toBe('https://c.com');
+    });
+
+    it('returns empty array when no entries written', () => {
+      expect(journal.getRecent(10)).toEqual([]);
+    });
+
+    it('does not throw when journal dir does not exist yet', () => {
+      const nonExistentDir = path.join(os.tmpdir(), `no-such-${Date.now()}`);
+      const j = new TaskJournal({ dir: nonExistentDir });
+      expect(() => j.getRecent(5)).not.toThrow();
+    });
+
+    it('record() does not throw when dir does not exist', () => {
+      const nonExistentDir = path.join(os.tmpdir(), `no-such-${Date.now()}`);
+      const j = new TaskJournal({ dir: nonExistentDir });
+      const entry = j.createEntry('navigate', 'sess', { url: 'https://example.com' }, 10, true);
+      // Should not throw (best-effort)
+      expect(() => j.record(entry)).not.toThrow();
+    });
+
+    it('skips malformed JSONL lines', () => {
+      // Write a valid entry, then a corrupt line, then another valid entry
+      const entry1 = journal.createEntry('navigate', 'sess', { url: 'https://a.com' }, 10, true);
+      const entry2 = journal.createEntry('read_page', 'sess', {}, 10, true);
+      journal.record(entry1);
+
+      // Manually inject a corrupt line
+      const today = new Date().toISOString().slice(0, 10);
+      const filepath = path.join(dir, `journal-${today}.jsonl`);
+      fs.appendFileSync(filepath, 'NOT_VALID_JSON\n');
+
+      journal.record(entry2);
+
+      const recent = journal.getRecent(10);
+      expect(recent).toHaveLength(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getMilestones()
+  // -------------------------------------------------------------------------
+  describe('getMilestones()', () => {
+    it('returns only milestone entries', () => {
+      journal.record(journal.createEntry('navigate', 'sess', { url: 'https://a.com' }, 10, true));
+      journal.record(journal.createEntry('read_page', 'sess', {}, 10, true));
+      journal.record(journal.createEntry('fill_form', 'sess', { fields: {} }, 10, true));
+
+      const milestones = journal.getMilestones();
+      expect(milestones.every(e => e.milestone)).toBe(true);
+      expect(milestones.map(e => e.tool)).toEqual(expect.arrayContaining(['navigate', 'fill_form']));
+      expect(milestones.map(e => e.tool)).not.toContain('read_page');
+    });
+
+    it('filters by since timestamp', () => {
+      journal.record(journal.createEntry('navigate', 'sess', { url: 'https://old.com' }, 10, true));
+
+      const checkpoint = Date.now();
+
+      // Small delay to ensure ts difference
+      const futureTs = checkpoint + 1;
+      const newEntry = journal.createEntry('tabs_create', 'sess', {}, 10, true);
+      // Override ts to be clearly after checkpoint
+      const laterEntry: JournalEntry = { ...newEntry, ts: futureTs };
+      journal.record(laterEntry);
+
+      const milestones = journal.getMilestones({ since: checkpoint });
+      expect(milestones).toHaveLength(1);
+      expect(milestones[0].tool).toBe('tabs_create');
+    });
+
+    it('respects limit option', () => {
+      for (let i = 0; i < 10; i++) {
+        journal.record(journal.createEntry('navigate', 'sess', { url: `https://site${i}.com` }, 10, true));
+      }
+      const milestones = journal.getMilestones({ limit: 3 });
+      expect(milestones).toHaveLength(3);
+    });
+
+    it('returns empty array when no milestones exist', () => {
+      journal.record(journal.createEntry('read_page', 'sess', {}, 10, true));
+      expect(journal.getMilestones()).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getSummary()
+  // -------------------------------------------------------------------------
+  describe('getSummary()', () => {
+    it('returns correct total, succeeded, failed counts', () => {
+      journal.record(journal.createEntry('navigate', 'sess', { url: 'https://a.com' }, 10, true));
+      journal.record(journal.createEntry('read_page', 'sess', {}, 10, true));
+      journal.record(journal.createEntry('navigate', 'sess', { url: 'https://b.com' }, 10, false));
+
+      const summary = journal.getSummary();
+      expect(summary.total).toBe(3);
+      expect(summary.succeeded).toBe(2);
+      expect(summary.failed).toBe(1);
+    });
+
+    it('returns correct toolCounts', () => {
+      journal.record(journal.createEntry('navigate', 'sess', { url: 'https://a.com' }, 10, true));
+      journal.record(journal.createEntry('navigate', 'sess', { url: 'https://b.com' }, 10, true));
+      journal.record(journal.createEntry('read_page', 'sess', {}, 10, true));
+
+      const summary = journal.getSummary();
+      expect(summary.toolCounts['navigate']).toBe(2);
+      expect(summary.toolCounts['read_page']).toBe(1);
+    });
+
+    it('includes milestones in summary', () => {
+      journal.record(journal.createEntry('navigate', 'sess', { url: 'https://a.com' }, 10, true));
+      journal.record(journal.createEntry('read_page', 'sess', {}, 10, true));
+
+      const summary = journal.getSummary();
+      expect(summary.milestones.map(e => e.tool)).toContain('navigate');
+      expect(summary.milestones.map(e => e.tool)).not.toContain('read_page');
+    });
+
+    it('returns period with start and end timestamps', () => {
+      const before = Date.now();
+      journal.record(journal.createEntry('navigate', 'sess', { url: 'https://a.com' }, 10, true));
+      journal.record(journal.createEntry('read_page', 'sess', {}, 10, true));
+      const after = Date.now();
+
+      const summary = journal.getSummary();
+      expect(summary.period.start).toBeGreaterThanOrEqual(before);
+      expect(summary.period.end).toBeLessThanOrEqual(after);
+      expect(summary.period.end).toBeGreaterThanOrEqual(summary.period.start);
+    });
+
+    it('filters by since timestamp', () => {
+      journal.record(journal.createEntry('navigate', 'sess', { url: 'https://old.com' }, 10, true));
+
+      const checkpoint = Date.now();
+
+      const laterEntry: JournalEntry = {
+        ...journal.createEntry('read_page', 'sess', {}, 10, true),
+        ts: checkpoint + 1,
+      };
+      journal.record(laterEntry);
+
+      const summary = journal.getSummary({ since: checkpoint });
+      expect(summary.total).toBe(1);
+      expect(summary.toolCounts['read_page']).toBe(1);
+    });
+
+    it('returns zeros when no entries exist', () => {
+      const summary = journal.getSummary();
+      expect(summary.total).toBe(0);
+      expect(summary.succeeded).toBe(0);
+      expect(summary.failed).toBe(0);
+      expect(summary.toolCounts).toEqual({});
+      expect(summary.milestones).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // pruneOldFiles() via init()
+  // -------------------------------------------------------------------------
+  describe('pruneOldFiles() via init()', () => {
+    it('deletes files older than maxAgeDays', async () => {
+      const j = new TaskJournal({ dir, maxAgeDays: 3 });
+
+      // Create an old file (10 days ago)
+      const oldDate = new Date(Date.now() - 10 * 86400000).toISOString().slice(0, 10);
+      const oldFile = path.join(dir, `journal-${oldDate}.jsonl`);
+      fs.writeFileSync(oldFile, '{"ts":1,"tool":"navigate","sessionId":"s","args":{},"durationMs":1,"ok":true,"summary":"x"}\n');
+
+      // Create a recent file (1 day ago)
+      const recentDate = new Date(Date.now() - 1 * 86400000).toISOString().slice(0, 10);
+      const recentFile = path.join(dir, `journal-${recentDate}.jsonl`);
+      fs.writeFileSync(recentFile, '{"ts":2,"tool":"read_page","sessionId":"s","args":{},"durationMs":1,"ok":true,"summary":"y"}\n');
+
+      await j.init();
+
+      expect(fs.existsSync(oldFile)).toBe(false);
+      expect(fs.existsSync(recentFile)).toBe(true);
+    });
+
+    it('does not delete files within maxAgeDays', async () => {
+      const j = new TaskJournal({ dir, maxAgeDays: 7 });
+
+      // Create a file 2 days ago (within 7-day window)
+      const recentDate = new Date(Date.now() - 2 * 86400000).toISOString().slice(0, 10);
+      const recentFile = path.join(dir, `journal-${recentDate}.jsonl`);
+      fs.writeFileSync(recentFile, '{"ts":1,"tool":"navigate","sessionId":"s","args":{},"durationMs":1,"ok":true,"summary":"x"}\n');
+
+      await j.init();
+
+      expect(fs.existsSync(recentFile)).toBe(true);
+    });
+
+    it('ignores non-journal files in the directory', async () => {
+      const j = new TaskJournal({ dir, maxAgeDays: 1 });
+
+      const otherFile = path.join(dir, 'some-other-file.txt');
+      fs.writeFileSync(otherFile, 'data');
+
+      await j.init();
+
+      expect(fs.existsSync(otherFile)).toBe(true);
+    });
+
+    it('creates journal directory if it does not exist', async () => {
+      const newDir = path.join(os.tmpdir(), `journal-init-test-${Math.random().toString(36).slice(2)}`);
+      const j = new TaskJournal({ dir: newDir });
+      try {
+        await j.init();
+        expect(fs.existsSync(newDir)).toBe(true);
+      } finally {
+        cleanupDir(newDir);
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getTaskJournal() singleton
+  // -------------------------------------------------------------------------
+  describe('getTaskJournal()', () => {
+    it('returns the same instance on repeated calls', () => {
+      const a = getTaskJournal();
+      const b = getTaskJournal();
+      expect(a).toBe(b);
+    });
+
+    it('returns a TaskJournal instance', () => {
+      expect(getTaskJournal()).toBeInstanceOf(TaskJournal);
+    });
+  });
+});

--- a/tests/tools/journal.test.ts
+++ b/tests/tools/journal.test.ts
@@ -1,0 +1,308 @@
+/// <reference types="jest" />
+/**
+ * Tests for oc_journal tool
+ */
+
+import { parseSince } from '../../src/tools/journal';
+
+// ─── Mock getTaskJournal ────────────────────────────────────────────────────
+
+const mockGetRecent = jest.fn();
+const mockGetSummary = jest.fn();
+const mockCreateEntry = jest.fn();
+const mockRecord = jest.fn();
+
+jest.mock('../../src/journal/task-journal', () => ({
+  getTaskJournal: jest.fn(() => ({
+    getRecent: mockGetRecent,
+    getSummary: mockGetSummary,
+    createEntry: mockCreateEntry,
+    record: mockRecord,
+    init: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+// Mock session manager and chrome launcher to satisfy MCPServer constructor
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(() => ({
+    getAllSessionInfos: jest.fn().mockReturnValue([]),
+    getOrCreateSession: jest.fn().mockResolvedValue({}),
+    cleanupAllSessions: jest.fn().mockResolvedValue(undefined),
+    deleteSession: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock('../../src/chrome/launcher', () => ({
+  getChromeLauncher: jest.fn(() => ({
+    isConnected: jest.fn().mockReturnValue(false),
+    getProfileState: jest.fn().mockReturnValue({ type: 'temp', extensionsAvailable: false }),
+  })),
+}));
+
+import { MCPServer } from '../../src/mcp-server';
+import { registerJournalTool } from '../../src/tools/journal';
+import { JournalEntry } from '../../src/journal/task-journal';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeEntry(overrides: Partial<JournalEntry> = {}): JournalEntry {
+  return {
+    ts: Date.now(),
+    tool: 'navigate',
+    sessionId: 'default',
+    args: { url: 'https://example.com' },
+    durationMs: 123,
+    ok: true,
+    summary: '✓ → https://example.com',
+    milestone: true,
+    ...overrides,
+  };
+}
+
+// ─── parseSince ──────────────────────────────────────────────────────────────
+
+describe('parseSince', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-15T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('returns undefined for undefined input', () => {
+    expect(parseSince(undefined)).toBeUndefined();
+  });
+
+  test('returns undefined for empty string', () => {
+    expect(parseSince('')).toBeUndefined();
+  });
+
+  test('parses relative minutes "30m"', () => {
+    const result = parseSince('30m');
+    const expected = Date.now() - 30 * 60000;
+    expect(result).toBe(expected);
+  });
+
+  test('parses relative hours "1h"', () => {
+    const result = parseSince('1h');
+    const expected = Date.now() - 1 * 3600000;
+    expect(result).toBe(expected);
+  });
+
+  test('parses relative days "2d"', () => {
+    const result = parseSince('2d');
+    const expected = Date.now() - 2 * 86400000;
+    expect(result).toBe(expected);
+  });
+
+  test('parses ISO timestamp', () => {
+    const iso = '2024-01-15T10:00:00.000Z';
+    const result = parseSince(iso);
+    expect(result).toBe(new Date(iso).getTime());
+  });
+
+  test('returns undefined for invalid string', () => {
+    expect(parseSince('invalid')).toBeUndefined();
+  });
+});
+
+// ─── Handler tests ───────────────────────────────────────────────────────────
+
+describe('oc_journal tool', () => {
+  let server: MCPServer;
+  let handler: (sessionId: string, args: Record<string, unknown>) => Promise<any>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    server = new MCPServer();
+    registerJournalTool(server);
+    handler = server.getToolHandler('oc_journal')!;
+    expect(handler).toBeDefined();
+  });
+
+  // ─── action=summary ──────────────────────────────────────────────────────
+
+  describe('action=summary', () => {
+    test('returns formatted summary with milestones', async () => {
+      const now = Date.now();
+      const milestone = makeEntry({ ts: now - 60000, milestone: true, summary: '✓ → https://example.com' });
+
+      mockGetSummary.mockReturnValue({
+        total: 10,
+        succeeded: 8,
+        failed: 2,
+        toolCounts: { navigate: 5, read_page: 3, interact: 2 },
+        milestones: [milestone],
+        period: { start: now - 300000, end: now },
+      });
+
+      const result = await handler('default', { action: 'summary' });
+      expect(result.content).toHaveLength(1);
+      const text: string = result.content[0].text;
+
+      expect(text).toContain('SESSION JOURNAL SUMMARY');
+      expect(text).toContain('Total calls: 10 (8 success, 2 failed)');
+      expect(text).toContain('Milestones:');
+      expect(text).toContain('✓ → https://example.com');
+      expect(text).toContain('navigate(5)');
+      expect(text).toContain('Failure rate: 20.0%');
+    });
+
+    test('returns summary with no milestones or tool counts', async () => {
+      const now = Date.now();
+      mockGetSummary.mockReturnValue({
+        total: 0,
+        succeeded: 0,
+        failed: 0,
+        toolCounts: {},
+        milestones: [],
+        period: { start: now, end: now },
+      });
+
+      const result = await handler('default', { action: 'summary' });
+      const text: string = result.content[0].text;
+
+      expect(text).toContain('SESSION JOURNAL SUMMARY');
+      expect(text).toContain('Total calls: 0');
+      expect(text).not.toContain('Milestones:');
+      expect(text).not.toContain('Tools:');
+      expect(text).not.toContain('Failure rate:');
+    });
+
+    test('passes since filter to getSummary', async () => {
+      const now = Date.now();
+      mockGetSummary.mockReturnValue({
+        total: 5,
+        succeeded: 5,
+        failed: 0,
+        toolCounts: { navigate: 5 },
+        milestones: [],
+        period: { start: now - 3600000, end: now },
+      });
+
+      await handler('default', { action: 'summary', since: '1h' });
+
+      expect(mockGetSummary).toHaveBeenCalledWith(
+        expect.objectContaining({ since: expect.any(Number) })
+      );
+    });
+  });
+
+  // ─── action=recent ───────────────────────────────────────────────────────
+
+  describe('action=recent', () => {
+    test('returns formatted recent entries', async () => {
+      const now = Date.now();
+      const entries = [
+        makeEntry({ ts: now - 5000, tool: 'navigate', durationMs: 200, milestone: true }),
+        makeEntry({ ts: now - 3000, tool: 'read_page', durationMs: 50, ok: true, summary: '✓ Read page', milestone: undefined }),
+      ];
+      mockGetRecent.mockReturnValue(entries);
+
+      const result = await handler('default', { action: 'recent' });
+      const text: string = result.content[0].text;
+      const lines = text.split('\n');
+
+      expect(lines).toHaveLength(2);
+      expect(lines[0]).toContain('200ms');
+      expect(lines[0]).toContain('★'); // milestone marker
+      expect(lines[1]).toContain('50ms');
+      expect(lines[1]).not.toContain('★');
+    });
+
+    test('uses default count of 20', async () => {
+      mockGetRecent.mockReturnValue([makeEntry()]);
+      await handler('default', { action: 'recent' });
+      expect(mockGetRecent).toHaveBeenCalledWith(20);
+    });
+
+    test('respects count parameter (clamped to 1-100)', async () => {
+      mockGetRecent.mockReturnValue([makeEntry()]);
+      await handler('default', { action: 'recent', count: 50 });
+      expect(mockGetRecent).toHaveBeenCalledWith(50);
+    });
+
+    test('clamps count to max 100', async () => {
+      mockGetRecent.mockReturnValue([makeEntry()]);
+      await handler('default', { action: 'recent', count: 999 });
+      expect(mockGetRecent).toHaveBeenCalledWith(100);
+    });
+
+    test('clamps count to min 1', async () => {
+      mockGetRecent.mockReturnValue([makeEntry()]);
+      await handler('default', { action: 'recent', count: -5 });
+      expect(mockGetRecent).toHaveBeenCalledWith(1);
+    });
+
+    test('filters by tool name', async () => {
+      const now = Date.now();
+      const entries = [
+        makeEntry({ tool: 'navigate', summary: '✓ → https://a.com' }),
+        makeEntry({ tool: 'read_page', summary: '✓ Read page' }),
+        makeEntry({ tool: 'navigate', summary: '✓ → https://b.com' }),
+      ];
+      mockGetRecent.mockReturnValue(entries);
+
+      const result = await handler('default', { action: 'recent', tool: 'navigate' });
+      const text: string = result.content[0].text;
+
+      expect(text).toContain('https://a.com');
+      expect(text).toContain('https://b.com');
+      expect(text).not.toContain('Read page');
+    });
+
+    test('filters by since timestamp', async () => {
+      const now = Date.now();
+      const oldEntry = makeEntry({ ts: now - 7200000, summary: '✓ Old entry' });
+      const newEntry = makeEntry({ ts: now - 1000, summary: '✓ New entry' });
+      mockGetRecent.mockReturnValue([oldEntry, newEntry]);
+
+      // Filter to last 1 hour
+      const result = await handler('default', { action: 'recent', since: '1h' });
+      const text: string = result.content[0].text;
+
+      expect(text).toContain('New entry');
+      expect(text).not.toContain('Old entry');
+    });
+
+    test('returns no entries message when list is empty', async () => {
+      mockGetRecent.mockReturnValue([]);
+
+      const result = await handler('default', { action: 'recent' });
+      expect(result.content[0].text).toBe('No journal entries found.');
+    });
+
+    test('returns no entries message when filter eliminates all entries', async () => {
+      const entries = [makeEntry({ tool: 'navigate' })];
+      mockGetRecent.mockReturnValue(entries);
+
+      const result = await handler('default', { action: 'recent', tool: 'read_page' });
+      expect(result.content[0].text).toBe('No journal entries found.');
+    });
+  });
+
+  // ─── unknown action ──────────────────────────────────────────────────────
+
+  describe('unknown action', () => {
+    test('returns error message for unknown action', async () => {
+      mockGetSummary.mockReturnValue({
+        total: 0, succeeded: 0, failed: 0, toolCounts: {}, milestones: [],
+        period: { start: Date.now(), end: Date.now() },
+      });
+      mockGetRecent.mockReturnValue([]);
+
+      const result = await handler('default', { action: 'invalid' });
+      expect(result.content[0].text).toContain('Unknown action: invalid');
+      expect(result.content[0].text).toContain('"summary"');
+      expect(result.content[0].text).toContain('"recent"');
+    });
+  });
+
+  // ─── registration ────────────────────────────────────────────────────────
+
+  test('tool is registered with correct name', () => {
+    expect(server.getToolNames()).toContain('oc_journal');
+  });
+});

--- a/tests/tools/session-resume.test.ts
+++ b/tests/tools/session-resume.test.ts
@@ -1,0 +1,595 @@
+/// <reference types="jest" />
+/**
+ * Tests for Session Resume Tool (oc_session_resume)
+ * Part of #355: AI Agent Continuity.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// ─── Mock fs before imports that use it ───────────────────────────────────
+jest.mock('fs');
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(),
+}));
+
+import { getSessionManager } from '../../src/session-manager';
+import {
+  loadSnapshot,
+  analyzeTabs,
+  generateResumeGuide,
+  SNAPSHOT_DIR,
+  registerSessionResumeTool,
+} from '../../src/tools/session-resume';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function makeSnapshot(overrides: Partial<{
+  id: string;
+  timestamp: number;
+  tabs: unknown[];
+  memo: unknown;
+  label: string;
+  version: number;
+}> = {}) {
+  return {
+    version: 1,
+    id: 'snap-abc123',
+    timestamp: Date.now() - 5000,
+    tabs: [],
+    memo: {
+      objective: 'Fill out the registration form',
+      currentStep: 'Submitted form, waiting for confirmation',
+      nextActions: ['Check confirmation email', 'Screenshot the result'],
+      completedSteps: ['Navigated to form', 'Filled in all fields'],
+      notes: 'Use test@example.com',
+    },
+    label: 'after-form-submit',
+    ...overrides,
+  };
+}
+
+function makeTab(overrides: Partial<{
+  targetId: string;
+  workerId: string;
+  sessionId: string;
+  url: string;
+  title: string;
+}> = {}) {
+  return {
+    targetId: 'target-aaa',
+    workerId: 'default',
+    sessionId: 'session-111',
+    url: 'https://example.com/form',
+    title: 'Registration Form',
+    ...overrides,
+  };
+}
+
+function makeMockPage(url: string) {
+  return { url: jest.fn().mockReturnValue(url) };
+}
+
+function makeMockSessionManager(options: {
+  getPage?: jest.Mock;
+  getAllSessionInfos?: jest.Mock;
+  getWorkerTargetIds?: jest.Mock;
+} = {}) {
+  return {
+    getPage: options.getPage ?? jest.fn().mockRejectedValue(new Error('Target not found')),
+    getAllSessionInfos: options.getAllSessionInfos ?? jest.fn().mockReturnValue([]),
+    getWorkerTargetIds: options.getWorkerTargetIds ?? jest.fn().mockReturnValue([]),
+  };
+}
+
+// ─── loadSnapshot ─────────────────────────────────────────────────────────
+
+describe('loadSnapshot', () => {
+  const mockReadFileSync = fs.readFileSync as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('reads latest.json when no snapshotId given', () => {
+    const snap = makeSnapshot();
+    mockReadFileSync.mockReturnValue(JSON.stringify(snap));
+
+    const result = loadSnapshot();
+
+    expect(mockReadFileSync).toHaveBeenCalledWith(
+      path.join(SNAPSHOT_DIR, 'latest.json'),
+      'utf-8',
+    );
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('snap-abc123');
+  });
+
+  test('reads <id>.json when snapshotId is given', () => {
+    const snap = makeSnapshot({ id: 'snap-xyz' });
+    mockReadFileSync.mockReturnValue(JSON.stringify(snap));
+
+    const result = loadSnapshot('snap-xyz');
+
+    expect(mockReadFileSync).toHaveBeenCalledWith(
+      path.join(SNAPSHOT_DIR, 'snap-xyz.json'),
+      'utf-8',
+    );
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('snap-xyz');
+  });
+
+  test('returns null when file does not exist', () => {
+    mockReadFileSync.mockImplementation(() => { throw new Error('ENOENT: no such file'); });
+
+    const result = loadSnapshot();
+
+    expect(result).toBeNull();
+  });
+
+  test('returns null when JSON is invalid', () => {
+    mockReadFileSync.mockReturnValue('not valid json {{{');
+
+    const result = loadSnapshot();
+
+    expect(result).toBeNull();
+  });
+
+  test('returns null when version is not 1', () => {
+    const snap = makeSnapshot({ version: 2 });
+    mockReadFileSync.mockReturnValue(JSON.stringify(snap));
+
+    const result = loadSnapshot();
+
+    expect(result).toBeNull();
+  });
+});
+
+// ─── analyzeTabs ─────────────────────────────────────────────────────────
+
+describe('analyzeTabs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns LIVE when targetId found in same session', async () => {
+    const tab = makeTab();
+    const page = makeMockPage('https://example.com/form');
+    const sm = makeMockSessionManager({
+      getPage: jest.fn().mockResolvedValue(page),
+    });
+    (getSessionManager as jest.Mock).mockReturnValue(sm);
+
+    const result = await analyzeTabs([tab]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe('LIVE');
+    expect(result[0].currentTargetId).toBe('target-aaa');
+    expect(result[0].currentUrl).toBe('https://example.com/form');
+  });
+
+  test('returns REMAPPED when targetId gone but URL matches another tab', async () => {
+    const tab = makeTab({ targetId: 'target-old', url: 'https://example.com/form' });
+
+    // getPage for saved targetId throws, but getPage for a different target returns matching URL
+    const page = makeMockPage('https://example.com/form');
+    const getPageMock = jest.fn()
+      .mockRejectedValueOnce(new Error('Target not found'))  // first call: exact match fails
+      .mockResolvedValue(page);                              // subsequent calls: URL scan succeeds
+
+    const sm = makeMockSessionManager({
+      getPage: getPageMock,
+      getAllSessionInfos: jest.fn().mockReturnValue([
+        {
+          id: 'session-111',
+          workers: [{ id: 'default', targetCount: 1 }],
+        },
+      ]),
+      getWorkerTargetIds: jest.fn().mockReturnValue(['target-new']),
+    });
+    (getSessionManager as jest.Mock).mockReturnValue(sm);
+
+    const result = await analyzeTabs([tab]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe('REMAPPED');
+    expect(result[0].currentTargetId).toBe('target-new');
+    expect(result[0].saved.targetId).toBe('target-old');
+  });
+
+  test('returns CLOSED when neither targetId nor URL matches', async () => {
+    const tab = makeTab({ url: 'https://gone.example.com' });
+    const page = makeMockPage('https://different.com');
+    const getPageMock = jest.fn()
+      .mockRejectedValueOnce(new Error('Target not found'))  // exact match fails
+      .mockResolvedValue(page);                              // URL scan: different URL
+
+    const sm = makeMockSessionManager({
+      getPage: getPageMock,
+      getAllSessionInfos: jest.fn().mockReturnValue([
+        {
+          id: 'session-111',
+          workers: [{ id: 'default', targetCount: 1 }],
+        },
+      ]),
+      getWorkerTargetIds: jest.fn().mockReturnValue(['target-other']),
+    });
+    (getSessionManager as jest.Mock).mockReturnValue(sm);
+
+    const result = await analyzeTabs([tab]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe('CLOSED');
+  });
+
+  test('returns CLOSED for all tabs when Chrome is disconnected', async () => {
+    const tabs = [
+      makeTab({ targetId: 'target-aaa' }),
+      makeTab({ targetId: 'target-bbb', url: 'https://other.com' }),
+    ];
+    const sm = makeMockSessionManager({
+      getPage: jest.fn().mockRejectedValue(new Error('Chrome disconnected')),
+      getAllSessionInfos: jest.fn().mockReturnValue([]),
+    });
+    (getSessionManager as jest.Mock).mockReturnValue(sm);
+
+    const result = await analyzeTabs(tabs);
+
+    expect(result).toHaveLength(2);
+    expect(result.every(r => r.status === 'CLOSED')).toBe(true);
+  });
+
+  test('handles empty tabs array', async () => {
+    const sm = makeMockSessionManager();
+    (getSessionManager as jest.Mock).mockReturnValue(sm);
+
+    const result = await analyzeTabs([]);
+
+    expect(result).toHaveLength(0);
+  });
+
+  test('analyzes multiple tabs independently', async () => {
+    const liveTab = makeTab({ targetId: 'target-live', url: 'https://live.com' });
+    const closedTab = makeTab({ targetId: 'target-dead', url: 'https://dead.com' });
+
+    const livePage = makeMockPage('https://live.com');
+    const getPageMock = jest.fn()
+      .mockResolvedValueOnce(livePage)        // first tab: exact match -> LIVE
+      .mockRejectedValueOnce(new Error('not found'))  // second tab exact match fails
+      .mockResolvedValue(makeMockPage('https://unrelated.com')); // URL scan: no match
+
+    const sm = makeMockSessionManager({
+      getPage: getPageMock,
+      getAllSessionInfos: jest.fn().mockReturnValue([
+        { id: 'session-111', workers: [{ id: 'default', targetCount: 1 }] },
+      ]),
+      getWorkerTargetIds: jest.fn().mockReturnValue(['target-other']),
+    });
+    (getSessionManager as jest.Mock).mockReturnValue(sm);
+
+    const result = await analyzeTabs([liveTab, closedTab]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].status).toBe('LIVE');
+    expect(result[1].status).toBe('CLOSED');
+  });
+});
+
+// ─── generateResumeGuide ─────────────────────────────────────────────────
+
+describe('generateResumeGuide', () => {
+  test('includes objective and last step', () => {
+    const snap = makeSnapshot() as ReturnType<typeof makeSnapshot>;
+    const guide = generateResumeGuide(snap as any, []);
+
+    expect(guide).toContain('Fill out the registration form');
+    expect(guide).toContain('Submitted form, waiting for confirmation');
+  });
+
+  test('includes snapshot age', () => {
+    const snap = makeSnapshot({ timestamp: Date.now() - 5000 });
+    const guide = generateResumeGuide(snap as any, []);
+
+    expect(guide).toMatch(/Snapshot age: \d+s/);
+  });
+
+  test('includes label when present', () => {
+    const snap = makeSnapshot({ label: 'after-form-submit' });
+    const guide = generateResumeGuide(snap as any, []);
+
+    expect(guide).toContain('after-form-submit');
+  });
+
+  test('shows tab counts correctly', () => {
+    const snap = makeSnapshot();
+    const tabAnalysis = [
+      { saved: makeTab(), status: 'LIVE' as const, currentTargetId: 'target-aaa', currentUrl: 'https://example.com' },
+      { saved: makeTab({ targetId: 'target-bbb' }), status: 'REMAPPED' as const, currentTargetId: 'target-ccc', currentUrl: 'https://example.com' },
+      { saved: makeTab({ targetId: 'target-ddd' }), status: 'CLOSED' as const },
+    ];
+
+    const guide = generateResumeGuide(snap as any, tabAnalysis);
+
+    expect(guide).toContain('1 LIVE');
+    expect(guide).toContain('1 REMAPPED');
+    expect(guide).toContain('1 CLOSED');
+  });
+
+  test('shows LIVE tab with targetId', () => {
+    const snap = makeSnapshot();
+    const tabAnalysis = [
+      { saved: makeTab({ targetId: 'target-aaa', url: 'https://example.com', title: 'My Page' }), status: 'LIVE' as const, currentTargetId: 'target-aaa', currentUrl: 'https://example.com' },
+    ];
+
+    const guide = generateResumeGuide(snap as any, tabAnalysis);
+
+    expect(guide).toContain('LIVE');
+    expect(guide).toContain('target-aaa');
+    expect(guide).toContain('https://example.com');
+    expect(guide).toContain('"My Page"');
+  });
+
+  test('shows REMAPPED tab with old -> new targetId', () => {
+    const snap = makeSnapshot();
+    const tabAnalysis = [
+      {
+        saved: makeTab({ targetId: 'target-old', url: 'https://example.com' }),
+        status: 'REMAPPED' as const,
+        currentTargetId: 'target-new',
+        currentUrl: 'https://example.com',
+      },
+    ];
+
+    const guide = generateResumeGuide(snap as any, tabAnalysis);
+
+    expect(guide).toContain('REMAPPED');
+    expect(guide).toContain('target-old');
+    expect(guide).toContain('target-new');
+  });
+
+  test('shows CLOSED tab with URL', () => {
+    const snap = makeSnapshot();
+    const tabAnalysis = [
+      { saved: makeTab({ url: 'https://closed.example.com' }), status: 'CLOSED' as const },
+    ];
+
+    const guide = generateResumeGuide(snap as any, tabAnalysis);
+
+    expect(guide).toContain('CLOSED');
+    expect(guide).toContain('https://closed.example.com');
+  });
+
+  test('includes completed steps', () => {
+    const snap = makeSnapshot();
+    const guide = generateResumeGuide(snap as any, []);
+
+    expect(guide).toContain('Completed:');
+    expect(guide).toContain('Navigated to form');
+    expect(guide).toContain('Filled in all fields');
+  });
+
+  test('includes next actions with numbering', () => {
+    const snap = makeSnapshot();
+    const guide = generateResumeGuide(snap as any, []);
+
+    expect(guide).toContain('Next actions:');
+    expect(guide).toContain('1. Check confirmation email');
+    expect(guide).toContain('2. Screenshot the result');
+  });
+
+  test('includes notes when present', () => {
+    const snap = makeSnapshot();
+    const guide = generateResumeGuide(snap as any, []);
+
+    expect(guide).toContain('Notes: Use test@example.com');
+  });
+
+  test('omits completed steps section when empty', () => {
+    const snap = makeSnapshot({
+      memo: {
+        objective: 'Do something',
+        currentStep: 'Working',
+        nextActions: ['Step A'],
+        // no completedSteps
+      },
+    });
+    const guide = generateResumeGuide(snap as any, []);
+
+    expect(guide).not.toContain('Completed:');
+  });
+
+  test('omits notes section when absent', () => {
+    const snap = makeSnapshot({
+      memo: {
+        objective: 'Do something',
+        currentStep: 'Working',
+        nextActions: ['Step A'],
+        // no notes
+      },
+    });
+    const guide = generateResumeGuide(snap as any, []);
+
+    expect(guide).not.toContain('Notes:');
+  });
+
+  test('shows stale warning for snapshots over 24 hours old', () => {
+    const snap = makeSnapshot({ timestamp: Date.now() - 25 * 3600000 });
+    const guide = generateResumeGuide(snap as any, []);
+
+    expect(guide).toContain('WARNING');
+    expect(guide).toContain('24 hours');
+  });
+
+  test('does not show stale warning for recent snapshots', () => {
+    const snap = makeSnapshot({ timestamp: Date.now() - 60000 });
+    const guide = generateResumeGuide(snap as any, []);
+
+    expect(guide).not.toContain('WARNING');
+  });
+
+  test('age shown in minutes for snapshots 1-59 min old', () => {
+    const snap = makeSnapshot({ timestamp: Date.now() - 10 * 60000 });
+    const guide = generateResumeGuide(snap as any, []);
+
+    expect(guide).toMatch(/Snapshot age: \d+m/);
+  });
+
+  test('age shown in hours for snapshots 1+ hours old', () => {
+    const snap = makeSnapshot({ timestamp: Date.now() - 2 * 3600000 });
+    const guide = generateResumeGuide(snap as any, []);
+
+    expect(guide).toMatch(/Snapshot age: \d+h/);
+  });
+
+  test('handles empty tabs array gracefully', () => {
+    const snap = makeSnapshot();
+    const guide = generateResumeGuide(snap as any, []);
+
+    expect(guide).toContain('0 LIVE, 0 REMAPPED, 0 CLOSED');
+  });
+});
+
+// ─── Handler ─────────────────────────────────────────────────────────────
+
+describe('oc_session_resume handler', () => {
+  const mockReadFileSync = fs.readFileSync as jest.Mock;
+
+  const getHandler = async () => {
+    jest.resetModules();
+    jest.doMock('fs', () => ({ readFileSync: mockReadFileSync }));
+    jest.doMock('../../src/session-manager', () => ({
+      getSessionManager: getSessionManager,
+    }));
+
+    const { registerSessionResumeTool } = await import('../../src/tools/session-resume');
+
+    const tools: Map<string, { handler: (sessionId: string, args: Record<string, unknown>) => Promise<unknown> }> = new Map();
+    const mockServer = {
+      registerTool: (name: string, handler: unknown) => {
+        tools.set(name, { handler: handler as (sessionId: string, args: Record<string, unknown>) => Promise<unknown> });
+      },
+    };
+
+    registerSessionResumeTool(mockServer as any);
+    return tools.get('oc_session_resume')!.handler;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: no snapshot file
+    mockReadFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
+  });
+
+  test('returns "No snapshot found" when no file exists', async () => {
+    const sm = makeMockSessionManager();
+    (getSessionManager as jest.Mock).mockReturnValue(sm);
+
+    const handler = await getHandler();
+    const result = await handler('session-x', {}) as any;
+
+    expect(result.content[0].text).toContain('No snapshot found');
+    expect(result.content[0].text).toContain('oc_session_snapshot');
+  });
+
+  test('returns "No snapshot found" with snapshotId when specific ID missing', async () => {
+    const sm = makeMockSessionManager();
+    (getSessionManager as jest.Mock).mockReturnValue(sm);
+
+    const handler = await getHandler();
+    const result = await handler('session-x', { snapshotId: 'missing-snap' }) as any;
+
+    expect(result.content[0].text).toContain('No snapshot found');
+    expect(result.content[0].text).toContain('"missing-snap"');
+  });
+
+  test('returns full resume guide when snapshot exists with no tabs', async () => {
+    const snap = makeSnapshot({ tabs: [] });
+    mockReadFileSync.mockReturnValue(JSON.stringify(snap));
+
+    const sm = makeMockSessionManager();
+    (getSessionManager as jest.Mock).mockReturnValue(sm);
+
+    const handler = await getHandler();
+    const result = await handler('session-x', {}) as any;
+
+    expect(result.content[0].text).toContain('CONTEXT RESTORED');
+    expect(result.content[0].text).toContain('Fill out the registration form');
+    expect(result._snapshotId).toBe('snap-abc123');
+  });
+
+  test('includes tab analysis in guide when snapshot has tabs', async () => {
+    const tab = makeTab();
+    const snap = makeSnapshot({ tabs: [tab] });
+    mockReadFileSync.mockReturnValue(JSON.stringify(snap));
+
+    // Chrome connected, tab is LIVE
+    const page = makeMockPage('https://example.com/form');
+    const sm = makeMockSessionManager({
+      getPage: jest.fn().mockResolvedValue(page),
+    });
+    (getSessionManager as jest.Mock).mockReturnValue(sm);
+
+    const handler = await getHandler();
+    const result = await handler('session-x', {}) as any;
+
+    expect(result.content[0].text).toContain('1 LIVE');
+  });
+
+  test('gracefully degrades to CLOSED when Chrome is disconnected', async () => {
+    const tab = makeTab();
+    const snap = makeSnapshot({ tabs: [tab] });
+    mockReadFileSync.mockReturnValue(JSON.stringify(snap));
+
+    // Chrome is disconnected — analyzeTabs throws entirely
+    const sm = makeMockSessionManager({
+      getPage: jest.fn().mockRejectedValue(new Error('CDP disconnected')),
+      getAllSessionInfos: jest.fn().mockImplementation(() => { throw new Error('CDP disconnected'); }),
+    });
+    (getSessionManager as jest.Mock).mockReturnValue(sm);
+
+    const handler = await getHandler();
+    const result = await handler('session-x', {}) as any;
+
+    // Should still return a guide, not crash
+    expect(result.content[0].text).toContain('CONTEXT RESTORED');
+    expect(result.content[0].text).toContain('CLOSED');
+  });
+
+  test('passes snapshotId to loadSnapshot', async () => {
+    const snap = makeSnapshot({ id: 'my-snap' });
+    mockReadFileSync.mockReturnValue(JSON.stringify(snap));
+
+    const sm = makeMockSessionManager();
+    (getSessionManager as jest.Mock).mockReturnValue(sm);
+
+    const handler = await getHandler();
+    await handler('session-x', { snapshotId: 'my-snap' });
+
+    expect(mockReadFileSync).toHaveBeenCalledWith(
+      path.join(SNAPSHOT_DIR, 'my-snap.json'),
+      'utf-8',
+    );
+  });
+});
+
+// ─── registerSessionResumeTool ────────────────────────────────────────────
+
+describe('registerSessionResumeTool', () => {
+  test('registers tool with correct name', () => {
+    const tools: Map<string, unknown> = new Map();
+    const mockServer = {
+      registerTool: jest.fn((name: string, handler: unknown, def: unknown) => {
+        tools.set(name, { handler, def });
+      }),
+    };
+
+    registerSessionResumeTool(mockServer as any);
+
+    expect(mockServer.registerTool).toHaveBeenCalledWith(
+      'oc_session_resume',
+      expect.any(Function),
+      expect.objectContaining({ name: 'oc_session_resume' }),
+    );
+  });
+});

--- a/tests/tools/session-snapshot.test.ts
+++ b/tests/tools/session-snapshot.test.ts
@@ -1,0 +1,498 @@
+/// <reference types="jest" />
+/**
+ * Tests for oc_session_snapshot tool
+ * Part of #355: AI Agent Continuity
+ */
+
+import * as path from 'path';
+import * as os from 'os';
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(),
+}));
+
+jest.mock('../../src/utils/atomic-file', () => ({
+  writeFileAtomicSafe: jest.fn().mockResolvedValue(undefined),
+}));
+
+// fs.promises is mocked selectively per test via jest.spyOn
+import { getSessionManager } from '../../src/session-manager';
+import { writeFileAtomicSafe } from '../../src/utils/atomic-file';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeMockPage(url: string, title: string) {
+  return {
+    url: jest.fn().mockReturnValue(url),
+    title: jest.fn().mockResolvedValue(title),
+    isClosed: jest.fn().mockReturnValue(false),
+  };
+}
+
+function makeMockSessionManager(sessions: Array<{
+  id: string;
+  workers: Array<{ id: string; targetIds: string[] }>;
+  pages?: Record<string, { url: string; title: string }>;
+}>) {
+  const sessionInfos = sessions.map(s => ({
+    id: s.id,
+    name: `Session ${s.id}`,
+    workerCount: s.workers.length,
+    targetCount: s.workers.reduce((sum, w) => sum + w.targetIds.length, 0),
+    createdAt: Date.now(),
+    lastActivityAt: Date.now(),
+    workers: s.workers.map(w => ({
+      id: w.id,
+      name: `Worker ${w.id}`,
+      targetCount: w.targetIds.length,
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    })),
+  }));
+
+  const pagesByTarget: Record<string, ReturnType<typeof makeMockPage>> = {};
+  for (const s of sessions) {
+    for (const w of s.workers) {
+      for (const targetId of w.targetIds) {
+        const pageData = s.pages?.[targetId] ?? { url: 'about:blank', title: '' };
+        pagesByTarget[targetId] = makeMockPage(pageData.url, pageData.title);
+      }
+    }
+  }
+
+  const workerTargetIds: Record<string, Record<string, string[]>> = {};
+  for (const s of sessions) {
+    workerTargetIds[s.id] = {};
+    for (const w of s.workers) {
+      workerTargetIds[s.id][w.id] = w.targetIds;
+    }
+  }
+
+  return {
+    getAllSessionInfos: jest.fn().mockReturnValue(sessionInfos),
+    getWorkerTargetIds: jest.fn().mockImplementation((sessionId: string, workerId: string) => {
+      return workerTargetIds[sessionId]?.[workerId] ?? [];
+    }),
+    getPage: jest.fn().mockImplementation(async (sessionId: string, targetId: string) => {
+      return pagesByTarget[targetId] ?? null;
+    }),
+    _pagesByTarget: pagesByTarget,
+  };
+}
+
+// ─── Handler Factory ─────────────────────────────────────────────────────────
+
+async function getSnapshotHandler() {
+  const { registerSessionSnapshotTool } = await import('../../src/tools/session-snapshot');
+
+  const tools: Map<string, { handler: (sessionId: string, args: Record<string, unknown>) => Promise<unknown> }> = new Map();
+  const mockServer = {
+    registerTool: (name: string, handler: unknown) => {
+      tools.set(name, { handler: handler as (sessionId: string, args: Record<string, unknown>) => Promise<unknown> });
+    },
+  };
+
+  registerSessionSnapshotTool(mockServer as unknown as Parameters<typeof registerSessionSnapshotTool>[0]);
+  return tools.get('oc_session_snapshot')!.handler;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('oc_session_snapshot', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (writeFileAtomicSafe as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  // ── Snapshot ID format ───────────────────────────────────────────────────
+
+  describe('generateSnapshotId', () => {
+    test('returns snap- prefixed string with timestamp and hex suffix', async () => {
+      const { generateSnapshotId } = await import('../../src/tools/session-snapshot');
+      const id = generateSnapshotId();
+      expect(id).toMatch(/^snap-\d{8}-\d{6}-[0-9a-f]{4}$/);
+    });
+
+    test('generates unique IDs on successive calls', async () => {
+      const { generateSnapshotId } = await import('../../src/tools/session-snapshot');
+      const ids = new Set(Array.from({ length: 20 }, () => generateSnapshotId()));
+      // With random hex suffix the probability of collision is negligible
+      expect(ids.size).toBeGreaterThan(1);
+    });
+  });
+
+  // ── Tab collection ───────────────────────────────────────────────────────
+
+  describe('collectTabs', () => {
+    test('returns empty array when no sessions exist', async () => {
+      const mockSM = makeMockSessionManager([]);
+      (getSessionManager as jest.Mock).mockReturnValue(mockSM);
+
+      const { collectTabs } = await import('../../src/tools/session-snapshot');
+      const tabs = await collectTabs();
+      expect(tabs).toEqual([]);
+    });
+
+    test('returns tabs for a single session with one worker', async () => {
+      const mockSM = makeMockSessionManager([
+        {
+          id: 'session-1',
+          workers: [{ id: 'default', targetIds: ['target-1', 'target-2'] }],
+          pages: {
+            'target-1': { url: 'https://example.com', title: 'Example' },
+            'target-2': { url: 'https://google.com', title: 'Google' },
+          },
+        },
+      ]);
+      (getSessionManager as jest.Mock).mockReturnValue(mockSM);
+
+      const { collectTabs } = await import('../../src/tools/session-snapshot');
+      const tabs = await collectTabs();
+
+      expect(tabs).toHaveLength(2);
+      expect(tabs[0]).toMatchObject({
+        targetId: 'target-1',
+        workerId: 'default',
+        sessionId: 'session-1',
+        url: 'https://example.com',
+        title: 'Example',
+      });
+      expect(tabs[1]).toMatchObject({
+        targetId: 'target-2',
+        workerId: 'default',
+        sessionId: 'session-1',
+        url: 'https://google.com',
+        title: 'Google',
+      });
+    });
+
+    test('returns tabs for multiple sessions and workers', async () => {
+      const mockSM = makeMockSessionManager([
+        {
+          id: 'session-1',
+          workers: [
+            { id: 'default', targetIds: ['t1'] },
+            { id: 'worker-2', targetIds: ['t2', 't3'] },
+          ],
+          pages: {
+            't1': { url: 'https://a.com', title: 'A' },
+            't2': { url: 'https://b.com', title: 'B' },
+            't3': { url: 'https://c.com', title: 'C' },
+          },
+        },
+        {
+          id: 'session-2',
+          workers: [{ id: 'default', targetIds: ['t4'] }],
+          pages: { 't4': { url: 'https://d.com', title: 'D' } },
+        },
+      ]);
+      (getSessionManager as jest.Mock).mockReturnValue(mockSM);
+
+      const { collectTabs } = await import('../../src/tools/session-snapshot');
+      const tabs = await collectTabs();
+
+      expect(tabs).toHaveLength(4);
+      const urls = tabs.map(t => t.url);
+      expect(urls).toContain('https://a.com');
+      expect(urls).toContain('https://b.com');
+      expect(urls).toContain('https://c.com');
+      expect(urls).toContain('https://d.com');
+    });
+
+    test('falls back gracefully when session manager throws', async () => {
+      (getSessionManager as jest.Mock).mockImplementation(() => {
+        throw new Error('Not initialized');
+      });
+
+      const { collectTabs } = await import('../../src/tools/session-snapshot');
+      const tabs = await collectTabs();
+      expect(tabs).toEqual([]);
+    });
+
+    test('uses about:blank when page.url() returns empty string', async () => {
+      const mockSM = makeMockSessionManager([
+        {
+          id: 'session-1',
+          workers: [{ id: 'default', targetIds: ['target-1'] }],
+          pages: { 'target-1': { url: '', title: '' } },
+        },
+      ]);
+      // Override the page mock to return empty string for url
+      mockSM._pagesByTarget['target-1'].url.mockReturnValue('');
+      (getSessionManager as jest.Mock).mockReturnValue(mockSM);
+
+      const { collectTabs } = await import('../../src/tools/session-snapshot');
+      const tabs = await collectTabs();
+
+      expect(tabs[0].url).toBe('about:blank');
+    });
+
+    test('handles page.title() throwing by using empty string', async () => {
+      const mockSM = makeMockSessionManager([
+        {
+          id: 'session-1',
+          workers: [{ id: 'default', targetIds: ['target-1'] }],
+          pages: { 'target-1': { url: 'https://example.com', title: 'ignored' } },
+        },
+      ]);
+      mockSM._pagesByTarget['target-1'].title.mockRejectedValue(new Error('page crashed'));
+      (getSessionManager as jest.Mock).mockReturnValue(mockSM);
+
+      const { collectTabs } = await import('../../src/tools/session-snapshot');
+      const tabs = await collectTabs();
+
+      expect(tabs[0].title).toBe('');
+      expect(tabs[0].url).toBe('https://example.com');
+    });
+
+    test('handles getPage returning null gracefully', async () => {
+      const mockSM = makeMockSessionManager([
+        {
+          id: 'session-1',
+          workers: [{ id: 'default', targetIds: ['target-1'] }],
+        },
+      ]);
+      mockSM.getPage.mockResolvedValue(null);
+      (getSessionManager as jest.Mock).mockReturnValue(mockSM);
+
+      const { collectTabs } = await import('../../src/tools/session-snapshot');
+      const tabs = await collectTabs();
+
+      expect(tabs).toHaveLength(1);
+      expect(tabs[0].url).toBe('about:blank');
+      expect(tabs[0].title).toBe('');
+    });
+  });
+
+  // ── File save ────────────────────────────────────────────────────────────
+
+  describe('saveSnapshot', () => {
+    test('writes latest.json and history file atomically', async () => {
+      const { saveSnapshot, SNAPSHOT_DIR } = await import('../../src/tools/session-snapshot');
+
+      // Mock fs.promises.mkdir and readdir for pruneSnapshots
+      jest.spyOn(fs.promises, 'mkdir').mockResolvedValue(undefined);
+      jest.spyOn(fs.promises, 'readdir').mockResolvedValue([] as any);
+
+      const snapshot = {
+        version: 1 as const,
+        id: 'snap-20240101-120000-abcd',
+        timestamp: 1704067200000,
+        tabs: [],
+        memo: {
+          objective: 'Test objective',
+          currentStep: 'Step 1',
+          nextActions: ['Do X', 'Do Y'],
+        },
+      };
+
+      await saveSnapshot(snapshot);
+
+      const calls = (writeFileAtomicSafe as jest.Mock).mock.calls;
+      const paths = calls.map((c: unknown[]) => c[0] as string);
+
+      expect(paths).toContain(path.join(SNAPSHOT_DIR, 'latest.json'));
+      expect(paths).toContain(path.join(SNAPSHOT_DIR, 'snap-20240101-120000-abcd.json'));
+
+      // Both calls should pass the same snapshot object
+      expect(calls[0][1]).toEqual(snapshot);
+      expect(calls[1][1]).toEqual(snapshot);
+    });
+  });
+
+  // ── Prune logic ──────────────────────────────────────────────────────────
+
+  describe('pruneSnapshots', () => {
+    test('removes oldest snapshots when count exceeds MAX_SNAPSHOTS', async () => {
+      const { pruneSnapshots, MAX_SNAPSHOTS, SNAPSHOT_DIR } = await import('../../src/tools/session-snapshot');
+
+      // Generate MAX_SNAPSHOTS + 3 fake snapshot files (sorted lexicographically = chronological)
+      const snapFiles: string[] = [];
+      for (let i = 0; i < MAX_SNAPSHOTS + 3; i++) {
+        snapFiles.push(`snap-2024010${i < 10 ? '0' + i : i}-120000-aaaa.json`);
+      }
+      snapFiles.sort();
+
+      const unlinkMock = jest.spyOn(fs.promises, 'unlink').mockResolvedValue(undefined);
+      jest.spyOn(fs.promises, 'readdir').mockResolvedValue(snapFiles as any);
+      jest.spyOn(fs.promises, 'stat').mockResolvedValue({ mtimeMs: Date.now() } as fs.Stats);
+
+      await pruneSnapshots();
+
+      // Should have deleted the 3 oldest
+      expect(unlinkMock).toHaveBeenCalledTimes(3);
+      const deletedPaths = unlinkMock.mock.calls.map((c: unknown[]) => c[0] as string);
+      for (let i = 0; i < 3; i++) {
+        expect(deletedPaths).toContain(path.join(SNAPSHOT_DIR, snapFiles[i]));
+      }
+    });
+
+    test('removes snapshots older than 30 days', async () => {
+      const { pruneSnapshots, SNAPSHOT_DIR } = await import('../../src/tools/session-snapshot');
+
+      const oldFile = 'snap-20200101-000000-aaaa.json';
+      const newFile = 'snap-20240101-000000-bbbb.json';
+
+      const unlinkMock = jest.spyOn(fs.promises, 'unlink').mockResolvedValue(undefined);
+      jest.spyOn(fs.promises, 'readdir').mockResolvedValue([oldFile, newFile] as any);
+      jest.spyOn(fs.promises, 'stat').mockImplementation(async (filePath) => {
+        const fp = filePath as string;
+        if (fp.includes('20200101')) {
+          return { mtimeMs: Date.now() - (31 * 24 * 60 * 60 * 1000) } as fs.Stats;
+        }
+        return { mtimeMs: Date.now() } as fs.Stats;
+      });
+
+      await pruneSnapshots();
+
+      const deletedPaths = unlinkMock.mock.calls.map((c: unknown[]) => c[0] as string);
+      expect(deletedPaths).toContain(path.join(SNAPSHOT_DIR, oldFile));
+      expect(deletedPaths).not.toContain(path.join(SNAPSHOT_DIR, newFile));
+    });
+
+    test('handles readdir failure gracefully (best-effort)', async () => {
+      const { pruneSnapshots } = await import('../../src/tools/session-snapshot');
+
+      jest.spyOn(fs.promises, 'readdir').mockRejectedValue(new Error('ENOENT'));
+
+      // Should not throw
+      await expect(pruneSnapshots()).resolves.toBeUndefined();
+    });
+  });
+
+  // ── Handler integration ──────────────────────────────────────────────────
+
+  describe('handler', () => {
+    beforeEach(() => {
+      jest.spyOn(fs.promises, 'mkdir').mockResolvedValue(undefined);
+      jest.spyOn(fs.promises, 'readdir').mockResolvedValue([] as any);
+    });
+
+    test('creates snapshot with required memo fields and returns correct text', async () => {
+      const mockSM = makeMockSessionManager([]);
+      (getSessionManager as jest.Mock).mockReturnValue(mockSM);
+
+      const handler = await getSnapshotHandler();
+
+      const result = await handler('session-1', {
+        objective: 'Scrape product data',
+        currentStep: 'Navigating to listing page',
+        nextActions: ['Extract table rows', 'Follow pagination'],
+      }) as { content: Array<{ type: string; text: string }>; _snapshotId: string };
+
+      expect(result.content[0].type).toBe('text');
+      const text = result.content[0].text;
+      expect(text).toContain('Snapshot saved: snap-');
+      expect(text).toContain('Tabs: 0');
+      expect(text).toContain('Objective: Scrape product data');
+      expect(text).toContain('Step: Navigating to listing page');
+      expect(text).toContain('Next: Extract table rows, Follow pagination');
+      expect(text).toContain('Use oc_session_resume to restore this context after compaction.');
+    });
+
+    test('returns _snapshotId in result matching text', async () => {
+      const mockSM = makeMockSessionManager([]);
+      (getSessionManager as jest.Mock).mockReturnValue(mockSM);
+
+      const handler = await getSnapshotHandler();
+
+      const result = await handler('session-1', {
+        objective: 'Test',
+        currentStep: 'Step 1',
+        nextActions: [],
+      }) as { content: Array<{ type: string; text: string }>; _snapshotId: string };
+
+      expect(result._snapshotId).toMatch(/^snap-/);
+      expect(result.content[0].text).toContain(result._snapshotId);
+    });
+
+    test('captures tabs from active sessions', async () => {
+      const mockSM = makeMockSessionManager([
+        {
+          id: 'session-1',
+          workers: [{ id: 'default', targetIds: ['t1', 't2'] }],
+          pages: {
+            't1': { url: 'https://example.com', title: 'Example' },
+            't2': { url: 'https://test.com', title: 'Test' },
+          },
+        },
+      ]);
+      (getSessionManager as jest.Mock).mockReturnValue(mockSM);
+
+      const handler = await getSnapshotHandler();
+
+      const result = await handler('session-1', {
+        objective: 'Test tabs',
+        currentStep: 'Collecting',
+        nextActions: [],
+      }) as { content: Array<{ type: string; text: string }> };
+
+      expect(result.content[0].text).toContain('Tabs: 2');
+    });
+
+    test('includes optional completedSteps and notes in memo', async () => {
+      const mockSM = makeMockSessionManager([]);
+      (getSessionManager as jest.Mock).mockReturnValue(mockSM);
+
+      const handler = await getSnapshotHandler();
+
+      await handler('session-1', {
+        objective: 'Full workflow',
+        currentStep: 'Phase 2',
+        nextActions: ['Action A'],
+        completedSteps: ['Phase 1 done', 'Login complete'],
+        notes: 'Using staging environment',
+        label: 'phase-2-checkpoint',
+      });
+
+      // Verify writeFileAtomicSafe received snapshot with all optional fields
+      const savedSnapshot = (writeFileAtomicSafe as jest.Mock).mock.calls[0][1];
+      expect(savedSnapshot.memo.completedSteps).toEqual(['Phase 1 done', 'Login complete']);
+      expect(savedSnapshot.memo.notes).toBe('Using staging environment');
+      expect(savedSnapshot.label).toBe('phase-2-checkpoint');
+    });
+
+    test('snapshot has correct version, id, and timestamp shape', async () => {
+      const mockSM = makeMockSessionManager([]);
+      (getSessionManager as jest.Mock).mockReturnValue(mockSM);
+
+      const before = Date.now();
+      const handler = await getSnapshotHandler();
+
+      await handler('session-1', {
+        objective: 'Verify shape',
+        currentStep: 'Step A',
+        nextActions: ['Next'],
+      });
+
+      const savedSnapshot = (writeFileAtomicSafe as jest.Mock).mock.calls[0][1];
+      expect(savedSnapshot.version).toBe(1);
+      expect(savedSnapshot.id).toMatch(/^snap-/);
+      expect(savedSnapshot.timestamp).toBeGreaterThanOrEqual(before);
+      expect(savedSnapshot.timestamp).toBeLessThanOrEqual(Date.now());
+    });
+
+    test('works without Chrome connected (tabs = [])', async () => {
+      (getSessionManager as jest.Mock).mockImplementation(() => {
+        throw new Error('Chrome not connected');
+      });
+
+      const handler = await getSnapshotHandler();
+
+      const result = await handler('session-1', {
+        objective: 'Fallback test',
+        currentStep: 'Step 1',
+        nextActions: [],
+      }) as { content: Array<{ type: string; text: string }> };
+
+      // Should succeed with empty tabs
+      expect(result.content[0].text).toContain('Tabs: 0');
+      expect(result.content[0].text).toContain('Snapshot saved:');
+    });
+  });
+});
+
+// Need fs import for spyOn
+import * as fs from 'fs';


### PR DESCRIPTION
## Summary

Implement `oc_session_snapshot`, `oc_session_resume`, and `oc_journal` MCP tools that enable AI agents to persist and restore working context across Claude Code context compaction events. This is OpenChrome's primary differentiation — **no competing project has solved the compaction recovery problem**.

Closes #355, closes #356

## Problem

When Claude Code performs context compaction:
- The MCP server stays alive with all browser tabs open
- But the AI agent **loses**: tab IDs, current step, progress, intermediate data
- The agent must restart from scratch, wasting time re-navigating and re-authenticating

## Solution: 3 New MCP Tools

### `oc_session_snapshot` — Save state before it's lost
- Captures open tabs (targetId, URL, title, worker, session)
- Accepts agent memo (objective, currentStep, nextActions, completedSteps, notes)
- Saves atomically to `~/.openchrome/snapshots/` with history (max 10, 30-day auto-prune)
- Works without Chrome connection (graceful fallback: `tabs=[]`)

### `oc_session_resume` — Restore state after compaction
- Reads latest or specific snapshot from disk
- Cross-references saved tabs with live browser state
- Classifies each tab as **LIVE** (exact match), **REMAPPED** (URL match, new targetId), or **CLOSED**
- Generates structured resume guide:
```
=== CONTEXT RESTORED ===

Objective: Scrape product prices from 3 sites
Last step: Completed site 1, starting site 2

Tabs: 1 LIVE, 1 REMAPPED, 1 CLOSED
  🟢 LIVE     tab-abc https://site1.com/products
  🔄 REMAPPED tab-old → tab-new https://site2.com/login
  🔴 CLOSED   https://site3.com

Completed:
  ✓ Login to site1
  ✓ Extract site1 prices

Next actions:
  1. Navigate to site2.com
  2. Extract price table
```

### `oc_journal` — Automatic tool call tracking
- Records every MCP tool call to daily JSONL files (`~/.openchrome/journal/`)
- Sanitizes sensitive args (passwords, tokens, cookies → `[REDACTED]`)
- Marks milestone tools (navigate, fill_form, workflow_init, etc.)
- Query actions: `summary` (milestone overview) and `recent` (last N entries)
- Auto-prunes files older than 7 days

## Integration

- All 3 tools in `SKIP_SESSION_INIT_TOOLS` (work without Chrome connection)
- Journal recording wired into `handleToolsCall()` for automatic tracking
- All tools assigned to Tier 1 (always exposed)

## Test plan

- [x] Build passes — 0 errors
- [x] All 2071 tests pass across 103 suites (+123 new tests)
- [x] Session snapshot: 19 tests (tab collection, file management, pruning, handler)
- [x] Session resume: 35 tests (LIVE/REMAPPED/CLOSED analysis, guide generation, edge cases)
- [x] Task journal core: 28 tests (record/read, sanitization, summaries, milestones, pruning)
- [x] Journal query tool: 18 tests (summary format, recent entries, filters, parseSince)
- [x] All tools work without Chrome (graceful degradation)

## Files changed (11)

| Type | File | Description |
|------|------|-------------|
| NEW | `src/journal/task-journal.ts` | Journal core writer + singleton |
| NEW | `src/tools/session-snapshot.ts` | Snapshot tool + tab collection |
| NEW | `src/tools/session-resume.ts` | Resume tool + tab analysis + guide |
| NEW | `src/tools/journal.ts` | Journal query tool |
| MOD | `src/tools/index.ts` | Register 3 new tools |
| MOD | `src/config/tool-tiers.ts` | Tier 1 assignment |
| MOD | `src/mcp-server.ts` | Journal recording + SKIP_SESSION_INIT_TOOLS |
| NEW | `tests/journal/task-journal.test.ts` | 28 tests |
| NEW | `tests/tools/session-snapshot.test.ts` | 19 tests |
| NEW | `tests/tools/session-resume.test.ts` | 35 tests |
| NEW | `tests/tools/journal.test.ts` | 18 tests |

## Architecture

```
Agent                    OpenChrome MCP              File System
  |                          |                           |
  |- oc_session_snapshot --->|-- collect tabs + memo ---->| snapshots/latest.json
  |                          |                           |
  +== COMPACTION ================================================+
  |                          |                           |
  |- oc_session_resume ----->|-- read snapshot ----------|
  |                          |-- cross-ref live state    |
  |<-- resume guide ---------|                           |
  |                          |                           |
  |- oc_journal summary ---->|-- read JSONL -------------|
  |<-- milestone overview ---|                           |
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)