### PR TITLE
feat(auth): multi-tenant API key store (issue #9, PR 1/4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.9.7",
       "license": "MIT",
       "dependencies": {
-        "argon2": "^0.44.0",
+        "argon2": "^0.43.0",
         "commander": "^12.0.0",
         "proper-lockfile": "^4.1.2",
         "puppeteer-core": "npm:rebrowser-puppeteer-core@23.10.3",
@@ -579,12 +579,6 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
-    },
-    "node_modules/@epic-web/invariant": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
-      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
-      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -1995,15 +1989,14 @@
       "license": "MIT"
     },
     "node_modules/argon2": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.44.0.tgz",
-      "integrity": "sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==",
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.43.1.tgz",
+      "integrity": "sha512-TfOzvDWUaQPurCT1hOwIeFNkgrAJDpbBGBGWDgzDsm11nNhImc13WhdGdCU6K7brkp8VpeY07oGtSex0Wmhg8w==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@phc/format": "^1.0.0",
-        "cross-env": "^10.0.0",
-        "node-addon-api": "^8.5.0",
+        "node-addon-api": "^8.4.0",
         "node-gyp-build": "^4.8.4"
       },
       "engines": {
@@ -2643,27 +2636,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cross-env": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
-      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
-      "license": "MIT",
-      "dependencies": {
-        "@epic-web/invariant": "^1.0.0",
-        "cross-spawn": "^7.0.6"
-      },
-      "bin": {
-        "cross-env": "dist/bin/cross-env.js",
-        "cross-env-shell": "dist/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3872,6 +3849,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -5091,6 +5069,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5601,6 +5580,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5613,6 +5593,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6288,6 +6269,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.9.7",
       "license": "MIT",
       "dependencies": {
+        "argon2": "^0.44.0",
         "commander": "^12.0.0",
         "proper-lockfile": "^4.1.2",
         "puppeteer-core": "npm:rebrowser-puppeteer-core@23.10.3",
@@ -578,6 +579,12 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -1342,6 +1349,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1978,6 +1994,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argon2": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.44.0.tgz",
+      "integrity": "sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@phc/format": "^1.0.0",
+        "cross-env": "^10.0.0",
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2611,11 +2643,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3824,7 +3872,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -4807,6 +4854,26 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5024,7 +5091,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5535,7 +5601,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5548,7 +5613,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6224,7 +6288,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "typescript": "^5.4.0"
   },
   "dependencies": {
+    "argon2": "^0.44.0",
     "commander": "^12.0.0",
     "proper-lockfile": "^4.1.2",
     "puppeteer-core": "npm:rebrowser-puppeteer-core@23.10.3",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "typescript": "^5.4.0"
   },
   "dependencies": {
-    "argon2": "^0.44.0",
+    "argon2": "^0.43.0",
     "commander": "^12.0.0",
     "proper-lockfile": "^4.1.2",
     "puppeteer-core": "npm:rebrowser-puppeteer-core@23.10.3",

--- a/src/auth/api-key-store.ts
+++ b/src/auth/api-key-store.ts
@@ -286,6 +286,11 @@ export class ApiKeyStore {
       description: input.description ?? '',
     };
     await this.withLock(async () => {
+      // Ingest peer appends made between our last sync and this lock
+      // acquisition BEFORE we advance the cursor via appendRecord. Otherwise
+      // appendRecord jumps lastReadSize to EOF and this process would never
+      // replay those peer records (Codex P1 on commit 64af728).
+      await this.syncFromDisk();
       await this.appendRecord(record);
       this.index.set(keyId, record);
     });
@@ -360,16 +365,17 @@ export class ApiKeyStore {
   }
 
   async touchLastUsed(keyId: string): Promise<void> {
-    await this.syncFromDisk();
-    const existing = this.index.get(keyId);
-    if (!existing) return;
-    const updated: ApiKey = { ...existing, lastUsedAt: Date.now() };
-    // lastUsedAt churn can be frequent; keep file writes serialized but cheap
-    // via append. Preserves replay semantics (latest wins, revokedAt sticks).
+    // Sync INSIDE the lock so a peer revoke that lands between any pre-lock
+    // sync and our lock acquisition is observed before we build `merged`.
+    // Syncing outside the lock would leave `current.revokedAt` absent, and
+    // appending `{ ...current, lastUsedAt }` plus the subsequent cursor
+    // advance to EOF would clobber the peer revoke in this instance's view
+    // (Codex P1 on commit 64af728).
     await this.withLock(async () => {
+      await this.syncFromDisk();
       const current = this.index.get(keyId);
       if (!current) return;
-      const merged: ApiKey = { ...current, lastUsedAt: updated.lastUsedAt };
+      const merged: ApiKey = { ...current, lastUsedAt: Date.now() };
       await this.appendRecord(merged);
       this.index.set(keyId, merged);
     });

--- a/src/auth/api-key-store.ts
+++ b/src/auth/api-key-store.ts
@@ -197,8 +197,24 @@ export class ApiKeyStore {
     const fd = await fs.promises.open(this.storePath, 'r');
     try {
       const buf = Buffer.allocUnsafe(toRead);
-      await fd.read(buf, 0, toRead, this.lastReadSize);
-      const text = buf.toString('utf8');
+      // fd.read can return fewer bytes than requested if the file was
+      // truncated/replaced between stat() and read(). Only decode the
+      // prefix that was actually filled — the tail of `allocUnsafe` is
+      // uninitialized memory and must never be interpreted as content
+      // (Codex P1 on a7e216b).
+      const { bytesRead } = await fd.read(buf, 0, toRead, this.lastReadSize);
+      if (bytesRead <= 0) return;
+      if (bytesRead < toRead) {
+        // Short read: the file was truncated or replaced between our stat()
+        // and read(). Cached state may no longer reflect disk, so drop it;
+        // the next syncFromDisk will re-replay from offset 0 (or via the
+        // inode-change branch if the file was rotated).
+        this.index.clear();
+        this.lastReadSize = 0;
+        this.lastReadIno = 0;
+        return;
+      }
+      const text = buf.subarray(0, bytesRead).toString('utf8');
       const lastNewline = text.lastIndexOf('\n');
       if (lastNewline < 0) return;
       const complete = text.slice(0, lastNewline + 1);

--- a/src/auth/api-key-store.ts
+++ b/src/auth/api-key-store.ts
@@ -1,0 +1,304 @@
+// Tenant-scoped API key store.
+// Append-only JSONL log at ~/.openchrome/auth/api-keys.jsonl, replayed into an
+// in-memory Map on load. Hashes with argon2id; plaintext is never persisted and
+// is returned only once from create()/rotate(). See issue #9 / PR1.
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import writeFileAtomic from 'write-file-atomic';
+import * as lockfile from 'proper-lockfile';
+import * as argon2 from 'argon2';
+import type {
+  ApiKey,
+  ApiKeyCreateInput,
+  ApiKeyCreateResult,
+  Scope,
+} from './api-key-types';
+
+const KEY_PREFIX = 'oc_live_';
+const RANDOM_BYTES = 24; // ~32 base62 chars
+const ARGON2_OPTS: argon2.Options = {
+  type: argon2.argon2id,
+  memoryCost: 19456, // 19 MiB
+  timeCost: 2,
+  parallelism: 1,
+};
+
+// Base62 alphabet: 0-9 A-Z a-z (no padding, URL-safe).
+const BASE62_ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+function base62Encode(buf: Buffer): string {
+  // Convert bytes -> bigint -> base62 digits, preserving a fixed output length
+  // derived from input size so differently sized buffers map to stable widths.
+  if (buf.length === 0) return '';
+  let num = 0n;
+  for (const byte of buf) {
+    num = (num << 8n) | BigInt(byte);
+  }
+  let out = '';
+  while (num > 0n) {
+    const rem = Number(num % 62n);
+    out = BASE62_ALPHABET[rem] + out;
+    num = num / 62n;
+  }
+  // Pad with leading zero digits to keep output length deterministic.
+  // 1 byte ~ log62(256) ~ 1.344 chars -> ceil(n * 1.344)
+  const targetLen = Math.ceil(buf.length * Math.log(256) / Math.log(62));
+  if (out.length < targetLen) {
+    out = BASE62_ALPHABET[0].repeat(targetLen - out.length) + out;
+  }
+  return out;
+}
+
+function computeKeyId(plaintext: string): string {
+  const digest = crypto.createHash('sha256').update(plaintext).digest();
+  // First 10 chars of base62(sha256(plaintext)). Safe to log.
+  return 'k_' + base62Encode(digest).slice(0, 10);
+}
+
+function defaultStoreDir(): string {
+  return path.join(os.homedir(), '.openchrome', 'auth');
+}
+
+function defaultStorePath(): string {
+  return path.join(defaultStoreDir(), 'api-keys.jsonl');
+}
+
+function cloneRecord(r: ApiKey): ApiKey {
+  return {
+    keyId: r.keyId,
+    keyHash: r.keyHash,
+    tenantId: r.tenantId,
+    scopes: [...r.scopes],
+    createdAt: r.createdAt,
+    expiresAt: r.expiresAt,
+    revokedAt: r.revokedAt,
+    lastUsedAt: r.lastUsedAt,
+    description: r.description,
+  };
+}
+
+function isExpired(r: ApiKey, now: number): boolean {
+  return typeof r.expiresAt === 'number' && r.expiresAt < now;
+}
+
+function isRevoked(r: ApiKey): boolean {
+  return typeof r.revokedAt === 'number';
+}
+
+export class ApiKeyStore {
+  private readonly storePath: string;
+  private readonly lockPath: string;
+  private readonly index: Map<string, ApiKey> = new Map();
+  // Precomputed decoy hash so verify(unknown) performs argon2.verify with
+  // indistinguishable timing vs verify(known). Initialised in open().
+  private decoyHash: string = '';
+
+  private constructor(storePath: string) {
+    this.storePath = storePath;
+    this.lockPath = storePath + '.lock';
+  }
+
+  static async open(storePath?: string): Promise<ApiKeyStore> {
+    const finalPath = storePath ?? defaultStorePath();
+    const dir = path.dirname(finalPath);
+    await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
+    // Tighten perms on existing dir (mkdir mode only applies on create).
+    if (process.platform !== 'win32') {
+      try {
+        await fs.promises.chmod(dir, 0o700);
+      } catch {
+        // best-effort
+      }
+    }
+
+    // Ensure the store file exists with 0600 so proper-lockfile and appends work.
+    try {
+      await fs.promises.access(finalPath);
+    } catch {
+      await fs.promises.writeFile(finalPath, '', { mode: 0o600 });
+    }
+    if (process.platform !== 'win32') {
+      try {
+        await fs.promises.chmod(finalPath, 0o600);
+      } catch {
+        // best-effort
+      }
+    }
+
+    const store = new ApiKeyStore(finalPath);
+    await store.loadFromDisk();
+    // Pre-hash a throwaway value. Using a random secret each open prevents any
+    // adversarial timing signal from a fixed decoy across processes.
+    const decoySecret = crypto.randomBytes(32).toString('hex');
+    store.decoyHash = await argon2.hash(decoySecret, ARGON2_OPTS);
+    return store;
+  }
+
+  private async loadFromDisk(): Promise<void> {
+    let raw = '';
+    try {
+      raw = await fs.promises.readFile(this.storePath, 'utf8');
+    } catch {
+      return;
+    }
+    if (!raw) return;
+    const lines = raw.split('\n');
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let parsed: ApiKey;
+      try {
+        parsed = JSON.parse(line) as ApiKey;
+      } catch (err) {
+        console.error('[api-key-store] skipping malformed JSONL line:', err);
+        continue;
+      }
+      if (!parsed || typeof parsed.keyId !== 'string') continue;
+      // Latest record wins; revokedAt sticks (do not clear on later records).
+      const prior = this.index.get(parsed.keyId);
+      if (prior && prior.revokedAt && !parsed.revokedAt) {
+        parsed.revokedAt = prior.revokedAt;
+      }
+      this.index.set(parsed.keyId, parsed);
+    }
+  }
+
+  private async withLock<T>(fn: () => Promise<T>): Promise<T> {
+    // proper-lockfile requires the target file to exist.
+    try {
+      await fs.promises.access(this.storePath);
+    } catch {
+      await fs.promises.writeFile(this.storePath, '', { mode: 0o600 });
+    }
+    const release = await lockfile.lock(this.storePath, {
+      lockfilePath: this.lockPath,
+      retries: { retries: 10, minTimeout: 25, maxTimeout: 200 },
+      stale: 5000,
+    });
+    try {
+      return await fn();
+    } finally {
+      await release();
+    }
+  }
+
+  private async appendRecord(record: ApiKey): Promise<void> {
+    const line = JSON.stringify(record) + '\n';
+    await fs.promises.appendFile(this.storePath, line, { mode: 0o600 });
+  }
+
+  private async rewriteAll(records: ApiKey[]): Promise<void> {
+    const data = records.map((r) => JSON.stringify(r)).join('\n') + (records.length ? '\n' : '');
+    await new Promise<void>((resolve, reject) => {
+      writeFileAtomic(this.storePath, data, { mode: 0o600 }, (err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  }
+
+  async create(input: ApiKeyCreateInput): Promise<ApiKeyCreateResult> {
+    if (!input.tenantId || typeof input.tenantId !== 'string') {
+      throw new Error('tenantId is required');
+    }
+    if (!Array.isArray(input.scopes) || input.scopes.length === 0) {
+      throw new Error('at least one scope is required');
+    }
+    const random = base62Encode(crypto.randomBytes(RANDOM_BYTES)).slice(0, 32);
+    const plaintext = `${KEY_PREFIX}${input.tenantId}_${random}`;
+    const keyId = computeKeyId(plaintext);
+    const keyHash = await argon2.hash(plaintext, ARGON2_OPTS);
+    const record: ApiKey = {
+      keyId,
+      keyHash,
+      tenantId: input.tenantId,
+      scopes: [...input.scopes] as Scope[],
+      createdAt: Date.now(),
+      expiresAt: input.expiresAt,
+      description: input.description ?? '',
+    };
+    await this.withLock(async () => {
+      await this.appendRecord(record);
+      this.index.set(keyId, record);
+    });
+    return { record: cloneRecord(record), plaintext };
+  }
+
+  async list(): Promise<ApiKey[]> {
+    return Array.from(this.index.values()).map(cloneRecord);
+  }
+
+  async revoke(keyId: string): Promise<boolean> {
+    return this.withLock(async () => {
+      const existing = this.index.get(keyId);
+      if (!existing) return false;
+      if (existing.revokedAt) return true; // idempotent
+      const updated: ApiKey = { ...existing, revokedAt: Date.now() };
+      await this.appendRecord(updated);
+      this.index.set(keyId, updated);
+      return true;
+    });
+  }
+
+  async rotate(keyId: string): Promise<ApiKeyCreateResult> {
+    const prior = this.index.get(keyId);
+    if (!prior) {
+      throw new Error(`unknown keyId: ${keyId}`);
+    }
+    // Revoke old (best-effort idempotent) then create new with same tenant+scopes.
+    await this.revoke(keyId);
+    return this.create({
+      tenantId: prior.tenantId,
+      scopes: [...prior.scopes],
+      description: prior.description,
+      expiresAt: prior.expiresAt,
+    });
+  }
+
+  async verify(plaintext: string): Promise<ApiKey | null> {
+    // Constant-ish time: always perform exactly one argon2.verify regardless of
+    // miss/hit, against either the real hash or the decoy.
+    const now = Date.now();
+    let candidateHash = this.decoyHash;
+    let candidate: ApiKey | null = null;
+
+    if (typeof plaintext === 'string' && plaintext.startsWith(KEY_PREFIX)) {
+      const keyId = computeKeyId(plaintext);
+      const found = this.index.get(keyId) ?? null;
+      if (found && !isRevoked(found) && !isExpired(found, now)) {
+        candidate = found;
+        candidateHash = found.keyHash;
+      }
+    }
+
+    let ok = false;
+    try {
+      ok = await argon2.verify(candidateHash, plaintext ?? '');
+    } catch {
+      ok = false;
+    }
+    if (ok && candidate) {
+      return cloneRecord(candidate);
+    }
+    return null;
+  }
+
+  async touchLastUsed(keyId: string): Promise<void> {
+    const existing = this.index.get(keyId);
+    if (!existing) return;
+    const updated: ApiKey = { ...existing, lastUsedAt: Date.now() };
+    // lastUsedAt churn can be frequent; keep file writes serialized but cheap
+    // via append. Preserves replay semantics (latest wins, revokedAt sticks).
+    await this.withLock(async () => {
+      const current = this.index.get(keyId);
+      if (!current) return;
+      const merged: ApiKey = { ...current, lastUsedAt: updated.lastUsedAt };
+      await this.appendRecord(merged);
+      this.index.set(keyId, merged);
+    });
+  }
+}
+
+export { defaultStorePath };

--- a/src/auth/api-key-store.ts
+++ b/src/auth/api-key-store.ts
@@ -298,7 +298,25 @@ export class ApiKeyStore {
   }
 
   private async appendRecord(record: ApiKey): Promise<void> {
-    const line = JSON.stringify(record) + '\n';
+    let line = JSON.stringify(record) + '\n';
+    try {
+      const st = await fs.promises.stat(this.storePath);
+      if (st.size > 0) {
+        const fh = await fs.promises.open(this.storePath, 'r');
+        try {
+          const tail = Buffer.alloc(1);
+          const { bytesRead } = await fh.read(tail, 0, 1, st.size - 1);
+          if (bytesRead === 1 && tail[0] !== 0x0a) {
+            line = '\n' + line;
+          }
+        } finally {
+          await fh.close();
+        }
+      }
+    } catch {
+      // Best-effort: if stat/read fails we still append the record and let the
+      // next sync reconcile from disk.
+    }
     await fs.promises.appendFile(this.storePath, line, { mode: 0o600 });
     // Advance the read cursor so the next syncFromDisk() doesn't re-parse
     // our own append. Best-effort: on stat failure, the next sync reconciles.

--- a/src/auth/api-key-store.ts
+++ b/src/auth/api-key-store.ts
@@ -95,6 +95,16 @@ export class ApiKeyStore {
   // Precomputed decoy hash so verify(unknown) performs argon2.verify with
   // indistinguishable timing vs verify(known). Initialised in open().
   private decoyHash: string = '';
+  // Byte offset up to which the JSONL has already been replayed into `index`,
+  // plus the inode observed at that time. verify()/list()/revoke() call
+  // syncFromDisk() to incrementally apply lines appended by peer processes so
+  // a long-lived store sees cross-process create/revoke in multi-process
+  // deployments (fixes issue #9 PR1 Codex P1 review).
+  private lastReadSize: number = 0;
+  private lastReadIno: number = 0;
+  // Coalesce concurrent syncFromDisk() callers so we don't issue redundant
+  // reads when verify() is called in a burst.
+  private pendingSync: Promise<void> | null = null;
 
   private constructor(storePath: string) {
     this.storePath = storePath;
@@ -129,7 +139,7 @@ export class ApiKeyStore {
     }
 
     const store = new ApiKeyStore(finalPath);
-    await store.loadFromDisk();
+    await store.syncFromDisk();
     // Pre-hash a throwaway value. Using a random secret each open prevents any
     // adversarial timing signal from a fixed decoy across processes.
     const decoySecret = crypto.randomBytes(32).toString('hex');
@@ -137,16 +147,8 @@ export class ApiKeyStore {
     return store;
   }
 
-  private async loadFromDisk(): Promise<void> {
-    let raw = '';
-    try {
-      raw = await fs.promises.readFile(this.storePath, 'utf8');
-    } catch {
-      return;
-    }
-    if (!raw) return;
-    const lines = raw.split('\n');
-    for (const line of lines) {
+  private applyLines(text: string): void {
+    for (const line of text.split('\n')) {
       if (!line.trim()) continue;
       let parsed: ApiKey;
       try {
@@ -163,6 +165,61 @@ export class ApiKeyStore {
       }
       this.index.set(parsed.keyId, parsed);
     }
+  }
+
+  // Incrementally replay appended JSONL lines since the last sync. Callers
+  // that rely on fresh state (verify, list, revoke, rotate, touchLastUsed)
+  // invoke this before reading the index so peer-process writes become
+  // visible without a restart. Read-only: safe to call without holding the
+  // write lock. Torn-appends are tolerated by consuming only up to the last
+  // newline; a partial trailing record is deferred to the next sync.
+  private async syncFromDisk(): Promise<void> {
+    if (this.pendingSync) return this.pendingSync;
+    this.pendingSync = (async () => {
+      try {
+        let stat: fs.Stats;
+        try {
+          stat = await fs.promises.stat(this.storePath);
+        } catch {
+          // File is gone: drop cached state so we don't keep answering for
+          // keys that no longer exist on disk.
+          this.index.clear();
+          this.lastReadSize = 0;
+          this.lastReadIno = 0;
+          return;
+        }
+        // File replaced (rotated) or truncated: re-replay from scratch.
+        if (
+          (this.lastReadIno !== 0 && stat.ino !== this.lastReadIno) ||
+          stat.size < this.lastReadSize
+        ) {
+          this.index.clear();
+          this.lastReadSize = 0;
+        }
+        this.lastReadIno = stat.ino;
+        if (stat.size === this.lastReadSize) return;
+
+        const toRead = stat.size - this.lastReadSize;
+        const fd = await fs.promises.open(this.storePath, 'r');
+        try {
+          const buf = Buffer.allocUnsafe(toRead);
+          await fd.read(buf, 0, toRead, this.lastReadSize);
+          const text = buf.toString('utf8');
+          // Only consume complete lines. Any trailing bytes after the last
+          // newline are a torn/in-flight append from a peer — defer them.
+          const lastNewline = text.lastIndexOf('\n');
+          if (lastNewline < 0) return;
+          const complete = text.slice(0, lastNewline + 1);
+          this.applyLines(complete);
+          this.lastReadSize += Buffer.byteLength(complete, 'utf8');
+        } finally {
+          await fd.close();
+        }
+      } finally {
+        this.pendingSync = null;
+      }
+    })();
+    return this.pendingSync;
   }
 
   private async withLock<T>(fn: () => Promise<T>): Promise<T> {
@@ -187,6 +244,15 @@ export class ApiKeyStore {
   private async appendRecord(record: ApiKey): Promise<void> {
     const line = JSON.stringify(record) + '\n';
     await fs.promises.appendFile(this.storePath, line, { mode: 0o600 });
+    // Advance the read cursor so the next syncFromDisk() doesn't re-parse
+    // our own append. Best-effort: on stat failure, the next sync reconciles.
+    try {
+      const st = await fs.promises.stat(this.storePath);
+      this.lastReadSize = st.size;
+      this.lastReadIno = st.ino;
+    } catch {
+      // fallthrough — next sync will detect the change
+    }
   }
 
   private async rewriteAll(records: ApiKey[]): Promise<void> {
@@ -227,11 +293,13 @@ export class ApiKeyStore {
   }
 
   async list(): Promise<ApiKey[]> {
+    await this.syncFromDisk();
     return Array.from(this.index.values()).map(cloneRecord);
   }
 
   async revoke(keyId: string): Promise<boolean> {
     return this.withLock(async () => {
+      await this.syncFromDisk();
       const existing = this.index.get(keyId);
       if (!existing) return false;
       if (existing.revokedAt) return true; // idempotent
@@ -243,6 +311,7 @@ export class ApiKeyStore {
   }
 
   async rotate(keyId: string): Promise<ApiKeyCreateResult> {
+    await this.syncFromDisk();
     const prior = this.index.get(keyId);
     if (!prior) {
       throw new Error(`unknown keyId: ${keyId}`);
@@ -258,6 +327,11 @@ export class ApiKeyStore {
   }
 
   async verify(plaintext: string): Promise<ApiKey | null> {
+    // Pull in any records appended by peer processes (create/revoke) before
+    // we consult the in-memory index. Without this, a long-lived instance
+    // would keep honouring revoked keys or reject freshly created ones until
+    // process restart.
+    await this.syncFromDisk();
     // Constant-ish time: always perform exactly one argon2.verify regardless of
     // miss/hit, against either the real hash or the decoy.
     const now = Date.now();
@@ -286,6 +360,7 @@ export class ApiKeyStore {
   }
 
   async touchLastUsed(keyId: string): Promise<void> {
+    await this.syncFromDisk();
     const existing = this.index.get(keyId);
     if (!existing) return;
     const updated: ApiKey = { ...existing, lastUsedAt: Date.now() };

--- a/src/auth/api-key-store.ts
+++ b/src/auth/api-key-store.ts
@@ -114,9 +114,16 @@ export class ApiKeyStore {
   static async open(storePath?: string): Promise<ApiKeyStore> {
     const finalPath = storePath ?? defaultStorePath();
     const dir = path.dirname(finalPath);
-    await fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
-    // Tighten perms on existing dir (mkdir mode only applies on create).
-    if (process.platform !== 'win32') {
+    // mkdir returns the first path it had to create, or undefined if the
+    // directory tree already existed. Only chmod when WE created the dir —
+    // otherwise a caller passing a custom path inside a shared parent
+    // (e.g. `/tmp/api-keys.jsonl`) would have that parent's permissions
+    // silently rewritten (Codex P2 on a9e73c8).
+    const dirCreated = await fs.promises.mkdir(dir, {
+      recursive: true,
+      mode: 0o700,
+    });
+    if (dirCreated && process.platform !== 'win32') {
       try {
         await fs.promises.chmod(dir, 0o700);
       } catch {
@@ -124,13 +131,17 @@ export class ApiKeyStore {
       }
     }
 
-    // Ensure the store file exists with 0600 so proper-lockfile and appends work.
+    // Ensure the store file exists with 0600 so proper-lockfile and appends
+    // work. Only force-chmod if WE just created the file — don't mutate the
+    // mode of a pre-existing caller-owned file.
+    let fileCreated = false;
     try {
       await fs.promises.access(finalPath);
     } catch {
       await fs.promises.writeFile(finalPath, '', { mode: 0o600 });
+      fileCreated = true;
     }
-    if (process.platform !== 'win32') {
+    if (fileCreated && process.platform !== 'win32') {
       try {
         await fs.promises.chmod(finalPath, 0o600);
       } catch {

--- a/src/auth/api-key-store.ts
+++ b/src/auth/api-key-store.ts
@@ -167,54 +167,83 @@ export class ApiKeyStore {
     }
   }
 
-  // Incrementally replay appended JSONL lines since the last sync. Callers
-  // that rely on fresh state (verify, list, revoke, rotate, touchLastUsed)
-  // invoke this before reading the index so peer-process writes become
-  // visible without a restart. Read-only: safe to call without holding the
-  // write lock. Torn-appends are tolerated by consuming only up to the last
-  // newline; a partial trailing record is deferred to the next sync.
+  // The actual stat+read body. Never touches `pendingSync` — callers own
+  // the coalescing decision. Tolerates torn peer appends by consuming only
+  // up to the last newline; a partial trailing record is deferred.
+  private async doSyncFromDisk(): Promise<void> {
+    let stat: fs.Stats;
+    try {
+      stat = await fs.promises.stat(this.storePath);
+    } catch {
+      // File is gone: drop cached state so we don't keep answering for
+      // keys that no longer exist on disk.
+      this.index.clear();
+      this.lastReadSize = 0;
+      this.lastReadIno = 0;
+      return;
+    }
+    // File replaced (rotated) or truncated: re-replay from scratch.
+    if (
+      (this.lastReadIno !== 0 && stat.ino !== this.lastReadIno) ||
+      stat.size < this.lastReadSize
+    ) {
+      this.index.clear();
+      this.lastReadSize = 0;
+    }
+    this.lastReadIno = stat.ino;
+    if (stat.size === this.lastReadSize) return;
+
+    const toRead = stat.size - this.lastReadSize;
+    const fd = await fs.promises.open(this.storePath, 'r');
+    try {
+      const buf = Buffer.allocUnsafe(toRead);
+      await fd.read(buf, 0, toRead, this.lastReadSize);
+      const text = buf.toString('utf8');
+      const lastNewline = text.lastIndexOf('\n');
+      if (lastNewline < 0) return;
+      const complete = text.slice(0, lastNewline + 1);
+      this.applyLines(complete);
+      this.lastReadSize += Buffer.byteLength(complete, 'utf8');
+    } finally {
+      await fd.close();
+    }
+  }
+
+  // Coalesced sync for unlocked read paths (verify, list, rotate-precheck).
+  // Concurrent callers share a single in-flight sync to avoid redundant
+  // stat+read under burst traffic. NOT safe for writers inside the cross-
+  // process lock — use syncInsideLock() there.
   private async syncFromDisk(): Promise<void> {
     if (this.pendingSync) return this.pendingSync;
     this.pendingSync = (async () => {
       try {
-        let stat: fs.Stats;
-        try {
-          stat = await fs.promises.stat(this.storePath);
-        } catch {
-          // File is gone: drop cached state so we don't keep answering for
-          // keys that no longer exist on disk.
-          this.index.clear();
-          this.lastReadSize = 0;
-          this.lastReadIno = 0;
-          return;
-        }
-        // File replaced (rotated) or truncated: re-replay from scratch.
-        if (
-          (this.lastReadIno !== 0 && stat.ino !== this.lastReadIno) ||
-          stat.size < this.lastReadSize
-        ) {
-          this.index.clear();
-          this.lastReadSize = 0;
-        }
-        this.lastReadIno = stat.ino;
-        if (stat.size === this.lastReadSize) return;
+        await this.doSyncFromDisk();
+      } finally {
+        this.pendingSync = null;
+      }
+    })();
+    return this.pendingSync;
+  }
 
-        const toRead = stat.size - this.lastReadSize;
-        const fd = await fs.promises.open(this.storePath, 'r');
-        try {
-          const buf = Buffer.allocUnsafe(toRead);
-          await fd.read(buf, 0, toRead, this.lastReadSize);
-          const text = buf.toString('utf8');
-          // Only consume complete lines. Any trailing bytes after the last
-          // newline are a torn/in-flight append from a peer — defer them.
-          const lastNewline = text.lastIndexOf('\n');
-          if (lastNewline < 0) return;
-          const complete = text.slice(0, lastNewline + 1);
-          this.applyLines(complete);
-          this.lastReadSize += Buffer.byteLength(complete, 'utf8');
-        } finally {
-          await fd.close();
-        }
+  // Writer sync: runs INSIDE the cross-process file lock. Must not reuse
+  // an in-flight `pendingSync` because that promise's `stat` may have been
+  // taken BEFORE a peer append landed — sharing it would hand the writer a
+  // stale EOF, appendRecord would then jump lastReadSize past those peer
+  // bytes, and this process would skip them forever. Instead, drain any
+  // in-flight sync (to avoid clobbering its lastReadSize mutation) and
+  // then run a guaranteed-fresh stat+read ourselves (Codex P1 on 0538a8c).
+  private async syncInsideLock(): Promise<void> {
+    while (this.pendingSync) {
+      try {
+        await this.pendingSync;
+      } catch {
+        // Broken sync: retry until the flag clears (doSyncFromDisk's own
+        // errors will re-surface when we run our own fresh sync below).
+      }
+    }
+    this.pendingSync = (async () => {
+      try {
+        await this.doSyncFromDisk();
       } finally {
         this.pendingSync = null;
       }
@@ -286,11 +315,12 @@ export class ApiKeyStore {
       description: input.description ?? '',
     };
     await this.withLock(async () => {
-      // Ingest peer appends made between our last sync and this lock
-      // acquisition BEFORE we advance the cursor via appendRecord. Otherwise
-      // appendRecord jumps lastReadSize to EOF and this process would never
-      // replay those peer records (Codex P1 on commit 64af728).
-      await this.syncFromDisk();
+      // Guaranteed-fresh sync inside the cross-process lock: MUST NOT reuse
+      // a pre-lock coalesced pendingSync whose stat may predate a peer
+      // append, which would leave this process blind to those bytes after
+      // appendRecord advances the cursor to EOF (Codex P1 on commits
+      // 64af728 + 0538a8c).
+      await this.syncInsideLock();
       await this.appendRecord(record);
       this.index.set(keyId, record);
     });
@@ -304,7 +334,7 @@ export class ApiKeyStore {
 
   async revoke(keyId: string): Promise<boolean> {
     return this.withLock(async () => {
-      await this.syncFromDisk();
+      await this.syncInsideLock();
       const existing = this.index.get(keyId);
       if (!existing) return false;
       if (existing.revokedAt) return true; // idempotent
@@ -372,7 +402,7 @@ export class ApiKeyStore {
     // advance to EOF would clobber the peer revoke in this instance's view
     // (Codex P1 on commit 64af728).
     await this.withLock(async () => {
-      await this.syncFromDisk();
+      await this.syncInsideLock();
       const current = this.index.get(keyId);
       if (!current) return;
       const merged: ApiKey = { ...current, lastUsedAt: Date.now() };

--- a/src/auth/api-key-types.ts
+++ b/src/auth/api-key-types.ts
@@ -1,0 +1,28 @@
+// Shared types for the tenant API key store.
+// Used across the auth store, HTTP middleware, and admin CLI.
+
+export type Scope = 'read' | 'write' | 'admin' | 'headless-only';
+
+export interface ApiKey {
+  keyId: string;
+  keyHash: string;
+  tenantId: string;
+  scopes: Scope[];
+  createdAt: number;
+  expiresAt?: number;
+  revokedAt?: number;
+  lastUsedAt?: number;
+  description: string;
+}
+
+export interface ApiKeyCreateInput {
+  tenantId: string;
+  scopes: Scope[];
+  description: string;
+  expiresAt?: number;
+}
+
+export interface ApiKeyCreateResult {
+  record: ApiKey;
+  plaintext: string;
+}

--- a/tests/auth/api-key-store.test.ts
+++ b/tests/auth/api-key-store.test.ts
@@ -140,6 +140,70 @@ describe('ApiKeyStore', () => {
     expect(await b.verify(plaintext)).toBeNull();
   });
 
+  // Regression: Codex P1 on commit 64af728. create() previously appended
+  // without syncing while holding the lock, so appendRecord advanced the
+  // cursor to EOF past any peer appends that landed in the gap — those peer
+  // records were then permanently invisible to this instance. Simulate the
+  // peer by writing a record directly to the file before calling create().
+  test('create() ingests peer appends that landed before we took the lock', async () => {
+    const p = tmpStore();
+    const a = await ApiKeyStore.open(p);
+
+    // Craft a plausible record as if appended by a peer process. The hash
+    // field is opaque to the store — we never verify against it here.
+    const peerKeyId = 'k_peerZZZZZ1';
+    const peerRecord = {
+      keyId: peerKeyId,
+      keyHash: 'peer-hash-placeholder',
+      tenantId: 'peer-tenant',
+      scopes: ['read'],
+      createdAt: Date.now(),
+      description: 'peer-appended',
+    };
+    await fs.promises.appendFile(p, JSON.stringify(peerRecord) + '\n');
+
+    // Now create via instance `a`. With the fix, sync happens inside the
+    // lock before appendRecord advances the cursor, so the peer record is
+    // replayed into a's index.
+    const { record } = await a.create({
+      tenantId: 'self',
+      scopes: ['read'],
+      description: '',
+    });
+
+    const listed = await a.list();
+    const ids = listed.map((r) => r.keyId);
+    expect(ids).toContain(peerKeyId);
+    expect(ids).toContain(record.keyId);
+  });
+
+  // Regression: Codex P1 on commit 64af728. touchLastUsed() previously
+  // synced before acquiring the lock, so a peer revoke appended in the gap
+  // between outer-sync and lock-acquire was missed; the subsequent merged
+  // write clobbered the peer revoke. We simulate that gap deterministically
+  // by writing the revoke directly to disk — with sync-inside-lock, the
+  // lock-held sync replays the revoke into `current` and the merged record
+  // preserves `revokedAt`, so verify() correctly rejects the key afterwards.
+  test('touchLastUsed() does not clobber a peer revoke', async () => {
+    const p = tmpStore();
+    const a = await ApiKeyStore.open(p);
+    const { plaintext, record } = await a.create({
+      tenantId: 't1',
+      scopes: ['read'],
+      description: '',
+    });
+
+    // Peer revoke: append a revoked copy of the record directly to the file.
+    const revokedRecord = { ...record, revokedAt: Date.now() };
+    await fs.promises.appendFile(p, JSON.stringify(revokedRecord) + '\n');
+
+    // Call touchLastUsed; with the fix, the under-lock sync picks up the
+    // peer revoke, so the merged append inherits revokedAt.
+    await a.touchLastUsed(record.keyId);
+
+    expect(await a.verify(plaintext)).toBeNull();
+  });
+
   test('reopen preserves revocation across instances', async () => {
     const p = tmpStore();
     const a = await ApiKeyStore.open(p);

--- a/tests/auth/api-key-store.test.ts
+++ b/tests/auth/api-key-store.test.ts
@@ -1,0 +1,229 @@
+/// <reference types="jest" />
+// Unit tests for the tenant API key store.
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { ApiKeyStore } from '../../src/auth/api-key-store';
+
+function tmpStore(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-apikeys-'));
+  return path.join(dir, 'api-keys.jsonl');
+}
+
+describe('ApiKeyStore', () => {
+  test('create returns plaintext once and list omits it', async () => {
+    const store = await ApiKeyStore.open(tmpStore());
+    const res = await store.create({
+      tenantId: 'acme',
+      scopes: ['read'],
+      description: 'test',
+    });
+    expect(res.plaintext).toMatch(/^oc_live_acme_[A-Za-z0-9]{32}$/);
+    expect(res.record.keyId).toMatch(/^k_/);
+    const listed = await store.list();
+    expect(listed).toHaveLength(1);
+    const first = listed[0] as ApiKey & { plaintext?: string };
+    expect(first.keyId).toBe(res.record.keyId);
+    expect(first.keyHash).toBe(res.record.keyHash);
+    expect(first.plaintext).toBeUndefined();
+    expect(JSON.stringify(first)).not.toContain(res.plaintext);
+  });
+
+  test('verify returns the record for correct plaintext', async () => {
+    const store = await ApiKeyStore.open(tmpStore());
+    const { plaintext, record } = await store.create({
+      tenantId: 't1',
+      scopes: ['read', 'write'],
+      description: '',
+    });
+    const verified = await store.verify(plaintext);
+    expect(verified).not.toBeNull();
+    expect(verified?.keyId).toBe(record.keyId);
+    expect(verified?.scopes).toEqual(['read', 'write']);
+  });
+
+  test('verify returns null for wrong plaintext', async () => {
+    const store = await ApiKeyStore.open(tmpStore());
+    await store.create({ tenantId: 't1', scopes: ['read'], description: '' });
+    expect(await store.verify('oc_live_t1_' + 'x'.repeat(32))).toBeNull();
+    expect(await store.verify('not-even-a-key')).toBeNull();
+    expect(await store.verify('')).toBeNull();
+  });
+
+  test('verify returns null after revoke', async () => {
+    const store = await ApiKeyStore.open(tmpStore());
+    const { plaintext, record } = await store.create({
+      tenantId: 't1',
+      scopes: ['read'],
+      description: '',
+    });
+    expect(await store.verify(plaintext)).not.toBeNull();
+    const ok = await store.revoke(record.keyId);
+    expect(ok).toBe(true);
+    expect(await store.verify(plaintext)).toBeNull();
+  });
+
+  test('verify returns null when expired', async () => {
+    const store = await ApiKeyStore.open(tmpStore());
+    const { plaintext } = await store.create({
+      tenantId: 't1',
+      scopes: ['read'],
+      description: '',
+      expiresAt: Date.now() - 1000,
+    });
+    expect(await store.verify(plaintext)).toBeNull();
+  });
+
+  test('revoke returns false for unknown keyId', async () => {
+    const store = await ApiKeyStore.open(tmpStore());
+    expect(await store.revoke('k_nonexistent')).toBe(false);
+  });
+
+  test('rotate revokes old and issues new plaintext', async () => {
+    const store = await ApiKeyStore.open(tmpStore());
+    const first = await store.create({
+      tenantId: 't1',
+      scopes: ['read', 'admin'],
+      description: 'orig',
+    });
+    const rotated = await store.rotate(first.record.keyId);
+    expect(rotated.plaintext).not.toBe(first.plaintext);
+    expect(rotated.record.keyId).not.toBe(first.record.keyId);
+    expect(rotated.record.tenantId).toBe('t1');
+    expect(rotated.record.scopes).toEqual(['read', 'admin']);
+    expect(await store.verify(first.plaintext)).toBeNull();
+    expect(await store.verify(rotated.plaintext)).not.toBeNull();
+  });
+
+  test('reopen sees writes from another store instance', async () => {
+    const p = tmpStore();
+    const a = await ApiKeyStore.open(p);
+    const { plaintext, record } = await a.create({
+      tenantId: 't1',
+      scopes: ['read'],
+      description: 'x',
+    });
+    const b = await ApiKeyStore.open(p);
+    const listed = await b.list();
+    expect(listed.some((r) => r.keyId === record.keyId)).toBe(true);
+    expect(await b.verify(plaintext)).not.toBeNull();
+  });
+
+  test('reopen preserves revocation across instances', async () => {
+    const p = tmpStore();
+    const a = await ApiKeyStore.open(p);
+    const { plaintext, record } = await a.create({
+      tenantId: 't1',
+      scopes: ['read'],
+      description: '',
+    });
+    await a.revoke(record.keyId);
+    const b = await ApiKeyStore.open(p);
+    expect(await b.verify(plaintext)).toBeNull();
+  });
+
+  test('touchLastUsed updates lastUsedAt in-memory and on reopen', async () => {
+    const p = tmpStore();
+    const a = await ApiKeyStore.open(p);
+    const { record } = await a.create({
+      tenantId: 't1',
+      scopes: ['read'],
+      description: '',
+    });
+    await a.touchLastUsed(record.keyId);
+    const listed = await a.list();
+    expect(listed[0].lastUsedAt).toBeGreaterThan(0);
+    const b = await ApiKeyStore.open(p);
+    const listedB = await b.list();
+    expect(listedB[0].lastUsedAt).toBeGreaterThan(0);
+  });
+
+  test('verify timing: wrong vs correct are indistinguishable', async () => {
+    // The issue target is <1ms; we relax to a ratio-based check to survive
+    // loaded CI runners. argon2.verify at memoryCost=19MiB takes ~50-120ms per
+    // call with natural jitter of several ms, so absolute-ms thresholds are
+    // flaky. We instead require the median ratio to be within 25% of 1.0,
+    // which is sensitive to a real short-circuit on miss (which would be ~0ms)
+    // but tolerant of OS-level jitter.
+    const store = await ApiKeyStore.open(tmpStore());
+    const { plaintext } = await store.create({
+      tenantId: 't1',
+      scopes: ['read'],
+      description: '',
+    });
+    const wrong = 'oc_live_t1_' + 'y'.repeat(32);
+    const runs = 20;
+
+    // Warmup to prime JIT / native addon.
+    for (let i = 0; i < 3; i++) {
+      await store.verify(plaintext);
+      await store.verify(wrong);
+    }
+
+    async function time(fn: () => Promise<unknown>): Promise<number> {
+      const start = process.hrtime.bigint();
+      await fn();
+      return Number(process.hrtime.bigint() - start) / 1e6;
+    }
+
+    const correctTimes: number[] = [];
+    const wrongTimes: number[] = [];
+    for (let i = 0; i < runs; i++) {
+      correctTimes.push(await time(() => store.verify(plaintext)));
+      wrongTimes.push(await time(() => store.verify(wrong)));
+    }
+    const median = (xs: number[]): number => {
+      const s = [...xs].sort((a, b) => a - b);
+      const mid = Math.floor(s.length / 2);
+      return s.length % 2 === 0 ? (s[mid - 1] + s[mid]) / 2 : s[mid];
+    };
+    const mCorrect = median(correctTimes);
+    const mWrong = median(wrongTimes);
+    // Both medians must be non-trivial (argon2 actually ran on the miss path).
+    expect(mCorrect).toBeGreaterThan(5);
+    expect(mWrong).toBeGreaterThan(5);
+    const ratio = mWrong / mCorrect;
+    expect(ratio).toBeGreaterThan(0.75);
+    expect(ratio).toBeLessThan(1.25);
+  }, 60000);
+
+  test('JSONL file never contains plaintext', async () => {
+    const p = tmpStore();
+    const store = await ApiKeyStore.open(p);
+    const { plaintext } = await store.create({
+      tenantId: 'acme',
+      scopes: ['read'],
+      description: 'secret-free',
+    });
+    const raw = await fs.promises.readFile(p, 'utf8');
+    expect(raw).not.toContain(plaintext);
+    // The random tail alone should also not leak.
+    const tail = plaintext.split('_').slice(-1)[0];
+    expect(raw).not.toContain(tail);
+  });
+
+  test('file has 0600 permissions (skip on Windows)', async () => {
+    if (process.platform === 'win32') return;
+    const p = tmpStore();
+    await ApiKeyStore.open(p);
+    const st = await fs.promises.stat(p);
+    // eslint-disable-next-line no-bitwise
+    const mode = st.mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test('directory has 0700 permissions (skip on Windows)', async () => {
+    if (process.platform === 'win32') return;
+    const p = tmpStore();
+    await ApiKeyStore.open(p);
+    const st = await fs.promises.stat(path.dirname(p));
+    // eslint-disable-next-line no-bitwise
+    const mode = st.mode & 0o777;
+    expect(mode).toBe(0o700);
+  });
+});
+
+// Local helper type alias to keep imports lean while asserting shape.
+type ApiKey = import('../../src/auth/api-key-types').ApiKey;

--- a/tests/auth/api-key-store.test.ts
+++ b/tests/auth/api-key-store.test.ts
@@ -111,6 +111,35 @@ describe('ApiKeyStore', () => {
     expect(await b.verify(plaintext)).not.toBeNull();
   });
 
+  // Regression: the Codex P1 review on PR #18. A long-lived store instance
+  // must observe create/revoke performed by a peer process without a restart.
+  // We simulate two processes by opening two stores against the same JSONL
+  // file; `b` is opened BEFORE `a` writes, so `b`'s in-memory index starts
+  // empty and must catch up via the sync-on-verify path.
+  test('verify() picks up peer-process create and revoke without restart', async () => {
+    const p = tmpStore();
+    const a = await ApiKeyStore.open(p);
+    const b = await ApiKeyStore.open(p);
+
+    // b was opened before any writes — its index is empty.
+    expect(await b.list()).toHaveLength(0);
+
+    // Peer (a) creates a key. b must see it on the next verify().
+    const { plaintext, record } = await a.create({
+      tenantId: 't1',
+      scopes: ['read'],
+      description: 'peer-created',
+    });
+    const seen = await b.verify(plaintext);
+    expect(seen).not.toBeNull();
+    expect(seen?.keyId).toBe(record.keyId);
+
+    // Peer (a) revokes the key. b must stop accepting it without restart.
+    const ok = await a.revoke(record.keyId);
+    expect(ok).toBe(true);
+    expect(await b.verify(plaintext)).toBeNull();
+  });
+
   test('reopen preserves revocation across instances', async () => {
     const p = tmpStore();
     const a = await ApiKeyStore.open(p);

--- a/tests/auth/api-key-store.test.ts
+++ b/tests/auth/api-key-store.test.ts
@@ -204,6 +204,30 @@ describe('ApiKeyStore', () => {
     expect(await a.verify(plaintext)).toBeNull();
   });
 
+  // Regression: Codex P1 on commit 482f779. If a crash leaves a partial JSONL
+  // tail without a trailing newline, the next append must start on a fresh
+  // line; otherwise the partial fragment and new record become one malformed
+  // JSON line and the new record is lost on replay after restart.
+  test('create() inserts a newline before appending after an unterminated tail', async () => {
+    const p = tmpStore();
+    const store = await ApiKeyStore.open(p);
+
+    await fs.promises.writeFile(p, '{"partial":true');
+
+    const created = await store.create({
+      tenantId: 't1',
+      scopes: ['read'],
+      description: 'after-crash-tail',
+    });
+
+    const raw = await fs.promises.readFile(p, 'utf-8');
+    expect(raw).toContain('\n{"keyId":"');
+
+    const reopened = await ApiKeyStore.open(p);
+    const verified = await reopened.verify(created.plaintext);
+    expect(verified?.keyId).toBe(created.record.keyId);
+  });
+
   test('reopen preserves revocation across instances', async () => {
     const p = tmpStore();
     const a = await ApiKeyStore.open(p);


### PR DESCRIPTION
## Summary

Foundation layer for the issue #9 multi-tenant API key system — **PR 1 of 4** in a stacked series. No runtime behavior change yet: this PR only introduces the store + types. The HTTP transport still uses the legacy shared bearer token; that wiring lands in PR 2/4.

Relates to: #9

## What's in this PR

- `src/auth/api-key-types.ts` — `ApiKey`, `Scope`, `ApiKeyCreateInput`, `ApiKeyCreateResult`
- `src/auth/api-key-store.ts` — `ApiKeyStore` class
- `tests/auth/api-key-store.test.ts` — 14 tests
- `argon2@^0.44.0` added (both `package.json` and `package-lock.json` updated together per CLAUDE.md)

## Design notes

- **Storage**: append-only JSONL at `~/.openchrome/auth/api-keys.jsonl`; dir `0700` / file `0600`; all writes under `proper-lockfile` so multi-process is safe.
- **Key format**: `oc_live_<tenantId>_<32-char base62>` — prefix follows the issue spec (Stripe-style) so logs + audit streams can identify environment/tenant at a glance.
- **keyId**: short non-secret identifier derived from `sha256(plaintext)` — deterministic, safe to print, referenced from audit log in PR 2/4.
- **Hashing**: argon2id (memoryCost=19456, timeCost=2, parallelism=1).
- **Constant-time verify**: every `verify()` call performs exactly one `argon2.verify` (against a per-process decoy hash on miss/revoked/expired), so wall time does not leak whether the keyId exists.
- **Plaintext**: only returned from `create()` / `rotate()`. `list()` deep-clones and never includes plaintext. JSONL file is checked in-test to never contain plaintext.

## Stacked PR chain

This series targets `develop`:

1. **PR 1/4 — API key store (this PR)**
2. PR 2/4 — HTTP middleware, scope check, rate-limiter tenant keying, audit log keyId
3. PR 3/4 — admin CLI + JWT/OAuth verifier (JWKS)
4. PR 4/4 — docs + E2E + rollback polish

Reviewers can land PR 1 independently; subsequent PRs will rebase on top as they merge.

## Test plan

- [x] npm install && npm run build — clean
- [x] npx jest tests/auth/api-key-store.test.ts — 14/14 pass (~42s, dominated by argon2 cost)
- [x] Plaintext never appears in on-disk JSONL (asserted in test)
- [x] verify(correct) vs verify(wrong) timing indistinguishable (ratio check in test)
- [x] File 0600, directory 0700 (POSIX; skipped on Windows)
- [ ] Integration / HTTP path — lands in PR 2/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Original comments

**@junghwan-oss — 2026-04-20T06:48:51Z**

### Addressed Codex P1: `verify()` stale across processes

Pushed `64af728` which fixes the cross-process visibility gap flagged by @chatgpt-codex-connector.

**Root cause.** `verify()`/`list()` consulted only the in-memory `index` that `open()` populated once. In a multi-process deployment (the intended shape for issue #9), a revoke on process A stays invisible to process B until B restarts — and the converse for newly created keys.

**Fix — `syncFromDisk()`**

- Track `(lastReadSize, lastReadIno)`. Before every read path (`verify`, `list`, `revoke`, `rotate`, `touchLastUsed`), stat the file and replay only the bytes appended since the last sync into the index.
- Consume only up to the last `\n` in the new range, so a torn/in-flight append from a peer is deferred to the next sync rather than ingested as malformed.
- Detect rotation/truncation (inode change or shrink) by clearing the index and reloading from offset 0.
- Writers call `stat()` after `appendFile` to advance the cursor past their own append, so peer processes' next sync doesn't re-parse lines our own in-memory index already reflects.
- Concurrent sync calls are coalesced through a `pendingSync` promise to avoid redundant reads under burst traffic.
- Replay keeps the existing "latest record wins, `revokedAt` sticks" semantic.

**Why this is safe for the constant-time guarantee.** `syncFromDisk()` is called unconditionally before the miss/hit branch, so its latency is not correlated with whether the caller's plaintext is valid. The existing ratio-timing test still passes (median ratio inside 25% of 1.0).

**Regression test.** `tests/auth/api-key-store.test.ts` adds `verify() picks up peer-process create and revoke without restart`: opens two `ApiKeyStore` instances on the same JSONL, creates + revokes via A, asserts B (never reopened) reflects both via `verify()`. The old implementation fails both halves of this test.

**Verification**

- `npm run build` — clean
- `npm test` — 3222 passed, 86 skipped, 0 failed (172/173 suites, one unrelated integration suite is env-gated)
- `npx jest tests/auth/api-key-store.test.ts` — 15/15 (added regression included)

Ready for another review pass.

**@junghwan-oss — 2026-04-20T07:02:01Z**

### Addressed Codex's second pass (P1#2 + P1#3)

Pushed `0538a8c` resolving both P1s raised against `64af728`:

| Finding | Fix |
|---|---|
| `create()` skips peer appends because `appendRecord` advances cursor to EOF without first replaying what's new | Moved `syncFromDisk()` inside `create()`'s `withLock` block, before `appendRecord` |
| `touchLastUsed()` syncs before the lock → peer revoke in the gap clobbered by merged append | Moved `syncFromDisk()` inside `touchLastUsed()`'s `withLock` block, before reading `current` |

The invariant is now consistent across all writer paths: **any method that calls `appendRecord` syncs inside the lock first.** `revoke()` already did this; `rotate()` composes `revoke + create` so inherits the fix.

Two regression tests simulate peer processes via direct JSONL writes:
- `create() ingests peer appends that landed before we took the lock`
- `touchLastUsed() does not clobber a peer revoke`

Both fail on the prior commit and pass now. 17/17 suite tests pass; full `npm test` and `npm run build` are green.

**@junghwan-oss — 2026-04-20T08:07:04Z**

@codex review


---
_Migrated from junghwan-oss/openchrome#18 — originally by @junghwan-oss on 2026-04-20T03:53:13Z. Original state: OPEN._