### PR TITLE
Expose explicit cookie-scan partial results

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -46,6 +46,17 @@ type CookieEntry = {
   sameSite?: string;
 };
 
+export type CookieScanStatus = 'complete' | 'partial' | 'no_candidates' | 'no_cookies';
+
+export interface CookieScanResult {
+  status: CookieScanStatus;
+  targetId: string | null;
+  scanned: number;
+  total: number;
+  elapsedMs: number;
+  warning?: string;
+}
+
 export interface CDPClientOptions {
   port?: number;
   maxReconnectAttempts?: number;
@@ -99,7 +110,9 @@ export class CDPClient {
   private cookieSourceCache: Map<string, { targetId: string; timestamp: number }> = new Map();
   private cookieDataCache: Map<string, { cookies: CookieEntry[]; timestamp: number }> = new Map();
   private targetIdIndex: Map<string, Page> = new Map();
-  private inFlightCookieScans: Map<string, Promise<string | null>> = new Map();
+  private targetActivityAt: Map<string, number> = new Map();
+  private inFlightCookieScans: Map<string, Promise<CookieScanResult>> = new Map();
+  private lastCookieScanResult: CookieScanResult | null = null;
   /** Coalesces concurrent connect() calls — only one connectInternal() runs at a time. */
   private pendingConnect: Promise<void> | null = null;
   /** Timestamp of last successful connection verification (heartbeat or active probe). */
@@ -206,6 +219,7 @@ export class CDPClient {
     }
     // Clean up cookie data cache for this target
     this.cookieDataCache.delete(targetId);
+    this.targetActivityAt.delete(targetId);
     // Look up page BEFORE deleting from index so listeners can use it
     const page = this.targetIdIndex.get(targetId);
     this.targetIdIndex.delete(targetId);
@@ -216,6 +230,14 @@ export class CDPClient {
         console.error('[CDPClient] Target destroyed listener error:', e);
       }
     }
+  }
+
+  private touchTargetActivity(targetId: string): void {
+    this.targetActivityAt.set(targetId, Date.now());
+  }
+
+  getLastCookieScanResult(): CookieScanResult | null {
+    return this.lastCookieScanResult;
   }
 
   /**
@@ -843,7 +865,9 @@ export class CDPClient {
       this.browser = null;
       this.sessions.clear();
       this.targetIdIndex.clear();
+      this.targetActivityAt.clear();
       this.inFlightCookieScans.clear();
+      this.lastCookieScanResult = null;
     }
 
     if (this.disconnectRequested) {
@@ -1035,13 +1059,21 @@ export class CDPClient {
    *
    * @param targetDomain Optional domain to prioritize when selecting cookie source
    */
-  async findAuthenticatedPageTargetId(targetDomain?: string): Promise<string | null> {
+  async findAuthenticatedPageTarget(targetDomain?: string): Promise<CookieScanResult> {
     // Check cache first (stale targetId is handled gracefully: copyCookiesViaCDP returns 0)
     const cacheKey = targetDomain || '*';
     const cached = this.cookieSourceCache.get(cacheKey);
     if (cached && Date.now() - cached.timestamp < CDPClient.COOKIE_CACHE_TTL) {
       console.error(`[CDPClient] Cache hit for cookie source (domain: ${cacheKey}): ${cached.targetId.slice(0, 8)}`);
-      return cached.targetId;
+      const result: CookieScanResult = {
+        status: 'complete',
+        targetId: cached.targetId,
+        scanned: 0,
+        total: 0,
+        elapsedMs: 0,
+      };
+      this.lastCookieScanResult = result;
+      return result;
     }
 
     // Promise coalescing: if a scan for this domain is already in-flight, reuse it
@@ -1052,7 +1084,7 @@ export class CDPClient {
     }
 
     // Start the scan and register it so concurrent callers share this promise
-    const scanPromise = this._doFindAuthenticatedPageTargetId(targetDomain, cacheKey);
+    const scanPromise = this._doFindAuthenticatedPageTarget(targetDomain, cacheKey);
     this.inFlightCookieScans.set(cacheKey, scanPromise);
     try {
       return await scanPromise;
@@ -1061,40 +1093,52 @@ export class CDPClient {
     }
   }
 
+  async findAuthenticatedPageTargetId(targetDomain?: string): Promise<string | null> {
+    const result = await this.findAuthenticatedPageTarget(targetDomain);
+    return result.targetId;
+  }
+
   /**
    * Internal implementation of the authenticated-page probe.
    * Uses Target.attachToTarget (multiplexed CDP) instead of raw WebSocket connections.
    * Uses Target.getTargets result directly instead of /json/list HTTP calls.
    */
-  private async _doFindAuthenticatedPageTargetId(targetDomain: string | undefined, cacheKey: string): Promise<string | null> {
+  private async _doFindAuthenticatedPageTarget(targetDomain: string | undefined, cacheKey: string): Promise<CookieScanResult> {
     const scanStart = Date.now();
     const browser = this.getBrowser();
     const session = await browser.target().createCDPSession();
-
-    // Outcome tracking — one of these is set before every return path so we
-    // always surface to metrics whether the scan ran to completion, timed
-    // out partway, or short-circuited because there were no candidates.
-    type ScanOutcome = 'complete' | 'partial' | 'no_candidates' | 'no_cookies';
     let targetsScanned = 0;
 
-    const recordOutcome = (
-      finalOutcome: ScanOutcome,
+    const buildResult = (
+      status: CookieScanStatus,
       totalCandidates: number,
-    ) => {
-      const durationSec = (Date.now() - scanStart) / 1000;
+      targetId: string | null,
+      warning?: string,
+    ): CookieScanResult => ({
+      status,
+      targetId,
+      scanned: targetsScanned,
+      total: totalCandidates,
+      elapsedMs: Date.now() - scanStart,
+      warning,
+    });
+
+    const recordOutcome = (result: CookieScanResult) => {
+      this.lastCookieScanResult = result;
+      const durationSec = result.elapsedMs / 1000;
       try {
         const m = getMetricsCollector();
-        m.inc('openchrome_cookie_scan_total', { status: finalOutcome });
-        m.observe('openchrome_cookie_scan_duration_seconds', { status: finalOutcome }, durationSec);
-        m.observe('openchrome_cookie_scan_targets_scanned', { status: finalOutcome }, targetsScanned);
+        m.inc('openchrome_cookie_scan_total', { status: result.status });
+        m.observe('openchrome_cookie_scan_duration_seconds', { status: result.status }, durationSec);
+        m.observe('openchrome_cookie_scan_targets_scanned', { status: result.status }, targetsScanned);
       } catch {
         // Metrics collector unavailable — scan behavior must not depend on it.
       }
-      if (finalOutcome === 'partial') {
+      if (result.status === 'partial' && !result.targetId) {
         console.error(
-          `[CDPClient] Cookie scan partial: scanned ${targetsScanned}/${totalCandidates} targets ` +
+          `[CDPClient] Cookie scan partial: scanned ${targetsScanned}/${result.total} targets ` +
           `in ${(durationSec * 1000).toFixed(0)}ms before ${DEFAULT_COOKIE_SCAN_TIMEOUT_MS}ms timeout — ` +
-          `no authenticated tab matched among scanned targets; remaining ${totalCandidates - targetsScanned} were skipped.`,
+          `no authenticated tab matched among scanned targets; remaining ${result.total - targetsScanned} were skipped.`,
         );
       }
     };
@@ -1117,8 +1161,9 @@ export class CDPClient {
 
       if (candidates.length === 0) {
         console.error('[CDPClient] No candidate pages found for cookie source');
-        recordOutcome('no_candidates', 0);
-        return null;
+        const result = buildResult('no_candidates', 0, null);
+        recordOutcome(result);
+        return result;
       }
 
       // If targeting an external domain (not localhost), exclude localhost pages
@@ -1130,14 +1175,21 @@ export class CDPClient {
         }
       }
 
-      // Sort candidates by domain match score (highest first)
+      // Sort candidates by domain match score first, then by best-known recent
+      // activity. This makes actively-used OpenChrome pages win ties while still
+      // prioritizing explicit domain affinity for cookie restoration.
+      candidates.sort((a, b) => {
+        const scoreA = targetDomain ? this.domainMatchScore(a.url, targetDomain) : 0;
+        const scoreB = targetDomain ? this.domainMatchScore(b.url, targetDomain) : 0;
+        if (scoreA !== scoreB) return scoreB - scoreA;
+        const activityA = this.targetActivityAt.get(a.targetId) ?? 0;
+        const activityB = this.targetActivityAt.get(b.targetId) ?? 0;
+        return activityB - activityA;
+      });
       if (targetDomain) {
-        candidates.sort((a, b) => {
-          const scoreA = this.domainMatchScore(a.url, targetDomain);
-          const scoreB = this.domainMatchScore(b.url, targetDomain);
-          return scoreB - scoreA;
-        });
-        console.error(`[CDPClient] Sorted ${candidates.length} candidates by domain match to ${targetDomain}`);
+        console.error(`[CDPClient] Sorted ${candidates.length} candidates by domain match and recent activity for ${targetDomain}`);
+      } else {
+        console.error(`[CDPClient] Sorted ${candidates.length} candidates by recent activity`);
       }
 
       // Limit candidates to prevent N×30s cascading timeouts in parallel sessions.
@@ -1154,8 +1206,12 @@ export class CDPClient {
         // Check overall scan timeout to prevent cascading hangs
         if (Date.now() - scanStart > DEFAULT_COOKIE_SCAN_TIMEOUT_MS) {
           console.error(`[CDPClient] Cookie scan timed out after ${Date.now() - scanStart}ms`);
-          recordOutcome('partial', candidates.length);
-          return null;
+          const warning =
+            `Cookie scan timed out after scanning ${targetsScanned}/${candidates.length} targets; ` +
+            `a matching authenticated page may still exist in the skipped remainder.`;
+          const result = buildResult('partial', candidates.length, null, warning);
+          recordOutcome(result);
+          return result;
         }
         targetsScanned += 1;
 
@@ -1188,8 +1244,11 @@ export class CDPClient {
             const domainScore = targetDomain ? this.domainMatchScore(candidate.url, targetDomain) : 0;
             console.error(`[CDPClient] Found authenticated page ${candidate.targetId.slice(0, 8)} at ${candidate.url.slice(0, 50)} (${cookieCount} cookies, domain score: ${domainScore})`);
             this.cookieSourceCache.set(cacheKey, { targetId: candidate.targetId, timestamp: Date.now() });
-            recordOutcome('complete', candidates.length);
-            return candidate.targetId;
+            this.touchTargetActivity(candidate.targetId);
+            const status: CookieScanStatus = targetsScanned < candidates.length ? 'partial' : 'complete';
+            const resultSummary = buildResult(status, candidates.length, candidate.targetId);
+            recordOutcome(resultSummary);
+            return resultSummary;
           }
         } catch {
           // Target may be unresponsive, timed out, or already detached — skip
@@ -1201,8 +1260,9 @@ export class CDPClient {
       }
 
       console.error('[CDPClient] No pages with cookies found');
-      recordOutcome('no_cookies', candidates.length);
-      return null;
+      const result = buildResult('no_cookies', candidates.length, null);
+      recordOutcome(result);
+      return result;
     } finally {
       await session.detach().catch(() => {});
     }
@@ -1367,10 +1427,15 @@ export class CDPClient {
       // The global skipCookieBridge flag serves as a manual override escape hatch.
       // Overall timeout prevents cascading hangs from unresponsive source tabs.
       if (!skipCookieBridge && !getGlobalConfig().skipCookieBridge) {
-        const authPageTargetId = await this.findAuthenticatedPageTargetId(targetDomain);
-        if (authPageTargetId) {
+        const cookieScan = await this.findAuthenticatedPageTarget(targetDomain);
+        if (cookieScan.status === 'partial' && !cookieScan.targetId) {
+          console.error(
+            `[CDPClient] Cookie bridge proceeding without copied cookies: ${cookieScan.warning ?? 'cookie scan incomplete'}`,
+          );
+        }
+        if (cookieScan.targetId) {
           await Promise.race([
-            this.copyCookiesViaCDP(authPageTargetId, page),
+            this.copyCookiesViaCDP(cookieScan.targetId, page),
             new Promise<void>((resolve) =>
               setTimeout(() => {
                 console.error(`[CDPClient] Cookie copy timed out after ${DEFAULT_COOKIE_COPY_TIMEOUT_MS}ms, proceeding without cookies`);
@@ -1383,7 +1448,11 @@ export class CDPClient {
     }
 
     // Index page for O(1) target-to-page lookups (replaces eager targetcreated indexing)
-    this.targetIdIndex.set(getTargetId(page.target()), page);
+    {
+      const pageTargetId = getTargetId(page.target());
+      this.targetIdIndex.set(pageTargetId, page);
+      this.touchTargetActivity(pageTargetId);
+    }
 
     this.configurePageDefenses(page);
 
@@ -1839,6 +1908,7 @@ export class CDPClient {
         if (!page.isClosed()) {
           const targetId = getTargetId(page.target());
           newIndex.set(targetId, page);
+          this.touchTargetActivity(targetId);
           indexed++;
         }
       }
@@ -1856,6 +1926,7 @@ export class CDPClient {
     // Fast path: check index first (O(1))
     const indexed = this.targetIdIndex.get(targetId);
     if (indexed && !indexed.isClosed()) {
+      this.touchTargetActivity(targetId);
       return indexed;
     }
 
@@ -1872,6 +1943,7 @@ export class CDPClient {
         if (page) {
           // Populate index for future lookups
           this.targetIdIndex.set(targetId, page);
+          this.touchTargetActivity(targetId);
           this.configurePageDefenses(page);
         }
         return page;
@@ -1890,9 +1962,11 @@ export class CDPClient {
    */
   indexExternalPage(targetId: string, page: Page): void {
     this.targetIdIndex.set(targetId, page);
+    this.touchTargetActivity(targetId);
     this.configurePageDefenses(page);
     page.once('close', () => {
       this.targetIdIndex.delete(targetId);
+      this.targetActivityAt.delete(targetId);
       // sessions and cookie cache cleanup handled by onTargetDestroyed via browser targetdestroyed event
     });
   }

--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -748,6 +748,7 @@ export class CDPClient {
         const page = await target.page();
         if (page) {
           this.targetIdIndex.set(targetId, page);
+          this.touchTargetActivity(targetId);
           this.configurePageDefenses(page);
           console.error(`[CDPClient] Indexed popup target ${targetId} (URL: ${url})`);
         }
@@ -1568,6 +1569,7 @@ export class CDPClient {
     // evaluateOnNewDocument scripts persist on the CDP session and execute at
     // document_start of every new document — before any <script> tag on the page.
     this.targetIdIndex.set(targetId, page);
+    this.touchTargetActivity(targetId);
     this.configurePageDefenses(page);
 
     // Stealth-only fingerprint defenses (WebGL, Canvas, Audio, hardware, screen, webdriver)

--- a/src/orchestration/workflow-engine.ts
+++ b/src/orchestration/workflow-engine.ts
@@ -208,9 +208,14 @@ export class WorkflowEngine {
         if (step.url && !getGlobalConfig().skipCookieBridge) {
           try {
             const targetHost = new URL(step.url).hostname;
-            const authTargetId = await cdpClient.findAuthenticatedPageTargetId(targetHost);
-            if (authTargetId) {
-              await cdpClient.copyCookiesViaCDP(authTargetId, page);
+            const cookieScan = await cdpClient.findAuthenticatedPageTarget(targetHost);
+            if (cookieScan.status === 'partial' && !cookieScan.targetId) {
+              console.error(
+                `[WorkflowEngine] Cookie bridge incomplete for ${targetHost}: ${cookieScan.warning ?? 'scan incomplete'}`,
+              );
+            }
+            if (cookieScan.targetId) {
+              await cdpClient.copyCookiesViaCDP(cookieScan.targetId, page);
             }
           } catch {
             // Cookie bridging failure is non-fatal — page navigates without cookies

--- a/tests/cdp/cookie-scan-partial.test.ts
+++ b/tests/cdp/cookie-scan-partial.test.ts
@@ -1,0 +1,136 @@
+/// <reference types="jest" />
+
+// Mock global fetch before imports
+const mockFetch = jest.fn();
+global.fetch = mockFetch as any;
+
+jest.mock('ws', () => class MockWebSocket {});
+
+jest.mock('puppeteer-core', () => ({
+  default: {
+    connect: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/chrome/launcher', () => ({
+  getChromeLauncher: jest.fn().mockReturnValue({
+    ensureChrome: jest.fn().mockResolvedValue({ wsEndpoint: 'ws://localhost:9222' }),
+  }),
+}));
+
+jest.mock('../../src/config/global', () => ({
+  getGlobalConfig: jest.fn().mockReturnValue({ port: 9222, autoLaunch: false, skipCookieBridge: false }),
+}));
+
+import { CDPClient } from '../../src/cdp/client';
+
+function createConnectedClient(): CDPClient {
+  const client = new CDPClient({ port: 9222 });
+  const mockBrowserTarget = { createCDPSession: jest.fn() };
+  const mockBrowser = {
+    isConnected: jest.fn().mockReturnValue(true),
+    target: jest.fn().mockReturnValue(mockBrowserTarget),
+    on: jest.fn(),
+    pages: jest.fn().mockResolvedValue([]),
+    targets: jest.fn().mockReturnValue([]),
+    newPage: jest.fn(),
+  };
+  (client as any).browser = mockBrowser;
+  (client as any).connectionState = 'connected';
+  return client;
+}
+
+describe('CDPClient cookie scan explicit results', () => {
+  let client: CDPClient;
+
+  beforeEach(() => {
+    jest.useFakeTimers({ doNotFake: ['setImmediate'] });
+    jest.clearAllMocks();
+    client = createConnectedClient();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('returns a partial result when overall timeout expires before all candidates are scanned', async () => {
+    const candidates = ['a', 'b', 'c', 'd'].map((id) => ({
+      targetId: id,
+      type: 'page',
+      url: `https://${id}.example.com`,
+    }));
+
+    const mockSession = {
+      send: jest.fn((method: string, params?: any) => {
+        if (method === 'Target.getTargets') {
+          return Promise.resolve({ targetInfos: candidates });
+        }
+        if (method === 'Target.attachToTarget') {
+          return Promise.resolve({ sessionId: `session-${params.targetId}` });
+        }
+        if (method === 'Network.getAllCookies') {
+          return new Promise(() => {});
+        }
+        if (method === 'Target.detachFromTarget') {
+          return Promise.resolve(undefined);
+        }
+        return Promise.resolve(undefined);
+      }),
+      detach: jest.fn().mockResolvedValue(undefined),
+    };
+    (client as any).browser.target().createCDPSession = jest.fn().mockResolvedValue(mockSession);
+
+    const promise = client.findAuthenticatedPageTarget('example.com');
+    await jest.advanceTimersByTimeAsync(7_000);
+    const result = await promise;
+
+    expect(result.status).toBe('partial');
+    expect(result.targetId).toBeNull();
+    expect(result.scanned).toBe(3);
+    expect(result.total).toBe(4);
+    expect(result.warning).toContain('timed out');
+  });
+
+  test('prioritizes recently active targets when domain scores tie', async () => {
+    const now = Date.now();
+    (client as any).targetActivityAt.set('recent-target', now);
+    (client as any).targetActivityAt.set('stale-target', now - 10_000);
+
+    const attachOrder: string[] = [];
+    const mockSession = {
+      send: jest.fn((method: string, params?: any, extra?: any) => {
+        if (method === 'Target.getTargets') {
+          return Promise.resolve({
+            targetInfos: [
+              { targetId: 'stale-target', type: 'page', url: 'https://app.example.com/dashboard' },
+              { targetId: 'recent-target', type: 'page', url: 'https://app.example.com/settings' },
+            ],
+          });
+        }
+        if (method === 'Target.attachToTarget') {
+          attachOrder.push(params.targetId);
+          return Promise.resolve({ sessionId: `session-${params.targetId}` });
+        }
+        if (method === 'Network.getAllCookies') {
+          return Promise.resolve({
+            cookies: extra?.sessionId === 'session-recent-target'
+              ? [{ name: 'session', value: 'abc', domain: 'example.com', path: '/', expires: -1, httpOnly: true, secure: true }]
+              : [],
+          });
+        }
+        if (method === 'Target.detachFromTarget') {
+          return Promise.resolve(undefined);
+        }
+        return Promise.resolve(undefined);
+      }),
+      detach: jest.fn().mockResolvedValue(undefined),
+    };
+    (client as any).browser.target().createCDPSession = jest.fn().mockResolvedValue(mockSession);
+
+    const result = await client.findAuthenticatedPageTarget('example.com');
+
+    expect(attachOrder[0]).toBe('recent-target');
+    expect(result.targetId).toBe('recent-target');
+    expect(result.status).toBe('partial');
+  });
+});


### PR DESCRIPTION
## Summary
- add an explicit `findAuthenticatedPageTarget()` result contract for cookie scans
- preserve `findAuthenticatedPageTargetId()` as a compatibility wrapper
- surface partial scan warnings to the main cookie-bridge callers and prefer recently active targets when domain scores tie

## Why
Fixes #620.

Before this change, cookie scans collapsed several distinct outcomes into `string | null`, so callers could not tell the difference between:
- no authenticated page existing
- timing out before the scan finished
- short-circuiting early after a successful match

## What changed
- introduced `CookieScanResult` / `CookieScanStatus`
- kept the legacy targetId wrapper for older callers/tests
- updated cookie-bridge callers to react to partial/no-target outcomes explicitly
- added tie-breaking by recent target activity after domain scoring
- added focused regression tests for partial timeout behavior and ordering

## Verification
- `npm run build`
- `npx jest --runInBand tests/src/cdp-client-optimization.test.ts tests/cdp/cookie-scan-partial.test.ts`
