### PR TITLE
feat(pilot): beforeIrreversibleAction hook (Phase 3, closes #795)

### DIFF
--- a/src/pilot/runtime/before-irreversible.ts
+++ b/src/pilot/runtime/before-irreversible.ts
@@ -1,0 +1,141 @@
+/**
+ * `beforeIrreversibleAction` hook — Phase 3 of the OpenChrome 1.11 cleanup
+ * (issue #795, replaces the cherry-pick from closed PR #756).
+ *
+ * The hook fires inside `runWithContract()` immediately before the skill
+ * (the "irreversible action") executes, but ONLY for contracts flagged
+ * `critical: true`. This gives operators a single chokepoint to require
+ * additional verification — manual confirm, MFA challenge, audit-trail
+ * write — before the skill performs a side effect that cannot be undone
+ * (submit checkout, send transfer, delete record).
+ *
+ * Activation:
+ *   - The hook firing path is gated by `isContractRuntimeEnabled()` via
+ *     its only caller, `runWithContract()`. When the contract runtime
+ *     family is off, `runWithContract()` short-circuits to the disabled
+ *     no-op path BEFORE this module is exercised. As a result the hook is
+ *     unreachable when `--pilot` is unset, satisfying the P2 1.10.4
+ *     behavior-preserved invariant.
+ *   - Even with the runtime enabled, non-critical contracts pass through
+ *     unchanged: `runWithContract()` does not invoke the hook unless
+ *     `contract.critical === true`.
+ *
+ * Operator API:
+ *   - `registerBeforeIrreversibleHook(hook)` installs a single hook,
+ *     replacing any previously registered hook. The default registered
+ *     hook is a no-op pass-through that always returns `{ proceed: true }`
+ *     so the 1.10.4 behavior is preserved when no operator registers a
+ *     custom hook.
+ *   - Replacement emits a `console.error` warning so operators that
+ *     accidentally double-register can spot the override during a smoke
+ *     test. Per CLAUDE.md `console.log` is forbidden — it corrupts the
+ *     MCP JSON-RPC stream on stdout.
+ *   - `resetBeforeIrreversibleHookForTests()` restores the default no-op
+ *     hook; intended only for test setup/teardown.
+ *
+ * Hook contract:
+ *   - The hook receives `{ contractId, action, evidence }` describing the
+ *     contract about to fire, the operator-supplied action label, and any
+ *     pre-condition evidence the runtime has already gathered (so the
+ *     hook can authenticate against the same probe data the runtime is
+ *     about to act on).
+ *   - The hook returns one of:
+ *       `{ proceed: true }` — runtime executes the skill.
+ *       `{ proceed: false, reason: string }` — runtime aborts before the
+ *         skill runs and settles with verdict `aborted_by_hook`.
+ *       `{ proceed: 'await-human', externalToken: string }` — runtime
+ *         aborts in the same way; the token is recorded so an external
+ *         confirmation system (signed approval, MFA challenge) can later
+ *         resume the workflow out-of-band.
+ *   - The hook may be sync or async. Throws are caught by the caller and
+ *     surface as an aborted decision so an unhealthy hook can never let
+ *     an irreversible action execute by accident.
+ */
+
+import type { Evidence } from '../../contracts/types.js';
+
+/**
+ * Input passed to the hook on every fire.
+ *
+ * `action` is a free-form operator-supplied label (e.g.
+ * `"submit-checkout"`). The runtime does not interpret it — it is forwarded
+ * as-is so the hook can drive policy lookups, audit log entries, or human-
+ * facing confirmation prompts.
+ *
+ * `evidence` is the pre-condition `Evidence` block the runtime gathered
+ * (when `contract.pre` is set and passed); `undefined` when the contract
+ * has no precondition or the runtime never ran one.
+ */
+export interface BeforeIrreversibleHookInput {
+  contractId: string;
+  action: string;
+  evidence?: Evidence;
+}
+
+/**
+ * Decision returned by the hook.
+ *
+ *   - `{ proceed: true }` — runtime continues into the skill.
+ *   - `{ proceed: false, reason }` — runtime aborts; `reason` is preserved
+ *     verbatim on the resulting `TransactionRecord.error_message` so the
+ *     audit log records why the irreversible action was blocked.
+ *   - `{ proceed: 'await-human', externalToken }` — runtime aborts and
+ *     records the token on the resulting record so an out-of-band system
+ *     (signed approval, MFA challenge) can later resume the workflow.
+ */
+export type BeforeIrreversibleDecision =
+  | { proceed: true }
+  | { proceed: false; reason: string }
+  | { proceed: 'await-human'; externalToken: string };
+
+/** Operator hook signature. May be sync or async. */
+export type BeforeIrreversibleHook = (
+  input: BeforeIrreversibleHookInput,
+) => BeforeIrreversibleDecision | Promise<BeforeIrreversibleDecision>;
+
+/**
+ * Default registered hook — a no-op pass-through. Always proceeds so the
+ * pre-#795 (1.10.4) behavior is preserved when no operator has installed
+ * a custom hook. Exported so callers (and the reset helper) can detect
+ * the default vs an operator-installed instance via identity comparison.
+ */
+export const defaultBeforeIrreversibleHook: BeforeIrreversibleHook = () => ({
+  proceed: true,
+});
+
+let registeredHook: BeforeIrreversibleHook = defaultBeforeIrreversibleHook;
+
+/**
+ * Register the operator's `beforeIrreversibleAction` hook. There is a
+ * single registered hook at any time; calling this again replaces the
+ * previously registered hook. A `console.error` warning is emitted on
+ * replacement (but not when the default no-op is being replaced for the
+ * first time) so operators that accidentally double-register can spot
+ * the override during a smoke test.
+ */
+export function registerBeforeIrreversibleHook(hook: BeforeIrreversibleHook): void {
+  if (registeredHook !== defaultBeforeIrreversibleHook) {
+    // Use console.error per CLAUDE.md — console.log corrupts MCP JSON-RPC.
+    console.error(
+      '[pilot] beforeIrreversibleAction hook replaced; previously registered hook is no longer active',
+    );
+  }
+  registeredHook = hook;
+}
+
+/**
+ * Return the currently registered hook. Internal helper used by
+ * `runWithContract()` so the hook can be swapped at runtime without the
+ * runtime caching a stale reference.
+ */
+export function getBeforeIrreversibleHook(): BeforeIrreversibleHook {
+  return registeredHook;
+}
+
+/**
+ * Restore the default no-op hook. Intended for test setup / teardown so
+ * tests do not leak hook state into one another.
+ */
+export function resetBeforeIrreversibleHookForTests(): void {
+  registeredHook = defaultBeforeIrreversibleHook;
+}

--- a/src/pilot/runtime/index.ts
+++ b/src/pilot/runtime/index.ts
@@ -6,8 +6,8 @@
  *
  * Import-safety guarantee: this module must NOT throw on load even if
  * other pilot subdirectories (executor, handoff, voting, curator) are
- * missing. We only re-export from `./runtime.js` and `./types.js` so the
- * surface stays self-contained.
+ * missing. We only re-export from `./runtime.js`, `./types.js`, and
+ * `./before-irreversible.js` so the surface stays self-contained.
  */
 
 export {
@@ -15,6 +15,13 @@ export {
   LogAuditEntryEmitter,
   runWithContract,
 } from './runtime.js';
+
+export {
+  defaultBeforeIrreversibleHook,
+  getBeforeIrreversibleHook,
+  registerBeforeIrreversibleHook,
+  resetBeforeIrreversibleHookForTests,
+} from './before-irreversible.js';
 
 export type {
   AuditEmitter,
@@ -24,3 +31,9 @@ export type {
   TransactionRecord,
   Verdict,
 } from './types.js';
+
+export type {
+  BeforeIrreversibleDecision,
+  BeforeIrreversibleHook,
+  BeforeIrreversibleHookInput,
+} from './before-irreversible.js';

--- a/src/pilot/runtime/runtime.ts
+++ b/src/pilot/runtime/runtime.ts
@@ -43,6 +43,7 @@ import type { EvalContext } from '../../contracts/eval-context.js';
 import { evaluate } from '../../contracts/evaluate.js';
 import { validateAssertion, type ValidationError } from '../../contracts/validator.js';
 import { isContractRuntimeEnabled } from '../../harness/flags.js';
+import { getBeforeIrreversibleHook } from './before-irreversible.js';
 import type {
   AuditEmitter,
   Contract,
@@ -233,7 +234,80 @@ export async function runWithContract(args: ContractRuntimeArgs): Promise<Transa
     }
   }
 
-  // 3. Execute skill (cooperative budget tracking).
+  // 3. beforeIrreversibleAction hook — fires immediately before the
+  //    skill executes, but only for contracts flagged `critical: true`.
+  //    Non-critical contracts pass through unchanged, preserving 1.10.4
+  //    behavior by default (issue #795). The default registered hook is
+  //    a no-op pass-through, so even critical contracts proceed normally
+  //    until an operator installs a custom hook via
+  //    `registerBeforeIrreversibleHook()`.
+  //
+  //    The hook firing path is reachable only when
+  //    `isContractRuntimeEnabled()` returned true at the top of this
+  //    function — when the pilot tier is unset the runtime short-circuits
+  //    before this block runs (P2: 1.10.4 behavior preserved).
+  if (args.contract.critical === true) {
+    const action = args.contract.action ?? args.contract.id;
+    const hook = getBeforeIrreversibleHook();
+    let decision;
+    try {
+      decision = await hook({
+        contractId: args.contract.id,
+        action,
+        evidence: pre_evidence,
+      });
+    } catch (e) {
+      // The runtime contract is "always settles". A throwing operator
+      // hook must never let an irreversible action execute by accident,
+      // so we treat a throw as an implicit deny and abort with the
+      // throw message captured on the record.
+      return emit({
+        txn_id,
+        contract_id: args.contract.id,
+        verdict: 'aborted_by_hook',
+        started_at: startedAt,
+        ended_at: now(),
+        wall_ms: now() - startedAt,
+        retries: 0,
+        pre_evidence,
+        error_message: `beforeIrreversibleAction hook threw: ${errMsg(e)}`,
+        hook_decision: { action, reason: errMsg(e) },
+      });
+    }
+    if (decision.proceed === false) {
+      return emit({
+        txn_id,
+        contract_id: args.contract.id,
+        verdict: 'aborted_by_hook',
+        started_at: startedAt,
+        ended_at: now(),
+        wall_ms: now() - startedAt,
+        retries: 0,
+        pre_evidence,
+        error_message: decision.reason,
+        hook_decision: { action, reason: decision.reason },
+      });
+    }
+    if (decision.proceed === 'await-human') {
+      return emit({
+        txn_id,
+        contract_id: args.contract.id,
+        verdict: 'aborted_by_hook',
+        started_at: startedAt,
+        ended_at: now(),
+        wall_ms: now() - startedAt,
+        retries: 0,
+        pre_evidence,
+        error_message: `beforeIrreversibleAction hook deferred to external resume (token=${decision.externalToken})`,
+        hook_decision: { action, external_token: decision.externalToken },
+      });
+    }
+    // decision.proceed === true — fall through to the skill execution
+    // path. No `hook_decision` is emitted on success to keep the audit
+    // record compact for the common case.
+  }
+
+  // 4. Execute skill (cooperative budget tracking).
   //    Normalize wall_ms so non-finite or negative values cannot
   //    silently disable the budget guard (`x > NaN` is always false) or
   //    force every call to fail (`-1` immediately exhausts). See Codex
@@ -271,7 +345,7 @@ export async function runWithContract(args: ContractRuntimeArgs): Promise<Transa
     });
   }
 
-  // 4. Post-check with retry + backoff. Normalize the retry count so a
+  // 5. Post-check with retry + backoff. Normalize the retry count so a
   //    runtime-supplied non-integer / NaN cannot drive an infinite loop
   //    (`attempt >= NaN` is always false) or expand the retry budget
   //    silently. See Codex round 3 (24481ed) and round 6 (d593354).
@@ -366,7 +440,7 @@ export async function runWithContract(args: ContractRuntimeArgs): Promise<Transa
     });
   }
 
-  // 5. Escalate or postcondition_violation. The three escalate values
+  // 6. Escalate or postcondition_violation. The three escalate values
   //    are handled distinctly: 'human-review' / 'headed-handoff' route
   //    to the 'escalated' verdict; 'abort' is an explicit "settle as
   //    failed, do not escalate" so the audit trail records that the

--- a/src/pilot/runtime/types.ts
+++ b/src/pilot/runtime/types.ts
@@ -38,6 +38,23 @@ export interface Contract {
   idempotency_key?: string;
   /** Domain label for audit log routing. */
   domain?: string;
+  /**
+   * Marks the skill as performing an irreversible side effect (submit
+   * checkout, send transfer, delete record). When true the runtime fires
+   * the `beforeIrreversibleAction` hook immediately before invoking the
+   * skill so operators can require additional verification. Non-critical
+   * contracts (`critical: false` / omitted) pass through unchanged —
+   * preserving 1.10.4 behavior by default. See issue #795.
+   */
+  critical?: boolean;
+  /**
+   * Operator-supplied action label forwarded to the
+   * `beforeIrreversibleAction` hook (e.g. `"submit-checkout"`,
+   * `"send-transfer"`). The runtime does not interpret it. Defaults to
+   * the contract id when omitted so the hook always receives a non-empty
+   * action string.
+   */
+  action?: string;
 }
 
 /** Verdict taxonomy emitted by the runtime. Exactly one per call. */
@@ -48,7 +65,8 @@ export type Verdict =
   | 'budget_exhausted'
   | 'execution_error'
   | 'validation_error'
-  | 'escalated';
+  | 'escalated'
+  | 'aborted_by_hook';
 
 /** Final settle record emitted by the runtime for every call. */
 export interface TransactionRecord {
@@ -80,6 +98,20 @@ export interface TransactionRecord {
   escalation?: { target: 'human-review' | 'headed-handoff' };
   /** Result returned by the skill on success paths. */
   skill_result?: unknown;
+  /**
+   * Decision summary written when verdict === 'aborted_by_hook' — captures
+   * the operator-supplied action label and either the deny reason or the
+   * external-token issued for an `await-human` resume. The `evidence` from
+   * the hook input is intentionally not duplicated here (it is already on
+   * `pre_evidence`) to keep the record compact. See issue #795.
+   */
+  hook_decision?: {
+    action: string;
+    /** Set when the hook returned `{ proceed: false, reason }`. */
+    reason?: string;
+    /** Set when the hook returned `{ proceed: 'await-human', externalToken }`. */
+    external_token?: string;
+  };
 }
 
 export type SkillFn = () => Promise<unknown>;

--- a/tests/pilot/runtime/before-irreversible.test.ts
+++ b/tests/pilot/runtime/before-irreversible.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Tests for the `beforeIrreversibleAction` hook (issue #795, Phase 3).
+ *
+ * Coverage:
+ *   - Hook not invoked for non-critical contracts (default behavior preserved)
+ *   - Default hook (no registration) returns proceed:true, contract proceeds
+ *   - Registered hook returning `{ proceed: false, reason }` aborts with
+ *     verdict `aborted_by_hook` and reason in the record
+ *   - Registered hook returning `{ proceed: 'await-human', externalToken }`
+ *     aborts with token in the record
+ *   - Registering a second hook warns via console.error
+ *   - Hook throw is treated as implicit deny (always-settles guarantee)
+ *   - Non-critical contract is unchanged when hook is registered
+ */
+
+import { runWithContract } from '../../../src/pilot/runtime/index.js';
+import {
+  registerBeforeIrreversibleHook,
+  resetBeforeIrreversibleHookForTests,
+} from '../../../src/pilot/runtime/index.js';
+import type {
+  AuditEmitter,
+  TransactionRecord,
+} from '../../../src/pilot/runtime/index.js';
+import type { EvalContext } from '../../../src/contracts/eval-context.js';
+import type { Assertion } from '../../../src/contracts/types.js';
+import { resetFlagsCache } from '../../../src/harness/flags.js';
+
+// All tests run with the pilot flag forced on.
+beforeEach(() => {
+  process.argv = ['node', 'cli/index.js', '--pilot'];
+  resetFlagsCache();
+  resetBeforeIrreversibleHookForTests();
+});
+
+afterEach(() => {
+  resetBeforeIrreversibleHookForTests();
+});
+
+const POST_OK: Assertion = { kind: 'dom_text', contains: 'Done' };
+
+function ctx(bodyText = 'Done'): EvalContext {
+  return {
+    url: async () => 'https://example.com/',
+    domText: async () => bodyText,
+    domCount: async () => 0,
+    networkSince: async () => [],
+    screenshotPng: async () => null,
+    hasOpenDialog: async () => false,
+  };
+}
+
+function captureEmitter(): { emitter: AuditEmitter; records: TransactionRecord[] } {
+  const records: TransactionRecord[] = [];
+  return {
+    emitter: { emit: (r) => { records.push(r); } },
+    records,
+  };
+}
+
+describe('beforeIrreversibleAction hook — non-critical contracts', () => {
+  test('hook is NOT invoked for a non-critical contract (critical omitted)', async () => {
+    let hookCalls = 0;
+    registerBeforeIrreversibleHook(async () => {
+      hookCalls++;
+      return { proceed: true };
+    });
+
+    const r = await runWithContract({
+      contract: { id: 'non-critical', post: POST_OK },
+      skill: async () => 'ok',
+      snapshot: async () => ctx('Done'),
+    });
+
+    expect(r.verdict).toBe('success');
+    expect(hookCalls).toBe(0);
+  });
+
+  test('hook is NOT invoked for a contract with critical: false', async () => {
+    let hookCalls = 0;
+    registerBeforeIrreversibleHook(async () => {
+      hookCalls++;
+      return { proceed: true };
+    });
+
+    const r = await runWithContract({
+      contract: { id: 'non-critical-false', post: POST_OK, critical: false },
+      skill: async () => 'ok',
+      snapshot: async () => ctx('Done'),
+    });
+
+    expect(r.verdict).toBe('success');
+    expect(hookCalls).toBe(0);
+  });
+});
+
+describe('beforeIrreversibleAction hook — default behavior (no registration)', () => {
+  test('default hook allows critical contract to proceed (proceed: true)', async () => {
+    // No registerBeforeIrreversibleHook call — default no-op hook must fire
+    // and return proceed:true so the skill executes normally.
+    const r = await runWithContract({
+      contract: { id: 'critical-default', post: POST_OK, critical: true },
+      skill: async () => 'done',
+      snapshot: async () => ctx('Done'),
+    });
+
+    expect(r.verdict).toBe('success');
+    expect(r.skill_result).toBe('done');
+  });
+});
+
+describe('beforeIrreversibleAction hook — proceed: false', () => {
+  test('hook returning { proceed: false, reason } aborts with aborted_by_hook verdict', async () => {
+    registerBeforeIrreversibleHook(async () => ({
+      proceed: false,
+      reason: 'manual policy block',
+    }));
+
+    let skillCalls = 0;
+    const r = await runWithContract({
+      contract: { id: 'critical-blocked', post: POST_OK, critical: true },
+      skill: async () => {
+        skillCalls++;
+        return 'never';
+      },
+      snapshot: async () => ctx('Done'),
+    });
+
+    expect(r.verdict).toBe('aborted_by_hook');
+    expect(r.error_message).toBe('manual policy block');
+    expect(r.hook_decision?.reason).toBe('manual policy block');
+    expect(skillCalls).toBe(0);
+  });
+
+  test('aborted_by_hook record is emitted to audit', async () => {
+    const { emitter, records } = captureEmitter();
+    registerBeforeIrreversibleHook(async () => ({
+      proceed: false,
+      reason: 'audit check',
+    }));
+
+    const r = await runWithContract({
+      contract: { id: 'critical-audit', post: POST_OK, critical: true },
+      skill: async () => 'never',
+      snapshot: async () => ctx('Done'),
+      audit: emitter,
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].verdict).toBe('aborted_by_hook');
+    expect(r.contract_id).toBe('critical-audit');
+  });
+
+  test('action label in hook_decision defaults to contract id when action omitted', async () => {
+    registerBeforeIrreversibleHook(async () => ({
+      proceed: false,
+      reason: 'blocked',
+    }));
+
+    const r = await runWithContract({
+      contract: { id: 'my-contract', post: POST_OK, critical: true },
+      skill: async () => 'never',
+      snapshot: async () => ctx('Done'),
+    });
+
+    expect(r.hook_decision?.action).toBe('my-contract');
+  });
+
+  test('action label in hook_decision uses contract.action when set', async () => {
+    registerBeforeIrreversibleHook(async () => ({
+      proceed: false,
+      reason: 'blocked',
+    }));
+
+    const r = await runWithContract({
+      contract: {
+        id: 'my-contract',
+        post: POST_OK,
+        critical: true,
+        action: 'submit-checkout',
+      },
+      skill: async () => 'never',
+      snapshot: async () => ctx('Done'),
+    });
+
+    expect(r.hook_decision?.action).toBe('submit-checkout');
+  });
+});
+
+describe('beforeIrreversibleAction hook — proceed: await-human', () => {
+  test('hook returning await-human aborts with externalToken in details', async () => {
+    const token = 'approval-token-abc123';
+    registerBeforeIrreversibleHook(async () => ({
+      proceed: 'await-human',
+      externalToken: token,
+    }));
+
+    let skillCalls = 0;
+    const r = await runWithContract({
+      contract: { id: 'critical-await', post: POST_OK, critical: true },
+      skill: async () => {
+        skillCalls++;
+        return 'never';
+      },
+      snapshot: async () => ctx('Done'),
+    });
+
+    expect(r.verdict).toBe('aborted_by_hook');
+    expect(r.error_message).toContain(token);
+    expect(r.hook_decision?.external_token).toBe(token);
+    expect(skillCalls).toBe(0);
+  });
+
+  test('await-human record is emitted to audit with token', async () => {
+    const { emitter, records } = captureEmitter();
+    const token = 'mfa-challenge-xyz';
+    registerBeforeIrreversibleHook(async () => ({
+      proceed: 'await-human',
+      externalToken: token,
+    }));
+
+    await runWithContract({
+      contract: { id: 'critical-mfa', post: POST_OK, critical: true },
+      skill: async () => 'never',
+      snapshot: async () => ctx('Done'),
+      audit: emitter,
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].hook_decision?.external_token).toBe(token);
+  });
+});
+
+describe('beforeIrreversibleAction hook — registration warnings', () => {
+  test('registering a second hook emits a console.error warning', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      // First registration — replaces the default no-op (no warning).
+      registerBeforeIrreversibleHook(async () => ({ proceed: true }));
+      expect(errorSpy).not.toHaveBeenCalled();
+
+      // Second registration — replaces a non-default hook (warning).
+      registerBeforeIrreversibleHook(async () => ({ proceed: true }));
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0][0]).toContain('beforeIrreversibleAction hook replaced');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  test('registering over the default (first call) does NOT warn', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      registerBeforeIrreversibleHook(async () => ({ proceed: true }));
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});
+
+describe('beforeIrreversibleAction hook — always-settles guarantee', () => {
+  test('hook that throws is treated as implicit deny (aborted_by_hook)', async () => {
+    registerBeforeIrreversibleHook(async () => {
+      throw new Error('hook exploded');
+    });
+
+    let skillCalls = 0;
+    const r = await runWithContract({
+      contract: { id: 'critical-throw', post: POST_OK, critical: true },
+      skill: async () => {
+        skillCalls++;
+        return 'never';
+      },
+      snapshot: async () => ctx('Done'),
+    });
+
+    expect(r.verdict).toBe('aborted_by_hook');
+    expect(r.error_message).toContain('hook threw');
+    expect(r.error_message).toContain('hook exploded');
+    expect(skillCalls).toBe(0);
+  });
+});
+
+describe('beforeIrreversibleAction hook — proceed: true for critical contracts', () => {
+  test('hook returning { proceed: true } allows critical contract to execute', async () => {
+    let hookCalls = 0;
+    registerBeforeIrreversibleHook(async () => {
+      hookCalls++;
+      return { proceed: true };
+    });
+
+    const r = await runWithContract({
+      contract: { id: 'critical-allowed', post: POST_OK, critical: true },
+      skill: async () => 'executed',
+      snapshot: async () => ctx('Done'),
+    });
+
+    expect(r.verdict).toBe('success');
+    expect(r.skill_result).toBe('executed');
+    expect(hookCalls).toBe(1);
+  });
+
+  test('hook is invoked exactly once per runWithContract call', async () => {
+    let hookCalls = 0;
+    registerBeforeIrreversibleHook(async () => {
+      hookCalls++;
+      return { proceed: true };
+    });
+
+    await runWithContract({
+      contract: { id: 'critical-once', post: POST_OK, critical: true },
+      skill: async () => 'ok',
+      snapshot: async () => ctx('Done'),
+    });
+
+    expect(hookCalls).toBe(1);
+  });
+});
+
+describe('beforeIrreversibleAction hook — pre_evidence forwarded', () => {
+  test('hook receives pre_evidence when contract has a pre-condition', async () => {
+    let capturedEvidence: unknown;
+    registerBeforeIrreversibleHook(async (input) => {
+      capturedEvidence = input.evidence;
+      return { proceed: false, reason: 'inspect evidence' };
+    });
+
+    const PRE: Assertion = { kind: 'url', pattern: 'example\\.com' };
+    await runWithContract({
+      contract: { id: 'critical-pre', pre: PRE, post: POST_OK, critical: true },
+      skill: async () => 'never',
+      snapshot: async () => ctx('Done'),
+    });
+
+    // Pre-condition evidence should be passed to the hook.
+    expect(capturedEvidence).toBeDefined();
+    expect((capturedEvidence as { passed?: boolean }).passed).toBe(true);
+  });
+
+  test('hook receives undefined evidence when contract has no pre-condition', async () => {
+    let capturedEvidence: unknown = 'sentinel';
+    registerBeforeIrreversibleHook(async (input) => {
+      capturedEvidence = input.evidence;
+      return { proceed: true };
+    });
+
+    await runWithContract({
+      contract: { id: 'critical-nopre', post: POST_OK, critical: true },
+      skill: async () => 'ok',
+      snapshot: async () => ctx('Done'),
+    });
+
+    expect(capturedEvidence).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `beforeIrreversibleAction` hook that fires before a `critical: true` contract executes its irreversible action (closes #795, Phase 3 of OpenChrome 1.11 cleanup).
- Non-critical contracts are unchanged — 1.10.4 behavior is fully preserved by default.
- Hook path is unreachable when `--pilot` is unset (gated by `isContractRuntimeEnabled()` at the top of `runWithContract()`).

## Changes

**`src/pilot/runtime/before-irreversible.ts`** (new)
- `BeforeIrreversibleHookInput` type: `{ contractId, action, evidence? }`
- `BeforeIrreversibleDecision` type: `{ proceed: true } | { proceed: false, reason } | { proceed: 'await-human', externalToken }`
- `BeforeIrreversibleHook` type alias
- `registerBeforeIrreversibleHook()` — single-slot registration; warns via `console.error` on double-register
- `getBeforeIrreversibleHook()` — used by runtime to avoid stale reference
- `resetBeforeIrreversibleHookForTests()` — test teardown helper
- Default hook is a no-op pass-through (`async () => ({ proceed: true })`)

**`src/pilot/runtime/runtime.ts`**
- Step 3 (between pre-check and skill execution): invokes hook for `critical: true` contracts only
- `proceed: false` → verdict `aborted_by_hook`, `error_message = reason`, `hook_decision.reason`
- `proceed: 'await-human'` → verdict `aborted_by_hook`, `error_message` contains token, `hook_decision.external_token`
- Hook throw → treated as implicit deny (always-settles guarantee preserved)

**`src/pilot/runtime/types.ts`**
- `Contract`: added `critical?: boolean` and `action?: string`
- `Verdict`: added `aborted_by_hook`
- `TransactionRecord`: added `hook_decision?: { action, reason?, external_token? }`

**`src/pilot/runtime/index.ts`**
- Re-exports all new hook API surface and types

**`tests/pilot/runtime/before-irreversible.test.ts`** (new, 16 tests)
- Hook not invoked for non-critical contracts
- Default hook allows critical contracts to proceed
- `proceed: false` → `aborted_by_hook` with reason in record, skill never runs
- `proceed: 'await-human'` → `aborted_by_hook` with token in record, skill never runs
- Double-register warns via `console.error`; first registration (replacing default) does not warn
- Hook throw treated as implicit deny
- Hook invoked exactly once per call
- `pre_evidence` forwarded to hook when pre-condition present; `undefined` when absent

## References

- Closes #795
- Phase 3 of OpenChrome 1.11 cleanup
- Follows contract runtime established in PR #797 (closes #790)
- Related: PR #774, PR #780, closed PR #756

## Test plan

- [x] `npx jest tests/pilot/runtime/before-irreversible.test.ts` → 16 passed
- [x] `tsc -p tsconfig.json --noEmit` → clean
- [x] `tsc -p tsconfig.cli.json --noEmit` → clean
- [x] `eslint src/pilot/runtime/` → clean
- [x] `depcruise --config .dependency-cruiser.cjs src` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)