### PR TITLE
fix: ensure numeric type coercion for batch_paginate args

### DIFF
--- a/src/tools/batch-paginate.ts
+++ b/src/tools/batch-paginate.ts
@@ -110,15 +110,15 @@ const handler: ToolHandler = async (
 ): Promise<MCPResult> => {
   const tabId = args.tabId as string;
   const strategy = args.strategy as string;
-  const totalPages = args.totalPages as number | undefined;
-  const startPage = (args.startPage as number) || 1;
+  const totalPages = args.totalPages != null ? Number(args.totalPages) : undefined;
+  const startPage = Number(args.startPage) || 1;
   const captureMode = (args.captureMode as string) || 'text';
   const keyAction = (args.keyAction as string) || 'ArrowRight';
   const nextSelector = args.nextSelector as string | undefined;
   const urlTemplate = args.urlTemplate as string | undefined;
-  const waitBetweenPages = (args.waitBetweenPages as number) ?? 500;
-  const scrollAmount = (args.scrollAmount as number) || 1;
-  const maxScrolls = (args.maxScrolls as number) || 50;
+  const waitBetweenPages = args.waitBetweenPages != null ? Number(args.waitBetweenPages) : 500;
+  const scrollAmount = Number(args.scrollAmount) || 1;
+  const maxScrolls = Number(args.maxScrolls) || 50;
 
   if (!tabId) {
     return {


### PR DESCRIPTION
## Summary

- Fix numeric type coercion bug in `batch_paginate` tool where MCP args arriving as strings from JSON caused string concatenation instead of arithmetic (e.g. `"49" + 0 = "490"` instead of `49`)
- Replace TypeScript `as number` casts with explicit `Number()` conversion for all numeric parameters: `totalPages`, `startPage`, `waitBetweenPages`, `scrollAmount`, `maxScrolls`
- String parameters (`captureMode`, `keyAction`, `nextSelector`, `urlTemplate`) are unchanged

## Details

TypeScript's `as number` is a compile-time type assertion that performs no runtime conversion. When MCP tool arguments arrive as strings from JSON parsing, the cast silently passes through the string value, causing arithmetic operators like `+` to concatenate instead of add.

The fix uses `Number()` for explicit runtime conversion. For optional parameters with defaults (`waitBetweenPages`), a `!= null` guard ensures `undefined`/`null` falls through to the default value while still converting string inputs.

## Test plan

- [x] `npm run build` passes with no TypeScript errors
- [x] All 2409 tests pass across 126 test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)