### PR TITLE
fix: prevent navigation hang on DNS errors and block non-http URL schemes

### DIFF
--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -69,6 +69,17 @@ const handler: ToolHandler = async (
     try {
       // Normalize URL first
       let targetUrl = url;
+      // Detect non-http schemes before normalization to prevent https:// prepending
+      const schemeMatch = targetUrl.match(/^([a-z][a-z0-9+.-]*):\/\//i);
+      if (schemeMatch && !['http', 'https'].includes(schemeMatch[1].toLowerCase())) {
+        return {
+          content: [{
+            type: 'text',
+            text: `Navigation error: "${schemeMatch[1]}://" URLs are not supported. Only http:// and https:// URLs can be navigated.`,
+          }],
+          isError: true,
+        };
+      }
       if (!targetUrl.startsWith('http://') && !targetUrl.startsWith('https://')) {
         targetUrl = 'https://' + targetUrl;
       }
@@ -116,7 +127,11 @@ const handler: ToolHandler = async (
         if (await sessionManager.isTargetValid(existingTabId)) {
           const page = await sessionManager.getPage(sessionId, existingTabId, undefined, 'navigate');
           if (page) {
-            const { authRedirect } = await smartGoto(page, targetUrl, { timeout: DEFAULT_NAVIGATION_TIMEOUT_MS });
+            const { authRedirect } = await withTimeout(
+              smartGoto(page, targetUrl, { timeout: DEFAULT_NAVIGATION_TIMEOUT_MS }),
+              DEFAULT_NAVIGATION_TIMEOUT_MS + 5000,
+              `navigate to ${targetUrl}`
+            );
             if (authRedirect) {
               AdaptiveScreenshot.getInstance().reset(existingTabId);
               return {
@@ -327,6 +342,17 @@ const handler: ToolHandler = async (
 
     // Normalize URL
     let targetUrl = url;
+    // Detect non-http schemes before normalization to prevent https:// prepending
+    const schemeMatch = targetUrl.match(/^([a-z][a-z0-9+.-]*):\/\//i);
+    if (schemeMatch && !['http', 'https'].includes(schemeMatch[1].toLowerCase())) {
+      return {
+        content: [{
+          type: 'text',
+          text: `Navigation error: "${schemeMatch[1]}://" URLs are not supported. Only http:// and https:// URLs can be navigated.`,
+        }],
+        isError: true,
+      };
+    }
     if (!targetUrl.startsWith('http://') && !targetUrl.startsWith('https://')) {
       targetUrl = 'https://' + targetUrl;
     }
@@ -376,7 +402,11 @@ const handler: ToolHandler = async (
     assertDomainAllowed(targetUrl);
 
     // Navigate with smart auth redirect detection
-    const { authRedirect } = await smartGoto(page, targetUrl, { timeout: DEFAULT_NAVIGATION_TIMEOUT_MS });
+    const { authRedirect } = await withTimeout(
+      smartGoto(page, targetUrl, { timeout: DEFAULT_NAVIGATION_TIMEOUT_MS }),
+      DEFAULT_NAVIGATION_TIMEOUT_MS + 5000,
+      `navigate to ${targetUrl}`
+    );
 
     // Auth redirect = fail-fast with clear error
     if (authRedirect) {


### PR DESCRIPTION
## Summary

- **Bug #3 (HIGH):** Wrap all `smartGoto()` calls in `navigate.ts` with `withTimeout()` (35s outer fence) to prevent MCP server hang on DNS resolution errors. Previously, `page.goto()` could hang indefinitely past its own 30s timeout due to Puppeteer lifecycle watcher races.
- **Bug #2 (MEDIUM):** Add scheme detection before URL normalization to block `chrome://`, `file://`, and other non-http schemes with a clear error message. Previously, `chrome://crash` was silently rewritten to `https://chrome://crash`.

## Test plan

- [ ] `navigate({ url: 'https://this-domain-does-not-exist.invalid' })` returns error within 35s (not hang)
- [ ] Server remains responsive after DNS error
- [ ] `navigate({ url: 'chrome://crash' })` returns clear error: "chrome:// URLs are not supported"
- [ ] `navigate({ url: 'file:///etc/passwd' })` returns clear error
- [ ] Normal navigation still works: `navigate({ url: 'https://example.com' })`
- [ ] `npm run build` passes

Closes part of #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)