### PR TITLE
feat(pool): add profile-aware Chrome instance management

### DIFF
--- a/src/chrome/pool.ts
+++ b/src/chrome/pool.ts
@@ -18,6 +18,7 @@ export interface PooledInstance {
   origins: Set<string>;  // origins currently using this instance
   tabCount: number;
   isPreExisting: boolean; // was it already running when we found it?
+  profileDirectory?: string; // Chrome profile directory (e.g., "Profile 1", "Default")
 }
 
 const DEFAULT_POOL_CONFIG: ChromePoolConfig = {
@@ -119,6 +120,46 @@ export class ChromePool {
   }
 
   /**
+   * Acquire a Chrome instance running a specific profile.
+   * Returns an existing instance if one is already running this profile,
+   * otherwise launches a new Chrome process with --profile-directory.
+   */
+  async acquireInstanceForProfile(profileDirectory: string, origin?: string): Promise<PooledInstance> {
+    // 1. Find an existing instance already running this profile
+    for (const [, instance] of this.instances) {
+      if (instance.profileDirectory === profileDirectory) {
+        if (origin) {
+          instance.origins.add(origin);
+        }
+        instance.tabCount++;
+        console.error(
+          `[ChromePool] Reusing existing instance on port ${instance.port} for profile "${profileDirectory}"`
+        );
+        return instance;
+      }
+    }
+
+    // 2. No instance with this profile — launch a new one
+    if (this.instances.size >= this.config.maxInstances) {
+      throw new Error(
+        `[ChromePool] Cannot launch Chrome for profile "${profileDirectory}": ` +
+        `pool is at max capacity (${this.config.maxInstances} instances). ` +
+        `Close unused profiles first.`
+      );
+    }
+
+    const newInstance = await this.launchNewInstance(profileDirectory);
+    if (origin) {
+      newInstance.origins.add(origin);
+    }
+    newInstance.tabCount++;
+    console.error(
+      `[ChromePool] Launched new instance on port ${newInstance.port} for profile "${profileDirectory}"`
+    );
+    return newInstance;
+  }
+
+  /**
    * Mark that an origin is no longer using a port.
    */
   releaseInstance(port: number, origin: string): void {
@@ -169,13 +210,14 @@ export class ChromePool {
   // Private helpers
   // ---------------------------------------------------------------------------
 
-  private async launchNewInstance(): Promise<PooledInstance> {
+  private async launchNewInstance(profileDirectory?: string): Promise<PooledInstance> {
     const port = this.nextAvailablePort();
     const launcher = new ChromeLauncher(port);
 
     const launchOptions: LaunchOptions = {
       port,
       autoLaunch: this.config.autoLaunch,
+      ...(profileDirectory && { profileDirectory }),
     };
 
     let isPreExisting = false;
@@ -199,6 +241,7 @@ export class ChromePool {
       origins: new Set(),
       tabCount: 0,
       isPreExisting,
+      profileDirectory,
     };
 
     this.instances.set(port, pooled);

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -146,6 +146,17 @@ export class SessionManager {
   }
 
   /**
+   * Lazily initialize ChromePool when needed (e.g., first multi-profile request).
+   */
+  private ensurePool(): ChromePool {
+    if (!this.chromePool) {
+      this.chromePool = getChromePool({ autoLaunch: getGlobalConfig().autoLaunch });
+      console.error('[SessionManager] ChromePool lazily initialized for multi-profile support');
+    }
+    return this.chromePool;
+  }
+
+  /**
    * Get the CDPClient for a specific worker (may be on a different Chrome instance)
    */
   private getCDPClientForWorker(sessionId: string, workerId: string): CDPClient {
@@ -505,17 +516,43 @@ export class SessionManager {
       ? null
       : await this.cdpClient.createBrowserContext();
 
-    // If pool is enabled and targetUrl provided, acquire a separate Chrome instance
+    // Acquire a Chrome instance from the pool when:
+    // 1. profileDirectory is specified (multi-profile: lazily init pool)
+    // 2. Pool is enabled and targetUrl is provided (origin isolation)
     let workerPort: number | undefined;
     let workerPoolOrigin: string | undefined;
-    if (this.chromePool && options.targetUrl) {
+    let workerProfileDirectory: string | undefined;
+
+    if (options.profileDirectory) {
+      // Multi-profile: lazily enable pool and acquire profile-specific instance
+      try {
+        const pool = this.ensurePool();
+        const origin = options.targetUrl ? new URL(options.targetUrl).origin : undefined;
+        const poolInstance = await pool.acquireInstanceForProfile(options.profileDirectory, origin);
+        workerPort = poolInstance.port;
+        workerPoolOrigin = origin;
+        workerProfileDirectory = options.profileDirectory;
+
+        const workerCdpClient = this.cdpFactory.getOrCreate(workerPort, {
+          autoLaunch: getGlobalConfig().autoLaunch,
+        });
+        if (!workerCdpClient.isConnected()) {
+          await workerCdpClient.connect();
+        }
+
+        console.error(`[SessionManager] Worker ${workerId} assigned to profile "${options.profileDirectory}" on port ${workerPort}`);
+      } catch (err) {
+        console.error(`[SessionManager] Profile acquisition failed for "${options.profileDirectory}":`, err);
+        throw err; // Propagate — caller explicitly requested a profile
+      }
+    } else if (this.chromePool && options.targetUrl) {
+      // Origin isolation: existing pool behavior
       try {
         const origin = new URL(options.targetUrl).origin;
         const poolInstance = await this.chromePool.acquireInstance(origin);
         workerPort = poolInstance.port;
         workerPoolOrigin = origin;
 
-        // Ensure CDPClient for this port is connected
         const workerCdpClient = this.cdpFactory.getOrCreate(workerPort, {
           autoLaunch: getGlobalConfig().autoLaunch,
         });
@@ -540,6 +577,7 @@ export class SessionManager {
       lastActivityAt: Date.now(),
       port: workerPort,
       poolOrigin: workerPoolOrigin,
+      profileDirectory: workerProfileDirectory,
     };
 
     session.workers.set(workerId, worker);
@@ -568,7 +606,7 @@ export class SessionManager {
   /**
    * Get or create a worker
    */
-  async getOrCreateWorker(sessionId: string, workerId?: string): Promise<Worker> {
+  async getOrCreateWorker(sessionId: string, workerId?: string, options?: { profileDirectory?: string; targetUrl?: string }): Promise<Worker> {
     const session = await this.getOrCreateSession(sessionId);
 
     // If no workerId specified, use default worker
@@ -576,7 +614,11 @@ export class SessionManager {
 
     let worker = session.workers.get(targetWorkerId);
     if (!worker) {
-      worker = await this.createWorker(sessionId, { id: targetWorkerId });
+      worker = await this.createWorker(sessionId, {
+        id: targetWorkerId,
+        ...(options?.profileDirectory && { profileDirectory: options.profileDirectory }),
+        ...(options?.targetUrl && { targetUrl: options.targetUrl }),
+      });
     }
 
     return worker;
@@ -691,11 +733,12 @@ export class SessionManager {
   async createTarget(
     sessionId: string,
     url?: string,
-    workerId?: string
+    workerId?: string,
+    profileDirectory?: string
   ): Promise<{ targetId: string; page: Page; workerId: string }> {
     let createTargetTid: ReturnType<typeof setTimeout>;
     return Promise.race([
-      this._createTargetImpl(sessionId, url, workerId).finally(() => clearTimeout(createTargetTid)),
+      this._createTargetImpl(sessionId, url, workerId, profileDirectory).finally(() => clearTimeout(createTargetTid)),
       new Promise<never>((_, reject) => {
         createTargetTid = setTimeout(() => reject(new Error(`createTarget timed out after ${DEFAULT_CREATE_TARGET_TIMEOUT_MS}ms`)), DEFAULT_CREATE_TARGET_TIMEOUT_MS);
       }),
@@ -705,11 +748,15 @@ export class SessionManager {
   private async _createTargetImpl(
     sessionId: string,
     url?: string,
-    workerId?: string
+    workerId?: string,
+    profileDirectory?: string
   ): Promise<{ targetId: string; page: Page; workerId: string }> {
     await this.ensureConnected();
 
-    const worker = await this.getOrCreateWorker(sessionId, workerId);
+    const worker = await this.getOrCreateWorker(sessionId, workerId, {
+      profileDirectory,
+      targetUrl: url,
+    });
 
     // Enforce per-worker tab limit: close oldest tab when limit reached
     if (worker.targets.size >= this.config.maxTargetsPerWorker) {
@@ -863,11 +910,15 @@ export class SessionManager {
     sessionId: string,
     url: string,
     workerId?: string,
-    settleMs: number = 8000
+    settleMs: number = 8000,
+    profileDirectory?: string
   ): Promise<{ targetId: string; page: Page; workerId: string }> {
     await this.ensureConnected();
 
-    const worker = await this.getOrCreateWorker(sessionId, workerId);
+    const worker = await this.getOrCreateWorker(sessionId, workerId, {
+      profileDirectory,
+      targetUrl: url,
+    });
 
     // Enforce per-worker tab limit: close oldest tab when limit reached
     if (worker.targets.size >= this.config.maxTargetsPerWorker) {

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -16,8 +16,9 @@ export interface Worker {
   context: BrowserContext | null;  // null = use default browser context (shares Chrome profile cookies)
   createdAt: number;
   lastActivityAt: number;
-  port?: number;         // Chrome instance port (when using pool)
-  poolOrigin?: string;   // Origin used for pool allocation
+  port?: number;              // Chrome instance port (when using pool)
+  poolOrigin?: string;        // Origin used for pool allocation
+  profileDirectory?: string;  // Chrome profile directory (when using multi-profile)
 }
 
 export interface WorkerInfo {
@@ -31,8 +32,9 @@ export interface WorkerInfo {
 export interface WorkerCreateOptions {
   id?: string;
   name?: string;
-  shareCookies?: boolean;  // If true, use default browser context (shares Chrome profile cookies) instead of isolated context
-  targetUrl?: string;      // URL for origin-aware Chrome instance selection
+  shareCookies?: boolean;       // If true, use default browser context (shares Chrome profile cookies) instead of isolated context
+  targetUrl?: string;           // URL for origin-aware Chrome instance selection
+  profileDirectory?: string;    // Chrome profile directory for multi-profile support
 }
 
 export interface Session {


### PR DESCRIPTION
## Summary

- Add `acquireInstanceForProfile()` to `ChromePool` for profile-specific Chrome instance routing — reuses existing instances matching the requested profile or launches a new Chrome process with `--profile-directory`
- Add `ensurePool()` to `SessionManager` for lazy `ChromePool` initialization on first multi-profile request (no config flag needed)
- Thread `profileDirectory` through `createWorker()` → `createTarget()` → `createTargetStealth()` so MCP tools can request specific Chrome profiles
- Update `Worker` and `WorkerCreateOptions` types with `profileDirectory` field

This is the core infrastructure for #369. The MCP tool interface (Phase 2) and UX updates (Phase 4/5) follow in a stacked PR.

## Test plan

- [x] `npm run build` passes
- [x] All 2083 unit tests pass — zero regressions
- [ ] Manual: start server, call `navigate` without `profileDirectory` — existing behavior unchanged
- [ ] Manual: call `navigate` with `profileDirectory: "Profile 1"` — new Chrome instance launches on separate port with correct profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)