### PR TITLE
feat(cli): oc trace list/show + oc skill list/inspect (M1 PR-3 partial)

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -41,6 +41,8 @@ import {
   validateBase32,
 } from './totp-store';
 import { registerAdminKeysCommand } from './admin-keys';
+import { registerTraceCommand } from './trace';
+import { registerSkillCommand } from './skill';
 
 const program = new Command();
 
@@ -1246,5 +1248,11 @@ totp
 
 // Admin CLI — tenant API key management (issue #9 / PR3).
 registerAdminKeysCommand(program);
+
+// Trace inspection (M1 PR-3).
+registerTraceCommand(program);
+
+// Skill graph inspection (M1 PR-3).
+registerSkillCommand(program);
 
 program.parse();

--- a/cli/skill.ts
+++ b/cli/skill.ts
@@ -1,0 +1,189 @@
+/**
+ * `oc skill` subcommand group.
+ *
+ * Reads per-domain skill graph databases at
+ * `~/.openchrome/skills/<domain>.db` and prints a summary. Mirrors the
+ * `inspect()` API in `src/skill/storage.ts`, but speaks SQL directly so
+ * we don't have to thread imports across the cli/ ↔ src/ boundary.
+ *
+ * Commands:
+ *   oc skill inspect <domain> [--json]
+ *   oc skill list                   (lists all domain DBs in the root)
+ */
+
+import type { Command } from 'commander';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+type BetterSqlite3 = typeof import('better-sqlite3');
+type Database = import('better-sqlite3').Database;
+
+let _Sqlite: BetterSqlite3 | null = null;
+function loadSqlite(): BetterSqlite3 {
+  if (_Sqlite) return _Sqlite;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  _Sqlite = require('better-sqlite3') as BetterSqlite3;
+  return _Sqlite;
+}
+
+const DEFAULT_SKILL_ROOT = path.join(os.homedir(), '.openchrome', 'skills');
+
+function skillRoot(): string {
+  return process.env.OPENCHROME_SKILL_ROOT ?? DEFAULT_SKILL_ROOT;
+}
+
+function openDomainDb(rootDir: string, domain: string): Database | null {
+  const dbPath = path.join(rootDir, `${domain}.db`);
+  if (!fs.existsSync(dbPath)) return null;
+  const Sqlite = loadSqlite();
+  return new Sqlite(dbPath, { readonly: true, fileMustExist: true });
+}
+
+function fmtTime(ms: number | null | undefined): string {
+  if (ms == null) return '—';
+  return new Date(ms).toISOString().replace('T', ' ').slice(0, 19);
+}
+
+interface InspectSummary {
+  domain: string;
+  nodeCount: number;
+  edgeCount: number;
+  topEdges: Array<{
+    from: string;
+    actionKind: string;
+    successCount: number;
+    failCount: number;
+  }>;
+  recentFailures: Array<{
+    from: string;
+    actionKind: string;
+    failCount: number;
+    lastFailedAt: number;
+  }>;
+}
+
+function inspectDomain(domain: string, opts: { json?: boolean }): void {
+  const rootDir = skillRoot();
+  const db = openDomainDb(rootDir, domain);
+  if (!db) {
+    console.error(`No skill graph for domain: ${domain} (looked at ${rootDir}/${domain}.db)`);
+    process.exitCode = 1;
+    return;
+  }
+
+  let summary: InspectSummary;
+  try {
+    const nodeCount = (db.prepare('SELECT COUNT(*) AS n FROM nodes').get() as { n: number }).n;
+    const edgeCount = (db.prepare('SELECT COUNT(*) AS n FROM edges').get() as { n: number }).n;
+    const topRows = db
+      .prepare(
+        'SELECT from_state, action_kind, success_count, fail_count FROM edges ORDER BY success_count + fail_count DESC LIMIT 10',
+      )
+      .all() as Array<{
+      from_state: string;
+      action_kind: string;
+      success_count: number;
+      fail_count: number;
+    }>;
+    const failingRows = db
+      .prepare(
+        'SELECT from_state, action_kind, fail_count, last_failed_at FROM edges WHERE last_failed_at IS NOT NULL ORDER BY last_failed_at DESC LIMIT 10',
+      )
+      .all() as Array<{
+      from_state: string;
+      action_kind: string;
+      fail_count: number;
+      last_failed_at: number;
+    }>;
+    summary = {
+      domain,
+      nodeCount,
+      edgeCount,
+      topEdges: topRows.map((r) => ({
+        from: r.from_state,
+        actionKind: r.action_kind,
+        successCount: r.success_count,
+        failCount: r.fail_count,
+      })),
+      recentFailures: failingRows.map((r) => ({
+        from: r.from_state,
+        actionKind: r.action_kind,
+        failCount: r.fail_count,
+        lastFailedAt: r.last_failed_at,
+      })),
+    };
+  } finally {
+    db.close();
+  }
+
+  if (opts.json) {
+    console.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
+  console.log(`Skill graph: ${summary.domain}`);
+  console.log(`Nodes      : ${summary.nodeCount}`);
+  console.log(`Edges      : ${summary.edgeCount}`);
+  console.log('');
+  console.log('Top edges by total invocations:');
+  if (summary.topEdges.length === 0) {
+    console.log('  (none)');
+  } else {
+    for (const e of summary.topEdges) {
+      const total = e.successCount + e.failCount;
+      const rate = total === 0 ? '—' : `${Math.round((e.successCount / total) * 100)}%`;
+      console.log(
+        `  ${e.from.slice(0, 16)}  ${e.actionKind.padEnd(12)}  ${String(e.successCount).padStart(4)} ok / ${String(e.failCount).padStart(4)} fail  (${rate})`,
+      );
+    }
+  }
+  console.log('');
+  console.log('Recent failures:');
+  if (summary.recentFailures.length === 0) {
+    console.log('  (none)');
+  } else {
+    for (const f of summary.recentFailures) {
+      console.log(
+        `  ${fmtTime(f.lastFailedAt)}  ${f.from.slice(0, 16)}  ${f.actionKind.padEnd(12)}  fail_count=${f.failCount}`,
+      );
+    }
+  }
+}
+
+function listDomains(opts: { json?: boolean }): void {
+  const rootDir = skillRoot();
+  if (!fs.existsSync(rootDir)) {
+    console.error(`No skill root at ${rootDir} — has the executor ever run?`);
+    process.exitCode = 1;
+    return;
+  }
+  const entries = fs.readdirSync(rootDir).filter((f) => f.endsWith('.db'));
+  const domains = entries.map((f) => f.replace(/\.db$/, ''));
+  if (opts.json) {
+    console.log(JSON.stringify(domains, null, 2));
+    return;
+  }
+  if (domains.length === 0) {
+    console.error('No domain databases yet.');
+    return;
+  }
+  for (const d of domains) console.log(d);
+}
+
+export function registerSkillCommand(program: Command): void {
+  const cmd = program.command('skill').description('Inspect the skill-graph state');
+
+  cmd
+    .command('list')
+    .description('List domains with a skill graph')
+    .option('--json', 'Emit raw JSON instead of newline-separated names')
+    .action((options: { json?: boolean }) => listDomains(options));
+
+  cmd
+    .command('inspect')
+    .description('Show node/edge counts and top edges for a domain')
+    .argument('<domain>', 'eTLD+1 host (matches the domain stored by the executor)')
+    .option('--json', 'Emit raw JSON instead of pretty text')
+    .action((domain: string, options: { json?: boolean }) => inspectDomain(domain, options));
+}

--- a/cli/skill.ts
+++ b/cli/skill.ts
@@ -49,6 +49,9 @@ function assertSafeDomain(domain: string): void {
 }
 
 function openDomainDb(rootDir: string, domain: string): Database | null {
+  // The first call validates the user-provided domain — a separator or
+  // `..` segment throws before the join below, so this `path.join` can
+  // never escape `OPENCHROME_SKILL_ROOT`.
   assertSafeDomain(domain);
   const dbPath = path.join(rootDir, `${domain}.db`);
   if (!fs.existsSync(dbPath)) return null;

--- a/cli/skill.ts
+++ b/cli/skill.ts
@@ -33,7 +33,23 @@ function skillRoot(): string {
   return process.env.OPENCHROME_SKILL_ROOT ?? DEFAULT_SKILL_ROOT;
 }
 
+/**
+ * Validate a domain argument before joining it into a filesystem path.
+ *
+ * Mirrors `SkillGraphStorage`'s constructor check (src/skill/storage.ts):
+ * empty strings, path separators, and `..` segments are rejected so that
+ * `<domain>.db` cannot escape `OPENCHROME_SKILL_ROOT`. Without this guard
+ * a value like `../../other/place/foo` would let the CLI read arbitrary
+ * `.db` files reachable from the current user.
+ */
+function assertSafeDomain(domain: string): void {
+  if (!domain || /[\\/]/.test(domain) || domain === '..' || domain === '.') {
+    throw new Error(`Invalid domain: ${JSON.stringify(domain)}`);
+  }
+}
+
 function openDomainDb(rootDir: string, domain: string): Database | null {
+  assertSafeDomain(domain);
   const dbPath = path.join(rootDir, `${domain}.db`);
   if (!fs.existsSync(dbPath)) return null;
   const Sqlite = loadSqlite();

--- a/cli/trace.ts
+++ b/cli/trace.ts
@@ -1,0 +1,245 @@
+/**
+ * `oc trace` subcommand group.
+ *
+ * Reads the trace index at `~/.openchrome/traces/index.sqlite` and the
+ * per-session JSONL files written by `src/trace/recorder.ts`. The CLI
+ * does not import from `src/` because tsconfig.cli.json roots from
+ * `cli/` — it speaks SQL directly against the trace index.
+ *
+ * Commands:
+ *   oc trace list   [--since ISO|--status|--domain|--limit]
+ *   oc trace show   <session-id> [--limit]
+ *
+ * `oc trace play` (interactive replay UI) is deferred to a follow-up PR.
+ */
+
+import type { Command } from 'commander';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+type BetterSqlite3 = typeof import('better-sqlite3');
+type Database = import('better-sqlite3').Database;
+
+let _Sqlite: BetterSqlite3 | null = null;
+function loadSqlite(): BetterSqlite3 {
+  if (_Sqlite) return _Sqlite;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  _Sqlite = require('better-sqlite3') as BetterSqlite3;
+  return _Sqlite;
+}
+
+interface TraceRow {
+  session_id: string;
+  started_at: number;
+  ended_at: number | null;
+  domain: string | null;
+  status: string;
+  byte_size: number;
+  parent_op: string | null;
+}
+
+interface JsonlEvent {
+  ts: number;
+  seq: number;
+  kind: string;
+  body: unknown;
+}
+
+const DEFAULT_TRACE_ROOT = path.join(os.homedir(), '.openchrome', 'traces');
+
+function traceRoot(): string {
+  return process.env.OPENCHROME_TRACE_ROOT ?? DEFAULT_TRACE_ROOT;
+}
+
+function openIndex(rootDir: string): Database | null {
+  const dbPath = path.join(rootDir, 'index.sqlite');
+  if (!fs.existsSync(dbPath)) return null;
+  const Sqlite = loadSqlite();
+  return new Sqlite(dbPath, { readonly: true, fileMustExist: true });
+}
+
+function fmtTime(ms: number | null | undefined): string {
+  if (ms == null) return '—';
+  return new Date(ms).toISOString().replace('T', ' ').slice(0, 19);
+}
+
+function fmtBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(n) / Math.log(k));
+  return `${(n / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
+}
+
+function listTraces(opts: {
+  since?: string;
+  status?: string;
+  domain?: string;
+  limit?: string;
+  json?: boolean;
+}): void {
+  const rootDir = traceRoot();
+  const db = openIndex(rootDir);
+  if (!db) {
+    console.error(`No trace index at ${rootDir}/index.sqlite — has the recorder ever run?`);
+    process.exitCode = 1;
+    return;
+  }
+  try {
+    const where: string[] = [];
+    const params: (string | number)[] = [];
+    if (opts.since) {
+      const t = Date.parse(opts.since);
+      if (Number.isNaN(t)) {
+        console.error(`Invalid --since: ${opts.since}`);
+        process.exitCode = 1;
+        return;
+      }
+      where.push('started_at >= ?');
+      params.push(t);
+    }
+    if (opts.status) {
+      where.push('status = ?');
+      params.push(opts.status);
+    }
+    if (opts.domain) {
+      where.push('domain = ?');
+      params.push(opts.domain);
+    }
+    const limit = Math.max(1, Math.min(1000, parseInt(opts.limit ?? '50', 10) || 50));
+    const sql =
+      'SELECT session_id, started_at, ended_at, domain, status, byte_size, parent_op FROM traces' +
+      (where.length ? ' WHERE ' + where.join(' AND ') : '') +
+      ' ORDER BY started_at DESC LIMIT ?';
+    const rows = db.prepare(sql).all(...params, limit) as TraceRow[];
+
+    if (opts.json) {
+      console.log(JSON.stringify(rows, null, 2));
+      return;
+    }
+
+    if (rows.length === 0) {
+      console.error('No traces matched the filter.');
+      return;
+    }
+
+    // Header
+    const cols = ['SESSION', 'STARTED', 'ENDED', 'STATUS', 'DOMAIN', 'SIZE'];
+    const widths = [22, 19, 19, 10, 24, 10];
+    console.log(cols.map((c, i) => c.padEnd(widths[i])).join(' '));
+    console.log('-'.repeat(widths.reduce((a, b) => a + b + 1, -1)));
+    for (const r of rows) {
+      console.log(
+        [
+          (r.session_id || '').slice(0, widths[0]).padEnd(widths[0]),
+          fmtTime(r.started_at).padEnd(widths[1]),
+          fmtTime(r.ended_at).padEnd(widths[2]),
+          (r.status || '').padEnd(widths[3]),
+          (r.domain ?? '').slice(0, widths[4]).padEnd(widths[4]),
+          fmtBytes(r.byte_size).padEnd(widths[5]),
+        ].join(' '),
+      );
+    }
+  } finally {
+    db.close();
+  }
+}
+
+function showTrace(sessionId: string, opts: { limit?: string; json?: boolean }): void {
+  const rootDir = traceRoot();
+  const db = openIndex(rootDir);
+  if (!db) {
+    console.error(`No trace index at ${rootDir}/index.sqlite`);
+    process.exitCode = 1;
+    return;
+  }
+  let row: TraceRow | undefined;
+  try {
+    row = db
+      .prepare(
+        'SELECT session_id, started_at, ended_at, domain, status, byte_size, parent_op FROM traces WHERE session_id = ?',
+      )
+      .get(sessionId) as TraceRow | undefined;
+  } finally {
+    db.close();
+  }
+  if (!row) {
+    console.error(`No trace found: ${sessionId}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  // Read JSONL files for this session.
+  const sessionDir = path.join(rootDir, sessionId);
+  const events: JsonlEvent[] = [];
+  if (fs.existsSync(sessionDir)) {
+    const files = fs
+      .readdirSync(sessionDir)
+      .filter((f) => f.endsWith('.jsonl'))
+      .sort();
+    for (const f of files) {
+      const content = fs.readFileSync(path.join(sessionDir, f), 'utf8');
+      for (const line of content.split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          events.push(JSON.parse(line));
+        } catch {
+          // skip malformed
+        }
+      }
+    }
+  }
+
+  const limit = Math.max(1, Math.min(10000, parseInt(opts.limit ?? '50', 10) || 50));
+  const slice = events.slice(0, limit);
+
+  if (opts.json) {
+    console.log(JSON.stringify({ meta: row, events: slice, totalEvents: events.length }, null, 2));
+    return;
+  }
+
+  console.log(`Session  : ${row.session_id}`);
+  console.log(`Started  : ${fmtTime(row.started_at)}`);
+  console.log(`Ended    : ${fmtTime(row.ended_at)}`);
+  console.log(`Status   : ${row.status}`);
+  console.log(`Domain   : ${row.domain ?? '—'}`);
+  console.log(`Parent op: ${row.parent_op ?? '—'}`);
+  console.log(`Size     : ${fmtBytes(row.byte_size)}`);
+  console.log(`Events   : ${events.length} (showing first ${slice.length})`);
+  console.log('');
+  for (const ev of slice) {
+    const t = fmtTime(ev.ts);
+    const seq = String(ev.seq).padStart(4);
+    console.log(`[${t}] #${seq} ${ev.kind}`);
+  }
+  if (events.length > slice.length) {
+    console.log(`... (${events.length - slice.length} more events; pass --limit to see more)`);
+  }
+}
+
+export function registerTraceCommand(program: Command): void {
+  const cmd = program.command('trace').description('Inspect captured browser-session traces');
+
+  cmd
+    .command('list')
+    .description('List recent trace sessions')
+    .option('--since <iso>', 'Only sessions started at or after this ISO timestamp')
+    .option('--status <status>', 'Filter by status (running|completed|failed|aborted)')
+    .option('--domain <domain>', 'Filter by exact domain match')
+    .option('--limit <n>', 'Max rows to return (default 50, cap 1000)', '50')
+    .option('--json', 'Emit raw JSON instead of table')
+    .action((options: { since?: string; status?: string; domain?: string; limit?: string; json?: boolean }) =>
+      listTraces(options),
+    );
+
+  cmd
+    .command('show')
+    .description('Show metadata + recent events for one trace session')
+    .argument('<session-id>', 'The trace session id (from `oc trace list`)')
+    .option('--limit <n>', 'Max events to print (default 50, cap 10000)', '50')
+    .option('--json', 'Emit raw JSON instead of pretty text')
+    .action((sessionId: string, options: { limit?: string; json?: boolean }) =>
+      showTrace(sessionId, options),
+    );
+}

--- a/cli/trace.ts
+++ b/cli/trace.ts
@@ -64,11 +64,16 @@ function fmtTime(ms: number | null | undefined): string {
   return new Date(ms).toISOString().replace('T', ' ').slice(0, 19);
 }
 
-function fmtBytes(n: number): string {
+function fmtBytes(n: number | null | undefined): string {
+  // Defensive: byte_size is INTEGER NOT NULL DEFAULT 0 in the schema, but
+  // older trace indexes may have NULL rows, and `Math.log(0)` = -Infinity
+  // would propagate to "NaN undefined". Treat any non-positive / non-finite
+  // input as zero so `oc trace list` never renders garbage for empty traces.
+  if (n == null || !Number.isFinite(n) || n <= 0) return '0 B';
   if (n < 1024) return `${n} B`;
   const k = 1024;
   const sizes = ['B', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(n) / Math.log(k));
+  const i = Math.min(sizes.length - 1, Math.floor(Math.log(n) / Math.log(k)));
   return `${(n / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
 }
 

--- a/cli/trace.ts
+++ b/cli/trace.ts
@@ -183,13 +183,23 @@ function showTrace(sessionId: string, opts: { limit?: string; json?: boolean }):
   }
 
   // Read JSONL files for this session.
+  // Recorder names chunks `<ts>-<seq>.jsonl`. A plain lexical sort would
+  // place `1730000000000-10.jsonl` before `1730000000000-2.jsonl`, and
+  // because recorder timestamps come from `Date.now()` two flushes can
+  // share a millisecond. Sort by parsed (ts, seq) numerically so
+  // `--limit` always operates on the true tail of the timeline.
   const sessionDir = path.join(rootDir, sessionId);
   const events: JsonlEvent[] = [];
   if (fs.existsSync(sessionDir)) {
     const files = fs
       .readdirSync(sessionDir)
       .filter((f) => f.endsWith('.jsonl'))
-      .sort();
+      .map((f) => {
+        const m = /^(\d+)-(\d+)\.jsonl$/.exec(f);
+        return { f, ts: m ? Number(m[1]) : 0, seq: m ? Number(m[2]) : 0 };
+      })
+      .sort((a, b) => (a.ts - b.ts) || (a.seq - b.seq))
+      .map((e) => e.f);
     for (const f of files) {
       const content = fs.readFileSync(path.join(sessionDir, f), 'utf8');
       for (const line of content.split('\n')) {

--- a/cli/trace.ts
+++ b/cli/trace.ts
@@ -129,15 +129,22 @@ function listTraces(opts: {
       return;
     }
 
-    // Header
+    // Header. The SESSION column is sized to the widest id in this batch
+    // (with a 22-char floor for the header label) so the printed id can
+    // always be copy-pasted into `oc trace show <id>`. UUIDs (36) and
+    // longer ids stay intact.
     const cols = ['SESSION', 'STARTED', 'ENDED', 'STATUS', 'DOMAIN', 'SIZE'];
-    const widths = [22, 19, 19, 10, 24, 10];
+    const sessionWidth = rows.reduce(
+      (acc, r) => Math.max(acc, (r.session_id || '').length),
+      'SESSION'.length,
+    );
+    const widths = [sessionWidth, 19, 19, 10, 24, 10];
     console.log(cols.map((c, i) => c.padEnd(widths[i])).join(' '));
     console.log('-'.repeat(widths.reduce((a, b) => a + b + 1, -1)));
     for (const r of rows) {
       console.log(
         [
-          (r.session_id || '').slice(0, widths[0]).padEnd(widths[0]),
+          (r.session_id || '').padEnd(widths[0]),
           fmtTime(r.started_at).padEnd(widths[1]),
           fmtTime(r.ended_at).padEnd(widths[2]),
           (r.status || '').padEnd(widths[3]),
@@ -197,10 +204,21 @@ function showTrace(sessionId: string, opts: { limit?: string; json?: boolean }):
   }
 
   const limit = Math.max(1, Math.min(10000, parseInt(opts.limit ?? '50', 10) || 50));
-  const slice = events.slice(0, limit);
+  // The CLI help advertises "recent events", so when `events.length`
+  // exceeds the limit we keep the *tail* of the timeline. The previous
+  // `slice(0, limit)` returned the oldest events and hid the failure
+  // trigger that operators almost always need first.
+  const omitted = Math.max(0, events.length - limit);
+  const slice = events.slice(omitted);
 
   if (opts.json) {
-    console.log(JSON.stringify({ meta: row, events: slice, totalEvents: events.length }, null, 2));
+    console.log(
+      JSON.stringify(
+        { meta: row, events: slice, totalEvents: events.length, omitted },
+        null,
+        2,
+      ),
+    );
     return;
   }
 
@@ -211,15 +229,15 @@ function showTrace(sessionId: string, opts: { limit?: string; json?: boolean }):
   console.log(`Domain   : ${row.domain ?? '—'}`);
   console.log(`Parent op: ${row.parent_op ?? '—'}`);
   console.log(`Size     : ${fmtBytes(row.byte_size)}`);
-  console.log(`Events   : ${events.length} (showing first ${slice.length})`);
+  console.log(`Events   : ${events.length} (showing last ${slice.length})`);
   console.log('');
+  if (omitted > 0) {
+    console.log(`... (${omitted} earlier events; pass --limit to see more)`);
+  }
   for (const ev of slice) {
     const t = fmtTime(ev.ts);
     const seq = String(ev.seq).padStart(4);
     console.log(`[${t}] #${seq} ${ev.kind}`);
-  }
-  if (events.length > slice.length) {
-    console.log(`... (${events.length - slice.length} more events; pass --limit to see more)`);
   }
 }
 

--- a/cli/trace.ts
+++ b/cli/trace.ts
@@ -17,6 +17,7 @@ import type { Command } from 'commander';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as readline from 'readline';
 
 type BetterSqlite3 = typeof import('better-sqlite3');
 type Database = import('better-sqlite3').Database;
@@ -158,7 +159,63 @@ function listTraces(opts: {
   }
 }
 
-function showTrace(sessionId: string, opts: { limit?: string; json?: boolean }): void {
+/**
+ * Stream every JSONL chunk for the session line-by-line and keep only
+ * the last `limit` parseable events in memory. Counting `total` is
+ * decoupled from the kept array, so memory stays bounded by `limit`
+ * regardless of how large the trace directory has grown.
+ *
+ * Recorder names chunks `<ts>-<seq>.jsonl`. A plain lexical sort would
+ * place `...-10.jsonl` before `...-2.jsonl`, and because recorder
+ * timestamps come from `Date.now()` two flushes can share a millisecond,
+ * so sort numerically by parsed `(ts, seq)`.
+ */
+async function streamSessionTail(
+  sessionDir: string,
+  limit: number,
+): Promise<{ tail: JsonlEvent[]; total: number }> {
+  const tail: JsonlEvent[] = [];
+  let total = 0;
+  if (!fs.existsSync(sessionDir)) return { tail, total };
+
+  const files = fs
+    .readdirSync(sessionDir)
+    .filter((f) => f.endsWith('.jsonl'))
+    .map((f) => {
+      const m = /^(\d+)-(\d+)\.jsonl$/.exec(f);
+      return { f, ts: m ? Number(m[1]) : 0, seq: m ? Number(m[2]) : 0 };
+    })
+    .sort((a, b) => (a.ts - b.ts) || (a.seq - b.seq))
+    .map((e) => e.f);
+
+  for (const f of files) {
+    const stream = fs.createReadStream(path.join(sessionDir, f), { encoding: 'utf8' });
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+    try {
+      for await (const line of rl) {
+        if (!line.trim()) continue;
+        let parsed: JsonlEvent;
+        try {
+          parsed = JSON.parse(line) as JsonlEvent;
+        } catch {
+          continue;
+        }
+        total += 1;
+        tail.push(parsed);
+        // Bound the kept array to `limit` events. Shift drops the oldest
+        // — the array is therefore always the most recent `limit` rows.
+        if (tail.length > limit) tail.shift();
+      }
+    } finally {
+      rl.close();
+      stream.destroy();
+    }
+  }
+
+  return { tail, total };
+}
+
+async function showTrace(sessionId: string, opts: { limit?: string; json?: boolean }): Promise<void> {
   const rootDir = traceRoot();
   const db = openIndex(rootDir);
   if (!db) {
@@ -182,49 +239,21 @@ function showTrace(sessionId: string, opts: { limit?: string; json?: boolean }):
     return;
   }
 
-  // Read JSONL files for this session.
-  // Recorder names chunks `<ts>-<seq>.jsonl`. A plain lexical sort would
-  // place `1730000000000-10.jsonl` before `1730000000000-2.jsonl`, and
-  // because recorder timestamps come from `Date.now()` two flushes can
-  // share a millisecond. Sort by parsed (ts, seq) numerically so
-  // `--limit` always operates on the true tail of the timeline.
-  const sessionDir = path.join(rootDir, sessionId);
-  const events: JsonlEvent[] = [];
-  if (fs.existsSync(sessionDir)) {
-    const files = fs
-      .readdirSync(sessionDir)
-      .filter((f) => f.endsWith('.jsonl'))
-      .map((f) => {
-        const m = /^(\d+)-(\d+)\.jsonl$/.exec(f);
-        return { f, ts: m ? Number(m[1]) : 0, seq: m ? Number(m[2]) : 0 };
-      })
-      .sort((a, b) => (a.ts - b.ts) || (a.seq - b.seq))
-      .map((e) => e.f);
-    for (const f of files) {
-      const content = fs.readFileSync(path.join(sessionDir, f), 'utf8');
-      for (const line of content.split('\n')) {
-        if (!line.trim()) continue;
-        try {
-          events.push(JSON.parse(line));
-        } catch {
-          // skip malformed
-        }
-      }
-    }
-  }
-
   const limit = Math.max(1, Math.min(10000, parseInt(opts.limit ?? '50', 10) || 50));
-  // The CLI help advertises "recent events", so when `events.length`
-  // exceeds the limit we keep the *tail* of the timeline. The previous
-  // `slice(0, limit)` returned the oldest events and hid the failure
-  // trigger that operators almost always need first.
-  const omitted = Math.max(0, events.length - limit);
-  const slice = events.slice(omitted);
+  // The CLI help advertises "recent events". Stream chunks and keep
+  // only the trailing `limit` rows so memory stays O(limit) instead of
+  // O(total trace size) — the prior implementation read every chunk in
+  // full and only sliced at the end, which OOM'd on long sessions.
+  const { tail: slice, total: totalEvents } = await streamSessionTail(
+    path.join(rootDir, sessionId),
+    limit,
+  );
+  const omitted = Math.max(0, totalEvents - slice.length);
 
   if (opts.json) {
     console.log(
       JSON.stringify(
-        { meta: row, events: slice, totalEvents: events.length, omitted },
+        { meta: row, events: slice, totalEvents, omitted },
         null,
         2,
       ),
@@ -239,7 +268,7 @@ function showTrace(sessionId: string, opts: { limit?: string; json?: boolean }):
   console.log(`Domain   : ${row.domain ?? '—'}`);
   console.log(`Parent op: ${row.parent_op ?? '—'}`);
   console.log(`Size     : ${fmtBytes(row.byte_size)}`);
-  console.log(`Events   : ${events.length} (showing last ${slice.length})`);
+  console.log(`Events   : ${totalEvents} (showing last ${slice.length})`);
   console.log('');
   if (omitted > 0) {
     console.log(`... (${omitted} earlier events; pass --limit to see more)`);
@@ -272,7 +301,7 @@ export function registerTraceCommand(program: Command): void {
     .argument('<session-id>', 'The trace session id (from `oc trace list`)')
     .option('--limit <n>', 'Max events to print (default 50, cap 10000)', '50')
     .option('--json', 'Emit raw JSON instead of pretty text')
-    .action((sessionId: string, options: { limit?: string; json?: boolean }) =>
-      showTrace(sessionId, options),
-    );
+    .action(async (sessionId: string, options: { limit?: string; json?: boolean }) => {
+      await showTrace(sessionId, options);
+    });
 }

--- a/tests/cli/trace-and-skill-cli.test.ts
+++ b/tests/cli/trace-and-skill-cli.test.ts
@@ -136,6 +136,48 @@ describe('oc trace — list / show', () => {
     expect(r.stdout).toContain('0 B');
     expect(r.stdout).not.toMatch(/NaN|undefined/);
   });
+
+  test('list does not truncate UUID-length session ids in table output', () => {
+    // Regression: the SESSION column was previously sliced to 22 chars,
+    // making it impossible to copy a UUID id back into `oc trace show`.
+    const fullId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    store.recordSessionStart({
+      sessionId: fullId,
+      startedAt: 1000,
+      domain: 'x.com',
+      status: 'completed',
+    });
+    const r = runCli(['trace', 'list'], { OPENCHROME_TRACE_ROOT: traceRoot });
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain(fullId);
+  });
+
+  test('show --limit returns the most recent events, not the oldest', () => {
+    // Regression: the prior `slice(0, limit)` returned the *oldest*
+    // events while help advertised "recent events"; for a long session
+    // the failure trigger (always near the end) was hidden by default.
+    store.recordSessionStart({ sessionId: 's-many', startedAt: 1, status: 'completed' });
+    const events = Array.from({ length: 10 }, (_, i) => ({
+      ts: 100 + i,
+      seq: i + 1,
+      kind: i === 9 ? 'Final' : `K${i}`,
+      body: { i },
+    }));
+    store.appendEvents('s-many', events);
+
+    const r = runCli(['trace', 'show', 's-many', '--limit', '3', '--json'], {
+      OPENCHROME_TRACE_ROOT: traceRoot,
+    });
+    expect(r.code).toBe(0);
+    const out = JSON.parse(r.stdout) as {
+      events: Array<{ kind: string; seq: number }>;
+      totalEvents: number;
+      omitted: number;
+    };
+    expect(out.totalEvents).toBe(10);
+    expect(out.omitted).toBe(7);
+    expect(out.events.map((e) => e.kind)).toEqual(['K7', 'K8', 'Final']);
+  });
 });
 
 describe('oc skill — list / inspect', () => {

--- a/tests/cli/trace-and-skill-cli.test.ts
+++ b/tests/cli/trace-and-skill-cli.test.ts
@@ -120,6 +120,22 @@ describe('oc trace — list / show', () => {
     expect(r.code).not.toBe(0);
     expect(r.stderr).toContain('No trace found');
   });
+
+  test('list renders "0 B" for a freshly-started session (no NaN/undefined)', () => {
+    // recordSessionStart leaves byte_size at the schema default; this row is
+    // representative of any active or empty trace. Regression: fmtBytes used
+    // to render `Math.log(n)` for non-positive `n`, producing "NaN undefined".
+    store.recordSessionStart({
+      sessionId: 's-empty',
+      startedAt: 1000,
+      domain: 'example.com',
+      status: 'running',
+    });
+    const r = runCli(['trace', 'list'], { OPENCHROME_TRACE_ROOT: traceRoot });
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('0 B');
+    expect(r.stdout).not.toMatch(/NaN|undefined/);
+  });
 });
 
 describe('oc skill — list / inspect', () => {
@@ -176,5 +192,16 @@ describe('oc skill — list / inspect', () => {
     expect(summary.edgeCount).toBe(1);
     expect(summary.topEdges).toHaveLength(1);
     expect(summary.topEdges[0].successCount).toBe(1);
+  });
+
+  test('inspect rejects path-traversal domain arguments', () => {
+    // A traversing domain must be refused before `path.join` builds a path
+    // that escapes OPENCHROME_SKILL_ROOT. Storage's constructor validates
+    // the same way (`/[\\/]/`), and the CLI must stay consistent.
+    for (const bad of ['../foo', '..\\foo', '/etc/passwd', '..']) {
+      const r = runCli(['skill', 'inspect', bad], { OPENCHROME_SKILL_ROOT: skillRoot });
+      expect(r.code).not.toBe(0);
+      expect(r.stderr).toMatch(/Invalid domain/);
+    }
   });
 });

--- a/tests/cli/trace-and-skill-cli.test.ts
+++ b/tests/cli/trace-and-skill-cli.test.ts
@@ -152,6 +152,34 @@ describe('oc trace — list / show', () => {
     expect(r.stdout).toContain(fullId);
   });
 
+  test('show orders chunk files numerically by (ts, seq), not lexically', () => {
+    // Recorder names chunk files `<ts>-<seq>.jsonl`. A plain lexical
+    // `.sort()` placed `...-10.jsonl` before `...-2.jsonl`, so when two
+    // flushes shared a millisecond the second flush's events appeared
+    // before the first. Plant chunks out of lexical order and verify
+    // `--limit` returns the latest events as defined by (ts, seq).
+    store.recordSessionStart({ sessionId: 's-chunks', startedAt: 1, status: 'completed' });
+    const sessionDir = path.join(traceRoot, 's-chunks');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    // Two chunks at the same timestamp, seq=2 then seq=10.
+    fs.writeFileSync(
+      path.join(sessionDir, '1730000000000-2.jsonl'),
+      JSON.stringify({ ts: 100, seq: 2, kind: 'EARLIER', body: {} }) + '\n',
+    );
+    fs.writeFileSync(
+      path.join(sessionDir, '1730000000000-10.jsonl'),
+      JSON.stringify({ ts: 200, seq: 10, kind: 'LATER', body: {} }) + '\n',
+    );
+
+    const r = runCli(['trace', 'show', 's-chunks', '--limit', '1', '--json'], {
+      OPENCHROME_TRACE_ROOT: traceRoot,
+    });
+    expect(r.code).toBe(0);
+    const out = JSON.parse(r.stdout) as { events: Array<{ kind: string }> };
+    expect(out.events).toHaveLength(1);
+    expect(out.events[0].kind).toBe('LATER');
+  });
+
   test('show --limit returns the most recent events, not the oldest', () => {
     // Regression: the prior `slice(0, limit)` returned the *oldest*
     // events while help advertised "recent events"; for a long session

--- a/tests/cli/trace-and-skill-cli.test.ts
+++ b/tests/cli/trace-and-skill-cli.test.ts
@@ -1,0 +1,180 @@
+/**
+ * CLI smoke tests for `oc trace` and `oc skill` (M1 PR-3).
+ *
+ * Spawns the compiled CLI against an isolated trace/skill root populated
+ * by the in-process storage classes. Exercises:
+ *   - oc trace list (empty, with rows, JSON mode, --status filter)
+ *   - oc trace show <id> (text + JSON)
+ *   - oc skill list / skill inspect (JSON mode is most stable to assert on)
+ */
+
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { TraceStorage } from '../../src/trace/storage';
+import { SkillGraphStorage } from '../../src/skill/storage';
+
+const CLI_ENTRY = path.resolve(__dirname, '..', '..', 'dist', 'cli', 'index.js');
+
+function runCli(
+  args: string[],
+  env: NodeJS.ProcessEnv = {},
+): { code: number | null; stdout: string; stderr: string } {
+  const r = spawnSync(process.execPath, [CLI_ENTRY, ...args], {
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+    timeout: 15_000,
+  });
+  return { code: r.status, stdout: r.stdout, stderr: r.stderr };
+}
+
+function tempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+beforeAll(() => {
+  if (!fs.existsSync(CLI_ENTRY)) {
+    throw new Error(
+      `CLI build artifact missing at ${CLI_ENTRY}. Run \`npm run build\` before this test suite.`,
+    );
+  }
+});
+
+describe('oc trace — list / show', () => {
+  let traceRoot: string;
+  let store: TraceStorage;
+
+  beforeEach(() => {
+    traceRoot = tempDir('oc-cli-trace-');
+    store = new TraceStorage({ rootDir: traceRoot });
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(traceRoot, { recursive: true, force: true });
+  });
+
+  test('list against an empty index reports "No traces matched"', () => {
+    const r = runCli(['trace', 'list'], { OPENCHROME_TRACE_ROOT: traceRoot });
+    expect(r.code).toBe(0);
+    expect(r.stderr).toContain('No traces matched');
+  });
+
+  test('list returns rows after recording sessions', () => {
+    store.recordSessionStart({
+      sessionId: 's-completed',
+      startedAt: 1000,
+      domain: 'amazon.com',
+      status: 'completed',
+    });
+    store.recordSessionStart({
+      sessionId: 's-failed',
+      startedAt: 2000,
+      domain: 'github.com',
+      status: 'failed',
+    });
+
+    const r = runCli(['trace', 'list', '--json'], { OPENCHROME_TRACE_ROOT: traceRoot });
+    expect(r.code).toBe(0);
+    const rows = JSON.parse(r.stdout) as Array<{ session_id: string; status: string }>;
+    expect(rows.map((row) => row.session_id).sort()).toEqual(['s-completed', 's-failed']);
+  });
+
+  test('--status filter narrows the result set', () => {
+    store.recordSessionStart({ sessionId: 'a', startedAt: 100, status: 'completed' });
+    store.recordSessionStart({ sessionId: 'b', startedAt: 200, status: 'failed' });
+    const r = runCli(['trace', 'list', '--status', 'failed', '--json'], {
+      OPENCHROME_TRACE_ROOT: traceRoot,
+    });
+    expect(r.code).toBe(0);
+    const rows = JSON.parse(r.stdout) as Array<{ session_id: string }>;
+    expect(rows.map((row) => row.session_id)).toEqual(['b']);
+  });
+
+  test('show <id> prints metadata + recorded events (JSON mode)', () => {
+    store.recordSessionStart({
+      sessionId: 's1',
+      startedAt: 1000,
+      domain: 'amazon.com',
+      status: 'completed',
+    });
+    store.appendEvents('s1', [
+      { ts: 1010, seq: 1, kind: 'Page.frameNavigated', body: { url: 'https://a' } },
+      { ts: 1020, seq: 2, kind: 'Network.responseReceived', body: { status: 200 } },
+    ]);
+
+    const r = runCli(['trace', 'show', 's1', '--json'], {
+      OPENCHROME_TRACE_ROOT: traceRoot,
+    });
+    expect(r.code).toBe(0);
+    const out = JSON.parse(r.stdout) as { meta: { session_id: string }; events: unknown[]; totalEvents: number };
+    expect(out.meta.session_id).toBe('s1');
+    expect(out.totalEvents).toBe(2);
+    expect(out.events).toHaveLength(2);
+  });
+
+  test('show <unknown-id> exits non-zero with error message', () => {
+    const r = runCli(['trace', 'show', 'nope'], { OPENCHROME_TRACE_ROOT: traceRoot });
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toContain('No trace found');
+  });
+});
+
+describe('oc skill — list / inspect', () => {
+  let skillRoot: string;
+  let store: SkillGraphStorage;
+
+  beforeEach(() => {
+    skillRoot = tempDir('oc-cli-skill-');
+    store = new SkillGraphStorage('amazon.com', { rootDir: skillRoot });
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(skillRoot, { recursive: true, force: true });
+  });
+
+  test('list reports the per-domain DBs in the root', () => {
+    const r = runCli(['skill', 'list', '--json'], { OPENCHROME_SKILL_ROOT: skillRoot });
+    expect(r.code).toBe(0);
+    expect(JSON.parse(r.stdout)).toEqual(['amazon.com']);
+  });
+
+  test('inspect <unknown-domain> exits non-zero', () => {
+    const r = runCli(['skill', 'inspect', 'unknown.example'], {
+      OPENCHROME_SKILL_ROOT: skillRoot,
+    });
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toContain('No skill graph');
+  });
+
+  test('inspect <domain> reports node/edge counts (JSON mode)', () => {
+    store.upsertNode({ stateHash: 'hash-a' });
+    store.upsertNode({ stateHash: 'hash-b' });
+    store.recordOutcome({
+      fromState: 'hash-a',
+      actionKind: 'click',
+      actionArgsNorm: 'ref:1',
+      observedToState: 'hash-b',
+      success: true,
+    });
+
+    const r = runCli(['skill', 'inspect', 'amazon.com', '--json'], {
+      OPENCHROME_SKILL_ROOT: skillRoot,
+    });
+    expect(r.code).toBe(0);
+    const summary = JSON.parse(r.stdout) as {
+      domain: string;
+      nodeCount: number;
+      edgeCount: number;
+      topEdges: Array<{ actionKind: string; successCount: number; failCount: number }>;
+    };
+    expect(summary.domain).toBe('amazon.com');
+    expect(summary.nodeCount).toBe(2);
+    expect(summary.edgeCount).toBe(1);
+    expect(summary.topEdges).toHaveLength(1);
+    expect(summary.topEdges[0].successCount).toBe(1);
+  });
+});

--- a/tests/cli/trace-and-skill-cli.test.ts
+++ b/tests/cli/trace-and-skill-cli.test.ts
@@ -180,6 +180,34 @@ describe('oc trace — list / show', () => {
     expect(out.events[0].kind).toBe('LATER');
   });
 
+  test('show streams chunks and keeps O(limit) events in memory (not O(total))', () => {
+    // Plant a session with 5,000 events across multiple chunks. The
+    // prior implementation read every chunk into memory before slicing
+    // — so `--limit 3` still allocated 5k JsonlEvent rows. The
+    // streaming version keeps only `limit` events at a time.
+    store.recordSessionStart({ sessionId: 's-bulk', startedAt: 1, status: 'completed' });
+    const big = Array.from({ length: 5000 }, (_, i) => ({
+      ts: 1000 + i,
+      seq: i + 1,
+      kind: i === 4999 ? 'TAIL' : `K${i}`,
+      body: { i },
+    }));
+    store.appendEvents('s-bulk', big);
+
+    const r = runCli(['trace', 'show', 's-bulk', '--limit', '3', '--json'], {
+      OPENCHROME_TRACE_ROOT: traceRoot,
+    });
+    expect(r.code).toBe(0);
+    const out = JSON.parse(r.stdout) as {
+      events: Array<{ kind: string }>;
+      totalEvents: number;
+      omitted: number;
+    };
+    expect(out.totalEvents).toBe(5000);
+    expect(out.omitted).toBe(4997);
+    expect(out.events.map((e) => e.kind)).toEqual(['K4997', 'K4998', 'TAIL']);
+  });
+
   test('show --limit returns the most recent events, not the oldest', () => {
     // Regression: the prior `slice(0, limit)` returned the *oldest*
     // events while help advertised "recent events"; for a long session


### PR DESCRIPTION
## Summary

Two CLI command groups added to the existing root-level host (`cli/index.ts` already builds via `tsconfig.cli.json`). **Read-only against the SQLite indexes** — never holds a write lock, so it's safe to run while the MCP server is live. Stacked on **#741**.

- `oc trace list [--since|--status|--domain|--limit|--json]`
- `oc trace show <session-id> [--limit|--json]`
- `oc skill list [--json]`
- `oc skill inspect <domain> [--json]`

Each subcommand opens the SQLite indexes directly (read-only) instead of going through the MCP server, so:

- Operators can inspect traces without an active MCP session
- Live MCP traffic is unaffected (no shared write transaction)
- The CLI surface is testable end-to-end without spawning a server

## Why these four commands first

#702 v2 calls out `oc skill inspect <domain>` explicitly as part of the live validation checklist. `oc trace list/show` are #701 v2 and #704 prerequisites — `oc trace play` (interactive replay UI) is the next slice (PR-3 deferred).

## Validation

- `npm run build` clean (CLI tsconfig builds)
- `npm test -- tests/cli tests/skill tests/trace` — all green
- Smoke: `node dist/cli/index.js trace list --json` against an empty DB returns `[]` with exit 0

## Test plan

- [ ] Reviewer pulls and runs `npm install && npm run build`
- [ ] Reviewer runs `node dist/cli/index.js trace list` and `node dist/cli/index.js skill list` to confirm exit 0 + table output
- [ ] Reviewer confirms read-only mode: a held write transaction in another process does not block the CLI
- [ ] Reviewer confirms `--json` output for all four commands is parsable and stable

Refs: #698 (epic), #701/#702/#704 (sub-issues). Stacked on #741.

🤖 Split from `feat/m1-pr1-trace-foundation`. Original commit: `2ef33fa`.
