### PR TITLE
feat(auth): admin CLI + JWT/OAuth verifier (issue #9, PR 3/4)

### DIFF
--- a/cli/admin-keys.ts
+++ b/cli/admin-keys.ts
@@ -1,0 +1,282 @@
+/**
+ * Admin CLI for tenant API key management (issue #9 / PR3).
+ *
+ * Subcommands under `openchrome admin keys`:
+ *   - create  — issue a new key and print the plaintext ONCE to stdout
+ *   - list    — table (default) or JSON of ApiKey metadata (never plaintext)
+ *   - revoke  — mark a key revoked
+ *   - rotate  — revoke and reissue (same tenant + scopes)
+ *
+ * Admin auth: the env var OPENCHROME_ADMIN_TOKEN must be set and non-empty.
+ * The token is a CLI-local gate only — it is NEVER written to disk or
+ * injected into the API key store. If unset we abort with exit code 1.
+ *
+ * Output contract:
+ *   - stdout: plaintext key (create/rotate) or JSON (list --json) only
+ *   - stderr: diagnostics, tables, warnings, errors
+ *
+ * Designed so `openchrome admin keys create ... --json | jq` (future-proof)
+ * and `openchrome admin keys list --json | jq` work cleanly with pipes.
+ */
+
+import { Command } from 'commander';
+
+// Types mirrored from src/auth/api-key-types.ts so the CLI tsconfig (rootDir=./cli)
+// can compile without depending on the src tree directly. Runtime resolves the
+// real ApiKeyStore via require() against dist/auth/api-key-store.js.
+type Scope = 'read' | 'write' | 'admin' | 'headless-only';
+
+interface ApiKey {
+  keyId: string;
+  keyHash: string;
+  tenantId: string;
+  scopes: Scope[];
+  createdAt: number;
+  expiresAt?: number;
+  revokedAt?: number;
+  lastUsedAt?: number;
+  description: string;
+}
+
+interface ApiKeyCreateResult {
+  record: ApiKey;
+  plaintext: string;
+}
+
+interface ApiKeyStoreInstance {
+  create(input: { tenantId: string; scopes: Scope[]; description: string; expiresAt?: number }): Promise<ApiKeyCreateResult>;
+  list(): Promise<ApiKey[]>;
+  revoke(keyId: string): Promise<boolean>;
+  rotate(keyId: string): Promise<ApiKeyCreateResult>;
+}
+
+interface ApiKeyStoreCtor {
+  open(storePath?: string): Promise<ApiKeyStoreInstance>;
+}
+
+const VALID_SCOPES: ReadonlySet<Scope> = new Set<Scope>([
+  'read',
+  'write',
+  'admin',
+  'headless-only',
+]);
+
+function requireAdminToken(): void {
+  const token = process.env.OPENCHROME_ADMIN_TOKEN;
+  if (typeof token !== 'string' || token.length === 0) {
+    console.error('Error: OPENCHROME_ADMIN_TOKEN environment variable must be set.');
+    console.error('       Export a non-empty admin token before running admin commands.');
+    process.exit(1);
+  }
+}
+
+// Exported so tests can inject a local store. Default resolution walks the
+// candidate locations: when running from dist/cli (the shipped bin) the store
+// lives at ../auth/api-key-store; when running from ts-jest against the src
+// tree it lives at ../src/auth/api-key-store relative to this file's dirname.
+export function defaultLoadStore(): ApiKeyStoreCtor {
+  const candidates = ['../auth/api-key-store', '../src/auth/api-key-store'];
+  let lastErr: unknown;
+  for (const spec of candidates) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const mod = require(spec) as { ApiKeyStore: ApiKeyStoreCtor };
+      if (mod && mod.ApiKeyStore) return mod.ApiKeyStore;
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw new Error(
+    `Unable to load ApiKeyStore from any candidate path: ${lastErr instanceof Error ? lastErr.message : String(lastErr)}`,
+  );
+}
+
+let loadStore: () => ApiKeyStoreCtor = defaultLoadStore;
+
+/** Test hook: override the ApiKeyStore loader. */
+export function _setStoreLoader(loader: () => ApiKeyStoreCtor): void {
+  loadStore = loader;
+}
+
+function coerceScopes(values: string[] | undefined): Scope[] {
+  if (!values || values.length === 0) {
+    console.error('Error: at least one --scope is required (read|write|admin|headless-only).');
+    process.exit(1);
+  }
+  const out: Scope[] = [];
+  for (const v of values) {
+    if (!VALID_SCOPES.has(v as Scope)) {
+      console.error(`Error: invalid scope "${v}". Allowed: read, write, admin, headless-only.`);
+      process.exit(1);
+    }
+    if (!out.includes(v as Scope)) out.push(v as Scope);
+  }
+  return out;
+}
+
+function formatTimestamp(ts: number | undefined): string {
+  if (typeof ts !== 'number' || !Number.isFinite(ts)) return '-';
+  try {
+    return new Date(ts).toISOString();
+  } catch {
+    return '-';
+  }
+}
+
+function printTable(rows: ApiKey[]): void {
+  const headers = ['keyId', 'tenantId', 'scopes', 'createdAt', 'expiresAt', 'revokedAt', 'lastUsedAt'] as const;
+  const data: string[][] = rows.map((r) => [
+    r.keyId,
+    r.tenantId,
+    r.scopes.join(','),
+    formatTimestamp(r.createdAt),
+    formatTimestamp(r.expiresAt),
+    formatTimestamp(r.revokedAt),
+    formatTimestamp(r.lastUsedAt),
+  ]);
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...data.map((row) => row[i].length)),
+  );
+  const headerLine = headers.map((h, i) => h.padEnd(widths[i])).join('  ');
+  const sepLine = widths.map((w) => '-'.repeat(w)).join('  ');
+  console.error(headerLine);
+  console.error(sepLine);
+  for (const row of data) {
+    console.error(row.map((cell, i) => cell.padEnd(widths[i])).join('  '));
+  }
+}
+
+export function registerAdminKeysCommand(program: Command): void {
+  const admin = program
+    .command('admin')
+    .description('Admin commands (requires OPENCHROME_ADMIN_TOKEN env var)');
+
+  const keys = admin.command('keys').description('Manage tenant API keys');
+
+  keys
+    .command('create')
+    .description('Create a new API key for a tenant')
+    .requiredOption('--tenant <id>', 'Tenant identifier (e.g. acme)')
+    .option(
+      '--scope <scope>',
+      'Scope (read|write|admin|headless-only). Repeat for multiple.',
+      (value: string, previous: string[] | undefined) => {
+        const arr = previous ?? [];
+        arr.push(value);
+        return arr;
+      },
+      [] as string[],
+    )
+    .option('--description <text>', 'Human-readable description', '')
+    .option('--expires-in <days>', 'Expiry in days from now (integer > 0)')
+    .action(async (options: {
+      tenant: string;
+      scope: string[];
+      description: string;
+      expiresIn?: string;
+    }) => {
+      requireAdminToken();
+      const scopes = coerceScopes(options.scope);
+      let expiresAt: number | undefined;
+      if (options.expiresIn !== undefined) {
+        const days = Number.parseInt(options.expiresIn, 10);
+        if (!Number.isFinite(days) || days <= 0) {
+          console.error('Error: --expires-in must be a positive integer number of days.');
+          process.exit(1);
+        }
+        expiresAt = Date.now() + days * 24 * 60 * 60 * 1000;
+      }
+      try {
+        const Store = loadStore();
+        const store = await Store.open();
+        const result = await store.create({
+          tenantId: options.tenant,
+          scopes,
+          description: options.description,
+          expiresAt,
+        });
+        console.error('SAVE THIS KEY NOW. It will never be shown again.');
+        // Plaintext goes to stdout on its own line so pipes work cleanly.
+        process.stdout.write(result.plaintext + '\n');
+        console.error(`keyId: ${result.record.keyId}`);
+        console.error(`tenant: ${result.record.tenantId}`);
+        console.error(`scopes: ${result.record.scopes.join(',')}`);
+        if (result.record.expiresAt) {
+          console.error(`expires: ${formatTimestamp(result.record.expiresAt)}`);
+        }
+      } catch (err) {
+        console.error(`Error creating key: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+    });
+
+  keys
+    .command('list')
+    .description('List API keys (never shows plaintext)')
+    .option('--tenant <id>', 'Filter by tenant')
+    .option('--json', 'Emit JSON array to stdout instead of a table')
+    .action(async (options: { tenant?: string; json?: boolean }) => {
+      requireAdminToken();
+      try {
+        const Store = loadStore();
+        const store = await Store.open();
+        let records = await store.list();
+        if (options.tenant) {
+          records = records.filter((r) => r.tenantId === options.tenant);
+        }
+        if (options.json) {
+          process.stdout.write(JSON.stringify(records) + '\n');
+          return;
+        }
+        if (records.length === 0) {
+          console.error('No API keys found.');
+          return;
+        }
+        printTable(records);
+      } catch (err) {
+        console.error(`Error listing keys: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+    });
+
+  keys
+    .command('revoke <keyId>')
+    .description('Revoke an API key by keyId')
+    .action(async (keyId: string) => {
+      requireAdminToken();
+      try {
+        const Store = loadStore();
+        const store = await Store.open();
+        const ok = await store.revoke(keyId);
+        if (!ok) {
+          console.error(`Error: unknown keyId "${keyId}".`);
+          process.exit(1);
+        }
+        console.error(`Revoked ${keyId}.`);
+      } catch (err) {
+        console.error(`Error revoking key: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+    });
+
+  keys
+    .command('rotate <keyId>')
+    .description('Revoke an existing key and issue a new one for the same tenant + scopes')
+    .action(async (keyId: string) => {
+      requireAdminToken();
+      try {
+        const Store = loadStore();
+        const store = await Store.open();
+        const result = await store.rotate(keyId);
+        console.error('SAVE THIS KEY NOW. It will never be shown again.');
+        process.stdout.write(result.plaintext + '\n');
+        console.error(`oldKeyId: ${keyId}`);
+        console.error(`newKeyId: ${result.record.keyId}`);
+        console.error(`tenant: ${result.record.tenantId}`);
+        console.error(`scopes: ${result.record.scopes.join(',')}`);
+      } catch (err) {
+        console.error(`Error rotating key: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+    });
+}

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -40,6 +40,7 @@ import {
   totpSecondsRemaining,
   validateBase32,
 } from './totp-store';
+import { registerAdminKeysCommand } from './admin-keys';
 
 const program = new Command();
 
@@ -1242,5 +1243,8 @@ totp
       process.exit(1);
     }
   });
+
+// Admin CLI — tenant API key management (issue #9 / PR3).
+registerAdminKeysCommand(program);
 
 program.parse();

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "argon2": "^0.44.0",
         "commander": "^12.0.0",
+        "jose": "^5.10.0",
         "proper-lockfile": "^4.1.2",
         "puppeteer-core": "npm:rebrowser-puppeteer-core@23.10.3",
         "uuid": "^9.0.0",
@@ -4542,6 +4543,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "argon2": "^0.44.0",
     "commander": "^12.0.0",
+    "jose": "^5.10.0",
     "proper-lockfile": "^4.1.2",
     "puppeteer-core": "npm:rebrowser-puppeteer-core@23.10.3",
     "uuid": "^9.0.0",

--- a/src/auth/api-key-store.ts
+++ b/src/auth/api-key-store.ts
@@ -102,7 +102,8 @@ export class ApiKeyStore {
   }
 
   static async open(storePath?: string): Promise<ApiKeyStore> {
-    const finalPath = storePath ?? defaultStorePath();
+    const envOverride = process.env.OPENCHROME_API_KEY_STORE_PATH;
+    const finalPath = storePath ?? (envOverride && envOverride.length > 0 ? envOverride : defaultStorePath());
     const dir = path.dirname(finalPath);
     await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
     // Tighten perms on existing dir (mkdir mode only applies on create).

--- a/src/auth/api-key-types.ts
+++ b/src/auth/api-key-types.ts
@@ -32,5 +32,5 @@ export interface Principal {
   tenantId: string;
   scopes: Scope[];
   keyId?: string;
-  mode: 'disabled' | 'legacy' | 'api-key';
+  mode: 'disabled' | 'legacy' | 'api-key' | 'jwt';
 }

--- a/src/auth/jwt-verifier.ts
+++ b/src/auth/jwt-verifier.ts
@@ -1,0 +1,85 @@
+// JWT / OAuth verifier for the HTTP auth middleware (issue #9 / PR3).
+//
+// Wraps `jose.createRemoteJWKSet` + `jose.jwtVerify` and maps verified
+// claims to the shared `Principal` shape. All failures (signature,
+// expiry, issuer/audience mismatch, missing tenant/scopes) collapse to
+// `null` so callers can treat them uniformly as 401.
+
+import * as jose from 'jose';
+import type { Principal, Scope } from './api-key-types';
+
+const VALID_SCOPES: ReadonlySet<Scope> = new Set<Scope>([
+  'read',
+  'write',
+  'admin',
+  'headless-only',
+]);
+
+export interface JwtConfig {
+  jwksUrl: string;
+  issuer?: string;
+  audience?: string;
+  tenantClaim?: string;
+  scopeClaim?: string;
+}
+
+export interface JwtVerifier {
+  verify(token: string): Promise<Principal | null>;
+}
+
+function parseScopes(raw: unknown): Scope[] {
+  let candidates: string[] = [];
+  if (typeof raw === 'string') {
+    candidates = raw.split(/\s+/).filter((s) => s.length > 0);
+  } else if (Array.isArray(raw)) {
+    candidates = raw.filter((x): x is string => typeof x === 'string');
+  } else {
+    return [];
+  }
+  const out: Scope[] = [];
+  for (const c of candidates) {
+    if (VALID_SCOPES.has(c as Scope) && !out.includes(c as Scope)) {
+      out.push(c as Scope);
+    }
+  }
+  return out;
+}
+
+export function createJwtVerifier(config: JwtConfig): JwtVerifier {
+  const jwks = jose.createRemoteJWKSet(new URL(config.jwksUrl));
+  const tenantClaim = config.tenantClaim ?? 'tenantId';
+  const scopeClaim = config.scopeClaim ?? 'scope';
+
+  return {
+    async verify(token: string): Promise<Principal | null> {
+      if (typeof token !== 'string' || token.length === 0) return null;
+      try {
+        const { payload, protectedHeader } = await jose.jwtVerify(token, jwks, {
+          issuer: config.issuer,
+          audience: config.audience,
+          algorithms: ['RS256'],
+        });
+
+        const tenantRaw = payload[tenantClaim] ?? payload.sub;
+        const tenantId = typeof tenantRaw === 'string' && tenantRaw.length > 0 ? tenantRaw : null;
+        if (!tenantId) return null;
+
+        const scopes = parseScopes(payload[scopeClaim]);
+        if (scopes.length === 0) return null;
+
+        const principal: Principal = {
+          tenantId,
+          scopes,
+          mode: 'jwt',
+        };
+        if (typeof protectedHeader.kid === 'string' && protectedHeader.kid.length > 0) {
+          principal.keyId = protectedHeader.kid;
+        }
+        return principal;
+      } catch {
+        // Intentionally swallow — never log raw token.
+        return null;
+      }
+    },
+  };
+}

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -10,13 +10,16 @@ import * as crypto from 'node:crypto';
 import type { IncomingMessage } from 'node:http';
 import type { ApiKeyStore } from '../auth/api-key-store';
 import type { Principal, Scope } from '../auth/api-key-types';
+import type { JwtVerifier } from '../auth/jwt-verifier';
 
 export type { Principal };
 
 export type AuthMode =
   | { kind: 'disabled' }
   | { kind: 'legacy-shared-token'; token: string }
-  | { kind: 'api-key'; store: ApiKeyStore };
+  | { kind: 'api-key'; store: ApiKeyStore }
+  | { kind: 'jwt'; verifier: JwtVerifier }
+  | { kind: 'api-key-or-jwt'; store: ApiKeyStore; verifier: JwtVerifier };
 
 export type AuthResult =
   | { ok: true; principal: Principal }
@@ -92,17 +95,32 @@ export async function authenticate(
     };
   }
 
-  // mode.kind === 'api-key'
+  if (mode.kind === 'api-key') {
+    return authenticateApiKey(token, mode.store);
+  }
+
+  if (mode.kind === 'jwt') {
+    return authenticateJwt(token, mode.verifier);
+  }
+
+  // mode.kind === 'api-key-or-jwt' — route by prefix.
+  if (token.startsWith(KEY_PREFIX)) {
+    return authenticateApiKey(token, mode.store);
+  }
+  return authenticateJwt(token, mode.verifier);
+}
+
+async function authenticateApiKey(token: string, store: ApiKeyStore): Promise<AuthResult> {
   if (!token.startsWith(KEY_PREFIX)) {
     return { ok: false, status: 401, error: 'Unauthorized' };
   }
   const attemptKeyId = computeKeyIdFromPlaintext(token);
-  const record = await mode.store.verify(token);
+  const record = await store.verify(token);
   if (!record) {
     return { ok: false, status: 401, error: 'Unauthorized', keyId: attemptKeyId };
   }
   // Fire-and-forget lastUsedAt update; failures must not block the request.
-  mode.store.touchLastUsed(record.keyId).catch((err) => {
+  store.touchLastUsed(record.keyId).catch((err) => {
     console.error('[auth] touchLastUsed failed:', err);
   });
   return {
@@ -114,4 +132,12 @@ export async function authenticate(
       mode: 'api-key',
     },
   };
+}
+
+async function authenticateJwt(token: string, verifier: JwtVerifier): Promise<AuthResult> {
+  const principal = await verifier.verify(token);
+  if (!principal) {
+    return { ok: false, status: 401, error: 'Unauthorized' };
+  }
+  return { ok: true, principal };
 }

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -17,6 +17,7 @@ import { MCPTransport } from './index';
 import { getDashboardState } from '../desktop/dashboard-state';
 import type { SessionManager } from '../session-manager';
 import type { ApiKeyStore } from '../auth/api-key-store';
+import { createJwtVerifier, type JwtConfig, type JwtVerifier } from '../auth/jwt-verifier';
 import {
   authenticate,
   requestPrincipals,
@@ -39,6 +40,7 @@ interface SSEConnection {
 
 export interface HTTPTransportOptions {
   apiKeyStore?: ApiKeyStore;
+  jwt?: JwtConfig;
 }
 
 export class HTTPTransport implements MCPTransport {
@@ -64,24 +66,37 @@ export class HTTPTransport implements MCPTransport {
     this.port = port;
     this.host = host;
     this.authToken = authToken;
-    this.authMode = HTTPTransport.resolveAuthMode(authToken, options.apiKeyStore);
+    const verifier = options.jwt ? createJwtVerifier(options.jwt) : undefined;
+    this.authMode = HTTPTransport.resolveAuthMode(authToken, options.apiKeyStore, verifier);
   }
 
   /**
    * Resolve the runtime auth mode from env + ctor args.
    * Precedence:
    *   1. Explicit env OPENCHROME_AUTH_MODE=legacy-shared-token with a token -> legacy
-   *   2. ApiKeyStore provided -> api-key
-   *   3. authToken provided (backwards compat) -> legacy
-   *   4. Nothing configured -> disabled
+   *   2. store && jwt -> api-key-or-jwt
+   *   3. ApiKeyStore provided -> api-key
+   *   4. jwt provided -> jwt
+   *   5. authToken provided (backwards compat) -> legacy
+   *   6. Nothing configured -> disabled
    */
-  static resolveAuthMode(authToken: string | undefined, store: ApiKeyStore | undefined): AuthMode {
+  static resolveAuthMode(
+    authToken: string | undefined,
+    store: ApiKeyStore | undefined,
+    verifier?: JwtVerifier,
+  ): AuthMode {
     const envMode = process.env.OPENCHROME_AUTH_MODE;
     if (envMode === 'legacy-shared-token' && authToken) {
       return { kind: 'legacy-shared-token', token: authToken };
     }
+    if (store && verifier) {
+      return { kind: 'api-key-or-jwt', store, verifier };
+    }
     if (store) {
       return { kind: 'api-key', store };
+    }
+    if (verifier) {
+      return { kind: 'jwt', verifier };
     }
     if (authToken) {
       return { kind: 'legacy-shared-token', token: authToken };

--- a/tests/auth/jwt-verifier.test.ts
+++ b/tests/auth/jwt-verifier.test.ts
@@ -1,0 +1,228 @@
+/// <reference types="jest" />
+/**
+ * Tests for src/auth/jwt-verifier.ts (issue #9 / PR3).
+ *
+ * A local HTTP server serves a JWKS generated in-test with jose.generateKeyPair.
+ * Tokens are signed with the matching private key. We exercise happy path,
+ * claim/validator mismatches, scope shapes, and invalid-scope filtering.
+ */
+
+import * as http from 'http';
+import type { AddressInfo } from 'net';
+import * as jose from 'jose';
+
+import { createJwtVerifier } from '../../src/auth/jwt-verifier';
+
+const ISSUER = 'https://idp.test';
+const AUDIENCE = 'openchrome';
+
+type PrivateKey = Awaited<ReturnType<typeof jose.generateKeyPair>>['privateKey'];
+
+interface KeyMaterial {
+  privateKey: PrivateKey;
+  publicJwk: jose.JWK;
+  kid: string;
+}
+
+async function generateKey(): Promise<KeyMaterial> {
+  const { privateKey, publicKey } = await jose.generateKeyPair('RS256', { modulusLength: 2048 });
+  const publicJwk = await jose.exportJWK(publicKey);
+  publicJwk.alg = 'RS256';
+  publicJwk.use = 'sig';
+  publicJwk.kid = 'test-kid-1';
+  return { privateKey, publicJwk, kid: 'test-kid-1' };
+}
+
+function startJwksServer(jwk: jose.JWK): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      if (req.url === '/jwks.json') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ keys: [jwk] }));
+      } else {
+        res.writeHead(404);
+        res.end();
+      }
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as AddressInfo;
+      resolve({
+        url: `http://127.0.0.1:${addr.port}/jwks.json`,
+        close: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+async function signToken(
+  privateKey: PrivateKey,
+  kid: string,
+  payload: Record<string, unknown>,
+  opts: { issuer?: string; audience?: string; expiresIn?: string; notBefore?: string } = {},
+): Promise<string> {
+  let jwt = new jose.SignJWT(payload)
+    .setProtectedHeader({ alg: 'RS256', kid })
+    .setIssuedAt();
+  if (opts.issuer !== undefined) jwt = jwt.setIssuer(opts.issuer);
+  if (opts.audience !== undefined) jwt = jwt.setAudience(opts.audience);
+  if (opts.expiresIn !== undefined) jwt = jwt.setExpirationTime(opts.expiresIn);
+  if (opts.notBefore !== undefined) jwt = jwt.setNotBefore(opts.notBefore);
+  return jwt.sign(privateKey);
+}
+
+describe('createJwtVerifier', () => {
+  let key: KeyMaterial;
+  let jwks: { url: string; close: () => Promise<void> };
+
+  beforeAll(async () => {
+    key = await generateKey();
+    jwks = await startJwksServer(key.publicJwk);
+  });
+
+  afterAll(async () => {
+    await jwks.close();
+  });
+
+  test('happy path — returns Principal with tenantId + scopes', async () => {
+    const verifier = createJwtVerifier({
+      jwksUrl: jwks.url,
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    });
+    const token = await signToken(key.privateKey, key.kid, {
+      tenantId: 'acme',
+      scope: 'read write',
+    }, { issuer: ISSUER, audience: AUDIENCE, expiresIn: '5m' });
+
+    const principal = await verifier.verify(token);
+    expect(principal).not.toBeNull();
+    expect(principal!.tenantId).toBe('acme');
+    expect(principal!.scopes).toEqual(['read', 'write']);
+    expect(principal!.mode).toBe('jwt');
+    expect(principal!.keyId).toBe(key.kid);
+  });
+
+  test('falls back to sub when tenantClaim is missing', async () => {
+    const verifier = createJwtVerifier({ jwksUrl: jwks.url, issuer: ISSUER, audience: AUDIENCE });
+    const token = await signToken(key.privateKey, key.kid, {
+      sub: 'subject-tenant',
+      scope: 'read',
+    }, { issuer: ISSUER, audience: AUDIENCE, expiresIn: '5m' });
+    const principal = await verifier.verify(token);
+    expect(principal).not.toBeNull();
+    expect(principal!.tenantId).toBe('subject-tenant');
+  });
+
+  test('wrong issuer returns null', async () => {
+    const verifier = createJwtVerifier({ jwksUrl: jwks.url, issuer: ISSUER, audience: AUDIENCE });
+    const token = await signToken(key.privateKey, key.kid, {
+      tenantId: 'acme',
+      scope: 'read',
+    }, { issuer: 'https://wrong.test', audience: AUDIENCE, expiresIn: '5m' });
+    const principal = await verifier.verify(token);
+    expect(principal).toBeNull();
+  });
+
+  test('wrong audience returns null', async () => {
+    const verifier = createJwtVerifier({ jwksUrl: jwks.url, issuer: ISSUER, audience: AUDIENCE });
+    const token = await signToken(key.privateKey, key.kid, {
+      tenantId: 'acme',
+      scope: 'read',
+    }, { issuer: ISSUER, audience: 'wrong-aud', expiresIn: '5m' });
+    const principal = await verifier.verify(token);
+    expect(principal).toBeNull();
+  });
+
+  test('expired token returns null', async () => {
+    const verifier = createJwtVerifier({ jwksUrl: jwks.url, issuer: ISSUER, audience: AUDIENCE });
+    // jose.setExpirationTime('5m') from now; use negative seconds past epoch via raw payload.
+    const token = await new jose.SignJWT({
+      tenantId: 'acme',
+      scope: 'read',
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: key.kid })
+      .setIssuer(ISSUER)
+      .setAudience(AUDIENCE)
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 3600)
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 60)
+      .sign(key.privateKey);
+    const principal = await verifier.verify(token);
+    expect(principal).toBeNull();
+  });
+
+  test('missing tenantId and sub returns null', async () => {
+    const verifier = createJwtVerifier({ jwksUrl: jwks.url, issuer: ISSUER, audience: AUDIENCE });
+    const token = await signToken(key.privateKey, key.kid, {
+      scope: 'read',
+    }, { issuer: ISSUER, audience: AUDIENCE, expiresIn: '5m' });
+    const principal = await verifier.verify(token);
+    expect(principal).toBeNull();
+  });
+
+  test('scope as space-delimited string is parsed', async () => {
+    const verifier = createJwtVerifier({ jwksUrl: jwks.url, issuer: ISSUER, audience: AUDIENCE });
+    const token = await signToken(key.privateKey, key.kid, {
+      tenantId: 'acme',
+      scope: 'read write admin',
+    }, { issuer: ISSUER, audience: AUDIENCE, expiresIn: '5m' });
+    const principal = await verifier.verify(token);
+    expect(principal).not.toBeNull();
+    expect(principal!.scopes).toEqual(expect.arrayContaining(['read', 'write', 'admin']));
+  });
+
+  test('scope as array is parsed', async () => {
+    const verifier = createJwtVerifier({ jwksUrl: jwks.url, issuer: ISSUER, audience: AUDIENCE });
+    const token = await signToken(key.privateKey, key.kid, {
+      tenantId: 'acme',
+      scope: ['read', 'write'],
+    }, { issuer: ISSUER, audience: AUDIENCE, expiresIn: '5m' });
+    const principal = await verifier.verify(token);
+    expect(principal).not.toBeNull();
+    expect(principal!.scopes).toEqual(['read', 'write']);
+  });
+
+  test('invalid scope values are filtered out', async () => {
+    const verifier = createJwtVerifier({ jwksUrl: jwks.url, issuer: ISSUER, audience: AUDIENCE });
+    const token = await signToken(key.privateKey, key.kid, {
+      tenantId: 'acme',
+      scope: ['read', 'super-admin', 'write', 'junk'],
+    }, { issuer: ISSUER, audience: AUDIENCE, expiresIn: '5m' });
+    const principal = await verifier.verify(token);
+    expect(principal).not.toBeNull();
+    expect(principal!.scopes).toEqual(['read', 'write']);
+  });
+
+  test('empty scopes after filtering returns null', async () => {
+    const verifier = createJwtVerifier({ jwksUrl: jwks.url, issuer: ISSUER, audience: AUDIENCE });
+    const token = await signToken(key.privateKey, key.kid, {
+      tenantId: 'acme',
+      scope: ['junk', 'nope'],
+    }, { issuer: ISSUER, audience: AUDIENCE, expiresIn: '5m' });
+    const principal = await verifier.verify(token);
+    expect(principal).toBeNull();
+  });
+
+  test('custom tenantClaim and scopeClaim are respected', async () => {
+    const verifier = createJwtVerifier({
+      jwksUrl: jwks.url,
+      issuer: ISSUER,
+      audience: AUDIENCE,
+      tenantClaim: 'org_id',
+      scopeClaim: 'permissions',
+    });
+    const token = await signToken(key.privateKey, key.kid, {
+      org_id: 'contoso',
+      permissions: 'read admin',
+    }, { issuer: ISSUER, audience: AUDIENCE, expiresIn: '5m' });
+    const principal = await verifier.verify(token);
+    expect(principal).not.toBeNull();
+    expect(principal!.tenantId).toBe('contoso');
+    expect(principal!.scopes).toEqual(expect.arrayContaining(['read', 'admin']));
+  });
+
+  test('garbage string returns null (no throw)', async () => {
+    const verifier = createJwtVerifier({ jwksUrl: jwks.url, issuer: ISSUER, audience: AUDIENCE });
+    await expect(verifier.verify('not-a-jwt')).resolves.toBeNull();
+    await expect(verifier.verify('')).resolves.toBeNull();
+  });
+});

--- a/tests/cli/admin-keys.test.ts
+++ b/tests/cli/admin-keys.test.ts
@@ -1,0 +1,239 @@
+/// <reference types="jest" />
+/**
+ * Tests for the admin-keys CLI (issue #9 / PR3).
+ *
+ * Approach: load cli/admin-keys.ts and drive it via a local commander
+ * Command instance. The ApiKeyStore is backed by a tmpdir file via the
+ * OPENCHROME_API_KEY_STORE_PATH env override. stdout/stderr are captured
+ * in-process so assertions can prove plaintext only appears on stdout once
+ * and never leaks into stderr/list output.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Command } from 'commander';
+
+import { registerAdminKeysCommand } from '../../cli/admin-keys';
+
+// ─── Test harness ────────────────────────────────────────────────────────────
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+async function runCli(argv: string[]): Promise<RunResult> {
+  const program = new Command();
+  program.exitOverride((err) => {
+    // Re-throw so exitCode bubbles up; commander signals non-zero on usage errs.
+    throw err;
+  });
+  registerAdminKeysCommand(program);
+
+  let stdout = '';
+  let stderr = '';
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  const origLogErr = console.error;
+  const origExit = process.exit;
+  let exitCode: number | null = null;
+
+  (process.stdout.write as unknown as (chunk: string | Uint8Array) => boolean) = ((chunk: string | Uint8Array) => {
+    stdout += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stdout.write;
+  (process.stderr.write as unknown as (chunk: string | Uint8Array) => boolean) = ((chunk: string | Uint8Array) => {
+    stderr += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stderr.write;
+  console.error = (...args: unknown[]) => {
+    stderr += args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ') + '\n';
+  };
+
+  class ExitCalled extends Error {
+    constructor(public readonly code: number) {
+      super(`process.exit(${code})`);
+    }
+  }
+  process.exit = ((code?: number) => {
+    exitCode = code ?? 0;
+    throw new ExitCalled(exitCode);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any;
+
+  try {
+    await program.parseAsync(['node', 'openchrome', ...argv]);
+  } catch (err) {
+    if (err instanceof ExitCalled) {
+      // expected path for early exits
+    } else if (err && typeof err === 'object' && 'exitCode' in (err as Record<string, unknown>)) {
+      const rec = err as { exitCode?: number };
+      exitCode = rec.exitCode ?? 1;
+    } else {
+      throw err;
+    }
+  } finally {
+    process.stdout.write = origOut;
+    process.stderr.write = origErr;
+    console.error = origLogErr;
+    process.exit = origExit;
+  }
+
+  return { stdout, stderr, exitCode };
+}
+
+let tmpDir: string;
+let storePath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-admin-keys-'));
+  storePath = path.join(tmpDir, 'api-keys.jsonl');
+  process.env.OPENCHROME_API_KEY_STORE_PATH = storePath;
+  process.env.OPENCHROME_ADMIN_TOKEN = 'test-admin-token';
+});
+
+afterEach(() => {
+  delete process.env.OPENCHROME_API_KEY_STORE_PATH;
+  delete process.env.OPENCHROME_ADMIN_TOKEN;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('admin keys CLI', () => {
+  test('create: prints plaintext exactly once to stdout', async () => {
+    const { stdout, stderr, exitCode } = await runCli([
+      'admin', 'keys', 'create',
+      '--tenant', 'acme',
+      '--scope', 'read',
+      '--scope', 'write',
+      '--description', 'test key',
+    ]);
+    expect(exitCode).toBeNull();
+    // Plaintext is the sole stdout payload.
+    const stdoutLines = stdout.split('\n').filter((l) => l.length > 0);
+    expect(stdoutLines).toHaveLength(1);
+    const plaintext = stdoutLines[0];
+    expect(plaintext).toMatch(/^oc_live_acme_[A-Za-z0-9]+$/);
+    // Warning routed to stderr.
+    expect(stderr).toContain('SAVE THIS KEY NOW');
+    // keyId is reported on stderr, not stdout.
+    expect(stderr).toMatch(/keyId: k_/);
+    // The plaintext must not leak into stderr.
+    expect(stderr).not.toContain(plaintext);
+  }, 30000);
+
+  test('create: without OPENCHROME_ADMIN_TOKEN exits 1 with stderr error', async () => {
+    delete process.env.OPENCHROME_ADMIN_TOKEN;
+    const { stdout, stderr, exitCode } = await runCli([
+      'admin', 'keys', 'create',
+      '--tenant', 'acme',
+      '--scope', 'read',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('OPENCHROME_ADMIN_TOKEN');
+    expect(stdout).toBe('');
+  }, 20000);
+
+  test('create: invalid scope exits 1', async () => {
+    const { exitCode, stderr } = await runCli([
+      'admin', 'keys', 'create',
+      '--tenant', 'acme',
+      '--scope', 'superuser',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/invalid scope/i);
+  }, 20000);
+
+  test('list: shows keyId after create and never includes plaintext', async () => {
+    const created = await runCli([
+      'admin', 'keys', 'create',
+      '--tenant', 'acme',
+      '--scope', 'read',
+    ]);
+    const plaintext = created.stdout.trim();
+    expect(plaintext).toMatch(/^oc_live_/);
+    const keyIdMatch = created.stderr.match(/keyId: (k_\S+)/);
+    expect(keyIdMatch).not.toBeNull();
+    const keyId = keyIdMatch![1];
+
+    const listed = await runCli(['admin', 'keys', 'list']);
+    expect(listed.exitCode).toBeNull();
+    expect(listed.stderr).toContain(keyId);
+    // Plaintext must NEVER appear in either stream of list.
+    const combined = listed.stdout + listed.stderr;
+    expect(combined).not.toContain(plaintext);
+    expect(combined).not.toContain('oc_live_');
+  }, 30000);
+
+  test('list --json: emits JSON array on stdout without plaintext', async () => {
+    const created = await runCli([
+      'admin', 'keys', 'create',
+      '--tenant', 'acme',
+      '--scope', 'read',
+    ]);
+    const plaintext = created.stdout.trim();
+
+    const listed = await runCli(['admin', 'keys', 'list', '--json']);
+    expect(listed.exitCode).toBeNull();
+    const parsed = JSON.parse(listed.stdout) as Array<{ keyId: string; tenantId: string }>;
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].tenantId).toBe('acme');
+    expect(listed.stdout).not.toContain(plaintext);
+    expect(listed.stdout).not.toContain('oc_live_');
+  }, 30000);
+
+  test('revoke: list afterwards shows revokedAt populated', async () => {
+    const created = await runCli([
+      'admin', 'keys', 'create',
+      '--tenant', 'acme',
+      '--scope', 'read',
+    ]);
+    const keyId = created.stderr.match(/keyId: (k_\S+)/)![1];
+
+    const revoked = await runCli(['admin', 'keys', 'revoke', keyId]);
+    expect(revoked.exitCode).toBeNull();
+    expect(revoked.stderr).toContain('Revoked');
+
+    const listed = await runCli(['admin', 'keys', 'list', '--json']);
+    const parsed = JSON.parse(listed.stdout) as Array<{ keyId: string; revokedAt?: number }>;
+    const row = parsed.find((r) => r.keyId === keyId);
+    expect(row).toBeDefined();
+    expect(typeof row!.revokedAt).toBe('number');
+    expect(row!.revokedAt!).toBeGreaterThan(0);
+  }, 30000);
+
+  test('rotate: produces new plaintext and revokes the old keyId', async () => {
+    const created = await runCli([
+      'admin', 'keys', 'create',
+      '--tenant', 'acme',
+      '--scope', 'read',
+    ]);
+    const firstPlaintext = created.stdout.trim();
+    const firstKeyId = created.stderr.match(/keyId: (k_\S+)/)![1];
+
+    const rotated = await runCli(['admin', 'keys', 'rotate', firstKeyId]);
+    expect(rotated.exitCode).toBeNull();
+    const secondPlaintext = rotated.stdout.trim();
+    expect(secondPlaintext).toMatch(/^oc_live_acme_/);
+    expect(secondPlaintext).not.toBe(firstPlaintext);
+    expect(rotated.stderr).toContain('SAVE THIS KEY NOW');
+    // Old plaintext must NOT appear anywhere in rotate output.
+    expect(rotated.stdout + rotated.stderr).not.toContain(firstPlaintext);
+
+    const listed = await runCli(['admin', 'keys', 'list', '--json']);
+    const parsed = JSON.parse(listed.stdout) as Array<{ keyId: string; revokedAt?: number }>;
+    const oldRow = parsed.find((r) => r.keyId === firstKeyId);
+    expect(oldRow).toBeDefined();
+    expect(typeof oldRow!.revokedAt).toBe('number');
+  }, 60000);
+
+  test('revoke: unknown keyId exits 1', async () => {
+    const { exitCode, stderr } = await runCli(['admin', 'keys', 'revoke', 'k_doesnotexist']);
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/unknown keyId/);
+  }, 20000);
+});

--- a/tests/middleware/auth.test.ts
+++ b/tests/middleware/auth.test.ts
@@ -8,6 +8,8 @@ import { IncomingMessage } from 'http';
 import { Socket } from 'net';
 import { ApiKeyStore } from '../../src/auth/api-key-store';
 import { authenticate, type AuthMode } from '../../src/middleware/auth';
+import type { JwtVerifier } from '../../src/auth/jwt-verifier';
+import type { Principal } from '../../src/auth/api-key-types';
 
 function makeReq(headers: Record<string, string> = {}): IncomingMessage {
   const req = new IncomingMessage(new Socket());
@@ -156,4 +158,93 @@ describe('api-key mode', () => {
     }
     expect(key?.lastUsedAt).toBeGreaterThanOrEqual(before);
   }, 20000);
+});
+
+// ─── jwt mode ────────────────────────────────────────────────────────────────
+
+function stubVerifier(principal: Principal | null): JwtVerifier {
+  return {
+    verify: async () => (principal ? { ...principal, scopes: [...principal.scopes] } : null),
+  };
+}
+
+describe('jwt mode', () => {
+  it('happy path — verifier returns principal, middleware wraps as ok', async () => {
+    const verifier = stubVerifier({
+      tenantId: 'acme',
+      scopes: ['read', 'write'],
+      mode: 'jwt',
+      keyId: 'kid-abc',
+    });
+    const mode: AuthMode = { kind: 'jwt', verifier };
+    const req = makeReq({ authorization: 'Bearer header.payload.sig' });
+    const result = await authenticate(req, mode);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.principal.tenantId).toBe('acme');
+    expect(result.principal.mode).toBe('jwt');
+    expect(result.principal.scopes).toEqual(['read', 'write']);
+    expect(result.principal.keyId).toBe('kid-abc');
+  });
+
+  it('verifier returning null yields 401', async () => {
+    const verifier = stubVerifier(null);
+    const mode: AuthMode = { kind: 'jwt', verifier };
+    const req = makeReq({ authorization: 'Bearer bad.token' });
+    const result = await authenticate(req, mode);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(401);
+  });
+});
+
+// ─── api-key-or-jwt mode ─────────────────────────────────────────────────────
+
+describe('api-key-or-jwt mode', () => {
+  let store: ApiKeyStore;
+
+  beforeEach(async () => {
+    store = await ApiKeyStore.open(tmpStore());
+  });
+
+  it('routes oc_live_* tokens through the api-key store', async () => {
+    const verifier = stubVerifier(null); // would fail if asked
+    const { plaintext, record } = await store.create({
+      tenantId: 'acme',
+      scopes: ['read'],
+      description: '',
+    });
+    const mode: AuthMode = { kind: 'api-key-or-jwt', store, verifier };
+    const req = makeReq({ authorization: `Bearer ${plaintext}` });
+    const result = await authenticate(req, mode);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.principal.mode).toBe('api-key');
+    expect(result.principal.keyId).toBe(record.keyId);
+  }, 20000);
+
+  it('routes non-prefix tokens through the jwt verifier', async () => {
+    const verifier = stubVerifier({
+      tenantId: 'jwt-tenant',
+      scopes: ['read'],
+      mode: 'jwt',
+    });
+    const mode: AuthMode = { kind: 'api-key-or-jwt', store, verifier };
+    const req = makeReq({ authorization: 'Bearer eyJ.looks.likeajwt' });
+    const result = await authenticate(req, mode);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.principal.mode).toBe('jwt');
+    expect(result.principal.tenantId).toBe('jwt-tenant');
+  });
+
+  it('jwt path returning null yields 401', async () => {
+    const verifier = stubVerifier(null);
+    const mode: AuthMode = { kind: 'api-key-or-jwt', store, verifier };
+    const req = makeReq({ authorization: 'Bearer nope.nope.nope' });
+    const result = await authenticate(req, mode);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(401);
+  });
 });


### PR DESCRIPTION
## Summary

Operator-facing admin CLI and JWT/OAuth verifier — **PR 3 of 4** in the issue #9 stacked chain.

**Base branch**: `feat/issue-9-pr2-auth-middleware` (will retarget to `develop` once PR 1/4 and PR 2/4 merge).

Relates to: #9 · Builds on: #18 · Stacks on: #28

## What's in this PR

### Admin CLI (`cli/admin-keys.ts` + `cli/index.ts`)
```
openchrome admin keys create --tenant <id> --scope <read|write|admin|headless-only> [--description ...] [--expires-in <days>]
openchrome admin keys list [--tenant <id>] [--json]
openchrome admin keys revoke <keyId>
openchrome admin keys rotate <keyId>
```
- Gated by `OPENCHROME_ADMIN_TOKEN` env (read, validated, never persisted).
- `create` / `rotate` emit the **plaintext key once to stdout** (pipeable); all warnings / tables go to stderr, so `... --json | jq` works.
- Default list output is tabular (no plaintext anywhere); `--json` emits `ApiKey[]`.

### JWT / OAuth verifier (`src/auth/jwt-verifier.ts`)
- Built on `jose.createRemoteJWKSet` + `jose.jwtVerify`, RS256.
- Configurable `tenantClaim` (falls back to `sub`) and `scopeClaim` (accepts both `"read write"` string and `["read","write"]` array; filters unknown values).
- Surfaces `kid` as `keyId` for audit correlation.
- Any failure (bad signature, expired, wrong iss/aud, no tenantId resolvable, empty scopes) → returns `null` without logging the token.

### Middleware integration (`src/middleware/auth.ts`)
Two new `AuthMode` variants added alongside existing ones:
- `{ kind: 'jwt'; verifier }`
- `{ kind: 'api-key-or-jwt'; store; verifier }` — routes by `oc_live_` prefix (API key) vs. JWT fallback so callers can migrate gradually.

`Principal.mode` union extended with `'jwt'`.

### HTTP transport (`src/transports/http.ts`)
- `HTTPTransportOptions.jwt?: JwtConfig` — construct the verifier programmatically.
- `resolveAuthMode()` priority: `env legacy-shared-token > store+jwt → api-key-or-jwt > store → api-key > jwt → jwt > token → legacy > disabled`.

### Dep choice
`jose@^5.10.0` — v6 is ESM-only and breaks under ts-jest's CJS runtime without extra config, so v5 is the pragmatic pick.

## Test plan

- [x] `npm run build` clean (both tsconfig passes)
- [x] `npx jest tests/cli tests/middleware tests/auth/jwt-verifier --forceExit` → **74/74 pass**
  - admin-keys CLI (8): create emits plaintext once, missing token → exit 1, invalid scope → exit 1, list visibility, list --json, revoke, rotate, unknown-revoke
  - jwt-verifier (12): happy path, wrong iss/aud, expired, missing tenant claim, string scope, array scope, unknown scopes filtered, etc.
  - middleware (14): existing 9 + new 5 (jwt happy, jwt null, api-key-or-jwt routes to api-key, routes to jwt, both fail)
- [x] `npx jest tests/transports/http-bearer-auth.test.ts --forceExit` → 9/9 (legacy path regression-free)
- [x] `npx jest tests/mcp-server.test.ts --forceExit` → 31/31 (no dispatch regression)
- [x] Plaintext key is never written to stderr or log — asserted in CLI test (full stdout+stderr scan for `oc_live_`)

## Stacked PR chain

1. ✅ [PR 1/4 — API key store](https://github.com/junghwan-oss/openchrome/pull/18)
2. ✅ [PR 2/4 — middleware + scope gate](https://github.com/junghwan-oss/openchrome/pull/28)
3. **PR 3/4 — admin CLI + JWT/OAuth (this PR)**
4. PR 4/4 — docs + E2E + rollback polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Migrated from junghwan-oss/openchrome#32 — originally by @junghwan-oss on 2026-04-20T04:48:39Z. Original state: OPEN._