### PR TITLE
feat(pilot): handoff persistence with AES-256-GCM ephemeral key (Phase 3, closes #794)

### DIFF
--- a/src/pilot/handoff/index.ts
+++ b/src/pilot/handoff/index.ts
@@ -32,3 +32,10 @@ export type {
 } from './manager.js';
 
 export { registerOcPilotHandoffTool } from './tool.js';
+
+export {
+  EphemeralEncryptedPersistence,
+  FileBackedKeyEncryptedPersistence,
+  autoSelectHandoffPersistence,
+} from './persistence.js';
+export type { PersistenceAdapter, AutoSelectOptions } from './persistence.js';

--- a/src/pilot/handoff/manager.ts
+++ b/src/pilot/handoff/manager.ts
@@ -29,6 +29,7 @@
  */
 
 import { createHandoffToken, type CreateHandoffTokenArgs, type HandoffTokenResult } from './token.js';
+import type { PersistenceAdapter } from './persistence.js';
 
 export interface HandoffPayload {
   /** Session being transferred. */
@@ -70,6 +71,14 @@ export interface HandoffManagerOptions {
   now?: () => number;
   /** Test hook: replaceable token minter. */
   mintToken?: (args: CreateHandoffTokenArgs) => HandoffTokenResult;
+  /**
+   * Optional at-rest persistence adapter (issue #794). When provided,
+   * `register` writes the serialised record, `redeem` falls back to it on
+   * an in-memory miss, and `revoke` deletes from both stores. Backward-
+   * compatible: omitting this option preserves the existing in-memory-only
+   * behaviour.
+   */
+  persistence?: PersistenceAdapter;
 }
 
 const DEFAULT_PRUNE_INTERVAL_MS = 60 * 1000;
@@ -92,11 +101,13 @@ export class HandoffManager {
   private readonly byToken = new Map<string, string>();
   private readonly now: () => number;
   private readonly mintToken: (args: CreateHandoffTokenArgs) => HandoffTokenResult;
+  private readonly persistence: PersistenceAdapter | undefined;
   private timer: ReturnType<typeof setInterval> | undefined;
 
   constructor(opts: HandoffManagerOptions = {}) {
     this.now = opts.now ?? Date.now;
     this.mintToken = opts.mintToken ?? createHandoffToken;
+    this.persistence = opts.persistence;
     const interval = opts.pruneIntervalMs ?? DEFAULT_PRUNE_INTERVAL_MS;
     if (interval > 0) {
       this.timer = setInterval(() => {
@@ -132,6 +143,11 @@ export class HandoffManager {
     if (prior) {
       this.byToken.delete(prior.token);
       this.bySession.delete(prior.sessionId);
+      if (this.persistence) {
+        this.persistence.delete(prior.token).catch((err: unknown) => {
+          console.error('[HandoffManager] persistence.delete failed on rotate:', err);
+        });
+      }
     }
     const result = this.mintToken({
       sessionId: payload.sessionId,
@@ -148,6 +164,11 @@ export class HandoffManager {
     };
     this.bySession.set(record.sessionId, record);
     this.byToken.set(record.token, record.sessionId);
+    if (this.persistence) {
+      this.persistence.put(result.token, JSON.stringify(record)).catch((err: unknown) => {
+        console.error('[HandoffManager] persistence.put failed:', err);
+      });
+    }
     return { token: result.token, expiresAt: result.expiresAt };
   }
 
@@ -156,6 +177,11 @@ export class HandoffManager {
    * Returns null when the token is unknown, expired, or already redeemed.
    * Expired records are also removed as a side effect so subsequent calls
    * with the same (now-stale) token return null without lingering state.
+   *
+   * When a persistence adapter is configured, an in-memory miss falls back
+   * to the persisted store. This is synchronous-first: the caller receives
+   * the in-memory result immediately; the persistence fallback path uses
+   * {@link redeemAsync} instead.
    */
   redeem(token: string): HandoffRedemption | null {
     if (typeof token !== 'string' || token.length === 0) return null;
@@ -171,11 +197,21 @@ export class HandoffManager {
     if (now >= record.expiresAt) {
       this.byToken.delete(token);
       this.bySession.delete(sessionId);
+      if (this.persistence) {
+        this.persistence.delete(token).catch((err: unknown) => {
+          console.error('[HandoffManager] persistence.delete on expiry failed:', err);
+        });
+      }
       return null;
     }
     // Consume on success. Single-use: subsequent redeem(token) returns null.
     this.byToken.delete(token);
     this.bySession.delete(sessionId);
+    if (this.persistence) {
+      this.persistence.delete(token).catch((err: unknown) => {
+        console.error('[HandoffManager] persistence.delete on redeem failed:', err);
+      });
+    }
     return {
       sessionId: record.sessionId,
       scope: record.scope,
@@ -186,7 +222,63 @@ export class HandoffManager {
   }
 
   /**
-   * Operator-initiated revoke. Returns true iff a record was removed.
+   * Async variant of {@link redeem} that also checks the persistence layer
+   * when the token is absent from the in-memory index. Use this when the
+   * manager may have been restarted with a stable key
+   * (`FileBackedKeyEncryptedPersistence`) and callers need to recover tokens
+   * that were registered in a previous process.
+   */
+  async redeemAsync(token: string): Promise<HandoffRedemption | null> {
+    // Fast path: in-memory hit.
+    const inMemory = this.redeem(token);
+    if (inMemory !== null) return inMemory;
+
+    if (!this.persistence) return null;
+
+    // Fallback: attempt to load from the persistence layer.
+    let raw: string | null;
+    try {
+      raw = await this.persistence.get(token);
+    } catch (err) {
+      console.error('[HandoffManager] persistence.get failed:', err);
+      return null;
+    }
+    if (raw === null) return null;
+
+    let record: HandoffRecord;
+    try {
+      record = JSON.parse(raw) as HandoffRecord;
+    } catch {
+      return null;
+    }
+
+    const now = this.now();
+    if (now >= record.expiresAt) {
+      await this.persistence.delete(token).catch((err: unknown) => {
+        console.error('[HandoffManager] persistence.delete on expired recovery failed:', err);
+      });
+      return null;
+    }
+
+    // Consume: remove from persistence so it cannot be redeemed again.
+    await this.persistence.delete(token).catch((err: unknown) => {
+      console.error('[HandoffManager] persistence.delete on redeemAsync failed:', err);
+    });
+
+    return {
+      sessionId: record.sessionId,
+      scope: record.scope,
+      expiresAt: record.expiresAt,
+      createdAt: record.createdAt,
+      redeemedAt: now,
+    };
+  }
+
+  /**
+   * Operator-initiated revoke. Returns true iff a record was removed from
+   * the in-memory store. Also schedules a best-effort delete from the
+   * persistence layer (if configured) — the return value reflects only the
+   * in-memory outcome.
    * Idempotent — calling revoke on an unknown token returns false rather
    * than throwing.
    */
@@ -196,6 +288,11 @@ export class HandoffManager {
     if (sessionId === undefined) return false;
     this.byToken.delete(token);
     this.bySession.delete(sessionId);
+    if (this.persistence) {
+      this.persistence.delete(token).catch((err: unknown) => {
+        console.error('[HandoffManager] persistence.delete on revoke failed:', err);
+      });
+    }
     return true;
   }
 

--- a/src/pilot/handoff/persistence.ts
+++ b/src/pilot/handoff/persistence.ts
@@ -1,0 +1,250 @@
+/**
+ * At-rest encryption for persisted handoff tokens (Phase 3, issue #794).
+ *
+ * Design:
+ *   - AES-256-GCM with a random 12-byte IV per record and a 16-byte auth tag.
+ *   - Token identity is stored as sha256(token) so the raw token is never
+ *     visible in the filesystem (avoids leaking secrets via file names).
+ *   - Default mode: ephemeral key generated at construction via
+ *     `crypto.randomBytes(32)`. Key is held only in memory; a process
+ *     restart invalidates every persisted record.
+ *   - Opt-in stable mode: `FileBackedKeyEncryptedPersistence` reads a
+ *     32-byte raw key from a file path. Specify the path via the
+ *     `OPENCHROME_HANDOFF_KEY_FILE` env var or the `keyFilePath` option
+ *     passed to `autoSelectHandoffPersistence`.
+ *
+ * Wire format (each `.enc` file):
+ *   [ 12 bytes IV ][ 16 bytes auth tag ][ N bytes ciphertext ]
+ *
+ * No OS keychain integration — P3 constraint. Cross-platform by design;
+ * uses only `node:crypto`, `node:fs`, and `node:path`.
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const IV_BYTES = 12;
+const TAG_BYTES = 16;
+const KEY_BYTES = 32;
+const ALGORITHM = 'aes-256-gcm' as const;
+
+// ---------------------------------------------------------------------------
+// PersistenceAdapter interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Storage contract for persisted handoff payloads. All implementations must
+ * treat the `token` parameter as an opaque identifier — they must not log
+ * it or store it verbatim on disk.
+ */
+export interface PersistenceAdapter {
+  /** Encrypt and write `payload` keyed by `token`. */
+  put(token: string, payload: string): Promise<void>;
+  /**
+   * Decrypt and return the payload for `token`, or `null` when the file is
+   * missing or the auth tag fails (wrong key / tampered ciphertext).
+   */
+  get(token: string): Promise<string | null>;
+  /** Remove the persisted record for `token`. No-op if absent. */
+  delete(token: string): Promise<void>;
+  /** Remove every persisted record under rootDir. */
+  clear(): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the on-disk filename from a token. Using sha256 prevents the raw
+ * token bytes from appearing in filesystem paths / directory listings.
+ */
+function tokenToFilename(token: string): string {
+  return crypto.createHash('sha256').update(token, 'utf8').digest('hex') + '.enc';
+}
+
+function encryptRecord(key: Buffer, payload: string): Buffer {
+  const iv = crypto.randomBytes(IV_BYTES);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+  const ct = Buffer.concat([cipher.update(payload, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  // Layout: [ IV | tag | ciphertext ]
+  return Buffer.concat([iv, tag, ct]);
+}
+
+function decryptRecord(key: Buffer, data: Buffer): string | null {
+  if (data.length < IV_BYTES + TAG_BYTES) return null;
+  const iv = data.subarray(0, IV_BYTES);
+  const tag = data.subarray(IV_BYTES, IV_BYTES + TAG_BYTES);
+  const ct = data.subarray(IV_BYTES + TAG_BYTES);
+  try {
+    const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAuthTag(tag);
+    return decipher.update(ct).toString('utf8') + decipher.final('utf8');
+  } catch {
+    // Auth tag verification failed or other crypto error — treat as missing.
+    return null;
+  }
+}
+
+function ensureDir(dir: string): void {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// EphemeralEncryptedPersistence
+// ---------------------------------------------------------------------------
+
+/**
+ * Persists encrypted handoff records to disk using a key that is generated
+ * fresh at construction time. The key never leaves memory, so a process
+ * restart produces a new key and all previously persisted records become
+ * permanently unreadable (returns null on get).
+ *
+ * This is the safe default: at-rest data is encrypted, but a restart is a
+ * natural invalidation boundary — no key material needs protection beyond the
+ * process lifetime.
+ */
+export class EphemeralEncryptedPersistence implements PersistenceAdapter {
+  protected key: Buffer;
+  protected readonly rootDir: string;
+
+  constructor(rootDir: string) {
+    this.rootDir = rootDir;
+    this.key = crypto.randomBytes(KEY_BYTES);
+  }
+
+  async put(token: string, payload: string): Promise<void> {
+    ensureDir(this.rootDir);
+    const enc = encryptRecord(this.key, payload);
+    const filePath = path.join(this.rootDir, tokenToFilename(token));
+    fs.writeFileSync(filePath, enc);
+  }
+
+  async get(token: string): Promise<string | null> {
+    const filePath = path.join(this.rootDir, tokenToFilename(token));
+    let data: Buffer;
+    try {
+      data = fs.readFileSync(filePath);
+    } catch {
+      return null;
+    }
+    return decryptRecord(this.key, data);
+  }
+
+  async delete(token: string): Promise<void> {
+    const filePath = path.join(this.rootDir, tokenToFilename(token));
+    try {
+      fs.unlinkSync(filePath);
+    } catch {
+      // No-op if already absent.
+    }
+  }
+
+  async clear(): Promise<void> {
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(this.rootDir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.endsWith('.enc')) {
+        try {
+          fs.unlinkSync(path.join(this.rootDir, entry));
+        } catch {
+          // best-effort
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// FileBackedKeyEncryptedPersistence
+// ---------------------------------------------------------------------------
+
+/**
+ * Variant of {@link EphemeralEncryptedPersistence} that loads its 32-byte AES
+ * key from a file path at construction time.
+ *
+ * The file must contain exactly 32 bytes of raw key material. The path is
+ * never logged. Useful when the operator manages key rotation externally (e.g.
+ * a secrets manager writes the key file on startup).
+ *
+ * If the key file cannot be read or has the wrong size, construction throws.
+ * Callers that want a safe fallback should use `autoSelectHandoffPersistence`
+ * instead, which falls back to ephemeral on any error.
+ */
+export class FileBackedKeyEncryptedPersistence extends EphemeralEncryptedPersistence {
+  constructor(rootDir: string, keyFilePath: string) {
+    // Call super first (generates an ephemeral key), then overwrite with the
+    // file-backed key. We can't skip super() in JS/TS, so we replace the
+    // property after the fact via Object.defineProperty to work around the
+    // `readonly` constraint.
+    super(rootDir);
+    const raw = fs.readFileSync(keyFilePath);
+    if (raw.length !== KEY_BYTES) {
+      throw new Error(
+        `FileBackedKeyEncryptedPersistence: key file must be exactly ${KEY_BYTES} bytes, got ${raw.length}`
+      );
+    }
+    // Overwrite the ephemeral key generated by super() with the file-backed key.
+    this.key = raw;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// autoSelectHandoffPersistence
+// ---------------------------------------------------------------------------
+
+export interface AutoSelectOptions {
+  /** Base directory for encrypted .enc record files. */
+  rootDir: string;
+  /**
+   * Optional explicit path to a 32-byte key file. Takes precedence over the
+   * `OPENCHROME_HANDOFF_KEY_FILE` environment variable when provided.
+   */
+  keyFilePath?: string;
+}
+
+/**
+ * Choose the appropriate persistence adapter based on runtime configuration.
+ *
+ * Selection logic:
+ *   1. Resolve `keyFilePath` from the argument or the
+ *      `OPENCHROME_HANDOFF_KEY_FILE` environment variable.
+ *   2. If a path is available, the file is readable, and its size is exactly
+ *      32 bytes → return `FileBackedKeyEncryptedPersistence`.
+ *   3. Otherwise → return `EphemeralEncryptedPersistence` (safe default).
+ *
+ * This function never throws. Any error (missing file, wrong size, permissions)
+ * silently falls back to the ephemeral adapter; a diagnostic is emitted via
+ * `console.error` so operators see the fallback without crashing the host.
+ */
+export function autoSelectHandoffPersistence(opts: AutoSelectOptions): PersistenceAdapter {
+  const resolvedPath = opts.keyFilePath ?? process.env['OPENCHROME_HANDOFF_KEY_FILE'];
+
+  if (resolvedPath) {
+    try {
+      const stat = fs.statSync(resolvedPath);
+      if (stat.size !== KEY_BYTES) {
+        console.error(
+          `[handoff] Key file "${resolvedPath}" is ${stat.size} bytes; expected ${KEY_BYTES}. Falling back to ephemeral key.`
+        );
+        return new EphemeralEncryptedPersistence(opts.rootDir);
+      }
+      return new FileBackedKeyEncryptedPersistence(opts.rootDir, resolvedPath);
+    } catch (err) {
+      console.error(
+        `[handoff] Could not read key file (falling back to ephemeral): ${(err as Error).message}`
+      );
+      return new EphemeralEncryptedPersistence(opts.rootDir);
+    }
+  }
+
+  return new EphemeralEncryptedPersistence(opts.rootDir);
+}

--- a/tests/pilot/handoff/persistence.test.ts
+++ b/tests/pilot/handoff/persistence.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Tests for handoff persistence (Phase 3, issue #794).
+ *
+ * All disk I/O uses a real temp directory created per-test and cleaned up
+ * in afterEach. No mocking of `node:crypto` or `node:fs` — the real
+ * implementations are used to validate the AES-256-GCM round-trip.
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  EphemeralEncryptedPersistence,
+  FileBackedKeyEncryptedPersistence,
+  autoSelectHandoffPersistence,
+} from '../../../src/pilot/handoff/persistence.js';
+import { HandoffManager } from '../../../src/pilot/handoff/manager.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-794-test-'));
+}
+
+function removeTmpDir(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+function writeKeyFile(dir: string, bytes: number): string {
+  const filePath = path.join(dir, 'handoff.key');
+  fs.writeFileSync(filePath, crypto.randomBytes(bytes));
+  return filePath;
+}
+
+// ---------------------------------------------------------------------------
+// EphemeralEncryptedPersistence — encrypt + decrypt round-trip
+// ---------------------------------------------------------------------------
+
+describe('EphemeralEncryptedPersistence — round-trip', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    removeTmpDir(tmpDir);
+  });
+
+  it('put then get returns the original payload', async () => {
+    const p = new EphemeralEncryptedPersistence(tmpDir);
+    const token = 'tok-abc-123';
+    const payload = JSON.stringify({ sessionId: 's1', scope: 'checkout' });
+    await p.put(token, payload);
+    const result = await p.get(token);
+    expect(result).toBe(payload);
+  });
+
+  it('get on missing token returns null', async () => {
+    const p = new EphemeralEncryptedPersistence(tmpDir);
+    const result = await p.get('nonexistent-token');
+    expect(result).toBeNull();
+  });
+
+  it('delete removes the file; subsequent get returns null', async () => {
+    const p = new EphemeralEncryptedPersistence(tmpDir);
+    const token = 'tok-del-1';
+    await p.put(token, 'hello');
+    await p.delete(token);
+    expect(await p.get(token)).toBeNull();
+  });
+
+  it('delete on absent token is a no-op (does not throw)', async () => {
+    const p = new EphemeralEncryptedPersistence(tmpDir);
+    await expect(p.delete('no-such-token')).resolves.toBeUndefined();
+  });
+
+  it('clear removes all .enc files', async () => {
+    const p = new EphemeralEncryptedPersistence(tmpDir);
+    await p.put('t1', 'payload-1');
+    await p.put('t2', 'payload-2');
+    await p.clear();
+    expect(await p.get('t1')).toBeNull();
+    expect(await p.get('t2')).toBeNull();
+    const remaining = fs.readdirSync(tmpDir).filter((f) => f.endsWith('.enc'));
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('stores the file under a sha256 hash, not the raw token', async () => {
+    const p = new EphemeralEncryptedPersistence(tmpDir);
+    const token = 'super-secret-token';
+    await p.put(token, 'data');
+    const files = fs.readdirSync(tmpDir);
+    for (const f of files) {
+      expect(f).not.toContain(token);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EphemeralEncryptedPersistence — wrong key cannot decrypt
+// ---------------------------------------------------------------------------
+
+describe('EphemeralEncryptedPersistence — key isolation', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    removeTmpDir(tmpDir);
+  });
+
+  it('a new instance (different ephemeral key) cannot decrypt records written by a previous instance', async () => {
+    const token = 'shared-token';
+    const payload = '{"sessionId":"s2","scope":"admin"}';
+
+    // First instance writes the record.
+    const p1 = new EphemeralEncryptedPersistence(tmpDir);
+    await p1.put(token, payload);
+
+    // Second instance has a different key — decryption must fail gracefully.
+    const p2 = new EphemeralEncryptedPersistence(tmpDir);
+    const result = await p2.get(token);
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FileBackedKeyEncryptedPersistence
+// ---------------------------------------------------------------------------
+
+describe('FileBackedKeyEncryptedPersistence — key file with exactly 32 bytes', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    removeTmpDir(tmpDir);
+  });
+
+  it('encrypts and decrypts with the file-backed key', async () => {
+    const keyFile = writeKeyFile(tmpDir, 32);
+    const p = new FileBackedKeyEncryptedPersistence(tmpDir, keyFile);
+    const token = 'fb-token-1';
+    const payload = '{"sessionId":"s3","scope":"write"}';
+    await p.put(token, payload);
+    const result = await p.get(token);
+    expect(result).toBe(payload);
+  });
+
+  it('two instances sharing the same key file can cross-read each other', async () => {
+    const keyFile = writeKeyFile(tmpDir, 32);
+    const p1 = new FileBackedKeyEncryptedPersistence(tmpDir, keyFile);
+    const p2 = new FileBackedKeyEncryptedPersistence(tmpDir, keyFile);
+    const token = 'fb-token-cross';
+    const payload = '{"sessionId":"s4","scope":"read"}';
+    await p1.put(token, payload);
+    const result = await p2.get(token);
+    expect(result).toBe(payload);
+  });
+});
+
+describe('FileBackedKeyEncryptedPersistence — wrong size key file throws', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    removeTmpDir(tmpDir);
+  });
+
+  it('throws when key file is 16 bytes (too short)', () => {
+    const keyFile = writeKeyFile(tmpDir, 16);
+    expect(() => new FileBackedKeyEncryptedPersistence(tmpDir, keyFile)).toThrow(
+      /must be exactly 32 bytes/
+    );
+  });
+
+  it('throws when key file is 64 bytes (too long)', () => {
+    const keyFile = writeKeyFile(tmpDir, 64);
+    expect(() => new FileBackedKeyEncryptedPersistence(tmpDir, keyFile)).toThrow(
+      /must be exactly 32 bytes/
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// autoSelectHandoffPersistence
+// ---------------------------------------------------------------------------
+
+describe('autoSelectHandoffPersistence — selection heuristic', () => {
+  let tmpDir: string;
+  const envKey = 'OPENCHROME_HANDOFF_KEY_FILE';
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    delete process.env[envKey];
+  });
+
+  afterEach(() => {
+    removeTmpDir(tmpDir);
+    delete process.env[envKey];
+  });
+
+  it('returns EphemeralEncryptedPersistence when no env var and no keyFilePath', () => {
+    const adapter = autoSelectHandoffPersistence({ rootDir: tmpDir });
+    expect(adapter).toBeInstanceOf(EphemeralEncryptedPersistence);
+    expect(adapter).not.toBeInstanceOf(FileBackedKeyEncryptedPersistence);
+  });
+
+  it('returns FileBackedKeyEncryptedPersistence when keyFilePath has exactly 32 bytes', () => {
+    const keyFile = writeKeyFile(tmpDir, 32);
+    const adapter = autoSelectHandoffPersistence({ rootDir: tmpDir, keyFilePath: keyFile });
+    expect(adapter).toBeInstanceOf(FileBackedKeyEncryptedPersistence);
+  });
+
+  it('falls back to ephemeral when keyFilePath file is wrong size', () => {
+    const keyFile = writeKeyFile(tmpDir, 16);
+    const adapter = autoSelectHandoffPersistence({ rootDir: tmpDir, keyFilePath: keyFile });
+    expect(adapter).toBeInstanceOf(EphemeralEncryptedPersistence);
+    expect(adapter).not.toBeInstanceOf(FileBackedKeyEncryptedPersistence);
+  });
+
+  it('falls back to ephemeral when keyFilePath file does not exist', () => {
+    const adapter = autoSelectHandoffPersistence({
+      rootDir: tmpDir,
+      keyFilePath: path.join(tmpDir, 'nonexistent.key'),
+    });
+    expect(adapter).toBeInstanceOf(EphemeralEncryptedPersistence);
+    expect(adapter).not.toBeInstanceOf(FileBackedKeyEncryptedPersistence);
+  });
+
+  it('returns FileBackedKeyEncryptedPersistence when OPENCHROME_HANDOFF_KEY_FILE env var is set', () => {
+    const keyFile = writeKeyFile(tmpDir, 32);
+    process.env[envKey] = keyFile;
+    const adapter = autoSelectHandoffPersistence({ rootDir: tmpDir });
+    expect(adapter).toBeInstanceOf(FileBackedKeyEncryptedPersistence);
+  });
+
+  it('explicit keyFilePath takes precedence over env var', () => {
+    // Env var points to a bad key (16 bytes); explicit arg points to good key.
+    const badKey = writeKeyFile(tmpDir, 16);
+    const subDir = path.join(tmpDir, 'sub');
+    fs.mkdirSync(subDir, { recursive: true });
+    const goodKey = writeKeyFile(subDir, 32);
+    process.env[envKey] = badKey;
+    const adapter = autoSelectHandoffPersistence({ rootDir: tmpDir, keyFilePath: goodKey });
+    expect(adapter).toBeInstanceOf(FileBackedKeyEncryptedPersistence);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Manager integration — ephemeral key restart invalidates persisted tokens
+// ---------------------------------------------------------------------------
+
+describe('HandoffManager + EphemeralEncryptedPersistence — restart invalidation', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    removeTmpDir(tmpDir);
+  });
+
+  it('token registered with instance A cannot be redeemed by instance B (different ephemeral key)', async () => {
+    // Instance A: register a token and persist it.
+    const persistA = new EphemeralEncryptedPersistence(tmpDir);
+    const managerA = new HandoffManager({
+      pruneIntervalMs: 0,
+      persistence: persistA,
+    });
+    const { token } = managerA.register({ sessionId: 'sess-restart', scope: 'test' });
+
+    // Wait for the fire-and-forget persistence.put to settle.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    managerA.dispose();
+
+    // Instance B: new ephemeral key — cannot decrypt A's persisted record.
+    const persistB = new EphemeralEncryptedPersistence(tmpDir);
+    const managerB = new HandoffManager({
+      pruneIntervalMs: 0,
+      persistence: persistB,
+    });
+
+    // In-memory miss.
+    expect(managerB.redeem(token)).toBeNull();
+
+    // Persistence fallback also returns null (different key).
+    const recovered = await managerB.redeemAsync(token);
+    expect(recovered).toBeNull();
+
+    managerB.dispose();
+  });
+
+  it('redeemAsync recovers a valid token from persistence on an in-memory miss', async () => {
+    const persist = new EphemeralEncryptedPersistence(tmpDir);
+    const managerA = new HandoffManager({
+      pruneIntervalMs: 0,
+      persistence: persist,
+    });
+    const { token } = managerA.register({ sessionId: 'sess-recover', scope: 'read' });
+
+    // Wait for persistence.put to complete.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    managerA.dispose();
+
+    // Instance B reuses the same persistence adapter (same key) — simulates
+    // a graceful restart where the key is stable.
+    const managerB = new HandoffManager({
+      pruneIntervalMs: 0,
+      persistence: persist,
+    });
+
+    // In-memory miss — token was registered only in A.
+    expect(managerB.redeem(token)).toBeNull();
+
+    // Async path falls back to persistence and succeeds.
+    const redemption = await managerB.redeemAsync(token);
+    expect(redemption).not.toBeNull();
+    expect(redemption!.sessionId).toBe('sess-recover');
+    expect(redemption!.scope).toBe('read');
+
+    // Consumed — second call returns null.
+    expect(await managerB.redeemAsync(token)).toBeNull();
+
+    managerB.dispose();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds at-rest encryption of persisted handoff tokens using AES-256-GCM (`node:crypto` only, no new deps).
- Default mode: **ephemeral key** generated via `crypto.randomBytes(32)` at construction — held in memory, never written to disk. A process restart produces a new key and all previously persisted `.enc` files become permanently unreadable (safe invalidation boundary).
- Opt-in stable mode: **`FileBackedKeyEncryptedPersistence`** reads a 32-byte raw key from a file path. Enabled by setting `OPENCHROME_HANDOFF_KEY_FILE=<path>` or passing `keyFilePath` to `autoSelectHandoffPersistence`.
- Wire format per record: `[ IV(12 bytes) | auth-tag(16 bytes) | ciphertext ]`. Token filenames are `sha256(token).enc` so raw token bytes never appear on disk.
- `HandoffManager` gains an optional `persistence` option (backward-compatible). `register` writes, `redeem`/`revoke` delete. New `redeemAsync` enables cross-restart recovery when a stable key is in use.

## Files changed

| File | Change |
|---|---|
| `src/pilot/handoff/persistence.ts` | New — `PersistenceAdapter`, `EphemeralEncryptedPersistence`, `FileBackedKeyEncryptedPersistence`, `autoSelectHandoffPersistence` |
| `src/pilot/handoff/manager.ts` | Wired `persistence` option into register/redeem/revoke; added `redeemAsync` |
| `src/pilot/handoff/index.ts` | Re-exported new persistence symbols |
| `tests/pilot/handoff/persistence.test.ts` | New — 19 tests |

## References

- Closes #794
- Closes #721 (cross-restart token recovery with stable key)
- Builds on #803 (handoff token + in-memory manager, just merged)
- Related closed PR #755 (Linux-specific encrypted persistence, generalized here to cross-platform ephemeral default)
- Related #774, #780 (Phase 3 cleanup series)

## No OS keychain integration

P3 constraint: no keychain. The ephemeral default is safe by design — encryption protects data at rest during the process lifetime; restart is a natural invalidation boundary.

## Test plan

- [x] `npm run build` — zero errors
- [x] `npm run lint` — zero warnings
- [x] `npm run lint:tier` — zero dependency violations (295 modules, 613 deps)
- [x] `npx jest tests/pilot/handoff/persistence.test.ts` — 19/19 pass
- [x] `npx jest tests/pilot/handoff/manager.test.ts` — 15/15 pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)