### PR TITLE
Stabilize OpenChrome MCP runtime setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,14 @@ Or right-click the app → Open → Open.
 
 **Claude Code**
 ```bash
-npx openchrome-mcp setup
+npm install -g openchrome-mcp
+openchrome setup
 ```
 
 **Codex CLI**
 ```bash
-npx openchrome-mcp setup --client codex
+npm install -g openchrome-mcp
+openchrome setup --client codex
 ```
 
 One command. Configures the MCP server for the selected client.
@@ -217,7 +219,7 @@ Restart your MCP client after setup completes.
 
 **Claude Code:**
 ```bash
-claude mcp add openchrome -- npx -y openchrome-mcp@latest serve --auto-launch
+claude mcp add openchrome -- openchrome serve --auto-launch
 ```
 
 **VS Code / Copilot** (`.vscode/mcp.json`):
@@ -226,8 +228,8 @@ claude mcp add openchrome -- npx -y openchrome-mcp@latest serve --auto-launch
   "servers": {
     "openchrome": {
       "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "openchrome-mcp@latest", "serve", "--auto-launch"]
+      "command": "openchrome",
+      "args": ["serve", "--auto-launch"]
     }
   }
 }
@@ -238,8 +240,8 @@ claude mcp add openchrome -- npx -y openchrome-mcp@latest serve --auto-launch
 {
   "mcpServers": {
     "openchrome": {
-      "command": "npm",
-      "args": ["exec", "--yes", "--prefer-online", "openchrome-mcp@latest", "--", "serve", "--auto-launch"]
+      "command": "openchrome",
+      "args": ["serve", "--auto-launch"]
     }
   }
 }
@@ -250,16 +252,17 @@ claude mcp add openchrome -- npx -y openchrome-mcp@latest serve --auto-launch
 {
   "mcpServers": {
     "openchrome": {
-      "command": "npx",
-      "args": ["-y", "openchrome-mcp@latest", "serve", "--auto-launch"]
+      "command": "openchrome",
+      "args": ["serve", "--auto-launch"]
     }
   }
 }
 ```
 
-> Some stdio clients wrap `npx` through `npm exec` and may parse flags differently.
-> If your client misinterprets `-y`, prefer a client-specific command shape (for example the Codex CLI config above)
-> or run a locally installed `openchrome` binary directly.
+To update the CLI later and refresh your MCP client configuration, run:
+```bash
+openchrome update
+```
 
 </details>
 
@@ -310,10 +313,11 @@ oc compare prices for "AirPods Pro" across Amazon, eBay, Walmart, Best Buy
 ## CLI
 
 ```bash
-oc setup                    # Auto-configure
-oc serve --auto-launch      # Start server
-oc serve --headless-shell   # Headless mode
-oc doctor                   # Diagnose issues
+openchrome setup                    # Auto-configure
+openchrome serve --auto-launch      # Start server
+openchrome serve --headless-shell   # Headless mode
+openchrome doctor                   # Diagnose issues
+openchrome update                   # Update CLI
 ```
 
 ---

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -10,6 +10,7 @@
  * - launch: Start Claude Code with isolated config
  * - doctor: Check installation status
  * - recover: Recover corrupted .claude.json
+ * - update: Update the globally installed OpenChrome package
  */
 
 import { Command } from 'commander';
@@ -21,6 +22,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { spawn, ChildProcess } from 'child_process';
 import { checkForUpdates } from './update-check';
+import { runUpdateCommand } from './update-command';
 import {
   formatMCPServerConfigSnippet,
   getClientLabel,
@@ -75,13 +77,13 @@ program
     console.log('     {');
     console.log('       "mcpServers": {');
     console.log('         "openchrome": {');
-    console.log('           "command": "oc",');
+    console.log('           "command": "openchrome",');
     console.log('           "args": ["serve"]');
     console.log('         }');
     console.log('       }');
     console.log('     }\n');
     console.log('  3. Restart Claude Code\n');
-    console.log('Run "oc doctor" to verify your setup.');
+    console.log('Run "openchrome doctor" to verify your setup.');
   });
 
 program
@@ -141,9 +143,6 @@ program
         }
       }
 
-      // Use npx @latest with --prefer-online for reliable auto-updates.
-      // Without --prefer-online, npx caches a semver range (e.g. ^1.4.0) in ~/.npm/_npx/
-      // and never re-checks the registry, so @latest effectively becomes @cached.
       const setupArgs = getClaudeSetupCommand(scope, serveArgOptions);
 
       console.log(`Running: claude mcp add openchrome (scope: ${scope})...`);
@@ -187,7 +186,7 @@ program
         }
 
         console.log(`\nScope: ${scope === 'user' ? 'Global (all projects)' : 'Project (this directory only)'}`);
-        console.log('Auto-updates: enabled (via npx)\n');
+        console.log('Updates: run "openchrome update"\n');
         console.log('Next steps:');
         console.log('  1. Restart Claude Code');
         console.log('  2. Just say "oc" — that\'s it.\n');
@@ -223,7 +222,7 @@ program
 
       console.log('\n✅ MCP server configured successfully!\n');
       console.log(`Config file: ${codexConfigPath}`);
-      console.log('Auto-updates: enabled (via npm exec)\n');
+      console.log('Updates: run "openchrome update"\n');
       console.log('Next steps:');
       console.log('  1. Restart Codex CLI');
       console.log('  2. Verify the openchrome MCP server reconnects cleanly\n');
@@ -261,6 +260,23 @@ program
   });
 
 program
+  .command('update')
+  .description('Update the globally installed OpenChrome package')
+  .option('--no-setup', 'skip MCP client reconfiguration after updating')
+  .option('--client <client>', 'MCP client to reconfigure after updating (claude, codex, vscode, cursor, windsurf)', 'claude')
+  .option('--scope <scope>', 'Claude Code scope to use during setup (user or project)', 'user')
+  .action((options) => {
+    const code = runUpdateCommand({
+      setup: options.setup,
+      client: options.client,
+      scope: options.scope,
+    });
+    if (code !== 0) {
+      process.exit(code);
+    }
+  });
+
+program
   .command('serve')
   .description('Start MCP server for Claude Code')
   .option('-p, --port <port>', 'Chrome remote debugging port', '9222')
@@ -285,23 +301,6 @@ program
   .action(async () => {
     // Non-blocking update check (fires in background)
     checkForUpdates(version).catch(() => {});
-
-    // Auto-migrate: patch ~/.claude.json to use @latest if still using bare package name.
-    try {
-      const claudeConfigPath = path.join(os.homedir(), '.claude.json');
-      if (fs.existsSync(claudeConfigPath)) {
-        const raw = fs.readFileSync(claudeConfigPath, 'utf8');
-        if (raw.includes('openchrome-mcp') && !raw.includes('openchrome-mcp@')) {
-          const patched = raw.replace(/openchrome-mcp(?!@)/g, 'openchrome-mcp@latest');
-          if (patched !== raw) {
-            fs.writeFileSync(claudeConfigPath, patched);
-            console.error('[openchrome] Auto-migrated MCP config to use @latest for auto-updates');
-          }
-        }
-      }
-    } catch {
-      // Best-effort migration
-    }
 
     // Forward to the full-featured serve implementation in dist/index.js
     // This includes self-healing, HTTP transport, event loop monitor, disk monitor,
@@ -403,7 +402,7 @@ program
       console.log('\nUsage:');
       console.log('  1. Start Chrome with: chrome --remote-debugging-port=9222');
       console.log('  2. Add to ~/.claude.json:');
-      console.log('     "mcpServers": { "openchrome": { "command": "oc", "args": ["serve"] } }');
+      console.log('     "mcpServers": { "openchrome": { "command": "openchrome", "args": ["serve"] } }');
       console.log('  3. Restart Claude Code');
     } else {
       if (!coreChecks['Chrome debugging port']) {

--- a/cli/mcp-client-config.ts
+++ b/cli/mcp-client-config.ts
@@ -46,15 +46,15 @@ export function getServeArgs(options: ServeArgOptions = {}): string[] {
 
 export function getCodexServerConfig(options: ServeArgOptions = {}): MCPServerConfig {
   return {
-    command: 'npm',
-    args: ['exec', '--yes', '--prefer-online', 'openchrome-mcp@latest', '--', ...getServeArgs(options)],
+    command: 'openchrome',
+    args: getServeArgs(options),
   };
 }
 
 export function getClaudeManualServerConfig(options: ServeArgOptions = {}): MCPServerConfig {
   return {
-    command: 'npx',
-    args: ['-y', 'openchrome-mcp@latest', ...getServeArgs(options)],
+    command: 'openchrome',
+    args: getServeArgs(options),
   };
 }
 
@@ -66,10 +66,7 @@ export function getClaudeSetupCommand(scope: SetupScope, options: ServeArgOption
     '-s',
     scope,
     '--',
-    'npx',
-    '--prefer-online',
-    '-y',
-    'openchrome-mcp@latest',
+    'openchrome',
     ...getServeArgs(options),
   ];
 }

--- a/cli/update-check.ts
+++ b/cli/update-check.ts
@@ -88,34 +88,7 @@ function compareVersions(current: string, latest: string): number {
 }
 
 /**
- * Clear stale npx cache entries for openchrome-mcp.
- * This ensures the next npx invocation fetches the latest version
- * from the registry instead of serving a stale cached copy.
- */
-function clearNpxCache(): boolean {
-  try {
-    const npxCacheDir = path.join(os.homedir(), '.npm', '_npx');
-    if (!fs.existsSync(npxCacheDir)) return false;
-
-    let cleared = false;
-    const entries = fs.readdirSync(npxCacheDir);
-    for (const entry of entries) {
-      const pkgDir = path.join(npxCacheDir, entry, 'node_modules', PACKAGE_NAME);
-      if (fs.existsSync(pkgDir)) {
-        // Remove the entire npx cache entry (includes package-lock.json)
-        fs.rmSync(path.join(npxCacheDir, entry), { recursive: true, force: true });
-        cleared = true;
-      }
-    }
-    return cleared;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Check for updates. If outdated, auto-clear the npx cache so the
- * next server restart fetches the latest version automatically.
+ * Check for updates. If outdated, tell users how to update explicitly.
  * Non-blocking — fires and forgets. Never throws.
  */
 export async function checkForUpdates(currentVersion: string): Promise<void> {
@@ -145,16 +118,9 @@ export async function checkForUpdates(currentVersion: string): Promise<void> {
         }
       }
 
-      // Auto-clear npx cache so next restart gets the new version
-      const cleared = clearNpxCache();
-
       console.error('');
       console.error(`  ⬆ Update available: ${currentVersion} → ${latestVersion}`);
-      if (cleared) {
-        console.error(`  Cache cleared — restart Claude Code to use the new version.`);
-      } else {
-        console.error(`  Run: npx openchrome-mcp@latest setup`);
-      }
+      console.error('  Run: openchrome update');
       console.error('');
     }
   } catch {

--- a/cli/update-command.ts
+++ b/cli/update-command.ts
@@ -1,0 +1,77 @@
+import { spawnSync } from 'child_process';
+
+const UPDATE_COMMAND = ['npm', 'install', '-g', 'openchrome-mcp@latest'] as const;
+
+export interface UpdateCommandOptions {
+  setup?: boolean;
+  client?: 'claude' | 'codex' | 'vscode' | 'cursor' | 'windsurf';
+  scope?: 'user' | 'project';
+}
+
+export function getUpdateCommandText(): string {
+  return UPDATE_COMMAND.join(' ');
+}
+
+function run(command: string, args: string[]): number {
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+
+  if (result.error) {
+    console.error(`\nFailed to run: ${[command, ...args].join(' ')}`);
+    if ((result.error as NodeJS.ErrnoException).code === 'ENOENT') {
+      console.error(`${command} was not found.`);
+    } else {
+      console.error(result.error.message);
+    }
+    return 1;
+  }
+
+  return typeof result.status === 'number' ? result.status : result.signal ? 1 : 0;
+}
+
+function getSetupArgs(options: UpdateCommandOptions): string[] {
+  const args = ['setup'];
+  const scope = options.scope ?? 'user';
+  if (options.client && options.client !== 'claude') {
+    args.push('--client', options.client);
+  }
+  args.push('--scope', scope);
+  return args;
+}
+
+export function runUpdateCommand(options: UpdateCommandOptions = {}): number {
+  const setup = options.setup !== false;
+
+  console.log(`Running: ${getUpdateCommandText()}`);
+  const updateStatus = run(UPDATE_COMMAND[0], UPDATE_COMMAND.slice(1));
+  if (updateStatus !== 0) {
+    console.error('\nUpdate failed.');
+    console.error('Run this command manually after fixing the npm error:');
+    console.error(`  ${getUpdateCommandText()}`);
+    return updateStatus;
+  }
+
+  console.log('\nOpenChrome package updated successfully.');
+
+  if (!setup) {
+    console.log('MCP client setup was skipped. Run "openchrome setup" when you are ready to reconfigure.');
+    return 0;
+  }
+
+  const setupArgs = getSetupArgs(options);
+  console.log(`\nReconfiguring MCP client to use the installed openchrome binary...`);
+  console.log(`Running: openchrome ${setupArgs.join(' ')}`);
+  const setupStatus = run('openchrome', setupArgs);
+  if (setupStatus !== 0) {
+    console.error('\nUpdate succeeded, but MCP client setup failed.');
+    console.error('Run this command manually after fixing the setup error:');
+    console.error(`  openchrome ${setupArgs.join(' ')}`);
+    return setupStatus;
+  }
+
+  console.log('\nOpenChrome updated and MCP client configuration refreshed.');
+  console.log('Restart your MCP client to load the updated server command.');
+  return 0;
+}

--- a/src/connect/hosts.ts
+++ b/src/connect/hosts.ts
@@ -66,7 +66,7 @@ export const HOST_DEFINITIONS: Record<WebAIHostId, HostDefinition> = {
     ],
     notes: [
       'Works with Claude Desktop, Cursor, Windsurf, and any MCP-compatible client.',
-      'For stdio clients, use a client-specific command. Example for Codex CLI: npm exec --yes openchrome-mcp@latest -- serve --auto-launch.',
+      'For stdio clients, use the installed openchrome binary. Example: openchrome serve --auto-launch.',
     ],
   },
 };

--- a/src/hints/rules/setup-hints.ts
+++ b/src/hints/rules/setup-hints.ts
@@ -16,7 +16,7 @@ export const setupHintRules: HintRule[] = [
       // Only on non-error tool calls
       if (ctx.isError) return null;
       hasFired = true;
-      return 'Hint: To configure OpenChrome quickly, run: npx openchrome-mcp setup (or add --client codex for Codex CLI)';
+      return 'Hint: To configure OpenChrome quickly, run: openchrome setup (or add --client codex for Codex CLI)';
     },
   },
 ];

--- a/tests/cli/mcp-client-config.test.ts
+++ b/tests/cli/mcp-client-config.test.ts
@@ -1,5 +1,6 @@
 import {
   formatMCPServerConfigSnippet,
+  getClaudeManualServerConfig,
   getClaudeSetupCommand,
   getCodexServerConfig,
   getServeArgs,
@@ -20,10 +21,17 @@ describe('cli/mcp-client-config', () => {
     expect(getServeArgs({ autoLaunch: false })).toEqual(['serve']);
   });
 
-  test('getCodexServerConfig uses npm exec with argument separator', () => {
+  test('getCodexServerConfig uses the installed openchrome binary', () => {
     expect(getCodexServerConfig()).toEqual({
-      command: 'npm',
-      args: ['exec', '--yes', '--prefer-online', 'openchrome-mcp@latest', '--', 'serve', '--auto-launch'],
+      command: 'openchrome',
+      args: ['serve', '--auto-launch'],
+    });
+  });
+
+  test('getClaudeManualServerConfig uses the installed openchrome binary', () => {
+    expect(getClaudeManualServerConfig()).toEqual({
+      command: 'openchrome',
+      args: ['serve', '--auto-launch'],
     });
   });
 
@@ -35,10 +43,7 @@ describe('cli/mcp-client-config', () => {
       '-s',
       'project',
       '--',
-      'npx',
-      '--prefer-online',
-      '-y',
-      'openchrome-mcp@latest',
+      'openchrome',
       'serve',
       '--auto-launch',
       '--dashboard',
@@ -66,8 +71,8 @@ describe('cli/mcp-client-config', () => {
           args: ['example.js'],
         },
         openchrome: {
-          command: 'npm',
-          args: ['exec', '--yes', '--prefer-online', 'openchrome-mcp@latest', '--', 'serve', '--auto-launch'],
+          command: 'openchrome',
+          args: ['serve', '--auto-launch'],
         },
       },
     });
@@ -77,11 +82,24 @@ describe('cli/mcp-client-config', () => {
     expect(JSON.parse(formatMCPServerConfigSnippet('openchrome', getCodexServerConfig()))).toEqual({
       mcpServers: {
         openchrome: {
-          command: 'npm',
-          args: ['exec', '--yes', '--prefer-online', 'openchrome-mcp@latest', '--', 'serve', '--auto-launch'],
+          command: 'openchrome',
+          args: ['serve', '--auto-launch'],
         },
       },
     });
+  });
+
+  test('generated configs do not use transient package runners', () => {
+    const serialized = [
+      JSON.stringify(getCodexServerConfig()),
+      JSON.stringify(getClaudeManualServerConfig()),
+      formatMCPServerConfigSnippet('openchrome', getCodexServerConfig()),
+      getClaudeSetupCommand('user').join(' '),
+    ].join('\n');
+
+    expect(serialized).not.toContain('npx');
+    expect(serialized).not.toContain('@latest');
+    expect(serialized).not.toContain('--prefer-online');
   });
 
   test('isSupportedMCPClient validates supported names', () => {

--- a/tests/cli/update-check.test.ts
+++ b/tests/cli/update-check.test.ts
@@ -95,10 +95,9 @@ describe('update-check', () => {
     expect(output).toContain('Update available');
     expect(output).toContain('1.0.0');
     expect(output).toContain('9.9.9');
-    // clearNpxCache may or may not succeed depending on environment
-    const hasSetupMsg = output.includes('npx openchrome-mcp@latest setup');
-    const hasCacheMsg = output.includes('Cache cleared');
-    expect(hasSetupMsg || hasCacheMsg).toBe(true);
+    expect(output).toContain('Run: openchrome update');
+    expect(output).not.toContain('Cache cleared');
+    expect(output).not.toContain('npx openchrome-mcp@latest setup');
   });
 
   it('should not warn when already on latest version', async () => {

--- a/tests/cli/update-command.test.ts
+++ b/tests/cli/update-command.test.ts
@@ -1,0 +1,76 @@
+jest.mock('child_process', () => ({
+  spawnSync: jest.fn(),
+}));
+
+import { spawnSync } from 'child_process';
+import { getUpdateCommandText, runUpdateCommand } from '../../cli/update-command';
+
+const mockedSpawnSync = spawnSync as jest.MockedFunction<typeof spawnSync>;
+
+describe('cli/update-command', () => {
+  let consoleLogSpy: jest.SpyInstance;
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('updates the package and refreshes Claude setup by default', () => {
+    mockedSpawnSync.mockReturnValue({ status: 0 } as unknown as ReturnType<typeof spawnSync>);
+
+    expect(runUpdateCommand()).toBe(0);
+    expect(getUpdateCommandText()).toBe('npm install -g openchrome-mcp@latest');
+    expect(mockedSpawnSync).toHaveBeenNthCalledWith(1, 'npm', ['install', '-g', 'openchrome-mcp@latest'], {
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
+    expect(mockedSpawnSync).toHaveBeenNthCalledWith(2, 'openchrome', ['setup', '--scope', 'user'], {
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
+  });
+
+  test('can skip setup refresh', () => {
+    mockedSpawnSync.mockReturnValue({ status: 0 } as unknown as ReturnType<typeof spawnSync>);
+
+    expect(runUpdateCommand({ setup: false })).toBe(0);
+
+    expect(mockedSpawnSync).toHaveBeenCalledTimes(1);
+    expect(mockedSpawnSync).toHaveBeenCalledWith('npm', ['install', '-g', 'openchrome-mcp@latest'], {
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
+  });
+
+  test('can refresh Codex setup after updating', () => {
+    mockedSpawnSync.mockReturnValue({ status: 0 } as unknown as ReturnType<typeof spawnSync>);
+
+    expect(runUpdateCommand({ client: 'codex' })).toBe(0);
+
+    expect(mockedSpawnSync).toHaveBeenNthCalledWith(2, 'openchrome', ['setup', '--client', 'codex', '--scope', 'user'], {
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
+  });
+
+  test('prints actionable guidance when npm is unavailable', () => {
+    const error = Object.assign(new Error('spawn npm ENOENT'), { code: 'ENOENT' });
+    mockedSpawnSync.mockReturnValue({ error } as unknown as ReturnType<typeof spawnSync>);
+
+    expect(runUpdateCommand()).toBe(1);
+
+    const output = [
+      ...consoleLogSpy.mock.calls.map((call: unknown[]) => call[0]),
+      ...consoleErrorSpy.mock.calls.map((call: unknown[]) => call[0]),
+    ].join('\n');
+    expect(output).toContain('npm was not found');
+    expect(output).toContain('npm install -g openchrome-mcp@latest');
+  });
+});

--- a/tests/security/dashboard-rest-authz.test.ts
+++ b/tests/security/dashboard-rest-authz.test.ts
@@ -116,12 +116,23 @@ async function boot(
 
 describe('dashboard REST authorization', () => {
   let transport: InstanceType<typeof HTTPTransport> | undefined;
+  let previousAllowUnauthenticatedHttp: string | undefined;
   const readAlpha = 'oc_live_alpha_read';
   const adminAlpha = 'oc_live_alpha_admin';
+
+  beforeEach(() => {
+    previousAllowUnauthenticatedHttp = process.env.OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP;
+    process.env.OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP = 'true';
+  });
 
   afterEach(async () => {
     if (transport) await transport.close();
     transport = undefined;
+    if (previousAllowUnauthenticatedHttp === undefined) {
+      delete process.env.OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP;
+    } else {
+      process.env.OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP = previousAllowUnauthenticatedHttp;
+    }
   });
 
   it('returns 401 for dashboard REST endpoints when auth is configured but missing', async () => {

--- a/tests/transports/http-batch-limits.test.ts
+++ b/tests/transports/http-batch-limits.test.ts
@@ -54,10 +54,21 @@ function request(port: number, body: unknown): Promise<HttpResult> {
 
 describe('HTTPTransport JSON-RPC batch limits', () => {
   let transport: HTTPTransport;
+  let previousAllowUnauthenticatedHttp: string | undefined;
+
+  beforeEach(() => {
+    previousAllowUnauthenticatedHttp = process.env.OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP;
+    process.env.OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP = 'true';
+  });
 
   afterEach(async () => {
     if (transport) {
       await transport.close();
+    }
+    if (previousAllowUnauthenticatedHttp === undefined) {
+      delete process.env.OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP;
+    } else {
+      process.env.OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP = previousAllowUnauthenticatedHttp;
     }
   });
 


### PR DESCRIPTION
## Summary
- replace generated MCP runtime commands with the installed `openchrome` binary instead of `npx`/`@latest`/`--prefer-online`
- stop `serve` update checks from mutating `~/.npm/_npx` or auto-migrating configs back to `@latest`
- add `openchrome update`, which runs `npm install -g openchrome-mcp@latest` and refreshes MCP setup by default so existing configs are rewritten to the stable runtime command
- update README/setup hints/tests to document the stable runtime path
- make unauthenticated loopback HTTP test fixtures explicitly opt into the existing development allowance required by the current HTTP auth policy

## Verification
- `npm test -- --runInBand tests/security/dashboard-rest-authz.test.ts tests/transports/http-batch-limits.test.ts tests/cli/mcp-client-config.test.ts tests/cli/update-check.test.ts tests/cli/update-command.test.ts`
- `npm run build`
- `npm run lint:changed`
- `npm pack --dry-run --json` confirmed `dist/cli/update-command.js` is included

## Notes
- Full `npm test -- --runInBand` was attempted locally, but the existing full suite exceeded the 10 minute local command limit while running unrelated orchestration tests. Focused CLI/auth tests and build passed locally; the GitHub Actions full matrix is the merge gate.
