### PR TITLE
docs(roadmap): portability-harness contract + 1.11 cleanup plan

### DIFF
--- a/docs/roadmap/openchrome-1.11-cleanup.md
+++ b/docs/roadmap/openchrome-1.11-cleanup.md
@@ -2,44 +2,61 @@
 
 One-time application of `portability-harness-contract.md` to the 35 PRs that
 were open at the start of the 1.11 cleanup cycle. This document is not
-normative; once every action listed here is taken, this document becomes a
-historical record.
+normative; once every action listed here is taken, it becomes a historical
+record and moves to `docs/roadmap/history/`.
 
 The contract takes precedence over any disposition below. If a discrepancy is
 discovered between this plan and the contract, the contract wins and this
 document is amended.
 
+The plan applies the **hybrid resolution** of PR #774 and issue #768: the
+`core` / `pilot` tier mechanism from #768, with the stricter content of PR #774
+(better-sqlite3 not adopted; in-server LLM features go to separate packages, not
+to `src/pilot/`).
+
 ---
 
 ## Family classification recap
 
-| Family             | Verdict       | Reason                                                                                          |
-|--------------------|---------------|-------------------------------------------------------------------------------------------------|
-| Outcome Contracts  | Necessary     | Directly reinforces "tool call returns within timeout" via verdicts, idempotency, irrev. hook   |
-| Trace recorder     | Optional      | Useful for replay and audit; not required for the contract; gated by `OPENCHROME_TRACE`         |
-| Skill state graph  | Optional      | Cross-session learning data layer; gated by `OPENCHROME_STATE_GRAPH`; executor must Noop when off |
-| Perception (prim.) | Optional      | Pure-compute primitives; gated by `OPENCHROME_PERCEPTION`                                       |
-| Skill memory       | Optional      | Recall data layer; gated by `OPENCHROME_SKILL_MEMORY`                                           |
-| In-server LLM      | Out of scope  | Violates P3 and P4; belongs in host-side library or separate package                            |
+| Family             | Tier               | Action shape                                                         |
+|--------------------|--------------------|----------------------------------------------------------------------|
+| Outcome Contracts  | core (DSL, oc_assert, oc_evidence_bundle, pHash, screenshot class) + pilot (runtime, retry, idempotency, handoff, beforeIrreversibleAction) | merge with directory move; some reroute to pilot |
+| Trace recorder     | core               | merge with directory move; SQLite storage rewritten as JSONL         |
+| Skill state graph  | core (storage, hashing, CLI, MCP resource) + pilot (graph executor with resume-from-state) | merge with directory move + storage rewrite; executor reroute to pilot |
+| Perception         | core (primitives) + pilot (voting framework, deterministic voters only) | merge with directory move; LLM voter wrappers go to separate package |
+| Skill memory       | core (store + audit-log stats) + pilot (curator, extractor, recall ranking) | merge with directory move + storage rewrite; LLM merge requester to separate package |
+| In-server LLM      | **out of scope**   | close with redirect to separate-package extraction issues             |
 
-`better-sqlite3` is not adopted. All storage layers in the optional families
-must use JSONL or JSON plus `proper-lockfile`.
+`better-sqlite3` is not adopted. All storage layers in both tiers use JSONL or
+JSON plus the existing `src/utils/atomic-file.ts` + `proper-lockfile`.
 
 ---
 
 ## Action codes
 
-- **merge-now** — already complies with the contract; merge after standard CI.
-- **merge-after-gate** — code is sound; add the per-family environment flag
-  and a Noop branch when off, then merge.
-- **close-rewrite** — storage layer assumes `better-sqlite3`; close the PR,
-  reopen a replacement that uses JSONL/JSON + `proper-lockfile`.
-- **close-rebase** — depends on a `close-rewrite` ancestor; close, then reopen
-  rebased onto the new ancestor with the appropriate feature gate.
-- **close-move** — out of scope (P3 / P4 violation); close with a redirect
-  comment, code moves to a separate package or host-side library.
-- **modify-body** — code is fine; only the PR description needs adjustment
-  before merge.
+- **MERGE → core/X** — retarget to `develop`, move files into `src/core/X/`,
+  merge after CI. Code is preserved as written.
+- **MERGE → docs/core/X** — same but for documentation PRs.
+- **REROUTE → pilot/X** — retarget to `develop`, move files into `src/pilot/X/`,
+  open as new PR with `tier:pilot` label, close original with pointer.
+- **MERGE-RECONCILE → core/X** — same as MERGE but requires file-conflict
+  resolution (notably `src/contracts/phash.ts` between #752 and #753).
+- **SPLIT** — one PR becomes two: a core slice and a pilot slice.
+- **CLOSE-REWRITE** — close the PR; reopen replacement that drops
+  `better-sqlite3` for JSONL/JSON + `proper-lockfile`.
+- **CLOSE-MOVE** — close the PR with a redirect; code moves to a separate npm
+  package or host-side library (tracked in #775 / #776).
+- **MERGE-NOW** — standalone fix, already compliant; merge after standard CI.
+
+For every REROUTE the procedure is:
+
+1. `git cherry-pick` each commit from the original PR onto a new branch based
+   on `develop`.
+2. `git mv` the affected files into `src/pilot/<subdir>/`.
+3. Open a new PR titled `feat(pilot): <original title> [relocated from #N]`.
+4. Close the original PR with: *"Code preserved in #NEW; relocated under
+   `src/pilot/` per the hybrid plan in `openchrome-1.11-cleanup.md` and
+   PR #774."*
 
 ---
 
@@ -47,71 +64,91 @@ must use JSONL or JSON plus `proper-lockfile`.
 
 ### Standalone fixes (target: develop, no stack)
 
-| PR    | Title                                                              | Action     | Notes                                       |
-|-------|--------------------------------------------------------------------|------------|---------------------------------------------|
-| #773  | fix: improve javascript_tool diagnostics and shadow DOM helpers    | merge-now  | Reliability/security aligned; no contract concern |
-| #771  | Fix auto-launched Chrome window bounds placement                   | merge-now  | Cross-platform CI green                     |
-| #767  | test: opt-in to allowUnauthenticatedHttp in HTTP transport tests   | merge-now  | Uses documented escape hatch                |
-| #742  | fix(deps): bump basic-ftp and ip-address via npm overrides         | merge-now  | Security advisories closed, no source changes |
+| PR    | Title                                                              | Action     | Notes |
+|-------|--------------------------------------------------------------------|------------|-------|
+| #773  | fix: improve javascript_tool diagnostics and shadow DOM helpers    | MERGE-NOW  | Currently base=`main`. Retarget to `develop` first (`gh pr edit 773 --base develop`) |
+| #771  | Fix auto-launched Chrome window bounds placement                   | MERGE-NOW  | Cross-platform CI green |
+| #767  | test: opt-in to allowUnauthenticatedHttp in HTTP transport tests   | MERGE-NOW  | **Merge first** — fixes 4 inherited HTTP-auth test failures on develop |
+| #742  | fix(deps): bump basic-ftp and ip-address via npm overrides         | MERGE-NOW  | Security advisories closed, no source changes |
 
 ### M1 trace recorder (#735, #736, #743–#747)
 
-| PR    | Title                                                                                  | Action          | Notes |
-|-------|----------------------------------------------------------------------------------------|-----------------|-------|
-| #735  | feat(trace): SQLite storage backend + credential redactor (M1 PR-1)                    | close-rewrite   | Storage layer must be JSONL-only. `better-sqlite3` removed from `package.json`. Index for `oc trace list` becomes filesystem scan or JSON sidecar |
-| #736  | feat(trace): session recorder with CDP event subscription (M1 PR-2)                    | close-rebase    | Rebased onto new JSONL trace storage |
-| #743  | feat(cli): oc trace list/show + oc skill list/inspect                                  | close-rebase    | Rebased; list path adjusted to JSONL scan |
-| #744  | feat(trace): wire recorder into CDPClient.createPage()                                 | close-rebase    | Gate behind `OPENCHROME_TRACE`; Noop when off |
-| #745  | feat(cli): oc trace play replay UI                                                     | close-rebase    | No storage code change; rebase for base ref |
-| #746  | feat(mcp): expose openchrome://trace/* resources to LLM clients                        | close-rebase    | Resources registered only when `OPENCHROME_TRACE` is set |
-| #747  | feat(trace): wire recorder into createTargetStealth() too                              | close-rebase    | Gate behind `OPENCHROME_TRACE`; Noop when off |
+| PR    | Title                                                                                  | Action                              |
+|-------|----------------------------------------------------------------------------------------|-------------------------------------|
+| #735  | feat(trace): SQLite storage backend + credential redactor (M1 PR-1)                    | **CLOSE-REWRITE** → `src/core/trace/` with JSONL storage |
+| #736  | feat(trace): session recorder with CDP event subscription (M1 PR-2)                    | MERGE → `src/core/trace/` (after #735 rewrite lands) |
+| #743  | feat(cli): oc trace list/show + oc skill list/inspect                                  | MERGE → `src/core/cli/` (list path uses filesystem scan, not SQLite query) |
+| #744  | feat(trace): wire recorder into CDPClient.createPage()                                 | MERGE → `src/core/trace/` |
+| #745  | feat(cli): oc trace play replay UI                                                     | MERGE → `src/core/cli/` |
+| #746  | feat(mcp): expose openchrome://trace/* resources to LLM clients                        | MERGE → `src/core/mcp/resources/` |
+| #747  | feat(trace): wire recorder into createTargetStealth() too                              | MERGE → `src/core/trace/` |
 
 ### M1 skill state graph (#737–#741)
 
-| PR    | Title                                                                                  | Action            | Notes |
-|-------|----------------------------------------------------------------------------------------|-------------------|-------|
-| #737  | feat(skill): state hashing + URL normalizer + interactive filter                       | merge-after-gate  | Pure logic; no storage. Gate consumers behind `OPENCHROME_STATE_GRAPH` when wired |
-| #738  | feat(skill): per-domain skill graph SQLite storage (M1 PR-5)                           | close-rewrite     | Rewrite as JSON-per-domain + `proper-lockfile`. Same `to_state_distribution` schema, file-based. Per-domain lock matches the original concurrency model |
-| #739  | feat(skill): graph-aware executor with resume-from-state                               | close-rebase      | Rebased onto new JSON graph. Executor branch must be unreachable when `OPENCHROME_STATE_GRAPH` unset |
-| #740  | docs(skill-graph): DOM snapshot capture procedure for fixtures                         | modify-body       | Update docs to reflect JSON storage; merge |
-| #741  | feat(skill): graph audit telemetry + executor integration                              | close-rebase      | Rebased; Noop when feature off |
+| PR    | Title                                                                                  | Action                              |
+|-------|----------------------------------------------------------------------------------------|-------------------------------------|
+| #737  | feat(skill): state hashing + URL normalizer + interactive filter                       | MERGE → `src/core/skill/` |
+| #738  | feat(skill): per-domain skill graph SQLite storage (M1 PR-5)                           | **CLOSE-REWRITE** → `src/core/skill/` as JSON-per-domain + `proper-lockfile`. Read-only API exposed under `openchrome://skill-graph/<domain>` |
+| #739  | feat(skill): graph-aware executor with resume-from-state                               | **REROUTE → `src/pilot/executor/`** |
+| #740  | docs(skill-graph): DOM snapshot capture procedure for fixtures                         | MERGE → `docs/core/skill/` after rewriting to reference JSON storage |
+| #741  | feat(skill): graph audit telemetry + executor integration                              | **SPLIT** — telemetry to `src/core/skill/`, executor wiring to `src/pilot/executor/` |
 
 ### M2 outcome contracts (#748–#756)
 
-All necessary. Standard review applies. The contract document does not require
-gating these.
+All currently stacked on top of the M1 chain. Each needs to be cherry-picked
+onto develop as a new PR before any tier action can be taken.
 
-| PR    | Title                                                                                  | Action     | Notes |
-|-------|----------------------------------------------------------------------------------------|------------|-------|
-| #748  | feat(contracts): DSL types + assertions + validator (M2 PR-9)                          | merge-now  | |
-| #749  | feat(contracts): runtime core with verdict taxonomy + retry (M2 PR-11)                 | merge-now  | |
-| #750  | feat(contracts): idempotency cache + preemptive cancellation (M2 PR-12)                | merge-now  | |
-| #751  | feat(contracts): evidence bundle generator + MCP resource (M2 PR-13)                   | merge-now  | |
-| #752  | feat(#705): contract DSL and assertion primitives                                      | merge-now  | Resolve phash.ts divergence with #753 before merge |
-| #753  | feat(contracts): pHash + screenshot class registry + screenshot_class assertion        | merge-now  | After #752 lands, rebase and reconcile phash.ts |
-| #754  | feat(contracts): handoff token + banner + manager (happy path)                         | merge-now  | In-memory tokens; persistence is #755 |
-| #755  | feat(contracts): handoff persistence with AES-256-GCM                                  | merge-after-gate | Key management policy: ephemeral default; `OPENCHROME_HANDOFF_KEY_FILE=<path>` opts into file-backed persistence. Document in PR body before merge |
-| #756  | feat(contracts): beforeIrreversibleAction hook for critical contracts                  | merge-now  | Hook fires only when a contract is declared `critical: true`; default path unchanged |
+| PR    | Title                                                                                  | Action                              |
+|-------|----------------------------------------------------------------------------------------|-------------------------------------|
+| #748  | feat(contracts): DSL types + assertions + validator (M2 PR-9)                          | MERGE → `src/core/contracts/`. Schema accepts `on_fail` / `budget` fields but core ignores them; pilot runtime interprets |
+| #749  | feat(contracts): runtime core with verdict taxonomy + retry (M2 PR-11)                 | **REROUTE → `src/pilot/runtime/`** |
+| #750  | feat(contracts): idempotency cache + preemptive cancellation (M2 PR-12)                | **REROUTE → `src/pilot/runtime/`** |
+| #751  | feat(contracts): evidence bundle generator + MCP resource (M2 PR-13)                   | MERGE → `src/core/contracts/`, exposed as MCP tool `oc_evidence_bundle`, decoupled from failure verdict (so it works in core without the pilot runtime) |
+| #752  | feat(#705): contract DSL and assertion primitives                                      | MERGE-RECONCILE → `src/core/contracts/`. Merge first (already on `develop`); keep its DCT-II `phash.ts` |
+| #753  | feat(contracts): pHash + screenshot class registry + screenshot_class assertion (M2 PR-10) | MERGE-RECONCILE → `src/core/contracts/` after `phash.ts` reconciled with #752 |
+| #754  | feat(contracts): handoff token + banner + manager (M2 PR-14 happy path)                | **REROUTE → `src/pilot/handoff/`** |
+| #755  | feat(contracts): handoff persistence with AES-256-GCM (M2 PR-15 partial)               | **REROUTE → `src/pilot/handoff/`**. Ephemeral key by default; `OPENCHROME_HANDOFF_KEY_FILE=<path>` opts into file-backed persistence. Document in PR body. No OS keychain (P3) |
+| #756  | feat(contracts): beforeIrreversibleAction hook for critical contracts                  | **REROUTE → `src/pilot/runtime/`** |
 
 ### M3 perception (#757–#760)
 
-| PR    | Title                                                                                  | Action            | Notes |
-|-------|----------------------------------------------------------------------------------------|-------------------|-------|
-| #757  | feat(perception): perceptual DOM metadata + cache                                      | merge-after-gate  | Pure compute; gate behind `OPENCHROME_PERCEPTION` |
-| #758  | feat(perception): cross-check core — Sobel + color distance                            | merge-after-gate  | Pure compute; gate behind `OPENCHROME_PERCEPTION` |
-| #759  | feat(perception): multi-model voting + args equivalence (M3 PR-19)                     | modify-body       | Voter interface is neutral. PR body must reframe "two configured perception models" to "two configured voters (deterministic or LLM)" and add at least one deterministic voter test before merge |
-| #760  | feat(perception): voting provider HTTP wrappers (anthropic + openai)                   | close-move        | Violates P3 (mandatory third-party API egress) and P4 (decision in server). Move to `openchrome-perception-voters` (separate npm package) or host-side library. Close PR with redirect comment |
+| PR    | Title                                                                                  | Action                              |
+|-------|----------------------------------------------------------------------------------------|-------------------------------------|
+| #757  | feat(perception): perceptual DOM metadata + cache                                      | MERGE → `src/core/perception/` |
+| #758  | feat(perception): cross-check core — Sobel + color distance                            | MERGE → `src/core/perception/` |
+| #759  | feat(perception): multi-model voting + args equivalence                                | **REROUTE → `src/pilot/voting/`**. PR body must reframe "two configured perception models" to "two configured voters (deterministic or LLM)" and ship at least one deterministic voter test. **No Anthropic/OpenAI providers ship with this PR.** |
+| #760  | feat(perception): voting provider HTTP wrappers (anthropic + openai)                   | **CLOSE-MOVE** → tracked by #775 (separate `openchrome-perception-voters` package). Violates P3 (mandatory third-party API egress) — would be rejected even in pilot |
 
 ### M4 skill memory (#761–#766)
 
-| PR    | Title                                                                                  | Action            | Notes |
-|-------|----------------------------------------------------------------------------------------|-------------------|-------|
-| #761  | feat(skill-memory): verified skill extractor (M4 PR-20)                                | merge-after-gate  | Deterministic transform; gate behind `OPENCHROME_SKILL_MEMORY` |
-| #762  | feat(skill-memory): skill recall + frozen-snapshot store (M4 PR-21)                    | close-rewrite     | Rewrite as JSON-per-domain `skills.json` + `proper-lockfile`. Frozen snapshots remain `.json.gz` on disk |
-| #763  | feat(skill-memory): curator (Pass 1 + Pass 3) + PID lock (M4 PR-22)                    | close-rebase      | Rebased onto new JSON store; PID lock retained |
-| #764  | feat(skill-memory): curator Pass 2 — sibling skill merge (M4 PR-23)                    | close-rebase      | Structural-only heuristic; no LLM. Rebased onto new store |
-| #765  | feat(skill-memory): LLM merge requester for curator Pass 2                             | close-move        | Violates P3 and P4. Move to host-side library or `openchrome-skill-curator-llm` package. Close PR with redirect comment |
-| #766  | feat(skill-memory): audit-log-backed SkillStatsResolver for the curator                | close-rebase      | Audit log path unchanged; only the consuming store is rebased |
+| PR    | Title                                                                                  | Action                              |
+|-------|----------------------------------------------------------------------------------------|-------------------------------------|
+| #761  | feat(skill-memory): verified skill extractor (M4 PR-20)                                | **REROUTE → `src/pilot/curator/`**. Deterministic transform, but lives in pilot because the extractor only runs when a curator is active |
+| #762  | feat(skill-memory): skill recall + frozen-snapshot store (M4 PR-21)                    | **CLOSE-REWRITE + SPLIT**. Replacement opens two PRs: store → `src/core/skill-memory/` (JSON-per-domain + `proper-lockfile`); recall ranking → `src/pilot/curator/recall.ts` |
+| #763  | feat(skill-memory): curator (Pass 1 + Pass 3) + PID lock (M4 PR-22)                    | **REROUTE → `src/pilot/curator/`** after rebase onto JSON store |
+| #764  | feat(skill-memory): curator Pass 2 — sibling skill merge (M4 PR-23)                    | **REROUTE → `src/pilot/curator/`**. Structural-only heuristic; no LLM |
+| #765  | feat(skill-memory): LLM merge requester for curator Pass 2                             | **CLOSE-MOVE** → tracked by #776 (separate `openchrome-skill-curator-llm` package). Violates P3 — would be rejected even in pilot |
+| #766  | feat(skill-memory): audit-log-backed SkillStatsResolver for the curator                | MERGE → `src/core/skill-memory/` (read-only over audit log; serves both core consumers and the pilot curator) |
+
+---
+
+## New tools that ship with v1.11.0 core
+
+The core tier adds four new MCP tools beyond the 1.10.4 surface. These are
+unflagged (active without `--pilot`) because they are read-only or verification
+primitives that satisfy P1–P5 strictly.
+
+| Tool / Resource                          | Source            | Tracking issue |
+|------------------------------------------|-------------------|----------------|
+| `oc_assert`                              | new               | TBD (file alongside Phase 0 amendment) |
+| `oc_evidence_bundle`                     | generalizes #751  | TBD            |
+| `oc_skill_record`                        | new               | TBD            |
+| `oc_skill_recall` (read-only over store) | new               | TBD            |
+| `openchrome://skill-graph/<domain>` (MCP resource, read-only) | new | TBD |
+
+These four are filed as a single bootstrap batch alongside the dependency-cruiser
+lint rule, two-stage CI workflow, `--pilot` flag scaffolding, and v1.11 release
+plan.
 
 ---
 
@@ -119,61 +156,110 @@ gating these.
 
 The cleanup proceeds in phases. Each phase's completion is the gate for the
 next; this is to prevent partial states where some PRs see one storage layer
-and other PRs see another.
+or one tier layout and other PRs see another.
 
 ### Phase 0 — Contract publication
 
-Land `portability-harness-contract.md` and this cleanup plan on `develop` so
-every subsequent PR references them.
+PR #774 (this document + `portability-harness-contract.md`) lands on develop.
+Issue #768 receives the hybrid-resolution comment. Issues #775–#780 are filed.
+Tier labels (`tier:core`, `tier:pilot`) are created.
 
-### Phase 1 — Standalone fixes
+### Phase 1 — Standalone fixes + boundary plumbing
 
-Merge #773, #771, #767, #742. No dependency on contract; mergeable in parallel.
+In parallel:
 
-### Phase 2 — Outcome Contracts (necessary family)
+- Merge #767, #773 (retarget first), #771, #742.
+- Land **boundary plumbing**: `dependency-cruiser` config, two-stage CI
+  workflow, `tier:core` / `tier:pilot` labels, empty `src/core/` and
+  `src/pilot/` directories, `--pilot` flag scaffolding (lazy bootstrap, no
+  pilot tools registered yet). File the four new core tool issues from §"New
+  tools" above.
+- Backfill tier labels on #698–#734 per the table in §7 of issue #768.
+- Update #780 meta tracker after each merge.
 
-Merge #748 → #749 → #750 → #751 → #752 → #753 (phash.ts reconciled) → #754
-→ #755 (with handoff key policy documented in PR body) → #756.
+**Gate** before proceeding: develop CI green; `--pilot` flag wired but
+registers nothing; lint forbids `src/core/ → src/pilot/` imports.
 
-This phase delivers the necessary family. Existing 1.10.4 behavior is
-preserved because the new tools live behind their existing contract DSL
-declarations; calls that do not declare a contract are unaffected.
+### Phase 2a — Close-or-rebase decisions on the M1/M2 stack
 
-### Phase 3 — Storage rewrites (close + reopen)
+The M1 + M2 stack is 22 PRs deep. Each PR is touched once:
 
-Close #735, #738, #762. Open three replacement PRs:
+- M1 PRs that become **MERGE → core**: #736, #737, #740, #743–#747 — close the
+  original, open a new PR retargeted to `develop` with the same code under
+  `src/core/<subdir>/`.
+- M1 PRs that become **REROUTE → pilot** or **SPLIT**: #739, #741 — same flow
+  but into `src/pilot/`.
+- M1 PRs that become **CLOSE-REWRITE**: #735, #738 — close, write replacement
+  PRs in Phase 3.
 
-- new trace storage (JSONL-only, no SQLite, no index DB)
-- new skill graph storage (JSON per domain + `proper-lockfile`)
-- new skill memory recall store (JSON per domain + `proper-lockfile`)
+For each closed M1 PR, append a comment that lists the Codex P1/P2 findings
+already resolved on that branch (provenance preserved for the replacement
+reviewer).
 
-Each replacement PR carries the relevant `OPENCHROME_*` flag gate from the
-contract. The replacement PRs are smaller than the originals because they ship
-no migrations and no SQLite-specific code paths.
+### Phase 2b — M2 cherry-pick to develop
 
-### Phase 4 — Stack rebases (close + reopen)
+Strictly serial within this phase:
 
-Close and reopen the upper-stack PRs against the new bases:
+1. Merge #752 (already on `develop`). Canonical `phash.ts` lands.
+2. Cherry-pick #748 → new PR → MERGE → `src/core/contracts/`.
+3. Cherry-pick #749 → new PR → REROUTE → `src/pilot/runtime/`.
+4. Cherry-pick #750 → new PR → REROUTE → `src/pilot/runtime/`.
+5. Cherry-pick #751 → new PR → MERGE → `src/core/contracts/` (decoupled
+   `oc_evidence_bundle`).
+6. Cherry-pick #753 → new PR → MERGE-RECONCILE → `src/core/contracts/` (phash
+   reconciliation).
+7. Cherry-pick #754 → new PR → REROUTE → `src/pilot/handoff/`.
+8. Cherry-pick #755 → new PR → REROUTE → `src/pilot/handoff/` (with key
+   policy documented in body).
+9. Cherry-pick #756 → new PR → REROUTE → `src/pilot/runtime/`.
 
-- M1 trace upper stack: #736, #743, #744, #745, #746, #747
-- M1 skill graph upper stack: #739, #741 (plus #740 as modify-body)
-- M4 skill memory upper stack: #763, #764, #766
-- #737 (state hashing) is merge-after-gate independently; can land in either
-  phase.
+After each merge, close the corresponding old stacked PR with:
+*"Superseded by #NNN (retargeted to develop and routed to <tier> per the
+hybrid plan in `openchrome-1.11-cleanup.md`)."*
 
-Each reopened PR adds the relevant feature gate; off-by-default behavior must
-match 1.10.4 exactly. Phase 4 PRs do not need to be merged in lockstep with
-each other, only with the corresponding Phase 3 base.
+### Phase 3 — Storage rewrites
 
-### Phase 5 — Perception and Skill Memory entrypoints
+Three independent replacement PRs against `develop`, all using
+`src/utils/atomic-file.ts` + `proper-lockfile`:
 
-Merge #757, #758, #761 (each `merge-after-gate`). Merge #759 after the body
-reframing.
+- New trace storage replacing #735 → `src/core/trace/storage.ts` (JSONL only;
+  session index = filesystem scan).
+- New skill graph storage replacing #738 → `src/core/skill/storage.ts`
+  (JSON-per-domain with per-domain lockfile).
+- New skill-memory store replacing #762's storage half → `src/core/skill-memory/store.ts`
+  (JSON-per-domain).
+
+These three carry forward the credential redactor (#735), the
+`to_state_distribution` schema (#738), and the frozen-snapshot scheme (#762)
+without their SQLite backing.
+
+### Phase 4 — Upper-stack moves into pilot
+
+After Phase 3 storage lands:
+
+- M1: #739 (graph executor) reopens against develop, files in `src/pilot/executor/`.
+  #741 splits as described.
+- M4: #761, #763, #764 reopen against develop, files in `src/pilot/curator/`.
+  Recall ranking from the #762 split lands as `src/pilot/curator/recall.ts`.
+- M4: #766 reopens against develop, files in `src/core/skill-memory/`.
+
+### Phase 5 — Perception entrypoints
+
+- #757, #758 reopen against develop → MERGE → `src/core/perception/`.
+- #759 reopens against develop → REROUTE → `src/pilot/voting/` with the body
+  reframe and deterministic voter test.
 
 ### Phase 6 — Out-of-scope close-and-move
 
-Close #760 and #765 with redirect comments. Open issues tracking the host-side
-or separate-package replacements; link from this document once those exist.
+- #760 closed with redirect to #775. Branch preserved for the separate package.
+- #765 closed with redirect to #776. Branch preserved for the separate package.
+
+### Phase 7 — Release wiring
+
+- CHANGELOG entry for v1.11.0: core tier complete, pilot stub present, pilot
+  not yet experimental.
+- Tag and ship v1.11.0.
+- Open the v1.12.0 milestone tracking pilot-experimental landings.
 
 ---
 
@@ -181,15 +267,24 @@ or separate-package replacements; link from this document once those exist.
 
 This cleanup is complete when:
 
-- every row in the per-PR table has reached its terminal state (merged, closed,
-  or replaced);
-- `develop` builds, lints, and the full test suite passes;
-- `tools/list` and `resources/list` against the resulting build, with every
-  `OPENCHROME_*` flag unset, return the 1.10.4 tool surface byte-for-byte
-  (modulo the contract-related additions from Phase 2 that operate without a
-  flag);
+- every row in the per-PR table has reached its terminal state (merged with
+  directory move, rerouted to pilot, rewritten without SQLite, or closed with
+  separate-package redirect);
+- `develop` builds, lints (including the dependency-cruiser core↛pilot rule),
+  and the full test suite passes;
+- `tools/list` and `resources/list` against the resulting build, with `--pilot`
+  unset, return the 1.10.4 surface bit-identically, plus the four core-tier
+  additions documented above;
+- `tools/list` with `--pilot --pilot-features=trace,state_graph,runtime,
+  handoff,perception_pilot,skill_curator` registers the rerouted pilot tools
+  and prints a startup line listing them;
 - the contract checklist in `portability-harness-contract.md` is verifiably
-  satisfied by every PR that landed during the cleanup.
+  satisfied by every PR that landed during the cleanup;
+- issues #768 (resolved), #770 (auto-closed by #771), #772 (auto-closed by #773),
+  #721 (closed with P3 redirect), #734 (closed or moved host-side) are
+  terminal;
+- audit-followup issues #687, #690 (and #684 if not auto-closed by #696)
+  remain on their own track, unaffected by this cleanup.
 
 After completion, this document is moved to `docs/roadmap/history/` and
-referenced from a release note. The contract document remains.
+referenced from the v1.11.0 release note. The contract document remains.

--- a/docs/roadmap/openchrome-1.11-cleanup.md
+++ b/docs/roadmap/openchrome-1.11-cleanup.md
@@ -1,0 +1,195 @@
+# OpenChrome 1.11 Cleanup — Open PR Disposition
+
+One-time application of `portability-harness-contract.md` to the 35 PRs that
+were open at the start of the 1.11 cleanup cycle. This document is not
+normative; once every action listed here is taken, this document becomes a
+historical record.
+
+The contract takes precedence over any disposition below. If a discrepancy is
+discovered between this plan and the contract, the contract wins and this
+document is amended.
+
+---
+
+## Family classification recap
+
+| Family             | Verdict       | Reason                                                                                          |
+|--------------------|---------------|-------------------------------------------------------------------------------------------------|
+| Outcome Contracts  | Necessary     | Directly reinforces "tool call returns within timeout" via verdicts, idempotency, irrev. hook   |
+| Trace recorder     | Optional      | Useful for replay and audit; not required for the contract; gated by `OPENCHROME_TRACE`         |
+| Skill state graph  | Optional      | Cross-session learning data layer; gated by `OPENCHROME_STATE_GRAPH`; executor must Noop when off |
+| Perception (prim.) | Optional      | Pure-compute primitives; gated by `OPENCHROME_PERCEPTION`                                       |
+| Skill memory       | Optional      | Recall data layer; gated by `OPENCHROME_SKILL_MEMORY`                                           |
+| In-server LLM      | Out of scope  | Violates P3 and P4; belongs in host-side library or separate package                            |
+
+`better-sqlite3` is not adopted. All storage layers in the optional families
+must use JSONL or JSON plus `proper-lockfile`.
+
+---
+
+## Action codes
+
+- **merge-now** — already complies with the contract; merge after standard CI.
+- **merge-after-gate** — code is sound; add the per-family environment flag
+  and a Noop branch when off, then merge.
+- **close-rewrite** — storage layer assumes `better-sqlite3`; close the PR,
+  reopen a replacement that uses JSONL/JSON + `proper-lockfile`.
+- **close-rebase** — depends on a `close-rewrite` ancestor; close, then reopen
+  rebased onto the new ancestor with the appropriate feature gate.
+- **close-move** — out of scope (P3 / P4 violation); close with a redirect
+  comment, code moves to a separate package or host-side library.
+- **modify-body** — code is fine; only the PR description needs adjustment
+  before merge.
+
+---
+
+## Per-PR disposition
+
+### Standalone fixes (target: develop, no stack)
+
+| PR    | Title                                                              | Action     | Notes                                       |
+|-------|--------------------------------------------------------------------|------------|---------------------------------------------|
+| #773  | fix: improve javascript_tool diagnostics and shadow DOM helpers    | merge-now  | Reliability/security aligned; no contract concern |
+| #771  | Fix auto-launched Chrome window bounds placement                   | merge-now  | Cross-platform CI green                     |
+| #767  | test: opt-in to allowUnauthenticatedHttp in HTTP transport tests   | merge-now  | Uses documented escape hatch                |
+| #742  | fix(deps): bump basic-ftp and ip-address via npm overrides         | merge-now  | Security advisories closed, no source changes |
+
+### M1 trace recorder (#735, #736, #743–#747)
+
+| PR    | Title                                                                                  | Action          | Notes |
+|-------|----------------------------------------------------------------------------------------|-----------------|-------|
+| #735  | feat(trace): SQLite storage backend + credential redactor (M1 PR-1)                    | close-rewrite   | Storage layer must be JSONL-only. `better-sqlite3` removed from `package.json`. Index for `oc trace list` becomes filesystem scan or JSON sidecar |
+| #736  | feat(trace): session recorder with CDP event subscription (M1 PR-2)                    | close-rebase    | Rebased onto new JSONL trace storage |
+| #743  | feat(cli): oc trace list/show + oc skill list/inspect                                  | close-rebase    | Rebased; list path adjusted to JSONL scan |
+| #744  | feat(trace): wire recorder into CDPClient.createPage()                                 | close-rebase    | Gate behind `OPENCHROME_TRACE`; Noop when off |
+| #745  | feat(cli): oc trace play replay UI                                                     | close-rebase    | No storage code change; rebase for base ref |
+| #746  | feat(mcp): expose openchrome://trace/* resources to LLM clients                        | close-rebase    | Resources registered only when `OPENCHROME_TRACE` is set |
+| #747  | feat(trace): wire recorder into createTargetStealth() too                              | close-rebase    | Gate behind `OPENCHROME_TRACE`; Noop when off |
+
+### M1 skill state graph (#737–#741)
+
+| PR    | Title                                                                                  | Action            | Notes |
+|-------|----------------------------------------------------------------------------------------|-------------------|-------|
+| #737  | feat(skill): state hashing + URL normalizer + interactive filter                       | merge-after-gate  | Pure logic; no storage. Gate consumers behind `OPENCHROME_STATE_GRAPH` when wired |
+| #738  | feat(skill): per-domain skill graph SQLite storage (M1 PR-5)                           | close-rewrite     | Rewrite as JSON-per-domain + `proper-lockfile`. Same `to_state_distribution` schema, file-based. Per-domain lock matches the original concurrency model |
+| #739  | feat(skill): graph-aware executor with resume-from-state                               | close-rebase      | Rebased onto new JSON graph. Executor branch must be unreachable when `OPENCHROME_STATE_GRAPH` unset |
+| #740  | docs(skill-graph): DOM snapshot capture procedure for fixtures                         | modify-body       | Update docs to reflect JSON storage; merge |
+| #741  | feat(skill): graph audit telemetry + executor integration                              | close-rebase      | Rebased; Noop when feature off |
+
+### M2 outcome contracts (#748–#756)
+
+All necessary. Standard review applies. The contract document does not require
+gating these.
+
+| PR    | Title                                                                                  | Action     | Notes |
+|-------|----------------------------------------------------------------------------------------|------------|-------|
+| #748  | feat(contracts): DSL types + assertions + validator (M2 PR-9)                          | merge-now  | |
+| #749  | feat(contracts): runtime core with verdict taxonomy + retry (M2 PR-11)                 | merge-now  | |
+| #750  | feat(contracts): idempotency cache + preemptive cancellation (M2 PR-12)                | merge-now  | |
+| #751  | feat(contracts): evidence bundle generator + MCP resource (M2 PR-13)                   | merge-now  | |
+| #752  | feat(#705): contract DSL and assertion primitives                                      | merge-now  | Resolve phash.ts divergence with #753 before merge |
+| #753  | feat(contracts): pHash + screenshot class registry + screenshot_class assertion        | merge-now  | After #752 lands, rebase and reconcile phash.ts |
+| #754  | feat(contracts): handoff token + banner + manager (happy path)                         | merge-now  | In-memory tokens; persistence is #755 |
+| #755  | feat(contracts): handoff persistence with AES-256-GCM                                  | merge-after-gate | Key management policy: ephemeral default; `OPENCHROME_HANDOFF_KEY_FILE=<path>` opts into file-backed persistence. Document in PR body before merge |
+| #756  | feat(contracts): beforeIrreversibleAction hook for critical contracts                  | merge-now  | Hook fires only when a contract is declared `critical: true`; default path unchanged |
+
+### M3 perception (#757–#760)
+
+| PR    | Title                                                                                  | Action            | Notes |
+|-------|----------------------------------------------------------------------------------------|-------------------|-------|
+| #757  | feat(perception): perceptual DOM metadata + cache                                      | merge-after-gate  | Pure compute; gate behind `OPENCHROME_PERCEPTION` |
+| #758  | feat(perception): cross-check core — Sobel + color distance                            | merge-after-gate  | Pure compute; gate behind `OPENCHROME_PERCEPTION` |
+| #759  | feat(perception): multi-model voting + args equivalence (M3 PR-19)                     | modify-body       | Voter interface is neutral. PR body must reframe "two configured perception models" to "two configured voters (deterministic or LLM)" and add at least one deterministic voter test before merge |
+| #760  | feat(perception): voting provider HTTP wrappers (anthropic + openai)                   | close-move        | Violates P3 (mandatory third-party API egress) and P4 (decision in server). Move to `openchrome-perception-voters` (separate npm package) or host-side library. Close PR with redirect comment |
+
+### M4 skill memory (#761–#766)
+
+| PR    | Title                                                                                  | Action            | Notes |
+|-------|----------------------------------------------------------------------------------------|-------------------|-------|
+| #761  | feat(skill-memory): verified skill extractor (M4 PR-20)                                | merge-after-gate  | Deterministic transform; gate behind `OPENCHROME_SKILL_MEMORY` |
+| #762  | feat(skill-memory): skill recall + frozen-snapshot store (M4 PR-21)                    | close-rewrite     | Rewrite as JSON-per-domain `skills.json` + `proper-lockfile`. Frozen snapshots remain `.json.gz` on disk |
+| #763  | feat(skill-memory): curator (Pass 1 + Pass 3) + PID lock (M4 PR-22)                    | close-rebase      | Rebased onto new JSON store; PID lock retained |
+| #764  | feat(skill-memory): curator Pass 2 — sibling skill merge (M4 PR-23)                    | close-rebase      | Structural-only heuristic; no LLM. Rebased onto new store |
+| #765  | feat(skill-memory): LLM merge requester for curator Pass 2                             | close-move        | Violates P3 and P4. Move to host-side library or `openchrome-skill-curator-llm` package. Close PR with redirect comment |
+| #766  | feat(skill-memory): audit-log-backed SkillStatsResolver for the curator                | close-rebase      | Audit log path unchanged; only the consuming store is rebased |
+
+---
+
+## Sequencing
+
+The cleanup proceeds in phases. Each phase's completion is the gate for the
+next; this is to prevent partial states where some PRs see one storage layer
+and other PRs see another.
+
+### Phase 0 — Contract publication
+
+Land `portability-harness-contract.md` and this cleanup plan on `develop` so
+every subsequent PR references them.
+
+### Phase 1 — Standalone fixes
+
+Merge #773, #771, #767, #742. No dependency on contract; mergeable in parallel.
+
+### Phase 2 — Outcome Contracts (necessary family)
+
+Merge #748 → #749 → #750 → #751 → #752 → #753 (phash.ts reconciled) → #754
+→ #755 (with handoff key policy documented in PR body) → #756.
+
+This phase delivers the necessary family. Existing 1.10.4 behavior is
+preserved because the new tools live behind their existing contract DSL
+declarations; calls that do not declare a contract are unaffected.
+
+### Phase 3 — Storage rewrites (close + reopen)
+
+Close #735, #738, #762. Open three replacement PRs:
+
+- new trace storage (JSONL-only, no SQLite, no index DB)
+- new skill graph storage (JSON per domain + `proper-lockfile`)
+- new skill memory recall store (JSON per domain + `proper-lockfile`)
+
+Each replacement PR carries the relevant `OPENCHROME_*` flag gate from the
+contract. The replacement PRs are smaller than the originals because they ship
+no migrations and no SQLite-specific code paths.
+
+### Phase 4 — Stack rebases (close + reopen)
+
+Close and reopen the upper-stack PRs against the new bases:
+
+- M1 trace upper stack: #736, #743, #744, #745, #746, #747
+- M1 skill graph upper stack: #739, #741 (plus #740 as modify-body)
+- M4 skill memory upper stack: #763, #764, #766
+- #737 (state hashing) is merge-after-gate independently; can land in either
+  phase.
+
+Each reopened PR adds the relevant feature gate; off-by-default behavior must
+match 1.10.4 exactly. Phase 4 PRs do not need to be merged in lockstep with
+each other, only with the corresponding Phase 3 base.
+
+### Phase 5 — Perception and Skill Memory entrypoints
+
+Merge #757, #758, #761 (each `merge-after-gate`). Merge #759 after the body
+reframing.
+
+### Phase 6 — Out-of-scope close-and-move
+
+Close #760 and #765 with redirect comments. Open issues tracking the host-side
+or separate-package replacements; link from this document once those exist.
+
+---
+
+## Acceptance
+
+This cleanup is complete when:
+
+- every row in the per-PR table has reached its terminal state (merged, closed,
+  or replaced);
+- `develop` builds, lints, and the full test suite passes;
+- `tools/list` and `resources/list` against the resulting build, with every
+  `OPENCHROME_*` flag unset, return the 1.10.4 tool surface byte-for-byte
+  (modulo the contract-related additions from Phase 2 that operate without a
+  flag);
+- the contract checklist in `portability-harness-contract.md` is verifiably
+  satisfied by every PR that landed during the cleanup.
+
+After completion, this document is moved to `docs/roadmap/history/` and
+referenced from a release note. The contract document remains.

--- a/docs/roadmap/portability-harness-contract.md
+++ b/docs/roadmap/portability-harness-contract.md
@@ -1,0 +1,217 @@
+# Portability-Harness Contract
+
+## Motivation
+
+OpenChrome already has one documented reliability contract: *"Every tool call MUST
+return a result — success or error — within the timeout. OpenChrome never hangs."*
+(see `issue-reliability-guarantee.md`). That contract governs **how the server
+behaves**.
+
+This document defines a complementary, equally narrow contract that governs **what
+the server is allowed to become** as harness features expand. As of the 1.11
+cleanup cycle, the open PR queue contains five candidate harness families (trace,
+skill state graph, outcome contracts, perception primitives, skill memory) whose
+unconstrained adoption would compromise two existing OpenChrome value propositions:
+
+1. **Backward compatibility.** Existing 1.10.4 MCP clients depend on the current
+   tool surface behaving exactly as documented. Harness features that mutate that
+   surface — by default — break those clients silently.
+2. **MCP portability.** OpenChrome's distribution model is `npx openchrome-mcp` and
+   the Tauri desktop app. Both rely on the server starting on any modern Linux,
+   macOS, or Windows host without external secrets, manual setup, or platform-specific
+   compile toolchains. Features that quietly require API keys, network egress to
+   third-party LLM providers, or native modules without a fallback degrade that
+   "anywhere-compatible" property.
+
+This contract is the design constraint that lets harness work proceed without
+eroding either property.
+
+---
+
+## Philosophy
+
+> **OpenChrome is a tool server.** Harness features reinforce the tool-call
+> guarantee and the data captured around it. They never trade portability or
+> existing-client compatibility for harness richness.
+
+The contract is narrow and precise by design. It does not dictate which harness
+features are valuable. It dictates the conditions under which a harness feature
+may ship inside the `openchrome-mcp` package.
+
+---
+
+## Scope
+
+Applies to every PR that:
+
+- adds or modifies a tool, resource, or transport on the MCP surface;
+- introduces a new module under `src/` that is reachable from tool dispatch,
+  recorder, or executor paths;
+- adds, removes, or pins a runtime dependency in `package.json`;
+- modifies `src/index.ts`, `src/mcp-server.ts`, `cli/`, or any startup wiring.
+
+Does **not** apply to: documentation-only PRs, CI infrastructure PRs, test-only
+PRs that touch no production code.
+
+---
+
+## Principles
+
+### P1. Tool server identity
+
+OpenChrome accepts tool calls, executes them, and returns results. It does not
+orchestrate multi-step tasks, manage AI agent lifecycles, or operate as a
+continuous autonomous loop. Long-lived background work inside the server is
+permitted only when it serves a tool-call guarantee (e.g., Chrome process
+supervision, CDP reconnection).
+
+This principle re-states the responsibility boundary from
+`issue-reliability-guarantee.md` and is reproduced here so that
+portability-relevant PRs are evaluated against it without a cross-reference.
+
+### P2. Zero-impact harness extension
+
+A harness feature may add capability, but it must not change the observable
+behavior of any tool, resource, transport, or startup sequence that existed in
+1.10.4 when the feature is off. "Off" includes:
+
+- the feature's environment flag is unset or `0`;
+- the feature's optional native dependency failed to load;
+- the feature's storage directory is missing or unwritable.
+
+In each "off" condition, the server boots, every 1.10.4 tool call executes, and
+`tools/list` / `resources/list` return the 1.10.4 surface exactly.
+
+### P3. Anywhere-compatible MCP
+
+`npx openchrome-mcp setup` and the Tauri desktop installer must succeed on:
+
+- Linux x86_64 (glibc and musl) and aarch64;
+- macOS x86_64 and arm64;
+- Windows x86_64.
+
+A harness feature may not require:
+
+- an outbound HTTP call to any third-party LLM API (Anthropic, OpenAI, Google,
+  or comparable) inside the server process;
+- a mandatory API key, OAuth token, or vendor credential at boot;
+- a platform-specific build toolchain at install time;
+- access to OS keychain, Secret Service, or Credential Manager;
+- a network-attached secret store.
+
+Features that are useful only with such resources must remain disabled until the
+operator opts in; their disabled state must satisfy P2.
+
+### P4. Facts versus decisions
+
+OpenChrome captures, computes, stores, retrieves, normalizes, and verifies
+facts about browser sessions. It does not make LLM-driven decisions. The host
+agent that connects to OpenChrome may make any decision it wants using the
+facts the server exposes; the server itself does not call out to language
+models or other "judgment" services to interpret captured data.
+
+Operationally: a PR that adds a tool returning a perceptual hash, a screenshot
+class, a verdict from a deterministic contract runner, or a stored skill record
+is a *fact* PR and is in scope for this server. A PR that adds a tool calling
+Anthropic to vote on the meaning of those facts is a *decision* PR and belongs
+in a host-side library or a separate package.
+
+### P5. Native dependency discipline
+
+The main `openchrome-mcp` package may declare at most one mandatory native
+runtime dependency: `argon2` (required by authentication). Every other native
+dependency must satisfy all of the following:
+
+- declared in `optionalDependencies`, not `dependencies`;
+- consumed via a lazy `require` guarded by a try/catch fallback that produces a
+  Noop or pure-JS implementation;
+- documented in `docs/roadmap/native-deps.md` (created when the second native
+  dependency is proposed) with the fallback path and the failure surface.
+
+`better-sqlite3` is not adopted. Storage layers that previously assumed it use
+JSONL or JSON files plus `proper-lockfile` for concurrent-write coordination.
+
+---
+
+## Per-feature activation flags
+
+Optional harness families are gated by per-family environment variables. Each
+defaults to off and Noops independently:
+
+| Family             | Flag                          | Default |
+|--------------------|-------------------------------|---------|
+| Trace recorder     | `OPENCHROME_TRACE`            | off     |
+| Skill state graph  | `OPENCHROME_STATE_GRAPH`      | off     |
+| Perception         | `OPENCHROME_PERCEPTION`       | off     |
+| Skill memory       | `OPENCHROME_SKILL_MEMORY`     | off     |
+
+The presence of any flag must not change the behavior of unrelated features.
+Outcome Contracts (the necessary family) ships unflagged because its existence
+strengthens the reliability contract and adds no surface that could be off.
+
+A combined flag (e.g., `OPENCHROME_HARNESS=1`) is explicitly not provided. The
+per-family separation is part of the contract; a future PR proposing a
+combined flag must amend this document first.
+
+---
+
+## Handoff token encryption (#755 family)
+
+The handoff token persistence layer encrypts tokens with AES-256-GCM. The
+encryption key is ephemeral by default — it lives in process memory and is
+regenerated on every server start, which invalidates any persisted handoff
+tokens from prior runs. Operators wanting cross-restart persistence set
+`OPENCHROME_HANDOFF_KEY_FILE=<path>`; the file contains a 32-byte key,
+loaded at boot, never logged, never embedded in audit records.
+
+No OS keychain integration is provided (P3 prohibits it).
+
+---
+
+## PR review checklist
+
+Every PR matching the scope above must demonstrate the following in its body
+or in the diff:
+
+- [ ] **Facts, not decisions.** The PR adds capability that is descriptive,
+      computational, or storage-oriented. It does not call an LLM API from the
+      server. If the PR adds a `Voter` or similar interface, at least one
+      deterministic implementation accompanies it.
+- [ ] **Off behavior.** When the relevant feature flag is unset, every code
+      path added by this PR is unreachable from tool dispatch, recorder, and
+      executor. A test or trace demonstrates this.
+- [ ] **No new mandatory native dependency.** `package.json` changes do not
+      add anything to `dependencies` beyond `argon2`. New native modules, if
+      any, are in `optionalDependencies` with a documented fallback.
+- [ ] **No mandatory API key, network egress, or vendor credential.** Boot
+      succeeds with all third-party LLM provider variables unset.
+- [ ] **1.10.4 surface preserved.** `tools/list` and `resources/list` return
+      the 1.10.4 set when all feature flags are unset.
+- [ ] **Reliability contract not regressed.** Tool-call timeout behavior is
+      unchanged. Any new path that could block the event loop has an explicit
+      bound.
+
+PRs failing any item must be modified before merge. PRs that cannot satisfy
+P4 (facts vs decisions) are out of scope and should be moved to a separate
+package or host-side library; close-with-redirect is the expected outcome.
+
+---
+
+## Non-goals
+
+- This contract does not impose a feature roadmap. It does not require any
+  optional family to ship; it only specifies the conditions under which they
+  may.
+- It does not promise zero-config across all features. With every flag unset
+  the server is zero-config; enabling a family is the operator's act.
+- It does not duplicate the reliability contract. Where they overlap (e.g.,
+  P1, the no-event-loop-block checklist item) the reliability contract is the
+  authoritative source.
+
+---
+
+## Document status
+
+Normative. Every PR landing on `develop` after this document merges must satisfy
+the checklist. Application to the 35 currently-open PRs is tracked in
+`openchrome-1.11-cleanup.md`.

--- a/docs/roadmap/portability-harness-contract.md
+++ b/docs/roadmap/portability-harness-contract.md
@@ -8,20 +8,24 @@ return a result — success or error — within the timeout. OpenChrome never ha
 behaves**.
 
 This document defines a complementary, equally narrow contract that governs **what
-the server is allowed to become** as harness features expand. As of the 1.11
-cleanup cycle, the open PR queue contains five candidate harness families (trace,
-skill state graph, outcome contracts, perception primitives, skill memory) whose
-unconstrained adoption would compromise two existing OpenChrome value propositions:
+the server is allowed to become** as harness features expand. It supersedes the
+discussion in issue #768 (`Restructure proposal: core/pilot tier split`); see the
+hybrid-resolution comment on that issue for how the two were merged.
+
+As of the 1.11 cleanup cycle, the open PR queue contains five candidate harness
+families (trace, skill state graph, outcome contracts, perception primitives,
+skill memory) whose unconstrained adoption would compromise two existing
+OpenChrome value propositions:
 
 1. **Backward compatibility.** Existing 1.10.4 MCP clients depend on the current
    tool surface behaving exactly as documented. Harness features that mutate that
    surface — by default — break those clients silently.
-2. **MCP portability.** OpenChrome's distribution model is `npx openchrome-mcp` and
-   the Tauri desktop app. Both rely on the server starting on any modern Linux,
-   macOS, or Windows host without external secrets, manual setup, or platform-specific
-   compile toolchains. Features that quietly require API keys, network egress to
-   third-party LLM providers, or native modules without a fallback degrade that
-   "anywhere-compatible" property.
+2. **MCP portability.** OpenChrome's distribution model is `npx openchrome-mcp`
+   and the Tauri desktop app. Both rely on the server starting on any modern
+   Linux, macOS, or Windows host without external secrets, manual setup, or
+   platform-specific compile toolchains. Features that quietly require API keys,
+   network egress to third-party LLM providers, or native modules without a
+   fallback degrade that "anywhere-compatible" property.
 
 This contract is the design constraint that lets harness work proceed without
 eroding either property.
@@ -31,12 +35,16 @@ eroding either property.
 ## Philosophy
 
 > **OpenChrome is a tool server.** Harness features reinforce the tool-call
-> guarantee and the data captured around it. They never trade portability or
-> existing-client compatibility for harness richness.
+> guarantee and the data captured around it. Experimental features that need to
+> relax those guarantees ship in a separate `pilot` tier inside the same npm
+> package, behind an explicit `--pilot` opt-in CLI flag. The server never trades
+> portability for harness richness; *outbound LLM API calls and mandatory
+> third-party credentials remain out of bounds even in pilot*.
 
 The contract is narrow and precise by design. It does not dictate which harness
 features are valuable. It dictates the conditions under which a harness feature
-may ship inside the `openchrome-mcp` package.
+may ship inside `openchrome-mcp` at all, and which of those features go into
+which tier.
 
 ---
 
@@ -45,10 +53,10 @@ may ship inside the `openchrome-mcp` package.
 Applies to every PR that:
 
 - adds or modifies a tool, resource, or transport on the MCP surface;
-- introduces a new module under `src/` that is reachable from tool dispatch,
-  recorder, or executor paths;
+- introduces a new module under `src/core/**` or `src/pilot/**` that is reachable
+  from tool dispatch, recorder, or executor paths;
 - adds, removes, or pins a runtime dependency in `package.json`;
-- modifies `src/index.ts`, `src/mcp-server.ts`, `cli/`, or any startup wiring.
+- modifies `src/index.ts`, `src/core/mcp/**`, `cli/`, or any startup wiring.
 
 Does **not** apply to: documentation-only PRs, CI infrastructure PRs, test-only
 PRs that touch no production code.
@@ -56,6 +64,13 @@ PRs that touch no production code.
 ---
 
 ## Principles
+
+These five principles apply at the *project* level. The `core` tier must satisfy
+all five strictly; the `pilot` tier explicitly relaxes some of them in exchange
+for opt-in status. **Principle P3 (Anywhere-compatible MCP) is the one
+principle that pilot also satisfies strictly** — pilot features may add policy
+or background work, but they may not introduce outbound LLM API calls or
+mandatory third-party credentials.
 
 ### P1. Tool server identity
 
@@ -65,9 +80,9 @@ continuous autonomous loop. Long-lived background work inside the server is
 permitted only when it serves a tool-call guarantee (e.g., Chrome process
 supervision, CDP reconnection).
 
-This principle re-states the responsibility boundary from
-`issue-reliability-guarantee.md` and is reproduced here so that
-portability-relevant PRs are evaluated against it without a cross-reference.
+The `core` tier enforces this strictly: no work outlives a tool call's lifetime.
+The `pilot` tier may run scheduled background work (e.g., the skill curator)
+when the operator explicitly enables it via `--pilot`.
 
 ### P2. Zero-impact harness extension
 
@@ -75,7 +90,8 @@ A harness feature may add capability, but it must not change the observable
 behavior of any tool, resource, transport, or startup sequence that existed in
 1.10.4 when the feature is off. "Off" includes:
 
-- the feature's environment flag is unset or `0`;
+- the `--pilot` CLI flag is unset (no pilot tools registered at all);
+- the per-family sub-flag is unset (the specific family Noops within pilot);
 - the feature's optional native dependency failed to load;
 - the feature's storage directory is missing or unwritable.
 
@@ -90,17 +106,19 @@ In each "off" condition, the server boots, every 1.10.4 tool call executes, and
 - macOS x86_64 and arm64;
 - Windows x86_64.
 
-A harness feature may not require:
+Neither tier may require:
 
 - an outbound HTTP call to any third-party LLM API (Anthropic, OpenAI, Google,
-  or comparable) inside the server process;
+  or comparable) inside the server process — *this restriction applies to both
+  core and pilot*;
 - a mandatory API key, OAuth token, or vendor credential at boot;
 - a platform-specific build toolchain at install time;
 - access to OS keychain, Secret Service, or Credential Manager;
 - a network-attached secret store.
 
-Features that are useful only with such resources must remain disabled until the
-operator opts in; their disabled state must satisfy P2.
+Server-side LLM-driven decisions (voting, merging, judging) are out of scope for
+this repository entirely. They live in separate npm packages or host-side
+libraries — see issues #775 and #776.
 
 ### P4. Facts versus decisions
 
@@ -110,11 +128,9 @@ agent that connects to OpenChrome may make any decision it wants using the
 facts the server exposes; the server itself does not call out to language
 models or other "judgment" services to interpret captured data.
 
-Operationally: a PR that adds a tool returning a perceptual hash, a screenshot
-class, a verdict from a deterministic contract runner, or a stored skill record
-is a *fact* PR and is in scope for this server. A PR that adds a tool calling
-Anthropic to vote on the meaning of those facts is a *decision* PR and belongs
-in a host-side library or a separate package.
+The `core` tier holds this strictly. The `pilot` tier may encode workflow
+policy (retry, escalation, irreversible-action confirmation) but still does not
+call LLM APIs (see P3).
 
 ### P5. Native dependency discipline
 
@@ -128,43 +144,143 @@ dependency must satisfy all of the following:
 - documented in `docs/roadmap/native-deps.md` (created when the second native
   dependency is proposed) with the fallback path and the failure surface.
 
-`better-sqlite3` is not adopted. Storage layers that previously assumed it use
-JSONL or JSON files plus `proper-lockfile` for concurrent-write coordination.
+`better-sqlite3` is **not adopted**. Storage layers that previously assumed it
+use JSONL or JSON files plus `proper-lockfile` for concurrent-write coordination
+(the project already ships `src/utils/atomic-file.ts` which provides this).
 
 ---
 
-## Per-feature activation flags
+## The core / pilot tier model
 
-Optional harness families are gated by per-family environment variables. Each
-defaults to off and Noops independently:
+OpenChrome's source tree is split into two tiers within the same npm package
+and the same CLI binary.
 
-| Family             | Flag                          | Default |
-|--------------------|-------------------------------|---------|
-| Trace recorder     | `OPENCHROME_TRACE`            | off     |
-| Skill state graph  | `OPENCHROME_STATE_GRAPH`      | off     |
-| Perception         | `OPENCHROME_PERCEPTION`       | off     |
-| Skill memory       | `OPENCHROME_SKILL_MEMORY`     | off     |
+### Source layout
 
-The presence of any flag must not change the behavior of unrelated features.
-Outcome Contracts (the necessary family) ships unflagged because its existence
-strengthens the reliability contract and adds no surface that could be off.
+```
+openchrome/
+├── src/
+│   ├── core/                             ← P1–P5 strictly enforced
+│   │   ├── trace/                        session recorder, JSONL storage, CDP hooks
+│   │   ├── skill/                        state hashing, JSON skill graph, read-only API
+│   │   ├── contracts/                    DSL, oc_assert, oc_evidence_bundle, pHash, screenshot class
+│   │   ├── perception/                   DOM metadata, Sobel+color cross-check
+│   │   ├── skill-memory/                 JSON store + audit-log stats (no extractor)
+│   │   ├── cli/                          oc trace, oc skill inspect, oc trace play
+│   │   └── mcp/                          server, transport, resource registry
+│   └── pilot/                            ← P1 relaxed (background work), P4 relaxed (policy)
+│       ├── executor/                     graph executor with resume-from-state
+│       ├── runtime/                      contract runtime, retry, idempotency, beforeIrreversibleAction
+│       ├── handoff/                      handoff token + AES-256-GCM persistence
+│       ├── voting/                       Voter interface + deterministic implementations (no LLM)
+│       ├── curator/                      structural skill curator (no LLM merge)
+│       └── index.ts                      lazy bootstrap, registered only when --pilot
+├── tests/
+│   ├── core/                             required for every PR
+│   └── pilot/                            required only when src/pilot/ changes
+├── docs/
+│   ├── roadmap/portability-harness-contract.md   this document
+│   ├── roadmap/openchrome-1.11-cleanup.md        one-time application plan
+│   └── pilot/README.md                            experimental tier user docs
+└── package.json
+```
 
-A combined flag (e.g., `OPENCHROME_HARNESS=1`) is explicitly not provided. The
-per-family separation is part of the contract; a future PR proposing a
-combined flag must amend this document first.
+### Import direction (enforced by lint)
+
+- `src/core/**` may **not** import from `src/pilot/**`.
+- `src/pilot/**` **may** import from `src/core/**`.
+- Enforced via `dependency-cruiser` rule in CI. Configuration ships with the
+  PR that lands this contract document.
+
+### CLI surface
+
+- `openchrome serve` — registers tools from `src/core/` only. Exact behavior
+  of v1.10.x is preserved bit-for-bit.
+- `openchrome serve --pilot` — bootstraps `src/pilot/` too. Pilot tools carry
+  an `oc_pilot_` prefix or live under `openchrome://pilot/...` resources so the
+  experimental nature is visible to MCP clients.
+- `openchrome serve --pilot --pilot-features=trace,state_graph` — optional
+  per-family sub-flag for finer-grained activation within pilot. When omitted,
+  all pilot families register.
+- `npx openchrome install <feature>` — convenience to install missing
+  `optionalDependencies` for a named pilot feature. Used by pilot's friendly
+  fallback prompts.
+
+The `--pilot` flag is the *only* user-facing change for opting into the
+extended harness. Adding it to an existing config flips features on; removing
+it flips them off. There is no second `npm install`, no second package, no
+separate config file.
+
+### Two-stage CI
+
+- **Stage 1** (mandatory on every PR): `npm test -- tests/core`. This is the
+  gate for every PR regardless of tier.
+- **Stage 2** (mandatory only when `src/pilot/**` is touched):
+  `npm test -- tests/pilot`. PRs that don't touch pilot don't pay this cost.
+
+### Tier labels
+
+GitHub labels:
+
+- `tier:core` (color `0e8a16`) — "Lives in src/core/, must satisfy P1-P5
+  strictly"
+- `tier:pilot` (color `fbca04`) — "Lives in src/pilot/, opt-in via --pilot,
+  P1/P4 relaxed but P3 still enforced"
+
+Every open issue (#701–#734) and every PR carries exactly one tier label after
+this contract merges.
+
+### Per-feature sub-flags (inside `--pilot`)
+
+| Family | Sub-flag | Default when `--pilot` is set |
+|---|---|---|
+| Trace recorder | `--pilot-features=trace` or `OPENCHROME_TRACE=1` | active |
+| Skill state graph | `--pilot-features=state_graph` or `OPENCHROME_STATE_GRAPH=1` | active |
+| Contract runtime (retry, escalation) | `--pilot-features=runtime` or `OPENCHROME_CONTRACT_RUNTIME=1` | active |
+| Handoff persistence | `--pilot-features=handoff` or `OPENCHROME_HANDOFF_PERSIST=1` | active (in-memory only by default; see below) |
+| Perception extras (voting framework) | `--pilot-features=perception_pilot` or `OPENCHROME_PERCEPTION_VOTING=1` | active |
+| Skill curator | `--pilot-features=skill_curator` or `OPENCHROME_SKILL_CURATOR=1` | active |
+
+`core`-tier features (trace primitives, pHash, screenshot class, perception
+primitives, skill-memory store, audit-log stats) are *always* registered and
+need no flag — they ship inside `serve` without `--pilot`.
+
+When `--pilot` is unset, none of the above sub-flags or env variables have any
+effect; the pilot bootstrap module is never loaded.
 
 ---
 
 ## Handoff token encryption (#755 family)
 
-The handoff token persistence layer encrypts tokens with AES-256-GCM. The
-encryption key is ephemeral by default — it lives in process memory and is
-regenerated on every server start, which invalidates any persisted handoff
-tokens from prior runs. Operators wanting cross-restart persistence set
-`OPENCHROME_HANDOFF_KEY_FILE=<path>`; the file contains a 32-byte key,
-loaded at boot, never logged, never embedded in audit records.
+The handoff token persistence layer (pilot tier) encrypts tokens with
+AES-256-GCM. The encryption key is **ephemeral by default** — it lives in
+process memory and is regenerated on every server start, which invalidates any
+persisted handoff tokens from prior runs. Operators wanting cross-restart
+persistence set `OPENCHROME_HANDOFF_KEY_FILE=<path>`; the file contains a
+32-byte key, loaded at boot, never logged, never embedded in audit records.
 
-No OS keychain integration is provided (P3 prohibits it).
+No OS keychain integration is provided (P3 prohibits it). Issue #721, which
+proposed macOS Keychain + Windows Credential Manager adapters, is superseded by
+this policy.
+
+---
+
+## Release sequencing
+
+Three-step rollout aligned with the tier split:
+
+- **v1.11.0 — core tier complete, pilot stub.** All core-tier PRs from §8 of
+  `openchrome-1.11-cleanup.md` land. `--pilot` flag exists but registers nothing
+  (empty bootstrap). Users who run `openchrome serve` see the full extended
+  core feature set: trace recorder, JSON skill graph (read-only), pHash,
+  screenshot class, perception primitives, skill-memory store + stats, new
+  `oc_assert` / `oc_evidence_bundle` / `oc_skill_record` / `oc_skill_recall`
+  tools.
+- **v1.12.0 — pilot tier experimental.** Pilot PRs land into `src/pilot/`.
+  README and CHANGELOG label pilot as experimental. SemVer minor — breaking
+  changes are still allowed inside pilot.
+- **v1.13.0 — pilot tier stable.** Pilot tools become semver-stable. Epic
+  acceptance criteria from #698–#700 and #712 are satisfied.
 
 ---
 
@@ -173,27 +289,35 @@ No OS keychain integration is provided (P3 prohibits it).
 Every PR matching the scope above must demonstrate the following in its body
 or in the diff:
 
+- [ ] **Tier declaration.** PR body states `tier:core` or `tier:pilot` and the
+      target directory under `src/core/**` or `src/pilot/**`.
 - [ ] **Facts, not decisions.** The PR adds capability that is descriptive,
       computational, or storage-oriented. It does not call an LLM API from the
       server. If the PR adds a `Voter` or similar interface, at least one
       deterministic implementation accompanies it.
-- [ ] **Off behavior.** When the relevant feature flag is unset, every code
-      path added by this PR is unreachable from tool dispatch, recorder, and
-      executor. A test or trace demonstrates this.
+- [ ] **Off behavior.** When `--pilot` is unset (and any relevant sub-flag is
+      unset), every code path added by this PR is unreachable from tool
+      dispatch, recorder, and executor. A test or trace demonstrates this.
 - [ ] **No new mandatory native dependency.** `package.json` changes do not
       add anything to `dependencies` beyond `argon2`. New native modules, if
       any, are in `optionalDependencies` with a documented fallback.
 - [ ] **No mandatory API key, network egress, or vendor credential.** Boot
-      succeeds with all third-party LLM provider variables unset.
+      succeeds with all third-party LLM provider variables unset. The PR
+      does not introduce outbound calls to LLM APIs (this restriction is
+      identical for core and pilot).
 - [ ] **1.10.4 surface preserved.** `tools/list` and `resources/list` return
-      the 1.10.4 set when all feature flags are unset.
+      the 1.10.4 set when `--pilot` is unset (modulo unflagged additions
+      enumerated in the cleanup doc).
 - [ ] **Reliability contract not regressed.** Tool-call timeout behavior is
       unchanged. Any new path that could block the event loop has an explicit
       bound.
+- [ ] **Import direction respected.** No import from `src/core/**` to
+      `src/pilot/**`. dependency-cruiser CI gate passes.
 
 PRs failing any item must be modified before merge. PRs that cannot satisfy
-P4 (facts vs decisions) are out of scope and should be moved to a separate
-package or host-side library; close-with-redirect is the expected outcome.
+the "no outbound LLM call" requirement of P3 are out of scope and should be
+moved to a separate package or host-side library; close-with-redirect is the
+expected outcome.
 
 ---
 
@@ -202,11 +326,14 @@ package or host-side library; close-with-redirect is the expected outcome.
 - This contract does not impose a feature roadmap. It does not require any
   optional family to ship; it only specifies the conditions under which they
   may.
-- It does not promise zero-config across all features. With every flag unset
-  the server is zero-config; enabling a family is the operator's act.
+- It does not promise zero-config across all features. With `--pilot` unset the
+  server is zero-config; enabling pilot is the operator's act.
 - It does not duplicate the reliability contract. Where they overlap (e.g.,
   P1, the no-event-loop-block checklist item) the reliability contract is the
   authoritative source.
+- It does not adopt OS keychain / Secret Service / Credential Manager
+  integration. Operators wanting durable handoff persistence use a key file
+  they manage themselves.
 
 ---
 
@@ -215,3 +342,13 @@ package or host-side library; close-with-redirect is the expected outcome.
 Normative. Every PR landing on `develop` after this document merges must satisfy
 the checklist. Application to the 35 currently-open PRs is tracked in
 `openchrome-1.11-cleanup.md`.
+
+References:
+- `docs/roadmap/issue-reliability-guarantee.md` — the reliability contract this
+  document complements.
+- Issue #768 — the original `core/pilot` restructure proposal; superseded by
+  this contract (hybrid resolution adopted 2026-05-12; see comment thread).
+- Issues #775, #776 — separate-package extractions for server-side LLM features
+  rejected by P3.
+- Issues #777, #778, #779, #780 — supporting infrastructure issues for this
+  cleanup cycle.


### PR DESCRIPTION
## Summary

Establishes the design constraint that governs how harness work expands in 1.11 without breaking backward compatibility or "anywhere-compatible MCP" portability.

Two documents, following the existing `docs/roadmap/issue-reliability-guarantee.md` + `issue-reliability-tracking.md` precedent:

### 1. `docs/roadmap/portability-harness-contract.md` (normative, durable)

Five principles every future PR must satisfy:

- **P1. Tool server identity** — OpenChrome accepts tool calls and returns results. It does not orchestrate, manage AI agent lifecycles, or run continuous autonomous loops. (Restates the reliability contract's responsibility boundary for portability-relevant PRs.)
- **P2. Zero-impact harness extension** — When the feature flag is unset, the dependency fails to load, or the storage directory is missing, the 1.10.4 tool surface and behavior are preserved bit-identically.
- **P3. Anywhere-compatible MCP** — No mandatory third-party LLM API egress, no mandatory API key at boot, no platform-specific compile toolchain at install time, no OS keychain/Secret Service requirement.
- **P4. Facts versus decisions** — The server captures, computes, stores, retrieves, normalizes, and verifies facts. LLM-driven decisions live in host-side libraries or separate packages.
- **P5. Native dependency discipline** — `argon2` is the only mandatory native runtime dep. `better-sqlite3` is not adopted. Future native deps go in `optionalDependencies` with documented fallbacks.

Per-family env flags (each defaults off, independent Noop):
- `OPENCHROME_TRACE`
- `OPENCHROME_STATE_GRAPH`
- `OPENCHROME_PERCEPTION`
- `OPENCHROME_SKILL_MEMORY`

Handoff token encryption (#755 family): AES-256-GCM with ephemeral key by default; `OPENCHROME_HANDOFF_KEY_FILE=<path>` opts into file-backed persistence. No OS keychain.

PR review checklist (six items): facts-not-decisions, off behavior, no new mandatory native dep, no mandatory API key, 1.10.4 surface preserved, reliability contract not regressed.

### 2. `docs/roadmap/openchrome-1.11-cleanup.md` (one-time application)

Disposition map for the 35 currently-open PRs with six action codes:

- **merge-now** (13): #773, #771, #767, #742, #748–#754, #756, #740
- **merge-after-gate** (6): #737, #755, #757, #758, #759, #761
- **close-rewrite** (3): #735, #738, #762 — replace SQLite layers with JSONL/JSON + `proper-lockfile`
- **close-rebase** (11): M1/M4 upper-stack PRs
- **close-move** (2): #760, #765 — server-side LLM violations, move to separate package or host-side library

Six-phase sequencing (Phase 0 contract publication → Phase 6 close-and-move) with explicit acceptance criteria. This PR is Phase 0.

## Why this lands first

Every subsequent cleanup PR (close comments, close-with-redirects, gate-addition body text) needs to reference these documents by path. Phase 0 must merge before Phase 1.

## Validation

- Documentation-only change. No code, no tests, no build behavior touched.
- Markdown lints clean (manual inspection of headers, lists, tables).
- File layout matches the existing `docs/roadmap/` structure.

## Test plan

- [ ] Reviewer confirms no code paths are touched (`git diff --stat develop..HEAD` shows only the two new doc files).
- [ ] Reviewer reads `portability-harness-contract.md` end-to-end and confirms the five principles are coherent with `issue-reliability-guarantee.md`.
- [ ] Reviewer reads the per-PR action table in `openchrome-1.11-cleanup.md` and flags any disposition they disagree with **before** Phase 2 begins.

Refs: continues the docs/roadmap/ pattern established by #issues-tracked-in-reliability-initiative.