### PR TITLE
fix: infinite reconnect race condition and watchdog dead-chrome detection

### DIFF
--- a/src/chrome/process-watchdog.ts
+++ b/src/chrome/process-watchdog.ts
@@ -74,12 +74,19 @@ export class ChromeProcessWatchdog extends EventEmitter {
     if (this.launcher.intentionalStop) return; // Chrome was stopped intentionally — do not relaunch
 
     const instance = this.launcher.getInstance();
-    if (!instance) return; // Chrome not launched by us — nothing to watch
+    let pid: number | undefined;
 
-    const pid = instance.process?.pid;
+    if (instance) {
+      pid = instance.process?.pid;
+      if (pid) this.lastKnownPid = pid;
+    } else if (this.lastKnownPid) {
+      // Instance was invalidated by CDPClient reconnection loop, but we
+      // still know the last Chrome PID — check if it's alive so we can
+      // trigger a relaunch when it's not.
+      pid = this.lastKnownPid;
+    }
+
     if (!pid) return; // no PID tracked
-
-    this.lastKnownPid = pid;
 
     try {
       process.kill(pid, 0); // signal 0 = check existence only

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,6 +180,13 @@ program
       console.error('[openchrome] Tier 2 tools exposed from startup');
     }
 
+    // Set infinite reconnection for HTTP daemon mode BEFORE creating CDPClient singleton.
+    // getMCPServer() → SessionManager → getCDPClient() reads this env var at construction.
+    const useHttp = options.http !== undefined && options.http !== false;
+    if (useHttp && !process.env.OPENCHROME_MAX_RECONNECT_ATTEMPTS) {
+      process.env.OPENCHROME_MAX_RECONNECT_ATTEMPTS = '0';
+    }
+
     const server = getMCPServer();
     registerAllTools(server);
 
@@ -226,11 +233,7 @@ program
     if (process.platform === 'win32') {
       process.on('SIGHUP', () => shutdown('SIGHUP'));
     }
-    // Determine transport mode
-    const useHttp = options.http !== undefined && options.http !== false;
-    if (useHttp && !process.env.OPENCHROME_MAX_RECONNECT_ATTEMPTS) {
-      process.env.OPENCHROME_MAX_RECONNECT_ATTEMPTS = '0';
-    }
+    // Start transport (useHttp was determined above, before getMCPServer)
     if (useHttp) {
       const httpPort = typeof options.http === 'string' ? parseInt(options.http, 10) : 3100;
       const transport = createTransport('http', { port: httpPort });


### PR DESCRIPTION
## Summary

- **Fix CDPClient infinite reconnect race condition** — `OPENCHROME_MAX_RECONNECT_ATTEMPTS='0'` was set AFTER `getMCPServer()` created the CDPClient singleton (via SessionManager), causing `maxReconnectAttempts=5` instead of `Infinity` in HTTP daemon mode
- **Fix ProcessWatchdog dead-chrome detection** — CDPClient's reconnect loop calls `invalidateInstance()` which nulled the cached Chrome instance, making the Watchdog skip its check ("nothing to watch") and never relaunch Chrome
- Together these bugs meant Chrome crashes in daemon mode were unrecoverable

## Root Cause

### Bug 1: Initialization order
```
index.ts:183  getMCPServer()
  → MCPServer → SessionManager → getCDPClient()
    → reads OPENCHROME_MAX_RECONNECT_ATTEMPTS (NOT SET → defaults to 5)

index.ts:232  process.env.OPENCHROME_MAX_RECONNECT_ATTEMPTS = '0'  ← TOO LATE
```

### Bug 2: Instance invalidation race
```
CDPClient.handleDisconnect() → invalidateInstance() → launcher.instance = null
ProcessWatchdog.check() → getInstance() === null → return (skip)
→ Chrome never relaunched
```

## Fix

1. Move env var setting to before `getMCPServer()` call
2. Use `lastKnownPid` as fallback in ProcessWatchdog when instance is invalidated

## Verification

Tested Chrome kill → recovery cycle on macOS:

```
Kill Chrome (SIGKILL)
  → [CDPClient] Reconnect attempt 1/∞...          (was 1/5 before fix)
  → [ProcessWatchdog] Chrome (PID 67041) is dead   (was silent before fix)
  → [ProcessWatchdog] Chrome relaunched (PID 67397)
  → [CDPClient] Reconnected
  → Health: Chrome=True, Reconnects=1
  → Tool call: SUCCESS (navigate to httpbin.org)
```

Full recovery in ~15 seconds. OpenChrome process survives throughout.

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` — 113 suites, 2152 tests all pass
- [ ] Start HTTP daemon, kill Chrome → reconnect shows `1/∞` (not `1/5`)
- [ ] Watchdog logs `Chrome process is dead, attempting relaunch`
- [ ] Tool call succeeds after Chrome relaunch
- [ ] Stdio mode still defaults to 5 reconnect attempts

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)