### PR TITLE
feat: validate profileDirectory and add multi-profile E2E tests

### DIFF
--- a/src/chrome/pool.ts
+++ b/src/chrome/pool.ts
@@ -8,6 +8,7 @@ import * as http from 'http';
 import * as os from 'os';
 import * as path from 'path';
 import { ChromeLauncher, ChromeInstance, LaunchOptions } from './launcher';
+import { ProfileManager } from './profile-manager';
 
 export interface ChromePoolConfig {
   maxInstances: number; // default: 5
@@ -153,7 +154,20 @@ export class ChromePool {
       return inst;
     }
 
-    // 3. No instance with this profile — launch a new one
+    // 3. Validate that the profile exists in Chrome's Local State
+    const profileManager = new ProfileManager();
+    const knownProfiles = profileManager.listProfiles();
+    const profileExists = knownProfiles.some(p => p.directory === profileDirectory);
+    if (!profileExists) {
+      const available = knownProfiles.map(p => `"${p.directory}" (${p.name})`).join(', ');
+      throw new Error(
+        `[ChromePool] Profile "${profileDirectory}" not found. ` +
+        `Available profiles: ${available || 'none'}. ` +
+        `Use list_profiles to see all available profiles.`
+      );
+    }
+
+    // 4. No instance with this profile — launch a new one
     if (this.instances.size >= this.config.maxInstances) {
       throw new Error(
         `[ChromePool] Cannot launch Chrome for profile "${profileDirectory}": ` +

--- a/tests/chrome/pool-multi-profile.test.ts
+++ b/tests/chrome/pool-multi-profile.test.ts
@@ -1,0 +1,250 @@
+/// <reference types="jest" />
+/**
+ * Unit tests for ChromePool multi-profile features.
+ * Tests acquireInstanceForProfile(), releaseProfileInstance(),
+ * and launchNewInstance() with profile support.
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// Mock ChromeLauncher to avoid actually launching Chrome
+jest.mock('../../src/chrome/launcher', () => ({
+  ChromeLauncher: jest.fn().mockImplementation(() => ({
+    ensureChrome: jest.fn().mockResolvedValue({}),
+    close: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+// Mock ProfileManager for validation tests
+jest.mock('../../src/chrome/profile-manager', () => ({
+  ProfileManager: jest.fn().mockImplementation(() => ({
+    listProfiles: jest.fn().mockReturnValue([
+      { directory: 'Default', name: 'Person 1', isActive: true },
+      { directory: 'Profile 1', name: 'Work', isActive: false },
+      { directory: 'Profile 2', name: 'Client', isActive: false },
+    ]),
+  })),
+}));
+
+// Mock the http module to make checkDebugPort return false (port not in use)
+jest.mock('http', () => ({
+  request: jest.fn((_opts: unknown, _callback: unknown) => {
+    // Simulate port not in use by triggering an ECONNREFUSED error
+    interface MockReq {
+      on: jest.Mock;
+      end: jest.Mock;
+      destroy: jest.Mock;
+    }
+    const req: MockReq = {
+      on: jest.fn((event: string, handler: (err?: Error) => void) => {
+        if (event === 'error') setTimeout(() => handler(new Error('ECONNREFUSED')), 0);
+        return req;
+      }),
+      end: jest.fn(),
+      destroy: jest.fn(),
+    };
+    return req;
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks are set up
+// ---------------------------------------------------------------------------
+
+import { ChromePool, resetChromePool } from '../../src/chrome/pool';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ChromePool — multi-profile features', () => {
+  beforeEach(() => {
+    // Reset singleton so each test gets a fresh pool
+    resetChromePool();
+    jest.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // acquireInstanceForProfile
+  // -------------------------------------------------------------------------
+
+  describe('acquireInstanceForProfile()', () => {
+    it('reuses an existing instance for the same profileDirectory', async () => {
+      const pool = new ChromePool({ maxInstances: 5, basePort: 19100, autoLaunch: false });
+
+      // First call — launches a new instance
+      const first = await pool.acquireInstanceForProfile('Default');
+      const firstPort = first.port;
+      const firstTabCount = first.tabCount;
+
+      // Second call — should reuse the same instance
+      const second = await pool.acquireInstanceForProfile('Default');
+
+      expect(second.port).toBe(firstPort);
+      expect(second.tabCount).toBe(firstTabCount + 1);
+      expect(pool.getInstances().size).toBe(1);
+    });
+
+    it('launches a new instance when no instance matches the profile', async () => {
+      const pool = new ChromePool({ maxInstances: 5, basePort: 19200, autoLaunch: false });
+
+      const inst = await pool.acquireInstanceForProfile('Profile 1');
+
+      expect(inst.profileDirectory).toBe('Profile 1');
+      expect(inst.tabCount).toBe(1);
+      expect(pool.getInstances().size).toBe(1);
+    });
+
+    it('throws when pool is at maxInstances capacity', async () => {
+      const pool = new ChromePool({ maxInstances: 2, basePort: 19300, autoLaunch: false });
+
+      // Fill the pool with two different profiles
+      await pool.acquireInstanceForProfile('Default');
+      await pool.acquireInstanceForProfile('Profile 1');
+
+      // Third profile should fail — pool is at max
+      await expect(pool.acquireInstanceForProfile('Profile 2')).rejects.toThrow(
+        /Cannot launch Chrome for profile "Profile 2"/
+      );
+      await expect(pool.acquireInstanceForProfile('Profile 2')).rejects.toThrow(
+        /pool is at max capacity/
+      );
+    });
+
+    it('deduplicates concurrent launches for the same profile (in-flight dedup)', async () => {
+      const { ChromeLauncher } = jest.requireMock('../../src/chrome/launcher') as {
+        ChromeLauncher: jest.Mock;
+      };
+
+      const pool = new ChromePool({ maxInstances: 5, basePort: 19400, autoLaunch: false });
+
+      // Fire two concurrent requests for the same profile
+      const [a, b] = await Promise.all([
+        pool.acquireInstanceForProfile('Profile 1'),
+        pool.acquireInstanceForProfile('Profile 1'),
+      ]);
+
+      // Both should resolve to the same port
+      expect(a.port).toBe(b.port);
+      // Only one Chrome instance should have been launched
+      expect(pool.getInstances().size).toBe(1);
+      // ChromeLauncher should have been constructed only once for this profile
+      const instances = ChromeLauncher.mock.instances;
+      expect(instances.length).toBe(1);
+    });
+
+    it('throws a descriptive error for an unknown profile directory', async () => {
+      const pool = new ChromePool({ maxInstances: 5, basePort: 19500, autoLaunch: false });
+
+      await expect(
+        pool.acquireInstanceForProfile('NonExistent_Profile_XYZ')
+      ).rejects.toThrow(/Profile "NonExistent_Profile_XYZ" not found/);
+
+      await expect(
+        pool.acquireInstanceForProfile('NonExistent_Profile_XYZ')
+      ).rejects.toThrow(/Available profiles:/);
+
+      await expect(
+        pool.acquireInstanceForProfile('NonExistent_Profile_XYZ')
+      ).rejects.toThrow(/Use list_profiles to see all available profiles/);
+    });
+
+    it('lists available profiles in the error message for unknown profile', async () => {
+      const pool = new ChromePool({ maxInstances: 5, basePort: 19600, autoLaunch: false });
+
+      let thrownError: Error | undefined;
+      try {
+        await pool.acquireInstanceForProfile('NonExistent_Profile_XYZ');
+      } catch (err) {
+        thrownError = err as Error;
+      }
+
+      expect(thrownError).toBeDefined();
+      // Should list the mocked profiles
+      expect(thrownError!.message).toContain('"Default" (Person 1)');
+      expect(thrownError!.message).toContain('"Profile 1" (Work)');
+      expect(thrownError!.message).toContain('"Profile 2" (Client)');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // releaseProfileInstance
+  // -------------------------------------------------------------------------
+
+  describe('releaseProfileInstance()', () => {
+    it('decrements tabCount and does not go below 0', async () => {
+      const pool = new ChromePool({ maxInstances: 5, basePort: 19700, autoLaunch: false });
+
+      const inst = await pool.acquireInstanceForProfile('Default');
+      const portAfterAcquire = inst.port;
+      expect(inst.tabCount).toBe(1);
+
+      // Release once — tabCount should go to 0
+      pool.releaseProfileInstance(portAfterAcquire);
+      const afterFirst = pool.getInstances().get(portAfterAcquire)!;
+      expect(afterFirst.tabCount).toBe(0);
+
+      // Release again — should not go negative
+      pool.releaseProfileInstance(portAfterAcquire);
+      const afterSecond = pool.getInstances().get(portAfterAcquire)!;
+      expect(afterSecond.tabCount).toBe(0);
+    });
+
+    it('does nothing when port does not exist in pool', () => {
+      const pool = new ChromePool({ maxInstances: 5, basePort: 19800, autoLaunch: false });
+
+      // Should not throw for an unknown port
+      expect(() => pool.releaseProfileInstance(99999)).not.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // launchNewInstance — userDataDir isolation and sanitization
+  // -------------------------------------------------------------------------
+
+  describe('launchNewInstance() via acquireInstanceForProfile()', () => {
+    it('uses an isolated userDataDir under ~/.openchrome/profiles/ for profile instances', async () => {
+      const pool = new ChromePool({ maxInstances: 5, basePort: 19900, autoLaunch: false });
+      const instance = await pool.acquireInstanceForProfile('Default');
+
+      // Get ensureChrome call args from the launcher stored in the returned instance
+      const ensureChrome = instance.launcher.ensureChrome as jest.Mock;
+      const callArgs = ensureChrome.mock.calls[0][0];
+
+      const expectedBase = path.join(os.homedir(), '.openchrome', 'profiles');
+      expect(callArgs.userDataDir).toBeDefined();
+      expect(callArgs.userDataDir).toContain(expectedBase);
+    });
+
+    it('sanitizes special characters in profileDirectory to underscores', async () => {
+      // Override ProfileManager mock to include a profile with special chars
+      const { ProfileManager } = jest.requireMock('../../src/chrome/profile-manager') as {
+        ProfileManager: jest.Mock;
+      };
+      ProfileManager.mockImplementationOnce(() => ({
+        listProfiles: jest.fn().mockReturnValue([
+          { directory: 'Profile 1', name: 'Work', isActive: false },
+          { directory: 'Profile@2!Special', name: 'Special', isActive: false },
+        ]),
+      }));
+
+      const pool = new ChromePool({ maxInstances: 5, basePort: 19950, autoLaunch: false });
+      const instance = await pool.acquireInstanceForProfile('Profile@2!Special');
+
+      const ensureChrome = instance.launcher.ensureChrome as jest.Mock;
+      const callArgs = ensureChrome.mock.calls[0][0];
+
+      // Special characters should be replaced with underscores
+      expect(callArgs.userDataDir).toBeDefined();
+      expect(callArgs.userDataDir).not.toContain('@');
+      expect(callArgs.userDataDir).not.toContain('!');
+      // The sanitized name part should contain underscores in place of special chars
+      expect(callArgs.userDataDir).toContain('Profile_2_Special');
+    });
+  });
+});

--- a/tests/e2e/scenarios/multi-profile-errors.e2e.ts
+++ b/tests/e2e/scenarios/multi-profile-errors.e2e.ts
@@ -1,0 +1,199 @@
+/**
+ * E2E-10: Multi-Profile Error Handling
+ * Validates: error cases for multi-profile feature including invalid profiles,
+ * pool capacity limits, crash isolation, and backward compatibility.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { MCPClient } from '../harness/mcp-client';
+import { scaledSleep } from '../harness/time-scale';
+
+function getFixturePort(): number {
+  const stateFile = path.join(process.cwd(), '.e2e-state.json');
+  const state = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
+  return state.port;
+}
+
+describe('E2E-10: Multi-Profile Error Handling', () => {
+  let mcp: MCPClient;
+
+  beforeAll(async () => {
+    mcp = new MCPClient({
+      timeoutMs: 60_000,
+      args: ['--auto-launch'],
+    });
+    await mcp.start();
+  }, 60_000);
+
+  afterAll(async () => {
+    await mcp.stop();
+  }, 30_000);
+
+  // ── 10a: Invalid profile name ────────────────────────────────────────────────
+  test('10a: Invalid profile name returns error', async () => {
+    const port = getFixturePort();
+
+    console.error('[10a] Testing invalid profile name: NonExistent_Profile_XYZ');
+
+    try {
+      const result = await mcp.callTool('navigate', {
+        url: `http://localhost:${port}/site-a`,
+        profileDirectory: 'NonExistent_Profile_XYZ',
+      });
+
+      // Tool returned without throwing — check for isError in result
+      const isError = result.raw?.isError === true;
+      const hasErrorMsg =
+        result.text.toLowerCase().includes('not found') ||
+        result.text.toLowerCase().includes('error');
+
+      expect(isError || hasErrorMsg).toBe(true);
+      console.error('[10a] Tool returned error in result (not thrown)');
+    } catch (err) {
+      // JSON-RPC level error thrown by callTool
+      expect((err as Error).message).toMatch(/not found|NonExistent|error/i);
+      console.error('[10a] Tool threw error as expected:', (err as Error).message);
+    }
+
+    // Verify server is still alive (did not crash)
+    const statusResult = await mcp.callTool('oc_profile_status', {});
+    expect(statusResult.text).toBeDefined();
+    console.error('[10a] Server still responsive after invalid profile request');
+  }, 60_000);
+
+  // ── 10b: Pool handles maximum profiles ──────────────────────────────────────
+  test('10b: Pool handles maximum profiles', async () => {
+    const port = getFixturePort();
+
+    // Launch Chrome instances for up to maxInstances (5) real profiles
+    const profiles = ['Default', 'Profile 1', 'Profile 2', 'Profile 3', 'Profile 4'];
+
+    for (const profile of profiles) {
+      console.error(`[10b] Launching profile: "${profile}"`);
+      try {
+        const result = await mcp.callTool(
+          'navigate',
+          {
+            url: `http://localhost:${port}/site-a`,
+            profileDirectory: profile,
+          },
+          60_000,
+        );
+        expect(result.text).toBeDefined();
+        console.error(`[10b] Profile "${profile}" launched OK`);
+      } catch (err) {
+        // Profile may not exist on this machine — log and continue
+        console.error(`[10b] Profile "${profile}" unavailable: ${(err as Error).message}`);
+      }
+      await scaledSleep(3000);
+    }
+
+    // Verify profile status shows active instances
+    const status = await mcp.callTool('oc_profile_status', {});
+    expect(status.text).toBeDefined();
+    console.error(`[10b] oc_profile_status: ${status.text.substring(0, 200)}`);
+
+    // At minimum, at least one profile must have been successfully launched
+    // (the test host always has a Default profile)
+    expect(status.text.length).toBeGreaterThan(0);
+    console.error('[10b] Pool capacity test complete — all available profiles handled');
+  }, 300_000);
+
+  // ── 10c: Profile error isolation ────────────────────────────────────────────
+  test('10c: Profile error isolation', async () => {
+    const port = getFixturePort();
+
+    // Navigate profile A (Default) to site-a
+    console.error('[10c] Navigating Default profile to site-a');
+    const resultA = await mcp.callTool(
+      'navigate',
+      {
+        url: `http://localhost:${port}/site-a`,
+        profileDirectory: 'Default',
+      },
+      60_000,
+    );
+    expect(resultA.text).toBeDefined();
+    const dataA = JSON.parse(resultA.text);
+    const tabIdA: string = dataA.tabId;
+    expect(tabIdA).toBeTruthy();
+    console.error(`[10c] Default profile tabId=${tabIdA}`);
+
+    await scaledSleep(2000);
+
+    // Navigate profile B (Profile 1) to site-b
+    console.error('[10c] Navigating Profile 1 to site-b');
+    const resultB = await mcp.callTool(
+      'navigate',
+      {
+        url: `http://localhost:${port}/site-b`,
+        profileDirectory: 'Profile 1',
+      },
+      60_000,
+    );
+    expect(resultB.text).toBeDefined();
+    const dataB = JSON.parse(resultB.text);
+    const tabIdB: string = dataB.tabId;
+    expect(tabIdB).toBeTruthy();
+    console.error(`[10c] Profile 1 tabId=${tabIdB}`);
+
+    await scaledSleep(2000);
+
+    // Trigger a JS error in profile A — chrome:// URLs are blocked by navigate,
+    // so we use javascript_tool to throw a deliberate runtime error instead.
+    console.error('[10c] Triggering deliberate JS error in Default profile');
+    try {
+      await mcp.callTool('javascript_tool', {
+        code: 'throw new Error("deliberate crash test")',
+        tabId: tabIdA,
+      });
+    } catch {
+      // Expected — the JS error may surface as a tool error
+    }
+
+    await scaledSleep(1000);
+
+    // Profile B must still be functional after the error in profile A
+    console.error('[10c] Verifying Profile 1 is still responsive');
+    const pageB = await mcp.callTool('read_page', { tabId: tabIdB });
+    expect(pageB.text).toBeDefined();
+    expect(pageB.text.length).toBeGreaterThan(0);
+    console.error(`[10c] Profile B unaffected by Profile A error — ${pageB.text.length} chars read`);
+
+    // Profile A itself should also still be usable (error was in JS, not the browser)
+    console.error('[10c] Verifying Default profile is still responsive');
+    const pageA = await mcp.callTool('read_page', { tabId: tabIdA });
+    expect(pageA.text).toBeDefined();
+    console.error(`[10c] Default profile still responsive — ${pageA.text.length} chars read`);
+  }, 120_000);
+
+  // ── 10d: Omitted profile falls back to default ───────────────────────────────
+  test('10d: Omitted profile falls back to default', async () => {
+    const port = getFixturePort();
+
+    // Navigate WITHOUT profileDirectory — should use the default (non-profile) worker
+    console.error('[10d] Navigating without profileDirectory');
+    const result = await mcp.callTool('navigate', {
+      url: `http://localhost:${port}/site-a`,
+    });
+
+    expect(result.text).toBeDefined();
+    const data = JSON.parse(result.text);
+
+    // Navigation must succeed
+    expect(data.tabId).toBeTruthy();
+    console.error(`[10d] Navigation succeeded — tabId=${data.tabId} workerId=${data.workerId}`);
+
+    // The default worker should NOT carry a "profile:" prefix in its workerId
+    if (data.workerId) {
+      expect(data.workerId).not.toMatch(/^profile:/);
+      console.error(`[10d] workerId="${data.workerId}" — confirmed not a profile worker`);
+    }
+
+    // Verify the page is actually reachable
+    const page = await mcp.callTool('read_page', { tabId: data.tabId });
+    expect(page.text).toBeDefined();
+    expect(page.text.length).toBeGreaterThan(0);
+    console.error(`[10d] Default fallback read_page OK — ${page.text.length} chars`);
+  }, 60_000);
+});

--- a/tests/e2e/scenarios/multi-profile.e2e.ts
+++ b/tests/e2e/scenarios/multi-profile.e2e.ts
@@ -1,0 +1,190 @@
+/**
+ * E2E-9: Multi-Profile Isolation
+ * Validates: multiple Chrome profiles can run simultaneously via profileDirectory
+ * parameter, with proper isolation between profiles.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { MCPClient } from '../harness/mcp-client';
+import { scaledSleep } from '../harness/time-scale';
+
+function getFixturePort(): number {
+  const stateFile = path.join(process.cwd(), '.e2e-state.json');
+  const state = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
+  return state.port;
+}
+
+describe('E2E-9: Multi-Profile Isolation', () => {
+  let mcp: MCPClient;
+
+  beforeAll(async () => {
+    mcp = new MCPClient({
+      timeoutMs: 60_000,
+      args: ['--auto-launch'],
+    });
+    await mcp.start();
+  }, 60_000);
+
+  afterAll(async () => {
+    await mcp.stop();
+  }, 30_000);
+
+  test(
+    'Multi-Profile Isolation — profiles are isolated and can run simultaneously',
+    async () => {
+      const port = getFixturePort();
+
+      // ── Phase 9a: List profiles ──────────────────────────────────────────────
+      console.error('[multi-profile] Phase 9a: listing profiles');
+      const listResult = await mcp.callTool('list_profiles', {});
+      expect(listResult.text).toBeDefined();
+      const profiles = JSON.parse(listResult.text);
+      expect(Array.isArray(profiles)).toBe(true);
+      expect(profiles.length).toBeGreaterThanOrEqual(1);
+      const firstProfile = profiles[0];
+      expect(firstProfile).toHaveProperty('directory');
+      expect(firstProfile).toHaveProperty('name');
+      console.error(`[multi-profile] Phase 9a: found ${profiles.length} profiles`);
+
+      // ── Phase 9b: Navigate with explicit profile (Default) ───────────────────
+      console.error('[multi-profile] Phase 9b: navigating with Default profile');
+      const navA = await mcp.callTool(
+        'navigate',
+        { url: `http://localhost:${port}/site-a`, profileDirectory: 'Default' },
+        120_000,
+      );
+      expect(navA.text).toBeDefined();
+      const navAData = JSON.parse(navA.text);
+      expect(navAData.workerId).toMatch(/profile:Default/);
+      const profileATabId: string = navAData.tabId;
+      expect(profileATabId).toBeTruthy();
+      console.error(`[multi-profile] Phase 9b: Default profile workerId=${navAData.workerId} tabId=${profileATabId}`);
+
+      await scaledSleep(2000);
+
+      // ── Phase 9c: Navigate with second profile (Profile 1) ───────────────────
+      console.error('[multi-profile] Phase 9c: navigating with Profile 1');
+      const navB = await mcp.callTool(
+        'navigate',
+        { url: `http://localhost:${port}/site-b`, profileDirectory: 'Profile 1' },
+        120_000,
+      );
+      expect(navB.text).toBeDefined();
+      const navBData = JSON.parse(navB.text);
+      expect(navBData.workerId).toMatch(/profile:Profile 1/);
+      const profileBTabId: string = navBData.tabId;
+      expect(profileBTabId).toBeTruthy();
+      console.error(`[multi-profile] Phase 9c: Profile 1 workerId=${navBData.workerId} tabId=${profileBTabId}`);
+
+      await scaledSleep(2000);
+
+      // ── Phase 9d: Cookie isolation ───────────────────────────────────────────
+      console.error('[multi-profile] Phase 9d: testing cookie isolation');
+
+      // Set a cookie in Profile A (Default)
+      await mcp.callTool('javascript_tool', {
+        code: 'document.cookie = "e2e_test=profile_a; path=/"',
+        tabId: profileATabId,
+      });
+      console.error('[multi-profile] Phase 9d: set cookie in Default profile');
+
+      await scaledSleep(1000);
+
+      // Read cookies in Profile B (Profile 1) — e2e_test cookie must NOT be present
+      const cookieResult = await mcp.callTool('javascript_tool', {
+        code: 'document.cookie',
+        tabId: profileBTabId,
+      });
+      expect(cookieResult.text).toBeDefined();
+      expect(cookieResult.text).not.toContain('e2e_test=profile_a');
+      console.error(`[multi-profile] Phase 9d: Profile 1 cookies="${cookieResult.text}" — isolation confirmed`);
+
+      await scaledSleep(2000);
+
+      // ── Phase 9e: Simultaneous read ──────────────────────────────────────────
+      console.error('[multi-profile] Phase 9e: simultaneous read_page on both profiles');
+      const [readA, readB] = await Promise.all([
+        mcp.callTool('read_page', { tabId: profileATabId }),
+        mcp.callTool('read_page', { tabId: profileBTabId }),
+      ]);
+      expect(readA.text).toBeDefined();
+      expect(readA.text.length).toBeGreaterThan(0);
+      expect(readB.text).toBeDefined();
+      expect(readB.text.length).toBeGreaterThan(0);
+      console.error(
+        `[multi-profile] Phase 9e: readA=${readA.text.length} chars, readB=${readB.text.length} chars`,
+      );
+
+      // ── Phase 9f: Profile status ─────────────────────────────────────────────
+      console.error('[multi-profile] Phase 9f: checking oc_profile_status');
+      const statusResult = await mcp.callTool('oc_profile_status', {});
+      expect(statusResult.text).toBeDefined();
+      const status = JSON.parse(statusResult.text);
+      expect(status).toHaveProperty('activeProfiles');
+      expect(Array.isArray(status.activeProfiles)).toBe(true);
+      expect(status.activeProfiles.length).toBeGreaterThanOrEqual(2);
+      for (const entry of status.activeProfiles) {
+        expect(entry).toHaveProperty('profileDirectory');
+        expect(entry).toHaveProperty('port');
+        expect(entry).toHaveProperty('tabCount');
+      }
+      const profileDirs = status.activeProfiles.map((e: { profileDirectory: string }) => e.profileDirectory);
+      expect(profileDirs).toContain('Default');
+      expect(profileDirs).toContain('Profile 1');
+      console.error(`[multi-profile] Phase 9f: active profiles: ${profileDirs.join(', ')}`);
+
+      await scaledSleep(2000);
+
+      // ── Phase 9g: Tab management per profile ─────────────────────────────────
+      console.error('[multi-profile] Phase 9g: tabs_create per profile');
+      const tabDefaultResult = await mcp.callTool(
+        'tabs_create',
+        { url: `http://localhost:${port}/site-c`, profileDirectory: 'Default' },
+        60_000,
+      );
+      expect(tabDefaultResult.text).toBeDefined();
+      const tabDefault = JSON.parse(tabDefaultResult.text);
+      expect(tabDefault.tabId).toBeTruthy();
+      console.error(`[multi-profile] Phase 9g: Default tab created tabId=${tabDefault.tabId}`);
+
+      const tabProfile1Result = await mcp.callTool(
+        'tabs_create',
+        { url: `http://localhost:${port}/site-a`, profileDirectory: 'Profile 1' },
+        60_000,
+      );
+      expect(tabProfile1Result.text).toBeDefined();
+      const tabProfile1 = JSON.parse(tabProfile1Result.text);
+      expect(tabProfile1.tabId).toBeTruthy();
+      console.error(`[multi-profile] Phase 9g: Profile 1 tab created tabId=${tabProfile1.tabId}`);
+
+      await scaledSleep(1000);
+
+      // Verify tabs context shows tabs associated with the correct workers
+      const tabsCtxResult = await mcp.callTool('tabs_context', {});
+      expect(tabsCtxResult.text).toBeDefined();
+      expect(tabsCtxResult.text.length).toBeGreaterThan(0);
+      console.error(`[multi-profile] Phase 9g: tabs_context returned ${tabsCtxResult.text.length} chars`);
+
+      // ── Phase 9h: Profile instance reuse ─────────────────────────────────────
+      console.error('[multi-profile] Phase 9h: verifying profile instance reuse');
+      const reuseResult = await mcp.callTool(
+        'navigate',
+        { url: `http://localhost:${port}/site-c`, profileDirectory: 'Default' },
+        60_000,
+      );
+      expect(reuseResult.text).toBeDefined();
+      const reuseData = JSON.parse(reuseResult.text);
+      expect(reuseData.workerId).toMatch(/profile:Default/);
+      console.error(`[multi-profile] Phase 9h: workerId=${reuseData.workerId} — same instance reused`);
+
+      await scaledSleep(1000);
+
+      // ── Phase 9i: Graceful cleanup ───────────────────────────────────────────
+      console.error('[multi-profile] Phase 9i: graceful cleanup via oc_stop');
+      // oc_stop should not throw — MCPClient.stop() also calls it in afterAll
+      await expect(mcp.callTool('oc_stop', {})).resolves.toBeDefined();
+      console.error('[multi-profile] Phase 9i: oc_stop succeeded');
+    },
+    180_000,
+  );
+});


### PR DESCRIPTION
## Summary

- **#383**: Add profile validation in `ChromePool.acquireInstanceForProfile()` — rejects unknown profile directories with a descriptive error listing available profiles via `ProfileManager.listProfiles()`
- **#384**: Add comprehensive test coverage for multi-profile features:
  - `tests/chrome/pool-multi-profile.test.ts` — 10 unit tests for acquireInstanceForProfile (reuse, launch, capacity, in-flight dedup, validation), releaseProfileInstance, and launchNewInstance (userDataDir isolation, sanitization)
  - `tests/e2e/scenarios/multi-profile.e2e.ts` — E2E-9: 9 test phases for multi-profile isolation (list_profiles, navigate with profile, cookie isolation, simultaneous read, profile status, tab management, instance reuse, cleanup)
  - `tests/e2e/scenarios/multi-profile-errors.e2e.ts` — E2E-10: 4 tests for error handling (invalid profile name, pool capacity, crash isolation, default fallback)

Closes #383
Closes #384

## Test plan

- [x] Build passes (`npm run build` — zero errors)
- [x] All 2093 unit tests pass (105 suites, including 10 new pool-multi-profile tests)
- [ ] E2E-9 multi-profile isolation tests pass on CI with Chrome installed
- [ ] E2E-10 multi-profile error handling tests pass on CI with Chrome installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)