### PR TITLE
Add listener-failure cleanup and health visibility

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -470,6 +470,7 @@ export class CDPClient {
     if (this.browser) {
       this.browser.removeAllListeners('disconnected');
       this.browser.removeAllListeners('targetdestroyed');
+      this.browser.removeAllListeners('targetchanged');
       this.browser.removeAllListeners('targetcreated');
       try {
         this.browser.disconnect();
@@ -632,6 +633,7 @@ export class CDPClient {
         if (this.browser) {
           this.browser.removeAllListeners('disconnected');
           this.browser.removeAllListeners('targetdestroyed');
+          this.browser.removeAllListeners('targetchanged');
           this.browser.removeAllListeners('targetcreated');
           this.browser.disconnect().catch(() => {});
           this.browser = null;
@@ -674,11 +676,19 @@ export class CDPClient {
     });
 
     // Set up target destroyed handler
-    this.browser!.on('targetdestroyed', (target) => {
+    this.browser!.on('targetdestroyed', safeAsyncListener('targetdestroyed', async (target: Target) => {
       const targetId = getTargetId(target);
       console.error(`[CDPClient] Target destroyed: ${targetId}`);
       this.onTargetDestroyed(targetId);
-    });
+    }));
+
+    this.browser!.on('targetchanged', safeAsyncListener('targetchanged', async (target: Target) => {
+      if (target.type() !== 'page') return;
+      const targetId = getTargetId(target);
+      if (this.targetIdIndex.has(targetId)) {
+        console.error(`[CDPClient] Target changed: ${targetId}`);
+      }
+    }));
 
     // Note: We intentionally do NOT call target.page() for EVERY targetcreated event.
     // Eagerly calling target.page() on every new target can materialize Chrome's internal
@@ -732,6 +742,17 @@ export class CDPClient {
       } catch {
         // Target may have already closed — expected race, not an error.
       }
+    }, (_err, args) => {
+      const target = args[0];
+      const targetId = getTargetId(target as Target);
+      if (!targetId) return;
+      import('../session-manager')
+        .then(({ getSessionManager }) => {
+          getSessionManager().evictTarget(targetId, 'listener_error');
+        })
+        .catch(() => {
+          // best-effort cleanup only
+        });
     }));
 
     this.connectionState = 'connected';
@@ -835,6 +856,7 @@ export class CDPClient {
       try {
         this.browser.removeAllListeners('disconnected');
         this.browser.removeAllListeners('targetdestroyed');
+        this.browser.removeAllListeners('targetchanged');
         this.browser.removeAllListeners('targetcreated');
         await this.browser.disconnect();
       } catch {
@@ -924,6 +946,7 @@ export class CDPClient {
       try {
         this.browser.removeAllListeners('disconnected');
         this.browser.removeAllListeners('targetdestroyed');
+        this.browser.removeAllListeners('targetchanged');
         this.browser.removeAllListeners('targetcreated');
         await this.browser.disconnect();
       } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import { getCDPClient } from './cdp/client';
 import { getSessionManager } from './session-manager';
 import { getChromeLauncher } from './chrome/launcher';
 import { getBrowserStateManager } from './browser-state';
-import { installUnhandledRejectionSafetyNet } from './utils/safe-listener';
+import { getListenerErrorStats, installUnhandledRejectionSafetyNet } from './utils/safe-listener';
 import {
   DEFAULT_PROCESS_WATCHDOG_INTERVAL_MS,
   DEFAULT_TAB_HEALTH_PROBE_INTERVAL_MS,
@@ -497,6 +497,7 @@ program
         browserState: stateManager.getStatus(),
         chromeProcess: chromeProcessData,
         sessions: { active: sessionManager?.sessionCount ?? 0 },
+        listeners: getListenerErrorStats(),
       };
       return data;
     }, healthPort, healthBind);

--- a/src/metrics/collector.ts
+++ b/src/metrics/collector.ts
@@ -253,6 +253,7 @@ export function getMetricsCollector(): MetricsCollector {
     instance.registerGauge('openchrome_tabs_health', 'Tab health status count');
     instance.registerCounter('openchrome_rate_limit_rejections_total', 'Requests rejected by rate limiter');
     instance.registerCounter('openchrome_listener_errors_total', 'Async EventEmitter listener errors surfaced by safeAsyncListener');
+    instance.registerCounter('openchrome_zombie_targets_cleaned_total', 'Tracked targets evicted after listener or cleanup failures');
     instance.registerCounter('openchrome_unhandled_rejections_total', 'Process-level unhandled promise rejections (safety-net counter)');
     instance.registerCounter('openchrome_cookie_scan_total', 'Cookie source scans by outcome (complete/partial/no_candidates/no_cookies)');
     instance.registerHistogram('openchrome_cookie_scan_duration_seconds', 'Cookie source scan duration in seconds',

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -22,6 +22,7 @@ import { StorageStateConfig } from './config';
 import { assertDomainAllowed } from './security/domain-guard';
 import { getTargetId } from './utils/puppeteer-helpers';
 import { safeTitle } from './utils/safe-title';
+import { getMetricsCollector } from './metrics/collector';
 import { getTenantManager, isStrictTenantIsolationEnabled } from './tenant/registry';
 import type { TenantManager } from './tenant/manager';
 import { DEFAULT_TENANT_ID, type TenantId } from './tenant/types';
@@ -1483,6 +1484,24 @@ export class SessionManager {
         });
       }
     }
+  }
+
+  /**
+   * Evict a tracked target after out-of-band listener or cleanup failures.
+   * Removes SessionManager ownership state and records a cleanup metric when
+   * the target was actually tracked.
+   */
+  evictTarget(targetId: string, reason = 'listener_error'): boolean {
+    const hadOwner = this.targetToWorker.has(targetId);
+    this.onTargetClosed(targetId);
+    if (hadOwner) {
+      try {
+        getMetricsCollector().inc('openchrome_zombie_targets_cleaned_total', { reason });
+      } catch {
+        // best-effort observability
+      }
+    }
+    return hadOwner;
   }
 
   /**

--- a/src/utils/safe-listener.ts
+++ b/src/utils/safe-listener.ts
@@ -16,6 +16,43 @@
 
 import { getMetricsCollector } from '../metrics/collector';
 
+interface ListenerErrorSample {
+  listener: string;
+  timestamp: number;
+}
+
+const listenerErrorSamples: ListenerErrorSample[] = [];
+
+function pruneListenerErrors(now = Date.now()): void {
+  const cutoff = now - 60 * 60 * 1000;
+  while (listenerErrorSamples.length > 0 && listenerErrorSamples[0].timestamp < cutoff) {
+    listenerErrorSamples.shift();
+  }
+}
+
+function recordListenerError(listener: string): void {
+  const now = Date.now();
+  pruneListenerErrors(now);
+  listenerErrorSamples.push({ listener, timestamp: now });
+}
+
+export function getListenerErrorStats(now = Date.now()): { errorCount1m: number; errorCount1h: number } {
+  pruneListenerErrors(now);
+  const cutoff1m = now - 60 * 1000;
+  let errorCount1m = 0;
+  for (const sample of listenerErrorSamples) {
+    if (sample.timestamp >= cutoff1m) errorCount1m++;
+  }
+  return {
+    errorCount1m,
+    errorCount1h: listenerErrorSamples.length,
+  };
+}
+
+export function resetListenerErrorStatsForTests(): void {
+  listenerErrorSamples.length = 0;
+}
+
 /**
  * Wraps an async listener so its rejections are caught, counted, and logged.
  * The returned function is synchronous (returns `void`), which matches the
@@ -34,6 +71,7 @@ export function safeAsyncListener<A extends unknown[]>(
     // Using `void` to explicitly discard the Promise — required to keep the
     // EventEmitter callback synchronous.
     void handler(...args).catch((err) => {
+      recordListenerError(name);
       try {
         getMetricsCollector().inc('openchrome_listener_errors_total', { listener: name });
       } catch {

--- a/src/utils/safe-listener.ts
+++ b/src/utils/safe-listener.ts
@@ -16,41 +16,52 @@
 
 import { getMetricsCollector } from '../metrics/collector';
 
-interface ListenerErrorSample {
-  listener: string;
-  timestamp: number;
+interface ListenerErrorBucket {
+  minuteEpoch: number;
+  count: number;
 }
 
-const listenerErrorSamples: ListenerErrorSample[] = [];
+const LISTENER_ERROR_BUCKETS = 60;
+const listenerErrorBuckets: ListenerErrorBucket[] = Array.from({ length: LISTENER_ERROR_BUCKETS }, () => ({
+  minuteEpoch: 0,
+  count: 0,
+}));
 
-function pruneListenerErrors(now = Date.now()): void {
-  const cutoff = now - 60 * 60 * 1000;
-  while (listenerErrorSamples.length > 0 && listenerErrorSamples[0].timestamp < cutoff) {
-    listenerErrorSamples.shift();
+function bucketFor(now = Date.now()): ListenerErrorBucket {
+  const minuteEpoch = Math.floor(now / 60_000);
+  const index = minuteEpoch % LISTENER_ERROR_BUCKETS;
+  const bucket = listenerErrorBuckets[index];
+  if (bucket.minuteEpoch !== minuteEpoch) {
+    bucket.minuteEpoch = minuteEpoch;
+    bucket.count = 0;
   }
+  return bucket;
 }
 
-function recordListenerError(listener: string): void {
-  const now = Date.now();
-  pruneListenerErrors(now);
-  listenerErrorSamples.push({ listener, timestamp: now });
+function recordListenerError(_listener: string): void {
+  const bucket = bucketFor(Date.now());
+  bucket.count += 1;
 }
 
 export function getListenerErrorStats(now = Date.now()): { errorCount1m: number; errorCount1h: number } {
-  pruneListenerErrors(now);
-  const cutoff1m = now - 60 * 1000;
+  const currentMinute = Math.floor(now / 60_000);
   let errorCount1m = 0;
-  for (const sample of listenerErrorSamples) {
-    if (sample.timestamp >= cutoff1m) errorCount1m++;
+  let errorCount1h = 0;
+  for (const bucket of listenerErrorBuckets) {
+    if (currentMinute - bucket.minuteEpoch >= LISTENER_ERROR_BUCKETS) continue;
+    errorCount1h += bucket.count;
+    if (bucket.minuteEpoch === currentMinute) {
+      errorCount1m += bucket.count;
+    }
   }
-  return {
-    errorCount1m,
-    errorCount1h: listenerErrorSamples.length,
-  };
+  return { errorCount1m, errorCount1h };
 }
 
 export function resetListenerErrorStatsForTests(): void {
-  listenerErrorSamples.length = 0;
+  for (const bucket of listenerErrorBuckets) {
+    bucket.minuteEpoch = 0;
+    bucket.count = 0;
+  }
 }
 
 /**

--- a/src/watchdog/health-endpoint.ts
+++ b/src/watchdog/health-endpoint.ts
@@ -42,6 +42,10 @@ export interface HealthData {
   sessions?: {
     active: number;
   };
+  listeners?: {
+    errorCount1m: number;
+    errorCount1h: number;
+  };
 }
 
 export type HealthDataProvider = () => HealthData;

--- a/tests/cdp/listener-error.test.ts
+++ b/tests/cdp/listener-error.test.ts
@@ -1,0 +1,92 @@
+/// <reference types="jest" />
+
+const browserHandlers: Record<string, Function> = {};
+const mockConnect = jest.fn();
+
+jest.mock('puppeteer-core', () => ({
+  __esModule: true,
+  default: {
+    connect: (...args: any[]) => mockConnect(...args),
+  },
+}));
+
+jest.mock('../../src/chrome/launcher', () => ({
+  getChromeLauncher: jest.fn().mockReturnValue({
+    ensureChrome: jest.fn().mockResolvedValue({ wsEndpoint: 'ws://127.0.0.1:9222/devtools/browser/test' }),
+    invalidateInstance: jest.fn(),
+  }),
+}));
+
+jest.mock('../../src/config/global', () => ({
+  getGlobalConfig: jest.fn().mockReturnValue({ port: 9222, autoLaunch: false }),
+}));
+
+const sessionManagerMock = {
+  getTargetOwner: jest.fn().mockReturnValue({ sessionId: 's1', workerId: 'default' }),
+  registerExternalTarget: jest.fn(() => { throw new Error('listener boom'); }),
+  evictTarget: jest.fn(),
+};
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(() => sessionManagerMock),
+}));
+
+import { CDPClient } from '../../src/cdp/client';
+import { getMetricsCollector } from '../../src/metrics/collector';
+
+function counterValueFor(listener: string): number {
+  const dump = getMetricsCollector().export();
+  const pattern = new RegExp(`openchrome_listener_errors_total\\{listener="${listener}"\\}\\s+(\\d+)`);
+  const match = dump.match(pattern);
+  return match ? parseInt(match[1], 10) : 0;
+}
+
+describe('CDPClient listener error integration', () => {
+  let client: CDPClient;
+  let browser: any;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    for (const key of Object.keys(browserHandlers)) delete browserHandlers[key];
+
+    browser = {
+      isConnected: jest.fn().mockReturnValue(true),
+      on: jest.fn((event: string, handler: Function) => {
+        browserHandlers[event] = handler;
+      }),
+      removeAllListeners: jest.fn(),
+      disconnect: jest.fn().mockResolvedValue(undefined),
+      target: jest.fn().mockReturnValue({ createCDPSession: jest.fn() }),
+      pages: jest.fn().mockResolvedValue([]),
+      targets: jest.fn().mockReturnValue([]),
+    };
+    mockConnect.mockResolvedValue(browser);
+
+    client = new CDPClient({ port: 9222, autoLaunch: false });
+    await client.connect();
+  });
+
+  afterEach(async () => {
+    await client.disconnect();
+    jest.restoreAllMocks();
+  });
+
+  test('evicts a popup target when the targetcreated listener fails after ownership lookup', async () => {
+    const before = counterValueFor('targetcreated');
+    const opener = { _targetId: 'opener-1' };
+    const target = {
+      _targetId: 'popup-1',
+      type: jest.fn().mockReturnValue('page'),
+      url: jest.fn().mockReturnValue('https://example.com/popup'),
+      opener: jest.fn().mockReturnValue(opener),
+      page: jest.fn().mockResolvedValue(null),
+    };
+
+    browserHandlers.targetcreated(target);
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(counterValueFor('targetcreated')).toBe(before + 1);
+    expect(sessionManagerMock.evictTarget).toHaveBeenCalledWith('popup-1', 'listener_error');
+  });
+});

--- a/tests/session-manager-evict-target.test.ts
+++ b/tests/session-manager-evict-target.test.ts
@@ -1,0 +1,92 @@
+/// <reference types="jest" />
+
+import type { BrowserContext } from 'puppeteer-core';
+
+const mockCdpClientInstance = {
+  connect: jest.fn().mockResolvedValue(undefined),
+  isConnected: jest.fn().mockReturnValue(true),
+  addConnectionListener: jest.fn(),
+  addTargetDestroyedListener: jest.fn(),
+  createBrowserContext: jest.fn(),
+  closeBrowserContext: jest.fn().mockResolvedValue(undefined),
+  getBrowser: jest.fn().mockReturnValue({ targets: jest.fn().mockReturnValue([]) }),
+};
+
+jest.mock('../src/cdp/client', () => ({
+  CDPClient: jest.fn().mockImplementation(() => mockCdpClientInstance),
+  getCDPClient: jest.fn().mockReturnValue(mockCdpClientInstance),
+  getCDPClientFactory: jest.fn().mockReturnValue({
+    get: jest.fn().mockReturnValue(mockCdpClientInstance),
+    getOrCreate: jest.fn().mockReturnValue(mockCdpClientInstance),
+    getAll: jest.fn().mockReturnValue([mockCdpClientInstance]),
+    disconnectAll: jest.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+jest.mock('../src/cdp/connection-pool', () => ({
+  CDPConnectionPool: jest.fn(),
+  getCDPConnectionPool: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../src/utils/request-queue', () => ({
+  RequestQueueManager: jest.fn().mockImplementation(() => ({
+    enqueue: jest.fn((_, fn) => fn()),
+    deleteQueue: jest.fn(),
+  })),
+}));
+
+jest.mock('../src/utils/ref-id-manager', () => ({
+  getRefIdManager: jest.fn(() => ({
+    clearSessionRefs: jest.fn(),
+    clearTargetRefs: jest.fn(),
+  })),
+}));
+
+import { SessionManager } from '../src/session-manager';
+import { getMetricsCollector } from '../src/metrics/collector';
+
+function counterValueFor(reason: string): number {
+  const dump = getMetricsCollector().export();
+  const pattern = new RegExp(
+    `openchrome_zombie_targets_cleaned_total\\{reason="${reason}"\\}\\s+(\\d+)`,
+  );
+  const match = dump.match(pattern);
+  return match ? parseInt(match[1], 10) : 0;
+}
+
+describe('SessionManager.evictTarget', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('removes tracked ownership state and increments the zombie cleanup metric', async () => {
+    const sm = new SessionManager(undefined, {
+      autoCleanup: false,
+      useConnectionPool: false,
+      useDefaultContext: true,
+    });
+
+    await sm.createSession({ id: 's1' });
+    sm.registerExternalTarget('target-1', 's1', 'default');
+    expect(sm.getTargetOwner('target-1')).toEqual({ sessionId: 's1', workerId: 'default' });
+
+    const before = counterValueFor('listener_error');
+    expect(sm.evictTarget('target-1', 'listener_error')).toBe(true);
+    expect(sm.getTargetOwner('target-1')).toBeUndefined();
+    expect(counterValueFor('listener_error')).toBe(before + 1);
+  });
+
+  test('returns false when target is unknown', () => {
+    const sm = new SessionManager(undefined, {
+      autoCleanup: false,
+      useConnectionPool: false,
+      useDefaultContext: true,
+    });
+    expect(sm.evictTarget('missing-target')).toBe(false);
+  });
+});

--- a/tests/utils/safe-listener.test.ts
+++ b/tests/utils/safe-listener.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { EventEmitter } from 'node:events';
-import { safeAsyncListener } from '../../src/utils/safe-listener';
+import { getListenerErrorStats, resetListenerErrorStatsForTests, safeAsyncListener } from '../../src/utils/safe-listener';
 import { getMetricsCollector } from '../../src/metrics/collector';
 
 function counterValueFor(listener: string): number {
@@ -24,6 +24,7 @@ describe('safeAsyncListener', () => {
   let consoleErrorSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    resetListenerErrorStatsForTests();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
@@ -88,6 +89,20 @@ describe('safeAsyncListener', () => {
     await new Promise((r) => setTimeout(r, 20));
 
     expect(counterValueFor('rejects')).toBe(before + 1);
+  });
+
+
+  it('tracks recent listener-error stats for health reporting', async () => {
+    const ee = new EventEmitter();
+    ee.on('evt', safeAsyncListener('health-stats', async () => {
+      throw new Error('stats-boom');
+    }));
+
+    ee.emit('evt');
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(getListenerErrorStats().errorCount1m).toBe(1);
+    expect(getListenerErrorStats().errorCount1h).toBe(1);
   });
 
   it('invokes the optional onError hook and shields listener from onError throws', async () => {

--- a/tests/watchdog/event-loop-monitor.test.ts
+++ b/tests/watchdog/event-loop-monitor.test.ts
@@ -273,6 +273,7 @@ describe('HealthEndpoint', () => {
       uptime: 100,
       memory: process.memoryUsage(),
       eventLoop: { maxDriftMs: 5, warnCount: 0 },
+      listeners: { errorCount1m: 1, errorCount1h: 2 },
     });
 
     // Use a random high port to avoid conflicts
@@ -296,6 +297,7 @@ describe('HealthEndpoint', () => {
     const data = JSON.parse(response.body);
     expect(data.status).toBe('ok');
     expect(data.uptime).toBe(100);
+    expect(data.listeners).toEqual({ errorCount1m: 1, errorCount1h: 2 });
   });
 
   test('returns 404 for unknown paths', async () => {


### PR DESCRIPTION
## Summary
- record recent listener-error history for health reporting
- evict tracked targets when popup target-registration fails mid-listener
- add explicit zombie-target cleanup metric and broaden wrapped target lifecycle listeners

## Why
Fixes #621.

Before this change, the first safe-listener layer existed, but the listener failure path still lacked:
- explicit tracked-target eviction
- a dedicated zombie-cleanup metric
- health-visible recent listener error counts
- coverage for the broader browser target lifecycle listener set

## Verification
- `npm run build`
- `npx jest --runInBand tests/utils/safe-listener.test.ts tests/session-manager-evict-target.test.ts tests/cdp/listener-error.test.ts tests/watchdog/event-loop-monitor.test.ts -t 'safeAsyncListener|SessionManager.evictTarget|listener error integration|starts and responds to /health'`
