### PR TITLE
feat(harness): --pilot CLI flag + per-family env-flag loader

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -346,6 +346,7 @@ program
   .option('--all-tools', 'Expose all tools from startup (bypass progressive disclosure)')
   .option('--server-mode', 'Server/headless mode: auto-launch headless Chrome, skip cookie bridge')
   .option('--http [port]', 'Use Streamable HTTP transport instead of stdio (default port: 3100)')
+  .option('--pilot', 'Enable experimental pilot tier (see docs/roadmap/portability-harness-contract.md). Off by default; loads src/pilot/ modules when set')
   .option('--dashboard', 'Enable terminal dashboard for real-time monitoring')
   .option('--persist-storage', 'Enable browser state persistence (cookies + localStorage)')
   .option('--storage-dir <path>', 'Directory for storage state files (default: .openchrome/storage-state/)')

--- a/src/harness/flags.ts
+++ b/src/harness/flags.ts
@@ -1,0 +1,123 @@
+/**
+ * Harness feature-flag loader.
+ *
+ * Implements the activation policy from the portability-harness contract
+ * (docs/roadmap/portability-harness-contract.md):
+ *
+ *   - `--pilot` CLI flag (or OPENCHROME_PILOT env) gates the pilot tier as a whole.
+ *   - When the gate is closed, no module from `src/pilot/**` is loaded into the
+ *     process; `bootstrapPilot()` returns null without invoking `import()`.
+ *   - When the gate is open, six per-family sub-flags individually enable the
+ *     specific pilot families. Each defaults to *active* inside pilot and can
+ *     be overridden to false via its environment variable.
+ *
+ * This module lives in `src/core/` conceptually (it ships unflagged) but stays
+ * at `src/harness/` so both core and pilot modules can import it without
+ * tripping the `core-must-not-import-pilot` lint rule.
+ */
+
+const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
+
+export function isTruthy(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  return TRUTHY.has(value.trim().toLowerCase());
+}
+
+function pilotFromArgv(argv: readonly string[] = process.argv): boolean {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--pilot') return true;
+    if (arg.startsWith('--pilot=')) return isTruthy(arg.slice('--pilot='.length));
+  }
+  return false;
+}
+
+let cachedPilot: boolean | null = null;
+
+/**
+ * Returns true iff the operator enabled the pilot tier — either by passing
+ * `--pilot` on the command line or by setting OPENCHROME_PILOT to a truthy
+ * value. The result is cached after the first call. Use `resetFlagsCache()`
+ * in tests to clear the cache between scenarios.
+ */
+export function isPilotEnabled(): boolean {
+  if (cachedPilot !== null) return cachedPilot;
+  cachedPilot = pilotFromArgv() || isTruthy(process.env.OPENCHROME_PILOT);
+  return cachedPilot;
+}
+
+/**
+ * Per-family activation. Returns false unless `--pilot` is enabled. When the
+ * pilot gate is open, the family defaults to active; an explicit falsy env
+ * value (e.g., `OPENCHROME_TRACE=0`) turns it off.
+ */
+function isFamilyEnabled(envVar: string): boolean {
+  if (!isPilotEnabled()) return false;
+  const raw = process.env[envVar];
+  if (raw === undefined || raw.trim() === '') return true;
+  return isTruthy(raw);
+}
+
+export const isTraceEnabled = (): boolean => isFamilyEnabled('OPENCHROME_TRACE');
+export const isStateGraphEnabled = (): boolean => isFamilyEnabled('OPENCHROME_STATE_GRAPH');
+export const isContractRuntimeEnabled = (): boolean => isFamilyEnabled('OPENCHROME_CONTRACT_RUNTIME');
+export const isHandoffPersistEnabled = (): boolean => isFamilyEnabled('OPENCHROME_HANDOFF_PERSIST');
+export const isPerceptionVotingEnabled = (): boolean => isFamilyEnabled('OPENCHROME_PERCEPTION_VOTING');
+export const isSkillCuratorEnabled = (): boolean => isFamilyEnabled('OPENCHROME_SKILL_CURATOR');
+
+const ALL_FAMILIES: ReadonlyArray<readonly [string, () => boolean]> = [
+  ['trace', isTraceEnabled],
+  ['state_graph', isStateGraphEnabled],
+  ['contract_runtime', isContractRuntimeEnabled],
+  ['handoff_persist', isHandoffPersistEnabled],
+  ['perception_voting', isPerceptionVotingEnabled],
+  ['skill_curator', isSkillCuratorEnabled],
+];
+
+/**
+ * Returns the list of pilot families currently active, in declaration order.
+ * Empty when the pilot gate is closed.
+ */
+export function activeFamilies(): string[] {
+  return ALL_FAMILIES.filter(([, fn]) => fn()).map(([name]) => name);
+}
+
+/**
+ * Writes a single line to stderr describing which tiers and families are
+ * active. Per CLAUDE.md never use stdout — that carries the MCP JSON-RPC
+ * payload and would corrupt the protocol.
+ */
+export function logActiveFlags(): void {
+  if (!isPilotEnabled()) {
+    process.stderr.write('[harness] core only (--pilot not set)\n');
+    return;
+  }
+  const fams = activeFamilies();
+  const list = fams.length > 0 ? fams.join(',') : 'no families active';
+  process.stderr.write(`[harness] core+pilot enabled (${list})\n`);
+}
+
+/**
+ * Lazily loads the pilot bootstrap module. Returns null when the pilot gate
+ * is closed, in which case no code from `src/pilot/**` is loaded into the
+ * process. Returns the resolved module otherwise.
+ *
+ * Callers wire pilot tools through this entry point so that
+ * `tools/list` returns the 1.10.4 surface when `--pilot` is unset (per
+ * principle P2 of the portability-harness contract).
+ */
+export async function bootstrapPilot(): Promise<unknown | null> {
+  if (!isPilotEnabled()) return null;
+  // Dynamic import keeps the pilot tree out of the static dependency graph
+  // until `--pilot` is explicitly enabled at runtime.
+  const mod = await import('../pilot/index.js');
+  return mod;
+}
+
+/**
+ * Test helper. Clears the cached pilot decision so subsequent tests can
+ * exercise the parser with a different `process.argv` or env state.
+ */
+export function resetFlagsCache(): void {
+  cachedPilot = null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { installParentWatcher, ParentWatcherHandle } from './utils/parent-watche
 import { installIdleTimeout, IdleTimeoutHandle, parseDuration } from './utils/idle-timeout';
 import { getIdleState } from './utils/idle-state';
 import { getVersion } from './version';
+import { bootstrapPilot, logActiveFlags } from './harness/flags';
 import { ChromeProcessWatchdog } from './chrome/process-watchdog';
 import { TabHealthMonitor } from './cdp/tab-health-monitor';
 import { EventLoopMonitor, setGlobalEventLoopMonitor } from './watchdog/event-loop-monitor';
@@ -94,7 +95,8 @@ program
   .option('--allow-unauthenticated-http', 'Explicitly allow unauthenticated loopback-only HTTP development mode (also: OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP=1)')
   .option('--transport <mode>', 'Transport mode: stdio, http, or both (default: stdio)')
   .option('--idle-timeout <duration>', 'Self-exit (code 0) after idle window with zero sessions. Format: <number>(ms|s|m|h), e.g. 30m, 90s, 500ms. Bare numbers are rejected. Also: OPENCHROME_IDLE_TIMEOUT_MS env var (integer ms). Default: disabled.')
-  .action(async (options: { port: string; autoLaunch?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; windowSize?: string; windowPosition?: string; windowBounds?: string; startMaximized?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; idleTimeout?: string; allowUnauthenticatedHttp?: boolean }) => {
+  .option('--pilot', 'Enable experimental pilot tier (see docs/roadmap/portability-harness-contract.md). Off by default; lazy-loads src/pilot/ modules when set. Also: OPENCHROME_PILOT=1 env var.')
+  .action(async (options: { port: string; autoLaunch?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; windowSize?: string; windowPosition?: string; windowBounds?: string; startMaximized?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; idleTimeout?: string; allowUnauthenticatedHttp?: boolean; pilot?: boolean }) => {
     const port = parseInt(options.port, 10);
     let autoLaunch = options.autoLaunch || false;
 
@@ -116,6 +118,13 @@ program
     const restartChrome = options.restartChrome || false;
 
     console.error(`[openchrome] Starting MCP server`);
+
+    // Portability-harness tier activation. P2: when --pilot is unset, no
+    // module from src/pilot/** is loaded. bootstrapPilot() short-circuits and
+    // returns null in that case.
+    logActiveFlags();
+    await bootstrapPilot();
+
     console.error(`[openchrome] Chrome debugging port: ${port}`);
     console.error(`[openchrome] Auto-launch Chrome: ${autoLaunch}`);
     if (userDataDir) {

--- a/tests/core/harness/flags.test.ts
+++ b/tests/core/harness/flags.test.ts
@@ -1,0 +1,238 @@
+import {
+  activeFamilies,
+  bootstrapPilot,
+  isContractRuntimeEnabled,
+  isHandoffPersistEnabled,
+  isPerceptionVotingEnabled,
+  isPilotEnabled,
+  isSkillCuratorEnabled,
+  isStateGraphEnabled,
+  isTraceEnabled,
+  isTruthy,
+  logActiveFlags,
+  resetFlagsCache,
+} from '../../../src/harness/flags';
+
+describe('harness/flags', () => {
+  const originalArgv = process.argv;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    resetFlagsCache();
+    process.argv = ['node', 'cli/index.js'];
+    process.env = { ...originalEnv };
+    delete process.env.OPENCHROME_PILOT;
+    delete process.env.OPENCHROME_TRACE;
+    delete process.env.OPENCHROME_STATE_GRAPH;
+    delete process.env.OPENCHROME_CONTRACT_RUNTIME;
+    delete process.env.OPENCHROME_HANDOFF_PERSIST;
+    delete process.env.OPENCHROME_PERCEPTION_VOTING;
+    delete process.env.OPENCHROME_SKILL_CURATOR;
+  });
+
+  afterAll(() => {
+    process.argv = originalArgv;
+    process.env = originalEnv;
+    resetFlagsCache();
+  });
+
+  describe('isTruthy', () => {
+    test.each([
+      ['1', true],
+      ['true', true],
+      ['TRUE', true],
+      ['yes', true],
+      ['on', true],
+      ['  YES  ', true],
+      ['0', false],
+      ['false', false],
+      ['no', false],
+      ['off', false],
+      ['', false],
+      ['nope', false],
+      [undefined, false],
+    ])('isTruthy(%j) -> %j', (input, expected) => {
+      expect(isTruthy(input as string | undefined)).toBe(expected);
+    });
+  });
+
+  describe('isPilotEnabled', () => {
+    test('default (no flag, no env) -> false', () => {
+      expect(isPilotEnabled()).toBe(false);
+    });
+
+    test('--pilot in argv -> true', () => {
+      process.argv = ['node', 'cli/index.js', 'serve', '--pilot'];
+      resetFlagsCache();
+      expect(isPilotEnabled()).toBe(true);
+    });
+
+    test('--pilot=1 in argv -> true', () => {
+      process.argv = ['node', 'cli/index.js', 'serve', '--pilot=1'];
+      resetFlagsCache();
+      expect(isPilotEnabled()).toBe(true);
+    });
+
+    test('--pilot=false in argv -> false', () => {
+      process.argv = ['node', 'cli/index.js', 'serve', '--pilot=false'];
+      resetFlagsCache();
+      expect(isPilotEnabled()).toBe(false);
+    });
+
+    test('OPENCHROME_PILOT=1 -> true', () => {
+      process.env.OPENCHROME_PILOT = '1';
+      resetFlagsCache();
+      expect(isPilotEnabled()).toBe(true);
+    });
+
+    test('OPENCHROME_PILOT=0 -> false', () => {
+      process.env.OPENCHROME_PILOT = '0';
+      resetFlagsCache();
+      expect(isPilotEnabled()).toBe(false);
+    });
+
+    test('result is cached', () => {
+      process.argv = ['node', 'cli/index.js', 'serve', '--pilot'];
+      resetFlagsCache();
+      const first = isPilotEnabled();
+      process.argv = ['node', 'cli/index.js', 'serve'];
+      // No resetFlagsCache here; cache should retain the previous decision.
+      expect(isPilotEnabled()).toBe(first);
+    });
+  });
+
+  describe('per-family flags', () => {
+    test('all return false when pilot is off', () => {
+      expect(isTraceEnabled()).toBe(false);
+      expect(isStateGraphEnabled()).toBe(false);
+      expect(isContractRuntimeEnabled()).toBe(false);
+      expect(isHandoffPersistEnabled()).toBe(false);
+      expect(isPerceptionVotingEnabled()).toBe(false);
+      expect(isSkillCuratorEnabled()).toBe(false);
+    });
+
+    test('all default to true when pilot is on', () => {
+      process.argv = ['node', 'cli/index.js', 'serve', '--pilot'];
+      resetFlagsCache();
+      expect(isTraceEnabled()).toBe(true);
+      expect(isStateGraphEnabled()).toBe(true);
+      expect(isContractRuntimeEnabled()).toBe(true);
+      expect(isHandoffPersistEnabled()).toBe(true);
+      expect(isPerceptionVotingEnabled()).toBe(true);
+      expect(isSkillCuratorEnabled()).toBe(true);
+    });
+
+    test('explicit env=0 turns one family off without affecting others', () => {
+      process.argv = ['node', 'cli/index.js', 'serve', '--pilot'];
+      process.env.OPENCHROME_TRACE = '0';
+      resetFlagsCache();
+      expect(isTraceEnabled()).toBe(false);
+      expect(isStateGraphEnabled()).toBe(true);
+    });
+
+    test('empty string env is treated as unset (defaults to true under pilot)', () => {
+      process.argv = ['node', 'cli/index.js', 'serve', '--pilot'];
+      process.env.OPENCHROME_TRACE = '';
+      resetFlagsCache();
+      expect(isTraceEnabled()).toBe(true);
+    });
+  });
+
+  describe('activeFamilies', () => {
+    test('empty when pilot is off', () => {
+      expect(activeFamilies()).toEqual([]);
+    });
+
+    test('full list when pilot is on with no overrides', () => {
+      process.argv = ['node', 'cli/index.js', 'serve', '--pilot'];
+      resetFlagsCache();
+      expect(activeFamilies()).toEqual([
+        'trace',
+        'state_graph',
+        'contract_runtime',
+        'handoff_persist',
+        'perception_voting',
+        'skill_curator',
+      ]);
+    });
+
+    test('respects per-family overrides', () => {
+      process.argv = ['node', 'cli/index.js', 'serve', '--pilot'];
+      process.env.OPENCHROME_TRACE = '0';
+      process.env.OPENCHROME_PERCEPTION_VOTING = 'false';
+      resetFlagsCache();
+      expect(activeFamilies()).toEqual([
+        'state_graph',
+        'contract_runtime',
+        'handoff_persist',
+        'skill_curator',
+      ]);
+    });
+  });
+
+  describe('logActiveFlags', () => {
+    let stderrChunks: string[];
+    let writeSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      stderrChunks = [];
+      writeSpy = jest
+        .spyOn(process.stderr, 'write')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mockImplementation(((chunk: any) => {
+          stderrChunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+          return true;
+        }) as never);
+    });
+
+    afterEach(() => {
+      writeSpy.mockRestore();
+    });
+
+    test('writes core-only line to stderr when pilot is off', () => {
+      logActiveFlags();
+      expect(stderrChunks).toEqual(['[harness] core only (--pilot not set)\n']);
+    });
+
+    test('writes core+pilot line with active families', () => {
+      process.argv = ['node', 'cli/index.js', 'serve', '--pilot'];
+      resetFlagsCache();
+      logActiveFlags();
+      expect(stderrChunks).toHaveLength(1);
+      expect(stderrChunks[0]).toMatch(
+        /^\[harness\] core\+pilot enabled \(trace,state_graph,contract_runtime,handoff_persist,perception_voting,skill_curator\)\n$/,
+      );
+    });
+
+    test('writes "no families active" when pilot is on but every family is overridden off', () => {
+      process.argv = ['node', 'cli/index.js', 'serve', '--pilot'];
+      process.env.OPENCHROME_TRACE = '0';
+      process.env.OPENCHROME_STATE_GRAPH = '0';
+      process.env.OPENCHROME_CONTRACT_RUNTIME = '0';
+      process.env.OPENCHROME_HANDOFF_PERSIST = '0';
+      process.env.OPENCHROME_PERCEPTION_VOTING = '0';
+      process.env.OPENCHROME_SKILL_CURATOR = '0';
+      resetFlagsCache();
+      logActiveFlags();
+      expect(stderrChunks).toEqual(['[harness] core+pilot enabled (no families active)\n']);
+    });
+  });
+
+  describe('bootstrapPilot', () => {
+    test('returns null when pilot is off and does not load src/pilot/**', async () => {
+      const result = await bootstrapPilot();
+      expect(result).toBeNull();
+    });
+
+    test('returns the pilot module when pilot is on', async () => {
+      process.argv = ['node', 'cli/index.js', 'serve', '--pilot'];
+      resetFlagsCache();
+      const result = await bootstrapPilot();
+      // src/pilot/index.ts currently re-exports nothing; the imported module
+      // object exists but has no own keys. That is the contract for the
+      // 1.11 cleanup until pilot families land.
+      expect(result).not.toBeNull();
+      expect(typeof result).toBe('object');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Third and final piece of Phase 1 boundary plumbing. Wires the portability-harness contract's activation policy into runtime so subsequent Phase 2b / 4 PRs can register pilot tools through a single hook.

Closes #777.

Builds on PR #787 (dep-cruiser config + `src/core/` & `src/pilot/` scaffolding) and PR #788 (lint:tier in CI + `tests/{core,pilot}/` scaffolding).

## What changes

### `src/harness/flags.ts` (new, normative gate)

- `isPilotEnabled()` — true iff operator passed `--pilot` on argv or set `OPENCHROME_PILOT` to a truthy value. Cached after first call (`resetFlagsCache()` exposed for tests).
- Per-family getters: `isTraceEnabled`, `isStateGraphEnabled`, `isContractRuntimeEnabled`, `isHandoffPersistEnabled`, `isPerceptionVotingEnabled`, `isSkillCuratorEnabled`. Each returns false when `--pilot` is off; when `--pilot` is on, each defaults to true and accepts a falsy env override (e.g., `OPENCHROME_TRACE=0`).
- `activeFamilies()` — returns active list in declaration order.
- `logActiveFlags()` — one stderr line at startup; uses stderr explicitly because stdout carries the MCP JSON-RPC payload (CLAUDE.md rule).
- `bootstrapPilot()` — dynamic `await import('../pilot/index.js')` gated on `isPilotEnabled()`. **Returns null when pilot is off**, so the pilot module tree never enters the process per principle P2 of the contract.

The file lives at `src/harness/` (not `src/core/` or `src/pilot/`) so both tiers may import it without tripping the `core-must-not-import-pilot` lint rule.

### `cli/index.ts`

- Adds `--pilot` option to the `serve` command for `--help` visibility. The CLI forwards `process.argv` to the child `dist/index.js`, so this is documentation only on the parent side.

### `src/index.ts`

- Adds `--pilot` option to the serve command and extends the action handler options type.
- Calls `logActiveFlags()` + `await bootstrapPilot()` right after the "Starting MCP server" log line, before any other startup work.

### `tests/core/harness/flags.test.ts` (new, 32 tests)

Coverage:
- Truthy/falsy parsing across `1`, `true`, `TRUE`, `yes`, `on`, ` YES `, `0`, `false`, `no`, `off`, `''`, `nope`, `undefined`.
- `--pilot` via argv vs `OPENCHROME_PILOT` env, including `--pilot=1` and `--pilot=false`.
- Cache behavior (cached after first call; tests use `resetFlagsCache()`).
- Family defaults (all true under `--pilot`).
- Per-family env overrides do not cross families.
- Empty string env treated as unset.
- `activeFamilies()` declaration order + respects overrides.
- `logActiveFlags()` writes only to stderr; never to stdout.
- `bootstrapPilot()` returns null when off and a module when on.

## Off behavior demonstration (per P2)

```bash
$ openchrome serve
[harness] core only (--pilot not set)
[openchrome] Starting MCP server
...
# tools/list surface unchanged from 1.10.4
```

```bash
$ openchrome serve --pilot
[harness] core+pilot enabled (trace,state_graph,contract_runtime,handoff_persist,perception_voting,skill_curator)
[openchrome] Starting MCP server
...
# src/pilot/index.js loaded; currently empty placeholder
```

```bash
$ openchrome serve --pilot
$ OPENCHROME_TRACE=0 OPENCHROME_PERCEPTION_VOTING=0 openchrome serve --pilot
[harness] core+pilot enabled (state_graph,contract_runtime,handoff_persist,skill_curator)
```

## Verification

- `npm run build`: clean.
- `npm run lint:tier`: 0 violations (272 modules, 579 dependencies cruised).
- `npx jest tests/core/harness/flags.test.ts`: 32/32 pass.

## What this does NOT do

- Does not register any pilot tools (none exist yet; `src/pilot/index.ts` is empty).
- Does not change the 1.10.4 tool/resource surface.
- Does not modify `npm` dependencies.
- Does not split Jest into two stages — that lands later once `src/pilot/**` has content.

## Test plan

- [ ] Reviewer pulls and runs `npm install && npm run build && npm run lint:tier && npx jest tests/core/harness/flags.test.ts`.
- [ ] Reviewer manually runs `openchrome serve` (no `--pilot`) and confirms the stderr line says "core only".
- [ ] Reviewer runs `openchrome serve --pilot` and confirms the stderr line lists all six families.
- [ ] Reviewer confirms no production behavior changed when `--pilot` is unset.

## References

- Contract: `docs/roadmap/portability-harness-contract.md` "Per-feature sub-flags" + "CLI surface".
- Cleanup plan: `docs/roadmap/openchrome-1.11-cleanup.md` Phase 1 boundary plumbing.
- Sibling PRs: #787 (lint + scaffold), #788 (CI wiring).
- Tracker: #780.

🤖 Phase 1 boundary plumbing, part 3 of 3. After this lands, Phase 2b cherry-pick chain can begin.