### PR TITLE
chore: backport v1.10.1 CI hotfixes from main into develop

### DIFF
--- a/src/chrome/headed-fallback.ts
+++ b/src/chrome/headed-fallback.ts
@@ -25,11 +25,11 @@ import { spawnProcessGuardian } from '../utils/process-guardian';
 /** Default port offset from main Chrome port for the headed fallback */
 const HEADED_PORT_OFFSET = 100;
 
-let activeCleanupTarget: HeadedFallbackManager | null = null;
+let activeCleanup: (() => void) | null = null;
 let cleanupHandlersInstalled = false;
 
 function runGlobalCleanup(): void {
-  activeCleanupTarget?.shutdown();
+  activeCleanup?.();
 }
 
 function installGlobalCleanupHandlers(): void {
@@ -85,9 +85,10 @@ class HeadedFallbackManager {
   private port: number;
   private alivePages: Map<string, Page> = new Map();
   private profileDirectory?: string;
+  private readonly cleanup = (): void => { this.shutdown(); };
   constructor(basePort: number = 9222) {
     this.port = basePort + HEADED_PORT_OFFSET;
-    activeCleanupTarget = this;
+    activeCleanup = this.cleanup;
     installGlobalCleanupHandlers();
   }
 
@@ -304,8 +305,8 @@ class HeadedFallbackManager {
 
   /** Shut down the headed Chrome instance */
   shutdown(): void {
-    if (activeCleanupTarget === this) {
-      activeCleanupTarget = null;
+    if (activeCleanup === this.cleanup) {
+      activeCleanup = null;
     }
 
     // Close any kept-alive pages

--- a/src/chrome/headed-fallback.ts
+++ b/src/chrome/headed-fallback.ts
@@ -25,6 +25,21 @@ import { spawnProcessGuardian } from '../utils/process-guardian';
 /** Default port offset from main Chrome port for the headed fallback */
 const HEADED_PORT_OFFSET = 100;
 
+let activeCleanupTarget: HeadedFallbackManager | null = null;
+let cleanupHandlersInstalled = false;
+
+function runGlobalCleanup(): void {
+  activeCleanupTarget?.shutdown();
+}
+
+function installGlobalCleanupHandlers(): void {
+  if (cleanupHandlersInstalled) return;
+  process.on('exit', runGlobalCleanup);
+  process.on('SIGINT', runGlobalCleanup);
+  process.on('SIGTERM', runGlobalCleanup);
+  cleanupHandlersInstalled = true;
+}
+
 /** Navigate result from headed fallback */
 export interface HeadedNavigateResult {
   url: string;
@@ -70,15 +85,10 @@ class HeadedFallbackManager {
   private port: number;
   private alivePages: Map<string, Page> = new Map();
   private profileDirectory?: string;
-
   constructor(basePort: number = 9222) {
     this.port = basePort + HEADED_PORT_OFFSET;
-
-    // Clean up on process exit
-    const cleanup = () => this.shutdown();
-    process.on('exit', cleanup);
-    process.on('SIGINT', cleanup);
-    process.on('SIGTERM', cleanup);
+    activeCleanupTarget = this;
+    installGlobalCleanupHandlers();
   }
 
   /** Check if headed fallback is available in this environment */
@@ -93,7 +103,15 @@ class HeadedFallbackManager {
 
   /** Get or launch the headed Chrome browser */
   private async ensureBrowser(): Promise<Browser> {
-    if (this.browser?.connected) return this.browser;
+    const isConnected = this.browser && (
+      (typeof (this.browser as unknown as { connected?: boolean }).connected === 'boolean'
+        ? (this.browser as unknown as { connected?: boolean }).connected
+        : undefined)
+      ?? (typeof (this.browser as unknown as { isConnected?: () => boolean }).isConnected === 'function'
+        ? (this.browser as unknown as { isConnected: () => boolean }).isConnected()
+        : false)
+    );
+    if (isConnected) return this.browser!;
 
     // Prevent concurrent launches
     if (this.launching) return this.launching;
@@ -286,6 +304,10 @@ class HeadedFallbackManager {
 
   /** Shut down the headed Chrome instance */
   shutdown(): void {
+    if (activeCleanupTarget === this) {
+      activeCleanupTarget = null;
+    }
+
     // Close any kept-alive pages
     for (const [, page] of this.alivePages) {
       try { page.close().catch(() => {}); } catch { /* ignore */ }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -173,11 +173,13 @@ export class MCPServer {
     // than waiting for the periodic sweep. This is the authoritative signal
     // — sessionTenants is always keyed by the same sessionId space that
     // sessionManager uses, unlike the transport's Mcp-Session-Id.
-    this.sessionManager.addEventListener((event) => {
-      if (event.type === 'session:deleted') {
-        this.sessionTenants.delete(event.sessionId);
-      }
-    });
+    if (typeof this.sessionManager.addEventListener === 'function') {
+      this.sessionManager.addEventListener((event) => {
+        if (event.type === 'session:deleted') {
+          this.sessionTenants.delete(event.sessionId);
+        }
+      });
+    }
 
     // Register built-in resources
     this.registerResource(usageGuideResource);

--- a/tests/cli/admin-keys.test.ts
+++ b/tests/cli/admin-keys.test.ts
@@ -24,6 +24,20 @@ interface RunResult {
   exitCode: number | null;
 }
 
+/**
+ * Extract an `oc_live_*` plaintext token from captured stdout, ignoring any
+ * surrounding noise. The in-process harness shares its `process.stdout.write`
+ * hook with Jest's own console-capture rendering, so a leaked timer firing a
+ * console.error from a prior test in the same worker can prepend a decorated
+ * block ahead of the CLI's own single-line token emission. The CLI only ever
+ * emits exactly one token, so a regex match is both sufficient and robust.
+ */
+function extractToken(stdout: string): string {
+  const m = stdout.match(/oc_live_[A-Za-z0-9_]+/);
+  if (!m) throw new Error(`No oc_live_* token found in stdout: ${JSON.stringify(stdout)}`);
+  return m[0];
+}
+
 async function runCli(argv: string[]): Promise<RunResult> {
   const program = new Command();
   program.exitOverride((err) => {
@@ -153,8 +167,7 @@ describe('admin keys CLI', () => {
       '--tenant', 'acme',
       '--scope', 'read',
     ]);
-    const plaintext = created.stdout.trim();
-    expect(plaintext).toMatch(/^oc_live_/);
+    const plaintext = extractToken(created.stdout);
     const keyIdMatch = created.stderr.match(/keyId: (k_\S+)/);
     expect(keyIdMatch).not.toBeNull();
     const keyId = keyIdMatch![1];
@@ -174,7 +187,7 @@ describe('admin keys CLI', () => {
       '--tenant', 'acme',
       '--scope', 'read',
     ]);
-    const plaintext = created.stdout.trim();
+    const plaintext = extractToken(created.stdout);
 
     const listed = await runCli(['admin', 'keys', 'list', '--json']);
     expect(listed.exitCode).toBeNull();
@@ -212,12 +225,12 @@ describe('admin keys CLI', () => {
       '--tenant', 'acme',
       '--scope', 'read',
     ]);
-    const firstPlaintext = created.stdout.trim();
+    const firstPlaintext = extractToken(created.stdout);
     const firstKeyId = created.stderr.match(/keyId: (k_\S+)/)![1];
 
     const rotated = await runCli(['admin', 'keys', 'rotate', firstKeyId]);
     expect(rotated.exitCode).toBeNull();
-    const secondPlaintext = rotated.stdout.trim();
+    const secondPlaintext = extractToken(rotated.stdout);
     expect(secondPlaintext).toMatch(/^oc_live_acme_/);
     expect(secondPlaintext).not.toBe(firstPlaintext);
     expect(rotated.stderr).toContain('SAVE THIS KEY NOW');

--- a/tests/headed/headed-fallback-manager.test.ts
+++ b/tests/headed/headed-fallback-manager.test.ts
@@ -88,6 +88,10 @@ jest.mock('../../src/utils/puppeteer-helpers', () => ({
   getTargetId: (...args: any[]) => mockGetTargetId(...args),
 }));
 
+jest.mock('../../src/utils/process-guardian', () => ({
+  spawnProcessGuardian: jest.fn(),
+}));
+
 import { getHeadedFallback, shutdownHeadedFallback } from '../../src/chrome/headed-fallback';
 
 describe('HeadedFallbackManager', () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -327,7 +327,10 @@ describe('MCPServer', () => {
 
       await server.handleRequest(request);
 
-      expect(mockSessionManager.getOrCreateSession).toHaveBeenCalledWith('new-session-123');
+      expect(mockSessionManager.getOrCreateSession).toHaveBeenCalledWith(
+        'new-session-123',
+        expect.objectContaining({ label: 'session-init' }),
+      );
     });
   });
 

--- a/tests/transports/http-abort-on-disconnect.test.ts
+++ b/tests/transports/http-abort-on-disconnect.test.ts
@@ -101,13 +101,16 @@ describe('HTTPTransport — abort-on-disconnect (issue #8)', () => {
 
     await postAndAbort(JSON.stringify({ jsonrpc: '2.0', id: 7, method: 'tools/call' }), 80);
 
+    // The inner race timeout must absorb macOS CI event-loop jitter; the
+    // abort propagation path (socket close → req.on('close') → controller
+    // abort) is fast locally but can exceed 2s under loaded Actions runners.
     const reason = (await Promise.race([
       abortReason,
-      new Promise<unknown>((resolve) => setTimeout(() => resolve('TIMEOUT'), 2000)),
+      new Promise<unknown>((resolve) => setTimeout(() => resolve('TIMEOUT'), 8000)),
     ])) as unknown;
 
     expect(reason).toBeInstanceOf(ClientDisconnectError);
-  });
+  }, 15000);
 
   test('does NOT abort signal on normal completion', async () => {
     let signalRef: AbortSignal | undefined;

--- a/tests/transports/http-streamable.test.ts
+++ b/tests/transports/http-streamable.test.ts
@@ -36,6 +36,15 @@ function request(
   });
 }
 
+// CI runners (especially ubuntu-20) occasionally hit a "socket hang up"
+// on the first SSE request after `transport.start()`, which looks like a
+// narrow connect/handshake race between the server's listen callback and
+// the client's connect attempt rather than a functional defect — the
+// response body is correctly produced when the connection succeeds.
+// Retry twice so transient runner-level flakes don't block CI; a real
+// regression would still fail all three attempts.
+jest.retryTimes(2, { logErrorsBeforeRetry: true });
+
 describe('Streamable HTTP - POST with Accept: text/event-stream', () => {
   let transport: InstanceType<typeof HTTPTransport>;
 

--- a/tests/utils/process-guardian.test.ts
+++ b/tests/utils/process-guardian.test.ts
@@ -14,7 +14,10 @@ function isAlive(pid: number): boolean {
   }
 }
 
-async function waitForDead(pid: number, timeoutMs = 4000): Promise<void> {
+// Windows CI can spend several seconds on Node cold-start for the detached
+// guardian process plus the `taskkill` execSync roundtrip before the child
+// exits. Bump the default well past that to prevent spurious timeouts.
+async function waitForDead(pid: number, timeoutMs = 15000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (!isAlive(pid)) return;
@@ -36,7 +39,7 @@ describe('spawnProcessGuardian', () => {
 
     await waitForDead(child.pid);
     expect(isAlive(child.pid)).toBe(false);
-  });
+  }, 20000);
 
   test('does not delete a pid file that was rewritten for a newer process', async () => {
     const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { detached: true, stdio: 'ignore' });
@@ -57,5 +60,5 @@ describe('spawnProcessGuardian', () => {
     expect(fs.existsSync(pidFile)).toBe(true);
     expect(fs.readFileSync(pidFile, 'utf8').trim()).toBe('123456');
     fs.rmSync(dir, { recursive: true, force: true });
-  });
+  }, 20000);
 });


### PR DESCRIPTION
Prereq for #645 (parent-watcher PR for issue #644). No functional changes.

## What

Cherry-picks two commits already on `main` that are missing from `develop`:

- `59be0ad` — Keep CI green after the post-merge hardening work (test
  hardening for admin-keys, http-abort-on-disconnect, process-guardian,
  http-streamable).
- `5d54ec1` — Hotfix: unblock main CI by removing this-aliasing in
  HeadedFallbackManager (PR #643).

## Why

The recent CI runs against `develop` (e.g.
[run 24814037874](https://github.com/shaun0927/openchrome/actions/runs/24814037874))
are red on every job in the matrix because of these two regressions, which
were already fixed on `main` after v1.10.1 shipped but were never brought
back to `develop`. Any PR targeting `develop` therefore inherits a 9/9 red
matrix even when its own changes are clean.

## Verification

`npx jest --config jest.ci.config.js` against this branch:

- before backport (current `develop` HEAD): **38 failed, 86 skipped, 3178
  passed** across 6 failing suites (`mcp-server`, `tools/journal`,
  `tools/recording`, `headed/headed-fallback-manager`, `security/audit-logger-extended`,
  `transports/http-abort-on-disconnect`).
- after backport (this branch): **1 failed, 86 skipped, 3206 passed**
  across 1 failing suite (`watchdog/event-loop-monitor`, a known timing
  flake — re-running it in isolation gives 17/17 green).

`npm run build` and `npm run lint` are both green; lint warnings are
identical to the pre-existing `develop` baseline.

## Why not just "rebase main into develop"

These two commits are the only delta in the relevant CI surface. The rest
of the `main`-only commits (`ba32d8e`, `dfd9d57`) are v1.10.1 release-
metadata commits that should not enter `develop` ahead of the actual
release work for v1.10.2.