### PR TITLE
fix: add page validity guard to CDPClient for fast-fail on stale references

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -28,6 +28,7 @@ import {
 } from '../config/defaults';
 import { withTimeout } from '../utils/with-timeout';
 import { getMetricsCollector } from '../metrics/collector';
+import { OpenChromeConnectionError } from '../errors/connection';
 
 // Cookie type shared across methods
 type CookieEntry = {
@@ -1768,6 +1769,16 @@ export class CDPClient {
     const target = page.target();
     const targetId = getTargetId(target);
 
+    // Fail fast if the target is no longer valid (browser may have reconnected)
+    if (targetId && !this.targetIdIndex.has(targetId)) {
+      console.error(`[CDPClient] Rejecting getCDPSession() for stale target ${targetId} — page reference is no longer valid`);
+      throw new OpenChromeConnectionError(
+        `Target ${targetId} is no longer valid (browser disconnected or reconnected). ` +
+        `Retry the operation to get a fresh page reference.`,
+        targetId
+      );
+    }
+
     let session = this.sessions.get(targetId);
     if (!session) {
       session = await page.createCDPSession();
@@ -1786,6 +1797,17 @@ export class CDPClient {
     method: string,
     params?: Record<string, unknown>
   ): Promise<T> {
+    // Fail fast if the target is no longer valid (browser may have reconnected)
+    const targetId = getTargetId(page.target());
+    if (targetId && !this.targetIdIndex.has(targetId)) {
+      console.error(`[CDPClient] Rejecting send() for stale target ${targetId} — page reference is no longer valid`);
+      throw new OpenChromeConnectionError(
+        `Target ${targetId} is no longer valid (browser disconnected or reconnected). ` +
+        `Retry the operation to get a fresh page reference.`,
+        targetId
+      );
+    }
+
     const session = await this.getCDPSession(page);
     return withTimeout(
       session.send(method as any, params as any) as Promise<T>,

--- a/src/errors/connection.ts
+++ b/src/errors/connection.ts
@@ -1,0 +1,22 @@
+/**
+ * Typed connection error for OpenChrome.
+ * Thrown when a CDP operation is attempted on a stale or invalid target.
+ */
+export class OpenChromeConnectionError extends Error {
+  /** The target ID that was no longer valid, if available. */
+  readonly targetId: string | undefined;
+
+  constructor(message: string, targetId?: string) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.name = 'OpenChromeConnectionError';
+    this.targetId = targetId;
+  }
+}
+
+/**
+ * Type guard for OpenChromeConnectionError instances.
+ */
+export function isOpenChromeConnectionError(error: unknown): error is OpenChromeConnectionError {
+  return error instanceof OpenChromeConnectionError;
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -35,6 +35,7 @@ import { getMetricsCollector } from './metrics/collector';
 import { logAuditEntry } from './security/audit-logger';
 import { getVersion } from './version';
 import { isTimeoutError } from './errors/timeout';
+import { OpenChromeConnectionError } from './errors/connection';
 import { getTaskJournal } from './journal/task-journal';
 
 /**
@@ -42,6 +43,7 @@ import { getTaskJournal } from './journal/task-journal';
  * by reconnecting to the browser.
  */
 export function isConnectionError(error: unknown): boolean {
+  if (error instanceof OpenChromeConnectionError) return true;
   const message = formatError(error);
   const patterns = [
     'not connected to chrome',

--- a/tests/src/cdp-client-optimization.test.ts
+++ b/tests/src/cdp-client-optimization.test.ts
@@ -377,8 +377,9 @@ describe('CDPClient – triggerGC', () => {
 
   test('sends HeapProfiler.collectGarbage via CDP session', async () => {
     const mockPage = createMockPage('gc-target');
-    // Inject session into the sessions map so getCDPSession returns it directly
+    // Inject session and target index so getCDPSession returns it directly
     (client as any).sessions.set('gc-target', mockPage._cdpSession);
+    (client as any).targetIdIndex.set('gc-target', mockPage);
 
     await client.triggerGC(mockPage as any);
 
@@ -420,8 +421,9 @@ describe('CDPClient – closePage', () => {
       callOrder.push('close');
     });
 
-    // Inject the session and make getPageByTargetId return the page
+    // Inject the session, target index, and make getPageByTargetId return the page
     (client as any).sessions.set(targetId, mockPage._cdpSession);
+    (client as any).targetIdIndex.set(targetId, mockPage);
     const origGetPage = client.getPageByTargetId.bind(client);
     jest.spyOn(client, 'getPageByTargetId').mockResolvedValue(mockPage as any);
 


### PR DESCRIPTION
## Summary

Addresses P1 of #440 — When the browser disconnects and reconnects mid-operation, in-flight tool handlers hold stale `Page` references that wait up to 30s (`protocolTimeout`) before failing with "Connection closed". This adds a fast-fail validity check that detects stale pages immediately.

### Changes
- **`src/errors/connection.ts`** (new): `OpenChromeConnectionError` class with optional `targetId` field
- **`src/cdp/client.ts`**: Add `targetIdIndex` validity check in `getCDPSession()` and `send()` — if target ID is not in the index, throw immediately instead of waiting 30s
- **`src/mcp-server.ts`**: Register `OpenChromeConnectionError` in `isConnectionError()` so the retry logic in tool execution handles it correctly
- **`tests/src/cdp-client-optimization.test.ts`**: Register mock target IDs in `targetIdIndex` for triggerGC and closePage tests

### Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Call `interact` on a disconnected page | 30s hang, then "Connection closed" | Immediate `OpenChromeConnectionError`, triggers retry |
| Call `navigate` after Chrome restart | 30s hang per CDP call | Immediate error, auto-reconnect kicks in |

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — all tests pass (including updated cdp-client-optimization tests)
- [ ] Manual: kill Chrome mid-operation → tool returns fast error instead of 30s hang
- [ ] Manual: after reconnection, stale tab IDs rejected with clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)