### PR TITLE
fix: wire circuit breaker into find tool's discoverElements call (#440)

### DIFF
--- a/src/tools/find.ts
+++ b/src/tools/find.ts
@@ -10,6 +10,7 @@ import { withTimeout } from '../utils/with-timeout';
 import { discoverElements, cleanupTags, DISCOVERY_TAG } from '../utils/element-discovery';
 import { FoundElement, normalizeQuery, scoreElement, tokenizeQuery } from '../utils/element-finder';
 import { resolveElementsByAXTree, MATCH_LEVEL_LABELS } from '../utils/ax-element-resolver';
+import { getCircuitBreaker } from '../utils/ralph/circuit-breaker';
 
 const definition: MCPToolDefinition = {
   name: 'find',
@@ -121,6 +122,7 @@ const handler: ToolHandler = async (
     }
 
     // ─── CSS Fallback ───
+    const cb = getCircuitBreaker();
     do { // --- polling loop start ---
     let scored: FoundElement[];
     try {
@@ -129,6 +131,11 @@ const handler: ToolHandler = async (
         useCenter: false,
         timeout: 10000,
         toolName: 'find',
+        circuitBreaker: {
+          check: (_pageUrl: string) => !cb.check(tabId, queryLower).allowed,
+          recordFailure: (_pageUrl: string) => cb.recordElementFailure(tabId, queryLower),
+          recordSuccess: (_pageUrl: string) => cb.recordElementSuccess(tabId, queryLower),
+        },
       });
 
       const queryTokens = tokenizeQuery(query);


### PR DESCRIPTION
## Summary

- The circuit breaker was integrated into `discoverElements()` in PR #444 via the optional `circuitBreaker` parameter in `DiscoverOptions`
- Only `interact.ts` was updated to pass it — `find.ts` also calls `discoverElements()` but without the circuit breaker
- This PR wires `getCircuitBreaker()` into `find.ts` using the same adapter pattern as `interact.ts`, so repeated failures on `find` now benefit from fast-fail

## Test plan

- [x] `npm run build` passes with zero TypeScript errors
- [x] `npm test` passes — 2346 tests, 121 suites, all green
- [x] Pattern matches `interact.ts` exactly (same adapter shape, same variable naming convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)