### PR TITLE
feat(#657): flip auto-launch default to headed; add --headless opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,13 +429,13 @@ If client A opens five tabs and client B opens five tabs, all ten `tabId`s are d
 
 Two mechanisms, used together in practice:
 
-**1. Persistent-profile headless — log in once, automate forever.**
-Point OpenChrome at a persistent `userDataDir` (+ optional `profileDirectory`) and cookies / `localStorage` / IndexedDB survive across runs. After the first login, subsequent **headless** runs stay logged in until the site invalidates the session.
+**1. Persistent-profile login — log in once, automate forever.**
+Point OpenChrome at a persistent `userDataDir` (+ optional `profileDirectory`) and cookies / `localStorage` / IndexedDB survive across runs. After the first login, subsequent runs stay logged in until the site invalidates the session.
 
-**2. Headed fallback for the initial login or WAF-blocked sites.**
-When a human action is genuinely required (first-time login, 2FA, CAPTCHA, WebAuthn) or when a Tier-1/Tier-2 headless attempt is blocked by a CDN/WAF, OpenChrome lazy-launches a separate headed Chrome on a different debug port. Cookies are sync'd from the real Chrome profile before launch, and the headed page is registered back into the same logical session so the surrounding workflow continues seamlessly.
+**2. Headed-by-default — interactive logins just work.**
+Since #657 the launcher runs headed by default; first-time login, 2FA, CAPTCHA, WebAuthn all work without any flag because there's a real visible window. CI / Docker users opt into headless via `--headless` or `OPENCHROME_HEADLESS=1` once their persistent profile is bootstrapped. Cookies sync'd from the real Chrome profile remain available in headless runs.
 
-**Typical pattern:** bootstrap the login once via the headed path → the persistent profile carries the cookies → all subsequent automation runs headless without a window.
+**Typical pattern:** bootstrap the login interactively in the default headed mode → the persistent profile carries the cookies → CI runs use `--headless` and stay authenticated.
 
 ### Does OpenChrome steal focus with popup windows?
 
@@ -443,12 +443,12 @@ When a human action is genuinely required (first-time login, 2FA, CAPTCHA, WebAu
 
 The headed-browser focus-stealing pattern that users encounter with some MCP servers (cross-Space jumps on macOS, un-minimizable popups, per-tool-call window raises) comes from designs where the MCP drives a user-visible browser and creates OS windows as it works. OpenChrome is architected differently:
 
-- **Default mode is headless** — no window exists, so there is nothing to take focus.
 - **`tabs_create` opens a tab, not an OS window.** New tabs are created via CDP inside the already-running Chrome, and OpenChrome never calls `page.bringToFront()` anywhere in the codebase.
-- **The headed fallback is lazy and reused.** When it is needed, it launches **once** per server lifetime; every later navigation/tab runs inside that same instance. At worst you see one focus grab the very first time the fallback activates — not one per action, never one per tab.
-- **The headed fallback is optional.** If persistent-profile headless is sufficient for your sites, you will never see a browser window.
+- **No per-call window raises.** Each navigation/click/tool call runs against the existing window without `bringToFront()`, `focus()`, or any other stealing primitive. After the initial Chrome launch you keep working in your other apps without interruption.
+- **One Chrome per server lifetime.** Auto-launch creates Chrome **once** at startup and reuses it for every later tool call — no popup-per-action loop.
+- **Headless opt-in available.** For CI/server use, `--headless` or `OPENCHROME_HEADLESS=1` runs without any window at all. The default is headed since #657 because headless mode is materially more prone to silent hangs and login failures on real-world sites.
 
-The only scenario in which a window appears at all is the first time the Tier-3 headed fallback activates in a given session.
+The only scenario in which a focus grab can happen is the very first Chrome launch — not one per tool call, never one per tab.
 
 ---
 
@@ -539,6 +539,7 @@ docker run openchrome
 | `OPENCHROME_PPID_WATCH` | Set to `0` to disable the parent-process watcher in stdio mode. Default: enabled. The watcher exits the server when its launching MCP-client parent dies, so abrupt parent termination (force-quit, `kill -9`, tmux teardown) does not orphan the openchrome process. HTTP and `both` transport modes ignore this flag — they remain daemon-capable. |
 | `OPENCHROME_PPID_WATCH_INTERVAL_MS` | Polling interval for the parent watcher in milliseconds. Default: `2000`. Clamped to `[500, 60000]`. |
 | `OPENCHROME_HEALTH_ENDPOINT` | Force-enable (`1`/`true`) or force-disable (`0`/`false`) the `/health` and `/metrics` HTTP listener. Default: on for `--transport http` / `both`, off for `--transport stdio`. Stdio-mode instances usually talk to a single MCP client over the pipe and do not need an external monitoring port; disabling it saves ~200-300 KB heap + one file descriptor per instance. Operators who run stdio under a supervisor can opt in with `OPENCHROME_HEALTH_ENDPOINT=1`; daemon-mode operators who run the health check externally can opt out with `OPENCHROME_HEALTH_ENDPOINT=0`. Invalid values (e.g. `yes`, `2`) fall through to the transport-mode default. |
+| `OPENCHROME_HEADLESS` | Opt into headless Chrome from CI / Docker without `--headless`. Accepts `1`/`true`/`yes` (headless) or `0`/`false`/`no` (headed). Lower precedence than the CLI flag, higher than persisted config. Default since #657 is headed. |
 
 ### Individual flags
 
@@ -554,9 +555,10 @@ openchrome serve \
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--auto-launch` | `false` | Auto-launch Chrome if not running |
+| `--headless` | `false` | Run Chrome headless. Also: `OPENCHROME_HEADLESS=1`. Default since #657 is headed. |
 | `--headless-shell` | `false` | Use chrome-headless-shell binary |
-| `--visible` | `false` | Show Chrome window (disables headless) |
-| `--server-mode` | `false` | Compound flag for server deployment |
+| `--visible` | (deprecated) | No-op alias for headed; the new default is headed since #657. Will be removed in a future release. |
+| `--server-mode` | `false` | Compound flag for server deployment (forces `--headless` + auto-launch) |
 
 ---
 

--- a/src/config/global.ts
+++ b/src/config/global.ts
@@ -15,7 +15,9 @@ export interface GlobalConfig {
   chromeBinary?: string;
   /** Use chrome-headless-shell if available (default: false) */
   useHeadlessShell?: boolean;
-  /** Run Chrome in headless mode (default: true when auto-launch is enabled) */
+  /** Run Chrome in headless mode. Default is headed (#657); this field is the
+   *  persisted-preference layer of the headless resolver (see src/config/headless-resolver.ts).
+   *  Resolution precedence: --headless / --visible CLI flags > OPENCHROME_HEADLESS env > this field > headed default. */
   headless?: boolean;
   /** If true, quit running Chrome to reuse the real profile instead of using temp profile (default: false) */
   restartChrome?: boolean;

--- a/src/config/headless-resolver.ts
+++ b/src/config/headless-resolver.ts
@@ -1,0 +1,72 @@
+/**
+ * Headless mode resolver — single source of truth for the headed-vs-headless
+ * decision when openchrome auto-launches Chrome.
+ *
+ * The default flipped from 'headless' to 'headed' in #657 because headless
+ * Chrome is materially more prone to silent hangs, anti-bot blocks, and
+ * login-flow failures. Users who genuinely want headless (CI, Docker, kiosk)
+ * opt in explicitly via --headless or OPENCHROME_HEADLESS=1.
+ */
+
+export type HeadlessMode = 'headed' | 'headless';
+
+export interface HeadlessOptions {
+  /** Explicit opt-in to headless. */
+  headless?: boolean;
+  /** Back-compat alias: explicit opt-in to headed. */
+  visible?: boolean;
+}
+
+export interface HeadlessEnv {
+  OPENCHROME_HEADLESS?: string;
+}
+
+export interface HeadlessConfig {
+  headless?: boolean;
+}
+
+export class HeadlessFlagConflictError extends Error {
+  constructor() {
+    super('--headless and --visible cannot both be specified');
+    this.name = 'HeadlessFlagConflictError';
+  }
+}
+
+/**
+ * Resolves headed-vs-headless intent from CLI flags, env vars, and config.
+ *
+ * Precedence (highest first):
+ *   1. CLI --headless          (explicit headless)
+ *   2. CLI --visible           (explicit headed; back-compat alias)
+ *   3. OPENCHROME_HEADLESS env (1/true/yes → headless; 0/false/no → headed)
+ *   4. config.headless         (persisted preference)
+ *   5. default                 → 'headed' (new default; was 'headless' before #657)
+ *
+ * Throws HeadlessFlagConflictError when both --headless and --visible are set.
+ */
+export function resolveHeadlessMode(
+  options: HeadlessOptions,
+  env: HeadlessEnv,
+  config: HeadlessConfig,
+): HeadlessMode {
+  if (options.headless === true && options.visible === true) {
+    throw new HeadlessFlagConflictError();
+  }
+
+  if (options.headless === true) return 'headless';
+  if (options.visible === true) return 'headed';
+
+  const envValue = env.OPENCHROME_HEADLESS;
+  if (typeof envValue === 'string' && envValue.length > 0) {
+    const normalized = envValue.trim().toLowerCase();
+    if (normalized === '1' || normalized === 'true' || normalized === 'yes') return 'headless';
+    if (normalized === '0' || normalized === 'false' || normalized === 'no') return 'headed';
+    // Unknown env value: ignore, fall through to config / default.
+  }
+
+  if (typeof config.headless === 'boolean') {
+    return config.headless ? 'headless' : 'headed';
+  }
+
+  return 'headed';
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,19 +129,24 @@ program
 
     // Resolve headed-vs-headless intent (#657). Default flipped to headed.
     // The resolver throws HeadlessFlagConflictError if --headless and --visible both set.
-    let headless = false;
+    //
+    // We resolve unconditionally (not gated on autoLaunch) so any *implicit*
+    // relaunch path — process watchdog (#347/#649) or pool warm-up that
+    // flips autoLaunch on later — picks up the user's actual intent from
+    // global config rather than the headed default. (qodo P1 review on #665.)
+    let headless: boolean;
+    try {
+      const mode = resolveHeadlessMode(
+        { headless: options.headless, visible: options.visible },
+        { OPENCHROME_HEADLESS: process.env.OPENCHROME_HEADLESS },
+        { headless: getGlobalConfig().headless },
+      );
+      headless = mode === 'headless';
+    } catch (err) {
+      console.error(`[openchrome] ${(err as Error).message}`);
+      process.exit(2);
+    }
     if (autoLaunch) {
-      try {
-        const mode = resolveHeadlessMode(
-          { headless: options.headless, visible: options.visible },
-          { OPENCHROME_HEADLESS: process.env.OPENCHROME_HEADLESS },
-          { headless: getGlobalConfig().headless },
-        );
-        headless = mode === 'headless';
-      } catch (err) {
-        console.error(`[openchrome] ${(err as Error).message}`);
-        process.exit(2);
-      }
       console.error(`[openchrome] Headless mode: ${headless}`);
       if (options.visible === true && options.headless !== true) {
         console.error('[openchrome] Note: --visible is deprecated; headed is the default since #657.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { getMCPServer, setMCPServerOptions } from './mcp-server';
 import { registerAllTools } from './tools';
 import { createTransport } from './transports/index';
 import { getGlobalConfig, setGlobalConfig } from './config/global';
+import { resolveHeadlessMode } from './config/headless-resolver';
 import { ToolTier } from './config/tool-tiers';
 import { writePidFile, cleanOrphanedChromeProcesses } from './utils/pid-manager';
 import { installParentWatcher, ParentWatcherHandle } from './utils/parent-watcher';
@@ -74,7 +75,8 @@ program
   .option('--profile-directory <name>', 'Chrome profile directory name (e.g., "Profile 1", "Default")')
   .option('--chrome-binary <path>', 'Path to Chrome binary (e.g., chrome-headless-shell)')
   .option('--headless-shell', 'Use chrome-headless-shell if available (default: false)')
-  .option('--visible', 'Show Chrome window (default: headless when auto-launch)')
+  .option('--headless', 'Run Chrome headless (default: headed). Also: OPENCHROME_HEADLESS=1 env var.')
+  .option('--visible', '[deprecated] Show Chrome window. Headed is the default since #657; this flag is now a no-op alias and will be removed in a future release.')
   .option('--restart-chrome', 'Quit running Chrome to reuse real profile (default: uses temp profile)')
   .option('--hybrid', 'Enable hybrid mode (Lightpanda + Chrome routing)')
   .option('--lp-port <port>', 'Lightpanda debugging port (default: 9223)', '9223')
@@ -88,7 +90,7 @@ program
   .option('--auth-token <token>', 'Bearer token for HTTP transport authentication (also: OPENCHROME_AUTH_TOKEN env var)')
   .option('--transport <mode>', 'Transport mode: stdio, http, or both (default: stdio)')
   .option('--idle-timeout <duration>', 'Self-exit (code 0) after idle window with zero sessions. Format: <number>(ms|s|m|h), e.g. 30m, 90s, 500ms. Bare numbers are rejected. Also: OPENCHROME_IDLE_TIMEOUT_MS env var (integer ms). Default: disabled.')
-  .action(async (options: { port: string; autoLaunch?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; visible?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; idleTimeout?: string }) => {
+  .action(async (options: { port: string; autoLaunch?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; idleTimeout?: string }) => {
     const port = parseInt(options.port, 10);
     let autoLaunch = options.autoLaunch || false;
 
@@ -98,7 +100,9 @@ program
       if (options.visible) {
         console.error('[openchrome] Warning: --visible ignored in server mode (headless forced)');
       }
+      // Force headless via the resolver-visible flag, not visible=false (which now means "user did not pass --visible").
       options.visible = false;
+      options.headless = true;
       console.error('[openchrome] Server mode: enabled (headless, no cookie bridge)');
     }
     const userDataDir = options.userDataDir || process.env.CHROME_USER_DATA_DIR || undefined;
@@ -123,10 +127,25 @@ program
       console.error(`[openchrome] Using headless-shell mode`);
     }
 
-    // Headless by default when auto-launching, unless --visible is specified
-    const headless = autoLaunch && !options.visible;
+    // Resolve headed-vs-headless intent (#657). Default flipped to headed.
+    // The resolver throws HeadlessFlagConflictError if --headless and --visible both set.
+    let headless = false;
     if (autoLaunch) {
+      try {
+        const mode = resolveHeadlessMode(
+          { headless: options.headless, visible: options.visible },
+          { OPENCHROME_HEADLESS: process.env.OPENCHROME_HEADLESS },
+          { headless: getGlobalConfig().headless },
+        );
+        headless = mode === 'headless';
+      } catch (err) {
+        console.error(`[openchrome] ${(err as Error).message}`);
+        process.exit(2);
+      }
       console.error(`[openchrome] Headless mode: ${headless}`);
+      if (options.visible === true && options.headless !== true) {
+        console.error('[openchrome] Note: --visible is deprecated; headed is the default since #657.');
+      }
     }
 
     // Set global config before initializing anything

--- a/tests/config/headless-resolver.test.ts
+++ b/tests/config/headless-resolver.test.ts
@@ -1,0 +1,99 @@
+import { resolveHeadlessMode, HeadlessFlagConflictError } from '../../src/config/headless-resolver';
+
+describe('resolveHeadlessMode (#657)', () => {
+  describe('CLI flag precedence', () => {
+    it('returns headless when --headless is true', () => {
+      expect(resolveHeadlessMode({ headless: true }, {}, {})).toBe('headless');
+    });
+
+    it('returns headed when --visible is true', () => {
+      expect(resolveHeadlessMode({ visible: true }, {}, {})).toBe('headed');
+    });
+
+    it('throws HeadlessFlagConflictError when both --headless and --visible are true', () => {
+      expect(() => resolveHeadlessMode({ headless: true, visible: true }, {}, {})).toThrow(HeadlessFlagConflictError);
+    });
+
+    it('CLI --headless overrides env and config', () => {
+      expect(
+        resolveHeadlessMode(
+          { headless: true },
+          { OPENCHROME_HEADLESS: '0' },
+          { headless: false },
+        ),
+      ).toBe('headless');
+    });
+
+    it('CLI --visible overrides env and config', () => {
+      expect(
+        resolveHeadlessMode(
+          { visible: true },
+          { OPENCHROME_HEADLESS: '1' },
+          { headless: true },
+        ),
+      ).toBe('headed');
+    });
+  });
+
+  describe('environment variable', () => {
+    it.each(['1', 'true', 'TRUE', 'yes', 'Yes'])('%s → headless', (value) => {
+      expect(resolveHeadlessMode({}, { OPENCHROME_HEADLESS: value }, {})).toBe('headless');
+    });
+
+    it.each(['0', 'false', 'FALSE', 'no', 'No'])('%s → headed', (value) => {
+      expect(resolveHeadlessMode({}, { OPENCHROME_HEADLESS: value }, {})).toBe('headed');
+    });
+
+    it('unrecognized value falls through to config / default', () => {
+      expect(resolveHeadlessMode({}, { OPENCHROME_HEADLESS: 'maybe' }, { headless: true })).toBe('headless');
+      expect(resolveHeadlessMode({}, { OPENCHROME_HEADLESS: 'maybe' }, {})).toBe('headed');
+    });
+
+    it('empty string is ignored', () => {
+      expect(resolveHeadlessMode({}, { OPENCHROME_HEADLESS: '' }, { headless: true })).toBe('headless');
+    });
+
+    it('whitespace is trimmed', () => {
+      expect(resolveHeadlessMode({}, { OPENCHROME_HEADLESS: '  1  ' }, {})).toBe('headless');
+    });
+  });
+
+  describe('config layer', () => {
+    it('config.headless=true → headless', () => {
+      expect(resolveHeadlessMode({}, {}, { headless: true })).toBe('headless');
+    });
+
+    it('config.headless=false → headed', () => {
+      expect(resolveHeadlessMode({}, {}, { headless: false })).toBe('headed');
+    });
+
+    it('env overrides config', () => {
+      expect(resolveHeadlessMode({}, { OPENCHROME_HEADLESS: '1' }, { headless: false })).toBe('headless');
+      expect(resolveHeadlessMode({}, { OPENCHROME_HEADLESS: '0' }, { headless: true })).toBe('headed');
+    });
+  });
+
+  describe('default (no input)', () => {
+    it('returns headed when nothing is specified', () => {
+      expect(resolveHeadlessMode({}, {}, {})).toBe('headed');
+    });
+
+    it('headless=undefined and visible=undefined behaves like empty', () => {
+      expect(
+        resolveHeadlessMode({ headless: undefined, visible: undefined }, {}, {}),
+      ).toBe('headed');
+    });
+  });
+
+  describe('conflict-error message', () => {
+    it('mentions both flags', () => {
+      try {
+        resolveHeadlessMode({ headless: true, visible: true }, {}, {});
+        fail('expected throw');
+      } catch (err) {
+        expect((err as Error).message).toContain('--headless');
+        expect((err as Error).message).toContain('--visible');
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #657.

## Summary

- Flip the `--auto-launch` headless/headed default from **headless** to **headed**.
- Add a new `--headless` CLI flag and `OPENCHROME_HEADLESS` env var for explicit opt-in to headless (CI / Docker / kiosk).
- Keep `--visible` as a no-op back-compat alias (deprecated, removed in a future release).
- `--server-mode` continues to force headless — no behavior change for that path.

## Why

Headless Chrome is materially more prone to silent hangs, anti-bot blocks, and login-flow failures on real-world sites. New users hitting `--auto-launch` should land in a working configuration; headless should be an explicit, documented opt-in.

## Resolution chain

| # | Source | How specified |
|---|---|---|
| 1 | CLI `--headless` | explicit headless |
| 2 | CLI `--visible` (alias) | explicit headed (back-compat) |
| 3 | `OPENCHROME_HEADLESS` env | `1`/`true`/`yes` headless; `0`/`false`/`no` headed |
| 4 | `config.headless` | persisted preference |
| 5 | **default** | **`headed`** (new; was `headless`) |

`--headless` and `--visible` together exit with code 2 and a clear error.

## Test plan

- [x] `npm run build` clean.
- [x] `npm test` — 3606 passed, 86 skipped, 0 failed (1 unrelated pre-existing worker-teardown warning).
- [x] New unit tests: `tests/config/headless-resolver.test.ts` — 24 cases covering precedence, env parsing, conflict, defaults.
- [x] Manual smoke: `--auto-launch` → headed (no `--headless=new` in args); `--auto-launch --headless` → headless; `OPENCHROME_HEADLESS=1` → headless; conflict → exit 2; `--visible` → headed + deprecation note.

## Backwards compatibility

| Scenario | Old | New |
|---|---|---|
| `--auto-launch --visible` | headed | headed (unchanged) |
| `--auto-launch` | headless | **headed (changed)** |
| `--auto-launch --headless` | error (unknown flag) | headless |
| `OPENCHROME_HEADLESS=1` | (no env support) | headless |
| `--server-mode` | headless | headless (unchanged) |
| `launcher.launch({ headless: true })` (programmatic) | headless | headless (unchanged — explicit beats default) |

## Files changed

- `src/config/headless-resolver.ts` (new) — pure resolver helper.
- `src/index.ts` — wire resolver, add `--headless` flag, deprecation hint for `--visible`.
- `src/config/global.ts` — update `headless` field doc to reference the resolver.
- `tests/config/headless-resolver.test.ts` (new).
- `README.md` — update default-mode language, focus-stealing FAQ, flag table, env-var table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)