### PR TITLE
feat: add crawl tool for recursive web crawling (#576)

### DIFF
--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -56,6 +56,7 @@ export const TOOL_TIERS: Record<string, ToolTier> = {
   file_upload: 2,
   batch_execute: 2,
   batch_paginate: 2,
+  crawl: 2,
 
   // Internal/diagnostic tools (exposed at Tier 1 but explicitly declared)
   // Names must match the 'name' field in each tool's definition

--- a/src/tools/crawl.ts
+++ b/src/tools/crawl.ts
@@ -1,0 +1,579 @@
+/**
+ * Crawl Tool - Recursive web crawling via BFS traversal
+ *
+ * Opens pages in new tabs, extracts content and links, respects robots.txt
+ * and scope constraints. Uses CrawlTracker from crawl-utils for deduplication.
+ *
+ * @see https://github.com/shaun0927/openchrome/issues/576
+ */
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
+import { getSessionManager } from '../session-manager';
+import { MAX_OUTPUT_CHARS } from '../config/defaults';
+import { withTimeout } from '../utils/with-timeout';
+import {
+  normalizeUrl,
+  matchesScope,
+  passesFilters,
+  parseRobotsTxt,
+  isAllowedByRobots,
+  CrawlTracker,
+  RobotsRules,
+} from '../utils/crawl-utils';
+
+const definition: MCPToolDefinition = {
+  name: 'crawl',
+  description:
+    'Recursively crawl a website via BFS. Opens each page in a new tab, extracts text content and discovers links, then follows them up to max_depth. Respects robots.txt and scope constraints.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      url: {
+        type: 'string',
+        description: 'Starting URL to crawl',
+      },
+      max_depth: {
+        type: 'number',
+        description: 'Maximum link-follow depth (0 = start page only). Default: 2',
+      },
+      max_pages: {
+        type: 'number',
+        description: 'Maximum number of pages to crawl. Default: 20',
+      },
+      scope: {
+        type: 'string',
+        description:
+          'URL glob pattern limiting which URLs to follow (e.g. "https://docs.example.com/**"). Default: same origin as start URL.',
+      },
+      include_patterns: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'URL glob patterns — only follow links matching at least one',
+      },
+      exclude_patterns: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'URL glob patterns — skip links matching any of these',
+      },
+      output_format: {
+        type: 'string',
+        enum: ['markdown', 'text', 'structured'],
+        description: 'Content format per page. Default: markdown',
+      },
+      respect_robots: {
+        type: 'boolean',
+        description: 'Whether to fetch and obey robots.txt. Default: true',
+      },
+      delay_ms: {
+        type: 'number',
+        description: 'Delay between page fetches in milliseconds. Default: 1000',
+      },
+      concurrency: {
+        type: 'number',
+        description: 'Max parallel tab fetches. Default: 3',
+      },
+    },
+    required: ['url'],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Concurrency limiter (same pattern as batch-paginate.ts)
+// ---------------------------------------------------------------------------
+
+function createLimiter(concurrency: number) {
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  return async function <T>(fn: () => Promise<T>): Promise<T> {
+    if (active >= concurrency) {
+      await new Promise<void>((resolve) => queue.push(resolve));
+    }
+    active++;
+    try {
+      return await fn();
+    } finally {
+      active--;
+      if (queue.length > 0) {
+        const next = queue.shift()!;
+        next();
+      }
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CrawledPage {
+  url: string;
+  title: string;
+  content: string;
+  depth: number;
+  links_found: number;
+  error?: string;
+}
+
+interface CrawlSummary {
+  total_pages: number;
+  succeeded: number;
+  failed: number;
+  max_depth_reached: number;
+  duration_ms: number;
+  scope: string;
+}
+
+// ---------------------------------------------------------------------------
+// Robots.txt cache (per-origin, within a single crawl invocation)
+// ---------------------------------------------------------------------------
+
+async function fetchRobotsTxt(
+  sessionId: string,
+  origin: string,
+  context?: ToolContext,
+): Promise<RobotsRules | null> {
+  const sessionManager = getSessionManager();
+  const robotsUrl = `${origin}/robots.txt`;
+  let targetId: string | null = null;
+
+  try {
+    const { targetId: tid, page } = await sessionManager.createTarget(sessionId, robotsUrl);
+    targetId = tid;
+
+    // Wait for page load with a short timeout
+    await withTimeout(
+      page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
+      10000,
+      'crawl.robots.waitForNavigation',
+      context,
+    );
+
+    const bodyText = await withTimeout(
+      page.evaluate(() => document.body?.innerText || ''),
+      5000,
+      'crawl.robots.evaluate',
+      context,
+    );
+
+    await sessionManager.closeTarget(sessionId, tid);
+    targetId = null;
+
+    // If the response looks like robots.txt (has User-agent or Disallow), parse it
+    if (bodyText && (bodyText.toLowerCase().includes('user-agent') || bodyText.toLowerCase().includes('disallow'))) {
+      return parseRobotsTxt(bodyText);
+    }
+
+    return null;
+  } catch (err) {
+    console.error(`[crawl] Failed to fetch robots.txt from ${origin}: ${err instanceof Error ? err.message : String(err)}`);
+    if (targetId) {
+      try {
+        await sessionManager.closeTarget(sessionId, targetId);
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Single page fetch
+// ---------------------------------------------------------------------------
+
+async function fetchPage(
+  sessionId: string,
+  url: string,
+  depth: number,
+  outputFormat: string,
+  context?: ToolContext,
+): Promise<CrawledPage> {
+  const sessionManager = getSessionManager();
+  let targetId: string | null = null;
+
+  try {
+    const { targetId: tid, page } = await sessionManager.createTarget(sessionId, url);
+    targetId = tid;
+
+    // Wait for the page to be mostly loaded
+    await withTimeout(
+      page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
+      15000,
+      'crawl.page.waitForNavigation',
+      context,
+    );
+
+    // Small settle delay for dynamic content
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Extract content and links in one page.evaluate call
+    const result = await withTimeout(
+      page.evaluate((format: string) => {
+        const title = document.title || '';
+
+        // Collect links
+        const links: string[] = [];
+        const anchors = document.querySelectorAll('a[href]');
+        anchors.forEach((a) => {
+          const href = (a as HTMLAnchorElement).href;
+          if (href && !href.startsWith('javascript:') && !href.startsWith('mailto:') && !href.startsWith('tel:')) {
+            links.push(href);
+          }
+        });
+
+        // Extract content based on format
+        let content = '';
+        if (format === 'markdown') {
+          // Build a markdown-like representation
+          const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT);
+          const parts: string[] = [];
+          let node: Node | null = walker.currentNode;
+
+          while (node) {
+            const el = node as HTMLElement;
+            const tag = el.tagName?.toLowerCase();
+
+            if (tag === 'script' || tag === 'style' || tag === 'noscript') {
+              node = walker.nextSibling() || walker.parentNode();
+              continue;
+            }
+
+            if (tag === 'h1') parts.push(`\n# ${el.textContent?.trim()}\n`);
+            else if (tag === 'h2') parts.push(`\n## ${el.textContent?.trim()}\n`);
+            else if (tag === 'h3') parts.push(`\n### ${el.textContent?.trim()}\n`);
+            else if (tag === 'h4') parts.push(`\n#### ${el.textContent?.trim()}\n`);
+            else if (tag === 'h5') parts.push(`\n##### ${el.textContent?.trim()}\n`);
+            else if (tag === 'h6') parts.push(`\n###### ${el.textContent?.trim()}\n`);
+            else if (tag === 'p') {
+              const text = el.textContent?.trim();
+              if (text) parts.push(`\n${text}\n`);
+            }
+            else if (tag === 'li') {
+              const text = el.textContent?.trim();
+              if (text) parts.push(`- ${text}`);
+            }
+            else if (tag === 'pre' || tag === 'code') {
+              const text = el.textContent?.trim();
+              if (text && tag === 'pre') parts.push(`\n\`\`\`\n${text}\n\`\`\`\n`);
+            }
+            else if (tag === 'a') {
+              // Skip — links handled separately
+            }
+            else if (tag === 'blockquote') {
+              const text = el.textContent?.trim();
+              if (text) parts.push(`\n> ${text}\n`);
+            }
+
+            node = walker.nextNode();
+          }
+
+          content = parts.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+
+          // Fallback to innerText if markdown extraction is empty
+          if (!content) {
+            content = document.body.innerText || '';
+          }
+        } else if (format === 'text') {
+          content = document.body.innerText || '';
+        } else {
+          // structured — return raw HTML body
+          content = document.body.innerHTML || '';
+        }
+
+        return { title, content, links };
+      }, outputFormat),
+      15000,
+      'crawl.page.evaluate',
+      context,
+    );
+
+    await sessionManager.closeTarget(sessionId, tid);
+    targetId = null;
+
+    // Truncate content if too large
+    let content = result.content;
+    if (content.length > MAX_OUTPUT_CHARS) {
+      content = content.slice(0, MAX_OUTPUT_CHARS) + '...[truncated]';
+    }
+
+    return {
+      url,
+      title: result.title,
+      content,
+      depth,
+      links_found: result.links.length,
+      // Store links transiently — caller uses them for BFS
+      ...(result.links.length > 0 ? { _links: result.links } as Record<string, unknown> : {}),
+    } as CrawledPage & { _links?: string[] };
+  } catch (err) {
+    if (targetId) {
+      try {
+        await sessionManager.closeTarget(sessionId, targetId);
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+    return {
+      url,
+      title: '',
+      content: '',
+      depth,
+      links_found: 0,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+const handler: ToolHandler = async (
+  sessionId: string,
+  args: Record<string, unknown>,
+  context?: ToolContext,
+): Promise<MCPResult> => {
+  const url = args.url as string;
+  if (!url) {
+    return {
+      content: [{ type: 'text', text: 'Error: url is required' }],
+      isError: true,
+    };
+  }
+
+  // Validate URL
+  let startUrl: URL;
+  try {
+    startUrl = new URL(url);
+  } catch {
+    return {
+      content: [{ type: 'text', text: `Error: Invalid URL "${url}"` }],
+      isError: true,
+    };
+  }
+
+  const maxDepth = args.max_depth != null ? Number(args.max_depth) : 2;
+  const maxPages = args.max_pages != null ? Number(args.max_pages) : 20;
+  const scope = (args.scope as string) || `${startUrl.origin}/**`;
+  const includePatterns = args.include_patterns as string[] | undefined;
+  const excludePatterns = args.exclude_patterns as string[] | undefined;
+  const outputFormat = (args.output_format as string) || 'markdown';
+  const respectRobots = args.respect_robots !== false;
+  const delayMs = args.delay_ms != null ? Number(args.delay_ms) : 1000;
+  const concurrency = args.concurrency != null ? Math.max(1, Math.min(10, Number(args.concurrency))) : 3;
+
+  const startTime = Date.now();
+  const tracker = new CrawlTracker();
+  const pages: CrawledPage[] = [];
+  let maxDepthReached = 0;
+
+  // Fetch robots.txt if needed
+  const robotsCache = new Map<string, RobotsRules | null>();
+
+  async function getRobotsRules(pageUrl: string): Promise<RobotsRules | null> {
+    if (!respectRobots) return null;
+    try {
+      const origin = new URL(pageUrl).origin;
+      if (robotsCache.has(origin)) return robotsCache.get(origin)!;
+      const rules = await fetchRobotsTxt(sessionId, origin, context);
+      robotsCache.set(origin, rules);
+      return rules;
+    } catch {
+      return null;
+    }
+  }
+
+  // Check if a URL should be crawled
+  function shouldCrawl(candidateUrl: string): boolean {
+    // Must match scope
+    if (!matchesScope(candidateUrl, scope)) return false;
+
+    // Must pass include/exclude filters
+    if (!passesFilters(candidateUrl, includePatterns, excludePatterns)) return false;
+
+    // Must not already be visited
+    if (tracker.hasVisited(candidateUrl)) return false;
+
+    return true;
+  }
+
+  // Check robots.txt compliance
+  async function isRobotsAllowed(candidateUrl: string): Promise<boolean> {
+    if (!respectRobots) return true;
+    try {
+      const rules = await getRobotsRules(candidateUrl);
+      if (!rules) return true;
+      const parsedUrl = new URL(candidateUrl);
+      return isAllowedByRobots(parsedUrl.pathname, rules);
+    } catch {
+      return true;
+    }
+  }
+
+  try {
+    // Seed the BFS queue with the start URL
+    const normalizedStart = normalizeUrl(url);
+    tracker.enqueue([{ url: normalizedStart, depth: 0 }]);
+
+    const limiter = createLimiter(concurrency);
+
+    // BFS loop
+    while (pages.length < maxPages) {
+      // Check budget
+      if (context && !hasBudget(context, 15_000)) {
+        console.error('[crawl] Deadline approaching, stopping crawl');
+        break;
+      }
+
+      // Collect a batch of URLs to fetch in parallel
+      const batch: Array<{ url: string; depth: number }> = [];
+      const batchSize = Math.min(concurrency, maxPages - pages.length);
+
+      for (let i = 0; i < batchSize; i++) {
+        const next = tracker.dequeue();
+        if (!next) break;
+
+        // Skip if exceeds max depth
+        if (next.depth > maxDepth) continue;
+
+        batch.push(next);
+      }
+
+      if (batch.length === 0) {
+        // Check if there are still items in the queue beyond max_depth
+        const probe = tracker.dequeue();
+        if (!probe) break; // Queue is truly empty
+        // If it's beyond depth, we're done
+        if (probe.depth > maxDepth) break;
+        // Otherwise put it back and try again — shouldn't happen but be safe
+        tracker.enqueue([probe]);
+        break;
+      }
+
+      // Fetch batch in parallel with concurrency limiter
+      const batchResults = await Promise.all(
+        batch.map((item) =>
+          limiter(async () => {
+            // Check robots.txt before fetching
+            const allowed = await isRobotsAllowed(item.url);
+            if (!allowed) {
+              console.error(`[crawl] Blocked by robots.txt: ${item.url}`);
+              return {
+                page: {
+                  url: item.url,
+                  title: '',
+                  content: '',
+                  depth: item.depth,
+                  links_found: 0,
+                  error: 'Blocked by robots.txt',
+                } as CrawledPage,
+                links: [] as string[],
+                depth: item.depth,
+              };
+            }
+
+            // Mark as visited
+            tracker.visit(item.url);
+
+            const result = await fetchPage(sessionId, item.url, item.depth, outputFormat, context);
+
+            // Extract discovered links (stored transiently)
+            const links = ((result as CrawledPage & { _links?: string[] })._links || []);
+            delete (result as CrawledPage & { _links?: string[] })._links;
+
+            // Apply delay between fetches
+            if (delayMs > 0) {
+              await new Promise((r) => setTimeout(r, delayMs));
+            }
+
+            return { page: result, links, depth: item.depth };
+          }),
+        ),
+      );
+
+      // Process results and enqueue discovered links
+      for (const { page, links, depth } of batchResults) {
+        pages.push(page);
+        if (depth > maxDepthReached) maxDepthReached = depth;
+
+        // Enqueue discovered links for next depth level
+        if (depth < maxDepth && !page.error) {
+          const nextDepth = depth + 1;
+          const newUrls: Array<{ url: string; depth: number }> = [];
+
+          for (const link of links) {
+            const normalized = normalizeUrl(link);
+            if (shouldCrawl(normalized)) {
+              newUrls.push({ url: normalized, depth: nextDepth });
+            }
+          }
+
+          if (newUrls.length > 0) {
+            tracker.enqueue(newUrls);
+          }
+        }
+      }
+    }
+
+    const durationMs = Date.now() - startTime;
+    const succeeded = pages.filter((p) => !p.error).length;
+    const failed = pages.filter((p) => p.error).length;
+
+    const summary: CrawlSummary = {
+      total_pages: pages.length,
+      succeeded,
+      failed,
+      max_depth_reached: maxDepthReached,
+      duration_ms: durationMs,
+      scope,
+    };
+
+    const output = { summary, pages };
+
+    // Ensure output fits within limits
+    let outputJson = JSON.stringify(output, null, 2);
+    if (outputJson.length > MAX_OUTPUT_CHARS) {
+      // Truncate page contents progressively to fit
+      const truncatedPages = pages.map((p) => ({
+        ...p,
+        content: p.content.length > 2000
+          ? p.content.slice(0, 2000) + '...[truncated]'
+          : p.content,
+      }));
+      outputJson = JSON.stringify({ summary, pages: truncatedPages }, null, 2);
+
+      // If still too large, remove content entirely
+      if (outputJson.length > MAX_OUTPUT_CHARS) {
+        const minimalPages = pages.map((p) => ({
+          url: p.url,
+          title: p.title,
+          depth: p.depth,
+          links_found: p.links_found,
+          content_length: p.content.length,
+          error: p.error,
+        }));
+        outputJson = JSON.stringify({ summary, pages: minimalPages, note: 'Content omitted due to size constraints' }, null, 2);
+      }
+    }
+
+    return {
+      content: [{ type: 'text', text: outputJson }],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `crawl error: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+};
+
+export function registerCrawlTool(server: MCPServer): void {
+  server.registerTool('crawl', handler, definition);
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -74,6 +74,9 @@ import { registerCheckpointTool } from './checkpoint';
 // Web AI host connection tools (#523)
 import { registerConnectTools } from './connect';
 
+// Crawl tools (#576)
+import { registerCrawlTool } from './crawl';
+
 export function registerAllTools(server: MCPServer): void {
   // Core browser tools
   registerNavigateTool(server);
@@ -151,6 +154,9 @@ export function registerAllTools(server: MCPServer): void {
 
   // Web AI host connection tools (#523)
   registerConnectTools(server);
+
+  // Crawl tools (#576)
+  registerCrawlTool(server);
 
   console.error(`[Tools] Registered ${server.getToolNames().length} tools`);
 }

--- a/src/utils/crawl-utils.ts
+++ b/src/utils/crawl-utils.ts
@@ -1,0 +1,416 @@
+/**
+ * Crawl Utilities - URL normalization, scope matching, link discovery,
+ * robots.txt parsing, and sitemap XML parsing for web crawling tools.
+ *
+ * @see https://github.com/shaun0927/openchrome/issues/576
+ */
+
+// ---------------------------------------------------------------------------
+// URL Normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a URL for deduplication:
+ * - Remove fragment (#...)
+ * - Remove trailing slash (except root path "/")
+ * - Sort query parameters alphabetically
+ * - Lowercase scheme and hostname
+ */
+export function normalizeUrl(raw: string): string {
+  try {
+    const url = new URL(raw);
+
+    // Lowercase scheme and host
+    url.hash = '';
+
+    // Sort query parameters
+    const params = Array.from(url.searchParams.entries());
+    params.sort(([a], [b]) => a.localeCompare(b));
+    url.search = '';
+    for (const [key, value] of params) {
+      url.searchParams.append(key, value);
+    }
+
+    let result = url.toString();
+
+    // Remove trailing slash unless it's just the root
+    if (result.endsWith('/') && url.pathname !== '/') {
+      result = result.slice(0, -1);
+    }
+
+    return result;
+  } catch {
+    return raw;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scope Matching (glob-style URL patterns)
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a URL glob pattern to a RegExp.
+ * Supports `**` (match anything including `/`) and `*` (match anything except `/`).
+ *
+ * Example: `https://docs.example.com/**` matches all pages under that origin.
+ */
+export function urlGlobToRegex(pattern: string): RegExp {
+  // Escape regex special chars except * and ?
+  let escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  // ** matches anything (including slashes)
+  escaped = escaped.replace(/\*\*/g, '___DOUBLESTAR___');
+  // * matches anything except slash
+  escaped = escaped.replace(/\*/g, '[^/]*');
+  escaped = escaped.replace(/___DOUBLESTAR___/g, '.*');
+  // ? matches single char
+  escaped = escaped.replace(/\?/g, '.');
+  return new RegExp(`^${escaped}$`);
+}
+
+/**
+ * Check if a URL matches a scope pattern (glob).
+ */
+export function matchesScope(url: string, scopePattern: string): boolean {
+  const regex = urlGlobToRegex(scopePattern);
+  return regex.test(url);
+}
+
+/**
+ * Check if a URL passes include/exclude filters.
+ * - If includePatterns is provided, URL must match at least one.
+ * - If excludePatterns is provided, URL must not match any.
+ */
+export function passesFilters(
+  url: string,
+  includePatterns?: string[],
+  excludePatterns?: string[],
+): boolean {
+  if (excludePatterns && excludePatterns.length > 0) {
+    for (const pattern of excludePatterns) {
+      if (matchesScope(url, pattern)) return false;
+    }
+  }
+  if (includePatterns && includePatterns.length > 0) {
+    for (const pattern of includePatterns) {
+      if (matchesScope(url, pattern)) return true;
+    }
+    return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Link Discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract all `<a href>` links from HTML content and resolve them
+ * against a base URL. Returns deduplicated absolute URLs.
+ */
+export function discoverLinks(html: string, baseUrl: string): string[] {
+  const seen = new Set<string>();
+  const results: string[] = [];
+
+  // Match href attributes in anchor tags
+  const hrefRegex = /<a\s[^>]*href\s*=\s*["']([^"']+)["'][^>]*>/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = hrefRegex.exec(html)) !== null) {
+    const href = match[1];
+    if (!href) continue;
+
+    // Skip non-http links
+    if (
+      href.startsWith('javascript:') ||
+      href.startsWith('mailto:') ||
+      href.startsWith('tel:') ||
+      href.startsWith('data:') ||
+      href.startsWith('#')
+    ) {
+      continue;
+    }
+
+    try {
+      const resolved = new URL(href, baseUrl).toString();
+      const normalized = normalizeUrl(resolved);
+      if (!seen.has(normalized)) {
+        seen.add(normalized);
+        results.push(normalized);
+      }
+    } catch {
+      // Skip malformed URLs
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Robots.txt Parser
+// ---------------------------------------------------------------------------
+
+export interface RobotsRules {
+  /** Disallowed path prefixes for the matched user-agent */
+  disallow: string[];
+  /** Explicitly allowed path prefixes (override disallow) */
+  allow: string[];
+  /** Sitemap URLs declared in robots.txt */
+  sitemaps: string[];
+  /** Crawl-delay in seconds (if specified) */
+  crawlDelay?: number;
+}
+
+/**
+ * Parse a robots.txt file and extract rules for a given user-agent.
+ * Falls back to `*` rules if no specific match is found.
+ */
+export function parseRobotsTxt(
+  robotsTxt: string,
+  userAgent = '*',
+): RobotsRules {
+  const result: RobotsRules = { disallow: [], allow: [], sitemaps: [] };
+  const lines = robotsTxt.split('\n').map((l) => l.trim());
+
+  let currentAgents: string[] = [];
+  let isRelevant = false;
+  let foundSpecific = false;
+
+  // Collect wildcard rules separately
+  const wildcardRules: RobotsRules = { disallow: [], allow: [], sitemaps: [] };
+
+  for (const line of lines) {
+    // Skip comments and empty lines
+    if (line.startsWith('#') || line === '') {
+      continue;
+    }
+
+    // Extract sitemap directives (global, not agent-specific)
+    const sitemapMatch = line.match(/^sitemap:\s*(.+)$/i);
+    if (sitemapMatch) {
+      result.sitemaps.push(sitemapMatch[1].trim());
+      continue;
+    }
+
+    const uaMatch = line.match(/^user-agent:\s*(.+)$/i);
+    if (uaMatch) {
+      const agent = uaMatch[1].trim().toLowerCase();
+      // If we were in a relevant block and encounter a new UA, stop collecting
+      if (isRelevant && foundSpecific) {
+        break; // Already got specific rules
+      }
+      currentAgents.push(agent);
+      if (agent === userAgent.toLowerCase()) {
+        isRelevant = true;
+        foundSpecific = true;
+      } else if (agent === '*') {
+        isRelevant = true;
+      } else {
+        isRelevant = false;
+      }
+      continue;
+    }
+
+    // Reset agent list on non-UA directives
+    if (currentAgents.length > 0 && !uaMatch) {
+      const target =
+        foundSpecific && currentAgents.includes(userAgent.toLowerCase())
+          ? result
+          : currentAgents.includes('*')
+            ? wildcardRules
+            : null;
+
+      if (target && isRelevant) {
+        const disallowMatch = line.match(/^disallow:\s*(.*)$/i);
+        if (disallowMatch) {
+          const path = disallowMatch[1].trim();
+          if (path) target.disallow.push(path);
+        }
+
+        const allowMatch = line.match(/^allow:\s*(.*)$/i);
+        if (allowMatch) {
+          const path = allowMatch[1].trim();
+          if (path) target.allow.push(path);
+        }
+
+        const delayMatch = line.match(/^crawl-delay:\s*(\d+\.?\d*)$/i);
+        if (delayMatch) {
+          target.crawlDelay = parseFloat(delayMatch[1]);
+        }
+      }
+    }
+  }
+
+  // If no specific rules found, use wildcard rules
+  if (!foundSpecific) {
+    result.disallow = wildcardRules.disallow;
+    result.allow = wildcardRules.allow;
+    if (wildcardRules.crawlDelay !== undefined) {
+      result.crawlDelay = wildcardRules.crawlDelay;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Check if a URL path is allowed by robots.txt rules.
+ * Allow rules take precedence over disallow rules (per spec).
+ */
+export function isAllowedByRobots(
+  urlPath: string,
+  rules: RobotsRules,
+): boolean {
+  // Check allow rules first (more specific wins)
+  for (const allowPath of rules.allow) {
+    if (urlPath.startsWith(allowPath)) return true;
+  }
+  for (const disallowPath of rules.disallow) {
+    if (urlPath.startsWith(disallowPath)) return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Sitemap XML Parser
+// ---------------------------------------------------------------------------
+
+export interface SitemapUrl {
+  loc: string;
+  lastmod?: string;
+  changefreq?: string;
+  priority?: number;
+}
+
+export interface SitemapParseResult {
+  /** URLs found in a regular sitemap */
+  urls: SitemapUrl[];
+  /** Child sitemap URLs found in a sitemap index */
+  sitemapIndexUrls: string[];
+  /** Whether this was a sitemap index file */
+  isSitemapIndex: boolean;
+}
+
+/**
+ * Parse a sitemap XML string. Supports both regular sitemaps and sitemap index files.
+ * Uses regex parsing to avoid XML library dependencies.
+ */
+export function parseSitemapXml(xml: string): SitemapParseResult {
+  const result: SitemapParseResult = {
+    urls: [],
+    sitemapIndexUrls: [],
+    isSitemapIndex: false,
+  };
+
+  // Check if this is a sitemap index
+  if (xml.includes('<sitemapindex') || xml.includes(':sitemapindex')) {
+    result.isSitemapIndex = true;
+
+    // Extract sitemap locations from index
+    const sitemapRegex = /<sitemap[^>]*>([\s\S]*?)<\/sitemap>/gi;
+    let sitemapMatch: RegExpExecArray | null;
+
+    while ((sitemapMatch = sitemapRegex.exec(xml)) !== null) {
+      const block = sitemapMatch[1];
+      const locMatch = block.match(/<loc[^>]*>\s*([\s\S]*?)\s*<\/loc>/i);
+      if (locMatch) {
+        result.sitemapIndexUrls.push(locMatch[1].trim());
+      }
+    }
+  } else {
+    // Regular sitemap — extract URLs
+    const urlRegex = /<url[^>]*>([\s\S]*?)<\/url>/gi;
+    let urlMatch: RegExpExecArray | null;
+
+    while ((urlMatch = urlRegex.exec(xml)) !== null) {
+      const block = urlMatch[1];
+      const locMatch = block.match(/<loc[^>]*>\s*([\s\S]*?)\s*<\/loc>/i);
+      if (!locMatch) continue;
+
+      const entry: SitemapUrl = { loc: locMatch[1].trim() };
+
+      const lastmodMatch = block.match(
+        /<lastmod[^>]*>\s*([\s\S]*?)\s*<\/lastmod>/i,
+      );
+      if (lastmodMatch) entry.lastmod = lastmodMatch[1].trim();
+
+      const changefreqMatch = block.match(
+        /<changefreq[^>]*>\s*([\s\S]*?)\s*<\/changefreq>/i,
+      );
+      if (changefreqMatch) entry.changefreq = changefreqMatch[1].trim();
+
+      const priorityMatch = block.match(
+        /<priority[^>]*>\s*([\s\S]*?)\s*<\/priority>/i,
+      );
+      if (priorityMatch) {
+        const p = parseFloat(priorityMatch[1].trim());
+        if (!isNaN(p)) entry.priority = p;
+      }
+
+      result.urls.push(entry);
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Crawl State Tracker
+// ---------------------------------------------------------------------------
+
+/**
+ * Tracks visited URLs during a crawl to prevent duplicates.
+ * Uses a Set with normalized URLs for O(1) lookup.
+ */
+export class CrawlTracker {
+  private visited = new Set<string>();
+  private pending: Array<{ url: string; depth: number }> = [];
+
+  /** Mark a URL as visited. Returns false if already visited. */
+  visit(url: string): boolean {
+    const normalized = normalizeUrl(url);
+    if (this.visited.has(normalized)) return false;
+    this.visited.add(normalized);
+    return true;
+  }
+
+  /** Check if URL has been visited. */
+  hasVisited(url: string): boolean {
+    return this.visited.has(normalizeUrl(url));
+  }
+
+  /** Add URLs to the pending queue if not already visited. */
+  enqueue(urls: Array<{ url: string; depth: number }>): void {
+    for (const entry of urls) {
+      const normalized = normalizeUrl(entry.url);
+      if (!this.visited.has(normalized)) {
+        this.pending.push({ url: normalized, depth: entry.depth });
+      }
+    }
+  }
+
+  /** Get the next unvisited URL from the queue. Returns undefined if empty. */
+  dequeue(): { url: string; depth: number } | undefined {
+    while (this.pending.length > 0) {
+      const next = this.pending.shift()!;
+      if (!this.visited.has(next.url)) {
+        return next;
+      }
+    }
+    return undefined;
+  }
+
+  /** Number of URLs visited so far. */
+  get visitedCount(): number {
+    return this.visited.size;
+  }
+
+  /** Number of URLs still pending. */
+  get pendingCount(): number {
+    return this.pending.length;
+  }
+
+  /** Get all visited URLs. */
+  getVisitedUrls(): string[] {
+    return Array.from(this.visited);
+  }
+}

--- a/tests/cross-env/cursor-verification.test.ts
+++ b/tests/cross-env/cursor-verification.test.ts
@@ -233,8 +233,8 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
         expect(toolNames).toContain(tool);
       }
 
-      // Total should be 54 (30 T1 + 15 T2 + 9 T3)
-      expect(toolNames.length).toBe(54);
+      // Total should be 55 (30 T1 + 16 T2 + 9 T3)
+      expect(toolNames.length).toBe(55);
     });
 
     test('resources/list returns usage guide resource', async () => {
@@ -289,7 +289,7 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
       'request_intercept', 'http_auth', 'user_agent', 'geolocation',
       'emulate_device', 'page_pdf', 'page_screenshot', 'page_content',
       'console_capture', 'performance_metrics', 'file_upload',
-      'batch_execute', 'batch_paginate',
+      'batch_execute', 'batch_paginate', 'crawl',
     ];
     tier2Tools.forEach(tool => {
       test(`Tier 2: ${tool} registered`, () => {
@@ -412,8 +412,8 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
 
       // Should NOT have expand_tools (progressive disclosure disabled)
       expect(toolNames).not.toContain('expand_tools');
-      // Total should be 54 (30 T1 + 15 T2 + 9 T3)
-      expect(toolNames.length).toBe(54);
+      // Total should be 55 (30 T1 + 16 T2 + 9 T3)
+      expect(toolNames.length).toBe(55);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add `crawl` MCP tool (`src/tools/crawl.ts`) for BFS-based recursive web crawling with configurable depth, page limits, scope matching (URL globs), and robots.txt compliance
- Register the tool in `src/tools/index.ts` and assign it to Tier 2 (specialist) in `src/config/tool-tiers.ts`
- Features: concurrency limiter, budget-aware execution, include/exclude URL patterns, multiple output formats (markdown/text/structured), and progressive output truncation for large crawls

Depends on PR1: feat/576-crawl-utils (commit 0e40f0f) which provides `CrawlTracker`, URL normalization, scope matching, robots.txt parser, and link discovery utilities.

## Test plan
- [ ] Verify `npm run build` passes (confirmed locally)
- [ ] Manual test: crawl a single page with `max_depth: 0`
- [ ] Manual test: crawl a multi-page site with `max_depth: 2, max_pages: 5`
- [ ] Verify robots.txt compliance blocks disallowed paths
- [ ] Verify scope matching limits crawl to same origin by default
- [ ] Verify budget-aware execution stops before deadline
- [ ] Verify output truncation when content exceeds MAX_OUTPUT_CHARS
- [ ] Unit tests will be added in PR4

🤖 Generated with [Claude Code](https://claude.com/claude-code)