### PR TITLE
feat(tenant): integrate TenantManager into SessionManager with STRICT flag (B-1 part 3/5)

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -294,3 +294,21 @@ export const DEFAULT_CHROME_MONITOR_INTERVAL_MS = 30000;
 export const DEFAULT_CHROME_MEMORY_WARN_BYTES = 1024 * 1024 * 1024;
 /** Chrome RSS memory critical threshold in bytes. Default: 2GB */
 export const DEFAULT_CHROME_MEMORY_CRITICAL_BYTES = 2 * 1024 * 1024 * 1024;
+
+// ─── Tenant Isolation (#7) ────────────────────────────────────────────
+
+/**
+ * Strict tenant isolation mode. When true, every session is pinned to a
+ * tenant-scoped BrowserContext and the "use default context" escape hatch is
+ * rejected at session creation time. Default false preserves stdio / single
+ * user backward compatibility. Override via
+ * OPENCHROME_STRICT_TENANT_ISOLATION=true for SaaS deployments.
+ */
+export const DEFAULT_STRICT_TENANT_ISOLATION = false;
+
+/**
+ * Idle timeout in ms before a tenant BrowserContext is eligible for eviction
+ * by TenantManager.sweepIdle(). The `default` tenant is never evicted.
+ * Override via OPENCHROME_TENANT_CONTEXT_IDLE_TIMEOUT_MS.
+ */
+export const DEFAULT_TENANT_CONTEXT_IDLE_TIMEOUT_MS = 10 * 60 * 1000;

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -22,6 +22,9 @@ import { StorageStateConfig } from './config';
 import { assertDomainAllowed } from './security/domain-guard';
 import { getTargetId } from './utils/puppeteer-helpers';
 import { safeTitle } from './utils/safe-title';
+import { getTenantManager, isStrictTenantIsolationEnabled } from './tenant/registry';
+import type { TenantManager } from './tenant/manager';
+import { DEFAULT_TENANT_ID, type TenantId } from './tenant/types';
 
 /** The primary session ID used by most single-agent workflows. */
 const DEFAULT_SESSION_ID = 'default';
@@ -49,6 +52,17 @@ export interface SessionManagerConfig {
   usePool?: boolean;
   /** Storage state persistence config (default: disabled) */
   storageState?: StorageStateConfig;
+  /**
+   * TenantManager used to resolve per-tenant BrowserContexts (#7). When
+   * omitted, the process-wide singleton from tenant/registry is used.
+   */
+  tenantManager?: TenantManager;
+  /**
+   * Force strict tenant isolation. When true, `useDefaultContext` is rejected
+   * at session creation time and every session is pinned to a tenant context.
+   * Defaults to reading OPENCHROME_STRICT_TENANT_ISOLATION.
+   */
+  strictTenantIsolation?: boolean;
 }
 
 export interface SessionManagerStats {
@@ -63,7 +77,7 @@ export interface SessionManagerStats {
   connectionPool?: PoolStats;
 }
 
-const DEFAULT_CONFIG: Required<SessionManagerConfig> = {
+const DEFAULT_CONFIG: Required<Omit<SessionManagerConfig, 'tenantManager' | 'strictTenantIsolation'>> = {
   sessionTTL: 30 * 60 * 1000,      // 30 minutes
   cleanupInterval: 60 * 1000,       // 1 minute
   autoCleanup: true,
@@ -95,7 +109,11 @@ export class SessionManager {
   private stealthTargets = new Set<string>();
 
   // TTL & Stats
-  private config: Required<SessionManagerConfig>;
+  private config: Required<Omit<SessionManagerConfig, 'tenantManager' | 'strictTenantIsolation'>>;
+  // Tenant isolation (#7) — lazily bound to the process-wide TenantManager
+  // singleton unless an override was provided via config.
+  private tenantManagerOverride: TenantManager | null;
+  private strictTenantIsolation: boolean;
   private cleanupTimer: NodeJS.Timeout | null = null;
   private startTime: number = Date.now();
   private totalSessionsCreated: number = 0;
@@ -105,7 +123,10 @@ export class SessionManager {
   constructor(cdpClient?: CDPClient, config?: SessionManagerConfig) {
     this.cdpClient = cdpClient || getCDPClient();
     this.queueManager = new RequestQueueManager();
-    this.config = { ...DEFAULT_CONFIG, ...config };
+    const { tenantManager: tenantMgrOverride, strictTenantIsolation, ...rest } = config ?? {};
+    this.config = { ...DEFAULT_CONFIG, ...rest };
+    this.tenantManagerOverride = tenantMgrOverride ?? null;
+    this.strictTenantIsolation = isStrictTenantIsolationEnabled(strictTenantIsolation);
     this.cdpFactory = getCDPClientFactory();
 
     if (this.config.useConnectionPool) {
@@ -262,7 +283,7 @@ export class SessionManager {
   /**
    * Get current configuration
    */
-  getConfig(): Required<SessionManagerConfig> {
+  getConfig(): Required<Omit<SessionManagerConfig, 'tenantManager' | 'strictTenantIsolation'>> {
     return { ...this.config };
   }
 
@@ -293,6 +314,47 @@ export class SessionManager {
   // ==================== SESSION MANAGEMENT ====================
 
   /**
+   * Resolve the TenantManager used by this session manager instance. Prefers
+   * the constructor-injected override so tests can stub context creation.
+   */
+  private getTenantManager(): TenantManager {
+    return this.tenantManagerOverride ?? getTenantManager({ cdpClient: this.cdpClient });
+  }
+
+  /**
+   * Resolve the BrowserContext to assign to a newly created session / worker
+   * based on the requested tenant and strict-isolation policy (#7).
+   *
+   * - STRICT on + `useDefaultContext=true`  → reject (throws)
+   * - STRICT on                             → tenant-scoped context for any tenant
+   * - STRICT off + non-default tenant       → tenant-scoped context
+   * - STRICT off + default tenant           → preserves legacy behavior:
+   *    `useDefaultContext=true`  → null (shares Chrome profile cookies)
+   *    `useDefaultContext=false` → fresh anonymous incognito context
+   */
+  private async resolveSessionContext(
+    tenantId: TenantId,
+    useDefaultContext: boolean,
+  ): Promise<BrowserContext | null> {
+    if (this.strictTenantIsolation) {
+      if (useDefaultContext) {
+        throw new Error(
+          `[SessionManager] STRICT tenant isolation is enabled; ` +
+            `useDefaultContext=true is rejected because it would share the Chrome profile across tenants. ` +
+            `Disable OPENCHROME_STRICT_TENANT_ISOLATION or set useDefaultContext=false.`,
+        );
+      }
+      const tenant = await this.getTenantManager().getOrCreate(tenantId);
+      return tenant.browserContext;
+    }
+    if (tenantId !== DEFAULT_TENANT_ID) {
+      const tenant = await this.getTenantManager().getOrCreate(tenantId);
+      return tenant.browserContext;
+    }
+    return useDefaultContext ? null : await this.cdpClient.createBrowserContext();
+  }
+
+  /**
    * Create a new session with a default worker
    */
   async createSession(options: SessionCreateOptions = {}): Promise<Session> {
@@ -314,12 +376,12 @@ export class SessionManager {
 
     const name = options.name || `Session ${id.slice(0, 8)}`;
     const defaultWorkerId = 'default';
+    const tenantId = options.tenantId ?? DEFAULT_TENANT_ID;
 
-    // Create default worker - use default context if configured (shares Chrome profile's cookies)
-    // or create isolated browser context for session isolation
-    const defaultContext = this.config.useDefaultContext
-      ? null  // null means use default browser context (shares cookies with Chrome profile)
-      : await this.cdpClient.createBrowserContext();
+    // Resolve tenant-scoped context (#7). Falls back to legacy behavior for
+    // the default tenant when STRICT mode is off so stdio callers see no
+    // change in behavior.
+    const defaultContext = await this.resolveSessionContext(tenantId, this.config.useDefaultContext);
     const defaultWorker: Worker = {
       id: defaultWorkerId,
       name: 'Default Worker',
@@ -338,13 +400,14 @@ export class SessionManager {
       lastActivityAt: Date.now(),
       name,
       context: defaultContext,  // Legacy support
+      tenantId,
     };
 
     this.sessions.set(id, session);
     this.totalSessionsCreated++;
     this.emitEvent({ type: 'session:created', sessionId: id, timestamp: Date.now() });
 
-    console.error(`[SessionManager] Created session ${id} with default worker`);
+    console.error(`[SessionManager] Created session ${id} with default worker (tenant=${tenantId})`);
     return session;
   }
 

--- a/src/tenant/registry.ts
+++ b/src/tenant/registry.ts
@@ -1,0 +1,68 @@
+/**
+ * Process-wide TenantManager accessor.
+ *
+ * Lazily constructs a singleton TenantManager whose BrowserContext factory
+ * is backed by the primary CDPClient. Callers that need tenant-scoped
+ * contexts (SessionManager, tool handlers) go through this registry so there
+ * is a single place to configure idle timeouts and wiring.
+ *
+ * Tests can override the singleton via `setTenantManager(mgr)` and reset it
+ * with `resetTenantManager()`.
+ */
+
+import { getCDPClient, type CDPClient } from '../cdp/client';
+import {
+  DEFAULT_TENANT_CONTEXT_IDLE_TIMEOUT_MS,
+  DEFAULT_STRICT_TENANT_ISOLATION,
+} from '../config/defaults';
+import { TenantManager } from './manager';
+
+let singleton: TenantManager | null = null;
+
+export interface TenantRegistryOptions {
+  cdpClient?: CDPClient;
+  idleTimeoutMs?: number;
+}
+
+function readNumberEnv(name: string): number | undefined {
+  const raw = process.env[name];
+  if (!raw) return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+export function getTenantManager(options: TenantRegistryOptions = {}): TenantManager {
+  if (singleton) return singleton;
+  const client = options.cdpClient ?? getCDPClient();
+  const idleTimeoutMs =
+    options.idleTimeoutMs ??
+    readNumberEnv('OPENCHROME_TENANT_CONTEXT_IDLE_TIMEOUT_MS') ??
+    DEFAULT_TENANT_CONTEXT_IDLE_TIMEOUT_MS;
+  singleton = new TenantManager({
+    createContext: () => client.createBrowserContext(),
+    config: { idleTimeoutMs },
+  });
+  return singleton;
+}
+
+/** Test-only. Replaces the singleton. Call `resetTenantManager()` to clear. */
+export function setTenantManager(mgr: TenantManager | null): void {
+  singleton = mgr;
+}
+
+/** Test-only. Forces the next `getTenantManager()` call to rebuild. */
+export function resetTenantManager(): void {
+  singleton = null;
+}
+
+/**
+ * Read strict-isolation mode from env. Precedence: explicit arg > env > default.
+ * When true, SessionManager rejects the "default browser context" path so a
+ * session cannot share Chrome profile cookies across tenants.
+ */
+export function isStrictTenantIsolationEnabled(override?: boolean): boolean {
+  if (typeof override === 'boolean') return override;
+  const raw = process.env.OPENCHROME_STRICT_TENANT_ISOLATION;
+  if (raw === undefined) return DEFAULT_STRICT_TENANT_ISOLATION;
+  return raw === 'true' || raw === '1';
+}

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -3,6 +3,7 @@
  */
 
 import { BrowserContext } from 'puppeteer-core';
+import type { TenantId } from '../tenant/types';
 
 /**
  * Worker - An isolated browser context within a session
@@ -50,6 +51,8 @@ export interface Session {
   // Legacy: targets directly on session (for backwards compat)
   targets: Set<string>;
   context?: BrowserContext | null;  // null = use default browser context (shares Chrome profile cookies)
+  /** Tenant that owns this session. Defaults to DEFAULT_TENANT_ID. (#7) */
+  tenantId?: TenantId;
 }
 
 export interface SessionInfo {
@@ -65,6 +68,13 @@ export interface SessionInfo {
 export interface SessionCreateOptions {
   id?: string;
   name?: string;
+  /**
+   * Tenant to bind this session to. When omitted, falls back to
+   * DEFAULT_TENANT_ID. The SessionManager resolves the BrowserContext through
+   * TenantManager so sessions in different tenants never share cookies,
+   * localStorage, IndexedDB, or service worker caches. (#7)
+   */
+  tenantId?: TenantId;
 }
 
 export interface SessionEvent {

--- a/tests/src/session-manager-tenant.test.ts
+++ b/tests/src/session-manager-tenant.test.ts
@@ -1,0 +1,210 @@
+/// <reference types="jest" />
+/**
+ * Tests for SessionManager tenant isolation integration (#7).
+ */
+
+import type { BrowserContext } from 'puppeteer-core';
+
+// ─── mocks ─────────────────────────────────────────────────────────────
+
+const mockCdpClientInstance = {
+  connect: jest.fn().mockResolvedValue(undefined),
+  isConnected: jest.fn().mockReturnValue(true),
+  addConnectionListener: jest.fn(),
+  addTargetDestroyedListener: jest.fn(),
+  createBrowserContext: jest.fn(),
+  closeBrowserContext: jest.fn().mockResolvedValue(undefined),
+  getBrowser: jest.fn().mockReturnValue({ targets: jest.fn().mockReturnValue([]) }),
+};
+
+jest.mock('../../src/cdp/client', () => ({
+  CDPClient: jest.fn().mockImplementation(() => mockCdpClientInstance),
+  getCDPClient: jest.fn().mockReturnValue(mockCdpClientInstance),
+  getCDPClientFactory: jest.fn().mockReturnValue({
+    get: jest.fn().mockReturnValue(mockCdpClientInstance),
+    getOrCreate: jest.fn().mockReturnValue(mockCdpClientInstance),
+    getAll: jest.fn().mockReturnValue([mockCdpClientInstance]),
+    disconnectAll: jest.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+jest.mock('../../src/cdp/connection-pool', () => ({
+  CDPConnectionPool: jest.fn(),
+  getCDPConnectionPool: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../../src/utils/request-queue', () => ({
+  RequestQueueManager: jest.fn().mockImplementation(() => ({
+    enqueue: jest.fn((_, fn) => fn()),
+    deleteQueue: jest.fn(),
+  })),
+}));
+
+jest.mock('../../src/utils/ref-id-manager', () => ({
+  getRefIdManager: jest.fn(() => ({
+    clearSessionRefs: jest.fn(),
+    clearTargetRefs: jest.fn(),
+  })),
+}));
+
+import { SessionManager } from '../../src/session-manager';
+import { TenantManager } from '../../src/tenant/manager';
+import { DEFAULT_TENANT_ID } from '../../src/tenant/types';
+import { resetTenantManager } from '../../src/tenant/registry';
+
+function stubContext(id: string): BrowserContext {
+  return {
+    __id: id,
+    close: jest.fn().mockResolvedValue(undefined),
+  } as unknown as BrowserContext;
+}
+
+describe('SessionManager tenant isolation (#7)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetTenantManager();
+    delete process.env.OPENCHROME_STRICT_TENANT_ISOLATION;
+    mockCdpClientInstance.createBrowserContext.mockReset();
+  });
+
+  it('preserves legacy behavior: default tenant + useDefaultContext=true yields null context', async () => {
+    const sm = new SessionManager(undefined, {
+      autoCleanup: false,
+      useConnectionPool: false,
+      useDefaultContext: true,
+    });
+    const session = await sm.createSession({ id: 's1' });
+    expect(session.context).toBeNull();
+    expect(session.tenantId).toBe(DEFAULT_TENANT_ID);
+    expect(mockCdpClientInstance.createBrowserContext).not.toHaveBeenCalled();
+  });
+
+  it('preserves legacy behavior: default tenant + useDefaultContext=false creates anonymous context', async () => {
+    const anon = stubContext('anon');
+    mockCdpClientInstance.createBrowserContext.mockResolvedValue(anon);
+    const sm = new SessionManager(undefined, {
+      autoCleanup: false,
+      useConnectionPool: false,
+      useDefaultContext: false,
+    });
+    const session = await sm.createSession({ id: 's1' });
+    expect(session.context).toBe(anon);
+    expect(mockCdpClientInstance.createBrowserContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes a non-default tenant through TenantManager and returns its context', async () => {
+    let n = 0;
+    const tenantCtx = stubContext('tenant');
+    const tm = new TenantManager({
+      createContext: jest.fn(async () => {
+        n++;
+        return tenantCtx;
+      }),
+    });
+    const sm = new SessionManager(undefined, {
+      autoCleanup: false,
+      useConnectionPool: false,
+      useDefaultContext: true,
+      tenantManager: tm,
+    });
+
+    const session = await sm.createSession({ id: 's1', tenantId: 'acme' });
+    expect(session.tenantId).toBe('acme');
+    expect(session.context).toBe(tenantCtx);
+    expect(mockCdpClientInstance.createBrowserContext).not.toHaveBeenCalled();
+    expect(n).toBe(1);
+  });
+
+  it('reuses the same tenant context across multiple sessions for the same tenant', async () => {
+    const ctx = stubContext('t');
+    const factory = jest.fn(async () => ctx);
+    const tm = new TenantManager({ createContext: factory });
+    const sm = new SessionManager(undefined, {
+      autoCleanup: false,
+      useConnectionPool: false,
+      tenantManager: tm,
+    });
+
+    const a = await sm.createSession({ id: 's1', tenantId: 'acme' });
+    const b = await sm.createSession({ id: 's2', tenantId: 'acme' });
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(a.context).toBe(b.context);
+  });
+
+  it('isolates different tenants with distinct BrowserContexts', async () => {
+    let n = 0;
+    const contexts: BrowserContext[] = [];
+    const factory = jest.fn(async () => {
+      const ctx = stubContext(`t${++n}`);
+      contexts.push(ctx);
+      return ctx;
+    });
+    const tm = new TenantManager({ createContext: factory });
+    const sm = new SessionManager(undefined, {
+      autoCleanup: false,
+      useConnectionPool: false,
+      tenantManager: tm,
+    });
+
+    const a = await sm.createSession({ id: 's1', tenantId: 'alpha' });
+    const b = await sm.createSession({ id: 's2', tenantId: 'beta' });
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(a.context).not.toBe(b.context);
+  });
+
+  it('STRICT mode rejects useDefaultContext=true at session creation', async () => {
+    const tm = new TenantManager({ createContext: async () => stubContext('t') });
+    const sm = new SessionManager(undefined, {
+      autoCleanup: false,
+      useConnectionPool: false,
+      useDefaultContext: true,
+      tenantManager: tm,
+      strictTenantIsolation: true,
+    });
+
+    await expect(sm.createSession({ id: 's1' })).rejects.toThrow(
+      /STRICT tenant isolation is enabled.*useDefaultContext=true is rejected/,
+    );
+  });
+
+  it('STRICT mode assigns a tenant context even for the default tenant', async () => {
+    const ctx = stubContext('def');
+    const tm = new TenantManager({ createContext: async () => ctx });
+    const sm = new SessionManager(undefined, {
+      autoCleanup: false,
+      useConnectionPool: false,
+      useDefaultContext: false,
+      tenantManager: tm,
+      strictTenantIsolation: true,
+    });
+
+    const session = await sm.createSession({ id: 's1' });
+    expect(session.tenantId).toBe(DEFAULT_TENANT_ID);
+    expect(session.context).toBe(ctx);
+    expect(mockCdpClientInstance.createBrowserContext).not.toHaveBeenCalled();
+  });
+
+  it('strictTenantIsolation honors OPENCHROME_STRICT_TENANT_ISOLATION env var', async () => {
+    process.env.OPENCHROME_STRICT_TENANT_ISOLATION = 'true';
+    const tm = new TenantManager({ createContext: async () => stubContext('t') });
+    const sm = new SessionManager(undefined, {
+      autoCleanup: false,
+      useConnectionPool: false,
+      useDefaultContext: true,
+      tenantManager: tm,
+    });
+    await expect(sm.createSession({ id: 's1' })).rejects.toThrow(
+      /STRICT tenant isolation is enabled/,
+    );
+  });
+
+  it('getConfig does not expose DI fields', async () => {
+    const sm = new SessionManager(undefined, {
+      autoCleanup: false,
+      useConnectionPool: false,
+    });
+    const cfg = sm.getConfig() as Record<string, unknown>;
+    expect(cfg.tenantManager).toBeUndefined();
+    expect(cfg.strictTenantIsolation).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Third slice of [#7](https://github.com/junghwan-oss/openchrome/issues/7). Wires the TenantManager (#24) into \`SessionManager\` so sessions can be pinned to an isolated per-tenant \`BrowserContext\`.

**Stacked on** [#27](https://github.com/junghwan-oss/openchrome/pull/27) — this PR targets \`feat/b1-tenant-middleware\` so the diff shows only the session-layer changes. Will auto-retarget \`develop\` as parents merge.

## Behavior

Backward compatible by construction: callers that do **not** pass \`tenantId\` hit the existing code path unchanged.

| config | tenantId | useDefaultContext | result |
|---|---|---|---|
| STRICT off | omitted / \`'default'\` | \`true\` | \`null\` (legacy — shares Chrome profile) |
| STRICT off | omitted / \`'default'\` | \`false\` | anonymous incognito context (legacy) |
| STRICT off | \`'acme'\` | either | TenantManager-scoped context |
| STRICT on | any | \`true\` | **throws** — rejects shared-profile path |
| STRICT on | any | \`false\` | TenantManager-scoped context (even for default tenant) |

STRICT mode is read from \`OPENCHROME_STRICT_TENANT_ISOLATION\` with explicit constructor override winning. Default stays **off** so existing stdio / single-user deployments see zero behavior change.

## Files

- \`src/config/defaults.ts\` — \`DEFAULT_STRICT_TENANT_ISOLATION=false\`, \`DEFAULT_TENANT_CONTEXT_IDLE_TIMEOUT_MS=10min\`
- \`src/types/session.ts\` — optional \`tenantId\` on \`Session\` and \`SessionCreateOptions\`
- \`src/tenant/registry.ts\` — \`getTenantManager()\` singleton backed by \`getCDPClient().createBrowserContext\`, \`isStrictTenantIsolationEnabled()\`, plus test reset helpers
- \`src/session-manager.ts\`:
  - New DI config fields: \`tenantManager\`, \`strictTenantIsolation\`
  - Private \`resolveSessionContext(tenantId, useDefaultContext)\` centralizes the decision
  - \`createSession\` now plumbs \`tenantId\` onto the \`Session\`
- \`tests/src/session-manager-tenant.test.ts\` — **9 tests**:
  - Legacy default/default + default/off paths unchanged
  - Non-default tenant routes through TenantManager
  - Same tenant → same context (isolation)
  - Different tenants → distinct contexts
  - STRICT mode rejects \`useDefaultContext=true\`
  - STRICT mode assigns a default-tenant context
  - \`OPENCHROME_STRICT_TENANT_ISOLATION\` env var honored
  - \`getConfig()\` does not leak DI fields

## Regression check

- \`tests/src/session-manager-ttl.test.ts\` — 20/20 passing (unchanged legacy surface)
- \`tests/tenant/\` + \`tests/middleware/\` — 37/37 passing from parent PRs
- \`npx tsc --noEmit\` — clean

## Not in this PR

- HTTP transport wiring (\`src/transports/http.ts\` calls \`extractTenantId\` + threads \`tenantId\` into handlers) — part 4/5
- Tool handler \`tenantId\` propagation — part 4/5
- E2E cross-tenant cookie leak test + metrics + GC timer — part 5/5

## Test plan

- [x] Tenant unit tests (12/12 — PR #24)
- [x] Middleware unit tests (25/25 — PR #27)
- [x] SessionManager tenant tests (9/9)
- [x] SessionManager TTL regression (20/20)
- [x] \`npx tsc --noEmit\` clean
- [ ] Real-Chrome E2E covered in PR #5

Refs: https://github.com/junghwan-oss/openchrome/issues/7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Original comments

**@chatgpt-codex-connector — 2026-04-20T04:28:26Z**

You have reached your Codex usage limits for code reviews. You can see your limits in the [Codex usage dashboard](https://chatgpt.com/codex/cloud/settings/usage).
To continue using code reviews, add credits to your account and enable them for code reviews in your [settings](https://chatgpt.com/codex/cloud/settings/code-review).


---
_Migrated from junghwan-oss/openchrome#30 — originally by @junghwan-oss on 2026-04-20T04:28:21Z. Original state: OPEN._