### PR TITLE
Surface same-site login redirects for auth handoff

### DIFF
--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -65,7 +65,7 @@ interface AuthRedirectGuidance {
 
 function isLikelyLoginUrl(url: URL): boolean {
   const path = url.pathname.toLowerCase();
-  return /(^|\/)(login|signin|sign-in|auth|session|sessions)(\/|$)/.test(path);
+  return /(^|\/)(login|signin|sign-in|auth)(\/|$)/.test(path);
 }
 
 function sameSiteAuthRedirectGuidance(requestedUrl: string, finalUrl: string, title: string): AuthRedirectGuidance | null {

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -53,6 +53,45 @@ async function getReadiness(page: Page, context?: ToolContext): Promise<{ readyS
   }
 }
 
+interface AuthRedirectGuidance {
+  authRedirect: true;
+  authRedirectKind: 'same-site-login';
+  redirectedFrom: string;
+  authRedirectUrl: string;
+  authRedirectHost: string;
+  recommendedNextAction: string;
+  message: string;
+}
+
+function isLikelyLoginUrl(url: URL): boolean {
+  const path = url.pathname.toLowerCase();
+  return /(^|\/)(login|signin|sign-in|auth|session|sessions)(\/|$)/.test(path);
+}
+
+function sameSiteAuthRedirectGuidance(requestedUrl: string, finalUrl: string, title: string): AuthRedirectGuidance | null {
+  try {
+    const requested = new URL(requestedUrl);
+    const final = new URL(finalUrl);
+    if (requested.origin !== final.origin) return null;
+    if (requested.pathname === final.pathname) return null;
+
+    const loginTitle = /\b(log[ -]?in|sign[ -]?in|authentication)\b/i.test(title);
+    if (!isLikelyLoginUrl(final) && !loginTitle) return null;
+
+    return {
+      authRedirect: true,
+      authRedirectKind: 'same-site-login',
+      redirectedFrom: requestedUrl,
+      authRedirectUrl: finalUrl,
+      authRedirectHost: final.hostname,
+      recommendedNextAction: 'Open the same URL with headed: true and the same profileDirectory, let the user complete login, then retry headless with that persistent profile.',
+      message: 'ACTION_REQUIRED: Same-site login redirect detected. The requested page resolved to a login/authentication page. Use headed mode with the same persistent profile for the user login step; do not keep retrying unauthenticated headless navigation.',
+    };
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Auto-fallback: retry navigation with stealth mode when a CDN/WAF block is detected.
  * Closes the original blocked tab (if just created), creates a new stealth tab,
@@ -512,10 +551,13 @@ const handler: ToolHandler = async (
               return stealthAutoRetry(sessionId, targetUrl, workerId, stealthSettleMs, profileDirectory, reuseBlocking, undefined, autoFallback, context);
             }
 
+            const reuseUrl = page.url();
+            const reuseTitle = await safeTitle(page);
+            const reuseAuthGuidance = sameSiteAuthRedirectGuidance(targetUrl, reuseUrl, reuseTitle);
             const reuseResultText = JSON.stringify({
               action: 'navigate',
-              url: page.url(),
-              title: await safeTitle(page),
+              url: reuseUrl,
+              title: reuseTitle,
               tabId: existingTabId,
               workerId: resolvedWorkerId,
               reused: true,
@@ -524,6 +566,7 @@ const handler: ToolHandler = async (
               ...(summary && { visualSummary: summary }),
               ...buildCaptchaFields(reuseBlocking),
               ...(reuseBlocking && { blockingPage: reuseBlocking }),
+              ...(reuseAuthGuidance ?? {}),
             });
             return {
               content: [{ type: 'text', text: reuseResultText }],
@@ -576,10 +619,13 @@ const handler: ToolHandler = async (
         if (headedResult) return headedResult;
       }
 
+      const newTabUrl = page.url();
+      const newTabTitle = await safeTitle(page);
+      const newTabAuthGuidance = sameSiteAuthRedirectGuidance(targetUrl, newTabUrl, newTabTitle);
       const newTabResultText = JSON.stringify({
         action: 'navigate',
-        url: page.url(),
-        title: await safeTitle(page),
+        url: newTabUrl,
+        title: newTabTitle,
         tabId: targetId,
         workerId: assignedWorkerId,
         created: true,
@@ -589,6 +635,7 @@ const handler: ToolHandler = async (
         ...(newTabSummary && { visualSummary: newTabSummary }),
         ...buildCaptchaFields(newTabBlocking),
         ...(newTabBlocking && { blockingPage: newTabBlocking }),
+        ...(newTabAuthGuidance ?? {}),
       });
       return {
         content: [{ type: 'text', text: newTabResultText }],

--- a/tests/tools/navigate.test.ts
+++ b/tests/tools/navigate.test.ts
@@ -522,6 +522,35 @@ describe('NavigateTool', () => {
       expect(parsed.authRedirect).toBe(true);
       expect(parsed.message).toContain('accounts.google.com');
     });
+
+    test('same-site login redirect includes profile handoff guidance', async () => {
+      const handler = await getNavigateHandler();
+      const loginPage = createMockPage({
+        url: 'https://app.test/login',
+        title: 'FreeScout',
+        targetId: 'same-site-login-target',
+      });
+
+      (mockSessionManager.createTarget as jest.Mock).mockResolvedValueOnce({
+        targetId: 'same-site-login-target',
+        page: loginPage,
+        workerId: 'auth-test',
+      });
+
+      const result = await handler(testSessionId, {
+        url: 'https://app.test/protected',
+        workerId: 'auth-test',
+      }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.authRedirect).toBe(true);
+      expect(parsed.authRedirectKind).toBe('same-site-login');
+      expect(parsed.redirectedFrom).toBe('https://app.test/protected');
+      expect(parsed.authRedirectUrl).toBe('https://app.test/login');
+      expect(parsed.recommendedNextAction).toContain('headed: true');
+      expect(parsed.message).toContain('Same-site login redirect detected');
+    });
   });
 
   describe('Element Count (SPA Readiness)', () => {

--- a/tests/tools/navigate.test.ts
+++ b/tests/tools/navigate.test.ts
@@ -551,6 +551,31 @@ describe('NavigateTool', () => {
       expect(parsed.recommendedNextAction).toContain('headed: true');
       expect(parsed.message).toContain('Same-site login redirect detected');
     });
+
+    test('same-site non-login navigation does not emit auth guidance', async () => {
+      const handler = await getNavigateHandler();
+      const sessionsPage = createMockPage({
+        url: 'https://app.test/sessions/123',
+        title: 'Session details',
+        targetId: 'same-site-session-target',
+      });
+
+      (mockSessionManager.createTarget as jest.Mock).mockResolvedValueOnce({
+        targetId: 'same-site-session-target',
+        page: sessionsPage,
+        workerId: 'session-test',
+      });
+
+      const result = await handler(testSessionId, {
+        url: 'https://app.test/dashboard',
+        workerId: 'session-test',
+      }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.authRedirect).toBeUndefined();
+      expect(parsed.authRedirectKind).toBeUndefined();
+    });
   });
 
   describe('Element Count (SPA Readiness)', () => {


### PR DESCRIPTION
## Summary
- Detect same-site login redirects in `navigate` responses, not only external auth-domain redirects.
- Add structured auth handoff fields (`authRedirectKind`, `authRedirectUrl`, `recommendedNextAction`) so models stop retrying unauthenticated headless navigation.
- Cover the FreeScout-style `/protected -> /login` behavior from #671 with a targeted unit test.
- Add a negative regression test so ordinary same-site resources like `/sessions/123` are not mislabeled as auth handoffs.

## Verification
- `npm ci`
- `npm test -- --runInBand tests/tools/navigate.test.ts`
- `npm run build`
- `npm run lint -- --quiet`

## Related
- Fixes part of #671
