### PR TITLE
feat: expose stealth status in navigate response (#453)

### DIFF
--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -268,6 +268,7 @@ const handler: ToolHandler = async (
         created: true,
         elementCount: newTabElementCount,
         readiness: newTabReadiness,
+        ...(stealth && { stealth: true }),
         ...(newTabSummary && { visualSummary: newTabSummary }),
         ...(newTabBlocking && { blockingPage: newTabBlocking }),
       });

--- a/tests/tools/navigate-stealth.test.ts
+++ b/tests/tools/navigate-stealth.test.ts
@@ -182,9 +182,19 @@ describe('NavigateTool - Stealth Mode', () => {
         tabId: expect.any(String),
         workerId: expect.any(String),
         created: true,
+        stealth: true,
       });
       expect(typeof parsed['url']).toBe('string');
       expect(typeof parsed['title']).toBe('string');
+    });
+
+    test('non-stealth response does not include stealth field', async () => {
+      const handler = await getNavigateHandler();
+      const result = await handler(testSessionId, {
+        url: 'https://example.com',
+      });
+      const parsed = parseResultJSON(result as any) as Record<string, unknown>;
+      expect(parsed).not.toHaveProperty('stealth');
     });
 
     test('stealth mode passes workerId to createTargetStealth', async () => {


### PR DESCRIPTION
## Summary

- Add `stealth: true` field to navigate tool response when stealth mode is used
- AI agents can now detect stealth context and choose appropriate follow-up actions (e.g., human-like interactions on stealth pages)
- Non-stealth responses remain unchanged (no `stealth` field)

Closes #446 item 4.2. Refs #453.

## Changes

- `src/tools/navigate.ts`: Add `...(stealth && { stealth: true })` to new-tab response object
- `tests/tools/navigate-stealth.test.ts`: Add assertion for `stealth: true` in stealth response; add negative test for non-stealth response

## Test plan

- [x] Stealth response includes `stealth: true` field
- [x] Non-stealth response does not include `stealth` field
- [x] All 16 navigate-stealth tests pass
- [x] Build succeeds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)