### PR TITLE
feat: add deployment infrastructure (systemd, Docker, PM2)

### DIFF
--- a/deploy/docker/.dockerignore
+++ b/deploy/docker/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+dist
+.git
+.github
+tests
+docs
+*.md
+.eslintrc*
+.prettierrc*
+jest.config.*
+tsconfig.*.json
+!tsconfig.json
+!tsconfig.cli.json

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,0 +1,64 @@
+# OpenChrome MCP Server — Production Docker Image
+# Build:  docker build -t openchrome -f deploy/docker/Dockerfile .
+# Run:    docker run -p 3100:3100 -p 9090:9090 openchrome
+
+FROM node:22-slim AS builder
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json tsconfig.cli.json ./
+COPY src/ src/
+COPY cli/ cli/
+RUN npm run build
+
+FROM node:22-slim
+
+# Install Chrome dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    chromium \
+    fonts-liberation \
+    libnss3 \
+    libatk-bridge2.0-0 \
+    libdrm2 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxrandr2 \
+    libgbm1 \
+    libasound2 \
+    libpangocairo-1.0-0 \
+    libgtk-3-0 \
+    ca-certificates \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN groupadd -r openchrome && useradd -r -g openchrome -m openchrome
+
+WORKDIR /app
+
+# Copy built artifacts and production dependencies
+COPY --from=builder /app/dist/ dist/
+COPY --from=builder /app/node_modules/ node_modules/
+COPY package.json ./
+
+# Create data directory
+RUN mkdir -p /home/openchrome/.openchrome && chown -R openchrome:openchrome /home/openchrome
+
+USER openchrome
+
+# Environment defaults
+ENV CHROME_BINARY=/usr/bin/chromium
+ENV NODE_ENV=production
+ENV OPENCHROME_MAX_RECONNECT_ATTEMPTS=0
+ENV OPENCHROME_EVENT_LOOP_FATAL_MS=30000
+
+# Expose ports: MCP HTTP transport + Health endpoint
+EXPOSE 3100 9090
+
+# Health check using the built-in health endpoint
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -sf http://localhost:9090/health || exit 1
+
+# Start in HTTP daemon mode
+CMD ["node", "dist/index.js", "serve", "--http", "3100", "--auto-launch", "--server-mode"]

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -1,0 +1,27 @@
+# OpenChrome MCP Server — Docker Compose
+# Start: docker compose -f deploy/docker/docker-compose.yml up -d
+# Logs:  docker compose -f deploy/docker/docker-compose.yml logs -f
+
+services:
+  openchrome:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/Dockerfile
+    ports:
+      - "3100:3100"   # MCP HTTP transport
+      - "9090:9090"   # Health + Metrics endpoint
+    volumes:
+      - openchrome-data:/home/openchrome/.openchrome
+    environment:
+      - OPENCHROME_RATE_LIMIT_RPM=120
+      - OPENCHROME_MAX_RECONNECT_ATTEMPTS=0
+      - OPENCHROME_EVENT_LOOP_FATAL_MS=30000
+    restart: unless-stopped
+    # Chrome needs these for headless operation
+    shm_size: '2gb'
+    security_opt:
+      - no-new-privileges:true
+
+volumes:
+  openchrome-data:
+    driver: local

--- a/deploy/pm2/ecosystem.config.js
+++ b/deploy/pm2/ecosystem.config.js
@@ -1,0 +1,46 @@
+// OpenChrome MCP Server — PM2 Ecosystem Configuration
+// Install: npm install -g pm2
+// Start:   pm2 start deploy/pm2/ecosystem.config.js
+// Monitor: pm2 monit
+// Logs:    pm2 logs openchrome
+
+module.exports = {
+  apps: [
+    {
+      name: 'openchrome',
+      script: 'dist/index.js',
+      args: 'serve --http 3100 --auto-launch --server-mode',
+
+      // Restart policy
+      autorestart: true,
+      exp_backoff_restart_delay: 100, // Exponential backoff: 100ms, 200ms, 400ms...
+      max_restarts: 50,               // Max restarts within restart_delay window
+      min_uptime: '10s',              // Consider crashed if exits within 10s
+
+      // Resource limits
+      max_memory_restart: '500M',     // Restart if memory exceeds 500MB
+
+      // Environment
+      env: {
+        NODE_ENV: 'production',
+        OPENCHROME_MAX_RECONNECT_ATTEMPTS: '0',      // Infinite reconnection
+        OPENCHROME_EVENT_LOOP_FATAL_MS: '30000',      // 30s fatal threshold
+        OPENCHROME_RATE_LIMIT_RPM: '120',             // Rate limit
+      },
+
+      // Logging
+      error_file: 'logs/openchrome-error.log',
+      out_file: 'logs/openchrome-out.log',
+      merge_logs: true,
+      log_date_format: 'YYYY-MM-DD HH:mm:ss Z',
+
+      // Watch (disabled for production — enable for development)
+      watch: false,
+      ignore_watch: ['node_modules', 'logs', '.openchrome', '.omc'],
+
+      // Cluster mode (single instance — Chrome connection is per-process)
+      instances: 1,
+      exec_mode: 'fork',
+    },
+  ],
+};

--- a/deploy/systemd/openchrome.env
+++ b/deploy/systemd/openchrome.env
@@ -1,0 +1,23 @@
+# OpenChrome environment configuration
+# Copy to /etc/openchrome/env and customize
+
+# Chrome debugging port (default: 9222)
+# CHROME_PORT=9222
+
+# HTTP transport port (default: 3100)
+# OPENCHROME_HTTP_PORT=3100
+
+# Health endpoint port (default: 9090)
+# OPENCHROME_HEALTH_PORT=9090
+
+# Rate limit (requests/minute per session, 0=disabled)
+# OPENCHROME_RATE_LIMIT_RPM=120
+
+# Reconnection attempts (0=infinite, default in HTTP mode: infinite)
+# OPENCHROME_MAX_RECONNECT_ATTEMPTS=0
+
+# Event loop fatal threshold (ms, 0=disabled, default: 30000)
+# OPENCHROME_EVENT_LOOP_FATAL_MS=30000
+
+# Chrome binary path (auto-detected if not set)
+# CHROME_BINARY=/usr/bin/google-chrome-stable

--- a/deploy/systemd/openchrome.service
+++ b/deploy/systemd/openchrome.service
@@ -1,0 +1,47 @@
+# OpenChrome MCP Server — systemd service unit
+# Install: sudo cp deploy/systemd/openchrome.service /etc/systemd/system/
+# Enable:  sudo systemctl enable --now openchrome
+# Logs:    journalctl -u openchrome -f
+
+[Unit]
+Description=OpenChrome MCP Browser Automation Server
+Documentation=https://github.com/shaun0927/openchrome
+After=network.target
+
+[Service]
+Type=simple
+User=openchrome
+Group=openchrome
+WorkingDirectory=/opt/openchrome
+
+# Environment configuration (override defaults here)
+EnvironmentFile=-/etc/openchrome/env
+
+# Start the HTTP daemon
+ExecStart=/usr/bin/node dist/index.js serve --http 3100 --auto-launch --server-mode
+
+# Wait for health endpoint before reporting ready
+ExecStartPost=/bin/sh -c 'for i in $(seq 1 30); do curl -sf http://127.0.0.1:9090/health > /dev/null && exit 0; sleep 1; done; exit 1'
+
+# Restart policy
+Restart=always
+RestartSec=3
+
+# Resource limits
+MemoryMax=512M
+TasksMax=100
+
+# Security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/home/openchrome/.openchrome
+PrivateTmp=true
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=openchrome
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Add production-ready deployment artifacts for systemd, Docker, and PM2
- All configurations pre-tuned with HTTP daemon mode, infinite reconnection, rate limiting, and fatal threshold
- No code changes — configuration files only

This is **Phase 6** of the [Reliability Guarantee Initiative](docs/roadmap/issue-reliability-guarantee.md). Depends on Phase 1 (`--http` flag).

## Problem

OpenChrome is production-ready at the code level but ships no deployment artifacts. Users who want to run it as a system daemon must write their own init configuration, often missing critical settings like `shm_size` for Chrome or infinite reconnection mode.

## Artifacts

### systemd (`deploy/systemd/`)

| File | Purpose |
|------|---------|
| `openchrome.service` | Unit file with `Restart=always`, 512MB memory limit, security hardening (`NoNewPrivileges`, `ProtectSystem=strict`), health check via `ExecStartPost` |
| `openchrome.env` | Sample environment file with all configurable env vars documented |

```bash
sudo cp deploy/systemd/openchrome.service /etc/systemd/system/
sudo systemctl enable --now openchrome
journalctl -u openchrome -f
```

### Docker (`deploy/docker/`)

| File | Purpose |
|------|---------|
| `Dockerfile` | Multi-stage build (builder + runtime), Chromium installed, non-root user, `HEALTHCHECK` directive |
| `docker-compose.yml` | Single-service with 2GB `shm_size` (Chrome needs this), persistent volume, port mapping |
| `.dockerignore` | Optimized build context (excludes tests, docs, node_modules) |

```bash
docker compose -f deploy/docker/docker-compose.yml up -d
curl http://localhost:9090/health
```

### PM2 (`deploy/pm2/`)

| File | Purpose |
|------|---------|
| `ecosystem.config.js` | Fork mode, exponential backoff restart (100ms base), 500MB memory limit, structured log files |

```bash
pm2 start deploy/pm2/ecosystem.config.js
pm2 monit
```

## Pre-configured settings (all three)

| Setting | Value | Purpose |
|---------|-------|---------|
| `--http 3100` | HTTP daemon mode | Server survives client disconnect |
| `--auto-launch` | Auto-start Chrome | No manual Chrome management |
| `--server-mode` | Headless, no cookie bridge | Production optimized |
| `OPENCHROME_MAX_RECONNECT_ATTEMPTS=0` | Infinite | Never give up reconnecting |
| `OPENCHROME_EVENT_LOOP_FATAL_MS=30000` | 30s | Exit on hang (supervisor restarts) |
| `OPENCHROME_RATE_LIMIT_RPM=120` | 120 req/min | Overload protection |

## Test plan

- [x] No code changes — build/test unaffected
- [ ] Manual: systemd unit starts and health check passes
- [ ] Manual: Docker build succeeds and container starts
- [ ] Manual: PM2 starts and restarts on crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)