### PR TITLE
feat(desktop): CLI coexistence logic

### DIFF
--- a/src/desktop/cli-coexistence.ts
+++ b/src/desktop/cli-coexistence.ts
@@ -9,6 +9,12 @@
 import { EventEmitter } from 'events';
 import * as http from 'http';
 
+/**
+ * 'none'     — no server detected
+ * 'external' — external CLI-spawned server detected via health check
+ * 'built-in' — reserved for the parent application to set when it starts its own server;
+ *              CLICoexistence never sets this value itself.
+ */
 export type ServerSource = 'none' | 'external' | 'built-in';
 
 export interface CoexistenceOptions {
@@ -154,7 +160,6 @@ export class CLICoexistence extends EventEmitter {
 
   private async _monitorTick(): Promise<void> {
     const prevSource = this.source;
-    const prevHealthy = this.healthy;
 
     const healthy = await this._httpGet();
     this.lastHealthCheck = Date.now();
@@ -179,9 +184,6 @@ export class CLICoexistence extends EventEmitter {
       // Built-in server lost health — just update healthy flag, no source change
       this.healthy = false;
     }
-
-    // Suppress unused-variable warning — prevHealthy used as logical guard above
-    void prevHealthy;
   }
 
   /**

--- a/tests/desktop/cli-coexistence.test.ts
+++ b/tests/desktop/cli-coexistence.test.ts
@@ -1,6 +1,7 @@
 /// <reference types="jest" />
 
 import * as http from 'http';
+import * as net from 'net';
 import { AddressInfo } from 'net';
 import { CLICoexistence } from '../../src/desktop/cli-coexistence';
 
@@ -30,8 +31,20 @@ function createHealthServer(statusCode = 200): Promise<{ server: http.Server; po
   });
 }
 
-// Port that nothing is listening on (use a known-free ephemeral port approach)
-const UNUSED_PORT = 19999;
+// Get a guaranteed-free port by binding to 0 and immediately closing
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, '127.0.0.1', () => {
+      const port = (srv.address() as net.AddressInfo).port;
+      srv.close(() => resolve(port));
+    });
+    srv.on('error', reject);
+  });
+}
+
+// Will be set in beforeAll
+let UNUSED_PORT: number;
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -39,6 +52,10 @@ const UNUSED_PORT = 19999;
 
 describe('CLICoexistence', () => {
   let coexistence: CLICoexistence;
+
+  beforeAll(async () => {
+    UNUSED_PORT = await getFreePort();
+  });
 
   afterEach(() => {
     coexistence?.stopMonitoring();


### PR DESCRIPTION
## Summary

- Adds `src/desktop/cli-coexistence.ts`: `CLICoexistence` class (extends `EventEmitter`) that detects an existing CLI-spawned server on startup and monitors its health continuously
- Adds `tests/desktop/cli-coexistence.test.ts`: 16 tests covering all state transitions, timeout handling, ECONNREFUSED, and monitoring lifecycle

## Behaviour

**On app start** (`checkForExistingServer()`):
- `GET http://localhost:{port}/health` with configurable timeout
- Server found → source becomes `external`, emits `external-detected`
- No server → source stays `none`, emits `no-server`

**During monitoring** (`startMonitoring()`):
- `external` → unhealthy: emits `external-lost` with "External server stopped. Start built-in server?" message
- `none` → healthy: emits `external-detected`
- Every tick emits `health-check`; source transitions emit `status-changed`

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)