### PR TITLE
feat(desktop): add plain-language error banner to dashboard

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -15,6 +15,9 @@
           <span class="status-label" id="status-label">Stopped</span>
         </div>
         <div class="titlebar-center">
+          <select id="profile-select" class="profile-select" title="Chrome Profile">
+            <option value="">Default</option>
+          </select>
           <button class="tab-btn active" id="tab-dashboard" data-tab="dashboard">Dashboard</button>
           <button class="tab-btn" id="tab-connect" data-tab="connect">Connect</button>
         </div>
@@ -96,6 +99,12 @@
             <ul class="connect-notes" id="connect-notes"></ul>
           </div>
         </div>
+      </div>
+
+      <div class="error-banner" id="error-banner" hidden>
+        <span class="error-icon">⚠️</span>
+        <span class="error-text" id="error-text"></span>
+        <button class="error-dismiss" id="error-dismiss">✕</button>
       </div>
 
       <footer class="statusbar">

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -57,6 +57,42 @@ const toolFeedList = document.getElementById("tool-feed-list")!;
 const metricRam = document.getElementById("metric-ram")!;
 const metricTabs = document.getElementById("metric-tabs")!;
 const metricUptime = document.getElementById("metric-uptime")!;
+const errorBanner = document.getElementById("error-banner")!;
+const errorText = document.getElementById("error-text")!;
+const errorDismiss = document.getElementById("error-dismiss") as HTMLButtonElement;
+
+// --- Error Banner ---
+
+function classifyError(raw: string): string {
+  if (/EADDRINUSE/.test(raw)) {
+    return "Port is already in use. Another server may be running. Try stopping it first or change the port.";
+  }
+  if (/ECONNREFUSED/.test(raw)) {
+    return "Could not connect to Chrome. Make sure Chrome is installed.";
+  }
+  if (/EACCES|EPERM/.test(raw)) {
+    return "Permission denied. Your antivirus may be blocking the server.";
+  }
+  if (/ENOENT.*chrome/i.test(raw)) {
+    return "Chrome was not found. Please install Google Chrome.";
+  }
+  if (/ETIMEDOUT/.test(raw)) {
+    return "Connection timed out. Chrome may be unresponsive — try restarting.";
+  }
+  return `Something went wrong: ${raw.slice(0, 120)}`;
+}
+
+function showError(message: string): void {
+  errorText.textContent = message;
+  errorBanner.hidden = false;
+}
+
+function hideError(): void {
+  errorBanner.hidden = true;
+  errorText.textContent = "";
+}
+
+errorDismiss.addEventListener("click", hideError);
 
 // --- State ---
 
@@ -109,6 +145,12 @@ function updateServerStatus(resp: ServerStatus): void {
     error: resp.error || "Error",
   };
   statusLabel.textContent = labels[resp.status] || resp.status;
+
+  if (resp.status === "error" && resp.error) {
+    showError(classifyError(resp.error));
+  } else if (resp.status === "running") {
+    hideError();
+  }
 
   if (resp.status === "running") {
     btnToggle.textContent = "Stop";

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -328,6 +328,19 @@ body {
 .tab-btn:hover { color: var(--text); }
 .tab-btn.active { background: var(--surface-hover); color: var(--text); }
 
+/* Profile selector */
+.profile-select {
+  background: var(--bg-secondary, #2a2a2a);
+  color: var(--text-primary, #e0e0e0);
+  border: 1px solid var(--border, #444);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 12px;
+  cursor: pointer;
+  max-width: 140px;
+}
+.profile-select:focus { outline: 1px solid var(--accent, #4a9eff); }
+
 /* Connect view */
 .connect-view {
   flex: 1;
@@ -494,3 +507,27 @@ body {
   left: 4px;
   color: var(--text-muted);
 }
+
+/* Error banner */
+.error-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--error-bg, #3a1a1a);
+  border-top: 1px solid var(--error-border, #ff4444);
+  color: var(--error-text, #ff8888);
+  font-size: 12px;
+}
+.error-icon { font-size: 14px; flex-shrink: 0; }
+.error-text { flex: 1; }
+.error-dismiss {
+  background: none;
+  border: none;
+  color: var(--error-text, #ff8888);
+  cursor: pointer;
+  padding: 2px 6px;
+  font-size: 14px;
+  opacity: 0.7;
+}
+.error-dismiss:hover { opacity: 1; }


### PR DESCRIPTION
## Summary

- Adds an error banner (`#error-banner`) to `desktop/index.html` above the footer that shows when the sidecar server encounters an error
- Adds `classifyError(raw)` to `desktop/src/main.ts` that maps technical error codes to readable messages (EADDRINUSE, ECONNREFUSED, EACCES/EPERM, ENOENT+chrome, ETIMEDOUT, with a safe truncated fallback)
- Adds `showError` / `hideError` helpers; banner auto-hides when server transitions to `running`, and has a dismiss (✕) button
- Adds `.error-banner` CSS to `desktop/src/styles.css` with dark error palette using CSS custom properties

## Test plan

- [ ] Start server normally — no banner appears
- [ ] Trigger EADDRINUSE (start server twice) — banner shows "Port is already in use..."
- [ ] Trigger ECONNREFUSED — banner shows "Could not connect to Chrome..."
- [ ] Server recovers to `running` — banner auto-hides
- [ ] Click ✕ dismiss button — banner hides immediately
- [ ] Unknown error — banner shows truncated raw message (max 120 chars, no jargon bleed)
- [ ] `npm run build` passes with exit code 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)