### PR TITLE
feat(tenant): validate X-Tenant-Id at HTTP transport and bind to MCP session (B-1 part 4/5)

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -16,6 +16,9 @@ import { MCPResponse, MCPErrorCodes } from '../types/mcp';
 import { MCPTransport } from './index';
 import { getDashboardState } from '../desktop/dashboard-state';
 import type { SessionManager } from '../session-manager';
+import { extractTenantId, TenantIdError } from '../middleware/tenant-extractor';
+import { isStrictTenantIsolationEnabled } from '../tenant/registry';
+import type { TenantId } from '../tenant/types';
 
 /** Maximum allowed HTTP request body size (10 MB) to prevent OOM from oversized requests */
 const MAX_BODY_BYTES = 10 * 1024 * 1024;
@@ -41,11 +44,23 @@ export class HTTPTransport implements MCPTransport {
   private sessionManager: SessionManager | null = null;
   private readonly serverStartTime: number = Date.now();
   private sseKeepaliveTimer: ReturnType<typeof setInterval> | null = null;
+  /** Tenant bound to each MCP session. Populated on initialize and checked
+   *  on subsequent requests so a leaked session id cannot swap tenants. (#7) */
+  private sessionTenants: Map<string, TenantId> = new Map();
 
   constructor(port: number, host = '127.0.0.1', authToken?: string) {
     this.port = port;
     this.host = host;
     this.authToken = authToken;
+  }
+
+  /**
+   * Look up the tenant bound to an MCP session id. Callers outside this
+   * transport (e.g. MCPServer handlers) use this to resolve the tenant for
+   * the currently-processed request. Returns undefined when unknown. (#7)
+   */
+  getTenantForMcpSession(mcpSessionId: string): TenantId | undefined {
+    return this.sessionTenants.get(mcpSessionId);
   }
 
   /**
@@ -126,6 +141,7 @@ export class HTTPTransport implements MCPTransport {
       }
     }
     this.sseConnections = [];
+    this.sessionTenants.clear();
 
     return new Promise((resolve) => {
       if (this.server) {
@@ -146,7 +162,7 @@ export class HTTPTransport implements MCPTransport {
     // CORS headers for all responses — restrict origin when auth is enabled
     res.setHeader('Access-Control-Allow-Origin', this.authToken ? 'null' : '*');
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Mcp-Session-Id, Authorization');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Mcp-Session-Id, Authorization, X-Tenant-Id');
     res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id');
 
     // Handle CORS preflight
@@ -196,7 +212,9 @@ export class HTTPTransport implements MCPTransport {
     // Explicit /mcp/sse endpoint (MCP spec alias for GET /mcp SSE stream)
     if (pathname === '/mcp/sse') {
       if (req.method === 'GET') {
-        this.handleSSE(req, res);
+        const tenantId = this.resolveRequestTenant(req, res);
+        if (tenantId === null) return;
+        this.handleSSE(req, res, tenantId);
       } else {
         res.writeHead(405, { 'Allow': 'GET', 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: 'Method not allowed' }));
@@ -206,12 +224,18 @@ export class HTTPTransport implements MCPTransport {
 
     if (pathname === '/mcp') {
       switch (req.method) {
-        case 'POST':
-          this.handlePost(req, res);
+        case 'POST': {
+          const tenantId = this.resolveRequestTenant(req, res);
+          if (tenantId === null) return;
+          this.handlePost(req, res, tenantId);
           return;
-        case 'GET':
-          this.handleSSE(req, res);
+        }
+        case 'GET': {
+          const tenantId = this.resolveRequestTenant(req, res);
+          if (tenantId === null) return;
+          this.handleSSE(req, res, tenantId);
           return;
+        }
         case 'DELETE':
           this.handleDelete(req, res);
           return;
@@ -225,6 +249,65 @@ export class HTTPTransport implements MCPTransport {
     // Unknown path
     res.writeHead(404, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: 'Not found' }));
+  }
+
+  /**
+   * Validate `X-Tenant-Id` on an incoming /mcp request and resolve the
+   * effective tenant. Writes a 400 JSON-RPC error and returns `null` on
+   * failure so the caller can bail out without doing further work. (#7)
+   *
+   * - Missing header in STRICT mode                   → 400 (code `missing`)
+   * - Invalid header format                           → 400 (code `invalid`)
+   * - Header present but differs from a tenant already bound to the
+   *   same Mcp-Session-Id                             → 400 (code `invalid`)
+   */
+  private resolveRequestTenant(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): TenantId | null {
+    const strict = isStrictTenantIsolationEnabled();
+    let tenantId: TenantId;
+    try {
+      tenantId = extractTenantId(req.headers, { required: strict });
+    } catch (err) {
+      if (err instanceof TenantIdError) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: 0,
+            error: {
+              code: MCPErrorCodes.INVALID_REQUEST,
+              message: err.message,
+              data: { field: 'X-Tenant-Id', reason: err.code },
+            },
+          }),
+        );
+        return null;
+      }
+      throw err;
+    }
+
+    const mcpSessionId = req.headers['mcp-session-id'] as string | undefined;
+    if (mcpSessionId) {
+      const bound = this.sessionTenants.get(mcpSessionId);
+      if (bound !== undefined && bound !== tenantId) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: 0,
+            error: {
+              code: MCPErrorCodes.INVALID_REQUEST,
+              message: 'X-Tenant-Id does not match the tenant bound to this Mcp-Session-Id',
+              data: { field: 'X-Tenant-Id', reason: 'tenant_mismatch' },
+            },
+          }),
+        );
+        return null;
+      }
+    }
+    return tenantId;
   }
 
   /**
@@ -379,7 +462,11 @@ export class HTTPTransport implements MCPTransport {
   /**
    * POST /mcp - handle JSON-RPC request or batch
    */
-  private handlePost(req: http.IncomingMessage, res: http.ServerResponse): void {
+  private handlePost(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    tenantId: TenantId,
+  ): void {
     const acceptSSE = (req.headers['accept'] || '').includes('text/event-stream');
 
     const chunks: Buffer[] = [];
@@ -444,7 +531,7 @@ export class HTTPTransport implements MCPTransport {
 
       // Handle JSON-RPC batch (array of requests)
       if (Array.isArray(parsed)) {
-        const results = await this.processBatch(parsed, sessionId);
+        const results = await this.processBatch(parsed, sessionId, tenantId);
         // Filter out null results (notifications don't produce responses)
         const responses = results.filter((r): r is MCPResponse => r !== null);
 
@@ -473,6 +560,7 @@ export class HTTPTransport implements MCPTransport {
       if (msg.method === 'initialize' && !sessionId) {
         sessionId = crypto.randomUUID();
         this.sessions.add(sessionId);
+        this.sessionTenants.set(sessionId, tenantId);
       }
 
       try {
@@ -529,7 +617,11 @@ export class HTTPTransport implements MCPTransport {
   /**
    * GET /mcp or GET /mcp/sse - Server-Sent Events for server-initiated notifications
    */
-  private handleSSE(req: http.IncomingMessage, res: http.ServerResponse): void {
+  private handleSSE(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    _tenantId: TenantId,
+  ): void {
     const sessionId = req.headers['mcp-session-id'] as string || 'anonymous';
 
     res.writeHead(200, {
@@ -562,6 +654,7 @@ export class HTTPTransport implements MCPTransport {
 
     if (sessionId && this.sessions.has(sessionId)) {
       this.sessions.delete(sessionId);
+      this.sessionTenants.delete(sessionId);
 
       // Notify session-delete listeners (e.g. rate-limiter cleanup)
       if (this.sessionDeleteHandler) {
@@ -595,6 +688,7 @@ export class HTTPTransport implements MCPTransport {
   private async processBatch(
     messages: unknown[],
     sessionId: string | undefined,
+    tenantId: TenantId,
   ): Promise<(MCPResponse | null)[]> {
     const handler = this.messageHandler!;
 
@@ -607,6 +701,7 @@ export class HTTPTransport implements MCPTransport {
       if (hasInitialize) {
         sessionId = crypto.randomUUID();
         this.sessions.add(sessionId);
+        this.sessionTenants.set(sessionId, tenantId);
       }
     }
 

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -531,6 +531,24 @@ export class HTTPTransport implements MCPTransport {
 
       // Handle JSON-RPC batch (array of requests)
       if (Array.isArray(parsed)) {
+        // Same guard as the single-message path: forbid client-supplied
+        // Mcp-Session-Id when the batch contains an `initialize`. (#7 security)
+        if (sessionId && parsed.some(
+          (m) => typeof m === 'object' && m !== null
+            && (m as Record<string, unknown>).method === 'initialize',
+        )) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            jsonrpc: '2.0',
+            id: 0,
+            error: {
+              code: MCPErrorCodes.INVALID_REQUEST,
+              message: 'Mcp-Session-Id must not be supplied on initialize',
+              data: { field: 'Mcp-Session-Id', reason: 'unexpected_on_initialize' },
+            },
+          }));
+          return;
+        }
         const results = await this.processBatch(parsed, sessionId, tenantId);
         // Filter out null results (notifications don't produce responses)
         const responses = results.filter((r): r is MCPResponse => r !== null);
@@ -555,6 +573,24 @@ export class HTTPTransport implements MCPTransport {
 
       // Single request/notification
       const msg = parsed as Record<string, unknown>;
+
+      // Per MCP spec the server assigns Mcp-Session-Id on initialize.
+      // A client-supplied session id on initialize would skip the
+      // `sessionTenants` binding below (and thus the tenant_mismatch guard),
+      // so reject those requests up front. (#7 security)
+      if (msg.method === 'initialize' && sessionId) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          jsonrpc: '2.0',
+          id: (msg.id as string | number) ?? 0,
+          error: {
+            code: MCPErrorCodes.INVALID_REQUEST,
+            message: 'Mcp-Session-Id must not be supplied on initialize',
+            data: { field: 'Mcp-Session-Id', reason: 'unexpected_on_initialize' },
+          },
+        }));
+        return;
+      }
 
       // Check if this is an initialize request — assign session ID
       if (msg.method === 'initialize' && !sessionId) {

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -30,6 +30,10 @@ const SSE_KEEPALIVE_INTERVAL_MS = 30_000;
 interface SSEConnection {
   res: http.ServerResponse;
   sessionId: string;
+  /** Tenant that opened this stream. Populated for future tenant-scoped
+   *  broadcasts; `send()` still broadcasts to all connections because the
+   *  MCPServer tenant threading lands in part 5/5. (#7) */
+  tenantId: TenantId;
 }
 
 export class HTTPTransport implements MCPTransport {
@@ -541,10 +545,28 @@ export class HTTPTransport implements MCPTransport {
       if (Array.isArray(parsed)) {
         // Same guard as the single-message path: forbid client-supplied
         // Mcp-Session-Id when the batch contains an `initialize`. (#7 security)
-        if (sessionId && parsed.some(
-          (m) => typeof m === 'object' && m !== null
-            && (m as Record<string, unknown>).method === 'initialize',
-        )) {
+        const initializeCount = parsed.reduce<number>((n, m) => (
+          typeof m === 'object' && m !== null
+            && (m as Record<string, unknown>).method === 'initialize'
+            ? n + 1 : n
+        ), 0);
+        if (initializeCount > 1) {
+          // Two `initialize` messages would race over the single
+          // `sessionId` assigned in `processBatch`, producing
+          // ambiguous tenant-binding state. Reject outright.
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            jsonrpc: '2.0',
+            id: 0,
+            error: {
+              code: MCPErrorCodes.INVALID_REQUEST,
+              message: 'A JSON-RPC batch may contain at most one initialize',
+              data: { field: 'method', reason: 'duplicate_initialize' },
+            },
+          }));
+          return;
+        }
+        if (sessionId && initializeCount > 0) {
           res.writeHead(400, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({
             jsonrpc: '2.0',
@@ -664,7 +686,7 @@ export class HTTPTransport implements MCPTransport {
   private handleSSE(
     req: http.IncomingMessage,
     res: http.ServerResponse,
-    _tenantId: TenantId,
+    tenantId: TenantId,
   ): void {
     const sessionId = req.headers['mcp-session-id'] as string || 'anonymous';
 
@@ -677,7 +699,7 @@ export class HTTPTransport implements MCPTransport {
     // Send initial keepalive
     res.write(': keepalive\n\n');
 
-    const conn: SSEConnection = { res, sessionId };
+    const conn: SSEConnection = { res, sessionId, tenantId };
     this.sseConnections.push(conn);
 
     // Clean up on disconnect

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -236,9 +236,17 @@ export class HTTPTransport implements MCPTransport {
           this.handleSSE(req, res, tenantId);
           return;
         }
-        case 'DELETE':
-          this.handleDelete(req, res);
+        case 'DELETE': {
+          // Tenant guard: DELETE /mcp terminates the session, so an attacker
+          // who learns another tenant's Mcp-Session-Id could otherwise
+          // cross-tenant-DoS them by calling DELETE without X-Tenant-Id or
+          // with a mismatched one. Route through resolveRequestTenant so
+          // the `tenant_mismatch` check applies here too. (#7 security)
+          const tenantId = this.resolveRequestTenant(req, res);
+          if (tenantId === null) return;
+          this.handleDelete(req, res, tenantId);
           return;
+        }
         default:
           res.writeHead(405, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Method not allowed' }));
@@ -683,9 +691,19 @@ export class HTTPTransport implements MCPTransport {
   }
 
   /**
-   * DELETE /mcp - Session termination
+   * DELETE /mcp - Session termination.
+   *
+   * The caller has already passed `resolveRequestTenant`, so any provided
+   * Mcp-Session-Id is guaranteed to either be unbound or belong to the
+   * resolved tenant. `_tenantId` is accepted for symmetry with handlePost
+   * / handleSSE and to let future hooks (audit log, per-tenant metrics)
+   * attribute the termination correctly.
    */
-  private handleDelete(req: http.IncomingMessage, res: http.ServerResponse): void {
+  private handleDelete(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    _tenantId: TenantId,
+  ): void {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
 
     if (sessionId && this.sessions.has(sessionId)) {

--- a/tests/transports/http-tenant.test.ts
+++ b/tests/transports/http-tenant.test.ts
@@ -1,0 +1,203 @@
+/// <reference types="jest" />
+/**
+ * HTTP transport tenant extraction & binding (#7).
+ */
+
+import * as http from 'node:http';
+
+const { HTTPTransport } = require('../../src/transports/http');
+
+const TEST_PORT = 19922;
+
+type ResponseTuple = {
+  status: number;
+  body: string;
+  headers: http.IncomingHttpHeaders;
+};
+
+function request(
+  path: string,
+  method = 'GET',
+  headers: Record<string, string> = {},
+  body?: string,
+): Promise<ResponseTuple> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: '127.0.0.1', port: TEST_PORT, path, method, headers },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode || 0,
+            body: Buffer.concat(chunks).toString(),
+            headers: res.headers,
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+function mcpPost(headers: Record<string, string>, body: unknown) {
+  return request(
+    '/mcp',
+    'POST',
+    { 'Content-Type': 'application/json', ...headers },
+    JSON.stringify(body),
+  );
+}
+
+describe('HTTP transport — tenant extraction (#7)', () => {
+  let transport: InstanceType<typeof HTTPTransport>;
+
+  afterEach(async () => {
+    if (transport) await transport.close();
+    delete process.env.OPENCHROME_STRICT_TENANT_ISOLATION;
+    // Give OS a moment to release the port so the next test's bind does not race
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  async function boot() {
+    transport = new HTTPTransport(TEST_PORT, '127.0.0.1');
+    transport.onMessage(async (msg: Record<string, unknown>) => ({
+      jsonrpc: '2.0',
+      id: msg.id,
+      result: { ok: true, method: msg.method },
+    }));
+    transport.start();
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  it('accepts a valid X-Tenant-Id header and returns 200', async () => {
+    await boot();
+    const res = await mcpPost(
+      { 'X-Tenant-Id': 'acme' },
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+    );
+    expect(res.status).toBe(200);
+    const data = JSON.parse(res.body);
+    expect(data.result.ok).toBe(true);
+  });
+
+  it('falls back to default tenant when header is absent (non-strict)', async () => {
+    await boot();
+    const res = await mcpPost(
+      {},
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+    );
+    expect(res.status).toBe(200);
+    const mcpSession = res.headers['mcp-session-id'] as string;
+    expect(transport.getTenantForMcpSession(mcpSession)).toBe('default');
+  });
+
+  it('rejects malformed X-Tenant-Id with 400 and invalid code', async () => {
+    await boot();
+    const res = await mcpPost(
+      { 'X-Tenant-Id': 'a/b' },
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+    );
+    expect(res.status).toBe(400);
+    const err = JSON.parse(res.body);
+    expect(err.error.code).toBeDefined();
+    expect(err.error.data.reason).toBe('invalid');
+    expect(err.error.data.field).toBe('X-Tenant-Id');
+  });
+
+  it('rejects leading-hyphen X-Tenant-Id with 400', async () => {
+    await boot();
+    // Note: control chars like null bytes are blocked by Node's http client
+    // before they hit the wire — see extractor unit tests for that coverage.
+    const res = await mcpPost(
+      { 'X-Tenant-Id': '-bad' },
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+    );
+    expect(res.status).toBe(400);
+    const err = JSON.parse(res.body);
+    expect(err.error.data.reason).toBe('invalid');
+  });
+
+it('STRICT mode rejects missing X-Tenant-Id with 400 (code=missing)', async () => {
+    process.env.OPENCHROME_STRICT_TENANT_ISOLATION = 'true';
+    await boot();
+    const res = await mcpPost(
+      {},
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+    );
+    expect(res.status).toBe(400);
+    const err = JSON.parse(res.body);
+    expect(err.error.data.reason).toBe('missing');
+  });
+
+  it('binds tenant to mcp-session-id on initialize and exposes it via lookup', async () => {
+    await boot();
+    const first = await mcpPost(
+      { 'X-Tenant-Id': 'acme' },
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+    );
+    const mcpSession = first.headers['mcp-session-id'] as string;
+    expect(mcpSession).toBeTruthy();
+    expect(transport.getTenantForMcpSession(mcpSession)).toBe('acme');
+  });
+
+  it('rejects subsequent request that swaps tenants on the same mcp session', async () => {
+    await boot();
+    const first = await mcpPost(
+      { 'X-Tenant-Id': 'acme' },
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+    );
+    const mcpSession = first.headers['mcp-session-id'] as string;
+    expect(mcpSession).toBeTruthy();
+
+    const swap = await mcpPost(
+      { 'X-Tenant-Id': 'evil', 'Mcp-Session-Id': mcpSession },
+      { jsonrpc: '2.0', id: 2, method: 'ping' },
+    );
+    expect(swap.status).toBe(400);
+    const err = JSON.parse(swap.body);
+    expect(err.error.data.reason).toBe('tenant_mismatch');
+  });
+
+  it('allows the same tenant to reuse its bound mcp session', async () => {
+    await boot();
+    const first = await mcpPost(
+      { 'X-Tenant-Id': 'acme' },
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+    );
+    const mcpSession = first.headers['mcp-session-id'] as string;
+    const second = await mcpPost(
+      { 'X-Tenant-Id': 'acme', 'Mcp-Session-Id': mcpSession },
+      { jsonrpc: '2.0', id: 2, method: 'ping' },
+    );
+    expect(second.status).toBe(200);
+  });
+
+  it('DELETE /mcp clears the tenant binding', async () => {
+    await boot();
+    const first = await mcpPost(
+      { 'X-Tenant-Id': 'acme' },
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+    );
+    const mcpSession = first.headers['mcp-session-id'] as string;
+    expect(transport.getTenantForMcpSession(mcpSession)).toBe('acme');
+
+    const del = await request('/mcp', 'DELETE', { 'Mcp-Session-Id': mcpSession });
+    expect(del.status).toBe(200);
+    expect(transport.getTenantForMcpSession(mcpSession)).toBeUndefined();
+  });
+
+  it('advertises X-Tenant-Id in CORS Allow-Headers', async () => {
+    await boot();
+    const res = await request('/mcp', 'OPTIONS', {
+      Origin: 'http://example.com',
+      'Access-Control-Request-Method': 'POST',
+      'Access-Control-Request-Headers': 'X-Tenant-Id, Content-Type',
+    });
+    expect(res.status).toBe(204);
+    const allowed = String(res.headers['access-control-allow-headers'] || '');
+    expect(allowed.toLowerCase()).toContain('x-tenant-id');
+  });
+});

--- a/tests/transports/http-tenant.test.ts
+++ b/tests/transports/http-tenant.test.ts
@@ -211,6 +211,23 @@ it('STRICT mode rejects missing X-Tenant-Id with 400 (code=missing)', async () =
     expect(transport.getTenantForMcpSession('client-chosen-id')).toBeUndefined();
   });
 
+  it('rejects batch containing multiple initialize requests (no ambiguous tenant binding)', async () => {
+    // Two initialize messages in a single batch would race over the
+    // single `sessionId` minted in `processBatch`, leaving an ambiguous
+    // binding. Reject the batch outright.
+    await boot();
+    const res = await mcpPost(
+      { 'X-Tenant-Id': 'acme' },
+      [
+        { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+        { jsonrpc: '2.0', id: 2, method: 'initialize', params: {} },
+      ],
+    );
+    expect(res.status).toBe(400);
+    const err = JSON.parse(res.body);
+    expect(err.error.data.reason).toBe('duplicate_initialize');
+  });
+
   it('rejects batch containing initialize with client-supplied Mcp-Session-Id', async () => {
     await boot();
     const res = await mcpPost(

--- a/tests/transports/http-tenant.test.ts
+++ b/tests/transports/http-tenant.test.ts
@@ -184,7 +184,10 @@ it('STRICT mode rejects missing X-Tenant-Id with 400 (code=missing)', async () =
     const mcpSession = first.headers['mcp-session-id'] as string;
     expect(transport.getTenantForMcpSession(mcpSession)).toBe('acme');
 
-    const del = await request('/mcp', 'DELETE', { 'Mcp-Session-Id': mcpSession });
+    const del = await request('/mcp', 'DELETE', {
+      'Mcp-Session-Id': mcpSession,
+      'X-Tenant-Id': 'acme',
+    });
     expect(del.status).toBe(200);
     expect(transport.getTenantForMcpSession(mcpSession)).toBeUndefined();
   });
@@ -221,6 +224,60 @@ it('STRICT mode rejects missing X-Tenant-Id with 400 (code=missing)', async () =
     const err = JSON.parse(res.body);
     expect(err.error.data.reason).toBe('unexpected_on_initialize');
     expect(transport.getTenantForMcpSession('client-chosen-id')).toBeUndefined();
+  });
+
+  it('rejects DELETE /mcp from a different tenant (no cross-tenant DoS)', async () => {
+    // Regression for Codex P1 #2: DELETE /mcp previously skipped
+    // resolveRequestTenant, so any caller who learned another tenant's
+    // Mcp-Session-Id could terminate that session by sending DELETE with
+    // no X-Tenant-Id or a mismatched one. Now DELETE runs through the
+    // same tenant_mismatch guard as POST/GET.
+    await boot();
+    const init = await mcpPost(
+      { 'X-Tenant-Id': 'acme' },
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+    );
+    const mcpSession = init.headers['mcp-session-id'] as string;
+    expect(transport.getTenantForMcpSession(mcpSession)).toBe('acme');
+
+    // Attacker (different tenant) tries to DELETE acme's session.
+    const evil = await request('/mcp', 'DELETE', {
+      'Mcp-Session-Id': mcpSession,
+      'X-Tenant-Id': 'evil',
+    });
+    expect(evil.status).toBe(400);
+    const err = JSON.parse(evil.body);
+    expect(err.error.data.reason).toBe('tenant_mismatch');
+    // Binding must still be intact.
+    expect(transport.getTenantForMcpSession(mcpSession)).toBe('acme');
+
+    // Owner can still DELETE.
+    const ownDel = await request('/mcp', 'DELETE', {
+      'Mcp-Session-Id': mcpSession,
+      'X-Tenant-Id': 'acme',
+    });
+    expect(ownDel.status).toBe(200);
+    expect(transport.getTenantForMcpSession(mcpSession)).toBeUndefined();
+  });
+
+  it('STRICT mode rejects DELETE /mcp missing X-Tenant-Id with 400', async () => {
+    // In STRICT mode a DELETE with no X-Tenant-Id would otherwise hit the
+    // missing-header 400 from the extractor — assert that behaviour so it
+    // does not regress to silently terminating the session.
+    process.env.OPENCHROME_STRICT_TENANT_ISOLATION = 'true';
+    await boot();
+    const init = await mcpPost(
+      { 'X-Tenant-Id': 'acme' },
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+    );
+    const mcpSession = init.headers['mcp-session-id'] as string;
+
+    const del = await request('/mcp', 'DELETE', { 'Mcp-Session-Id': mcpSession });
+    expect(del.status).toBe(400);
+    const err = JSON.parse(del.body);
+    expect(err.error.data.reason).toBe('missing');
+    // Session must still be alive.
+    expect(transport.getTenantForMcpSession(mcpSession)).toBe('acme');
   });
 
   it('advertises X-Tenant-Id in CORS Allow-Headers', async () => {

--- a/tests/transports/http-tenant.test.ts
+++ b/tests/transports/http-tenant.test.ts
@@ -189,6 +189,40 @@ it('STRICT mode rejects missing X-Tenant-Id with 400 (code=missing)', async () =
     expect(transport.getTenantForMcpSession(mcpSession)).toBeUndefined();
   });
 
+  it('rejects initialize that carries a client-supplied Mcp-Session-Id (no tenant bypass)', async () => {
+    // Regression for the Codex P1: previously, `initialize` with a
+    // pre-supplied Mcp-Session-Id would skip `sessionTenants.set(...)`,
+    // leaving the id unbound. A subsequent request could then present a
+    // different X-Tenant-Id because the mismatch guard only fires when
+    // a binding already exists. The transport now rejects such requests.
+    await boot();
+    const res = await mcpPost(
+      { 'X-Tenant-Id': 'acme', 'Mcp-Session-Id': 'client-chosen-id' },
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+    );
+    expect(res.status).toBe(400);
+    const err = JSON.parse(res.body);
+    expect(err.error.data.reason).toBe('unexpected_on_initialize');
+    expect(err.error.data.field).toBe('Mcp-Session-Id');
+    // And the client-chosen id must not have become a live binding.
+    expect(transport.getTenantForMcpSession('client-chosen-id')).toBeUndefined();
+  });
+
+  it('rejects batch containing initialize with client-supplied Mcp-Session-Id', async () => {
+    await boot();
+    const res = await mcpPost(
+      { 'X-Tenant-Id': 'acme', 'Mcp-Session-Id': 'client-chosen-id' },
+      [
+        { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+        { jsonrpc: '2.0', id: 2, method: 'ping' },
+      ],
+    );
+    expect(res.status).toBe(400);
+    const err = JSON.parse(res.body);
+    expect(err.error.data.reason).toBe('unexpected_on_initialize');
+    expect(transport.getTenantForMcpSession('client-chosen-id')).toBeUndefined();
+  });
+
   it('advertises X-Tenant-Id in CORS Allow-Headers', async () => {
     await boot();
     const res = await request('/mcp', 'OPTIONS', {


### PR DESCRIPTION
## Summary

Fourth slice of [#7](https://github.com/junghwan-oss/openchrome/issues/7). Hooks the tenant extractor from #27 into the HTTP transport so every \`/mcp\` request is validated at the edge and bound to the MCP session that owns it.

**Stacked on** [#30](https://github.com/junghwan-oss/openchrome/pull/30) — targets \`feat/b1-tenant-session\`. Will auto-retarget \`develop\` as parents merge.

## What this changes

### HTTP transport
- \`resolveRequestTenant(req, res)\` validates \`X-Tenant-Id\` against the extractor and:
  - **400** on malformed header (\`{ reason: 'invalid' }\`)
  - **400** on missing header when \`OPENCHROME_STRICT_TENANT_ISOLATION=true\` (\`{ reason: 'missing' }\`)
  - **400** when an already-bound \`Mcp-Session-Id\` carries a different tenant than its original (\`{ reason: 'tenant_mismatch' }\`)
  - Otherwise returns the resolved \`TenantId\` (defaults to \`'default'\` in non-strict mode)
- \`handlePost\` and \`processBatch\` record \`mcpSessionId → tenantId\` on \`initialize\`; \`handleDelete\` and \`close()\` purge the binding
- CORS \`Access-Control-Allow-Headers\` advertises \`X-Tenant-Id\`
- New public \`getTenantForMcpSession(id)\` lets MCPServer / tool handlers resolve the tenant without revalidating headers

### Why bind the tenant to the session
A leaked / stolen \`Mcp-Session-Id\` is still a concern. Binding means the request can only reuse the same tenant it originally initialised under. This closes the "swap the tenant header to hop workspaces" avenue before #30's STRICT mode flip makes it exploitable.

## Files

- \`src/transports/http.ts\` (+88 −9)
- \`tests/transports/http-tenant.test.ts\` (new, +225) — 10 tests:
  - valid header → 200
  - missing header non-strict → defaults to \`'default'\`
  - malformed → 400 \`invalid\`
  - leading-hyphen → 400 \`invalid\`
  - STRICT + missing → 400 \`missing\`
  - initialize binds tenant to MCP session
  - swap tenant on bound session → 400 \`tenant_mismatch\`
  - same tenant reuses bound session → 200
  - DELETE /mcp clears the binding
  - CORS advertises \`X-Tenant-Id\`

## Regression check

- \`tests/transports/\` — 32/32 passing (3 suites previously existing + new tenant suite)
- \`tests/middleware/\` + \`tests/tenant/\` — 37/37 passing from parent PRs
- \`npx tsc --noEmit\` — clean

## Not in this PR

- MCPServer / tool handler \`tenantId\` threading so \`createSession()\` actually receives the bound tenant — part 5/5
- Real-Chrome cross-tenant E2E (two tenants, same domain, verify cookies isolated) — part 5/5
- \`openchrome_tenant_contexts_active\` Prometheus gauge + periodic \`sweepIdle()\` timer — part 5/5

## Test plan

- [x] Tenant unit tests (12/12 — #24)
- [x] Middleware unit tests (25/25 — #27)
- [x] SessionManager tenant tests (9/9 — #30)
- [x] HTTP tenant tests (10/10)
- [x] \`npx tsc --noEmit\` clean
- [ ] Real-Chrome E2E covered in follow-up

Refs: https://github.com/junghwan-oss/openchrome/issues/7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Original comments

**@junghwan-oss — 2026-04-20T06:43:04Z**

@codex review

**@junghwan-oss — 2026-04-20T06:52:33Z**

@codex review

**@chatgpt-codex-connector — 2026-04-20T06:57:31Z**

Codex Review: Didn't find any major issues. Keep it up!

<details> <summary>ℹ️ About Codex in GitHub</summary>
<br/>

[Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you
- Open a pull request for review
- Mark a draft as ready
- Comment "@codex review".

If Codex has suggestions, it will comment; otherwise it will react with 👍.




Codex can also answer questions or update the PR. Try commenting "@codex address that feedback".
            
</details>

**@junghwan-oss — 2026-04-20T07:10:56Z**

## Review iteration complete

Addressed both Codex P1 findings plus two P2 defence-in-depth items surfaced by a local security pass.

### Commits on this review round
- **36b3c39** — `fix(tenant): reject initialize with client-supplied Mcp-Session-Id`
  - Closes Codex P1 #1 (tenant binding bypassed when client pre-chooses the session id).
- **3a6f35a** — `fix(tenant): guard DELETE /mcp with tenant validation (cross-tenant DoS)`
  - Closes Codex P1 #2. DELETE now routes through `resolveRequestTenant` like POST/GET.
- **19d700a** — `fix(tenant): reject duplicate initialize in batch; tag SSE conns with tenant`
  - Defence-in-depth: batch with two `initialize` messages → 400 `duplicate_initialize`; `SSEConnection` now carries `tenantId` so part 5/5 can add scoped broadcasts without another transport change.

### Known deferred (explicitly part 5/5)
- `send()` still broadcasts to all SSE connections. Filtering it by tenant requires the MCPServer-side `tenantId` threading that the PR body already defers to part 5/5. The groundwork (`tenantId` stored on each connection) is now in place.

### Verification
- `npx tsc --noEmit` — clean
- `tests/transports/ tests/middleware/ tests/tenant/` — **74/74 passing** (added 4 new tests: client-supplied session id rejection on single + batch, cross-tenant DELETE DoS, STRICT DELETE missing, duplicate-initialize batch)

PR is `MERGEABLE` + `CLEAN`.


---
_Migrated from junghwan-oss/openchrome#31 — originally by @junghwan-oss on 2026-04-20T04:48:16Z. Original state: OPEN._