### PR TITLE
feat: add budget-aware deadline context for tool handlers (#440)

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -10,6 +10,7 @@ import {
   MCPError,
   MCPToolDefinition,
   ToolHandler,
+  ToolContext,
   ToolRegistry,
   MCPErrorCodes,
 } from './types/mcp';
@@ -714,9 +715,13 @@ export class MCPServer {
 
       let result: MCPResult;
       try {
+        const toolContext: ToolContext = {
+          startTime: Date.now(),
+          deadlineMs: DEFAULT_TOOL_EXECUTION_TIMEOUT_MS,
+        };
         let tid: ReturnType<typeof setTimeout>;
         result = await Promise.race([
-          Promise.resolve(tool.handler(sessionId, toolArgs)).finally(() => clearTimeout(tid)),
+          Promise.resolve(tool.handler(sessionId, toolArgs, toolContext)).finally(() => clearTimeout(tid)),
           new Promise<never>((_, reject) => {
             tid = setTimeout(
               () => reject(new Error(`Tool '${toolName}' timed out after ${DEFAULT_TOOL_EXECUTION_TIMEOUT_MS}ms`)),
@@ -745,9 +750,13 @@ export class MCPServer {
               console.error('[MCPServer] Post-reconnect reconciliation failed, aborting retry:', reconcileErr);
               throw handlerError; // Abort retry — stale state would cause wrong-target errors
             }
+            const retryToolContext: ToolContext = {
+              startTime: Date.now(),
+              deadlineMs: DEFAULT_TOOL_EXECUTION_TIMEOUT_MS,
+            };
             let tid2: ReturnType<typeof setTimeout>;
             result = await Promise.race([
-              Promise.resolve(tool.handler(sessionId, toolArgs)).finally(() => clearTimeout(tid2)),
+              Promise.resolve(tool.handler(sessionId, toolArgs, retryToolContext)).finally(() => clearTimeout(tid2)),
               new Promise<never>((_, reject) => {
                 tid2 = setTimeout(
                   () => reject(new Error(`Tool '${toolName}' timed out after ${DEFAULT_TOOL_EXECUTION_TIMEOUT_MS}ms (retry)`)),
@@ -779,7 +788,11 @@ export class MCPServer {
             const cdpClientRetry = getCDPClient();
             await cdpClientRetry.forceReconnect();
             // Retry the tool call once
-            result = await Promise.resolve(tool.handler(sessionId, toolArgs));
+            const swallowedRetryContext: ToolContext = {
+              startTime: Date.now(),
+              deadlineMs: DEFAULT_TOOL_EXECUTION_TIMEOUT_MS,
+            };
+            result = await Promise.resolve(tool.handler(sessionId, toolArgs, swallowedRetryContext));
             console.error(`[MCPServer] Retry after swallowed connection error succeeded for "${toolName}"`);
           } catch (retryError) {
             console.error(`[MCPServer] Retry after swallowed connection error failed for "${toolName}":`, retryError);

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -51,9 +51,32 @@ export interface MCPToolDefinition {
   };
 }
 
+/**
+ * Context passed to tool handlers for budget-aware execution.
+ * Tools can use getRemainingBudget() to check how much time remains
+ * before the tool execution timeout fires.
+ */
+export interface ToolContext {
+  /** When the tool handler started executing */
+  startTime: number;
+  /** Total budget in milliseconds (default: DEFAULT_TOOL_EXECUTION_TIMEOUT_MS) */
+  deadlineMs: number;
+}
+
+/** Returns the number of milliseconds remaining before the tool deadline. */
+export function getRemainingBudget(ctx: ToolContext): number {
+  return Math.max(0, ctx.deadlineMs - (Date.now() - ctx.startTime));
+}
+
+/** Returns true if at least `needed` ms remain before the tool deadline. */
+export function hasBudget(ctx: ToolContext, needed = 0): boolean {
+  return getRemainingBudget(ctx) > needed;
+}
+
 export type ToolHandler = (
   sessionId: string,
-  params: Record<string, unknown>
+  params: Record<string, unknown>,
+  context?: ToolContext
 ) => Promise<MCPResult>;
 
 export interface ToolRegistry {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -212,7 +212,7 @@ describe('MCPServer', () => {
 
       await server.handleRequest(request);
 
-      expect(handler).toHaveBeenCalledWith('test-session', { foo: 'bar' });
+      expect(handler).toHaveBeenCalledWith('test-session', { foo: 'bar' }, expect.objectContaining({ startTime: expect.any(Number), deadlineMs: expect.any(Number) }));
     });
 
     test('returns tool result', async () => {


### PR DESCRIPTION
## Summary

- Add `ToolContext` interface (`startTime`, `deadlineMs`) to `src/types/mcp.ts`
- Add `getRemainingBudget()` and `hasBudget()` helper functions exported from `src/types/mcp.ts`
- Pass a `ToolContext` instance as an optional 3rd argument at all 3 `tool.handler(...)` call sites in `src/mcp-server.ts`
- Update `tests/mcp-server.test.ts` to assert the new 3rd argument is present

## Design

`ToolContext` is a lightweight, read-only budget token — no AbortController, no cancellation semantics, no cleanup complexity. It simply captures when a tool started and how much total budget was allocated:

```ts
interface ToolContext {
  startTime: number;   // Date.now() at handler invocation
  deadlineMs: number;  // DEFAULT_TOOL_EXECUTION_TIMEOUT_MS (120 000 ms)
}

getRemainingBudget(ctx): number  // ms remaining before timeout fires
hasBudget(ctx, needed?): boolean // true if remaining > needed
```

The existing 120 s `Promise.race` safety net is **unchanged** — `ToolContext` is informational only, allowing tools to skip expensive sub-operations when budget is nearly exhausted.

## Changes

| File | Change |
|------|--------|
| `src/types/mcp.ts` | Add `ToolContext` interface + `getRemainingBudget` / `hasBudget` helpers; add optional `context?: ToolContext` to `ToolHandler` signature |
| `src/mcp-server.ts` | Import `ToolContext`; create and pass context at all 3 handler call sites (initial call, reconnect retry, swallowed-error retry) |
| `tests/mcp-server.test.ts` | Update handler call assertion to `expect.objectContaining({ startTime: expect.any(Number), deadlineMs: expect.any(Number) })` |

## Before / After

**Before:**
```ts
tool.handler(sessionId, toolArgs)
```

**After:**
```ts
const toolContext: ToolContext = { startTime: Date.now(), deadlineMs: DEFAULT_TOOL_EXECUTION_TIMEOUT_MS };
tool.handler(sessionId, toolArgs, toolContext)
```

The parameter is **optional** — all existing tool handlers that ignore it continue to work unchanged.

## Test Results

```
Test Suites: 121 passed, 121 total
Tests:       2346 passed, 2346 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)