### PR TITLE
fix: auto-escalate to headed Chrome when explicit stealth is blocked (#453)

### DIFF
--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -404,6 +404,13 @@ const handler: ToolHandler = async (
         return stealthAutoRetry(sessionId, targetUrl, workerId, stealthSettleMs, profileDirectory, newTabBlocking, targetId, autoFallback, context);
       }
 
+      // When explicit stealth hits a block, escalate directly to tier 3 (headed Chrome)
+      // since tier 2 (stealth) is already being used. (#453)
+      if (newTabBlocking && stealth && autoFallback && RETRYABLE_BLOCK_TYPES.has(newTabBlocking.type)) {
+        const headedResult = await headedAutoRetry(targetUrl, newTabBlocking);
+        if (headedResult) return headedResult;
+      }
+
       const newTabResultText = JSON.stringify({
         action: 'navigate',
         url: page.url(),

--- a/tests/tools/navigate-auto-fallback.test.ts
+++ b/tests/tools/navigate-auto-fallback.test.ts
@@ -65,7 +65,7 @@ describe('NavigateTool - Auto-fallback (#459)', () => {
   let mockSessionManager: ReturnType<typeof createMockSessionManager>;
   let testSessionId: string;
 
-  const getNavigateHandler = async () => {
+  const getNavigateHandler = async (opts?: { headedAvailable?: boolean; headedResult?: any }) => {
     jest.resetModules();
     jest.doMock('../../src/session-manager', () => ({
       getSessionManager: () => mockSessionManager,
@@ -85,8 +85,13 @@ describe('NavigateTool - Auto-fallback (#459)', () => {
     }));
     jest.doMock('../../src/chrome/headed-fallback', () => ({
       getHeadedFallback: () => ({
-        isAvailable: () => false,
-        navigate: jest.fn(),
+        isAvailable: () => opts?.headedAvailable ?? false,
+        navigate: jest.fn().mockResolvedValue(opts?.headedResult ?? {
+          url: 'https://www.coupang.com/',
+          title: 'Coupang',
+          elementCount: 977,
+          blockingPage: null,
+        }),
       }),
     }));
     jest.doMock('../../src/config/global', () => ({
@@ -198,7 +203,8 @@ describe('NavigateTool - Auto-fallback (#459)', () => {
       expect((mockSessionManager as any).createTargetStealth).not.toHaveBeenCalled();
     });
 
-    test('does NOT retry when stealth was already explicitly used', async () => {
+    test('does NOT retry stealth-to-stealth when stealth was already explicitly used', async () => {
+      // Headed is unavailable (default) — escalation returns null, falls through to blocked result
       const handler = await getNavigateHandler();
 
       mockDetectBlockingPage
@@ -207,7 +213,8 @@ describe('NavigateTool - Auto-fallback (#459)', () => {
       const result = await handler(testSessionId, { url: 'https://www.coupang.com', stealth: true });
       const parsed = parseResultJSON<NavResult>(result as MCPResult);
 
-      // Stealth was already used — should NOT trigger auto-fallback
+      // Stealth was already used — stealth-to-stealth should NOT be triggered.
+      // Headed is not available, so escalation returns null and the blocked result is returned.
       expect(parsed.stealth).toBe(true);
       expect(parsed.blockingPage).toBeDefined();
       expect(parsed.fallbackTier).toBeUndefined();
@@ -333,6 +340,81 @@ describe('NavigateTool - Auto-fallback (#459)', () => {
       expect(parsed.blockingPage).toBeDefined();
       expect(parsed.fallbackTier).toBeUndefined();
       expect((mockSessionManager as any).createTargetStealth).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('explicit stealth → headed escalation (#453)', () => {
+    test('escalates to headed when explicit stealth hits access-denied block', async () => {
+      const handler = await getNavigateHandler({ headedAvailable: true });
+
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'access-denied', detail: 'Access Denied' });
+
+      const result = await handler(testSessionId, { url: 'https://www.coupang.com', stealth: true });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed.headed).toBe(true);
+      expect(parsed.fallbackTier).toBe(3);
+      expect(parsed.fallbackReason).toBe('access-denied');
+    });
+
+    test('escalates to headed when explicit stealth hits bot-check block', async () => {
+      const handler = await getNavigateHandler({ headedAvailable: true });
+
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'bot-check', detail: 'Security Check' });
+
+      const result = await handler(testSessionId, { url: 'https://www.example.com', stealth: true });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed.headed).toBe(true);
+      expect(parsed.fallbackTier).toBe(3);
+      expect(parsed.fallbackReason).toBe('bot-check');
+    });
+
+    test('does NOT escalate to headed when autoFallback is false', async () => {
+      const handler = await getNavigateHandler({ headedAvailable: true });
+
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'access-denied', detail: 'Access Denied' });
+
+      const result = await handler(testSessionId, { url: 'https://www.coupang.com', stealth: true, autoFallback: false });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed.blockingPage).toBeDefined();
+      expect(parsed.fallbackTier).toBeUndefined();
+      expect(parsed.headed).toBeUndefined();
+    });
+
+    test('returns stealth blocked result when headed is not available', async () => {
+      // headedAvailable defaults to false
+      const handler = await getNavigateHandler();
+
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'access-denied', detail: 'Access Denied' });
+
+      const result = await handler(testSessionId, { url: 'https://www.coupang.com', stealth: true });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed.stealth).toBe(true);
+      expect(parsed.blockingPage).toBeDefined();
+      expect(parsed.fallbackTier).toBeUndefined();
+      expect(parsed.headed).toBeUndefined();
+    });
+
+    test('does NOT escalate for js-required block type', async () => {
+      const handler = await getNavigateHandler({ headedAvailable: true });
+
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'js-required', detail: 'Page requires JavaScript' });
+
+      const result = await handler(testSessionId, { url: 'https://www.example.com', stealth: true });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed.blockingPage).toBeDefined();
+      expect(parsed.blockingPage.type).toBe('js-required');
+      expect(parsed.fallbackTier).toBeUndefined();
+      expect(parsed.headed).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

- When `stealth: true` is explicitly passed and the page hits a CDN/WAF block, **auto-escalate directly to tier 3 (headed Chrome)** since tier 2 (stealth) is already in use
- Previously, explicit stealth blocks had no fallback path — the blocked result was returned without attempting headed Chrome
- This completes the fallback chain: `stealth (blocked) → headed Chrome (bypasses TLS-level detection)`

## Problem

```
navigate(url: "https://www.coupang.com", stealth: true)
→ "Access Denied" (no escalation to headed Chrome)

navigate(url: "https://www.coupang.com")  // autoFallback default
→ normal (blocked) → stealth (blocked) → headed (success) ✓
```

The `!stealth` guard on line 403 prevented any fallback when stealth was explicitly requested, even though headed Chrome was available and would have succeeded.

## Fix

Added a 7-line escalation block after the existing auto-retry check in `navigate.ts`:

```typescript
// When explicit stealth hits a block, escalate directly to tier 3 (headed Chrome)
if (newTabBlocking && stealth && autoFallback && RETRYABLE_BLOCK_TYPES.has(newTabBlocking.type)) {
  const headedResult = await headedAutoRetry(targetUrl, newTabBlocking);
  if (headedResult) return headedResult;
}
```

## Files Changed

| File | Change |
|---|---|
| `src/tools/navigate.ts` | Added tier 3 escalation for explicit stealth blocks |
| `tests/tools/navigate-auto-fallback.test.ts` | 5 new tests + updated `getNavigateHandler` to support configurable headed availability |

## Test plan

- [x] Explicit stealth + access-denied → escalates to headed (tier 3)
- [x] Explicit stealth + bot-check → escalates to headed (tier 3)
- [x] Explicit stealth + autoFallback: false → no escalation
- [x] Explicit stealth + headed unavailable → returns blocked result (graceful)
- [x] Explicit stealth + js-required → no escalation (not retryable)
- [x] All existing auto-fallback tests pass (no regression)
- [x] `npm run build` passes
- [x] `npm test` passes (2414 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)