### PR TITLE
fix: reduce heartbeat ping timeout to detect frozen Chrome faster

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -124,9 +124,11 @@ export const DEFAULT_MAX_RECONNECT_ATTEMPTS_HTTP = Infinity;
 /** Heartbeat active ping timeout in milliseconds.
  *  Sends Browser.getVersion to detect half-open WebSocket connections
  *  (e.g., after macOS sleep/wake) that browser.isConnected() misses.
- *  Set higher than heartbeat interval (5s) to avoid false-positive disconnects
- *  when Chrome is under heavy CPU load (GC pauses, complex JS execution). */
-export const DEFAULT_HEARTBEAT_PING_TIMEOUT_MS = 15000;
+ *  5s is 50x longer than normal Chrome response (<100ms) and handles
+ *  heavy CPU load (GC pauses ~1-2s). The 2-strike policy in checkConnection()
+ *  provides additional false-positive protection. Lower values enable faster
+ *  detection of frozen/network-blocked Chrome (#408). */
+export const DEFAULT_HEARTBEAT_PING_TIMEOUT_MS = 5000;
 
 /** Connection verification staleness threshold in milliseconds.
  *  If the connection hasn't been verified (by heartbeat or probe) within this window,


### PR DESCRIPTION
## Summary

Reduces `DEFAULT_HEARTBEAT_PING_TIMEOUT_MS` from 15s to 5s so that in-flight tool calls return errors within ~15s when Chrome is frozen or network-blocked, instead of hanging for 30-40s.

## Problem

When Chrome is frozen (SIGSTOP / network block), the MCP server's heartbeat detection was too slow:
- Heartbeat interval: 5s
- Ping timeout: **15s** (old)
- 2 consecutive failures required
- **Total detection time: ~35-40s** — tool calls hang for the entire duration

## Fix

- Reduce `DEFAULT_HEARTBEAT_PING_TIMEOUT_MS` from 15000 to **5000**ms
- Combined with `browser.disconnect()` in `handleDisconnect()` (merged in 087100b), this rejects in-flight CDP operations immediately upon detection
- **New detection time: ~15s**

## Why 5s is safe

- Normal `Browser.getVersion()` response: **<100ms**
- Chrome under heavy CPU load (GC pauses): **1-2s**
- 5s timeout: **50x safety margin**
- The 2-strike policy in `checkConnection()` already protects against false positives (one timeout is forgiven)

## Verification

SIGSTOP freeze test on macOS:

| Metric | Before | After |
|--------|--------|-------|
| Error return time | **25s+ (curl timeout)** | **12.5s** |
| Error type | None (hang) | `Protocol error: Target closed` |
| Recovery after SIGCONT | Yes | Yes |
| Unit tests | 2152 pass | 2152 pass |

## Test plan

- [x] `npm test` — 2152/2152 pass (no regressions)
- [x] Manual SIGSTOP/SIGCONT test — error in 12.5s, recovery confirmed
- [x] `kill-recovery.e2e.ts` — PASS
- [x] `marathon.e2e.ts` — PASS (100% success rate)

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)