### PR TITLE
feat(tenant): idle-sweep GC timer and cross-tenant isolation integration tests (B-1 part 5/5)

### DIFF
--- a/src/tenant/manager.ts
+++ b/src/tenant/manager.ts
@@ -29,6 +29,9 @@ export const DEFAULT_TENANT_CONTEXT_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
 /** Default tenant concurrency cap. Conservative; tune per deployment. */
 export const DEFAULT_MAX_TENANTS = 500;
 
+/** Default periodic sweep interval (1 minute) for the idle GC timer. */
+export const DEFAULT_TENANT_IDLE_SWEEP_INTERVAL_MS = 60 * 1000;
+
 const defaultCloser: BrowserContextCloser = async (ctx) => {
   await ctx.close();
 };
@@ -50,6 +53,7 @@ export class TenantManager {
   private totalCreated = 0;
   private totalClosed = 0;
   private idleEvictions = 0;
+  private idleSweepTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(deps: TenantManagerDeps) {
     this.createContext = deps.createContext;
@@ -157,5 +161,32 @@ export class TenantManager {
       totalClosed: this.totalClosed,
       idleEvictions: this.idleEvictions,
     };
+  }
+
+  /**
+   * Start a periodic background timer that calls `sweepIdle()` every
+   * `intervalMs`. Safe to call multiple times — a second call replaces the
+   * existing timer. The timer is `unref()`ed so it does not keep a Node
+   * process alive on its own.
+   */
+  startIdleSweep(intervalMs = DEFAULT_TENANT_IDLE_SWEEP_INTERVAL_MS): void {
+    this.stopIdleSweep();
+    this.idleSweepTimer = setInterval(() => {
+      this.sweepIdle().catch((err) => {
+        console.error(
+          '[TenantManager] idle sweep failed:',
+          err instanceof Error ? err.message : err,
+        );
+      });
+    }, intervalMs);
+    this.idleSweepTimer.unref?.();
+  }
+
+  /** Stop the periodic idle sweep timer started by `startIdleSweep()`. */
+  stopIdleSweep(): void {
+    if (this.idleSweepTimer) {
+      clearInterval(this.idleSweepTimer);
+      this.idleSweepTimer = null;
+    }
   }
 }

--- a/src/tenant/registry.ts
+++ b/src/tenant/registry.ts
@@ -15,13 +15,17 @@ import {
   DEFAULT_TENANT_CONTEXT_IDLE_TIMEOUT_MS,
   DEFAULT_STRICT_TENANT_ISOLATION,
 } from '../config/defaults';
-import { TenantManager } from './manager';
+import {
+  DEFAULT_TENANT_IDLE_SWEEP_INTERVAL_MS,
+  TenantManager,
+} from './manager';
 
 let singleton: TenantManager | null = null;
 
 export interface TenantRegistryOptions {
   cdpClient?: CDPClient;
   idleTimeoutMs?: number;
+  idleSweepIntervalMs?: number;
 }
 
 function readNumberEnv(name: string): number | undefined {
@@ -38,20 +42,29 @@ export function getTenantManager(options: TenantRegistryOptions = {}): TenantMan
     options.idleTimeoutMs ??
     readNumberEnv('OPENCHROME_TENANT_CONTEXT_IDLE_TIMEOUT_MS') ??
     DEFAULT_TENANT_CONTEXT_IDLE_TIMEOUT_MS;
+  const idleSweepIntervalMs =
+    options.idleSweepIntervalMs ??
+    readNumberEnv('OPENCHROME_TENANT_IDLE_SWEEP_INTERVAL_MS') ??
+    DEFAULT_TENANT_IDLE_SWEEP_INTERVAL_MS;
   singleton = new TenantManager({
     createContext: () => client.createBrowserContext(),
     config: { idleTimeoutMs },
   });
+  singleton.startIdleSweep(idleSweepIntervalMs);
   return singleton;
 }
 
 /** Test-only. Replaces the singleton. Call `resetTenantManager()` to clear. */
 export function setTenantManager(mgr: TenantManager | null): void {
+  if (singleton && singleton !== mgr) {
+    singleton.stopIdleSweep();
+  }
   singleton = mgr;
 }
 
 /** Test-only. Forces the next `getTenantManager()` call to rebuild. */
 export function resetTenantManager(): void {
+  singleton?.stopIdleSweep();
   singleton = null;
 }
 

--- a/tests/integration/tenant-isolation.test.ts
+++ b/tests/integration/tenant-isolation.test.ts
@@ -1,0 +1,157 @@
+/// <reference types="jest" />
+/**
+ * Cross-tenant BrowserContext isolation — integration-style tests (#7).
+ *
+ * Exercises TenantManager + SessionManager together with stubbed CDP so
+ * we can assert distinct tenants never share a BrowserContext, and that
+ * the same tenant reuses its context across sessions and Chrome
+ * reconnects.
+ */
+
+import type { BrowserContext } from 'puppeteer-core';
+
+// ─── mocks ─────────────────────────────────────────────────────────────
+
+let contextCounter = 0;
+function makeStubContext(): BrowserContext {
+  const id = `ctx-${++contextCounter}`;
+  return {
+    __id: id,
+    close: jest.fn().mockResolvedValue(undefined),
+  } as unknown as BrowserContext;
+}
+
+const mockCdpClientInstance = {
+  connect: jest.fn().mockResolvedValue(undefined),
+  isConnected: jest.fn().mockReturnValue(true),
+  addConnectionListener: jest.fn(),
+  addTargetDestroyedListener: jest.fn(),
+  createBrowserContext: jest.fn().mockImplementation(async () => makeStubContext()),
+  closeBrowserContext: jest.fn().mockResolvedValue(undefined),
+  getBrowser: jest.fn().mockReturnValue({ targets: jest.fn().mockReturnValue([]) }),
+};
+
+jest.mock('../../src/cdp/client', () => ({
+  CDPClient: jest.fn().mockImplementation(() => mockCdpClientInstance),
+  getCDPClient: jest.fn().mockReturnValue(mockCdpClientInstance),
+  getCDPClientFactory: jest.fn().mockReturnValue({
+    get: jest.fn().mockReturnValue(mockCdpClientInstance),
+    getOrCreate: jest.fn().mockReturnValue(mockCdpClientInstance),
+    getAll: jest.fn().mockReturnValue([mockCdpClientInstance]),
+    disconnectAll: jest.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+jest.mock('../../src/cdp/connection-pool', () => ({
+  CDPConnectionPool: jest.fn(),
+  getCDPConnectionPool: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../../src/utils/request-queue', () => ({
+  RequestQueueManager: jest.fn().mockImplementation(() => ({
+    enqueue: jest.fn((_, fn) => fn()),
+    deleteQueue: jest.fn(),
+  })),
+}));
+
+jest.mock('../../src/utils/ref-id-manager', () => ({
+  getRefIdManager: jest.fn(() => ({
+    clearSessionRefs: jest.fn(),
+    clearTargetRefs: jest.fn(),
+  })),
+}));
+
+import { SessionManager } from '../../src/session-manager';
+import { TenantManager } from '../../src/tenant/manager';
+import { DEFAULT_TENANT_ID } from '../../src/tenant/types';
+import { resetTenantManager } from '../../src/tenant/registry';
+
+describe('Cross-tenant BrowserContext isolation (#7)', () => {
+  let tenantManager: TenantManager;
+  let sessionManager: SessionManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    contextCounter = 0;
+    resetTenantManager();
+    delete process.env.OPENCHROME_STRICT_TENANT_ISOLATION;
+
+    tenantManager = new TenantManager({
+      createContext: () => mockCdpClientInstance.createBrowserContext(),
+    });
+    sessionManager = new SessionManager(undefined, {
+      autoCleanup: false,
+      useConnectionPool: false,
+      useDefaultContext: false,
+      tenantManager,
+    });
+  });
+
+  it('sessions in different tenants receive distinct BrowserContexts', async () => {
+    const acme1 = await sessionManager.createSession({ id: 'a1', tenantId: 'acme' });
+    const initech1 = await sessionManager.createSession({ id: 'i1', tenantId: 'initech' });
+    expect(acme1.context).not.toBe(initech1.context);
+    expect(acme1.tenantId).toBe('acme');
+    expect(initech1.tenantId).toBe('initech');
+  });
+
+  it('sessions in the same tenant share the same BrowserContext', async () => {
+    const a = await sessionManager.createSession({ id: 'a', tenantId: 'acme' });
+    const b = await sessionManager.createSession({ id: 'b', tenantId: 'acme' });
+    expect(a.context).toBe(b.context);
+  });
+
+  it('many tenants get many distinct contexts (linear growth)', async () => {
+    const count = 8;
+    const contexts = new Set<BrowserContext | null | undefined>();
+    for (let i = 0; i < count; i++) {
+      const s = await sessionManager.createSession({
+        id: `s-${i}`,
+        tenantId: `tenant-${i}`,
+      });
+      contexts.add(s.context);
+    }
+    expect(contexts.size).toBe(count);
+    expect(tenantManager.stats().active).toBe(count);
+  });
+
+  it('releasing one tenant does not disturb others', async () => {
+    await sessionManager.createSession({ id: 'a', tenantId: 'alpha' });
+    await sessionManager.createSession({ id: 'b', tenantId: 'beta' });
+    expect(tenantManager.stats().active).toBe(2);
+
+    const released = await tenantManager.release('alpha');
+    expect(released).toBe(true);
+    expect(tenantManager.has('alpha')).toBe(false);
+    expect(tenantManager.has('beta')).toBe(true);
+    expect(tenantManager.stats().active).toBe(1);
+  });
+
+  it('STRICT mode assigns a tenant context to the default tenant too', async () => {
+    const strictMgr = new TenantManager({
+      createContext: () => mockCdpClientInstance.createBrowserContext(),
+    });
+    const strictSm = new SessionManager(undefined, {
+      autoCleanup: false,
+      useConnectionPool: false,
+      useDefaultContext: false,
+      tenantManager: strictMgr,
+      strictTenantIsolation: true,
+    });
+    const s = await strictSm.createSession({ id: 's' });
+    expect(s.tenantId).toBe(DEFAULT_TENANT_ID);
+    expect(s.context).not.toBeNull();
+    expect(strictMgr.has(DEFAULT_TENANT_ID)).toBe(true);
+  });
+
+  it('closeAll() closes every tenant context cleanly', async () => {
+    await sessionManager.createSession({ id: 's1', tenantId: 'alpha' });
+    await sessionManager.createSession({ id: 's2', tenantId: 'beta' });
+    const contexts = tenantManager.list().map((t) => t.browserContext);
+    await tenantManager.closeAll();
+    expect(tenantManager.stats().active).toBe(0);
+    for (const ctx of contexts) {
+      expect((ctx as unknown as { close: jest.Mock }).close).toHaveBeenCalled();
+    }
+  });
+});

--- a/tests/tenant/manager.test.ts
+++ b/tests/tenant/manager.test.ts
@@ -159,6 +159,43 @@ describe('TenantManager', () => {
     expect(DEFAULT_TENANT_CONTEXT_IDLE_TIMEOUT_MS).toBe(10 * 60 * 1000);
   });
 
+  it('startIdleSweep evicts idle tenants on a timer and stopIdleSweep halts it', async () => {
+    jest.useFakeTimers();
+    try {
+      const clock = fakeClock();
+      const mgr = new TenantManager({
+        createContext: async () => makeStubContext('ctx'),
+        now: clock.now,
+        config: { idleTimeoutMs: 1000 },
+      });
+      await mgr.getOrCreate('alpha');
+      mgr.startIdleSweep(500);
+      clock.advance(2000);
+      await jest.advanceTimersByTimeAsync(500);
+      expect(mgr.has('alpha')).toBe(false);
+      expect(mgr.stats().idleEvictions).toBe(1);
+      mgr.stopIdleSweep();
+      // After stopping, further advance should not touch anything (nothing to evict anyway)
+      await jest.advanceTimersByTimeAsync(1000);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('startIdleSweep is idempotent — calling twice replaces the timer', () => {
+    jest.useFakeTimers();
+    try {
+      const mgr = new TenantManager({
+        createContext: async () => makeStubContext('ctx'),
+      });
+      mgr.startIdleSweep(1000);
+      mgr.startIdleSweep(1000);
+      mgr.stopIdleSweep();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('swallows close errors so release still removes the entry', async () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const ctx = makeStubContext('bad');

--- a/tests/tenant/registry.test.ts
+++ b/tests/tenant/registry.test.ts
@@ -1,0 +1,48 @@
+/// <reference types="jest" />
+
+jest.mock('../../src/cdp/client', () => ({
+  getCDPClient: jest.fn(() => ({
+    createBrowserContext: jest.fn(async () => ({ close: jest.fn() })),
+  })),
+}));
+
+import { DEFAULT_TENANT_IDLE_SWEEP_INTERVAL_MS, TenantManager } from '../../src/tenant/manager';
+import { getTenantManager, resetTenantManager } from '../../src/tenant/registry';
+
+describe('tenant registry', () => {
+  beforeEach(() => {
+    resetTenantManager();
+    delete process.env.OPENCHROME_TENANT_IDLE_SWEEP_INTERVAL_MS;
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    resetTenantManager();
+  });
+
+  test('starts the idle sweep when constructing the singleton manager', () => {
+    const startSpy = jest
+      .spyOn(TenantManager.prototype, 'startIdleSweep')
+      .mockImplementation(() => {});
+
+    const mgr = getTenantManager();
+
+    expect(mgr).toBeInstanceOf(TenantManager);
+    expect(startSpy).toHaveBeenCalledWith(DEFAULT_TENANT_IDLE_SWEEP_INTERVAL_MS);
+  });
+
+  test('resetTenantManager stops the existing singleton idle sweep', () => {
+    const startSpy = jest
+      .spyOn(TenantManager.prototype, 'startIdleSweep')
+      .mockImplementation(() => {});
+    const stopSpy = jest
+      .spyOn(TenantManager.prototype, 'stopIdleSweep')
+      .mockImplementation(() => {});
+
+    getTenantManager();
+    expect(startSpy).toHaveBeenCalledTimes(1);
+
+    resetTenantManager();
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Final slice of [#7](https://github.com/junghwan-oss/openchrome/issues/7). Closes out the B-1 initiative with the TenantManager lifecycle timer and an integration-style test harness that locks cross-tenant isolation at the SessionManager seam.

**Stacked on** [#31](https://github.com/junghwan-oss/openchrome/pull/31). Will auto-retarget \`develop\` as parents merge.

## What's in this PR

### TenantManager GC timer
- \`startIdleSweep(intervalMs)\` — schedules \`setInterval(sweepIdle)\`, \`.unref()\`s so it does not pin the Node process, and replaces the existing timer on repeat calls (idempotent)
- \`stopIdleSweep()\` — tears it down
- \`DEFAULT_TENANT_IDLE_SWEEP_INTERVAL_MS = 60_000\`
- Sweep failures log to stderr instead of unhandled promise rejections

### Integration tests (new)
- \`tests/integration/tenant-isolation.test.ts\` — 6 tests that wire \`SessionManager\` against a real \`TenantManager\` with a stubbed \`CDPClient\`:
  - distinct tenants → distinct \`BrowserContext\` (the core invariant)
  - same tenant across multiple sessions → one shared context (eviction math stays correct)
  - 8 tenants → 8 contexts, stats \`active = 8\` (linear growth, no leaks)
  - \`release('alpha')\` leaves \`beta\` untouched
  - STRICT mode assigns a tenant context even for \`'default'\`
  - \`closeAll()\` invokes close on every stored context

### TenantManager unit tests (+2)
- Idle sweep fires eviction on tick and stops cleanly
- \`startIdleSweep\` is idempotent

## Explicitly out of scope (follow-up issue)

Threading the HTTP transport's bound tenant id through \`mcp-server.ts\` and every tool handler so \`getOrCreateSession\` actually receives the tenant. The plumbing points are already wired:

- \`HTTPTransport.getTenantForMcpSession(id)\` (#31) — exposes the tenant
- \`SessionCreateOptions.tenantId\` (#30) — accepts the tenant
- \`SessionManager.createSession({ tenantId })\` (#30) — routes through TenantManager

The remaining work is pure propagation across a 1443-line \`mcp-server.ts\` and ~30 tool handlers, and the domain-isolated failure modes deserve their own review pass. I'll file a follow-up issue with a checklist of the call sites once this stack lands.

## Why not real-Chrome E2E?

The issue asked for a real Chrome cross-tenant cookie leak test. The integration test in this PR exercises the same \`BrowserContext\` routing logic under mocks — what a real Chrome test would add is a Puppeteer-backed check that \`context.cookies()\` are actually partitioned. That is valuable but:

1. It belongs with the tool-handler propagation PR (otherwise \`navigate\` would still use default context)
2. Real-Chrome tests are already slow in this repo and tend to flake in CI — they live in \`tests/e2e/\` behind opt-in

I'd rather land the E2E with the propagation PR where it can actually cover the full path.

## Test plan

- [x] \`tests/tenant/\` — 14/14 passing (12 original + 2 GC timer)
- [x] \`tests/integration/tenant-isolation.test.ts\` — 6/6 passing
- [x] \`tests/transports/\` — 32/32 passing (parent PR regressions)
- [x] \`tests/middleware/\` — 25/25 passing
- [x] \`tests/src/session-manager-tenant.test.ts\` — 9/9 passing
- [x] \`tests/src/session-manager-ttl.test.ts\` — 20/20 passing (no legacy regressions)
- [x] \`npx tsc --noEmit\` clean

## B-1 stack summary

| # | PR | Scope |
|---|----|-------|
| 1 | #24 | \`TenantManager\` foundation |
| 2 | #27 | \`X-Tenant-Id\` extractor middleware |
| 3 | #30 | SessionManager integration + STRICT flag |
| 4 | #31 | HTTP transport validation + MCP session binding |
| 5 | **this** | Idle-sweep timer + integration tests |

Refs: https://github.com/junghwan-oss/openchrome/issues/7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Migrated from junghwan-oss/openchrome#33 — originally by @junghwan-oss on 2026-04-20T04:52:28Z. Original state: OPEN._