### PR TITLE
fix(session): propagate Budget from mcp-server through session-manager (A-3 3/3)

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -781,7 +781,7 @@ export class CDPClient {
         return;
       } catch {
         console.error('[CDPClient] Connection probe failed, reconnecting...');
-        await this.forceReconnect();
+        await this.forceReconnect({ budget });
         return;
       }
     }
@@ -824,7 +824,8 @@ export class CDPClient {
    * post-reconnect operations from using orphaned page references that would
    * hang until protocolTimeout (30s).
    */
-  async forceReconnect(): Promise<void> {
+  async forceReconnect(options?: { budget?: Budget }): Promise<void> {
+    const budget = options?.budget;
     // Invalidate any in-flight connect() — we're replacing the connection entirely
     this.pendingConnect = null;
     this.stopHeartbeat();
@@ -857,7 +858,7 @@ export class CDPClient {
     try {
       // Do NOT auto-launch Chrome on heartbeat-triggered reconnect.
       // If Chrome was closed, stay disconnected until the next tool call.
-      await this.connectInternal({ autoLaunch: false });
+      await this.connectInternal({ autoLaunch: false, budget });
       this.lastVerifiedAt = Date.now();
       this.consecutiveHeartbeatFailures = 0;
       this.startHeartbeat();

--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -749,8 +749,13 @@ export class CDPClient {
    * Uses promise coalescing: concurrent callers share a single connectInternal() call
    * instead of each independently opening a WebSocket (which would orphan event listeners
    * and heartbeat timers from the first connection).
+   *
+   * When `budget` is provided, it is forwarded to `connectInternal()` so the
+   * retry loop stays within the caller's deadline (A-3). Coalesced callers
+   * share whatever budget the first caller supplied.
    */
-  async connect(): Promise<void> {
+  async connect(options?: { budget?: Budget }): Promise<void> {
+    const budget = options?.budget;
     if (this.browser && this.browser.isConnected()) {
       // Skip active probe if recently verified by heartbeat (avoids per-call overhead)
       if (Date.now() - this.lastVerifiedAt < DEFAULT_CONNECT_VERIFY_STALENESS_MS) {
@@ -793,7 +798,7 @@ export class CDPClient {
     this.connectionState = 'connecting';
     this.pendingConnect = (async () => {
       try {
-        await this.connectInternal();
+        await this.connectInternal({ budget });
         this.lastVerifiedAt = Date.now();
         this.startHeartbeat();
         console.error('[CDPClient] Connected to Chrome');

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -28,6 +28,8 @@ import { getChromeLauncher } from './chrome/launcher';
 import { getChromePool } from './chrome/pool';
 import { ToolManifest, ToolEntry, ToolCategory } from './types/tool-manifest';
 import { DEFAULT_TOOL_EXECUTION_TIMEOUT_MS, DEFAULT_SESSION_INIT_TIMEOUT_MS, DEFAULT_SESSION_INIT_TIMEOUT_AUTO_LAUNCH_MS, DEFAULT_RECONNECT_TIMEOUT_MS, DEFAULT_OPERATION_GATE_TIMEOUT_MS, DEFAULT_HEARTBEAT_IDLE_TIMEOUT_MS, DEFAULT_RATE_LIMIT_RPM } from './config/defaults';
+import { createBudget, isLegacyBudgetMode } from './utils/budget';
+import { SessionInitBudgetExhausted } from './cdp/errors';
 import { getGlobalEventLoopMonitor } from './watchdog/event-loop-monitor';
 import { SessionRateLimiter } from './utils/rate-limiter';
 import { getGlobalConfig } from './config/global';
@@ -722,13 +724,48 @@ export class MCPServer {
         const sessionInitTimeout = globalConfig.autoLaunch
           ? DEFAULT_SESSION_INIT_TIMEOUT_AUTO_LAUNCH_MS
           : DEFAULT_SESSION_INIT_TIMEOUT_MS;
-        let sessionInitTid: ReturnType<typeof setTimeout>;
-        await Promise.race([
-          this.sessionManager.getOrCreateSession(sessionId).finally(() => clearTimeout(sessionInitTid)),
-          new Promise<never>((_, reject) => {
-            sessionInitTid = setTimeout(() => reject(new Error(`Session initialization timed out after ${sessionInitTimeout}ms`)), sessionInitTimeout);
-          }),
-        ]);
+
+        // A-3: Time-based budget propagation. In legacy mode, fall back to the
+        // old Promise.race-with-setTimeout pattern so ops can revert instantly
+        // via OPENCHROME_SESSION_INIT_BUDGET_MODE=legacy.
+        if (isLegacyBudgetMode()) {
+          let sessionInitTid: ReturnType<typeof setTimeout>;
+          await Promise.race([
+            this.sessionManager.getOrCreateSession(sessionId).finally(() => clearTimeout(sessionInitTid)),
+            new Promise<never>((_, reject) => {
+              sessionInitTid = setTimeout(() => reject(new Error(`Session initialization timed out after ${sessionInitTimeout}ms`)), sessionInitTimeout);
+            }),
+          ]);
+        } else {
+          const budget = createBudget(sessionInitTimeout, 'session-init');
+          let sessionInitTid: ReturnType<typeof setTimeout>;
+          try {
+            await Promise.race([
+              this.sessionManager.getOrCreateSession(sessionId, budget).finally(() => clearTimeout(sessionInitTid)),
+              // Outer safety net — budget-aware code should always win this race,
+              // but add a small slack (+2s) in case an un-budgeted code path hangs.
+              new Promise<never>((_, reject) => {
+                sessionInitTid = setTimeout(
+                  () => reject(new Error(`Session initialization timed out after ${sessionInitTimeout + 2000}ms (budget outer safety)`)),
+                  sessionInitTimeout + 2000,
+                );
+              }),
+            ]);
+          } catch (err) {
+            if (err instanceof SessionInitBudgetExhausted) {
+              try {
+                getMetricsCollector().inc(
+                  'openchrome_session_init_budget_exhausted_total',
+                  { stage: err.stage },
+                );
+              } catch { /* best-effort */ }
+              console.error(
+                `[MCPServer] Session init budget exhausted: stage=${err.stage} elapsed=${err.elapsedMs}ms total=${err.totalMs}ms`,
+              );
+            }
+            throw err;
+          }
+        }
       }
 
       // Wait at gate if paused

--- a/src/metrics/collector.ts
+++ b/src/metrics/collector.ts
@@ -202,6 +202,10 @@ export function getMetricsCollector(): MetricsCollector {
     instance.registerGauge('openchrome_active_sessions', 'Current active MCP sessions');
     instance.registerGauge('openchrome_tabs_health', 'Tab health status count');
     instance.registerCounter('openchrome_rate_limit_rejections_total', 'Requests rejected by rate limiter');
+    instance.registerCounter(
+      'openchrome_session_init_budget_exhausted_total',
+      'Session-init operations that ran out of budget, labeled by exhausting stage (A-3)',
+    );
   }
   return instance;
 }

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -22,6 +22,11 @@ import { StorageStateConfig } from './config';
 import { assertDomainAllowed } from './security/domain-guard';
 import { getTargetId } from './utils/puppeteer-helpers';
 import { safeTitle } from './utils/safe-title';
+import { Budget, isLegacyBudgetMode } from './utils/budget';
+import {
+  DEFAULT_SESSION_INIT_BUDGET_LAUNCH_FRACTION,
+  DEFAULT_SESSION_INIT_BUDGET_CONNECT_FRACTION,
+} from './config/defaults';
 
 /** The primary session ID used by most single-agent workflows. */
 const DEFAULT_SESSION_ID = 'default';
@@ -282,11 +287,23 @@ export class SessionManager {
   }
 
   /**
-   * Ensure connected to Chrome
+   * Ensure connected to Chrome.
+   *
+   * When `budget` is supplied and budget mode is not legacy, a child budget
+   * covering launch + puppeteer.connect share (~55% of the parent) is carved
+   * and passed to `cdpClient.connect()`. This keeps the overall session-init
+   * stage-time sliced as described in A-3 §3-2.
    */
-  async ensureConnected(): Promise<void> {
+  async ensureConnected(budget?: Budget): Promise<void> {
     if (!this.cdpClient.isConnected()) {
-      await this.cdpClient.connect();
+      if (budget && !isLegacyBudgetMode()) {
+        const connectFraction = DEFAULT_SESSION_INIT_BUDGET_LAUNCH_FRACTION
+          + DEFAULT_SESSION_INIT_BUDGET_CONNECT_FRACTION;
+        const connectBudget = budget.slice(Math.min(connectFraction, 1), 'connect');
+        await this.cdpClient.connect({ budget: connectBudget });
+      } else {
+        await this.cdpClient.connect();
+      }
     }
   }
 
@@ -296,7 +313,8 @@ export class SessionManager {
    * Create a new session with a default worker
    */
   async createSession(options: SessionCreateOptions = {}): Promise<Session> {
-    await this.ensureConnected();
+    const budget = options.budget as Budget | undefined;
+    await this.ensureConnected(budget);
 
     const id = options.id || crypto.randomUUID();
 
@@ -349,9 +367,14 @@ export class SessionManager {
   }
 
   /**
-   * Get or create a session
+   * Get or create a session.
+   *
+   * `budget` (A-3) flows through to `createSession()` on cold-start. If a
+   * concurrent creation is already in flight, the pending promise is
+   * returned as-is — the second caller inherits whatever budget the first
+   * caller supplied (or none).
    */
-  async getOrCreateSession(sessionId: string): Promise<Session> {
+  async getOrCreateSession(sessionId: string, budget?: Budget): Promise<Session> {
     const existing = this.sessions.get(sessionId);
     if (existing) {
       this.touchSession(sessionId);
@@ -364,7 +387,7 @@ export class SessionManager {
       return pending;
     }
 
-    const creation = this.createSession({ id: sessionId }).finally(() => {
+    const creation = this.createSession({ id: sessionId, budget }).finally(() => {
       this.pendingCreations.delete(sessionId);
     });
     this.pendingCreations.set(sessionId, creation);

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -65,6 +65,10 @@ export interface SessionInfo {
 export interface SessionCreateOptions {
   id?: string;
   name?: string;
+  /** Optional time budget for the underlying CDP connect path (A-3).
+   *  Typed as `unknown` here to keep the shared types file free of a
+   *  dependency on the utils/budget module; consumers cast to `Budget`. */
+  budget?: unknown;
 }
 
 export interface SessionEvent {

--- a/tests/src/cdp-active-probe.test.ts
+++ b/tests/src/cdp-active-probe.test.ts
@@ -32,6 +32,7 @@ jest.mock('../../src/config/global', () => ({
 // ─── Imports ──────────────────────────────────────────────────────────────────
 
 import { CDPClient } from '../../src/cdp/client';
+import { createBudget } from '../../src/utils/budget';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -240,6 +241,24 @@ describe('CDPClient – connect() active probe', () => {
     await client.connect();
 
     expect(forceReconnectSpy).toHaveBeenCalledTimes(1);
+    stopHeartbeat(client);
+  });
+
+  test('connect() forwards session-init budget into probe-triggered reconnects', async () => {
+    const client = new CDPClient({ port: 9222 });
+    const mockBrowser = createMockBrowser();
+    mockBrowser.version.mockRejectedValue(new Error('dead connection'));
+    (client as any).browser = mockBrowser;
+    (client as any).connectionState = 'connected';
+    (client as any).lastVerifiedAt = 0;
+
+    const budget = createBudget(1_000, 'session-init');
+    const forceReconnectSpy = jest.spyOn(client, 'forceReconnect')
+      .mockResolvedValue(undefined);
+
+    await client.connect({ budget });
+
+    expect(forceReconnectSpy).toHaveBeenCalledWith({ budget });
     stopHeartbeat(client);
   });
 


### PR DESCRIPTION
Closes #3 (A-3).

Third and final PR for issue #3 (A-3). Depends on 1/3 (Budget primitive) and 2/3 (`connectInternal` budget support).

## Summary
Wires the Budget created at the `mcp-server` session-init boundary down through the session manager into `CDPClient.connect()`, and adds a metrics counter labeled by the exhausting stage for post-deploy observability.

This completes the A-3 fix — the 75s `DEFAULT_SESSION_INIT_TIMEOUT_AUTO_LAUNCH_MS` is now enforced as a hard wall-clock deadline rather than an upstream timeout that a runaway internal retry loop could blow past.

## Files
- `src/mcp-server.ts` — replaces `setTimeout`/`Promise.race` with `createBudget(sessionInitTimeout, 'session-init')` passed to `getOrCreateSession()`. Outer `Promise.race` kept as a +2s safety net for any not-yet-budget-aware subpath. Catches `SessionInitBudgetExhausted` to increment the counter and log the exhausting stage.
- `src/session-manager.ts`
  - `ensureConnected(budget?)` — carves a launch+connect child budget (~55%) and forwards to `cdpClient.connect({ budget })`.
  - `getOrCreateSession(sessionId, budget?)` — accepts optional budget; coalesced concurrent callers inherit the first caller's budget.
  - `createSession(options)` — reads `options.budget` and forwards.
- `src/cdp/client.ts` — `connect({ budget })` accepts optional budget, forwarded to `connectInternal` (budget-aware as of 2/3).
- `src/types/session.ts` — `SessionCreateOptions.budget?: unknown`. Typed as `unknown` to keep the shared types file free of a dependency on `utils/budget`.
- `src/metrics/collector.ts` — registers `openchrome_session_init_budget_exhausted_total{stage}`.

## Test Plan
- [x] `npm run build` — passes
- [x] All relevant suites: `budget.test.ts`, `session-init-budget.test.ts`, `cdp-connect-coalescing.test.ts`, `cdp-reconnect.test.ts`, `cdp-active-probe.test.ts` — 59/59 passed
- [x] Legacy env flag path preserved verbatim (no behavior change when set)
- [ ] Local smoke: `openchrome serve --http 3100 --auto-launch` happy path (unchanged) — run before merge

## Post-Deploy Validation (issue #3 §7)
- Monitor `openchrome_session_init_budget_exhausted_total` on `/metrics`.
- Stage distribution (`connect`, `attempt-gate`, `post-attempt`) indicates which phase needs tuning.
- Expect p99 session-init latency to drop — fail-fast replaces silent 115s+ hangs.

## Stack
- 1/3 → base `develop` (foundation)
- 2/3 → base `fix/a3-budget-util` (consumer)
- **3/3 (this PR)** → base `fix/a3-connect-budget` (top-level wiring)

## Rollback
`OPENCHROME_SESSION_INIT_BUDGET_MODE=legacy` restores the pre-A-3 setTimeout/Promise.race behavior end-to-end without a redeploy. `git revert` also works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Migrated from junghwan-oss/openchrome#17 — originally by @junghwan-oss on 2026-04-20T03:50:05Z. Original state: OPEN._