### PR TITLE
feat(auth): add TOTP generator and encrypted credential store (#575)

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -31,6 +31,15 @@ import {
   isSupportedMCPClient,
   upsertMCPServerConfig,
 } from './mcp-client-config';
+import {
+  addTotpSecret,
+  generateTOTP,
+  getTotpSecret,
+  listTotpDomains,
+  removeTotpSecret,
+  totpSecondsRemaining,
+  validateBase32,
+} from './totp-store';
 
 const program = new Command();
 
@@ -1140,5 +1149,98 @@ function attemptJsonRecovery(content: string): object | null {
 
   return null;
 }
+
+// ---------------------------------------------------------------------------
+// totp command group
+// ---------------------------------------------------------------------------
+
+const totp = program.command('totp').description('Manage TOTP secrets for 2FA automation');
+
+totp
+  .command('add')
+  .description('Add a TOTP secret for a domain')
+  .requiredOption('--domain <domain>', 'Domain the secret belongs to (e.g. github.com)')
+  .requiredOption('--secret <base32-secret>', 'TOTP secret in base32 format')
+  .option('--issuer <name>', 'Human-readable issuer name (e.g. GitHub)')
+  .action(async (options: { domain: string; secret: string; issuer?: string }) => {
+    if (!validateBase32(options.secret)) {
+      console.error(`❌ Invalid base32 secret. Ensure the secret only contains characters A-Z and 2-7.`);
+      process.exit(1);
+    }
+    try {
+      await addTotpSecret(options.domain, options.secret, options.issuer);
+      console.error(`TOTP secret added for ${options.domain}`);
+    } catch (error) {
+      console.error(`❌ Failed to store TOTP secret: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+totp
+  .command('list')
+  .description('List all configured TOTP domains')
+  .action(async () => {
+    try {
+      const domains = await listTotpDomains();
+      if (domains.length === 0) {
+        console.error('No TOTP secrets configured.');
+        return;
+      }
+      // Table header
+      const domainWidth = Math.max(6, ...domains.map((d) => d.domain.length));
+      const issuerWidth = Math.max(6, ...domains.map((d) => (d.issuer ?? '').length));
+      const header = `${'Domain'.padEnd(domainWidth)}  ${'Issuer'.padEnd(issuerWidth)}  Added`;
+      const separator = '-'.repeat(header.length);
+      console.error(header);
+      console.error(separator);
+      for (const entry of domains) {
+        const addedAt = new Date(entry.addedAt).toISOString().split('T')[0];
+        console.error(
+          `${entry.domain.padEnd(domainWidth)}  ${(entry.issuer ?? '').padEnd(issuerWidth)}  ${addedAt}`
+        );
+      }
+    } catch (error) {
+      console.error(`❌ Failed to list TOTP secrets: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+totp
+  .command('remove')
+  .description('Remove the TOTP secret for a domain')
+  .requiredOption('--domain <domain>', 'Domain to remove')
+  .action(async (options: { domain: string }) => {
+    try {
+      const removed = await removeTotpSecret(options.domain);
+      if (!removed) {
+        console.error(`❌ No TOTP secret found for ${options.domain}`);
+        process.exit(1);
+      }
+      console.error(`TOTP secret removed for ${options.domain}`);
+    } catch (error) {
+      console.error(`❌ Failed to remove TOTP secret: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+totp
+  .command('generate')
+  .description('Generate the current TOTP code for a domain')
+  .requiredOption('--domain <domain>', 'Domain to generate code for')
+  .action(async (options: { domain: string }) => {
+    try {
+      const secret = await getTotpSecret(options.domain);
+      if (secret === null) {
+        console.error(`❌ No TOTP secret configured for ${options.domain}`);
+        process.exit(1);
+      }
+      const code = generateTOTP(secret);
+      const secondsLeft = totpSecondsRemaining();
+      console.error(`${code} (${secondsLeft}s remaining)`);
+    } catch (error) {
+      console.error(`❌ Failed to generate TOTP code: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 program.parse();

--- a/cli/totp-store.ts
+++ b/cli/totp-store.ts
@@ -129,9 +129,13 @@ function decrypt(data: Buffer): string {
   const authTag = data.subarray(SALT_LENGTH + IV_LENGTH, SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH);
   const ciphertext = data.subarray(SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH);
   const key = deriveKey(salt);
-  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
-  decipher.setAuthTag(authTag);
-  return decipher.update(ciphertext) + decipher.final('utf8');
+  try {
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+    decipher.setAuthTag(authTag);
+    return decipher.update(ciphertext) + decipher.final('utf8');
+  } catch {
+    throw new Error('Failed to decrypt credential store: wrong passphrase or corrupted data');
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/totp-store.ts
+++ b/cli/totp-store.ts
@@ -1,0 +1,242 @@
+/**
+ * Self-contained TOTP store for CLI use.
+ *
+ * Provides TOTP generation (RFC 6238, SHA1, 6 digits, 30s period) and
+ * encrypted storage of TOTP secrets using AES-256-GCM.
+ *
+ * Storage path: ~/.openchrome/credentials/totp-secrets.enc
+ * Encryption key: scrypt(hostname + username, salt, 32)
+ * File permissions: 0o600 (directory: 0o700)
+ */
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Base32 helpers
+// ---------------------------------------------------------------------------
+
+const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+/**
+ * Decode a base32-encoded string to a Buffer.
+ * Accepts uppercase and lowercase input; ignores padding characters.
+ */
+export function base32Decode(encoded: string): Buffer {
+  const input = encoded.toUpperCase().replace(/=+$/, '');
+  let bits = 0;
+  let value = 0;
+  const output: number[] = [];
+
+  for (const char of input) {
+    const idx = BASE32_ALPHABET.indexOf(char);
+    if (idx === -1) {
+      throw new Error(`Invalid base32 character: ${char}`);
+    }
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      output.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+
+  return Buffer.from(output);
+}
+
+/**
+ * Return true when the input is a valid base32 string (RFC 4648).
+ * Allows lowercase, optional padding, and ignores surrounding whitespace.
+ */
+export function validateBase32(secret: string): boolean {
+  const cleaned = secret.trim().toUpperCase().replace(/=+$/, '');
+  if (cleaned.length === 0) return false;
+  return /^[A-Z2-7]+$/.test(cleaned);
+}
+
+// ---------------------------------------------------------------------------
+// TOTP generation (RFC 6238)
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate the current TOTP code for a base32-encoded secret.
+ * Uses SHA1, 6 digits, 30-second period.
+ */
+export function generateTOTP(secret: string): string {
+  const key = base32Decode(secret);
+  const counter = Math.floor(Date.now() / 1000 / 30);
+
+  const counterBuf = Buffer.alloc(8);
+  // Write as big-endian 64-bit integer (upper 32 bits are 0 for near-future dates)
+  counterBuf.writeUInt32BE(Math.floor(counter / 0x100000000), 0);
+  counterBuf.writeUInt32BE(counter >>> 0, 4);
+
+  const hmac = crypto.createHmac('sha1', key);
+  hmac.update(counterBuf);
+  const digest = hmac.digest();
+
+  const offset = digest[digest.length - 1] & 0x0f;
+  const code =
+    ((digest[offset] & 0x7f) << 24) |
+    ((digest[offset + 1] & 0xff) << 16) |
+    ((digest[offset + 2] & 0xff) << 8) |
+    (digest[offset + 3] & 0xff);
+
+  return String(code % 1_000_000).padStart(6, '0');
+}
+
+/**
+ * Return the number of seconds remaining in the current 30-second TOTP window.
+ */
+export function totpSecondsRemaining(): number {
+  return 30 - (Math.floor(Date.now() / 1000) % 30);
+}
+
+// ---------------------------------------------------------------------------
+// Encryption helpers (AES-256-GCM)
+// ---------------------------------------------------------------------------
+
+const SALT = 'openchrome-totp-v1';
+const SCRYPT_N = 16384;
+const SCRYPT_R = 8;
+const SCRYPT_P = 1;
+const KEY_LEN = 32;
+
+function deriveKey(): Buffer {
+  const passphrase = `${os.hostname()}:${os.userInfo().username}`;
+  return crypto.scryptSync(passphrase, SALT, KEY_LEN, { N: SCRYPT_N, r: SCRYPT_R, p: SCRYPT_P });
+}
+
+function encrypt(plaintext: string, key: Buffer): string {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  // Format: iv(12) + tag(16) + ciphertext — all hex-encoded
+  return Buffer.concat([iv, tag, encrypted]).toString('hex');
+}
+
+function decrypt(hexData: string, key: Buffer): string {
+  const data = Buffer.from(hexData, 'hex');
+  const iv = data.subarray(0, 12);
+  const tag = data.subarray(12, 28);
+  const ciphertext = data.subarray(28);
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(tag);
+  return decipher.update(ciphertext) + decipher.final('utf8');
+}
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
+
+function getStoragePath(): string {
+  return path.join(os.homedir(), '.openchrome', 'credentials', 'totp-secrets.enc');
+}
+
+interface TotpEntry {
+  domain: string;
+  encryptedSecret: string;
+  issuer?: string;
+  addedAt: string;
+}
+
+function readEntries(): TotpEntry[] {
+  const storagePath = getStoragePath();
+  if (!fs.existsSync(storagePath)) return [];
+
+  try {
+    const raw = fs.readFileSync(storagePath, 'utf8').trim();
+    if (!raw) return [];
+    const key = deriveKey();
+    const plaintext = decrypt(raw, key);
+    return JSON.parse(plaintext) as TotpEntry[];
+  } catch {
+    return [];
+  }
+}
+
+function writeEntries(entries: TotpEntry[]): void {
+  const storagePath = getStoragePath();
+  const dir = path.dirname(storagePath);
+
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+
+  const key = deriveKey();
+  const plaintext = JSON.stringify(entries, null, 2);
+  const encrypted = encrypt(plaintext, key);
+
+  fs.writeFileSync(storagePath, encrypted, { encoding: 'utf8', mode: 0o600 });
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Add (or overwrite) a TOTP secret for a domain.
+ */
+export async function addTotpSecret(domain: string, secret: string, issuer?: string): Promise<void> {
+  const entries = readEntries();
+  const idx = entries.findIndex((e) => e.domain === domain);
+
+  const key = deriveKey();
+  const encryptedSecret = encrypt(secret.toUpperCase().replace(/\s/g, ''), key);
+
+  const entry: TotpEntry = {
+    domain,
+    encryptedSecret,
+    issuer,
+    addedAt: new Date().toISOString(),
+  };
+
+  if (idx >= 0) {
+    entries[idx] = entry;
+  } else {
+    entries.push(entry);
+  }
+
+  writeEntries(entries);
+}
+
+/**
+ * Remove a TOTP secret for a domain.
+ * Returns true if removed, false if not found.
+ */
+export async function removeTotpSecret(domain: string): Promise<boolean> {
+  const entries = readEntries();
+  const idx = entries.findIndex((e) => e.domain === domain);
+  if (idx < 0) return false;
+
+  entries.splice(idx, 1);
+  writeEntries(entries);
+  return true;
+}
+
+/**
+ * List all configured TOTP domains (never returns secrets).
+ */
+export async function listTotpDomains(): Promise<Array<{ domain: string; issuer?: string; addedAt: string }>> {
+  const entries = readEntries();
+  return entries.map(({ domain, issuer, addedAt }) => ({ domain, issuer, addedAt }));
+}
+
+/**
+ * Retrieve the plaintext TOTP secret for a domain, or null if not found.
+ */
+export async function getTotpSecret(domain: string): Promise<string | null> {
+  const entries = readEntries();
+  const entry = entries.find((e) => e.domain === domain);
+  if (!entry) return null;
+
+  try {
+    const key = deriveKey();
+    return decrypt(entry.encryptedSecret, key);
+  } catch {
+    return null;
+  }
+}

--- a/cli/totp-store.ts
+++ b/cli/totp-store.ts
@@ -5,7 +5,8 @@
  * encrypted storage of TOTP secrets using AES-256-GCM.
  *
  * Storage path: ~/.openchrome/credentials/totp-secrets.enc
- * Encryption key: scrypt(hostname + username, salt, 32)
+ * File format:  [salt(16)][iv(16)][authTag(16)][ciphertext]
+ * Key derivation: scrypt('openchrome-totp-v1' + hostname + username, randomSalt, 32)
  * File permissions: 0o600 (directory: 0o700)
  */
 
@@ -98,33 +99,38 @@ export function totpSecondsRemaining(): number {
 // Encryption helpers (AES-256-GCM)
 // ---------------------------------------------------------------------------
 
-const SALT = 'openchrome-totp-v1';
-const SCRYPT_N = 16384;
-const SCRYPT_R = 8;
-const SCRYPT_P = 1;
-const KEY_LEN = 32;
+const PASSPHRASE = 'openchrome-totp-v1';
+const SALT_LENGTH = 16;
+const IV_LENGTH = 16;
+const AUTH_TAG_LENGTH = 16;
+// File format: [salt(16)][iv(16)][authTag(16)][ciphertext]
 
-function deriveKey(): Buffer {
-  const passphrase = `${os.hostname()}:${os.userInfo().username}`;
-  return crypto.scryptSync(passphrase, SALT, KEY_LEN, { N: SCRYPT_N, r: SCRYPT_R, p: SCRYPT_P });
+function deriveKey(salt: Buffer): Buffer {
+  const machineId = os.hostname() + os.userInfo().username;
+  return crypto.scryptSync(PASSPHRASE + machineId, salt, 32) as Buffer;
 }
 
-function encrypt(plaintext: string, key: Buffer): string {
-  const iv = crypto.randomBytes(12);
+function encrypt(plaintext: string): Buffer {
+  const salt = crypto.randomBytes(SALT_LENGTH);
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const key = deriveKey(salt);
   const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
   const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
-  const tag = cipher.getAuthTag();
-  // Format: iv(12) + tag(16) + ciphertext — all hex-encoded
-  return Buffer.concat([iv, tag, encrypted]).toString('hex');
+  const authTag = cipher.getAuthTag();
+  return Buffer.concat([salt, iv, authTag, encrypted]);
 }
 
-function decrypt(hexData: string, key: Buffer): string {
-  const data = Buffer.from(hexData, 'hex');
-  const iv = data.subarray(0, 12);
-  const tag = data.subarray(12, 28);
-  const ciphertext = data.subarray(28);
+function decrypt(data: Buffer): string {
+  if (data.length < SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH) {
+    throw new Error('Credential file is too short or corrupted');
+  }
+  const salt = data.subarray(0, SALT_LENGTH);
+  const iv = data.subarray(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
+  const authTag = data.subarray(SALT_LENGTH + IV_LENGTH, SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH);
+  const ciphertext = data.subarray(SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH);
+  const key = deriveKey(salt);
   const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
-  decipher.setAuthTag(tag);
+  decipher.setAuthTag(authTag);
   return decipher.update(ciphertext) + decipher.final('utf8');
 }
 
@@ -138,24 +144,37 @@ function getStoragePath(): string {
 
 interface TotpEntry {
   domain: string;
-  encryptedSecret: string;
+  secret: string;
   issuer?: string;
   addedAt: string;
+}
+
+interface TotpStore {
+  entries: TotpEntry[];
 }
 
 function readEntries(): TotpEntry[] {
   const storagePath = getStoragePath();
   if (!fs.existsSync(storagePath)) return [];
 
+  const data = fs.readFileSync(storagePath);
+  if (data.length === 0) return [];
+
+  let plaintext: string;
   try {
-    const raw = fs.readFileSync(storagePath, 'utf8').trim();
-    if (!raw) return [];
-    const key = deriveKey();
-    const plaintext = decrypt(raw, key);
-    return JSON.parse(plaintext) as TotpEntry[];
+    plaintext = decrypt(data);
   } catch {
-    return [];
+    throw new Error('Failed to decrypt credential store');
   }
+
+  let store: TotpStore;
+  try {
+    store = JSON.parse(plaintext) as TotpStore;
+  } catch {
+    throw new Error('Credential store corrupted');
+  }
+
+  return store.entries;
 }
 
 function writeEntries(entries: TotpEntry[]): void {
@@ -166,11 +185,10 @@ function writeEntries(entries: TotpEntry[]): void {
     fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
 
-  const key = deriveKey();
-  const plaintext = JSON.stringify(entries, null, 2);
-  const encrypted = encrypt(plaintext, key);
+  const plaintext = JSON.stringify({ entries });
+  const encrypted = encrypt(plaintext);
 
-  fs.writeFileSync(storagePath, encrypted, { encoding: 'utf8', mode: 0o600 });
+  fs.writeFileSync(storagePath, encrypted, { mode: 0o600 });
 }
 
 // ---------------------------------------------------------------------------
@@ -184,12 +202,9 @@ export async function addTotpSecret(domain: string, secret: string, issuer?: str
   const entries = readEntries();
   const idx = entries.findIndex((e) => e.domain === domain);
 
-  const key = deriveKey();
-  const encryptedSecret = encrypt(secret.toUpperCase().replace(/\s/g, ''), key);
-
   const entry: TotpEntry = {
     domain,
-    encryptedSecret,
+    secret: secret.toUpperCase().replace(/\s/g, ''),
     issuer,
     addedAt: new Date().toISOString(),
   };
@@ -231,12 +246,5 @@ export async function listTotpDomains(): Promise<Array<{ domain: string; issuer?
 export async function getTotpSecret(domain: string): Promise<string | null> {
   const entries = readEntries();
   const entry = entries.find((e) => e.domain === domain);
-  if (!entry) return null;
-
-  try {
-    const key = deriveKey();
-    return decrypt(entry.encryptedSecret, key);
-  } catch {
-    return null;
-  }
+  return entry?.secret ?? null;
 }

--- a/src/auth/adapters/bitwarden-adapter.ts
+++ b/src/auth/adapters/bitwarden-adapter.ts
@@ -66,6 +66,9 @@ export class BitwardenAdapter implements CredentialProvider {
   }
 
   async getCredentials(domain: string): Promise<Credentials | null> {
+    if (!/^[a-zA-Z0-9._\-]+$/.test(domain)) {
+      throw new Error(`Invalid domain format: "${domain}"`);
+    }
     const session = this.getSession();
 
     let stdout: string;

--- a/src/auth/adapters/bitwarden-adapter.ts
+++ b/src/auth/adapters/bitwarden-adapter.ts
@@ -1,0 +1,151 @@
+/**
+ * Bitwarden CLI credential adapter
+ * Uses the `bw` CLI binary to fetch credentials from Bitwarden vault
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import type { CredentialProvider, Credentials } from '../credential-provider';
+
+const CLI_TIMEOUT_MS = 10_000;
+
+type ExecFileAsync = (
+  cmd: string,
+  args: string[],
+  opts: { timeout: number }
+) => Promise<{ stdout: string; stderr: string }>;
+
+interface BwLoginField {
+  username?: string;
+  password?: string;
+  totp?: string;
+  uris?: Array<{ uri: string; match?: number | null }>;
+}
+
+interface BwItem {
+  id: string;
+  name: string;
+  type: number;
+  login?: BwLoginField;
+}
+
+function extractDomainFromUri(uri: string): string {
+  try {
+    return new URL(uri).hostname;
+  } catch {
+    return uri;
+  }
+}
+
+export class BitwardenAdapter implements CredentialProvider {
+  readonly name = 'bitwarden';
+
+  private readonly exec: ExecFileAsync;
+
+  constructor(exec?: ExecFileAsync) {
+    this.exec = exec ?? (promisify(execFile) as unknown as ExecFileAsync);
+  }
+
+  private getSession(): string {
+    const session = process.env.OPENCHROME_BITWARDEN_SESSION;
+    if (!session) {
+      throw new Error(
+        'Bitwarden session key not set. Run `bw unlock` and set OPENCHROME_BITWARDEN_SESSION.'
+      );
+    }
+    return session;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      await this.exec('bw', ['--version'], { timeout: CLI_TIMEOUT_MS });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getCredentials(domain: string): Promise<Credentials | null> {
+    const session = this.getSession();
+
+    let stdout: string;
+    try {
+      const result = await this.exec(
+        'bw',
+        ['get', 'item', domain, '--session', session],
+        { timeout: CLI_TIMEOUT_MS }
+      );
+      stdout = result.stdout;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      const lower = message.toLowerCase();
+
+      if (lower.includes('not found') || lower.includes('no items found')) {
+        return null;
+      }
+      if (
+        lower.includes('vault is locked') ||
+        lower.includes('session key is invalid') ||
+        lower.includes('not logged in') ||
+        lower.includes('you are not logged in')
+      ) {
+        throw new Error(
+          'Bitwarden vault is locked or session expired. Run `bw unlock` and update OPENCHROME_BITWARDEN_SESSION.'
+        );
+      }
+      throw new Error(`Bitwarden CLI error: ${message}`);
+    }
+
+    let item: BwItem;
+    try {
+      item = JSON.parse(stdout) as BwItem;
+    } catch {
+      throw new Error('Bitwarden returned invalid JSON');
+    }
+
+    const login = item.login ?? {};
+    return {
+      username: login.username ?? '',
+      password: login.password ?? '',
+      totpSecret: login.totp ?? undefined,
+    };
+  }
+
+  async listDomains(): Promise<string[]> {
+    const session = this.getSession();
+
+    let stdout: string;
+    try {
+      const result = await this.exec(
+        'bw',
+        ['list', 'items', '--session', session],
+        { timeout: CLI_TIMEOUT_MS }
+      );
+      stdout = result.stdout;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Bitwarden CLI error listing items: ${message}`);
+    }
+
+    let items: BwItem[];
+    try {
+      items = JSON.parse(stdout) as BwItem[];
+    } catch {
+      throw new Error('Bitwarden returned invalid JSON for item list');
+    }
+
+    const domains: string[] = [];
+    for (const item of items) {
+      const uris = item.login?.uris ?? [];
+      for (const uriObj of uris) {
+        if (uriObj.uri) {
+          const domain = extractDomainFromUri(uriObj.uri);
+          if (domain && !domains.includes(domain)) {
+            domains.push(domain);
+          }
+        }
+      }
+    }
+    return domains;
+  }
+}

--- a/src/auth/adapters/index.ts
+++ b/src/auth/adapters/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Re-exports for all credential provider adapters
+ */
+
+export { LocalAdapter } from './local-adapter';
+export { OnePasswordAdapter } from './onepassword-adapter';
+export { BitwardenAdapter } from './bitwarden-adapter';

--- a/src/auth/adapters/local-adapter.ts
+++ b/src/auth/adapters/local-adapter.ts
@@ -23,8 +23,11 @@ export class LocalAdapter implements CredentialProvider {
       // Dynamic import to avoid hard dependency until PR 1 lands
       try {
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const { CredentialStore } = require('../credential-store');
-        this.store = new CredentialStore();
+        const credentialStore = require('../credential-store');
+        this.store = {
+          getTotpSecret: credentialStore.getTotpSecret,
+          listTotpDomains: credentialStore.listTotpDomains,
+        };
       } catch {
         // credential-store not yet available — use no-op stub
         this.store = {

--- a/src/auth/adapters/local-adapter.ts
+++ b/src/auth/adapters/local-adapter.ts
@@ -1,0 +1,63 @@
+/**
+ * Local storage credential adapter
+ * Wraps the credential store from PR 1 (credential-store module)
+ */
+
+import type { CredentialProvider, Credentials } from '../credential-provider';
+
+// Stub interface — will use real credential-store when PR 1 lands
+interface CredentialStoreStub {
+  getTotpSecret(domain: string): Promise<string | null>;
+  listTotpDomains(): Promise<Array<{ domain: string; issuer?: string; addedAt: string }>>;
+}
+
+export class LocalAdapter implements CredentialProvider {
+  readonly name = 'local';
+
+  private store: CredentialStoreStub;
+
+  constructor(store?: CredentialStoreStub) {
+    if (store) {
+      this.store = store;
+    } else {
+      // Dynamic import to avoid hard dependency until PR 1 lands
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { CredentialStore } = require('../credential-store');
+        this.store = new CredentialStore();
+      } catch {
+        // credential-store not yet available — use no-op stub
+        this.store = {
+          getTotpSecret: async (_domain: string) => null,
+          listTotpDomains: async () => [],
+        };
+      }
+    }
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  /**
+   * Returns credentials from local store.
+   * Local store only holds TOTP secrets — username/password are not stored locally.
+   */
+  async getCredentials(domain: string): Promise<Credentials | null> {
+    const totpSecret = await this.store.getTotpSecret(domain);
+    if (totpSecret === null) {
+      return null;
+    }
+    // Local store does not hold username/password; provide empty strings as placeholders
+    return {
+      username: '',
+      password: '',
+      totpSecret,
+    };
+  }
+
+  async listDomains(): Promise<string[]> {
+    const entries = await this.store.listTotpDomains();
+    return entries.map((e) => e.domain);
+  }
+}

--- a/src/auth/adapters/onepassword-adapter.ts
+++ b/src/auth/adapters/onepassword-adapter.ts
@@ -68,6 +68,9 @@ export class OnePasswordAdapter implements CredentialProvider {
   }
 
   async getCredentials(domain: string): Promise<Credentials | null> {
+    if (!/^[a-zA-Z0-9._\-]+$/.test(domain)) {
+      throw new Error(`Invalid domain format: "${domain}"`);
+    }
     let stdout: string;
     try {
       const result = await this.exec(
@@ -111,12 +114,27 @@ export class OnePasswordAdapter implements CredentialProvider {
     const passwordField = fields.find(
       (f) => f.purpose === 'PASSWORD' || f.id === 'password'
     );
+    // OTP field: `value` contains the live TOTP code (6-digit), not the base32 seed.
+    // The `totp` field contains the otpauth:// URI with the actual secret.
     const otpField = fields.find((f) => f.type === 'OTP');
+    let totpSecret: string | undefined;
+    if (otpField) {
+      // Try to extract base32 secret from otpauth:// URI (e.g., otpauth://totp/...?secret=BASE32)
+      const totpUri = (otpField as Record<string, unknown>).totp as string | undefined;
+      if (totpUri) {
+        const secretMatch = totpUri.match(/[?&]secret=([A-Z2-7]+=*)/i);
+        if (secretMatch) totpSecret = secretMatch[1];
+      }
+      // Fallback: if value looks like a base32 string (not a 6-digit code), use it
+      if (!totpSecret && otpField.value && /^[A-Z2-7]+=*$/i.test(otpField.value) && otpField.value.length > 10) {
+        totpSecret = otpField.value;
+      }
+    }
 
     return {
       username: usernameField?.value ?? '',
       password: passwordField?.value ?? '',
-      totpSecret: otpField?.value,
+      totpSecret,
     };
   }
 

--- a/src/auth/adapters/onepassword-adapter.ts
+++ b/src/auth/adapters/onepassword-adapter.ts
@@ -1,0 +1,157 @@
+/**
+ * 1Password CLI credential adapter
+ * Uses the `op` CLI binary to fetch credentials from 1Password vaults
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import type { CredentialProvider, Credentials } from '../credential-provider';
+
+const CLI_TIMEOUT_MS = 10_000;
+
+type ExecFileAsync = (
+  cmd: string,
+  args: string[],
+  opts: { timeout: number }
+) => Promise<{ stdout: string; stderr: string }>;
+
+interface OpField {
+  id?: string;
+  label?: string;
+  purpose?: string;
+  type?: string;
+  value?: string;
+}
+
+interface OpItem {
+  id: string;
+  title: string;
+  fields?: OpField[];
+  urls?: Array<{ href: string; primary?: boolean }>;
+}
+
+interface OpListItem {
+  id: string;
+  title: string;
+  urls?: Array<{ href: string }>;
+}
+
+function extractDomainFromUrl(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+export class OnePasswordAdapter implements CredentialProvider {
+  readonly name = '1password';
+
+  private readonly exec: ExecFileAsync;
+
+  constructor(exec?: ExecFileAsync) {
+    this.exec = exec ?? (promisify(execFile) as unknown as ExecFileAsync);
+  }
+
+  private get vaultArgs(): string[] {
+    const vault = process.env.OPENCHROME_1PASSWORD_VAULT;
+    return vault ? ['--vault', vault] : [];
+  }
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      await this.exec('op', ['--version'], { timeout: CLI_TIMEOUT_MS });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getCredentials(domain: string): Promise<Credentials | null> {
+    let stdout: string;
+    try {
+      const result = await this.exec(
+        'op',
+        ['item', 'get', domain, '--format', 'json', ...this.vaultArgs],
+        { timeout: CLI_TIMEOUT_MS }
+      );
+      stdout = result.stdout;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      const lower = message.toLowerCase();
+
+      if (lower.includes('not found') || lower.includes("isn't an item")) {
+        return null;
+      }
+      if (
+        lower.includes('not signed in') ||
+        lower.includes('vault is locked') ||
+        lower.includes('authentication required') ||
+        lower.includes('please sign in')
+      ) {
+        throw new Error(
+          '1Password vault is locked or not signed in. Run `op signin` to authenticate.'
+        );
+      }
+      throw new Error(`1Password CLI error: ${message}`);
+    }
+
+    let item: OpItem;
+    try {
+      item = JSON.parse(stdout) as OpItem;
+    } catch {
+      throw new Error('1Password returned invalid JSON');
+    }
+
+    const fields = item.fields ?? [];
+
+    const usernameField = fields.find(
+      (f) => f.purpose === 'USERNAME' || f.id === 'username'
+    );
+    const passwordField = fields.find(
+      (f) => f.purpose === 'PASSWORD' || f.id === 'password'
+    );
+    const otpField = fields.find((f) => f.type === 'OTP');
+
+    return {
+      username: usernameField?.value ?? '',
+      password: passwordField?.value ?? '',
+      totpSecret: otpField?.value,
+    };
+  }
+
+  async listDomains(): Promise<string[]> {
+    let stdout: string;
+    try {
+      const result = await this.exec(
+        'op',
+        ['item', 'list', '--categories', 'Login', '--format', 'json', ...this.vaultArgs],
+        { timeout: CLI_TIMEOUT_MS }
+      );
+      stdout = result.stdout;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`1Password CLI error listing items: ${message}`);
+    }
+
+    let items: OpListItem[];
+    try {
+      items = JSON.parse(stdout) as OpListItem[];
+    } catch {
+      throw new Error('1Password returned invalid JSON for item list');
+    }
+
+    const domains: string[] = [];
+    for (const item of items) {
+      if (item.urls && item.urls.length > 0) {
+        for (const urlObj of item.urls) {
+          const domain = extractDomainFromUrl(urlObj.href);
+          if (domain && !domains.includes(domain)) {
+            domains.push(domain);
+          }
+        }
+      }
+    }
+    return domains;
+  }
+}

--- a/src/auth/credential-provider.ts
+++ b/src/auth/credential-provider.ts
@@ -1,0 +1,44 @@
+/**
+ * Credential provider interface and factory
+ * Supports local, 1Password, and Bitwarden credential stores
+ */
+
+export interface Credentials {
+  username: string;
+  password: string;
+  totpSecret?: string;
+}
+
+export interface CredentialProvider {
+  readonly name: string;
+  isAvailable(): Promise<boolean>;
+  getCredentials(domain: string): Promise<Credentials | null>;
+  listDomains(): Promise<string[]>;
+}
+
+/**
+ * Factory function that reads OPENCHROME_CREDENTIAL_PROVIDER env var
+ * and returns the appropriate credential provider adapter.
+ *
+ * Supported values: 'local' (default), '1password', 'bitwarden'
+ */
+export function getCredentialProvider(): CredentialProvider {
+  const providerName = process.env.OPENCHROME_CREDENTIAL_PROVIDER ?? 'local';
+
+  switch (providerName.toLowerCase()) {
+    case '1password':
+    case 'onepassword': {
+      const { OnePasswordAdapter } = require('./adapters/onepassword-adapter');
+      return new OnePasswordAdapter();
+    }
+    case 'bitwarden': {
+      const { BitwardenAdapter } = require('./adapters/bitwarden-adapter');
+      return new BitwardenAdapter();
+    }
+    case 'local':
+    default: {
+      const { LocalAdapter } = require('./adapters/local-adapter');
+      return new LocalAdapter();
+    }
+  }
+}

--- a/src/auth/credential-provider.ts
+++ b/src/auth/credential-provider.ts
@@ -3,6 +3,10 @@
  * Supports local, 1Password, and Bitwarden credential stores
  */
 
+import { OnePasswordAdapter } from './adapters/onepassword-adapter';
+import { BitwardenAdapter } from './adapters/bitwarden-adapter';
+import { LocalAdapter } from './adapters/local-adapter';
+
 export interface Credentials {
   username: string;
   password: string;
@@ -27,18 +31,12 @@ export function getCredentialProvider(): CredentialProvider {
 
   switch (providerName.toLowerCase()) {
     case '1password':
-    case 'onepassword': {
-      const { OnePasswordAdapter } = require('./adapters/onepassword-adapter');
+    case 'onepassword':
       return new OnePasswordAdapter();
-    }
-    case 'bitwarden': {
-      const { BitwardenAdapter } = require('./adapters/bitwarden-adapter');
+    case 'bitwarden':
       return new BitwardenAdapter();
-    }
     case 'local':
-    default: {
-      const { LocalAdapter } = require('./adapters/local-adapter');
+    default:
       return new LocalAdapter();
-    }
   }
 }

--- a/src/auth/credential-store.ts
+++ b/src/auth/credential-store.ts
@@ -46,7 +46,13 @@ function getLockPath(): string {
 // ---------------------------------------------------------------------------
 
 function getMachineId(): string {
-  return os.hostname() + os.userInfo().username;
+  let username = 'unknown';
+  try {
+    username = os.userInfo().username;
+  } catch {
+    username = process.env.USER ?? process.env.USERNAME ?? 'unknown';
+  }
+  return os.hostname() + username;
 }
 
 function deriveKey(passphrase: string, salt: Buffer): Buffer {
@@ -138,11 +144,22 @@ function writeStore(store: TotpStore, passphrase: string): void {
 // Passphrase resolution
 // ---------------------------------------------------------------------------
 
-// Default passphrase: machine-bound (no user input required for basic usage)
+// WARNING: The built-in default passphrase provides only obfuscation, not real
+// encryption. It is mixed with hostname + username via scrypt, but all components
+// are trivially discoverable on the local machine. For meaningful security, set
+// OPENCHROME_TOTP_PASSPHRASE to a strong user-supplied secret.
 const DEFAULT_PASSPHRASE = 'openchrome-totp-v1';
+let passphraseWarned = false;
 
 function resolvePassphrase(passphrase?: string): string {
-  return passphrase ?? DEFAULT_PASSPHRASE;
+  if (passphrase) return passphrase;
+  const envPassphrase = process.env.OPENCHROME_TOTP_PASSPHRASE;
+  if (envPassphrase) return envPassphrase;
+  if (!passphraseWarned) {
+    console.error('[credential-store] Using default passphrase (obfuscation only). Set OPENCHROME_TOTP_PASSPHRASE for stronger encryption.');
+    passphraseWarned = true;
+  }
+  return DEFAULT_PASSPHRASE;
 }
 
 // ---------------------------------------------------------------------------
@@ -170,8 +187,9 @@ export async function addTotpSecret(
 
   // Ensure lock file exists before locking
   const lockPath = getLockPath();
-  if (!fs.existsSync(lockPath)) {
-    fs.writeFileSync(lockPath, '', { mode: 0o600 });
+  const lockExists = await fs.promises.access(lockPath).then(() => true).catch(() => false);
+  if (!lockExists) {
+    await fs.promises.writeFile(lockPath, '', { mode: 0o600 });
   }
 
   const release = await lockfile.lock(lockPath, { retries: { retries: 5, minTimeout: 50 } });
@@ -203,11 +221,13 @@ export async function removeTotpSecret(domain: string, passphrase?: string): Pro
   const pp = resolvePassphrase(passphrase);
   ensureCredentialsDir();
   const storePath = getStorePath();
-  if (!fs.existsSync(storePath)) return false;
+  const storeExists = await fs.promises.access(storePath).then(() => true).catch(() => false);
+  if (!storeExists) return false;
 
   const lockPath = getLockPath();
-  if (!fs.existsSync(lockPath)) {
-    fs.writeFileSync(lockPath, '', { mode: 0o600 });
+  const lockExists = await fs.promises.access(lockPath).then(() => true).catch(() => false);
+  if (!lockExists) {
+    await fs.promises.writeFile(lockPath, '', { mode: 0o600 });
   }
 
   const release = await lockfile.lock(lockPath, { retries: { retries: 5, minTimeout: 50 } });
@@ -234,9 +254,10 @@ export async function listTotpDomains(
   const pp = resolvePassphrase(passphrase);
   ensureCredentialsDir();
   const storePath = getStorePath();
-  if (!fs.existsSync(storePath)) return [];
+  const storeExists = await fs.promises.access(storePath).then(() => true).catch(() => false);
+  if (!storeExists) return [];
 
-  const data = fs.readFileSync(storePath);
+  const data = await fs.promises.readFile(storePath);
   if (data.length === 0) return [];
 
   const store: TotpStore = JSON.parse(decrypt(data, pp));
@@ -251,9 +272,10 @@ export async function getTotpSecret(domain: string, passphrase?: string): Promis
   const pp = resolvePassphrase(passphrase);
   ensureCredentialsDir();
   const storePath = getStorePath();
-  if (!fs.existsSync(storePath)) return null;
+  const storeExists = await fs.promises.access(storePath).then(() => true).catch(() => false);
+  if (!storeExists) return null;
 
-  const data = fs.readFileSync(storePath);
+  const data = await fs.promises.readFile(storePath);
   if (data.length === 0) return null;
 
   const store: TotpStore = JSON.parse(decrypt(data, pp));

--- a/src/auth/credential-store.ts
+++ b/src/auth/credential-store.ts
@@ -1,0 +1,280 @@
+/**
+ * Credential Store - Encrypted TOTP secret storage
+ * Stores secrets in ~/.openchrome/credentials/totp-secrets.enc using AES-256-GCM
+ */
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import writeFileAtomic from 'write-file-atomic';
+import * as lockfile from 'proper-lockfile';
+import { validateBase32, generateTOTP } from './totp-manager';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface TotpEntry {
+  domain: string;
+  secret: string;
+  issuer?: string;
+  addedAt: string;
+}
+
+interface TotpStore {
+  entries: TotpEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// File paths
+// ---------------------------------------------------------------------------
+
+function getCredentialsDir(): string {
+  return path.join(os.homedir(), '.openchrome', 'credentials');
+}
+
+function getStorePath(): string {
+  return path.join(getCredentialsDir(), 'totp-secrets.enc');
+}
+
+function getLockPath(): string {
+  return getStorePath() + '.lock';
+}
+
+// ---------------------------------------------------------------------------
+// Key derivation
+// ---------------------------------------------------------------------------
+
+function getMachineId(): string {
+  return os.hostname() + os.userInfo().username;
+}
+
+function deriveKey(passphrase: string, salt: Buffer): Buffer {
+  const machineId = getMachineId();
+  return crypto.scryptSync(passphrase + machineId, salt, 32) as Buffer;
+}
+
+// ---------------------------------------------------------------------------
+// Encryption / Decryption
+// ---------------------------------------------------------------------------
+
+const SALT_LENGTH = 16;
+const IV_LENGTH = 16;
+const AUTH_TAG_LENGTH = 16;
+// File format: [salt(16)] [iv(16)] [authTag(16)] [ciphertext...]
+
+function encrypt(plaintext: string, passphrase: string): Buffer {
+  const salt = crypto.randomBytes(SALT_LENGTH);
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const key = deriveKey(passphrase, salt);
+
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return Buffer.concat([salt, iv, authTag, encrypted]);
+}
+
+function decrypt(data: Buffer, passphrase: string): string {
+  if (data.length < SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH) {
+    throw new Error('Credential file is too short or corrupted');
+  }
+
+  const salt = data.subarray(0, SALT_LENGTH);
+  const iv = data.subarray(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
+  const authTag = data.subarray(SALT_LENGTH + IV_LENGTH, SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH);
+  const ciphertext = data.subarray(SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH);
+
+  const key = deriveKey(passphrase, salt);
+
+  try {
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+    decipher.setAuthTag(authTag);
+    return decipher.update(ciphertext) + decipher.final('utf8');
+  } catch {
+    throw new Error('Failed to decrypt credentials: wrong passphrase or corrupted data');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Directory and file initialization
+// ---------------------------------------------------------------------------
+
+function ensureCredentialsDir(): void {
+  const dir = getCredentialsDir();
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+}
+
+function ensureStoreFileExists(storePath: string): void {
+  if (!fs.existsSync(storePath)) {
+    // Touch the file so proper-lockfile can lock it
+    fs.writeFileSync(storePath, Buffer.alloc(0), { mode: 0o600 });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Read / Write store (caller holds lock)
+// ---------------------------------------------------------------------------
+
+function readStore(passphrase: string): TotpStore {
+  const storePath = getStorePath();
+  const data = fs.readFileSync(storePath);
+  if (data.length === 0) {
+    return { entries: [] };
+  }
+  const json = decrypt(data, passphrase);
+  return JSON.parse(json) as TotpStore;
+}
+
+function writeStore(store: TotpStore, passphrase: string): void {
+  const storePath = getStorePath();
+  const json = JSON.stringify(store);
+  const encrypted = encrypt(json, passphrase);
+  // Use synchronous write via writeFileAtomic (sync variant)
+  writeFileAtomic.sync(storePath, encrypted, { mode: 0o600 });
+}
+
+// ---------------------------------------------------------------------------
+// Passphrase resolution
+// ---------------------------------------------------------------------------
+
+// Default passphrase: machine-bound (no user input required for basic usage)
+const DEFAULT_PASSPHRASE = 'openchrome-totp-v1';
+
+function resolvePassphrase(passphrase?: string): string {
+  return passphrase ?? DEFAULT_PASSPHRASE;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Add or update a TOTP secret for a domain.
+ * Throws if `secret` is not valid base32.
+ */
+export async function addTotpSecret(
+  domain: string,
+  secret: string,
+  issuer?: string,
+  passphrase?: string
+): Promise<void> {
+  if (!validateBase32(secret)) {
+    throw new Error(`Invalid base32 secret for domain "${domain}"`);
+  }
+
+  const pp = resolvePassphrase(passphrase);
+  ensureCredentialsDir();
+  const storePath = getStorePath();
+  ensureStoreFileExists(storePath);
+
+  // Ensure lock file exists before locking
+  const lockPath = getLockPath();
+  if (!fs.existsSync(lockPath)) {
+    fs.writeFileSync(lockPath, '', { mode: 0o600 });
+  }
+
+  const release = await lockfile.lock(lockPath, { retries: { retries: 5, minTimeout: 50 } });
+  try {
+    const store = readStore(pp);
+    const existing = store.entries.findIndex((e) => e.domain === domain);
+    const entry: TotpEntry = {
+      domain,
+      secret,
+      issuer,
+      addedAt: new Date().toISOString(),
+    };
+    if (existing >= 0) {
+      store.entries[existing] = entry;
+    } else {
+      store.entries.push(entry);
+    }
+    writeStore(store, pp);
+  } finally {
+    await release();
+  }
+}
+
+/**
+ * Remove a TOTP secret for a domain.
+ * Returns true if found and removed, false if not found.
+ */
+export async function removeTotpSecret(domain: string, passphrase?: string): Promise<boolean> {
+  const pp = resolvePassphrase(passphrase);
+  ensureCredentialsDir();
+  const storePath = getStorePath();
+  if (!fs.existsSync(storePath)) return false;
+
+  const lockPath = getLockPath();
+  if (!fs.existsSync(lockPath)) {
+    fs.writeFileSync(lockPath, '', { mode: 0o600 });
+  }
+
+  const release = await lockfile.lock(lockPath, { retries: { retries: 5, minTimeout: 50 } });
+  try {
+    const store = readStore(pp);
+    const before = store.entries.length;
+    store.entries = store.entries.filter((e) => e.domain !== domain);
+    const removed = store.entries.length < before;
+    if (removed) {
+      writeStore(store, pp);
+    }
+    return removed;
+  } finally {
+    await release();
+  }
+}
+
+/**
+ * List all stored domains with issuer and addedAt (secrets are NOT returned).
+ */
+export async function listTotpDomains(
+  passphrase?: string
+): Promise<Array<{ domain: string; issuer?: string; addedAt: string }>> {
+  const pp = resolvePassphrase(passphrase);
+  ensureCredentialsDir();
+  const storePath = getStorePath();
+  if (!fs.existsSync(storePath)) return [];
+
+  const data = fs.readFileSync(storePath);
+  if (data.length === 0) return [];
+
+  const store: TotpStore = JSON.parse(decrypt(data, pp));
+  return store.entries.map(({ domain, issuer, addedAt }) => ({ domain, issuer, addedAt }));
+}
+
+/**
+ * Retrieve the decrypted TOTP secret for a domain.
+ * Returns null if not found.
+ */
+export async function getTotpSecret(domain: string, passphrase?: string): Promise<string | null> {
+  const pp = resolvePassphrase(passphrase);
+  ensureCredentialsDir();
+  const storePath = getStorePath();
+  if (!fs.existsSync(storePath)) return null;
+
+  const data = fs.readFileSync(storePath);
+  if (data.length === 0) return null;
+
+  const store: TotpStore = JSON.parse(decrypt(data, pp));
+  const entry = store.entries.find((e) => e.domain === domain);
+  return entry?.secret ?? null;
+}
+
+/**
+ * Convenience: retrieve the TOTP secret for a domain and generate the current code.
+ * Returns null if the domain is not found.
+ */
+export async function generateTotpForDomain(
+  domain: string,
+  passphrase?: string
+): Promise<string | null> {
+  const secret = await getTotpSecret(domain, passphrase);
+  if (secret === null) return null;
+  try {
+    return generateTOTP(secret);
+  } catch (err) {
+    console.error(`[credential-store] Failed to generate TOTP for "${domain}":`, err);
+    return null;
+  }
+}

--- a/src/auth/totp-manager.ts
+++ b/src/auth/totp-manager.ts
@@ -1,0 +1,117 @@
+/**
+ * TOTP Manager - RFC 6238 Time-Based One-Time Password generation
+ * Uses Node.js built-in crypto module only (no external dependencies)
+ */
+import * as crypto from 'crypto';
+
+const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+/**
+ * Validate that a string is a valid base32-encoded secret
+ */
+export function validateBase32(secret: string): boolean {
+  if (!secret || secret.length === 0) return false;
+  // Remove padding and whitespace, uppercase
+  const normalized = secret.toUpperCase().replace(/\s/g, '').replace(/=+$/, '');
+  if (normalized.length === 0) return false;
+  return /^[A-Z2-7]+$/.test(normalized);
+}
+
+/**
+ * Decode a base32-encoded string to a Buffer
+ */
+export function base32Decode(encoded: string): Buffer {
+  const normalized = encoded.toUpperCase().replace(/\s/g, '').replace(/=+$/, '');
+  let bits = 0;
+  let value = 0;
+  const output: number[] = [];
+
+  for (let i = 0; i < normalized.length; i++) {
+    const charIndex = BASE32_ALPHABET.indexOf(normalized[i]);
+    if (charIndex === -1) {
+      throw new Error(`Invalid base32 character: ${normalized[i]}`);
+    }
+    // Accumulate 5 bits per base32 character
+    value = (value << 5) | charIndex;
+    bits += 5;
+    if (bits >= 8) {
+      bits -= 8;
+      output.push((value >> bits) & 0xff);
+    }
+  }
+
+  return Buffer.from(output);
+}
+
+/**
+ * Compute HMAC digest
+ */
+export function hmacDigest(algorithm: string, key: Buffer, counter: Buffer): Buffer {
+  const hmac = crypto.createHmac(algorithm.toLowerCase(), key);
+  hmac.update(counter);
+  return hmac.digest();
+}
+
+/**
+ * RFC 4226 dynamic truncation: extract a 31-bit integer from HMAC output
+ */
+export function dynamicTruncation(hmac: Buffer): number {
+  // Use the last nibble as the offset
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  // Extract 4 bytes at that offset, mask the most significant bit
+  return (
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff)
+  );
+}
+
+export interface TOTPOptions {
+  /** Time step in seconds (default: 30) */
+  period?: number;
+  /** Number of digits in the OTP (default: 6) */
+  digits?: number;
+  /** HMAC algorithm (default: 'sha1') */
+  algorithm?: string;
+  /** Time offset in steps for clock drift correction (e.g. -1, 0, 1) */
+  timeOffset?: number;
+}
+
+/**
+ * Generate a TOTP code from a base32-encoded secret (RFC 6238)
+ *
+ * @param secret - base32-encoded TOTP secret
+ * @param options - optional overrides for period, digits, algorithm, timeOffset
+ * @returns zero-padded OTP string of length `digits`
+ */
+export function generateTOTP(secret: string, options?: TOTPOptions): string {
+  const period = options?.period ?? 30;
+  const digits = options?.digits ?? 6;
+  const algorithm = options?.algorithm ?? 'sha1';
+  const timeOffset = options?.timeOffset ?? 0;
+
+  // Decode base32 secret to raw key bytes
+  const key = base32Decode(secret);
+
+  // Compute the time step counter (T0 = Unix epoch, T = floor(now / period))
+  const timeStep = Math.floor(Date.now() / 1000 / period) + timeOffset;
+
+  // Encode counter as big-endian 8-byte buffer
+  const counter = Buffer.alloc(8);
+  // JavaScript bitwise ops are 32-bit, handle high/low words separately
+  const high = Math.floor(timeStep / 0x100000000);
+  const low = timeStep >>> 0;
+  counter.writeUInt32BE(high, 0);
+  counter.writeUInt32BE(low, 4);
+
+  // Compute HMAC
+  const hmac = hmacDigest(algorithm, key, counter);
+
+  // Dynamic truncation
+  const truncated = dynamicTruncation(hmac);
+
+  // Compute OTP: truncated mod 10^digits, zero-padded
+  const otp = truncated % Math.pow(10, digits);
+  return otp.toString().padStart(digits, '0');
+}

--- a/src/auth/twofa-detector.ts
+++ b/src/auth/twofa-detector.ts
@@ -1,0 +1,340 @@
+/**
+ * 2FA Detection Engine - Detects and classifies 2FA challenges on web pages
+ */
+
+export enum TwoFAType {
+  TOTP = 'totp',
+  SMS = 'sms',
+  EMAIL = 'email',
+  PUSH = 'push',
+  RECOVERY = 'recovery',
+  UNKNOWN = 'unknown',
+}
+
+export interface TwoFADetectionResult {
+  detected: boolean;
+  type: TwoFAType;
+  confidence: number;      // 0-1
+  inputSelector?: string;  // CSS selector for the input field
+  submitSelector?: string; // CSS selector for submit button
+  hints: string[];         // Human-readable hints about what was detected
+}
+
+/** Signals gathered from the page DOM for classification */
+interface PageSignals {
+  pageText: string;
+  inputSelector?: string;
+  inputAttributes?: Record<string, string>;
+  submitSelector?: string;
+}
+
+/**
+ * Classify 2FA type from page text and optional input attributes.
+ * Priority: TOTP > SMS > Email > Push > Recovery > Unknown
+ */
+export function classifyTwoFAType(
+  pageText: string,
+  inputAttributes?: Record<string, string>,
+): TwoFAType {
+  const text = pageText.toLowerCase();
+
+  // TOTP indicators (highest priority)
+  const totpTextIndicators = [
+    'authenticator',
+    'verification code',
+    '6-digit code',
+    'two-factor',
+    '2fa',
+    'totp',
+    'enter code from your',
+  ];
+  const hasTotpText = totpTextIndicators.some((indicator) => text.includes(indicator));
+  const hasSixDigitInput =
+    inputAttributes &&
+    (inputAttributes.maxlength === '6' ||
+      inputAttributes.pattern === '[0-9]{6}' ||
+      (inputAttributes.type === 'number' && inputAttributes.maxlength === '6'));
+
+  if (hasTotpText && hasSixDigitInput) {
+    return TwoFAType.TOTP;
+  }
+  if (hasTotpText) {
+    return TwoFAType.TOTP;
+  }
+
+  // SMS indicators
+  const smsTextIndicators = [
+    'text message',
+    'sms',
+    'sent to your phone',
+    'phone number',
+    'mobile',
+  ];
+  const hasSmsText = smsTextIndicators.some((indicator) => text.includes(indicator));
+  // Phone number masking pattern: ***-***-1234
+  const hasMaskedPhone = /\*+[-.\s]?\*+[-.\s]?\d{4}/.test(pageText);
+
+  if (hasSmsText || hasMaskedPhone) {
+    return TwoFAType.SMS;
+  }
+
+  // Email indicators
+  const emailTextIndicators = [
+    'check your email',
+    'email verification',
+    'sent to your email',
+    'verify your email',
+  ];
+  const hasEmailText = emailTextIndicators.some((indicator) => text.includes(indicator));
+  // Email masking pattern: j***@gmail.com
+  const hasMaskedEmail = /[a-z]\*+@[a-z]+\.[a-z]+/.test(pageText.toLowerCase());
+
+  if (hasEmailText || hasMaskedEmail) {
+    return TwoFAType.EMAIL;
+  }
+
+  // Push indicators
+  const pushTextIndicators = [
+    'approve on your device',
+    'push notification',
+    'open your app to approve',
+    'check your phone',
+    'tap approve',
+  ];
+  const hasPushText = pushTextIndicators.some((indicator) => text.includes(indicator));
+
+  if (hasPushText) {
+    return TwoFAType.PUSH;
+  }
+
+  // Recovery code indicators
+  const recoveryTextIndicators = [
+    'backup code',
+    'recovery code',
+    'use a recovery code',
+  ];
+  const hasRecoveryText = recoveryTextIndicators.some((indicator) => text.includes(indicator));
+
+  if (hasRecoveryText) {
+    return TwoFAType.RECOVERY;
+  }
+
+  return TwoFAType.UNKNOWN;
+}
+
+/**
+ * Compute confidence score for a 2FA detection result based on signals.
+ */
+function computeConfidence(
+  type: TwoFAType,
+  signals: PageSignals,
+): number {
+  if (type === TwoFAType.UNKNOWN) {
+    return 0;
+  }
+
+  let score = 0.3; // base score for non-unknown type
+
+  const text = signals.pageText.toLowerCase();
+
+  if (type === TwoFAType.TOTP) {
+    if (text.includes('authenticator')) score += 0.4;
+    if (signals.inputAttributes?.maxlength === '6') score += 0.3;
+    if (text.includes('6-digit')) score += 0.1;
+    if (text.includes('two-factor') || text.includes('2fa')) score += 0.1;
+  } else if (type === TwoFAType.SMS) {
+    if (text.includes('sms') || text.includes('text message')) score += 0.3;
+    if (/\*+[-.\s]?\*+[-.\s]?\d{4}/.test(signals.pageText)) score += 0.3;
+    if (signals.inputAttributes?.maxlength === '6') score += 0.1;
+  } else if (type === TwoFAType.EMAIL) {
+    if (text.includes('check your email')) score += 0.3;
+    if (/[a-z]\*+@[a-z]+\.[a-z]+/.test(signals.pageText.toLowerCase())) score += 0.3;
+    if (signals.inputAttributes) score += 0.1;
+  } else if (type === TwoFAType.PUSH) {
+    if (text.includes('approve on your device')) score += 0.4;
+    if (text.includes('push notification')) score += 0.2;
+    if (!signals.inputSelector) score += 0.1; // push typically has no input
+  } else if (type === TwoFAType.RECOVERY) {
+    if (text.includes('backup code') || text.includes('recovery code')) score += 0.4;
+    if (signals.inputAttributes) score += 0.1;
+  }
+
+  return Math.min(1, score);
+}
+
+/**
+ * Build human-readable hints from signals and detected type.
+ */
+function buildHints(type: TwoFAType, signals: PageSignals): string[] {
+  const hints: string[] = [];
+
+  switch (type) {
+    case TwoFAType.TOTP:
+      hints.push('TOTP authenticator code required');
+      if (signals.inputAttributes?.maxlength === '6') {
+        hints.push('6-digit input field detected');
+      }
+      if (signals.inputSelector) {
+        hints.push(`Input field: ${signals.inputSelector}`);
+      }
+      break;
+    case TwoFAType.SMS:
+      hints.push('SMS verification code required');
+      {
+        const phoneMatch = signals.pageText.match(/\*+[-.\s]?\*+[-.\s]?\d{4}/);
+        if (phoneMatch) hints.push(`Phone pattern detected: ${phoneMatch[0]}`);
+      }
+      break;
+    case TwoFAType.EMAIL:
+      hints.push('Email verification code required');
+      {
+        const emailMatch = signals.pageText.toLowerCase().match(/[a-z]\*+@[a-z]+\.[a-z]+/);
+        if (emailMatch) hints.push(`Email pattern detected: ${emailMatch[0]}`);
+      }
+      break;
+    case TwoFAType.PUSH:
+      hints.push('Push notification approval required — check your device');
+      if (!signals.inputSelector) {
+        hints.push('No input field detected (push approval only)');
+      }
+      break;
+    case TwoFAType.RECOVERY:
+      hints.push('Recovery/backup code required');
+      break;
+    case TwoFAType.UNKNOWN:
+      hints.push('2FA page detected but type could not be classified');
+      break;
+  }
+
+  return hints;
+}
+
+/**
+ * Detect whether the current page presents a 2FA challenge.
+ * Runs detection logic inside the page via page.evaluate().
+ */
+export async function detectTwoFA(page: any): Promise<TwoFADetectionResult> {
+  let signals: PageSignals;
+
+  try {
+    signals = await page.evaluate(() => {
+      const bodyText = document.body?.innerText || '';
+
+      // Find candidate input fields for 2FA codes
+      let inputSelector: string | undefined;
+      let inputAttributes: Record<string, string> | undefined;
+
+      // Look for numeric/text inputs that could be 2FA code fields
+      const inputs = Array.from(
+        document.querySelectorAll<HTMLInputElement>('input[type="text"], input[type="number"], input[type="tel"], input'),
+      );
+
+      for (const input of inputs) {
+        const maxlength = input.getAttribute('maxlength');
+        const pattern = input.getAttribute('pattern');
+        const autocomplete = input.getAttribute('autocomplete');
+        const name = input.getAttribute('name') || '';
+        const id = input.getAttribute('id') || '';
+        const placeholder = input.getAttribute('placeholder') || '';
+
+        // Skip hidden/password inputs
+        if (input.type === 'hidden' || input.type === 'password' || input.type === 'email') {
+          continue;
+        }
+
+        // High-signal: OTP autocomplete, or 6-digit maxlength, or OTP-named field
+        const isOtpInput =
+          autocomplete === 'one-time-code' ||
+          maxlength === '6' ||
+          /otp|2fa|token|code|pin/i.test(name) ||
+          /otp|2fa|token|code|pin/i.test(id) ||
+          /otp|2fa|token|code|pin/i.test(placeholder) ||
+          pattern === '[0-9]{6}';
+
+        if (isOtpInput) {
+          // Build a reliable CSS selector
+          if (id) {
+            inputSelector = `#${CSS.escape(id)}`;
+          } else if (name) {
+            inputSelector = `input[name="${CSS.escape(name)}"]`;
+          } else {
+            inputSelector = 'input[maxlength="6"]';
+          }
+
+          inputAttributes = {
+            type: input.type || 'text',
+            maxlength: maxlength || '',
+            pattern: pattern || '',
+            autocomplete: autocomplete || '',
+            name,
+            id,
+            placeholder,
+          };
+          break;
+        }
+      }
+
+      // Find submit button
+      let submitSelector: string | undefined;
+      const buttons = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          'button[type="submit"], input[type="submit"], button',
+        ),
+      );
+      for (const btn of buttons) {
+        const inputVal = (btn as HTMLInputElement).value;
+        const btnText = (btn.innerText || (inputVal ? inputVal : '') || '').toLowerCase();
+        if (
+          btnText.includes('verify') ||
+          btnText.includes('submit') ||
+          btnText.includes('confirm') ||
+          btnText.includes('continue') ||
+          btnText.includes('next')
+        ) {
+          const btnId = btn.getAttribute('id');
+          const btnType = btn.getAttribute('type');
+          submitSelector = btnId
+            ? `#${CSS.escape(btnId)}`
+            : btnType === 'submit'
+              ? 'button[type="submit"]'
+              : 'button';
+          break;
+        }
+      }
+
+      return { pageText: bodyText, inputSelector, inputAttributes, submitSelector };
+    });
+  } catch (err) {
+    console.error('[twofa-detector] page.evaluate failed:', err instanceof Error ? err.message : err);
+    return {
+      detected: false,
+      type: TwoFAType.UNKNOWN,
+      confidence: 0,
+      hints: ['Detection failed: could not access page content'],
+    };
+  }
+
+  const type = classifyTwoFAType(signals.pageText, signals.inputAttributes);
+
+  // Not detected if type is unknown and no input selector found
+  if (type === TwoFAType.UNKNOWN && !signals.inputSelector) {
+    return {
+      detected: false,
+      type: TwoFAType.UNKNOWN,
+      confidence: 0,
+      hints: [],
+    };
+  }
+
+  const confidence = computeConfidence(type, signals);
+  const hints = buildHints(type, signals);
+
+  return {
+    detected: type !== TwoFAType.UNKNOWN || confidence > 0,
+    type,
+    confidence,
+    inputSelector: signals.inputSelector,
+    submitSelector: signals.submitSelector,
+    hints,
+  };
+}

--- a/src/auth/twofa-handler.ts
+++ b/src/auth/twofa-handler.ts
@@ -1,0 +1,280 @@
+/**
+ * 2FA Auto-Handling Logic - Handles 2FA challenges detected on pages
+ */
+
+import { TwoFAType, TwoFADetectionResult } from './twofa-detector';
+
+/** Minimal interface for a credential provider (stub for standalone compilation) */
+interface CredentialProvider {
+  getTOTPSecret(domain: string): Promise<string | undefined>;
+}
+
+export interface TwoFAHandlerOptions {
+  credentialProvider?: CredentialProvider;
+  domain: string;
+  maxRetries?: number;  // Default: 3
+  timeoutMs?: number;   // Default: 30000
+}
+
+export interface TwoFAHandlerResult {
+  handled: boolean;
+  type: TwoFAType;
+  method: 'auto-fill' | 'manual-hint' | 'timeout' | 'not-detected';
+  message: string;
+}
+
+/**
+ * Generate a TOTP code from a base32 secret.
+ * Implements RFC 6238 (TOTP) over RFC 4226 (HOTP).
+ */
+function generateTOTPCode(secret: string, offsetSeconds = 0): string {
+  const base32Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  const cleanSecret = secret.toUpperCase().replace(/[^A-Z2-7]/g, '');
+
+  // Decode base32
+  let bits = '';
+  for (const char of cleanSecret) {
+    const val = base32Chars.indexOf(char);
+    if (val === -1) continue;
+    bits += val.toString(2).padStart(5, '0');
+  }
+
+  const bytes = new Uint8Array(Math.floor(bits.length / 8));
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(bits.slice(i * 8, i * 8 + 8), 2);
+  }
+
+  // Time step (30s intervals)
+  const timeStep = Math.floor((Date.now() / 1000 + offsetSeconds) / 30);
+
+  // Pack time step as 8-byte big-endian
+  const timeBytes = new Uint8Array(8);
+  let t = timeStep;
+  for (let i = 7; i >= 0; i--) {
+    timeBytes[i] = t & 0xff;
+    t = Math.floor(t / 256);
+  }
+
+  // HMAC-SHA1 using Node.js crypto
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const crypto = require('crypto') as typeof import('crypto');
+  const hmac = crypto.createHmac('sha1', Buffer.from(bytes));
+  hmac.update(Buffer.from(timeBytes));
+  const digest = hmac.digest();
+
+  // Dynamic truncation
+  const offset = digest[digest.length - 1] & 0x0f;
+  const code =
+    (((digest[offset] & 0x7f) << 24) |
+      ((digest[offset + 1] & 0xff) << 16) |
+      ((digest[offset + 2] & 0xff) << 8) |
+      (digest[offset + 3] & 0xff)) %
+    1000000;
+
+  return code.toString().padStart(6, '0');
+}
+
+/**
+ * Wait for page URL or content to change (indicates 2FA success).
+ */
+async function waitForPageChange(
+  page: any,
+  originalUrl: string,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  const pollIntervalMs = 500;
+
+  while (Date.now() < deadline) {
+    try {
+      const currentUrl = page.url();
+      if (currentUrl !== originalUrl) {
+        return true;
+      }
+    } catch {
+      // Page may have navigated away (frame detached)
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  return false;
+}
+
+/**
+ * Fill and submit a 2FA input field on the page.
+ */
+async function fillAndSubmit(
+  page: any,
+  inputSelector: string,
+  submitSelector: string | undefined,
+  code: string,
+): Promise<void> {
+  await page.click(inputSelector);
+  await page.evaluate(
+    (selector: string) => {
+      const el = document.querySelector<HTMLInputElement>(selector);
+      if (el) el.value = '';
+    },
+    inputSelector,
+  );
+  await page.type(inputSelector, code);
+
+  if (submitSelector) {
+    try {
+      await page.click(submitSelector);
+    } catch {
+      // Fall back to pressing Enter on the input
+      await page.keyboard.press('Enter');
+    }
+  } else {
+    await page.keyboard.press('Enter');
+  }
+}
+
+/**
+ * Handle a detected 2FA challenge.
+ * Returns a result indicating how the 2FA was handled.
+ */
+export async function handleTwoFA(
+  page: any,
+  detection: TwoFADetectionResult,
+  options: TwoFAHandlerOptions,
+): Promise<TwoFAHandlerResult> {
+  const { domain, credentialProvider, maxRetries = 3, timeoutMs = 30000 } = options;
+
+  if (!detection.detected) {
+    return {
+      handled: false,
+      type: TwoFAType.UNKNOWN,
+      method: 'not-detected',
+      message: 'No 2FA challenge detected',
+    };
+  }
+
+  switch (detection.type) {
+    case TwoFAType.TOTP: {
+      // Try to auto-fill if a credential provider is available
+      if (credentialProvider && detection.inputSelector) {
+        const secret = await credentialProvider.getTOTPSecret(domain);
+        if (secret) {
+          const originalUrl = page.url();
+          let filled = false;
+
+          for (let attempt = 0; attempt < maxRetries; attempt++) {
+            // On retries, apply ±30s offset for clock drift
+            const offsets = [0, 30, -30];
+            const offsetSeconds = offsets[attempt] || 0;
+
+            try {
+              const code = generateTOTPCode(secret, offsetSeconds);
+              await fillAndSubmit(
+                page,
+                detection.inputSelector,
+                detection.submitSelector,
+                code,
+              );
+
+              // Wait briefly and check if page changed
+              const changed = await waitForPageChange(page, originalUrl, 3000);
+              if (changed) {
+                filled = true;
+                break;
+              }
+            } catch (err) {
+              console.error(
+                `[twofa-handler] TOTP fill attempt ${attempt + 1} failed:`,
+                err instanceof Error ? err.message : err,
+              );
+            }
+          }
+
+          if (filled) {
+            return {
+              handled: true,
+              type: TwoFAType.TOTP,
+              method: 'auto-fill',
+              message: `TOTP code automatically filled for ${domain}`,
+            };
+          }
+
+          return {
+            handled: false,
+            type: TwoFAType.TOTP,
+            method: 'manual-hint',
+            message: `TOTP fill failed after ${maxRetries} attempts for ${domain}. Please verify the TOTP secret is correct.`,
+          };
+        }
+      }
+
+      // No secret available — provide setup instructions
+      return {
+        handled: false,
+        type: TwoFAType.TOTP,
+        method: 'manual-hint',
+        message: `TOTP code required for ${domain}. Configure via: npx openchrome totp add --domain ${domain} --secret <base32>`,
+      };
+    }
+
+    case TwoFAType.SMS: {
+      const pageText = await page.evaluate(() => document.body?.innerText || '').catch(() => '');
+      const phoneMatch = pageText.match(/\*+[-.\s]?\*+[-.\s]?\d{4}/);
+      const phoneHint = phoneMatch ? ` Code sent to ${phoneMatch[0]}.` : '';
+      return {
+        handled: false,
+        type: TwoFAType.SMS,
+        method: 'manual-hint',
+        message: `SMS 2FA detected.${phoneHint} Manual input required.`,
+      };
+    }
+
+    case TwoFAType.EMAIL: {
+      return {
+        handled: false,
+        type: TwoFAType.EMAIL,
+        method: 'manual-hint',
+        message: 'Email 2FA detected. Check your email for verification code.',
+      };
+    }
+
+    case TwoFAType.PUSH: {
+      // Wait for page change (user approves on device)
+      const originalUrl = page.url();
+      const changed = await waitForPageChange(page, originalUrl, timeoutMs);
+
+      if (changed) {
+        return {
+          handled: true,
+          type: TwoFAType.PUSH,
+          method: 'auto-fill',
+          message: `Push notification approved — page changed for ${domain}`,
+        };
+      }
+
+      return {
+        handled: false,
+        type: TwoFAType.PUSH,
+        method: 'timeout',
+        message: `Push 2FA timed out after ${timeoutMs}ms. Open your authentication app and approve the request.`,
+      };
+    }
+
+    case TwoFAType.RECOVERY: {
+      return {
+        handled: false,
+        type: TwoFAType.RECOVERY,
+        method: 'manual-hint',
+        message: 'Recovery code required. Use stored recovery codes.',
+      };
+    }
+
+    default: {
+      return {
+        handled: false,
+        type: TwoFAType.UNKNOWN,
+        method: 'manual-hint',
+        message: `Unknown 2FA type detected on ${domain}. Manual intervention required.`,
+      };
+    }
+  }
+}

--- a/src/auth/twofa-handler.ts
+++ b/src/auth/twofa-handler.ts
@@ -3,10 +3,14 @@
  */
 
 import { TwoFAType, TwoFADetectionResult } from './twofa-detector';
+import { generateTOTP } from './totp-manager';
 
-/** Minimal interface for a credential provider (stub for standalone compilation) */
+/**
+ * Minimal credential provider interface compatible with PR #582's shape.
+ * When credential-provider.ts lands, this can be replaced with an import.
+ */
 interface CredentialProvider {
-  getTOTPSecret(domain: string): Promise<string | undefined>;
+  getCredentials(domain: string): Promise<{ totpSecret?: string } | null>;
 }
 
 export interface TwoFAHandlerOptions {
@@ -21,57 +25,6 @@ export interface TwoFAHandlerResult {
   type: TwoFAType;
   method: 'auto-fill' | 'manual-hint' | 'timeout' | 'not-detected';
   message: string;
-}
-
-/**
- * Generate a TOTP code from a base32 secret.
- * Implements RFC 6238 (TOTP) over RFC 4226 (HOTP).
- */
-function generateTOTPCode(secret: string, offsetSeconds = 0): string {
-  const base32Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
-  const cleanSecret = secret.toUpperCase().replace(/[^A-Z2-7]/g, '');
-
-  // Decode base32
-  let bits = '';
-  for (const char of cleanSecret) {
-    const val = base32Chars.indexOf(char);
-    if (val === -1) continue;
-    bits += val.toString(2).padStart(5, '0');
-  }
-
-  const bytes = new Uint8Array(Math.floor(bits.length / 8));
-  for (let i = 0; i < bytes.length; i++) {
-    bytes[i] = parseInt(bits.slice(i * 8, i * 8 + 8), 2);
-  }
-
-  // Time step (30s intervals)
-  const timeStep = Math.floor((Date.now() / 1000 + offsetSeconds) / 30);
-
-  // Pack time step as 8-byte big-endian
-  const timeBytes = new Uint8Array(8);
-  let t = timeStep;
-  for (let i = 7; i >= 0; i--) {
-    timeBytes[i] = t & 0xff;
-    t = Math.floor(t / 256);
-  }
-
-  // HMAC-SHA1 using Node.js crypto
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const crypto = require('crypto') as typeof import('crypto');
-  const hmac = crypto.createHmac('sha1', Buffer.from(bytes));
-  hmac.update(Buffer.from(timeBytes));
-  const digest = hmac.digest();
-
-  // Dynamic truncation
-  const offset = digest[digest.length - 1] & 0x0f;
-  const code =
-    (((digest[offset] & 0x7f) << 24) |
-      ((digest[offset + 1] & 0xff) << 16) |
-      ((digest[offset + 2] & 0xff) << 8) |
-      (digest[offset + 3] & 0xff)) %
-    1000000;
-
-  return code.toString().padStart(6, '0');
 }
 
 /**
@@ -156,18 +109,19 @@ export async function handleTwoFA(
     case TwoFAType.TOTP: {
       // Try to auto-fill if a credential provider is available
       if (credentialProvider && detection.inputSelector) {
-        const secret = await credentialProvider.getTOTPSecret(domain);
+        const credentials = await credentialProvider.getCredentials(domain);
+        const secret = credentials?.totpSecret;
         if (secret) {
           const originalUrl = page.url();
           let filled = false;
 
           for (let attempt = 0; attempt < maxRetries; attempt++) {
-            // On retries, apply ±30s offset for clock drift
-            const offsets = [0, 30, -30];
-            const offsetSeconds = offsets[attempt] || 0;
+            // On retries, apply ±1 step offset for clock drift
+            const stepOffsets = [0, 1, -1];
+            const timeOffset = stepOffsets[attempt] || 0;
 
             try {
-              const code = generateTOTPCode(secret, offsetSeconds);
+              const code = generateTOTP(secret, { timeOffset });
               await fillAndSubmit(
                 page,
                 detection.inputSelector,

--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -43,6 +43,7 @@ export const TOOL_TIERS: Record<string, ToolTier> = {
 
   // Tier 2: Specialist (on demand)
   extract_data: 2,              // src/tools/extract-data.ts — structured extraction (#571)
+  oc_totp_generate: 2,
   drag_drop: 2,
   network: 2,
   request_intercept: 2,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -90,6 +90,9 @@ import { registerActTool } from './act';
 // Structured extraction (#571)
 import { registerExtractDataTool } from './extract-data';
 
+// 2FA tools (#575)
+import { registerTotpGenerateTool } from './totp-generate';
+
 export function registerAllTools(server: MCPServer): void {
   // Core browser tools
   registerNavigateTool(server);
@@ -183,6 +186,9 @@ export function registerAllTools(server: MCPServer): void {
 
   // Structured extraction (#571)
   registerExtractDataTool(server);
+
+  // 2FA tools (#575)
+  registerTotpGenerateTool(server);
 
   console.error(`[Tools] Registered ${server.getToolNames().length} tools`);
 }

--- a/src/tools/totp-generate.ts
+++ b/src/tools/totp-generate.ts
@@ -2,7 +2,7 @@
  * TOTP Generate Tool - Generate current TOTP 2FA codes for configured domains
  */
 
-import * as crypto from 'crypto';
+import { generateTOTP } from '../auth/totp-manager';
 import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 
@@ -23,73 +23,18 @@ const definition: MCPToolDefinition = {
 };
 
 /**
- * Generate a TOTP code from a base32-encoded secret.
- * Implements RFC 6238 (TOTP) using HMAC-SHA1 per RFC 4226 (HOTP).
- * Returns the 6-digit code and seconds remaining in the current 30s period.
- */
-function generateTOTPCode(secret: string): { code: string; secondsRemaining: number } {
-  const base32Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
-  const cleanSecret = secret.toUpperCase().replace(/[^A-Z2-7]/g, '');
-
-  // Decode base32 to bytes
-  let bits = '';
-  for (const char of cleanSecret) {
-    const val = base32Chars.indexOf(char);
-    if (val === -1) continue;
-    bits += val.toString(2).padStart(5, '0');
-  }
-
-  const keyBytes = Buffer.alloc(Math.floor(bits.length / 8));
-  for (let i = 0; i < keyBytes.length; i++) {
-    keyBytes[i] = parseInt(bits.slice(i * 8, i * 8 + 8), 2);
-  }
-
-  // Current time step (30-second intervals)
-  const nowSeconds = Math.floor(Date.now() / 1000);
-  const timeStep = Math.floor(nowSeconds / 30);
-  const secondsRemaining = 30 - (nowSeconds % 30);
-
-  // Pack time step as 8-byte big-endian buffer
-  const timeBuffer = Buffer.alloc(8);
-  let t = timeStep;
-  for (let i = 7; i >= 0; i--) {
-    timeBuffer[i] = t & 0xff;
-    t = Math.floor(t / 256);
-  }
-
-  // HMAC-SHA1
-  const hmac = crypto.createHmac('sha1', keyBytes);
-  hmac.update(timeBuffer);
-  const digest = hmac.digest();
-
-  // Dynamic truncation (RFC 4226 §5.3)
-  const offset = digest[digest.length - 1] & 0x0f;
-  const code =
-    (((digest[offset] & 0x7f) << 24) |
-      ((digest[offset + 1] & 0xff) << 16) |
-      ((digest[offset + 2] & 0xff) << 8) |
-      (digest[offset + 3] & 0xff)) %
-    1_000_000;
-
-  return {
-    code: code.toString().padStart(6, '0'),
-    secondsRemaining,
-  };
-}
-
-/**
  * Look up TOTP secret for a domain.
- * Stub implementation — integrates with credential store when PR 1 lands.
  * Falls back to environment variable OPENCHROME_TOTP_<DOMAIN> for testing.
  */
 async function getTOTPSecret(domain: string): Promise<string | undefined> {
-  // Try to load the credential store dynamically (available when PR 1 is merged).
+  // Try to load the credential store dynamically (available when PR lands).
   // Using require() at runtime so TypeScript does not resolve the module at compile time.
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const credModule = require('../security/credential-store') as { getTOTPSecret?: (d: string) => Promise<string | undefined> };
-    if (typeof credModule.getTOTPSecret === 'function') {
-      return credModule.getTOTPSecret(domain);
+    const credModule = require('../auth/credential-store') as { getTotpSecret?: (d: string) => Promise<string | null> };
+    if (typeof credModule.getTotpSecret === 'function') {
+      const result = await credModule.getTotpSecret(domain);
+      return result ?? undefined;
     }
   } catch {
     // Credential store not available yet — fall through to env var fallback
@@ -133,7 +78,9 @@ const handler: ToolHandler = async (
       };
     }
 
-    const { code, secondsRemaining } = generateTOTPCode(secret);
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const secondsRemaining = 30 - (nowSeconds % 30);
+    const code = generateTOTP(secret);
 
     return {
       content: [

--- a/src/tools/totp-generate.ts
+++ b/src/tools/totp-generate.ts
@@ -1,0 +1,167 @@
+/**
+ * TOTP Generate Tool - Generate current TOTP 2FA codes for configured domains
+ */
+
+import * as crypto from 'crypto';
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+
+const definition: MCPToolDefinition = {
+  name: 'oc_totp_generate',
+  description:
+    'Generate a current TOTP 2FA code for a domain. Requires TOTP secret to be configured.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      domain: {
+        type: 'string',
+        description: 'Domain to generate TOTP code for (e.g., "github.com")',
+      },
+    },
+    required: ['domain'],
+  },
+};
+
+/**
+ * Generate a TOTP code from a base32-encoded secret.
+ * Implements RFC 6238 (TOTP) using HMAC-SHA1 per RFC 4226 (HOTP).
+ * Returns the 6-digit code and seconds remaining in the current 30s period.
+ */
+function generateTOTPCode(secret: string): { code: string; secondsRemaining: number } {
+  const base32Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  const cleanSecret = secret.toUpperCase().replace(/[^A-Z2-7]/g, '');
+
+  // Decode base32 to bytes
+  let bits = '';
+  for (const char of cleanSecret) {
+    const val = base32Chars.indexOf(char);
+    if (val === -1) continue;
+    bits += val.toString(2).padStart(5, '0');
+  }
+
+  const keyBytes = Buffer.alloc(Math.floor(bits.length / 8));
+  for (let i = 0; i < keyBytes.length; i++) {
+    keyBytes[i] = parseInt(bits.slice(i * 8, i * 8 + 8), 2);
+  }
+
+  // Current time step (30-second intervals)
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const timeStep = Math.floor(nowSeconds / 30);
+  const secondsRemaining = 30 - (nowSeconds % 30);
+
+  // Pack time step as 8-byte big-endian buffer
+  const timeBuffer = Buffer.alloc(8);
+  let t = timeStep;
+  for (let i = 7; i >= 0; i--) {
+    timeBuffer[i] = t & 0xff;
+    t = Math.floor(t / 256);
+  }
+
+  // HMAC-SHA1
+  const hmac = crypto.createHmac('sha1', keyBytes);
+  hmac.update(timeBuffer);
+  const digest = hmac.digest();
+
+  // Dynamic truncation (RFC 4226 §5.3)
+  const offset = digest[digest.length - 1] & 0x0f;
+  const code =
+    (((digest[offset] & 0x7f) << 24) |
+      ((digest[offset + 1] & 0xff) << 16) |
+      ((digest[offset + 2] & 0xff) << 8) |
+      (digest[offset + 3] & 0xff)) %
+    1_000_000;
+
+  return {
+    code: code.toString().padStart(6, '0'),
+    secondsRemaining,
+  };
+}
+
+/**
+ * Look up TOTP secret for a domain.
+ * Stub implementation — integrates with credential store when PR 1 lands.
+ * Falls back to environment variable OPENCHROME_TOTP_<DOMAIN> for testing.
+ */
+async function getTOTPSecret(domain: string): Promise<string | undefined> {
+  // Try to load the credential store dynamically (available when PR 1 is merged).
+  // Using require() at runtime so TypeScript does not resolve the module at compile time.
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const credModule = require('../security/credential-store') as { getTOTPSecret?: (d: string) => Promise<string | undefined> };
+    if (typeof credModule.getTOTPSecret === 'function') {
+      return credModule.getTOTPSecret(domain);
+    }
+  } catch {
+    // Credential store not available yet — fall through to env var fallback
+  }
+
+  // Environment variable fallback for testing:
+  // OPENCHROME_TOTP_GITHUB_COM=JBSWY3DPEHPK3PXP
+  const envKey = `OPENCHROME_TOTP_${domain.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`;
+  return process.env[envKey];
+}
+
+const handler: ToolHandler = async (
+  _sessionId: string,
+  args: Record<string, unknown>,
+): Promise<MCPResult> => {
+  const domain = args.domain as string | undefined;
+
+  if (!domain) {
+    return {
+      content: [{ type: 'text', text: 'Error: domain is required' }],
+      isError: true,
+    };
+  }
+
+  try {
+    const secret = await getTOTPSecret(domain);
+
+    if (!secret) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              error: 'TOTP secret not configured',
+              domain,
+              setup: `Configure TOTP for this domain with: npx openchrome totp add --domain ${domain} --secret <base32>`,
+            }),
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const { code, secondsRemaining } = generateTOTPCode(secret);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            domain,
+            code,
+            secondsRemaining,
+            expiresAt: new Date(Date.now() + secondsRemaining * 1000).toISOString(),
+            note: 'Code expires at the indicated time. Request a new code if needed.',
+          }),
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `TOTP generation error: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+};
+
+export function registerTotpGenerateTool(server: MCPServer): void {
+  server.registerTool('oc_totp_generate', handler, definition);
+}

--- a/src/tools/totp-generate.ts
+++ b/src/tools/totp-generate.ts
@@ -34,13 +34,14 @@ async function getTOTPSecret(domain: string): Promise<string | undefined> {
     const credModule = require('../auth/credential-store') as { getTotpSecret?: (d: string) => Promise<string | null> };
     if (typeof credModule.getTotpSecret === 'function') {
       const result = await credModule.getTotpSecret(domain);
-      return result ?? undefined;
+      if (result) return result;
+      // Not in store — fall through to env var fallback
     }
   } catch {
     // Credential store not available yet — fall through to env var fallback
   }
 
-  // Environment variable fallback for testing:
+  // Environment variable fallback for testing and quick setup:
   // OPENCHROME_TOTP_GITHUB_COM=JBSWY3DPEHPK3PXP
   const envKey = `OPENCHROME_TOTP_${domain.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`;
   return process.env[envKey];

--- a/tests/auth/adapters/bitwarden-adapter.test.ts
+++ b/tests/auth/adapters/bitwarden-adapter.test.ts
@@ -1,0 +1,230 @@
+/// <reference types="jest" />
+/**
+ * Unit tests for Bitwarden CLI credential adapter
+ */
+
+import { BitwardenAdapter } from '../../../src/auth/adapters/bitwarden-adapter';
+
+type ExecFileAsync = (
+  cmd: string,
+  args: string[],
+  opts: { timeout: number }
+) => Promise<{ stdout: string; stderr: string }>;
+
+/**
+ * Helper: create a mock exec that resolves with the given stdout
+ */
+function makeSuccessExec(stdout: string): jest.MockedFunction<ExecFileAsync> {
+  return jest.fn().mockResolvedValue({ stdout, stderr: '' });
+}
+
+/**
+ * Helper: create a mock exec that rejects with the given error message
+ */
+function makeFailureExec(message: string): jest.MockedFunction<ExecFileAsync> {
+  return jest.fn().mockRejectedValue(new Error(message));
+}
+
+const BW_VERSION_OUTPUT = '2024.1.0\n';
+
+const BW_ITEM_JSON = JSON.stringify({
+  id: 'xyz789',
+  name: 'example.com',
+  type: 1,
+  login: {
+    username: 'bob@example.com',
+    password: 'p@ssw0rd',
+    totp: 'JBSWY3DPEHPK3PXP',
+    uris: [{ uri: 'https://example.com', match: null }],
+  },
+});
+
+const BW_LIST_JSON = JSON.stringify([
+  {
+    id: 'item1',
+    name: 'example.com',
+    type: 1,
+    login: {
+      username: 'user1',
+      uris: [{ uri: 'https://example.com/login' }],
+    },
+  },
+  {
+    id: 'item2',
+    name: 'another.org',
+    type: 1,
+    login: {
+      username: 'user2',
+      uris: [{ uri: 'https://another.org' }, { uri: 'https://sub.another.org' }],
+    },
+  },
+  {
+    id: 'item3',
+    name: 'No URI item',
+    type: 1,
+    login: {
+      username: 'user3',
+    },
+  },
+]);
+
+describe('BitwardenAdapter', () => {
+  const originalEnv = process.env;
+  const SESSION_KEY = 'test-session-key-abc123';
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.OPENCHROME_BITWARDEN_SESSION = SESSION_KEY;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('isAvailable()', () => {
+    test('returns true when bw --version succeeds', async () => {
+      const exec = makeSuccessExec(BW_VERSION_OUTPUT);
+      const adapter = new BitwardenAdapter(exec);
+      const result = await adapter.isAvailable();
+      expect(result).toBe(true);
+      expect(exec).toHaveBeenCalledWith('bw', ['--version'], { timeout: 10000 });
+    });
+
+    test('returns false when bw binary is not found', async () => {
+      const exec = makeFailureExec('command not found: bw');
+      const adapter = new BitwardenAdapter(exec);
+      const result = await adapter.isAvailable();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getCredentials()', () => {
+    test('parses Bitwarden item JSON and returns credentials', async () => {
+      const exec = makeSuccessExec(BW_ITEM_JSON);
+      const adapter = new BitwardenAdapter(exec);
+      const creds = await adapter.getCredentials('example.com');
+      expect(creds).not.toBeNull();
+      expect(creds!.username).toBe('bob@example.com');
+      expect(creds!.password).toBe('p@ssw0rd');
+      expect(creds!.totpSecret).toBe('JBSWY3DPEHPK3PXP');
+    });
+
+    test('returns null when item is not found', async () => {
+      const exec = makeFailureExec('Not found.');
+      const adapter = new BitwardenAdapter(exec);
+      const creds = await adapter.getCredentials('missing.com');
+      expect(creds).toBeNull();
+    });
+
+    test('returns null for "no items found" error', async () => {
+      const exec = makeFailureExec('no items found');
+      const adapter = new BitwardenAdapter(exec);
+      const creds = await adapter.getCredentials('missing.com');
+      expect(creds).toBeNull();
+    });
+
+    test('throws descriptive error when vault is locked', async () => {
+      const exec = makeFailureExec('Vault is locked.');
+      const adapter = new BitwardenAdapter(exec);
+      await expect(adapter.getCredentials('example.com')).rejects.toThrow(
+        /vault is locked|session expired/i
+      );
+    });
+
+    test('throws descriptive error for expired/invalid session', async () => {
+      const exec = makeFailureExec('Session key is invalid.');
+      const adapter = new BitwardenAdapter(exec);
+      await expect(adapter.getCredentials('example.com')).rejects.toThrow(
+        /vault is locked|session expired/i
+      );
+    });
+
+    test('throws when session env var is not set', async () => {
+      delete process.env.OPENCHROME_BITWARDEN_SESSION;
+      const exec = makeSuccessExec(BW_ITEM_JSON);
+      const adapter = new BitwardenAdapter(exec);
+      await expect(adapter.getCredentials('example.com')).rejects.toThrow(
+        /session key not set|bw unlock/i
+      );
+    });
+
+    test('passes --session flag from OPENCHROME_BITWARDEN_SESSION', async () => {
+      const exec = makeSuccessExec(BW_ITEM_JSON);
+      const adapter = new BitwardenAdapter(exec);
+      await adapter.getCredentials('example.com');
+      expect(exec).toHaveBeenCalledWith(
+        'bw',
+        ['get', 'item', 'example.com', '--session', SESSION_KEY],
+        expect.objectContaining({ timeout: 10000 })
+      );
+    });
+
+    test('returns undefined totpSecret when item has no totp', async () => {
+      const itemWithoutTotp = JSON.stringify({
+        id: 'xyz789',
+        name: 'example.com',
+        type: 1,
+        login: { username: 'bob@example.com', password: 'p@ssw0rd' },
+      });
+      const exec = makeSuccessExec(itemWithoutTotp);
+      const adapter = new BitwardenAdapter(exec);
+      const creds = await adapter.getCredentials('example.com');
+      expect(creds).not.toBeNull();
+      expect(creds!.totpSecret).toBeUndefined();
+    });
+  });
+
+  describe('listDomains()', () => {
+    test('parses item list and extracts domains from URIs', async () => {
+      const exec = makeSuccessExec(BW_LIST_JSON);
+      const adapter = new BitwardenAdapter(exec);
+      const domains = await adapter.listDomains();
+      expect(domains).toContain('example.com');
+      expect(domains).toContain('another.org');
+      expect(domains).toContain('sub.another.org');
+    });
+
+    test('skips items without URIs', async () => {
+      const exec = makeSuccessExec(BW_LIST_JSON);
+      const adapter = new BitwardenAdapter(exec);
+      const domains = await adapter.listDomains();
+      // 'No URI item' has no uris — should not contribute
+      expect(domains).not.toContain('No URI item');
+    });
+
+    test('deduplicates domains that appear in multiple items', async () => {
+      const duplicateList = JSON.stringify([
+        {
+          id: 'a', name: 'a', type: 1,
+          login: { uris: [{ uri: 'https://example.com/login' }] },
+        },
+        {
+          id: 'b', name: 'b', type: 1,
+          login: { uris: [{ uri: 'https://example.com/settings' }] },
+        },
+      ]);
+      const exec = makeSuccessExec(duplicateList);
+      const adapter = new BitwardenAdapter(exec);
+      const domains = await adapter.listDomains();
+      expect(domains).toEqual(['example.com']);
+    });
+
+    test('passes --session flag when listing items', async () => {
+      const exec = makeSuccessExec(BW_LIST_JSON);
+      const adapter = new BitwardenAdapter(exec);
+      await adapter.listDomains();
+      expect(exec).toHaveBeenCalledWith(
+        'bw',
+        ['list', 'items', '--session', SESSION_KEY],
+        expect.objectContaining({ timeout: 10000 })
+      );
+    });
+
+    test('throws when session env var is not set', async () => {
+      delete process.env.OPENCHROME_BITWARDEN_SESSION;
+      const exec = makeSuccessExec(BW_LIST_JSON);
+      const adapter = new BitwardenAdapter(exec);
+      await expect(adapter.listDomains()).rejects.toThrow(/session key not set|bw unlock/i);
+    });
+  });
+});

--- a/tests/auth/adapters/onepassword-adapter.test.ts
+++ b/tests/auth/adapters/onepassword-adapter.test.ts
@@ -1,0 +1,189 @@
+/// <reference types="jest" />
+/**
+ * Unit tests for 1Password CLI credential adapter
+ */
+
+import { OnePasswordAdapter } from '../../../src/auth/adapters/onepassword-adapter';
+
+type ExecFileAsync = (
+  cmd: string,
+  args: string[],
+  opts: { timeout: number }
+) => Promise<{ stdout: string; stderr: string }>;
+
+/**
+ * Helper: create a mock exec that resolves with the given stdout
+ */
+function makeSuccessExec(stdout: string): jest.MockedFunction<ExecFileAsync> {
+  return jest.fn().mockResolvedValue({ stdout, stderr: '' });
+}
+
+/**
+ * Helper: create a mock exec that rejects with the given error message
+ */
+function makeFailureExec(message: string): jest.MockedFunction<ExecFileAsync> {
+  return jest.fn().mockRejectedValue(new Error(message));
+}
+
+const OP_VERSION_OUTPUT = '2.24.0\n';
+
+const OP_ITEM_JSON = JSON.stringify({
+  id: 'abc123',
+  title: 'example.com',
+  fields: [
+    { id: 'username', purpose: 'USERNAME', value: 'alice@example.com' },
+    { id: 'password', purpose: 'PASSWORD', value: 's3cr3t!' },
+    { id: 'totp', type: 'OTP', value: 'JBSWY3DPEHPK3PXP' },
+  ],
+  urls: [{ href: 'https://example.com', primary: true }],
+});
+
+const OP_LIST_JSON = JSON.stringify([
+  {
+    id: 'item1',
+    title: 'example.com',
+    urls: [{ href: 'https://example.com' }],
+  },
+  {
+    id: 'item2',
+    title: 'another.org',
+    urls: [{ href: 'https://another.org/login' }],
+  },
+  {
+    id: 'item3',
+    title: 'No URL item',
+  },
+]);
+
+describe('OnePasswordAdapter', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.OPENCHROME_1PASSWORD_VAULT;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('isAvailable()', () => {
+    test('returns true when op --version succeeds', async () => {
+      const exec = makeSuccessExec(OP_VERSION_OUTPUT);
+      const adapter = new OnePasswordAdapter(exec);
+      const result = await adapter.isAvailable();
+      expect(result).toBe(true);
+      expect(exec).toHaveBeenCalledWith('op', ['--version'], { timeout: 10000 });
+    });
+
+    test('returns false when op binary is not found', async () => {
+      const exec = makeFailureExec('command not found: op');
+      const adapter = new OnePasswordAdapter(exec);
+      const result = await adapter.isAvailable();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getCredentials()', () => {
+    test('parses 1Password item JSON and returns credentials', async () => {
+      const exec = makeSuccessExec(OP_ITEM_JSON);
+      const adapter = new OnePasswordAdapter(exec);
+      const creds = await adapter.getCredentials('example.com');
+      expect(creds).not.toBeNull();
+      expect(creds!.username).toBe('alice@example.com');
+      expect(creds!.password).toBe('s3cr3t!');
+      expect(creds!.totpSecret).toBe('JBSWY3DPEHPK3PXP');
+    });
+
+    test('returns null when item is not found', async () => {
+      const exec = makeFailureExec("example.com isn't an item in any vault");
+      const adapter = new OnePasswordAdapter(exec);
+      const creds = await adapter.getCredentials('example.com');
+      expect(creds).toBeNull();
+    });
+
+    test('returns null for "not found" error message', async () => {
+      const exec = makeFailureExec('[ERROR] 2024/01/01 not found');
+      const adapter = new OnePasswordAdapter(exec);
+      const creds = await adapter.getCredentials('missing.com');
+      expect(creds).toBeNull();
+    });
+
+    test('throws descriptive error when vault is locked', async () => {
+      const exec = makeFailureExec('You are not signed in. Please sign in and try again.');
+      const adapter = new OnePasswordAdapter(exec);
+      await expect(adapter.getCredentials('example.com')).rejects.toThrow(
+        /vault is locked|not signed in/i
+      );
+    });
+
+    test('throws descriptive error for authentication required', async () => {
+      const exec = makeFailureExec('authentication required');
+      const adapter = new OnePasswordAdapter(exec);
+      await expect(adapter.getCredentials('example.com')).rejects.toThrow(
+        /vault is locked|not signed in/i
+      );
+    });
+
+    test('passes --vault flag when OPENCHROME_1PASSWORD_VAULT is set', async () => {
+      process.env.OPENCHROME_1PASSWORD_VAULT = 'Personal';
+      const exec = makeSuccessExec(OP_ITEM_JSON);
+      const adapter = new OnePasswordAdapter(exec);
+      await adapter.getCredentials('example.com');
+      expect(exec).toHaveBeenCalledWith(
+        'op',
+        ['item', 'get', 'example.com', '--format', 'json', '--vault', 'Personal'],
+        expect.objectContaining({ timeout: 10000 })
+      );
+    });
+
+    test('does not pass --vault flag when env var is not set', async () => {
+      const exec = makeSuccessExec(OP_ITEM_JSON);
+      const adapter = new OnePasswordAdapter(exec);
+      await adapter.getCredentials('example.com');
+      const callArgs = exec.mock.calls[0][1] as string[];
+      expect(callArgs).not.toContain('--vault');
+    });
+  });
+
+  describe('listDomains()', () => {
+    test('parses item list and extracts domains from URLs', async () => {
+      const exec = makeSuccessExec(OP_LIST_JSON);
+      const adapter = new OnePasswordAdapter(exec);
+      const domains = await adapter.listDomains();
+      expect(domains).toContain('example.com');
+      expect(domains).toContain('another.org');
+    });
+
+    test('skips items without URLs', async () => {
+      const exec = makeSuccessExec(OP_LIST_JSON);
+      const adapter = new OnePasswordAdapter(exec);
+      const domains = await adapter.listDomains();
+      // 'No URL item' has no urls — only 2 unique domains expected
+      expect(domains).toHaveLength(2);
+    });
+
+    test('deduplicates domains that appear in multiple items', async () => {
+      const duplicateList = JSON.stringify([
+        { id: 'a', title: 'a', urls: [{ href: 'https://example.com/login' }] },
+        { id: 'b', title: 'b', urls: [{ href: 'https://example.com/settings' }] },
+      ]);
+      const exec = makeSuccessExec(duplicateList);
+      const adapter = new OnePasswordAdapter(exec);
+      const domains = await adapter.listDomains();
+      expect(domains).toEqual(['example.com']);
+    });
+
+    test('passes --vault flag when OPENCHROME_1PASSWORD_VAULT is set', async () => {
+      process.env.OPENCHROME_1PASSWORD_VAULT = 'Work';
+      const exec = makeSuccessExec(OP_LIST_JSON);
+      const adapter = new OnePasswordAdapter(exec);
+      await adapter.listDomains();
+      expect(exec).toHaveBeenCalledWith(
+        'op',
+        ['item', 'list', '--categories', 'Login', '--format', 'json', '--vault', 'Work'],
+        expect.objectContaining({ timeout: 10000 })
+      );
+    });
+  });
+});

--- a/tests/auth/credential-provider.test.ts
+++ b/tests/auth/credential-provider.test.ts
@@ -1,0 +1,66 @@
+/// <reference types="jest" />
+/**
+ * Unit tests for credential provider factory
+ */
+
+describe('getCredentialProvider', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test('returns LocalAdapter by default when env var not set', () => {
+    delete process.env.OPENCHROME_CREDENTIAL_PROVIDER;
+    const { getCredentialProvider } = require('../../src/auth/credential-provider');
+    const provider = getCredentialProvider();
+    expect(provider.name).toBe('local');
+  });
+
+  test('returns LocalAdapter when env var is "local"', () => {
+    process.env.OPENCHROME_CREDENTIAL_PROVIDER = 'local';
+    const { getCredentialProvider } = require('../../src/auth/credential-provider');
+    const provider = getCredentialProvider();
+    expect(provider.name).toBe('local');
+  });
+
+  test('returns OnePasswordAdapter when env var is "1password"', () => {
+    process.env.OPENCHROME_CREDENTIAL_PROVIDER = '1password';
+    const { getCredentialProvider } = require('../../src/auth/credential-provider');
+    const provider = getCredentialProvider();
+    expect(provider.name).toBe('1password');
+  });
+
+  test('returns OnePasswordAdapter when env var is "onepassword" (alias)', () => {
+    process.env.OPENCHROME_CREDENTIAL_PROVIDER = 'onepassword';
+    const { getCredentialProvider } = require('../../src/auth/credential-provider');
+    const provider = getCredentialProvider();
+    expect(provider.name).toBe('1password');
+  });
+
+  test('returns BitwardenAdapter when env var is "bitwarden"', () => {
+    process.env.OPENCHROME_CREDENTIAL_PROVIDER = 'bitwarden';
+    const { getCredentialProvider } = require('../../src/auth/credential-provider');
+    const provider = getCredentialProvider();
+    expect(provider.name).toBe('bitwarden');
+  });
+
+  test('is case-insensitive for provider name', () => {
+    process.env.OPENCHROME_CREDENTIAL_PROVIDER = 'BITWARDEN';
+    const { getCredentialProvider } = require('../../src/auth/credential-provider');
+    const provider = getCredentialProvider();
+    expect(provider.name).toBe('bitwarden');
+  });
+
+  test('falls back to local for unknown provider values', () => {
+    process.env.OPENCHROME_CREDENTIAL_PROVIDER = 'unknown-vault';
+    const { getCredentialProvider } = require('../../src/auth/credential-provider');
+    const provider = getCredentialProvider();
+    expect(provider.name).toBe('local');
+  });
+});

--- a/tests/auth/credential-store.test.ts
+++ b/tests/auth/credential-store.test.ts
@@ -1,0 +1,219 @@
+/// <reference types="jest" />
+/**
+ * Unit tests for the encrypted credential store
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// ---------------------------------------------------------------------------
+// Redirect os.homedir to a per-test temp directory BEFORE importing the module
+// ---------------------------------------------------------------------------
+
+let tempDir: string = '';
+
+jest.mock('os', () => {
+  const real = jest.requireActual<typeof os>('os');
+  return {
+    ...real,
+    homedir: () => tempDir || real.homedir(),
+  };
+});
+
+// Import AFTER mock is set up
+import {
+  addTotpSecret,
+  removeTotpSecret,
+  listTotpDomains,
+  getTotpSecret,
+  generateTotpForDomain,
+} from '../../src/auth/credential-store';
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-cred-test-'));
+});
+
+afterEach(async () => {
+  const dir = tempDir;
+  tempDir = '';
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // ignore cleanup errors
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const VALID_SECRET = 'JBSWY3DPEHPK3PXP'; // valid base32
+const ANOTHER_SECRET = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ'; // RFC test vector
+
+describe('addTotpSecret / getTotpSecret', () => {
+  test('write-read round-trip preserves secret', async () => {
+    await addTotpSecret('example.com', VALID_SECRET, 'Example');
+    const retrieved = await getTotpSecret('example.com');
+    expect(retrieved).toBe(VALID_SECRET);
+  });
+
+  test('returns null for unknown domain', async () => {
+    const result = await getTotpSecret('unknown.com');
+    expect(result).toBeNull();
+  });
+
+  test('rejects invalid base32 on add', async () => {
+    await expect(addTotpSecret('bad.com', 'NOT-BASE32!!!')).rejects.toThrow(
+      /Invalid base32 secret/
+    );
+  });
+
+  test('updates existing entry when domain is re-added', async () => {
+    await addTotpSecret('example.com', VALID_SECRET, 'Old Issuer');
+    await addTotpSecret('example.com', ANOTHER_SECRET, 'New Issuer');
+    const retrieved = await getTotpSecret('example.com');
+    expect(retrieved).toBe(ANOTHER_SECRET);
+  });
+});
+
+describe('listTotpDomains', () => {
+  test('returns empty array when store does not exist', async () => {
+    const list = await listTotpDomains();
+    expect(list).toEqual([]);
+  });
+
+  test('returns domains and issuers but NOT secrets', async () => {
+    await addTotpSecret('github.com', VALID_SECRET, 'GitHub');
+    await addTotpSecret('google.com', ANOTHER_SECRET, 'Google');
+
+    const list = await listTotpDomains();
+    expect(list).toHaveLength(2);
+
+    const domains = list.map((e) => e.domain);
+    expect(domains).toContain('github.com');
+    expect(domains).toContain('google.com');
+
+    // No entry should have a "secret" property
+    for (const entry of list) {
+      expect(Object.keys(entry)).not.toContain('secret');
+    }
+
+    // Issuers should be present
+    const github = list.find((e) => e.domain === 'github.com');
+    expect(github?.issuer).toBe('GitHub');
+  });
+
+  test('each entry has an addedAt ISO date string', async () => {
+    await addTotpSecret('example.com', VALID_SECRET);
+    const list = await listTotpDomains();
+    expect(list).toHaveLength(1);
+    expect(() => new Date(list[0].addedAt)).not.toThrow();
+    expect(new Date(list[0].addedAt).toISOString()).toBe(list[0].addedAt);
+  });
+});
+
+describe('removeTotpSecret', () => {
+  test('removes an existing domain and returns true', async () => {
+    await addTotpSecret('example.com', VALID_SECRET, 'Example');
+    const removed = await removeTotpSecret('example.com');
+    expect(removed).toBe(true);
+    const retrieved = await getTotpSecret('example.com');
+    expect(retrieved).toBeNull();
+  });
+
+  test('returns false for non-existent domain', async () => {
+    const removed = await removeTotpSecret('nonexistent.com');
+    expect(removed).toBe(false);
+  });
+
+  test('preserves other entries when one is removed', async () => {
+    await addTotpSecret('github.com', VALID_SECRET, 'GitHub');
+    await addTotpSecret('google.com', ANOTHER_SECRET, 'Google');
+
+    await removeTotpSecret('github.com');
+
+    const remaining = await listTotpDomains();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].domain).toBe('google.com');
+
+    const googleSecret = await getTotpSecret('google.com');
+    expect(googleSecret).toBe(ANOTHER_SECRET);
+  });
+});
+
+describe('generateTotpForDomain', () => {
+  test('generates a 6-digit code for a stored domain', async () => {
+    await addTotpSecret('example.com', VALID_SECRET);
+    const code = await generateTotpForDomain('example.com');
+    expect(code).not.toBeNull();
+    expect(/^\d{6}$/.test(code!)).toBe(true);
+  });
+
+  test('returns null for unknown domain', async () => {
+    const code = await generateTotpForDomain('unknown.com');
+    expect(code).toBeNull();
+  });
+});
+
+describe('multiple entries', () => {
+  test('stores and retrieves multiple independent entries', async () => {
+    await addTotpSecret('github.com', VALID_SECRET, 'GitHub');
+    await addTotpSecret('google.com', ANOTHER_SECRET, 'Google');
+    await addTotpSecret('aws.com', VALID_SECRET, 'AWS');
+
+    expect(await getTotpSecret('github.com')).toBe(VALID_SECRET);
+    expect(await getTotpSecret('google.com')).toBe(ANOTHER_SECRET);
+    expect(await getTotpSecret('aws.com')).toBe(VALID_SECRET);
+  });
+});
+
+describe('wrong passphrase', () => {
+  test('decryption with wrong passphrase fails with a clear error', async () => {
+    await addTotpSecret('example.com', VALID_SECRET, 'Example', 'correct-passphrase');
+    await expect(getTotpSecret('example.com', 'wrong-passphrase')).rejects.toThrow(
+      /Failed to decrypt credentials|wrong passphrase|corrupted/
+    );
+  });
+});
+
+describe('file permissions', () => {
+  // Skip on Windows where POSIX permissions don't apply
+  const isWindows = os.platform() === 'win32';
+
+  (isWindows ? test.skip : test)('credentials file has mode 0o600', async () => {
+    await addTotpSecret('example.com', VALID_SECRET);
+    const storePath = path.join(tempDir, '.openchrome', 'credentials', 'totp-secrets.enc');
+    const stat = fs.statSync(storePath);
+    // eslint-disable-next-line no-bitwise
+    const mode = stat.mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  (isWindows ? test.skip : test)('credentials directory has mode 0o700', async () => {
+    await addTotpSecret('example.com', VALID_SECRET);
+    const credDir = path.join(tempDir, '.openchrome', 'credentials');
+    const stat = fs.statSync(credDir);
+    // eslint-disable-next-line no-bitwise
+    const mode = stat.mode & 0o777;
+    expect(mode).toBe(0o700);
+  });
+});
+
+describe('concurrent access', () => {
+  test('two rapid adds produce two entries without data loss', async () => {
+    await Promise.all([
+      addTotpSecret('site-a.com', VALID_SECRET, 'Site A'),
+      addTotpSecret('site-b.com', ANOTHER_SECRET, 'Site B'),
+    ]);
+
+    const list = await listTotpDomains();
+    expect(list).toHaveLength(2);
+    const domains = list.map((e) => e.domain).sort();
+    expect(domains).toEqual(['site-a.com', 'site-b.com']);
+  });
+});

--- a/tests/auth/totp-manager.test.ts
+++ b/tests/auth/totp-manager.test.ts
@@ -1,0 +1,228 @@
+/// <reference types="jest" />
+/**
+ * Unit tests for TOTP Manager (RFC 6238)
+ */
+
+import {
+  generateTOTP,
+  validateBase32,
+  base32Decode,
+  hmacDigest,
+  dynamicTruncation,
+} from '../../src/auth/totp-manager';
+
+// RFC 6238 test vectors use SHA1 with the ASCII secret "12345678901234567890"
+// Base32 encoding of "12345678901234567890":
+// Each ASCII char is a byte; base32-encode the raw bytes.
+const RFC_SECRET_ASCII = '12345678901234567890';
+// Pre-computed base32 of the 20-byte ASCII sequence
+const RFC_SECRET_BASE32 = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
+
+describe('validateBase32', () => {
+  test('accepts valid uppercase base32', () => {
+    expect(validateBase32('JBSWY3DPEHPK3PXP')).toBe(true);
+  });
+
+  test('accepts valid lowercase base32 (case-insensitive)', () => {
+    expect(validateBase32('jbswy3dpehpk3pxp')).toBe(true);
+  });
+
+  test('accepts base32 with padding', () => {
+    expect(validateBase32('JBSWY3DPEHPK3PXP==')).toBe(true);
+  });
+
+  test('accepts base32 with whitespace', () => {
+    expect(validateBase32('JBSWY 3DPE HPK3 PXP')).toBe(true);
+  });
+
+  test('rejects string with invalid characters (0, 1, 8, 9)', () => {
+    expect(validateBase32('INVALID0189')).toBe(false);
+  });
+
+  test('rejects empty string', () => {
+    expect(validateBase32('')).toBe(false);
+  });
+
+  test('rejects string that is only padding/whitespace', () => {
+    expect(validateBase32('   ')).toBe(false);
+    expect(validateBase32('===')).toBe(false);
+  });
+
+  test('accepts RFC test secret in base32', () => {
+    expect(validateBase32(RFC_SECRET_BASE32)).toBe(true);
+  });
+});
+
+describe('base32Decode', () => {
+  test('decodes known secret correctly', () => {
+    // "JBSWY3DPEHPK3PXP" decodes to the bytes: 48 65 6c 6c 6f 21 de ad be ef
+    const decoded = base32Decode('JBSWY3DPEHPK3PXP');
+    const expected = Buffer.from([0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x21, 0xde, 0xad, 0xbe, 0xef]);
+    expect(decoded).toEqual(expected);
+  });
+
+  test('decodes RFC test vector base32 to ASCII bytes', () => {
+    const decoded = base32Decode(RFC_SECRET_BASE32);
+    const expected = Buffer.from(RFC_SECRET_ASCII, 'ascii');
+    expect(decoded).toEqual(expected);
+  });
+
+  test('decodes case-insensitively', () => {
+    const upper = base32Decode('JBSWY3DPEHPK3PXP');
+    const lower = base32Decode('jbswy3dpehpk3pxp');
+    expect(upper).toEqual(lower);
+  });
+
+  test('throws on invalid base32 character', () => {
+    expect(() => base32Decode('INVALID0189')).toThrow('Invalid base32 character');
+  });
+});
+
+describe('hmacDigest', () => {
+  test('returns a Buffer', () => {
+    const key = Buffer.from('secret');
+    const counter = Buffer.alloc(8, 0);
+    const result = hmacDigest('sha1', key, counter);
+    expect(Buffer.isBuffer(result)).toBe(true);
+  });
+
+  test('SHA1 HMAC produces 20-byte output', () => {
+    const key = Buffer.from('key');
+    const counter = Buffer.alloc(8, 1);
+    const result = hmacDigest('sha1', key, counter);
+    expect(result.length).toBe(20);
+  });
+
+  test('same inputs produce same output (deterministic)', () => {
+    const key = Buffer.from('testkey');
+    const counter = Buffer.from([0, 0, 0, 0, 0, 0, 0, 1]);
+    const r1 = hmacDigest('sha1', key, counter);
+    const r2 = hmacDigest('sha1', key, counter);
+    expect(r1).toEqual(r2);
+  });
+});
+
+describe('dynamicTruncation', () => {
+  test('returns a number', () => {
+    const hmac = Buffer.alloc(20, 0xab);
+    const result = dynamicTruncation(hmac);
+    expect(typeof result).toBe('number');
+  });
+
+  test('result fits in 31 bits (< 0x80000000)', () => {
+    // Try many patterns
+    for (let i = 0; i < 256; i++) {
+      const hmac = Buffer.alloc(20, i);
+      const result = dynamicTruncation(hmac);
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBeLessThan(0x80000000);
+    }
+  });
+});
+
+describe('generateTOTP', () => {
+  // Well-known secret for deterministic tests
+  const KNOWN_SECRET = 'JBSWY3DPEHPK3PXP'; // "Hello!" in base32
+
+  test('generates a 6-character string', () => {
+    const code = generateTOTP(KNOWN_SECRET);
+    expect(typeof code).toBe('string');
+    expect(code).toHaveLength(6);
+  });
+
+  test('output is all digits', () => {
+    const code = generateTOTP(KNOWN_SECRET);
+    expect(/^\d{6}$/.test(code)).toBe(true);
+  });
+
+  test('respects digits option (8 digits)', () => {
+    const code = generateTOTP(KNOWN_SECRET, { digits: 8 });
+    expect(code).toHaveLength(8);
+    expect(/^\d{8}$/.test(code)).toBe(true);
+  });
+
+  test('same time step produces same code (deterministic)', () => {
+    const now = 1700000000000;
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+    const c1 = generateTOTP(KNOWN_SECRET);
+    const c2 = generateTOTP(KNOWN_SECRET);
+    expect(c1).toBe(c2);
+    jest.restoreAllMocks();
+  });
+
+  test('code changes when time step changes', () => {
+    // Step 1
+    jest.spyOn(Date, 'now').mockReturnValue(0);
+    const c1 = generateTOTP(KNOWN_SECRET);
+    // Step 2 (30 seconds later)
+    jest.spyOn(Date, 'now').mockReturnValue(30000);
+    const c2 = generateTOTP(KNOWN_SECRET);
+    // Step 3 (60 seconds after start)
+    jest.spyOn(Date, 'now').mockReturnValue(60000);
+    const c3 = generateTOTP(KNOWN_SECRET);
+
+    // At least two of the three codes should differ (statistically certain)
+    const allSame = c1 === c2 && c2 === c3;
+    expect(allSame).toBe(false);
+    jest.restoreAllMocks();
+  });
+
+  describe('RFC 6238 test vectors (SHA1)', () => {
+    // RFC 6238 Appendix B — SHA1 test vectors
+    // Secret: "12345678901234567890" (20 ASCII bytes)
+    // T0=0, period=30
+    const vectors: Array<{ unixTime: number; expected: string }> = [
+      { unixTime: 59, expected: '287082' },
+      { unixTime: 1111111109, expected: '081804' },
+      { unixTime: 1111111111, expected: '050471' },
+      { unixTime: 1234567890, expected: '005924' },
+      { unixTime: 2000000000, expected: '279037' },
+    ];
+
+    for (const { unixTime, expected } of vectors) {
+      test(`at T=${unixTime} code is ${expected}`, () => {
+        jest.spyOn(Date, 'now').mockReturnValue(unixTime * 1000);
+        const code = generateTOTP(RFC_SECRET_BASE32, { algorithm: 'sha1', digits: 6, period: 30 });
+        expect(code).toBe(expected);
+        jest.restoreAllMocks();
+      });
+    }
+  });
+
+  describe('clock drift / timeOffset', () => {
+    test('timeOffset=0 and timeOffset=1 can produce different codes', () => {
+      jest.spyOn(Date, 'now').mockReturnValue(1700000000000);
+      const current = generateTOTP(KNOWN_SECRET, { timeOffset: 0 });
+      const next = generateTOTP(KNOWN_SECRET, { timeOffset: 1 });
+      const prev = generateTOTP(KNOWN_SECRET, { timeOffset: -1 });
+
+      // They are each valid 6-digit codes
+      expect(/^\d{6}$/.test(current)).toBe(true);
+      expect(/^\d{6}$/.test(next)).toBe(true);
+      expect(/^\d{6}$/.test(prev)).toBe(true);
+
+      // At least one adjacent step differs
+      expect(current === next && current === prev).toBe(false);
+      jest.restoreAllMocks();
+    });
+
+    test('timeOffset shifts the time step by the given amount', () => {
+      const fixedTime = 1700000000000; // T-step = floor(1700000000 / 30)
+      jest.spyOn(Date, 'now').mockReturnValue(fixedTime);
+
+      const codeAtStep = generateTOTP(KNOWN_SECRET, { timeOffset: 0 });
+
+      // Advance clock by exactly 1 period
+      jest.spyOn(Date, 'now').mockReturnValue(fixedTime + 30000);
+      const codeNextStep = generateTOTP(KNOWN_SECRET, { timeOffset: 0 });
+
+      // Rewind clock, use offset +1 to simulate "next step"
+      jest.spyOn(Date, 'now').mockReturnValue(fixedTime);
+      const codeWithOffset = generateTOTP(KNOWN_SECRET, { timeOffset: 1 });
+
+      expect(codeWithOffset).toBe(codeNextStep);
+      expect(codeWithOffset).not.toBe(codeAtStep);
+      jest.restoreAllMocks();
+    });
+  });
+});

--- a/tests/auth/twofa-detector.test.ts
+++ b/tests/auth/twofa-detector.test.ts
@@ -1,0 +1,299 @@
+/// <reference types="jest" />
+/**
+ * Unit tests for 2FA Detection Engine
+ */
+
+import { detectTwoFA, classifyTwoFAType, TwoFAType } from '../../src/auth/twofa-detector';
+
+/** Build a minimal mock page that returns specific body text and input state */
+function makeMockPage(bodyText: string, inputs: Array<Record<string, string>> = [], buttons: Array<{ innerText: string; id?: string }> = []) {
+  return {
+    evaluate: jest.fn().mockImplementation((fn: Function) => {
+      // Simulate page.evaluate running in "page context"
+      // We capture what the real evaluate would return by calling the function
+      // with a fake DOM-like environment
+      return Promise.resolve(
+        fn.call(
+          undefined,
+          // The evaluate fn receives no args (it uses document directly)
+          // We override it by making evaluate return a static payload instead
+        ),
+      );
+    }),
+  };
+}
+
+/** Create a mock page whose evaluate resolves to a fixed PageSignals object */
+function makePage(signals: {
+  pageText: string;
+  inputSelector?: string;
+  inputAttributes?: Record<string, string>;
+  submitSelector?: string;
+}) {
+  return {
+    evaluate: jest.fn().mockResolvedValue(signals),
+    url: jest.fn().mockReturnValue('https://example.com/login/2fa'),
+  };
+}
+
+describe('classifyTwoFAType', () => {
+  describe('TOTP classification', () => {
+    test('identifies authenticator text as TOTP', () => {
+      expect(classifyTwoFAType('Enter your authenticator code')).toBe(TwoFAType.TOTP);
+    });
+
+    test('identifies "verification code" text as TOTP', () => {
+      expect(classifyTwoFAType('Enter your verification code to continue')).toBe(TwoFAType.TOTP);
+    });
+
+    test('identifies "6-digit code" text as TOTP', () => {
+      expect(classifyTwoFAType('Please enter the 6-digit code from your app')).toBe(TwoFAType.TOTP);
+    });
+
+    test('identifies "two-factor" text as TOTP', () => {
+      expect(classifyTwoFAType('Two-factor authentication required')).toBe(TwoFAType.TOTP);
+    });
+
+    test('identifies "2FA" text as TOTP', () => {
+      expect(classifyTwoFAType('2FA verification needed')).toBe(TwoFAType.TOTP);
+    });
+
+    test('authenticator text + maxlength=6 input gives TOTP', () => {
+      const result = classifyTwoFAType('Enter code from your authenticator app', { maxlength: '6', type: 'text' });
+      expect(result).toBe(TwoFAType.TOTP);
+    });
+  });
+
+  describe('SMS classification', () => {
+    test('identifies "text message" as SMS', () => {
+      expect(classifyTwoFAType('We sent a text message to your number')).toBe(TwoFAType.SMS);
+    });
+
+    test('identifies "SMS" keyword as SMS type', () => {
+      expect(classifyTwoFAType('Enter the SMS code we sent you')).toBe(TwoFAType.SMS);
+    });
+
+    test('identifies "sent to your phone" as SMS', () => {
+      expect(classifyTwoFAType('Code sent to your phone. Please enter it.')).toBe(TwoFAType.SMS);
+    });
+
+    test('identifies masked phone pattern as SMS', () => {
+      expect(classifyTwoFAType('Code sent to ***-***-1234')).toBe(TwoFAType.SMS);
+    });
+  });
+
+  describe('Email classification', () => {
+    test('identifies "check your email" as EMAIL', () => {
+      expect(classifyTwoFAType('Please check your email for the code we sent you')).toBe(TwoFAType.EMAIL);
+    });
+
+    test('identifies "email verification" as EMAIL', () => {
+      expect(classifyTwoFAType('Email verification required')).toBe(TwoFAType.EMAIL);
+    });
+
+    test('identifies "sent to your email" as EMAIL', () => {
+      expect(classifyTwoFAType('Code sent to your email address')).toBe(TwoFAType.EMAIL);
+    });
+
+    test('identifies masked email pattern as EMAIL', () => {
+      expect(classifyTwoFAType('Code sent to j***@gmail.com')).toBe(TwoFAType.EMAIL);
+    });
+  });
+
+  describe('Push classification', () => {
+    test('identifies "approve on your device" as PUSH', () => {
+      expect(classifyTwoFAType('Approve on your device to continue')).toBe(TwoFAType.PUSH);
+    });
+
+    test('identifies "push notification" as PUSH', () => {
+      expect(classifyTwoFAType('A push notification was sent to your app')).toBe(TwoFAType.PUSH);
+    });
+
+    test('identifies "open your app to approve" as PUSH', () => {
+      expect(classifyTwoFAType('Open your app to approve this sign-in')).toBe(TwoFAType.PUSH);
+    });
+  });
+
+  describe('Recovery classification', () => {
+    test('identifies "backup code" as RECOVERY', () => {
+      expect(classifyTwoFAType('Enter a backup code to continue')).toBe(TwoFAType.RECOVERY);
+    });
+
+    test('identifies "recovery code" as RECOVERY', () => {
+      expect(classifyTwoFAType('Use a recovery code to access your account')).toBe(TwoFAType.RECOVERY);
+    });
+  });
+
+  describe('Classification priority', () => {
+    test('TOTP wins when both TOTP and SMS indicators present', () => {
+      // Text contains both "authenticator" (TOTP) and "text message" (SMS)
+      const result = classifyTwoFAType(
+        'Enter the verification code from your authenticator app. ' +
+        'Or enter the code from the text message we sent.',
+      );
+      expect(result).toBe(TwoFAType.TOTP);
+    });
+
+    test('TOTP wins over email when authenticator text present', () => {
+      const result = classifyTwoFAType(
+        'Enter your authenticator code. Check your email for details.',
+      );
+      expect(result).toBe(TwoFAType.TOTP);
+    });
+
+    test('Unknown for regular login page', () => {
+      expect(classifyTwoFAType('Enter your username and password')).toBe(TwoFAType.UNKNOWN);
+    });
+
+    test('Unknown for empty text', () => {
+      expect(classifyTwoFAType('')).toBe(TwoFAType.UNKNOWN);
+    });
+  });
+});
+
+describe('detectTwoFA', () => {
+  describe('TOTP detection', () => {
+    test('detects 6-digit input with authenticator text', async () => {
+      const page = makePage({
+        pageText: 'Enter the 6-digit code from your authenticator app',
+        inputSelector: '#otp-input',
+        inputAttributes: { maxlength: '6', type: 'text', name: 'otp', id: 'otp-input', pattern: '', autocomplete: 'one-time-code', placeholder: '' },
+        submitSelector: 'button[type="submit"]',
+      });
+
+      const result = await detectTwoFA(page);
+
+      expect(result.detected).toBe(true);
+      expect(result.type).toBe(TwoFAType.TOTP);
+      expect(result.confidence).toBeGreaterThan(0.7);
+      expect(result.inputSelector).toBe('#otp-input');
+      expect(result.hints).toContain('TOTP authenticator code required');
+    });
+
+    test('gives high confidence for authenticator keyword + 6-digit input', async () => {
+      const page = makePage({
+        pageText: 'Open your authenticator app and enter the 6-digit code',
+        inputSelector: 'input[maxlength="6"]',
+        inputAttributes: { maxlength: '6', type: 'text', name: '', id: '', pattern: '', autocomplete: '', placeholder: '' },
+      });
+
+      const result = await detectTwoFA(page);
+
+      expect(result.detected).toBe(true);
+      expect(result.type).toBe(TwoFAType.TOTP);
+      expect(result.confidence).toBeGreaterThan(0.7);
+    });
+  });
+
+  describe('SMS detection', () => {
+    test('identifies SMS-related text patterns', async () => {
+      const page = makePage({
+        pageText: 'Enter the code sent via SMS to ***-***-5678',
+        inputSelector: 'input[name="code"]',
+        inputAttributes: { maxlength: '6', type: 'text', name: 'code', id: '', pattern: '', autocomplete: '', placeholder: '' },
+      });
+
+      const result = await detectTwoFA(page);
+
+      expect(result.detected).toBe(true);
+      expect(result.type).toBe(TwoFAType.SMS);
+    });
+  });
+
+  describe('Email detection', () => {
+    test('identifies email verification patterns', async () => {
+      const page = makePage({
+        pageText: 'Check your email at j***@gmail.com for the code we sent',
+        inputSelector: '#email-code',
+        inputAttributes: { maxlength: '6', type: 'text', name: 'code', id: 'email-code', pattern: '', autocomplete: '', placeholder: '' },
+      });
+
+      const result = await detectTwoFA(page);
+
+      expect(result.detected).toBe(true);
+      expect(result.type).toBe(TwoFAType.EMAIL);
+    });
+  });
+
+  describe('Push detection', () => {
+    test('identifies push notification patterns', async () => {
+      const page = makePage({
+        pageText: 'Approve on your device. A push notification has been sent to your app.',
+      });
+
+      const result = await detectTwoFA(page);
+
+      expect(result.detected).toBe(true);
+      expect(result.type).toBe(TwoFAType.PUSH);
+    });
+  });
+
+  describe('Recovery detection', () => {
+    test('identifies recovery code patterns', async () => {
+      const page = makePage({
+        pageText: 'Enter a backup code or recovery code from your saved list',
+        inputSelector: '#recovery-input',
+        inputAttributes: { maxlength: '12', type: 'text', name: 'recovery', id: 'recovery-input', pattern: '', autocomplete: '', placeholder: '' },
+      });
+
+      const result = await detectTwoFA(page);
+
+      expect(result.detected).toBe(true);
+      expect(result.type).toBe(TwoFAType.RECOVERY);
+    });
+  });
+
+  describe('No 2FA', () => {
+    test('returns detected=false for regular login page', async () => {
+      const page = makePage({
+        pageText: 'Sign in to your account. Enter your username and password.',
+      });
+
+      const result = await detectTwoFA(page);
+
+      expect(result.detected).toBe(false);
+      expect(result.type).toBe(TwoFAType.UNKNOWN);
+      expect(result.confidence).toBe(0);
+    });
+
+    test('handles page.evaluate failure gracefully', async () => {
+      const page = {
+        evaluate: jest.fn().mockRejectedValue(new Error('Frame detached')),
+        url: jest.fn().mockReturnValue('https://example.com'),
+      };
+
+      const result = await detectTwoFA(page);
+
+      expect(result.detected).toBe(false);
+      expect(result.hints).toContain('Detection failed: could not access page content');
+    });
+  });
+
+  describe('Confidence scoring', () => {
+    test('authenticator keyword + 6-digit input = high confidence', async () => {
+      const page = makePage({
+        pageText: 'Enter your authenticator code below',
+        inputSelector: '#code',
+        inputAttributes: { maxlength: '6', type: 'text', name: 'code', id: 'code', pattern: '', autocomplete: '', placeholder: '' },
+      });
+
+      const result = await detectTwoFA(page);
+
+      expect(result.confidence).toBeGreaterThan(0.7);
+    });
+
+    test('low confidence for ambiguous page', async () => {
+      const page = makePage({
+        pageText: 'Enter your code',
+        inputSelector: 'input[name="code"]',
+        inputAttributes: { maxlength: '6', type: 'text', name: 'code', id: '', pattern: '', autocomplete: '', placeholder: '' },
+      });
+
+      // "Enter your code" alone triggers TOTP via "6-digit input" input attribute
+      const result = await detectTwoFA(page);
+
+      // Confidence should be lower than the high-signal case
+      expect(result.confidence).toBeLessThan(0.9);
+    });
+  });
+});

--- a/tests/auth/twofa-handler.test.ts
+++ b/tests/auth/twofa-handler.test.ts
@@ -1,0 +1,254 @@
+/// <reference types="jest" />
+/**
+ * Unit tests for 2FA Handler
+ */
+
+import { handleTwoFA, TwoFAHandlerOptions } from '../../src/auth/twofa-handler';
+import { TwoFAType, TwoFADetectionResult } from '../../src/auth/twofa-detector';
+
+function makeDetection(overrides: Partial<TwoFADetectionResult> = {}): TwoFADetectionResult {
+  return {
+    detected: true,
+    type: TwoFAType.TOTP,
+    confidence: 0.9,
+    inputSelector: '#otp-code',
+    submitSelector: 'button[type="submit"]',
+    hints: ['TOTP authenticator code required'],
+    ...overrides,
+  };
+}
+
+function makePage(overrides: {
+  url?: string;
+  urlSequence?: string[];
+  evaluateResult?: string;
+} = {}) {
+  let callCount = 0;
+  const urlSequence = overrides.urlSequence || ['https://example.com/2fa'];
+
+  return {
+    url: jest.fn().mockImplementation(() => {
+      const idx = Math.min(callCount, urlSequence.length - 1);
+      return urlSequence[idx];
+    }),
+    click: jest.fn().mockResolvedValue(undefined),
+    type: jest.fn().mockImplementation(() => {
+      callCount++;
+      return Promise.resolve();
+    }),
+    evaluate: jest.fn().mockResolvedValue(overrides.evaluateResult || ''),
+    keyboard: {
+      press: jest.fn().mockResolvedValue(undefined),
+    },
+  };
+}
+
+describe('handleTwoFA', () => {
+  describe('not-detected', () => {
+    test('returns not-detected when detection.detected=false', async () => {
+      const detection = makeDetection({ detected: false, type: TwoFAType.UNKNOWN });
+      const page = makePage();
+      const options: TwoFAHandlerOptions = { domain: 'example.com' };
+
+      const result = await handleTwoFA(page, detection, options);
+
+      expect(result.handled).toBe(false);
+      expect(result.method).toBe('not-detected');
+    });
+  });
+
+  describe('TOTP handling', () => {
+    test('returns manual-hint when no credential provider configured', async () => {
+      const detection = makeDetection({ type: TwoFAType.TOTP });
+      const page = makePage();
+      const options: TwoFAHandlerOptions = { domain: 'github.com' };
+
+      const result = await handleTwoFA(page, detection, options);
+
+      expect(result.handled).toBe(false);
+      expect(result.type).toBe(TwoFAType.TOTP);
+      expect(result.method).toBe('manual-hint');
+      expect(result.message).toContain('github.com');
+      expect(result.message).toContain('npx openchrome totp add');
+    });
+
+    test('returns manual-hint when credential provider has no secret', async () => {
+      const detection = makeDetection({ type: TwoFAType.TOTP });
+      const page = makePage();
+      const credentialProvider = {
+        getTOTPSecret: jest.fn().mockResolvedValue(undefined),
+      };
+      const options: TwoFAHandlerOptions = { domain: 'github.com', credentialProvider };
+
+      const result = await handleTwoFA(page, detection, options);
+
+      expect(result.handled).toBe(false);
+      expect(result.method).toBe('manual-hint');
+      expect(result.message).toContain('github.com');
+    });
+
+    test('auto-fills when credential provider returns a secret and page changes URL', async () => {
+      const detection = makeDetection({ type: TwoFAType.TOTP });
+      // URL changes after first type() call, simulating successful login
+      const page = makePage({
+        urlSequence: ['https://github.com/login/two-factor', 'https://github.com/dashboard'],
+      });
+      const credentialProvider = {
+        getTOTPSecret: jest.fn().mockResolvedValue('JBSWY3DPEHPK3PXP'),
+      };
+      const options: TwoFAHandlerOptions = {
+        domain: 'github.com',
+        credentialProvider,
+        timeoutMs: 5000,
+      };
+
+      const result = await handleTwoFA(page, detection, options);
+
+      expect(result.handled).toBe(true);
+      expect(result.type).toBe(TwoFAType.TOTP);
+      expect(result.method).toBe('auto-fill');
+      expect(page.click).toHaveBeenCalledWith('#otp-code');
+      expect(page.type).toHaveBeenCalledWith('#otp-code', expect.stringMatching(/^\d{6}$/));
+    });
+
+    test('retries with clock drift offset on first failure', async () => {
+      const detection = makeDetection({ type: TwoFAType.TOTP });
+      // URL never changes (all attempts fail)
+      const page = makePage({
+        urlSequence: ['https://github.com/login/two-factor'],
+      });
+      const credentialProvider = {
+        getTOTPSecret: jest.fn().mockResolvedValue('JBSWY3DPEHPK3PXP'),
+      };
+      const options: TwoFAHandlerOptions = {
+        domain: 'github.com',
+        credentialProvider,
+        maxRetries: 3,
+        timeoutMs: 1000,
+      };
+
+      const result = await handleTwoFA(page, detection, options);
+
+      // Should have tried maxRetries times
+      expect(page.type).toHaveBeenCalledTimes(3);
+      expect(result.handled).toBe(false);
+      expect(result.method).toBe('manual-hint');
+    });
+
+    test('stops after maxRetries', async () => {
+      const detection = makeDetection({ type: TwoFAType.TOTP });
+      const page = makePage({
+        urlSequence: ['https://github.com/login/two-factor'],
+      });
+      const credentialProvider = {
+        getTOTPSecret: jest.fn().mockResolvedValue('JBSWY3DPEHPK3PXP'),
+      };
+      const options: TwoFAHandlerOptions = {
+        domain: 'github.com',
+        credentialProvider,
+        maxRetries: 2,
+        timeoutMs: 500,
+      };
+
+      await handleTwoFA(page, detection, options);
+
+      expect(page.type).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('SMS handling', () => {
+    test('returns manual-hint with phone info', async () => {
+      const detection = makeDetection({ type: TwoFAType.SMS, inputSelector: '#sms-code' });
+      const page = makePage({ evaluateResult: 'Code sent to ***-***-5678' });
+      const options: TwoFAHandlerOptions = { domain: 'example.com' };
+
+      const result = await handleTwoFA(page, detection, options);
+
+      expect(result.handled).toBe(false);
+      expect(result.type).toBe(TwoFAType.SMS);
+      expect(result.method).toBe('manual-hint');
+      expect(result.message).toContain('SMS 2FA detected');
+    });
+
+    test('SMS includes masked phone number in message when present', async () => {
+      const detection = makeDetection({ type: TwoFAType.SMS });
+      const page = makePage({ evaluateResult: 'Code sent to ***-***-9012' });
+      const options: TwoFAHandlerOptions = { domain: 'example.com' };
+
+      const result = await handleTwoFA(page, detection, options);
+
+      expect(result.message).toContain('***-***-9012');
+    });
+  });
+
+  describe('Email handling', () => {
+    test('returns manual-hint for email 2FA', async () => {
+      const detection = makeDetection({ type: TwoFAType.EMAIL });
+      const page = makePage();
+      const options: TwoFAHandlerOptions = { domain: 'example.com' };
+
+      const result = await handleTwoFA(page, detection, options);
+
+      expect(result.handled).toBe(false);
+      expect(result.type).toBe(TwoFAType.EMAIL);
+      expect(result.method).toBe('manual-hint');
+      expect(result.message).toContain('email');
+    });
+  });
+
+  describe('Push handling', () => {
+    test('returns timeout when page does not change within timeoutMs', async () => {
+      const detection = makeDetection({ type: TwoFAType.PUSH, inputSelector: undefined });
+      const page = makePage({
+        urlSequence: ['https://example.com/2fa'],
+      });
+      const options: TwoFAHandlerOptions = { domain: 'example.com', timeoutMs: 600 };
+
+      const result = await handleTwoFA(page, detection, options);
+
+      expect(result.handled).toBe(false);
+      expect(result.type).toBe(TwoFAType.PUSH);
+      expect(result.method).toBe('timeout');
+      expect(result.message).toContain('timed out');
+    }, 5000);
+
+    test('returns handled when page URL changes (push approved)', async () => {
+      const detection = makeDetection({ type: TwoFAType.PUSH, inputSelector: undefined });
+      let urlCallCount = 0;
+      const page = {
+        url: jest.fn().mockImplementation(() => {
+          urlCallCount++;
+          // First 2 calls: same URL; 3rd call: changed (approved)
+          return urlCallCount <= 2
+            ? 'https://example.com/2fa'
+            : 'https://example.com/dashboard';
+        }),
+        evaluate: jest.fn().mockResolvedValue(''),
+        click: jest.fn().mockResolvedValue(undefined),
+        type: jest.fn().mockResolvedValue(undefined),
+        keyboard: { press: jest.fn().mockResolvedValue(undefined) },
+      };
+      const options: TwoFAHandlerOptions = { domain: 'example.com', timeoutMs: 5000 };
+
+      const result = await handleTwoFA(page, detection, options);
+
+      expect(result.handled).toBe(true);
+      expect(result.method).toBe('auto-fill');
+    }, 10000);
+  });
+
+  describe('Recovery handling', () => {
+    test('returns manual-hint for recovery codes', async () => {
+      const detection = makeDetection({ type: TwoFAType.RECOVERY });
+      const page = makePage();
+      const options: TwoFAHandlerOptions = { domain: 'example.com' };
+
+      const result = await handleTwoFA(page, detection, options);
+
+      expect(result.handled).toBe(false);
+      expect(result.type).toBe(TwoFAType.RECOVERY);
+      expect(result.method).toBe('manual-hint');
+      expect(result.message).toContain('Recovery code required');
+    });
+  });
+});

--- a/tests/auth/twofa-handler.test.ts
+++ b/tests/auth/twofa-handler.test.ts
@@ -76,7 +76,7 @@ describe('handleTwoFA', () => {
       const detection = makeDetection({ type: TwoFAType.TOTP });
       const page = makePage();
       const credentialProvider = {
-        getTOTPSecret: jest.fn().mockResolvedValue(undefined),
+        getCredentials: jest.fn().mockResolvedValue(null),
       };
       const options: TwoFAHandlerOptions = { domain: 'github.com', credentialProvider };
 
@@ -94,7 +94,7 @@ describe('handleTwoFA', () => {
         urlSequence: ['https://github.com/login/two-factor', 'https://github.com/dashboard'],
       });
       const credentialProvider = {
-        getTOTPSecret: jest.fn().mockResolvedValue('JBSWY3DPEHPK3PXP'),
+        getCredentials: jest.fn().mockResolvedValue({ totpSecret: 'JBSWY3DPEHPK3PXP' }),
       };
       const options: TwoFAHandlerOptions = {
         domain: 'github.com',
@@ -118,7 +118,7 @@ describe('handleTwoFA', () => {
         urlSequence: ['https://github.com/login/two-factor'],
       });
       const credentialProvider = {
-        getTOTPSecret: jest.fn().mockResolvedValue('JBSWY3DPEHPK3PXP'),
+        getCredentials: jest.fn().mockResolvedValue({ totpSecret: 'JBSWY3DPEHPK3PXP' }),
       };
       const options: TwoFAHandlerOptions = {
         domain: 'github.com',
@@ -141,7 +141,7 @@ describe('handleTwoFA', () => {
         urlSequence: ['https://github.com/login/two-factor'],
       });
       const credentialProvider = {
-        getTOTPSecret: jest.fn().mockResolvedValue('JBSWY3DPEHPK3PXP'),
+        getCredentials: jest.fn().mockResolvedValue({ totpSecret: 'JBSWY3DPEHPK3PXP' }),
       };
       const options: TwoFAHandlerOptions = {
         domain: 'github.com',

--- a/tests/cli/totp-cli.test.ts
+++ b/tests/cli/totp-cli.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for CLI TOTP management commands and totp-store core functions.
+ *
+ * File system operations are redirected to a temp directory by mocking the
+ * `os` module so that `os.homedir()` returns a test-local temp directory.
+ * No real ~/.openchrome/credentials/ files are touched.
+ */
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Set up a real temp directory and redirect homedir BEFORE importing the
+// module under test. We mock the entire `os` module so homedir() is writable.
+// ---------------------------------------------------------------------------
+
+const realTmpdir = os.tmpdir();
+const tempDir = fs.mkdtempSync(path.join(realTmpdir, 'totp-cli-test-'));
+
+// Mock os module so homedir() returns our temp directory
+jest.mock('os', () => {
+  const realOs = jest.requireActual<typeof os>('os');
+  return {
+    ...realOs,
+    homedir: () => tempDir,
+  };
+});
+
+afterAll(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  // Remove the encrypted store between tests so each test starts clean
+  const storePath = path.join(tempDir, '.openchrome', 'credentials', 'totp-secrets.enc');
+  if (fs.existsSync(storePath)) {
+    fs.unlinkSync(storePath);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Import AFTER mocking os
+// ---------------------------------------------------------------------------
+
+import {
+  addTotpSecret,
+  base32Decode,
+  generateTOTP,
+  getTotpSecret,
+  listTotpDomains,
+  removeTotpSecret,
+  validateBase32,
+} from '../../cli/totp-store';
+
+// ---------------------------------------------------------------------------
+// base32Decode
+// ---------------------------------------------------------------------------
+
+describe('base32Decode', () => {
+  test('decodes a known base32 value', () => {
+    // base32("f") = "MY======"
+    const result = base32Decode('MY');
+    expect(result).toEqual(Buffer.from([0x66])); // 0x66 = 'f'
+  });
+
+  test('handles lowercase input', () => {
+    expect(base32Decode('my')).toEqual(base32Decode('MY'));
+  });
+
+  test('throws on invalid character', () => {
+    expect(() => base32Decode('1NVALID!')).toThrow(/Invalid base32/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateBase32
+// ---------------------------------------------------------------------------
+
+describe('validateBase32', () => {
+  test('accepts valid uppercase base32', () => {
+    expect(validateBase32('JBSWY3DPEHPK3PXP')).toBe(true);
+  });
+
+  test('accepts valid lowercase base32', () => {
+    expect(validateBase32('jbswy3dpehpk3pxp')).toBe(true);
+  });
+
+  test('rejects strings with invalid characters', () => {
+    expect(validateBase32('NOT_VALID!')).toBe(false);
+  });
+
+  test('rejects empty string', () => {
+    expect(validateBase32('')).toBe(false);
+  });
+
+  test('rejects digit 1 (not in base32 alphabet)', () => {
+    expect(validateBase32('1NVALID')).toBe(false);
+  });
+
+  test('accepts base32 with padding characters', () => {
+    expect(validateBase32('MY======')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateTOTP
+// ---------------------------------------------------------------------------
+
+describe('generateTOTP', () => {
+  test('returns a 6-digit string', () => {
+    const code = generateTOTP('JBSWY3DPEHPK3PXP');
+    expect(code).toMatch(/^\d{6}$/);
+  });
+
+  test('two consecutive calls in the same time window return the same code', () => {
+    const secret = 'JBSWY3DPEHPK3PXP';
+    expect(generateTOTP(secret)).toBe(generateTOTP(secret));
+  });
+
+  test('produces consistent output for a known counter value (RFC 6238 test vector)', () => {
+    // RFC 6238 test vector: secret ASCII "12345678901234567890"
+    // Base32 of that byte sequence: GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ
+    // T=59s → counter = floor(59/30) = 1, expected TOTP = 287082 (SHA1)
+    const secret = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
+    const realDateNow = Date.now;
+    try {
+      Date.now = () => 59 * 1000;
+      const code = generateTOTP(secret);
+      expect(code).toBe('287082');
+    } finally {
+      Date.now = realDateNow;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Storage: add / list / get / remove
+// ---------------------------------------------------------------------------
+
+describe('totp storage', () => {
+  const DOMAIN = 'example.com';
+  const SECRET = 'JBSWY3DPEHPK3PXP';
+  const ISSUER = 'Example';
+
+  test('totp add: stores an encrypted secret that can be retrieved', async () => {
+    await addTotpSecret(DOMAIN, SECRET, ISSUER);
+    const retrieved = await getTotpSecret(DOMAIN);
+    expect(retrieved).toBe(SECRET.toUpperCase());
+  });
+
+  test('totp list: shows domain and issuer but NOT the raw secret', async () => {
+    await addTotpSecret(DOMAIN, SECRET, ISSUER);
+    const list = await listTotpDomains();
+
+    expect(list).toHaveLength(1);
+    expect(list[0].domain).toBe(DOMAIN);
+    expect(list[0].issuer).toBe(ISSUER);
+    expect(list[0].addedAt).toBeTruthy();
+
+    // The list entry must not expose the secret in any form
+    const serialised = JSON.stringify(list[0]);
+    expect(serialised).not.toContain(SECRET);
+  });
+
+  test('totp list: returns empty array when no secrets are configured', async () => {
+    const list = await listTotpDomains();
+    expect(list).toHaveLength(0);
+  });
+
+  test('totp remove: deletes the specific domain entry and returns true', async () => {
+    await addTotpSecret(DOMAIN, SECRET, ISSUER);
+    const removed = await removeTotpSecret(DOMAIN);
+    expect(removed).toBe(true);
+
+    const list = await listTotpDomains();
+    expect(list).toHaveLength(0);
+  });
+
+  test('totp remove: returns false for a non-existent domain', async () => {
+    const removed = await removeTotpSecret('nonexistent.com');
+    expect(removed).toBe(false);
+  });
+
+  test('getTotpSecret returns null for an unconfigured domain', async () => {
+    const secret = await getTotpSecret('unconfigured.com');
+    expect(secret).toBeNull();
+  });
+
+  test('totp add: overwrites the existing entry when called twice for the same domain', async () => {
+    await addTotpSecret(DOMAIN, SECRET, 'Old Issuer');
+    await addTotpSecret(DOMAIN, 'MFRA', 'New Issuer');
+
+    const list = await listTotpDomains();
+    expect(list).toHaveLength(1);
+    expect(list[0].issuer).toBe('New Issuer');
+
+    const retrieved = await getTotpSecret(DOMAIN);
+    expect(retrieved).toBe('MFRA');
+  });
+
+  test('encryption round-trip: decrypt(encrypt(secret)) === secret', async () => {
+    const domain = 'roundtrip.test';
+    const secret = 'NBSWY3DPEB3W64TMMQ';
+    await addTotpSecret(domain, secret);
+    const result = await getTotpSecret(domain);
+    expect(result).toBe(secret);
+  });
+
+  test('storage file is created with mode 0o600', async () => {
+    await addTotpSecret(DOMAIN, SECRET);
+    const storePath = path.join(tempDir, '.openchrome', 'credentials', 'totp-secrets.enc');
+    const stat = fs.statSync(storePath);
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: totp generate uses the stored secret
+// ---------------------------------------------------------------------------
+
+describe('totp generate (integration)', () => {
+  test('generate: outputs a valid 6-digit code for a configured domain', async () => {
+    const domain = 'generate.test';
+    const secret = 'JBSWY3DPEHPK3PXP';
+    await addTotpSecret(domain, secret);
+
+    const stored = await getTotpSecret(domain);
+    expect(stored).toBeTruthy();
+
+    const code = generateTOTP(stored!);
+    expect(code).toMatch(/^\d{6}$/);
+  });
+
+  test('generate: returns null secret for an unconfigured domain', async () => {
+    const secret = await getTotpSecret('not-configured.com');
+    expect(secret).toBeNull();
+  });
+});

--- a/tests/cli/totp-cli.test.ts
+++ b/tests/cli/totp-cli.test.ts
@@ -208,7 +208,8 @@ describe('totp storage', () => {
     expect(result).toBe(secret);
   });
 
-  test('storage file is created with mode 0o600', async () => {
+  const isWindows = os.platform() === 'win32';
+  (isWindows ? test.skip : test)('storage file is created with mode 0o600', async () => {
     await addTotpSecret(DOMAIN, SECRET);
     const storePath = path.join(tempDir, '.openchrome', 'credentials', 'totp-secrets.enc');
     const stat = fs.statSync(storePath);

--- a/tests/cli/totp-cli.test.ts
+++ b/tests/cli/totp-cli.test.ts
@@ -215,6 +215,49 @@ describe('totp storage', () => {
     const stat = fs.statSync(storePath);
     expect(stat.mode & 0o777).toBe(0o600);
   });
+
+  test('storage file is binary (not hex text)', async () => {
+    await addTotpSecret(DOMAIN, SECRET);
+    const storePath = path.join(tempDir, '.openchrome', 'credentials', 'totp-secrets.enc');
+    const data = fs.readFileSync(storePath);
+    // Binary buffer: length should be 16(salt) + 16(iv) + 16(tag) + ciphertext
+    // Minimum length is 48 bytes (header alone), actual ciphertext adds more
+    expect(data.length).toBeGreaterThan(48);
+    // Must NOT be valid UTF-8 hex string (i.e., not all hex chars)
+    const asHex = data.toString('hex');
+    expect(asHex.length).toBe(data.length * 2); // hex is double length of binary
+    // The raw buffer should NOT equal its own hex re-encoding as string bytes
+    expect(data.toString('utf8')).not.toMatch(/^[0-9a-f]+$/i);
+  });
+
+  test('decryption failure throws with clear message', async () => {
+    const storePath = path.join(tempDir, '.openchrome', 'credentials', 'totp-secrets.enc');
+    const dir = path.dirname(storePath);
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    // Write a file that is large enough to pass the length check but has garbage data
+    fs.writeFileSync(storePath, crypto.randomBytes(64), { mode: 0o600 });
+    await expect(getTotpSecret(DOMAIN)).rejects.toThrow('Failed to decrypt credential store');
+  });
+
+  test('corrupted JSON throws with clear message', async () => {
+    const storePath = path.join(tempDir, '.openchrome', 'credentials', 'totp-secrets.enc');
+    const dir = path.dirname(storePath);
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+
+    // Encrypt invalid JSON and write it directly
+    const { createCipheriv, randomBytes, scryptSync } = crypto;
+    const salt = randomBytes(16);
+    const iv = randomBytes(16);
+    const machineId = os.hostname() + os.userInfo().username;
+    const key = scryptSync('openchrome-totp-v1' + machineId, salt, 32) as Buffer;
+    const cipher = createCipheriv('aes-256-gcm', key, iv);
+    const encrypted = Buffer.concat([cipher.update('not valid json', 'utf8'), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+    const fileData = Buffer.concat([salt, iv, authTag, encrypted]);
+    fs.writeFileSync(storePath, fileData, { mode: 0o600 });
+
+    await expect(getTotpSecret(DOMAIN)).rejects.toThrow('Credential store corrupted');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/cross-env/cursor-verification.test.ts
+++ b/tests/cross-env/cursor-verification.test.ts
@@ -235,8 +235,8 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
         expect(toolNames).toContain(tool);
       }
 
-      // Total should be 63 (31 T1 + 23 T2 + 9 T3)
-      expect(toolNames.length).toBe(63);
+      // Total should be 64 (31 T1 + 24 T2 + 9 T3)
+      expect(toolNames.length).toBe(64);
     });
 
     test('resources/list returns usage guide resource', async () => {
@@ -294,7 +294,7 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
       'console_capture', 'performance_metrics', 'file_upload',
       'batch_execute', 'batch_paginate',
       'oc_recording_start', 'oc_recording_stop', 'oc_recording_list', 'oc_recording_export',
-      'crawl', 'crawl_sitemap', 'vision_find', 'extract_data',
+      'crawl', 'crawl_sitemap', 'vision_find', 'extract_data', 'oc_totp_generate',
     ];
     tier2Tools.forEach(tool => {
       test(`Tier 2: ${tool} registered`, () => {
@@ -417,8 +417,8 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
 
       // Should NOT have expand_tools (progressive disclosure disabled)
       expect(toolNames).not.toContain('expand_tools');
-      // Total should be 63 (31 T1 + 23 T2 + 9 T3)
-      expect(toolNames.length).toBe(63);
+      // Total should be 64 (31 T1 + 24 T2 + 9 T3)
+      expect(toolNames.length).toBe(64);
     });
   });
 });

--- a/tests/tools/totp-generate.test.ts
+++ b/tests/tools/totp-generate.test.ts
@@ -1,0 +1,140 @@
+/// <reference types="jest" />
+/**
+ * Unit tests for oc_totp_generate MCP tool
+ */
+
+import { MCPServer } from '../../src/mcp-server';
+
+// We'll capture the registered handler by intercepting registerTool
+let capturedHandler: ((sessionId: string, args: Record<string, unknown>) => Promise<unknown>) | null = null;
+
+function getHandler() {
+  if (!capturedHandler) throw new Error('Handler not registered');
+  return capturedHandler;
+}
+
+// Known TOTP secret for deterministic testing (RFC 4226 test vector)
+const TEST_SECRET = 'JBSWY3DPEHPK3PXP'; // base32 of "Hello!\xDE\xAD\xBE\xEF"
+const TEST_DOMAIN = 'github.com';
+
+describe('oc_totp_generate tool', () => {
+  beforeEach(() => {
+    capturedHandler = null;
+    jest.resetModules();
+    // Clear env vars between tests
+    delete process.env[`OPENCHROME_TOTP_${TEST_DOMAIN.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`];
+  });
+
+  async function loadTool() {
+    const { registerTotpGenerateTool } = await import('../../src/tools/totp-generate');
+    const mockServer = {
+      registerTool: jest.fn().mockImplementation((_name: string, handler: Function) => {
+        capturedHandler = handler as typeof capturedHandler;
+      }),
+    } as unknown as MCPServer;
+    registerTotpGenerateTool(mockServer);
+    return getHandler();
+  }
+
+  describe('error handling', () => {
+    test('returns error when domain is missing', async () => {
+      const handler = await loadTool();
+      const result = await handler('session-1', {}) as any;
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('domain is required');
+    });
+
+    test('returns error with setup instructions when domain not configured', async () => {
+      const handler = await loadTool();
+      const result = await handler('session-1', { domain: 'unconfigured.com' }) as any;
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error).toContain('not configured');
+      expect(parsed.domain).toBe('unconfigured.com');
+      expect(parsed.setup).toContain('npx openchrome totp add');
+      expect(parsed.setup).toContain('unconfigured.com');
+    });
+  });
+
+  describe('code generation', () => {
+    test('generates a 6-digit code for configured domain', async () => {
+      process.env[`OPENCHROME_TOTP_${TEST_DOMAIN.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`] = TEST_SECRET;
+
+      const handler = await loadTool();
+      const result = await handler('session-1', { domain: TEST_DOMAIN }) as any;
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.code).toMatch(/^\d{6}$/);
+      expect(parsed.domain).toBe(TEST_DOMAIN);
+    });
+
+    test('response includes secondsRemaining in range 1-30', async () => {
+      process.env[`OPENCHROME_TOTP_${TEST_DOMAIN.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`] = TEST_SECRET;
+
+      const handler = await loadTool();
+      const result = await handler('session-1', { domain: TEST_DOMAIN }) as any;
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.secondsRemaining).toBeGreaterThanOrEqual(1);
+      expect(parsed.secondsRemaining).toBeLessThanOrEqual(30);
+    });
+
+    test('response includes expiresAt timestamp', async () => {
+      process.env[`OPENCHROME_TOTP_${TEST_DOMAIN.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`] = TEST_SECRET;
+
+      const handler = await loadTool();
+      const result = await handler('session-1', { domain: TEST_DOMAIN }) as any;
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.expiresAt).toBeTruthy();
+      // Should be a valid ISO date string
+      expect(() => new Date(parsed.expiresAt)).not.toThrow();
+      const expiryDate = new Date(parsed.expiresAt);
+      expect(expiryDate.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    test('response does NOT include the secret', async () => {
+      process.env[`OPENCHROME_TOTP_${TEST_DOMAIN.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`] = TEST_SECRET;
+
+      const handler = await loadTool();
+      const result = await handler('session-1', { domain: TEST_DOMAIN }) as any;
+
+      const responseText = result.content[0].text;
+      // Secret must not appear in the response
+      expect(responseText).not.toContain(TEST_SECRET);
+      expect(responseText).not.toContain(TEST_SECRET.toLowerCase());
+    });
+
+    test('generates same code within same 30s window', async () => {
+      process.env[`OPENCHROME_TOTP_${TEST_DOMAIN.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`] = TEST_SECRET;
+
+      const handler = await loadTool();
+
+      const result1 = await handler('session-1', { domain: TEST_DOMAIN }) as any;
+      const result2 = await handler('session-1', { domain: TEST_DOMAIN }) as any;
+
+      const parsed1 = JSON.parse(result1.content[0].text);
+      const parsed2 = JSON.parse(result2.content[0].text);
+
+      // Both generated within same test run — should be same time step
+      expect(parsed1.code).toBe(parsed2.code);
+    });
+
+    test('registers with correct tool name', async () => {
+      const { registerTotpGenerateTool } = await import('../../src/tools/totp-generate');
+      const registeredNames: string[] = [];
+      const mockServer = {
+        registerTool: jest.fn().mockImplementation((name: string) => {
+          registeredNames.push(name);
+        }),
+      } as unknown as MCPServer;
+
+      registerTotpGenerateTool(mockServer);
+
+      expect(registeredNames).toContain('oc_totp_generate');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **`src/auth/totp-manager.ts`**: RFC 6238 TOTP code generation using Node.js built-in `crypto` only (no external dependencies). Exports `generateTOTP`, `validateBase32`, `base32Decode`, `hmacDigest`, and `dynamicTruncation`. Supports configurable period, digits, algorithm, and ±N-step time offset for clock drift.
- **`src/auth/credential-store.ts`**: AES-256-GCM encrypted storage of TOTP secrets in `~/.openchrome/credentials/totp-secrets.enc`. Key derived via `crypto.scryptSync(passphrase + machineId, salt, 32)`. File permissions 0o600, directory 0o700. Uses `write-file-atomic` for safe writes and `proper-lockfile` for concurrent access safety.
- **`tests/auth/totp-manager.test.ts`**: 29 unit tests covering RFC 6238 test vectors (all 5 SHA1 vectors pass), base32 validation/decode, HMAC, dynamic truncation, digit/period options, and clock drift offsets.
- **`tests/auth/credential-store.test.ts`**: 17 unit tests covering round-trip encryption, multi-entry storage, remove/preserve, invalid base32 rejection, wrong passphrase error, file permissions (POSIX only), and concurrent add safety.

## Test plan

- [x] `npm run build` — compiles cleanly with zero errors
- [x] `npx jest tests/auth/` — 46/46 tests pass across both suites
- [x] RFC 6238 SHA1 test vectors verified: T=59→287082, T=1111111109→081804, T=1111111111→050471, T=1234567890→005924, T=2000000000→279037
- [x] File permissions 0o600/0o700 verified on macOS
- [x] Concurrent add test (Promise.all) verifies no data loss under lock contention

Closes shaun0927/TheGiant#30 (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)