### PR TITLE
feat(tools): add profileDirectory parameter to MCP tools

### DIFF
--- a/src/tools/list-profiles.ts
+++ b/src/tools/list-profiles.ts
@@ -63,7 +63,8 @@ const handler: ToolHandler = async (
     }
 
     lines.push('');
-    lines.push('To use a specific profile, restart the server with --profile-directory "<directory>" (e.g., --profile-directory "Profile 1").');
+    lines.push('To use a specific profile, pass profileDirectory to navigate or tabs_create (e.g., navigate({ url: "...", profileDirectory: "Profile 1" })). Each profile runs in its own Chrome instance.');
+    lines.push('Alternatively, set the server default with --profile-directory "<directory>" at startup.');
 
     return {
       content: [

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -40,6 +40,10 @@ const definition: MCPToolDefinition = {
         type: 'number',
         description: 'How long to wait (ms) before attaching CDP in stealth mode. Default: 8000. Range: 1000-30000.',
       },
+      profileDirectory: {
+        type: 'string',
+        description: 'Chrome profile directory name (e.g., "Profile 1"). Use list_profiles to see available profiles. Launches a separate Chrome instance for each profile. If omitted, uses the server default.',
+      },
     },
     required: ['url'],
   },
@@ -51,7 +55,9 @@ const handler: ToolHandler = async (
 ): Promise<MCPResult> => {
   const tabId = args.tabId as string | undefined;
   const url = args.url as string;
-  const workerId = args.workerId as string | undefined;
+  const profileDirectory = args.profileDirectory as string | undefined;
+  // Auto-generate a profile-scoped workerId when profileDirectory is specified without explicit workerId
+  const workerId = (args.workerId as string | undefined) || (profileDirectory ? `profile:${profileDirectory}` : undefined);
   const stealth = args.stealth as boolean | undefined;
   const stealthSettleMs = Math.min(Math.max((args.stealthSettleMs as number) || 8000, 1000), 30000);
   const stealthIgnoredWarning = stealth && tabId ? 'stealth mode only works when creating new tabs (omit tabId). The stealth parameter was ignored for this navigation.' : undefined;
@@ -194,8 +200,8 @@ const handler: ToolHandler = async (
       // Create new tab with URL directly (in specified worker or default)
       // Use stealth mode (CDP-free load) when requested, e.g. for Cloudflare Turnstile pages
       const { targetId, page, workerId: assignedWorkerId } = stealth
-        ? await sessionManager.createTargetStealth(sessionId, targetUrl, workerId, stealthSettleMs)
-        : await sessionManager.createTarget(sessionId, targetUrl, workerId);
+        ? await sessionManager.createTargetStealth(sessionId, targetUrl, workerId, stealthSettleMs, profileDirectory)
+        : await sessionManager.createTarget(sessionId, targetUrl, workerId, profileDirectory);
 
       AdaptiveScreenshot.getInstance().reset(targetId);
       const [newTabSummary, newTabBlocking] = await Promise.all([

--- a/src/tools/profile-status.ts
+++ b/src/tools/profile-status.ts
@@ -9,6 +9,7 @@
 import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { getChromeLauncher } from '../chrome/launcher';
+import { getChromePool } from '../chrome/pool';
 import { formatAge } from '../utils/format-age';
 
 const definition: MCPToolDefinition = {
@@ -86,6 +87,24 @@ const handler: ToolHandler = async (
       }
     } else {
       lines.push('Profile: Unknown (Chrome may not be launched yet)');
+    }
+
+    // Append multi-profile pool info if multiple instances are running
+    const pool = getChromePool();
+    const instances = pool.getInstances();
+    const profileInstances = Array.from(instances.values()).filter(i => i.profileDirectory);
+    if (profileInstances.length > 0) {
+      const activeProfiles = profileInstances.map(i => ({
+        profileDirectory: i.profileDirectory,
+        port: i.port,
+        tabCount: i.tabCount,
+      }));
+      result.activeProfiles = activeProfiles;
+      lines.push('');
+      lines.push(`Active profile instances (${profileInstances.length}):`);
+      for (const p of profileInstances) {
+        lines.push(`  "${p.profileDirectory}" — port ${p.port}, ${p.tabCount} tab(s)`);
+      }
     }
 
     return {

--- a/src/tools/tabs-create.ts
+++ b/src/tools/tabs-create.ts
@@ -22,6 +22,10 @@ const definition: MCPToolDefinition = {
         type: 'string',
         description: 'Worker ID for parallel ops. Default: default',
       },
+      profileDirectory: {
+        type: 'string',
+        description: 'Chrome profile directory name (e.g., "Profile 1"). Use list_profiles to see available profiles. Launches a separate Chrome instance for each profile. If omitted, uses the server default.',
+      },
     },
     required: ['url'],
   },
@@ -33,7 +37,8 @@ const handler: ToolHandler = async (
 ): Promise<MCPResult> => {
   const sessionManager = getSessionManager();
   const url = args.url as string;
-  const workerId = args.workerId as string | undefined;
+  const profileDirectory = args.profileDirectory as string | undefined;
+  const workerId = (args.workerId as string | undefined) || (profileDirectory ? `profile:${profileDirectory}` : undefined);
 
   // URL is required
   if (!url) {
@@ -64,7 +69,7 @@ const handler: ToolHandler = async (
   }
 
   try {
-    const { targetId, page, workerId: assignedWorkerId } = await sessionManager.createTarget(sessionId, url, workerId);
+    const { targetId, page, workerId: assignedWorkerId } = await sessionManager.createTarget(sessionId, url, workerId, profileDirectory);
 
     return {
       content: [

--- a/tests/tools/navigate-stealth.test.ts
+++ b/tests/tools/navigate-stealth.test.ts
@@ -108,7 +108,8 @@ describe('NavigateTool - Stealth Mode', () => {
         testSessionId,
         'https://example.com',
         undefined,
-        8000
+        8000,
+        undefined
       );
     });
 
@@ -125,7 +126,8 @@ describe('NavigateTool - Stealth Mode', () => {
         testSessionId,
         'https://example.com',
         undefined,
-        10000
+        10000,
+        undefined
       );
     });
 
@@ -142,7 +144,8 @@ describe('NavigateTool - Stealth Mode', () => {
         testSessionId,
         'https://example.com',
         undefined,
-        1000
+        1000,
+        undefined
       );
     });
 
@@ -159,7 +162,8 @@ describe('NavigateTool - Stealth Mode', () => {
         testSessionId,
         'https://example.com',
         undefined,
-        30000
+        30000,
+        undefined
       );
     });
 
@@ -196,7 +200,8 @@ describe('NavigateTool - Stealth Mode', () => {
         testSessionId,
         'https://example.com',
         'worker-1',
-        8000
+        8000,
+        undefined
       );
     });
 
@@ -212,7 +217,8 @@ describe('NavigateTool - Stealth Mode', () => {
         testSessionId,
         'https://example.com',
         undefined,
-        8000
+        8000,
+        undefined
       );
     });
   });
@@ -235,7 +241,8 @@ describe('NavigateTool - Stealth Mode', () => {
         testSessionId,
         'https://turnstile-protected.com',
         undefined,
-        8000
+        8000,
+        undefined
       );
       expect(mockSmartGotoFn).not.toHaveBeenCalled();
     });
@@ -273,7 +280,8 @@ describe('NavigateTool - Stealth Mode', () => {
         testSessionId,
         'https://turnstile-protected.com',
         undefined,
-        15000
+        15000,
+        undefined
       );
       expect(mockSmartGotoFn).not.toHaveBeenCalled();
     });
@@ -295,7 +303,8 @@ describe('NavigateTool - Stealth Mode', () => {
         testSessionId,
         'https://turnstile-protected.com',
         'worker-stealth',
-        8000
+        8000,
+        undefined
       );
       expect(mockSmartGotoFn).not.toHaveBeenCalled();
     });

--- a/tests/tools/tabs.test.ts
+++ b/tests/tools/tabs.test.ts
@@ -226,7 +226,7 @@ describe('TabsCreateTool', () => {
       await handler(testSessionId, { url: 'https://google.com' });
 
       // Now includes optional workerId parameter
-      expect(mockSessionManager.createTarget).toHaveBeenCalledWith(testSessionId, 'https://google.com', undefined);
+      expect(mockSessionManager.createTarget).toHaveBeenCalledWith(testSessionId, 'https://google.com', undefined, undefined);
     });
 
     test('returns error when URL is not provided', async () => {
@@ -246,7 +246,7 @@ describe('TabsCreateTool', () => {
       await handler(testSessionId, { url: 'https://example.com' });
 
       // createTarget implicitly creates/uses session, now with optional workerId
-      expect(mockSessionManager.createTarget).toHaveBeenCalledWith(testSessionId, 'https://example.com', undefined);
+      expect(mockSessionManager.createTarget).toHaveBeenCalledWith(testSessionId, 'https://example.com', undefined, undefined);
     });
   });
 


### PR DESCRIPTION
## Summary

- Add `profileDirectory` parameter to `navigate` and `tabs_create` tools — users can now specify which Chrome profile to use per-request
- Auto-generate profile-scoped `workerId` (`profile:<name>`) when `profileDirectory` is given without explicit `workerId`, ensuring automatic isolation between profiles
- Enrich `oc_profile_status` to report all active profile instances from ChromePool (port, tab count)
- Update `list_profiles` guidance text to explain runtime `profileDirectory` usage instead of only suggesting server restart
- Fix test assertions for new parameter pass-through

Stacked on #370. Part of #369.

## Usage Example

```json
// Navigate with a specific Chrome profile
{ "tool": "navigate", "args": { "url": "https://example.com", "profileDirectory": "Profile 1" } }

// Different profile in parallel
{ "tool": "tabs_create", "args": { "url": "https://example.com", "profileDirectory": "Profile 2" } }
```

## Test plan

- [x] `npm run build` passes
- [x] All 2083 unit tests pass — zero regressions
- [ ] Manual: `navigate` without `profileDirectory` — existing behavior unchanged
- [ ] Manual: `navigate` with `profileDirectory: "Profile 1"` — launches separate Chrome instance
- [ ] Manual: `list_profiles` — shows updated guidance text
- [ ] Manual: `oc_profile_status` with multiple profiles — shows all active instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)