### PR TITLE
fix: use globalConfig.headless for stealth headless detection (#361)

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -1243,13 +1243,20 @@ export class CDPClient {
     console.error(`[CDPClient] Stealth tab created: ${targetId}, settling for ${settleMs}ms`);
 
     // Warn if headless — Turnstile detection is nearly guaranteed in headless mode
-    try {
-      const version = await browser.version();
-      if (version.toLowerCase().includes('headless')) {
+    {
+      const { headless } = getGlobalConfig();
+      let isHeadless = !!headless;
+      if (!isHeadless) {
+        try {
+          const version = await browser.version();
+          isHeadless = version.toLowerCase().includes('headless');
+        } catch {
+          // Version check failed — continue
+        }
+      }
+      if (isHeadless) {
         console.error('[CDPClient] WARNING: Stealth mode in headless Chrome is unlikely to bypass Turnstile. Use headed Chrome (--visible) for anti-bot pages.');
       }
-    } catch {
-      // Version check failed — continue
     }
 
     // Step 2: Wait for the page to load without CDP observation (Turnstile runs here)


### PR DESCRIPTION
## Summary

- Fix headless detection bug in `createTargetStealth()` where the stealth warning never fired with `--headless=new`
- `browser.version()` with `--headless=new` returns `"Chrome/..."` without the `"Headless"` prefix (unlike old `--headless` which returned `"HeadlessChrome/..."`)
- Now checks `getGlobalConfig().headless` first (reliably set by the launcher), falling back to `browser.version()` for externally-launched Chrome instances

## Context

This was the last unchecked acceptance criterion in #361. All other fixes (outerWidth/outerHeight, mimeTypes, chrome.app/loadTimes, stealthSettleMs=8000) were shipped in PR #362.

**Verified at runtime:**
| Check | Before Fix | After Fix |
|-------|-----------|-----------|
| Headless warning fires (`--auto-launch`, no `--visible`) | Not fired | Fires correctly |
| Headed mode (`--auto-launch --visible`) | Not fired (correct) | Not fired (correct) |

## Test plan

- [x] Full test suite passes (104 suites, 2083 tests)
- [x] Stealth-specific tests pass (28/28)
- [x] Runtime verified: warning fires in headless mode
- [x] Runtime verified: warning does NOT fire in headed mode
- [x] Build clean (no type errors)

Closes the last open item in #361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)