### PR TITLE
feat(cli): oc trace play replay UI (M1 PR-3 deferred slice)

### DIFF
--- a/assets/replay/index.html
+++ b/assets/replay/index.html
@@ -114,12 +114,17 @@
         fetch(`/api/trace/${encodeURIComponent(id)}/meta`),
         fetch(`/api/trace/${encodeURIComponent(id)}/events?limit=2000`),
       ]);
+      // Stale-fetch guard: if the user clicked another session while
+      // these requests were in flight, drop this response so a slower
+      // older fetch cannot overwrite a newer selection's UI.
+      if (activeId !== id) return;
       if (!metaRes.ok) {
         document.getElementById('events').innerHTML = '<div class="empty">trace not found</div>';
         return;
       }
       const meta = await metaRes.json();
       const data = await eventsRes.json();
+      if (activeId !== id) return;
       const metaEl = document.getElementById('meta');
       metaEl.innerHTML = `
         <dl class="meta-grid">

--- a/assets/replay/index.html
+++ b/assets/replay/index.html
@@ -1,0 +1,157 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>OpenChrome trace replay</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    :root { color-scheme: light dark; }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      font-size: 14px;
+      line-height: 1.4;
+      background: Canvas;
+      color: CanvasText;
+    }
+    header {
+      padding: 14px 18px;
+      border-bottom: 1px solid color-mix(in srgb, CanvasText 12%, transparent);
+      display: flex; align-items: baseline; gap: 12px;
+    }
+    header h1 { font-size: 16px; margin: 0; font-weight: 600; }
+    header .sub { font-size: 12px; opacity: 0.6; }
+    main { display: grid; grid-template-columns: 320px 1fr; min-height: calc(100vh - 56px); }
+    aside {
+      border-right: 1px solid color-mix(in srgb, CanvasText 12%, transparent);
+      overflow: auto;
+      padding: 6px;
+    }
+    aside ul { list-style: none; margin: 0; padding: 0; }
+    aside li {
+      padding: 6px 8px;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 12px;
+    }
+    aside li:hover { background: color-mix(in srgb, CanvasText 6%, transparent); }
+    aside li.active { background: color-mix(in srgb, AccentColor 22%, transparent); }
+    aside li .id { font-family: ui-monospace, monospace; font-size: 11px; opacity: 0.7; }
+    aside li .meta { display: flex; justify-content: space-between; font-size: 11px; opacity: 0.65; }
+    section.events { padding: 14px 18px; overflow: auto; }
+    .meta-grid { display: grid; grid-template-columns: max-content 1fr; gap: 4px 18px; margin-bottom: 16px; font-size: 12px; }
+    .meta-grid dt { opacity: 0.6; }
+    .meta-grid dd { margin: 0; font-family: ui-monospace, monospace; }
+    table { width: 100%; border-collapse: collapse; font-size: 12px; }
+    th, td { text-align: left; padding: 4px 8px; border-bottom: 1px solid color-mix(in srgb, CanvasText 8%, transparent); vertical-align: top; }
+    th { font-weight: 600; opacity: 0.7; }
+    td.kind { font-family: ui-monospace, monospace; }
+    td.body { font-family: ui-monospace, monospace; white-space: pre; max-width: 600px; overflow: hidden; text-overflow: ellipsis; }
+    .empty { opacity: 0.5; padding: 28px; text-align: center; }
+    .badge { display: inline-block; padding: 1px 6px; border-radius: 4px; font-size: 11px; }
+    .badge.completed { background: #d1fae5; color: #065f46; }
+    .badge.failed { background: #fee2e2; color: #991b1b; }
+    .badge.running { background: #fef3c7; color: #92400e; }
+    .badge.aborted { background: #e5e7eb; color: #374151; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>OpenChrome trace replay</h1>
+    <span class="sub">click a session on the left to load its events</span>
+  </header>
+  <main>
+    <aside id="sessions"><div class="empty">loading…</div></aside>
+    <section class="events">
+      <div id="meta"></div>
+      <div id="events"><div class="empty">no session selected</div></div>
+    </section>
+  </main>
+  <script>
+    function fmtTime(ms) {
+      if (ms == null) return '—';
+      return new Date(ms).toISOString().replace('T', ' ').slice(0, 19);
+    }
+    function fmtBytes(n) {
+      if (!Number.isFinite(n) || n < 1024) return (n ?? 0) + ' B';
+      const k = 1024;
+      const sizes = ['B','KB','MB','GB'];
+      const i = Math.floor(Math.log(n)/Math.log(k));
+      return (n/Math.pow(k,i)).toFixed(1) + ' ' + sizes[i];
+    }
+    function escape(s) {
+      return String(s).replace(/[&<>"]/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+    }
+
+    let activeId = null;
+
+    async function loadList() {
+      const res = await fetch('/api/trace/list');
+      const rows = await res.json();
+      const aside = document.getElementById('sessions');
+      if (!Array.isArray(rows) || rows.length === 0) {
+        aside.innerHTML = '<div class="empty">no traces</div>';
+        return;
+      }
+      aside.innerHTML = '<ul>' + rows.map((r) => `
+        <li data-id="${escape(r.session_id)}">
+          <div class="id">${escape(r.session_id.slice(0,18))}</div>
+          <div class="meta"><span>${escape(r.domain ?? '—')}</span><span class="badge ${escape(r.status)}">${escape(r.status)}</span></div>
+          <div class="meta"><span>${fmtTime(r.started_at)}</span><span>${fmtBytes(r.byte_size)}</span></div>
+        </li>`).join('') + '</ul>';
+      aside.querySelectorAll('li').forEach((li) => {
+        li.addEventListener('click', () => loadSession(li.getAttribute('data-id')));
+      });
+    }
+
+    async function loadSession(id) {
+      activeId = id;
+      document.querySelectorAll('aside li').forEach((li) => {
+        li.classList.toggle('active', li.getAttribute('data-id') === id);
+      });
+      const [metaRes, eventsRes] = await Promise.all([
+        fetch(`/api/trace/${encodeURIComponent(id)}/meta`),
+        fetch(`/api/trace/${encodeURIComponent(id)}/events?limit=2000`),
+      ]);
+      if (!metaRes.ok) {
+        document.getElementById('events').innerHTML = '<div class="empty">trace not found</div>';
+        return;
+      }
+      const meta = await metaRes.json();
+      const data = await eventsRes.json();
+      const metaEl = document.getElementById('meta');
+      metaEl.innerHTML = `
+        <dl class="meta-grid">
+          <dt>session</dt><dd>${escape(meta.session_id)}</dd>
+          <dt>started</dt><dd>${fmtTime(meta.started_at)}</dd>
+          <dt>ended</dt><dd>${fmtTime(meta.ended_at)}</dd>
+          <dt>status</dt><dd><span class="badge ${escape(meta.status)}">${escape(meta.status)}</span></dd>
+          <dt>domain</dt><dd>${escape(meta.domain ?? '—')}</dd>
+          <dt>parent</dt><dd>${escape(meta.parent_op ?? '—')}</dd>
+          <dt>size</dt><dd>${fmtBytes(meta.byte_size)}</dd>
+          <dt>events</dt><dd>${data.total} (showing first ${data.returned})</dd>
+        </dl>
+      `;
+      const evs = data.events || [];
+      const evEl = document.getElementById('events');
+      if (evs.length === 0) {
+        evEl.innerHTML = '<div class="empty">no events recorded</div>';
+        return;
+      }
+      evEl.innerHTML = '<table><thead><tr><th>#</th><th>time</th><th>kind</th><th>body</th></tr></thead><tbody>' +
+        evs.map((e) => `
+          <tr>
+            <td>${e.seq}</td>
+            <td>${fmtTime(e.ts)}</td>
+            <td class="kind">${escape(e.kind)}</td>
+            <td class="body">${escape(JSON.stringify(e.body)).slice(0, 240)}</td>
+          </tr>`).join('') + '</tbody></table>';
+    }
+
+    loadList().catch((e) => {
+      document.getElementById('sessions').innerHTML = '<div class="empty">failed to load: ' + escape(String(e)) + '</div>';
+    });
+  </script>
+</body>
+</html>

--- a/cli/replay-server.ts
+++ b/cli/replay-server.ts
@@ -83,7 +83,29 @@ function send404(res: http.ServerResponse): void {
 }
 
 function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
-  const url = new URL(req.url ?? '/', 'http://localhost');
+  // Top-level guard so a malformed URL (URIError from new URL or
+  // decodeURIComponent on a bad percent-encoded segment) cannot escape
+  // and terminate the listener — that would let one bad local request
+  // DoS the replay server until restart.
+  try {
+    handleRequestInner(req, res);
+  } catch (err) {
+    if (err instanceof URIError) {
+      send(res, 400, { error: 'bad_request', detail: 'malformed URI' });
+      return;
+    }
+    console.error('[replay] request handler crashed:', err);
+    if (!res.headersSent) send(res, 500, { error: 'internal' });
+  }
+}
+
+function handleRequestInner(req: http.IncomingMessage, res: http.ServerResponse): void {
+  let url: URL;
+  try {
+    url = new URL(req.url ?? '/', 'http://localhost');
+  } catch {
+    return send(res, 400, { error: 'bad_request', detail: 'malformed URL' });
+  }
   const rootDir = traceRoot();
 
   // Static index
@@ -119,7 +141,12 @@ function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): voi
   // Trace meta + events
   const traceMatch = /^\/api\/trace\/([^/]+)\/(meta|events)$/.exec(url.pathname);
   if (req.method === 'GET' && traceMatch) {
-    const sessionId = decodeURIComponent(traceMatch[1]);
+    let sessionId: string;
+    try {
+      sessionId = decodeURIComponent(traceMatch[1]);
+    } catch {
+      return send(res, 400, { error: 'bad_request', detail: 'malformed session id' });
+    }
     const which = traceMatch[2];
     let db: Database;
     try {

--- a/cli/replay-server.ts
+++ b/cli/replay-server.ts
@@ -1,0 +1,197 @@
+/**
+ * Tiny HTTP server backing `oc trace play`.
+ *
+ * Binds to 127.0.0.1 only (no external exposure). Default port is
+ * ephemeral (resolved by the OS); override with `OPENCHROME_REPLAY_PORT`
+ * for deterministic dev setups. The actual port is printed to stdout
+ * after the listen() callback fires so callers can detect it.
+ *
+ * Endpoints:
+ *   GET /                     → served from assets/replay/index.html
+ *   GET /api/trace/list       → JSON array (latest 50 traces)
+ *   GET /api/trace/<id>/meta  → JSON metadata for one trace
+ *   GET /api/trace/<id>/events?from=<ts>&to=<ts>&limit=<n>
+ *                             → JSON event slice
+ *
+ * The server reads the same `~/.openchrome/traces/index.sqlite` and
+ * per-session JSONL files written by `src/trace/recorder.ts`.
+ */
+
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import type { AddressInfo } from 'net';
+
+type BetterSqlite3 = typeof import('better-sqlite3');
+type Database = import('better-sqlite3').Database;
+
+let _Sqlite: BetterSqlite3 | null = null;
+function loadSqlite(): BetterSqlite3 {
+  if (_Sqlite) return _Sqlite;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  _Sqlite = require('better-sqlite3') as BetterSqlite3;
+  return _Sqlite;
+}
+
+const DEFAULT_TRACE_ROOT = path.join(os.homedir(), '.openchrome', 'traces');
+
+function traceRoot(): string {
+  return process.env.OPENCHROME_TRACE_ROOT ?? DEFAULT_TRACE_ROOT;
+}
+
+function staticAssetPath(): string {
+  // dist/cli/replay-server.js → assets/replay/index.html
+  // src cli/replay-server.ts → assets/replay/index.html (during ts-node)
+  const candidates = [
+    path.resolve(__dirname, '..', '..', 'assets', 'replay', 'index.html'),
+    path.resolve(__dirname, '..', 'assets', 'replay', 'index.html'),
+  ];
+  for (const c of candidates) if (fs.existsSync(c)) return c;
+  return candidates[0];
+}
+
+function readSessionEvents(rootDir: string, sessionId: string): unknown[] {
+  const sessionDir = path.join(rootDir, sessionId);
+  if (!fs.existsSync(sessionDir)) return [];
+  const out: unknown[] = [];
+  const files = fs.readdirSync(sessionDir).filter((f) => f.endsWith('.jsonl')).sort();
+  for (const f of files) {
+    const content = fs.readFileSync(path.join(sessionDir, f), 'utf8');
+    for (const line of content.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        out.push(JSON.parse(line));
+      } catch {
+        // skip malformed lines
+      }
+    }
+  }
+  return out;
+}
+
+function send(res: http.ServerResponse, status: number, body: unknown, contentType = 'application/json'): void {
+  const payload = typeof body === 'string' || Buffer.isBuffer(body) ? body : JSON.stringify(body);
+  res.statusCode = status;
+  res.setHeader('Content-Type', contentType);
+  res.setHeader('Cache-Control', 'no-store');
+  res.end(payload);
+}
+
+function send404(res: http.ServerResponse): void {
+  send(res, 404, { error: 'not_found' });
+}
+
+function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
+  const url = new URL(req.url ?? '/', 'http://localhost');
+  const rootDir = traceRoot();
+
+  // Static index
+  if (req.method === 'GET' && (url.pathname === '/' || url.pathname === '/index.html')) {
+    const assetPath = staticAssetPath();
+    if (!fs.existsSync(assetPath)) {
+      return send(res, 500, '<h1>Replay UI assets missing</h1><p>Expected at assets/replay/index.html</p>', 'text/html');
+    }
+    return send(res, 200, fs.readFileSync(assetPath), 'text/html; charset=utf-8');
+  }
+
+  // Trace list
+  if (req.method === 'GET' && url.pathname === '/api/trace/list') {
+    let db: Database;
+    try {
+      const Sqlite = loadSqlite();
+      db = new Sqlite(path.join(rootDir, 'index.sqlite'), { readonly: true, fileMustExist: true });
+    } catch {
+      return send(res, 200, []);
+    }
+    try {
+      const rows = db
+        .prepare(
+          'SELECT session_id, started_at, ended_at, domain, status, byte_size, parent_op FROM traces ORDER BY started_at DESC LIMIT 50',
+        )
+        .all();
+      return send(res, 200, rows);
+    } finally {
+      db.close();
+    }
+  }
+
+  // Trace meta + events
+  const traceMatch = /^\/api\/trace\/([^/]+)\/(meta|events)$/.exec(url.pathname);
+  if (req.method === 'GET' && traceMatch) {
+    const sessionId = decodeURIComponent(traceMatch[1]);
+    const which = traceMatch[2];
+    let db: Database;
+    try {
+      const Sqlite = loadSqlite();
+      db = new Sqlite(path.join(rootDir, 'index.sqlite'), { readonly: true, fileMustExist: true });
+    } catch {
+      return send404(res);
+    }
+    try {
+      const meta = db
+        .prepare(
+          'SELECT session_id, started_at, ended_at, domain, status, byte_size, parent_op FROM traces WHERE session_id = ?',
+        )
+        .get(sessionId);
+      if (!meta) return send404(res);
+      if (which === 'meta') return send(res, 200, meta);
+
+      const events = readSessionEvents(rootDir, sessionId);
+      const fromTs = numberQueryParam(url, 'from');
+      const toTs = numberQueryParam(url, 'to');
+      const limit = Math.max(1, Math.min(10000, numberQueryParam(url, 'limit') ?? 1000));
+      let filtered = events as Array<{ ts: number }>;
+      if (fromTs !== undefined) filtered = filtered.filter((e) => e.ts >= fromTs);
+      if (toTs !== undefined) filtered = filtered.filter((e) => e.ts <= toTs);
+      const slice = filtered.slice(0, limit);
+      return send(res, 200, { sessionId, total: events.length, returned: slice.length, events: slice });
+    } finally {
+      db.close();
+    }
+  }
+
+  send404(res);
+}
+
+function numberQueryParam(url: URL, name: string): number | undefined {
+  const raw = url.searchParams.get(name);
+  if (raw == null) return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+export interface ReplayServerHandle {
+  /** Concrete port the server bound to. */
+  port: number;
+  /** URL to print to stdout / open in a browser. */
+  url: string;
+  /** Closes the listener. Resolves once close(callback) settles. */
+  close(): Promise<void>;
+}
+
+/**
+ * Start the replay HTTP server. Returns once it is listening on the
+ * resolved port. Default: 127.0.0.1:0 (ephemeral); override with
+ * `OPENCHROME_REPLAY_PORT` or the `port` option.
+ */
+export async function startReplayServer(opts: { port?: number } = {}): Promise<ReplayServerHandle> {
+  const desiredPort =
+    opts.port ?? (process.env.OPENCHROME_REPLAY_PORT ? Number(process.env.OPENCHROME_REPLAY_PORT) : 0);
+  const server = http.createServer(handleRequest);
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(desiredPort, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const addr = server.address() as AddressInfo;
+  const port = addr.port;
+  const url = `http://127.0.0.1:${port}/`;
+  return {
+    port,
+    url,
+    close: () => new Promise((res) => server.close(() => res())),
+  };
+}

--- a/cli/trace.ts
+++ b/cli/trace.ts
@@ -254,27 +254,39 @@ export function registerTraceCommand(program: Command): void {
       // `startReplayServer` also reads) before handing off — passing NaN
       // or a negative integer to `server.listen()` throws a RangeError
       // deep in net internals. A clear CLI error is friendlier.
+      // `parsePort` accepts a string and returns an integer in 0..65535
+      // or `null` for invalid input. Fractional values (e.g. "1234.5"),
+      // negatives, NaN, and out-of-range values are all rejected so the
+      // value forwarded to `server.listen()` is always a valid port —
+      // the prior `Number()` check accepted "1234.5" and let listen()
+      // throw a low-level RangeError downstream.
+      const parsePort = (raw: string): number | null => {
+        if (!/^-?\d+$/.test(raw.trim())) return null;
+        const n = Number(raw);
+        if (!Number.isInteger(n) || n < 0 || n > 65535) return null;
+        return n;
+      };
       let portNum: number | undefined;
       if (options.port !== undefined) {
-        const parsed = Number.parseInt(options.port, 10);
-        if (!Number.isFinite(parsed) || parsed < 0 || parsed > 65535) {
+        const n = parsePort(options.port);
+        if (n === null) {
           console.error(
             `Invalid --port: ${options.port} (expected an integer in 0..65535; 0 = ephemeral)`,
           );
           process.exitCode = 1;
           return;
         }
-        portNum = parsed;
+        portNum = n;
       } else if (process.env.OPENCHROME_REPLAY_PORT) {
-        const parsed = Number(process.env.OPENCHROME_REPLAY_PORT);
-        if (!Number.isFinite(parsed) || parsed < 0 || parsed > 65535) {
+        const n = parsePort(process.env.OPENCHROME_REPLAY_PORT);
+        if (n === null) {
           console.error(
-            `Invalid OPENCHROME_REPLAY_PORT: ${process.env.OPENCHROME_REPLAY_PORT} (expected 0..65535)`,
+            `Invalid OPENCHROME_REPLAY_PORT: ${process.env.OPENCHROME_REPLAY_PORT} (expected an integer in 0..65535)`,
           );
           process.exitCode = 1;
           return;
         }
-        portNum = parsed;
+        portNum = n;
       }
       const handle = await startReplayServer({ port: portNum });
       console.log(`Replay UI: ${handle.url}`);

--- a/cli/trace.ts
+++ b/cli/trace.ts
@@ -242,4 +242,40 @@ export function registerTraceCommand(program: Command): void {
     .action((sessionId: string, options: { limit?: string; json?: boolean }) =>
       showTrace(sessionId, options),
     );
+
+  cmd
+    .command('play')
+    .description('Open the local replay UI in a browser (127.0.0.1 only)')
+    .option('--port <port>', 'Bind to a specific port (default: ephemeral, OPENCHROME_REPLAY_PORT honored)')
+    .option('--no-open', 'Print the URL but do not auto-open the browser')
+    .action(async (options: { port?: string; open?: boolean }) => {
+      const { startReplayServer } = await import('./replay-server');
+      const portNum = options.port ? Number.parseInt(options.port, 10) : undefined;
+      const handle = await startReplayServer({ port: portNum });
+      console.log(`Replay UI: ${handle.url}`);
+      console.log('Press Ctrl-C to stop.');
+      if (options.open !== false) {
+        // Best-effort browser open. macOS / Linux / Windows.
+        const cmd =
+          process.platform === 'darwin'
+            ? 'open'
+            : process.platform === 'win32'
+              ? 'start'
+              : 'xdg-open';
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const cp = require('child_process');
+          cp.spawn(cmd, [handle.url], { detached: true, stdio: 'ignore', shell: process.platform === 'win32' }).unref();
+        } catch {
+          // Open is best-effort — user can copy the URL from stdout.
+        }
+      }
+      // Keep the process alive on stdin close (Ctrl-C / parent exit).
+      process.on('SIGINT', () => {
+        void handle.close().then(() => process.exit(0));
+      });
+      process.on('SIGTERM', () => {
+        void handle.close().then(() => process.exit(0));
+      });
+    });
 }

--- a/cli/trace.ts
+++ b/cli/trace.ts
@@ -265,7 +265,17 @@ export function registerTraceCommand(program: Command): void {
         try {
           // eslint-disable-next-line @typescript-eslint/no-var-requires
           const cp = require('child_process');
-          cp.spawn(cmd, [handle.url], { detached: true, stdio: 'ignore', shell: process.platform === 'win32' }).unref();
+          const child = cp.spawn(cmd, [handle.url], {
+            detached: true,
+            stdio: 'ignore',
+            shell: process.platform === 'win32',
+          });
+          // `spawn` reports a missing launcher (e.g. xdg-open absent on a
+          // minimal CI image) via an asynchronous 'error' event, not a
+          // synchronous throw. Without a listener, the event would crash
+          // the process — defeating the "best-effort" contract. Swallow it.
+          child.on('error', () => undefined);
+          child.unref();
         } catch {
           // Open is best-effort — user can copy the URL from stdout.
         }

--- a/cli/trace.ts
+++ b/cli/trace.ts
@@ -250,7 +250,32 @@ export function registerTraceCommand(program: Command): void {
     .option('--no-open', 'Print the URL but do not auto-open the browser')
     .action(async (options: { port?: string; open?: boolean }) => {
       const { startReplayServer } = await import('./replay-server');
-      const portNum = options.port ? Number.parseInt(options.port, 10) : undefined;
+      // Validate `--port` (and the `OPENCHROME_REPLAY_PORT` env, which
+      // `startReplayServer` also reads) before handing off — passing NaN
+      // or a negative integer to `server.listen()` throws a RangeError
+      // deep in net internals. A clear CLI error is friendlier.
+      let portNum: number | undefined;
+      if (options.port !== undefined) {
+        const parsed = Number.parseInt(options.port, 10);
+        if (!Number.isFinite(parsed) || parsed < 0 || parsed > 65535) {
+          console.error(
+            `Invalid --port: ${options.port} (expected an integer in 0..65535; 0 = ephemeral)`,
+          );
+          process.exitCode = 1;
+          return;
+        }
+        portNum = parsed;
+      } else if (process.env.OPENCHROME_REPLAY_PORT) {
+        const parsed = Number(process.env.OPENCHROME_REPLAY_PORT);
+        if (!Number.isFinite(parsed) || parsed < 0 || parsed > 65535) {
+          console.error(
+            `Invalid OPENCHROME_REPLAY_PORT: ${process.env.OPENCHROME_REPLAY_PORT} (expected 0..65535)`,
+          );
+          process.exitCode = 1;
+          return;
+        }
+        portNum = parsed;
+      }
       const handle = await startReplayServer({ port: portNum });
       console.log(`Replay UI: ${handle.url}`);
       console.log('Press Ctrl-C to stop.');

--- a/tests/cli/replay-server.test.ts
+++ b/tests/cli/replay-server.test.ts
@@ -144,4 +144,16 @@ describe('replay server — endpoints', () => {
     const r = await getJson(`${handle.url}does/not/exist`);
     expect(r.status).toBe(404);
   });
+
+  test('malformed percent-encoded session id is rejected with 400 (no crash)', async () => {
+    // Regression: an unguarded `decodeURIComponent` on the session id let
+    // a single bad local request kill the request handler with URIError,
+    // which would terminate the listener until restart. The handler now
+    // catches URIError and returns 400; the server remains live for the
+    // follow-up request below.
+    const r = await getJson(`${handle.url}api/trace/%E0%A4%A/meta`);
+    expect(r.status).toBe(400);
+    const r2 = await getJson(`${handle.url}api/trace/list`);
+    expect(r2.status).toBe(200);
+  });
 });

--- a/tests/cli/replay-server.test.ts
+++ b/tests/cli/replay-server.test.ts
@@ -145,6 +145,17 @@ describe('replay server — endpoints', () => {
     expect(r.status).toBe(404);
   });
 
+  test('startReplayServer rejects negative port and non-finite numbers cleanly', async () => {
+    // Sanity check that the validation done in `oc trace play` matches
+    // what `server.listen()` would refuse — anything outside 0..65535
+    // throws a low-level RangeError, which is what the CLI is supposed
+    // to head off with its own validation. NaN / negative / >65535 must
+    // not reach `server.listen()`.
+    const { startReplayServer } = await import('../../cli/replay-server');
+    await expect(startReplayServer({ port: -1 })).rejects.toThrow();
+    await expect(startReplayServer({ port: 70000 })).rejects.toThrow();
+  });
+
   test('malformed percent-encoded session id is rejected with 400 (no crash)', async () => {
     // Regression: an unguarded `decodeURIComponent` on the session id let
     // a single bad local request kill the request handler with URIError,

--- a/tests/cli/replay-server.test.ts
+++ b/tests/cli/replay-server.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Replay-server smoke tests for `oc trace play` (M1 PR-3 deferred slice).
+ *
+ * Spawns the in-process server (no subprocess), seeds an isolated trace
+ * root via TraceStorage, and hits each endpoint to assert shape + bind
+ * scope. Verifies 127.0.0.1-only binding by checking the listening
+ * address rather than attempting cross-host connections.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { startReplayServer } from '../../cli/replay-server';
+import { TraceStorage } from '../../src/trace/storage';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-replay-'));
+}
+
+async function getJson(url: string): Promise<{ status: number; body: unknown }> {
+  const res = await fetch(url);
+  const text = await res.text();
+  let body: unknown = text;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    /* keep raw text */
+  }
+  return { status: res.status, body };
+}
+
+describe('replay server — endpoints', () => {
+  let traceRootPath: string;
+  let store: TraceStorage;
+  let originalRoot: string | undefined;
+  let handle: Awaited<ReturnType<typeof startReplayServer>>;
+
+  beforeEach(async () => {
+    traceRootPath = tempRoot();
+    originalRoot = process.env.OPENCHROME_TRACE_ROOT;
+    process.env.OPENCHROME_TRACE_ROOT = traceRootPath;
+    store = new TraceStorage({ rootDir: traceRootPath });
+    handle = await startReplayServer({ port: 0 });
+  });
+
+  afterEach(async () => {
+    await handle.close();
+    store.close();
+    fs.rmSync(traceRootPath, { recursive: true, force: true });
+    if (originalRoot === undefined) delete process.env.OPENCHROME_TRACE_ROOT;
+    else process.env.OPENCHROME_TRACE_ROOT = originalRoot;
+  });
+
+  test('binds to 127.0.0.1 with an OS-assigned port', () => {
+    expect(handle.port).toBeGreaterThan(0);
+    expect(handle.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/);
+  });
+
+  test('GET / returns the static replay HTML', async () => {
+    const res = await fetch(handle.url);
+    const ct = res.headers.get('content-type') ?? '';
+    expect(res.status).toBe(200);
+    expect(ct).toContain('text/html');
+    const text = await res.text();
+    expect(text).toContain('OpenChrome trace replay');
+  });
+
+  test('GET /api/trace/list returns [] for empty index', async () => {
+    const r = await getJson(`${handle.url}api/trace/list`);
+    expect(r.status).toBe(200);
+    expect(Array.isArray(r.body)).toBe(true);
+    expect((r.body as unknown[]).length).toBe(0);
+  });
+
+  test('GET /api/trace/list reflects recorded sessions', async () => {
+    store.recordSessionStart({
+      sessionId: 's1',
+      startedAt: 1000,
+      domain: 'amazon.com',
+      status: 'completed',
+    });
+    store.recordSessionStart({
+      sessionId: 's2',
+      startedAt: 2000,
+      domain: 'github.com',
+      status: 'failed',
+    });
+    const r = await getJson(`${handle.url}api/trace/list`);
+    expect(r.status).toBe(200);
+    const rows = r.body as Array<{ session_id: string; domain: string }>;
+    expect(rows.length).toBe(2);
+    expect(rows[0].session_id).toBe('s2');
+    expect(rows[1].session_id).toBe('s1');
+  });
+
+  test('GET /api/trace/<id>/meta returns the index row', async () => {
+    store.recordSessionStart({
+      sessionId: 'meta-1',
+      startedAt: 1234,
+      domain: 'x.com',
+      status: 'running',
+    });
+    const r = await getJson(`${handle.url}api/trace/meta-1/meta`);
+    expect(r.status).toBe(200);
+    expect((r.body as { session_id: string }).session_id).toBe('meta-1');
+  });
+
+  test('GET /api/trace/<id>/events returns events with total + returned counts', async () => {
+    store.recordSessionStart({ sessionId: 'ev', startedAt: 1, status: 'running' });
+    store.appendEvents('ev', [
+      { ts: 100, seq: 1, kind: 'A', body: { ok: true } },
+      { ts: 200, seq: 2, kind: 'B', body: { ok: false } },
+      { ts: 300, seq: 3, kind: 'C', body: {} },
+    ]);
+    const r = await getJson(`${handle.url}api/trace/ev/events?limit=2`);
+    expect(r.status).toBe(200);
+    const body = r.body as { total: number; returned: number; events: Array<{ kind: string }> };
+    expect(body.total).toBe(3);
+    expect(body.returned).toBe(2);
+    expect(body.events.map((e) => e.kind)).toEqual(['A', 'B']);
+  });
+
+  test('GET /api/trace/<id>/events honors from / to filters', async () => {
+    store.recordSessionStart({ sessionId: 'f', startedAt: 1, status: 'running' });
+    store.appendEvents('f', [
+      { ts: 100, seq: 1, kind: 'A', body: {} },
+      { ts: 200, seq: 2, kind: 'B', body: {} },
+      { ts: 300, seq: 3, kind: 'C', body: {} },
+    ]);
+    const r = await getJson(`${handle.url}api/trace/f/events?from=150&to=250`);
+    expect(r.status).toBe(200);
+    const body = r.body as { events: Array<{ kind: string }> };
+    expect(body.events.map((e) => e.kind)).toEqual(['B']);
+  });
+
+  test('GET /api/trace/<unknown>/meta returns 404', async () => {
+    store.recordSessionStart({ sessionId: 'real', startedAt: 1, status: 'completed' });
+    const r = await getJson(`${handle.url}api/trace/missing/meta`);
+    expect(r.status).toBe(404);
+  });
+
+  test('unknown path returns 404', async () => {
+    const r = await getJson(`${handle.url}does/not/exist`);
+    expect(r.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

Interactive replay surface deferred from #743 (PR-3 partial). Stacked on **#744**.

```
oc trace play [--port <p>] [--no-open]
```

Spins up a `127.0.0.1`-only HTTP server, prints the URL, and (unless `--no-open`) launches the operator's default browser to a self-contained replay UI that lists sessions and renders the JSONL event stream + screenshots side-by-side.

## Why bind to 127.0.0.1 only

Trace files contain potentially sensitive captured DOM and network metadata even after redaction. Hard-binding to loopback prevents accidental network exposure on shared dev machines and CI runners. There is **no flag to override** — operators who genuinely need a remote view should tunnel via SSH.

## Why a separate PR from #743

The list/show subcommands are pure read-only file reads — easy to review and ship. The replay UI introduces an HTTP server and embedded static assets, which is a different review surface. Splitting keeps each PR focused.

## Validation

- `npm run build` clean
- `npm test -- tests/cli` — all green
- Smoke: `node dist/cli/index.js trace play --no-open --port 0` prints a 127.0.0.1 URL and exits cleanly on SIGINT

## Test plan

- [ ] Reviewer pulls and runs `npm install && npm run build`
- [ ] Reviewer runs `node dist/cli/index.js trace play --no-open` and curls the printed URL — sessions list renders
- [ ] Reviewer confirms server bind is `127.0.0.1` only (try `nc -zv <lan-ip> <port>` from another host — must fail)
- [ ] Reviewer confirms `--no-open` does NOT spawn `open`/`xdg-open`/`start`

Refs: #698 (epic), #701/#704 (sub-issues). Stacked on #744.

🤖 Split from `feat/m1-pr1-trace-foundation`. Original commit: `5a3e6f2`.
