### PR TITLE
fix: sync cookies from real Chrome profile in ChromePool profile instances (#559)

### DIFF
--- a/src/chrome/pool.ts
+++ b/src/chrome/pool.ts
@@ -355,6 +355,27 @@ export class ChromePool {
       ? path.join(os.homedir(), '.openchrome', 'profiles', profileDirectory.replace(/[^a-zA-Z0-9_\- ]/g, '_'))
       : undefined;
 
+    // Sync cookies from the real Chrome profile into the isolated user-data-dir
+    // so that profile instances start with up-to-date session data.
+    if (profileDirectory && profileUserDataDir) {
+      try {
+        const profileManager = new ProfileManager();
+        const realProfileDir = profileManager.getDefaultUserDataDir();
+        if (realProfileDir && profileManager.needsSync(realProfileDir, profileDirectory)) {
+          const result = profileManager.syncProfileData(realProfileDir, profileUserDataDir, profileDirectory);
+          console.error(
+            `[ChromePool] Cookie sync for profile "${profileDirectory}": ` +
+            `success=${result.success}, atomic=${result.atomic}`
+          );
+        }
+      } catch (err) {
+        console.error(
+          `[ChromePool] Warning: cookie sync failed for profile "${profileDirectory}":`,
+          err instanceof Error ? err.message : err
+        );
+      }
+    }
+
     const launchOptions: LaunchOptions = {
       port,
       autoLaunch: profileDirectory ? true : this.config.autoLaunch,


### PR DESCRIPTION
## Summary

- Fixes #559: `ChromePool.launchNewInstance()` now syncs cookies from the real Chrome profile into the isolated `userDataDir` before launching Chrome when `profileDirectory` is specified
- Uses `ProfileManager.needsSync()` to check freshness (30-min threshold) and `syncProfileData()` to perform the sync
- Sync failure is non-fatal — logs a warning via `console.error()` and continues launching

## Test plan

- [x] `npm run build` compiles without errors
- [x] `npm test` passes all 141 suites (2671 tests, 0 failures)
- [ ] Manual: launch a profile instance and verify cookies from the real Chrome profile are present
- [ ] Manual: verify that a sync failure (e.g., missing source dir) does not block Chrome launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)