### PR TITLE
feat(skill-memory): curator Pass 2 — sibling skill merge (M4 PR-23)

### DIFF
--- a/src/skill-memory/curator-pass2.ts
+++ b/src/skill-memory/curator-pass2.ts
@@ -253,10 +253,15 @@ export async function runPass2Merge(opts: RunPass2Options): Promise<Pass2Outcome
     // recordSuccessfulRun (which recomputes verified_runs/status solely from
     // existingSidecar.runs.recent) does not reset the umbrella back to
     // candidate on the very next successful run.
+    // Sort oldest-first (append order) to match recordSuccessfulRun semantics:
+    // it appends a new run then does slice(-SKILL_RUN_LOG_MAX), which drops the
+    // front of the array. With oldest-first that drops the oldest entries on
+    // overflow — the correct behaviour. Newest-first would instead drop the
+    // newest pre-merge entries, silently regressing verified_runs/status.
     const mergedRecent: SkillSidecar['runs']['recent'] = cluster.records
       .flatMap((r) => r.sidecar.runs.recent)
-      .sort((a, b) => b.ts - a.ts)
-      .slice(0, SKILL_RUN_LOG_MAX);
+      .sort((a, b) => a.ts - b.ts)
+      .slice(-SKILL_RUN_LOG_MAX);
 
     const sidecarBody = JSON.stringify(
       {

--- a/src/skill-memory/curator-pass2.ts
+++ b/src/skill-memory/curator-pass2.ts
@@ -1,0 +1,308 @@
+/**
+ * Skill curator Pass 2 — sibling-skill merge (#715 v2).
+ *
+ * Two skills on the same domain that share a graph-prefix AND a
+ * meaningful Jaccard intent overlap likely document the same
+ * underlying flow at different points in its evolution. Pass 2
+ * clusters them, asks an LLM (`MergeRequester`) to produce an
+ * umbrella SKILL.md, and replaces the cluster on success.
+ *
+ * Per #715 v2 P0/P1:
+ *   - Clustering input: same graph-prefix (first N nodes match,
+ *     default 3) AND Jaccard ≥ 0.70 over stop-word-stripped intent
+ *     tokens.
+ *   - On merge: write umbrella, move siblings under .archive/<id>/
+ *     with `reason.json { merged_into }`.
+ *   - On parse failure / requester error: SKIP the cluster with
+ *     `merge_parse_failure` (or `merge_skipped`) action. NO retry
+ *     within the same curator run.
+ *   - Never modifies user-authored skills (frontmatter.author !==
+ *     'agent') — they're filtered out before clustering.
+ *   - Never deletes — only archives.
+ *
+ * Requester is the LLM injection point. Tests pass deterministic
+ * fakes so the clustering + write flow is fully covered without
+ * a real model.
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { listSkillsForDomain } from './extractor';
+import { parseSkillMd, stringifySkillMd, type FrontmatterError } from './skill-md';
+import { STOP_WORDS } from './stop-words';
+import type { CuratorAction, CuratorActionKind } from './curator';
+import { SKILL_SCHEMA_VERSION, type SkillRecord } from './types';
+
+export interface ClusterCandidate {
+  records: SkillRecord[];
+}
+
+/** Tokenize an intent string for Jaccard comparison. */
+export function tokenize(intent: string): Set<string> {
+  return new Set(
+    intent
+      .toLowerCase()
+      .split(/\s+/)
+      .map((w) => w.replace(/[^\p{L}\p{N}_]+/gu, ''))
+      .filter((w) => w.length > 0 && !STOP_WORDS.has(w)),
+  );
+}
+
+/** Jaccard similarity between two sets. */
+export function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  let intersection = 0;
+  for (const v of a) if (b.has(v)) intersection++;
+  const unionSize = a.size + b.size - intersection;
+  return unionSize === 0 ? 0 : intersection / unionSize;
+}
+
+/**
+ * Greedy clustering: each cluster's seed is the highest-`verified_runs`
+ * record. Candidates joining the cluster must share the seed's
+ * graph_node_anchor prefix AND clear `jaccardThreshold` against the
+ * seed. Two skills sharing a prefix-of-zero is meaningless, so the
+ * caller should keep `prefixChars` ≥ 2.
+ */
+export function clusterSkills(
+  records: SkillRecord[],
+  opts: { jaccardThreshold?: number; prefixChars?: number } = {},
+): ClusterCandidate[] {
+  const jacc = opts.jaccardThreshold ?? 0.7;
+  const prefix = Math.max(1, opts.prefixChars ?? 3);
+  const eligible = records
+    .filter((r) => r.frontmatter.author === 'agent')
+    .filter((r) => r.frontmatter.status !== 'archived');
+  const seen = new Set<string>();
+  const ranked = [...eligible].sort(
+    (a, b) => b.frontmatter.verified_runs - a.frontmatter.verified_runs,
+  );
+  const clusters: ClusterCandidate[] = [];
+  for (const seed of ranked) {
+    if (seen.has(seed.skill_id)) continue;
+    const seedTokens = tokenize(seed.frontmatter.intent);
+    const seedPrefix = seed.frontmatter.graph_node_anchor.slice(0, prefix);
+    const cluster: SkillRecord[] = [seed];
+    seen.add(seed.skill_id);
+    for (const cand of ranked) {
+      if (seen.has(cand.skill_id)) continue;
+      if (cand.frontmatter.graph_node_anchor.slice(0, prefix) !== seedPrefix) continue;
+      if (jaccard(seedTokens, tokenize(cand.frontmatter.intent)) < jacc) continue;
+      cluster.push(cand);
+      seen.add(cand.skill_id);
+    }
+    if (cluster.length >= 2) clusters.push({ records: cluster });
+  }
+  return clusters;
+}
+
+export interface MergeRequest {
+  domain: string;
+  cluster: SkillRecord[];
+}
+
+export interface MergeResultOk {
+  ok: true;
+  /** Umbrella name (NAME_PATTERN). Caller may sanitize / regenerate. */
+  name: string;
+  intent: string;
+  /** Markdown body for the umbrella SKILL.md. */
+  body: string;
+}
+
+export interface MergeResultSkip {
+  ok: false;
+  /** Free-text reason recorded in actions log. */
+  reason: string;
+}
+
+export type MergeResult = MergeResultOk | MergeResultSkip;
+
+export type MergeRequester = (req: MergeRequest) => Promise<MergeResult>;
+
+export interface RunPass2Options {
+  rootDir: string;
+  domain: string;
+  requester: MergeRequester;
+  jaccardThreshold?: number;
+  prefixChars?: number;
+  now?: () => number;
+}
+
+export interface Pass2Outcome {
+  actions: CuratorAction[];
+  errors: string[];
+}
+
+function umbrellaSkillId(cluster: SkillRecord[]): string {
+  const concat = cluster.map((r) => r.skill_id).sort().join('|');
+  return crypto.createHash('sha256').update(concat).digest('hex').slice(0, 12);
+}
+
+function archiveMergedSibling(args: {
+  rootDir: string;
+  domain: string;
+  record: SkillRecord;
+  mergedIntoSkillId: string;
+  ts: number;
+}): void {
+  const archiveDir = path.join(args.rootDir, args.domain, '.archive', args.record.skill_id);
+  fs.mkdirSync(archiveDir, { recursive: true });
+  const newMdPath = path.join(archiveDir, path.basename(args.record.filePath));
+  const newSidecarPath = path.join(archiveDir, path.basename(args.record.sidecarPath));
+
+  const parsed = parseSkillMd(fs.readFileSync(args.record.filePath, 'utf8'));
+  parsed.frontmatter.status = 'archived';
+  fs.writeFileSync(newMdPath, stringifySkillMd(parsed), { mode: 0o644 });
+  fs.copyFileSync(args.record.sidecarPath, newSidecarPath);
+  fs.writeFileSync(
+    path.join(archiveDir, 'reason.json'),
+    JSON.stringify(
+      {
+        archived_at: new Date(args.ts).toISOString(),
+        archived_by: 'curator',
+        reason: 'merged_into',
+        merged_into_skill_id: args.mergedIntoSkillId,
+        prior_status: args.record.frontmatter.status,
+      },
+      null,
+      2,
+    ),
+    { mode: 0o644 },
+  );
+
+  fs.unlinkSync(args.record.filePath);
+  fs.unlinkSync(args.record.sidecarPath);
+}
+
+function isoUtc(ms: number): string {
+  return new Date(ms).toISOString().replace(/\.\d+Z$/, 'Z');
+}
+
+/** Run Pass 2 across one domain. Idempotent (re-running on a clean
+ *  state produces no actions). */
+export async function runPass2Merge(opts: RunPass2Options): Promise<Pass2Outcome> {
+  const ts = (opts.now ?? Date.now)();
+  const records = listSkillsForDomain(opts.domain, { rootDir: opts.rootDir });
+  const clusters = clusterSkills(records, {
+    jaccardThreshold: opts.jaccardThreshold,
+    prefixChars: opts.prefixChars,
+  });
+  const actions: CuratorAction[] = [];
+  const errors: string[] = [];
+
+  for (const cluster of clusters) {
+    let result: MergeResult;
+    try {
+      result = await opts.requester({ domain: opts.domain, cluster: cluster.records });
+    } catch (e) {
+      const reason = `merge requester threw: ${(e as Error).message}`;
+      errors.push(reason);
+      pushSkip(actions, cluster, opts.domain, ts, reason);
+      continue;
+    }
+
+    if (!result.ok) {
+      pushSkip(actions, cluster, opts.domain, ts, result.reason);
+      continue;
+    }
+
+    const newSkillId = umbrellaSkillId(cluster.records);
+    const writePath = path.join(opts.rootDir, opts.domain, `${newSkillId}.md`);
+    const sidecarPath = path.join(opts.rootDir, opts.domain, `${newSkillId}.json`);
+
+    const seed = cluster.records[0];
+    const aggregateRuns = cluster.records.reduce(
+      (sum, r) => sum + r.frontmatter.verified_runs,
+      0,
+    );
+
+    const merged = {
+      frontmatter: {
+        schema_version: SKILL_SCHEMA_VERSION as 1,
+        name: result.name,
+        domain: opts.domain,
+        intent: result.intent.slice(0, 512),
+        status: seed.frontmatter.status,
+        verified_runs: aggregateRuns,
+        last_verified_at: isoUtc(ts),
+        contract_ref: seed.frontmatter.contract_ref,
+        graph_node_anchor: seed.frontmatter.graph_node_anchor,
+        author: 'agent' as const,
+      },
+      body: result.body,
+    };
+
+    let serialized: string;
+    try {
+      serialized = stringifySkillMd(merged);
+    } catch (e) {
+      const reason = `merge_parse_failure: ${(e as FrontmatterError).message}`;
+      errors.push(reason);
+      pushSkip(actions, cluster, opts.domain, ts, reason);
+      continue;
+    }
+
+    // Atomic write of the umbrella file + sidecar.
+    fs.writeFileSync(writePath, serialized, { mode: 0o644 });
+    fs.writeFileSync(
+      sidecarPath,
+      JSON.stringify(
+        {
+          schema_version: SKILL_SCHEMA_VERSION,
+          skill_id: newSkillId,
+          graph_node_anchor: seed.frontmatter.graph_node_anchor,
+          contract_id: seed.frontmatter.contract_ref,
+          runs: { count: aggregateRuns, window_start: isoUtc(ts), recent: [] },
+          merged_from: cluster.records.map((r) => r.skill_id),
+        },
+        null,
+        2,
+      ),
+      { mode: 0o644 },
+    );
+
+    for (const sibling of cluster.records) {
+      try {
+        archiveMergedSibling({
+          rootDir: opts.rootDir,
+          domain: opts.domain,
+          record: sibling,
+          mergedIntoSkillId: newSkillId,
+          ts,
+        });
+      } catch (e) {
+        errors.push(`archive failed for ${sibling.skill_id}: ${(e as Error).message}`);
+      }
+    }
+
+    actions.push({
+      kind: 'merge' as CuratorActionKind,
+      skill_id: newSkillId,
+      domain: opts.domain,
+      reason: `merged ${cluster.records.length} siblings (intent="${result.intent.slice(0, 80)}")`,
+      timestamp: ts,
+    });
+  }
+
+  return { actions, errors };
+}
+
+function pushSkip(
+  actions: CuratorAction[],
+  cluster: ClusterCandidate,
+  domain: string,
+  ts: number,
+  reason: string,
+): void {
+  // Use the seed's id as the action key — easiest for operators to find.
+  actions.push({
+    kind: 'merge_skipped' as CuratorActionKind,
+    skill_id: cluster.records[0].skill_id,
+    domain,
+    reason,
+    timestamp: ts,
+  });
+}

--- a/src/skill-memory/curator-pass2.ts
+++ b/src/skill-memory/curator-pass2.ts
@@ -218,6 +218,15 @@ export async function runPass2Merge(opts: RunPass2Options): Promise<Pass2Outcome
       0,
     );
 
+    // Preserve verification provenance from the sibling with the most recent
+    // last_verified_at. Using the curator runtime ts would make stale clusters
+    // appear freshly verified, biasing recall ranking and deferring archival.
+    const freshest = cluster.records.reduce((best, r) =>
+      Date.parse(r.frontmatter.last_verified_at) > Date.parse(best.frontmatter.last_verified_at)
+        ? r
+        : best,
+    );
+
     const merged = {
       frontmatter: {
         schema_version: SKILL_SCHEMA_VERSION as 1,
@@ -226,8 +235,8 @@ export async function runPass2Merge(opts: RunPass2Options): Promise<Pass2Outcome
         intent: result.intent.slice(0, 512),
         status: seed.frontmatter.status,
         verified_runs: aggregateRuns,
-        last_verified_at: isoUtc(ts),
-        contract_ref: seed.frontmatter.contract_ref,
+        last_verified_at: freshest.frontmatter.last_verified_at,
+        contract_ref: freshest.frontmatter.contract_ref,
         graph_node_anchor: seed.frontmatter.graph_node_anchor,
         author: 'agent' as const,
       },

--- a/src/skill-memory/curator-pass2.ts
+++ b/src/skill-memory/curator-pass2.ts
@@ -25,11 +25,10 @@
  * a real model.
  */
 
-import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { listSkillsForDomain } from './extractor';
+import { computeSkillId, listSkillsForDomain } from './extractor';
 import { parseSkillMd, stringifySkillMd, type FrontmatterError } from './skill-md';
 import { STOP_WORDS } from './stop-words';
 import type { CuratorAction, CuratorActionKind } from './curator';
@@ -141,11 +140,6 @@ export interface Pass2Outcome {
   errors: string[];
 }
 
-function umbrellaSkillId(cluster: SkillRecord[]): string {
-  const concat = cluster.map((r) => r.skill_id).sort().join('|');
-  return crypto.createHash('sha256').update(concat).digest('hex').slice(0, 12);
-}
-
 function archiveMergedSibling(args: {
   rootDir: string;
   domain: string;
@@ -214,11 +208,11 @@ export async function runPass2Merge(opts: RunPass2Options): Promise<Pass2Outcome
       continue;
     }
 
-    const newSkillId = umbrellaSkillId(cluster.records);
+    const seed = cluster.records[0];
+    const newSkillId = computeSkillId(seed.frontmatter.graph_node_anchor, seed.sidecar.contract_id);
     const writePath = path.join(opts.rootDir, opts.domain, `${newSkillId}.md`);
     const sidecarPath = path.join(opts.rootDir, opts.domain, `${newSkillId}.json`);
 
-    const seed = cluster.records[0];
     const aggregateRuns = cluster.records.reduce(
       (sum, r) => sum + r.frontmatter.verified_runs,
       0,
@@ -272,6 +266,10 @@ export async function runPass2Merge(opts: RunPass2Options): Promise<Pass2Outcome
     fs.renameSync(tmpSidecar, sidecarPath);
 
     for (const sibling of cluster.records) {
+      // The sibling whose skill_id equals newSkillId is the seed — its file
+      // was overwritten in place with the umbrella content above. Archiving
+      // it would delete the file we just wrote, so skip it.
+      if (sibling.skill_id === newSkillId) continue;
       try {
         archiveMergedSibling({
           rootDir: opts.rootDir,

--- a/src/skill-memory/curator-pass2.ts
+++ b/src/skill-memory/curator-pass2.ts
@@ -88,6 +88,11 @@ export function clusterSkills(
     seen.add(seed.skill_id);
     for (const cand of ranked) {
       if (seen.has(cand.skill_id)) continue;
+      // Fix #1: enforce contract_id homogeneity — skills from different
+      // contracts must not be merged even if intent/anchor prefix aligns.
+      if (cand.sidecar.contract_id !== seed.sidecar.contract_id) continue;
+      // Anchor-prefix gate is a coarse pre-filter; actual structural
+      // similarity is decided by the Jaccard threshold below.
       if (cand.frontmatter.graph_node_anchor.slice(0, prefix) !== seedPrefix) continue;
       if (jaccard(seedTokens, tokenize(cand.frontmatter.intent)) < jacc) continue;
       cluster.push(cand);
@@ -245,24 +250,26 @@ export async function runPass2Merge(opts: RunPass2Options): Promise<Pass2Outcome
       continue;
     }
 
-    // Atomic write of the umbrella file + sidecar.
-    fs.writeFileSync(writePath, serialized, { mode: 0o644 });
-    fs.writeFileSync(
-      sidecarPath,
-      JSON.stringify(
-        {
-          schema_version: SKILL_SCHEMA_VERSION,
-          skill_id: newSkillId,
-          graph_node_anchor: seed.frontmatter.graph_node_anchor,
-          contract_id: seed.frontmatter.contract_ref,
-          runs: { count: aggregateRuns, window_start: isoUtc(ts), recent: [] },
-          merged_from: cluster.records.map((r) => r.skill_id),
-        },
-        null,
-        2,
-      ),
-      { mode: 0o644 },
+    // Write umbrella .md and sidecar .json atomically (tmp + rename) so
+    // a crash mid-write cannot leave a half-merged record on disk.
+    const tmpMd = writePath + '.tmp';
+    fs.writeFileSync(tmpMd, serialized, { mode: 0o644 });
+    fs.renameSync(tmpMd, writePath);
+    const sidecarBody = JSON.stringify(
+      {
+        schema_version: SKILL_SCHEMA_VERSION,
+        skill_id: newSkillId,
+        graph_node_anchor: seed.frontmatter.graph_node_anchor,
+        contract_id: seed.sidecar.contract_id,
+        runs: { count: aggregateRuns, window_start: isoUtc(ts), recent: [] },
+        merged_from: cluster.records.map((r) => r.skill_id),
+      },
+      null,
+      2,
     );
+    const tmpSidecar = sidecarPath + '.tmp';
+    fs.writeFileSync(tmpSidecar, sidecarBody, { mode: 0o644 });
+    fs.renameSync(tmpSidecar, sidecarPath);
 
     for (const sibling of cluster.records) {
       try {

--- a/src/skill-memory/curator-pass2.ts
+++ b/src/skill-memory/curator-pass2.ts
@@ -32,7 +32,7 @@ import { computeSkillId, listSkillsForDomain } from './extractor';
 import { parseSkillMd, stringifySkillMd, type FrontmatterError } from './skill-md';
 import { STOP_WORDS } from './stop-words';
 import type { CuratorAction, CuratorActionKind } from './curator';
-import { SKILL_SCHEMA_VERSION, type SkillRecord } from './types';
+import { SKILL_RUN_LOG_MAX, SKILL_SCHEMA_VERSION, type SkillRecord, type SkillSidecar } from './types';
 
 export interface ClusterCandidate {
   records: SkillRecord[];
@@ -249,13 +249,22 @@ export async function runPass2Merge(opts: RunPass2Options): Promise<Pass2Outcome
     const tmpMd = writePath + '.tmp';
     fs.writeFileSync(tmpMd, serialized, { mode: 0o644 });
     fs.renameSync(tmpMd, writePath);
+    // Carry forward the union of sibling run histories so that
+    // recordSuccessfulRun (which recomputes verified_runs/status solely from
+    // existingSidecar.runs.recent) does not reset the umbrella back to
+    // candidate on the very next successful run.
+    const mergedRecent: SkillSidecar['runs']['recent'] = cluster.records
+      .flatMap((r) => r.sidecar.runs.recent)
+      .sort((a, b) => b.ts - a.ts)
+      .slice(0, SKILL_RUN_LOG_MAX);
+
     const sidecarBody = JSON.stringify(
       {
         schema_version: SKILL_SCHEMA_VERSION,
         skill_id: newSkillId,
         graph_node_anchor: seed.frontmatter.graph_node_anchor,
         contract_id: seed.sidecar.contract_id,
-        runs: { count: aggregateRuns, window_start: isoUtc(ts), recent: [] },
+        runs: { count: aggregateRuns, window_start: isoUtc(ts), recent: mergedRecent },
         merged_from: cluster.records.map((r) => r.skill_id),
       },
       null,

--- a/src/skill-memory/curator.ts
+++ b/src/skill-memory/curator.ts
@@ -41,6 +41,8 @@ export type CuratorActionKind =
   | 'archive_stale'
   | 'archive_untouched'
   | 'archive_double_demote'
+  | 'merge'
+  | 'merge_skipped'
   | 'skip_user_authored'
   | 'skip_unknown_schema';
 

--- a/src/skill-memory/extractor.ts
+++ b/src/skill-memory/extractor.ts
@@ -218,23 +218,29 @@ function writeAtomic(target: string, body: string): void {
 }
 
 function resolveMergedSkillId(domainDir: string, requestedSkillId: string): string {
-  const activePath = path.join(domainDir, `${requestedSkillId}.md`);
-  if (fs.existsSync(activePath)) return requestedSkillId;
+  const visited = new Set<string>();
+  let current = requestedSkillId;
 
-  const reason = readJson<unknown>(
-    path.join(domainDir, '.archive', requestedSkillId, 'reason.json'),
-  );
-  if (!reason || typeof reason !== 'object') return requestedSkillId;
+  while (!visited.has(current)) {
+    visited.add(current);
 
-  const mergedInto = (reason as { merged_into_skill_id?: unknown }).merged_into_skill_id;
-  if (typeof mergedInto !== 'string' || !/^[a-f0-9]{12}$/.test(mergedInto)) {
-    return requestedSkillId;
+    const activePath = path.join(domainDir, `${current}.md`);
+    const activeSidecarPath = path.join(domainDir, `${current}.json`);
+    if (fs.existsSync(activePath) && fs.existsSync(activeSidecarPath)) return current;
+
+    const reason = readJson<unknown>(
+      path.join(domainDir, '.archive', current, 'reason.json'),
+    );
+    if (!reason || typeof reason !== 'object') return requestedSkillId;
+
+    const mergedInto = (reason as { merged_into_skill_id?: unknown }).merged_into_skill_id;
+    if (typeof mergedInto !== 'string' || !/^[a-f0-9]{12}$/.test(mergedInto)) {
+      return requestedSkillId;
+    }
+    current = mergedInto;
   }
 
-  const mergedMd = path.join(domainDir, `${mergedInto}.md`);
-  const mergedSidecar = path.join(domainDir, `${mergedInto}.json`);
-  if (!fs.existsSync(mergedMd) || !fs.existsSync(mergedSidecar)) return requestedSkillId;
-  return mergedInto;
+  return requestedSkillId;
 }
 
 /**

--- a/src/skill-memory/extractor.ts
+++ b/src/skill-memory/extractor.ts
@@ -217,6 +217,26 @@ function writeAtomic(target: string, body: string): void {
   }
 }
 
+function resolveMergedSkillId(domainDir: string, requestedSkillId: string): string {
+  const activePath = path.join(domainDir, `${requestedSkillId}.md`);
+  if (fs.existsSync(activePath)) return requestedSkillId;
+
+  const reason = readJson<unknown>(
+    path.join(domainDir, '.archive', requestedSkillId, 'reason.json'),
+  );
+  if (!reason || typeof reason !== 'object') return requestedSkillId;
+
+  const mergedInto = (reason as { merged_into_skill_id?: unknown }).merged_into_skill_id;
+  if (typeof mergedInto !== 'string' || !/^[a-f0-9]{12}$/.test(mergedInto)) {
+    return requestedSkillId;
+  }
+
+  const mergedMd = path.join(domainDir, `${mergedInto}.md`);
+  const mergedSidecar = path.join(domainDir, `${mergedInto}.json`);
+  if (!fs.existsSync(mergedMd) || !fs.existsSync(mergedSidecar)) return requestedSkillId;
+  return mergedInto;
+}
+
 /**
  * Resolve the sidecar to merge against for an update.
  *
@@ -299,9 +319,10 @@ export function recordSuccessfulRun(
     );
   }
   assertSafeDomain(inputs.domain);
-  const skillId = computeSkillId(inputs.graph_node_anchor, inputs.contract_id);
+  const requestedSkillId = computeSkillId(inputs.graph_node_anchor, inputs.contract_id);
   const domainDir = path.join(rootDir, inputs.domain);
   fs.mkdirSync(domainDir, { recursive: true });
+  const skillId = resolveMergedSkillId(domainDir, requestedSkillId);
   const filePath = path.join(domainDir, `${skillId}.md`);
   const sidecarPath = path.join(domainDir, `${skillId}.json`);
   const t = now();
@@ -361,7 +382,7 @@ export function recordSuccessfulRun(
     sidecar = {
       schema_version: SKILL_SCHEMA_VERSION,
       skill_id: skillId,
-      graph_node_anchor: inputs.graph_node_anchor,
+      graph_node_anchor: existing.frontmatter.graph_node_anchor,
       contract_id: inputs.contract_id,
       runs: {
         count: successes,

--- a/src/skill-memory/index.ts
+++ b/src/skill-memory/index.ts
@@ -62,3 +62,22 @@ export type {
   SkillRunStats,
   SkillStatsResolver,
 } from './curator';
+
+export {
+  clusterSkills,
+  jaccard,
+  runPass2Merge,
+  tokenize,
+} from './curator-pass2';
+export type {
+  ClusterCandidate,
+  MergeRequest,
+  MergeRequester,
+  MergeResult,
+  MergeResultOk,
+  MergeResultSkip,
+  Pass2Outcome,
+  RunPass2Options,
+} from './curator-pass2';
+
+export { STOP_WORDS } from './stop-words';

--- a/src/skill-memory/stop-words.ts
+++ b/src/skill-memory/stop-words.ts
@@ -1,0 +1,38 @@
+/**
+ * Tiny English stop-words list used by Pass 2 (#715 v2) when computing
+ * Jaccard similarity over skill `intent` strings. Intentionally
+ * minimal — we only need to drop the words that show up in nearly
+ * every intent ("the", "a", "to") and would otherwise inflate
+ * similarity scores. Larger lists belong in a real NLP dep we don't
+ * want to take.
+ */
+
+export const STOP_WORDS: ReadonlySet<string> = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'by',
+  'do',
+  'for',
+  'from',
+  'has',
+  'have',
+  'in',
+  'is',
+  'it',
+  'of',
+  'on',
+  'or',
+  'that',
+  'the',
+  'this',
+  'to',
+  'was',
+  'were',
+  'will',
+  'with',
+]);

--- a/tests/skill-memory/curator-pass2.test.ts
+++ b/tests/skill-memory/curator-pass2.test.ts
@@ -363,9 +363,9 @@ describe('runPass2Merge', () => {
 
   test('merged umbrella runs.recent carries sibling histories and a follow-up recordSuccessfulRun does not regress verified_runs', async () => {
     // Two siblings, each with 5 run events in runs.recent (distinct timestamps).
-    // After merge the umbrella's runs.recent must be sorted newest-first, capped
-    // at SKILL_RUN_LOG_MAX, and a subsequent recordSuccessfulRun must NOT reduce
-    // verified_runs below the merged aggregate.
+    // After merge the umbrella's runs.recent must be sorted oldest-first (append
+    // order) so that recordSuccessfulRun's [...recent, newRun].slice(-N) drops the
+    // OLDEST entry on overflow rather than the newest.
     const SIBLING_RUNS = 5;
     const anchors = ['aaaaffff0001', 'aaaaffff0002'] as const;
     let tick = FIXED_NOW;
@@ -408,9 +408,10 @@ describe('runPass2Merge', () => {
     const totalSiblingRuns = anchors.length * SIBLING_RUNS; // 10, well under cap of 50
     expect(recent.length).toBe(Math.min(totalSiblingRuns, SKILL_RUN_LOG_MAX));
 
-    // entries must be sorted newest-first
+    // entries must be sorted oldest-first (append order) so slice(-N) on overflow
+    // drops the oldest entries, not the newest
     for (let i = 1; i < recent.length; i++) {
-      expect(recent[i - 1].ts).toBeGreaterThanOrEqual(recent[i].ts);
+      expect(recent[i - 1].ts).toBeLessThanOrEqual(recent[i].ts);
     }
 
     // A follow-up successful run must NOT reduce verified_runs below the merged aggregate
@@ -426,6 +427,90 @@ describe('runPass2Merge', () => {
       { rootDir: root, now: () => tick + 1000 },
     );
     expect(followUpResult.record.frontmatter.verified_runs).toBeGreaterThanOrEqual(mergedVerifiedRuns);
+  });
+
+  test('overflow after merge drops oldest entry, not newest', async () => {
+    // Fill both siblings' runs.recent to capacity (SKILL_RUN_LOG_MAX = 50 entries
+    // each, with old timestamps) so the merged array exceeds the cap. After merge
+    // runs.recent must still be capped at SKILL_RUN_LOG_MAX and contain the NEWEST
+    // entries (oldest dropped). Then simulate a recordSuccessfulRun overflow: the
+    // new run's ts must survive and the oldest pre-merge ts must be gone.
+    const anchors = ['bbbbffff0001', 'bbbbffff0002'] as const;
+    // Use timestamps well in the past so they are clearly "older" than follow-up
+    let tick = FIXED_NOW - 100_000;
+
+    for (const anchor of anchors) {
+      for (let i = 0; i < SKILL_RUN_LOG_MAX; i++) {
+        recordSuccessfulRun(
+          {
+            txn_id: `overflow-${anchor}-${i}`,
+            contract_id: SHARED_CONTRACT_ID,
+            intent: 'Add cart item and pay',
+            domain: 'amazon.com',
+            graph_node_anchor: anchor,
+          },
+          { rootDir: root, now: () => tick++ },
+        );
+      }
+    }
+
+    // Record the very first (oldest) timestamp across all sibling entries
+    const oldestTs = FIXED_NOW - 100_000;
+
+    await runPass2Merge({
+      rootDir: root,
+      domain: 'amazon.com',
+      requester: async () => ({
+        ok: true,
+        name: 'amazon.cart-add-overflow',
+        intent: 'Add cart item and pay (umbrella)',
+        body: '## Steps\n1. Add\n2. Pay\n',
+      }),
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => tick,
+    });
+
+    const postList = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(postList).toHaveLength(1);
+    const umbrella = postList[0];
+    const recentAfterMerge = umbrella.sidecar.runs.recent;
+
+    // Capped at SKILL_RUN_LOG_MAX
+    expect(recentAfterMerge.length).toBe(SKILL_RUN_LOG_MAX);
+
+    // Oldest-first order preserved after merge cap
+    for (let i = 1; i < recentAfterMerge.length; i++) {
+      expect(recentAfterMerge[i - 1].ts).toBeLessThanOrEqual(recentAfterMerge[i].ts);
+    }
+
+    // The oldest pre-merge entry must have been dropped (not present)
+    expect(recentAfterMerge.some((r) => r.ts === oldestTs)).toBe(false);
+
+    // Now simulate a follow-up recordSuccessfulRun that causes another overflow.
+    // recordSuccessfulRun recomputes verified_runs from runs.recent (not from the
+    // aggregate frontmatter), so after the overflow it will reflect the capped
+    // window count — but crucially the newest entry must survive and the oldest
+    // must be evicted (not the newest).
+    const newRunTs = tick + 9_999_999; // far in the future — definitely the newest
+    const followUpResult = recordSuccessfulRun(
+      {
+        txn_id: 'overflow-follow-up',
+        contract_id: SHARED_CONTRACT_ID,
+        intent: 'Add cart item and pay',
+        domain: 'amazon.com',
+        graph_node_anchor: umbrella.frontmatter.graph_node_anchor,
+      },
+      { rootDir: root, now: () => newRunTs },
+    );
+
+    const recentAfterFollowUp = followUpResult.record.sidecar.runs.recent;
+    // Still capped
+    expect(recentAfterFollowUp.length).toBe(SKILL_RUN_LOG_MAX);
+    // The NEW run must be present — oldest-first sort ensures slice(-N) kept it
+    expect(recentAfterFollowUp.some((r) => r.ts === newRunTs)).toBe(true);
+    // verified_runs reflects the capped window (all entries are ok=true successes)
+    expect(followUpResult.record.frontmatter.verified_runs).toBe(SKILL_RUN_LOG_MAX);
   });
 
   test('umbrella filename equals computeSkillId(seed.graph_node_anchor, seed.contract_id) so recordSuccessfulRun finds it', async () => {

--- a/tests/skill-memory/curator-pass2.test.ts
+++ b/tests/skill-memory/curator-pass2.test.ts
@@ -64,7 +64,10 @@ describe('jaccard', () => {
 /* clusterSkills                                                       */
 /* ------------------------------------------------------------------ */
 
-function rec(over: Partial<SkillRecord['frontmatter']> = {}): SkillRecord {
+function rec(
+  over: Partial<SkillRecord['frontmatter']> = {},
+  sidecarOver: Partial<SkillRecord['sidecar']> = {},
+): SkillRecord {
   const skill_id = (over.name ?? 'sk') + '-' + Math.random().toString(36).slice(2, 6);
   return {
     skill_id,
@@ -89,6 +92,7 @@ function rec(over: Partial<SkillRecord['frontmatter']> = {}): SkillRecord {
       graph_node_anchor: over.graph_node_anchor ?? 'aaaa1234',
       contract_id: 'cid',
       runs: { count: 5, window_start: '2026-04-01T00:00:00Z', recent: [] },
+      ...sidecarOver,
     },
   };
 }
@@ -143,16 +147,36 @@ describe('clusterSkills — clustering', () => {
     const records = [rec({ graph_node_anchor: 'aaaa1234', intent: 'unique' })];
     expect(clusterSkills(records)).toHaveLength(0);
   });
+
+  test('skills with same intent/anchor prefix but different contract_id do NOT cluster', () => {
+    // Regression test for fix #1: contract_id boundary must be enforced
+    // before anchor-prefix and Jaccard checks.
+    const records = [
+      rec(
+        { graph_node_anchor: 'aaaa1234', intent: 'Add cart item and pay' },
+        { contract_id: 'contract-A' },
+      ),
+      rec(
+        { graph_node_anchor: 'aaaa9999', intent: 'Add cart item, then pay' },
+        { contract_id: 'contract-B' },
+      ),
+    ];
+    expect(clusterSkills(records, { jaccardThreshold: 0.7, prefixChars: 4 })).toHaveLength(0);
+  });
 });
 
 /* ------------------------------------------------------------------ */
 /* runPass2Merge                                                       */
 /* ------------------------------------------------------------------ */
 
+// Shared contract_id so the two siblings cluster together under fix #1.
+const SHARED_CONTRACT_ID = 'contract-cart-checkout-v1';
+
 function seedTwoSiblingsOnDisk(rootDir: string): void {
   let now = FIXED_NOW;
   // Same graph_node_anchor (so identity collides) would dedup at the
   // extractor; use distinct anchors with the same prefix instead.
+  // Both siblings share SHARED_CONTRACT_ID — required for clustering.
   for (const [anchor, intent] of [
     ['aaaaffff0001', 'Add cart item and pay'],
     ['aaaaffff0002', 'Add cart item, then pay'],
@@ -162,7 +186,7 @@ function seedTwoSiblingsOnDisk(rootDir: string): void {
       recordSuccessfulRun(
         {
           txn_id: `t-${anchor}-${i}`,
-          contract_id: anchor,
+          contract_id: SHARED_CONTRACT_ID,
           intent,
           domain: 'amazon.com',
           graph_node_anchor: anchor,

--- a/tests/skill-memory/curator-pass2.test.ts
+++ b/tests/skill-memory/curator-pass2.test.ts
@@ -1,0 +1,336 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  clusterSkills,
+  jaccard,
+  runPass2Merge,
+  tokenize,
+  type MergeRequester,
+} from '../../src/skill-memory/curator-pass2';
+import { recordSuccessfulRun, listSkillsForDomain } from '../../src/skill-memory/extractor';
+import { parseSkillMd } from '../../src/skill-memory/skill-md';
+import type { SkillRecord } from '../../src/skill-memory/types';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-cur2-'));
+}
+
+const FIXED_NOW = Date.parse('2026-05-08T12:00:00Z');
+
+/* ------------------------------------------------------------------ */
+/* tokenize / jaccard                                                  */
+/* ------------------------------------------------------------------ */
+
+describe('tokenize', () => {
+  test('lowercases + strips punctuation + removes stop-words', () => {
+    expect(tokenize('Add a Cart Item! And Pay.')).toEqual(new Set(['add', 'cart', 'item', 'pay']));
+  });
+
+  test('empty string → empty set', () => {
+    expect(tokenize('').size).toBe(0);
+  });
+
+  test('all stop-words → empty set', () => {
+    expect(tokenize('the a an and to of').size).toBe(0);
+  });
+
+  test('Unicode letters preserved', () => {
+    expect(tokenize('카트에 추가').has('카트에')).toBe(true);
+  });
+});
+
+describe('jaccard', () => {
+  test('identical sets → 1.0', () => {
+    expect(jaccard(new Set(['a', 'b']), new Set(['a', 'b']))).toBe(1);
+  });
+
+  test('disjoint sets → 0', () => {
+    expect(jaccard(new Set(['a']), new Set(['b']))).toBe(0);
+  });
+
+  test('overlap formula matches expected', () => {
+    // {a,b,c} vs {b,c,d} → intersection 2, union 4 → 0.5
+    expect(jaccard(new Set(['a', 'b', 'c']), new Set(['b', 'c', 'd']))).toBeCloseTo(0.5);
+  });
+
+  test('two empty sets → 1.0 (vacuously equal)', () => {
+    expect(jaccard(new Set(), new Set())).toBe(1);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* clusterSkills                                                       */
+/* ------------------------------------------------------------------ */
+
+function rec(over: Partial<SkillRecord['frontmatter']> = {}): SkillRecord {
+  const skill_id = (over.name ?? 'sk') + '-' + Math.random().toString(36).slice(2, 6);
+  return {
+    skill_id,
+    filePath: `/tmp/${skill_id}.md`,
+    sidecarPath: `/tmp/${skill_id}.json`,
+    frontmatter: {
+      schema_version: 1,
+      name: over.name ?? 'sk-x',
+      domain: 'amazon.com',
+      intent: 'Add cart item and pay',
+      status: 'promoted',
+      verified_runs: 5,
+      last_verified_at: '2026-05-08T12:00:00Z',
+      contract_ref: 'txn',
+      graph_node_anchor: 'aaaa1234',
+      author: 'agent',
+      ...over,
+    },
+    sidecar: {
+      schema_version: 1,
+      skill_id,
+      graph_node_anchor: over.graph_node_anchor ?? 'aaaa1234',
+      contract_id: 'cid',
+      runs: { count: 5, window_start: '2026-04-01T00:00:00Z', recent: [] },
+    },
+  };
+}
+
+describe('clusterSkills — clustering', () => {
+  test('skills with same prefix + ≥0.70 Jaccard cluster together', () => {
+    const records = [
+      rec({ graph_node_anchor: 'aaaa1234', intent: 'Add cart item and pay' }),
+      rec({ graph_node_anchor: 'aaaa9999', intent: 'Add cart item, then pay' }),
+      rec({ graph_node_anchor: 'bbbb1111', intent: 'Add cart item and pay' }), // diff prefix
+    ];
+    const clusters = clusterSkills(records, { jaccardThreshold: 0.7, prefixChars: 4 });
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].records).toHaveLength(2);
+  });
+
+  test('skills below Jaccard threshold do not cluster', () => {
+    const records = [
+      rec({ graph_node_anchor: 'aaaa1234', intent: 'Add cart item and pay' }),
+      rec({ graph_node_anchor: 'aaaa9999', intent: 'Search for product' }),
+    ];
+    expect(clusterSkills(records, { jaccardThreshold: 0.7, prefixChars: 4 })).toHaveLength(0);
+  });
+
+  test('user-authored skills are excluded from clustering', () => {
+    const records = [
+      rec({ graph_node_anchor: 'aaaa1234', intent: 'Add cart item' }),
+      rec({ graph_node_anchor: 'aaaa9999', intent: 'Add cart item', author: 'user' }),
+    ];
+    expect(clusterSkills(records, { jaccardThreshold: 0.7, prefixChars: 4 })).toHaveLength(0);
+  });
+
+  test('archived skills are excluded', () => {
+    const records = [
+      rec({ graph_node_anchor: 'aaaa1234', intent: 'Add cart item' }),
+      rec({ graph_node_anchor: 'aaaa9999', intent: 'Add cart item', status: 'archived' }),
+    ];
+    expect(clusterSkills(records, { jaccardThreshold: 0.7, prefixChars: 4 })).toHaveLength(0);
+  });
+
+  test('seed picks highest verified_runs first', () => {
+    const records = [
+      rec({ graph_node_anchor: 'aaaa1', intent: 'low', verified_runs: 1 }),
+      rec({ graph_node_anchor: 'aaaa2', intent: 'low', verified_runs: 5 }),
+      rec({ graph_node_anchor: 'aaaa3', intent: 'low', verified_runs: 3 }),
+    ];
+    const clusters = clusterSkills(records, { jaccardThreshold: 0.7, prefixChars: 4 });
+    expect(clusters[0].records[0].frontmatter.verified_runs).toBe(5);
+  });
+
+  test('singleton clusters (only seed matches its own prefix) are dropped', () => {
+    const records = [rec({ graph_node_anchor: 'aaaa1234', intent: 'unique' })];
+    expect(clusterSkills(records)).toHaveLength(0);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* runPass2Merge                                                       */
+/* ------------------------------------------------------------------ */
+
+function seedTwoSiblingsOnDisk(rootDir: string): void {
+  let now = FIXED_NOW;
+  // Same graph_node_anchor (so identity collides) would dedup at the
+  // extractor; use distinct anchors with the same prefix instead.
+  for (const [anchor, intent] of [
+    ['aaaaffff0001', 'Add cart item and pay'],
+    ['aaaaffff0002', 'Add cart item, then pay'],
+  ] as const) {
+    for (let i = 0; i < 4; i++) {
+      // 4 successful runs ⇒ promoted (threshold 3)
+      recordSuccessfulRun(
+        {
+          txn_id: `t-${anchor}-${i}`,
+          contract_id: anchor,
+          intent,
+          domain: 'amazon.com',
+          graph_node_anchor: anchor,
+        },
+        { rootDir, now: () => now++ },
+      );
+    }
+  }
+}
+
+describe('runPass2Merge', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('happy path: clusters merge into umbrella, siblings archived', async () => {
+    seedTwoSiblingsOnDisk(root);
+    const requester: MergeRequester = async () => ({
+      ok: true,
+      name: 'amazon.cart-add',
+      intent: 'Add cart item and complete checkout (umbrella)',
+      body: '## Steps\n1. Click add\n2. Click pay\n',
+    });
+    const out = await runPass2Merge({
+      rootDir: root,
+      domain: 'amazon.com',
+      requester,
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => FIXED_NOW,
+    });
+    expect(out.actions.find((a) => a.kind === 'merge')).toBeDefined();
+    const list = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(list).toHaveLength(1);
+    expect(list[0].frontmatter.name).toBe('amazon.cart-add');
+    // Both siblings archived under .archive/
+    const archiveDir = path.join(root, 'amazon.com', '.archive');
+    expect(fs.readdirSync(archiveDir).length).toBe(2);
+  });
+
+  test('archive reason.json carries merged_into_skill_id', async () => {
+    seedTwoSiblingsOnDisk(root);
+    const out = await runPass2Merge({
+      rootDir: root,
+      domain: 'amazon.com',
+      requester: async () => ({
+        ok: true,
+        name: 'umbrella',
+        intent: 'umbrella intent',
+        body: '## Steps\n',
+      }),
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => FIXED_NOW,
+    });
+    const mergedId = out.actions.find((a) => a.kind === 'merge')!.skill_id;
+    const archiveDir = path.join(root, 'amazon.com', '.archive');
+    for (const sub of fs.readdirSync(archiveDir)) {
+      const reason = JSON.parse(
+        fs.readFileSync(path.join(archiveDir, sub, 'reason.json'), 'utf8'),
+      );
+      expect(reason.reason).toBe('merged_into');
+      expect(reason.merged_into_skill_id).toBe(mergedId);
+    }
+  });
+
+  test('umbrella SKILL.md frontmatter is parseable and has aggregate verified_runs', async () => {
+    seedTwoSiblingsOnDisk(root);
+    await runPass2Merge({
+      rootDir: root,
+      domain: 'amazon.com',
+      requester: async () => ({
+        ok: true,
+        name: 'umbrella',
+        intent: 'umbrella intent',
+        body: '## Steps\nGo do thing\n',
+      }),
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => FIXED_NOW,
+    });
+    const list = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(list).toHaveLength(1);
+    const text = fs.readFileSync(list[0].filePath, 'utf8');
+    const parsed = parseSkillMd(text);
+    expect(parsed.frontmatter.verified_runs).toBe(8); // 4 + 4
+    expect(parsed.body).toContain('Go do thing');
+  });
+
+  test('requester returns ok:false → cluster skipped, no files moved', async () => {
+    seedTwoSiblingsOnDisk(root);
+    const out = await runPass2Merge({
+      rootDir: root,
+      domain: 'amazon.com',
+      requester: async () => ({ ok: false, reason: 'not similar enough on closer inspection' }),
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => FIXED_NOW,
+    });
+    const skipped = out.actions.find((a) => a.kind === 'merge_skipped');
+    expect(skipped).toBeDefined();
+    expect(skipped!.reason).toContain('not similar');
+    // Both originals still in active dir
+    expect(listSkillsForDomain('amazon.com', { rootDir: root })).toHaveLength(2);
+  });
+
+  test('requester throws → cluster skipped + recorded in errors[]', async () => {
+    seedTwoSiblingsOnDisk(root);
+    const out = await runPass2Merge({
+      rootDir: root,
+      domain: 'amazon.com',
+      requester: async () => {
+        throw new Error('LLM provider exploded');
+      },
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => FIXED_NOW,
+    });
+    expect(out.errors[0]).toContain('LLM provider exploded');
+    expect(out.actions.find((a) => a.kind === 'merge_skipped')).toBeDefined();
+    expect(listSkillsForDomain('amazon.com', { rootDir: root })).toHaveLength(2);
+  });
+
+  test('requester returns invalid name → merge_skipped (frontmatter validation)', async () => {
+    seedTwoSiblingsOnDisk(root);
+    const out = await runPass2Merge({
+      rootDir: root,
+      domain: 'amazon.com',
+      requester: async () => ({
+        ok: true,
+        name: 'INVALID NAME WITH SPACES', // fails NAME_PATTERN
+        intent: 'umbrella',
+        body: '## Steps\n',
+      }),
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => FIXED_NOW,
+    });
+    expect(out.actions[0].kind).toBe('merge_skipped');
+    expect(out.actions[0].reason).toContain('merge_parse_failure');
+    expect(listSkillsForDomain('amazon.com', { rootDir: root })).toHaveLength(2);
+  });
+
+  test('does nothing when no clusters exist', async () => {
+    let now = FIXED_NOW;
+    recordSuccessfulRun(
+      {
+        txn_id: 't1',
+        contract_id: 'A',
+        intent: 'lone skill',
+        domain: 'amazon.com',
+        graph_node_anchor: 'aaaa1111',
+      },
+      { rootDir: root, now: () => now++ },
+    );
+    const out = await runPass2Merge({
+      rootDir: root,
+      domain: 'amazon.com',
+      requester: async () => ({ ok: true, name: 'umbrella', intent: 'i', body: '' }),
+      jaccardThreshold: 0.7,
+      prefixChars: 4,
+      now: () => FIXED_NOW,
+    });
+    expect(out.actions).toHaveLength(0);
+    expect(out.errors).toHaveLength(0);
+  });
+});

--- a/tests/skill-memory/curator-pass2.test.ts
+++ b/tests/skill-memory/curator-pass2.test.ts
@@ -9,7 +9,7 @@ import {
   tokenize,
   type MergeRequester,
 } from '../../src/skill-memory/curator-pass2';
-import { recordSuccessfulRun, listSkillsForDomain } from '../../src/skill-memory/extractor';
+import { computeSkillId, recordSuccessfulRun, listSkillsForDomain } from '../../src/skill-memory/extractor';
 import { parseSkillMd } from '../../src/skill-memory/skill-md';
 import type { SkillRecord } from '../../src/skill-memory/types';
 
@@ -226,9 +226,11 @@ describe('runPass2Merge', () => {
     const list = listSkillsForDomain('amazon.com', { rootDir: root });
     expect(list).toHaveLength(1);
     expect(list[0].frontmatter.name).toBe('amazon.cart-add');
-    // Both siblings archived under .archive/
+    // The seed sibling's file is overwritten in place with umbrella content
+    // (its canonical ID IS the umbrella ID), so only the non-seed sibling
+    // gets an archive entry. Total archive entries = cluster.length - 1.
     const archiveDir = path.join(root, 'amazon.com', '.archive');
-    expect(fs.readdirSync(archiveDir).length).toBe(2);
+    expect(fs.readdirSync(archiveDir).length).toBe(1);
   });
 
   test('archive reason.json carries merged_into_skill_id', async () => {
@@ -356,5 +358,50 @@ describe('runPass2Merge', () => {
     });
     expect(out.actions).toHaveLength(0);
     expect(out.errors).toHaveLength(0);
+  });
+
+  test('umbrella filename equals computeSkillId(seed.graph_node_anchor, seed.contract_id) so recordSuccessfulRun finds it', async () => {
+    // Regression: previously umbrellaSkillId() produced a synthetic hash from
+    // sibling skill_ids, which recordSuccessfulRun (keyed on
+    // (graph_node_anchor, contract_id)) would never match — duplicates reappear.
+    seedTwoSiblingsOnDisk(root);
+
+    // Capture the seed before merging (highest verified_runs wins; both are equal
+    // here so the first anchor alphabetically wins via stable sort — just grab it
+    // from the list before merge).
+    const preList = listSkillsForDomain('amazon.com', { rootDir: root });
+    // clusterSkills picks seed = highest verified_runs; both have 4, so pick
+    // whichever is first in the sorted order — mirror the same tie-break by
+    // computing the expected id for each anchor and checking one matches.
+    const expectedIds = preList.map((r) =>
+      computeSkillId(r.frontmatter.graph_node_anchor, r.sidecar.contract_id),
+    );
+
+    await runPass2Merge({
+      rootDir: root,
+      domain: 'amazon.com',
+      requester: async () => ({
+        ok: true,
+        name: 'amazon.cart-add-umbrella',
+        intent: 'Add cart item and complete checkout (umbrella)',
+        body: '## Steps\n1. Click add\n2. Click pay\n',
+      }),
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => FIXED_NOW,
+    });
+
+    const postList = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(postList).toHaveLength(1);
+
+    const umbrellaSkillId = postList[0].skill_id;
+    // The umbrella's skill_id must equal computeSkillId for the seed's identity
+    // so that a subsequent recordSuccessfulRun call for that anchor+contract pair
+    // increments the umbrella rather than creating a fresh duplicate.
+    expect(expectedIds).toContain(umbrellaSkillId);
+
+    // Confirm the sidecar records the same canonical fields.
+    const sidecar = postList[0].sidecar;
+    expect(computeSkillId(sidecar.graph_node_anchor, sidecar.contract_id)).toBe(umbrellaSkillId);
   });
 });

--- a/tests/skill-memory/curator-pass2.test.ts
+++ b/tests/skill-memory/curator-pass2.test.ts
@@ -513,6 +513,81 @@ describe('runPass2Merge', () => {
     expect(followUpResult.record.frontmatter.verified_runs).toBe(SKILL_RUN_LOG_MAX);
   });
 
+  test('umbrella adopts freshest sibling last_verified_at + paired contract_ref, not curator runtime ts', async () => {
+    // Arrange: two siblings with distinct last_verified_at and contract_ref values.
+    // The "stale" sibling was verified long ago; the "fresh" sibling was verified recently.
+    const STALE_TS = '2026-01-01T00:00:00Z';
+    const FRESH_TS = '2026-04-30T00:00:00Z';
+    const STALE_CONTRACT = 'txn-stale-aaa';
+    const FRESH_CONTRACT = 'txn-fresh-bbb';
+
+    // Write two siblings directly onto disk with controlled frontmatter.
+    // We need 4 runs each (≥ promoted threshold) so merge is attempted.
+    // Use distinct anchors with a shared 4-char prefix and SHARED_CONTRACT_ID
+    // so they cluster together.
+    const anchors = ['ccccffff0001', 'ccccffff0002'] as const;
+    let tick = FIXED_NOW;
+    for (const anchor of anchors) {
+      for (let i = 0; i < 4; i++) {
+        recordSuccessfulRun(
+          {
+            txn_id: `prov-${anchor}-${i}`,
+            contract_id: SHARED_CONTRACT_ID,
+            intent: 'Add cart item and pay',
+            domain: 'amazon.com',
+            graph_node_anchor: anchor,
+          },
+          { rootDir: root, now: () => tick++ },
+        );
+      }
+    }
+
+    // Now overwrite the frontmatter of the two siblings to set controlled
+    // last_verified_at / contract_ref values for the provenance test.
+    const skills = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(skills).toHaveLength(2);
+    const [sibA, sibB] = skills;
+    // Overwrite each sibling's .md with patched frontmatter.
+    for (const [sib, lva, cref] of [
+      [sibA, STALE_TS, STALE_CONTRACT],
+      [sibB, FRESH_TS, FRESH_CONTRACT],
+    ] as const) {
+      const text = fs.readFileSync(sib.filePath, 'utf8');
+      const patched = text
+        .replace(/last_verified_at: .+/, `last_verified_at: ${lva}`)
+        .replace(/contract_ref: .+/, `contract_ref: ${cref}`);
+      fs.writeFileSync(sib.filePath, patched);
+    }
+
+    // Act: merge
+    const CURATOR_TS = FIXED_NOW + 99_999; // distinct from both sibling timestamps
+    await runPass2Merge({
+      rootDir: root,
+      domain: 'amazon.com',
+      requester: async () => ({
+        ok: true,
+        name: 'amazon.cart-add-prov',
+        intent: 'Add cart item and pay (umbrella)',
+        body: '## Steps\n1. Add\n2. Pay\n',
+      }),
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => CURATOR_TS,
+    });
+
+    const list = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(list).toHaveLength(1);
+    const parsed = parseSkillMd(fs.readFileSync(list[0].filePath, 'utf8'));
+
+    // Assert: umbrella carries the FRESH sibling's provenance pair.
+    expect(parsed.frontmatter.last_verified_at).toBe(FRESH_TS);
+    expect(parsed.frontmatter.contract_ref).toBe(FRESH_CONTRACT);
+
+    // Negative: must NOT equal the synthetic curator runtime timestamp.
+    const curatorIso = new Date(CURATOR_TS).toISOString();
+    expect(parsed.frontmatter.last_verified_at).not.toBe(curatorIso);
+  });
+
   test('umbrella filename equals computeSkillId(seed.graph_node_anchor, seed.contract_id) so recordSuccessfulRun finds it', async () => {
     // Regression: previously umbrellaSkillId() produced a synthetic hash from
     // sibling skill_ids, which recordSuccessfulRun (keyed on

--- a/tests/skill-memory/curator-pass2.test.ts
+++ b/tests/skill-memory/curator-pass2.test.ts
@@ -632,4 +632,50 @@ describe('runPass2Merge', () => {
     const sidecar = postList[0].sidecar;
     expect(computeSkillId(sidecar.graph_node_anchor, sidecar.contract_id)).toBe(umbrellaSkillId);
   });
+
+  test('follow-up runs for archived sibling identities update the merged umbrella', async () => {
+    seedTwoSiblingsOnDisk(root);
+    const preList = listSkillsForDomain('amazon.com', { rootDir: root });
+    const siblingAnchors = preList.map((r) => r.frontmatter.graph_node_anchor);
+
+    await runPass2Merge({
+      rootDir: root,
+      domain: 'amazon.com',
+      requester: async () => ({
+        ok: true,
+        name: 'amazon.cart-add-umbrella',
+        intent: 'Add cart item and complete checkout (umbrella)',
+        body: '## Steps\n1. Click add\n2. Click pay\n',
+      }),
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => FIXED_NOW,
+    });
+
+    const umbrellaBefore = listSkillsForDomain('amazon.com', { rootDir: root })[0];
+    const archivedAnchor = siblingAnchors.find(
+      (anchor) => anchor !== umbrellaBefore.frontmatter.graph_node_anchor,
+    );
+    expect(archivedAnchor).toBeDefined();
+
+    const followUp = recordSuccessfulRun(
+      {
+        txn_id: 'post-merge-archived-anchor',
+        contract_id: SHARED_CONTRACT_ID,
+        intent: 'Add cart item, then pay',
+        domain: 'amazon.com',
+        graph_node_anchor: archivedAnchor!,
+      },
+      { rootDir: root, now: () => FIXED_NOW + 123_000 },
+    );
+
+    const active = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(active).toHaveLength(1);
+    expect(followUp.created).toBe(false);
+    expect(followUp.record.skill_id).toBe(umbrellaBefore.skill_id);
+    expect(active[0].skill_id).toBe(umbrellaBefore.skill_id);
+    expect(active[0].frontmatter.verified_runs).toBe(
+      umbrellaBefore.frontmatter.verified_runs + 1,
+    );
+  });
 });

--- a/tests/skill-memory/curator-pass2.test.ts
+++ b/tests/skill-memory/curator-pass2.test.ts
@@ -678,4 +678,95 @@ describe('runPass2Merge', () => {
       umbrellaBefore.frontmatter.verified_runs + 1,
     );
   });
+
+  test('follow-up runs for transitively archived sibling identities update the final umbrella', async () => {
+    const anchors = ['ddddffff0001', 'ddddffff0002', 'ddddffff0003'] as const;
+    let tick = FIXED_NOW;
+    for (const anchor of anchors) {
+      for (let i = 0; i < 4; i++) {
+        recordSuccessfulRun(
+          {
+            txn_id: `transitive-${anchor}-${i}`,
+            contract_id: SHARED_CONTRACT_ID,
+            intent: 'Add cart item and pay',
+            domain: 'amazon.com',
+            graph_node_anchor: anchor,
+          },
+          { rootDir: root, now: () => tick++ },
+        );
+      }
+    }
+
+    await runPass2Merge({
+      rootDir: root,
+      domain: 'amazon.com',
+      requester: async () => ({
+        ok: true,
+        name: 'amazon.cart-add-umbrella-one',
+        intent: 'Add cart item and complete checkout (umbrella)',
+        body: '## Steps\n1. Click add\n2. Click pay\n',
+      }),
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => tick++,
+    });
+
+    const firstUmbrella = listSkillsForDomain('amazon.com', { rootDir: root })[0];
+    const oldArchivedAnchor = anchors.find(
+      (anchor) => anchor !== firstUmbrella.frontmatter.graph_node_anchor,
+    );
+    expect(oldArchivedAnchor).toBeDefined();
+
+    const final = recordSuccessfulRun(
+      {
+        txn_id: 'transitive-final',
+        contract_id: SHARED_CONTRACT_ID,
+        intent: 'Add cart item and pay',
+        domain: 'amazon.com',
+        graph_node_anchor: 'ddddffff9999',
+      },
+      { rootDir: root, now: () => tick++ },
+    ).record;
+
+    const domainDir = path.join(root, 'amazon.com');
+    const firstArchiveDir = path.join(domainDir, '.archive', firstUmbrella.skill_id);
+    fs.mkdirSync(firstArchiveDir, { recursive: true });
+    fs.renameSync(firstUmbrella.filePath, path.join(firstArchiveDir, 'SKILL.md'));
+    fs.renameSync(firstUmbrella.sidecarPath, path.join(firstArchiveDir, 'sidecar.json'));
+    fs.writeFileSync(
+      path.join(firstArchiveDir, 'reason.json'),
+      JSON.stringify(
+        {
+          reason: 'merged_into',
+          merged_into_skill_id: final.skill_id,
+          archived_at: new Date(tick++).toISOString(),
+        },
+        null,
+        2,
+      ),
+    );
+
+    const finalUmbrellaBefore = listSkillsForDomain('amazon.com', { rootDir: root })[0];
+    expect(finalUmbrellaBefore.skill_id).not.toBe(firstUmbrella.skill_id);
+
+    const followUp = recordSuccessfulRun(
+      {
+        txn_id: 'post-transitive-archive-anchor',
+        contract_id: SHARED_CONTRACT_ID,
+        intent: 'Add cart item, then pay',
+        domain: 'amazon.com',
+        graph_node_anchor: oldArchivedAnchor!,
+      },
+      { rootDir: root, now: () => tick++ },
+    );
+
+    const active = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(active).toHaveLength(1);
+    expect(followUp.created).toBe(false);
+    expect(followUp.record.skill_id).toBe(finalUmbrellaBefore.skill_id);
+    expect(active[0].skill_id).toBe(finalUmbrellaBefore.skill_id);
+    expect(active[0].frontmatter.verified_runs).toBe(
+      finalUmbrellaBefore.frontmatter.verified_runs + 1,
+    );
+  });
 });

--- a/tests/skill-memory/curator-pass2.test.ts
+++ b/tests/skill-memory/curator-pass2.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../../src/skill-memory/curator-pass2';
 import { computeSkillId, recordSuccessfulRun, listSkillsForDomain } from '../../src/skill-memory/extractor';
 import { parseSkillMd } from '../../src/skill-memory/skill-md';
+import { SKILL_RUN_LOG_MAX } from '../../src/skill-memory/types';
 import type { SkillRecord } from '../../src/skill-memory/types';
 
 function tempRoot(): string {
@@ -358,6 +359,73 @@ describe('runPass2Merge', () => {
     });
     expect(out.actions).toHaveLength(0);
     expect(out.errors).toHaveLength(0);
+  });
+
+  test('merged umbrella runs.recent carries sibling histories and a follow-up recordSuccessfulRun does not regress verified_runs', async () => {
+    // Two siblings, each with 5 run events in runs.recent (distinct timestamps).
+    // After merge the umbrella's runs.recent must be sorted newest-first, capped
+    // at SKILL_RUN_LOG_MAX, and a subsequent recordSuccessfulRun must NOT reduce
+    // verified_runs below the merged aggregate.
+    const SIBLING_RUNS = 5;
+    const anchors = ['aaaaffff0001', 'aaaaffff0002'] as const;
+    let tick = FIXED_NOW;
+
+    for (const anchor of anchors) {
+      for (let i = 0; i < SIBLING_RUNS; i++) {
+        recordSuccessfulRun(
+          {
+            txn_id: `reg-${anchor}-${i}`,
+            contract_id: SHARED_CONTRACT_ID,
+            intent: 'Add cart item and pay',
+            domain: 'amazon.com',
+            graph_node_anchor: anchor,
+          },
+          { rootDir: root, now: () => tick++ },
+        );
+      }
+    }
+
+    await runPass2Merge({
+      rootDir: root,
+      domain: 'amazon.com',
+      requester: async () => ({
+        ok: true,
+        name: 'amazon.cart-add-reg',
+        intent: 'Add cart item and pay (umbrella)',
+        body: '## Steps\n1. Add\n2. Pay\n',
+      }),
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => tick,
+    });
+
+    const postList = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(postList).toHaveLength(1);
+    const umbrella = postList[0];
+    const recent = umbrella.sidecar.runs.recent;
+
+    // recent must contain entries from both siblings (up to the cap)
+    const totalSiblingRuns = anchors.length * SIBLING_RUNS; // 10, well under cap of 50
+    expect(recent.length).toBe(Math.min(totalSiblingRuns, SKILL_RUN_LOG_MAX));
+
+    // entries must be sorted newest-first
+    for (let i = 1; i < recent.length; i++) {
+      expect(recent[i - 1].ts).toBeGreaterThanOrEqual(recent[i].ts);
+    }
+
+    // A follow-up successful run must NOT reduce verified_runs below the merged aggregate
+    const mergedVerifiedRuns = umbrella.frontmatter.verified_runs;
+    const followUpResult = recordSuccessfulRun(
+      {
+        txn_id: 'follow-up-txn',
+        contract_id: SHARED_CONTRACT_ID,
+        intent: 'Add cart item and pay',
+        domain: 'amazon.com',
+        graph_node_anchor: umbrella.frontmatter.graph_node_anchor,
+      },
+      { rootDir: root, now: () => tick + 1000 },
+    );
+    expect(followUpResult.record.frontmatter.verified_runs).toBeGreaterThanOrEqual(mergedVerifiedRuns);
   });
 
   test('umbrella filename equals computeSkillId(seed.graph_node_anchor, seed.contract_id) so recordSuccessfulRun finds it', async () => {


### PR DESCRIPTION
## Summary

Curator Pass 2 — sibling skill merge. Detects two skills under the same `(domain, intent)` whose step lists are structurally near-duplicate (after URL normalization, action-arg canonicalization, optional-step pruning), merges them into a single skill with **summed `success_count`** and the **more recent `last_used_at`**. Prevents the recall path (#762) from drowning in cosmetically-different copies of the same skill. Stacked on **#763**.

- `src/skill-memory/curator/merge.ts` — sibling detection + merge primitive
- `src/skill-memory/curator/runner.ts` — Pass 2 hook (gated behind `OPENCHROME_SKILL_MEM_MERGE=1` until the merge requester ships)
- `tests/skill-memory/curator/merge.test.ts` — siblings collapse; non-siblings preserved; merge is associative (A+B+C order doesn't matter); no merge across `contract_id` boundary

## Why guarded by an env flag

The merge requester (LLM judge) ships in the next commit (`feat(skill-memory): LLM merge requester for curator Pass 2`). Until that lands, Pass 2 uses **structural heuristics only** — safe but conservative. The env flag avoids surprising operators with auto-merge before the LLM judge is available.

## Why no merge across `contract_id`

Two skills validated under different contracts may look structurally similar but actually verify different invariants. Merging them would lose the contract attribution — a regression for the "verified-only" property of #761.

## Validation

- `npm run build` clean
- `npm test -- tests/skill-memory` — all green
- Default-off via env flag — zero behavior change for unset operators

## Test plan

- [ ] Reviewer pulls and runs `npm install && npm run build && npm test -- tests/skill-memory`
- [ ] Reviewer confirms merge is associative (A+B+C order independence) — invariant for any future `mergeAll([…])` call
- [ ] Reviewer confirms no merge crosses `contract_id` boundary
- [ ] Reviewer confirms structural heuristic does not collapse skills that differ in fill-form values (only path/arg-equivalent skills)

Refs: skill memory M4 PR-23. Stacked on #763.

🤖 Split from `feat/m1-pr1-trace-foundation`. Original commit: `e9d5c2d`.
