### PR TITLE
fix(tauri): register cloudflared in externalBin and capabilities

### DIFF
--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -5,6 +5,6 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    {"identifier": "shell:allow-execute", "allow": [{"name": "binaries/openchrome-sidecar", "sidecar": true, "args": ["serve", {"validator": "\\S+"}]}]}
+    {"identifier": "shell:allow-execute", "allow": [{"name": "binaries/openchrome-sidecar", "sidecar": true, "args": ["serve", {"validator": "\\S+"}]}, {"name": "binaries/cloudflared", "sidecar": true, "args": true}]}
   ]
 }

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -13,7 +13,7 @@
     "active": true,
     "targets": "all",
     "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
-    "externalBin": ["binaries/openchrome-sidecar"]
+    "externalBin": ["binaries/openchrome-sidecar", "binaries/cloudflared"]
   },
   "app": {
     "windows": [{"label":"main","title":"OpenChrome","width":960,"height":680,"minWidth":800,"minHeight":600,"resizable":true,"center":true}],


### PR DESCRIPTION
## Summary
- Add `binaries/cloudflared` to `tauri.conf.json` externalBin so Tauri bundles it at build time
- Add cloudflared shell capability in `default.json` so the tunnel feature can spawn it at runtime
- Without this fix, `tunnel.rs` calling `app.shell().sidecar("binaries/cloudflared")` fails with "sidecar not found"

## Related
- Affects #521 (Tunnel + Bearer token)

## Test plan
- [ ] `npm test` passes (no regressions)
- [ ] Verify `tauri.conf.json` lists both `openchrome-sidecar` and `cloudflared` in externalBin
- [ ] Verify `default.json` permits execution of cloudflared binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)