### PR TITLE
test: add 24-hour endurance test for self-healing validation (#347)

### DIFF
--- a/tests/e2e/endurance-runner.ts
+++ b/tests/e2e/endurance-runner.ts
@@ -1,0 +1,410 @@
+/**
+ * Endurance Runner — standalone script for the E2E-8 24-hour endurance test.
+ *
+ * Usage:
+ *   ENDURANCE_HOURS=24 npx ts-node tests/e2e/endurance-runner.ts
+ *   ENDURANCE_HOURS=1  npx ts-node tests/e2e/endurance-runner.ts   # 1-hour smoke run
+ *
+ * The script:
+ *   1. Builds the MCP server (if dist/ is missing)
+ *   2. Starts a fixture HTTP server
+ *   3. Runs the endurance loop directly (no Jest overhead)
+ *   4. Writes a JSON metrics report to endurance-report-<timestamp>.json
+ *   5. Exits 0 (pass) or 1 (fail)
+ *
+ * Environment variables:
+ *   ENDURANCE_HOURS   Duration in hours (default: 1)
+ *   TIME_SCALE        CI compression factor (default: 1)
+ *   DEBUG             Set to 1 for verbose MCP output
+ */
+import * as http from 'http';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { execSync } from 'child_process';
+import { MCPClient } from './harness/mcp-client';
+import { ChromeController } from './harness/chrome-controller';
+import { HeapSampler } from './harness/heap-sampler';
+import { scaled } from './harness/time-scale';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const DURATION_HOURS = parseInt(process.env.ENDURANCE_HOURS || '1', 10);
+const DURATION_MS    = scaled(DURATION_HOURS * 60 * 60 * 1000);
+
+const FIXTURE_PORT       = 18930; // Isolated port for runner
+const CHROME_DEBUG_PORT  = 19444; // Isolated port for runner Chrome
+
+const ACTIVE_PHASE_MS            = scaled(10 * 60 * 1000);
+const IDLE_PHASE_MS              = scaled(20 * 60 * 1000);
+const CHROME_RESTART_INTERVAL_MS = scaled(60 * 60 * 1000);
+const MCP_RESTART_INTERVAL_MS    = scaled(4 * 60 * 60 * 1000);
+const HEALTH_LOG_INTERVAL_MS     = scaled(5 * 60 * 1000);
+const ACTIVE_POLL_DELAY_MS       = scaled(5_000);
+const IDLE_POLL_DELAY_MS         = scaled(30_000);
+const CHROME_RECOVERY_WAIT_MS    = 15_000;
+
+// ---------------------------------------------------------------------------
+// Fixture HTTP server (mirrors E2E setup.ts pages)
+// ---------------------------------------------------------------------------
+
+function buildFixturePages(): Record<string, string> {
+  return {
+    '/': `<!DOCTYPE html><html><head><title>E2E Endurance</title></head>
+<body><h1>OpenChrome Endurance Runner</h1></body></html>`,
+    '/site-a': `<!DOCTYPE html><html><head><title>Site A</title></head>
+<body><h1>Welcome to Site A</h1></body></html>`,
+    '/site-b': `<!DOCTYPE html><html><head><title>Site B</title></head>
+<body><h1>Search Portal</h1></body></html>`,
+    '/site-c': `<!DOCTYPE html><html><head><title>Site C</title></head>
+<body><h1>Data Dashboard</h1></body></html>`,
+  };
+}
+
+function startFixtureServer(): Promise<http.Server> {
+  const pages = buildFixturePages();
+  const server = http.createServer((req, res) => {
+    const url = req.url?.split('?')[0] || '/';
+    const html = pages[url];
+    if (html) {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(html);
+    } else {
+      res.writeHead(404);
+      res.end('Not found');
+    }
+  });
+
+  return new Promise((resolve, reject) => {
+    server.listen(FIXTURE_PORT, () => {
+      console.error(`[runner] Fixture server on http://localhost:${FIXTURE_PORT}`);
+      resolve(server);
+    });
+    server.on('error', reject);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+
+interface EnduranceReport {
+  durationHours: number;
+  durationMs: number;
+  startTime: string;
+  endTime: string;
+  totalOperations: number;
+  successfulOperations: number;
+  failedOperations: number;
+  successRatePct: number;
+  chromeRestarts: number;
+  mcpRestarts: number;
+  reconnects: number;
+  recoveryTimes: number[];
+  avgRecoveryTimeMs: number;
+  maxRecoveryTimeMs: number;
+  heapSamplesMB: number[];
+  heapGrowthMB: number;
+  passed: boolean;
+  failureReasons: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Main endurance loop
+// ---------------------------------------------------------------------------
+
+async function runEndurance(mcp: MCPClient, chrome: ChromeController, heapSampler: HeapSampler): Promise<EnduranceReport> {
+  const testUrls = [
+    `http://localhost:${FIXTURE_PORT}/site-a`,
+    `http://localhost:${FIXTURE_PORT}/site-b`,
+    `http://localhost:${FIXTURE_PORT}/site-c`,
+  ];
+
+  const startTime = Date.now();
+  const endTime   = startTime + DURATION_MS;
+
+  let totalOperations      = 0;
+  let successfulOperations = 0;
+  let failedOperations     = 0;
+  let chromeRestarts       = 0;
+  let mcpRestarts          = 0;
+  let reconnects           = 0;
+  const recoveryTimes: number[] = [];
+  const heapSamplesMB: number[] = [];
+
+  let lastChromeRestart = startTime;
+  let lastMcpRestart    = startTime;
+  let lastHealthLog     = startTime;
+  let isActivePhase     = true;
+  let phaseStartTime    = startTime;
+
+  heapSampler.takeBaseline();
+
+  // Initial connectivity check
+  await mcp.callTool('navigate', { url: testUrls[0] });
+  totalOperations++;
+  successfulOperations++;
+  console.error('[runner] Initial navigation OK — endurance loop starting');
+  console.error(`[runner] Duration: ${DURATION_HOURS}h (${DURATION_MS}ms scaled)`);
+
+  while (Date.now() < endTime) {
+    const now = Date.now();
+
+    // Phase transition
+    const phaseElapsed = now - phaseStartTime;
+    if (isActivePhase && phaseElapsed > ACTIVE_PHASE_MS) {
+      isActivePhase  = false;
+      phaseStartTime = now;
+      console.error('[runner] -> IDLE phase');
+    } else if (!isActivePhase && phaseElapsed > IDLE_PHASE_MS) {
+      isActivePhase  = true;
+      phaseStartTime = now;
+      console.error('[runner] -> ACTIVE phase');
+    }
+
+    // MCP server restart every 4 hours
+    if (now - lastMcpRestart > MCP_RESTART_INTERVAL_MS) {
+      console.error('[runner] Restarting MCP server (scheduled 4-hour cycle)...');
+      const restartStart = Date.now();
+      try {
+        await mcp.restart();
+        const elapsed = Date.now() - restartStart;
+        mcpRestarts++;
+        reconnects++;
+        recoveryTimes.push(elapsed);
+        console.error(`[runner] MCP server restarted in ${elapsed}ms`);
+      } catch (err) {
+        console.error('[runner] MCP restart failed:', err);
+        failedOperations++;
+      }
+      lastMcpRestart = Date.now();
+    }
+
+    // Chrome crash simulation every hour
+    if (now - lastChromeRestart > CHROME_RESTART_INTERVAL_MS) {
+      console.error('[runner] Simulating Chrome crash (scheduled hourly kill)...');
+      const restartStart = Date.now();
+      try {
+        await chrome.discoverPid(CHROME_DEBUG_PORT);
+        await chrome.kill('SIGKILL');
+
+        // Wait for watchdog / auto-launch
+        await new Promise<void>((r) => setTimeout(r, CHROME_RECOVERY_WAIT_MS));
+
+        // Verify recovery
+        await mcp.callTool('navigate', { url: testUrls[0] }, 60_000);
+        const recoveryMs = Date.now() - restartStart;
+        recoveryTimes.push(recoveryMs);
+        chromeRestarts++;
+        reconnects++;
+        console.error(`[runner] Chrome recovered in ${recoveryMs}ms`);
+      } catch (err) {
+        console.error('[runner] Chrome restart/recovery failed:', err);
+        failedOperations++;
+        totalOperations++;
+      }
+      lastChromeRestart = Date.now();
+    }
+
+    // Active phase operations
+    if (isActivePhase) {
+      const url = testUrls[totalOperations % testUrls.length];
+      try {
+        const navResult = await mcp.callTool('navigate', { url });
+        totalOperations++;
+        successfulOperations++;
+
+        const tabIdMatch = navResult.text.match(/"tabId"\s*:\s*"([A-F0-9]{32})"/);
+        if (tabIdMatch) {
+          const readResult = await mcp.callTool('read_page', { tabId: tabIdMatch[1] });
+          if (!readResult.text || readResult.text.length === 0) {
+            throw new Error('read_page returned empty content');
+          }
+          totalOperations++;
+          successfulOperations++;
+        }
+      } catch (err) {
+        totalOperations++;
+        failedOperations++;
+        console.error('[runner] Operation failed:', err);
+      }
+    }
+
+    // Health logging every 5 minutes
+    if (now - lastHealthLog > HEALTH_LOG_INTERVAL_MS) {
+      const heapBytes  = process.memoryUsage().heapUsed;
+      const heapMB     = heapBytes / 1024 / 1024;
+      heapSamplesMB.push(heapMB);
+      heapSampler.takeSample();
+
+      const elapsedPct  = ((now - startTime) / DURATION_MS * 100).toFixed(1);
+      const successRate = totalOperations > 0
+        ? (successfulOperations / totalOperations * 100).toFixed(1)
+        : '100.0';
+
+      console.error(
+        `[runner] Progress: ${elapsedPct}% | ` +
+        `Ops: ${totalOperations} (${successRate}% success) | ` +
+        `ChromeRestarts: ${chromeRestarts} | McpRestarts: ${mcpRestarts} | ` +
+        `Heap: ${heapMB.toFixed(1)}MB`
+      );
+      lastHealthLog = now;
+    }
+
+    // Throttle polling
+    await new Promise<void>((r) =>
+      setTimeout(r, isActivePhase ? ACTIVE_POLL_DELAY_MS : IDLE_POLL_DELAY_MS)
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Build report
+  // ---------------------------------------------------------------------------
+
+  const actualEndTime = Date.now();
+  const successRatePct = totalOperations > 0
+    ? (successfulOperations / totalOperations) * 100
+    : 100;
+
+  const avgRecoveryTimeMs = recoveryTimes.length > 0
+    ? recoveryTimes.reduce((a, b) => a + b, 0) / recoveryTimes.length
+    : 0;
+
+  const maxRecoveryTimeMs = recoveryTimes.length > 0
+    ? Math.max(...recoveryTimes)
+    : 0;
+
+  let heapGrowthMB = 0;
+  if (heapSamplesMB.length >= 2) {
+    const quarterLen = Math.ceil(heapSamplesMB.length / 4);
+    const avgFirst   = heapSamplesMB.slice(0, quarterLen).reduce((a, b) => a + b, 0) / quarterLen;
+    const avgLast    = heapSamplesMB.slice(-quarterLen).reduce((a, b) => a + b, 0) / quarterLen;
+    heapGrowthMB     = avgLast - avgFirst;
+  }
+
+  const failureReasons: string[] = [];
+  if (successRatePct <= 95) {
+    failureReasons.push(`Success rate ${successRatePct.toFixed(2)}% <= 95%`);
+  }
+  if (avgRecoveryTimeMs >= 30_000) {
+    failureReasons.push(`Avg recovery ${avgRecoveryTimeMs.toFixed(0)}ms >= 30000ms`);
+  }
+  if (heapGrowthMB >= 200) {
+    failureReasons.push(`Heap growth ${heapGrowthMB.toFixed(1)}MB >= 200MB`);
+  }
+
+  return {
+    durationHours: DURATION_HOURS,
+    durationMs: DURATION_MS,
+    startTime: new Date(startTime).toISOString(),
+    endTime: new Date(actualEndTime).toISOString(),
+    totalOperations,
+    successfulOperations,
+    failedOperations,
+    successRatePct,
+    chromeRestarts,
+    mcpRestarts,
+    reconnects,
+    recoveryTimes,
+    avgRecoveryTimeMs,
+    maxRecoveryTimeMs,
+    heapSamplesMB,
+    heapGrowthMB,
+    passed: failureReasons.length === 0,
+    failureReasons,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  console.error(`[runner] E2E-8 Endurance Runner — ${DURATION_HOURS}h run`);
+
+  // Ensure MCP server is built
+  const serverPath = path.join(process.cwd(), 'dist', 'index.js');
+  if (!fs.existsSync(serverPath)) {
+    console.error('[runner] dist/index.js not found — building...');
+    execSync('npm run build', { stdio: 'inherit' });
+  }
+
+  // Start fixture server
+  const fixtureServer = await startFixtureServer();
+
+  // Start MCP client
+  const mcp = new MCPClient({
+    timeoutMs: 60_000,
+    args: ['--auto-launch', '--port', String(CHROME_DEBUG_PORT)],
+  });
+  await mcp.start();
+  console.error('[runner] MCP server started');
+
+  const chrome      = new ChromeController();
+  const heapSampler = new HeapSampler({ pid: mcp.pid });
+
+  let report: EnduranceReport | null = null;
+
+  try {
+    report = await runEndurance(mcp, chrome, heapSampler);
+  } catch (err) {
+    console.error('[runner] Fatal error during endurance loop:', err);
+    // Build minimal failure report
+    report = {
+      durationHours: DURATION_HOURS,
+      durationMs: DURATION_MS,
+      startTime: new Date().toISOString(),
+      endTime: new Date().toISOString(),
+      totalOperations: 0,
+      successfulOperations: 0,
+      failedOperations: 1,
+      successRatePct: 0,
+      chromeRestarts: 0,
+      mcpRestarts: 0,
+      reconnects: 0,
+      recoveryTimes: [],
+      avgRecoveryTimeMs: 0,
+      maxRecoveryTimeMs: 0,
+      heapSamplesMB: [],
+      heapGrowthMB: 0,
+      passed: false,
+      failureReasons: [`Fatal: ${(err as Error).message}`],
+    };
+  } finally {
+    await mcp.stop().catch(() => { /* ignore */ });
+    await new Promise<void>((r) => fixtureServer.close(() => r()));
+    console.error('[runner] Cleanup complete');
+  }
+
+  // Write JSON report
+  const reportFile = path.join(
+    process.cwd(),
+    `endurance-report-${Date.now()}.json`
+  );
+  fs.writeFileSync(reportFile, JSON.stringify(report, null, 2));
+  console.error(`[runner] Report written to: ${reportFile}`);
+
+  // Print summary
+  console.error('[runner] ========== ENDURANCE REPORT ==========');
+  console.error(`[runner] Duration:      ${report.durationHours}h`);
+  console.error(`[runner] Operations:    ${report.successfulOperations}/${report.totalOperations} (${report.successRatePct.toFixed(2)}% success)`);
+  console.error(`[runner] ChromeRestarts:${report.chromeRestarts}`);
+  console.error(`[runner] McpRestarts:   ${report.mcpRestarts}`);
+  console.error(`[runner] Avg recovery:  ${report.avgRecoveryTimeMs.toFixed(0)}ms`);
+  console.error(`[runner] Max recovery:  ${report.maxRecoveryTimeMs.toFixed(0)}ms`);
+  console.error(`[runner] Heap growth:   ${report.heapGrowthMB.toFixed(1)}MB`);
+  console.error(`[runner] Result:        ${report.passed ? 'PASS' : 'FAIL'}`);
+  if (report.failureReasons.length > 0) {
+    report.failureReasons.forEach((r) => console.error(`[runner]   FAIL: ${r}`));
+  }
+  console.error('[runner] ==========================================');
+
+  process.exit(report.passed ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('[runner] Unhandled error:', err);
+  process.exit(1);
+});

--- a/tests/e2e/scenarios/endurance-24h.e2e.ts
+++ b/tests/e2e/scenarios/endurance-24h.e2e.ts
@@ -1,0 +1,276 @@
+/**
+ * E2E-8: 24-Hour Endurance Test
+ * Validates: sustained operation, Chrome crash recovery, memory stability.
+ *
+ * Enable with: OPENCHROME_ENDURANCE=1
+ * Duration:    ENDURANCE_HOURS=24 (default: 1 for CI)
+ *
+ * PASS criteria:
+ *   - Task completion rate > 95%
+ *   - Zero permanent failures (all Chrome restarts recover)
+ *   - Average Chrome recovery time < 30s
+ *   - Heap growth < 200MB over test duration
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { MCPClient } from '../harness/mcp-client';
+import { ChromeController } from '../harness/chrome-controller';
+import { HeapSampler } from '../harness/heap-sampler';
+import { scaled, JEST_OVERHEAD_MS } from '../harness/time-scale';
+
+const CHROME_DEBUG_PORT = 19333; // Isolated port to avoid interference
+
+const DURATION_HOURS = parseInt(process.env.ENDURANCE_HOURS || '1', 10);
+const DURATION_MS = scaled(DURATION_HOURS * 60 * 60 * 1000);
+
+// Phase durations (also scaled for CI)
+const ACTIVE_PHASE_MS = scaled(10 * 60 * 1000);  // 10 min active
+const IDLE_PHASE_MS   = scaled(20 * 60 * 1000);  // 20 min idle
+
+// Event intervals (scaled)
+const CHROME_RESTART_INTERVAL_MS   = scaled(60 * 60 * 1000); // every hour
+const MCP_RESTART_INTERVAL_MS      = scaled(4 * 60 * 60 * 1000); // every 4 hours
+const HEALTH_LOG_INTERVAL_MS       = scaled(5 * 60 * 1000);  // every 5 min
+
+// Polling delays
+const ACTIVE_POLL_DELAY_MS = scaled(5_000);   // 5s between ops in active phase
+const IDLE_POLL_DELAY_MS   = scaled(30_000);  // 30s between checks in idle phase
+
+// Recovery wait after Chrome kill
+const CHROME_RECOVERY_WAIT_MS = 15_000;
+
+function getFixturePort(): number {
+  const stateFile = path.join(process.cwd(), '.e2e-state.json');
+  const state = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
+  return state.port;
+}
+
+interface EnduranceMetrics {
+  totalOperations: number;
+  successfulOperations: number;
+  failedOperations: number;
+  chromeRestarts: number;
+  mcpRestarts: number;
+  reconnects: number;
+  recoveryTimes: number[];
+  avgRecoveryTimeMs: number;
+  heapSamples: number[];
+  startTime: number;
+}
+
+describe('E2E-8: 24-Hour Endurance', () => {
+  // Guard: only run when explicitly opted in
+  const runEndurance = process.env.OPENCHROME_ENDURANCE === '1';
+  const describeOrSkip = runEndurance ? describe : describe.skip;
+
+  describeOrSkip('endurance session', () => {
+    let mcp: MCPClient;
+    let chrome: ChromeController;
+    let heapSampler: HeapSampler;
+
+    const metrics: EnduranceMetrics = {
+      totalOperations: 0,
+      successfulOperations: 0,
+      failedOperations: 0,
+      chromeRestarts: 0,
+      mcpRestarts: 0,
+      reconnects: 0,
+      recoveryTimes: [],
+      avgRecoveryTimeMs: 0,
+      heapSamples: [],
+      startTime: 0,
+    };
+
+    beforeAll(async () => {
+      mcp = new MCPClient({
+        timeoutMs: 60_000,
+        args: ['--auto-launch', '--port', String(CHROME_DEBUG_PORT)],
+      });
+      await mcp.start();
+      chrome = new ChromeController();
+      heapSampler = new HeapSampler({ pid: mcp.pid });
+    }, 90_000);
+
+    afterAll(async () => {
+      // Log final metrics regardless of pass/fail
+      if (metrics.startTime > 0) {
+        console.error('[endurance] FINAL METRICS:', JSON.stringify(metrics, null, 2));
+      }
+      await mcp.stop();
+    }, 30_000);
+
+    test(
+      'sustained operation over extended period',
+      async () => {
+        const port = getFixturePort();
+        const testUrls = [
+          `http://localhost:${port}/site-a`,
+          `http://localhost:${port}/site-b`,
+          `http://localhost:${port}/site-c`,
+        ];
+
+        metrics.startTime = Date.now();
+        const endTime = metrics.startTime + DURATION_MS;
+
+        let lastChromeRestart = metrics.startTime;
+        let lastMcpRestart    = metrics.startTime;
+        let lastHealthLog     = metrics.startTime;
+        let isActivePhase     = true;
+        let phaseStartTime    = metrics.startTime;
+
+        heapSampler.takeBaseline();
+
+        // Initial navigation to confirm connectivity
+        await mcp.callTool('navigate', { url: testUrls[0] });
+        metrics.totalOperations++;
+        metrics.successfulOperations++;
+        console.error('[endurance] Initial navigation OK, starting endurance loop');
+
+        while (Date.now() < endTime) {
+          const now = Date.now();
+
+          // --- Phase transition ---
+          const phaseElapsed = now - phaseStartTime;
+          if (isActivePhase && phaseElapsed > ACTIVE_PHASE_MS) {
+            isActivePhase = false;
+            phaseStartTime = now;
+            console.error('[endurance] -> IDLE phase');
+          } else if (!isActivePhase && phaseElapsed > IDLE_PHASE_MS) {
+            isActivePhase = true;
+            phaseStartTime = now;
+            console.error('[endurance] -> ACTIVE phase');
+          }
+
+          // --- MCP server restart every 4 hours ---
+          if (now - lastMcpRestart > MCP_RESTART_INTERVAL_MS) {
+            console.error('[endurance] Restarting MCP server (scheduled 4-hour cycle)...');
+            const restartStart = Date.now();
+            try {
+              await mcp.restart();
+              const elapsed = Date.now() - restartStart;
+              metrics.mcpRestarts++;
+              metrics.reconnects++;
+              metrics.recoveryTimes.push(elapsed);
+              console.error(`[endurance] MCP server restarted in ${elapsed}ms`);
+            } catch (err) {
+              console.error('[endurance] MCP restart failed:', err);
+              metrics.failedOperations++;
+            }
+            lastMcpRestart = Date.now();
+          }
+
+          // --- Chrome restart every hour (simulate crash) ---
+          if (now - lastChromeRestart > CHROME_RESTART_INTERVAL_MS) {
+            console.error('[endurance] Simulating Chrome crash (scheduled hourly kill)...');
+            const restartStart = Date.now();
+            try {
+              await chrome.discoverPid(CHROME_DEBUG_PORT);
+              await chrome.kill('SIGKILL');
+
+              // Wait for watchdog / auto-launch to recover Chrome
+              await new Promise<void>((r) => setTimeout(r, CHROME_RECOVERY_WAIT_MS));
+
+              // Verify recovery by performing a navigation
+              await mcp.callTool('navigate', { url: testUrls[0] }, 60_000);
+              const recoveryMs = Date.now() - restartStart;
+              metrics.recoveryTimes.push(recoveryMs);
+              metrics.chromeRestarts++;
+              metrics.reconnects++;
+              console.error(`[endurance] Chrome recovered in ${recoveryMs}ms`);
+            } catch (err) {
+              console.error('[endurance] Chrome restart/recovery failed:', err);
+              metrics.failedOperations++;
+              metrics.totalOperations++;
+            }
+            lastChromeRestart = Date.now();
+          }
+
+          // --- Active phase: cycle through operations ---
+          if (isActivePhase) {
+            const url = testUrls[metrics.totalOperations % testUrls.length];
+            try {
+              const navResult = await mcp.callTool('navigate', { url });
+              metrics.totalOperations++;
+              metrics.successfulOperations++;
+
+              // Follow-up read_page on the navigated tab
+              const tabIdMatch = navResult.text.match(/"tabId"\s*:\s*"([A-F0-9]{32})"/);
+              if (tabIdMatch) {
+                const readResult = await mcp.callTool('read_page', { tabId: tabIdMatch[1] });
+                expect(readResult.text.length).toBeGreaterThan(0);
+                metrics.totalOperations++;
+                metrics.successfulOperations++;
+              }
+            } catch (err) {
+              metrics.totalOperations++;
+              metrics.failedOperations++;
+              console.error('[endurance] Operation failed:', err);
+            }
+          }
+
+          // --- Health metrics every 5 minutes ---
+          if (now - lastHealthLog > HEALTH_LOG_INTERVAL_MS) {
+            const heapBytes = process.memoryUsage().heapUsed;
+            metrics.heapSamples.push(heapBytes);
+            heapSampler.takeSample();
+
+            const elapsedPct  = ((now - metrics.startTime) / DURATION_MS * 100).toFixed(1);
+            const successRate = metrics.totalOperations > 0
+              ? (metrics.successfulOperations / metrics.totalOperations * 100).toFixed(1)
+              : '100.0';
+
+            console.error(
+              `[endurance] Progress: ${elapsedPct}% | ` +
+              `Ops: ${metrics.totalOperations} (${successRate}% success) | ` +
+              `ChromeRestarts: ${metrics.chromeRestarts} | ` +
+              `McpRestarts: ${metrics.mcpRestarts} | ` +
+              `Heap: ${Math.round(heapBytes / 1024 / 1024)}MB`
+            );
+            lastHealthLog = now;
+          }
+
+          // Throttle polling to avoid CPU spin (constants are already pre-scaled)
+          await new Promise<void>((r) =>
+            setTimeout(r, isActivePhase ? ACTIVE_POLL_DELAY_MS : IDLE_POLL_DELAY_MS)
+          );
+        }
+
+        // --- Final assertions ---
+
+        // 1. Success rate > 95%
+        const successRate = metrics.totalOperations > 0
+          ? metrics.successfulOperations / metrics.totalOperations
+          : 1;
+        console.error(
+          `[endurance] Final success rate: ${(successRate * 100).toFixed(2)}% ` +
+          `(${metrics.successfulOperations}/${metrics.totalOperations})`
+        );
+        expect(successRate).toBeGreaterThan(0.95);
+
+        // 2. Average Chrome recovery time < 30s
+        if (metrics.recoveryTimes.length > 0) {
+          const avgRecovery =
+            metrics.recoveryTimes.reduce((a, b) => a + b, 0) / metrics.recoveryTimes.length;
+          metrics.avgRecoveryTimeMs = avgRecovery;
+          console.error(`[endurance] Avg recovery time: ${avgRecovery.toFixed(0)}ms`);
+          expect(avgRecovery).toBeLessThan(30_000);
+        }
+
+        // 3. Heap growth < 200MB over duration
+        if (metrics.heapSamples.length >= 2) {
+          const quarterLen  = Math.ceil(metrics.heapSamples.length / 4);
+          const firstSlice  = metrics.heapSamples.slice(0, quarterLen);
+          const lastSlice   = metrics.heapSamples.slice(-quarterLen);
+          const avgFirst    = firstSlice.reduce((a, b) => a + b, 0) / firstSlice.length;
+          const avgLast     = lastSlice.reduce((a, b) => a + b, 0) / lastSlice.length;
+          const growthMB    = (avgLast - avgFirst) / 1024 / 1024;
+          console.error(`[endurance] Heap growth: ${growthMB.toFixed(1)}MB`);
+          expect(growthMB).toBeLessThan(200);
+        }
+
+        heapSampler.assertStable(200); // < 200MB MCP server RSS delta
+      },
+      DURATION_MS + JEST_OVERHEAD_MS + 60_000 // duration + 1-min buffer + fixed overhead
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `tests/e2e/scenarios/endurance-24h.e2e.ts` — Jest-based E2E-8 endurance test, skipped by default (requires `OPENCHROME_ENDURANCE=1`). Alternates 10-min active / 20-min idle phases, simulates hourly Chrome crashes, restarts the MCP server every 4 hours, and asserts >95% success rate, <30s avg recovery, and <200MB heap growth.
- Adds `tests/e2e/endurance-runner.ts` — standalone `ts-node` script that manages its own fixture HTTP server, runs the same loop, and writes a timestamped JSON metrics report, exiting 0 (pass) or 1 (fail).
- Both files honour `ENDURANCE_HOURS` (default 1 for CI, 24 for manual runs) and `TIME_SCALE` for CI compression.

## Test plan

- [ ] `npm run build` passes with no TypeScript errors
- [ ] Normal `npm test` skips E2E-8 (no `OPENCHROME_ENDURANCE=1` set)
- [ ] `OPENCHROME_ENDURANCE=1 ENDURANCE_HOURS=1 npx jest tests/e2e/scenarios/endurance-24h.e2e.ts` runs the 1-hour smoke run
- [ ] `ENDURANCE_HOURS=1 npx ts-node tests/e2e/endurance-runner.ts` produces a JSON report and exits 0
- [ ] Nightly CI can set `OPENCHROME_ENDURANCE=1 ENDURANCE_HOURS=24` for a full 24-hour run

🤖 Generated with [Claude Code](https://claude.com/claude-code)