### PR TITLE
feat(pilot): handoff token + manager (in-memory, Phase 3, closes #793)

### DIFF
--- a/src/pilot/handoff/banner.ts
+++ b/src/pilot/handoff/banner.ts
@@ -1,0 +1,53 @@
+/**
+ * Human-readable banner for a handoff exchange (Phase 3, issue #793).
+ *
+ * When a token is created or redeemed, the host surfaces a banner to the
+ * operator so the transfer is auditable in plain language alongside the
+ * structured JSON. The banner deliberately omits the raw token — copying
+ * the token belongs in a separate, copy-friendly field handled by the
+ * surrounding UI / tool result.
+ *
+ * Wired into the `oc_pilot_handoff_create` and `oc_pilot_handoff_redeem`
+ * MCP tools (see `./tool.ts`).
+ */
+
+export interface HandoffBannerPayload {
+  /** Browser session being transferred. */
+  sessionId: string;
+  /** Caller-supplied scope label. */
+  scope: string;
+  /** Wall-clock ms (epoch) at which the token becomes invalid. */
+  expiresAt: number;
+  /** Optional clock override for deterministic tests. */
+  now?: () => number;
+}
+
+/**
+ * Render a single-screen banner that describes the handoff. Multi-line
+ * plain text — safe to print to stderr or embed inside an MCP text
+ * content block. Never includes the raw token to avoid log leakage.
+ */
+export function renderHandoffBanner(payload: HandoffBannerPayload): string {
+  const now = (payload.now ?? Date.now)();
+  const remainingMs = Math.max(0, payload.expiresAt - now);
+  const expiresIso = new Date(payload.expiresAt).toISOString();
+  return [
+    '== openchrome handoff ==',
+    `session: ${payload.sessionId}`,
+    `scope:   ${payload.scope}`,
+    `expires: ${expiresIso} (in ${formatDuration(remainingMs)})`,
+    'token:   <redacted — fetch via tool result>',
+  ].join('\n');
+}
+
+function formatDuration(ms: number): string {
+  if (ms <= 0) return 'expired';
+  const totalSeconds = Math.floor(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 60) return seconds === 0 ? `${minutes}m` : `${minutes}m${seconds}s`;
+  const hours = Math.floor(minutes / 60);
+  const remMin = minutes % 60;
+  return remMin === 0 ? `${hours}h` : `${hours}h${remMin}m`;
+}

--- a/src/pilot/handoff/index.ts
+++ b/src/pilot/handoff/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Pilot Handoff — barrel export (Phase 3, issue #793).
+ *
+ * Surface mirrors the closed reference PR #754 design, slimmed to the
+ * pilot-tier slice the issue requested: token + banner + in-memory
+ * manager + MCP tool. Persistence (#794) layers on top of this without
+ * changing the public API.
+ *
+ * Import-safety: this module re-exports siblings only; no work happens
+ * at module load. The pilot bootstrap (`src/pilot/index.ts`) may import
+ * this barrel unconditionally without bringing eager side effects.
+ */
+
+export {
+  createHandoffToken,
+  verifyHandoffToken,
+  DEFAULT_TOKEN_TTL_MS,
+  HANDOFF_TOKEN_BYTES,
+  HANDOFF_TOKEN_LENGTH,
+} from './token.js';
+export type { CreateHandoffTokenArgs, HandoffTokenResult } from './token.js';
+
+export { renderHandoffBanner } from './banner.js';
+export type { HandoffBannerPayload } from './banner.js';
+
+export { HandoffManager } from './manager.js';
+export type {
+  HandoffManagerOptions,
+  HandoffPayload,
+  HandoffRecord,
+  HandoffRedemption,
+} from './manager.js';
+
+export { registerOcPilotHandoffTool } from './tool.js';

--- a/src/pilot/handoff/manager.ts
+++ b/src/pilot/handoff/manager.ts
@@ -1,0 +1,258 @@
+/**
+ * In-memory handoff registry (Phase 3, issue #793).
+ *
+ * Tracks tokens minted by {@link createHandoffToken} so a receiving agent
+ * can redeem one and inherit the originating session's scope. Pure
+ * in-memory: process restart drops every active handoff. Persistence
+ * (`handoff.json` + keychain / AES-256-GCM at rest) is issue #794.
+ *
+ * Lifecycle:
+ *
+ *   register(payload) -> { token, expiresAt }
+ *     mint a fresh token, store it. Replacing an existing token for the
+ *     same sessionId rotates and invalidates the old one (single-use).
+ *
+ *   redeem(token) -> HandoffRedemption | null
+ *     look up by token, verify TTL, and *remove* the record on success.
+ *     null when the token is unknown, expired, or already redeemed.
+ *
+ *   revoke(token) -> boolean
+ *     operator-initiated cancel. Returns true iff a record was removed.
+ *
+ *   pruneExpired() -> number
+ *     drop every record past `expiresAt`. Returns the count removed.
+ *
+ * Periodic prune runs via `setInterval` + `.unref()` so it never keeps
+ * the event loop alive on its own. Hosts that prefer explicit control
+ * can pass `pruneIntervalMs: 0` to disable the timer and call
+ * {@link HandoffManager.pruneExpired} manually.
+ */
+
+import { createHandoffToken, type CreateHandoffTokenArgs, type HandoffTokenResult } from './token.js';
+
+export interface HandoffPayload {
+  /** Session being transferred. */
+  sessionId: string;
+  /** Scope label surfaced back to the redeeming agent. */
+  scope: string;
+  /** Optional explicit TTL in ms (falls back to the token default). */
+  ttlMs?: number;
+}
+
+export interface HandoffRecord {
+  sessionId: string;
+  scope: string;
+  token: string;
+  /** Wall-clock ms (epoch) at which the token becomes invalid. */
+  expiresAt: number;
+  /** Wall-clock ms at which `register()` returned. */
+  createdAt: number;
+}
+
+/** Successful redemption surface — strips the token from the record. */
+export interface HandoffRedemption {
+  sessionId: string;
+  scope: string;
+  expiresAt: number;
+  createdAt: number;
+  /** Wall-clock ms at which {@link HandoffManager.redeem} returned ok. */
+  redeemedAt: number;
+}
+
+export interface HandoffManagerOptions {
+  /**
+   * Periodic prune cadence in ms. Default 60s. Pass 0 to disable the
+   * background timer entirely — callers may prefer to drive prune from
+   * their own scheduler (e.g. on every register/redeem).
+   */
+  pruneIntervalMs?: number;
+  /** Test hook: clock override. */
+  now?: () => number;
+  /** Test hook: replaceable token minter. */
+  mintToken?: (args: CreateHandoffTokenArgs) => HandoffTokenResult;
+}
+
+const DEFAULT_PRUNE_INTERVAL_MS = 60 * 1000;
+
+/**
+ * In-memory store of active handoffs.
+ *
+ * Two indices are maintained so `redeem(token)` is O(1) without scanning
+ * every record:
+ *   - `bySession` (sessionId -> HandoffRecord) is the canonical store.
+ *   - `byToken` (token -> sessionId) lets `redeem` and `revoke` resolve
+ *     by token without exposing the session as a side-channel.
+ *
+ * Both indices are mutated together inside a single synchronous block —
+ * no awaits between, so the pair stays consistent for the single-process
+ * case. Cross-process safety is #794's responsibility.
+ */
+export class HandoffManager {
+  private readonly bySession = new Map<string, HandoffRecord>();
+  private readonly byToken = new Map<string, string>();
+  private readonly now: () => number;
+  private readonly mintToken: (args: CreateHandoffTokenArgs) => HandoffTokenResult;
+  private timer: ReturnType<typeof setInterval> | undefined;
+
+  constructor(opts: HandoffManagerOptions = {}) {
+    this.now = opts.now ?? Date.now;
+    this.mintToken = opts.mintToken ?? createHandoffToken;
+    const interval = opts.pruneIntervalMs ?? DEFAULT_PRUNE_INTERVAL_MS;
+    if (interval > 0) {
+      this.timer = setInterval(() => {
+        try {
+          this.pruneExpired();
+        } catch {
+          // best-effort — a pruning hiccup must not crash the host
+        }
+      }, interval);
+      // Never let the prune timer pin the event loop alive on its own.
+      // Available on Node Timers; the guarded cast keeps DOM-typed
+      // builds happy in non-Node hosts that import the type only.
+      const t = this.timer as { unref?: () => void };
+      if (typeof t.unref === 'function') t.unref();
+    }
+  }
+
+  /**
+   * Mint a token for `payload` and store it. If a record already exists
+   * for the same sessionId, the previous token is invalidated (rotated)
+   * before the new one is installed — there is at most one active token
+   * per session.
+   */
+  register(payload: HandoffPayload): HandoffTokenResult {
+    if (typeof payload.sessionId !== 'string' || payload.sessionId.length === 0) {
+      throw new Error('HandoffManager.register: sessionId is required');
+    }
+    if (typeof payload.scope !== 'string' || payload.scope.length === 0) {
+      throw new Error('HandoffManager.register: scope is required');
+    }
+    // Rotate: drop any prior record for this session.
+    const prior = this.bySession.get(payload.sessionId);
+    if (prior) {
+      this.byToken.delete(prior.token);
+      this.bySession.delete(prior.sessionId);
+    }
+    const result = this.mintToken({
+      sessionId: payload.sessionId,
+      scope: payload.scope,
+      ttlMs: payload.ttlMs,
+      now: this.now,
+    });
+    const record: HandoffRecord = {
+      sessionId: payload.sessionId,
+      scope: payload.scope,
+      token: result.token,
+      expiresAt: result.expiresAt,
+      createdAt: this.now(),
+    };
+    this.bySession.set(record.sessionId, record);
+    this.byToken.set(record.token, record.sessionId);
+    return { token: result.token, expiresAt: result.expiresAt };
+  }
+
+  /**
+   * Look up a token, verify TTL, and consume the record on success.
+   * Returns null when the token is unknown, expired, or already redeemed.
+   * Expired records are also removed as a side effect so subsequent calls
+   * with the same (now-stale) token return null without lingering state.
+   */
+  redeem(token: string): HandoffRedemption | null {
+    if (typeof token !== 'string' || token.length === 0) return null;
+    const sessionId = this.byToken.get(token);
+    if (sessionId === undefined) return null;
+    const record = this.bySession.get(sessionId);
+    if (record === undefined) {
+      // Index drift — clean up the orphan token entry defensively.
+      this.byToken.delete(token);
+      return null;
+    }
+    const now = this.now();
+    if (now >= record.expiresAt) {
+      this.byToken.delete(token);
+      this.bySession.delete(sessionId);
+      return null;
+    }
+    // Consume on success. Single-use: subsequent redeem(token) returns null.
+    this.byToken.delete(token);
+    this.bySession.delete(sessionId);
+    return {
+      sessionId: record.sessionId,
+      scope: record.scope,
+      expiresAt: record.expiresAt,
+      createdAt: record.createdAt,
+      redeemedAt: now,
+    };
+  }
+
+  /**
+   * Operator-initiated revoke. Returns true iff a record was removed.
+   * Idempotent — calling revoke on an unknown token returns false rather
+   * than throwing.
+   */
+  revoke(token: string): boolean {
+    if (typeof token !== 'string' || token.length === 0) return false;
+    const sessionId = this.byToken.get(token);
+    if (sessionId === undefined) return false;
+    this.byToken.delete(token);
+    this.bySession.delete(sessionId);
+    return true;
+  }
+
+  /**
+   * Drop every record whose `expiresAt` is in the past. Returns the
+   * count removed. Safe to call frequently — both indices are walked
+   * synchronously so there are no await boundaries to interleave with
+   * register/redeem.
+   */
+  pruneExpired(): number {
+    const now = this.now();
+    let purged = 0;
+    for (const [sessionId, record] of this.bySession.entries()) {
+      if (now >= record.expiresAt) {
+        this.byToken.delete(record.token);
+        this.bySession.delete(sessionId);
+        purged += 1;
+      }
+    }
+    return purged;
+  }
+
+  /**
+   * Snapshot of currently-active records. Useful for diagnostics; copies
+   * the underlying records so callers cannot mutate the internal map.
+   */
+  list(): HandoffRecord[] {
+    return [...this.bySession.values()].map((r) => ({ ...r }));
+  }
+
+  /** Number of currently-active records. */
+  size(): number {
+    return this.bySession.size;
+  }
+
+  /**
+   * Cancel the periodic prune timer without clearing stored records.
+   * Useful when the caller wants to drive pruning manually via
+   * {@link pruneExpired} on its own schedule.
+   * Returns true iff a timer was running and has been cancelled.
+   */
+  stopPrune(): boolean {
+    if (this.timer === undefined) return false;
+    clearInterval(this.timer);
+    this.timer = undefined;
+    return true;
+  }
+
+  /**
+   * Tear down the prune timer and drop every stored record. Hosts should
+   * call this when shutting down to release the timer immediately — the
+   * `.unref()` on construction means it would not block exit, but
+   * explicit cleanup keeps long-lived test processes from leaking timers.
+   */
+  dispose(): void {
+    this.stopPrune();
+    this.bySession.clear();
+    this.byToken.clear();
+  }
+}

--- a/src/pilot/handoff/token.ts
+++ b/src/pilot/handoff/token.ts
@@ -1,0 +1,100 @@
+/**
+ * Handoff token utilities (Phase 3, issue #793).
+ *
+ * Pilot-tier primitive that lets an MCP client transfer browser-session
+ * ownership to another agent. This module deals only with the token bytes
+ * and the structured payload that accompanies them:
+ *
+ *   - Generation: 32 bytes from `node:crypto` randomBytes, encoded with
+ *     base64url (URL-safe, no padding). Yields a 43-character ASCII token.
+ *   - Verification: `crypto.timingSafeEqual` after structural length /
+ *     charset validation, so a malformed candidate cannot leak timing
+ *     information about a stored token.
+ *   - Single-use: the manager (`./manager.ts`) enforces — `redeem()`
+ *     removes the entry on success and refuses subsequent attempts.
+ *
+ * Storage at rest is out of scope for this PR — issue #794 will land
+ * keychain / AES-256-GCM persistence on top of the in-memory registry.
+ * See docs/roadmap/portability-harness-contract.md "Handoff token
+ * encryption" for the persistence design.
+ */
+
+import * as crypto from 'node:crypto';
+
+/** Number of random bytes that back a handoff token. */
+export const HANDOFF_TOKEN_BYTES = 32;
+/** Length of the resulting base64url string (no padding). */
+export const HANDOFF_TOKEN_LENGTH = Math.ceil((HANDOFF_TOKEN_BYTES * 4) / 3);
+/** base64url charset, used to reject obviously malformed candidates early. */
+const TOKEN_CHARSET = /^[A-Za-z0-9_-]+$/;
+/** Default time-to-live for a freshly minted token. 5 minutes. */
+export const DEFAULT_TOKEN_TTL_MS = 5 * 60 * 1000;
+
+export interface CreateHandoffTokenArgs {
+  /** Browser session being transferred. Required. */
+  sessionId: string;
+  /**
+   * Caller-defined scope label (e.g. "checkout", "read-only"). Free-form;
+   * the manager surfaces it back when the token is redeemed so the receiving
+   * agent can branch on it without a separate side-channel.
+   */
+  scope: string;
+  /**
+   * Optional explicit TTL in ms. Falls back to {@link DEFAULT_TOKEN_TTL_MS}.
+   * Non-finite, zero or negative inputs are coerced to the default rather
+   * than silently producing an already-expired token.
+   */
+  ttlMs?: number;
+  /** Test hook: clock override. */
+  now?: () => number;
+}
+
+export interface HandoffTokenResult {
+  /** Base64url-encoded random 32 bytes. URL-safe, no padding. */
+  token: string;
+  /** Wall-clock ms (epoch) at which the token becomes invalid. */
+  expiresAt: number;
+}
+
+/**
+ * Mint a fresh handoff token. Pure — does not register the token with
+ * any manager. Callers that want lifecycle tracking should hand the
+ * result to {@link HandoffManager.register}.
+ */
+export function createHandoffToken(args: CreateHandoffTokenArgs): HandoffTokenResult {
+  if (typeof args.sessionId !== 'string' || args.sessionId.length === 0) {
+    throw new Error('createHandoffToken: sessionId is required');
+  }
+  if (typeof args.scope !== 'string' || args.scope.length === 0) {
+    throw new Error('createHandoffToken: scope is required');
+  }
+  const ttl = normalizeTtl(args.ttlMs);
+  const now = (args.now ?? Date.now)();
+  return {
+    token: crypto.randomBytes(HANDOFF_TOKEN_BYTES).toString('base64url'),
+    expiresAt: now + ttl,
+  };
+}
+
+/**
+ * Timing-safe comparison of a candidate token against the expected one.
+ * Returns false (without throwing) for malformed, wrong-charset, or
+ * wrong-length input so callers do not need to wrap this in a try/catch.
+ */
+export function verifyHandoffToken(candidate: string, expected: string): boolean {
+  if (typeof candidate !== 'string' || typeof expected !== 'string') return false;
+  if (candidate.length !== expected.length) return false;
+  if (candidate.length !== HANDOFF_TOKEN_LENGTH) return false;
+  if (!TOKEN_CHARSET.test(candidate) || !TOKEN_CHARSET.test(expected)) return false;
+  const a = Buffer.from(candidate, 'utf8');
+  const b = Buffer.from(expected, 'utf8');
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+function normalizeTtl(ms: number | undefined): number {
+  if (ms === undefined) return DEFAULT_TOKEN_TTL_MS;
+  if (typeof ms !== 'number' || !Number.isFinite(ms) || ms <= 0) {
+    return DEFAULT_TOKEN_TTL_MS;
+  }
+  return Math.floor(ms);
+}

--- a/src/pilot/handoff/tool.ts
+++ b/src/pilot/handoff/tool.ts
@@ -1,0 +1,253 @@
+/**
+ * MCP tool surface for the pilot handoff primitive (Phase 3, issue #793).
+ *
+ * Exposes two tools, both gated by `isHandoffPersistEnabled()`:
+ *
+ *   oc_pilot_handoff_create   — mint a token for { sessionId, scope, ttlMs }
+ *   oc_pilot_handoff_redeem   — exchange a token for the originating record
+ *
+ * The "handoff_persist" family flag covers both the in-memory primitive
+ * (this PR) and the persistence layer (#794) because the two ship as a
+ * unit — operators that want one want the other. When the flag is off,
+ * the tools register but every call settles `{ ok: false, reason:
+ * "disabled" }` so the agent receives a structured response rather than
+ * a missing-tool error.
+ *
+ * Pilot-tier convention: this module owns its own process-wide singleton
+ * `HandoffManager` so multiple registrations (one per server instance)
+ * share the same in-memory store. Tests can swap it via
+ * {@link _resetHandoffManagerForTesting}.
+ */
+
+import { MCPServer } from '../../mcp-server.js';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../../types/mcp.js';
+import { isHandoffPersistEnabled } from '../../harness/flags.js';
+import { HandoffManager } from './manager.js';
+import { renderHandoffBanner } from './banner.js';
+import { verifyHandoffToken, DEFAULT_TOKEN_TTL_MS } from './token.js';
+
+/**
+ * Process-wide handoff store. The singleton is intentional — pilot
+ * registers tools per MCPServer instance, but a token minted on one
+ * server must redeem on another (the whole point of handoff). Use
+ * {@link _resetHandoffManagerForTesting} from tests to drop state.
+ */
+let manager: HandoffManager | undefined;
+
+function getManager(): HandoffManager {
+  if (manager === undefined) {
+    manager = new HandoffManager();
+  }
+  return manager;
+}
+
+/**
+ * Test-only hook. Disposes any existing manager (clearing its timer) and
+ * lets the next `getManager()` call create a fresh one. Exposed with a
+ * leading underscore so production callers do not depend on it.
+ */
+export function _resetHandoffManagerForTesting(): void {
+  if (manager !== undefined) {
+    manager.dispose();
+    manager = undefined;
+  }
+}
+
+interface CreateOutput extends Record<string, unknown> {
+  ok: boolean;
+  reason?: 'disabled' | 'invalid_args';
+  token?: string;
+  expires_at?: number;
+  banner?: string;
+  scope?: string;
+  session_id?: string;
+  error_message?: string;
+}
+
+interface RedeemOutput extends Record<string, unknown> {
+  ok: boolean;
+  reason?: 'disabled' | 'invalid_args' | 'unknown_token';
+  session_id?: string;
+  scope?: string;
+  expires_at?: number;
+  created_at?: number;
+  redeemed_at?: number;
+  banner?: string;
+  error_message?: string;
+}
+
+const createDefinition: MCPToolDefinition = {
+  name: 'oc_pilot_handoff_create',
+  description:
+    'Pilot-tier: mint a single-use handoff token that lets another agent ' +
+    'inherit the named browser session. In-memory only; process restart ' +
+    'drops every active handoff. Gated by --pilot + handoff_persist family.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      session_id: {
+        type: 'string',
+        description: 'Browser session being transferred. Required.',
+      },
+      scope: {
+        type: 'string',
+        description:
+          'Caller-defined scope label (e.g. "checkout", "read-only"). ' +
+          'Surfaced back to the redeeming agent. Required.',
+      },
+      ttl_ms: {
+        type: 'number',
+        description:
+          'Optional explicit TTL in ms. Defaults to ' +
+          `${DEFAULT_TOKEN_TTL_MS}ms (5 min). Non-finite, zero, or negative ` +
+          'values fall back to the default.',
+      },
+    },
+    required: ['session_id', 'scope'],
+  },
+};
+
+const redeemDefinition: MCPToolDefinition = {
+  name: 'oc_pilot_handoff_redeem',
+  description:
+    'Pilot-tier: redeem a single-use handoff token previously minted by ' +
+    'oc_pilot_handoff_create. Consumes the record on success — subsequent ' +
+    'calls with the same token return unknown_token. Gated by --pilot + ' +
+    'handoff_persist family.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      token: {
+        type: 'string',
+        description: 'Token returned by oc_pilot_handoff_create.',
+      },
+    },
+    required: ['token'],
+  },
+};
+
+const createHandler: ToolHandler = async (
+  _sessionId: string,
+  args: Record<string, unknown>,
+): Promise<MCPResult> => {
+  if (!isHandoffPersistEnabled()) {
+    return jsonResult<CreateOutput>({
+      ok: false,
+      reason: 'disabled',
+      error_message:
+        'handoff_persist family is disabled — start the server with ' +
+        '`--pilot` (and do not unset OPENCHROME_HANDOFF_PERSIST).',
+    });
+  }
+  const sessionIdArg = args.session_id;
+  const scopeArg = args.scope;
+  const ttlArg = args.ttl_ms;
+  if (typeof sessionIdArg !== 'string' || sessionIdArg.length === 0) {
+    return jsonResult<CreateOutput>({
+      ok: false,
+      reason: 'invalid_args',
+      error_message: 'session_id is required and must be a non-empty string',
+    });
+  }
+  if (typeof scopeArg !== 'string' || scopeArg.length === 0) {
+    return jsonResult<CreateOutput>({
+      ok: false,
+      reason: 'invalid_args',
+      error_message: 'scope is required and must be a non-empty string',
+    });
+  }
+  const result = getManager().register({
+    sessionId: sessionIdArg,
+    scope: scopeArg,
+    ttlMs: typeof ttlArg === 'number' ? ttlArg : undefined,
+  });
+  const banner = renderHandoffBanner({
+    sessionId: sessionIdArg,
+    scope: scopeArg,
+    expiresAt: result.expiresAt,
+  });
+  return jsonResult<CreateOutput>({
+    ok: true,
+    token: result.token,
+    expires_at: result.expiresAt,
+    banner,
+    scope: scopeArg,
+    session_id: sessionIdArg,
+  });
+};
+
+const redeemHandler: ToolHandler = async (
+  _sessionId: string,
+  args: Record<string, unknown>,
+): Promise<MCPResult> => {
+  if (!isHandoffPersistEnabled()) {
+    return jsonResult<RedeemOutput>({
+      ok: false,
+      reason: 'disabled',
+      error_message:
+        'handoff_persist family is disabled — start the server with ' +
+        '`--pilot` (and do not unset OPENCHROME_HANDOFF_PERSIST).',
+    });
+  }
+  const tokenArg = args.token;
+  if (typeof tokenArg !== 'string' || tokenArg.length === 0) {
+    return jsonResult<RedeemOutput>({
+      ok: false,
+      reason: 'invalid_args',
+      error_message: 'token is required and must be a non-empty string',
+    });
+  }
+  const redemption = getManager().redeem(tokenArg);
+  if (redemption === null) {
+    return jsonResult<RedeemOutput>({
+      ok: false,
+      reason: 'unknown_token',
+      error_message: 'token is unknown, expired, or already redeemed',
+    });
+  }
+  // Defensive: timing-safe verify against the originating token format.
+  // `verifyHandoffToken` rejects malformed candidates without throwing;
+  // we never receive the original here (it was consumed), so we compare
+  // the supplied token against itself purely to assert the charset /
+  // length invariants survived round-tripping.
+  if (!verifyHandoffToken(tokenArg, tokenArg)) {
+    return jsonResult<RedeemOutput>({
+      ok: false,
+      reason: 'unknown_token',
+      error_message: 'token failed structural verification',
+    });
+  }
+  const banner = renderHandoffBanner({
+    sessionId: redemption.sessionId,
+    scope: redemption.scope,
+    expiresAt: redemption.expiresAt,
+    now: () => redemption.redeemedAt,
+  });
+  return jsonResult<RedeemOutput>({
+    ok: true,
+    session_id: redemption.sessionId,
+    scope: redemption.scope,
+    expires_at: redemption.expiresAt,
+    created_at: redemption.createdAt,
+    redeemed_at: redemption.redeemedAt,
+    banner,
+  });
+};
+
+function jsonResult<T extends Record<string, unknown>>(payload: T): MCPResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload) }],
+    ...payload,
+  };
+}
+
+/**
+ * Register both pilot handoff MCP tools onto the given server. Idempotent
+ * per server (the underlying registry overwrites by name). Wired through
+ * `src/pilot/index.ts` so registration happens iff `--pilot` opened the
+ * bootstrap path.
+ */
+export function registerOcPilotHandoffTool(server: MCPServer): void {
+  server.registerTool('oc_pilot_handoff_create', createHandler, createDefinition);
+  server.registerTool('oc_pilot_handoff_redeem', redeemHandler, redeemDefinition);
+}

--- a/src/pilot/index.ts
+++ b/src/pilot/index.ts
@@ -28,3 +28,6 @@
 // Keep this as a namespace export so adding sibling subdirs later does not
 // reorder the public surface and break consumer destructuring.
 export * as runtime from './runtime/index.js';
+
+// Phase 3 (issue #793): pilot-tier handoff token + manager.
+export * as handoff from './handoff/index.js';

--- a/tests/pilot/handoff/manager.test.ts
+++ b/tests/pilot/handoff/manager.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for HandoffManager (Phase 3, issue #793).
+ *
+ * All tests drive a fake clock via the `now` option so they never sleep.
+ * The prune timer is disabled (`pruneIntervalMs: 0`) except in the
+ * stopPrune test which exercises the live timer path.
+ */
+
+import { HandoffManager } from '../../../src/pilot/handoff/manager.js';
+import { HANDOFF_TOKEN_LENGTH } from '../../../src/pilot/handoff/token.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeManager(nowMs = 1_000_000) {
+  let clock = nowMs;
+  const now = () => clock;
+  const advance = (ms: number) => {
+    clock += ms;
+  };
+  const manager = new HandoffManager({ pruneIntervalMs: 0, now });
+  return { manager, now, advance };
+}
+
+// ---------------------------------------------------------------------------
+// Create + redeem round-trip
+// ---------------------------------------------------------------------------
+
+describe('HandoffManager — create + redeem round-trip', () => {
+  it('register returns a base64url token with correct length', () => {
+    const { manager } = makeManager();
+    const result = manager.register({ sessionId: 'sess-1', scope: 'checkout' });
+    expect(typeof result.token).toBe('string');
+    expect(result.token.length).toBe(HANDOFF_TOKEN_LENGTH);
+    expect(/^[A-Za-z0-9_-]+$/.test(result.token)).toBe(true);
+    manager.dispose();
+  });
+
+  it('redeem returns the payload for a valid token', () => {
+    const { manager } = makeManager();
+    const { token } = manager.register({ sessionId: 'sess-2', scope: 'read-only' });
+    const redemption = manager.redeem(token);
+    expect(redemption).not.toBeNull();
+    expect(redemption!.sessionId).toBe('sess-2');
+    expect(redemption!.scope).toBe('read-only');
+    expect(typeof redemption!.expiresAt).toBe('number');
+    expect(typeof redemption!.createdAt).toBe('number');
+    expect(typeof redemption!.redeemedAt).toBe('number');
+    manager.dispose();
+  });
+
+  it('redeem is single-use — second call returns null', () => {
+    const { manager } = makeManager();
+    const { token } = manager.register({ sessionId: 'sess-3', scope: 'write' });
+    expect(manager.redeem(token)).not.toBeNull();
+    expect(manager.redeem(token)).toBeNull();
+    manager.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wrong token returns null
+// ---------------------------------------------------------------------------
+
+describe('HandoffManager — wrong token returns null', () => {
+  it('returns null for an unknown token string', () => {
+    const { manager } = makeManager();
+    manager.register({ sessionId: 'sess-4', scope: 'admin' });
+    expect(manager.redeem('this-is-not-a-real-token')).toBeNull();
+    manager.dispose();
+  });
+
+  it('returns null for an empty string', () => {
+    const { manager } = makeManager();
+    expect(manager.redeem('')).toBeNull();
+    manager.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Revoke removes
+// ---------------------------------------------------------------------------
+
+describe('HandoffManager — revoke', () => {
+  it('revoke returns true and the token can no longer be redeemed', () => {
+    const { manager } = makeManager();
+    const { token } = manager.register({ sessionId: 'sess-5', scope: 'checkout' });
+    expect(manager.revoke(token)).toBe(true);
+    expect(manager.redeem(token)).toBeNull();
+    manager.dispose();
+  });
+
+  it('revoke on unknown token returns false', () => {
+    const { manager } = makeManager();
+    expect(manager.revoke('not-a-real-token')).toBe(false);
+    manager.dispose();
+  });
+
+  it('revoke decrements size', () => {
+    const { manager } = makeManager();
+    const { token } = manager.register({ sessionId: 'sess-6', scope: 'x' });
+    expect(manager.size()).toBe(1);
+    manager.revoke(token);
+    expect(manager.size()).toBe(0);
+    manager.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TTL expiry returns null
+// ---------------------------------------------------------------------------
+
+describe('HandoffManager — TTL expiry', () => {
+  it('redeem returns null after the token expires', () => {
+    const { manager, advance } = makeManager();
+    const { token } = manager.register({
+      sessionId: 'sess-7',
+      scope: 'short-lived',
+      ttlMs: 500,
+    });
+    advance(501);
+    expect(manager.redeem(token)).toBeNull();
+    manager.dispose();
+  });
+
+  it('redeem succeeds just before expiry', () => {
+    const { manager, advance } = makeManager();
+    const { token } = manager.register({
+      sessionId: 'sess-8',
+      scope: 'just-in-time',
+      ttlMs: 1000,
+    });
+    advance(999);
+    expect(manager.redeem(token)).not.toBeNull();
+    manager.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pruneExpired returns count
+// ---------------------------------------------------------------------------
+
+describe('HandoffManager — pruneExpired', () => {
+  it('returns 0 when nothing has expired', () => {
+    const { manager } = makeManager();
+    manager.register({ sessionId: 'sess-9', scope: 'a', ttlMs: 10_000 });
+    manager.register({ sessionId: 'sess-10', scope: 'b', ttlMs: 10_000 });
+    expect(manager.pruneExpired()).toBe(0);
+    manager.dispose();
+  });
+
+  it('returns count of expired records and removes them', () => {
+    const { manager, advance } = makeManager();
+    manager.register({ sessionId: 'sess-11', scope: 'a', ttlMs: 100 });
+    manager.register({ sessionId: 'sess-12', scope: 'b', ttlMs: 100 });
+    manager.register({ sessionId: 'sess-13', scope: 'c', ttlMs: 10_000 });
+    advance(200);
+    const pruned = manager.pruneExpired();
+    expect(pruned).toBe(2);
+    expect(manager.size()).toBe(1);
+    manager.dispose();
+  });
+
+  it('expired records cannot be redeemed after pruneExpired', () => {
+    const { manager, advance } = makeManager();
+    const { token } = manager.register({ sessionId: 'sess-14', scope: 'x', ttlMs: 50 });
+    advance(100);
+    manager.pruneExpired();
+    expect(manager.redeem(token)).toBeNull();
+    manager.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stopPrune cancels the timer
+// ---------------------------------------------------------------------------
+
+describe('HandoffManager — stopPrune', () => {
+  it('stopPrune returns true when a timer is running and cancels it', () => {
+    // Use a real short interval so we can verify the timer was created.
+    let clock = 1_000_000;
+    const manager = new HandoffManager({
+      pruneIntervalMs: 60_000,
+      now: () => clock,
+    });
+    expect(manager.stopPrune()).toBe(true);
+    // A second call after the timer is already gone returns false.
+    expect(manager.stopPrune()).toBe(false);
+    manager.dispose();
+  });
+
+  it('stopPrune returns false when no timer was created (pruneIntervalMs: 0)', () => {
+    const { manager } = makeManager();
+    expect(manager.stopPrune()).toBe(false);
+    manager.dispose();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the pilot-tier handoff token primitive (in-memory only; persistence is #794)
- `HandoffManager` provides register/redeem/revoke/pruneExpired/stopPrune with O(1) redeem via dual index and a background prune timer (`.unref()`'d, default 60 s)
- Two MCP tools (`oc_pilot_handoff_create`, `oc_pilot_handoff_redeem`) gated by `isHandoffPersistEnabled()` from `src/harness/flags.ts`
- 15 unit tests; all verification gates green

## Files

| File | Role |
|---|---|
| `src/pilot/handoff/token.ts` | `createHandoffToken()` + `verifyHandoffToken()` — 32-byte base64url, timing-safe |
| `src/pilot/handoff/banner.ts` | `renderHandoffBanner()` — human-readable multi-line summary |
| `src/pilot/handoff/manager.ts` | `HandoffManager` — in-memory registry with stopPrune/dispose |
| `src/pilot/handoff/tool.ts` | MCP tool registration — create + redeem, flag-gated |
| `src/pilot/handoff/index.ts` | Barrel exports |
| `src/pilot/index.ts` | Adds `export * as handoff` namespace |
| `tests/pilot/handoff/manager.test.ts` | 15 tests covering all required scenarios |

## Verification gates

- `npm run build` — clean (no TS errors)
- `npm run lint` — clean
- `npm run lint:tier` — no dependency violations (293 modules, 610 deps)
- `npx jest tests/pilot/handoff/` — 15/15 passed

## Test plan

- [x] create + redeem round-trip
- [x] redeem with wrong token returns null
- [x] redeem is single-use (second call returns null)
- [x] revoke removes entry, subsequent redeem returns null
- [x] TTL expiry — redeem returns null after `expiresAt`
- [x] `pruneExpired()` returns count of expired records removed
- [x] `stopPrune()` cancels live timer; returns false when no timer

## Related

- Closes #793
- Persistence layer: #794 (out of scope for this PR)
- Follows design from closed PR #754 (evidence bundle MCP tool)
- Phase 3 cleanup series: #774, #780

🤖 Generated with [Claude Code](https://claude.com/claude-code)