### PR TITLE
fix: escalate to Tier 3 when stealth retry produces empty/broken page (#459)

### DIFF
--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -102,9 +102,13 @@ async function stealthAutoRetry(
     ...(summary && { visualSummary: summary }),
     ...(blocking && { blockingPage: blocking }),
   });
-  // Tier 3: if stealth retry also got blocked and headed Chrome is available, escalate (#459)
-  if (blocking && autoFallbackToHeaded && RETRYABLE_BLOCK_TYPES.has(blocking.type)) {
-    const headedResult = await headedAutoRetry(targetUrl, blocking);
+  // Tier 3: escalate to headed Chrome if stealth retry also got blocked
+  // OR if stealth produced an empty/broken page (can't detect blocking in broken pages).
+  // This is safe because we only reach here after Tier 1 already detected a block. (#459)
+  const stealthBlocked = blocking && RETRYABLE_BLOCK_TYPES.has(blocking.type);
+  const stealthBroken = elementCount === 0 || readiness.readyState === 'unknown';
+  if (autoFallbackToHeaded && (stealthBlocked || stealthBroken)) {
+    const headedResult = await headedAutoRetry(targetUrl, blocking || blockingInfo);
     if (headedResult) return headedResult;
   }
 

--- a/tests/tools/navigate-headed-fallback.test.ts
+++ b/tests/tools/navigate-headed-fallback.test.ts
@@ -208,6 +208,77 @@ describe('NavigateTool - Headed Chrome Fallback (#459)', () => {
       expect(mockHeadedNavigate).not.toHaveBeenCalled();
     });
 
+    test('escalates to Tier 3 when stealth produces empty page (elementCount=0)', async () => {
+      const handler = await getNavigateHandler();
+
+      // Normal tab blocked; stealth page has elementCount=0 (evaluate throws) and no JS blocking detected
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'access-denied', detail: 'Akamai CDN' })  // Tier 1
+        .mockResolvedValueOnce(null);  // Tier 2: blocking detection returns null (can't run JS)
+
+      // Make the stealth page's evaluate throw so elementCount=0 and readyState='unknown'
+      (mockSessionManager as any).createTargetStealth = jest.fn().mockImplementation(
+        async (sessionId: string, url: string, workerId?: string) => {
+          const resolvedWorkerId = workerId || 'default';
+          const targetId = `stealth-broken-${Date.now()}`;
+          const page = createMockPage({ url, targetId, title: '' });
+          (page.evaluate as jest.Mock).mockRejectedValue(new Error('Target closed'));
+          return { targetId, page, workerId: resolvedWorkerId };
+        },
+      );
+
+      const result = await handler(testSessionId, { url: 'https://www.coupang.com' });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed.headed).toBe(true);
+      expect(parsed.fallbackTier).toBe(3);
+      expect(parsed.fallbackReason).toBe('access-denied');
+      expect(mockHeadedNavigate).toHaveBeenCalledWith('https://www.coupang.com');
+    });
+
+    test('escalates to Tier 3 when stealth produces broken page (readyState=unknown)', async () => {
+      const handler = await getNavigateHandler();
+
+      // Normal tab blocked; stealth page's readyState evaluation throws → 'unknown'
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'bot-check', detail: 'Security Check' })  // Tier 1
+        .mockResolvedValueOnce(null);  // Tier 2: can't detect blocking
+
+      (mockSessionManager as any).createTargetStealth = jest.fn().mockImplementation(
+        async (sessionId: string, url: string, workerId?: string) => {
+          const resolvedWorkerId = workerId || 'default';
+          const targetId = `stealth-broken-${Date.now()}`;
+          const page = createMockPage({ url, targetId, title: '' });
+          // evaluate throws so readyState becomes 'unknown' and elementCount stays 0
+          (page.evaluate as jest.Mock).mockRejectedValue(new Error('Execution context destroyed'));
+          return { targetId, page, workerId: resolvedWorkerId };
+        },
+      );
+
+      const result = await handler(testSessionId, { url: 'https://www.coupang.com' });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed.headed).toBe(true);
+      expect(parsed.fallbackTier).toBe(3);
+      expect(parsed.fallbackReason).toBe('bot-check');
+      expect(mockHeadedNavigate).toHaveBeenCalledWith('https://www.coupang.com');
+    });
+
+    test('does NOT escalate to Tier 3 when autoFallback is false and stealth page is empty', async () => {
+      const handler = await getNavigateHandler();
+
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'access-denied', detail: 'Akamai CDN' });
+
+      // autoFallback: false means Tier 2 never happens, so no stealth retry at all
+      const result = await handler(testSessionId, { url: 'https://www.coupang.com', autoFallback: false });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed.fallbackTier).toBeUndefined();
+      expect(parsed.headed).toBeUndefined();
+      expect(mockHeadedNavigate).not.toHaveBeenCalled();
+    });
+
     test('Tier 3 returns blockingPage if headed Chrome also gets blocked', async () => {
       const handler = await getNavigateHandler();
 


### PR DESCRIPTION
## Summary

- **Problem**: When stealth retry (Tier 2) returns a completely broken page (`elementCount=0` or `readyState="unknown"`), `detectBlockingPage()` returns `null` because it cannot evaluate JavaScript on the broken page. The existing Tier 3 condition only checked for explicit blocking detection (`blocking != null`), so headed Chrome escalation never triggered for these broken pages.
- **Fix**: Added a `stealthBroken` heuristic — if the stealth page has `elementCount === 0` OR `readiness.readyState === 'unknown'`, treat it as a blocking signal and escalate to Tier 3. Falls back to the original Tier 1 `blockingInfo` for the `fallbackReason` when stealth blocking detection failed.
- **Why this is safe**: `stealthAutoRetry()` is only called after Tier 1 already detected a real block (access-denied, bot-check, captcha). We are never guessing — a broken/empty stealth page on top of a known Tier 1 block is a reliable signal that the site is still blocking.

## What changed

**`src/tools/navigate.ts`** — `stealthAutoRetry()` function, Tier 3 escalation block:

```typescript
// Before:
if (blocking && autoFallbackToHeaded && RETRYABLE_BLOCK_TYPES.has(blocking.type)) {
  const headedResult = await headedAutoRetry(targetUrl, blocking);
  if (headedResult) return headedResult;
}

// After:
const stealthBlocked = blocking && RETRYABLE_BLOCK_TYPES.has(blocking.type);
const stealthBroken = elementCount === 0 || readiness.readyState === 'unknown';
if (autoFallbackToHeaded && (stealthBlocked || stealthBroken)) {
  const headedResult = await headedAutoRetry(targetUrl, blocking || blockingInfo);
  if (headedResult) return headedResult;
}
```

**`tests/tools/navigate-headed-fallback.test.ts`** — 3 new tests added:
- `escalates to Tier 3 when stealth produces empty page (elementCount=0)`
- `escalates to Tier 3 when stealth produces broken page (readyState=unknown)`
- `does NOT escalate to Tier 3 when autoFallback is false and stealth page is empty`

## Test plan

- [x] New tests pass: all 3 scenarios for broken/empty stealth page escalation
- [x] Existing Tier 3 tests still pass (no regression)
- [x] Full test suite: 2412 tests across 126 suites — all passing
- [x] Build clean: `tsc` with zero errors

Closes #459