### PR TITLE
fix: auto-detect client capability for progressive tool disclosure

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -106,6 +106,7 @@ export class MCPServer {
   private profileWarningShown = false;
   private exposedTier: ToolTier = 1;
   private clientSupportsListChanged = true;
+  private clientDetected = false;
   private heartbeatIdleTimer: NodeJS.Timeout | null = null;
 
   constructor(sessionManager?: SessionManager, options: MCPServerOptions = {}) {
@@ -206,8 +207,10 @@ export class MCPServer {
   public expandToolTier(tier: ToolTier): void {
     if (tier > this.exposedTier) {
       this.exposedTier = tier;
-      // Notify client that tool list has changed (MCP spec compliant)
-      this.sendNotification('notifications/tools/list_changed');
+      // Only notify clients that support listChanged — unknown clients already have all tools
+      if (this.clientSupportsListChanged) {
+        this.sendNotification('notifications/tools/list_changed');
+      }
     }
   }
 
@@ -399,27 +402,33 @@ export class MCPServer {
     const rawName = clientInfo?.name ?? '';
     const nameLower = rawName.toLowerCase();
 
-    // Only auto-detect if no explicit override (--all-tools or OPENCHROME_TOOL_TIER)
-    if (!this.options.initialToolTier) {
-      const isKnownClient = Array.from(PROGRESSIVE_DISCLOSURE_CLIENTS).some(known =>
-        nameLower.includes(known)
-      );
+    // Idempotency: only detect client on first initialize (reconnects preserve state)
+    if (!this.clientDetected) {
+      this.clientDetected = true;
 
-      if (rawName && !isKnownClient) {
-        // Unknown client: expose all tools immediately (no progressive disclosure)
-        this.exposedTier = 3;
-        this.clientSupportsListChanged = false;
-        console.error(`[openchrome] Client "${rawName}" — progressive disclosure disabled, exposing all tools`);
+      if (this.options.initialToolTier) {
+        console.error(`[openchrome] Tool tier override: initialToolTier=${this.options.initialToolTier}, skipping client detection`);
       } else {
-        // Known client or no client info: keep progressive disclosure enabled
-        console.error(`[openchrome] Client "${rawName || '(unknown)'}" supports tool list changes — progressive disclosure enabled`);
+        const isKnownClient = rawName !== '' && Array.from(PROGRESSIVE_DISCLOSURE_CLIENTS).some(known =>
+          nameLower.includes(known)
+        );
+
+        if (!isKnownClient) {
+          // Unknown or absent client: expose all tools immediately (no progressive disclosure)
+          this.exposedTier = 3;
+          this.clientSupportsListChanged = false;
+          console.error(`[openchrome] Client "${rawName || '(no clientInfo)'}" — progressive disclosure disabled, exposing all tools`);
+        } else {
+          // Known client: keep progressive disclosure enabled
+          console.error(`[openchrome] Client "${rawName}" supports tool list changes — progressive disclosure enabled`);
+        }
       }
     }
 
     return {
       protocolVersion: '2024-11-05',
       capabilities: {
-        tools: { listChanged: true },
+        tools: { listChanged: this.clientSupportsListChanged },
         resources: {},
       },
       serverInfo: {


### PR DESCRIPTION
## Summary

- Auto-detect MCP client capability during `initialize` handshake
- Unknown/unsupported clients get all tools exposed immediately (no more stuck on Tier 1)
- Known clients (Claude Code, Cursor, VS Code, etc.) keep progressive disclosure

## Problem

The progressive disclosure system relies on `notifications/tools/list_changed` — a notification that tells clients to re-fetch `tools/list`. On unsupported IDEs (like Antigravity), this notification is silently ignored, leaving users stuck with only 24 Tier 1 tools and no way to access the remaining 24 specialist/orchestration tools.

Root cause: `handleInitialize` discarded client params entirely (`_params` unused), so the server could never detect whether the client supports `listChanged`.

Closes #364

## Changes

**`src/mcp-server.ts`** (+44 lines)

| Change | Description |
|--------|-------------|
| `PROGRESSIVE_DISCLOSURE_CLIENTS` | Allowlist of clients known to support `listChanged` (claude-code, cursor, vscode, windsurf, cline, zed, continue) |
| `clientSupportsListChanged` field | Tracks whether current client supports dynamic tool list changes |
| `handleInitialize` | Now parses `clientInfo.name`, checks allowlist (case-insensitive partial match), auto-sets `exposedTier=3` for unknown clients |
| `handleToolsList` | Skips `expand_tools` injection when client doesn't support `listChanged` |

### Behavior Matrix

| Client | Progressive Disclosure | Tools at Startup | `expand_tools` Visible |
|--------|:---------------------:|:----------------:|:----------------------:|
| Claude Code | Yes | Tier 1 (24) | Yes |
| Cursor | Yes | Tier 1 (24) | Yes |
| Antigravity | No (auto-detected) | All (48) | No |
| Unknown IDE | No (auto-detected) | All (48) | No |
| Any + `--all-tools` | No (explicit) | All (48) | No |

### Override Priority

1. Explicit `--all-tools` or `OPENCHROME_TOOL_TIER` → always respected
2. Client auto-detection → only when no explicit override

## Verification

- [x] Build: clean
- [x] Unit tests: 104 suites, 2083 tests — ALL PASS (including expand-tools-schema tests)
- [ ] Manual verification M1-M6 (see [checklist on #364](https://github.com/shaun0927/openchrome/issues/364#issuecomment-4109144131))

## Test plan

- [x] Existing `expand-tools-schema.test.ts` (7 tests) pass — no regression
- [ ] M1: Known client gets Tier 1 + expand_tools works
- [ ] M2: Unknown client gets all tools immediately
- [ ] M3: `--all-tools` overrides client detection
- [ ] M5: Edge cases (empty/null clientInfo) fall back to all-tools
- [ ] M6: Startup log shows detection decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)