### PR TITLE
feat: add desktop app release CI/CD pipeline

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -44,6 +44,8 @@ jobs:
   build:
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     timeout-minutes: 60
 
     strategy:
@@ -147,12 +149,14 @@ jobs:
           bun build src/index.ts \
             --compile \
             --target=${{ matrix.bun_target }} \
-            --outfile desktop/src-tauri/binaries/openchrome-server-${{ matrix.target }}
+            --outfile desktop/src-tauri/binaries/openchrome-sidecar-${{ matrix.target }}
 
-          # Windows: Bun appends .exe automatically; ensure consistent naming.
+          # Windows: Bun may or may not append .exe; ensure .exe suffix exists.
           if [[ "${{ runner.os }}" == "Windows" ]]; then
-            mv desktop/src-tauri/binaries/openchrome-server-${{ matrix.target }}.exe \
-               desktop/src-tauri/binaries/openchrome-server-${{ matrix.target }}.exe || true
+            if [[ ! -f "desktop/src-tauri/binaries/openchrome-sidecar-${{ matrix.target }}.exe" ]]; then
+              mv "desktop/src-tauri/binaries/openchrome-sidecar-${{ matrix.target }}" \
+                 "desktop/src-tauri/binaries/openchrome-sidecar-${{ matrix.target }}.exe"
+            fi
           fi
 
           echo "Sidecar binary:"
@@ -216,23 +220,6 @@ jobs:
           rm -f /tmp/certificate.p12
 
       # -----------------------------------------------------------------------
-      # Windows: import signing certificate
-      # -----------------------------------------------------------------------
-      - name: Import Windows signing certificate
-        if: runner.os == 'Windows'
-        env:
-          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
-          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
-        shell: pwsh
-        run: |
-          $certBytes = [System.Convert]::FromBase64String($env:WINDOWS_CERTIFICATE)
-          $certPath = Join-Path $env:TEMP "certificate.pfx"
-          [System.IO.File]::WriteAllBytes($certPath, $certBytes)
-          Write-Host "Certificate written to $certPath"
-          # The path is consumed by signtool inside tauri-action via WINDOWS_SIGN_COMMAND.
-          echo "WINDOWS_CERTIFICATE_PATH=$certPath" >> $env:GITHUB_ENV
-
-      # -----------------------------------------------------------------------
       # Build the Tauri application (handles Rust compilation, bundling,
       # signing, and notarization for each platform).
       # -----------------------------------------------------------------------
@@ -247,15 +234,9 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          # Windows signing — signtool is invoked by the action if this is set.
-          WINDOWS_SIGN_COMMAND: >-
-            signtool sign
-            /f "${{ env.WINDOWS_CERTIFICATE_PATH }}"
-            /p "${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}"
-            /tr http://timestamp.digicert.com
-            /td sha256
-            /fd sha256
-            __INPUT__
+          # Windows signing — tauri-action handles signtool natively via these env vars.
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
         with:
           projectPath: desktop
           # Do not create a GitHub release here; the publish job does that


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/desktop-release.yml` — a multi-platform GitHub Actions workflow that builds, signs, and publishes the OpenChrome desktop app (Tauri) on every `desktop-v*` tag push
- Implements the CI/CD portion of issue #525 (desktop app release pipeline)
- Separate from the CLI release track with its own `desktop-v{major}.{minor}.{patch}` tag convention

## What the workflow does

**`build` job** (4 parallel runners):
- macOS arm64 (`macos-latest`) — Apple Silicon
- macOS x64 (`macos-13`) — Intel
- Windows x64 (`windows-latest`)
- Linux x64 (`ubuntu-22.04`) — AppImage, no signing

Each runner:
1. Compiles the openchrome MCP server into a self-contained sidecar binary using `bun build --compile` targeting the correct platform triple
2. Downloads the platform-specific `cloudflared` binary from Cloudflare releases
3. Builds the Tauri app via `tauri-apps/tauri-action` (handles Rust compilation, frontend bundling, packaging)
4. Applies code signing — macOS (Apple Developer certificate + notarization), Windows (Authenticode via signtool), Linux (unsigned)
5. Uploads `.dmg`, `.exe`/`.msi`, and `.AppImage` artifacts

**`publish` job** (runs after all builds succeed):
1. Generates a CHANGELOG from commits since the previous `desktop-v*` tag
2. Downloads all platform artifacts
3. Generates `latest.json` — the Tauri auto-updater manifest with per-platform URLs and Ed25519 signatures
4. Creates a GitHub Release with all artifacts and `latest.json` attached
5. Prints a summary to the Actions run page

## Required secrets

| Secret | Purpose |
|--------|---------|
| `APPLE_CERTIFICATE` | Base64-encoded .p12 signing cert |
| `APPLE_CERTIFICATE_PASSWORD` | .p12 password |
| `APPLE_SIGNING_IDENTITY` | e.g. `Developer ID Application: ...` |
| `APPLE_ID` | Apple ID for notarization |
| `APPLE_PASSWORD` | App-specific password for notarization |
| `APPLE_TEAM_ID` | Apple Developer Team ID |
| `WINDOWS_CERTIFICATE` | Base64-encoded .pfx signing cert |
| `WINDOWS_CERTIFICATE_PASSWORD` | .pfx password |

## Test plan

- [ ] Push a `desktop-v0.0.1-rc.1` tag to validate the full pipeline in a dry-run once the Tauri app skeleton (`desktop/`) exists
- [ ] Verify `latest.json` is attached to the release and parseable by the Tauri updater
- [ ] Confirm macOS `.dmg` is notarized (no Gatekeeper warning on download)
- [ ] Confirm Windows `.exe` is Authenticode-signed (no SmartScreen warning)
- [ ] Confirm Linux `.AppImage` runs without a signing error

🤖 Generated with [Claude Code](https://claude.com/claude-code)