### PR TITLE
feat(core): JSON-per-domain skill graph storage (Phase 3, replaces #738)

### DIFF
--- a/src/core/skill/index.ts
+++ b/src/core/skill/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Barrel export for the JSON-per-domain skill graph storage subsystem.
+ *
+ * The persisted schema and counter semantics are preserved verbatim from
+ * closed PR #738 v2; only the backend (SQLite → JSON + `proper-lockfile`)
+ * changed, per the portability-harness contract clause P5.
+ */
+
+export {
+  SkillGraphStorage,
+  defaultSkillGraphRootDir,
+} from './storage';
+export type {
+  RecordEdgeInput,
+  SkillGraphStorageOptions,
+} from './storage';
+export type {
+  EdgeKey,
+  PersistedEdge,
+  PersistedNode,
+  SkillEdge,
+  SkillGraphFile,
+  SkillGraphInspectSummary,
+  SkillNode,
+  ToStateDistribution,
+} from './types';

--- a/src/core/skill/storage.ts
+++ b/src/core/skill/storage.ts
@@ -1,0 +1,628 @@
+/**
+ * Per-domain skill graph storage — JSON-per-domain backend.
+ *
+ * One JSON file per domain at `<rootDir>/<encodedDomain>.json`. This keeps
+ * concurrent activity on different domains fully independent — only writes
+ * to the same domain serialise via a per-file `proper-lockfile` lock.
+ *
+ * This module replaces the SQLite backend from closed PR #738 per the
+ * portability-harness contract clause P5 (Native dependency discipline —
+ * argon2 only). The persisted record shape (nodes + edges +
+ * to_state_distribution) is preserved verbatim from PR #738 v2 so the
+ * executor (#703) sees an identical graph model.
+ *
+ * File layout (schema_version 1):
+ *   {
+ *     "schema_version": 1,
+ *     "nodes": { "<state_hash>": { state_hash, evidence?, thumbnail_path?,
+ *                                  last_seen_at, visit_count } },
+ *     "edges": [ { from_state, action_kind, action_args_norm,
+ *                  to_state_distribution, success_count, fail_count,
+ *                  last_failed_at?, last_error? } ]
+ *   }
+ *
+ * Concurrency model:
+ *   • Cross-domain writes proceed in parallel — separate files, separate
+ *     locks.
+ *   • Same-domain writes serialise on the per-file `proper-lockfile` lock.
+ *   • Every mutating call follows the pattern
+ *     `acquireLock → readFileSafe → mutate → writeFileAtomicSafe → release`
+ *     so success/fail counters never race against concurrent same-domain
+ *     writers (a Codex finding from the previous iteration).
+ *
+ * The lock file is `<rootDir>/<encodedDomain>.json.lock`. `acquireLock`
+ * from `src/utils/atomic-file.ts` creates an empty `{}` placeholder at the
+ * lock path if one is missing so `proper-lockfile` has something to lock.
+ * The graph data file itself is kept separate from the lock file so the
+ * placeholder JSON is never confused with the graph payload.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { acquireLock, readFileSafe, writeFileAtomicSafe } from '../../utils/atomic-file';
+import type {
+  EdgeKey,
+  PersistedEdge,
+  PersistedNode,
+  SkillEdge,
+  SkillGraphFile,
+  SkillGraphInspectSummary,
+  SkillNode,
+  ToStateDistribution,
+} from './types';
+
+const CURRENT_SCHEMA_VERSION = 1 as const;
+
+export interface SkillGraphStorageOptions {
+  /** Filesystem root for per-domain JSON files. */
+  rootDir?: string;
+  /** Required: the domain this storage handle owns. */
+  domain: string;
+}
+
+export interface RecordEdgeInput {
+  from_state: string;
+  action_kind: string;
+  action_args_norm: string;
+  /**
+   * Optional observed `to_state`. When provided, the edge's
+   * `to_state_distribution` is incremented; when omitted (e.g. the action
+   * failed before the page settled) the distribution is left alone.
+   */
+  to_state?: string;
+}
+
+/** Default rootDir resolves to `${HOME}/.openchrome/skills`. */
+export function defaultSkillGraphRootDir(): string {
+  return path.join(os.homedir(), '.openchrome', 'skills');
+}
+
+/**
+ * Windows reserved device names that are illegal as basenames even with
+ * an extension (`CON.json` is rejected by the Win32 file API). Lower-cased
+ * for case-insensitive match. Sourced from Microsoft's Win32 file-naming
+ * docs.
+ */
+const WINDOWS_RESERVED_BASENAMES = new Set([
+  'con',
+  'prn',
+  'aux',
+  'nul',
+  'com0',
+  'com1',
+  'com2',
+  'com3',
+  'com4',
+  'com5',
+  'com6',
+  'com7',
+  'com8',
+  'com9',
+  'lpt0',
+  'lpt1',
+  'lpt2',
+  'lpt3',
+  'lpt4',
+  'lpt5',
+  'lpt6',
+  'lpt7',
+  'lpt8',
+  'lpt9',
+]);
+
+/**
+ * Encode a domain into a basename safe on every supported OS:
+ *
+ *   • `encodeURIComponent` handles characters Windows rejects in
+ *     filenames (`:`, `[`, `]`, `*`, `?`, `<`, `>`, `|`, `"`, `/`, `\\`,
+ *     whitespace, control chars).
+ *   • A leading underscore is added when the encoded basename matches a
+ *     Windows reserved device name (`CON.json` is invalid even with an
+ *     extension; `_CON.json` is fine). The underscore is stable so the
+ *     keying remains deterministic for the same domain.
+ *
+ * Ordinary URL-hostname characters (`a-z`, `0-9`, `.`, `-`) round-trip
+ * unchanged, so `amazon.com` still maps to `amazon.com.json`.
+ */
+function encodeDomainForFilename(domain: string): string {
+  const encoded = encodeURIComponent(domain);
+  if (WINDOWS_RESERVED_BASENAMES.has(encoded.toLowerCase())) {
+    return `_${encoded}`;
+  }
+  return encoded;
+}
+
+function emptyFile(): SkillGraphFile {
+  return { schema_version: CURRENT_SCHEMA_VERSION, nodes: {}, edges: [] };
+}
+
+function loadNode(row: PersistedNode): SkillNode {
+  return {
+    stateHash: row.state_hash,
+    evidence: row.evidence,
+    thumbnailPath: row.thumbnail_path,
+    lastSeenAt: row.last_seen_at,
+    visitCount: row.visit_count,
+  };
+}
+
+function loadEdge(row: PersistedEdge): SkillEdge {
+  return {
+    fromState: row.from_state,
+    actionKind: row.action_kind,
+    actionArgsNorm: row.action_args_norm,
+    toStateDistribution: row.to_state_distribution ?? [],
+    successCount: row.success_count,
+    failCount: row.fail_count,
+    lastFailedAt: row.last_failed_at,
+    lastError: row.last_error,
+  };
+}
+
+function matchesKey(row: PersistedEdge, key: EdgeKey): boolean {
+  return (
+    row.from_state === key.fromState &&
+    row.action_kind === key.actionKind &&
+    row.action_args_norm === key.actionArgsNorm
+  );
+}
+
+function successRate(e: SkillEdge): number {
+  const total = e.successCount + e.failCount;
+  if (total === 0) return 0;
+  return e.successCount / total;
+}
+
+/**
+ * Single-domain JSON-backed handle. Multiple instances against the same
+ * `domain` and `rootDir` are safe — writes serialise on the per-file
+ * `proper-lockfile` lock.
+ */
+export class SkillGraphStorage {
+  private readonly rootDir: string;
+  readonly domain: string;
+  private readonly filePath: string;
+  private readonly lockPath: string;
+
+  constructor(opts: SkillGraphStorageOptions) {
+    const domain = opts?.domain;
+    if (!domain || domain === '.' || domain === '..') {
+      throw new Error(`SkillGraphStorage: invalid domain "${domain}"`);
+    }
+    this.domain = domain;
+    this.rootDir = opts.rootDir ?? defaultSkillGraphRootDir();
+    fs.mkdirSync(this.rootDir, { recursive: true });
+    const basename = `${encodeDomainForFilename(domain)}.json`;
+    this.filePath = path.join(this.rootDir, basename);
+    // Keep the lock placeholder separate from the data file so the
+    // `{}` content `acquireLock` writes never gets parsed as a real
+    // empty graph file. Sibling file with `.lock` suffix.
+    this.lockPath = path.join(this.rootDir, `${basename}.lock`);
+    this.ensureSeedFileSync();
+  }
+
+  /**
+   * Ensure the per-domain graph file exists with a fresh `schema_version`
+   * payload. If a file already exists with the current schema version we
+   * leave it alone — the initial-write path has to be idempotent so two
+   * processes opening the same domain concurrently do not blank-overwrite
+   * each other's state (Codex finding from the SQLite iteration).
+   *
+   * The check is synchronous so the constructor can present a complete
+   * handle to the caller without forcing an `await`.
+   */
+  private ensureSeedFileSync(): void {
+    if (fs.existsSync(this.filePath)) {
+      // Validate the existing file roughly; if it's missing or has the
+      // wrong schema version, leave it as-is and let the next mutating
+      // call read+rewrite under a lock. We must NOT blow it away here.
+      return;
+    }
+    // Best-effort initial seed. If another process creates the same file
+    // between `existsSync` and `writeFileSync` the loser's content is
+    // identical (empty graph at schema_version 1) so this is safe to
+    // re-attempt without coordination.
+    try {
+      fs.writeFileSync(this.filePath, JSON.stringify(emptyFile(), null, 2), {
+        flag: 'wx',
+      });
+    } catch (err) {
+      // EEXIST is fine — another opener won the race and produced an
+      // equivalent file. Re-throw anything else so the caller learns
+      // about real I/O failures up front instead of at the first write.
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'EEXIST') {
+        throw err;
+      }
+    }
+  }
+
+  /** Returns the schema version this handle reads/writes. */
+  getSchemaVersion(): number {
+    return CURRENT_SCHEMA_VERSION;
+  }
+
+  /** Path to the on-disk JSON file (exposed for tests / inspection). */
+  getFilePath(): string {
+    return this.filePath;
+  }
+
+  /**
+   * Read the entire graph payload. Best-effort: a missing or corrupted
+   * file resolves to an empty graph. Reads do NOT take the write lock —
+   * write callers re-read under the lock anyway, and read-only callers
+   * (getNode, topEdges, recentFailures, inspect) tolerate a slightly
+   * stale snapshot.
+   */
+  private async readGraph(): Promise<SkillGraphFile> {
+    const res = await readFileSafe<SkillGraphFile>(this.filePath);
+    if (!res.success || !res.data) {
+      return emptyFile();
+    }
+    const data = res.data;
+    if (
+      typeof data !== 'object' ||
+      data === null ||
+      data.schema_version !== CURRENT_SCHEMA_VERSION ||
+      typeof data.nodes !== 'object' ||
+      data.nodes === null ||
+      !Array.isArray(data.edges)
+    ) {
+      // Unknown schema or shape — present an empty graph to the caller.
+      // A subsequent write will canonicalise the file.
+      return emptyFile();
+    }
+    return data;
+  }
+
+  /** Synchronous variant for non-async surfaces (`getNode`, etc.). */
+  private readGraphSync(): SkillGraphFile {
+    if (!fs.existsSync(this.filePath)) return emptyFile();
+    let raw: string;
+    try {
+      raw = fs.readFileSync(this.filePath, 'utf8');
+    } catch {
+      return emptyFile();
+    }
+    try {
+      const data = JSON.parse(raw) as SkillGraphFile;
+      if (
+        typeof data !== 'object' ||
+        data === null ||
+        data.schema_version !== CURRENT_SCHEMA_VERSION ||
+        typeof data.nodes !== 'object' ||
+        data.nodes === null ||
+        !Array.isArray(data.edges)
+      ) {
+        return emptyFile();
+      }
+      return data;
+    } catch {
+      return emptyFile();
+    }
+  }
+
+  private async writeGraph(payload: SkillGraphFile): Promise<void> {
+    await writeFileAtomicSafe(this.filePath, payload);
+  }
+
+  /**
+   * Acquire the per-domain lock, run `mutator` against a freshly-read
+   * graph, write back the result, and release the lock. The lock is
+   * always released via `try/finally` so a thrown mutator does not strand
+   * the lock file.
+   */
+  private async withLockedGraph<T>(
+    mutator: (graph: SkillGraphFile) => T,
+  ): Promise<T> {
+    const release = await acquireLock(this.lockPath);
+    try {
+      const graph = await this.readGraph();
+      const result = mutator(graph);
+      await this.writeGraph(graph);
+      return result;
+    } finally {
+      await release();
+    }
+  }
+
+  /**
+   * Insert or refresh a node. Increments visit_count on every call. The
+   * caller's `seenAt` (or `Date.now()` if omitted) becomes the new
+   * `last_seen_at`. When `evidence` / `thumbnailPath` are omitted the
+   * prior values are preserved (matching the SQLite COALESCE behaviour).
+   */
+  async upsertNode(args: {
+    stateHash: string;
+    evidence?: unknown;
+    thumbnailPath?: string;
+    seenAt?: number;
+  }): Promise<void> {
+    const seenAt = args.seenAt ?? Date.now();
+    await this.withLockedGraph((graph) => {
+      const prior = graph.nodes[args.stateHash];
+      const next: PersistedNode = {
+        state_hash: args.stateHash,
+        evidence: args.evidence !== undefined ? args.evidence : prior?.evidence,
+        thumbnail_path:
+          args.thumbnailPath !== undefined ? args.thumbnailPath : prior?.thumbnail_path,
+        last_seen_at: seenAt,
+        visit_count: (prior?.visit_count ?? 0) + 1,
+      };
+      if (next.evidence === undefined) delete next.evidence;
+      if (next.thumbnail_path === undefined) delete next.thumbnail_path;
+      graph.nodes[args.stateHash] = next;
+    });
+  }
+
+  /** Look up a node row. Returns `null` if not found. */
+  getNode(stateHash: string): SkillNode | null {
+    const graph = this.readGraphSync();
+    const row = graph.nodes[stateHash];
+    return row ? loadNode(row) : null;
+  }
+
+  /** Returns all nodes ordered by visit_count DESC. */
+  listNodes(limit = 100): SkillNode[] {
+    const graph = this.readGraphSync();
+    return Object.values(graph.nodes)
+      .map(loadNode)
+      .sort((a, b) => b.visitCount - a.visitCount)
+      .slice(0, limit);
+  }
+
+  /**
+   * Ensure both endpoints referenced by an edge exist as nodes. The
+   * SQLite backend leaned on `FOREIGN KEY` to reject orphan edges; in
+   * JSON we enforce the invariant in application code by creating empty
+   * Node stubs (`visit_count = 0`) for any state hash the edge mentions
+   * that doesn't already have a node row. Same behaviour as the original
+   * "create-if-missing" semantics for the executor.
+   */
+  private ensureNodeStub(graph: SkillGraphFile, stateHash: string, at: number): void {
+    if (!graph.nodes[stateHash]) {
+      graph.nodes[stateHash] = {
+        state_hash: stateHash,
+        last_seen_at: at,
+        visit_count: 0,
+      };
+    }
+  }
+
+  /**
+   * Record (or upsert) an edge with an optional observed `to_state`. The
+   * edge's `success_count` / `fail_count` are NOT touched here — call
+   * `recordSuccess` or `recordFailure` to update those. Use this when the
+   * caller wants to register that an action was attempted without yet
+   * knowing the outcome (the SQLite implementation merged both into
+   * `recordOutcome`; this split lets callers stamp observation order
+   * without forcing a success/fail decision).
+   */
+  async recordEdge(input: RecordEdgeInput): Promise<void> {
+    const at = Date.now();
+    await this.withLockedGraph((graph) => {
+      this.ensureNodeStub(graph, input.from_state, at);
+      if (input.to_state) {
+        this.ensureNodeStub(graph, input.to_state, at);
+      }
+      const idx = graph.edges.findIndex((row) =>
+        matchesKey(row, {
+          fromState: input.from_state,
+          actionKind: input.action_kind,
+          actionArgsNorm: input.action_args_norm,
+        }),
+      );
+      if (idx === -1) {
+        const dist: ToStateDistribution = input.to_state
+          ? [{ to_state: input.to_state, count: 1 }]
+          : [];
+        graph.edges.push({
+          from_state: input.from_state,
+          action_kind: input.action_kind,
+          action_args_norm: input.action_args_norm,
+          to_state_distribution: dist,
+          success_count: 0,
+          fail_count: 0,
+        });
+        return;
+      }
+      const edge = graph.edges[idx];
+      if (input.to_state) {
+        edge.to_state_distribution = mergeDistribution(
+          edge.to_state_distribution,
+          input.to_state,
+          1,
+        );
+      }
+    });
+  }
+
+  /**
+   * Increment `success_count` for an existing or newly-created edge.
+   * When the edge does not exist yet it is created with
+   * `success_count = 1`. Reads happen inside the same lock window as the
+   * write so concurrent same-domain writers never race the counter (a
+   * Codex finding from the SQLite iteration).
+   */
+  async recordSuccess(edgeKey: EdgeKey, observedToState?: string): Promise<void> {
+    const at = Date.now();
+    await this.withLockedGraph((graph) => {
+      this.applyOutcome(graph, edgeKey, {
+        success: true,
+        observedToState,
+        at,
+      });
+    });
+  }
+
+  /**
+   * Increment `fail_count` for an existing or newly-created edge, stamp
+   * `last_failed_at`, and (optionally) capture the error string for the
+   * inspector / replay tooling.
+   */
+  async recordFailure(edgeKey: EdgeKey, error?: string): Promise<void> {
+    const at = Date.now();
+    await this.withLockedGraph((graph) => {
+      this.applyOutcome(graph, edgeKey, {
+        success: false,
+        at,
+        error,
+      });
+    });
+  }
+
+  /**
+   * Shared mutator used by recordSuccess / recordFailure. Locates the
+   * edge by composite key, creates it if missing, and updates the
+   * counters + distribution + last_failed_at fields.
+   */
+  private applyOutcome(
+    graph: SkillGraphFile,
+    edgeKey: EdgeKey,
+    args: {
+      success: boolean;
+      at: number;
+      observedToState?: string;
+      error?: string;
+    },
+  ): void {
+    this.ensureNodeStub(graph, edgeKey.fromState, args.at);
+    if (args.observedToState) {
+      this.ensureNodeStub(graph, args.observedToState, args.at);
+    }
+    let idx = graph.edges.findIndex((row) => matchesKey(row, edgeKey));
+    if (idx === -1) {
+      graph.edges.push({
+        from_state: edgeKey.fromState,
+        action_kind: edgeKey.actionKind,
+        action_args_norm: edgeKey.actionArgsNorm,
+        to_state_distribution: [],
+        success_count: 0,
+        fail_count: 0,
+      });
+      idx = graph.edges.length - 1;
+    }
+    const edge = graph.edges[idx];
+    if (args.observedToState) {
+      edge.to_state_distribution = mergeDistribution(
+        edge.to_state_distribution,
+        args.observedToState,
+        1,
+      );
+    }
+    if (args.success) {
+      edge.success_count += 1;
+    } else {
+      edge.fail_count += 1;
+      edge.last_failed_at = args.at;
+      if (args.error !== undefined) {
+        edge.last_error = args.error;
+      }
+    }
+  }
+
+  /** Look up a single edge row by composite key. */
+  getEdge(edgeKey: EdgeKey): SkillEdge | null {
+    const graph = this.readGraphSync();
+    const row = graph.edges.find((r) => matchesKey(r, edgeKey));
+    return row ? loadEdge(row) : null;
+  }
+
+  /**
+   * Top edges leaving `fromState` ordered by historical success rate
+   * (success / (success+fail)) DESC, with raw success_count as the
+   * tiebreaker. Replaces #738's `edgesFrom`; the ordering contract is
+   * identical so the executor's "best next action" selector still works.
+   */
+  topEdges(fromState: string, limit = 100): SkillEdge[] {
+    const graph = this.readGraphSync();
+    const edges = graph.edges
+      .filter((row) => row.from_state === fromState)
+      .map(loadEdge);
+    edges.sort((a, b) => {
+      const ar = successRate(a);
+      const br = successRate(b);
+      if (ar !== br) return br - ar;
+      return b.successCount - a.successCount;
+    });
+    return edges.slice(0, limit);
+  }
+
+  /**
+   * Edges with at least one observed failure, ordered by `lastFailedAt`
+   * DESC. Used by the inspector to surface recently-broken flows.
+   */
+  recentFailures(limit = 10): SkillEdge[] {
+    const graph = this.readGraphSync();
+    return graph.edges
+      .filter((row) => row.last_failed_at !== undefined)
+      .map(loadEdge)
+      .sort((a, b) => (b.lastFailedAt ?? 0) - (a.lastFailedAt ?? 0))
+      .slice(0, limit);
+  }
+
+  /**
+   * Diagnostic snapshot consumed by `oc skill inspect`. Cheap to
+   * compute — single pass over the in-memory graph.
+   */
+  inspect(): SkillGraphInspectSummary {
+    const graph = this.readGraphSync();
+    const allEdges = graph.edges.map(loadEdge);
+    const topRows = [...allEdges]
+      .sort((a, b) => b.successCount + b.failCount - (a.successCount + a.failCount))
+      .slice(0, 10);
+    const failingRows = allEdges
+      .filter((e) => e.lastFailedAt !== undefined)
+      .sort((a, b) => (b.lastFailedAt ?? 0) - (a.lastFailedAt ?? 0))
+      .slice(0, 10);
+    return {
+      domain: this.domain,
+      nodeCount: Object.keys(graph.nodes).length,
+      edgeCount: graph.edges.length,
+      topEdgesByVisit: topRows.map((e) => ({
+        from: e.fromState,
+        actionKind: e.actionKind,
+        successCount: e.successCount,
+        failCount: e.failCount,
+      })),
+      recentFailures: failingRows.map((e) => ({
+        from: e.fromState,
+        actionKind: e.actionKind,
+        failCount: e.failCount,
+        lastFailedAt: e.lastFailedAt ?? 0,
+      })),
+    };
+  }
+
+  /**
+   * Symmetric with #738's `close()` so call-sites that already wrap the
+   * SQLite handle in a lifecycle don't need to special-case this
+   * backend. No open file handles to release in the JSON layout — this
+   * is a no-op kept on the surface for parity.
+   */
+  close(): void {
+    // intentionally empty
+  }
+}
+
+/**
+ * Merge a new (`toState`, `count`) observation into the running
+ * distribution. The returned array stays sorted by `count` DESC so
+ * inspection callers can read the top entry without re-sorting.
+ */
+function mergeDistribution(
+  dist: ToStateDistribution,
+  toState: string,
+  delta: number,
+): ToStateDistribution {
+  const next = dist.map((entry) => ({ ...entry }));
+  const idx = next.findIndex((entry) => entry.to_state === toState);
+  if (idx >= 0) {
+    next[idx].count += delta;
+  } else {
+    next.push({ to_state: toState, count: delta });
+  }
+  return next.sort((a, b) => b.count - a.count);
+}

--- a/src/core/skill/types.ts
+++ b/src/core/skill/types.ts
@@ -1,0 +1,96 @@
+/**
+ * Skill-graph storage types. Schema preserved verbatim from closed PR #738
+ * v2 — the storage backend changed from SQLite to JSON-per-domain (P5 of
+ * the portability-harness contract), but the persisted shape of nodes and
+ * edges stays the same so #703's executor sees an identical record model.
+ *
+ * `to_state_distribution` is included from day one so a multi-outcome
+ * action can be matched without a follow-up migration.
+ */
+
+/** A graph node — one observed page-state hash. */
+export interface SkillNode {
+  stateHash: string;
+  evidence?: unknown;
+  thumbnailPath?: string;
+  lastSeenAt: number;
+  visitCount: number;
+}
+
+/**
+ * Sorted (by count DESC) distribution of observed `to_state` outcomes for
+ * a single edge. Sorting makes inspection cheap and is preserved across
+ * reads/writes.
+ */
+export type ToStateDistribution = Array<{ to_state: string; count: number }>;
+
+/** A graph edge — one (from_state, action_kind, action_args_norm) entry. */
+export interface SkillEdge {
+  fromState: string;
+  actionKind: string;
+  actionArgsNorm: string;
+  toStateDistribution: ToStateDistribution;
+  successCount: number;
+  failCount: number;
+  lastFailedAt?: number;
+  /** Last error string captured by recordFailure(). */
+  lastError?: string;
+}
+
+/** Composite primary key for an edge. */
+export interface EdgeKey {
+  fromState: string;
+  actionKind: string;
+  actionArgsNorm: string;
+}
+
+/** Diagnostic snapshot consumed by `oc skill inspect`. */
+export interface SkillGraphInspectSummary {
+  domain: string;
+  nodeCount: number;
+  edgeCount: number;
+  topEdgesByVisit: Array<{
+    from: string;
+    actionKind: string;
+    successCount: number;
+    failCount: number;
+  }>;
+  recentFailures: Array<{
+    from: string;
+    actionKind: string;
+    failCount: number;
+    lastFailedAt: number;
+  }>;
+}
+
+/**
+ * The shape persisted on disk for a single domain. Versioned so a future
+ * migration can detect old layouts and rewrite the file. Nodes are stored
+ * as an Object keyed by stateHash (cheap point lookup); edges are stored
+ * as an Array because the PK is composite and JSON has no native tuple
+ * key.
+ */
+export interface SkillGraphFile {
+  schema_version: 1;
+  nodes: Record<string, PersistedNode>;
+  edges: PersistedEdge[];
+}
+
+export interface PersistedNode {
+  state_hash: string;
+  evidence?: unknown;
+  thumbnail_path?: string;
+  last_seen_at: number;
+  visit_count: number;
+}
+
+export interface PersistedEdge {
+  from_state: string;
+  action_kind: string;
+  action_args_norm: string;
+  to_state_distribution: ToStateDistribution;
+  success_count: number;
+  fail_count: number;
+  last_failed_at?: number;
+  last_error?: string;
+}

--- a/tests/core/skill/storage.test.ts
+++ b/tests/core/skill/storage.test.ts
@@ -1,0 +1,541 @@
+/**
+ * Tests for the JSON-per-domain skill graph storage backend.
+ *
+ * The shape of the test suite mirrors closed PR #738's SQLite test file,
+ * minus the migration-table tests (no SQL here) and with the API surface
+ * updated to the Phase 3 spec:
+ *   - `new SkillGraphStorage({ rootDir, domain })`
+ *   - `recordEdge({ from_state, action_kind, action_args_norm, to_state? })`
+ *   - `recordSuccess(edgeKey)` / `recordFailure(edgeKey, error?)`
+ *   - `getNode(stateHash)` returns `null` on miss (not `undefined`)
+ *   - `topEdges(fromState, limit?)` / `recentFailures(limit?)`
+ *
+ * Concurrency tests assert:
+ *   - same-domain writes serialise (success/fail counters never collide)
+ *   - cross-domain writes proceed in parallel (independent lock files)
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { SkillGraphStorage } from '../../../src/core/skill';
+import type { EdgeKey } from '../../../src/core/skill';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-skill-'));
+}
+
+describe('SkillGraphStorage — schema and lifecycle', () => {
+  let root: string;
+  let store: SkillGraphStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    store = new SkillGraphStorage({ domain: 'amazon.com', rootDir: root });
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('creates per-domain JSON file at <rootDir>/<domain>.json', () => {
+    expect(fs.existsSync(path.join(root, 'amazon.com.json'))).toBe(true);
+  });
+
+  test('schema version is 1', () => {
+    expect(store.getSchemaVersion()).toBe(1);
+  });
+
+  test('reopening on the same domain is a no-op (idempotent seed)', () => {
+    expect(() => {
+      const second = new SkillGraphStorage({ domain: 'amazon.com', rootDir: root });
+      second.close();
+    }).not.toThrow();
+  });
+
+  test('reopening with prior data does NOT blank-overwrite the file', async () => {
+    // Codex finding from the SQLite iteration: the initial-write path
+    // has to be idempotent. Persist a node, reopen the same domain, and
+    // confirm the node is still there.
+    await store.upsertNode({ stateHash: 'persist-me', seenAt: 42 });
+    store.close();
+    const reopened = new SkillGraphStorage({ domain: 'amazon.com', rootDir: root });
+    try {
+      const node = reopened.getNode('persist-me');
+      expect(node).not.toBeNull();
+      expect(node?.lastSeenAt).toBe(42);
+    } finally {
+      reopened.close();
+    }
+  });
+
+  test('rejects empty / dot / dotdot domains', () => {
+    expect(() => new SkillGraphStorage({ domain: '', rootDir: root })).toThrow();
+    expect(() => new SkillGraphStorage({ domain: '.', rootDir: root })).toThrow();
+    expect(() => new SkillGraphStorage({ domain: '..', rootDir: root })).toThrow();
+  });
+
+  test('encodes filesystem-unsafe domain characters into a portable filename', () => {
+    // IPv6 literal hostnames carry `:` and `[`/`]` which are invalid
+    // filename characters on Windows. The constructor must encode them.
+    const ipv6 = '[2001:db8::1]';
+    const sg = new SkillGraphStorage({ domain: ipv6, rootDir: root });
+    sg.close();
+    const expected = path.join(root, `${encodeURIComponent(ipv6)}.json`);
+    expect(fs.existsSync(expected)).toBe(true);
+    // Sanity: no file with the raw, unsafe name was created.
+    expect(fs.existsSync(path.join(root, `${ipv6}.json`))).toBe(false);
+  });
+
+  test('Windows reserved device names get prefixed (CON.json is illegal on Windows)', () => {
+    const reserved = ['con', 'CON', 'aux', 'NUL', 'com1', 'lpt5'];
+    for (const r of reserved) {
+      const sg = new SkillGraphStorage({ domain: r, rootDir: root });
+      sg.close();
+      expect(fs.existsSync(path.join(root, `_${encodeURIComponent(r)}.json`))).toBe(true);
+      expect(fs.existsSync(path.join(root, `${r}.json`))).toBe(false);
+    }
+  });
+
+  test('domain with `/` or `\\\\` is encoded, not rejected', () => {
+    // Path separators can't legitimately appear in a URL hostname, but if
+    // a caller passes one (mistakenly or maliciously), encoding keeps
+    // the file inside rootDir without an exception.
+    const a = new SkillGraphStorage({ domain: 'a/b', rootDir: root });
+    a.close();
+    const b = new SkillGraphStorage({ domain: 'a\\b', rootDir: root });
+    b.close();
+    expect(fs.existsSync(path.join(root, `${encodeURIComponent('a/b')}.json`))).toBe(true);
+    expect(fs.existsSync(path.join(root, `${encodeURIComponent('a\\b')}.json`))).toBe(true);
+  });
+
+  test('concurrent same-domain initializers do not race the seed file', () => {
+    // The SQLite version used `INSERT OR IGNORE` to dodge a PK race; the
+    // JSON variant uses `wx`-flag write + EEXIST tolerance. Two
+    // constructors against the same domain must coexist without
+    // exception.
+    expect(() => {
+      const a = new SkillGraphStorage({ domain: 'race.test', rootDir: root });
+      const b = new SkillGraphStorage({ domain: 'race.test', rootDir: root });
+      a.close();
+      b.close();
+    }).not.toThrow();
+  });
+});
+
+describe('SkillGraphStorage — nodes', () => {
+  let root: string;
+  let store: SkillGraphStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    store = new SkillGraphStorage({ domain: 'x.com', rootDir: root });
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('upsertNode inserts a new row with visit_count=1', async () => {
+    await store.upsertNode({ stateHash: 'aaaa', seenAt: 100, evidence: { url: 'https://x' } });
+    const node = store.getNode('aaaa');
+    expect(node).not.toBeNull();
+    expect(node?.visitCount).toBe(1);
+    expect(node?.lastSeenAt).toBe(100);
+    expect(node?.evidence).toEqual({ url: 'https://x' });
+  });
+
+  test('upsertNode increments visit_count on subsequent calls', async () => {
+    await store.upsertNode({ stateHash: 'a', seenAt: 100 });
+    await store.upsertNode({ stateHash: 'a', seenAt: 200 });
+    await store.upsertNode({ stateHash: 'a', seenAt: 300 });
+    const node = store.getNode('a');
+    expect(node?.visitCount).toBe(3);
+    expect(node?.lastSeenAt).toBe(300);
+  });
+
+  test('upsertNode preserves prior evidence when next call omits it', async () => {
+    await store.upsertNode({ stateHash: 'a', evidence: { kept: true } });
+    await store.upsertNode({ stateHash: 'a' });
+    expect(store.getNode('a')?.evidence).toEqual({ kept: true });
+  });
+
+  test('listNodes orders by visit_count DESC', async () => {
+    await store.upsertNode({ stateHash: 'a' }); // 1
+    await store.upsertNode({ stateHash: 'b' });
+    await store.upsertNode({ stateHash: 'b' }); // 2
+    await store.upsertNode({ stateHash: 'c' });
+    await store.upsertNode({ stateHash: 'c' });
+    await store.upsertNode({ stateHash: 'c' }); // 3
+    const list = store.listNodes();
+    expect(list.map((n) => n.stateHash)).toEqual(['c', 'b', 'a']);
+  });
+
+  test('getNode returns null for unknown hash', () => {
+    expect(store.getNode('missing')).toBeNull();
+  });
+});
+
+describe('SkillGraphStorage — edges and outcome counters', () => {
+  let root: string;
+  let store: SkillGraphStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    store = new SkillGraphStorage({ domain: 'x.com', rootDir: root });
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('recordEdge creates an edge with empty counters and seeded distribution', async () => {
+    await store.recordEdge({
+      from_state: 'from1',
+      action_kind: 'click',
+      action_args_norm: 'ref:add',
+      to_state: 'to1',
+    });
+    const edge = store.getEdge({
+      fromState: 'from1',
+      actionKind: 'click',
+      actionArgsNorm: 'ref:add',
+    });
+    expect(edge).not.toBeNull();
+    expect(edge?.successCount).toBe(0);
+    expect(edge?.failCount).toBe(0);
+    expect(edge?.toStateDistribution).toEqual([{ to_state: 'to1', count: 1 }]);
+    expect(edge?.lastFailedAt).toBeUndefined();
+  });
+
+  test('recordEdge ensures both endpoint nodes exist (application-level FK)', async () => {
+    // The SQLite version enforced `from_state` → nodes via foreign-key
+    // pragma. JSON has no such pragma so we create empty Node stubs.
+    await store.recordEdge({
+      from_state: 'from-stub',
+      action_kind: 'click',
+      action_args_norm: 'x',
+      to_state: 'to-stub',
+    });
+    expect(store.getNode('from-stub')).not.toBeNull();
+    expect(store.getNode('to-stub')).not.toBeNull();
+    // visit_count stays 0 — these are stubs, not real visits.
+    expect(store.getNode('from-stub')?.visitCount).toBe(0);
+  });
+
+  test('recordSuccess increments success_count and updates distribution', async () => {
+    const key: EdgeKey = {
+      fromState: 'from1',
+      actionKind: 'click',
+      actionArgsNorm: 'ref:add',
+    };
+    for (let i = 0; i < 5; i++) {
+      await store.recordSuccess(key, 'to1');
+    }
+    const edge = store.getEdge(key);
+    expect(edge?.successCount).toBe(5);
+    expect(edge?.failCount).toBe(0);
+    expect(edge?.toStateDistribution).toEqual([{ to_state: 'to1', count: 5 }]);
+  });
+
+  test('multiple to_state outcomes produce distribution sorted by count DESC', async () => {
+    const key: EdgeKey = { fromState: 'from1', actionKind: 'click', actionArgsNorm: 'a' };
+    await store.recordSuccess(key, 'A');
+    await store.recordSuccess(key, 'A');
+    await store.recordSuccess(key, 'A');
+    await store.recordSuccess(key, 'B');
+    const edge = store.getEdge(key);
+    expect(edge?.toStateDistribution).toEqual([
+      { to_state: 'A', count: 3 },
+      { to_state: 'B', count: 1 },
+    ]);
+  });
+
+  test('recordFailure increments fail_count and stamps last_failed_at', async () => {
+    const key: EdgeKey = { fromState: 'from1', actionKind: 'click', actionArgsNorm: 'a' };
+    const before = Date.now();
+    await store.recordFailure(key, 'boom');
+    const after = Date.now();
+    const edge = store.getEdge(key);
+    expect(edge?.successCount).toBe(0);
+    expect(edge?.failCount).toBe(1);
+    expect(edge?.lastFailedAt).toBeGreaterThanOrEqual(before);
+    expect(edge?.lastFailedAt).toBeLessThanOrEqual(after);
+    expect(edge?.lastError).toBe('boom');
+  });
+
+  test('last_failed_at survives subsequent successes (sticky)', async () => {
+    const key: EdgeKey = { fromState: 'from1', actionKind: 'click', actionArgsNorm: 'a' };
+    await store.recordFailure(key);
+    const failedAt = store.getEdge(key)?.lastFailedAt;
+    expect(failedAt).toBeDefined();
+    await store.recordSuccess(key, 'X');
+    const edge = store.getEdge(key);
+    expect(edge?.lastFailedAt).toBe(failedAt);
+    expect(edge?.successCount).toBe(1);
+    expect(edge?.failCount).toBe(1);
+  });
+
+  test('recordSuccess without observedToState does not change distribution', async () => {
+    const key: EdgeKey = { fromState: 'from1', actionKind: 'click', actionArgsNorm: 'a' };
+    await store.recordSuccess(key, 'X');
+    await store.recordSuccess(key); // omit observedToState
+    expect(store.getEdge(key)?.toStateDistribution).toEqual([{ to_state: 'X', count: 1 }]);
+  });
+
+  test('getEdge returns null for unknown key', () => {
+    expect(
+      store.getEdge({
+        fromState: 'nope',
+        actionKind: 'nope',
+        actionArgsNorm: 'nope',
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('SkillGraphStorage — topEdges ordering', () => {
+  let root: string;
+  let store: SkillGraphStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    store = new SkillGraphStorage({ domain: 'x.com', rootDir: root });
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('orders edges by success rate DESC, then success_count DESC', async () => {
+    // Edge "low" — 1/2 = 0.5 success rate
+    await store.recordSuccess(
+      { fromState: 'from', actionKind: 'a', actionArgsNorm: 'low' },
+      't',
+    );
+    await store.recordFailure({ fromState: 'from', actionKind: 'a', actionArgsNorm: 'low' });
+    // Edge "high" — 3/3 = 1.0 success rate
+    for (let i = 0; i < 3; i++) {
+      await store.recordSuccess(
+        { fromState: 'from', actionKind: 'a', actionArgsNorm: 'high' },
+        't',
+      );
+    }
+    // Edge "small" — 1/1 = 1.0 success rate but lower successCount → tiebreak loser
+    await store.recordSuccess(
+      { fromState: 'from', actionKind: 'a', actionArgsNorm: 'small' },
+      't',
+    );
+
+    const edges = store.topEdges('from');
+    expect(edges.map((e) => e.actionArgsNorm)).toEqual(['high', 'small', 'low']);
+  });
+
+  test('returns empty array for unknown from_state', () => {
+    expect(store.topEdges('nope')).toEqual([]);
+  });
+
+  test('respects the limit parameter', async () => {
+    for (let i = 0; i < 5; i++) {
+      await store.recordSuccess(
+        { fromState: 'from', actionKind: 'a', actionArgsNorm: `arg-${i}` },
+        't',
+      );
+    }
+    expect(store.topEdges('from', 2)).toHaveLength(2);
+  });
+});
+
+describe('SkillGraphStorage — recentFailures', () => {
+  let root: string;
+  let store: SkillGraphStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    store = new SkillGraphStorage({ domain: 'x.com', rootDir: root });
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('only includes edges with last_failed_at set, ordered DESC', async () => {
+    await store.recordSuccess({ fromState: 'a', actionKind: 'click', actionArgsNorm: 'ok' }, 'b');
+    await store.recordFailure(
+      { fromState: 'a', actionKind: 'click', actionArgsNorm: 'broken-1' },
+      'first',
+    );
+    // Tiny wait so the second failure has a strictly-later timestamp.
+    await new Promise((r) => setTimeout(r, 5));
+    await store.recordFailure(
+      { fromState: 'a', actionKind: 'click', actionArgsNorm: 'broken-2' },
+      'second',
+    );
+    const failures = store.recentFailures();
+    expect(failures).toHaveLength(2);
+    expect(failures[0].actionArgsNorm).toBe('broken-2');
+    expect(failures[1].actionArgsNorm).toBe('broken-1');
+  });
+
+  test('returns empty array when nothing has failed', () => {
+    expect(store.recentFailures()).toEqual([]);
+  });
+});
+
+describe('SkillGraphStorage — inspect summary', () => {
+  let root: string;
+  let store: SkillGraphStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    store = new SkillGraphStorage({ domain: 'amazon.com', rootDir: root });
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('reports node and edge counts', async () => {
+    await store.upsertNode({ stateHash: 'a' });
+    await store.upsertNode({ stateHash: 'b' });
+    await store.recordSuccess(
+      { fromState: 'a', actionKind: 'click', actionArgsNorm: 'x' },
+      'b',
+    );
+    const s = store.inspect();
+    expect(s.domain).toBe('amazon.com');
+    expect(s.nodeCount).toBe(2);
+    expect(s.edgeCount).toBe(1);
+  });
+
+  test('top edges include success/fail counts', async () => {
+    await store.upsertNode({ stateHash: 'a' });
+    await store.recordSuccess(
+      { fromState: 'a', actionKind: 'click', actionArgsNorm: 'x' },
+      'b',
+    );
+    await store.recordFailure({ fromState: 'a', actionKind: 'click', actionArgsNorm: 'x' });
+    const s = store.inspect();
+    expect(s.topEdgesByVisit).toHaveLength(1);
+    expect(s.topEdgesByVisit[0].successCount).toBe(1);
+    expect(s.topEdgesByVisit[0].failCount).toBe(1);
+  });
+
+  test('recent failures only includes edges with last_failed_at set', async () => {
+    await store.upsertNode({ stateHash: 'a' });
+    await store.recordSuccess(
+      { fromState: 'a', actionKind: 'click', actionArgsNorm: 'ok' },
+      'b',
+    );
+    await store.recordFailure({ fromState: 'a', actionKind: 'click', actionArgsNorm: 'broken' });
+    const s = store.inspect();
+    expect(s.recentFailures).toHaveLength(1);
+    expect(s.recentFailures[0].actionKind).toBe('click');
+    expect(s.recentFailures[0].lastFailedAt).toBeGreaterThan(0);
+  });
+});
+
+describe('SkillGraphStorage — concurrent same-domain writes serialise', () => {
+  let root: string;
+  let store: SkillGraphStorage;
+
+  beforeEach(() => {
+    root = tempRoot();
+    store = new SkillGraphStorage({ domain: 'concurrent.test', rootDir: root });
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('parallel recordSuccess calls on the same edge sum correctly (no lost updates)', async () => {
+    // Codex finding from the SQLite iteration: recordOutcome reads and
+    // writes inside the same lock window so concurrent same-domain
+    // writers cannot read the same `success_count` and clobber each
+    // other. Fire N parallel writes against a single edge and verify
+    // the final counter is exactly N — anything less means we lost an
+    // update.
+    const key: EdgeKey = {
+      fromState: 'from',
+      actionKind: 'click',
+      actionArgsNorm: 'concurrent',
+    };
+    const N = 25;
+    await Promise.all(
+      Array.from({ length: N }, () => store.recordSuccess(key, 'to')),
+    );
+    const edge = store.getEdge(key);
+    expect(edge?.successCount).toBe(N);
+    expect(edge?.toStateDistribution).toEqual([{ to_state: 'to', count: N }]);
+  });
+
+  test('parallel recordEdge + recordSuccess on the same key serialise', async () => {
+    const key: EdgeKey = { fromState: 'a', actionKind: 'k', actionArgsNorm: 'v' };
+    await Promise.all([
+      store.recordEdge({
+        from_state: key.fromState,
+        action_kind: key.actionKind,
+        action_args_norm: key.actionArgsNorm,
+        to_state: 'observed',
+      }),
+      store.recordSuccess(key, 'observed'),
+      store.recordSuccess(key, 'observed'),
+      store.recordFailure(key, 'transient'),
+    ]);
+    const edge = store.getEdge(key);
+    expect(edge?.successCount).toBe(2);
+    expect(edge?.failCount).toBe(1);
+    // Distribution should have aggregated all three observations.
+    const observed = edge?.toStateDistribution.find((d) => d.to_state === 'observed');
+    expect(observed?.count).toBe(3);
+  });
+});
+
+describe('SkillGraphStorage — cross-domain writes proceed in parallel', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = tempRoot();
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('writes against different domains use independent lock files', async () => {
+    const a = new SkillGraphStorage({ domain: 'a.example', rootDir: root });
+    const b = new SkillGraphStorage({ domain: 'b.example', rootDir: root });
+    const c = new SkillGraphStorage({ domain: 'c.example', rootDir: root });
+
+    try {
+      const key: EdgeKey = { fromState: 'from', actionKind: 'k', actionArgsNorm: 'v' };
+      await Promise.all([
+        a.recordSuccess(key, 'to'),
+        b.recordSuccess(key, 'to'),
+        c.recordSuccess(key, 'to'),
+      ]);
+
+      // Each domain's file holds exactly one success on the single edge.
+      expect(a.getEdge(key)?.successCount).toBe(1);
+      expect(b.getEdge(key)?.successCount).toBe(1);
+      expect(c.getEdge(key)?.successCount).toBe(1);
+
+      // Per-domain JSON files exist and are independent.
+      expect(fs.existsSync(path.join(root, 'a.example.json'))).toBe(true);
+      expect(fs.existsSync(path.join(root, 'b.example.json'))).toBe(true);
+      expect(fs.existsSync(path.join(root, 'c.example.json'))).toBe(true);
+    } finally {
+      a.close();
+      b.close();
+      c.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Reimplement the skill graph storage with **one JSON file per domain + `proper-lockfile`**, replacing the SQLite backend from closed PR #738. The persisted record shape (nodes, edges, `to_state_distribution`, counters) is preserved verbatim so the executor (#703) sees an identical graph model — only the backend changed.

Per **portability-harness contract clause P5** (Native dependency discipline — argon2 only) the storage tier must avoid native deps. JSON + `proper-lockfile` keeps cross-domain writes parallel (separate files, separate locks) and same-domain writes serialised on a per-file lock.

## API surface (Phase 3 spec)

- `new SkillGraphStorage({ domain, rootDir? })`
- `recordEdge({ from_state, action_kind, action_args_norm, to_state? })`
- `recordSuccess(edgeKey, observedToState?)`
- `recordFailure(edgeKey, error?)`
- `getNode(stateHash): SkillNode | null`
- `topEdges(fromState, limit?): SkillEdge[]`
- `recentFailures(limit?): SkillEdge[]`
- `inspect()` and `getEdge()` / `listNodes()` helpers

## Storage layout

```
<rootDir>/<encodedDomain>.json        # graph data
<rootDir>/<encodedDomain>.json.lock   # proper-lockfile placeholder
```

```jsonc
{
  "schema_version": 1,
  "nodes":   { "<state_hash>": { state_hash, evidence?, thumbnail_path?,
                                  last_seen_at, visit_count } },
  "edges":   [ { from_state, action_kind, action_args_norm,
                 to_state_distribution, success_count, fail_count,
                 last_failed_at?, last_error? } ]
}
```

Every mutating call: `acquireLock → readFileSafe → mutate → writeFileAtomicSafe → release` (via `src/utils/atomic-file.ts`).

## Codex findings preserved from the previous iteration

- **Counter race fix**: `recordSuccess` / `recordFailure` read inside the same lock window as the write so concurrent same-domain writers can't race the counter (test: 25 parallel writes sum to exactly 25).
- **Filesystem-safe encoding**: `encodeURIComponent(domain)` so IPv6 literals (`[2001:db8::1]`) and odd hostnames don't break Windows file names.
- **Windows reserved basenames**: `CON`, `PRN`, `NUL`, `COM1..9`, `LPT1..9` get an underscore prefix (`_CON.json`).
- **Idempotent initial seed**: uses `wx` flag + `EEXIST` tolerance so two processes opening the same domain can't blank-overwrite each other.
- **Application-level FK**: `recordEdge` / `recordSuccess` / `recordFailure` stub empty Node rows for any referenced `state_hash`, matching the original foreign-key enforcement without SQLite pragmas.

## Refs

- Closed **#738** — SQLite original (reference only, not cherry-picked)
- **#698** — M1 epic
- **#774** — portability-harness contract
- **#780** — Phase 3 tracker

## Test plan

- [x] `npm run build` (clean)
- [x] `npm run lint` (clean, 0 warnings)
- [x] `npm run lint:tier` (0 violations across 283 modules)
- [x] `npx jest tests/core/skill/` — **33/33 passed** (~4.2 s)
  - schema + lifecycle (9 tests including idempotent reopen, Windows basenames, IPv6 encoding)
  - nodes (5 tests: upsert / visit_count / evidence preservation / listNodes ordering / getNode null)
  - edges + outcome counters (9 tests: recordEdge, FK stubs, success/fail counters, sticky lastFailedAt, distribution sort)
  - topEdges ordering (3 tests: success-rate DESC, tiebreaker, limit)
  - recentFailures (2 tests)
  - inspect summary (3 tests)
  - **concurrency**: 25 parallel same-domain writes serialise correctly; cross-domain writes proceed independently
- [ ] CI green on `develop`