### PR TITLE
fix: use withDomDelta for navigation-safe clicks in batch_paginate

### DIFF
--- a/src/tools/batch-paginate.ts
+++ b/src/tools/batch-paginate.ts
@@ -11,6 +11,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
 import { DEFAULT_SCREENSHOT_QUALITY, DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS, DEFAULT_SCREENSHOT_TIMEOUT_MS, MAX_OUTPUT_CHARS } from '../config/defaults';
+import { withDomDelta } from '../utils/dom-delta';
 import { withTimeout } from '../utils/with-timeout';
 
 const definition: MCPToolDefinition = {
@@ -311,8 +312,9 @@ const handler: ToolHandler = async (
               });
               break;
             }
-            await nextButton.click();
-            await new Promise((r) => setTimeout(r, waitBetweenPages));
+            await withDomDelta(page, async () => {
+              await nextButton.click();
+            }, { settleMs: Math.max(150, waitBetweenPages) });
           } catch (err) {
             pages.push({
               pageNumber: i + 1,


### PR DESCRIPTION
## Summary
- Replace bare `nextButton.click()` in the click strategy with `withDomDelta()` wrapper to handle full-page navigation safely
- The bare click hung with CDP protocol timeout when navigation destroyed the execution context
- Uses the same navigation-safe pattern already established in `interact.ts` and `click-element.ts`

## Test plan
- [x] `npm run build` passes with no errors
- [x] `npm test` passes (2405/2409 pass; 4 failures are pre-existing flaky timing tests in `event-loop-monitor.test.ts`, confirmed passing in isolation)
- [ ] Manual: use `batch_paginate` with click strategy on a site where "next" triggers full-page navigation (e.g., classic server-rendered pagination)

🤖 Generated with [Claude Code](https://claude.com/claude-code)