### PR TITLE
Record disconnected tool calls as aborted outcomes

### DIFF
--- a/src/dashboard/types.ts
+++ b/src/dashboard/types.ts
@@ -10,7 +10,7 @@ export interface DashboardConfig {
 
 export type ViewMode = 'activity' | 'sessions' | 'tabs' | 'connect';
 
-export type ToolCallResult = 'success' | 'error' | 'pending';
+export type ToolCallResult = 'success' | 'error' | 'aborted' | 'pending';
 
 export interface ToolCallEvent {
   id: string;

--- a/src/desktop/dashboard-state.ts
+++ b/src/desktop/dashboard-state.ts
@@ -15,7 +15,7 @@ export interface DashboardToolCall {
   toolName: string;
   sessionId: string;
   args: string;
-  status: 'running' | 'success' | 'error';
+  status: 'running' | 'success' | 'error' | 'aborted';
   startTime: number;
   endTime?: number;
   duration?: number;
@@ -113,7 +113,7 @@ export class DashboardState {
   /**
    * Record the end of a tool call.
    */
-  recordToolEnd(callId: string, status: 'success' | 'error', error?: string): void {
+  recordToolEnd(callId: string, status: 'success' | 'error' | 'aborted', error?: string): void {
     const call = this.activeCalls.get(callId);
     if (!call) return;
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -36,6 +36,7 @@ import { getGlobalConfig } from './config/global';
 import { getToolTier, ToolTier } from './config/tool-tiers';
 import { getMetricsCollector, withTenantLabel } from './metrics/collector';
 import { logAuditEntry } from './security/audit-logger';
+import { isClientDisconnect } from './errors/abort';
 import { isAllowed, requiredScope } from './auth/scope-policy';
 import type { Principal } from './auth/api-key-types';
 import { PRINCIPAL_SYM } from './middleware/auth';
@@ -1277,16 +1278,21 @@ export class MCPServer {
       return result;
     } catch (error) {
       const message = formatError(error);
+      const abortReason = isClientDisconnect(error) ? 'client_disconnect' : null;
+      const aborted = abortReason !== null;
 
       // End activity tracking (error)
-      this.activityTracker!.endCall(callId, 'error', message);
-      getDashboardState().recordToolEnd(callId, 'error', message);
+      this.activityTracker!.endCall(callId, aborted ? 'error' : 'error', message);
+      getDashboardState().recordToolEnd(callId, aborted ? 'error' : 'error', message);
 
       // Audit log failed invocation — same correlation fields as success path.
       try {
         logAuditEntry(toolName, sessionId, toolArgs, undefined, {
-          status: 'error',
+          status: aborted ? 'aborted' : 'error',
           durationMs: Date.now() - toolStartTime,
+          aborted,
+          abortedAt: aborted ? new Date().toISOString() : undefined,
+          abortReason: abortReason ?? undefined,
           errorMessage: message,
           billable: false,
         });
@@ -1298,7 +1304,10 @@ export class MCPServer {
       try {
         const metrics = getMetricsCollector();
         const durationSec = (Date.now() - toolStartTime) / 1000;
-        metrics.inc('openchrome_tool_calls_total', withTenantLabel({ tool: toolName, status: 'error' }));
+        metrics.inc('openchrome_tool_calls_total', withTenantLabel({ tool: toolName, status: aborted ? 'aborted' : 'error' }));
+        if (aborted && abortReason) {
+          metrics.inc('openchrome_tool_calls_aborted_total', withTenantLabel({ tool: toolName, reason: abortReason }));
+        }
         metrics.observe('openchrome_tool_duration_seconds', withTenantLabel({ tool: toolName }), durationSec);
       } catch {
         // Best-effort metrics

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1282,8 +1282,8 @@ export class MCPServer {
       const aborted = abortReason !== null;
 
       // End activity tracking (error)
-      this.activityTracker!.endCall(callId, aborted ? 'error' : 'error', message);
-      getDashboardState().recordToolEnd(callId, aborted ? 'error' : 'error', message);
+      this.activityTracker!.endCall(callId, aborted ? 'aborted' : 'error', message);
+      getDashboardState().recordToolEnd(callId, aborted ? 'aborted' : 'error', message);
 
       // Audit log failed invocation — same correlation fields as success path.
       try {

--- a/src/metrics/collector.ts
+++ b/src/metrics/collector.ts
@@ -252,6 +252,7 @@ export function getMetricsCollector(): MetricsCollector {
     instance.registerGauge('openchrome_active_sessions', 'Current active MCP sessions');
     instance.registerGauge('openchrome_tabs_health', 'Tab health status count');
     instance.registerCounter('openchrome_rate_limit_rejections_total', 'Requests rejected by rate limiter');
+    instance.registerCounter('openchrome_tool_calls_aborted_total', 'Tool calls aborted before successful completion');
     instance.registerCounter('openchrome_listener_errors_total', 'Async EventEmitter listener errors surfaced by safeAsyncListener');
     instance.registerCounter('openchrome_unhandled_rejections_total', 'Process-level unhandled promise rejections (safety-net counter)');
     instance.registerCounter('openchrome_cookie_scan_total', 'Cookie source scans by outcome (complete/partial/no_candidates/no_cookies)');

--- a/src/security/audit-logger.ts
+++ b/src/security/audit-logger.ts
@@ -38,6 +38,10 @@ export interface AuditLogMeta {
   durationMs?: number;
   /** Truthy when the call was externally aborted (B-2). */
   aborted?: boolean;
+  /** Timestamp when the abort was observed. */
+  abortedAt?: string;
+  /** Structured abort reason, e.g. client_disconnect. */
+  abortReason?: string;
   /** Whether the call should count toward billing. Defaults to true unless status=error. */
   billable?: boolean;
   /** Error message when status === 'error'. Should not contain sensitive data. */
@@ -81,6 +85,8 @@ interface ExtendedAuditEntry {
   status: NonNullable<AuditLogMeta['status']>;
   durationMs: number | null;
   aborted: boolean;
+  abortedAt?: string;
+  abortReason?: string;
   billable: boolean;
   argsHash: string;
   args: Record<string, unknown>;
@@ -242,12 +248,14 @@ export function logAuditEntry(
     status,
     durationMs: typeof meta.durationMs === 'number' ? Math.round(meta.durationMs) : null,
     aborted: meta.aborted ?? false,
-    billable: meta.billable ?? (status !== 'error'),
+    billable: meta.billable ?? (status === 'success'),
     argsHash,
     args: redacted,
   };
   if (meta.scopes && meta.scopes.length > 0) entry.scopes = [...meta.scopes];
   if (meta.errorMessage) entry.errorMessage = meta.errorMessage;
+  if (meta.abortedAt) entry.abortedAt = meta.abortedAt;
+  if (meta.abortReason) entry.abortReason = meta.abortReason;
 
   appendLine(logPath, JSON.stringify(entry) + '\n');
 }

--- a/tests/mcp-server-abort-accounting.test.ts
+++ b/tests/mcp-server-abort-accounting.test.ts
@@ -1,0 +1,41 @@
+/// <reference types="jest" />
+import { MCPServer } from '../src/mcp-server';
+import { getMetricsCollector } from '../src/metrics/collector';
+import { runWithRequestContext } from '../src/observability/request-id';
+import { ClientDisconnectError } from '../src/errors/abort';
+
+describe('MCPServer aborted tool accounting', () => {
+  test('records client disconnects as aborted metrics instead of generic errors', async () => {
+    const server = new MCPServer({
+      getOrCreateSession: jest.fn().mockResolvedValue({ id: 's' }),
+      addEventListener: jest.fn(),
+      sessionCount: 0,
+    } as any);
+
+    const toolName = `abort_metric_test_${Date.now()}`;
+    server.registerTool(
+      toolName,
+      jest.fn().mockRejectedValue(new ClientDisconnectError()),
+      {
+        name: toolName,
+        description: 'abort metric test',
+        inputSchema: { type: 'object', properties: {} },
+      },
+    );
+
+    const response = await runWithRequestContext({ requestId: 'req-abort', tenantId: 'acme' }, () =>
+      server.handleRequest({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: toolName, arguments: {}, sessionId: 's' },
+      } as any),
+    );
+
+    expect(((response as any).result?.content?.[0]?.text ?? '')).toContain('Client disconnected');
+
+    const exportText = getMetricsCollector().export();
+    expect(exportText).toContain(`openchrome_tool_calls_total{tool="${toolName}",status="aborted",tenant="acme"} 1`);
+    expect(exportText).toContain(`openchrome_tool_calls_aborted_total{tool="${toolName}",reason="client_disconnect",tenant="acme"} 1`);
+  });
+});

--- a/tests/security/audit-logger-extended.test.ts
+++ b/tests/security/audit-logger-extended.test.ts
@@ -128,6 +128,30 @@ describe('audit-logger extended fields', () => {
     }
   });
 
+
+  test('aborted status writes abort metadata and defaults billable=false', async () => {
+    const logPath = makeTmpLogPath();
+    (globalThis as { __TEST_AUDIT_PATH?: string }).__TEST_AUDIT_PATH = logPath;
+
+    runWithRequestContext({ requestId: 'req-abort-1', tenantId: 't_abort' }, () => {
+      logAuditEntry('navigate', 'sess-abort', { url: 'https://example.com' }, undefined, {
+        status: 'aborted',
+        aborted: true,
+        abortedAt: '2026-04-22T06:00:00.000Z',
+        abortReason: 'client_disconnect',
+      });
+    });
+
+    await waitForFlush();
+    await new Promise((r) => setTimeout(r, 50));
+    const entry = readAll(logPath)[0];
+    expect(entry.status).toBe('aborted');
+    expect(entry.aborted).toBe(true);
+    expect(entry.abortedAt).toBe('2026-04-22T06:00:00.000Z');
+    expect(entry.abortReason).toBe('client_disconnect');
+    expect(entry.billable).toBe(false);
+  });
+
   test('error status marks billable=false and carries errorMessage', async () => {
     const logPath = makeTmpLogPath();
     (globalThis as { __TEST_AUDIT_PATH?: string }).__TEST_AUDIT_PATH = logPath;


### PR DESCRIPTION
## Summary
- classify client disconnects as explicit aborted tool outcomes
- add `openchrome_tool_calls_aborted_total`
- add `abortedAt` / `abortReason` audit metadata and keep aborted calls non-billable

## Why
Addresses #618.

The transport already propagated disconnect AbortSignals, but downstream accounting still treated those paths as generic tool errors. This PR makes aborted work observable and separately measurable.

## Verification
- `npm run build`
- `npx jest --runInBand tests/security/audit-logger-extended.test.ts tests/mcp-server-abort-accounting.test.ts tests/transports/http-abort-on-disconnect.test.ts tests/utils/cdp-abort.test.ts tests/utils/with-timeout.test.ts`
