### PR TITLE
feat: integrate CAPTCHA solver into fallback chain with domain memory (#574)

### DIFF
--- a/src/captcha/handler.ts
+++ b/src/captcha/handler.ts
@@ -10,7 +10,7 @@
 import type { Page } from 'puppeteer-core';
 import type { BlockingInfo } from '../utils/page-diagnostics';
 import { detectCaptcha } from './detect';
-import { getSolverRegistry } from './solver-registry';
+import { getSolverRegistry, waitForSolverReady } from './solver-registry';
 import { injectSolution } from './inject-solution';
 import { getDomainMemory, extractDomainFromUrl } from '../memory/domain-memory';
 
@@ -30,6 +30,8 @@ export async function handleCaptcha(
   page: Page,
   blockingInfo: BlockingInfo,
 ): Promise<CaptchaHandleResult> {
+  // Ensure solver is fully initialized before checking configuration
+  await waitForSolverReady();
   const registry = getSolverRegistry();
 
   // Check if solver is available
@@ -41,20 +43,28 @@ export async function handleCaptcha(
     };
   }
 
-  // Detailed detection to get site key
-  const detection = await detectCaptcha(page);
-  if (!detection) {
-    return {
-      solved: false,
-      captchaType: blockingInfo.captchaType || 'unknown',
-      error: 'CAPTCHA detection failed during solve attempt',
-    };
+  // Use already-captured data from blockingInfo when available to avoid
+  // redundant CDP round-trips and TOCTOU issues. Fall back to detectCaptcha
+  // only when the site key is missing from blockingInfo.
+  const captchaType = blockingInfo.captchaType || 'unknown';
+  let siteKey: { key: string; source: string } | null = null;
+
+  if (blockingInfo.captchaSiteKey) {
+    siteKey = { key: blockingInfo.captchaSiteKey, source: 'blockingInfo' };
+  } else {
+    const detection = await detectCaptcha(page);
+    if (!detection) {
+      return {
+        solved: false,
+        captchaType,
+        error: 'CAPTCHA detection failed during solve attempt',
+      };
+    }
+    siteKey = detection.siteKey ?? null;
   }
 
-  const captchaType = detection.captchaType;
-
   // Check if solver supports this type
-  if (!registry.canSolve(captchaType)) {
+  if (!registry.canSolve(captchaType as any)) {
     return {
       solved: false,
       captchaType,
@@ -63,7 +73,7 @@ export async function handleCaptcha(
   }
 
   // Need site key for solving
-  if (!detection.siteKey) {
+  if (!siteKey) {
     return {
       solved: false,
       captchaType,
@@ -72,7 +82,9 @@ export async function handleCaptcha(
   }
 
   // Record CAPTCHA encounter in domain memory
-  const domain = extractDomainFromUrl(detection.pageUrl);
+  let pageUrl: string;
+  try { pageUrl = page.url(); } catch { pageUrl = 'unknown'; }
+  const domain = extractDomainFromUrl(pageUrl);
   if (domain) {
     const memory = getDomainMemory();
     memory.record(domain, 'captcha:type', captchaType);
@@ -82,17 +94,16 @@ export async function handleCaptcha(
   try {
     // Submit to solver
     const result = await registry.solve({
-      captchaType,
-      siteKey: detection.siteKey.key,
-      pageUrl: detection.pageUrl,
-      invisible: detection.invisible,
+      captchaType: captchaType as any,
+      siteKey: siteKey.key,
+      pageUrl,
+      invisible: false,
     });
 
     // Inject solution into page
-    const injected = await injectSolution(page, captchaType, result.token);
+    const injected = await injectSolution(page, captchaType as any, result.token);
 
     if (!injected) {
-      // Record failure in domain memory
       if (domain) {
         getDomainMemory().record(domain, 'captcha:inject_failed', 'true');
       }
@@ -105,8 +116,24 @@ export async function handleCaptcha(
       };
     }
 
-    // Wait briefly for the page to process the solution
+    // Wait for the page to process the solution, then verify dismissal
     await new Promise(resolve => setTimeout(resolve, 2000));
+
+    // Post-injection verification: confirm the CAPTCHA is actually dismissed
+    const { detectBlockingPage } = await import('../utils/page-diagnostics');
+    const stillBlocked = await detectBlockingPage(page).catch(() => null);
+    if (stillBlocked?.type === 'captcha') {
+      if (domain) {
+        getDomainMemory().record(domain, 'captcha:inject_failed', 'verification');
+      }
+      return {
+        solved: false,
+        captchaType,
+        solveTimeMs: result.solveTimeMs,
+        costUsd: result.costUsd,
+        error: 'Token injected but CAPTCHA still present after verification',
+      };
+    }
 
     // Record success in domain memory
     if (domain) {

--- a/src/captcha/handler.ts
+++ b/src/captcha/handler.ts
@@ -1,0 +1,155 @@
+/**
+ * CAPTCHA Handler (#574)
+ *
+ * Orchestrates the full CAPTCHA solving flow:
+ * detect → extract site key → submit to solver → inject solution → verify
+ *
+ * Integrates with the navigate fallback chain and domain memory.
+ */
+
+import type { Page } from 'puppeteer-core';
+import type { BlockingInfo } from '../utils/page-diagnostics';
+import { detectCaptcha } from './detect';
+import { getSolverRegistry } from './solver-registry';
+import { injectSolution } from './inject-solution';
+import { getDomainMemory, extractDomainFromUrl } from '../memory/domain-memory';
+
+export interface CaptchaHandleResult {
+  solved: boolean;
+  captchaType: string;
+  solveTimeMs?: number;
+  costUsd?: number;
+  error?: string;
+}
+
+/**
+ * Attempt to solve a CAPTCHA on the given page.
+ * Returns the result of the attempt.
+ */
+export async function handleCaptcha(
+  page: Page,
+  blockingInfo: BlockingInfo,
+): Promise<CaptchaHandleResult> {
+  const registry = getSolverRegistry();
+
+  // Check if solver is available
+  if (!registry.isConfigured()) {
+    return {
+      solved: false,
+      captchaType: blockingInfo.captchaType || 'unknown',
+      error: 'No CAPTCHA solver configured',
+    };
+  }
+
+  // Detailed detection to get site key
+  const detection = await detectCaptcha(page);
+  if (!detection) {
+    return {
+      solved: false,
+      captchaType: blockingInfo.captchaType || 'unknown',
+      error: 'CAPTCHA detection failed during solve attempt',
+    };
+  }
+
+  const captchaType = detection.captchaType;
+
+  // Check if solver supports this type
+  if (!registry.canSolve(captchaType)) {
+    return {
+      solved: false,
+      captchaType,
+      error: `Solver does not support ${captchaType}`,
+    };
+  }
+
+  // Need site key for solving
+  if (!detection.siteKey) {
+    return {
+      solved: false,
+      captchaType,
+      error: 'Could not extract site key from CAPTCHA',
+    };
+  }
+
+  // Record CAPTCHA encounter in domain memory
+  const domain = extractDomainFromUrl(detection.pageUrl);
+  if (domain) {
+    const memory = getDomainMemory();
+    memory.record(domain, 'captcha:type', captchaType);
+    memory.record(domain, 'captcha:encountered', new Date().toISOString());
+  }
+
+  try {
+    // Submit to solver
+    const result = await registry.solve({
+      captchaType,
+      siteKey: detection.siteKey.key,
+      pageUrl: detection.pageUrl,
+      invisible: detection.invisible,
+    });
+
+    // Inject solution into page
+    const injected = await injectSolution(page, captchaType, result.token);
+
+    if (!injected) {
+      // Record failure in domain memory
+      if (domain) {
+        getDomainMemory().record(domain, 'captcha:inject_failed', 'true');
+      }
+      return {
+        solved: false,
+        captchaType,
+        solveTimeMs: result.solveTimeMs,
+        costUsd: result.costUsd,
+        error: 'Solution obtained but injection failed',
+      };
+    }
+
+    // Wait briefly for the page to process the solution
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    // Record success in domain memory
+    if (domain) {
+      const memory = getDomainMemory();
+      memory.record(domain, 'captcha:solved', 'true');
+      memory.record(domain, 'captcha:solver_provider', registry.getProviderName() || 'unknown');
+    }
+
+    return {
+      solved: true,
+      captchaType,
+      solveTimeMs: result.solveTimeMs,
+      costUsd: result.costUsd,
+    };
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    console.error(`[CaptchaSolver] Solve failed for ${captchaType}: ${errorMsg}`);
+
+    // Record failure in domain memory
+    if (domain) {
+      getDomainMemory().record(domain, 'captcha:solve_failed', errorMsg);
+    }
+
+    return {
+      solved: false,
+      captchaType,
+      error: errorMsg,
+    };
+  }
+}
+
+/**
+ * Check domain memory for known CAPTCHA sites.
+ * Returns the known CAPTCHA type if the domain has been seen before.
+ */
+export function checkDomainCaptchaHistory(url: string): string | null {
+  const domain = extractDomainFromUrl(url);
+  if (!domain) return null;
+
+  const memory = getDomainMemory();
+  const entries = memory.query(domain, 'captcha:type');
+  if (entries.length > 0 && entries[0].confidence >= 0.3) {
+    return entries[0].value;
+  }
+  return null;
+}

--- a/src/captcha/index.ts
+++ b/src/captcha/index.ts
@@ -5,7 +5,7 @@
 export { detectCaptcha } from './detect';
 export { CaptchaSolver } from './solver-interface';
 export type { SolveRequest, SolveResult, SolverConfig, SolverError } from './solver-interface';
-export { SolverRegistry, getSolverRegistry } from './solver-registry';
+export { SolverRegistry, getSolverRegistry, waitForSolverReady } from './solver-registry';
 export type { SolverProvider, CostTracker } from './solver-registry';
 export { handleCaptcha, checkDomainCaptchaHistory } from './handler';
 export type { CaptchaHandleResult } from './handler';

--- a/src/captcha/index.ts
+++ b/src/captcha/index.ts
@@ -7,4 +7,7 @@ export { CaptchaSolver } from './solver-interface';
 export type { SolveRequest, SolveResult, SolverConfig, SolverError } from './solver-interface';
 export { SolverRegistry, getSolverRegistry } from './solver-registry';
 export type { SolverProvider, CostTracker } from './solver-registry';
+export { handleCaptcha, checkDomainCaptchaHistory } from './handler';
+export type { CaptchaHandleResult } from './handler';
+export { injectSolution } from './inject-solution';
 export type { CaptchaType, CaptchaDetectionResult, CaptchaSiteKey } from '../types/captcha';

--- a/src/captcha/index.ts
+++ b/src/captcha/index.ts
@@ -1,1 +1,10 @@
+/**
+ * CAPTCHA module - detection, classification, and solving (#574)
+ */
+
 export { detectCaptcha } from './detect';
+export { CaptchaSolver } from './solver-interface';
+export type { SolveRequest, SolveResult, SolverConfig, SolverError } from './solver-interface';
+export { SolverRegistry, getSolverRegistry } from './solver-registry';
+export type { SolverProvider, CostTracker } from './solver-registry';
+export type { CaptchaType, CaptchaDetectionResult, CaptchaSiteKey } from '../types/captcha';

--- a/src/captcha/inject-solution.ts
+++ b/src/captcha/inject-solution.ts
@@ -47,22 +47,17 @@ export async function injectSolution(
               }
             }
           } catch { /* fallback: just set textarea */ }
-          // Try grecaptcha.enterprise or grecaptcha
-          try {
-            const g = (window as any).grecaptcha?.enterprise || (window as any).grecaptcha;
-            if (g?.getResponse) return true;
-          } catch { /* ignore */ }
           return !!textarea;
         }
 
         case 'hcaptcha': {
           const textarea = document.querySelector('[name="h-captcha-response"], textarea[name="g-recaptcha-response"]') as HTMLTextAreaElement | null;
           if (textarea) textarea.value = tok;
+          // Call hcaptcha.setResponse if available to register the token,
+          // NOT hcaptcha.execute() which starts a new challenge
           try {
-            const iframe = document.querySelector('iframe[src*="hcaptcha.com"]') as HTMLIFrameElement | null;
-            if (iframe) {
-              (window as any).hcaptcha?.execute?.();
-            }
+            const w = (window as any).hcaptcha;
+            if (w && typeof w.setResponse === 'function') w.setResponse(tok);
           } catch { /* ignore */ }
           return !!textarea;
         }

--- a/src/captcha/inject-solution.ts
+++ b/src/captcha/inject-solution.ts
@@ -1,0 +1,108 @@
+/**
+ * CAPTCHA Solution Injector (#574)
+ *
+ * Injects solver tokens into pages to dismiss CAPTCHAs.
+ * Each CAPTCHA type has a different injection strategy.
+ */
+
+import type { Page } from 'puppeteer-core';
+import type { CaptchaType } from '../types/captcha';
+
+/**
+ * Inject a CAPTCHA solution token into the page.
+ * Returns true if the injection appeared successful.
+ */
+export async function injectSolution(
+  page: Page,
+  captchaType: CaptchaType,
+  token: string,
+): Promise<boolean> {
+  try {
+    return await page.evaluate((type: string, tok: string) => {
+      switch (type) {
+        case 'recaptcha_v2':
+        case 'recaptcha_v3': {
+          // Set the response textarea
+          const textarea = document.querySelector('#g-recaptcha-response, [name="g-recaptcha-response"]') as HTMLTextAreaElement | null;
+          if (textarea) {
+            textarea.value = tok;
+            textarea.style.display = 'block';
+          }
+          // Try to call the callback
+          try {
+            const widgetId = Object.keys((window as any).___grecaptcha_cfg?.clients || {})[0];
+            if (widgetId !== undefined) {
+              const client = (window as any).___grecaptcha_cfg.clients[widgetId];
+              // Walk the client to find the callback
+              for (const key of Object.keys(client)) {
+                const val = client[key];
+                if (val && typeof val === 'object') {
+                  for (const k2 of Object.keys(val)) {
+                    if (typeof val[k2]?.callback === 'function') {
+                      val[k2].callback(tok);
+                      return true;
+                    }
+                  }
+                }
+              }
+            }
+          } catch { /* fallback: just set textarea */ }
+          // Try grecaptcha.enterprise or grecaptcha
+          try {
+            const g = (window as any).grecaptcha?.enterprise || (window as any).grecaptcha;
+            if (g?.getResponse) return true;
+          } catch { /* ignore */ }
+          return !!textarea;
+        }
+
+        case 'hcaptcha': {
+          const textarea = document.querySelector('[name="h-captcha-response"], textarea[name="g-recaptcha-response"]') as HTMLTextAreaElement | null;
+          if (textarea) textarea.value = tok;
+          try {
+            const iframe = document.querySelector('iframe[src*="hcaptcha.com"]') as HTMLIFrameElement | null;
+            if (iframe) {
+              (window as any).hcaptcha?.execute?.();
+            }
+          } catch { /* ignore */ }
+          return !!textarea;
+        }
+
+        case 'turnstile': {
+          // Turnstile uses a hidden input or callback
+          const input = document.querySelector('[name="cf-turnstile-response"], input[name="cf-turnstile-response"]') as HTMLInputElement | null;
+          if (input) input.value = tok;
+          try {
+            const cb = (window as any).turnstile?.getResponse ? true : false;
+            if (!cb) {
+              // Try triggering the widget callback
+              const widget = document.querySelector('.cf-turnstile') as HTMLElement | null;
+              if (widget) {
+                const event = new CustomEvent('cf-turnstile-callback', { detail: tok });
+                widget.dispatchEvent(event);
+              }
+            }
+          } catch { /* ignore */ }
+          return !!input;
+        }
+
+        case 'aws_waf': {
+          // AWS WAF uses ChallengeScript callback
+          try {
+            const awsWaf = (window as any).AwsWafIntegration || (window as any).AwsWafCaptcha;
+            if (awsWaf?.submitCaptcha) {
+              awsWaf.submitCaptcha(tok);
+              return true;
+            }
+          } catch { /* ignore */ }
+          return false;
+        }
+
+        default:
+          return false;
+      }
+    }, captchaType, token);
+  } catch (err) {
+    console.error('[CaptchaSolver] Solution injection failed:', err instanceof Error ? err.message : err);
+    return false;
+  }
+}

--- a/src/captcha/providers/anticaptcha.ts
+++ b/src/captcha/providers/anticaptcha.ts
@@ -32,6 +32,7 @@ export class AntiCaptchaSolver extends CaptchaSolver {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ clientKey: this.config.apiKey, task }),
+      signal: AbortSignal.timeout(15000),
     });
     const createData = await createResponse.json() as { errorId: number; errorDescription?: string; taskId?: number };
 
@@ -58,6 +59,7 @@ export class AntiCaptchaSolver extends CaptchaSolver {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ clientKey: this.config.apiKey }),
+      signal: AbortSignal.timeout(15000),
     });
     const data = await response.json() as { balance: number };
     return data.balance;
@@ -109,6 +111,7 @@ export class AntiCaptchaSolver extends CaptchaSolver {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ clientKey: this.config.apiKey, taskId: parseInt(taskId, 10) }),
+          signal: AbortSignal.timeout(15000),
         });
         data = await response.json() as typeof data;
         consecutiveErrors = 0;

--- a/src/captcha/providers/anticaptcha.ts
+++ b/src/captcha/providers/anticaptcha.ts
@@ -1,0 +1,130 @@
+/**
+ * Anti-Captcha Solver Adapter (#574)
+ *
+ * Integrates with the anti-captcha.com API.
+ * Supports: reCAPTCHA v2/v3, hCaptcha, Turnstile.
+ */
+
+import type { CaptchaType } from '../../types/captcha';
+import { CaptchaSolver, SolveRequest, SolveResult, SolverConfig } from '../solver-interface';
+
+const API_BASE = 'https://api.anti-captcha.com';
+
+const SUPPORTED_TYPES: ReadonlySet<CaptchaType> = new Set([
+  'recaptcha_v2', 'recaptcha_v3', 'hcaptcha', 'turnstile',
+]);
+
+export class AntiCaptchaSolver extends CaptchaSolver {
+  constructor(config: SolverConfig) {
+    super('anticaptcha', config);
+  }
+
+  supportsType(captchaType: CaptchaType): boolean {
+    return SUPPORTED_TYPES.has(captchaType);
+  }
+
+  async solve(request: SolveRequest): Promise<SolveResult> {
+    const startTime = Date.now();
+    const task = this.buildTask(request);
+
+    // Create task
+    const createResponse = await fetch(`${API_BASE}/createTask`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ clientKey: this.config.apiKey, task }),
+    });
+    const createData = await createResponse.json() as { errorId: number; errorDescription?: string; taskId?: number };
+
+    if (createData.errorId !== 0) {
+      throw new Error(`Anti-Captcha create failed: ${createData.errorDescription}`);
+    }
+
+    const taskId = String(createData.taskId);
+
+    // Poll for result
+    const token = await this.pollResult(taskId);
+    const solveTimeMs = Date.now() - startTime;
+
+    return {
+      token,
+      taskId,
+      solveTimeMs,
+      costUsd: this.estimateCost(request.captchaType),
+    };
+  }
+
+  async getBalance(): Promise<number> {
+    const response = await fetch(`${API_BASE}/getBalance`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ clientKey: this.config.apiKey }),
+    });
+    const data = await response.json() as { balance: number };
+    return data.balance;
+  }
+
+  private buildTask(request: SolveRequest): Record<string, unknown> {
+    switch (request.captchaType) {
+      case 'recaptcha_v2':
+        return {
+          type: 'RecaptchaV2TaskProxyless',
+          websiteURL: request.pageUrl,
+          websiteKey: request.siteKey,
+          isInvisible: request.invisible ?? false,
+        };
+      case 'recaptcha_v3':
+        return {
+          type: 'RecaptchaV3TaskProxyless',
+          websiteURL: request.pageUrl,
+          websiteKey: request.siteKey,
+          minScore: request.minScore ?? 0.3,
+          pageAction: request.action ?? 'verify',
+        };
+      case 'hcaptcha':
+        return {
+          type: 'HCaptchaTaskProxyless',
+          websiteURL: request.pageUrl,
+          websiteKey: request.siteKey,
+        };
+      case 'turnstile':
+        return {
+          type: 'TurnstileTaskProxyless',
+          websiteURL: request.pageUrl,
+          websiteKey: request.siteKey,
+        };
+      default:
+        throw new Error(`Unsupported CAPTCHA type: ${request.captchaType}`);
+    }
+  }
+
+  private async pollResult(taskId: string): Promise<string> {
+    const deadline = Date.now() + this.timeoutMs;
+
+    while (Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, this.pollIntervalMs));
+      const response = await fetch(`${API_BASE}/getTaskResult`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clientKey: this.config.apiKey, taskId: parseInt(taskId, 10) }),
+      });
+      const data = await response.json() as { status: string; errorId: number; errorDescription?: string; solution?: { gRecaptchaResponse?: string; token?: string } };
+
+      if (data.status === 'processing') continue;
+      if (data.errorId !== 0) throw new Error(`Anti-Captcha solve failed: ${data.errorDescription}`);
+      if (data.solution) return data.solution.gRecaptchaResponse || data.solution.token || '';
+      throw new Error('Anti-Captcha: empty solution');
+    }
+
+    throw new Error(`Anti-Captcha solve timed out after ${this.timeoutMs}ms`);
+  }
+
+  private estimateCost(captchaType: CaptchaType): number {
+    switch (captchaType) {
+      case 'recaptcha_v2': return 0.002;
+      case 'recaptcha_v3': return 0.003;
+      case 'hcaptcha': return 0.002;
+      case 'turnstile': return 0.002;
+      default: return 0.002;
+    }
+  }
+}

--- a/src/captcha/providers/anticaptcha.ts
+++ b/src/captcha/providers/anticaptcha.ts
@@ -99,15 +99,23 @@ export class AntiCaptchaSolver extends CaptchaSolver {
 
   private async pollResult(taskId: string): Promise<string> {
     const deadline = Date.now() + this.timeoutMs;
+    let consecutiveErrors = 0;
 
     while (Date.now() < deadline) {
       await new Promise(resolve => setTimeout(resolve, this.pollIntervalMs));
-      const response = await fetch(`${API_BASE}/getTaskResult`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ clientKey: this.config.apiKey, taskId: parseInt(taskId, 10) }),
-      });
-      const data = await response.json() as { status: string; errorId: number; errorDescription?: string; solution?: { gRecaptchaResponse?: string; token?: string } };
+      let data: { status: string; errorId: number; errorDescription?: string; solution?: { gRecaptchaResponse?: string; token?: string } };
+      try {
+        const response = await fetch(`${API_BASE}/getTaskResult`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ clientKey: this.config.apiKey, taskId: parseInt(taskId, 10) }),
+        });
+        data = await response.json() as typeof data;
+        consecutiveErrors = 0;
+      } catch (err) {
+        if (++consecutiveErrors >= 3) throw new Error(`Anti-Captcha poll failed after 3 consecutive network errors: ${err}`);
+        continue;
+      }
 
       if (data.status === 'processing') continue;
       if (data.errorId !== 0) throw new Error(`Anti-Captcha solve failed: ${data.errorDescription}`);

--- a/src/captcha/providers/capsolver.ts
+++ b/src/captcha/providers/capsolver.ts
@@ -1,0 +1,133 @@
+/**
+ * CapSolver Solver Adapter (#574)
+ *
+ * Integrates with the capsolver.com API.
+ * Supports: reCAPTCHA v2/v3, hCaptcha, Turnstile, AWS WAF.
+ */
+
+import type { CaptchaType } from '../../types/captcha';
+import { CaptchaSolver, SolveRequest, SolveResult, SolverConfig } from '../solver-interface';
+
+const API_BASE = 'https://api.capsolver.com';
+
+const SUPPORTED_TYPES: ReadonlySet<CaptchaType> = new Set([
+  'recaptcha_v2', 'recaptcha_v3', 'hcaptcha', 'turnstile', 'aws_waf',
+]);
+
+export class CapSolverSolver extends CaptchaSolver {
+  constructor(config: SolverConfig) {
+    super('capsolver', config);
+  }
+
+  supportsType(captchaType: CaptchaType): boolean {
+    return SUPPORTED_TYPES.has(captchaType);
+  }
+
+  async solve(request: SolveRequest): Promise<SolveResult> {
+    const startTime = Date.now();
+    const task = this.buildTask(request);
+
+    const createResponse = await fetch(`${API_BASE}/createTask`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ clientKey: this.config.apiKey, task }),
+    });
+    const createData = await createResponse.json() as { errorId: number; errorDescription?: string; taskId?: string };
+
+    if (createData.errorId !== 0) {
+      throw new Error(`CapSolver create failed: ${createData.errorDescription}`);
+    }
+
+    const taskId = createData.taskId || '';
+    const token = await this.pollResult(taskId);
+    const solveTimeMs = Date.now() - startTime;
+
+    return {
+      token,
+      taskId,
+      solveTimeMs,
+      costUsd: this.estimateCost(request.captchaType),
+    };
+  }
+
+  async getBalance(): Promise<number> {
+    const response = await fetch(`${API_BASE}/getBalance`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ clientKey: this.config.apiKey }),
+    });
+    const data = await response.json() as { balance: number };
+    return data.balance;
+  }
+
+  private buildTask(request: SolveRequest): Record<string, unknown> {
+    switch (request.captchaType) {
+      case 'recaptcha_v2':
+        return {
+          type: 'ReCaptchaV2TaskProxyLess',
+          websiteURL: request.pageUrl,
+          websiteKey: request.siteKey,
+          isInvisible: request.invisible ?? false,
+        };
+      case 'recaptcha_v3':
+        return {
+          type: 'ReCaptchaV3TaskProxyLess',
+          websiteURL: request.pageUrl,
+          websiteKey: request.siteKey,
+          pageAction: request.action ?? 'verify',
+          minScore: request.minScore ?? 0.3,
+        };
+      case 'hcaptcha':
+        return {
+          type: 'HCaptchaTaskProxyLess',
+          websiteURL: request.pageUrl,
+          websiteKey: request.siteKey,
+        };
+      case 'turnstile':
+        return {
+          type: 'AntiTurnstileTaskProxyLess',
+          websiteURL: request.pageUrl,
+          websiteKey: request.siteKey,
+        };
+      case 'aws_waf':
+        return {
+          type: 'AntiAwsWafTaskProxyLess',
+          websiteURL: request.pageUrl,
+        };
+      default:
+        throw new Error(`Unsupported CAPTCHA type: ${request.captchaType}`);
+    }
+  }
+
+  private async pollResult(taskId: string): Promise<string> {
+    const deadline = Date.now() + this.timeoutMs;
+
+    while (Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, this.pollIntervalMs));
+      const response = await fetch(`${API_BASE}/getTaskResult`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clientKey: this.config.apiKey, taskId }),
+      });
+      const data = await response.json() as { status: string; errorId: number; errorDescription?: string; solution?: { gRecaptchaResponse?: string; token?: string } };
+
+      if (data.status === 'processing') continue;
+      if (data.errorId !== 0) throw new Error(`CapSolver solve failed: ${data.errorDescription}`);
+      if (data.solution) return data.solution.gRecaptchaResponse || data.solution.token || '';
+      throw new Error('CapSolver: empty solution');
+    }
+
+    throw new Error(`CapSolver solve timed out after ${this.timeoutMs}ms`);
+  }
+
+  private estimateCost(captchaType: CaptchaType): number {
+    switch (captchaType) {
+      case 'recaptcha_v2': return 0.002;
+      case 'recaptcha_v3': return 0.003;
+      case 'hcaptcha': return 0.002;
+      case 'turnstile': return 0.001;
+      case 'aws_waf': return 0.002;
+      default: return 0.002;
+    }
+  }
+}

--- a/src/captcha/providers/capsolver.ts
+++ b/src/captcha/providers/capsolver.ts
@@ -101,15 +101,23 @@ export class CapSolverSolver extends CaptchaSolver {
 
   private async pollResult(taskId: string): Promise<string> {
     const deadline = Date.now() + this.timeoutMs;
+    let consecutiveErrors = 0;
 
     while (Date.now() < deadline) {
       await new Promise(resolve => setTimeout(resolve, this.pollIntervalMs));
-      const response = await fetch(`${API_BASE}/getTaskResult`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ clientKey: this.config.apiKey, taskId }),
-      });
-      const data = await response.json() as { status: string; errorId: number; errorDescription?: string; solution?: { gRecaptchaResponse?: string; token?: string } };
+      let data: { status: string; errorId: number; errorDescription?: string; solution?: { gRecaptchaResponse?: string; token?: string } };
+      try {
+        const response = await fetch(`${API_BASE}/getTaskResult`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ clientKey: this.config.apiKey, taskId }),
+        });
+        data = await response.json() as typeof data;
+        consecutiveErrors = 0;
+      } catch (err) {
+        if (++consecutiveErrors >= 3) throw new Error(`CapSolver poll failed after 3 consecutive network errors: ${err}`);
+        continue;
+      }
 
       if (data.status === 'processing') continue;
       if (data.errorId !== 0) throw new Error(`CapSolver solve failed: ${data.errorDescription}`);

--- a/src/captcha/providers/capsolver.ts
+++ b/src/captcha/providers/capsolver.ts
@@ -31,6 +31,7 @@ export class CapSolverSolver extends CaptchaSolver {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ clientKey: this.config.apiKey, task }),
+      signal: AbortSignal.timeout(15000),
     });
     const createData = await createResponse.json() as { errorId: number; errorDescription?: string; taskId?: string };
 
@@ -55,6 +56,7 @@ export class CapSolverSolver extends CaptchaSolver {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ clientKey: this.config.apiKey }),
+      signal: AbortSignal.timeout(15000),
     });
     const data = await response.json() as { balance: number };
     return data.balance;
@@ -111,6 +113,7 @@ export class CapSolverSolver extends CaptchaSolver {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ clientKey: this.config.apiKey, taskId }),
+          signal: AbortSignal.timeout(15000),
         });
         data = await response.json() as typeof data;
         consecutiveErrors = 0;

--- a/src/captcha/providers/twocaptcha.ts
+++ b/src/captcha/providers/twocaptcha.ts
@@ -26,10 +26,13 @@ export class TwoCaptchaSolver extends CaptchaSolver {
   async solve(request: SolveRequest): Promise<SolveResult> {
     const startTime = Date.now();
 
-    // Submit task
+    // Submit task via POST to avoid leaking API key in access logs
     const submitParams = this.buildSubmitParams(request);
-    const submitUrl = `${API_BASE}/in.php?${submitParams}`;
-    const submitResponse = await fetch(submitUrl);
+    const submitResponse = await fetch(`${API_BASE}/in.php`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: submitParams,
+    });
     const submitText = await submitResponse.text();
 
     if (!submitText.startsWith('OK|')) {
@@ -51,8 +54,12 @@ export class TwoCaptchaSolver extends CaptchaSolver {
   }
 
   async getBalance(): Promise<number> {
-    const url = `${API_BASE}/res.php?key=${this.config.apiKey}&action=getbalance&json=1`;
-    const response = await fetch(url);
+    // Use POST to avoid leaking API key in server access logs
+    const response = await fetch(`${API_BASE}/res.php`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ key: this.config.apiKey, action: 'getbalance', json: '1' }).toString(),
+    });
     const data = await response.json() as { status: number; request: string };
     return parseFloat(data.request);
   }
@@ -92,16 +99,27 @@ export class TwoCaptchaSolver extends CaptchaSolver {
 
   private async pollResult(taskId: string): Promise<string> {
     const deadline = Date.now() + this.timeoutMs;
-    const url = `${API_BASE}/res.php?key=${this.config.apiKey}&action=get&id=${taskId}&json=0`;
+    const params = new URLSearchParams({ key: this.config.apiKey, action: 'get', id: taskId, json: '0' }).toString();
+    let consecutiveErrors = 0;
 
     while (Date.now() < deadline) {
       await new Promise(resolve => setTimeout(resolve, this.pollIntervalMs));
-      const response = await fetch(url);
-      const text = await response.text();
+      try {
+        const response = await fetch(`${API_BASE}/res.php`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: params,
+        });
+        const text = await response.text();
+        consecutiveErrors = 0;
 
-      if (text === 'CAPCHA_NOT_READY') continue;
-      if (text.startsWith('OK|')) return text.split('|')[1];
-      throw new Error(`2Captcha solve failed: ${text}`);
+        if (text === 'CAPCHA_NOT_READY') continue;
+        if (text.startsWith('OK|')) return text.split('|')[1];
+        throw new Error(`2Captcha solve failed: ${text}`);
+      } catch (err) {
+        if (err instanceof Error && err.message.startsWith('2Captcha solve failed')) throw err;
+        if (++consecutiveErrors >= 3) throw new Error(`2Captcha poll failed after 3 consecutive network errors: ${err}`);
+      }
     }
 
     throw new Error(`2Captcha solve timed out after ${this.timeoutMs}ms`);

--- a/src/captcha/providers/twocaptcha.ts
+++ b/src/captcha/providers/twocaptcha.ts
@@ -1,0 +1,119 @@
+/**
+ * 2Captcha Solver Adapter (#574)
+ *
+ * Integrates with the 2captcha.com API for solving CAPTCHAs.
+ * Supports: reCAPTCHA v2/v3, hCaptcha, Turnstile.
+ */
+
+import type { CaptchaType } from '../../types/captcha';
+import { CaptchaSolver, SolveRequest, SolveResult, SolverConfig } from '../solver-interface';
+
+const API_BASE = 'https://2captcha.com';
+
+const SUPPORTED_TYPES: ReadonlySet<CaptchaType> = new Set([
+  'recaptcha_v2', 'recaptcha_v3', 'hcaptcha', 'turnstile',
+]);
+
+export class TwoCaptchaSolver extends CaptchaSolver {
+  constructor(config: SolverConfig) {
+    super('2captcha', config);
+  }
+
+  supportsType(captchaType: CaptchaType): boolean {
+    return SUPPORTED_TYPES.has(captchaType);
+  }
+
+  async solve(request: SolveRequest): Promise<SolveResult> {
+    const startTime = Date.now();
+
+    // Submit task
+    const submitParams = this.buildSubmitParams(request);
+    const submitUrl = `${API_BASE}/in.php?${submitParams}`;
+    const submitResponse = await fetch(submitUrl);
+    const submitText = await submitResponse.text();
+
+    if (!submitText.startsWith('OK|')) {
+      throw new Error(`2Captcha submit failed: ${submitText}`);
+    }
+
+    const taskId = submitText.split('|')[1];
+
+    // Poll for result
+    const token = await this.pollResult(taskId);
+    const solveTimeMs = Date.now() - startTime;
+
+    return {
+      token,
+      taskId,
+      solveTimeMs,
+      costUsd: this.estimateCost(request.captchaType),
+    };
+  }
+
+  async getBalance(): Promise<number> {
+    const url = `${API_BASE}/res.php?key=${this.config.apiKey}&action=getbalance&json=1`;
+    const response = await fetch(url);
+    const data = await response.json() as { status: number; request: string };
+    return parseFloat(data.request);
+  }
+
+  private buildSubmitParams(request: SolveRequest): string {
+    const params = new URLSearchParams({
+      key: this.config.apiKey,
+      json: '0',
+      pageurl: request.pageUrl,
+    });
+
+    switch (request.captchaType) {
+      case 'recaptcha_v2':
+        params.set('method', 'userrecaptcha');
+        params.set('googlekey', request.siteKey);
+        if (request.invisible) params.set('invisible', '1');
+        break;
+      case 'recaptcha_v3':
+        params.set('method', 'userrecaptcha');
+        params.set('version', 'v3');
+        params.set('googlekey', request.siteKey);
+        if (request.action) params.set('action', request.action);
+        if (request.minScore) params.set('min_score', request.minScore.toString());
+        break;
+      case 'hcaptcha':
+        params.set('method', 'hcaptcha');
+        params.set('sitekey', request.siteKey);
+        break;
+      case 'turnstile':
+        params.set('method', 'turnstile');
+        params.set('sitekey', request.siteKey);
+        break;
+    }
+
+    return params.toString();
+  }
+
+  private async pollResult(taskId: string): Promise<string> {
+    const deadline = Date.now() + this.timeoutMs;
+    const url = `${API_BASE}/res.php?key=${this.config.apiKey}&action=get&id=${taskId}&json=0`;
+
+    while (Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, this.pollIntervalMs));
+      const response = await fetch(url);
+      const text = await response.text();
+
+      if (text === 'CAPCHA_NOT_READY') continue;
+      if (text.startsWith('OK|')) return text.split('|')[1];
+      throw new Error(`2Captcha solve failed: ${text}`);
+    }
+
+    throw new Error(`2Captcha solve timed out after ${this.timeoutMs}ms`);
+  }
+
+  private estimateCost(captchaType: CaptchaType): number {
+    switch (captchaType) {
+      case 'recaptcha_v2': return 0.003;
+      case 'recaptcha_v3': return 0.004;
+      case 'hcaptcha': return 0.003;
+      case 'turnstile': return 0.003;
+      default: return 0.003;
+    }
+  }
+}

--- a/src/captcha/providers/twocaptcha.ts
+++ b/src/captcha/providers/twocaptcha.ts
@@ -32,6 +32,7 @@ export class TwoCaptchaSolver extends CaptchaSolver {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: submitParams,
+      signal: AbortSignal.timeout(15000),
     });
     const submitText = await submitResponse.text();
 
@@ -59,6 +60,7 @@ export class TwoCaptchaSolver extends CaptchaSolver {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: new URLSearchParams({ key: this.config.apiKey, action: 'getbalance', json: '1' }).toString(),
+      signal: AbortSignal.timeout(15000),
     });
     const data = await response.json() as { status: number; request: string };
     return parseFloat(data.request);
@@ -109,6 +111,7 @@ export class TwoCaptchaSolver extends CaptchaSolver {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
           body: params,
+          signal: AbortSignal.timeout(15000),
         });
         const text = await response.text();
         consecutiveErrors = 0;

--- a/src/captcha/solver-interface.ts
+++ b/src/captcha/solver-interface.ts
@@ -1,0 +1,86 @@
+/**
+ * CAPTCHA Solver Interface (#574)
+ *
+ * Abstract interface for third-party CAPTCHA solving services.
+ * Implementations: 2Captcha, Anti-Captcha, CapSolver.
+ */
+
+import type { CaptchaType } from '../types/captcha';
+
+/** Request payload sent to a solver provider. */
+export interface SolveRequest {
+  /** The type of CAPTCHA to solve. */
+  captchaType: CaptchaType;
+  /** The site key extracted from the page. */
+  siteKey: string;
+  /** The URL of the page containing the CAPTCHA. */
+  pageUrl: string;
+  /** Whether this is an invisible CAPTCHA (reCAPTCHA v3). */
+  invisible?: boolean;
+  /** Optional reCAPTCHA v3 action string. */
+  action?: string;
+  /** Optional minimum score for reCAPTCHA v3 (0.1-0.9). */
+  minScore?: number;
+}
+
+/** Solution returned by a solver provider. */
+export interface SolveResult {
+  /** The solution token to inject into the page. */
+  token: string;
+  /** Provider-specific task/request ID for tracking. */
+  taskId: string;
+  /** Time in milliseconds the solve took. */
+  solveTimeMs: number;
+  /** Estimated cost in USD. */
+  costUsd: number;
+}
+
+/** Error from a solver provider. */
+export interface SolverError {
+  code: string;
+  message: string;
+  retryable: boolean;
+}
+
+/** Provider configuration. */
+export interface SolverConfig {
+  /** API key for the provider. */
+  apiKey: string;
+  /** Solve timeout in milliseconds (default: 120000). */
+  timeoutMs?: number;
+  /** Poll interval in milliseconds (default: 5000). */
+  pollIntervalMs?: number;
+}
+
+/**
+ * Abstract CAPTCHA solver. Each provider (2Captcha, Anti-Captcha, CapSolver)
+ * implements this interface.
+ */
+export abstract class CaptchaSolver {
+  readonly name: string;
+  protected config: SolverConfig;
+
+  constructor(name: string, config: SolverConfig) {
+    this.name = name;
+    this.config = config;
+  }
+
+  /** Check if this solver supports the given CAPTCHA type. */
+  abstract supportsType(captchaType: CaptchaType): boolean;
+
+  /** Submit a CAPTCHA for solving and return the solution. */
+  abstract solve(request: SolveRequest): Promise<SolveResult>;
+
+  /** Get the current account balance (for cost tracking). */
+  abstract getBalance(): Promise<number>;
+
+  /** Timeout for solving in milliseconds. */
+  get timeoutMs(): number {
+    return this.config.timeoutMs ?? 120000;
+  }
+
+  /** Poll interval for checking solution status. */
+  get pollIntervalMs(): number {
+    return this.config.pollIntervalMs ?? 5000;
+  }
+}

--- a/src/captcha/solver-registry.ts
+++ b/src/captcha/solver-registry.ts
@@ -149,13 +149,20 @@ export class SolverRegistry {
 
 // Singleton
 let instance: SolverRegistry | null = null;
+let initPromise: Promise<void> | null = null;
 
 export function getSolverRegistry(): SolverRegistry {
   if (!instance) {
     instance = new SolverRegistry();
-    instance.initialize().catch(err => {
+    initPromise = instance.initialize().catch(err => {
       console.error('[CaptchaSolver] Initialization failed:', err instanceof Error ? err.message : err);
     });
   }
   return instance;
+}
+
+/** Wait for the solver registry to finish initialization. */
+export async function waitForSolverReady(): Promise<void> {
+  getSolverRegistry();
+  if (initPromise) await initPromise;
 }

--- a/src/captcha/solver-registry.ts
+++ b/src/captcha/solver-registry.ts
@@ -1,0 +1,161 @@
+/**
+ * CAPTCHA Solver Registry (#574)
+ *
+ * Manages solver provider instances and dispatches solve requests
+ * with rate limiting and cost tracking.
+ */
+
+import type { CaptchaType } from '../types/captcha';
+import { CaptchaSolver, SolveRequest, SolveResult, SolverConfig } from './solver-interface';
+
+/** Supported provider names. */
+export type SolverProvider = '2captcha' | 'anticaptcha' | 'capsolver';
+
+/** Session-level cost tracking. */
+export interface CostTracker {
+  totalSolves: number;
+  totalCostUsd: number;
+  dailySolves: number;
+  dailyLimitReached: boolean;
+  lastSolveAt: number;
+}
+
+export class SolverRegistry {
+  private solver: CaptchaSolver | null = null;
+  private costTracker: CostTracker = {
+    totalSolves: 0,
+    totalCostUsd: 0,
+    dailySolves: 0,
+    dailyLimitReached: false,
+    lastSolveAt: 0,
+  };
+  private dailyLimit: number;
+  private minSolveIntervalMs: number;
+  private autoSolve: boolean;
+  private dailyResetDate: string = '';
+
+  constructor() {
+    this.dailyLimit = parseInt(process.env.OPENCHROME_CAPTCHA_DAILY_LIMIT || '', 10) || 100;
+    this.minSolveIntervalMs = 3000; // Minimum 3s between solves
+    this.autoSolve = process.env.OPENCHROME_CAPTCHA_AUTO_SOLVE === 'true';
+  }
+
+  /** Initialize the solver from environment variables. */
+  async initialize(): Promise<void> {
+    const provider = process.env.OPENCHROME_CAPTCHA_PROVIDER as SolverProvider | undefined;
+    const apiKey = process.env.OPENCHROME_CAPTCHA_API_KEY;
+
+    if (!provider || !apiKey) {
+      this.solver = null;
+      return;
+    }
+
+    const config: SolverConfig = { apiKey };
+
+    switch (provider) {
+      case '2captcha': {
+        const { TwoCaptchaSolver } = await import('./providers/twocaptcha');
+        this.solver = new TwoCaptchaSolver(config);
+        break;
+      }
+      case 'anticaptcha': {
+        const { AntiCaptchaSolver } = await import('./providers/anticaptcha');
+        this.solver = new AntiCaptchaSolver(config);
+        break;
+      }
+      case 'capsolver': {
+        const { CapSolverSolver } = await import('./providers/capsolver');
+        this.solver = new CapSolverSolver(config);
+        break;
+      }
+      default:
+        console.error(`[CaptchaSolver] Unknown provider: ${provider}. Supported: 2captcha, anticaptcha, capsolver`);
+        this.solver = null;
+    }
+
+    if (this.solver) {
+      console.error(`[CaptchaSolver] Initialized provider: ${provider}, auto-solve: ${this.autoSolve}`);
+    }
+  }
+
+  /** Whether a solver is configured and available. */
+  isConfigured(): boolean {
+    return this.solver !== null;
+  }
+
+  /** Whether auto-solve is enabled. */
+  isAutoSolveEnabled(): boolean {
+    return this.autoSolve && this.isConfigured();
+  }
+
+  /** Whether this CAPTCHA type can be solved. */
+  canSolve(captchaType: CaptchaType): boolean {
+    if (!this.solver) return false;
+    if (this.costTracker.dailyLimitReached) return false;
+    return this.solver.supportsType(captchaType);
+  }
+
+  /** Solve a CAPTCHA. Enforces rate limiting and daily limits. */
+  async solve(request: SolveRequest): Promise<SolveResult> {
+    if (!this.solver) {
+      throw new Error('No CAPTCHA solver configured. Set OPENCHROME_CAPTCHA_PROVIDER and OPENCHROME_CAPTCHA_API_KEY.');
+    }
+
+    // Reset daily counter if date changed
+    const today = new Date().toISOString().slice(0, 10);
+    if (this.dailyResetDate !== today) {
+      this.dailyResetDate = today;
+      this.costTracker.dailySolves = 0;
+      this.costTracker.dailyLimitReached = false;
+    }
+
+    // Check daily limit
+    if (this.costTracker.dailySolves >= this.dailyLimit) {
+      this.costTracker.dailyLimitReached = true;
+      throw new Error(`Daily CAPTCHA solve limit reached (${this.dailyLimit}). Set OPENCHROME_CAPTCHA_DAILY_LIMIT to increase.`);
+    }
+
+    // Rate limiting: minimum 3s between solves
+    const now = Date.now();
+    const elapsed = now - this.costTracker.lastSolveAt;
+    if (elapsed < this.minSolveIntervalMs) {
+      const waitMs = this.minSolveIntervalMs - elapsed;
+      await new Promise(resolve => setTimeout(resolve, waitMs));
+    }
+
+    console.error(`[CaptchaSolver] Solving ${request.captchaType} on ${request.pageUrl}...`);
+    const result = await this.solver.solve(request);
+
+    // Update cost tracking
+    this.costTracker.totalSolves++;
+    this.costTracker.dailySolves++;
+    this.costTracker.totalCostUsd += result.costUsd;
+    this.costTracker.lastSolveAt = Date.now();
+
+    console.error(`[CaptchaSolver] Solved in ${result.solveTimeMs}ms, cost: $${result.costUsd.toFixed(4)}`);
+    return result;
+  }
+
+  /** Get current cost tracking data. */
+  getCostTracker(): CostTracker {
+    return { ...this.costTracker };
+  }
+
+  /** Get solver provider name. */
+  getProviderName(): string | null {
+    return this.solver?.name ?? null;
+  }
+}
+
+// Singleton
+let instance: SolverRegistry | null = null;
+
+export function getSolverRegistry(): SolverRegistry {
+  if (!instance) {
+    instance = new SolverRegistry();
+    instance.initialize().catch(err => {
+      console.error('[CaptchaSolver] Initialization failed:', err instanceof Error ? err.message : err);
+    });
+  }
+  return instance;
+}

--- a/src/hints/rules/blocking-page.ts
+++ b/src/hints/rules/blocking-page.ts
@@ -12,13 +12,19 @@ export const blockingPageRules: HintRule[] = [
       if (ctx.toolName !== 'navigate') return null;
       if (ctx.isError) return null;
       if (/"blockingPage"\s*:\s*\{[^}]*"type"\s*:\s*"captcha"/i.test(ctx.resultText)) {
+        // If CAPTCHA was already auto-solved, don't fire the hint
+        if (/"captcha_solved"\s*:\s*true/.test(ctx.resultText)) return null;
+
         const typeMatch = ctx.resultText.match(/"captchaType"\s*:\s*"([^"]+)"/);
         const captchaType = typeMatch ? typeMatch[1] : 'unknown';
-        return (
-          'Hint: CAPTCHA detected (type: ' + captchaType + '). ' +
-          'STOP all interaction attempts with this page. ' +
-          'Ask the user to solve the CAPTCHA in their Chrome browser, then use wait_for to detect when the page changes, and resume automation.'
-        );
+        const canAutoSolve = process.env.OPENCHROME_CAPTCHA_API_KEY &&
+          process.env.OPENCHROME_CAPTCHA_AUTO_SOLVE === 'true';
+
+        return canAutoSolve
+          ? 'Hint: CAPTCHA detected (type: ' + captchaType + '). Auto-solve is active and will attempt to dismiss it. Wait for the result before retrying.'
+          : 'Hint: CAPTCHA detected (type: ' + captchaType + '). ' +
+            'STOP all interaction attempts with this page. ' +
+            'Ask the user to solve the CAPTCHA in their Chrome browser, then use wait_for to detect when the page changes, and resume automation.';
       }
       return null;
     },

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -12,6 +12,8 @@ import { generateVisualSummary } from '../utils/visual-summary';
 import { AdaptiveScreenshot } from '../utils/adaptive-screenshot';
 import { assertDomainAllowed } from '../security/domain-guard';
 import { detectBlockingPage, BlockingInfo } from '../utils/page-diagnostics';
+import { handleCaptcha } from '../captcha/handler';
+import { getSolverRegistry } from '../captcha/solver-registry';
 import { withTimeout } from '../utils/with-timeout';
 import { simulatePresence } from '../stealth/human-behavior';
 import { getHeadedFallback } from '../chrome/headed-fallback';
@@ -118,6 +120,33 @@ async function stealthAutoRetry(
   // This is safe because we only reach here after Tier 1 already detected a block. (#459)
   const stealthBlocked = blocking && RETRYABLE_BLOCK_TYPES.has(blocking.type);
   const stealthBroken = elementCount === 0 || readiness.readyState === 'unknown';
+  // Try CAPTCHA solver before escalating to headed Chrome (#574)
+  if (stealthBlocked && blocking?.type === 'captcha' && getSolverRegistry().isAutoSolveEnabled()) {
+    const solveResult = await handleCaptcha(page, blocking);
+    if (solveResult.solved) {
+      console.error(`[navigate] CAPTCHA solved via ${getSolverRegistry().getProviderName()} in ${solveResult.solveTimeMs}ms`);
+      const postSolveSummary = await generateVisualSummary(page).catch(() => null);
+      const resultText = JSON.stringify({
+        action: 'navigate',
+        url: page.url(),
+        title: await safeTitle(page),
+        tabId: targetId,
+        workerId: assignedWorkerId,
+        created: true,
+        elementCount,
+        readiness,
+        stealth: true,
+        fallbackTier: 2,
+        fallbackReason: blockingInfo.type,
+        captcha_solved: true,
+        captcha_type: solveResult.captchaType,
+        captcha_solve_time_ms: solveResult.solveTimeMs,
+        ...(postSolveSummary && { visualSummary: postSolveSummary }),
+      });
+      return { content: [{ type: 'text', text: resultText }] };
+    }
+    console.error(`[navigate] CAPTCHA solve failed: ${solveResult.error}, escalating to Tier 3`);
+  }
   if (autoFallbackToHeaded && (stealthBlocked || stealthBroken)) {
     const headedResult = await headedAutoRetry(targetUrl, blocking || blockingInfo, sessionId);
     if (headedResult) return headedResult;

--- a/tests/captcha/captcha-handler.test.ts
+++ b/tests/captcha/captcha-handler.test.ts
@@ -1,0 +1,73 @@
+/**
+ * CAPTCHA Handler Tests (#574)
+ */
+import { BlockingInfo } from '../../src/utils/page-diagnostics';
+
+describe('CAPTCHA Handler', () => {
+  it('should export handleCaptcha function', async () => {
+    const mod = await import('../../src/captcha/handler');
+    expect(typeof mod.handleCaptcha).toBe('function');
+  });
+
+  it('should export checkDomainCaptchaHistory function', async () => {
+    const mod = await import('../../src/captcha/handler');
+    expect(typeof mod.checkDomainCaptchaHistory).toBe('function');
+  });
+
+  it('should return not-solved when no solver configured', async () => {
+    // Clear env to ensure no solver
+    delete process.env.OPENCHROME_CAPTCHA_PROVIDER;
+    delete process.env.OPENCHROME_CAPTCHA_API_KEY;
+
+    const { handleCaptcha } = await import('../../src/captcha/handler');
+    const page = {
+      evaluate: () => Promise.resolve(null),
+      url: () => 'http://test.com',
+    } as any;
+    const blocking: BlockingInfo = {
+      type: 'captcha',
+      detail: 'test',
+      captchaType: 'turnstile',
+    };
+
+    const result = await handleCaptcha(page, blocking);
+    expect(result.solved).toBe(false);
+    expect(result.error).toContain('No CAPTCHA solver configured');
+  });
+
+  it('checkDomainCaptchaHistory should return null for unknown domains', async () => {
+    const { checkDomainCaptchaHistory } = await import('../../src/captcha/handler');
+    expect(checkDomainCaptchaHistory('http://never-seen-before-domain.test')).toBeNull();
+  });
+});
+
+describe('Solution Injector', () => {
+  it('should export injectSolution function', async () => {
+    const mod = await import('../../src/captcha/inject-solution');
+    expect(typeof mod.injectSolution).toBe('function');
+  });
+
+  it('should handle injection errors gracefully', async () => {
+    const { injectSolution } = await import('../../src/captcha/inject-solution');
+    const page = {
+      evaluate: () => Promise.reject(new Error('page crashed')),
+    } as any;
+    const result = await injectSolution(page, 'turnstile', 'token');
+    expect(result).toBe(false);
+  });
+});
+
+describe('Fallback chain integration', () => {
+  it('navigate.ts should import handleCaptcha', async () => {
+    const fs = await import('fs');
+    const content = fs.readFileSync('src/tools/navigate.ts', 'utf-8');
+    expect(content).toContain('handleCaptcha');
+    expect(content).toContain('getSolverRegistry');
+  });
+
+  it('navigate.ts should have captcha_solved response field', async () => {
+    const fs = await import('fs');
+    const content = fs.readFileSync('src/tools/navigate.ts', 'utf-8');
+    expect(content).toContain('captcha_solved');
+  });
+});

--- a/tests/captcha/solver-providers.test.ts
+++ b/tests/captcha/solver-providers.test.ts
@@ -1,0 +1,83 @@
+/**
+ * CAPTCHA Solver Providers Tests (#574)
+ */
+import { TwoCaptchaSolver } from '../../src/captcha/providers/twocaptcha';
+import { AntiCaptchaSolver } from '../../src/captcha/providers/anticaptcha';
+import { CapSolverSolver } from '../../src/captcha/providers/capsolver';
+
+describe('TwoCaptchaSolver', () => {
+  const solver = new TwoCaptchaSolver({ apiKey: 'test-key' });
+
+  it('should have correct name', () => {
+    expect(solver.name).toBe('2captcha');
+  });
+
+  it('should support reCAPTCHA v2/v3, hCaptcha, Turnstile', () => {
+    expect(solver.supportsType('recaptcha_v2')).toBe(true);
+    expect(solver.supportsType('recaptcha_v3')).toBe(true);
+    expect(solver.supportsType('hcaptcha')).toBe(true);
+    expect(solver.supportsType('turnstile')).toBe(true);
+  });
+
+  it('should not support AWS WAF or unknown', () => {
+    expect(solver.supportsType('aws_waf')).toBe(false);
+    expect(solver.supportsType('unknown')).toBe(false);
+  });
+
+  it('should have default timeout of 120s', () => {
+    expect(solver.timeoutMs).toBe(120000);
+  });
+
+  it('should have default poll interval of 5s', () => {
+    expect(solver.pollIntervalMs).toBe(5000);
+  });
+});
+
+describe('AntiCaptchaSolver', () => {
+  const solver = new AntiCaptchaSolver({ apiKey: 'test-key' });
+
+  it('should have correct name', () => {
+    expect(solver.name).toBe('anticaptcha');
+  });
+
+  it('should support reCAPTCHA v2/v3, hCaptcha, Turnstile', () => {
+    expect(solver.supportsType('recaptcha_v2')).toBe(true);
+    expect(solver.supportsType('recaptcha_v3')).toBe(true);
+    expect(solver.supportsType('hcaptcha')).toBe(true);
+    expect(solver.supportsType('turnstile')).toBe(true);
+  });
+
+  it('should not support AWS WAF', () => {
+    expect(solver.supportsType('aws_waf')).toBe(false);
+  });
+
+  it('should respect custom timeout', () => {
+    const s = new AntiCaptchaSolver({ apiKey: 'k', timeoutMs: 60000 });
+    expect(s.timeoutMs).toBe(60000);
+  });
+});
+
+describe('CapSolverSolver', () => {
+  const solver = new CapSolverSolver({ apiKey: 'test-key' });
+
+  it('should have correct name', () => {
+    expect(solver.name).toBe('capsolver');
+  });
+
+  it('should support all main types including AWS WAF', () => {
+    expect(solver.supportsType('recaptcha_v2')).toBe(true);
+    expect(solver.supportsType('recaptcha_v3')).toBe(true);
+    expect(solver.supportsType('hcaptcha')).toBe(true);
+    expect(solver.supportsType('turnstile')).toBe(true);
+    expect(solver.supportsType('aws_waf')).toBe(true);
+  });
+
+  it('should not support unknown type', () => {
+    expect(solver.supportsType('unknown')).toBe(false);
+  });
+
+  it('should respect custom poll interval', () => {
+    const s = new CapSolverSolver({ apiKey: 'k', pollIntervalMs: 3000 });
+    expect(s.pollIntervalMs).toBe(3000);
+  });
+});

--- a/tests/captcha/solver-registry.test.ts
+++ b/tests/captcha/solver-registry.test.ts
@@ -1,0 +1,57 @@
+/**
+ * CAPTCHA Solver Registry Tests (#574)
+ */
+import { SolverRegistry } from '../../src/captcha/solver-registry';
+
+describe('SolverRegistry', () => {
+  let registry: SolverRegistry;
+
+  beforeEach(() => {
+    // Clear env vars
+    delete process.env.OPENCHROME_CAPTCHA_PROVIDER;
+    delete process.env.OPENCHROME_CAPTCHA_API_KEY;
+    delete process.env.OPENCHROME_CAPTCHA_AUTO_SOLVE;
+    delete process.env.OPENCHROME_CAPTCHA_DAILY_LIMIT;
+    registry = new SolverRegistry();
+  });
+
+  it('should not be configured without env vars', () => {
+    expect(registry.isConfigured()).toBe(false);
+    expect(registry.isAutoSolveEnabled()).toBe(false);
+    expect(registry.getProviderName()).toBeNull();
+  });
+
+  it('should not be able to solve without configuration', () => {
+    expect(registry.canSolve('turnstile')).toBe(false);
+  });
+
+  it('should throw on solve without configuration', async () => {
+    await expect(registry.solve({
+      captchaType: 'turnstile',
+      siteKey: 'test',
+      pageUrl: 'http://test.com',
+    })).rejects.toThrow('No CAPTCHA solver configured');
+  });
+
+  it('should initialize cost tracker at zero', () => {
+    const tracker = registry.getCostTracker();
+    expect(tracker.totalSolves).toBe(0);
+    expect(tracker.totalCostUsd).toBe(0);
+    expect(tracker.dailySolves).toBe(0);
+    expect(tracker.dailyLimitReached).toBe(false);
+  });
+
+  it('should respect daily limit from env var', () => {
+    process.env.OPENCHROME_CAPTCHA_DAILY_LIMIT = '50';
+    const r = new SolverRegistry();
+    const tracker = r.getCostTracker();
+    expect(tracker.dailyLimitReached).toBe(false);
+  });
+
+  it('should detect auto-solve setting', () => {
+    process.env.OPENCHROME_CAPTCHA_AUTO_SOLVE = 'true';
+    const r = new SolverRegistry();
+    // Not configured, so auto-solve is still false
+    expect(r.isAutoSolveEnabled()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of CAPTCHA Auto-Solving Integration (#574). Depends on shaun0927/openchrome#585, shaun0927/openchrome#587.

- **Solution injector** (`src/captcha/inject-solution.ts`) — injects solver tokens into pages for reCAPTCHA v2/v3, hCaptcha, Turnstile, and AWS WAF using type-specific strategies
- **CAPTCHA handler** (`src/captcha/handler.ts`) — orchestrates the full solving flow: detect → extract site key → submit to solver → inject solution → verify
- **Fallback chain integration** — solver is invoked in stealth auto-retry (Tier 2) before escalating to headed Chrome (Tier 3):
  ```
  Tier 1 (headless) → block detected →
  Tier 2 (stealth) → CAPTCHA detected → try solver →
    solved? → continue | failed? → Tier 3 (headed) → HITL
  ```
- **Domain memory integration** — records CAPTCHA encounters per domain (type, timestamp, solve success/failure, provider) for pre-emptive stealth routing
- **Navigate response enrichment** — `captcha_solved`, `captcha_type`, `captcha_solve_time_ms` fields in responses when CAPTCHA is auto-solved
- **43 unit tests** across all 3 phases

### Files changed
- `src/captcha/inject-solution.ts` — new: token injection per CAPTCHA type
- `src/captcha/handler.ts` — new: solve orchestration + domain memory
- `src/captcha/index.ts` — updated: export handler and injector
- `src/tools/navigate.ts` — updated: solver in stealth fallback chain
- `tests/captcha/captcha-handler.test.ts` — new: handler + integration tests

## Test plan
- [x] 43 unit tests pass across all 3 phases
- [x] TypeScript compilation succeeds
- [ ] E2E: reCAPTCHA v2 demo page with 2Captcha test key
- [ ] E2E: Cloudflare Turnstile demo page
- [ ] E2E: Solver failure → headed fallback → HITL hint
- [ ] Verify domain memory records CAPTCHA encounters

🤖 Generated with [Claude Code](https://claude.com/claude-code)