### PR TITLE
feat: activate heavy heartbeat mode and add Chrome stability flags (#347)

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -223,14 +223,6 @@ export class CDPClient {
         return;
       }
 
-      // Check for idle transition: no commands for 5 minutes → switch to idle mode
-      if ((this.heartbeatMode === 'active' || this.heartbeatMode === 'heavy')
-          && this.lastCommandAt > 0
-          && now - this.lastCommandAt > 300000) {
-        this.setHeartbeatMode('idle');
-        return; // setHeartbeatMode restarts the timer with new interval
-      }
-
       this.checkConnection();
     }, this.getEffectiveHeartbeatInterval());
   }
@@ -289,6 +281,9 @@ export class CDPClient {
 
   /**
    * Record that a command was executed (for idle detection).
+   * @deprecated Idle transitions are now managed by MCPServer via setTimeout. This method
+   * is retained for API compatibility but the internal idle-check in startHeartbeat() has
+   * been removed as dead code (#347).
    */
   recordCommandActivity(): void {
     this.lastCommandAt = Date.now();

--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -442,6 +442,10 @@ export class ChromeLauncher {
       '--disable-backgrounding-occluded-windows',
       // Prevent Chrome from self-terminating after repeated GPU crashes (headed mode)
       '--disable-gpu-crash-limit',
+      // Suppress crash UI that blocks automation in long sessions (#347)
+      '--disable-crash-reporter',
+      '--disable-session-crashed-bubble',
+      '--hide-crash-restore-bubble',
     );
 
     // Prevent Blink from setting navigator.webdriver = true when CDP is connected.

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -588,11 +588,11 @@ export class MCPServer {
     const callId = this.activityTracker!.startCall(toolName, sessionId || 'default', toolArgs, requestId);
     const toolStartTime = Date.now();
 
-    // Adaptive heartbeat: switch to active mode during tool execution
+    // Adaptive heartbeat: switch to heavy mode during tool execution
     try {
       const cdpClient = getCDPClient();
       if (cdpClient.setHeartbeatMode) {
-        cdpClient.setHeartbeatMode('active');
+        cdpClient.setHeartbeatMode('heavy');
       }
       if (this.heartbeatIdleTimer) {
         clearTimeout(this.heartbeatIdleTimer);
@@ -697,6 +697,16 @@ export class MCPServer {
         // Best-effort journal recording
       }
 
+      // Transition from heavy back to active after tool completes
+      try {
+        const cdpClient = getCDPClient();
+        if (cdpClient.setHeartbeatMode) {
+          cdpClient.setHeartbeatMode('active');
+        }
+      } catch {
+        // CDP client may not be initialized
+      }
+
       // Schedule heartbeat idle mode transition
       if (this.heartbeatIdleTimer) {
         clearTimeout(this.heartbeatIdleTimer);
@@ -797,6 +807,16 @@ export class MCPServer {
         journal.record(entry);
       } catch {
         // Best-effort journal recording
+      }
+
+      // Transition from heavy back to active after tool completes
+      try {
+        const cdpClient = getCDPClient();
+        if (cdpClient.setHeartbeatMode) {
+          cdpClient.setHeartbeatMode('active');
+        }
+      } catch {
+        // CDP client may not be initialized
       }
 
       // Schedule heartbeat idle mode transition


### PR DESCRIPTION
## Summary

- **Heavy heartbeat mode during tool execution**: Switch from `active` to `heavy` (2s interval) when a tool starts executing, matching the Phase 3B adaptive heartbeat spec. Immediately transitions back to `active` on tool completion (both success and error paths) before the 5-minute idle timer fires.
- **Remove dead code in CDPClient**: The idle-check inside `startHeartbeat()` depended on `lastCommandAt` which was never set externally — the condition `lastCommandAt > 0` was never true. Removed that dead branch. `recordCommandActivity()` is retained but marked `@deprecated` for API compatibility.
- **Chrome stability flags**: Add three missing flags for long sessions: `--disable-crash-reporter`, `--disable-session-crashed-bubble`, `--hide-crash-restore-bubble` to suppress crash UI that blocks automation.

## Test plan

- [ ] `npm run build` passes with no TypeScript errors
- [ ] `npm test` — all 2083 tests pass across 104 suites
- [ ] Heartbeat mode transitions: tool start → `heavy`, tool end → `active`, after 5min idle → `idle`
- [ ] Chrome launcher: new flags appear in launched Chrome process args
- [ ] No regressions in CDP reconnect or session management behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)