### PR TITLE
feat: auto-retry with stealth on CDN/WAF block detection (#459)

### DIFF
--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -11,10 +11,13 @@ import { DEFAULT_NAVIGATION_TIMEOUT_MS } from '../config/defaults';
 import { generateVisualSummary } from '../utils/visual-summary';
 import { AdaptiveScreenshot } from '../utils/adaptive-screenshot';
 import { assertDomainAllowed } from '../security/domain-guard';
-import { detectBlockingPage } from '../utils/page-diagnostics';
+import { detectBlockingPage, BlockingInfo } from '../utils/page-diagnostics';
 import { withTimeout } from '../utils/with-timeout';
 import { simulatePresence } from '../stealth/human-behavior';
 import type { Page } from 'puppeteer-core';
+
+/** Blocking types that warrant automatic stealth retry (#459) */
+const RETRYABLE_BLOCK_TYPES: ReadonlySet<string> = new Set(['access-denied', 'bot-check', 'captcha']);
 
 /** Compute readiness data for navigate responses. Non-critical — returns defaults on failure. */
 async function getReadiness(page: Page): Promise<{ readyState: string; domStable: boolean; framework: string }> {
@@ -34,6 +37,69 @@ async function getReadiness(page: Page): Promise<{ readyState: string; domStable
   } catch {
     return { readyState: 'unknown', domStable: false, framework: 'unknown' };
   }
+}
+
+/**
+ * Auto-fallback: retry navigation with stealth mode when a CDN/WAF block is detected.
+ * Closes the original blocked tab (if just created), creates a new stealth tab,
+ * and returns the result with fallbackTier/fallbackReason metadata. (#459)
+ */
+async function stealthAutoRetry(
+  sessionId: string,
+  targetUrl: string,
+  workerId: string | undefined,
+  stealthSettleMs: number,
+  profileDirectory: string | undefined,
+  blockingInfo: BlockingInfo,
+  closeTabId?: string,
+): Promise<MCPResult> {
+  const sessionManager = getSessionManager();
+
+  if (closeTabId) {
+    await sessionManager.closeTarget(sessionId, closeTabId).catch(() => {});
+  }
+
+  console.error(`[navigate] Auto-fallback: block detected (${blockingInfo.type}), retrying with stealth...`);
+
+  const { targetId, page, workerId: assignedWorkerId } =
+    await sessionManager.createTargetStealth(sessionId, targetUrl, workerId, stealthSettleMs, profileDirectory);
+
+  await simulatePresence(page);
+
+  AdaptiveScreenshot.getInstance().reset(targetId);
+  const [summary, blocking] = await Promise.all([
+    generateVisualSummary(page),
+    Promise.race([
+      detectBlockingPage(page),
+      new Promise<null>(resolve => setTimeout(() => resolve(null), 5000)),
+    ]).catch(() => null),
+  ]);
+
+  let elementCount = 0;
+  try {
+    elementCount = await withTimeout(
+      page.evaluate(() => document.querySelectorAll('*').length),
+      3000, 'elementCount',
+    );
+  } catch { /* non-critical */ }
+
+  const readiness = await getReadiness(page);
+  const resultText = JSON.stringify({
+    action: 'navigate',
+    url: page.url(),
+    title: await safeTitle(page),
+    tabId: targetId,
+    workerId: assignedWorkerId,
+    created: true,
+    elementCount,
+    readiness,
+    stealth: true,
+    fallbackTier: 2,
+    fallbackReason: blockingInfo.type,
+    ...(summary && { visualSummary: summary }),
+    ...(blocking && { blockingPage: blocking }),
+  });
+  return { content: [{ type: 'text', text: resultText }] };
 }
 
 const definition: MCPToolDefinition = {
@@ -61,6 +127,10 @@ const definition: MCPToolDefinition = {
       stealthSettleMs: {
         type: 'number',
         description: 'How long to wait (ms) before attaching CDP in stealth mode. Default: 8000. Range: 1000-30000.',
+      },
+      autoFallback: {
+        type: 'boolean',
+        description: 'Auto-retry with stealth when CDN/WAF block is detected (access-denied, bot-check, captcha). Default: true. Set false to disable.',
       },
       profileDirectory: {
         type: 'string',
@@ -90,6 +160,7 @@ const handler: ToolHandler = async (
   const workerId = (args.workerId as string | undefined) || (profileDirectory ? `profile:${profileDirectory}` : undefined);
   const stealth = args.stealth as boolean | undefined;
   const stealthSettleMs = Math.min(Math.max((args.stealthSettleMs as number) || 8000, 1000), 30000);
+  const autoFallback = args.autoFallback !== false; // default: true
   const stealthIgnoredWarning = stealth && tabId ? 'stealth mode only works when creating new tabs (omit tabId). The stealth parameter was ignored for this navigation.' : undefined;
   const sessionManager = getSessionManager();
 
@@ -210,6 +281,12 @@ const handler: ToolHandler = async (
               // Non-critical — proceed without count
             }
             const reuseReadiness = await getReadiness(page);
+
+            // Auto-fallback: if reused tab hit a CDN/WAF block, retry with stealth in a new tab (#459)
+            if (reuseBlocking && autoFallback && RETRYABLE_BLOCK_TYPES.has(reuseBlocking.type)) {
+              return stealthAutoRetry(sessionId, targetUrl, workerId, stealthSettleMs, profileDirectory, reuseBlocking);
+            }
+
             const reuseResultText = JSON.stringify({
               action: 'navigate',
               url: page.url(),
@@ -260,6 +337,12 @@ const handler: ToolHandler = async (
         // Non-critical — proceed without count
       }
       const newTabReadiness = await getReadiness(page);
+
+      // Auto-fallback: if new tab hit a CDN/WAF block and stealth wasn't already used, retry with stealth (#459)
+      if (newTabBlocking && !stealth && autoFallback && RETRYABLE_BLOCK_TYPES.has(newTabBlocking.type)) {
+        return stealthAutoRetry(sessionId, targetUrl, workerId, stealthSettleMs, profileDirectory, newTabBlocking, targetId);
+      }
+
       const newTabResultText = JSON.stringify({
         action: 'navigate',
         url: page.url(),

--- a/tests/stealth/stealth-integration.test.ts
+++ b/tests/stealth/stealth-integration.test.ts
@@ -23,21 +23,29 @@ describe('Stealth v2 Integration: navigate.ts', () => {
   });
 
   test('calls simulatePresence only when stealth is true', () => {
-    // Find the stealth block
-    const stealthBlock = source.slice(
-      source.indexOf('if (stealth) {'),
-      source.indexOf('AdaptiveScreenshot.getInstance().reset(targetId)')
+    // Find the stealth block in the handler (after 'if (stealth) {'),
+    // scoped to the handler to avoid matching stealthAutoRetry helper (#459)
+    const handlerStart = source.indexOf('const handler: ToolHandler');
+    const handlerSource = source.slice(handlerStart);
+    const stealthBlock = handlerSource.slice(
+      handlerSource.indexOf('if (stealth) {'),
+      handlerSource.indexOf('AdaptiveScreenshot.getInstance().reset(targetId)')
     );
     expect(stealthBlock).toContain('simulatePresence(page)');
   });
 
   test('non-stealth path does not call simulatePresence', () => {
-    // The simulatePresence call should be guarded by if (stealth)
-    const lines = source.split('\n');
-    const presenceLine = lines.findIndex(l => l.includes('simulatePresence(page)'));
+    // The simulatePresence call inside the handler should be guarded by if (stealth).
+    // Find the handler's simulatePresence call (inside the 'if (stealth)' block),
+    // not the one in stealthAutoRetry helper which is always-stealth by design (#459).
+    const handlerStart = source.indexOf('const handler: ToolHandler');
+    expect(handlerStart).toBeGreaterThan(-1);
+    const handlerSource = source.slice(handlerStart);
+    const handlerLines = handlerSource.split('\n');
+    const presenceLine = handlerLines.findIndex(l => l.includes('simulatePresence(page)'));
     expect(presenceLine).toBeGreaterThan(-1);
     // Check the guard exists before it
-    const guardLine = lines.slice(Math.max(0, presenceLine - 5), presenceLine)
+    const guardLine = handlerLines.slice(Math.max(0, presenceLine - 5), presenceLine)
       .some(l => l.includes('if (stealth)'));
     expect(guardLine).toBe(true);
   });

--- a/tests/tools/navigate-auto-fallback.test.ts
+++ b/tests/tools/navigate-auto-fallback.test.ts
@@ -1,0 +1,347 @@
+/// <reference types="jest" />
+/**
+ * Tests for Navigate Tool - Auto-fallback: stealth retry on CDN/WAF block detection (#459)
+ */
+
+import { createMockSessionManager } from '../utils/mock-session';
+import { createMockPage } from '../utils/mock-cdp';
+import { parseResultJSON } from '../utils/test-helpers';
+import type { MCPResult } from '../../src/types/mcp';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type NavResult = Record<string, any>;
+
+// Mock session-manager
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(),
+}));
+
+// Mock smart-goto
+import type { SmartGotoResult } from '../../src/utils/smart-goto';
+const mockSmartGotoFn = jest.fn<Promise<SmartGotoResult>, [any, string, any?]>(
+  async (page, url, opts) => {
+    await page.goto(url, opts);
+    return { response: null };
+  },
+);
+jest.mock('../../src/utils/smart-goto', () => ({
+  smartGoto: mockSmartGotoFn,
+}));
+
+// Mock page-diagnostics to control blocking detection
+const mockDetectBlockingPage = jest.fn().mockResolvedValue(null);
+jest.mock('../../src/utils/page-diagnostics', () => ({
+  detectBlockingPage: (...args: any[]) => mockDetectBlockingPage(...args),
+  BlockingInfo: {},
+}));
+
+// Mock visual-summary
+jest.mock('../../src/utils/visual-summary', () => ({
+  generateVisualSummary: jest.fn().mockResolvedValue(null),
+}));
+
+// Mock stealth human behavior
+const mockSimulatePresence = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../src/stealth/human-behavior', () => ({
+  simulatePresence: mockSimulatePresence,
+}));
+
+import { getSessionManager } from '../../src/session-manager';
+
+describe('NavigateTool - Auto-fallback (#459)', () => {
+  let mockSessionManager: ReturnType<typeof createMockSessionManager>;
+  let testSessionId: string;
+
+  const getNavigateHandler = async () => {
+    jest.resetModules();
+    jest.doMock('../../src/session-manager', () => ({
+      getSessionManager: () => mockSessionManager,
+    }));
+    jest.doMock('../../src/utils/smart-goto', () => ({
+      smartGoto: mockSmartGotoFn,
+    }));
+    jest.doMock('../../src/utils/page-diagnostics', () => ({
+      detectBlockingPage: (...args: any[]) => mockDetectBlockingPage(...args),
+      BlockingInfo: {},
+    }));
+    jest.doMock('../../src/utils/visual-summary', () => ({
+      generateVisualSummary: jest.fn().mockResolvedValue(null),
+    }));
+    jest.doMock('../../src/stealth/human-behavior', () => ({
+      simulatePresence: mockSimulatePresence,
+    }));
+    const { registerNavigateTool } = await import('../../src/tools/navigate');
+
+    const tools: Map<string, { handler: (sessionId: string, args: Record<string, unknown>) => Promise<unknown> }> = new Map();
+    const mockServer = {
+      registerTool: (name: string, handler: unknown) => {
+        tools.set(name, { handler: handler as (sessionId: string, args: Record<string, unknown>) => Promise<unknown> });
+      },
+    };
+
+    registerNavigateTool(mockServer as unknown as Parameters<typeof registerNavigateTool>[0]);
+    return tools.get('navigate')!.handler;
+  };
+
+  beforeEach(() => {
+    mockSessionManager = createMockSessionManager();
+    (getSessionManager as jest.Mock).mockReturnValue(mockSessionManager);
+    testSessionId = 'test-session-fallback';
+    mockDetectBlockingPage.mockResolvedValue(null);
+    mockSimulatePresence.mockResolvedValue(undefined);
+
+    // Add createTargetStealth mock
+    (mockSessionManager as any).createTargetStealth = jest.fn().mockImplementation(
+      async (sessionId: string, url: string, workerId?: string) => {
+        const resolvedWorkerId = workerId || 'default';
+        const targetId = `stealth-target-${Date.now()}`;
+        const page = createMockPage({ url, targetId, title: 'Stealth Page' });
+        return { targetId, page, workerId: resolvedWorkerId };
+      },
+    );
+
+    // Add closeTarget mock
+    (mockSessionManager as any).closeTarget = jest.fn().mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('new-tab auto-fallback', () => {
+    test('retries with stealth when access-denied block detected', async () => {
+      const handler = await getNavigateHandler();
+
+      // First call to detectBlockingPage returns access-denied (for the normal tab)
+      // Second call returns null (stealth tab succeeds)
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'access-denied', detail: 'Access Denied' })
+        .mockResolvedValueOnce(null);
+
+      const result = await handler(testSessionId, { url: 'https://www.coupang.com' });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed.stealth).toBe(true);
+      expect(parsed.fallbackTier).toBe(2);
+      expect(parsed.fallbackReason).toBe('access-denied');
+      expect(parsed.created).toBe(true);
+      // Original blocked tab should be closed
+      expect((mockSessionManager as any).closeTarget).toHaveBeenCalled();
+      // Stealth target should be created
+      expect((mockSessionManager as any).createTargetStealth).toHaveBeenCalled();
+    });
+
+    test('retries with stealth when bot-check block detected', async () => {
+      const handler = await getNavigateHandler();
+
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'bot-check', detail: 'Security Check' })
+        .mockResolvedValueOnce(null);
+
+      const result = await handler(testSessionId, { url: 'https://www.example.com' });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed.fallbackTier).toBe(2);
+      expect(parsed.fallbackReason).toBe('bot-check');
+      expect(parsed.stealth).toBe(true);
+    });
+
+    test('retries with stealth when captcha block detected', async () => {
+      const handler = await getNavigateHandler();
+
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'captcha', detail: 'Turnstile' })
+        .mockResolvedValueOnce(null);
+
+      const result = await handler(testSessionId, { url: 'https://www.example.com' });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed.fallbackTier).toBe(2);
+      expect(parsed.fallbackReason).toBe('captcha');
+    });
+
+    test('does NOT retry for js-required block type', async () => {
+      const handler = await getNavigateHandler();
+
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'js-required', detail: 'Page requires JavaScript' });
+
+      const result = await handler(testSessionId, { url: 'https://www.example.com' });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      // Should return the original result with blockingPage, no fallback
+      expect(parsed.blockingPage).toBeDefined();
+      expect(parsed.blockingPage.type).toBe('js-required');
+      expect(parsed.fallbackTier).toBeUndefined();
+      expect((mockSessionManager as any).createTargetStealth).not.toHaveBeenCalled();
+    });
+
+    test('does NOT retry when stealth was already explicitly used', async () => {
+      const handler = await getNavigateHandler();
+
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'access-denied', detail: 'Access Denied' });
+
+      const result = await handler(testSessionId, { url: 'https://www.coupang.com', stealth: true });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      // Stealth was already used — should NOT trigger auto-fallback
+      expect(parsed.stealth).toBe(true);
+      expect(parsed.blockingPage).toBeDefined();
+      expect(parsed.fallbackTier).toBeUndefined();
+      // createTargetStealth called once (original stealth request), not twice
+      expect((mockSessionManager as any).createTargetStealth).toHaveBeenCalledTimes(1);
+    });
+
+    test('does NOT retry when autoFallback is false', async () => {
+      const handler = await getNavigateHandler();
+
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'access-denied', detail: 'Access Denied' });
+
+      const result = await handler(testSessionId, { url: 'https://www.coupang.com', autoFallback: false });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed.blockingPage).toBeDefined();
+      expect(parsed.fallbackTier).toBeUndefined();
+      expect((mockSessionManager as any).createTargetStealth).not.toHaveBeenCalled();
+    });
+
+    test('no fallback when page loads normally (no block)', async () => {
+      const handler = await getNavigateHandler();
+
+      mockDetectBlockingPage.mockResolvedValueOnce(null);
+
+      const result = await handler(testSessionId, { url: 'https://www.naver.com' });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed.fallbackTier).toBeUndefined();
+      expect(parsed.fallbackReason).toBeUndefined();
+      expect(parsed.stealth).toBeUndefined();
+      expect((mockSessionManager as any).createTargetStealth).not.toHaveBeenCalled();
+    });
+
+    test('returns blocked result if stealth retry also gets blocked', async () => {
+      const handler = await getNavigateHandler();
+
+      // Both normal and stealth get blocked
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'access-denied', detail: 'Access Denied' })
+        .mockResolvedValueOnce({ type: 'access-denied', detail: 'Still Denied' });
+
+      const result = await handler(testSessionId, { url: 'https://www.coupang.com' });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      // Should return the stealth result WITH blockingPage (not loop)
+      expect(parsed.fallbackTier).toBe(2);
+      expect(parsed.stealth).toBe(true);
+      expect(parsed.blockingPage).toBeDefined();
+      expect(parsed.blockingPage.type).toBe('access-denied');
+    });
+
+    test('closes original blocked tab before stealth retry', async () => {
+      const handler = await getNavigateHandler();
+
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'access-denied', detail: 'Access Denied' })
+        .mockResolvedValueOnce(null);
+
+      await handler(testSessionId, { url: 'https://www.coupang.com' });
+
+      expect((mockSessionManager as any).closeTarget).toHaveBeenCalledWith(
+        testSessionId,
+        expect.any(String),
+      );
+    });
+
+    test('simulatePresence is called on stealth fallback tab', async () => {
+      const handler = await getNavigateHandler();
+
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'bot-check', detail: 'Bot Check' })
+        .mockResolvedValueOnce(null);
+
+      await handler(testSessionId, { url: 'https://www.example.com' });
+
+      expect(mockSimulatePresence).toHaveBeenCalled();
+    });
+  });
+
+  describe('tab-reuse auto-fallback', () => {
+    test('retries with stealth when reused tab hits a block', async () => {
+      const handler = await getNavigateHandler();
+
+      // Set up an existing tab for the worker
+      const existingTabId = 'existing-tab-1';
+      const existingPage = createMockPage({ url: 'https://www.coupang.com', targetId: existingTabId, title: 'Access Denied' });
+      mockSessionManager.getWorkerTargetIds.mockReturnValue([existingTabId]);
+      mockSessionManager.isTargetValid.mockResolvedValue(true);
+      mockSessionManager.getPage.mockResolvedValue(existingPage);
+
+      // Tab reuse detects block, stealth retry succeeds
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'access-denied', detail: 'Access Denied' })
+        .mockResolvedValueOnce(null);
+
+      const result = await handler(testSessionId, { url: 'https://www.coupang.com' });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed.fallbackTier).toBe(2);
+      expect(parsed.fallbackReason).toBe('access-denied');
+      expect(parsed.stealth).toBe(true);
+      // Reused tab should NOT be closed (it existed before)
+      expect((mockSessionManager as any).closeTarget).not.toHaveBeenCalled();
+    });
+
+    test('does NOT retry reused tab when autoFallback is false', async () => {
+      const handler = await getNavigateHandler();
+
+      const existingTabId = 'existing-tab-2';
+      const existingPage = createMockPage({ url: 'https://www.coupang.com', targetId: existingTabId });
+      mockSessionManager.getWorkerTargetIds.mockReturnValue([existingTabId]);
+      mockSessionManager.isTargetValid.mockResolvedValue(true);
+      mockSessionManager.getPage.mockResolvedValue(existingPage);
+
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'access-denied', detail: 'Access Denied' });
+
+      const result = await handler(testSessionId, { url: 'https://www.coupang.com', autoFallback: false });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed.blockingPage).toBeDefined();
+      expect(parsed.fallbackTier).toBeUndefined();
+      expect((mockSessionManager as any).createTargetStealth).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('response schema', () => {
+    test('fallbackTier and fallbackReason are present when fallback triggered', async () => {
+      const handler = await getNavigateHandler();
+
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'access-denied', detail: 'Akamai CDN' })
+        .mockResolvedValueOnce(null);
+
+      const result = await handler(testSessionId, { url: 'https://www.coupang.com' });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed).toHaveProperty('fallbackTier', 2);
+      expect(parsed).toHaveProperty('fallbackReason', 'access-denied');
+      expect(parsed).toHaveProperty('stealth', true);
+      expect(parsed).toHaveProperty('created', true);
+      expect(parsed).toHaveProperty('action', 'navigate');
+    });
+
+    test('fallbackTier and fallbackReason are absent when no fallback', async () => {
+      const handler = await getNavigateHandler();
+
+      mockDetectBlockingPage.mockResolvedValueOnce(null);
+
+      const result = await handler(testSessionId, { url: 'https://www.naver.com' });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed.fallbackTier).toBeUndefined();
+      expect(parsed.fallbackReason).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements **Tier 2 auto-fallback** from #459: when `navigate` detects a CDN/WAF block (`access-denied`, `bot-check`, `captcha`), it automatically retries with stealth mode before returning the blocked result
- Adds `autoFallback` parameter (default: `true`) — set `false` to disable
- Response includes `fallbackTier: 2` and `fallbackReason` metadata when auto-retry triggers
- Works for both new-tab and tab-reuse navigation paths
- No retry when `stealth: true` was already explicit (prevents infinite loops)
- No retry for `js-required` blocks (not bot-related)

### Changed files
- `src/tools/navigate.ts` — `stealthAutoRetry()` helper, `autoFallback` param, retry logic in both navigation paths
- `tests/tools/navigate-auto-fallback.test.ts` — 14 new tests covering all scenarios
- `tests/stealth/stealth-integration.test.ts` — Scope source assertions to handler context (avoids matching helper function)

## Test plan

- [x] 14 new auto-fallback tests pass
- [x] All 2396 existing tests pass (0 regressions)
- [x] Build succeeds (`npm run build`)
- [ ] Live verification: `navigate("https://www.coupang.com")` triggers auto-fallback with `fallbackTier: 2`
- [ ] Live verification: `navigate("https://www.naver.com")` completes normally (no fallback triggered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)