### PR TITLE
feat: make withTimeout budget-aware and add deadline error distinction (#454)

### DIFF
--- a/src/errors/timeout.ts
+++ b/src/errors/timeout.ts
@@ -9,14 +9,20 @@ export class OpenChromeTimeoutError extends Error {
   readonly label: string;
   /** Timeout duration in milliseconds. */
   readonly timeoutMs: number;
+  /** True when the error was caused by overall tool deadline exhaustion, not an individual operation timeout. */
+  readonly deadline: boolean;
 
-  constructor(label: string, timeoutMs: number, recoverable = false) {
-    super(`${label} timed out after ${timeoutMs}ms`);
+  constructor(label: string, timeoutMs: number, recoverable = false, deadline = false) {
+    const msg = deadline
+      ? `${label}: deadline exceeded (budget exhausted)`
+      : `${label} timed out after ${timeoutMs}ms`;
+    super(msg);
     Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'OpenChromeTimeoutError';
     this.label = label;
     this.timeoutMs = timeoutMs;
     this.recoverable = recoverable;
+    this.deadline = deadline;
   }
 }
 

--- a/src/utils/with-timeout.ts
+++ b/src/utils/with-timeout.ts
@@ -1,12 +1,30 @@
 import { OpenChromeTimeoutError } from '../errors/timeout';
+import { ToolContext, getRemainingBudget } from '../types/mcp';
 
 /**
  * Race a promise against a timeout. Rejects with an OpenChromeTimeoutError if the timeout fires first.
+ *
+ * When a `ToolContext` is provided, the effective timeout is capped to the remaining budget.
+ * This prevents individual CDP operations from being started with a 15s timeout when only
+ * 3s of overall tool budget remains, eliminating cumulative timeout stacking.
  */
-export function withTimeout<T>(promise: Promise<T>, ms: number, label = 'Operation'): Promise<T> {
+export function withTimeout<T>(promise: Promise<T>, ms: number, label = 'Operation', context?: ToolContext): Promise<T> {
+  const effectiveMs = context
+    ? Math.min(ms, getRemainingBudget(context))
+    : ms;
+
+  if (effectiveMs <= 0) {
+    return Promise.reject(new OpenChromeTimeoutError(label, 0, false, true));
+  }
+
+  const isDeadlineCapped = context !== undefined && effectiveMs < ms;
+
   let timer: ReturnType<typeof setTimeout>;
   const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new OpenChromeTimeoutError(label, ms)), ms);
+    timer = setTimeout(
+      () => reject(new OpenChromeTimeoutError(label, effectiveMs, false, isDeadlineCapped)),
+      effectiveMs,
+    );
   });
   return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }

--- a/tests/utils/with-timeout.test.ts
+++ b/tests/utils/with-timeout.test.ts
@@ -1,0 +1,113 @@
+/// <reference types="jest" />
+import { withTimeout } from '../../src/utils/with-timeout';
+import { OpenChromeTimeoutError } from '../../src/errors/timeout';
+import { ToolContext } from '../../src/types/mcp';
+
+describe('withTimeout', () => {
+  test('should resolve when promise completes before timeout', async () => {
+    const result = await withTimeout(Promise.resolve('ok'), 1000, 'test');
+    expect(result).toBe('ok');
+  });
+
+  test('should reject with OpenChromeTimeoutError when timeout fires', async () => {
+    const never = new Promise<string>(() => {});
+    await expect(withTimeout(never, 50, 'slow-op')).rejects.toThrow(OpenChromeTimeoutError);
+    await expect(withTimeout(never, 50, 'slow-op')).rejects.toThrow('slow-op timed out after 50ms');
+  });
+
+  test('should set deadline=false for normal timeouts', async () => {
+    const never = new Promise<string>(() => {});
+    try {
+      await withTimeout(never, 50, 'normal');
+      fail('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(OpenChromeTimeoutError);
+      expect((e as OpenChromeTimeoutError).deadline).toBe(false);
+    }
+  });
+
+  describe('with ToolContext (budget-aware)', () => {
+    test('should cap timeout to remaining budget', async () => {
+      const context: ToolContext = {
+        startTime: Date.now() - 119_000, // 119s elapsed, 1s remaining
+        deadlineMs: 120_000,
+      };
+      const never = new Promise<string>(() => {});
+      const start = Date.now();
+      try {
+        await withTimeout(never, 15_000, 'capped', context);
+        fail('should have thrown');
+      } catch (e) {
+        const elapsed = Date.now() - start;
+        expect(e).toBeInstanceOf(OpenChromeTimeoutError);
+        // Should have timed out in ~1s, not 15s
+        expect(elapsed).toBeLessThan(5000);
+        expect((e as OpenChromeTimeoutError).deadline).toBe(true);
+      }
+    });
+
+    test('should reject immediately when budget is already exhausted', async () => {
+      const context: ToolContext = {
+        startTime: Date.now() - 130_000, // already past deadline
+        deadlineMs: 120_000,
+      };
+      const start = Date.now();
+      try {
+        await withTimeout(Promise.resolve('ok'), 15_000, 'exhausted', context);
+        fail('should have thrown');
+      } catch (e) {
+        const elapsed = Date.now() - start;
+        expect(elapsed).toBeLessThan(100); // immediate rejection
+        expect(e).toBeInstanceOf(OpenChromeTimeoutError);
+        expect((e as OpenChromeTimeoutError).deadline).toBe(true);
+        expect((e as OpenChromeTimeoutError).message).toContain('deadline exceeded');
+      }
+    });
+
+    test('should not cap when budget is larger than individual timeout', async () => {
+      const context: ToolContext = {
+        startTime: Date.now(), // full budget remaining
+        deadlineMs: 120_000,
+      };
+      const never = new Promise<string>(() => {});
+      try {
+        await withTimeout(never, 50, 'uncapped', context);
+        fail('should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(OpenChromeTimeoutError);
+        // Budget (120s) > individual timeout (50ms), so not deadline-capped
+        expect((e as OpenChromeTimeoutError).deadline).toBe(false);
+        expect((e as OpenChromeTimeoutError).timeoutMs).toBe(50);
+      }
+    });
+
+    test('should resolve normally when promise completes within budget', async () => {
+      const context: ToolContext = {
+        startTime: Date.now(),
+        deadlineMs: 120_000,
+      };
+      const result = await withTimeout(Promise.resolve('ok'), 5000, 'fast', context);
+      expect(result).toBe('ok');
+    });
+  });
+});
+
+describe('OpenChromeTimeoutError', () => {
+  test('should format normal timeout message', () => {
+    const err = new OpenChromeTimeoutError('fill_form', 15000);
+    expect(err.message).toBe('fill_form timed out after 15000ms');
+    expect(err.deadline).toBe(false);
+  });
+
+  test('should format deadline exceeded message', () => {
+    const err = new OpenChromeTimeoutError('fill_form', 0, false, true);
+    expect(err.message).toBe('fill_form: deadline exceeded (budget exhausted)');
+    expect(err.deadline).toBe(true);
+  });
+
+  test('should be instanceof Error', () => {
+    const err = new OpenChromeTimeoutError('test', 100);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('OpenChromeTimeoutError');
+  });
+});


### PR DESCRIPTION
## Summary

- `withTimeout()` now accepts an optional `ToolContext` 4th parameter and caps the effective timeout to the remaining budget via `getRemainingBudget()`
- When budget is already exhausted (`remainingMs <= 0`), rejects immediately with `deadline: true` instead of starting a doomed timer
- `OpenChromeTimeoutError` gains a `deadline` boolean flag to distinguish "overall budget exhausted" from "individual operation timeout"
- 10 new unit tests covering budget capping, immediate rejection, backward compatibility, and error message formatting

This is the **foundation layer** for #454. A follow-up PR will wire `context` into all tool handler signatures and insert `hasBudget()` checks at sequential CDP call boundaries.

### Before (cumulative stacking possible)
```
withTimeout(cdpCall, 15_000, 'label')  // always waits 15s even if only 2s of budget left
```

### After (budget-aware capping)
```
withTimeout(cdpCall, 15_000, 'label', context)  // caps to min(15_000, remainingBudget)
```

## Test plan

- [x] `withTimeout` resolves normally when promise completes before timeout
- [x] `withTimeout` rejects with `OpenChromeTimeoutError` on timeout (deadline=false)
- [x] With `ToolContext`: caps timeout to remaining budget (~1s, not 15s)
- [x] With exhausted budget: rejects immediately (< 100ms) with `deadline=true`
- [x] With ample budget: does NOT cap (individual timeout fires first, deadline=false)
- [x] `OpenChromeTimeoutError.deadline` distinguishes budget vs individual timeout
- [x] Error messages: "deadline exceeded (budget exhausted)" vs "timed out after Xms"
- [x] Full test suite: 2363/2363 pass (122 suites)
- [x] Build passes: `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)