### PR TITLE
test(#648): make graceful-shutdown audit OS-aware on Windows

### DIFF
--- a/tests/integration/health-endpoint-gating.test.ts
+++ b/tests/integration/health-endpoint-gating.test.ts
@@ -256,12 +256,25 @@ describeFn('health endpoint gating (issue #648)', () => {
           expect(probe).not.toBe('connected');
         }
 
-        // Graceful shutdown audit (criterion #6): SIGTERM must exit 0
-        // and must NOT produce a TypeError for the stdio case where
-        // healthEndpoint === null.
+        // Graceful shutdown audit (criterion #6): the teardown path for
+        // the stdio case (where healthEndpoint === null) must NOT produce
+        // a TypeError or unhandled rejection. The stderr audit below is
+        // the load-bearing check that #648's NPE is fixed.
+        //
+        // The exit-code half of this audit is POSIX-only by design. On
+        // Windows, Node maps `subprocess.kill(...)` to TerminateProcess
+        // regardless of the signal name (POSIX signals don't exist
+        // there); on the GitHub Actions windows-latest runner the child
+        // observably stays alive past 10s on this code path — neither
+        // 'exit' nor 'close' fires — so any exit-code assertion is
+        // unreachable. We trigger the kill anyway (the test's `finally`
+        // block will SIGKILL on the way out) and lean on the stderr
+        // audit, which is what the criterion is really about.
         child.kill('SIGTERM');
-        const exitCode = await waitForExit(child, 10_000);
-        expect(exitCode).toBe(0);
+        if (process.platform !== 'win32') {
+          const exitCode = await waitForExit(child, 10_000);
+          expect(exitCode).toBe(0);
+        }
         expect(stderr).not.toMatch(/TypeError/);
         expect(stderr).not.toMatch(/Cannot read properties of null/);
         expect(stderr).not.toMatch(/UnhandledPromiseRejection/);


### PR DESCRIPTION
## Summary

Fixes the Windows-only CI regression introduced when #652 landed on `develop` (4 consecutive failed Windows runs since `2ff1d02`). PR #654 (screenshot format) inherited the red but is unrelated.

## What's broken

`tests/integration/health-endpoint-gating.test.ts:264` asserts:

```ts
child.kill('SIGTERM');
const exitCode = await waitForExit(child, 10_000);
expect(exitCode).toBe(0);
```

Per the [Node.js docs](https://nodejs.org/api/child_process.html#subprocesskillsignal), on Windows `subprocess.kill(...)` is mapped to `TerminateProcess` regardless of the signal name — POSIX signals do not exist there, so our `enhancedShutdown` handler can never run.

In practice it's worse than that on `windows-latest`: the child observably stays alive past 10s on this code path. Neither `'exit'` nor `'close'` fires (verified by an intermediate iteration of this fix that fell back to `'close'` and still timed out — log: [run 25200614528](https://github.com/shaun0927/openchrome/actions/runs/25200614528)). Any exit-code assertion is unreachable.

## What's fixed

Criterion #6's load-bearing check has always been the stderr audit — no `TypeError`, no `Cannot read properties of null`, no `UnhandledPromiseRejection` from the `await healthEndpoint.stop()` path when the endpoint was never constructed. That stays unchanged.

The exit-code assertion is now POSIX-only. The SIGTERM kick still fires on Windows so the existing `finally` block (SIGKILL fallback) can free the handle.

## Why a separate PR

This is unrelated to #654 (screenshot format). Keeping the fix in its own commit makes the regression history readable.

## Out of scope

The underlying "child does not respond to kill on Windows" behavior is a real concern (it might mean Windows daemons can't be cleanly stopped), but it's a deeper investigation than a CI unblock. Tracked separately — not in this PR.

## Test plan

- [x] `npx jest tests/integration/health-endpoint-gating.test.ts` — 7/7 pass on macOS in 4.8s
- [ ] CI Windows matrix turns green on this PR (the real verification)