### PR TITLE
Support OpenCode setup client

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,11 @@ npx openchrome-mcp setup
 npx openchrome-mcp setup --client codex
 ```
 
+**OpenCode**
+```bash
+npx openchrome-mcp setup --client opencode
+```
+
 One command. Configures the MCP server for the selected client.
 Restart your MCP client after setup completes.
 
@@ -239,6 +244,20 @@ claude mcp add openchrome -- npx -y openchrome-mcp@latest serve --auto-launch
     "openchrome": {
       "command": "npm",
       "args": ["exec", "--yes", "--prefer-online", "openchrome-mcp@latest", "--", "serve", "--auto-launch"]
+    }
+  }
+}
+```
+
+
+**OpenCode** (`~/.config/opencode/opencode.json`):
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "openchrome": {
+      "type": "local",
+      "command": ["npx", "--prefer-online", "-y", "openchrome-mcp@latest", "serve", "--auto-launch"]
     }
   }
 }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -27,8 +27,11 @@ import {
   getClaudeManualServerConfig,
   getClaudeSetupCommand,
   getCodexServerConfig,
+  getOpenCodeServerConfig,
+  formatOpenCodeMCPServerConfigSnippet,
   getSupportedMCPClients,
   isSupportedMCPClient,
+  upsertOpenCodeMCPServerConfig,
   upsertMCPServerConfig,
 } from './mcp-client-config';
 import {
@@ -95,8 +98,8 @@ program
 
 program
   .command('setup')
-  .description('Automatically configure MCP server for Claude Code or Codex CLI')
-  .option('--client <client>', 'Client to configure: "claude" (default) or "codex"', 'claude')
+  .description('Automatically configure MCP server for Claude Code, Codex CLI, or OpenCode')
+  .option('--client <client>', 'Client to configure: "claude" (default), "codex", or "opencode"', 'claude')
   .option('--dashboard', 'Enable terminal dashboard')
   .option('--auto-launch', 'Auto-launch Chrome if not running (default: true)')
   .option('-s, --scope <scope>', 'Installation scope: "user" (global, default) or "project" (current project only)', 'user')
@@ -205,6 +208,43 @@ program
       return;
     }
 
+    if (client === 'opencode') {
+      if (scope !== 'user') {
+        console.warn('⚠️  Scope is not used for OpenCode; writing to ~/.config/opencode/opencode.json.');
+      }
+
+      const openCodeServerConfig = getOpenCodeServerConfig(serveArgOptions);
+      try {
+        const openCodeConfigPath = path.join(os.homedir(), '.config', 'opencode', 'opencode.json');
+        fs.mkdirSync(path.dirname(openCodeConfigPath), { recursive: true });
+
+        let config: Record<string, unknown> = { $schema: 'https://opencode.ai/config.json' };
+        if (fs.existsSync(openCodeConfigPath)) {
+          config = JSON.parse(fs.readFileSync(openCodeConfigPath, 'utf8'));
+        }
+
+        const updatedConfig = upsertOpenCodeMCPServerConfig(config, 'openchrome', openCodeServerConfig);
+        fs.writeFileSync(openCodeConfigPath, JSON.stringify(updatedConfig, null, 2) + '\n');
+
+        console.log('\n✅ MCP server configured successfully!\n');
+        console.log(`Config file: ${openCodeConfigPath}`);
+        console.log('Auto-updates: enabled (via npx)\n');
+        console.log('Next steps:');
+        console.log('  1. Restart OpenCode');
+        console.log('  2. Verify the openchrome MCP server reconnects cleanly\n');
+        console.log('Installed MCP snippet:');
+        console.log(formatOpenCodeMCPServerConfigSnippet('openchrome', openCodeServerConfig));
+      } catch (error) {
+        console.error('\n❌ Failed to configure MCP server for OpenCode.');
+        console.error(`   ${error instanceof Error ? error.message : String(error)}`);
+        console.error('   You can manually add this to ~/.config/opencode/opencode.json:');
+        console.error(formatOpenCodeMCPServerConfigSnippet('openchrome', openCodeServerConfig));
+        process.exit(1);
+      }
+
+      return;
+    }
+
     if (scope !== 'user') {
       console.warn('⚠️  Scope is not used for Codex CLI; writing to ~/.codex/mcp.json.');
     }
@@ -241,7 +281,7 @@ program
 program
   .command('config')
   .description('Print MCP configuration for a supported client')
-  .requiredOption('--client <client>', 'Client to generate config for: "claude" or "codex"')
+  .requiredOption('--client <client>', 'Client to generate config for: "claude", "codex", or "opencode"')
   .option('--dashboard', 'Enable terminal dashboard')
   .option('--auto-launch', 'Auto-launch Chrome if not running (default: true)')
   .action((options: { client: string; dashboard?: boolean; autoLaunch?: boolean }) => {
@@ -254,6 +294,11 @@ program
 
     if (options.client === 'claude') {
       console.log(['claude', ...getClaudeSetupCommand('user', serveArgOptions)].join(' '));
+      return;
+    }
+
+    if (options.client === 'opencode') {
+      console.log(formatOpenCodeMCPServerConfigSnippet('openchrome', getOpenCodeServerConfig(serveArgOptions)));
       return;
     }
 

--- a/cli/mcp-client-config.ts
+++ b/cli/mcp-client-config.ts
@@ -1,4 +1,4 @@
-export type SupportedMCPClient = 'claude' | 'codex';
+export type SupportedMCPClient = 'claude' | 'codex' | 'opencode';
 export type SetupScope = 'user' | 'project';
 
 export interface ServeArgOptions {
@@ -27,7 +27,7 @@ export interface OpenCodeConfigDocument {
   [key: string]: unknown;
 }
 
-const SUPPORTED_CLIENTS: SupportedMCPClient[] = ['claude', 'codex'];
+const SUPPORTED_CLIENTS: SupportedMCPClient[] = ['claude', 'codex', 'opencode'];
 
 export function getSupportedMCPClients(): SupportedMCPClient[] {
   return [...SUPPORTED_CLIENTS];
@@ -38,7 +38,14 @@ export function isSupportedMCPClient(value: string): value is SupportedMCPClient
 }
 
 export function getClientLabel(client: SupportedMCPClient): string {
-  return client === 'claude' ? 'Claude Code' : 'Codex CLI';
+  switch (client) {
+    case 'claude':
+      return 'Claude Code';
+    case 'codex':
+      return 'Codex CLI';
+    case 'opencode':
+      return 'OpenCode';
+  }
 }
 
 export function getServeArgs(options: ServeArgOptions = {}): string[] {

--- a/tests/cli/mcp-client-config.test.ts
+++ b/tests/cli/mcp-client-config.test.ts
@@ -2,6 +2,7 @@ import {
   formatMCPServerConfigSnippet,
   getClaudeSetupCommand,
   getCodexServerConfig,
+  getClientLabel,
   getOpenCodeServerConfig,
   getServeArgs,
   formatOpenCodeMCPServerConfigSnippet,
@@ -134,9 +135,14 @@ describe('cli/mcp-client-config', () => {
     });
   });
 
+  test('getClientLabel returns the OpenCode label', () => {
+    expect(getClientLabel('opencode')).toBe('OpenCode');
+  });
+
   test('isSupportedMCPClient validates supported names', () => {
     expect(isSupportedMCPClient('claude')).toBe(true);
     expect(isSupportedMCPClient('codex')).toBe(true);
+    expect(isSupportedMCPClient('opencode')).toBe(true);
     expect(isSupportedMCPClient('cursor')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Register `opencode` as a supported MCP setup/config client.
- Wire `openchrome setup --client opencode` to write `~/.config/opencode/opencode.json` with OpenCode's official `mcp.openchrome` local-server shape.
- Wire `openchrome config --client opencode` and document the OpenCode quick start/manual config.

## Validation
- `PATH=./node_modules/.bin:$PATH npm run build`
- `PATH=./node_modules/.bin:$PATH jest tests/integration/health-endpoint-gating.test.ts tests/cli/mcp-client-config.test.ts --runInBand`
- `node dist/cli/index.js config --client opencode` and JSON parsing smoke check
- `HOME=<tmp> node dist/cli/index.js setup --client opencode` and generated config JSON parsing smoke check

## Stacking
- Stacked on #674.
- This PR closes #673 once the helper PR is merged.

Closes #673
