### PR TITLE
feat: remove bot-detection Chrome flags for stealth fingerprint reduction (#453)

### DIFF
--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -440,6 +440,7 @@ export class ChromeLauncher {
       ?? globalConfig.restoreLastSession
       ?? DEFAULT_RESTORE_LAST_SESSION;
 
+    // Essential flags — required for all modes
     args.push(
       '--no-first-run',
       '--no-default-browser-check',
@@ -448,16 +449,6 @@ export class ChromeLauncher {
       '--start-maximized',
       // Fallback window size if maximize doesn't work
       `--window-size=${DEFAULT_VIEWPORT.width},${DEFAULT_VIEWPORT.height}`,
-      // Memory-saving flags (applies to all profile types)
-      '--renderer-process-limit=16',
-      '--js-flags=--max-old-space-size=1024',
-      '--disable-backgrounding-occluded-windows',
-      // Prevent Chrome from self-terminating after repeated GPU crashes (headed mode)
-      '--disable-gpu-crash-limit',
-      // Suppress crash UI that blocks automation in long sessions (#347)
-      '--disable-crash-reporter',
-      '--disable-session-crashed-bubble',
-      '--hide-crash-restore-bubble',
     );
 
     // Prevent Blink from setting navigator.webdriver = true when CDP is connected.
@@ -469,17 +460,27 @@ export class ChromeLauncher {
       args.push('--disable-blink-features=AutomationControlled');
     }
 
-    // Only disable background features for non-real profiles.
-    // Several flags previously included here were removed as known bot-detection signals
-    // per Patchright's stealth analysis (issue #257). Specifically omitted: metrics
-    // recording, extension disabling, component extension pages, and default apps flags.
+    // Stability flags — suppress crash UI that blocks automation in long sessions (#347).
+    // Applied only to managed profiles; real profiles retain stock Chrome behavior
+    // to minimize fingerprint divergence.
     if (profileType !== 'real') {
       args.push(
-        '--disable-background-networking',
-        '--disable-sync',
-        '--disable-translate',
+        '--disable-backgrounding-occluded-windows',
+        // Prevent Chrome from self-terminating after repeated GPU crashes (headed mode)
+        '--disable-gpu-crash-limit',
+        '--disable-session-crashed-bubble',
+        '--hide-crash-restore-bubble',
       );
     }
+
+    // NOTE: The following flags were removed as known bot-detection signals
+    // per Patchright and undetected-chromedriver analysis (#257, #453):
+    //   --disable-background-networking  (Akamai/Imperva fingerprint signal)
+    //   --disable-sync                   (automation fingerprint signal)
+    //   --disable-translate              (automation fingerprint signal)
+    //   --renderer-process-limit=N       (non-standard, reveals automation)
+    //   --js-flags=--max-old-space-size  (non-standard V8 config)
+    //   --disable-crash-reporter         (automation fingerprint signal)
 
     // Headless mode: explicit option > global config (default when auto-launch)
     const headless = options.headless ?? globalConfig.headless ?? false;

--- a/tests/chrome/launcher-stealth-flags.test.ts
+++ b/tests/chrome/launcher-stealth-flags.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for Chrome launcher flag optimization for stealth mode (#453)
+ *
+ * Verifies that known bot-detection signals are absent from the launcher source,
+ * essential flags are present, and stability flags are conditional on profileType.
+ *
+ * Uses source-level checks (same pattern as launcher-diagnostics.test.ts) since
+ * the flags are built from static string literals in launcher.ts.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const launcherPath = path.join(__dirname, '../../src/chrome/launcher.ts');
+let launcherSource: string;
+
+beforeAll(() => {
+  launcherSource = fs.readFileSync(launcherPath, 'utf8');
+});
+
+describe('Chrome launch flag stealth optimization (#453)', () => {
+  describe('bot-detection flags are removed', () => {
+    // These checks verify that removed flags do not appear as active string literals
+    // (i.e., inside args.push() calls). They may still appear in comments for
+    // auditability — so we match only quoted flag strings, not comment text.
+
+    it('should NOT contain --disable-background-networking as an active argument', () => {
+      expect(launcherSource).not.toMatch(/'--disable-background-networking'/);
+    });
+
+    it('should NOT contain --disable-sync as an active argument', () => {
+      expect(launcherSource).not.toMatch(/'--disable-sync'/);
+    });
+
+    it('should NOT contain --disable-translate as an active argument', () => {
+      expect(launcherSource).not.toMatch(/'--disable-translate'/);
+    });
+
+    it('should NOT contain --renderer-process-limit as an active argument', () => {
+      expect(launcherSource).not.toMatch(/'--renderer-process-limit/);
+    });
+
+    it('should NOT contain --js-flags=--max-old-space-size as an active argument', () => {
+      expect(launcherSource).not.toMatch(/'--js-flags=--max-old-space-size/);
+    });
+
+    it('should NOT contain --disable-crash-reporter as an active argument', () => {
+      expect(launcherSource).not.toMatch(/'--disable-crash-reporter'/);
+    });
+  });
+
+  describe('essential flags are present', () => {
+    it('should contain --no-first-run', () => {
+      expect(launcherSource).toContain('--no-first-run');
+    });
+
+    it('should contain --no-default-browser-check', () => {
+      expect(launcherSource).toContain('--no-default-browser-check');
+    });
+
+    it('should contain --start-maximized', () => {
+      expect(launcherSource).toContain('--start-maximized');
+    });
+
+    it('should contain --window-size', () => {
+      expect(launcherSource).toContain('--window-size=');
+    });
+
+    it('should contain --disable-blink-features=AutomationControlled (regression guard, #247)', () => {
+      expect(launcherSource).toContain('--disable-blink-features=AutomationControlled');
+    });
+
+    it('should contain --remote-debugging-port', () => {
+      expect(launcherSource).toContain('--remote-debugging-port=');
+    });
+
+    it('should contain --user-data-dir', () => {
+      expect(launcherSource).toContain('--user-data-dir=');
+    });
+  });
+
+  describe('stability flags are conditional on profileType', () => {
+    it('should gate --disable-backgrounding-occluded-windows behind profileType !== real check', () => {
+      const lines = launcherSource.split('\n');
+      const flagIdx = lines.findIndex(l => l.includes('--disable-backgrounding-occluded-windows'));
+      expect(flagIdx).toBeGreaterThan(-1);
+
+      const precedingCode = lines.slice(0, flagIdx).join('\n');
+      const lastProfileCheck = precedingCode.lastIndexOf("profileType !== 'real'");
+      expect(lastProfileCheck).toBeGreaterThan(-1);
+    });
+
+    it('should gate --disable-gpu-crash-limit behind profileType !== real check', () => {
+      const lines = launcherSource.split('\n');
+      const flagIdx = lines.findIndex(l => l.includes('--disable-gpu-crash-limit'));
+      expect(flagIdx).toBeGreaterThan(-1);
+
+      const precedingCode = lines.slice(0, flagIdx).join('\n');
+      const lastProfileCheck = precedingCode.lastIndexOf("profileType !== 'real'");
+      expect(lastProfileCheck).toBeGreaterThan(-1);
+    });
+
+    it('should gate --disable-session-crashed-bubble behind profileType !== real check', () => {
+      const lines = launcherSource.split('\n');
+      const flagIdx = lines.findIndex(l => l.includes('--disable-session-crashed-bubble'));
+      expect(flagIdx).toBeGreaterThan(-1);
+
+      const precedingCode = lines.slice(0, flagIdx).join('\n');
+      const lastProfileCheck = precedingCode.lastIndexOf("profileType !== 'real'");
+      expect(lastProfileCheck).toBeGreaterThan(-1);
+    });
+
+    it('should gate --hide-crash-restore-bubble behind profileType !== real check', () => {
+      const lines = launcherSource.split('\n');
+      const flagIdx = lines.findIndex(l => l.includes('--hide-crash-restore-bubble'));
+      expect(flagIdx).toBeGreaterThan(-1);
+
+      const precedingCode = lines.slice(0, flagIdx).join('\n');
+      const lastProfileCheck = precedingCode.lastIndexOf("profileType !== 'real'");
+      expect(lastProfileCheck).toBeGreaterThan(-1);
+    });
+  });
+
+  describe('removal comment documentation', () => {
+    it('should have a comment documenting the removed flags for auditability', () => {
+      expect(launcherSource).toContain('--disable-background-networking');
+      expect(launcherSource).toContain('--disable-sync');
+      expect(launcherSource).toContain('--disable-translate');
+      expect(launcherSource).toContain('#453');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Remove 6 Chrome launch flags identified as automation fingerprint signals by Akamai, Imperva, and other CDN/WAF bot detection systems
- Restructure remaining flags into essential vs stability categories
- Gate stability flags behind `profileType !== 'real'` so real profiles stay as close to stock Chrome as possible

Refs #453

## Removed Flags

| Flag | Reason |
|------|--------|
| `--disable-background-networking` | Akamai/Imperva fingerprint signal |
| `--disable-sync` | Automation fingerprint signal |
| `--disable-translate` | Automation fingerprint signal |
| `--renderer-process-limit=N` | Non-standard, reveals automation |
| `--js-flags=--max-old-space-size` | Non-standard V8 config |
| `--disable-crash-reporter` | Automation fingerprint signal |

These flags were identified via Patchright and undetected-chromedriver analysis. They contribute to a distinctive browser fingerprint that CDN/WAF systems (Akamai Bot Manager) use to classify requests as automated before any JavaScript executes.

## Flag Categories After Change

- **Essential** (always): `--no-first-run`, `--no-default-browser-check`, `--start-maximized`, `--window-size`, `--disable-blink-features=AutomationControlled`
- **Stability** (managed profiles only): `--disable-backgrounding-occluded-windows`, `--disable-gpu-crash-limit`, `--disable-session-crashed-bubble`, `--hide-crash-restore-bubble`
- **Removed**: 6 flags listed above (documented in comments for auditability)

## Test plan

- [x] 18 new source-level tests verify flag presence/absence (`tests/chrome/launcher-stealth-flags.test.ts`)
- [x] All 2381 existing tests pass (zero regressions)
- [x] Build succeeds (`npm run build`)
- [ ] Real-world verification: `navigate(url: "https://www.coupang.com", stealth: true)` — requires manual test after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)