### PR TITLE
feat(core): oc_skill_record + oc_skill_recall MCP tools (Phase 3, closes #785)

### DIFF
--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -45,6 +45,8 @@ export const TOOL_TIERS: Record<string, ToolTier> = {
   oc_reap_orphans: 1,         // src/tools/reap-orphans.ts — manual lifecycle recovery sweep
   oc_assert: 1,               // src/tools/oc-assert.ts — Outcome Contracts single-call verifier (#784)
   oc_evidence_bundle: 1,      // src/tools/oc-evidence-bundle.ts — Outcome Contracts evidence bundle capture (#792)
+  oc_skill_record: 1,         // src/tools/oc-skill-record.ts — skill memory write surface (#785)
+  oc_skill_recall: 1,         // src/tools/oc-skill-recall.ts — skill memory read surface (#785)
 
   // Tier 2: Specialist (on demand)
   extract_data: 2,              // src/tools/extract-data.ts — structured extraction (#571)

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -103,6 +103,10 @@ import { registerOcAssertTool } from './oc-assert';
 // Outcome Contracts (#792) — evidence bundle capture
 import { registerOcEvidenceBundleTool } from './oc-evidence-bundle';
 
+// Skill memory tools (#785) — record + recall
+import { registerOcSkillRecordTool } from './oc-skill-record';
+import { registerOcSkillRecallTool } from './oc-skill-recall';
+
 export function registerAllTools(server: MCPServer): void {
   // Core browser tools
   registerNavigateTool(server);
@@ -209,6 +213,10 @@ export function registerAllTools(server: MCPServer): void {
 
   // Outcome Contracts (#792) — evidence bundle capture
   registerOcEvidenceBundleTool(server);
+
+  // Skill memory tools (#785) — record + recall
+  registerOcSkillRecordTool(server);
+  registerOcSkillRecallTool(server);
 
   console.error(`[Tools] Registered ${server.getToolNames().length} tools`);
 }

--- a/src/tools/oc-skill-recall.ts
+++ b/src/tools/oc-skill-recall.ts
@@ -1,0 +1,123 @@
+/**
+ * oc_skill_recall — retrieve skills from the JSON skill memory store (issue #785).
+ *
+ * Core-tier MCP tool. Returns a recency-sorted, optionally filtered listing
+ * of skills stored via oc_skill_record. No LLM ranking is applied — the
+ * deterministic order (last_used_at desc, skill_id asc on ties) is produced
+ * directly by the store. The pilot recall layer is responsible for any
+ * relevance reranking above this surface.
+ *
+ * Filtering: `contract_id` restricts to skills bound to that contract;
+ * `limit` caps the result count (default 20).
+ */
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import { SkillMemoryStore, type SkillRecord } from '../core/skill-memory';
+
+interface OcSkillRecallOutput {
+  skills: SkillRecord[];
+  error?: string;
+}
+
+const DEFAULT_LIMIT = 20;
+
+const definition: MCPToolDefinition = {
+  name: 'oc_skill_recall',
+  description:
+    'Retrieve skills from the JSON skill memory store for a given domain. ' +
+    'Returns a recency-sorted list (last_used_at desc). Optionally filter by ' +
+    '`contract_id` and cap results with `limit` (default 20). No LLM ranking — ' +
+    'deterministic store order is returned as-is. Use oc_skill_record to write skills.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      domain: {
+        type: 'string',
+        description:
+          'Domain to retrieve skills for (e.g. "amazon.com"). Must be a ' +
+          'non-empty string ≤ 253 chars and match the domain used at record time.',
+      },
+      contract_id: {
+        type: 'string',
+        description:
+          'Optional. Restrict results to skills whose contract_id matches ' +
+          'this value exactly. Omit to return skills across all contracts.',
+      },
+      limit: {
+        type: 'number',
+        description:
+          `Maximum number of skills to return. Default ${DEFAULT_LIMIT}. ` +
+          'Pass 0 to return an empty list. Values below 0 are treated as 0.',
+      },
+    },
+    required: ['domain'],
+  },
+};
+
+const handler: ToolHandler = async (
+  _sessionId: string,
+  args: Record<string, unknown>,
+): Promise<MCPResult> => {
+  const domain = args.domain as string | undefined;
+  const contractId = args.contract_id as string | undefined;
+  const rawLimit = args.limit;
+
+  if (typeof domain !== 'string' || domain.length === 0) {
+    const output: OcSkillRecallOutput = {
+      skills: [],
+      error: 'missing required field: domain (must be a non-empty string)',
+    };
+    return jsonResult(output);
+  }
+
+  const limit =
+    typeof rawLimit === 'number'
+      ? Math.max(0, Math.floor(rawLimit))
+      : DEFAULT_LIMIT;
+
+  let store: SkillMemoryStore;
+  try {
+    store = new SkillMemoryStore({ domain });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const output: OcSkillRecallOutput = {
+      skills: [],
+      error: `failed to initialise skill memory store: ${message}`,
+    };
+    return jsonResult(output);
+  }
+
+  let skills: SkillRecord[];
+  try {
+    skills = store.list({
+      contract_id: contractId,
+      limit,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const output: OcSkillRecallOutput = {
+      skills: [],
+      error: `failed to list skills: ${message}`,
+    };
+    return jsonResult(output);
+  }
+
+  return jsonResult({ skills });
+};
+
+function jsonResult(payload: OcSkillRecallOutput): MCPResult {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(payload),
+      },
+    ],
+    ...payload,
+  };
+}
+
+export function registerOcSkillRecallTool(server: MCPServer): void {
+  server.registerTool('oc_skill_recall', handler, definition);
+}

--- a/src/tools/oc-skill-record.ts
+++ b/src/tools/oc-skill-record.ts
@@ -1,0 +1,211 @@
+/**
+ * oc_skill_record — record a skill into the JSON skill memory store (issue #785).
+ *
+ * Core-tier MCP tool. Accepts a skill definition (domain, name, steps,
+ * contract_id) and persists it via SkillMemoryStore. Optionally writes a
+ * frozen snapshot alongside the record and returns the snapshot path.
+ *
+ * The tool is idempotent on (domain, name): re-recording with the same name
+ * updates mutable fields (steps, contract_id, frozen_snapshot_path) but
+ * preserves the existing skill_id and usage counters. This lets host agents
+ * flush skill updates safely without risk of duplication.
+ *
+ * No LLM ranking is performed here — this is a pure write surface. Recall
+ * with optional filtering lives in oc_skill_recall (#785).
+ */
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import { SkillMemoryStore } from '../core/skill-memory';
+
+interface OcSkillRecordOutput {
+  skill_id: string;
+  stored_at: number;
+  snapshot_path?: string;
+}
+
+const definition: MCPToolDefinition = {
+  name: 'oc_skill_record',
+  description:
+    'Record a skill (domain, name, steps, contract_id) into the JSON skill ' +
+    'memory store. Idempotent on (domain, name) — re-recording preserves the ' +
+    'existing skill_id and usage counters while updating steps and contract_id. ' +
+    'Pass `frozen_snapshot` to atomically write a gzipped snapshot alongside ' +
+    'the record. Returns { skill_id, stored_at, snapshot_path? }. Core-tier; ' +
+    'no LLM ranking. Use oc_skill_recall to retrieve skills.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      domain: {
+        type: 'string',
+        description:
+          'Domain this skill belongs to (e.g. "amazon.com"). Used as the ' +
+          'storage partition key and must be a non-empty string ≤ 253 chars.',
+      },
+      name: {
+        type: 'string',
+        description:
+          'Human-readable skill name, unique within the domain ' +
+          '(e.g. "add-to-cart"). Acts as the idempotency key together with domain.',
+      },
+      steps: {
+        type: 'array',
+        description:
+          'Opaque step list supplied by the host agent. The store persists ' +
+          'this inline in the JSON file without schema validation. Each element ' +
+          'may be any JSON-serialisable value.',
+        items: {},
+      },
+      contract_id: {
+        type: 'string',
+        description:
+          'Identifier of the Outcome Contract that governs this skill ' +
+          '(ties into oc_assert #784 and the contracts registry).',
+      },
+      frozen_snapshot: {
+        type: 'object',
+        description:
+          'Optional opaque snapshot payload to persist alongside the record. ' +
+          'Written exactly once (write-once semantics) under ' +
+          '<rootDir>/<domain>/snapshots/<skill_id>.json.gz. ' +
+          'Omit on re-records when you do not want to update the snapshot.',
+      },
+    },
+    required: ['domain', 'name', 'steps', 'contract_id'],
+  },
+};
+
+const handler: ToolHandler = async (
+  _sessionId: string,
+  args: Record<string, unknown>,
+): Promise<MCPResult> => {
+  const domain = args.domain as string | undefined;
+  const name = args.name as string | undefined;
+  const steps = args.steps as unknown[] | undefined;
+  const contractId = args.contract_id as string | undefined;
+  const frozenSnapshot = args.frozen_snapshot as Record<string, unknown> | undefined;
+
+  if (typeof domain !== 'string' || domain.length === 0) {
+    return jsonResult({
+      skill_id: '',
+      stored_at: 0,
+      error: 'missing required field: domain (must be a non-empty string)',
+    } as OcSkillRecordOutput & { error: string });
+  }
+  if (typeof name !== 'string' || name.length === 0) {
+    return jsonResult({
+      skill_id: '',
+      stored_at: 0,
+      error: 'missing required field: name (must be a non-empty string)',
+    } as OcSkillRecordOutput & { error: string });
+  }
+  if (!Array.isArray(steps)) {
+    return jsonResult({
+      skill_id: '',
+      stored_at: 0,
+      error: 'missing required field: steps (must be an array)',
+    } as OcSkillRecordOutput & { error: string });
+  }
+  if (typeof contractId !== 'string' || contractId.length === 0) {
+    return jsonResult({
+      skill_id: '',
+      stored_at: 0,
+      error: 'missing required field: contract_id (must be a non-empty string)',
+    } as OcSkillRecordOutput & { error: string });
+  }
+
+  let store: SkillMemoryStore;
+  try {
+    store = new SkillMemoryStore({ domain });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return jsonResult({
+      skill_id: '',
+      stored_at: 0,
+      error: `failed to initialise skill memory store: ${message}`,
+    } as OcSkillRecordOutput & { error: string });
+  }
+
+  // Write the frozen snapshot before record() so that if the snapshot write
+  // fails (e.g. write-once violation), we surface the error before mutating
+  // skills.json. The skill_id is deterministically derived from (domain, name)
+  // so we can compute it here without reading the store.
+  let snapshotPath: string | undefined;
+  if (frozenSnapshot !== undefined) {
+    // Compute the skill_id the same way the store will — SHA-256 of
+    // "<domain>\x00<name>", first 16 hex chars. We need it as the snapshot
+    // basename before we call record().
+    const skillId = computeSkillId(domain, name);
+    try {
+      const result = store.writeFrozenSnapshot(skillId, frozenSnapshot);
+      snapshotPath = result.snapshot_path;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // write-once violation is surfaced as an error; the tool does not
+      // silently continue because the caller likely expects a fresh snapshot.
+      return jsonResult({
+        skill_id: '',
+        stored_at: 0,
+        error: `failed to write frozen snapshot: ${message}`,
+      } as OcSkillRecordOutput & { error: string });
+    }
+  }
+
+  let recordResult: { skill_id: string; stored_at: number };
+  try {
+    recordResult = await store.record({
+      domain,
+      name,
+      steps,
+      contractId,
+      successCount: 0,
+      lastUsedAt: 0,
+      frozenSnapshotPath: snapshotPath ?? null,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return jsonResult({
+      skill_id: '',
+      stored_at: 0,
+      error: `failed to record skill: ${message}`,
+    } as OcSkillRecordOutput & { error: string });
+  }
+
+  const output: OcSkillRecordOutput = {
+    skill_id: recordResult.skill_id,
+    stored_at: recordResult.stored_at,
+  };
+  if (snapshotPath !== undefined) {
+    output.snapshot_path = snapshotPath;
+  }
+  return jsonResult(output);
+};
+
+/**
+ * Compute the deterministic skill_id for a (domain, name) pair.
+ * Must match the private `computeSkillId` in store.ts exactly.
+ */
+function computeSkillId(domain: string, name: string): string {
+  const crypto = require('node:crypto') as typeof import('node:crypto');
+  return crypto
+    .createHash('sha256')
+    .update(`${domain}\x00${name}`, 'utf8')
+    .digest('hex')
+    .slice(0, 16);
+}
+
+function jsonResult(payload: OcSkillRecordOutput | (OcSkillRecordOutput & { error: string })): MCPResult {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(payload),
+      },
+    ],
+    ...payload,
+  };
+}
+
+export function registerOcSkillRecordTool(server: MCPServer): void {
+  server.registerTool('oc_skill_record', handler, definition);
+}

--- a/tests/core/skill-memory/oc-skill-tools.test.ts
+++ b/tests/core/skill-memory/oc-skill-tools.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Tests for oc_skill_record and oc_skill_recall MCP tools (issue #785).
+ *
+ * Tests call the tool handlers directly (no MCP transport) by wiring a minimal
+ * fake server and using jest.mock to inject a per-test rootDir into the
+ * SkillMemoryStore constructor so fixtures land in a temp directory instead of
+ * ~/.openchrome/skill-memory.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// ── rootDir injection ─────────────────────────────────────────────────────────
+// Jest module mocking must be declared before any imports that use the module.
+// We store the desired rootDir in a closure variable and swap it per test.
+
+let _testRoot = '';
+
+jest.mock('../../../src/core/skill-memory', () => {
+  // Pull in the real module but wrap SkillMemoryStore so construction always
+  // uses _testRoot when no explicit rootDir is given.
+  const real = jest.requireActual<typeof import('../../../src/core/skill-memory')>(
+    '../../../src/core/skill-memory',
+  );
+  return {
+    ...real,
+    SkillMemoryStore: class extends real.SkillMemoryStore {
+      constructor(opts: { domain: string; rootDir?: string }) {
+        super({ ...opts, rootDir: opts.rootDir ?? _testRoot });
+      }
+    },
+  };
+});
+
+import { registerOcSkillRecordTool } from '../../../src/tools/oc-skill-record';
+import { registerOcSkillRecallTool } from '../../../src/tools/oc-skill-recall';
+import { SkillMemoryStore } from '../../../src/core/skill-memory';
+import type { MCPServer } from '../../../src/mcp-server';
+
+// ── Minimal fake MCPServer ────────────────────────────────────────────────────
+
+type HandlerFn = (sessionId: string, args: Record<string, unknown>) => Promise<unknown>;
+
+class FakeMCPServer {
+  private handlers = new Map<string, HandlerFn>();
+
+  registerTool(name: string, handler: HandlerFn, _definition: unknown): void {
+    this.handlers.set(name, handler);
+  }
+
+  async call(name: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const h = this.handlers.get(name);
+    if (!h) throw new Error(`Unknown tool: ${name}`);
+    return h('test-session', args) as Promise<Record<string, unknown>>;
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-skill-tools-'));
+}
+
+function parseResult(result: Record<string, unknown>): Record<string, unknown> {
+  const content = result.content as Array<{ type: string; text: string }>;
+  return JSON.parse(content[0].text) as Record<string, unknown>;
+}
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+let server: FakeMCPServer;
+
+beforeEach(() => {
+  _testRoot = tempRoot();
+  server = new FakeMCPServer();
+  registerOcSkillRecordTool(server as unknown as MCPServer);
+  registerOcSkillRecallTool(server as unknown as MCPServer);
+});
+
+afterEach(() => {
+  fs.rmSync(_testRoot, { recursive: true, force: true });
+});
+
+// ── oc_skill_record ───────────────────────────────────────────────────────────
+
+describe('oc_skill_record', () => {
+  test('records a skill and returns skill_id + stored_at', async () => {
+    const result = parseResult(
+      await server.call('oc_skill_record', {
+        domain: 'amazon.com',
+        name: 'add-to-cart',
+        steps: [{ kind: 'click', selector: '#buy' }],
+        contract_id: 'c-1',
+      }),
+    );
+
+    expect(typeof result.skill_id).toBe('string');
+    expect((result.skill_id as string).length).toBeGreaterThan(0);
+    expect(typeof result.stored_at).toBe('number');
+    expect(result.error).toBeUndefined();
+  });
+
+  test('is idempotent on (domain, name) — same skill_id returned on re-record', async () => {
+    const first = parseResult(
+      await server.call('oc_skill_record', {
+        domain: 'amazon.com',
+        name: 'add-to-cart',
+        steps: [{ kind: 'click', selector: '#buy' }],
+        contract_id: 'c-1',
+      }),
+    );
+
+    const second = parseResult(
+      await server.call('oc_skill_record', {
+        domain: 'amazon.com',
+        name: 'add-to-cart',
+        steps: [{ kind: 'click', selector: '#buy-v2' }],
+        contract_id: 'c-2',
+      }),
+    );
+
+    expect(second.skill_id).toBe(first.skill_id);
+    expect(second.error).toBeUndefined();
+  });
+
+  test('with frozen_snapshot writes to disk and returns snapshot_path', async () => {
+    const result = parseResult(
+      await server.call('oc_skill_record', {
+        domain: 'amazon.com',
+        name: 'checkout',
+        steps: [{ kind: 'navigate', url: '/checkout' }],
+        contract_id: 'c-checkout',
+        frozen_snapshot: { page: 'checkout', items: 3 },
+      }),
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(typeof result.snapshot_path).toBe('string');
+    const snapshotPath = result.snapshot_path as string;
+    expect(fs.existsSync(snapshotPath)).toBe(true);
+    expect(snapshotPath.endsWith('.json.gz')).toBe(true);
+  });
+
+  test('returns error when domain is missing', async () => {
+    const result = parseResult(
+      await server.call('oc_skill_record', {
+        name: 'foo',
+        steps: [],
+        contract_id: 'c-1',
+      }),
+    );
+    expect(typeof result.error).toBe('string');
+    expect((result.error as string).toLowerCase()).toContain('domain');
+  });
+
+  test('returns error when steps is not an array', async () => {
+    const result = parseResult(
+      await server.call('oc_skill_record', {
+        domain: 'amazon.com',
+        name: 'foo',
+        steps: 'not-an-array',
+        contract_id: 'c-1',
+      }),
+    );
+    expect(typeof result.error).toBe('string');
+    expect((result.error as string).toLowerCase()).toContain('steps');
+  });
+});
+
+// ── oc_skill_recall ───────────────────────────────────────────────────────────
+
+describe('oc_skill_recall', () => {
+  /** Seed skills with controlled lastUsedAt values via the store directly. */
+  async function seedSkills(): Promise<void> {
+    const store = new SkillMemoryStore({ domain: 'amazon.com', rootDir: _testRoot });
+    const a = await store.record({
+      domain: 'amazon.com',
+      name: 'skill-a',
+      steps: [],
+      contractId: 'c-1',
+      successCount: 0,
+      lastUsedAt: 0,
+      frozenSnapshotPath: null,
+    });
+    await store.markUsed(a.skill_id, 3000, true);
+
+    const b = await store.record({
+      domain: 'amazon.com',
+      name: 'skill-b',
+      steps: [],
+      contractId: 'c-2',
+      successCount: 0,
+      lastUsedAt: 0,
+      frozenSnapshotPath: null,
+    });
+    await store.markUsed(b.skill_id, 2000, true);
+
+    // skill-c: never used (lastUsedAt stays 0)
+    await store.record({
+      domain: 'amazon.com',
+      name: 'skill-c',
+      steps: [],
+      contractId: 'c-1',
+      successCount: 0,
+      lastUsedAt: 0,
+      frozenSnapshotPath: null,
+    });
+  }
+
+  test('returns recent skills first (recency order)', async () => {
+    await seedSkills();
+
+    const result = parseResult(
+      await server.call('oc_skill_recall', { domain: 'amazon.com' }),
+    );
+
+    expect(result.error).toBeUndefined();
+    const skills = result.skills as Array<{ name: string }>;
+    expect(skills.length).toBe(3);
+    expect(skills[0].name).toBe('skill-a');
+    expect(skills[1].name).toBe('skill-b');
+    expect(skills[2].name).toBe('skill-c');
+  });
+
+  test('filtered by contract_id returns only matching skills', async () => {
+    await seedSkills();
+
+    const result = parseResult(
+      await server.call('oc_skill_recall', {
+        domain: 'amazon.com',
+        contract_id: 'c-1',
+      }),
+    );
+
+    expect(result.error).toBeUndefined();
+    const skills = result.skills as Array<{ contractId: string }>;
+    expect(skills.length).toBe(2);
+    for (const s of skills) {
+      expect(s.contractId).toBe('c-1');
+    }
+  });
+
+  test('respects limit', async () => {
+    await seedSkills();
+
+    const result = parseResult(
+      await server.call('oc_skill_recall', {
+        domain: 'amazon.com',
+        limit: 2,
+      }),
+    );
+
+    expect(result.error).toBeUndefined();
+    expect((result.skills as unknown[]).length).toBe(2);
+  });
+
+  test('returns empty array when domain has no skills', async () => {
+    const result = parseResult(
+      await server.call('oc_skill_recall', { domain: 'empty.com' }),
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.skills).toEqual([]);
+  });
+
+  test('returns error when domain is missing', async () => {
+    const result = parseResult(await server.call('oc_skill_recall', {}));
+    expect(typeof result.error).toBe('string');
+    expect((result.error as string).toLowerCase()).toContain('domain');
+  });
+
+  test('default limit is 20 — does not return more than 20 skills', async () => {
+    const store = new SkillMemoryStore({ domain: 'big.com', rootDir: _testRoot });
+    for (let i = 0; i < 25; i++) {
+      await store.record({
+        domain: 'big.com',
+        name: `skill-${i}`,
+        steps: [],
+        contractId: 'c-x',
+        successCount: 0,
+        lastUsedAt: i,
+        frozenSnapshotPath: null,
+      });
+    }
+
+    const result = parseResult(
+      await server.call('oc_skill_recall', { domain: 'big.com' }),
+    );
+
+    expect(result.error).toBeUndefined();
+    expect((result.skills as unknown[]).length).toBe(20);
+  });
+});

--- a/tests/cross-env/cursor-verification.test.ts
+++ b/tests/cross-env/cursor-verification.test.ts
@@ -135,16 +135,16 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
   describe('C2: Tool Discovery & Listing', () => {
     let tier1Tools: any[];
 
-    test('Initial tools/list returns Tier 1 tools only (36 tools) + expand_tools', async () => {
+    test('Initial tools/list returns Tier 1 tools only (38 tools) + expand_tools', async () => {
       const { response } = await sendAndReceive(server, 'tools/list');
       tier1Tools = response.result.tools;
-      // 36 Tier 1 tools (includes oc_reap_orphans lifecycle sweep, oc_assert,
-      // oc_evidence_bundle) + 1 expand_tools virtual tool = 37
+      // 38 Tier 1 tools (includes oc_reap_orphans lifecycle sweep, oc_assert,
+      // oc_evidence_bundle, oc_skill_record, oc_skill_recall) + 1 expand_tools virtual tool = 39
       const toolNames = tier1Tools.map((t: any) => t.name);
       expect(toolNames).toContain('expand_tools');
 
       const nonExpandTools = tier1Tools.filter((t: any) => t.name !== 'expand_tools');
-      expect(nonExpandTools.length).toBe(36);
+      expect(nonExpandTools.length).toBe(38);
     });
 
     test('expand_tools virtual tool present in initial list', () => {


### PR DESCRIPTION
## Summary

- Adds `oc_skill_record` (Tier 1) — idempotent write surface for the JSON skill memory store (PR #800). Accepts `domain`, `name`, `steps`, `contract_id`, and optional `frozen_snapshot`; returns `{ skill_id, stored_at, snapshot_path? }`.
- Adds `oc_skill_recall` (Tier 1) — read surface returning recency-sorted `SkillRecord[]` for a domain with optional `contract_id` filter and `limit` (default 20). No LLM ranking — deterministic store order.
- Registers both tools in `src/tools/index.ts` and `src/config/tool-tiers.ts` as Tier 1.
- Bumps Tier-1 count in `tests/cross-env/cursor-verification.test.ts` from 36 → 38.
- Adds 11-test suite `tests/core/skill-memory/oc-skill-tools.test.ts` covering: idempotency on `(domain, name)`, frozen snapshot disk write, recency order, `contract_id` filtering, `limit` enforcement, and error handling.

## References

- Closes #785 (Phase 3 of OpenChrome 1.11 cleanup)
- Builds on PR #800 (JSON skill memory store)
- Outcome Contract surface: PR #774 (contract), PR #780 (tracker)
- Sibling tool pattern: PR #796 (`oc_assert`), PR #799 (`oc_evidence_bundle`)

## Test plan

- [x] `npm run build` — clean (both tsconfig targets)
- [x] `npm run lint` — zero warnings on new files
- [x] `npm run lint:tier` — no dependency violations (298 modules)
- [x] `npx jest tests/core/skill-memory/` — 39 passed (11 new + 28 existing store tests)
- [ ] `npx jest tests/cross-env/cursor-verification.test.ts` — requires built dist + Node ≥ 22 on macOS; Tier-1 count bumped to 38

🤖 Generated with [Claude Code](https://claude.com/claude-code)