### PR TITLE
feat(#658): generic login-failure detection in fill_form

### DIFF
--- a/src/tools/fill-form.ts
+++ b/src/tools/fill-form.ts
@@ -15,6 +15,7 @@ import { resolveElementsByAXTree, invalidateAXCache } from '../utils/ax-element-
 import { getTargetId } from '../utils/puppeteer-helpers';
 import { normalizeQuery } from '../utils/element-finder';
 import { humanType, humanMouseMove } from '../stealth/human-behavior';
+import { detectLoginOutcome, LoginDetectResult } from './login-detector';
 
 const definition: MCPToolDefinition = {
   name: 'fill_form',
@@ -49,6 +50,11 @@ const definition: MCPToolDefinition = {
         type: 'number',
         description: 'Poll interval in ms (50-2000). Default: 300',
       },
+      loginCheck: {
+        type: 'string',
+        enum: ['auto', 'off'],
+        description: 'After submit, run a generic login-failure detector that flips success → failure when the password form is still mounted. Default: "auto". Set "off" to restore pre-#658 behavior.',
+      },
     },
     required: ['tabId', 'fields'],
   },
@@ -67,6 +73,7 @@ const handler: ToolHandler = async (
   const clearFirst = args.clear_first !== false; // Default to true
   const waitForMs = args.waitForMs as number | undefined;
   const pollInterval = Math.min(Math.max((args.pollInterval as number) || 300, 50), 2000);
+  const loginCheck: 'auto' | 'off' = (args.loginCheck === 'off') ? 'off' : 'auto';
 
   const sessionManager = getSessionManager();
 
@@ -341,6 +348,7 @@ const handler: ToolHandler = async (
       }
 
       // Optional: Click submit button
+      let loginResult: LoginDetectResult | null = null;
       if (submit && filledFields.length > 0) {
         try {
           const submitLower = normalizeQuery(submit);
@@ -374,9 +382,32 @@ const handler: ToolHandler = async (
           }, submitLower), 10000, 'fill_form', context);
 
           if (submitButton) {
+            // #658: capture pre-submit URL/origin BEFORE the click for the login-outcome detector.
+            const preSubmitUrl = page.url();
+            let preSubmitOrigin = '';
+            try { preSubmitOrigin = new URL(preSubmitUrl).origin; } catch { preSubmitOrigin = ''; }
+
             await page.mouse.click(Math.round(submitButton.x), Math.round(submitButton.y));
             submitted = true;
             await new Promise(resolve => setTimeout(resolve, DEFAULT_FORM_SUBMIT_SETTLE_MS));
+
+            // #658: Detect generic login failure (form still mounted, error banner, no nav).
+            // Only runs when (a) the user opted in (loginCheck !== 'off'), (b) the form
+            // contained a password field. We check (b) by sniffing the page after submit;
+            // forms without a password field skip the detector entirely so non-login
+            // submissions are unaffected.
+            if (loginCheck === 'auto') {
+              try {
+                const hasPasswordField = await page.evaluate(
+                  () => document.querySelector('input[type="password"]') !== null,
+                );
+                if (hasPasswordField) {
+                  loginResult = await detectLoginOutcome(page as any, { preSubmitOrigin, preSubmitUrl });
+                }
+              } catch {
+                // Detector errors are non-fatal — leave loginResult null.
+              }
+            }
           } else {
             errors.push(`Could not find submit button matching "${submit}"`);
           }
@@ -385,7 +416,7 @@ const handler: ToolHandler = async (
           errors.push(`Failed to submit: ${e instanceof Error ? e.message : String(e)}`);
         }
       }
-      return { submitted };
+      return { submitted, loginResult };
     }, { settleMs: 200 });
 
     // Build compact result message
@@ -409,6 +440,21 @@ const handler: ToolHandler = async (
       resultParts.push(`Errors: ${errors.join('; ')}`);
     }
 
+    // #658: surface login-detector outcome.
+    const loginOutcome = formResult.loginResult;
+    if (loginOutcome && loginOutcome.outcome === 'failed') {
+      resultParts.push(`Login appears to have failed: ${loginOutcome.reason}`);
+    } else if (loginOutcome && loginOutcome.outcome === 'success') {
+      resultParts.push(`Login appears successful: ${loginOutcome.reason}`);
+    }
+
+    // Failure conditions (in priority order):
+    //   1. Submit was attempted, the page still shows the login form, and the
+    //      detector classified the outcome as 'failed' (#658).
+    //   2. Errors collected during fill AND no fields were filled.
+    const detectorFailedLogin = loginOutcome?.outcome === 'failed';
+    const isError = detectorFailedLogin || (errors.length > 0 && filledFields.length === 0);
+
     return {
       content: [
         {
@@ -416,8 +462,9 @@ const handler: ToolHandler = async (
           text: resultParts.join('\n') + (delta || ''),
         },
       ],
-      isError: errors.length > 0 && filledFields.length === 0,
-    };
+      isError,
+      ...(detectorFailedLogin ? { _meta: { errorReason: 'login_failed', loginCheckReason: loginOutcome.reason } } : {}),
+    } as MCPResult;
   } catch (error) {
     return {
       content: [

--- a/src/tools/fill-form.ts
+++ b/src/tools/fill-form.ts
@@ -365,6 +365,11 @@ const handler: ToolHandler = async (
           // Find submit button + report whether its enclosing <form> contains a
           // password field. The form-scoped check rules out unrelated password
           // inputs elsewhere on the page.
+          //
+          // codex P2 review on #669: a submit button can target a form via the
+          // `form` attribute while being OUTSIDE that form's DOM subtree. We
+          // therefore prefer `el.form` (HTMLFormElement-style API) when
+          // present and fall back to `el.closest('form')`.
           const submitButton = await withTimeout(page.evaluate((query: string): { x: number; y: number; formHasPassword: boolean } | null => {
             const queryLower = query.toLowerCase();
             const selectors = [
@@ -384,7 +389,11 @@ const handler: ToolHandler = async (
                 if (text.includes(queryLower) || queryLower.includes(text.trim())) {
                   const rect = el.getBoundingClientRect();
                   if (rect.width > 0 && rect.height > 0) {
-                    const form = el.closest('form');
+                    // Prefer the HTMLButtonElement / HTMLInputElement `.form`
+                    // accessor — handles `<button form="loginForm">` cases that
+                    // `closest('form')` misses.
+                    let form: HTMLFormElement | null = (el as HTMLButtonElement | HTMLInputElement).form ?? null;
+                    if (!form) form = el.closest('form');
                     const formHasPassword = form
                       ? form.querySelector('input[type="password"]') !== null
                       : false;
@@ -415,11 +424,32 @@ const handler: ToolHandler = async (
             // Run the detector iff (a) caller opted in and (b) the submitted
             // form was a login form (decided pre-submit, so success is reachable
             // even when the page has navigated away).
+            //
+            // codex P1 review on #669: a single 100ms probe is too short for
+            // real-world latency — successful logins often stay on the form
+            // for >100ms before the redirect lands, producing false 'failed'.
+            // Poll up to ~3s, returning EARLY on the first definitive result
+            // (success → fast; unknown stays cheap; only failed waits the
+            // full window before locking in).
             if (loginCheck === 'auto' && submitTargetIsLogin) {
+              const detectorDeadline = Date.now() + 3000;
+              loginResult = null;
               try {
-                loginResult = await detectLoginOutcome(page as any, { preSubmitOrigin, preSubmitUrl });
+                while (Date.now() < detectorDeadline) {
+                  const probe = await detectLoginOutcome(page as any, { preSubmitOrigin, preSubmitUrl });
+                  if (probe.outcome === 'success') {
+                    loginResult = probe;
+                    break;
+                  }
+                  // Keep the latest snapshot as the working answer; only
+                  // commit to 'failed' after the full window to give
+                  // delayed redirects a chance to land.
+                  loginResult = probe;
+                  if (probe.outcome === 'unknown') break;
+                  await new Promise(resolve => setTimeout(resolve, 200));
+                }
               } catch {
-                // Detector errors are non-fatal — leave loginResult null.
+                // Detector errors are non-fatal — keep whatever loginResult is set.
               }
             }
           } else {

--- a/src/tools/fill-form.ts
+++ b/src/tools/fill-form.ts
@@ -349,12 +349,23 @@ const handler: ToolHandler = async (
 
       // Optional: Click submit button
       let loginResult: LoginDetectResult | null = null;
+      // #658 (codex P1 + gemini medium): we have to decide PRE-submit whether
+      // this is a login form, scoped to the *form being submitted*. Doing the
+      // password-field check post-submit causes two failure modes:
+      //   (a) successful logins navigate away → password field gone → success
+      //       outcome is never reported.
+      //   (b) pages with a persistent password form (e.g. account settings)
+      //       plus an unrelated form being submitted → detector wrongly fires.
+      let submitTargetIsLogin = false;
+      let submitErrored = false;
       if (submit && filledFields.length > 0) {
         try {
           const submitLower = normalizeQuery(submit);
 
-          // Find submit button
-          const submitButton = await withTimeout(page.evaluate((query: string): { x: number; y: number } | null => {
+          // Find submit button + report whether its enclosing <form> contains a
+          // password field. The form-scoped check rules out unrelated password
+          // inputs elsewhere on the page.
+          const submitButton = await withTimeout(page.evaluate((query: string): { x: number; y: number; formHasPassword: boolean } | null => {
             const queryLower = query.toLowerCase();
             const selectors = [
               'button[type="submit"]',
@@ -373,7 +384,15 @@ const handler: ToolHandler = async (
                 if (text.includes(queryLower) || queryLower.includes(text.trim())) {
                   const rect = el.getBoundingClientRect();
                   if (rect.width > 0 && rect.height > 0) {
-                    return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+                    const form = el.closest('form');
+                    const formHasPassword = form
+                      ? form.querySelector('input[type="password"]') !== null
+                      : false;
+                    return {
+                      x: rect.x + rect.width / 2,
+                      y: rect.y + rect.height / 2,
+                      formHasPassword,
+                    };
                   }
                 }
               }
@@ -382,6 +401,8 @@ const handler: ToolHandler = async (
           }, submitLower), 10000, 'fill_form', context);
 
           if (submitButton) {
+            submitTargetIsLogin = submitButton.formHasPassword === true;
+
             // #658: capture pre-submit URL/origin BEFORE the click for the login-outcome detector.
             const preSubmitUrl = page.url();
             let preSubmitOrigin = '';
@@ -391,32 +412,29 @@ const handler: ToolHandler = async (
             submitted = true;
             await new Promise(resolve => setTimeout(resolve, DEFAULT_FORM_SUBMIT_SETTLE_MS));
 
-            // #658: Detect generic login failure (form still mounted, error banner, no nav).
-            // Only runs when (a) the user opted in (loginCheck !== 'off'), (b) the form
-            // contained a password field. We check (b) by sniffing the page after submit;
-            // forms without a password field skip the detector entirely so non-login
-            // submissions are unaffected.
-            if (loginCheck === 'auto') {
+            // Run the detector iff (a) caller opted in and (b) the submitted
+            // form was a login form (decided pre-submit, so success is reachable
+            // even when the page has navigated away).
+            if (loginCheck === 'auto' && submitTargetIsLogin) {
               try {
-                const hasPasswordField = await page.evaluate(
-                  () => document.querySelector('input[type="password"]') !== null,
-                );
-                if (hasPasswordField) {
-                  loginResult = await detectLoginOutcome(page as any, { preSubmitOrigin, preSubmitUrl });
-                }
+                loginResult = await detectLoginOutcome(page as any, { preSubmitOrigin, preSubmitUrl });
               } catch {
                 // Detector errors are non-fatal — leave loginResult null.
               }
             }
           } else {
+            // No submit button = the user asked us to submit but we couldn't.
+            // Per qodo Action#1: this is a real failure even if some fields filled.
+            submitErrored = true;
             errors.push(`Could not find submit button matching "${submit}"`);
           }
         } catch (e) {
           throwIfAborted(context);
+          submitErrored = true;
           errors.push(`Failed to submit: ${e instanceof Error ? e.message : String(e)}`);
         }
       }
-      return { submitted, loginResult };
+      return { submitted, loginResult, submitErrored };
     }, { settleMs: 200 });
 
     // Build compact result message
@@ -449,11 +467,25 @@ const handler: ToolHandler = async (
     }
 
     // Failure conditions (in priority order):
-    //   1. Submit was attempted, the page still shows the login form, and the
-    //      detector classified the outcome as 'failed' (#658).
-    //   2. Errors collected during fill AND no fields were filled.
+    //   1. Submit was attempted but the click target wasn't found OR threw —
+    //      a true submit failure that should never be hidden behind partial
+    //      field fills (qodo Action#1 review on #669).
+    //   2. The login-outcome detector returned 'failed' (#658).
+    //   3. Errors collected during fill AND no fields were filled.
     const detectorFailedLogin = loginOutcome?.outcome === 'failed';
-    const isError = detectorFailedLogin || (errors.length > 0 && filledFields.length === 0);
+    const submitFailed = formResult.submitErrored === true;
+    const isError =
+      submitFailed ||
+      detectorFailedLogin ||
+      (errors.length > 0 && filledFields.length === 0);
+
+    // qodo Action#2: surface a structured errorReason at the top level so
+    // callers can branch on it without parsing the result text or reaching
+    // into _meta. We keep _meta for back-compat with anything that already
+    // reads it.
+    let errorReason: string | undefined;
+    if (detectorFailedLogin) errorReason = 'login_failed';
+    else if (submitFailed) errorReason = 'submit_failed';
 
     return {
       content: [
@@ -463,7 +495,12 @@ const handler: ToolHandler = async (
         },
       ],
       isError,
-      ...(detectorFailedLogin ? { _meta: { errorReason: 'login_failed', loginCheckReason: loginOutcome.reason } } : {}),
+      ...(errorReason ? { errorReason } : {}),
+      ...(detectorFailedLogin
+        ? { _meta: { errorReason: 'login_failed', loginCheckReason: loginOutcome.reason } }
+        : submitFailed
+          ? { _meta: { errorReason: 'submit_failed' } }
+          : {}),
     } as MCPResult;
   } catch (error) {
     return {

--- a/src/tools/login-detector.ts
+++ b/src/tools/login-detector.ts
@@ -1,0 +1,207 @@
+/**
+ * Login-failure detector (#658).
+ *
+ * Today, openchrome silently returns `success: true` from `fill_form` even
+ * when authentication actually failed. This detector adds a single, generic
+ * post-submit check based on three site-agnostic signals:
+ *
+ *   1. The login form itself is still mounted with an empty password field
+ *      (universal "you got bounced back" signal).
+ *   2. An ARIA-error element (role=alert, aria-live=assertive,
+ *      [data-testid*="error"]) appeared with non-empty text.
+ *   3. The page navigated away from the login origin (treated as success).
+ *
+ * Higher-confidence network-level signals (HTTP 4xx on the form POST,
+ * Set-Cookie comparisons) are intentionally out of scope here because they
+ * would require CDP Network-domain plumbing that is mostly orthogonal to
+ * this PR. Adding them later is straightforward: extend the detector's
+ * decision matrix without changing call sites.
+ *
+ * The detector is **conservative**: it only returns `'failed'` on a strong
+ * signal. Ambiguous cases return `'unknown'` so existing successful flows
+ * are never regressed (issue #658 design constraint #1).
+ */
+
+import type { Page } from 'puppeteer-core';
+
+export type LoginOutcome = 'success' | 'failed' | 'unknown';
+
+export interface LoginDetectInput {
+  /** Origin (URL) of the page when the form-submit click was issued. */
+  preSubmitOrigin: string;
+  /** URL of the page when the form-submit click was issued. */
+  preSubmitUrl: string;
+}
+
+export interface LoginDetectResult {
+  outcome: LoginOutcome;
+  /** Human-readable reason for the outcome (for logging / tool responses). */
+  reason: string;
+}
+
+/**
+ * Heuristic: does an element look like a "submit a login form" button?
+ * Defined here rather than inline so call sites can share the rule.
+ *
+ * Site-agnostic and tested via the fixtures in tests/tools/login-detector.test.ts:
+ * - Native `input[type="submit"]` / `button[type="submit"]`
+ * - `button` or `[role="button"]` whose nearest `form` ancestor contains an
+ *   `input[type="password"]`. (Most "Sign in" buttons satisfy this.)
+ *
+ * Closed shadow DOM is out of scope — login forms inside closed shadow roots
+ * are rare; document the limitation rather than reach into them.
+ */
+export const isSubmitButtonScript = `
+(function isSubmitButton(target) {
+  if (!target || !(target instanceof Element)) return false;
+  if (target.matches && target.matches('input[type="submit"], button[type="submit"]')) return true;
+  if (target.matches && target.matches('button, [role="button"]')) {
+    const form = target.closest('form');
+    if (!form) return false;
+    return !!form.querySelector('input[type="password"]');
+  }
+  return false;
+})
+`;
+
+/**
+ * Result of the in-page detection script. Each field is independently
+ * checked so the host can produce a richer reason string.
+ */
+export interface InPageSignals {
+  /** Same login form still mounted (form root contains an empty password input). */
+  loginFormStillMounted: boolean;
+  /** Visible ARIA-error / data-testid=error element with non-empty text. */
+  ariaErrorText: string | null;
+  /** Page URL after submit (for change detection). */
+  currentUrl: string;
+  /** document.title after submit (debug-only; not used in classification). */
+  title: string;
+}
+
+/**
+ * In-page script: collects the structural signals from the live DOM.
+ * Designed to be evaluated via `page.evaluate()` so tests can stub the page
+ * with a fake `evaluate` implementation.
+ */
+export const detectionScript = `
+(function detectLoginOutcomeSignals() {
+  function isVisible(el) {
+    if (!(el instanceof HTMLElement)) return false;
+    const style = window.getComputedStyle(el);
+    if (style.display === 'none' || style.visibility === 'hidden') return false;
+    const rect = el.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  }
+
+  // Signal 1: any <form> still mounted with an empty password input?
+  let loginFormStillMounted = false;
+  for (const form of Array.from(document.querySelectorAll('form'))) {
+    const pw = form.querySelector('input[type="password"]');
+    if (pw && isVisible(pw)) {
+      loginFormStillMounted = true;
+      break;
+    }
+  }
+
+  // Signal 2: ARIA-error element with non-empty text.
+  const errorSelectors = [
+    '[role="alert"]',
+    '[aria-live="assertive"]',
+    '[aria-live="polite"]',
+    '[data-testid*="error" i]',
+    '[data-test*="error" i]',
+    '[class*="error" i]',
+  ];
+  let ariaErrorText = null;
+  for (const sel of errorSelectors) {
+    for (const el of Array.from(document.querySelectorAll(sel))) {
+      if (!isVisible(el)) continue;
+      const text = (el.textContent || '').trim();
+      if (text.length === 0) continue;
+      // Avoid false-positives on huge regions (entire wrappers labelled "errors")
+      if (text.length > 240) continue;
+      ariaErrorText = text;
+      break;
+    }
+    if (ariaErrorText) break;
+  }
+
+  return {
+    loginFormStillMounted: loginFormStillMounted,
+    ariaErrorText: ariaErrorText,
+    currentUrl: location.href,
+    title: document.title,
+  };
+})()
+`;
+
+/**
+ * Classify in-page signals + URL change into a LoginOutcome.
+ *
+ * Pure function: separated from the page evaluation so it can be unit-tested
+ * without spinning up Chrome.
+ */
+export function classifyLoginSignals(
+  signals: InPageSignals,
+  input: LoginDetectInput,
+): LoginDetectResult {
+  // Strong success: navigated away from the login origin.
+  let currentOrigin = '';
+  try {
+    currentOrigin = new URL(signals.currentUrl).origin;
+  } catch {
+    currentOrigin = '';
+  }
+
+  if (currentOrigin && currentOrigin !== input.preSubmitOrigin) {
+    return { outcome: 'success', reason: `navigated to ${currentOrigin}` };
+  }
+  if (signals.currentUrl !== input.preSubmitUrl && signals.currentUrl.length > 0 && currentOrigin === input.preSubmitOrigin) {
+    // Same-origin path change: treat as success (e.g. /login → /dashboard).
+    // The form is gone (we still check below).
+    if (!signals.loginFormStillMounted) {
+      return { outcome: 'success', reason: `navigated to ${signals.currentUrl}` };
+    }
+  }
+
+  // Strong failure: form still mounted AND we did not navigate away.
+  if (signals.loginFormStillMounted && signals.currentUrl === input.preSubmitUrl) {
+    if (signals.ariaErrorText) {
+      return { outcome: 'failed', reason: `login form still mounted; error banner: "${signals.ariaErrorText}"` };
+    }
+    return { outcome: 'failed', reason: 'login form still mounted; submit had no effect' };
+  }
+
+  // Same URL but form is gone — likely an SPA mid-transition. Avoid claiming
+  // failure (could be a 2FA challenge or a magic-link "check your email" page).
+  if (signals.ariaErrorText && signals.loginFormStillMounted) {
+    return { outcome: 'failed', reason: `login error banner: "${signals.ariaErrorText}"` };
+  }
+
+  return { outcome: 'unknown', reason: 'no decisive signal' };
+}
+
+/**
+ * High-level helper: snapshot the page, classify, return a result.
+ *
+ * `page` can be any object exposing `url(): string` and
+ * `evaluate(script: string): Promise<InPageSignals>` — we intentionally
+ * keep the type structural so tests can hand in a fake.
+ */
+export async function detectLoginOutcome(
+  page: Pick<Page, 'url'> & { evaluate: (script: string) => Promise<unknown> },
+  input: LoginDetectInput,
+): Promise<LoginDetectResult> {
+  let signals: InPageSignals;
+  try {
+    const raw = await page.evaluate(detectionScript);
+    signals = raw as InPageSignals;
+    if (!signals || typeof signals !== 'object') {
+      return { outcome: 'unknown', reason: 'detector evaluation returned no data' };
+    }
+  } catch (err) {
+    return { outcome: 'unknown', reason: `detector error: ${(err as Error).message}` };
+  }
+  return classifyLoginSignals(signals, input);
+}

--- a/tests/tools/login-detector.test.ts
+++ b/tests/tools/login-detector.test.ts
@@ -1,0 +1,112 @@
+import { classifyLoginSignals, detectLoginOutcome, InPageSignals } from '../../src/tools/login-detector';
+
+function signals(overrides: Partial<InPageSignals> = {}): InPageSignals {
+  return {
+    loginFormStillMounted: false,
+    ariaErrorText: null,
+    currentUrl: 'https://example.com/login',
+    title: 'Login',
+    ...overrides,
+  };
+}
+
+describe('classifyLoginSignals (#658)', () => {
+  const PRE = { preSubmitOrigin: 'https://example.com', preSubmitUrl: 'https://example.com/login' };
+
+  it('cross-origin navigation → success', () => {
+    expect(classifyLoginSignals(signals({ currentUrl: 'https://app.example.com/dashboard' }), PRE).outcome).toBe('success');
+  });
+
+  it('same-origin path change with form gone → success', () => {
+    expect(classifyLoginSignals(signals({
+      currentUrl: 'https://example.com/dashboard',
+      loginFormStillMounted: false,
+    }), PRE).outcome).toBe('success');
+  });
+
+  it('form still mounted, same URL → failed (no banner)', () => {
+    const r = classifyLoginSignals(signals({ loginFormStillMounted: true }), PRE);
+    expect(r.outcome).toBe('failed');
+    expect(r.reason).toContain('still mounted');
+  });
+
+  it('form still mounted, error banner present → failed (banner in reason)', () => {
+    const r = classifyLoginSignals(signals({
+      loginFormStillMounted: true,
+      ariaErrorText: 'Invalid email or password',
+    }), PRE);
+    expect(r.outcome).toBe('failed');
+    expect(r.reason).toContain('Invalid email or password');
+  });
+
+  it('form gone, same URL (SPA mid-transition) → unknown (don\'t false-positive)', () => {
+    expect(classifyLoginSignals(signals({ loginFormStillMounted: false }), PRE).outcome).toBe('unknown');
+  });
+
+  it('2FA: form gone, URL unchanged briefly → unknown (NOT failed)', () => {
+    expect(classifyLoginSignals(signals({
+      loginFormStillMounted: false,
+      currentUrl: 'https://example.com/login',
+    }), PRE).outcome).toBe('unknown');
+  });
+
+  it('magic-link page: same origin, form gone, has banner → unknown', () => {
+    // "Check your email" banner is typically positive UI, not a login error.
+    // Detector should NOT mark as failed when form is gone.
+    expect(classifyLoginSignals(signals({
+      loginFormStillMounted: false,
+      ariaErrorText: 'Check your email for the magic link',
+    }), PRE).outcome).toBe('unknown');
+  });
+
+  it('malformed currentUrl falls back to unknown rather than throwing', () => {
+    expect(classifyLoginSignals(signals({ currentUrl: 'not-a-url' }), PRE).outcome).toBe('unknown');
+  });
+});
+
+describe('detectLoginOutcome', () => {
+  it('returns unknown when page.evaluate throws', async () => {
+    const fakePage = {
+      url: () => 'https://example.com/login',
+      evaluate: () => Promise.reject(new Error('detached frame')),
+    };
+    const result = await detectLoginOutcome(fakePage as any, {
+      preSubmitOrigin: 'https://example.com',
+      preSubmitUrl: 'https://example.com/login',
+    });
+    expect(result.outcome).toBe('unknown');
+    expect(result.reason).toContain('detector error');
+  });
+
+  it('passes through structured failure signal', async () => {
+    const fakePage = {
+      url: () => 'https://example.com/login',
+      evaluate: () =>
+        Promise.resolve({
+          loginFormStillMounted: true,
+          ariaErrorText: 'Wrong password',
+          currentUrl: 'https://example.com/login',
+          title: 'Login',
+        } as InPageSignals),
+    };
+    const result = await detectLoginOutcome(fakePage as any, {
+      preSubmitOrigin: 'https://example.com',
+      preSubmitUrl: 'https://example.com/login',
+    });
+    expect(result.outcome).toBe('failed');
+    expect(result.reason).toContain('Wrong password');
+  });
+
+  it('returns unknown when page.evaluate returns null', async () => {
+    const fakePage = {
+      url: () => 'https://example.com/login',
+      evaluate: () => Promise.resolve(null),
+    };
+    const result = await detectLoginOutcome(fakePage as any, {
+      preSubmitOrigin: 'https://example.com',
+      preSubmitUrl: 'https://example.com/login',
+    });
+    expect(result.outcome).toBe('unknown');
+    expect(result.reason).toContain('no data');
+  });
+});


### PR DESCRIPTION
Closes #658 (focused scope — see "Out of scope" below).

## Summary

Today, `fill_form` returns `success: true` even when the password was wrong, because nothing in the codebase looks for "you got bounced back" signals. This PR adds a small, site-agnostic detector and wires it into the post-submit path of `fill_form` so a failed login surfaces as `isError: true` with a clear reason.

## Decision matrix (intentionally conservative)

False positives are worse than false negatives — they break working flows. The detector only returns `'failed'` on a strong signal; ambiguous cases stay `'unknown'`.

| Signal | Outcome |
| --- | --- |
| Cross-origin navigation away from login origin | success |
| Same-origin path change AND form unmounted | success |
| Login form still mounted at the same URL | **failed** |
| Login form still mounted with ARIA-error banner | **failed** (banner in reason) |
| Form unmounted at same URL (SPA / 2FA / magic-link) | unknown — DO NOT regress |
| URL parse failure / detector exception | unknown |

The detector **only runs when the submitted form contained a password field**. Non-login submits keep their previous behavior unchanged.

## Changes

- new: `src/tools/login-detector.ts`
  - `detectionScript` — in-page DOM signals
  - `classifyLoginSignals(signals, input)` — pure decision matrix (unit-testable)
  - `detectLoginOutcome(page, input)` — high-level helper
  - Exports `LoginOutcome`, `LoginDetectResult`, `InPageSignals`
- modified: `src/tools/fill-form.ts`
  - new optional input parameter `loginCheck: 'auto' | 'off'` (default `'auto'`)
  - capture pre-submit URL/origin before the click
  - after settle, if the form had a password field, run the detector
  - emit `Login appears to have failed: …` line in tool text
  - flip `isError: true` when detector returns `'failed'`
  - attach `_meta.errorReason='login_failed'` so callers can branch
- new: `tests/tools/login-detector.test.ts` (11 cases)

## Out of scope (deferred to follow-up issues)

The full #658 spec listed five phases. This PR ships **Phase 1 + 2** (detector + fill_form integration). Other phases are deferred to keep the diff focused and reviewable:

- ⏭️ Phase 3 — `navigate.ts` `.catch(e => null)` audit. Wide blast radius; will be its own PR.
- ⏭️ Phase 4 — `act.ts` `SILENT_CLICK` reclassification on submit-button targets. Touches the step-loop; deserves its own review.
- ⏭️ Phase 1 (weak signals) — multilingual error glossary, HTTP 4xx / Set-Cookie network checks. Easy extensions of the matrix; defer until needed by a real failure mode.

The current Phase 1 + 2 already eliminates the original symptom (silent `success: true` on wrong password) for `fill_form`, which is the user-reported case.

## Backwards compatibility

| Scenario | Old | New |
|---|---|---|
| `fill_form` on a non-login form | unchanged | **unchanged** (no password field → detector skipped) |
| `fill_form` on login with correct creds and navigation | `success: true` | `success: true` (cross-origin → detector returns `success`) |
| `fill_form` on login with wrong creds, form re-renders | `success: true` (silent fail) | `isError: true`, `errorReason: 'login_failed'` |
| `loginCheck: 'off'` | n/a (new param) | restores pre-#658 behavior |
| Detector exception (e.g. detached frame mid-detection) | n/a | falls through as `'unknown'` — no regression |

## Test plan

- [x] `npm run build` clean.
- [x] 11 new `login-detector` cases pass.
- [x] Full suite: 3593 passed, 86 skipped, 0 failed.

## Manual verification (post-merge)

- A login flow with correct credentials on any public IdP → `success: true` (no regression).
- A login flow with deliberately wrong credentials → `isError: true`, response text starts `Login appears to have failed: …`.
- 2FA challenge after correct password → `unknown` (so the agent can proceed to the next step without false-failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)