### PR TITLE
fix: guard screenshot payload sizes

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -27,6 +27,12 @@ export const DEFAULT_PROTOCOL_TIMEOUT_MS = 30000;
 /** Screenshot-specific timeout. Shorter than protocol timeout for fast fallback. */
 export const DEFAULT_SCREENSHOT_TIMEOUT_MS = 15000;
 
+/** Maximum base64-encoded image bytes returned inline in MCP responses (10 MiB). */
+export const MAX_INLINE_IMAGE_PAYLOAD_BYTES = 10 * 1024 * 1024;
+
+/** Maximum screenshot capture area in CSS pixels (25 megapixels). */
+export const MAX_CAPTURE_AREA_PIXELS = 25 * 1000 * 1000;
+
 /** Maximum number of tabs (targets) per worker. Oldest tab is closed when limit is reached. */
 export const DEFAULT_MAX_TARGETS_PER_WORKER = 5;
 

--- a/src/tools/computer.ts
+++ b/src/tools/computer.ts
@@ -197,9 +197,12 @@ const handler: ToolHandler = async (
           };
         }
 
-        const viewport = page.viewport();
+        // Fall back to a sensible default (matches src/vision/screenshot-analyzer.ts)
+        // when page.viewport() returns null so the area guard cannot be silently
+        // bypassed by a 0x0 area report.
+        const viewport = page.viewport() ?? { width: 1920, height: 1080 };
         const areaError = validateCaptureArea(
-          { width: viewport?.width ?? 0, height: viewport?.height ?? 0 },
+          { width: viewport.width, height: viewport.height },
           'Screenshot'
         );
         if (areaError) {

--- a/src/tools/computer.ts
+++ b/src/tools/computer.ts
@@ -13,6 +13,7 @@ import { generateVisualSummary } from '../utils/visual-summary';
 import { AdaptiveScreenshot } from '../utils/adaptive-screenshot';
 import { withTimeout } from '../utils/with-timeout';
 import { retryWithFallback } from '../utils/retry-with-fallback';
+import { getBase64EncodedByteLength, validateCaptureArea, validateInlineImagePayload } from '../utils/screenshot-guards';
 
 const definition: MCPToolDefinition = {
   name: 'computer',
@@ -196,8 +197,25 @@ const handler: ToolHandler = async (
           };
         }
 
+        const viewport = page.viewport();
+        const areaError = validateCaptureArea(
+          { width: viewport?.width ?? 0, height: viewport?.height ?? 0 },
+          'Screenshot'
+        );
+        if (areaError) {
+          return {
+            content: [{ type: 'text', text: `Error: ${areaError}` }],
+            isError: true,
+          };
+        }
+
         // Phase 2: Screenshot with retry
-        const attemptScreenshot = async (): Promise<{ data: string; mimeType: string } | null> => {
+        type ScreenshotAttempt =
+          | { status: 'success'; data: string; mimeType: string }
+          | { status: 'timeout' }
+          | { status: 'error' };
+
+        const attemptScreenshot = async (): Promise<ScreenshotAttempt> => {
           try {
             const screenshotData = await Promise.race([
               (async () => {
@@ -222,23 +240,36 @@ const handler: ToolHandler = async (
               })(),
               new Promise<null>((resolve) => setTimeout(() => resolve(null), DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS)),
             ]);
-            if (screenshotData === null) return null;
-            return { data: screenshotData, mimeType: mimeTypeForFormat[effectiveFormat] };
+            if (screenshotData === null) return { status: 'timeout' };
+            return { status: 'success', data: screenshotData, mimeType: mimeTypeForFormat[effectiveFormat] };
           } catch {
-            return null;
+            return { status: 'error' };
           }
         };
 
         // First attempt
         let screenshot = await attemptScreenshot();
 
-        // Retry once after 500ms if failed
-        if (!screenshot) {
+        // Retry once after 500ms on synchronous CDP failure. Do not start a
+        // duplicate expensive capture after timeout because Chrome may still be
+        // working on the first Page.captureScreenshot request.
+        if (screenshot.status === 'error') {
           await new Promise(r => setTimeout(r, 500));
           screenshot = await attemptScreenshot();
         }
 
-        if (screenshot) {
+        if (screenshot.status === 'success') {
+          const payloadError = validateInlineImagePayload(
+            getBase64EncodedByteLength(screenshot.data),
+            'Screenshot'
+          );
+          if (payloadError) {
+            return {
+              content: [{ type: 'text', text: `Error: ${payloadError}` }],
+              isError: true,
+            };
+          }
+
           const content: MCPContent[] = [
             { type: 'image', data: screenshot.data, mimeType: screenshot.mimeType },
           ];

--- a/src/tools/computer.ts
+++ b/src/tools/computer.ts
@@ -13,7 +13,12 @@ import { generateVisualSummary } from '../utils/visual-summary';
 import { AdaptiveScreenshot } from '../utils/adaptive-screenshot';
 import { withTimeout } from '../utils/with-timeout';
 import { retryWithFallback } from '../utils/retry-with-fallback';
-import { getBase64EncodedByteLength, validateCaptureArea, validateInlineImagePayload } from '../utils/screenshot-guards';
+import {
+  getBase64EncodedByteLength,
+  resolveViewportDimensions,
+  validateCaptureArea,
+  validateInlineImagePayload,
+} from '../utils/screenshot-guards';
 
 const definition: MCPToolDefinition = {
   name: 'computer',
@@ -197,14 +202,12 @@ const handler: ToolHandler = async (
           };
         }
 
-        // Fall back to a sensible default (matches src/vision/screenshot-analyzer.ts)
-        // when page.viewport() returns null so the area guard cannot be silently
-        // bypassed by a 0x0 area report.
-        const viewport = page.viewport() ?? { width: 1920, height: 1080 };
-        const areaError = validateCaptureArea(
-          { width: viewport.width, height: viewport.height },
-          'Screenshot'
-        );
+        // page.viewport() can return null when Chrome is launched with
+        // defaultViewport: null. Read live window dimensions in that case so
+        // the area guard reflects the real capture size, not a hardcoded
+        // fallback that could underestimate when --window-size is large.
+        const captureDimensions = await resolveViewportDimensions(page);
+        const areaError = validateCaptureArea(captureDimensions, 'Screenshot');
         if (areaError) {
           return {
             content: [{ type: 'text', text: `Error: ${areaError}` }],

--- a/src/tools/page-screenshot.ts
+++ b/src/tools/page-screenshot.ts
@@ -9,6 +9,9 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
 import { bufferToBase64WithPayloadGuard, validateCaptureArea } from '../utils/screenshot-guards';
+import { withTimeout } from '../utils/with-timeout';
+
+const FULL_PAGE_DIMENSION_TIMEOUT_MS = 5000;
 
 const definition: MCPToolDefinition = {
   name: 'page_screenshot',
@@ -99,18 +102,22 @@ const handler: ToolHandler = async (
     const captureDimensions = clip
       ? { width: clip.width, height: clip.height }
       : fullPage
-        ? await page.evaluate(() => ({
-            width: Math.max(
-              document.documentElement?.scrollWidth ?? 0,
-              document.body?.scrollWidth ?? 0,
-              window.innerWidth ?? 0
-            ),
-            height: Math.max(
-              document.documentElement?.scrollHeight ?? 0,
-              document.body?.scrollHeight ?? 0,
-              window.innerHeight ?? 0
-            ),
-          }))
+        ? await withTimeout(
+            page.evaluate(() => ({
+              width: Math.max(
+                document.documentElement?.scrollWidth ?? 0,
+                document.body?.scrollWidth ?? 0,
+                window.innerWidth ?? 0
+              ),
+              height: Math.max(
+                document.documentElement?.scrollHeight ?? 0,
+                document.body?.scrollHeight ?? 0,
+                window.innerHeight ?? 0
+              ),
+            })),
+            FULL_PAGE_DIMENSION_TIMEOUT_MS,
+            'Full-page dimension lookup'
+          )
         : { width: viewport?.width ?? 0, height: viewport?.height ?? 0 };
 
     const areaLabel = clip ? 'Clipped screenshot' : fullPage ? 'Full-page screenshot' : 'Screenshot';

--- a/src/tools/page-screenshot.ts
+++ b/src/tools/page-screenshot.ts
@@ -98,7 +98,11 @@ const handler: ToolHandler = async (
       return makeError(`Error: Tab ${tabId} not found`);
     }
 
-    const viewport = page.viewport();
+    // page.viewport() can legitimately return null when Chrome is launched with
+    // defaultViewport: null (see src/cdp/client.ts). Fall back to a sensible
+    // default (matches src/vision/screenshot-analyzer.ts) so the area guard is
+    // not silently bypassed by a 0x0 area report on the viewport-only path.
+    const viewport = page.viewport() ?? { width: 1920, height: 1080 };
     const captureDimensions = clip
       ? { width: clip.width, height: clip.height }
       : fullPage
@@ -118,7 +122,7 @@ const handler: ToolHandler = async (
             FULL_PAGE_DIMENSION_TIMEOUT_MS,
             'Full-page dimension lookup'
           )
-        : { width: viewport?.width ?? 0, height: viewport?.height ?? 0 };
+        : { width: viewport.width, height: viewport.height };
 
     const areaLabel = clip ? 'Clipped screenshot' : fullPage ? 'Full-page screenshot' : 'Screenshot';
     const areaError = validateCaptureArea(captureDimensions, areaLabel);

--- a/src/tools/page-screenshot.ts
+++ b/src/tools/page-screenshot.ts
@@ -8,7 +8,11 @@ import * as path from 'path';
 import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
-import { bufferToBase64WithPayloadGuard, validateCaptureArea } from '../utils/screenshot-guards';
+import {
+  bufferToBase64WithPayloadGuard,
+  resolveViewportDimensions,
+  validateCaptureArea,
+} from '../utils/screenshot-guards';
 import { withTimeout } from '../utils/with-timeout';
 
 const FULL_PAGE_DIMENSION_TIMEOUT_MS = 5000;
@@ -98,11 +102,6 @@ const handler: ToolHandler = async (
       return makeError(`Error: Tab ${tabId} not found`);
     }
 
-    // page.viewport() can legitimately return null when Chrome is launched with
-    // defaultViewport: null (see src/cdp/client.ts). Fall back to a sensible
-    // default (matches src/vision/screenshot-analyzer.ts) so the area guard is
-    // not silently bypassed by a 0x0 area report on the viewport-only path.
-    const viewport = page.viewport() ?? { width: 1920, height: 1080 };
     const captureDimensions = clip
       ? { width: clip.width, height: clip.height }
       : fullPage
@@ -122,7 +121,7 @@ const handler: ToolHandler = async (
             FULL_PAGE_DIMENSION_TIMEOUT_MS,
             'Full-page dimension lookup'
           )
-        : { width: viewport.width, height: viewport.height };
+        : await resolveViewportDimensions(page);
 
     const areaLabel = clip ? 'Clipped screenshot' : fullPage ? 'Full-page screenshot' : 'Screenshot';
     const areaError = validateCaptureArea(captureDimensions, areaLabel);

--- a/src/tools/page-screenshot.ts
+++ b/src/tools/page-screenshot.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
+import { bufferToBase64WithPayloadGuard, validateCaptureArea } from '../utils/screenshot-guards';
 
 const definition: MCPToolDefinition = {
   name: 'page_screenshot',
@@ -68,30 +69,54 @@ const handler: ToolHandler = async (
   const clip = args.clip as { x: number; y: number; width: number; height: number } | undefined;
   const omitBackground = (args.omitBackground as boolean | undefined) ?? false;
 
+  const makeError = (text: string): MCPResult => ({
+    content: [{ type: 'text', text }],
+    isError: true,
+  });
+
   const sessionManager = getSessionManager();
 
   if (!tabId) {
-    return {
-      content: [{ type: 'text', text: 'Error: tabId is required' }],
-      isError: true,
-    };
+    return makeError('Error: tabId is required');
   }
 
   // Validate quality
   if (quality < 0 || quality > 100) {
-    return {
-      content: [{ type: 'text', text: 'Error: quality must be between 0 and 100' }],
-      isError: true,
-    };
+    return makeError('Error: quality must be between 0 and 100');
+  }
+
+  if (clip && (!Number.isFinite(clip.x) || !Number.isFinite(clip.y) || !Number.isFinite(clip.width) || !Number.isFinite(clip.height) || clip.width <= 0 || clip.height <= 0)) {
+    return makeError('Error: clip x, y, width, and height must be finite numbers, and clip width/height must be greater than 0');
   }
 
   try {
     const page = await sessionManager.getPage(sessionId, tabId, undefined, 'page_screenshot');
     if (!page) {
-      return {
-        content: [{ type: 'text', text: `Error: Tab ${tabId} not found` }],
-        isError: true,
-      };
+      return makeError(`Error: Tab ${tabId} not found`);
+    }
+
+    const viewport = page.viewport();
+    const captureDimensions = clip
+      ? { width: clip.width, height: clip.height }
+      : fullPage
+        ? await page.evaluate(() => ({
+            width: Math.max(
+              document.documentElement?.scrollWidth ?? 0,
+              document.body?.scrollWidth ?? 0,
+              window.innerWidth ?? 0
+            ),
+            height: Math.max(
+              document.documentElement?.scrollHeight ?? 0,
+              document.body?.scrollHeight ?? 0,
+              window.innerHeight ?? 0
+            ),
+          }))
+        : { width: viewport?.width ?? 0, height: viewport?.height ?? 0 };
+
+    const areaLabel = clip ? 'Clipped screenshot' : fullPage ? 'Full-page screenshot' : 'Screenshot';
+    const areaError = validateCaptureArea(captureDimensions, areaLabel);
+    if (areaError) {
+      return makeError(`Error: ${areaError}`);
     }
 
     // Build screenshot options
@@ -155,9 +180,8 @@ const handler: ToolHandler = async (
       await fs.writeFile(resolvedPath, screenshotBuffer);
 
       // Determine dimensions
-      const viewport = page.viewport();
-      const width = clip ? clip.width : (viewport?.width ?? 0);
-      const height = clip ? clip.height : (fullPage ? 'full' : (viewport?.height ?? 0));
+      const width = captureDimensions.width;
+      const height = captureDimensions.height;
 
       return {
         content: [
@@ -175,18 +199,9 @@ const handler: ToolHandler = async (
         ],
       };
     } else {
-      // Check size before returning base64 (5MB limit)
-      const fiveMB = 5 * 1024 * 1024;
-      if (screenshotBuffer.length > fiveMB) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Error: Screenshot is ${Math.round(screenshotBuffer.length / 1024 / 1024 * 10) / 10}MB which exceeds the 5MB inline limit. Use the 'path' parameter to save to a file instead.`,
-            },
-          ],
-          isError: true,
-        };
+      const encoded = bufferToBase64WithPayloadGuard(screenshotBuffer, 'Screenshot');
+      if ('error' in encoded) {
+        return makeError(`Error: ${encoded.error}`);
       }
 
       const mimeType = format === 'jpeg' ? 'image/jpeg' : format === 'webp' ? 'image/webp' : 'image/png';
@@ -194,7 +209,7 @@ const handler: ToolHandler = async (
         content: [
           {
             type: 'image',
-            data: screenshotBuffer.toString('base64'),
+            data: encoded.data,
             mimeType,
           },
         ],

--- a/src/utils/screenshot-guards.ts
+++ b/src/utils/screenshot-guards.ts
@@ -2,8 +2,60 @@ import {
   MAX_CAPTURE_AREA_PIXELS,
   MAX_INLINE_IMAGE_PAYLOAD_BYTES,
 } from '../config/defaults';
+import { withTimeout } from './with-timeout';
 
 export { MAX_CAPTURE_AREA_PIXELS, MAX_INLINE_IMAGE_PAYLOAD_BYTES };
+
+/** Default fallback when viewport cannot be determined live (matches existing call sites). */
+export const FALLBACK_VIEWPORT_DIMENSIONS: CaptureDimensions = { width: 1920, height: 1080 };
+
+/** Maximum time to wait for live viewport dimension lookup via page.evaluate. */
+export const VIEWPORT_DIMENSION_LOOKUP_TIMEOUT_MS = 5000;
+
+/**
+ * Subset of the puppeteer Page API needed to resolve viewport dimensions.
+ * Duck-typed to keep this util free of a direct puppeteer-core dependency.
+ */
+export interface ViewportLookupPage {
+  viewport(): { width: number; height: number } | null;
+  evaluate<T>(pageFunction: () => T | Promise<T>): Promise<T>;
+}
+
+/**
+ * Resolve the live viewport dimensions for the area guard.
+ *
+ * page.viewport() returns null when Chrome is launched with
+ * `defaultViewport: null` (see src/cdp/client.ts), so a hardcoded fallback
+ * cannot reflect the real window size when --window-size is large. Read the
+ * live `window.innerWidth/innerHeight` via page.evaluate (with a short
+ * timeout so a hung renderer cannot block the screenshot pipeline) and only
+ * fall back to a hardcoded default if both sources fail.
+ */
+export async function resolveViewportDimensions(
+  page: ViewportLookupPage,
+  timeoutMs: number = VIEWPORT_DIMENSION_LOOKUP_TIMEOUT_MS
+): Promise<CaptureDimensions> {
+  const v = page.viewport();
+  if (v && v.width > 0 && v.height > 0) {
+    return { width: v.width, height: v.height };
+  }
+  try {
+    const live = await withTimeout(
+      page.evaluate(() => ({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      })),
+      timeoutMs,
+      'Viewport dimension lookup'
+    );
+    if (live && Number.isFinite(live.width) && Number.isFinite(live.height) && live.width > 0 && live.height > 0) {
+      return { width: live.width, height: live.height };
+    }
+  } catch {
+    // Renderer hung or unresponsive — fall through to the hardcoded fallback.
+  }
+  return { ...FALLBACK_VIEWPORT_DIMENSIONS };
+}
 
 export interface CaptureDimensions {
   width: number;

--- a/src/utils/screenshot-guards.ts
+++ b/src/utils/screenshot-guards.ts
@@ -1,0 +1,59 @@
+import {
+  MAX_CAPTURE_AREA_PIXELS,
+  MAX_INLINE_IMAGE_PAYLOAD_BYTES,
+} from '../config/defaults';
+
+export { MAX_CAPTURE_AREA_PIXELS, MAX_INLINE_IMAGE_PAYLOAD_BYTES };
+
+export interface CaptureDimensions {
+  width: number;
+  height: number;
+}
+
+export function getCaptureAreaPixels(dimensions: CaptureDimensions): number {
+  return dimensions.width * dimensions.height;
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${Math.round((bytes / 1024 / 1024) * 10) / 10} MiB`;
+  }
+  return `${Math.round(bytes / 1024)} KiB`;
+}
+
+export function validateCaptureArea(
+  dimensions: CaptureDimensions,
+  label = 'Screenshot'
+): string | undefined {
+  const area = getCaptureAreaPixels(dimensions);
+  if (area <= MAX_CAPTURE_AREA_PIXELS) return undefined;
+
+  return `${label} area ${dimensions.width}x${dimensions.height} (${area.toLocaleString()} pixels) exceeds the ${MAX_CAPTURE_AREA_PIXELS.toLocaleString()} pixel capture limit. Request viewport-only capture, use a smaller clip, or lower the page dimensions before retrying.`;
+}
+
+export function getBase64EncodedByteLength(data: string): number {
+  return Buffer.byteLength(data, 'utf8');
+}
+
+export function validateInlineImagePayload(
+  encodedByteLength: number,
+  label = 'Screenshot'
+): string | undefined {
+  if (encodedByteLength <= MAX_INLINE_IMAGE_PAYLOAD_BYTES) return undefined;
+
+  return `${label} inline payload is ${formatBytes(encodedByteLength)} after base64 encoding, which exceeds the ${formatBytes(MAX_INLINE_IMAGE_PAYLOAD_BYTES)} inline limit. Use the path parameter to save the image to a file, request viewport-only capture, use a smaller clip, or lower the page dimensions before retrying.`;
+}
+
+export function getBase64EncodedByteLengthForRawBytes(rawByteLength: number): number {
+  return Math.ceil(rawByteLength / 3) * 4;
+}
+
+export function bufferToBase64WithPayloadGuard(
+  buffer: Buffer,
+  label = 'Screenshot'
+): { data: string; error?: never } | { data?: never; error: string } {
+  const encodedByteLength = getBase64EncodedByteLengthForRawBytes(buffer.byteLength);
+  const error = validateInlineImagePayload(encodedByteLength, label);
+  if (error) return { error };
+  return { data: buffer.toString('base64') };
+}

--- a/src/vision/screenshot-analyzer.ts
+++ b/src/vision/screenshot-analyzer.ts
@@ -26,7 +26,7 @@ import type {
   AnnotatedScreenshotResult,
   VisionElementMap,
 } from './types';
-import { bufferToBase64WithPayloadGuard, validateCaptureArea } from '../utils/screenshot-guards';
+import { bufferToBase64WithPayloadGuard, resolveViewportDimensions, validateCaptureArea } from '../utils/screenshot-guards';
 
 /** Raw element collected from the page */
 export interface RawElement {
@@ -205,7 +205,7 @@ async function captureAnnotatedScreenshot(
   elements: RawElement[],
   options: Required<AnnotationOptions>
 ): Promise<{ screenshot: string; mimeType: string }> {
-  const viewport = page.viewport() || { width: 1920, height: 1080 };
+  const viewport = await resolveViewportDimensions(page);
   const areaError = validateCaptureArea(viewport, 'Annotated screenshot');
   if (areaError) {
     throw new Error(areaError);

--- a/src/vision/screenshot-analyzer.ts
+++ b/src/vision/screenshot-analyzer.ts
@@ -26,6 +26,7 @@ import type {
   AnnotatedScreenshotResult,
   VisionElementMap,
 } from './types';
+import { bufferToBase64WithPayloadGuard, validateCaptureArea } from '../utils/screenshot-guards';
 
 /** Raw element collected from the page */
 export interface RawElement {
@@ -204,6 +205,12 @@ async function captureAnnotatedScreenshot(
   elements: RawElement[],
   options: Required<AnnotationOptions>
 ): Promise<{ screenshot: string; mimeType: string }> {
+  const viewport = page.viewport() || { width: 1920, height: 1080 };
+  const areaError = validateCaptureArea(viewport, 'Annotated screenshot');
+  if (areaError) {
+    throw new Error(areaError);
+  }
+
   try {
     // Inject overlay with annotations
     await page.evaluate(
@@ -303,10 +310,14 @@ async function captureAnnotatedScreenshot(
     ]).finally(() => { if (timer) clearTimeout(timer); });
 
     const screenshotBuffer = Buffer.from(buffer);
+    const encoded = bufferToBase64WithPayloadGuard(screenshotBuffer, 'Annotated screenshot');
+    if ('error' in encoded) {
+      throw new Error(encoded.error);
+    }
     const mimeType = options.format === 'webp' ? 'image/webp' : 'image/png';
 
     return {
-      screenshot: screenshotBuffer.toString('base64'),
+      screenshot: encoded.data,
       mimeType,
     };
   } finally {

--- a/tests/tools/computer.test.ts
+++ b/tests/tools/computer.test.ts
@@ -586,10 +586,11 @@ describe('ComputerTool', () => {
       expect(cdpSession.send).not.toHaveBeenCalledWith('Page.captureScreenshot', expect.anything());
     });
 
-    test('falls back to default viewport when page.viewport() returns null', async () => {
+    test('reads live window dimensions when page.viewport() returns null', async () => {
       const handler = await getComputerHandler();
       const page = (await mockSessionManager.getPage(testSessionId, testTargetId))!;
       (page.viewport as jest.Mock).mockReturnValue(null);
+      (page.evaluate as jest.Mock).mockResolvedValue({ width: 1024, height: 768 });
       const cdpSession = await (page as any).createCDPSession();
       (cdpSession.send as jest.Mock).mockResolvedValue({ data: 'ZmFrZQ==' });
 
@@ -600,7 +601,25 @@ describe('ComputerTool', () => {
 
       expect(result.isError).toBeFalsy();
       expect(result.content[0].type).toBe('image');
+      expect(page.evaluate).toHaveBeenCalled();
       expect(cdpSession.send).toHaveBeenCalledWith('Page.captureScreenshot', expect.any(Object));
+    });
+
+    test('rejects oversized live window dimensions when page.viewport() is null', async () => {
+      const handler = await getComputerHandler();
+      const page = (await mockSessionManager.getPage(testSessionId, testTargetId))!;
+      (page.viewport as jest.Mock).mockReturnValue(null);
+      (page.evaluate as jest.Mock).mockResolvedValue({ width: 6000, height: 5000 });
+      const cdpSession = await (page as any).createCDPSession();
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        action: 'screenshot',
+      }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Screenshot area 6000x5000');
+      expect(cdpSession.send).not.toHaveBeenCalledWith('Page.captureScreenshot', expect.anything());
     });
 
     test('does not start a duplicate screenshot capture after race timeout', async () => {

--- a/tests/tools/computer.test.ts
+++ b/tests/tools/computer.test.ts
@@ -586,6 +586,23 @@ describe('ComputerTool', () => {
       expect(cdpSession.send).not.toHaveBeenCalledWith('Page.captureScreenshot', expect.anything());
     });
 
+    test('falls back to default viewport when page.viewport() returns null', async () => {
+      const handler = await getComputerHandler();
+      const page = (await mockSessionManager.getPage(testSessionId, testTargetId))!;
+      (page.viewport as jest.Mock).mockReturnValue(null);
+      const cdpSession = await (page as any).createCDPSession();
+      (cdpSession.send as jest.Mock).mockResolvedValue({ data: 'ZmFrZQ==' });
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        action: 'screenshot',
+      }) as { content: Array<{ type: string }>; isError?: boolean };
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].type).toBe('image');
+      expect(cdpSession.send).toHaveBeenCalledWith('Page.captureScreenshot', expect.any(Object));
+    });
+
     test('does not start a duplicate screenshot capture after race timeout', async () => {
       jest.useFakeTimers();
       try {

--- a/tests/tools/computer.test.ts
+++ b/tests/tools/computer.test.ts
@@ -5,6 +5,7 @@
 
 import { createMockSessionManager, createMockRefIdManager } from '../utils/mock-session';
 import { keyNormalizationMap } from '../utils/test-helpers';
+import { DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS, MAX_INLINE_IMAGE_PAYLOAD_BYTES } from '../../src/config/defaults';
 
 // Mock the session manager and ref-id-manager modules
 jest.mock('../../src/session-manager', () => ({
@@ -549,6 +550,65 @@ describe('ComputerTool', () => {
         (c) => c[0] === 'Page.captureScreenshot',
       );
       expect((captureCall![1] as Record<string, unknown>).format).toBe('webp');
+    });
+
+    test('rejects inline screenshot payloads over 10 MiB after encoding', async () => {
+      const handler = await getComputerHandler();
+      const page = (await mockSessionManager.getPage(testSessionId, testTargetId))!;
+      const cdpSession = await (page as any).createCDPSession();
+      (cdpSession.send as jest.Mock).mockResolvedValue({
+        data: 'a'.repeat(MAX_INLINE_IMAGE_PAYLOAD_BYTES + 1),
+      });
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        action: 'screenshot',
+      }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('exceeds the 10 MiB inline limit');
+    });
+
+    test('rejects oversized viewport area before CDP capture', async () => {
+      const handler = await getComputerHandler();
+      const page = (await mockSessionManager.getPage(testSessionId, testTargetId))!;
+      (page.viewport as jest.Mock).mockReturnValue({ width: 6000, height: 5000 });
+      const cdpSession = await (page as any).createCDPSession();
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        action: 'screenshot',
+      }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Screenshot area 6000x5000');
+      expect(result.content[0].text).toContain('Request viewport-only capture');
+      expect(cdpSession.send).not.toHaveBeenCalledWith('Page.captureScreenshot', expect.anything());
+    });
+
+    test('does not start a duplicate screenshot capture after race timeout', async () => {
+      jest.useFakeTimers();
+      try {
+        const handler = await getComputerHandler();
+        const page = (await mockSessionManager.getPage(testSessionId, testTargetId))!;
+        const cdpSession = await (page as any).createCDPSession();
+        (cdpSession.send as jest.Mock).mockImplementation(() => new Promise(() => {}));
+
+        const pending = handler(testSessionId, {
+          tabId: testTargetId,
+          action: 'screenshot',
+        }) as Promise<{ content: Array<{ text?: string }>; isError?: boolean }>;
+
+        await jest.advanceTimersByTimeAsync(DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS);
+        await pending;
+
+        const captureCalls = (cdpSession.send as jest.Mock).mock.calls.filter(
+          (c) => c[0] === 'Page.captureScreenshot'
+        );
+        expect(captureCalls).toHaveLength(1);
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 

--- a/tests/tools/page-screenshot-guards.test.ts
+++ b/tests/tools/page-screenshot-guards.test.ts
@@ -41,6 +41,22 @@ describe('page_screenshot payload guards', () => {
     tabId = target.targetId;
   });
 
+  it('falls back to default viewport when page.viewport() returns null on the viewport-only path', async () => {
+    const handler = await getPageScreenshotHandler(mockSessionManager);
+    const page = (await mockSessionManager.getPage(sessionId, tabId))!;
+    (page.viewport as jest.Mock).mockReturnValue(null);
+    (page.screenshot as jest.Mock).mockResolvedValue(Buffer.from('small image'));
+
+    const result = await handler(sessionId, { tabId }) as {
+      content: Array<{ type: string }>;
+      isError?: boolean;
+    };
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].type).toBe('image');
+    expect(page.screenshot).toHaveBeenCalled();
+  });
+
   it('returns existing viewport screenshots when inline payload is under the cap', async () => {
     const handler = await getPageScreenshotHandler(mockSessionManager);
     const page = (await mockSessionManager.getPage(sessionId, tabId))!;

--- a/tests/tools/page-screenshot-guards.test.ts
+++ b/tests/tools/page-screenshot-guards.test.ts
@@ -131,6 +131,30 @@ describe('page_screenshot payload guards', () => {
     expect(page.screenshot).not.toHaveBeenCalled();
   });
 
+  it('times out instead of blocking forever when full-page dimension lookup hangs', async () => {
+    jest.useFakeTimers();
+    try {
+      const handler = await getPageScreenshotHandler(mockSessionManager);
+      const page = (await mockSessionManager.getPage(sessionId, tabId))!;
+      (page.evaluate as jest.Mock).mockImplementation(() => new Promise(() => {}));
+      (page.screenshot as jest.Mock).mockResolvedValue(Buffer.from('never reached'));
+
+      const pending = handler(sessionId, { tabId, fullPage: true }) as Promise<{
+        content: Array<{ text?: string }>;
+        isError?: boolean;
+      }>;
+
+      await jest.advanceTimersByTimeAsync(5000);
+      const result = await pending;
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toMatch(/Full-page dimension lookup/i);
+      expect(page.screenshot).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('computes base64 payload size before encoding oversized buffers', () => {
     expect(getBase64EncodedByteLengthForRawBytes(0)).toBe(0);
     expect(getBase64EncodedByteLengthForRawBytes(1)).toBe(4);

--- a/tests/tools/page-screenshot-guards.test.ts
+++ b/tests/tools/page-screenshot-guards.test.ts
@@ -41,10 +41,11 @@ describe('page_screenshot payload guards', () => {
     tabId = target.targetId;
   });
 
-  it('falls back to default viewport when page.viewport() returns null on the viewport-only path', async () => {
+  it('reads live window dimensions when page.viewport() returns null on the viewport-only path', async () => {
     const handler = await getPageScreenshotHandler(mockSessionManager);
     const page = (await mockSessionManager.getPage(sessionId, tabId))!;
     (page.viewport as jest.Mock).mockReturnValue(null);
+    (page.evaluate as jest.Mock).mockResolvedValue({ width: 1024, height: 768 });
     (page.screenshot as jest.Mock).mockResolvedValue(Buffer.from('small image'));
 
     const result = await handler(sessionId, { tabId }) as {
@@ -54,7 +55,24 @@ describe('page_screenshot payload guards', () => {
 
     expect(result.isError).toBeFalsy();
     expect(result.content[0].type).toBe('image');
+    expect(page.evaluate).toHaveBeenCalled();
     expect(page.screenshot).toHaveBeenCalled();
+  });
+
+  it('rejects oversized live window dimensions when page.viewport() is null', async () => {
+    const handler = await getPageScreenshotHandler(mockSessionManager);
+    const page = (await mockSessionManager.getPage(sessionId, tabId))!;
+    (page.viewport as jest.Mock).mockReturnValue(null);
+    (page.evaluate as jest.Mock).mockResolvedValue({ width: 6000, height: 5000 });
+
+    const result = await handler(sessionId, { tabId }) as {
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Screenshot area 6000x5000');
+    expect(page.screenshot).not.toHaveBeenCalled();
   });
 
   it('returns existing viewport screenshots when inline payload is under the cap', async () => {

--- a/tests/tools/page-screenshot-guards.test.ts
+++ b/tests/tools/page-screenshot-guards.test.ts
@@ -1,0 +1,146 @@
+/// <reference types="jest" />
+
+import { createMockSessionManager } from '../utils/mock-session';
+import { MAX_INLINE_IMAGE_PAYLOAD_BYTES } from '../../src/config/defaults';
+import {
+  bufferToBase64WithPayloadGuard,
+  getBase64EncodedByteLengthForRawBytes,
+} from '../../src/utils/screenshot-guards';
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(),
+}));
+
+async function getPageScreenshotHandler(mockSessionManager: ReturnType<typeof createMockSessionManager>) {
+  jest.resetModules();
+  jest.doMock('../../src/session-manager', () => ({
+    getSessionManager: () => mockSessionManager,
+  }));
+
+  const { registerPageScreenshotTool } = await import('../../src/tools/page-screenshot');
+  const tools = new Map<string, (sessionId: string, args: Record<string, unknown>) => Promise<unknown>>();
+  const server = {
+    registerTool: (name: string, handler: unknown) => {
+      tools.set(name, handler as (sessionId: string, args: Record<string, unknown>) => Promise<unknown>);
+    },
+  };
+
+  registerPageScreenshotTool(server as unknown as Parameters<typeof registerPageScreenshotTool>[0]);
+  return tools.get('page_screenshot')!;
+}
+
+describe('page_screenshot payload guards', () => {
+  let mockSessionManager: ReturnType<typeof createMockSessionManager>;
+  let sessionId: string;
+  let tabId: string;
+
+  beforeEach(async () => {
+    mockSessionManager = createMockSessionManager();
+    sessionId = 'screenshot-guard-session';
+    const target = await mockSessionManager.createTarget(sessionId, 'about:blank');
+    tabId = target.targetId;
+  });
+
+  it('returns existing viewport screenshots when inline payload is under the cap', async () => {
+    const handler = await getPageScreenshotHandler(mockSessionManager);
+    const page = (await mockSessionManager.getPage(sessionId, tabId))!;
+    (page.screenshot as jest.Mock).mockResolvedValue(Buffer.from('small image'));
+
+    const result = await handler(sessionId, { tabId }) as {
+      content: Array<{ type: string; data?: string; mimeType?: string }>;
+      isError?: boolean;
+    };
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0]).toEqual({
+      type: 'image',
+      data: Buffer.from('small image').toString('base64'),
+      mimeType: 'image/png',
+    });
+  });
+
+  it('rejects inline base64 payloads over 10 MiB after encoding', async () => {
+    const handler = await getPageScreenshotHandler(mockSessionManager);
+    const page = (await mockSessionManager.getPage(sessionId, tabId))!;
+    const rawBytesNeeded = Math.ceil((MAX_INLINE_IMAGE_PAYLOAD_BYTES + 1) * 3 / 4);
+    (page.screenshot as jest.Mock).mockResolvedValue(Buffer.alloc(rawBytesNeeded));
+
+    const result = await handler(sessionId, { tabId }) as {
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('exceeds the 10 MiB inline limit');
+    expect(result.content[0].text).toContain('path parameter');
+  });
+
+  it('rejects oversized full-page captures before starting capture with actionable hint', async () => {
+    const handler = await getPageScreenshotHandler(mockSessionManager);
+    const page = (await mockSessionManager.getPage(sessionId, tabId))!;
+    (page.evaluate as jest.Mock).mockResolvedValue({ width: 6000, height: 5000 });
+
+    const result = await handler(sessionId, { tabId, fullPage: true }) as {
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Full-page screenshot area 6000x5000');
+    expect(result.content[0].text).toContain('Request viewport-only capture');
+    expect(page.screenshot).not.toHaveBeenCalled();
+  });
+
+  it('validates clip option parsing and uses clip instead of fullPage', async () => {
+    const handler = await getPageScreenshotHandler(mockSessionManager);
+    const page = (await mockSessionManager.getPage(sessionId, tabId))!;
+    (page.screenshot as jest.Mock).mockResolvedValue(Buffer.from('clipped'));
+
+    const invalid = await handler(sessionId, {
+      tabId,
+      clip: { x: 0, y: 0, width: 0, height: 100 },
+    }) as { isError?: boolean; content: Array<{ text: string }> };
+    expect(invalid.isError).toBe(true);
+    expect(invalid.content[0].text).toContain('clip width/height must be greater than 0');
+
+    await handler(sessionId, {
+      tabId,
+      fullPage: true,
+      clip: { x: 1, y: 2, width: 300, height: 200 },
+    });
+
+    expect(page.screenshot).toHaveBeenCalledWith(expect.objectContaining({
+      fullPage: false,
+      clip: { x: 1, y: 2, width: 300, height: 200 },
+    }));
+  });
+
+  it('labels oversized clips correctly even when fullPage is also requested', async () => {
+    const handler = await getPageScreenshotHandler(mockSessionManager);
+    const page = (await mockSessionManager.getPage(sessionId, tabId))!;
+
+    const result = await handler(sessionId, {
+      tabId,
+      fullPage: true,
+      clip: { x: 0, y: 0, width: 6000, height: 5000 },
+    }) as { isError?: boolean; content: Array<{ text: string }> };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Clipped screenshot area 6000x5000');
+    expect(result.content[0].text).not.toContain('Full-page screenshot area');
+    expect(page.screenshot).not.toHaveBeenCalled();
+  });
+
+  it('computes base64 payload size before encoding oversized buffers', () => {
+    expect(getBase64EncodedByteLengthForRawBytes(0)).toBe(0);
+    expect(getBase64EncodedByteLengthForRawBytes(1)).toBe(4);
+    expect(getBase64EncodedByteLengthForRawBytes(3)).toBe(4);
+    expect(getBase64EncodedByteLengthForRawBytes(4)).toBe(8);
+
+    const rawBytesNeeded = Math.ceil((MAX_INLINE_IMAGE_PAYLOAD_BYTES + 1) * 3 / 4);
+    const result = bufferToBase64WithPayloadGuard(Buffer.alloc(rawBytesNeeded));
+
+    expect(result.error).toContain('exceeds the 10 MiB inline limit');
+    expect(result.data).toBeUndefined();
+  });
+});

--- a/tests/vision/screenshot-analyzer.test.ts
+++ b/tests/vision/screenshot-analyzer.test.ts
@@ -15,9 +15,16 @@ import { MAX_INLINE_IMAGE_PAYLOAD_BYTES } from '../../src/config/defaults';
 
 // ─── Mock Page Factory ───
 
-function createMockPage(evaluateResult: unknown[] = [], viewport = { width: 1920, height: 1080 }) {
+function createMockPage(
+  evaluateResult: unknown[] = [],
+  viewport: { width: number; height: number } | null = { width: 1920, height: 1080 },
+  liveViewport?: { width: number; height: number }
+) {
   return {
     evaluate: jest.fn().mockImplementation((_fn: Function, ...args: unknown[]) => {
+      if (args.length === 0) {
+        return Promise.resolve(liveViewport ?? evaluateResult);
+      }
       if (args.length === 3 && typeof args[2] === 'string' && String(args[2]).includes('oc_vision')) {
         return Promise.resolve();
       }
@@ -207,6 +214,14 @@ describe('analyzeScreenshot', () => {
     const page = createMockPage([], { width: 6000, height: 5000 });
 
     await expect(analyzeScreenshot(page as any)).rejects.toThrow('Annotated screenshot area 6000x5000');
+    expect(page.screenshot).not.toHaveBeenCalled();
+  });
+
+  it('rejects oversized live viewport dimensions when page.viewport() returns null before capture', async () => {
+    const page = createMockPage([], null, { width: 6000, height: 5000 });
+
+    await expect(analyzeScreenshot(page as any)).rejects.toThrow('Annotated screenshot area 6000x5000');
+    expect(page.evaluate).toHaveBeenCalledWith(expect.any(Function));
     expect(page.screenshot).not.toHaveBeenCalled();
   });
 });

--- a/tests/vision/screenshot-analyzer.test.ts
+++ b/tests/vision/screenshot-analyzer.test.ts
@@ -11,6 +11,7 @@ import {
   RawElement,
 } from '../../src/vision/screenshot-analyzer';
 import type { VisionElementMap } from '../../src/vision/types';
+import { MAX_INLINE_IMAGE_PAYLOAD_BYTES } from '../../src/config/defaults';
 
 // ─── Mock Page Factory ───
 
@@ -192,5 +193,20 @@ describe('analyzeScreenshot', () => {
     page.viewport.mockReturnValue(null);
     const result = await analyzeScreenshot(page as any);
     expect(result.viewport).toEqual({ width: 1920, height: 1080 });
+  });
+
+  it('rejects annotated screenshots over the inline payload cap', async () => {
+    const page = createMockPage([]);
+    const rawBytesNeeded = Math.ceil((MAX_INLINE_IMAGE_PAYLOAD_BYTES + 1) * 3 / 4);
+    page.screenshot.mockResolvedValueOnce(Buffer.alloc(rawBytesNeeded));
+
+    await expect(analyzeScreenshot(page as any)).rejects.toThrow('exceeds the 10 MiB inline limit');
+  });
+
+  it('rejects annotated screenshots over the capture area cap before capture', async () => {
+    const page = createMockPage([], { width: 6000, height: 5000 });
+
+    await expect(analyzeScreenshot(page as any)).rejects.toThrow('Annotated screenshot area 6000x5000');
+    expect(page.screenshot).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add shared screenshot capture-area and inline payload guard helpers
- guard page_screenshot, computer screenshots, and annotated vision screenshots before returning oversized inline images
- add targeted tests for payload caps, capture area caps, and timeout retry behavior

Closes #686

## Validation
- ./node_modules/.bin/jest tests/tools/page-screenshot-guards.test.ts tests/tools/computer.test.ts tests/vision/screenshot-analyzer.test.ts --runInBand --no-cache --testTimeout=90000 --silent
- ./node_modules/.bin/tsc -p tsconfig.json --pretty false --incremental false
- ./node_modules/.bin/tsc -p tsconfig.cli.json --pretty false --incremental false
- ./node_modules/.bin/eslint src/utils/screenshot-guards.ts src/tools/page-screenshot.ts src/tools/computer.ts src/vision/screenshot-analyzer.ts --max-warnings=0
- git diff --check

Note: Jest completed successfully and printed the repository's existing open-handle warning after completion.
