### PR TITLE
test(cdp): replace fixed sleeps with waitFor polling in tab-health-monitor

### DIFF
--- a/tests/cdp/tab-health-monitor.test.ts
+++ b/tests/cdp/tab-health-monitor.test.ts
@@ -18,6 +18,22 @@ function createMockPage(opts: {
   return { evaluate } as unknown as jest.Mocked<Pick<Page, 'evaluate'>>;
 }
 
+// Polls `predicate` until it returns truthy or `timeoutMs` elapses. Replaces
+// fixed `setTimeout` waits that were brittle on loaded CI runners — the
+// probe interval is 30ms but a single jest worker tick on the GitHub
+// Actions runners can stretch well past that under contention.
+async function waitFor(
+  predicate: () => boolean,
+  { timeoutMs = 2000, intervalMs = 20 }: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`waitFor: predicate did not become truthy within ${timeoutMs}ms`);
+}
+
 describe('TabHealthMonitor', () => {
   let monitor: TabHealthMonitor;
 
@@ -66,8 +82,7 @@ describe('TabHealthMonitor', () => {
 
     monitor.monitorTab('tab1', page as unknown as Page);
 
-    // Wait for enough probes to exceed threshold
-    await new Promise(r => setTimeout(r, 150));
+    await waitFor(() => unhealthyHandler.mock.calls.length > 0);
 
     expect(unhealthyHandler).toHaveBeenCalledWith(
       expect.objectContaining({ targetId: 'tab1' })
@@ -89,7 +104,7 @@ describe('TabHealthMonitor', () => {
 
     monitor.monitorTab('tab1', page as unknown as Page);
 
-    await new Promise(r => setTimeout(r, 150));
+    await waitFor(() => evictHandler.mock.calls.length > 0);
 
     expect(evictHandler).toHaveBeenCalledWith(
       expect.objectContaining({ targetId: 'tab1' })
@@ -118,7 +133,13 @@ describe('TabHealthMonitor', () => {
 
     monitor.monitorTab('tab1', page);
 
-    await new Promise(r => setTimeout(r, 150));
+    // First a failure recovers to healthy: wait until probe count is high
+    // enough that we have observed at least one healthy result after the
+    // initial transient failure.
+    await waitFor(() => {
+      const h = monitor.getTabHealth('tab1');
+      return h !== undefined && h.status === 'healthy' && h.consecutiveFailures === 0 && callCount >= 2;
+    });
 
     const health = monitor.getTabHealth('tab1');
     expect(health?.status).toBe('healthy');
@@ -183,7 +204,7 @@ describe('TabHealthMonitor', () => {
 
     monitor.monitorTab('tab1', page as unknown as Page);
 
-    await new Promise(r => setTimeout(r, 200));
+    await waitFor(() => unhealthyHandler.mock.calls.length > 0);
 
     expect(unhealthyHandler).toHaveBeenCalled();
 


### PR DESCRIPTION
## Summary

Eliminates a CI flake observed on PR #662's matrix run ([macos-latest, 20]: \`tab-health-monitor.test.ts:72\` reported \`Number of calls: 0\`).

## Root cause

Four tests in \`tests/cdp/tab-health-monitor.test.ts\` used fixed \`setTimeout\` waits sized just barely above the deterministic minimum:

| Test | Probe interval | Threshold | Wait | Theoretical min | Margin |
|---|---|---|---|---|---|
| marks tab unhealthy | 30ms | 2 fails | 150ms | 60ms | 90ms |
| emits tab-evict | 20ms | 2 fails | 150ms | 40ms | 110ms |
| tab recovers | 30ms | 3 fails | 150ms | 90ms | 60ms |
| probe timeout detects hanging renderer | 30ms | 2 fails | 200ms | 60ms | 140ms |

On loaded GitHub Actions runners (especially \`macos-latest, 20\` per #662 logs), three jitter sources combine to eat that margin:

1. Jest worker scheduling — a single tick under contention can stretch from <1ms to 50–100ms.
2. GC pauses on the worker heap.
3. The probe's own \`Promise.race\` against a 10ms timeout adds another scheduling-dependent step per probe.

Result: 150ms windows that are >2σ on a developer laptop are <1σ on a CI runner.

## Fix

Replace each fixed sleep with a \`waitFor(predicate, { timeoutMs: 2000, intervalMs: 20 })\` helper that:
- returns **immediately** on a fast machine (the condition is usually true within 1–2 probe intervals)
- tolerates jitter up to **2s** on a busy runner

The 2s ceiling is well below jest's default 5s timeout for these tests, and the 20ms polling interval is small enough that resolution latency is invisible.

## Verified

- \`npx jest tests/cdp/tab-health-monitor.test.ts\` — 9/9 pass locally
- 10 consecutive full-suite runs all pass (was previously seeing intermittent failures on CI)
- Average per-test time **drops** (e.g. \`marks tab unhealthy\`: 150ms → 83ms) since polling exits as soon as the condition is satisfied

## Out of scope

\`reports healthy tab after successful probe\` (line 39) keeps its 120ms wait — the test verifies that the default \`healthy\` state is **maintained** while probes run, which is not a "wait until" condition. No flake observed there.