### PR TITLE
fix: prevent rate limiter bucket memory leak on session cleanup

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -253,6 +253,14 @@ export class MCPServer {
       this.transport = createTransport('stdio');
     }
 
+    // Wire rate-limiter session cleanup into the HTTP transport so that
+    // bucket memory is freed immediately when a client sends DELETE /mcp.
+    if (this.rateLimiter && typeof (this.transport as unknown as { onSessionDelete?: unknown }).onSessionDelete === 'function') {
+      (this.transport as unknown as { onSessionDelete: (cb: (id: string) => void) => void }).onSessionDelete(
+        (sessionId: string) => this.rateLimiter!.removeSession(sessionId),
+      );
+    }
+
     console.error('[MCPServer] Starting server...');
 
     // Start dashboard if enabled

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -27,9 +27,18 @@ export class HTTPTransport implements MCPTransport {
   private port: number;
   private sessions: Set<string> = new Set();
   private sseConnections: SSEConnection[] = [];
+  private sessionDeleteHandler: ((sessionId: string) => void) | null = null;
 
   constructor(port: number) {
     this.port = port;
+  }
+
+  /**
+   * Register a callback to be invoked whenever a session is deleted.
+   * Used by MCPServer to clean up per-session state (e.g. rate-limiter buckets).
+   */
+  onSessionDelete(handler: (sessionId: string) => void): void {
+    this.sessionDeleteHandler = handler;
   }
 
   onMessage(handler: (msg: Record<string, unknown>) => Promise<MCPResponse | null>): void {
@@ -310,6 +319,11 @@ export class HTTPTransport implements MCPTransport {
 
     if (sessionId && this.sessions.has(sessionId)) {
       this.sessions.delete(sessionId);
+
+      // Notify session-delete listeners (e.g. rate-limiter cleanup)
+      if (this.sessionDeleteHandler) {
+        this.sessionDeleteHandler(sessionId);
+      }
 
       // Close any SSE connections for this session
       this.sseConnections = this.sseConnections.filter((conn) => {

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -13,6 +13,7 @@ export interface RateLimiterOptions {
 export class TokenBucket {
   private tokens: number;
   private lastRefillAt: number;
+  private lastUsedAt: number;
   private readonly maxTokens: number;
   private readonly refillRatePerSec: number;
 
@@ -21,6 +22,7 @@ export class TokenBucket {
     this.refillRatePerSec = opts.refillRatePerSec;
     this.tokens = opts.maxTokens; // Start full
     this.lastRefillAt = Date.now();
+    this.lastUsedAt = Date.now();
   }
 
   /**
@@ -28,12 +30,20 @@ export class TokenBucket {
    * Returns true if token was consumed; false if the bucket is empty.
    */
   consume(): boolean {
+    this.lastUsedAt = Date.now();
     this.refill();
     if (this.tokens >= 1) {
       this.tokens -= 1;
       return true;
     }
     return false;
+  }
+
+  /**
+   * Returns the timestamp (ms since epoch) when this bucket was last used.
+   */
+  getLastUsedAt(): number {
+    return this.lastUsedAt;
   }
 
   /**
@@ -104,6 +114,24 @@ export class SessionRateLimiter {
    */
   removeSession(sessionId: string): void {
     this.buckets.delete(sessionId);
+  }
+
+  /**
+   * Remove buckets that have not been used for longer than maxIdleMs.
+   * Call periodically to reclaim memory from abandoned sessions that never
+   * received an explicit DELETE (e.g. clients that silently disconnected).
+   * Returns the number of buckets removed.
+   */
+  sweep(maxIdleMs: number): number {
+    const cutoff = Date.now() - maxIdleMs;
+    let removed = 0;
+    for (const [sessionId, bucket] of this.buckets) {
+      if (bucket.getLastUsedAt() < cutoff) {
+        this.buckets.delete(sessionId);
+        removed++;
+      }
+    }
+    return removed;
   }
 
   /**


### PR DESCRIPTION
## Summary
- **P1**: Rate limiter `SessionRateLimiter.buckets` Map grew without bound because `removeSession` was never called from the HTTP transport's session deletion path
- Add `lastUsedAt` tracking to `TokenBucket` for idle detection
- Add `sweep(maxIdleMs)` method to `SessionRateLimiter` for periodic stale bucket cleanup
- Add `onSessionDelete` callback to `HTTPTransport`, wired via `MCPServer` to call `removeSession` on session deletion

## Files changed
- `src/utils/rate-limiter.ts` — `lastUsedAt` tracking + `sweep()` method
- `src/transports/http.ts` — `onSessionDelete` callback + invocation in `handleDelete`
- `src/mcp-server.ts` — wires rate limiter cleanup into HTTP transport

## Test plan
- [ ] Start HTTP daemon, connect/disconnect multiple clients → verify bucket count stays bounded
- [ ] Long-running session with many short-lived clients → memory stable
- [ ] `npm run build` passes
- [ ] `npm test` — all 2152 tests pass

Fixes #421 (item 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)