### PR TITLE
fix: fail closed HTTP auth and tighten CORS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,9 +88,10 @@ program
   .option('--http [port]', 'Use Streamable HTTP transport instead of stdio (default port: 3100)')
   .option('--http-host <host>', 'Bind address for HTTP transport (default: 127.0.0.1, use 0.0.0.0 for external access)')
   .option('--auth-token <token>', 'Bearer token for HTTP transport authentication (also: OPENCHROME_AUTH_TOKEN env var)')
+  .option('--allow-unauthenticated-http', 'Explicitly allow unauthenticated loopback-only HTTP development mode (also: OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP=1)')
   .option('--transport <mode>', 'Transport mode: stdio, http, or both (default: stdio)')
   .option('--idle-timeout <duration>', 'Self-exit (code 0) after idle window with zero sessions. Format: <number>(ms|s|m|h), e.g. 30m, 90s, 500ms. Bare numbers are rejected. Also: OPENCHROME_IDLE_TIMEOUT_MS env var (integer ms). Default: disabled.')
-  .action(async (options: { port: string; autoLaunch?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; idleTimeout?: string }) => {
+  .action(async (options: { port: string; autoLaunch?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; idleTimeout?: string; allowUnauthenticatedHttp?: boolean }) => {
     const port = parseInt(options.port, 10);
     let autoLaunch = options.autoLaunch || false;
 
@@ -313,6 +314,7 @@ program
     if (authToken) {
       console.error('[openchrome] Bearer token authentication: enabled');
     }
+    const allowUnauthenticatedHttp = options.allowUnauthenticatedHttp;
 
     // Multi-tenant API key store: when OPENCHROME_API_KEYS_PATH points at a
     // JSONL store file, load it and pass it to the HTTP transport so
@@ -347,7 +349,7 @@ program
         httpPort,
         httpHost,
         authToken,
-        apiKeyStore ? { apiKeyStore } : undefined,
+        { ...(apiKeyStore ? { apiKeyStore } : {}), allowUnauthenticatedHttp },
       ) as import('./transports/http').HTTPTransport;
       httpTransport = httpTrans;
 
@@ -367,7 +369,7 @@ program
     } else if (useHttp) {
       const httpPort = typeof options.http === 'string' ? parseInt(options.http, 10) : parseInt(process.env.OPENCHROME_HTTP_PORT || '', 10) || 3100;
       const httpHost = (options as Record<string, unknown>).httpHost as string || process.env.OPENCHROME_HTTP_HOST || '127.0.0.1';
-      const transport = createTransport('http', { port: httpPort, host: httpHost, authToken, apiKeyStore });
+      const transport = createTransport('http', { port: httpPort, host: httpHost, authToken, apiKeyStore, allowUnauthenticatedHttp });
       httpTransport = transport as import('./transports/http').HTTPTransport;
       server.start(transport);
       console.error(`[openchrome] HTTP transport enabled on ${httpHost}:${httpPort}`);

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -82,16 +82,25 @@ function parseCorsOrigins(raw: string | undefined): Set<string> {
 }
 
 /**
- * Treat a request as same-origin when the URL's host (including port) in the
- * `Origin` header matches the request's `Host` header. Browsers send `Origin`
- * on same-origin non-GET requests (POST/OPTIONS), so without this gate a
- * browser app served from the OpenChrome origin would be rejected by the CORS
- * allowlist even though no cross-origin trust boundary is crossed.
+ * Treat a request as same-origin when the full origin tuple (scheme, host,
+ * port) in the `Origin` header matches the transport scheme and the request's
+ * `Host` header. Browsers send `Origin` on same-origin non-GET requests
+ * (POST/OPTIONS), so without this bypass a browser app served from the
+ * OpenChrome origin would be rejected by the CORS allowlist even though no
+ * cross-origin trust boundary is crossed.
+ *
+ * Scheme is enforced because the HTTP transport speaks plain `http` only;
+ * permitting an `https` Origin to bypass the allowlist would let cross-origin
+ * `https` callers reach `/mcp` whenever the same host is also exposed over
+ * `http`. Operators behind TLS termination must add the public origin to the
+ * allowlist explicitly.
  */
 function isSameOriginRequest(originValue: string, hostHeader: string | undefined): boolean {
   if (!hostHeader) return false;
   try {
-    return new URL(originValue).host.toLowerCase() === hostHeader.toLowerCase();
+    const originUrl = new URL(originValue);
+    if (originUrl.protocol !== 'http:') return false;
+    return originUrl.host.toLowerCase() === hostHeader.toLowerCase();
   } catch {
     return false;
   }

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -81,6 +81,22 @@ function parseCorsOrigins(raw: string | undefined): Set<string> {
   return new Set((raw || '').split(',').map((origin) => origin.trim()).filter(Boolean));
 }
 
+/**
+ * Treat a request as same-origin when the URL's host (including port) in the
+ * `Origin` header matches the request's `Host` header. Browsers send `Origin`
+ * on same-origin non-GET requests (POST/OPTIONS), so without this gate a
+ * browser app served from the OpenChrome origin would be rejected by the CORS
+ * allowlist even though no cross-origin trust boundary is crossed.
+ */
+function isSameOriginRequest(originValue: string, hostHeader: string | undefined): boolean {
+  if (!hostHeader) return false;
+  try {
+    return new URL(originValue).host.toLowerCase() === hostHeader.toLowerCase();
+  } catch {
+    return false;
+  }
+}
+
 const HTTP_REQUEST_TIMEOUT_MS  = envInt('OPENCHROME_HTTP_REQUEST_TIMEOUT_MS',  DEFAULT_HTTP_REQUEST_TIMEOUT_MS);
 const HTTP_HEADERS_TIMEOUT_MS  = envInt('OPENCHROME_HTTP_HEADERS_TIMEOUT_MS',  DEFAULT_HTTP_HEADERS_TIMEOUT_MS);
 const HTTP_KEEPALIVE_TIMEOUT_MS = envInt('OPENCHROME_HTTP_KEEPALIVE_TIMEOUT_MS', DEFAULT_HTTP_KEEPALIVE_TIMEOUT_MS);
@@ -221,6 +237,7 @@ export class HTTPTransport implements MCPTransport {
   private applyCors(req: http.IncomingMessage, res: http.ServerResponse, pathname: string): boolean {
     const origin = req.headers.origin;
     const originValue = typeof origin === 'string' ? origin : undefined;
+    const sameOrigin = originValue ? isSameOriginRequest(originValue, req.headers.host) : false;
     if (originValue && this.corsAllowedOrigins.has(originValue)) {
       res.setHeader('Access-Control-Allow-Origin', originValue);
       res.setHeader('Vary', 'Origin');
@@ -230,7 +247,7 @@ export class HTTPTransport implements MCPTransport {
     res.setHeader('Access-Control-Expose-Headers', `Mcp-Session-Id, ${REQUEST_ID_HEADER}`);
 
     const isMcpEndpoint = pathname === '/mcp' || pathname === '/mcp/sse';
-    if (originValue && isMcpEndpoint && !this.corsAllowedOrigins.has(originValue)) {
+    if (originValue && isMcpEndpoint && !sameOrigin && !this.corsAllowedOrigins.has(originValue)) {
       res.writeHead(403, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'CORS origin not allowed' }));
       return false;

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -67,6 +67,20 @@ function envInt(name: string, fallback: number): number {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
 }
 
+function envFlag(name: string): boolean {
+  const raw = process.env[name];
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
+function isLoopbackHost(host: string): boolean {
+  const normalized = host.trim().toLowerCase().replace(/^\[(.*)\]$/, '$1');
+  return normalized === '127.0.0.1' || normalized === 'localhost' || normalized === '::1';
+}
+
+function parseCorsOrigins(raw: string | undefined): Set<string> {
+  return new Set((raw || '').split(',').map((origin) => origin.trim()).filter(Boolean));
+}
+
 const HTTP_REQUEST_TIMEOUT_MS  = envInt('OPENCHROME_HTTP_REQUEST_TIMEOUT_MS',  DEFAULT_HTTP_REQUEST_TIMEOUT_MS);
 const HTTP_HEADERS_TIMEOUT_MS  = envInt('OPENCHROME_HTTP_HEADERS_TIMEOUT_MS',  DEFAULT_HTTP_HEADERS_TIMEOUT_MS);
 const HTTP_KEEPALIVE_TIMEOUT_MS = envInt('OPENCHROME_HTTP_KEEPALIVE_TIMEOUT_MS', DEFAULT_HTTP_KEEPALIVE_TIMEOUT_MS);
@@ -91,6 +105,14 @@ interface SSEConnection {
 export interface HTTPTransportOptions {
   apiKeyStore?: ApiKeyStore;
   jwt?: JwtConfig;
+  /**
+   * Explicit opt-in for unauthenticated loopback-only HTTP development.
+   * Production/daemon HTTP mode must configure auth instead of silently
+   * receiving admin-scoped disabled auth.
+   */
+  allowUnauthenticatedHttp?: boolean;
+  /** Explicit browser origins allowed to use MCP CORS. Defaults to env. */
+  corsAllowedOrigins?: string[];
 }
 
 export class HTTPTransport implements MCPTransport {
@@ -102,6 +124,7 @@ export class HTTPTransport implements MCPTransport {
   private host: string;
   private authToken: string | undefined;
   private authMode: AuthMode;
+  private readonly corsAllowedOrigins: Set<string>;
   private sessions: Set<string> = new Set();
   private sseConnections: SSEConnection[] = [];
   private sessionDeleteHandler: ((sessionId: string) => void) | null = null;
@@ -123,6 +146,12 @@ export class HTTPTransport implements MCPTransport {
     this.authToken = authToken;
     const verifier = options.jwt ? createJwtVerifier(options.jwt) : undefined;
     this.authMode = HTTPTransport.resolveAuthMode(authToken, options.apiKeyStore, verifier);
+    const allowUnauthenticatedHttp = options.allowUnauthenticatedHttp ?? envFlag('OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP');
+    HTTPTransport.validateUnauthenticatedHttpPolicy(this.authMode, this.host, allowUnauthenticatedHttp);
+    this.corsAllowedOrigins = new Set([
+      ...parseCorsOrigins(process.env.OPENCHROME_HTTP_CORS_ORIGINS),
+      ...(options.corsAllowedOrigins || []),
+    ]);
   }
 
   /**
@@ -168,6 +197,45 @@ export class HTTPTransport implements MCPTransport {
       return { kind: 'legacy-shared-token', token: authToken };
     }
     return { kind: 'disabled' };
+  }
+
+  private static validateUnauthenticatedHttpPolicy(
+    authMode: AuthMode,
+    host: string,
+    allowUnauthenticatedHttp: boolean,
+  ): void {
+    if (authMode.kind !== 'disabled') return;
+
+    const migration = 'Configure HTTP auth (OPENCHROME_AUTH_TOKEN, API keys, or JWT), use stdio, ' +
+      'or set OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP=1 for loopback-only development.';
+    if (!allowUnauthenticatedHttp) {
+      throw new Error(`Refusing to start unauthenticated HTTP transport. ${migration}`);
+    }
+    if (!isLoopbackHost(host)) {
+      throw new Error(
+        `Refusing to start unauthenticated HTTP transport on non-loopback host ${host}. ${migration}`,
+      );
+    }
+  }
+
+  private applyCors(req: http.IncomingMessage, res: http.ServerResponse, pathname: string): boolean {
+    const origin = req.headers.origin;
+    const originValue = typeof origin === 'string' ? origin : undefined;
+    if (originValue && this.corsAllowedOrigins.has(originValue)) {
+      res.setHeader('Access-Control-Allow-Origin', originValue);
+      res.setHeader('Vary', 'Origin');
+    }
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', `Content-Type, Mcp-Session-Id, Authorization, X-Tenant-Id, ${REQUEST_ID_HEADER}`);
+    res.setHeader('Access-Control-Expose-Headers', `Mcp-Session-Id, ${REQUEST_ID_HEADER}`);
+
+    const isMcpEndpoint = pathname === '/mcp' || pathname === '/mcp/sse';
+    if (originValue && isMcpEndpoint && !this.corsAllowedOrigins.has(originValue)) {
+      res.writeHead(403, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'CORS origin not allowed' }));
+      return false;
+    }
+    return true;
   }
 
   /** Returns the resolved principal for a given request, if any. */
@@ -305,12 +373,11 @@ export class HTTPTransport implements MCPTransport {
     const url = new URL(req.url || '/', `http://${this.host}:${this.port}`);
     const pathname = url.pathname;
 
-    // CORS headers for all responses — restrict origin when auth is enforced
-    const authEnforced = this.authMode.kind !== 'disabled';
-    res.setHeader('Access-Control-Allow-Origin', authEnforced ? 'null' : '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', `Content-Type, Mcp-Session-Id, Authorization, X-Tenant-Id, ${REQUEST_ID_HEADER}`);
-    res.setHeader('Access-Control-Expose-Headers', `Mcp-Session-Id, ${REQUEST_ID_HEADER}`);
+    // CORS is explicit allowlist-only for browser-origin MCP requests. Non-browser
+    // clients that do not send Origin continue through normal authentication.
+    if (!this.applyCors(req, res, pathname)) {
+      return;
+    }
 
     // Request correlation: honour client-supplied X-Request-Id, otherwise mint
     // a fresh UUID. Echo it back on every response so clients (and downstream

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -82,25 +82,48 @@ function parseCorsOrigins(raw: string | undefined): Set<string> {
 }
 
 /**
+ * Format the configured server bind into a canonical origin host (URL `host`
+ * form: `hostname` or `hostname:port`, with IPv6 hostnames bracketed). This
+ * value is what `isSameOriginRequest` compares against — it is derived from
+ * operator configuration, not from the request, so it cannot be spoofed via
+ * the Host header.
+ */
+function formatServerOriginHost(host: string, port: number): string {
+  const trimmed = host.trim().toLowerCase();
+  const stripped = trimmed.replace(/^\[(.*)\]$/, '$1');
+  const isIPv6 = stripped.includes(':');
+  const hostPart = isIPv6 ? `[${stripped}]` : stripped;
+  // Default port 80 is the only http default; OpenChrome binds 3100 by
+  // default, but be explicit about what `URL.host` would produce.
+  return port === 80 ? hostPart : `${hostPart}:${port}`;
+}
+
+/**
  * Treat a request as same-origin when the full origin tuple (scheme, host,
- * port) in the `Origin` header matches the transport scheme and the request's
- * `Host` header. Browsers send `Origin` on same-origin non-GET requests
- * (POST/OPTIONS), so without this bypass a browser app served from the
- * OpenChrome origin would be rejected by the CORS allowlist even though no
- * cross-origin trust boundary is crossed.
+ * port) in the `Origin` header matches the configured server bind. Browsers
+ * send `Origin` on same-origin non-GET requests (POST/OPTIONS), so without
+ * this bypass a browser app served from the OpenChrome origin would be
+ * rejected by the CORS allowlist even though no cross-origin trust boundary
+ * is crossed.
+ *
+ * The comparison uses the operator-configured `host:port`, NOT the client-
+ * supplied `Host` header. Trusting the Host header here would let DNS-
+ * rebinding attackers (whose page is served from a domain that was rebound
+ * to loopback) match `Origin === Host` and bypass the allowlist — defeating
+ * the very protection the allowlist provides for the unauthenticated
+ * loopback development mode.
  *
  * Scheme is enforced because the HTTP transport speaks plain `http` only;
- * permitting an `https` Origin to bypass the allowlist would let cross-origin
- * `https` callers reach `/mcp` whenever the same host is also exposed over
- * `http`. Operators behind TLS termination must add the public origin to the
- * allowlist explicitly.
+ * permitting an `https` Origin to bypass the allowlist would let cross-
+ * origin `https` callers reach `/mcp` whenever the same host is also exposed
+ * over `http`. Operators behind TLS termination must add the public origin
+ * to the allowlist explicitly.
  */
-function isSameOriginRequest(originValue: string, hostHeader: string | undefined): boolean {
-  if (!hostHeader) return false;
+function isSameOriginRequest(originValue: string, serverOriginHost: string): boolean {
   try {
     const originUrl = new URL(originValue);
     if (originUrl.protocol !== 'http:') return false;
-    return originUrl.host.toLowerCase() === hostHeader.toLowerCase();
+    return originUrl.host.toLowerCase() === serverOriginHost;
   } catch {
     return false;
   }
@@ -150,6 +173,7 @@ export class HTTPTransport implements MCPTransport {
   private authToken: string | undefined;
   private authMode: AuthMode;
   private readonly corsAllowedOrigins: Set<string>;
+  private readonly serverOriginHost: string;
   private sessions: Set<string> = new Set();
   private sseConnections: SSEConnection[] = [];
   private sessionDeleteHandler: ((sessionId: string) => void) | null = null;
@@ -177,6 +201,7 @@ export class HTTPTransport implements MCPTransport {
       ...parseCorsOrigins(process.env.OPENCHROME_HTTP_CORS_ORIGINS),
       ...(options.corsAllowedOrigins || []),
     ]);
+    this.serverOriginHost = formatServerOriginHost(this.host, this.port);
   }
 
   /**
@@ -246,7 +271,7 @@ export class HTTPTransport implements MCPTransport {
   private applyCors(req: http.IncomingMessage, res: http.ServerResponse, pathname: string): boolean {
     const origin = req.headers.origin;
     const originValue = typeof origin === 'string' ? origin : undefined;
-    const sameOrigin = originValue ? isSameOriginRequest(originValue, req.headers.host) : false;
+    const sameOrigin = originValue ? isSameOriginRequest(originValue, this.serverOriginHost) : false;
     if (originValue && this.corsAllowedOrigins.has(originValue)) {
       res.setHeader('Access-Control-Allow-Origin', originValue);
       res.setHeader('Vary', 'Origin');

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -55,6 +55,7 @@ export interface TransportOptions {
    * keys must pass this option.
    */
   apiKeyStore?: ApiKeyStore;
+  allowUnauthenticatedHttp?: boolean;
 }
 
 /**
@@ -71,7 +72,10 @@ export function createTransport(mode: TransportMode, options?: TransportOptions)
       options?.port || 3100,
       options?.host || '127.0.0.1',
       options?.authToken,
-      options?.apiKeyStore ? { apiKeyStore: options.apiKeyStore } : undefined,
+      {
+        ...(options?.apiKeyStore ? { apiKeyStore: options.apiKeyStore } : {}),
+        allowUnauthenticatedHttp: options?.allowUnauthenticatedHttp,
+      },
     );
   }
   // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -56,6 +56,12 @@ export interface TransportOptions {
    */
   apiKeyStore?: ApiKeyStore;
   allowUnauthenticatedHttp?: boolean;
+  /**
+   * Programmatic browser origins allowed to use MCP CORS, merged with the
+   * env var `OPENCHROME_HTTP_CORS_ORIGINS`. Without this, callers using the
+   * factory cannot configure CORS origins outside the environment.
+   */
+  corsAllowedOrigins?: string[];
 }
 
 /**
@@ -75,6 +81,7 @@ export function createTransport(mode: TransportMode, options?: TransportOptions)
       {
         ...(options?.apiKeyStore ? { apiKeyStore: options.apiKeyStore } : {}),
         allowUnauthenticatedHttp: options?.allowUnauthenticatedHttp,
+        ...(options?.corsAllowedOrigins ? { corsAllowedOrigins: options.corsAllowedOrigins } : {}),
       },
     );
   }

--- a/tests/integration/health-endpoint-gating.test.ts
+++ b/tests/integration/health-endpoint-gating.test.ts
@@ -181,7 +181,7 @@ describeFn('health endpoint gating (issue #648)', () => {
     test(scenario.name, async () => {
       const healthPort = pickPort();
       const { chromePort, httpPort } = pickTransportPorts();
-      const env = {
+      const env: NodeJS.ProcessEnv = {
         ...process.env,
         OPENCHROME_HEALTH_PORT: String(healthPort),
         OPENCHROME_HEALTH_BIND: '127.0.0.1',
@@ -197,6 +197,7 @@ describeFn('health endpoint gating (issue #648)', () => {
       // default :3100; always point it at our random high port.
       if (scenario.args.includes('http') || scenario.args.includes('both')) {
         args.push('--http-host', '127.0.0.1');
+        env.OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP = '1';
       }
 
       // IMPORTANT: stdin must be a *pipe* (not 'ignore'), because 'ignore'

--- a/tests/transports/http-abort-on-disconnect.test.ts
+++ b/tests/transports/http-abort-on-disconnect.test.ts
@@ -27,7 +27,7 @@ describe('HTTPTransport — abort-on-disconnect (issue #8)', () => {
   });
 
   function startTransport(handler: (msg: any, signal?: AbortSignal) => Promise<any>) {
-    transport = new HTTPTransport(TEST_PORT, '127.0.0.1');
+    transport = new HTTPTransport(TEST_PORT, '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
     transport.onMessage(handler);
     transport.start();
     return new Promise<void>((r) => setTimeout(r, 50));

--- a/tests/transports/http-bearer-auth.test.ts
+++ b/tests/transports/http-bearer-auth.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="jest" />
 /**
- * Tests for HTTP transport Bearer token authentication.
- * Validates that the auth middleware correctly gates /mcp while leaving /health open.
+ * Tests for HTTP transport Bearer token authentication and fail-closed
+ * unauthenticated HTTP startup policy.
  */
 
 import * as http from 'node:http';
@@ -10,7 +10,8 @@ import * as http from 'node:http';
 const { HTTPTransport } = require('../../src/transports/http');
 
 const TEST_PORT = 19876;
-const TEST_TOKEN = 'test-secret-token-abc123';
+const TEST_TOKEN = 'test-s...c123';
+const TRUSTED_ORIGIN = 'http://127.0.0.1:5173';
 
 function request(
   path: string,
@@ -20,7 +21,7 @@ function request(
 ): Promise<{ status: number; body: string; headers: http.IncomingHttpHeaders }> {
   return new Promise((resolve, reject) => {
     const req = http.request(
-      { hostname: '127.0.0.1', port: TEST_PORT, path, method, headers },
+      { hostname: '127.0.0.1', port: TEST_PORT, path, method, headers, timeout: 3000 },
       (res) => {
         const chunks: Buffer[] = [];
         res.on('data', (c: Buffer) => chunks.push(c));
@@ -33,33 +34,50 @@ function request(
         });
       },
     );
+    req.on('timeout', () => req.destroy(new Error(`request timeout: ${method} ${path}`)));
     req.on('error', reject);
     if (body) req.write(body);
     req.end();
   });
 }
 
+async function startTransport(transport: InstanceType<typeof HTTPTransport>): Promise<void> {
+  transport.onMessage(async (msg: Record<string, unknown>) => {
+    if (msg.method === 'initialize') {
+      return { jsonrpc: '2.0', id: msg.id, result: { serverInfo: { name: 'test' } } };
+    }
+    return { jsonrpc: '2.0', id: msg.id, result: { ok: true } };
+  });
+  transport.start();
+  await new Promise((r) => setTimeout(r, 100));
+}
+
 describe('HTTP Bearer Token Auth', () => {
-  let transport: InstanceType<typeof HTTPTransport>;
+  let transport: InstanceType<typeof HTTPTransport> | null = null;
+  const originalCorsOrigins = process.env.OPENCHROME_HTTP_CORS_ORIGINS;
+  const originalAllowUnauthenticated = process.env.OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP;
 
   afterEach(async () => {
     if (transport) {
       await transport.close();
+      transport = null;
+    }
+    if (originalCorsOrigins === undefined) {
+      delete process.env.OPENCHROME_HTTP_CORS_ORIGINS;
+    } else {
+      process.env.OPENCHROME_HTTP_CORS_ORIGINS = originalCorsOrigins;
+    }
+    if (originalAllowUnauthenticated === undefined) {
+      delete process.env.OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP;
+    } else {
+      process.env.OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP = originalAllowUnauthenticated;
     }
   });
 
   describe('with auth token configured', () => {
     beforeEach(async () => {
       transport = new HTTPTransport(TEST_PORT, '127.0.0.1', TEST_TOKEN);
-      transport.onMessage(async (msg: Record<string, unknown>) => {
-        if (msg.method === 'initialize') {
-          return { jsonrpc: '2.0', id: msg.id, result: { serverInfo: { name: 'test' } } };
-        }
-        return { jsonrpc: '2.0', id: msg.id, result: {} };
-      });
-      transport.start();
-      // Wait for server to bind
-      await new Promise((r) => setTimeout(r, 100));
+      await startTransport(transport);
     });
 
     it('returns 200 for /health without token', async () => {
@@ -100,37 +118,67 @@ describe('HTTP Bearer Token Auth', () => {
       expect(res.status).toBe(401);
     });
 
-    it('allows CORS preflight without token', async () => {
+    it('allows CORS preflight without Origin and includes Authorization header', async () => {
       const res = await request('/mcp', 'OPTIONS');
       expect(res.status).toBe(204);
-    });
-
-    it('includes Authorization in CORS allowed headers', async () => {
-      const res = await request('/mcp', 'OPTIONS');
       const allowHeaders = res.headers['access-control-allow-headers'] as string;
       expect(allowHeaders).toContain('Authorization');
     });
   });
 
-  describe('without auth token (backward compatible)', () => {
-    beforeEach(async () => {
-      transport = new HTTPTransport(TEST_PORT, '127.0.0.1');
-      transport.onMessage(async (msg: Record<string, unknown>) => {
-        return { jsonrpc: '2.0', id: msg.id, result: { ok: true } };
-      });
-      transport.start();
-      await new Promise((r) => setTimeout(r, 100));
+  describe('unauthenticated HTTP policy', () => {
+    it('fails closed by default when no auth is configured', () => {
+      expect(() => new HTTPTransport(TEST_PORT, '127.0.0.1')).toThrow(/Refusing to start unauthenticated HTTP transport/);
     });
 
-    it('allows /mcp without any token', async () => {
+    it('allows explicit loopback-only development mode', async () => {
+      transport = new HTTPTransport(TEST_PORT, '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
+      await startTransport(transport);
       const res = await request('/mcp', 'POST', { 'Content-Type': 'application/json' },
         JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: {} }));
       expect(res.status).toBe(200);
     });
 
-    it('allows /health without any token', async () => {
+    it('allows explicit loopback development mode via env flag', async () => {
+      process.env.OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP = '1';
+      transport = new HTTPTransport(TEST_PORT, '127.0.0.1');
+      await startTransport(transport);
       const res = await request('/health');
       expect(res.status).toBe(200);
+    });
+
+    it('refuses external bind without auth even with development opt-in', () => {
+      expect(() => new HTTPTransport(TEST_PORT, '0.0.0.0', undefined, { allowUnauthenticatedHttp: true }))
+        .toThrow(/non-loopback host/);
+    });
+  });
+
+  describe('CORS allowlist', () => {
+    beforeEach(async () => {
+      process.env.OPENCHROME_HTTP_CORS_ORIGINS = TRUSTED_ORIGIN;
+      transport = new HTTPTransport(TEST_PORT, '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
+      await startTransport(transport);
+    });
+
+    it('rejects browser-origin MCP preflight when Origin is not allowlisted', async () => {
+      const res = await request('/mcp', 'OPTIONS', { Origin: 'https://evil.example' });
+      expect(res.status).toBe(403);
+      expect(res.headers['access-control-allow-origin']).toBeUndefined();
+    });
+
+    it('accepts browser-origin MCP preflight when Origin is allowlisted', async () => {
+      const res = await request('/mcp', 'OPTIONS', { Origin: TRUSTED_ORIGIN });
+      expect(res.status).toBe(204);
+      expect(res.headers['access-control-allow-origin']).toBe(TRUSTED_ORIGIN);
+      expect(res.headers.vary).toBe('Origin');
+    });
+
+    it('rejects browser-origin MCP POST when Origin is not allowlisted', async () => {
+      const res = await request('/mcp', 'POST', {
+        'Content-Type': 'application/json',
+        Origin: 'https://evil.example',
+      }, JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: {} }));
+      expect(res.status).toBe(403);
     });
   });
 });

--- a/tests/transports/http-bearer-auth.test.ts
+++ b/tests/transports/http-bearer-auth.test.ts
@@ -180,5 +180,18 @@ describe('HTTP Bearer Token Auth', () => {
       }, JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: {} }));
       expect(res.status).toBe(403);
     });
+
+    it('accepts same-origin MCP preflight even when Origin is not in allowlist', async () => {
+      const res = await request('/mcp', 'OPTIONS', { Origin: `http://127.0.0.1:${TEST_PORT}` });
+      expect(res.status).toBe(204);
+    });
+
+    it('accepts same-origin MCP POST even when Origin is not in allowlist', async () => {
+      const res = await request('/mcp', 'POST', {
+        'Content-Type': 'application/json',
+        Origin: `http://127.0.0.1:${TEST_PORT}`,
+      }, JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: {} }));
+      expect(res.status).toBe(200);
+    });
   });
 });

--- a/tests/transports/http-bearer-auth.test.ts
+++ b/tests/transports/http-bearer-auth.test.ts
@@ -203,5 +203,19 @@ describe('HTTP Bearer Token Auth', () => {
       }, JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: {} }));
       expect(res.status).toBe(403);
     });
+
+    it('rejects forged Host header that matches a cross-origin Origin (DNS rebinding defense)', async () => {
+      // Simulates DNS rebinding: attacker.example was rebound to loopback, so
+      // a browser at attacker.example sends Origin/Host both pointing at
+      // attacker.example. The same-origin bypass must compare against the
+      // configured server bind, not the request Host header, or the allowlist
+      // is defeated whenever unauthenticated HTTP mode is enabled.
+      const res = await request('/mcp', 'POST', {
+        'Content-Type': 'application/json',
+        Origin: 'http://attacker.example',
+        Host: 'attacker.example',
+      }, JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: {} }));
+      expect(res.status).toBe(403);
+    });
   });
 });

--- a/tests/transports/http-bearer-auth.test.ts
+++ b/tests/transports/http-bearer-auth.test.ts
@@ -5,6 +5,7 @@
  */
 
 import * as http from 'node:http';
+import * as net from 'node:net';
 
 // Inline require to avoid TS module resolution issues with dynamic transport loading
 const { HTTPTransport } = require('../../src/transports/http');
@@ -38,6 +39,48 @@ function request(
     req.on('error', reject);
     if (body) req.write(body);
     req.end();
+  });
+}
+
+function rawRequest(
+  raw: string,
+): Promise<{ status: number; body: string; headers: Record<string, string> }> {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect({ host: '127.0.0.1', port: TEST_PORT });
+    let response = '';
+
+    socket.setTimeout(3000);
+    socket.on('connect', () => socket.end(raw));
+    socket.on('data', (chunk: Buffer) => {
+      response += chunk.toString('utf8');
+    });
+    socket.on('timeout', () => socket.destroy(new Error('raw request timeout')));
+    socket.on('error', (err) => {
+      if (response) return;
+      reject(err);
+    });
+    socket.on('close', () => {
+      const [head = '', body = ''] = response.split('\r\n\r\n');
+      const statusMatch = head.match(/^HTTP\/1\.[01] (\d{3})/);
+      const headers = Object.fromEntries(
+        head
+          .split('\r\n')
+          .slice(1)
+          .map((line) => {
+            const separator = line.indexOf(':');
+            return separator === -1
+              ? undefined
+              : [line.slice(0, separator).toLowerCase(), line.slice(separator + 1).trim()];
+          })
+          .filter((entry): entry is [string, string] => Boolean(entry)),
+      );
+
+      resolve({
+        status: statusMatch ? parseInt(statusMatch[1], 10) : 0,
+        body,
+        headers,
+      });
+    });
   });
 }
 
@@ -210,12 +253,19 @@ describe('HTTP Bearer Token Auth', () => {
       // attacker.example. The same-origin bypass must compare against the
       // configured server bind, not the request Host header, or the allowlist
       // is defeated whenever unauthenticated HTTP mode is enabled.
-      const res = await request('/mcp', 'POST', {
-        'Content-Type': 'application/json',
-        Origin: 'http://attacker.example',
-        Host: 'attacker.example',
-      }, JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: {} }));
+      const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: {} });
+      const res = await rawRequest(
+        `POST /mcp HTTP/1.1\r\n` +
+        `Host: attacker.example\r\n` +
+        `Origin: http://attacker.example\r\n` +
+        `Content-Type: application/json\r\n` +
+        `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+        `Connection: close\r\n` +
+        `\r\n` +
+        body,
+      );
       expect(res.status).toBe(403);
+      expect(res.headers['access-control-allow-origin']).toBeUndefined();
     });
   });
 });

--- a/tests/transports/http-bearer-auth.test.ts
+++ b/tests/transports/http-bearer-auth.test.ts
@@ -193,5 +193,15 @@ describe('HTTP Bearer Token Auth', () => {
       }, JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: {} }));
       expect(res.status).toBe(200);
     });
+
+    it('rejects cross-origin scheme mismatch even when host:port matches Host header', async () => {
+      // The HTTP transport speaks http only; an https Origin pointing at the
+      // same host:port is cross-origin per the CORS scheme/host/port tuple.
+      const res = await request('/mcp', 'POST', {
+        'Content-Type': 'application/json',
+        Origin: `https://127.0.0.1:${TEST_PORT}`,
+      }, JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: {} }));
+      expect(res.status).toBe(403);
+    });
   });
 });

--- a/tests/transports/http-body-timeout-disable.test.ts
+++ b/tests/transports/http-body-timeout-disable.test.ts
@@ -40,7 +40,7 @@ describe('HTTP transport body timeout disable (=0)', () => {
 
   beforeEach(async () => {
     port = await ephemeralPort();
-    transport = new HTTPTransport(port, '127.0.0.1');
+    transport = new HTTPTransport(port, '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
     transport.onMessage(async (msg: Record<string, unknown>) => ({
       jsonrpc: '2.0',
       id: msg.id ?? 0,

--- a/tests/transports/http-body-timeout.test.ts
+++ b/tests/transports/http-body-timeout.test.ts
@@ -44,7 +44,7 @@ describe('HTTP transport body/socket timeouts', () => {
 
   beforeEach(async () => {
     port = await ephemeralPort();
-    transport = new HTTPTransport(port, '127.0.0.1');
+    transport = new HTTPTransport(port, '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
     transport.onMessage(async (msg: Record<string, unknown>) => ({
       jsonrpc: '2.0',
       id: msg.id ?? 0,

--- a/tests/transports/http-socket-timeout-long-tool.test.ts
+++ b/tests/transports/http-socket-timeout-long-tool.test.ts
@@ -36,7 +36,7 @@ describe('HTTP transport socket timeout during long-running tool execution', () 
 
   beforeEach(async () => {
     port = await ephemeralPort();
-    transport = new HTTPTransport(port, '127.0.0.1');
+    transport = new HTTPTransport(port, '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
     transport.onMessage(async (msg: Record<string, unknown>) => {
       await new Promise((resolve) => setTimeout(resolve, 250));
       return {

--- a/tests/transports/http-streamable.test.ts
+++ b/tests/transports/http-streamable.test.ts
@@ -49,7 +49,7 @@ describe('Streamable HTTP - POST with Accept: text/event-stream', () => {
   let transport: InstanceType<typeof HTTPTransport>;
 
   beforeEach(async () => {
-    transport = new HTTPTransport(TEST_PORT, '127.0.0.1');
+    transport = new HTTPTransport(TEST_PORT, '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
     transport.onMessage(async (msg: Record<string, unknown>) => {
       // Notifications (no id) return null per MCP spec
       if (!msg.id) return null;

--- a/tests/transports/http-tenant.test.ts
+++ b/tests/transports/http-tenant.test.ts
@@ -63,7 +63,10 @@ describe('HTTP transport — tenant extraction (#7)', () => {
   });
 
   async function boot(handler?: (msg: Record<string, unknown>) => Promise<Record<string, unknown>>) {
-    transport = new HTTPTransport(TEST_PORT, '127.0.0.1');
+    transport = new HTTPTransport(TEST_PORT, '127.0.0.1', undefined, {
+      allowUnauthenticatedHttp: true,
+      corsAllowedOrigins: ['http://example.com'],
+    });
     transport.onMessage(async (msg: Record<string, unknown>) => ({
       jsonrpc: '2.0',
       id: msg.id,

--- a/tests/transports/http-transport-phase1.test.ts
+++ b/tests/transports/http-transport-phase1.test.ts
@@ -65,7 +65,7 @@ describe('HTTP Transport Phase 1', () => {
 
   describe('/mcp/sse endpoint', () => {
     beforeEach(async () => {
-      transport = new HTTPTransport(TEST_PORT, '127.0.0.1');
+      transport = new HTTPTransport(TEST_PORT, '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
       transport.onMessage(async (msg: Record<string, unknown>) => {
         return { jsonrpc: '2.0', id: msg.id, result: {} };
       });
@@ -108,7 +108,7 @@ describe('HTTP Transport Phase 1', () => {
 
   describe('SSE keepalive timer', () => {
     it('cleans up keepalive timer on close', async () => {
-      transport = new HTTPTransport(TEST_PORT, '127.0.0.1');
+      transport = new HTTPTransport(TEST_PORT, '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
       transport.onMessage(async () => null);
       transport.start();
       await new Promise((r) => setTimeout(r, 100));
@@ -119,7 +119,7 @@ describe('HTTP Transport Phase 1', () => {
 
   describe('404 for unknown paths', () => {
     beforeEach(async () => {
-      transport = new HTTPTransport(TEST_PORT, '127.0.0.1');
+      transport = new HTTPTransport(TEST_PORT, '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
       transport.onMessage(async () => null);
       transport.start();
       await new Promise((r) => setTimeout(r, 100));
@@ -140,7 +140,7 @@ describe('Transport mode types', () => {
 
   it('createTransport with http mode returns HTTPTransport', () => {
     const { createTransport } = require('../../src/transports/index');
-    const t = createTransport('http', { port: 19999 });
+    const t = createTransport('http', { port: 19999, allowUnauthenticatedHttp: true });
     expect(t).toBeDefined();
     expect(typeof t.start).toBe('function');
     expect(typeof t.close).toBe('function');
@@ -150,7 +150,7 @@ describe('Transport mode types', () => {
     const { StdioTransport } = require('../../src/transports/stdio');
     const { HTTPTransport: HTTP } = require('../../src/transports/http');
     const stdio = new StdioTransport();
-    const httpT = new HTTP(19997, '127.0.0.1');
+    const httpT = new HTTP(19997, '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
     expect(stdio).toBeDefined();
     expect(httpT).toBeDefined();
     expect(typeof stdio.start).toBe('function');


### PR DESCRIPTION
## Summary
- Fail closed for HTTP transport startup when no auth mode is configured by default.
- Add an explicit loopback-only compatibility opt-in for unauthenticated local HTTP development.
- Tighten browser-origin MCP CORS to an allowlist while preserving non-browser/local client flows and bearer/API-key/JWT auth compatibility.
- Update focused HTTP transport and health endpoint tests for the new explicit unauthenticated opt-in and CORS policy.

## Discussion / implementation notes
- `stdio` remains unaffected.
- Unauthenticated HTTP can still be used only by explicitly opting in and only on loopback hosts.
- Browser requests with `Origin` to MCP endpoints must match the configured CORS allowlist; preflight includes `Authorization` and tenant/request headers.
- The CLI exposes `--allow-unauthenticated-http`; env parsing for `OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP` stays centralized in `HTTPTransport`.

## Risk / vulnerability analysis
- Security risk is reduced by preventing silent unauthenticated daemon HTTP exposure.
- Backward compatibility is preserved via explicit loopback-only opt-in for local development/tests.
- External binds still require an auth mechanism even when the compatibility opt-in is set.

## Validation
- [x] `./node_modules/.bin/jest tests/transports/http-bearer-auth.test.ts --runInBand --no-cache`
- [x] `./node_modules/.bin/jest tests/integration/health-endpoint-gating.test.ts --runInBand --no-cache --testTimeout=90000 --silent`
- [x] `./node_modules/.bin/jest tests/transports/http-transport-phase1.test.ts tests/transports/http-body-timeout.test.ts tests/transports/http-abort-on-disconnect.test.ts --runInBand --no-cache --testTimeout=30000 --silent`
- [x] `./node_modules/.bin/jest tests/transports/http-bearer-auth.test.ts tests/transports/http-streamable.test.ts tests/transports/http-socket-timeout-long-tool.test.ts tests/transports/http-tenant.test.ts tests/transports/http-body-timeout-disable.test.ts --runInBand --no-cache --testTimeout=30000 --silent`
- [x] `./node_modules/.bin/tsc -p tsconfig.cli.json --pretty false --incremental false`
- [x] `./node_modules/.bin/tsc -p tsconfig.json --pretty false --incremental false`
- [x] `git diff --check`
- [x] `./node_modules/.bin/eslint src/transports/http.ts src/transports/index.ts --max-warnings=0`
- [x] Remote CI: 9/9 checks passed on `8feca28`

Note: full changed-file ESLint including `src/index.ts` still reports existing baseline unused-import warnings in `src/index.ts`; this PR does not introduce those warnings.

Closes #681
