### PR TITLE
Preserve profile context during headed fallback

### DIFF
--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -155,8 +155,19 @@ async function stealthAutoRetry(
   return { content: [{ type: 'text', text: resultText }] };
 }
 
-/** Worker ID used for all headed fallback tabs */
+/** Worker ID used for unprofiled headed fallback tabs */
 const HEADED_WORKER_ID = 'headed';
+
+/**
+ * Worker ID for headed pages that were opened with a Chrome profile.
+ * Keep this distinct from `profile:<directory>` headless workers because those
+ * may already be bound to a profile ChromePool port. Headed pages are indexed
+ * into the main CDP client by registerHeadedPage(), so mixing them with a
+ * port-bound profile worker sends later tool calls to the wrong CDP client.
+ */
+function headedWorkerId(profileDirectory?: string): string {
+  return profileDirectory ? `headed:profile:${profileDirectory}` : HEADED_WORKER_ID;
+}
 
 /**
  * Tier 3 fallback: retry navigation in headed Chrome when stealth also fails.
@@ -194,7 +205,7 @@ async function headedAutoRetry(
       try {
         const sessionManager = getSessionManager();
 
-        const resolvedWorkerId = profileDirectory ? `profile:${profileDirectory}` : HEADED_WORKER_ID;
+        const resolvedWorkerId = headedWorkerId(profileDirectory);
 
         // Create/reuse the headed worker WITH the headed Chrome port so that
         // getCDPClientForWorker() routes CDP commands to the correct instance. (#561)
@@ -266,9 +277,7 @@ async function headedNavigateDirect(
   try {
     const result = await headedFallback.navigatePersistent(targetUrl, options.profileDirectory);
     let tabId: string | undefined;
-    const resolvedWorkerId = options.profileDirectory
-      ? `profile:${options.profileDirectory}`
-      : HEADED_WORKER_ID;
+    const resolvedWorkerId = headedWorkerId(options.profileDirectory);
 
     if (sessionId) {
       try {
@@ -277,10 +286,11 @@ async function headedNavigateDirect(
 
         await sessionManager.getOrCreateWorker(sessionId, resolvedWorkerId, {
           shareCookies: true,
-          // Don't pass port or profileDirectory — the headed page is managed by
-          // HeadedFallbackManager and indexed via registerHeadedPage() into the
-          // main CDPClient. Passing port would create a duplicate puppeteer
-          // connection; passing profileDirectory would trigger ChromePool. (#562)
+          // Don't pass port or profileDirectory for profile-scoped headed pages —
+          // they are managed by HeadedFallbackManager and indexed via
+          // registerHeadedPage() into the main CDPClient. Passing profileDirectory
+          // would trigger ChromePool; reusing `profile:<dir>` would route later
+          // tool calls to a port-bound headless profile worker. (#562, #671)
           ...(!options.profileDirectory && { port: headedPort }),
         });
 

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -148,7 +148,7 @@ async function stealthAutoRetry(
     console.error(`[navigate] CAPTCHA solve failed: ${solveResult.error}, escalating to Tier 3`);
   }
   if (autoFallbackToHeaded && (stealthBlocked || stealthBroken)) {
-    const headedResult = await headedAutoRetry(targetUrl, blocking || blockingInfo, sessionId);
+    const headedResult = await headedAutoRetry(targetUrl, blocking || blockingInfo, sessionId, profileDirectory);
     if (headedResult) return headedResult;
   }
 
@@ -170,6 +170,7 @@ async function headedAutoRetry(
   targetUrl: string,
   blockingInfo: BlockingInfo,
   sessionId?: string,
+  profileDirectory?: string,
 ): Promise<MCPResult | null> {
   const headedFallback = getHeadedFallback(getGlobalConfig().port);
   if (!headedFallback.isAvailable()) {
@@ -181,7 +182,7 @@ async function headedAutoRetry(
 
   try {
     // Use persistent navigation so the page stays alive for tool interaction (#485)
-    const result = await headedFallback.navigatePersistent(targetUrl);
+    const result = await headedFallback.navigatePersistent(targetUrl, profileDirectory);
     let tabId: string | undefined;
     let assignedWorkerId: string | undefined;
 
@@ -193,26 +194,31 @@ async function headedAutoRetry(
       try {
         const sessionManager = getSessionManager();
 
+        const resolvedWorkerId = profileDirectory ? `profile:${profileDirectory}` : HEADED_WORKER_ID;
+
         // Create/reuse the headed worker WITH the headed Chrome port so that
         // getCDPClientForWorker() routes CDP commands to the correct instance. (#561)
+        // Profile-scoped headed fallback pages are managed by HeadedFallbackManager
+        // and indexed into the session directly, so do not pass port/profileDirectory
+        // or SessionManager would launch a second ChromePool instance. (#562, #671)
         const headedPort = headedFallback.getPort();
-        await sessionManager.getOrCreateWorker(sessionId, HEADED_WORKER_ID, {
+        await sessionManager.getOrCreateWorker(sessionId, resolvedWorkerId, {
           shareCookies: true,
-          port: headedPort,
+          ...(!profileDirectory && { port: headedPort }),
         });
 
         // Get the live Page object from HeadedFallbackManager and register it
         const page = headedFallback.getPage(result.targetId);
         if (page) {
-          sessionManager.registerHeadedPage(result.targetId, sessionId, HEADED_WORKER_ID, page);
+          sessionManager.registerHeadedPage(result.targetId, sessionId, resolvedWorkerId, page);
         } else {
           // Fallback: register without page injection (navigation-only, no tool access)
-          sessionManager.registerExternalTarget(result.targetId, sessionId, HEADED_WORKER_ID);
+          sessionManager.registerExternalTarget(result.targetId, sessionId, resolvedWorkerId);
         }
 
         tabId = result.targetId;
-        assignedWorkerId = HEADED_WORKER_ID;
-        console.error(`[navigate] Headed tab registered: tabId=${tabId.slice(0, 8)}... workerId=${HEADED_WORKER_ID}`);
+        assignedWorkerId = resolvedWorkerId;
+        console.error(`[navigate] Headed tab registered: tabId=${tabId.slice(0, 8)}... workerId=${resolvedWorkerId}`);
       } catch (regErr) {
         console.error('[navigate] Headed tab registration failed (page still accessible via headed Chrome):', regErr instanceof Error ? regErr.message : regErr);
       }
@@ -230,6 +236,7 @@ async function headedAutoRetry(
       stealth: true,
       fallbackTier: 3,
       fallbackReason: blockingInfo.type,
+      ...(profileDirectory && { profileDirectory }),
       ...(result.blockingPage && { blockingPage: result.blockingPage }),
     });
     return { content: [{ type: 'text', text: resultText }] };
@@ -572,7 +579,7 @@ const handler: ToolHandler = async (
       // When explicit stealth hits a block, escalate directly to tier 3 (headed Chrome)
       // since tier 2 (stealth) is already being used. (#453)
       if (newTabBlocking && stealth && autoFallback && RETRYABLE_BLOCK_TYPES.has(newTabBlocking.type)) {
-        const headedResult = await headedAutoRetry(targetUrl, newTabBlocking, sessionId);
+        const headedResult = await headedAutoRetry(targetUrl, newTabBlocking, sessionId, profileDirectory);
         if (headedResult) return headedResult;
       }
 

--- a/tests/tools/navigate-headed-fallback.test.ts
+++ b/tests/tools/navigate-headed-fallback.test.ts
@@ -179,7 +179,7 @@ describe('NavigateTool - Headed Chrome Fallback (#459)', () => {
       expect(parsed.fallbackTier).toBe(3);
       expect(parsed.fallbackReason).toBe('access-denied');
       expect(parsed.title).toBe('Coupang');
-      expect(mockHeadedNavigatePersistent).toHaveBeenCalledWith('https://www.coupang.com');
+      expect(mockHeadedNavigatePersistent).toHaveBeenCalledWith('https://www.coupang.com', undefined);
     });
 
     test('does not escalate to Tier 3 when Tier 2 succeeds', async () => {
@@ -257,7 +257,7 @@ describe('NavigateTool - Headed Chrome Fallback (#459)', () => {
       expect(parsed.headed).toBe(true);
       expect(parsed.fallbackTier).toBe(3);
       expect(parsed.fallbackReason).toBe('access-denied');
-      expect(mockHeadedNavigatePersistent).toHaveBeenCalledWith('https://www.coupang.com');
+      expect(mockHeadedNavigatePersistent).toHaveBeenCalledWith('https://www.coupang.com', undefined);
     });
 
     test('escalates to Tier 3 when stealth produces broken page (readyState=unknown)', async () => {
@@ -285,7 +285,7 @@ describe('NavigateTool - Headed Chrome Fallback (#459)', () => {
       expect(parsed.headed).toBe(true);
       expect(parsed.fallbackTier).toBe(3);
       expect(parsed.fallbackReason).toBe('bot-check');
-      expect(mockHeadedNavigatePersistent).toHaveBeenCalledWith('https://www.coupang.com');
+      expect(mockHeadedNavigatePersistent).toHaveBeenCalledWith('https://www.coupang.com', undefined);
     });
 
     test('does NOT escalate to Tier 3 when autoFallback is false and stealth page is empty', async () => {
@@ -483,6 +483,46 @@ describe('NavigateTool - Headed Chrome Fallback (#459)', () => {
         'headed-target-123',
         testSessionId,
         'headed',
+        mockPage,
+      );
+    });
+
+    test('Tier 3 auto-escalation preserves profileDirectory context', async () => {
+      const handler = await getNavigateHandler();
+      const mockPage = createMockPage({ url: 'https://www.coupang.com/', targetId: 'headed-profile-target-123' });
+      mockHeadedGetPage.mockReturnValue(mockPage);
+      mockHeadedNavigatePersistent.mockResolvedValueOnce({
+        url: 'https://www.coupang.com/',
+        title: 'Coupang',
+        elementCount: 500,
+        blockingPage: null,
+        targetId: 'headed-profile-target-123',
+      });
+
+      mockDetectBlockingPage
+        .mockResolvedValueOnce({ type: 'access-denied', detail: 'Akamai CDN' })
+        .mockResolvedValueOnce({ type: 'access-denied', detail: 'Still Denied' });
+
+      const result = await handler(testSessionId, {
+        url: 'https://www.coupang.com',
+        profileDirectory: 'Profile 1',
+      });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed.headed).toBe(true);
+      expect(parsed.fallbackTier).toBe(3);
+      expect(parsed.workerId).toBe('profile:Profile 1');
+      expect(parsed.profileDirectory).toBe('Profile 1');
+      expect(mockHeadedNavigatePersistent).toHaveBeenCalledWith('https://www.coupang.com', 'Profile 1');
+      expect(mockSessionManager.getOrCreateWorker).toHaveBeenCalledWith(
+        testSessionId,
+        'profile:Profile 1',
+        { shareCookies: true },
+      );
+      expect(mockSessionManager.registerHeadedPage).toHaveBeenCalledWith(
+        'headed-profile-target-123',
+        testSessionId,
+        'profile:Profile 1',
         mockPage,
       );
     });

--- a/tests/tools/navigate-headed-fallback.test.ts
+++ b/tests/tools/navigate-headed-fallback.test.ts
@@ -445,7 +445,7 @@ describe('NavigateTool - Headed Chrome Fallback (#459)', () => {
       const parsed = parseResultJSON<NavResult>(result as MCPResult);
 
       // Should use profile-scoped workerId, not "headed"
-      expect(parsed.workerId).toBe('profile:Profile 1');
+      expect(parsed.workerId).toBe('headed:profile:Profile 1');
       expect(parsed.profileDirectory).toBe('Profile 1');
       expect(parsed.headed).toBe(true);
       expect(parsed.userRequested).toBe(true);
@@ -460,7 +460,7 @@ describe('NavigateTool - Headed Chrome Fallback (#459)', () => {
       // passing profileDirectory would trigger ChromePool. (#562)
       expect(mockSessionManager.getOrCreateWorker).toHaveBeenCalledWith(
         testSessionId,
-        'profile:Profile 1',
+        'headed:profile:Profile 1',
         { shareCookies: true },
       );
     });
@@ -487,8 +487,42 @@ describe('NavigateTool - Headed Chrome Fallback (#459)', () => {
       );
     });
 
+    test('headed=true with profileDirectory does not reuse an existing headless profile worker', async () => {
+      const handler = await getNavigateHandler();
+      const existingProfileWorker = await mockSessionManager.getOrCreateWorker(testSessionId, 'profile:Profile 1');
+      (existingProfileWorker as any).port = 9444;
+      (existingProfileWorker as any).profileDirectory = 'Profile 1';
+
+      const mockPage = createMockPage({ url: 'https://aws.amazon.com/', targetId: 'headed-profile-123' });
+      mockHeadedGetPage.mockReturnValue(mockPage);
+
+      const result = await handler(testSessionId, {
+        url: 'https://aws.amazon.com',
+        headed: true,
+        profileDirectory: 'Profile 1',
+      });
+      const parsed = parseResultJSON<NavResult>(result as MCPResult);
+
+      expect(parsed.workerId).toBe('headed:profile:Profile 1');
+      expect(parsed.profileDirectory).toBe('Profile 1');
+      expect(mockSessionManager.getOrCreateWorker).toHaveBeenCalledWith(
+        testSessionId,
+        'headed:profile:Profile 1',
+        { shareCookies: true },
+      );
+      expect(mockSessionManager.registerHeadedPage).toHaveBeenCalledWith(
+        'headed-target-123',
+        testSessionId,
+        'headed:profile:Profile 1',
+        mockPage,
+      );
+    });
+
     test('Tier 3 auto-escalation preserves profileDirectory context', async () => {
       const handler = await getNavigateHandler();
+      const existingProfileWorker = await mockSessionManager.getOrCreateWorker(testSessionId, 'profile:Profile 1');
+      (existingProfileWorker as any).port = 9444;
+      (existingProfileWorker as any).profileDirectory = 'Profile 1';
       const mockPage = createMockPage({ url: 'https://www.coupang.com/', targetId: 'headed-profile-target-123' });
       mockHeadedGetPage.mockReturnValue(mockPage);
       mockHeadedNavigatePersistent.mockResolvedValueOnce({
@@ -511,18 +545,18 @@ describe('NavigateTool - Headed Chrome Fallback (#459)', () => {
 
       expect(parsed.headed).toBe(true);
       expect(parsed.fallbackTier).toBe(3);
-      expect(parsed.workerId).toBe('profile:Profile 1');
+      expect(parsed.workerId).toBe('headed:profile:Profile 1');
       expect(parsed.profileDirectory).toBe('Profile 1');
       expect(mockHeadedNavigatePersistent).toHaveBeenCalledWith('https://www.coupang.com', 'Profile 1');
       expect(mockSessionManager.getOrCreateWorker).toHaveBeenCalledWith(
         testSessionId,
-        'profile:Profile 1',
+        'headed:profile:Profile 1',
         { shareCookies: true },
       );
       expect(mockSessionManager.registerHeadedPage).toHaveBeenCalledWith(
         'headed-profile-target-123',
         testSessionId,
-        'profile:Profile 1',
+        'headed:profile:Profile 1',
         mockPage,
       );
     });


### PR DESCRIPTION
## Summary
- Preserve `profileDirectory` when Tier-3 headed fallback is reached from a profile-scoped headless attempt.
- Register profile-scoped headed pages under distinct `headed:profile:<directory>` workers instead of generic `headed` or existing `profile:<directory>` headless workers.
- Avoid routing headed fallback targets through port-bound headless profile CDP clients when a `profile:<directory>` worker already exists.
- Add regression coverage for profile context propagation through automatic headed escalation and direct headed profile navigation.

## Verification
- `npm ci`
- `npm test -- --runInBand tests/tools/navigate-headed-fallback.test.ts`
- `npm run build`
- `npm run lint -- --quiet`

## Related
- Fixes part of #671
