### PR TITLE
feat: stealth v3 — pre-navigation fingerprint injection via about:blank

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -1328,30 +1328,34 @@ export class CDPClient {
    * CDP observer attached. CDP is attached only after the settle window expires.
    *
    * @param url      URL to open in the new tab
-   * @param settleMs Milliseconds to wait before attaching CDP (default 5000, range 1000-30000)
+   * @param settleMs Total settle time in ms — used for navigation timeout and post-nav wait (default 8000)
    * @returns        The Puppeteer Page and its targetId
    */
   async createTargetStealth(url: string, settleMs: number = 8000): Promise<{ page: Page; targetId: string }> {
     const browser = this.getBrowser();
 
-    // Step 1: Create target via CDP Target.createTarget.
-    // Puppeteer's ChromeTargetManager uses Target.setAutoAttach with { exclude: true }
-    // for page targets, so the new tab is added to #discoveredTargetsByTargetId but NOT
-    // #attachedTargetsByTargetId. This means browser.pages() will never find it.
-    // We use a CDP session on the browser target to issue the command directly.
+    // Stealth v3 architecture (#450):
+    // Instead of navigating directly to the target URL (which lets anti-bot scripts
+    // fingerprint the raw browser before defenses are applied), we:
+    //   1. Create tab with about:blank (no anti-bot scripts, no network request)
+    //   2. Attach CDP immediately and register all defenses via evaluateOnNewDocument
+    //   3. Navigate to the real URL — defenses fire at document_start, BEFORE any page JS
+    // This closes the fingerprint timing gap that caused Access Denied on Coupang/Reddit.
+
+    // Step 1: Create target with about:blank — invisible to anti-bot systems
     const cdp = await browser.target().createCDPSession();
     let targetId: string;
     try {
-      const result = await cdp.send('Target.createTarget', { url }) as { targetId: string };
+      const result = await cdp.send('Target.createTarget', { url: 'about:blank' }) as { targetId: string };
       targetId = result.targetId;
     } catch (createErr) {
       await cdp.detach().catch(() => {});
       throw new Error(`Stealth navigation: failed to create target: ${createErr instanceof Error ? createErr.message : String(createErr)}`);
     }
 
-    console.error(`[CDPClient] Stealth tab created: ${targetId}, settling for ${settleMs}ms`);
+    console.error(`[CDPClient] Stealth tab created: ${targetId} (about:blank), will navigate to ${url}`);
 
-    // Warn if headless — Turnstile detection is nearly guaranteed in headless mode
+    // Warn if headless — anti-bot detection is nearly guaranteed in headless mode
     {
       const { headless } = getGlobalConfig();
       let isHeadless = !!headless;
@@ -1364,27 +1368,19 @@ export class CDPClient {
         }
       }
       if (isHeadless) {
-        console.error('[CDPClient] WARNING: Stealth mode in headless Chrome is unlikely to bypass Turnstile. Use headed Chrome (--visible) for anti-bot pages.');
+        console.error('[CDPClient] WARNING: Stealth mode in headless Chrome is unlikely to bypass anti-bot systems. Use headed Chrome (--visible) for anti-bot pages.');
       }
     }
 
-    // Step 2: Wait for the page to load without CDP observation (Turnstile runs here)
-    await new Promise<void>(resolve => setTimeout(resolve, settleMs));
-
-    // Step 3: Attach to the target via CDP to bring it into Puppeteer's attached set
+    // Step 2: Attach CDP immediately (about:blank has no anti-bot to detect it)
     try {
       await cdp.send('Target.attachToTarget', { targetId, flatten: true });
     } catch (attachErr) {
-      // Ghost tab cleanup: close the orphaned Chrome tab before throwing
       await cdp.send('Target.closeTarget', { targetId }).catch(() => {});
       await cdp.detach().catch(() => {});
       throw new Error(`Stealth navigation: failed to attach to target ${targetId}: ${attachErr instanceof Error ? attachErr.message : String(attachErr)}`);
     }
 
-    // Step 4: Use browser.waitForTarget() to reliably find the target.
-    // After attachToTarget, Puppeteer's internal ChromeTargetManager processes the
-    // attachment asynchronously. browser.targets().find() may miss it due to a race
-    // condition. waitForTarget() listens for the target event and handles timing.
     let target: Target;
     try {
       target = await browser.waitForTarget(
@@ -1392,7 +1388,6 @@ export class CDPClient {
         { timeout: 5000 }
       );
     } catch {
-      // Ghost tab cleanup: close the orphaned Chrome tab before throwing
       await cdp.send('Target.closeTarget', { targetId }).catch(() => {});
       await cdp.detach().catch(() => {});
       throw new Error(`Stealth navigation: target ${targetId} not found after attach (waitForTarget timed out)`);
@@ -1406,33 +1401,49 @@ export class CDPClient {
     }
 
     if (!page) {
-      // Ghost tab cleanup: close the orphaned Chrome tab before throwing
       await cdp.send('Target.closeTarget', { targetId }).catch(() => {});
       await cdp.detach().catch(() => {});
       throw new Error(`Stealth navigation: could not get page for target ${targetId}`);
     }
 
-    // Clean up the helper session — the page now has its own CDP session managed by Puppeteer
     await cdp.detach().catch(() => {});
 
-    // Step 5: Index the page and configure defenses (CDP commands flow from here)
+    // Step 3: Register ALL defense scripts BEFORE navigation.
+    // evaluateOnNewDocument scripts persist on the CDP session and execute at
+    // document_start of every new document — before any <script> tag on the page.
     this.targetIdIndex.set(targetId, page);
     this.configurePageDefenses(page);
 
-    // Step 5b: Apply advanced stealth fingerprint defenses (WebGL, Canvas, Audio, hardware).
-    // These scripts are stealth-only and not registered in configurePageDefenses to avoid
-    // overhead on normal pages. Register for future navigations AND apply to current page.
+    // Stealth-only fingerprint defenses (WebGL, Canvas, Audio, hardware, screen, webdriver)
     const fpScript = getStealthFingerprintDefenseScript();
     const stackScript = getStealthStackSanitizationScript();
     await page.evaluateOnNewDocument(fpScript).catch(() => {});
     await page.evaluateOnNewDocument(stackScript).catch(() => {});
-    // Apply immediately to the already-loaded page
+
+    // Step 4: Navigate to the real URL — all defenses now fire at document_start
+    console.error(`[CDPClient] Stealth tab ${targetId}: navigating to ${url} with defenses pre-registered`);
+    try {
+      await page.goto(url, {
+        waitUntil: 'domcontentloaded',
+        timeout: Math.max(settleMs, 30000),
+      });
+    } catch (navErr) {
+      // Navigation timeout is not fatal — the page may still be usable
+      // (e.g., Turnstile challenge pages load slowly but are interactive)
+      console.error(`[CDPClient] Stealth navigation warning: ${navErr instanceof Error ? navErr.message : String(navErr)}`);
+    }
+
+    // Step 5: Post-navigation settle period for challenge completion (Turnstile, etc.)
+    // The page has loaded with defenses active; this extra wait lets async challenges finish.
+    const postNavSettleMs = Math.max(settleMs - 5000, 2000); // At least 2s, reduced from total settle
+    await new Promise<void>(resolve => setTimeout(resolve, postNavSettleMs));
+
+    // Step 6: Defense-in-depth — apply patches directly to the current page.
+    // evaluateOnNewDocument should have handled this at document_start, but we
+    // re-apply as fallback in case of edge cases (e.g., SPA soft-navigation).
     await page.evaluate(fpScript).catch(() => {});
     await page.evaluate(stackScript).catch(() => {});
 
-    // Step 6: Apply all stealth defenses immediately to the already-loaded page.
-    // configurePageDefenses() registers evaluateOnNewDocument scripts that only run on
-    // future navigations. The current page loaded without CDP, so we must patch it now.
     await page.evaluate(() => {
       // 1. navigator.webdriver — prototype-level deletion (less detectable than defineProperty)
       try {
@@ -1533,7 +1544,7 @@ export class CDPClient {
       }
     }).catch(() => {});
 
-    console.error(`[CDPClient] Stealth tab ${targetId} attached after settle period`);
+    console.error(`[CDPClient] Stealth tab ${targetId} ready (defenses pre-injected, page loaded)`);
     return { page, targetId };
   }
 

--- a/tests/stealth/stealth-integration.test.ts
+++ b/tests/stealth/stealth-integration.test.ts
@@ -115,7 +115,7 @@ describe('Stealth v2 Integration: lightweight-scroll.ts', () => {
   });
 });
 
-describe('Stealth v2 Integration: cdp/client.ts', () => {
+describe('Stealth v3 Integration: cdp/client.ts (#450)', () => {
   const source = readSource('cdp/client.ts');
 
   test('imports fingerprint defense scripts', () => {
@@ -124,9 +124,37 @@ describe('Stealth v2 Integration: cdp/client.ts', () => {
     expect(source).toContain('getStealthStackSanitizationScript');
   });
 
-  test('applies fingerprint defenses in createTargetStealth', () => {
-    const methodStart = source.indexOf('createTargetStealth(');
-    const methodBlock = source.slice(methodStart, source.indexOf('console.error(`[CDPClient] Stealth tab ${targetId} attached'));
+  test('creates target with about:blank, not the real URL (#450)', () => {
+    const methodStart = source.indexOf('async createTargetStealth(');
+    const methodEnd = source.indexOf('console.error(`[CDPClient] Stealth tab ${targetId} ready');
+    const methodBlock = source.slice(methodStart, methodEnd);
+    // Must create with about:blank to avoid fingerprinting during load
+    expect(methodBlock).toContain("url: 'about:blank'");
+    // Must NOT pass the real URL to createTarget
+    expect(methodBlock).not.toMatch(/createTarget\(\s*\{\s*url\s*\}\s*\)/);
+  });
+
+  test('registers evaluateOnNewDocument BEFORE page.goto (#450)', () => {
+    const methodStart = source.indexOf('async createTargetStealth(');
+    const methodBlock = source.slice(methodStart, source.indexOf('console.error(`[CDPClient] Stealth tab ${targetId} ready'));
+    const evalOnNewDocPos = methodBlock.indexOf('evaluateOnNewDocument(fpScript)');
+    const gotoPos = methodBlock.indexOf('page.goto(url');
+    // evaluateOnNewDocument must come before page.goto
+    expect(evalOnNewDocPos).toBeGreaterThan(-1);
+    expect(gotoPos).toBeGreaterThan(-1);
+    expect(evalOnNewDocPos).toBeLessThan(gotoPos);
+  });
+
+  test('navigates to real URL via page.goto after defenses are registered (#450)', () => {
+    const methodStart = source.indexOf('async createTargetStealth(');
+    const methodBlock = source.slice(methodStart, source.indexOf('console.error(`[CDPClient] Stealth tab ${targetId} ready'));
+    expect(methodBlock).toContain('page.goto(url');
+    expect(methodBlock).toContain('configurePageDefenses(page)');
+  });
+
+  test('applies fingerprint defenses via evaluateOnNewDocument and page.evaluate', () => {
+    const methodStart = source.indexOf('async createTargetStealth(');
+    const methodBlock = source.slice(methodStart, source.indexOf('console.error(`[CDPClient] Stealth tab ${targetId} ready'));
     expect(methodBlock).toContain('fpScript');
     expect(methodBlock).toContain('stackScript');
     expect(methodBlock).toContain('evaluateOnNewDocument(fpScript)');
@@ -141,7 +169,6 @@ describe('Stealth v2 Integration: cdp/client.ts', () => {
     const configStart = source.indexOf('private configurePageDefenses');
     const configEnd = source.indexOf('\n  /**', configStart + 100);
     const configBlock = source.slice(configStart, configEnd > configStart ? configEnd : configStart + 2000);
-    // configurePageDefenses should NOT contain fingerprint defense imports
     expect(configBlock).not.toContain('getStealthFingerprintDefenseScript');
     expect(configBlock).not.toContain('fpScript');
   });


### PR DESCRIPTION
## Summary

- Redesign `createTargetStealth()` to close the fingerprint timing gap that caused **Access Denied on Coupang** (Radware/ShieldSquare) and **network security block on Reddit** (PerimeterX)
- Create tab with `about:blank` instead of the real URL, attach CDP immediately, register all defense scripts via `evaluateOnNewDocument`, then `page.goto(url)` — defenses now fire at `document_start` before any page JavaScript
- Keep existing defense-in-depth `page.evaluate()` as fallback after navigation

### Architecture Change

```
BEFORE (v2):                              AFTER (v3):
Target.createTarget({ url })              Target.createTarget({ about:blank })
  ↓ 8s NO CDP, NO defenses                 ↓ CDP attaches immediately
  ↓ Anti-bot collects REAL fingerprints     ↓ evaluateOnNewDocument(defenses)
Target.attachToTarget                       ↓ configurePageDefenses(page)
  ↓ evaluateOnNewDocument (TOO LATE)      page.goto(url)
  ↓ page.evaluate (TOO LATE)               ↓ Defenses fire at document_start
                                            ↓ Anti-bot sees SPOOFED fingerprints
```

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 2349 tests pass across 121 suites (`npm test`)
- [x] Stealth-specific tests: 104 pass across 5 suites
- [x] New integration tests verify about:blank creation, evaluateOnNewDocument before page.goto, defense registration order
- [ ] Real-world verification: `navigate(url: "https://www.coupang.com", stealth: true)` — no Access Denied
- [ ] Real-world verification: `navigate(url: "https://www.reddit.com", stealth: true)` — no network block

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)