### PR TITLE
feat: add oc_connection_health MCP tool for session monitoring (#347)

### DIFF
--- a/src/tools/connection-health.ts
+++ b/src/tools/connection-health.ts
@@ -1,0 +1,68 @@
+/**
+ * Connection Health Tool — exposes CDP connection metrics for AI agent monitoring.
+ * Part of #347 Phase 3C: Connection Health Metrics.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import { getCDPClient } from '../cdp/client';
+
+const definition: MCPToolDefinition = {
+  name: 'oc_connection_health',
+  description:
+    'Get CDP connection health metrics including heartbeat mode, reconnect count, ping latency, and connection state. Use this to monitor connection stability during long-running sessions.',
+  inputSchema: {
+    type: 'object',
+    properties: {},
+    required: [],
+  },
+};
+
+const handler: ToolHandler = async (
+  _sessionId: string,
+  _args: Record<string, unknown>
+): Promise<MCPResult> => {
+  try {
+    const cdpClient = getCDPClient();
+    const metrics = cdpClient.getConnectionMetrics();
+    const state = cdpClient.getConnectionState();
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              connectionState: state,
+              heartbeatMode: metrics.heartbeatMode,
+              reconnectCount: metrics.reconnectCount,
+              avgPingLatencyMs: metrics.avgPingLatencyMs,
+              msSinceLastVerified: metrics.msSinceLastVerified,
+              consecutiveSuccesses: metrics.consecutiveSuccesses,
+              lastVerifiedAt:
+                metrics.lastVerifiedAt > 0
+                  ? new Date(metrics.lastVerifiedAt).toISOString()
+                  : null,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Connection health unavailable: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+};
+
+export function registerConnectionHealthTool(server: MCPServer): void {
+  server.registerTool('oc_connection_health', handler, definition);
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -65,6 +65,9 @@ import { registerSessionSnapshotTool } from './session-snapshot';
 import { registerSessionResumeTool } from './session-resume';
 import { registerJournalTool } from './journal';
 
+// Self-healing tools (#347)
+import { registerConnectionHealthTool } from './connection-health';
+
 export function registerAllTools(server: MCPServer): void {
   // Core browser tools
   registerNavigateTool(server);
@@ -132,6 +135,9 @@ export function registerAllTools(server: MCPServer): void {
   registerSessionSnapshotTool(server);
   registerSessionResumeTool(server);
   registerJournalTool(server);
+
+  // Self-healing tools (#347)
+  registerConnectionHealthTool(server);
 
   console.error(`[Tools] Registered ${server.getToolNames().length} tools`);
 }

--- a/tests/tools/connection-health.test.ts
+++ b/tests/tools/connection-health.test.ts
@@ -1,0 +1,146 @@
+/// <reference types="jest" />
+/**
+ * Tests for oc_connection_health tool
+ */
+
+import { createMockSessionManager } from '../utils/mock-session';
+
+const mockGetConnectionMetrics = jest.fn();
+const mockGetConnectionState = jest.fn();
+
+jest.mock('../../src/cdp/client', () => ({
+  getCDPClient: jest.fn(() => ({
+    getConnectionMetrics: mockGetConnectionMetrics,
+    getConnectionState: mockGetConnectionState,
+  })),
+}));
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(),
+}));
+
+import { getSessionManager } from '../../src/session-manager';
+import { MCPServer } from '../../src/mcp-server';
+import { registerConnectionHealthTool } from '../../src/tools/connection-health';
+
+describe('oc_connection_health tool', () => {
+  let server: MCPServer;
+  let handler: (sessionId: string, args: Record<string, unknown>) => Promise<any>;
+
+  const baseMetrics = {
+    heartbeatMode: 'active',
+    reconnectCount: 2,
+    avgPingLatencyMs: 42,
+    msSinceLastVerified: 1500,
+    consecutiveSuccesses: 5,
+    lastVerifiedAt: Date.now() - 1500,
+  };
+
+  beforeEach(() => {
+    const mockSessionManager = createMockSessionManager();
+    (getSessionManager as jest.Mock).mockReturnValue(mockSessionManager);
+    server = new MCPServer(mockSessionManager as any);
+    registerConnectionHealthTool(server);
+    handler = server.getToolHandler('oc_connection_health')!;
+    expect(handler).toBeDefined();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('tool is registered with correct name', () => {
+    expect(server.getToolNames()).toContain('oc_connection_health');
+  });
+
+  test('returns all expected fields in connected state', async () => {
+    mockGetConnectionState.mockReturnValue('connected');
+    mockGetConnectionMetrics.mockReturnValue(baseMetrics);
+
+    const result = await handler('default', {});
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toHaveLength(1);
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.connectionState).toBe('connected');
+    expect(data.heartbeatMode).toBe('active');
+    expect(data.reconnectCount).toBe(2);
+    expect(data.avgPingLatencyMs).toBe(42);
+    expect(data.msSinceLastVerified).toBe(1500);
+    expect(data.consecutiveSuccesses).toBe(5);
+    expect(data.lastVerifiedAt).not.toBeNull();
+    // Should be an ISO string
+    expect(typeof data.lastVerifiedAt).toBe('string');
+    expect(() => new Date(data.lastVerifiedAt)).not.toThrow();
+  });
+
+  test('returns null for lastVerifiedAt when lastVerifiedAt is 0', async () => {
+    mockGetConnectionState.mockReturnValue('disconnected');
+    mockGetConnectionMetrics.mockReturnValue({
+      ...baseMetrics,
+      lastVerifiedAt: 0,
+      msSinceLastVerified: 0,
+    });
+
+    const result = await handler('default', {});
+
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text);
+    expect(data.lastVerifiedAt).toBeNull();
+    expect(data.connectionState).toBe('disconnected');
+  });
+
+  test('reports reconnecting state correctly', async () => {
+    mockGetConnectionState.mockReturnValue('reconnecting');
+    mockGetConnectionMetrics.mockReturnValue({
+      ...baseMetrics,
+      reconnectCount: 3,
+      consecutiveSuccesses: 0,
+    });
+
+    const result = await handler('default', {});
+
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text);
+    expect(data.connectionState).toBe('reconnecting');
+    expect(data.reconnectCount).toBe(3);
+    expect(data.consecutiveSuccesses).toBe(0);
+  });
+
+  test('returns isError when getCDPClient throws', async () => {
+    const { getCDPClient } = require('../../src/cdp/client');
+    (getCDPClient as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('CDP client not initialized');
+    });
+
+    const result = await handler('default', {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Connection health unavailable');
+    expect(result.content[0].text).toContain('CDP client not initialized');
+  });
+
+  test('returns isError when getConnectionMetrics throws', async () => {
+    mockGetConnectionState.mockReturnValue('connected');
+    mockGetConnectionMetrics.mockImplementation(() => {
+      throw new Error('Metrics not available');
+    });
+
+    const result = await handler('default', {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Connection health unavailable');
+    expect(result.content[0].text).toContain('Metrics not available');
+  });
+
+  test('output is valid JSON', async () => {
+    mockGetConnectionState.mockReturnValue('connected');
+    mockGetConnectionMetrics.mockReturnValue(baseMetrics);
+
+    const result = await handler('default', {});
+
+    expect(result.content[0].type).toBe('text');
+    expect(() => JSON.parse(result.content[0].text)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `oc_connection_health` MCP tool from issue #347 Phase 3C
- Exposes CDP connection metrics to AI agents: heartbeat mode, reconnect count, average ping latency, connection state, consecutive successes, and last verified timestamp
- Follows existing tool registration pattern (`MCPToolDefinition` + `ToolHandler` + `registerTool`)

## Files Changed

- `src/tools/connection-health.ts` — new tool implementation
- `src/tools/index.ts` — registers the tool under "Self-healing tools (#347)" section
- `tests/tools/connection-health.test.ts` — 7 tests covering happy path, null `lastVerifiedAt`, reconnecting state, and two error-handling paths

## Test plan

- [x] `npm run build` — compiles cleanly with no TypeScript errors
- [x] `npx jest tests/tools/connection-health.test.ts` — 7/7 tests pass
- [ ] Manual: call `oc_connection_health` in a live session and verify JSON output matches schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)