### PR TITLE
feat(vision): add vision_find tool and find fallback chain (#577)

### DIFF
--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -58,6 +58,7 @@ export const TOOL_TIERS: Record<string, ToolTier> = {
   batch_paginate: 2,
   crawl: 2,
   crawl_sitemap: 2,
+  vision_find: 2,
 
   // Session recording tools (#572) — opt-in, not needed for every session
   oc_recording_start: 2,

--- a/src/tools/find.ts
+++ b/src/tools/find.ts
@@ -11,6 +11,8 @@ import { discoverElements, cleanupTags, DISCOVERY_TAG } from '../utils/element-d
 import { FoundElement, normalizeQuery, scoreElement, tokenizeQuery } from '../utils/element-finder';
 import { resolveElementsByAXTree, MATCH_LEVEL_LABELS } from '../utils/ax-element-resolver';
 import { getCircuitBreaker } from '../utils/ralph/circuit-breaker';
+import { analyzeScreenshot, formatElementMapAsText } from '../vision/screenshot-analyzer';
+import { getVisionMode } from '../vision/config';
 
 const definition: MCPToolDefinition = {
   name: 'find',
@@ -34,6 +36,10 @@ const definition: MCPToolDefinition = {
         type: 'number',
         description: 'Poll interval in ms. Default: 200',
       },
+      vision_fallback: {
+        type: 'boolean',
+        description: 'Use vision-based screenshot analysis if DOM discovery finds nothing. Default: follows OPENCHROME_VISION_MODE env.',
+      },
     },
     required: ['query', 'tabId'],
   },
@@ -48,6 +54,8 @@ const handler: ToolHandler = async (
   const query = args.query as string;
   const waitForMs = args.waitForMs as number | undefined;
   const pollInterval = Math.min(Math.max((args.pollInterval as number) || 200, 50), 2000);
+  const visionFallback = args.vision_fallback as boolean | undefined;
+  const visionMode = getVisionMode();
 
   const sessionManager = getSessionManager();
   const refIdManager = getRefIdManager();
@@ -198,6 +206,38 @@ const handler: ToolHandler = async (
     await cleanupTags(page, DISCOVERY_TAG).catch(() => {});
 
     if (output.length === 0) {
+      // ─── Vision Fallback ───
+      const shouldUseVision = (visionFallback || visionMode === 'auto') && visionMode !== 'off';
+      if (shouldUseVision && context && hasBudget(context, 10_000)) {
+        try {
+          console.error(`[find] DOM discovery found nothing for "${query}" — trying vision fallback`);
+          const visionResult = await analyzeScreenshot(page, {
+            interactiveOnly: true,
+            showBoundingBoxes: true,
+          });
+
+          if (visionResult.elementCount > 0) {
+            const textMap = formatElementMapAsText(visionResult.elementMap);
+            console.error(`[find] Vision fallback found ${visionResult.elementCount} elements for "${query}"`);
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: `DOM found nothing for "${query}" — vision fallback found ${visionResult.elementCount} elements:\n\n${textMap}`,
+                },
+                {
+                  type: 'image',
+                  data: visionResult.screenshot,
+                  mimeType: visionResult.mimeType,
+                },
+              ],
+            };
+          }
+        } catch (visionError) {
+          console.error(`[find] Vision fallback failed: ${visionError instanceof Error ? visionError.message : String(visionError)}`);
+        }
+      }
+
       let url = 'unknown', readyState = 'unknown', totalElements = 0;
       try {
         ({ url, readyState, totalElements } = await withTimeout(page.evaluate(() => ({

--- a/src/tools/find.ts
+++ b/src/tools/find.ts
@@ -207,7 +207,8 @@ const handler: ToolHandler = async (
 
     if (output.length === 0) {
       // ─── Vision Fallback ───
-      const shouldUseVision = (visionFallback || visionMode === 'auto') && visionMode !== 'off';
+      const shouldUseVision = visionMode !== 'off' &&
+        (visionFallback === true || visionMode === 'fallback' || visionMode === 'auto');
       if (shouldUseVision && context && hasBudget(context, 10_000)) {
         try {
           console.error(`[find] DOM discovery found nothing for "${query}" — trying vision fallback`);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -49,6 +49,9 @@ import { registerBatchPaginateTool } from './batch-paginate';
 import { registerInteractTool } from './interact';
 import { registerInspectTool } from './inspect';
 
+// Vision tools (vision-based element discovery #577)
+import { registerVisionFindTool } from './vision-find';
+
 // Memory tools (domain knowledge persistence)
 import { registerMemoryTools } from './memory';
 
@@ -136,6 +139,9 @@ export function registerAllTools(server: MCPServer): void {
   // Smart Tools (reduce LLM wandering — response enrichment + composite tools)
   registerInteractTool(server);
   registerInspectTool(server);
+
+  // Vision tools (vision-based element discovery #577)
+  registerVisionFindTool(server);
 
   // Memory tools (domain knowledge persistence)
   registerMemoryTools(server);

--- a/src/tools/vision-find.ts
+++ b/src/tools/vision-find.ts
@@ -1,0 +1,125 @@
+/**
+ * Vision Find Tool - Explicit vision-based element discovery using annotated screenshots.
+ *
+ * Uses the screenshot analyzer to capture an annotated screenshot with numbered
+ * interactive elements, returning both the image and a text element map.
+ *
+ * This tool is useful when DOM-based discovery (find, interact) cannot locate
+ * elements — e.g. canvas apps, complex iframes, or heavily dynamic UIs.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
+import { getSessionManager } from '../session-manager';
+import { analyzeScreenshot, formatElementMapAsText } from '../vision/screenshot-analyzer';
+
+const definition: MCPToolDefinition = {
+  name: 'vision_find',
+  description: 'Find elements using vision-based screenshot analysis. Returns annotated screenshot with numbered elements.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      tabId: {
+        type: 'string',
+        description: 'Tab ID to analyze',
+      },
+      instruction: {
+        type: 'string',
+        description: 'Optional hint about what to look for (for future use)',
+      },
+      showGrid: {
+        type: 'boolean',
+        description: 'Overlay coordinate grid on screenshot. Default: false',
+      },
+      showBoundingBoxes: {
+        type: 'boolean',
+        description: 'Show bounding boxes around elements. Default: true',
+      },
+      interactiveOnly: {
+        type: 'boolean',
+        description: 'Only show interactive elements (buttons, links, inputs). Default: true',
+      },
+    },
+    required: ['tabId'],
+  },
+};
+
+const handler: ToolHandler = async (
+  sessionId: string,
+  args: Record<string, unknown>,
+  context?: ToolContext
+): Promise<MCPResult> => {
+  const tabId = args.tabId as string;
+
+  if (!tabId) {
+    return {
+      content: [{ type: 'text', text: 'Error: tabId is required' }],
+      isError: true,
+    };
+  }
+
+  // Budget check: vision analysis needs at least 10s
+  if (context && !hasBudget(context, 10_000)) {
+    return {
+      content: [{ type: 'text', text: 'vision_find: deadline approaching — need at least 10s budget' }],
+      isError: true,
+    };
+  }
+
+  const sessionManager = getSessionManager();
+
+  try {
+    const page = await sessionManager.getPage(sessionId, tabId, undefined, 'vision_find');
+    if (!page) {
+      const available = await sessionManager.getAvailableTargets(sessionId);
+      const availableInfo = available.length > 0
+        ? `\nAvailable tabs:\n${available.map(t => `  - tabId: ${t.tabId} | ${t.url} | ${t.title}`).join('\n')}`
+        : '\nNo tabs available. Call navigate without tabId to create a new tab.';
+      return {
+        content: [{ type: 'text', text: `Error: Tab ${tabId} not found or no longer available.${availableInfo}` }],
+        isError: true,
+      };
+    }
+
+    const showGrid = args.showGrid === true;
+    const showBoundingBoxes = args.showBoundingBoxes !== false;
+    const interactiveOnly = args.interactiveOnly !== false;
+
+    const result = await analyzeScreenshot(page, {
+      showGrid,
+      showBoundingBoxes,
+      interactiveOnly,
+    });
+
+    const textMap = formatElementMapAsText(result.elementMap);
+    console.error(`[vision_find] Analyzed tab ${tabId}: ${result.elementCount} elements in ${result.annotationTimeMs}ms`);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Vision analysis: ${result.elementCount} elements found (${result.viewport.width}x${result.viewport.height} viewport, ${result.annotationTimeMs}ms)\n\n${textMap}`,
+        },
+        {
+          type: 'image',
+          data: result.screenshot,
+          mimeType: result.mimeType,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `vision_find error: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+};
+
+export function registerVisionFindTool(server: MCPServer): void {
+  server.registerTool('vision_find', handler, definition);
+}

--- a/src/vision/config.ts
+++ b/src/vision/config.ts
@@ -1,0 +1,20 @@
+/**
+ * Vision Mode Configuration
+ *
+ * Controls when vision-based element discovery is used (#577).
+ *
+ * Modes:
+ *   - 'off'      — Vision fallback completely disabled
+ *   - 'fallback' — Vision used only when DOM discovery fails (default)
+ *   - 'auto'     — Vision automatically used alongside DOM discovery
+ *
+ * Set via OPENCHROME_VISION_MODE environment variable.
+ */
+
+import type { VisionMode } from './types';
+
+export function getVisionMode(): VisionMode {
+  const env = process.env.OPENCHROME_VISION_MODE;
+  if (env === 'off' || env === 'auto') return env;
+  return 'fallback';
+}

--- a/tests/cross-env/cursor-verification.test.ts
+++ b/tests/cross-env/cursor-verification.test.ts
@@ -234,8 +234,8 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
         expect(toolNames).toContain(tool);
       }
 
-      // Total should be 60 (30 T1 + 21 T2 + 9 T3)
-      expect(toolNames.length).toBe(60);
+      // Total should be 61 (30 T1 + 22 T2 + 9 T3)
+      expect(toolNames.length).toBe(61);
     });
 
     test('resources/list returns usage guide resource', async () => {
@@ -292,7 +292,7 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
       'console_capture', 'performance_metrics', 'file_upload',
       'batch_execute', 'batch_paginate',
       'oc_recording_start', 'oc_recording_stop', 'oc_recording_list', 'oc_recording_export',
-      'crawl', 'crawl_sitemap',
+      'crawl', 'crawl_sitemap', 'vision_find',
     ];
     tier2Tools.forEach(tool => {
       test(`Tier 2: ${tool} registered`, () => {
@@ -415,8 +415,8 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
 
       // Should NOT have expand_tools (progressive disclosure disabled)
       expect(toolNames).not.toContain('expand_tools');
-      // Total should be 60 (30 T1 + 21 T2 + 9 T3)
-      expect(toolNames.length).toBe(60);
+      // Total should be 61 (30 T1 + 22 T2 + 9 T3)
+      expect(toolNames.length).toBe(61);
     });
   });
 });

--- a/tests/vision/vision-find.test.ts
+++ b/tests/vision/vision-find.test.ts
@@ -1,0 +1,199 @@
+/// <reference types="jest" />
+/**
+ * Tests for Vision Find Tool and Vision Config (Phase 2: Vision Hybrid Mode #577)
+ */
+
+// ─── getVisionMode config tests ───
+
+describe('getVisionMode', () => {
+  const originalEnv = process.env.OPENCHROME_VISION_MODE;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.OPENCHROME_VISION_MODE;
+    } else {
+      process.env.OPENCHROME_VISION_MODE = originalEnv;
+    }
+    jest.resetModules();
+  });
+
+  it('returns fallback by default when env is not set', async () => {
+    delete process.env.OPENCHROME_VISION_MODE;
+    const { getVisionMode } = await import('../../src/vision/config');
+    expect(getVisionMode()).toBe('fallback');
+  });
+
+  it('returns off when env is off', async () => {
+    process.env.OPENCHROME_VISION_MODE = 'off';
+    const { getVisionMode } = await import('../../src/vision/config');
+    expect(getVisionMode()).toBe('off');
+  });
+
+  it('returns auto when env is auto', async () => {
+    process.env.OPENCHROME_VISION_MODE = 'auto';
+    const { getVisionMode } = await import('../../src/vision/config');
+    expect(getVisionMode()).toBe('auto');
+  });
+
+  it('returns fallback for invalid values', async () => {
+    process.env.OPENCHROME_VISION_MODE = 'invalid-value';
+    const { getVisionMode } = await import('../../src/vision/config');
+    expect(getVisionMode()).toBe('fallback');
+  });
+});
+
+// ─── Mock Page Factory ───
+
+function createMockPage(evaluateResult: unknown[] = [], viewport = { width: 1920, height: 1080 }) {
+  return {
+    evaluate: jest.fn().mockImplementation((_fn: Function, ...args: unknown[]) => {
+      // Overlay injection/removal calls
+      if (args.length === 3 && typeof args[2] === 'string' && String(args[2]).includes('oc_vision')) {
+        return Promise.resolve();
+      }
+      if (args.length === 1 && typeof args[0] === 'string' && String(args[0]).includes('oc_vision')) {
+        return Promise.resolve();
+      }
+      return Promise.resolve(evaluateResult);
+    }),
+    screenshot: jest.fn().mockResolvedValue(Buffer.from('fake-screenshot-data')),
+    viewport: jest.fn().mockReturnValue(viewport),
+  };
+}
+
+// ─── VisionFindTool ───
+
+describe('VisionFindTool', () => {
+  const getVisionFindHandler = async (mockSessionManager: Record<string, jest.Mock>) => {
+    jest.resetModules();
+    jest.doMock('../../src/session-manager', () => ({
+      getSessionManager: jest.fn(() => mockSessionManager),
+    }));
+
+    const { registerVisionFindTool } = await import('../../src/tools/vision-find');
+
+    const tools: Map<string, { handler: (sessionId: string, args: Record<string, unknown>, context?: unknown) => Promise<unknown> }> = new Map();
+    const mockServer = {
+      registerTool: (name: string, handler: unknown) => {
+        tools.set(name, { handler: handler as (sessionId: string, args: Record<string, unknown>, context?: unknown) => Promise<unknown> });
+      },
+    };
+
+    registerVisionFindTool(mockServer as unknown as Parameters<typeof registerVisionFindTool>[0]);
+    return tools.get('vision_find')!.handler;
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns annotated screenshot and element map', async () => {
+    const mockElements = [
+      { role: 'button', name: 'Submit', x: 100, y: 200, width: 80, height: 30 },
+      { role: 'link', name: 'Home', x: 10, y: 10, width: 60, height: 20 },
+    ];
+    const page = createMockPage(mockElements);
+
+    const mockSessionManager = {
+      getPage: jest.fn().mockResolvedValue(page),
+      getAvailableTargets: jest.fn().mockResolvedValue([]),
+    };
+
+    const handler = await getVisionFindHandler(mockSessionManager);
+    const context = { startTime: Date.now(), deadlineMs: 60000 };
+    const result = await handler('session-1', { tabId: 'tab-1' }, context) as any;
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('2 elements found');
+    expect(result.content[1].type).toBe('image');
+    expect(result.content[1].data).toBeTruthy();
+    expect(result.content[1].mimeType).toMatch(/^image\//);
+  });
+
+  it('errors on missing tabId', async () => {
+    const mockSessionManager = {
+      getPage: jest.fn(),
+      getAvailableTargets: jest.fn().mockResolvedValue([]),
+    };
+
+    const handler = await getVisionFindHandler(mockSessionManager);
+    const result = await handler('session-1', {}) as any;
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('tabId is required');
+  });
+
+  it('errors on missing tab', async () => {
+    const mockSessionManager = {
+      getPage: jest.fn().mockResolvedValue(null),
+      getAvailableTargets: jest.fn().mockResolvedValue([]),
+    };
+
+    const handler = await getVisionFindHandler(mockSessionManager);
+    const context = { startTime: Date.now(), deadlineMs: 60000 };
+    const result = await handler('session-1', { tabId: 'nonexistent' }, context) as any;
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('not found');
+  });
+
+  it('errors on low budget', async () => {
+    const mockSessionManager = {
+      getPage: jest.fn(),
+      getAvailableTargets: jest.fn().mockResolvedValue([]),
+    };
+
+    const handler = await getVisionFindHandler(mockSessionManager);
+    // Budget of only 5s — less than the 10s minimum
+    const context = { startTime: Date.now(), deadlineMs: 5000 };
+    const result = await handler('session-1', { tabId: 'tab-1' }, context) as any;
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('deadline approaching');
+  });
+});
+
+// ─── Find tool schema includes vision_fallback ───
+
+describe('FindTool schema', () => {
+  it('find tool includes vision_fallback property', async () => {
+    jest.resetModules();
+
+    // Mock all find tool dependencies
+    jest.doMock('../../src/session-manager', () => ({
+      getSessionManager: jest.fn(() => ({})),
+    }));
+    jest.doMock('../../src/utils/ref-id-manager', () => ({
+      getRefIdManager: jest.fn(() => ({})),
+    }));
+    jest.doMock('../../src/utils/ax-element-resolver', () => ({
+      resolveElementsByAXTree: jest.fn().mockResolvedValue([]),
+      invalidateAXCache: jest.fn(),
+      clearAXCache: jest.fn(),
+      MATCH_LEVEL_LABELS: ['exact', 'partial', 'fuzzy'],
+    }));
+    jest.doMock('../../src/utils/ralph/circuit-breaker', () => ({
+      getCircuitBreaker: jest.fn(() => ({
+        check: jest.fn().mockReturnValue({ allowed: true }),
+        recordElementFailure: jest.fn(),
+        recordElementSuccess: jest.fn(),
+      })),
+    }));
+
+    const { registerFindTool } = await import('../../src/tools/find');
+
+    let capturedDefinition: any;
+    const mockServer = {
+      registerTool: (_name: string, _handler: unknown, definition: unknown) => {
+        capturedDefinition = definition;
+      },
+    };
+
+    registerFindTool(mockServer as unknown as Parameters<typeof registerFindTool>[0]);
+
+    expect(capturedDefinition.inputSchema.properties).toHaveProperty('vision_fallback');
+    expect(capturedDefinition.inputSchema.properties.vision_fallback.type).toBe('boolean');
+  });
+});


### PR DESCRIPTION
## Summary
- **`src/vision/config.ts`** — Vision mode configuration (`off`/`fallback`/`auto`) controlled by `OPENCHROME_VISION_MODE` env var, defaults to `fallback`
- **`src/tools/vision-find.ts`** — New `vision_find` MCP tool for explicit vision-based element discovery using annotated screenshots with numbered elements, bounding boxes, and optional coordinate grid
- **`src/tools/find.ts`** — Added vision fallback chain: when DOM discovery (AX tree + CSS) finds nothing, automatically falls back to screenshot analysis if `vision_fallback` is enabled or vision mode is `auto`
- **`src/tools/index.ts`** — Registered `vision_find` tool in the tool registry
- **`tests/vision/vision-find.test.ts`** — 9 tests covering config parsing, tool behavior (success, missing tabId, missing tab, low budget), and find tool schema validation

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npx jest --testPathPattern='vision/' --no-coverage` — 27 tests pass (18 Phase 1 + 9 Phase 2)
- [ ] Manual: verify `vision_find` tool appears in tool listing
- [ ] Manual: verify find tool falls back to vision when DOM returns empty on a canvas-heavy page

**Phase 2 of 3** for Vision Hybrid Mode (#577). Builds on Phase 1 (`feat/577-phase1-screenshot-analyzer`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)