### PR TITLE
chore(ci): wire lint:tier into workflow and scaffold tests/{core,pilot}/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Lint tier boundary (core must not import pilot)
+        run: npm run lint:tier
+
       - name: Run tests
         run: npx jest --config jest.ci.config.js
         env:

--- a/tests/core/README.md
+++ b/tests/core/README.md
@@ -1,0 +1,33 @@
+# tests/core/
+
+Tests for modules under `src/core/**`. Per the portability-harness contract
+(`docs/roadmap/portability-harness-contract.md`), the two-stage CI requires
+this directory's tests to pass on **every** PR regardless of which tier the PR
+touches.
+
+## Scope
+
+- Tests for any module living under `src/core/**`.
+- Tests verifying P1–P5 contract invariants (e.g., "with `--pilot` unset, no
+  module from `src/pilot/**` is loaded").
+
+## Migration status (1.11 cleanup)
+
+The existing test directory at `tests/` predates the tier split. Tests there
+remain in place and continue to run on every PR. As the 1.11 cleanup PRs land,
+new tests for `src/core/**` modules go directly into `tests/core/<subdir>/`.
+A separate consolidation PR (post-cleanup) will migrate the existing
+`tests/<subdir>/` files into `tests/core/<subdir>/` once the corresponding
+source modules have all relocated to `src/core/<subdir>/`.
+
+## Running
+
+The CI workflow runs the full Jest suite. To run only the core-tier slice:
+
+```bash
+npx jest tests/core
+```
+
+Locally, the dependency-cruiser rule (`npm run lint:tier`) guards against
+`src/core/**` modules importing from `src/pilot/**`. Tests that violate this
+boundary also fail to compile.

--- a/tests/pilot/README.md
+++ b/tests/pilot/README.md
@@ -1,0 +1,46 @@
+# tests/pilot/
+
+Tests for modules under `src/pilot/**`. Per the portability-harness contract
+(`docs/roadmap/portability-harness-contract.md`), pilot-tier code is opt-in via
+the `--pilot` CLI flag and must satisfy:
+
+- **P2**: bit-identical 1.10.4 behavior when `--pilot` is unset.
+- **P3**: no outbound LLM API egress, no mandatory third-party credentials.
+- **P5**: no native dependency without graceful fallback.
+
+P1 and P4 are relaxed for pilot (it may run background work and encode workflow
+policy).
+
+## Scope
+
+- Tests for any module living under `src/pilot/**`.
+- Tests verifying that pilot tools are not registered when `--pilot` is unset.
+- Tests for pilot-specific behavior (retry, escalation, irreversible-action
+  confirmation, handoff persistence, structural curator, deterministic voters).
+
+## Two-stage CI
+
+The CI workflow runs this directory's tests on every PR for now. Once the
+`src/pilot/**` source modules have content (Phase 2b/4 of the 1.11 cleanup),
+this directory will graduate to a path-filtered job that only runs when
+`src/pilot/**` or `tests/pilot/**` is touched.
+
+Migration plan:
+
+1. **Now** (this PR): scaffold `tests/pilot/` with this README. Full suite
+   still runs on every PR.
+2. **After Phase 4** (pilot reroute PRs merge): split jest config so that
+   `tests/pilot/` runs only when pilot files change. The CI workflow gets a
+   second job gated by `paths: ['src/pilot/**', 'tests/pilot/**']`.
+
+## Running
+
+To run only the pilot-tier slice:
+
+```bash
+npx jest tests/pilot
+```
+
+Pilot tests should construct the server with `--pilot` set in their setup;
+core-tier tests should assert that `--pilot` is unset and that pilot modules
+are not loaded.


### PR DESCRIPTION
## Summary

Second piece of Phase 1 boundary plumbing. Builds on #787 which added the dependency-cruiser config and core/pilot source directories.

Closes #782.

## What changes

- `.github/workflows/ci.yml` — adds a `Lint tier boundary` step running `npm run lint:tier` after the existing eslint step. PRs that introduce a `src/core/**` import from `src/pilot/**` now fail CI directly, not just locally.
- `tests/core/README.md` — documents the tier model for tests, including the migration plan during the 1.11 cleanup.
- `tests/pilot/README.md` — documents the tier model for pilot tests and the future path-filtered second-stage CI job.

## What does NOT change

- No production code is touched.
- No existing test file is moved or renamed (those migrations land alongside the source-module relocations they verify).
- Jest is **not yet** split into two stages. Full suite continues to run on every PR. The path-filtered pilot-stage job comes after `src/pilot/**` has content (post Phase 2b/4 of the cleanup).

## Verification

- `npm run lint:tier`: 0 violations.
- YAML syntax check on `.github/workflows/ci.yml`: valid.
- CI itself will verify the new `Lint tier boundary` step runs correctly.

## Test plan

- [ ] Reviewer pulls and runs `npm install && npm run lint:tier`.
- [ ] Reviewer confirms the new CI step is present in `.github/workflows/ci.yml`.
- [ ] Reviewer confirms no production code or existing tests are touched: `git diff --stat develop..HEAD` shows only the 3 files.

## References

- Contract: `docs/roadmap/portability-harness-contract.md` "Two-stage CI" — landed via PR #774.
- Cleanup plan: `docs/roadmap/openchrome-1.11-cleanup.md` Phase 1 boundary plumbing.
- Sibling PR: #787 (dep-cruiser config + tier source scaffolding).
- Issue: #782.
- Tracker: #780.

🤖 Phase 1 boundary plumbing, part 2 of 3. Next: PR for #777 (--pilot CLI flag + harness/flags.ts).