### PR TITLE
feat(cli): add Codex CLI MCP setup preset

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -21,6 +21,16 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { spawn, ChildProcess } from 'child_process';
 import { checkForUpdates } from './update-check';
+import {
+  formatMCPServerConfigSnippet,
+  getClientLabel,
+  getClaudeManualServerConfig,
+  getClaudeSetupCommand,
+  getCodexServerConfig,
+  getSupportedMCPClients,
+  isSupportedMCPClient,
+  upsertMCPServerConfig,
+} from './mcp-client-config';
 
 const program = new Command();
 
@@ -75,116 +85,169 @@ program
 
 program
   .command('setup')
-  .description('Automatically configure MCP server for Claude Code')
+  .description('Automatically configure MCP server for Claude Code or Codex CLI')
+  .option('--client <client>', 'Client to configure: "claude" (default) or "codex"', 'claude')
   .option('--dashboard', 'Enable terminal dashboard')
   .option('--auto-launch', 'Auto-launch Chrome if not running (default: true)')
   .option('-s, --scope <scope>', 'Installation scope: "user" (global, default) or "project" (current project only)', 'user')
-  .action(async (options: { dashboard?: boolean; autoLaunch?: boolean; scope?: string }) => {
-    const { execSync, spawnSync } = require('child_process');
+  .action(async (options: { client?: string; dashboard?: boolean; autoLaunch?: boolean; scope?: string }) => {
+    const { execFileSync } = require('child_process');
 
-    console.log('Setting up OpenChrome for Claude Code...\n');
-
-    // Check if claude CLI is available
-    try {
-      execSync('claude --version', { stdio: 'pipe' });
-    } catch {
-      console.error('❌ Claude Code CLI not found.');
-      console.error('   Please install Claude Code first: https://claude.ai/code');
+    const requestedClient = options.client || 'claude';
+    if (!isSupportedMCPClient(requestedClient)) {
+      console.error(`❌ Invalid client. Use one of: ${getSupportedMCPClients().join(', ')}`);
       process.exit(1);
     }
 
-    // Validate scope
+    const client = requestedClient;
+    console.log(`Setting up OpenChrome for ${getClientLabel(client)}...\n`);
+
+    // Check if claude CLI is available
     const scope = options.scope || 'user';
     if (scope !== 'user' && scope !== 'project') {
       console.error('❌ Invalid scope. Use "user" (global) or "project" (current project only).');
       process.exit(1);
     }
 
-    // Build the serve arguments
-    const serveArgs = ['serve', '--auto-launch'];
-    if (options.dashboard) {
-      serveArgs.push('--dashboard');
-    }
+    const serveArgOptions = { autoLaunch: options.autoLaunch, dashboard: options.dashboard };
 
-    // Remove existing configuration from ALL scopes to prevent duplicates.
-    // Without explicit scope flags, `claude mcp remove` only targets one scope,
-    // leaving the other intact and causing dual-registration conflicts.
-    for (const removeScope of ['user', 'project']) {
+    if (client === 'claude') {
       try {
-        execSync(`claude mcp remove openchrome -s ${removeScope} 2>/dev/null`, { stdio: 'pipe' });
+        execFileSync('claude', ['--version'], { stdio: 'pipe' });
       } catch {
-        // Ignore if not exists in this scope
+        console.error('❌ Claude Code CLI not found.');
+        console.error('   Please install Claude Code first: https://claude.ai/code');
+        process.exit(1);
       }
+
+      // Remove existing configuration from ALL scopes to prevent duplicates.
+      // Without explicit scope flags, `claude mcp remove` only targets one scope,
+      // leaving the other intact and causing dual-registration conflicts.
+      for (const removeScope of ['user', 'project'] as const) {
+        try {
+          execFileSync('claude', ['mcp', 'remove', 'openchrome', '-s', removeScope], { stdio: 'pipe' });
+        } catch {
+          // Ignore if not exists in this scope
+        }
+      }
+
+      // Use npx @latest with --prefer-online for reliable auto-updates.
+      // Without --prefer-online, npx caches a semver range (e.g. ^1.4.0) in ~/.npm/_npx/
+      // and never re-checks the registry, so @latest effectively becomes @cached.
+      const setupArgs = getClaudeSetupCommand(scope, serveArgOptions);
+
+      console.log(`Running: claude mcp add openchrome (scope: ${scope})...`);
+
+      try {
+        execFileSync('claude', setupArgs, { stdio: 'inherit' });
+        console.log('\n✅ MCP server configured successfully!\n');
+
+        // Configure tool permissions in ~/.claude/settings.json
+        const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
+        const permissionEntry = 'mcp__openchrome__*';
+        try {
+          let settings: Record<string, unknown> = {};
+          if (fs.existsSync(settingsPath)) {
+            settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+          } else {
+            // Ensure ~/.claude/ directory exists
+            fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+          }
+
+          // Ensure permissions.allow array exists
+          if (!settings.permissions || typeof settings.permissions !== 'object') {
+            settings.permissions = {};
+          }
+          const permissions = settings.permissions as Record<string, unknown>;
+          if (!Array.isArray(permissions.allow)) {
+            permissions.allow = [];
+          }
+          const allowList = permissions.allow as string[];
+
+          if (allowList.includes(permissionEntry)) {
+            console.log('✓ Tool permissions already configured (auto-approve OpenChrome tools)');
+          } else {
+            allowList.push(permissionEntry);
+            fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+            console.log('✓ Tool permissions configured (auto-approve OpenChrome tools)');
+          }
+        } catch {
+          console.warn('⚠️  Could not configure tool permissions automatically.');
+          console.warn(`   Manually add "${permissionEntry}" to permissions.allow in ${settingsPath}`);
+        }
+
+        console.log(`\nScope: ${scope === 'user' ? 'Global (all projects)' : 'Project (this directory only)'}`);
+        console.log('Auto-updates: enabled (via npx)\n');
+        console.log('Next steps:');
+        console.log('  1. Restart Claude Code');
+        console.log('  2. Just say "oc" — that\'s it.\n');
+        console.log('Examples:');
+        console.log('  "oc screenshot my Gmail"');
+        console.log('  "use oc to check AWS billing"');
+        console.log('  "oc search on naver.com"\n');
+      } catch {
+        console.error('\n❌ Failed to configure MCP server.');
+        console.error('   You can manually add to ~/.claude.json:');
+        console.error(formatMCPServerConfigSnippet('openchrome', getClaudeManualServerConfig(serveArgOptions)));
+        process.exit(1);
+      }
+
+      return;
     }
 
-    // Use npx @latest with --prefer-online for reliable auto-updates.
-    // Without --prefer-online, npx caches a semver range (e.g. ^1.4.0) in ~/.npm/_npx/
-    // and never re-checks the registry, so @latest effectively becomes @cached.
-    const fullCommand = `claude mcp add openchrome -s ${scope} -- npx --prefer-online -y openchrome-mcp@latest ${serveArgs.join(' ')}`;
-
-    console.log(`Running: claude mcp add openchrome (scope: ${scope})...`);
+    if (scope !== 'user') {
+      console.warn('⚠️  Scope is not used for Codex CLI; writing to ~/.codex/mcp.json.');
+    }
 
     try {
-      execSync(fullCommand, { stdio: 'inherit' });
-      console.log('\n✅ MCP server configured successfully!\n');
+      const codexConfigPath = path.join(os.homedir(), '.codex', 'mcp.json');
+      fs.mkdirSync(path.dirname(codexConfigPath), { recursive: true });
 
-      // Configure tool permissions in ~/.claude/settings.json
-      const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
-      const permissionEntry = 'mcp__openchrome__*';
-      try {
-        let settings: Record<string, unknown> = {};
-        if (fs.existsSync(settingsPath)) {
-          settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-        } else {
-          // Ensure ~/.claude/ directory exists
-          fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
-        }
-
-        // Ensure permissions.allow array exists
-        if (!settings.permissions || typeof settings.permissions !== 'object') {
-          settings.permissions = {};
-        }
-        const permissions = settings.permissions as Record<string, unknown>;
-        if (!Array.isArray(permissions.allow)) {
-          permissions.allow = [];
-        }
-        const allowList = permissions.allow as string[];
-
-        if (allowList.includes(permissionEntry)) {
-          console.log('✓ Tool permissions already configured (auto-approve OpenChrome tools)');
-        } else {
-          allowList.push(permissionEntry);
-          fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
-          console.log('✓ Tool permissions configured (auto-approve OpenChrome tools)');
-        }
-      } catch (permError) {
-        console.warn('⚠️  Could not configure tool permissions automatically.');
-        console.warn(`   Manually add "${permissionEntry}" to permissions.allow in ${settingsPath}`);
+      let config: Record<string, unknown> = {};
+      if (fs.existsSync(codexConfigPath)) {
+        config = JSON.parse(fs.readFileSync(codexConfigPath, 'utf8'));
       }
 
-      console.log(`\nScope: ${scope === 'user' ? 'Global (all projects)' : 'Project (this directory only)'}`);
-      console.log('Auto-updates: enabled (via npx)\n');
+      const updatedConfig = upsertMCPServerConfig(config, 'openchrome', getCodexServerConfig(serveArgOptions));
+      fs.writeFileSync(codexConfigPath, JSON.stringify(updatedConfig, null, 2) + '\n');
+
+      console.log('\n✅ MCP server configured successfully!\n');
+      console.log(`Config file: ${codexConfigPath}`);
+      console.log('Auto-updates: enabled (via npm exec)\n');
       console.log('Next steps:');
-      console.log('  1. Restart Claude Code');
-      console.log('  2. Just say "oc" — that\'s it.\n');
-      console.log('Examples:');
-      console.log('  "oc screenshot my Gmail"');
-      console.log('  "use oc to check AWS billing"');
-      console.log('  "oc search on naver.com"\n');
+      console.log('  1. Restart Codex CLI');
+      console.log('  2. Verify the openchrome MCP server reconnects cleanly\n');
+      console.log('Installed MCP snippet:');
+      console.log(formatMCPServerConfigSnippet('openchrome', getCodexServerConfig(serveArgOptions)));
     } catch (error) {
-      console.error('\n❌ Failed to configure MCP server.');
-      console.error('   You can manually add to ~/.claude.json:');
-      console.error('   {');
-      console.error('     "mcpServers": {');
-      console.error('       "openchrome": {');
-      console.error('         "command": "npx",');
-      console.error(`         "args": ["-y", "openchrome-mcp@latest", ${serveArgs.map(a => `"${a}"`).join(', ')}]`);
-      console.error('       }');
-      console.error('     }');
-      console.error('   }');
+      console.error('\n❌ Failed to configure MCP server for Codex CLI.');
+      console.error(`   ${error instanceof Error ? error.message : String(error)}`);
+      console.error('   You can manually add this to ~/.codex/mcp.json:');
+      console.error(formatMCPServerConfigSnippet('openchrome', getCodexServerConfig(serveArgOptions)));
+      process.exit(1);
+    }
+  });
+
+program
+  .command('config')
+  .description('Print MCP configuration for a supported client')
+  .requiredOption('--client <client>', 'Client to generate config for: "claude" or "codex"')
+  .option('--dashboard', 'Enable terminal dashboard')
+  .option('--auto-launch', 'Auto-launch Chrome if not running (default: true)')
+  .action((options: { client: string; dashboard?: boolean; autoLaunch?: boolean }) => {
+    if (!isSupportedMCPClient(options.client)) {
+      console.error(`❌ Invalid client. Use one of: ${getSupportedMCPClients().join(', ')}`);
       process.exit(1);
     }
 
+    const serveArgOptions = { autoLaunch: options.autoLaunch, dashboard: options.dashboard };
+
+    if (options.client === 'claude') {
+      console.log(['claude', ...getClaudeSetupCommand('user', serveArgOptions)].join(' '));
+      return;
+    }
+
+    console.log(formatMCPServerConfigSnippet('openchrome', getCodexServerConfig(serveArgOptions)));
   });
 
 program

--- a/cli/mcp-client-config.ts
+++ b/cli/mcp-client-config.ts
@@ -1,0 +1,106 @@
+export type SupportedMCPClient = 'claude' | 'codex';
+export type SetupScope = 'user' | 'project';
+
+export interface ServeArgOptions {
+  autoLaunch?: boolean;
+  dashboard?: boolean;
+}
+
+export interface MCPServerConfig {
+  command: string;
+  args: string[];
+}
+
+export interface MCPConfigDocument {
+  mcpServers?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+const SUPPORTED_CLIENTS: SupportedMCPClient[] = ['claude', 'codex'];
+
+export function getSupportedMCPClients(): SupportedMCPClient[] {
+  return [...SUPPORTED_CLIENTS];
+}
+
+export function isSupportedMCPClient(value: string): value is SupportedMCPClient {
+  return SUPPORTED_CLIENTS.includes(value as SupportedMCPClient);
+}
+
+export function getClientLabel(client: SupportedMCPClient): string {
+  return client === 'claude' ? 'Claude Code' : 'Codex CLI';
+}
+
+export function getServeArgs(options: ServeArgOptions = {}): string[] {
+  const serveArgs = ['serve'];
+
+  if (options.autoLaunch !== false) {
+    serveArgs.push('--auto-launch');
+  }
+
+  if (options.dashboard) {
+    serveArgs.push('--dashboard');
+  }
+
+  return serveArgs;
+}
+
+export function getCodexServerConfig(options: ServeArgOptions = {}): MCPServerConfig {
+  return {
+    command: 'npm',
+    args: ['exec', '--yes', '--prefer-online', 'openchrome-mcp@latest', '--', ...getServeArgs(options)],
+  };
+}
+
+export function getClaudeManualServerConfig(options: ServeArgOptions = {}): MCPServerConfig {
+  return {
+    command: 'npx',
+    args: ['-y', 'openchrome-mcp@latest', ...getServeArgs(options)],
+  };
+}
+
+export function getClaudeSetupCommand(scope: SetupScope, options: ServeArgOptions = {}): string[] {
+  return [
+    'mcp',
+    'add',
+    'openchrome',
+    '-s',
+    scope,
+    '--',
+    'npx',
+    '--prefer-online',
+    '-y',
+    'openchrome-mcp@latest',
+    ...getServeArgs(options),
+  ];
+}
+
+export function upsertMCPServerConfig(
+  document: MCPConfigDocument,
+  serverName: string,
+  serverConfig: MCPServerConfig
+): MCPConfigDocument {
+  const nextDocument: MCPConfigDocument = { ...document };
+  const nextServers =
+    document.mcpServers && typeof document.mcpServers === 'object' && !Array.isArray(document.mcpServers)
+      ? { ...document.mcpServers }
+      : {};
+
+  nextServers[serverName] = serverConfig as unknown as Record<string, unknown>;
+  nextDocument.mcpServers = nextServers;
+  return nextDocument;
+}
+
+export function formatMCPServerConfigSnippet(
+  serverName: string,
+  serverConfig: MCPServerConfig
+): string {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        [serverName]: serverConfig,
+      },
+    },
+    null,
+    2
+  );
+}

--- a/src/connect/hosts.ts
+++ b/src/connect/hosts.ts
@@ -66,7 +66,7 @@ export const HOST_DEFINITIONS: Record<WebAIHostId, HostDefinition> = {
     ],
     notes: [
       'Works with Claude Desktop, Cursor, Windsurf, and any MCP-compatible client.',
-      'For stdio clients, use: npx openchrome serve (no tunnel needed).',
+      'For stdio clients, use a client-specific command. Example for Codex CLI: npm exec --yes openchrome-mcp@latest -- serve --auto-launch.',
     ],
   },
 };

--- a/src/hints/rules/setup-hints.ts
+++ b/src/hints/rules/setup-hints.ts
@@ -16,7 +16,7 @@ export const setupHintRules: HintRule[] = [
       // Only on non-error tool calls
       if (ctx.isError) return null;
       hasFired = true;
-      return 'Hint: To skip permission prompts for OpenChrome tools, run: npx openchrome-mcp setup';
+      return 'Hint: To configure OpenChrome quickly, run: npx openchrome-mcp setup (or add --client codex for Codex CLI)';
     },
   },
 ];

--- a/src/resources/usage-guide.ts
+++ b/src/resources/usage-guide.ts
@@ -117,7 +117,7 @@ If the browser connection is lost during a session:
    connection issues — this can break multi-scope configurations. Instead,
    use your client's built-in MCP reconnect mechanism:
    - **IDE clients (Cursor, Windsurf, VS Code)**: Restart the MCP server from settings
-   - **CLI clients (Claude Code)**: Reconnect using the built-in MCP management command
+   - **CLI clients (Claude Code, Codex CLI)**: Reconnect using the client's built-in MCP management command or restart the CLI session
    - **Web clients**: Refresh the page or re-establish the connection
 `;
 

--- a/tests/cli/mcp-client-config.test.ts
+++ b/tests/cli/mcp-client-config.test.ts
@@ -1,0 +1,92 @@
+import {
+  formatMCPServerConfigSnippet,
+  getClaudeSetupCommand,
+  getCodexServerConfig,
+  getServeArgs,
+  isSupportedMCPClient,
+  upsertMCPServerConfig,
+} from '../../cli/mcp-client-config';
+
+describe('cli/mcp-client-config', () => {
+  test('getServeArgs enables auto-launch by default', () => {
+    expect(getServeArgs()).toEqual(['serve', '--auto-launch']);
+  });
+
+  test('getServeArgs includes dashboard when requested', () => {
+    expect(getServeArgs({ dashboard: true })).toEqual(['serve', '--auto-launch', '--dashboard']);
+  });
+
+  test('getServeArgs omits auto-launch when explicitly disabled', () => {
+    expect(getServeArgs({ autoLaunch: false })).toEqual(['serve']);
+  });
+
+  test('getCodexServerConfig uses npm exec with argument separator', () => {
+    expect(getCodexServerConfig()).toEqual({
+      command: 'npm',
+      args: ['exec', '--yes', '--prefer-online', 'openchrome-mcp@latest', '--', 'serve', '--auto-launch'],
+    });
+  });
+
+  test('getClaudeSetupCommand preserves the Claude-specific mcp add flow', () => {
+    expect(getClaudeSetupCommand('project', { dashboard: true })).toEqual([
+      'mcp',
+      'add',
+      'openchrome',
+      '-s',
+      'project',
+      '--',
+      'npx',
+      '--prefer-online',
+      '-y',
+      'openchrome-mcp@latest',
+      'serve',
+      '--auto-launch',
+      '--dashboard',
+    ]);
+  });
+
+  test('upsertMCPServerConfig preserves sibling servers', () => {
+    const updated = upsertMCPServerConfig(
+      {
+        mcpServers: {
+          existing: {
+            command: 'node',
+            args: ['example.js'],
+          },
+        },
+      },
+      'openchrome',
+      getCodexServerConfig()
+    );
+
+    expect(updated).toEqual({
+      mcpServers: {
+        existing: {
+          command: 'node',
+          args: ['example.js'],
+        },
+        openchrome: {
+          command: 'npm',
+          args: ['exec', '--yes', '--prefer-online', 'openchrome-mcp@latest', '--', 'serve', '--auto-launch'],
+        },
+      },
+    });
+  });
+
+  test('formatMCPServerConfigSnippet serializes a full mcpServers document', () => {
+    expect(JSON.parse(formatMCPServerConfigSnippet('openchrome', getCodexServerConfig()))).toEqual({
+      mcpServers: {
+        openchrome: {
+          command: 'npm',
+          args: ['exec', '--yes', '--prefer-online', 'openchrome-mcp@latest', '--', 'serve', '--auto-launch'],
+        },
+      },
+    });
+  });
+
+  test('isSupportedMCPClient validates supported names', () => {
+    expect(isSupportedMCPClient('claude')).toBe(true);
+    expect(isSupportedMCPClient('codex')).toBe(true);
+    expect(isSupportedMCPClient('cursor')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared MCP client config helper for Claude Code and Codex CLI
- teach `oc setup` how to write a Codex-safe `~/.codex/mcp.json` entry
- add `oc config --client <name>` so users can print the exact MCP command/snippet for supported clients
- update runtime-facing guidance strings to mention Codex CLI where relevant

## Why
Codex CLI fails with the documented generic `npx -y openchrome-mcp@latest serve --auto-launch` shape because its launcher path can reinterpret `-y` as a package name before OpenChrome ever returns an MCP `initialize` response.

This change gives Codex a first-class preset using:

```json
{
  "command": "npm",
  "args": ["exec", "--yes", "--prefer-online", "openchrome-mcp@latest", "--", "serve", "--auto-launch"]
}
```

## Changes
- add `cli/mcp-client-config.ts`
- extend `openchrome setup` with `--client codex`
- add `openchrome config --client codex`
- keep the existing Claude flow intact
- update non-README user guidance strings to reference the new Codex-aware setup flow
- add unit tests for preset generation / config merging

## Validation
- `npm run build`
- `npm test -- --runInBand tests/cli/mcp-client-config.test.ts tests/connect/config-generator.test.ts`
- `node dist/cli/index.js config --client codex`
- `HOME=$(mktemp -d) node dist/cli/index.js setup --client codex`
