### PR TITLE
fix: add hasBudget guards in navigate, computer, query-dom, form-input, drag-drop

### DIFF
--- a/src/tools/computer.ts
+++ b/src/tools/computer.ts
@@ -163,7 +163,7 @@ const handler: ToolHandler = async (
 
         // text_only mode: skip expensive screenshot, return visual summary
         if (effectiveMode === 'text_only') {
-          const summary = await generateVisualSummary(page);
+          const summary = (context && !hasBudget(context, 5_000)) ? null : await generateVisualSummary(page);
           return {
             content: [{
               type: 'text',
@@ -283,7 +283,7 @@ const handler: ToolHandler = async (
 
         if (refInfo) {
           const { delta } = await withDomDelta(page, () => page.mouse.click(clickCoord[0], clickCoord[1]));
-          const summary = await generateVisualSummary(page);
+          const summary = (context && !hasBudget(context, 5_000)) ? null : await generateVisualSummary(page);
           const summaryText = summary ? `\n${summary}` : '';
           return {
             content: [{ type: 'text', text: `Clicked element ${ref} at (${clickCoord[0]}, ${clickCoord[1]})${delta}${summaryText}` }],
@@ -303,7 +303,7 @@ const handler: ToolHandler = async (
 
         // Internal fallback: if hit non-interactive element, suggest but don't auto-retry
         // (auto-retry could cause unintended side effects on elements the LLM didn't intend)
-        const summary = await generateVisualSummary(page);
+        const summary = (context && !hasBudget(context, 5_000)) ? null : await generateVisualSummary(page);
         const summaryText = summary ? `\n${summary}` : '';
 
         const resultText = leftClickValidation.warning

--- a/src/tools/drag-drop.ts
+++ b/src/tools/drag-drop.ts
@@ -3,7 +3,7 @@
  */
 
 import { MCPServer } from '../mcp-server';
-import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext } from '../types/mcp';
+import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
 
 interface Position {
@@ -108,6 +108,14 @@ const handler: ToolHandler = async (
           text: 'Error: Either targetSelector or both targetX and targetY are required',
         },
       ],
+      isError: true,
+    };
+  }
+
+  // Budget gate: drag_drop involves multiple sequential CDP calls (resolve + mouseDown + mouseMove × steps + mouseUp)
+  if (context && !hasBudget(context, 10_000)) {
+    return {
+      content: [{ type: 'text', text: 'drag_drop: skipped (deadline approaching)' }],
       isError: true,
     };
   }

--- a/src/tools/form-input.ts
+++ b/src/tools/form-input.ts
@@ -3,7 +3,7 @@
  */
 
 import { MCPServer } from '../mcp-server';
-import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext } from '../types/mcp';
+import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
 import { getRefIdManager } from '../utils/ref-id-manager';
 import { withDomDelta } from '../utils/dom-delta';
@@ -60,6 +60,14 @@ const handler: ToolHandler = async (
   if (value === undefined) {
     return {
       content: [{ type: 'text', text: 'Error: value is required' }],
+      isError: true,
+    };
+  }
+
+  // Budget gate: form_input involves multiple sequential CDP calls (resolve + focus + evaluate + type)
+  if (context && !hasBudget(context, 10_000)) {
+    return {
+      content: [{ type: 'text', text: 'form_input: skipped (deadline approaching)' }],
       isError: true,
     };
   }

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -3,7 +3,7 @@
  */
 
 import { MCPServer } from '../mcp-server';
-import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext } from '../types/mcp';
+import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
 import { smartGoto } from '../utils/smart-goto';
 import { safeTitle } from '../utils/safe-title';
@@ -193,7 +193,7 @@ const handler: ToolHandler = async (
             }
             AdaptiveScreenshot.getInstance().reset(existingTabId);
             const [summary, reuseBlocking] = await Promise.all([
-              generateVisualSummary(page),
+              (context && !hasBudget(context, 5_000)) ? Promise.resolve(null) : generateVisualSummary(page),
               Promise.race([
                 detectBlockingPage(page),
                 new Promise<null>(resolve => setTimeout(() => resolve(null), 5000)),
@@ -243,7 +243,7 @@ const handler: ToolHandler = async (
 
       AdaptiveScreenshot.getInstance().reset(targetId);
       const [newTabSummary, newTabBlocking] = await Promise.all([
-        generateVisualSummary(page),
+        (context && !hasBudget(context, 5_000)) ? Promise.resolve(null) : generateVisualSummary(page),
         Promise.race([
           detectBlockingPage(page),
           new Promise<null>(resolve => setTimeout(() => resolve(null), 5000)),
@@ -327,7 +327,7 @@ const handler: ToolHandler = async (
       await page.goBack({ waitUntil: 'domcontentloaded', timeout: DEFAULT_NAVIGATION_TIMEOUT_MS });
       AdaptiveScreenshot.getInstance().reset(tabId);
       const [backSummary, backBlocking] = await Promise.all([
-        generateVisualSummary(page),
+        (context && !hasBudget(context, 5_000)) ? Promise.resolve(null) : generateVisualSummary(page),
         Promise.race([
           detectBlockingPage(page),
           new Promise<null>(resolve => setTimeout(() => resolve(null), 5000)),
@@ -361,7 +361,7 @@ const handler: ToolHandler = async (
       await page.goForward({ waitUntil: 'domcontentloaded', timeout: DEFAULT_NAVIGATION_TIMEOUT_MS });
       AdaptiveScreenshot.getInstance().reset(tabId);
       const [fwdSummary, fwdBlocking] = await Promise.all([
-        generateVisualSummary(page),
+        (context && !hasBudget(context, 5_000)) ? Promise.resolve(null) : generateVisualSummary(page),
         Promise.race([
           detectBlockingPage(page),
           new Promise<null>(resolve => setTimeout(() => resolve(null), 5000)),
@@ -484,7 +484,7 @@ const handler: ToolHandler = async (
 
     AdaptiveScreenshot.getInstance().reset(tabId);
     const [navSummary, navBlocking] = await Promise.all([
-      generateVisualSummary(page),
+      (context && !hasBudget(context, 5_000)) ? Promise.resolve(null) : generateVisualSummary(page),
       Promise.race([
         detectBlockingPage(page),
         new Promise<null>(resolve => setTimeout(() => resolve(null), 5000)),

--- a/src/tools/query-dom.ts
+++ b/src/tools/query-dom.ts
@@ -5,7 +5,7 @@
  */
 
 import { MCPServer } from '../mcp-server';
-import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext } from '../types/mcp';
+import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
 import { withTimeout } from '../utils/with-timeout';
 import { getAllShadowRoots, querySelectorInShadowRoots } from '../utils/shadow-dom';
@@ -230,7 +230,8 @@ async function shadowCSSFallback(
 
 async function handleCSS(
   sessionId: string,
-  args: Record<string, unknown>
+  args: Record<string, unknown>,
+  context?: ToolContext
 ): Promise<MCPResult> {
   const tabId = args.tabId as string;
   const selector = args.selector as string;
@@ -306,6 +307,10 @@ async function handleCSS(
     const elementInfos: CSSElementInfo[] = [];
 
     for (let i = 0; i < limitedElements.length; i++) {
+      // Budget check: return partial results if deadline is approaching
+      if (context && !hasBudget(context, 10_000)) {
+        break;
+      }
       const element = limitedElements[i];
       const info = await withTimeout(page.evaluate(
         (el: Element, index: number): CSSElementInfo => {
@@ -726,7 +731,7 @@ const handler: ToolHandler = async (
   try {
     switch (method) {
       case 'css':
-        return await handleCSS(sessionId, args);
+        return await handleCSS(sessionId, args, context);
       case 'xpath':
         return await handleXPath(sessionId, args);
       default:


### PR DESCRIPTION
## Summary

- Add explicit `hasBudget()` budget consumption checks to 5 tool handlers that accepted `ToolContext` but never consumed it
- Complements existing budget guards in fill-form, interact, click-element, find, and batch-paginate
- Uses graceful degradation pattern: skip enrichments under budget pressure, never fail the core operation

## Changes by tool

| Tool | Guard | Threshold | Behavior when budget low |
|------|-------|:---------:|--------------------------|
| `navigate` | Before `generateVisualSummary()` (5 locations) | 5s | Returns navigation result without visual summary |
| `computer` | Before `generateVisualSummary()` (3 locations) | 5s | Returns action result without visual summary |
| `query-dom` | In per-element CSS evaluation loop | 10s | Breaks loop, returns partial results collected |
| `form-input` | Before main CDP sequence | 10s | Early-return with "deadline approaching" message |
| `drag-drop` | Before main mouse sequence | 10s | Early-return with "deadline approaching" message |

## Design decisions

- **Navigate/computer**: Visual summary is a post-operation enrichment, not core functionality. Skipping it under budget pressure is safe — downstream code already handles null summaries via `...(summary && { visualSummary: summary })`
- **Query-dom**: Breaking the element loop returns whatever partial results were collected. Better than hanging for 120s iterating over 50 elements
- **Form-input/drag-drop**: These start multi-step CDP sequences (resolve + focus + type, or mouseDown + mouseMove × N + mouseUp). Early-return prevents starting work that can't finish
- **Thresholds**: 5s for enrichment-only skips (summary generation), 10s for operation-level gates (need enough budget to complete the core work)

## Test plan

- [x] `npm run build` — zero errors
- [x] `npm test` — 2382/2382 pass (no regressions)
- [ ] Live openchrome test: `navigate` to google.com returns visual summary (normal path)
- [ ] Live openchrome test: `computer` screenshot and click complete normally
- [ ] Live openchrome test: `query_dom` CSS selector returns results on normal page
- [ ] Live openchrome test: `form_input` sets value correctly on normal form
- [ ] Live openchrome test: `drag_drop` completes normally on draggable element

Refs #460 (Part 2), #454, #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)