### PR TITLE
fix: optimize read_page large-page hot paths

### DIFF
--- a/src/dom/dom-serializer.ts
+++ b/src/dom/dom-serializer.ts
@@ -523,11 +523,16 @@ export async function serializeDOM(
     'serializeDOM:pageStats',
   ) as PageStats;
 
-  // Get full DOM tree via CDP
+  // Get DOM tree via CDP. When callers request bounded output depth, avoid
+  // fetching the full document and all pierced subtree content up front. CDP's
+  // depth starts at the document root, while this serializer starts element
+  // indentation at the document element, so add one level to preserve existing
+  // maxDepth output semantics.
+  const documentDepth = maxDepth >= 0 ? maxDepth + 1 : -1;
   const { root } = await cdpClient.send<{ root: DOMNode }>(
     page,
     'DOM.getDocument',
-    { depth: -1, pierce: true },
+    { depth: documentDepth, pierce: pierceIframes },
   );
 
   const lines: string[] = [];

--- a/src/dom/dom-serializer.ts
+++ b/src/dom/dom-serializer.ts
@@ -523,20 +523,22 @@ export async function serializeDOM(
     'serializeDOM:pageStats',
   ) as PageStats;
 
-  // Get DOM tree via CDP. When callers request bounded output depth, avoid
-  // fetching the full document and all pierced subtree content up front. CDP's
-  // depth starts at the document root, while this serializer starts element
-  // indentation at the document element, so add one level to preserve existing
-  // maxDepth output semantics. When piercing iframes the serializer's document
-  // handler iterates contentDocument children at the same depth, so each
-  // iframe nesting level introduces an unbounded gap between serializer-depth
-  // and CDP-depth — fall back to an unbounded CDP fetch in that case so iframe
-  // body content within maxDepth is not silently dropped.
+  // Get DOM tree via CDP. Always pierce at the CDP layer so shadowRoots are
+  // present; ctx.pierceIframes below controls whether iframe contentDocument
+  // subtrees are emitted. When callers request bounded output depth, avoid
+  // fetching the full document up front where possible. CDP's depth starts at
+  // the document root, while this serializer starts element indentation at the
+  // document element, so add one level to preserve existing maxDepth output
+  // semantics. When emitting iframes, the serializer's document handler
+  // iterates contentDocument children at the same depth, so each iframe nesting
+  // level introduces an unbounded gap between serializer-depth and CDP-depth —
+  // fall back to an unbounded CDP fetch in that case so iframe body content
+  // within maxDepth is not silently dropped.
   const documentDepth = maxDepth >= 0 && !pierceIframes ? maxDepth + 1 : -1;
   const { root } = await cdpClient.send<{ root: DOMNode }>(
     page,
     'DOM.getDocument',
-    { depth: documentDepth, pierce: pierceIframes },
+    { depth: documentDepth, pierce: true },
   );
 
   const lines: string[] = [];

--- a/src/dom/dom-serializer.ts
+++ b/src/dom/dom-serializer.ts
@@ -527,8 +527,12 @@ export async function serializeDOM(
   // fetching the full document and all pierced subtree content up front. CDP's
   // depth starts at the document root, while this serializer starts element
   // indentation at the document element, so add one level to preserve existing
-  // maxDepth output semantics.
-  const documentDepth = maxDepth >= 0 ? maxDepth + 1 : -1;
+  // maxDepth output semantics. When piercing iframes the serializer's document
+  // handler iterates contentDocument children at the same depth, so each
+  // iframe nesting level introduces an unbounded gap between serializer-depth
+  // and CDP-depth — fall back to an unbounded CDP fetch in that case so iframe
+  // body content within maxDepth is not silently dropped.
+  const documentDepth = maxDepth >= 0 && !pierceIframes ? maxDepth + 1 : -1;
   const { root } = await cdpClient.send<{ root: DOMNode }>(
     page,
     'DOM.getDocument',

--- a/src/tools/read-page.ts
+++ b/src/tools/read-page.ts
@@ -68,6 +68,11 @@ const definition: MCPToolDefinition = {
         enum: ['none', 'delta'],
         description: 'Compression mode. "delta" returns only changes since last read.',
       },
+      fallback: {
+        type: 'string',
+        enum: ['none', 'dom'],
+        description: 'AX mode only: use "dom" to explicitly fall back to DOM output if AX output exceeds the output budget. Default: none.',
+      },
     },
     required: ['tabId'],
   },
@@ -125,6 +130,13 @@ const handler: ToolHandler = async (
     if (mode !== 'ax' && mode !== 'dom' && mode !== 'css') {
       return {
         content: [{ type: 'text', text: `Error: Invalid mode "${mode}". Must be "ax", "dom", or "css".` }],
+        isError: true,
+      };
+    }
+    const axOverflowFallback = (args.fallback as string | undefined) || 'none';
+    if (axOverflowFallback !== 'none' && axOverflowFallback !== 'dom') {
+      return {
+        content: [{ type: 'text', text: `Error: Invalid fallback "${axOverflowFallback}". Must be "none" or "dom".` }],
         isError: true,
       };
     }
@@ -403,10 +415,18 @@ const handler: ToolHandler = async (
     // Clear previous refs for this target
     refIdManager.clearTargetRefs(sessionId, tabId);
 
-    // Build the tree structure
+    // Build the tree structure and child-id set in one pass. Root detection used
+    // to scan every node's children for every candidate root (O(n^2)); keeping a
+    // child set by construction makes the root pass O(n).
     const nodeMap = new Map<number, AXNode>();
+    const childNodeIds = new Set<number>();
     for (const node of nodes) {
       nodeMap.set(node.nodeId, node);
+      if (node.childIds) {
+        for (const childId of node.childIds) {
+          childNodeIds.add(childId);
+        }
+      }
     }
 
     // Interactive roles
@@ -530,7 +550,7 @@ const handler: ToolHandler = async (
       if (!scopedNode && refEntrySnapshot) {
         // Refs were cleared — use snapshot to search by element attributes
         // tryRelocateRef won't work here because clearTargetRefs already deleted the entry
-        const { tagName, name, role } = refEntrySnapshot;
+        const { name, role } = refEntrySnapshot;
         scopedNode = nodes.find((n) => {
           if (!n.backendDOMNodeId) return false;
           const nodeRole = n.role?.value;
@@ -550,9 +570,7 @@ const handler: ToolHandler = async (
       }
       startNodes = [scopedNode];
     } else {
-      startNodes = nodes.filter(
-        (n) => !nodes.some((other) => other.childIds?.includes(n.nodeId))
-      );
+      startNodes = nodes.filter((n) => !childNodeIds.has(n.nodeId));
     }
     for (const root of startNodes) {
       formatNode(root, 0);
@@ -563,18 +581,37 @@ const handler: ToolHandler = async (
     const axPaginationSection = includePaginationAx ? formatPaginationSection(await detectPagination(page, tabId)) : '';
 
     if (charCount > MAX_OUTPUT) {
-      // Auto-fallback: DOM mode produces complete output at ~5-10x fewer tokens
+      // Large AX output should not trigger a second full DOM traversal unless
+      // the caller explicitly opts into that fallback. Otherwise preserve AX
+      // intent and return the bounded/truncated AX representation.
+      if (axOverflowFallback !== 'dom') {
+        return {
+          content: [
+            {
+              type: 'text',
+              text:
+                pageStatsLine +
+                output +
+                '\n\n[Output truncated. AX output exceeded the output budget. Use mode: "dom" or fallback: "dom" for DOM output, or use smaller depth / ref_id to focus on specific element.]' +
+                axPaginationSection,
+            },
+          ],
+        };
+      }
+
+      // Explicit fallback: DOM mode often produces equivalent page structure at
+      // fewer tokens, but it can require another CDP DOM traversal.
       try {
         const domResult = await serializeDOM(page, cdpClient, {
-          maxDepth: -1,
+          maxDepth,
           filter: filter,
           interactiveOnly: filter === 'interactive',
         });
 
         const fallbackNote =
           '\n\n[AX tree exceeded output limit (' + charCount + ' chars). ' +
-          'Auto-switched to DOM mode for complete output. ' +
-          'Use mode: "ax" with ref_id to scope specific subtrees for AX format.]';
+          'Switched to DOM mode because fallback: "dom" was requested. ' +
+          'Use mode: "ax" with smaller depth / ref_id to scope specific subtrees for AX format.]';
 
         return {
           content: [

--- a/tests/dom/dom-serializer.test.ts
+++ b/tests/dom/dom-serializer.test.ts
@@ -550,6 +550,64 @@ describe('DOM Serializer', () => {
     expect(result.content).toContain('[1200]<iframe');
   });
 
+  test('keeps open shadow roots while omitting iframe content when pierceIframes is false', async () => {
+    const shadowAndIframeDoc = {
+      nodeId: 1, backendNodeId: 1, nodeType: 9, nodeName: '#document', localName: '',
+      children: [{
+        nodeId: 2, backendNodeId: 2, nodeType: 1, nodeName: 'BODY', localName: 'body',
+        attributes: [],
+        children: [
+          {
+            nodeId: 3, backendNodeId: 1300, nodeType: 1, nodeName: 'DIV', localName: 'div',
+            attributes: ['id', 'shadow-host'],
+            shadowRoots: [{
+              nodeId: 4, backendNodeId: 4, nodeType: 11, nodeName: '#document-fragment', localName: '',
+              shadowRootType: 'open',
+              children: [{
+                nodeId: 5, backendNodeId: 1301, nodeType: 1, nodeName: 'BUTTON', localName: 'button',
+                attributes: ['id', 'shadow-button'],
+                children: [{
+                  nodeId: 6, backendNodeId: 6, nodeType: 3, nodeName: '#text', localName: '',
+                  nodeValue: 'Shadow button',
+                }],
+              }],
+            }],
+          },
+          {
+            nodeId: 7, backendNodeId: 1302, nodeType: 1, nodeName: 'IFRAME', localName: 'iframe',
+            attributes: ['src', 'https://inner.example.com'],
+            contentDocument: {
+              nodeId: 8, backendNodeId: 8, nodeType: 9, nodeName: '#document', localName: '',
+              children: [{
+                nodeId: 9, backendNodeId: 1303, nodeType: 1, nodeName: 'P', localName: 'p',
+                attributes: ['id', 'iframe-content'],
+                children: [],
+              }],
+            },
+          },
+        ],
+      }],
+    };
+
+    const page = createMockPageForDOM();
+    const cdpClient = createMockCDPClientForDOM(shadowAndIframeDoc);
+
+    const result = await serializeDOM(page as never, cdpClient as never, { includePageStats: false, pierceIframes: false });
+
+    expect(result.content).toContain('--shadow-root-- (open)');
+    expect(result.content).toContain('[1301]<button');
+    expect(result.content).toContain('Shadow button');
+    expect(result.content).toContain('[1302]<iframe');
+    expect(result.content).not.toContain('--page-separator--');
+    expect(result.content).not.toContain('[1303]<p');
+    expect(result.content).not.toContain('id="iframe-content"');
+    expect(cdpClient.send).toHaveBeenCalledWith(
+      page,
+      'DOM.getDocument',
+      { depth: -1, pierce: true },
+    );
+  });
+
   // 11. Return value structure
   test('returns pageStats object with correct properties', async () => {
     const page = createMockPageForDOM({
@@ -613,12 +671,11 @@ describe('DOM Serializer', () => {
     );
   });
 
-  test('passes bounded depth to CDP DOM.getDocument when maxDepth is requested without pierce', async () => {
-    // When pierceIframes is false, the serializer-depth-to-CDP-depth mapping
-    // is exact (offset by 1 for the #document root), so the bounded fetch is
-    // safe. With pierceIframes=true (the default) iframe contentDocument
-    // descents create an open-ended gap, so the serializer falls back to
-    // an unbounded fetch — exercised by a separate test below.
+  test('passes bounded depth to CDP DOM.getDocument when maxDepth is requested without iframe output', async () => {
+    // Iframe output is disabled here, so the serializer-depth-to-CDP-depth
+    // mapping is exact for emitted nodes (offset by 1 for the #document root)
+    // and the bounded fetch is safe. CDP still pierces so shadowRoots are
+    // available to the serializer.
     const page = createMockPageForDOM();
     const cdpClient = createMockCDPClientForDOM(simpleDoc);
 
@@ -627,7 +684,7 @@ describe('DOM Serializer', () => {
     expect(cdpClient.send).toHaveBeenCalledWith(
       page,
       'DOM.getDocument',
-      { depth: 3, pierce: false },
+      { depth: 3, pierce: true },
     );
   });
 
@@ -644,7 +701,7 @@ describe('DOM Serializer', () => {
     );
   });
 
-  test('honors pierceIframes=false for unbounded document fetches', async () => {
+  test('still pierces CDP DOM when pierceIframes=false for unbounded document fetches', async () => {
     const page = createMockPageForDOM();
     const cdpClient = createMockCDPClientForDOM(simpleDoc);
 
@@ -653,7 +710,7 @@ describe('DOM Serializer', () => {
     expect(cdpClient.send).toHaveBeenCalledWith(
       page,
       'DOM.getDocument',
-      { depth: -1, pierce: false },
+      { depth: -1, pierce: true },
     );
   });
 

--- a/tests/dom/dom-serializer.test.ts
+++ b/tests/dom/dom-serializer.test.ts
@@ -613,7 +613,25 @@ describe('DOM Serializer', () => {
     );
   });
 
-  test('passes bounded depth to CDP DOM.getDocument when maxDepth is requested', async () => {
+  test('passes bounded depth to CDP DOM.getDocument when maxDepth is requested without pierce', async () => {
+    // When pierceIframes is false, the serializer-depth-to-CDP-depth mapping
+    // is exact (offset by 1 for the #document root), so the bounded fetch is
+    // safe. With pierceIframes=true (the default) iframe contentDocument
+    // descents create an open-ended gap, so the serializer falls back to
+    // an unbounded fetch — exercised by a separate test below.
+    const page = createMockPageForDOM();
+    const cdpClient = createMockCDPClientForDOM(simpleDoc);
+
+    await serializeDOM(page as never, cdpClient as never, { maxDepth: 2, pierceIframes: false });
+
+    expect(cdpClient.send).toHaveBeenCalledWith(
+      page,
+      'DOM.getDocument',
+      { depth: 3, pierce: false },
+    );
+  });
+
+  test('falls back to unbounded fetch when maxDepth is set with pierceIframes=true', async () => {
     const page = createMockPageForDOM();
     const cdpClient = createMockCDPClientForDOM(simpleDoc);
 
@@ -622,7 +640,7 @@ describe('DOM Serializer', () => {
     expect(cdpClient.send).toHaveBeenCalledWith(
       page,
       'DOM.getDocument',
-      { depth: 3, pierce: true },
+      { depth: -1, pierce: true },
     );
   });
 
@@ -637,5 +655,82 @@ describe('DOM Serializer', () => {
       'DOM.getDocument',
       { depth: -1, pierce: false },
     );
+  });
+
+  // 13. Bounded depth + iframe pierce regression
+  // Document handler iterates contentDocument children at the same
+  // serializer-depth, but each pierce hop costs a CDP depth level. With
+  // pierceIframes=true the serializer must request unbounded depth so
+  // iframe body content within maxDepth is not silently dropped.
+  test('bounded maxDepth + pierceIframes renders iframe body content', async () => {
+    // Layout (serializer / CDP depths):
+    //   #document (s—, c0)
+    //     html      (s0, c1)
+    //       body    (s1, c2)
+    //         iframe(s2, c3)
+    //           contentDocument (handler same-depth s3, c4)
+    //             html  (s3, c5)
+    //               body(s4, c6)            ← within maxDepth=4 budget
+    //                 p (s5, c7)            ← outside maxDepth
+    //
+    // A naive bounded fetch (depth = maxDepth + 1 = 5) would stop at
+    // inner-html, dropping inner-body silently. The serializer guards
+    // against this by requesting unbounded depth when pierceIframes is
+    // true, so the simulated CDP response below contains the full tree.
+    const fullDoc = {
+      nodeId: 1, backendNodeId: 1, nodeType: 9, nodeName: '#document', localName: '',
+      children: [{
+        nodeId: 2, backendNodeId: 2, nodeType: 1, nodeName: 'HTML', localName: 'html',
+        attributes: [],
+        children: [{
+          nodeId: 3, backendNodeId: 3, nodeType: 1, nodeName: 'BODY', localName: 'body',
+          attributes: [],
+          children: [{
+            nodeId: 4, backendNodeId: 4000, nodeType: 1, nodeName: 'IFRAME', localName: 'iframe',
+            attributes: ['src', 'https://inner.example.com'],
+            contentDocument: {
+              nodeId: 10, backendNodeId: 10, nodeType: 9, nodeName: '#document', localName: '',
+              children: [{
+                nodeId: 11, backendNodeId: 11, nodeType: 1, nodeName: 'HTML', localName: 'html',
+                attributes: [],
+                children: [{
+                  nodeId: 12, backendNodeId: 12, nodeType: 1, nodeName: 'BODY', localName: 'body',
+                  attributes: [],
+                  children: [{
+                    nodeId: 13, backendNodeId: 4001, nodeType: 1, nodeName: 'P', localName: 'p',
+                    attributes: ['id', 'iframe-content'],
+                    children: [],
+                  }],
+                }],
+              }],
+            },
+          }],
+        }],
+      }],
+    };
+
+    const page = createMockPageForDOM();
+    const cdpClient = createMockCDPClientForDOM(fullDoc);
+
+    const result = await serializeDOM(page as never, cdpClient as never, {
+      includePageStats: false,
+      maxDepth: 4,
+      pierceIframes: true,
+    });
+
+    // CDP must be asked for an unbounded fetch so iframe content is
+    // not silently truncated.
+    expect(cdpClient.send).toHaveBeenCalledWith(
+      page,
+      'DOM.getDocument',
+      { depth: -1, pierce: true },
+    );
+
+    // Inner body shows up after the iframe page separator, and inner
+    // body's children at serializer-depth 5 are correctly cut by the
+    // maxDepth check (not by missing CDP data).
+    expect(result.content).toContain('--page-separator-- iframe: https://inner.example.com');
+    expect(result.content).toMatch(/--page-separator--[\s\S]*\[12\]<body/);
+    expect(result.content).not.toContain('id="iframe-content"');
   });
 });

--- a/tests/dom/dom-serializer.test.ts
+++ b/tests/dom/dom-serializer.test.ts
@@ -612,4 +612,30 @@ describe('DOM Serializer', () => {
       { depth: -1, pierce: true },
     );
   });
+
+  test('passes bounded depth to CDP DOM.getDocument when maxDepth is requested', async () => {
+    const page = createMockPageForDOM();
+    const cdpClient = createMockCDPClientForDOM(simpleDoc);
+
+    await serializeDOM(page as never, cdpClient as never, { maxDepth: 2 });
+
+    expect(cdpClient.send).toHaveBeenCalledWith(
+      page,
+      'DOM.getDocument',
+      { depth: 3, pierce: true },
+    );
+  });
+
+  test('honors pierceIframes=false for unbounded document fetches', async () => {
+    const page = createMockPageForDOM();
+    const cdpClient = createMockCDPClientForDOM(simpleDoc);
+
+    await serializeDOM(page as never, cdpClient as never, { pierceIframes: false });
+
+    expect(cdpClient.send).toHaveBeenCalledWith(
+      page,
+      'DOM.getDocument',
+      { depth: -1, pierce: false },
+    );
+  });
 });

--- a/tests/tools/read-page-dom.test.ts
+++ b/tests/tools/read-page-dom.test.ts
@@ -113,6 +113,11 @@ describe('ReadPageTool - DOM Mode', () => {
       { depth: -1, pierce: true },
       { root: sampleDOMTree }
     );
+    mockSessionManager.mockCDPClient.setCDPResponse(
+      'DOM.getDocument',
+      { depth: 3, pierce: true },
+      { root: sampleDOMTree }
+    );
 
     // Set up page.evaluate for page stats (DOM mode)
     const page = mockSessionManager.pages.get(testTargetId);
@@ -192,6 +197,11 @@ describe('ReadPageTool - DOM Mode', () => {
       const result = await handler(testSessionId, { tabId: testTargetId, mode: 'dom', depth: 2 }) as any;
 
       expect(result.isError).toBeUndefined();
+      expect(mockSessionManager.mockCDPClient.send).toHaveBeenCalledWith(
+        expect.anything(),
+        'DOM.getDocument',
+        { depth: 3, pierce: true }
+      );
       // Output should still be valid
       expect(result.content[0].text).toContain('[page_stats]');
     });

--- a/tests/tools/read-page-dom.test.ts
+++ b/tests/tools/read-page-dom.test.ts
@@ -113,11 +113,6 @@ describe('ReadPageTool - DOM Mode', () => {
       { depth: -1, pierce: true },
       { root: sampleDOMTree }
     );
-    mockSessionManager.mockCDPClient.setCDPResponse(
-      'DOM.getDocument',
-      { depth: 3, pierce: true },
-      { root: sampleDOMTree }
-    );
 
     // Set up page.evaluate for page stats (DOM mode)
     const page = mockSessionManager.pages.get(testTargetId);
@@ -197,10 +192,15 @@ describe('ReadPageTool - DOM Mode', () => {
       const result = await handler(testSessionId, { tabId: testTargetId, mode: 'dom', depth: 2 }) as any;
 
       expect(result.isError).toBeUndefined();
+      // CDP is fetched with unbounded depth even when a maxDepth is set:
+      // pierceIframes defaults to true in DOM mode, and the contentDocument
+      // descent gap means a bounded fetch can silently drop iframe body
+      // content within maxDepth. The serializer enforces maxDepth on the
+      // output side instead.
       expect(mockSessionManager.mockCDPClient.send).toHaveBeenCalledWith(
         expect.anything(),
         'DOM.getDocument',
-        { depth: 3, pierce: true }
+        { depth: -1, pierce: true }
       );
       // Output should still be valid
       expect(result.content[0].text).toContain('[page_stats]');

--- a/tests/tools/read-page.test.ts
+++ b/tests/tools/read-page.test.ts
@@ -399,7 +399,7 @@ describe('ReadPageTool', () => {
       return { nodes };
     }
 
-    test('auto-fallback to DOM mode when AX tree exceeds output limit', async () => {
+    test('does not fall back to DOM when explicit AX output exceeds limit', async () => {
       const mockSerializeDOM = jest.fn().mockResolvedValue({
         content: '[page_stats] url: https://example.com\n\n<body>\n  <button />\n</body>',
       });
@@ -418,16 +418,13 @@ describe('ReadPageTool', () => {
       }) as { content: Array<{ type: string; text: string }> };
 
       const text = result.content[0].text;
-      // Should contain DOM output (from serializeDOM mock)
-      expect(text).toContain('<body>');
-      // Should contain the auto-fallback notice
-      expect(text).toContain('[AX tree exceeded output limit');
-      expect(text).toContain('Auto-switched to DOM mode');
-      // Should NOT contain the old truncation message
-      expect(text).not.toContain('[Output truncated');
+      expect(mockSerializeDOM).not.toHaveBeenCalled();
+      expect(text).not.toContain('<body>');
+      expect(text).toContain('[Output truncated');
+      expect(text).toContain('fallback: "dom"');
     });
 
-    test('auto-fallback passes correct options to serializeDOM', async () => {
+    test('explicit fallback=dom switches to DOM when AX tree exceeds output limit', async () => {
       const mockSerializeDOM = jest.fn().mockResolvedValue({
         content: '[page_stats] url: https://example.com\n\n<body></body>',
       });
@@ -441,6 +438,8 @@ describe('ReadPageTool', () => {
 
       await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
+        fallback: 'dom',
         filter: 'all',
       });
 
@@ -448,7 +447,7 @@ describe('ReadPageTool', () => {
         expect.anything(),
         expect.anything(),
         expect.objectContaining({
-          maxDepth: -1,
+          maxDepth: 8,
           filter: 'all',
           interactiveOnly: false,
         })
@@ -467,15 +466,63 @@ describe('ReadPageTool', () => {
 
       const result = await handler(testSessionId, {
         tabId: testTargetId,
+        mode: 'ax',
+        fallback: 'dom',
       }) as { content: Array<{ type: string; text: string }> };
 
       const text = result.content[0].text;
       // Should fall back to original truncation message
       expect(text).toContain('[Output truncated');
       expect(text).toContain('mode: "dom"');
-      expect(text).toContain('~5-10x fewer tokens');
+      expect(text).toContain('smaller depth / ref_id');
       // Should NOT contain the auto-fallback notice
       expect(text).not.toContain('[AX tree exceeded output limit');
+    });
+
+    test('detects roots with linear child-id construction on a 5000-node AX tree', async () => {
+      const handler = await getReadPageHandler();
+      const nodes: any[] = [];
+      let childIdsAccesses = 0;
+      const rootChildren = Array.from({ length: 4999 }, (_, i) => i + 2);
+      nodes.push({
+        nodeId: 1,
+        role: { value: 'WebArea' },
+        name: { value: 'Root' },
+        get childIds() {
+          childIdsAccesses++;
+          return rootChildren;
+        },
+      });
+      for (let i = 2; i <= 5000; i++) {
+        nodes.push({
+          nodeId: i,
+          backendDOMNodeId: i * 10,
+          role: { value: 'button' },
+          name: { value: `Button ${i}` },
+          get childIds() {
+            childIdsAccesses++;
+            return [];
+          },
+        });
+      }
+
+      mockSessionManager.mockCDPClient.setCDPResponse(
+        'Accessibility.getFullAXTree',
+        { depth: 1 },
+        { nodes }
+      );
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        mode: 'ax',
+        depth: 1,
+      }) as { content: Array<{ type: string; text: string }> };
+
+      expect(result.content[0].type).toBe('text');
+      // O(n) root detection/formatting reads childIds a small number of times;
+      // the previous nodes.filter(...nodes.some(...includes)) path reads it
+      // roughly n*n times for this tree.
+      expect(childIdsAccesses).toBeLessThan(15000);
     });
 
     test('invalid mode returns clear error', async () => {


### PR DESCRIPTION
## Summary
- Replaces AX root detection with a child-id set so root discovery is O(n).
- Adds an explicit `fallback: "dom"` opt-in for expensive AX-overflow DOM traversal; default AX overflow now returns bounded AX output with actionable guidance.
- Passes bounded read depth into `DOM.getDocument` while preserving iframe/shadow piercing compatibility.
- Adds regression coverage for large AX trees, explicit fallback behavior, and bounded DOM depth.

## Discussion / implementation notes
This is an independent Wave 3 slice for #684. It preserves normal `read_page` output compatibility while avoiding a second full DOM traversal unless the caller explicitly requests DOM fallback.

## Risk / vulnerability analysis
Low behavior risk for normal pages. The main intentional behavior change is that AX overflow no longer automatically performs a potentially expensive DOM traversal; callers can request `fallback: "dom"` when they want that behavior.

## Validation
- [x] `./node_modules/.bin/jest tests/tools/read-page.test.ts tests/tools/read-page-dom.test.ts tests/dom/dom-serializer.test.ts --runInBand --no-cache` (65 passed)
- [x] `./node_modules/.bin/tsc -p tsconfig.json --pretty false --incremental false`
- [x] `./node_modules/.bin/tsc -p tsconfig.cli.json --pretty false --incremental false`
- [x] `./node_modules/.bin/eslint src/tools/read-page.ts src/dom/dom-serializer.ts --max-warnings=0`
- [x] `git diff --check`

Refs #684
