### PR TITLE
feat(core): oc_evidence_bundle MCP tool (Phase 3, closes #792)

### DIFF
--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -44,6 +44,7 @@ export const TOOL_TIERS: Record<string, ToolTier> = {
   validate_page: 1,           // src/tools/validate-page.ts — composite page-health check (#token-efficiency)
   oc_reap_orphans: 1,         // src/tools/reap-orphans.ts — manual lifecycle recovery sweep
   oc_assert: 1,               // src/tools/oc-assert.ts — Outcome Contracts single-call verifier (#784)
+  oc_evidence_bundle: 1,      // src/tools/oc-evidence-bundle.ts — Outcome Contracts evidence bundle capture (#792)
 
   // Tier 2: Specialist (on demand)
   extract_data: 2,              // src/tools/extract-data.ts — structured extraction (#571)

--- a/src/core/contracts/evidence-bundle.ts
+++ b/src/core/contracts/evidence-bundle.ts
@@ -1,0 +1,265 @@
+/**
+ * Evidence bundle generator (issue #792).
+ *
+ * Captures a snapshot of the current page state into a flat directory under
+ * `<rootDir>/<bundle_id>/`. Each requested part is written as a separate
+ * file; the `parts` array returned by `writeEvidenceBundle` enumerates the
+ * relative filenames that were produced.
+ *
+ * This module is intentionally standalone: it does NOT depend on the pilot
+ * contract runtime (#749), the live browser, or any third-party archiver.
+ * Inputs arrive as a plain JS object (see `EvidenceBundleSnapshot`) supplied
+ * by the caller — today the MCP tool surfaces it directly; a future PR will
+ * have `oc_assert` produce an `evidence_handle` that materializes to one of
+ * these snapshots.
+ *
+ * Why flat layout instead of a ZIP archive?
+ *   The repo intentionally avoids a hard `archiver` dependency for this
+ *   first cut. The bundle directory is the unit of consumption; future
+ *   tooling can zip it on demand.
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { phashFromPng, phashToHex } from '../../contracts/phash';
+
+/** Parts the caller can request. Each maps to a file in the bundle dir. */
+export type EvidenceBundlePart = 'dom' | 'screenshot' | 'network' | 'console' | 'phash';
+
+/** Default include set — cheap parts that almost every caller wants. */
+export const DEFAULT_INCLUDE: readonly EvidenceBundlePart[] = ['dom', 'screenshot'];
+
+/** Default rolling window for the network slice. */
+export const DEFAULT_NETWORK_WINDOW_MS = 5000;
+
+/** One captured network entry. Shape mirrors the existing NetworkActivityLog. */
+export interface NetworkEntry {
+  /** Epoch ms when the request started. */
+  started_at?: number;
+  url?: string;
+  method?: string;
+  status?: number;
+  /** Free-form additional fields are preserved as-is. */
+  [k: string]: unknown;
+}
+
+/** One captured console entry. */
+export interface ConsoleEntry {
+  /** Epoch ms when the entry was emitted. */
+  ts?: number;
+  level?: string;
+  text?: string;
+  [k: string]: unknown;
+}
+
+/**
+ * Caller-supplied snapshot of the current page state. Every field is
+ * optional; missing fields cause the corresponding part to fall through
+ * gracefully (the part name is omitted from the result's `parts` array).
+ */
+export interface EvidenceBundleSnapshot {
+  /** Serialized DOM (HTML string or a JSON-serializable object). */
+  dom?: string | Record<string, unknown> | null;
+  /** PNG bytes (Buffer) or base64-encoded PNG string. */
+  screenshot_png?: Buffer | string;
+  /** All captured network entries — `network_window_ms` filters them. */
+  network?: NetworkEntry[];
+  /** All captured console entries — last N (by ts) are kept. */
+  console?: ConsoleEntry[];
+  /** Optional clock used for the network window. Defaults to `Date.now()`. */
+  now_ms?: number;
+}
+
+export interface EvidenceBundleOptions {
+  /**
+   * Root directory; defaults to `<os.tmpdir()>/openchrome-evidence`. The
+   * tmpdir default keeps tests from polluting `~/.openchrome`.
+   */
+  rootDir?: string;
+  /** Filter for which parts to capture. Default = DEFAULT_INCLUDE. */
+  include?: readonly EvidenceBundlePart[];
+  /** Network slice window in ms. Default = DEFAULT_NETWORK_WINDOW_MS. */
+  networkWindowMs?: number;
+  /** Cap for console entries kept. Default = 200. */
+  consoleMaxEntries?: number;
+}
+
+export interface EvidenceBundleResult {
+  bundle_id: string;
+  /** Absolute path to the directory containing the bundle parts. */
+  path: string;
+  /** Total bytes written across all parts (excluding the directory itself). */
+  size_bytes: number;
+  /** Relative filenames written, in capture order. */
+  parts: string[];
+}
+
+const CONSOLE_MAX_DEFAULT = 200;
+
+/** Compute the default root dir for evidence bundles. */
+export function defaultEvidenceRootDir(): string {
+  return path.join(os.tmpdir(), 'openchrome-evidence');
+}
+
+/**
+ * Write an evidence bundle to disk and return its metadata.
+ *
+ * Missing inputs are silently dropped from `parts` — the function never
+ * throws on a missing field, only on actual filesystem errors. Callers can
+ * treat an empty `parts` array as the "inconclusive" outcome.
+ */
+export function writeEvidenceBundle(
+  snapshot: EvidenceBundleSnapshot,
+  opts: EvidenceBundleOptions = {},
+): EvidenceBundleResult {
+  const include = normalizeInclude(opts.include);
+  const rootDir = opts.rootDir ?? defaultEvidenceRootDir();
+  const bundleId = crypto.randomUUID();
+  const bundleDir = path.join(rootDir, bundleId);
+  fs.mkdirSync(bundleDir, { recursive: true });
+
+  const parts: string[] = [];
+  let totalBytes = 0;
+
+  // ── DOM ───────────────────────────────────────────────────────────────
+  if (include.has('dom') && snapshot.dom !== undefined && snapshot.dom !== null) {
+    const filename = 'dom.json';
+    const payload =
+      typeof snapshot.dom === 'string'
+        ? JSON.stringify({ format: 'html', html: snapshot.dom }, null, 2)
+        : JSON.stringify(snapshot.dom, null, 2);
+    totalBytes += writePart(bundleDir, filename, payload);
+    parts.push(filename);
+  }
+
+  // ── Screenshot ────────────────────────────────────────────────────────
+  let screenshotBuffer: Buffer | null = null;
+  if (include.has('screenshot') && snapshot.screenshot_png !== undefined) {
+    screenshotBuffer = coerceScreenshot(snapshot.screenshot_png);
+    if (screenshotBuffer !== null) {
+      const filename = 'screenshot.png';
+      totalBytes += writePart(bundleDir, filename, screenshotBuffer);
+      parts.push(filename);
+    }
+  }
+
+  // ── Network slice ─────────────────────────────────────────────────────
+  if (include.has('network') && Array.isArray(snapshot.network)) {
+    const windowMs = readWindowMs(opts.networkWindowMs);
+    const now = typeof snapshot.now_ms === 'number' ? snapshot.now_ms : Date.now();
+    const cutoff = now - windowMs;
+    const sliced = snapshot.network.filter((entry) => {
+      const ts = typeof entry.started_at === 'number' ? entry.started_at : now;
+      return ts >= cutoff;
+    });
+    const filename = 'network.json';
+    const payload = JSON.stringify(
+      { window_ms: windowMs, captured_at: now, entries: sliced },
+      null,
+      2,
+    );
+    totalBytes += writePart(bundleDir, filename, payload);
+    parts.push(filename);
+  }
+
+  // ── Console slice ─────────────────────────────────────────────────────
+  if (include.has('console') && Array.isArray(snapshot.console)) {
+    const cap = readConsoleCap(opts.consoleMaxEntries);
+    // Keep the most recent `cap` entries, preserving original order.
+    const slice =
+      snapshot.console.length > cap ? snapshot.console.slice(-cap) : snapshot.console.slice();
+    const filename = 'console.json';
+    const payload = JSON.stringify({ max_entries: cap, entries: slice }, null, 2);
+    totalBytes += writePart(bundleDir, filename, payload);
+    parts.push(filename);
+  }
+
+  // ── Perceptual hash ───────────────────────────────────────────────────
+  if (include.has('phash')) {
+    // If the caller didn't ask for the screenshot part but did ask for
+    // phash, still try to decode the supplied PNG so we can compute it.
+    const pngForPhash =
+      screenshotBuffer ?? coerceScreenshot(snapshot.screenshot_png);
+    if (pngForPhash !== null) {
+      try {
+        const hash = phashFromPng(pngForPhash);
+        const filename = 'phash.json';
+        const payload = JSON.stringify(
+          { algorithm: 'dct-ii-8x8', hash_hex: phashToHex(hash) },
+          null,
+          2,
+        );
+        totalBytes += writePart(bundleDir, filename, payload);
+        parts.push(filename);
+      } catch (err) {
+        // phash is best-effort: a malformed PNG should not abort the bundle.
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[evidence-bundle] phash skipped: ${message}`);
+      }
+    }
+  }
+
+  return {
+    bundle_id: bundleId,
+    path: bundleDir,
+    size_bytes: totalBytes,
+    parts,
+  };
+}
+
+// ─── Internals ───────────────────────────────────────────────────────────
+
+function normalizeInclude(
+  include: readonly EvidenceBundlePart[] | undefined,
+): Set<EvidenceBundlePart> {
+  if (!include || include.length === 0) {
+    return new Set(DEFAULT_INCLUDE);
+  }
+  const valid: EvidenceBundlePart[] = ['dom', 'screenshot', 'network', 'console', 'phash'];
+  const out = new Set<EvidenceBundlePart>();
+  for (const item of include) {
+    if ((valid as string[]).includes(item)) out.add(item);
+  }
+  return out;
+}
+
+function readWindowMs(supplied: number | undefined): number {
+  if (typeof supplied === 'number' && Number.isFinite(supplied) && supplied >= 0) {
+    return supplied;
+  }
+  return DEFAULT_NETWORK_WINDOW_MS;
+}
+
+function readConsoleCap(supplied: number | undefined): number {
+  if (typeof supplied === 'number' && Number.isFinite(supplied) && supplied > 0) {
+    return Math.floor(supplied);
+  }
+  return CONSOLE_MAX_DEFAULT;
+}
+
+function coerceScreenshot(input: Buffer | string | undefined): Buffer | null {
+  if (input === undefined) return null;
+  if (Buffer.isBuffer(input)) return input.length > 0 ? input : null;
+  if (typeof input === 'string' && input.length > 0) {
+    try {
+      const buf = Buffer.from(input, 'base64');
+      return buf.length > 0 ? buf : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function writePart(dir: string, filename: string, payload: string | Buffer): number {
+  const target = path.join(dir, filename);
+  if (typeof payload === 'string') {
+    fs.writeFileSync(target, payload, 'utf8');
+    return Buffer.byteLength(payload, 'utf8');
+  }
+  fs.writeFileSync(target, payload);
+  return payload.length;
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -100,6 +100,9 @@ import { registerTotpGenerateTool } from './totp-generate';
 // Outcome Contracts (#784) — single-call assertion verifier
 import { registerOcAssertTool } from './oc-assert';
 
+// Outcome Contracts (#792) — evidence bundle capture
+import { registerOcEvidenceBundleTool } from './oc-evidence-bundle';
+
 export function registerAllTools(server: MCPServer): void {
   // Core browser tools
   registerNavigateTool(server);
@@ -203,6 +206,9 @@ export function registerAllTools(server: MCPServer): void {
 
   // Outcome Contracts (#784) — single-call assertion verifier
   registerOcAssertTool(server);
+
+  // Outcome Contracts (#792) — evidence bundle capture
+  registerOcEvidenceBundleTool(server);
 
   console.error(`[Tools] Registered ${server.getToolNames().length} tools`);
 }

--- a/src/tools/oc-evidence-bundle.ts
+++ b/src/tools/oc-evidence-bundle.ts
@@ -1,0 +1,184 @@
+/**
+ * oc_evidence_bundle — capture a snapshot of current page state (issue #792).
+ *
+ * Tier 1 MCP tool. Accepts a caller-supplied snapshot (DOM, screenshot bytes,
+ * network entries, console entries) and writes the requested parts to a flat
+ * directory under `<rootDir>/<bundle_id>/`. Returns the bundle metadata so
+ * the caller can locate the produced files.
+ *
+ * The tool is intentionally standalone: it does NOT depend on the pilot
+ * contract runtime (#749). The `oc_assert` tool (#784) already returns an
+ * `evidence_handle` placeholder; a follow-up PR will let this tool consume
+ * those handles to produce a bundle from previously recorded evidence.
+ *
+ * See `src/core/contracts/evidence-bundle.ts` for the capture helpers.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import {
+  DEFAULT_INCLUDE,
+  DEFAULT_NETWORK_WINDOW_MS,
+  writeEvidenceBundle,
+  type EvidenceBundlePart,
+  type EvidenceBundleSnapshot,
+  type ConsoleEntry,
+  type NetworkEntry,
+} from '../core/contracts/evidence-bundle';
+
+interface OcEvidenceBundleOutput {
+  bundle_id: string;
+  path: string;
+  size_bytes: number;
+  parts: string[];
+  /** Filled when no snapshot was supplied; bundle is still created (empty). */
+  inconclusive_reason?: string;
+}
+
+interface SnapshotInput {
+  dom?: string | Record<string, unknown> | null;
+  /** Base64 PNG. */
+  screenshot_png_base64?: string;
+  network?: NetworkEntry[];
+  console?: ConsoleEntry[];
+  now_ms?: number;
+}
+
+const VALID_PARTS: readonly EvidenceBundlePart[] = [
+  'dom',
+  'screenshot',
+  'network',
+  'console',
+  'phash',
+];
+
+const definition: MCPToolDefinition = {
+  name: 'oc_evidence_bundle',
+  description:
+    'Capture a snapshot of the current page state (DOM, screenshot, network ' +
+    'slice, console, perceptual hash) and write it to a bundle directory. ' +
+    "Returns { bundle_id, path, size_bytes, parts }. Default include = " +
+    "['dom', 'screenshot']; pass `include` to capture more parts. " +
+    '`network_window_ms` (default 5000) limits the network slice to recent ' +
+    'entries. Core-tier; does not depend on the pilot runtime.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      include: {
+        type: 'array',
+        description:
+          "Which parts to capture. Default ['dom', 'screenshot']. Allowed " +
+          "items: 'dom' | 'screenshot' | 'network' | 'console' | 'phash'.",
+        items: {
+          type: 'string',
+          enum: VALID_PARTS as unknown as string[],
+        },
+      },
+      network_window_ms: {
+        type: 'number',
+        description:
+          'Rolling window (ms) used to slice the supplied `evidence.snapshot.network` ' +
+          `array. Default ${DEFAULT_NETWORK_WINDOW_MS}.`,
+      },
+      evidence: {
+        type: 'object',
+        description:
+          'Caller-supplied snapshot. Provide the subset of fields the requested ' +
+          'parts need: `dom`, `screenshot_png_base64`, `network`, `console`, `now_ms`. ' +
+          'Missing fields cause the corresponding part to be omitted gracefully.',
+        properties: {
+          snapshot: {
+            type: 'object',
+            description:
+              'Snapshot fields. `dom` (string|object), `screenshot_png_base64` (base64 PNG), ' +
+              '`network` (NetworkEntry[]), `console` (ConsoleEntry[]), `now_ms` (epoch ms ' +
+              'used for the network window cutoff).',
+          },
+        },
+      },
+    },
+    required: [],
+  },
+};
+
+function parseInclude(raw: unknown): EvidenceBundlePart[] | undefined {
+  if (raw === undefined) return undefined;
+  if (!Array.isArray(raw)) return [];
+  const out: EvidenceBundlePart[] = [];
+  for (const item of raw) {
+    if (typeof item === 'string' && (VALID_PARTS as readonly string[]).includes(item)) {
+      out.push(item as EvidenceBundlePart);
+    }
+  }
+  return out;
+}
+
+function buildSnapshot(input: SnapshotInput | undefined): EvidenceBundleSnapshot {
+  if (!input) return {};
+  const out: EvidenceBundleSnapshot = {};
+  if (input.dom !== undefined) out.dom = input.dom;
+  if (input.screenshot_png_base64) out.screenshot_png = input.screenshot_png_base64;
+  if (Array.isArray(input.network)) out.network = input.network;
+  if (Array.isArray(input.console)) out.console = input.console;
+  if (typeof input.now_ms === 'number') out.now_ms = input.now_ms;
+  return out;
+}
+
+const handler: ToolHandler = async (
+  _sessionId: string,
+  args: Record<string, unknown>,
+): Promise<MCPResult> => {
+  const include = parseInclude(args.include);
+  const networkWindowMs =
+    typeof args.network_window_ms === 'number' ? args.network_window_ms : undefined;
+  const evidenceArg = args.evidence as { snapshot?: SnapshotInput } | undefined;
+  const snapshot = buildSnapshot(evidenceArg?.snapshot);
+
+  let result;
+  try {
+    result = writeEvidenceBundle(snapshot, { include, networkWindowMs });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const failure: OcEvidenceBundleOutput = {
+      bundle_id: '',
+      path: '',
+      size_bytes: 0,
+      parts: [],
+      inconclusive_reason: `failed to write evidence bundle: ${message}`,
+    };
+    return jsonResult(failure);
+  }
+
+  const output: OcEvidenceBundleOutput = {
+    bundle_id: result.bundle_id,
+    path: result.path,
+    size_bytes: result.size_bytes,
+    parts: result.parts,
+  };
+  if (result.parts.length === 0) {
+    output.inconclusive_reason =
+      'no evidence parts captured — supply `evidence.snapshot` with at least one of ' +
+      "dom / screenshot_png_base64 / network / console, and select matching `include` parts.";
+  }
+  return jsonResult(output);
+};
+
+function jsonResult(payload: OcEvidenceBundleOutput): MCPResult {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(payload),
+      },
+    ],
+    ...payload,
+  };
+}
+
+export function registerOcEvidenceBundleTool(server: MCPServer): void {
+  server.registerTool('oc_evidence_bundle', handler, definition);
+}
+
+// Re-export defaults so consumers (e.g. tests) can reference them without
+// reaching into the helper module.
+export { DEFAULT_INCLUDE, DEFAULT_NETWORK_WINDOW_MS };

--- a/tests/core/contracts/evidence-bundle.test.ts
+++ b/tests/core/contracts/evidence-bundle.test.ts
@@ -1,0 +1,260 @@
+/// <reference types="jest" />
+
+/**
+ * Tests for the evidence bundle helper (issue #792).
+ *
+ * Covers:
+ *  - default include = ['dom', 'screenshot']
+ *  - each include flag in isolation
+ *  - missing inputs fall through gracefully (no thrown error, empty `parts`)
+ *  - network slice respects `network_window_ms`
+ *  - console slice keeps the most recent N entries
+ *  - phash produces a 16-char lowercase hex digest
+ *  - corrupt PNG does not abort the bundle when phash is requested
+ *
+ * Filesystem isolation: every test points `rootDir` at a unique tmp dir so
+ * runs cannot collide.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  DEFAULT_INCLUDE,
+  DEFAULT_NETWORK_WINDOW_MS,
+  defaultEvidenceRootDir,
+  writeEvidenceBundle,
+} from '../../../src/core/contracts/evidence-bundle';
+import { encodeRgbaPng, gradientRgba } from '../../contracts/png-fixtures';
+
+function mkRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'evidence-bundle-test-'));
+}
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+describe('writeEvidenceBundle — defaults', () => {
+  test('DEFAULT_INCLUDE is [dom, screenshot]', () => {
+    expect([...DEFAULT_INCLUDE].sort()).toEqual(['dom', 'screenshot']);
+  });
+
+  test('DEFAULT_NETWORK_WINDOW_MS is 5000', () => {
+    expect(DEFAULT_NETWORK_WINDOW_MS).toBe(5000);
+  });
+
+  test('defaultEvidenceRootDir lives under os.tmpdir()', () => {
+    expect(defaultEvidenceRootDir().startsWith(os.tmpdir())).toBe(true);
+  });
+
+  test('default include captures dom + screenshot when both supplied', () => {
+    const rootDir = mkRoot();
+    const png = encodeRgbaPng(8, 8, gradientRgba(8, 8));
+    const result = writeEvidenceBundle(
+      { dom: '<html>hi</html>', screenshot_png: png },
+      { rootDir },
+    );
+
+    expect(result.bundle_id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(result.path.startsWith(rootDir)).toBe(true);
+    expect(result.parts.sort()).toEqual(['dom.json', 'screenshot.png']);
+    expect(result.size_bytes).toBeGreaterThan(0);
+
+    const domPath = path.join(result.path, 'dom.json');
+    expect(fs.existsSync(domPath)).toBe(true);
+    expect(readJson(domPath)).toEqual({ format: 'html', html: '<html>hi</html>' });
+
+    const screenshotPath = path.join(result.path, 'screenshot.png');
+    expect(fs.existsSync(screenshotPath)).toBe(true);
+    expect(fs.statSync(screenshotPath).size).toBe(png.length);
+  });
+});
+
+describe('writeEvidenceBundle — individual include flags', () => {
+  test("include=['dom']: writes only dom.json", () => {
+    const rootDir = mkRoot();
+    const result = writeEvidenceBundle({ dom: { nodes: 3 } }, { rootDir, include: ['dom'] });
+    expect(result.parts).toEqual(['dom.json']);
+    expect(readJson(path.join(result.path, 'dom.json'))).toEqual({ nodes: 3 });
+  });
+
+  test("include=['screenshot']: writes only screenshot.png", () => {
+    const rootDir = mkRoot();
+    const png = encodeRgbaPng(4, 4, gradientRgba(4, 4));
+    const result = writeEvidenceBundle(
+      { screenshot_png: png },
+      { rootDir, include: ['screenshot'] },
+    );
+    expect(result.parts).toEqual(['screenshot.png']);
+    expect(fs.statSync(path.join(result.path, 'screenshot.png')).size).toBe(png.length);
+  });
+
+  test("include=['screenshot']: accepts base64-encoded PNG", () => {
+    const rootDir = mkRoot();
+    const png = encodeRgbaPng(4, 4, gradientRgba(4, 4));
+    const result = writeEvidenceBundle(
+      { screenshot_png: png.toString('base64') },
+      { rootDir, include: ['screenshot'] },
+    );
+    expect(result.parts).toEqual(['screenshot.png']);
+    const written = fs.readFileSync(path.join(result.path, 'screenshot.png'));
+    expect(written.equals(png)).toBe(true);
+  });
+
+  test("include=['network']: filters by `network_window_ms`", () => {
+    const rootDir = mkRoot();
+    const now = 1_000_000;
+    const entries = [
+      { started_at: now - 10_000, url: 'old.com' }, // outside window
+      { started_at: now - 1_000, url: 'recent.com' }, // inside window
+      { started_at: now - 100, url: 'newest.com' }, // inside window
+    ];
+    const result = writeEvidenceBundle(
+      { network: entries, now_ms: now },
+      { rootDir, include: ['network'], networkWindowMs: 5_000 },
+    );
+    expect(result.parts).toEqual(['network.json']);
+    const payload = readJson(path.join(result.path, 'network.json')) as {
+      window_ms: number;
+      captured_at: number;
+      entries: Array<{ url: string }>;
+    };
+    expect(payload.window_ms).toBe(5_000);
+    expect(payload.captured_at).toBe(now);
+    expect(payload.entries.map((e) => e.url)).toEqual(['recent.com', 'newest.com']);
+  });
+
+  test("include=['console']: keeps the most recent N entries", () => {
+    const rootDir = mkRoot();
+    const entries = Array.from({ length: 250 }, (_, i) => ({ ts: i, text: `line-${i}` }));
+    const result = writeEvidenceBundle(
+      { console: entries },
+      { rootDir, include: ['console'], consoleMaxEntries: 50 },
+    );
+    expect(result.parts).toEqual(['console.json']);
+    const payload = readJson(path.join(result.path, 'console.json')) as {
+      max_entries: number;
+      entries: Array<{ text: string }>;
+    };
+    expect(payload.max_entries).toBe(50);
+    expect(payload.entries).toHaveLength(50);
+    expect(payload.entries[0].text).toBe('line-200');
+    expect(payload.entries[49].text).toBe('line-249');
+  });
+
+  test("include=['phash']: writes a 16-char lowercase hex digest", () => {
+    const rootDir = mkRoot();
+    const png = encodeRgbaPng(32, 32, gradientRgba(32, 32));
+    const result = writeEvidenceBundle(
+      { screenshot_png: png },
+      { rootDir, include: ['phash'] },
+    );
+    expect(result.parts).toEqual(['phash.json']);
+    const payload = readJson(path.join(result.path, 'phash.json')) as {
+      algorithm: string;
+      hash_hex: string;
+    };
+    expect(payload.algorithm).toBe('dct-ii-8x8');
+    expect(payload.hash_hex).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test("include=['screenshot', 'phash']: both parts written from one PNG", () => {
+    const rootDir = mkRoot();
+    const png = encodeRgbaPng(16, 16, gradientRgba(16, 16));
+    const result = writeEvidenceBundle(
+      { screenshot_png: png },
+      { rootDir, include: ['screenshot', 'phash'] },
+    );
+    expect(result.parts.sort()).toEqual(['phash.json', 'screenshot.png']);
+  });
+});
+
+describe('writeEvidenceBundle — graceful fallthrough', () => {
+  test('no snapshot at all: bundle dir exists but parts is empty', () => {
+    const rootDir = mkRoot();
+    const result = writeEvidenceBundle({}, { rootDir });
+    expect(result.parts).toEqual([]);
+    expect(result.size_bytes).toBe(0);
+    expect(fs.existsSync(result.path)).toBe(true);
+  });
+
+  test("include=['phash'] without a screenshot: phash part omitted", () => {
+    const rootDir = mkRoot();
+    const result = writeEvidenceBundle({}, { rootDir, include: ['phash'] });
+    expect(result.parts).toEqual([]);
+  });
+
+  test('include with unknown items: filtered to empty (no defaults applied)', () => {
+    const rootDir = mkRoot();
+    const result = writeEvidenceBundle(
+      { dom: '<x/>' },
+      { rootDir, include: ['bogus' as unknown as 'dom'] },
+    );
+    expect(result.parts).toEqual([]);
+  });
+
+  test('include=[] (empty array): falls back to DEFAULT_INCLUDE', () => {
+    const rootDir = mkRoot();
+    const png = encodeRgbaPng(8, 8, gradientRgba(8, 8));
+    const result = writeEvidenceBundle(
+      { dom: '<x/>', screenshot_png: png },
+      { rootDir, include: [] },
+    );
+    expect(result.parts.sort()).toEqual(['dom.json', 'screenshot.png']);
+  });
+
+  test("include=['phash'] with corrupt PNG: phash skipped, no throw", () => {
+    const rootDir = mkRoot();
+    const corrupt = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+    const result = writeEvidenceBundle(
+      { screenshot_png: corrupt },
+      { rootDir, include: ['phash'] },
+    );
+    expect(result.parts).toEqual([]);
+  });
+
+  test('include=["network"] with no network field: network part omitted', () => {
+    const rootDir = mkRoot();
+    const result = writeEvidenceBundle({}, { rootDir, include: ['network'] });
+    expect(result.parts).toEqual([]);
+  });
+
+  test('network entries without timestamps: kept as recent (within window)', () => {
+    const rootDir = mkRoot();
+    const result = writeEvidenceBundle(
+      { network: [{ url: 'a.com' }, { url: 'b.com' }], now_ms: 1_000_000 },
+      { rootDir, include: ['network'], networkWindowMs: 5_000 },
+    );
+    const payload = readJson(path.join(result.path, 'network.json')) as {
+      entries: Array<{ url: string }>;
+    };
+    expect(payload.entries.map((e) => e.url)).toEqual(['a.com', 'b.com']);
+  });
+});
+
+describe('writeEvidenceBundle — bundle metadata', () => {
+  test('bundle_id is a UUID and uniqueness holds across calls', () => {
+    const rootDir = mkRoot();
+    const a = writeEvidenceBundle({ dom: 'a' }, { rootDir });
+    const b = writeEvidenceBundle({ dom: 'b' }, { rootDir });
+    expect(a.bundle_id).not.toBe(b.bundle_id);
+    expect(a.bundle_id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(b.bundle_id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  test('size_bytes matches the sum of written file sizes', () => {
+    const rootDir = mkRoot();
+    const png = encodeRgbaPng(8, 8, gradientRgba(8, 8));
+    const result = writeEvidenceBundle(
+      { dom: 'hello', screenshot_png: png },
+      { rootDir },
+    );
+    const onDisk = result.parts.reduce(
+      (acc, part) => acc + fs.statSync(path.join(result.path, part)).size,
+      0,
+    );
+    expect(result.size_bytes).toBe(onDisk);
+  });
+});

--- a/tests/cross-env/cursor-verification.test.ts
+++ b/tests/cross-env/cursor-verification.test.ts
@@ -135,16 +135,16 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
   describe('C2: Tool Discovery & Listing', () => {
     let tier1Tools: any[];
 
-    test('Initial tools/list returns Tier 1 tools only (35 tools) + expand_tools', async () => {
+    test('Initial tools/list returns Tier 1 tools only (36 tools) + expand_tools', async () => {
       const { response } = await sendAndReceive(server, 'tools/list');
       tier1Tools = response.result.tools;
-      // 35 Tier 1 tools (includes oc_reap_orphans lifecycle sweep, oc_assert)
-      // + 1 expand_tools virtual tool = 36
+      // 36 Tier 1 tools (includes oc_reap_orphans lifecycle sweep, oc_assert,
+      // oc_evidence_bundle) + 1 expand_tools virtual tool = 37
       const toolNames = tier1Tools.map((t: any) => t.name);
       expect(toolNames).toContain('expand_tools');
 
       const nonExpandTools = tier1Tools.filter((t: any) => t.name !== 'expand_tools');
-      expect(nonExpandTools.length).toBe(35);
+      expect(nonExpandTools.length).toBe(36);
     });
 
     test('expand_tools virtual tool present in initial list', () => {


### PR DESCRIPTION
## Summary

- Adds Tier 1 MCP tool `oc_evidence_bundle` that captures a snapshot of the current page state (DOM, screenshot, network HAR slice, console, perceptual hash) into a flat bundle directory under `<rootDir>/<bundle_id>/`.
- Standalone core-tier tool — does **not** depend on the pilot contract runtime. Future PRs can have `oc_assert` (#784) materialize its `evidence_handle` through this surface.
- Reuses the existing DCT-II `phashFromPng` helper from `src/contracts/phash.ts`. No new runtime dependencies; flat directory layout instead of a ZIP archive since the repo intentionally avoids an `archiver` dep at this point.

## Implementation

- `src/core/contracts/evidence-bundle.ts` — pure helper that writes the requested parts to disk. Defaults: `include = ['dom', 'screenshot']`, `network_window_ms = 5000`, console cap = 200 entries. Missing inputs fall through gracefully (the corresponding part is simply omitted from `parts`).
- `src/tools/oc-evidence-bundle.ts` — MCP tool surface, accepts a caller-supplied `evidence.snapshot` (mirrors the `oc_assert` pattern from #784).
- `src/tools/index.ts` and `src/config/tool-tiers.ts` — registered as Tier 1.
- `tests/cross-env/cursor-verification.test.ts` — snapshot tool count bumped 35 → 36.

## References

- Closes #792
- Builds on #784 (`oc_assert`)
- References closed PR #751 (M2 PR-13) for bundle structure precedent
- Follows the core/pilot boundary established in PR #774

## Test plan

- [x] `npm run build` — pass
- [x] `npm run lint` — 0 errors (2 pre-existing warnings in unrelated `src/core/skill/storage.ts`)
- [x] `npm run lint:tier` — 0 violations
- [x] `npx jest tests/core/contracts/evidence-bundle.test.ts` — 20/20 passing
- [x] `npx jest tests/core/contracts/` — 35/35 passing (oc-assert + evidence-bundle)
- [ ] Reviewer: verify the snapshot tool count bump in `tests/cross-env/cursor-verification.test.ts` does not need adjustment elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)