### PR TITLE
feat: add crawl and crawl_sitemap tools for web crawling (#576)

### DIFF
--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -56,6 +56,8 @@ export const TOOL_TIERS: Record<string, ToolTier> = {
   file_upload: 2,
   batch_execute: 2,
   batch_paginate: 2,
+  crawl: 2,
+  crawl_sitemap: 2,
 
   // Internal/diagnostic tools (exposed at Tier 1 but explicitly declared)
   // Names must match the 'name' field in each tool's definition

--- a/src/tools/crawl-sitemap.ts
+++ b/src/tools/crawl-sitemap.ts
@@ -1,0 +1,418 @@
+/**
+ * Crawl Sitemap Tool - Sitemap-based page crawler.
+ *
+ * Discovers URLs via sitemap.xml (or robots.txt → sitemap) and crawls them
+ * in parallel, returning content from each page.
+ *
+ * @see https://github.com/shaun0927/openchrome/issues/576
+ */
+
+import { MCPServer } from '../mcp-server';
+import {
+  MCPToolDefinition,
+  MCPResult,
+  ToolHandler,
+  ToolContext,
+  hasBudget,
+} from '../types/mcp';
+import { getSessionManager } from '../session-manager';
+import { MAX_OUTPUT_CHARS } from '../config/defaults';
+import { withTimeout } from '../utils/with-timeout';
+import {
+  parseSitemapXml,
+  parseRobotsTxt,
+  urlGlobToRegex,
+} from '../utils/crawl-utils';
+
+const definition: MCPToolDefinition = {
+  name: 'crawl_sitemap',
+  description:
+    'Crawl pages listed in a website sitemap. Discovers URLs via sitemap.xml (auto-detected from robots.txt or well-known paths) and fetches content from each page.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      url: {
+        type: 'string',
+        description: 'Website base URL (e.g. "https://docs.example.com")',
+      },
+      sitemap_url: {
+        type: 'string',
+        description:
+          'Explicit sitemap URL. If omitted, auto-discovered via robots.txt and /sitemap.xml',
+      },
+      filter: {
+        type: 'string',
+        description:
+          'Glob pattern to filter sitemap URLs (e.g., "https://docs.example.com/api/**")',
+      },
+      max_pages: {
+        type: 'number',
+        description: 'Maximum pages to crawl from sitemap. Default: 50',
+      },
+      output_format: {
+        type: 'string',
+        enum: ['markdown', 'text', 'structured'],
+        description: 'Content format per page. Default: "markdown"',
+      },
+      concurrency: {
+        type: 'number',
+        description: 'Maximum concurrent page fetches. Default: 3',
+      },
+    },
+    required: ['url'],
+  },
+};
+
+interface SitemapPageResult {
+  url: string;
+  title: string;
+  content: string;
+  error?: string;
+}
+
+/**
+ * Simple concurrency limiter (same pattern as batch-paginate.ts)
+ */
+function createLimiter(concurrency: number) {
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  return async function <T>(fn: () => Promise<T>): Promise<T> {
+    if (active >= concurrency) {
+      await new Promise<void>((resolve) => queue.push(resolve));
+    }
+    active++;
+    try {
+      return await fn();
+    } finally {
+      active--;
+      if (queue.length > 0) {
+        const next = queue.shift()!;
+        next();
+      }
+    }
+  };
+}
+
+/**
+ * Fetch raw text/XML from a URL via a browser tab.
+ */
+async function fetchRawText(
+  sessionId: string,
+  url: string,
+  context?: ToolContext,
+): Promise<string> {
+  const sessionManager = getSessionManager();
+  let targetId: string | null = null;
+
+  try {
+    const { targetId: tid, page } = await sessionManager.createTarget(sessionId, url);
+    targetId = tid;
+
+    await new Promise((r) => setTimeout(r, 500));
+
+    const text = await withTimeout(
+      page.evaluate(() => {
+        // For XML documents, use XMLSerializer to get the raw content
+        if (document.contentType && document.contentType.includes('xml')) {
+          return new XMLSerializer().serializeToString(document);
+        }
+        return document.body?.innerText || document.documentElement?.innerText || '';
+      }),
+      10000,
+      'crawl_sitemap.fetchRaw',
+      context,
+    );
+
+    await sessionManager.closeTarget(sessionId, tid);
+    targetId = null;
+
+    return text;
+  } catch (err) {
+    if (targetId) {
+      try {
+        await sessionManager.closeTarget(sessionId, targetId);
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+    throw err;
+  }
+}
+
+/**
+ * Fetch a page and extract its title and content.
+ */
+async function fetchPage(
+  sessionId: string,
+  url: string,
+  outputFormat: string,
+  context?: ToolContext,
+): Promise<SitemapPageResult> {
+  const sessionManager = getSessionManager();
+  let targetId: string | null = null;
+
+  try {
+    const { targetId: tid, page } = await sessionManager.createTarget(sessionId, url);
+    targetId = tid;
+
+    await new Promise((r) => setTimeout(r, 500));
+
+    const extracted = await withTimeout(
+      page.evaluate((fmt: string) => {
+        const title = document.title || '';
+        let content: string;
+
+        if (fmt === 'text') {
+          content = document.body?.innerText || '';
+        } else {
+          const body = document.body;
+          if (!body) {
+            content = '';
+          } else {
+            const parts: string[] = [];
+            const headings = body.querySelectorAll('h1, h2, h3, h4, h5, h6');
+            headings.forEach((h) => {
+              const level = parseInt(h.tagName[1]);
+              const prefix = '#'.repeat(level);
+              parts.push(`${prefix} ${h.textContent?.trim()}`);
+            });
+            parts.push(body.innerText || '');
+            content = parts.join('\n\n');
+          }
+        }
+
+        return { title, content };
+      }, outputFormat),
+      15000,
+      'crawl_sitemap.extract',
+      context,
+    );
+
+    await sessionManager.closeTarget(sessionId, tid);
+    targetId = null;
+
+    let content = extracted.content;
+    if (content.length > MAX_OUTPUT_CHARS) {
+      content = content.slice(0, MAX_OUTPUT_CHARS) + '...[truncated]';
+    }
+
+    return { url, title: extracted.title, content };
+  } catch (err) {
+    if (targetId) {
+      try {
+        await sessionManager.closeTarget(sessionId, targetId);
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+    return {
+      url,
+      title: '',
+      content: '',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Auto-discover the sitemap URL from robots.txt or well-known paths.
+ */
+async function discoverSitemapUrl(
+  sessionId: string,
+  baseUrl: string,
+  context?: ToolContext,
+): Promise<string | null> {
+  // 1. Try robots.txt
+  try {
+    const robotsUrl = `${baseUrl.replace(/\/$/, '')}/robots.txt`;
+    const robotsText = await fetchRawText(sessionId, robotsUrl, context);
+    const rules = parseRobotsTxt(robotsText);
+    if (rules.sitemaps.length > 0) {
+      return rules.sitemaps[0];
+    }
+  } catch {
+    // continue to fallback
+  }
+
+  // 2. Try /sitemap.xml
+  try {
+    const sitemapUrl = `${baseUrl.replace(/\/$/, '')}/sitemap.xml`;
+    const text = await fetchRawText(sessionId, sitemapUrl, context);
+    if (text && (text.includes('<urlset') || text.includes('<sitemapindex'))) {
+      return sitemapUrl;
+    }
+  } catch {
+    // continue to fallback
+  }
+
+  // 3. Try /sitemap_index.xml
+  try {
+    const sitemapIndexUrl = `${baseUrl.replace(/\/$/, '')}/sitemap_index.xml`;
+    const text = await fetchRawText(sessionId, sitemapIndexUrl, context);
+    if (text && (text.includes('<urlset') || text.includes('<sitemapindex'))) {
+      return sitemapIndexUrl;
+    }
+  } catch {
+    // ignore
+  }
+
+  return null;
+}
+
+/**
+ * Resolve all page URLs from a sitemap (handles sitemap index recursion up to 2 levels).
+ * Applies the optional filter glob pattern.
+ */
+async function resolveSitemapPageUrls(
+  sessionId: string,
+  sitemapUrl: string,
+  filter: string | undefined,
+  maxPages: number,
+  context?: ToolContext,
+): Promise<string[]> {
+  const filterRegex = filter ? urlGlobToRegex(filter) : null;
+  const pageUrls: string[] = [];
+
+  async function processSitemap(url: string, depth: number): Promise<void> {
+    if (pageUrls.length >= maxPages) return;
+
+    let text: string;
+    try {
+      text = await fetchRawText(sessionId, url, context);
+    } catch (err) {
+      console.error(`[crawl_sitemap] Failed to fetch sitemap ${url}: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+
+    const result = parseSitemapXml(text);
+
+    if (result.isSitemapIndex && depth < 2) {
+      for (const indexUrl of result.sitemapIndexUrls) {
+        if (pageUrls.length >= maxPages) break;
+        await processSitemap(indexUrl, depth + 1);
+      }
+    } else {
+      for (const sitemapEntry of result.urls) {
+        if (pageUrls.length >= maxPages) break;
+        const loc = sitemapEntry.loc;
+        if (!filterRegex || filterRegex.test(loc)) {
+          pageUrls.push(loc);
+        }
+      }
+    }
+  }
+
+  await processSitemap(sitemapUrl, 0);
+  return pageUrls;
+}
+
+const handler: ToolHandler = async (
+  sessionId: string,
+  args: Record<string, unknown>,
+  context?: ToolContext,
+): Promise<MCPResult> => {
+  const url = args.url as string;
+  if (!url) {
+    return {
+      content: [{ type: 'text', text: 'Error: url is required' }],
+      isError: true,
+    };
+  }
+
+  const sitemapUrlArg = args.sitemap_url as string | undefined;
+  const filter = args.filter as string | undefined;
+  const maxPages = args.max_pages != null ? Number(args.max_pages) : 50;
+  const outputFormat = (args.output_format as string) || 'markdown';
+  const concurrency = args.concurrency != null ? Number(args.concurrency) : 3;
+
+  // Discover or use explicit sitemap URL
+  let sitemapUrl = sitemapUrlArg;
+  if (!sitemapUrl) {
+    if (context && !hasBudget(context, 30_000)) {
+      return {
+        content: [{ type: 'text', text: 'Error: Insufficient budget for sitemap discovery' }],
+        isError: true,
+      };
+    }
+    sitemapUrl = await discoverSitemapUrl(sessionId, url, context) ?? undefined;
+    if (!sitemapUrl) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error: Could not discover sitemap for ${url}. Try providing sitemap_url explicitly.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+    console.error(`[crawl_sitemap] Discovered sitemap: ${sitemapUrl}`);
+  }
+
+  // Resolve page URLs from the sitemap
+  const pageUrls = await resolveSitemapPageUrls(sessionId, sitemapUrl, filter, maxPages, context);
+
+  if (pageUrls.length === 0) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            summary: {
+              sitemap_url: sitemapUrl,
+              total_pages: 0,
+              succeeded: 0,
+              failed: 0,
+              filter: filter ?? null,
+            },
+            pages: [],
+          }, null, 2),
+        },
+      ],
+    };
+  }
+
+  // Crawl pages in parallel batches
+  const startTime = Date.now();
+  const limiter = createLimiter(concurrency);
+  const results = await Promise.all(
+    pageUrls.map((pageUrl) =>
+      limiter(() => {
+        if (context && !hasBudget(context, 10_000)) {
+          return Promise.resolve<SitemapPageResult>({
+            url: pageUrl,
+            title: '',
+            content: '',
+            error: 'budget exhausted',
+          });
+        }
+        return fetchPage(sessionId, pageUrl, outputFormat, context);
+      }),
+    ),
+  );
+
+  const durationMs = Date.now() - startTime;
+  const successCount = results.filter((r) => !r.error).length;
+  const failedCount = results.filter((r) => r.error).length;
+
+  const output = {
+    summary: {
+      sitemap_url: sitemapUrl,
+      total_pages: results.length,
+      succeeded: successCount,
+      failed: failedCount,
+      duration_ms: durationMs,
+      filter: filter ?? null,
+    },
+    pages: results,
+  };
+
+  return {
+    content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],
+  };
+};
+
+export function registerCrawlSitemapTool(server: MCPServer): void {
+  server.registerTool('crawl_sitemap', handler, definition);
+}

--- a/src/tools/crawl.ts
+++ b/src/tools/crawl.ts
@@ -1,0 +1,183 @@
+/**
+ * Crawl Tool - Recursive link-following web crawler with depth/scope controls.
+ * Server-side BFS execution eliminates LLM round-trips per page.
+ * @see https://github.com/shaun0927/openchrome/issues/576
+ */
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
+import { getSessionManager } from '../session-manager';
+import { MAX_OUTPUT_CHARS } from '../config/defaults';
+import { withTimeout } from '../utils/with-timeout';
+import {
+  normalizeUrl, matchesScope, passesFilters, discoverLinks,
+  CrawlTracker, parseRobotsTxt, isAllowedByRobots, RobotsRules,
+} from '../utils/crawl-utils';
+
+const definition: MCPToolDefinition = {
+  name: 'crawl',
+  description: 'Recursively crawl a website by following links. Server-side execution — no LLM round-trip per page.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      url: { type: 'string', description: 'Starting URL to crawl from' },
+      max_depth: { type: 'number', description: 'Maximum link-following depth. Default: 2' },
+      max_pages: { type: 'number', description: 'Maximum total pages to visit. Default: 20' },
+      scope: { type: 'string', description: 'URL glob pattern to stay within. Default: same origin.' },
+      include_patterns: { type: 'array', items: { type: 'string' }, description: 'URL glob patterns to include' },
+      exclude_patterns: { type: 'array', items: { type: 'string' }, description: 'URL glob patterns to skip' },
+      output_format: { type: 'string', enum: ['markdown', 'text', 'structured'], description: 'Content format. Default: markdown' },
+      respect_robots: { type: 'boolean', description: 'Respect robots.txt. Default: true' },
+      delay_ms: { type: 'number', description: 'Delay between requests in ms. Default: 1000' },
+      concurrency: { type: 'number', description: 'Max concurrent fetches. Default: 3' },
+    },
+    required: ['url'],
+  },
+};
+
+interface CrawlPageResult {
+  url: string; title: string; content: string; depth: number; links_found: number; error?: string;
+}
+interface InternalCrawlResult extends CrawlPageResult { discoveredLinks: string[]; }
+
+function createLimiter(concurrency: number) {
+  let active = 0;
+  const queue: Array<() => void> = [];
+  return async function <T>(fn: () => Promise<T>): Promise<T> {
+    if (active >= concurrency) await new Promise<void>((resolve) => queue.push(resolve));
+    active++;
+    try { return await fn(); }
+    finally { active--; if (queue.length > 0) queue.shift()!(); }
+  };
+}
+
+async function crawlSinglePage(
+  sessionId: string, url: string, depth: number, outputFormat: string, context?: ToolContext,
+): Promise<InternalCrawlResult> {
+  const sessionManager = getSessionManager();
+  let targetId: string | null = null;
+  try {
+    const { targetId: tid, page } = await sessionManager.createTarget(sessionId, url);
+    targetId = tid;
+    await new Promise((r) => setTimeout(r, 500));
+    const extracted = await withTimeout(
+      page.evaluate((fmt: string) => {
+        const title = document.title || '';
+        const html = document.body?.innerHTML || '';
+        let content: string;
+        if (fmt === 'text') { content = document.body?.innerText || ''; }
+        else {
+          const body = document.body;
+          if (!body) { content = ''; }
+          else {
+            const parts: string[] = [];
+            body.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
+              parts.push(`${'#'.repeat(parseInt(h.tagName[1]))} ${h.textContent?.trim()}`);
+            });
+            parts.push(body.innerText || '');
+            content = parts.join('\n\n');
+          }
+        }
+        return { title, content, html };
+      }, outputFormat), 15000, 'crawl.extract', context,
+    );
+    await sessionManager.closeTarget(sessionId, tid);
+    targetId = null;
+    let content = extracted.content;
+    if (content.length > MAX_OUTPUT_CHARS) content = content.slice(0, MAX_OUTPUT_CHARS) + '...[truncated]';
+    const discoveredLinks = discoverLinks(extracted.html, url);
+    return { url, title: extracted.title, content, depth, links_found: discoveredLinks.length, discoveredLinks };
+  } catch (err) {
+    if (targetId) { try { await sessionManager.closeTarget(sessionId, targetId); } catch { /* ignore */ } }
+    return { url, title: '', content: '', depth, links_found: 0, error: err instanceof Error ? err.message : String(err), discoveredLinks: [] };
+  }
+}
+
+async function fetchRobotsTxt(sessionId: string, origin: string, context?: ToolContext): Promise<RobotsRules | null> {
+  const sessionManager = getSessionManager();
+  let targetId: string | null = null;
+  try {
+    const { targetId: tid, page } = await sessionManager.createTarget(sessionId, `${origin}/robots.txt`);
+    targetId = tid;
+    await new Promise((r) => setTimeout(r, 500));
+    const text = await withTimeout(page.evaluate(() => document.body?.innerText || ''), 5000, 'crawl.robots', context);
+    await sessionManager.closeTarget(sessionId, tid); targetId = null;
+    if (!text || text.includes('404') || text.includes('Not Found')) return null;
+    return parseRobotsTxt(text);
+  } catch {
+    if (targetId) { try { await sessionManager.closeTarget(sessionId, targetId); } catch { /* ignore */ } }
+    return null;
+  }
+}
+
+const handler: ToolHandler = async (sessionId: string, args: Record<string, unknown>, context?: ToolContext): Promise<MCPResult> => {
+  const url = args.url as string;
+  if (!url) return { content: [{ type: 'text', text: 'Error: url is required' }], isError: true };
+
+  const maxDepth = args.max_depth != null ? Number(args.max_depth) : 2;
+  const maxPages = args.max_pages != null ? Number(args.max_pages) : 20;
+  const outputFormat = (args.output_format as string) || 'markdown';
+  const respectRobots = args.respect_robots !== false;
+  const delayMs = args.delay_ms != null ? Number(args.delay_ms) : 1000;
+  const concurrency = args.concurrency != null ? Number(args.concurrency) : 3;
+
+  let scope = args.scope as string | undefined;
+  if (!scope) {
+    try { scope = `${new URL(url).origin}/**`; }
+    catch { return { content: [{ type: 'text', text: `Error: Invalid URL: ${url}` }], isError: true }; }
+  }
+  const includePatterns = args.include_patterns as string[] | undefined;
+  const excludePatterns = args.exclude_patterns as string[] | undefined;
+
+  if (maxDepth < 0 || maxDepth > 10) return { content: [{ type: 'text', text: 'Error: max_depth must be between 0 and 10' }], isError: true };
+  if (maxPages < 1 || maxPages > 100) return { content: [{ type: 'text', text: 'Error: max_pages must be between 1 and 100' }], isError: true };
+
+  const startTime = Date.now();
+  const tracker = new CrawlTracker();
+  const results: CrawlPageResult[] = [];
+  const limiter = createLimiter(concurrency);
+
+  let robotsRules: RobotsRules | null = null;
+  if (respectRobots) { try { robotsRules = await fetchRobotsTxt(sessionId, new URL(url).origin, context); } catch { /* continue */ } }
+
+  tracker.enqueue([{ url: normalizeUrl(url), depth: 0 }]);
+
+  while (results.length < maxPages) {
+    if (context && !hasBudget(context, 15_000)) { console.error('[crawl] Budget exhausted'); break; }
+    const next = tracker.dequeue();
+    if (!next) break;
+    const { url: currentUrl, depth: currentDepth } = next;
+    if (currentDepth > maxDepth) continue;
+    if (!matchesScope(currentUrl, scope)) continue;
+    if (!passesFilters(currentUrl, includePatterns, excludePatterns)) continue;
+    if (robotsRules) {
+      try { if (!isAllowedByRobots(new URL(currentUrl).pathname, robotsRules)) { console.error(`[crawl] Blocked by robots.txt: ${currentUrl}`); continue; } }
+      catch { continue; }
+    }
+    if (!tracker.visit(currentUrl)) continue;
+    const internalResult = await limiter(() => crawlSinglePage(sessionId, currentUrl, currentDepth, outputFormat, context));
+    if (currentDepth < maxDepth && !internalResult.error) {
+      tracker.enqueue(internalResult.discoveredLinks.map((link) => ({ url: link, depth: currentDepth + 1 })));
+    }
+    const { discoveredLinks: _, ...pageResult } = internalResult;
+    results.push(pageResult);
+    if (delayMs > 0 && results.length < maxPages) await new Promise((r) => setTimeout(r, delayMs));
+  }
+
+  const durationMs = Date.now() - startTime;
+  const output = {
+    summary: {
+      total_pages: results.length,
+      succeeded: results.filter((r) => !r.error).length,
+      failed: results.filter((r) => r.error).length,
+      max_depth_reached: Math.max(0, ...results.map((r) => r.depth)),
+      duration_ms: durationMs,
+      scope,
+    },
+    pages: results,
+  };
+  return { content: [{ type: 'text', text: JSON.stringify(output, null, 2) }] };
+};
+
+export function registerCrawlTool(server: MCPServer): void {
+  server.registerTool('crawl', handler, definition);
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -74,6 +74,10 @@ import { registerCheckpointTool } from './checkpoint';
 // Web AI host connection tools (#523)
 import { registerConnectTools } from './connect';
 
+// Crawl tools (#576)
+import { registerCrawlTool } from './crawl';
+import { registerCrawlSitemapTool } from './crawl-sitemap';
+
 export function registerAllTools(server: MCPServer): void {
   // Core browser tools
   registerNavigateTool(server);
@@ -151,6 +155,10 @@ export function registerAllTools(server: MCPServer): void {
 
   // Web AI host connection tools (#523)
   registerConnectTools(server);
+
+  // Crawl tools (#576)
+  registerCrawlTool(server);
+  registerCrawlSitemapTool(server);
 
   console.error(`[Tools] Registered ${server.getToolNames().length} tools`);
 }

--- a/src/utils/crawl-utils.ts
+++ b/src/utils/crawl-utils.ts
@@ -1,0 +1,235 @@
+/**
+ * Crawl Utilities - URL normalization, scope matching, link discovery,
+ * robots.txt parsing, and sitemap XML parsing for web crawling tools.
+ *
+ * @see https://github.com/shaun0927/openchrome/issues/576
+ */
+
+// ---------------------------------------------------------------------------
+// URL Normalization
+// ---------------------------------------------------------------------------
+
+export function normalizeUrl(raw: string): string {
+  try {
+    const url = new URL(raw);
+    url.hash = '';
+    const params = Array.from(url.searchParams.entries());
+    params.sort(([a], [b]) => a.localeCompare(b));
+    url.search = '';
+    for (const [key, value] of params) {
+      url.searchParams.append(key, value);
+    }
+    let result = url.toString();
+    if (result.endsWith('/') && url.pathname !== '/') {
+      result = result.slice(0, -1);
+    }
+    return result;
+  } catch {
+    return raw;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scope Matching
+// ---------------------------------------------------------------------------
+
+export function urlGlobToRegex(pattern: string): RegExp {
+  let escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  escaped = escaped.replace(/\*\*/g, '___DOUBLESTAR___');
+  escaped = escaped.replace(/\*/g, '[^/]*');
+  escaped = escaped.replace(/___DOUBLESTAR___/g, '.*');
+  escaped = escaped.replace(/\?/g, '.');
+  return new RegExp(`^${escaped}$`);
+}
+
+export function matchesScope(url: string, scopePattern: string): boolean {
+  return urlGlobToRegex(scopePattern).test(url);
+}
+
+export function passesFilters(
+  url: string,
+  includePatterns?: string[],
+  excludePatterns?: string[],
+): boolean {
+  if (excludePatterns && excludePatterns.length > 0) {
+    for (const pattern of excludePatterns) {
+      if (matchesScope(url, pattern)) return false;
+    }
+  }
+  if (includePatterns && includePatterns.length > 0) {
+    for (const pattern of includePatterns) {
+      if (matchesScope(url, pattern)) return true;
+    }
+    return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Link Discovery
+// ---------------------------------------------------------------------------
+
+export function discoverLinks(html: string, baseUrl: string): string[] {
+  const seen = new Set<string>();
+  const results: string[] = [];
+  const hrefRegex = /<a\s[^>]*href\s*=\s*["']([^"']+)["'][^>]*>/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = hrefRegex.exec(html)) !== null) {
+    const href = match[1];
+    if (!href) continue;
+    if (
+      href.startsWith('javascript:') ||
+      href.startsWith('mailto:') ||
+      href.startsWith('tel:') ||
+      href.startsWith('data:') ||
+      href.startsWith('#')
+    ) continue;
+    try {
+      const resolved = new URL(href, baseUrl).toString();
+      const normalized = normalizeUrl(resolved);
+      if (!seen.has(normalized)) {
+        seen.add(normalized);
+        results.push(normalized);
+      }
+    } catch {
+      // skip malformed
+    }
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Robots.txt Parser
+// ---------------------------------------------------------------------------
+
+export interface RobotsRules {
+  disallow: string[];
+  allow: string[];
+  sitemaps: string[];
+  crawlDelay?: number;
+}
+
+export function parseRobotsTxt(robotsTxt: string, userAgent = '*'): RobotsRules {
+  const result: RobotsRules = { disallow: [], allow: [], sitemaps: [] };
+  const lines = robotsTxt.split('\n').map((l) => l.trim());
+  let currentAgents: string[] = [];
+  let isRelevant = false;
+  let foundSpecific = false;
+  let inDirectiveBlock = false;
+  const wildcardRules: RobotsRules = { disallow: [], allow: [], sitemaps: [] };
+
+  for (const line of lines) {
+    if (line.startsWith('#') || line === '') continue;
+    // Strip inline comments (e.g., "Disallow: /path # comment")
+    const commentIdx = line.indexOf(' #');
+    const cleanLine = commentIdx >= 0 ? line.slice(0, commentIdx).trim() : line;
+    const sitemapMatch = cleanLine.match(/^sitemap:\s*(.+)$/i);
+    if (sitemapMatch) { result.sitemaps.push(sitemapMatch[1].trim()); continue; }
+    const uaMatch = cleanLine.match(/^user-agent:\s*(.+)$/i);
+    if (uaMatch) {
+      const agent = uaMatch[1].trim().toLowerCase();
+      if (foundSpecific && inDirectiveBlock) break;
+      if (inDirectiveBlock) { currentAgents = []; isRelevant = false; inDirectiveBlock = false; }
+      currentAgents.push(agent);
+      if (agent === userAgent.toLowerCase()) { isRelevant = true; foundSpecific = true; }
+      else if (agent === '*') { isRelevant = true; }
+      continue;
+    }
+    inDirectiveBlock = true;
+    if (currentAgents.length > 0 && isRelevant) {
+      const target = foundSpecific && currentAgents.includes(userAgent.toLowerCase())
+        ? result : currentAgents.includes('*') ? wildcardRules : null;
+      if (target) {
+        const disallowMatch = cleanLine.match(/^disallow:\s*(.*)$/i);
+        if (disallowMatch) { const p = disallowMatch[1].trim(); if (p) target.disallow.push(p); }
+        const allowMatch = cleanLine.match(/^allow:\s*(.*)$/i);
+        if (allowMatch) { const p = allowMatch[1].trim(); if (p) target.allow.push(p); }
+        const delayMatch = cleanLine.match(/^crawl-delay:\s*(\d+\.?\d*)$/i);
+        if (delayMatch) target.crawlDelay = parseFloat(delayMatch[1]);
+      }
+    }
+  }
+  if (!foundSpecific) {
+    result.disallow = wildcardRules.disallow;
+    result.allow = wildcardRules.allow;
+    if (wildcardRules.crawlDelay !== undefined) result.crawlDelay = wildcardRules.crawlDelay;
+  }
+  return result;
+}
+
+export function isAllowedByRobots(urlPath: string, rules: RobotsRules): boolean {
+  for (const a of rules.allow) { if (urlPath.startsWith(a)) return true; }
+  for (const d of rules.disallow) { if (urlPath.startsWith(d)) return false; }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Sitemap XML Parser
+// ---------------------------------------------------------------------------
+
+export interface SitemapUrl { loc: string; lastmod?: string; changefreq?: string; priority?: number; }
+export interface SitemapParseResult { urls: SitemapUrl[]; sitemapIndexUrls: string[]; isSitemapIndex: boolean; }
+
+export function parseSitemapXml(xml: string): SitemapParseResult {
+  const result: SitemapParseResult = { urls: [], sitemapIndexUrls: [], isSitemapIndex: false };
+  if (xml.includes('<sitemapindex') || xml.includes(':sitemapindex')) {
+    result.isSitemapIndex = true;
+    const re = /<(?:\w+:)?sitemap[^>]*>([\s\S]*?)<\/(?:\w+:)?sitemap>/gi;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(xml)) !== null) {
+      const loc = m[1].match(/<(?:\w+:)?loc[^>]*>\s*([\s\S]*?)\s*<\/(?:\w+:)?loc>/i);
+      if (loc) result.sitemapIndexUrls.push(loc[1].trim());
+    }
+  } else {
+    const re = /<(?:\w+:)?url[^>]*>([\s\S]*?)<\/(?:\w+:)?url>/gi;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(xml)) !== null) {
+      const block = m[1];
+      const loc = block.match(/<(?:\w+:)?loc[^>]*>\s*([\s\S]*?)\s*<\/(?:\w+:)?loc>/i);
+      if (!loc) continue;
+      const entry: SitemapUrl = { loc: loc[1].trim() };
+      const lm = block.match(/<(?:\w+:)?lastmod[^>]*>\s*([\s\S]*?)\s*<\/(?:\w+:)?lastmod>/i);
+      if (lm) entry.lastmod = lm[1].trim();
+      const cf = block.match(/<(?:\w+:)?changefreq[^>]*>\s*([\s\S]*?)\s*<\/(?:\w+:)?changefreq>/i);
+      if (cf) entry.changefreq = cf[1].trim();
+      const pr = block.match(/<(?:\w+:)?priority[^>]*>\s*([\s\S]*?)\s*<\/(?:\w+:)?priority>/i);
+      if (pr) { const p = parseFloat(pr[1].trim()); if (!isNaN(p)) entry.priority = p; }
+      result.urls.push(entry);
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Crawl State Tracker
+// ---------------------------------------------------------------------------
+
+export class CrawlTracker {
+  private visited = new Set<string>();
+  private pending: Array<{ url: string; depth: number }> = [];
+
+  visit(url: string): boolean {
+    const n = normalizeUrl(url);
+    if (this.visited.has(n)) return false;
+    this.visited.add(n);
+    return true;
+  }
+  hasVisited(url: string): boolean { return this.visited.has(normalizeUrl(url)); }
+  enqueue(urls: Array<{ url: string; depth: number }>): void {
+    for (const e of urls) {
+      const n = normalizeUrl(e.url);
+      if (!this.visited.has(n)) this.pending.push({ url: n, depth: e.depth });
+    }
+  }
+  dequeue(): { url: string; depth: number } | undefined {
+    while (this.pending.length > 0) {
+      const next = this.pending.shift()!;
+      if (!this.visited.has(next.url)) return next;
+    }
+    return undefined;
+  }
+  get visitedCount(): number { return this.visited.size; }
+  get pendingCount(): number { return this.pending.length; }
+  getVisitedUrls(): string[] { return Array.from(this.visited); }
+}

--- a/tests/cross-env/cursor-verification.test.ts
+++ b/tests/cross-env/cursor-verification.test.ts
@@ -197,6 +197,7 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
         'emulate_device', 'page_pdf', 'page_screenshot', 'page_content',
         'console_capture', 'performance_metrics', 'file_upload',
         'batch_execute', 'batch_paginate',
+        'crawl', 'crawl_sitemap',
       ];
       for (const tool of expectedTier2) {
         expect(toolNames).toContain(tool);
@@ -233,8 +234,8 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
         expect(toolNames).toContain(tool);
       }
 
-      // Total should be 54 (30 T1 + 15 T2 + 9 T3)
-      expect(toolNames.length).toBe(54);
+      // Total should be 56 (30 T1 + 17 T2 + 9 T3)
+      expect(toolNames.length).toBe(56);
     });
 
     test('resources/list returns usage guide resource', async () => {
@@ -290,6 +291,7 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
       'emulate_device', 'page_pdf', 'page_screenshot', 'page_content',
       'console_capture', 'performance_metrics', 'file_upload',
       'batch_execute', 'batch_paginate',
+        'crawl', 'crawl_sitemap',
     ];
     tier2Tools.forEach(tool => {
       test(`Tier 2: ${tool} registered`, () => {
@@ -412,8 +414,8 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
 
       // Should NOT have expand_tools (progressive disclosure disabled)
       expect(toolNames).not.toContain('expand_tools');
-      // Total should be 54 (30 T1 + 15 T2 + 9 T3)
-      expect(toolNames.length).toBe(54);
+      // Total should be 56 (30 T1 + 17 T2 + 9 T3)
+      expect(toolNames.length).toBe(56);
     });
   });
 });

--- a/tests/utils/crawl-utils.test.ts
+++ b/tests/utils/crawl-utils.test.ts
@@ -1,0 +1,365 @@
+/// <reference types="jest" />
+
+import {
+  normalizeUrl,
+  urlGlobToRegex,
+  matchesScope,
+  passesFilters,
+  discoverLinks,
+  parseRobotsTxt,
+  isAllowedByRobots,
+  parseSitemapXml,
+  CrawlTracker,
+} from '../../src/utils/crawl-utils';
+
+// ─── normalizeUrl ─────────────────────────────────────────────────────────────
+
+describe('normalizeUrl', () => {
+  test('removes fragment', () => {
+    expect(normalizeUrl('https://example.com/page#section')).toBe('https://example.com/page');
+  });
+
+  test('removes trailing slash (non-root)', () => {
+    expect(normalizeUrl('https://example.com/page/')).toBe('https://example.com/page');
+  });
+
+  test('preserves root slash', () => {
+    expect(normalizeUrl('https://example.com/')).toBe('https://example.com/');
+  });
+
+  test('sorts query params', () => {
+    expect(normalizeUrl('https://example.com/?z=1&a=2')).toBe('https://example.com/?a=2&z=1');
+  });
+
+  test('lowercases scheme and host', () => {
+    expect(normalizeUrl('HTTPS://Example.COM/Path')).toBe('https://example.com/Path');
+  });
+
+  test('returns raw string for invalid URLs', () => {
+    expect(normalizeUrl('not-a-url')).toBe('not-a-url');
+  });
+});
+
+// ─── urlGlobToRegex / matchesScope ───────────────────────────────────────────
+
+describe('urlGlobToRegex', () => {
+  test('** matches path with slashes', () => {
+    const re = urlGlobToRegex('https://example.com/**');
+    expect(re.test('https://example.com/foo/bar/baz')).toBe(true);
+  });
+
+  test('* does not match slash', () => {
+    const re = urlGlobToRegex('https://example.com/docs/*');
+    expect(re.test('https://example.com/docs/page')).toBe(true);
+    expect(re.test('https://example.com/docs/a/b')).toBe(false);
+  });
+
+  test('escapes regex special chars in pattern', () => {
+    const re = urlGlobToRegex('https://example.com/page.html');
+    expect(re.test('https://example.com/pageXhtml')).toBe(false);
+    expect(re.test('https://example.com/page.html')).toBe(true);
+  });
+
+  test('exact match', () => {
+    const re = urlGlobToRegex('https://example.com/about');
+    expect(re.test('https://example.com/about')).toBe(true);
+    expect(re.test('https://example.com/about/team')).toBe(false);
+  });
+});
+
+describe('matchesScope', () => {
+  test('** scope matches deep paths', () => {
+    expect(matchesScope('https://docs.example.com/api/v1/endpoint', 'https://docs.example.com/**')).toBe(true);
+  });
+
+  test('* scope matches single segment', () => {
+    expect(matchesScope('https://example.com/docs/page', 'https://example.com/docs/*')).toBe(true);
+    expect(matchesScope('https://example.com/docs/a/b', 'https://example.com/docs/*')).toBe(false);
+  });
+
+  test('non-matching scope returns false', () => {
+    expect(matchesScope('https://other.com/page', 'https://example.com/**')).toBe(false);
+  });
+});
+
+// ─── passesFilters ───────────────────────────────────────────────────────────
+
+describe('passesFilters', () => {
+  test('no filters: always passes', () => {
+    expect(passesFilters('https://example.com/any')).toBe(true);
+  });
+
+  test('include only: passes when matching', () => {
+    expect(passesFilters('https://example.com/docs/page', ['https://example.com/docs/**'])).toBe(true);
+  });
+
+  test('include only: fails when not matching', () => {
+    expect(passesFilters('https://example.com/blog/post', ['https://example.com/docs/**'])).toBe(false);
+  });
+
+  test('exclude only: fails when matching', () => {
+    expect(passesFilters('https://example.com/admin/panel', undefined, ['https://example.com/admin/**'])).toBe(false);
+  });
+
+  test('exclude only: passes when not matching', () => {
+    expect(passesFilters('https://example.com/docs/page', undefined, ['https://example.com/admin/**'])).toBe(true);
+  });
+
+  test('exclude takes priority over include', () => {
+    expect(passesFilters(
+      'https://example.com/docs/secret',
+      ['https://example.com/docs/**'],
+      ['https://example.com/docs/secret*'],
+    )).toBe(false);
+  });
+
+  test('both filters: passes when include matches and exclude does not', () => {
+    expect(passesFilters(
+      'https://example.com/docs/public',
+      ['https://example.com/docs/**'],
+      ['https://example.com/docs/secret*'],
+    )).toBe(true);
+  });
+});
+
+// ─── discoverLinks ───────────────────────────────────────────────────────────
+
+describe('discoverLinks', () => {
+  test('extracts basic href links', () => {
+    const html = '<a href="https://example.com/page">link</a>';
+    expect(discoverLinks(html, 'https://example.com')).toContain('https://example.com/page');
+  });
+
+  test('resolves relative URLs against baseUrl', () => {
+    const html = '<a href="/about">about</a>';
+    const links = discoverLinks(html, 'https://example.com/page');
+    expect(links).toContain('https://example.com/about');
+  });
+
+  test('skips javascript: hrefs', () => {
+    const html = '<a href="javascript:void(0)">click</a>';
+    expect(discoverLinks(html, 'https://example.com')).toHaveLength(0);
+  });
+
+  test('skips mailto: hrefs', () => {
+    const html = '<a href="mailto:test@example.com">email</a>';
+    expect(discoverLinks(html, 'https://example.com')).toHaveLength(0);
+  });
+
+  test('skips tel: hrefs', () => {
+    const html = '<a href="tel:+1234567890">call</a>';
+    expect(discoverLinks(html, 'https://example.com')).toHaveLength(0);
+  });
+
+  test('skips fragment-only hrefs', () => {
+    const html = '<a href="#section">anchor</a>';
+    expect(discoverLinks(html, 'https://example.com')).toHaveLength(0);
+  });
+
+  test('deduplicates normalized URLs', () => {
+    const html = '<a href="/page">1</a><a href="/page/">2</a>';
+    const links = discoverLinks(html, 'https://example.com');
+    expect(links).toHaveLength(1);
+  });
+
+  test('returns empty array for empty HTML', () => {
+    expect(discoverLinks('', 'https://example.com')).toHaveLength(0);
+  });
+
+  test('skips malformed URLs gracefully', () => {
+    const html = '<a href="http://[invalid">bad</a><a href="/good">good</a>';
+    const links = discoverLinks(html, 'https://example.com');
+    expect(links).toContain('https://example.com/good');
+    expect(links).toHaveLength(1);
+  });
+});
+
+// ─── parseRobotsTxt ──────────────────────────────────────────────────────────
+
+describe('parseRobotsTxt', () => {
+  test('parses disallow rules for wildcard agent', () => {
+    const txt = 'User-agent: *\nDisallow: /admin\n';
+    const rules = parseRobotsTxt(txt);
+    expect(rules.disallow).toContain('/admin');
+  });
+
+  test('parses allow rules', () => {
+    const txt = 'User-agent: *\nAllow: /public\nDisallow: /\n';
+    const rules = parseRobotsTxt(txt);
+    expect(rules.allow).toContain('/public');
+    expect(rules.disallow).toContain('/');
+  });
+
+  test('parses crawl-delay', () => {
+    const txt = 'User-agent: *\nCrawl-delay: 2\n';
+    const rules = parseRobotsTxt(txt);
+    expect(rules.crawlDelay).toBe(2);
+  });
+
+  test('parses sitemap directives', () => {
+    const txt = 'Sitemap: https://example.com/sitemap.xml\n';
+    const rules = parseRobotsTxt(txt);
+    expect(rules.sitemaps).toContain('https://example.com/sitemap.xml');
+  });
+
+  test('uses specific user-agent block when available', () => {
+    const txt = [
+      'User-agent: *',
+      'Disallow: /general',
+      '',
+      'User-agent: mybot',
+      'Disallow: /specific',
+    ].join('\n');
+    const rules = parseRobotsTxt(txt, 'mybot');
+    expect(rules.disallow).toContain('/specific');
+    expect(rules.disallow).not.toContain('/general');
+  });
+
+  test('falls back to wildcard when specific agent not found', () => {
+    const txt = 'User-agent: *\nDisallow: /fallback\n';
+    const rules = parseRobotsTxt(txt, 'unknownbot');
+    expect(rules.disallow).toContain('/fallback');
+  });
+
+  test('strips comments from lines', () => {
+    const txt = 'User-agent: * # all bots\nDisallow: /secret # keep out\n';
+    const rules = parseRobotsTxt(txt);
+    expect(rules.disallow).toContain('/secret');
+  });
+
+  test('returns empty rules for empty input', () => {
+    const rules = parseRobotsTxt('');
+    expect(rules.disallow).toHaveLength(0);
+    expect(rules.allow).toHaveLength(0);
+    expect(rules.sitemaps).toHaveLength(0);
+  });
+});
+
+// ─── isAllowedByRobots ───────────────────────────────────────────────────────
+
+describe('isAllowedByRobots', () => {
+  test('allow takes precedence over disallow', () => {
+    const rules = { disallow: ['/docs'], allow: ['/docs/public'], sitemaps: [] };
+    expect(isAllowedByRobots('/docs/public/page', rules)).toBe(true);
+  });
+
+  test('disallowed path returns false', () => {
+    const rules = { disallow: ['/admin'], allow: [], sitemaps: [] };
+    expect(isAllowedByRobots('/admin/panel', rules)).toBe(false);
+  });
+
+  test('allowed when no matching rules', () => {
+    const rules = { disallow: ['/private'], allow: [], sitemaps: [] };
+    expect(isAllowedByRobots('/public/page', rules)).toBe(true);
+  });
+
+  test('allowed when rules are empty', () => {
+    const rules = { disallow: [], allow: [], sitemaps: [] };
+    expect(isAllowedByRobots('/anything', rules)).toBe(true);
+  });
+});
+
+// ─── parseSitemapXml ─────────────────────────────────────────────────────────
+
+describe('parseSitemapXml', () => {
+  test('parses regular sitemap with urls', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/page1</loc></url>
+  <url><loc>https://example.com/page2</loc></url>
+</urlset>`;
+    const result = parseSitemapXml(xml);
+    expect(result.isSitemapIndex).toBe(false);
+    expect(result.urls).toHaveLength(2);
+    expect(result.urls[0].loc).toBe('https://example.com/page1');
+  });
+
+  test('parses sitemap index', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://example.com/sitemap1.xml</loc></sitemap>
+  <sitemap><loc>https://example.com/sitemap2.xml</loc></sitemap>
+</sitemapindex>`;
+    const result = parseSitemapXml(xml);
+    expect(result.isSitemapIndex).toBe(true);
+    expect(result.sitemapIndexUrls).toHaveLength(2);
+    expect(result.sitemapIndexUrls[0]).toBe('https://example.com/sitemap1.xml');
+  });
+
+  test('parses priority, lastmod, and changefreq', () => {
+    const xml = `<urlset>
+  <url>
+    <loc>https://example.com/</loc>
+    <lastmod>2024-01-01</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>`;
+    const result = parseSitemapXml(xml);
+    expect(result.urls[0].lastmod).toBe('2024-01-01');
+    expect(result.urls[0].changefreq).toBe('daily');
+    expect(result.urls[0].priority).toBe(1.0);
+  });
+
+  test('handles namespaced tags', () => {
+    const xml = `<ns:urlset>
+  <ns:url><ns:loc>https://example.com/ns-page</ns:loc></ns:url>
+</ns:urlset>`;
+    const result = parseSitemapXml(xml);
+    expect(result.urls).toHaveLength(1);
+    expect(result.urls[0].loc).toBe('https://example.com/ns-page');
+  });
+});
+
+// ─── CrawlTracker ────────────────────────────────────────────────────────────
+
+describe('CrawlTracker', () => {
+  test('visit marks URL as visited', () => {
+    const tracker = new CrawlTracker();
+    tracker.visit('https://example.com/page');
+    expect(tracker.hasVisited('https://example.com/page')).toBe(true);
+  });
+
+  test('hasVisited returns false for unvisited URLs', () => {
+    const tracker = new CrawlTracker();
+    expect(tracker.hasVisited('https://example.com/new')).toBe(false);
+  });
+
+  test('visit deduplication: visitedCount increments once per URL', () => {
+    const tracker = new CrawlTracker();
+    tracker.visit('https://example.com/page');
+    tracker.visit('https://example.com/page');
+    expect(tracker.visitedCount).toBe(1);
+  });
+
+  test('enqueue/dequeue is FIFO', () => {
+    const tracker = new CrawlTracker();
+    tracker.enqueue([{ url: 'https://example.com/a', depth: 0 }, { url: 'https://example.com/b', depth: 0 }, { url: 'https://example.com/c', depth: 0 }]);
+    expect(tracker.dequeue()?.url).toBe('https://example.com/a');
+    expect(tracker.dequeue()?.url).toBe('https://example.com/b');
+    expect(tracker.dequeue()?.url).toBe('https://example.com/c');
+  });
+
+  test('enqueue skips already visited URLs', () => {
+    const tracker = new CrawlTracker();
+    tracker.visit('https://example.com/visited');
+    tracker.enqueue([{ url: 'https://example.com/visited', depth: 0 }, { url: 'https://example.com/new', depth: 0 }]);
+    expect(tracker.pendingCount).toBe(1);
+    expect(tracker.dequeue()?.url).toBe('https://example.com/new');
+  });
+
+  test('dequeue returns undefined when empty', () => {
+    const tracker = new CrawlTracker();
+    expect(tracker.dequeue()).toBeUndefined();
+  });
+
+  test('getVisitedUrls returns all visited URLs', () => {
+    const tracker = new CrawlTracker();
+    tracker.visit('https://example.com/a');
+    tracker.visit('https://example.com/b');
+    const visited = tracker.getVisitedUrls();
+    expect(visited).toContain('https://example.com/a');
+    expect(visited).toContain('https://example.com/b');
+    expect(visited).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Consolidates PRs #579, #592, #596, #597 into a single clean implementation that adds web crawling as first-class MCP tools.

**Why consolidate?** The 4 original PRs all targeted `develop` independently and duplicated `crawl-utils.ts` across every branch. Only the first merge would succeed — the remaining 3 would have merge conflicts. This PR resolves that structural issue.

### Changes
- **`src/utils/crawl-utils.ts`** — URL normalization, glob scope matching, link discovery, robots.txt parser (with inline comment stripping, proper user-agent block handling), sitemap XML parser (with namespace support), BFS CrawlTracker
- **`src/tools/crawl.ts`** — Recursive BFS web crawler: configurable depth/page limits, scope constraints, include/exclude URL patterns, robots.txt compliance, concurrency control
- **`src/tools/crawl-sitemap.ts`** — Sitemap-based crawler: auto-discovers sitemaps (robots.txt → /sitemap.xml → /sitemap_index.xml), sitemap index recursion (up to 2 levels), URL glob filtering, concurrent page fetching
- **`src/tools/index.ts`** / **`src/config/tool-tiers.ts`** — Both tools registered at Tier 2
- **`tests/utils/crawl-utils.test.ts`** — 52 unit tests covering all crawl-utils exports
- **`tests/cross-env/cursor-verification.test.ts`** — Tool count updated (54 → 56)

### Fixes over original PRs
- **robots.txt parser bug**: `currentAgents` array was never reset between agent blocks — consecutive `User-agent:` lines in a grouped block would cause early `break`. Fixed with `inDirectiveBlock` tracking.
- **Inline comment stripping**: `Disallow: /path # comment` now correctly strips the `# comment` part
- **Namespace support**: Sitemap XML parser now handles `<ns:url>`, `<ns:loc>` etc.
- **No spurious whitespace changes** to `tool-tiers.ts`
- **No code duplication** of `crawl-utils.ts` across branches

### Supersedes
- #579 (crawl-utils)
- #592 (crawl tool)
- #596 (crawl_sitemap tool)
- #597 (crawl-utils tests)

## Test plan
- [x] `npm run build` — zero errors
- [x] `npx jest --no-coverage` — 2732 passed, 0 failed (143 suites)
- [x] crawl-utils unit tests — 52 passed
- [x] cursor-verification — tool count correctly updated to 56

🤖 Generated with [Claude Code](https://claude.com/claude-code)