### PR TITLE
fix: enrich stale tab errors with available tab IDs

### DIFF
--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -21,6 +21,7 @@ import { StorageStateManager } from './storage-state';
 import { StorageStateConfig } from './config';
 import { assertDomainAllowed } from './security/domain-guard';
 import { getTargetId } from './utils/puppeteer-helpers';
+import { safeTitle } from './utils/safe-title';
 
 /** The primary session ID used by most single-agent workflows. */
 const DEFAULT_SESSION_ID = 'default';
@@ -1381,6 +1382,35 @@ export class SessionManager {
       : ' No tabs available in this session. Use navigate to open a new page.';
 
     return `Target ${targetId} not found in session ${sessionId}. The tab may have been closed or Chrome may have been restarted.${tabInfo}`;
+  }
+
+  /**
+   * Get available targets for a session, formatted for error messages.
+   * Returns an array of { tabId, url, title } for each live target.
+   */
+  async getAvailableTargets(sessionId: string): Promise<Array<{ tabId: string; url: string; title: string }>> {
+    const session = this.sessions.get(sessionId);
+    if (!session) return [];
+
+    const results: Array<{ tabId: string; url: string; title: string }> = [];
+    for (const [workerId, worker] of session.workers.entries()) {
+      const cdpClient = this.getCDPClientForWorker(sessionId, workerId);
+      for (const targetId of worker.targets) {
+        try {
+          const page = await cdpClient.getPageByTargetId(targetId);
+          if (page && !page.isClosed()) {
+            results.push({
+              tabId: targetId,
+              url: page.url(),
+              title: await safeTitle(page),
+            });
+          }
+        } catch {
+          // Target may have closed between iteration steps — skip it
+        }
+      }
+    }
+    return results;
   }
 
   /**

--- a/src/tools/computer.ts
+++ b/src/tools/computer.ts
@@ -111,8 +111,12 @@ const handler: ToolHandler = async (
   try {
     const page = await sessionManager.getPage(sessionId, tabId);
     if (!page) {
+      const available = await sessionManager.getAvailableTargets(sessionId);
+      const availableInfo = available.length > 0
+        ? `\nAvailable tabs:\n${available.map(t => `  - tabId: ${t.tabId} | ${t.url} | ${t.title}`).join('\n')}`
+        : '\nNo tabs available. Call navigate without tabId to create a new tab.';
       return {
-        content: [{ type: 'text', text: `Error: Tab ${tabId} not found. Hint: The tab may have been closed or the session expired. Use navigate() to open a new tab.` }],
+        content: [{ type: 'text', text: `Error: Tab ${tabId} not found or no longer available.${availableInfo}` }],
         isError: true,
       };
     }

--- a/src/tools/find.ts
+++ b/src/tools/find.ts
@@ -67,8 +67,12 @@ const handler: ToolHandler = async (
   try {
     const page = await sessionManager.getPage(sessionId, tabId, undefined, 'find');
     if (!page) {
+      const available = await sessionManager.getAvailableTargets(sessionId);
+      const availableInfo = available.length > 0
+        ? `\nAvailable tabs:\n${available.map(t => `  - tabId: ${t.tabId} | ${t.url} | ${t.title}`).join('\n')}`
+        : '\nNo tabs available. Call navigate without tabId to create a new tab.';
       return {
-        content: [{ type: 'text', text: `Error: Tab ${tabId} not found` }],
+        content: [{ type: 'text', text: `Error: Tab ${tabId} not found or no longer available.${availableInfo}` }],
         isError: true,
       };
     }

--- a/src/tools/interact.ts
+++ b/src/tools/interact.ts
@@ -96,8 +96,12 @@ const handler: ToolHandler = async (
   try {
     const page = await sessionManager.getPage(sessionId, tabId, undefined, 'interact');
     if (!page) {
+      const available = await sessionManager.getAvailableTargets(sessionId);
+      const availableInfo = available.length > 0
+        ? `\nAvailable tabs:\n${available.map(t => `  - tabId: ${t.tabId} | ${t.url} | ${t.title}`).join('\n')}`
+        : '\nNo tabs available. Call navigate without tabId to create a new tab.';
       return {
-        content: [{ type: 'text', text: `Error: Tab ${tabId} not found` }],
+        content: [{ type: 'text', text: `Error: Tab ${tabId} not found or no longer available.${availableInfo}` }],
         isError: true,
       };
     }

--- a/src/tools/javascript.ts
+++ b/src/tools/javascript.ts
@@ -280,8 +280,12 @@ const handler: ToolHandler = async (
   try {
     const page = await sessionManager.getPage(sessionId, tabId, undefined, 'javascript_tool');
     if (!page) {
+      const available = await sessionManager.getAvailableTargets(sessionId);
+      const availableInfo = available.length > 0
+        ? `\nAvailable tabs:\n${available.map(t => `  - tabId: ${t.tabId} | ${t.url} | ${t.title}`).join('\n')}`
+        : '\nNo tabs available. Call navigate without tabId to create a new tab.';
       return {
-        content: [{ type: 'text', text: `Error: Tab ${tabId} not found. Hint: The tab may have been closed or the session expired. Use navigate() to open a new tab.` }],
+        content: [{ type: 'text', text: `Error: Tab ${tabId} not found or no longer available.${availableInfo}` }],
         isError: true,
       };
     }

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -278,8 +278,12 @@ const handler: ToolHandler = async (
 
     const page = await sessionManager.getPage(sessionId, tabId, undefined, 'navigate');
     if (!page) {
+      const available = await sessionManager.getAvailableTargets(sessionId);
+      const availableInfo = available.length > 0
+        ? `\nAvailable tabs:\n${available.map(t => `  - tabId: ${t.tabId} | ${t.url} | ${t.title}`).join('\n')}`
+        : '\nNo tabs available. Call navigate without tabId to create a new tab.';
       return {
-        content: [{ type: 'text', text: `Error: Tab ${tabId} not found` }],
+        content: [{ type: 'text', text: `Error: Tab ${tabId} not found or no longer available.${availableInfo}` }],
         isError: true,
       };
     }

--- a/src/tools/read-page.ts
+++ b/src/tools/read-page.ts
@@ -106,8 +106,12 @@ const handler: ToolHandler = async (
   try {
     const page = await sessionManager.getPage(sessionId, tabId);
     if (!page) {
+      const available = await sessionManager.getAvailableTargets(sessionId);
+      const availableInfo = available.length > 0
+        ? `\nAvailable tabs:\n${available.map(t => `  - tabId: ${t.tabId} | ${t.url} | ${t.title}`).join('\n')}`
+        : '\nNo tabs available. Call navigate without tabId to create a new tab.';
       return {
-        content: [{ type: 'text', text: `Error: Tab ${tabId} not found. Hint: The tab may have been closed or the session expired. Use navigate() to open a new tab.` }],
+        content: [{ type: 'text', text: `Error: Tab ${tabId} not found or no longer available.${availableInfo}` }],
         isError: true,
       };
     }

--- a/tests/utils/mock-session.ts
+++ b/tests/utils/mock-session.ts
@@ -63,6 +63,8 @@ export function createMockSessionManager(options: MockSessionManagerOptions = {}
     pages,
     mockCDPClient,
 
+    getAvailableTargets: jest.fn().mockReturnValue([]),
+
     ensureConnected: jest.fn().mockResolvedValue(undefined),
 
     createSession: jest.fn().mockImplementation(async (opts: { id?: string; name?: string } = {}) => {


### PR DESCRIPTION
## Summary
When `getPage()` returns null (tab not found), error responses now include a list of available tabs with their tabId, URL, and title. This lets the LLM self-correct in a single round-trip without calling `tabs_context`.

**Before:** `"Error: Tab ABC123 not found"`
**After:** `"Error: Tab ABC123 not found or no longer available.\nAvailable tabs:\n  - tabId: DEF456 | https://example.com | Example Page"`

### Changes
- Add `getAvailableTargets()` to `SessionManager` — returns live targets for a session
- Update 6 core tools: `navigate`, `computer`, `read_page`, `interact`, `javascript_tool`, `find`
- Add `getAvailableTargets` mock to test utilities

### What's NOT changed
- No auto-tab-substitution (that would be orchestration)
- No changes to tools not in the core 6 (follow-up scope)
- Error is still `isError: true` — just with better information

## Test plan
- [ ] Close a tab, call `read_page(stale-tabId)` → error includes available tabs
- [ ] Multi-tab scenario: error lists all remaining tabs
- [ ] No-tabs scenario: error suggests calling navigate without tabId
- [ ] `npm run build` passes
- [ ] `npm test` — all 2152 tests pass

Fixes #430 (Fix 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)