### PR TITLE
feat(core): openchrome://skill-graph/<domain> MCP resource (Phase 3, closes #783)

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -18,6 +18,12 @@ import { MCPTransport, createTransport } from './transports/index';
 import { SessionManager, getSessionManager } from './session-manager';
 import { Dashboard, getDashboard, ActivityTracker, getActivityTracker, OperationController } from './dashboard/index.js';
 import { usageGuideResource, getUsageGuideContent, MCPResourceDefinition } from './resources/usage-guide';
+import {
+  skillGraphResourceTemplate,
+  SKILL_GRAPH_RESOURCE_PREFIX,
+  parseDomainFromUri,
+  readSkillGraphResource,
+} from './resources/skill-graph';
 import { HintEngine } from './hints';
 import { validateToolSchema } from './utils/schema-validator';
 import { formatAge } from './utils/format-age';
@@ -200,6 +206,7 @@ export class MCPServer {
 
     // Register built-in resources
     this.registerResource(usageGuideResource);
+    this.registerResource(skillGraphResourceTemplate);
 
     // Initialize dashboard if enabled
     if (options.dashboard) {
@@ -697,6 +704,25 @@ export class MCPServer {
     const uri = params.uri as string;
     if (!uri) {
       throw new Error('Missing resource uri');
+    }
+
+    // Skill-graph resources use a URI prefix with a variable domain segment.
+    // Handle them before the exact-match lookup.
+    if (uri.startsWith(SKILL_GRAPH_RESOURCE_PREFIX)) {
+      const domain = parseDomainFromUri(uri);
+      if (!domain) {
+        throw new Error(`Invalid skill-graph resource URI: ${uri}`);
+      }
+      const content = readSkillGraphResource(domain);
+      return {
+        contents: [
+          {
+            uri,
+            mimeType: skillGraphResourceTemplate.mimeType,
+            text: content,
+          },
+        ],
+      };
     }
 
     const resource = this.resources.get(uri);

--- a/src/resources/skill-graph.ts
+++ b/src/resources/skill-graph.ts
@@ -1,0 +1,172 @@
+/**
+ * Skill-Graph MCP Resource — openchrome://skill-graph/<encodedDomain>
+ *
+ * Returns a JSON snapshot of the per-domain skill graph at request time.
+ * Read-only. Backed by SkillGraphStorage (PR #801).
+ *
+ * Cache: in-process map keyed by domain, invalidated by mtime check on the
+ * underlying JSON file so a fresh read after a write always sees the latest
+ * data without hitting the disk on every call when the file is unchanged.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+  SkillGraphStorage,
+  defaultSkillGraphRootDir,
+  type SkillGraphStorageOptions,
+} from '../core/skill/storage';
+import type { MCPResourceDefinition } from './usage-guide';
+
+/** The URI prefix for all skill-graph resources. */
+export const SKILL_GRAPH_RESOURCE_PREFIX = 'openchrome://skill-graph/';
+
+/**
+ * Template resource definition registered in the MCP resource list.
+ * The actual per-domain URIs are derived at request time from the prefix.
+ */
+export const skillGraphResourceTemplate: MCPResourceDefinition = {
+  uri: SKILL_GRAPH_RESOURCE_PREFIX,
+  name: 'skill-graph',
+  description:
+    'Per-domain skill graph snapshot — nodes, edges, and to_state_distribution as JSON.',
+  mimeType: 'text/json',
+};
+
+interface CacheEntry {
+  mtimeMs: number;
+  snapshot: SkillGraphSnapshot;
+}
+
+/**
+ * The serialised shape returned to MCP callers. Mirrors the on-disk
+ * SkillGraphFile layout so consumers can parse nodes + edges directly.
+ */
+export interface SkillGraphSnapshot {
+  domain: string;
+  schema_version: number;
+  nodes: Record<string, unknown>;
+  edges: unknown[];
+}
+
+// In-process cache: domain → { mtimeMs, snapshot }
+const cache = new Map<string, CacheEntry>();
+
+/** Override root dir for tests. */
+let _rootDirOverride: string | undefined;
+
+/** Visible for testing only — override the storage root directory. */
+export function _setRootDirOverride(dir: string | undefined): void {
+  _rootDirOverride = dir;
+  cache.clear();
+}
+
+function getRootDir(): string {
+  return _rootDirOverride ?? defaultSkillGraphRootDir();
+}
+
+/**
+ * Resolve the JSON file path for a domain without constructing a full
+ * SkillGraphStorage (avoids writing the seed file on a read-only path).
+ * We replicate the basename encoding logic from storage.ts:
+ *   encodedBasename = encodeURIComponent(domain) [+ leading _ if reserved]
+ */
+function resolveFilePath(domain: string, rootDir: string): string {
+  const encoded = encodeURIComponent(domain);
+  const WINDOWS_RESERVED = new Set([
+    'con', 'prn', 'aux', 'nul',
+    'com0', 'com1', 'com2', 'com3', 'com4', 'com5', 'com6', 'com7', 'com8', 'com9',
+    'lpt0', 'lpt1', 'lpt2', 'lpt3', 'lpt4', 'lpt5', 'lpt6', 'lpt7', 'lpt8', 'lpt9',
+  ]);
+  const basename = WINDOWS_RESERVED.has(encoded.toLowerCase())
+    ? `_${encoded}.json`
+    : `${encoded}.json`;
+  return path.join(rootDir, basename);
+}
+
+/**
+ * Return a JSON snapshot of the skill graph for `domain`.
+ *
+ * If the domain has never been seen, returns an empty graph rather than
+ * throwing — unknown domains are not an error.
+ *
+ * Cache invalidation: we stat the file and compare mtimeMs. When the mtime
+ * matches the cached entry we return the cached snapshot without re-reading.
+ * When the file changes (or does not exist) we re-read from disk.
+ */
+export function readSkillGraphResource(domain: string): string {
+  const rootDir = getRootDir();
+  const filePath = resolveFilePath(domain, rootDir);
+
+  // --- mtime-based cache invalidation ---
+  let currentMtime = 0;
+  try {
+    currentMtime = fs.statSync(filePath).mtimeMs;
+  } catch {
+    // File does not exist — unknown domain, return empty graph.
+  }
+
+  const cached = cache.get(domain);
+  if (cached && cached.mtimeMs === currentMtime && currentMtime !== 0) {
+    return JSON.stringify(cached.snapshot);
+  }
+
+  // --- Read (or construct empty) snapshot ---
+  let snapshot: SkillGraphSnapshot;
+
+  if (currentMtime === 0) {
+    // Domain has no graph file yet.
+    snapshot = { domain, schema_version: 1, nodes: {}, edges: [] };
+  } else {
+    // Use SkillGraphStorage to read so validation / fallback logic is shared.
+    const opts: SkillGraphStorageOptions = { domain, rootDir };
+    const storage = new SkillGraphStorage(opts);
+    try {
+      // Read the raw file for the full SkillGraphFile shape so we can
+      // include the verbatim nodes + edges in the snapshot.
+      const raw = fs.readFileSync(filePath, 'utf8');
+      const parsed = JSON.parse(raw) as {
+        schema_version?: number;
+        nodes?: Record<string, unknown>;
+        edges?: unknown[];
+      };
+      snapshot = {
+        domain,
+        schema_version: parsed.schema_version ?? 1,
+        nodes: parsed.nodes ?? {},
+        edges: parsed.edges ?? [],
+      };
+    } catch {
+      // Corrupted file — degrade gracefully to empty graph.
+      snapshot = { domain, schema_version: 1, nodes: {}, edges: [] };
+    } finally {
+      storage.close();
+    }
+  }
+
+  // Update cache with the mtime we observed before reading (handles the
+  // edge case where the file is written after our stat but before our read
+  // — we'll just re-read on the next call, which is correct).
+  cache.set(domain, { mtimeMs: currentMtime, snapshot });
+  return JSON.stringify(snapshot);
+}
+
+/**
+ * Extract the domain from a skill-graph resource URI.
+ * Returns null if the URI does not match the expected prefix.
+ */
+export function parseDomainFromUri(uri: string): string | null {
+  if (!uri.startsWith(SKILL_GRAPH_RESOURCE_PREFIX)) {
+    return null;
+  }
+  const encoded = uri.slice(SKILL_GRAPH_RESOURCE_PREFIX.length);
+  if (!encoded) {
+    return null;
+  }
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return null;
+  }
+}

--- a/tests/core/mcp/resources/skill-graph.test.ts
+++ b/tests/core/mcp/resources/skill-graph.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for the openchrome://skill-graph/<domain> MCP resource.
+ *
+ * Coverage:
+ *   - Unknown domain returns empty graph (not an error)
+ *   - Populated domain returns nodes + edges
+ *   - Cache invalidation when the underlying JSON file is touched
+ *   - URI encoding round-trips (percent-encoded chars, IPv6-style brackets)
+ *   - parseDomainFromUri edge cases
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  readSkillGraphResource,
+  parseDomainFromUri,
+  SKILL_GRAPH_RESOURCE_PREFIX,
+  _setRootDirOverride,
+} from '../../../../src/resources/skill-graph';
+import { SkillGraphStorage } from '../../../../src/core/skill/storage';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-sgr-'));
+}
+
+describe('readSkillGraphResource — unknown domain', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = tempRoot();
+    _setRootDirOverride(root);
+  });
+
+  afterEach(() => {
+    _setRootDirOverride(undefined);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('returns empty graph for a domain that has never been written', () => {
+    const raw = readSkillGraphResource('never-seen.com');
+    const snapshot = JSON.parse(raw) as { domain: string; nodes: object; edges: unknown[] };
+    expect(snapshot.domain).toBe('never-seen.com');
+    expect(snapshot.nodes).toEqual({});
+    expect(snapshot.edges).toEqual([]);
+  });
+
+  test('does not throw for an unknown domain', () => {
+    expect(() => readSkillGraphResource('ghost.example')).not.toThrow();
+  });
+});
+
+describe('readSkillGraphResource — populated domain', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = tempRoot();
+    _setRootDirOverride(root);
+  });
+
+  afterEach(() => {
+    _setRootDirOverride(undefined);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('returns nodes and edges written by SkillGraphStorage', async () => {
+    const store = new SkillGraphStorage({ domain: 'example.com', rootDir: root });
+    await store.upsertNode({ stateHash: 'hash-abc', seenAt: 1000 });
+    await store.recordEdge({
+      from_state: 'hash-abc',
+      action_kind: 'click',
+      action_args_norm: '{"selector":"button"}',
+      to_state: 'hash-def',
+    });
+    store.close();
+
+    const raw = readSkillGraphResource('example.com');
+    const snapshot = JSON.parse(raw) as {
+      domain: string;
+      nodes: Record<string, unknown>;
+      edges: unknown[];
+    };
+
+    expect(snapshot.domain).toBe('example.com');
+    expect(Object.keys(snapshot.nodes)).toContain('hash-abc');
+    expect(snapshot.edges).toHaveLength(1);
+    const edge = snapshot.edges[0] as { from_state: string; action_kind: string };
+    expect(edge.from_state).toBe('hash-abc');
+    expect(edge.action_kind).toBe('click');
+  });
+
+  test('schema_version is 1', async () => {
+    const store = new SkillGraphStorage({ domain: 'versioned.com', rootDir: root });
+    store.close();
+
+    const raw = readSkillGraphResource('versioned.com');
+    const snapshot = JSON.parse(raw) as { schema_version: number };
+    expect(snapshot.schema_version).toBe(1);
+  });
+});
+
+describe('readSkillGraphResource — cache invalidation', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = tempRoot();
+    _setRootDirOverride(root);
+  });
+
+  afterEach(() => {
+    _setRootDirOverride(undefined);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('serves cached snapshot when file is unchanged', async () => {
+    const store = new SkillGraphStorage({ domain: 'cached.com', rootDir: root });
+    await store.upsertNode({ stateHash: 'node-1', seenAt: 100 });
+    store.close();
+
+    const first = readSkillGraphResource('cached.com');
+    const second = readSkillGraphResource('cached.com');
+    // Both calls return identical JSON when nothing changed.
+    expect(first).toBe(second);
+  });
+
+  test('re-reads after the underlying JSON file is touched (mtime changes)', async () => {
+    const store = new SkillGraphStorage({ domain: 'touch-test.com', rootDir: root });
+    await store.upsertNode({ stateHash: 'before', seenAt: 1 });
+    store.close();
+
+    // Prime the cache.
+    const before = JSON.parse(readSkillGraphResource('touch-test.com')) as {
+      nodes: Record<string, unknown>;
+    };
+    expect(Object.keys(before.nodes)).toContain('before');
+    expect(Object.keys(before.nodes)).not.toContain('after');
+
+    // Wait a tick so the mtime will differ even on coarse (1 s) filesystems.
+    // We do this by explicitly setting a future mtime on the file.
+    const filePath = path.join(root, 'touch-test.com.json');
+    const stat = fs.statSync(filePath);
+
+    // Write a new node (this changes the file content + mtime).
+    const store2 = new SkillGraphStorage({ domain: 'touch-test.com', rootDir: root });
+    await store2.upsertNode({ stateHash: 'after', seenAt: 2 });
+    store2.close();
+
+    // Force an mtime change even if the write completed within the same ms.
+    const futureMs = stat.mtimeMs + 2000;
+    fs.utimesSync(filePath, new Date(futureMs), new Date(futureMs));
+
+    const after = JSON.parse(readSkillGraphResource('touch-test.com')) as {
+      nodes: Record<string, unknown>;
+    };
+    expect(Object.keys(after.nodes)).toContain('after');
+  });
+});
+
+describe('readSkillGraphResource — URL encoding round-trips', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = tempRoot();
+    _setRootDirOverride(root);
+  });
+
+  afterEach(() => {
+    _setRootDirOverride(undefined);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('percent-encoded domain characters decode correctly', async () => {
+    // Domain with a path-like component; the resource URI encodes it.
+    const domain = 'sub.example.com:8080';
+    const store = new SkillGraphStorage({ domain, rootDir: root });
+    await store.upsertNode({ stateHash: 'port-node', seenAt: 1 });
+    store.close();
+
+    const raw = readSkillGraphResource(domain);
+    const snapshot = JSON.parse(raw) as { domain: string };
+    expect(snapshot.domain).toBe(domain);
+  });
+
+  test('IPv6-style bracketed domain encodes and decodes round-trip', async () => {
+    // Brackets are encoded by encodeURIComponent: [ → %5B, ] → %5D
+    const domain = '[::1]';
+    const store = new SkillGraphStorage({ domain, rootDir: root });
+    store.close();
+
+    const encoded = encodeURIComponent(domain);
+    const uri = `${SKILL_GRAPH_RESOURCE_PREFIX}${encoded}`;
+    const decoded = parseDomainFromUri(uri);
+    expect(decoded).toBe(domain);
+
+    const raw = readSkillGraphResource(domain);
+    const snapshot = JSON.parse(raw) as { domain: string };
+    expect(snapshot.domain).toBe(domain);
+  });
+});
+
+describe('parseDomainFromUri', () => {
+  test('extracts domain from a valid URI', () => {
+    expect(parseDomainFromUri('openchrome://skill-graph/amazon.com')).toBe('amazon.com');
+  });
+
+  test('decodes percent-encoded characters', () => {
+    expect(parseDomainFromUri('openchrome://skill-graph/sub.example.com%3A8080')).toBe(
+      'sub.example.com:8080',
+    );
+  });
+
+  test('returns null for unrelated URI', () => {
+    expect(parseDomainFromUri('openchrome://usage-guide')).toBeNull();
+  });
+
+  test('returns null for bare prefix with no domain', () => {
+    expect(parseDomainFromUri('openchrome://skill-graph/')).toBeNull();
+  });
+
+  test('returns null for empty string', () => {
+    expect(parseDomainFromUri('')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a core-tier (unflagged) read-only MCP resource at `openchrome://skill-graph/<encodedDomain>` that returns a JSON snapshot of the per-domain skill graph at request time
- Backed by `SkillGraphStorage` from PR #801 (JSON skill graph storage)
- In-process cache keyed by domain, invalidated by `fs.statSync().mtimeMs` check on the underlying JSON file — no stale reads, no unnecessary disk I/O
- Unknown domains return an empty graph (not an error)
- URI decoding via `decodeURIComponent` so percent-encoded chars and IPv6 brackets round-trip correctly

## Changes

- `src/resources/skill-graph.ts` (new): URI prefix handler (`openchrome://skill-graph/`), `readSkillGraphResource(domain)`, `parseDomainFromUri(uri)`, mtime cache, `_setRootDirOverride` for tests
- `src/mcp-server.ts`: imports skill-graph exports, registers `skillGraphResourceTemplate`, adds prefix-based dispatch in `handleResourcesRead` before the existing exact-match path
- `tests/core/mcp/resources/skill-graph.test.ts` (new): 13 tests — unknown domain, populated domain, cache invalidation (mtime), URL encoding round-trips, `parseDomainFromUri` edge cases

## Related

- Issue: #783
- Storage backend: PR #801
- Previous skill-graph phases: PR #774, PR #780

## Test plan

- [x] `npm run build` — passes (tsc clean)
- [x] `npm run lint` — no violations
- [x] `npm run lint:tier` — no dependency violations (296 modules cruised)
- [x] `npx jest tests/core/mcp/resources/` — 13/13 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)