### PR TITLE
feat(auth): auto-generated tokens, --no-auth, TLS support (#573)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ program
   .option('--http [port]', 'Use Streamable HTTP transport instead of stdio (default port: 3100)')
   .option('--http-host <host>', 'Bind address for HTTP transport (default: 127.0.0.1, use 0.0.0.0 for external access)')
   .option('--auth-token <token>', 'Bearer token for HTTP transport authentication (also: OPENCHROME_AUTH_TOKEN env var)')
-  .action(async (options: { port: string; autoLaunch?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; visible?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string }) => {
+  .action(async (options: { port: string; autoLaunch?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; visible?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; auth?: boolean; tlsCert?: string; tlsKey?: string }) => {
     const port = parseInt(options.port, 10);
     let autoLaunch = options.autoLaunch || false;
 


### PR DESCRIPTION
## Summary

Phase 2 of shaun0927/TheGiant#28 (SSE/Streamable HTTP Transport Layer) — Authentication & Security:

- **Auto-generated auth tokens**: On first HTTP launch, generates a 256-bit cryptographically secure token stored in `~/.openchrome/auth-token` with `600` permissions. Reuses existing token on subsequent launches.
- **Token display**: Shows token prefix (first 8 chars) on startup for identification
- **`--no-auth` flag**: Disables authentication for local development use
- **TLS support**: `--tls-cert` and `--tls-key` flags enable HTTPS with user-provided certificates

## Changes

- `src/utils/auth-token.ts`: New module — `generateToken()`, `getOrCreateAuthToken()`, `loadAuthToken()`
- `src/transports/http.ts`: Accept `tlsOptions` in constructor, create `https.createServer` when TLS configured
- `src/index.ts`: Add `--no-auth`, `--tls-cert`, `--tls-key` flags; auto-generate token for HTTP mode
- `tests/transports/http-auth-tls.test.ts`: 6 new tests for token generation and TLS constructor

## Test plan

- [x] `generateToken()` returns 64-char hex (256-bit)
- [x] `generateToken()` returns unique tokens each call
- [x] Token file creation works
- [x] `loadAuthToken()` handles missing file gracefully
- [x] HTTPTransport accepts TLS options in constructor
- [x] HTTPTransport works without TLS (backward compatible)
- [x] Existing bearer auth tests still pass (9/9)
- [x] All 15 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)