### PR TITLE
fix: wire up 3 missing Prometheus metrics from Phase 5

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -27,6 +27,7 @@ import {
   DEFAULT_RECONNECT_DELAY_MS,
 } from '../config/defaults';
 import { withTimeout } from '../utils/with-timeout';
+import { getMetricsCollector } from '../metrics/collector';
 
 // Cookie type shared across methods
 type CookieEntry = {
@@ -474,6 +475,7 @@ export class CDPClient {
         this.reconnectingAttempt = 0;
         this.reconnectNextRetryAt = 0;
         this.reconnectCount++;
+        try { getMetricsCollector().inc('openchrome_reconnect_total'); } catch { /* best-effort */ }
         this.setHeartbeatMode('recovery');
         this.emitConnectionEvent({
           type: 'reconnected',

--- a/src/index.ts
+++ b/src/index.ts
@@ -349,6 +349,7 @@ program
         chrome: chromeData,
         tabs: { total: tabHealth.size, healthy: healthyTabs, unhealthy: unhealthyTabs },
         disk: diskData,
+        sessions: { active: sessionManager?.sessionCount ?? 0 },
       };
       return data;
     }, healthPort);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -577,6 +577,7 @@ export class MCPServer {
       const rateResult = this.rateLimiter.check(sessionId);
       if (!rateResult.allowed) {
         console.error(`[MCPServer] Rate limit exceeded for session ${sessionId}, retry after ${rateResult.retryAfterSec}s`);
+        try { getMetricsCollector().inc('openchrome_rate_limit_rejections_total', { tool: toolName }); } catch { /* best-effort */ }
         return {
           content: [
             {

--- a/src/metrics/collector.ts
+++ b/src/metrics/collector.ts
@@ -197,6 +197,7 @@ export function getMetricsCollector(): MetricsCollector {
     instance.registerGauge('openchrome_heap_bytes', 'Node.js heap usage in bytes');
     instance.registerGauge('openchrome_active_sessions', 'Current active MCP sessions');
     instance.registerGauge('openchrome_tabs_health', 'Tab health status count');
+    instance.registerCounter('openchrome_rate_limit_rejections_total', 'Requests rejected by rate limiter');
   }
   return instance;
 }

--- a/src/watchdog/health-endpoint.ts
+++ b/src/watchdog/health-endpoint.ts
@@ -31,6 +31,9 @@ export interface HealthData {
     totalBytes: number;
     fileCount: number;
   };
+  sessions?: {
+    active: number;
+  };
 }
 
 export type HealthDataProvider = () => HealthData;
@@ -75,7 +78,7 @@ export class HealthEndpoint {
               metrics.set('openchrome_tabs_health', { status: 'unhealthy' }, data.tabs.unhealthy);
             }
             if (data.chrome) {
-              metrics.set('openchrome_active_sessions', {}, 0); // Will be updated by MCPServer
+              metrics.set('openchrome_active_sessions', {}, data.sessions?.active ?? 0);
             }
 
             res.writeHead(200, { 'Content-Type': 'text/plain; version=0.0.4; charset=utf-8' });


### PR DESCRIPTION
## Summary

Closes the last code-level gaps from the Reliability Guarantee Initiative (#403, Phase 5 — Prometheus Metrics Export):

- **`openchrome_reconnect_total`**: Was registered in the metrics collector but never incremented. Added `getMetricsCollector().inc()` call in `CDPClient.handleDisconnect()` after each successful reconnection.
- **`openchrome_active_sessions`**: Was registered but hardcoded to `0` with a TODO comment. Added `sessions` field to `HealthData` interface, wired `SessionManager.sessionCount` into the health provider closure, and replaced the hardcoded `0` with the live value.
- **`openchrome_rate_limit_rejections_total`**: Was completely absent. Registered the new counter in the metrics singleton and added an increment in the rate-limiter rejection path in `handleToolsCall()` before the early return.

All three follow the existing best-effort pattern (wrapped in try/catch) to avoid impacting tool call reliability.

### Files Changed (5 files, +9 −1)

| File | Change |
|------|--------|
| `src/cdp/client.ts` | Import `getMetricsCollector`, increment `openchrome_reconnect_total` on reconnect |
| `src/metrics/collector.ts` | Register `openchrome_rate_limit_rejections_total` counter |
| `src/mcp-server.ts` | Increment rate limit rejection counter before early return |
| `src/watchdog/health-endpoint.ts` | Add `sessions` to `HealthData`, use live value for gauge |
| `src/index.ts` | Populate `sessions.active` from `SessionManager.sessionCount` |

## Test plan

- [x] `npm run build` passes (0 errors)
- [x] `npm test` passes (2152/2152 tests green)
- [ ] Start HTTP daemon, verify `/metrics` shows `openchrome_active_sessions` > 0 during active session
- [ ] Trigger Chrome reconnection, verify `openchrome_reconnect_total` increments
- [ ] Send requests exceeding rate limit, verify `openchrome_rate_limit_rejections_total` increments

Ref: #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)