### PR TITLE
feat: reject tool calls cleanly during Chrome reconnection

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -134,6 +134,24 @@ export class CDPClient {
   }
 
   /**
+   * Whether the client is currently in a reconnection loop.
+   */
+  isReconnecting(): boolean {
+    return this.reconnecting || this.connectionState === 'reconnecting';
+  }
+
+  /**
+   * Estimated milliseconds until the next reconnection attempt completes.
+   * Returns 0 if not reconnecting.
+   */
+  estimatedRetryMs(): number {
+    if (!this.isReconnecting()) return 0;
+    return this.reconnectNextRetryAt > 0
+      ? Math.max(0, this.reconnectNextRetryAt - Date.now())
+      : this.reconnectDelayMs; // fallback to base delay
+  }
+
+  /**
    * Add connection event listener
    */
   addConnectionListener(listener: (event: ConnectionEvent) => void): void {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -589,6 +589,28 @@ export class MCPServer {
       }
     }
 
+    // Reconnection gate — reject immediately if Chrome is reconnecting
+    try {
+      const cdpClient = getCDPClient();
+      if (cdpClient.isReconnecting()) {
+        const retryMs = cdpClient.estimatedRetryMs();
+        const retrySec = Math.ceil(retryMs / 1000);
+        console.error(`[MCPServer] Rejecting tool call '${toolName}' — Chrome is reconnecting (retry in ~${retrySec}s)`);
+        try { getMetricsCollector().inc('openchrome_tool_calls_total', { tool: toolName, status: 'reconnecting' }); } catch { /* best-effort */ }
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Chrome is currently reconnecting after a disconnection. Please retry in approximately ${retrySec} second(s). The server will automatically reconnect and resume normal operation.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    } catch {
+      // CDPClient may not be initialized — proceed with normal flow
+    }
+
     // Start activity tracking
     const callId = this.activityTracker!.startCall(toolName, sessionId || 'default', toolArgs, requestId);
     const toolStartTime = Date.now();


### PR DESCRIPTION
## Summary

Implements Gap 3 from #416: Reconnection-Aware Request Handling.

- Adds `isReconnecting()` and `estimatedRetryMs()` public accessors to `CDPClient` so callers can inspect reconnection state without coupling to internal fields
- Adds a reconnection gate in `MCPServer.handleToolsCall` that rejects incoming tool calls with a structured error and retry hint when Chrome is in a reconnection loop — preventing race conditions and cryptic failures that previously occurred when requests raced against an in-progress reconnect

## Problem fixed

Before this change, tool calls arriving while Chrome was reconnecting would either race into CDP operations and fail with low-level errors, or queue up and eventually time out with no useful message. The gate makes the failure mode explicit and actionable for callers.

## Test plan

- [x] `npm run build` passes (no TypeScript errors)
- [x] `npm test` passes — 2152 tests across 113 suites
- [x] Manual: `isReconnecting()` returns `true` when `this.reconnecting === true` or `connectionState === 'reconnecting'`
- [x] Manual: `estimatedRetryMs()` returns time-until-next-attempt or falls back to base delay when `reconnectNextRetryAt` is 0
- [x] Gate logs via `console.error` (never `console.log`) to avoid corrupting MCP JSON-RPC stream
- [x] Metrics increment is best-effort (wrapped in try/catch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>