### PR TITLE
feat(auth): HTTP middleware + scope gate + tenant rate-limiter (issue #9, PR 2/4)

### DIFF
--- a/src/auth/api-key-types.ts
+++ b/src/auth/api-key-types.ts
@@ -26,3 +26,11 @@ export interface ApiKeyCreateResult {
   record: ApiKey;
   plaintext: string;
 }
+
+// Request-scoped identity derived by the auth middleware. See src/middleware/auth.ts.
+export interface Principal {
+  tenantId: string;
+  scopes: Scope[];
+  keyId?: string;
+  mode: 'disabled' | 'legacy' | 'api-key';
+}

--- a/src/auth/scope-policy.ts
+++ b/src/auth/scope-policy.ts
@@ -1,0 +1,97 @@
+// Scope -> tool mapping for API-key authentication (issue #9).
+//
+// Classification rule of thumb:
+//   - WRITE_TOOLS: anything that can change browser/tab state, navigate,
+//     mutate the DOM, fill or submit forms, set cookies/storage, run JS,
+//     or trigger network/file-upload side effects.
+//   - ADMIN_TOOLS: admin-keys-* family. Empty for now; PR3 adds entries.
+//   - Everything else falls through to 'read' (screenshot, read_page,
+//     query_dom, find, inspect, wait_for, tabs_context, metrics, etc.).
+//
+// Scope implication: admin > write > read. 'headless-only' is an
+// AND-constraint the caller must enforce separately; it is not in the
+// implication chain.
+
+import type { Scope } from './api-key-types';
+
+export type ToolId = string;
+
+export const WRITE_TOOLS: ReadonlySet<ToolId> = new Set<ToolId>([
+  // User-facing interaction / mutation
+  'act',
+  'interact',
+  'click',
+  'type',
+  'press',
+  'scroll',
+  'drag_drop',
+  'lightweight_scroll',
+  'fill_form',
+  'form_input',
+  'file_upload',
+  'select_option',
+
+  // Navigation / tab lifecycle
+  'navigate',
+  'page_reload',
+  'tabs_create',
+  'tabs_close',
+
+  // Script / cookie / storage mutation
+  'javascript_tool',
+  'cookies',
+  'storage',
+  'http_auth',
+
+  // Network / device emulation (side-effects on session)
+  'network',
+  'request_intercept',
+  'emulate_device',
+  'user_agent',
+  'geolocation',
+
+  // Server-side session lifecycle
+  'oc_stop',
+  'oc_session_resume',
+  'oc_session_snapshot',
+  'oc_checkpoint',
+
+  // Orchestration (spawns workers, mutates workflow state)
+  'workflow_init',
+  'workflow_cleanup',
+  'worker_update',
+  'worker_complete',
+  'execute_plan',
+
+  // Recording lifecycle
+  'oc_recording_start',
+  'oc_recording_stop',
+
+  // Automation actions that are effectively writes
+  'computer',
+  'batch_execute',
+  'batch_paginate',
+  'crawl',
+  'crawl_sitemap',
+]);
+
+export const ADMIN_TOOLS: ReadonlySet<ToolId> = new Set<ToolId>([
+  // PR3 will add: 'admin_keys_create', 'admin_keys_list', ...
+]);
+
+export function requiredScope(toolId: ToolId): Scope {
+  if (ADMIN_TOOLS.has(toolId)) return 'admin';
+  if (WRITE_TOOLS.has(toolId)) return 'write';
+  return 'read';
+}
+
+export function isAllowed(toolId: ToolId, granted: readonly Scope[]): boolean {
+  if (!granted || granted.length === 0) return false;
+  const required = requiredScope(toolId);
+  if (granted.includes('admin')) return true;
+  if (required === 'admin') return false;
+  if (granted.includes('write')) return true;
+  if (required === 'write') return false;
+  // required === 'read'
+  return granted.includes('read');
+}

--- a/src/auth/scope-policy.ts
+++ b/src/auth/scope-policy.ts
@@ -1,12 +1,17 @@
 // Scope -> tool mapping for API-key authentication (issue #9).
 //
 // Classification rule of thumb:
+//   - ADMIN_TOOLS: admin-keys-* family. Empty for now; PR3 adds entries.
+//   - READ_TOOLS: explicit allow-list of non-mutating tools (safe for read-only
+//     API keys). Anything that only inspects page/tab/session state.
 //   - WRITE_TOOLS: anything that can change browser/tab state, navigate,
 //     mutate the DOM, fill or submit forms, set cookies/storage, run JS,
-//     or trigger network/file-upload side effects.
-//   - ADMIN_TOOLS: admin-keys-* family. Empty for now; PR3 adds entries.
-//   - Everything else falls through to 'read' (screenshot, read_page,
-//     query_dom, find, inspect, wait_for, tabs_context, metrics, etc.).
+//     or trigger network/file-upload side effects. Also includes composite
+//     tools whose subactions can mutate (e.g. `worker` with create/delete,
+//     `memory` with record/validate).
+//   - Unknown tools default to 'write' (least-privilege fail-safe): a new
+//     tool added without updating this file will reject read-only keys
+//     instead of silently granting them mutation capability.
 //
 // Scope implication: admin > write > read. 'headless-only' is an
 // AND-constraint the caller must enforce separately; it is not in the
@@ -15,6 +20,42 @@
 import type { Scope } from './api-key-types';
 
 export type ToolId = string;
+
+export const READ_TOOLS: ReadonlySet<ToolId> = new Set<ToolId>([
+  // Page/DOM inspection
+  'read_page',
+  'page_content',
+  'page_screenshot',
+  'page_pdf',
+  'query_dom',
+  'find',
+  'vision_find',
+  'inspect',
+
+  // Tab / session / profile introspection
+  'tabs_context',
+  'list_profiles',
+  'oc_profile_status',
+  'oc_get_connection_info',
+  'oc_connection_health',
+  'oc_journal',
+
+  // Diagnostics / metrics
+  'performance_metrics',
+  'console_capture',
+  'extract_data',
+  'wait_for',
+
+  // Workflow / recording read-only queries
+  'workflow_status',
+  'workflow_collect',
+  'workflow_collect_partial',
+  'oc_recording_list',
+  'oc_recording_export',
+
+  // Local, non-browser-mutating utilities
+  'oc_totp_generate',
+]);
 
 export const WRITE_TOOLS: ReadonlySet<ToolId> = new Set<ToolId>([
   // User-facing interaction / mutation
@@ -63,9 +104,17 @@ export const WRITE_TOOLS: ReadonlySet<ToolId> = new Set<ToolId>([
   'worker_complete',
   'execute_plan',
 
+  // Composite tools whose subactions can mutate state
+  'worker',   // create / delete subactions
+  'memory',   // record / validate subactions
+
   // Recording lifecycle
   'oc_recording_start',
   'oc_recording_stop',
+
+  // Host / clipboard mutations (affect the end-user environment)
+  'oc_copy_to_clipboard',
+  'oc_open_host_settings',
 
   // Automation actions that are effectively writes
   'computer',
@@ -81,8 +130,11 @@ export const ADMIN_TOOLS: ReadonlySet<ToolId> = new Set<ToolId>([
 
 export function requiredScope(toolId: ToolId): Scope {
   if (ADMIN_TOOLS.has(toolId)) return 'admin';
-  if (WRITE_TOOLS.has(toolId)) return 'write';
-  return 'read';
+  if (READ_TOOLS.has(toolId)) return 'read';
+  // Default: WRITE_TOOLS members AND any unlisted/new tools require 'write'.
+  // This fail-safes new composite tools (e.g. future `worker`-style additions)
+  // against read-only keys bypassing the least-privilege boundary.
+  return 'write';
 }
 
 export function isAllowed(toolId: ToolId, granted: readonly Scope[]): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -262,6 +262,27 @@ program
       console.error('[openchrome] Bearer token authentication: enabled');
     }
 
+    // Multi-tenant API key store: when OPENCHROME_API_KEYS_PATH points at a
+    // JSONL store file, load it and pass it to the HTTP transport so
+    // resolveAuthMode() selects `api-key` mode. Without this wiring the
+    // middleware/scope/rate-limit code from PR 2/4 would be unreachable from
+    // normal startup (the CLI never constructs a store otherwise). Admin-CLI
+    // key management lands in PR 3/4 (#32); this is the minimum plumbing to
+    // make api-key mode usable in this PR.
+    const apiKeysPath = process.env.OPENCHROME_API_KEYS_PATH;
+    let apiKeyStore: import('./auth/api-key-store').ApiKeyStore | undefined;
+    if (apiKeysPath) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { ApiKeyStore } = require('./auth/api-key-store');
+        apiKeyStore = await ApiKeyStore.open(apiKeysPath);
+        console.error(`[openchrome] API key store loaded from ${apiKeysPath} (api-key auth mode)`);
+      } catch (err) {
+        console.error(`[openchrome] Failed to load API key store at ${apiKeysPath}:`, err);
+        throw err;
+      }
+    }
+
     // Start transport (useHttp/transportMode determined above, before getMCPServer)
     let httpTransport: import('./transports/http').HTTPTransport | null = null;
 
@@ -270,7 +291,12 @@ program
       const httpPort = typeof options.http === 'string' ? parseInt(options.http, 10) : parseInt(process.env.OPENCHROME_HTTP_PORT || '', 10) || 3100;
       const httpHost = (options as Record<string, unknown>).httpHost as string || process.env.OPENCHROME_HTTP_HOST || '127.0.0.1';
       const { HTTPTransport } = require('./transports/http');
-      const httpTrans = new HTTPTransport(httpPort, httpHost, authToken) as import('./transports/http').HTTPTransport;
+      const httpTrans = new HTTPTransport(
+        httpPort,
+        httpHost,
+        authToken,
+        apiKeyStore ? { apiKeyStore } : undefined,
+      ) as import('./transports/http').HTTPTransport;
       httpTransport = httpTrans;
 
       // Start server with stdio as primary transport (wires JSON-RPC validation, rate-limiter, etc.)
@@ -287,7 +313,7 @@ program
     } else if (useHttp) {
       const httpPort = typeof options.http === 'string' ? parseInt(options.http, 10) : parseInt(process.env.OPENCHROME_HTTP_PORT || '', 10) || 3100;
       const httpHost = (options as Record<string, unknown>).httpHost as string || process.env.OPENCHROME_HTTP_HOST || '127.0.0.1';
-      const transport = createTransport('http', { port: httpPort, host: httpHost, authToken });
+      const transport = createTransport('http', { port: httpPort, host: httpHost, authToken, apiKeyStore });
       httpTransport = transport as import('./transports/http').HTTPTransport;
       server.start(transport);
       console.error(`[openchrome] HTTP transport enabled on ${httpHost}:${httpPort}`);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -165,6 +165,17 @@ export class MCPServer {
       this.exposedTier = options.initialToolTier;
     }
 
+    // Release the tenant binding as soon as the underlying session is
+    // destroyed (tool-triggered cascade, cleanup-on-shutdown, etc.) rather
+    // than waiting for the periodic sweep. This is the authoritative signal
+    // — sessionTenants is always keyed by the same sessionId space that
+    // sessionManager uses, unlike the transport's Mcp-Session-Id.
+    this.sessionManager.addEventListener((event) => {
+      if (event.type === 'session:deleted') {
+        this.sessionTenants.delete(event.sessionId);
+      }
+    });
+
     // Register built-in resources
     this.registerResource(usageGuideResource);
 
@@ -299,12 +310,41 @@ export class MCPServer {
         if (this.rateLimiter) {
           this.rateLimiter.removeSession(sessionId);
         }
-        // Also release the session-tenant binding so a future session with
-        // the same id (after UUID reuse across restarts, or an explicit
-        // client-chosen id) can be claimed by any tenant again.
-        this.sessionTenants.delete(sessionId);
+        // Intentionally NOT clearing sessionTenants here: the transport
+        // callback receives the HTTP `Mcp-Session-Id` (a UUID assigned at
+        // initialize), whereas tenant claims are keyed by the tool-call
+        // sessionId (client-supplied via params/toolArgs, defaulting to
+        // 'default'). Those two spaces don't match, so deleting by this id
+        // would usually be a no-op, and on an unlucky collision would drop
+        // someone else's binding. sessionTenants is instead reclaimed by
+        // (a) the MCP `sessions/delete` handler and (b) the periodic
+        // `sweepSessionTenants()` tick scheduled in start().
       },
     );
+  }
+
+  /**
+   * Remove `sessionTenants` entries whose underlying session no longer
+   * exists in sessionManager. Called on the same interval as the
+   * rate-limiter sweep so stale bindings don't accumulate when a tenant
+   * abandons a session without calling `sessions/delete` explicitly.
+   */
+  private sweepSessionTenants(): number {
+    if (this.sessionTenants.size === 0) return 0;
+    let live: Set<string>;
+    try {
+      live = new Set(this.sessionManager.getAllSessionInfos().map((s) => s.id));
+    } catch {
+      return 0;
+    }
+    let removed = 0;
+    for (const id of this.sessionTenants.keys()) {
+      if (!live.has(id)) {
+        this.sessionTenants.delete(id);
+        removed++;
+      }
+    }
+    return removed;
   }
 
   /**
@@ -405,6 +445,19 @@ export class MCPServer {
           }
         } catch (err) {
           console.error('[MCPServer] Rate-limiter sweep failed:', err);
+        }
+        // Piggyback: reclaim tenant-session bindings whose session no
+        // longer exists. Cheap (a single set-diff) and closes the gap
+        // that the transport onSessionDelete hook cannot cover — tool
+        // sessionIds are a separate namespace from the transport's
+        // Mcp-Session-Id UUIDs.
+        try {
+          const released = this.sweepSessionTenants();
+          if (released > 0) {
+            console.error(`[MCPServer] Tenant-binding sweep: released ${released} stale binding(s)`);
+          }
+        } catch (err) {
+          console.error('[MCPServer] Tenant-binding sweep failed:', err);
         }
       }, sweepIntervalMs);
       this.rateLimiterSweepTimer.unref();
@@ -656,15 +709,16 @@ export class MCPServer {
     }
 
     // Session-tenant binding (api-key mode only): reject if the session was
-    // already claimed by a different tenant. First api-key caller wins; other
-    // auth modes (disabled/legacy) and stdio callers are not subject to this
-    // check. Structural session-create binding lands in B-1 (#30/#31); this
-    // is the PR-2-scope defense-in-depth against cross-tenant session access.
+    // already claimed by a different tenant. First api-key caller to COMPLETE
+    // an authorized + validated call wins — the claim itself is deferred
+    // until after scope / tool / args checks pass, so a denied or invalid
+    // request cannot lock a sessionId and block other tenants.
+    // Other auth modes (disabled/legacy) and stdio callers are not subject
+    // to this check. Structural session-create binding lands in B-1
+    // (#30/#31); this is the PR-2-scope defense-in-depth.
     if (principal && principal.mode === 'api-key') {
       const claimedBy = this.sessionTenants.get(sessionId);
-      if (claimedBy === undefined) {
-        this.sessionTenants.set(sessionId, principal.tenantId);
-      } else if (claimedBy !== principal.tenantId) {
+      if (claimedBy !== undefined && claimedBy !== principal.tenantId) {
         console.error(
           `[MCPServer] tenant binding violation: session=${sessionId} claimedBy=${claimedBy} requestedBy=${principal.tenantId} tool=${toolName}`,
         );
@@ -766,6 +820,18 @@ export class MCPServer {
           isError: true,
         };
       }
+    }
+
+    // All static gates passed (scope, tool existence, required args). Only
+    // now do we claim the session for the caller's tenant — a denied or
+    // invalid call must NOT be able to lock a sessionId that would then
+    // block other tenants. (Codex round-6 P1.)
+    if (
+      principal &&
+      principal.mode === 'api-key' &&
+      !this.sessionTenants.has(sessionId)
+    ) {
+      this.sessionTenants.set(sessionId, principal.tenantId);
     }
 
     // Auto-expand tier if a higher-tier tool is called directly

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -671,12 +671,17 @@ export class MCPServer {
     }
 
     // Rate limit check — reject before doing any work.
-    // Key by tenantId when a principal is present so all sessions from the
-    // same tenant share one bucket; fall back to sessionId for stdio callers.
+    // Only switch to tenant-scoped keying in real api-key mode; disabled and
+    // legacy modes synthesize a fixed principal ('anonymous' / 'legacy'), so
+    // keying by their tenantId would collapse every HTTP session into one
+    // bucket and let one noisy client throttle unrelated sessions. Fall back
+    // to per-session keying for stdio callers (no principal) and for the
+    // synthetic disabled/legacy principals.
     if (this.rateLimiter) {
-      const rateLimitKey = principal
-        ? SessionRateLimiter.tenantKey(principal.tenantId)
-        : sessionId;
+      const rateLimitKey =
+        principal && principal.mode === 'api-key'
+          ? SessionRateLimiter.tenantKey(principal.tenantId)
+          : sessionId;
       const rateResult = this.rateLimiter.check(rateLimitKey);
       if (!rateResult.allowed) {
         console.error(`[MCPServer] Rate limit exceeded for session ${sessionId}, retry after ${rateResult.retryAfterSec}s`);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -474,15 +474,15 @@ export class MCPServer {
           break;
 
         case 'sessions/list':
-          result = await this.handleSessionsList();
+          result = await this.handleSessionsList(principal);
           break;
 
         case 'sessions/create':
-          result = await this.handleSessionsCreate(params);
+          result = await this.handleSessionsCreate(params, principal);
           break;
 
         case 'sessions/delete':
-          result = await this.handleSessionsDelete(params);
+          result = await this.handleSessionsDelete(params, principal);
           break;
 
         default:
@@ -1290,31 +1290,106 @@ export class MCPServer {
   }
 
   /**
-   * Handle sessions/list request
+   * Scope implication check (admin > write > read) without using a tool id.
+   * Used by session-management methods that are not registered tools.
    */
-  private async handleSessionsList(): Promise<MCPResult> {
-    const sessions = this.sessionManager.getAllSessionInfos();
+  private hasScope(principal: Principal, needed: 'read' | 'write' | 'admin'): boolean {
+    if (principal.scopes.includes('admin')) return true;
+    if (needed === 'admin') return false;
+    if (principal.scopes.includes('write')) return true;
+    if (needed === 'write') return false;
+    return principal.scopes.includes('read');
+  }
+
+  /**
+   * Return an MCP "Forbidden" error result; also emits an audit entry so
+   * the rejection is observable in the existing audit stream.
+   */
+  private forbiddenResult(
+    method: string,
+    sessionId: string,
+    principal: Principal,
+    text: string,
+  ): MCPResult {
+    try {
+      logAuditEntry(method, sessionId, {}, undefined, {
+        keyId: principal.keyId,
+        tenantId: principal.tenantId,
+        scopes: principal.scopes,
+      });
+    } catch {
+      // best-effort
+    }
+    return {
+      content: [{ type: 'text', text: `Forbidden: ${text}` }],
+      isError: true,
+    };
+  }
+
+  /**
+   * Handle sessions/list request. In api-key mode the result is filtered to
+   * sessions claimed by the caller's tenant (see sessionTenants); other auth
+   * modes and stdio callers see all sessions (no regression).
+   */
+  private async handleSessionsList(principal?: Principal): Promise<MCPResult> {
+    if (principal && !this.hasScope(principal, 'read')) {
+      return this.forbiddenResult('sessions/list', 'n/a', principal, `scope 'read' required`);
+    }
+    const all = this.sessionManager.getAllSessionInfos();
+    const visible = principal && principal.mode === 'api-key'
+      ? all.filter((s) => this.sessionTenants.get(s.id) === principal.tenantId)
+      : all;
     return {
       content: [
         {
           type: 'text',
-          text: JSON.stringify(sessions, null, 2),
+          text: JSON.stringify(visible, null, 2),
         },
       ],
     };
   }
 
   /**
-   * Handle sessions/create request
+   * Handle sessions/create request. Requires 'write' scope for authenticated
+   * callers. In api-key mode, a requested sessionId that is already claimed
+   * by a different tenant is rejected; on success the new session is bound
+   * to the caller's tenantId in sessionTenants.
    */
-  private async handleSessionsCreate(params?: Record<string, unknown>): Promise<MCPResult> {
+  private async handleSessionsCreate(
+    params?: Record<string, unknown>,
+    principal?: Principal,
+  ): Promise<MCPResult> {
     const sessionId = params?.sessionId as string | undefined;
     const name = params?.name as string | undefined;
+
+    if (principal && !this.hasScope(principal, 'write')) {
+      return this.forbiddenResult(
+        'sessions/create',
+        sessionId ?? 'n/a',
+        principal,
+        `scope 'write' required`,
+      );
+    }
+    if (principal && principal.mode === 'api-key' && sessionId) {
+      const owner = this.sessionTenants.get(sessionId);
+      if (owner !== undefined && owner !== principal.tenantId) {
+        return this.forbiddenResult(
+          'sessions/create',
+          sessionId,
+          principal,
+          `session '${sessionId}' is owned by another tenant`,
+        );
+      }
+    }
 
     const session = await this.sessionManager.createSession({
       id: sessionId,
       name,
     });
+
+    if (principal && principal.mode === 'api-key') {
+      this.sessionTenants.set(session.id, principal.tenantId);
+    }
 
     return {
       content: [
@@ -1335,15 +1410,48 @@ export class MCPServer {
   }
 
   /**
-   * Handle sessions/delete request
+   * Handle sessions/delete request. Requires 'write' scope and, in api-key
+   * mode, matching tenant ownership of the session. On successful delete
+   * the session-tenant binding is released so a later caller (possibly a
+   * different tenant) can claim the same sessionId — this is the MCP-method
+   * twin of the transport-level onSessionDelete hook wired in
+   * wireRateLimiterCleanup(), closing the cleanup gap that otherwise
+   * leaves stale bindings behind and produces spurious "owned by another
+   * tenant" rejections after logical deletion.
    */
-  private async handleSessionsDelete(params?: Record<string, unknown>): Promise<MCPResult> {
+  private async handleSessionsDelete(
+    params?: Record<string, unknown>,
+    principal?: Principal,
+  ): Promise<MCPResult> {
     const sessionId = params?.sessionId as string;
     if (!sessionId) {
       throw new Error('Missing sessionId');
     }
 
+    if (principal && !this.hasScope(principal, 'write')) {
+      return this.forbiddenResult(
+        'sessions/delete',
+        sessionId,
+        principal,
+        `scope 'write' required`,
+      );
+    }
+    if (principal && principal.mode === 'api-key') {
+      const owner = this.sessionTenants.get(sessionId);
+      if (owner !== undefined && owner !== principal.tenantId) {
+        return this.forbiddenResult(
+          'sessions/delete',
+          sessionId,
+          principal,
+          `session '${sessionId}' is owned by another tenant`,
+        );
+      }
+    }
+
     await this.sessionManager.deleteSession(sessionId);
+    // Release the binding so sessionId (notably 'default') can be reclaimed
+    // by a subsequent tenant after MCP-level deletion.
+    this.sessionTenants.delete(sessionId);
 
     return {
       content: [

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -34,6 +34,8 @@ import { getGlobalConfig } from './config/global';
 import { getToolTier, ToolTier } from './config/tool-tiers';
 import { getMetricsCollector } from './metrics/collector';
 import { logAuditEntry } from './security/audit-logger';
+import { isAllowed, requiredScope } from './auth/scope-policy';
+import type { Principal } from './auth/api-key-types';
 import { getVersion } from './version';
 import { isTimeoutError } from './errors/timeout';
 import { OpenChromeConnectionError } from './errors/connection';
@@ -291,6 +293,12 @@ export class MCPServer {
       };
     }
 
+    // Extract + remove the transport-injected principal. Absent for stdio.
+    const principal = (parsed as Record<string, unknown>).__principal as Principal | undefined;
+    if ('__principal' in parsed) {
+      delete (parsed as Record<string, unknown>).__principal;
+    }
+
     // Notifications have no `id` field — must NOT receive a response per JSON-RPC 2.0 spec
     if (parsed.id === undefined || parsed.id === null) {
       const method = parsed.method as string;
@@ -304,7 +312,7 @@ export class MCPServer {
     const request = parsed as unknown as MCPRequest;
 
     try {
-      return await this.handleRequest(request);
+      return await this.handleRequest(request, principal);
     } catch (error) {
       return {
         jsonrpc: '2.0' as const,
@@ -366,7 +374,7 @@ export class MCPServer {
   /**
    * Handle incoming MCP request
    */
-  async handleRequest(request: MCPRequest): Promise<MCPResponse> {
+  async handleRequest(request: MCPRequest, principal?: Principal): Promise<MCPResponse> {
     const requestReceivedAt = Date.now();
     const { id, method, params } = request;
 
@@ -383,7 +391,7 @@ export class MCPServer {
           break;
 
         case 'tools/call':
-          result = await this.handleToolsCall(params, id);
+          result = await this.handleToolsCall(params, id, principal);
           break;
 
         case 'resources/list':
@@ -558,7 +566,11 @@ export class MCPServer {
   /**
    * Handle tools/call request
    */
-  private async handleToolsCall(params?: Record<string, unknown>, requestId?: number | string): Promise<MCPResult> {
+  private async handleToolsCall(
+    params?: Record<string, unknown>,
+    requestId?: number | string,
+    principal?: Principal,
+  ): Promise<MCPResult> {
     if (!params) {
       throw new Error('Missing params for tools/call');
     }
@@ -570,6 +582,40 @@ export class MCPServer {
 
     if (!toolName) {
       throw new Error('Missing tool name');
+    }
+
+    // Scope gate: if a principal was provided by the transport, check it can
+    // call this tool. Absent principal (e.g. stdio) is treated as full access
+    // so there is no regression for non-HTTP users.
+    if (principal && !isAllowed(toolName, principal.scopes)) {
+      const needed = requiredScope(toolName);
+      console.error(
+        `[MCPServer] scope denied: tool=${toolName} tenant=${principal.tenantId} required=${needed} granted=${principal.scopes.join(',')}`,
+      );
+      try {
+        logAuditEntry(
+          toolName,
+          sessionId,
+          toolArgs,
+          undefined,
+          {
+            keyId: principal.keyId,
+            tenantId: principal.tenantId,
+            scopes: principal.scopes,
+          },
+        );
+      } catch {
+        // best-effort
+      }
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Forbidden: tool '${toolName}' requires scope '${needed}'.`,
+          },
+        ],
+        isError: true,
+      };
     }
 
     // Handle the expand_tools meta-tool before normal tool lookup
@@ -624,9 +670,14 @@ export class MCPServer {
       this.expandToolTier(toolTier);
     }
 
-    // Rate limit check — reject before doing any work
+    // Rate limit check — reject before doing any work.
+    // Key by tenantId when a principal is present so all sessions from the
+    // same tenant share one bucket; fall back to sessionId for stdio callers.
     if (this.rateLimiter) {
-      const rateResult = this.rateLimiter.check(sessionId);
+      const rateLimitKey = principal
+        ? SessionRateLimiter.tenantKey(principal.tenantId)
+        : sessionId;
+      const rateResult = this.rateLimiter.check(rateLimitKey);
       if (!rateResult.allowed) {
         console.error(`[MCPServer] Rate limit exceeded for session ${sessionId}, retry after ${rateResult.retryAfterSec}s`);
         try { getMetricsCollector().inc('openchrome_rate_limit_rejections_total', { tool: toolName }); } catch { /* best-effort */ }
@@ -839,8 +890,10 @@ export class MCPServer {
         }
       }
 
-      // Audit log successful invocation
-      logAuditEntry(toolName, sessionId, toolArgs);
+      // Audit log successful invocation (include auth context when present)
+      logAuditEntry(toolName, sessionId, toolArgs, undefined, principal
+        ? { keyId: principal.keyId, tenantId: principal.tenantId, scopes: principal.scopes }
+        : undefined);
 
       // End activity tracking (success)
       this.activityTracker!.endCall(callId, 'success');

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -134,6 +134,21 @@ export class MCPServer {
   private stopPromise: Promise<void> | null = null;
   private rateLimiter: SessionRateLimiter | null = null;
   /**
+   * Per-session tenant binding for api-key mode. The first api-key principal
+   * to touch a given sessionId "claims" the session; subsequent tools/call
+   * requests that arrive with a different tenantId are rejected with a 403,
+   * preventing a tenant with a valid API key from operating on a session
+   * created by another tenant (cross-tenant session hijack via a guessed /
+   * leaked sessionId). Cleared when the session is deleted (DELETE /mcp) via
+   * the same hook that reclaims rate-limit buckets.
+   *
+   * Structural enforcement (binding at session-create time via TenantManager,
+   * X-Tenant-Id header validation) lands in the tenant-propagation series
+   * (B-1, PRs #30 / #31). This map is the minimum defense-in-depth so
+   * PR 2/4 does not ship with a cross-tenant access path.
+   */
+  private sessionTenants: Map<string, string> = new Map();
+  /**
    * Timer that periodically reclaims idle rate-limit buckets. Required because
    * tenant-keyed buckets (used in api-key mode) are shared across sessions, so
    * the per-session DELETE /mcp cleanup hook cannot be used to evict them —
@@ -277,11 +292,19 @@ export class MCPServer {
    * in start().
    */
   wireRateLimiterCleanup(transport: MCPTransport): void {
-    if (this.rateLimiter && typeof (transport as unknown as { onSessionDelete?: unknown }).onSessionDelete === 'function') {
-      (transport as unknown as { onSessionDelete: (cb: (id: string) => void) => void }).onSessionDelete(
-        (sessionId: string) => this.rateLimiter!.removeSession(sessionId),
-      );
-    }
+    const hasHook = typeof (transport as unknown as { onSessionDelete?: unknown }).onSessionDelete === 'function';
+    if (!hasHook) return;
+    (transport as unknown as { onSessionDelete: (cb: (id: string) => void) => void }).onSessionDelete(
+      (sessionId: string) => {
+        if (this.rateLimiter) {
+          this.rateLimiter.removeSession(sessionId);
+        }
+        // Also release the session-tenant binding so a future session with
+        // the same id (after UUID reuse across restarts, or an explicit
+        // client-chosen id) can be claimed by any tenant again.
+        this.sessionTenants.delete(sessionId);
+      },
+    );
   }
 
   /**
@@ -630,6 +653,40 @@ export class MCPServer {
 
     if (!toolName) {
       throw new Error('Missing tool name');
+    }
+
+    // Session-tenant binding (api-key mode only): reject if the session was
+    // already claimed by a different tenant. First api-key caller wins; other
+    // auth modes (disabled/legacy) and stdio callers are not subject to this
+    // check. Structural session-create binding lands in B-1 (#30/#31); this
+    // is the PR-2-scope defense-in-depth against cross-tenant session access.
+    if (principal && principal.mode === 'api-key') {
+      const claimedBy = this.sessionTenants.get(sessionId);
+      if (claimedBy === undefined) {
+        this.sessionTenants.set(sessionId, principal.tenantId);
+      } else if (claimedBy !== principal.tenantId) {
+        console.error(
+          `[MCPServer] tenant binding violation: session=${sessionId} claimedBy=${claimedBy} requestedBy=${principal.tenantId} tool=${toolName}`,
+        );
+        try {
+          logAuditEntry(toolName, sessionId, toolArgs, undefined, {
+            keyId: principal.keyId,
+            tenantId: principal.tenantId,
+            scopes: principal.scopes,
+          });
+        } catch {
+          // best-effort
+        }
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Forbidden: session '${sessionId}' is owned by another tenant.`,
+            },
+          ],
+          isError: true,
+        };
+      }
     }
 
     // Scope gate: if a principal was provided by the transport, check it can

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -36,6 +36,7 @@ import { getMetricsCollector } from './metrics/collector';
 import { logAuditEntry } from './security/audit-logger';
 import { isAllowed, requiredScope } from './auth/scope-policy';
 import type { Principal } from './auth/api-key-types';
+import { PRINCIPAL_SYM } from './middleware/auth';
 import { getVersion } from './version';
 import { isTimeoutError } from './errors/timeout';
 import { OpenChromeConnectionError } from './errors/connection';
@@ -132,6 +133,14 @@ export class MCPServer {
   private heartbeatIdleTimer: NodeJS.Timeout | null = null;
   private stopPromise: Promise<void> | null = null;
   private rateLimiter: SessionRateLimiter | null = null;
+  /**
+   * Timer that periodically reclaims idle rate-limit buckets. Required because
+   * tenant-keyed buckets (used in api-key mode) are shared across sessions, so
+   * the per-session DELETE /mcp cleanup hook cannot be used to evict them —
+   * without this sweep, the bucket map would grow unbounded with each new
+   * tenant seen over process lifetime.
+   */
+  private rateLimiterSweepTimer: NodeJS.Timeout | null = null;
 
   constructor(sessionManager?: SessionManager, options: MCPServerOptions = {}) {
     this.sessionManager = sessionManager || getSessionManager();
@@ -260,6 +269,12 @@ export class MCPServer {
   /**
    * Wire rate-limiter session cleanup into the given transport so that
    * bucket memory is freed immediately when a client sends DELETE /mcp.
+   *
+   * Note: this only reclaims session-keyed buckets (legacy / disabled auth
+   * modes and stdio callers). Tenant-keyed buckets used in api-key mode
+   * are shared across sessions, so they cannot be evicted on a per-session
+   * DELETE — those rely on the periodic `rateLimiterSweepTimer` scheduled
+   * in start().
    */
   wireRateLimiterCleanup(transport: MCPTransport): void {
     if (this.rateLimiter && typeof (transport as unknown as { onSessionDelete?: unknown }).onSessionDelete === 'function') {
@@ -293,8 +308,17 @@ export class MCPServer {
       };
     }
 
-    // Extract + remove the transport-injected principal. Absent for stdio.
-    const principal = (parsed as Record<string, unknown>).__principal as Principal | undefined;
+    // Read the transport-injected principal via the non-forgeable Symbol key
+    // (see PRINCIPAL_SYM in src/middleware/auth.ts). JSON.parse cannot produce
+    // symbol-keyed properties, so anything under PRINCIPAL_SYM was placed here
+    // by the transport after authenticating the request — clients cannot
+    // spoof a principal by including `"__principal": {...}` in their JSON body.
+    const principal = (parsed as Record<PropertyKey, unknown>)[PRINCIPAL_SYM] as
+      | Principal
+      | undefined;
+    // Scrub any string-named `__principal` that a malicious caller may have
+    // embedded in the JSON. We don't read it, but deleting here prevents it
+    // from echoing back out via JSON.stringify in later response paths.
     if ('__principal' in parsed) {
       delete (parsed as Record<string, unknown>).__principal;
     }
@@ -338,6 +362,30 @@ export class MCPServer {
 
     // Wire rate-limiter session cleanup into the transport
     this.wireRateLimiterCleanup(this.transport);
+
+    // Schedule periodic sweep of idle rate-limit buckets. Per-session cleanup
+    // (via DELETE /mcp) cannot reclaim tenant-keyed buckets (shared across
+    // sessions in api-key mode), and also does not run for stdio callers, so
+    // without this sweep the bucket map would grow without bound. Defaults
+    // (sweep every 5 min, evict buckets idle > 15 min) are overridable via
+    // env for operators with unusual tenant cardinality.
+    if (this.rateLimiter) {
+      const sweepIntervalMs =
+        parseInt(process.env.OPENCHROME_RATE_LIMIT_SWEEP_INTERVAL_MS || '', 10) || 5 * 60_000;
+      const maxIdleMs =
+        parseInt(process.env.OPENCHROME_RATE_LIMIT_IDLE_MS || '', 10) || 15 * 60_000;
+      this.rateLimiterSweepTimer = setInterval(() => {
+        try {
+          const removed = this.rateLimiter!.sweep(maxIdleMs);
+          if (removed > 0) {
+            console.error(`[MCPServer] Rate-limiter sweep: reclaimed ${removed} idle bucket(s)`);
+          }
+        } catch (err) {
+          console.error('[MCPServer] Rate-limiter sweep failed:', err);
+        }
+      }, sweepIntervalMs);
+      this.rateLimiterSweepTimer.unref();
+    }
 
     console.error('[MCPServer] Starting server...');
 
@@ -1405,6 +1453,13 @@ export class MCPServer {
     // Stop dashboard
     if (this.dashboard) {
       this.dashboard.stop();
+    }
+
+    // Cancel the rate-limiter sweep timer (if running) so the process can
+    // exit cleanly and tests don't leak timers across runs.
+    if (this.rateLimiterSweepTimer) {
+      clearInterval(this.rateLimiterSweepTimer);
+      this.rateLimiterSweepTimer = null;
     }
 
     if (this.transport) {

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,0 +1,117 @@
+// Pluggable auth middleware for the HTTP transport (issue #9 / PR2).
+//
+// Resolves a request to a Principal according to the configured AuthMode.
+// Callers (the HTTP transport) receive either `{ ok: true, principal }` or
+// a structured failure `{ ok: false, status, error, keyId? }` — the keyId
+// on failure is the sha256-derived id of the *attempted* plaintext so audit
+// logs can reference the attempt without ever storing the plaintext itself.
+
+import * as crypto from 'node:crypto';
+import type { IncomingMessage } from 'node:http';
+import type { ApiKeyStore } from '../auth/api-key-store';
+import type { Principal, Scope } from '../auth/api-key-types';
+
+export type { Principal };
+
+export type AuthMode =
+  | { kind: 'disabled' }
+  | { kind: 'legacy-shared-token'; token: string }
+  | { kind: 'api-key'; store: ApiKeyStore };
+
+export type AuthResult =
+  | { ok: true; principal: Principal }
+  | { ok: false; status: 401 | 403; error: string; keyId?: string };
+
+// Per-request principal storage. The HTTP transport stashes the principal
+// under the IncomingMessage key so downstream handlers can retrieve it
+// without passing it through every call site.
+export const requestPrincipals: WeakMap<IncomingMessage, Principal> = new WeakMap();
+
+const KEY_PREFIX = 'oc_live_';
+
+function extractBearer(req: IncomingMessage): string | null {
+  const raw = req.headers['authorization'];
+  if (!raw || typeof raw !== 'string') return null;
+  if (!raw.startsWith('Bearer ')) return null;
+  return raw.slice(7);
+}
+
+function timingSafeStringEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return crypto.timingSafeEqual(ab, bb);
+}
+
+function computeKeyIdFromPlaintext(plaintext: string): string {
+  // Mirrors the derivation in ApiKeyStore so audit logs on failure can
+  // reference the same opaque id the store would have assigned.
+  const digest = crypto.createHash('sha256').update(plaintext).digest();
+  const ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+  let num = 0n;
+  for (const byte of digest) num = (num << 8n) | BigInt(byte);
+  let out = '';
+  while (num > 0n) {
+    out = ALPHABET[Number(num % 62n)] + out;
+    num = num / 62n;
+  }
+  return 'k_' + out.slice(0, 10);
+}
+
+export async function authenticate(
+  req: IncomingMessage,
+  mode: AuthMode,
+): Promise<AuthResult> {
+  if (mode.kind === 'disabled') {
+    return {
+      ok: true,
+      principal: {
+        tenantId: 'anonymous',
+        scopes: ['admin'] as Scope[],
+        mode: 'disabled',
+      },
+    };
+  }
+
+  const token = extractBearer(req);
+  if (!token) {
+    return { ok: false, status: 401, error: 'Unauthorized' };
+  }
+
+  if (mode.kind === 'legacy-shared-token') {
+    if (!timingSafeStringEqual(token, mode.token)) {
+      return { ok: false, status: 401, error: 'Unauthorized' };
+    }
+    return {
+      ok: true,
+      principal: {
+        tenantId: 'legacy',
+        scopes: ['admin'] as Scope[],
+        mode: 'legacy',
+      },
+    };
+  }
+
+  // mode.kind === 'api-key'
+  if (!token.startsWith(KEY_PREFIX)) {
+    return { ok: false, status: 401, error: 'Unauthorized' };
+  }
+  const attemptKeyId = computeKeyIdFromPlaintext(token);
+  const record = await mode.store.verify(token);
+  if (!record) {
+    return { ok: false, status: 401, error: 'Unauthorized', keyId: attemptKeyId };
+  }
+  // Fire-and-forget lastUsedAt update; failures must not block the request.
+  mode.store.touchLastUsed(record.keyId).catch((err) => {
+    console.error('[auth] touchLastUsed failed:', err);
+  });
+  return {
+    ok: true,
+    principal: {
+      tenantId: record.tenantId,
+      scopes: [...record.scopes],
+      keyId: record.keyId,
+      mode: 'api-key',
+    },
+  };
+}

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -44,8 +44,11 @@ function timingSafeStringEqual(a: string, b: string): boolean {
 }
 
 function computeKeyIdFromPlaintext(plaintext: string): string {
-  // Mirrors the derivation in ApiKeyStore so audit logs on failure can
-  // reference the same opaque id the store would have assigned.
+  // Mirrors the derivation in ApiKeyStore.base62Encode exactly — including
+  // the fixed-length left-padding — so audit logs on failure reference the
+  // same opaque id the store would have assigned. Without the pad, digests
+  // starting with zero bytes produced a shorter bigint string and a keyId
+  // that disagreed with the stored record, breaking correlation.
   const digest = crypto.createHash('sha256').update(plaintext).digest();
   const ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
   let num = 0n;
@@ -54,6 +57,10 @@ function computeKeyIdFromPlaintext(plaintext: string): string {
   while (num > 0n) {
     out = ALPHABET[Number(num % 62n)] + out;
     num = num / 62n;
+  }
+  const targetLen = Math.ceil((digest.length * Math.log(256)) / Math.log(62));
+  if (out.length < targetLen) {
+    out = ALPHABET[0].repeat(targetLen - out.length) + out;
   }
   return 'k_' + out.slice(0, 10);
 }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -13,6 +13,20 @@ import type { Principal, Scope } from '../auth/api-key-types';
 
 export type { Principal };
 
+/**
+ * Non-forgeable key used by the transport layer to attach a trusted Principal
+ * to a parsed JSON-RPC message before it reaches the MCP server core.
+ *
+ * Why a Symbol: `JSON.parse` can never produce symbol-keyed properties, so
+ * clients cannot inject this field through the wire payload. A string key
+ * like `__principal` would be forgeable by any caller that controls the
+ * JSON body (notably stdio callers, whose transport does not inject a
+ * principal at all). Using a symbol here eliminates the trust boundary
+ * question entirely — if `msg[PRINCIPAL_SYM]` is present, the transport
+ * set it.
+ */
+export const PRINCIPAL_SYM: unique symbol = Symbol('mcp.auth.principal');
+
 export type AuthMode =
   | { kind: 'disabled' }
   | { kind: 'legacy-shared-token'; token: string }

--- a/src/security/audit-logger.ts
+++ b/src/security/audit-logger.ts
@@ -14,6 +14,25 @@ interface AuditEntry {
   domain: string | null;  // extracted from page URL, null if N/A
   sessionId: string;
   args_summary: string;   // brief summary, no sensitive data
+  keyId?: string;         // api-key id (sha256-derived); never plaintext
+  tenantId?: string;      // tenant owner of the key
+  scopes?: string[];      // scopes granted by the key
+}
+
+export interface AuditEntryExtras {
+  keyId?: string;
+  tenantId?: string;
+  scopes?: readonly string[];
+}
+
+const PLAINTEXT_KEY_PREFIX = 'oc_live_';
+
+// Belt-and-braces: strip anything that looks like a plaintext API key from
+// audit inputs. The store never emits these, but defensive redaction here
+// prevents accidental leaks via caller-supplied args.
+function redactPlaintextKeys(value: string): string {
+  if (!value.includes(PLAINTEXT_KEY_PREFIX)) return value;
+  return value.replace(/oc_live_[A-Za-z0-9_]+/g, '[REDACTED]');
 }
 
 let logDirEnsured = false;
@@ -45,16 +64,23 @@ function summarizeArgs(args: Record<string, unknown>): string {
   for (const [key, value] of Object.entries(args)) {
     if (isSensitiveKey(key)) {
       safe[key] = '[REDACTED]';
-    } else if (typeof value === 'string' && value.length > 100) {
-      safe[key] = value.slice(0, 100) + '...';
+    } else if (typeof value === 'string') {
+      const redacted = redactPlaintextKeys(value);
+      safe[key] = redacted.length > 100 ? redacted.slice(0, 100) + '...' : redacted;
     } else {
       safe[key] = value;
     }
   }
-  return JSON.stringify(safe);
+  return redactPlaintextKeys(JSON.stringify(safe));
 }
 
-export function logAuditEntry(tool: string, sessionId: string, args: Record<string, unknown>, pageUrl?: string): void {
+export function logAuditEntry(
+  tool: string,
+  sessionId: string,
+  args: Record<string, unknown>,
+  pageUrl?: string,
+  extras?: AuditEntryExtras,
+): void {
   const config = getGlobalConfig();
   if (!config.security?.audit_log) return; // Disabled by default
 
@@ -64,6 +90,9 @@ export function logAuditEntry(tool: string, sessionId: string, args: Record<stri
     domain: extractDomain(pageUrl || (args.url as string)),
     sessionId,
     args_summary: summarizeArgs(args),
+    ...(extras?.keyId ? { keyId: extras.keyId } : {}),
+    ...(extras?.tenantId ? { tenantId: extras.tenantId } : {}),
+    ...(extras?.scopes ? { scopes: [...extras.scopes] } : {}),
   };
 
   const logPath = getLogPath();

--- a/src/security/audit-logger.ts
+++ b/src/security/audit-logger.ts
@@ -30,9 +30,17 @@ const PLAINTEXT_KEY_PREFIX = 'oc_live_';
 // Belt-and-braces: strip anything that looks like a plaintext API key from
 // audit inputs. The store never emits these, but defensive redaction here
 // prevents accidental leaks via caller-supplied args.
-function redactPlaintextKeys(value: string): string {
+//
+// Plaintext format: `oc_live_{tenantId}_{32 base62 chars}`. tenantId is
+// operator-supplied and is NOT restricted to [A-Za-z0-9_] — hyphens, dots,
+// and other characters are valid. Matching only `[A-Za-z0-9_]+` after the
+// prefix would stop at the first hyphen and leak the remainder of the key.
+// We therefore match greedily up to a JSON/log delimiter (whitespace, string
+// quote, or backslash) so the entire plaintext is redacted regardless of
+// the tenantId character set.
+export function redactPlaintextKeys(value: string): string {
   if (!value.includes(PLAINTEXT_KEY_PREFIX)) return value;
-  return value.replace(/oc_live_[A-Za-z0-9_]+/g, '[REDACTED]');
+  return value.replace(/oc_live_[^\s"'\\]+/g, '[REDACTED]');
 }
 
 let logDirEnsured = false;

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -20,6 +20,7 @@ import type { ApiKeyStore } from '../auth/api-key-store';
 import {
   authenticate,
   requestPrincipals,
+  PRINCIPAL_SYM,
   type AuthMode,
   type Principal,
 } from '../middleware/auth';
@@ -569,8 +570,15 @@ export class HTTPTransport implements MCPTransport {
         this.sessions.add(sessionId);
       }
 
+      // Strip any client-provided `__principal` (defense-in-depth: this field
+      // is a legacy string name; the trusted channel is the non-forgeable
+      // PRINCIPAL_SYM Symbol below, but we still scrub the string key so a
+      // malicious body cannot survive to downstream JSON serialization).
+      if ('__principal' in (msg as Record<string, unknown>)) {
+        delete (msg as Record<string, unknown>).__principal;
+      }
       if (principal) {
-        (msg as Record<string, unknown>).__principal = principal;
+        (msg as Record<PropertyKey, unknown>)[PRINCIPAL_SYM] = principal;
       }
 
       try {
@@ -722,8 +730,13 @@ export class HTTPTransport implements MCPTransport {
       }
 
       const record = msg as Record<string, unknown>;
+      // Same defense-in-depth as the single-message path: scrub any
+      // client-provided `__principal` and attach the trusted one via Symbol.
+      if ('__principal' in record) {
+        delete record.__principal;
+      }
       if (principal) {
-        record.__principal = principal;
+        (record as Record<PropertyKey, unknown>)[PRINCIPAL_SYM] = principal;
       }
 
       try {

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -16,6 +16,14 @@ import { MCPResponse, MCPErrorCodes } from '../types/mcp';
 import { MCPTransport } from './index';
 import { getDashboardState } from '../desktop/dashboard-state';
 import type { SessionManager } from '../session-manager';
+import type { ApiKeyStore } from '../auth/api-key-store';
+import {
+  authenticate,
+  requestPrincipals,
+  type AuthMode,
+  type Principal,
+} from '../middleware/auth';
+import { logAuditEntry } from '../security/audit-logger';
 
 /** Maximum allowed HTTP request body size (10 MB) to prevent OOM from oversized requests */
 const MAX_BODY_BYTES = 10 * 1024 * 1024;
@@ -29,12 +37,17 @@ interface SSEConnection {
   sessionId: string;
 }
 
+export interface HTTPTransportOptions {
+  apiKeyStore?: ApiKeyStore;
+}
+
 export class HTTPTransport implements MCPTransport {
   private server: http.Server | null = null;
   private messageHandler: ((msg: Record<string, unknown>) => Promise<MCPResponse | null>) | null = null;
   private port: number;
   private host: string;
   private authToken: string | undefined;
+  private authMode: AuthMode;
   private sessions: Set<string> = new Set();
   private sseConnections: SSEConnection[] = [];
   private sessionDeleteHandler: ((sessionId: string) => void) | null = null;
@@ -42,10 +55,43 @@ export class HTTPTransport implements MCPTransport {
   private readonly serverStartTime: number = Date.now();
   private sseKeepaliveTimer: ReturnType<typeof setInterval> | null = null;
 
-  constructor(port: number, host = '127.0.0.1', authToken?: string) {
+  constructor(
+    port: number,
+    host = '127.0.0.1',
+    authToken?: string,
+    options: HTTPTransportOptions = {},
+  ) {
     this.port = port;
     this.host = host;
     this.authToken = authToken;
+    this.authMode = HTTPTransport.resolveAuthMode(authToken, options.apiKeyStore);
+  }
+
+  /**
+   * Resolve the runtime auth mode from env + ctor args.
+   * Precedence:
+   *   1. Explicit env OPENCHROME_AUTH_MODE=legacy-shared-token with a token -> legacy
+   *   2. ApiKeyStore provided -> api-key
+   *   3. authToken provided (backwards compat) -> legacy
+   *   4. Nothing configured -> disabled
+   */
+  static resolveAuthMode(authToken: string | undefined, store: ApiKeyStore | undefined): AuthMode {
+    const envMode = process.env.OPENCHROME_AUTH_MODE;
+    if (envMode === 'legacy-shared-token' && authToken) {
+      return { kind: 'legacy-shared-token', token: authToken };
+    }
+    if (store) {
+      return { kind: 'api-key', store };
+    }
+    if (authToken) {
+      return { kind: 'legacy-shared-token', token: authToken };
+    }
+    return { kind: 'disabled' };
+  }
+
+  /** Returns the resolved principal for a given request, if any. */
+  static getPrincipal(req: http.IncomingMessage): Principal | undefined {
+    return requestPrincipals.get(req);
   }
 
   /**
@@ -143,8 +189,9 @@ export class HTTPTransport implements MCPTransport {
     const url = new URL(req.url || '/', `http://${this.host}:${this.port}`);
     const pathname = url.pathname;
 
-    // CORS headers for all responses — restrict origin when auth is enabled
-    res.setHeader('Access-Control-Allow-Origin', this.authToken ? 'null' : '*');
+    // CORS headers for all responses — restrict origin when auth is enforced
+    const authEnforced = this.authMode.kind !== 'disabled';
+    res.setHeader('Access-Control-Allow-Origin', authEnforced ? 'null' : '*');
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Mcp-Session-Id, Authorization');
     res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id');
@@ -162,18 +209,52 @@ export class HTTPTransport implements MCPTransport {
       return;
     }
 
-    // Bearer token validation: reject requests without valid token when configured
-    if (this.authToken) {
-      const authHeader = req.headers['authorization'];
-      const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : '';
-      const expected = Buffer.from(this.authToken);
-      const provided = Buffer.from(token);
-      if (provided.length !== expected.length || !crypto.timingSafeEqual(expected, provided)) {
-        res.writeHead(401, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Unauthorized' }));
-        return;
+    // Pluggable auth: resolves Principal or returns a structured failure.
+    // Route through a helper so we can keep this method synchronous in layout
+    // while awaiting the async middleware.
+    this.authenticateAndContinue(req, res, pathname, url).catch((err) => {
+      console.error('[HTTPTransport] Auth error:', err);
+      if (!res.headersSent) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Internal auth error' }));
       }
+    });
+  }
+
+  private async authenticateAndContinue(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    pathname: string,
+    url: URL,
+  ): Promise<void> {
+    const result = await authenticate(req, this.authMode);
+    if (!result.ok) {
+      // Audit the failure with the attempted keyId (never plaintext).
+      try {
+        logAuditEntry(
+          'auth_failure',
+          'anonymous',
+          { path: pathname, status: result.status },
+          undefined,
+          result.keyId ? { keyId: result.keyId } : undefined,
+        );
+      } catch {
+        // best-effort
+      }
+      res.writeHead(result.status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(result.keyId ? { error: result.error, keyId: result.keyId } : { error: result.error }));
+      return;
     }
+    requestPrincipals.set(req, result.principal);
+    this.routeAuthenticated(req, res, pathname, url);
+  }
+
+  private routeAuthenticated(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    pathname: string,
+    url: URL,
+  ): void {
 
     // ─── Dashboard REST API ────────────────────────────────────────────
     if (pathname === '/api/screenshot' && req.method === 'GET') {
@@ -442,9 +523,11 @@ export class HTTPTransport implements MCPTransport {
         return;
       }
 
+      const principal = requestPrincipals.get(req);
+
       // Handle JSON-RPC batch (array of requests)
       if (Array.isArray(parsed)) {
-        const results = await this.processBatch(parsed, sessionId);
+        const results = await this.processBatch(parsed, sessionId, principal);
         // Filter out null results (notifications don't produce responses)
         const responses = results.filter((r): r is MCPResponse => r !== null);
 
@@ -473,6 +556,10 @@ export class HTTPTransport implements MCPTransport {
       if (msg.method === 'initialize' && !sessionId) {
         sessionId = crypto.randomUUID();
         this.sessions.add(sessionId);
+      }
+
+      if (principal) {
+        (msg as Record<string, unknown>).__principal = principal;
       }
 
       try {
@@ -595,6 +682,7 @@ export class HTTPTransport implements MCPTransport {
   private async processBatch(
     messages: unknown[],
     sessionId: string | undefined,
+    principal?: Principal,
   ): Promise<(MCPResponse | null)[]> {
     const handler = this.messageHandler!;
 
@@ -623,6 +711,9 @@ export class HTTPTransport implements MCPTransport {
       }
 
       const record = msg as Record<string, unknown>;
+      if (principal) {
+        record.__principal = principal;
+      }
 
       try {
         return await handler(record);

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -70,14 +70,25 @@ export class HTTPTransport implements MCPTransport {
   /**
    * Resolve the runtime auth mode from env + ctor args.
    * Precedence:
-   *   1. Explicit env OPENCHROME_AUTH_MODE=legacy-shared-token with a token -> legacy
+   *   1. Explicit env OPENCHROME_AUTH_MODE=legacy-shared-token -> legacy
+   *      (fail-closed: throws if no token is configured; setting this env is
+   *      an explicit operator request to enforce auth, so we must not silently
+   *      downgrade to `disabled` on a wiring/secret-injection failure).
    *   2. ApiKeyStore provided -> api-key
    *   3. authToken provided (backwards compat) -> legacy
    *   4. Nothing configured -> disabled
    */
   static resolveAuthMode(authToken: string | undefined, store: ApiKeyStore | undefined): AuthMode {
     const envMode = process.env.OPENCHROME_AUTH_MODE;
-    if (envMode === 'legacy-shared-token' && authToken) {
+    if (envMode === 'legacy-shared-token') {
+      if (!authToken) {
+        throw new Error(
+          'OPENCHROME_AUTH_MODE=legacy-shared-token requires a shared token ' +
+            '(set OPENCHROME_AUTH_TOKEN or pass authToken to HTTPTransport). ' +
+            'Refusing to start with the env flag set but no token configured — ' +
+            'silently falling back to unauthenticated mode would be a security regression.',
+        );
+      }
       return { kind: 'legacy-shared-token', token: authToken };
     }
     if (store) {

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { MCPResponse } from '../types/mcp';
+import type { ApiKeyStore } from '../auth/api-key-store';
 
 /**
  * Abstraction over the wire protocol (stdio or HTTP).
@@ -39,6 +40,15 @@ export interface TransportOptions {
   port?: number;
   host?: string;
   authToken?: string;
+  /**
+   * Optional multi-tenant API key store. When provided, the HTTP transport
+   * resolves auth to `api-key` mode (see HTTPTransport.resolveAuthMode) and
+   * every /mcp request is authenticated against a stored key instead of the
+   * legacy shared token. Without this, the transport silently falls through
+   * to legacy or disabled mode — so real deployments that want per-tenant
+   * keys must pass this option.
+   */
+  apiKeyStore?: ApiKeyStore;
 }
 
 /**
@@ -51,7 +61,12 @@ export function createTransport(mode: TransportMode, options?: TransportOptions)
     // Use require to avoid loading HTTP module when not needed
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { HTTPTransport } = require('./http');
-    return new HTTPTransport(options?.port || 3100, options?.host || '127.0.0.1', options?.authToken);
+    return new HTTPTransport(
+      options?.port || 3100,
+      options?.host || '127.0.0.1',
+      options?.authToken,
+      options?.apiKeyStore ? { apiKeyStore: options.apiKeyStore } : undefined,
+    );
   }
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { StdioTransport } = require('./stdio');

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -74,8 +74,12 @@ export class TokenBucket {
 }
 
 /**
- * Manages per-session rate limiters.
- * Creates a bucket for each session on first use; cleans up when sessions are removed.
+ * Manages rate limiters keyed by an opaque identifier (tenant id, session id, ...).
+ * Creates a bucket for each key on first use; cleans up when keys are removed.
+ *
+ * Backwards compat: `check(id)` works with any string, so existing callers
+ * that pass a session id continue to work unchanged. New callers may pass
+ * a tenant id (via `tenantLimiter()`) to share one bucket across sessions.
  */
 export class SessionRateLimiter {
   private buckets: Map<string, TokenBucket> = new Map();
@@ -89,14 +93,14 @@ export class SessionRateLimiter {
   }
 
   /**
-   * Check if a request from the given session is allowed.
+   * Check if a request identified by the given key is allowed.
    * Returns { allowed: true } or { allowed: false, retryAfterSec }.
    */
-  check(sessionId: string): { allowed: true } | { allowed: false; retryAfterSec: number } {
-    let bucket = this.buckets.get(sessionId);
+  check(key: string): { allowed: true } | { allowed: false; retryAfterSec: number } {
+    let bucket = this.buckets.get(key);
     if (!bucket) {
       bucket = new TokenBucket(this.options);
-      this.buckets.set(sessionId, bucket);
+      this.buckets.set(key, bucket);
     }
 
     if (bucket.consume()) {
@@ -110,10 +114,23 @@ export class SessionRateLimiter {
   }
 
   /**
-   * Remove a session's bucket (call on session cleanup).
+   * Remove a key's bucket (call on session or tenant cleanup).
    */
-  removeSession(sessionId: string): void {
-    this.buckets.delete(sessionId);
+  removeSession(key: string): void {
+    this.buckets.delete(key);
+  }
+
+  /** Alias of removeSession for tenant-keyed callers. */
+  removeKey(key: string): void {
+    this.buckets.delete(key);
+  }
+
+  /**
+   * Return a stable key for a tenant. Prefix keeps it disjoint from session ids
+   * so an attacker cannot collide on a session id they happen to know.
+   */
+  static tenantKey(tenantId: string): string {
+    return `tenant:${tenantId}`;
   }
 
   /**

--- a/tests/auth/scope-policy.test.ts
+++ b/tests/auth/scope-policy.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="jest" />
 // Tests for src/auth/scope-policy.ts — PR2 (issue #9)
 
-import { isAllowed, requiredScope, WRITE_TOOLS, ADMIN_TOOLS } from '../../src/auth/scope-policy';
+import { isAllowed, requiredScope, WRITE_TOOLS, READ_TOOLS, ADMIN_TOOLS } from '../../src/auth/scope-policy';
 
 describe('requiredScope', () => {
   it('screenshot -> read', () => {
@@ -12,8 +12,17 @@ describe('requiredScope', () => {
     expect(requiredScope('navigate')).toBe('write');
   });
 
-  it('unknown tool defaults to read', () => {
-    expect(requiredScope('some_future_tool')).toBe('read');
+  it('unknown tool defaults to write (least-privilege fail-safe)', () => {
+    // New/unclassified tools require 'write' so that composite tools added
+    // after PR2 cannot be invoked by read-only keys by default.
+    expect(requiredScope('some_future_tool')).toBe('write');
+  });
+
+  it('composite tools with mutating subactions require write', () => {
+    // `worker` (create/delete) and `memory` (record/validate) must not be
+    // reachable by read-only keys — regression guard for the Codex P1 finding.
+    expect(requiredScope('worker')).toBe('write');
+    expect(requiredScope('memory')).toBe('write');
   });
 
   it('admin tools -> admin (empty set returns read for now)', () => {
@@ -51,19 +60,25 @@ describe('isAllowed', () => {
     expect(isAllowed('page_screenshot', ['write'])).toBe(true);
   });
 
+  it('read-only key is denied unclassified tools (fail-safe default)', () => {
+    expect(isAllowed('some_future_tool', ['read'])).toBe(false);
+    expect(isAllowed('some_future_tool', ['write'])).toBe(true);
+  });
+
   it('WRITE_TOOLS set contains expected browser-mutating tools', () => {
     expect(WRITE_TOOLS.has('navigate')).toBe(true);
     expect(WRITE_TOOLS.has('fill_form')).toBe(true);
     expect(WRITE_TOOLS.has('javascript_tool')).toBe(true);
     expect(WRITE_TOOLS.has('cookies')).toBe(true);
     expect(WRITE_TOOLS.has('interact')).toBe(true);
+    expect(WRITE_TOOLS.has('worker')).toBe(true);
+    expect(WRITE_TOOLS.has('memory')).toBe(true);
   });
 
-  it('read-only tools are NOT in WRITE_TOOLS', () => {
-    expect(WRITE_TOOLS.has('page_screenshot')).toBe(false);
-    expect(WRITE_TOOLS.has('read_page')).toBe(false);
-    expect(WRITE_TOOLS.has('query_dom')).toBe(false);
-    expect(WRITE_TOOLS.has('find')).toBe(false);
-    expect(WRITE_TOOLS.has('wait_for')).toBe(false);
+  it('read-only tools are in READ_TOOLS and NOT in WRITE_TOOLS', () => {
+    for (const t of ['page_screenshot', 'read_page', 'query_dom', 'find', 'wait_for']) {
+      expect(READ_TOOLS.has(t)).toBe(true);
+      expect(WRITE_TOOLS.has(t)).toBe(false);
+    }
   });
 });

--- a/tests/auth/scope-policy.test.ts
+++ b/tests/auth/scope-policy.test.ts
@@ -1,0 +1,69 @@
+/// <reference types="jest" />
+// Tests for src/auth/scope-policy.ts — PR2 (issue #9)
+
+import { isAllowed, requiredScope, WRITE_TOOLS, ADMIN_TOOLS } from '../../src/auth/scope-policy';
+
+describe('requiredScope', () => {
+  it('screenshot -> read', () => {
+    expect(requiredScope('page_screenshot')).toBe('read');
+  });
+
+  it('navigate -> write', () => {
+    expect(requiredScope('navigate')).toBe('write');
+  });
+
+  it('unknown tool defaults to read', () => {
+    expect(requiredScope('some_future_tool')).toBe('read');
+  });
+
+  it('admin tools -> admin (empty set returns read for now)', () => {
+    // ADMIN_TOOLS is empty in PR2; any call falls through to write/read
+    expect(ADMIN_TOOLS.size).toBe(0);
+  });
+});
+
+describe('isAllowed', () => {
+  // read-only principal
+  it('screenshot allowed with [read]', () => {
+    expect(isAllowed('page_screenshot', ['read'])).toBe(true);
+  });
+
+  it('navigate denied with [read]', () => {
+    expect(isAllowed('navigate', ['read'])).toBe(false);
+  });
+
+  it('navigate allowed with [write]', () => {
+    expect(isAllowed('navigate', ['write'])).toBe(true);
+  });
+
+  it('admin implies all tools allowed', () => {
+    expect(isAllowed('navigate', ['admin'])).toBe(true);
+    expect(isAllowed('page_screenshot', ['admin'])).toBe(true);
+    expect(isAllowed('javascript_tool', ['admin'])).toBe(true);
+  });
+
+  it('empty scopes denies everything', () => {
+    expect(isAllowed('page_screenshot', [])).toBe(false);
+    expect(isAllowed('navigate', [])).toBe(false);
+  });
+
+  it('write implies read tools are also allowed', () => {
+    expect(isAllowed('page_screenshot', ['write'])).toBe(true);
+  });
+
+  it('WRITE_TOOLS set contains expected browser-mutating tools', () => {
+    expect(WRITE_TOOLS.has('navigate')).toBe(true);
+    expect(WRITE_TOOLS.has('fill_form')).toBe(true);
+    expect(WRITE_TOOLS.has('javascript_tool')).toBe(true);
+    expect(WRITE_TOOLS.has('cookies')).toBe(true);
+    expect(WRITE_TOOLS.has('interact')).toBe(true);
+  });
+
+  it('read-only tools are NOT in WRITE_TOOLS', () => {
+    expect(WRITE_TOOLS.has('page_screenshot')).toBe(false);
+    expect(WRITE_TOOLS.has('read_page')).toBe(false);
+    expect(WRITE_TOOLS.has('query_dom')).toBe(false);
+    expect(WRITE_TOOLS.has('find')).toBe(false);
+    expect(WRITE_TOOLS.has('wait_for')).toBe(false);
+  });
+});

--- a/tests/middleware/auth.test.ts
+++ b/tests/middleware/auth.test.ts
@@ -1,0 +1,159 @@
+/// <reference types="jest" />
+// Tests for src/middleware/auth.ts — PR2 (issue #9)
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { IncomingMessage } from 'http';
+import { Socket } from 'net';
+import { ApiKeyStore } from '../../src/auth/api-key-store';
+import { authenticate, type AuthMode } from '../../src/middleware/auth';
+
+function makeReq(headers: Record<string, string> = {}): IncomingMessage {
+  const req = new IncomingMessage(new Socket());
+  Object.assign(req.headers, headers);
+  return req;
+}
+
+function tmpStore(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-auth-test-'));
+  return path.join(dir, 'api-keys.jsonl');
+}
+
+// ─── disabled mode ────────────────────────────────────────────────────────────
+
+describe('disabled mode', () => {
+  const mode: AuthMode = { kind: 'disabled' };
+
+  it('returns ok=true with admin scopes and no Bearer header', async () => {
+    const result = await authenticate(makeReq(), mode);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.principal.mode).toBe('disabled');
+    expect(result.principal.scopes).toContain('admin');
+    expect(result.principal.tenantId).toBe('anonymous');
+  });
+});
+
+// ─── legacy-shared-token mode ─────────────────────────────────────────────────
+
+describe('legacy-shared-token mode', () => {
+  const TOKEN = 'super-secret-token-xyz';
+  const mode: AuthMode = { kind: 'legacy-shared-token', token: TOKEN };
+
+  it('happy path — correct bearer returns legacy principal', async () => {
+    const req = makeReq({ authorization: `Bearer ${TOKEN}` });
+    const result = await authenticate(req, mode);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.principal.mode).toBe('legacy');
+    expect(result.principal.tenantId).toBe('legacy');
+    expect(result.principal.scopes).toContain('admin');
+    expect(result.principal.keyId).toBeUndefined();
+  });
+
+  it('wrong token returns 401', async () => {
+    const req = makeReq({ authorization: 'Bearer wrong-token' });
+    const result = await authenticate(req, mode);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(401);
+  });
+
+  it('missing Authorization header returns 401', async () => {
+    const result = await authenticate(makeReq(), mode);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(401);
+  });
+});
+
+// ─── api-key mode ─────────────────────────────────────────────────────────────
+
+describe('api-key mode', () => {
+  let store: ApiKeyStore;
+  let mode: AuthMode;
+
+  beforeEach(async () => {
+    store = await ApiKeyStore.open(tmpStore());
+    mode = { kind: 'api-key', store };
+  });
+
+  it('happy path — correct key returns principal with tenantId + scopes', async () => {
+    const { plaintext, record } = await store.create({
+      tenantId: 'acme',
+      scopes: ['read', 'write'],
+      description: 'test key',
+    });
+    const req = makeReq({ authorization: `Bearer ${plaintext}` });
+    const result = await authenticate(req, mode);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.principal.tenantId).toBe('acme');
+    expect(result.principal.scopes).toEqual(expect.arrayContaining(['read', 'write']));
+    expect(result.principal.keyId).toBe(record.keyId);
+    expect(result.principal.mode).toBe('api-key');
+  }, 20000);
+
+  it('wrong key returns 401 with a keyId in the failure result', async () => {
+    await store.create({ tenantId: 'acme', scopes: ['read'], description: '' });
+    // Construct a syntactically valid but wrong plaintext
+    const fakeKey = 'oc_live_acme_' + 'X'.repeat(32);
+    const req = makeReq({ authorization: `Bearer ${fakeKey}` });
+    const result = await authenticate(req, mode);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(401);
+    expect(result.keyId).toMatch(/^k_/);
+  }, 20000);
+
+  it('revoked key returns 401', async () => {
+    const { plaintext, record } = await store.create({
+      tenantId: 't1',
+      scopes: ['read'],
+      description: '',
+    });
+    await store.revoke(record.keyId);
+    const req = makeReq({ authorization: `Bearer ${plaintext}` });
+    const result = await authenticate(req, mode);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(401);
+  }, 20000);
+
+  it('expired key returns 401', async () => {
+    const { plaintext } = await store.create({
+      tenantId: 't2',
+      scopes: ['read'],
+      description: '',
+      expiresAt: Date.now() - 1000, // already expired
+    });
+    const req = makeReq({ authorization: `Bearer ${plaintext}` });
+    const result = await authenticate(req, mode);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(401);
+  }, 20000);
+
+  it('sets lastUsedAt via touchLastUsed (fire-and-forget)', async () => {
+    const { plaintext, record } = await store.create({
+      tenantId: 'touch-test',
+      scopes: ['read'],
+      description: '',
+    });
+    const before = Date.now();
+    const req = makeReq({ authorization: `Bearer ${plaintext}` });
+    await authenticate(req, mode);
+    // touchLastUsed is fire-and-forget from the middleware. It needs to acquire
+    // the file lock and append — poll until the value appears (max 5s).
+    let key: Awaited<ReturnType<typeof store.list>>[number] | undefined;
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 200));
+      const keys = await store.list();
+      key = keys.find((k) => k.keyId === record.keyId);
+      if (key?.lastUsedAt !== undefined) break;
+    }
+    expect(key?.lastUsedAt).toBeGreaterThanOrEqual(before);
+  }, 20000);
+});

--- a/tests/middleware/auth.test.ts
+++ b/tests/middleware/auth.test.ts
@@ -107,6 +107,25 @@ describe('api-key mode', () => {
     expect(result.keyId).toMatch(/^k_/);
   }, 20000);
 
+  it('successful auth produces the same keyId as the store (base62 padding parity)', async () => {
+    // Regression guard for Codex P2: middleware's computeKeyIdFromPlaintext
+    // omitted the base62 left-pad used by ApiKeyStore. Any drift re-surfaces
+    // as the middleware's attempt-keyId disagreeing with record.keyId.
+    const samples = 12;
+    for (let i = 0; i < samples; i++) {
+      const { plaintext, record } = await store.create({
+        tenantId: `t-${i}`,
+        scopes: ['read'],
+        description: '',
+      });
+      const req = makeReq({ authorization: `Bearer ${plaintext}` });
+      const result = await authenticate(req, mode);
+      expect(result.ok).toBe(true);
+      if (!result.ok) continue;
+      expect(result.principal.keyId).toBe(record.keyId);
+    }
+  }, 60000);
+
   it('revoked key returns 401', async () => {
     const { plaintext, record } = await store.create({
       tenantId: 't1',

--- a/tests/security/audit-redaction.test.ts
+++ b/tests/security/audit-redaction.test.ts
@@ -1,0 +1,54 @@
+/// <reference types="jest" />
+// Tests for redactPlaintextKeys in src/security/audit-logger.ts
+// Regression guard for Codex P2 (PR #28): redaction must not leak keys
+// whose tenantId contains hyphens, dots, or other non-[A-Za-z0-9_] chars.
+
+import { redactPlaintextKeys } from '../../src/security/audit-logger';
+
+describe('redactPlaintextKeys', () => {
+  it('redacts a plain key with alphanumeric tenantId', () => {
+    const k = 'oc_live_acme_' + 'a'.repeat(32);
+    expect(redactPlaintextKeys(k)).toBe('[REDACTED]');
+  });
+
+  it('redacts a key with hyphenated tenantId (Codex P2 regression)', () => {
+    const k = 'oc_live_acme-inc_' + 'b'.repeat(32);
+    const out = redactPlaintextKeys(k);
+    expect(out).toBe('[REDACTED]');
+    expect(out).not.toContain('inc');
+    expect(out).not.toContain('b'.repeat(4));
+  });
+
+  it('redacts a key with dotted tenantId', () => {
+    const k = 'oc_live_acme.prod_' + 'c'.repeat(32);
+    expect(redactPlaintextKeys(k)).toBe('[REDACTED]');
+  });
+
+  it('redacts embedded keys inside JSON strings', () => {
+    const raw = JSON.stringify({
+      token: 'oc_live_acme-eu_' + 'd'.repeat(32),
+      other: 'safe',
+    });
+    const out = redactPlaintextKeys(raw);
+    expect(out).toContain('[REDACTED]');
+    expect(out).not.toContain('acme-eu');
+    expect(out).not.toContain('d'.repeat(4));
+    expect(out).toContain('"other":"safe"');
+  });
+
+  it('redacts multiple keys in the same string', () => {
+    const s = 'first=oc_live_a-b_' + 'x'.repeat(32) + ' second=oc_live_c.d_' + 'y'.repeat(32);
+    const out = redactPlaintextKeys(s);
+    expect(out).toBe('first=[REDACTED] second=[REDACTED]');
+  });
+
+  it('preserves surrounding content', () => {
+    const k = 'oc_live_t-1_' + 'z'.repeat(32);
+    const s = `before "${k}" after`;
+    expect(redactPlaintextKeys(s)).toBe('before "[REDACTED]" after');
+  });
+
+  it('is a no-op when no prefix is present', () => {
+    expect(redactPlaintextKeys('nothing sensitive here')).toBe('nothing sensitive here');
+  });
+});

--- a/tests/security/principal-forgery.test.ts
+++ b/tests/security/principal-forgery.test.ts
@@ -1,0 +1,76 @@
+/// <reference types="jest" />
+// Regression guard for Codex round-3 P1 (PR #28): ensure a client-supplied
+// `__principal` string field in the JSON-RPC body cannot influence the
+// server's authorization context. The trusted channel is the non-forgeable
+// PRINCIPAL_SYM Symbol set by the transport; JSON.parse cannot produce
+// symbol-keyed properties, so a forged body should be stripped and ignored.
+
+import { PRINCIPAL_SYM, type Principal } from '../../src/middleware/auth';
+
+describe('principal forgery defense', () => {
+  it('PRINCIPAL_SYM is a Symbol (non-forgeable via JSON)', () => {
+    expect(typeof PRINCIPAL_SYM).toBe('symbol');
+    // JSON round-trip must not surface the symbol as a string key.
+    const obj: Record<PropertyKey, unknown> = {};
+    obj[PRINCIPAL_SYM] = { tenantId: 'trusted', scopes: ['admin'], mode: 'api-key' };
+    const serialized = JSON.stringify(obj);
+    const parsed = JSON.parse(serialized);
+    expect(parsed).toEqual({});
+    expect((parsed as Record<PropertyKey, unknown>)[PRINCIPAL_SYM]).toBeUndefined();
+  });
+
+  it('parsed JSON with a malicious __principal string key does not populate the symbol slot', () => {
+    // Simulates a stdio caller posting a crafted JSON-RPC body trying to
+    // impersonate `mode: 'api-key'` with arbitrary tenantId/scopes.
+    const body = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'navigate', arguments: { url: 'https://example.com' } },
+      __principal: { mode: 'api-key', tenantId: 'victim-tenant', scopes: ['admin'] },
+    });
+    const parsed = JSON.parse(body);
+    const principalFromSym = (parsed as Record<PropertyKey, unknown>)[PRINCIPAL_SYM] as
+      | Principal
+      | undefined;
+    expect(principalFromSym).toBeUndefined();
+    // The string key is present on parsed (JSON does deliver it), but code
+    // paths must only read PRINCIPAL_SYM — so this test documents the
+    // invariant that the forged field must never be authoritative.
+    expect(parsed.__principal).toBeDefined();
+  });
+
+  it('transport-injected symbol value is readable and survives property enumeration independent of JSON', () => {
+    // Models the HTTP transport path: after authenticating, the transport
+    // attaches the real principal via the symbol. Downstream code reads the
+    // symbol slot; any client-supplied `__principal` string is ignored and
+    // scrubbed.
+    const injectedPrincipal: Principal = {
+      tenantId: 'real-tenant',
+      scopes: ['read'],
+      keyId: 'k_abc',
+      mode: 'api-key',
+    };
+    const parsed = JSON.parse(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        __principal: { mode: 'api-key', tenantId: 'attacker', scopes: ['admin'] },
+      }),
+    ) as Record<PropertyKey, unknown>;
+
+    // Simulate handleMessage's scrubbing step:
+    if ('__principal' in parsed) delete (parsed as Record<string, unknown>).__principal;
+    // Simulate transport injection:
+    parsed[PRINCIPAL_SYM] = injectedPrincipal;
+
+    const readBack = parsed[PRINCIPAL_SYM] as Principal;
+    expect(readBack.tenantId).toBe('real-tenant');
+    expect(readBack.scopes).toEqual(['read']);
+    expect(parsed.__principal).toBeUndefined();
+    // JSON re-serialization must not leak the injected principal back to the wire.
+    expect(JSON.stringify(parsed)).not.toContain('real-tenant');
+    expect(JSON.stringify(parsed)).not.toContain('k_abc');
+  });
+});

--- a/tests/security/session-methods-authz.test.ts
+++ b/tests/security/session-methods-authz.test.ts
@@ -1,0 +1,181 @@
+/// <reference types="jest" />
+// Regression guard for Codex round-5 P1 + P2 (PR #28):
+//   P1: `sessions/{list,create,delete}` must enforce scope + tenant binding
+//       (previously only `tools/call` did).
+//   P2: `sessions/delete` via JSON-RPC must clear the sessionTenants binding
+//       so the sessionId can be reclaimed by another tenant afterwards.
+
+import { MCPServer } from '../../src/mcp-server';
+import type { Principal } from '../../src/auth/api-key-types';
+import { PRINCIPAL_SYM } from '../../src/middleware/auth';
+
+const originalEnv = { ...process.env };
+
+function principal(tenantId: string, scopes: Principal['scopes']): Principal {
+  return { tenantId, scopes, mode: 'api-key', keyId: `k_${tenantId.slice(0, 8)}` };
+}
+
+function msg(
+  method: string,
+  params: Record<string, unknown>,
+  p?: Principal,
+  id = 1,
+): Record<PropertyKey, unknown> {
+  const m: Record<PropertyKey, unknown> = { jsonrpc: '2.0', id, method, params };
+  if (p) m[PRINCIPAL_SYM] = p;
+  return m;
+}
+
+function extractResult(resp: unknown): { text: string; isError: boolean } {
+  const r = resp as { result?: { content?: Array<{ text?: string }>; isError?: boolean } };
+  const text = r?.result?.content?.[0]?.text ?? '';
+  return { text, isError: Boolean(r?.result?.isError) };
+}
+
+describe('sessions/* authz (MCPServer round-5)', () => {
+  let server: MCPServer;
+
+  beforeAll(() => {
+    process.env.OPENCHROME_AUTO_LAUNCH = 'false';
+    process.env.OPENCHROME_RATE_LIMIT_RPM = '0';
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  beforeEach(() => {
+    server = new MCPServer();
+  });
+
+  describe('sessions/create', () => {
+    it('read-only api-key is denied (scope gate)', async () => {
+      const alice = principal('alice', ['read']);
+      const resp = await server.handleMessage(
+        msg('sessions/create', { sessionId: 's-create-1' }, alice),
+      );
+      const { text, isError } = extractResult(resp);
+      expect(isError).toBe(true);
+      expect(text).toContain("scope 'write' required");
+    });
+
+    it('write-scoped tenant that does not own the requested sessionId is rejected', async () => {
+      const alice = principal('alice', ['read', 'write']);
+      const bob = principal('bob', ['read', 'write']);
+
+      // Alice claims the id first (via tools/call → sessionTenants).
+      await server.handleMessage(
+        msg(
+          'tools/call',
+          { name: 'wait_for', arguments: { sessionId: 's-create-2', condition: 'timeout', timeoutMs: 1 } },
+          alice,
+        ),
+      );
+      // Bob tries to explicitly (re)create the same id.
+      const resp = await server.handleMessage(
+        msg('sessions/create', { sessionId: 's-create-2' }, bob, 2),
+      );
+      const { text, isError } = extractResult(resp);
+      expect(isError).toBe(true);
+      expect(text).toContain('owned by another tenant');
+    }, 20000);
+  });
+
+  describe('sessions/delete', () => {
+    it('read-only api-key is denied (scope gate)', async () => {
+      const alice = principal('alice', ['read']);
+      const resp = await server.handleMessage(
+        msg('sessions/delete', { sessionId: 's-del-1' }, alice),
+      );
+      const { text, isError } = extractResult(resp);
+      expect(isError).toBe(true);
+      expect(text).toContain("scope 'write' required");
+    });
+
+    it('tenant cannot delete a session owned by another tenant', async () => {
+      const alice = principal('alice', ['read', 'write']);
+      const bob = principal('bob', ['read', 'write']);
+      await server.handleMessage(
+        msg(
+          'tools/call',
+          { name: 'wait_for', arguments: { sessionId: 's-del-2', condition: 'timeout', timeoutMs: 1 } },
+          alice,
+        ),
+      );
+      const resp = await server.handleMessage(
+        msg('sessions/delete', { sessionId: 's-del-2' }, bob, 2),
+      );
+      const { text, isError } = extractResult(resp);
+      expect(isError).toBe(true);
+      expect(text).toContain('owned by another tenant');
+    }, 20000);
+
+    it('successful delete releases the binding so another tenant can reclaim the id', async () => {
+      const alice = principal('alice', ['read', 'write']);
+      const bob = principal('bob', ['read', 'write']);
+      await server.handleMessage(
+        msg(
+          'tools/call',
+          { name: 'wait_for', arguments: { sessionId: 's-del-3', condition: 'timeout', timeoutMs: 1 } },
+          alice,
+        ),
+      );
+      // Alice deletes her own session through the MCP method — this must
+      // also clear sessionTenants (round-5 P2). If it doesn't, Bob's next
+      // call below would spuriously fail with "owned by another tenant".
+      const del = await server.handleMessage(
+        msg('sessions/delete', { sessionId: 's-del-3' }, alice, 2),
+      );
+      expect(extractResult(del).isError).toBe(false);
+
+      const reclaim = await server.handleMessage(
+        msg(
+          'tools/call',
+          { name: 'wait_for', arguments: { sessionId: 's-del-3', condition: 'timeout', timeoutMs: 1 } },
+          bob,
+          3,
+        ),
+      );
+      const { text } = extractResult(reclaim);
+      expect(text).not.toContain('owned by another tenant');
+    }, 20000);
+  });
+
+  describe('sessions/list', () => {
+    it('read-only api-key can list (scope check passes)', async () => {
+      const alice = principal('alice', ['read']);
+      const resp = await server.handleMessage(msg('sessions/list', {}, alice));
+      expect(extractResult(resp).isError).toBe(false);
+    });
+
+    it('api-key caller only sees sessions claimed by their own tenant', async () => {
+      const alice = principal('alice', ['read', 'write']);
+      const bob = principal('bob', ['read', 'write']);
+      await server.handleMessage(
+        msg(
+          'tools/call',
+          { name: 'wait_for', arguments: { sessionId: 's-list-a', condition: 'timeout', timeoutMs: 1 } },
+          alice,
+        ),
+      );
+      await server.handleMessage(
+        msg(
+          'tools/call',
+          { name: 'wait_for', arguments: { sessionId: 's-list-b', condition: 'timeout', timeoutMs: 1 } },
+          bob,
+          2,
+        ),
+      );
+      const aliceList = await server.handleMessage(msg('sessions/list', {}, alice, 3));
+      const bobList = await server.handleMessage(msg('sessions/list', {}, bob, 4));
+      // Alice's view must not include Bob's sessionId, and vice versa.
+      expect(extractResult(aliceList).text).not.toContain('s-list-b');
+      expect(extractResult(bobList).text).not.toContain('s-list-a');
+    }, 20000);
+  });
+
+  it('stdio callers (no principal) can still use session methods', async () => {
+    const resp = await server.handleMessage(msg('sessions/list', {}));
+    expect(extractResult(resp).isError).toBe(false);
+  });
+});

--- a/tests/security/tenant-session-binding.test.ts
+++ b/tests/security/tenant-session-binding.test.ts
@@ -1,0 +1,102 @@
+/// <reference types="jest" />
+// Regression guard for Codex round-4 P1 (PR #28): an authenticated tenant
+// must not be able to operate on a session already claimed by a different
+// tenant. The PR-scope defense-in-depth is a per-session tenant map in
+// MCPServer; structural binding (at session-create time) lands later.
+//
+// Full HTTP E2E coverage is explicitly deferred to PR 4/4 per the PR
+// description; this suite asserts the core invariant at the MCPServer
+// layer directly.
+
+import { MCPServer } from '../../src/mcp-server';
+import type { Principal } from '../../src/auth/api-key-types';
+import { PRINCIPAL_SYM } from '../../src/middleware/auth';
+
+const originalEnv = { ...process.env };
+
+function principal(tenantId: string, scopes: Principal['scopes'] = ['read', 'write']): Principal {
+  return { tenantId, scopes, mode: 'api-key', keyId: `k_${tenantId.slice(0, 8)}` };
+}
+
+function msg(method: string, params: Record<string, unknown>, p: Principal, id = 1): Record<PropertyKey, unknown> {
+  const m: Record<PropertyKey, unknown> = { jsonrpc: '2.0', id, method, params };
+  m[PRINCIPAL_SYM] = p;
+  return m;
+}
+
+describe('tenant-session binding (MCPServer)', () => {
+  let server: MCPServer;
+
+  beforeAll(() => {
+    // Avoid Chrome/CDP auto-launch for this unit-level test.
+    process.env.OPENCHROME_AUTO_LAUNCH = 'false';
+    process.env.OPENCHROME_RATE_LIMIT_RPM = '0';
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  beforeEach(() => {
+    server = new MCPServer();
+  });
+
+  it('first api-key caller claims the session; same tenant is allowed to re-enter', async () => {
+    const alice = principal('alice');
+    // Use a trivial read-only tool so we can avoid heavy fixtures.
+    const r1 = await server.handleMessage(
+      msg('tools/call', { name: 'wait_for', arguments: { sessionId: 's-1', condition: 'timeout', timeoutMs: 1 } }, alice),
+    );
+    expect(r1).not.toBeNull();
+    // Shape: response is a JSON-RPC response (may be error or success — we don't
+    // care here, only that it isn't the 403-tenant-binding error).
+    const body1 = JSON.stringify(r1);
+    expect(body1).not.toContain('owned by another tenant');
+
+    const r2 = await server.handleMessage(
+      msg('tools/call', { name: 'wait_for', arguments: { sessionId: 's-1', condition: 'timeout', timeoutMs: 1 } }, alice, 2),
+    );
+    const body2 = JSON.stringify(r2);
+    expect(body2).not.toContain('owned by another tenant');
+  }, 20000);
+
+  it('second tenant is rejected with 403-equivalent error on the claimed session', async () => {
+    const alice = principal('alice');
+    const bob = principal('bob');
+    await server.handleMessage(
+      msg('tools/call', { name: 'wait_for', arguments: { sessionId: 's-2', condition: 'timeout', timeoutMs: 1 } }, alice),
+    );
+    const resp = await server.handleMessage(
+      msg('tools/call', { name: 'wait_for', arguments: { sessionId: 's-2', condition: 'timeout', timeoutMs: 1 } }, bob, 2),
+    );
+    expect(resp).not.toBeNull();
+    const body = JSON.stringify(resp);
+    expect(body).toContain('owned by another tenant');
+    expect(body).toContain('s-2');
+  }, 20000);
+
+  it('disabled / legacy principals are unaffected (no binding enforced)', async () => {
+    const disabled: Principal = { tenantId: 'anonymous', scopes: ['admin'], mode: 'disabled' };
+    const legacy: Principal = { tenantId: 'legacy', scopes: ['admin'], mode: 'legacy' };
+    // Both "tenants" share the legacy synthetic id but must still coexist.
+    const r1 = await server.handleMessage(
+      msg('tools/call', { name: 'wait_for', arguments: { sessionId: 's-3', condition: 'timeout', timeoutMs: 1 } }, disabled),
+    );
+    const r2 = await server.handleMessage(
+      msg('tools/call', { name: 'wait_for', arguments: { sessionId: 's-3', condition: 'timeout', timeoutMs: 1 } }, legacy, 2),
+    );
+    expect(JSON.stringify(r1)).not.toContain('owned by another tenant');
+    expect(JSON.stringify(r2)).not.toContain('owned by another tenant');
+  }, 20000);
+
+  it('stdio callers (no principal) are unaffected', async () => {
+    const m: Record<string, unknown> = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'wait_for', arguments: { sessionId: 's-4', condition: 'timeout', timeoutMs: 1 } },
+    };
+    const resp = await server.handleMessage(m);
+    expect(JSON.stringify(resp)).not.toContain('owned by another tenant');
+  }, 20000);
+});

--- a/tests/transports/http-auth-mode.test.ts
+++ b/tests/transports/http-auth-mode.test.ts
@@ -1,0 +1,56 @@
+/// <reference types="jest" />
+// Tests for HTTPTransport.resolveAuthMode — Codex P1 regression guard (PR #28).
+// When OPENCHROME_AUTH_MODE=legacy-shared-token is set, the transport must fail
+// closed if no token is configured instead of silently downgrading to `disabled`.
+
+import { HTTPTransport } from '../../src/transports/http';
+
+describe('HTTPTransport.resolveAuthMode', () => {
+  const ORIGINAL_ENV = process.env.OPENCHROME_AUTH_MODE;
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.OPENCHROME_AUTH_MODE;
+    } else {
+      process.env.OPENCHROME_AUTH_MODE = ORIGINAL_ENV;
+    }
+  });
+
+  it('throws when OPENCHROME_AUTH_MODE=legacy-shared-token is set but no token is configured', () => {
+    process.env.OPENCHROME_AUTH_MODE = 'legacy-shared-token';
+    expect(() => HTTPTransport.resolveAuthMode(undefined, undefined)).toThrow(
+      /OPENCHROME_AUTH_MODE=legacy-shared-token requires a shared token/,
+    );
+  });
+
+  it('throws even when an ApiKeyStore is also available (env flag must win explicitly)', () => {
+    process.env.OPENCHROME_AUTH_MODE = 'legacy-shared-token';
+    const fakeStore = {} as Parameters<typeof HTTPTransport.resolveAuthMode>[1];
+    expect(() => HTTPTransport.resolveAuthMode(undefined, fakeStore)).toThrow();
+  });
+
+  it('returns legacy mode when env + token are both set (happy path)', () => {
+    process.env.OPENCHROME_AUTH_MODE = 'legacy-shared-token';
+    const mode = HTTPTransport.resolveAuthMode('shared-secret', undefined);
+    expect(mode.kind).toBe('legacy-shared-token');
+  });
+
+  it('returns api-key mode when store is provided and no env flag is set', () => {
+    delete process.env.OPENCHROME_AUTH_MODE;
+    const fakeStore = {} as Parameters<typeof HTTPTransport.resolveAuthMode>[1];
+    const mode = HTTPTransport.resolveAuthMode(undefined, fakeStore);
+    expect(mode.kind).toBe('api-key');
+  });
+
+  it('returns legacy mode for backwards-compat when only authToken is passed (no env)', () => {
+    delete process.env.OPENCHROME_AUTH_MODE;
+    const mode = HTTPTransport.resolveAuthMode('legacy-token', undefined);
+    expect(mode.kind).toBe('legacy-shared-token');
+  });
+
+  it('returns disabled when nothing is configured', () => {
+    delete process.env.OPENCHROME_AUTH_MODE;
+    const mode = HTTPTransport.resolveAuthMode(undefined, undefined);
+    expect(mode.kind).toBe('disabled');
+  });
+});

--- a/tests/utils/rate-limiter-sweep.test.ts
+++ b/tests/utils/rate-limiter-sweep.test.ts
@@ -1,0 +1,37 @@
+/// <reference types="jest" />
+// Regression guard for Codex round-3 P2 (PR #28): tenant-keyed rate-limit
+// buckets are not reclaimed by the per-session DELETE /mcp hook (they are
+// shared across sessions), so the limiter must expose a sweep() that reclaims
+// buckets idle beyond a cutoff. The MCP server schedules this on start().
+
+import { SessionRateLimiter } from '../../src/utils/rate-limiter';
+
+describe('SessionRateLimiter.sweep', () => {
+  it('reclaims tenant-keyed buckets once they pass the idle cutoff', () => {
+    const limiter = new SessionRateLimiter(60);
+    const tenants = ['alpha', 'beta', 'gamma'].map(SessionRateLimiter.tenantKey);
+    for (const key of tenants) {
+      expect(limiter.check(key)).toEqual({ allowed: true });
+    }
+    expect(limiter.sessionCount).toBe(3);
+
+    // Nothing idle yet — cutoff far in the future.
+    expect(limiter.sweep(24 * 60 * 60 * 1000)).toBe(0);
+    expect(limiter.sessionCount).toBe(3);
+
+    // Cutoff in the past relative to lastUsedAt — all three go.
+    expect(limiter.sweep(-1)).toBe(3);
+    expect(limiter.sessionCount).toBe(0);
+  });
+
+  it('leaves recently-used buckets alone and removes only stale ones', async () => {
+    const limiter = new SessionRateLimiter(60);
+    limiter.check(SessionRateLimiter.tenantKey('old'));
+    await new Promise((r) => setTimeout(r, 25));
+    limiter.check(SessionRateLimiter.tenantKey('fresh'));
+
+    const removed = limiter.sweep(10); // older than 10ms is idle
+    expect(removed).toBe(1);
+    expect(limiter.sessionCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Wires the `ApiKeyStore` from PR 1/4 into the HTTP transport, adds scope-gated tool dispatch, keys the rate limiter by tenantId, and threads audit-log context — **PR 2 of 4** in the stacked chain for issue #9.

**Base branch**: `feat/issue-9-pr1-api-key-store` (will retarget to `develop` once PR 1/4 merges).

Relates to: #9 · Builds on: #18

## What's in this PR

### New
- `src/middleware/auth.ts` — `authenticate(req, mode)` returning an `AuthResult`. Modes: `disabled` / `legacy-shared-token` / `api-key`. Exports `requestPrincipals: WeakMap<IncomingMessage, Principal>` for downstream handlers; fire-and-forget `touchLastUsed` on hit; `keyId` derived from attempted plaintext on miss so audit logs can reference failed attempts.
- `src/auth/scope-policy.ts` — `WRITE_TOOLS` (50 browser-mutating tools), `ADMIN_TOOLS` (empty, reserved for PR 3/4), `requiredScope()`, `isAllowed()` with admin → write → read implication chain.
- `tests/auth/scope-policy.test.ts` (12 tests) + `tests/middleware/auth.test.ts` (9 tests).

### Modified
- `src/transports/http.ts` — dropped the `crypto.timingSafeEqual` bearer block. New `HTTPTransportOptions { apiKeyStore? }`, `resolveAuthMode()` (env `OPENCHROME_AUTH_MODE=legacy-shared-token` > store > token > disabled). Principal injected as `__principal` into each JSON-RPC message (single + batch) so mcp-server reads it without interface changes. Auth failures emit an `auth_failure` audit entry with keyId when present. CORS `Access-Control-Allow-Origin: 'null'` when auth is enforced, `'*'` only when `disabled`.
- `src/mcp-server.ts` — `handleToolsCall` gains three behaviours when a Principal is present: (1) scope gate before tool lookup; (2) rate-limiter keyed by tenantId; (3) audit extras `{keyId, tenantId, scopes}`. stdio callers (no principal) bypass the gate so local usage is unaffected.
- `src/utils/rate-limiter.ts` — `check(sessionId)` param renamed to `key`; added `static tenantKey(tenantId) → \"tenant:<id>\"` so tenant traffic is namespaced away from session ids.
- `src/security/audit-logger.ts` — `AuditEntry` extended with optional `keyId`, `tenantId`, `scopes`. `redactPlaintextKeys()` scans args + final summary for any `oc_live_*` substring and replaces with `[REDACTED]` (defense-in-depth; the store already never emits plaintext).
- `src/auth/api-key-types.ts` — added `Principal` interface next to the store types.

## Auth-mode resolution

| Env / ctor | Mode |
|---|---|
| `OPENCHROME_AUTH_MODE=legacy-shared-token` + token set | `legacy-shared-token` |
| `apiKeyStore` option passed | `api-key` |
| Legacy `authToken` only (no env, no store) | `legacy-shared-token` (backwards compat default) |
| Neither | `disabled` |

## Rollback

Setting `OPENCHROME_AUTH_MODE=legacy-shared-token` reverts to the pre-issue-9 single-token behaviour without code changes. Existing deployments that only pass `authToken` continue to work untouched — they land on the legacy branch automatically.

## Stacked PR chain

1. ✅ [PR 1/4 — API key store](https://github.com/junghwan-oss/openchrome/pull/18)
2. **PR 2/4 — middleware + scope gate (this PR)**
3. PR 3/4 — admin CLI + JWT/OAuth verifier (JWKS)
4. PR 4/4 — docs + E2E + rollback polish

## Test plan

- [x] `npm run build` — clean (both tsconfig passes)
- [x] `npx jest tests/middleware tests/auth/scope-policy` — 21/21 pass
- [x] `npx jest tests/transports tests/mcp-server.test.ts` — 53/53 pass (no regression)
- [x] Legacy shared-token path unchanged (request with no `Authorization` returns 401; wrong token returns 401; correct token succeeds)
- [x] api-key path: wrong key → 401 with keyId in failure result; revoked → 401; expired → 401
- [x] Scope gate: `read` scope can call `screenshot` but not `navigate`; `admin` can call anything
- [x] Rate limiter keys tenant traffic by `tenant:<id>` (verified via `tenantKey()`)
- [ ] HTTP E2E across tenants (tenant A key rejected for tenant B) — lands in PR 4/4

## Known pre-existing issue

`tests/auth/api-key-store.test.ts` — the timing-parity test (ratio > 0.75) is flaky on fast machines because of argon2 cost variance and OS scheduling. Confirmed present on the PR 1/4 branch before any PR 2/4 edits. Will be addressed in a follow-up (widen ratio window to 0.5–1.5 and increase sample count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Original comments

**@junghwan-oss — 2026-04-20T06:46:24Z**

@codex review

**@junghwan-oss — 2026-04-20T06:58:29Z**

@codex review

**@junghwan-oss — 2026-04-20T07:16:47Z**

@codex review

**@junghwan-oss — 2026-04-20T07:42:31Z**

@codex review

**@junghwan-oss — 2026-04-20T07:53:18Z**

@codex review


---
_Migrated from junghwan-oss/openchrome#28 — originally by @junghwan-oss on 2026-04-20T04:20:33Z. Original state: OPEN._