### PR TITLE
fix: apply normalizeQuery to wait-and-click tool (#440)

### DIFF
--- a/src/tools/wait-and-click.ts
+++ b/src/tools/wait-and-click.ts
@@ -11,7 +11,7 @@ import { getRefIdManager } from '../utils/ref-id-manager';
 import { DEFAULT_DOM_SETTLE_DELAY_MS } from '../config/defaults';
 import { withDomDelta } from '../utils/dom-delta';
 import { discoverElements, getTaggedElementRect, cleanupTags, DISCOVERY_TAG } from '../utils/element-discovery';
-import { FoundElement, scoreElement, tokenizeQuery } from '../utils/element-finder';
+import { FoundElement, normalizeQuery, scoreElement, tokenizeQuery } from '../utils/element-finder';
 import { resolveElementsByAXTree, invalidateAXCache, AXResolvedElement, MATCH_LEVEL_LABELS } from '../utils/ax-element-resolver';
 import { classifyOutcome, formatOutcomeLine } from '../utils/ralph/outcome-classifier';
 import { getTargetId } from '../utils/puppeteer-helpers';
@@ -78,7 +78,7 @@ const handler: ToolHandler = async (
       };
     }
 
-    const queryLower = query.toLowerCase();
+    const queryLower = normalizeQuery(query);
     const queryTokens = tokenizeQuery(query);
 
     const startTime = Date.now();


### PR DESCRIPTION
## Summary

- `wait-and-click.ts` was calling `query.toLowerCase()` on line 81 in the CSS fallback path, bypassing the shared `normalizeQuery()` helper used by every other tool (`interact`, `find`, `fill-form`, `click-element`)
- This meant NFC normalization and curly-quote stripping were silently skipped when wait-and-click fell through to its CSS path
- Fix: import `normalizeQuery` from `../utils/element-finder` and replace the one-liner

**Before:**
```ts
const queryLower = query.toLowerCase();
```

**After:**
```ts
const queryLower = normalizeQuery(query);
```

This is a 2-line diff (import + call site) with no behavior change for ASCII queries and correct behavior for Unicode/curly-quote queries.

## Test plan

- [x] `npm run build` — compiles cleanly (zero TypeScript errors)
- [x] `npm test` — 2346 tests pass across 121 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)