### PR TITLE
fix(persistence): force-save cookie state on graceful shutdown

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -538,9 +538,20 @@ program
       tabHealthMonitor.stopAll();
       eventLoopMonitor.stop();
       diskMonitor?.stop();
-      stateManager.stop();
       chromeProcessMonitor.stop();
       await healthEndpoint.stop();
+
+      // Force-save storage state before exit to preserve cookies across restarts
+      try {
+        await Promise.race([
+          sessionManager.saveAllStorageState(),
+          new Promise<void>((resolve) => setTimeout(resolve, 5000)),
+        ]);
+      } catch (err) {
+        console.error(`[openchrome] Storage state save on shutdown failed (non-fatal): ${err}`);
+      }
+
+      stateManager.stop();
       sessionPersistence.cancelPendingSave();
       await originalShutdown(signal);
     };

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -1670,6 +1670,35 @@ export class SessionManager {
   }
 
   /**
+   * Force-save storage state for all active sessions.
+   * Called during graceful shutdown to preserve cookies across restarts.
+   */
+  async saveAllStorageState(): Promise<void> {
+    if (!this.storageStateConfig?.enabled) return;
+
+    for (const [sessionId, session] of this.sessions) {
+      const manager = this.storageStateManagers.get(sessionId);
+      if (!manager) continue;
+
+      try {
+        for (const worker of session.workers.values()) {
+          for (const tid of worker.targets) {
+            const cdpClient = this.getCDPClientForWorker(sessionId, worker.id);
+            const p = await cdpClient.getPageByTargetId(tid);
+            if (p) {
+              await manager.save(p, cdpClient, this.getStorageStatePath(sessionId));
+              console.error(`[SessionManager] Storage state saved for session ${sessionId} on shutdown`);
+              break;
+            }
+          }
+        }
+      } catch (err) {
+        console.error(`[SessionManager] Storage state save failed for session ${sessionId} (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  }
+
+  /**
    * Get the storage state file path for a session
    */
   private getStorageStatePath(sessionId: string): string {


### PR DESCRIPTION
## Summary

- Add `saveAllStorageState()` method to `SessionManager` that iterates all active sessions and saves their storage state via CDP `Network.getAllCookies`
- Wire it into the `enhancedShutdown` handler in `src/index.ts` with a 5-second timeout to prevent hanging shutdown
- Ensures cookies are persisted before process exit on SIGTERM/SIGINT

## Problem

The `StorageStateManager` watchdog timer uses `.unref()`, meaning it does not prevent Node.js process exit. If the MCP server is killed (SIGTERM/SIGINT), the final periodic save may not have completed, causing cookie/session loss across restarts.

This is the compounding factor from #606 — even when the persistent profile correctly stores cookies, the storage state backup (which serves as a safety net for headless-shell and cross-session restoration) was not guaranteed to be written on exit.

## Changes

| File | Change |
|------|--------|
| `src/session-manager.ts` | Added `saveAllStorageState()` — iterates all sessions with active `StorageStateManager`, finds a page per session, calls `manager.save()` |
| `src/index.ts` | Call `saveAllStorageState()` in `enhancedShutdown` before stopping `stateManager`, with 5s timeout |

## Test plan

- [x] `npm run build` — clean (zero TypeScript errors)
- [x] `npm test` — 170 suites passed, 3191 tests pass
- [ ] Manual: launch with `--auto-launch`, authenticate to a site, send SIGTERM, verify storage state JSON exists in `~/.openchrome/storage-state/`
- [ ] Manual: restart after SIGTERM, verify cookies are restored on first target creation

Closes #606 (compounding factor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)