### PR TITLE
feat: replace puppeteer-core with rebrowser-puppeteer-core for CDP fingerprint evasion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "commander": "^12.0.0",
         "proper-lockfile": "^4.1.2",
-        "puppeteer-core": "^23.11.1",
+        "puppeteer-core": "npm:rebrowser-puppeteer-core@23.10.3",
         "uuid": "^9.0.0",
         "write-file-atomic": "^5.0.1"
       },
@@ -2473,12 +2473,13 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.11.0.tgz",
-      "integrity": "sha512-6CJWHkNRoyZyjV9Rwv2lYONZf1Xm0IuDyNq97nwSsxxP3wf5Bwy15K5rOvVKMtJ127jJBmxFUanSAOjgFRxgrA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.8.0.tgz",
+      "integrity": "sha512-uJydbGdTw0DEUjhoogGveneJVWX/9YuqkWePzMmkBYwtdAqo5d3J/ovNKFr+/2hWXYmYCr6it8mSSTIj6SS6Ug==",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "3.0.1",
+        "urlpattern-polyfill": "10.0.0",
         "zod": "3.23.8"
       },
       "peerDependencies": {
@@ -5302,13 +5303,14 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "23.11.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.11.1.tgz",
-      "integrity": "sha512-3HZ2/7hdDKZvZQ7dhhITOUg4/wOrDRjyK2ZBllRB0ZCOi9u0cwq1ACHDjBB+nX+7+kltHjQvBRdeY7+W0T+7Gg==",
+      "name": "rebrowser-puppeteer-core",
+      "version": "23.10.3",
+      "resolved": "https://registry.npmjs.org/rebrowser-puppeteer-core/-/rebrowser-puppeteer-core-23.10.3.tgz",
+      "integrity": "sha512-oWwuFg3XoZUkAt6Te4zTU6sQeS39I9tctjdSEiDPa76MF47R0IfLX8VQhyRwwzMySqD5L1wambYcWyEAN0b9AA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.6.1",
-        "chromium-bidi": "0.11.0",
+        "chromium-bidi": "0.8.0",
         "debug": "^4.4.0",
         "devtools-protocol": "0.0.1367902",
         "typed-query-selector": "^2.12.0",
@@ -6166,6 +6168,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "commander": "^12.0.0",
     "proper-lockfile": "^4.1.2",
-    "puppeteer-core": "^23.11.1",
+    "puppeteer-core": "npm:rebrowser-puppeteer-core@23.10.3",
     "uuid": "^9.0.0",
     "write-file-atomic": "^5.0.1"
   },


### PR DESCRIPTION
## Summary

- Replace `puppeteer-core@^23.11.1` with `rebrowser-puppeteer-core@23.10.3` via npm alias — zero source code changes required
- Patches three CDP-level detection vectors: `Runtime.enable` leak, `pptr:evaluate` sourceURL pattern, `__puppeteer_utility_world__` naming
- Pinned to exact version (not `^`) for supply chain risk mitigation

Closes #374. Supersedes #372 (closed — version 23.11.1 doesn't exist in the fork).

## Why rebrowser?

OpenChrome already mitigates JS-layer detection (navigator.webdriver, plugins, mimeTypes, etc.) and delays CDP attachment via `createTargetStealth()`. The remaining detection surface is at the CDP protocol level — specifically `Runtime.enable` which puppeteer-core calls automatically on every frame. Anti-bot systems (Cloudflare, DataDome) detect this.

## Why 23.10.3?

| Version | Status |
|---------|--------|
| 23.11.1 | Does not exist in rebrowser fork |
| 23.10.3 | Closest available — stable, no regressions |
| 24.8.1 | Has open regression (Fetch.enable fails on latest Chrome) |

The only dependency diff: chromium-bidi 0.8.0 (ours) vs 0.11.0 (23.11.1). OpenChrome uses CDP exclusively, so BiDi changes have no impact.

## Why not rebrowser-patches postinstall?

Attempted first — patches fail to apply to puppeteer-core@23.11.1 (hunk failures in WebWorker.js and browser bundle). The drop-in replacement is the reliable path.

## Test plan

- [x] `npm run build` — zero TypeScript errors
- [x] `npm test` — 2083/2083 tests pass
- [x] Installed package verified: `rebrowser-puppeteer-core@23.10.3`
- [x] Manual: `page.evaluate()` works correctly — 5/5 subtests pass (simple expr, DOM access, complex object, async/await, error handling)
- [x] Manual: `createTargetStealth()` works correctly — 7/7 subtests pass (stealth nav, webdriver=undefined, plugins=5, languages, window.chrome, permissions=prompt, DOM access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
