### PR TITLE
feat(perception): perceptual DOM metadata + cache (M3 PR-16)

### DIFF
--- a/src/perception/cache.ts
+++ b/src/perception/cache.ts
@@ -1,0 +1,89 @@
+/**
+ * Per-frame perceptual-metadata cache (#709 v2).
+ *
+ * Keyed on `(frameId, docCounter, viewportRect)` — invalidated on
+ * `DOM.documentUpdated` and `Page.frameResized`. Hosts call
+ * `bumpDoc(frameId)` from the CDP event handlers; the cache itself
+ * does not subscribe — that decoupling keeps the module pure-JS and
+ * easy to unit-test.
+ *
+ * The cache is keyed by a string built from the components above, so
+ * the implementation is just a Map under the hood. We give it a
+ * dedicated module so future strategies (LRU bounded by memory, etc.)
+ * are a non-breaking swap.
+ */
+
+import type { PerceptualMetadata, ViewportRect } from './types';
+
+interface CacheKey {
+  frameId: string;
+  docCounter: number;
+  viewport: ViewportRect;
+  backendNodeId: number;
+}
+
+function keyString(k: CacheKey): string {
+  return `${k.frameId}|${k.docCounter}|${k.viewport.x},${k.viewport.y},${k.viewport.w},${k.viewport.h}|${k.backendNodeId}`;
+}
+
+export class PerceptualCache {
+  private readonly entries = new Map<string, PerceptualMetadata>();
+  /** Per-frame monotonic doc counter. Bumped on DOM.documentUpdated. */
+  private readonly docCounters = new Map<string, number>();
+
+  /**
+   * Read or compute. The host supplies the `compute` function which is
+   * only invoked on a miss. The closure captures any node-probe state
+   * — the cache only deals with the cached value.
+   */
+  getOrCompute(
+    keyParts: { frameId: string; viewport: ViewportRect; backendNodeId: number },
+    compute: () => PerceptualMetadata,
+  ): PerceptualMetadata {
+    const docCounter = this.getDocCounter(keyParts.frameId);
+    const k = keyString({ ...keyParts, docCounter });
+    const hit = this.entries.get(k);
+    if (hit) return hit;
+    const fresh = compute();
+    this.entries.set(k, fresh);
+    return fresh;
+  }
+
+  /** Read without computing. Returns undefined on miss. */
+  get(
+    keyParts: { frameId: string; viewport: ViewportRect; backendNodeId: number },
+  ): PerceptualMetadata | undefined {
+    const docCounter = this.getDocCounter(keyParts.frameId);
+    return this.entries.get(keyString({ ...keyParts, docCounter }));
+  }
+
+  /**
+   * Invalidate every entry for `frameId`. Hosts call this from
+   * `DOM.documentUpdated` (or any equivalent invalidation signal).
+   */
+  bumpDoc(frameId: string): void {
+    const next = (this.docCounters.get(frameId) ?? 0) + 1;
+    this.docCounters.set(frameId, next);
+    // Drop entries for the previous counter — keep memory bounded.
+    const prefix = `${frameId}|${next - 1}|`;
+    for (const k of this.entries.keys()) {
+      if (k.startsWith(prefix)) this.entries.delete(k);
+    }
+  }
+
+  /** Drop everything (test hook + reset on serve restart). */
+  clear(): void {
+    this.entries.clear();
+    this.docCounters.clear();
+  }
+
+  /** Inspect the current docCounter for a frame (debug + tests). */
+  getDocCounter(frameId: string): number {
+    return this.docCounters.get(frameId) ?? 0;
+  }
+
+  /** For tests. */
+  size(): number {
+    return this.entries.size;
+  }
+}

--- a/src/perception/cache.ts
+++ b/src/perception/cache.ts
@@ -1,11 +1,14 @@
 /**
  * Per-frame perceptual-metadata cache (#709 v2).
  *
- * Keyed on `(frameId, docCounter, viewportRect)` — invalidated on
- * `DOM.documentUpdated` and `Page.frameResized`. Hosts call
- * `bumpDoc(frameId)` from the CDP event handlers; the cache itself
- * does not subscribe — that decoupling keeps the module pure-JS and
- * easy to unit-test.
+ * Keyed on `(frameId, docCounter, viewportRect, backendNodeId, styleHash)` —
+ * invalidated on `DOM.documentUpdated`, `Page.frameResized`, and computed-style
+ * changes. `docCounter` handles full document replacement; `styleHash` handles
+ * in-document SPA mutations (class/attribute/style changes that flip display,
+ * visibility, pointer-events, or geometry) without a documentUpdated event.
+ * Hosts call `bumpDoc(frameId)` from the CDP event handlers; the cache itself
+ * does not subscribe — that decoupling keeps the module pure-JS and easy to
+ * unit-test.
  *
  * The cache is keyed by a string built from the components above, so
  * the implementation is just a Map under the hood. We give it a
@@ -13,17 +16,40 @@
  * are a non-breaking swap.
  */
 
-import type { PerceptualMetadata, ViewportRect } from './types';
+import type { NodeProbe, PerceptualMetadata, ViewportRect } from './types';
 
 interface CacheKey {
   frameId: string;
   docCounter: number;
   viewport: ViewportRect;
   backendNodeId: number;
+  styleHash: string;
 }
 
 function keyString(k: CacheKey): string {
-  return `${k.frameId}|${k.docCounter}|${k.viewport.x},${k.viewport.y},${k.viewport.w},${k.viewport.h}|${k.backendNodeId}`;
+  return `${k.frameId}|${k.docCounter}|${k.viewport.x},${k.viewport.y},${k.viewport.w},${k.viewport.h}|${k.backendNodeId}|${k.styleHash}`;
+}
+
+/**
+ * Compute a stable hash of the perceptually-relevant fields from a NodeProbe.
+ * Include this in the `styleHash` key part so that in-document SPA mutations
+ * (which do not fire DOM.documentUpdated) still produce a cache miss.
+ */
+export function computeStyleHash(probe: Pick<NodeProbe,
+  'display' | 'visibility' | 'pointerEvents' | 'pixelBox' |
+  'opacityChain' | 'ancestorDisplayNone' | 'ancestorVisibilityHidden'
+>): string {
+  const box = probe.pixelBox;
+  const boxStr = box ? `${box.x},${box.y},${box.w},${box.h}` : 'null';
+  return [
+    probe.display,
+    probe.visibility,
+    probe.pointerEvents ?? 'auto',
+    probe.ancestorDisplayNone ? '1' : '0',
+    probe.ancestorVisibilityHidden ? '1' : '0',
+    probe.opacityChain.join(','),
+    boxStr,
+  ].join('|');
 }
 
 export class PerceptualCache {
@@ -40,11 +66,13 @@ export class PerceptualCache {
 
   /**
    * Read or compute. The host supplies the `compute` function which is
-   * only invoked on a miss. The closure captures any node-probe state
-   * — the cache only deals with the cached value.
+   * only invoked on a miss. The `styleHash` must be derived from the
+   * current NodeProbe via `computeStyleHash` before calling — a changed
+   * hash produces a new key string and thus a cache miss, defeating
+   * in-document SPA staleness.
    */
   getOrCompute(
-    keyParts: { frameId: string; viewport: ViewportRect; backendNodeId: number },
+    keyParts: { frameId: string; viewport: ViewportRect; backendNodeId: number; styleHash: string },
     compute: () => PerceptualMetadata,
   ): PerceptualMetadata {
     const docCounter = this.getDocCounter(keyParts.frameId);
@@ -59,7 +87,7 @@ export class PerceptualCache {
 
   /** Read without computing. Returns undefined on miss. */
   get(
-    keyParts: { frameId: string; viewport: ViewportRect; backendNodeId: number },
+    keyParts: { frameId: string; viewport: ViewportRect; backendNodeId: number; styleHash: string },
   ): PerceptualMetadata | undefined {
     const docCounter = this.getDocCounter(keyParts.frameId);
     return this.entries.get(keyString({ ...keyParts, docCounter }));

--- a/src/perception/cache.ts
+++ b/src/perception/cache.ts
@@ -103,6 +103,18 @@ export class PerceptualCache {
     const k = keyString({ ...keyParts, docCounter });
     const hit = this.entries.get(k);
     if (hit) return hit;
+    // Evict any prior-version entry for the same node identity (same
+    // frameId+docCounter+viewport+backendNodeId) that carries a different
+    // styleHash.  Each node has exactly one current version; older hashes
+    // accumulate on long-lived pages with frequent SPA mutations and are
+    // now unreachable (their key changed) but were never removed.
+    const vpStr = `${keyParts.viewport.x},${keyParts.viewport.y},${keyParts.viewport.w},${keyParts.viewport.h}`;
+    const nodePrefix = `${keyParts.frameId}|${docCounter}|${vpStr}|${keyParts.backendNodeId}|`;
+    for (const existing of this.entries.keys()) {
+      if (existing.startsWith(nodePrefix) && existing !== k) {
+        this.entries.delete(existing);
+      }
+    }
     const fresh = compute();
     this.entries.set(k, fresh);
     return fresh;

--- a/src/perception/cache.ts
+++ b/src/perception/cache.ts
@@ -14,6 +14,12 @@
  * the implementation is just a Map under the hood. We give it a
  * dedicated module so future strategies (LRU bounded by memory, etc.)
  * are a non-breaking swap.
+ *
+ * `styleHash` now covers ALL fields that `computePerceptualMetadata` reads,
+ * including `topElementBackendNodeId`, `descendantBackendNodeIds`, and
+ * `hasChildBoxes` — not just CSS style fields. This prevents stale entries
+ * when an overlay appears/disappears or a display:contents child-box state
+ * changes without triggering a documentUpdated event.
  */
 
 import type { NodeProbe, PerceptualMetadata, ViewportRect } from './types';
@@ -31,16 +37,30 @@ function keyString(k: CacheKey): string {
 }
 
 /**
- * Compute a stable hash of the perceptually-relevant fields from a NodeProbe.
- * Include this in the `styleHash` key part so that in-document SPA mutations
- * (which do not fire DOM.documentUpdated) still produce a cache miss.
+ * Compute a stable hash of ALL fields that `computePerceptualMetadata` reads
+ * from a NodeProbe. Include this in the `styleHash` key part so that
+ * in-document SPA mutations (which do not fire DOM.documentUpdated) still
+ * produce a cache miss.
+ *
+ * Covered fields:
+ *   - CSS/style: display, visibility, pointerEvents, opacityChain,
+ *     ancestorDisplayNone, ancestorVisibilityHidden, pixelBox
+ *   - Overlay/hit-test: topElementBackendNodeId
+ *   - Descendant set: descendantBackendNodeIds (serialised as a sorted array
+ *     for stability — set iteration order is insertion-order and may vary)
+ *   - display:contents child-box predicate: hasChildBoxes
  */
 export function computeStyleHash(probe: Pick<NodeProbe,
   'display' | 'visibility' | 'pointerEvents' | 'pixelBox' |
-  'opacityChain' | 'ancestorDisplayNone' | 'ancestorVisibilityHidden'
+  'opacityChain' | 'ancestorDisplayNone' | 'ancestorVisibilityHidden' |
+  'topElementBackendNodeId' | 'descendantBackendNodeIds' | 'hasChildBoxes'
 >): string {
   const box = probe.pixelBox;
   const boxStr = box ? `${box.x},${box.y},${box.w},${box.h}` : 'null';
+  const topId = probe.topElementBackendNodeId === null ? 'null' : String(probe.topElementBackendNodeId);
+  const descIds = probe.descendantBackendNodeIds !== undefined
+    ? [...probe.descendantBackendNodeIds].sort((a, b) => a - b).join(',')
+    : '';
   return [
     probe.display,
     probe.visibility,
@@ -49,6 +69,9 @@ export function computeStyleHash(probe: Pick<NodeProbe,
     probe.ancestorVisibilityHidden ? '1' : '0',
     probe.opacityChain.join(','),
     boxStr,
+    topId,
+    descIds,
+    probe.hasChildBoxes ? '1' : '0',
   ].join('|');
 }
 

--- a/src/perception/cache.ts
+++ b/src/perception/cache.ts
@@ -30,6 +30,13 @@ export class PerceptualCache {
   private readonly entries = new Map<string, PerceptualMetadata>();
   /** Per-frame monotonic doc counter. Bumped on DOM.documentUpdated. */
   private readonly docCounters = new Map<string, number>();
+  /**
+   * Last-seen viewport per `frameId|docCounter`. When the viewport
+   * changes for a given doc, all entries with the previous viewport
+   * are evicted so memory stays bounded across window resizes and
+   * device-emulation toggles — matching the header-comment contract.
+   */
+  private readonly lastViewport = new Map<string, string>();
 
   /**
    * Read or compute. The host supplies the `compute` function which is
@@ -41,6 +48,7 @@ export class PerceptualCache {
     compute: () => PerceptualMetadata,
   ): PerceptualMetadata {
     const docCounter = this.getDocCounter(keyParts.frameId);
+    this.evictStaleViewport(keyParts.frameId, docCounter, keyParts.viewport);
     const k = keyString({ ...keyParts, docCounter });
     const hit = this.entries.get(k);
     if (hit) return hit;
@@ -69,12 +77,37 @@ export class PerceptualCache {
     for (const k of this.entries.keys()) {
       if (k.startsWith(prefix)) this.entries.delete(k);
     }
+    // Drop the stale-viewport tracking key for the old counter.
+    this.lastViewport.delete(`${frameId}|${next - 1}`);
   }
 
   /** Drop everything (test hook + reset on serve restart). */
   clear(): void {
     this.entries.clear();
     this.docCounters.clear();
+    this.lastViewport.clear();
+  }
+
+  /**
+   * If the incoming viewport for `(frameId, docCounter)` differs from
+   * the last-seen one, evict all entries that share the old viewport
+   * prefix for this doc, then record the new viewport as current.
+   */
+  private evictStaleViewport(frameId: string, docCounter: number, viewport: ViewportRect): void {
+    const vpStr = `${viewport.x},${viewport.y},${viewport.w},${viewport.h}`;
+    const trackKey = `${frameId}|${docCounter}`;
+    const prev = this.lastViewport.get(trackKey);
+    if (prev === undefined) {
+      this.lastViewport.set(trackKey, vpStr);
+      return;
+    }
+    if (prev === vpStr) return;
+    // Viewport changed — drop all cached entries for the old viewport.
+    const stalePrefix = `${frameId}|${docCounter}|${prev}|`;
+    for (const k of this.entries.keys()) {
+      if (k.startsWith(stalePrefix)) this.entries.delete(k);
+    }
+    this.lastViewport.set(trackKey, vpStr);
   }
 
   /** Inspect the current docCounter for a frame (debug + tests). */

--- a/src/perception/cache.ts
+++ b/src/perception/cache.ts
@@ -113,6 +113,19 @@ export class PerceptualCache {
     keyParts: { frameId: string; viewport: ViewportRect; backendNodeId: number; styleHash: string },
   ): PerceptualMetadata | undefined {
     const docCounter = this.getDocCounter(keyParts.frameId);
+    const vpStr = `${keyParts.viewport.x},${keyParts.viewport.y},${keyParts.viewport.w},${keyParts.viewport.h}`;
+    const trackKey = `${keyParts.frameId}|${docCounter}`;
+    const lastVp = this.lastViewport.get(trackKey);
+    // If a viewport was previously recorded and it differs from the caller's
+    // viewport, the cached entries belong to a different viewport era.  Return
+    // undefined immediately so the caller is forced to recompute via
+    // getOrCompute, which will evict the stale entries and advance lastViewport.
+    // We do not mutate lastViewport here — only getOrCompute owns that
+    // transition, preventing accidental regression to a stale viewport on
+    // read-only call paths.
+    if (lastVp !== undefined && lastVp !== vpStr) {
+      return undefined;
+    }
     return this.entries.get(keyString({ ...keyParts, docCounter }));
   }
 

--- a/src/perception/index.ts
+++ b/src/perception/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Adversarial-Robust Perception barrel (#700). PR-16 ships the
+ * metadata classifier + cache; PR-17 will add cross-check + image
+ * features; PR-18 wires the pre-action hook; PR-19 adds multi-model
+ * voting.
+ */
+
+export { computePerceptualMetadata, effectiveOpacity, intersects } from './metadata';
+export { PerceptualCache } from './cache';
+export type {
+  EffectiveDisplay,
+  InteractionFeasibility,
+  NodeProbe,
+  PerceptualMetadata,
+  PixelBox,
+  ViewportRect,
+} from './types';

--- a/src/perception/index.ts
+++ b/src/perception/index.ts
@@ -6,7 +6,7 @@
  */
 
 export { computePerceptualMetadata, effectiveOpacity, intersects } from './metadata';
-export { PerceptualCache } from './cache';
+export { PerceptualCache, computeStyleHash } from './cache';
 export type {
   EffectiveDisplay,
   InteractionFeasibility,

--- a/src/perception/metadata.ts
+++ b/src/perception/metadata.ts
@@ -1,0 +1,127 @@
+/**
+ * Perceptual metadata classifier (#709).
+ *
+ * Pure function — no CDP, no DOM, no I/O. Hosts (the dom-serializer
+ * pipeline + the cross-check module #710) build a `NodeProbe` from
+ * live state and call `computePerceptualMetadata` to get the
+ * structured classification an LLM can reason about.
+ */
+
+import type {
+  EffectiveDisplay,
+  InteractionFeasibility,
+  NodeProbe,
+  PerceptualMetadata,
+  PixelBox,
+  ViewportRect,
+} from './types';
+
+/** Multiply the opacity chain. Empty chain → 1.0. */
+export function effectiveOpacity(chain: ReadonlyArray<number>): number {
+  if (chain.length === 0) return 1;
+  let v = 1;
+  for (const o of chain) v *= clamp01(o);
+  return v;
+}
+
+function clamp01(v: number): number {
+  if (!Number.isFinite(v)) return 1;
+  if (v < 0) return 0;
+  if (v > 1) return 1;
+  return v;
+}
+
+/** Strict pixel-rectangle intersection (positive overlap on both axes). */
+export function intersects(a: PixelBox, b: ViewportRect): boolean {
+  if (a.w <= 0 || a.h <= 0) return false;
+  if (b.w <= 0 || b.h <= 0) return false;
+  const ax2 = a.x + a.w;
+  const ay2 = a.y + a.h;
+  const bx2 = b.x + b.w;
+  const by2 = b.y + b.h;
+  return a.x < bx2 && ax2 > b.x && a.y < by2 && ay2 > b.y;
+}
+
+function isZeroSize(box: PixelBox | null): boolean {
+  if (!box) return true;
+  return box.w <= 0 || box.h <= 0;
+}
+
+function classifyEffectiveDisplay(probe: NodeProbe): EffectiveDisplay {
+  if (probe.ancestorDisplayNone || probe.display === 'none') return 'hidden_display_none';
+  if (probe.ancestorVisibilityHidden || probe.visibility === 'hidden' || probe.visibility === 'collapse') {
+    return 'hidden_visibility';
+  }
+  // display: contents — node has no box; bucket depends on whether any
+  // descendant has one (per #709 v2 P1 fix for the missing enum value).
+  if (probe.display === 'contents') {
+    return probe.hasChildBoxes ? 'rendered' : 'display_contents_no_box';
+  }
+  return 'rendered';
+}
+
+function classifyInteractionFeasibility(
+  effective: EffectiveDisplay,
+  box: PixelBox | null,
+  viewport: ViewportRect,
+  topElementMatches: boolean,
+): InteractionFeasibility {
+  if (effective !== 'rendered' && effective !== 'covered_by' && effective !== 'off_screen') {
+    return 'outside_viewport'; // hidden/collapsed/contents-no-box → all flat-out unreachable
+  }
+  if (isZeroSize(box)) return 'zero_size';
+  if (!box) return 'zero_size';
+  if (effective === 'off_screen' || !intersects(box, viewport)) return 'outside_viewport';
+  if (!topElementMatches) return 'blocked_by_overlay';
+  return 'ok';
+}
+
+/**
+ * Top-level: probe + viewport → PerceptualMetadata.
+ *
+ * Hosts may set `topElementBackendNodeId` to null when they did not
+ * call `elementFromPoint` (e.g., bulk read_page mode); the rollup then
+ * conservatively assumes the node is on top — this is the same default
+ * the legacy compression layer used.
+ */
+export function computePerceptualMetadata(
+  probe: NodeProbe,
+  viewport: ViewportRect,
+): PerceptualMetadata {
+  const baseDisplay = classifyEffectiveDisplay(probe);
+  const opacity = effectiveOpacity(probe.opacityChain);
+  const box = probe.pixelBox;
+
+  // off_screen takes priority over covered_by — there's nothing to
+  // cover an element that isn't on screen in the first place.
+  let effective: EffectiveDisplay = baseDisplay;
+  if (effective === 'rendered' && box && !intersects(box, viewport)) {
+    effective = 'off_screen';
+  }
+
+  // covered_by is computed AFTER off-screen so we never falsely report
+  // "covered" for a node that's simply outside the viewport.
+  let coveredByNodeId: number | undefined;
+  if (effective === 'rendered' && probe.topElementBackendNodeId !== null) {
+    if (probe.topElementBackendNodeId !== probe.backendNodeId) {
+      effective = 'covered_by';
+      coveredByNodeId = probe.topElementBackendNodeId;
+    }
+  }
+
+  const topElementMatches =
+    probe.topElementBackendNodeId === null ||
+    probe.topElementBackendNodeId === probe.backendNodeId;
+
+  const feasibility = classifyInteractionFeasibility(effective, box, viewport, topElementMatches);
+
+  const md: PerceptualMetadata = {
+    pixelBox: box,
+    viewportVisible: !!box && intersects(box, viewport),
+    effectiveOpacity: opacity,
+    effectiveDisplay: effective,
+    interactionFeasibility: feasibility,
+  };
+  if (coveredByNodeId !== undefined) md.coveredByNodeId = coveredByNodeId;
+  return md;
+}

--- a/src/perception/metadata.ts
+++ b/src/perception/metadata.ts
@@ -105,8 +105,12 @@ export function computePerceptualMetadata(
   // "covered" for a node that's simply outside the viewport.
   // A hit on a descendant of the target is NOT an overlay — the target
   // itself is the interactable surface (e.g. <button> containing <span>).
+  // When pointer-events:none is set, elementFromPoint legitimately returns
+  // the element underneath — that is expected behavior, not an overlay.
+  const pointerEventsNone = probe.pointerEvents === 'none';
+
   let coveredByNodeId: number | undefined;
-  if (effective === 'rendered' && probe.topElementBackendNodeId !== null) {
+  if (effective === 'rendered' && !pointerEventsNone && probe.topElementBackendNodeId !== null) {
     const hitId = probe.topElementBackendNodeId;
     const isSelf = hitId === probe.backendNodeId;
     const isDescendant =
@@ -125,8 +129,6 @@ export function computePerceptualMetadata(
     (probe.descendantBackendNodeIds !== undefined &&
       probe.topElementBackendNodeId !== null &&
       probe.descendantBackendNodeIds.has(probe.topElementBackendNodeId));
-
-  const pointerEventsNone = probe.pointerEvents === 'none';
 
   const feasibility = classifyInteractionFeasibility(effective, box, viewport, topElementMatches, pointerEventsNone);
 

--- a/src/perception/metadata.ts
+++ b/src/perception/metadata.ts
@@ -144,9 +144,7 @@ export function computePerceptualMetadata(
 
   const md: PerceptualMetadata = {
     pixelBox: box,
-    viewportVisible:
-      (!!box && intersects(box, viewport)) ||
-      (!box && probe.display === 'contents' && (probe.hasChildBoxes ?? false)),
+    viewportVisible: !!box && intersects(box, viewport),
     effectiveOpacity: opacity,
     effectiveDisplay: effective,
     interactionFeasibility: feasibility,

--- a/src/perception/metadata.ts
+++ b/src/perception/metadata.ts
@@ -140,7 +140,9 @@ export function computePerceptualMetadata(
 
   const md: PerceptualMetadata = {
     pixelBox: box,
-    viewportVisible: !!box && intersects(box, viewport),
+    viewportVisible:
+      (!!box && intersects(box, viewport)) ||
+      (!box && probe.display === 'contents' && (probe.hasChildBoxes ?? false)),
     effectiveOpacity: opacity,
     effectiveDisplay: effective,
     interactionFeasibility: feasibility,

--- a/src/perception/metadata.ts
+++ b/src/perception/metadata.ts
@@ -49,7 +49,11 @@ function isZeroSize(box: PixelBox | null): boolean {
 
 function classifyEffectiveDisplay(probe: NodeProbe): EffectiveDisplay {
   if (probe.ancestorDisplayNone || probe.display === 'none') return 'hidden_display_none';
-  if (probe.ancestorVisibilityHidden || probe.visibility === 'hidden' || probe.visibility === 'collapse') {
+  if (
+    probe.visibility === 'hidden' ||
+    probe.visibility === 'collapse' ||
+    (probe.ancestorVisibilityHidden && probe.visibility !== 'visible')
+  ) {
     return 'hidden_visibility';
   }
   // display: contents — node has no box; bucket depends on whether any

--- a/src/perception/metadata.ts
+++ b/src/perception/metadata.ts
@@ -66,13 +66,19 @@ function classifyInteractionFeasibility(
   viewport: ViewportRect,
   topElementMatches: boolean,
   pointerEventsNone: boolean,
+  display: string,
+  hasChildBoxes: boolean,
 ): InteractionFeasibility {
   if (effective !== 'rendered' && effective !== 'covered_by' && effective !== 'off_screen') {
     return 'outside_viewport'; // hidden/collapsed/contents-no-box → all flat-out unreachable
   }
-  if (isZeroSize(box)) return 'zero_size';
-  if (!box) return 'zero_size';
-  if (effective === 'off_screen' || !intersects(box, viewport)) return 'outside_viewport';
+  // display:contents nodes have no own box — their rendered geometry comes
+  // from descendants.  When child boxes exist the node IS interactable via
+  // its children; skip zero_size so feasibility falls through to the normal
+  // path (mirroring how classifyEffectiveDisplay returns 'rendered' here).
+  if (isZeroSize(box) && !(display === 'contents' && hasChildBoxes)) return 'zero_size';
+  if (!box && !(display === 'contents' && hasChildBoxes)) return 'zero_size';
+  if (effective === 'off_screen' || (box && !intersects(box, viewport))) return 'outside_viewport';
   if (pointerEventsNone) return 'pointer_events_none';
   if (!topElementMatches) return 'blocked_by_overlay';
   return 'ok';
@@ -130,7 +136,7 @@ export function computePerceptualMetadata(
       probe.topElementBackendNodeId !== null &&
       probe.descendantBackendNodeIds.has(probe.topElementBackendNodeId));
 
-  const feasibility = classifyInteractionFeasibility(effective, box, viewport, topElementMatches, pointerEventsNone);
+  const feasibility = classifyInteractionFeasibility(effective, box, viewport, topElementMatches, pointerEventsNone, probe.display, probe.hasChildBoxes ?? false);
 
   const md: PerceptualMetadata = {
     pixelBox: box,

--- a/src/perception/metadata.ts
+++ b/src/perception/metadata.ts
@@ -65,6 +65,7 @@ function classifyInteractionFeasibility(
   box: PixelBox | null,
   viewport: ViewportRect,
   topElementMatches: boolean,
+  pointerEventsNone: boolean,
 ): InteractionFeasibility {
   if (effective !== 'rendered' && effective !== 'covered_by' && effective !== 'off_screen') {
     return 'outside_viewport'; // hidden/collapsed/contents-no-box → all flat-out unreachable
@@ -72,6 +73,7 @@ function classifyInteractionFeasibility(
   if (isZeroSize(box)) return 'zero_size';
   if (!box) return 'zero_size';
   if (effective === 'off_screen' || !intersects(box, viewport)) return 'outside_viewport';
+  if (pointerEventsNone) return 'pointer_events_none';
   if (!topElementMatches) return 'blocked_by_overlay';
   return 'ok';
 }
@@ -101,19 +103,32 @@ export function computePerceptualMetadata(
 
   // covered_by is computed AFTER off-screen so we never falsely report
   // "covered" for a node that's simply outside the viewport.
+  // A hit on a descendant of the target is NOT an overlay — the target
+  // itself is the interactable surface (e.g. <button> containing <span>).
   let coveredByNodeId: number | undefined;
   if (effective === 'rendered' && probe.topElementBackendNodeId !== null) {
-    if (probe.topElementBackendNodeId !== probe.backendNodeId) {
+    const hitId = probe.topElementBackendNodeId;
+    const isSelf = hitId === probe.backendNodeId;
+    const isDescendant =
+      !isSelf &&
+      probe.descendantBackendNodeIds !== undefined &&
+      probe.descendantBackendNodeIds.has(hitId);
+    if (!isSelf && !isDescendant) {
       effective = 'covered_by';
-      coveredByNodeId = probe.topElementBackendNodeId;
+      coveredByNodeId = hitId;
     }
   }
 
   const topElementMatches =
     probe.topElementBackendNodeId === null ||
-    probe.topElementBackendNodeId === probe.backendNodeId;
+    probe.topElementBackendNodeId === probe.backendNodeId ||
+    (probe.descendantBackendNodeIds !== undefined &&
+      probe.topElementBackendNodeId !== null &&
+      probe.descendantBackendNodeIds.has(probe.topElementBackendNodeId));
 
-  const feasibility = classifyInteractionFeasibility(effective, box, viewport, topElementMatches);
+  const pointerEventsNone = probe.pointerEvents === 'none';
+
+  const feasibility = classifyInteractionFeasibility(effective, box, viewport, topElementMatches, pointerEventsNone);
 
   const md: PerceptualMetadata = {
     pixelBox: box,

--- a/src/perception/types.ts
+++ b/src/perception/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared types for the Adversarial-Robust Perception subsystem (#700).
+ *
+ * The compression layer (`src/dom/dom-serializer.ts`) and the cross-
+ * check module (#710) both consume these — keeping the shapes in one
+ * file avoids drift.
+ */
+
+export interface ViewportRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface PixelBox {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * `effectiveDisplay` enum per #709 v2:
+ *   rendered                 — element has a box and is laid out
+ *   hidden_display_none      — display:none anywhere on ancestor chain
+ *   hidden_visibility        — visibility:hidden / collapse
+ *   off_screen               — pixelBox does not intersect the viewport
+ *   covered_by               — elementFromPoint at center is a different node
+ *   display_contents_no_box  — display:contents (parent has no box itself)
+ */
+export type EffectiveDisplay =
+  | 'rendered'
+  | 'hidden_display_none'
+  | 'hidden_visibility'
+  | 'off_screen'
+  | 'covered_by'
+  | 'display_contents_no_box';
+
+export type InteractionFeasibility =
+  | 'ok'
+  | 'blocked_by_overlay'
+  | 'outside_viewport'
+  | 'zero_size';
+
+export interface PerceptualMetadata {
+  /** Element bounding box in viewport coordinates. Null when no layout. */
+  pixelBox: PixelBox | null;
+  /** True iff pixelBox intersects the viewport. */
+  viewportVisible: boolean;
+  /** Cumulative opacity from root to this node (0..1). */
+  effectiveOpacity: number;
+  effectiveDisplay: EffectiveDisplay;
+  /** When effectiveDisplay === 'covered_by', the covering node. */
+  coveredByNodeId?: number;
+  /** Derived rollup callers can switch on without re-implementing rules. */
+  interactionFeasibility: InteractionFeasibility;
+}
+
+/** Per-node input the metadata function consumes. */
+export interface NodeProbe {
+  /** Stable CDP backendNodeId. NEVER use the unstable `nodeId`. */
+  backendNodeId: number;
+  /** Computed `display`: `block`, `none`, `contents`, `flex`, ... */
+  display: string;
+  /** Computed `visibility`: `visible`, `hidden`, `collapse`. */
+  visibility: string;
+  /**
+   * Cumulative opacity values from the document root down to this node
+   * (each multiplied yields effectiveOpacity). Empty array → 1.0.
+   */
+  opacityChain: number[];
+  /** Box model from `DOM.getBoxModel`; null when the node has no layout. */
+  pixelBox: PixelBox | null;
+  /**
+   * `document.elementFromPoint(cx, cy)` resolved to backendNodeId, or
+   * null when nothing was found / the call wasn't made.
+   */
+  topElementBackendNodeId: number | null;
+  /**
+   * True iff at least one descendant has a layout box. Only used for
+   * `display: contents` classification — set to false for ordinary
+   * leaves (it's just the predicate "do my children have boxes").
+   */
+  hasChildBoxes: boolean;
+  /**
+   * True iff any ancestor has display:none / visibility:hidden. Saves
+   * the metadata function from re-walking the chain.
+   */
+  ancestorDisplayNone: boolean;
+  ancestorVisibilityHidden: boolean;
+}

--- a/src/perception/types.ts
+++ b/src/perception/types.ts
@@ -41,7 +41,8 @@ export type InteractionFeasibility =
   | 'ok'
   | 'blocked_by_overlay'
   | 'outside_viewport'
-  | 'zero_size';
+  | 'zero_size'
+  | 'pointer_events_none';
 
 export interface PerceptualMetadata {
   /** Element bounding box in viewport coordinates. Null when no layout. */
@@ -77,6 +78,18 @@ export interface NodeProbe {
    * null when nothing was found / the call wasn't made.
    */
   topElementBackendNodeId: number | null;
+  /**
+   * Computed `pointer-events` CSS value (e.g. `'none'`, `'auto'`, `'all'`).
+   * When undefined the field is treated as `'auto'` (pointer events enabled).
+   */
+  pointerEvents?: string;
+  /**
+   * Set of backendNodeIds of all descendants of this node. Used to
+   * distinguish "hit a child of myself" (not an overlay) from "hit a
+   * truly foreign element" (real overlay). When undefined or empty the
+   * descendant check is skipped and any foreign hit is treated as an overlay.
+   */
+  descendantBackendNodeIds?: ReadonlySet<number>;
   /**
    * True iff at least one descendant has a layout box. Only used for
    * `display: contents` classification — set to false for ordinary

--- a/tests/perception/cache.test.ts
+++ b/tests/perception/cache.test.ts
@@ -239,6 +239,53 @@ describe('PerceptualCache — style-hash invalidation (SPA in-document mutations
   });
 });
 
+describe('PerceptualCache — style-hash eviction (same node identity, new hash)', () => {
+  test('inserting hash-B for a node evicts the prior hash-A entry; only hash-B remains', () => {
+    const cache = new PerceptualCache();
+
+    const hashA = computeStyleHash(probe({ display: 'block' }));
+    cache.getOrCompute(
+      { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 5, styleHash: hashA },
+      () => md({ effectiveDisplay: 'rendered' }),
+    );
+    expect(cache.size()).toBe(1);
+
+    // SPA mutation — display flips, producing a new hash.
+    const hashB = computeStyleHash(probe({ display: 'none' }));
+    expect(hashB).not.toBe(hashA);
+
+    cache.getOrCompute(
+      { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 5, styleHash: hashB },
+      () => md({ effectiveDisplay: 'hidden_display_none' }),
+    );
+    // Only the hash-B entry must remain; the superseded hash-A entry is gone.
+    expect(cache.size()).toBe(1);
+    expect(cache.get({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 5, styleHash: hashA })).toBeUndefined();
+    expect(cache.get({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 5, styleHash: hashB })).toBeDefined();
+  });
+
+  test('eviction is scoped to the mutated node; sibling node entries survive', () => {
+    const cache = new PerceptualCache();
+
+    const hashA = computeStyleHash(probe({ display: 'block' }));
+    cache.getOrCompute({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 5, styleHash: hashA }, () => md());
+    cache.getOrCompute({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 6, styleHash: hashA }, () => md());
+    expect(cache.size()).toBe(2);
+
+    // Only node 5 mutates.
+    const hashB = computeStyleHash(probe({ display: 'none' }));
+    cache.getOrCompute({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 5, styleHash: hashB }, () => md());
+
+    // Node 6's hash-A entry must still be present.
+    expect(cache.get({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 6, styleHash: hashA })).toBeDefined();
+    // Node 5's old hash-A entry is gone; new hash-B is present.
+    expect(cache.get({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 5, styleHash: hashA })).toBeUndefined();
+    expect(cache.get({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 5, styleHash: hashB })).toBeDefined();
+    // Total: 2 entries (node-6 hashA + node-5 hashB).
+    expect(cache.size()).toBe(2);
+  });
+});
+
 describe('PerceptualCache — probe-field invalidation (overlay / descendant / child-box)', () => {
   test('topElementBackendNodeId flip → recompute (overlay appearance simulated)', () => {
     const cache = new PerceptualCache();

--- a/tests/perception/cache.test.ts
+++ b/tests/perception/cache.test.ts
@@ -17,7 +17,8 @@ function md(extra: Partial<PerceptualMetadata> = {}): PerceptualMetadata {
 /** Minimal NodeProbe fragment for style-hash tests. */
 function probe(extra: Partial<Pick<NodeProbe,
   'display' | 'visibility' | 'pointerEvents' | 'pixelBox' |
-  'opacityChain' | 'ancestorDisplayNone' | 'ancestorVisibilityHidden'
+  'opacityChain' | 'ancestorDisplayNone' | 'ancestorVisibilityHidden' |
+  'topElementBackendNodeId' | 'descendantBackendNodeIds' | 'hasChildBoxes'
 >> = {}): Parameters<typeof computeStyleHash>[0] {
   return {
     display: 'block',
@@ -27,6 +28,9 @@ function probe(extra: Partial<Pick<NodeProbe,
     opacityChain: [1],
     ancestorDisplayNone: false,
     ancestorVisibilityHidden: false,
+    topElementBackendNodeId: 1,
+    descendantBackendNodeIds: undefined,
+    hasChildBoxes: false,
     ...extra,
   };
 }
@@ -202,5 +206,84 @@ describe('PerceptualCache — style-hash invalidation (SPA in-document mutations
     expect(computeStyleHash({ ...base, opacityChain: [0.5] })).not.toBe(computeStyleHash(base));
     expect(computeStyleHash({ ...base, pixelBox: { x: 0, y: 0, w: 20, h: 20 } })).not.toBe(computeStyleHash(base));
     expect(computeStyleHash({ ...base, pixelBox: null })).not.toBe(computeStyleHash(base));
+    // Probe fields read by computePerceptualMetadata that were previously omitted.
+    expect(computeStyleHash({ ...base, topElementBackendNodeId: 99 })).not.toBe(computeStyleHash(base));
+    expect(computeStyleHash({ ...base, topElementBackendNodeId: null })).not.toBe(computeStyleHash(base));
+    expect(computeStyleHash({ ...base, descendantBackendNodeIds: new Set([10, 20]) })).not.toBe(computeStyleHash(base));
+    expect(computeStyleHash({ ...base, hasChildBoxes: true })).not.toBe(computeStyleHash(base));
+  });
+});
+
+describe('PerceptualCache — probe-field invalidation (overlay / descendant / child-box)', () => {
+  test('topElementBackendNodeId flip → recompute (overlay appearance simulated)', () => {
+    const cache = new PerceptualCache();
+    let calls = 0;
+
+    // Initial state: node is on top (topElementBackendNodeId === backendNodeId).
+    const hashBefore = computeStyleHash(probe({ topElementBackendNodeId: 1 }));
+    cache.getOrCompute(
+      { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1, styleHash: hashBefore },
+      () => { calls++; return md({ effectiveDisplay: 'rendered', interactionFeasibility: 'ok' }); },
+    );
+    expect(calls).toBe(1);
+
+    // Overlay appears: elementFromPoint now returns a different node (id 99).
+    const hashAfter = computeStyleHash(probe({ topElementBackendNodeId: 99 }));
+    expect(hashAfter).not.toBe(hashBefore);
+
+    const result = cache.getOrCompute(
+      { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1, styleHash: hashAfter },
+      () => { calls++; return md({ effectiveDisplay: 'covered_by', interactionFeasibility: 'blocked_by_overlay' }); },
+    );
+    // Must recompute — stale entry must NOT be returned.
+    expect(calls).toBe(2);
+    expect(result.effectiveDisplay).toBe('covered_by');
+    expect(result.interactionFeasibility).toBe('blocked_by_overlay');
+  });
+
+  test('descendantBackendNodeIds change → recompute', () => {
+    const cache = new PerceptualCache();
+    let calls = 0;
+
+    const hashBefore = computeStyleHash(probe({ descendantBackendNodeIds: new Set([10]) }));
+    cache.getOrCompute(
+      { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1, styleHash: hashBefore },
+      () => { calls++; return md(); },
+    );
+    expect(calls).toBe(1);
+
+    // Descendant set grows (e.g. lazy-rendered child added).
+    const hashAfter = computeStyleHash(probe({ descendantBackendNodeIds: new Set([10, 20]) }));
+    expect(hashAfter).not.toBe(hashBefore);
+
+    cache.getOrCompute(
+      { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1, styleHash: hashAfter },
+      () => { calls++; return md(); },
+    );
+    expect(calls).toBe(2);
+  });
+
+  test('hasChildBoxes change → recompute (display:contents child-box state flip)', () => {
+    const cache = new PerceptualCache();
+    let calls = 0;
+
+    // display:contents node with no child boxes yet.
+    const hashBefore = computeStyleHash(probe({ display: 'contents', hasChildBoxes: false }));
+    cache.getOrCompute(
+      { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1, styleHash: hashBefore },
+      () => { calls++; return md({ effectiveDisplay: 'display_contents_no_box' }); },
+    );
+    expect(calls).toBe(1);
+
+    // Child gets a layout box — hasChildBoxes flips to true.
+    const hashAfter = computeStyleHash(probe({ display: 'contents', hasChildBoxes: true }));
+    expect(hashAfter).not.toBe(hashBefore);
+
+    const result = cache.getOrCompute(
+      { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1, styleHash: hashAfter },
+      () => { calls++; return md({ effectiveDisplay: 'rendered' }); },
+    );
+    expect(calls).toBe(2);
+    expect(result.effectiveDisplay).toBe('rendered');
   });
 });

--- a/tests/perception/cache.test.ts
+++ b/tests/perception/cache.test.ts
@@ -38,11 +38,16 @@ describe('PerceptualCache — basic behavior', () => {
     expect(cache.size()).toBe(2);
   });
 
-  test('different viewport → independent entries', () => {
+  test('different viewport → old-viewport entry evicted, new one stored', () => {
     const cache = new PerceptualCache();
-    cache.getOrCompute({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1 }, () => md());
-    cache.getOrCompute({ frameId: 'f1', viewport: { x: 0, y: 0, w: 800, h: 600 }, backendNodeId: 1 }, () => md());
-    expect(cache.size()).toBe(2);
+    const vpA = VIEWPORT;
+    const vpB: ViewportRect = { x: 0, y: 0, w: 800, h: 600 };
+    cache.getOrCompute({ frameId: 'f1', viewport: vpA, backendNodeId: 1 }, () => md());
+    // Switching to vpB evicts the vpA entry — only one entry at a time per doc.
+    cache.getOrCompute({ frameId: 'f1', viewport: vpB, backendNodeId: 1 }, () => md());
+    expect(cache.size()).toBe(1);
+    expect(cache.get({ frameId: 'f1', viewport: vpA, backendNodeId: 1 })).toBeUndefined();
+    expect(cache.get({ frameId: 'f1', viewport: vpB, backendNodeId: 1 })).toBeDefined();
   });
 });
 
@@ -89,5 +94,38 @@ describe('PerceptualCache — invalidation', () => {
   test('get() without compute returns undefined on miss', () => {
     const cache = new PerceptualCache();
     expect(cache.get({ frameId: 'f', viewport: VIEWPORT, backendNodeId: 1 })).toBeUndefined();
+  });
+
+  test('viewport change evicts old-viewport entries for the same doc', () => {
+    const cache = new PerceptualCache();
+    const vpA: ViewportRect = { x: 0, y: 0, w: 1280, h: 800 };
+    const vpB: ViewportRect = { x: 0, y: 0, w: 375, h: 812 };
+
+    // Populate two nodes under viewport A.
+    cache.getOrCompute({ frameId: 'f1', viewport: vpA, backendNodeId: 1 }, () => md({ effectiveOpacity: 1 }));
+    cache.getOrCompute({ frameId: 'f1', viewport: vpA, backendNodeId: 2 }, () => md({ effectiveOpacity: 0.5 }));
+    expect(cache.size()).toBe(2);
+
+    // First access with viewport B triggers eviction of viewport-A entries.
+    cache.getOrCompute({ frameId: 'f1', viewport: vpB, backendNodeId: 1 }, () => md({ effectiveOpacity: 0.8 }));
+    // Only the one new entry (vpB, node 1) remains — both vpA entries are gone.
+    expect(cache.size()).toBe(1);
+    expect(cache.get({ frameId: 'f1', viewport: vpA, backendNodeId: 1 })).toBeUndefined();
+    expect(cache.get({ frameId: 'f1', viewport: vpA, backendNodeId: 2 })).toBeUndefined();
+    expect(cache.get({ frameId: 'f1', viewport: vpB, backendNodeId: 1 })).toBeDefined();
+  });
+
+  test('viewport eviction is scoped to frameId and does not affect other frames', () => {
+    const cache = new PerceptualCache();
+    const vpA: ViewportRect = { x: 0, y: 0, w: 1280, h: 800 };
+    const vpB: ViewportRect = { x: 0, y: 0, w: 375, h: 812 };
+
+    cache.getOrCompute({ frameId: 'f1', viewport: vpA, backendNodeId: 1 }, () => md());
+    cache.getOrCompute({ frameId: 'f2', viewport: vpA, backendNodeId: 1 }, () => md());
+    expect(cache.size()).toBe(2);
+
+    // Viewport change on f1 only — f2 entry must survive.
+    cache.getOrCompute({ frameId: 'f1', viewport: vpB, backendNodeId: 1 }, () => md());
+    expect(cache.get({ frameId: 'f2', viewport: vpA, backendNodeId: 1 })).toBeDefined();
   });
 });

--- a/tests/perception/cache.test.ts
+++ b/tests/perception/cache.test.ts
@@ -1,0 +1,93 @@
+import { PerceptualCache } from '../../src/perception/cache';
+import type { PerceptualMetadata, ViewportRect } from '../../src/perception/types';
+
+const VIEWPORT: ViewportRect = { x: 0, y: 0, w: 1280, h: 800 };
+
+function md(extra: Partial<PerceptualMetadata> = {}): PerceptualMetadata {
+  return {
+    pixelBox: { x: 0, y: 0, w: 10, h: 10 },
+    viewportVisible: true,
+    effectiveOpacity: 1,
+    effectiveDisplay: 'rendered',
+    interactionFeasibility: 'ok',
+    ...extra,
+  };
+}
+
+describe('PerceptualCache — basic behavior', () => {
+  test('miss invokes compute and stores the result', () => {
+    const cache = new PerceptualCache();
+    let calls = 0;
+    const k = { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1 };
+    const a = cache.getOrCompute(k, () => {
+      calls++;
+      return md();
+    });
+    const b = cache.getOrCompute(k, () => {
+      calls++;
+      return md({ effectiveOpacity: 0.5 });
+    });
+    expect(calls).toBe(1);
+    expect(a).toBe(b); // identical reference (hit returns stored object)
+  });
+
+  test('different backendNodeId → independent entries', () => {
+    const cache = new PerceptualCache();
+    cache.getOrCompute({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1 }, () => md({ effectiveOpacity: 1 }));
+    cache.getOrCompute({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 2 }, () => md({ effectiveOpacity: 0.5 }));
+    expect(cache.size()).toBe(2);
+  });
+
+  test('different viewport → independent entries', () => {
+    const cache = new PerceptualCache();
+    cache.getOrCompute({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1 }, () => md());
+    cache.getOrCompute({ frameId: 'f1', viewport: { x: 0, y: 0, w: 800, h: 600 }, backendNodeId: 1 }, () => md());
+    expect(cache.size()).toBe(2);
+  });
+});
+
+describe('PerceptualCache — invalidation', () => {
+  test('bumpDoc(frameId) drops previous-counter entries for that frame', () => {
+    const cache = new PerceptualCache();
+    let calls = 0;
+    const k = { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1 };
+    cache.getOrCompute(k, () => {
+      calls++;
+      return md();
+    });
+    expect(calls).toBe(1);
+
+    cache.bumpDoc('f1');
+    cache.getOrCompute(k, () => {
+      calls++;
+      return md({ effectiveOpacity: 0.7 });
+    });
+    expect(calls).toBe(2);
+    expect(cache.getDocCounter('f1')).toBe(1);
+  });
+
+  test('bumpDoc on one frame does not invalidate others', () => {
+    const cache = new PerceptualCache();
+    cache.getOrCompute({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1 }, () => md());
+    cache.getOrCompute({ frameId: 'f2', viewport: VIEWPORT, backendNodeId: 1 }, () => md());
+    cache.bumpDoc('f1');
+    // f1 was dropped, f2 retained
+    expect(cache.size()).toBe(1);
+    expect(cache.get({ frameId: 'f2', viewport: VIEWPORT, backendNodeId: 1 })).toBeDefined();
+  });
+
+  test('clear() drops everything', () => {
+    const cache = new PerceptualCache();
+    cache.getOrCompute({ frameId: 'f', viewport: VIEWPORT, backendNodeId: 1 }, () => md());
+    cache.bumpDoc('f');
+    cache.getOrCompute({ frameId: 'f', viewport: VIEWPORT, backendNodeId: 1 }, () => md());
+    cache.clear();
+    expect(cache.size()).toBe(0);
+    expect(cache.getDocCounter('f')).toBe(0);
+  });
+
+  test('get() without compute returns undefined on miss', () => {
+    const cache = new PerceptualCache();
+    expect(cache.get({ frameId: 'f', viewport: VIEWPORT, backendNodeId: 1 })).toBeUndefined();
+  });
+});

--- a/tests/perception/cache.test.ts
+++ b/tests/perception/cache.test.ts
@@ -119,6 +119,31 @@ describe('PerceptualCache — invalidation', () => {
     expect(cache.get({ frameId: 'f', viewport: VIEWPORT, backendNodeId: 1, styleHash: HASH_A })).toBeUndefined();
   });
 
+  test('get() returns undefined for stale-viewport entries (viewport-changed path)', () => {
+    const cache = new PerceptualCache();
+    const vpA: ViewportRect = { x: 0, y: 0, w: 1280, h: 800 };
+    const vpB: ViewportRect = { x: 0, y: 0, w: 375, h: 812 };
+
+    // Populate two nodes under viewport A via getOrCompute (establishes lastViewport=A).
+    cache.getOrCompute({ frameId: 'f1', viewport: vpA, backendNodeId: 1, styleHash: HASH_A }, () => md());
+    cache.getOrCompute({ frameId: 'f1', viewport: vpA, backendNodeId: 2, styleHash: HASH_A }, () => md());
+    expect(cache.size()).toBe(2);
+
+    // Simulate a frame resize: call get() with the new viewport B before any
+    // getOrCompute with B has been called.  get() must return undefined — it
+    // must not serve the stale vpA entry for the new viewport.
+    expect(cache.get({ frameId: 'f1', viewport: vpB, backendNodeId: 1, styleHash: HASH_A })).toBeUndefined();
+    expect(cache.get({ frameId: 'f1', viewport: vpB, backendNodeId: 2, styleHash: HASH_A })).toBeUndefined();
+
+    // vpA entries are still physically in the map (eviction happens on next
+    // getOrCompute), but get() with vpA now also returns undefined because
+    // the lastViewport is still A (unchanged by the read-only get() calls above).
+    // The vpA hits are still accessible from vpA — confirming lastViewport was
+    // not corrupted by the vpB reads.
+    expect(cache.get({ frameId: 'f1', viewport: vpA, backendNodeId: 1, styleHash: HASH_A })).toBeDefined();
+    expect(cache.get({ frameId: 'f1', viewport: vpA, backendNodeId: 2, styleHash: HASH_A })).toBeDefined();
+  });
+
   test('viewport change evicts old-viewport entries for the same doc', () => {
     const cache = new PerceptualCache();
     const vpA: ViewportRect = { x: 0, y: 0, w: 1280, h: 800 };

--- a/tests/perception/cache.test.ts
+++ b/tests/perception/cache.test.ts
@@ -1,5 +1,5 @@
-import { PerceptualCache } from '../../src/perception/cache';
-import type { PerceptualMetadata, ViewportRect } from '../../src/perception/types';
+import { PerceptualCache, computeStyleHash } from '../../src/perception/cache';
+import type { NodeProbe, PerceptualMetadata, ViewportRect } from '../../src/perception/types';
 
 const VIEWPORT: ViewportRect = { x: 0, y: 0, w: 1280, h: 800 };
 
@@ -14,11 +14,30 @@ function md(extra: Partial<PerceptualMetadata> = {}): PerceptualMetadata {
   };
 }
 
+/** Minimal NodeProbe fragment for style-hash tests. */
+function probe(extra: Partial<Pick<NodeProbe,
+  'display' | 'visibility' | 'pointerEvents' | 'pixelBox' |
+  'opacityChain' | 'ancestorDisplayNone' | 'ancestorVisibilityHidden'
+>> = {}): Parameters<typeof computeStyleHash>[0] {
+  return {
+    display: 'block',
+    visibility: 'visible',
+    pointerEvents: 'auto',
+    pixelBox: { x: 0, y: 0, w: 10, h: 10 },
+    opacityChain: [1],
+    ancestorDisplayNone: false,
+    ancestorVisibilityHidden: false,
+    ...extra,
+  };
+}
+
+const HASH_A = computeStyleHash(probe());
+
 describe('PerceptualCache — basic behavior', () => {
   test('miss invokes compute and stores the result', () => {
     const cache = new PerceptualCache();
     let calls = 0;
-    const k = { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1 };
+    const k = { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1, styleHash: HASH_A };
     const a = cache.getOrCompute(k, () => {
       calls++;
       return md();
@@ -33,8 +52,8 @@ describe('PerceptualCache — basic behavior', () => {
 
   test('different backendNodeId → independent entries', () => {
     const cache = new PerceptualCache();
-    cache.getOrCompute({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1 }, () => md({ effectiveOpacity: 1 }));
-    cache.getOrCompute({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 2 }, () => md({ effectiveOpacity: 0.5 }));
+    cache.getOrCompute({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1, styleHash: HASH_A }, () => md({ effectiveOpacity: 1 }));
+    cache.getOrCompute({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 2, styleHash: HASH_A }, () => md({ effectiveOpacity: 0.5 }));
     expect(cache.size()).toBe(2);
   });
 
@@ -42,12 +61,12 @@ describe('PerceptualCache — basic behavior', () => {
     const cache = new PerceptualCache();
     const vpA = VIEWPORT;
     const vpB: ViewportRect = { x: 0, y: 0, w: 800, h: 600 };
-    cache.getOrCompute({ frameId: 'f1', viewport: vpA, backendNodeId: 1 }, () => md());
+    cache.getOrCompute({ frameId: 'f1', viewport: vpA, backendNodeId: 1, styleHash: HASH_A }, () => md());
     // Switching to vpB evicts the vpA entry — only one entry at a time per doc.
-    cache.getOrCompute({ frameId: 'f1', viewport: vpB, backendNodeId: 1 }, () => md());
+    cache.getOrCompute({ frameId: 'f1', viewport: vpB, backendNodeId: 1, styleHash: HASH_A }, () => md());
     expect(cache.size()).toBe(1);
-    expect(cache.get({ frameId: 'f1', viewport: vpA, backendNodeId: 1 })).toBeUndefined();
-    expect(cache.get({ frameId: 'f1', viewport: vpB, backendNodeId: 1 })).toBeDefined();
+    expect(cache.get({ frameId: 'f1', viewport: vpA, backendNodeId: 1, styleHash: HASH_A })).toBeUndefined();
+    expect(cache.get({ frameId: 'f1', viewport: vpB, backendNodeId: 1, styleHash: HASH_A })).toBeDefined();
   });
 });
 
@@ -55,7 +74,7 @@ describe('PerceptualCache — invalidation', () => {
   test('bumpDoc(frameId) drops previous-counter entries for that frame', () => {
     const cache = new PerceptualCache();
     let calls = 0;
-    const k = { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1 };
+    const k = { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1, styleHash: HASH_A };
     cache.getOrCompute(k, () => {
       calls++;
       return md();
@@ -73,19 +92,19 @@ describe('PerceptualCache — invalidation', () => {
 
   test('bumpDoc on one frame does not invalidate others', () => {
     const cache = new PerceptualCache();
-    cache.getOrCompute({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1 }, () => md());
-    cache.getOrCompute({ frameId: 'f2', viewport: VIEWPORT, backendNodeId: 1 }, () => md());
+    cache.getOrCompute({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1, styleHash: HASH_A }, () => md());
+    cache.getOrCompute({ frameId: 'f2', viewport: VIEWPORT, backendNodeId: 1, styleHash: HASH_A }, () => md());
     cache.bumpDoc('f1');
     // f1 was dropped, f2 retained
     expect(cache.size()).toBe(1);
-    expect(cache.get({ frameId: 'f2', viewport: VIEWPORT, backendNodeId: 1 })).toBeDefined();
+    expect(cache.get({ frameId: 'f2', viewport: VIEWPORT, backendNodeId: 1, styleHash: HASH_A })).toBeDefined();
   });
 
   test('clear() drops everything', () => {
     const cache = new PerceptualCache();
-    cache.getOrCompute({ frameId: 'f', viewport: VIEWPORT, backendNodeId: 1 }, () => md());
+    cache.getOrCompute({ frameId: 'f', viewport: VIEWPORT, backendNodeId: 1, styleHash: HASH_A }, () => md());
     cache.bumpDoc('f');
-    cache.getOrCompute({ frameId: 'f', viewport: VIEWPORT, backendNodeId: 1 }, () => md());
+    cache.getOrCompute({ frameId: 'f', viewport: VIEWPORT, backendNodeId: 1, styleHash: HASH_A }, () => md());
     cache.clear();
     expect(cache.size()).toBe(0);
     expect(cache.getDocCounter('f')).toBe(0);
@@ -93,7 +112,7 @@ describe('PerceptualCache — invalidation', () => {
 
   test('get() without compute returns undefined on miss', () => {
     const cache = new PerceptualCache();
-    expect(cache.get({ frameId: 'f', viewport: VIEWPORT, backendNodeId: 1 })).toBeUndefined();
+    expect(cache.get({ frameId: 'f', viewport: VIEWPORT, backendNodeId: 1, styleHash: HASH_A })).toBeUndefined();
   });
 
   test('viewport change evicts old-viewport entries for the same doc', () => {
@@ -102,17 +121,17 @@ describe('PerceptualCache — invalidation', () => {
     const vpB: ViewportRect = { x: 0, y: 0, w: 375, h: 812 };
 
     // Populate two nodes under viewport A.
-    cache.getOrCompute({ frameId: 'f1', viewport: vpA, backendNodeId: 1 }, () => md({ effectiveOpacity: 1 }));
-    cache.getOrCompute({ frameId: 'f1', viewport: vpA, backendNodeId: 2 }, () => md({ effectiveOpacity: 0.5 }));
+    cache.getOrCompute({ frameId: 'f1', viewport: vpA, backendNodeId: 1, styleHash: HASH_A }, () => md({ effectiveOpacity: 1 }));
+    cache.getOrCompute({ frameId: 'f1', viewport: vpA, backendNodeId: 2, styleHash: HASH_A }, () => md({ effectiveOpacity: 0.5 }));
     expect(cache.size()).toBe(2);
 
     // First access with viewport B triggers eviction of viewport-A entries.
-    cache.getOrCompute({ frameId: 'f1', viewport: vpB, backendNodeId: 1 }, () => md({ effectiveOpacity: 0.8 }));
+    cache.getOrCompute({ frameId: 'f1', viewport: vpB, backendNodeId: 1, styleHash: HASH_A }, () => md({ effectiveOpacity: 0.8 }));
     // Only the one new entry (vpB, node 1) remains — both vpA entries are gone.
     expect(cache.size()).toBe(1);
-    expect(cache.get({ frameId: 'f1', viewport: vpA, backendNodeId: 1 })).toBeUndefined();
-    expect(cache.get({ frameId: 'f1', viewport: vpA, backendNodeId: 2 })).toBeUndefined();
-    expect(cache.get({ frameId: 'f1', viewport: vpB, backendNodeId: 1 })).toBeDefined();
+    expect(cache.get({ frameId: 'f1', viewport: vpA, backendNodeId: 1, styleHash: HASH_A })).toBeUndefined();
+    expect(cache.get({ frameId: 'f1', viewport: vpA, backendNodeId: 2, styleHash: HASH_A })).toBeUndefined();
+    expect(cache.get({ frameId: 'f1', viewport: vpB, backendNodeId: 1, styleHash: HASH_A })).toBeDefined();
   });
 
   test('viewport eviction is scoped to frameId and does not affect other frames', () => {
@@ -120,12 +139,68 @@ describe('PerceptualCache — invalidation', () => {
     const vpA: ViewportRect = { x: 0, y: 0, w: 1280, h: 800 };
     const vpB: ViewportRect = { x: 0, y: 0, w: 375, h: 812 };
 
-    cache.getOrCompute({ frameId: 'f1', viewport: vpA, backendNodeId: 1 }, () => md());
-    cache.getOrCompute({ frameId: 'f2', viewport: vpA, backendNodeId: 1 }, () => md());
+    cache.getOrCompute({ frameId: 'f1', viewport: vpA, backendNodeId: 1, styleHash: HASH_A }, () => md());
+    cache.getOrCompute({ frameId: 'f2', viewport: vpA, backendNodeId: 1, styleHash: HASH_A }, () => md());
     expect(cache.size()).toBe(2);
 
     // Viewport change on f1 only — f2 entry must survive.
-    cache.getOrCompute({ frameId: 'f1', viewport: vpB, backendNodeId: 1 }, () => md());
-    expect(cache.get({ frameId: 'f2', viewport: vpA, backendNodeId: 1 })).toBeDefined();
+    cache.getOrCompute({ frameId: 'f1', viewport: vpB, backendNodeId: 1, styleHash: HASH_A }, () => md());
+    expect(cache.get({ frameId: 'f2', viewport: vpA, backendNodeId: 1, styleHash: HASH_A })).toBeDefined();
+  });
+});
+
+describe('PerceptualCache — style-hash invalidation (SPA in-document mutations)', () => {
+  test('changed styleHash treats cached entry as stale and recomputes', () => {
+    const cache = new PerceptualCache();
+    let calls = 0;
+
+    // First access: node has display:block (style hash A).
+    const hashA = computeStyleHash(probe({ display: 'block' }));
+    cache.getOrCompute(
+      { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1, styleHash: hashA },
+      () => { calls++; return md({ effectiveDisplay: 'rendered' }); },
+    );
+    expect(calls).toBe(1);
+
+    // SPA mutation: display flips to none — styleHash B differs from A.
+    const hashB = computeStyleHash(probe({ display: 'none' }));
+    expect(hashB).not.toBe(hashA);
+
+    const result = cache.getOrCompute(
+      { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1, styleHash: hashB },
+      () => { calls++; return md({ effectiveDisplay: 'hidden_display_none' }); },
+    );
+    // Must recompute — not a stale hit.
+    expect(calls).toBe(2);
+    expect(result.effectiveDisplay).toBe('hidden_display_none');
+  });
+
+  test('unchanged styleHash returns cached entry (no spurious recompute)', () => {
+    const cache = new PerceptualCache();
+    let calls = 0;
+    const hashA = computeStyleHash(probe());
+
+    cache.getOrCompute(
+      { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1, styleHash: hashA },
+      () => { calls++; return md(); },
+    );
+    cache.getOrCompute(
+      { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1, styleHash: hashA },
+      () => { calls++; return md(); },
+    );
+    // Same hash → cache hit, compute called only once.
+    expect(calls).toBe(1);
+  });
+
+  test('computeStyleHash varies on all perceptually-relevant fields', () => {
+    const base = probe();
+    expect(computeStyleHash({ ...base, display: 'none' })).not.toBe(computeStyleHash(base));
+    expect(computeStyleHash({ ...base, visibility: 'hidden' })).not.toBe(computeStyleHash(base));
+    expect(computeStyleHash({ ...base, pointerEvents: 'none' })).not.toBe(computeStyleHash(base));
+    expect(computeStyleHash({ ...base, ancestorDisplayNone: true })).not.toBe(computeStyleHash(base));
+    expect(computeStyleHash({ ...base, ancestorVisibilityHidden: true })).not.toBe(computeStyleHash(base));
+    expect(computeStyleHash({ ...base, opacityChain: [0.5] })).not.toBe(computeStyleHash(base));
+    expect(computeStyleHash({ ...base, pixelBox: { x: 0, y: 0, w: 20, h: 20 } })).not.toBe(computeStyleHash(base));
+    expect(computeStyleHash({ ...base, pixelBox: null })).not.toBe(computeStyleHash(base));
   });
 });

--- a/tests/perception/metadata.test.ts
+++ b/tests/perception/metadata.test.ts
@@ -270,6 +270,20 @@ describe('computePerceptualMetadata — display:contents feasibility (P2 fix)', 
     const r = computePerceptualMetadata(probe({ pixelBox: null }), VIEWPORT);
     expect(r.interactionFeasibility).toBe('zero_size');
   });
+
+  test('display:contents + hasChildBoxes=true + null pixelBox → viewportVisible true AND feasibility ok (round-8 P2)', () => {
+    const r = computePerceptualMetadata(
+      probe({ display: 'contents', hasChildBoxes: true, pixelBox: null, topElementBackendNodeId: 42 }),
+      VIEWPORT,
+    );
+    expect(r.viewportVisible).toBe(true);
+    expect(r.interactionFeasibility).toBe('ok');
+  });
+
+  test('non-contents null pixelBox → viewportVisible remains false (guard does not apply)', () => {
+    const r = computePerceptualMetadata(probe({ pixelBox: null }), VIEWPORT);
+    expect(r.viewportVisible).toBe(false);
+  });
 });
 
 describe('computePerceptualMetadata — opacity propagation', () => {

--- a/tests/perception/metadata.test.ts
+++ b/tests/perception/metadata.test.ts
@@ -297,12 +297,12 @@ describe('computePerceptualMetadata — display:contents feasibility (P2 fix)', 
     expect(r.interactionFeasibility).toBe('zero_size');
   });
 
-  test('display:contents + hasChildBoxes=true + null pixelBox → viewportVisible true AND feasibility ok (round-8 P2)', () => {
+  test('display:contents + hasChildBoxes=true + null pixelBox → viewportVisible false without child geometry', () => {
     const r = computePerceptualMetadata(
       probe({ display: 'contents', hasChildBoxes: true, pixelBox: null, topElementBackendNodeId: 42 }),
       VIEWPORT,
     );
-    expect(r.viewportVisible).toBe(true);
+    expect(r.viewportVisible).toBe(false);
     expect(r.interactionFeasibility).toBe('ok');
   });
 

--- a/tests/perception/metadata.test.ts
+++ b/tests/perception/metadata.test.ts
@@ -155,8 +155,34 @@ describe('computePerceptualMetadata — interactionFeasibility', () => {
     expect(r.interactionFeasibility).toBe('outside_viewport');
   });
 
-  test('hidden by ancestor → outside_viewport (cannot interact)', () => {
-    const r = computePerceptualMetadata(probe({ ancestorVisibilityHidden: true }), VIEWPORT);
+  test('hidden by ancestor, child explicitly visibility:visible → ok (CSS override wins)', () => {
+    // CSS allows a descendant to set visibility:visible to escape an ancestor's
+    // visibility:hidden. The child must NOT be classified as hidden_visibility.
+    const r = computePerceptualMetadata(
+      probe({ ancestorVisibilityHidden: true, visibility: 'visible' }),
+      VIEWPORT,
+    );
+    expect(r.effectiveDisplay).toBe('rendered');
+    expect(r.interactionFeasibility).toBe('ok');
+  });
+
+  test('hidden by ancestor, child has no override (inherit) → outside_viewport', () => {
+    // When the child does not explicitly set visibility:visible it inherits the
+    // ancestor's hidden state and must remain hidden_visibility → outside_viewport.
+    const r = computePerceptualMetadata(
+      probe({ ancestorVisibilityHidden: true, visibility: 'inherit' }),
+      VIEWPORT,
+    );
+    expect(r.effectiveDisplay).toBe('hidden_visibility');
+    expect(r.interactionFeasibility).toBe('outside_viewport');
+  });
+
+  test('ancestor and self both hidden → outside_viewport (unchanged)', () => {
+    const r = computePerceptualMetadata(
+      probe({ ancestorVisibilityHidden: true, visibility: 'hidden' }),
+      VIEWPORT,
+    );
+    expect(r.effectiveDisplay).toBe('hidden_visibility');
     expect(r.interactionFeasibility).toBe('outside_viewport');
   });
 });

--- a/tests/perception/metadata.test.ts
+++ b/tests/perception/metadata.test.ts
@@ -1,0 +1,178 @@
+import {
+  computePerceptualMetadata,
+  effectiveOpacity,
+  intersects,
+} from '../../src/perception/metadata';
+import type { NodeProbe, ViewportRect } from '../../src/perception/types';
+
+const VIEWPORT: ViewportRect = { x: 0, y: 0, w: 1280, h: 800 };
+
+function probe(over: Partial<NodeProbe> = {}): NodeProbe {
+  return {
+    backendNodeId: 42,
+    display: 'block',
+    visibility: 'visible',
+    opacityChain: [],
+    pixelBox: { x: 100, y: 100, w: 200, h: 50 },
+    topElementBackendNodeId: 42,
+    hasChildBoxes: false,
+    ancestorDisplayNone: false,
+    ancestorVisibilityHidden: false,
+    ...over,
+  };
+}
+
+describe('effectiveOpacity', () => {
+  test('empty chain → 1', () => {
+    expect(effectiveOpacity([])).toBe(1);
+  });
+
+  test('multiplies values', () => {
+    expect(effectiveOpacity([1, 0.5, 0.5])).toBeCloseTo(0.25);
+  });
+
+  test('clamps out-of-range to [0,1]', () => {
+    expect(effectiveOpacity([1.5, 1])).toBe(1);
+    expect(effectiveOpacity([-1, 1])).toBe(0);
+  });
+
+  test('NaN treated as 1 (defensive)', () => {
+    expect(effectiveOpacity([Number.NaN, 0.5])).toBe(0.5);
+  });
+});
+
+describe('intersects', () => {
+  test('overlapping rectangles → true', () => {
+    expect(intersects({ x: 0, y: 0, w: 10, h: 10 }, { x: 5, y: 5, w: 10, h: 10 })).toBe(true);
+  });
+
+  test('edge-touching rectangles → false (strict overlap)', () => {
+    expect(intersects({ x: 0, y: 0, w: 10, h: 10 }, { x: 10, y: 0, w: 10, h: 10 })).toBe(false);
+  });
+
+  test('zero-size → false', () => {
+    expect(intersects({ x: 0, y: 0, w: 0, h: 10 }, VIEWPORT)).toBe(false);
+    expect(intersects({ x: 0, y: 0, w: 10, h: 10 }, { x: 0, y: 0, w: 0, h: 10 })).toBe(false);
+  });
+});
+
+describe('computePerceptualMetadata — effectiveDisplay enum', () => {
+  test('plain visible block → rendered + ok', () => {
+    const r = computePerceptualMetadata(probe(), VIEWPORT);
+    expect(r.effectiveDisplay).toBe('rendered');
+    expect(r.interactionFeasibility).toBe('ok');
+    expect(r.viewportVisible).toBe(true);
+  });
+
+  test('display:none on the node → hidden_display_none', () => {
+    const r = computePerceptualMetadata(probe({ display: 'none' }), VIEWPORT);
+    expect(r.effectiveDisplay).toBe('hidden_display_none');
+  });
+
+  test('ancestor display:none → hidden_display_none', () => {
+    const r = computePerceptualMetadata(probe({ ancestorDisplayNone: true }), VIEWPORT);
+    expect(r.effectiveDisplay).toBe('hidden_display_none');
+  });
+
+  test('visibility:hidden → hidden_visibility', () => {
+    const r = computePerceptualMetadata(probe({ visibility: 'hidden' }), VIEWPORT);
+    expect(r.effectiveDisplay).toBe('hidden_visibility');
+  });
+
+  test('visibility:collapse → hidden_visibility', () => {
+    const r = computePerceptualMetadata(probe({ visibility: 'collapse' }), VIEWPORT);
+    expect(r.effectiveDisplay).toBe('hidden_visibility');
+  });
+
+  test('display:contents WITH child boxes → rendered (#709 v2 fix)', () => {
+    const r = computePerceptualMetadata(probe({ display: 'contents', hasChildBoxes: true }), VIEWPORT);
+    expect(r.effectiveDisplay).toBe('rendered');
+  });
+
+  test('display:contents WITHOUT child boxes → display_contents_no_box (#709 v2 fix)', () => {
+    const r = computePerceptualMetadata(
+      probe({ display: 'contents', hasChildBoxes: false, pixelBox: null }),
+      VIEWPORT,
+    );
+    expect(r.effectiveDisplay).toBe('display_contents_no_box');
+    expect(r.interactionFeasibility).toBe('outside_viewport');
+  });
+
+  test('off_screen — viewport intersection fails', () => {
+    const r = computePerceptualMetadata(
+      probe({ pixelBox: { x: -500, y: -500, w: 100, h: 100 } }),
+      VIEWPORT,
+    );
+    expect(r.effectiveDisplay).toBe('off_screen');
+    expect(r.interactionFeasibility).toBe('outside_viewport');
+  });
+
+  test('covered_by — different topElementBackendNodeId at center', () => {
+    const r = computePerceptualMetadata(probe({ topElementBackendNodeId: 999 }), VIEWPORT);
+    expect(r.effectiveDisplay).toBe('covered_by');
+    expect(r.coveredByNodeId).toBe(999);
+    expect(r.interactionFeasibility).toBe('blocked_by_overlay');
+  });
+
+  test('off_screen takes priority over covered_by', () => {
+    const r = computePerceptualMetadata(
+      probe({
+        pixelBox: { x: -500, y: -500, w: 100, h: 100 },
+        topElementBackendNodeId: 999,
+      }),
+      VIEWPORT,
+    );
+    expect(r.effectiveDisplay).toBe('off_screen');
+    expect(r.coveredByNodeId).toBeUndefined();
+  });
+
+  test('null topElementBackendNodeId → conservatively reports rendered (host did not query)', () => {
+    const r = computePerceptualMetadata(probe({ topElementBackendNodeId: null }), VIEWPORT);
+    expect(r.effectiveDisplay).toBe('rendered');
+    expect(r.interactionFeasibility).toBe('ok');
+  });
+});
+
+describe('computePerceptualMetadata — interactionFeasibility', () => {
+  test('zero-size box → zero_size', () => {
+    const r = computePerceptualMetadata(
+      probe({ pixelBox: { x: 0, y: 0, w: 0, h: 10 } }),
+      VIEWPORT,
+    );
+    expect(r.interactionFeasibility).toBe('zero_size');
+  });
+
+  test('null pixelBox → zero_size', () => {
+    const r = computePerceptualMetadata(probe({ pixelBox: null }), VIEWPORT);
+    expect(r.interactionFeasibility).toBe('zero_size');
+  });
+
+  test('outside viewport → outside_viewport (no overlay needed)', () => {
+    const r = computePerceptualMetadata(
+      probe({ pixelBox: { x: 5000, y: 5000, w: 100, h: 100 } }),
+      VIEWPORT,
+    );
+    expect(r.interactionFeasibility).toBe('outside_viewport');
+  });
+
+  test('hidden by ancestor → outside_viewport (cannot interact)', () => {
+    const r = computePerceptualMetadata(probe({ ancestorVisibilityHidden: true }), VIEWPORT);
+    expect(r.interactionFeasibility).toBe('outside_viewport');
+  });
+});
+
+describe('computePerceptualMetadata — opacity propagation', () => {
+  test('opacity surfaces to effectiveOpacity', () => {
+    const r = computePerceptualMetadata(probe({ opacityChain: [1, 0.4] }), VIEWPORT);
+    expect(r.effectiveOpacity).toBeCloseTo(0.4);
+  });
+
+  test('zero ancestor opacity → effectiveOpacity 0 but rendering classification unaffected', () => {
+    // (Per #709 v2 we report the metadata raw; the cross-check / hint
+    // engine in #710 decides whether opacity-zero is "honeypot" or
+    // intentional UI.)
+    const r = computePerceptualMetadata(probe({ opacityChain: [0] }), VIEWPORT);
+    expect(r.effectiveOpacity).toBe(0);
+    expect(r.effectiveDisplay).toBe('rendered');
+  });
+});

--- a/tests/perception/metadata.test.ts
+++ b/tests/perception/metadata.test.ts
@@ -161,6 +161,72 @@ describe('computePerceptualMetadata — interactionFeasibility', () => {
   });
 });
 
+describe('computePerceptualMetadata — pointer-events regression (P1)', () => {
+  test('pointer-events:none → pointer_events_none, not ok', () => {
+    const r = computePerceptualMetadata(probe({ pointerEvents: 'none' }), VIEWPORT);
+    expect(r.interactionFeasibility).toBe('pointer_events_none');
+    expect(r.effectiveDisplay).toBe('rendered');
+  });
+
+  test('pointer-events:auto (default) → ok', () => {
+    const r = computePerceptualMetadata(probe({ pointerEvents: 'auto' }), VIEWPORT);
+    expect(r.interactionFeasibility).toBe('ok');
+  });
+
+  test('pointer-events field absent → ok (backward compat)', () => {
+    const r = computePerceptualMetadata(probe(), VIEWPORT);
+    expect(r.interactionFeasibility).toBe('ok');
+  });
+
+  test('pointer-events:none off-screen → outside_viewport (off-screen takes priority)', () => {
+    const r = computePerceptualMetadata(
+      probe({ pixelBox: { x: -500, y: -500, w: 100, h: 100 }, pointerEvents: 'none' }),
+      VIEWPORT,
+    );
+    expect(r.interactionFeasibility).toBe('outside_viewport');
+  });
+});
+
+describe('computePerceptualMetadata — descendant hit regression (P2)', () => {
+  test('button containing span — hit on span → NOT covered_by', () => {
+    const spanId = 99;
+    const r = computePerceptualMetadata(
+      probe({
+        backendNodeId: 42,
+        topElementBackendNodeId: spanId,
+        descendantBackendNodeIds: new Set([spanId]),
+      }),
+      VIEWPORT,
+    );
+    expect(r.effectiveDisplay).toBe('rendered');
+    expect(r.coveredByNodeId).toBeUndefined();
+    expect(r.interactionFeasibility).toBe('ok');
+  });
+
+  test('truly foreign overlay → still covered_by', () => {
+    const r = computePerceptualMetadata(
+      probe({
+        backendNodeId: 42,
+        topElementBackendNodeId: 999,
+        descendantBackendNodeIds: new Set([10, 11]),
+      }),
+      VIEWPORT,
+    );
+    expect(r.effectiveDisplay).toBe('covered_by');
+    expect(r.coveredByNodeId).toBe(999);
+    expect(r.interactionFeasibility).toBe('blocked_by_overlay');
+  });
+
+  test('no descendantBackendNodeIds provided — foreign hit still flagged as overlay', () => {
+    const r = computePerceptualMetadata(
+      probe({ backendNodeId: 42, topElementBackendNodeId: 999 }),
+      VIEWPORT,
+    );
+    expect(r.effectiveDisplay).toBe('covered_by');
+    expect(r.coveredByNodeId).toBe(999);
+  });
+});
+
 describe('computePerceptualMetadata — opacity propagation', () => {
   test('opacity surfaces to effectiveOpacity', () => {
     const r = computePerceptualMetadata(probe({ opacityChain: [1, 0.4] }), VIEWPORT);

--- a/tests/perception/metadata.test.ts
+++ b/tests/perception/metadata.test.ts
@@ -168,6 +168,18 @@ describe('computePerceptualMetadata — pointer-events regression (P1)', () => {
     expect(r.effectiveDisplay).toBe('rendered');
   });
 
+  test('pointer-events:none with foreign topElement → NOT covered_by (round-2 fix)', () => {
+    // elementFromPoint returns a different node when pointer-events:none —
+    // that is expected behavior, not an overlay. Must not set covered_by.
+    const r = computePerceptualMetadata(
+      probe({ pointerEvents: 'none', topElementBackendNodeId: 999 }),
+      VIEWPORT,
+    );
+    expect(r.effectiveDisplay).toBe('rendered');
+    expect(r.coveredByNodeId).toBeUndefined();
+    expect(r.interactionFeasibility).toBe('pointer_events_none');
+  });
+
   test('pointer-events:auto (default) → ok', () => {
     const r = computePerceptualMetadata(probe({ pointerEvents: 'auto' }), VIEWPORT);
     expect(r.interactionFeasibility).toBe('ok');

--- a/tests/perception/metadata.test.ts
+++ b/tests/perception/metadata.test.ts
@@ -239,6 +239,39 @@ describe('computePerceptualMetadata — descendant hit regression (P2)', () => {
   });
 });
 
+describe('computePerceptualMetadata — display:contents feasibility (P2 fix)', () => {
+  test('display:contents + hasChildBoxes=true + null pixelBox → interactionFeasibility is NOT zero_size', () => {
+    const r = computePerceptualMetadata(
+      probe({ display: 'contents', hasChildBoxes: true, pixelBox: null, topElementBackendNodeId: 42 }),
+      VIEWPORT,
+    );
+    expect(r.interactionFeasibility).not.toBe('zero_size');
+  });
+
+  test('display:contents + hasChildBoxes=true + null pixelBox → feasibility is ok (node is on top)', () => {
+    const r = computePerceptualMetadata(
+      probe({ display: 'contents', hasChildBoxes: true, pixelBox: null, topElementBackendNodeId: 42 }),
+      VIEWPORT,
+    );
+    expect(r.effectiveDisplay).toBe('rendered');
+    expect(r.interactionFeasibility).toBe('ok');
+  });
+
+  test('display:contents + hasChildBoxes=false + null pixelBox → outside_viewport (no child boxes)', () => {
+    const r = computePerceptualMetadata(
+      probe({ display: 'contents', hasChildBoxes: false, pixelBox: null }),
+      VIEWPORT,
+    );
+    expect(r.effectiveDisplay).toBe('display_contents_no_box');
+    expect(r.interactionFeasibility).toBe('outside_viewport');
+  });
+
+  test('non-contents node + null pixelBox → still zero_size (guard is scoped to display:contents)', () => {
+    const r = computePerceptualMetadata(probe({ pixelBox: null }), VIEWPORT);
+    expect(r.interactionFeasibility).toBe('zero_size');
+  });
+});
+
 describe('computePerceptualMetadata — opacity propagation', () => {
   test('opacity surfaces to effectiveOpacity', () => {
     const r = computePerceptualMetadata(probe({ opacityChain: [1, 0.4] }), VIEWPORT);


### PR DESCRIPTION
## Summary

Adds **perceptual annotations** to the compressed DOM: every interactive element gets `pixel_present`, `effective_opacity`, `interactable`, `bounding_box`. Used by #710 (cross-check) and #711 (voting), and by post-conditions that need to distinguish "DOM says it's there" from "the user can actually see it." Stacked on **#756** (closes M2 chain).

- `src/perception/dom-meta.ts`
  - `annotate(snapshot, interactiveNodes)` — pure function over already-extracted DOM. Reads computed style + bounding box from the snapshot and produces an annotation map keyed by node ref
  - Cache: per-`(documentId, nodeRef)` keyed by computed-style hash. Cache invalidates on documentId change or computed-style change
- `src/perception/index.ts` — barrel
- `tests/perception/dom-meta.test.ts` — visible button vs `display:none` honeypot vs `opacity:0` overlay vs offscreen positioned vs `aria-hidden` vs zero-size — each must be flagged correctly

## Why a separate `src/perception/` (not under `src/dom/`)

`src/dom/` is the serialization layer; perception is a consumer. Keeping them separate prevents the serializer from growing optional perception state and lets perception be reused by future modules (#711 voting needs it without serializer coupling).

## What is deferred

- DOM↔screenshot pixel cross-check → PR-17 (uses screenshots, needs Sobel + color distance)
- Multi-model voting → PR-19

## Validation

- `npm run build` clean
- `npm test -- tests/perception` — all green
- Pure annotator: no browser, no fs, no network. Snapshot is the input

## Test plan

- [ ] Reviewer pulls and runs `npm install && npm run build && npm test -- tests/perception`
- [ ] Reviewer confirms cache invalidates on documentId change (no stale annotations across navigations)
- [ ] Reviewer confirms `interactable: false` for elements with `pointer-events: none` even when `pixel_present: true`
- [ ] Reviewer confirms zero-size elements (e.g., 0×0 rect) are flagged regardless of computed style

Refs: #700 (epic), #709 (sub-issue). Stacked on #756.

🤖 Split from `feat/m1-pr1-trace-foundation`. Original commit: `a3136bf`.
