### PR TITLE
fix: complete budget consumption — withTimeout context passthrough + hasBudget guards

### DIFF
--- a/src/tools/computer.ts
+++ b/src/tools/computer.ts
@@ -163,7 +163,7 @@ const handler: ToolHandler = async (
 
         // text_only mode: skip expensive screenshot, return visual summary
         if (effectiveMode === 'text_only') {
-          const summary = await generateVisualSummary(page);
+          const summary = (context && !hasBudget(context, 5_000)) ? null : await generateVisualSummary(page);
           return {
             content: [{
               type: 'text',
@@ -283,7 +283,7 @@ const handler: ToolHandler = async (
 
         if (refInfo) {
           const { delta } = await withDomDelta(page, () => page.mouse.click(clickCoord[0], clickCoord[1]));
-          const summary = await generateVisualSummary(page);
+          const summary = (context && !hasBudget(context, 5_000)) ? null : await generateVisualSummary(page);
           const summaryText = summary ? `\n${summary}` : '';
           return {
             content: [{ type: 'text', text: `Clicked element ${ref} at (${clickCoord[0]}, ${clickCoord[1]})${delta}${summaryText}` }],
@@ -303,7 +303,7 @@ const handler: ToolHandler = async (
 
         // Internal fallback: if hit non-interactive element, suggest but don't auto-retry
         // (auto-retry could cause unintended side effects on elements the LLM didn't intend)
-        const summary = await generateVisualSummary(page);
+        const summary = (context && !hasBudget(context, 5_000)) ? null : await generateVisualSummary(page);
         const summaryText = summary ? `\n${summary}` : '';
 
         const resultText = leftClickValidation.warning

--- a/src/tools/drag-drop.ts
+++ b/src/tools/drag-drop.ts
@@ -3,7 +3,7 @@
  */
 
 import { MCPServer } from '../mcp-server';
-import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext } from '../types/mcp';
+import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
 
 interface Position {
@@ -108,6 +108,14 @@ const handler: ToolHandler = async (
           text: 'Error: Either targetSelector or both targetX and targetY are required',
         },
       ],
+      isError: true,
+    };
+  }
+
+  // Budget gate: drag_drop involves multiple sequential CDP calls (resolve + mouseDown + mouseMove × steps + mouseUp)
+  if (context && !hasBudget(context, 10_000)) {
+    return {
+      content: [{ type: 'text', text: 'drag_drop: skipped (deadline approaching)' }],
       isError: true,
     };
   }

--- a/src/tools/form-input.ts
+++ b/src/tools/form-input.ts
@@ -3,7 +3,7 @@
  */
 
 import { MCPServer } from '../mcp-server';
-import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext } from '../types/mcp';
+import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
 import { getRefIdManager } from '../utils/ref-id-manager';
 import { withDomDelta } from '../utils/dom-delta';
@@ -60,6 +60,14 @@ const handler: ToolHandler = async (
   if (value === undefined) {
     return {
       content: [{ type: 'text', text: 'Error: value is required' }],
+      isError: true,
+    };
+  }
+
+  // Budget gate: form_input involves multiple sequential CDP calls (resolve + focus + evaluate + type)
+  if (context && !hasBudget(context, 10_000)) {
+    return {
+      content: [{ type: 'text', text: 'form_input: skipped (deadline approaching)' }],
       isError: true,
     };
   }

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -3,7 +3,7 @@
  */
 
 import { MCPServer } from '../mcp-server';
-import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext } from '../types/mcp';
+import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
 import { smartGoto } from '../utils/smart-goto';
 import { safeTitle } from '../utils/safe-title';
@@ -72,7 +72,7 @@ async function stealthAutoRetry(
 
   AdaptiveScreenshot.getInstance().reset(targetId);
   const [summary, blocking] = await Promise.all([
-    generateVisualSummary(page),
+    (context && !hasBudget(context, 5_000)) ? Promise.resolve(null) : generateVisualSummary(page),
     Promise.race([
       detectBlockingPage(page),
       new Promise<null>(resolve => setTimeout(() => resolve(null), 5000)),
@@ -325,7 +325,7 @@ const handler: ToolHandler = async (
             }
             AdaptiveScreenshot.getInstance().reset(existingTabId);
             const [summary, reuseBlocking] = await Promise.all([
-              generateVisualSummary(page),
+              (context && !hasBudget(context, 5_000)) ? Promise.resolve(null) : generateVisualSummary(page),
               Promise.race([
                 detectBlockingPage(page),
                 new Promise<null>(resolve => setTimeout(() => resolve(null), 5000)),
@@ -381,7 +381,7 @@ const handler: ToolHandler = async (
 
       AdaptiveScreenshot.getInstance().reset(targetId);
       const [newTabSummary, newTabBlocking] = await Promise.all([
-        generateVisualSummary(page),
+        (context && !hasBudget(context, 5_000)) ? Promise.resolve(null) : generateVisualSummary(page),
         Promise.race([
           detectBlockingPage(page),
           new Promise<null>(resolve => setTimeout(() => resolve(null), 5000)),
@@ -471,7 +471,7 @@ const handler: ToolHandler = async (
       await page.goBack({ waitUntil: 'domcontentloaded', timeout: DEFAULT_NAVIGATION_TIMEOUT_MS });
       AdaptiveScreenshot.getInstance().reset(tabId);
       const [backSummary, backBlocking] = await Promise.all([
-        generateVisualSummary(page),
+        (context && !hasBudget(context, 5_000)) ? Promise.resolve(null) : generateVisualSummary(page),
         Promise.race([
           detectBlockingPage(page),
           new Promise<null>(resolve => setTimeout(() => resolve(null), 5000)),
@@ -505,7 +505,7 @@ const handler: ToolHandler = async (
       await page.goForward({ waitUntil: 'domcontentloaded', timeout: DEFAULT_NAVIGATION_TIMEOUT_MS });
       AdaptiveScreenshot.getInstance().reset(tabId);
       const [fwdSummary, fwdBlocking] = await Promise.all([
-        generateVisualSummary(page),
+        (context && !hasBudget(context, 5_000)) ? Promise.resolve(null) : generateVisualSummary(page),
         Promise.race([
           detectBlockingPage(page),
           new Promise<null>(resolve => setTimeout(() => resolve(null), 5000)),
@@ -628,7 +628,7 @@ const handler: ToolHandler = async (
 
     AdaptiveScreenshot.getInstance().reset(tabId);
     const [navSummary, navBlocking] = await Promise.all([
-      generateVisualSummary(page),
+      (context && !hasBudget(context, 5_000)) ? Promise.resolve(null) : generateVisualSummary(page),
       Promise.race([
         detectBlockingPage(page),
         new Promise<null>(resolve => setTimeout(() => resolve(null), 5000)),

--- a/src/tools/query-dom.ts
+++ b/src/tools/query-dom.ts
@@ -5,7 +5,7 @@
  */
 
 import { MCPServer } from '../mcp-server';
-import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext } from '../types/mcp';
+import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
 import { withTimeout } from '../utils/with-timeout';
 import { getAllShadowRoots, querySelectorInShadowRoots } from '../utils/shadow-dom';
@@ -308,6 +308,10 @@ async function handleCSS(
     const elementInfos: CSSElementInfo[] = [];
 
     for (let i = 0; i < limitedElements.length; i++) {
+      // Budget check: return partial results if deadline is approaching
+      if (context && !hasBudget(context, 10_000)) {
+        break;
+      }
       const element = limitedElements[i];
       const info = await withTimeout(page.evaluate(
         (el: Element, index: number): CSSElementInfo => {


### PR DESCRIPTION
## Summary

Activate the budget-aware timeout infrastructure (built in #449, verified inert in #454) by wiring up all 34 `withTimeout()` call sites and adding `hasBudget()` guards in 5 tools that lacked them.

This is a combined PR replacing #463 and #464 (which had merge conflicts after #461/#462 merged).

## Changes

### Part 1: withTimeout context passthrough (34 call sites, 7 files)

Thread `context` as the 4th argument to every `withTimeout()` call. Caps individual CDP call timeouts to `Math.min(ms, remainingBudget)` — zero behavioral change on normal pages.

### Part 2: hasBudget guards (5 files)

| Tool | Guard | Threshold | Behavior |
|------|-------|:---------:|----------|
| `navigate` | Before `generateVisualSummary()` ×5 | 5s | Skip enrichment |
| `computer` | Before `generateVisualSummary()` ×3 | 5s | Skip enrichment |
| `query-dom` | In per-element CSS loop | 10s | Return partial results |
| `form-input` | Before main CDP sequence | 10s | Early-return |
| `drag-drop` | Before main mouse sequence | 10s | Early-return |

## Test plan

- [x] `npm run build` — zero errors
- [x] `npm test` — 2409/2409 pass
- [x] 34/34 withTimeout calls verified to pass context
- [x] hasBudget present in all 5 target tools

Closes #460, supersedes #463 and #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)