### PR TITLE
feat(desktop): Chrome profile detection and settings persistence

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2224,6 +2224,8 @@ dependencies = [
 name = "openchrome-desktop"
 version = "0.1.0"
 dependencies = [
+ "dirs",
+ "getrandom 0.2.17",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -19,3 +19,4 @@ serde_json = "1"
 reqwest = { version = "0.12", features = ["json"] }
 tokio = { version = "1", features = ["sync", "time"] }
 getrandom = "0.2"
+dirs = "6"

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,5 +1,7 @@
 mod sidecar;
 mod tunnel;
+mod profiles;
+mod settings;
 
 use std::sync::Arc;
 use sidecar::{SidecarState, SidecarStatus};
@@ -139,6 +141,26 @@ async fn get_bearer_token(
     Ok(guard.to_status().bearer_token)
 }
 
+#[tauri::command]
+fn list_chrome_profiles() -> Vec<profiles::ChromeProfile> {
+    profiles::detect_profiles()
+}
+
+#[tauri::command]
+fn load_settings() -> settings::AppSettings {
+    settings::load()
+}
+
+#[tauri::command]
+fn save_settings(settings: settings::AppSettings) -> Result<(), String> {
+    settings::save(&settings)
+}
+
+#[tauri::command]
+fn get_selected_profile() -> String {
+    settings::load().selected_profile
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let sidecar_state = Arc::new(Mutex::new(SidecarState::new()));
@@ -151,6 +173,7 @@ pub fn run() {
             start_server, stop_server, get_server_status, get_health,
             capture_screenshot, get_sessions, get_tool_calls, get_metrics,
             start_tunnel, stop_tunnel, get_tunnel_status, get_tunnel_url, get_bearer_token,
+            list_chrome_profiles, load_settings, save_settings, get_selected_profile,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/profiles.rs
+++ b/desktop/src-tauri/src/profiles.rs
@@ -1,0 +1,58 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChromeProfile {
+    pub id: String,
+    pub name: String,
+}
+
+/// Detect installed Chrome profiles with friendly names.
+pub fn detect_profiles() -> Vec<ChromeProfile> {
+    let base = match chrome_user_data_dir() {
+        Some(p) if p.exists() => p,
+        _ => return vec![],
+    };
+
+    let local_state_path = base.join("Local State");
+    let profile_dirs = read_profile_dirs(&local_state_path)
+        .unwrap_or_else(|| vec!["Default".to_string()]);
+
+    profile_dirs
+        .into_iter()
+        .map(|dir_name| {
+            let prefs_path = base.join(&dir_name).join("Preferences");
+            let friendly = read_profile_name(&prefs_path).unwrap_or_else(|| dir_name.clone());
+            ChromeProfile { id: dir_name, name: friendly }
+        })
+        .collect()
+}
+
+fn chrome_user_data_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        // dirs::config_dir() returns ~/Library/Application Support on macOS
+        dirs::config_dir().map(|d| d.join("Google").join("Chrome"))
+    }
+    #[cfg(target_os = "windows")]
+    {
+        dirs::data_local_dir().map(|d| d.join("Google").join("Chrome").join("User Data"))
+    }
+    #[cfg(target_os = "linux")]
+    {
+        dirs::config_dir().map(|d| d.join("google-chrome"))
+    }
+}
+
+fn read_profile_dirs(path: &PathBuf) -> Option<Vec<String>> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let cache = json.get("profile")?.get("info_cache")?.as_object()?;
+    Some(cache.keys().cloned().collect())
+}
+
+fn read_profile_name(path: &PathBuf) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+    json.get("profile")?.get("name")?.as_str().map(|s| s.to_string())
+}

--- a/desktop/src-tauri/src/settings.rs
+++ b/desktop/src-tauri/src/settings.rs
@@ -1,0 +1,67 @@
+//! Persistent application settings stored as human-readable JSON.
+//! Path: platform app-data directory / openchrome-desktop / config.json
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppSettings {
+    /// Selected Chrome profile directory name (e.g. "Default", "Profile 1")
+    #[serde(default)]
+    pub selected_profile: String,
+    /// Server port (default: 3100)
+    #[serde(default = "default_port")]
+    pub port: u16,
+    /// Auto-start server when app launches
+    #[serde(default)]
+    pub auto_start: bool,
+}
+
+fn default_port() -> u16 {
+    3100
+}
+
+impl Default for AppSettings {
+    fn default() -> Self {
+        Self {
+            selected_profile: String::new(),
+            port: 3100,
+            auto_start: false,
+        }
+    }
+}
+
+/// Platform-appropriate settings directory
+fn settings_dir() -> PathBuf {
+    let base = dirs::config_dir().unwrap_or_else(|| {
+        dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".config")
+    });
+    base.join("openchrome-desktop")
+}
+
+fn settings_path() -> PathBuf {
+    settings_dir().join("config.json")
+}
+
+/// Load settings from disk, returning defaults if file is missing or corrupt.
+pub fn load() -> AppSettings {
+    let path = settings_path();
+    match std::fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+        Err(_) => AppSettings::default(),
+    }
+}
+
+/// Save settings to disk. Creates the directory if needed.
+pub fn save(settings: &AppSettings) -> Result<(), String> {
+    let dir = settings_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create settings dir: {}", e))?;
+
+    let path = settings_path();
+    let json = serde_json::to_string_pretty(settings)
+        .map_err(|e| format!("Failed to serialize settings: {}", e))?;
+
+    std::fs::write(&path, json).map_err(|e| format!("Failed to write settings: {}", e))
+}


### PR DESCRIPTION
## Summary

- **`profiles.rs`**: Detects installed Chrome profiles by reading `Local State` JSON from the Chrome user data directory. Cross-platform paths use `dirs::config_dir()` (macOS/Linux) and `dirs::data_local_dir()` (Windows) — no `dirs::home_dir()`. Falls back gracefully to a `["Default"]` list if the file is missing or unreadable.
- **`settings.rs`**: `AppSettings` struct with `selected_profile` (String), `port` (default 3100), and `auto_start` (default false). `load()`/`save()` persist to the platform config dir (`openchrome-desktop/config.json`) as human-readable JSON.
- **`lib.rs`**: Added `mod profiles;` and `mod settings;` declarations, plus 4 new Tauri IPC commands registered in `generate_handler!`:
  - `list_chrome_profiles` → returns `Vec<ChromeProfile>`
  - `load_settings` → returns `AppSettings`
  - `save_settings` → persists `AppSettings` to disk
  - `get_selected_profile` → convenience shortcut returning the selected profile string
- **`Cargo.toml`**: Added `dirs = "6"` dependency.

## Test plan

- [ ] Run `cargo check` in `desktop/src-tauri` — confirms no type errors (pre-existing icon panic in `generate_context!` is unrelated to these changes)
- [ ] Launch the desktop app and call `invoke("list_chrome_profiles")` from the frontend console — should return an array of `{id, name}` objects matching installed Chrome profiles
- [ ] Call `invoke("load_settings")` — should return defaults (`port: 3100, auto_start: false, selected_profile: ""`) on first run
- [ ] Call `invoke("save_settings", { settings: { selected_profile: "Default", port: 3100, auto_start: false } })` then `invoke("load_settings")` — should round-trip correctly
- [ ] Call `invoke("get_selected_profile")` — should return the currently saved profile string
- [ ] Verify settings file created at `~/Library/Application Support/openchrome-desktop/config.json` (macOS) or equivalent platform path

🤖 Generated with [Claude Code](https://claude.com/claude-code)