### PR TITLE
fix: use dynamic home path and raise memory limits in systemd config

### DIFF
--- a/deploy/systemd/openchrome.service
+++ b/deploy/systemd/openchrome.service
@@ -31,14 +31,15 @@ RestartSec=3
 KillMode=control-group
 
 # Resource limits
-MemoryMax=512M
+MemoryHigh=1G
+MemoryMax=2G
 TasksMax=100
 
 # Security hardening
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=/home/openchrome/.openchrome
+ReadWritePaths=%h/.openchrome
 PrivateTmp=true
 
 # Logging


### PR DESCRIPTION
## Summary
- **P0**: `ReadWritePaths` now uses `%h` specifier instead of hardcoded `/home/openchrome/.openchrome` for portability across system account configurations (e.g., `useradd -r` creates home at `/var/lib/openchrome`)
- **P1**: `MemoryHigh=1G` (soft throttle) + `MemoryMax=2G` (hard kill) replaces the too-low `MemoryMax=512M`, aligned with app-level Chrome memory thresholds (`DEFAULT_CHROME_MEMORY_CRITICAL_BYTES=2GB`)

## Test plan
- [ ] Review systemd unit file syntax (`systemd-analyze verify`)
- [ ] Deploy to a Linux server with a system account and verify persistence writes succeed
- [ ] Confirm Chrome + Node.js survive normal multi-tab usage without OOM kills

Fixes #421 (items 1, 7 partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)