### PR TITLE
feat(skill): state hashing + URL normalizer + interactive filter (M1 PR-4)

### DIFF
--- a/src/skill/index.ts
+++ b/src/skill/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Skill subsystem barrel — state hashing, URL normalization, interactive
+ * filter. Future PRs add storage (#702) and executor (#703).
+ */
+
+export { normalizeUrl, TRACKING_PARAM_PATTERNS } from './url-normalizer';
+export type { NormalizeUrlResult } from './url-normalizer';
+
+export { isInteractiveNode } from './interactive-filter';
+export type { InteractiveProbe } from './interactive-filter';
+
+export { computeStateHash, canonicalJson } from './state';
+export type {
+  PageSnapshot,
+  LandmarkFlags,
+  StateHashEvidence,
+  StateHashResult,
+} from './state';

--- a/src/skill/interactive-filter.ts
+++ b/src/skill/interactive-filter.ts
@@ -40,26 +40,36 @@ const INTERACTIVE_ROLES = new Set([
 ]);
 
 /**
- * Common ARIA roles that explicitly DO NOT carry interactive semantics.
- * Used as a fallback-chain terminator: when a `role="X Y"` chain has X
- * recognised as one of these, we honour the user-agent rule that the
- * first valid token wins and stop without checking later tokens. This
- * keeps `role="heading button"` non-interactive (consistent with
- * browsers) instead of a false positive that would skew the state hash.
+ * ARIA roles that are recognised but do NOT carry interactive
+ * semantics. Together with `INTERACTIVE_ROLES`, this set forms the
+ * "known role" universe. ARIA 1.2 fallback semantics resolve a
+ * `role="X Y"` chain to the first **recognised** token; an unknown
+ * token is skipped to the next one. Without a complete known-role
+ * universe, valid roles outside this set leak through the unknown
+ * fallback path and a later interactive token wrongly wins.
  *
- * The set is intentionally narrow — only roles common enough to appear
- * in real-world fallback chains. Truly unknown tokens fall through to
- * the next one (matches ARIA 1.2 token-resolution semantics).
+ * This list mirrors the WAI-ARIA 1.2 role taxonomy (document
+ * structure, landmark, live region, window, and abstract container
+ * roles) excluding the widget roles already in `INTERACTIVE_ROLES`.
  */
 const NON_INTERACTIVE_ROLES = new Set([
   // Document structure
-  'heading', 'list', 'listitem', 'article', 'document', 'figure', 'group',
-  'separator', 'table', 'row', 'rowgroup', 'cell', 'columnheader', 'rowheader',
-  'definition', 'term', 'note', 'paragraph', 'presentation', 'none',
-  // Landmarks
-  'banner', 'complementary', 'contentinfo', 'main', 'navigation', 'region', 'search', 'form',
-  // Live regions / status
-  'alert', 'log', 'marquee', 'status', 'timer', 'tooltip',
+  'article', 'blockquote', 'caption', 'cell', 'code', 'columnheader',
+  'definition', 'deletion', 'directory', 'document', 'emphasis', 'feed',
+  'figure', 'generic', 'group', 'heading', 'image', 'img', 'insertion',
+  'list', 'listitem', 'mark', 'math', 'meter', 'none', 'note', 'paragraph',
+  'presentation', 'row', 'rowgroup', 'rowheader', 'separator', 'strong',
+  'subscript', 'superscript', 'table', 'term', 'time', 'toolbar', 'tooltip',
+  // Landmark
+  'banner', 'complementary', 'contentinfo', 'form', 'main', 'navigation',
+  'region', 'search',
+  // Live region / status
+  'alert', 'alertdialog', 'dialog', 'log', 'marquee', 'status', 'timer',
+  // Composite container (the focusable child carries interactivity, not
+  // the container itself, so it does not promote when it appears as
+  // the first token of a fallback chain).
+  'grid', 'listbox', 'menu', 'menubar', 'radiogroup', 'tablist',
+  'tabpanel', 'tree', 'treegrid', 'treeitem',
 ]);
 
 /** Subset of an element/node descriptor sufficient for the predicate. */

--- a/src/skill/interactive-filter.ts
+++ b/src/skill/interactive-filter.ts
@@ -17,8 +17,13 @@ const INTERACTIVE_TAG_NAMES = new Set([
   'textarea',
   'option',
   'summary',
-  'video',
-  'audio',
+  // Note: `video` and `audio` are intentionally excluded. Without the
+  // `controls` attribute (or an explicit `role`/`tabindex`) these
+  // elements are not user-operable — they're typically decorative or
+  // auto-playing background media. Treating every `<video>` /
+  // `<audio>` as interactive inflated `interactive_node_count` and
+  // produced different state hashes for pages whose actual
+  // affordances were unchanged. See `hasControls` on `InteractiveProbe`.
 ]);
 
 const INTERACTIVE_ROLES = new Set([
@@ -80,6 +85,8 @@ export interface InteractiveProbe {
   role?: string;
   /** Presence of href on `<a>`. Anchors without href are not interactive. */
   hasHref?: boolean;
+  /** Presence of `controls` attribute on `<video>` / `<audio>`. */
+  hasControls?: boolean;
   /** Presence of contenteditable. Treated as interactive textbox-equivalent. */
   contentEditable?: boolean;
   /** tabindex >= 0 makes any element focusable. */
@@ -97,6 +104,12 @@ export function isInteractiveNode(probe: InteractiveProbe): boolean {
   // short-circuiting.
   if (tag === 'a') {
     if (probe.hasHref) return true;
+  } else if (tag === 'video' || tag === 'audio') {
+    // Media elements are only user-operable when `controls` is
+    // present. Without it they fall through to the role/tabindex
+    // checks (covers `<video role="button" tabindex="0">` patterns
+    // some sites use to wrap media in a clickable surface).
+    if (probe.hasControls) return true;
   } else if (INTERACTIVE_TAG_NAMES.has(tag)) {
     return true;
   }

--- a/src/skill/interactive-filter.ts
+++ b/src/skill/interactive-filter.ts
@@ -39,6 +39,29 @@ const INTERACTIVE_ROLES = new Set([
   'menuitemradio',
 ]);
 
+/**
+ * Common ARIA roles that explicitly DO NOT carry interactive semantics.
+ * Used as a fallback-chain terminator: when a `role="X Y"` chain has X
+ * recognised as one of these, we honour the user-agent rule that the
+ * first valid token wins and stop without checking later tokens. This
+ * keeps `role="heading button"` non-interactive (consistent with
+ * browsers) instead of a false positive that would skew the state hash.
+ *
+ * The set is intentionally narrow — only roles common enough to appear
+ * in real-world fallback chains. Truly unknown tokens fall through to
+ * the next one (matches ARIA 1.2 token-resolution semantics).
+ */
+const NON_INTERACTIVE_ROLES = new Set([
+  // Document structure
+  'heading', 'list', 'listitem', 'article', 'document', 'figure', 'group',
+  'separator', 'table', 'row', 'rowgroup', 'cell', 'columnheader', 'rowheader',
+  'definition', 'term', 'note', 'paragraph', 'presentation', 'none',
+  // Landmarks
+  'banner', 'complementary', 'contentinfo', 'main', 'navigation', 'region', 'search', 'form',
+  // Live regions / status
+  'alert', 'log', 'marquee', 'status', 'timer', 'tooltip',
+]);
+
 /** Subset of an element/node descriptor sufficient for the predicate. */
 export interface InteractiveProbe {
   /** Lowercased tag name (e.g. "button", "a"). */
@@ -79,13 +102,28 @@ export function isInteractiveNode(probe: InteractiveProbe): boolean {
 
 /**
  * ARIA permits the `role` attribute to be a space-separated fallback
- * chain (`role="switch checkbox"`); the user agent picks the first
- * supported token. We follow the same rule: any interactive token
- * anywhere in the chain promotes the element.
+ * chain (`role="switch checkbox"`); per ARIA 1.2, the user agent
+ * resolves the element as the FIRST recognised token, not the first
+ * interactive one. We follow the same precedence:
+ *
+ *   • Walk tokens left-to-right.
+ *   • A token in `INTERACTIVE_ROLES` → interactive (return true).
+ *   • A token in `NON_INTERACTIVE_ROLES` → not interactive (return
+ *     false), even if a later token is interactive — this keeps
+ *     `role="heading button"` consistent with the browser, which
+ *     resolves it as `heading`.
+ *   • An unrecognised token is skipped, mirroring the user-agent
+ *     fallback (`role="weirdname button"` → `button`).
+ *
+ * If no recognised token is found, the role chain is treated as
+ * non-interactive (the caller may still promote via tabIndex /
+ * contentEditable / native tag).
  */
 function hasInteractiveRoleToken(role: string): boolean {
   for (const token of role.toLowerCase().split(/\s+/)) {
-    if (token && INTERACTIVE_ROLES.has(token)) return true;
+    if (!token) continue;
+    if (INTERACTIVE_ROLES.has(token)) return true;
+    if (NON_INTERACTIVE_ROLES.has(token)) return false;
   }
   return false;
 }

--- a/src/skill/interactive-filter.ts
+++ b/src/skill/interactive-filter.ts
@@ -68,11 +68,24 @@ export function isInteractiveNode(probe: InteractiveProbe): boolean {
     return true;
   }
 
-  if (probe.role && INTERACTIVE_ROLES.has(probe.role.toLowerCase())) return true;
+  if (probe.role && hasInteractiveRoleToken(probe.role)) return true;
 
   if (probe.contentEditable) return true;
 
   if (typeof probe.tabIndex === 'number' && probe.tabIndex >= 0) return true;
 
+  return false;
+}
+
+/**
+ * ARIA permits the `role` attribute to be a space-separated fallback
+ * chain (`role="switch checkbox"`); the user agent picks the first
+ * supported token. We follow the same rule: any interactive token
+ * anywhere in the chain promotes the element.
+ */
+function hasInteractiveRoleToken(role: string): boolean {
+  for (const token of role.toLowerCase().split(/\s+/)) {
+    if (token && INTERACTIVE_ROLES.has(token)) return true;
+  }
   return false;
 }

--- a/src/skill/interactive-filter.ts
+++ b/src/skill/interactive-filter.ts
@@ -56,10 +56,17 @@ export interface InteractiveProbe {
 export function isInteractiveNode(probe: InteractiveProbe): boolean {
   const tag = probe.tagName.toLowerCase();
 
-  // Anchors require href to be interactive (a name-anchor isn't).
-  if (tag === 'a') return Boolean(probe.hasHref);
-
-  if (INTERACTIVE_TAG_NAMES.has(tag)) return true;
+  // Anchors with `href` are interactive on the strength of the tag alone.
+  // Anchors without `href` (name-anchors) are NOT interactive on tag alone,
+  // but may still be promoted by an ARIA role / contentEditable / tabindex
+  // — common SPA pattern: `<a role="button" tabindex="0">…</a>`. We
+  // therefore fall through to the role/focus checks below instead of
+  // short-circuiting.
+  if (tag === 'a') {
+    if (probe.hasHref) return true;
+  } else if (INTERACTIVE_TAG_NAMES.has(tag)) {
+    return true;
+  }
 
   if (probe.role && INTERACTIVE_ROLES.has(probe.role.toLowerCase())) return true;
 

--- a/src/skill/interactive-filter.ts
+++ b/src/skill/interactive-filter.ts
@@ -1,0 +1,71 @@
+/**
+ * Canonical "is this an interactive element?" predicate.
+ *
+ * Shared by #702 (state hashing — must be deterministic across runs) and
+ * #709 (perceptual metadata — must annotate the same set). Defined once
+ * here so the two consumers don't drift.
+ *
+ * The set is intentionally narrow: only nodes a user could plausibly
+ * interact with via click/type/select. Excludes labels, headings, lists.
+ */
+
+const INTERACTIVE_TAG_NAMES = new Set([
+  'a',
+  'button',
+  'input',
+  'select',
+  'textarea',
+  'option',
+  'summary',
+  'video',
+  'audio',
+]);
+
+const INTERACTIVE_ROLES = new Set([
+  'button',
+  'link',
+  'tab',
+  'menuitem',
+  'checkbox',
+  'radio',
+  'switch',
+  'option',
+  'combobox',
+  'searchbox',
+  'textbox',
+  'slider',
+  'spinbutton',
+  'menuitemcheckbox',
+  'menuitemradio',
+]);
+
+/** Subset of an element/node descriptor sufficient for the predicate. */
+export interface InteractiveProbe {
+  /** Lowercased tag name (e.g. "button", "a"). */
+  tagName: string;
+  /** ARIA role attribute, lowercased. */
+  role?: string;
+  /** Presence of href on `<a>`. Anchors without href are not interactive. */
+  hasHref?: boolean;
+  /** Presence of contenteditable. Treated as interactive textbox-equivalent. */
+  contentEditable?: boolean;
+  /** tabindex >= 0 makes any element focusable. */
+  tabIndex?: number;
+}
+
+export function isInteractiveNode(probe: InteractiveProbe): boolean {
+  const tag = probe.tagName.toLowerCase();
+
+  // Anchors require href to be interactive (a name-anchor isn't).
+  if (tag === 'a') return Boolean(probe.hasHref);
+
+  if (INTERACTIVE_TAG_NAMES.has(tag)) return true;
+
+  if (probe.role && INTERACTIVE_ROLES.has(probe.role.toLowerCase())) return true;
+
+  if (probe.contentEditable) return true;
+
+  if (typeof probe.tabIndex === 'number' && probe.tabIndex >= 0) return true;
+
+  return false;
+}

--- a/src/skill/state.ts
+++ b/src/skill/state.ts
@@ -1,0 +1,163 @@
+/**
+ * Deterministic state hashing for the skill-graph nodes.
+ *
+ * Two visits to "the same logical page" must produce the same hash. Two
+ * meaningfully different states (logged-out vs logged-in, empty cart vs
+ * has-item) must differ. Concretely we hash:
+ *
+ *   1. Normalized URL (host lowercased, tracking params stripped, query
+ *      keys sorted) — see `url-normalizer.ts`.
+ *   2. Histogram of interactive-element tag-paths — captures structural
+ *      identity without being sensitive to dynamic ad/news content.
+ *   3. Sorted set of visible top-level headings (h1-h3 text after
+ *      whitespace collapse).
+ *   4. Bitmap flags for known landmarks: login form, payment fields,
+ *      cart count badge, modal overlay, captcha challenge.
+ *
+ * The output is `{ hash, evidence }`; callers persist `hash` in the graph
+ * DB and stash `evidence` in the node's `evidence_blob` so an operator
+ * inspecting the graph can see why two states differed.
+ */
+
+import * as crypto from 'node:crypto';
+
+import { normalizeUrl } from './url-normalizer';
+import { isInteractiveNode, type InteractiveProbe } from './interactive-filter';
+
+/** A snapshot the hasher consumes — produced from a real page or a fixture. */
+export interface PageSnapshot {
+  url: string;
+  /** Top-level interactive elements with their tag-path from `<body>`. */
+  interactives: Array<InteractiveProbe & { tagPath: string }>;
+  /** Visible h1/h2/h3 text (innerText, whitespace-collapsed). */
+  headings: string[];
+  /** Landmark probes — `true` when the landmark is detected on the page. */
+  landmarks: LandmarkFlags;
+}
+
+export interface LandmarkFlags {
+  loginForm?: boolean;
+  paymentFields?: boolean;
+  cartBadge?: boolean;
+  modalOverlay?: boolean;
+  captchaChallenge?: boolean;
+}
+
+const LANDMARK_BIT_ORDER: (keyof LandmarkFlags)[] = [
+  'loginForm',
+  'paymentFields',
+  'cartBadge',
+  'modalOverlay',
+  'captchaChallenge',
+];
+
+export interface StateHashEvidence {
+  url_normalized: string;
+  url_dropped_params: string[];
+  interactive_node_count: number;
+  /** Sorted (tag-path → count) pairs. Stable across visits. */
+  interactive_histogram: Array<[string, number]>;
+  heading_set: string[];
+  landmark_flags: number;
+  /** Bump when the algorithm changes; old hashes can be compared by version. */
+  hash_components_version: 1;
+}
+
+export interface StateHashResult {
+  /** 64-bit hex (16 chars) — derived from SHA-256 truncated to first 64 bits. */
+  hash: string;
+  evidence: StateHashEvidence;
+}
+
+/**
+ * Build the canonical evidence object for a snapshot. Pure; no I/O.
+ */
+function buildEvidence(snapshot: PageSnapshot): StateHashEvidence {
+  const { url: url_normalized, droppedParams } = normalizeUrl(snapshot.url);
+
+  // Histogram of interactive tag-paths (only nodes the predicate accepts).
+  const counts = new Map<string, number>();
+  for (const node of snapshot.interactives) {
+    if (!isInteractiveNode(node)) continue;
+    counts.set(node.tagPath, (counts.get(node.tagPath) ?? 0) + 1);
+  }
+  const histogram = [...counts.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+
+  // Stable heading set: trim, collapse whitespace, drop empty, sort, unique.
+  const headingSet = [
+    ...new Set(
+      snapshot.headings
+        .map((h) => h.replace(/\s+/g, ' ').trim())
+        .filter((h) => h.length > 0),
+    ),
+  ].sort();
+
+  // Bitmap of detected landmarks.
+  let bits = 0;
+  LANDMARK_BIT_ORDER.forEach((flag, i) => {
+    if (snapshot.landmarks[flag]) bits |= 1 << i;
+  });
+
+  return {
+    url_normalized,
+    url_dropped_params: droppedParams,
+    interactive_node_count: snapshot.interactives.filter(isInteractiveNode).length,
+    interactive_histogram: histogram,
+    heading_set: headingSet,
+    landmark_flags: bits,
+    hash_components_version: 1,
+  };
+}
+
+/**
+ * Subset of the evidence that contributes to the hash. Diagnostic-only
+ * fields like `url_dropped_params` are excluded so two snapshots that
+ * differ only in tracking-param presence still hash identically.
+ */
+function hashInput(evidence: StateHashEvidence): Record<string, unknown> {
+  // Pick fields explicitly — easier to audit than picking out the omitted ones.
+  return {
+    url_normalized: evidence.url_normalized,
+    interactive_histogram: evidence.interactive_histogram,
+    heading_set: evidence.heading_set,
+    landmark_flags: evidence.landmark_flags,
+    hash_components_version: evidence.hash_components_version,
+  };
+}
+
+/**
+ * Compute a deterministic 64-bit hex hash from the snapshot. The hash is
+ * the first 16 hex chars of SHA-256(canonicalJSON(hashInput(evidence))).
+ * Truncation is acceptable because the value space (potentially infinite
+ * real-world pages) is far smaller than 2^64; collision risk on a
+ * per-domain graph with thousands of nodes is negligible.
+ *
+ * `url_dropped_params` is intentionally NOT part of the hash — it is
+ * diagnostic only.
+ */
+export function computeStateHash(snapshot: PageSnapshot): StateHashResult {
+  const evidence = buildEvidence(snapshot);
+  const canonical = canonicalJson(hashInput(evidence));
+  const sha = crypto.createHash('sha256').update(canonical).digest('hex');
+  return { hash: sha.slice(0, 16), evidence };
+}
+
+/**
+ * Stable JSON: object keys sorted recursively. Arrays preserve order
+ * because the inputs are already sorted by `buildEvidence`.
+ */
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortKeys(value));
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+      out[k] = sortKeys((value as Record<string, unknown>)[k]);
+    }
+    return out;
+  }
+  return value;
+}

--- a/src/skill/url-normalizer.ts
+++ b/src/skill/url-normalizer.ts
@@ -27,7 +27,12 @@ export const TRACKING_PARAM_PATTERNS: RegExp[] = [
   /^mc_cid$/i,
   /^_ke$/i,
   /^trk$/i,
-  /^source$/i,
+  // Note: `source` was previously here but it is too commonly load-bearing
+  // for application state (e.g. `/feed?source=following` vs
+  // `?source=notifications`) to be safe as a global denylist entry.
+  // Folding those distinct states into one normalised URL would corrupt
+  // skill-graph node identity. Re-add only behind a per-domain rule
+  // (deferred to #702 follow-up if/when needed).
 ];
 
 export interface NormalizeUrlResult {

--- a/src/skill/url-normalizer.ts
+++ b/src/skill/url-normalizer.ts
@@ -38,16 +38,16 @@ export interface NormalizeUrlResult {
 }
 
 /**
- * Stable sentinel returned for inputs that do not parse as a URL. Chosen
- * because:
- *   • `about:invalid` is a real RFC-defined "always-invalid" address, so
- *     downstream code that treats the value as a URL won't be surprised by
- *     a host or query string.
- *   • The fragment marks it as the recorder's sentinel so operators can
- *     filter it out of skill-graph snapshots.
+ * Stable sentinel returned for inputs that do not parse as a URL. We use
+ * the bare `about:invalid` (RFC 6694) so re-normalising the sentinel is
+ * idempotent: `normalizeUrl()` always clears `u.hash`, so a sentinel that
+ * carried a fragment would round-trip to a different value than its
+ * first emission, leaking non-determinism into the state hash. The bare
+ * form has no host, query, or fragment, so all normalization steps are
+ * no-ops and `normalizeUrl(INVALID_URL_SENTINEL).url === INVALID_URL_SENTINEL`.
  * Callers must not depend on the exact string except for equality checks.
  */
-export const INVALID_URL_SENTINEL = 'about:invalid#openchrome-normalize';
+export const INVALID_URL_SENTINEL = 'about:invalid';
 
 /**
  * Normalize a URL string for hashing/equality:

--- a/src/skill/url-normalizer.ts
+++ b/src/skill/url-normalizer.ts
@@ -43,6 +43,15 @@ export interface NormalizeUrlResult {
 }
 
 /**
+ * Recognise the SPA hash-router shapes (`#/<path>`, `#!/<path>`).
+ * Anything else (`#section`, `#`, empty) is treated as a scroll
+ * anchor and stripped during normalisation.
+ */
+function isHashRoute(hash: string): boolean {
+  return hash.startsWith('#/') || hash.startsWith('#!/');
+}
+
+/**
  * Stable sentinel returned for inputs that do not parse as a URL. We use
  * the bare `about:invalid` (RFC 6694) so re-normalising the sentinel is
  * idempotent: `normalizeUrl()` always clears `u.hash`, so a sentinel that
@@ -76,7 +85,15 @@ export function normalizeUrl(input: string): NormalizeUrlResult {
   }
   // Lowercase host only (preserve path case)
   u.hostname = u.hostname.toLowerCase();
-  u.hash = '';
+  // SPA hash routers encode state in the fragment (`/#/cart` vs
+  // `/#/checkout`). Stripping every fragment would merge those
+  // distinct states into the same normalised URL and corrupt
+  // skill-graph node identity on hash-routed sites. We keep hashes
+  // that look like routes (`#/...`, `#!/...`) and drop pure scroll
+  // anchors (`#section`) that don't change page state.
+  if (!isHashRoute(u.hash)) {
+    u.hash = '';
+  }
 
   const dropped: string[] = [];
   const kept: [string, string][] = [];

--- a/src/skill/url-normalizer.ts
+++ b/src/skill/url-normalizer.ts
@@ -38,16 +38,37 @@ export interface NormalizeUrlResult {
 }
 
 /**
+ * Stable sentinel returned for inputs that do not parse as a URL. Chosen
+ * because:
+ *   • `about:invalid` is a real RFC-defined "always-invalid" address, so
+ *     downstream code that treats the value as a URL won't be surprised by
+ *     a host or query string.
+ *   • The fragment marks it as the recorder's sentinel so operators can
+ *     filter it out of skill-graph snapshots.
+ * Callers must not depend on the exact string except for equality checks.
+ */
+export const INVALID_URL_SENTINEL = 'about:invalid#openchrome-normalize';
+
+/**
  * Normalize a URL string for hashing/equality:
  * - lowercase the host (paths are case-sensitive on most servers; we leave them alone)
  * - drop hash fragment
  * - drop tracking params matching `TRACKING_PARAM_PATTERNS`
  * - stable-sort remaining query keys
  *
- * Throws if the input does not parse as a URL — callers should pre-validate.
+ * Total function: when the input does not parse as a URL (empty string,
+ * relative path, junk text), returns `{ url: INVALID_URL_SENTINEL,
+ * droppedParams: [] }` instead of throwing. This keeps `computeStateHash`
+ * deterministic even when instrumentation emits incomplete URLs, e.g.
+ * after a failed navigation.
  */
 export function normalizeUrl(input: string): NormalizeUrlResult {
-  const u = new URL(input);
+  let u: URL;
+  try {
+    u = new URL(input);
+  } catch {
+    return { url: INVALID_URL_SENTINEL, droppedParams: [] };
+  }
   // Lowercase host only (preserve path case)
   u.hostname = u.hostname.toLowerCase();
   u.hash = '';

--- a/src/skill/url-normalizer.ts
+++ b/src/skill/url-normalizer.ts
@@ -1,0 +1,78 @@
+/**
+ * URL normalization for state-hash inputs and skill-graph keys.
+ *
+ * Two pages with the same logical state should produce the same normalized
+ * URL. We strip tracking params (utm_*, fbclid, …) and stable-sort the
+ * remaining query keys; host is lowercased; hash fragment is dropped
+ * because it never affects server-rendered state.
+ *
+ * The denylist is conservative — only well-known tracking params. Site-
+ * specific params that look like tracking but actually carry state (Amazon
+ * `pd_rd_*` is debatable but commonly noise) get a regex match. Add new
+ * patterns here as we learn from real fixtures (#702 v2 capture procedure).
+ */
+
+export const TRACKING_PARAM_PATTERNS: RegExp[] = [
+  /^utm_/i,
+  /^fbclid$/i,
+  /^gclid$/i,
+  /^msclkid$/i,
+  /^ref$/i,
+  /^tag$/i,
+  /^pd_rd_/i,
+  /^_encoding$/i,
+  /^psc$/i,
+  /^_branch_match_id$/i,
+  /^mc_eid$/i,
+  /^mc_cid$/i,
+  /^_ke$/i,
+  /^trk$/i,
+  /^source$/i,
+];
+
+export interface NormalizeUrlResult {
+  /** The normalized URL string. */
+  url: string;
+  /** Tracking params that were stripped (sorted by name, useful for evidence). */
+  droppedParams: string[];
+}
+
+/**
+ * Normalize a URL string for hashing/equality:
+ * - lowercase the host (paths are case-sensitive on most servers; we leave them alone)
+ * - drop hash fragment
+ * - drop tracking params matching `TRACKING_PARAM_PATTERNS`
+ * - stable-sort remaining query keys
+ *
+ * Throws if the input does not parse as a URL — callers should pre-validate.
+ */
+export function normalizeUrl(input: string): NormalizeUrlResult {
+  const u = new URL(input);
+  // Lowercase host only (preserve path case)
+  u.hostname = u.hostname.toLowerCase();
+  u.hash = '';
+
+  const dropped: string[] = [];
+  const kept: [string, string][] = [];
+  for (const [k, v] of u.searchParams.entries()) {
+    if (TRACKING_PARAM_PATTERNS.some((re) => re.test(k))) {
+      dropped.push(k);
+    } else {
+      kept.push([k, v]);
+    }
+  }
+
+  // Stable-sort by key, then value, so the same logical params produce the
+  // same string regardless of authoring order.
+  kept.sort(([ak, av], [bk, bv]) => {
+    if (ak !== bk) return ak < bk ? -1 : 1;
+    return av < bv ? -1 : av > bv ? 1 : 0;
+  });
+
+  // Rebuild search string deterministically.
+  const search = new URLSearchParams();
+  for (const [k, v] of kept) search.append(k, v);
+  u.search = search.toString();
+
+  return { url: u.toString(), droppedParams: dropped.sort() };
+}

--- a/tests/skill/interactive-filter.test.ts
+++ b/tests/skill/interactive-filter.test.ts
@@ -79,6 +79,16 @@ describe('isInteractiveNode — ARIA roles on non-native tags', () => {
   test('all tokens unknown → role chain is treated as non-interactive', () => {
     expect(isInteractiveNode({ tagName: 'div', role: 'totallymade up' })).toBe(false);
   });
+
+  test('first-token precedence respects the full ARIA role universe', () => {
+    // `img` is a valid ARIA non-interactive role. The fallback chain
+    // `"img button"` must resolve to `img` (non-interactive) — earlier
+    // code with a narrow non-interactive set treated `img` as unknown
+    // and let the trailing `button` token wrongly win.
+    expect(isInteractiveNode({ tagName: 'div', role: 'img button' })).toBe(false);
+    expect(isInteractiveNode({ tagName: 'span', role: 'figure link' })).toBe(false);
+    expect(isInteractiveNode({ tagName: 'span', role: 'paragraph button' })).toBe(false);
+  });
 });
 
 describe('isInteractiveNode — focus/edit affordances', () => {

--- a/tests/skill/interactive-filter.test.ts
+++ b/tests/skill/interactive-filter.test.ts
@@ -1,0 +1,76 @@
+import { isInteractiveNode } from '../../src/skill/interactive-filter';
+
+describe('isInteractiveNode — native interactive tags', () => {
+  test('button is interactive', () => {
+    expect(isInteractiveNode({ tagName: 'BUTTON' })).toBe(true);
+  });
+
+  test('input/select/textarea are interactive', () => {
+    expect(isInteractiveNode({ tagName: 'input' })).toBe(true);
+    expect(isInteractiveNode({ tagName: 'select' })).toBe(true);
+    expect(isInteractiveNode({ tagName: 'textarea' })).toBe(true);
+  });
+
+  test('span without role is not interactive', () => {
+    expect(isInteractiveNode({ tagName: 'span' })).toBe(false);
+  });
+});
+
+describe('isInteractiveNode — anchor handling', () => {
+  test('<a href> is interactive', () => {
+    expect(isInteractiveNode({ tagName: 'a', hasHref: true })).toBe(true);
+  });
+
+  test('<a> name-anchor (no href, no role) is not interactive', () => {
+    expect(isInteractiveNode({ tagName: 'a', hasHref: false })).toBe(false);
+  });
+
+  test('<a role="button"> without href IS interactive (role fallthrough)', () => {
+    // Common SPA pattern: anchor used as a button via ARIA. Earlier code
+    // short-circuited on `tag === 'a'` and never consulted role/tabindex,
+    // dropping these from the interactive set.
+    expect(
+      isInteractiveNode({ tagName: 'a', hasHref: false, role: 'button' }),
+    ).toBe(true);
+  });
+
+  test('<a tabindex="0"> without href IS interactive (focus fallthrough)', () => {
+    expect(
+      isInteractiveNode({ tagName: 'a', hasHref: false, tabIndex: 0 }),
+    ).toBe(true);
+  });
+
+  test('<a contenteditable> without href IS interactive', () => {
+    expect(
+      isInteractiveNode({ tagName: 'a', hasHref: false, contentEditable: true }),
+    ).toBe(true);
+  });
+});
+
+describe('isInteractiveNode — ARIA roles on non-native tags', () => {
+  test('<div role="button"> is interactive', () => {
+    expect(isInteractiveNode({ tagName: 'div', role: 'button' })).toBe(true);
+  });
+
+  test('<div role="heading"> is NOT interactive', () => {
+    expect(isInteractiveNode({ tagName: 'div', role: 'heading' })).toBe(false);
+  });
+
+  test('uppercased role is matched (case-insensitive)', () => {
+    expect(isInteractiveNode({ tagName: 'div', role: 'BUTTON' })).toBe(true);
+  });
+});
+
+describe('isInteractiveNode — focus/edit affordances', () => {
+  test('tabindex=0 makes any element interactive', () => {
+    expect(isInteractiveNode({ tagName: 'div', tabIndex: 0 })).toBe(true);
+  });
+
+  test('tabindex=-1 alone is not interactive', () => {
+    expect(isInteractiveNode({ tagName: 'div', tabIndex: -1 })).toBe(false);
+  });
+
+  test('contentEditable is interactive', () => {
+    expect(isInteractiveNode({ tagName: 'div', contentEditable: true })).toBe(true);
+  });
+});

--- a/tests/skill/interactive-filter.test.ts
+++ b/tests/skill/interactive-filter.test.ts
@@ -60,18 +60,24 @@ describe('isInteractiveNode — ARIA roles on non-native tags', () => {
     expect(isInteractiveNode({ tagName: 'div', role: 'BUTTON' })).toBe(true);
   });
 
-  test('multi-token role: any interactive token in the fallback chain promotes the node', () => {
-    // ARIA permits a space-separated fallback chain; the user agent
-    // honours the first valid token. Earlier code compared the whole
-    // string against the role set and missed `<div role="switch checkbox">`,
-    // dropping these nodes from the histogram.
+  test('multi-token role: first recognised token wins (ARIA 1.2 precedence)', () => {
+    // ARIA fallback chain semantics: user agent resolves to the first
+    // recognised token. `switch` is a known interactive role → interactive.
     expect(isInteractiveNode({ tagName: 'div', role: 'switch checkbox' })).toBe(true);
+    // First token unknown → fall through to next.
     expect(isInteractiveNode({ tagName: 'div', role: 'unknown button' })).toBe(true);
-    expect(isInteractiveNode({ tagName: 'div', role: 'heading button' })).toBe(true);
+    // First token is a recognised non-interactive role → element is
+    // resolved as `heading`, NOT promoted by the trailing `button`.
+    // This was a false positive in the earlier "any-token" check.
+    expect(isInteractiveNode({ tagName: 'div', role: 'heading button' })).toBe(false);
   });
 
   test('multi-token role with no interactive tokens stays non-interactive', () => {
     expect(isInteractiveNode({ tagName: 'div', role: 'heading note' })).toBe(false);
+  });
+
+  test('all tokens unknown → role chain is treated as non-interactive', () => {
+    expect(isInteractiveNode({ tagName: 'div', role: 'totallymade up' })).toBe(false);
   });
 });
 

--- a/tests/skill/interactive-filter.test.ts
+++ b/tests/skill/interactive-filter.test.ts
@@ -16,6 +16,26 @@ describe('isInteractiveNode — native interactive tags', () => {
   });
 });
 
+describe('isInteractiveNode — media elements', () => {
+  test('video without `controls` is NOT interactive', () => {
+    // Decorative / auto-playing backgrounds should not inflate the
+    // interactive histogram and skew the state hash.
+    expect(isInteractiveNode({ tagName: 'video' })).toBe(false);
+    expect(isInteractiveNode({ tagName: 'audio' })).toBe(false);
+  });
+
+  test('video/audio with `controls` IS interactive', () => {
+    expect(isInteractiveNode({ tagName: 'video', hasControls: true })).toBe(true);
+    expect(isInteractiveNode({ tagName: 'audio', hasControls: true })).toBe(true);
+  });
+
+  test('video without controls but with role=button IS interactive (fall-through)', () => {
+    expect(
+      isInteractiveNode({ tagName: 'video', hasControls: false, role: 'button' }),
+    ).toBe(true);
+  });
+});
+
 describe('isInteractiveNode — anchor handling', () => {
   test('<a href> is interactive', () => {
     expect(isInteractiveNode({ tagName: 'a', hasHref: true })).toBe(true);

--- a/tests/skill/interactive-filter.test.ts
+++ b/tests/skill/interactive-filter.test.ts
@@ -59,6 +59,20 @@ describe('isInteractiveNode — ARIA roles on non-native tags', () => {
   test('uppercased role is matched (case-insensitive)', () => {
     expect(isInteractiveNode({ tagName: 'div', role: 'BUTTON' })).toBe(true);
   });
+
+  test('multi-token role: any interactive token in the fallback chain promotes the node', () => {
+    // ARIA permits a space-separated fallback chain; the user agent
+    // honours the first valid token. Earlier code compared the whole
+    // string against the role set and missed `<div role="switch checkbox">`,
+    // dropping these nodes from the histogram.
+    expect(isInteractiveNode({ tagName: 'div', role: 'switch checkbox' })).toBe(true);
+    expect(isInteractiveNode({ tagName: 'div', role: 'unknown button' })).toBe(true);
+    expect(isInteractiveNode({ tagName: 'div', role: 'heading button' })).toBe(true);
+  });
+
+  test('multi-token role with no interactive tokens stays non-interactive', () => {
+    expect(isInteractiveNode({ tagName: 'div', role: 'heading note' })).toBe(false);
+  });
 });
 
 describe('isInteractiveNode — focus/edit affordances', () => {

--- a/tests/skill/state.test.ts
+++ b/tests/skill/state.test.ts
@@ -1,0 +1,144 @@
+import {
+  computeStateHash,
+  canonicalJson,
+  type PageSnapshot,
+} from '../../src/skill/state';
+
+function snap(over: Partial<PageSnapshot> = {}): PageSnapshot {
+  return {
+    url: 'https://amazon.com/cart',
+    interactives: [
+      { tagName: 'button', tagPath: 'body>div>button', role: 'button' },
+      { tagName: 'a', tagPath: 'body>nav>a', hasHref: true },
+      { tagName: 'input', tagPath: 'body>form>input' },
+    ],
+    headings: ['Your Shopping Cart'],
+    landmarks: { cartBadge: true },
+    ...over,
+  };
+}
+
+describe('computeStateHash — determinism', () => {
+  test('identical snapshots produce identical hashes', () => {
+    const a = computeStateHash(snap());
+    const b = computeStateHash(snap());
+    expect(a.hash).toBe(b.hash);
+  });
+
+  test('hash is 16 hex chars (64-bit truncated SHA-256)', () => {
+    const r = computeStateHash(snap());
+    expect(r.hash).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test('reordering interactive elements does not change the hash', () => {
+    const a = computeStateHash(
+      snap({
+        interactives: [
+          { tagName: 'a', tagPath: 'body>nav>a', hasHref: true },
+          { tagName: 'button', tagPath: 'body>div>button', role: 'button' },
+        ],
+      }),
+    );
+    const b = computeStateHash(
+      snap({
+        interactives: [
+          { tagName: 'button', tagPath: 'body>div>button', role: 'button' },
+          { tagName: 'a', tagPath: 'body>nav>a', hasHref: true },
+        ],
+      }),
+    );
+    expect(a.hash).toBe(b.hash);
+  });
+
+  test('reordering headings does not change the hash', () => {
+    const a = computeStateHash(snap({ headings: ['One', 'Two'] }));
+    const b = computeStateHash(snap({ headings: ['Two', 'One'] }));
+    expect(a.hash).toBe(b.hash);
+  });
+
+  test('utm_ params do not affect the hash (URL normalization)', () => {
+    const a = computeStateHash(snap({ url: 'https://amazon.com/cart' }));
+    const b = computeStateHash(snap({ url: 'https://amazon.com/cart?utm_source=email' }));
+    expect(a.hash).toBe(b.hash);
+  });
+});
+
+describe('computeStateHash — sensitivity', () => {
+  test('logged-in vs logged-out (loginForm landmark) produce different hashes', () => {
+    const out = computeStateHash(snap({ landmarks: { loginForm: true } }));
+    const inn = computeStateHash(snap({ landmarks: {} }));
+    expect(out.hash).not.toBe(inn.hash);
+  });
+
+  test('empty cart vs has-item (cartBadge landmark) differ', () => {
+    const empty = computeStateHash(snap({ landmarks: {} }));
+    const has = computeStateHash(snap({ landmarks: { cartBadge: true } }));
+    expect(empty.hash).not.toBe(has.hash);
+  });
+
+  test('different URL paths produce different hashes', () => {
+    const a = computeStateHash(snap({ url: 'https://amazon.com/cart' }));
+    const b = computeStateHash(snap({ url: 'https://amazon.com/checkout' }));
+    expect(a.hash).not.toBe(b.hash);
+  });
+
+  test('captcha challenge bit flips the hash', () => {
+    const a = computeStateHash(snap({ landmarks: { cartBadge: true } }));
+    const b = computeStateHash(snap({ landmarks: { cartBadge: true, captchaChallenge: true } }));
+    expect(a.hash).not.toBe(b.hash);
+  });
+});
+
+describe('computeStateHash — evidence object', () => {
+  test('evidence carries normalized URL and dropped params', () => {
+    const r = computeStateHash(snap({ url: 'https://amazon.com/cart?utm_source=x&q=1' }));
+    expect(r.evidence.url_normalized).toBe('https://amazon.com/cart?q=1');
+    expect(r.evidence.url_dropped_params).toEqual(['utm_source']);
+  });
+
+  test('evidence interactive_histogram is sorted by tag-path', () => {
+    const r = computeStateHash(snap());
+    const paths = r.evidence.interactive_histogram.map(([p]) => p);
+    expect(paths).toEqual([...paths].sort());
+  });
+
+  test('evidence heading_set is unique + sorted', () => {
+    const r = computeStateHash(snap({ headings: ['B', 'A', 'B', '  '] }));
+    expect(r.evidence.heading_set).toEqual(['A', 'B']);
+  });
+
+  test('evidence landmark_flags is a 5-bit bitmap', () => {
+    const r = computeStateHash(
+      snap({ landmarks: { loginForm: true, captchaChallenge: true } }),
+    );
+    // Bit order: loginForm=0, paymentFields=1, cartBadge=2, modalOverlay=3, captcha=4
+    expect(r.evidence.landmark_flags).toBe(0b10001);
+  });
+
+  test('hash_components_version is set to 1', () => {
+    expect(computeStateHash(snap()).evidence.hash_components_version).toBe(1);
+  });
+
+  test('non-interactive elements (e.g. role=heading) do not contribute', () => {
+    const r = computeStateHash(
+      snap({
+        interactives: [
+          { tagName: 'div', tagPath: 'body>div', role: 'heading' },
+          { tagName: 'a', tagPath: 'body>a', hasHref: true },
+        ],
+      }),
+    );
+    expect(r.evidence.interactive_node_count).toBe(1);
+  });
+});
+
+describe('canonicalJson — key sorting', () => {
+  test('sorts object keys recursively', () => {
+    const out = canonicalJson({ b: 2, a: { z: 1, y: 2 } });
+    expect(out).toBe('{"a":{"y":2,"z":1},"b":2}');
+  });
+
+  test('preserves array order', () => {
+    expect(canonicalJson([3, 1, 2])).toBe('[3,1,2]');
+  });
+});

--- a/tests/skill/url-normalizer.test.ts
+++ b/tests/skill/url-normalizer.test.ts
@@ -5,8 +5,24 @@ describe('normalizeUrl — host and fragment', () => {
     expect(normalizeUrl('https://EXAMPLE.com/path').url).toBe('https://example.com/path');
   });
 
-  test('drops hash fragment', () => {
+  test('drops scroll-anchor fragments', () => {
+    // `#section` is a pure scroll anchor — same DOM, same state.
     expect(normalizeUrl('https://x.com/p#section').url).toBe('https://x.com/p');
+    expect(normalizeUrl('https://x.com/p#').url).toBe('https://x.com/p');
+  });
+
+  test('preserves hash-router routes (SPA state lives in the fragment)', () => {
+    // `/#/cart` and `/#/checkout` represent distinct application
+    // states; stripping the fragment would merge them in the state
+    // hash and corrupt skill-graph node identity.
+    expect(normalizeUrl('https://x.com/#/cart').url).toBe('https://x.com/#/cart');
+    expect(normalizeUrl('https://x.com/#/checkout').url).toBe('https://x.com/#/checkout');
+    // Angular legacy `#!/...` shape too.
+    expect(normalizeUrl('https://x.com/#!/orders').url).toBe('https://x.com/#!/orders');
+    // Two routes hash to different normalised URLs.
+    const a = normalizeUrl('https://x.com/#/cart').url;
+    const b = normalizeUrl('https://x.com/#/checkout').url;
+    expect(a).not.toBe(b);
   });
 
   test('preserves path case (paths are case-sensitive)', () => {

--- a/tests/skill/url-normalizer.test.ts
+++ b/tests/skill/url-normalizer.test.ts
@@ -1,0 +1,65 @@
+import { normalizeUrl, TRACKING_PARAM_PATTERNS } from '../../src/skill/url-normalizer';
+
+describe('normalizeUrl — host and fragment', () => {
+  test('lowercases hostname', () => {
+    expect(normalizeUrl('https://EXAMPLE.com/path').url).toBe('https://example.com/path');
+  });
+
+  test('drops hash fragment', () => {
+    expect(normalizeUrl('https://x.com/p#section').url).toBe('https://x.com/p');
+  });
+
+  test('preserves path case (paths are case-sensitive)', () => {
+    expect(normalizeUrl('https://x.com/MyPath').url).toBe('https://x.com/MyPath');
+  });
+});
+
+describe('normalizeUrl — tracking params', () => {
+  test('strips utm_* params', () => {
+    const r = normalizeUrl('https://x.com/?utm_source=a&utm_medium=b&q=hello');
+    expect(r.url).toBe('https://x.com/?q=hello');
+    expect(r.droppedParams).toEqual(['utm_medium', 'utm_source']);
+  });
+
+  test('strips known single-name params (fbclid, gclid, msclkid)', () => {
+    expect(normalizeUrl('https://x/?fbclid=abc').url).toBe('https://x/');
+    expect(normalizeUrl('https://x/?gclid=abc').url).toBe('https://x/');
+    expect(normalizeUrl('https://x/?msclkid=abc').url).toBe('https://x/');
+  });
+
+  test('strips Amazon pd_rd_* family', () => {
+    const r = normalizeUrl('https://amazon.com/?pd_rd_w=abc&pd_rd_r=xyz&node=42');
+    expect(r.url).toBe('https://amazon.com/?node=42');
+    expect(r.droppedParams).toEqual(['pd_rd_r', 'pd_rd_w']);
+  });
+
+  test('TRACKING_PARAM_PATTERNS is the source of truth (visible to consumers)', () => {
+    expect(TRACKING_PARAM_PATTERNS.length).toBeGreaterThan(5);
+    expect(TRACKING_PARAM_PATTERNS.some((re) => re.test('utm_source'))).toBe(true);
+  });
+});
+
+describe('normalizeUrl — query stability', () => {
+  test('sorts query keys alphabetically', () => {
+    const a = normalizeUrl('https://x/?b=1&a=2&c=3').url;
+    const b = normalizeUrl('https://x/?c=3&a=2&b=1').url;
+    expect(a).toBe(b);
+    expect(a).toBe('https://x/?a=2&b=1&c=3');
+  });
+
+  test('sorts equal keys by value (deterministic)', () => {
+    const r = normalizeUrl('https://x/?a=2&a=1').url;
+    expect(r).toBe('https://x/?a=1&a=2');
+  });
+
+  test('returns sorted droppedParams for evidence stability', () => {
+    const r = normalizeUrl('https://x/?utm_term=a&utm_medium=b&utm_source=c');
+    expect(r.droppedParams).toEqual(['utm_medium', 'utm_source', 'utm_term']);
+  });
+});
+
+describe('normalizeUrl — invalid input', () => {
+  test('throws on non-URL input', () => {
+    expect(() => normalizeUrl('not a url')).toThrow();
+  });
+});

--- a/tests/skill/url-normalizer.test.ts
+++ b/tests/skill/url-normalizer.test.ts
@@ -1,4 +1,4 @@
-import { normalizeUrl, TRACKING_PARAM_PATTERNS } from '../../src/skill/url-normalizer';
+import { INVALID_URL_SENTINEL, normalizeUrl, TRACKING_PARAM_PATTERNS } from '../../src/skill/url-normalizer';
 
 describe('normalizeUrl — host and fragment', () => {
   test('lowercases hostname', () => {
@@ -58,8 +58,21 @@ describe('normalizeUrl — query stability', () => {
   });
 });
 
-describe('normalizeUrl — invalid input', () => {
-  test('throws on non-URL input', () => {
-    expect(() => normalizeUrl('not a url')).toThrow();
+describe('normalizeUrl — invalid input (total function, no throw)', () => {
+  test('non-URL string returns the stable sentinel', () => {
+    const r = normalizeUrl('not a url');
+    expect(r.url).toBe(INVALID_URL_SENTINEL);
+    expect(r.droppedParams).toEqual([]);
+  });
+
+  test('empty string returns the stable sentinel', () => {
+    const r = normalizeUrl('');
+    expect(r.url).toBe(INVALID_URL_SENTINEL);
+  });
+
+  test('two malformed URLs hash identically (deterministic fallback)', () => {
+    const a = normalizeUrl('not a url');
+    const b = normalizeUrl('also not a url');
+    expect(a.url).toBe(b.url);
   });
 });

--- a/tests/skill/url-normalizer.test.ts
+++ b/tests/skill/url-normalizer.test.ts
@@ -56,6 +56,17 @@ describe('normalizeUrl — query stability', () => {
     const r = normalizeUrl('https://x/?utm_term=a&utm_medium=b&utm_source=c');
     expect(r.droppedParams).toEqual(['utm_medium', 'utm_source', 'utm_term']);
   });
+
+  test('bare `source` is NOT a tracking param (load-bearing for app state)', () => {
+    // `/feed?source=following` vs `/feed?source=notifications` represent
+    // different application state; collapsing them would corrupt
+    // skill-graph node identity. This test guards against re-adding the
+    // pattern as a global denylist entry.
+    const a = normalizeUrl('https://x.com/feed?source=following');
+    const b = normalizeUrl('https://x.com/feed?source=notifications');
+    expect(a.url).not.toBe(b.url);
+    expect(a.droppedParams).toEqual([]);
+  });
 });
 
 describe('normalizeUrl — invalid input (total function, no throw)', () => {

--- a/tests/skill/url-normalizer.test.ts
+++ b/tests/skill/url-normalizer.test.ts
@@ -75,4 +75,15 @@ describe('normalizeUrl — invalid input (total function, no throw)', () => {
     const b = normalizeUrl('also not a url');
     expect(a.url).toBe(b.url);
   });
+
+  test('sentinel is idempotent under re-normalization', () => {
+    // If an upstream stage already emitted the sentinel, normalising it
+    // again must produce the same string. A fragment-bearing sentinel
+    // would round-trip to a different value because `u.hash = ''` clears
+    // it, leaking non-determinism into the state hash.
+    const once = normalizeUrl('not a url');
+    const twice = normalizeUrl(once.url);
+    expect(twice.url).toBe(once.url);
+    expect(twice.url).toBe(INVALID_URL_SENTINEL);
+  });
 });


### PR DESCRIPTION
## Summary

Foundation for the skill graph (#702). **No SQLite or graph executor yet** — those land in PR-5 and PR-6 to keep this slice focused on pure functions.

- `src/skill/url-normalizer.ts` — `TRACKING_PARAM_PATTERNS` denylist (`utm_*`, `fbclid`, `gclid`, `msclkid`, `ref`, `tag`, `pd_rd_*`, `_encoding`, `psc`, …) plus `normalizeUrl()` that lowercases host, drops hash, strips tracking params, stable-sorts query keys
- `src/skill/interactive-filter.ts` — shared `isInteractiveNode()` predicate. **Owned here per #702 v2 cross-issue dependency note** (#709 perceptual metadata will import from this file)
- `src/skill/state.ts` — `computeStateHash(snapshot) → { hash (16 hex), evidence }`. Hash inputs: normalized URL + interactive tag-path histogram + sorted heading set + landmark bitmap. SHA-256 truncated to 64 bits. `evidence.url_dropped_params` is diagnostic only and explicitly excluded from the hash so dropping more params later doesn't invalidate prior hashes
- `src/skill/index.ts` — barrel export
- `tests/skill/url-normalizer.test.ts` + `tests/skill/state.test.ts` — coverage on tracking-param patterns, ordering stability, hash determinism, hash sensitivity to interactive-element changes vs noise

## Why interactive-filter lives in `src/skill/` (not `src/dom/`)

#702 v2 calls out that #709 (perceptual DOM metadata) needs to use the same predicate. Putting it under `src/skill/` is a deliberate choice: skill state is the primary consumer, and #709's import path is a one-line dependency declaration rather than a circular `src/dom/ ↔ src/skill/` coupling.

## Why hash is truncated SHA-256, not BLAKE2

64-bit hex output stays operator-readable in CLI tables (#703 `oc skill inspect`). Collision probability across the projected per-domain node count (1k-10k) is negligible at 64 bits, and we never use the hash for security — only equality.

## Validation

- `npm run build` clean
- `npm test -- tests/skill` — all green
- No coupling to recorder, storage, or CDP — pure functions over already-extracted DOM snapshots

## Test plan

- [ ] Reviewer pulls branch, runs `npm install && npm run build && npm test -- tests/skill`
- [ ] Reviewer confirms `evidence.url_dropped_params` is NOT included in the hash input (state.ts)
- [ ] Reviewer confirms `normalizeUrl()` is total (does not throw on malformed URLs — falls back to a stable error sentinel)
- [ ] Reviewer reads `interactive-filter.test.ts` and confirms the predicate matches what `#709` will need (role=button|link|tab|menuitem|checkbox|radio + native interactive tags)

Refs: #698 (epic), #702 (sub-issue). Stacked on #736.

🤖 Split from `feat/m1-pr1-trace-foundation`. Original commit: `e99df63`.
