### PR TITLE
fix: add timeout guards and Unicode normalization to interact tool

### DIFF
--- a/src/tools/interact.ts
+++ b/src/tools/interact.ts
@@ -106,8 +106,8 @@ const handler: ToolHandler = async (
       };
     }
 
-    const queryLower = query.toLowerCase();
-    const queryTokens = tokenizeQuery(query);
+    const queryLower = query.normalize('NFC').toLowerCase().replace(/["""'''`]/g, '');
+    const queryTokens = tokenizeQuery(queryLower);
 
     // Optional polling for dynamic/lazy content
     const maxWait = waitForMs ? Math.min(Math.max(waitForMs, 100), 30000) : 0;
@@ -118,10 +118,14 @@ const handler: ToolHandler = async (
     // ─── AX-First Resolution ───
     // Try AX tree first — the browser's accessibility engine understands all UI frameworks
     try {
-      const axMatches = await resolveElementsByAXTree(page, cdpClient, query, {
-        useCenter: true,
-        maxResults: 3,
-      });
+      const axMatches = await withTimeout(
+        resolveElementsByAXTree(page, cdpClient, query, {
+          useCenter: true,
+          maxResults: 3,
+        }),
+        10000,
+        'ax-resolution'
+      );
       if (axMatches.length > 0) {
         const ax = axMatches[0];
 
@@ -208,8 +212,9 @@ const handler: ToolHandler = async (
 
         return { content: resultContent };
       }
-    } catch {
+    } catch (axError) {
       // AX resolution failed — fall through to CSS discovery
+      console.error(`[interact] AX resolution failed, falling back to CSS: ${axError instanceof Error ? axError.message : String(axError)}`);
     }
 
     // ─── CSS Fallback (existing logic) ───
@@ -415,7 +420,10 @@ const handler: ToolHandler = async (
       }
 
       return { url, title, scrollX, scrollY, activeInfo, panels, headings };
-    }), 10000, 'interact');
+    }), 10000, 'interact').catch(() => ({
+      url: '', title: '', scrollX: 0, scrollY: 0,
+      activeInfo: 'unknown', panels: [] as string[], headings: [] as string[],
+    }));
 
     // Build the response — compact success format
     const lines: string[] = [interactedLine];

--- a/src/utils/ax-element-resolver.ts
+++ b/src/utils/ax-element-resolver.ts
@@ -90,6 +90,22 @@ const ROLE_KEYWORDS: Array<[string, string]> = [
   ['tree item', 'treeitem'],
   ['tab panel', 'tabpanel'],
   ['list item', 'listitem'],
+  // Localized role keywords — Korean (ko)
+  // LLM clients send queries in the user's language; these map Korean UI terms to ARIA roles.
+  // To add another locale: append entries here, longest-first within each language block.
+  // Keep keywords >= 2 characters to avoid spurious matches.
+  ['라디오 버튼', 'radio'],
+  ['체크박스', 'checkbox'],
+  ['콤보박스', 'combobox'],
+  ['텍스트 필드', 'textbox'],
+  ['검색창', 'searchbox'],
+  ['메뉴 항목', 'menuitem'],
+  ['드롭다운', 'combobox'],
+  ['버튼', 'button'],
+  ['링크', 'link'],
+  ['스위치', 'switch'],
+  ['슬라이더', 'slider'],
+  ['이미지', 'image'],
   ['button', 'button'],
   ['link', 'link'],
   ['radio', 'radio'],
@@ -136,25 +152,25 @@ const INTERACTIVE_ROLES = new Set([
  *   "로그인"              → { roleHint: null, nameHint: "로그인" }
  */
 export function parseQueryForAX(query: string): ParsedAXQuery {
-  const queryLower = query.toLowerCase().trim();
+  const queryLower = query.normalize('NFC').toLowerCase().trim();
 
   for (const [keyword, role] of ROLE_KEYWORDS) {
     const idx = queryLower.indexOf(keyword);
     if (idx !== -1) {
       const before = query.slice(0, idx).trim();
       const after = query.slice(idx + keyword.length).trim();
-      const nameHint = [before, after].filter(Boolean).join(' ').trim();
+      const nameHint = [before, after].filter(Boolean).join(' ').trim().replace(/["""'''`]/g, '');
 
       return {
         roleHint: role,
-        nameHint: nameHint || query.trim(),
+        nameHint: nameHint || query.trim().replace(/["""'''`]/g, ''),
       };
     }
   }
 
   return {
     roleHint: null,
-    nameHint: query.trim(),
+    nameHint: query.trim().replace(/["""'''`]/g, ''),
   };
 }
 
@@ -183,11 +199,11 @@ export function cascadeFilter(
     INTERACTIVE_ROLES.has(n.role.toLowerCase())
   );
 
-  const nameLower = nameHint.toLowerCase().trim();
+  const nameLower = nameHint.normalize('NFC').toLowerCase().trim();
   if (!nameLower) return [];
 
-  const eq = (nodeName: string) => nodeName.toLowerCase().trim() === nameLower;
-  const includes = (nodeName: string) => nodeName.toLowerCase().trim().includes(nameLower);
+  const eq = (nodeName: string) => nodeName.normalize('NFC').toLowerCase().trim() === nameLower;
+  const includes = (nodeName: string) => nodeName.normalize('NFC').toLowerCase().trim().includes(nameLower);
 
   // Level 1: exact role + exact name
   if (roleHint) {

--- a/src/utils/element-discovery.ts
+++ b/src/utils/element-discovery.ts
@@ -90,7 +90,7 @@ export async function discoverElements(
     page.evaluate(
       (searchQuery: string, maxRes: number, centerCoords: boolean, tagProp: string): RawElement[] => {
         const elements: RawElement[] = [];
-        const searchLower = searchQuery.toLowerCase();
+        const searchLower = searchQuery.normalize('NFC').toLowerCase().replace(/["""'''`]/g, '');
         const queryTokens = searchLower
           .split(/\s+/)
           .filter(t => t.length > 1)
@@ -250,7 +250,7 @@ export async function discoverElements(
 
         return elements;
       },
-      query.toLowerCase(),
+      query.normalize('NFC').toLowerCase().replace(/["""'''`]/g, ''),
       maxResults,
       useCenter,
       DISCOVERY_TAG,
@@ -556,7 +556,9 @@ export async function resolveBackendNodeIds(
     );
   }
 
-  await Promise.all(describePromises);
+  await withTimeout(Promise.all(describePromises), 8000, 'resolve-backend-node-ids').catch(() => {
+    // Timeout resolving backend node IDs — partial results are acceptable
+  });
 }
 
 /**

--- a/src/utils/element-finder.ts
+++ b/src/utils/element-finder.ts
@@ -34,7 +34,9 @@ const STOP_WORDS = new Set([
  */
 export function tokenizeQuery(query: string): string[] {
   return query
+    .normalize('NFC')
     .toLowerCase()
+    .replace(/["""'''`]/g, '')
     .split(/\s+/)
     .filter(t => t.length > 1)
     .filter(t => !STOP_WORDS.has(t));


### PR DESCRIPTION
## Summary

Fixes #438 — The `interact` tool could hang 60+ seconds on no-match queries and failed to match elements when queries contained quotes or non-English role keywords.

### Timeout fixes (hang prevention)
- **`interact.ts`**: Wrap `resolveElementsByAXTree` with `withTimeout(10s)` — previously could stall up to 60s with no outer timeout
- **`element-discovery.ts`**: Wrap `resolveBackendNodeIds` `Promise.all` with `withTimeout(8s)` — previously unbounded for up to 30 parallel CDP calls
- **`interact.ts`**: Add `console.error` logging to AX catch block (was bare `catch {}` with zero visibility)
- **`interact.ts`**: Add `.catch()` to CSS-path `stateSummary` — previously a timeout here would report a successful action as an error

### Unicode fixes (query matching)
- **`element-finder.ts`**, **`ax-element-resolver.ts`**, **`element-discovery.ts`**, **`interact.ts`**: Strip quote characters (`"`, `'`, curly quotes, backticks) before tokenization — LLM clients frequently wrap element names in quotes which broke matching
- **All comparison paths**: Add `.normalize('NFC')` to prevent silent mismatch between NFC/NFD Unicode forms
- **`ax-element-resolver.ts`**: Add Korean role keywords (`버튼`→button, `링크`→link, etc.) to `ROLE_KEYWORDS` with locale-extensibility documentation

### Intentionally NOT changed
- **`dom-delta.ts`**: Existing `Promise.race` with resolving timer is correct graceful degradation — not a hang risk
- **No reverse-includes matching**: Considered adding "Level 5" where query contains node name, but rejected due to high false-positive risk on short element names (`"View"`, `"Go"`, `"OK"`)

## Files changed (4)

| File | Changes |
|------|---------|
| `src/tools/interact.ts` | AX timeout wrapper, error logging, stateSummary catch, quote stripping |
| `src/utils/ax-element-resolver.ts` | Korean keywords, NFC normalization, quote stripping in parseQueryForAX/cascadeFilter |
| `src/utils/element-discovery.ts` | Backend node ID batch timeout, inline tokenizer quote stripping |
| `src/utils/element-finder.ts` | tokenizeQuery NFC + quote stripping |

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — 2273/2273 pass (1 pre-existing flaky test in event-loop-monitor)
- [ ] Manual: call `interact` with quoted query like `"Submit" button` — should match correctly
- [ ] Manual: call `interact` with Korean query like `자세히 보기 버튼` — should extract role hint and match
- [ ] Manual: verify AX resolution timeout logs to stderr on slow pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)