### PR TITLE
fix: escape Prometheus label values per text format spec

### DIFF
--- a/src/metrics/collector.ts
+++ b/src/metrics/collector.ts
@@ -168,10 +168,14 @@ export class MetricsCollector {
   }
 }
 
+function escapeLabel(v: string): string {
+  return v.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
+}
+
 function formatLabels(labels: Record<string, string>): string {
   const keys = Object.keys(labels);
   if (keys.length === 0) return '';
-  const pairs = keys.map(k => `${k}="${labels[k]}"`).join(',');
+  const pairs = keys.map(k => `${k}="${escapeLabel(labels[k])}"`).join(',');
   return `{${pairs}}`;
 }
 


### PR DESCRIPTION
## Summary
- **P1**: Escape backslash (`\\`), double-quote (`\"`), and newline (`\n`) in Prometheus label values
- Without this, any label value containing these characters causes malformed metrics text, and Prometheus silently rejects the entire scrape

## Test plan
- [ ] Verify `/metrics` endpoint output with tool names containing special characters
- [ ] Validate output against Prometheus text format spec
- [ ] `npm run build` passes
- [ ] `npm test` passes

Fixes #421 (item 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)