### PR TITLE
feat(skill): graph-aware executor with resume-from-state (M1 PR-6)

### DIFF
--- a/src/skill/executor.ts
+++ b/src/skill/executor.ts
@@ -1,0 +1,268 @@
+/**
+ * Graph-aware skill executor.
+ *
+ * Replaces the old "always-restart" pattern with state-aware resume:
+ *   1. Snapshot the page → compute the current state hash (#702).
+ *   2. Look up the node in the per-domain skill graph (#702 storage).
+ *   3. Pick the highest-success-rate outgoing edge that matches `intent`.
+ *   4. Execute the action via the tool-router adapter (existing src/tools/*).
+ *   5. Re-snapshot, compute new hash, validate against the edge's
+ *      `to_state_distribution` per #703 v2 rules.
+ *   6. Record the outcome (success/fail, observed to_state).
+ *   7. If no edge matches in step 3, fall back to the existing waterfall
+ *      and *promote* the observed transition into the graph as a new edge.
+ *
+ * The router is injected so tests can mock it (the real adapter wiring
+ * to `src/tools/` lives in PR-7).
+ */
+
+import { computeStateHash, type PageSnapshot } from './state';
+import {
+  SkillGraphStorage,
+  type SkillEdge,
+  type ToStateDistribution,
+} from './storage';
+
+/** A single action the router can execute. */
+export interface ActionInvocation {
+  /** Action kind: `click`, `type`, `navigate`, etc. */
+  kind: string;
+  /** Canonical args representation used for graph identity. */
+  argsNorm: string;
+  /** Raw args passed to the underlying tool. */
+  args: unknown;
+}
+
+export interface ActionResult {
+  ok: boolean;
+  /** Optional reason for failure — surfaced in audit + telemetry. */
+  reason?: string;
+}
+
+/**
+ * Context the executor needs from its host. Hosts (PR-7's MCP layer)
+ * supply real puppeteer-driven snapshotters; tests supply fakes.
+ */
+export interface ExecutionContext {
+  /** Capture the current page state. Called before and after each action. */
+  snapshotPageState(): Promise<PageSnapshot>;
+}
+
+/** Tool dispatcher abstraction — adapter to existing src/tools/* in PR-7. */
+export interface ToolRouter {
+  /**
+   * Pick a best action for the current snapshot + intent, without using
+   * the graph. Used as the fallback path when the graph has no edge.
+   */
+  pickFallbackAction(snapshot: PageSnapshot, intent: SkillIntent): Promise<ActionInvocation | null>;
+  /** Execute the action; returns ok/fail. */
+  runAction(action: ActionInvocation): Promise<ActionResult>;
+}
+
+export interface SkillIntent {
+  /** Human-readable description (logging only). */
+  description?: string;
+  /** Restrict edge selection to these action kinds. */
+  allowedKinds?: string[];
+}
+
+export type RunOutcomeKind =
+  | 'graph_hit'
+  | 'graph_miss'
+  | 'graph_fallback_promoted';
+
+export interface RunSkillResult {
+  outcome: RunOutcomeKind;
+  fromState: string;
+  toState?: string;
+  /** The action invocation that was executed (if any). */
+  action?: ActionInvocation;
+  ok: boolean;
+  /** Failure reason or "expected_state_mismatch" / "no_action_available". */
+  reason?: string;
+  /** True when the new hash matched the edge's expected distribution. */
+  matchedExpected?: boolean;
+}
+
+export interface RunSkillArgs {
+  storage: SkillGraphStorage;
+  router: ToolRouter;
+  ctx: ExecutionContext;
+  intent: SkillIntent;
+}
+
+/** Threshold per #703 v2: 10% of total invocations. */
+const DISTRIBUTION_MATCH_THRESHOLD = 0.1;
+/** Below this total invocation count, fall back to the looser rule. */
+const SMALL_SAMPLE_TOTAL = 10;
+
+/**
+ * One pass of skill execution. Hosts call this in a loop (or once per
+ * intent step, depending on skill granularity).
+ */
+export async function runSkill(args: RunSkillArgs): Promise<RunSkillResult> {
+  const { storage, router, ctx, intent } = args;
+
+  const before = await ctx.snapshotPageState();
+  const fromHash = computeStateHash(before).hash;
+  storage.upsertNode({
+    stateHash: fromHash,
+    evidence: computeStateHash(before).evidence,
+  });
+
+  const candidate = pickBestEdge(storage.edgesFrom(fromHash), intent);
+
+  // Path A — graph hit
+  if (candidate) {
+    const action: ActionInvocation = {
+      kind: candidate.actionKind,
+      argsNorm: candidate.actionArgsNorm,
+      args: parseArgs(candidate.actionArgsNorm),
+    };
+    const result = await router.runAction(action);
+    const after = await ctx.snapshotPageState();
+    const toHash = computeStateHash(after).hash;
+    storage.upsertNode({
+      stateHash: toHash,
+      evidence: computeStateHash(after).evidence,
+    });
+    const matched = result.ok && matchesExpected(toHash, candidate);
+    storage.recordOutcome({
+      fromState: fromHash,
+      actionKind: action.kind,
+      actionArgsNorm: action.argsNorm,
+      observedToState: toHash,
+      success: matched,
+    });
+    return {
+      outcome: 'graph_hit',
+      fromState: fromHash,
+      toState: toHash,
+      action,
+      ok: matched,
+      matchedExpected: matched,
+      reason: result.ok && !matched ? 'expected_state_mismatch' : result.reason,
+    };
+  }
+
+  // Path B — graph miss → fallback
+  const fallback = await router.pickFallbackAction(before, intent);
+  if (!fallback) {
+    return {
+      outcome: 'graph_miss',
+      fromState: fromHash,
+      ok: false,
+      reason: 'no_action_available',
+    };
+  }
+  const fallbackResult = await router.runAction(fallback);
+  const after = await ctx.snapshotPageState();
+  const toHash = computeStateHash(after).hash;
+  storage.upsertNode({
+    stateHash: toHash,
+    evidence: computeStateHash(after).evidence,
+  });
+
+  // Promote the observed transition to the graph (only on success — failed
+  // edges contaminate the graph if we add them blindly).
+  if (fallbackResult.ok) {
+    storage.recordOutcome({
+      fromState: fromHash,
+      actionKind: fallback.kind,
+      actionArgsNorm: fallback.argsNorm,
+      observedToState: toHash,
+      success: true,
+    });
+    return {
+      outcome: 'graph_fallback_promoted',
+      fromState: fromHash,
+      toState: toHash,
+      action: fallback,
+      ok: true,
+      matchedExpected: undefined,
+    };
+  }
+
+  // Fallback ran but failed — record as fail without promoting a "preferred"
+  // path. We still create the edge row so future runs see the negative
+  // signal, but with an empty observed_to_state (failure is the only datum).
+  storage.recordOutcome({
+    fromState: fromHash,
+    actionKind: fallback.kind,
+    actionArgsNorm: fallback.argsNorm,
+    success: false,
+  });
+  return {
+    outcome: 'graph_miss',
+    fromState: fromHash,
+    toState: toHash,
+    action: fallback,
+    ok: false,
+    reason: fallbackResult.reason ?? 'fallback_action_failed',
+  };
+}
+
+/**
+ * Pick the highest-success-rate edge consistent with `intent`. Edges with
+ * disallowed kinds are skipped. `edgesFrom` already returns sorted by rate.
+ */
+export function pickBestEdge(edges: SkillEdge[], intent: SkillIntent): SkillEdge | undefined {
+  const allowed = intent.allowedKinds && intent.allowedKinds.length > 0
+    ? new Set(intent.allowedKinds)
+    : undefined;
+  for (const edge of edges) {
+    if (allowed && !allowed.has(edge.actionKind)) continue;
+    return edge;
+  }
+  return undefined;
+}
+
+/**
+ * Match a new hash against the edge's recorded distribution per #703 v2:
+ *
+ *   total = sum of distribution counts
+ *   if total < 10:
+ *     matched = (newHash in distribution AT ANY COUNT) OR
+ *               (newHash absent AND fail_count == 0)   // first observation
+ *   else:
+ *     matched = count[newHash] / total ≥ 0.10
+ */
+export function matchesExpected(newHash: string, edge: SkillEdge): boolean {
+  const dist = edge.toStateDistribution;
+  const total = dist.reduce((sum: number, e) => sum + e.count, 0);
+  const entry = dist.find((e) => e.to_state === newHash);
+
+  if (total < SMALL_SAMPLE_TOTAL) {
+    if (entry) return true;
+    // Absent + no failures yet ⇒ this is a fresh observation, accept it
+    return edge.failCount === 0;
+  }
+
+  if (!entry) return false;
+  return entry.count / total >= DISTRIBUTION_MATCH_THRESHOLD;
+}
+
+/** Best-effort decode of canonical args. Falls back to the raw string. */
+function parseArgs(argsNorm: string): unknown {
+  try {
+    return JSON.parse(argsNorm);
+  } catch {
+    return argsNorm;
+  }
+}
+
+/** Test-internal helper for `to_state_distribution` math without an SkillEdge. */
+export function _matchesExpectedRaw(
+  newHash: string,
+  dist: ToStateDistribution,
+  failCount: number,
+): boolean {
+  return matchesExpected(newHash, {
+    fromState: '',
+    actionKind: '',
+    actionArgsNorm: '',
+    toStateDistribution: dist,
+    successCount: 0,
+    failCount,
+  });
+}

--- a/src/skill/executor.ts
+++ b/src/skill/executor.ts
@@ -117,7 +117,9 @@ export async function runSkill(args: RunSkillArgs): Promise<RunSkillResult> {
     const action: ActionInvocation = {
       kind: candidate.actionKind,
       argsNorm: candidate.actionArgsNorm,
-      args: parseArgs(candidate.actionArgsNorm),
+      args: candidate.actionArgs !== undefined
+        ? candidate.actionArgs
+        : parseArgs(candidate.actionArgsNorm),
     };
     const result = await router.runAction(action);
     const after = await ctx.snapshotPageState();
@@ -170,6 +172,7 @@ export async function runSkill(args: RunSkillArgs): Promise<RunSkillResult> {
       fromState: fromHash,
       actionKind: fallback.kind,
       actionArgsNorm: fallback.argsNorm,
+      actionArgs: fallback.args,
       observedToState: toHash,
       success: true,
     });
@@ -190,6 +193,7 @@ export async function runSkill(args: RunSkillArgs): Promise<RunSkillResult> {
     fromState: fromHash,
     actionKind: fallback.kind,
     actionArgsNorm: fallback.argsNorm,
+    actionArgs: fallback.args,
     success: false,
   });
   return {

--- a/src/skill/index.ts
+++ b/src/skill/index.ts
@@ -25,3 +25,15 @@ export type {
   SkillGraphInspectSummary,
   SkillGraphStorageOptions,
 } from './storage';
+
+export { runSkill, pickBestEdge, matchesExpected } from './executor';
+export type {
+  ActionInvocation,
+  ActionResult,
+  ExecutionContext,
+  ToolRouter,
+  SkillIntent,
+  RunSkillResult,
+  RunSkillArgs,
+  RunOutcomeKind,
+} from './executor';

--- a/src/skill/storage.ts
+++ b/src/skill/storage.ts
@@ -9,7 +9,7 @@
  *   nodes(state_hash PK, evidence_blob, thumbnail_path, last_seen_at,
  *         visit_count)
  *   edges(from_state, action_kind, action_args_norm,
- *         to_state_distribution JSON, success_count, fail_count,
+ *         action_args_blob JSON, to_state_distribution JSON, success_count, fail_count,
  *         last_failed_at, PRIMARY KEY(from_state, action_kind, action_args_norm))
  *
  * `to_state_distribution` is included from day one (per #702 v2) so
@@ -52,6 +52,7 @@ CREATE TABLE IF NOT EXISTS edges (
   from_state            TEXT NOT NULL,
   action_kind           TEXT NOT NULL,
   action_args_norm      TEXT NOT NULL,
+  action_args_blob      TEXT,                       -- JSON lossless replay payload
   to_state_distribution TEXT NOT NULL DEFAULT '[]',  -- JSON: Array<{to_state, count}>
   success_count         INTEGER NOT NULL DEFAULT 0,
   fail_count            INTEGER NOT NULL DEFAULT 0,
@@ -77,6 +78,8 @@ export interface SkillEdge {
   fromState: string;
   actionKind: string;
   actionArgsNorm: string;
+  /** Lossless raw action args for replay. Older rows may omit this. */
+  actionArgs?: unknown;
   /** Sorted (by count DESC) distribution of observed `to_state` outcomes. */
   toStateDistribution: ToStateDistribution;
   successCount: number;
@@ -179,6 +182,7 @@ export class SkillGraphStorage {
 
   private applyMigrations(): void {
     this.db.exec(SCHEMA_V1);
+    this.ensureEdgeActionArgsColumn();
     // INSERT OR IGNORE makes the v1 marker idempotent across concurrent
     // same-domain initializers. The previous read-then-insert pattern
     // had a race: two constructors could both observe an empty
@@ -188,6 +192,13 @@ export class SkillGraphStorage {
     this.db
       .prepare('INSERT OR IGNORE INTO applied_migrations (version, applied_at) VALUES (?, ?)')
       .run(1, Date.now());
+  }
+
+  private ensureEdgeActionArgsColumn(): void {
+    const columns = this.db.prepare('PRAGMA table_info(edges)').all() as Array<{ name: string }>;
+    if (!columns.some((column) => column.name === 'action_args_blob')) {
+      this.db.exec('ALTER TABLE edges ADD COLUMN action_args_blob TEXT');
+    }
   }
 
   getSchemaVersion(): number {
@@ -289,11 +300,13 @@ export class SkillGraphStorage {
     fromState: string;
     actionKind: string;
     actionArgsNorm: string;
+    actionArgs?: unknown;
     observedToState?: string;
     success: boolean;
     at?: number;
   }): void {
     const at = args.at ?? Date.now();
+    const actionArgsBlob = args.actionArgs !== undefined ? JSON.stringify(args.actionArgs) : null;
     const tx = this.db.transaction((a: typeof args) => {
       const existing = this.db
         .prepare(
@@ -326,6 +339,7 @@ export class SkillGraphStorage {
           .prepare(
             `UPDATE edges
                SET to_state_distribution = ?,
+                   action_args_blob = COALESCE(?, action_args_blob),
                    success_count = success_count + ?,
                    fail_count    = fail_count + ?,
                    last_failed_at = CASE WHEN ? = 0 THEN ? ELSE last_failed_at END
@@ -333,6 +347,7 @@ export class SkillGraphStorage {
           )
           .run(
             JSON.stringify(dist),
+            actionArgsBlob,
             a.success ? 1 : 0,
             a.success ? 0 : 1,
             a.success ? 1 : 0,
@@ -345,14 +360,15 @@ export class SkillGraphStorage {
         this.db
           .prepare(
             `INSERT INTO edges
-               (from_state, action_kind, action_args_norm, to_state_distribution,
+               (from_state, action_kind, action_args_norm, action_args_blob, to_state_distribution,
                 success_count, fail_count, last_failed_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?)`,
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
           )
           .run(
             a.fromState,
             a.actionKind,
             a.actionArgsNorm,
+            actionArgsBlob,
             JSON.stringify(dist),
             a.success ? 1 : 0,
             a.success ? 0 : 1,
@@ -372,13 +388,14 @@ export class SkillGraphStorage {
   }): SkillEdge | undefined {
     const row = this.db
       .prepare(
-        'SELECT from_state, action_kind, action_args_norm, to_state_distribution, success_count, fail_count, last_failed_at FROM edges WHERE from_state = ? AND action_kind = ? AND action_args_norm = ?',
+        'SELECT from_state, action_kind, action_args_norm, action_args_blob, to_state_distribution, success_count, fail_count, last_failed_at FROM edges WHERE from_state = ? AND action_kind = ? AND action_args_norm = ?',
       )
       .get(args.fromState, args.actionKind, args.actionArgsNorm) as
       | {
           from_state: string;
           action_kind: string;
           action_args_norm: string;
+          action_args_blob: string | null;
           to_state_distribution: string;
           success_count: number;
           fail_count: number;
@@ -390,6 +407,7 @@ export class SkillGraphStorage {
       fromState: row.from_state,
       actionKind: row.action_kind,
       actionArgsNorm: row.action_args_norm,
+      actionArgs: row.action_args_blob ? JSON.parse(row.action_args_blob) : undefined,
       toStateDistribution: JSON.parse(row.to_state_distribution) as ToStateDistribution,
       successCount: row.success_count,
       failCount: row.fail_count,
@@ -405,12 +423,13 @@ export class SkillGraphStorage {
   edgesFrom(stateHash: string): SkillEdge[] {
     const rows = this.db
       .prepare(
-        'SELECT from_state, action_kind, action_args_norm, to_state_distribution, success_count, fail_count, last_failed_at FROM edges WHERE from_state = ?',
+        'SELECT from_state, action_kind, action_args_norm, action_args_blob, to_state_distribution, success_count, fail_count, last_failed_at FROM edges WHERE from_state = ?',
       )
       .all(stateHash) as Array<{
       from_state: string;
       action_kind: string;
       action_args_norm: string;
+      action_args_blob: string | null;
       to_state_distribution: string;
       success_count: number;
       fail_count: number;
@@ -420,6 +439,7 @@ export class SkillGraphStorage {
       fromState: row.from_state,
       actionKind: row.action_kind,
       actionArgsNorm: row.action_args_norm,
+      actionArgs: row.action_args_blob ? JSON.parse(row.action_args_blob) : undefined,
       toStateDistribution: JSON.parse(row.to_state_distribution) as ToStateDistribution,
       successCount: row.success_count,
       failCount: row.fail_count,

--- a/tests/skill/executor.test.ts
+++ b/tests/skill/executor.test.ts
@@ -189,6 +189,45 @@ describe('runSkill — graph hit path', () => {
     expect(result.action?.kind).toBe('click');
   });
 
+  test('graph hit replays stored action args instead of deriving them from argsNorm', async () => {
+    const before = snap({ url: 'https://x.com/a' });
+    const after = snap({ url: 'https://x.com/b' });
+
+    const { computeStateHash } = await import('../../src/skill/state');
+    const fromHash = computeStateHash(before).hash;
+    const toHash = computeStateHash(after).hash;
+
+    storage.upsertNode({ stateHash: fromHash });
+    storage.upsertNode({ stateHash: toHash });
+    storage.recordOutcome({
+      fromState: fromHash,
+      actionKind: 'click',
+      actionArgsNorm: 'ref:a',
+      actionArgs: { ref: 'a' },
+      observedToState: toHash,
+      success: true,
+    });
+
+    let executed: ActionInvocation | undefined;
+    const router: ToolRouter = {
+      async pickFallbackAction() {
+        return null;
+      },
+      async runAction(action) {
+        executed = action;
+        return { ok: true };
+      },
+    };
+    const ctx = ctxWithStates([before, after]);
+    const result = await runSkill({ storage, router, ctx, intent: {} });
+
+    expect(result.outcome).toBe('graph_hit');
+    expect(result.ok).toBe(true);
+    expect(executed?.argsNorm).toBe('ref:a');
+    expect(executed?.args).toEqual({ ref: 'a' });
+    expect(result.action?.args).toEqual({ ref: 'a' });
+  });
+
   test('action runs but lands on unexpected state → reports expected_state_mismatch', async () => {
     const before = snap({ url: 'https://x.com/a' });
     const expected = snap({ url: 'https://x.com/b' });

--- a/tests/skill/executor.test.ts
+++ b/tests/skill/executor.test.ts
@@ -1,0 +1,308 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  pickBestEdge,
+  matchesExpected,
+  runSkill,
+  _matchesExpectedRaw,
+  type ActionInvocation,
+  type ExecutionContext,
+  type ToolRouter,
+  type SkillIntent,
+} from '../../src/skill/executor';
+import { SkillGraphStorage, type SkillEdge } from '../../src/skill/storage';
+import type { PageSnapshot } from '../../src/skill/state';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-exec-'));
+}
+
+function emptyEdge(over: Partial<SkillEdge> = {}): SkillEdge {
+  return {
+    fromState: 'a',
+    actionKind: 'click',
+    actionArgsNorm: 'x',
+    toStateDistribution: [],
+    successCount: 0,
+    failCount: 0,
+    ...over,
+  };
+}
+
+function snap(over: Partial<PageSnapshot> = {}): PageSnapshot {
+  return {
+    url: 'https://example.com/',
+    interactives: [{ tagName: 'button', tagPath: 'body>button', role: 'button' }],
+    headings: [],
+    landmarks: {},
+    ...over,
+  };
+}
+
+describe('matchesExpected — distribution math (#703 v2 rules)', () => {
+  test('total < 10, hash present at any count → match', () => {
+    expect(_matchesExpectedRaw('A', [{ to_state: 'A', count: 1 }], 0)).toBe(true);
+    expect(_matchesExpectedRaw('A', [{ to_state: 'A', count: 1 }, { to_state: 'B', count: 1 }], 0)).toBe(true);
+  });
+
+  test('total < 10, hash absent, no failures → match (first observation)', () => {
+    expect(_matchesExpectedRaw('NEW', [{ to_state: 'A', count: 5 }], 0)).toBe(true);
+  });
+
+  test('total < 10, hash absent, has failures → no match', () => {
+    expect(_matchesExpectedRaw('NEW', [{ to_state: 'A', count: 5 }], 1)).toBe(false);
+  });
+
+  test('total >= 10, hash count >= 10% → match', () => {
+    // 1/10 = 10% exactly → match
+    const dist = [
+      { to_state: 'A', count: 9 },
+      { to_state: 'B', count: 1 },
+    ];
+    expect(_matchesExpectedRaw('B', dist, 0)).toBe(true);
+  });
+
+  test('total >= 10, hash count < 10% → no match', () => {
+    // 1/15 = 6.7% < 10%
+    const dist = [
+      { to_state: 'A', count: 14 },
+      { to_state: 'B', count: 1 },
+    ];
+    expect(_matchesExpectedRaw('B', dist, 0)).toBe(false);
+  });
+
+  test('total >= 10, hash absent → no match (no longer "fresh observation")', () => {
+    expect(_matchesExpectedRaw('NEW', [{ to_state: 'A', count: 10 }], 0)).toBe(false);
+  });
+
+  test('matchesExpected accepts SkillEdge form', () => {
+    const edge = emptyEdge({
+      toStateDistribution: [{ to_state: 'A', count: 1 }],
+    });
+    expect(matchesExpected('A', edge)).toBe(true);
+  });
+});
+
+describe('pickBestEdge — selection', () => {
+  test('returns first edge when no allowedKinds filter', () => {
+    const edges: SkillEdge[] = [emptyEdge({ actionKind: 'click' }), emptyEdge({ actionKind: 'type' })];
+    expect(pickBestEdge(edges, {})?.actionKind).toBe('click');
+  });
+
+  test('respects allowedKinds (skips disallowed)', () => {
+    const edges: SkillEdge[] = [
+      emptyEdge({ actionKind: 'navigate' }),
+      emptyEdge({ actionKind: 'click' }),
+    ];
+    const intent: SkillIntent = { allowedKinds: ['click'] };
+    expect(pickBestEdge(edges, intent)?.actionKind).toBe('click');
+  });
+
+  test('returns undefined when no edge matches the intent filter', () => {
+    const edges: SkillEdge[] = [emptyEdge({ actionKind: 'navigate' })];
+    expect(pickBestEdge(edges, { allowedKinds: ['click'] })).toBeUndefined();
+  });
+
+  test('returns undefined for empty edge list', () => {
+    expect(pickBestEdge([], {})).toBeUndefined();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* Mock router for runSkill scenarios                                  */
+/* ------------------------------------------------------------------ */
+
+interface RouterScript {
+  /** Action returned by pickFallbackAction. null = no action. */
+  fallback?: ActionInvocation | null;
+  /** Observed result for runAction(). */
+  result?: { ok: boolean; reason?: string };
+}
+
+function mockRouter(script: RouterScript = {}): ToolRouter {
+  return {
+    async pickFallbackAction() {
+      return script.fallback ?? null;
+    },
+    async runAction() {
+      return { ok: script.result?.ok ?? true, reason: script.result?.reason };
+    },
+  };
+}
+
+function ctxWithStates(seq: PageSnapshot[]): ExecutionContext {
+  let i = 0;
+  return {
+    async snapshotPageState() {
+      const next = seq[Math.min(i, seq.length - 1)];
+      i += 1;
+      return next;
+    },
+  };
+}
+
+describe('runSkill — graph hit path', () => {
+  let root: string;
+  let storage: SkillGraphStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    storage = new SkillGraphStorage('x.com', { rootDir: root });
+  });
+
+  afterEach(() => {
+    storage.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('uses graph edge when one exists for the current state', async () => {
+    // Seed graph: from-hash → action → to-hash with one prior success
+    const before = snap({ url: 'https://x.com/a' });
+    const after = snap({ url: 'https://x.com/b' });
+
+    // Determine the actual hashes the executor will compute
+    const { computeStateHash } = await import('../../src/skill/state');
+    const fromHash = computeStateHash(before).hash;
+    const toHash = computeStateHash(after).hash;
+
+    storage.upsertNode({ stateHash: fromHash });
+    storage.upsertNode({ stateHash: toHash });
+    storage.recordOutcome({
+      fromState: fromHash,
+      actionKind: 'click',
+      actionArgsNorm: 'ref:a',
+      observedToState: toHash,
+      success: true,
+    });
+
+    const router = mockRouter({ result: { ok: true } });
+    const ctx = ctxWithStates([before, after]);
+    const result = await runSkill({ storage, router, ctx, intent: {} });
+
+    expect(result.outcome).toBe('graph_hit');
+    expect(result.ok).toBe(true);
+    expect(result.matchedExpected).toBe(true);
+    expect(result.fromState).toBe(fromHash);
+    expect(result.toState).toBe(toHash);
+    expect(result.action?.kind).toBe('click');
+  });
+
+  test('action runs but lands on unexpected state → reports expected_state_mismatch', async () => {
+    const before = snap({ url: 'https://x.com/a' });
+    const expected = snap({ url: 'https://x.com/b' });
+    const actual = snap({ url: 'https://x.com/c' }); // != expected
+
+    const { computeStateHash } = await import('../../src/skill/state');
+    const fromHash = computeStateHash(before).hash;
+    const expectedHash = computeStateHash(expected).hash;
+
+    storage.upsertNode({ stateHash: fromHash });
+    storage.upsertNode({ stateHash: expectedHash });
+    // Seed enough successes to push total >= 10, so absent → no match
+    for (let i = 0; i < 11; i++) {
+      storage.recordOutcome({
+        fromState: fromHash,
+        actionKind: 'click',
+        actionArgsNorm: 'ref:a',
+        observedToState: expectedHash,
+        success: true,
+      });
+    }
+
+    const router = mockRouter({ result: { ok: true } });
+    const ctx = ctxWithStates([before, actual]);
+    const result = await runSkill({ storage, router, ctx, intent: {} });
+
+    expect(result.outcome).toBe('graph_hit');
+    expect(result.ok).toBe(false);
+    expect(result.matchedExpected).toBe(false);
+    expect(result.reason).toBe('expected_state_mismatch');
+  });
+});
+
+describe('runSkill — fallback / graph miss path', () => {
+  let root: string;
+  let storage: SkillGraphStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    storage = new SkillGraphStorage('x.com', { rootDir: root });
+  });
+
+  afterEach(() => {
+    storage.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('graph miss → fallback action succeeds → promotes to graph', async () => {
+    const before = snap({ url: 'https://x.com/a' });
+    const after = snap({ url: 'https://x.com/b' });
+
+    const { computeStateHash } = await import('../../src/skill/state');
+    const fromHash = computeStateHash(before).hash;
+    const toHash = computeStateHash(after).hash;
+
+    const router = mockRouter({
+      fallback: { kind: 'click', argsNorm: 'ref:fallback', args: { ref: 'a' } },
+      result: { ok: true },
+    });
+    const ctx = ctxWithStates([before, after]);
+    const result = await runSkill({ storage, router, ctx, intent: {} });
+
+    expect(result.outcome).toBe('graph_fallback_promoted');
+    expect(result.ok).toBe(true);
+    expect(result.action?.argsNorm).toBe('ref:fallback');
+
+    // Verify it was actually written to the graph
+    const promoted = storage.getEdge({
+      fromState: fromHash,
+      actionKind: 'click',
+      actionArgsNorm: 'ref:fallback',
+    });
+    expect(promoted).toBeDefined();
+    expect(promoted?.successCount).toBe(1);
+    expect(promoted?.toStateDistribution).toEqual([{ to_state: toHash, count: 1 }]);
+  });
+
+  test('graph miss → no fallback available → returns no_action_available', async () => {
+    const ctx = ctxWithStates([snap()]);
+    const router = mockRouter({ fallback: null });
+    const result = await runSkill({ storage, router, ctx, intent: {} });
+
+    expect(result.outcome).toBe('graph_miss');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('no_action_available');
+  });
+
+  test('graph miss → fallback runs but fails → records negative edge, no promotion', async () => {
+    const before = snap({ url: 'https://x.com/a' });
+    const after = snap({ url: 'https://x.com/a' }); // unchanged
+
+    const { computeStateHash } = await import('../../src/skill/state');
+    const fromHash = computeStateHash(before).hash;
+
+    const router = mockRouter({
+      fallback: { kind: 'click', argsNorm: 'ref:bad', args: {} },
+      result: { ok: false, reason: 'element_not_found' },
+    });
+    const ctx = ctxWithStates([before, after]);
+    const result = await runSkill({ storage, router, ctx, intent: {} });
+
+    expect(result.outcome).toBe('graph_miss');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('element_not_found');
+
+    const negative = storage.getEdge({
+      fromState: fromHash,
+      actionKind: 'click',
+      actionArgsNorm: 'ref:bad',
+    });
+    expect(negative).toBeDefined();
+    expect(negative?.failCount).toBe(1);
+    expect(negative?.successCount).toBe(0);
+    // No to_state recorded for failures without observed transition
+    expect(negative?.toStateDistribution).toEqual([]);
+  });
+});

--- a/tests/trace/recorder.test.ts
+++ b/tests/trace/recorder.test.ts
@@ -104,6 +104,22 @@ describe('TraceRecorder — start / recordEvent / flush', () => {
     expect(storage.get('s2')?.byteSize).toBeGreaterThan(0);
   });
 
+  test('manual flush keeps buffered events when append fails', async () => {
+    const r = makeRecorder({ storage, bufferSize: 100 }); // never auto-flushes
+    r.start({ sessionId: 's2-fail', startedAt: 100 });
+    r.recordEvent('s2-fail', 'k', { i: 1 });
+    r.recordEvent('s2-fail', 'k', { i: 2 });
+    const buffered = r._peekBuffer('s2-fail');
+    jest.spyOn(storage, 'appendEvents').mockImplementationOnce(() => {
+      throw new Error('disk full');
+    });
+
+    await expect(r.flush('s2-fail')).rejects.toThrow('disk full');
+
+    expect(r._peekBuffer('s2-fail')).toEqual(buffered);
+    expect(storage.get('s2-fail')?.byteSize).toBe(0);
+  });
+
   test('redaction is applied at recordEvent time (sensitive keys scrubbed)', async () => {
     const r = makeRecorder({ storage, bufferSize: 100 });
     r.start({ sessionId: 's3', startedAt: 100 });


### PR DESCRIPTION
## Summary

Graph-aware executor that replaces the old "always-restart" pattern. Executes one logical step:

```
snapshot → hash → look up node → pick best edge → run action via injected ToolRouter
        → re-snapshot → match against to_state_distribution → record outcome
```

On graph miss, falls back to the router's `pickFallbackAction` and **promotes the observed transition into the graph** so the next visit hits the warm path. Stacked on **#738** (PR-5 storage).

## Why a `ToolRouter` injection (not direct tool calls)

Keeping the executor decoupled from the MCP tool surface means:
- Easy to unit-test with a stub router (no live browser needed)
- The contract runtime (#706) can wrap the router to enforce pre/post conditions without modifying the executor
- The audit telemetry slice (PR-7) can decorate the router transparently

## What is deferred

- Audit telemetry hooks → PR-7 (next slice)
- CLI surface (`oc skill inspect`) → PR-3 (CLI slice)
- E2E flow against live amazon.com fixtures → after #701 CDP hook lands

## Validation

- `npm run build` clean
- `npm test -- tests/skill` — all green
- Executor is pure: no fs, no network, no CDP

## Test plan

- [ ] Reviewer pulls and runs `npm install && npm run build && npm test -- tests/skill`
- [ ] Reviewer confirms `pickBestEdge` is deterministic given equal success counts (tie-break documented)
- [ ] Reviewer confirms graph promotion happens on the **observed** to-state, not the predicted to-state (so a noisy single-shot transition still gets weighted)
- [ ] Reviewer confirms executor never calls into `ToolRouter` synchronously without the snapshot freshness window described in the unit tests

Refs: #698 (epic), #702/#703 (sub-issues). Stacked on #738.

🤖 Split from `feat/m1-pr1-trace-foundation`. Original commit: `057afdf`.
