### PR TITLE
fix(validate_page): surface auth redirects and normalize uppercase URL schemes

### DIFF
--- a/src/tools/validate-page.ts
+++ b/src/tools/validate-page.ts
@@ -49,13 +49,16 @@ const NAV_TIMEOUT_MS = 15_000;
 
 const CAPTURED_TYPES = new Set(['error', 'warning', 'assert']);
 
-function normalizeUrl(raw: string): string {
+export function normalizeUrl(raw: string): string {
   let target = raw;
   const schemeMatch = target.match(/^([a-z][a-z0-9+.-]*):\/\//i);
-  if (schemeMatch && !['http', 'https'].includes(schemeMatch[1].toLowerCase())) {
-    throw new Error(`"${schemeMatch[1]}://" URLs are not supported. Only http:// and https:// can be navigated.`);
-  }
-  if (!target.startsWith('http://') && !target.startsWith('https://')) {
+  if (schemeMatch) {
+    const scheme = schemeMatch[1].toLowerCase();
+    if (!['http', 'https'].includes(scheme)) {
+      throw new Error(`"${schemeMatch[1]}://" URLs are not supported. Only http:// and https:// can be navigated.`);
+    }
+    target = scheme + '://' + target.slice(schemeMatch[0].length);
+  } else {
     target = 'https://' + target;
   }
   const parsed = new URL(target);
@@ -223,10 +226,16 @@ const handler: ToolHandler = async (
   }
 
   // Navigate
-  let status: 'ok' | 'navigation_failed' | 'timeout' = 'ok';
+  let status: 'ok' | 'navigation_failed' | 'timeout' | 'auth_redirect_required' = 'ok';
   let navError: string | undefined;
+  let authRedirect: { from: string; to: string; host: string } | undefined;
   try {
-    await smartGoto(page, targetUrl, { timeout: NAV_TIMEOUT_MS });
+    const gotoResult = await smartGoto(page, targetUrl, { timeout: NAV_TIMEOUT_MS });
+    if (gotoResult.authRedirect) {
+      authRedirect = gotoResult.authRedirect;
+      status = 'auth_redirect_required';
+      navError = `Authentication redirect detected — page redirected from ${authRedirect.from} to ${authRedirect.host}. Sign in via the browser, then retry.`;
+    }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     navError = msg;
@@ -309,7 +318,9 @@ const handler: ToolHandler = async (
   const summaryLine =
     status === 'ok'
       ? `validate_page ok — ${totalErrors} error(s), ${totalWarnings} warning(s), ${summary.interactiveCount} interactive elements (${durationMs}ms)`
-      : `validate_page ${status}${navError ? ': ' + navError : ''}`;
+      : status === 'auth_redirect_required'
+        ? `validate_page auth_redirect_required — redirected to ${authRedirect?.host ?? 'unknown'}`
+        : `validate_page ${status}${navError ? ': ' + navError : ''}`;
 
   return {
     content: [{ type: 'text', text: summaryLine }],
@@ -326,6 +337,11 @@ const handler: ToolHandler = async (
       totalWarnings,
     },
     summary,
+    ...(authRedirect && {
+      authRedirect: true,
+      redirectedFrom: authRedirect.from,
+      authRedirectHost: authRedirect.host,
+    }),
     ...(navError && { error: navError }),
   };
 };

--- a/tests/tools/validate-page.test.ts
+++ b/tests/tools/validate-page.test.ts
@@ -1,0 +1,229 @@
+/// <reference types="jest" />
+/**
+ * Tests for Validate Page Tool — covers regressions called out by Codex on PR #653:
+ *  - P1: smartGoto authRedirect was being silently dropped, so SSO/login redirects
+ *        looked like healthy pages.
+ *  - P2: normalizeUrl mishandled uppercase schemes ("HTTP://example.com" became
+ *        "https://HTTP://example.com").
+ */
+
+import { createMockSessionManager } from '../utils/mock-session';
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(),
+}));
+
+import type { SmartGotoResult } from '../../src/utils/smart-goto';
+
+// Variables prefixed with `mock` are accessible inside `jest.mock` factories.
+// Wrapped via getter so the factory references the binding lazily — `validate-page`
+// is loaded via dynamic import inside the handler describe-block, after this
+// const has been initialized, avoiding the TDZ error a static import would cause.
+const mockSmartGotoFn = jest.fn<Promise<SmartGotoResult>, [unknown, string, unknown?]>(
+  async () => ({ response: null }),
+);
+jest.mock('../../src/utils/smart-goto', () => ({
+  smartGoto: (...args: unknown[]) => mockSmartGotoFn(...(args as [unknown, string, unknown?])),
+}));
+
+import { getSessionManager } from '../../src/session-manager';
+
+interface ValidatePageResult {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  status: string;
+  authRedirect?: boolean;
+  redirectedFrom?: string;
+  authRedirectHost?: string;
+  error?: string;
+}
+
+// Lazy loader — defers requiring validate-page until after the mock module
+// graph above is registered with jest.
+const loadValidatePageModule = (): typeof import('../../src/tools/validate-page') => {
+  return require('../../src/tools/validate-page');
+};
+
+describe('normalizeUrl (P2 regression)', () => {
+  let normalizeUrl: (raw: string) => string;
+
+  beforeAll(() => {
+    normalizeUrl = loadValidatePageModule().normalizeUrl;
+  });
+
+  test('lowercase http:// is preserved', () => {
+    expect(normalizeUrl('http://example.com')).toBe('http://example.com');
+  });
+
+  test('lowercase https:// is preserved', () => {
+    expect(normalizeUrl('https://example.com/path')).toBe('https://example.com/path');
+  });
+
+  test('bare domain gets https:// prepended', () => {
+    expect(normalizeUrl('example.com')).toBe('https://example.com');
+  });
+
+  test('uppercase HTTP:// is normalized to lowercase, host preserved', () => {
+    expect(normalizeUrl('HTTP://example.com')).toBe('http://example.com');
+  });
+
+  test('uppercase HTTPS:// is normalized to lowercase, host preserved', () => {
+    expect(normalizeUrl('HTTPS://example.com/foo')).toBe('https://example.com/foo');
+  });
+
+  test('mixed-case Https:// is normalized to lowercase', () => {
+    expect(normalizeUrl('Https://Example.COM/Path')).toBe('https://Example.COM/Path');
+  });
+
+  test('uppercase scheme does NOT produce a doubled-scheme URL', () => {
+    const out = normalizeUrl('HTTP://example.com');
+    expect(out).not.toMatch(/https:\/\/HTTP:/i);
+    const parsed = new URL(out);
+    expect(parsed.hostname).toBe('example.com');
+    expect(parsed.protocol).toBe('http:');
+  });
+
+  test('rejects non-http schemes (lowercase)', () => {
+    expect(() => normalizeUrl('ftp://example.com')).toThrow(/not supported/);
+  });
+
+  test('rejects non-http schemes (uppercase)', () => {
+    expect(() => normalizeUrl('FTP://example.com')).toThrow(/not supported/);
+    expect(() => normalizeUrl('FILE:///etc/passwd')).toThrow(/not supported/);
+  });
+
+  test('rejects malformed URLs with no hostname', () => {
+    expect(() => normalizeUrl('https://')).toThrow();
+  });
+});
+
+describe('validate_page handler — auth redirect (P1 regression)', () => {
+  let mockSessionManager: ReturnType<typeof createMockSessionManager>;
+  let testSessionId: string;
+  let testTargetId: string;
+
+  const getValidatePageHandler = async () => {
+    jest.resetModules();
+    jest.doMock('../../src/session-manager', () => ({
+      getSessionManager: () => mockSessionManager,
+    }));
+    jest.doMock('../../src/utils/smart-goto', () => ({
+      smartGoto: (...args: unknown[]) => mockSmartGotoFn(...(args as [unknown, string, unknown?])),
+    }));
+    const { registerValidatePageTool } = await import('../../src/tools/validate-page');
+
+    const tools: Map<
+      string,
+      { handler: (sessionId: string, args: Record<string, unknown>) => Promise<unknown> }
+    > = new Map();
+    const mockServer = {
+      registerTool: (name: string, handler: unknown) => {
+        tools.set(name, {
+          handler: handler as (
+            sessionId: string,
+            args: Record<string, unknown>,
+          ) => Promise<unknown>,
+        });
+      },
+    };
+
+    registerValidatePageTool(
+      mockServer as unknown as Parameters<typeof registerValidatePageTool>[0],
+    );
+    return tools.get('validate_page')!.handler;
+  };
+
+  beforeEach(async () => {
+    mockSessionManager = createMockSessionManager();
+    (getSessionManager as jest.Mock).mockReturnValue(mockSessionManager);
+    mockSmartGotoFn.mockReset();
+    mockSmartGotoFn.mockResolvedValue({ response: null });
+
+    testSessionId = 'test-session-validate-page';
+    const created = await mockSessionManager.createTarget(testSessionId, 'about:blank');
+    testTargetId = created.targetId;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('marks status as auth_redirect_required when smartGoto reports a redirect', async () => {
+    mockSmartGotoFn.mockResolvedValue({
+      response: null,
+      authRedirect: {
+        from: 'https://app.example.com',
+        to: 'https://accounts.google.com/signin',
+        host: 'accounts.google.com',
+      },
+    });
+
+    const handler = await getValidatePageHandler();
+    const page = (await mockSessionManager.getPage(testSessionId, testTargetId))!;
+    (page.url as jest.Mock).mockReturnValue('https://accounts.google.com/signin');
+
+    const result = (await handler(testSessionId, {
+      tabId: testTargetId,
+      url: 'https://app.example.com',
+      captureConsoleMs: 0,
+    })) as ValidatePageResult;
+
+    expect(result.status).toBe('auth_redirect_required');
+    expect(result.authRedirect).toBe(true);
+    expect(result.redirectedFrom).toBe('https://app.example.com');
+    expect(result.authRedirectHost).toBe('accounts.google.com');
+    expect(result.error).toContain('accounts.google.com');
+    expect(result.content[0].text).toContain('auth_redirect_required');
+    expect(result.content[0].text).toContain('accounts.google.com');
+  });
+
+  test('returns status=ok with no authRedirect fields when smartGoto succeeds', async () => {
+    mockSmartGotoFn.mockResolvedValue({ response: null });
+
+    const handler = await getValidatePageHandler();
+    const page = (await mockSessionManager.getPage(testSessionId, testTargetId))!;
+    (page.url as jest.Mock).mockReturnValue('https://example.com');
+    (page.evaluate as jest.Mock).mockResolvedValue({
+      interactiveCount: 0,
+      formCount: 0,
+      hasCanvas: false,
+      hasIframe: false,
+      bodyTextSample: '',
+    });
+
+    const result = (await handler(testSessionId, {
+      tabId: testTargetId,
+      url: 'https://example.com',
+      captureConsoleMs: 0,
+    })) as ValidatePageResult;
+
+    expect(result.status).toBe('ok');
+    expect(result.authRedirect).toBeUndefined();
+    expect(result.redirectedFrom).toBeUndefined();
+    expect(result.authRedirectHost).toBeUndefined();
+  });
+
+  test('does not run waitForSelector when an auth redirect is detected', async () => {
+    mockSmartGotoFn.mockResolvedValue({
+      response: null,
+      authRedirect: {
+        from: 'https://app.example.com',
+        to: 'https://accounts.google.com/signin',
+        host: 'accounts.google.com',
+      },
+    });
+
+    const handler = await getValidatePageHandler();
+    const page = (await mockSessionManager.getPage(testSessionId, testTargetId))!;
+    (page.url as jest.Mock).mockReturnValue('https://accounts.google.com/signin');
+
+    await handler(testSessionId, {
+      tabId: testTargetId,
+      url: 'https://app.example.com',
+      waitForSelector: '#dashboard',
+      captureConsoleMs: 0,
+    });
+
+    expect(page.waitForSelector).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Two follow-ups to #653 that Codex flagged on the merge commit (`b31b559`) but were not addressed before merge:

- **P1 — Auth redirects silently treated as healthy.** [`validate_page` was discarding `smartGoto`'s `authRedirect` return value](https://github.com/shaun0927/openchrome/pull/653#discussion_r-codex-p1) so any SSO/login bounce (Google, Okta, Microsoft, Supabase, …) returned `status: 'ok'` while actually summarizing a login page. Now mirrors the contract `navigate` already exposes (`src/tools/navigate.ts:462-481`, `:775-794`):
  - `status: 'auth_redirect_required'`
  - `authRedirect: true`, `redirectedFrom`, `authRedirectHost`
  - `error` carries an `ACTION_REQUIRED`-style message
  - the optional `waitForSelector` gate is skipped when a redirect is detected (the page is on a login screen)
- **P2 — Uppercase URL schemes corrupted.** [`normalizeUrl`'s scheme detection was case-insensitive but the follow-up `startsWith('http://')` check was case-sensitive](https://github.com/shaun0927/openchrome/pull/653#discussion_r-codex-p2), so `HTTP://example.com` became `https://HTTP://example.com` (host parsed as `http`, real host swallowed into the path). Lowercase the scheme once after detection and drop the redundant `startsWith` branch.

## Tests

New `tests/tools/validate-page.test.ts` — 13 cases:
- **10** for `normalizeUrl`: lowercase preserved, bare-domain prepended, uppercase `HTTP://`/`HTTPS://`/`Https://` normalized, no doubled-scheme regression, non-http (lowercase + uppercase, e.g. `FILE:///etc/passwd`) rejected, malformed URL rejected.
- **3** for the handler: auth-redirect path sets the new status + fields, success path leaves them undefined, redirect path skips `waitForSelector`.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — **3595 pass**, 0 fail (86 pre-existing skipped)
- [x] New `validate-page.test.ts` — 13/13 pass
- [ ] Reviewer eyeballs the new `auth_redirect_required` status value (added to the union type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)