### PR TITLE
feat(skill): graph audit telemetry + executor integration (M1 PR-7 partial)

### DIFF
--- a/src/skill/audit.ts
+++ b/src/skill/audit.ts
@@ -8,7 +8,8 @@
  * `skill_graph` and the kind is encoded in `args.event`.
  *
  * Schema (rendered as ExtendedAuditEntry.args):
- *   { event: "graph_hit"  | "graph_miss" | "graph_fallback_promoted",
+ *   { event: "graph_hit" | "graph_miss" | "graph_fallback_promoted"
+ *           | "graph_error",
  *     domain: string,
  *     fromState: string,
  *     toState?: string,
@@ -16,11 +17,19 @@
  *     ok: boolean,
  *     reason?: string,
  *     matchedExpected?: boolean }
+ *
+ * `graph_error` is emitted when `runSkill` itself rejects (snapshot,
+ * router, or storage failure). The 1:1 call-to-event guarantee covers
+ * exception paths so operational dashboards never undercount failures.
  */
 
 import { logAuditEntry } from '../security/audit-logger';
 
-import type { RunOutcomeKind, RunSkillResult } from './executor';
+import type {
+  ActionInvocation,
+  RunOutcomeKind,
+  RunSkillResult,
+} from './executor';
 
 export type GraphAuditEventKind = RunOutcomeKind;
 
@@ -78,6 +87,35 @@ export function buildEventFromResult(
     ok: result.ok,
     reason: result.reason,
     matchedExpected: result.matchedExpected,
+  };
+}
+
+/**
+ * Build a `graph_error` event from whatever progress the executor managed
+ * to capture before throwing. `fromState`/`toState`/`action` may be
+ * undefined when the snapshot itself failed; callers must tolerate that
+ * — the `event` and `ok=false` fields are sufficient to count failures.
+ */
+export function buildEventFromError(
+  domain: string,
+  err: unknown,
+  trace: { fromState?: string; toState?: string; action?: ActionInvocation },
+): GraphAuditEvent {
+  const reason =
+    err instanceof Error
+      ? err.message
+      : typeof err === 'string'
+        ? err
+        : 'unknown_error';
+  return {
+    event: 'graph_error',
+    domain,
+    fromState: trace.fromState ?? '',
+    toState: trace.toState,
+    actionKind: trace.action?.kind,
+    actionArgsNorm: trace.action?.argsNorm,
+    ok: false,
+    reason,
   };
 }
 

--- a/src/skill/audit.ts
+++ b/src/skill/audit.ts
@@ -54,19 +54,28 @@ export interface GraphAuditEmitter {
  * Default emitter that writes to `~/.openchrome/audit.jsonl` via the
  * existing audit pipeline. Bound to a sessionId at construction time so
  * each call site doesn't have to thread it through.
+ *
+ * The constructor takes a `defaultDomain` used only when the event's
+ * `domain` field is empty — `event.domain` is authoritative because the
+ * caller can override it per call via `RunSkillArgs.domain`.
  */
 export class AuditLogGraphEmitter implements GraphAuditEmitter {
-  constructor(private readonly sessionId: string, private readonly domain: string) {}
+  constructor(
+    private readonly sessionId: string,
+    private readonly defaultDomain: string,
+  ) {}
 
   emit(event: GraphAuditEvent): void {
     // Tool name is fixed; the event kind lives in args so existing audit
     // tooling can filter via a single field path (`args.event`).
     //
-    // `logAuditEntry` derives the top-level `entry.domain` from either the
-    // `pageUrl` argument or `args.url`. Skill graph events have neither, so
-    // we synthesise a stand-in URL from the bound `domain` so existing
-    // per-domain audit queries can still filter `skill_graph` rows.
-    const domainUrl = synthesiseDomainUrl(this.domain);
+    // `logAuditEntry` derives the top-level `entry.domain` from either
+    // the `pageUrl` argument or `args.url`. Skill graph events have
+    // neither, so we synthesise a stand-in URL from the *event's* domain
+    // (falling back to the bound default) so per-call domain overrides
+    // are reflected in `entry.domain`, not just in `args.domain`.
+    const domain = event.domain || this.defaultDomain;
+    const domainUrl = synthesiseDomainUrl(domain);
     logAuditEntry(
       'skill_graph',
       this.sessionId,

--- a/src/skill/audit.ts
+++ b/src/skill/audit.ts
@@ -1,0 +1,95 @@
+/**
+ * Skill-graph audit telemetry.
+ *
+ * The graph executor (#703) emits one structured event per outcome so an
+ * operator can answer "did the system use the graph or fall back?" from
+ * the audit log. The events ride on the existing `logAuditEntry` writer
+ * — no new file, no new format. The `tool` field is fixed to
+ * `skill_graph` and the kind is encoded in `args.event`.
+ *
+ * Schema (rendered as ExtendedAuditEntry.args):
+ *   { event: "graph_hit"  | "graph_miss" | "graph_fallback_promoted",
+ *     domain: string,
+ *     fromState: string,
+ *     toState?: string,
+ *     actionKind?: string,
+ *     ok: boolean,
+ *     reason?: string,
+ *     matchedExpected?: boolean }
+ */
+
+import { logAuditEntry } from '../security/audit-logger';
+
+import type { RunOutcomeKind, RunSkillResult } from './executor';
+
+export type GraphAuditEventKind = RunOutcomeKind;
+
+export interface GraphAuditEvent {
+  event: GraphAuditEventKind;
+  domain: string;
+  fromState: string;
+  toState?: string;
+  actionKind?: string;
+  actionArgsNorm?: string;
+  ok: boolean;
+  reason?: string;
+  matchedExpected?: boolean;
+}
+
+/** Hook the executor invokes after each step. Tests can substitute a fake. */
+export interface GraphAuditEmitter {
+  emit(event: GraphAuditEvent): void;
+}
+
+/**
+ * Default emitter that writes to `~/.openchrome/audit.jsonl` via the
+ * existing audit pipeline. Bound to a sessionId at construction time so
+ * each call site doesn't have to thread it through.
+ */
+export class AuditLogGraphEmitter implements GraphAuditEmitter {
+  constructor(private readonly sessionId: string, private readonly domain: string) {}
+
+  emit(event: GraphAuditEvent): void {
+    // Tool name is fixed; the event kind lives in args so existing audit
+    // tooling can filter via a single field path (`args.event`).
+    logAuditEntry(
+      'skill_graph',
+      this.sessionId,
+      // logAuditEntry expects Record<string, unknown> — coerce via spread.
+      { ...event } as unknown as Record<string, unknown>,
+      undefined,
+      { status: event.ok ? 'success' : 'error' },
+    );
+  }
+}
+
+/** Build a `GraphAuditEvent` from a `RunSkillResult`. Pure; safe to test. */
+export function buildEventFromResult(
+  domain: string,
+  result: RunSkillResult,
+): GraphAuditEvent {
+  return {
+    event: result.outcome,
+    domain,
+    fromState: result.fromState,
+    toState: result.toState,
+    actionKind: result.action?.kind,
+    actionArgsNorm: result.action?.argsNorm,
+    ok: result.ok,
+    reason: result.reason,
+    matchedExpected: result.matchedExpected,
+  };
+}
+
+/**
+ * Convenience helper — call from executor wrappers that already have a
+ * `RunSkillResult` and want one-line emission.
+ */
+export function emitGraphEvent(
+  emitter: GraphAuditEmitter | undefined,
+  domain: string,
+  result: RunSkillResult,
+): void {
+  if (!emitter) return;
+  emitter.emit(buildEventFromResult(domain, result));
+}

--- a/src/skill/audit.ts
+++ b/src/skill/audit.ts
@@ -61,15 +61,33 @@ export class AuditLogGraphEmitter implements GraphAuditEmitter {
   emit(event: GraphAuditEvent): void {
     // Tool name is fixed; the event kind lives in args so existing audit
     // tooling can filter via a single field path (`args.event`).
+    //
+    // `logAuditEntry` derives the top-level `entry.domain` from either the
+    // `pageUrl` argument or `args.url`. Skill graph events have neither, so
+    // we synthesise a stand-in URL from the bound `domain` so existing
+    // per-domain audit queries can still filter `skill_graph` rows.
+    const domainUrl = synthesiseDomainUrl(this.domain);
     logAuditEntry(
       'skill_graph',
       this.sessionId,
       // logAuditEntry expects Record<string, unknown> — coerce via spread.
       { ...event } as unknown as Record<string, unknown>,
-      undefined,
+      domainUrl,
       { status: event.ok ? 'success' : 'error' },
     );
   }
+}
+
+/**
+ * Build a URL that `extractHostname()` can parse back into the original
+ * domain. Skill-graph domains arrive without a scheme (e.g. `amazon.com`,
+ * `localhost:3000`) — wrap them in `https://…/` for the URL parser. If the
+ * input is already a URL we leave it alone.
+ */
+function synthesiseDomainUrl(domain: string): string {
+  if (!domain) return '';
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(domain)) return domain;
+  return `https://${domain}/`;
 }
 
 /** Build a `GraphAuditEvent` from a `RunSkillResult`. Pure; safe to test. */

--- a/src/skill/executor.ts
+++ b/src/skill/executor.ts
@@ -119,26 +119,39 @@ const SMALL_SAMPLE_TOTAL = 10;
  * executor still emits a `graph_error` event with whatever progress was
  * captured before the throw, then re-raises so the caller's error
  * handling stays responsible for retry/abort.
+ *
+ * Audit emission is isolated from the run outcome: if the emitter itself
+ * throws, the failure is swallowed and surfaced through `console.error`
+ * so a logging or evidence-writer fault never reclassifies a successful
+ * skill step as `graph_error`, and never masks a genuine inner exception.
  */
 export async function runSkill(args: RunSkillArgs): Promise<RunSkillResult> {
   const { storage, router, ctx, intent } = args;
   const trace: ProgressTrace = {};
+  let result: RunSkillResult | undefined;
+  let innerError: unknown;
   try {
-    const result = await runSkillInner({ storage, router, ctx, intent, trace });
-    if (args.audit) {
-      const { buildEventFromResult } = await import('./audit');
-      args.audit.emit(buildEventFromResult(args.domain ?? storage.domain, result));
-    }
-    return result;
+    result = await runSkillInner({ storage, router, ctx, intent, trace });
   } catch (err) {
-    if (args.audit) {
-      const { buildEventFromError } = await import('./audit');
-      args.audit.emit(
-        buildEventFromError(args.domain ?? storage.domain, err, trace),
-      );
-    }
-    throw err;
+    innerError = err;
   }
+
+  if (args.audit) {
+    try {
+      const domain = args.domain ?? storage.domain;
+      const { buildEventFromResult, buildEventFromError } = await import('./audit');
+      const event = result
+        ? buildEventFromResult(domain, result)
+        : buildEventFromError(domain, innerError, trace);
+      args.audit.emit(event);
+    } catch (emitErr) {
+      // Telemetry failure is observability-only; don't poison the run.
+      console.error('[skill] graph audit emit failed:', emitErr);
+    }
+  }
+
+  if (innerError !== undefined) throw innerError;
+  return result as RunSkillResult;
 }
 
 /** Captures partial progress so a thrown call can still produce an audit row. */

--- a/src/skill/executor.ts
+++ b/src/skill/executor.ts
@@ -69,7 +69,8 @@ export interface SkillIntent {
 export type RunOutcomeKind =
   | 'graph_hit'
   | 'graph_miss'
-  | 'graph_fallback_promoted';
+  | 'graph_fallback_promoted'
+  | 'graph_error';
 
 export interface RunSkillResult {
   outcome: RunOutcomeKind;
@@ -113,16 +114,38 @@ const SMALL_SAMPLE_TOTAL = 10;
  *
  * When `args.audit` is supplied, exactly one event is emitted before
  * return — even on the early "no_action_available" path — so audit
- * consumers see a 1:1 correspondence between calls and events.
+ * consumers see a 1:1 correspondence between calls and events. If
+ * `runSkillInner` rejects (snapshot, router, or storage failure), the
+ * executor still emits a `graph_error` event with whatever progress was
+ * captured before the throw, then re-raises so the caller's error
+ * handling stays responsible for retry/abort.
  */
 export async function runSkill(args: RunSkillArgs): Promise<RunSkillResult> {
   const { storage, router, ctx, intent } = args;
-  const result = await runSkillInner({ storage, router, ctx, intent });
-  if (args.audit) {
-    const { buildEventFromResult } = await import('./audit');
-    args.audit.emit(buildEventFromResult(args.domain ?? storage.domain, result));
+  const trace: ProgressTrace = {};
+  try {
+    const result = await runSkillInner({ storage, router, ctx, intent, trace });
+    if (args.audit) {
+      const { buildEventFromResult } = await import('./audit');
+      args.audit.emit(buildEventFromResult(args.domain ?? storage.domain, result));
+    }
+    return result;
+  } catch (err) {
+    if (args.audit) {
+      const { buildEventFromError } = await import('./audit');
+      args.audit.emit(
+        buildEventFromError(args.domain ?? storage.domain, err, trace),
+      );
+    }
+    throw err;
   }
-  return result;
+}
+
+/** Captures partial progress so a thrown call can still produce an audit row. */
+interface ProgressTrace {
+  fromState?: string;
+  toState?: string;
+  action?: ActionInvocation;
 }
 
 async function runSkillInner(args: {
@@ -130,11 +153,13 @@ async function runSkillInner(args: {
   router: ToolRouter;
   ctx: ExecutionContext;
   intent: SkillIntent;
+  trace: ProgressTrace;
 }): Promise<RunSkillResult> {
-  const { storage, router, ctx, intent } = args;
+  const { storage, router, ctx, intent, trace } = args;
 
   const before = await ctx.snapshotPageState();
   const fromHash = computeStateHash(before).hash;
+  trace.fromState = fromHash;
   storage.upsertNode({
     stateHash: fromHash,
     evidence: computeStateHash(before).evidence,
@@ -147,11 +172,13 @@ async function runSkillInner(args: {
     const action: ActionInvocation = {
       kind: candidate.actionKind,
       argsNorm: candidate.actionArgsNorm,
-      args: parseArgs(candidate.actionArgsNorm),
+      args: replayArgs(candidate),
     };
+    trace.action = action;
     const result = await router.runAction(action);
     const after = await ctx.snapshotPageState();
     const toHash = computeStateHash(after).hash;
+    trace.toState = toHash;
     storage.upsertNode({
       stateHash: toHash,
       evidence: computeStateHash(after).evidence,
@@ -185,9 +212,11 @@ async function runSkillInner(args: {
       reason: 'no_action_available',
     };
   }
+  trace.action = fallback;
   const fallbackResult = await router.runAction(fallback);
   const after = await ctx.snapshotPageState();
   const toHash = computeStateHash(after).hash;
+  trace.toState = toHash;
   storage.upsertNode({
     stateHash: toHash,
     evidence: computeStateHash(after).evidence,
@@ -200,6 +229,7 @@ async function runSkillInner(args: {
       fromState: fromHash,
       actionKind: fallback.kind,
       actionArgsNorm: fallback.argsNorm,
+      actionArgsReplay: encodeReplayArgs(fallback.args),
       observedToState: toHash,
       success: true,
     });
@@ -272,12 +302,47 @@ export function matchesExpected(newHash: string, edge: SkillEdge): boolean {
   return entry.count / total >= DISTRIBUTION_MATCH_THRESHOLD;
 }
 
-/** Best-effort decode of canonical args. Falls back to the raw string. */
-function parseArgs(argsNorm: string): unknown {
+/**
+ * Restore the structured args for a graph_hit replay.
+ *
+ * Prefers the lossless `actionArgsReplay` payload (recorded when the edge
+ * was promoted from the fallback path). Falls back to parsing
+ * `actionArgsNorm` for legacy edges captured before the v2 schema bump —
+ * those edges may have non-JSON identities (e.g. `ref:*`), in which case
+ * we surface the raw string to keep behaviour bug-compatible with v1.
+ *
+ * Exported for unit tests; the executor itself is the only production
+ * caller.
+ */
+export function replayArgs(edge: SkillEdge): unknown {
+  if (edge.actionArgsReplay !== undefined) {
+    try {
+      return JSON.parse(edge.actionArgsReplay);
+    } catch {
+      // Replay payload was corrupted — fall through to argsNorm so the
+      // edge isn't unusable, but the caller will surface the action via
+      // audit telemetry either way.
+    }
+  }
   try {
-    return JSON.parse(argsNorm);
+    return JSON.parse(edge.actionArgsNorm);
   } catch {
-    return argsNorm;
+    return edge.actionArgsNorm;
+  }
+}
+
+/**
+ * Serialise the original action args into the lossless replay payload.
+ * Returns undefined when the args don't survive a JSON round-trip (for
+ * example, args containing functions or circular references). In that
+ * case the edge is still promoted, but graph_hit replay falls back to
+ * parsing `actionArgsNorm` — same behaviour as before this change.
+ */
+export function encodeReplayArgs(args: unknown): string | undefined {
+  try {
+    return JSON.stringify(args);
+  } catch {
+    return undefined;
   }
 }
 

--- a/src/skill/executor.ts
+++ b/src/skill/executor.ts
@@ -16,6 +16,8 @@
  * to `src/tools/` lives in PR-7).
  */
 
+import { isDeepStrictEqual } from 'node:util';
+
 import { computeStateHash, type PageSnapshot } from './state';
 import {
   SkillGraphStorage,
@@ -351,17 +353,33 @@ export function replayArgs(edge: SkillEdge): unknown {
 
 /**
  * Serialise the original action args into the lossless replay payload.
- * Returns undefined when the args don't survive a JSON round-trip (for
- * example, args containing functions or circular references). In that
- * case the edge is still promoted, but graph_hit replay falls back to
- * parsing `actionArgsNorm` — same behaviour as before this change.
+ * Returns undefined when the args don't survive a JSON round-trip — that
+ * covers both *failures* (circular references, BigInt, etc.) and *silent
+ * mutations* (`Infinity`/`NaN` → `null`, dropped `undefined` properties,
+ * `Date` objects collapsing to ISO strings, function-valued props
+ * vanishing). When the payload is rejected the edge is still promoted,
+ * but graph_hit replay falls back to parsing `actionArgsNorm` — same
+ * behaviour as before lossless replay was added.
  */
 export function encodeReplayArgs(args: unknown): string | undefined {
+  let serialized: string;
   try {
-    return JSON.stringify(args);
+    serialized = JSON.stringify(args) as string;
   } catch {
     return undefined;
   }
+  if (typeof serialized !== 'string') return undefined; // top-level undefined / function
+  let roundTripped: unknown;
+  try {
+    roundTripped = JSON.parse(serialized);
+  } catch {
+    return undefined;
+  }
+  // Reject when the round-trip mutated the value. JSON.stringify is
+  // happy to silently coerce `Infinity`, drop `undefined`/function-valued
+  // properties, and stringify `Date` — replay would then run with
+  // different args than the original successful call.
+  return isDeepStrictEqual(roundTripped, args) ? serialized : undefined;
 }
 
 /** Test-internal helper for `to_state_distribution` math without an SkillEdge. */

--- a/src/skill/executor.ts
+++ b/src/skill/executor.ts
@@ -130,19 +130,24 @@ export async function runSkill(args: RunSkillArgs): Promise<RunSkillResult> {
   const trace: ProgressTrace = {};
   let result: RunSkillResult | undefined;
   let innerError: unknown;
+  // Separate boolean — `innerError` alone is ambiguous because callers can
+  // legitimately throw `undefined` or do `Promise.reject()`. We must
+  // re-raise any rejection, even one that carries no value.
+  let didThrow = false;
   try {
     result = await runSkillInner({ storage, router, ctx, intent, trace });
   } catch (err) {
     innerError = err;
+    didThrow = true;
   }
 
   if (args.audit) {
     try {
       const domain = args.domain ?? storage.domain;
       const { buildEventFromResult, buildEventFromError } = await import('./audit');
-      const event = result
-        ? buildEventFromResult(domain, result)
-        : buildEventFromError(domain, innerError, trace);
+      const event = didThrow
+        ? buildEventFromError(domain, innerError, trace)
+        : buildEventFromResult(domain, result as RunSkillResult);
       args.audit.emit(event);
     } catch (emitErr) {
       // Telemetry failure is observability-only; don't poison the run.
@@ -150,7 +155,7 @@ export async function runSkill(args: RunSkillArgs): Promise<RunSkillResult> {
     }
   }
 
-  if (innerError !== undefined) throw innerError;
+  if (didThrow) throw innerError;
   return result as RunSkillResult;
 }
 

--- a/src/skill/executor.ts
+++ b/src/skill/executor.ts
@@ -89,6 +89,17 @@ export interface RunSkillArgs {
   router: ToolRouter;
   ctx: ExecutionContext;
   intent: SkillIntent;
+  /**
+   * Optional audit emitter — when supplied, the executor emits one
+   * `GraphAuditEvent` per call (graph_hit / graph_miss /
+   * graph_fallback_promoted). Hosts wire this to the audit-logger
+   * pipeline; tests can substitute a fake to assert on emissions.
+   */
+  audit?: { emit(event: import('./audit').GraphAuditEvent): void };
+  /**
+   * Domain label for audit events. Defaults to `storage.domain`.
+   */
+  domain?: string;
 }
 
 /** Threshold per #703 v2: 10% of total invocations. */
@@ -99,8 +110,27 @@ const SMALL_SAMPLE_TOTAL = 10;
 /**
  * One pass of skill execution. Hosts call this in a loop (or once per
  * intent step, depending on skill granularity).
+ *
+ * When `args.audit` is supplied, exactly one event is emitted before
+ * return — even on the early "no_action_available" path — so audit
+ * consumers see a 1:1 correspondence between calls and events.
  */
 export async function runSkill(args: RunSkillArgs): Promise<RunSkillResult> {
+  const { storage, router, ctx, intent } = args;
+  const result = await runSkillInner({ storage, router, ctx, intent });
+  if (args.audit) {
+    const { buildEventFromResult } = await import('./audit');
+    args.audit.emit(buildEventFromResult(args.domain ?? storage.domain, result));
+  }
+  return result;
+}
+
+async function runSkillInner(args: {
+  storage: SkillGraphStorage;
+  router: ToolRouter;
+  ctx: ExecutionContext;
+  intent: SkillIntent;
+}): Promise<RunSkillResult> {
   const { storage, router, ctx, intent } = args;
 
   const before = await ctx.snapshotPageState();

--- a/src/skill/index.ts
+++ b/src/skill/index.ts
@@ -41,6 +41,7 @@ export type {
 export {
   AuditLogGraphEmitter,
   buildEventFromResult,
+  buildEventFromError,
   emitGraphEvent,
 } from './audit';
 export type { GraphAuditEvent, GraphAuditEventKind, GraphAuditEmitter } from './audit';

--- a/src/skill/index.ts
+++ b/src/skill/index.ts
@@ -37,3 +37,10 @@ export type {
   RunSkillArgs,
   RunOutcomeKind,
 } from './executor';
+
+export {
+  AuditLogGraphEmitter,
+  buildEventFromResult,
+  emitGraphEvent,
+} from './audit';
+export type { GraphAuditEvent, GraphAuditEventKind, GraphAuditEmitter } from './audit';

--- a/src/skill/storage.ts
+++ b/src/skill/storage.ts
@@ -32,7 +32,7 @@ function loadSqlite(): BetterSqlite3 {
   return _Sqlite;
 }
 
-const CURRENT_SCHEMA_VERSION = 1;
+const CURRENT_SCHEMA_VERSION = 2;
 
 const SCHEMA_V1 = `
 CREATE TABLE IF NOT EXISTS applied_migrations (
@@ -63,6 +63,20 @@ CREATE TABLE IF NOT EXISTS edges (
 CREATE INDEX IF NOT EXISTS idx_edges_from ON edges(from_state);
 `;
 
+/**
+ * v2 — replayable action payload.
+ *
+ * `action_args_norm` is a canonical *identity* string (used as part of the
+ * edge primary key) and must round-trip through `JSON.parse` to be safely
+ * replayed. Real-world actions use non-JSON normalizations (e.g. `ref:*`),
+ * so we store the original structured args separately as JSON. The graph
+ * executor (#703) reads this column on graph_hit replay; legacy edges
+ * (NULL) fall back to parsing `action_args_norm`.
+ */
+const SCHEMA_V2 = `
+ALTER TABLE edges ADD COLUMN action_args_replay TEXT;
+`;
+
 /** A row from `nodes`. */
 export interface SkillNode {
   stateHash: string;
@@ -77,6 +91,12 @@ export interface SkillEdge {
   fromState: string;
   actionKind: string;
   actionArgsNorm: string;
+  /**
+   * Lossless JSON-encoded original action args. Restored on graph_hit so
+   * the executor can replay the exact structured payload (not the canonical
+   * identity string). Undefined for legacy edges captured before v2.
+   */
+  actionArgsReplay?: string;
   /** Sorted (by count DESC) distribution of observed `to_state` outcomes. */
   toStateDistribution: ToStateDistribution;
   successCount: number;
@@ -139,12 +159,28 @@ export class SkillGraphStorage {
 
   private applyMigrations(): void {
     this.db.exec(SCHEMA_V1);
-    const applied = (this.db.prepare('SELECT version FROM applied_migrations').all() as { version: number }[])
-      .map((r) => r.version);
-    if (!applied.includes(1)) {
+    const applied = new Set(
+      (this.db.prepare('SELECT version FROM applied_migrations').all() as { version: number }[])
+        .map((r) => r.version),
+    );
+    const recordApplied = (version: number): void => {
       this.db
         .prepare('INSERT INTO applied_migrations (version, applied_at) VALUES (?, ?)')
-        .run(1, Date.now());
+        .run(version, Date.now());
+    };
+    if (!applied.has(1)) recordApplied(1);
+    if (!applied.has(2)) {
+      // ALTER TABLE … ADD COLUMN throws when the column already exists; on
+      // a fresh DB the column is absent (SCHEMA_V1 has no replay column),
+      // but a hand-recovered DB may have re-applied SCHEMA_V1 then partially
+      // applied v2. Probe pragma_table_info to stay idempotent either way.
+      const cols = this.db
+        .prepare("SELECT name FROM pragma_table_info('edges')")
+        .all() as Array<{ name: string }>;
+      if (!cols.some((c) => c.name === 'action_args_replay')) {
+        this.db.exec(SCHEMA_V2);
+      }
+      recordApplied(2);
     }
   }
 
@@ -238,6 +274,14 @@ export class SkillGraphStorage {
     fromState: string;
     actionKind: string;
     actionArgsNorm: string;
+    /**
+     * Lossless JSON-encoded original action args. Stored on the edge so a
+     * graph_hit later can rebuild the exact structured payload — necessary
+     * when `actionArgsNorm` is a non-JSON identity (e.g. `ref:*`). On UPDATE
+     * an explicit value overwrites; if omitted we leave the previously
+     * recorded payload alone.
+     */
+    actionArgsReplay?: string;
     observedToState?: string;
     success: boolean;
     at?: number;
@@ -271,13 +315,17 @@ export class SkillGraphStorage {
       }
 
       if (existing) {
+        // COALESCE keeps a previously recorded replay payload when the
+        // caller doesn't pass one (e.g. failure paths where the identity
+        // already exists).
         this.db
           .prepare(
             `UPDATE edges
                SET to_state_distribution = ?,
                    success_count = success_count + ?,
                    fail_count    = fail_count + ?,
-                   last_failed_at = CASE WHEN ? = 0 THEN ? ELSE last_failed_at END
+                   last_failed_at = CASE WHEN ? = 0 THEN ? ELSE last_failed_at END,
+                   action_args_replay = COALESCE(?, action_args_replay)
              WHERE from_state = ? AND action_kind = ? AND action_args_norm = ?`,
           )
           .run(
@@ -286,6 +334,7 @@ export class SkillGraphStorage {
             a.success ? 0 : 1,
             a.success ? 1 : 0,
             at,
+            a.actionArgsReplay ?? null,
             a.fromState,
             a.actionKind,
             a.actionArgsNorm,
@@ -294,14 +343,15 @@ export class SkillGraphStorage {
         this.db
           .prepare(
             `INSERT INTO edges
-               (from_state, action_kind, action_args_norm, to_state_distribution,
-                success_count, fail_count, last_failed_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?)`,
+               (from_state, action_kind, action_args_norm, action_args_replay,
+                to_state_distribution, success_count, fail_count, last_failed_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
           )
           .run(
             a.fromState,
             a.actionKind,
             a.actionArgsNorm,
+            a.actionArgsReplay ?? null,
             JSON.stringify(dist),
             a.success ? 1 : 0,
             a.success ? 0 : 1,
@@ -320,13 +370,14 @@ export class SkillGraphStorage {
   }): SkillEdge | undefined {
     const row = this.db
       .prepare(
-        'SELECT from_state, action_kind, action_args_norm, to_state_distribution, success_count, fail_count, last_failed_at FROM edges WHERE from_state = ? AND action_kind = ? AND action_args_norm = ?',
+        'SELECT from_state, action_kind, action_args_norm, action_args_replay, to_state_distribution, success_count, fail_count, last_failed_at FROM edges WHERE from_state = ? AND action_kind = ? AND action_args_norm = ?',
       )
       .get(args.fromState, args.actionKind, args.actionArgsNorm) as
       | {
           from_state: string;
           action_kind: string;
           action_args_norm: string;
+          action_args_replay: string | null;
           to_state_distribution: string;
           success_count: number;
           fail_count: number;
@@ -338,6 +389,7 @@ export class SkillGraphStorage {
       fromState: row.from_state,
       actionKind: row.action_kind,
       actionArgsNorm: row.action_args_norm,
+      actionArgsReplay: row.action_args_replay ?? undefined,
       toStateDistribution: JSON.parse(row.to_state_distribution) as ToStateDistribution,
       successCount: row.success_count,
       failCount: row.fail_count,
@@ -353,12 +405,13 @@ export class SkillGraphStorage {
   edgesFrom(stateHash: string): SkillEdge[] {
     const rows = this.db
       .prepare(
-        'SELECT from_state, action_kind, action_args_norm, to_state_distribution, success_count, fail_count, last_failed_at FROM edges WHERE from_state = ?',
+        'SELECT from_state, action_kind, action_args_norm, action_args_replay, to_state_distribution, success_count, fail_count, last_failed_at FROM edges WHERE from_state = ?',
       )
       .all(stateHash) as Array<{
       from_state: string;
       action_kind: string;
       action_args_norm: string;
+      action_args_replay: string | null;
       to_state_distribution: string;
       success_count: number;
       fail_count: number;
@@ -368,6 +421,7 @@ export class SkillGraphStorage {
       fromState: row.from_state,
       actionKind: row.action_kind,
       actionArgsNorm: row.action_args_norm,
+      actionArgsReplay: row.action_args_replay ?? undefined,
       toStateDistribution: JSON.parse(row.to_state_distribution) as ToStateDistribution,
       successCount: row.success_count,
       failCount: row.fail_count,

--- a/tests/skill/audit-domain.test.ts
+++ b/tests/skill/audit-domain.test.ts
@@ -11,7 +11,10 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { AuditLogGraphEmitter } from '../../src/skill/audit';
+import { AuditLogGraphEmitter, type GraphAuditEvent } from '../../src/skill/audit';
+import { runSkill, type ExecutionContext, type ToolRouter } from '../../src/skill/executor';
+import { SkillGraphStorage } from '../../src/skill/storage';
+import type { PageSnapshot } from '../../src/skill/state';
 import { __resetAuditLoggerCachesForTests } from '../../src/security/audit-logger';
 
 jest.mock('../../src/config/global', () => ({
@@ -91,5 +94,85 @@ describe('AuditLogGraphEmitter — preserves entry.domain', () => {
     expect(entry).toBeDefined();
     expect(entry.tool).toBe('skill_graph');
     expect(entry.domain).toBe('shop.example.co.uk');
+  });
+
+  test('event.domain takes precedence over the emitter default', async () => {
+    // The emitter is bound to "amazon.com" but the event came from a
+    // call that overrode `RunSkillArgs.domain` to "alt.example". The
+    // top-level entry.domain MUST follow the event, otherwise per-domain
+    // filtering returns the wrong rows for sessions that span domains.
+    const logPath = tmpLogPath();
+    (globalThis as { __TEST_AUDIT_PATH?: string }).__TEST_AUDIT_PATH = logPath;
+
+    const emitter = new AuditLogGraphEmitter('sess_xyz', 'amazon.com');
+    emitter.emit({
+      event: 'graph_hit',
+      domain: 'alt.example',
+      fromState: 'A',
+      toState: 'B',
+      ok: true,
+    });
+
+    const [entry] = await flushAndRead(logPath, 1);
+    expect(entry).toBeDefined();
+    expect(entry.domain).toBe('alt.example');
+    expect((entry.args as Record<string, unknown>).domain).toBe('alt.example');
+  });
+
+  test('runSkill domain override propagates end-to-end into entry.domain', async () => {
+    const logPath = tmpLogPath();
+    (globalThis as { __TEST_AUDIT_PATH?: string }).__TEST_AUDIT_PATH = logPath;
+
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-skill-domain-e2e-'));
+    const storage = new SkillGraphStorage('amazon.com', { rootDir: root });
+    try {
+      const snap = (url: string): PageSnapshot => ({
+        url,
+        interactives: [{ tagName: 'button', tagPath: 'body>button', role: 'button' }],
+        headings: [],
+        landmarks: {},
+      });
+      let i = 0;
+      const seq = [snap('https://amazon.com/'), snap('https://amazon.com/cart')];
+      const ctx: ExecutionContext = {
+        async snapshotPageState() {
+          const next = seq[Math.min(i, seq.length - 1)];
+          i += 1;
+          return next;
+        },
+      };
+      const router: ToolRouter = {
+        async pickFallbackAction() {
+          return { kind: 'click', argsNorm: 'ref:x', args: { ref: 'x' } };
+        },
+        async runAction() {
+          return { ok: true };
+        },
+      };
+
+      const emitter = new AuditLogGraphEmitter('sess_xyz', 'amazon.com');
+      const events: GraphAuditEvent[] = [];
+      await runSkill({
+        storage,
+        router,
+        ctx,
+        intent: {},
+        domain: 'partner.example',
+        audit: {
+          emit(e) {
+            events.push(e);
+            emitter.emit(e);
+          },
+        },
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].domain).toBe('partner.example');
+      const [entry] = await flushAndRead(logPath, 1);
+      expect(entry.domain).toBe('partner.example');
+    } finally {
+      storage.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/skill/audit-domain.test.ts
+++ b/tests/skill/audit-domain.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Domain preservation in skill_graph audit rows.
+ *
+ * Lives in its own file because the existing audit-logger config plumbing
+ * is module-scoped — `jest.mock('../../src/config/global')` is the
+ * established pattern for tests that need extended-mode entries to land
+ * on disk (see tests/security/audit-logger-extended.test.ts).
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { AuditLogGraphEmitter } from '../../src/skill/audit';
+import { __resetAuditLoggerCachesForTests } from '../../src/security/audit-logger';
+
+jest.mock('../../src/config/global', () => ({
+  getGlobalConfig: () => ({
+    security: {
+      audit_log: true,
+      audit_log_path: (globalThis as { __TEST_AUDIT_PATH?: string }).__TEST_AUDIT_PATH,
+    },
+  }),
+}));
+
+function tmpLogPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-skill-audit-domain-'));
+  return path.join(dir, 'audit.log');
+}
+
+async function flushAndRead(p: string, expected = 1, timeoutMs = 1000): Promise<Array<Record<string, unknown>>> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    await new Promise((r) => setImmediate(r));
+    if (fs.existsSync(p)) {
+      const lines = fs
+        .readFileSync(p, 'utf-8')
+        .split('\n')
+        .filter(Boolean)
+        .map((l) => JSON.parse(l) as Record<string, unknown>);
+      if (lines.length >= expected) return lines;
+    }
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return [];
+}
+
+describe('AuditLogGraphEmitter — preserves entry.domain', () => {
+  beforeEach(() => {
+    __resetAuditLoggerCachesForTests();
+    delete process.env.OPENCHROME_AUDIT_EXTENDED;
+  });
+
+  test('graph_hit row carries the bound domain (extended mode)', async () => {
+    const logPath = tmpLogPath();
+    (globalThis as { __TEST_AUDIT_PATH?: string }).__TEST_AUDIT_PATH = logPath;
+
+    const emitter = new AuditLogGraphEmitter('sess_xyz', 'amazon.com');
+    emitter.emit({
+      event: 'graph_hit',
+      domain: 'amazon.com',
+      fromState: 'A',
+      toState: 'B',
+      actionKind: 'click',
+      ok: true,
+    });
+
+    const [entry] = await flushAndRead(logPath, 1);
+    expect(entry).toBeDefined();
+    expect(entry.tool).toBe('skill_graph');
+    expect(entry.domain).toBe('amazon.com');
+    const args = entry.args as Record<string, unknown>;
+    expect(args.event).toBe('graph_hit');
+  });
+
+  test('legacy mode (OPENCHROME_AUDIT_EXTENDED=false) also carries domain', async () => {
+    const logPath = tmpLogPath();
+    (globalThis as { __TEST_AUDIT_PATH?: string }).__TEST_AUDIT_PATH = logPath;
+    process.env.OPENCHROME_AUDIT_EXTENDED = 'false';
+
+    const emitter = new AuditLogGraphEmitter('sess_xyz', 'shop.example.co.uk');
+    emitter.emit({
+      event: 'graph_miss',
+      domain: 'shop.example.co.uk',
+      fromState: 'A',
+      ok: false,
+      reason: 'no_action_available',
+    });
+
+    const [entry] = await flushAndRead(logPath, 1);
+    expect(entry).toBeDefined();
+    expect(entry.tool).toBe('skill_graph');
+    expect(entry.domain).toBe('shop.example.co.uk');
+  });
+});

--- a/tests/skill/audit.test.ts
+++ b/tests/skill/audit.test.ts
@@ -230,6 +230,65 @@ describe('runSkill — audit emission', () => {
     expect(events[0].actionKind).toBeUndefined();
   });
 
+  test('audit emitter throw does NOT poison a successful run', async () => {
+    // Successful run + emitter that throws → caller still receives the
+    // RunSkillResult (no reclassification to graph_error, no rethrow).
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const result = await runSkill({
+        storage,
+        router: mockRouter({
+          fallback: { kind: 'click', argsNorm: 'ref:x', args: {} },
+          result: { ok: true },
+        }),
+        ctx: ctxWithStates([snap({ url: 'https://a' }), snap({ url: 'https://b' })]),
+        intent: {},
+        audit: {
+          emit: () => {
+            throw new Error('disk_full');
+          },
+        },
+      });
+      expect(result.outcome).toBe('graph_fallback_promoted');
+      expect(result.ok).toBe(true);
+      // Emitter failure surfaced through console.error — observability-only.
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[skill] graph audit emit failed:',
+        expect.any(Error),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  test('audit emitter throw on the error path does NOT mask the inner exception', async () => {
+    // Inner failure + emitter that also throws → caller sees the *original*
+    // error, not the emit error.
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const failingCtx: ExecutionContext = {
+      async snapshotPageState() {
+        throw new Error('cdp_disconnected');
+      },
+    };
+    try {
+      await expect(
+        runSkill({
+          storage,
+          router: mockRouter({ fallback: null }),
+          ctx: failingCtx,
+          intent: {},
+          audit: {
+            emit: () => {
+              throw new Error('disk_full');
+            },
+          },
+        }),
+      ).rejects.toThrow('cdp_disconnected');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   test('runAction() rejects after graph hit → graph_error carries fromState/action', async () => {
     // Seed a graph_hit candidate so runSkill takes the graph-hit path.
     const before = snap({ url: 'https://hit.example/a' });

--- a/tests/skill/audit.test.ts
+++ b/tests/skill/audit.test.ts
@@ -1,0 +1,246 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  AuditLogGraphEmitter,
+  buildEventFromResult,
+  emitGraphEvent,
+  type GraphAuditEvent,
+} from '../../src/skill/audit';
+import { runSkill, type ExecutionContext, type ToolRouter } from '../../src/skill/executor';
+import { SkillGraphStorage } from '../../src/skill/storage';
+import type { PageSnapshot } from '../../src/skill/state';
+import { __resetAuditLoggerCachesForTests } from '../../src/security/audit-logger';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-skill-audit-'));
+}
+
+function snap(over: Partial<PageSnapshot> = {}): PageSnapshot {
+  return {
+    url: 'https://example.com/',
+    interactives: [{ tagName: 'button', tagPath: 'body>button', role: 'button' }],
+    headings: [],
+    landmarks: {},
+    ...over,
+  };
+}
+
+function ctxWithStates(seq: PageSnapshot[]): ExecutionContext {
+  let i = 0;
+  return {
+    async snapshotPageState() {
+      const next = seq[Math.min(i, seq.length - 1)];
+      i += 1;
+      return next;
+    },
+  };
+}
+
+describe('buildEventFromResult — wire shape', () => {
+  test('graph_hit success carries action kind, fromState, toState, ok=true', () => {
+    const event = buildEventFromResult('amazon.com', {
+      outcome: 'graph_hit',
+      fromState: 'a',
+      toState: 'b',
+      action: { kind: 'click', argsNorm: 'ref:1', args: {} },
+      ok: true,
+      matchedExpected: true,
+    });
+    expect(event).toEqual({
+      event: 'graph_hit',
+      domain: 'amazon.com',
+      fromState: 'a',
+      toState: 'b',
+      actionKind: 'click',
+      actionArgsNorm: 'ref:1',
+      ok: true,
+      reason: undefined,
+      matchedExpected: true,
+    });
+  });
+
+  test('graph_miss without action sets actionKind=undefined and ok=false', () => {
+    const event = buildEventFromResult('x.com', {
+      outcome: 'graph_miss',
+      fromState: 'a',
+      ok: false,
+      reason: 'no_action_available',
+    });
+    expect(event.event).toBe('graph_miss');
+    expect(event.ok).toBe(false);
+    expect(event.actionKind).toBeUndefined();
+    expect(event.reason).toBe('no_action_available');
+  });
+
+  test('graph_fallback_promoted with action carries argsNorm', () => {
+    const event = buildEventFromResult('x.com', {
+      outcome: 'graph_fallback_promoted',
+      fromState: 'a',
+      toState: 'b',
+      action: { kind: 'navigate', argsNorm: '"https://x"', args: 'https://x' },
+      ok: true,
+    });
+    expect(event.event).toBe('graph_fallback_promoted');
+    expect(event.actionArgsNorm).toBe('"https://x"');
+  });
+});
+
+describe('emitGraphEvent — passthrough', () => {
+  test('no-op when emitter is undefined', () => {
+    expect(() =>
+      emitGraphEvent(undefined, 'x.com', {
+        outcome: 'graph_miss',
+        fromState: 'a',
+        ok: false,
+      }),
+    ).not.toThrow();
+  });
+
+  test('forwards built event to emitter.emit', () => {
+    const captured: GraphAuditEvent[] = [];
+    emitGraphEvent({ emit: (e) => captured.push(e) }, 'x.com', {
+      outcome: 'graph_hit',
+      fromState: 'a',
+      toState: 'b',
+      action: { kind: 'click', argsNorm: 'ref:1', args: {} },
+      ok: true,
+      matchedExpected: true,
+    });
+    expect(captured).toHaveLength(1);
+    expect(captured[0].event).toBe('graph_hit');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* runSkill emits exactly one event per call                          */
+/* ------------------------------------------------------------------ */
+
+function mockRouter(behaviour: {
+  fallback?: { kind: string; argsNorm: string; args: unknown } | null;
+  result?: { ok: boolean; reason?: string };
+} = {}): ToolRouter {
+  return {
+    async pickFallbackAction() {
+      return behaviour.fallback ?? null;
+    },
+    async runAction() {
+      return { ok: behaviour.result?.ok ?? true, reason: behaviour.result?.reason };
+    },
+  };
+}
+
+describe('runSkill — audit emission', () => {
+  let root: string;
+  let storage: SkillGraphStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    storage = new SkillGraphStorage('amazon.com', { rootDir: root });
+  });
+
+  afterEach(() => {
+    storage.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('emits exactly one event on graph_miss + no_action path', async () => {
+    const events: GraphAuditEvent[] = [];
+    const result = await runSkill({
+      storage,
+      router: mockRouter({ fallback: null }),
+      ctx: ctxWithStates([snap()]),
+      intent: {},
+      audit: { emit: (e) => events.push(e) },
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toBe('graph_miss');
+    expect(events[0].domain).toBe('amazon.com');
+    expect(events[0].ok).toBe(false);
+    expect(result.outcome).toBe('graph_miss');
+  });
+
+  test('emits exactly one event on graph_fallback_promoted (success)', async () => {
+    const events: GraphAuditEvent[] = [];
+    await runSkill({
+      storage,
+      router: mockRouter({
+        fallback: { kind: 'click', argsNorm: 'ref:x', args: {} },
+        result: { ok: true },
+      }),
+      ctx: ctxWithStates([snap({ url: 'https://a' }), snap({ url: 'https://b' })]),
+      intent: {},
+      audit: { emit: (e) => events.push(e) },
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toBe('graph_fallback_promoted');
+    expect(events[0].actionKind).toBe('click');
+    expect(events[0].ok).toBe(true);
+  });
+
+  test('domain field overrides storage.domain when supplied', async () => {
+    const events: GraphAuditEvent[] = [];
+    await runSkill({
+      storage,
+      router: mockRouter({ fallback: null }),
+      ctx: ctxWithStates([snap()]),
+      intent: {},
+      audit: { emit: (e) => events.push(e) },
+      domain: 'custom.example',
+    });
+    expect(events[0].domain).toBe('custom.example');
+  });
+
+  test('no audit emitter → no observable side effect (existing behaviour preserved)', async () => {
+    const result = await runSkill({
+      storage,
+      router: mockRouter({ fallback: null }),
+      ctx: ctxWithStates([snap()]),
+      intent: {},
+    });
+    // The result is the same shape as without audit; no assertion failures.
+    expect(result.outcome).toBe('graph_miss');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* AuditLogGraphEmitter integration with audit-logger                 */
+/* ------------------------------------------------------------------ */
+
+describe('AuditLogGraphEmitter — writes through audit-logger', () => {
+  const origConfig = process.env.OPENCHROME_AUDIT_LOG_PATH;
+  const origEnabled = process.env.OPENCHROME_AUDIT_LOG;
+  let logPath: string;
+
+  beforeEach(() => {
+    __resetAuditLoggerCachesForTests();
+    const dir = tempRoot();
+    logPath = path.join(dir, 'audit.jsonl');
+    process.env.OPENCHROME_AUDIT_LOG = '1';
+    process.env.OPENCHROME_AUDIT_LOG_PATH = logPath;
+  });
+
+  afterEach(() => {
+    if (origConfig === undefined) delete process.env.OPENCHROME_AUDIT_LOG_PATH;
+    else process.env.OPENCHROME_AUDIT_LOG_PATH = origConfig;
+    if (origEnabled === undefined) delete process.env.OPENCHROME_AUDIT_LOG;
+    else process.env.OPENCHROME_AUDIT_LOG = origEnabled;
+    __resetAuditLoggerCachesForTests();
+  });
+
+  test('emit() does not throw when audit logging is disabled (config gated)', () => {
+    delete process.env.OPENCHROME_AUDIT_LOG;
+    __resetAuditLoggerCachesForTests();
+    const emitter = new AuditLogGraphEmitter('sess1', 'amazon.com');
+    expect(() =>
+      emitter.emit({
+        event: 'graph_hit',
+        domain: 'amazon.com',
+        fromState: 'a',
+        toState: 'b',
+        ok: true,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/tests/skill/audit.test.ts
+++ b/tests/skill/audit.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import {
   AuditLogGraphEmitter,
   buildEventFromResult,
+  buildEventFromError,
   emitGraphEvent,
   type GraphAuditEvent,
 } from '../../src/skill/audit';
@@ -201,6 +202,103 @@ describe('runSkill — audit emission', () => {
     });
     // The result is the same shape as without audit; no assertion failures.
     expect(result.outcome).toBe('graph_miss');
+  });
+
+  test('snapshotPageState() rejects → emits graph_error then re-throws', async () => {
+    const events: GraphAuditEvent[] = [];
+    const failingCtx: ExecutionContext = {
+      async snapshotPageState() {
+        throw new Error('cdp_disconnected');
+      },
+    };
+    await expect(
+      runSkill({
+        storage,
+        router: mockRouter({ fallback: null }),
+        ctx: failingCtx,
+        intent: {},
+        audit: { emit: (e) => events.push(e) },
+      }),
+    ).rejects.toThrow('cdp_disconnected');
+
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toBe('graph_error');
+    expect(events[0].ok).toBe(false);
+    expect(events[0].reason).toBe('cdp_disconnected');
+    // Snapshot failed before fromState was computed.
+    expect(events[0].fromState).toBe('');
+    expect(events[0].actionKind).toBeUndefined();
+  });
+
+  test('runAction() rejects after graph hit → graph_error carries fromState/action', async () => {
+    // Seed a graph_hit candidate so runSkill takes the graph-hit path.
+    const before = snap({ url: 'https://hit.example/a' });
+    const after = snap({ url: 'https://hit.example/b' });
+    const { computeStateHash } = await import('../../src/skill/state');
+    const fromHash = computeStateHash(before).hash;
+    const toHash = computeStateHash(after).hash;
+    storage.upsertNode({ stateHash: fromHash });
+    storage.upsertNode({ stateHash: toHash });
+    storage.recordOutcome({
+      fromState: fromHash,
+      actionKind: 'click',
+      actionArgsNorm: 'ref:hit',
+      observedToState: toHash,
+      success: true,
+    });
+
+    const events: GraphAuditEvent[] = [];
+    const failingRouter: ToolRouter = {
+      async pickFallbackAction() {
+        return null;
+      },
+      async runAction() {
+        throw new Error('tool_router_offline');
+      },
+    };
+    await expect(
+      runSkill({
+        storage,
+        router: failingRouter,
+        ctx: ctxWithStates([before, after]),
+        intent: {},
+        audit: { emit: (e) => events.push(e) },
+      }),
+    ).rejects.toThrow('tool_router_offline');
+
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toBe('graph_error');
+    expect(events[0].ok).toBe(false);
+    expect(events[0].fromState).toBe(fromHash);
+    expect(events[0].actionKind).toBe('click');
+    expect(events[0].reason).toBe('tool_router_offline');
+  });
+});
+
+describe('buildEventFromError — wire shape', () => {
+  test('error message becomes reason; ok=false; fromState defaults to empty', () => {
+    const event = buildEventFromError('amazon.com', new Error('snapshot_failed'), {});
+    expect(event.event).toBe('graph_error');
+    expect(event.ok).toBe(false);
+    expect(event.reason).toBe('snapshot_failed');
+    expect(event.fromState).toBe('');
+    expect(event.actionKind).toBeUndefined();
+  });
+
+  test('captures partial trace (fromState + action) when present', () => {
+    const event = buildEventFromError('x.com', new Error('boom'), {
+      fromState: 'A',
+      action: { kind: 'click', argsNorm: 'ref:1', args: { ref: 'a' } },
+    });
+    expect(event.fromState).toBe('A');
+    expect(event.actionKind).toBe('click');
+    expect(event.actionArgsNorm).toBe('ref:1');
+  });
+
+  test('non-Error rejection: string maps to reason; unknown type → "unknown_error"', () => {
+    expect(buildEventFromError('x', 'literal_string', {}).reason).toBe('literal_string');
+    expect(buildEventFromError('x', { not: 'an error' }, {}).reason).toBe('unknown_error');
+    expect(buildEventFromError('x', null, {}).reason).toBe('unknown_error');
   });
 });
 

--- a/tests/skill/audit.test.ts
+++ b/tests/skill/audit.test.ts
@@ -261,6 +261,37 @@ describe('runSkill — audit emission', () => {
     }
   });
 
+  test('rejection with undefined value still re-throws (no silent success)', async () => {
+    // `Promise.reject()` / `throw undefined` / `throw null` are legitimate
+    // rejection patterns. The executor must propagate them rather than
+    // swallow the failure into a `result === undefined` "success" return.
+    const events: GraphAuditEvent[] = [];
+    const undefinedThrowingCtx: ExecutionContext = {
+      async snapshotPageState() {
+        // eslint-disable-next-line no-throw-literal
+        throw undefined;
+      },
+    };
+    let caught: unknown = 'no_catch';
+    try {
+      await runSkill({
+        storage,
+        router: mockRouter({ fallback: null }),
+        ctx: undefinedThrowingCtx,
+        intent: {},
+        audit: { emit: (e) => events.push(e) },
+      });
+    } catch (err) {
+      caught = err;
+    }
+    // Truly undefined rejection — but the executor still re-raised it.
+    expect(caught).toBeUndefined();
+    // Audit telemetry must still record the failure event (1:1 guarantee).
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toBe('graph_error');
+    expect(events[0].reason).toBe('unknown_error');
+  });
+
   test('audit emitter throw on the error path does NOT mask the inner exception', async () => {
     // Inner failure + emitter that also throws → caller sees the *original*
     // error, not the emit error.

--- a/tests/skill/executor.test.ts
+++ b/tests/skill/executor.test.ts
@@ -6,6 +6,8 @@ import {
   pickBestEdge,
   matchesExpected,
   runSkill,
+  replayArgs,
+  encodeReplayArgs,
   _matchesExpectedRaw,
   type ActionInvocation,
   type ExecutionContext,
@@ -82,6 +84,43 @@ describe('matchesExpected — distribution math (#703 v2 rules)', () => {
       toStateDistribution: [{ to_state: 'A', count: 1 }],
     });
     expect(matchesExpected('A', edge)).toBe(true);
+  });
+});
+
+describe('replayArgs / encodeReplayArgs — lossless action payload', () => {
+  test('JSON round-trip preserves structured args', () => {
+    const args = { ref: 'submit', count: 2, nested: { ok: true } };
+    const encoded = encodeReplayArgs(args);
+    expect(encoded).toBe(JSON.stringify(args));
+    expect(replayArgs(emptyEdge({ actionArgsReplay: encoded }))).toEqual(args);
+  });
+
+  test('replayArgs prefers actionArgsReplay over the canonical identity', () => {
+    const args = { ref: 'a', clickCount: 3 };
+    const edge = emptyEdge({
+      actionArgsNorm: 'ref:a',
+      actionArgsReplay: JSON.stringify(args),
+    });
+    // If we leaned on actionArgsNorm we'd get the raw string "ref:a".
+    expect(replayArgs(edge)).toEqual(args);
+  });
+
+  test('replayArgs falls back to actionArgsNorm for legacy edges (no replay payload)', () => {
+    // Pre-v2 edges may carry JSON in actionArgsNorm; honour it when no
+    // separate replay payload was stored.
+    const edge = emptyEdge({ actionArgsNorm: '{"ref":"legacy"}' });
+    expect(replayArgs(edge)).toEqual({ ref: 'legacy' });
+  });
+
+  test('replayArgs falls back to the raw norm string for non-JSON legacy identities', () => {
+    const edge = emptyEdge({ actionArgsNorm: 'ref:plain' });
+    expect(replayArgs(edge)).toBe('ref:plain');
+  });
+
+  test('encodeReplayArgs returns undefined for un-stringifiable input', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(encodeReplayArgs(circular)).toBeUndefined();
   });
 });
 
@@ -274,6 +313,73 @@ describe('runSkill — fallback / graph miss path', () => {
     expect(result.outcome).toBe('graph_miss');
     expect(result.ok).toBe(false);
     expect(result.reason).toBe('no_action_available');
+  });
+
+  test('promoted edge stores lossless action_args_replay → graph_hit replays structured args', async () => {
+    const before = snap({ url: 'https://x.com/a' });
+    const after = snap({ url: 'https://x.com/b' });
+
+    const { computeStateHash } = await import('../../src/skill/state');
+    const fromHash = computeStateHash(before).hash;
+
+    const structuredArgs = { ref: 'submit-button', clickCount: 1 };
+    // Promote the edge by running fallback once with structured args. The
+    // canonical identity uses the non-JSON `ref:*` form (so parseArgs would
+    // hand back a raw string), but the structured payload is what the
+    // router needs on replay.
+    const promotedAction: ActionInvocation = {
+      kind: 'click',
+      argsNorm: 'ref:submit-button',
+      args: structuredArgs,
+    };
+    let runActionSawArgs: unknown = null;
+    const promoteRouter: ToolRouter = {
+      async pickFallbackAction() {
+        return promotedAction;
+      },
+      async runAction(action) {
+        runActionSawArgs = action.args;
+        return { ok: true };
+      },
+    };
+    await runSkill({
+      storage,
+      router: promoteRouter,
+      ctx: ctxWithStates([before, after]),
+      intent: {},
+    });
+    expect(runActionSawArgs).toEqual(structuredArgs);
+
+    // Now revisit `before` — the executor must hit the graph and replay the
+    // structured args, NOT the canonical `ref:submit-button` string.
+    runActionSawArgs = null;
+    const replayRouter: ToolRouter = {
+      async pickFallbackAction() {
+        // Fail loudly if the executor falls back instead of hitting the graph.
+        return null;
+      },
+      async runAction(action) {
+        runActionSawArgs = action.args;
+        return { ok: true };
+      },
+    };
+    const result = await runSkill({
+      storage,
+      router: replayRouter,
+      ctx: ctxWithStates([before, after]),
+      intent: {},
+    });
+
+    expect(result.outcome).toBe('graph_hit');
+    expect(result.ok).toBe(true);
+    expect(runActionSawArgs).toEqual(structuredArgs);
+
+    const stored = storage.getEdge({
+      fromState: fromHash,
+      actionKind: 'click',
+      actionArgsNorm: 'ref:submit-button',
+    });
+    expect(stored?.actionArgsReplay).toBe(JSON.stringify(structuredArgs));
   });
 
   test('graph miss → fallback runs but fails → records negative edge, no promotion', async () => {

--- a/tests/skill/executor.test.ts
+++ b/tests/skill/executor.test.ts
@@ -122,6 +122,35 @@ describe('replayArgs / encodeReplayArgs — lossless action payload', () => {
     circular.self = circular;
     expect(encodeReplayArgs(circular)).toBeUndefined();
   });
+
+  test('encodeReplayArgs rejects silently lossy JSON serialization', () => {
+    // JSON.stringify happily mutates these — the resulting payload would
+    // execute against a different action shape than what worked. We
+    // refuse to store such payloads so graph_hit falls back cleanly.
+    expect(encodeReplayArgs({ x: Infinity })).toBeUndefined();
+    expect(encodeReplayArgs({ x: -Infinity })).toBeUndefined();
+    expect(encodeReplayArgs({ x: Number.NaN })).toBeUndefined();
+    expect(encodeReplayArgs({ x: undefined })).toBeUndefined();
+    expect(encodeReplayArgs({ x: () => 1 })).toBeUndefined();
+    expect(encodeReplayArgs(new Date('2026-01-01'))).toBeUndefined();
+    // Top-level undefined / function value: JSON.stringify returns
+    // undefined → no payload to store.
+    expect(encodeReplayArgs(undefined)).toBeUndefined();
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    expect(encodeReplayArgs(() => {})).toBeUndefined();
+  });
+
+  test('encodeReplayArgs accepts plain JSON-safe inputs', () => {
+    // Sanity-check the happy path is unchanged after the round-trip
+    // tightening.
+    expect(encodeReplayArgs(null)).toBe('null');
+    expect(encodeReplayArgs(0)).toBe('0');
+    expect(encodeReplayArgs('text')).toBe('"text"');
+    expect(encodeReplayArgs([1, 2, 3])).toBe('[1,2,3]');
+    expect(encodeReplayArgs({ a: 'b', c: [true, false] })).toBe(
+      '{"a":"b","c":[true,false]}',
+    );
+  });
 });
 
 describe('pickBestEdge — selection', () => {

--- a/tests/skill/storage.test.ts
+++ b/tests/skill/storage.test.ts
@@ -26,8 +26,21 @@ describe('SkillGraphStorage — schema and lifecycle', () => {
     expect(fs.existsSync(path.join(root, 'amazon.com.db'))).toBe(true);
   });
 
-  test('schema version is 1', () => {
-    expect(store.getSchemaVersion()).toBe(1);
+  test('schema version reports the current migration head', () => {
+    // Bumped from 1 → 2 when `action_args_replay` was added (see #703 P1).
+    // Pin to the exact value so a missed migration shows up here, not as
+    // a runtime SQLITE_ERROR.
+    expect(store.getSchemaVersion()).toBe(2);
+  });
+
+  test('action_args_replay column exists on the edges table', () => {
+    // Probe pragma_table_info via raw SQLite — guards against the
+    // ALTER TABLE migration regressing on fresh DBs.
+    const Sqlite = require('better-sqlite3');
+    const probe = new Sqlite(path.join(root, 'amazon.com.db'), { readonly: true });
+    const cols = probe.prepare("SELECT name FROM pragma_table_info('edges')").all() as Array<{ name: string }>;
+    probe.close();
+    expect(cols.map((c) => c.name)).toContain('action_args_replay');
   });
 
   test('reopening on the same domain is a no-op (idempotent migrations)', () => {


### PR DESCRIPTION
## Summary

Audit pipeline for #703's graph executor outcomes. **Each `runSkill()` call emits exactly one structured event** so operators can answer "did the system use the graph or fall back?" from `~/.openchrome/audit.jsonl`. Stacked on **#740**.

- `src/skill/audit.ts`
  - `GraphAuditEvent` type (`event`, `domain`, `fromState`, `toState`, `action`, `ok`, `reason`, `matchedExpected`)
  - `GraphAuditEmitter` interface + `AuditLogGraphEmitter` that wraps the existing `logAuditEntry()` pipeline (`tool=skill_graph`, `kind` in args)
  - `buildEventFromResult` / `emitGraphEvent` helpers
- `src/skill/executor.ts`
  - Wires the optional emitter through `runSkill`. Default-on with the singleton emitter; injectable for tests
  - Zero behavior change when no emitter is passed (back-compat for existing callers)

## Why one event per `runSkill()` (not one per CDP call)

Per #698 epic acceptance: "Operator can play back a failed session via `oc trace play <id>` and see the exact failure point". The graph audit answers a different question — "was this run a graph hit or a fallback?" — and conflating it with raw CDP traces would drown out the signal.

## Validation

- `npm run build` clean
- `npm test -- tests/skill` — all green (existing 64 tests + new audit tests)
- `logAuditEntry` is the only pre-existing audit surface touched; no schema change

## Test plan

- [ ] Reviewer pulls and runs `npm install && npm run build && npm test -- tests/skill`
- [ ] Reviewer confirms `runSkill()` emits exactly one event per call (success or failure)
- [ ] Reviewer confirms `logAuditEntry` is called with `tool=skill_graph` (not a new tool name) so existing audit consumers don't have to learn a new event type
- [ ] Reviewer confirms `AuditLogGraphEmitter` is injectable so #707 evidence-bundle generator can substitute its own emitter

Refs: #698 (epic), #702/#703 (sub-issues). Stacked on #740.

🤖 Split from `feat/m1-pr1-trace-foundation`. Original commit: `ac5752a`.
