### PR TITLE
test: opt-in to allowUnauthenticatedHttp in HTTP transport tests

### DIFF
--- a/tests/security/dashboard-rest-authz.test.ts
+++ b/tests/security/dashboard-rest-authz.test.ts
@@ -102,7 +102,9 @@ async function boot(
   smOverrides: { defaultTenantId?: string } = {},
 ) {
   const port = await freePort();
-  const transport = new HTTPTransport(port, '127.0.0.1', authToken, store ? { apiKeyStore: store as never } : {});
+  const baseOptions = store ? { apiKeyStore: store as never } : {};
+  const options = authToken ? baseOptions : { ...baseOptions, allowUnauthenticatedHttp: true };
+  const transport = new HTTPTransport(port, '127.0.0.1', authToken, options);
   transport.setSessionManager(sessionManager(smOverrides) as never);
   transport.onMessage(async (msg: Record<string, unknown>) => ({
     jsonrpc: '2.0',

--- a/tests/transports/http-batch-limits.test.ts
+++ b/tests/transports/http-batch-limits.test.ts
@@ -68,7 +68,7 @@ describe('HTTPTransport JSON-RPC batch limits', () => {
       id: msg.id as number,
       result: { ok: true },
     }));
-    transport = new HTTPTransport(port, '127.0.0.1');
+    transport = new HTTPTransport(port, '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
     transport.onMessage(handler);
     transport.start();
 
@@ -100,7 +100,7 @@ describe('HTTPTransport JSON-RPC batch limits', () => {
   it('rejects an oversized notification-only batch with a single id:null error', async () => {
     const port = await ephemeralPort();
     const handler = jest.fn(async () => null);
-    transport = new HTTPTransport(port, '127.0.0.1');
+    transport = new HTTPTransport(port, '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
     transport.onMessage(handler);
     transport.start();
 
@@ -129,7 +129,7 @@ describe('HTTPTransport JSON-RPC batch limits', () => {
     let maxActive = 0;
     const releaseHandlers: Array<() => void> = [];
 
-    transport = new HTTPTransport(port, '127.0.0.1');
+    transport = new HTTPTransport(port, '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
     transport.onMessage(async (msg: JsonRpcMessage) => {
       active += 1;
       maxActive = Math.max(maxActive, active);


### PR DESCRIPTION
## Summary

PR #692 (`fix: fail closed HTTP auth and tighten CORS`) introduced `validateUnauthenticatedHttpPolicy` which throws on unauthenticated HTTP transport boots unless either:

1. `OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP=1` is set in the environment, **or**
2. `allowUnauthenticatedHttp: true` is passed in the constructor options

That fail-closed posture is correct for production. But four existing tests instantiated `HTTPTransport` with no auth token to exercise the loopback-only / disabled-auth path, and they were not updated to pass the escape hatch — so they regressed:

- `tests/transports/http-batch-limits.test.ts` — 3 tests on the rate-limit / batch-rejection paths
- `tests/security/dashboard-rest-authz.test.ts` — 1 test (`keeps disabled auth backward-compatible for dashboard REST`) that explicitly tests the unauthenticated path

This PR adds the **documented escape hatch** to the affected test sites — `allowUnauthenticatedHttp: true`, exactly the flag `validateUnauthenticatedHttpPolicy` was designed for.

## Why this approach (and not the alternatives)

- **Why not set `OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP=1` in jest setup?** That would silently affect every other test that asserts the fail-closed behavior — exactly the regression PR #692 was guarding against. The flag's blast radius would be the entire test runner.
- **Why not relax `validateUnauthenticatedHttpPolicy`?** Production users would lose the fail-closed protection. The flag is the contract; the tests should use it.
- **Why not introduce a `bootHttpForTest()` helper?** Three call sites in one file and a four-line boot helper in another — a helper would be more code than the fix it replaces. Keeping the option visible at each call site makes it obvious which tests are deliberately exercising the disabled-auth path.

## Generality

The same pattern works for any future test that needs to exercise an unauthenticated loopback HTTP transport: pass `{ allowUnauthenticatedHttp: true }` in the options. No special-case test infrastructure is added.

## Validation

- `npm run build` clean
- `npm test -- tests/transports/http-batch-limits tests/security/dashboard-rest-authz` — 13/13 pass (was 4 failed / 9 passed)
- Spot-checked: production code paths in `src/transports/http.ts` are unchanged. The fail-closed policy still throws for unauthenticated boots that don't explicitly opt in. Other tests that assert the throw (`tests/transports/http-auth-policy.test.ts` etc.) still pass

## Test plan

- [ ] Reviewer pulls and runs `npm install && npm run build`
- [ ] Reviewer runs `npm test -- tests/transports/http-batch-limits tests/security/dashboard-rest-authz` — all green
- [ ] Reviewer runs the full suite — no new failures introduced
- [ ] Reviewer confirms `src/transports/http.ts` is **untouched** (this PR only modifies test files)

Refs: regression introduced by #692. Discovered while running the full suite to verify the M1-M4 PR stack (#735-#766) doesn't introduce new failures — it doesn't, but this pre-existing failure surfaced.

🤖 Filed independently of the M1-M4 stack so it can land immediately on `develop` without waiting for the larger review.
