### PR TITLE
fix: authorize dashboard REST endpoints

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -73,6 +73,18 @@ Each key is issued with one or more scopes. Scopes are additive; `write` implies
 
 Scope implication chain: `admin` > `write` > `read`. `headless-only` is orthogonal and enforced separately by the caller.
 
+### Dashboard REST endpoints
+
+Dashboard REST endpoints use the same trusted HTTP principal as `/mcp`; clients cannot supply scope or tenant identity in JSON bodies or query parameters. Missing or invalid bearer auth returns `401`; authenticated callers without the required endpoint scope, or callers requesting another tenant's session, receive `403`.
+
+| Endpoint | Required scope | Tenant/session rule |
+|---|---|---|
+| `GET /api/screenshot` | `read` | When `session_id` or `sessionId` is supplied, the session must belong to the caller's tenant. |
+| `GET /api/sessions` | `read` | API-key/JWT callers receive only sessions owned by their tenant. |
+| `GET /api/tool-calls` | `admin` | Admin-only because tool-call records can include sensitive arguments. |
+| `GET /api/metrics` | `admin` | Admin-only while the endpoint exposes global process/server counters. |
+
+
 ---
 
 ## Key rotation

--- a/src/middleware/dashboard-authz.ts
+++ b/src/middleware/dashboard-authz.ts
@@ -1,0 +1,54 @@
+import type { IncomingMessage } from 'node:http';
+import type { Principal, Scope } from '../auth/api-key-types';
+import { requestPrincipals } from './auth';
+
+export type DashboardEndpoint = 'screenshot' | 'sessions' | 'tool-calls' | 'metrics';
+
+export type DashboardAuthzResult =
+  | { ok: true; principal: Principal }
+  | { ok: false; status: 401 | 403; error: string };
+
+export interface DashboardAuthzOptions {
+  requestedSessionTenantId?: string;
+  requireSessionOwnership?: boolean;
+}
+
+function hasScope(principal: Principal, required: Scope): boolean {
+  if (principal.scopes.includes('admin')) return true;
+  if (required === 'admin') return false;
+  if (principal.scopes.includes('write')) return true;
+  return required === 'read' && principal.scopes.includes('read');
+}
+
+function isTenantPrincipal(principal: Principal): boolean {
+  return principal.mode === 'api-key' || principal.mode === 'jwt';
+}
+
+export function canSeeTenant(principal: Principal, tenantId: string | undefined): boolean {
+  if (!isTenantPrincipal(principal)) return true;
+  return tenantId !== undefined && tenantId === principal.tenantId;
+}
+
+export function authorizeDashboardEndpoint(
+  req: IncomingMessage,
+  endpoint: DashboardEndpoint,
+  options: DashboardAuthzOptions = {},
+): DashboardAuthzResult {
+  const principal = requestPrincipals.get(req);
+  if (!principal) {
+    return { ok: false, status: 401, error: 'Unauthorized' };
+  }
+
+  const requiredScope: Scope = endpoint === 'tool-calls' || endpoint === 'metrics'
+    ? 'admin'
+    : 'read';
+  if (!hasScope(principal, requiredScope)) {
+    return { ok: false, status: 403, error: 'Forbidden' };
+  }
+
+  if (options.requireSessionOwnership && !canSeeTenant(principal, options.requestedSessionTenantId)) {
+    return { ok: false, status: 403, error: 'Forbidden' };
+  }
+
+  return { ok: true, principal };
+}

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -1738,6 +1738,7 @@ export class SessionManager {
       createdAt: session.createdAt,
       lastActivityAt: session.lastActivityAt,
       name: session.name,
+      tenantId: session.tenantId,
     };
   }
 

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -33,6 +33,7 @@ import {
   type Principal,
 } from '../middleware/auth';
 import { logAuditEntry } from '../security/audit-logger';
+import { authorizeDashboardEndpoint, canSeeTenant } from '../middleware/dashboard-authz';
 import { extractTenantId, TenantIdError } from '../middleware/tenant-extractor';
 import { isStrictTenantIsolationEnabled } from '../tenant/registry';
 import type { TenantId } from '../tenant/types';
@@ -381,19 +382,19 @@ export class HTTPTransport implements MCPTransport {
 
     // ─── Dashboard REST API ────────────────────────────────────────────
     if (pathname === '/api/screenshot' && req.method === 'GET') {
-      this.handleScreenshot(url, res);
+      this.handleScreenshot(req, url, res);
       return;
     }
     if (pathname === '/api/sessions' && req.method === 'GET') {
-      this.handleSessions(res);
+      this.handleSessions(req, res);
       return;
     }
     if (pathname === '/api/tool-calls' && req.method === 'GET') {
-      this.handleToolCalls(url, res);
+      this.handleToolCalls(req, url, res);
       return;
     }
     if (pathname === '/api/metrics' && req.method === 'GET') {
-      this.handleMetrics(res);
+      this.handleMetrics(req, res);
       return;
     }
 
@@ -516,12 +517,30 @@ export class HTTPTransport implements MCPTransport {
   /**
    * GET /api/screenshot - capture active tab screenshot as base64 WebP
    */
-  private handleScreenshot(url: URL, res: http.ServerResponse): void {
-    const sessionId = url.searchParams.get('session_id') || 'default';
+  private handleScreenshot(req: http.IncomingMessage, url: URL, res: http.ServerResponse): void {
+    const requestedSessionId = url.searchParams.get('session_id') || url.searchParams.get('sessionId');
+    const sessionId = requestedSessionId || 'default';
 
     if (!this.sessionManager) {
+      const authz = authorizeDashboardEndpoint(req, 'screenshot');
+      if (!authz.ok) {
+        this.writeDashboardAuthzFailure(res, authz.status, authz.error);
+        return;
+      }
       res.writeHead(503, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Session manager not available' }));
+      return;
+    }
+
+    const sessionInfo = requestedSessionId
+      ? this.sessionManager.getAllSessionInfos().find((s) => s.id === requestedSessionId)
+      : undefined;
+    const authz = authorizeDashboardEndpoint(req, 'screenshot', {
+      requireSessionOwnership: requestedSessionId !== null,
+      requestedSessionTenantId: sessionInfo?.tenantId,
+    });
+    if (!authz.ok) {
+      this.writeDashboardAuthzFailure(res, authz.status, authz.error);
       return;
     }
 
@@ -533,8 +552,17 @@ export class HTTPTransport implements MCPTransport {
       .catch((err) => {
         console.error('[HTTPTransport] Screenshot error:', err);
         res.writeHead(500, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: err instanceof Error ? err.message : 'Screenshot failed' }));
+        res.end(JSON.stringify({ error: 'Screenshot failed' }));
       });
+  }
+
+  private writeDashboardAuthzFailure(
+    res: http.ServerResponse,
+    status: 401 | 403,
+    error: string,
+  ): void {
+    res.writeHead(status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error }));
   }
 
   private async captureScreenshot(sessionId: string): Promise<{ base64: string; format: string; sessionId: string }> {
@@ -585,14 +613,21 @@ export class HTTPTransport implements MCPTransport {
   /**
    * GET /api/sessions - return connected sessions with tab counts
    */
-  private handleSessions(res: http.ServerResponse): void {
+  private handleSessions(req: http.IncomingMessage, res: http.ServerResponse): void {
+    const authz = authorizeDashboardEndpoint(req, 'sessions');
+    if (!authz.ok) {
+      this.writeDashboardAuthzFailure(res, authz.status, authz.error);
+      return;
+    }
+
     if (!this.sessionManager) {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ sessions: [] }));
       return;
     }
 
-    const infos = this.sessionManager.getAllSessionInfos();
+    const infos = this.sessionManager.getAllSessionInfos()
+      .filter((info) => canSeeTenant(authz.principal, info.tenantId));
     const sessions = infos.map((info) => ({
       id: info.id,
       name: info.name,
@@ -609,7 +644,13 @@ export class HTTPTransport implements MCPTransport {
   /**
    * GET /api/tool-calls - return recent tool calls from dashboard state
    */
-  private handleToolCalls(url: URL, res: http.ServerResponse): void {
+  private handleToolCalls(req: http.IncomingMessage, url: URL, res: http.ServerResponse): void {
+    const authz = authorizeDashboardEndpoint(req, 'tool-calls');
+    if (!authz.ok) {
+      this.writeDashboardAuthzFailure(res, authz.status, authz.error);
+      return;
+    }
+
     const sessionId = url.searchParams.get('session_id') || undefined;
     const limit = parseInt(url.searchParams.get('limit') || '20', 10);
     const clampedLimit = Math.min(Math.max(1, limit), 100);
@@ -624,7 +665,13 @@ export class HTTPTransport implements MCPTransport {
   /**
    * GET /api/metrics - return server metrics
    */
-  private handleMetrics(res: http.ServerResponse): void {
+  private handleMetrics(req: http.IncomingMessage, res: http.ServerResponse): void {
+    const authz = authorizeDashboardEndpoint(req, 'metrics');
+    if (!authz.ok) {
+      this.writeDashboardAuthzFailure(res, authz.status, authz.error);
+      return;
+    }
+
     const mem = process.memoryUsage();
     const dashboardState = getDashboardState();
 

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -532,12 +532,13 @@ export class HTTPTransport implements MCPTransport {
       return;
     }
 
-    const sessionInfo = requestedSessionId
-      ? this.sessionManager.getAllSessionInfos().find((s) => s.id === requestedSessionId)
-      : undefined;
+    // Always look up the resolved session — including the implicit "default" —
+    // so that a tenant-scoped caller cannot read another tenant's default
+    // session screenshot just by omitting `session_id`.
+    const session = this.sessionManager.getSession(sessionId);
     const authz = authorizeDashboardEndpoint(req, 'screenshot', {
-      requireSessionOwnership: requestedSessionId !== null,
-      requestedSessionTenantId: sessionInfo?.tenantId,
+      requireSessionOwnership: true,
+      requestedSessionTenantId: session?.tenantId,
     });
     if (!authz.ok) {
       this.writeDashboardAuthzFailure(res, authz.status, authz.error);
@@ -645,18 +646,34 @@ export class HTTPTransport implements MCPTransport {
    * GET /api/tool-calls - return recent tool calls from dashboard state
    */
   private handleToolCalls(req: http.IncomingMessage, url: URL, res: http.ServerResponse): void {
-    const authz = authorizeDashboardEndpoint(req, 'tool-calls');
+    const sessionId = url.searchParams.get('session_id') || undefined;
+    const requestedSession = sessionId && this.sessionManager
+      ? this.sessionManager.getSession(sessionId)
+      : undefined;
+
+    const authz = authorizeDashboardEndpoint(req, 'tool-calls', {
+      requireSessionOwnership: sessionId !== undefined,
+      requestedSessionTenantId: requestedSession?.tenantId,
+    });
     if (!authz.ok) {
       this.writeDashboardAuthzFailure(res, authz.status, authz.error);
       return;
     }
 
-    const sessionId = url.searchParams.get('session_id') || undefined;
     const limit = parseInt(url.searchParams.get('limit') || '20', 10);
     const clampedLimit = Math.min(Math.max(1, limit), 100);
 
     const dashboardState = getDashboardState();
-    const calls = dashboardState.getToolCalls(sessionId, clampedLimit);
+    let calls = dashboardState.getToolCalls(sessionId, clampedLimit);
+
+    // Tenant-scoped admins must not see tool calls from other tenants. When the
+    // session has been deleted we cannot prove ownership, so the call is hidden.
+    const sm = this.sessionManager;
+    if (sm) {
+      calls = calls.filter((c) => canSeeTenant(authz.principal, sm.getSession(c.sessionId)?.tenantId));
+    } else if (!canSeeTenant(authz.principal, undefined)) {
+      calls = [];
+    }
 
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ calls }));

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -524,7 +524,7 @@ export class HTTPTransport implements MCPTransport {
     if (!this.sessionManager) {
       const authz = authorizeDashboardEndpoint(req, 'screenshot');
       if (!authz.ok) {
-        this.writeDashboardAuthzFailure(res, authz.status, authz.error);
+        this.writeDashboardAuthzFailure(res, 'screenshot', sessionId, authz.status, authz.error);
         return;
       }
       res.writeHead(503, { 'Content-Type': 'application/json' });
@@ -541,7 +541,7 @@ export class HTTPTransport implements MCPTransport {
       requestedSessionTenantId: session?.tenantId,
     });
     if (!authz.ok) {
-      this.writeDashboardAuthzFailure(res, authz.status, authz.error);
+      this.writeDashboardAuthzFailure(res, 'screenshot', sessionId, authz.status, authz.error);
       return;
     }
 
@@ -559,9 +559,18 @@ export class HTTPTransport implements MCPTransport {
 
   private writeDashboardAuthzFailure(
     res: http.ServerResponse,
+    endpoint: 'screenshot' | 'sessions' | 'tool-calls' | 'metrics',
+    sessionId: string,
     status: 401 | 403,
     error: string,
   ): void {
+    // Audit denial so that probing of cross-tenant resources is observable in
+    // the same place that auth_failure entries already live.
+    try {
+      logAuditEntry('dashboard_authz_failure', sessionId, { endpoint, status }, undefined, { status: 'error' });
+    } catch {
+      // best-effort
+    }
     res.writeHead(status, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error }));
   }
@@ -617,7 +626,7 @@ export class HTTPTransport implements MCPTransport {
   private handleSessions(req: http.IncomingMessage, res: http.ServerResponse): void {
     const authz = authorizeDashboardEndpoint(req, 'sessions');
     if (!authz.ok) {
-      this.writeDashboardAuthzFailure(res, authz.status, authz.error);
+      this.writeDashboardAuthzFailure(res, 'sessions', 'anonymous', authz.status, authz.error);
       return;
     }
 
@@ -656,7 +665,7 @@ export class HTTPTransport implements MCPTransport {
       requestedSessionTenantId: requestedSession?.tenantId,
     });
     if (!authz.ok) {
-      this.writeDashboardAuthzFailure(res, authz.status, authz.error);
+      this.writeDashboardAuthzFailure(res, 'tool-calls', sessionId ?? 'anonymous', authz.status, authz.error);
       return;
     }
 
@@ -685,7 +694,7 @@ export class HTTPTransport implements MCPTransport {
   private handleMetrics(req: http.IncomingMessage, res: http.ServerResponse): void {
     const authz = authorizeDashboardEndpoint(req, 'metrics');
     if (!authz.ok) {
-      this.writeDashboardAuthzFailure(res, authz.status, authz.error);
+      this.writeDashboardAuthzFailure(res, 'metrics', 'anonymous', authz.status, authz.error);
       return;
     }
 
@@ -695,9 +704,14 @@ export class HTTPTransport implements MCPTransport {
     let tabCount = 0;
     let sessionCount = 0;
     if (this.sessionManager) {
-      const stats = this.sessionManager.getStats();
-      tabCount = stats.totalTargets;
-      sessionCount = stats.activeSessions;
+      // Tenant-scoped principals must only see counts for their own tenant —
+      // the global getStats() exposes activity from every tenant.
+      const visible = this.sessionManager.getAllSessionInfos()
+        .filter((info) => canSeeTenant(authz.principal, info.tenantId));
+      sessionCount = visible.length;
+      for (const info of visible) {
+        tabCount += info.targetCount;
+      }
     }
 
     const metrics = {

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -63,6 +63,7 @@ export interface SessionInfo {
   createdAt: number;
   lastActivityAt: number;
   name: string;
+  tenantId?: TenantId;
 }
 
 export interface SessionCreateOptions {

--- a/tests/security/dashboard-rest-authz.test.ts
+++ b/tests/security/dashboard-rest-authz.test.ts
@@ -144,6 +144,19 @@ describe('dashboard REST authorization', () => {
     expect(JSON.parse(res.body).session_count).toBe(2);
   });
 
+  it('reports per-tenant metrics counts to tenant-scoped admins', async () => {
+    const booted = await boot(undefined, fakeStore({ [adminAlpha]: { tenantId: 'alpha', scopes: ['admin'] } }));
+    transport = booted.transport;
+
+    const res = await request(booted.port, '/api/metrics', { Authorization: `Bearer ${adminAlpha}` });
+
+    expect(res.status).toBe(200);
+    const data = JSON.parse(res.body);
+    // Two sessions exist globally (alpha, beta); the alpha admin must only see one.
+    expect(data.session_count).toBe(1);
+    expect(data.tab_count).toBe(0);
+  });
+
   it('allows read-scoped session listing but omits other-tenant sessions', async () => {
     const booted = await boot(undefined, fakeStore({ [readAlpha]: { tenantId: 'alpha', scopes: ['read'] } }));
     transport = booted.transport;

--- a/tests/security/dashboard-rest-authz.test.ts
+++ b/tests/security/dashboard-rest-authz.test.ts
@@ -1,0 +1,194 @@
+/// <reference types="jest" />
+
+import * as http from 'node:http';
+import * as net from 'node:net';
+import { IncomingMessage } from 'node:http';
+import { HTTPTransport } from '../../src/transports/http';
+import { authorizeDashboardEndpoint } from '../../src/middleware/dashboard-authz';
+import { requestPrincipals, PRINCIPAL_SYM } from '../../src/middleware/auth';
+import type { Principal, Scope } from '../../src/auth/api-key-types';
+
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('No port assigned')));
+        return;
+      }
+      const port = address.port;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+type ResponseTuple = { status: number; body: string; headers: http.IncomingHttpHeaders };
+
+function request(port: number, path: string, headers: Record<string, string> = {}): Promise<ResponseTuple> {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ hostname: '127.0.0.1', port, path, method: 'GET', headers }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (chunk: Buffer) => chunks.push(chunk));
+      res.on('end', () => resolve({
+        status: res.statusCode || 0,
+        body: Buffer.concat(chunks).toString(),
+        headers: res.headers,
+      }));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+function fakeStore(records: Record<string, { tenantId: string; scopes: Scope[] }>) {
+  return {
+    verify: jest.fn(async (token: string) => {
+      const record = records[token];
+      if (!record) return null;
+      return {
+        keyId: `k_${record.tenantId}`,
+        keyHash: 'hash',
+        tenantId: record.tenantId,
+        scopes: record.scopes,
+        createdAt: Date.now(),
+        description: 'test',
+      };
+    }),
+    touchLastUsed: jest.fn(async () => undefined),
+  };
+}
+
+function sessionManager() {
+  return {
+    getAllSessionInfos: jest.fn(() => [
+      {
+        id: 'alpha-session',
+        name: 'Alpha',
+        targetCount: 0,
+        workerCount: 0,
+        workers: [],
+        createdAt: 1,
+        lastActivityAt: 2,
+        tenantId: 'alpha',
+      },
+      {
+        id: 'beta-session',
+        name: 'Beta',
+        targetCount: 0,
+        workerCount: 0,
+        workers: [],
+        createdAt: 3,
+        lastActivityAt: 4,
+        tenantId: 'beta',
+      },
+    ]),
+    getStats: jest.fn(() => ({ totalTargets: 0, activeSessions: 2 })),
+  };
+}
+
+async function boot(authToken?: string, store?: ReturnType<typeof fakeStore>) {
+  const port = await freePort();
+  const transport = new HTTPTransport(port, '127.0.0.1', authToken, store ? { apiKeyStore: store as never } : {});
+  transport.setSessionManager(sessionManager() as never);
+  transport.onMessage(async (msg: Record<string, unknown>) => ({
+    jsonrpc: '2.0',
+    id: (typeof msg.id === 'string' || typeof msg.id === 'number') ? msg.id : 0,
+    result: { ok: true },
+  }));
+  transport.start();
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  return { port, transport };
+}
+
+describe('dashboard REST authorization', () => {
+  let transport: InstanceType<typeof HTTPTransport> | undefined;
+  const readAlpha = 'oc_live_alpha_read';
+  const adminAlpha = 'oc_live_alpha_admin';
+
+  afterEach(async () => {
+    if (transport) await transport.close();
+    transport = undefined;
+  });
+
+  it('returns 401 for dashboard REST endpoints when auth is configured but missing', async () => {
+    const booted = await boot('shared-secret');
+    transport = booted.transport;
+
+    const res = await request(booted.port, '/api/sessions');
+
+    expect(res.status).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('keeps disabled auth backward-compatible for dashboard REST', async () => {
+    const booted = await boot();
+    transport = booted.transport;
+
+    const res = await request(booted.port, '/api/metrics');
+
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body).session_count).toBe(2);
+  });
+
+  it('allows read-scoped session listing but omits other-tenant sessions', async () => {
+    const booted = await boot(undefined, fakeStore({ [readAlpha]: { tenantId: 'alpha', scopes: ['read'] } }));
+    transport = booted.transport;
+
+    const res = await request(booted.port, '/api/sessions', { Authorization: `Bearer ${readAlpha}` });
+
+    expect(res.status).toBe(200);
+    const data = JSON.parse(res.body);
+    expect(data.sessions.map((s: { id: string }) => s.id)).toEqual(['alpha-session']);
+    expect(JSON.stringify(data)).not.toContain('beta-session');
+  });
+
+  it('requires admin for tool-call and global metrics endpoints', async () => {
+    const booted = await boot(undefined, fakeStore({
+      [readAlpha]: { tenantId: 'alpha', scopes: ['read'] },
+      [adminAlpha]: { tenantId: 'alpha', scopes: ['admin'] },
+    }));
+    transport = booted.transport;
+
+    const readToolCalls = await request(booted.port, '/api/tool-calls', { Authorization: `Bearer ${readAlpha}` });
+    const readMetrics = await request(booted.port, '/api/metrics', { Authorization: `Bearer ${readAlpha}` });
+    const adminToolCalls = await request(booted.port, '/api/tool-calls', { Authorization: `Bearer ${adminAlpha}` });
+    const adminMetrics = await request(booted.port, '/api/metrics', { Authorization: `Bearer ${adminAlpha}` });
+
+    expect(readToolCalls.status).toBe(403);
+    expect(JSON.parse(readToolCalls.body)).toEqual({ error: 'Forbidden' });
+    expect(readMetrics.status).toBe(403);
+    expect(adminToolCalls.status).toBe(200);
+    expect(adminMetrics.status).toBe(200);
+  });
+
+  it('rejects cross-tenant requested screenshots without leaking session details', async () => {
+    const booted = await boot(undefined, fakeStore({ [readAlpha]: { tenantId: 'alpha', scopes: ['read'] } }));
+    transport = booted.transport;
+
+    const res = await request(booted.port, '/api/screenshot?session_id=beta-session', {
+      Authorization: `Bearer ${readAlpha}`,
+    });
+
+    expect(res.status).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Forbidden' });
+    expect(res.body).not.toContain('beta-session');
+  });
+});
+
+describe('dashboard REST principal trust boundary', () => {
+  it('uses requestPrincipals instead of forgeable request fields', () => {
+    const req = new IncomingMessage(null as never) as IncomingMessage & {
+      __principal?: Principal;
+      [PRINCIPAL_SYM]?: Principal;
+    };
+    req.__principal = { tenantId: 'attacker', scopes: ['admin'], mode: 'api-key' };
+    req[PRINCIPAL_SYM] = { tenantId: 'attacker', scopes: ['admin'], mode: 'api-key' };
+    requestPrincipals.set(req, { tenantId: 'alpha', scopes: ['read'], mode: 'api-key' });
+
+    const result = authorizeDashboardEndpoint(req, 'metrics');
+
+    expect(result).toEqual({ ok: false, status: 403, error: 'Forbidden' });
+  });
+});

--- a/tests/security/dashboard-rest-authz.test.ts
+++ b/tests/security/dashboard-rest-authz.test.ts
@@ -60,7 +60,14 @@ function fakeStore(records: Record<string, { tenantId: string; scopes: Scope[] }
   };
 }
 
-function sessionManager() {
+function sessionManager(extras: { defaultTenantId?: string } = {}) {
+  const sessions = new Map<string, { id: string; tenantId: string }>([
+    ['alpha-session', { id: 'alpha-session', tenantId: 'alpha' }],
+    ['beta-session', { id: 'beta-session', tenantId: 'beta' }],
+  ]);
+  if (extras.defaultTenantId) {
+    sessions.set('default', { id: 'default', tenantId: extras.defaultTenantId });
+  }
   return {
     getAllSessionInfos: jest.fn(() => [
       {
@@ -84,14 +91,19 @@ function sessionManager() {
         tenantId: 'beta',
       },
     ]),
+    getSession: jest.fn((id: string) => sessions.get(id)),
     getStats: jest.fn(() => ({ totalTargets: 0, activeSessions: 2 })),
   };
 }
 
-async function boot(authToken?: string, store?: ReturnType<typeof fakeStore>) {
+async function boot(
+  authToken?: string,
+  store?: ReturnType<typeof fakeStore>,
+  smOverrides: { defaultTenantId?: string } = {},
+) {
   const port = await freePort();
   const transport = new HTTPTransport(port, '127.0.0.1', authToken, store ? { apiKeyStore: store as never } : {});
-  transport.setSessionManager(sessionManager() as never);
+  transport.setSessionManager(sessionManager(smOverrides) as never);
   transport.onMessage(async (msg: Record<string, unknown>) => ({
     jsonrpc: '2.0',
     id: (typeof msg.id === 'string' || typeof msg.id === 'number') ? msg.id : 0,
@@ -174,6 +186,65 @@ describe('dashboard REST authorization', () => {
     expect(res.status).toBe(403);
     expect(JSON.parse(res.body)).toEqual({ error: 'Forbidden' });
     expect(res.body).not.toContain('beta-session');
+  });
+
+  it('blocks default-session screenshots when the default belongs to another tenant', async () => {
+    const booted = await boot(
+      undefined,
+      fakeStore({ [readAlpha]: { tenantId: 'alpha', scopes: ['read'] } }),
+      { defaultTenantId: 'beta' },
+    );
+    transport = booted.transport;
+
+    const res = await request(booted.port, '/api/screenshot', {
+      Authorization: `Bearer ${readAlpha}`,
+    });
+
+    expect(res.status).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Forbidden' });
+  });
+
+  it('hides cross-tenant tool calls from tenant-scoped admins listing without session_id', async () => {
+    const booted = await boot(
+      undefined,
+      fakeStore({ [adminAlpha]: { tenantId: 'alpha', scopes: ['admin'] } }),
+    );
+    transport = booted.transport;
+
+    const { getDashboardState } = await import('../../src/desktop/dashboard-state');
+    const state = getDashboardState();
+    state.recordToolStart('alpha-session', 'navigate', { url: 'https://alpha.example' }, 'call-alpha');
+    state.recordToolStart('beta-session', 'navigate', { url: 'https://beta.example' }, 'call-beta');
+
+    try {
+      const res = await request(booted.port, '/api/tool-calls', {
+        Authorization: `Bearer ${adminAlpha}`,
+      });
+
+      expect(res.status).toBe(200);
+      const data = JSON.parse(res.body) as { calls: Array<{ id: string; sessionId: string }> };
+      const ids = data.calls.map((c) => c.id);
+      expect(ids).toContain('call-alpha');
+      expect(ids).not.toContain('call-beta');
+    } finally {
+      state.recordToolEnd('call-alpha', 'success');
+      state.recordToolEnd('call-beta', 'success');
+    }
+  });
+
+  it('rejects tool-call requests targeting another tenant\'s session', async () => {
+    const booted = await boot(
+      undefined,
+      fakeStore({ [adminAlpha]: { tenantId: 'alpha', scopes: ['admin'] } }),
+    );
+    transport = booted.transport;
+
+    const res = await request(booted.port, '/api/tool-calls?session_id=beta-session', {
+      Authorization: `Bearer ${adminAlpha}`,
+    });
+
+    expect(res.status).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Forbidden' });
   });
 });
 


### PR DESCRIPTION
## Summary
- enforce request-principal authorization for dashboard REST endpoints
- scope session/screenshot access by tenant and require admin for tool-call/metrics endpoints
- document dashboard REST scope expectations and add focused authz tests

Closes #682

## Validation
- ./node_modules/.bin/jest tests/security/dashboard-rest-authz.test.ts tests/transports/http-bearer-auth.test.ts tests/transports/http-tenant.test.ts --runInBand --no-cache --testTimeout=90000 --silent
- ./node_modules/.bin/tsc -p tsconfig.json --pretty false --incremental false
- ./node_modules/.bin/tsc -p tsconfig.cli.json --pretty false --incremental false
- ./node_modules/.bin/eslint src/middleware/dashboard-authz.ts src/transports/http.ts src/session-manager.ts src/types/session.ts --max-warnings=0
- git diff --check
