### PR TITLE
feat(trace): wire recorder into createTargetStealth() too (#701)

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -1820,6 +1820,32 @@ export class CDPClient {
     }).catch(() => {});
 
     console.error(`[CDPClient] Stealth tab ${targetId} ready (defenses pre-injected, page loaded)`);
+
+    // Trace recorder hook — same env-gated pattern as createPage(). Stealth
+    // sessions are exactly where tracing is most valuable for debugging
+    // anti-bot misbehavior. Failure must never regress page creation.
+    try {
+      const cdpAttach = await import('../trace/cdp-attach');
+      if (cdpAttach.traceEnvEnabled()) {
+        let stealthDomain: string | undefined;
+        try {
+          stealthDomain = new URL(url).hostname;
+        } catch {
+          // url may be about:blank or invalid; fall through with undefined
+        }
+        await cdpAttach.attachRecorderToPage(
+          page as unknown as Parameters<typeof cdpAttach.attachRecorderToPage>[0],
+          {
+            sessionId: targetId,
+            domain: stealthDomain,
+            parentOp: 'cdp.createTargetStealth',
+          },
+        );
+      }
+    } catch (err) {
+      console.error('[CDPClient] trace recorder attach failed (tracing inactive for this stealth page):', err);
+    }
+
     return { page, targetId };
   }
 


### PR DESCRIPTION
## Summary

The trace recorder hook from #744 only covered `CDPClient.createPage()`. **Stealth sessions** (`createTargetStealth`) — used for anti-bot bypass on sites like Coupang / Reddit / Cloudflare-protected targets — are exactly where trace evidence is most useful, but were silently un-recorded. Stacked on **#746**.

This commit adds the **same opt-in / fail-safe / lazy-import pattern** at the stealth-session call site. **+26 LOC**, no behavior change when `OPENCHROME_TRACE` is unset.

## Why this matters

Anti-bot pages are precisely where:
- Failures happen
- Reproducibility is hardest (CDN response varies by IP/UA/timing)
- An LLM operator most needs evidence

Leaving stealth sessions un-recorded would have meant the recorder is dead for the workflows it was built to debug.

## Validation

- `npm run build` clean
- `npm test -- tests/trace` — all green
- Default-off behavior preserved

## Test plan

- [ ] Reviewer pulls and runs `npm install && npm run build && npm test -- tests/trace`
- [ ] Reviewer confirms the call pattern matches `createPage()` exactly (same try/catch, same env gate, same detach)
- [ ] Reviewer confirms `+26 LOC` is the entire diff — no other code paths touched

Refs: #698 (epic), #701 (sub-issue). Stacked on #746.

🤖 Split from `feat/m1-pr1-trace-foundation`. Original commit: `e0f20fe`.
