### PR TITLE
fix: guard createCDPSession in pool cleanup to prevent page leak (#487)

### DIFF
--- a/src/cdp/connection-pool.ts
+++ b/src/cdp/connection-pool.ts
@@ -315,8 +315,17 @@ export class CDPConnectionPool {
       return;
     }
 
-    // Clear cookies and storage via CDP session (with proper cleanup in finally)
-    const client = await page.createCDPSession();
+    // Clear cookies and storage via CDP session.
+    // If createCDPSession() fails (page destroyed, Chrome under pressure),
+    // the page is unusable — close it to prevent an orphan leak.
+    let client;
+    try {
+      client = await page.createCDPSession();
+    } catch (err) {
+      console.error(`[ConnectionPool] createCDPSession failed during cleanup, discarding page: ${err instanceof Error ? err.message : String(err)}`);
+      await page.close().catch(() => {});
+      return;
+    }
     try {
       await client.send('Network.clearBrowserCookies');
 


### PR DESCRIPTION
## Summary

- Guard the unprotected `page.createCDPSession()` call in `cleanAndReturnToPool()` with try/catch
- On failure, close the page and return early to prevent orphan page leaks
- Matches the existing defensive pattern used for `goto('about:blank')` just above

## Context

Issue #308 fixed a page leak where `goto('about:blank')` failure orphaned pages. However, `createCDPSession()` at line 319 had the same vulnerability — if it throws (page destroyed, Chrome under memory pressure), the page is already removed from `inUsePages` but never closed or returned to `availablePages`.

While the outer `.catch()` in `releasePage` provides a safety net, the explicit try/catch is more robust and consistent with the #308 fix pattern.

Closes #487

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Existing connection pool tests pass
- [ ] No changes to pool behavior in normal operation (only affects error path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)