### PR TITLE
feat(cli): add TOTP management commands (#575)

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -31,6 +31,15 @@ import {
   isSupportedMCPClient,
   upsertMCPServerConfig,
 } from './mcp-client-config';
+import {
+  addTotpSecret,
+  generateTOTP,
+  getTotpSecret,
+  listTotpDomains,
+  removeTotpSecret,
+  totpSecondsRemaining,
+  validateBase32,
+} from './totp-store';
 
 const program = new Command();
 
@@ -1140,5 +1149,98 @@ function attemptJsonRecovery(content: string): object | null {
 
   return null;
 }
+
+// ---------------------------------------------------------------------------
+// totp command group
+// ---------------------------------------------------------------------------
+
+const totp = program.command('totp').description('Manage TOTP secrets for 2FA automation');
+
+totp
+  .command('add')
+  .description('Add a TOTP secret for a domain')
+  .requiredOption('--domain <domain>', 'Domain the secret belongs to (e.g. github.com)')
+  .requiredOption('--secret <base32-secret>', 'TOTP secret in base32 format')
+  .option('--issuer <name>', 'Human-readable issuer name (e.g. GitHub)')
+  .action(async (options: { domain: string; secret: string; issuer?: string }) => {
+    if (!validateBase32(options.secret)) {
+      console.error(`❌ Invalid base32 secret. Ensure the secret only contains characters A-Z and 2-7.`);
+      process.exit(1);
+    }
+    try {
+      await addTotpSecret(options.domain, options.secret, options.issuer);
+      console.error(`TOTP secret added for ${options.domain}`);
+    } catch (error) {
+      console.error(`❌ Failed to store TOTP secret: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+totp
+  .command('list')
+  .description('List all configured TOTP domains')
+  .action(async () => {
+    try {
+      const domains = await listTotpDomains();
+      if (domains.length === 0) {
+        console.error('No TOTP secrets configured.');
+        return;
+      }
+      // Table header
+      const domainWidth = Math.max(6, ...domains.map((d) => d.domain.length));
+      const issuerWidth = Math.max(6, ...domains.map((d) => (d.issuer ?? '').length));
+      const header = `${'Domain'.padEnd(domainWidth)}  ${'Issuer'.padEnd(issuerWidth)}  Added`;
+      const separator = '-'.repeat(header.length);
+      console.error(header);
+      console.error(separator);
+      for (const entry of domains) {
+        const addedAt = new Date(entry.addedAt).toISOString().split('T')[0];
+        console.error(
+          `${entry.domain.padEnd(domainWidth)}  ${(entry.issuer ?? '').padEnd(issuerWidth)}  ${addedAt}`
+        );
+      }
+    } catch (error) {
+      console.error(`❌ Failed to list TOTP secrets: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+totp
+  .command('remove')
+  .description('Remove the TOTP secret for a domain')
+  .requiredOption('--domain <domain>', 'Domain to remove')
+  .action(async (options: { domain: string }) => {
+    try {
+      const removed = await removeTotpSecret(options.domain);
+      if (!removed) {
+        console.error(`❌ No TOTP secret found for ${options.domain}`);
+        process.exit(1);
+      }
+      console.error(`TOTP secret removed for ${options.domain}`);
+    } catch (error) {
+      console.error(`❌ Failed to remove TOTP secret: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
+
+totp
+  .command('generate')
+  .description('Generate the current TOTP code for a domain')
+  .requiredOption('--domain <domain>', 'Domain to generate code for')
+  .action(async (options: { domain: string }) => {
+    try {
+      const secret = await getTotpSecret(options.domain);
+      if (secret === null) {
+        console.error(`❌ No TOTP secret configured for ${options.domain}`);
+        process.exit(1);
+      }
+      const code = generateTOTP(secret);
+      const secondsLeft = totpSecondsRemaining();
+      console.error(`${code} (${secondsLeft}s remaining)`);
+    } catch (error) {
+      console.error(`❌ Failed to generate TOTP code: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    }
+  });
 
 program.parse();

--- a/cli/totp-store.ts
+++ b/cli/totp-store.ts
@@ -1,0 +1,242 @@
+/**
+ * Self-contained TOTP store for CLI use.
+ *
+ * Provides TOTP generation (RFC 6238, SHA1, 6 digits, 30s period) and
+ * encrypted storage of TOTP secrets using AES-256-GCM.
+ *
+ * Storage path: ~/.openchrome/credentials/totp-secrets.enc
+ * Encryption key: scrypt(hostname + username, salt, 32)
+ * File permissions: 0o600 (directory: 0o700)
+ */
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Base32 helpers
+// ---------------------------------------------------------------------------
+
+const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+/**
+ * Decode a base32-encoded string to a Buffer.
+ * Accepts uppercase and lowercase input; ignores padding characters.
+ */
+export function base32Decode(encoded: string): Buffer {
+  const input = encoded.toUpperCase().replace(/=+$/, '');
+  let bits = 0;
+  let value = 0;
+  const output: number[] = [];
+
+  for (const char of input) {
+    const idx = BASE32_ALPHABET.indexOf(char);
+    if (idx === -1) {
+      throw new Error(`Invalid base32 character: ${char}`);
+    }
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      output.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+
+  return Buffer.from(output);
+}
+
+/**
+ * Return true when the input is a valid base32 string (RFC 4648).
+ * Allows lowercase, optional padding, and ignores surrounding whitespace.
+ */
+export function validateBase32(secret: string): boolean {
+  const cleaned = secret.trim().toUpperCase().replace(/=+$/, '');
+  if (cleaned.length === 0) return false;
+  return /^[A-Z2-7]+$/.test(cleaned);
+}
+
+// ---------------------------------------------------------------------------
+// TOTP generation (RFC 6238)
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate the current TOTP code for a base32-encoded secret.
+ * Uses SHA1, 6 digits, 30-second period.
+ */
+export function generateTOTP(secret: string): string {
+  const key = base32Decode(secret);
+  const counter = Math.floor(Date.now() / 1000 / 30);
+
+  const counterBuf = Buffer.alloc(8);
+  // Write as big-endian 64-bit integer (upper 32 bits are 0 for near-future dates)
+  counterBuf.writeUInt32BE(Math.floor(counter / 0x100000000), 0);
+  counterBuf.writeUInt32BE(counter >>> 0, 4);
+
+  const hmac = crypto.createHmac('sha1', key);
+  hmac.update(counterBuf);
+  const digest = hmac.digest();
+
+  const offset = digest[digest.length - 1] & 0x0f;
+  const code =
+    ((digest[offset] & 0x7f) << 24) |
+    ((digest[offset + 1] & 0xff) << 16) |
+    ((digest[offset + 2] & 0xff) << 8) |
+    (digest[offset + 3] & 0xff);
+
+  return String(code % 1_000_000).padStart(6, '0');
+}
+
+/**
+ * Return the number of seconds remaining in the current 30-second TOTP window.
+ */
+export function totpSecondsRemaining(): number {
+  return 30 - (Math.floor(Date.now() / 1000) % 30);
+}
+
+// ---------------------------------------------------------------------------
+// Encryption helpers (AES-256-GCM)
+// ---------------------------------------------------------------------------
+
+const SALT = 'openchrome-totp-v1';
+const SCRYPT_N = 16384;
+const SCRYPT_R = 8;
+const SCRYPT_P = 1;
+const KEY_LEN = 32;
+
+function deriveKey(): Buffer {
+  const passphrase = `${os.hostname()}:${os.userInfo().username}`;
+  return crypto.scryptSync(passphrase, SALT, KEY_LEN, { N: SCRYPT_N, r: SCRYPT_R, p: SCRYPT_P });
+}
+
+function encrypt(plaintext: string, key: Buffer): string {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  // Format: iv(12) + tag(16) + ciphertext — all hex-encoded
+  return Buffer.concat([iv, tag, encrypted]).toString('hex');
+}
+
+function decrypt(hexData: string, key: Buffer): string {
+  const data = Buffer.from(hexData, 'hex');
+  const iv = data.subarray(0, 12);
+  const tag = data.subarray(12, 28);
+  const ciphertext = data.subarray(28);
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(tag);
+  return decipher.update(ciphertext) + decipher.final('utf8');
+}
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
+
+function getStoragePath(): string {
+  return path.join(os.homedir(), '.openchrome', 'credentials', 'totp-secrets.enc');
+}
+
+interface TotpEntry {
+  domain: string;
+  encryptedSecret: string;
+  issuer?: string;
+  addedAt: string;
+}
+
+function readEntries(): TotpEntry[] {
+  const storagePath = getStoragePath();
+  if (!fs.existsSync(storagePath)) return [];
+
+  try {
+    const raw = fs.readFileSync(storagePath, 'utf8').trim();
+    if (!raw) return [];
+    const key = deriveKey();
+    const plaintext = decrypt(raw, key);
+    return JSON.parse(plaintext) as TotpEntry[];
+  } catch {
+    return [];
+  }
+}
+
+function writeEntries(entries: TotpEntry[]): void {
+  const storagePath = getStoragePath();
+  const dir = path.dirname(storagePath);
+
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+
+  const key = deriveKey();
+  const plaintext = JSON.stringify(entries, null, 2);
+  const encrypted = encrypt(plaintext, key);
+
+  fs.writeFileSync(storagePath, encrypted, { encoding: 'utf8', mode: 0o600 });
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Add (or overwrite) a TOTP secret for a domain.
+ */
+export async function addTotpSecret(domain: string, secret: string, issuer?: string): Promise<void> {
+  const entries = readEntries();
+  const idx = entries.findIndex((e) => e.domain === domain);
+
+  const key = deriveKey();
+  const encryptedSecret = encrypt(secret.toUpperCase().replace(/\s/g, ''), key);
+
+  const entry: TotpEntry = {
+    domain,
+    encryptedSecret,
+    issuer,
+    addedAt: new Date().toISOString(),
+  };
+
+  if (idx >= 0) {
+    entries[idx] = entry;
+  } else {
+    entries.push(entry);
+  }
+
+  writeEntries(entries);
+}
+
+/**
+ * Remove a TOTP secret for a domain.
+ * Returns true if removed, false if not found.
+ */
+export async function removeTotpSecret(domain: string): Promise<boolean> {
+  const entries = readEntries();
+  const idx = entries.findIndex((e) => e.domain === domain);
+  if (idx < 0) return false;
+
+  entries.splice(idx, 1);
+  writeEntries(entries);
+  return true;
+}
+
+/**
+ * List all configured TOTP domains (never returns secrets).
+ */
+export async function listTotpDomains(): Promise<Array<{ domain: string; issuer?: string; addedAt: string }>> {
+  const entries = readEntries();
+  return entries.map(({ domain, issuer, addedAt }) => ({ domain, issuer, addedAt }));
+}
+
+/**
+ * Retrieve the plaintext TOTP secret for a domain, or null if not found.
+ */
+export async function getTotpSecret(domain: string): Promise<string | null> {
+  const entries = readEntries();
+  const entry = entries.find((e) => e.domain === domain);
+  if (!entry) return null;
+
+  try {
+    const key = deriveKey();
+    return decrypt(entry.encryptedSecret, key);
+  } catch {
+    return null;
+  }
+}

--- a/cli/totp-store.ts
+++ b/cli/totp-store.ts
@@ -5,7 +5,8 @@
  * encrypted storage of TOTP secrets using AES-256-GCM.
  *
  * Storage path: ~/.openchrome/credentials/totp-secrets.enc
- * Encryption key: scrypt(hostname + username, salt, 32)
+ * File format:  [salt(16)][iv(16)][authTag(16)][ciphertext]
+ * Key derivation: scrypt('openchrome-totp-v1' + hostname + username, randomSalt, 32)
  * File permissions: 0o600 (directory: 0o700)
  */
 
@@ -98,33 +99,38 @@ export function totpSecondsRemaining(): number {
 // Encryption helpers (AES-256-GCM)
 // ---------------------------------------------------------------------------
 
-const SALT = 'openchrome-totp-v1';
-const SCRYPT_N = 16384;
-const SCRYPT_R = 8;
-const SCRYPT_P = 1;
-const KEY_LEN = 32;
+const PASSPHRASE = 'openchrome-totp-v1';
+const SALT_LENGTH = 16;
+const IV_LENGTH = 16;
+const AUTH_TAG_LENGTH = 16;
+// File format: [salt(16)][iv(16)][authTag(16)][ciphertext]
 
-function deriveKey(): Buffer {
-  const passphrase = `${os.hostname()}:${os.userInfo().username}`;
-  return crypto.scryptSync(passphrase, SALT, KEY_LEN, { N: SCRYPT_N, r: SCRYPT_R, p: SCRYPT_P });
+function deriveKey(salt: Buffer): Buffer {
+  const machineId = os.hostname() + os.userInfo().username;
+  return crypto.scryptSync(PASSPHRASE + machineId, salt, 32) as Buffer;
 }
 
-function encrypt(plaintext: string, key: Buffer): string {
-  const iv = crypto.randomBytes(12);
+function encrypt(plaintext: string): Buffer {
+  const salt = crypto.randomBytes(SALT_LENGTH);
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const key = deriveKey(salt);
   const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
   const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
-  const tag = cipher.getAuthTag();
-  // Format: iv(12) + tag(16) + ciphertext — all hex-encoded
-  return Buffer.concat([iv, tag, encrypted]).toString('hex');
+  const authTag = cipher.getAuthTag();
+  return Buffer.concat([salt, iv, authTag, encrypted]);
 }
 
-function decrypt(hexData: string, key: Buffer): string {
-  const data = Buffer.from(hexData, 'hex');
-  const iv = data.subarray(0, 12);
-  const tag = data.subarray(12, 28);
-  const ciphertext = data.subarray(28);
+function decrypt(data: Buffer): string {
+  if (data.length < SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH) {
+    throw new Error('Credential file is too short or corrupted');
+  }
+  const salt = data.subarray(0, SALT_LENGTH);
+  const iv = data.subarray(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
+  const authTag = data.subarray(SALT_LENGTH + IV_LENGTH, SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH);
+  const ciphertext = data.subarray(SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH);
+  const key = deriveKey(salt);
   const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
-  decipher.setAuthTag(tag);
+  decipher.setAuthTag(authTag);
   return decipher.update(ciphertext) + decipher.final('utf8');
 }
 
@@ -138,24 +144,37 @@ function getStoragePath(): string {
 
 interface TotpEntry {
   domain: string;
-  encryptedSecret: string;
+  secret: string;
   issuer?: string;
   addedAt: string;
+}
+
+interface TotpStore {
+  entries: TotpEntry[];
 }
 
 function readEntries(): TotpEntry[] {
   const storagePath = getStoragePath();
   if (!fs.existsSync(storagePath)) return [];
 
+  const data = fs.readFileSync(storagePath);
+  if (data.length === 0) return [];
+
+  let plaintext: string;
   try {
-    const raw = fs.readFileSync(storagePath, 'utf8').trim();
-    if (!raw) return [];
-    const key = deriveKey();
-    const plaintext = decrypt(raw, key);
-    return JSON.parse(plaintext) as TotpEntry[];
+    plaintext = decrypt(data);
   } catch {
-    return [];
+    throw new Error('Failed to decrypt credential store');
   }
+
+  let store: TotpStore;
+  try {
+    store = JSON.parse(plaintext) as TotpStore;
+  } catch {
+    throw new Error('Credential store corrupted');
+  }
+
+  return store.entries;
 }
 
 function writeEntries(entries: TotpEntry[]): void {
@@ -166,11 +185,10 @@ function writeEntries(entries: TotpEntry[]): void {
     fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
 
-  const key = deriveKey();
-  const plaintext = JSON.stringify(entries, null, 2);
-  const encrypted = encrypt(plaintext, key);
+  const plaintext = JSON.stringify({ entries });
+  const encrypted = encrypt(plaintext);
 
-  fs.writeFileSync(storagePath, encrypted, { encoding: 'utf8', mode: 0o600 });
+  fs.writeFileSync(storagePath, encrypted, { mode: 0o600 });
 }
 
 // ---------------------------------------------------------------------------
@@ -184,12 +202,9 @@ export async function addTotpSecret(domain: string, secret: string, issuer?: str
   const entries = readEntries();
   const idx = entries.findIndex((e) => e.domain === domain);
 
-  const key = deriveKey();
-  const encryptedSecret = encrypt(secret.toUpperCase().replace(/\s/g, ''), key);
-
   const entry: TotpEntry = {
     domain,
-    encryptedSecret,
+    secret: secret.toUpperCase().replace(/\s/g, ''),
     issuer,
     addedAt: new Date().toISOString(),
   };
@@ -231,12 +246,5 @@ export async function listTotpDomains(): Promise<Array<{ domain: string; issuer?
 export async function getTotpSecret(domain: string): Promise<string | null> {
   const entries = readEntries();
   const entry = entries.find((e) => e.domain === domain);
-  if (!entry) return null;
-
-  try {
-    const key = deriveKey();
-    return decrypt(entry.encryptedSecret, key);
-  } catch {
-    return null;
-  }
+  return entry?.secret ?? null;
 }

--- a/tests/cli/totp-cli.test.ts
+++ b/tests/cli/totp-cli.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for CLI TOTP management commands and totp-store core functions.
+ *
+ * File system operations are redirected to a temp directory by mocking the
+ * `os` module so that `os.homedir()` returns a test-local temp directory.
+ * No real ~/.openchrome/credentials/ files are touched.
+ */
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Set up a real temp directory and redirect homedir BEFORE importing the
+// module under test. We mock the entire `os` module so homedir() is writable.
+// ---------------------------------------------------------------------------
+
+const realTmpdir = os.tmpdir();
+const tempDir = fs.mkdtempSync(path.join(realTmpdir, 'totp-cli-test-'));
+
+// Mock os module so homedir() returns our temp directory
+jest.mock('os', () => {
+  const realOs = jest.requireActual<typeof os>('os');
+  return {
+    ...realOs,
+    homedir: () => tempDir,
+  };
+});
+
+afterAll(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  // Remove the encrypted store between tests so each test starts clean
+  const storePath = path.join(tempDir, '.openchrome', 'credentials', 'totp-secrets.enc');
+  if (fs.existsSync(storePath)) {
+    fs.unlinkSync(storePath);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Import AFTER mocking os
+// ---------------------------------------------------------------------------
+
+import {
+  addTotpSecret,
+  base32Decode,
+  generateTOTP,
+  getTotpSecret,
+  listTotpDomains,
+  removeTotpSecret,
+  validateBase32,
+} from '../../cli/totp-store';
+
+// ---------------------------------------------------------------------------
+// base32Decode
+// ---------------------------------------------------------------------------
+
+describe('base32Decode', () => {
+  test('decodes a known base32 value', () => {
+    // base32("f") = "MY======"
+    const result = base32Decode('MY');
+    expect(result).toEqual(Buffer.from([0x66])); // 0x66 = 'f'
+  });
+
+  test('handles lowercase input', () => {
+    expect(base32Decode('my')).toEqual(base32Decode('MY'));
+  });
+
+  test('throws on invalid character', () => {
+    expect(() => base32Decode('1NVALID!')).toThrow(/Invalid base32/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateBase32
+// ---------------------------------------------------------------------------
+
+describe('validateBase32', () => {
+  test('accepts valid uppercase base32', () => {
+    expect(validateBase32('JBSWY3DPEHPK3PXP')).toBe(true);
+  });
+
+  test('accepts valid lowercase base32', () => {
+    expect(validateBase32('jbswy3dpehpk3pxp')).toBe(true);
+  });
+
+  test('rejects strings with invalid characters', () => {
+    expect(validateBase32('NOT_VALID!')).toBe(false);
+  });
+
+  test('rejects empty string', () => {
+    expect(validateBase32('')).toBe(false);
+  });
+
+  test('rejects digit 1 (not in base32 alphabet)', () => {
+    expect(validateBase32('1NVALID')).toBe(false);
+  });
+
+  test('accepts base32 with padding characters', () => {
+    expect(validateBase32('MY======')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateTOTP
+// ---------------------------------------------------------------------------
+
+describe('generateTOTP', () => {
+  test('returns a 6-digit string', () => {
+    const code = generateTOTP('JBSWY3DPEHPK3PXP');
+    expect(code).toMatch(/^\d{6}$/);
+  });
+
+  test('two consecutive calls in the same time window return the same code', () => {
+    const secret = 'JBSWY3DPEHPK3PXP';
+    expect(generateTOTP(secret)).toBe(generateTOTP(secret));
+  });
+
+  test('produces consistent output for a known counter value (RFC 6238 test vector)', () => {
+    // RFC 6238 test vector: secret ASCII "12345678901234567890"
+    // Base32 of that byte sequence: GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ
+    // T=59s → counter = floor(59/30) = 1, expected TOTP = 287082 (SHA1)
+    const secret = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
+    const realDateNow = Date.now;
+    try {
+      Date.now = () => 59 * 1000;
+      const code = generateTOTP(secret);
+      expect(code).toBe('287082');
+    } finally {
+      Date.now = realDateNow;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Storage: add / list / get / remove
+// ---------------------------------------------------------------------------
+
+describe('totp storage', () => {
+  const DOMAIN = 'example.com';
+  const SECRET = 'JBSWY3DPEHPK3PXP';
+  const ISSUER = 'Example';
+
+  test('totp add: stores an encrypted secret that can be retrieved', async () => {
+    await addTotpSecret(DOMAIN, SECRET, ISSUER);
+    const retrieved = await getTotpSecret(DOMAIN);
+    expect(retrieved).toBe(SECRET.toUpperCase());
+  });
+
+  test('totp list: shows domain and issuer but NOT the raw secret', async () => {
+    await addTotpSecret(DOMAIN, SECRET, ISSUER);
+    const list = await listTotpDomains();
+
+    expect(list).toHaveLength(1);
+    expect(list[0].domain).toBe(DOMAIN);
+    expect(list[0].issuer).toBe(ISSUER);
+    expect(list[0].addedAt).toBeTruthy();
+
+    // The list entry must not expose the secret in any form
+    const serialised = JSON.stringify(list[0]);
+    expect(serialised).not.toContain(SECRET);
+  });
+
+  test('totp list: returns empty array when no secrets are configured', async () => {
+    const list = await listTotpDomains();
+    expect(list).toHaveLength(0);
+  });
+
+  test('totp remove: deletes the specific domain entry and returns true', async () => {
+    await addTotpSecret(DOMAIN, SECRET, ISSUER);
+    const removed = await removeTotpSecret(DOMAIN);
+    expect(removed).toBe(true);
+
+    const list = await listTotpDomains();
+    expect(list).toHaveLength(0);
+  });
+
+  test('totp remove: returns false for a non-existent domain', async () => {
+    const removed = await removeTotpSecret('nonexistent.com');
+    expect(removed).toBe(false);
+  });
+
+  test('getTotpSecret returns null for an unconfigured domain', async () => {
+    const secret = await getTotpSecret('unconfigured.com');
+    expect(secret).toBeNull();
+  });
+
+  test('totp add: overwrites the existing entry when called twice for the same domain', async () => {
+    await addTotpSecret(DOMAIN, SECRET, 'Old Issuer');
+    await addTotpSecret(DOMAIN, 'MFRA', 'New Issuer');
+
+    const list = await listTotpDomains();
+    expect(list).toHaveLength(1);
+    expect(list[0].issuer).toBe('New Issuer');
+
+    const retrieved = await getTotpSecret(DOMAIN);
+    expect(retrieved).toBe('MFRA');
+  });
+
+  test('encryption round-trip: decrypt(encrypt(secret)) === secret', async () => {
+    const domain = 'roundtrip.test';
+    const secret = 'NBSWY3DPEB3W64TMMQ';
+    await addTotpSecret(domain, secret);
+    const result = await getTotpSecret(domain);
+    expect(result).toBe(secret);
+  });
+
+  test('storage file is created with mode 0o600', async () => {
+    await addTotpSecret(DOMAIN, SECRET);
+    const storePath = path.join(tempDir, '.openchrome', 'credentials', 'totp-secrets.enc');
+    const stat = fs.statSync(storePath);
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: totp generate uses the stored secret
+// ---------------------------------------------------------------------------
+
+describe('totp generate (integration)', () => {
+  test('generate: outputs a valid 6-digit code for a configured domain', async () => {
+    const domain = 'generate.test';
+    const secret = 'JBSWY3DPEHPK3PXP';
+    await addTotpSecret(domain, secret);
+
+    const stored = await getTotpSecret(domain);
+    expect(stored).toBeTruthy();
+
+    const code = generateTOTP(stored!);
+    expect(code).toMatch(/^\d{6}$/);
+  });
+
+  test('generate: returns null secret for an unconfigured domain', async () => {
+    const secret = await getTotpSecret('not-configured.com');
+    expect(secret).toBeNull();
+  });
+});

--- a/tests/cli/totp-cli.test.ts
+++ b/tests/cli/totp-cli.test.ts
@@ -208,7 +208,8 @@ describe('totp storage', () => {
     expect(result).toBe(secret);
   });
 
-  test('storage file is created with mode 0o600', async () => {
+  const isWindows = os.platform() === 'win32';
+  (isWindows ? test.skip : test)('storage file is created with mode 0o600', async () => {
     await addTotpSecret(DOMAIN, SECRET);
     const storePath = path.join(tempDir, '.openchrome', 'credentials', 'totp-secrets.enc');
     const stat = fs.statSync(storePath);

--- a/tests/cli/totp-cli.test.ts
+++ b/tests/cli/totp-cli.test.ts
@@ -215,6 +215,49 @@ describe('totp storage', () => {
     const stat = fs.statSync(storePath);
     expect(stat.mode & 0o777).toBe(0o600);
   });
+
+  test('storage file is binary (not hex text)', async () => {
+    await addTotpSecret(DOMAIN, SECRET);
+    const storePath = path.join(tempDir, '.openchrome', 'credentials', 'totp-secrets.enc');
+    const data = fs.readFileSync(storePath);
+    // Binary buffer: length should be 16(salt) + 16(iv) + 16(tag) + ciphertext
+    // Minimum length is 48 bytes (header alone), actual ciphertext adds more
+    expect(data.length).toBeGreaterThan(48);
+    // Must NOT be valid UTF-8 hex string (i.e., not all hex chars)
+    const asHex = data.toString('hex');
+    expect(asHex.length).toBe(data.length * 2); // hex is double length of binary
+    // The raw buffer should NOT equal its own hex re-encoding as string bytes
+    expect(data.toString('utf8')).not.toMatch(/^[0-9a-f]+$/i);
+  });
+
+  test('decryption failure throws with clear message', async () => {
+    const storePath = path.join(tempDir, '.openchrome', 'credentials', 'totp-secrets.enc');
+    const dir = path.dirname(storePath);
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    // Write a file that is large enough to pass the length check but has garbage data
+    fs.writeFileSync(storePath, crypto.randomBytes(64), { mode: 0o600 });
+    await expect(getTotpSecret(DOMAIN)).rejects.toThrow('Failed to decrypt credential store');
+  });
+
+  test('corrupted JSON throws with clear message', async () => {
+    const storePath = path.join(tempDir, '.openchrome', 'credentials', 'totp-secrets.enc');
+    const dir = path.dirname(storePath);
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+
+    // Encrypt invalid JSON and write it directly
+    const { createCipheriv, randomBytes, scryptSync } = crypto;
+    const salt = randomBytes(16);
+    const iv = randomBytes(16);
+    const machineId = os.hostname() + os.userInfo().username;
+    const key = scryptSync('openchrome-totp-v1' + machineId, salt, 32) as Buffer;
+    const cipher = createCipheriv('aes-256-gcm', key, iv);
+    const encrypted = Buffer.concat([cipher.update('not valid json', 'utf8'), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+    const fileData = Buffer.concat([salt, iv, authTag, encrypted]);
+    fs.writeFileSync(storePath, fileData, { mode: 0o600 });
+
+    await expect(getTotpSecret(DOMAIN)).rejects.toThrow('Credential store corrupted');
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `openchrome totp add/list/remove/generate` subcommand group to the CLI
- Create `cli/totp-store.ts`: self-contained TOTP engine (RFC 6238, SHA1, 6-digit, 30s period) + AES-256-GCM encrypted storage at `~/.openchrome/credentials/totp-secrets.enc`
- No external dependencies — uses Node.js built-in `crypto` module throughout
- Storage key derived via `scrypt(hostname + username, salt, 32)`; file permissions `0o600`, directory `0o700`
- All output goes to `stderr` (`console.error`) to avoid corrupting the MCP JSON-RPC stdout channel

## Commands added

```
openchrome totp add    --domain <domain> --secret <base32> [--issuer <name>]
openchrome totp list
openchrome totp remove --domain <domain>
openchrome totp generate --domain <domain>
```

## Test plan

- [x] `totp add`: stores encrypted secret that round-trips correctly
- [x] `totp add`: rejects non-base32 input with a clear error
- [x] `totp list`: shows domain + issuer but never the raw secret
- [x] `totp remove`: deletes specific domain entry; returns true on success
- [x] `totp remove`: returns false (and exits 1 in CLI) for non-existent domain
- [x] `totp generate`: outputs a valid 6-digit code for a configured domain
- [x] `totp generate`: returns null for an unconfigured domain
- [x] RFC 6238 test vector passes (`T=59s`, counter=1, secret="12345678901234567890" → `287082`)
- [x] Storage file created with mode `0o600`
- [x] `npm run build` passes with zero TypeScript errors
- [x] 23/23 unit tests pass

Closes shaun0927/TheGiant#30

🤖 Generated with [Claude Code](https://claude.com/claude-code)