### PR TITLE
feat(auth): add credential provider interface with 1Password and Bitwarden adapters (#575)

### DIFF
--- a/src/auth/adapters/bitwarden-adapter.ts
+++ b/src/auth/adapters/bitwarden-adapter.ts
@@ -1,0 +1,151 @@
+/**
+ * Bitwarden CLI credential adapter
+ * Uses the `bw` CLI binary to fetch credentials from Bitwarden vault
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import type { CredentialProvider, Credentials } from '../credential-provider';
+
+const CLI_TIMEOUT_MS = 10_000;
+
+type ExecFileAsync = (
+  cmd: string,
+  args: string[],
+  opts: { timeout: number }
+) => Promise<{ stdout: string; stderr: string }>;
+
+interface BwLoginField {
+  username?: string;
+  password?: string;
+  totp?: string;
+  uris?: Array<{ uri: string; match?: number | null }>;
+}
+
+interface BwItem {
+  id: string;
+  name: string;
+  type: number;
+  login?: BwLoginField;
+}
+
+function extractDomainFromUri(uri: string): string {
+  try {
+    return new URL(uri).hostname;
+  } catch {
+    return uri;
+  }
+}
+
+export class BitwardenAdapter implements CredentialProvider {
+  readonly name = 'bitwarden';
+
+  private readonly exec: ExecFileAsync;
+
+  constructor(exec?: ExecFileAsync) {
+    this.exec = exec ?? (promisify(execFile) as unknown as ExecFileAsync);
+  }
+
+  private getSession(): string {
+    const session = process.env.OPENCHROME_BITWARDEN_SESSION;
+    if (!session) {
+      throw new Error(
+        'Bitwarden session key not set. Run `bw unlock` and set OPENCHROME_BITWARDEN_SESSION.'
+      );
+    }
+    return session;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      await this.exec('bw', ['--version'], { timeout: CLI_TIMEOUT_MS });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getCredentials(domain: string): Promise<Credentials | null> {
+    const session = this.getSession();
+
+    let stdout: string;
+    try {
+      const result = await this.exec(
+        'bw',
+        ['get', 'item', domain, '--session', session],
+        { timeout: CLI_TIMEOUT_MS }
+      );
+      stdout = result.stdout;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      const lower = message.toLowerCase();
+
+      if (lower.includes('not found') || lower.includes('no items found')) {
+        return null;
+      }
+      if (
+        lower.includes('vault is locked') ||
+        lower.includes('session key is invalid') ||
+        lower.includes('not logged in') ||
+        lower.includes('you are not logged in')
+      ) {
+        throw new Error(
+          'Bitwarden vault is locked or session expired. Run `bw unlock` and update OPENCHROME_BITWARDEN_SESSION.'
+        );
+      }
+      throw new Error(`Bitwarden CLI error: ${message}`);
+    }
+
+    let item: BwItem;
+    try {
+      item = JSON.parse(stdout) as BwItem;
+    } catch {
+      throw new Error('Bitwarden returned invalid JSON');
+    }
+
+    const login = item.login ?? {};
+    return {
+      username: login.username ?? '',
+      password: login.password ?? '',
+      totpSecret: login.totp ?? undefined,
+    };
+  }
+
+  async listDomains(): Promise<string[]> {
+    const session = this.getSession();
+
+    let stdout: string;
+    try {
+      const result = await this.exec(
+        'bw',
+        ['list', 'items', '--session', session],
+        { timeout: CLI_TIMEOUT_MS }
+      );
+      stdout = result.stdout;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Bitwarden CLI error listing items: ${message}`);
+    }
+
+    let items: BwItem[];
+    try {
+      items = JSON.parse(stdout) as BwItem[];
+    } catch {
+      throw new Error('Bitwarden returned invalid JSON for item list');
+    }
+
+    const domains: string[] = [];
+    for (const item of items) {
+      const uris = item.login?.uris ?? [];
+      for (const uriObj of uris) {
+        if (uriObj.uri) {
+          const domain = extractDomainFromUri(uriObj.uri);
+          if (domain && !domains.includes(domain)) {
+            domains.push(domain);
+          }
+        }
+      }
+    }
+    return domains;
+  }
+}

--- a/src/auth/adapters/index.ts
+++ b/src/auth/adapters/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Re-exports for all credential provider adapters
+ */
+
+export { LocalAdapter } from './local-adapter';
+export { OnePasswordAdapter } from './onepassword-adapter';
+export { BitwardenAdapter } from './bitwarden-adapter';

--- a/src/auth/adapters/local-adapter.ts
+++ b/src/auth/adapters/local-adapter.ts
@@ -23,8 +23,11 @@ export class LocalAdapter implements CredentialProvider {
       // Dynamic import to avoid hard dependency until PR 1 lands
       try {
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const { CredentialStore } = require('../credential-store');
-        this.store = new CredentialStore();
+        const credentialStore = require('../credential-store');
+        this.store = {
+          getTotpSecret: credentialStore.getTotpSecret,
+          listTotpDomains: credentialStore.listTotpDomains,
+        };
       } catch {
         // credential-store not yet available — use no-op stub
         this.store = {

--- a/src/auth/adapters/local-adapter.ts
+++ b/src/auth/adapters/local-adapter.ts
@@ -1,0 +1,63 @@
+/**
+ * Local storage credential adapter
+ * Wraps the credential store from PR 1 (credential-store module)
+ */
+
+import type { CredentialProvider, Credentials } from '../credential-provider';
+
+// Stub interface — will use real credential-store when PR 1 lands
+interface CredentialStoreStub {
+  getTotpSecret(domain: string): Promise<string | null>;
+  listTotpDomains(): Promise<Array<{ domain: string; issuer?: string; addedAt: string }>>;
+}
+
+export class LocalAdapter implements CredentialProvider {
+  readonly name = 'local';
+
+  private store: CredentialStoreStub;
+
+  constructor(store?: CredentialStoreStub) {
+    if (store) {
+      this.store = store;
+    } else {
+      // Dynamic import to avoid hard dependency until PR 1 lands
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { CredentialStore } = require('../credential-store');
+        this.store = new CredentialStore();
+      } catch {
+        // credential-store not yet available — use no-op stub
+        this.store = {
+          getTotpSecret: async (_domain: string) => null,
+          listTotpDomains: async () => [],
+        };
+      }
+    }
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  /**
+   * Returns credentials from local store.
+   * Local store only holds TOTP secrets — username/password are not stored locally.
+   */
+  async getCredentials(domain: string): Promise<Credentials | null> {
+    const totpSecret = await this.store.getTotpSecret(domain);
+    if (totpSecret === null) {
+      return null;
+    }
+    // Local store does not hold username/password; provide empty strings as placeholders
+    return {
+      username: '',
+      password: '',
+      totpSecret,
+    };
+  }
+
+  async listDomains(): Promise<string[]> {
+    const entries = await this.store.listTotpDomains();
+    return entries.map((e) => e.domain);
+  }
+}

--- a/src/auth/adapters/onepassword-adapter.ts
+++ b/src/auth/adapters/onepassword-adapter.ts
@@ -1,0 +1,157 @@
+/**
+ * 1Password CLI credential adapter
+ * Uses the `op` CLI binary to fetch credentials from 1Password vaults
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import type { CredentialProvider, Credentials } from '../credential-provider';
+
+const CLI_TIMEOUT_MS = 10_000;
+
+type ExecFileAsync = (
+  cmd: string,
+  args: string[],
+  opts: { timeout: number }
+) => Promise<{ stdout: string; stderr: string }>;
+
+interface OpField {
+  id?: string;
+  label?: string;
+  purpose?: string;
+  type?: string;
+  value?: string;
+}
+
+interface OpItem {
+  id: string;
+  title: string;
+  fields?: OpField[];
+  urls?: Array<{ href: string; primary?: boolean }>;
+}
+
+interface OpListItem {
+  id: string;
+  title: string;
+  urls?: Array<{ href: string }>;
+}
+
+function extractDomainFromUrl(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+export class OnePasswordAdapter implements CredentialProvider {
+  readonly name = '1password';
+
+  private readonly exec: ExecFileAsync;
+
+  constructor(exec?: ExecFileAsync) {
+    this.exec = exec ?? (promisify(execFile) as unknown as ExecFileAsync);
+  }
+
+  private get vaultArgs(): string[] {
+    const vault = process.env.OPENCHROME_1PASSWORD_VAULT;
+    return vault ? ['--vault', vault] : [];
+  }
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      await this.exec('op', ['--version'], { timeout: CLI_TIMEOUT_MS });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getCredentials(domain: string): Promise<Credentials | null> {
+    let stdout: string;
+    try {
+      const result = await this.exec(
+        'op',
+        ['item', 'get', domain, '--format', 'json', ...this.vaultArgs],
+        { timeout: CLI_TIMEOUT_MS }
+      );
+      stdout = result.stdout;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      const lower = message.toLowerCase();
+
+      if (lower.includes('not found') || lower.includes("isn't an item")) {
+        return null;
+      }
+      if (
+        lower.includes('not signed in') ||
+        lower.includes('vault is locked') ||
+        lower.includes('authentication required') ||
+        lower.includes('please sign in')
+      ) {
+        throw new Error(
+          '1Password vault is locked or not signed in. Run `op signin` to authenticate.'
+        );
+      }
+      throw new Error(`1Password CLI error: ${message}`);
+    }
+
+    let item: OpItem;
+    try {
+      item = JSON.parse(stdout) as OpItem;
+    } catch {
+      throw new Error('1Password returned invalid JSON');
+    }
+
+    const fields = item.fields ?? [];
+
+    const usernameField = fields.find(
+      (f) => f.purpose === 'USERNAME' || f.id === 'username'
+    );
+    const passwordField = fields.find(
+      (f) => f.purpose === 'PASSWORD' || f.id === 'password'
+    );
+    const otpField = fields.find((f) => f.type === 'OTP');
+
+    return {
+      username: usernameField?.value ?? '',
+      password: passwordField?.value ?? '',
+      totpSecret: otpField?.value,
+    };
+  }
+
+  async listDomains(): Promise<string[]> {
+    let stdout: string;
+    try {
+      const result = await this.exec(
+        'op',
+        ['item', 'list', '--categories', 'Login', '--format', 'json', ...this.vaultArgs],
+        { timeout: CLI_TIMEOUT_MS }
+      );
+      stdout = result.stdout;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`1Password CLI error listing items: ${message}`);
+    }
+
+    let items: OpListItem[];
+    try {
+      items = JSON.parse(stdout) as OpListItem[];
+    } catch {
+      throw new Error('1Password returned invalid JSON for item list');
+    }
+
+    const domains: string[] = [];
+    for (const item of items) {
+      if (item.urls && item.urls.length > 0) {
+        for (const urlObj of item.urls) {
+          const domain = extractDomainFromUrl(urlObj.href);
+          if (domain && !domains.includes(domain)) {
+            domains.push(domain);
+          }
+        }
+      }
+    }
+    return domains;
+  }
+}

--- a/src/auth/credential-provider.ts
+++ b/src/auth/credential-provider.ts
@@ -1,0 +1,44 @@
+/**
+ * Credential provider interface and factory
+ * Supports local, 1Password, and Bitwarden credential stores
+ */
+
+export interface Credentials {
+  username: string;
+  password: string;
+  totpSecret?: string;
+}
+
+export interface CredentialProvider {
+  readonly name: string;
+  isAvailable(): Promise<boolean>;
+  getCredentials(domain: string): Promise<Credentials | null>;
+  listDomains(): Promise<string[]>;
+}
+
+/**
+ * Factory function that reads OPENCHROME_CREDENTIAL_PROVIDER env var
+ * and returns the appropriate credential provider adapter.
+ *
+ * Supported values: 'local' (default), '1password', 'bitwarden'
+ */
+export function getCredentialProvider(): CredentialProvider {
+  const providerName = process.env.OPENCHROME_CREDENTIAL_PROVIDER ?? 'local';
+
+  switch (providerName.toLowerCase()) {
+    case '1password':
+    case 'onepassword': {
+      const { OnePasswordAdapter } = require('./adapters/onepassword-adapter');
+      return new OnePasswordAdapter();
+    }
+    case 'bitwarden': {
+      const { BitwardenAdapter } = require('./adapters/bitwarden-adapter');
+      return new BitwardenAdapter();
+    }
+    case 'local':
+    default: {
+      const { LocalAdapter } = require('./adapters/local-adapter');
+      return new LocalAdapter();
+    }
+  }
+}

--- a/tests/auth/adapters/bitwarden-adapter.test.ts
+++ b/tests/auth/adapters/bitwarden-adapter.test.ts
@@ -1,0 +1,230 @@
+/// <reference types="jest" />
+/**
+ * Unit tests for Bitwarden CLI credential adapter
+ */
+
+import { BitwardenAdapter } from '../../../src/auth/adapters/bitwarden-adapter';
+
+type ExecFileAsync = (
+  cmd: string,
+  args: string[],
+  opts: { timeout: number }
+) => Promise<{ stdout: string; stderr: string }>;
+
+/**
+ * Helper: create a mock exec that resolves with the given stdout
+ */
+function makeSuccessExec(stdout: string): jest.MockedFunction<ExecFileAsync> {
+  return jest.fn().mockResolvedValue({ stdout, stderr: '' });
+}
+
+/**
+ * Helper: create a mock exec that rejects with the given error message
+ */
+function makeFailureExec(message: string): jest.MockedFunction<ExecFileAsync> {
+  return jest.fn().mockRejectedValue(new Error(message));
+}
+
+const BW_VERSION_OUTPUT = '2024.1.0\n';
+
+const BW_ITEM_JSON = JSON.stringify({
+  id: 'xyz789',
+  name: 'example.com',
+  type: 1,
+  login: {
+    username: 'bob@example.com',
+    password: 'p@ssw0rd',
+    totp: 'JBSWY3DPEHPK3PXP',
+    uris: [{ uri: 'https://example.com', match: null }],
+  },
+});
+
+const BW_LIST_JSON = JSON.stringify([
+  {
+    id: 'item1',
+    name: 'example.com',
+    type: 1,
+    login: {
+      username: 'user1',
+      uris: [{ uri: 'https://example.com/login' }],
+    },
+  },
+  {
+    id: 'item2',
+    name: 'another.org',
+    type: 1,
+    login: {
+      username: 'user2',
+      uris: [{ uri: 'https://another.org' }, { uri: 'https://sub.another.org' }],
+    },
+  },
+  {
+    id: 'item3',
+    name: 'No URI item',
+    type: 1,
+    login: {
+      username: 'user3',
+    },
+  },
+]);
+
+describe('BitwardenAdapter', () => {
+  const originalEnv = process.env;
+  const SESSION_KEY = 'test-session-key-abc123';
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.OPENCHROME_BITWARDEN_SESSION = SESSION_KEY;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('isAvailable()', () => {
+    test('returns true when bw --version succeeds', async () => {
+      const exec = makeSuccessExec(BW_VERSION_OUTPUT);
+      const adapter = new BitwardenAdapter(exec);
+      const result = await adapter.isAvailable();
+      expect(result).toBe(true);
+      expect(exec).toHaveBeenCalledWith('bw', ['--version'], { timeout: 10000 });
+    });
+
+    test('returns false when bw binary is not found', async () => {
+      const exec = makeFailureExec('command not found: bw');
+      const adapter = new BitwardenAdapter(exec);
+      const result = await adapter.isAvailable();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getCredentials()', () => {
+    test('parses Bitwarden item JSON and returns credentials', async () => {
+      const exec = makeSuccessExec(BW_ITEM_JSON);
+      const adapter = new BitwardenAdapter(exec);
+      const creds = await adapter.getCredentials('example.com');
+      expect(creds).not.toBeNull();
+      expect(creds!.username).toBe('bob@example.com');
+      expect(creds!.password).toBe('p@ssw0rd');
+      expect(creds!.totpSecret).toBe('JBSWY3DPEHPK3PXP');
+    });
+
+    test('returns null when item is not found', async () => {
+      const exec = makeFailureExec('Not found.');
+      const adapter = new BitwardenAdapter(exec);
+      const creds = await adapter.getCredentials('missing.com');
+      expect(creds).toBeNull();
+    });
+
+    test('returns null for "no items found" error', async () => {
+      const exec = makeFailureExec('no items found');
+      const adapter = new BitwardenAdapter(exec);
+      const creds = await adapter.getCredentials('missing.com');
+      expect(creds).toBeNull();
+    });
+
+    test('throws descriptive error when vault is locked', async () => {
+      const exec = makeFailureExec('Vault is locked.');
+      const adapter = new BitwardenAdapter(exec);
+      await expect(adapter.getCredentials('example.com')).rejects.toThrow(
+        /vault is locked|session expired/i
+      );
+    });
+
+    test('throws descriptive error for expired/invalid session', async () => {
+      const exec = makeFailureExec('Session key is invalid.');
+      const adapter = new BitwardenAdapter(exec);
+      await expect(adapter.getCredentials('example.com')).rejects.toThrow(
+        /vault is locked|session expired/i
+      );
+    });
+
+    test('throws when session env var is not set', async () => {
+      delete process.env.OPENCHROME_BITWARDEN_SESSION;
+      const exec = makeSuccessExec(BW_ITEM_JSON);
+      const adapter = new BitwardenAdapter(exec);
+      await expect(adapter.getCredentials('example.com')).rejects.toThrow(
+        /session key not set|bw unlock/i
+      );
+    });
+
+    test('passes --session flag from OPENCHROME_BITWARDEN_SESSION', async () => {
+      const exec = makeSuccessExec(BW_ITEM_JSON);
+      const adapter = new BitwardenAdapter(exec);
+      await adapter.getCredentials('example.com');
+      expect(exec).toHaveBeenCalledWith(
+        'bw',
+        ['get', 'item', 'example.com', '--session', SESSION_KEY],
+        expect.objectContaining({ timeout: 10000 })
+      );
+    });
+
+    test('returns undefined totpSecret when item has no totp', async () => {
+      const itemWithoutTotp = JSON.stringify({
+        id: 'xyz789',
+        name: 'example.com',
+        type: 1,
+        login: { username: 'bob@example.com', password: 'p@ssw0rd' },
+      });
+      const exec = makeSuccessExec(itemWithoutTotp);
+      const adapter = new BitwardenAdapter(exec);
+      const creds = await adapter.getCredentials('example.com');
+      expect(creds).not.toBeNull();
+      expect(creds!.totpSecret).toBeUndefined();
+    });
+  });
+
+  describe('listDomains()', () => {
+    test('parses item list and extracts domains from URIs', async () => {
+      const exec = makeSuccessExec(BW_LIST_JSON);
+      const adapter = new BitwardenAdapter(exec);
+      const domains = await adapter.listDomains();
+      expect(domains).toContain('example.com');
+      expect(domains).toContain('another.org');
+      expect(domains).toContain('sub.another.org');
+    });
+
+    test('skips items without URIs', async () => {
+      const exec = makeSuccessExec(BW_LIST_JSON);
+      const adapter = new BitwardenAdapter(exec);
+      const domains = await adapter.listDomains();
+      // 'No URI item' has no uris — should not contribute
+      expect(domains).not.toContain('No URI item');
+    });
+
+    test('deduplicates domains that appear in multiple items', async () => {
+      const duplicateList = JSON.stringify([
+        {
+          id: 'a', name: 'a', type: 1,
+          login: { uris: [{ uri: 'https://example.com/login' }] },
+        },
+        {
+          id: 'b', name: 'b', type: 1,
+          login: { uris: [{ uri: 'https://example.com/settings' }] },
+        },
+      ]);
+      const exec = makeSuccessExec(duplicateList);
+      const adapter = new BitwardenAdapter(exec);
+      const domains = await adapter.listDomains();
+      expect(domains).toEqual(['example.com']);
+    });
+
+    test('passes --session flag when listing items', async () => {
+      const exec = makeSuccessExec(BW_LIST_JSON);
+      const adapter = new BitwardenAdapter(exec);
+      await adapter.listDomains();
+      expect(exec).toHaveBeenCalledWith(
+        'bw',
+        ['list', 'items', '--session', SESSION_KEY],
+        expect.objectContaining({ timeout: 10000 })
+      );
+    });
+
+    test('throws when session env var is not set', async () => {
+      delete process.env.OPENCHROME_BITWARDEN_SESSION;
+      const exec = makeSuccessExec(BW_LIST_JSON);
+      const adapter = new BitwardenAdapter(exec);
+      await expect(adapter.listDomains()).rejects.toThrow(/session key not set|bw unlock/i);
+    });
+  });
+});

--- a/tests/auth/adapters/onepassword-adapter.test.ts
+++ b/tests/auth/adapters/onepassword-adapter.test.ts
@@ -1,0 +1,189 @@
+/// <reference types="jest" />
+/**
+ * Unit tests for 1Password CLI credential adapter
+ */
+
+import { OnePasswordAdapter } from '../../../src/auth/adapters/onepassword-adapter';
+
+type ExecFileAsync = (
+  cmd: string,
+  args: string[],
+  opts: { timeout: number }
+) => Promise<{ stdout: string; stderr: string }>;
+
+/**
+ * Helper: create a mock exec that resolves with the given stdout
+ */
+function makeSuccessExec(stdout: string): jest.MockedFunction<ExecFileAsync> {
+  return jest.fn().mockResolvedValue({ stdout, stderr: '' });
+}
+
+/**
+ * Helper: create a mock exec that rejects with the given error message
+ */
+function makeFailureExec(message: string): jest.MockedFunction<ExecFileAsync> {
+  return jest.fn().mockRejectedValue(new Error(message));
+}
+
+const OP_VERSION_OUTPUT = '2.24.0\n';
+
+const OP_ITEM_JSON = JSON.stringify({
+  id: 'abc123',
+  title: 'example.com',
+  fields: [
+    { id: 'username', purpose: 'USERNAME', value: 'alice@example.com' },
+    { id: 'password', purpose: 'PASSWORD', value: 's3cr3t!' },
+    { id: 'totp', type: 'OTP', value: 'JBSWY3DPEHPK3PXP' },
+  ],
+  urls: [{ href: 'https://example.com', primary: true }],
+});
+
+const OP_LIST_JSON = JSON.stringify([
+  {
+    id: 'item1',
+    title: 'example.com',
+    urls: [{ href: 'https://example.com' }],
+  },
+  {
+    id: 'item2',
+    title: 'another.org',
+    urls: [{ href: 'https://another.org/login' }],
+  },
+  {
+    id: 'item3',
+    title: 'No URL item',
+  },
+]);
+
+describe('OnePasswordAdapter', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.OPENCHROME_1PASSWORD_VAULT;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('isAvailable()', () => {
+    test('returns true when op --version succeeds', async () => {
+      const exec = makeSuccessExec(OP_VERSION_OUTPUT);
+      const adapter = new OnePasswordAdapter(exec);
+      const result = await adapter.isAvailable();
+      expect(result).toBe(true);
+      expect(exec).toHaveBeenCalledWith('op', ['--version'], { timeout: 10000 });
+    });
+
+    test('returns false when op binary is not found', async () => {
+      const exec = makeFailureExec('command not found: op');
+      const adapter = new OnePasswordAdapter(exec);
+      const result = await adapter.isAvailable();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getCredentials()', () => {
+    test('parses 1Password item JSON and returns credentials', async () => {
+      const exec = makeSuccessExec(OP_ITEM_JSON);
+      const adapter = new OnePasswordAdapter(exec);
+      const creds = await adapter.getCredentials('example.com');
+      expect(creds).not.toBeNull();
+      expect(creds!.username).toBe('alice@example.com');
+      expect(creds!.password).toBe('s3cr3t!');
+      expect(creds!.totpSecret).toBe('JBSWY3DPEHPK3PXP');
+    });
+
+    test('returns null when item is not found', async () => {
+      const exec = makeFailureExec("example.com isn't an item in any vault");
+      const adapter = new OnePasswordAdapter(exec);
+      const creds = await adapter.getCredentials('example.com');
+      expect(creds).toBeNull();
+    });
+
+    test('returns null for "not found" error message', async () => {
+      const exec = makeFailureExec('[ERROR] 2024/01/01 not found');
+      const adapter = new OnePasswordAdapter(exec);
+      const creds = await adapter.getCredentials('missing.com');
+      expect(creds).toBeNull();
+    });
+
+    test('throws descriptive error when vault is locked', async () => {
+      const exec = makeFailureExec('You are not signed in. Please sign in and try again.');
+      const adapter = new OnePasswordAdapter(exec);
+      await expect(adapter.getCredentials('example.com')).rejects.toThrow(
+        /vault is locked|not signed in/i
+      );
+    });
+
+    test('throws descriptive error for authentication required', async () => {
+      const exec = makeFailureExec('authentication required');
+      const adapter = new OnePasswordAdapter(exec);
+      await expect(adapter.getCredentials('example.com')).rejects.toThrow(
+        /vault is locked|not signed in/i
+      );
+    });
+
+    test('passes --vault flag when OPENCHROME_1PASSWORD_VAULT is set', async () => {
+      process.env.OPENCHROME_1PASSWORD_VAULT = 'Personal';
+      const exec = makeSuccessExec(OP_ITEM_JSON);
+      const adapter = new OnePasswordAdapter(exec);
+      await adapter.getCredentials('example.com');
+      expect(exec).toHaveBeenCalledWith(
+        'op',
+        ['item', 'get', 'example.com', '--format', 'json', '--vault', 'Personal'],
+        expect.objectContaining({ timeout: 10000 })
+      );
+    });
+
+    test('does not pass --vault flag when env var is not set', async () => {
+      const exec = makeSuccessExec(OP_ITEM_JSON);
+      const adapter = new OnePasswordAdapter(exec);
+      await adapter.getCredentials('example.com');
+      const callArgs = exec.mock.calls[0][1] as string[];
+      expect(callArgs).not.toContain('--vault');
+    });
+  });
+
+  describe('listDomains()', () => {
+    test('parses item list and extracts domains from URLs', async () => {
+      const exec = makeSuccessExec(OP_LIST_JSON);
+      const adapter = new OnePasswordAdapter(exec);
+      const domains = await adapter.listDomains();
+      expect(domains).toContain('example.com');
+      expect(domains).toContain('another.org');
+    });
+
+    test('skips items without URLs', async () => {
+      const exec = makeSuccessExec(OP_LIST_JSON);
+      const adapter = new OnePasswordAdapter(exec);
+      const domains = await adapter.listDomains();
+      // 'No URL item' has no urls — only 2 unique domains expected
+      expect(domains).toHaveLength(2);
+    });
+
+    test('deduplicates domains that appear in multiple items', async () => {
+      const duplicateList = JSON.stringify([
+        { id: 'a', title: 'a', urls: [{ href: 'https://example.com/login' }] },
+        { id: 'b', title: 'b', urls: [{ href: 'https://example.com/settings' }] },
+      ]);
+      const exec = makeSuccessExec(duplicateList);
+      const adapter = new OnePasswordAdapter(exec);
+      const domains = await adapter.listDomains();
+      expect(domains).toEqual(['example.com']);
+    });
+
+    test('passes --vault flag when OPENCHROME_1PASSWORD_VAULT is set', async () => {
+      process.env.OPENCHROME_1PASSWORD_VAULT = 'Work';
+      const exec = makeSuccessExec(OP_LIST_JSON);
+      const adapter = new OnePasswordAdapter(exec);
+      await adapter.listDomains();
+      expect(exec).toHaveBeenCalledWith(
+        'op',
+        ['item', 'list', '--categories', 'Login', '--format', 'json', '--vault', 'Work'],
+        expect.objectContaining({ timeout: 10000 })
+      );
+    });
+  });
+});

--- a/tests/auth/credential-provider.test.ts
+++ b/tests/auth/credential-provider.test.ts
@@ -1,0 +1,66 @@
+/// <reference types="jest" />
+/**
+ * Unit tests for credential provider factory
+ */
+
+describe('getCredentialProvider', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test('returns LocalAdapter by default when env var not set', () => {
+    delete process.env.OPENCHROME_CREDENTIAL_PROVIDER;
+    const { getCredentialProvider } = require('../../src/auth/credential-provider');
+    const provider = getCredentialProvider();
+    expect(provider.name).toBe('local');
+  });
+
+  test('returns LocalAdapter when env var is "local"', () => {
+    process.env.OPENCHROME_CREDENTIAL_PROVIDER = 'local';
+    const { getCredentialProvider } = require('../../src/auth/credential-provider');
+    const provider = getCredentialProvider();
+    expect(provider.name).toBe('local');
+  });
+
+  test('returns OnePasswordAdapter when env var is "1password"', () => {
+    process.env.OPENCHROME_CREDENTIAL_PROVIDER = '1password';
+    const { getCredentialProvider } = require('../../src/auth/credential-provider');
+    const provider = getCredentialProvider();
+    expect(provider.name).toBe('1password');
+  });
+
+  test('returns OnePasswordAdapter when env var is "onepassword" (alias)', () => {
+    process.env.OPENCHROME_CREDENTIAL_PROVIDER = 'onepassword';
+    const { getCredentialProvider } = require('../../src/auth/credential-provider');
+    const provider = getCredentialProvider();
+    expect(provider.name).toBe('1password');
+  });
+
+  test('returns BitwardenAdapter when env var is "bitwarden"', () => {
+    process.env.OPENCHROME_CREDENTIAL_PROVIDER = 'bitwarden';
+    const { getCredentialProvider } = require('../../src/auth/credential-provider');
+    const provider = getCredentialProvider();
+    expect(provider.name).toBe('bitwarden');
+  });
+
+  test('is case-insensitive for provider name', () => {
+    process.env.OPENCHROME_CREDENTIAL_PROVIDER = 'BITWARDEN';
+    const { getCredentialProvider } = require('../../src/auth/credential-provider');
+    const provider = getCredentialProvider();
+    expect(provider.name).toBe('bitwarden');
+  });
+
+  test('falls back to local for unknown provider values', () => {
+    process.env.OPENCHROME_CREDENTIAL_PROVIDER = 'unknown-vault';
+    const { getCredentialProvider } = require('../../src/auth/credential-provider');
+    const provider = getCredentialProvider();
+    expect(provider.name).toBe('local');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `CredentialProvider` interface + `Credentials` type in `src/auth/credential-provider.ts`
- Implements factory function `getCredentialProvider()` that reads `OPENCHROME_CREDENTIAL_PROVIDER` env var (`local` default, `1password`, `bitwarden`)
- `LocalAdapter` — wraps credential-store (stub until PR 1 lands); returns TOTP secrets only
- `OnePasswordAdapter` — uses `op` CLI via `execFile`; supports `OPENCHROME_1PASSWORD_VAULT` filter; handles locked vault / not-signed-in errors
- `BitwardenAdapter` — uses `bw` CLI via `execFile`; requires `OPENCHROME_BITWARDEN_SESSION`; handles locked/expired session errors
- All CLI calls have 10-second timeout; no credentials logged anywhere

## Test plan

- [ ] `npx jest tests/auth/` → 35 tests, 3 suites, all pass
- [ ] `npm run build` → zero TypeScript errors
- [ ] Provider selection: env var correctly routes to each adapter (7 tests)
- [ ] `OnePasswordAdapter`: isAvailable, getCredentials parse/null/locked, listDomains, vault flag (13 tests)
- [ ] `BitwardenAdapter`: isAvailable, getCredentials parse/null/locked/expired/no-session, listDomains, session flag (15 tests)
- [ ] Constructor-injected `exec` used for all tests — no `child_process` mocking needed

## Related

Part of shaun0927/TheGiant#30 (2FA & Credential Management) — PR 2 of 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)