### PR TITLE
feat: add crawl_sitemap tool for sitemap-based crawling (#576)

### DIFF
--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -57,6 +57,7 @@ export const TOOL_TIERS: Record<string, ToolTier> = {
   batch_execute: 2,
   batch_paginate: 2,
   crawl: 2,
+  crawl_sitemap: 2,
 
   // Session recording tools (#572) — opt-in, not needed for every session
   oc_recording_start: 2,

--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -56,6 +56,7 @@ export const TOOL_TIERS: Record<string, ToolTier> = {
   file_upload: 2,
   batch_execute: 2,
   batch_paginate: 2,
+  crawl: 2,
 
   // Session recording tools (#572) — opt-in, not needed for every session
   oc_recording_start: 2,

--- a/src/tools/crawl-sitemap.ts
+++ b/src/tools/crawl-sitemap.ts
@@ -118,15 +118,16 @@ async function fetchRawText(
     const { targetId: tid, page } = await sessionManager.createTarget(sessionId, url);
     targetId = tid;
 
-    await withTimeout(
-      page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
-      15000,
-      'crawl_sitemap.fetchRawText.waitForNavigation',
-      context,
-    );
-
     const bodyText = await withTimeout(
-      page.evaluate(() => document.body?.innerText || ''),
+      page.evaluate(() => {
+        // For XML documents (sitemaps), Chrome XSLT-renders the content.
+        // Use XMLSerializer to get the raw XML source.
+        if (document.contentType && document.contentType.includes('xml')) {
+          return new XMLSerializer().serializeToString(document);
+        }
+        // For HTML documents (robots.txt served as HTML, error pages), use innerText
+        return document.body?.innerText || '';
+      }),
       5000,
       'crawl_sitemap.fetchRawText.evaluate',
       context,
@@ -272,13 +273,6 @@ async function fetchPage(
     const { targetId: tid, page } = await sessionManager.createTarget(sessionId, url);
     targetId = tid;
 
-    await withTimeout(
-      page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
-      15000,
-      'crawl_sitemap.page.waitForNavigation',
-      context,
-    );
-
     // Small settle delay for dynamic content
     await new Promise((r) => setTimeout(r, 500));
 
@@ -299,18 +293,19 @@ async function fetchPage(
         // Extract content based on format
         let content = '';
         if (format === 'markdown') {
-          const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT);
+          const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, {
+            acceptNode(n: Node) {
+              const t = (n as HTMLElement).tagName?.toLowerCase();
+              if (t === 'script' || t === 'style' || t === 'noscript') return NodeFilter.FILTER_REJECT;
+              return NodeFilter.FILTER_ACCEPT;
+            },
+          });
           const parts: string[] = [];
           let node: Node | null = walker.currentNode;
 
           while (node) {
             const el = node as HTMLElement;
             const tag = el.tagName?.toLowerCase();
-
-            if (tag === 'script' || tag === 'style' || tag === 'noscript') {
-              node = walker.nextSibling() || walker.parentNode();
-              continue;
-            }
 
             if (tag === 'h1') parts.push(`\n# ${el.textContent?.trim()}\n`);
             else if (tag === 'h2') parts.push(`\n## ${el.textContent?.trim()}\n`);

--- a/src/tools/crawl-sitemap.ts
+++ b/src/tools/crawl-sitemap.ts
@@ -1,0 +1,611 @@
+/**
+ * Crawl Sitemap Tool - Sitemap-based web crawling via sitemap.xml discovery
+ *
+ * Discovers sitemaps from robots.txt or well-known locations, parses sitemap XML,
+ * and crawls listed pages. Supports sitemap index files with recursive resolution.
+ *
+ * @see https://github.com/shaun0927/openchrome/issues/576
+ */
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
+import { getSessionManager } from '../session-manager';
+import { MAX_OUTPUT_CHARS } from '../config/defaults';
+import { withTimeout } from '../utils/with-timeout';
+import {
+  normalizeUrl,
+  parseSitemapXml,
+  parseRobotsTxt,
+  CrawlTracker,
+  urlGlobToRegex,
+} from '../utils/crawl-utils';
+
+const definition: MCPToolDefinition = {
+  name: 'crawl_sitemap',
+  description:
+    'Crawl a website using its sitemap.xml. Auto-discovers sitemaps from robots.txt or well-known URLs (/sitemap.xml, /sitemap_index.xml). Supports sitemap index files and URL filtering.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      url: {
+        type: 'string',
+        description: 'Website URL (auto-discovers /sitemap.xml, /sitemap_index.xml)',
+      },
+      sitemap_url: {
+        type: 'string',
+        description: 'Explicit sitemap URL (skips auto-discovery)',
+      },
+      filter: {
+        type: 'string',
+        description: 'URL glob pattern to filter which sitemap URLs to visit',
+      },
+      max_pages: {
+        type: 'number',
+        description: 'Maximum number of pages to visit. Default: 50',
+      },
+      output_format: {
+        type: 'string',
+        enum: ['markdown', 'text', 'structured'],
+        description: 'Content format per page. Default: markdown',
+      },
+      concurrency: {
+        type: 'number',
+        description: 'Max concurrent page fetches. Default: 3',
+      },
+    },
+    required: ['url'],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Concurrency limiter (same pattern as crawl.ts / batch-paginate.ts)
+// ---------------------------------------------------------------------------
+
+function createLimiter(concurrency: number) {
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  return async function <T>(fn: () => Promise<T>): Promise<T> {
+    if (active >= concurrency) {
+      await new Promise<void>((resolve) => queue.push(resolve));
+    }
+    active++;
+    try {
+      return await fn();
+    } finally {
+      active--;
+      if (queue.length > 0) {
+        const next = queue.shift()!;
+        next();
+      }
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CrawledPage {
+  url: string;
+  title: string;
+  content: string;
+  links_found: number;
+  error?: string;
+}
+
+interface CrawlSitemapSummary {
+  total_pages: number;
+  succeeded: number;
+  failed: number;
+  duration_ms: number;
+  sitemap_source: string;
+}
+
+// ---------------------------------------------------------------------------
+// Fetch raw text from a URL via browser target
+// ---------------------------------------------------------------------------
+
+async function fetchRawText(
+  sessionId: string,
+  url: string,
+  context?: ToolContext,
+): Promise<string | null> {
+  const sessionManager = getSessionManager();
+  let targetId: string | null = null;
+
+  try {
+    const { targetId: tid, page } = await sessionManager.createTarget(sessionId, url);
+    targetId = tid;
+
+    await withTimeout(
+      page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
+      15000,
+      'crawl_sitemap.fetchRawText.waitForNavigation',
+      context,
+    );
+
+    const bodyText = await withTimeout(
+      page.evaluate(() => document.body?.innerText || ''),
+      5000,
+      'crawl_sitemap.fetchRawText.evaluate',
+      context,
+    );
+
+    await sessionManager.closeTarget(sessionId, tid);
+    targetId = null;
+
+    return bodyText || null;
+  } catch (err) {
+    console.error(
+      `[crawl_sitemap] Failed to fetch ${url}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    if (targetId) {
+      try {
+        await sessionManager.closeTarget(sessionId, targetId);
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sitemap discovery: robots.txt -> /sitemap.xml -> /sitemap_index.xml
+// ---------------------------------------------------------------------------
+
+async function discoverSitemapUrls(
+  sessionId: string,
+  origin: string,
+  context?: ToolContext,
+): Promise<{ urls: string[]; source: string }> {
+  // Step 1: Try robots.txt
+  const robotsText = await fetchRawText(sessionId, `${origin}/robots.txt`, context);
+  if (robotsText && (robotsText.toLowerCase().includes('user-agent') || robotsText.toLowerCase().includes('sitemap'))) {
+    const rules = parseRobotsTxt(robotsText);
+    if (rules.sitemaps.length > 0) {
+      console.error(`[crawl_sitemap] Found ${rules.sitemaps.length} sitemap(s) in robots.txt`);
+      return { urls: rules.sitemaps, source: `${origin}/robots.txt` };
+    }
+  }
+
+  // Step 2: Try /sitemap.xml
+  const sitemapXml = await fetchRawText(sessionId, `${origin}/sitemap.xml`, context);
+  if (sitemapXml && (sitemapXml.includes('<urlset') || sitemapXml.includes('<sitemapindex'))) {
+    console.error(`[crawl_sitemap] Found sitemap at ${origin}/sitemap.xml`);
+    return { urls: [`${origin}/sitemap.xml`], source: `${origin}/sitemap.xml` };
+  }
+
+  // Step 3: Try /sitemap_index.xml
+  const indexXml = await fetchRawText(sessionId, `${origin}/sitemap_index.xml`, context);
+  if (indexXml && (indexXml.includes('<urlset') || indexXml.includes('<sitemapindex'))) {
+    console.error(`[crawl_sitemap] Found sitemap at ${origin}/sitemap_index.xml`);
+    return { urls: [`${origin}/sitemap_index.xml`], source: `${origin}/sitemap_index.xml` };
+  }
+
+  return { urls: [], source: 'none' };
+}
+
+// ---------------------------------------------------------------------------
+// Resolve sitemap URLs (handles sitemap index recursion up to 2 levels)
+// ---------------------------------------------------------------------------
+
+async function resolveSitemapPageUrls(
+  sessionId: string,
+  sitemapUrls: string[],
+  filterPattern: string | undefined,
+  maxPages: number,
+  context?: ToolContext,
+  depth = 0,
+): Promise<string[]> {
+  const pageUrls: string[] = [];
+  const filterRegex = filterPattern ? urlGlobToRegex(filterPattern) : null;
+
+  for (const sitemapUrl of sitemapUrls) {
+    if (pageUrls.length >= maxPages) break;
+
+    // Check budget before fetching each sitemap
+    if (context && !hasBudget(context, 10_000)) {
+      console.error('[crawl_sitemap] Budget limit approaching, stopping sitemap resolution');
+      break;
+    }
+
+    const xml = await fetchRawText(sessionId, sitemapUrl, context);
+    if (!xml) {
+      console.error(`[crawl_sitemap] Could not fetch sitemap: ${sitemapUrl}`);
+      continue;
+    }
+
+    const parsed = parseSitemapXml(xml);
+
+    if (parsed.isSitemapIndex) {
+      // Recurse into child sitemaps (up to 2 levels deep)
+      if (depth < 2) {
+        console.error(
+          `[crawl_sitemap] Sitemap index with ${parsed.sitemapIndexUrls.length} child sitemaps (depth=${depth})`,
+        );
+        const childUrls = await resolveSitemapPageUrls(
+          sessionId,
+          parsed.sitemapIndexUrls,
+          filterPattern,
+          maxPages - pageUrls.length,
+          context,
+          depth + 1,
+        );
+        pageUrls.push(...childUrls);
+      } else {
+        console.error(`[crawl_sitemap] Max sitemap index depth reached, skipping: ${sitemapUrl}`);
+      }
+    } else {
+      // Regular sitemap — collect page URLs
+      for (const entry of parsed.urls) {
+        if (pageUrls.length >= maxPages) break;
+
+        const normalized = normalizeUrl(entry.loc);
+
+        // Apply filter if provided
+        if (filterRegex && !filterRegex.test(normalized)) continue;
+
+        pageUrls.push(normalized);
+      }
+    }
+  }
+
+  return pageUrls;
+}
+
+// ---------------------------------------------------------------------------
+// Single page fetch (same pattern as crawl.ts)
+// ---------------------------------------------------------------------------
+
+async function fetchPage(
+  sessionId: string,
+  url: string,
+  outputFormat: string,
+  context?: ToolContext,
+): Promise<CrawledPage> {
+  const sessionManager = getSessionManager();
+  let targetId: string | null = null;
+
+  try {
+    const { targetId: tid, page } = await sessionManager.createTarget(sessionId, url);
+    targetId = tid;
+
+    await withTimeout(
+      page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
+      15000,
+      'crawl_sitemap.page.waitForNavigation',
+      context,
+    );
+
+    // Small settle delay for dynamic content
+    await new Promise((r) => setTimeout(r, 500));
+
+    const result = await withTimeout(
+      page.evaluate((format: string) => {
+        const title = document.title || '';
+
+        // Collect links
+        const links: string[] = [];
+        const anchors = document.querySelectorAll('a[href]');
+        anchors.forEach((a) => {
+          const href = (a as HTMLAnchorElement).href;
+          if (href && !href.startsWith('javascript:') && !href.startsWith('mailto:') && !href.startsWith('tel:')) {
+            links.push(href);
+          }
+        });
+
+        // Extract content based on format
+        let content = '';
+        if (format === 'markdown') {
+          const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT);
+          const parts: string[] = [];
+          let node: Node | null = walker.currentNode;
+
+          while (node) {
+            const el = node as HTMLElement;
+            const tag = el.tagName?.toLowerCase();
+
+            if (tag === 'script' || tag === 'style' || tag === 'noscript') {
+              node = walker.nextSibling() || walker.parentNode();
+              continue;
+            }
+
+            if (tag === 'h1') parts.push(`\n# ${el.textContent?.trim()}\n`);
+            else if (tag === 'h2') parts.push(`\n## ${el.textContent?.trim()}\n`);
+            else if (tag === 'h3') parts.push(`\n### ${el.textContent?.trim()}\n`);
+            else if (tag === 'h4') parts.push(`\n#### ${el.textContent?.trim()}\n`);
+            else if (tag === 'h5') parts.push(`\n##### ${el.textContent?.trim()}\n`);
+            else if (tag === 'h6') parts.push(`\n###### ${el.textContent?.trim()}\n`);
+            else if (tag === 'p') {
+              const text = el.textContent?.trim();
+              if (text) parts.push(`\n${text}\n`);
+            }
+            else if (tag === 'li') {
+              const text = el.textContent?.trim();
+              if (text) parts.push(`- ${text}`);
+            }
+            else if (tag === 'pre' || tag === 'code') {
+              const text = el.textContent?.trim();
+              if (text && tag === 'pre') parts.push(`\n\`\`\`\n${text}\n\`\`\`\n`);
+            }
+            else if (tag === 'blockquote') {
+              const text = el.textContent?.trim();
+              if (text) parts.push(`\n> ${text}\n`);
+            }
+
+            node = walker.nextNode();
+          }
+
+          content = parts.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+
+          if (!content) {
+            content = document.body.innerText || '';
+          }
+        } else if (format === 'text') {
+          content = document.body.innerText || '';
+        } else {
+          content = document.body.innerHTML || '';
+        }
+
+        return { title, content, linksCount: links.length };
+      }, outputFormat),
+      15000,
+      'crawl_sitemap.page.evaluate',
+      context,
+    );
+
+    await sessionManager.closeTarget(sessionId, tid);
+    targetId = null;
+
+    // Truncate content if too large
+    let content = result.content;
+    if (content.length > MAX_OUTPUT_CHARS) {
+      content = content.slice(0, MAX_OUTPUT_CHARS) + '...[truncated]';
+    }
+
+    return {
+      url,
+      title: result.title,
+      content,
+      links_found: result.linksCount,
+    };
+  } catch (err) {
+    if (targetId) {
+      try {
+        await sessionManager.closeTarget(sessionId, targetId);
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+    return {
+      url,
+      title: '',
+      content: '',
+      links_found: 0,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+const handler: ToolHandler = async (
+  sessionId: string,
+  args: Record<string, unknown>,
+  context?: ToolContext,
+): Promise<MCPResult> => {
+  const url = args.url as string;
+  if (!url) {
+    return {
+      content: [{ type: 'text', text: 'Error: url is required' }],
+      isError: true,
+    };
+  }
+
+  // Validate URL
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return {
+      content: [{ type: 'text', text: `Error: Invalid URL "${url}"` }],
+      isError: true,
+    };
+  }
+
+  const sitemapUrlArg = args.sitemap_url as string | undefined;
+  const filterPattern = args.filter as string | undefined;
+  const maxPages = args.max_pages != null ? Number(args.max_pages) : 50;
+  const outputFormat = (args.output_format as string) || 'markdown';
+  const concurrency = args.concurrency != null ? Math.max(1, Math.min(10, Number(args.concurrency))) : 3;
+
+  const startTime = Date.now();
+  const tracker = new CrawlTracker();
+  const pages: CrawledPage[] = [];
+  let sitemapSource = '';
+
+  try {
+    // -----------------------------------------------------------------------
+    // Step 1: Discover or use provided sitemap URL(s)
+    // -----------------------------------------------------------------------
+    let sitemapUrls: string[];
+
+    if (sitemapUrlArg) {
+      // Explicit sitemap URL provided
+      sitemapUrls = [sitemapUrlArg];
+      sitemapSource = sitemapUrlArg;
+      console.error(`[crawl_sitemap] Using explicit sitemap: ${sitemapUrlArg}`);
+    } else {
+      // Auto-discover from robots.txt -> /sitemap.xml -> /sitemap_index.xml
+      const origin = parsedUrl.origin;
+      const discovery = await discoverSitemapUrls(sessionId, origin, context);
+      sitemapUrls = discovery.urls;
+      sitemapSource = discovery.source;
+
+      if (sitemapUrls.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  error: 'No sitemap found',
+                  tried: [
+                    `${origin}/robots.txt`,
+                    `${origin}/sitemap.xml`,
+                    `${origin}/sitemap_index.xml`,
+                  ],
+                  suggestion:
+                    'Provide an explicit sitemap_url parameter or use the crawl tool for BFS-based crawling.',
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 2: Resolve all page URLs from sitemap(s)
+    // -----------------------------------------------------------------------
+    const pageUrls = await resolveSitemapPageUrls(
+      sessionId,
+      sitemapUrls,
+      filterPattern,
+      maxPages,
+      context,
+    );
+
+    if (pageUrls.length === 0) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                error: 'Sitemap found but no matching URLs',
+                sitemap_source: sitemapSource,
+                filter: filterPattern || 'none',
+                suggestion: 'Check the filter pattern or try without a filter.',
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    console.error(`[crawl_sitemap] Resolved ${pageUrls.length} page URLs from sitemap`);
+
+    // -----------------------------------------------------------------------
+    // Step 3: Crawl pages with concurrency limiter
+    // -----------------------------------------------------------------------
+    const limiter = createLimiter(concurrency);
+    const urlsToVisit = pageUrls.slice(0, maxPages);
+
+    // Process in batches to allow budget checking between batches
+    const batchSize = concurrency;
+    for (let i = 0; i < urlsToVisit.length; i += batchSize) {
+      // Check budget before each batch
+      if (context && !hasBudget(context, 15_000)) {
+        console.error('[crawl_sitemap] Deadline approaching, stopping page crawl');
+        break;
+      }
+
+      const batch = urlsToVisit.slice(i, i + batchSize);
+      const batchResults = await Promise.all(
+        batch.map((pageUrl) =>
+          limiter(async () => {
+            // Skip already visited URLs (deduplication)
+            if (tracker.hasVisited(pageUrl)) {
+              return null;
+            }
+            tracker.visit(pageUrl);
+
+            return fetchPage(sessionId, pageUrl, outputFormat, context);
+          }),
+        ),
+      );
+
+      for (const result of batchResults) {
+        if (result) {
+          pages.push(result);
+        }
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 4: Build output
+    // -----------------------------------------------------------------------
+    const durationMs = Date.now() - startTime;
+    const succeeded = pages.filter((p) => !p.error).length;
+    const failed = pages.filter((p) => p.error).length;
+
+    const summary: CrawlSitemapSummary = {
+      total_pages: pages.length,
+      succeeded,
+      failed,
+      duration_ms: durationMs,
+      sitemap_source: sitemapSource,
+    };
+
+    const output = { summary, pages };
+
+    // Ensure output fits within limits
+    let outputJson = JSON.stringify(output, null, 2);
+    if (outputJson.length > MAX_OUTPUT_CHARS) {
+      // Truncate page contents progressively to fit
+      const truncatedPages = pages.map((p) => ({
+        ...p,
+        content:
+          p.content.length > 2000
+            ? p.content.slice(0, 2000) + '...[truncated]'
+            : p.content,
+      }));
+      outputJson = JSON.stringify({ summary, pages: truncatedPages }, null, 2);
+
+      // If still too large, remove content entirely
+      if (outputJson.length > MAX_OUTPUT_CHARS) {
+        const minimalPages = pages.map((p) => ({
+          url: p.url,
+          title: p.title,
+          links_found: p.links_found,
+          content_length: p.content.length,
+          error: p.error,
+        }));
+        outputJson = JSON.stringify(
+          { summary, pages: minimalPages, note: 'Content omitted due to size constraints' },
+          null,
+          2,
+        );
+      }
+    }
+
+    return {
+      content: [{ type: 'text', text: outputJson }],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `crawl_sitemap error: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+};
+
+export function registerCrawlSitemapTool(server: MCPServer): void {
+  server.registerTool('crawl_sitemap', handler, definition);
+}

--- a/src/tools/crawl-sitemap.ts
+++ b/src/tools/crawl-sitemap.ts
@@ -411,6 +411,12 @@ const handler: ToolHandler = async (
       isError: true,
     };
   }
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    return {
+      content: [{ type: 'text', text: 'Error: url must use http or https scheme' }],
+      isError: true,
+    };
+  }
 
   const sitemapUrlArg = args.sitemap_url as string | undefined;
   const filterPattern = args.filter as string | undefined;
@@ -430,6 +436,15 @@ const handler: ToolHandler = async (
     let sitemapUrls: string[];
 
     if (sitemapUrlArg) {
+      // Validate sitemap URL scheme
+      try {
+        const sp = new URL(sitemapUrlArg);
+        if (sp.protocol !== 'http:' && sp.protocol !== 'https:') {
+          return { content: [{ type: 'text', text: 'Error: sitemap_url must use http or https scheme' }], isError: true };
+        }
+      } catch {
+        return { content: [{ type: 'text', text: `Error: Invalid sitemap_url "${sitemapUrlArg}"` }], isError: true };
+      }
       // Explicit sitemap URL provided
       sitemapUrls = [sitemapUrlArg];
       sitemapSource = sitemapUrlArg;

--- a/src/tools/crawl.ts
+++ b/src/tools/crawl.ts
@@ -1,0 +1,579 @@
+/**
+ * Crawl Tool - Recursive web crawling via BFS traversal
+ *
+ * Opens pages in new tabs, extracts content and links, respects robots.txt
+ * and scope constraints. Uses CrawlTracker from crawl-utils for deduplication.
+ *
+ * @see https://github.com/shaun0927/openchrome/issues/576
+ */
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
+import { getSessionManager } from '../session-manager';
+import { MAX_OUTPUT_CHARS } from '../config/defaults';
+import { withTimeout } from '../utils/with-timeout';
+import {
+  normalizeUrl,
+  matchesScope,
+  passesFilters,
+  parseRobotsTxt,
+  isAllowedByRobots,
+  CrawlTracker,
+  RobotsRules,
+} from '../utils/crawl-utils';
+
+const definition: MCPToolDefinition = {
+  name: 'crawl',
+  description:
+    'Recursively crawl a website via BFS. Opens each page in a new tab, extracts text content and discovers links, then follows them up to max_depth. Respects robots.txt and scope constraints.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      url: {
+        type: 'string',
+        description: 'Starting URL to crawl',
+      },
+      max_depth: {
+        type: 'number',
+        description: 'Maximum link-follow depth (0 = start page only). Default: 2',
+      },
+      max_pages: {
+        type: 'number',
+        description: 'Maximum number of pages to crawl. Default: 20',
+      },
+      scope: {
+        type: 'string',
+        description:
+          'URL glob pattern limiting which URLs to follow (e.g. "https://docs.example.com/**"). Default: same origin as start URL.',
+      },
+      include_patterns: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'URL glob patterns — only follow links matching at least one',
+      },
+      exclude_patterns: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'URL glob patterns — skip links matching any of these',
+      },
+      output_format: {
+        type: 'string',
+        enum: ['markdown', 'text', 'structured'],
+        description: 'Content format per page. Default: markdown',
+      },
+      respect_robots: {
+        type: 'boolean',
+        description: 'Whether to fetch and obey robots.txt. Default: true',
+      },
+      delay_ms: {
+        type: 'number',
+        description: 'Delay between page fetches in milliseconds. Default: 1000',
+      },
+      concurrency: {
+        type: 'number',
+        description: 'Max parallel tab fetches. Default: 3',
+      },
+    },
+    required: ['url'],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Concurrency limiter (same pattern as batch-paginate.ts)
+// ---------------------------------------------------------------------------
+
+function createLimiter(concurrency: number) {
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  return async function <T>(fn: () => Promise<T>): Promise<T> {
+    if (active >= concurrency) {
+      await new Promise<void>((resolve) => queue.push(resolve));
+    }
+    active++;
+    try {
+      return await fn();
+    } finally {
+      active--;
+      if (queue.length > 0) {
+        const next = queue.shift()!;
+        next();
+      }
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CrawledPage {
+  url: string;
+  title: string;
+  content: string;
+  depth: number;
+  links_found: number;
+  error?: string;
+}
+
+interface CrawlSummary {
+  total_pages: number;
+  succeeded: number;
+  failed: number;
+  max_depth_reached: number;
+  duration_ms: number;
+  scope: string;
+}
+
+// ---------------------------------------------------------------------------
+// Robots.txt cache (per-origin, within a single crawl invocation)
+// ---------------------------------------------------------------------------
+
+async function fetchRobotsTxt(
+  sessionId: string,
+  origin: string,
+  context?: ToolContext,
+): Promise<RobotsRules | null> {
+  const sessionManager = getSessionManager();
+  const robotsUrl = `${origin}/robots.txt`;
+  let targetId: string | null = null;
+
+  try {
+    const { targetId: tid, page } = await sessionManager.createTarget(sessionId, robotsUrl);
+    targetId = tid;
+
+    // Wait for page load with a short timeout
+    await withTimeout(
+      page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
+      10000,
+      'crawl.robots.waitForNavigation',
+      context,
+    );
+
+    const bodyText = await withTimeout(
+      page.evaluate(() => document.body?.innerText || ''),
+      5000,
+      'crawl.robots.evaluate',
+      context,
+    );
+
+    await sessionManager.closeTarget(sessionId, tid);
+    targetId = null;
+
+    // If the response looks like robots.txt (has User-agent or Disallow), parse it
+    if (bodyText && (bodyText.toLowerCase().includes('user-agent') || bodyText.toLowerCase().includes('disallow'))) {
+      return parseRobotsTxt(bodyText);
+    }
+
+    return null;
+  } catch (err) {
+    console.error(`[crawl] Failed to fetch robots.txt from ${origin}: ${err instanceof Error ? err.message : String(err)}`);
+    if (targetId) {
+      try {
+        await sessionManager.closeTarget(sessionId, targetId);
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Single page fetch
+// ---------------------------------------------------------------------------
+
+async function fetchPage(
+  sessionId: string,
+  url: string,
+  depth: number,
+  outputFormat: string,
+  context?: ToolContext,
+): Promise<CrawledPage> {
+  const sessionManager = getSessionManager();
+  let targetId: string | null = null;
+
+  try {
+    const { targetId: tid, page } = await sessionManager.createTarget(sessionId, url);
+    targetId = tid;
+
+    // Wait for the page to be mostly loaded
+    await withTimeout(
+      page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
+      15000,
+      'crawl.page.waitForNavigation',
+      context,
+    );
+
+    // Small settle delay for dynamic content
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Extract content and links in one page.evaluate call
+    const result = await withTimeout(
+      page.evaluate((format: string) => {
+        const title = document.title || '';
+
+        // Collect links
+        const links: string[] = [];
+        const anchors = document.querySelectorAll('a[href]');
+        anchors.forEach((a) => {
+          const href = (a as HTMLAnchorElement).href;
+          if (href && !href.startsWith('javascript:') && !href.startsWith('mailto:') && !href.startsWith('tel:')) {
+            links.push(href);
+          }
+        });
+
+        // Extract content based on format
+        let content = '';
+        if (format === 'markdown') {
+          // Build a markdown-like representation
+          const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT);
+          const parts: string[] = [];
+          let node: Node | null = walker.currentNode;
+
+          while (node) {
+            const el = node as HTMLElement;
+            const tag = el.tagName?.toLowerCase();
+
+            if (tag === 'script' || tag === 'style' || tag === 'noscript') {
+              node = walker.nextSibling() || walker.parentNode();
+              continue;
+            }
+
+            if (tag === 'h1') parts.push(`\n# ${el.textContent?.trim()}\n`);
+            else if (tag === 'h2') parts.push(`\n## ${el.textContent?.trim()}\n`);
+            else if (tag === 'h3') parts.push(`\n### ${el.textContent?.trim()}\n`);
+            else if (tag === 'h4') parts.push(`\n#### ${el.textContent?.trim()}\n`);
+            else if (tag === 'h5') parts.push(`\n##### ${el.textContent?.trim()}\n`);
+            else if (tag === 'h6') parts.push(`\n###### ${el.textContent?.trim()}\n`);
+            else if (tag === 'p') {
+              const text = el.textContent?.trim();
+              if (text) parts.push(`\n${text}\n`);
+            }
+            else if (tag === 'li') {
+              const text = el.textContent?.trim();
+              if (text) parts.push(`- ${text}`);
+            }
+            else if (tag === 'pre' || tag === 'code') {
+              const text = el.textContent?.trim();
+              if (text && tag === 'pre') parts.push(`\n\`\`\`\n${text}\n\`\`\`\n`);
+            }
+            else if (tag === 'a') {
+              // Skip — links handled separately
+            }
+            else if (tag === 'blockquote') {
+              const text = el.textContent?.trim();
+              if (text) parts.push(`\n> ${text}\n`);
+            }
+
+            node = walker.nextNode();
+          }
+
+          content = parts.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+
+          // Fallback to innerText if markdown extraction is empty
+          if (!content) {
+            content = document.body.innerText || '';
+          }
+        } else if (format === 'text') {
+          content = document.body.innerText || '';
+        } else {
+          // structured — return raw HTML body
+          content = document.body.innerHTML || '';
+        }
+
+        return { title, content, links };
+      }, outputFormat),
+      15000,
+      'crawl.page.evaluate',
+      context,
+    );
+
+    await sessionManager.closeTarget(sessionId, tid);
+    targetId = null;
+
+    // Truncate content if too large
+    let content = result.content;
+    if (content.length > MAX_OUTPUT_CHARS) {
+      content = content.slice(0, MAX_OUTPUT_CHARS) + '...[truncated]';
+    }
+
+    return {
+      url,
+      title: result.title,
+      content,
+      depth,
+      links_found: result.links.length,
+      // Store links transiently — caller uses them for BFS
+      ...(result.links.length > 0 ? { _links: result.links } as Record<string, unknown> : {}),
+    } as CrawledPage & { _links?: string[] };
+  } catch (err) {
+    if (targetId) {
+      try {
+        await sessionManager.closeTarget(sessionId, targetId);
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+    return {
+      url,
+      title: '',
+      content: '',
+      depth,
+      links_found: 0,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+const handler: ToolHandler = async (
+  sessionId: string,
+  args: Record<string, unknown>,
+  context?: ToolContext,
+): Promise<MCPResult> => {
+  const url = args.url as string;
+  if (!url) {
+    return {
+      content: [{ type: 'text', text: 'Error: url is required' }],
+      isError: true,
+    };
+  }
+
+  // Validate URL
+  let startUrl: URL;
+  try {
+    startUrl = new URL(url);
+  } catch {
+    return {
+      content: [{ type: 'text', text: `Error: Invalid URL "${url}"` }],
+      isError: true,
+    };
+  }
+
+  const maxDepth = args.max_depth != null ? Number(args.max_depth) : 2;
+  const maxPages = args.max_pages != null ? Number(args.max_pages) : 20;
+  const scope = (args.scope as string) || `${startUrl.origin}/**`;
+  const includePatterns = args.include_patterns as string[] | undefined;
+  const excludePatterns = args.exclude_patterns as string[] | undefined;
+  const outputFormat = (args.output_format as string) || 'markdown';
+  const respectRobots = args.respect_robots !== false;
+  const delayMs = args.delay_ms != null ? Number(args.delay_ms) : 1000;
+  const concurrency = args.concurrency != null ? Math.max(1, Math.min(10, Number(args.concurrency))) : 3;
+
+  const startTime = Date.now();
+  const tracker = new CrawlTracker();
+  const pages: CrawledPage[] = [];
+  let maxDepthReached = 0;
+
+  // Fetch robots.txt if needed
+  const robotsCache = new Map<string, RobotsRules | null>();
+
+  async function getRobotsRules(pageUrl: string): Promise<RobotsRules | null> {
+    if (!respectRobots) return null;
+    try {
+      const origin = new URL(pageUrl).origin;
+      if (robotsCache.has(origin)) return robotsCache.get(origin)!;
+      const rules = await fetchRobotsTxt(sessionId, origin, context);
+      robotsCache.set(origin, rules);
+      return rules;
+    } catch {
+      return null;
+    }
+  }
+
+  // Check if a URL should be crawled
+  function shouldCrawl(candidateUrl: string): boolean {
+    // Must match scope
+    if (!matchesScope(candidateUrl, scope)) return false;
+
+    // Must pass include/exclude filters
+    if (!passesFilters(candidateUrl, includePatterns, excludePatterns)) return false;
+
+    // Must not already be visited
+    if (tracker.hasVisited(candidateUrl)) return false;
+
+    return true;
+  }
+
+  // Check robots.txt compliance
+  async function isRobotsAllowed(candidateUrl: string): Promise<boolean> {
+    if (!respectRobots) return true;
+    try {
+      const rules = await getRobotsRules(candidateUrl);
+      if (!rules) return true;
+      const parsedUrl = new URL(candidateUrl);
+      return isAllowedByRobots(parsedUrl.pathname, rules);
+    } catch {
+      return true;
+    }
+  }
+
+  try {
+    // Seed the BFS queue with the start URL
+    const normalizedStart = normalizeUrl(url);
+    tracker.enqueue([{ url: normalizedStart, depth: 0 }]);
+
+    const limiter = createLimiter(concurrency);
+
+    // BFS loop
+    while (pages.length < maxPages) {
+      // Check budget
+      if (context && !hasBudget(context, 15_000)) {
+        console.error('[crawl] Deadline approaching, stopping crawl');
+        break;
+      }
+
+      // Collect a batch of URLs to fetch in parallel
+      const batch: Array<{ url: string; depth: number }> = [];
+      const batchSize = Math.min(concurrency, maxPages - pages.length);
+
+      for (let i = 0; i < batchSize; i++) {
+        const next = tracker.dequeue();
+        if (!next) break;
+
+        // Skip if exceeds max depth
+        if (next.depth > maxDepth) continue;
+
+        batch.push(next);
+      }
+
+      if (batch.length === 0) {
+        // Check if there are still items in the queue beyond max_depth
+        const probe = tracker.dequeue();
+        if (!probe) break; // Queue is truly empty
+        // If it's beyond depth, we're done
+        if (probe.depth > maxDepth) break;
+        // Otherwise put it back and try again — shouldn't happen but be safe
+        tracker.enqueue([probe]);
+        break;
+      }
+
+      // Fetch batch in parallel with concurrency limiter
+      const batchResults = await Promise.all(
+        batch.map((item) =>
+          limiter(async () => {
+            // Check robots.txt before fetching
+            const allowed = await isRobotsAllowed(item.url);
+            if (!allowed) {
+              console.error(`[crawl] Blocked by robots.txt: ${item.url}`);
+              return {
+                page: {
+                  url: item.url,
+                  title: '',
+                  content: '',
+                  depth: item.depth,
+                  links_found: 0,
+                  error: 'Blocked by robots.txt',
+                } as CrawledPage,
+                links: [] as string[],
+                depth: item.depth,
+              };
+            }
+
+            // Mark as visited
+            tracker.visit(item.url);
+
+            const result = await fetchPage(sessionId, item.url, item.depth, outputFormat, context);
+
+            // Extract discovered links (stored transiently)
+            const links = ((result as CrawledPage & { _links?: string[] })._links || []);
+            delete (result as CrawledPage & { _links?: string[] })._links;
+
+            // Apply delay between fetches
+            if (delayMs > 0) {
+              await new Promise((r) => setTimeout(r, delayMs));
+            }
+
+            return { page: result, links, depth: item.depth };
+          }),
+        ),
+      );
+
+      // Process results and enqueue discovered links
+      for (const { page, links, depth } of batchResults) {
+        pages.push(page);
+        if (depth > maxDepthReached) maxDepthReached = depth;
+
+        // Enqueue discovered links for next depth level
+        if (depth < maxDepth && !page.error) {
+          const nextDepth = depth + 1;
+          const newUrls: Array<{ url: string; depth: number }> = [];
+
+          for (const link of links) {
+            const normalized = normalizeUrl(link);
+            if (shouldCrawl(normalized)) {
+              newUrls.push({ url: normalized, depth: nextDepth });
+            }
+          }
+
+          if (newUrls.length > 0) {
+            tracker.enqueue(newUrls);
+          }
+        }
+      }
+    }
+
+    const durationMs = Date.now() - startTime;
+    const succeeded = pages.filter((p) => !p.error).length;
+    const failed = pages.filter((p) => p.error).length;
+
+    const summary: CrawlSummary = {
+      total_pages: pages.length,
+      succeeded,
+      failed,
+      max_depth_reached: maxDepthReached,
+      duration_ms: durationMs,
+      scope,
+    };
+
+    const output = { summary, pages };
+
+    // Ensure output fits within limits
+    let outputJson = JSON.stringify(output, null, 2);
+    if (outputJson.length > MAX_OUTPUT_CHARS) {
+      // Truncate page contents progressively to fit
+      const truncatedPages = pages.map((p) => ({
+        ...p,
+        content: p.content.length > 2000
+          ? p.content.slice(0, 2000) + '...[truncated]'
+          : p.content,
+      }));
+      outputJson = JSON.stringify({ summary, pages: truncatedPages }, null, 2);
+
+      // If still too large, remove content entirely
+      if (outputJson.length > MAX_OUTPUT_CHARS) {
+        const minimalPages = pages.map((p) => ({
+          url: p.url,
+          title: p.title,
+          depth: p.depth,
+          links_found: p.links_found,
+          content_length: p.content.length,
+          error: p.error,
+        }));
+        outputJson = JSON.stringify({ summary, pages: minimalPages, note: 'Content omitted due to size constraints' }, null, 2);
+      }
+    }
+
+    return {
+      content: [{ type: 'text', text: outputJson }],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `crawl error: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+};
+
+export function registerCrawlTool(server: MCPServer): void {
+  server.registerTool('crawl', handler, definition);
+}

--- a/src/tools/crawl.ts
+++ b/src/tools/crawl.ts
@@ -353,6 +353,12 @@ const handler: ToolHandler = async (
       isError: true,
     };
   }
+  if (startUrl.protocol !== 'http:' && startUrl.protocol !== 'https:') {
+    return {
+      content: [{ type: 'text', text: 'Error: url must use http or https scheme' }],
+      isError: true,
+    };
+  }
 
   const maxDepth = args.max_depth != null ? Number(args.max_depth) : 2;
   const maxPages = args.max_pages != null ? Number(args.max_pages) : 20;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -77,6 +77,9 @@ import { registerConnectTools } from './connect';
 // Session recording tools (#572)
 import { registerRecordingTools } from './recording';
 
+// Crawl tools (#576)
+import { registerCrawlTool } from './crawl';
+
 export function registerAllTools(server: MCPServer): void {
   // Core browser tools
   registerNavigateTool(server);
@@ -157,6 +160,9 @@ export function registerAllTools(server: MCPServer): void {
 
   // Session recording tools (#572)
   registerRecordingTools(server);
+
+  // Crawl tools (#576)
+  registerCrawlTool(server);
 
   console.error(`[Tools] Registered ${server.getToolNames().length} tools`);
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -79,6 +79,7 @@ import { registerRecordingTools } from './recording';
 
 // Crawl tools (#576)
 import { registerCrawlTool } from './crawl';
+import { registerCrawlSitemapTool } from './crawl-sitemap';
 
 export function registerAllTools(server: MCPServer): void {
   // Core browser tools
@@ -163,6 +164,7 @@ export function registerAllTools(server: MCPServer): void {
 
   // Crawl tools (#576)
   registerCrawlTool(server);
+  registerCrawlSitemapTool(server);
 
   console.error(`[Tools] Registered ${server.getToolNames().length} tools`);
 }

--- a/tests/cross-env/cursor-verification.test.ts
+++ b/tests/cross-env/cursor-verification.test.ts
@@ -234,8 +234,8 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
         expect(toolNames).toContain(tool);
       }
 
-      // Total should be 58 (30 T1 + 19 T2 + 9 T3)
-      expect(toolNames.length).toBe(58);
+      // Total should be 60 (30 T1 + 21 T2 + 9 T3)
+      expect(toolNames.length).toBe(60);
     });
 
     test('resources/list returns usage guide resource', async () => {
@@ -292,6 +292,7 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
       'console_capture', 'performance_metrics', 'file_upload',
       'batch_execute', 'batch_paginate',
       'oc_recording_start', 'oc_recording_stop', 'oc_recording_list', 'oc_recording_export',
+      'crawl', 'crawl_sitemap',
     ];
     tier2Tools.forEach(tool => {
       test(`Tier 2: ${tool} registered`, () => {
@@ -414,8 +415,8 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
 
       // Should NOT have expand_tools (progressive disclosure disabled)
       expect(toolNames).not.toContain('expand_tools');
-      // Total should be 58 (30 T1 + 19 T2 + 9 T3)
-      expect(toolNames.length).toBe(58);
+      // Total should be 60 (30 T1 + 21 T2 + 9 T3)
+      expect(toolNames.length).toBe(60);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `crawl_sitemap` MCP tool that crawls websites using sitemap.xml discovery
- Auto-discovers sitemaps from robots.txt, `/sitemap.xml`, and `/sitemap_index.xml`
- Supports sitemap index files with recursive resolution (up to 2 levels), URL glob filtering, concurrent page fetches, budget-aware execution, and CrawlTracker deduplication
- Registered in tool index and assigned tier 2 in tool-tiers config

## Test plan
- [ ] Verify `npm run build` passes (confirmed locally)
- [ ] Test with a site that has `/sitemap.xml` — should auto-discover and crawl listed pages
- [ ] Test with explicit `sitemap_url` parameter — should skip discovery and use directly
- [ ] Test `filter` parameter with a glob pattern — should only crawl matching URLs
- [ ] Test with a sitemap index file — should recursively resolve child sitemaps
- [ ] Test with a site that has no sitemap — should return informative error with suggestions
- [ ] Test `max_pages` limit — should stop after reaching the limit
- [ ] Test concurrency parameter — verify parallel fetching works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)