### PR TITLE
feat(desktop): polished start/stop UI with plain-language errors

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -8,29 +8,48 @@
   </head>
   <body>
     <div id="app">
-      <header>
-        <h1>OpenChrome</h1>
-        <p class="subtitle">Browser automation server</p>
+      <header class="app-header">
+        <div class="logo">OpenChrome</div>
       </header>
 
-      <div class="status-card">
-        <div class="profile-row">
-          <label for="profile-select">Chrome Profile</label>
+      <main class="app-main">
+        <div class="profile-section">
+          <label for="profile-select">Chrome Profile:</label>
           <select id="profile-select" class="profile-select">
             <option value="">Loading...</option>
           </select>
+          <div id="profile-hint" class="hint" hidden></div>
         </div>
-        <div class="status-row">
-          <div class="status-dot" id="status-dot"></div>
-          <span class="status-text" id="status-text">Stopped</span>
-        </div>
-        <button id="btn-toggle" class="btn btn-start">Start Server</button>
-      </div>
 
-      <div class="metrics-card" id="metrics-card">
-        <span class="metric" id="metric-uptime">Uptime: --</span>
-        <span class="metric" id="metric-port">Port: 3100</span>
-      </div>
+        <button id="btn-toggle" class="btn-toggle btn-start">
+          <span class="btn-icon" id="btn-icon">&#9654;</span>
+          <span id="btn-label">Start Server</span>
+        </button>
+
+        <div id="error-banner" class="error-banner" hidden>
+          <span id="error-text"></span>
+          <button id="error-dismiss" class="error-dismiss">&times;</button>
+        </div>
+
+        <div class="status-bar">
+          <span class="status-indicator">
+            <span class="status-dot" id="status-dot"></span>
+            <span id="status-text">Stopped</span>
+          </span>
+          <span class="status-meta" id="status-meta"></span>
+        </div>
+
+        <div class="metrics">
+          <div class="metric-item">
+            <span class="metric-label">Port</span>
+            <span class="metric-value" id="metric-port">3100</span>
+          </div>
+          <div class="metric-item">
+            <span class="metric-label">Uptime</span>
+            <span class="metric-value" id="metric-uptime">--</span>
+          </div>
+        </div>
+      </main>
     </div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1,7 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
 
-// --- Types ---
-
 interface ServerStatus {
   status: "stopped" | "starting" | "running" | "error";
   port: number;
@@ -9,78 +7,74 @@ interface ServerStatus {
   uptime_secs: number | null;
   profile: string | null;
 }
-
-interface ChromeProfile {
-  id: string;
-  name: string;
-}
-
-interface AppSettings {
-  selected_profile: string;
-  port: number;
-  auto_start: boolean;
-}
-
-// --- DOM ---
+interface ChromeProfile { id: string; name: string; }
+interface AppSettings { selected_profile: string; port: number; auto_start: boolean; }
 
 const btnToggle = document.getElementById("btn-toggle") as HTMLButtonElement;
+const btnIcon = document.getElementById("btn-icon")!;
+const btnLabel = document.getElementById("btn-label")!;
 const statusDot = document.getElementById("status-dot")!;
 const statusText = document.getElementById("status-text")!;
-const profileSelect = document.getElementById(
-  "profile-select",
-) as HTMLSelectElement;
+const statusMeta = document.getElementById("status-meta")!;
+const profileSelect = document.getElementById("profile-select") as HTMLSelectElement;
+const profileHint = document.getElementById("profile-hint")!;
 const metricUptime = document.getElementById("metric-uptime")!;
 const metricPort = document.getElementById("metric-port")!;
-
-// --- State ---
+const errorBanner = document.getElementById("error-banner")!;
+const errorText = document.getElementById("error-text")!;
+const errorDismiss = document.getElementById("error-dismiss")!;
 
 let currentStatus: ServerStatus["status"] = "stopped";
+let runningProfile: string | null = null;
 let settings: AppSettings = { selected_profile: "", port: 3100, auto_start: false };
 
-// --- Settings ---
+// --- Error handling ---
+function showError(msg: string): void {
+  errorText.textContent = friendlyError(msg);
+  errorBanner.hidden = false;
+}
+function hideError(): void { errorBanner.hidden = true; }
+errorDismiss.addEventListener("click", hideError);
 
-async function loadSettings(): Promise<void> {
-  try {
-    settings = await invoke<AppSettings>("load_settings");
-  } catch {
-    // Use defaults
-  }
+function friendlyError(msg: string): string {
+  if (msg.includes("EADDRINUSE") || (msg.includes("port") && msg.includes("in use")))
+    return "Port is already in use. Try closing other servers or changing the port.";
+  if (msg.includes("ENOENT") || msg.includes("not found") || msg.includes("No such file"))
+    return "Chrome isn't installed or couldn't be found on this computer.";
+  if (msg.includes("timed out") || msg.includes("timeout"))
+    return "Server took too long to start. Please try again.";
+  if (msg.includes("Failed to spawn"))
+    return "Couldn't start the server. Make sure Chrome is installed.";
+  if (msg.includes("Failed to create sidecar"))
+    return "Server files are missing. Please reinstall the app.";
+  return msg.replace(/^(Error: |error: )/, "");
 }
 
+// --- Settings ---
+async function loadSettings(): Promise<void> {
+  try { settings = await invoke<AppSettings>("load_settings"); } catch { /* defaults */ }
+}
 async function saveSettings(): Promise<void> {
-  try {
-    await invoke("save_settings", { settingsData: settings });
-  } catch (e) {
-    console.error("Failed to save settings:", e);
-  }
+  try { await invoke("save_settings", { settingsData: settings }); } catch { /* silent */ }
 }
 
 // --- Profile Picker ---
-
 async function loadProfiles(): Promise<void> {
   try {
     const profiles = await invoke<ChromeProfile[]>("get_chrome_profiles");
     profileSelect.innerHTML = "";
-
     if (profiles.length === 0) {
-      const opt = document.createElement("option");
-      opt.value = "";
-      opt.textContent = "Default";
-      profileSelect.appendChild(opt);
+      profileSelect.innerHTML = '<option value="">Default</option>';
       return;
     }
-
     for (const p of profiles) {
       const opt = document.createElement("option");
       opt.value = p.id;
       opt.textContent = p.name;
       profileSelect.appendChild(opt);
     }
-
-    // Restore saved selection
-    if (settings.selected_profile && profiles.some((p) => p.id === settings.selected_profile)) {
+    if (settings.selected_profile && profiles.some((p) => p.id === settings.selected_profile))
       profileSelect.value = settings.selected_profile;
-    }
   } catch {
     profileSelect.innerHTML = '<option value="">Default</option>';
   }
@@ -89,123 +83,91 @@ async function loadProfiles(): Promise<void> {
 profileSelect.addEventListener("change", () => {
   settings.selected_profile = profileSelect.value;
   saveSettings();
+  if (currentStatus === "running" && runningProfile !== profileSelect.value) {
+    profileHint.textContent = "Restart the server to use this profile.";
+    profileHint.hidden = false;
+  } else {
+    profileHint.hidden = true;
+  }
 });
 
 // --- Server Toggle ---
-
 btnToggle.addEventListener("click", async () => {
   btnToggle.disabled = true;
-
+  hideError();
   try {
     if (currentStatus === "stopped" || currentStatus === "error") {
-      updateUI({
-        status: "starting",
-        port: settings.port,
-        error: null,
-        uptime_secs: null,
-        profile: null,
-      });
+      updateUI({ status: "starting", port: settings.port, error: null, uptime_secs: null, profile: null });
       const profileDir = profileSelect.value || undefined;
-      const result = await invoke<ServerStatus>("start_server", {
-        port: settings.port,
-        profileDirectory: profileDir,
-      });
+      const result = await invoke<ServerStatus>("start_server", { port: settings.port, profileDirectory: profileDir });
+      runningProfile = profileDir || null;
+      profileHint.hidden = true;
       updateUI(result);
     } else if (currentStatus === "running") {
       const result = await invoke<ServerStatus>("stop_server");
+      runningProfile = null;
+      profileHint.hidden = true;
       updateUI(result);
     }
   } catch (err) {
-    updateUI({
-      status: "error",
-      port: settings.port,
-      error: String(err),
-      uptime_secs: null,
-      profile: null,
-    });
+    showError(String(err));
+    updateUI({ status: "error", port: settings.port, error: String(err), uptime_secs: null, profile: null });
   }
-
   btnToggle.disabled = false;
 });
 
 // --- UI Update ---
-
 function updateUI(status: ServerStatus): void {
   currentStatus = status.status;
-
-  // Status dot
   statusDot.className = "status-dot " + status.status;
-
-  // Status text
-  const labels: Record<string, string> = {
-    stopped: "Stopped",
-    starting: "Starting...",
-    running: `Running (port ${status.port})`,
-    error: status.error || "Error",
-  };
+  const labels: Record<string, string> = { stopped: "Stopped", starting: "Starting...", running: "Running", error: "Error" };
   statusText.textContent = labels[status.status] || status.status;
+  statusMeta.textContent = status.status === "running" ? "port " + status.port : "";
 
-  // Button
   switch (status.status) {
     case "running":
-      btnToggle.textContent = "Stop Server";
-      btnToggle.className = "btn btn-stop";
+      btnLabel.textContent = "Stop Server";
+      btnIcon.innerHTML = "&#9724;";
+      btnToggle.className = "btn-toggle btn-stop";
       btnToggle.disabled = false;
       profileSelect.disabled = true;
       break;
     case "starting":
-      btnToggle.textContent = "Starting...";
-      btnToggle.className = "btn btn-start";
+      btnLabel.textContent = "Starting...";
+      btnIcon.innerHTML = "&#8987;";
+      btnToggle.className = "btn-toggle btn-starting";
       btnToggle.disabled = true;
       profileSelect.disabled = true;
       break;
     default:
-      btnToggle.textContent = "Start Server";
-      btnToggle.className = "btn btn-start";
+      btnLabel.textContent = "Start Server";
+      btnIcon.innerHTML = "&#9654;";
+      btnToggle.className = "btn-toggle btn-start";
       btnToggle.disabled = false;
       profileSelect.disabled = false;
       break;
   }
 
-  // Metrics
-  metricPort.textContent = "Port: " + status.port;
-  if (status.uptime_secs != null) {
-    metricUptime.textContent = "Uptime: " + formatUptime(status.uptime_secs);
-  } else {
-    metricUptime.textContent = "Uptime: --";
-  }
+  metricPort.textContent = String(status.port);
+  metricUptime.textContent = status.uptime_secs != null ? formatUptime(status.uptime_secs) : "--";
 }
 
 function formatUptime(secs: number): string {
   if (secs < 60) return secs + "s";
   if (secs < 3600) return Math.floor(secs / 60) + "m " + (secs % 60) + "s";
-  const h = Math.floor(secs / 3600);
-  const m = Math.floor((secs % 3600) / 60);
-  return h + "h " + m + "m";
+  return Math.floor(secs / 3600) + "h " + Math.floor((secs % 3600) / 60) + "m";
 }
-
-// --- Status Polling ---
 
 async function pollStatus(): Promise<void> {
-  try {
-    const status = await invoke<ServerStatus>("get_server_status");
-    updateUI(status);
-  } catch {
-    // Silently retry on next poll
-  }
+  try { const s = await invoke<ServerStatus>("get_server_status"); updateUI(s); } catch { /* retry */ }
 }
-
-// --- Init ---
 
 async function init(): Promise<void> {
   await loadSettings();
   await loadProfiles();
+  metricPort.textContent = String(settings.port);
   pollStatus();
-
-  // Auto-start if configured
-  if (settings.auto_start) {
-    btnToggle.click();
-  }
+  if (settings.auto_start) btnToggle.click();
 }
 
 init();

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1,223 +1,86 @@
 :root {
-  --bg: #0f1117;
-  --surface: #1a1d27;
-  --border: #2a2d3a;
-  --text: #e4e4e7;
-  --text-muted: #71717a;
-  --green: #22c55e;
-  --yellow: #eab308;
-  --red: #ef4444;
-  --blue: #3b82f6;
-  --radius: 12px;
+  --bg: #0f0f14;
+  --bg-card: #1a1a24;
+  --text: #e8e8f0;
+  --text-dim: #8888a0;
+  --accent: #4ecca3;
+  --accent-hover: #3dbb91;
+  --danger: #e74c3c;
+  --danger-hover: #c0392b;
+  --warning: #f39c12;
+  --border: #2a2a3e;
+  --radius: 10px;
+  --radius-lg: 14px;
 }
-
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-
+* { margin: 0; padding: 0; box-sizing: border-box; }
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  background: var(--bg);
-  color: var(--text);
-  min-height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  background: var(--bg); color: var(--text);
+  height: 100vh; overflow: hidden;
+  user-select: none; -webkit-user-select: none;
 }
-
 #app {
-  width: 100%;
-  max-width: 480px;
-  padding: 2rem;
+  display: flex; flex-direction: column; height: 100vh;
+  max-width: 420px; margin: 0 auto; padding: 0 24px;
 }
-
-header {
-  text-align: center;
-  margin-bottom: 2rem;
-}
-
-header h1 {
-  font-size: 1.75rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-}
-
-.subtitle {
-  color: var(--text-muted);
-  font-size: 0.875rem;
-  margin-top: 0.25rem;
-}
-
-.status-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 1.5rem;
-  margin-bottom: 1rem;
-}
-
-.profile-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 1rem;
-}
-
-.profile-row label {
-  font-size: 0.875rem;
-  color: var(--text-muted);
-}
-
+.app-header { padding: 32px 0 8px; text-align: center; }
+.logo { font-size: 22px; font-weight: 700; letter-spacing: -0.5px; }
+.app-main { flex: 1; display: flex; flex-direction: column; gap: 20px; padding-top: 24px; }
+.profile-section { display: flex; flex-direction: column; gap: 6px; }
+.profile-section label { font-size: 13px; font-weight: 600; color: var(--text-dim); }
 .profile-select {
-  background: var(--bg);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 0.375rem 0.75rem;
-  font-size: 0.875rem;
-  min-width: 160px;
-  cursor: pointer;
+  padding: 10px 14px; border: 1px solid var(--border); border-radius: var(--radius);
+  background: var(--bg-card); color: var(--text); font-size: 14px; cursor: pointer;
+  appearance: none; -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%238888a0'%3E%3Cpath d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat; background-position: right 12px center;
 }
-
-.profile-select:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
+.profile-select:disabled { opacity: 0.5; cursor: not-allowed; }
+.hint { font-size: 12px; color: var(--warning); padding: 4px 0; }
+.btn-toggle {
+  display: flex; align-items: center; justify-content: center; gap: 10px;
+  padding: 16px 24px; border: none; border-radius: var(--radius-lg);
+  font-size: 16px; font-weight: 700; cursor: pointer;
+  transition: background 0.2s, transform 0.1s;
 }
-
-.status-row {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 1.25rem;
+.btn-toggle:active:not(:disabled) { transform: scale(0.98); }
+.btn-toggle:disabled { opacity: 0.6; cursor: not-allowed; }
+.btn-start { background: var(--accent); color: #0f0f14; }
+.btn-start:hover:not(:disabled) { background: var(--accent-hover); }
+.btn-stop { background: var(--danger); color: white; }
+.btn-stop:hover:not(:disabled) { background: var(--danger-hover); }
+.btn-starting { background: var(--bg-card); color: var(--text-dim); border: 1px solid var(--border); }
+.btn-icon { font-size: 14px; }
+.error-banner {
+  display: flex; align-items: center; gap: 8px; padding: 10px 14px;
+  background: rgba(231,76,60,0.12); border: 1px solid rgba(231,76,60,0.3);
+  border-radius: var(--radius); color: #f08070; font-size: 13px;
 }
-
+.error-banner[hidden] { display: none; }
+.error-dismiss {
+  margin-left: auto; background: none; border: none;
+  color: #f08070; font-size: 18px; cursor: pointer; padding: 0 4px;
+}
+.status-bar {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 12px 16px; background: var(--bg-card);
+  border: 1px solid var(--border); border-radius: var(--radius);
+}
+.status-indicator { display: flex; align-items: center; gap: 8px; font-size: 14px; font-weight: 600; }
 .status-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: var(--red);
-  transition: background 0.3s ease, box-shadow 0.3s ease;
+  width: 10px; height: 10px; border-radius: 50%; background: var(--text-dim);
+  transition: background 0.3s, box-shadow 0.3s;
 }
-
-.status-dot.running {
-  background: var(--green);
-  box-shadow: 0 0 8px rgba(34, 197, 94, 0.4);
+.status-dot.running { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+.status-dot.stopped { background: var(--text-dim); }
+.status-dot.starting { background: var(--warning); animation: pulse 1.2s ease-in-out infinite; }
+.status-dot.error { background: var(--danger); }
+@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.3; } }
+.status-meta { font-size: 12px; color: var(--text-dim); }
+.metrics { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.metric-item {
+  display: flex; flex-direction: column; gap: 4px; padding: 12px 16px;
+  background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius);
 }
-
-.status-dot.starting {
-  background: var(--yellow);
-  box-shadow: 0 0 8px rgba(234, 179, 8, 0.4);
-  animation: pulse 1s infinite;
-}
-
-.status-dot.stopped {
-  background: var(--red);
-}
-
-.status-dot.error {
-  background: var(--red);
-  box-shadow: 0 0 8px rgba(239, 68, 68, 0.4);
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
-}
-
-.status-text {
-  font-size: 1rem;
-  font-weight: 600;
-}
-
-.btn {
-  width: 100%;
-  padding: 0.625rem 1rem;
-  border: none;
-  border-radius: 8px;
-  font-size: 0.875rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: opacity 0.2s ease, transform 0.1s ease;
-}
-
-.btn:active {
-  transform: scale(0.98);
-}
-
-.btn:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-  transform: none;
-}
-
-.btn-start {
-  background: var(--green);
-  color: #fff;
-}
-
-.btn-stop {
-  background: var(--red);
-  color: #fff;
-}
-
-.metrics-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 1rem 1.25rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.metric {
-  font-size: 0.875rem;
-  color: var(--text-muted);
-  font-variant-numeric: tabular-nums;
-}
-
-/* Profile select dropdown */
-.profile-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 16px;
-}
-
-.profile-row label {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text-secondary, #a0a0b0);
-  white-space: nowrap;
-}
-
-.profile-select {
-  flex: 1;
-  padding: 6px 10px;
-  border: 1px solid var(--border, #2a2a4a);
-  border-radius: var(--radius, 8px);
-  background: var(--bg-secondary, #16213e);
-  color: var(--text-primary, #e8e8e8);
-  font-size: 13px;
-  cursor: pointer;
-}
-
-.profile-select:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-/* Metrics card */
-.metrics-card {
-  display: flex;
-  gap: 16px;
-  padding: 10px 16px;
-  margin-top: 12px;
-  background: var(--bg-secondary, #16213e);
-  border: 1px solid var(--border, #2a2a4a);
-  border-radius: var(--radius, 8px);
-  font-size: 12px;
-  color: var(--text-secondary, #a0a0b0);
-}
+.metric-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-dim); }
+.metric-value { font-size: 18px; font-weight: 700; }


### PR DESCRIPTION
## Summary
- **Redesigned UI**: centered card layout with prominent start/stop toggle matching the issue mockup
- **Plain-language errors**: port conflicts, Chrome not found, timeouts shown without technical jargon (no "sidecar", "EADDRINUSE", "CDP")
- **Restart hint**: warns user when Chrome profile changed while server is running
- **Visual status states**: green glow (running), yellow pulse (starting), red (error), gray (stopped)
- **Metrics grid**: port number and uptime displayed cleanly
- **Zero jargon UX**: no file paths, terminal commands, or technical terms visible anywhere

Stacked on #537.
Closes #520

## Test plan
- [ ] UI renders correctly with dark theme
- [ ] Start button shows "Starting..." with spinner, then "Stop Server" when running
- [ ] Stop button returns to "Start Server" state
- [ ] Error banner shows friendly message for port conflicts
- [ ] Error banner shows friendly message when Chrome not installed
- [ ] Profile change while running shows "Restart the server" hint
- [ ] Dismissing error banner works
- [ ] Metrics update with correct port and uptime

🤖 Generated with [Claude Code](https://claude.com/claude-code)