### PR TITLE
Kill managed Chrome after abrupt parent death

### DIFF
--- a/src/chrome/headed-fallback.ts
+++ b/src/chrome/headed-fallback.ts
@@ -20,6 +20,7 @@ import { hasDisplay } from '../utils/display-detect';
 import { detectBlockingPage, BlockingInfo } from '../utils/page-diagnostics';
 import { safeTitle } from '../utils/safe-title';
 import { getTargetId } from '../utils/puppeteer-helpers';
+import { spawnProcessGuardian } from '../utils/process-guardian';
 
 /** Default port offset from main Chrome port for the headed fallback */
 const HEADED_PORT_OFFSET = 100;
@@ -158,6 +159,11 @@ class HeadedFallbackManager {
       stdio: 'ignore',
     });
     this.chromeProcess.unref();
+    if (this.chromeProcess.pid) {
+      spawnProcessGuardian(process.pid, this.chromeProcess.pid, {
+        label: 'headed-fallback',
+      });
+    }
 
     // Wait for Chrome to be ready
     const wsEndpoint = await this.waitForDebugPort(15000);

--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -623,6 +623,12 @@ export class ChromeLauncher {
     // Note: On Windows, detached processes create a new process group.
     // Killing the root process may not clean up child processes (renderers, GPU).
     // The oc_stop tool handles this via session/pool cleanup before process kill.
+    if (chromeProcess.pid) {
+      spawnProcessGuardian(process.pid, chromeProcess.pid, {
+        pidFilePath: getChromePidFilePath(port),
+        label: 'managed-chrome',
+      });
+    }
 
     // Log Chrome process exit for immediate diagnostics
     chromeProcess.once('exit', (code, signal) => {
@@ -682,10 +688,6 @@ export class ChromeLauncher {
     // Persist Chrome PID to disk for orphan detection
     if (chromeProcess.pid) {
       writeChromePid(port, chromeProcess.pid);
-      spawnProcessGuardian(process.pid, chromeProcess.pid, {
-        pidFilePath: getChromePidFilePath(port),
-        label: 'managed-chrome',
-      });
     }
 
     this._intentionalStop = false;

--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -8,7 +8,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as http from 'http';
 import { getGlobalConfig } from '../config/global';
-import { writeChromePid, removeChromePid } from '../utils/pid-manager';
+import { writeChromePid, removeChromePid, getChromePidFilePath, killProcessTree } from '../utils/pid-manager';
+import { spawnProcessGuardian } from '../utils/process-guardian';
 import { DEFAULT_VIEWPORT, DEFAULT_CHROME_LAUNCH_TIMEOUT_MS, DEFAULT_RESTORE_LAST_SESSION } from '../config/defaults';
 import { ProfileManager } from './profile-manager';
 import type { ProfileType } from './profile-manager';
@@ -681,6 +682,10 @@ export class ChromeLauncher {
     // Persist Chrome PID to disk for orphan detection
     if (chromeProcess.pid) {
       writeChromePid(port, chromeProcess.pid);
+      spawnProcessGuardian(process.pid, chromeProcess.pid, {
+        pidFilePath: getChromePidFilePath(port),
+        label: 'managed-chrome',
+      });
     }
 
     this._intentionalStop = false;
@@ -753,7 +758,7 @@ export class ChromeLauncher {
           proc.kill();
         }
       } else {
-        proc.kill();
+        killProcessTree(proc.pid ?? 0, 'SIGTERM');
       }
 
       // Wait for the process to actually exit before clearing state.
@@ -766,7 +771,7 @@ export class ChromeLauncher {
             if (process.platform === 'win32') {
               proc.kill();
             } else {
-              proc.kill('SIGKILL');
+              killProcessTree(proc.pid ?? 0, 'SIGKILL');
             }
           } catch {
             // Process may have already exited

--- a/src/utils/pid-manager.ts
+++ b/src/utils/pid-manager.ts
@@ -102,6 +102,20 @@ export function getChromePidFilePath(port: number): string {
   return path.join(os.tmpdir(), `openchrome-chrome-${port}.pid`);
 }
 
+export function killProcessTree(pid: number, signal: NodeJS.Signals = 'SIGTERM'): void {
+  if (!Number.isFinite(pid) || pid <= 0) return;
+  if (process.platform === 'win32') {
+    try {
+      require('child_process').execSync(`taskkill /T /F /PID ${pid}`, { stdio: 'ignore' });
+    } catch {
+      try { process.kill(pid, signal); } catch { /* ignore */ }
+    }
+    return;
+  }
+  try { process.kill(-pid, signal); } catch { /* ignore */ }
+  try { process.kill(pid, signal); } catch { /* ignore */ }
+}
+
 /**
  * Write Chrome PID to file (called after successful Chrome spawn).
  * Uses atomic rename to prevent partial reads.
@@ -179,7 +193,7 @@ export function cleanOrphanedChromeProcesses(basePorts: number[]): number {
     // Orphan detected: Chrome is alive but no MCP server is managing it
     console.error(`${LOG_PREFIX} Killing orphaned Chrome process (PID ${chromePid}) on port ${port}`);
     try {
-      process.kill(chromePid, 'SIGTERM');
+      killProcessTree(chromePid, 'SIGTERM');
       killed++;
     } catch {
       // Process may have died between check and kill

--- a/src/utils/process-guardian.ts
+++ b/src/utils/process-guardian.ts
@@ -1,0 +1,76 @@
+import { spawn } from 'child_process';
+import * as path from 'path';
+
+function escapeForJsString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+/**
+ * Spawn a detached watchdog that kills `childPid` when `parentPid` disappears.
+ * This is used for abrupt parent death (e.g. SIGKILL) where the main process
+ * cannot run any shutdown hooks.
+ */
+export function spawnProcessGuardian(
+  parentPid: number,
+  childPid: number,
+  options?: { pidFilePath?: string; label?: string; pollMs?: number },
+): void {
+  const pidFilePath = options?.pidFilePath ? escapeForJsString(path.resolve(options.pidFilePath)) : '';
+  const label = escapeForJsString(options?.label ?? 'process');
+  const pollMs = Math.max(100, options?.pollMs ?? 500);
+
+  const script = `
+    const { execSync } = require('child_process');
+    const fs = require('fs');
+    const parentPid = ${parentPid};
+    const childPid = ${childPid};
+    const pollMs = ${pollMs};
+    const pidFilePath = '${pidFilePath}';
+    const label = '${label}';
+
+    function isAlive(pid) {
+      try { process.kill(pid, 0); return true; } catch { return false; }
+    }
+
+    function removePidFile() {
+      if (!pidFilePath) return;
+      try { fs.unlinkSync(pidFilePath); } catch {}
+    }
+
+    function killTree(pid, signal = 'SIGTERM') {
+      if (process.platform === 'win32') {
+        try {
+          execSync(\`taskkill /T /F /PID \${pid}\`, { stdio: 'ignore' });
+        } catch {}
+        return;
+      }
+      try { process.kill(-pid, signal); } catch {}
+      try { process.kill(pid, signal); } catch {}
+    }
+
+    const timer = setInterval(() => {
+      if (!isAlive(childPid)) {
+        removePidFile();
+        clearInterval(timer);
+        process.exit(0);
+      }
+      if (isAlive(parentPid)) return;
+
+      killTree(childPid, 'SIGTERM');
+      setTimeout(() => {
+        if (isAlive(childPid)) {
+          killTree(childPid, 'SIGKILL');
+        }
+        removePidFile();
+        clearInterval(timer);
+        process.exit(0);
+      }, 500);
+    }, pollMs);
+  `;
+
+  const guardian = spawn(process.execPath, ['-e', script], {
+    detached: true,
+    stdio: 'ignore',
+  });
+  guardian.unref();
+}

--- a/src/utils/process-guardian.ts
+++ b/src/utils/process-guardian.ts
@@ -34,7 +34,12 @@ export function spawnProcessGuardian(
 
     function removePidFile() {
       if (!pidFilePath) return;
-      try { fs.unlinkSync(pidFilePath); } catch {}
+      try {
+        const current = fs.readFileSync(pidFilePath, 'utf8').trim();
+        if (current === String(childPid)) {
+          fs.unlinkSync(pidFilePath);
+        }
+      } catch {}
     }
 
     function killTree(pid, signal = 'SIGTERM') {

--- a/tests/utils/chrome-pid-manager.test.ts
+++ b/tests/utils/chrome-pid-manager.test.ts
@@ -166,8 +166,8 @@ describe('Chrome PID file tracking', () => {
 
       const killed = cleanOrphanedChromeProcesses([TEST_PORT]);
       expect(killed).toBe(1);
-      // Verify SIGTERM was sent
-      expect(killSpy).toHaveBeenCalledWith(orphanPid, 'SIGTERM');
+      // Verify SIGTERM was sent to the process tree/root
+      expect(killSpy.mock.calls.some(([pid, signal]) => (pid === orphanPid || pid === -orphanPid) && signal === 'SIGTERM')).toBe(true);
       // PID file should be removed
       expect(fs.existsSync(getChromePidFilePath(TEST_PORT))).toBe(false);
     });

--- a/tests/utils/process-guardian.test.ts
+++ b/tests/utils/process-guardian.test.ts
@@ -1,5 +1,8 @@
 /// <reference types="jest" />
 import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { spawnProcessGuardian } from '../../src/utils/process-guardian';
 
 function isAlive(pid: number): boolean {
@@ -33,5 +36,26 @@ describe('spawnProcessGuardian', () => {
 
     await waitForDead(child.pid);
     expect(isAlive(child.pid)).toBe(false);
+  });
+
+  test('does not delete a pid file that was rewritten for a newer process', async () => {
+    const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { detached: true, stdio: 'ignore' });
+    child.unref();
+
+    if (!child.pid) {
+      throw new Error('failed to spawn child process');
+    }
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-guardian-'));
+    const pidFile = path.join(dir, 'chrome.pid');
+    fs.writeFileSync(pidFile, `${child.pid}\n`, 'utf8');
+
+    spawnProcessGuardian(99999999, child.pid, { label: 'guardian-test', pollMs: 200, pidFilePath: pidFile });
+    fs.writeFileSync(pidFile, '123456\n', 'utf8');
+
+    await waitForDead(child.pid);
+    expect(fs.existsSync(pidFile)).toBe(true);
+    expect(fs.readFileSync(pidFile, 'utf8').trim()).toBe('123456');
+    fs.rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/tests/utils/process-guardian.test.ts
+++ b/tests/utils/process-guardian.test.ts
@@ -1,0 +1,37 @@
+/// <reference types="jest" />
+import { spawn } from 'child_process';
+import { spawnProcessGuardian } from '../../src/utils/process-guardian';
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForDead(pid: number, timeoutMs = 4000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error('timeout waiting for child death');
+}
+
+describe('spawnProcessGuardian', () => {
+  test('kills the child process when the watched parent PID is already gone', async () => {
+    const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { detached: true, stdio: 'ignore' });
+    child.unref();
+
+    if (!child.pid) {
+      throw new Error('failed to spawn child process');
+    }
+
+    spawnProcessGuardian(99999999, child.pid, { label: 'guardian-test', pollMs: 100 });
+
+    await waitForDead(child.pid);
+    expect(isAlive(child.pid)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a detached process guardian that kills managed Chrome when the OpenChrome parent disappears abruptly
- use process-tree cleanup for orphan reclamation instead of killing only the root Chrome PID
- attach the same abrupt-death protection to headed fallback launches

## Why
Addresses:
- Fixes #611
- Fixes #613

The existing shutdown hooks were not enough for `SIGKILL` / abrupt parent death. Managed Chrome could survive as an orphan, accumulate across repeated sessions, and interfere with normal user Chrome launches.

## Verification
- `npm run build`
- `npx jest --runInBand tests/utils/process-guardian.test.ts tests/utils/chrome-pid-manager.test.ts tests/chrome/launcher-zombie.test.ts`
- live hard-kill smoke: launch server, trigger Chrome spawn, `SIGKILL` the server, confirm Chrome PID is gone within ~2.5s
- repeated hard-kill smoke: 3 sequential start/kill cycles, each Chrome PID gone after parent death
