### PR TITLE
feat(audit): B-4 PR3 — extend audit log with correlation + redaction

### DIFF
--- a/config/audit-redaction.json
+++ b/config/audit-redaction.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "./audit-redaction.schema.json",
+  "description": "Per-tool redaction rules applied to audit log entries. Each rule identifies a sensitive field by a JSON-path-like key and describes how the value should be recorded: 'redact' replaces with [REDACTED], 'hash' stores sha256:<hex>, 'truncate' keeps the first N bytes and appends a hash of the full value.",
+  "defaultSensitiveFieldNames": [
+    "password",
+    "passwd",
+    "pwd",
+    "secret",
+    "token",
+    "authorization",
+    "auth",
+    "api_key",
+    "apikey",
+    "access_key",
+    "refresh_token",
+    "id_token",
+    "session_token",
+    "cookie",
+    "set-cookie",
+    "credit_card",
+    "ssn",
+    "private_key"
+  ],
+  "tools": {
+    "cookies": [
+      { "path": "value", "mode": "hash" }
+    ],
+    "cookies.set": [
+      { "path": "value", "mode": "hash" },
+      { "path": "cookies[*].value", "mode": "hash" }
+    ],
+    "fill_form": [
+      { "path": "fields[*].value", "mode": "redactIfSensitiveName" }
+    ],
+    "form_input": [
+      { "path": "value", "mode": "redactIfSensitiveName" }
+    ],
+    "type": [
+      { "path": "text", "mode": "truncate", "maxBytes": 200 }
+    ],
+    "javascript_tool": [
+      { "path": "code", "mode": "truncate", "maxBytes": 200 }
+    ],
+    "storage": [
+      { "path": "value", "mode": "truncate", "maxBytes": 200 }
+    ]
+  }
+}

--- a/config/audit-redaction.json
+++ b/config/audit-redaction.json
@@ -33,7 +33,7 @@
       { "path": "fields[*].value", "mode": "redactIfSensitiveName" }
     ],
     "form_input": [
-      { "path": "value", "mode": "redactIfSensitiveName" }
+      { "path": "value", "mode": "redact" }
     ],
     "type": [
       { "path": "text", "mode": "truncate", "maxBytes": 200 }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "files": [
     "dist",
     "assets",
+    "config",
     "README.md",
     "LICENSE"
   ]

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -839,8 +839,12 @@ export class MCPServer {
         }
       }
 
-      // Audit log successful invocation
-      logAuditEntry(toolName, sessionId, toolArgs);
+      // Audit log successful invocation — extended fields (requestId, tenantId,
+      // status, durationMs) come from the active RequestContext + meta.
+      logAuditEntry(toolName, sessionId, toolArgs, undefined, {
+        status: 'success',
+        durationMs: Date.now() - toolStartTime,
+      });
 
       // End activity tracking (success)
       this.activityTracker!.endCall(callId, 'success');
@@ -998,6 +1002,18 @@ export class MCPServer {
       // End activity tracking (error)
       this.activityTracker!.endCall(callId, 'error', message);
       getDashboardState().recordToolEnd(callId, 'error', message);
+
+      // Audit log failed invocation — same correlation fields as success path.
+      try {
+        logAuditEntry(toolName, sessionId, toolArgs, undefined, {
+          status: 'error',
+          durationMs: Date.now() - toolStartTime,
+          errorMessage: message,
+          billable: false,
+        });
+      } catch {
+        // best-effort audit
+      }
 
       // Record Prometheus metrics
       try {

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -1,0 +1,235 @@
+/**
+ * Args redaction engine for audit log entries.
+ *
+ * Redaction is applied in two layers:
+ *   1. Per-tool rules from `config/audit-redaction.json` pin known sensitive
+ *      fields (for example `cookies.set.value` → hash).
+ *   2. A heuristic pass redacts values whose field name looks sensitive
+ *      (`password`, `token`, …) anywhere in the args tree.
+ *
+ * The output is a deep-cloned plain object safe for JSON serialisation.
+ * Original args are never mutated.
+ */
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export type RedactionMode = 'redact' | 'hash' | 'truncate' | 'redactIfSensitiveName';
+
+export interface RedactionRule {
+  /** Dot-path into args; `[*]` matches any array index. */
+  path: string;
+  mode: RedactionMode;
+  /** For `truncate`: keep first N bytes of the serialised value. */
+  maxBytes?: number;
+}
+
+export interface RedactionConfig {
+  defaultSensitiveFieldNames: string[];
+  tools: Record<string, RedactionRule[]>;
+}
+
+export const REDACTED = '[REDACTED]';
+
+const DEFAULT_TRUNCATE_MAX_BYTES = 200;
+
+/**
+ * Built-in minimum policy used when no config file is present. Keeps a safe
+ * fallback so that audit log entries never carry raw password/token values
+ * just because the operator forgot to ship the config file.
+ */
+export const BUILTIN_REDACTION_CONFIG: RedactionConfig = {
+  defaultSensitiveFieldNames: [
+    'password',
+    'passwd',
+    'pwd',
+    'secret',
+    'token',
+    'authorization',
+    'auth',
+    'api_key',
+    'apikey',
+    'access_key',
+    'refresh_token',
+    'id_token',
+    'session_token',
+    'cookie',
+    'set-cookie',
+    'credit_card',
+    'ssn',
+    'private_key',
+  ],
+  tools: {},
+};
+
+export function loadRedactionConfig(filePath: string): RedactionConfig {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<RedactionConfig>;
+    const sensitive = Array.isArray(parsed.defaultSensitiveFieldNames)
+      ? parsed.defaultSensitiveFieldNames.map((s) => String(s).toLowerCase())
+      : BUILTIN_REDACTION_CONFIG.defaultSensitiveFieldNames;
+    const tools = (parsed.tools && typeof parsed.tools === 'object') ? parsed.tools : {};
+    return { defaultSensitiveFieldNames: sensitive, tools };
+  } catch {
+    return BUILTIN_REDACTION_CONFIG;
+  }
+}
+
+/**
+ * Resolve the default config path. Prefer the repo-local `config/` tree; fall
+ * back to the built-in policy if the file is missing.
+ */
+export function defaultRedactionConfigPath(): string {
+  return path.resolve(process.cwd(), 'config', 'audit-redaction.json');
+}
+
+function sha256(value: string): string {
+  return 'sha256:' + crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function stringify(value: unknown): string {
+  if (typeof value === 'string') return value;
+  try { return JSON.stringify(value) ?? ''; } catch { return ''; }
+}
+
+function isSensitiveName(name: string, sensitiveNames: string[]): boolean {
+  const lower = name.toLowerCase();
+  return sensitiveNames.some((s) => lower.includes(s));
+}
+
+function applyMode(value: unknown, mode: RedactionMode, opts: { maxBytes?: number; sensitiveNames: string[]; name?: string; siblingName?: unknown }): unknown {
+  switch (mode) {
+    case 'redact':
+      return REDACTED;
+    case 'hash':
+      return sha256(stringify(value));
+    case 'truncate': {
+      const text = stringify(value);
+      const max = opts.maxBytes ?? DEFAULT_TRUNCATE_MAX_BYTES;
+      if (text.length <= max) return text;
+      return { preview: text.slice(0, max), hash: sha256(text), truncated: true };
+    }
+    case 'redactIfSensitiveName': {
+      // Check the containing field name first (for rules like {path: 'password'})
+      if (opts.name && isSensitiveName(opts.name, opts.sensitiveNames)) {
+        return REDACTED;
+      }
+      // Then check sibling `name` when the rule targets a `{name, value}` shape
+      // (form fields: {name: 'password', value: 'hunter2'}).
+      if (typeof opts.siblingName === 'string' && isSensitiveName(opts.siblingName, opts.sensitiveNames)) {
+        return REDACTED;
+      }
+      return value;
+    }
+  }
+}
+
+/**
+ * Split a dot-path like `cookies[*].value` into segments. `[*]` and `[n]` are
+ * treated as array wildcards / indexes.
+ */
+function splitPath(p: string): Array<{ key: string; index?: number | '*' }> {
+  // Normalise `a[0]` into `a.0` while remembering wildcard.
+  const parts = p
+    .replace(/\[(\*|\d+)\]/g, (_m, g1) => '.' + g1)
+    .split('.')
+    .filter(Boolean);
+  return parts.map((seg) => {
+    if (seg === '*') return { key: '', index: '*' as const };
+    if (/^\d+$/.test(seg)) return { key: '', index: Number(seg) };
+    return { key: seg };
+  });
+}
+
+function applyRuleAt(target: Record<string, unknown> | unknown[], segments: Array<{ key: string; index?: number | '*' }>, rule: RedactionRule, cfg: RedactionConfig, siblingName?: unknown): void {
+  if (segments.length === 0) return;
+  const [seg, ...rest] = segments;
+
+  if (seg.index !== undefined) {
+    if (!Array.isArray(target)) return;
+    const indices: number[] = seg.index === '*'
+      ? target.map((_v, i) => i)
+      : (seg.index < target.length ? [seg.index] : []);
+    for (const i of indices) {
+      if (rest.length === 0) {
+        target[i] = applyMode(target[i], rule.mode, {
+          maxBytes: rule.maxBytes,
+          sensitiveNames: cfg.defaultSensitiveFieldNames,
+        });
+      } else if (target[i] && typeof target[i] === 'object') {
+        // Recurse, but stash sibling 'name' for `{name, value}` shapes so
+        // redactIfSensitiveName can consult the form field's declared name.
+        const child = target[i] as Record<string, unknown> | unknown[];
+        const siblingName = (!Array.isArray(child) && 'name' in child)
+          ? (child as Record<string, unknown>).name
+          : undefined;
+        applyRuleAt(child, rest, rule, cfg, siblingName);
+      }
+    }
+    return;
+  }
+
+  if (Array.isArray(target) || !target || typeof target !== 'object') return;
+  const obj = target as Record<string, unknown>;
+  if (!(seg.key in obj)) return;
+
+  if (rest.length === 0) {
+    obj[seg.key] = applyMode(obj[seg.key], rule.mode, {
+      maxBytes: rule.maxBytes,
+      sensitiveNames: cfg.defaultSensitiveFieldNames,
+      name: seg.key,
+      siblingName,
+    });
+    return;
+  }
+
+  const next = obj[seg.key];
+  if (next && typeof next === 'object') {
+    applyRuleAt(next as Record<string, unknown> | unknown[], rest, rule, cfg);
+  }
+}
+
+function walkAndRedactByName(value: unknown, cfg: RedactionConfig): unknown {
+  if (Array.isArray(value)) {
+    return value.map((v) => walkAndRedactByName(v, cfg));
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (isSensitiveName(k, cfg.defaultSensitiveFieldNames)) {
+        out[k] = REDACTED;
+      } else {
+        out[k] = walkAndRedactByName(v, cfg);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
+/** Deep clone via JSON; safe because audit args are always JSON-serialisable. */
+function deepClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+/**
+ * Redact a tool-call args object. Returns a new object — original is not
+ * mutated. Also returns a sha256 of the canonicalised original args for audit
+ * integrity.
+ */
+export function redactArgs(
+  toolName: string,
+  args: Record<string, unknown>,
+  cfg: RedactionConfig = BUILTIN_REDACTION_CONFIG,
+): { redacted: Record<string, unknown>; argsHash: string } {
+  const clone = deepClone(args);
+  const rules = cfg.tools[toolName] || [];
+  for (const rule of rules) {
+    const segments = splitPath(rule.path);
+    applyRuleAt(clone as Record<string, unknown>, segments, rule, cfg);
+  }
+  const afterHeuristic = walkAndRedactByName(clone, cfg) as Record<string, unknown>;
+  const argsHash = sha256(stringify(args));
+  return { redacted: afterHeuristic, argsHash };
+}

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -32,6 +32,12 @@ export interface RedactionConfig {
 export const REDACTED = '[REDACTED]';
 
 const DEFAULT_TRUNCATE_MAX_BYTES = 200;
+const VALID_REDACTION_MODES = new Set<RedactionMode>([
+  'redact',
+  'hash',
+  'truncate',
+  'redactIfSensitiveName',
+]);
 
 /**
  * Built-in minimum policy used when no config file is present. Includes
@@ -73,7 +79,7 @@ export const BUILTIN_REDACTION_CONFIG: RedactionConfig = {
       { path: 'fields[*].value', mode: 'redactIfSensitiveName' },
     ],
     form_input: [
-      { path: 'value', mode: 'redactIfSensitiveName' },
+      { path: 'value', mode: 'redact' },
     ],
     type: [
       { path: 'text', mode: 'truncate', maxBytes: 200 },
@@ -86,6 +92,40 @@ export const BUILTIN_REDACTION_CONFIG: RedactionConfig = {
     ],
   },
 };
+
+function normalizeRule(toolName: string, rawRule: unknown): RedactionRule | null {
+  if (!rawRule || typeof rawRule !== 'object') {
+    console.error(`[redaction] ignoring rule for tool "${toolName}": rule must be an object`);
+    return null;
+  }
+
+  const rule = rawRule as Partial<RedactionRule>;
+  if (typeof rule.path !== 'string' || rule.path.trim() === '') {
+    console.error(`[redaction] ignoring rule for tool "${toolName}": path must be a non-empty string`);
+    return null;
+  }
+  if (!VALID_REDACTION_MODES.has(rule.mode as RedactionMode)) {
+    console.error(`[redaction] ignoring rule for tool "${toolName}": invalid mode "${String(rule.mode)}"`);
+    return null;
+  }
+
+  const normalized: RedactionRule = {
+    path: rule.path,
+    mode: rule.mode as RedactionMode,
+  };
+
+  if (rule.maxBytes !== undefined) {
+    if (typeof rule.maxBytes === 'number' && Number.isFinite(rule.maxBytes) && rule.maxBytes > 0) {
+      normalized.maxBytes = Math.floor(rule.maxBytes);
+    } else {
+      console.error(
+        `[redaction] ignoring maxBytes for tool "${toolName}" path "${rule.path}": expected positive number`,
+      );
+    }
+  }
+
+  return normalized;
+}
 
 export function loadRedactionConfig(filePath: string): RedactionConfig {
   try {
@@ -103,7 +143,10 @@ export function loadRedactionConfig(filePath: string): RedactionConfig {
     const tools: Record<string, RedactionRule[]> = {};
     for (const [name, rules] of Object.entries(toolsIn)) {
       if (Array.isArray(rules)) {
-        tools[name] = rules as RedactionRule[];
+        const normalized = rules
+          .map((rule) => normalizeRule(name, rule))
+          .filter((rule): rule is RedactionRule => rule !== null);
+        tools[name] = normalized;
       } else {
         console.error(`[redaction] ignoring tool "${name}": rules must be an array, got ${typeof rules}`);
       }
@@ -266,7 +309,11 @@ export function redactArgs(
   // Defense in depth: tolerate a malformed config that somehow reached here
   // (e.g. programmatic construction bypassing loadRedactionConfig). A bad
   // audit config must never break the tool call itself.
-  const rules: RedactionRule[] = Array.isArray(rawRules) ? rawRules : [];
+  const rules: RedactionRule[] = Array.isArray(rawRules)
+    ? rawRules
+        .map((rule) => normalizeRule(toolName, rule))
+        .filter((rule): rule is RedactionRule => rule !== null)
+    : [];
   for (const rule of rules) {
     const segments = splitPath(rule.path);
     applyRuleAt(clone as Record<string, unknown>, segments, rule, cfg);

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -34,9 +34,11 @@ export const REDACTED = '[REDACTED]';
 const DEFAULT_TRUNCATE_MAX_BYTES = 200;
 
 /**
- * Built-in minimum policy used when no config file is present. Keeps a safe
- * fallback so that audit log entries never carry raw password/token values
- * just because the operator forgot to ship the config file.
+ * Built-in minimum policy used when no config file is present. Includes
+ * per-tool rules for fields whose names (e.g. `value`, `text`, `code`) are
+ * not in the heuristic sensitive-name list but are sensitive by virtue of
+ * the containing tool — without these rules, raw cookie values or typed
+ * text would end up in the audit log in cleartext.
  */
 export const BUILTIN_REDACTION_CONFIG: RedactionConfig = {
   defaultSensitiveFieldNames: [
@@ -59,7 +61,30 @@ export const BUILTIN_REDACTION_CONFIG: RedactionConfig = {
     'ssn',
     'private_key',
   ],
-  tools: {},
+  tools: {
+    cookies: [
+      { path: 'value', mode: 'hash' },
+    ],
+    'cookies.set': [
+      { path: 'value', mode: 'hash' },
+      { path: 'cookies[*].value', mode: 'hash' },
+    ],
+    fill_form: [
+      { path: 'fields[*].value', mode: 'redactIfSensitiveName' },
+    ],
+    form_input: [
+      { path: 'value', mode: 'redactIfSensitiveName' },
+    ],
+    type: [
+      { path: 'text', mode: 'truncate', maxBytes: 200 },
+    ],
+    javascript_tool: [
+      { path: 'code', mode: 'truncate', maxBytes: 200 },
+    ],
+    storage: [
+      { path: 'value', mode: 'truncate', maxBytes: 200 },
+    ],
+  },
 };
 
 export function loadRedactionConfig(filePath: string): RedactionConfig {
@@ -69,7 +94,20 @@ export function loadRedactionConfig(filePath: string): RedactionConfig {
     const sensitive = Array.isArray(parsed.defaultSensitiveFieldNames)
       ? parsed.defaultSensitiveFieldNames.map((s) => String(s).toLowerCase())
       : BUILTIN_REDACTION_CONFIG.defaultSensitiveFieldNames;
-    const tools = (parsed.tools && typeof parsed.tools === 'object') ? parsed.tools : {};
+    // Only keep tool entries whose rules are arrays; a malformed entry
+    // (e.g. a single object) would otherwise crash `for...of` at runtime
+    // and break the tool call the audit log is meant to record.
+    const toolsIn = (parsed.tools && typeof parsed.tools === 'object')
+      ? (parsed.tools as Record<string, unknown>)
+      : {};
+    const tools: Record<string, RedactionRule[]> = {};
+    for (const [name, rules] of Object.entries(toolsIn)) {
+      if (Array.isArray(rules)) {
+        tools[name] = rules as RedactionRule[];
+      } else {
+        console.error(`[redaction] ignoring tool "${name}": rules must be an array, got ${typeof rules}`);
+      }
+    }
     return { defaultSensitiveFieldNames: sensitive, tools };
   } catch {
     return BUILTIN_REDACTION_CONFIG;
@@ -224,7 +262,11 @@ export function redactArgs(
   cfg: RedactionConfig = BUILTIN_REDACTION_CONFIG,
 ): { redacted: Record<string, unknown>; argsHash: string } {
   const clone = deepClone(args);
-  const rules = cfg.tools[toolName] || [];
+  const rawRules = cfg.tools[toolName];
+  // Defense in depth: tolerate a malformed config that somehow reached here
+  // (e.g. programmatic construction bypassing loadRedactionConfig). A bad
+  // audit config must never break the tool call itself.
+  const rules: RedactionRule[] = Array.isArray(rawRules) ? rawRules : [];
   for (const rule of rules) {
     const segments = splitPath(rule.path);
     applyRuleAt(clone as Record<string, unknown>, segments, rule, cfg);

--- a/src/observability/request-id.ts
+++ b/src/observability/request-id.ts
@@ -1,0 +1,101 @@
+/**
+ * Request correlation ID utilities.
+ *
+ * Every inbound MCP request is tagged with a requestId that is propagated
+ * across metrics labels, audit log entries, and log lines, so operators can
+ * trace a single request end-to-end. IDs follow UUID v7
+ * (draft-ietf-uuidrev-rfc4122bis): 48-bit Unix millisecond timestamp + 12-bit
+ * random + 4-bit version + 62 random bits — lexicographically sortable.
+ */
+import * as crypto from 'node:crypto';
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/** Canonical header name for request correlation IDs. */
+export const REQUEST_ID_HEADER = 'X-Request-Id';
+/** Lower-cased variant for Node's IncomingHttpHeaders lookups. */
+export const REQUEST_ID_HEADER_LOWER = 'x-request-id';
+
+/** Max accepted length for a client-supplied request ID. */
+export const MAX_REQUEST_ID_LEN = 128;
+
+/**
+ * Accept ASCII letters, digits, and a small set of delimiters. This keeps IDs
+ * safe to embed in Prometheus label values and log prefixes without escaping.
+ */
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
+
+/**
+ * Generate a UUID v7 (48-bit ms timestamp + random).
+ * Node's crypto.randomUUID() produces v4; we need v7 for time ordering.
+ */
+export function generateRequestId(): string {
+  const bytes = crypto.randomBytes(16);
+  const ms = BigInt(Date.now());
+
+  // Bytes 0-5: big-endian 48-bit millisecond timestamp
+  bytes[0] = Number((ms >> 40n) & 0xffn);
+  bytes[1] = Number((ms >> 32n) & 0xffn);
+  bytes[2] = Number((ms >> 24n) & 0xffn);
+  bytes[3] = Number((ms >> 16n) & 0xffn);
+  bytes[4] = Number((ms >> 8n) & 0xffn);
+  bytes[5] = Number(ms & 0xffn);
+
+  // Byte 6: version (0111) in high nibble
+  bytes[6] = (bytes[6] & 0x0f) | 0x70;
+  // Byte 8: variant (10) in high bits
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = bytes.toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+/**
+ * Validate and normalise a client-supplied request ID. Returns the trimmed
+ * value when it matches the allowed pattern and fits within the length limit,
+ * otherwise returns null so the caller can generate a fresh ID.
+ */
+export function normalizeRequestId(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.length > MAX_REQUEST_ID_LEN) return null;
+  if (!REQUEST_ID_PATTERN.test(trimmed)) return null;
+  return trimmed;
+}
+
+/**
+ * Resolve the request ID for an inbound request: honour a well-formed client
+ * header, otherwise generate a new UUID v7.
+ */
+export function resolveRequestId(headerValue: unknown): string {
+  return normalizeRequestId(headerValue) ?? generateRequestId();
+}
+
+/**
+ * Context carried through the async call tree for the duration of a single
+ * request. Lets deep-nested code (audit log, logger, metrics) attach the
+ * correlation ID without threading it through every function signature.
+ */
+export interface RequestContext {
+  requestId: string;
+  /** tenantId flows in here once B-1/B-3 land; defaults to 'unknown'. */
+  tenantId?: string;
+  /** keyId (hashed) when per-tenant auth identifies a specific API key. */
+  keyId?: string;
+}
+
+const requestStore = new AsyncLocalStorage<RequestContext>();
+
+/** Run `fn` with `ctx` bound as the active request context. */
+export function runWithRequestContext<T>(ctx: RequestContext, fn: () => T): T {
+  return requestStore.run(ctx, fn);
+}
+
+/** Get the active request context, if any. */
+export function currentRequestContext(): RequestContext | undefined {
+  return requestStore.getStore();
+}
+
+/** Get just the active requestId, if any. */
+export function currentRequestId(): string | undefined {
+  return requestStore.getStore()?.requestId;
+}

--- a/src/security/audit-logger.ts
+++ b/src/security/audit-logger.ts
@@ -89,13 +89,39 @@ function isExtendedEnabled(): boolean {
   return raw !== 'false' && raw !== '0';
 }
 
+/**
+ * Walk up from the compiled module's directory looking for a sibling
+ * `config/audit-redaction.json`. This finds the config shipped inside the
+ * installed package (e.g. `node_modules/openchrome-mcp/config/…`) regardless
+ * of whether the build layout is `dist/security/…` or `dist/src/security/…`.
+ */
+function findPackageRelativeConfig(): string | null {
+  let dir = __dirname;
+  for (let i = 0; i < 8; i++) {
+    const candidate = path.join(dir, 'config', 'audit-redaction.json');
+    try {
+      if (fs.existsSync(candidate)) return candidate;
+    } catch {
+      // ignore and keep walking
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
 function resolveRedactionConfig(): RedactionConfig {
   if (cachedConfig) return cachedConfig;
   const customPath = process.env.OPENCHROME_AUDIT_REDACTION_CONFIG;
   const candidates = [
     customPath,
+    // Repo/dev path: works when running from the project root.
     path.resolve(process.cwd(), 'config', 'audit-redaction.json'),
-  ].filter(Boolean) as string[];
+    // Installed path: walk up from this module so `npm install`-ed consumers
+    // still pick up the shipped per-tool rules (e.g. cookie `value` hashing).
+    findPackageRelativeConfig(),
+  ].filter((p): p is string => Boolean(p));
   for (const p of candidates) {
     try {
       if (fs.existsSync(p)) {

--- a/src/security/audit-logger.ts
+++ b/src/security/audit-logger.ts
@@ -1,49 +1,126 @@
 /**
- * Audit Logger - Logs tool invocations for security review
- * Writes structured JSONL to ~/.openchrome/audit.log
+ * Audit Logger — structured JSONL record of every tool invocation.
+ *
+ * Each entry carries enough correlation metadata (requestId, tenantId, keyId,
+ * sessionId, durationMs, status) to let an operator trace a single request
+ * end-to-end across logs, metrics, and audit. Arg values are redacted via the
+ * `observability/redaction` engine before writing, and an `argsHash` of the
+ * canonicalised original payload is recorded for integrity checks.
+ *
+ * Legacy fallback (when OPENCHROME_AUDIT_EXTENDED=false) preserves the
+ * original `{timestamp, tool, domain, sessionId, args_summary}` shape so
+ * downstream consumers can migrate on their own cadence.
  */
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { getGlobalConfig } from '../config/global';
 import { extractHostname } from '../utils/url-utils';
+import {
+  BUILTIN_REDACTION_CONFIG,
+  loadRedactionConfig,
+  redactArgs,
+  type RedactionConfig,
+} from '../observability/redaction';
+import { currentRequestContext } from '../observability/request-id';
 
-interface AuditEntry {
-  timestamp: string;      // ISO 8601
-  tool: string;           // tool name
-  domain: string | null;  // extracted from page URL, null if N/A
-  sessionId: string;
-  args_summary: string;   // brief summary, no sensitive data
+export interface AuditLogMeta {
+  /** Correlation ID; falls back to the active RequestContext or `null`. */
+  requestId?: string;
+  /** Tenant identifier; defaults to `'unknown'` until B-1/B-3 land. */
+  tenantId?: string;
+  /** Hashed prefix of the authenticating API key, when available. */
+  keyId?: string;
+  /** `'success'` | `'error'` | `'aborted'` — mirrors the metric status label. */
+  status?: 'success' | 'error' | 'aborted';
+  durationMs?: number;
+  /** Truthy when the call was externally aborted (B-2). */
+  aborted?: boolean;
+  /** Whether the call should count toward billing. Defaults to true unless status=error. */
+  billable?: boolean;
+  /** Error message when status === 'error'. Should not contain sensitive data. */
+  errorMessage?: string;
 }
 
-let logDirEnsured = false;
+interface LegacyAuditEntry {
+  timestamp: string;
+  tool: string;
+  domain: string | null;
+  sessionId: string;
+  args_summary: string;
+}
 
-// Get log file path
+interface ExtendedAuditEntry {
+  ts: string;
+  requestId: string | null;
+  tenantId: string;
+  keyId: string | null;
+  sessionId: string;
+  tool: string;
+  domain: string | null;
+  status: NonNullable<AuditLogMeta['status']>;
+  durationMs: number | null;
+  aborted: boolean;
+  billable: boolean;
+  argsHash: string;
+  args: Record<string, unknown>;
+  errorMessage?: string;
+}
+
+const TENANT_UNKNOWN = 'unknown';
+
+let logDirEnsured = false;
+let cachedConfig: RedactionConfig | null = null;
+
 function getLogPath(): string {
   const config = getGlobalConfig();
   return config.security?.audit_log_path ||
     path.join(os.homedir(), '.openchrome', 'audit.log');
 }
 
-// Extract domain from URL safely
 function extractDomain(url?: string): string | null {
   if (!url) return null;
   return extractHostname(url) || null;
 }
 
-const SENSITIVE_KEYS = ['password', 'cookie', 'token', 'secret', 'auth', 'credential', 'value', 'text'];
-
-function isSensitiveKey(key: string): boolean {
-  const lower = key.toLowerCase();
-  return SENSITIVE_KEYS.some(s => lower.includes(s));
+function isExtendedEnabled(): boolean {
+  const raw = process.env.OPENCHROME_AUDIT_EXTENDED;
+  if (raw === undefined) return true; // extended is default-on — legacy is opt-in rollback
+  return raw !== 'false' && raw !== '0';
 }
 
-// Summarize args (redact sensitive values)
-function summarizeArgs(args: Record<string, unknown>): string {
-  // Include keys like tabId, url, action but redact values of sensitive keys
+function resolveRedactionConfig(): RedactionConfig {
+  if (cachedConfig) return cachedConfig;
+  const customPath = process.env.OPENCHROME_AUDIT_REDACTION_CONFIG;
+  const candidates = [
+    customPath,
+    path.resolve(process.cwd(), 'config', 'audit-redaction.json'),
+  ].filter(Boolean) as string[];
+  for (const p of candidates) {
+    try {
+      if (fs.existsSync(p)) {
+        cachedConfig = loadRedactionConfig(p);
+        return cachedConfig;
+      }
+    } catch {
+      // ignore
+    }
+  }
+  cachedConfig = BUILTIN_REDACTION_CONFIG;
+  return cachedConfig;
+}
+
+const LEGACY_SENSITIVE_KEYS = ['password', 'cookie', 'token', 'secret', 'auth', 'credential', 'value', 'text'];
+
+function isLegacySensitiveKey(key: string): boolean {
+  const lower = key.toLowerCase();
+  return LEGACY_SENSITIVE_KEYS.some((s) => lower.includes(s));
+}
+
+function summarizeArgsLegacy(args: Record<string, unknown>): string {
   const safe: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(args)) {
-    if (isSensitiveKey(key)) {
+    if (isLegacySensitiveKey(key)) {
       safe[key] = '[REDACTED]';
     } else if (typeof value === 'string' && value.length > 100) {
       safe[key] = value.slice(0, 100) + '...';
@@ -54,32 +131,80 @@ function summarizeArgs(args: Record<string, unknown>): string {
   return JSON.stringify(safe);
 }
 
-export function logAuditEntry(tool: string, sessionId: string, args: Record<string, unknown>, pageUrl?: string): void {
-  const config = getGlobalConfig();
-  if (!config.security?.audit_log) return; // Disabled by default
+function ensureDir(logPath: string): boolean {
+  if (logDirEnsured) return true;
+  try {
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    logDirEnsured = true;
+    return true;
+  } catch {
+    return false;
+  }
+}
 
-  const entry: AuditEntry = {
-    timestamp: new Date().toISOString(),
-    tool,
-    domain: extractDomain(pageUrl || (args.url as string)),
-    sessionId,
-    args_summary: summarizeArgs(args),
-  };
+function appendLine(logPath: string, line: string): void {
+  fs.appendFile(logPath, line, (err) => {
+    if (err) console.error('[audit-logger] write failed:', err.code);
+  });
+}
+
+/**
+ * Log a tool invocation. `meta` carries the extended correlation fields; any
+ * field left undefined falls back to the active request context (for
+ * `requestId`/`tenantId`) or a safe default.
+ */
+export function logAuditEntry(
+  tool: string,
+  sessionId: string,
+  args: Record<string, unknown>,
+  pageUrl?: string,
+  meta: AuditLogMeta = {},
+): void {
+  const config = getGlobalConfig();
+  if (!config.security?.audit_log) return; // disabled by default
 
   const logPath = getLogPath();
-  const logDir = path.dirname(logPath);
+  if (!ensureDir(logPath)) return;
 
-  // Ensure directory exists (first time only)
-  if (!logDirEnsured) {
-    try {
-      fs.mkdirSync(logDir, { recursive: true });
-      logDirEnsured = true;
-    } catch {
-      return; // Non-fatal
-    }
+  if (!isExtendedEnabled()) {
+    const legacy: LegacyAuditEntry = {
+      timestamp: new Date().toISOString(),
+      tool,
+      domain: extractDomain(pageUrl || (args.url as string | undefined)),
+      sessionId,
+      args_summary: summarizeArgsLegacy(args),
+    };
+    appendLine(logPath, JSON.stringify(legacy) + '\n');
+    return;
   }
 
-  // Non-blocking append
-  const line = JSON.stringify(entry) + '\n';
-  fs.appendFile(logPath, line, (err) => { if (err) console.error('[audit-logger] write failed:', err.code); });
+  const ctx = currentRequestContext();
+  const cfg = resolveRedactionConfig();
+  const { redacted, argsHash } = redactArgs(tool, args, cfg);
+  const status = meta.status ?? 'success';
+
+  const entry: ExtendedAuditEntry = {
+    ts: new Date().toISOString(),
+    requestId: meta.requestId ?? ctx?.requestId ?? null,
+    tenantId: meta.tenantId ?? ctx?.tenantId ?? TENANT_UNKNOWN,
+    keyId: meta.keyId ?? ctx?.keyId ?? null,
+    sessionId,
+    tool,
+    domain: extractDomain(pageUrl || (args.url as string | undefined)),
+    status,
+    durationMs: typeof meta.durationMs === 'number' ? Math.round(meta.durationMs) : null,
+    aborted: meta.aborted ?? false,
+    billable: meta.billable ?? (status !== 'error'),
+    argsHash,
+    args: redacted,
+  };
+  if (meta.errorMessage) entry.errorMessage = meta.errorMessage;
+
+  appendLine(logPath, JSON.stringify(entry) + '\n');
+}
+
+/** Test hook — reset caches between tests. */
+export function __resetAuditLoggerCachesForTests(): void {
+  cachedConfig = null;
+  logDirEnsured = false;
 }

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -16,6 +16,12 @@ import { MCPResponse, MCPErrorCodes } from '../types/mcp';
 import { MCPTransport } from './index';
 import { getDashboardState } from '../desktop/dashboard-state';
 import type { SessionManager } from '../session-manager';
+import {
+  REQUEST_ID_HEADER,
+  REQUEST_ID_HEADER_LOWER,
+  resolveRequestId,
+  runWithRequestContext,
+} from '../observability/request-id';
 
 /** Maximum allowed HTTP request body size (10 MB) to prevent OOM from oversized requests */
 const MAX_BODY_BYTES = 10 * 1024 * 1024;
@@ -146,8 +152,16 @@ export class HTTPTransport implements MCPTransport {
     // CORS headers for all responses — restrict origin when auth is enabled
     res.setHeader('Access-Control-Allow-Origin', this.authToken ? 'null' : '*');
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Mcp-Session-Id, Authorization');
-    res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id');
+    res.setHeader('Access-Control-Allow-Headers', `Content-Type, Mcp-Session-Id, Authorization, ${REQUEST_ID_HEADER}`);
+    res.setHeader('Access-Control-Expose-Headers', `Mcp-Session-Id, ${REQUEST_ID_HEADER}`);
+
+    // Request correlation: honour client-supplied X-Request-Id, otherwise mint
+    // a fresh UUID v7. Echo it back on every response so clients (and
+    // downstream proxies) can correlate logs, metrics, and audit entries for
+    // this request.
+    const requestId = resolveRequestId(req.headers[REQUEST_ID_HEADER_LOWER]);
+    res.setHeader(REQUEST_ID_HEADER, requestId);
+    (req as http.IncomingMessage & { requestId?: string }).requestId = requestId;
 
     // Handle CORS preflight
     if (req.method === 'OPTIONS') {
@@ -442,9 +456,16 @@ export class HTTPTransport implements MCPTransport {
         return;
       }
 
+      // Correlation ID for this HTTP request — propagate into handler(s).
+      const requestId = (req as http.IncomingMessage & { requestId?: string }).requestId
+        || resolveRequestId(req.headers[REQUEST_ID_HEADER_LOWER]);
+
       // Handle JSON-RPC batch (array of requests)
       if (Array.isArray(parsed)) {
-        const results = await this.processBatch(parsed, sessionId);
+        const results = await runWithRequestContext(
+          { requestId },
+          () => this.processBatch(parsed, sessionId),
+        );
         // Filter out null results (notifications don't produce responses)
         const responses = results.filter((r): r is MCPResponse => r !== null);
 
@@ -476,7 +497,10 @@ export class HTTPTransport implements MCPTransport {
       }
 
       try {
-        const response = await this.messageHandler(msg);
+        const response = await runWithRequestContext(
+          { requestId },
+          () => this.messageHandler!(msg),
+        );
 
         if (sessionId) {
           res.setHeader('Mcp-Session-Id', sessionId);

--- a/tests/observability/redaction.test.ts
+++ b/tests/observability/redaction.test.ts
@@ -77,4 +77,22 @@ describe('redactArgs', () => {
     const out = redactArgs('no_such_tool', { Authorization: 'Bearer xyz' }, cfg);
     expect(out.redacted.Authorization).toBe(REDACTED);
   });
+
+  test('built-in config hashes cookie value even without an external config file', () => {
+    const args = { name: 'session', value: 'super-secret' };
+    const out = redactArgs('cookies.set', args, BUILTIN_REDACTION_CONFIG);
+    const v = out.redacted.value as string;
+    expect(v.startsWith('sha256:')).toBe(true);
+    expect(v).not.toContain('super-secret');
+  });
+
+  test('malformed tools entry (not an array) degrades gracefully instead of throwing', () => {
+    const badCfg: RedactionConfig = {
+      defaultSensitiveFieldNames: [...BUILTIN_REDACTION_CONFIG.defaultSensitiveFieldNames],
+      // A typo — single rule object instead of an array. Would crash a naive
+      // `for...of` without the Array.isArray guard.
+      tools: { cookies: { path: 'value', mode: 'hash' } as unknown as never },
+    };
+    expect(() => redactArgs('cookies', { value: 'x' }, badCfg)).not.toThrow();
+  });
 });

--- a/tests/observability/redaction.test.ts
+++ b/tests/observability/redaction.test.ts
@@ -1,9 +1,13 @@
 import {
   BUILTIN_REDACTION_CONFIG,
   REDACTED,
+  loadRedactionConfig,
   redactArgs,
   type RedactionConfig,
 } from '../../src/observability/redaction';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 const cfg: RedactionConfig = {
   defaultSensitiveFieldNames: [...BUILTIN_REDACTION_CONFIG.defaultSensitiveFieldNames],
@@ -47,6 +51,11 @@ describe('redactArgs', () => {
     const fields = out.redacted.fields as Array<{ name: string; value: string }>;
     expect(fields[0].value).toBe('a@b.c');
     expect(fields[1].value).toBe(REDACTED);
+  });
+
+  test('built-in config always redacts form_input values', () => {
+    const out = redactArgs('form_input', { ref: 'el_1', value: '123456' }, BUILTIN_REDACTION_CONFIG);
+    expect(out.redacted.value).toBe(REDACTED);
   });
 
   test('truncate keeps prefix and adds hash', () => {
@@ -94,5 +103,27 @@ describe('redactArgs', () => {
       tools: { cookies: { path: 'value', mode: 'hash' } as unknown as never },
     };
     expect(() => redactArgs('cookies', { value: 'x' }, badCfg)).not.toThrow();
+  });
+
+  test('loadRedactionConfig drops malformed rules instead of crashing later', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-redaction-'));
+    const cfgPath = path.join(dir, 'audit-redaction.json');
+    fs.writeFileSync(cfgPath, JSON.stringify({
+      defaultSensitiveFieldNames: ['token'],
+      tools: {
+        cookies: [
+          { mode: 'hash' },
+          { path: 'value', mode: 'hash' },
+          { path: 'value', mode: 'truncate', maxBytes: 'bad' },
+        ],
+      },
+    }));
+
+    const loaded = loadRedactionConfig(cfgPath);
+    expect(loaded.tools.cookies).toEqual([
+      { path: 'value', mode: 'hash' },
+      { path: 'value', mode: 'truncate' },
+    ]);
+    expect(() => redactArgs('cookies', { value: 'secret' }, loaded)).not.toThrow();
   });
 });

--- a/tests/observability/redaction.test.ts
+++ b/tests/observability/redaction.test.ts
@@ -1,0 +1,80 @@
+import {
+  BUILTIN_REDACTION_CONFIG,
+  REDACTED,
+  redactArgs,
+  type RedactionConfig,
+} from '../../src/observability/redaction';
+
+const cfg: RedactionConfig = {
+  defaultSensitiveFieldNames: [...BUILTIN_REDACTION_CONFIG.defaultSensitiveFieldNames],
+  tools: {
+    'cookies.set': [
+      { path: 'value', mode: 'hash' },
+      { path: 'cookies[*].value', mode: 'hash' },
+    ],
+    fill_form: [
+      { path: 'fields[*].value', mode: 'redactIfSensitiveName' },
+    ],
+    javascript_tool: [
+      { path: 'code', mode: 'truncate', maxBytes: 16 },
+    ],
+  },
+};
+
+describe('redactArgs', () => {
+  test('heuristic redacts password field by name', () => {
+    const out = redactArgs('fill_form', { username: 'u', password: 'p@ss' }, cfg);
+    expect(out.redacted.password).toBe(REDACTED);
+    expect(out.redacted.username).toBe('u');
+  });
+
+  test('per-tool rule hashes cookie value', () => {
+    const args = { name: 'session', value: 'super-secret' };
+    const out = redactArgs('cookies.set', args, cfg);
+    const v = out.redacted.value as string;
+    expect(v.startsWith('sha256:')).toBe(true);
+    expect(v).not.toContain('super-secret');
+  });
+
+  test('array wildcard rule redacts sensitive field in array', () => {
+    const args = {
+      fields: [
+        { name: 'email', value: 'a@b.c' },
+        { name: 'password', value: 'hunter2' },
+      ],
+    };
+    const out = redactArgs('fill_form', args, cfg);
+    const fields = out.redacted.fields as Array<{ name: string; value: string }>;
+    expect(fields[0].value).toBe('a@b.c');
+    expect(fields[1].value).toBe(REDACTED);
+  });
+
+  test('truncate keeps prefix and adds hash', () => {
+    const args = { code: 'console.error("a very long script body")' };
+    const out = redactArgs('javascript_tool', args, cfg);
+    const code = out.redacted.code as { preview: string; hash: string; truncated: boolean };
+    expect(code.truncated).toBe(true);
+    expect(code.preview.length).toBeLessThanOrEqual(16);
+    expect(code.hash.startsWith('sha256:')).toBe(true);
+  });
+
+  test('original args object is not mutated', () => {
+    const args = { password: 'p', nested: { token: 't' } };
+    const snapshot = JSON.parse(JSON.stringify(args));
+    redactArgs('unknown_tool', args, cfg);
+    expect(args).toEqual(snapshot);
+  });
+
+  test('argsHash stays stable across redaction', () => {
+    const args = { password: 'p', name: 'x' };
+    const a = redactArgs('unknown', args, cfg);
+    const b = redactArgs('unknown', args, cfg);
+    expect(a.argsHash).toBe(b.argsHash);
+    expect(a.argsHash.startsWith('sha256:')).toBe(true);
+  });
+
+  test('unknown tool still applies name-based heuristic', () => {
+    const out = redactArgs('no_such_tool', { Authorization: 'Bearer xyz' }, cfg);
+    expect(out.redacted.Authorization).toBe(REDACTED);
+  });
+});

--- a/tests/observability/request-id.test.ts
+++ b/tests/observability/request-id.test.ts
@@ -1,0 +1,53 @@
+import {
+  REQUEST_ID_HEADER,
+  REQUEST_ID_HEADER_LOWER,
+  generateRequestId,
+  normalizeRequestId,
+  resolveRequestId,
+} from '../../src/observability/request-id';
+
+const UUID_V7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe('request-id', () => {
+  test('header constants are canonical', () => {
+    expect(REQUEST_ID_HEADER).toBe('X-Request-Id');
+    expect(REQUEST_ID_HEADER_LOWER).toBe('x-request-id');
+  });
+
+  test('generateRequestId produces UUID v7', () => {
+    const id = generateRequestId();
+    expect(id).toMatch(UUID_V7_RE);
+  });
+
+  test('generateRequestId is monotonic over time', () => {
+    const a = generateRequestId();
+    // Sleep a millisecond-worth of work to advance the timestamp.
+    const start = Date.now();
+    while (Date.now() === start) { /* spin briefly */ }
+    const b = generateRequestId();
+    expect(a < b).toBe(true);
+  });
+
+  test('normalizeRequestId accepts well-formed values', () => {
+    expect(normalizeRequestId('abc-123_4:5.6')).toBe('abc-123_4:5.6');
+    expect(normalizeRequestId('  trimmed-me  ')).toBe('trimmed-me');
+  });
+
+  test('normalizeRequestId rejects bad values', () => {
+    expect(normalizeRequestId('')).toBeNull();
+    expect(normalizeRequestId('   ')).toBeNull();
+    expect(normalizeRequestId(undefined)).toBeNull();
+    expect(normalizeRequestId(123 as unknown)).toBeNull();
+    expect(normalizeRequestId('contains space')).toBeNull();
+    expect(normalizeRequestId('illegal/char')).toBeNull();
+    expect(normalizeRequestId('x'.repeat(200))).toBeNull();
+  });
+
+  test('resolveRequestId echoes a valid header, else mints UUID v7', () => {
+    expect(resolveRequestId('my-trace-42')).toBe('my-trace-42');
+    const minted = resolveRequestId(undefined);
+    expect(minted).toMatch(UUID_V7_RE);
+    const minted2 = resolveRequestId('has spaces not allowed');
+    expect(minted2).toMatch(UUID_V7_RE);
+  });
+});

--- a/tests/security/audit-logger-extended.test.ts
+++ b/tests/security/audit-logger-extended.test.ts
@@ -1,0 +1,117 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { logAuditEntry, __resetAuditLoggerCachesForTests } from '../../src/security/audit-logger';
+import { runWithRequestContext } from '../../src/observability/request-id';
+
+jest.mock('../../src/config/global', () => ({
+  getGlobalConfig: () => ({
+    security: {
+      audit_log: true,
+      audit_log_path: (globalThis as { __TEST_AUDIT_PATH?: string }).__TEST_AUDIT_PATH,
+    },
+  }),
+}));
+
+function makeTmpLogPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-audit-'));
+  return path.join(dir, 'audit.log');
+}
+
+function waitForFlush(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function readAll(p: string): Array<Record<string, unknown>> {
+  if (!fs.existsSync(p)) return [];
+  return fs
+    .readFileSync(p, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+describe('audit-logger extended fields', () => {
+  beforeEach(() => {
+    __resetAuditLoggerCachesForTests();
+    delete process.env.OPENCHROME_AUDIT_EXTENDED;
+  });
+
+  test('extended entries include correlation fields and redacted args', async () => {
+    const logPath = makeTmpLogPath();
+    (globalThis as { __TEST_AUDIT_PATH?: string }).__TEST_AUDIT_PATH = logPath;
+
+    runWithRequestContext({ requestId: 'req-abc-1', tenantId: 't_acme' }, () => {
+      logAuditEntry(
+        'fill_form',
+        'sess_xyz',
+        { username: 'u', password: 'hunter2' },
+        undefined,
+        { status: 'success', durationMs: 123 },
+      );
+    });
+
+    await waitForFlush();
+    await new Promise((r) => setTimeout(r, 50));
+    const lines = readAll(logPath);
+    expect(lines.length).toBe(1);
+    const entry = lines[0];
+
+    expect(entry.requestId).toBe('req-abc-1');
+    expect(entry.tenantId).toBe('t_acme');
+    expect(entry.sessionId).toBe('sess_xyz');
+    expect(entry.status).toBe('success');
+    expect(entry.durationMs).toBe(123);
+    expect(entry.billable).toBe(true);
+    expect(entry.argsHash).toMatch(/^sha256:[0-9a-f]{64}$/);
+    const args = entry.args as Record<string, unknown>;
+    expect(args.password).toBe('[REDACTED]');
+    expect(args.username).toBe('u');
+  });
+
+  test('falls back to tenant=unknown when no context', async () => {
+    const logPath = makeTmpLogPath();
+    (globalThis as { __TEST_AUDIT_PATH?: string }).__TEST_AUDIT_PATH = logPath;
+
+    logAuditEntry('navigate', 'sess_1', { url: 'https://example.com' });
+    await waitForFlush();
+    await new Promise((r) => setTimeout(r, 50));
+    const entry = readAll(logPath)[0];
+    expect(entry.tenantId).toBe('unknown');
+    expect(entry.requestId).toBeNull();
+  });
+
+  test('OPENCHROME_AUDIT_EXTENDED=false writes legacy shape', async () => {
+    const logPath = makeTmpLogPath();
+    (globalThis as { __TEST_AUDIT_PATH?: string }).__TEST_AUDIT_PATH = logPath;
+    process.env.OPENCHROME_AUDIT_EXTENDED = 'false';
+
+    logAuditEntry('navigate', 'sess_1', { url: 'https://example.com', password: 'secret' });
+    await waitForFlush();
+    await new Promise((r) => setTimeout(r, 50));
+    const entry = readAll(logPath)[0];
+    expect(entry.timestamp).toBeDefined();
+    expect(entry.args_summary).toBeDefined();
+    expect(entry.requestId).toBeUndefined();
+    expect(entry.tenantId).toBeUndefined();
+
+    delete process.env.OPENCHROME_AUDIT_EXTENDED;
+  });
+
+  test('error status marks billable=false and carries errorMessage', async () => {
+    const logPath = makeTmpLogPath();
+    (globalThis as { __TEST_AUDIT_PATH?: string }).__TEST_AUDIT_PATH = logPath;
+
+    logAuditEntry('navigate', 'sess_1', { url: 'https://x.y' }, undefined, {
+      status: 'error',
+      durationMs: 42,
+      errorMessage: 'boom',
+    });
+    await waitForFlush();
+    await new Promise((r) => setTimeout(r, 50));
+    const entry = readAll(logPath)[0];
+    expect(entry.status).toBe('error');
+    expect(entry.billable).toBe(false);
+    expect(entry.errorMessage).toBe('boom');
+  });
+});

--- a/tests/security/audit-logger-extended.test.ts
+++ b/tests/security/audit-logger-extended.test.ts
@@ -98,6 +98,36 @@ describe('audit-logger extended fields', () => {
     delete process.env.OPENCHROME_AUDIT_EXTENDED;
   });
 
+  test('cookie value is hashed via built-in rules when no external config is reachable', async () => {
+    const logPath = makeTmpLogPath();
+    (globalThis as { __TEST_AUDIT_PATH?: string }).__TEST_AUDIT_PATH = logPath;
+
+    // Point env config at a path that does not exist so loadRedactionConfig
+    // falls through to the built-in policy. cwd may or may not be the repo
+    // root under jest; either way the built-in rules must cover cookies.
+    process.env.OPENCHROME_AUDIT_REDACTION_CONFIG = path.join(
+      os.tmpdir(),
+      'oc-nonexistent-redaction-config.json',
+    );
+    const prevCwd = process.cwd();
+    const isolatedCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-cwd-'));
+    process.chdir(isolatedCwd);
+    try {
+      __resetAuditLoggerCachesForTests();
+      logAuditEntry('cookies.set', 'sess_1', { name: 'session', value: 'super-secret' });
+      await waitForFlush();
+      await new Promise((r) => setTimeout(r, 50));
+      const entry = readAll(logPath)[0];
+      const args = entry.args as Record<string, unknown>;
+      expect(typeof args.value).toBe('string');
+      expect(args.value as string).toMatch(/^sha256:/);
+      expect(args.value).not.toContain('super-secret');
+    } finally {
+      process.chdir(prevCwd);
+      delete process.env.OPENCHROME_AUDIT_REDACTION_CONFIG;
+    }
+  });
+
   test('error status marks billable=false and carries errorMessage', async () => {
     const logPath = makeTmpLogPath();
     (globalThis as { __TEST_AUDIT_PATH?: string }).__TEST_AUDIT_PATH = logPath;


### PR DESCRIPTION
## Summary

Part 3/5 of issue #10 (B-4). Extends the audit JSONL schema so every tool call records the correlation ID, tenant, timing, and a redacted args view.

- Extended shape: ` + "`{ts, requestId, tenantId, keyId, sessionId, tool, domain, status, durationMs, aborted, billable, argsHash, args, errorMessage?}`" + `.
- ` + "`requestId`" + ` / ` + "`tenantId`" + ` are picked up from the active ` + "`RequestContext`" + ` (no plumbing needed). ` + "`tenantId`" + ` defaults to ` + "`\"unknown\"`" + ` until B-1 / B-3 land.
- Args are run through the PR2 redaction engine; ` + "`argsHash`" + ` is sha256 of the canonicalised original.
- mcp-server now audit-logs error paths too, carrying ` + "`status`" + ` + ` + "`durationMs`" + ` + ` + "`errorMessage`" + `.
- Rollback: ` + "`OPENCHROME_AUDIT_EXTENDED=false`" + ` reverts to the legacy shape ` + "`{timestamp, tool, domain, sessionId, args_summary}`" + `.
- 4 new tests cover extended fields, fallback defaults, legacy-flag path, and error status semantics.

**Stacked on**: PR1 (#19 — request-id) and PR2 (redaction). This branch includes all three commits; merge PR1 and PR2 first, then this will rebase cleanly to just the audit commit.

## Test plan
- [x] ` + "`npm run build`" + `
- [x] ` + "`tests/security/audit-logger-extended.test.ts`" + ` (4 cases)
- [x] All 65 tests across observability / security / metrics / transports pass
- [ ] Manual: ` + "`OPENCHROME_AUDIT_EXTENDED=false`" + ` → legacy shape on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Original comments

**@junghwan-oss — 2026-04-20T06:48:23Z**

### Codex follow-up — addressed in 5f3f108

Thanks to the Codex bot for two solid catches. Both are now fixed on this branch. Summary of the rationale:

#### P1 — `resolveRedactionConfig` falls back to an empty policy when installed

The original `resolveRedactionConfig()` only probed `OPENCHROME_AUDIT_REDACTION_CONFIG` and `process.cwd()/config/audit-redaction.json`. That works in repo/dev runs, but in the installed npm case the caller's cwd is *their* project — `config/audit-redaction.json` is not there. Worse: I also had `config/` missing from `package.json` `files`, so the config was **not even shipped in the tarball**. The logger silently fell through to `BUILTIN_REDACTION_CONFIG` whose `tools: {}` had no per-tool rules, so fields the heuristic sensitive-name pass does not cover — cookie `value`, typed `text`, js `code`, storage `value` — ended up in the audit log in cleartext. That's a real regression vs. the legacy redaction shape.

Fixed in three layered ways (belt + braces):

1. **Ship the config.** Added `"config"` to `package.json` → `files`, so `config/audit-redaction.json` is included in the npm tarball.
2. **Package-relative lookup.** New `findPackageRelativeConfig()` walks up from `__dirname` looking for a sibling `config/audit-redaction.json`. This finds the shipped config under `node_modules/openchrome-mcp/…` regardless of whether the build layout is `dist/security/…` or `dist/src/security/…`. Precedence is: env override → cwd → package-relative → built-in.
3. **Strengthen the built-in.** Mirrored the shipped per-tool rules into `BUILTIN_REDACTION_CONFIG.tools` (`cookies`/`cookies.set` → hash value, `fill_form`/`form_input` → redact-if-sensitive-name, `type`/`javascript_tool`/`storage` → truncate). Even if #1 and #2 both fail, the built-in policy now carries the minimum-safe rules.

#### P2 — `redactArgs` iterates `cfg.tools[toolName]` without verifying it's an array

A typo like `"cookies": { path: "value", mode: "hash" }` (object instead of `[{…}]`) would throw `rules is not iterable` at runtime. Because `mcp-server` calls `logAuditEntry` on the success path without a try/catch wrapper, a malformed audit config could break otherwise-successful tool calls. Fixed in two places:

1. **`loadRedactionConfig()`** now filters `tools` to array-valued entries only, emitting a `console.error` warning for any skipped entry. Bad config shape no longer silently propagates.
2. **`redactArgs()`** has an `Array.isArray()` guard as defense-in-depth for programmatic configs that bypass the loader.

#### Tests

Two new cases:

- `built-in config hashes cookie value even without an external config file` in `tests/observability/redaction.test.ts` — feeds `BUILTIN_REDACTION_CONFIG` directly and asserts `cookies.set` → value is `sha256:…`.
- `cookie value is hashed via built-in rules when no external config is reachable` in `tests/security/audit-logger-extended.test.ts` — runs in an isolated `mkdtempSync` cwd with `OPENCHROME_AUDIT_REDACTION_CONFIG` pointed at a nonexistent file, proving the installed-dep scenario never logs a raw cookie value.
- `malformed tools entry (not an array) degrades gracefully instead of throwing` — regression guard for the P2 finding.

All 14 tests across the two affected suites pass locally. The one transport-unrelated flake (`http-streamable.test.ts` with `ECONNRESET`) from the full-suite run also passed on re-run and is not touched by this change.

/cc @codex

**@junghwan-oss — 2026-04-20T06:48:37Z**

@codex review

**@junghwan-oss — 2026-04-20T07:16:54Z**

After #19, #20, #22 merged to develop, this PR needs manual rebase onto develop. Hit a conflict on `tests/observability/redaction.test.ts` (interaction with #20's Codex-round-2 fixes). Also needs code review — was not included in the release-workflow review batch. Will revisit in a follow-up.


---
_Migrated from junghwan-oss/openchrome#21 — originally by @junghwan-oss on 2026-04-20T03:55:29Z. Original state: OPEN._