### PR TITLE
Honor bound HTTP tenants in sessions and metrics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -497,6 +497,7 @@ program
         browserState: stateManager.getStatus(),
         chromeProcess: chromeProcessData,
         sessions: { active: sessionManager?.sessionCount ?? 0 },
+        tenants: { activeContexts: sessionManager?.tenantContextCount ?? 0 },
       };
       return data;
     }, healthPort, healthBind);

--- a/src/metrics/collector.ts
+++ b/src/metrics/collector.ts
@@ -250,6 +250,7 @@ export function getMetricsCollector(): MetricsCollector {
     instance.registerCounter('openchrome_reconnect_total', 'Total successful CDP reconnections');
     instance.registerGauge('openchrome_heap_bytes', 'Node.js heap usage in bytes');
     instance.registerGauge('openchrome_active_sessions', 'Current active MCP sessions');
+    instance.registerGauge('openchrome_tenant_contexts_active', 'Current active tenant-scoped BrowserContexts');
     instance.registerGauge('openchrome_tabs_health', 'Tab health status count');
     instance.registerCounter('openchrome_rate_limit_rejections_total', 'Requests rejected by rate limiter');
     instance.registerCounter('openchrome_listener_errors_total', 'Async EventEmitter listener errors surfaced by safeAsyncListener');

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -25,6 +25,7 @@ import { safeTitle } from './utils/safe-title';
 import { getTenantManager, isStrictTenantIsolationEnabled } from './tenant/registry';
 import type { TenantManager } from './tenant/manager';
 import { DEFAULT_TENANT_ID, type TenantId } from './tenant/types';
+import { currentRequestContext } from './observability/request-id';
 import { Budget, isLegacyBudgetMode } from './utils/budget';
 import {
   DEFAULT_SESSION_INIT_BUDGET_LAUNCH_FRACTION,
@@ -352,9 +353,10 @@ export class SessionManager {
   private async resolveSessionContext(
     tenantId: TenantId,
     useDefaultContext: boolean,
+    forceTenantContext = false,
   ): Promise<BrowserContext | null> {
     if (this.strictTenantIsolation) {
-      if (useDefaultContext) {
+      if (useDefaultContext && !forceTenantContext) {
         throw new Error(
           `[SessionManager] STRICT tenant isolation is enabled; ` +
             `useDefaultContext=true is rejected because it would share the Chrome profile across tenants. ` +
@@ -394,12 +396,17 @@ export class SessionManager {
 
     const name = options.name || `Session ${id.slice(0, 8)}`;
     const defaultWorkerId = 'default';
-    const tenantId = options.tenantId ?? DEFAULT_TENANT_ID;
+    const tenantId = options.tenantId
+      ?? (currentRequestContext()?.tenantId as TenantId | undefined)
+      ?? DEFAULT_TENANT_ID;
+    const forceTenantContext = options.tenantId !== undefined
+      ? tenantId !== DEFAULT_TENANT_ID
+      : tenantId !== DEFAULT_TENANT_ID && currentRequestContext()?.tenantId === tenantId;
 
     // Resolve tenant-scoped context (#7). Falls back to legacy behavior for
     // the default tenant when STRICT mode is off so stdio callers see no
     // change in behavior.
-    const defaultContext = await this.resolveSessionContext(tenantId, this.config.useDefaultContext);
+    const defaultContext = await this.resolveSessionContext(tenantId, this.config.useDefaultContext, forceTenantContext);
     const defaultWorker: Worker = {
       id: defaultWorkerId,
       name: 'Default Worker',
@@ -741,6 +748,19 @@ export class SessionManager {
     }
 
     return worker;
+  }
+
+  /**
+   * Number of active tenant-scoped BrowserContexts currently held by the tenant manager.
+   * Includes the default tenant only when strict tenant isolation or explicit tenant
+   * allocation has created a dedicated BrowserContext for it.
+   */
+  get tenantContextCount(): number {
+    try {
+      return this.getTenantManager().stats().active;
+    } catch {
+      return 0;
+    }
   }
 
   /**

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -819,7 +819,13 @@ export class HTTPTransport implements MCPTransport {
       // Handle JSON-RPC batch (array of requests)
       if (Array.isArray(parsed)) {
         const results = await runWithRequestContext(
-          { requestId },
+          {
+            requestId,
+            tenantId: principal && (principal.mode === 'api-key' || principal.mode === 'jwt')
+              ? principal.tenantId
+              : tenantId,
+            keyId: principal?.mode === 'api-key' ? principal.keyId : undefined,
+          },
           () => this.processBatch(parsed, sessionId, tenantId, signal, principal),
         );
         // Filter out null results (notifications don't produce responses)
@@ -866,7 +872,13 @@ export class HTTPTransport implements MCPTransport {
 
       try {
         const response = await runWithRequestContext(
-          { requestId },
+          {
+            requestId,
+            tenantId: principal && (principal.mode === 'api-key' || principal.mode === 'jwt')
+              ? principal.tenantId
+              : tenantId,
+            keyId: principal?.mode === 'api-key' ? principal.keyId : undefined,
+          },
           () => this.messageHandler!(msg, signal),
         );
 

--- a/src/watchdog/health-endpoint.ts
+++ b/src/watchdog/health-endpoint.ts
@@ -42,6 +42,9 @@ export interface HealthData {
   sessions?: {
     active: number;
   };
+  tenants?: {
+    activeContexts: number;
+  };
 }
 
 export type HealthDataProvider = () => HealthData;
@@ -88,6 +91,7 @@ export class HealthEndpoint {
               metrics.set('openchrome_tabs_health', { status: 'unhealthy' }, data.tabs.unhealthy);
             }
             metrics.set('openchrome_active_sessions', {}, data.sessions?.active ?? 0);
+            metrics.set('openchrome_tenant_contexts_active', {}, data.tenants?.activeContexts ?? 0);
 
             res.writeHead(200, { 'Content-Type': 'text/plain; version=0.0.4; charset=utf-8' });
             res.end(metrics.export());

--- a/tests/mcp-server-tenant-metrics.test.ts
+++ b/tests/mcp-server-tenant-metrics.test.ts
@@ -1,0 +1,37 @@
+/// <reference types="jest" />
+import { MCPServer } from '../src/mcp-server';
+import { getMetricsCollector } from '../src/metrics/collector';
+import { runWithRequestContext } from '../src/observability/request-id';
+
+describe('MCPServer tenant-aware metric emission', () => {
+  test('emits tool metrics with tenant label from request context', async () => {
+    const server = new MCPServer({
+      getOrCreateSession: jest.fn().mockResolvedValue({ id: 's' }),
+      addEventListener: jest.fn(),
+      sessionCount: 0,
+    } as any);
+
+    const toolName = `tenant_metric_test_${Date.now()}`;
+    server.registerTool(
+      toolName,
+      jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] }),
+      {
+        name: toolName,
+        description: 'tenant metric test',
+        inputSchema: { type: 'object', properties: {} },
+      },
+    );
+
+    await runWithRequestContext({ requestId: 'req-metric', tenantId: 'acme' }, () =>
+      server.handleRequest({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: toolName, arguments: {}, sessionId: 's' },
+      } as any),
+    );
+
+    const exportText = getMetricsCollector().export();
+    expect(exportText).toContain(`openchrome_tool_calls_total{tool="${toolName}",status="success",tenant="acme"} 1`);
+  });
+});

--- a/tests/src/session-manager-tenant.test.ts
+++ b/tests/src/session-manager-tenant.test.ts
@@ -48,6 +48,7 @@ jest.mock('../../src/utils/ref-id-manager', () => ({
 }));
 
 import { SessionManager } from '../../src/session-manager';
+import { runWithRequestContext } from '../../src/observability/request-id';
 import { TenantManager } from '../../src/tenant/manager';
 import { DEFAULT_TENANT_ID } from '../../src/tenant/types';
 import { resetTenantManager } from '../../src/tenant/registry';
@@ -115,6 +116,28 @@ describe('SessionManager tenant isolation (#7)', () => {
     expect(n).toBe(1);
   });
 
+
+  it('uses the active request-context tenant when createSession omits tenantId', async () => {
+    const tenantCtx = stubContext('tenant-from-ctx');
+    const tm = new TenantManager({
+      createContext: jest.fn(async () => tenantCtx),
+    });
+    const sm = new SessionManager(undefined, {
+      autoCleanup: false,
+      useConnectionPool: false,
+      useDefaultContext: true,
+      tenantManager: tm,
+    });
+
+    const session = await runWithRequestContext({ requestId: 'req-1', tenantId: 'acme' }, () =>
+      sm.createSession({ id: 'ctx-session' }),
+    );
+
+    expect(session.tenantId).toBe('acme');
+    expect(session.context).toBe(tenantCtx);
+    expect(mockCdpClientInstance.createBrowserContext).not.toHaveBeenCalled();
+  });
+
   it('reuses the same tenant context across multiple sessions for the same tenant', async () => {
     const ctx = stubContext('t');
     const factory = jest.fn(async () => ctx);
@@ -165,6 +188,26 @@ describe('SessionManager tenant isolation (#7)', () => {
     await expect(sm.createSession({ id: 's1' })).rejects.toThrow(
       /STRICT tenant isolation is enabled.*useDefaultContext=true is rejected/,
     );
+  });
+
+
+  it('STRICT mode honors request-context tenant by forcing a tenant-scoped context for HTTP-style calls', async () => {
+    const tenantCtx = stubContext('strict-http-tenant');
+    const tm = new TenantManager({ createContext: async () => tenantCtx });
+    const sm = new SessionManager(undefined, {
+      autoCleanup: false,
+      useConnectionPool: false,
+      useDefaultContext: true,
+      tenantManager: tm,
+      strictTenantIsolation: true,
+    });
+
+    const session = await runWithRequestContext({ requestId: 'req-strict', tenantId: 'alpha' }, () =>
+      sm.createSession({ id: 'strict-http-session' }),
+    );
+
+    expect(session.tenantId).toBe('alpha');
+    expect(session.context).toBe(tenantCtx);
   });
 
   it('STRICT mode assigns a tenant context even for the default tenant', async () => {

--- a/tests/transports/http-tenant.test.ts
+++ b/tests/transports/http-tenant.test.ts
@@ -4,6 +4,7 @@
  */
 
 import * as http from 'node:http';
+import { currentRequestContext } from '../../src/observability/request-id';
 
 const { HTTPTransport } = require('../../src/transports/http');
 
@@ -61,12 +62,12 @@ describe('HTTP transport — tenant extraction (#7)', () => {
     await new Promise((r) => setTimeout(r, 50));
   });
 
-  async function boot() {
+  async function boot(handler?: (msg: Record<string, unknown>) => Promise<Record<string, unknown>>) {
     transport = new HTTPTransport(TEST_PORT, '127.0.0.1');
     transport.onMessage(async (msg: Record<string, unknown>) => ({
       jsonrpc: '2.0',
       id: msg.id,
-      result: { ok: true, method: msg.method },
+      result: handler ? await handler(msg) : { ok: true, method: msg.method },
     }));
     transport.start();
     await new Promise((r) => setTimeout(r, 100));
@@ -173,6 +174,26 @@ it('STRICT mode rejects missing X-Tenant-Id with 400 (code=missing)', async () =
       { jsonrpc: '2.0', id: 2, method: 'ping' },
     );
     expect(second.status).toBe(200);
+  });
+
+
+  it('propagates tenant and key context into the async request context for handlers', async () => {
+    await boot(async () => ({
+      requestContext: currentRequestContext(),
+    }));
+    const first = await mcpPost(
+      { 'X-Tenant-Id': 'acme' },
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+    );
+    const mcpSession = first.headers['mcp-session-id'] as string;
+    const second = await mcpPost(
+      { 'X-Tenant-Id': 'acme', 'Mcp-Session-Id': mcpSession, 'X-Request-Id': 'req-tenant-ctx' },
+      { jsonrpc: '2.0', id: 2, method: 'ping' },
+    );
+    expect(second.status).toBe(200);
+    const data = JSON.parse(second.body);
+    expect(data.result.requestContext.requestId).toBe('req-tenant-ctx');
+    expect(data.result.requestContext.tenantId).toBe('acme');
   });
 
   it('DELETE /mcp clears the tenant binding', async () => {

--- a/tests/watchdog/event-loop-monitor.test.ts
+++ b/tests/watchdog/event-loop-monitor.test.ts
@@ -298,6 +298,34 @@ describe('HealthEndpoint', () => {
     expect(data.uptime).toBe(100);
   });
 
+
+  test('exports tenant context gauge on /metrics when provider includes tenant data', async () => {
+    const provider = () => ({
+      status: 'ok' as const,
+      uptime: 100,
+      memory: process.memoryUsage(),
+      eventLoop: { maxDriftMs: 5, warnCount: 0 },
+      sessions: { active: 2 },
+      tenants: { activeContexts: 3 },
+    });
+
+    const port = 19200 + Math.floor(Math.random() * 800);
+    endpoint = new HealthEndpoint(provider, port);
+    await endpoint.start();
+
+    const response = await new Promise<{ statusCode: number; body: string }>((resolve) => {
+      const http = require('http');
+      http.get(`http://127.0.0.1:${port}/metrics`, (res: any) => {
+        let body = '';
+        res.on('data', (chunk: string) => { body += chunk; });
+        res.on('end', () => resolve({ statusCode: res.statusCode, body }));
+      });
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toContain('openchrome_tenant_contexts_active 3');
+  });
+
   test('returns 404 for unknown paths', async () => {
     const provider = () => ({ status: 'ok' as const, uptime: 0, memory: process.memoryUsage(), eventLoop: { maxDriftMs: 0, warnCount: 0 } });
     const port = 19200 + Math.floor(Math.random() * 800);


### PR DESCRIPTION
## Summary
- propagate bound HTTP tenant context through request execution so session creation can honor non-default tenants
- make tenant-aware metrics use the authenticated/bound tenant instead of `unknown`
- expose active tenant BrowserContext count via health/metrics and add regression coverage for the HTTP path

## Why
This addresses the transport/session/observability gap behind:
- Fixes #615
- Fixes #616
- Fixes #619

Before this change:
- strict tenant isolation still failed for ordinary HTTP tool calls because session creation missed the bound tenant
- real authenticated tool metrics could still emit `tenant="unknown"`
- tenant context counts were not exported via `/metrics`

After this change:
- HTTP-bound non-default tenants create/use tenant-scoped sessions by default in the request path
- request context carries tenant/key info into metric emission
- `/metrics` exports `openchrome_tenant_contexts_active`

## Verification
- `npm run build`
- `npx jest --runInBand tests/transports/http-tenant.test.ts tests/src/session-manager-tenant.test.ts tests/integration/tenant-isolation.test.ts tests/metrics/tenant-label.test.ts tests/security/audit-logger-extended.test.ts tests/auth/api-key-store.test.ts tests/auth/jwt-verifier.test.ts tests/middleware/auth.test.ts tests/security/tenant-session-binding.test.ts tests/security/session-methods-authz.test.ts tests/mcp-server-tenant-metrics.test.ts`
- live strict-tenant smoke: `OPENCHROME_STRICT_TENANT_ISOLATION=true` + `X-Tenant-Id: alpha` tool call succeeds
- live API-key metrics smoke: authenticated `tabs_context` call emits `openchrome_tool_calls_total{...,tenant="t_acme"}` and `openchrome_tenant_contexts_active 1`
