### PR TITLE
fix: use file creation time for disk monitor age-based pruning

### DIFF
--- a/src/watchdog/disk-monitor.ts
+++ b/src/watchdog/disk-monitor.ts
@@ -226,7 +226,8 @@ export class DiskMonitor {
       try {
         if (entry.isFile()) {
           const stat = await fs.stat(fullPath);
-          if (stat.mtimeMs < cutoff) {
+          const fileAge = stat.birthtimeMs > 0 ? stat.birthtimeMs : stat.mtimeMs;
+          if (fileAge < cutoff) {
             await fs.unlink(fullPath);
             pruned++;
           }


### PR DESCRIPTION
## Summary
- **P1**: Use `stat.birthtimeMs` (creation time) when available for accurate age-based pruning
- Falls back to `stat.mtimeMs` on platforms where birthtime is not supported (some Linux filesystems)
- Prevents touched/appended files from surviving past the configured retention window

## Test plan
- [ ] Create a journal file, touch it to update mtime → should still be pruned based on birthtime
- [ ] Verify pruning works on macOS (birthtimeMs supported) and Linux (fallback to mtimeMs)
- [ ] `npm run build` passes
- [ ] `npm test` passes

Fixes #421 (item 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)