### PR TITLE
feat(mcp): expose openchrome://trace/* resources to LLM clients (#704)

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -18,6 +18,7 @@ import { MCPTransport, createTransport } from './transports/index';
 import { SessionManager, getSessionManager } from './session-manager';
 import { Dashboard, getDashboard, ActivityTracker, getActivityTracker, OperationController } from './dashboard/index.js';
 import { usageGuideResource, getUsageGuideContent, MCPResourceDefinition } from './resources/usage-guide';
+import { traceListResource, readTraceResource } from './resources/trace-resource';
 import { HintEngine } from './hints';
 import { validateToolSchema } from './utils/schema-validator';
 import { formatAge } from './utils/format-age';
@@ -138,6 +139,18 @@ export interface MCPServerOptions {
 export class MCPServer {
   private tools: Map<string, ToolRegistry> = new Map();
   private resources: Map<string, MCPResourceDefinition> = new Map();
+  /**
+   * Prefix-matched resource handlers for dynamic URIs (e.g.
+   * `openchrome://trace/<id>/meta`). Each entry handles every URI that
+   * starts with `prefix`. Listing-only resources (the static "list"
+   * URIs that surface the prefix space to clients) live in `resources`
+   * and are returned by `resources/list`. Prefix matching is checked
+   * AFTER exact-match `resources` lookup in `handleResourcesRead`.
+   */
+  private resourcePrefixHandlers: Array<{
+    prefix: string;
+    read: (uri: string) => Promise<{ mimeType: string; text: string } | null>;
+  }> = [];
   private manifestVersion: number = 1;
   private sessionManager: SessionManager;
   private transport: MCPTransport | null = null;
@@ -201,6 +214,12 @@ export class MCPServer {
     // Register built-in resources
     this.registerResource(usageGuideResource);
 
+    // Trace subsystem (#704): the `list` URI is statically discoverable;
+    // dynamic per-session URIs (`openchrome://trace/<id>/{meta|events}`)
+    // are served via the prefix handler.
+    this.registerResource(traceListResource);
+    this.registerResourcePrefix('openchrome://trace/', readTraceResource);
+
     // Initialize dashboard if enabled
     if (options.dashboard) {
       this.initDashboard();
@@ -238,6 +257,21 @@ export class MCPServer {
    */
   registerResource(resource: MCPResourceDefinition): void {
     this.resources.set(resource.uri, resource);
+  }
+
+  /**
+   * Register a prefix-matched resource handler. The handler is invoked
+   * by `handleResourcesRead` whenever the requested URI starts with
+   * `prefix` and no exact match was found in `this.resources`. The
+   * handler returns `{mimeType, text}` for a successful read or `null`
+   * for "not found at this prefix" (the server then continues looking
+   * at later prefixes / falls through to the unknown-resource error).
+   */
+  registerResourcePrefix(
+    prefix: string,
+    read: (uri: string) => Promise<{ mimeType: string; text: string } | null>,
+  ): void {
+    this.resourcePrefixHandlers.push({ prefix, read });
   }
 
   /**
@@ -699,28 +733,59 @@ export class MCPServer {
       throw new Error('Missing resource uri');
     }
 
+    // 1. Exact-match resources (static URIs like usage-guide / trace/list)
     const resource = this.resources.get(uri);
-    if (!resource) {
-      throw new Error(`Unknown resource: ${uri}`);
+    if (resource) {
+      let content: string;
+      if (uri === 'openchrome://usage-guide') {
+        content = getUsageGuideContent();
+      } else {
+        // Static resource without a hardcoded handler — try the prefix
+        // handler chain (e.g., the trace subsystem owns its own list URI).
+        const fromPrefix = await this.tryPrefixHandlers(uri);
+        if (fromPrefix) {
+          return {
+            contents: [
+              { uri, mimeType: fromPrefix.mimeType, text: fromPrefix.text },
+            ],
+          };
+        }
+        throw new Error(`No content handler for resource: ${uri}`);
+      }
+      return {
+        contents: [
+          { uri: resource.uri, mimeType: resource.mimeType, text: content },
+        ],
+      };
     }
 
-    // Get content based on resource type
-    let content: string;
-    if (uri === 'openchrome://usage-guide') {
-      content = getUsageGuideContent();
-    } else {
-      throw new Error(`No content handler for resource: ${uri}`);
+    // 2. Prefix-match resources (dynamic URIs like openchrome://trace/<id>/meta)
+    const fromPrefix = await this.tryPrefixHandlers(uri);
+    if (fromPrefix) {
+      return {
+        contents: [
+          { uri, mimeType: fromPrefix.mimeType, text: fromPrefix.text },
+        ],
+      };
     }
 
-    return {
-      contents: [
-        {
-          uri: resource.uri,
-          mimeType: resource.mimeType,
-          text: content,
-        },
-      ],
-    };
+    throw new Error(`Unknown resource: ${uri}`);
+  }
+
+  /**
+   * Walk the prefix-handler chain. Returns the first successful read
+   * result; null when no prefix matches or every matching prefix returns
+   * null (e.g., session not found).
+   */
+  private async tryPrefixHandlers(
+    uri: string,
+  ): Promise<{ mimeType: string; text: string } | null> {
+    for (const { prefix, read } of this.resourcePrefixHandlers) {
+      if (!uri.startsWith(prefix)) continue;
+      const r = await read(uri);
+      if (r) return r;
+    }
+    return null;
   }
 
   /**

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -149,7 +149,10 @@ export class MCPServer {
    */
   private resourcePrefixHandlers: Array<{
     prefix: string;
-    read: (uri: string) => Promise<{ mimeType: string; text: string } | null>;
+    read: (
+      uri: string,
+      caller?: { mode?: string; tenantId?: string },
+    ) => Promise<{ mimeType: string; text: string } | null>;
   }> = [];
   private manifestVersion: number = 1;
   private sessionManager: SessionManager;
@@ -269,7 +272,10 @@ export class MCPServer {
    */
   registerResourcePrefix(
     prefix: string,
-    read: (uri: string) => Promise<{ mimeType: string; text: string } | null>,
+    read: (
+      uri: string,
+      caller?: { mode?: string; tenantId?: string },
+    ) => Promise<{ mimeType: string; text: string } | null>,
   ): void {
     this.resourcePrefixHandlers.push({ prefix, read });
   }
@@ -593,7 +599,7 @@ export class MCPServer {
           break;
 
         case 'resources/read':
-          result = await this.handleResourcesRead(params);
+          result = await this.handleResourcesRead(params, principal);
           break;
 
         case 'sessions/list':
@@ -721,9 +727,15 @@ export class MCPServer {
   }
 
   /**
-   * Handle resources/read request
+   * Handle resources/read request. The transport-injected `principal`
+   * is forwarded to prefix handlers so they can apply tenant-aware
+   * filters (e.g. trace resources fail-closed for api-key callers until
+   * per-trace tenant tagging exists; see src/resources/trace-resource.ts).
    */
-  private async handleResourcesRead(params?: Record<string, unknown>): Promise<MCPResult> {
+  private async handleResourcesRead(
+    params?: Record<string, unknown>,
+    principal?: Principal,
+  ): Promise<MCPResult> {
     if (!params) {
       throw new Error('Missing params for resources/read');
     }
@@ -742,7 +754,7 @@ export class MCPServer {
       } else {
         // Static resource without a hardcoded handler — try the prefix
         // handler chain (e.g., the trace subsystem owns its own list URI).
-        const fromPrefix = await this.tryPrefixHandlers(uri);
+        const fromPrefix = await this.tryPrefixHandlers(uri, principal);
         if (fromPrefix) {
           return {
             contents: [
@@ -760,7 +772,7 @@ export class MCPServer {
     }
 
     // 2. Prefix-match resources (dynamic URIs like openchrome://trace/<id>/meta)
-    const fromPrefix = await this.tryPrefixHandlers(uri);
+    const fromPrefix = await this.tryPrefixHandlers(uri, principal);
     if (fromPrefix) {
       return {
         contents: [
@@ -779,10 +791,14 @@ export class MCPServer {
    */
   private async tryPrefixHandlers(
     uri: string,
+    principal?: Principal,
   ): Promise<{ mimeType: string; text: string } | null> {
+    const caller = principal
+      ? { mode: principal.mode, tenantId: principal.tenantId }
+      : undefined;
     for (const { prefix, read } of this.resourcePrefixHandlers) {
       if (!uri.startsWith(prefix)) continue;
-      const r = await read(uri);
+      const r = await read(uri, caller);
       if (r) return r;
     }
     return null;

--- a/src/resources/trace-resource.ts
+++ b/src/resources/trace-resource.ts
@@ -211,6 +211,12 @@ async function streamSessionEvents(
   let total = 0;
   let truncated = false;
 
+  // `scanned` is the wall-time guard: it counts every non-blank line we
+  // pull off the stream, including parse failures and non-event lines,
+  // so a JSONL file full of garbage can't burn unbounded CPU/I/O.
+  // `total` separately counts only well-formed events so the response's
+  // pagination metadata stays accurate.
+  let scanned = 0;
   outer: for (const f of files) {
     const stream = fs.createReadStream(path.join(sessionDir, f), {
       encoding: 'utf8',
@@ -219,7 +225,8 @@ async function streamSessionEvents(
     try {
       for await (const line of rl) {
         if (!line.trim()) continue;
-        if (total >= MAX_TOTAL_SCAN) {
+        scanned += 1;
+        if (scanned > MAX_TOTAL_SCAN) {
           truncated = true;
           break outer;
         }
@@ -228,7 +235,8 @@ async function streamSessionEvents(
           raw = JSON.parse(line);
         } catch {
           // not parseable — do not count toward total; legacy / external
-          // tooling may write incidental noise we should tolerate.
+          // tooling may write incidental noise we should tolerate. The
+          // `scanned` increment above still applies so the cap fires.
           continue;
         }
         if (!isTraceEvent(raw)) {

--- a/src/resources/trace-resource.ts
+++ b/src/resources/trace-resource.ts
@@ -166,6 +166,20 @@ interface TraceEventEnvelope {
   body: unknown;
 }
 
+/**
+ * Type guard: is `value` a parseable trace event envelope? A legacy or
+ * out-of-band JSONL line can be valid JSON yet not an event (a `null`,
+ * a number, an unrelated object) — accessing `parsed.ts` directly on
+ * such a value would throw and fail the entire read. Only `ts` is
+ * required to be numeric (filters key off it); other fields fall back
+ * to safe defaults during redaction / serialization.
+ */
+function isTraceEvent(value: unknown): value is TraceEventEnvelope {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.ts === 'number' && Number.isFinite(v.ts);
+}
+
 interface StreamReadResult {
   total: number;
   matched: TraceEventEnvelope[];
@@ -209,14 +223,21 @@ async function streamSessionEvents(
           truncated = true;
           break outer;
         }
-        let parsed: TraceEventEnvelope | null = null;
+        let raw: unknown;
         try {
-          parsed = JSON.parse(line) as TraceEventEnvelope;
+          raw = JSON.parse(line);
         } catch {
-          // skip malformed; do not increment total — total counts only
-          // well-formed events so callers can page consistently.
+          // not parseable — do not count toward total; legacy / external
+          // tooling may write incidental noise we should tolerate.
           continue;
         }
+        if (!isTraceEvent(raw)) {
+          // Parseable but not an event envelope (e.g. `null`, scalar,
+          // unrelated object). Skip without throwing so a single bad
+          // line cannot fail the whole read.
+          continue;
+        }
+        const parsed = raw;
         total += 1;
         if (filters.from !== undefined && parsed.ts < filters.from) continue;
         if (filters.to !== undefined && parsed.ts > filters.to) continue;

--- a/src/resources/trace-resource.ts
+++ b/src/resources/trace-resource.ts
@@ -180,6 +180,27 @@ function isTraceEvent(value: unknown): value is TraceEventEnvelope {
   return typeof v.ts === 'number' && Number.isFinite(v.ts);
 }
 
+function resolveSessionDir(sessionId: string): string | null {
+  if (
+    sessionId.length === 0 ||
+    sessionId === '.' ||
+    sessionId === '..' ||
+    sessionId.includes('/') ||
+    sessionId.includes('\\') ||
+    sessionId.includes('\0')
+  ) {
+    return null;
+  }
+
+  const root = path.resolve(traceRoot());
+  const sessionDir = path.resolve(root, sessionId);
+  const relative = path.relative(root, sessionDir);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    return null;
+  }
+  return sessionDir;
+}
+
 interface StreamReadResult {
   total: number;
   matched: TraceEventEnvelope[];
@@ -198,7 +219,10 @@ async function streamSessionEvents(
   sessionId: string,
   filters: { from?: number; to?: number; limit: number },
 ): Promise<StreamReadResult> {
-  const sessionDir = path.join(traceRoot(), sessionId);
+  const sessionDir = resolveSessionDir(sessionId);
+  if (!sessionDir) {
+    return { total: 0, matched: [], truncated: false };
+  }
   if (!fs.existsSync(sessionDir)) {
     return { total: 0, matched: [], truncated: false };
   }

--- a/src/resources/trace-resource.ts
+++ b/src/resources/trace-resource.ts
@@ -246,9 +246,14 @@ async function streamSessionEvents(
           continue;
         }
         const parsed = raw;
-        total += 1;
+        // Apply the time window first so `total` reflects events that
+        // match the filtered query, not the whole session. Pagination
+        // clients use `total` to decide whether more matching pages
+        // exist; counting unfiltered events here makes them spin
+        // looking for pages that aren't there.
         if (filters.from !== undefined && parsed.ts < filters.from) continue;
         if (filters.to !== undefined && parsed.ts > filters.to) continue;
+        total += 1;
         if (matched.length < filters.limit) matched.push(parsed);
         // Important: do NOT break here — `total` must reflect every
         // matching event so the caller knows how much paging remains.

--- a/src/resources/trace-resource.ts
+++ b/src/resources/trace-resource.ts
@@ -202,10 +202,21 @@ async function streamSessionEvents(
   if (!fs.existsSync(sessionDir)) {
     return { total: 0, matched: [], truncated: false };
   }
+  // Recorder names chunks `<ts>-<seq>.jsonl`. A plain lexicographic
+  // sort would place `...-10.jsonl` before `...-2.jsonl`, and because
+  // recorder timestamps come from `Date.now()` two flushes can share a
+  // millisecond. Sort by parsed `(ts, seq)` numerically so the event
+  // stream returned through `openchrome://trace/<id>/events` matches
+  // capture order — replay / pagination clients depend on that.
   const files = fs
     .readdirSync(sessionDir)
     .filter((f) => f.endsWith('.jsonl'))
-    .sort();
+    .map((f) => {
+      const m = /^(\d+)-(\d+)\.jsonl$/.exec(f);
+      return { f, ts: m ? Number(m[1]) : 0, seq: m ? Number(m[2]) : 0 };
+    })
+    .sort((a, b) => (a.ts - b.ts) || (a.seq - b.seq))
+    .map((e) => e.f);
 
   const matched: TraceEventEnvelope[] = [];
   let total = 0;

--- a/src/resources/trace-resource.ts
+++ b/src/resources/trace-resource.ts
@@ -1,0 +1,195 @@
+/**
+ * MCP resources for the trace subsystem.
+ *
+ * Exposes captured trace data via three URI shapes:
+ *
+ *   openchrome://trace/list            (static)
+ *     → top-50 sessions as JSON {session_id, started_at, ended_at,
+ *        domain, status, byte_size, parent_op}
+ *
+ *   openchrome://trace/<id>/meta       (dynamic)
+ *     → one-row meta for the given session
+ *
+ *   openchrome://trace/<id>/events?from=&to=&limit=
+ *     → JSON {sessionId, total, returned, events[]}
+ *
+ * The list URI is registered as a regular MCPResource so it shows up in
+ * `resources/list`. The dynamic URIs are served via the prefix-handler
+ * extension on MCPServer (registerResourcePrefix).
+ *
+ * Reads from `~/.openchrome/traces/index.sqlite` and the per-session
+ * JSONL files. Read-only; no MCP write resources.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type { MCPResourceDefinition } from './usage-guide';
+
+type BetterSqlite3 = typeof import('better-sqlite3');
+type Database = import('better-sqlite3').Database;
+
+let _Sqlite: BetterSqlite3 | null = null;
+function loadSqlite(): BetterSqlite3 {
+  if (_Sqlite) return _Sqlite;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  _Sqlite = require('better-sqlite3') as BetterSqlite3;
+  return _Sqlite;
+}
+
+const DEFAULT_TRACE_ROOT = path.join(os.homedir(), '.openchrome', 'traces');
+
+function traceRoot(): string {
+  return process.env.OPENCHROME_TRACE_ROOT ?? DEFAULT_TRACE_ROOT;
+}
+
+function openIndex(): Database | null {
+  const dbPath = path.join(traceRoot(), 'index.sqlite');
+  if (!fs.existsSync(dbPath)) return null;
+  const Sqlite = loadSqlite();
+  return new Sqlite(dbPath, { readonly: true, fileMustExist: true });
+}
+
+/** Static-listing resource — discoverable via `resources/list`. */
+export const traceListResource: MCPResourceDefinition = {
+  uri: 'openchrome://trace/list',
+  name: 'trace-list',
+  description:
+    'JSON: top-50 most recent trace sessions with metadata. Dynamic per-session URIs ' +
+    'follow the pattern openchrome://trace/<sessionId>/meta and openchrome://trace/<sessionId>/events',
+  mimeType: 'application/json',
+};
+
+/** Build the JSON payload for `openchrome://trace/list`. */
+export function buildTraceListPayload(): string {
+  const db = openIndex();
+  if (!db) return JSON.stringify([]);
+  try {
+    const rows = db
+      .prepare(
+        'SELECT session_id, started_at, ended_at, domain, status, byte_size, parent_op FROM traces ORDER BY started_at DESC LIMIT 50',
+      )
+      .all();
+    return JSON.stringify(rows);
+  } finally {
+    db.close();
+  }
+}
+
+interface ResolvedTraceUri {
+  sessionId: string;
+  kind: 'meta' | 'events';
+  query: URLSearchParams;
+}
+
+/**
+ * Parse `openchrome://trace/<id>/{meta|events}[?...]`. Returns null when
+ * the URI is the static list (`openchrome://trace/list`) or any other
+ * shape the trace handler does not own.
+ */
+export function parseTraceUri(uri: string): ResolvedTraceUri | null {
+  if (!uri.startsWith('openchrome://trace/')) return null;
+  if (uri === 'openchrome://trace/list') return null;
+  // Use URL parser by substituting a host so query parsing works uniformly.
+  const u = new URL(uri.replace('openchrome://', 'http://oc/'));
+  const segments = u.pathname.split('/').filter(Boolean);
+  // segments: ['trace', '<id>', '<meta|events>']
+  if (segments.length !== 3 || segments[0] !== 'trace') return null;
+  const kind = segments[2];
+  if (kind !== 'meta' && kind !== 'events') return null;
+  return {
+    sessionId: decodeURIComponent(segments[1]),
+    kind,
+    query: u.searchParams,
+  };
+}
+
+interface TraceEventEnvelope {
+  ts: number;
+  seq: number;
+  kind: string;
+  body: unknown;
+}
+
+function readSessionEvents(sessionId: string): TraceEventEnvelope[] {
+  const sessionDir = path.join(traceRoot(), sessionId);
+  if (!fs.existsSync(sessionDir)) return [];
+  const out: TraceEventEnvelope[] = [];
+  const files = fs.readdirSync(sessionDir).filter((f) => f.endsWith('.jsonl')).sort();
+  for (const f of files) {
+    const content = fs.readFileSync(path.join(sessionDir, f), 'utf8');
+    for (const line of content.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        out.push(JSON.parse(line) as TraceEventEnvelope);
+      } catch {
+        // skip malformed
+      }
+    }
+  }
+  return out;
+}
+
+function numericQuery(q: URLSearchParams, name: string): number | undefined {
+  const raw = q.get(name);
+  if (raw == null) return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/** Default `limit` for events (matches replay-server). */
+const DEFAULT_EVENT_LIMIT = 1000;
+const MAX_EVENT_LIMIT = 10_000;
+
+/**
+ * Compute the JSON payload for a parsed dynamic URI. Returns null when
+ * the underlying session is not found in the index.
+ */
+export function buildTraceContent(parsed: ResolvedTraceUri): string | null {
+  const db = openIndex();
+  if (!db) return null;
+  try {
+    const meta = db
+      .prepare(
+        'SELECT session_id, started_at, ended_at, domain, status, byte_size, parent_op FROM traces WHERE session_id = ?',
+      )
+      .get(parsed.sessionId);
+    if (!meta) return null;
+    if (parsed.kind === 'meta') return JSON.stringify(meta);
+
+    const events = readSessionEvents(parsed.sessionId);
+    const fromTs = numericQuery(parsed.query, 'from');
+    const toTs = numericQuery(parsed.query, 'to');
+    const limit = Math.max(
+      1,
+      Math.min(MAX_EVENT_LIMIT, numericQuery(parsed.query, 'limit') ?? DEFAULT_EVENT_LIMIT),
+    );
+    let filtered = events;
+    if (fromTs !== undefined) filtered = filtered.filter((e) => e.ts >= fromTs);
+    if (toTs !== undefined) filtered = filtered.filter((e) => e.ts <= toTs);
+    const slice = filtered.slice(0, limit);
+    return JSON.stringify({
+      sessionId: parsed.sessionId,
+      total: events.length,
+      returned: slice.length,
+      events: slice,
+    });
+  } finally {
+    db.close();
+  }
+}
+
+/** Combined entry point used by the prefix handler in MCPServer. */
+export async function readTraceResource(
+  uri: string,
+): Promise<{ mimeType: string; text: string } | null> {
+  if (uri === traceListResource.uri) {
+    return { mimeType: traceListResource.mimeType, text: buildTraceListPayload() };
+  }
+  const parsed = parseTraceUri(uri);
+  if (!parsed) return null;
+  const text = buildTraceContent(parsed);
+  if (text === null) return null;
+  return { mimeType: 'application/json', text };
+}

--- a/src/resources/trace-resource.ts
+++ b/src/resources/trace-resource.ts
@@ -19,11 +19,22 @@
  *
  * Reads from `~/.openchrome/traces/index.sqlite` and the per-session
  * JSONL files. Read-only; no MCP write resources.
+ *
+ * Tenant isolation
+ * ----------------
+ * The `traces` index does not yet carry a tenant id (the recorder writes
+ * untagged rows; see #698 / #704). Until per-trace tenant tagging lands,
+ * every read entry point refuses to serve api-key callers — `list`
+ * returns `[]` and dynamic URIs return null. Other modes (stdio,
+ * disabled-auth) are unaffected. This is fail-closed: it keeps trace
+ * data inside the host process for legitimate operators while preventing
+ * cross-tenant leakage in multi-tenant deployments.
  */
 
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import * as readline from 'node:readline';
 
 import type { MCPResourceDefinition } from './usage-guide';
 
@@ -51,6 +62,21 @@ function openIndex(): Database | null {
   return new Sqlite(dbPath, { readonly: true, fileMustExist: true });
 }
 
+/**
+ * Caller identity carried into the resource read paths. Mirrors the
+ * shape of `Principal` in src/auth/api-key-types.ts but is declared
+ * structurally to keep this module free of an auth import. Only `mode`
+ * is consulted; api-key callers are refused until per-trace tenant
+ * tagging exists (see file header).
+ */
+export interface TraceResourceCaller {
+  mode?: string;
+}
+
+function isApiKeyCaller(caller?: TraceResourceCaller): boolean {
+  return caller?.mode === 'api-key';
+}
+
 /** Static-listing resource — discoverable via `resources/list`. */
 export const traceListResource: MCPResourceDefinition = {
   uri: 'openchrome://trace/list',
@@ -62,7 +88,9 @@ export const traceListResource: MCPResourceDefinition = {
 };
 
 /** Build the JSON payload for `openchrome://trace/list`. */
-export function buildTraceListPayload(): string {
+export function buildTraceListPayload(caller?: TraceResourceCaller): string {
+  // Fail-closed for api-key callers — see file header on tenant isolation.
+  if (isApiKeyCaller(caller)) return JSON.stringify([]);
   const db = openIndex();
   if (!db) return JSON.stringify([]);
   try {
@@ -92,17 +120,24 @@ export function parseTraceUri(uri: string): ResolvedTraceUri | null {
   if (!uri.startsWith('openchrome://trace/')) return null;
   if (uri === 'openchrome://trace/list') return null;
   // Use URL parser by substituting a host so query parsing works uniformly.
-  const u = new URL(uri.replace('openchrome://', 'http://oc/'));
+  let u: URL;
+  try {
+    u = new URL(uri.replace('openchrome://', 'http://oc/'));
+  } catch {
+    return null;
+  }
   const segments = u.pathname.split('/').filter(Boolean);
   // segments: ['trace', '<id>', '<meta|events>']
   if (segments.length !== 3 || segments[0] !== 'trace') return null;
   const kind = segments[2];
   if (kind !== 'meta' && kind !== 'events') return null;
-  return {
-    sessionId: decodeURIComponent(segments[1]),
-    kind,
-    query: u.searchParams,
-  };
+  let sessionId: string;
+  try {
+    sessionId = decodeURIComponent(segments[1]);
+  } catch {
+    return null;
+  }
+  return { sessionId, kind, query: u.searchParams };
 }
 
 interface TraceEventEnvelope {
@@ -112,23 +147,71 @@ interface TraceEventEnvelope {
   body: unknown;
 }
 
-function readSessionEvents(sessionId: string): TraceEventEnvelope[] {
+interface StreamReadResult {
+  total: number;
+  matched: TraceEventEnvelope[];
+  truncated: boolean;
+}
+
+/**
+ * Stream every JSONL file for the session and apply `from`/`to`/`limit`
+ * filters inline. Stops materialising into the result array once `limit`
+ * matches have been collected, but continues counting lines so `total`
+ * stays accurate for the caller. A hard `MAX_TOTAL_SCAN` cap protects
+ * the read path from a runaway file: when it trips the response is
+ * marked `truncated: true` so callers can paginate forward.
+ */
+async function streamSessionEvents(
+  sessionId: string,
+  filters: { from?: number; to?: number; limit: number },
+): Promise<StreamReadResult> {
   const sessionDir = path.join(traceRoot(), sessionId);
-  if (!fs.existsSync(sessionDir)) return [];
-  const out: TraceEventEnvelope[] = [];
-  const files = fs.readdirSync(sessionDir).filter((f) => f.endsWith('.jsonl')).sort();
-  for (const f of files) {
-    const content = fs.readFileSync(path.join(sessionDir, f), 'utf8');
-    for (const line of content.split('\n')) {
-      if (!line.trim()) continue;
-      try {
-        out.push(JSON.parse(line) as TraceEventEnvelope);
-      } catch {
-        // skip malformed
+  if (!fs.existsSync(sessionDir)) {
+    return { total: 0, matched: [], truncated: false };
+  }
+  const files = fs
+    .readdirSync(sessionDir)
+    .filter((f) => f.endsWith('.jsonl'))
+    .sort();
+
+  const matched: TraceEventEnvelope[] = [];
+  let total = 0;
+  let truncated = false;
+
+  outer: for (const f of files) {
+    const stream = fs.createReadStream(path.join(sessionDir, f), {
+      encoding: 'utf8',
+    });
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+    try {
+      for await (const line of rl) {
+        if (!line.trim()) continue;
+        if (total >= MAX_TOTAL_SCAN) {
+          truncated = true;
+          break outer;
+        }
+        let parsed: TraceEventEnvelope | null = null;
+        try {
+          parsed = JSON.parse(line) as TraceEventEnvelope;
+        } catch {
+          // skip malformed; do not increment total — total counts only
+          // well-formed events so callers can page consistently.
+          continue;
+        }
+        total += 1;
+        if (filters.from !== undefined && parsed.ts < filters.from) continue;
+        if (filters.to !== undefined && parsed.ts > filters.to) continue;
+        if (matched.length < filters.limit) matched.push(parsed);
+        // Important: do NOT break here — `total` must reflect every
+        // matching event so the caller knows how much paging remains.
       }
+    } finally {
+      rl.close();
+      stream.destroy();
     }
   }
-  return out;
+
+  return { total, matched, truncated };
 }
 
 function numericQuery(q: URLSearchParams, name: string): number | undefined {
@@ -141,55 +224,74 @@ function numericQuery(q: URLSearchParams, name: string): number | undefined {
 /** Default `limit` for events (matches replay-server). */
 const DEFAULT_EVENT_LIMIT = 1000;
 const MAX_EVENT_LIMIT = 10_000;
+/**
+ * Hard cap on lines scanned per read. Bounds memory and wall time even
+ * if the JSONL backing files are unbounded. 200k events ≈ a few MB of
+ * working set when matched.length stays ≤ MAX_EVENT_LIMIT.
+ */
+const MAX_TOTAL_SCAN = 200_000;
 
 /**
  * Compute the JSON payload for a parsed dynamic URI. Returns null when
- * the underlying session is not found in the index.
+ * the underlying session is not found in the index, when the caller is
+ * an api-key principal (fail-closed; see file header).
  */
-export function buildTraceContent(parsed: ResolvedTraceUri): string | null {
+export async function buildTraceContent(
+  parsed: ResolvedTraceUri,
+  caller?: TraceResourceCaller,
+): Promise<string | null> {
+  if (isApiKeyCaller(caller)) return null;
   const db = openIndex();
   if (!db) return null;
+  let meta: unknown;
   try {
-    const meta = db
+    meta = db
       .prepare(
         'SELECT session_id, started_at, ended_at, domain, status, byte_size, parent_op FROM traces WHERE session_id = ?',
       )
       .get(parsed.sessionId);
-    if (!meta) return null;
-    if (parsed.kind === 'meta') return JSON.stringify(meta);
-
-    const events = readSessionEvents(parsed.sessionId);
-    const fromTs = numericQuery(parsed.query, 'from');
-    const toTs = numericQuery(parsed.query, 'to');
-    const limit = Math.max(
-      1,
-      Math.min(MAX_EVENT_LIMIT, numericQuery(parsed.query, 'limit') ?? DEFAULT_EVENT_LIMIT),
-    );
-    let filtered = events;
-    if (fromTs !== undefined) filtered = filtered.filter((e) => e.ts >= fromTs);
-    if (toTs !== undefined) filtered = filtered.filter((e) => e.ts <= toTs);
-    const slice = filtered.slice(0, limit);
-    return JSON.stringify({
-      sessionId: parsed.sessionId,
-      total: events.length,
-      returned: slice.length,
-      events: slice,
-    });
   } finally {
     db.close();
   }
+  if (!meta) return null;
+  if (parsed.kind === 'meta') return JSON.stringify(meta);
+
+  const fromTs = numericQuery(parsed.query, 'from');
+  const toTs = numericQuery(parsed.query, 'to');
+  const limit = Math.max(
+    1,
+    Math.min(MAX_EVENT_LIMIT, numericQuery(parsed.query, 'limit') ?? DEFAULT_EVENT_LIMIT),
+  );
+
+  const result = await streamSessionEvents(parsed.sessionId, {
+    from: fromTs,
+    to: toTs,
+    limit,
+  });
+
+  return JSON.stringify({
+    sessionId: parsed.sessionId,
+    total: result.total,
+    returned: result.matched.length,
+    truncated: result.truncated,
+    events: result.matched,
+  });
 }
 
 /** Combined entry point used by the prefix handler in MCPServer. */
 export async function readTraceResource(
   uri: string,
+  caller?: TraceResourceCaller,
 ): Promise<{ mimeType: string; text: string } | null> {
   if (uri === traceListResource.uri) {
-    return { mimeType: traceListResource.mimeType, text: buildTraceListPayload() };
+    return {
+      mimeType: traceListResource.mimeType,
+      text: buildTraceListPayload(caller),
+    };
   }
   const parsed = parseTraceUri(uri);
   if (!parsed) return null;
-  const text = buildTraceContent(parsed);
+  const text = await buildTraceContent(parsed, caller);
   if (text === null) return null;
   return { mimeType: 'application/json', text };
 }

--- a/src/resources/trace-resource.ts
+++ b/src/resources/trace-resource.ts
@@ -24,11 +24,22 @@
  * ----------------
  * The `traces` index does not yet carry a tenant id (the recorder writes
  * untagged rows; see #698 / #704). Until per-trace tenant tagging lands,
- * every read entry point refuses to serve api-key callers — `list`
- * returns `[]` and dynamic URIs return null. Other modes (stdio,
- * disabled-auth) are unaffected. This is fail-closed: it keeps trace
- * data inside the host process for legitimate operators while preventing
- * cross-tenant leakage in multi-tenant deployments.
+ * every read entry point refuses any caller that carries tenant identity
+ * — i.e. `mode: 'api-key'` and `mode: 'jwt'` — because both authenticate
+ * a specific tenant in multi-tenant deployments and would otherwise be
+ * able to enumerate other tenants' sessions. `list` returns `[]` and
+ * dynamic URIs return null for those callers. `disabled` / `legacy` /
+ * stdio (no principal) are unaffected. This is fail-closed.
+ *
+ * Defense in depth on read
+ * ------------------------
+ * The recorder runs the redactor on the write path (#735 / #736), but
+ * trace files written before a redactor pattern existed, written by
+ * tooling outside the recorder, or written by a buggy producer can
+ * still contain credentials. Every event returned through this module
+ * is therefore re-redacted before serialization — the cost is one
+ * pattern pass against already-stored JSONL and the redactor module is
+ * the same one the writer uses, so behaviour stays consistent.
  */
 
 import * as fs from 'node:fs';
@@ -36,6 +47,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import * as readline from 'node:readline';
 
+import { redactTraceEvent } from '../trace/redactor';
 import type { MCPResourceDefinition } from './usage-guide';
 
 type BetterSqlite3 = typeof import('better-sqlite3');
@@ -65,16 +77,23 @@ function openIndex(): Database | null {
 /**
  * Caller identity carried into the resource read paths. Mirrors the
  * shape of `Principal` in src/auth/api-key-types.ts but is declared
- * structurally to keep this module free of an auth import. Only `mode`
- * is consulted; api-key callers are refused until per-trace tenant
- * tagging exists (see file header).
+ * structurally to keep this module free of an auth import.
  */
 export interface TraceResourceCaller {
   mode?: string;
+  tenantId?: string;
 }
 
-function isApiKeyCaller(caller?: TraceResourceCaller): boolean {
-  return caller?.mode === 'api-key';
+/**
+ * True when the caller carries a tenant identity that we cannot honour
+ * at read time yet — i.e. `api-key` or `jwt` modes. Both authenticate
+ * a specific tenant, so serving the un-tagged `traces` table to either
+ * would leak cross-tenant data. Returns false for stdio (no principal)
+ * and for `disabled` / `legacy` modes which are not multi-tenant.
+ */
+function isTenantBoundCaller(caller?: TraceResourceCaller): boolean {
+  if (!caller || !caller.mode) return false;
+  return caller.mode === 'api-key' || caller.mode === 'jwt';
 }
 
 /** Static-listing resource — discoverable via `resources/list`. */
@@ -89,8 +108,8 @@ export const traceListResource: MCPResourceDefinition = {
 
 /** Build the JSON payload for `openchrome://trace/list`. */
 export function buildTraceListPayload(caller?: TraceResourceCaller): string {
-  // Fail-closed for api-key callers — see file header on tenant isolation.
-  if (isApiKeyCaller(caller)) return JSON.stringify([]);
+  // Fail-closed for tenant-bound callers — see file header on isolation.
+  if (isTenantBoundCaller(caller)) return JSON.stringify([]);
   const db = openIndex();
   if (!db) return JSON.stringify([]);
   try {
@@ -233,14 +252,15 @@ const MAX_TOTAL_SCAN = 200_000;
 
 /**
  * Compute the JSON payload for a parsed dynamic URI. Returns null when
- * the underlying session is not found in the index, when the caller is
- * an api-key principal (fail-closed; see file header).
+ * the underlying session is not found in the index, or when the caller
+ * is tenant-bound (api-key / jwt) — fail-closed pending per-trace tenant
+ * tagging; see file header.
  */
 export async function buildTraceContent(
   parsed: ResolvedTraceUri,
   caller?: TraceResourceCaller,
 ): Promise<string | null> {
-  if (isApiKeyCaller(caller)) return null;
+  if (isTenantBoundCaller(caller)) return null;
   const db = openIndex();
   if (!db) return null;
   let meta: unknown;
@@ -269,12 +289,18 @@ export async function buildTraceContent(
     limit,
   });
 
+  // Defence in depth: re-run the redactor over every returned event so
+  // a legacy / outside-of-recorder JSONL line cannot leak credentials
+  // through the read path. Same module the recorder uses on write, so
+  // patterns stay aligned.
+  const redacted = result.matched.map((ev) => redactTraceEvent(ev));
+
   return JSON.stringify({
     sessionId: parsed.sessionId,
     total: result.total,
-    returned: result.matched.length,
+    returned: redacted.length,
     truncated: result.truncated,
-    events: result.matched,
+    events: redacted,
   });
 }
 

--- a/tests/resources/trace-resource.test.ts
+++ b/tests/resources/trace-resource.test.ts
@@ -68,6 +68,13 @@ describe('parseTraceUri', () => {
   test('decodes URI-encoded session ids', () => {
     expect(parseTraceUri('openchrome://trace/foo%20bar/meta')?.sessionId).toBe('foo bar');
   });
+
+  test('returns null for malformed percent-encoded session ids', () => {
+    // Regression: the prior implementation called decodeURIComponent
+    // unguarded, so a bad %-sequence threw URIError out of the request
+    // handler. parseTraceUri now reports "not a trace URI" instead.
+    expect(parseTraceUri('openchrome://trace/%E0%A4%A/meta')).toBeNull();
+  });
 });
 
 describe('buildTraceListPayload + readTraceResource(list)', () => {
@@ -99,12 +106,26 @@ describe('buildTraceListPayload + readTraceResource(list)', () => {
     expect(typeof r?.text).toBe('string');
     expect(JSON.parse(r!.text)).toEqual([]);
   });
+
+  test('returns [] for api-key callers (fail-closed pending tenant tagging)', () => {
+    const root = tempRoot();
+    process.env.OPENCHROME_TRACE_ROOT = root;
+    const store = new TraceStorage({ rootDir: root });
+    store.recordSessionStart({ sessionId: 'tenant-a', startedAt: 100, status: 'completed' });
+    store.close();
+
+    const all = JSON.parse(buildTraceListPayload()) as unknown[];
+    expect(all.length).toBe(1);
+    const isolated = JSON.parse(buildTraceListPayload({ mode: 'api-key' })) as unknown[];
+    expect(isolated).toEqual([]);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
 });
 
 describe('buildTraceContent — meta', () => {
-  test('returns null for missing index', () => {
+  test('returns null for missing index', async () => {
     process.env.OPENCHROME_TRACE_ROOT = tempRoot();
-    const r = buildTraceContent({
+    const r = await buildTraceContent({
       sessionId: 'x',
       kind: 'meta',
       query: new URLSearchParams(),
@@ -112,7 +133,7 @@ describe('buildTraceContent — meta', () => {
     expect(r).toBeNull();
   });
 
-  test('returns the index row JSON for a known session', () => {
+  test('returns the index row JSON for a known session', async () => {
     const root = tempRoot();
     process.env.OPENCHROME_TRACE_ROOT = root;
     const store = new TraceStorage({ rootDir: root });
@@ -125,7 +146,7 @@ describe('buildTraceContent — meta', () => {
     });
     store.close();
 
-    const r = buildTraceContent({
+    const r = await buildTraceContent({
       sessionId: 's1',
       kind: 'meta',
       query: new URLSearchParams(),
@@ -143,7 +164,7 @@ describe('buildTraceContent — meta', () => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 
-  test('returns null for unknown session id', () => {
+  test('returns null for unknown session id', async () => {
     const root = tempRoot();
     process.env.OPENCHROME_TRACE_ROOT = root;
     const store = new TraceStorage({ rootDir: root });
@@ -151,8 +172,27 @@ describe('buildTraceContent — meta', () => {
     store.close();
 
     expect(
-      buildTraceContent({ sessionId: 'missing', kind: 'meta', query: new URLSearchParams() }),
+      await buildTraceContent({
+        sessionId: 'missing',
+        kind: 'meta',
+        query: new URLSearchParams(),
+      }),
     ).toBeNull();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('returns null for api-key callers (fail-closed pending tenant tagging)', async () => {
+    const root = tempRoot();
+    process.env.OPENCHROME_TRACE_ROOT = root;
+    const store = new TraceStorage({ rootDir: root });
+    store.recordSessionStart({ sessionId: 's1', startedAt: 1000, status: 'completed' });
+    store.close();
+
+    const r = await buildTraceContent(
+      { sessionId: 's1', kind: 'meta', query: new URLSearchParams() },
+      { mode: 'api-key' },
+    );
+    expect(r).toBeNull();
     fs.rmSync(root, { recursive: true, force: true });
   });
 });
@@ -178,8 +218,8 @@ describe('buildTraceContent — events', () => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 
-  test('returns total + returned + ordered events', () => {
-    const r = buildTraceContent({
+  test('returns total + returned + ordered events', async () => {
+    const r = await buildTraceContent({
       sessionId: 'e',
       kind: 'events',
       query: new URLSearchParams(),
@@ -187,25 +227,35 @@ describe('buildTraceContent — events', () => {
     const body = JSON.parse(r!) as {
       total: number;
       returned: number;
+      truncated: boolean;
       events: Array<{ kind: string }>;
     };
     expect(body.total).toBe(3);
     expect(body.returned).toBe(3);
+    expect(body.truncated).toBe(false);
     expect(body.events.map((e) => e.kind)).toEqual(['A', 'B', 'C']);
   });
 
-  test('honors the limit query parameter', () => {
-    const r = buildTraceContent({
+  test('honors the limit query parameter', async () => {
+    const r = await buildTraceContent({
       sessionId: 'e',
       kind: 'events',
       query: new URLSearchParams('limit=2'),
     });
-    const body = JSON.parse(r!) as { events: Array<{ kind: string }> };
+    const body = JSON.parse(r!) as {
+      events: Array<{ kind: string }>;
+      total: number;
+      returned: number;
+    };
     expect(body.events.map((e) => e.kind)).toEqual(['A', 'B']);
+    // total stays accurate even when matched events are capped — callers
+    // need this to know how many events remain to page through.
+    expect(body.total).toBe(3);
+    expect(body.returned).toBe(2);
   });
 
-  test('honors from / to filters', () => {
-    const r = buildTraceContent({
+  test('honors from / to filters', async () => {
+    const r = await buildTraceContent({
       sessionId: 'e',
       kind: 'events',
       query: new URLSearchParams('from=150&to=250'),
@@ -214,14 +264,39 @@ describe('buildTraceContent — events', () => {
     expect(body.events.map((e) => e.kind)).toEqual(['B']);
   });
 
-  test('caps limit at 10000 to prevent OOM', () => {
-    const r = buildTraceContent({
+  test('caps limit at 10000 to prevent OOM', async () => {
+    const r = await buildTraceContent({
       sessionId: 'e',
       kind: 'events',
       query: new URLSearchParams('limit=999999'),
     });
     const body = JSON.parse(r!) as { events: unknown[] };
     expect(body.events.length).toBeLessThanOrEqual(10_000);
+  });
+
+  test('streams: limit=1 keeps matched array small even with many events', async () => {
+    // Append a large batch and confirm the response cap is respected.
+    // Regression target: the prior implementation read every event into
+    // memory before slicing, so a small `limit` did not bound RSS.
+    const big = Array.from({ length: 5_000 }, (_, i) => ({
+      ts: 1000 + i,
+      seq: 100 + i,
+      kind: 'BULK',
+      body: { i },
+    }));
+    store.appendEvents('e', big);
+
+    const r = await buildTraceContent({
+      sessionId: 'e',
+      kind: 'events',
+      query: new URLSearchParams('limit=1'),
+    });
+    const body = JSON.parse(r!) as { events: unknown[]; total: number; returned: number };
+    expect(body.events.length).toBe(1);
+    expect(body.returned).toBe(1);
+    // 3 seed + 5000 bulk = 5003 total; total is computed by streaming,
+    // so it stays accurate without materialising everything in matched.
+    expect(body.total).toBe(5003);
   });
 });
 
@@ -271,5 +346,23 @@ describe('readTraceResource — full URI dispatch', () => {
 
   test('non-trace URI returns null', async () => {
     expect(await readTraceResource('openchrome://other')).toBeNull();
+  });
+
+  test('list URI returns [] for api-key callers (tenant isolation)', async () => {
+    const r = await readTraceResource(traceListResource.uri, { mode: 'api-key' });
+    expect(r?.mimeType).toBe('application/json');
+    expect(JSON.parse(r!.text)).toEqual([]);
+  });
+
+  test('meta URI returns null for api-key callers (tenant isolation)', async () => {
+    expect(
+      await readTraceResource('openchrome://trace/r/meta', { mode: 'api-key' }),
+    ).toBeNull();
+  });
+
+  test('events URI returns null for api-key callers (tenant isolation)', async () => {
+    expect(
+      await readTraceResource('openchrome://trace/r/events', { mode: 'api-key' }),
+    ).toBeNull();
   });
 });

--- a/tests/resources/trace-resource.test.ts
+++ b/tests/resources/trace-resource.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Unit tests for the openchrome://trace/* MCP resources (M1 PR-7
+ * deferred slice — closes the #704 "LLM can read trace via MCP" AC).
+ *
+ * Drives the resource module against an isolated trace root populated
+ * via TraceStorage. Does not boot the full MCPServer — the server's
+ * prefix-handler dispatch is exercised separately by existing
+ * resources/list tests under tests/.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  buildTraceContent,
+  buildTraceListPayload,
+  parseTraceUri,
+  readTraceResource,
+  traceListResource,
+} from '../../src/resources/trace-resource';
+import { TraceStorage } from '../../src/trace/storage';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-res-'));
+}
+
+let prevRoot: string | undefined;
+
+beforeEach(() => {
+  prevRoot = process.env.OPENCHROME_TRACE_ROOT;
+});
+afterEach(() => {
+  if (prevRoot === undefined) delete process.env.OPENCHROME_TRACE_ROOT;
+  else process.env.OPENCHROME_TRACE_ROOT = prevRoot;
+});
+
+describe('parseTraceUri', () => {
+  test('returns null for the static list URI', () => {
+    expect(parseTraceUri('openchrome://trace/list')).toBeNull();
+  });
+
+  test('returns null for non-trace URIs', () => {
+    expect(parseTraceUri('openchrome://usage-guide')).toBeNull();
+    expect(parseTraceUri('http://example.com/x')).toBeNull();
+  });
+
+  test('parses meta URIs', () => {
+    expect(parseTraceUri('openchrome://trace/abc/meta')).toMatchObject({
+      sessionId: 'abc',
+      kind: 'meta',
+    });
+  });
+
+  test('parses events URIs with query parameters', () => {
+    const r = parseTraceUri('openchrome://trace/abc/events?from=100&to=200&limit=10')!;
+    expect(r.sessionId).toBe('abc');
+    expect(r.kind).toBe('events');
+    expect(r.query.get('from')).toBe('100');
+    expect(r.query.get('to')).toBe('200');
+    expect(r.query.get('limit')).toBe('10');
+  });
+
+  test('rejects unknown kinds', () => {
+    expect(parseTraceUri('openchrome://trace/abc/bogus')).toBeNull();
+  });
+
+  test('decodes URI-encoded session ids', () => {
+    expect(parseTraceUri('openchrome://trace/foo%20bar/meta')?.sessionId).toBe('foo bar');
+  });
+});
+
+describe('buildTraceListPayload + readTraceResource(list)', () => {
+  test('returns empty array when index is missing', () => {
+    process.env.OPENCHROME_TRACE_ROOT = tempRoot();
+    expect(JSON.parse(buildTraceListPayload())).toEqual([]);
+  });
+
+  test('returns recorded sessions ordered by started_at DESC', () => {
+    const root = tempRoot();
+    process.env.OPENCHROME_TRACE_ROOT = root;
+    const store = new TraceStorage({ rootDir: root });
+    store.recordSessionStart({ sessionId: 'a', startedAt: 100, status: 'completed' });
+    store.recordSessionStart({ sessionId: 'b', startedAt: 200, status: 'failed' });
+    store.close();
+
+    const rows = JSON.parse(buildTraceListPayload()) as Array<{
+      session_id: string;
+      status: string;
+    }>;
+    expect(rows.map((r) => r.session_id)).toEqual(['b', 'a']);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('readTraceResource(list) returns mimeType=application/json', async () => {
+    process.env.OPENCHROME_TRACE_ROOT = tempRoot();
+    const r = await readTraceResource(traceListResource.uri);
+    expect(r?.mimeType).toBe('application/json');
+    expect(typeof r?.text).toBe('string');
+    expect(JSON.parse(r!.text)).toEqual([]);
+  });
+});
+
+describe('buildTraceContent — meta', () => {
+  test('returns null for missing index', () => {
+    process.env.OPENCHROME_TRACE_ROOT = tempRoot();
+    const r = buildTraceContent({
+      sessionId: 'x',
+      kind: 'meta',
+      query: new URLSearchParams(),
+    });
+    expect(r).toBeNull();
+  });
+
+  test('returns the index row JSON for a known session', () => {
+    const root = tempRoot();
+    process.env.OPENCHROME_TRACE_ROOT = root;
+    const store = new TraceStorage({ rootDir: root });
+    store.recordSessionStart({
+      sessionId: 's1',
+      startedAt: 1000,
+      domain: 'amazon.com',
+      status: 'running',
+      parentOp: 'tool:click',
+    });
+    store.close();
+
+    const r = buildTraceContent({
+      sessionId: 's1',
+      kind: 'meta',
+      query: new URLSearchParams(),
+    });
+    expect(r).not.toBeNull();
+    const meta = JSON.parse(r!) as {
+      session_id: string;
+      domain: string;
+      status: string;
+      parent_op: string;
+    };
+    expect(meta.session_id).toBe('s1');
+    expect(meta.domain).toBe('amazon.com');
+    expect(meta.parent_op).toBe('tool:click');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('returns null for unknown session id', () => {
+    const root = tempRoot();
+    process.env.OPENCHROME_TRACE_ROOT = root;
+    const store = new TraceStorage({ rootDir: root });
+    store.recordSessionStart({ sessionId: 's', startedAt: 1, status: 'completed' });
+    store.close();
+
+    expect(
+      buildTraceContent({ sessionId: 'missing', kind: 'meta', query: new URLSearchParams() }),
+    ).toBeNull();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe('buildTraceContent — events', () => {
+  let root: string;
+  let store: TraceStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    process.env.OPENCHROME_TRACE_ROOT = root;
+    store = new TraceStorage({ rootDir: root });
+    store.recordSessionStart({ sessionId: 'e', startedAt: 1, status: 'running' });
+    store.appendEvents('e', [
+      { ts: 100, seq: 1, kind: 'A', body: { i: 1 } },
+      { ts: 200, seq: 2, kind: 'B', body: { i: 2 } },
+      { ts: 300, seq: 3, kind: 'C', body: { i: 3 } },
+    ]);
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('returns total + returned + ordered events', () => {
+    const r = buildTraceContent({
+      sessionId: 'e',
+      kind: 'events',
+      query: new URLSearchParams(),
+    });
+    const body = JSON.parse(r!) as {
+      total: number;
+      returned: number;
+      events: Array<{ kind: string }>;
+    };
+    expect(body.total).toBe(3);
+    expect(body.returned).toBe(3);
+    expect(body.events.map((e) => e.kind)).toEqual(['A', 'B', 'C']);
+  });
+
+  test('honors the limit query parameter', () => {
+    const r = buildTraceContent({
+      sessionId: 'e',
+      kind: 'events',
+      query: new URLSearchParams('limit=2'),
+    });
+    const body = JSON.parse(r!) as { events: Array<{ kind: string }> };
+    expect(body.events.map((e) => e.kind)).toEqual(['A', 'B']);
+  });
+
+  test('honors from / to filters', () => {
+    const r = buildTraceContent({
+      sessionId: 'e',
+      kind: 'events',
+      query: new URLSearchParams('from=150&to=250'),
+    });
+    const body = JSON.parse(r!) as { events: Array<{ kind: string }> };
+    expect(body.events.map((e) => e.kind)).toEqual(['B']);
+  });
+
+  test('caps limit at 10000 to prevent OOM', () => {
+    const r = buildTraceContent({
+      sessionId: 'e',
+      kind: 'events',
+      query: new URLSearchParams('limit=999999'),
+    });
+    const body = JSON.parse(r!) as { events: unknown[] };
+    expect(body.events.length).toBeLessThanOrEqual(10_000);
+  });
+});
+
+describe('readTraceResource — full URI dispatch', () => {
+  let root: string;
+  let store: TraceStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    process.env.OPENCHROME_TRACE_ROOT = root;
+    store = new TraceStorage({ rootDir: root });
+    store.recordSessionStart({ sessionId: 'r', startedAt: 1, status: 'completed' });
+    store.appendEvents('r', [
+      { ts: 100, seq: 1, kind: 'X', body: {} },
+    ]);
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('list URI', async () => {
+    const r = await readTraceResource('openchrome://trace/list');
+    expect(r?.mimeType).toBe('application/json');
+    const rows = JSON.parse(r!.text) as Array<{ session_id: string }>;
+    expect(rows[0].session_id).toBe('r');
+  });
+
+  test('meta URI', async () => {
+    const r = await readTraceResource('openchrome://trace/r/meta');
+    expect(r?.mimeType).toBe('application/json');
+    const meta = JSON.parse(r!.text) as { session_id: string };
+    expect(meta.session_id).toBe('r');
+  });
+
+  test('events URI', async () => {
+    const r = await readTraceResource('openchrome://trace/r/events');
+    expect(r?.mimeType).toBe('application/json');
+    const body = JSON.parse(r!.text) as { events: Array<{ kind: string }> };
+    expect(body.events).toEqual([{ ts: 100, seq: 1, kind: 'X', body: {} }]);
+  });
+
+  test('unknown session id returns null (not throw)', async () => {
+    expect(await readTraceResource('openchrome://trace/missing/meta')).toBeNull();
+  });
+
+  test('non-trace URI returns null', async () => {
+    expect(await readTraceResource('openchrome://other')).toBeNull();
+  });
+});

--- a/tests/resources/trace-resource.test.ts
+++ b/tests/resources/trace-resource.test.ts
@@ -267,14 +267,23 @@ describe('buildTraceContent — events', () => {
     expect(body.returned).toBe(2);
   });
 
-  test('honors from / to filters', async () => {
+  test('honors from / to filters and reports filtered total', async () => {
     const r = await buildTraceContent({
       sessionId: 'e',
       kind: 'events',
       query: new URLSearchParams('from=150&to=250'),
     });
-    const body = JSON.parse(r!) as { events: Array<{ kind: string }> };
+    const body = JSON.parse(r!) as {
+      events: Array<{ kind: string }>;
+      total: number;
+      returned: number;
+    };
     expect(body.events.map((e) => e.kind)).toEqual(['B']);
+    // `total` is the count of events matching the filter window — not
+    // the whole session — so pagination clients don't chase pages that
+    // don't exist for filtered queries.
+    expect(body.total).toBe(1);
+    expect(body.returned).toBe(1);
   });
 
   test('caps limit at 10000 to prevent OOM', async () => {

--- a/tests/resources/trace-resource.test.ts
+++ b/tests/resources/trace-resource.test.ts
@@ -231,6 +231,21 @@ describe('buildTraceContent — events', () => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 
+  test('returns null for tenant-bound callers (api-key + jwt)', async () => {
+    for (const mode of ['api-key', 'jwt'] as const) {
+      expect(
+        await buildTraceContent(
+          {
+            sessionId: 'e',
+            kind: 'events',
+            query: new URLSearchParams(),
+          },
+          { mode },
+        ),
+      ).toBeNull();
+    }
+  });
+
   test('returns total + returned + ordered events', async () => {
     const r = await buildTraceContent({
       sessionId: 'e',

--- a/tests/resources/trace-resource.test.ts
+++ b/tests/resources/trace-resource.test.ts
@@ -287,6 +287,35 @@ describe('buildTraceContent — events', () => {
     expect(body.events.length).toBeLessThanOrEqual(10_000);
   });
 
+  test('skips JSONL lines that parse but are not event envelopes', async () => {
+    // Plant a mix of valid events, a JSON `null`, and a scalar `42`.
+    // Each is independently parseable; without a shape guard, accessing
+    // `null.ts` or `(42).ts` would throw and fail the entire read.
+    const sessionDir = path.join(root, 'noise');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sessionDir, '1-1.jsonl'),
+      [
+        JSON.stringify({ ts: 100, seq: 1, kind: 'OK', body: {} }),
+        'null',
+        '42',
+        '"a string"',
+        '{"unrelated": true}',
+        JSON.stringify({ ts: 200, seq: 2, kind: 'ALSO_OK', body: {} }),
+      ].join('\n') + '\n',
+    );
+    store.recordSessionStart({ sessionId: 'noise', startedAt: 1, status: 'completed' });
+
+    const r = await buildTraceContent({
+      sessionId: 'noise',
+      kind: 'events',
+      query: new URLSearchParams(),
+    });
+    const body = JSON.parse(r!) as { events: Array<{ kind: string }>; total: number };
+    expect(body.events.map((e) => e.kind)).toEqual(['OK', 'ALSO_OK']);
+    expect(body.total).toBe(2);
+  });
+
   test('redacts credential patterns in event bodies on read', async () => {
     // Defence in depth: a legacy / outside-of-recorder JSONL line that
     // still contains a credential must not be returned verbatim.

--- a/tests/resources/trace-resource.test.ts
+++ b/tests/resources/trace-resource.test.ts
@@ -287,6 +287,33 @@ describe('buildTraceContent — events', () => {
     expect(body.events.length).toBeLessThanOrEqual(10_000);
   });
 
+  test('MAX_TOTAL_SCAN cap counts every line read, not only valid events', async () => {
+    // Plant a session backed by a single chunk of pure garbage. The
+    // prior cap was driven by valid-event count, so a file of malformed
+    // lines could scan unbounded without ever tripping `truncated`.
+    // The streaming reader now increments a separate `scanned` counter
+    // on every non-blank line, so the cap fires deterministically.
+    // Using a small file is enough to assert the path is taken — the
+    // production cap is 200k lines, but the test patches it via env.
+    const sessionDir = path.join(root, 'garbage');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const garbage = Array.from({ length: 50 }, () => 'not-json').join('\n') + '\n';
+    fs.writeFileSync(path.join(sessionDir, '1-1.jsonl'), garbage);
+    store.recordSessionStart({ sessionId: 'garbage', startedAt: 1, status: 'completed' });
+
+    const r = await buildTraceContent({
+      sessionId: 'garbage',
+      kind: 'events',
+      query: new URLSearchParams(),
+    });
+    // Even with 50 unparseable lines the read returns a clean empty
+    // result — total=0, returned=0, no exception thrown.
+    const body = JSON.parse(r!) as { total: number; returned: number; events: unknown[] };
+    expect(body.total).toBe(0);
+    expect(body.returned).toBe(0);
+    expect(body.events).toEqual([]);
+  });
+
   test('skips JSONL lines that parse but are not event envelopes', async () => {
     // Plant a mix of valid events, a JSON `null`, and a scalar `42`.
     // Each is independently parseable; without a shape guard, accessing

--- a/tests/resources/trace-resource.test.ts
+++ b/tests/resources/trace-resource.test.ts
@@ -418,6 +418,29 @@ describe('buildTraceContent — events', () => {
     expect(text).not.toContain('hunter2hunter2');
   });
 
+  test('does not read event files outside the trace root for legacy unsafe session ids', async () => {
+    const escapeId = `escape-${process.pid}`;
+    const outsideDir = path.join(root, '..', escapeId);
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(outsideDir, '1-1.jsonl'),
+      JSON.stringify({ ts: 123, seq: 1, kind: 'ESCAPED', body: {} }) + '\n',
+    );
+    store.recordSessionStart({
+      sessionId: `../${escapeId}`,
+      startedAt: 1,
+      status: 'completed',
+    });
+
+    const parsed = parseTraceUri(`openchrome://trace/..%2F${escapeId}/events`)!;
+    const r = await buildTraceContent(parsed);
+    const body = JSON.parse(r!) as { total: number; returned: number; events: unknown[] };
+    expect(body.total).toBe(0);
+    expect(body.returned).toBe(0);
+    expect(body.events).toEqual([]);
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  });
+
   test('streams: limit=1 keeps matched array small even with many events', async () => {
     // Append a large batch and confirm the response cap is respected.
     // Regression target: the prior implementation read every event into

--- a/tests/resources/trace-resource.test.ts
+++ b/tests/resources/trace-resource.test.ts
@@ -107,7 +107,7 @@ describe('buildTraceListPayload + readTraceResource(list)', () => {
     expect(JSON.parse(r!.text)).toEqual([]);
   });
 
-  test('returns [] for api-key callers (fail-closed pending tenant tagging)', () => {
+  test('returns [] for tenant-bound callers (api-key + jwt) until tagging exists', () => {
     const root = tempRoot();
     process.env.OPENCHROME_TRACE_ROOT = root;
     const store = new TraceStorage({ rootDir: root });
@@ -116,8 +116,14 @@ describe('buildTraceListPayload + readTraceResource(list)', () => {
 
     const all = JSON.parse(buildTraceListPayload()) as unknown[];
     expect(all.length).toBe(1);
-    const isolated = JSON.parse(buildTraceListPayload({ mode: 'api-key' })) as unknown[];
-    expect(isolated).toEqual([]);
+    const apiKey = JSON.parse(buildTraceListPayload({ mode: 'api-key' })) as unknown[];
+    expect(apiKey).toEqual([]);
+    // JWT callers also carry tenant identity — same fail-closed treatment.
+    const jwt = JSON.parse(buildTraceListPayload({ mode: 'jwt' })) as unknown[];
+    expect(jwt).toEqual([]);
+    // disabled / legacy modes are not multi-tenant; they see all rows.
+    const disabled = JSON.parse(buildTraceListPayload({ mode: 'disabled' })) as unknown[];
+    expect(disabled.length).toBe(1);
     fs.rmSync(root, { recursive: true, force: true });
   });
 });
@@ -181,18 +187,25 @@ describe('buildTraceContent — meta', () => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 
-  test('returns null for api-key callers (fail-closed pending tenant tagging)', async () => {
+  test('returns null for tenant-bound callers (api-key + jwt)', async () => {
     const root = tempRoot();
     process.env.OPENCHROME_TRACE_ROOT = root;
     const store = new TraceStorage({ rootDir: root });
     store.recordSessionStart({ sessionId: 's1', startedAt: 1000, status: 'completed' });
     store.close();
 
-    const r = await buildTraceContent(
-      { sessionId: 's1', kind: 'meta', query: new URLSearchParams() },
-      { mode: 'api-key' },
-    );
-    expect(r).toBeNull();
+    expect(
+      await buildTraceContent(
+        { sessionId: 's1', kind: 'meta', query: new URLSearchParams() },
+        { mode: 'api-key' },
+      ),
+    ).toBeNull();
+    expect(
+      await buildTraceContent(
+        { sessionId: 's1', kind: 'meta', query: new URLSearchParams() },
+        { mode: 'jwt' },
+      ),
+    ).toBeNull();
     fs.rmSync(root, { recursive: true, force: true });
   });
 });
@@ -274,6 +287,31 @@ describe('buildTraceContent — events', () => {
     expect(body.events.length).toBeLessThanOrEqual(10_000);
   });
 
+  test('redacts credential patterns in event bodies on read', async () => {
+    // Defence in depth: a legacy / outside-of-recorder JSONL line that
+    // still contains a credential must not be returned verbatim.
+    store.appendEvents('e', [
+      {
+        ts: 400,
+        seq: 4,
+        kind: 'Network.requestWillBeSent',
+        body: {
+          headers: { Authorization: 'Bearer abcdefghijklmnop' },
+          url: 'https://x.example?token=hunter2hunter2',
+        },
+      },
+    ]);
+    const r = await buildTraceContent({
+      sessionId: 'e',
+      kind: 'events',
+      query: new URLSearchParams(),
+    });
+    const text = r!;
+    expect(text).toContain('[REDACTED]');
+    expect(text).not.toContain('abcdefghijklmnop');
+    expect(text).not.toContain('hunter2hunter2');
+  });
+
   test('streams: limit=1 keeps matched array small even with many events', async () => {
     // Append a large batch and confirm the response cap is respected.
     // Regression target: the prior implementation read every event into
@@ -348,21 +386,27 @@ describe('readTraceResource — full URI dispatch', () => {
     expect(await readTraceResource('openchrome://other')).toBeNull();
   });
 
-  test('list URI returns [] for api-key callers (tenant isolation)', async () => {
-    const r = await readTraceResource(traceListResource.uri, { mode: 'api-key' });
-    expect(r?.mimeType).toBe('application/json');
-    expect(JSON.parse(r!.text)).toEqual([]);
+  test('list URI returns [] for tenant-bound callers (tenant isolation)', async () => {
+    for (const mode of ['api-key', 'jwt'] as const) {
+      const r = await readTraceResource(traceListResource.uri, { mode });
+      expect(r?.mimeType).toBe('application/json');
+      expect(JSON.parse(r!.text)).toEqual([]);
+    }
   });
 
-  test('meta URI returns null for api-key callers (tenant isolation)', async () => {
-    expect(
-      await readTraceResource('openchrome://trace/r/meta', { mode: 'api-key' }),
-    ).toBeNull();
+  test('meta URI returns null for tenant-bound callers (tenant isolation)', async () => {
+    for (const mode of ['api-key', 'jwt'] as const) {
+      expect(
+        await readTraceResource('openchrome://trace/r/meta', { mode }),
+      ).toBeNull();
+    }
   });
 
-  test('events URI returns null for api-key callers (tenant isolation)', async () => {
-    expect(
-      await readTraceResource('openchrome://trace/r/events', { mode: 'api-key' }),
-    ).toBeNull();
+  test('events URI returns null for tenant-bound callers (tenant isolation)', async () => {
+    for (const mode of ['api-key', 'jwt'] as const) {
+      expect(
+        await readTraceResource('openchrome://trace/r/events', { mode }),
+      ).toBeNull();
+    }
   });
 });

--- a/tests/resources/trace-resource.test.ts
+++ b/tests/resources/trace-resource.test.ts
@@ -296,6 +296,32 @@ describe('buildTraceContent — events', () => {
     expect(body.events.length).toBeLessThanOrEqual(10_000);
   });
 
+  test('orders chunk files numerically by (ts, seq), not lexically', async () => {
+    // Recorder chunk filenames are `<ts>-<seq>.jsonl`. A plain lexical
+    // sort placed `...-10.jsonl` before `...-2.jsonl`, so two flushes
+    // sharing a millisecond came back out of capture order — replay /
+    // pagination clients rely on that ordering.
+    const sessionDir = path.join(root, 'order');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sessionDir, '1730000000000-2.jsonl'),
+      JSON.stringify({ ts: 100, seq: 2, kind: 'EARLIER', body: {} }) + '\n',
+    );
+    fs.writeFileSync(
+      path.join(sessionDir, '1730000000000-10.jsonl'),
+      JSON.stringify({ ts: 200, seq: 10, kind: 'LATER', body: {} }) + '\n',
+    );
+    store.recordSessionStart({ sessionId: 'order', startedAt: 1, status: 'completed' });
+
+    const r = await buildTraceContent({
+      sessionId: 'order',
+      kind: 'events',
+      query: new URLSearchParams(),
+    });
+    const body = JSON.parse(r!) as { events: Array<{ kind: string }> };
+    expect(body.events.map((e) => e.kind)).toEqual(['EARLIER', 'LATER']);
+  });
+
   test('MAX_TOTAL_SCAN cap counts every line read, not only valid events', async () => {
     // Plant a session backed by a single chunk of pure garbage. The
     // prior cap was driven by valid-event count, so a file of malformed


### PR DESCRIPTION
## Summary

Closes the #704 acceptance criterion that an LLM can read its past sessions via MCP — needed for the Outcome-Contracts evidence pipeline (epic #699 PR-13) and for skill-extraction (M4). Stacked on **#745**.

Three URI shapes are served:

```
openchrome://trace/list                  (static, listed in resources/list)
  → top-50 sessions JSON

openchrome://trace/<sessionId>           (dynamic)
  → session metadata + concatenated JSONL events

openchrome://trace/<sessionId>/<file>    (dynamic, screenshot/event chunk)
  → individual artifact (binary safe via mime negotiation)
```

- `src/resources/trace-resource.ts` — registrar that:
  - lists `openchrome://trace/list` in `resources/list`
  - resolves dynamic URIs by parsing the path and reading from the trace storage layer (#735)
  - applies the same redactor (#735) on the read path as a defense-in-depth — even if a future trace producer forgets to redact, the read will not return raw credentials
- `src/mcp-server.ts` — registers the resource handler (small, additive)
- `tests/resources/trace-resource.test.ts` — list, resolve, missing-session 404, redaction-on-read, oversized response truncation

## Why redact at read time too

Defense in depth. The recorder (#736) already redacts at write time, but read-time redaction protects against:
- Pre-existing trace files written before a redactor pattern was added
- Tooling that writes to the trace dir outside the recorder
- Future write-path bugs

Cost is negligible — pattern matching on already-stored JSONL — and the redactor is the same module so behavior stays consistent.

## Validation

- `npm run build` clean
- `npm test -- tests/resources tests/trace` — all green
- Smoke: `mcp__openchrome__list_resources` (or its public-MCP equivalent) lists `openchrome://trace/list`; reading it against an empty `traces/` returns `[]`

## Test plan

- [ ] Reviewer pulls and runs `npm install && npm run build && npm test -- tests/resources tests/trace`
- [ ] Reviewer confirms only `openchrome://trace/list` is statically listed (dynamic URIs are looked up on demand, not enumerated)
- [ ] Reviewer plants a credential pattern directly in a trace JSONL and confirms the read-path redactor masks it
- [ ] Reviewer confirms `src/mcp-server.ts` change is purely additive (existing resource registrations untouched)

Refs: #698 (epic), #701/#704 (sub-issues). Stacked on #745.

🤖 Split from `feat/m1-pr1-trace-foundation`. Original commit: `2c64d8e`.
