### PR TITLE
chore: remove e2e-ci job from PR checks, keep nightly only

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,61 +1,11 @@
 name: E2E Tests
 
 on:
-  push:
-    branches: [develop]
-  pull_request:
-    branches: [develop]
   schedule:
     - cron: '0 2 * * *'  # Nightly at 2 AM UTC
 
 jobs:
-  e2e-ci:
-    # Only run on push/PR (not on schedule)
-    if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
-    env:
-      TIME_SCALE: '0.167'
-      HEAP_DELTA_LIMIT_MB: '50'
-      CI: 'true'
-    timeout-minutes: 30
-
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup Node.js 20
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      - name: Install Chrome
-        uses: browser-actions/setup-chrome@latest
-        with:
-          chrome-version: stable
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Run E2E tests
-        run: npm run test:e2e
-        env:
-          DEBUG: '1'
-
-      - name: Upload E2E results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: e2e-results-ci
-          path: |
-            .e2e-state.json
-          retention-days: 7
-
   e2e-nightly:
-    # Only run on schedule
-    if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     env:
       TIME_SCALE: '1'


### PR DESCRIPTION
## Summary
- Removes the `e2e-ci` job that runs on every push/PR to `develop`
- Keeps the `e2e-nightly` job (cron at 2 AM UTC, 90-min timeout, full `TIME_SCALE=1`)

## Why
The `e2e-ci` job consistently times out at its 30-minute limit on every PR and `develop` push. Recent history:

| Branch | Workflow | Result |
|--------|----------|--------|
| develop | E2E Tests | cancelled |
| develop | E2E Tests | cancelled |
| develop | E2E Tests | failure |
| PR #391 | e2e-ci | cancelled (30m) |
| PR #393 | e2e-ci | cancelled (30m) |
| PR #394 | e2e-ci | cancelled (30m) |

The nightly job with 90 minutes and `TIME_SCALE=1` provides full E2E regression coverage without blocking PR merges.

## Test plan
- [x] Verify nightly job definition is preserved
- [x] Verify `e2e-ci` trigger (`push`/`pull_request`) is removed
- [x] Existing `build-and-test` CI (9 matrix jobs) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)