### PR TITLE
docs(skill-graph): DOM snapshot capture procedure for fixtures (M1 PR-8 partial)

### DIFF
--- a/docs/skill-graph/capture.md
+++ b/docs/skill-graph/capture.md
@@ -1,0 +1,158 @@
+# DOM snapshot capture procedure for skill-graph fixtures
+
+This procedure produces the deterministic fixtures consumed by:
+
+- `tests/skill/state.test.ts` — state-hash stability
+- `tests/skill/state.stability.test.ts` (planned) — `≥ 19 / 20` hash matches
+  across captured Amazon variants
+- `tests/fixtures/skill/amazon-cart-variants/` (planned) — corpus of
+  20 captured DOM snapshots with intentional dynamic content variation
+
+It is intentionally manual — capturing in CI risks tripping anti-bot on
+real sites and violates ToS for some targets.
+
+## When to recapture
+
+Recapture the fixture set when **any** of the following changes:
+
+- `src/skill/state.ts` hashing algorithm (bump `hash_components_version`).
+- `src/skill/url-normalizer.ts` `TRACKING_PARAM_PATTERNS`.
+- `src/skill/interactive-filter.ts` predicate set.
+- A target site (e.g., Amazon) ships a layout change that pushes the
+  fixture stability rate below 95 %.
+
+Otherwise the existing fixtures are stable for the lifetime of v1 of the
+hash algorithm.
+
+## Procedure
+
+### 1. Open Chrome with the project's profile
+
+```bash
+oc serve --headed --profile-directory "Default"
+# In a second shell, attach DevTools to the running Chrome.
+```
+
+### 2. Navigate to the target page
+
+For each capture, vary one or more of these dimensions to exercise the
+"noise" the hasher should ignore:
+
+| Variation | What you change | What the hash should do |
+|---|---|---|
+| Timestamp / nonce | revisit the same URL minutes apart | unchanged |
+| Ad rotation | reload with cache disabled | unchanged |
+| Tracking params | append `?utm_source=test` | unchanged |
+| Logged-out / in | sign out and revisit | **change** |
+| Cart state | add an item then revisit | **change** |
+| Captcha challenge | visit through a VPN that triggers a challenge | **change** |
+
+### 3. Capture the snapshot
+
+In the DevTools Console of the captured tab, paste the snapshot script:
+
+```js
+(async () => {
+  // Interactive nodes (must match src/skill/interactive-filter.ts).
+  const INTERACTIVE_TAGS = new Set([
+    'a','button','input','select','textarea','option','summary','video','audio',
+  ]);
+  const INTERACTIVE_ROLES = new Set([
+    'button','link','tab','menuitem','checkbox','radio','switch','option',
+    'combobox','searchbox','textbox','slider','spinbutton',
+    'menuitemcheckbox','menuitemradio',
+  ]);
+  function tagPath(el) {
+    const parts = [];
+    while (el && el !== document.body) {
+      parts.unshift(el.tagName.toLowerCase());
+      el = el.parentElement;
+    }
+    parts.unshift('body');
+    return parts.join('>');
+  }
+  function isInteractive(el) {
+    const tag = el.tagName.toLowerCase();
+    if (tag === 'a') return Boolean(el.getAttribute('href'));
+    if (INTERACTIVE_TAGS.has(tag)) return true;
+    const role = (el.getAttribute('role') || '').toLowerCase();
+    if (role && INTERACTIVE_ROLES.has(role)) return true;
+    if (el.isContentEditable) return true;
+    const ti = parseInt(el.getAttribute('tabindex') ?? '', 10);
+    if (Number.isFinite(ti) && ti >= 0) return true;
+    return false;
+  }
+  const interactives = [...document.querySelectorAll('*')]
+    .filter(isInteractive)
+    .map((el) => ({
+      tagName: el.tagName.toLowerCase(),
+      tagPath: tagPath(el),
+      role: el.getAttribute('role') || undefined,
+      hasHref: el.tagName === 'A' ? Boolean(el.getAttribute('href')) : undefined,
+    }));
+  const headings = [...document.querySelectorAll('h1, h2, h3')].map((h) => h.innerText);
+  const landmarks = {
+    loginForm: Boolean(document.querySelector('input[type=password]')),
+    paymentFields: Boolean(document.querySelector('input[autocomplete*=cc-]')),
+    cartBadge: Boolean(document.querySelector('[data-testid*=cart-count], #nav-cart-count')),
+    modalOverlay: Boolean(document.querySelector('[role=dialog], [aria-modal=true]')),
+    captchaChallenge: Boolean(document.querySelector('[data-sitekey], iframe[src*=hcaptcha], iframe[src*=cf-challenge]')),
+  };
+  const snapshot = { url: location.href, interactives, headings, landmarks };
+  copy(JSON.stringify(snapshot, null, 2));
+  console.log('snapshot copied to clipboard');
+})();
+```
+
+### 4. Save the JSON
+
+Paste the clipboard contents into:
+
+```
+tests/fixtures/skill/<scenario>/<NN>.json
+```
+
+Where:
+
+- `<scenario>` matches the dimension you varied (e.g.
+  `amazon-cart-variants`, `amazon-login-states`).
+- `<NN>` is a zero-padded sequence number per scenario.
+
+Commit the file alongside any test changes that consume it. Fixtures are
+small (≈ 5–30 KB JSON) and live under version control.
+
+### 5. Update the consumer test
+
+For a stability scenario:
+
+```ts
+test('hash stability — 19 of 20 must match the canonical hash', () => {
+  const fixtures = fs.readdirSync(SCENARIO_DIR).filter((f) => f.endsWith('.json'));
+  expect(fixtures).toHaveLength(20);
+  const hashes = fixtures.map((f) => {
+    const snapshot = JSON.parse(fs.readFileSync(path.join(SCENARIO_DIR, f), 'utf8'));
+    return computeStateHash(snapshot).hash;
+  });
+  const dominant = mode(hashes);
+  const matches = hashes.filter((h) => h === dominant).length;
+  expect(matches).toBeGreaterThanOrEqual(19);
+});
+```
+
+For a sensitivity scenario, assert two scenarios produce **different**
+hashes:
+
+```ts
+test('logged-out vs logged-in produce distinct hashes', () => {
+  const a = computeStateHash(loadFixture('amazon-login-states/00.json')).hash;
+  const b = computeStateHash(loadFixture('amazon-login-states/01.json')).hash;
+  expect(a).not.toBe(b);
+});
+```
+
+## Recapture cadence
+
+Re-run this procedure every 6 months, or when stability drops below the
+acceptance threshold. Record the recapture date in
+`docs/skill-graph/CAPTURE-LOG.md` so future maintainers can correlate
+fixture age with site changes.

--- a/src/skill/executor.ts
+++ b/src/skill/executor.ts
@@ -1,0 +1,268 @@
+/**
+ * Graph-aware skill executor.
+ *
+ * Replaces the old "always-restart" pattern with state-aware resume:
+ *   1. Snapshot the page → compute the current state hash (#702).
+ *   2. Look up the node in the per-domain skill graph (#702 storage).
+ *   3. Pick the highest-success-rate outgoing edge that matches `intent`.
+ *   4. Execute the action via the tool-router adapter (existing src/tools/*).
+ *   5. Re-snapshot, compute new hash, validate against the edge's
+ *      `to_state_distribution` per #703 v2 rules.
+ *   6. Record the outcome (success/fail, observed to_state).
+ *   7. If no edge matches in step 3, fall back to the existing waterfall
+ *      and *promote* the observed transition into the graph as a new edge.
+ *
+ * The router is injected so tests can mock it (the real adapter wiring
+ * to `src/tools/` lives in PR-7).
+ */
+
+import { computeStateHash, type PageSnapshot } from './state';
+import {
+  SkillGraphStorage,
+  type SkillEdge,
+  type ToStateDistribution,
+} from './storage';
+
+/** A single action the router can execute. */
+export interface ActionInvocation {
+  /** Action kind: `click`, `type`, `navigate`, etc. */
+  kind: string;
+  /** Canonical args representation used for graph identity. */
+  argsNorm: string;
+  /** Raw args passed to the underlying tool. */
+  args: unknown;
+}
+
+export interface ActionResult {
+  ok: boolean;
+  /** Optional reason for failure — surfaced in audit + telemetry. */
+  reason?: string;
+}
+
+/**
+ * Context the executor needs from its host. Hosts (PR-7's MCP layer)
+ * supply real puppeteer-driven snapshotters; tests supply fakes.
+ */
+export interface ExecutionContext {
+  /** Capture the current page state. Called before and after each action. */
+  snapshotPageState(): Promise<PageSnapshot>;
+}
+
+/** Tool dispatcher abstraction — adapter to existing src/tools/* in PR-7. */
+export interface ToolRouter {
+  /**
+   * Pick a best action for the current snapshot + intent, without using
+   * the graph. Used as the fallback path when the graph has no edge.
+   */
+  pickFallbackAction(snapshot: PageSnapshot, intent: SkillIntent): Promise<ActionInvocation | null>;
+  /** Execute the action; returns ok/fail. */
+  runAction(action: ActionInvocation): Promise<ActionResult>;
+}
+
+export interface SkillIntent {
+  /** Human-readable description (logging only). */
+  description?: string;
+  /** Restrict edge selection to these action kinds. */
+  allowedKinds?: string[];
+}
+
+export type RunOutcomeKind =
+  | 'graph_hit'
+  | 'graph_miss'
+  | 'graph_fallback_promoted';
+
+export interface RunSkillResult {
+  outcome: RunOutcomeKind;
+  fromState: string;
+  toState?: string;
+  /** The action invocation that was executed (if any). */
+  action?: ActionInvocation;
+  ok: boolean;
+  /** Failure reason or "expected_state_mismatch" / "no_action_available". */
+  reason?: string;
+  /** True when the new hash matched the edge's expected distribution. */
+  matchedExpected?: boolean;
+}
+
+export interface RunSkillArgs {
+  storage: SkillGraphStorage;
+  router: ToolRouter;
+  ctx: ExecutionContext;
+  intent: SkillIntent;
+}
+
+/** Threshold per #703 v2: 10% of total invocations. */
+const DISTRIBUTION_MATCH_THRESHOLD = 0.1;
+/** Below this total invocation count, fall back to the looser rule. */
+const SMALL_SAMPLE_TOTAL = 10;
+
+/**
+ * One pass of skill execution. Hosts call this in a loop (or once per
+ * intent step, depending on skill granularity).
+ */
+export async function runSkill(args: RunSkillArgs): Promise<RunSkillResult> {
+  const { storage, router, ctx, intent } = args;
+
+  const before = await ctx.snapshotPageState();
+  const fromHash = computeStateHash(before).hash;
+  storage.upsertNode({
+    stateHash: fromHash,
+    evidence: computeStateHash(before).evidence,
+  });
+
+  const candidate = pickBestEdge(storage.edgesFrom(fromHash), intent);
+
+  // Path A — graph hit
+  if (candidate) {
+    const action: ActionInvocation = {
+      kind: candidate.actionKind,
+      argsNorm: candidate.actionArgsNorm,
+      args: parseArgs(candidate.actionArgsNorm),
+    };
+    const result = await router.runAction(action);
+    const after = await ctx.snapshotPageState();
+    const toHash = computeStateHash(after).hash;
+    storage.upsertNode({
+      stateHash: toHash,
+      evidence: computeStateHash(after).evidence,
+    });
+    const matched = result.ok && matchesExpected(toHash, candidate);
+    storage.recordOutcome({
+      fromState: fromHash,
+      actionKind: action.kind,
+      actionArgsNorm: action.argsNorm,
+      observedToState: toHash,
+      success: matched,
+    });
+    return {
+      outcome: 'graph_hit',
+      fromState: fromHash,
+      toState: toHash,
+      action,
+      ok: matched,
+      matchedExpected: matched,
+      reason: result.ok && !matched ? 'expected_state_mismatch' : result.reason,
+    };
+  }
+
+  // Path B — graph miss → fallback
+  const fallback = await router.pickFallbackAction(before, intent);
+  if (!fallback) {
+    return {
+      outcome: 'graph_miss',
+      fromState: fromHash,
+      ok: false,
+      reason: 'no_action_available',
+    };
+  }
+  const fallbackResult = await router.runAction(fallback);
+  const after = await ctx.snapshotPageState();
+  const toHash = computeStateHash(after).hash;
+  storage.upsertNode({
+    stateHash: toHash,
+    evidence: computeStateHash(after).evidence,
+  });
+
+  // Promote the observed transition to the graph (only on success — failed
+  // edges contaminate the graph if we add them blindly).
+  if (fallbackResult.ok) {
+    storage.recordOutcome({
+      fromState: fromHash,
+      actionKind: fallback.kind,
+      actionArgsNorm: fallback.argsNorm,
+      observedToState: toHash,
+      success: true,
+    });
+    return {
+      outcome: 'graph_fallback_promoted',
+      fromState: fromHash,
+      toState: toHash,
+      action: fallback,
+      ok: true,
+      matchedExpected: undefined,
+    };
+  }
+
+  // Fallback ran but failed — record as fail without promoting a "preferred"
+  // path. We still create the edge row so future runs see the negative
+  // signal, but with an empty observed_to_state (failure is the only datum).
+  storage.recordOutcome({
+    fromState: fromHash,
+    actionKind: fallback.kind,
+    actionArgsNorm: fallback.argsNorm,
+    success: false,
+  });
+  return {
+    outcome: 'graph_miss',
+    fromState: fromHash,
+    toState: toHash,
+    action: fallback,
+    ok: false,
+    reason: fallbackResult.reason ?? 'fallback_action_failed',
+  };
+}
+
+/**
+ * Pick the highest-success-rate edge consistent with `intent`. Edges with
+ * disallowed kinds are skipped. `edgesFrom` already returns sorted by rate.
+ */
+export function pickBestEdge(edges: SkillEdge[], intent: SkillIntent): SkillEdge | undefined {
+  const allowed = intent.allowedKinds && intent.allowedKinds.length > 0
+    ? new Set(intent.allowedKinds)
+    : undefined;
+  for (const edge of edges) {
+    if (allowed && !allowed.has(edge.actionKind)) continue;
+    return edge;
+  }
+  return undefined;
+}
+
+/**
+ * Match a new hash against the edge's recorded distribution per #703 v2:
+ *
+ *   total = sum of distribution counts
+ *   if total < 10:
+ *     matched = (newHash in distribution AT ANY COUNT) OR
+ *               (newHash absent AND fail_count == 0)   // first observation
+ *   else:
+ *     matched = count[newHash] / total ≥ 0.10
+ */
+export function matchesExpected(newHash: string, edge: SkillEdge): boolean {
+  const dist = edge.toStateDistribution;
+  const total = dist.reduce((sum: number, e) => sum + e.count, 0);
+  const entry = dist.find((e) => e.to_state === newHash);
+
+  if (total < SMALL_SAMPLE_TOTAL) {
+    if (entry) return true;
+    // Absent + no failures yet ⇒ this is a fresh observation, accept it
+    return edge.failCount === 0;
+  }
+
+  if (!entry) return false;
+  return entry.count / total >= DISTRIBUTION_MATCH_THRESHOLD;
+}
+
+/** Best-effort decode of canonical args. Falls back to the raw string. */
+function parseArgs(argsNorm: string): unknown {
+  try {
+    return JSON.parse(argsNorm);
+  } catch {
+    return argsNorm;
+  }
+}
+
+/** Test-internal helper for `to_state_distribution` math without an SkillEdge. */
+export function _matchesExpectedRaw(
+  newHash: string,
+  dist: ToStateDistribution,
+  failCount: number,
+): boolean {
+  return matchesExpected(newHash, {
+    fromState: '',
+    actionKind: '',
+    actionArgsNorm: '',
+    toStateDistribution: dist,
+    successCount: 0,
+    failCount,
+  });
+}

--- a/src/skill/index.ts
+++ b/src/skill/index.ts
@@ -25,3 +25,15 @@ export type {
   SkillGraphInspectSummary,
   SkillGraphStorageOptions,
 } from './storage';
+
+export { runSkill, pickBestEdge, matchesExpected } from './executor';
+export type {
+  ActionInvocation,
+  ActionResult,
+  ExecutionContext,
+  ToolRouter,
+  SkillIntent,
+  RunSkillResult,
+  RunSkillArgs,
+  RunOutcomeKind,
+} from './executor';

--- a/src/skill/index.ts
+++ b/src/skill/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Skill subsystem barrel — state hashing, URL normalization, interactive
+ * filter. Future PRs add storage (#702) and executor (#703).
+ */
+
+export { normalizeUrl, TRACKING_PARAM_PATTERNS } from './url-normalizer';
+export type { NormalizeUrlResult } from './url-normalizer';
+
+export { isInteractiveNode } from './interactive-filter';
+export type { InteractiveProbe } from './interactive-filter';
+
+export { computeStateHash, canonicalJson } from './state';
+export type {
+  PageSnapshot,
+  LandmarkFlags,
+  StateHashEvidence,
+  StateHashResult,
+} from './state';

--- a/src/skill/index.ts
+++ b/src/skill/index.ts
@@ -16,3 +16,12 @@ export type {
   StateHashEvidence,
   StateHashResult,
 } from './state';
+
+export { SkillGraphStorage, defaultSkillGraphRootDir } from './storage';
+export type {
+  SkillNode,
+  SkillEdge,
+  ToStateDistribution,
+  SkillGraphInspectSummary,
+  SkillGraphStorageOptions,
+} from './storage';

--- a/src/skill/interactive-filter.ts
+++ b/src/skill/interactive-filter.ts
@@ -1,0 +1,71 @@
+/**
+ * Canonical "is this an interactive element?" predicate.
+ *
+ * Shared by #702 (state hashing — must be deterministic across runs) and
+ * #709 (perceptual metadata — must annotate the same set). Defined once
+ * here so the two consumers don't drift.
+ *
+ * The set is intentionally narrow: only nodes a user could plausibly
+ * interact with via click/type/select. Excludes labels, headings, lists.
+ */
+
+const INTERACTIVE_TAG_NAMES = new Set([
+  'a',
+  'button',
+  'input',
+  'select',
+  'textarea',
+  'option',
+  'summary',
+  'video',
+  'audio',
+]);
+
+const INTERACTIVE_ROLES = new Set([
+  'button',
+  'link',
+  'tab',
+  'menuitem',
+  'checkbox',
+  'radio',
+  'switch',
+  'option',
+  'combobox',
+  'searchbox',
+  'textbox',
+  'slider',
+  'spinbutton',
+  'menuitemcheckbox',
+  'menuitemradio',
+]);
+
+/** Subset of an element/node descriptor sufficient for the predicate. */
+export interface InteractiveProbe {
+  /** Lowercased tag name (e.g. "button", "a"). */
+  tagName: string;
+  /** ARIA role attribute, lowercased. */
+  role?: string;
+  /** Presence of href on `<a>`. Anchors without href are not interactive. */
+  hasHref?: boolean;
+  /** Presence of contenteditable. Treated as interactive textbox-equivalent. */
+  contentEditable?: boolean;
+  /** tabindex >= 0 makes any element focusable. */
+  tabIndex?: number;
+}
+
+export function isInteractiveNode(probe: InteractiveProbe): boolean {
+  const tag = probe.tagName.toLowerCase();
+
+  // Anchors require href to be interactive (a name-anchor isn't).
+  if (tag === 'a') return Boolean(probe.hasHref);
+
+  if (INTERACTIVE_TAG_NAMES.has(tag)) return true;
+
+  if (probe.role && INTERACTIVE_ROLES.has(probe.role.toLowerCase())) return true;
+
+  if (probe.contentEditable) return true;
+
+  if (typeof probe.tabIndex === 'number' && probe.tabIndex >= 0) return true;
+
+  return false;
+}

--- a/src/skill/state.ts
+++ b/src/skill/state.ts
@@ -1,0 +1,163 @@
+/**
+ * Deterministic state hashing for the skill-graph nodes.
+ *
+ * Two visits to "the same logical page" must produce the same hash. Two
+ * meaningfully different states (logged-out vs logged-in, empty cart vs
+ * has-item) must differ. Concretely we hash:
+ *
+ *   1. Normalized URL (host lowercased, tracking params stripped, query
+ *      keys sorted) — see `url-normalizer.ts`.
+ *   2. Histogram of interactive-element tag-paths — captures structural
+ *      identity without being sensitive to dynamic ad/news content.
+ *   3. Sorted set of visible top-level headings (h1-h3 text after
+ *      whitespace collapse).
+ *   4. Bitmap flags for known landmarks: login form, payment fields,
+ *      cart count badge, modal overlay, captcha challenge.
+ *
+ * The output is `{ hash, evidence }`; callers persist `hash` in the graph
+ * DB and stash `evidence` in the node's `evidence_blob` so an operator
+ * inspecting the graph can see why two states differed.
+ */
+
+import * as crypto from 'node:crypto';
+
+import { normalizeUrl } from './url-normalizer';
+import { isInteractiveNode, type InteractiveProbe } from './interactive-filter';
+
+/** A snapshot the hasher consumes — produced from a real page or a fixture. */
+export interface PageSnapshot {
+  url: string;
+  /** Top-level interactive elements with their tag-path from `<body>`. */
+  interactives: Array<InteractiveProbe & { tagPath: string }>;
+  /** Visible h1/h2/h3 text (innerText, whitespace-collapsed). */
+  headings: string[];
+  /** Landmark probes — `true` when the landmark is detected on the page. */
+  landmarks: LandmarkFlags;
+}
+
+export interface LandmarkFlags {
+  loginForm?: boolean;
+  paymentFields?: boolean;
+  cartBadge?: boolean;
+  modalOverlay?: boolean;
+  captchaChallenge?: boolean;
+}
+
+const LANDMARK_BIT_ORDER: (keyof LandmarkFlags)[] = [
+  'loginForm',
+  'paymentFields',
+  'cartBadge',
+  'modalOverlay',
+  'captchaChallenge',
+];
+
+export interface StateHashEvidence {
+  url_normalized: string;
+  url_dropped_params: string[];
+  interactive_node_count: number;
+  /** Sorted (tag-path → count) pairs. Stable across visits. */
+  interactive_histogram: Array<[string, number]>;
+  heading_set: string[];
+  landmark_flags: number;
+  /** Bump when the algorithm changes; old hashes can be compared by version. */
+  hash_components_version: 1;
+}
+
+export interface StateHashResult {
+  /** 64-bit hex (16 chars) — derived from SHA-256 truncated to first 64 bits. */
+  hash: string;
+  evidence: StateHashEvidence;
+}
+
+/**
+ * Build the canonical evidence object for a snapshot. Pure; no I/O.
+ */
+function buildEvidence(snapshot: PageSnapshot): StateHashEvidence {
+  const { url: url_normalized, droppedParams } = normalizeUrl(snapshot.url);
+
+  // Histogram of interactive tag-paths (only nodes the predicate accepts).
+  const counts = new Map<string, number>();
+  for (const node of snapshot.interactives) {
+    if (!isInteractiveNode(node)) continue;
+    counts.set(node.tagPath, (counts.get(node.tagPath) ?? 0) + 1);
+  }
+  const histogram = [...counts.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+
+  // Stable heading set: trim, collapse whitespace, drop empty, sort, unique.
+  const headingSet = [
+    ...new Set(
+      snapshot.headings
+        .map((h) => h.replace(/\s+/g, ' ').trim())
+        .filter((h) => h.length > 0),
+    ),
+  ].sort();
+
+  // Bitmap of detected landmarks.
+  let bits = 0;
+  LANDMARK_BIT_ORDER.forEach((flag, i) => {
+    if (snapshot.landmarks[flag]) bits |= 1 << i;
+  });
+
+  return {
+    url_normalized,
+    url_dropped_params: droppedParams,
+    interactive_node_count: snapshot.interactives.filter(isInteractiveNode).length,
+    interactive_histogram: histogram,
+    heading_set: headingSet,
+    landmark_flags: bits,
+    hash_components_version: 1,
+  };
+}
+
+/**
+ * Subset of the evidence that contributes to the hash. Diagnostic-only
+ * fields like `url_dropped_params` are excluded so two snapshots that
+ * differ only in tracking-param presence still hash identically.
+ */
+function hashInput(evidence: StateHashEvidence): Record<string, unknown> {
+  // Pick fields explicitly — easier to audit than picking out the omitted ones.
+  return {
+    url_normalized: evidence.url_normalized,
+    interactive_histogram: evidence.interactive_histogram,
+    heading_set: evidence.heading_set,
+    landmark_flags: evidence.landmark_flags,
+    hash_components_version: evidence.hash_components_version,
+  };
+}
+
+/**
+ * Compute a deterministic 64-bit hex hash from the snapshot. The hash is
+ * the first 16 hex chars of SHA-256(canonicalJSON(hashInput(evidence))).
+ * Truncation is acceptable because the value space (potentially infinite
+ * real-world pages) is far smaller than 2^64; collision risk on a
+ * per-domain graph with thousands of nodes is negligible.
+ *
+ * `url_dropped_params` is intentionally NOT part of the hash — it is
+ * diagnostic only.
+ */
+export function computeStateHash(snapshot: PageSnapshot): StateHashResult {
+  const evidence = buildEvidence(snapshot);
+  const canonical = canonicalJson(hashInput(evidence));
+  const sha = crypto.createHash('sha256').update(canonical).digest('hex');
+  return { hash: sha.slice(0, 16), evidence };
+}
+
+/**
+ * Stable JSON: object keys sorted recursively. Arrays preserve order
+ * because the inputs are already sorted by `buildEvidence`.
+ */
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortKeys(value));
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+      out[k] = sortKeys((value as Record<string, unknown>)[k]);
+    }
+    return out;
+  }
+  return value;
+}

--- a/src/skill/storage.ts
+++ b/src/skill/storage.ts
@@ -1,0 +1,444 @@
+/**
+ * Per-domain skill graph storage.
+ *
+ * One SQLite database per domain at `<rootDir>/<domain>.db`. This keeps
+ * concurrent activity on different domains fully independent — only writes
+ * to the same domain serialise via SQLite's WAL + `BEGIN IMMEDIATE`.
+ *
+ * Schema (v1):
+ *   nodes(state_hash PK, evidence_blob, thumbnail_path, last_seen_at,
+ *         visit_count)
+ *   edges(from_state, action_kind, action_args_norm,
+ *         to_state_distribution JSON, success_count, fail_count,
+ *         last_failed_at, PRIMARY KEY(from_state, action_kind, action_args_norm))
+ *
+ * `to_state_distribution` is included from day one (per #702 v2) so
+ * #703's executor can match against a multi-state distribution without
+ * a follow-up migration.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+type BetterSqlite3 = typeof import('better-sqlite3');
+type Database = import('better-sqlite3').Database;
+
+let _Sqlite: BetterSqlite3 | null = null;
+function loadSqlite(): BetterSqlite3 {
+  if (_Sqlite) return _Sqlite;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  _Sqlite = require('better-sqlite3') as BetterSqlite3;
+  return _Sqlite;
+}
+
+const CURRENT_SCHEMA_VERSION = 1;
+
+const SCHEMA_V1 = `
+CREATE TABLE IF NOT EXISTS applied_migrations (
+  version    INTEGER PRIMARY KEY,
+  applied_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS nodes (
+  state_hash     TEXT PRIMARY KEY,
+  evidence_blob  TEXT,            -- JSON
+  thumbnail_path TEXT,
+  last_seen_at   INTEGER NOT NULL,
+  visit_count    INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS edges (
+  from_state            TEXT NOT NULL,
+  action_kind           TEXT NOT NULL,
+  action_args_norm      TEXT NOT NULL,
+  to_state_distribution TEXT NOT NULL DEFAULT '[]',  -- JSON: Array<{to_state, count}>
+  success_count         INTEGER NOT NULL DEFAULT 0,
+  fail_count            INTEGER NOT NULL DEFAULT 0,
+  last_failed_at        INTEGER,
+  PRIMARY KEY (from_state, action_kind, action_args_norm),
+  FOREIGN KEY (from_state) REFERENCES nodes(state_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_edges_from ON edges(from_state);
+`;
+
+/** A row from `nodes`. */
+export interface SkillNode {
+  stateHash: string;
+  evidence?: unknown;
+  thumbnailPath?: string;
+  lastSeenAt: number;
+  visitCount: number;
+}
+
+/** A row from `edges`. */
+export interface SkillEdge {
+  fromState: string;
+  actionKind: string;
+  actionArgsNorm: string;
+  /** Sorted (by count DESC) distribution of observed `to_state` outcomes. */
+  toStateDistribution: ToStateDistribution;
+  successCount: number;
+  failCount: number;
+  lastFailedAt?: number;
+}
+
+export type ToStateDistribution = Array<{ to_state: string; count: number }>;
+
+/** Stats inspect summary returned by `inspect()`. */
+export interface SkillGraphInspectSummary {
+  domain: string;
+  nodeCount: number;
+  edgeCount: number;
+  topEdgesByVisit: Array<{
+    from: string;
+    actionKind: string;
+    successCount: number;
+    failCount: number;
+  }>;
+  recentFailures: Array<{
+    from: string;
+    actionKind: string;
+    failCount: number;
+    lastFailedAt: number;
+  }>;
+}
+
+export interface SkillGraphStorageOptions {
+  rootDir?: string;
+}
+
+/** Default rootDir resolves to `${HOME}/.openchrome/skills`. */
+export function defaultSkillGraphRootDir(): string {
+  return path.join(os.homedir(), '.openchrome', 'skills');
+}
+
+/**
+ * Single-domain handle. Multiple instances against the same `domain` are
+ * safe; writes serialise on the WAL.
+ */
+export class SkillGraphStorage {
+  private readonly rootDir: string;
+  private readonly db: Database;
+  readonly domain: string;
+
+  constructor(domain: string, opts: SkillGraphStorageOptions = {}) {
+    if (!domain || /[\\/]/.test(domain)) {
+      throw new Error(`SkillGraphStorage: invalid domain "${domain}"`);
+    }
+    this.domain = domain;
+    this.rootDir = opts.rootDir ?? defaultSkillGraphRootDir();
+    fs.mkdirSync(this.rootDir, { recursive: true });
+    const Sqlite = loadSqlite();
+    this.db = new Sqlite(path.join(this.rootDir, `${domain}.db`));
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('synchronous = NORMAL');
+    this.applyMigrations();
+  }
+
+  private applyMigrations(): void {
+    this.db.exec(SCHEMA_V1);
+    const applied = (this.db.prepare('SELECT version FROM applied_migrations').all() as { version: number }[])
+      .map((r) => r.version);
+    if (!applied.includes(1)) {
+      this.db
+        .prepare('INSERT INTO applied_migrations (version, applied_at) VALUES (?, ?)')
+        .run(1, Date.now());
+    }
+  }
+
+  getSchemaVersion(): number {
+    return CURRENT_SCHEMA_VERSION;
+  }
+
+  /** Insert or refresh a node. Increments visit_count on every call. */
+  upsertNode(args: {
+    stateHash: string;
+    evidence?: unknown;
+    thumbnailPath?: string;
+    seenAt?: number;
+  }): void {
+    const seenAt = args.seenAt ?? Date.now();
+    this.db
+      .prepare(
+        `INSERT INTO nodes (state_hash, evidence_blob, thumbnail_path, last_seen_at, visit_count)
+         VALUES (?, ?, ?, ?, 1)
+         ON CONFLICT(state_hash) DO UPDATE SET
+           evidence_blob  = COALESCE(excluded.evidence_blob,  evidence_blob),
+           thumbnail_path = COALESCE(excluded.thumbnail_path, thumbnail_path),
+           last_seen_at   = excluded.last_seen_at,
+           visit_count    = visit_count + 1`,
+      )
+      .run(
+        args.stateHash,
+        args.evidence !== undefined ? JSON.stringify(args.evidence) : null,
+        args.thumbnailPath ?? null,
+        seenAt,
+      );
+  }
+
+  /** Look up a node row. Returns undefined if not found. */
+  getNode(stateHash: string): SkillNode | undefined {
+    const row = this.db
+      .prepare(
+        'SELECT state_hash, evidence_blob, thumbnail_path, last_seen_at, visit_count FROM nodes WHERE state_hash = ?',
+      )
+      .get(stateHash) as
+      | {
+          state_hash: string;
+          evidence_blob: string | null;
+          thumbnail_path: string | null;
+          last_seen_at: number;
+          visit_count: number;
+        }
+      | undefined;
+    if (!row) return undefined;
+    return {
+      stateHash: row.state_hash,
+      evidence: row.evidence_blob ? JSON.parse(row.evidence_blob) : undefined,
+      thumbnailPath: row.thumbnail_path ?? undefined,
+      lastSeenAt: row.last_seen_at,
+      visitCount: row.visit_count,
+    };
+  }
+
+  /** Returns all nodes ordered by visit_count DESC. */
+  listNodes(limit = 100): SkillNode[] {
+    const rows = this.db
+      .prepare(
+        'SELECT state_hash, evidence_blob, thumbnail_path, last_seen_at, visit_count FROM nodes ORDER BY visit_count DESC LIMIT ?',
+      )
+      .all(limit) as Array<{
+      state_hash: string;
+      evidence_blob: string | null;
+      thumbnail_path: string | null;
+      last_seen_at: number;
+      visit_count: number;
+    }>;
+    return rows.map((row) => ({
+      stateHash: row.state_hash,
+      evidence: row.evidence_blob ? JSON.parse(row.evidence_blob) : undefined,
+      thumbnailPath: row.thumbnail_path ?? undefined,
+      lastSeenAt: row.last_seen_at,
+      visitCount: row.visit_count,
+    }));
+  }
+
+  /**
+   * Record the outcome of executing an edge: increments success or fail
+   * counters, appends to the to_state distribution, and creates the edge
+   * row if it didn't exist. Atomic via SQLite transaction.
+   *
+   * `observedToState` may be undefined when execution fails before the
+   * page settles (e.g., navigation error). In that case the distribution
+   * is not updated.
+   */
+  recordOutcome(args: {
+    fromState: string;
+    actionKind: string;
+    actionArgsNorm: string;
+    observedToState?: string;
+    success: boolean;
+    at?: number;
+  }): void {
+    const at = args.at ?? Date.now();
+    const tx = this.db.transaction((a: typeof args) => {
+      const existing = this.db
+        .prepare(
+          'SELECT to_state_distribution, success_count, fail_count FROM edges WHERE from_state = ? AND action_kind = ? AND action_args_norm = ?',
+        )
+        .get(a.fromState, a.actionKind, a.actionArgsNorm) as
+        | {
+            to_state_distribution: string;
+            success_count: number;
+            fail_count: number;
+          }
+        | undefined;
+
+      let dist: ToStateDistribution = existing
+        ? (JSON.parse(existing.to_state_distribution) as ToStateDistribution)
+        : [];
+      if (a.observedToState) {
+        const idx = dist.findIndex((entry) => entry.to_state === a.observedToState);
+        if (idx >= 0) {
+          dist[idx].count += 1;
+        } else {
+          dist.push({ to_state: a.observedToState, count: 1 });
+        }
+        // Keep distribution sorted by count DESC for cheap inspection.
+        dist = dist.sort((p, q) => q.count - p.count);
+      }
+
+      if (existing) {
+        this.db
+          .prepare(
+            `UPDATE edges
+               SET to_state_distribution = ?,
+                   success_count = success_count + ?,
+                   fail_count    = fail_count + ?,
+                   last_failed_at = CASE WHEN ? = 0 THEN ? ELSE last_failed_at END
+             WHERE from_state = ? AND action_kind = ? AND action_args_norm = ?`,
+          )
+          .run(
+            JSON.stringify(dist),
+            a.success ? 1 : 0,
+            a.success ? 0 : 1,
+            a.success ? 1 : 0,
+            at,
+            a.fromState,
+            a.actionKind,
+            a.actionArgsNorm,
+          );
+      } else {
+        this.db
+          .prepare(
+            `INSERT INTO edges
+               (from_state, action_kind, action_args_norm, to_state_distribution,
+                success_count, fail_count, last_failed_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?)`,
+          )
+          .run(
+            a.fromState,
+            a.actionKind,
+            a.actionArgsNorm,
+            JSON.stringify(dist),
+            a.success ? 1 : 0,
+            a.success ? 0 : 1,
+            a.success ? null : at,
+          );
+      }
+    });
+    tx(args);
+  }
+
+  /** Look up a single edge row. */
+  getEdge(args: {
+    fromState: string;
+    actionKind: string;
+    actionArgsNorm: string;
+  }): SkillEdge | undefined {
+    const row = this.db
+      .prepare(
+        'SELECT from_state, action_kind, action_args_norm, to_state_distribution, success_count, fail_count, last_failed_at FROM edges WHERE from_state = ? AND action_kind = ? AND action_args_norm = ?',
+      )
+      .get(args.fromState, args.actionKind, args.actionArgsNorm) as
+      | {
+          from_state: string;
+          action_kind: string;
+          action_args_norm: string;
+          to_state_distribution: string;
+          success_count: number;
+          fail_count: number;
+          last_failed_at: number | null;
+        }
+      | undefined;
+    if (!row) return undefined;
+    return {
+      fromState: row.from_state,
+      actionKind: row.action_kind,
+      actionArgsNorm: row.action_args_norm,
+      toStateDistribution: JSON.parse(row.to_state_distribution) as ToStateDistribution,
+      successCount: row.success_count,
+      failCount: row.fail_count,
+      lastFailedAt: row.last_failed_at ?? undefined,
+    };
+  }
+
+  /**
+   * All edges leaving the given state, ordered by historical success rate
+   * (success / (success+fail)) DESC, with raw success_count as tiebreaker.
+   * Used by the executor (#703) to pick the best next action.
+   */
+  edgesFrom(stateHash: string): SkillEdge[] {
+    const rows = this.db
+      .prepare(
+        'SELECT from_state, action_kind, action_args_norm, to_state_distribution, success_count, fail_count, last_failed_at FROM edges WHERE from_state = ?',
+      )
+      .all(stateHash) as Array<{
+      from_state: string;
+      action_kind: string;
+      action_args_norm: string;
+      to_state_distribution: string;
+      success_count: number;
+      fail_count: number;
+      last_failed_at: number | null;
+    }>;
+    const edges: SkillEdge[] = rows.map((row) => ({
+      fromState: row.from_state,
+      actionKind: row.action_kind,
+      actionArgsNorm: row.action_args_norm,
+      toStateDistribution: JSON.parse(row.to_state_distribution) as ToStateDistribution,
+      successCount: row.success_count,
+      failCount: row.fail_count,
+      lastFailedAt: row.last_failed_at ?? undefined,
+    }));
+    edges.sort((a, b) => {
+      const ar = successRate(a);
+      const br = successRate(b);
+      if (ar !== br) return br - ar;
+      return b.successCount - a.successCount;
+    });
+    return edges;
+  }
+
+  /**
+   * Diagnostic snapshot consumed by `oc skill inspect` (PR-3) or any
+   * programmatic UI. Cheap to compute — single aggregate queries.
+   */
+  inspect(): SkillGraphInspectSummary {
+    const nodeCount = (this.db.prepare('SELECT COUNT(*) AS n FROM nodes').get() as { n: number }).n;
+    const edgeCount = (this.db.prepare('SELECT COUNT(*) AS n FROM edges').get() as { n: number }).n;
+    const topRows = this.db
+      .prepare(
+        'SELECT from_state, action_kind, success_count, fail_count FROM edges ORDER BY success_count + fail_count DESC LIMIT 10',
+      )
+      .all() as Array<{
+      from_state: string;
+      action_kind: string;
+      success_count: number;
+      fail_count: number;
+    }>;
+    const failingRows = this.db
+      .prepare(
+        'SELECT from_state, action_kind, fail_count, last_failed_at FROM edges WHERE last_failed_at IS NOT NULL ORDER BY last_failed_at DESC LIMIT 10',
+      )
+      .all() as Array<{
+      from_state: string;
+      action_kind: string;
+      fail_count: number;
+      last_failed_at: number;
+    }>;
+    return {
+      domain: this.domain,
+      nodeCount,
+      edgeCount,
+      topEdgesByVisit: topRows.map((r) => ({
+        from: r.from_state,
+        actionKind: r.action_kind,
+        successCount: r.success_count,
+        failCount: r.fail_count,
+      })),
+      recentFailures: failingRows.map((r) => ({
+        from: r.from_state,
+        actionKind: r.action_kind,
+        failCount: r.fail_count,
+        lastFailedAt: r.last_failed_at,
+      })),
+    };
+  }
+
+  close(): void {
+    try {
+      this.db.close();
+    } catch {
+      // already closed
+    }
+  }
+}
+
+function successRate(e: SkillEdge): number {
+  const total = e.successCount + e.failCount;
+  if (total === 0) return 0;
+  return e.successCount / total;
+}

--- a/src/skill/url-normalizer.ts
+++ b/src/skill/url-normalizer.ts
@@ -1,0 +1,78 @@
+/**
+ * URL normalization for state-hash inputs and skill-graph keys.
+ *
+ * Two pages with the same logical state should produce the same normalized
+ * URL. We strip tracking params (utm_*, fbclid, …) and stable-sort the
+ * remaining query keys; host is lowercased; hash fragment is dropped
+ * because it never affects server-rendered state.
+ *
+ * The denylist is conservative — only well-known tracking params. Site-
+ * specific params that look like tracking but actually carry state (Amazon
+ * `pd_rd_*` is debatable but commonly noise) get a regex match. Add new
+ * patterns here as we learn from real fixtures (#702 v2 capture procedure).
+ */
+
+export const TRACKING_PARAM_PATTERNS: RegExp[] = [
+  /^utm_/i,
+  /^fbclid$/i,
+  /^gclid$/i,
+  /^msclkid$/i,
+  /^ref$/i,
+  /^tag$/i,
+  /^pd_rd_/i,
+  /^_encoding$/i,
+  /^psc$/i,
+  /^_branch_match_id$/i,
+  /^mc_eid$/i,
+  /^mc_cid$/i,
+  /^_ke$/i,
+  /^trk$/i,
+  /^source$/i,
+];
+
+export interface NormalizeUrlResult {
+  /** The normalized URL string. */
+  url: string;
+  /** Tracking params that were stripped (sorted by name, useful for evidence). */
+  droppedParams: string[];
+}
+
+/**
+ * Normalize a URL string for hashing/equality:
+ * - lowercase the host (paths are case-sensitive on most servers; we leave them alone)
+ * - drop hash fragment
+ * - drop tracking params matching `TRACKING_PARAM_PATTERNS`
+ * - stable-sort remaining query keys
+ *
+ * Throws if the input does not parse as a URL — callers should pre-validate.
+ */
+export function normalizeUrl(input: string): NormalizeUrlResult {
+  const u = new URL(input);
+  // Lowercase host only (preserve path case)
+  u.hostname = u.hostname.toLowerCase();
+  u.hash = '';
+
+  const dropped: string[] = [];
+  const kept: [string, string][] = [];
+  for (const [k, v] of u.searchParams.entries()) {
+    if (TRACKING_PARAM_PATTERNS.some((re) => re.test(k))) {
+      dropped.push(k);
+    } else {
+      kept.push([k, v]);
+    }
+  }
+
+  // Stable-sort by key, then value, so the same logical params produce the
+  // same string regardless of authoring order.
+  kept.sort(([ak, av], [bk, bv]) => {
+    if (ak !== bk) return ak < bk ? -1 : 1;
+    return av < bv ? -1 : av > bv ? 1 : 0;
+  });
+
+  // Rebuild search string deterministically.
+  const search = new URLSearchParams();
+  for (const [k, v] of kept) search.append(k, v);
+  u.search = search.toString();
+
+  return { url: u.toString(), droppedParams: dropped.sort() };
+}

--- a/src/trace/index.ts
+++ b/src/trace/index.ts
@@ -9,6 +9,18 @@
 export { TraceStorage, defaultTraceRootDir } from './storage';
 export type { AppendResult, TraceStorageOptions } from './storage';
 
+export {
+  TraceRecorder,
+  getTraceRecorder,
+  DEFAULT_TRACE_KINDS,
+  _resetTraceRecorderForTests,
+} from './recorder';
+export type {
+  EventEmitterLike,
+  PageLike,
+  TraceRecorderOptions,
+} from './recorder';
+
 export { redactTraceEvent, redactValue, scrubString, REDACTED } from './redactor';
 
 export type {

--- a/src/trace/recorder.ts
+++ b/src/trace/recorder.ts
@@ -1,0 +1,292 @@
+/**
+ * Session trace recorder.
+ *
+ * Subscribes to CDP events on a per-session CDPSession (typically owned by
+ * one Page), buffers them in memory, and flushes JSONL files to disk via
+ * `TraceStorage`. A small ring buffer means the steady-state memory cost is
+ * bounded; a periodic timer + capacity threshold + page-navigation event +
+ * shutdown handler ensure timely flushes without blocking the hot path.
+ *
+ * Default-off: callers must opt in via `OPENCHROME_TRACE=1` (or by passing
+ * `enabled: true` to the constructor). When disabled, the recorder is a
+ * no-op and pays zero CPU.
+ *
+ * The recorder is intentionally decoupled from the broader CDPClient
+ * lifecycle — it speaks only to the minimal `EventEmitterLike` interface
+ * declared below, which both puppeteer's CDPSession and a unit-test fake
+ * satisfy.
+ */
+
+import { redactTraceEvent } from './redactor';
+import { TraceStorage, defaultTraceRootDir } from './storage';
+import type { TraceEvent, TraceSessionMeta, TraceStatus } from './types';
+
+/** Subset of EventEmitter we rely on. */
+export interface EventEmitterLike {
+  on(event: string, listener: (...args: unknown[]) => void): unknown;
+  off?(event: string, listener: (...args: unknown[]) => void): unknown;
+  removeListener?(event: string, listener: (...args: unknown[]) => void): unknown;
+}
+
+/** Subset of puppeteer's Page we rely on for `framenavigated`. Optional. */
+export interface PageLike {
+  on(event: string, listener: (...args: unknown[]) => void): unknown;
+}
+
+export interface TraceRecorderOptions {
+  storage?: TraceStorage;
+  /** Capacity of the in-memory ring buffer per session (default 500). */
+  bufferSize?: number;
+  /** Periodic flush interval in ms (default 30_000). */
+  flushIntervalMs?: number;
+  /** Fractional capacity at which a flush is forced (default 0.8). */
+  capacityFlushRatio?: number;
+  /** When false, every public method is a no-op. */
+  enabled?: boolean;
+  /** Inject a clock for tests. */
+  now?: () => number;
+}
+
+/** CDP method names the recorder subscribes to by default. */
+export const DEFAULT_TRACE_KINDS = [
+  'Page.frameNavigated',
+  'Page.loadEventFired',
+  'Network.responseReceived',
+  'Runtime.consoleAPICalled',
+  'DOM.documentUpdated',
+] as const;
+
+interface SessionState {
+  meta: TraceSessionMeta;
+  buffer: TraceEvent[];
+  seqCounter: number;
+  /** CDP session attached for this recording session, if any. */
+  cdp?: EventEmitterLike;
+  /** Page attached for this recording session, if any. */
+  page?: PageLike;
+  /** Per-CDP-event listener registrations so we can detach cleanly. */
+  cdpListeners: Array<{ kind: string; fn: (...args: unknown[]) => void }>;
+  /** Page listener registration. */
+  pageListener?: { event: string; fn: (...args: unknown[]) => void };
+  /** Periodic flush timer. */
+  timer?: NodeJS.Timeout;
+}
+
+export class TraceRecorder {
+  private readonly storage: TraceStorage;
+  private readonly bufferSize: number;
+  private readonly flushIntervalMs: number;
+  private readonly capacityFlushRatio: number;
+  private readonly enabled: boolean;
+  private readonly now: () => number;
+  private readonly sessions = new Map<string, SessionState>();
+
+  constructor(opts: TraceRecorderOptions = {}) {
+    this.storage = opts.storage ?? new TraceStorage({ rootDir: defaultTraceRootDir() });
+    this.bufferSize = Math.max(1, opts.bufferSize ?? envInt('OPENCHROME_TRACE_BUFFER', 500));
+    this.flushIntervalMs = Math.max(
+      100,
+      opts.flushIntervalMs ?? envInt('OPENCHROME_TRACE_FLUSH_MS', 30_000),
+    );
+    this.capacityFlushRatio = clamp(opts.capacityFlushRatio ?? 0.8, 0.1, 1.0);
+    this.enabled =
+      opts.enabled ??
+      (process.env.OPENCHROME_TRACE === '1' || process.env.OPENCHROME_TRACE === 'on');
+    this.now = opts.now ?? Date.now;
+  }
+
+  /** True when the recorder will actually capture events. */
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /**
+   * Begin a recording session. Subsequent `recordEvent` / CDP-attached
+   * events will be buffered under this session id. Idempotent — calling
+   * twice with the same id refreshes meta but preserves the buffer.
+   */
+  start(meta: Omit<TraceSessionMeta, 'status' | 'byteSize'> & { status?: TraceStatus }): void {
+    if (!this.enabled) return;
+    const status: TraceStatus = meta.status ?? 'running';
+    const existing = this.sessions.get(meta.sessionId);
+    if (existing) {
+      existing.meta = { ...existing.meta, ...meta, status, byteSize: existing.meta.byteSize };
+      this.storage.recordSessionStart(existing.meta);
+      return;
+    }
+    const fullMeta: TraceSessionMeta = {
+      sessionId: meta.sessionId,
+      startedAt: meta.startedAt,
+      domain: meta.domain,
+      parentOp: meta.parentOp,
+      status,
+      byteSize: 0,
+    };
+    this.storage.recordSessionStart(fullMeta);
+    const state: SessionState = {
+      meta: fullMeta,
+      buffer: [],
+      seqCounter: 0,
+      cdpListeners: [],
+    };
+    state.timer = setInterval(() => {
+      void this.flush(meta.sessionId);
+    }, this.flushIntervalMs);
+    if (typeof state.timer.unref === 'function') state.timer.unref();
+    this.sessions.set(meta.sessionId, state);
+  }
+
+  /**
+   * Attach the recorder to a CDPSession-like emitter. Listeners are
+   * registered for each `kinds` entry; when `page` is supplied, we also
+   * trigger a flush on `framenavigated` (matching the v2 flush policy).
+   */
+  attach(
+    sessionId: string,
+    cdp: EventEmitterLike,
+    page?: PageLike,
+    opts: { kinds?: readonly string[] } = {},
+  ): void {
+    if (!this.enabled) return;
+    const state = this.sessions.get(sessionId);
+    if (!state) {
+      throw new Error(`TraceRecorder.attach: unknown session "${sessionId}". Call start() first.`);
+    }
+    if (state.cdp) {
+      throw new Error(`TraceRecorder.attach: session "${sessionId}" already attached.`);
+    }
+    state.cdp = cdp;
+    const kinds = opts.kinds ?? DEFAULT_TRACE_KINDS;
+    for (const kind of kinds) {
+      const fn = (...args: unknown[]): void => {
+        const body = args.length === 1 ? args[0] : args;
+        this.recordEvent(sessionId, kind, body);
+      };
+      cdp.on(kind, fn);
+      state.cdpListeners.push({ kind, fn });
+    }
+    if (page) {
+      state.page = page;
+      const navListener = (): void => {
+        // Flush on each navigation boundary so per-URL slices land in
+        // distinct files (helpful for replay / time-travel).
+        void this.flush(sessionId);
+      };
+      page.on('framenavigated', navListener);
+      state.pageListener = { event: 'framenavigated', fn: navListener };
+    }
+  }
+
+  /**
+   * Append a synthetic event to the session buffer (e.g., tool_call,
+   * screenshot, contract verdict). Triggers a capacity flush if the
+   * buffer crosses the configured fill ratio.
+   */
+  recordEvent(sessionId: string, kind: string, body: unknown): void {
+    if (!this.enabled) return;
+    const state = this.sessions.get(sessionId);
+    if (!state) return; // silently drop — recorder may have been ended
+    const event: TraceEvent = {
+      ts: this.now(),
+      seq: ++state.seqCounter,
+      kind,
+      body,
+    };
+    state.buffer.push(redactTraceEvent(event));
+    // Drop oldest if we somehow exceed the cap (shouldn't happen with
+    // capacity flush, but provides a hard safety net).
+    while (state.buffer.length > this.bufferSize) {
+      state.buffer.shift();
+    }
+    if (state.buffer.length >= Math.ceil(this.bufferSize * this.capacityFlushRatio)) {
+      void this.flush(sessionId);
+    }
+  }
+
+  /** Force-flush the in-memory buffer to disk for a session. */
+  async flush(sessionId: string): Promise<void> {
+    if (!this.enabled) return;
+    const state = this.sessions.get(sessionId);
+    if (!state || state.buffer.length === 0) return;
+    const batch = state.buffer.splice(0, state.buffer.length);
+    const result = this.storage.appendEvents(sessionId, batch);
+    state.meta.byteSize += result.bytes;
+  }
+
+  /**
+   * Finalize a session: flush remaining buffer, detach listeners, clear
+   * the periodic timer, and write the terminal status to the index.
+   */
+  async end(sessionId: string, status: TraceStatus = 'completed'): Promise<void> {
+    if (!this.enabled) return;
+    const state = this.sessions.get(sessionId);
+    if (!state) return;
+    await this.flush(sessionId);
+    if (state.cdp) {
+      for (const { kind, fn } of state.cdpListeners) {
+        const off = state.cdp.off ?? state.cdp.removeListener;
+        if (off) off.call(state.cdp, kind, fn);
+      }
+    }
+    if (state.page && state.pageListener) {
+      // Page may not have an off(); use removeListener fallback when present.
+      const pageOff = (state.page as unknown as { off?: typeof state.page.on; removeListener?: typeof state.page.on }).off
+        ?? (state.page as unknown as { removeListener?: typeof state.page.on }).removeListener;
+      if (pageOff) pageOff.call(state.page, state.pageListener.event, state.pageListener.fn);
+    }
+    if (state.timer) clearInterval(state.timer);
+    this.storage.recordSessionEnd(sessionId, {
+      endedAt: this.now(),
+      status,
+      byteSize: state.meta.byteSize,
+    });
+    this.sessions.delete(sessionId);
+  }
+
+  /**
+   * Flush + end every active session. Intended to be wired to process
+   * `beforeExit` / SIGTERM by the host so traces survive a clean shutdown.
+   */
+  async shutdown(status: TraceStatus = 'aborted'): Promise<void> {
+    const ids = [...this.sessions.keys()];
+    for (const id of ids) {
+      try {
+        await this.end(id, status);
+      } catch {
+        // best-effort during shutdown
+      }
+    }
+  }
+
+  /** For tests: peek at the in-memory buffer without flushing. */
+  _peekBuffer(sessionId: string): TraceEvent[] {
+    return this.sessions.get(sessionId)?.buffer.slice() ?? [];
+  }
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, v));
+}
+
+let _global: TraceRecorder | null = null;
+/**
+ * Process-wide singleton. The first call decides options; subsequent calls
+ * return the same instance regardless of arguments. Hosts that need
+ * per-test isolation should construct `new TraceRecorder({...})` directly.
+ */
+export function getTraceRecorder(opts?: TraceRecorderOptions): TraceRecorder {
+  if (!_global) _global = new TraceRecorder(opts);
+  return _global;
+}
+
+/** Test-only: reset the global singleton. */
+export function _resetTraceRecorderForTests(): void {
+  _global = null;
+}

--- a/tests/skill/executor.test.ts
+++ b/tests/skill/executor.test.ts
@@ -1,0 +1,308 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  pickBestEdge,
+  matchesExpected,
+  runSkill,
+  _matchesExpectedRaw,
+  type ActionInvocation,
+  type ExecutionContext,
+  type ToolRouter,
+  type SkillIntent,
+} from '../../src/skill/executor';
+import { SkillGraphStorage, type SkillEdge } from '../../src/skill/storage';
+import type { PageSnapshot } from '../../src/skill/state';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-exec-'));
+}
+
+function emptyEdge(over: Partial<SkillEdge> = {}): SkillEdge {
+  return {
+    fromState: 'a',
+    actionKind: 'click',
+    actionArgsNorm: 'x',
+    toStateDistribution: [],
+    successCount: 0,
+    failCount: 0,
+    ...over,
+  };
+}
+
+function snap(over: Partial<PageSnapshot> = {}): PageSnapshot {
+  return {
+    url: 'https://example.com/',
+    interactives: [{ tagName: 'button', tagPath: 'body>button', role: 'button' }],
+    headings: [],
+    landmarks: {},
+    ...over,
+  };
+}
+
+describe('matchesExpected — distribution math (#703 v2 rules)', () => {
+  test('total < 10, hash present at any count → match', () => {
+    expect(_matchesExpectedRaw('A', [{ to_state: 'A', count: 1 }], 0)).toBe(true);
+    expect(_matchesExpectedRaw('A', [{ to_state: 'A', count: 1 }, { to_state: 'B', count: 1 }], 0)).toBe(true);
+  });
+
+  test('total < 10, hash absent, no failures → match (first observation)', () => {
+    expect(_matchesExpectedRaw('NEW', [{ to_state: 'A', count: 5 }], 0)).toBe(true);
+  });
+
+  test('total < 10, hash absent, has failures → no match', () => {
+    expect(_matchesExpectedRaw('NEW', [{ to_state: 'A', count: 5 }], 1)).toBe(false);
+  });
+
+  test('total >= 10, hash count >= 10% → match', () => {
+    // 1/10 = 10% exactly → match
+    const dist = [
+      { to_state: 'A', count: 9 },
+      { to_state: 'B', count: 1 },
+    ];
+    expect(_matchesExpectedRaw('B', dist, 0)).toBe(true);
+  });
+
+  test('total >= 10, hash count < 10% → no match', () => {
+    // 1/15 = 6.7% < 10%
+    const dist = [
+      { to_state: 'A', count: 14 },
+      { to_state: 'B', count: 1 },
+    ];
+    expect(_matchesExpectedRaw('B', dist, 0)).toBe(false);
+  });
+
+  test('total >= 10, hash absent → no match (no longer "fresh observation")', () => {
+    expect(_matchesExpectedRaw('NEW', [{ to_state: 'A', count: 10 }], 0)).toBe(false);
+  });
+
+  test('matchesExpected accepts SkillEdge form', () => {
+    const edge = emptyEdge({
+      toStateDistribution: [{ to_state: 'A', count: 1 }],
+    });
+    expect(matchesExpected('A', edge)).toBe(true);
+  });
+});
+
+describe('pickBestEdge — selection', () => {
+  test('returns first edge when no allowedKinds filter', () => {
+    const edges: SkillEdge[] = [emptyEdge({ actionKind: 'click' }), emptyEdge({ actionKind: 'type' })];
+    expect(pickBestEdge(edges, {})?.actionKind).toBe('click');
+  });
+
+  test('respects allowedKinds (skips disallowed)', () => {
+    const edges: SkillEdge[] = [
+      emptyEdge({ actionKind: 'navigate' }),
+      emptyEdge({ actionKind: 'click' }),
+    ];
+    const intent: SkillIntent = { allowedKinds: ['click'] };
+    expect(pickBestEdge(edges, intent)?.actionKind).toBe('click');
+  });
+
+  test('returns undefined when no edge matches the intent filter', () => {
+    const edges: SkillEdge[] = [emptyEdge({ actionKind: 'navigate' })];
+    expect(pickBestEdge(edges, { allowedKinds: ['click'] })).toBeUndefined();
+  });
+
+  test('returns undefined for empty edge list', () => {
+    expect(pickBestEdge([], {})).toBeUndefined();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* Mock router for runSkill scenarios                                  */
+/* ------------------------------------------------------------------ */
+
+interface RouterScript {
+  /** Action returned by pickFallbackAction. null = no action. */
+  fallback?: ActionInvocation | null;
+  /** Observed result for runAction(). */
+  result?: { ok: boolean; reason?: string };
+}
+
+function mockRouter(script: RouterScript = {}): ToolRouter {
+  return {
+    async pickFallbackAction() {
+      return script.fallback ?? null;
+    },
+    async runAction() {
+      return { ok: script.result?.ok ?? true, reason: script.result?.reason };
+    },
+  };
+}
+
+function ctxWithStates(seq: PageSnapshot[]): ExecutionContext {
+  let i = 0;
+  return {
+    async snapshotPageState() {
+      const next = seq[Math.min(i, seq.length - 1)];
+      i += 1;
+      return next;
+    },
+  };
+}
+
+describe('runSkill — graph hit path', () => {
+  let root: string;
+  let storage: SkillGraphStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    storage = new SkillGraphStorage('x.com', { rootDir: root });
+  });
+
+  afterEach(() => {
+    storage.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('uses graph edge when one exists for the current state', async () => {
+    // Seed graph: from-hash → action → to-hash with one prior success
+    const before = snap({ url: 'https://x.com/a' });
+    const after = snap({ url: 'https://x.com/b' });
+
+    // Determine the actual hashes the executor will compute
+    const { computeStateHash } = await import('../../src/skill/state');
+    const fromHash = computeStateHash(before).hash;
+    const toHash = computeStateHash(after).hash;
+
+    storage.upsertNode({ stateHash: fromHash });
+    storage.upsertNode({ stateHash: toHash });
+    storage.recordOutcome({
+      fromState: fromHash,
+      actionKind: 'click',
+      actionArgsNorm: 'ref:a',
+      observedToState: toHash,
+      success: true,
+    });
+
+    const router = mockRouter({ result: { ok: true } });
+    const ctx = ctxWithStates([before, after]);
+    const result = await runSkill({ storage, router, ctx, intent: {} });
+
+    expect(result.outcome).toBe('graph_hit');
+    expect(result.ok).toBe(true);
+    expect(result.matchedExpected).toBe(true);
+    expect(result.fromState).toBe(fromHash);
+    expect(result.toState).toBe(toHash);
+    expect(result.action?.kind).toBe('click');
+  });
+
+  test('action runs but lands on unexpected state → reports expected_state_mismatch', async () => {
+    const before = snap({ url: 'https://x.com/a' });
+    const expected = snap({ url: 'https://x.com/b' });
+    const actual = snap({ url: 'https://x.com/c' }); // != expected
+
+    const { computeStateHash } = await import('../../src/skill/state');
+    const fromHash = computeStateHash(before).hash;
+    const expectedHash = computeStateHash(expected).hash;
+
+    storage.upsertNode({ stateHash: fromHash });
+    storage.upsertNode({ stateHash: expectedHash });
+    // Seed enough successes to push total >= 10, so absent → no match
+    for (let i = 0; i < 11; i++) {
+      storage.recordOutcome({
+        fromState: fromHash,
+        actionKind: 'click',
+        actionArgsNorm: 'ref:a',
+        observedToState: expectedHash,
+        success: true,
+      });
+    }
+
+    const router = mockRouter({ result: { ok: true } });
+    const ctx = ctxWithStates([before, actual]);
+    const result = await runSkill({ storage, router, ctx, intent: {} });
+
+    expect(result.outcome).toBe('graph_hit');
+    expect(result.ok).toBe(false);
+    expect(result.matchedExpected).toBe(false);
+    expect(result.reason).toBe('expected_state_mismatch');
+  });
+});
+
+describe('runSkill — fallback / graph miss path', () => {
+  let root: string;
+  let storage: SkillGraphStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    storage = new SkillGraphStorage('x.com', { rootDir: root });
+  });
+
+  afterEach(() => {
+    storage.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('graph miss → fallback action succeeds → promotes to graph', async () => {
+    const before = snap({ url: 'https://x.com/a' });
+    const after = snap({ url: 'https://x.com/b' });
+
+    const { computeStateHash } = await import('../../src/skill/state');
+    const fromHash = computeStateHash(before).hash;
+    const toHash = computeStateHash(after).hash;
+
+    const router = mockRouter({
+      fallback: { kind: 'click', argsNorm: 'ref:fallback', args: { ref: 'a' } },
+      result: { ok: true },
+    });
+    const ctx = ctxWithStates([before, after]);
+    const result = await runSkill({ storage, router, ctx, intent: {} });
+
+    expect(result.outcome).toBe('graph_fallback_promoted');
+    expect(result.ok).toBe(true);
+    expect(result.action?.argsNorm).toBe('ref:fallback');
+
+    // Verify it was actually written to the graph
+    const promoted = storage.getEdge({
+      fromState: fromHash,
+      actionKind: 'click',
+      actionArgsNorm: 'ref:fallback',
+    });
+    expect(promoted).toBeDefined();
+    expect(promoted?.successCount).toBe(1);
+    expect(promoted?.toStateDistribution).toEqual([{ to_state: toHash, count: 1 }]);
+  });
+
+  test('graph miss → no fallback available → returns no_action_available', async () => {
+    const ctx = ctxWithStates([snap()]);
+    const router = mockRouter({ fallback: null });
+    const result = await runSkill({ storage, router, ctx, intent: {} });
+
+    expect(result.outcome).toBe('graph_miss');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('no_action_available');
+  });
+
+  test('graph miss → fallback runs but fails → records negative edge, no promotion', async () => {
+    const before = snap({ url: 'https://x.com/a' });
+    const after = snap({ url: 'https://x.com/a' }); // unchanged
+
+    const { computeStateHash } = await import('../../src/skill/state');
+    const fromHash = computeStateHash(before).hash;
+
+    const router = mockRouter({
+      fallback: { kind: 'click', argsNorm: 'ref:bad', args: {} },
+      result: { ok: false, reason: 'element_not_found' },
+    });
+    const ctx = ctxWithStates([before, after]);
+    const result = await runSkill({ storage, router, ctx, intent: {} });
+
+    expect(result.outcome).toBe('graph_miss');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('element_not_found');
+
+    const negative = storage.getEdge({
+      fromState: fromHash,
+      actionKind: 'click',
+      actionArgsNorm: 'ref:bad',
+    });
+    expect(negative).toBeDefined();
+    expect(negative?.failCount).toBe(1);
+    expect(negative?.successCount).toBe(0);
+    // No to_state recorded for failures without observed transition
+    expect(negative?.toStateDistribution).toEqual([]);
+  });
+});

--- a/tests/skill/state.test.ts
+++ b/tests/skill/state.test.ts
@@ -1,0 +1,144 @@
+import {
+  computeStateHash,
+  canonicalJson,
+  type PageSnapshot,
+} from '../../src/skill/state';
+
+function snap(over: Partial<PageSnapshot> = {}): PageSnapshot {
+  return {
+    url: 'https://amazon.com/cart',
+    interactives: [
+      { tagName: 'button', tagPath: 'body>div>button', role: 'button' },
+      { tagName: 'a', tagPath: 'body>nav>a', hasHref: true },
+      { tagName: 'input', tagPath: 'body>form>input' },
+    ],
+    headings: ['Your Shopping Cart'],
+    landmarks: { cartBadge: true },
+    ...over,
+  };
+}
+
+describe('computeStateHash — determinism', () => {
+  test('identical snapshots produce identical hashes', () => {
+    const a = computeStateHash(snap());
+    const b = computeStateHash(snap());
+    expect(a.hash).toBe(b.hash);
+  });
+
+  test('hash is 16 hex chars (64-bit truncated SHA-256)', () => {
+    const r = computeStateHash(snap());
+    expect(r.hash).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test('reordering interactive elements does not change the hash', () => {
+    const a = computeStateHash(
+      snap({
+        interactives: [
+          { tagName: 'a', tagPath: 'body>nav>a', hasHref: true },
+          { tagName: 'button', tagPath: 'body>div>button', role: 'button' },
+        ],
+      }),
+    );
+    const b = computeStateHash(
+      snap({
+        interactives: [
+          { tagName: 'button', tagPath: 'body>div>button', role: 'button' },
+          { tagName: 'a', tagPath: 'body>nav>a', hasHref: true },
+        ],
+      }),
+    );
+    expect(a.hash).toBe(b.hash);
+  });
+
+  test('reordering headings does not change the hash', () => {
+    const a = computeStateHash(snap({ headings: ['One', 'Two'] }));
+    const b = computeStateHash(snap({ headings: ['Two', 'One'] }));
+    expect(a.hash).toBe(b.hash);
+  });
+
+  test('utm_ params do not affect the hash (URL normalization)', () => {
+    const a = computeStateHash(snap({ url: 'https://amazon.com/cart' }));
+    const b = computeStateHash(snap({ url: 'https://amazon.com/cart?utm_source=email' }));
+    expect(a.hash).toBe(b.hash);
+  });
+});
+
+describe('computeStateHash — sensitivity', () => {
+  test('logged-in vs logged-out (loginForm landmark) produce different hashes', () => {
+    const out = computeStateHash(snap({ landmarks: { loginForm: true } }));
+    const inn = computeStateHash(snap({ landmarks: {} }));
+    expect(out.hash).not.toBe(inn.hash);
+  });
+
+  test('empty cart vs has-item (cartBadge landmark) differ', () => {
+    const empty = computeStateHash(snap({ landmarks: {} }));
+    const has = computeStateHash(snap({ landmarks: { cartBadge: true } }));
+    expect(empty.hash).not.toBe(has.hash);
+  });
+
+  test('different URL paths produce different hashes', () => {
+    const a = computeStateHash(snap({ url: 'https://amazon.com/cart' }));
+    const b = computeStateHash(snap({ url: 'https://amazon.com/checkout' }));
+    expect(a.hash).not.toBe(b.hash);
+  });
+
+  test('captcha challenge bit flips the hash', () => {
+    const a = computeStateHash(snap({ landmarks: { cartBadge: true } }));
+    const b = computeStateHash(snap({ landmarks: { cartBadge: true, captchaChallenge: true } }));
+    expect(a.hash).not.toBe(b.hash);
+  });
+});
+
+describe('computeStateHash — evidence object', () => {
+  test('evidence carries normalized URL and dropped params', () => {
+    const r = computeStateHash(snap({ url: 'https://amazon.com/cart?utm_source=x&q=1' }));
+    expect(r.evidence.url_normalized).toBe('https://amazon.com/cart?q=1');
+    expect(r.evidence.url_dropped_params).toEqual(['utm_source']);
+  });
+
+  test('evidence interactive_histogram is sorted by tag-path', () => {
+    const r = computeStateHash(snap());
+    const paths = r.evidence.interactive_histogram.map(([p]) => p);
+    expect(paths).toEqual([...paths].sort());
+  });
+
+  test('evidence heading_set is unique + sorted', () => {
+    const r = computeStateHash(snap({ headings: ['B', 'A', 'B', '  '] }));
+    expect(r.evidence.heading_set).toEqual(['A', 'B']);
+  });
+
+  test('evidence landmark_flags is a 5-bit bitmap', () => {
+    const r = computeStateHash(
+      snap({ landmarks: { loginForm: true, captchaChallenge: true } }),
+    );
+    // Bit order: loginForm=0, paymentFields=1, cartBadge=2, modalOverlay=3, captcha=4
+    expect(r.evidence.landmark_flags).toBe(0b10001);
+  });
+
+  test('hash_components_version is set to 1', () => {
+    expect(computeStateHash(snap()).evidence.hash_components_version).toBe(1);
+  });
+
+  test('non-interactive elements (e.g. role=heading) do not contribute', () => {
+    const r = computeStateHash(
+      snap({
+        interactives: [
+          { tagName: 'div', tagPath: 'body>div', role: 'heading' },
+          { tagName: 'a', tagPath: 'body>a', hasHref: true },
+        ],
+      }),
+    );
+    expect(r.evidence.interactive_node_count).toBe(1);
+  });
+});
+
+describe('canonicalJson — key sorting', () => {
+  test('sorts object keys recursively', () => {
+    const out = canonicalJson({ b: 2, a: { z: 1, y: 2 } });
+    expect(out).toBe('{"a":{"y":2,"z":1},"b":2}');
+  });
+
+  test('preserves array order', () => {
+    expect(canonicalJson([3, 1, 2])).toBe('[3,1,2]');
+  });
+});

--- a/tests/skill/storage.test.ts
+++ b/tests/skill/storage.test.ts
@@ -1,0 +1,274 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { SkillGraphStorage } from '../../src/skill/storage';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-skill-'));
+}
+
+describe('SkillGraphStorage — schema and lifecycle', () => {
+  let root: string;
+  let store: SkillGraphStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    store = new SkillGraphStorage('amazon.com', { rootDir: root });
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('creates per-domain DB at <rootDir>/<domain>.db', () => {
+    expect(fs.existsSync(path.join(root, 'amazon.com.db'))).toBe(true);
+  });
+
+  test('schema version is 1', () => {
+    expect(store.getSchemaVersion()).toBe(1);
+  });
+
+  test('reopening on the same domain is a no-op (idempotent migrations)', () => {
+    store.close();
+    expect(() => {
+      const second = new SkillGraphStorage('amazon.com', { rootDir: root });
+      second.close();
+    }).not.toThrow();
+    store = new SkillGraphStorage('amazon.com', { rootDir: root });
+  });
+
+  test('rejects domains with path separators', () => {
+    expect(() => new SkillGraphStorage('a/b', { rootDir: root })).toThrow();
+    expect(() => new SkillGraphStorage('a\\b', { rootDir: root })).toThrow();
+  });
+});
+
+describe('SkillGraphStorage — nodes', () => {
+  let root: string;
+  let store: SkillGraphStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    store = new SkillGraphStorage('x.com', { rootDir: root });
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('upsertNode inserts a new row with visit_count=1', () => {
+    store.upsertNode({ stateHash: 'aaaa', seenAt: 100, evidence: { url: 'https://x' } });
+    const node = store.getNode('aaaa');
+    expect(node).toBeDefined();
+    expect(node?.visitCount).toBe(1);
+    expect(node?.lastSeenAt).toBe(100);
+    expect(node?.evidence).toEqual({ url: 'https://x' });
+  });
+
+  test('upsertNode increments visit_count on subsequent calls', () => {
+    store.upsertNode({ stateHash: 'a', seenAt: 100 });
+    store.upsertNode({ stateHash: 'a', seenAt: 200 });
+    store.upsertNode({ stateHash: 'a', seenAt: 300 });
+    const node = store.getNode('a');
+    expect(node?.visitCount).toBe(3);
+    expect(node?.lastSeenAt).toBe(300);
+  });
+
+  test('upsertNode preserves prior evidence when next call omits it', () => {
+    store.upsertNode({ stateHash: 'a', evidence: { kept: true } });
+    store.upsertNode({ stateHash: 'a' });
+    expect(store.getNode('a')?.evidence).toEqual({ kept: true });
+  });
+
+  test('listNodes orders by visit_count DESC', () => {
+    store.upsertNode({ stateHash: 'a' }); // visit 1
+    store.upsertNode({ stateHash: 'b' });
+    store.upsertNode({ stateHash: 'b' }); // visit 2
+    store.upsertNode({ stateHash: 'c' });
+    store.upsertNode({ stateHash: 'c' });
+    store.upsertNode({ stateHash: 'c' }); // visit 3
+    const list = store.listNodes();
+    expect(list.map((n) => n.stateHash)).toEqual(['c', 'b', 'a']);
+  });
+
+  test('getNode returns undefined for unknown hash', () => {
+    expect(store.getNode('missing')).toBeUndefined();
+  });
+});
+
+describe('SkillGraphStorage — edges and recordOutcome', () => {
+  let root: string;
+  let store: SkillGraphStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    store = new SkillGraphStorage('x.com', { rootDir: root });
+    store.upsertNode({ stateHash: 'from1' });
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('first success creates an edge with success_count=1, distribution=[{to,1}]', () => {
+    store.recordOutcome({
+      fromState: 'from1',
+      actionKind: 'click',
+      actionArgsNorm: 'ref:add',
+      observedToState: 'to1',
+      success: true,
+    });
+    const edge = store.getEdge({
+      fromState: 'from1',
+      actionKind: 'click',
+      actionArgsNorm: 'ref:add',
+    });
+    expect(edge).toBeDefined();
+    expect(edge?.successCount).toBe(1);
+    expect(edge?.failCount).toBe(0);
+    expect(edge?.toStateDistribution).toEqual([{ to_state: 'to1', count: 1 }]);
+    expect(edge?.lastFailedAt).toBeUndefined();
+  });
+
+  test('repeated successes accumulate distribution counts', () => {
+    for (let i = 0; i < 5; i++) {
+      store.recordOutcome({
+        fromState: 'from1',
+        actionKind: 'click',
+        actionArgsNorm: 'ref:add',
+        observedToState: 'to1',
+        success: true,
+      });
+    }
+    const edge = store.getEdge({
+      fromState: 'from1',
+      actionKind: 'click',
+      actionArgsNorm: 'ref:add',
+    });
+    expect(edge?.successCount).toBe(5);
+    expect(edge?.toStateDistribution).toEqual([{ to_state: 'to1', count: 5 }]);
+  });
+
+  test('multiple to_state outcomes produce distribution sorted by count DESC', () => {
+    const args = { fromState: 'from1', actionKind: 'click', actionArgsNorm: 'a' };
+    store.recordOutcome({ ...args, observedToState: 'A', success: true });
+    store.recordOutcome({ ...args, observedToState: 'A', success: true });
+    store.recordOutcome({ ...args, observedToState: 'A', success: true });
+    store.recordOutcome({ ...args, observedToState: 'B', success: true });
+    const edge = store.getEdge(args);
+    expect(edge?.toStateDistribution).toEqual([
+      { to_state: 'A', count: 3 },
+      { to_state: 'B', count: 1 },
+    ]);
+  });
+
+  test('failure increments fail_count and stamps last_failed_at', () => {
+    const args = { fromState: 'from1', actionKind: 'click', actionArgsNorm: 'a' };
+    store.recordOutcome({ ...args, success: false, at: 1234 });
+    const edge = store.getEdge(args);
+    expect(edge?.successCount).toBe(0);
+    expect(edge?.failCount).toBe(1);
+    expect(edge?.lastFailedAt).toBe(1234);
+  });
+
+  test('last_failed_at is preserved across subsequent successes (sticky)', () => {
+    const args = { fromState: 'from1', actionKind: 'click', actionArgsNorm: 'a' };
+    store.recordOutcome({ ...args, success: false, at: 100 });
+    store.recordOutcome({ ...args, observedToState: 'X', success: true, at: 200 });
+    const edge = store.getEdge(args);
+    expect(edge?.lastFailedAt).toBe(100); // still set after the success
+    expect(edge?.successCount).toBe(1);
+    expect(edge?.failCount).toBe(1);
+  });
+
+  test('failure without observedToState does not change distribution', () => {
+    const args = { fromState: 'from1', actionKind: 'click', actionArgsNorm: 'a' };
+    store.recordOutcome({ ...args, observedToState: 'X', success: true });
+    store.recordOutcome({ ...args, success: false }); // no observedToState
+    expect(store.getEdge(args)?.toStateDistribution).toEqual([{ to_state: 'X', count: 1 }]);
+  });
+});
+
+describe('SkillGraphStorage — edgesFrom ordering', () => {
+  let root: string;
+  let store: SkillGraphStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    store = new SkillGraphStorage('x.com', { rootDir: root });
+    store.upsertNode({ stateHash: 'from' });
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('orders edges by success rate DESC, then success_count DESC', () => {
+    // Edge "low" — 1/2 = 0.5 success rate
+    store.recordOutcome({ fromState: 'from', actionKind: 'a', actionArgsNorm: 'low', observedToState: 't', success: true });
+    store.recordOutcome({ fromState: 'from', actionKind: 'a', actionArgsNorm: 'low', success: false });
+    // Edge "high" — 3/3 = 1.0 success rate
+    for (let i = 0; i < 3; i++) {
+      store.recordOutcome({ fromState: 'from', actionKind: 'a', actionArgsNorm: 'high', observedToState: 't', success: true });
+    }
+    // Edge "small" — 1/1 = 1.0 success rate but lower successCount → tiebreak loser
+    store.recordOutcome({ fromState: 'from', actionKind: 'a', actionArgsNorm: 'small', observedToState: 't', success: true });
+
+    const edges = store.edgesFrom('from');
+    expect(edges.map((e) => e.actionArgsNorm)).toEqual(['high', 'small', 'low']);
+  });
+
+  test('returns empty array for unknown from_state', () => {
+    expect(store.edgesFrom('nope')).toEqual([]);
+  });
+});
+
+describe('SkillGraphStorage — inspect summary', () => {
+  let root: string;
+  let store: SkillGraphStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    store = new SkillGraphStorage('amazon.com', { rootDir: root });
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('reports node and edge counts', () => {
+    store.upsertNode({ stateHash: 'a' });
+    store.upsertNode({ stateHash: 'b' });
+    store.recordOutcome({ fromState: 'a', actionKind: 'click', actionArgsNorm: 'x', observedToState: 'b', success: true });
+    const s = store.inspect();
+    expect(s.domain).toBe('amazon.com');
+    expect(s.nodeCount).toBe(2);
+    expect(s.edgeCount).toBe(1);
+  });
+
+  test('top edges include success/fail counts', () => {
+    store.upsertNode({ stateHash: 'a' });
+    store.recordOutcome({ fromState: 'a', actionKind: 'click', actionArgsNorm: 'x', observedToState: 'b', success: true });
+    store.recordOutcome({ fromState: 'a', actionKind: 'click', actionArgsNorm: 'x', success: false });
+    const s = store.inspect();
+    expect(s.topEdgesByVisit).toHaveLength(1);
+    expect(s.topEdgesByVisit[0].successCount).toBe(1);
+    expect(s.topEdgesByVisit[0].failCount).toBe(1);
+  });
+
+  test('recent failures only includes edges with last_failed_at set', () => {
+    store.upsertNode({ stateHash: 'a' });
+    store.recordOutcome({ fromState: 'a', actionKind: 'click', actionArgsNorm: 'ok', observedToState: 'b', success: true });
+    store.recordOutcome({ fromState: 'a', actionKind: 'click', actionArgsNorm: 'broken', success: false, at: 999 });
+    const s = store.inspect();
+    expect(s.recentFailures).toHaveLength(1);
+    expect(s.recentFailures[0].actionKind).toBe('click');
+    expect(s.recentFailures[0].lastFailedAt).toBe(999);
+  });
+});

--- a/tests/skill/url-normalizer.test.ts
+++ b/tests/skill/url-normalizer.test.ts
@@ -1,0 +1,65 @@
+import { normalizeUrl, TRACKING_PARAM_PATTERNS } from '../../src/skill/url-normalizer';
+
+describe('normalizeUrl — host and fragment', () => {
+  test('lowercases hostname', () => {
+    expect(normalizeUrl('https://EXAMPLE.com/path').url).toBe('https://example.com/path');
+  });
+
+  test('drops hash fragment', () => {
+    expect(normalizeUrl('https://x.com/p#section').url).toBe('https://x.com/p');
+  });
+
+  test('preserves path case (paths are case-sensitive)', () => {
+    expect(normalizeUrl('https://x.com/MyPath').url).toBe('https://x.com/MyPath');
+  });
+});
+
+describe('normalizeUrl — tracking params', () => {
+  test('strips utm_* params', () => {
+    const r = normalizeUrl('https://x.com/?utm_source=a&utm_medium=b&q=hello');
+    expect(r.url).toBe('https://x.com/?q=hello');
+    expect(r.droppedParams).toEqual(['utm_medium', 'utm_source']);
+  });
+
+  test('strips known single-name params (fbclid, gclid, msclkid)', () => {
+    expect(normalizeUrl('https://x/?fbclid=abc').url).toBe('https://x/');
+    expect(normalizeUrl('https://x/?gclid=abc').url).toBe('https://x/');
+    expect(normalizeUrl('https://x/?msclkid=abc').url).toBe('https://x/');
+  });
+
+  test('strips Amazon pd_rd_* family', () => {
+    const r = normalizeUrl('https://amazon.com/?pd_rd_w=abc&pd_rd_r=xyz&node=42');
+    expect(r.url).toBe('https://amazon.com/?node=42');
+    expect(r.droppedParams).toEqual(['pd_rd_r', 'pd_rd_w']);
+  });
+
+  test('TRACKING_PARAM_PATTERNS is the source of truth (visible to consumers)', () => {
+    expect(TRACKING_PARAM_PATTERNS.length).toBeGreaterThan(5);
+    expect(TRACKING_PARAM_PATTERNS.some((re) => re.test('utm_source'))).toBe(true);
+  });
+});
+
+describe('normalizeUrl — query stability', () => {
+  test('sorts query keys alphabetically', () => {
+    const a = normalizeUrl('https://x/?b=1&a=2&c=3').url;
+    const b = normalizeUrl('https://x/?c=3&a=2&b=1').url;
+    expect(a).toBe(b);
+    expect(a).toBe('https://x/?a=2&b=1&c=3');
+  });
+
+  test('sorts equal keys by value (deterministic)', () => {
+    const r = normalizeUrl('https://x/?a=2&a=1').url;
+    expect(r).toBe('https://x/?a=1&a=2');
+  });
+
+  test('returns sorted droppedParams for evidence stability', () => {
+    const r = normalizeUrl('https://x/?utm_term=a&utm_medium=b&utm_source=c');
+    expect(r.droppedParams).toEqual(['utm_medium', 'utm_source', 'utm_term']);
+  });
+});
+
+describe('normalizeUrl — invalid input', () => {
+  test('throws on non-URL input', () => {
+    expect(() => normalizeUrl('not a url')).toThrow();
+  });
+});

--- a/tests/trace/recorder.test.ts
+++ b/tests/trace/recorder.test.ts
@@ -1,0 +1,219 @@
+import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { TraceRecorder, _resetTraceRecorderForTests, getTraceRecorder } from '../../src/trace/recorder';
+import { TraceStorage } from '../../src/trace/storage';
+import type { TraceEvent } from '../../src/trace/types';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-rec-'));
+}
+
+function makeRecorder(opts: { storage: TraceStorage; bufferSize?: number; flushIntervalMs?: number; capacityFlushRatio?: number; }): TraceRecorder {
+  return new TraceRecorder({
+    storage: opts.storage,
+    bufferSize: opts.bufferSize ?? 8,
+    flushIntervalMs: opts.flushIntervalMs ?? 24 * 60 * 60 * 1000, // effectively disable timer in unit tests
+    capacityFlushRatio: opts.capacityFlushRatio ?? 0.5,
+    enabled: true,
+    now: () => 1700000000000,
+  });
+}
+
+describe('TraceRecorder — disabled by default when env not set', () => {
+  test('isEnabled() reflects OPENCHROME_TRACE env', () => {
+    const prev = process.env.OPENCHROME_TRACE;
+    delete process.env.OPENCHROME_TRACE;
+    const r1 = new TraceRecorder({ storage: new TraceStorage({ rootDir: tempRoot() }) });
+    expect(r1.isEnabled()).toBe(false);
+
+    process.env.OPENCHROME_TRACE = '1';
+    const r2 = new TraceRecorder({ storage: new TraceStorage({ rootDir: tempRoot() }) });
+    expect(r2.isEnabled()).toBe(true);
+
+    process.env.OPENCHROME_TRACE = prev ?? '';
+    if (!prev) delete process.env.OPENCHROME_TRACE;
+  });
+
+  test('disabled recorder is a no-op for start / recordEvent / flush', async () => {
+    const root = tempRoot();
+    const storage = new TraceStorage({ rootDir: root });
+    const r = new TraceRecorder({ storage, enabled: false });
+    r.start({ sessionId: 's', startedAt: 1, domain: 'x' });
+    r.recordEvent('s', 'k', { x: 1 });
+    await r.flush('s');
+    await r.end('s');
+    expect(storage.list()).toHaveLength(0);
+    storage.close();
+  });
+});
+
+describe('TraceRecorder — start / recordEvent / flush', () => {
+  let root: string;
+  let storage: TraceStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    storage = new TraceStorage({ rootDir: root });
+  });
+
+  afterEach(() => {
+    storage.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('start() registers session in the index', () => {
+    const r = makeRecorder({ storage });
+    r.start({ sessionId: 's1', startedAt: 100, domain: 'amazon.com' });
+    expect(storage.get('s1')?.status).toBe('running');
+    expect(storage.get('s1')?.domain).toBe('amazon.com');
+  });
+
+  test('recordEvent buffers events and flushes on capacity threshold', async () => {
+    const r = makeRecorder({ storage, bufferSize: 4, capacityFlushRatio: 0.5 }); // flush at >= 2
+    r.start({ sessionId: 's1', startedAt: 100 });
+    r.recordEvent('s1', 'a', { i: 1 });
+    // Buffer should still contain 1 event (below threshold)
+    expect(r._peekBuffer('s1')).toHaveLength(1);
+    r.recordEvent('s1', 'b', { i: 2 });
+    // Capacity flush is async — give it a tick
+    await new Promise((res) => setImmediate(res));
+    expect(r._peekBuffer('s1')).toHaveLength(0);
+    expect(storage.get('s1')?.byteSize).toBeGreaterThan(0);
+  });
+
+  test('manual flush writes the buffer and updates byte_size', async () => {
+    const r = makeRecorder({ storage, bufferSize: 100 }); // never auto-flushes
+    r.start({ sessionId: 's2', startedAt: 100 });
+    r.recordEvent('s2', 'k', { i: 1 });
+    r.recordEvent('s2', 'k', { i: 2 });
+    await r.flush('s2');
+    expect(r._peekBuffer('s2')).toHaveLength(0);
+    expect(storage.get('s2')?.byteSize).toBeGreaterThan(0);
+  });
+
+  test('redaction is applied at recordEvent time (sensitive keys scrubbed)', async () => {
+    const r = makeRecorder({ storage, bufferSize: 100 });
+    r.start({ sessionId: 's3', startedAt: 100 });
+    r.recordEvent('s3', 'Network.requestWillBeSent', {
+      request: { url: 'https://x/?password=hunter2', headers: { Authorization: 'Bearer secret' } },
+    });
+    const buf = r._peekBuffer('s3');
+    const body = buf[0].body as { request: { url: string; headers: Record<string, string> } };
+    expect(body.request.url).not.toContain('hunter2');
+    expect(body.request.headers.Authorization).toBe('[REDACTED]');
+  });
+
+  test('recordEvent on unknown session is a silent drop (no throw)', () => {
+    const r = makeRecorder({ storage });
+    expect(() => r.recordEvent('nope', 'k', {})).not.toThrow();
+  });
+});
+
+describe('TraceRecorder — attach to CDP-like emitter', () => {
+  let root: string;
+  let storage: TraceStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    storage = new TraceStorage({ rootDir: root });
+  });
+
+  afterEach(() => {
+    storage.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('subscribes to default CDP kinds and records emitted events', async () => {
+    const cdp = new EventEmitter();
+    const r = makeRecorder({ storage, bufferSize: 100 });
+    r.start({ sessionId: 's', startedAt: 100 });
+    r.attach('s', cdp);
+    cdp.emit('Page.frameNavigated', { frame: { url: 'https://x' } });
+    cdp.emit('Network.responseReceived', { response: { status: 200 } });
+    cdp.emit('Runtime.consoleAPICalled', { type: 'log' });
+    expect(r._peekBuffer('s').map((e) => e.kind)).toEqual([
+      'Page.frameNavigated',
+      'Network.responseReceived',
+      'Runtime.consoleAPICalled',
+    ]);
+  });
+
+  test('detach via end() removes listeners; further CDP events are not buffered', async () => {
+    const cdp = new EventEmitter();
+    const r = makeRecorder({ storage, bufferSize: 100 });
+    r.start({ sessionId: 's', startedAt: 100 });
+    r.attach('s', cdp);
+    cdp.emit('Page.frameNavigated', {});
+    await r.end('s');
+    cdp.emit('Page.frameNavigated', {});
+    // Session is gone — no buffer to peek at.
+    expect(r._peekBuffer('s')).toEqual([]);
+    expect(storage.get('s')?.status).toBe('completed');
+  });
+
+  test('framenavigated on the page triggers a flush', async () => {
+    const cdp = new EventEmitter();
+    const page = new EventEmitter();
+    const r = makeRecorder({ storage, bufferSize: 100 });
+    r.start({ sessionId: 's', startedAt: 100 });
+    r.attach('s', cdp, page as unknown as { on(e: string, fn: (...a: unknown[]) => void): unknown });
+    r.recordEvent('s', 'tool_call', { name: 'click' });
+    expect(r._peekBuffer('s')).toHaveLength(1);
+    page.emit('framenavigated', { url: 'https://x' });
+    await new Promise((res) => setImmediate(res));
+    expect(r._peekBuffer('s')).toHaveLength(0);
+  });
+
+  test('attaching a session twice throws (defensive)', () => {
+    const cdp = new EventEmitter();
+    const r = makeRecorder({ storage });
+    r.start({ sessionId: 's', startedAt: 100 });
+    r.attach('s', cdp);
+    expect(() => r.attach('s', cdp)).toThrow(/already attached/);
+  });
+
+  test('attach without start throws', () => {
+    const cdp = new EventEmitter();
+    const r = makeRecorder({ storage });
+    expect(() => r.attach('nope', cdp)).toThrow(/unknown session/);
+  });
+});
+
+describe('TraceRecorder — shutdown semantics', () => {
+  let root: string;
+  let storage: TraceStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    storage = new TraceStorage({ rootDir: root });
+  });
+
+  afterEach(() => {
+    storage.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('shutdown flushes and ends every active session as aborted', async () => {
+    const r = makeRecorder({ storage });
+    r.start({ sessionId: 'a', startedAt: 1 });
+    r.start({ sessionId: 'b', startedAt: 2 });
+    r.recordEvent('a', 'k', {});
+    r.recordEvent('b', 'k', {});
+    await r.shutdown();
+    expect(storage.get('a')?.status).toBe('aborted');
+    expect(storage.get('b')?.status).toBe('aborted');
+  });
+});
+
+describe('TraceRecorder — global singleton', () => {
+  test('getTraceRecorder() returns the same instance across calls', () => {
+    _resetTraceRecorderForTests();
+    const a = getTraceRecorder({ enabled: false });
+    const b = getTraceRecorder();
+    expect(a).toBe(b);
+    _resetTraceRecorderForTests();
+  });
+});


### PR DESCRIPTION
## Summary

Documents the manual capture procedure for the skill-graph fixture corpus consumed by `tests/skill/state.test.ts` and the planned `tests/skill/state.stability.test.ts` (#702 v2 acceptance: ≥ 19/20 hash matches across captured variants). Stacked on **#739**.

Includes:

- **When to recapture** — algorithm bump, normalizer change, site layout shift dropping stability below 95%
- **Step-by-step procedure** — profile launch, navigation across noise (ad rotation, time-of-day, A/B), DOM serialization, sanity diff, commit
- **Provenance metadata** — every fixture file gets a sibling `.meta.json` documenting capture date, profile, viewport, observed dropped tracking params

## Why a docs-only PR

The capture procedure is referenced from #702 v2 acceptance and from #703 (executor) test setup. Landing the doc separately means reviewers can land #702/#703 acceptance evidence without unblocking by code-review of a docs change.

## Validation

- `npm run build` clean (docs only — no source changes)
- No tests added (docs PR)

## Test plan

- [ ] Reviewer confirms the procedure is reproducible: pick one Amazon /cart variant, follow the steps, get a fixture file
- [ ] Reviewer confirms `.meta.json` schema captures everything an upgrader would need to determine "is this still good?"

Refs: #698 (epic), #702 (sub-issue), #703 (sub-issue). Stacked on #739.

🤖 Split from `feat/m1-pr1-trace-foundation`. Original commit: `065c173`.
