### PR TITLE
fix(profile): stable headless-shell profile directory for cookie persistence

### DIFF
--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -416,6 +416,8 @@ export class ChromeLauncher {
       console.error(`[ChromeLauncher] Using real Chrome profile: ${userDataDir}`);
     } else if (profileType === 'temp') {
       console.error(`[ChromeLauncher] Using temp profile: ${userDataDir}`);
+    } else if (profileType === 'headless-shell') {
+      console.error(`[ChromeLauncher] Using stable headless-shell profile: ${userDataDir}`);
     } else {
       console.error(`[ChromeLauncher] Using explicit profile: ${userDataDir}`);
     }

--- a/src/chrome/profile-manager.ts
+++ b/src/chrome/profile-manager.ts
@@ -15,7 +15,7 @@ import { execFileSync } from 'child_process';
 // Types
 // ---------------------------------------------------------------------------
 
-export type ProfileType = 'real' | 'persistent' | 'temp' | 'explicit';
+export type ProfileType = 'real' | 'persistent' | 'temp' | 'explicit' | 'headless-shell';
 
 export interface SyncMetadata {
   lastSyncTimestamp: number;
@@ -467,12 +467,22 @@ export class ProfileManager {
       };
     }
 
-    // 2. Temp profile requested or headless-shell (no profile support)
-    if (useTempProfile || usingHeadlessShell) {
+    // 2. Temp profile or headless-shell
+    if (useTempProfile) {
       const tempDir = path.join(os.tmpdir(), `openchrome-${Date.now()}`);
       return {
         userDataDir: tempDir,
         profileType: 'temp',
+        syncPerformed: false,
+        ...(profileDirectory && { profileDirectory }),
+      };
+    }
+
+    if (usingHeadlessShell) {
+      const stableDir = path.join(os.homedir(), '.openchrome', 'headless-shell-profile');
+      return {
+        userDataDir: stableDir,
+        profileType: 'headless-shell',
         syncPerformed: false,
         ...(profileDirectory && { profileDirectory }),
       };

--- a/tests/chrome/persistent-profile.test.ts
+++ b/tests/chrome/persistent-profile.test.ts
@@ -478,7 +478,7 @@ describe('ProfileManager', () => {
       expect(result.syncPerformed).toBe(false);
     });
 
-    it('should return temp profile when usingHeadlessShell is true', () => {
+    it('should return stable headless-shell profile when usingHeadlessShell is true', () => {
       const manager = new ProfileManager();
       const result = manager.resolveProfile({
         realProfileDir: '/some/chrome/profile',
@@ -486,7 +486,8 @@ describe('ProfileManager', () => {
         usingHeadlessShell: true,
       });
 
-      expect(result.profileType).toBe('temp');
+      expect(result.profileType).toBe('headless-shell');
+      expect(result.userDataDir).toContain('headless-shell-profile');
       expect(result.syncPerformed).toBe(false);
     });
 


### PR DESCRIPTION
## Summary

Fixes issue #606 Root Cause A: when `--headless-shell` is used, `profile-manager.ts` was creating a new ephemeral temp directory (`openchrome-<Date.now()>`) on every launch, destroying all cookies between restarts.

## Root Cause (A)

`resolveProfile()` previously handled `useTempProfile` and `usingHeadlessShell` in a single branch, giving both an ephemeral `os.tmpdir()/openchrome-<Date.now()>` path. Since `Date.now()` changes every launch, headless-shell sessions had no persistent storage for cookies, auth tokens, or session state.

## Fix

- Split the combined branch into two separate cases in `resolveProfile()`
- `useTempProfile` continues to use an ephemeral `os.tmpdir()/openchrome-<Date.now()>` path (intentional)
- `usingHeadlessShell` now uses a stable path: `~/.openchrome/headless-shell-profile` via `os.homedir()` (Windows-compatible)
- Added a new `'headless-shell'` value to `ProfileType` to make the distinction explicit
- Added a matching log message in `launcher.ts` for the new profile type
- Updated the test that previously expected `profileType === 'temp'` for headless-shell to now expect `profileType === 'headless-shell'` and verify the stable path

## Test plan

- [x] `tests/chrome/persistent-profile.test.ts` — all 47 tests pass, including updated headless-shell test
- [x] `tests/chrome/launcher-launch.test.ts` — all 9 tests pass
- [x] Build: `npm run build` exits cleanly (zero TypeScript errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)