### PR TITLE
feat(contracts): beforeIrreversibleAction hook for critical contracts

### DIFF
--- a/src/contracts/handoff/index.ts
+++ b/src/contracts/handoff/index.ts
@@ -1,6 +1,8 @@
 /**
- * Handoff subsystem barrel — token + banner + manager. Persistence and
- * keychain integration land in PR-15.
+ * Handoff subsystem barrel — token + banner + manager + persistence.
+ * OS-keychain bridges (macOS Keychain, Windows Credential Manager) ride
+ * a separate follow-up; the PersistenceAdapter interface is the
+ * extension point.
  */
 
 export {
@@ -20,3 +22,13 @@ export {
   type HandoffManagerOptions,
   type ResumeResult,
 } from './manager';
+
+export {
+  EncryptedFilePersistence,
+  PlaintextFilePersistence,
+  autoSelectHandoffPersistence,
+  defaultHandoffRootDir,
+  type EncryptedFilePersistenceOptions,
+  type FilePersistenceOptions,
+  type PersistenceAdapter,
+} from './persistence';

--- a/src/contracts/handoff/manager.ts
+++ b/src/contracts/handoff/manager.ts
@@ -13,6 +13,7 @@
  * will land in PR-15 and slot in via the same public API.
  */
 
+import type { PersistenceAdapter } from './persistence';
 import { generateHandoffToken } from './token';
 
 export type HandoffEscalationReason =
@@ -58,6 +59,13 @@ export interface HandoffManagerOptions {
   maxPerTxn?: number;
   /** Test hook: clock. */
   now?: () => number;
+  /**
+   * Optional persistence adapter (PR-15). When supplied, the manager
+   * loads previously-stored records on construction and persists after
+   * every mutation. When omitted, behavior is identical to PR-14 —
+   * fully in-memory, lost on process restart.
+   */
+  persistence?: PersistenceAdapter;
 }
 
 const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
@@ -86,6 +94,7 @@ export class HandoffManager {
   private readonly timeoutMs: number;
   private readonly maxPerTxn: number;
   private readonly now: () => number;
+  private readonly persistence?: PersistenceAdapter;
   /** Map<txn_id, HandoffRecord>. The latest attempt wins. */
   private readonly active = new Map<string, HandoffRecord>();
   /** attempt counter per txn so we can refuse a 4th call. */
@@ -95,6 +104,25 @@ export class HandoffManager {
     this.timeoutMs = opts.timeoutMs ?? envInt('OPENCHROME_HANDOFF_TIMEOUT_MS', DEFAULT_TIMEOUT_MS);
     this.maxPerTxn = opts.maxPerTxn ?? envInt('OPENCHROME_HANDOFF_MAX_PER_TXN', DEFAULT_MAX_PER_TXN);
     this.now = opts.now ?? Date.now;
+    this.persistence = opts.persistence;
+    // Restore prior state — pending handoffs whose deadline still lies
+    // ahead are resumable; everything else stays as a record so we can
+    // honor the per-txn cap across restarts.
+    if (this.persistence) {
+      for (const r of this.persistence.loadAll()) {
+        this.active.set(r.txn_id, r);
+        this.attempts.set(r.txn_id, Math.max(this.attempts.get(r.txn_id) ?? 0, r.attempt));
+      }
+    }
+  }
+
+  private flush(): void {
+    if (!this.persistence) return;
+    try {
+      this.persistence.saveAll([...this.active.values()]);
+    } catch {
+      // best-effort; in-memory state stays consistent regardless
+    }
   }
 
   /**
@@ -124,6 +152,7 @@ export class HandoffManager {
     };
     this.active.set(args.txn_id, record);
     this.attempts.set(args.txn_id, attempt);
+    this.flush();
     return record;
   }
 
@@ -159,6 +188,7 @@ export class HandoffManager {
     }
     rec.status = 'resumed';
     rec.resumed_at = this.now();
+    this.flush();
     return { ok: true, record: rec };
   }
 
@@ -168,6 +198,7 @@ export class HandoffManager {
     if (!rec) return undefined;
     if (rec.status === 'pending') {
       rec.status = 'aborted';
+      this.flush();
     }
     return rec;
   }
@@ -191,6 +222,7 @@ export class HandoffManager {
         purged += 1;
       }
     }
+    if (purged > 0) this.flush();
     return purged;
   }
 
@@ -199,9 +231,16 @@ export class HandoffManager {
     return [...this.active.values()];
   }
 
-  /** Test hook: drop everything. */
+  /** Test hook: drop everything (in-memory + persisted). */
   reset(): void {
     this.active.clear();
     this.attempts.clear();
+    if (this.persistence) {
+      try {
+        this.persistence.clear();
+      } catch {
+        // ignore
+      }
+    }
   }
 }

--- a/src/contracts/handoff/persistence.ts
+++ b/src/contracts/handoff/persistence.ts
@@ -1,0 +1,254 @@
+/**
+ * Persistence adapters for the handoff manager.
+ *
+ * Per #708 v2: handoff state at rest must survive a process restart so
+ * a long-lived 2FA challenge does not vaporize when the user
+ * accidentally Ctrl-C's the harness. The wire format is JSON; the
+ * primary at-rest concern is **token confidentiality** — a leaked
+ * token grants single-use authority to resume an in-flight transaction.
+ *
+ * Three confidentiality tiers (caller picks via constructor):
+ *
+ *   PlaintextFilePersistence      — JSON on disk at mode 0o600. Use only
+ *                                   on dev machines where you trust the
+ *                                   filesystem.
+ *
+ *   EncryptedFilePersistence(key) — AES-256-GCM with the supplied 32-
+ *                                   byte key. Used on Linux (keychain
+ *                                   not standardized) and as a portable
+ *                                   default. Key may come from
+ *                                   OPENCHROME_HANDOFF_KEY (hex/base64).
+ *
+ *   In-memory subclass            — manager spawned without persistence
+ *                                   keeps the original in-memory
+ *                                   semantics; persistence is opt-in.
+ *
+ * macOS Keychain / Windows Credential Manager bridges are intentionally
+ * scoped to a follow-up — they're external-CLI integrations with
+ * platform-specific failure modes, easier to add behind the same
+ * `PersistenceAdapter` interface once the Linux baseline lands.
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type { HandoffRecord } from './manager';
+
+const FILENAME = 'handoff.json';
+
+export interface PersistenceAdapter {
+  /** Read all stored records. Returns [] for a fresh install. */
+  loadAll(): HandoffRecord[];
+  /** Persist the full record set atomically. Caller deduplicates. */
+  saveAll(records: HandoffRecord[]): void;
+  /** Erase persisted state. Best-effort. */
+  clear(): void;
+}
+
+export interface FilePersistenceOptions {
+  rootDir?: string;
+}
+
+export function defaultHandoffRootDir(): string {
+  return path.join(os.homedir(), '.openchrome', 'transactions');
+}
+
+function pathFor(rootDir: string): string {
+  return path.join(rootDir, FILENAME);
+}
+
+function writeAtomic(target: string, body: string | Buffer): void {
+  const tmp = target + '.tmp';
+  fs.writeFileSync(tmp, body, { mode: 0o600 });
+  fs.renameSync(tmp, target);
+}
+
+/* ------------------------------------------------------------------ */
+/* PlaintextFilePersistence                                            */
+/* ------------------------------------------------------------------ */
+
+export class PlaintextFilePersistence implements PersistenceAdapter {
+  private readonly target: string;
+
+  constructor(opts: FilePersistenceOptions = {}) {
+    const root = opts.rootDir ?? defaultHandoffRootDir();
+    fs.mkdirSync(root, { recursive: true });
+    this.target = pathFor(root);
+  }
+
+  loadAll(): HandoffRecord[] {
+    if (!fs.existsSync(this.target)) return [];
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.target, 'utf8')) as { records?: unknown };
+      if (!Array.isArray(parsed.records)) return [];
+      return parsed.records.filter((r): r is HandoffRecord => isRecordShape(r));
+    } catch {
+      return [];
+    }
+  }
+
+  saveAll(records: HandoffRecord[]): void {
+    writeAtomic(this.target, JSON.stringify({ records }, null, 2));
+  }
+
+  clear(): void {
+    try {
+      fs.unlinkSync(this.target);
+    } catch {
+      // already gone — ok
+    }
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* EncryptedFilePersistence (AES-256-GCM)                              */
+/* ------------------------------------------------------------------ */
+
+const AES_ALGORITHM = 'aes-256-gcm';
+const IV_BYTES = 12;
+const TAG_BYTES = 16;
+const KEY_BYTES = 32;
+
+export interface EncryptedFilePersistenceOptions extends FilePersistenceOptions {
+  /** 32-byte key. Pass Buffer of length 32, or omit and supply via env. */
+  key?: Buffer;
+  /** Env var to read the key from when `key` is omitted. */
+  keyEnvVar?: string;
+}
+
+export class EncryptedFilePersistence implements PersistenceAdapter {
+  private readonly target: string;
+  private readonly key: Buffer;
+
+  constructor(opts: EncryptedFilePersistenceOptions = {}) {
+    const root = opts.rootDir ?? defaultHandoffRootDir();
+    fs.mkdirSync(root, { recursive: true });
+    this.target = pathFor(root);
+    this.key = resolveKey(opts);
+  }
+
+  loadAll(): HandoffRecord[] {
+    if (!fs.existsSync(this.target)) return [];
+    try {
+      const blob = fs.readFileSync(this.target);
+      const plaintext = decrypt(blob, this.key);
+      const parsed = JSON.parse(plaintext.toString('utf8')) as { records?: unknown };
+      if (!Array.isArray(parsed.records)) return [];
+      return parsed.records.filter((r): r is HandoffRecord => isRecordShape(r));
+    } catch {
+      // Corrupt / wrong key / partial write — treat as fresh install.
+      return [];
+    }
+  }
+
+  saveAll(records: HandoffRecord[]): void {
+    const plaintext = Buffer.from(JSON.stringify({ records }), 'utf8');
+    const encrypted = encrypt(plaintext, this.key);
+    writeAtomic(this.target, encrypted);
+  }
+
+  clear(): void {
+    try {
+      fs.unlinkSync(this.target);
+    } catch {
+      // already gone
+    }
+  }
+}
+
+function resolveKey(opts: EncryptedFilePersistenceOptions): Buffer {
+  if (opts.key) {
+    if (opts.key.length !== KEY_BYTES) {
+      throw new Error(`encryption key must be ${KEY_BYTES} bytes; got ${opts.key.length}`);
+    }
+    return opts.key;
+  }
+  const envVar = opts.keyEnvVar ?? 'OPENCHROME_HANDOFF_KEY';
+  const raw = process.env[envVar];
+  if (!raw) {
+    throw new Error(
+      `EncryptedFilePersistence: no key supplied and ${envVar} is unset (provide 32 bytes hex or base64)`,
+    );
+  }
+  return parseKey(raw);
+}
+
+/** Accept hex (64 chars), base64 (44 chars), or base64url. */
+function parseKey(raw: string): Buffer {
+  if (/^[0-9a-fA-F]+$/.test(raw)) {
+    if (raw.length !== KEY_BYTES * 2) {
+      throw new Error(`hex key must be ${KEY_BYTES * 2} chars; got ${raw.length}`);
+    }
+    return Buffer.from(raw, 'hex');
+  }
+  // base64 / base64url
+  const padded = raw.replace(/-/g, '+').replace(/_/g, '/');
+  const buf = Buffer.from(padded, 'base64');
+  if (buf.length !== KEY_BYTES) {
+    throw new Error(`base64 key must decode to ${KEY_BYTES} bytes; got ${buf.length}`);
+  }
+  return buf;
+}
+
+/**
+ * Wire format: [iv (12) | ciphertext | tag (16)]. Nonce-misuse risk is
+ * negligible because we generate a fresh random IV on every save and
+ * keys are 32 bytes.
+ */
+function encrypt(plaintext: Buffer, key: Buffer): Buffer {
+  const iv = crypto.randomBytes(IV_BYTES);
+  const cipher = crypto.createCipheriv(AES_ALGORITHM, key, iv);
+  const ct = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, ct, tag]);
+}
+
+function decrypt(blob: Buffer, key: Buffer): Buffer {
+  if (blob.length < IV_BYTES + TAG_BYTES + 1) {
+    throw new Error('blob too short to be valid AES-GCM ciphertext');
+  }
+  const iv = blob.subarray(0, IV_BYTES);
+  const tag = blob.subarray(blob.length - TAG_BYTES);
+  const ct = blob.subarray(IV_BYTES, blob.length - TAG_BYTES);
+  const decipher = crypto.createDecipheriv(AES_ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ct), decipher.final()]);
+}
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function isRecordShape(r: unknown): r is HandoffRecord {
+  if (!r || typeof r !== 'object') return false;
+  const obj = r as Record<string, unknown>;
+  return (
+    typeof obj.txn_id === 'string' &&
+    typeof obj.token === 'string' &&
+    typeof obj.attempt === 'number' &&
+    typeof obj.status === 'string' &&
+    typeof obj.created_at === 'number' &&
+    typeof obj.expires_at === 'number'
+  );
+}
+
+/**
+ * Convenience: pick a default adapter based on environment.
+ *
+ *   OPENCHROME_HANDOFF_KEY set        → EncryptedFilePersistence
+ *   otherwise                          → PlaintextFilePersistence
+ *
+ * Hosts that want OS keychain or anything else should construct the
+ * adapter directly. The factory exists for "give me a sane default"
+ * callers (e.g., the main MCP server boot path).
+ */
+export function autoSelectHandoffPersistence(
+  opts: FilePersistenceOptions = {},
+): PersistenceAdapter {
+  if (process.env.OPENCHROME_HANDOFF_KEY) {
+    return new EncryptedFilePersistence(opts);
+  }
+  return new PlaintextFilePersistence(opts);
+}

--- a/src/contracts/idempotency.ts
+++ b/src/contracts/idempotency.ts
@@ -94,6 +94,11 @@ export function computeIdempotencyKey(
     pre: contract.pre,
     post: contract.post,
     on_fail: contract.on_fail,
+    // critical gates whether beforeIrreversibleAction fires; a cached
+    // non-critical success MUST NOT short-circuit a critical run that
+    // would invoke the voting hook. Include it in the key so they are
+    // stored and retrieved independently.
+    critical: contract.critical ?? false,
     args: args ?? null,
   });
   return crypto.createHash('sha256').update(subject).digest('hex');

--- a/src/contracts/idempotency.ts
+++ b/src/contracts/idempotency.ts
@@ -115,6 +115,25 @@ export function computeIdempotencyKey(
   return crypto.createHash('sha256').update(subject).digest('hex');
 }
 
+/**
+ * Salt an explicit idempotency-key override with the same critical/hook
+ * state that `computeIdempotencyKey` encodes, so that enabling a hook or
+ * marking a contract critical produces a distinct cache key even when the
+ * caller supplies their own key.
+ *
+ * Without this, a success cached from a hookless/non-critical run could be
+ * replayed for a critical+hook run — the hook would never execute because
+ * the cache hit short-circuits block 2.5.
+ */
+export function saltIdempotencyOverride(
+  rawKey: string,
+  critical: boolean,
+  hookActive: boolean,
+): string {
+  const subject = canonicalJson({ key: rawKey, critical, hook_active: hookActive });
+  return crypto.createHash('sha256').update(subject).digest('hex');
+}
+
 export interface IdempotencyStore {
   /** Read a cached record. Side-effect: bumps `used_at` on hit. */
   get(key: string): TransactionRecord | undefined;

--- a/src/contracts/idempotency.ts
+++ b/src/contracts/idempotency.ts
@@ -83,10 +83,17 @@ function sortKeys(value: unknown): unknown {
  * `contract.idempotency_key` is the primary uniqueness scope; the
  * canonical-JSON hash makes equivalent contract+args pairs collide
  * regardless of property authoring order.
+ *
+ * `hookActive` must be `!!args.beforeIrreversibleAction` at the call
+ * site. A critical contract cached when no hook was configured MUST NOT
+ * be replayed after a hook is enabled — the new safety gate would be
+ * silently skipped. Including hook participation in the key ensures that
+ * enabling a hook invalidates prior cached results for those contracts.
  */
 export function computeIdempotencyKey(
   contract: Contract,
   args?: unknown,
+  hookActive?: boolean,
 ): string {
   const subject = canonicalJson({
     idempotency_key: contract.idempotency_key ?? null,
@@ -99,6 +106,10 @@ export function computeIdempotencyKey(
     // would invoke the voting hook. Include it in the key so they are
     // stored and retrieved independently.
     critical: contract.critical ?? false,
+    // hook_active distinguishes "hook configured at call time" from
+    // "no hook". A cached result from a hookless run must not be replayed
+    // after a hook is introduced during gradual rollout.
+    hook_active: hookActive ?? false,
     args: args ?? null,
   });
   return crypto.createHash('sha256').update(subject).digest('hex');

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -27,9 +27,11 @@ export {
   LogAuditEntryEmitter,
 } from './runtime';
 export type {
+  BeforeIrreversibleActionHook,
   Contract,
   ContractRuntimeArgs,
   AuditEmitter,
+  IrreversibleActionDecision,
   SkillFn,
   TransactionRecord,
   Verdict,

--- a/src/contracts/runtime.ts
+++ b/src/contracts/runtime.ts
@@ -276,9 +276,15 @@ export async function runWithContract(args: ContractRuntimeArgs): Promise<Transa
   //    to do but return it (with from_cache=true) and emit one fresh
   //    audit row so the audit log records the *retrieval*.
   if (args.idempotency) {
-    let key = args.idempotencyKey;
-    if (!key) {
-      const idem = await import('./idempotency');
+    let key: string;
+    const idem = await import('./idempotency');
+    if (args.idempotencyKey) {
+      key = idem.saltIdempotencyOverride(
+        args.idempotencyKey,
+        !!args.contract.critical,
+        !!args.beforeIrreversibleAction,
+      );
+    } else {
       key = idem.computeIdempotencyKey(args.contract, undefined, !!args.beforeIrreversibleAction);
     }
     const cached = args.idempotency.get(key);
@@ -599,9 +605,15 @@ export async function runWithContract(args: ContractRuntimeArgs): Promise<Transa
     };
     // Cache only successes per #706 v2.
     if (args.idempotency) {
-      let key = args.idempotencyKey;
-      if (!key) {
-        const idem = await import('./idempotency');
+      let key: string;
+      const idem = await import('./idempotency');
+      if (args.idempotencyKey) {
+        key = idem.saltIdempotencyOverride(
+          args.idempotencyKey,
+          !!args.contract.critical,
+          !!args.beforeIrreversibleAction,
+        );
+      } else {
         key = idem.computeIdempotencyKey(args.contract, undefined, !!args.beforeIrreversibleAction);
       }
       try {

--- a/src/contracts/runtime.ts
+++ b/src/contracts/runtime.ts
@@ -363,6 +363,31 @@ export async function runWithContract(args: ContractRuntimeArgs): Promise<Transa
           error_message: `beforeIrreversibleAction hook timed out after ${hookTimeoutMs}ms (hook_timeout)`,
         });
       }
+      // Shape-validate the hook result before dereferencing any field.
+      // A JS caller or any-typed integration may resolve to undefined,
+      // a non-object, or an object missing the `proceed` boolean.
+      // Dereferencing an invalid result outside this try block would
+      // throw a TypeError and break the "always settles" guarantee, so
+      // we map every malformed response to an escalation here.
+      if (
+        result === null ||
+        result === undefined ||
+        typeof result !== 'object' ||
+        typeof (result as Record<string, unknown>).proceed !== 'boolean'
+      ) {
+        return settle(audit, {
+          txn_id,
+          contract_id: args.contract.id,
+          verdict: 'escalated',
+          started_at: startedAt,
+          ended_at: now(),
+          wall_ms: now() - startedAt,
+          retries: 0,
+          pre_evidence,
+          escalation: { target: 'human-review' },
+          error_message: 'beforeIrreversibleAction hook returned an invalid response (hook_invalid_response)',
+        });
+      }
       decision = result;
     } catch (e) {
       if (hookTimeoutHandle !== null) clearTimer(hookTimeoutHandle);

--- a/src/contracts/runtime.ts
+++ b/src/contracts/runtime.ts
@@ -51,6 +51,13 @@ export interface Contract {
   idempotency_key?: string;
   /** Domain label for audit log routing. */
   domain?: string;
+  /**
+   * High-stakes flag (#711 v2). When true AND a voting hook is supplied
+   * via ContractRuntimeArgs.beforeIrreversibleAction, the runtime calls
+   * the hook between pre-check and skill execution. Disagreement →
+   * verdict='escalated' with a `voting_disagreement` evidence record.
+   */
+  critical?: boolean;
 }
 
 export type Verdict =
@@ -89,6 +96,12 @@ export interface TransactionRecord {
   from_cache?: boolean;
   /** True when the preemptive timer fired and force-aborted the skill. */
   hard_kill?: boolean;
+  /**
+   * Set when the voting hook on a `critical` contract returned
+   * `proceed=false`. Contains the disagreement structure so audit /
+   * evidence can replay the dispute without re-querying the providers.
+   */
+  voting_disagreement?: unknown;
 }
 
 /**
@@ -121,7 +134,34 @@ export interface ContractRuntimeArgs {
   setTimer?: (handler: () => void, ms: number) => unknown;
   /** Test hook: cancellation paired with `setTimer`. */
   clearTimer?: (handle: unknown) => void;
+  /**
+   * Voting hook fired between pre-check and skill execution when the
+   * contract is `critical: true`. The orchestrator (#711) is the
+   * canonical implementation; tests pass simpler fakes. When omitted,
+   * critical contracts behave like ordinary ones (no voting).
+   *
+   * Returning `{ proceed: false }` → verdict='escalated' with the
+   * disagreement payload threaded into the TransactionRecord. The skill
+   * does not run.
+   */
+  beforeIrreversibleAction?: BeforeIrreversibleActionHook;
 }
+
+/** Result envelope the voting hook returns. */
+export type IrreversibleActionDecision =
+  | { proceed: true }
+  | { proceed: false; reason?: string; disagreement?: unknown };
+
+/**
+ * Hook signature consumed by `runWithContract` for `critical` contracts.
+ * Concrete implementations live in `src/perception/voting/orchestrator.ts`
+ * (multi-model dispatcher) but the runtime only depends on this minimal
+ * surface so tests can stub it cheaply.
+ */
+export type BeforeIrreversibleActionHook = (ctx: {
+  contract: Contract;
+  txn_id: string;
+}) => Promise<IrreversibleActionDecision>;
 
 export interface AuditEmitter {
   emit(record: TransactionRecord): void;
@@ -253,6 +293,50 @@ export async function runWithContract(args: ContractRuntimeArgs): Promise<Transa
         wall_ms: now() - startedAt,
         retries: 0,
         pre_evidence,
+      });
+    }
+  }
+
+  // 2.5. Voting hook for critical contracts (#711 integration).
+  //      Pre-check has passed; budget timer hasn't started; skill is
+  //      not yet running. If two providers disagree we escalate
+  //      without consuming the budget.
+  if (args.contract.critical && args.beforeIrreversibleAction) {
+    let decision: IrreversibleActionDecision;
+    try {
+      decision = await args.beforeIrreversibleAction({
+        contract: args.contract,
+        txn_id,
+      });
+    } catch (e) {
+      // Hook failure is treated as a runtime execution error rather
+      // than a silent proceed — same blast-radius philosophy as
+      // pre-check snapshot failures above.
+      return settle(audit, {
+        txn_id,
+        contract_id: args.contract.id,
+        verdict: 'execution_error',
+        started_at: startedAt,
+        ended_at: now(),
+        wall_ms: now() - startedAt,
+        retries: 0,
+        pre_evidence,
+        error_message: `beforeIrreversibleAction hook threw: ${errMsg(e)}`,
+      });
+    }
+    if (!decision.proceed) {
+      return settle(audit, {
+        txn_id,
+        contract_id: args.contract.id,
+        verdict: 'escalated',
+        started_at: startedAt,
+        ended_at: now(),
+        wall_ms: now() - startedAt,
+        retries: 0,
+        pre_evidence,
+        escalation: { target: 'human-review' },
+        voting_disagreement: decision.disagreement,
+        error_message: decision.reason ?? 'voting hook returned proceed=false',
       });
     }
   }

--- a/src/contracts/runtime.ts
+++ b/src/contracts/runtime.ts
@@ -145,6 +145,13 @@ export interface ContractRuntimeArgs {
    * does not run.
    */
   beforeIrreversibleAction?: BeforeIrreversibleActionHook;
+  /**
+   * Maximum ms the `beforeIrreversibleAction` hook may take before the
+   * runtime treats it as a timed-out escalation (fail-safe, not
+   * fail-open). Defaults to 5000 ms. A timed-out hook yields
+   * verdict='escalated' with error_message containing 'hook_timeout'.
+   */
+  beforeIrreversibleActionTimeoutMs?: number;
 }
 
 /** Result envelope the voting hook returns. */
@@ -193,6 +200,12 @@ export function defaultAuditEmitter(): AuditEmitter {
 const BACKOFF_BASE_MS = 500;
 const BACKOFF_FACTOR = 2;
 const BACKOFF_CAP_MS = 5000;
+
+/**
+ * Default timeout for `beforeIrreversibleAction` hooks. A hook that
+ * does not settle within this window is treated as escalate (fail-safe).
+ */
+const BEFORE_IRREVERSIBLE_ACTION_DEFAULT_TIMEOUT_MS = 5000;
 
 function backoffMs(attempt: number): number {
   return Math.min(BACKOFF_BASE_MS * Math.pow(BACKOFF_FACTOR, attempt), BACKOFF_CAP_MS);
@@ -297,18 +310,62 @@ export async function runWithContract(args: ContractRuntimeArgs): Promise<Transa
     }
   }
 
+  // Timer helpers — hoisted here so block 2.5 (hook timeout) and block 3
+  // (preemptive skill timer) can both use them.
+  const setTimer = args.setTimer ?? ((h: () => void, ms: number) => {
+    const t = setTimeout(h, ms);
+    if (typeof (t as NodeJS.Timeout).unref === 'function') (t as NodeJS.Timeout).unref();
+    return t;
+  });
+  const clearTimer = args.clearTimer ?? ((h: unknown) => clearTimeout(h as NodeJS.Timeout));
+
   // 2.5. Voting hook for critical contracts (#711 integration).
   //      Pre-check has passed; budget timer hasn't started; skill is
   //      not yet running. If two providers disagree we escalate
   //      without consuming the budget.
+  //
+  //      The hook invocation is raced against a timeout (default 5s,
+  //      configurable via beforeIrreversibleActionTimeoutMs). A hung
+  //      hook is treated as escalate (fail-safe) so the "always
+  //      settles" guarantee is preserved even when the voting provider
+  //      is unresponsive.
   if (args.contract.critical && args.beforeIrreversibleAction) {
+    const hookTimeoutMs =
+      args.beforeIrreversibleActionTimeoutMs ??
+      BEFORE_IRREVERSIBLE_ACTION_DEFAULT_TIMEOUT_MS;
+
+    // Build a sentinel promise that resolves to null after the timeout.
+    // We use the same setTimer hook (if supplied) so tests can control time.
+    let hookTimeoutHandle: unknown = null;
+    const timeoutPromise = new Promise<null>((resolve) => {
+      hookTimeoutHandle = setTimer(() => resolve(null), hookTimeoutMs);
+    });
+
     let decision: IrreversibleActionDecision;
     try {
-      decision = await args.beforeIrreversibleAction({
-        contract: args.contract,
-        txn_id,
-      });
+      const result = await Promise.race([
+        args.beforeIrreversibleAction({ contract: args.contract, txn_id }),
+        timeoutPromise,
+      ]);
+      if (hookTimeoutHandle !== null) clearTimer(hookTimeoutHandle);
+      if (result === null) {
+        // Timeout fired before the hook resolved — escalate (fail-safe).
+        return settle(audit, {
+          txn_id,
+          contract_id: args.contract.id,
+          verdict: 'escalated',
+          started_at: startedAt,
+          ended_at: now(),
+          wall_ms: now() - startedAt,
+          retries: 0,
+          pre_evidence,
+          escalation: { target: 'human-review' },
+          error_message: `beforeIrreversibleAction hook timed out after ${hookTimeoutMs}ms (hook_timeout)`,
+        });
+      }
+      decision = result;
     } catch (e) {
+      if (hookTimeoutHandle !== null) clearTimer(hookTimeoutHandle);
       // Hook failure is treated as a runtime execution error rather
       // than a silent proceed — same blast-radius philosophy as
       // pre-check snapshot failures above.
@@ -348,12 +405,6 @@ export async function runWithContract(args: ContractRuntimeArgs): Promise<Transa
   const budgetWallMs = args.contract.budget?.wall_ms;
   const skillStart = now();
   const ctrl = new AbortController();
-  const setTimer = args.setTimer ?? ((h, ms) => {
-    const t = setTimeout(h, ms);
-    if (typeof (t as NodeJS.Timeout).unref === 'function') (t as NodeJS.Timeout).unref();
-    return t;
-  });
-  const clearTimer = args.clearTimer ?? ((h) => clearTimeout(h as NodeJS.Timeout));
   let preemptedHardKill = false;
   let preemptHandle: unknown = null;
   if (budgetWallMs !== undefined) {

--- a/src/contracts/runtime.ts
+++ b/src/contracts/runtime.ts
@@ -282,10 +282,14 @@ export async function runWithContract(args: ContractRuntimeArgs): Promise<Transa
       key = idem.saltIdempotencyOverride(
         args.idempotencyKey,
         !!args.contract.critical,
-        !!args.beforeIrreversibleAction,
+        args.contract.critical ? !!args.beforeIrreversibleAction : false,
       );
     } else {
-      key = idem.computeIdempotencyKey(args.contract, undefined, !!args.beforeIrreversibleAction);
+      key = idem.computeIdempotencyKey(
+        args.contract,
+        undefined,
+        args.contract.critical ? !!args.beforeIrreversibleAction : false,
+      );
     }
     const cached = args.idempotency.get(key);
     if (cached && cached.verdict === 'success') {
@@ -611,10 +615,14 @@ export async function runWithContract(args: ContractRuntimeArgs): Promise<Transa
         key = idem.saltIdempotencyOverride(
           args.idempotencyKey,
           !!args.contract.critical,
-          !!args.beforeIrreversibleAction,
+          args.contract.critical ? !!args.beforeIrreversibleAction : false,
         );
       } else {
-        key = idem.computeIdempotencyKey(args.contract, undefined, !!args.beforeIrreversibleAction);
+        key = idem.computeIdempotencyKey(
+          args.contract,
+          undefined,
+          args.contract.critical ? !!args.beforeIrreversibleAction : false,
+        );
       }
       try {
         args.idempotency.put(key, successRecord);

--- a/src/contracts/runtime.ts
+++ b/src/contracts/runtime.ts
@@ -214,6 +214,33 @@ const BACKOFF_CAP_MS = 5000;
  * does not settle within this window is treated as escalate (fail-safe).
  */
 const BEFORE_IRREVERSIBLE_ACTION_DEFAULT_TIMEOUT_MS = 5000;
+/** Maximum sane upper bound for the hook timeout (60 s). */
+const BEFORE_IRREVERSIBLE_ACTION_MAX_TIMEOUT_MS = 60_000;
+
+/**
+ * Validate and return a safe hook timeout value.
+ * If `provided` is undefined, NaN, non-finite, ≤ 0, or > the upper bound,
+ * falls back to BEFORE_IRREVERSIBLE_ACTION_DEFAULT_TIMEOUT_MS and emits a
+ * one-shot console.error so operators can identify misconfigured deployments.
+ */
+function resolveHookTimeoutMs(provided: number | undefined): number {
+  if (
+    provided === undefined ||
+    !Number.isFinite(provided) ||
+    provided <= 0 ||
+    provided > BEFORE_IRREVERSIBLE_ACTION_MAX_TIMEOUT_MS
+  ) {
+    if (provided !== undefined) {
+      console.error(
+        `[contracts/runtime] Invalid beforeIrreversibleActionTimeoutMs value: ${provided}. ` +
+        `Must be a finite positive number ≤ ${BEFORE_IRREVERSIBLE_ACTION_MAX_TIMEOUT_MS}. ` +
+        `Falling back to default ${BEFORE_IRREVERSIBLE_ACTION_DEFAULT_TIMEOUT_MS}ms.`
+      );
+    }
+    return BEFORE_IRREVERSIBLE_ACTION_DEFAULT_TIMEOUT_MS;
+  }
+  return provided;
+}
 
 function backoffMs(attempt: number): number {
   return Math.min(BACKOFF_BASE_MS * Math.pow(BACKOFF_FACTOR, attempt), BACKOFF_CAP_MS);
@@ -338,9 +365,7 @@ export async function runWithContract(args: ContractRuntimeArgs): Promise<Transa
   //      settles" guarantee is preserved even when the voting provider
   //      is unresponsive.
   if (args.contract.critical && args.beforeIrreversibleAction) {
-    const hookTimeoutMs =
-      args.beforeIrreversibleActionTimeoutMs ??
-      BEFORE_IRREVERSIBLE_ACTION_DEFAULT_TIMEOUT_MS;
+    const hookTimeoutMs = resolveHookTimeoutMs(args.beforeIrreversibleActionTimeoutMs);
 
     // Build a sentinel promise that resolves to the unforgeable HOOK_TIMEOUT_SENTINEL
     // symbol after the timeout.  Using a Symbol (not null) means a hook that

--- a/src/contracts/runtime.ts
+++ b/src/contracts/runtime.ts
@@ -21,6 +21,14 @@ import * as crypto from 'node:crypto';
 
 import { logAuditEntry } from '../security/audit-logger';
 
+/**
+ * Unforgeable sentinel used internally by the timeout Promise.race().
+ * Using a Symbol (rather than null/undefined) means a hook that legitimately
+ * resolves to null is NOT mistaken for a timeout — it falls through to the
+ * shape-validation guard and is reported as hook_invalid_response instead.
+ */
+const HOOK_TIMEOUT_SENTINEL = Symbol('hook_timeout');
+
 import type { Assertion, Evidence } from './types';
 import type { AssertionContext } from './evaluator';
 import { evaluate } from './evaluator';
@@ -334,11 +342,13 @@ export async function runWithContract(args: ContractRuntimeArgs): Promise<Transa
       args.beforeIrreversibleActionTimeoutMs ??
       BEFORE_IRREVERSIBLE_ACTION_DEFAULT_TIMEOUT_MS;
 
-    // Build a sentinel promise that resolves to null after the timeout.
+    // Build a sentinel promise that resolves to the unforgeable HOOK_TIMEOUT_SENTINEL
+    // symbol after the timeout.  Using a Symbol (not null) means a hook that
+    // legitimately resolves to null is never misclassified as a timeout.
     // We use the same setTimer hook (if supplied) so tests can control time.
     let hookTimeoutHandle: unknown = null;
-    const timeoutPromise = new Promise<null>((resolve) => {
-      hookTimeoutHandle = setTimer(() => resolve(null), hookTimeoutMs);
+    const timeoutPromise = new Promise<typeof HOOK_TIMEOUT_SENTINEL>((resolve) => {
+      hookTimeoutHandle = setTimer(() => resolve(HOOK_TIMEOUT_SENTINEL), hookTimeoutMs);
     });
 
     let decision: IrreversibleActionDecision;
@@ -348,7 +358,7 @@ export async function runWithContract(args: ContractRuntimeArgs): Promise<Transa
         timeoutPromise,
       ]);
       if (hookTimeoutHandle !== null) clearTimer(hookTimeoutHandle);
-      if (result === null) {
+      if (result === HOOK_TIMEOUT_SENTINEL) {
         // Timeout fired before the hook resolved — escalate (fail-safe).
         return settle(audit, {
           txn_id,

--- a/src/contracts/runtime.ts
+++ b/src/contracts/runtime.ts
@@ -462,8 +462,16 @@ export async function runWithContract(args: ContractRuntimeArgs): Promise<Transa
   //    (a) cooperative: skill receives AbortSignal it should observe
   //    (b) preemptive: setTimeout(wall_ms + grace) hard-aborts via the
   //        same AbortController and short-circuits the post-check loop.
+  //
+  // skillStartedAt is snapshotted HERE — after any beforeIrreversibleAction
+  // hook completes — so that hook latency is excluded from wall-budget
+  // retry-gate calculations. A slow hook must not eat the skill's budget.
+  // Audit/total-duration fields continue to use the original `startedAt`
+  // for observability (wall_ms in the TransactionRecord = total elapsed
+  // including hook time).
   const budgetWallMs = args.contract.budget?.wall_ms;
-  const skillStart = now();
+  const skillStartedAt = now();
+  const skillStart = skillStartedAt;
   const ctrl = new AbortController();
   let preemptedHardKill = false;
   let preemptHandle: unknown = null;
@@ -563,10 +571,12 @@ export async function runWithContract(args: ContractRuntimeArgs): Promise<Transa
     if (post_evidence.passed) break;
     if (attempt >= maxRetries) break;
     // Bail if the next backoff would exceed the remaining wall budget.
+    // Use skillStartedAt (not startedAt) so hook latency does not consume
+    // the skill's wall budget — wall_ms covers skill execution only.
     const next = backoffMs(attempt);
     if (
       budgetWallMs !== undefined &&
-      now() - startedAt + next > budgetWallMs
+      now() - skillStartedAt + next > budgetWallMs
     ) {
       break;
     }

--- a/src/contracts/runtime.ts
+++ b/src/contracts/runtime.ts
@@ -279,7 +279,7 @@ export async function runWithContract(args: ContractRuntimeArgs): Promise<Transa
     let key = args.idempotencyKey;
     if (!key) {
       const idem = await import('./idempotency');
-      key = idem.computeIdempotencyKey(args.contract);
+      key = idem.computeIdempotencyKey(args.contract, undefined, !!args.beforeIrreversibleAction);
     }
     const cached = args.idempotency.get(key);
     if (cached && cached.verdict === 'success') {
@@ -602,7 +602,7 @@ export async function runWithContract(args: ContractRuntimeArgs): Promise<Transa
       let key = args.idempotencyKey;
       if (!key) {
         const idem = await import('./idempotency');
-        key = idem.computeIdempotencyKey(args.contract);
+        key = idem.computeIdempotencyKey(args.contract, undefined, !!args.beforeIrreversibleAction);
       }
       try {
         args.idempotency.put(key, successRecord);

--- a/tests/contracts/handoff-persistence.test.ts
+++ b/tests/contracts/handoff-persistence.test.ts
@@ -1,0 +1,281 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  EncryptedFilePersistence,
+  HandoffManager,
+  PlaintextFilePersistence,
+  autoSelectHandoffPersistence,
+} from '../../src/contracts/handoff';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-hopst-'));
+}
+
+function key32(): Buffer {
+  return crypto.randomBytes(32);
+}
+
+describe('PlaintextFilePersistence', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('loadAll returns empty for fresh install', () => {
+    const p = new PlaintextFilePersistence({ rootDir: root });
+    expect(p.loadAll()).toEqual([]);
+  });
+
+  test('round-trips records via saveAll → loadAll', () => {
+    const p = new PlaintextFilePersistence({ rootDir: root });
+    p.saveAll([
+      {
+        txn_id: 't1',
+        attempt: 1,
+        token: 'a'.repeat(64),
+        status: 'pending',
+        reason: 'two_factor',
+        summary: '2FA',
+        created_at: 1000,
+        expires_at: 2000,
+      },
+    ]);
+    const loaded = p.loadAll();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].txn_id).toBe('t1');
+    expect(loaded[0].status).toBe('pending');
+  });
+
+  test('saveAll writes file with mode 0o600', () => {
+    const p = new PlaintextFilePersistence({ rootDir: root });
+    p.saveAll([]);
+    const target = path.join(root, 'handoff.json');
+    const stat = fs.statSync(target);
+    // Mask out higher mode bits and inspect the lower 9.
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  test('clear() removes the file', () => {
+    const p = new PlaintextFilePersistence({ rootDir: root });
+    p.saveAll([]);
+    expect(fs.existsSync(path.join(root, 'handoff.json'))).toBe(true);
+    p.clear();
+    expect(fs.existsSync(path.join(root, 'handoff.json'))).toBe(false);
+  });
+
+  test('corrupt JSON falls through to empty (does not throw)', () => {
+    fs.writeFileSync(path.join(root, 'handoff.json'), 'not json {{');
+    const p = new PlaintextFilePersistence({ rootDir: root });
+    expect(p.loadAll()).toEqual([]);
+  });
+});
+
+describe('EncryptedFilePersistence', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('round-trips records under AES-256-GCM', () => {
+    const k = key32();
+    const p = new EncryptedFilePersistence({ rootDir: root, key: k });
+    const record = {
+      txn_id: 't',
+      attempt: 1,
+      token: 'b'.repeat(64),
+      status: 'pending' as const,
+      reason: 'login_required' as const,
+      summary: 'login',
+      created_at: 1000,
+      expires_at: 2000,
+    };
+    p.saveAll([record]);
+    const reloaded = new EncryptedFilePersistence({ rootDir: root, key: k });
+    const loaded = reloaded.loadAll();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].token).toBe('b'.repeat(64));
+  });
+
+  test('on-disk blob is NOT plaintext (token does not appear)', () => {
+    const p = new EncryptedFilePersistence({ rootDir: root, key: key32() });
+    const tok = 'c'.repeat(64);
+    p.saveAll([
+      {
+        txn_id: 't',
+        attempt: 1,
+        token: tok,
+        status: 'pending',
+        reason: 'unknown',
+        summary: 's',
+        created_at: 1,
+        expires_at: 2,
+      },
+    ]);
+    const blob = fs.readFileSync(path.join(root, 'handoff.json'));
+    // Substring search across the entire blob (treat as bytes/string).
+    expect(blob.toString('binary').includes(tok)).toBe(false);
+  });
+
+  test('wrong key produces empty load (auth-tag mismatch swallowed)', () => {
+    const original = new EncryptedFilePersistence({ rootDir: root, key: key32() });
+    original.saveAll([
+      {
+        txn_id: 't',
+        attempt: 1,
+        token: 'a'.repeat(64),
+        status: 'pending',
+        reason: 'unknown',
+        summary: 's',
+        created_at: 1,
+        expires_at: 2,
+      },
+    ]);
+    const wrongKey = new EncryptedFilePersistence({ rootDir: root, key: key32() });
+    expect(wrongKey.loadAll()).toEqual([]);
+  });
+
+  test('rejects non-32-byte key', () => {
+    expect(
+      () => new EncryptedFilePersistence({ rootDir: root, key: Buffer.alloc(16) }),
+    ).toThrow();
+  });
+
+  test('reads OPENCHROME_HANDOFF_KEY env var (hex)', () => {
+    const k = key32().toString('hex');
+    const prev = process.env.OPENCHROME_HANDOFF_KEY;
+    process.env.OPENCHROME_HANDOFF_KEY = k;
+    try {
+      const p = new EncryptedFilePersistence({ rootDir: root });
+      p.saveAll([]);
+      expect(p.loadAll()).toEqual([]);
+    } finally {
+      if (prev === undefined) delete process.env.OPENCHROME_HANDOFF_KEY;
+      else process.env.OPENCHROME_HANDOFF_KEY = prev;
+    }
+  });
+
+  test('reads OPENCHROME_HANDOFF_KEY env var (base64)', () => {
+    const k = key32().toString('base64');
+    const prev = process.env.OPENCHROME_HANDOFF_KEY;
+    process.env.OPENCHROME_HANDOFF_KEY = k;
+    try {
+      const p = new EncryptedFilePersistence({ rootDir: root });
+      p.saveAll([]);
+      expect(p.loadAll()).toEqual([]);
+    } finally {
+      if (prev === undefined) delete process.env.OPENCHROME_HANDOFF_KEY;
+      else process.env.OPENCHROME_HANDOFF_KEY = prev;
+    }
+  });
+
+  test('throws when key is missing entirely', () => {
+    const prev = process.env.OPENCHROME_HANDOFF_KEY;
+    delete process.env.OPENCHROME_HANDOFF_KEY;
+    try {
+      expect(() => new EncryptedFilePersistence({ rootDir: root })).toThrow(/no key/);
+    } finally {
+      if (prev !== undefined) process.env.OPENCHROME_HANDOFF_KEY = prev;
+    }
+  });
+
+  test('IV randomness — two saveAll calls produce different ciphertext', () => {
+    const k = key32();
+    const p = new EncryptedFilePersistence({ rootDir: root, key: k });
+    p.saveAll([]);
+    const a = fs.readFileSync(path.join(root, 'handoff.json'));
+    p.saveAll([]);
+    const b = fs.readFileSync(path.join(root, 'handoff.json'));
+    expect(Buffer.compare(a, b)).not.toBe(0);
+  });
+});
+
+describe('autoSelectHandoffPersistence', () => {
+  let root: string;
+  let prev: string | undefined;
+  beforeEach(() => {
+    root = tempRoot();
+    prev = process.env.OPENCHROME_HANDOFF_KEY;
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+    if (prev === undefined) delete process.env.OPENCHROME_HANDOFF_KEY;
+    else process.env.OPENCHROME_HANDOFF_KEY = prev;
+  });
+
+  test('returns Encrypted when OPENCHROME_HANDOFF_KEY is set', () => {
+    process.env.OPENCHROME_HANDOFF_KEY = key32().toString('hex');
+    const p = autoSelectHandoffPersistence({ rootDir: root });
+    expect(p).toBeInstanceOf(EncryptedFilePersistence);
+  });
+
+  test('returns Plaintext when env var is unset', () => {
+    delete process.env.OPENCHROME_HANDOFF_KEY;
+    const p = autoSelectHandoffPersistence({ rootDir: root });
+    expect(p).toBeInstanceOf(PlaintextFilePersistence);
+  });
+});
+
+describe('HandoffManager — persistence integration', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('manager rebuilt from persistence sees previously-created handoffs', () => {
+    const p = new PlaintextFilePersistence({ rootDir: root });
+    const a = new HandoffManager({ persistence: p, now: () => 1000 });
+    a.create({ txn_id: 't', reason: 'two_factor', summary: '2FA' });
+    const tokenBefore = a.list()[0].token;
+
+    // Simulate a process restart by constructing a fresh manager.
+    const b = new HandoffManager({ persistence: p, now: () => 1100 });
+    expect(b.list()).toHaveLength(1);
+    expect(b.list()[0].token).toBe(tokenBefore);
+  });
+
+  test('per-txn cap survives a restart', () => {
+    const p = new PlaintextFilePersistence({ rootDir: root });
+    const a = new HandoffManager({ persistence: p, maxPerTxn: 3 });
+    a.create({ txn_id: 't', reason: 'unknown', summary: 's' });
+    a.create({ txn_id: 't', reason: 'unknown', summary: 's' });
+    a.create({ txn_id: 't', reason: 'unknown', summary: 's' });
+
+    const b = new HandoffManager({ persistence: p, maxPerTxn: 3 });
+    // Restart sees attempt count 3 → 4th attempt should still throw.
+    expect(() => b.create({ txn_id: 't', reason: 'unknown', summary: 's' })).toThrow(
+      /cap exhausted/,
+    );
+  });
+
+  test('resume after restart with the original token works', () => {
+    const p = new PlaintextFilePersistence({ rootDir: root });
+    const a = new HandoffManager({ persistence: p, now: () => 1000 });
+    const rec = a.create({ txn_id: 't', reason: 'unknown', summary: 's' });
+
+    const b = new HandoffManager({ persistence: p, now: () => 1100 });
+    const r = b.resume('t', rec.token);
+    expect(r.ok).toBe(true);
+    expect(r.record?.status).toBe('resumed');
+  });
+
+  test('reset() clears persisted file', () => {
+    const p = new PlaintextFilePersistence({ rootDir: root });
+    const m = new HandoffManager({ persistence: p });
+    m.create({ txn_id: 't', reason: 'unknown', summary: 's' });
+    expect(fs.existsSync(path.join(root, 'handoff.json'))).toBe(true);
+    m.reset();
+    expect(fs.existsSync(path.join(root, 'handoff.json'))).toBe(false);
+  });
+});

--- a/tests/contracts/idempotency.test.ts
+++ b/tests/contracts/idempotency.test.ts
@@ -251,6 +251,45 @@ describe('runWithContract — idempotency cache', () => {
     expect(skillCalls).toBe(2);
   });
 
+  test('critical=false cached success does NOT short-circuit a critical=true run (P2A regression)', async () => {
+    // A non-critical run succeeds and is cached. A subsequent run with the
+    // same contract shape but critical=true MUST NOT hit that cache — the
+    // voting hook must be invoked, not bypassed.
+    let hookCalls = 0;
+    const hook = async () => {
+      hookCalls++;
+      return { proceed: true };
+    };
+    const baseContract = {
+      id: 'c-critical',
+      idempotency_key: 'critical-regression',
+      post: { kind: 'no_dialog' as const },
+    };
+    // First run: non-critical, no hook supplied. Caches the success.
+    const r1 = await runWithContract({
+      contract: { ...baseContract, critical: false },
+      skill: async () => 'non-critical run',
+      snapshot: async () => snap(),
+      idempotency: store,
+    });
+    expect(r1.verdict).toBe('success');
+    expect(r1.from_cache).toBeUndefined();
+
+    // Second run: critical=true with the hook. Must NOT be a cache hit.
+    let skillCalls = 0;
+    const r2 = await runWithContract({
+      contract: { ...baseContract, critical: true },
+      skill: async () => { skillCalls++; return 'critical run'; },
+      snapshot: async () => snap(),
+      idempotency: store,
+      beforeIrreversibleAction: hook,
+    });
+    expect(r2.verdict).toBe('success');
+    expect(r2.from_cache).toBeUndefined(); // must not be from cache
+    expect(hookCalls).toBe(1); // hook was invoked
+    expect(skillCalls).toBe(1); // skill ran fresh
+  });
+
   test('different idempotency_key bypasses the cache', async () => {
     let skillCalls = 0;
     const make = (key: string) => ({

--- a/tests/contracts/idempotency.test.ts
+++ b/tests/contracts/idempotency.test.ts
@@ -346,6 +346,64 @@ describe('runWithContract — idempotency cache', () => {
     expect(hookCalls).toBe(1);        // hook was NOT called on cache hit
   });
 
+  test('explicit args.idempotencyKey override is salted — critical/hook state change MUST NOT replay cache (round-7 regression)', async () => {
+    // Scenario: caller supplies args.idempotencyKey = 'foo'.
+    // Run 1: critical=false, no hook → success cached.
+    // Run 2: same override 'foo' but critical=true + hook enabled →
+    //   MUST NOT be a cache hit; hook must fire and skill must run fresh.
+    let skillCalls = 0;
+    let hookCalls = 0;
+    const hook = async () => {
+      hookCalls++;
+      return { proceed: true };
+    };
+    const contract: Contract = {
+      id: 'c-override-salt',
+      post: { kind: 'no_dialog' as const },
+    };
+
+    // Run 1: non-critical, no hook, explicit override key.
+    const r1 = await runWithContract({
+      contract: { ...contract, critical: false },
+      skill: async () => { skillCalls++; return 'run1'; },
+      snapshot: async () => snap(),
+      idempotency: store,
+      idempotencyKey: 'foo',
+    });
+    expect(r1.verdict).toBe('success');
+    expect(r1.from_cache).toBeUndefined();
+    expect(skillCalls).toBe(1);
+
+    // Run 2: critical=true + hook. Same override key 'foo'.
+    // The override must be salted differently → cache miss → hook fires.
+    const r2 = await runWithContract({
+      contract: { ...contract, critical: true },
+      skill: async () => { skillCalls++; return 'run2'; },
+      snapshot: async () => snap(),
+      idempotency: store,
+      idempotencyKey: 'foo',
+      beforeIrreversibleAction: hook,
+    });
+    expect(r2.verdict).toBe('success');
+    expect(r2.from_cache).toBeUndefined(); // must not replay run-1 cache
+    expect(hookCalls).toBe(1);             // hook invoked
+    expect(skillCalls).toBe(2);            // skill ran fresh
+
+    // Run 3: same critical=true + hook again → should now hit run-2 cache.
+    const r3 = await runWithContract({
+      contract: { ...contract, critical: true },
+      skill: async () => { skillCalls++; return 'run3'; },
+      snapshot: async () => snap(),
+      idempotency: store,
+      idempotencyKey: 'foo',
+      beforeIrreversibleAction: hook,
+    });
+    expect(r3.verdict).toBe('success');
+    expect(r3.from_cache).toBe(true); // now hits the salted cache entry
+    expect(skillCalls).toBe(2);       // skill did NOT run again
+    expect(hookCalls).toBe(1);        // hook was NOT called on cache hit
+  });
+
   test('different idempotency_key bypasses the cache', async () => {
     let skillCalls = 0;
     const make = (key: string) => ({

--- a/tests/contracts/idempotency.test.ts
+++ b/tests/contracts/idempotency.test.ts
@@ -404,6 +404,47 @@ describe('runWithContract — idempotency cache', () => {
     expect(hookCalls).toBe(1);        // hook was NOT called on cache hit
   });
 
+  test('non-critical contract: flipping hook on does NOT invalidate cache (round-8 regression)', async () => {
+    // Scenario: non-critical contract runs (no hook possible), succeeds, cached.
+    // A second call that supplies a beforeIrreversibleAction hook (which will
+    // never fire because the contract is non-critical) MUST still hit the cache.
+    // Before this fix, hookActive was included as-is, so hook=true produced a
+    // different key and the skill ran a second time instead of short-circuiting.
+    let skillCalls = 0;
+    const hook = async () => ({ proceed: true });
+    const contract: Contract = {
+      id: 'c-noncritical-hook',
+      idempotency_key: 'noncritical-hook-key',
+      post: { kind: 'no_dialog' as const },
+      critical: false,
+    };
+
+    // Run 1: non-critical, no hook. Caches under hookActive=false.
+    const r1 = await runWithContract({
+      contract,
+      skill: async () => { skillCalls++; return 'run1'; },
+      snapshot: async () => snap(),
+      idempotency: store,
+    });
+    expect(r1.verdict).toBe('success');
+    expect(r1.from_cache).toBeUndefined();
+    expect(skillCalls).toBe(1);
+
+    // Run 2: same non-critical contract, but caller wires a hook. Since the
+    // contract is non-critical, hookActive is normalized to false → same key
+    // → cache hit → skill does NOT run again.
+    const r2 = await runWithContract({
+      contract,
+      skill: async () => { skillCalls++; return 'run2'; },
+      snapshot: async () => snap(),
+      idempotency: store,
+      beforeIrreversibleAction: hook,
+    });
+    expect(r2.verdict).toBe('success');
+    expect(r2.from_cache).toBe(true);  // must hit cache
+    expect(skillCalls).toBe(1);         // skill did NOT run again
+  });
+
   test('different idempotency_key bypasses the cache', async () => {
     let skillCalls = 0;
     const make = (key: string) => ({

--- a/tests/contracts/idempotency.test.ts
+++ b/tests/contracts/idempotency.test.ts
@@ -290,6 +290,62 @@ describe('runWithContract — idempotency cache', () => {
     expect(skillCalls).toBe(1); // skill ran fresh
   });
 
+  test('hook-inactive cached success does NOT short-circuit a hook-active run (round-6 regression)', async () => {
+    // Scenario: a critical contract runs WITHOUT a hook and succeeds → cached.
+    // A subsequent run with the same contract + hook MUST NOT hit that cache;
+    // the hook must fire and the skill must run fresh.
+    let hookCalls = 0;
+    const hook = async () => {
+      hookCalls++;
+      return { proceed: true };
+    };
+    const baseContract: Contract = {
+      id: 'c-hook-rollout',
+      idempotency_key: 'hook-rollout-key',
+      post: { kind: 'no_dialog' as const },
+      critical: true,
+    };
+
+    // First run: critical=true, NO hook. Caches the success under hook_active=false.
+    let skillCalls = 0;
+    const r1 = await runWithContract({
+      contract: baseContract,
+      skill: async () => { skillCalls++; return 'no-hook run'; },
+      snapshot: async () => snap(),
+      idempotency: store,
+    });
+    expect(r1.verdict).toBe('success');
+    expect(r1.from_cache).toBeUndefined();
+    expect(skillCalls).toBe(1);
+
+    // Second run: same contract, same idempotency_key, but hook NOW enabled.
+    // Must NOT replay from cache — hook must fire and skill must run fresh.
+    const r2 = await runWithContract({
+      contract: baseContract,
+      skill: async () => { skillCalls++; return 'hook run'; },
+      snapshot: async () => snap(),
+      idempotency: store,
+      beforeIrreversibleAction: hook,
+    });
+    expect(r2.verdict).toBe('success');
+    expect(r2.from_cache).toBeUndefined(); // must not replay from cache
+    expect(hookCalls).toBe(1);             // hook was invoked
+    expect(skillCalls).toBe(2);            // skill ran fresh
+
+    // Third run: hook still enabled. Now caches under hook_active=true → hits.
+    const r3 = await runWithContract({
+      contract: baseContract,
+      skill: async () => { skillCalls++; return 'hook run 2'; },
+      snapshot: async () => snap(),
+      idempotency: store,
+      beforeIrreversibleAction: hook,
+    });
+    expect(r3.verdict).toBe('success');
+    expect(r3.from_cache).toBe(true); // now hits the hook-active cache entry
+    expect(skillCalls).toBe(2);       // skill did NOT run again
+    expect(hookCalls).toBe(1);        // hook was NOT called on cache hit
+  });
+
   test('different idempotency_key bypasses the cache', async () => {
     let skillCalls = 0;
     const make = (key: string) => ({

--- a/tests/contracts/runtime-voting-hook.test.ts
+++ b/tests/contracts/runtime-voting-hook.test.ts
@@ -213,6 +213,25 @@ describe('runWithContract — beforeIrreversibleAction hook', () => {
     expect(records).toHaveLength(1);
   });
 
+  test('hook resolves to null → verdict=escalated with hook_invalid_response (NOT hook_timeout)', async () => {
+    // Regression: before the Symbol sentinel fix, a hook returning null was
+    // misclassified as hook_timeout because null was the timeout sentinel.
+    const hook: BeforeIrreversibleActionHook = async () => null as unknown as never;
+    const { emitter, records } = captureEmitter();
+    const r = await runWithContract({
+      contract: { id: 'c', post: POST_OK, critical: true },
+      skill: async () => 'should not run',
+      snapshot: async () => snap(),
+      beforeIrreversibleAction: hook,
+      audit: emitter,
+    });
+    expect(r.verdict).toBe('escalated');
+    expect(r.error_message).toContain('hook_invalid_response');
+    expect(r.error_message).not.toContain('hook_timeout');
+    expect(r.escalation?.target).toBe('human-review');
+    expect(records).toHaveLength(1);
+  });
+
   test('escalated record contains pre_evidence (when pre present and passed)', async () => {
     const hook: BeforeIrreversibleActionHook = async () => ({ proceed: false });
     const r = await runWithContract({

--- a/tests/contracts/runtime-voting-hook.test.ts
+++ b/tests/contracts/runtime-voting-hook.test.ts
@@ -134,6 +134,39 @@ describe('runWithContract — beforeIrreversibleAction hook', () => {
     expect(skillCalls).toBe(0);
   });
 
+  test('hung hook times out → verdict=escalated with hook_timeout message (fail-safe)', async () => {
+    // A hook that never resolves simulates a hung voting provider.
+    const hook: BeforeIrreversibleActionHook = () => new Promise(() => {/* never resolves */});
+    const { emitter, records } = captureEmitter();
+
+    // Use fake timer machinery so the test completes in ms, not seconds.
+    // setTimer resolves the sentinel immediately on next tick.
+    let timerCallback: (() => void) | null = null;
+    const fakeSetTimer = (handler: () => void, _ms: number) => {
+      timerCallback = handler;
+      // Schedule callback to fire asynchronously so Promise.race can set up.
+      Promise.resolve().then(() => timerCallback?.());
+      return 1; // opaque handle
+    };
+    const fakeClearTimer = (_h: unknown) => { timerCallback = null; };
+
+    const r = await runWithContract({
+      contract: { id: 'c', post: POST_OK, critical: true },
+      skill: async () => 'should not run',
+      snapshot: async () => snap(),
+      beforeIrreversibleAction: hook,
+      beforeIrreversibleActionTimeoutMs: 50,
+      setTimer: fakeSetTimer,
+      clearTimer: fakeClearTimer,
+      audit: emitter,
+    });
+
+    expect(r.verdict).toBe('escalated');
+    expect(r.error_message).toContain('hook_timeout');
+    expect(r.escalation?.target).toBe('human-review');
+    expect(records).toHaveLength(1);
+  });
+
   test('escalated record contains pre_evidence (when pre present and passed)', async () => {
     const hook: BeforeIrreversibleActionHook = async () => ({ proceed: false });
     const r = await runWithContract({

--- a/tests/contracts/runtime-voting-hook.test.ts
+++ b/tests/contracts/runtime-voting-hook.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Voting hook integration into the contract runtime (#711 + #706).
+ *
+ * The hook fires only when contract.critical === true AND a hook is
+ * supplied. These tests use a deterministic fake hook so they don't
+ * depend on real provider HTTP.
+ */
+
+import {
+  runWithContract,
+  type AuditEmitter,
+  type BeforeIrreversibleActionHook,
+  type TransactionRecord,
+} from '../../src/contracts/runtime';
+import type { AssertionContext } from '../../src/contracts/evaluator';
+import type { Assertion } from '../../src/contracts/types';
+
+function snap(over: Partial<AssertionContext> = {}): AssertionContext {
+  return {
+    url: 'https://example.com/',
+    bodyText: '',
+    domText: () => '',
+    domCount: () => 0,
+    hasDialog: false,
+    ...over,
+  };
+}
+
+function captureEmitter(): { emitter: AuditEmitter; records: TransactionRecord[] } {
+  const records: TransactionRecord[] = [];
+  return { emitter: { emit: (r) => records.push(r) }, records };
+}
+
+const POST_OK: Assertion = { kind: 'no_dialog' };
+
+describe('runWithContract — beforeIrreversibleAction hook', () => {
+  test('non-critical contracts ignore the hook entirely', async () => {
+    let called = 0;
+    const hook: BeforeIrreversibleActionHook = async () => {
+      called++;
+      return { proceed: false };
+    };
+    const r = await runWithContract({
+      contract: { id: 'c', post: POST_OK }, // critical = false (omitted)
+      skill: async () => 'ok',
+      snapshot: async () => snap(),
+      beforeIrreversibleAction: hook,
+    });
+    expect(r.verdict).toBe('success');
+    expect(called).toBe(0);
+  });
+
+  test('critical contracts WITHOUT a hook still proceed (no-op)', async () => {
+    const r = await runWithContract({
+      contract: { id: 'c', post: POST_OK, critical: true },
+      skill: async () => 'ok',
+      snapshot: async () => snap(),
+    });
+    expect(r.verdict).toBe('success');
+  });
+
+  test('critical + hook proceeds when decision.proceed=true', async () => {
+    const hook: BeforeIrreversibleActionHook = async () => ({ proceed: true });
+    const r = await runWithContract({
+      contract: { id: 'c', post: POST_OK, critical: true },
+      skill: async () => 'ok',
+      snapshot: async () => snap(),
+      beforeIrreversibleAction: hook,
+    });
+    expect(r.verdict).toBe('success');
+  });
+
+  test('critical + hook denies → verdict=escalated, skill never runs', async () => {
+    let skillCalls = 0;
+    const hook: BeforeIrreversibleActionHook = async () => ({
+      proceed: false,
+      reason: 'providers disagreed',
+      disagreement: { providers: ['anthropic', 'openai'] },
+    });
+    const { emitter, records } = captureEmitter();
+    const r = await runWithContract({
+      contract: { id: 'c', post: POST_OK, critical: true },
+      skill: async () => {
+        skillCalls++;
+      },
+      snapshot: async () => snap(),
+      beforeIrreversibleAction: hook,
+      audit: emitter,
+    });
+    expect(r.verdict).toBe('escalated');
+    expect(r.error_message).toBe('providers disagreed');
+    expect(r.voting_disagreement).toEqual({ providers: ['anthropic', 'openai'] });
+    expect(r.escalation?.target).toBe('human-review');
+    expect(skillCalls).toBe(0);
+    expect(records).toHaveLength(1);
+  });
+
+  test('hook fires AFTER pre-check (no skill consumed when pre fails)', async () => {
+    let hookCalls = 0;
+    const hook: BeforeIrreversibleActionHook = async () => {
+      hookCalls++;
+      return { proceed: true };
+    };
+    const r = await runWithContract({
+      contract: {
+        id: 'c',
+        pre: { kind: 'url', pattern: 'never-matches' },
+        post: POST_OK,
+        critical: true,
+      },
+      skill: async () => 'ok',
+      snapshot: async () => snap({ url: 'https://example.com/' }),
+      beforeIrreversibleAction: hook,
+    });
+    expect(r.verdict).toBe('precondition_violation');
+    expect(hookCalls).toBe(0); // hook never called when pre fails
+  });
+
+  test('hook throws → verdict=execution_error (skill never runs)', async () => {
+    let skillCalls = 0;
+    const hook: BeforeIrreversibleActionHook = async () => {
+      throw new Error('voting provider exploded');
+    };
+    const r = await runWithContract({
+      contract: { id: 'c', post: POST_OK, critical: true },
+      skill: async () => {
+        skillCalls++;
+      },
+      snapshot: async () => snap(),
+      beforeIrreversibleAction: hook,
+    });
+    expect(r.verdict).toBe('execution_error');
+    expect(r.error_message).toContain('voting provider exploded');
+    expect(skillCalls).toBe(0);
+  });
+
+  test('escalated record contains pre_evidence (when pre present and passed)', async () => {
+    const hook: BeforeIrreversibleActionHook = async () => ({ proceed: false });
+    const r = await runWithContract({
+      contract: {
+        id: 'c',
+        pre: { kind: 'no_dialog' },
+        post: POST_OK,
+        critical: true,
+      },
+      skill: async () => 'ok',
+      snapshot: async () => snap(),
+      beforeIrreversibleAction: hook,
+    });
+    expect(r.verdict).toBe('escalated');
+    expect(r.pre_evidence?.passed).toBe(true);
+  });
+});

--- a/tests/contracts/runtime-voting-hook.test.ts
+++ b/tests/contracts/runtime-voting-hook.test.ts
@@ -232,6 +232,80 @@ describe('runWithContract — beforeIrreversibleAction hook', () => {
     expect(records).toHaveLength(1);
   });
 
+  test('slow hook does not consume skill wall-budget — retries still fire (P2B regression)', async () => {
+    // Scenario: hook takes 4 s, skill takes 2 s, wall_ms budget = 5 s.
+    // Without the fix: elapsed from startedAt = 6 s > 5 s → retry suppressed.
+    // With the fix: elapsed from skillStartedAt = 2 s < 5 s → retry is allowed.
+    //
+    // We drive all time with a deterministic fake clock so no real waiting.
+    let t = 0;
+    const now = () => t;
+
+    // Hook occupies 4 000 ms of wall time.
+    const HOOK_DURATION = 4_000;
+    // Skill takes 2 000 ms.
+    const SKILL_DURATION = 2_000;
+    // Budget = 5 000 ms (less than hook+skill combined, but sufficient for skill alone).
+    const WALL_MS = 5_000;
+
+    // The hook advances the fake clock when it resolves.
+    const hook: BeforeIrreversibleActionHook = async () => {
+      t += HOOK_DURATION;
+      return { proceed: true };
+    };
+
+    // The skill advances the clock when it resolves.
+    let skillCalls = 0;
+    const skill = async () => {
+      skillCalls++;
+      t += SKILL_DURATION;
+      return 'done';
+    };
+
+    // Fake delay that advances the clock without real waiting.
+    const delay = async (ms: number) => { t += ms; };
+
+    // Post-check: fails on attempt 0, passes on attempt 1, so one retry fires.
+    let postChecks = 0;
+    const snapshot = async (): Promise<AssertionContext> => {
+      postChecks++;
+      return {
+        url: 'https://example.com/',
+        bodyText: postChecks >= 2 ? 'ready' : '',
+        domText: () => (postChecks >= 2 ? 'ready' : ''),
+        domCount: () => 0,
+        hasDialog: false,
+      };
+    };
+
+    // Use a setTimer that never fires automatically (budget preemption is not
+    // what we are testing here) so only the retry-gate logic is exercised.
+    const fakeSetTimer = (_h: () => void, _ms: number) => 99;
+    const fakeClearTimer = (_h: unknown) => undefined;
+
+    const r = await runWithContract({
+      contract: {
+        id: 'c-hook-budget',
+        post: { kind: 'dom_text', contains: 'ready' },
+        critical: true,
+        budget: { wall_ms: WALL_MS },
+        on_fail: { retry: 2 },
+      },
+      skill,
+      snapshot,
+      beforeIrreversibleAction: hook,
+      now,
+      delay,
+      setTimer: fakeSetTimer,
+      clearTimer: fakeClearTimer,
+    });
+
+    // The retry should have fired — post-check passes on attempt 1.
+    expect(r.verdict).toBe('success');
+    expect(r.retries).toBe(1);
+    expect(skillCalls).toBe(1);
+  });
+
   test('escalated record contains pre_evidence (when pre present and passed)', async () => {
     const hook: BeforeIrreversibleActionHook = async () => ({ proceed: false });
     const r = await runWithContract({

--- a/tests/contracts/runtime-voting-hook.test.ts
+++ b/tests/contracts/runtime-voting-hook.test.ts
@@ -248,4 +248,86 @@ describe('runWithContract — beforeIrreversibleAction hook', () => {
     expect(r.verdict).toBe('escalated');
     expect(r.pre_evidence?.passed).toBe(true);
   });
+
+  // --- resolveHookTimeoutMs sanitization regression tests ---
+  // These verify that invalid timeout values fall back to the default and do NOT
+  // cause an immediate-fire timer that escalates a fast-returning hook.
+
+  function makeInstantHook(): BeforeIrreversibleActionHook {
+    return async () => ({ proceed: true });
+  }
+
+  // Fake timer that fires ONLY after at least one microtask cycle, simulating
+  // a real delay (the hook should win the race when timeout is sane).
+  // For invalid-timeout cases the runtime uses the default (5000 ms) so the
+  // hook resolves first — we just need the timer NOT to fire immediately.
+  function makeFakeTimer() {
+    let cancelled = false;
+    const fakeSetTimer = (handler: () => void, _ms: number) => {
+      // Schedule with a real delay via setTimeout so the hook always wins.
+      const h = setTimeout(() => { if (!cancelled) handler(); }, 2000);
+      return h;
+    };
+    const fakeClearTimer = (h: unknown) => {
+      cancelled = true;
+      clearTimeout(h as ReturnType<typeof setTimeout>);
+    };
+    return { fakeSetTimer, fakeClearTimer };
+  }
+
+  test('beforeIrreversibleActionTimeoutMs: 0 → falls back to default, hook proceeds (not escalated)', async () => {
+    const { fakeSetTimer, fakeClearTimer } = makeFakeTimer();
+    const r = await runWithContract({
+      contract: { id: 'c', post: POST_OK, critical: true },
+      skill: async () => 'ok',
+      snapshot: async () => snap(),
+      beforeIrreversibleAction: makeInstantHook(),
+      beforeIrreversibleActionTimeoutMs: 0,
+      setTimer: fakeSetTimer,
+      clearTimer: fakeClearTimer,
+    });
+    expect(r.verdict).toBe('success');
+  });
+
+  test('beforeIrreversibleActionTimeoutMs: -5 → falls back to default, hook proceeds (not escalated)', async () => {
+    const { fakeSetTimer, fakeClearTimer } = makeFakeTimer();
+    const r = await runWithContract({
+      contract: { id: 'c', post: POST_OK, critical: true },
+      skill: async () => 'ok',
+      snapshot: async () => snap(),
+      beforeIrreversibleAction: makeInstantHook(),
+      beforeIrreversibleActionTimeoutMs: -5,
+      setTimer: fakeSetTimer,
+      clearTimer: fakeClearTimer,
+    });
+    expect(r.verdict).toBe('success');
+  });
+
+  test('beforeIrreversibleActionTimeoutMs: NaN → falls back to default, hook proceeds (not escalated)', async () => {
+    const { fakeSetTimer, fakeClearTimer } = makeFakeTimer();
+    const r = await runWithContract({
+      contract: { id: 'c', post: POST_OK, critical: true },
+      skill: async () => 'ok',
+      snapshot: async () => snap(),
+      beforeIrreversibleAction: makeInstantHook(),
+      beforeIrreversibleActionTimeoutMs: NaN,
+      setTimer: fakeSetTimer,
+      clearTimer: fakeClearTimer,
+    });
+    expect(r.verdict).toBe('success');
+  });
+
+  test('beforeIrreversibleActionTimeoutMs: 1000 → valid override applied, hook proceeds', async () => {
+    const { fakeSetTimer, fakeClearTimer } = makeFakeTimer();
+    const r = await runWithContract({
+      contract: { id: 'c', post: POST_OK, critical: true },
+      skill: async () => 'ok',
+      snapshot: async () => snap(),
+      beforeIrreversibleAction: makeInstantHook(),
+      beforeIrreversibleActionTimeoutMs: 1000,
+      setTimer: fakeSetTimer,
+      clearTimer: fakeClearTimer,
+    });
+    expect(r.verdict).toBe('success');
+  });
 });

--- a/tests/contracts/runtime-voting-hook.test.ts
+++ b/tests/contracts/runtime-voting-hook.test.ts
@@ -167,6 +167,52 @@ describe('runWithContract — beforeIrreversibleAction hook', () => {
     expect(records).toHaveLength(1);
   });
 
+  test('hook resolves to undefined → verdict=escalated with hook_invalid_response, audit record present, no thrown error', async () => {
+    const hook: BeforeIrreversibleActionHook = async () => undefined as unknown as never;
+    const { emitter, records } = captureEmitter();
+    const r = await runWithContract({
+      contract: { id: 'c', post: POST_OK, critical: true },
+      skill: async () => 'should not run',
+      snapshot: async () => snap(),
+      beforeIrreversibleAction: hook,
+      audit: emitter,
+    });
+    expect(r.verdict).toBe('escalated');
+    expect(r.error_message).toContain('hook_invalid_response');
+    expect(r.escalation?.target).toBe('human-review');
+    expect(records).toHaveLength(1);
+  });
+
+  test('hook resolves to {} (missing proceed) → verdict=escalated with hook_invalid_response', async () => {
+    const hook: BeforeIrreversibleActionHook = async () => ({} as unknown as never);
+    const { emitter, records } = captureEmitter();
+    const r = await runWithContract({
+      contract: { id: 'c', post: POST_OK, critical: true },
+      skill: async () => 'should not run',
+      snapshot: async () => snap(),
+      beforeIrreversibleAction: hook,
+      audit: emitter,
+    });
+    expect(r.verdict).toBe('escalated');
+    expect(r.error_message).toContain('hook_invalid_response');
+    expect(records).toHaveLength(1);
+  });
+
+  test('hook resolves to {proceed: "maybe"} (wrong type) → verdict=escalated with hook_invalid_response', async () => {
+    const hook: BeforeIrreversibleActionHook = async () => ({ proceed: 'maybe' } as unknown as never);
+    const { emitter, records } = captureEmitter();
+    const r = await runWithContract({
+      contract: { id: 'c', post: POST_OK, critical: true },
+      skill: async () => 'should not run',
+      snapshot: async () => snap(),
+      beforeIrreversibleAction: hook,
+      audit: emitter,
+    });
+    expect(r.verdict).toBe('escalated');
+    expect(r.error_message).toContain('hook_invalid_response');
+    expect(records).toHaveLength(1);
+  });
+
   test('escalated record contains pre_evidence (when pre present and passed)', async () => {
     const hook: BeforeIrreversibleActionHook = async () => ({ proceed: false });
     const r = await runWithContract({


### PR DESCRIPTION
## Summary

Adds `beforeIrreversibleAction` hook for `critical: true` contracts. The runtime calls registered hook(s) immediately before dispatching any action that would commit money / change account state / send a message. Hooks can **veto, escalate to handoff, or pass through**. This is the integration seam that #711 (multi-model voting, Epic #700) plugs into. Stacked on **#755**.

- `src/contracts/runtime.ts`
  - New optional `args.hooks.beforeIrreversibleAction?: (ctx) => Promise<HookVerdict>`
  - Called only when `contract.critical === true` AND the next action is in the `IRREVERSIBLE_ACTION_KINDS` set (`fill_form` with `submit`, `act` with intent containing "purchase|checkout|confirm|send|delete|pay", explicit `irreversible: true` flag)
  - `HookVerdict` ∈ `proceed | veto({reason}) | escalate({deepLink, reason})`
- `tests/contracts/before-irreversible.test.ts` — every verdict path, hook timeout (default 5s, configurable), multiple hooks composition (all-must-proceed semantics)

## Why a hook (not a hard-coded rule)

#711's voting logic, perception cross-check, and any future policy engine all need to gate the same set of irreversible actions. A hook seam keeps the runtime's responsibilities narrow and lets policy ship as a separate, swappable concern.

## What is deferred

- The actual #711 voting policy that consumes this hook → M3 PR (separate)
- A registry of irreversible action kinds beyond the conservative built-in set → out of scope; callers can use `irreversible: true` on the action

## Validation

- `npm run build` clean
- `npm test -- tests/contracts` — all green
- Pure runtime change: zero behavior change for non-`critical` contracts (hook is never called)

## Test plan

- [ ] Reviewer pulls and runs `npm install && npm run build && npm test -- tests/contracts`
- [ ] Reviewer confirms hook is **not** called for `critical: false` contracts (zero cost on the hot path)
- [ ] Reviewer confirms hook timeout is enforced and treated as `escalate` (fail-safe, not fail-open)
- [ ] Reviewer confirms multi-hook composition: any `veto` short-circuits; any `escalate` (in absence of veto) wins over `proceed`

Refs: #699 (epic) and #700 epic (#711). Stacked on #755.

🤖 Split from `feat/m1-pr1-trace-foundation`. Original commit: `929132a`.
