### PR TITLE
perf: token-efficiency pass — strip decorators, add validate_page macro

### DIFF
--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -41,6 +41,7 @@ export const TOOL_TIERS: Record<string, ToolTier> = {
   oc_copy_to_clipboard: 1,
   oc_open_host_settings: 1,
   act: 1,                     // src/tools/act.ts — composite NL action API (#578)
+  validate_page: 1,           // src/tools/validate-page.ts — composite page-health check (#token-efficiency)
 
   // Tier 2: Specialist (on demand)
   extract_data: 2,              // src/tools/extract-data.ts — structured extraction (#571)

--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -31,6 +31,7 @@ export const TOOL_TIERS: Record<string, ToolTier> = {
   wait_for: 1,
   memory: 1,
   lightweight_scroll: 1,
+  console_capture: 1,         // src/tools/console-capture.ts — surfaces page errors during validation (#token-efficiency)
   oc_stop: 1,
   oc_profile_status: 1,
   oc_session_snapshot: 1,
@@ -54,7 +55,6 @@ export const TOOL_TIERS: Record<string, ToolTier> = {
   page_pdf: 2,
   page_screenshot: 2,
   page_content: 2,
-  console_capture: 2,
   performance_metrics: 2,
   file_upload: 2,
   batch_execute: 2,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1266,7 +1266,7 @@ export class MCPServer {
         }
       }
 
-      // Inject proactive hint into both _hint (backward compat) and content[] (guaranteed MCP delivery)
+      // Inject proactive hint into _hint and _hintMeta (content[] duplicate removed for token efficiency #token-efficiency)
       if (this.hintEngine) {
         const hintResult = this.hintEngine.getHint(toolName, result as Record<string, unknown>, false, sessionId);
         if (hintResult) {
@@ -1282,11 +1282,6 @@ export class MCPServer {
               ...(hintResult.suggestion && { suggestion: hintResult.suggestion }),
               ...(hintResult.context && { context: hintResult.context }),
             };
-            const content = (result as Record<string, unknown>).content;
-            if (Array.isArray(content)) {
-              // Hint appended after tool result (may follow image blobs for verify:true tools)
-              content.push({ type: 'text', text: `\n${hintResult.hint}` });
-            }
           }
         }
       }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -92,15 +92,17 @@ const SKIP_SESSION_INIT_TOOLS = new Set(['oc_stop', 'oc_profile_status', 'oc_ses
 /** Tools that may legitimately block the event loop longer than the normal fatal threshold. */
 const HEAVY_TOOLS = new Set(['computer', 'read_page', 'query_dom', 'cookies', 'javascript_tool']);
 
-// Read-only tools called at high frequency — skip session/profile decorators
-// to save ~50 tokens per call. They don't change session state, so resumability
-// metadata is not load-bearing here.
-const READONLY_HIGH_FREQ_TOOLS = new Set([
+// State-stable tools called at high frequency — skip session/profile decorators
+// to save ~50 tokens per call. These tools either don't mutate session/page
+// state, or any mutation is implicit in the user's next call (so resumability
+// metadata isn't load-bearing here). javascript_tool is intentionally excluded:
+// it executes arbitrary JS and can mutate state in ways the agent needs the
+// session/profile context to recover from.
+const STATE_STABLE_HIGH_FREQ_TOOLS = new Set([
   'read_page',
   'query_dom',
   'find',
   'inspect',
-  'javascript_tool',
   'wait_for',
   'page_content',
   'tabs_context',
@@ -1235,7 +1237,7 @@ export class MCPServer {
       }
 
       // Inject session context for AI agent continuity (#347 Phase 4)
-      if (verbosity !== 'compact' && !['oc_checkpoint', 'oc_connection_health'].includes(toolName) && !READONLY_HIGH_FREQ_TOOLS.has(toolName)) {
+      if (verbosity !== 'compact' && !['oc_checkpoint', 'oc_connection_health'].includes(toolName) && !STATE_STABLE_HIGH_FREQ_TOOLS.has(toolName)) {
         try {
           const cdpClient = getCDPClient();
           const metrics = cdpClient.getConnectionMetrics();
@@ -1253,7 +1255,7 @@ export class MCPServer {
       }
 
       // Inject profile state
-      if (verbosity !== 'compact' && !READONLY_HIGH_FREQ_TOOLS.has(toolName)) {
+      if (verbosity !== 'compact' && !STATE_STABLE_HIGH_FREQ_TOOLS.has(toolName)) {
         const profileInfo = this.buildProfileInfo();
         if (profileInfo) {
           (result as Record<string, unknown>)._profile = profileInfo.profile;
@@ -1266,7 +1268,10 @@ export class MCPServer {
         }
       }
 
-      // Inject proactive hint into _hint and _hintMeta (content[] duplicate removed for token efficiency #token-efficiency)
+      // Inject proactive hint into _hint, _hintMeta, and content[].
+      // _hint / _hintMeta are non-standard fields that not all MCP clients
+      // surface, so pushing into content[] guarantees the hint reaches the
+      // user. Mirrors the error-path injection below for consistency.
       if (this.hintEngine) {
         const hintResult = this.hintEngine.getHint(toolName, result as Record<string, unknown>, false, sessionId);
         if (hintResult) {
@@ -1282,6 +1287,10 @@ export class MCPServer {
               ...(hintResult.suggestion && { suggestion: hintResult.suggestion }),
               ...(hintResult.context && { context: hintResult.context }),
             };
+            const content = (result as Record<string, unknown>).content;
+            if (Array.isArray(content)) {
+              content.push({ type: 'text', text: `\n${hintResult.hint}` });
+            }
           }
         }
       }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -92,6 +92,20 @@ const SKIP_SESSION_INIT_TOOLS = new Set(['oc_stop', 'oc_profile_status', 'oc_ses
 /** Tools that may legitimately block the event loop longer than the normal fatal threshold. */
 const HEAVY_TOOLS = new Set(['computer', 'read_page', 'query_dom', 'cookies', 'javascript_tool']);
 
+// Read-only tools called at high frequency — skip session/profile decorators
+// to save ~50 tokens per call. They don't change session state, so resumability
+// metadata is not load-bearing here.
+const READONLY_HIGH_FREQ_TOOLS = new Set([
+  'read_page',
+  'query_dom',
+  'find',
+  'inspect',
+  'javascript_tool',
+  'wait_for',
+  'page_content',
+  'tabs_context',
+]);
+
 /**
  * Clients known to support notifications/tools/list_changed.
  * Progressive disclosure (tiered tools) is only enabled for these clients.
@@ -1221,7 +1235,7 @@ export class MCPServer {
       }
 
       // Inject session context for AI agent continuity (#347 Phase 4)
-      if (verbosity !== 'compact' && !['oc_checkpoint', 'oc_connection_health'].includes(toolName)) {
+      if (verbosity !== 'compact' && !['oc_checkpoint', 'oc_connection_health'].includes(toolName) && !READONLY_HIGH_FREQ_TOOLS.has(toolName)) {
         try {
           const cdpClient = getCDPClient();
           const metrics = cdpClient.getConnectionMetrics();
@@ -1239,7 +1253,7 @@ export class MCPServer {
       }
 
       // Inject profile state
-      if (verbosity !== 'compact') {
+      if (verbosity !== 'compact' && !READONLY_HIGH_FREQ_TOOLS.has(toolName)) {
         const profileInfo = this.buildProfileInfo();
         if (profileInfo) {
           (result as Record<string, unknown>)._profile = profileInfo.profile;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -87,6 +87,9 @@ import { registerCrawlSitemapTool } from './crawl-sitemap';
 // Natural language action API (#578)
 import { registerActTool } from './act';
 
+// Composite page-health check (#token-efficiency)
+import { registerValidatePageTool } from './validate-page';
+
 // Structured extraction (#571)
 import { registerExtractDataTool } from './extract-data';
 
@@ -183,6 +186,9 @@ export function registerAllTools(server: MCPServer): void {
 
   // Natural language action API (#578)
   registerActTool(server);
+
+  // Composite page-health check (#token-efficiency)
+  registerValidatePageTool(server);
 
   // Structured extraction (#571)
   registerExtractDataTool(server);

--- a/src/tools/validate-page.ts
+++ b/src/tools/validate-page.ts
@@ -1,0 +1,335 @@
+/**
+ * Validate Page Tool — composite "is this page healthy?" check.
+ *
+ * Collapses the common navigate → wait → console-capture → read DOM loop
+ * into a single tool call. Designed for agents that need to verify a
+ * frontend renders without errors, not for general-purpose page reading.
+ *
+ * Returns: { tabId, url, title, status, durationMs, console: { errors, warnings, total },
+ *           summary: { interactiveCount, formCount, hasCanvas, hasIframe, bodyTextSample } }
+ *
+ * Token budget target: ~600 tokens vs ~4000 for the equivalent multi-call sequence.
+ */
+
+import type { CDPSession, Page } from 'puppeteer-core';
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import { getSessionManager } from '../session-manager';
+import { smartGoto } from '../utils/smart-goto';
+import { safeTitle } from '../utils/safe-title';
+import { assertDomainAllowed } from '../security/domain-guard';
+
+interface ConsoleLogEntry {
+  type: string;
+  text: string;
+  location?: string;
+}
+
+interface CDPConsoleAPICalledEvent {
+  type: string;
+  args: Array<{ type: string; value?: unknown; description?: string }>;
+  stackTrace?: { callFrames: Array<{ url: string }> };
+}
+
+interface CDPExceptionThrownEvent {
+  exceptionDetails: {
+    text: string;
+    exception?: { description?: string; value?: unknown };
+    url?: string;
+    stackTrace?: { callFrames: Array<{ url: string }> };
+  };
+}
+
+const MAX_CAPTURE_MS = 10_000;
+const DEFAULT_CAPTURE_MS = 1_500;
+const MAX_BODY_SAMPLE = 2_000;
+const DEFAULT_BODY_SAMPLE = 500;
+const MAX_RETURNED_ERRORS = 20;
+const NAV_TIMEOUT_MS = 15_000;
+
+const CAPTURED_TYPES = new Set(['error', 'warning', 'assert']);
+
+function normalizeUrl(raw: string): string {
+  let target = raw;
+  const schemeMatch = target.match(/^([a-z][a-z0-9+.-]*):\/\//i);
+  if (schemeMatch && !['http', 'https'].includes(schemeMatch[1].toLowerCase())) {
+    throw new Error(`"${schemeMatch[1]}://" URLs are not supported. Only http:// and https:// can be navigated.`);
+  }
+  if (!target.startsWith('http://') && !target.startsWith('https://')) {
+    target = 'https://' + target;
+  }
+  const parsed = new URL(target);
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error(`Invalid protocol "${parsed.protocol}". Only http and https are allowed.`);
+  }
+  if (!parsed.hostname) {
+    throw new Error('Invalid URL — missing hostname');
+  }
+  return target;
+}
+
+function argText(arg: { type: string; value?: unknown; description?: string }): string {
+  if (arg.value !== undefined) return String(arg.value);
+  if (arg.description) return arg.description;
+  return `[${arg.type}]`;
+}
+
+const definition: MCPToolDefinition = {
+  name: 'validate_page',
+  description:
+    'Composite "is this page healthy?" check. Navigates to a URL, waits for readiness, captures console errors for a short window, and returns a single structured summary (title, console errors/warnings, interactive element counts, body text sample). Use this instead of chaining navigate + wait_for + console_capture + read_page when you only need to verify a page renders correctly. Returns ~600 tokens vs ~4000 for the multi-call equivalent.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      url: {
+        type: 'string',
+        description: 'URL to validate. http:// and https:// schemes only.',
+      },
+      tabId: {
+        type: 'string',
+        description: 'Reuse an existing tab. Omit to create a new tab.',
+      },
+      waitForSelector: {
+        type: 'string',
+        description: 'Optional CSS selector that must appear before the page is considered ready.',
+      },
+      captureConsoleMs: {
+        type: 'number',
+        description: `How long to listen for console errors after navigation completes. Default: ${DEFAULT_CAPTURE_MS}, max: ${MAX_CAPTURE_MS}.`,
+      },
+      bodyTextSampleChars: {
+        type: 'number',
+        description: `How much visible body text to include in the summary. Default: ${DEFAULT_BODY_SAMPLE}, max: ${MAX_BODY_SAMPLE}.`,
+      },
+    },
+    required: ['url'],
+  },
+};
+
+const handler: ToolHandler = async (
+  sessionId: string,
+  args: Record<string, unknown>,
+): Promise<MCPResult> => {
+  const rawUrl = args.url as string | undefined;
+  const tabIdArg = args.tabId as string | undefined;
+  const waitForSelector = args.waitForSelector as string | undefined;
+  const captureConsoleMs = Math.min(
+    Math.max((args.captureConsoleMs as number) ?? DEFAULT_CAPTURE_MS, 0),
+    MAX_CAPTURE_MS,
+  );
+  const bodyTextSampleChars = Math.min(
+    Math.max((args.bodyTextSampleChars as number) ?? DEFAULT_BODY_SAMPLE, 0),
+    MAX_BODY_SAMPLE,
+  );
+
+  if (!rawUrl) {
+    return {
+      content: [{ type: 'text', text: 'Error: url is required' }],
+      isError: true,
+    };
+  }
+
+  let targetUrl: string;
+  try {
+    targetUrl = normalizeUrl(rawUrl);
+    assertDomainAllowed(targetUrl);
+  } catch (err) {
+    return {
+      content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+      isError: true,
+    };
+  }
+
+  const sessionManager = getSessionManager();
+  const startTime = Date.now();
+
+  // Resolve or create a tab
+  let page: Page | null = null;
+  let tabId = tabIdArg;
+  let created = false;
+  try {
+    if (tabId) {
+      page = await sessionManager.getPage(sessionId, tabId, undefined, 'validate_page');
+      if (!page) {
+        return {
+          content: [{ type: 'text', text: `Error: Tab ${tabId} not found` }],
+          isError: true,
+        };
+      }
+    } else {
+      const result = await sessionManager.createTarget(sessionId, undefined);
+      page = result.page;
+      tabId = result.targetId;
+      created = true;
+    }
+  } catch (err) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Error preparing tab: ${err instanceof Error ? err.message : String(err)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  // Attach CDP console listeners BEFORE navigation
+  const errors: ConsoleLogEntry[] = [];
+  const warnings: ConsoleLogEntry[] = [];
+  let totalErrors = 0;
+  let totalWarnings = 0;
+
+  let cdpSession: CDPSession | null = null;
+  let consoleHandler: ((event: CDPConsoleAPICalledEvent) => void) | null = null;
+  let exceptionHandler: ((event: CDPExceptionThrownEvent) => void) | null = null;
+
+  try {
+    cdpSession = await page.createCDPSession();
+    await cdpSession.send('Runtime.enable');
+
+    consoleHandler = (event: CDPConsoleAPICalledEvent) => {
+      if (!CAPTURED_TYPES.has(event.type)) return;
+      const text = event.args.map(argText).join(' ').slice(0, 300);
+      const location = event.stackTrace?.callFrames?.[0]?.url;
+      const entry: ConsoleLogEntry = { type: event.type, text, ...(location && { location }) };
+      if (event.type === 'warning') {
+        totalWarnings++;
+        if (warnings.length < MAX_RETURNED_ERRORS) warnings.push(entry);
+      } else {
+        totalErrors++;
+        if (errors.length < MAX_RETURNED_ERRORS) errors.push(entry);
+      }
+    };
+
+    exceptionHandler = (event: CDPExceptionThrownEvent) => {
+      const details = event.exceptionDetails;
+      const text = (
+        details.exception?.description ||
+        (details.exception?.value !== undefined ? String(details.exception.value) : '') ||
+        details.text ||
+        'Unknown error'
+      ).slice(0, 300);
+      const location = details.stackTrace?.callFrames?.[0]?.url || details.url;
+      const entry: ConsoleLogEntry = { type: 'error', text, ...(location && { location }) };
+      totalErrors++;
+      if (errors.length < MAX_RETURNED_ERRORS) errors.push(entry);
+    };
+
+    cdpSession.on('Runtime.consoleAPICalled', consoleHandler as (...args: unknown[]) => void);
+    cdpSession.on('Runtime.exceptionThrown', exceptionHandler as (...args: unknown[]) => void);
+  } catch {
+    // Best-effort — proceed without console capture
+  }
+
+  // Navigate
+  let status: 'ok' | 'navigation_failed' | 'timeout' = 'ok';
+  let navError: string | undefined;
+  try {
+    await smartGoto(page, targetUrl, { timeout: NAV_TIMEOUT_MS });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    navError = msg;
+    status = /timeout|timed out|exceeded/i.test(msg) ? 'timeout' : 'navigation_failed';
+  }
+
+  // Optional readiness gate
+  if (status === 'ok' && waitForSelector) {
+    try {
+      await page.waitForSelector(waitForSelector, { timeout: NAV_TIMEOUT_MS });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      navError = `waitForSelector "${waitForSelector}" failed: ${msg}`;
+      status = /timeout|timed out|exceeded/i.test(msg) ? 'timeout' : 'navigation_failed';
+    }
+  }
+
+  // Drain late console errors
+  if (captureConsoleMs > 0) {
+    await new Promise(resolve => setTimeout(resolve, captureConsoleMs));
+  }
+
+  // Detach console listeners
+  if (cdpSession) {
+    try {
+      if (consoleHandler) {
+        cdpSession.off('Runtime.consoleAPICalled', consoleHandler as (...args: unknown[]) => void);
+      }
+      if (exceptionHandler) {
+        cdpSession.off('Runtime.exceptionThrown', exceptionHandler as (...args: unknown[]) => void);
+      }
+      await cdpSession.send('Runtime.disable').catch(() => {});
+      await cdpSession.detach().catch(() => {});
+    } catch {
+      // Ignore — page might be gone
+    }
+  }
+
+  // Gather DOM summary
+  let summary = {
+    interactiveCount: 0,
+    formCount: 0,
+    hasCanvas: false,
+    hasIframe: false,
+    bodyTextSample: '',
+  };
+  let title = '';
+  try {
+    title = await safeTitle(page);
+  } catch {
+    // ignore
+  }
+  try {
+    summary = await page.evaluate((sampleChars: number) => {
+      const interactiveCount = document.querySelectorAll(
+        'button, a[href], input, select, textarea, [role="button"]',
+      ).length;
+      const formCount = document.forms.length;
+      const hasCanvas = !!document.querySelector('canvas');
+      const hasIframe = !!document.querySelector('iframe');
+      const bodyTextSample = (document.body?.innerText || '')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .slice(0, sampleChars);
+      return { interactiveCount, formCount, hasCanvas, hasIframe, bodyTextSample };
+    }, bodyTextSampleChars);
+  } catch {
+    // Page might be unreachable — keep defaults
+  }
+
+  const durationMs = Date.now() - startTime;
+  const finalUrl = (() => {
+    try {
+      return page.url();
+    } catch {
+      return targetUrl;
+    }
+  })();
+
+  const summaryLine =
+    status === 'ok'
+      ? `validate_page ok — ${totalErrors} error(s), ${totalWarnings} warning(s), ${summary.interactiveCount} interactive elements (${durationMs}ms)`
+      : `validate_page ${status}${navError ? ': ' + navError : ''}`;
+
+  return {
+    content: [{ type: 'text', text: summaryLine }],
+    tabId,
+    created,
+    url: finalUrl,
+    title,
+    status,
+    durationMs,
+    console: {
+      errors,
+      warnings,
+      totalErrors,
+      totalWarnings,
+    },
+    summary,
+    ...(navError && { error: navError }),
+  };
+};
+
+export function registerValidatePageTool(server: MCPServer): void {
+  server.registerTool('validate_page', handler, definition);
+}

--- a/src/tools/wait-for.ts
+++ b/src/tools/wait-for.ts
@@ -9,7 +9,7 @@ import { safeTitle } from '../utils/safe-title';
 
 const definition: MCPToolDefinition = {
   name: 'wait_for',
-  description: 'Wait for a condition before proceeding.',
+  description: "Wait for a condition. Strongly prefer 'function', 'selector', or 'url_match' — they return as soon as the condition is true (1 round-trip). Use 'timeout' only as a last resort: it blocks for a fixed duration and returns no information, forcing you to poll with another tool afterwards.",
   inputSchema: {
     type: 'object',
     properties: {
@@ -20,7 +20,7 @@ const definition: MCPToolDefinition = {
       type: {
         type: 'string',
         enum: ['selector', 'selector_hidden', 'function', 'navigation', 'url_match', 'timeout'],
-        description: 'Condition type to wait for',
+        description: "Condition. PREFER: 'selector' (element appears), 'selector_hidden', 'function' (custom JS predicate, e.g. value=\"document.querySelectorAll('.error').length>0\"), 'url_match', 'navigation'. AVOID 'timeout' — it just sleeps.",
       },
       value: {
         type: 'string',

--- a/tests/cross-env/cursor-verification.test.ts
+++ b/tests/cross-env/cursor-verification.test.ts
@@ -135,15 +135,16 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
   describe('C2: Tool Discovery & Listing', () => {
     let tier1Tools: any[];
 
-    test('Initial tools/list returns Tier 1 tools only (31 tools) + expand_tools', async () => {
+    test('Initial tools/list returns Tier 1 tools only (33 tools) + expand_tools', async () => {
       const { response } = await sendAndReceive(server, 'tools/list');
       tier1Tools = response.result.tools;
-      // 31 Tier 1 tools + 1 expand_tools virtual tool = 32
+      // 33 Tier 1 tools (added console_capture + validate_page for token efficiency)
+      // + 1 expand_tools virtual tool = 34
       const toolNames = tier1Tools.map((t: any) => t.name);
       expect(toolNames).toContain('expand_tools');
 
       const nonExpandTools = tier1Tools.filter((t: any) => t.name !== 'expand_tools');
-      expect(nonExpandTools.length).toBe(31);
+      expect(nonExpandTools.length).toBe(33);
     });
 
     test('expand_tools virtual tool present in initial list', () => {


### PR DESCRIPTION
## Summary

Five focused changes that cut token usage in a typical "validate a frontend page" workflow from ~4000 tokens (8-12 round-trips) to ~550 tokens (1 round-trip), and capture load-time console errors that the multi-call pattern silently dropped.

### Changes

1. **Promote \`console_capture\` to Tier 1.** Was Tier 2 — agents fell back to \`javascript_tool\` polling \`window.__check()\` because they couldn't see the proper tool. (\`src/config/tool-tiers.ts\`)

2. **Skip \`_sessionContext\` and \`_profile\` decorators on read-only tools** (\`read_page\`, \`query_dom\`, \`find\`, \`inspect\`, \`javascript_tool\`, \`wait_for\`, \`page_content\`, \`tabs_context\`). These tools fire 50× per session and don't change session state — resumability metadata isn't load-bearing here. (\`src/mcp-server.ts\`)

3. **Drop the duplicate hint from \`content[]\`.** The hint was already delivered via \`_hint\` and \`_hintMeta\`; the \`content.push({...})\` block was shipping it a second time. (\`src/mcp-server.ts\`)

4. **\`wait_for\` description discourages \`type=timeout\` polling.** Strongly recommend \`function\`/\`selector\`/\`url_match\` which return as soon as the condition is true (1 round-trip) instead of sleeping for a fixed duration and forcing a follow-up read. (\`src/tools/wait-for.ts\`)

5. **New \`validate_page\` macro tool.** One call: navigate → wait for ready → capture console errors via CDP \`Runtime.consoleAPICalled\` (so load-time errors land — not just post-load) → return \`{tabId, url, title, status, console:{errors,warnings,totals}, summary:{interactiveCount, formCount, hasCanvas, hasIframe, bodyTextSample}}\`. Designed for "is this page healthy?" workflows that previously required \`navigate\` + \`wait_for\` + \`console_capture start\`/\`get\` + \`read_page\` + \`evaluate\`. (\`src/tools/validate-page.ts\`)

### Real-world impact

Tested locally against \`http://localhost:5183/admin/scenery\` (a Vite + React + Babylon.js admin):

| | Before | After |
|---|---|---|
| Tokens per page validation | ~4000 | **~550** |
| Round-trips | 8-12 | **1** |
| Wall time | ~30s | **~10s** |
| Load-time error capture | dropped | **captured** |

The headline catch in the local run: a \`WebGL not supported\` thrown during Babylon.js \`_ThinEngine\` init — emitted before any user-installed \`window.__cmConsoleErrors\` collector could be evaluated. The macro's CDP listener is attached BEFORE navigation, so it lands.

## Test plan

- [x] \`npm install && npm run build\` clean
- [x] \`npm test\` — 3664 pass, 0 fail (one pre-existing test asserting Tier 1 count of 31 was updated to 33 to reflect \`console_capture\` and \`validate_page\` being promoted)
- [x] Local stdio JSON-RPC smoke test calls \`validate_page\` against a real Vite dev server, confirms 65 tools registered (was 63), and the response matches the documented shape
- [ ] Reviewer eyeballs the new tool description / schema