### PR TITLE
fix: validate page target for cookie restore after reconnection

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -511,19 +511,7 @@ export class CDPClient {
           const { getBrowserStateManager } = await import('../browser-state');
           const stateManager = getBrowserStateManager();
           const cookies = await stateManager.getLatestCookies();
-          const currentBrowser = this.browser as Browser | null;
-          if (cookies && cookies.length > 0 && currentBrowser) {
-            const pages = await currentBrowser.pages();
-            if (pages.length > 0) {
-              const client = await pages[0].createCDPSession();
-              try {
-                await client.send('Network.setCookies', { cookies });
-                console.error(`[CDPClient] Restored ${cookies.length} cookies from snapshot after reconnection`);
-              } finally {
-                await client.detach();
-              }
-            }
-          }
+          await this.restoreCookiesAfterReconnect(cookies);
         } catch (err) {
           console.error('[CDPClient] Cookie restore after reconnection failed (non-fatal):', err);
         }
@@ -824,19 +812,7 @@ export class CDPClient {
         const { getBrowserStateManager } = await import('../browser-state');
         const stateManager = getBrowserStateManager();
         const cookies = await stateManager.getLatestCookies();
-        const currentBrowser = this.browser as Browser | null;
-        if (cookies && cookies.length > 0 && currentBrowser) {
-          const pages = await currentBrowser.pages();
-          if (pages.length > 0) {
-            const client = await pages[0].createCDPSession();
-            try {
-              await client.send('Network.setCookies', { cookies });
-              console.error(`[CDPClient] Restored ${cookies.length} cookies from snapshot after reconnection`);
-            } finally {
-              await client.detach();
-            }
-          }
-        }
+        await this.restoreCookiesAfterReconnect(cookies);
       } catch (err) {
         console.error('[CDPClient] Cookie restore after reconnection failed (non-fatal):', err);
       }
@@ -848,6 +824,32 @@ export class CDPClient {
         error: err instanceof Error ? err.message : String(err),
       });
       throw err;
+    }
+  }
+
+  /**
+   * Restore cookies to the browser after reconnection.
+   * Filters out about:blank and chrome:// pages before selecting the CDP target
+   * to avoid setting cookies on ghost tabs or pool placeholders.
+   */
+  private async restoreCookiesAfterReconnect(cookies: any[] | null): Promise<void> {
+    if (!cookies || cookies.length === 0) return;
+    try {
+      const pages = await this.browser!.pages();
+      const validPage = pages.find(p => {
+        const url = p.url();
+        return url && url !== 'about:blank' && !url.startsWith('chrome://');
+      }) || pages[0]; // fallback to pages[0] if no valid page
+      if (!validPage) return;
+      const client = await validPage.createCDPSession();
+      try {
+        await client.send('Network.setCookies', { cookies });
+        console.error(`[CDPClient] Restored ${cookies.length} cookies from snapshot after reconnection`);
+      } finally {
+        await client.detach();
+      }
+    } catch (err) {
+      console.error('[CDPClient] Cookie restore failed:', err);
     }
   }
 


### PR DESCRIPTION
## Summary
- **P1**: Filter out `about:blank` and `chrome://` pages before selecting the CDP target for cookie restore after reconnection
- Extract shared `restoreCookiesAfterReconnect()` helper to eliminate duplicate code between `handleDisconnect` and `forceReconnect`
- Falls back to `pages[0]` if no valid page found (preserves existing behavior)

## Test plan
- [ ] Kill Chrome while cookies are set → reconnect → cookies restored to valid page (not about:blank)
- [ ] Verify no regression when Chrome has only about:blank tabs (graceful fallback)
- [ ] `npm run build` passes
- [ ] `npm test` — all 2152 tests pass

Fixes #421 (item 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)