### PR TITLE
docs(readme): add Codex CLI setup guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,13 +176,14 @@ Looking for something to work on? Here are the key areas where contributions wou
 ### Multi-Client Compatibility
 
 OpenChrome is a standard MCP server, but currently only tested with Claude Code. Help us verify and support other MCP clients.
+Codex CLI now has a dedicated setup/config preset, but runtime validation is still needed across real environments.
 
 | Client | Status | What's Needed |
 |--------|--------|---------------|
 | Claude Code | Verified | - |
 | Cursor | Untested | Test all 36 tools, verify `instructions` field |
 | Windsurf | Untested | Test all 36 tools, verify `instructions` field |
-| Codex CLI | Untested | Test all 36 tools, verify `instructions` field |
+| Codex CLI | Preset added, runtime validation needed | Verify `initialize`, `tools/list`, and at least one browser-backed tool call using the documented Codex config |
 | VS Code + MCP | Untested | Test basic tool flow |
 
 **How to contribute**: Pick a client, run the test suite against it, report what works and what doesn't. Adapt `oc setup` to support the client if needed.

--- a/README.md
+++ b/README.md
@@ -197,12 +197,18 @@ Or right-click the app → Open → Open.
 
 ## Quick Start
 
+**Claude Code**
 ```bash
 npx openchrome-mcp setup
 ```
 
-One command. Configures MCP server + auto-approves tool permissions.
-Restart Claude Code, then say `oc`.
+**Codex CLI**
+```bash
+npx openchrome-mcp setup --client codex
+```
+
+One command. Configures the MCP server for the selected client.
+Restart your MCP client after setup completes.
 
 <details>
 <summary>Manual config</summary>
@@ -225,7 +231,19 @@ claude mcp add openchrome -- npx -y openchrome-mcp@latest serve --auto-launch
 }
 ```
 
-**Cursor / Windsurf / Other MCP clients:**
+**Codex CLI** (`~/.codex/mcp.json`):
+```json
+{
+  "mcpServers": {
+    "openchrome": {
+      "command": "npm",
+      "args": ["exec", "--yes", "--prefer-online", "openchrome-mcp@latest", "--", "serve", "--auto-launch"]
+    }
+  }
+}
+```
+
+**Cursor / Windsurf / Other stdio MCP clients:**
 ```json
 {
   "mcpServers": {
@@ -236,6 +254,10 @@ claude mcp add openchrome -- npx -y openchrome-mcp@latest serve --auto-launch
   }
 }
 ```
+
+> Some stdio clients wrap `npx` through `npm exec` and may parse flags differently.
+> If your client misinterprets `-y`, prefer a client-specific command shape (for example the Codex CLI config above)
+> or run a locally installed `openchrome` binary directly.
 
 </details>
 


### PR DESCRIPTION
## Summary
- document a dedicated Codex CLI setup path in the README
- add a Codex-safe manual config example for `~/.codex/mcp.json`
- clarify that generic stdio clients may parse `npx` flags differently
- update contribution guidance so Codex moves from “untested” to “preset added, runtime validation needed”

## Why
The repo already calls out Codex CLI as a multi-client compatibility target, but the setup/docs only covered Claude-oriented or generic `npx` examples.

This PR makes the user-facing guidance match the new Codex-compatible setup flow introduced in the companion CLI PR.

## Notes
- no runtime code changes
- intended to land alongside or immediately after #565
