### PR TITLE
feat(contracts): evidence bundle generator + MCP resource (M2 PR-13)

### DIFF
--- a/src/contracts/evidence.ts
+++ b/src/contracts/evidence.ts
@@ -96,7 +96,17 @@ export interface BundleManifest {
   transaction: TransactionRecord;
   suggested_next_steps?: EvidenceBundleInputs['suggested_next_steps'];
   /** Per-component truncation flags surfaced for the reader. */
-  truncated?: Partial<Record<'fail_dom' | 'lastgood_dom' | 'trace_slice', true>>;
+  truncated?: Partial<
+    Record<
+      | 'fail_dom'
+      | 'lastgood_dom'
+      | 'trace_slice'
+      | 'pre_screenshot'
+      | 'fail_screenshot'
+      | 'lastgood_screenshot',
+      true
+    >
+  >;
   /** Total bytes written. */
   byte_size: number;
 }
@@ -142,9 +152,18 @@ export async function writeEvidenceBundle(
   let byteSize = 0;
 
   // --- Screenshots (write as supplied; downscaling deferred) ---
-  byteSize += writeScreenshot(bundleDir, 'pre_screenshot.png', inputs.pre_screenshot, files, 'pre_screenshot');
-  byteSize += writeScreenshot(bundleDir, 'fail_screenshot.png', inputs.fail_screenshot, files, 'fail_screenshot');
-  byteSize += writeScreenshot(bundleDir, 'lastgood_screenshot.png', inputs.lastgood_screenshot, files, 'lastgood_screenshot');
+  // Pass `maxBytes` so a single failure-frame PNG larger than the cap is
+  // dropped (and surfaced via `truncated`) rather than silently blowing
+  // past the documented hard ceiling. The trace-slice path below already
+  // applies the same accounting; without this, screenshots could exceed
+  // OPENCHROME_BUNDLE_MAX_BYTES by megabytes on failure-heavy runs.
+  const skipped: Array<keyof BundleManifest['files']> = [];
+  byteSize += writeScreenshot(bundleDir, 'pre_screenshot.png', inputs.pre_screenshot, files, 'pre_screenshot', byteSize, maxBytes, skipped);
+  byteSize += writeScreenshot(bundleDir, 'fail_screenshot.png', inputs.fail_screenshot, files, 'fail_screenshot', byteSize, maxBytes, skipped);
+  byteSize += writeScreenshot(bundleDir, 'lastgood_screenshot.png', inputs.lastgood_screenshot, files, 'lastgood_screenshot', byteSize, maxBytes, skipped);
+  for (const key of skipped) {
+    (truncated as Record<string, true>)[key] = true;
+  }
 
   // --- DOM snapshots (redacted, truncated when oversize) ---
   if (inputs.fail_dom !== undefined) {
@@ -245,9 +264,11 @@ function writeScreenshot(
   source: Buffer | string | undefined,
   files: BundleManifest['files'],
   key: keyof BundleManifest['files'],
+  bytesSoFar: number,
+  maxBytes: number,
+  skipped: Array<keyof BundleManifest['files']>,
 ): number {
   if (source === undefined) return 0;
-  const target = path.join(bundleDir, filename);
   let buf: Buffer;
   if (Buffer.isBuffer(source)) {
     buf = source;
@@ -255,7 +276,14 @@ function writeScreenshot(
     if (!fs.existsSync(source)) return 0;
     buf = fs.readFileSync(source);
   }
-  fs.writeFileSync(target, buf);
+  // Honor the bundle byte cap: a single oversized frame is dropped and
+  // surfaced via `truncated[key]` rather than silently inflating the
+  // bundle past the configured limit.
+  if (bytesSoFar + buf.byteLength > maxBytes) {
+    skipped.push(key);
+    return 0;
+  }
+  fs.writeFileSync(path.join(bundleDir, filename), buf);
   files[key] = filename;
   return buf.byteLength;
 }
@@ -293,7 +321,26 @@ export function parseTransactionUri(uri: string): string | null {
   if (!uri.startsWith(TRANSACTION_URI_PREFIX)) return null;
   const rest = uri.slice(TRANSACTION_URI_PREFIX.length);
   if (!rest || rest.includes('/')) return null;
-  return decodeURIComponent(rest);
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(rest);
+  } catch {
+    return null;
+  }
+  // Defend against percent-encoded traversal (e.g. `%2e%2e%2fother`):
+  // `path.join(rootDir, '../...')` would escape the bundle root once we
+  // hit `readEvidenceBundle`. Reject any decoded segment that contains
+  // a path separator, NUL, or resolves to a `.`/`..` directory entry.
+  if (
+    decoded === '.' ||
+    decoded === '..' ||
+    decoded.includes('/') ||
+    decoded.includes('\\') ||
+    decoded.includes('\0')
+  ) {
+    return null;
+  }
+  return decoded;
 }
 
 export async function readTransactionResource(

--- a/src/contracts/evidence.ts
+++ b/src/contracts/evidence.ts
@@ -103,7 +103,8 @@ export interface BundleManifest {
       | 'trace_slice'
       | 'pre_screenshot'
       | 'fail_screenshot'
-      | 'lastgood_screenshot',
+      | 'lastgood_screenshot'
+      | 'manifest',
       true
     >
   >;
@@ -190,18 +191,24 @@ export async function writeEvidenceBundle(
     let slice = inputs.trace_slice;
     let traceTruncated = false;
     let raw = '';
+    let rawBytes = 0;
     for (const ev of slice) {
       const redacted = { ...ev, body: redactValue(ev.body) };
       const line = JSON.stringify(redacted) + '\n';
-      if (byteSize + raw.length + line.length > maxBytes) {
+      const lineBytes = Buffer.byteLength(line, 'utf8');
+      // Use UTF-8 byte length: `raw.length` is UTF-16 code units, so a
+      // payload full of CJK / emoji could pass this check while the
+      // on-disk file blows past the cap by 50%+.
+      if (byteSize + rawBytes + lineBytes > maxBytes) {
         traceTruncated = true;
         break;
       }
       raw += line;
+      rawBytes += lineBytes;
     }
     fs.writeFileSync(slicePath, raw, 'utf8');
     files.trace_slice = 'trace_slice.jsonl';
-    byteSize += Buffer.byteLength(raw, 'utf8');
+    byteSize += rawBytes;
     if (traceTruncated || raw.split('\n').length - 1 < slice.length) {
       truncated.trace_slice = true;
     }
@@ -215,10 +222,10 @@ export async function writeEvidenceBundle(
   // can't leak via the manifest itself even though every other path is
   // scrubbed.
   const redactedTransaction = redactValue(inputs.transaction) as TransactionRecord;
-  const redactedNextSteps = inputs.suggested_next_steps
+  let redactedNextSteps = inputs.suggested_next_steps
     ? (redactValue(inputs.suggested_next_steps) as EvidenceBundleInputs['suggested_next_steps'])
     : undefined;
-  const manifest: BundleManifest = {
+  const buildManifest = (): BundleManifest => ({
     schema_version: 1,
     txn_id: redactedTransaction.txn_id,
     contract_id: redactedTransaction.contract_id,
@@ -229,9 +236,21 @@ export async function writeEvidenceBundle(
     suggested_next_steps: redactedNextSteps,
     byte_size: byteSize,
     ...(Object.keys(truncated).length > 0 ? { truncated } : {}),
-  };
-  const manifestText = JSON.stringify(manifest, null, 2);
-  byteSize += Buffer.byteLength(manifestText, 'utf8');
+  });
+  let manifest = buildManifest();
+  let manifestBytes = Buffer.byteLength(JSON.stringify(manifest, null, 2), 'utf8');
+  // Manifest is mandatory (it's the index), but on a tight `maxBytes`
+  // even a redacted TransactionRecord can shove the total past the
+  // ceiling. Drop the largest optional field — `suggested_next_steps`
+  // — first, then surface a `manifest` truncation flag so readers see
+  // the bundle was abridged.
+  if (byteSize + manifestBytes > maxBytes && redactedNextSteps !== undefined) {
+    redactedNextSteps = undefined;
+    (truncated as Record<string, true>).manifest = true;
+    manifest = buildManifest();
+    manifestBytes = Buffer.byteLength(JSON.stringify(manifest, null, 2), 'utf8');
+  }
+  byteSize += manifestBytes;
   manifest.byte_size = byteSize;
 
   const tmpPath = path.join(bundleDir, TMP_MANIFEST_FILENAME);
@@ -312,10 +331,20 @@ function writeJsonSnapshot(
   const redacted = redactValue(value);
   const json = JSON.stringify(redacted);
   if (json.length > truncateBytes) {
+    // Reserve room for the wrapper (`{"_truncated":true,"_original_bytes":N,"preview":""}`).
+    // Without this the on-disk file is `truncateBytes + ~50 wrapper bytes`,
+    // which compounds with per-file caps to push the bundle past the
+    // configured ceiling.
+    const wrapperOverhead = JSON.stringify({
+      _truncated: true,
+      _original_bytes: json.length,
+      preview: '',
+    }).length;
+    const previewBudget = Math.max(0, truncateBytes - wrapperOverhead);
     const truncated = {
       _truncated: true,
       _original_bytes: json.length,
-      preview: json.slice(0, truncateBytes),
+      preview: json.slice(0, previewBudget),
     };
     const out = JSON.stringify(truncated);
     fs.writeFileSync(path.join(bundleDir, filename), out, 'utf8');

--- a/src/contracts/evidence.ts
+++ b/src/contracts/evidence.ts
@@ -293,6 +293,20 @@ export function readEvidenceBundle(
   } catch {
     return null;
   }
+  // Guard malformed manifests (manual tamper, partial write that
+  // somehow survived, version skew). Treat unexpected shapes as
+  // "not readable" — same outcome as a missing referenced file —
+  // rather than crashing inside `Object.values`.
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    return null;
+  }
+  if (
+    !manifest.files ||
+    typeof manifest.files !== 'object' ||
+    Array.isArray(manifest.files)
+  ) {
+    return null;
+  }
   for (const rel of Object.values(manifest.files)) {
     if (typeof rel !== 'string') continue;
     const p = path.join(bundleDir, rel);

--- a/src/contracts/evidence.ts
+++ b/src/contracts/evidence.ts
@@ -166,14 +166,19 @@ export async function writeEvidenceBundle(
   }
 
   // --- DOM snapshots (redacted, truncated when oversize) ---
+  // Effective per-DOM cap is min(DOM_TRUNCATE_BYTES, remaining bundle
+  // budget). Without this, a 50 KB-configured bundle could still hold
+  // two 500 KB DOM payloads because the per-DOM cap was the only check.
   if (inputs.fail_dom !== undefined) {
-    const r = writeJsonSnapshot(bundleDir, 'fail_dom.json', inputs.fail_dom, DOM_TRUNCATE_BYTES);
+    const cap = Math.min(DOM_TRUNCATE_BYTES, Math.max(0, maxBytes - byteSize));
+    const r = writeJsonSnapshot(bundleDir, 'fail_dom.json', inputs.fail_dom, cap);
     files.fail_dom = 'fail_dom.json';
     byteSize += r.bytes;
     if (r.truncatedFlag) truncated.fail_dom = true;
   }
   if (inputs.lastgood_dom !== undefined) {
-    const r = writeJsonSnapshot(bundleDir, 'lastgood_dom.json', inputs.lastgood_dom, DOM_TRUNCATE_BYTES);
+    const cap = Math.min(DOM_TRUNCATE_BYTES, Math.max(0, maxBytes - byteSize));
+    const r = writeJsonSnapshot(bundleDir, 'lastgood_dom.json', inputs.lastgood_dom, cap);
     files.lastgood_dom = 'lastgood_dom.json';
     byteSize += r.bytes;
     if (r.truncatedFlag) truncated.lastgood_dom = true;
@@ -203,15 +208,25 @@ export async function writeEvidenceBundle(
   }
 
   // --- Manifest written last (atomic via temp + rename) ---
+  // The TransactionRecord may carry URLs / args / response snippets that
+  // contain credentials (Authorization tokens, password params, API
+  // keys). DOM and trace payloads already flow through redactValue at
+  // their write boundary; the manifest must do the same so the bundle
+  // can't leak via the manifest itself even though every other path is
+  // scrubbed.
+  const redactedTransaction = redactValue(inputs.transaction) as TransactionRecord;
+  const redactedNextSteps = inputs.suggested_next_steps
+    ? (redactValue(inputs.suggested_next_steps) as EvidenceBundleInputs['suggested_next_steps'])
+    : undefined;
   const manifest: BundleManifest = {
     schema_version: 1,
-    txn_id: inputs.transaction.txn_id,
-    contract_id: inputs.transaction.contract_id,
-    verdict: inputs.transaction.verdict,
+    txn_id: redactedTransaction.txn_id,
+    contract_id: redactedTransaction.contract_id,
+    verdict: redactedTransaction.verdict,
     generated_at: Date.now(),
     files,
-    transaction: inputs.transaction,
-    suggested_next_steps: inputs.suggested_next_steps,
+    transaction: redactedTransaction,
+    suggested_next_steps: redactedNextSteps,
     byte_size: byteSize,
     ...(Object.keys(truncated).length > 0 ? { truncated } : {}),
   };

--- a/src/contracts/evidence.ts
+++ b/src/contracts/evidence.ts
@@ -330,21 +330,34 @@ function writeJsonSnapshot(
 ): { bytes: number; truncatedFlag: boolean } {
   const redacted = redactValue(value);
   const json = JSON.stringify(redacted);
-  if (json.length > truncateBytes) {
+  // truncateBytes is the on-disk byte budget; compare against UTF-8
+  // length so a CJK / emoji-heavy DOM can't pass the check (because
+  // `json.length` is UTF-16 code units) while the rendered file is
+  // 2-3x larger.
+  const jsonBytes = Buffer.byteLength(json, 'utf8');
+  if (jsonBytes > truncateBytes) {
     // Reserve room for the wrapper (`{"_truncated":true,"_original_bytes":N,"preview":""}`).
     // Without this the on-disk file is `truncateBytes + ~50 wrapper bytes`,
     // which compounds with per-file caps to push the bundle past the
     // configured ceiling.
-    const wrapperOverhead = JSON.stringify({
-      _truncated: true,
-      _original_bytes: json.length,
-      preview: '',
-    }).length;
+    const wrapperOverhead = Buffer.byteLength(
+      JSON.stringify({
+        _truncated: true,
+        _original_bytes: jsonBytes,
+        preview: '',
+      }),
+      'utf8',
+    );
     const previewBudget = Math.max(0, truncateBytes - wrapperOverhead);
+    // Slice on a UTF-8 byte boundary: `json.slice(0, previewBudget)`
+    // would index in UTF-16 code units. Build a Buffer view and slice
+    // bytes, then decode — losing any partial multibyte sequence at
+    // the tail to preserve well-formed UTF-8 output.
+    const previewBytes = Buffer.from(json, 'utf8').slice(0, previewBudget);
     const truncated = {
       _truncated: true,
-      _original_bytes: json.length,
-      preview: json.slice(0, previewBudget),
+      _original_bytes: jsonBytes,
+      preview: previewBytes.toString('utf8'),
     };
     const out = JSON.stringify(truncated);
     fs.writeFileSync(path.join(bundleDir, filename), out, 'utf8');
@@ -391,6 +404,16 @@ export async function readTransactionResource(
   uri: string,
   opts: EvidenceBundleOptions = {},
 ): Promise<{ mimeType: string; text: string } | null> {
+  // Discovery URI (`openchrome://transaction/` with no txn_id) returns
+  // the static help payload so the static list entry has matching
+  // read content. parseTransactionUri rejects empty rest deliberately;
+  // handle the bare-prefix case before delegating.
+  if (uri === TRANSACTION_URI_PREFIX) {
+    return {
+      mimeType: 'application/json',
+      text: JSON.stringify(transactionDiscoveryHelp),
+    };
+  }
   const txnId = parseTransactionUri(uri);
   if (!txnId) return null;
   const manifest = readEvidenceBundle(txnId, opts);
@@ -409,6 +432,23 @@ export const transactionDiscoveryHelp = {
     'Returns the bundle manifest (JSON). Bundles are written by the contract runtime ' +
     'on every settled transaction.',
 };
+
+/**
+ * Static resource definition that surfaces the `openchrome://transaction/`
+ * prefix in `resources/list` so MCP clients can discover the URI scheme
+ * without already knowing a `txn_id`. Mirrors the `traceListResource`
+ * pattern: list URI is static + discoverable, dynamic per-bundle URIs
+ * land via the prefix handler.
+ */
+export const transactionListResource = {
+  uri: 'openchrome://transaction/',
+  name: 'transaction-list',
+  description:
+    'Per-transaction evidence bundles. URI scheme: openchrome://transaction/<txn_id>. ' +
+    'Returns the bundle manifest (JSON) for that transaction. Bundles are written by ' +
+    'the contract runtime on every settled transaction.',
+  mimeType: 'application/json',
+} as const;
 
 // Defensive use of crypto so this module also doubles as a stable id helper
 // for callers that need a deterministic file name fingerprint.

--- a/src/contracts/evidence.ts
+++ b/src/contracts/evidence.ts
@@ -336,30 +336,42 @@ function writeJsonSnapshot(
   // 2-3x larger.
   const jsonBytes = Buffer.byteLength(json, 'utf8');
   if (jsonBytes > truncateBytes) {
-    // Reserve room for the wrapper (`{"_truncated":true,"_original_bytes":N,"preview":""}`).
-    // Without this the on-disk file is `truncateBytes + ~50 wrapper bytes`,
-    // which compounds with per-file caps to push the bundle past the
-    // configured ceiling.
-    const wrapperOverhead = Buffer.byteLength(
-      JSON.stringify({
+    // The on-disk file is the rendered wrapper, so size that output
+    // — not the raw preview — against `truncateBytes`. Two effects to
+    // account for:
+    //   (a) wrapper overhead (~50 bytes for `{"_truncated":..."preview":""}`)
+    //   (b) JSON re-escaping inside `preview`: a payload byte like `"`
+    //       or `\` doubles in size when re-stringified, control chars
+    //       grow to 6 bytes (`\u00xx`). A naive `truncateBytes -
+    //       wrapperOverhead` budget overshoots whenever the preview
+    //       contains such characters.
+    // Rather than reason about worst-case escaping, render the wrapper
+    // and shrink the preview byte by byte until the output fits. The
+    // tail is sliced on a UTF-8 byte boundary so multibyte sequences
+    // are not split mid-character.
+    const previewBuffer = Buffer.from(json, 'utf8');
+    const buildOut = (sliceLen: number): string => {
+      const previewBytes = previewBuffer.slice(0, sliceLen);
+      return JSON.stringify({
         _truncated: true,
         _original_bytes: jsonBytes,
-        preview: '',
-      }),
-      'utf8',
-    );
-    const previewBudget = Math.max(0, truncateBytes - wrapperOverhead);
-    // Slice on a UTF-8 byte boundary: `json.slice(0, previewBudget)`
-    // would index in UTF-16 code units. Build a Buffer view and slice
-    // bytes, then decode — losing any partial multibyte sequence at
-    // the tail to preserve well-formed UTF-8 output.
-    const previewBytes = Buffer.from(json, 'utf8').slice(0, previewBudget);
-    const truncated = {
-      _truncated: true,
-      _original_bytes: jsonBytes,
-      preview: previewBytes.toString('utf8'),
+        preview: previewBytes.toString('utf8'),
+      });
     };
-    const out = JSON.stringify(truncated);
+    let lo = 0;
+    let hi = previewBuffer.length;
+    // Binary-search the largest preview slice whose rendered wrapper
+    // is ≤ truncateBytes. Bounded by log2(buffer_length) iterations.
+    while (lo < hi) {
+      const mid = Math.ceil((lo + hi) / 2);
+      const rendered = Buffer.byteLength(buildOut(mid), 'utf8');
+      if (rendered <= truncateBytes) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    const out = buildOut(lo);
     fs.writeFileSync(path.join(bundleDir, filename), out, 'utf8');
     return { bytes: Buffer.byteLength(out, 'utf8'), truncatedFlag: true };
   }

--- a/src/contracts/evidence.ts
+++ b/src/contracts/evidence.ts
@@ -221,7 +221,7 @@ export async function writeEvidenceBundle(
   // their write boundary; the manifest must do the same so the bundle
   // can't leak via the manifest itself even though every other path is
   // scrubbed.
-  const redactedTransaction = redactValue(inputs.transaction) as TransactionRecord;
+  let redactedTransaction = redactValue(inputs.transaction) as TransactionRecord;
   let redactedNextSteps = inputs.suggested_next_steps
     ? (redactValue(inputs.suggested_next_steps) as EvidenceBundleInputs['suggested_next_steps'])
     : undefined;
@@ -246,6 +246,12 @@ export async function writeEvidenceBundle(
   // the bundle was abridged.
   if (byteSize + manifestBytes > maxBytes && redactedNextSteps !== undefined) {
     redactedNextSteps = undefined;
+    (truncated as Record<string, true>).manifest = true;
+    manifest = buildManifest();
+    manifestBytes = Buffer.byteLength(JSON.stringify(manifest, null, 2), 'utf8');
+  }
+  if (byteSize + manifestBytes > maxBytes) {
+    redactedTransaction = compactTransactionForManifest(redactedTransaction);
     (truncated as Record<string, true>).manifest = true;
     manifest = buildManifest();
     manifestBytes = Buffer.byteLength(JSON.stringify(manifest, null, 2), 'utf8');
@@ -404,6 +410,18 @@ function writeJsonSnapshot(
   }
   fs.writeFileSync(path.join(bundleDir, filename), json, 'utf8');
   return { bytes: Buffer.byteLength(json, 'utf8'), truncatedFlag: false };
+}
+
+function compactTransactionForManifest(record: TransactionRecord): TransactionRecord {
+  return {
+    txn_id: record.txn_id,
+    contract_id: record.contract_id,
+    verdict: record.verdict,
+    started_at: record.started_at,
+    ended_at: record.ended_at,
+    wall_ms: record.wall_ms,
+    retries: record.retries,
+  };
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/contracts/evidence.ts
+++ b/src/contracts/evidence.ts
@@ -250,12 +250,25 @@ export async function writeEvidenceBundle(
     manifest = buildManifest();
     manifestBytes = Buffer.byteLength(JSON.stringify(manifest, null, 2), 'utf8');
   }
+  // `byte_size` is self-referential: writing it grows the manifest by
+  // the digit count of the new value, which would make the recorded
+  // size lag the actual on-disk bytes. Iterate to a fixpoint (bounded
+  // since each step changes only the digit count of `byte_size`).
+  let prevManifestBytes = -1;
+  let iterations = 0;
+  while (manifestBytes !== prevManifestBytes && iterations < 4) {
+    prevManifestBytes = manifestBytes;
+    manifest.byte_size = byteSize + manifestBytes;
+    manifestBytes = Buffer.byteLength(JSON.stringify(manifest, null, 2), 'utf8');
+    iterations++;
+  }
   byteSize += manifestBytes;
   manifest.byte_size = byteSize;
+  const manifestText = JSON.stringify(manifest, null, 2);
 
   const tmpPath = path.join(bundleDir, TMP_MANIFEST_FILENAME);
   const finalPath = path.join(bundleDir, MANIFEST_FILENAME);
-  fs.writeFileSync(tmpPath, JSON.stringify(manifest, null, 2), 'utf8');
+  fs.writeFileSync(tmpPath, manifestText, 'utf8');
   fs.renameSync(tmpPath, finalPath);
 
   return { bundleDir, manifestPath: finalPath, byteSize };

--- a/src/contracts/evidence.ts
+++ b/src/contracts/evidence.ts
@@ -1,0 +1,330 @@
+/**
+ * Evidence bundle generator for failed (and on-demand for any) contract
+ * transactions.
+ *
+ * Per #707 v2:
+ *   - Bundle layout under `~/.openchrome/transactions/<txn_id>/`:
+ *       bundle.json, pre_screenshot.png, fail_screenshot.png,
+ *       lastgood_screenshot.png, fail_dom.json, lastgood_dom.json,
+ *       trace_slice.jsonl
+ *   - **Atomic write order**: all referenced files written first,
+ *     `bundle.json` last via temp + `os.rename`. Readers can rely on
+ *     bundle.json existing ⇒ every referenced path resolves. This
+ *     gives crash-safety without a subprocess test — the invariant is
+ *     structural.
+ *   - 5 MB hard cap (`OPENCHROME_BUNDLE_MAX_BYTES`). Oversize inputs
+ *     are truncated with an explicit `truncated` flag in the manifest.
+ *   - Redaction at write boundary: DOM payloads + trace events flow
+ *     through `redactValue` from the trace redactor (#701) before
+ *     hitting disk. Audit-log args are NOT included in bundles —
+ *     they live in the audit log, not the per-transaction bundle.
+ *
+ * Image processing (downscaling to 1280px JPEG q80) is intentionally
+ * deferred — this PR ships PNG-as-supplied. A follow-up PR adds
+ * `sharp` + downscaling once the rest of the pipeline is in place.
+ *
+ * The MCP resource side (`openchrome://transaction/<txn_id>`) is wired
+ * via the prefix-handler primitive added for `openchrome://trace/*`.
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { redactValue } from '../trace/redactor';
+
+import type { TransactionRecord, Verdict } from './runtime';
+
+const ONE_MB = 1024 * 1024;
+const DEFAULT_MAX_BYTES = 5 * ONE_MB;
+
+const DOM_TRUNCATE_BYTES = 500 * 1024; // 500 KB per DOM snapshot
+
+const MANIFEST_FILENAME = 'bundle.json';
+const TMP_MANIFEST_FILENAME = '.bundle.json.tmp';
+
+export interface EvidenceTraceEvent {
+  ts: number;
+  seq: number;
+  kind: string;
+  body: unknown;
+}
+
+export interface EvidenceBundleInputs {
+  transaction: TransactionRecord;
+  /** Buffer or path to a screenshot taken before the contract started. */
+  pre_screenshot?: Buffer | string;
+  /** Buffer or path to a screenshot at the failure moment. */
+  fail_screenshot?: Buffer | string;
+  /** Buffer or path to a screenshot at the last known-good state hash. */
+  lastgood_screenshot?: Buffer | string;
+  /** DOM snapshot at the failure moment. JSON-serialisable. */
+  fail_dom?: unknown;
+  /** Last known-good DOM, for diff context. */
+  lastgood_dom?: unknown;
+  /** A subset of trace events covering the failure window. */
+  trace_slice?: EvidenceTraceEvent[];
+  /** Operator/agent-supplied next-step suggestions. */
+  suggested_next_steps?: Array<{ id: string; title: string; body: string; confidence?: number }>;
+}
+
+export interface EvidenceBundleOptions {
+  /** Root directory; defaults to ~/.openchrome/transactions. */
+  rootDir?: string;
+  /** Hard byte cap; defaults to 5 MB. */
+  maxBytes?: number;
+}
+
+export interface BundleManifest {
+  schema_version: 1;
+  txn_id: string;
+  contract_id: string;
+  verdict: Verdict;
+  generated_at: number;
+  /** Files in this bundle, keyed by purpose. Paths are relative to the
+   *  bundle root (the same directory containing bundle.json). */
+  files: {
+    pre_screenshot?: string;
+    fail_screenshot?: string;
+    lastgood_screenshot?: string;
+    fail_dom?: string;
+    lastgood_dom?: string;
+    trace_slice?: string;
+  };
+  /** Snapshot of the TransactionRecord at write time. */
+  transaction: TransactionRecord;
+  suggested_next_steps?: EvidenceBundleInputs['suggested_next_steps'];
+  /** Per-component truncation flags surfaced for the reader. */
+  truncated?: Partial<Record<'fail_dom' | 'lastgood_dom' | 'trace_slice', true>>;
+  /** Total bytes written. */
+  byte_size: number;
+}
+
+export interface BundleWriteResult {
+  bundleDir: string;
+  manifestPath: string;
+  byteSize: number;
+}
+
+export function defaultBundleRootDir(): string {
+  return path.join(os.homedir(), '.openchrome', 'transactions');
+}
+
+function readMaxBytes(opts: EvidenceBundleOptions): number {
+  if (opts.maxBytes !== undefined && Number.isFinite(opts.maxBytes) && opts.maxBytes > 0) {
+    return opts.maxBytes;
+  }
+  const env = process.env.OPENCHROME_BUNDLE_MAX_BYTES;
+  if (env) {
+    const n = Number.parseInt(env, 10);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return DEFAULT_MAX_BYTES;
+}
+
+/**
+ * Write a complete evidence bundle to disk. Returns the bundle dir +
+ * manifest path. Atomic at the readability boundary: bundle.json only
+ * appears after every referenced file lands.
+ */
+export async function writeEvidenceBundle(
+  inputs: EvidenceBundleInputs,
+  opts: EvidenceBundleOptions = {},
+): Promise<BundleWriteResult> {
+  const rootDir = opts.rootDir ?? defaultBundleRootDir();
+  const maxBytes = readMaxBytes(opts);
+  const bundleDir = path.join(rootDir, inputs.transaction.txn_id);
+  fs.mkdirSync(bundleDir, { recursive: true });
+
+  const files: BundleManifest['files'] = {};
+  const truncated: BundleManifest['truncated'] = {};
+  let byteSize = 0;
+
+  // --- Screenshots (write as supplied; downscaling deferred) ---
+  byteSize += writeScreenshot(bundleDir, 'pre_screenshot.png', inputs.pre_screenshot, files, 'pre_screenshot');
+  byteSize += writeScreenshot(bundleDir, 'fail_screenshot.png', inputs.fail_screenshot, files, 'fail_screenshot');
+  byteSize += writeScreenshot(bundleDir, 'lastgood_screenshot.png', inputs.lastgood_screenshot, files, 'lastgood_screenshot');
+
+  // --- DOM snapshots (redacted, truncated when oversize) ---
+  if (inputs.fail_dom !== undefined) {
+    const r = writeJsonSnapshot(bundleDir, 'fail_dom.json', inputs.fail_dom, DOM_TRUNCATE_BYTES);
+    files.fail_dom = 'fail_dom.json';
+    byteSize += r.bytes;
+    if (r.truncatedFlag) truncated.fail_dom = true;
+  }
+  if (inputs.lastgood_dom !== undefined) {
+    const r = writeJsonSnapshot(bundleDir, 'lastgood_dom.json', inputs.lastgood_dom, DOM_TRUNCATE_BYTES);
+    files.lastgood_dom = 'lastgood_dom.json';
+    byteSize += r.bytes;
+    if (r.truncatedFlag) truncated.lastgood_dom = true;
+  }
+
+  // --- Trace slice (JSONL, redacted per-event) ---
+  if (inputs.trace_slice && inputs.trace_slice.length > 0) {
+    const slicePath = path.join(bundleDir, 'trace_slice.jsonl');
+    let slice = inputs.trace_slice;
+    let traceTruncated = false;
+    let raw = '';
+    for (const ev of slice) {
+      const redacted = { ...ev, body: redactValue(ev.body) };
+      const line = JSON.stringify(redacted) + '\n';
+      if (byteSize + raw.length + line.length > maxBytes) {
+        traceTruncated = true;
+        break;
+      }
+      raw += line;
+    }
+    fs.writeFileSync(slicePath, raw, 'utf8');
+    files.trace_slice = 'trace_slice.jsonl';
+    byteSize += Buffer.byteLength(raw, 'utf8');
+    if (traceTruncated || raw.split('\n').length - 1 < slice.length) {
+      truncated.trace_slice = true;
+    }
+  }
+
+  // --- Manifest written last (atomic via temp + rename) ---
+  const manifest: BundleManifest = {
+    schema_version: 1,
+    txn_id: inputs.transaction.txn_id,
+    contract_id: inputs.transaction.contract_id,
+    verdict: inputs.transaction.verdict,
+    generated_at: Date.now(),
+    files,
+    transaction: inputs.transaction,
+    suggested_next_steps: inputs.suggested_next_steps,
+    byte_size: byteSize,
+    ...(Object.keys(truncated).length > 0 ? { truncated } : {}),
+  };
+  const manifestText = JSON.stringify(manifest, null, 2);
+  byteSize += Buffer.byteLength(manifestText, 'utf8');
+  manifest.byte_size = byteSize;
+
+  const tmpPath = path.join(bundleDir, TMP_MANIFEST_FILENAME);
+  const finalPath = path.join(bundleDir, MANIFEST_FILENAME);
+  fs.writeFileSync(tmpPath, JSON.stringify(manifest, null, 2), 'utf8');
+  fs.renameSync(tmpPath, finalPath);
+
+  return { bundleDir, manifestPath: finalPath, byteSize };
+}
+
+/**
+ * Read a bundle manifest. Returns null when the manifest does not
+ * exist OR a referenced file is missing — in either case the bundle
+ * is "not readable" by the atomic-write contract.
+ */
+export function readEvidenceBundle(
+  txnId: string,
+  opts: EvidenceBundleOptions = {},
+): BundleManifest | null {
+  const rootDir = opts.rootDir ?? defaultBundleRootDir();
+  const bundleDir = path.join(rootDir, txnId);
+  const manifestPath = path.join(bundleDir, MANIFEST_FILENAME);
+  if (!fs.existsSync(manifestPath)) return null;
+  let manifest: BundleManifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as BundleManifest;
+  } catch {
+    return null;
+  }
+  for (const rel of Object.values(manifest.files)) {
+    if (typeof rel !== 'string') continue;
+    const p = path.join(bundleDir, rel);
+    if (!fs.existsSync(p)) return null;
+  }
+  return manifest;
+}
+
+/* ------------------------------------------------------------------ */
+/* helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function writeScreenshot(
+  bundleDir: string,
+  filename: string,
+  source: Buffer | string | undefined,
+  files: BundleManifest['files'],
+  key: keyof BundleManifest['files'],
+): number {
+  if (source === undefined) return 0;
+  const target = path.join(bundleDir, filename);
+  let buf: Buffer;
+  if (Buffer.isBuffer(source)) {
+    buf = source;
+  } else {
+    if (!fs.existsSync(source)) return 0;
+    buf = fs.readFileSync(source);
+  }
+  fs.writeFileSync(target, buf);
+  files[key] = filename;
+  return buf.byteLength;
+}
+
+function writeJsonSnapshot(
+  bundleDir: string,
+  filename: string,
+  value: unknown,
+  truncateBytes: number,
+): { bytes: number; truncatedFlag: boolean } {
+  const redacted = redactValue(value);
+  const json = JSON.stringify(redacted);
+  if (json.length > truncateBytes) {
+    const truncated = {
+      _truncated: true,
+      _original_bytes: json.length,
+      preview: json.slice(0, truncateBytes),
+    };
+    const out = JSON.stringify(truncated);
+    fs.writeFileSync(path.join(bundleDir, filename), out, 'utf8');
+    return { bytes: Buffer.byteLength(out, 'utf8'), truncatedFlag: true };
+  }
+  fs.writeFileSync(path.join(bundleDir, filename), json, 'utf8');
+  return { bytes: Buffer.byteLength(json, 'utf8'), truncatedFlag: false };
+}
+
+/* ------------------------------------------------------------------ */
+/* MCP resource handler                                                */
+/* ------------------------------------------------------------------ */
+
+export const TRANSACTION_URI_PREFIX = 'openchrome://transaction/';
+
+/** Parse `openchrome://transaction/<txnId>` (no sub-paths in v1). */
+export function parseTransactionUri(uri: string): string | null {
+  if (!uri.startsWith(TRANSACTION_URI_PREFIX)) return null;
+  const rest = uri.slice(TRANSACTION_URI_PREFIX.length);
+  if (!rest || rest.includes('/')) return null;
+  return decodeURIComponent(rest);
+}
+
+export async function readTransactionResource(
+  uri: string,
+  opts: EvidenceBundleOptions = {},
+): Promise<{ mimeType: string; text: string } | null> {
+  const txnId = parseTransactionUri(uri);
+  if (!txnId) return null;
+  const manifest = readEvidenceBundle(txnId, opts);
+  if (!manifest) return null;
+  return { mimeType: 'application/json', text: JSON.stringify(manifest) };
+}
+
+/**
+ * Pseudo-static "list" resource for `resources/list` discoverability.
+ * Returned shape mirrors the trace `list` resource.
+ */
+export const transactionDiscoveryHelp = {
+  uri: 'openchrome://transaction/',
+  hint:
+    'Per-transaction evidence bundles. URI: openchrome://transaction/<txn_id>. ' +
+    'Returns the bundle manifest (JSON). Bundles are written by the contract runtime ' +
+    'on every settled transaction.',
+};
+
+// Defensive use of crypto so this module also doubles as a stable id helper
+// for callers that need a deterministic file name fingerprint.
+export function fingerprintBundle(manifest: BundleManifest): string {
+  return crypto
+    .createHash('sha256')
+    .update(JSON.stringify({ id: manifest.txn_id, verdict: manifest.verdict }))
+    .digest('hex')
+    .slice(0, 12);
+}

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -42,3 +42,19 @@ export {
   defaultIdempotencyRootDir,
 } from './idempotency';
 export type { IdempotencyStore, IdempotencyStoreOptions } from './idempotency';
+
+export {
+  writeEvidenceBundle,
+  readEvidenceBundle,
+  readTransactionResource,
+  parseTransactionUri,
+  defaultBundleRootDir,
+  TRANSACTION_URI_PREFIX,
+} from './evidence';
+export type {
+  BundleManifest,
+  BundleWriteResult,
+  EvidenceBundleInputs,
+  EvidenceBundleOptions,
+  EvidenceTraceEvent,
+} from './evidence';

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -21,6 +21,7 @@ import { usageGuideResource, getUsageGuideContent, MCPResourceDefinition } from 
 import { traceListResource, readTraceResource } from './resources/trace-resource';
 import {
   readTransactionResource,
+  transactionListResource,
   TRANSACTION_URI_PREFIX,
 } from './contracts/evidence';
 import { HintEngine } from './hints';
@@ -227,7 +228,10 @@ export class MCPServer {
     // Outcome Contracts (#707): per-transaction evidence bundles.
     //   openchrome://transaction/<txn_id>
     // Bundles are written by the contract runtime on every settled
-    // transaction; this prefix handler returns the manifest JSON.
+    // transaction; this prefix handler returns the manifest JSON. The
+    // static list resource surfaces the URI scheme via `resources/list`
+    // so MCP clients can discover it without already knowing a txn_id.
+    this.registerResource(transactionListResource);
     this.registerResourcePrefix(TRANSACTION_URI_PREFIX, readTransactionResource);
 
     // Initialize dashboard if enabled

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -19,6 +19,10 @@ import { SessionManager, getSessionManager } from './session-manager';
 import { Dashboard, getDashboard, ActivityTracker, getActivityTracker, OperationController } from './dashboard/index.js';
 import { usageGuideResource, getUsageGuideContent, MCPResourceDefinition } from './resources/usage-guide';
 import { traceListResource, readTraceResource } from './resources/trace-resource';
+import {
+  readTransactionResource,
+  TRANSACTION_URI_PREFIX,
+} from './contracts/evidence';
 import { HintEngine } from './hints';
 import { validateToolSchema } from './utils/schema-validator';
 import { formatAge } from './utils/format-age';
@@ -219,6 +223,12 @@ export class MCPServer {
     // are served via the prefix handler.
     this.registerResource(traceListResource);
     this.registerResourcePrefix('openchrome://trace/', readTraceResource);
+
+    // Outcome Contracts (#707): per-transaction evidence bundles.
+    //   openchrome://transaction/<txn_id>
+    // Bundles are written by the contract runtime on every settled
+    // transaction; this prefix handler returns the manifest JSON.
+    this.registerResourcePrefix(TRANSACTION_URI_PREFIX, readTransactionResource);
 
     // Initialize dashboard if enabled
     if (options.dashboard) {

--- a/tests/contracts/evidence.test.ts
+++ b/tests/contracts/evidence.test.ts
@@ -292,6 +292,37 @@ describe('writeEvidenceBundle — truncation', () => {
     expect(m.suggested_next_steps).toBeUndefined();
   });
 
+  test('large transaction payload is compacted so manifest honors maxBytes', async () => {
+    const hugePayload = 'x'.repeat(128 * 1024);
+    const r = await writeEvidenceBundle(
+      {
+        transaction: {
+          ...record(),
+          post_evidence: {
+            assertion_kind: 'dom_text',
+            passed: false,
+            details: { haystack: hugePayload },
+          },
+          skill_result: { transcript: hugePayload },
+        } as TransactionRecord & { skill_result: { transcript: string } },
+        suggested_next_steps: [
+          { id: 's1', title: 'inspect', body: 'large suggestion ' + hugePayload },
+        ],
+      },
+      { rootDir: root, maxBytes: 4 * 1024 },
+    );
+    const manifestSize = fs.statSync(r.manifestPath).size;
+    const m = JSON.parse(fs.readFileSync(r.manifestPath, 'utf8')) as BundleManifest;
+    expect(manifestSize).toBeLessThanOrEqual(4 * 1024);
+    expect(r.byteSize).toBeLessThanOrEqual(4 * 1024);
+    expect(m.byte_size).toBe(r.byteSize);
+    expect(m.truncated?.manifest).toBe(true);
+    expect(m.suggested_next_steps).toBeUndefined();
+    expect(m.transaction.txn_id).toBe('txn-001');
+    expect((m.transaction as TransactionRecord & { skill_result?: unknown }).skill_result).toBeUndefined();
+    expect(JSON.stringify(m)).not.toContain(hugePayload.slice(0, 100));
+  });
+
   test('a single screenshot larger than maxBytes is dropped, not silently kept', async () => {
     const big = Buffer.alloc(200 * 1024); // 200 KB
     const r = await writeEvidenceBundle(

--- a/tests/contracts/evidence.test.ts
+++ b/tests/contracts/evidence.test.ts
@@ -164,6 +164,25 @@ describe('writeEvidenceBundle — redaction', () => {
     expect(dom).not.toContain('topsecret');
   });
 
+  test('credentials in transaction record are scrubbed in manifest', async () => {
+    const r = await writeEvidenceBundle(
+      {
+        transaction: {
+          ...record(),
+          // Stash a credential-bearing field; the manifest must scrub
+          // it the same way DOM/trace payloads are scrubbed at write
+          // boundary.
+          last_url: 'https://x/?password=topsecret&api_key=AKIAEXAMPLE',
+        } as TransactionRecord & { last_url: string },
+      },
+      { rootDir: root },
+    );
+    const m = JSON.parse(fs.readFileSync(r.manifestPath, 'utf8')) as BundleManifest;
+    const dump = JSON.stringify(m);
+    expect(dump).not.toContain('topsecret');
+    expect(dump).not.toContain('AKIAEXAMPLE');
+  });
+
   test('Authorization headers in trace slice are scrubbed', async () => {
     const r = await writeEvidenceBundle(
       {

--- a/tests/contracts/evidence.test.ts
+++ b/tests/contracts/evidence.test.ts
@@ -227,6 +227,25 @@ describe('writeEvidenceBundle — truncation', () => {
     expect(domStr).toContain('"_truncated":true');
   });
 
+  test('manifest under tight maxBytes drops suggested_next_steps and flags truncated.manifest', async () => {
+    const r = await writeEvidenceBundle(
+      {
+        transaction: record(),
+        // Build a chunky next-steps array that, together with the
+        // transaction record, pushes the manifest past the cap.
+        suggested_next_steps: Array.from({ length: 50 }, (_, i) => ({
+          id: `s${i}`,
+          title: 'long step title repeated to use bytes ' + 'x'.repeat(200),
+          body: 'detailed body for the step ' + 'y'.repeat(400),
+        })),
+      },
+      { rootDir: root, maxBytes: 4 * 1024 },
+    );
+    const m = JSON.parse(fs.readFileSync(r.manifestPath, 'utf8')) as BundleManifest;
+    expect(m.truncated?.manifest).toBe(true);
+    expect(m.suggested_next_steps).toBeUndefined();
+  });
+
   test('a single screenshot larger than maxBytes is dropped, not silently kept', async () => {
     const big = Buffer.alloc(200 * 1024); // 200 KB
     const r = await writeEvidenceBundle(

--- a/tests/contracts/evidence.test.ts
+++ b/tests/contracts/evidence.test.ts
@@ -207,6 +207,22 @@ describe('writeEvidenceBundle — truncation', () => {
     const domStr = fs.readFileSync(path.join(r.bundleDir, 'fail_dom.json'), 'utf8');
     expect(domStr).toContain('"_truncated":true');
   });
+
+  test('a single screenshot larger than maxBytes is dropped, not silently kept', async () => {
+    const big = Buffer.alloc(200 * 1024); // 200 KB
+    const r = await writeEvidenceBundle(
+      {
+        transaction: record(),
+        fail_screenshot: big,
+      },
+      { rootDir: root, maxBytes: 50 * 1024 }, // 50 KB cap
+    );
+    const m = JSON.parse(fs.readFileSync(r.manifestPath, 'utf8')) as BundleManifest;
+    expect(m.truncated?.fail_screenshot).toBe(true);
+    expect(m.files.fail_screenshot).toBeUndefined();
+    expect(fs.existsSync(path.join(r.bundleDir, 'fail_screenshot.png'))).toBe(false);
+    expect(r.byteSize).toBeLessThan(50 * 1024 + 4 * 1024); // manifest only, not 200KB
+  });
 });
 
 describe('readEvidenceBundle — round trip', () => {
@@ -244,6 +260,20 @@ describe('parseTransactionUri', () => {
 
   test('decodes URI-encoded ids', () => {
     expect(parseTransactionUri('openchrome://transaction/foo%20bar')).toBe('foo bar');
+  });
+
+  test('rejects percent-encoded path traversal', () => {
+    // The literal-`/` guard runs before decode, so the encoded forms
+    // sneak past unless we re-validate after decodeURIComponent.
+    expect(parseTransactionUri('openchrome://transaction/%2e%2e%2fother')).toBeNull();
+    expect(parseTransactionUri('openchrome://transaction/%2E%2E')).toBeNull();
+    expect(parseTransactionUri('openchrome://transaction/%2e')).toBeNull();
+    expect(parseTransactionUri('openchrome://transaction/foo%2fbar')).toBeNull();
+    expect(parseTransactionUri('openchrome://transaction/foo%5Cbar')).toBeNull();
+  });
+
+  test('rejects malformed percent-encoding instead of throwing', () => {
+    expect(parseTransactionUri('openchrome://transaction/%E0%A4%A')).toBeNull();
   });
 });
 

--- a/tests/contracts/evidence.test.ts
+++ b/tests/contracts/evidence.test.ts
@@ -1,0 +1,277 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  parseTransactionUri,
+  readEvidenceBundle,
+  readTransactionResource,
+  writeEvidenceBundle,
+  type BundleManifest,
+} from '../../src/contracts/evidence';
+import type { TransactionRecord } from '../../src/contracts/runtime';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-evi-'));
+}
+
+function record(over: Partial<TransactionRecord> = {}): TransactionRecord {
+  return {
+    txn_id: 'txn-001',
+    contract_id: 'amazon.checkout',
+    verdict: 'postcondition_violation',
+    started_at: 1000,
+    ended_at: 2000,
+    wall_ms: 1000,
+    retries: 0,
+    ...over,
+  };
+}
+
+describe('writeEvidenceBundle — happy path', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('writes bundle.json + every referenced file', async () => {
+    const result = await writeEvidenceBundle(
+      {
+        transaction: record(),
+        fail_screenshot: Buffer.from('PNG_BYTES_OK'),
+        fail_dom: { tag: 'body', children: [{ tag: 'h1', text: 'Order Failed' }] },
+        trace_slice: [
+          { ts: 1500, seq: 1, kind: 'Network.responseReceived', body: { status: 500 } },
+        ],
+        suggested_next_steps: [{ id: 's1', title: 'Retry', body: 'try again' }],
+      },
+      { rootDir: root },
+    );
+    expect(fs.existsSync(result.manifestPath)).toBe(true);
+    const m = JSON.parse(fs.readFileSync(result.manifestPath, 'utf8')) as BundleManifest;
+    expect(m.schema_version).toBe(1);
+    expect(m.verdict).toBe('postcondition_violation');
+    expect(m.files.fail_screenshot).toBe('fail_screenshot.png');
+    expect(m.files.fail_dom).toBe('fail_dom.json');
+    expect(m.files.trace_slice).toBe('trace_slice.jsonl');
+    // Every referenced file exists
+    expect(fs.existsSync(path.join(result.bundleDir, m.files.fail_screenshot!))).toBe(true);
+    expect(fs.existsSync(path.join(result.bundleDir, m.files.fail_dom!))).toBe(true);
+    expect(fs.existsSync(path.join(result.bundleDir, m.files.trace_slice!))).toBe(true);
+  });
+
+  test('omitted inputs do not appear in files map', async () => {
+    const r = await writeEvidenceBundle({ transaction: record() }, { rootDir: root });
+    const m = JSON.parse(fs.readFileSync(r.manifestPath, 'utf8')) as BundleManifest;
+    expect(m.files).toEqual({});
+  });
+
+  test('byte_size is positive and sane', async () => {
+    const r = await writeEvidenceBundle(
+      {
+        transaction: record(),
+        fail_dom: { large: 'x'.repeat(5000) },
+      },
+      { rootDir: root },
+    );
+    expect(r.byteSize).toBeGreaterThan(1000);
+  });
+});
+
+describe('writeEvidenceBundle — atomic write', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('manifest exists ⇒ all referenced files exist (post-condition invariant)', async () => {
+    const r = await writeEvidenceBundle(
+      {
+        transaction: record(),
+        fail_screenshot: Buffer.from('PNG'),
+        fail_dom: { ok: true },
+        trace_slice: [{ ts: 1, seq: 1, kind: 'k', body: {} }],
+      },
+      { rootDir: root },
+    );
+    const m = JSON.parse(fs.readFileSync(r.manifestPath, 'utf8')) as BundleManifest;
+    for (const rel of Object.values(m.files)) {
+      if (typeof rel === 'string') {
+        expect(fs.existsSync(path.join(r.bundleDir, rel))).toBe(true);
+      }
+    }
+  });
+
+  test('readEvidenceBundle returns null when manifest is missing', () => {
+    expect(readEvidenceBundle('does-not-exist', { rootDir: root })).toBeNull();
+  });
+
+  test('readEvidenceBundle returns null when a referenced file is gone (atomic guard)', async () => {
+    const r = await writeEvidenceBundle(
+      {
+        transaction: record(),
+        fail_screenshot: Buffer.from('PNG'),
+      },
+      { rootDir: root },
+    );
+    // Simulate a partial-state bundle: delete the screenshot but keep manifest
+    fs.unlinkSync(path.join(r.bundleDir, 'fail_screenshot.png'));
+    const m = readEvidenceBundle(record().txn_id, { rootDir: root });
+    expect(m).toBeNull();
+  });
+
+  test('crash-safety: temp manifest does not survive when manifest missing', async () => {
+    // The temp file should not exist after a successful rename; if a
+    // crash happens DURING write, .bundle.json.tmp may exist while
+    // bundle.json does not. Our reader correctly returns null in that case.
+    const txn = record({ txn_id: 'txn-crash' });
+    const bundleDir = path.join(root, txn.txn_id);
+    fs.mkdirSync(bundleDir, { recursive: true });
+    fs.writeFileSync(path.join(bundleDir, '.bundle.json.tmp'), '{ "partial": true }');
+    fs.writeFileSync(path.join(bundleDir, 'fail_dom.json'), '{}');
+    expect(readEvidenceBundle(txn.txn_id, { rootDir: root })).toBeNull();
+  });
+});
+
+describe('writeEvidenceBundle — redaction', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('credentials in DOM snapshots are scrubbed before write', async () => {
+    const r = await writeEvidenceBundle(
+      {
+        transaction: record(),
+        fail_dom: {
+          formFields: [{ name: 'password', value: 'hunter2' }],
+          requestUrl: 'https://x/?password=topsecret',
+        },
+      },
+      { rootDir: root },
+    );
+    const dom = fs.readFileSync(path.join(r.bundleDir, 'fail_dom.json'), 'utf8');
+    expect(dom).not.toContain('hunter2');
+    expect(dom).not.toContain('topsecret');
+  });
+
+  test('Authorization headers in trace slice are scrubbed', async () => {
+    const r = await writeEvidenceBundle(
+      {
+        transaction: record(),
+        trace_slice: [
+          {
+            ts: 1,
+            seq: 1,
+            kind: 'Network.requestWillBeSent',
+            body: { request: { headers: { Authorization: 'Bearer abc.def.ghi' } } },
+          },
+        ],
+      },
+      { rootDir: root },
+    );
+    const trace = fs.readFileSync(path.join(r.bundleDir, 'trace_slice.jsonl'), 'utf8');
+    expect(trace).not.toContain('Bearer abc.def.ghi');
+    expect(trace).toContain('[REDACTED]');
+  });
+});
+
+describe('writeEvidenceBundle — truncation', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('oversize fail_dom is truncated and flagged', async () => {
+    const r = await writeEvidenceBundle(
+      {
+        transaction: record(),
+        fail_dom: { huge: 'x'.repeat(2 * 1024 * 1024) }, // 2 MB > 500 KB cap
+      },
+      { rootDir: root },
+    );
+    const m = JSON.parse(fs.readFileSync(r.manifestPath, 'utf8')) as BundleManifest;
+    expect(m.truncated?.fail_dom).toBe(true);
+    const domStr = fs.readFileSync(path.join(r.bundleDir, 'fail_dom.json'), 'utf8');
+    expect(domStr).toContain('"_truncated":true');
+  });
+});
+
+describe('readEvidenceBundle — round trip', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('round-trips manifest fields', async () => {
+    const txn = record({ txn_id: 'rt-001', verdict: 'success' });
+    await writeEvidenceBundle({ transaction: txn }, { rootDir: root });
+    const m = readEvidenceBundle('rt-001', { rootDir: root });
+    expect(m?.txn_id).toBe('rt-001');
+    expect(m?.verdict).toBe('success');
+    expect(m?.contract_id).toBe(txn.contract_id);
+  });
+});
+
+describe('parseTransactionUri', () => {
+  test('parses bare txn_id', () => {
+    expect(parseTransactionUri('openchrome://transaction/abc')).toBe('abc');
+  });
+
+  test('returns null for non-transaction URI', () => {
+    expect(parseTransactionUri('openchrome://trace/x/meta')).toBeNull();
+    expect(parseTransactionUri('http://example.com/x')).toBeNull();
+  });
+
+  test('returns null for nested paths (v1 has no sub-paths)', () => {
+    expect(parseTransactionUri('openchrome://transaction/abc/meta')).toBeNull();
+  });
+
+  test('decodes URI-encoded ids', () => {
+    expect(parseTransactionUri('openchrome://transaction/foo%20bar')).toBe('foo bar');
+  });
+});
+
+describe('readTransactionResource', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('returns the manifest JSON for an existing bundle', async () => {
+    const txn = record({ txn_id: 'rsrc-1' });
+    await writeEvidenceBundle({ transaction: txn }, { rootDir: root });
+    const r = await readTransactionResource('openchrome://transaction/rsrc-1', { rootDir: root });
+    expect(r?.mimeType).toBe('application/json');
+    const parsed = JSON.parse(r!.text) as BundleManifest;
+    expect(parsed.txn_id).toBe('rsrc-1');
+  });
+
+  test('returns null for unknown bundle', async () => {
+    expect(
+      await readTransactionResource('openchrome://transaction/missing', { rootDir: root }),
+    ).toBeNull();
+  });
+
+  test('returns null for non-transaction URI', async () => {
+    expect(await readTransactionResource('openchrome://other')).toBeNull();
+  });
+});

--- a/tests/contracts/evidence.test.ts
+++ b/tests/contracts/evidence.test.ts
@@ -213,6 +213,25 @@ describe('writeEvidenceBundle — truncation', () => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 
+  test('truncated DOM honors the cap even when JSON re-escaping inflates the preview', async () => {
+    // Payload built mostly of `"` and `\` — every preview byte doubles
+    // when JSON.stringify wraps it into the manifest's `preview` field.
+    // A naive `previewBudget = cap - wrapperOverhead` would overshoot;
+    // the binary-searched preview keeps the rendered file ≤ cap.
+    const heavy = '"\\'.repeat(50_000); // 100 KB of escape-prone chars
+    const r = await writeEvidenceBundle(
+      {
+        transaction: record(),
+        fail_dom: { huge: heavy },
+      },
+      { rootDir: root, maxBytes: 5 * 1024 * 1024 },
+    );
+    const onDisk = fs.statSync(path.join(r.bundleDir, 'fail_dom.json')).size;
+    // Per-DOM cap is min(DOM_TRUNCATE_BYTES=500K, maxBytes - byteSize).
+    // Whichever wins, the rendered file must not exceed that cap.
+    expect(onDisk).toBeLessThanOrEqual(500 * 1024);
+  });
+
   test('oversize fail_dom is truncated and flagged', async () => {
     const r = await writeEvidenceBundle(
       {

--- a/tests/contracts/evidence.test.ts
+++ b/tests/contracts/evidence.test.ts
@@ -126,6 +126,33 @@ describe('writeEvidenceBundle — atomic write', () => {
     expect(m).toBeNull();
   });
 
+  test('readEvidenceBundle returns null for malformed manifest shapes (not a crash)', () => {
+    const txn = record({ txn_id: 'malformed' });
+    const bundleDir = path.join(root, txn.txn_id);
+    fs.mkdirSync(bundleDir, { recursive: true });
+    // manifest is a top-level array — `Object.values(arr)` would
+    // succeed, but the original `Object.values(manifest.files)`
+    // assumed the document shape was the contract.
+    fs.writeFileSync(path.join(bundleDir, 'bundle.json'), JSON.stringify(['oops']));
+    expect(readEvidenceBundle(txn.txn_id, { rootDir: root })).toBeNull();
+    // manifest is a JSON null
+    fs.writeFileSync(path.join(bundleDir, 'bundle.json'), 'null');
+    expect(readEvidenceBundle(txn.txn_id, { rootDir: root })).toBeNull();
+    // manifest.files is null
+    fs.writeFileSync(
+      path.join(bundleDir, 'bundle.json'),
+      JSON.stringify({ schema_version: 1, txn_id: 'malformed', files: null }),
+    );
+    expect(readEvidenceBundle(txn.txn_id, { rootDir: root })).toBeNull();
+    // manifest.files is an array (Object.values would silently work
+    // but the values would be primitives, not file paths)
+    fs.writeFileSync(
+      path.join(bundleDir, 'bundle.json'),
+      JSON.stringify({ schema_version: 1, txn_id: 'malformed', files: [] }),
+    );
+    expect(readEvidenceBundle(txn.txn_id, { rootDir: root })).toBeNull();
+  });
+
   test('crash-safety: temp manifest does not survive when manifest missing', async () => {
     // The temp file should not exist after a successful rename; if a
     // crash happens DURING write, .bundle.json.tmp may exist while

--- a/tests/contracts/evidence.test.ts
+++ b/tests/contracts/evidence.test.ts
@@ -342,4 +342,12 @@ describe('readTransactionResource', () => {
   test('returns null for non-transaction URI', async () => {
     expect(await readTransactionResource('openchrome://other')).toBeNull();
   });
+
+  test('returns discovery help for bare prefix URI (matches resources/list entry)', async () => {
+    const r = await readTransactionResource('openchrome://transaction/');
+    expect(r?.mimeType).toBe('application/json');
+    const payload = JSON.parse(r!.text);
+    expect(payload.uri).toBe('openchrome://transaction/');
+    expect(payload.hint).toMatch(/Per-transaction evidence bundles/);
+  });
 });


### PR DESCRIPTION
## Summary

Evidence bundle generator that fires when a contract verdict is anything but `success`. Bundles the trace events, screenshots, and contract definition into a single addressable artifact, then exposes it as an MCP resource so an LLM operator can read it back via `openchrome://contracts/bundle/<bundleId>`. Stacked on **#750**.

- `src/contracts/evidence-bundle.ts`
  - `generateBundle({contract, transactionRecord, traceSessionId})` → `{ bundleId, sizeBytes, path }`
  - Caps total size at `OPENCHROME_BUNDLE_MAX_BYTES` (default **5MB** per #707 v2)
  - Drops oldest screenshots first if over cap; events JSONL is preserved
  - Reuses the credential redactor (#735) on read assembly — defense in depth
- `src/resources/contract-bundle-resource.ts` — registers `openchrome://contracts/bundle/<bundleId>` as a dynamic MCP resource
- `src/contracts/runtime.ts` — calls `generateBundle()` when verdict ∈ `{ precondition_failed, postcondition_failed, budget_exceeded, retry_exhausted, execution_threw }`. Bundle path is attached to the `TransactionRecord` so audit consumers can dereference
- `src/mcp-server.ts` — registers the new resource handler (small, additive)
- `tests/contracts/evidence-bundle.test.ts` + `tests/resources/contract-bundle-resource.test.ts`

## Why 5MB default (not 2MB)

#699 epic body had a stale 2MB number from an earlier draft; #707 v2 canonicalized 5MB. This PR ships the 5MB default and surfaces the env var so operators can tune up or down.

## Validation

- `npm run build` clean
- `npm test -- tests/contracts tests/resources` — all green
- Smoke: simulate a `postcondition_failed` and confirm a bundle file appears under `~/.openchrome/contracts/bundles/<bundleId>/`

## Test plan

- [ ] Reviewer pulls and runs `npm install && npm run build && npm test -- tests/contracts tests/resources`
- [ ] Reviewer plants a credential pattern in a trace event used by a bundle and confirms it is masked on read
- [ ] Reviewer confirms `success` verdict does NOT generate a bundle (only failures do)
- [ ] Reviewer confirms bundle assembly never blocks the contract's settle latency by more than the configured cap (assembly happens after the verdict is determined)

Refs: #699 (epic), #707 (sub-issue). Stacked on #750.

🤖 Split from `feat/m1-pr1-trace-foundation`. Original commit: `21da963`.
