### PR TITLE
fix: generalized block detection with structural heuristics (#453)

### DIFF
--- a/src/hints/progress-tracker.ts
+++ b/src/hints/progress-tracker.ts
@@ -54,6 +54,9 @@ const NON_PROGRESS_SIGNALS = [
   'bot-check',                       // Bot verification page detected
   'captcha detected',                // CAPTCHA page detected
   'Blocking page detected',          // Any blocking page warning from navigate
+  'blocked by',                      // Network security block (e.g. "blocked by network security")
+  'network security',                // CDN/WAF network security block
+  'been blocked',                    // Generic "you've been blocked" messages
 ];
 
 export class ProgressTracker {

--- a/src/utils/page-diagnostics.ts
+++ b/src/utils/page-diagnostics.ts
@@ -100,6 +100,38 @@ export async function detectBlockingPage(page: Page): Promise<BlockingInfo | nul
         return { type: 'js-required' as const, detail: 'Page requires JavaScript' };
       }
 
+      // Structural heuristic: sparse page + blocking vocabulary → likely a block page.
+      // This catches novel CDN/WAF block patterns (e.g. "blocked by network security")
+      // without requiring site-specific text matching. The element count + body length
+      // guard prevents false positives on real pages that happen to mention blocking.
+      const elementCount = document.querySelectorAll('*').length;
+      const isSparsePage = elementCount < 100 && bodyText.length < 800;
+
+      if (isSparsePage) {
+        // Blocking vocabulary — ordered by specificity (most specific first)
+        const BLOCK_SIGNALS = [
+          'blocked by',
+          'been blocked',
+          'request blocked',
+          'ip blocked',
+          'ip has been blocked',
+          'network security',
+          'security policy',
+          'permission denied',
+          'not permitted',
+          'rate limit',
+          'too many requests',
+          'temporarily banned',
+          'your ip',
+          'suspicious activity',
+          'unusual traffic',
+        ];
+
+        if (BLOCK_SIGNALS.some(signal => bodyText.includes(signal))) {
+          return { type: 'access-denied' as const, detail: document.title || bodyText.substring(0, 100) };
+        }
+      }
+
       return null;
     });
   } catch {

--- a/tests/utils/page-diagnostics.test.ts
+++ b/tests/utils/page-diagnostics.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Tests for detectBlockingPage() — structural heuristics and existing patterns.
+ */
+
+/// <reference types="jest" />
+
+import { detectBlockingPage } from '../../src/utils/page-diagnostics';
+import type { Page } from 'puppeteer-core';
+
+/**
+ * Creates a mock Page where page.evaluate(fn) runs fn() with a mocked document global.
+ * This lets us test the actual detection logic rather than mock the return value.
+ */
+function createTestPage(
+  title: string,
+  bodyText: string,
+  elementCount: number,
+  selectorResults: Record<string, boolean> = {},
+): Page {
+  return {
+    evaluate: jest.fn().mockImplementation(async (fn: (...args: any[]) => any) => {
+      const mockDocument = {
+        title,
+        body: { innerText: bodyText },
+        querySelectorAll: (sel: string) => {
+          if (sel === '*') return { length: elementCount };
+          return { length: 0 };
+        },
+        querySelector: (sel: string) => (selectorResults[sel] ? {} : null),
+        readyState: 'complete',
+      };
+
+      const origDocument = (globalThis as any).document;
+      const origLocation = (globalThis as any).location;
+
+      Object.defineProperty(globalThis, 'document', {
+        value: mockDocument,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(globalThis, 'location', {
+        value: { href: 'https://example.com' },
+        writable: true,
+        configurable: true,
+      });
+
+      try {
+        return fn();
+      } finally {
+        if (origDocument !== undefined) {
+          Object.defineProperty(globalThis, 'document', {
+            value: origDocument,
+            writable: true,
+            configurable: true,
+          });
+        }
+        if (origLocation !== undefined) {
+          Object.defineProperty(globalThis, 'location', {
+            value: origLocation,
+            writable: true,
+            configurable: true,
+          });
+        }
+      }
+    }),
+  } as unknown as Page;
+}
+
+describe('detectBlockingPage - structural heuristics', () => {
+  describe('Reddit-style block — sparse page + "blocked by network security"', () => {
+    it('returns access-denied for "You have been blocked by network security"', async () => {
+      const page = createTestPage(
+        'Access Restricted',
+        'you have been blocked by network security. please contact your administrator.',
+        42,
+      );
+      const result = await detectBlockingPage(page);
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('access-denied');
+    });
+
+    it('returns access-denied for "blocked by" on a sparse page', async () => {
+      const page = createTestPage(
+        'Blocked',
+        'your request has been blocked by our security system.',
+        30,
+      );
+      const result = await detectBlockingPage(page);
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('access-denied');
+    });
+  });
+
+  describe('Rate limit / too many requests', () => {
+    it('returns access-denied for "rate limit exceeded" on sparse page', async () => {
+      const page = createTestPage(
+        'Rate Limited',
+        'rate limit exceeded. please slow down your requests.',
+        20,
+      );
+      const result = await detectBlockingPage(page);
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('access-denied');
+    });
+
+    it('returns access-denied for "too many requests" on sparse page', async () => {
+      const page = createTestPage(
+        '429',
+        'too many requests. try again later.',
+        15,
+      );
+      const result = await detectBlockingPage(page);
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('access-denied');
+    });
+  });
+
+  describe('Suspicious activity / unusual traffic', () => {
+    it('returns access-denied for "suspicious activity detected" on sparse page', async () => {
+      const page = createTestPage(
+        'Security Warning',
+        'suspicious activity detected from your ip address.',
+        25,
+      );
+      const result = await detectBlockingPage(page);
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('access-denied');
+    });
+
+    it('returns access-denied for "unusual traffic" on sparse page', async () => {
+      const page = createTestPage(
+        'Blocked',
+        'unusual traffic detected. your access has been temporarily restricted.',
+        18,
+      );
+      const result = await detectBlockingPage(page);
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('access-denied');
+    });
+  });
+
+  describe('False positive prevention — normal page', () => {
+    it('returns null for a dense page (500+ elements) that mentions "blocked by"', async () => {
+      const page = createTestPage(
+        'Tech Blog',
+        'this article discusses how websites get blocked by firewalls and what you can do about it.',
+        600,
+      );
+      const result = await detectBlockingPage(page);
+      expect(result).toBeNull();
+    });
+
+    it('returns null for a page with many elements even with short body text', async () => {
+      const page = createTestPage(
+        'Dashboard',
+        'network security settings updated.',
+        150,
+      );
+      const result = await detectBlockingPage(page);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('Sparse page with no blocking keywords', () => {
+    it('returns null for a sparse page with generic content', async () => {
+      const page = createTestPage(
+        'Loading...',
+        'please wait while we load your content.',
+        10,
+      );
+      const result = await detectBlockingPage(page);
+      expect(result).toBeNull();
+    });
+
+    it('returns null for a sparse page with empty body', async () => {
+      const page = createTestPage('', '', 5);
+      const result = await detectBlockingPage(page);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('Regression — existing patterns still work', () => {
+    it('detects captcha via bodyText keyword', async () => {
+      const page = createTestPage(
+        'Verification',
+        'please complete the captcha to continue.',
+        200,
+      );
+      const result = await detectBlockingPage(page);
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('captcha');
+    });
+
+    it('detects captcha via cloudflare iframe selector', async () => {
+      const page = createTestPage(
+        'Cloudflare',
+        'just a moment...',
+        80,
+        { 'iframe[src*="captcha"], iframe[src*="recaptcha"], iframe[src*="challenges.cloudflare.com"], .g-recaptcha, .h-captcha, .cf-turnstile': true },
+      );
+      const result = await detectBlockingPage(page);
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('captcha');
+    });
+
+    it('detects bot-check for "verify you are human"', async () => {
+      const page = createTestPage(
+        'Security Check',
+        'please verify you are human to continue.',
+        300,
+      );
+      const result = await detectBlockingPage(page);
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('bot-check');
+    });
+
+    it('detects access-denied via title', async () => {
+      const page = createTestPage(
+        'Access Denied',
+        'you do not have permission to access this resource.',
+        400,
+      );
+      const result = await detectBlockingPage(page);
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('access-denied');
+    });
+
+    it('detects js-required', async () => {
+      const page = createTestPage(
+        'JavaScript Required',
+        'please enable javascript to view this page.',
+        50,
+      );
+      const result = await detectBlockingPage(page);
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('js-required');
+    });
+
+    it('returns null for a normal page', async () => {
+      const page = createTestPage(
+        'Home | Example',
+        'welcome to example.com. browse our products and services.',
+        800,
+      );
+      const result = await detectBlockingPage(page);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('detail field', () => {
+    it('uses document.title as detail when title is available', async () => {
+      const page = createTestPage(
+        'Network Security Block',
+        'you have been blocked by network security.',
+        30,
+      );
+      const result = await detectBlockingPage(page);
+      expect(result?.detail).toBe('Network Security Block');
+    });
+
+    it('uses bodyText substring as detail when title is empty', async () => {
+      const page = createTestPage(
+        '',
+        'you have been blocked by network security policy.',
+        30,
+      );
+      const result = await detectBlockingPage(page);
+      expect(result?.detail).toBeTruthy();
+      expect(result?.detail.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add a **structural heuristic** layer to `detectBlockingPage()` that catches novel CDN/WAF block patterns without site-specific text matching
- Detects blocks based on **page structure** (sparse elements < 100 + short body < 800 chars) combined with **blocking vocabulary** (15 keywords)
- Fixes detection of Reddit's "blocked by network security" and similar novel block patterns
- Extends `NON_PROGRESS_SIGNALS` with new blocking vocabulary

## Design

The key insight is that **blocking pages are structurally simple** — they have few elements, short content, and contain blocking-related keywords. Normal web pages have hundreds/thousands of elements and rich content. The combination of structural sparsity + blocking vocabulary is the generalizable signal, avoiding both false positives on real pages and the need for site-specific patterns.

**Detection tiers:**
1. Existing exact patterns (captcha, bot-check, access-denied, js-required) — high confidence, unchanged
2. **New**: Structural heuristic (sparse page + blocking keywords) — catches novel patterns

## Files Changed

| File | Change |
|---|---|
| `src/utils/page-diagnostics.ts` | Added heuristic detection layer after existing patterns |
| `src/hints/progress-tracker.ts` | Added `blocked by`, `network security`, `been blocked` to NON_PROGRESS_SIGNALS |
| `tests/utils/page-diagnostics.test.ts` | 18 new tests: heuristic detection, false positive prevention, regression |

## Test plan

- [x] Reddit-style "blocked by network security" detected as `access-denied`
- [x] Rate limit / too many requests detected
- [x] Suspicious activity / unusual traffic detected
- [x] Normal page (500+ elements) mentioning "blocked" does NOT trigger (no false positive)
- [x] Sparse page with no blocking keywords returns null
- [x] All existing detection patterns unchanged (regression tests)
- [x] `npm run build` passes
- [x] `npm test` passes (2427 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)