### PR TITLE
feat(desktop): Chrome profile picker + settings persistence

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -14,19 +14,22 @@
       </header>
 
       <div class="status-card">
-        <div class="status-indicator" id="status-indicator">
-          <div class="status-dot"></div>
+        <div class="profile-row">
+          <label for="profile-select">Chrome Profile</label>
+          <select id="profile-select" class="profile-select">
+            <option value="">Loading...</option>
+          </select>
+        </div>
+        <div class="status-row">
+          <div class="status-dot" id="status-dot"></div>
           <span class="status-text" id="status-text">Stopped</span>
         </div>
-        <div class="controls">
-          <button id="btn-toggle" class="btn btn-start" disabled>
-            Start Server
-          </button>
-        </div>
+        <button id="btn-toggle" class="btn btn-start">Start Server</button>
       </div>
 
-      <div class="health-info" id="health-info">
-        Ready to start. Connect from Claude, Cursor, or any MCP client.
+      <div class="metrics-card" id="metrics-card">
+        <span class="metric" id="metric-uptime">Uptime: --</span>
+        <span class="metric" id="metric-port">Port: 3100</span>
       </div>
     </div>
     <script type="module" src="/src/main.ts"></script>

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -18,3 +18,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", features = ["json"] }
 tokio = { version = "1", features = ["sync", "time"] }
+dirs = "5"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -18,7 +18,3 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", features = ["json"] }
 tokio = { version = "1", features = ["sync", "time"] }
-dirs = "5"
-reqwest = { version = "0.12", features = ["json"] }
-tokio = { version = "1", features = ["sync", "time"] }
-dirs = "5"

--- a/desktop/src-tauri/src/ipc.rs
+++ b/desktop/src-tauri/src/ipc.rs
@@ -2,17 +2,13 @@
 
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use crate::profiles;
 use crate::sidecar::{self, SidecarState, SidecarStatus};
 
 #[tauri::command]
 pub async fn start_server(
-    app: tauri::AppHandle,
-    state: tauri::State<'_, Arc<Mutex<SidecarState>>>,
-    port: Option<u16>,
+    app: tauri::AppHandle, state: tauri::State<'_, Arc<Mutex<SidecarState>>>, port: Option<u16>,
 ) -> Result<SidecarStatus, String> {
-    let port = port.unwrap_or(3100);
-    sidecar::spawn_sidecar(&app, &state, port).await
+    sidecar::spawn_sidecar(&app, &state, port.unwrap_or(3100)).await
 }
 
 #[tauri::command]
@@ -51,20 +47,10 @@ pub async fn get_health(
 
     match client.get(&url).send().await {
         Ok(resp) => {
-            let body = resp
-                .json::<serde_json::Value>()
-                .await
+            let body = resp.json::<serde_json::Value>().await
                 .unwrap_or(serde_json::json!({ "status": "ok" }));
             Ok(body)
         }
-        Err(e) => Ok(serde_json::json!({
-            "status": "error",
-            "error": format!("{}", e)
-        })),
+        Err(e) => Ok(serde_json::json!({ "status": "error", "error": format!("{}", e) })),
     }
-}
-
-#[tauri::command]
-pub fn get_chrome_profiles() -> Result<Vec<profiles::ChromeProfile>, String> {
-    Ok(profiles::detect_profiles())
 }

--- a/desktop/src-tauri/src/ipc.rs
+++ b/desktop/src-tauri/src/ipc.rs
@@ -2,13 +2,19 @@
 
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use crate::profiles;
+use crate::settings::{self, AppSettings};
 use crate::sidecar::{self, SidecarState, SidecarStatus};
 
 #[tauri::command]
 pub async fn start_server(
-    app: tauri::AppHandle, state: tauri::State<'_, Arc<Mutex<SidecarState>>>, port: Option<u16>,
+    app: tauri::AppHandle,
+    state: tauri::State<'_, Arc<Mutex<SidecarState>>>,
+    port: Option<u16>,
+    profile_directory: Option<String>,
 ) -> Result<SidecarStatus, String> {
-    sidecar::spawn_sidecar(&app, &state, port.unwrap_or(3100)).await
+    let port = port.unwrap_or(3100);
+    sidecar::spawn_sidecar(&app, &state, port, profile_directory).await
 }
 
 #[tauri::command]
@@ -47,10 +53,30 @@ pub async fn get_health(
 
     match client.get(&url).send().await {
         Ok(resp) => {
-            let body = resp.json::<serde_json::Value>().await
+            let body = resp
+                .json::<serde_json::Value>()
+                .await
                 .unwrap_or(serde_json::json!({ "status": "ok" }));
             Ok(body)
         }
-        Err(e) => Ok(serde_json::json!({ "status": "error", "error": format!("{}", e) })),
+        Err(e) => Ok(serde_json::json!({
+            "status": "error",
+            "error": format!("{}", e)
+        })),
     }
+}
+
+#[tauri::command]
+pub fn get_chrome_profiles() -> Result<Vec<profiles::ChromeProfile>, String> {
+    Ok(profiles::detect_profiles())
+}
+
+#[tauri::command]
+pub fn load_settings() -> Result<AppSettings, String> {
+    Ok(settings::load())
+}
+
+#[tauri::command]
+pub fn save_settings(settings_data: AppSettings) -> Result<(), String> {
+    settings::save(&settings_data)
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,8 @@
 // OpenChrome Desktop — Tauri application entry point
 
 mod ipc;
+mod profiles;
+mod settings;
 mod sidecar;
 
 use std::sync::Arc;
@@ -18,6 +20,9 @@ pub fn run() {
             ipc::stop_server,
             ipc::get_server_status,
             ipc::get_health,
+            ipc::get_chrome_profiles,
+            ipc::load_settings,
+            ipc::save_settings,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,7 +1,6 @@
 // OpenChrome Desktop — Tauri application entry point
 
 mod ipc;
-mod profiles;
 mod sidecar;
 
 use std::sync::Arc;
@@ -19,7 +18,6 @@ pub fn run() {
             ipc::stop_server,
             ipc::get_server_status,
             ipc::get_health,
-            ipc::get_chrome_profiles,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/profiles.rs
+++ b/desktop/src-tauri/src/profiles.rs
@@ -3,80 +3,55 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChromeProfile {
-    /// Internal directory name (e.g., "Default", "Profile 1")
     pub id: String,
-    /// Friendly name from Chrome preferences (e.g., "Personal", "Work")
     pub name: String,
 }
 
 /// Detect installed Chrome profiles with friendly names.
 pub fn detect_profiles() -> Vec<ChromeProfile> {
-    let base = chrome_user_data_dir();
-    let base = match base {
+    let base = match chrome_user_data_dir() {
         Some(p) if p.exists() => p,
         _ => return vec![],
     };
 
-    // Read Local State to find profile directories
     let local_state_path = base.join("Local State");
-    let profile_dirs = read_profile_dirs_from_local_state(&local_state_path)
+    let profile_dirs = read_profile_dirs(&local_state_path)
         .unwrap_or_else(|| vec!["Default".to_string()]);
 
-    let mut profiles = Vec::new();
-
-    for dir_name in profile_dirs {
-        let prefs_path = base.join(&dir_name).join("Preferences");
-        let friendly_name = read_profile_name(&prefs_path).unwrap_or_else(|| dir_name.clone());
-
-        profiles.push(ChromeProfile {
-            id: dir_name,
-            name: friendly_name,
-        });
-    }
-
-    profiles
+    profile_dirs
+        .into_iter()
+        .map(|dir_name| {
+            let prefs_path = base.join(&dir_name).join("Preferences");
+            let friendly = read_profile_name(&prefs_path).unwrap_or_else(|| dir_name.clone());
+            ChromeProfile { id: dir_name, name: friendly }
+        })
+        .collect()
 }
 
-/// Platform-specific Chrome user data directory
 fn chrome_user_data_dir() -> Option<PathBuf> {
-    let home = dirs::home_dir()?;
-
     #[cfg(target_os = "macos")]
     {
-        Some(home.join("Library/Application Support/Google/Chrome"))
+        dirs::home_dir().map(|h| h.join("Library/Application Support/Google/Chrome"))
     }
-
     #[cfg(target_os = "windows")]
     {
         dirs::data_local_dir().map(|d| d.join("Google").join("Chrome").join("User Data"))
     }
-
     #[cfg(target_os = "linux")]
     {
-        Some(home.join(".config/google-chrome"))
+        dirs::home_dir().map(|h| h.join(".config/google-chrome"))
     }
 }
 
-/// Parse Local State JSON to extract profile directory names
-fn read_profile_dirs_from_local_state(path: &PathBuf) -> Option<Vec<String>> {
+fn read_profile_dirs(path: &PathBuf) -> Option<Vec<String>> {
     let content = std::fs::read_to_string(path).ok()?;
     let json: serde_json::Value = serde_json::from_str(&content).ok()?;
-
-    let info_cache = json
-        .get("profile")?
-        .get("info_cache")?
-        .as_object()?;
-
-    Some(info_cache.keys().cloned().collect())
+    let cache = json.get("profile")?.get("info_cache")?.as_object()?;
+    Some(cache.keys().cloned().collect())
 }
 
-/// Read friendly profile name from Preferences file
-fn read_profile_name(prefs_path: &PathBuf) -> Option<String> {
-    let content = std::fs::read_to_string(prefs_path).ok()?;
+fn read_profile_name(path: &PathBuf) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
     let json: serde_json::Value = serde_json::from_str(&content).ok()?;
-
-    json.get("profile")?
-        .get("name")?
-        .as_str()
-        .map(|s| s.to_string())
+    json.get("profile")?.get("name")?.as_str().map(|s| s.to_string())
 }

--- a/desktop/src-tauri/src/settings.rs
+++ b/desktop/src-tauri/src/settings.rs
@@ -1,0 +1,67 @@
+//! Persistent application settings stored as human-readable JSON.
+//! Path: platform app-data directory / openchrome-desktop / config.json
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppSettings {
+    /// Selected Chrome profile directory name (e.g. "Default", "Profile 1")
+    #[serde(default)]
+    pub selected_profile: String,
+    /// Server port (default: 3100)
+    #[serde(default = "default_port")]
+    pub port: u16,
+    /// Auto-start server when app launches
+    #[serde(default)]
+    pub auto_start: bool,
+}
+
+fn default_port() -> u16 {
+    3100
+}
+
+impl Default for AppSettings {
+    fn default() -> Self {
+        Self {
+            selected_profile: String::new(),
+            port: 3100,
+            auto_start: false,
+        }
+    }
+}
+
+/// Platform-appropriate settings directory
+fn settings_dir() -> PathBuf {
+    let base = dirs::config_dir().unwrap_or_else(|| {
+        dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".config")
+    });
+    base.join("openchrome-desktop")
+}
+
+fn settings_path() -> PathBuf {
+    settings_dir().join("config.json")
+}
+
+/// Load settings from disk, returning defaults if file is missing or corrupt.
+pub fn load() -> AppSettings {
+    let path = settings_path();
+    match std::fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+        Err(_) => AppSettings::default(),
+    }
+}
+
+/// Save settings to disk. Creates the directory if needed.
+pub fn save(settings: &AppSettings) -> Result<(), String> {
+    let dir = settings_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create settings dir: {}", e))?;
+
+    let path = settings_path();
+    let json = serde_json::to_string_pretty(settings)
+        .map_err(|e| format!("Failed to serialize settings: {}", e))?;
+
+    std::fs::write(&path, json).map_err(|e| format!("Failed to write settings: {}", e))
+}

--- a/desktop/src-tauri/src/sidecar.rs
+++ b/desktop/src-tauri/src/sidecar.rs
@@ -9,9 +9,7 @@ use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tokio::sync::Mutex;
 use tokio::time::sleep;
 
-/// Maximum time to wait for the sidecar health check during startup.
 const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(15);
-/// Interval between health check polls.
 const HEALTH_CHECK_INTERVAL: Duration = Duration::from_millis(500);
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -30,69 +28,39 @@ pub struct SidecarState {
 
 impl SidecarState {
     pub fn new() -> Self {
-        Self {
-            child: None,
-            port: 3100,
-            started_at: None,
-        }
+        Self { child: None, port: 3100, started_at: None }
     }
 
-    pub fn port(&self) -> u16 {
-        self.port
-    }
+    pub fn port(&self) -> u16 { self.port }
 
-    pub fn is_running(&self) -> bool {
-        self.child.is_some()
-    }
+    pub fn is_running(&self) -> bool { self.child.is_some() }
 
     pub fn status_response(&self) -> SidecarStatus {
         let status = if self.child.is_some() { "running" } else { "stopped" };
         let uptime_secs = self.started_at.map(|t| t.elapsed().as_secs());
-        SidecarStatus {
-            status: status.to_string(),
-            port: self.port,
-            error: None,
-            uptime_secs,
-        }
+        SidecarStatus { status: status.to_string(), port: self.port, error: None, uptime_secs }
     }
 }
 
-/// Spawn the sidecar process and begin monitoring its output.
 pub async fn spawn_sidecar(
-    app: &AppHandle,
-    state: &Arc<Mutex<SidecarState>>,
-    port: u16,
+    app: &AppHandle, state: &Arc<Mutex<SidecarState>>, port: u16,
 ) -> Result<SidecarStatus, String> {
     let mut guard = state.lock().await;
-
-    // Already running — return current status
-    if guard.child.is_some() {
-        return Ok(guard.status_response());
-    }
-
+    if guard.child.is_some() { return Ok(guard.status_response()); }
     guard.port = port;
 
-    let sidecar_cmd = app
-        .shell()
+    let sidecar_cmd = app.shell()
         .sidecar("binaries/openchrome-sidecar")
         .map_err(|e| format!("Failed to create sidecar command: {}", e))?
-        .args([
-            "serve",
-            "--http",
-            &port.to_string(),
-            "--auto-launch",
-            "--server-mode",
-        ]);
+        .args(["serve", "--http", &port.to_string(), "--auto-launch", "--server-mode"]);
 
-    let (mut rx, child) = sidecar_cmd
-        .spawn()
+    let (mut rx, child) = sidecar_cmd.spawn()
         .map_err(|e| format!("Failed to spawn sidecar: {}", e))?;
 
     guard.child = Some(child);
     guard.started_at = Some(std::time::Instant::now());
 
     let app_handle = app.clone();
-    // Monitor sidecar stdout/stderr in background
     tauri::async_runtime::spawn(async move {
         while let Some(event) = rx.recv().await {
             match event {
@@ -106,10 +74,7 @@ pub async fn spawn_sidecar(
                     eprintln!("[sidecar:stdout] {}", text.trim_end());
                 }
                 CommandEvent::Terminated(payload) => {
-                    eprintln!(
-                        "[sidecar] terminated: code={:?} signal={:?}",
-                        payload.code, payload.signal
-                    );
+                    eprintln!("[sidecar] terminated: code={:?} signal={:?}", payload.code, payload.signal);
                     let _ = app_handle.emit("sidecar-exit", payload.code);
                     break;
                 }
@@ -121,7 +86,6 @@ pub async fn spawn_sidecar(
     let status = guard.status_response();
     drop(guard);
 
-    // Wait for health check in background (don't block the response)
     let health_state = Arc::clone(state);
     let health_app = app.clone();
     tauri::async_runtime::spawn(async move {
@@ -133,7 +97,6 @@ pub async fn spawn_sidecar(
             Err(e) => {
                 eprintln!("[sidecar] health check failed: {}", e);
                 let _ = health_app.emit("sidecar-health-failed", e.clone());
-                // Kill the sidecar if health never passed
                 let mut guard = health_state.lock().await;
                 if let Some(child) = guard.child.take() {
                     let _ = child.kill();
@@ -143,13 +106,9 @@ pub async fn spawn_sidecar(
         }
     });
 
-    Ok(SidecarStatus {
-        status: "starting".to_string(),
-        ..status
-    })
+    Ok(SidecarStatus { status: "starting".to_string(), ..status })
 }
 
-/// Stop the sidecar process gracefully.
 pub async fn stop_sidecar(state: &Arc<Mutex<SidecarState>>) -> SidecarStatus {
     let mut guard = state.lock().await;
     if let Some(child) = guard.child.take() {
@@ -160,26 +119,21 @@ pub async fn stop_sidecar(state: &Arc<Mutex<SidecarState>>) -> SidecarStatus {
     guard.status_response()
 }
 
-/// Poll the sidecar health endpoint until it responds or timeout.
 async fn wait_for_health(port: u16) -> Result<(), String> {
     let url = format!("http://127.0.0.1:{}/health", port);
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(2))
         .build()
         .map_err(|e| format!("HTTP client error: {}", e))?;
-
     let deadline = tokio::time::Instant::now() + HEALTH_CHECK_TIMEOUT;
-
     loop {
         if tokio::time::Instant::now() > deadline {
             return Err("Health check timed out".to_string());
         }
-
         match client.get(&url).send().await {
             Ok(resp) if resp.status().is_success() => return Ok(()),
             _ => {}
         }
-
         sleep(HEALTH_CHECK_INTERVAL).await;
     }
 }

--- a/desktop/src-tauri/src/sidecar.rs
+++ b/desktop/src-tauri/src/sidecar.rs
@@ -9,7 +9,9 @@ use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tokio::sync::Mutex;
 use tokio::time::sleep;
 
+/// Maximum time to wait for the sidecar health check during startup.
 const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(15);
+/// Interval between health check polls.
 const HEALTH_CHECK_INTERVAL: Duration = Duration::from_millis(500);
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -18,43 +20,93 @@ pub struct SidecarStatus {
     pub port: u16,
     pub error: Option<String>,
     pub uptime_secs: Option<u64>,
+    pub profile: Option<String>,
 }
 
 pub struct SidecarState {
     child: Option<CommandChild>,
     port: u16,
+    profile: Option<String>,
     started_at: Option<std::time::Instant>,
 }
 
 impl SidecarState {
     pub fn new() -> Self {
-        Self { child: None, port: 3100, started_at: None }
+        Self {
+            child: None,
+            port: 3100,
+            profile: None,
+            started_at: None,
+        }
     }
 
-    pub fn port(&self) -> u16 { self.port }
+    pub fn port(&self) -> u16 {
+        self.port
+    }
 
-    pub fn is_running(&self) -> bool { self.child.is_some() }
+    pub fn is_running(&self) -> bool {
+        self.child.is_some()
+    }
+
+    pub fn profile(&self) -> Option<&str> {
+        self.profile.as_deref()
+    }
 
     pub fn status_response(&self) -> SidecarStatus {
         let status = if self.child.is_some() { "running" } else { "stopped" };
         let uptime_secs = self.started_at.map(|t| t.elapsed().as_secs());
-        SidecarStatus { status: status.to_string(), port: self.port, error: None, uptime_secs }
+        SidecarStatus {
+            status: status.to_string(),
+            port: self.port,
+            error: None,
+            uptime_secs,
+            profile: self.profile.clone(),
+        }
     }
 }
 
+/// Spawn the sidecar process and begin monitoring its output.
 pub async fn spawn_sidecar(
-    app: &AppHandle, state: &Arc<Mutex<SidecarState>>, port: u16,
+    app: &AppHandle,
+    state: &Arc<Mutex<SidecarState>>,
+    port: u16,
+    profile_directory: Option<String>,
 ) -> Result<SidecarStatus, String> {
     let mut guard = state.lock().await;
-    if guard.child.is_some() { return Ok(guard.status_response()); }
-    guard.port = port;
 
-    let sidecar_cmd = app.shell()
+    // Already running — return current status
+    if guard.child.is_some() {
+        return Ok(guard.status_response());
+    }
+
+    guard.port = port;
+    guard.profile = profile_directory.clone();
+
+    let mut args = vec![
+        "serve".to_string(),
+        "--http".to_string(),
+        port.to_string(),
+        "--auto-launch".to_string(),
+        "--server-mode".to_string(),
+    ];
+
+    if let Some(ref profile) = profile_directory {
+        if !profile.is_empty() {
+            args.push("--profile-directory".to_string());
+            args.push(profile.clone());
+        }
+    }
+
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    let sidecar_cmd = app
+        .shell()
         .sidecar("binaries/openchrome-sidecar")
         .map_err(|e| format!("Failed to create sidecar command: {}", e))?
-        .args(["serve", "--http", &port.to_string(), "--auto-launch", "--server-mode"]);
+        .args(&arg_refs);
 
-    let (mut rx, child) = sidecar_cmd.spawn()
+    let (mut rx, child) = sidecar_cmd
+        .spawn()
         .map_err(|e| format!("Failed to spawn sidecar: {}", e))?;
 
     guard.child = Some(child);
@@ -74,7 +126,10 @@ pub async fn spawn_sidecar(
                     eprintln!("[sidecar:stdout] {}", text.trim_end());
                 }
                 CommandEvent::Terminated(payload) => {
-                    eprintln!("[sidecar] terminated: code={:?} signal={:?}", payload.code, payload.signal);
+                    eprintln!(
+                        "[sidecar] terminated: code={:?} signal={:?}",
+                        payload.code, payload.signal
+                    );
                     let _ = app_handle.emit("sidecar-exit", payload.code);
                     break;
                 }
@@ -86,6 +141,7 @@ pub async fn spawn_sidecar(
     let status = guard.status_response();
     drop(guard);
 
+    // Wait for health check in background
     let health_state = Arc::clone(state);
     let health_app = app.clone();
     tauri::async_runtime::spawn(async move {
@@ -106,9 +162,13 @@ pub async fn spawn_sidecar(
         }
     });
 
-    Ok(SidecarStatus { status: "starting".to_string(), ..status })
+    Ok(SidecarStatus {
+        status: "starting".to_string(),
+        ..status
+    })
 }
 
+/// Stop the sidecar process gracefully.
 pub async fn stop_sidecar(state: &Arc<Mutex<SidecarState>>) -> SidecarStatus {
     let mut guard = state.lock().await;
     if let Some(child) = guard.child.take() {
@@ -119,21 +179,26 @@ pub async fn stop_sidecar(state: &Arc<Mutex<SidecarState>>) -> SidecarStatus {
     guard.status_response()
 }
 
+/// Poll the sidecar health endpoint until it responds or timeout.
 async fn wait_for_health(port: u16) -> Result<(), String> {
     let url = format!("http://127.0.0.1:{}/health", port);
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(2))
         .build()
         .map_err(|e| format!("HTTP client error: {}", e))?;
+
     let deadline = tokio::time::Instant::now() + HEALTH_CHECK_TIMEOUT;
+
     loop {
         if tokio::time::Instant::now() > deadline {
             return Err("Health check timed out".to_string());
         }
+
         match client.get(&url).send().await {
             Ok(resp) if resp.status().is_success() => return Ok(()),
             _ => {}
         }
+
         sleep(HEALTH_CHECK_INTERVAL).await;
     }
 }

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1,22 +1,98 @@
 import { invoke } from "@tauri-apps/api/core";
 
+// --- Types ---
+
 interface ServerStatus {
   status: "stopped" | "starting" | "running" | "error";
   port: number;
   error: string | null;
   uptime_secs: number | null;
+  profile: string | null;
 }
 
-// DOM elements (from root index.html)
+interface ChromeProfile {
+  id: string;
+  name: string;
+}
+
+interface AppSettings {
+  selected_profile: string;
+  port: number;
+  auto_start: boolean;
+}
+
+// --- DOM ---
+
 const btnToggle = document.getElementById("btn-toggle") as HTMLButtonElement;
-const statusDot = document.getElementById("status-indicator")!;
+const statusDot = document.getElementById("status-dot")!;
 const statusText = document.getElementById("status-text")!;
+const profileSelect = document.getElementById(
+  "profile-select",
+) as HTMLSelectElement;
 const metricUptime = document.getElementById("metric-uptime")!;
-const mainPanel = document.getElementById("main-panel")!;
+const metricPort = document.getElementById("metric-port")!;
+
+// --- State ---
 
 let currentStatus: ServerStatus["status"] = "stopped";
+let settings: AppSettings = { selected_profile: "", port: 3100, auto_start: false };
 
-// Toggle server start/stop
+// --- Settings ---
+
+async function loadSettings(): Promise<void> {
+  try {
+    settings = await invoke<AppSettings>("load_settings");
+  } catch {
+    // Use defaults
+  }
+}
+
+async function saveSettings(): Promise<void> {
+  try {
+    await invoke("save_settings", { settingsData: settings });
+  } catch (e) {
+    console.error("Failed to save settings:", e);
+  }
+}
+
+// --- Profile Picker ---
+
+async function loadProfiles(): Promise<void> {
+  try {
+    const profiles = await invoke<ChromeProfile[]>("get_chrome_profiles");
+    profileSelect.innerHTML = "";
+
+    if (profiles.length === 0) {
+      const opt = document.createElement("option");
+      opt.value = "";
+      opt.textContent = "Default";
+      profileSelect.appendChild(opt);
+      return;
+    }
+
+    for (const p of profiles) {
+      const opt = document.createElement("option");
+      opt.value = p.id;
+      opt.textContent = p.name;
+      profileSelect.appendChild(opt);
+    }
+
+    // Restore saved selection
+    if (settings.selected_profile && profiles.some((p) => p.id === settings.selected_profile)) {
+      profileSelect.value = settings.selected_profile;
+    }
+  } catch {
+    profileSelect.innerHTML = '<option value="">Default</option>';
+  }
+}
+
+profileSelect.addEventListener("change", () => {
+  settings.selected_profile = profileSelect.value;
+  saveSettings();
+});
+
+// --- Server Toggle ---
+
 btnToggle.addEventListener("click", async () => {
   btnToggle.disabled = true;
 
@@ -24,12 +100,15 @@ btnToggle.addEventListener("click", async () => {
     if (currentStatus === "stopped" || currentStatus === "error") {
       updateUI({
         status: "starting",
-        port: 3100,
+        port: settings.port,
         error: null,
         uptime_secs: null,
+        profile: null,
       });
+      const profileDir = profileSelect.value || undefined;
       const result = await invoke<ServerStatus>("start_server", {
-        port: 3100,
+        port: settings.port,
+        profileDirectory: profileDir,
       });
       updateUI(result);
     } else if (currentStatus === "running") {
@@ -39,14 +118,17 @@ btnToggle.addEventListener("click", async () => {
   } catch (err) {
     updateUI({
       status: "error",
-      port: 3100,
+      port: settings.port,
       error: String(err),
       uptime_secs: null,
+      profile: null,
     });
   }
 
   btnToggle.disabled = false;
 });
+
+// --- UI Update ---
 
 function updateUI(status: ServerStatus): void {
   currentStatus = status.status;
@@ -69,61 +151,41 @@ function updateUI(status: ServerStatus): void {
       btnToggle.textContent = "Stop Server";
       btnToggle.className = "btn btn-stop";
       btnToggle.disabled = false;
+      profileSelect.disabled = true;
       break;
     case "starting":
       btnToggle.textContent = "Starting...";
       btnToggle.className = "btn btn-start";
       btnToggle.disabled = true;
+      profileSelect.disabled = true;
       break;
     default:
       btnToggle.textContent = "Start Server";
       btnToggle.className = "btn btn-start";
       btnToggle.disabled = false;
+      profileSelect.disabled = false;
       break;
   }
 
-  // Uptime metric
+  // Metrics
+  metricPort.textContent = "Port: " + status.port;
   if (status.uptime_secs != null) {
-    metricUptime.textContent = `Uptime: ${formatUptime(status.uptime_secs)}`;
+    metricUptime.textContent = "Uptime: " + formatUptime(status.uptime_secs);
   } else {
     metricUptime.textContent = "Uptime: --";
-  }
-
-  // Main panel content
-  if (status.status === "running") {
-    mainPanel.innerHTML = `
-      <div class="placeholder">
-        <p>Server is running on port ${status.port}.<br>
-        Connect from Claude, Cursor, or any MCP client.</p>
-      </div>`;
-  } else if (status.status === "error") {
-    mainPanel.innerHTML = `
-      <div class="placeholder">
-        <p style="color: var(--danger);">${escapeHtml(status.error || "Unknown error")}</p>
-      </div>`;
-  } else {
-    mainPanel.innerHTML = `
-      <div class="placeholder">
-        <p>Start the server and connect from Claude, Cursor, or any MCP client.</p>
-      </div>`;
   }
 }
 
 function formatUptime(secs: number): string {
-  if (secs < 60) return `${secs}s`;
-  if (secs < 3600) return `${Math.floor(secs / 60)}m ${secs % 60}s`;
+  if (secs < 60) return secs + "s";
+  if (secs < 3600) return Math.floor(secs / 60) + "m " + (secs % 60) + "s";
   const h = Math.floor(secs / 3600);
   const m = Math.floor((secs % 3600) / 60);
-  return `${h}h ${m}m`;
+  return h + "h " + m + "m";
 }
 
-function escapeHtml(text: string): string {
-  const div = document.createElement("div");
-  div.textContent = text;
-  return div.innerHTML;
-}
+// --- Status Polling ---
 
-// Poll server status every 2 seconds
 async function pollStatus(): Promise<void> {
   try {
     const status = await invoke<ServerStatus>("get_server_status");
@@ -133,5 +195,18 @@ async function pollStatus(): Promise<void> {
   }
 }
 
+// --- Init ---
+
+async function init(): Promise<void> {
+  await loadSettings();
+  await loadProfiles();
+  pollStatus();
+
+  // Auto-start if configured
+  if (settings.auto_start) {
+    btnToggle.click();
+  }
+}
+
+init();
 window.setInterval(pollStatus, 2000);
-pollStatus();

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -58,6 +58,34 @@ header h1 {
   margin-bottom: 1rem;
 }
 
+.profile-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.profile-row label {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+}
+
+.profile-select {
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.875rem;
+  min-width: 160px;
+  cursor: pointer;
+}
+
+.profile-select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .status-row {
   display: flex;
   align-items: center;
@@ -148,4 +176,48 @@ header h1 {
   font-size: 0.875rem;
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
+}
+
+/* Profile select dropdown */
+.profile-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.profile-row label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary, #a0a0b0);
+  white-space: nowrap;
+}
+
+.profile-select {
+  flex: 1;
+  padding: 6px 10px;
+  border: 1px solid var(--border, #2a2a4a);
+  border-radius: var(--radius, 8px);
+  background: var(--bg-secondary, #16213e);
+  color: var(--text-primary, #e8e8e8);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.profile-select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Metrics card */
+.metrics-card {
+  display: flex;
+  gap: 16px;
+  padding: 10px 16px;
+  margin-top: 12px;
+  background: var(--bg-secondary, #16213e);
+  border: 1px solid var(--border, #2a2a4a);
+  border-radius: var(--radius, 8px);
+  font-size: 12px;
+  color: var(--text-secondary, #a0a0b0);
 }


### PR DESCRIPTION
## Summary
- **Profile wiring**: selected Chrome profile passed to sidecar via `--profile-directory` CLI flag
- **Settings persistence** (`settings.rs`): human-readable `config.json` in platform app-data directory storing selected profile, port, and auto-start preference
- **IPC commands**: `load_settings` and `save_settings` for frontend ↔ backend settings sync
- **Frontend integration**: profile selection restored on app launch, auto-start support, dropdown disabled while server is running

Stacked on #535.
Ref: #520

## Test plan
- [ ] `cargo check` passes in `desktop/src-tauri/`
- [ ] Profile dropdown shows detected Chrome profiles with friendly names
- [ ] Selected profile persists across app restarts (check `config.json`)
- [ ] Deleting `config.json` falls back to sensible defaults
- [ ] Auto-start triggers server start on app launch when enabled
- [ ] Profile dropdown disabled while server is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)