### PR TITLE
feat(trace): session recorder with CDP event subscription (M1 PR-2)

### DIFF
--- a/src/trace/index.ts
+++ b/src/trace/index.ts
@@ -9,6 +9,18 @@
 export { TraceStorage, defaultTraceRootDir } from './storage';
 export type { AppendResult, TraceStorageOptions } from './storage';
 
+export {
+  TraceRecorder,
+  getTraceRecorder,
+  DEFAULT_TRACE_KINDS,
+  _resetTraceRecorderForTests,
+} from './recorder';
+export type {
+  EventEmitterLike,
+  PageLike,
+  TraceRecorderOptions,
+} from './recorder';
+
 export { redactTraceEvent, redactValue, scrubString, REDACTED } from './redactor';
 
 export type {

--- a/src/trace/recorder.ts
+++ b/src/trace/recorder.ts
@@ -259,13 +259,14 @@ export class TraceRecorder {
    * Finalize a session: flush remaining buffer, detach listeners, clear
    * the periodic timer, and write the terminal status to the index.
    *
-   * Cleanup of listeners / timer / session entry is run inside `finally`
-   * so a `flush()` rejection (disk full, sqlite write failure) cannot
-   * leave the recorder still subscribed to CDP/page events with a live
-   * timer for a session the caller intended to close. The flush
-   * rejection is re-thrown after cleanup so callers learn that some
-   * events did not persist; `shutdown()` already swallows per-session
-   * errors so a single bad session never blocks the rest.
+   * On flush failure (transient disk-full / sqlite-lock), CDP/page
+   * listeners and the periodic timer are still detached — the caller
+   * has asked the session to close, so we stop accumulating events —
+   * but the session entry and its buffer stay in `this.sessions`. That
+   * lets the caller retry `flush()`/`end()` later without losing the
+   * unpersisted tail. Successful retries write the terminal row and
+   * remove the entry; persistent failures leave the buffer for an
+   * eventual `shutdown()` or operator-driven discard.
    */
   async end(sessionId: string, status: TraceStatus = 'completed'): Promise<void> {
     if (!this.enabled) return;
@@ -277,35 +278,48 @@ export class TraceRecorder {
     } catch (err) {
       flushError = err;
     }
-    try {
-      if (state.cdp) {
-        for (const { kind, fn } of state.cdpListeners) {
-          const off = state.cdp.off ?? state.cdp.removeListener;
-          if (off) off.call(state.cdp, kind, fn);
-        }
+    // Detach listeners + timer regardless of flush outcome — recording
+    // is over either way. Idempotent: re-running end() after a retry
+    // sees state.cdp/page/timer already cleared and skips them.
+    if (state.cdp) {
+      for (const { kind, fn } of state.cdpListeners) {
+        const off = state.cdp.off ?? state.cdp.removeListener;
+        if (off) off.call(state.cdp, kind, fn);
       }
-      if (state.page && state.pageListener) {
-        // Page may not have an off(); use removeListener fallback when present.
-        const pageOff = (state.page as unknown as { off?: typeof state.page.on; removeListener?: typeof state.page.on }).off
-          ?? (state.page as unknown as { removeListener?: typeof state.page.on }).removeListener;
-        if (pageOff) pageOff.call(state.page, state.pageListener.event, state.pageListener.fn);
-      }
-      if (state.timer) clearInterval(state.timer);
-      // Best-effort terminal write; swallow storage failure here so
-      // cleanup completes. The flushError (if any) still surfaces below.
-      try {
-        this.getStorage().recordSessionEnd(sessionId, {
-          endedAt: this.now(),
-          status: flushError ? 'failed' : status,
-          byteSize: state.meta.byteSize,
-        });
-      } catch (err) {
-        if (!flushError) flushError = err;
-      }
-    } finally {
-      this.sessions.delete(sessionId);
+      state.cdp = undefined;
+      state.cdpListeners = [];
     }
-    if (flushError) throw flushError;
+    if (state.page && state.pageListener) {
+      const pageOff = (state.page as unknown as { off?: typeof state.page.on; removeListener?: typeof state.page.on }).off
+        ?? (state.page as unknown as { removeListener?: typeof state.page.on }).removeListener;
+      if (pageOff) pageOff.call(state.page, state.pageListener.event, state.pageListener.fn);
+      state.page = undefined;
+      state.pageListener = undefined;
+    }
+    if (state.timer) {
+      clearInterval(state.timer);
+      state.timer = undefined;
+    }
+    if (flushError) {
+      // Keep the session entry so the caller can retry flush()/end().
+      // The buffered tail is intact (flush() preserves it on failure).
+      throw flushError;
+    }
+    // Happy path: terminal write and remove the entry.
+    try {
+      this.getStorage().recordSessionEnd(sessionId, {
+        endedAt: this.now(),
+        status,
+        byteSize: state.meta.byteSize,
+      });
+    } catch (err) {
+      // Storage couldn't write the terminal row even though the data
+      // was already persisted. Surface the error but keep the session
+      // entry so the operator can decide; another end() call will
+      // retry the terminal write.
+      throw err;
+    }
+    this.sessions.delete(sessionId);
   }
 
   /**

--- a/src/trace/recorder.ts
+++ b/src/trace/recorder.ts
@@ -305,20 +305,16 @@ export class TraceRecorder {
       // The buffered tail is intact (flush() preserves it on failure).
       throw flushError;
     }
-    // Happy path: terminal write and remove the entry.
-    try {
-      this.getStorage().recordSessionEnd(sessionId, {
-        endedAt: this.now(),
-        status,
-        byteSize: state.meta.byteSize,
-      });
-    } catch (err) {
-      // Storage couldn't write the terminal row even though the data
-      // was already persisted. Surface the error but keep the session
-      // entry so the operator can decide; another end() call will
-      // retry the terminal write.
-      throw err;
-    }
+    // Happy path: write the terminal row, then remove the entry. If
+    // recordSessionEnd throws (storage error after data was already
+    // persisted), control never reaches `sessions.delete`, so the
+    // session entry stays in `this.sessions` and the caller can retry
+    // end() to complete the terminal write.
+    this.getStorage().recordSessionEnd(sessionId, {
+      endedAt: this.now(),
+      status,
+      byteSize: state.meta.byteSize,
+    });
     this.sessions.delete(sessionId);
   }
 

--- a/src/trace/recorder.ts
+++ b/src/trace/recorder.ts
@@ -1,0 +1,292 @@
+/**
+ * Session trace recorder.
+ *
+ * Subscribes to CDP events on a per-session CDPSession (typically owned by
+ * one Page), buffers them in memory, and flushes JSONL files to disk via
+ * `TraceStorage`. A small ring buffer means the steady-state memory cost is
+ * bounded; a periodic timer + capacity threshold + page-navigation event +
+ * shutdown handler ensure timely flushes without blocking the hot path.
+ *
+ * Default-off: callers must opt in via `OPENCHROME_TRACE=1` (or by passing
+ * `enabled: true` to the constructor). When disabled, the recorder is a
+ * no-op and pays zero CPU.
+ *
+ * The recorder is intentionally decoupled from the broader CDPClient
+ * lifecycle — it speaks only to the minimal `EventEmitterLike` interface
+ * declared below, which both puppeteer's CDPSession and a unit-test fake
+ * satisfy.
+ */
+
+import { redactTraceEvent } from './redactor';
+import { TraceStorage, defaultTraceRootDir } from './storage';
+import type { TraceEvent, TraceSessionMeta, TraceStatus } from './types';
+
+/** Subset of EventEmitter we rely on. */
+export interface EventEmitterLike {
+  on(event: string, listener: (...args: unknown[]) => void): unknown;
+  off?(event: string, listener: (...args: unknown[]) => void): unknown;
+  removeListener?(event: string, listener: (...args: unknown[]) => void): unknown;
+}
+
+/** Subset of puppeteer's Page we rely on for `framenavigated`. Optional. */
+export interface PageLike {
+  on(event: string, listener: (...args: unknown[]) => void): unknown;
+}
+
+export interface TraceRecorderOptions {
+  storage?: TraceStorage;
+  /** Capacity of the in-memory ring buffer per session (default 500). */
+  bufferSize?: number;
+  /** Periodic flush interval in ms (default 30_000). */
+  flushIntervalMs?: number;
+  /** Fractional capacity at which a flush is forced (default 0.8). */
+  capacityFlushRatio?: number;
+  /** When false, every public method is a no-op. */
+  enabled?: boolean;
+  /** Inject a clock for tests. */
+  now?: () => number;
+}
+
+/** CDP method names the recorder subscribes to by default. */
+export const DEFAULT_TRACE_KINDS = [
+  'Page.frameNavigated',
+  'Page.loadEventFired',
+  'Network.responseReceived',
+  'Runtime.consoleAPICalled',
+  'DOM.documentUpdated',
+] as const;
+
+interface SessionState {
+  meta: TraceSessionMeta;
+  buffer: TraceEvent[];
+  seqCounter: number;
+  /** CDP session attached for this recording session, if any. */
+  cdp?: EventEmitterLike;
+  /** Page attached for this recording session, if any. */
+  page?: PageLike;
+  /** Per-CDP-event listener registrations so we can detach cleanly. */
+  cdpListeners: Array<{ kind: string; fn: (...args: unknown[]) => void }>;
+  /** Page listener registration. */
+  pageListener?: { event: string; fn: (...args: unknown[]) => void };
+  /** Periodic flush timer. */
+  timer?: NodeJS.Timeout;
+}
+
+export class TraceRecorder {
+  private readonly storage: TraceStorage;
+  private readonly bufferSize: number;
+  private readonly flushIntervalMs: number;
+  private readonly capacityFlushRatio: number;
+  private readonly enabled: boolean;
+  private readonly now: () => number;
+  private readonly sessions = new Map<string, SessionState>();
+
+  constructor(opts: TraceRecorderOptions = {}) {
+    this.storage = opts.storage ?? new TraceStorage({ rootDir: defaultTraceRootDir() });
+    this.bufferSize = Math.max(1, opts.bufferSize ?? envInt('OPENCHROME_TRACE_BUFFER', 500));
+    this.flushIntervalMs = Math.max(
+      100,
+      opts.flushIntervalMs ?? envInt('OPENCHROME_TRACE_FLUSH_MS', 30_000),
+    );
+    this.capacityFlushRatio = clamp(opts.capacityFlushRatio ?? 0.8, 0.1, 1.0);
+    this.enabled =
+      opts.enabled ??
+      (process.env.OPENCHROME_TRACE === '1' || process.env.OPENCHROME_TRACE === 'on');
+    this.now = opts.now ?? Date.now;
+  }
+
+  /** True when the recorder will actually capture events. */
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /**
+   * Begin a recording session. Subsequent `recordEvent` / CDP-attached
+   * events will be buffered under this session id. Idempotent — calling
+   * twice with the same id refreshes meta but preserves the buffer.
+   */
+  start(meta: Omit<TraceSessionMeta, 'status' | 'byteSize'> & { status?: TraceStatus }): void {
+    if (!this.enabled) return;
+    const status: TraceStatus = meta.status ?? 'running';
+    const existing = this.sessions.get(meta.sessionId);
+    if (existing) {
+      existing.meta = { ...existing.meta, ...meta, status, byteSize: existing.meta.byteSize };
+      this.storage.recordSessionStart(existing.meta);
+      return;
+    }
+    const fullMeta: TraceSessionMeta = {
+      sessionId: meta.sessionId,
+      startedAt: meta.startedAt,
+      domain: meta.domain,
+      parentOp: meta.parentOp,
+      status,
+      byteSize: 0,
+    };
+    this.storage.recordSessionStart(fullMeta);
+    const state: SessionState = {
+      meta: fullMeta,
+      buffer: [],
+      seqCounter: 0,
+      cdpListeners: [],
+    };
+    state.timer = setInterval(() => {
+      void this.flush(meta.sessionId);
+    }, this.flushIntervalMs);
+    if (typeof state.timer.unref === 'function') state.timer.unref();
+    this.sessions.set(meta.sessionId, state);
+  }
+
+  /**
+   * Attach the recorder to a CDPSession-like emitter. Listeners are
+   * registered for each `kinds` entry; when `page` is supplied, we also
+   * trigger a flush on `framenavigated` (matching the v2 flush policy).
+   */
+  attach(
+    sessionId: string,
+    cdp: EventEmitterLike,
+    page?: PageLike,
+    opts: { kinds?: readonly string[] } = {},
+  ): void {
+    if (!this.enabled) return;
+    const state = this.sessions.get(sessionId);
+    if (!state) {
+      throw new Error(`TraceRecorder.attach: unknown session "${sessionId}". Call start() first.`);
+    }
+    if (state.cdp) {
+      throw new Error(`TraceRecorder.attach: session "${sessionId}" already attached.`);
+    }
+    state.cdp = cdp;
+    const kinds = opts.kinds ?? DEFAULT_TRACE_KINDS;
+    for (const kind of kinds) {
+      const fn = (...args: unknown[]): void => {
+        const body = args.length === 1 ? args[0] : args;
+        this.recordEvent(sessionId, kind, body);
+      };
+      cdp.on(kind, fn);
+      state.cdpListeners.push({ kind, fn });
+    }
+    if (page) {
+      state.page = page;
+      const navListener = (): void => {
+        // Flush on each navigation boundary so per-URL slices land in
+        // distinct files (helpful for replay / time-travel).
+        void this.flush(sessionId);
+      };
+      page.on('framenavigated', navListener);
+      state.pageListener = { event: 'framenavigated', fn: navListener };
+    }
+  }
+
+  /**
+   * Append a synthetic event to the session buffer (e.g., tool_call,
+   * screenshot, contract verdict). Triggers a capacity flush if the
+   * buffer crosses the configured fill ratio.
+   */
+  recordEvent(sessionId: string, kind: string, body: unknown): void {
+    if (!this.enabled) return;
+    const state = this.sessions.get(sessionId);
+    if (!state) return; // silently drop — recorder may have been ended
+    const event: TraceEvent = {
+      ts: this.now(),
+      seq: ++state.seqCounter,
+      kind,
+      body,
+    };
+    state.buffer.push(redactTraceEvent(event));
+    // Drop oldest if we somehow exceed the cap (shouldn't happen with
+    // capacity flush, but provides a hard safety net).
+    while (state.buffer.length > this.bufferSize) {
+      state.buffer.shift();
+    }
+    if (state.buffer.length >= Math.ceil(this.bufferSize * this.capacityFlushRatio)) {
+      void this.flush(sessionId);
+    }
+  }
+
+  /** Force-flush the in-memory buffer to disk for a session. */
+  async flush(sessionId: string): Promise<void> {
+    if (!this.enabled) return;
+    const state = this.sessions.get(sessionId);
+    if (!state || state.buffer.length === 0) return;
+    const batch = state.buffer.splice(0, state.buffer.length);
+    const result = this.storage.appendEvents(sessionId, batch);
+    state.meta.byteSize += result.bytes;
+  }
+
+  /**
+   * Finalize a session: flush remaining buffer, detach listeners, clear
+   * the periodic timer, and write the terminal status to the index.
+   */
+  async end(sessionId: string, status: TraceStatus = 'completed'): Promise<void> {
+    if (!this.enabled) return;
+    const state = this.sessions.get(sessionId);
+    if (!state) return;
+    await this.flush(sessionId);
+    if (state.cdp) {
+      for (const { kind, fn } of state.cdpListeners) {
+        const off = state.cdp.off ?? state.cdp.removeListener;
+        if (off) off.call(state.cdp, kind, fn);
+      }
+    }
+    if (state.page && state.pageListener) {
+      // Page may not have an off(); use removeListener fallback when present.
+      const pageOff = (state.page as unknown as { off?: typeof state.page.on; removeListener?: typeof state.page.on }).off
+        ?? (state.page as unknown as { removeListener?: typeof state.page.on }).removeListener;
+      if (pageOff) pageOff.call(state.page, state.pageListener.event, state.pageListener.fn);
+    }
+    if (state.timer) clearInterval(state.timer);
+    this.storage.recordSessionEnd(sessionId, {
+      endedAt: this.now(),
+      status,
+      byteSize: state.meta.byteSize,
+    });
+    this.sessions.delete(sessionId);
+  }
+
+  /**
+   * Flush + end every active session. Intended to be wired to process
+   * `beforeExit` / SIGTERM by the host so traces survive a clean shutdown.
+   */
+  async shutdown(status: TraceStatus = 'aborted'): Promise<void> {
+    const ids = [...this.sessions.keys()];
+    for (const id of ids) {
+      try {
+        await this.end(id, status);
+      } catch {
+        // best-effort during shutdown
+      }
+    }
+  }
+
+  /** For tests: peek at the in-memory buffer without flushing. */
+  _peekBuffer(sessionId: string): TraceEvent[] {
+    return this.sessions.get(sessionId)?.buffer.slice() ?? [];
+  }
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, v));
+}
+
+let _global: TraceRecorder | null = null;
+/**
+ * Process-wide singleton. The first call decides options; subsequent calls
+ * return the same instance regardless of arguments. Hosts that need
+ * per-test isolation should construct `new TraceRecorder({...})` directly.
+ */
+export function getTraceRecorder(opts?: TraceRecorderOptions): TraceRecorder {
+  if (!_global) _global = new TraceRecorder(opts);
+  return _global;
+}
+
+/** Test-only: reset the global singleton. */
+export function _resetTraceRecorderForTests(): void {
+  _global = null;
+}

--- a/src/trace/recorder.ts
+++ b/src/trace/recorder.ts
@@ -258,31 +258,54 @@ export class TraceRecorder {
   /**
    * Finalize a session: flush remaining buffer, detach listeners, clear
    * the periodic timer, and write the terminal status to the index.
+   *
+   * Cleanup of listeners / timer / session entry is run inside `finally`
+   * so a `flush()` rejection (disk full, sqlite write failure) cannot
+   * leave the recorder still subscribed to CDP/page events with a live
+   * timer for a session the caller intended to close. The flush
+   * rejection is re-thrown after cleanup so callers learn that some
+   * events did not persist; `shutdown()` already swallows per-session
+   * errors so a single bad session never blocks the rest.
    */
   async end(sessionId: string, status: TraceStatus = 'completed'): Promise<void> {
     if (!this.enabled) return;
     const state = this.sessions.get(sessionId);
     if (!state) return;
-    await this.flush(sessionId);
-    if (state.cdp) {
-      for (const { kind, fn } of state.cdpListeners) {
-        const off = state.cdp.off ?? state.cdp.removeListener;
-        if (off) off.call(state.cdp, kind, fn);
+    let flushError: unknown;
+    try {
+      await this.flush(sessionId);
+    } catch (err) {
+      flushError = err;
+    }
+    try {
+      if (state.cdp) {
+        for (const { kind, fn } of state.cdpListeners) {
+          const off = state.cdp.off ?? state.cdp.removeListener;
+          if (off) off.call(state.cdp, kind, fn);
+        }
       }
+      if (state.page && state.pageListener) {
+        // Page may not have an off(); use removeListener fallback when present.
+        const pageOff = (state.page as unknown as { off?: typeof state.page.on; removeListener?: typeof state.page.on }).off
+          ?? (state.page as unknown as { removeListener?: typeof state.page.on }).removeListener;
+        if (pageOff) pageOff.call(state.page, state.pageListener.event, state.pageListener.fn);
+      }
+      if (state.timer) clearInterval(state.timer);
+      // Best-effort terminal write; swallow storage failure here so
+      // cleanup completes. The flushError (if any) still surfaces below.
+      try {
+        this.getStorage().recordSessionEnd(sessionId, {
+          endedAt: this.now(),
+          status: flushError ? 'failed' : status,
+          byteSize: state.meta.byteSize,
+        });
+      } catch (err) {
+        if (!flushError) flushError = err;
+      }
+    } finally {
+      this.sessions.delete(sessionId);
     }
-    if (state.page && state.pageListener) {
-      // Page may not have an off(); use removeListener fallback when present.
-      const pageOff = (state.page as unknown as { off?: typeof state.page.on; removeListener?: typeof state.page.on }).off
-        ?? (state.page as unknown as { removeListener?: typeof state.page.on }).removeListener;
-      if (pageOff) pageOff.call(state.page, state.pageListener.event, state.pageListener.fn);
-    }
-    if (state.timer) clearInterval(state.timer);
-    this.getStorage().recordSessionEnd(sessionId, {
-      endedAt: this.now(),
-      status,
-      byteSize: state.meta.byteSize,
-    });
-    this.sessions.delete(sessionId);
+    if (flushError) throw flushError;
   }
 
   /**

--- a/src/trace/recorder.ts
+++ b/src/trace/recorder.ts
@@ -73,7 +73,7 @@ interface SessionState {
 }
 
 export class TraceRecorder {
-  private readonly storage: TraceStorage;
+  private _storage: TraceStorage | null;
   private readonly bufferSize: number;
   private readonly flushIntervalMs: number;
   private readonly capacityFlushRatio: number;
@@ -82,7 +82,12 @@ export class TraceRecorder {
   private readonly sessions = new Map<string, SessionState>();
 
   constructor(opts: TraceRecorderOptions = {}) {
-    this.storage = opts.storage ?? new TraceStorage({ rootDir: defaultTraceRootDir() });
+    // Storage is lazy: do NOT touch the filesystem or load `better-sqlite3`
+    // until the recorder actually needs to persist. A default-off recorder
+    // (env unset) must pay zero cost — initialising TraceStorage in the
+    // constructor would defeat that and break in environments where the
+    // optional native binding is unavailable.
+    this._storage = opts.storage ?? null;
     this.bufferSize = Math.max(1, opts.bufferSize ?? envInt('OPENCHROME_TRACE_BUFFER', 500));
     this.flushIntervalMs = Math.max(
       100,
@@ -93,6 +98,17 @@ export class TraceRecorder {
       opts.enabled ??
       (process.env.OPENCHROME_TRACE === '1' || process.env.OPENCHROME_TRACE === 'on');
     this.now = opts.now ?? Date.now;
+  }
+
+  /**
+   * Resolve the storage backend, lazily constructing the default one on
+   * first use. Only called from paths gated by `this.enabled`.
+   */
+  private getStorage(): TraceStorage {
+    if (!this._storage) {
+      this._storage = new TraceStorage({ rootDir: defaultTraceRootDir() });
+    }
+    return this._storage;
   }
 
   /** True when the recorder will actually capture events. */
@@ -111,7 +127,7 @@ export class TraceRecorder {
     const existing = this.sessions.get(meta.sessionId);
     if (existing) {
       existing.meta = { ...existing.meta, ...meta, status, byteSize: existing.meta.byteSize };
-      this.storage.recordSessionStart(existing.meta);
+      this.getStorage().recordSessionStart(existing.meta);
       return;
     }
     const fullMeta: TraceSessionMeta = {
@@ -122,7 +138,7 @@ export class TraceRecorder {
       status,
       byteSize: 0,
     };
-    this.storage.recordSessionStart(fullMeta);
+    this.getStorage().recordSessionStart(fullMeta);
     const state: SessionState = {
       meta: fullMeta,
       buffer: [],
@@ -203,13 +219,22 @@ export class TraceRecorder {
     }
   }
 
-  /** Force-flush the in-memory buffer to disk for a session. */
+  /**
+   * Force-flush the in-memory buffer to disk for a session. The events stay
+   * in the buffer until persistence succeeds; if `appendEvents` throws (disk
+   * full, permission error, sqlite write failure), the events are preserved
+   * for the next flush attempt instead of being silently dropped.
+   */
   async flush(sessionId: string): Promise<void> {
     if (!this.enabled) return;
     const state = this.sessions.get(sessionId);
     if (!state || state.buffer.length === 0) return;
-    const batch = state.buffer.splice(0, state.buffer.length);
-    const result = this.storage.appendEvents(sessionId, batch);
+    // Snapshot the current buffer prefix; do NOT remove yet.
+    const batch = state.buffer.slice();
+    const result = this.getStorage().appendEvents(sessionId, batch);
+    // Persistence succeeded — drop the persisted prefix. Anything appended
+    // by recordEvent during the (synchronous) write stays at the tail.
+    state.buffer.splice(0, batch.length);
     state.meta.byteSize += result.bytes;
   }
 
@@ -235,7 +260,7 @@ export class TraceRecorder {
       if (pageOff) pageOff.call(state.page, state.pageListener.event, state.pageListener.fn);
     }
     if (state.timer) clearInterval(state.timer);
-    this.storage.recordSessionEnd(sessionId, {
+    this.getStorage().recordSessionEnd(sessionId, {
       endedAt: this.now(),
       status,
       byteSize: state.meta.byteSize,
@@ -261,6 +286,11 @@ export class TraceRecorder {
   /** For tests: peek at the in-memory buffer without flushing. */
   _peekBuffer(sessionId: string): TraceEvent[] {
     return this.sessions.get(sessionId)?.buffer.slice() ?? [];
+  }
+
+  /** For tests: has storage been instantiated yet (lazy-init guard)? */
+  _storageInitializedForTests(): boolean {
+    return this._storage !== null;
   }
 }
 

--- a/src/trace/recorder.ts
+++ b/src/trace/recorder.ts
@@ -146,7 +146,7 @@ export class TraceRecorder {
       cdpListeners: [],
     };
     state.timer = setInterval(() => {
-      void this.flush(meta.sessionId);
+      this.fireAndForgetFlush(meta.sessionId);
     }, this.flushIntervalMs);
     if (typeof state.timer.unref === 'function') state.timer.unref();
     this.sessions.set(meta.sessionId, state);
@@ -186,7 +186,7 @@ export class TraceRecorder {
       const navListener = (): void => {
         // Flush on each navigation boundary so per-URL slices land in
         // distinct files (helpful for replay / time-travel).
-        void this.flush(sessionId);
+        this.fireAndForgetFlush(sessionId);
       };
       page.on('framenavigated', navListener);
       state.pageListener = { event: 'framenavigated', fn: navListener };
@@ -215,8 +215,25 @@ export class TraceRecorder {
       state.buffer.shift();
     }
     if (state.buffer.length >= Math.ceil(this.bufferSize * this.capacityFlushRatio)) {
-      void this.flush(sessionId);
+      this.fireAndForgetFlush(sessionId);
     }
+  }
+
+  /**
+   * Wrap a fire-and-forget flush so a rejection never escapes as an
+   * unhandled-promise: capacity, timer, and navigation flushes are all
+   * void-typed, and an unhandled rejection there can crash Node when
+   * `--unhandled-rejections=strict` is active. The events stay in the
+   * buffer (per the flush() contract) so the next attempt will retry.
+   */
+  private fireAndForgetFlush(sessionId: string): void {
+    this.flush(sessionId).catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[TraceRecorder] flush failed for session=${sessionId}: ${msg} ` +
+          '(events remain buffered for next flush attempt)',
+      );
+    });
   }
 
   /**

--- a/tests/trace/recorder.test.ts
+++ b/tests/trace/recorder.test.ts
@@ -282,6 +282,37 @@ describe('TraceRecorder — shutdown semantics', () => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 
+  test('end() runs cleanup even when flush rejects (no leaked listeners/timer)', async () => {
+    const cdp = new EventEmitter();
+    const fake: Pick<TraceStorage, 'recordSessionStart' | 'recordSessionEnd' | 'appendEvents' | 'list' | 'get' | 'close'> = {
+      recordSessionStart: () => undefined,
+      recordSessionEnd: () => undefined,
+      appendEvents: () => {
+        throw new Error('disk full');
+      },
+      list: () => [],
+      get: () => undefined,
+      close: () => undefined,
+    };
+    const r = new TraceRecorder({
+      storage: fake as unknown as TraceStorage,
+      enabled: true,
+      bufferSize: 100,
+      flushIntervalMs: 24 * 60 * 60 * 1000,
+      now: () => 1700000000000,
+    });
+    r.start({ sessionId: 's', startedAt: 1 });
+    r.attach('s', cdp);
+    r.recordEvent('s', 'tool_call', { name: 'click' });
+    expect(r._peekBuffer('s')).toHaveLength(1);
+    expect(cdp.listenerCount('Page.frameNavigated')).toBeGreaterThan(0);
+    // end() must reject (so the caller learns events did not persist)
+    // but cleanup of CDP listeners + session entry must still happen.
+    await expect(r.end('s')).rejects.toThrow(/disk full/);
+    expect(cdp.listenerCount('Page.frameNavigated')).toBe(0);
+    expect(r._peekBuffer('s')).toEqual([]); // session removed
+  });
+
   test('shutdown flushes and ends every active session as aborted', async () => {
     const r = makeRecorder({ storage });
     r.start({ sessionId: 'a', startedAt: 1 });

--- a/tests/trace/recorder.test.ts
+++ b/tests/trace/recorder.test.ts
@@ -121,6 +121,46 @@ describe('TraceRecorder — start / recordEvent / flush', () => {
     expect(() => r.recordEvent('nope', 'k', {})).not.toThrow();
   });
 
+  test('fire-and-forget capacity flush swallows rejection (no unhandled promise)', async () => {
+    const fake: Pick<TraceStorage, 'recordSessionStart' | 'recordSessionEnd' | 'appendEvents' | 'list' | 'get' | 'close'> = {
+      recordSessionStart: () => undefined,
+      recordSessionEnd: () => undefined,
+      appendEvents: () => {
+        throw new Error('disk full');
+      },
+      list: () => [],
+      get: () => undefined,
+      close: () => undefined,
+    };
+    const r = new TraceRecorder({
+      storage: fake as unknown as TraceStorage,
+      enabled: true,
+      bufferSize: 4,
+      capacityFlushRatio: 0.5, // flush at >= 2 events
+      flushIntervalMs: 24 * 60 * 60 * 1000,
+      now: () => 1700000000000,
+    });
+    const errors: unknown[] = [];
+    const onUnhandled = (err: unknown): void => { errors.push(err); };
+    process.on('unhandledRejection', onUnhandled);
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      r.start({ sessionId: 's', startedAt: 1 });
+      r.recordEvent('s', 'a', { i: 1 });
+      r.recordEvent('s', 'b', { i: 2 }); // crosses capacity threshold → fire-and-forget flush
+      // Allow the rejected promise to settle.
+      await new Promise((res) => setImmediate(res));
+      await new Promise((res) => setImmediate(res));
+      expect(errors).toEqual([]); // No unhandled rejection escaped.
+      expect(errSpy).toHaveBeenCalled(); // The error was logged for ops visibility.
+      // Buffer is preserved for the next attempt (per the flush contract).
+      expect(r._peekBuffer('s')).toHaveLength(2);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+      errSpy.mockRestore();
+    }
+  });
+
   test('flush preserves buffered events when persistence fails', async () => {
     // Fake storage that throws on the first appendEvents call, succeeds after.
     let throwCount = 0;

--- a/tests/trace/recorder.test.ts
+++ b/tests/trace/recorder.test.ts
@@ -1,0 +1,219 @@
+import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { TraceRecorder, _resetTraceRecorderForTests, getTraceRecorder } from '../../src/trace/recorder';
+import { TraceStorage } from '../../src/trace/storage';
+import type { TraceEvent } from '../../src/trace/types';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-rec-'));
+}
+
+function makeRecorder(opts: { storage: TraceStorage; bufferSize?: number; flushIntervalMs?: number; capacityFlushRatio?: number; }): TraceRecorder {
+  return new TraceRecorder({
+    storage: opts.storage,
+    bufferSize: opts.bufferSize ?? 8,
+    flushIntervalMs: opts.flushIntervalMs ?? 24 * 60 * 60 * 1000, // effectively disable timer in unit tests
+    capacityFlushRatio: opts.capacityFlushRatio ?? 0.5,
+    enabled: true,
+    now: () => 1700000000000,
+  });
+}
+
+describe('TraceRecorder — disabled by default when env not set', () => {
+  test('isEnabled() reflects OPENCHROME_TRACE env', () => {
+    const prev = process.env.OPENCHROME_TRACE;
+    delete process.env.OPENCHROME_TRACE;
+    const r1 = new TraceRecorder({ storage: new TraceStorage({ rootDir: tempRoot() }) });
+    expect(r1.isEnabled()).toBe(false);
+
+    process.env.OPENCHROME_TRACE = '1';
+    const r2 = new TraceRecorder({ storage: new TraceStorage({ rootDir: tempRoot() }) });
+    expect(r2.isEnabled()).toBe(true);
+
+    process.env.OPENCHROME_TRACE = prev ?? '';
+    if (!prev) delete process.env.OPENCHROME_TRACE;
+  });
+
+  test('disabled recorder is a no-op for start / recordEvent / flush', async () => {
+    const root = tempRoot();
+    const storage = new TraceStorage({ rootDir: root });
+    const r = new TraceRecorder({ storage, enabled: false });
+    r.start({ sessionId: 's', startedAt: 1, domain: 'x' });
+    r.recordEvent('s', 'k', { x: 1 });
+    await r.flush('s');
+    await r.end('s');
+    expect(storage.list()).toHaveLength(0);
+    storage.close();
+  });
+});
+
+describe('TraceRecorder — start / recordEvent / flush', () => {
+  let root: string;
+  let storage: TraceStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    storage = new TraceStorage({ rootDir: root });
+  });
+
+  afterEach(() => {
+    storage.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('start() registers session in the index', () => {
+    const r = makeRecorder({ storage });
+    r.start({ sessionId: 's1', startedAt: 100, domain: 'amazon.com' });
+    expect(storage.get('s1')?.status).toBe('running');
+    expect(storage.get('s1')?.domain).toBe('amazon.com');
+  });
+
+  test('recordEvent buffers events and flushes on capacity threshold', async () => {
+    const r = makeRecorder({ storage, bufferSize: 4, capacityFlushRatio: 0.5 }); // flush at >= 2
+    r.start({ sessionId: 's1', startedAt: 100 });
+    r.recordEvent('s1', 'a', { i: 1 });
+    // Buffer should still contain 1 event (below threshold)
+    expect(r._peekBuffer('s1')).toHaveLength(1);
+    r.recordEvent('s1', 'b', { i: 2 });
+    // Capacity flush is async — give it a tick
+    await new Promise((res) => setImmediate(res));
+    expect(r._peekBuffer('s1')).toHaveLength(0);
+    expect(storage.get('s1')?.byteSize).toBeGreaterThan(0);
+  });
+
+  test('manual flush writes the buffer and updates byte_size', async () => {
+    const r = makeRecorder({ storage, bufferSize: 100 }); // never auto-flushes
+    r.start({ sessionId: 's2', startedAt: 100 });
+    r.recordEvent('s2', 'k', { i: 1 });
+    r.recordEvent('s2', 'k', { i: 2 });
+    await r.flush('s2');
+    expect(r._peekBuffer('s2')).toHaveLength(0);
+    expect(storage.get('s2')?.byteSize).toBeGreaterThan(0);
+  });
+
+  test('redaction is applied at recordEvent time (sensitive keys scrubbed)', async () => {
+    const r = makeRecorder({ storage, bufferSize: 100 });
+    r.start({ sessionId: 's3', startedAt: 100 });
+    r.recordEvent('s3', 'Network.requestWillBeSent', {
+      request: { url: 'https://x/?password=hunter2', headers: { Authorization: 'Bearer secret' } },
+    });
+    const buf = r._peekBuffer('s3');
+    const body = buf[0].body as { request: { url: string; headers: Record<string, string> } };
+    expect(body.request.url).not.toContain('hunter2');
+    expect(body.request.headers.Authorization).toBe('[REDACTED]');
+  });
+
+  test('recordEvent on unknown session is a silent drop (no throw)', () => {
+    const r = makeRecorder({ storage });
+    expect(() => r.recordEvent('nope', 'k', {})).not.toThrow();
+  });
+});
+
+describe('TraceRecorder — attach to CDP-like emitter', () => {
+  let root: string;
+  let storage: TraceStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    storage = new TraceStorage({ rootDir: root });
+  });
+
+  afterEach(() => {
+    storage.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('subscribes to default CDP kinds and records emitted events', async () => {
+    const cdp = new EventEmitter();
+    const r = makeRecorder({ storage, bufferSize: 100 });
+    r.start({ sessionId: 's', startedAt: 100 });
+    r.attach('s', cdp);
+    cdp.emit('Page.frameNavigated', { frame: { url: 'https://x' } });
+    cdp.emit('Network.responseReceived', { response: { status: 200 } });
+    cdp.emit('Runtime.consoleAPICalled', { type: 'log' });
+    expect(r._peekBuffer('s').map((e) => e.kind)).toEqual([
+      'Page.frameNavigated',
+      'Network.responseReceived',
+      'Runtime.consoleAPICalled',
+    ]);
+  });
+
+  test('detach via end() removes listeners; further CDP events are not buffered', async () => {
+    const cdp = new EventEmitter();
+    const r = makeRecorder({ storage, bufferSize: 100 });
+    r.start({ sessionId: 's', startedAt: 100 });
+    r.attach('s', cdp);
+    cdp.emit('Page.frameNavigated', {});
+    await r.end('s');
+    cdp.emit('Page.frameNavigated', {});
+    // Session is gone — no buffer to peek at.
+    expect(r._peekBuffer('s')).toEqual([]);
+    expect(storage.get('s')?.status).toBe('completed');
+  });
+
+  test('framenavigated on the page triggers a flush', async () => {
+    const cdp = new EventEmitter();
+    const page = new EventEmitter();
+    const r = makeRecorder({ storage, bufferSize: 100 });
+    r.start({ sessionId: 's', startedAt: 100 });
+    r.attach('s', cdp, page as unknown as { on(e: string, fn: (...a: unknown[]) => void): unknown });
+    r.recordEvent('s', 'tool_call', { name: 'click' });
+    expect(r._peekBuffer('s')).toHaveLength(1);
+    page.emit('framenavigated', { url: 'https://x' });
+    await new Promise((res) => setImmediate(res));
+    expect(r._peekBuffer('s')).toHaveLength(0);
+  });
+
+  test('attaching a session twice throws (defensive)', () => {
+    const cdp = new EventEmitter();
+    const r = makeRecorder({ storage });
+    r.start({ sessionId: 's', startedAt: 100 });
+    r.attach('s', cdp);
+    expect(() => r.attach('s', cdp)).toThrow(/already attached/);
+  });
+
+  test('attach without start throws', () => {
+    const cdp = new EventEmitter();
+    const r = makeRecorder({ storage });
+    expect(() => r.attach('nope', cdp)).toThrow(/unknown session/);
+  });
+});
+
+describe('TraceRecorder — shutdown semantics', () => {
+  let root: string;
+  let storage: TraceStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    storage = new TraceStorage({ rootDir: root });
+  });
+
+  afterEach(() => {
+    storage.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('shutdown flushes and ends every active session as aborted', async () => {
+    const r = makeRecorder({ storage });
+    r.start({ sessionId: 'a', startedAt: 1 });
+    r.start({ sessionId: 'b', startedAt: 2 });
+    r.recordEvent('a', 'k', {});
+    r.recordEvent('b', 'k', {});
+    await r.shutdown();
+    expect(storage.get('a')?.status).toBe('aborted');
+    expect(storage.get('b')?.status).toBe('aborted');
+  });
+});
+
+describe('TraceRecorder — global singleton', () => {
+  test('getTraceRecorder() returns the same instance across calls', () => {
+    _resetTraceRecorderForTests();
+    const a = getTraceRecorder({ enabled: false });
+    const b = getTraceRecorder();
+    expect(a).toBe(b);
+    _resetTraceRecorderForTests();
+  });
+});

--- a/tests/trace/recorder.test.ts
+++ b/tests/trace/recorder.test.ts
@@ -48,6 +48,16 @@ describe('TraceRecorder — disabled by default when env not set', () => {
     expect(storage.list()).toHaveLength(0);
     storage.close();
   });
+
+  test('disabled recorder does not eagerly instantiate TraceStorage', () => {
+    // No storage passed in opts. A default-off recorder must not touch the
+    // filesystem or load `better-sqlite3` until tracing is actually used.
+    const r = new TraceRecorder({ enabled: false });
+    expect(r._storageInitializedForTests()).toBe(false);
+    r.start({ sessionId: 's', startedAt: 1 });
+    r.recordEvent('s', 'k', {});
+    expect(r._storageInitializedForTests()).toBe(false);
+  });
 });
 
 describe('TraceRecorder — start / recordEvent / flush', () => {
@@ -109,6 +119,42 @@ describe('TraceRecorder — start / recordEvent / flush', () => {
   test('recordEvent on unknown session is a silent drop (no throw)', () => {
     const r = makeRecorder({ storage });
     expect(() => r.recordEvent('nope', 'k', {})).not.toThrow();
+  });
+
+  test('flush preserves buffered events when persistence fails', async () => {
+    // Fake storage that throws on the first appendEvents call, succeeds after.
+    let throwCount = 0;
+    const fake: Pick<TraceStorage, 'recordSessionStart' | 'recordSessionEnd' | 'appendEvents' | 'list' | 'get' | 'close'> = {
+      recordSessionStart: () => undefined,
+      recordSessionEnd: () => undefined,
+      appendEvents: (_id: string, events: TraceEvent[]) => {
+        if (throwCount === 0) {
+          throwCount++;
+          throw new Error('disk full');
+        }
+        return { bytes: 1, filePath: '/tmp/fake.jsonl', count: events.length } as ReturnType<TraceStorage['appendEvents']>;
+      },
+      list: () => [],
+      get: () => undefined,
+      close: () => undefined,
+    };
+    const r = new TraceRecorder({
+      storage: fake as unknown as TraceStorage,
+      enabled: true,
+      bufferSize: 100,
+      flushIntervalMs: 24 * 60 * 60 * 1000,
+      now: () => 1700000000000,
+    });
+    r.start({ sessionId: 's', startedAt: 1 });
+    r.recordEvent('s', 'a', { i: 1 });
+    r.recordEvent('s', 'b', { i: 2 });
+    expect(r._peekBuffer('s')).toHaveLength(2);
+    // First flush throws; events must remain buffered, not be dropped.
+    await expect(r.flush('s')).rejects.toThrow(/disk full/);
+    expect(r._peekBuffer('s')).toHaveLength(2);
+    // Second flush succeeds; buffer is drained only after persistence.
+    await r.flush('s');
+    expect(r._peekBuffer('s')).toHaveLength(0);
   });
 });
 

--- a/tests/trace/recorder.test.ts
+++ b/tests/trace/recorder.test.ts
@@ -282,13 +282,21 @@ describe('TraceRecorder — shutdown semantics', () => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 
-  test('end() runs cleanup even when flush rejects (no leaked listeners/timer)', async () => {
+  test('end() detaches listeners but PRESERVES session+buffer on flush failure', async () => {
+    // Flush failure during end() must not silently drop the buffered
+    // tail. Listeners and the periodic timer are detached (recording
+    // is over) but the session entry and its buffer stay so the
+    // caller can retry flush()/end() once storage recovers.
     const cdp = new EventEmitter();
+    let throwOnAppend = true;
+    const persisted: Array<{ id: string; count: number }> = [];
     const fake: Pick<TraceStorage, 'recordSessionStart' | 'recordSessionEnd' | 'appendEvents' | 'list' | 'get' | 'close'> = {
       recordSessionStart: () => undefined,
       recordSessionEnd: () => undefined,
-      appendEvents: () => {
-        throw new Error('disk full');
+      appendEvents: (id: string, evts: unknown[]) => {
+        if (throwOnAppend) throw new Error('disk full');
+        persisted.push({ id, count: evts.length });
+        return { bytes: 1, filePath: '/tmp/fake.jsonl' } as ReturnType<TraceStorage['appendEvents']>;
       },
       list: () => [],
       get: () => undefined,
@@ -306,11 +314,17 @@ describe('TraceRecorder — shutdown semantics', () => {
     r.recordEvent('s', 'tool_call', { name: 'click' });
     expect(r._peekBuffer('s')).toHaveLength(1);
     expect(cdp.listenerCount('Page.frameNavigated')).toBeGreaterThan(0);
-    // end() must reject (so the caller learns events did not persist)
-    // but cleanup of CDP listeners + session entry must still happen.
+
+    // First end() rejects; listeners detached; buffer preserved.
     await expect(r.end('s')).rejects.toThrow(/disk full/);
     expect(cdp.listenerCount('Page.frameNavigated')).toBe(0);
-    expect(r._peekBuffer('s')).toEqual([]); // session removed
+    expect(r._peekBuffer('s')).toHaveLength(1);
+
+    // Storage recovers; retry end() drains the buffer and removes the session.
+    throwOnAppend = false;
+    await r.end('s');
+    expect(persisted).toEqual([{ id: 's', count: 1 }]);
+    expect(r._peekBuffer('s')).toEqual([]);
   });
 
   test('shutdown flushes and ends every active session as aborted', async () => {

--- a/tests/trace/storage.test.ts
+++ b/tests/trace/storage.test.ts
@@ -224,6 +224,28 @@ describe('TraceStorage — appendEvents', () => {
     expect(fs.existsSync(path.join(root, 'ghost'))).toBe(false);
   });
 
+  test('removes JSONL file when SQLite byte_size update fails after append', () => {
+    const dbHandle = (store as unknown as {
+      db: { prepare: (sql: string) => unknown };
+    }).db;
+    const originalPrepare = dbHandle.prepare.bind(dbHandle);
+    dbHandle.prepare = ((sql: string): unknown => {
+      if (sql.startsWith('UPDATE traces SET byte_size = byte_size + ?')) {
+        throw new Error('sqlite locked after append');
+      }
+      return originalPrepare(sql);
+    }) as typeof dbHandle.prepare;
+
+    try {
+      expect(() => store.appendEvents('s', [event(1, 123)])).toThrow(/sqlite locked/);
+    } finally {
+      dbHandle.prepare = originalPrepare as typeof dbHandle.prepare;
+    }
+
+    expect(fs.existsSync(path.join(root, 's', '123-1.jsonl'))).toBe(false);
+    expect(store.get('s')?.byteSize).toBe(0);
+  });
+
   test('rejects path-traversal session ids at all entry points', () => {
     // The recorder treats sessionId as a directory basename; without
     // validation `../foo` lets writes escape the trace root and a


### PR DESCRIPTION
## Summary

`TraceRecorder` — a default-off, ring-buffered event recorder that attaches to a `CDPSession`-like emitter and flushes JSONL via `TraceStorage` (#735). Wires the redactor in at record time so the in-memory buffer never holds raw credentials. Stacked on **#735** (PR-1 storage + redactor foundation).

- `src/trace/recorder.ts` — `TraceRecorder` with `start` / `attach` / `recordEvent` / `flush` / `end` / `shutdown`. Per-session ring buffer (default 500), flush triggered by capacity (default 80%) / periodic timer (default 30s) / `Page.frameNavigated` / shutdown. `EventEmitterLike` interface keeps the module decoupled from puppeteer types
- `src/trace/index.ts` — re-export `TraceRecorder` + `getTraceRecorder` singleton
- `tests/trace/recorder.test.ts` (14 cases) — disabled-by-default no-op, start / `recordEvent` / capacity flush, redaction at record time, attach to a fake CDP `EventEmitter`, `frameNavigated` triggers flush, `end()` detach semantics, `shutdown()` marks all sessions aborted, global singleton

## Why default-off

Per #701 v2 acceptance: "Median wall-time overhead ≤ 5%". Default-off via `OPENCHROME_TRACE=1` lets this PR ship behavior-neutral — the recorder pays zero CPU until an operator opts in. Once #701's later PRs add the CDP hook + benchmark suite, the env flag flips to opt-out.

## What is deferred

- `CDPClient.createPage()` opt-in hook → follow-up PR (this avoids touching `src/cdp/` in this slice)
- Benchmark suite for the 5% overhead claim → follow-up PR after the CDP hook lands
- E2E fixture flows (`tests/trace/fixtures/`) → after the CDP hook is wired

The recorder's public surface is testable in isolation today (mocked `CDPSession`) so this PR is self-contained.

## Validation

- `npm run build` clean
- `npm test -- tests/trace` — 50/50 pass (PR-1 36 + PR-2 14)
- No CDP-path coupling: `src/cdp/*` untouched, recorder pays zero cost when `OPENCHROME_TRACE` is unset

## Test plan

- [ ] Reviewer pulls branch, runs `npm install && npm run build && npm test -- tests/trace`
- [ ] Reviewer confirms `EventEmitterLike` interface in `recorder.ts` matches the puppeteer `CDPSession` shape (no direct puppeteer import)
- [ ] Reviewer confirms recorder is no-op without `OPENCHROME_TRACE=1` (test `disabled-by-default no-op`)
- [ ] Reviewer confirms redactor is applied at `recordEvent()` time, not at flush (so the in-memory buffer is already clean)

Refs: #698 (epic), #701 (sub-issue). Stacked on #735.

🤖 Split from `feat/m1-pr1-trace-foundation`. Original commit: `318dcad`.
