### PR TITLE
fix: improve stealth mode to reduce Turnstile detection

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -1217,7 +1217,7 @@ export class CDPClient {
    * @param settleMs Milliseconds to wait before attaching CDP (default 5000, range 1000-30000)
    * @returns        The Puppeteer Page and its targetId
    */
-  async createTargetStealth(url: string, settleMs: number = 5000): Promise<{ page: Page; targetId: string }> {
+  async createTargetStealth(url: string, settleMs: number = 8000): Promise<{ page: Page; targetId: string }> {
     const browser = this.getBrowser();
 
     // Step 1: Create target via CDP Target.createTarget.
@@ -1236,6 +1236,16 @@ export class CDPClient {
     }
 
     console.error(`[CDPClient] Stealth tab created: ${targetId}, settling for ${settleMs}ms`);
+
+    // Warn if headless — Turnstile detection is nearly guaranteed in headless mode
+    try {
+      const version = await browser.version();
+      if (version.toLowerCase().includes('headless')) {
+        console.error('[CDPClient] WARNING: Stealth mode in headless Chrome is unlikely to bypass Turnstile. Use headed Chrome (--visible) for anti-bot pages.');
+      }
+    } catch {
+      // Version check failed — continue
+    }
 
     // Step 2: Wait for the page to load without CDP observation (Turnstile runs here)
     await new Promise<void>(resolve => setTimeout(resolve, settleMs));
@@ -1350,6 +1360,40 @@ export class CDPClient {
           get: () => ['en-US', 'en'],
           configurable: true,
         });
+      }
+
+      // 6. window dimensions — headless Chrome returns 0
+      if (window.outerWidth === 0) {
+        Object.defineProperty(window, 'outerWidth', { get: () => window.innerWidth, configurable: true });
+      }
+      if (window.outerHeight === 0) {
+        Object.defineProperty(window, 'outerHeight', { get: () => window.innerHeight + 85, configurable: true });
+      }
+
+      // 7. navigator.mimeTypes — headless has 0 mimeTypes
+      if (navigator.mimeTypes.length === 0) {
+        Object.defineProperty(navigator, 'mimeTypes', {
+          get: () => {
+            const mt = typeof MimeTypeArray !== 'undefined' ? Object.create(MimeTypeArray.prototype) : [];
+            mt[0] = { type: 'application/pdf', suffixes: 'pdf', description: 'Portable Document Format' };
+            Object.defineProperty(mt, 'length', { value: 1 });
+            mt.item = (i: number) => mt[i] || null;
+            mt.namedItem = (name: string) => name === 'application/pdf' ? mt[0] : null;
+            return mt;
+          },
+          configurable: true,
+        });
+      }
+
+      // 8. chrome.app and chrome.loadTimes stubs
+      if ((window as any).chrome) {
+        const c = (window as any).chrome;
+        if (!c.app) {
+          c.app = { isInstalled: false, getDetails: () => null, getIsInstalled: () => false, installState: () => 'disabled' };
+        }
+        if (!c.loadTimes) {
+          c.loadTimes = () => ({});
+        }
       }
     }).catch(() => {});
 
@@ -1472,6 +1516,43 @@ export class CDPClient {
           get: () => ['en-US', 'en'],
           configurable: true,
         });
+      }
+    }).catch(() => {});
+
+    // Defense 4: window dimensions + chrome stubs (anti-headless, #361)
+    page.evaluateOnNewDocument(() => {
+      // outerWidth/outerHeight — headless Chrome returns 0
+      if (window.outerWidth === 0) {
+        Object.defineProperty(window, 'outerWidth', { get: () => window.innerWidth, configurable: true });
+      }
+      if (window.outerHeight === 0) {
+        Object.defineProperty(window, 'outerHeight', { get: () => window.innerHeight + 85, configurable: true });
+      }
+
+      // navigator.mimeTypes — headless has 0 mimeTypes
+      if (navigator.mimeTypes.length === 0) {
+        Object.defineProperty(navigator, 'mimeTypes', {
+          get: () => {
+            const mt = typeof MimeTypeArray !== 'undefined' ? Object.create(MimeTypeArray.prototype) : [];
+            mt[0] = { type: 'application/pdf', suffixes: 'pdf', description: 'Portable Document Format' };
+            Object.defineProperty(mt, 'length', { value: 1 });
+            mt.item = (i: number) => mt[i] || null;
+            mt.namedItem = (name: string) => name === 'application/pdf' ? mt[0] : null;
+            return mt;
+          },
+          configurable: true,
+        });
+      }
+
+      // chrome.app and chrome.loadTimes stubs
+      if ((window as any).chrome) {
+        const c = (window as any).chrome;
+        if (!c.app) {
+          c.app = { isInstalled: false, getDetails: () => null, getIsInstalled: () => false, installState: () => 'disabled' };
+        }
+        if (!c.loadTimes) {
+          c.loadTimes = () => ({});
+        }
       }
     }).catch(() => {});
 

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -212,3 +212,9 @@ export const DEFAULT_HEARTBEAT_IDLE_TIMEOUT_MS = 300000;
 /** Recovery mode duration in milliseconds.
  *  How long to use fast heartbeat (1s) after reconnection before switching to active. */
 export const DEFAULT_HEARTBEAT_RECOVERY_DURATION_MS = 30000;
+
+/** Stealth navigation settle time in milliseconds.
+ *  How long to wait with no CDP attached before attaching to the page.
+ *  Turnstile challenges typically complete in 6-8 seconds.
+ *  Override with stealthSettleMs parameter on navigate tool. */
+export const DEFAULT_STEALTH_SETTLE_MS = 8000;

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -863,7 +863,7 @@ export class SessionManager {
     sessionId: string,
     url: string,
     workerId?: string,
-    settleMs: number = 5000
+    settleMs: number = 8000
   ): Promise<{ targetId: string; page: Page; workerId: string }> {
     await this.ensureConnected();
 

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -38,7 +38,7 @@ const definition: MCPToolDefinition = {
       },
       stealthSettleMs: {
         type: 'number',
-        description: 'How long to wait (ms) before attaching CDP in stealth mode. Default: 5000. Range: 1000-30000.',
+        description: 'How long to wait (ms) before attaching CDP in stealth mode. Default: 8000. Range: 1000-30000.',
       },
     },
     required: ['url'],
@@ -53,7 +53,7 @@ const handler: ToolHandler = async (
   const url = args.url as string;
   const workerId = args.workerId as string | undefined;
   const stealth = args.stealth as boolean | undefined;
-  const stealthSettleMs = Math.min(Math.max((args.stealthSettleMs as number) || 5000, 1000), 30000);
+  const stealthSettleMs = Math.min(Math.max((args.stealthSettleMs as number) || 8000, 1000), 30000);
   const stealthIgnoredWarning = stealth && tabId ? 'stealth mode only works when creating new tabs (omit tabId). The stealth parameter was ignored for this navigation.' : undefined;
   const sessionManager = getSessionManager();
 

--- a/tests/stealth/stealth-defenses.test.ts
+++ b/tests/stealth/stealth-defenses.test.ts
@@ -74,9 +74,9 @@ describe('Stealth: configurePageDefenses source verification', () => {
       : clientSource.slice(methodStart);
   });
 
-  test('configurePageDefenses has exactly 3 evaluateOnNewDocument calls', () => {
+  test('configurePageDefenses has at least 4 evaluateOnNewDocument calls', () => {
     const evalCalls = (defenseBlock.match(/evaluateOnNewDocument/g) || []).length;
-    expect(evalCalls).toBe(3);
+    expect(evalCalls).toBeGreaterThanOrEqual(4);
   });
 
   test('stealth script covers all key fingerprinting vectors', () => {
@@ -87,10 +87,10 @@ describe('Stealth: configurePageDefenses source verification', () => {
     expect(defenseBlock).toContain('window.print');
   });
 
-  test('comment accurately describes chrome.runtime patching', () => {
-    expect(defenseBlock).not.toContain('chrome.csi');
-    expect(defenseBlock).not.toContain('chrome.loadTimes');
+  test('defense block includes chrome.runtime, chrome.app, and chrome.loadTimes stubs', () => {
     expect(defenseBlock).toContain('chrome.runtime');
+    expect(defenseBlock).toContain('chrome.app');
+    expect(defenseBlock).toContain('chrome.loadTimes');
   });
 
   test('Permissions API returns EventTarget-based PermissionStatus', () => {

--- a/tests/tools/navigate-stealth.test.ts
+++ b/tests/tools/navigate-stealth.test.ts
@@ -96,7 +96,7 @@ describe('NavigateTool - Stealth Mode', () => {
       expect((mockSessionManager as any).createTargetStealth).not.toHaveBeenCalled();
     });
 
-    test('stealth mode passes default settleMs of 5000', async () => {
+    test('stealth mode passes default settleMs of 8000', async () => {
       const handler = await getNavigateHandler();
 
       await handler(testSessionId, {
@@ -108,7 +108,7 @@ describe('NavigateTool - Stealth Mode', () => {
         testSessionId,
         'https://example.com',
         undefined,
-        5000
+        8000
       );
     });
 
@@ -196,7 +196,7 @@ describe('NavigateTool - Stealth Mode', () => {
         testSessionId,
         'https://example.com',
         'worker-1',
-        5000
+        8000
       );
     });
 
@@ -212,7 +212,7 @@ describe('NavigateTool - Stealth Mode', () => {
         testSessionId,
         'https://example.com',
         undefined,
-        5000
+        8000
       );
     });
   });
@@ -235,7 +235,7 @@ describe('NavigateTool - Stealth Mode', () => {
         testSessionId,
         'https://turnstile-protected.com',
         undefined,
-        5000
+        8000
       );
       expect(mockSmartGotoFn).not.toHaveBeenCalled();
     });
@@ -295,7 +295,7 @@ describe('NavigateTool - Stealth Mode', () => {
         testSessionId,
         'https://turnstile-protected.com',
         'worker-stealth',
-        5000
+        8000
       );
       expect(mockSmartGotoFn).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary

Enhance stealth navigation mode with additional fingerprint defenses to reduce Cloudflare Turnstile detection rate.

Refs #361, refs #359

## Changes

### New Fingerprint Defenses

| Defense | Detection Vector | Impact |
|---------|-----------------|--------|
| `window.outerWidth/outerHeight` patch | Headless returns 0 | HIGH |
| `navigator.mimeTypes` consistency | Headless has 0 mimeTypes | MEDIUM |
| `chrome.app` stub | Missing in automation | MEDIUM |
| `chrome.loadTimes` stub | Missing in automation | LOW |

### Settle Time: 5000ms -> 8000ms

Turnstile JS challenge takes 6-8s. Default increased across navigate tool, SessionManager, and CDPClient.

### Headless Warning

Logs warning when stealth mode used with headless Chrome.

## E2E Success Criteria

### Automated

- [x] configurePageDefenses has 4+ evaluateOnNewDocument calls
- [x] Defense includes outerWidth/outerHeight, mimeTypes, chrome.app, chrome.loadTimes
- [x] Default stealthSettleMs is 8000ms in all locations
- [x] Post-attach page.evaluate includes all new patches
- [x] Headless warning present in createTargetStealth

### Manual Verification

| # | Condition | Pass Criteria |
|---|-----------|---------------|
| M1 | Headed + residential IP + stealth | Turnstile passes >= 70% |
| M2 | Headless mode | Warning logged, failure expected |
| M3 | Custom stealthSettleMs: 12000 | Respects custom value |

## Test plan

- [x] Build passes
- [x] 28 stealth tests pass
- [x] 2082/2083 total (1 pre-existing flaky timeout)

Generated with [Claude Code](https://claude.com/claude-code)