### PR TITLE
feat(core): oc_assert MCP tool

### DIFF
--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -43,6 +43,7 @@ export const TOOL_TIERS: Record<string, ToolTier> = {
   act: 1,                     // src/tools/act.ts — composite NL action API (#578)
   validate_page: 1,           // src/tools/validate-page.ts — composite page-health check (#token-efficiency)
   oc_reap_orphans: 1,         // src/tools/reap-orphans.ts — manual lifecycle recovery sweep
+  oc_assert: 1,               // src/tools/oc-assert.ts — Outcome Contracts single-call verifier (#784)
 
   // Tier 2: Specialist (on demand)
   extract_data: 2,              // src/tools/extract-data.ts — structured extraction (#571)

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -97,6 +97,9 @@ import { registerExtractDataTool } from './extract-data';
 // 2FA tools (#575)
 import { registerTotpGenerateTool } from './totp-generate';
 
+// Outcome Contracts (#784) — single-call assertion verifier
+import { registerOcAssertTool } from './oc-assert';
+
 export function registerAllTools(server: MCPServer): void {
   // Core browser tools
   registerNavigateTool(server);
@@ -197,6 +200,9 @@ export function registerAllTools(server: MCPServer): void {
 
   // 2FA tools (#575)
   registerTotpGenerateTool(server);
+
+  // Outcome Contracts (#784) — single-call assertion verifier
+  registerOcAssertTool(server);
 
   console.error(`[Tools] Registered ${server.getToolNames().length} tools`);
 }

--- a/src/tools/oc-assert.ts
+++ b/src/tools/oc-assert.ts
@@ -1,0 +1,398 @@
+/**
+ * oc_assert — single-call Outcome Contract assertion (issue #784).
+ *
+ * Runs ONE contract assertion against caller-supplied evidence (snapshot)
+ * and returns a verdict. This is the core-tier surface from PR #774's
+ * portability-harness contract: no retry, no escalation, no irreversible-
+ * action gating — those live in the pilot runtime (#749, #750).
+ *
+ * Design notes:
+ *  - The DSL in src/contracts/ does not (yet) expose a contract-by-id
+ *    registry. To keep this PR scoped, `oc_assert` accepts the Assertion
+ *    inline under `contract`. `contract_id` is reserved as an optional
+ *    forward-compatible field; today it surfaces a clear error if used
+ *    without `contract`.
+ *  - Evaluation is snapshot-driven: callers pre-capture the page state
+ *    (url, dom text/count, network, screenshot bytes, dialog flag) and
+ *    pass it in `evidence.snapshot`. Live browser plumbing belongs to
+ *    the pilot runtime; the core tool stays a pure verifier.
+ *  - `evidence_handle` is a UUID placeholder that future
+ *    `oc_evidence_bundle` (#792) will consume to materialize a
+ *    downloadable archive. v1.11 does not persist these handles.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import { evaluate } from '../contracts/evaluate';
+import { validateAssertion } from '../contracts/validator';
+import type { EvalContext, NetworkLogEntry } from '../contracts/eval-context';
+import type {
+  Assertion,
+  EvaluationResult,
+  Evidence,
+  NetworkSinceMarker,
+} from '../contracts/types';
+
+type Verdict = 'pass' | 'fail' | 'inconclusive';
+
+interface FailedAssertion {
+  name: string;
+  expected: unknown;
+  actual: unknown;
+  location?: string;
+}
+
+interface OcAssertOutput {
+  verdict: Verdict;
+  failed_assertions?: FailedAssertion[];
+  evidence_handle?: string;
+  evidence?: Evidence;
+  validation_errors?: Array<{ path: string; message: string }>;
+  inconclusive_reason?: string;
+}
+
+interface SnapshotInput {
+  url?: string;
+  dom_text?: Record<string, string | null> | string | null;
+  dom_count?: Record<string, number>;
+  network?: NetworkLogEntry[];
+  /** PNG bytes, base64 encoded. */
+  screenshot_png_base64?: string;
+  has_open_dialog?: boolean;
+}
+
+const definition: MCPToolDefinition = {
+  name: 'oc_assert',
+  description:
+    'Evaluate a single Outcome Contract assertion against caller-supplied ' +
+    'evidence (snapshot). Returns verdict pass/fail/inconclusive plus the ' +
+    'list of failed leaf assertions. Core-tier single-call surface; retry ' +
+    'and escalation live in the pilot runtime.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      contract_id: {
+        type: 'string',
+        description:
+          'Optional identifier for a registered contract. Reserved for ' +
+          'forward compatibility — currently no registry exists, so callers ' +
+          'must supply `contract` inline.',
+      },
+      contract: {
+        type: 'object',
+        description:
+          'Assertion DSL object (see src/contracts/types.ts: kind ∈ ' +
+          'url|dom_text|dom_count|network|screenshot_class|no_dialog|and|or|not). ' +
+          'Validated via validateAssertion() before evaluation.',
+      },
+      args: {
+        type: 'object',
+        description:
+          'Reserved for future contract templating. Ignored in v1.11.',
+      },
+      evidence: {
+        type: 'object',
+        description:
+          'Pre-captured page evidence. Required for evaluation; without it ' +
+          'the verdict is `inconclusive`.',
+        properties: {
+          snapshot: {
+            type: 'object',
+            description:
+              'Snapshot fields. Provide the subset the assertion needs: ' +
+              '`url` (string), `dom_text` (string | { selector: string|null }), ' +
+              '`dom_count` ({ selector: number }), `network` (NetworkLogEntry[]), ' +
+              '`screenshot_png_base64` (base64 PNG), `has_open_dialog` (boolean).',
+          },
+        },
+      },
+    },
+    required: [],
+  },
+};
+
+function buildEvalContext(snapshot: SnapshotInput | undefined): EvalContext {
+  const domTextMap =
+    snapshot && typeof snapshot.dom_text === 'object' && snapshot.dom_text !== null
+      ? (snapshot.dom_text as Record<string, string | null>)
+      : undefined;
+  const defaultDomText =
+    snapshot && (typeof snapshot.dom_text === 'string' || snapshot.dom_text === null)
+      ? (snapshot.dom_text as string | null)
+      : null;
+
+  let screenshotBuffer: Buffer | null = null;
+  if (snapshot?.screenshot_png_base64) {
+    try {
+      screenshotBuffer = Buffer.from(snapshot.screenshot_png_base64, 'base64');
+    } catch {
+      screenshotBuffer = null;
+    }
+  }
+
+  return {
+    async url() {
+      return snapshot?.url ?? '';
+    },
+    async domText(selector) {
+      if (domTextMap && selector !== undefined && selector in domTextMap) {
+        return domTextMap[selector];
+      }
+      return defaultDomText;
+    },
+    async domCount(selector) {
+      return snapshot?.dom_count?.[selector] ?? 0;
+    },
+    async networkSince(_marker: NetworkSinceMarker) {
+      // The `since` marker is meaningful only with a live runtime that
+      // tracks tool-call boundaries. For snapshot-driven evaluation the
+      // caller is expected to supply only entries relevant to the
+      // assertion, so we return the entire array regardless of marker.
+      return snapshot?.network ?? [];
+    },
+    async screenshotPng() {
+      return screenshotBuffer;
+    },
+    async hasOpenDialog() {
+      return snapshot?.has_open_dialog ?? false;
+    },
+  };
+}
+
+/**
+ * Walk the evidence tree and collect failed leaf evidences.
+ *
+ * The evaluator records each leaf evaluation's evidence; logical nodes
+ * (and/or/not) attach their children's evidence under `details.children`
+ * (or `details.child` for `not`). We flatten failures so callers see
+ * exactly which leaf assertions tripped.
+ */
+function collectFailedAssertions(
+  assertion: Assertion,
+  evidence: Evidence,
+  pathPrefix: string,
+): FailedAssertion[] {
+  if (evidence.passed) return [];
+
+  const out: FailedAssertion[] = [];
+
+  if (assertion.kind === 'and' || assertion.kind === 'or') {
+    const childEvidences = (evidence.details.children as Evidence[] | undefined) ?? [];
+    for (let i = 0; i < assertion.children.length && i < childEvidences.length; i++) {
+      out.push(
+        ...collectFailedAssertions(
+          assertion.children[i],
+          childEvidences[i],
+          `${pathPrefix}.children.${i}`,
+        ),
+      );
+    }
+    if (out.length > 0) return out;
+    // If we could not crack the logical node open, fall through and emit
+    // a single record for the node itself so callers still see something.
+  } else if (assertion.kind === 'not') {
+    const childEvidence = evidence.details.child as Evidence | undefined;
+    if (childEvidence) {
+      // For `not`, the leaf "failed" because the child passed. Surface
+      // the child as the actionable record.
+      out.push({
+        name: `${pathPrefix}.child[${assertion.child.kind}]`,
+        expected: { negated: true },
+        actual: childEvidence.details,
+      });
+      return out;
+    }
+  }
+
+  // Leaf (or undecodable logical node): emit one record.
+  const { expected, actual } = expectedActualFor(assertion, evidence);
+  out.push({
+    name: `${pathPrefix}[${assertion.kind}]`,
+    expected,
+    actual,
+    location: pathPrefix,
+  });
+  return out;
+}
+
+function expectedActualFor(
+  assertion: Assertion,
+  evidence: Evidence,
+): { expected: unknown; actual: unknown } {
+  switch (assertion.kind) {
+    case 'url':
+      return {
+        expected: { pattern: assertion.pattern },
+        actual: evidence.details.url ?? null,
+      };
+    case 'dom_text':
+      return {
+        expected: { selector: assertion.selector ?? 'body', contains: assertion.contains },
+        actual: {
+          text_preview: evidence.details.text_preview ?? null,
+          text_length: evidence.details.text_length ?? 0,
+        },
+      };
+    case 'dom_count':
+      return {
+        expected: { selector: assertion.selector, op: assertion.op, value: assertion.value },
+        actual: { count: evidence.details.count ?? null },
+      };
+    case 'network':
+      return {
+        expected: {
+          url_pattern: assertion.url_pattern,
+          status_in: assertion.status_in,
+          since: assertion.since,
+        },
+        actual: evidence.details,
+      };
+    case 'screenshot_class':
+      return {
+        expected: { class_id: assertion.class_id, distance_max: assertion.distance_max },
+        actual: evidence.details,
+      };
+    case 'no_dialog':
+      return {
+        expected: { no_dialog: true },
+        actual: { has_open_dialog: evidence.details.has_open_dialog ?? null },
+      };
+    case 'and':
+    case 'or':
+    case 'not':
+      return { expected: { kind: assertion.kind }, actual: evidence.details };
+  }
+}
+
+function isInconclusive(evidence: Evidence): boolean {
+  // The evaluator signals undecidable evaluations by stamping an `error`
+  // string in details (e.g. screenshot_class with no registry hook, or a
+  // network entry list the runtime could not provide). We treat any such
+  // top-level error as inconclusive rather than a hard fail.
+  return typeof evidence.details.error === 'string';
+}
+
+const handler: ToolHandler = async (
+  _sessionId: string,
+  args: Record<string, unknown>,
+): Promise<MCPResult> => {
+  const contractInline = args.contract;
+  const contractId = args.contract_id as string | undefined;
+
+  if (contractInline === undefined) {
+    if (contractId !== undefined) {
+      const output: OcAssertOutput = {
+        verdict: 'inconclusive',
+        inconclusive_reason:
+          'contract_id lookup is not yet implemented; pass the assertion ' +
+          'inline via `contract`.',
+      };
+      return jsonResult(output);
+    }
+    const output: OcAssertOutput = {
+      verdict: 'inconclusive',
+      inconclusive_reason: 'missing required field: `contract`',
+    };
+    return jsonResult(output);
+  }
+
+  const validation = validateAssertion(contractInline);
+  if (!validation.ok) {
+    const output: OcAssertOutput = {
+      verdict: 'inconclusive',
+      inconclusive_reason: 'contract failed schema validation',
+      validation_errors: validation.errors,
+    };
+    return jsonResult(output);
+  }
+
+  const evidenceArg = args.evidence as { snapshot?: SnapshotInput } | undefined;
+  const snapshot = evidenceArg?.snapshot;
+
+  // Without any snapshot the verdict is inconclusive — there is no live
+  // browser binding in the core tool. The pilot runtime drives evaluation
+  // against an actual page.
+  if (!snapshot) {
+    const output: OcAssertOutput = {
+      verdict: 'inconclusive',
+      inconclusive_reason:
+        'no evidence.snapshot provided; oc_assert is a pure verifier and ' +
+        'cannot capture page state on its own.',
+    };
+    return jsonResult(output);
+  }
+
+  const ctx = buildEvalContext(snapshot);
+  let result: EvaluationResult;
+  try {
+    result = await evaluate(validation.value, ctx);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const output: OcAssertOutput = {
+      verdict: 'inconclusive',
+      inconclusive_reason: `evaluator threw: ${message}`,
+    };
+    return jsonResult(output);
+  }
+
+  let verdict: Verdict;
+  if (isInconclusive(result.evidence)) {
+    verdict = 'inconclusive';
+  } else if (result.passed) {
+    verdict = 'pass';
+  } else {
+    verdict = 'fail';
+  }
+
+  const output: OcAssertOutput = {
+    verdict,
+    evidence: result.evidence,
+    evidence_handle: makeEvidenceHandle(),
+  };
+
+  if (verdict === 'fail') {
+    output.failed_assertions = collectFailedAssertions(validation.value, result.evidence, '$');
+  } else if (verdict === 'inconclusive') {
+    output.inconclusive_reason =
+      typeof result.evidence.details.error === 'string'
+        ? (result.evidence.details.error as string)
+        : 'evaluation was inconclusive';
+  }
+
+  return jsonResult(output);
+};
+
+function makeEvidenceHandle(): string {
+  // Placeholder for #792 oc_evidence_bundle. The handle is currently not
+  // persisted; the pilot runtime / a future evidence store will materialize
+  // it when oc_evidence_bundle lands.
+  return `ev_${cryptoRandomUUID()}`;
+}
+
+function cryptoRandomUUID(): string {
+  // crypto is globally available on Node ≥ 19; require() avoids pulling
+  // type-only imports into the build surface.
+  const c: { randomUUID?: () => string } | undefined =
+    (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  if (c && typeof c.randomUUID === 'function') {
+    return c.randomUUID();
+  }
+  // Fallback: time + random. We do not use this for cryptographic purposes.
+  return `${Date.now().toString(16)}-${Math.random().toString(16).slice(2)}`;
+}
+
+function jsonResult(payload: OcAssertOutput): MCPResult {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(payload),
+      },
+    ],
+    ...payload,
+  };
+}
+
+export function registerOcAssertTool(server: MCPServer): void {
+  server.registerTool('oc_assert', handler, definition);
+}

--- a/tests/core/contracts/oc-assert.test.ts
+++ b/tests/core/contracts/oc-assert.test.ts
@@ -1,0 +1,233 @@
+/// <reference types="jest" />
+
+/**
+ * Tests for the `oc_assert` MCP tool (issue #784).
+ *
+ * Covers:
+ *  - registration into a mock server
+ *  - pass / fail / inconclusive verdicts
+ *  - failed_assertions extraction for leaf + logical (`and`) failures
+ *  - one case per evaluator that is practical to drive from a snapshot
+ *
+ * The `evidence_handle` is a forward-reference placeholder for #792
+ * (oc_evidence_bundle). It is asserted only by shape — not consumed.
+ */
+
+import { registerOcAssertTool } from '../../../src/tools/oc-assert';
+import type { MCPToolDefinition, MCPResult, ToolHandler } from '../../../src/types/mcp';
+
+interface RegisteredTool {
+  name: string;
+  handler: ToolHandler;
+  definition: MCPToolDefinition;
+}
+
+class MockServer {
+  public tools = new Map<string, RegisteredTool>();
+  registerTool(name: string, handler: ToolHandler, definition: MCPToolDefinition): void {
+    this.tools.set(name, { name, handler, definition });
+  }
+}
+
+function parseResult(result: MCPResult): Record<string, unknown> {
+  const text = result.content?.[0]?.text;
+  expect(typeof text).toBe('string');
+  return JSON.parse(text as string) as Record<string, unknown>;
+}
+
+async function invoke(
+  handler: ToolHandler,
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const result = await handler('test-session', args);
+  return parseResult(result);
+}
+
+function setup(): { handler: ToolHandler; definition: MCPToolDefinition } {
+  const server = new MockServer();
+  registerOcAssertTool(server as unknown as Parameters<typeof registerOcAssertTool>[0]);
+  const registered = server.tools.get('oc_assert');
+  expect(registered).toBeDefined();
+  return { handler: registered!.handler, definition: registered!.definition };
+}
+
+describe('oc_assert — registration', () => {
+  test('registers a tool named oc_assert with an object schema', () => {
+    const { definition } = setup();
+    expect(definition.name).toBe('oc_assert');
+    expect(definition.inputSchema.type).toBe('object');
+    expect(definition.description).toMatch(/Outcome Contract/);
+  });
+});
+
+describe('oc_assert — verdicts', () => {
+  test('pass: url assertion against matching snapshot', async () => {
+    const { handler } = setup();
+    const out = await invoke(handler, {
+      contract: { kind: 'url', pattern: '^https://example\\.com/?$' },
+      evidence: { snapshot: { url: 'https://example.com' } },
+    });
+    expect(out.verdict).toBe('pass');
+    expect(out.failed_assertions).toBeUndefined();
+    expect(typeof out.evidence_handle).toBe('string');
+    expect((out.evidence_handle as string).startsWith('ev_')).toBe(true);
+  });
+
+  test('fail: url assertion returns failed_assertions array', async () => {
+    const { handler } = setup();
+    const out = await invoke(handler, {
+      contract: { kind: 'url', pattern: '^https://other\\.com' },
+      evidence: { snapshot: { url: 'https://example.com' } },
+    });
+    expect(out.verdict).toBe('fail');
+    const failed = out.failed_assertions as Array<Record<string, unknown>>;
+    expect(Array.isArray(failed)).toBe(true);
+    expect(failed.length).toBe(1);
+    expect((failed[0].expected as { pattern: string }).pattern).toBe('^https://other\\.com');
+    expect(failed[0].actual).toBe('https://example.com');
+  });
+
+  test('inconclusive: missing evidence.snapshot', async () => {
+    const { handler } = setup();
+    const out = await invoke(handler, {
+      contract: { kind: 'url', pattern: '.*' },
+    });
+    expect(out.verdict).toBe('inconclusive');
+    expect(typeof out.inconclusive_reason).toBe('string');
+  });
+
+  test('inconclusive: missing contract entirely', async () => {
+    const { handler } = setup();
+    const out = await invoke(handler, {});
+    expect(out.verdict).toBe('inconclusive');
+    expect(out.inconclusive_reason).toMatch(/contract/);
+  });
+
+  test('inconclusive: contract_id supplied without a registry', async () => {
+    const { handler } = setup();
+    const out = await invoke(handler, { contract_id: 'cart_visible' });
+    expect(out.verdict).toBe('inconclusive');
+    expect(out.inconclusive_reason).toMatch(/contract_id/);
+  });
+
+  test('inconclusive: schema validation failure surfaces errors', async () => {
+    const { handler } = setup();
+    const out = await invoke(handler, {
+      contract: { kind: 'url' /* missing pattern */ },
+      evidence: { snapshot: { url: 'https://example.com' } },
+    });
+    expect(out.verdict).toBe('inconclusive');
+    const errors = out.validation_errors as Array<{ path: string; message: string }>;
+    expect(Array.isArray(errors)).toBe(true);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('oc_assert — per-evaluator coverage', () => {
+  test('dom_text: explicit selector hit', async () => {
+    const { handler } = setup();
+    const out = await invoke(handler, {
+      contract: { kind: 'dom_text', selector: 'h1', contains: 'Cart' },
+      evidence: { snapshot: { dom_text: { h1: 'Cart Total' } } },
+    });
+    expect(out.verdict).toBe('pass');
+  });
+
+  test('dom_text: default selector reads the string snapshot', async () => {
+    const { handler } = setup();
+    const out = await invoke(handler, {
+      contract: { kind: 'dom_text', contains: 'Welcome' },
+      evidence: { snapshot: { dom_text: 'Welcome to the site' } },
+    });
+    expect(out.verdict).toBe('pass');
+  });
+
+  test('dom_count: gte passes when observed >= target', async () => {
+    const { handler } = setup();
+    const out = await invoke(handler, {
+      contract: { kind: 'dom_count', selector: 'li.item', op: 'gte', value: 3 },
+      evidence: { snapshot: { dom_count: { 'li.item': 5 } } },
+    });
+    expect(out.verdict).toBe('pass');
+  });
+
+  test('network: matching status passes', async () => {
+    const { handler } = setup();
+    const out = await invoke(handler, {
+      contract: {
+        kind: 'network',
+        url_pattern: '/api/cart',
+        status_in: [200],
+        since: 'last_tool_call',
+      },
+      evidence: {
+        snapshot: {
+          network: [{ url: 'https://example.com/api/cart', status: 200, ts: 1 }],
+        },
+      },
+    });
+    expect(out.verdict).toBe('pass');
+  });
+
+  test('no_dialog: passes when no dialog is open', async () => {
+    const { handler } = setup();
+    const out = await invoke(handler, {
+      contract: { kind: 'no_dialog' },
+      evidence: { snapshot: { has_open_dialog: false } },
+    });
+    expect(out.verdict).toBe('pass');
+  });
+
+  test('no_dialog: fails when a dialog is open', async () => {
+    const { handler } = setup();
+    const out = await invoke(handler, {
+      contract: { kind: 'no_dialog' },
+      evidence: { snapshot: { has_open_dialog: true } },
+    });
+    expect(out.verdict).toBe('fail');
+  });
+
+  test('screenshot_class: inconclusive without registry hook', async () => {
+    // The default snapshot-driven EvalContext does not provide
+    // loadScreenshotClass, so the evaluator records an error in
+    // evidence.details — surfaced as `inconclusive`.
+    const { handler } = setup();
+    const out = await invoke(handler, {
+      contract: { kind: 'screenshot_class', class_id: 'cart.empty', distance_max: 8 },
+      evidence: {
+        snapshot: {
+          // 1×1 transparent PNG, base64 — content does not matter, the
+          // registry hook is what is missing.
+          screenshot_png_base64:
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+        },
+      },
+    });
+    expect(out.verdict).toBe('inconclusive');
+  });
+
+  test('and: short-circuits and surfaces the failing leaf in failed_assertions', async () => {
+    const { handler } = setup();
+    const out = await invoke(handler, {
+      contract: {
+        kind: 'and',
+        children: [
+          { kind: 'url', pattern: '^https://example\\.com' },
+          { kind: 'dom_text', selector: 'h1', contains: 'NotPresent' },
+        ],
+      },
+      evidence: {
+        snapshot: {
+          url: 'https://example.com',
+          dom_text: { h1: 'Cart Total' },
+        },
+      },
+    });
+    expect(out.verdict).toBe('fail');
+    const failed = out.failed_assertions as Array<{ name: string }>;
+    expect(failed.length).toBe(1);
+    // The failing leaf is the dom_text child at index 1.
+    expect(failed[0].name).toContain('dom_text');
+    expect(failed[0].name).toContain('children.1');
+  });
+});

--- a/tests/cross-env/cursor-verification.test.ts
+++ b/tests/cross-env/cursor-verification.test.ts
@@ -135,16 +135,16 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
   describe('C2: Tool Discovery & Listing', () => {
     let tier1Tools: any[];
 
-    test('Initial tools/list returns Tier 1 tools only (34 tools) + expand_tools', async () => {
+    test('Initial tools/list returns Tier 1 tools only (35 tools) + expand_tools', async () => {
       const { response } = await sendAndReceive(server, 'tools/list');
       tier1Tools = response.result.tools;
-      // 34 Tier 1 tools (includes oc_reap_orphans lifecycle sweep)
-      // + 1 expand_tools virtual tool = 35
+      // 35 Tier 1 tools (includes oc_reap_orphans lifecycle sweep, oc_assert)
+      // + 1 expand_tools virtual tool = 36
       const toolNames = tier1Tools.map((t: any) => t.name);
       expect(toolNames).toContain('expand_tools');
 
       const nonExpandTools = tier1Tools.filter((t: any) => t.name !== 'expand_tools');
-      expect(nonExpandTools.length).toBe(34);
+      expect(nonExpandTools.length).toBe(35);
     });
 
     test('expand_tools virtual tool present in initial list', () => {


### PR DESCRIPTION
## Summary

First Phase 3 implementation. Adds the `oc_assert` MCP tool: a single-call surface that runs one contract assertion and returns a verdict. Reuses the contract DSL on develop (#752) — no new contract surface, just a thin tool wrapper.

Closes #784.

## What changes

- `src/tools/oc-assert.ts` — tool registration + inline contract handler. Accepts the contract inline as a Zod-validated arg (matches existing tool surface; a registry can land later without breaking this).
- `src/tools/index.ts` — aggregator wires `registerOcAssertTool()` into `registerAllTools()`.
- `src/config/tool-tiers.ts` — tool surface classification entry.
- `tests/core/contracts/oc-assert.test.ts` — 15 tests covering each evaluator (dom_text, dom_count, network, no_dialog, screenshot_class), short-circuit logical `and`, and the inconclusive path when required evidence is missing.

## Tier classification

**Core**. Registers unconditionally without `--pilot`. Satisfies:

- **P1**: single call, single return; no retry, no escalation, no background work.
- **P2**: doesn't change any 1.10.4 tool behavior; pure additive.
- **P3**: no third-party API egress; no API key required.
- **P4**: pure evaluation against provided evidence — no LLM call, no judgment.
- **P5**: no new native deps.

## Verification

- `npm run build`: clean.
- `npm run lint`: clean.
- `npm run lint:tier`: 0 violations (273 modules, 582 deps).
- `npx jest tests/core/contracts/oc-assert.test.ts`: 15/15 pass.

## Test plan

- [ ] Reviewer pulls and runs `npm install && npm run build && npx jest tests/core/contracts/oc-assert.test.ts`.
- [ ] Reviewer confirms `tools/list` from the resulting build includes `oc_assert`.
- [ ] Reviewer reads `src/tools/oc-assert.ts` to confirm no `src/pilot/` import.
- [ ] Reviewer confirms `evidence_handle` is documented as a forward-reference to `oc_evidence_bundle` (#792).

## References

- Issue: #784.
- Contract: `docs/roadmap/portability-harness-contract.md` "New tools that ship with v1.11.0 core" (PR #774).
- Cleanup plan: `docs/roadmap/openchrome-1.11-cleanup.md` Phase 3.
- DSL foundation: #752 (already on develop).
- Tracker: #780.

🤖 Phase 3 implementation, first of several core tools. Next: #783 (skill-graph MCP resource), #785 (oc_skill_record/recall), JSONL trace storage rewrite, #790 (contract runtime to src/pilot/runtime/).