### PR TITLE
test(transports): handle pre-handler abort race in http-abort-on-disconnect

### DIFF
--- a/tests/transports/http-abort-on-disconnect.test.ts
+++ b/tests/transports/http-abort-on-disconnect.test.ts
@@ -91,6 +91,17 @@ describe('HTTPTransport — abort-on-disconnect (issue #8)', () => {
           handlerResolve();
           return;
         }
+        // The disconnect can race ahead of handler entry on a loaded CI
+        // runner: the server registers the socket-close listener before
+        // the handler is called, so controller.abort(reason) may have
+        // already fired by the time we get here. Cover that branch by
+        // checking signal.aborted synchronously, then fall back to the
+        // event listener for the slow path.
+        if (signal.aborted) {
+          captureReason(signal.reason);
+          handlerResolve();
+          return;
+        }
         signal.addEventListener('abort', () => {
           captureReason(signal.reason);
           handlerResolve();


### PR DESCRIPTION
## Summary

Eliminates a CI flake observed on PR #662's matrix run ([ubuntu-latest, 20]: \`http-abort-on-disconnect.test.ts:112\` reported \`Received value: \"TIMEOUT\"\`).

## Root cause — race in the test, not in production code

The test verifies the production transport's abort-on-disconnect path. When CI reported \`TIMEOUT\`, the test was failing for a reason the test itself created — a race in how it *observes* the abort signal:

1. Server \`handlePost\` runs synchronously to register the socket-close listener and create the AbortController (\`src/transports/http.ts:669-690\`).
2. Server starts receiving request body bytes.
3. **Client fires \`req.destroy()\` at t=80ms** — socket 'close' fires, \`controller.abort(new ClientDisconnectError())\` runs **before** the server has reached the \`onMessage(handler)\` call.
4. Server eventually invokes the handler with the (already-aborted) signal.
5. Test handler runs \`signal.addEventListener('abort', …)\` — but the \`abort\` event has *already fired*. The listener is never invoked, \`captureReason\` is never called, and the outer 8s race timeout wins.

On a fast machine (and on most CI matrix combos) the server reaches the handler well before t=80ms, so the listener registers in time and the test passes. On loaded \`ubuntu-latest, 20\` runners the order can flip.

## Fix

Test-only. In the message handler, check \`signal.aborted\` *synchronously* on entry and capture the reason directly when it's already true. Fall back to the event listener for the slow path.

```ts
if (signal.aborted) {
  captureReason(signal.reason);
  handlerResolve();
  return;
}
signal.addEventListener('abort', /* ... */);
```

Production transport code (\`src/transports/http.ts\`) is unchanged. The behaviour we want to verify (handler signal is aborted with \`ClientDisconnectError\` on client disconnect) is unchanged — we're just no longer dropping the event when it fires before the handler asks about it.

## Verified

- \`npx jest tests/transports/http-abort-on-disconnect.test.ts\` — 4/4 pass
- **20 consecutive full-suite runs** all pass (was previously seeing intermittent failures)

## Related

- Origin PR: #662 (matrix run [25200825837](https://github.com/shaun0927/openchrome/actions/runs/25200825837))
- Companion flake fix: #663 (tab-health-monitor)