### PR TITLE
fix(cookies): restore cookie bridge in server mode for cross-tab auth

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -1288,7 +1288,7 @@ export class CDPClient {
 
       // Copy cookies from an authenticated page (skip for pool pre-warming to avoid
       // CDP session conflicts and unnecessary overhead on about:blank pages).
-      // Also skip when server mode sets skipCookieBridge globally.
+      // The global skipCookieBridge flag serves as a manual override escape hatch.
       // Overall timeout prevents cascading hangs from unresponsive source tabs.
       if (!skipCookieBridge && !getGlobalConfig().skipCookieBridge) {
         const authPageTargetId = await this.findAuthenticatedPageTargetId(targetDomain);

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,10 +130,8 @@ program
       console.error(`[openchrome] Restart Chrome mode: enabled (will quit existing Chrome)`);
     }
 
-    // Apply server mode config (skip cookie bridge)
-    if (options.serverMode) {
-      setGlobalConfig({ skipCookieBridge: true });
-    }
+    // Server mode: cookie bridge remains active for normal page creation.
+    // Pool pre-warming passes skipCookieBridge per-call to avoid CDP conflicts.
 
     // Configure hybrid mode if enabled
     const hybrid = options.hybrid || false;


### PR DESCRIPTION
## Summary

Fixes #606 — Root Cause C: `skipCookieBridge` was set globally in server mode, breaking cross-tab cookie inheritance.

- Previously, `--server-mode` called `setGlobalConfig({ skipCookieBridge: true })`, which disabled cookie bridging for **all** page creations in the process
- This meant tab 2 could not inherit session cookies from an authenticated tab 1, even within the same session
- The skip was only ever needed for **pool pre-warming** (creating blank `about:blank` pages) to avoid CDP session conflicts — not for normal page creation

## Root Cause C

`CDPConnectionPool.createNewPage()` already passes `skipCookieBridge: true` explicitly as the third argument to `createPage()`:

```typescript
const page = await this.cdpClient.createPage(undefined, undefined, true); // pool pre-warming
```

So the global flag in server mode was redundant for pool pre-warming and harmful for normal page creation. Removing it restores cookie bridging for user-initiated tab creation while pool pre-warming continues to skip it per-call.

## Changes

- `src/index.ts`: Removed `setGlobalConfig({ skipCookieBridge: true })` from server mode startup
- `src/cdp/client.ts`: Updated stale comment to reflect that the global flag is a manual override escape hatch, not set automatically by server mode

## Test plan

- [ ] Build passes: `npm run build`
- [ ] Cookie/pool tests pass: `npm test -- --testPathPattern="cookie|connection-pool"`
- [ ] In server mode, authenticate in tab 1 — tab 2 should inherit those cookies on navigation
- [ ] Pool pre-warming still skips cookie bridging (no CDP session conflicts on `about:blank`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)