### PR TITLE
fix(sidecar): update state when process terminates

### DIFF
--- a/desktop/src-tauri/src/sidecar.rs
+++ b/desktop/src-tauri/src/sidecar.rs
@@ -66,6 +66,7 @@ pub async fn spawn_sidecar(
     guard.started_at = Some(std::time::Instant::now());
 
     let app_handle = app.clone();
+    let monitor_state = Arc::clone(state);
     tauri::async_runtime::spawn(async move {
         while let Some(event) = rx.recv().await {
             match event {
@@ -81,6 +82,9 @@ pub async fn spawn_sidecar(
                 CommandEvent::Terminated(payload) => {
                     eprintln!("[sidecar] terminated: code={:?} signal={:?}", payload.code, payload.signal);
                     let _ = app_handle.emit("sidecar-exit", payload.code);
+                    let mut guard = monitor_state.lock().await;
+                    guard.child = None;
+                    guard.started_at = None;
                     break;
                 }
                 _ => {}


### PR DESCRIPTION
## Summary
- Fix bug where `get_server_status` reports "running" after sidecar process crashes
- Pass `Arc<Mutex<SidecarState>>` into the monitoring task so `CommandEvent::Terminated` can clear `child` and `started_at`
- 4-line change in `sidecar.rs`

## Related
- Affects #524 (Error handling + fallback)

## Test plan
- [ ] `npm test` passes (2670+ tests, 0 new failures)
- [ ] Verify `get_server_status` returns "stopped" after simulated sidecar crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)