### PR TITLE
feat: add idle profile instance reaper to ChromePool

### DIFF
--- a/src/chrome/pool.ts
+++ b/src/chrome/pool.ts
@@ -23,6 +23,7 @@ export interface PooledInstance {
   tabCount: number;
   isPreExisting: boolean; // was it already running when we found it?
   profileDirectory?: string; // Chrome profile directory (e.g., "Profile 1", "Default")
+  lastActiveAt: number; // timestamp of last tab activity (used by idle reaper)
 }
 
 const DEFAULT_POOL_CONFIG: ChromePoolConfig = {
@@ -71,6 +72,9 @@ export class ChromePool {
   private instances: Map<number, PooledInstance> = new Map();
   // In-flight dedup: prevent concurrent launches for the same profile (P1-3 fix)
   private profileLaunchInFlight: Map<string, Promise<PooledInstance>> = new Map();
+  private reaperTimer: ReturnType<typeof setInterval> | null = null;
+  private static readonly DEFAULT_IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+  private static readonly DEFAULT_REAPER_INTERVAL_MS = 60 * 1000; // check every 60s
 
   constructor(config: Partial<ChromePoolConfig> = {}) {
     this.config = { ...DEFAULT_POOL_CONFIG, ...config };
@@ -86,6 +90,7 @@ export class ChromePool {
       if (!instance.origins.has(origin)) {
         instance.origins.add(origin);
         instance.tabCount++;
+        instance.lastActiveAt = Date.now();
         console.error(
           `[ChromePool] Assigned origin "${origin}" to existing instance on port ${instance.port}`
         );
@@ -98,6 +103,7 @@ export class ChromePool {
       const newInstance = await this.launchNewInstance();
       newInstance.origins.add(origin);
       newInstance.tabCount++;
+      newInstance.lastActiveAt = Date.now();
       console.error(
         `[ChromePool] Launched new instance on port ${newInstance.port} for origin "${origin}"`
       );
@@ -137,6 +143,7 @@ export class ChromePool {
       if (instance.profileDirectory === profileDirectory) {
         if (origin) instance.origins.add(origin);
         instance.tabCount++;
+        instance.lastActiveAt = Date.now();
         console.error(
           `[ChromePool] Reusing existing instance on port ${instance.port} for profile "${profileDirectory}"`
         );
@@ -151,6 +158,7 @@ export class ChromePool {
       const inst = await inflight;
       if (origin) inst.origins.add(origin);
       inst.tabCount++;
+      inst.lastActiveAt = Date.now();
       return inst;
     }
 
@@ -185,6 +193,7 @@ export class ChromePool {
     const newInstance = await launchPromise;
     if (origin) newInstance.origins.add(origin);
     newInstance.tabCount++;
+    newInstance.lastActiveAt = Date.now();
     console.error(
       `[ChromePool] Launched new instance on port ${newInstance.port} for profile "${profileDirectory}"`
     );
@@ -203,6 +212,7 @@ export class ChromePool {
     if (removed && instance.tabCount > 0) {
       instance.tabCount--;
     }
+    instance.lastActiveAt = Date.now();
     console.error(
       `[ChromePool] Released origin "${origin}" from port ${port}. ` +
         `Remaining origins: ${instance.tabCount}`
@@ -219,6 +229,7 @@ export class ChromePool {
     if (instance.tabCount > 0) {
       instance.tabCount--;
     }
+    instance.lastActiveAt = Date.now();
     console.error(
       `[ChromePool] Released profile instance on port ${port}. Tab count: ${instance.tabCount}`
     );
@@ -228,6 +239,7 @@ export class ChromePool {
    * Close all instances we launched (not pre-existing ones).
    */
   async cleanup(): Promise<void> {
+    this.stopReaper();
     const closurePromises: Promise<void>[] = [];
 
     for (const [port, instance] of this.instances) {
@@ -245,6 +257,74 @@ export class ChromePool {
     this.instances.clear();
     this.profileLaunchInFlight.clear();
     console.error('[ChromePool] Cleanup complete.');
+  }
+
+  /**
+   * Start the idle instance reaper.
+   * Periodically checks for profile instances with tabCount === 0
+   * that have been idle for longer than the threshold, and closes them.
+   */
+  startReaper(idleTimeoutMs: number = ChromePool.DEFAULT_IDLE_TIMEOUT_MS): void {
+    if (this.reaperTimer) return; // already running
+
+    this.reaperTimer = setInterval(() => {
+      this.reapIdleInstances(idleTimeoutMs).catch((err) => {
+        console.error('[ChromePool] Reaper error:', err);
+      });
+    }, ChromePool.DEFAULT_REAPER_INTERVAL_MS);
+    this.reaperTimer.unref(); // don't prevent process exit
+    console.error(`[ChromePool] Idle instance reaper started (timeout: ${idleTimeoutMs / 1000}s)`);
+  }
+
+  /**
+   * Stop the idle instance reaper.
+   */
+  stopReaper(): void {
+    if (this.reaperTimer) {
+      clearInterval(this.reaperTimer);
+      this.reaperTimer = null;
+      console.error('[ChromePool] Idle instance reaper stopped');
+    }
+  }
+
+  /**
+   * Close idle profile instances.
+   * An instance is considered idle if:
+   * 1. It has tabCount === 0 (no active workers)
+   * 2. It has been idle for longer than idleTimeoutMs
+   * 3. It is not pre-existing (we don't close user-started Chrome)
+   * 4. It has a profileDirectory (only profile instances are reaped, not origin-based)
+   */
+  private async reapIdleInstances(idleTimeoutMs: number): Promise<number> {
+    const now = Date.now();
+    let reaped = 0;
+
+    for (const [port, instance] of this.instances) {
+      if (
+        instance.tabCount === 0 &&
+        !instance.isPreExisting &&
+        instance.profileDirectory &&
+        (now - instance.lastActiveAt) > idleTimeoutMs
+      ) {
+        console.error(
+          `[ChromePool] Reaping idle profile instance "${instance.profileDirectory}" on port ${port} ` +
+          `(idle for ${Math.round((now - instance.lastActiveAt) / 1000)}s)`
+        );
+        try {
+          await instance.launcher.close();
+        } catch (err) {
+          console.error(`[ChromePool] Failed to close idle instance on port ${port}:`, err);
+        }
+        this.instances.delete(port);
+        reaped++;
+      }
+    }
+
+    if (reaped > 0) {
+      console.error(`[ChromePool] Reaped ${reaped} idle instance(s)`);
+    }
+
+    return reaped;
   }
 
   /**
@@ -299,6 +379,7 @@ export class ChromePool {
       tabCount: 0,
       isPreExisting,
       profileDirectory,
+      lastActiveAt: Date.now(),
     };
 
     this.instances.set(port, pooled);

--- a/tests/chrome/pool-reaper.test.ts
+++ b/tests/chrome/pool-reaper.test.ts
@@ -1,0 +1,172 @@
+import { ChromePool, resetChromePool, PooledInstance } from '../../src/chrome/pool';
+
+// Mock ChromeLauncher
+jest.mock('../../src/chrome/launcher', () => ({
+  ChromeLauncher: jest.fn().mockImplementation((port: number) => ({
+    ensureChrome: jest.fn().mockResolvedValue({
+      wsEndpoint: `ws://127.0.0.1:${port}`,
+      httpEndpoint: `http://127.0.0.1:${port}`,
+    }),
+    close: jest.fn().mockResolvedValue(undefined),
+    getPort: jest.fn().mockReturnValue(port),
+    isConnected: jest.fn().mockReturnValue(true),
+    getChromePid: jest.fn().mockReturnValue(undefined),
+  })),
+  getChromeLauncher: jest.fn(),
+}));
+
+// Mock ProfileManager
+jest.mock('../../src/chrome/profile-manager', () => ({
+  ProfileManager: jest.fn().mockImplementation(() => ({
+    listProfiles: jest.fn().mockReturnValue([
+      { directory: 'Default', name: 'Person 1' },
+      { directory: 'Profile 1', name: 'Person 2' },
+    ]),
+  })),
+}));
+
+// Mock http for checkDebugPort
+jest.mock('http', () => ({
+  request: jest.fn().mockImplementation((_opts: unknown, _cb: unknown) => {
+    // Simulate port not responding (for launchNewInstance)
+    const req = {
+      on: jest.fn().mockImplementation((event: string, handler: Function) => {
+        if (event === 'error') setTimeout(() => handler(new Error('ECONNREFUSED')), 10);
+        return req;
+      }),
+      end: jest.fn(),
+      destroy: jest.fn(),
+    };
+    return req;
+  }),
+}));
+
+describe('ChromePool idle instance reaper', () => {
+  let pool: ChromePool;
+
+  beforeEach(() => {
+    resetChromePool();
+    jest.useFakeTimers();
+    pool = new ChromePool({ maxInstances: 5, basePort: 19500, autoLaunch: true });
+  });
+
+  afterEach(() => {
+    pool.stopReaper();
+    jest.useRealTimers();
+    resetChromePool();
+  });
+
+  it('starts and stops the reaper without errors', () => {
+    pool.startReaper(60000);
+    pool.stopReaper();
+    // No error thrown
+  });
+
+  it('startReaper is idempotent', () => {
+    pool.startReaper(60000);
+    pool.startReaper(60000); // second call is no-op
+    pool.stopReaper();
+  });
+
+  it('reaps idle profile instances after timeout', async () => {
+    const mockLauncher = {
+      close: jest.fn().mockResolvedValue(undefined),
+      ensureChrome: jest.fn(),
+      getPort: jest.fn().mockReturnValue(19501),
+      isConnected: jest.fn().mockReturnValue(true),
+    };
+
+    const instances = (pool as any).instances as Map<number, PooledInstance>;
+    instances.set(19501, {
+      port: 19501,
+      launcher: mockLauncher as any,
+      origins: new Set(),
+      tabCount: 0,
+      isPreExisting: false,
+      profileDirectory: 'Profile 1',
+      lastActiveAt: Date.now() - 10 * 60 * 1000, // 10 minutes ago
+    });
+
+    // Call reapIdleInstances directly to avoid fake timer infinite loop with setInterval
+    const reaped = await (pool as any).reapIdleInstances(5 * 60 * 1000);
+
+    expect(reaped).toBe(1);
+    expect(mockLauncher.close).toHaveBeenCalled();
+    expect(instances.size).toBe(0);
+  });
+
+  it('does NOT reap instances with active tabs', async () => {
+    const mockLauncher = {
+      close: jest.fn().mockResolvedValue(undefined),
+      ensureChrome: jest.fn(),
+      getPort: jest.fn().mockReturnValue(19502),
+    };
+
+    const instances = (pool as any).instances as Map<number, PooledInstance>;
+    instances.set(19502, {
+      port: 19502,
+      launcher: mockLauncher as any,
+      origins: new Set(),
+      tabCount: 1, // active tab!
+      isPreExisting: false,
+      profileDirectory: 'Profile 1',
+      lastActiveAt: Date.now() - 10 * 60 * 1000,
+    });
+
+    const reaped = await (pool as any).reapIdleInstances(5 * 60 * 1000);
+
+    expect(reaped).toBe(0);
+    expect(mockLauncher.close).not.toHaveBeenCalled();
+    expect(instances.size).toBe(1);
+  });
+
+  it('does NOT reap pre-existing instances', async () => {
+    const mockLauncher = {
+      close: jest.fn().mockResolvedValue(undefined),
+      ensureChrome: jest.fn(),
+      getPort: jest.fn().mockReturnValue(19503),
+    };
+
+    const instances = (pool as any).instances as Map<number, PooledInstance>;
+    instances.set(19503, {
+      port: 19503,
+      launcher: mockLauncher as any,
+      origins: new Set(),
+      tabCount: 0,
+      isPreExisting: true, // pre-existing!
+      profileDirectory: 'Default',
+      lastActiveAt: Date.now() - 10 * 60 * 1000,
+    });
+
+    const reaped = await (pool as any).reapIdleInstances(5 * 60 * 1000);
+
+    expect(reaped).toBe(0);
+    expect(mockLauncher.close).not.toHaveBeenCalled();
+    expect(instances.size).toBe(1);
+  });
+
+  it('does NOT reap non-profile (origin-based) instances', async () => {
+    const mockLauncher = {
+      close: jest.fn().mockResolvedValue(undefined),
+      ensureChrome: jest.fn(),
+      getPort: jest.fn().mockReturnValue(19504),
+    };
+
+    const instances = (pool as any).instances as Map<number, PooledInstance>;
+    instances.set(19504, {
+      port: 19504,
+      launcher: mockLauncher as any,
+      origins: new Set(['https://example.com']),
+      tabCount: 0,
+      isPreExisting: false,
+      // no profileDirectory
+      lastActiveAt: Date.now() - 10 * 60 * 1000,
+    });
+
+    const reaped = await (pool as any).reapIdleInstances(5 * 60 * 1000);
+
+    expect(reaped).toBe(0);
+    expect(mockLauncher.close).not.toHaveBeenCalled();
+    expect(instances.size).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an idle instance reaper to `ChromePool` that periodically closes profile Chrome instances with `tabCount === 0` idle for longer than 5 minutes (configurable)
- Prevents memory/port leakage on long-running servers that create and delete profile sessions
- Only reaps profile instances (not origin-based or pre-existing)
- Tracks `lastActiveAt` timestamp on all pool instances

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (new: 6 tests)
- [x] Idle profile instances are reaped after timeout
- [x] Active instances (tabCount > 0) are NOT reaped
- [x] Pre-existing instances are NOT reaped
- [x] Non-profile (origin-based) instances are NOT reaped
- [x] startReaper/stopReaper are idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)