### PR TITLE
feat(core): JSON-per-domain skill memory store (Phase 3, replaces #762 storage half)

### DIFF
--- a/src/core/skill-memory/index.ts
+++ b/src/core/skill-memory/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Core skill memory barrel (#712 epic, Phase 3 cleanup).
+ *
+ * Exposes only the storage primitive — the recall ranking layer is
+ * pilot-tier work and lives under `src/pilot/**`.
+ */
+
+export {
+  SkillMemoryStore,
+  defaultSkillMemoryRootDir,
+} from './store';
+export type {
+  ListFilter,
+  RecordResult,
+  SkillMemoryStoreOptions,
+  WriteFrozenSnapshotResult,
+} from './store';
+
+export { SKILL_MEMORY_SCHEMA_VERSION } from './types';
+export type { FrozenSnapshot, SkillMemoryFile, SkillRecord } from './types';

--- a/src/core/skill-memory/store.ts
+++ b/src/core/skill-memory/store.ts
@@ -1,0 +1,454 @@
+/**
+ * JSON-per-domain skill memory store (#712 epic, Phase 3 cleanup —
+ * replaces the storage half of closed PR #762).
+ *
+ * On-disk layout under `rootDir`:
+ *
+ *   <rootDir>/
+ *     <encodedDomain>/
+ *       skills.json                       -- SkillMemoryFile (atomic writes)
+ *       .lock                             -- proper-lockfile coordination
+ *       snapshots/
+ *         <snapshotId>.json.gz            -- gzipped frozen snapshot
+ *
+ * Per portability-harness contract P5 (Native dependency discipline —
+ * argon2 only) this storage layer uses plain filesystem primitives plus
+ * the already-vendored `proper-lockfile` and Node's built-in `zlib`.
+ * No SQLite, no native binary deps.
+ *
+ * Write coordination is per-domain: two `SkillMemoryStore` instances
+ * targeting *different* domains can run fully in parallel because each
+ * domain has its own lock file. Within a domain, writes serialize via
+ * `acquireLock`. `record()` is idempotent on `(domain, name)` so retried
+ * extractor flushes do not produce duplicate skills.
+ *
+ * The recall *ranking* logic (relevance score, recency weighting,
+ * LLM-facing payload sizing) is pilot-tier work and is intentionally
+ * deferred to a separate issue. `list()` here returns an unranked
+ * listing sorted by `last_used_at desc` for deterministic order — the
+ * pilot recall layer is expected to rerank.
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as zlib from 'node:zlib';
+
+import { acquireLock, writeFileAtomicSafe } from '../../utils/atomic-file';
+
+import {
+  SKILL_MEMORY_SCHEMA_VERSION,
+  type FrozenSnapshot,
+  type SkillMemoryFile,
+  type SkillRecord,
+} from './types';
+
+export interface SkillMemoryStoreOptions {
+  /** Root directory for per-domain skills.json + snapshot files. */
+  rootDir?: string;
+  /** Domain this store instance is bound to. Required. */
+  domain: string;
+}
+
+export interface RecordResult {
+  /** The skill_id assigned (existing one on idempotent re-record). */
+  skill_id: string;
+  /** Wall-clock ms epoch when the record completed. */
+  stored_at: number;
+}
+
+export interface ListFilter {
+  /** Restrict to a single contract_id. */
+  contract_id?: string;
+  /** Cap the number of records returned (default: unlimited). */
+  limit?: number;
+}
+
+export interface WriteFrozenSnapshotResult {
+  /** Absolute path to the gzipped snapshot on disk. */
+  snapshot_path: string;
+}
+
+/** Default rootDir resolves to `${HOME}/.openchrome/skill-memory`. */
+export function defaultSkillMemoryRootDir(): string {
+  return path.join(os.homedir(), '.openchrome', 'skill-memory');
+}
+
+/**
+ * Windows reserved device names. Even on POSIX we prefix these so a
+ * domain recorded on Linux is round-trippable on Windows without
+ * collision. `CON`, `PRN`, `AUX`, `NUL`, `COM1..9`, `LPT1..9` (with or
+ * without an extension) are unusable as directory basenames on Windows.
+ */
+const WINDOWS_RESERVED = /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\..*)?$/i;
+
+/**
+ * Encode a domain string into a filesystem-safe directory basename.
+ *
+ * Domains arrive as eTLD+1 hosts (e.g. `amazon.com`) but the surface is
+ * declared as `string` so we cannot assume well-formed input. The
+ * encoding here is lossless enough to round-trip via `decodeURIComponent`
+ * but the store itself never decodes — the domain is also stored
+ * verbatim inside each `SkillRecord`. Encoding only governs the *path*.
+ */
+function encodeDomain(domain: string): string {
+  if (typeof domain !== 'string' || domain.length === 0) {
+    throw new Error('SkillMemoryStore: domain must be a non-empty string');
+  }
+  if (domain.length > 253) {
+    // RFC 1035 maximum DNS name length. Anything longer is almost
+    // certainly an attacker probe rather than a real host.
+    throw new Error(`SkillMemoryStore: domain too long (${domain.length} chars; max 253)`);
+  }
+  // Reject NUL and control characters outright — they are never valid
+  // host components and only ever appear in path-traversal probes.
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(domain)) {
+    throw new Error('SkillMemoryStore: domain contains a control character');
+  }
+  // Percent-encode anything that is not an unreserved DNS label
+  // character. This handles `.` (preserved), `/`, `\`, `:`, and
+  // anything else a creative caller might pass.
+  const encoded = domain.replace(/[^a-zA-Z0-9._-]/g, (ch) => {
+    return '%' + ch.charCodeAt(0).toString(16).padStart(2, '0').toUpperCase();
+  });
+  return WINDOWS_RESERVED.test(encoded) ? `_${encoded}` : encoded;
+}
+
+/**
+ * Reject snapshot IDs that would let a caller escape the snapshots
+ * directory via `path.join`. Same conservative basename policy as the
+ * trace storage uses for session IDs.
+ */
+function assertSafeSnapshotId(snapshotId: string): void {
+  if (typeof snapshotId !== 'string' || snapshotId.length === 0) {
+    throw new Error('SkillMemoryStore: snapshot_id must be a non-empty string');
+  }
+  if (snapshotId.length > 200) {
+    throw new Error(
+      `SkillMemoryStore: snapshot_id too long (${snapshotId.length} chars; max 200)`,
+    );
+  }
+  if (snapshotId === '.' || snapshotId === '..' || snapshotId.startsWith('.')) {
+    throw new Error(`SkillMemoryStore: snapshot_id "${snapshotId}" begins with a dot (reserved)`);
+  }
+  if (/[\\/\0]/.test(snapshotId)) {
+    throw new Error(
+      `SkillMemoryStore: snapshot_id "${snapshotId}" contains a path separator or NUL`,
+    );
+  }
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(snapshotId)) {
+    throw new Error(
+      `SkillMemoryStore: snapshot_id "${snapshotId}" contains a control character`,
+    );
+  }
+}
+
+/**
+ * Deterministic skill_id derived from (domain, name). Stable across
+ * process restarts so `record()` is idempotent without needing a
+ * separate uniqueness index.
+ */
+function computeSkillId(domain: string, name: string): string {
+  return crypto
+    .createHash('sha256')
+    .update(`${domain}\x00${name}`, 'utf8')
+    .digest('hex')
+    .slice(0, 16);
+}
+
+/**
+ * JSON-per-domain skill memory store. One instance is bound to a single
+ * domain; cross-domain workloads should construct one store per domain
+ * so locks do not contend. The instance is safe to share across async
+ * call sites — per-domain serialisation runs through `proper-lockfile`.
+ */
+export class SkillMemoryStore {
+  private readonly rootDir: string;
+  private readonly domain: string;
+  private readonly encodedDomain: string;
+  /** Lazy-init flag — we do not touch the filesystem in the constructor. */
+  private rootEnsured = false;
+
+  constructor(opts: SkillMemoryStoreOptions) {
+    if (!opts || typeof opts.domain !== 'string' || opts.domain.length === 0) {
+      throw new Error('SkillMemoryStore: opts.domain is required');
+    }
+    this.rootDir = opts.rootDir ?? defaultSkillMemoryRootDir();
+    this.domain = opts.domain;
+    this.encodedDomain = encodeDomain(opts.domain);
+  }
+
+  /** Ensure the per-domain directory exists exactly once per instance. */
+  private ensureDomainDir(): string {
+    const dir = this.domainDir();
+    if (!this.rootEnsured) {
+      fs.mkdirSync(dir, { recursive: true });
+      this.rootEnsured = true;
+    }
+    return dir;
+  }
+
+  /** Directory holding `skills.json` + `snapshots/` for this domain. */
+  private domainDir(): string {
+    return path.join(this.rootDir, this.encodedDomain);
+  }
+
+  /** Path to the per-domain skills.json. */
+  private skillsFile(): string {
+    return path.join(this.domainDir(), 'skills.json');
+  }
+
+  /** Path to the per-domain lock file used by `proper-lockfile`. */
+  private lockFile(): string {
+    return path.join(this.domainDir(), '.lock');
+  }
+
+  /** Path to the per-domain snapshots directory. */
+  private snapshotsDir(): string {
+    return path.join(this.domainDir(), 'snapshots');
+  }
+
+  /**
+   * Read skills.json synchronously. Returns an empty file shape when
+   * the file is missing, malformed, or stamped with an unknown schema
+   * version. The schema-mismatch case is logged via `console.error`
+   * (per project rule — `console.log` collides with MCP JSON-RPC) so
+   * operators can spot the rollback path during upgrades.
+   */
+  private readFileSync(): SkillMemoryFile {
+    const file = this.skillsFile();
+    if (!fs.existsSync(file)) {
+      return { schema_version: SKILL_MEMORY_SCHEMA_VERSION, skills: {} };
+    }
+    let raw: string;
+    try {
+      raw = fs.readFileSync(file, 'utf8');
+    } catch {
+      return { schema_version: SKILL_MEMORY_SCHEMA_VERSION, skills: {} };
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { schema_version: SKILL_MEMORY_SCHEMA_VERSION, skills: {} };
+    }
+    if (!parsed || typeof parsed !== 'object') {
+      return { schema_version: SKILL_MEMORY_SCHEMA_VERSION, skills: {} };
+    }
+    const obj = parsed as Partial<SkillMemoryFile>;
+    if (obj.schema_version !== SKILL_MEMORY_SCHEMA_VERSION) {
+      console.error(
+        `SkillMemoryStore: skipping ${file} — unknown schema_version=${String(obj.schema_version)}`,
+      );
+      return { schema_version: SKILL_MEMORY_SCHEMA_VERSION, skills: {} };
+    }
+    if (!obj.skills || typeof obj.skills !== 'object') {
+      return { schema_version: SKILL_MEMORY_SCHEMA_VERSION, skills: {} };
+    }
+    return { schema_version: SKILL_MEMORY_SCHEMA_VERSION, skills: obj.skills as Record<string, SkillRecord> };
+  }
+
+  /** Persist skills.json atomically (temp + rename via write-file-atomic). */
+  private async writeFile(file: SkillMemoryFile): Promise<void> {
+    await writeFileAtomicSafe(this.skillsFile(), JSON.stringify(file, null, 2));
+  }
+
+  /**
+   * Insert / update a skill record. Idempotent on `(domain, name)`:
+   * calling `record()` twice with the same name updates the existing
+   * record's mutable fields (`steps`, `contract_id`, `frozen_snapshot_path`,
+   * counter resets) but keeps the same `skill_id`. The persisted
+   * `success_count` and `last_used_at` are preserved across re-records
+   * — only `markUsed` mutates those.
+   *
+   * Returns the assigned `skill_id` and the wall-clock ms `stored_at`.
+   */
+  async record(skill: Omit<SkillRecord, 'skillId'> & { skillId?: string }): Promise<RecordResult> {
+    if (skill.domain !== this.domain) {
+      throw new Error(
+        `SkillMemoryStore: domain mismatch — store bound to "${this.domain}", record carries "${skill.domain}"`,
+      );
+    }
+    if (typeof skill.name !== 'string' || skill.name.length === 0) {
+      throw new Error('SkillMemoryStore: skill.name must be a non-empty string');
+    }
+    this.ensureDomainDir();
+    const release = await acquireLock(this.lockFile());
+    try {
+      const file = this.readFileSync();
+      // Locate an existing record by name (idempotency key is
+      // (domain, name) per the contract). The map key is skill_id, so
+      // we scan once — the count of skills per domain is small enough
+      // (low hundreds) that O(n) scan is well below any lock-hold budget.
+      let existingId: string | null = null;
+      for (const [id, rec] of Object.entries(file.skills)) {
+        if (rec.name === skill.name) {
+          existingId = id;
+          break;
+        }
+      }
+      const skillId = existingId ?? skill.skillId ?? computeSkillId(skill.domain, skill.name);
+      const existing = existingId ? file.skills[existingId] : undefined;
+      const next: SkillRecord = {
+        skillId,
+        domain: skill.domain,
+        name: skill.name,
+        steps: skill.steps,
+        contractId: skill.contractId,
+        // Preserve usage stats across idempotent re-records — only
+        // markUsed should bump these. New records start at the
+        // caller-supplied value (typically 0).
+        successCount: existing ? existing.successCount : skill.successCount,
+        lastUsedAt: existing ? existing.lastUsedAt : skill.lastUsedAt,
+        // `frozen_snapshot_path` is also caller-managed via
+        // writeFrozenSnapshot; re-record without an explicit override
+        // keeps the previously-recorded value.
+        frozenSnapshotPath: skill.frozenSnapshotPath ?? existing?.frozenSnapshotPath ?? null,
+      };
+      file.skills[skillId] = next;
+      await this.writeFile(file);
+      return { skill_id: skillId, stored_at: Date.now() };
+    } finally {
+      await release();
+    }
+  }
+
+  /** Look up a single skill by id. Returns null on miss. */
+  get(skillId: string): SkillRecord | null {
+    if (typeof skillId !== 'string' || skillId.length === 0) return null;
+    if (!fs.existsSync(this.skillsFile())) return null;
+    const file = this.readFileSync();
+    return file.skills[skillId] ?? null;
+  }
+
+  /**
+   * Unranked listing sorted by `last_used_at` descending (ties broken
+   * by `skill_id` ascending for byte-stable output). The pilot recall
+   * layer is responsible for any LLM-facing reranking.
+   */
+  list(filter: ListFilter = {}): SkillRecord[] {
+    if (!fs.existsSync(this.skillsFile())) return [];
+    const file = this.readFileSync();
+    let rows = Object.values(file.skills);
+    if (filter.contract_id !== undefined) {
+      rows = rows.filter((r) => r.contractId === filter.contract_id);
+    }
+    rows.sort((a, b) => {
+      if (a.lastUsedAt !== b.lastUsedAt) return b.lastUsedAt - a.lastUsedAt;
+      return a.skillId.localeCompare(b.skillId);
+    });
+    if (filter.limit !== undefined && filter.limit >= 0) {
+      rows = rows.slice(0, filter.limit);
+    }
+    return rows;
+  }
+
+  /**
+   * Mark a skill as used at `ts` (ms epoch). When `success` is true,
+   * `success_count` is incremented. `last_used_at` is updated
+   * unconditionally so the deterministic-order list reflects most-recent
+   * activity regardless of outcome.
+   *
+   * Throws if the skill_id is unknown — callers should not be calling
+   * `markUsed` on something they never `record`-ed.
+   */
+  async markUsed(skillId: string, ts: number, success: boolean): Promise<void> {
+    if (typeof skillId !== 'string' || skillId.length === 0) {
+      throw new Error('SkillMemoryStore.markUsed: skill_id must be a non-empty string');
+    }
+    if (!Number.isFinite(ts)) {
+      throw new Error('SkillMemoryStore.markUsed: ts must be a finite number');
+    }
+    this.ensureDomainDir();
+    const release = await acquireLock(this.lockFile());
+    try {
+      const file = this.readFileSync();
+      const existing = file.skills[skillId];
+      if (!existing) {
+        throw new Error(`SkillMemoryStore.markUsed: unknown skill_id=${skillId}`);
+      }
+      const next: SkillRecord = {
+        ...existing,
+        lastUsedAt: ts,
+        successCount: success ? existing.successCount + 1 : existing.successCount,
+      };
+      file.skills[skillId] = next;
+      await this.writeFile(file);
+    } finally {
+      await release();
+    }
+  }
+
+  /**
+   * Write a frozen snapshot to
+   * `<rootDir>/<encodedDomain>/snapshots/<snapshotId>.json.gz`.
+   *
+   * Snapshots are write-once: if the destination already exists, the
+   * call fails fast rather than overwriting. This matches the
+   * frozen-snapshot semantics the recall layer expects — once a
+   * snapshot is captured for a `(session_id, skill_id)` pair, hosts
+   * should never see a different payload at the same path.
+   *
+   * The `skill_id` argument is used as the on-disk basename so callers
+   * do not have to manage their own snapshot IDs. Callers needing
+   * versioned snapshots for the same skill should embed the version in
+   * the snapshot payload itself.
+   */
+  writeFrozenSnapshot(skillId: string, snapshot: FrozenSnapshot): WriteFrozenSnapshotResult {
+    assertSafeSnapshotId(skillId);
+    this.ensureDomainDir();
+    const dir = this.snapshotsDir();
+    fs.mkdirSync(dir, { recursive: true });
+    const target = path.join(dir, `${skillId}.json.gz`);
+    if (fs.existsSync(target)) {
+      throw new Error(
+        `SkillMemoryStore.writeFrozenSnapshot: snapshot already exists at ${target} (snapshots are write-once)`,
+      );
+    }
+    const json = JSON.stringify(snapshot);
+    const gzipped = zlib.gzipSync(Buffer.from(json, 'utf8'));
+    // Write to a sibling temp file then rename so a crash mid-write
+    // never leaves a half-gzipped blob at the target path.
+    const tmp = `${target}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(tmp, gzipped);
+    try {
+      fs.renameSync(tmp, target);
+    } catch (err) {
+      try {
+        fs.unlinkSync(tmp);
+      } catch {
+        // best-effort
+      }
+      throw err;
+    }
+    return { snapshot_path: target };
+  }
+
+  /**
+   * Read and gunzip a frozen snapshot. Accepts any absolute path
+   * returned by a prior `writeFrozenSnapshot` call (callers normally
+   * just plumb the path through from `SkillRecord.frozenSnapshotPath`).
+   *
+   * The path is validated to live inside this store's snapshots
+   * directory so a hostile caller cannot abuse the API as an arbitrary
+   * file reader.
+   */
+  readFrozenSnapshot(snapshotPath: string): FrozenSnapshot {
+    if (typeof snapshotPath !== 'string' || snapshotPath.length === 0) {
+      throw new Error('SkillMemoryStore.readFrozenSnapshot: path must be a non-empty string');
+    }
+    const resolved = path.resolve(snapshotPath);
+    const root = path.resolve(this.snapshotsDir());
+    if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+      throw new Error(
+        `SkillMemoryStore.readFrozenSnapshot: path "${snapshotPath}" is outside the domain snapshots dir`,
+      );
+    }
+    const raw = fs.readFileSync(resolved);
+    const json = zlib.gunzipSync(raw).toString('utf8');
+    return JSON.parse(json) as FrozenSnapshot;
+  }
+}

--- a/src/core/skill-memory/types.ts
+++ b/src/core/skill-memory/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Skill memory storage types (#712 epic, Phase 3 cleanup — replaces the
+ * storage half of closed PR #762).
+ *
+ * The persisted shape is one JSON file per domain:
+ *
+ *   <rootDir>/<encodedDomain>/skills.json
+ *
+ * with the structure:
+ *
+ *   { schema_version: 1, skills: { [skill_id]: SkillRecord } }
+ *
+ * `schema_version: 1` is mandatory. Future field additions bump the
+ * value; the store ignores files with an unknown schema rather than
+ * crashing the load path.
+ *
+ * The recall *ranking* logic (relevance score, recency weighting,
+ * LLM-facing payload sizing) is pilot-tier work and intentionally lives
+ * outside this module. Core only owns the storage primitive.
+ */
+
+export const SKILL_MEMORY_SCHEMA_VERSION = 1;
+
+/**
+ * A single stored skill.
+ *
+ * Field correspondence with the original SQL schema sketch
+ * `skills(skill_id PK, domain, name, steps_json, contract_id,
+ *  success_count, last_used_at, frozen_snapshot_path)`:
+ *
+ *   skill_id              -> skillId
+ *   domain                -> domain
+ *   name                  -> name
+ *   steps_json            -> steps (already-parsed JSON; the file
+ *                            stores it inline rather than as an
+ *                            opaque string so the JSON-per-domain
+ *                            file remains human-inspectable)
+ *   contract_id           -> contractId
+ *   success_count         -> successCount
+ *   last_used_at          -> lastUsedAt (ms epoch; 0 means never used)
+ *   frozen_snapshot_path  -> frozenSnapshotPath (absolute path; null
+ *                            until a snapshot is written)
+ */
+export interface SkillRecord {
+  skillId: string;
+  domain: string;
+  name: string;
+  steps: unknown;
+  contractId: string;
+  successCount: number;
+  lastUsedAt: number;
+  frozenSnapshotPath: string | null;
+}
+
+/** On-disk shape for `<rootDir>/<encodedDomain>/skills.json`. */
+export interface SkillMemoryFile {
+  schema_version: typeof SKILL_MEMORY_SCHEMA_VERSION;
+  skills: Record<string, SkillRecord>;
+}
+
+/**
+ * A frozen snapshot is an opaque blob written exactly once by the
+ * caller. The store gzips it and persists it under
+ * `<rootDir>/<encodedDomain>/snapshots/<snapshotId>.json.gz`.
+ */
+export interface FrozenSnapshot {
+  /**
+   * Free-form payload. The store performs no schema validation — it
+   * is the caller's responsibility to ship a JSON-serialisable object
+   * with whatever fields the pilot recall layer needs.
+   */
+  [key: string]: unknown;
+}

--- a/tests/core/skill-memory/store.test.ts
+++ b/tests/core/skill-memory/store.test.ts
@@ -1,0 +1,363 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as zlib from 'node:zlib';
+
+import {
+  SKILL_MEMORY_SCHEMA_VERSION,
+  SkillMemoryStore,
+  type SkillRecord,
+} from '../../../src/core/skill-memory';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-skill-mem-'));
+}
+
+function baseRecord(overrides: Partial<SkillRecord> = {}): Omit<SkillRecord, 'skillId'> {
+  return {
+    domain: 'amazon.com',
+    name: 'add-to-cart',
+    steps: [{ kind: 'click', selector: '#buy-now' }],
+    contractId: 'contract-1',
+    successCount: 0,
+    lastUsedAt: 0,
+    frozenSnapshotPath: null,
+    ...overrides,
+  };
+}
+
+describe('SkillMemoryStore — construction', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = tempRoot();
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('throws when domain is missing', () => {
+    expect(
+      () => new SkillMemoryStore({ rootDir: root, domain: '' }),
+    ).toThrow(/domain is required/);
+  });
+
+  test('throws when domain contains a control character', () => {
+    expect(
+      () => new SkillMemoryStore({ rootDir: root, domain: 'foo\x00.com' }),
+    ).toThrow(/control character/);
+  });
+
+  test('throws when domain is longer than 253 chars', () => {
+    const longDomain = 'a'.repeat(254);
+    expect(
+      () => new SkillMemoryStore({ rootDir: root, domain: longDomain }),
+    ).toThrow(/domain too long/);
+  });
+
+  test('does not touch the filesystem in the constructor (lazy init)', () => {
+    const lazyRoot = path.join(os.tmpdir(), `oc-skill-mem-lazy-${Date.now()}-${Math.random()}`);
+    expect(fs.existsSync(lazyRoot)).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const _s = new SkillMemoryStore({ rootDir: lazyRoot, domain: 'amazon.com' });
+    expect(fs.existsSync(lazyRoot)).toBe(false);
+  });
+});
+
+describe('SkillMemoryStore — record / get / list', () => {
+  let root: string;
+  let store: SkillMemoryStore;
+
+  beforeEach(() => {
+    root = tempRoot();
+    store = new SkillMemoryStore({ rootDir: root, domain: 'amazon.com' });
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('record persists a skill and returns a stable id', async () => {
+    const res = await store.record(baseRecord());
+    expect(typeof res.skill_id).toBe('string');
+    expect(res.skill_id.length).toBeGreaterThan(0);
+    expect(typeof res.stored_at).toBe('number');
+    const got = store.get(res.skill_id);
+    expect(got).toBeDefined();
+    expect(got?.domain).toBe('amazon.com');
+    expect(got?.name).toBe('add-to-cart');
+    expect(got?.contractId).toBe('contract-1');
+  });
+
+  test('record is idempotent on (domain, name) and preserves usage stats', async () => {
+    const first = await store.record(baseRecord());
+    // Simulate prior usage via markUsed before re-recording.
+    await store.markUsed(first.skill_id, 5000, true);
+    await store.markUsed(first.skill_id, 6000, true);
+    const second = await store.record(
+      baseRecord({
+        // Different steps_json + contract_id should override; counters
+        // and last_used_at must NOT reset.
+        steps: [{ kind: 'click', selector: '#buy-now-v2' }],
+        contractId: 'contract-2',
+      }),
+    );
+    expect(second.skill_id).toBe(first.skill_id);
+    const got = store.get(first.skill_id);
+    expect(got?.contractId).toBe('contract-2');
+    expect(got?.successCount).toBe(2);
+    expect(got?.lastUsedAt).toBe(6000);
+    expect(got?.steps).toEqual([{ kind: 'click', selector: '#buy-now-v2' }]);
+  });
+
+  test('record rejects domain mismatch with the store binding', async () => {
+    await expect(
+      store.record(baseRecord({ domain: 'other.com' })),
+    ).rejects.toThrow(/domain mismatch/);
+  });
+
+  test('record rejects empty name', async () => {
+    await expect(
+      store.record(baseRecord({ name: '' })),
+    ).rejects.toThrow(/name must be a non-empty string/);
+  });
+
+  test('get returns null on miss', () => {
+    expect(store.get('nope')).toBeNull();
+    expect(store.get('')).toBeNull();
+  });
+
+  test('list returns rows sorted by last_used_at desc, ties by skill_id asc', async () => {
+    const a = await store.record(baseRecord({ name: 'a' }));
+    const b = await store.record(baseRecord({ name: 'b' }));
+    const c = await store.record(baseRecord({ name: 'c' }));
+    await store.markUsed(b.skill_id, 1000, true);
+    await store.markUsed(a.skill_id, 2000, true);
+    // c untouched -> last_used_at stays 0
+    const rows = store.list();
+    expect(rows).toHaveLength(3);
+    expect(rows[0].skillId).toBe(a.skill_id);
+    expect(rows[1].skillId).toBe(b.skill_id);
+    expect(rows[2].skillId).toBe(c.skill_id);
+  });
+
+  test('list filters by contract_id', async () => {
+    await store.record(baseRecord({ name: 'a', contractId: 'k-1' }));
+    await store.record(baseRecord({ name: 'b', contractId: 'k-2' }));
+    await store.record(baseRecord({ name: 'c', contractId: 'k-1' }));
+    const filtered = store.list({ contract_id: 'k-1' });
+    expect(filtered).toHaveLength(2);
+    for (const row of filtered) {
+      expect(row.contractId).toBe('k-1');
+    }
+  });
+
+  test('list respects limit', async () => {
+    await store.record(baseRecord({ name: 'a' }));
+    await store.record(baseRecord({ name: 'b' }));
+    await store.record(baseRecord({ name: 'c' }));
+    expect(store.list({ limit: 2 })).toHaveLength(2);
+    expect(store.list({ limit: 0 })).toHaveLength(0);
+  });
+
+  test('list on a fresh store returns []', () => {
+    expect(store.list()).toEqual([]);
+  });
+});
+
+describe('SkillMemoryStore — markUsed', () => {
+  let root: string;
+  let store: SkillMemoryStore;
+
+  beforeEach(() => {
+    root = tempRoot();
+    store = new SkillMemoryStore({ rootDir: root, domain: 'amazon.com' });
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('increments success_count only when success=true', async () => {
+    const { skill_id } = await store.record(baseRecord());
+    await store.markUsed(skill_id, 1000, true);
+    await store.markUsed(skill_id, 2000, false);
+    await store.markUsed(skill_id, 3000, true);
+    const got = store.get(skill_id);
+    expect(got?.successCount).toBe(2);
+    expect(got?.lastUsedAt).toBe(3000);
+  });
+
+  test('updates last_used_at even on failure', async () => {
+    const { skill_id } = await store.record(baseRecord());
+    await store.markUsed(skill_id, 1234, false);
+    expect(store.get(skill_id)?.lastUsedAt).toBe(1234);
+    expect(store.get(skill_id)?.successCount).toBe(0);
+  });
+
+  test('throws on unknown skill_id', async () => {
+    await expect(store.markUsed('missing', 1, true)).rejects.toThrow(/unknown skill_id/);
+  });
+
+  test('rejects non-finite ts', async () => {
+    const { skill_id } = await store.record(baseRecord());
+    await expect(store.markUsed(skill_id, Number.NaN, true)).rejects.toThrow(/finite number/);
+  });
+});
+
+describe('SkillMemoryStore — frozen snapshots', () => {
+  let root: string;
+  let store: SkillMemoryStore;
+
+  beforeEach(() => {
+    root = tempRoot();
+    store = new SkillMemoryStore({ rootDir: root, domain: 'amazon.com' });
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('writeFrozenSnapshot gzip-encodes JSON to disk', () => {
+    const { snapshot_path } = store.writeFrozenSnapshot('skill-1', { hello: 'world', n: 42 });
+    expect(snapshot_path.endsWith(`${path.sep}skill-1.json.gz`)).toBe(true);
+    const raw = fs.readFileSync(snapshot_path);
+    const decoded = JSON.parse(zlib.gunzipSync(raw).toString('utf8')) as Record<string, unknown>;
+    expect(decoded).toEqual({ hello: 'world', n: 42 });
+  });
+
+  test('readFrozenSnapshot round-trips the payload', () => {
+    const payload = { steps: [1, 2, 3], meta: { author: 'agent' } };
+    const { snapshot_path } = store.writeFrozenSnapshot('skill-rt', payload);
+    expect(store.readFrozenSnapshot(snapshot_path)).toEqual(payload);
+  });
+
+  test('snapshots are write-once', () => {
+    store.writeFrozenSnapshot('skill-once', { v: 1 });
+    expect(() => store.writeFrozenSnapshot('skill-once', { v: 2 })).toThrow(/write-once/);
+  });
+
+  test('readFrozenSnapshot rejects paths outside the snapshots dir', () => {
+    store.writeFrozenSnapshot('skill-x', { v: 1 });
+    // Construct a sibling file that is NOT under snapshots/.
+    const outside = path.join(root, 'outside.json.gz');
+    fs.writeFileSync(outside, zlib.gzipSync(Buffer.from('{}', 'utf8')));
+    expect(() => store.readFrozenSnapshot(outside)).toThrow(/outside the domain snapshots dir/);
+  });
+
+  test('rejects unsafe snapshot ids', () => {
+    expect(() => store.writeFrozenSnapshot('', { v: 1 })).toThrow(/non-empty string/);
+    expect(() => store.writeFrozenSnapshot('foo/bar', { v: 1 })).toThrow(/path separator/);
+    expect(() => store.writeFrozenSnapshot('../escape', { v: 1 })).toThrow(/begins with a dot/);
+    expect(() => store.writeFrozenSnapshot('.hidden', { v: 1 })).toThrow(/begins with a dot/);
+  });
+});
+
+describe('SkillMemoryStore — file layout + schema', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = tempRoot();
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('writes one JSON file per domain with schema_version=1', async () => {
+    const a = new SkillMemoryStore({ rootDir: root, domain: 'amazon.com' });
+    const b = new SkillMemoryStore({ rootDir: root, domain: 'ebay.com' });
+    await a.record(baseRecord({ domain: 'amazon.com', name: 'cart' }));
+    await b.record(baseRecord({ domain: 'ebay.com', name: 'bid' }));
+    const aFile = path.join(root, 'amazon.com', 'skills.json');
+    const bFile = path.join(root, 'ebay.com', 'skills.json');
+    expect(fs.existsSync(aFile)).toBe(true);
+    expect(fs.existsSync(bFile)).toBe(true);
+    const parsed = JSON.parse(fs.readFileSync(aFile, 'utf8'));
+    expect(parsed.schema_version).toBe(SKILL_MEMORY_SCHEMA_VERSION);
+    expect(typeof parsed.skills).toBe('object');
+  });
+
+  test('domains with reserved Windows names get an underscore prefix', async () => {
+    const store = new SkillMemoryStore({ rootDir: root, domain: 'CON' });
+    await store.record({
+      domain: 'CON',
+      name: 'foo',
+      steps: [],
+      contractId: 'c',
+      successCount: 0,
+      lastUsedAt: 0,
+      frozenSnapshotPath: null,
+    });
+    expect(fs.existsSync(path.join(root, '_CON', 'skills.json'))).toBe(true);
+  });
+
+  test('unsafe domain characters are percent-encoded into the path', async () => {
+    const store = new SkillMemoryStore({ rootDir: root, domain: 'evil/../escape' });
+    await store.record({
+      domain: 'evil/../escape',
+      name: 'foo',
+      steps: [],
+      contractId: 'c',
+      successCount: 0,
+      lastUsedAt: 0,
+      frozenSnapshotPath: null,
+    });
+    // No traversal happened; everything ends up under a single basename
+    // (slashes are percent-encoded so `path.join` cannot escape root).
+    const entries = fs.readdirSync(root);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).not.toContain('/');
+    expect(entries[0]).not.toContain('\\');
+    expect(entries[0]).toContain('%2F');
+    // The reconstructed absolute path must still live inside root.
+    const reconstructed = path.resolve(root, entries[0]);
+    expect(reconstructed.startsWith(path.resolve(root) + path.sep)).toBe(true);
+  });
+
+  test('skips skills.json with an unknown schema_version', async () => {
+    const store = new SkillMemoryStore({ rootDir: root, domain: 'amazon.com' });
+    // Bootstrap the domain dir so we can plant a bad file in place.
+    await store.record(baseRecord());
+    const file = path.join(root, 'amazon.com', 'skills.json');
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ schema_version: 999, skills: { fake: {} } }),
+      'utf8',
+    );
+    // Silence the console.error from the schema-mismatch path so the
+    // jest output is not polluted.
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(store.list()).toEqual([]);
+      expect(store.get('fake')).toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('record across different domains does not contend (parallel safe)', async () => {
+    const a = new SkillMemoryStore({ rootDir: root, domain: 'amazon.com' });
+    const b = new SkillMemoryStore({ rootDir: root, domain: 'ebay.com' });
+    await Promise.all([
+      a.record(baseRecord({ domain: 'amazon.com', name: 'cart' })),
+      b.record(baseRecord({ domain: 'ebay.com', name: 'bid' })),
+    ]);
+    expect(a.list()).toHaveLength(1);
+    expect(b.list()).toHaveLength(1);
+  });
+
+  test('sequential records on the same domain serialize without dropping rows', async () => {
+    const store = new SkillMemoryStore({ rootDir: root, domain: 'amazon.com' });
+    // Run a small batch in parallel — the per-domain lock should
+    // serialise the writes so every name lands in the final file.
+    const names = ['a', 'b', 'c', 'd', 'e'];
+    await Promise.all(
+      names.map((n) =>
+        store.record(baseRecord({ name: n })),
+      ),
+    );
+    expect(store.list()).toHaveLength(names.length);
+  });
+});


### PR DESCRIPTION
## Summary

Reimplements **only the storage half** of closed PR #762 as a JSON-per-domain store backed by `proper-lockfile`. The recall-ranking layer that PR #762 also shipped is intentionally deferred to a follow-up issue — pilot-tier work that does not belong in `src/core/**`.

Per portability-harness contract P5 (Native dependency discipline — argon2 only): no SQLite, no native deps. Frozen snapshots gzip via Node's built-in `zlib`.

## Design

- **Layout**: `<rootDir>/<encodedDomain>/skills.json` with `{ schema_version: 1, skills: { [skill_id]: SkillRecord } }`.
- **Concurrency**: per-domain `proper-lockfile` (via `acquireLock` from `src/utils/atomic-file.ts`). Cross-domain workloads run fully in parallel because each domain has its own `.lock`.
- **Idempotency**: `record()` is idempotent on `(domain, name)` via a SHA-256-derived 16-hex `skill_id`. Re-records preserve `success_count` and `last_used_at` so retried extractor flushes do not reset stats.
- **Listing**: `list()` is unranked, sorted by `last_used_at desc` (ties by `skill_id asc`) for deterministic, byte-stable output. The pilot recall layer is expected to rerank.
- **Snapshots**: `writeFrozenSnapshot()` is write-once; gzipped JSON lives at `<rootDir>/<encodedDomain>/snapshots/<skill_id>.json.gz`. `readFrozenSnapshot()` rejects paths outside the per-domain snapshots dir.
- **Path safety**: domain names are percent-encoded into a single basename so `path.join(root, encoded)` cannot escape root; Windows-reserved device names (`CON`, `PRN`, `COM1`, ...) get a leading underscore.

## API (core scope only)

```ts
class SkillMemoryStore {
  constructor(opts: { rootDir?: string; domain: string });
  record(skill: SkillRecord): Promise<{ skill_id: string; stored_at: number }>;
  get(skill_id: string): SkillRecord | null;
  list(filter?: { contract_id?: string; limit?: number }): SkillRecord[];
  markUsed(skill_id: string, ts: number, success: boolean): Promise<void>;
  writeFrozenSnapshot(skill_id: string, snapshot: object): { snapshot_path: string };
  readFrozenSnapshot(path: string): object;
}
```

## Files

| File | Lines |
| --- | --- |
| `src/core/skill-memory/types.ts` | 73 |
| `src/core/skill-memory/store.ts` | 454 |
| `src/core/skill-memory/index.ts` | 20 |
| `tests/core/skill-memory/store.test.ts` | 363 |

## Verification

- [x] `npm run build` — pass
- [x] `npm run lint` — pass (0 errors; the 2 warnings reported are pre-existing in `src/core/skill/storage.ts`, untouched here)
- [x] `npm run lint:tier` — pass (288 modules / 600 deps, no violations; `src/core/**` does not import `src/pilot/**`)
- [x] `npx jest tests/core/skill-memory/` — **28/28** pass

## Test plan

- [x] Construction rejects empty / control-char / over-long domains.
- [x] Constructor is lazy — no filesystem touch.
- [x] `record()` persists + returns stable id.
- [x] `record()` is idempotent on `(domain, name)` and preserves `success_count` / `last_used_at` across re-records.
- [x] `record()` rejects domain mismatch and empty name.
- [x] `get()` returns null on miss.
- [x] `list()` sorts by `last_used_at desc`, ties by `skill_id asc`.
- [x] `list()` honors `contract_id` and `limit` filters.
- [x] `markUsed()` increments `success_count` only on success, updates `last_used_at` unconditionally, throws on unknown id, rejects non-finite `ts`.
- [x] `writeFrozenSnapshot()` gzip-encodes JSON, round-trips via `readFrozenSnapshot()`, is write-once, rejects paths outside the snapshots dir, rejects unsafe ids.
- [x] One JSON file per domain with `schema_version: 1`.
- [x] Windows-reserved domain names get an underscore prefix.
- [x] Unsafe domain characters are percent-encoded into a single basename (no traversal).
- [x] `skills.json` with unknown `schema_version` is skipped.
- [x] Cross-domain `record()` calls run in parallel.
- [x] Same-domain parallel `record()` serializes correctly (no dropped rows).

## Refs

- Closed PR #762 — storage half reimplemented here; recall ranking deferred.
- #712 — epic.
- #774 — contract.
- #780 — tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)