### PR TITLE
fix(desktop): wire Chrome profile selection through IPC to sidecar

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -10,9 +10,10 @@ use tokio::sync::Mutex;
 
 #[tauri::command]
 async fn start_server(
-    app: tauri::AppHandle, state: tauri::State<'_, Arc<Mutex<SidecarState>>>, port: Option<u16>,
+    app: tauri::AppHandle, state: tauri::State<'_, Arc<Mutex<SidecarState>>>,
+    port: Option<u16>, profile_directory: Option<String>,
 ) -> Result<SidecarStatus, String> {
-    sidecar::spawn_sidecar(&app, &state, port.unwrap_or(3100)).await
+    sidecar::spawn_sidecar(&app, &state, port.unwrap_or(3100), profile_directory).await
 }
 
 #[tauri::command]

--- a/desktop/src-tauri/src/sidecar.rs
+++ b/desktop/src-tauri/src/sidecar.rs
@@ -39,14 +39,27 @@ impl SidecarState {
 
 pub async fn spawn_sidecar(
     app: &AppHandle, state: &Arc<Mutex<SidecarState>>, port: u16,
+    profile_directory: Option<String>,
 ) -> Result<SidecarStatus, String> {
     let mut guard = state.lock().await;
     if guard.child.is_some() { return Ok(guard.status_response()); }
     guard.port = port;
 
+    let mut args = vec![
+        "serve".to_string(),
+        "--http".to_string(),
+        port.to_string(),
+        "--auto-launch".to_string(),
+        "--server-mode".to_string(),
+    ];
+    if let Some(ref dir) = profile_directory {
+        args.push("--profile-directory".to_string());
+        args.push(dir.clone());
+    }
+
     let cmd = app.shell().sidecar("binaries/openchrome-sidecar")
         .map_err(|e| format!("Failed to create sidecar command: {}", e))?
-        .args(["serve", "--http", &port.to_string(), "--auto-launch", "--server-mode"]);
+        .args(&args);
 
     let (mut rx, child) = cmd.spawn().map_err(|e| format!("Failed to spawn sidecar: {}", e))?;
     guard.child = Some(child);


### PR DESCRIPTION
## Summary

- Adds `profile_directory: Option<String>` parameter to `start_server` IPC command in `lib.rs`
- Forwards `profile_directory` to `spawn_sidecar()` in `sidecar.rs`
- Builds sidecar args dynamically, appending `--profile-directory <dir>` when a profile is selected
- No frontend changes needed — `main.ts` already sends `profileDirectory` in the invoke call

## Problem

The Chrome profile selector dropdown (PR #549) saves the user's selection, but the selected profile was never passed to the sidecar process. The server always launched with Chrome's default profile regardless of UI selection.

```
Frontend: invoke("start_server", { port, profileDirectory: "Profile 1" })
    ↓
Backend: start_server(port) ← profileDirectory silently dropped
    ↓
Sidecar: ["serve", "--http", "3100"] ← no --profile-directory flag
```

## Changes

| File | Change |
|------|--------|
| `desktop/src-tauri/src/lib.rs` | Add `profile_directory: Option<String>` to `start_server`, pass to `spawn_sidecar` |
| `desktop/src-tauri/src/sidecar.rs` | Accept `profile_directory`, build args vec dynamically with conditional `--profile-directory` flag |

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 138 suites, 2625 tests pass, 0 regressions
- [ ] Start app → select non-default profile → Start Server → verify `--profile-directory` in sidecar args
- [ ] Start app → default profile → Start Server → verify no `--profile-directory` flag
- [ ] Profile with spaces (e.g. "Profile 3") → verify correctly quoted in args

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)