### PR TITLE
feat(contracts): DSL types + assertions + validator (M2 PR-9)

### DIFF
--- a/src/contracts/evaluator.ts
+++ b/src/contracts/evaluator.ts
@@ -54,7 +54,21 @@ export function evaluate(assertion: Assertion, ctx: AssertionContext): Evidence 
     }
     case 'dom_text': {
       const selector = assertion.selector ?? 'body';
-      const haystack = selector === 'body' ? ctx.bodyText : ctx.domText(selector);
+      // Host-supplied probes throw on bad selectors (e.g.,
+      // `querySelector('#'.invalid)` raises SyntaxError). The evaluator
+      // promises never to throw — convert probe failures into a
+      // structured passed=false instead so composite evaluators see a
+      // normal evidence record and the runtime stays "always settles".
+      let haystack: string;
+      try {
+        haystack = selector === 'body' ? ctx.bodyText : ctx.domText(selector);
+      } catch (e) {
+        return mkEvidence('dom_text', false, {
+          selector,
+          contains: assertion.contains,
+          probe_error: e instanceof Error ? e.message : String(e),
+        }, ctx);
+      }
       const passed = haystack.includes(assertion.contains);
       return mkEvidence('dom_text', passed, {
         selector,
@@ -65,7 +79,17 @@ export function evaluate(assertion: Assertion, ctx: AssertionContext): Evidence 
       }, ctx);
     }
     case 'dom_count': {
-      const actual = ctx.domCount(assertion.selector);
+      let actual: number;
+      try {
+        actual = ctx.domCount(assertion.selector);
+      } catch (e) {
+        return mkEvidence('dom_count', false, {
+          selector: assertion.selector,
+          op: assertion.op,
+          expected: assertion.value,
+          probe_error: e instanceof Error ? e.message : String(e),
+        }, ctx);
+      }
       const passed = compareCount(actual, assertion.op, assertion.value);
       return mkEvidence('dom_count', passed, {
         selector: assertion.selector,
@@ -77,43 +101,75 @@ export function evaluate(assertion: Assertion, ctx: AssertionContext): Evidence 
     case 'no_dialog':
       return mkEvidence('no_dialog', !ctx.hasDialog, { hasDialog: ctx.hasDialog }, ctx);
     case 'network':
-      return mkEvidence('network', false, {
-        unsupported_in_pr9: true,
-        message: 'network assertion is wired in PR-10 (#705 closes there)',
-      }, ctx);
+      return mkUnsupportedEvidence(
+        'network',
+        'network assertion is wired in PR-10 (#705 closes there)',
+        ctx,
+      );
     case 'screenshot_class':
-      return mkEvidence('screenshot_class', false, {
-        unsupported_in_pr9: true,
-        message: 'screenshot_class assertion is wired in PR-10 (pHash + class registry)',
-      }, ctx);
+      return mkUnsupportedEvidence(
+        'screenshot_class',
+        'screenshot_class assertion is wired in PR-10 (pHash + class registry)',
+        ctx,
+      );
     case 'and': {
       const children = assertion.children.map((c) => evaluate(c, ctx));
-      const passed = children.every((c) => c.passed);
+      // An unsupported child fails the whole conjunction; the composite
+      // is also marked unsupported so callers / `not` can distinguish
+      // "evaluated and failed" from "could not be evaluated yet".
+      const unsupportedCount = children.filter(isUnsupported).length;
+      const passed = unsupportedCount === 0 && children.every((c) => c.passed);
+      const details: Record<string, unknown> = {
+        count: children.length,
+        failed_count: children.filter((c) => !c.passed).length,
+      };
+      if (unsupportedCount > 0) {
+        details.unsupported = true;
+        details.unsupported_count = unsupportedCount;
+      }
       return {
         passed,
         assertion_kind: 'and',
-        details: { count: children.length, failed_count: children.filter((c) => !c.passed).length },
+        details,
         children,
         ...(ctx.traceRef ? { trace_ref: ctx.traceRef } : {}),
       };
     }
     case 'or': {
       const children = assertion.children.map((c) => evaluate(c, ctx));
-      const passed = children.some((c) => c.passed);
+      // For `or`, a real pass from any supported child still wins. If
+      // no child passes AND any child is unsupported, mark the
+      // composite unsupported so `not` does not flip it into a true.
+      const supportedPasses = children.some((c) => !isUnsupported(c) && c.passed);
+      const anyUnsupported = children.some(isUnsupported);
+      const details: Record<string, unknown> = {
+        count: children.length,
+        passed_count: children.filter((c) => c.passed).length,
+      };
+      if (!supportedPasses && anyUnsupported) {
+        details.unsupported = true;
+      }
       return {
-        passed,
+        passed: supportedPasses,
         assertion_kind: 'or',
-        details: { count: children.length, passed_count: children.filter((c) => c.passed).length },
+        details,
         children,
         ...(ctx.traceRef ? { trace_ref: ctx.traceRef } : {}),
       };
     }
     case 'not': {
       const child = evaluate(assertion.child, ctx);
+      // Negating an unsupported child cannot yield a true result —
+      // otherwise `not(network)` would always "pass" before PR-10
+      // wires network up. Propagate the unsupported marker and keep
+      // passed=false so callers cannot drive logic off a stub.
+      const unsupported = isUnsupported(child);
+      const details: Record<string, unknown> = { negated: child.assertion_kind };
+      if (unsupported) details.unsupported = true;
       return {
-        passed: !child.passed,
+        passed: unsupported ? false : !child.passed,
         assertion_kind: 'not',
-        details: { negated: child.assertion_kind },
+        details,
         children: [child],
         ...(ctx.traceRef ? { trace_ref: ctx.traceRef } : {}),
       };
@@ -158,4 +214,24 @@ function mkEvidence(
     details,
     ...(ctx.traceRef ? { trace_ref: ctx.traceRef } : {}),
   };
+}
+
+/** Stable shape for "this assertion kind is not yet wired up". The
+ *  `unsupported: true` flag lives at the top of `details` so composite
+ *  evaluators can branch on it without sniffing kind-specific keys. */
+function mkUnsupportedEvidence(
+  kind: AssertionKind,
+  message: string,
+  ctx: AssertionContext,
+): Evidence {
+  return {
+    passed: false,
+    assertion_kind: kind,
+    details: { unsupported: true, message },
+    ...(ctx.traceRef ? { trace_ref: ctx.traceRef } : {}),
+  };
+}
+
+function isUnsupported(evidence: Evidence): boolean {
+  return evidence.details?.unsupported === true;
 }

--- a/src/contracts/evaluator.ts
+++ b/src/contracts/evaluator.ts
@@ -1,0 +1,161 @@
+/**
+ * Synchronous Outcome Contract assertion evaluator.
+ *
+ * Takes a validated `Assertion` tree and an `AssertionContext` (page
+ * snapshot probe + run metadata) and returns an `Evidence` envelope
+ * describing whether the assertion held and why.
+ *
+ * The evaluator is intentionally sync: hosts (PR-11 runtime) collect a
+ * snapshot from the live page once and pass it here. Tests can supply
+ * fakes without spinning a browser.
+ *
+ * `network` and `screenshot_class` are stubs in this PR — they live in
+ * the validator vocabulary but always evaluate as a structured
+ * `unsupported_in_pr9` evidence record. PR-10 wires them up.
+ */
+
+import type {
+  Assertion,
+  AssertionKind,
+  DomCountOp,
+  Evidence,
+} from './types';
+
+/**
+ * What the evaluator needs from the page and runtime. Hosts build this
+ * once per evaluation; passing pre-computed values keeps assertions
+ * cheap and synchronous.
+ */
+export interface AssertionContext {
+  /** Current page URL. */
+  url: string;
+  /** `document.body.innerText` (visible text only). */
+  bodyText: string;
+  /** Selector → visible text lookup. Default lookup uses `bodyText`. */
+  domText: (selector: string) => string;
+  /** Selector → element count. */
+  domCount: (selector: string) => number;
+  /** True when a JS dialog is currently open / unhandled. */
+  hasDialog: boolean;
+  /** Optional pointer into the recording (#704). Surfaces in evidence. */
+  traceRef?: { trace_id: string; from_ts: number; to_ts: number };
+}
+
+/** Evaluate an assertion tree. Pure; no I/O. */
+export function evaluate(assertion: Assertion, ctx: AssertionContext): Evidence {
+  switch (assertion.kind) {
+    case 'url': {
+      const re = safeRegExp(assertion.pattern);
+      const passed = re.test(ctx.url);
+      return mkEvidence('url', passed, {
+        url: ctx.url,
+        pattern: assertion.pattern,
+      }, ctx);
+    }
+    case 'dom_text': {
+      const selector = assertion.selector ?? 'body';
+      const haystack = selector === 'body' ? ctx.bodyText : ctx.domText(selector);
+      const passed = haystack.includes(assertion.contains);
+      return mkEvidence('dom_text', passed, {
+        selector,
+        contains: assertion.contains,
+        // Trim long bodies in evidence to keep bundles small (see #707).
+        haystack_excerpt: haystack.length > 240 ? haystack.slice(0, 240) + '…' : haystack,
+        haystack_length: haystack.length,
+      }, ctx);
+    }
+    case 'dom_count': {
+      const actual = ctx.domCount(assertion.selector);
+      const passed = compareCount(actual, assertion.op, assertion.value);
+      return mkEvidence('dom_count', passed, {
+        selector: assertion.selector,
+        op: assertion.op,
+        expected: assertion.value,
+        actual,
+      }, ctx);
+    }
+    case 'no_dialog':
+      return mkEvidence('no_dialog', !ctx.hasDialog, { hasDialog: ctx.hasDialog }, ctx);
+    case 'network':
+      return mkEvidence('network', false, {
+        unsupported_in_pr9: true,
+        message: 'network assertion is wired in PR-10 (#705 closes there)',
+      }, ctx);
+    case 'screenshot_class':
+      return mkEvidence('screenshot_class', false, {
+        unsupported_in_pr9: true,
+        message: 'screenshot_class assertion is wired in PR-10 (pHash + class registry)',
+      }, ctx);
+    case 'and': {
+      const children = assertion.children.map((c) => evaluate(c, ctx));
+      const passed = children.every((c) => c.passed);
+      return {
+        passed,
+        assertion_kind: 'and',
+        details: { count: children.length, failed_count: children.filter((c) => !c.passed).length },
+        children,
+        ...(ctx.traceRef ? { trace_ref: ctx.traceRef } : {}),
+      };
+    }
+    case 'or': {
+      const children = assertion.children.map((c) => evaluate(c, ctx));
+      const passed = children.some((c) => c.passed);
+      return {
+        passed,
+        assertion_kind: 'or',
+        details: { count: children.length, passed_count: children.filter((c) => c.passed).length },
+        children,
+        ...(ctx.traceRef ? { trace_ref: ctx.traceRef } : {}),
+      };
+    }
+    case 'not': {
+      const child = evaluate(assertion.child, ctx);
+      return {
+        passed: !child.passed,
+        assertion_kind: 'not',
+        details: { negated: child.assertion_kind },
+        children: [child],
+        ...(ctx.traceRef ? { trace_ref: ctx.traceRef } : {}),
+      };
+    }
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function compareCount(actual: number, op: DomCountOp, expected: number): boolean {
+  switch (op) {
+    case 'eq':
+      return actual === expected;
+    case 'gte':
+      return actual >= expected;
+    case 'lte':
+      return actual <= expected;
+  }
+}
+
+function safeRegExp(pattern: string): RegExp {
+  try {
+    return new RegExp(pattern);
+  } catch {
+    // Validator should have caught this; the runtime evaluator must not
+    // throw. A regex that won't compile fails its assertion.
+    return /(?!)/; // matches nothing
+  }
+}
+
+function mkEvidence(
+  kind: AssertionKind,
+  passed: boolean,
+  details: Record<string, unknown>,
+  ctx: AssertionContext,
+): Evidence {
+  return {
+    passed,
+    assertion_kind: kind,
+    details,
+    ...(ctx.traceRef ? { trace_ref: ctx.traceRef } : {}),
+  };
+}

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Outcome Contracts subsystem barrel — assertion DSL types, validator,
+ * evaluator. Runtime (PR-11), idempotency / cancellation (PR-12), and
+ * evidence bundling (PR-13) build on these primitives.
+ */
+
+export type {
+  Assertion,
+  AssertionKind,
+  CompositeAssertionKind,
+  DomCountOp,
+  Evidence,
+  NetworkSinceMode,
+  PrimitiveAssertionKind,
+} from './types';
+export {
+  COMPOSITE_ASSERTION_KINDS,
+  PRIMITIVE_ASSERTION_KINDS,
+} from './types';
+
+export { validateAssertion, type ValidationError } from './validator';
+export { evaluate, type AssertionContext } from './evaluator';

--- a/src/contracts/types.ts
+++ b/src/contracts/types.ts
@@ -1,0 +1,79 @@
+/**
+ * Outcome Contract DSL — assertion types + evidence shape.
+ *
+ * The DSL is intentionally JSON-first so an LLM can author it via tool
+ * calls. Each `Assertion` evaluates to an `Evidence` envelope; the
+ * runtime (PR-11) stitches `Evidence` records into the final
+ * TransactionRecord.
+ *
+ * Per #705 v2:
+ *   - `not` takes a single `child` (not an array). For "none of these"
+ *     compose `{kind:"and", children:[{kind:"not",child:A}, ...]}`.
+ *   - `op` uses string enums (`"eq" | "gte" | "lte"`) — not JSON token
+ *     operators like `==`.
+ *   - `dom_text` default selector is `"body"`; matches `innerText`
+ *     (visible text only).
+ *   - `screenshot_class.distance_max` is **Hamming distance over a
+ *     64-bit perceptual hash** (range 0-64) — defined here for #705's
+ *     PR-10 slice.
+ *   - `network.since` is `"contract_enter" | "last_tool_call"`:
+ *       contract_enter  = ts when runWithContract begins pre-check
+ *       last_tool_call  = ts of most recent MCP tool invocation.
+ */
+
+export type Assertion =
+  | { kind: 'url'; pattern: string /* JS RegExp source, anchored on caller */ }
+  | { kind: 'dom_text'; selector?: string /* default: "body" */; contains: string }
+  | { kind: 'dom_count'; selector: string; op: DomCountOp; value: number }
+  | { kind: 'no_dialog' }
+  | {
+      kind: 'network';
+      url_pattern: string;
+      status_in: number[];
+      since: NetworkSinceMode;
+    }
+  | {
+      kind: 'screenshot_class';
+      class_id: string;
+      distance_max: number /* Hamming distance 0-64 over 64-bit pHash */;
+    }
+  | { kind: 'and'; children: Assertion[] /* len ≥ 1 */ }
+  | { kind: 'or'; children: Assertion[] /* len ≥ 1 */ }
+  | { kind: 'not'; child: Assertion /* exactly one */ };
+
+export type DomCountOp = 'eq' | 'gte' | 'lte';
+export type NetworkSinceMode = 'contract_enter' | 'last_tool_call';
+
+/** Stable list of all primitive (non-composite) assertion kinds. */
+export const PRIMITIVE_ASSERTION_KINDS = [
+  'url',
+  'dom_text',
+  'dom_count',
+  'no_dialog',
+  'network',
+  'screenshot_class',
+] as const;
+export type PrimitiveAssertionKind = (typeof PRIMITIVE_ASSERTION_KINDS)[number];
+
+export const COMPOSITE_ASSERTION_KINDS = ['and', 'or', 'not'] as const;
+export type CompositeAssertionKind = (typeof COMPOSITE_ASSERTION_KINDS)[number];
+
+export type AssertionKind = PrimitiveAssertionKind | CompositeAssertionKind;
+
+/**
+ * Result envelope produced by the evaluator. `assertion_kind` is named
+ * with an underscore (instead of `kind`) so `Evidence` can be embedded
+ * in larger JSON without shadowing a parent's `kind` field.
+ */
+export interface Evidence {
+  passed: boolean;
+  assertion_kind: AssertionKind;
+  details: Record<string, unknown>;
+  /** Optional pointer into a recorded trace slice (#704). */
+  trace_ref?: { trace_id: string; from_ts: number; to_ts: number };
+  /** Optional pointer to a screenshot file backing this evidence. */
+  screenshot_path?: string;
+  /** When this Evidence wraps composite child evidence (and/or/not), the
+   *  recursive structure preserved here so a debugger can drill in. */
+  children?: Evidence[];
+}

--- a/src/contracts/validator.ts
+++ b/src/contracts/validator.ts
@@ -109,7 +109,7 @@ function validateOne(
     case 'network':
       requireString(obj, 'url_pattern', path, errors);
       validateRegex(obj.url_pattern, `${path}.url_pattern`, errors);
-      requireNumberArray(obj, 'status_in', path, errors);
+      requireHttpStatusArray(obj, 'status_in', path, errors);
       requireEnum(obj, 'since', path, VALID_NETWORK_SINCE, errors);
       return;
     case 'screenshot_class':
@@ -263,6 +263,52 @@ function requireNumberArray(
         path: `${path}.${field}[${i}]`,
         code: 'wrong_type',
         message: 'expected finite number',
+      });
+    }
+  }
+}
+
+/** HTTP status codes are integer-valued in [100, 599]. Anything else
+ *  cannot match a real response and should fail registration so the
+ *  contract author can correct the typo before runtime evaluation. */
+function requireHttpStatusArray(
+  obj: Record<string, unknown>,
+  field: string,
+  path: string,
+  errors: ValidationError[],
+): void {
+  const v = obj[field];
+  if (!Array.isArray(v)) {
+    errors.push({
+      path: `${path}.${field}`,
+      code: 'wrong_type',
+      message: `${field} must be an array of HTTP status codes`,
+    });
+    return;
+  }
+  for (let i = 0; i < v.length; i++) {
+    const item = v[i];
+    if (typeof item !== 'number' || !Number.isFinite(item)) {
+      errors.push({
+        path: `${path}.${field}[${i}]`,
+        code: 'wrong_type',
+        message: 'expected finite number',
+      });
+      continue;
+    }
+    if (!Number.isInteger(item)) {
+      errors.push({
+        path: `${path}.${field}[${i}]`,
+        code: 'wrong_type',
+        message: 'HTTP status code must be an integer',
+      });
+      continue;
+    }
+    if (item < 100 || item > 599) {
+      errors.push({
+        path: `${path}.${field}[${i}]`,
+        code: 'out_of_range',
+        message: 'HTTP status code must be in [100, 599]',
       });
     }
   }

--- a/src/contracts/validator.ts
+++ b/src/contracts/validator.ts
@@ -36,7 +36,8 @@ export interface ValidationError {
     | 'out_of_range'
     | 'invalid_regex'
     | 'empty_children'
-    | 'unknown_enum';
+    | 'unknown_enum'
+    | 'unexpected_field';
 }
 
 const VALID_DOM_COUNT_OPS: ReadonlySet<DomCountOp> = new Set(['eq', 'gte', 'lte']);
@@ -114,8 +115,14 @@ function validateOne(
     case 'screenshot_class':
       requireString(obj, 'class_id', path, errors);
       requireFiniteNumber(obj, 'distance_max', path, errors);
-      if (typeof obj.distance_max === 'number') {
-        if (obj.distance_max < 0 || obj.distance_max > 64) {
+      if (typeof obj.distance_max === 'number' && Number.isFinite(obj.distance_max)) {
+        if (!Number.isInteger(obj.distance_max)) {
+          errors.push({
+            path: `${path}.distance_max`,
+            code: 'wrong_type',
+            message: 'distance_max must be an integer (Hamming distance is integer-valued)',
+          });
+        } else if (obj.distance_max < 0 || obj.distance_max > 64) {
           errors.push({
             path: `${path}.distance_max`,
             code: 'out_of_range',
@@ -153,6 +160,16 @@ function validateOne(
           message: 'not requires a single `child` (not `children`)',
         });
         return;
+      }
+      // Reject mixed payloads where the author also supplied `children`.
+      // Silently ignoring the extra field hides authoring mistakes whose
+      // intent (multi-child negation) cannot be represented by `not`.
+      if ('children' in obj) {
+        errors.push({
+          path: `${path}.children`,
+          code: 'unexpected_field',
+          message: 'not takes a single `child`; remove `children` (use `and`/`or` for multi-child composition)',
+        });
       }
       validateOne(obj.child, `${path}.child`, errors);
       return;

--- a/src/contracts/validator.ts
+++ b/src/contracts/validator.ts
@@ -1,0 +1,265 @@
+/**
+ * Structural validator for Outcome Contract assertions.
+ *
+ * Runs at the boundary (when a contract is registered or a postcondition
+ * is parsed from a tool call). Returns *all* errors in one batch so an
+ * LLM can fix multiple problems in a single retry.
+ *
+ * Validation is purely structural — does the shape match the type? It
+ * does NOT evaluate against a page; that's the evaluator's job.
+ *
+ * Per #705 v2 P0 fixes:
+ *   - `not` must have exactly one `child` (not an array of children).
+ *   - `op` must be one of the string enums.
+ *   - `screenshot_class.distance_max` must be in [0, 64].
+ *   - `network.since` must be `contract_enter` or `last_tool_call`.
+ *   - `and` / `or` must have ≥1 children.
+ *   - All `pattern` / `url_pattern` strings must compile as RegExp.
+ */
+
+import type {
+  Assertion,
+  AssertionKind,
+  DomCountOp,
+  NetworkSinceMode,
+} from './types';
+
+export interface ValidationError {
+  /** JSON-Pointer-ish path describing where the error lives. */
+  path: string;
+  message: string;
+  /** Coarse category — useful for grouping in UIs. */
+  code:
+    | 'unknown_kind'
+    | 'missing_field'
+    | 'wrong_type'
+    | 'out_of_range'
+    | 'invalid_regex'
+    | 'empty_children'
+    | 'unknown_enum';
+}
+
+const VALID_DOM_COUNT_OPS: ReadonlySet<DomCountOp> = new Set(['eq', 'gte', 'lte']);
+const VALID_NETWORK_SINCE: ReadonlySet<NetworkSinceMode> = new Set([
+  'contract_enter',
+  'last_tool_call',
+]);
+
+const KNOWN_KINDS: ReadonlySet<AssertionKind> = new Set<AssertionKind>([
+  'url',
+  'dom_text',
+  'dom_count',
+  'no_dialog',
+  'network',
+  'screenshot_class',
+  'and',
+  'or',
+  'not',
+]);
+
+/** Validate an entire assertion tree. Empty array means valid. */
+export function validateAssertion(value: unknown, path = '$'): ValidationError[] {
+  const errors: ValidationError[] = [];
+  validateOne(value, path, errors);
+  return errors;
+}
+
+function validateOne(
+  value: unknown,
+  path: string,
+  errors: ValidationError[],
+): void {
+  if (!isPlainObject(value)) {
+    errors.push({ path, code: 'wrong_type', message: 'expected object' });
+    return;
+  }
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.kind !== 'string') {
+    errors.push({ path: `${path}.kind`, code: 'missing_field', message: 'kind must be a string' });
+    return;
+  }
+  if (!KNOWN_KINDS.has(obj.kind as AssertionKind)) {
+    errors.push({
+      path: `${path}.kind`,
+      code: 'unknown_kind',
+      message: `unknown assertion kind "${obj.kind}"`,
+    });
+    return;
+  }
+
+  switch (obj.kind as AssertionKind) {
+    case 'url':
+      requireString(obj, 'pattern', path, errors);
+      validateRegex(obj.pattern, `${path}.pattern`, errors);
+      return;
+    case 'dom_text':
+      if ('selector' in obj && obj.selector !== undefined) {
+        requireString(obj, 'selector', path, errors);
+      }
+      requireString(obj, 'contains', path, errors);
+      return;
+    case 'dom_count':
+      requireString(obj, 'selector', path, errors);
+      requireEnum(obj, 'op', path, VALID_DOM_COUNT_OPS, errors);
+      requireFiniteNumber(obj, 'value', path, errors);
+      return;
+    case 'no_dialog':
+      return;
+    case 'network':
+      requireString(obj, 'url_pattern', path, errors);
+      validateRegex(obj.url_pattern, `${path}.url_pattern`, errors);
+      requireNumberArray(obj, 'status_in', path, errors);
+      requireEnum(obj, 'since', path, VALID_NETWORK_SINCE, errors);
+      return;
+    case 'screenshot_class':
+      requireString(obj, 'class_id', path, errors);
+      requireFiniteNumber(obj, 'distance_max', path, errors);
+      if (typeof obj.distance_max === 'number') {
+        if (obj.distance_max < 0 || obj.distance_max > 64) {
+          errors.push({
+            path: `${path}.distance_max`,
+            code: 'out_of_range',
+            message: 'distance_max must be in [0, 64] (Hamming distance over 64-bit pHash)',
+          });
+        }
+      }
+      return;
+    case 'and':
+    case 'or': {
+      const children = obj.children;
+      if (!Array.isArray(children)) {
+        errors.push({
+          path: `${path}.children`,
+          code: 'wrong_type',
+          message: 'children must be an array',
+        });
+        return;
+      }
+      if (children.length < 1) {
+        errors.push({
+          path: `${path}.children`,
+          code: 'empty_children',
+          message: `${obj.kind} must have ≥1 children`,
+        });
+      }
+      children.forEach((c, i) => validateOne(c, `${path}.children[${i}]`, errors));
+      return;
+    }
+    case 'not':
+      if (!('child' in obj) || obj.child === undefined) {
+        errors.push({
+          path: `${path}.child`,
+          code: 'missing_field',
+          message: 'not requires a single `child` (not `children`)',
+        });
+        return;
+      }
+      validateOne(obj.child, `${path}.child`, errors);
+      return;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function requireString(
+  obj: Record<string, unknown>,
+  field: string,
+  path: string,
+  errors: ValidationError[],
+): void {
+  const v = obj[field];
+  if (typeof v !== 'string' || v.length === 0) {
+    errors.push({
+      path: `${path}.${field}`,
+      code: typeof v === 'string' ? 'wrong_type' : 'missing_field',
+      message: `${field} must be a non-empty string`,
+    });
+  }
+}
+
+function requireFiniteNumber(
+  obj: Record<string, unknown>,
+  field: string,
+  path: string,
+  errors: ValidationError[],
+): void {
+  const v = obj[field];
+  if (typeof v !== 'number' || !Number.isFinite(v)) {
+    errors.push({
+      path: `${path}.${field}`,
+      code: typeof v === 'number' ? 'wrong_type' : 'missing_field',
+      message: `${field} must be a finite number`,
+    });
+  }
+}
+
+function requireEnum<E extends string>(
+  obj: Record<string, unknown>,
+  field: string,
+  path: string,
+  allowed: ReadonlySet<E>,
+  errors: ValidationError[],
+): void {
+  const v = obj[field];
+  if (typeof v !== 'string') {
+    errors.push({
+      path: `${path}.${field}`,
+      code: 'missing_field',
+      message: `${field} must be a string enum`,
+    });
+    return;
+  }
+  if (!allowed.has(v as E)) {
+    errors.push({
+      path: `${path}.${field}`,
+      code: 'unknown_enum',
+      message: `${field} must be one of: ${[...allowed].join(', ')}`,
+    });
+  }
+}
+
+function requireNumberArray(
+  obj: Record<string, unknown>,
+  field: string,
+  path: string,
+  errors: ValidationError[],
+): void {
+  const v = obj[field];
+  if (!Array.isArray(v)) {
+    errors.push({
+      path: `${path}.${field}`,
+      code: 'wrong_type',
+      message: `${field} must be an array of numbers`,
+    });
+    return;
+  }
+  for (let i = 0; i < v.length; i++) {
+    const item = v[i];
+    if (typeof item !== 'number' || !Number.isFinite(item)) {
+      errors.push({
+        path: `${path}.${field}[${i}]`,
+        code: 'wrong_type',
+        message: 'expected finite number',
+      });
+    }
+  }
+}
+
+function validateRegex(value: unknown, path: string, errors: ValidationError[]): void {
+  if (typeof value !== 'string') return;
+  try {
+    new RegExp(value);
+  } catch (e) {
+    errors.push({
+      path,
+      code: 'invalid_regex',
+      message: `regex failed to compile: ${e instanceof Error ? e.message : String(e)}`,
+    });
+  }
+}

--- a/tests/contracts/evaluator.test.ts
+++ b/tests/contracts/evaluator.test.ts
@@ -137,7 +137,7 @@ describe('evaluate — network / screenshot_class are PR-10 stubs', () => {
       ctx(),
     );
     expect(r.passed).toBe(false);
-    expect(r.details.unsupported_in_pr9).toBe(true);
+    expect(r.details.unsupported).toBe(true);
   });
 
   test('screenshot_class returns passed=false with unsupported flag', () => {
@@ -146,7 +146,104 @@ describe('evaluate — network / screenshot_class are PR-10 stubs', () => {
       ctx(),
     );
     expect(r.passed).toBe(false);
-    expect(r.details.unsupported_in_pr9).toBe(true);
+    expect(r.details.unsupported).toBe(true);
+  });
+});
+
+describe('evaluate — host probe failures (always-settles guarantee)', () => {
+  test('dom_text whose probe throws → passed=false with probe_error', () => {
+    const r = evaluate(
+      { kind: 'dom_text', selector: '#bad', contains: 'x' },
+      {
+        url: 'https://x',
+        bodyText: '',
+        domText: () => {
+          throw new Error('Invalid selector');
+        },
+        domCount: () => 0,
+        hasDialog: false,
+      },
+    );
+    expect(r.passed).toBe(false);
+    expect(r.details.probe_error).toContain('Invalid selector');
+  });
+
+  test('dom_count whose probe throws → passed=false with probe_error', () => {
+    const r = evaluate(
+      { kind: 'dom_count', selector: '#bad', op: 'eq', value: 0 },
+      {
+        url: 'https://x',
+        bodyText: '',
+        domText: () => '',
+        domCount: () => {
+          throw new Error('querySelectorAll failed');
+        },
+        hasDialog: false,
+      },
+    );
+    expect(r.passed).toBe(false);
+    expect(r.details.probe_error).toContain('querySelectorAll');
+  });
+});
+
+describe('evaluate — composite propagates unsupported correctly', () => {
+  test('not(unsupported) cannot pass — propagates unsupported', () => {
+    // Without this guard `not(network)` would return passed=true while
+    // network is still a stub, letting authors drive logic off a kind
+    // that has not been wired up yet.
+    const r = evaluate(
+      {
+        kind: 'not',
+        child: { kind: 'network', url_pattern: '/x', status_in: [200], since: 'contract_enter' },
+      },
+      ctx(),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.details.unsupported).toBe(true);
+  });
+
+  test('and with an unsupported child → unsupported composite, passed=false', () => {
+    const r = evaluate(
+      {
+        kind: 'and',
+        children: [
+          { kind: 'no_dialog' },
+          { kind: 'network', url_pattern: '/x', status_in: [200], since: 'contract_enter' },
+        ],
+      },
+      ctx(),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.details.unsupported).toBe(true);
+  });
+
+  test('or with a real-passing child still passes (unsupported sibling does not poison)', () => {
+    const r = evaluate(
+      {
+        kind: 'or',
+        children: [
+          { kind: 'no_dialog' }, // passes
+          { kind: 'network', url_pattern: '/x', status_in: [200], since: 'contract_enter' },
+        ],
+      },
+      ctx(),
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  test('or with only failing + unsupported children → unsupported composite', () => {
+    const r = evaluate(
+      {
+        kind: 'or',
+        children: [
+          { kind: 'url', pattern: 'will-not-match' },
+          { kind: 'network', url_pattern: '/x', status_in: [200], since: 'contract_enter' },
+        ],
+      },
+      ctx(),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.details.unsupported).toBe(true);
   });
 });
 

--- a/tests/contracts/evaluator.test.ts
+++ b/tests/contracts/evaluator.test.ts
@@ -1,0 +1,213 @@
+import { evaluate } from '../../src/contracts/evaluator';
+import type { AssertionContext } from '../../src/contracts/evaluator';
+
+function ctx(over: Partial<AssertionContext> = {}): AssertionContext {
+  return {
+    url: 'https://example.com/',
+    bodyText: 'Welcome to Example',
+    domText: () => '',
+    domCount: () => 0,
+    hasDialog: false,
+    ...over,
+  };
+}
+
+describe('evaluate — url', () => {
+  test('passes when pattern matches', () => {
+    const r = evaluate({ kind: 'url', pattern: 'example\\.com' }, ctx({ url: 'https://example.com/' }));
+    expect(r.passed).toBe(true);
+    expect(r.assertion_kind).toBe('url');
+  });
+
+  test('fails when pattern does not match', () => {
+    const r = evaluate({ kind: 'url', pattern: 'not-here' }, ctx());
+    expect(r.passed).toBe(false);
+    expect(r.details).toMatchObject({ pattern: 'not-here' });
+  });
+
+  test('malformed regex falls back to never-match (no throw)', () => {
+    const r = evaluate({ kind: 'url', pattern: '[unclosed' }, ctx());
+    expect(r.passed).toBe(false);
+  });
+});
+
+describe('evaluate — dom_text', () => {
+  test('default selector "body" reads ctx.bodyText', () => {
+    const r = evaluate(
+      { kind: 'dom_text', contains: 'Welcome' },
+      ctx({ bodyText: 'Welcome traveler' }),
+    );
+    expect(r.passed).toBe(true);
+    expect(r.details.selector).toBe('body');
+  });
+
+  test('explicit selector reads via domText()', () => {
+    const r = evaluate(
+      { kind: 'dom_text', selector: '#title', contains: 'Hello' },
+      ctx({
+        domText: (sel) => (sel === '#title' ? 'Hello world' : ''),
+      }),
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  test('returns truncated haystack_excerpt for long bodies', () => {
+    const long = 'x'.repeat(1000);
+    const r = evaluate({ kind: 'dom_text', contains: 'x' }, ctx({ bodyText: long }));
+    expect(typeof r.details.haystack_excerpt).toBe('string');
+    expect((r.details.haystack_excerpt as string).length).toBeLessThan(260);
+    expect(r.details.haystack_length).toBe(1000);
+  });
+});
+
+describe('evaluate — dom_count', () => {
+  test('eq pass / fail', () => {
+    expect(
+      evaluate(
+        { kind: 'dom_count', selector: 'button', op: 'eq', value: 3 },
+        ctx({ domCount: () => 3 }),
+      ).passed,
+    ).toBe(true);
+    expect(
+      evaluate(
+        { kind: 'dom_count', selector: 'button', op: 'eq', value: 3 },
+        ctx({ domCount: () => 4 }),
+      ).passed,
+    ).toBe(false);
+  });
+
+  test('gte pass / fail', () => {
+    expect(
+      evaluate(
+        { kind: 'dom_count', selector: 'button', op: 'gte', value: 3 },
+        ctx({ domCount: () => 5 }),
+      ).passed,
+    ).toBe(true);
+    expect(
+      evaluate(
+        { kind: 'dom_count', selector: 'button', op: 'gte', value: 3 },
+        ctx({ domCount: () => 1 }),
+      ).passed,
+    ).toBe(false);
+  });
+
+  test('lte pass / fail', () => {
+    expect(
+      evaluate(
+        { kind: 'dom_count', selector: 'button', op: 'lte', value: 3 },
+        ctx({ domCount: () => 1 }),
+      ).passed,
+    ).toBe(true);
+    expect(
+      evaluate(
+        { kind: 'dom_count', selector: 'button', op: 'lte', value: 3 },
+        ctx({ domCount: () => 5 }),
+      ).passed,
+    ).toBe(false);
+  });
+
+  test('details record actual + expected', () => {
+    const r = evaluate(
+      { kind: 'dom_count', selector: '.x', op: 'gte', value: 2 },
+      ctx({ domCount: () => 7 }),
+    );
+    expect(r.details).toMatchObject({ actual: 7, expected: 2, op: 'gte' });
+  });
+});
+
+describe('evaluate — no_dialog', () => {
+  test('passes when no dialog is open', () => {
+    expect(evaluate({ kind: 'no_dialog' }, ctx({ hasDialog: false })).passed).toBe(true);
+  });
+
+  test('fails when a dialog is open', () => {
+    expect(evaluate({ kind: 'no_dialog' }, ctx({ hasDialog: true })).passed).toBe(false);
+  });
+
+  test('details carry the boolean', () => {
+    const r = evaluate({ kind: 'no_dialog' }, ctx({ hasDialog: true }));
+    expect(r.details).toEqual({ hasDialog: true });
+  });
+});
+
+describe('evaluate — network / screenshot_class are PR-10 stubs', () => {
+  test('network returns passed=false with unsupported flag', () => {
+    const r = evaluate(
+      { kind: 'network', url_pattern: '/x', status_in: [200], since: 'contract_enter' },
+      ctx(),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.details.unsupported_in_pr9).toBe(true);
+  });
+
+  test('screenshot_class returns passed=false with unsupported flag', () => {
+    const r = evaluate(
+      { kind: 'screenshot_class', class_id: 'x', distance_max: 12 },
+      ctx(),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.details.unsupported_in_pr9).toBe(true);
+  });
+});
+
+describe('evaluate — and/or/not (composite)', () => {
+  test('and: passes only when every child passes', () => {
+    const c = ctx({ url: 'https://x.com/', bodyText: 'OK' });
+    expect(
+      evaluate(
+        { kind: 'and', children: [
+          { kind: 'url', pattern: 'x\\.com' },
+          { kind: 'dom_text', contains: 'OK' },
+        ] },
+        c,
+      ).passed,
+    ).toBe(true);
+    expect(
+      evaluate(
+        { kind: 'and', children: [
+          { kind: 'url', pattern: 'x\\.com' },
+          { kind: 'dom_text', contains: 'MISSING' },
+        ] },
+        c,
+      ).passed,
+    ).toBe(false);
+  });
+
+  test('or: passes when any child passes', () => {
+    const c = ctx({ url: 'https://x.com/', bodyText: 'A' });
+    expect(
+      evaluate(
+        { kind: 'or', children: [
+          { kind: 'dom_text', contains: 'B' },
+          { kind: 'dom_text', contains: 'A' },
+        ] },
+        c,
+      ).passed,
+    ).toBe(true);
+  });
+
+  test('not: inverts a single child', () => {
+    const c = ctx({ hasDialog: true });
+    const r = evaluate({ kind: 'not', child: { kind: 'no_dialog' } }, c);
+    expect(r.passed).toBe(true);
+    expect(r.children).toHaveLength(1);
+    expect(r.children![0].passed).toBe(false);
+  });
+
+  test('composite evidence preserves children for debugging', () => {
+    const r = evaluate(
+      { kind: 'and', children: [{ kind: 'no_dialog' }, { kind: 'no_dialog' }] },
+      ctx(),
+    );
+    expect(r.children).toHaveLength(2);
+    expect(r.children!.every((c) => c.passed)).toBe(true);
+  });
+});
+
+describe('evaluate — trace_ref propagation', () => {
+  test('trace_ref from ctx is included in evidence', () => {
+    const c = ctx({ traceRef: { trace_id: 't1', from_ts: 100, to_ts: 200 } });
+    const r = evaluate({ kind: 'no_dialog' }, c);
+    expect(r.trace_ref).toEqual({ trace_id: 't1', from_ts: 100, to_ts: 200 });
+  });
+});

--- a/tests/contracts/validator.test.ts
+++ b/tests/contracts/validator.test.ts
@@ -174,6 +174,39 @@ describe('validateAssertion — per-kind field rules', () => {
     });
     expect(errors.some((e) => e.path === '$.status_in')).toBe(true);
   });
+
+  test('network with non-integer status_in → wrong_type', () => {
+    const errors = validateAssertion({
+      kind: 'network',
+      url_pattern: '/x',
+      status_in: [200.5],
+      since: 'contract_enter',
+    });
+    expect(
+      errors.some((e) => e.path === '$.status_in[0]' && e.code === 'wrong_type'),
+    ).toBe(true);
+  });
+
+  test('network status_in below 100 or above 599 → out_of_range', () => {
+    const lo = validateAssertion({
+      kind: 'network',
+      url_pattern: '/x',
+      status_in: [42],
+      since: 'contract_enter',
+    });
+    expect(
+      lo.some((e) => e.path === '$.status_in[0]' && e.code === 'out_of_range'),
+    ).toBe(true);
+    const hi = validateAssertion({
+      kind: 'network',
+      url_pattern: '/x',
+      status_in: [700],
+      since: 'contract_enter',
+    });
+    expect(
+      hi.some((e) => e.path === '$.status_in[0]' && e.code === 'out_of_range'),
+    ).toBe(true);
+  });
 });
 
 describe('validateAssertion — composite rules', () => {

--- a/tests/contracts/validator.test.ts
+++ b/tests/contracts/validator.test.ts
@@ -1,0 +1,188 @@
+import { validateAssertion } from '../../src/contracts/validator';
+
+describe('validateAssertion — happy paths', () => {
+  test('valid url assertion → no errors', () => {
+    expect(validateAssertion({ kind: 'url', pattern: 'amazon\\.com/cart' })).toEqual([]);
+  });
+
+  test('valid dom_text with default selector → no errors', () => {
+    expect(validateAssertion({ kind: 'dom_text', contains: 'Order Placed' })).toEqual([]);
+  });
+
+  test('valid dom_count → no errors', () => {
+    expect(
+      validateAssertion({ kind: 'dom_count', selector: 'button', op: 'gte', value: 1 }),
+    ).toEqual([]);
+  });
+
+  test('valid no_dialog → no errors', () => {
+    expect(validateAssertion({ kind: 'no_dialog' })).toEqual([]);
+  });
+
+  test('valid screenshot_class → no errors', () => {
+    expect(
+      validateAssertion({
+        kind: 'screenshot_class',
+        class_id: 'order-confirmation/v3',
+        distance_max: 12,
+      }),
+    ).toEqual([]);
+  });
+
+  test('valid network → no errors', () => {
+    expect(
+      validateAssertion({
+        kind: 'network',
+        url_pattern: '/checkout/.*',
+        status_in: [200, 201],
+        since: 'contract_enter',
+      }),
+    ).toEqual([]);
+  });
+
+  test('nested composite (and/or/not) → no errors', () => {
+    expect(
+      validateAssertion({
+        kind: 'and',
+        children: [
+          { kind: 'url', pattern: '/cart' },
+          { kind: 'or', children: [{ kind: 'no_dialog' }, { kind: 'dom_text', contains: 'OK' }] },
+          { kind: 'not', child: { kind: 'no_dialog' } },
+        ],
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe('validateAssertion — structural failures', () => {
+  test('non-object input → wrong_type', () => {
+    expect(validateAssertion(null)).toEqual([
+      { path: '$', code: 'wrong_type', message: 'expected object' },
+    ]);
+    expect(validateAssertion('hello')).toHaveLength(1);
+    expect(validateAssertion([])).toHaveLength(1);
+  });
+
+  test('missing kind → missing_field', () => {
+    const errors = validateAssertion({ pattern: 'x' });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].code).toBe('missing_field');
+    expect(errors[0].path).toBe('$.kind');
+  });
+
+  test('unknown kind → unknown_kind (does not crash)', () => {
+    const errors = validateAssertion({ kind: 'never-existed' });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].code).toBe('unknown_kind');
+  });
+});
+
+describe('validateAssertion — per-kind field rules', () => {
+  test('url with invalid regex → invalid_regex', () => {
+    const errors = validateAssertion({ kind: 'url', pattern: '[unclosed' });
+    expect(errors.some((e) => e.code === 'invalid_regex')).toBe(true);
+  });
+
+  test('url without pattern → missing_field', () => {
+    expect(validateAssertion({ kind: 'url' })).toEqual([
+      expect.objectContaining({ code: 'missing_field', path: '$.pattern' }),
+    ]);
+  });
+
+  test('dom_text without contains → missing_field', () => {
+    const errors = validateAssertion({ kind: 'dom_text' });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].path).toBe('$.contains');
+  });
+
+  test('dom_count with bogus op → unknown_enum', () => {
+    const errors = validateAssertion({
+      kind: 'dom_count',
+      selector: 'button',
+      op: '==',
+      value: 1,
+    });
+    expect(errors.some((e) => e.code === 'unknown_enum' && e.path === '$.op')).toBe(true);
+  });
+
+  test('dom_count with non-finite value → wrong_type', () => {
+    const errors = validateAssertion({
+      kind: 'dom_count',
+      selector: 'button',
+      op: 'eq',
+      value: Number.POSITIVE_INFINITY,
+    });
+    expect(errors.some((e) => e.path === '$.value')).toBe(true);
+  });
+
+  test('screenshot_class distance_max out of [0,64] → out_of_range', () => {
+    const errors = validateAssertion({
+      kind: 'screenshot_class',
+      class_id: 'x',
+      distance_max: 100,
+    });
+    expect(errors.some((e) => e.code === 'out_of_range' && e.path === '$.distance_max')).toBe(true);
+  });
+
+  test('network with bogus since → unknown_enum', () => {
+    const errors = validateAssertion({
+      kind: 'network',
+      url_pattern: '/x',
+      status_in: [200],
+      since: 'bogus',
+    });
+    expect(errors.some((e) => e.code === 'unknown_enum' && e.path === '$.since')).toBe(true);
+  });
+
+  test('network with non-array status_in → wrong_type', () => {
+    const errors = validateAssertion({
+      kind: 'network',
+      url_pattern: '/x',
+      status_in: 200,
+      since: 'contract_enter',
+    });
+    expect(errors.some((e) => e.path === '$.status_in')).toBe(true);
+  });
+});
+
+describe('validateAssertion — composite rules', () => {
+  test('and with empty children → empty_children', () => {
+    const errors = validateAssertion({ kind: 'and', children: [] });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].code).toBe('empty_children');
+  });
+
+  test('and with non-array children → wrong_type', () => {
+    const errors = validateAssertion({ kind: 'and', children: 'oops' });
+    expect(errors[0].code).toBe('wrong_type');
+  });
+
+  test('not with `children` instead of `child` → missing_field', () => {
+    const errors = validateAssertion({
+      kind: 'not',
+      children: [{ kind: 'no_dialog' }],
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].path).toBe('$.child');
+  });
+
+  test('not with single child → no errors', () => {
+    expect(validateAssertion({ kind: 'not', child: { kind: 'no_dialog' } })).toEqual([]);
+  });
+
+  test('errors aggregate across the tree (batch reporting)', () => {
+    const errors = validateAssertion({
+      kind: 'and',
+      children: [
+        { kind: 'url' /* missing pattern */ },
+        { kind: 'dom_count', selector: 'x', op: '?', value: 'oops' },
+        { kind: 'not', children: [] },
+      ],
+    });
+    expect(errors.length).toBeGreaterThanOrEqual(3);
+    // path stamps include the array index
+    expect(errors.some((e) => e.path.startsWith('$.children[0]'))).toBe(true);
+    expect(errors.some((e) => e.path.startsWith('$.children[1]'))).toBe(true);
+    expect(errors.some((e) => e.path.startsWith('$.children[2]'))).toBe(true);
+  });
+});

--- a/tests/contracts/validator.test.ts
+++ b/tests/contracts/validator.test.ts
@@ -124,6 +124,37 @@ describe('validateAssertion — per-kind field rules', () => {
     expect(errors.some((e) => e.code === 'out_of_range' && e.path === '$.distance_max')).toBe(true);
   });
 
+  test('screenshot_class distance_max non-integer → wrong_type', () => {
+    // Hamming distance over a 64-bit hash is integer by definition;
+    // 12.5 cannot represent a real distance and must be rejected at
+    // registration time so contracts cannot silently mis-evaluate.
+    const errors = validateAssertion({
+      kind: 'screenshot_class',
+      class_id: 'x',
+      distance_max: 12.5,
+    });
+    expect(
+      errors.some((e) => e.code === 'wrong_type' && e.path === '$.distance_max'),
+    ).toBe(true);
+  });
+
+  test('screenshot_class distance_max integer at bound → no errors', () => {
+    expect(
+      validateAssertion({
+        kind: 'screenshot_class',
+        class_id: 'x',
+        distance_max: 64,
+      }),
+    ).toEqual([]);
+    expect(
+      validateAssertion({
+        kind: 'screenshot_class',
+        class_id: 'x',
+        distance_max: 0,
+      }),
+    ).toEqual([]);
+  });
+
   test('network with bogus since → unknown_enum', () => {
     const errors = validateAssertion({
       kind: 'network',
@@ -168,6 +199,19 @@ describe('validateAssertion — composite rules', () => {
 
   test('not with single child → no errors', () => {
     expect(validateAssertion({ kind: 'not', child: { kind: 'no_dialog' } })).toEqual([]);
+  });
+
+  test('not with both `child` and `children` → unexpected_field', () => {
+    // Silently ignoring `children` would hide authoring mistakes where
+    // the user expected multi-child negation; flag it explicitly.
+    const errors = validateAssertion({
+      kind: 'not',
+      child: { kind: 'no_dialog' },
+      children: [{ kind: 'url', pattern: 'x' }],
+    });
+    expect(
+      errors.some((e) => e.code === 'unexpected_field' && e.path === '$.children'),
+    ).toBe(true);
   });
 
   test('errors aggregate across the tree (batch reporting)', () => {


### PR DESCRIPTION
## Summary

Foundation for Outcome Contracts (Epic #699). Ships the **JSON-first assertion vocabulary** and a synchronous evaluator so the runtime (PR-11) can call `evaluate(assertion, snapshot)` without spinning a browser in unit tests. Stacked on **#747** (closes the M1 epic chain).

- `src/contracts/types.ts` — `Assertion` union per #705 v2 — `not` takes a single child (not an array), `screenshot_class` carries `class_id` + `distance_max` (Hamming distance over a 64-bit perceptual hash, range 0-64)
- `src/contracts/validator.ts` — schema validator that rejects malformed contracts at registration time
- `src/contracts/evaluator.ts` — pure synchronous evaluator over `(assertion, snapshot)` returning `{ ok, failedAssertionId, evidence }`
- `src/contracts/index.ts` — barrel
- `tests/contracts/validator.test.ts` (covers all assertion shapes, rejection paths)
- `tests/contracts/evaluator.test.ts` (covers each assertion kind happy path + failure path + nested `not`/`and`/`or` composition)

## Why JSON-first (not TS-class-first)

Per #705 v2: contracts must be portable across services and storable in the audit log. JSON definitions can be serialized into the trace recorder's evidence bundles (#707) and replayed; TS-class definitions cannot. The TS types provide compile-time safety on top of the JSON shape.

## What is deferred

- Runtime that wires this evaluator to live snapshots → PR-11
- Screenshot-class assertions (need pHash module first) → PR-10
- Network-assert (`response_seen`) → PR-11 (needs the recorder's network event stream)

## Validation

- `npm run build` clean
- `npm test -- tests/contracts` — all green
- Pure module: no browser, no fs, no clock dependency

## Test plan

- [ ] Reviewer pulls and runs `npm install && npm run build && npm test -- tests/contracts`
- [ ] Reviewer confirms `not` takes a single child per #705 v2 (rejects an array form at the type level)
- [ ] Reviewer confirms `screenshot_class.distance_max` is documented as Hamming distance 0-64
- [ ] Reviewer confirms validator rejects unknown assertion `kind` strings (forward-compat for new kinds)

Refs: #699 (epic), #705 (sub-issue). Stacked on #747.

🤖 Split from `feat/m1-pr1-trace-foundation`. Original commit: `fc1d456`.
