### PR TITLE
feat(core): perceptual DOM metadata + cache (Phase 4, replaces #757)

### DIFF
--- a/src/core/perception/cache.ts
+++ b/src/core/perception/cache.ts
@@ -1,0 +1,89 @@
+/**
+ * Per-frame perceptual-metadata cache (#709 v2).
+ *
+ * Keyed on `(frameId, docCounter, viewportRect)` — invalidated on
+ * `DOM.documentUpdated` and `Page.frameResized`. Hosts call
+ * `bumpDoc(frameId)` from the CDP event handlers; the cache itself
+ * does not subscribe — that decoupling keeps the module pure-JS and
+ * easy to unit-test.
+ *
+ * The cache is keyed by a string built from the components above, so
+ * the implementation is just a Map under the hood. We give it a
+ * dedicated module so future strategies (LRU bounded by memory, etc.)
+ * are a non-breaking swap.
+ */
+
+import type { PerceptualMetadata, ViewportRect } from './types';
+
+interface CacheKey {
+  frameId: string;
+  docCounter: number;
+  viewport: ViewportRect;
+  backendNodeId: number;
+}
+
+function keyString(k: CacheKey): string {
+  return `${k.frameId}|${k.docCounter}|${k.viewport.x},${k.viewport.y},${k.viewport.w},${k.viewport.h}|${k.backendNodeId}`;
+}
+
+export class PerceptualCache {
+  private readonly entries = new Map<string, PerceptualMetadata>();
+  /** Per-frame monotonic doc counter. Bumped on DOM.documentUpdated. */
+  private readonly docCounters = new Map<string, number>();
+
+  /**
+   * Read or compute. The host supplies the `compute` function which is
+   * only invoked on a miss. The closure captures any node-probe state
+   * — the cache only deals with the cached value.
+   */
+  getOrCompute(
+    keyParts: { frameId: string; viewport: ViewportRect; backendNodeId: number },
+    compute: () => PerceptualMetadata,
+  ): PerceptualMetadata {
+    const docCounter = this.getDocCounter(keyParts.frameId);
+    const k = keyString({ ...keyParts, docCounter });
+    const hit = this.entries.get(k);
+    if (hit) return hit;
+    const fresh = compute();
+    this.entries.set(k, fresh);
+    return fresh;
+  }
+
+  /** Read without computing. Returns undefined on miss. */
+  get(
+    keyParts: { frameId: string; viewport: ViewportRect; backendNodeId: number },
+  ): PerceptualMetadata | undefined {
+    const docCounter = this.getDocCounter(keyParts.frameId);
+    return this.entries.get(keyString({ ...keyParts, docCounter }));
+  }
+
+  /**
+   * Invalidate every entry for `frameId`. Hosts call this from
+   * `DOM.documentUpdated` (or any equivalent invalidation signal).
+   */
+  bumpDoc(frameId: string): void {
+    const next = (this.docCounters.get(frameId) ?? 0) + 1;
+    this.docCounters.set(frameId, next);
+    // Drop entries for the previous counter — keep memory bounded.
+    const prefix = `${frameId}|${next - 1}|`;
+    for (const k of this.entries.keys()) {
+      if (k.startsWith(prefix)) this.entries.delete(k);
+    }
+  }
+
+  /** Drop everything (test hook + reset on serve restart). */
+  clear(): void {
+    this.entries.clear();
+    this.docCounters.clear();
+  }
+
+  /** Inspect the current docCounter for a frame (debug + tests). */
+  getDocCounter(frameId: string): number {
+    return this.docCounters.get(frameId) ?? 0;
+  }
+
+  /** For tests. */
+  size(): number {
+    return this.entries.size;
+  }
+}

--- a/src/core/perception/index.ts
+++ b/src/core/perception/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Adversarial-Robust Perception barrel (#700). PR-16 ships the
+ * metadata classifier + cache; PR-17 will add cross-check + image
+ * features; PR-18 wires the pre-action hook; PR-19 adds multi-model
+ * voting.
+ */
+
+export { computePerceptualMetadata, effectiveOpacity, intersects } from './metadata';
+export { PerceptualCache } from './cache';
+export type {
+  EffectiveDisplay,
+  InteractionFeasibility,
+  NodeProbe,
+  PerceptualMetadata,
+  PixelBox,
+  ViewportRect,
+} from './types';

--- a/src/core/perception/metadata.ts
+++ b/src/core/perception/metadata.ts
@@ -1,0 +1,127 @@
+/**
+ * Perceptual metadata classifier (#709).
+ *
+ * Pure function — no CDP, no DOM, no I/O. Hosts (the dom-serializer
+ * pipeline + the cross-check module #710) build a `NodeProbe` from
+ * live state and call `computePerceptualMetadata` to get the
+ * structured classification an LLM can reason about.
+ */
+
+import type {
+  EffectiveDisplay,
+  InteractionFeasibility,
+  NodeProbe,
+  PerceptualMetadata,
+  PixelBox,
+  ViewportRect,
+} from './types';
+
+/** Multiply the opacity chain. Empty chain → 1.0. */
+export function effectiveOpacity(chain: ReadonlyArray<number>): number {
+  if (chain.length === 0) return 1;
+  let v = 1;
+  for (const o of chain) v *= clamp01(o);
+  return v;
+}
+
+function clamp01(v: number): number {
+  if (!Number.isFinite(v)) return 1;
+  if (v < 0) return 0;
+  if (v > 1) return 1;
+  return v;
+}
+
+/** Strict pixel-rectangle intersection (positive overlap on both axes). */
+export function intersects(a: PixelBox, b: ViewportRect): boolean {
+  if (a.w <= 0 || a.h <= 0) return false;
+  if (b.w <= 0 || b.h <= 0) return false;
+  const ax2 = a.x + a.w;
+  const ay2 = a.y + a.h;
+  const bx2 = b.x + b.w;
+  const by2 = b.y + b.h;
+  return a.x < bx2 && ax2 > b.x && a.y < by2 && ay2 > b.y;
+}
+
+function isZeroSize(box: PixelBox | null): boolean {
+  if (!box) return true;
+  return box.w <= 0 || box.h <= 0;
+}
+
+function classifyEffectiveDisplay(probe: NodeProbe): EffectiveDisplay {
+  if (probe.ancestorDisplayNone || probe.display === 'none') return 'hidden_display_none';
+  if (probe.ancestorVisibilityHidden || probe.visibility === 'hidden' || probe.visibility === 'collapse') {
+    return 'hidden_visibility';
+  }
+  // display: contents — node has no box; bucket depends on whether any
+  // descendant has one (per #709 v2 P1 fix for the missing enum value).
+  if (probe.display === 'contents') {
+    return probe.hasChildBoxes ? 'rendered' : 'display_contents_no_box';
+  }
+  return 'rendered';
+}
+
+function classifyInteractionFeasibility(
+  effective: EffectiveDisplay,
+  box: PixelBox | null,
+  viewport: ViewportRect,
+  topElementMatches: boolean,
+): InteractionFeasibility {
+  if (effective !== 'rendered' && effective !== 'covered_by' && effective !== 'off_screen') {
+    return 'outside_viewport'; // hidden/collapsed/contents-no-box → all flat-out unreachable
+  }
+  if (isZeroSize(box)) return 'zero_size';
+  if (!box) return 'zero_size';
+  if (effective === 'off_screen' || !intersects(box, viewport)) return 'outside_viewport';
+  if (!topElementMatches) return 'blocked_by_overlay';
+  return 'ok';
+}
+
+/**
+ * Top-level: probe + viewport → PerceptualMetadata.
+ *
+ * Hosts may set `topElementBackendNodeId` to null when they did not
+ * call `elementFromPoint` (e.g., bulk read_page mode); the rollup then
+ * conservatively assumes the node is on top — this is the same default
+ * the legacy compression layer used.
+ */
+export function computePerceptualMetadata(
+  probe: NodeProbe,
+  viewport: ViewportRect,
+): PerceptualMetadata {
+  const baseDisplay = classifyEffectiveDisplay(probe);
+  const opacity = effectiveOpacity(probe.opacityChain);
+  const box = probe.pixelBox;
+
+  // off_screen takes priority over covered_by — there's nothing to
+  // cover an element that isn't on screen in the first place.
+  let effective: EffectiveDisplay = baseDisplay;
+  if (effective === 'rendered' && box && !intersects(box, viewport)) {
+    effective = 'off_screen';
+  }
+
+  // covered_by is computed AFTER off-screen so we never falsely report
+  // "covered" for a node that's simply outside the viewport.
+  let coveredByNodeId: number | undefined;
+  if (effective === 'rendered' && probe.topElementBackendNodeId !== null) {
+    if (probe.topElementBackendNodeId !== probe.backendNodeId) {
+      effective = 'covered_by';
+      coveredByNodeId = probe.topElementBackendNodeId;
+    }
+  }
+
+  const topElementMatches =
+    probe.topElementBackendNodeId === null ||
+    probe.topElementBackendNodeId === probe.backendNodeId;
+
+  const feasibility = classifyInteractionFeasibility(effective, box, viewport, topElementMatches);
+
+  const md: PerceptualMetadata = {
+    pixelBox: box,
+    viewportVisible: !!box && intersects(box, viewport),
+    effectiveOpacity: opacity,
+    effectiveDisplay: effective,
+    interactionFeasibility: feasibility,
+  };
+  if (coveredByNodeId !== undefined) md.coveredByNodeId = coveredByNodeId;
+  return md;
+}

--- a/src/core/perception/types.ts
+++ b/src/core/perception/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared types for the Adversarial-Robust Perception subsystem (#700).
+ *
+ * The compression layer (`src/dom/dom-serializer.ts`) and the cross-
+ * check module (#710) both consume these — keeping the shapes in one
+ * file avoids drift.
+ */
+
+export interface ViewportRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface PixelBox {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * `effectiveDisplay` enum per #709 v2:
+ *   rendered                 — element has a box and is laid out
+ *   hidden_display_none      — display:none anywhere on ancestor chain
+ *   hidden_visibility        — visibility:hidden / collapse
+ *   off_screen               — pixelBox does not intersect the viewport
+ *   covered_by               — elementFromPoint at center is a different node
+ *   display_contents_no_box  — display:contents (parent has no box itself)
+ */
+export type EffectiveDisplay =
+  | 'rendered'
+  | 'hidden_display_none'
+  | 'hidden_visibility'
+  | 'off_screen'
+  | 'covered_by'
+  | 'display_contents_no_box';
+
+export type InteractionFeasibility =
+  | 'ok'
+  | 'blocked_by_overlay'
+  | 'outside_viewport'
+  | 'zero_size';
+
+export interface PerceptualMetadata {
+  /** Element bounding box in viewport coordinates. Null when no layout. */
+  pixelBox: PixelBox | null;
+  /** True iff pixelBox intersects the viewport. */
+  viewportVisible: boolean;
+  /** Cumulative opacity from root to this node (0..1). */
+  effectiveOpacity: number;
+  effectiveDisplay: EffectiveDisplay;
+  /** When effectiveDisplay === 'covered_by', the covering node. */
+  coveredByNodeId?: number;
+  /** Derived rollup callers can switch on without re-implementing rules. */
+  interactionFeasibility: InteractionFeasibility;
+}
+
+/** Per-node input the metadata function consumes. */
+export interface NodeProbe {
+  /** Stable CDP backendNodeId. NEVER use the unstable `nodeId`. */
+  backendNodeId: number;
+  /** Computed `display`: `block`, `none`, `contents`, `flex`, ... */
+  display: string;
+  /** Computed `visibility`: `visible`, `hidden`, `collapse`. */
+  visibility: string;
+  /**
+   * Cumulative opacity values from the document root down to this node
+   * (each multiplied yields effectiveOpacity). Empty array → 1.0.
+   */
+  opacityChain: number[];
+  /** Box model from `DOM.getBoxModel`; null when the node has no layout. */
+  pixelBox: PixelBox | null;
+  /**
+   * `document.elementFromPoint(cx, cy)` resolved to backendNodeId, or
+   * null when nothing was found / the call wasn't made.
+   */
+  topElementBackendNodeId: number | null;
+  /**
+   * True iff at least one descendant has a layout box. Only used for
+   * `display: contents` classification — set to false for ordinary
+   * leaves (it's just the predicate "do my children have boxes").
+   */
+  hasChildBoxes: boolean;
+  /**
+   * True iff any ancestor has display:none / visibility:hidden. Saves
+   * the metadata function from re-walking the chain.
+   */
+  ancestorDisplayNone: boolean;
+  ancestorVisibilityHidden: boolean;
+}

--- a/tests/core/perception/cache.test.ts
+++ b/tests/core/perception/cache.test.ts
@@ -1,0 +1,93 @@
+import { PerceptualCache } from '../../../src/core/perception/cache';
+import type { PerceptualMetadata, ViewportRect } from '../../../src/core/perception/types';
+
+const VIEWPORT: ViewportRect = { x: 0, y: 0, w: 1280, h: 800 };
+
+function md(extra: Partial<PerceptualMetadata> = {}): PerceptualMetadata {
+  return {
+    pixelBox: { x: 0, y: 0, w: 10, h: 10 },
+    viewportVisible: true,
+    effectiveOpacity: 1,
+    effectiveDisplay: 'rendered',
+    interactionFeasibility: 'ok',
+    ...extra,
+  };
+}
+
+describe('PerceptualCache — basic behavior', () => {
+  test('miss invokes compute and stores the result', () => {
+    const cache = new PerceptualCache();
+    let calls = 0;
+    const k = { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1 };
+    const a = cache.getOrCompute(k, () => {
+      calls++;
+      return md();
+    });
+    const b = cache.getOrCompute(k, () => {
+      calls++;
+      return md({ effectiveOpacity: 0.5 });
+    });
+    expect(calls).toBe(1);
+    expect(a).toBe(b); // identical reference (hit returns stored object)
+  });
+
+  test('different backendNodeId → independent entries', () => {
+    const cache = new PerceptualCache();
+    cache.getOrCompute({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1 }, () => md({ effectiveOpacity: 1 }));
+    cache.getOrCompute({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 2 }, () => md({ effectiveOpacity: 0.5 }));
+    expect(cache.size()).toBe(2);
+  });
+
+  test('different viewport → independent entries', () => {
+    const cache = new PerceptualCache();
+    cache.getOrCompute({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1 }, () => md());
+    cache.getOrCompute({ frameId: 'f1', viewport: { x: 0, y: 0, w: 800, h: 600 }, backendNodeId: 1 }, () => md());
+    expect(cache.size()).toBe(2);
+  });
+});
+
+describe('PerceptualCache — invalidation', () => {
+  test('bumpDoc(frameId) drops previous-counter entries for that frame', () => {
+    const cache = new PerceptualCache();
+    let calls = 0;
+    const k = { frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1 };
+    cache.getOrCompute(k, () => {
+      calls++;
+      return md();
+    });
+    expect(calls).toBe(1);
+
+    cache.bumpDoc('f1');
+    cache.getOrCompute(k, () => {
+      calls++;
+      return md({ effectiveOpacity: 0.7 });
+    });
+    expect(calls).toBe(2);
+    expect(cache.getDocCounter('f1')).toBe(1);
+  });
+
+  test('bumpDoc on one frame does not invalidate others', () => {
+    const cache = new PerceptualCache();
+    cache.getOrCompute({ frameId: 'f1', viewport: VIEWPORT, backendNodeId: 1 }, () => md());
+    cache.getOrCompute({ frameId: 'f2', viewport: VIEWPORT, backendNodeId: 1 }, () => md());
+    cache.bumpDoc('f1');
+    // f1 was dropped, f2 retained
+    expect(cache.size()).toBe(1);
+    expect(cache.get({ frameId: 'f2', viewport: VIEWPORT, backendNodeId: 1 })).toBeDefined();
+  });
+
+  test('clear() drops everything', () => {
+    const cache = new PerceptualCache();
+    cache.getOrCompute({ frameId: 'f', viewport: VIEWPORT, backendNodeId: 1 }, () => md());
+    cache.bumpDoc('f');
+    cache.getOrCompute({ frameId: 'f', viewport: VIEWPORT, backendNodeId: 1 }, () => md());
+    cache.clear();
+    expect(cache.size()).toBe(0);
+    expect(cache.getDocCounter('f')).toBe(0);
+  });
+
+  test('get() without compute returns undefined on miss', () => {
+    const cache = new PerceptualCache();
+    expect(cache.get({ frameId: 'f', viewport: VIEWPORT, backendNodeId: 1 })).toBeUndefined();
+  });
+});

--- a/tests/core/perception/metadata.test.ts
+++ b/tests/core/perception/metadata.test.ts
@@ -1,0 +1,178 @@
+import {
+  computePerceptualMetadata,
+  effectiveOpacity,
+  intersects,
+} from '../../../src/core/perception/metadata';
+import type { NodeProbe, ViewportRect } from '../../../src/core/perception/types';
+
+const VIEWPORT: ViewportRect = { x: 0, y: 0, w: 1280, h: 800 };
+
+function probe(over: Partial<NodeProbe> = {}): NodeProbe {
+  return {
+    backendNodeId: 42,
+    display: 'block',
+    visibility: 'visible',
+    opacityChain: [],
+    pixelBox: { x: 100, y: 100, w: 200, h: 50 },
+    topElementBackendNodeId: 42,
+    hasChildBoxes: false,
+    ancestorDisplayNone: false,
+    ancestorVisibilityHidden: false,
+    ...over,
+  };
+}
+
+describe('effectiveOpacity', () => {
+  test('empty chain → 1', () => {
+    expect(effectiveOpacity([])).toBe(1);
+  });
+
+  test('multiplies values', () => {
+    expect(effectiveOpacity([1, 0.5, 0.5])).toBeCloseTo(0.25);
+  });
+
+  test('clamps out-of-range to [0,1]', () => {
+    expect(effectiveOpacity([1.5, 1])).toBe(1);
+    expect(effectiveOpacity([-1, 1])).toBe(0);
+  });
+
+  test('NaN treated as 1 (defensive)', () => {
+    expect(effectiveOpacity([Number.NaN, 0.5])).toBe(0.5);
+  });
+});
+
+describe('intersects', () => {
+  test('overlapping rectangles → true', () => {
+    expect(intersects({ x: 0, y: 0, w: 10, h: 10 }, { x: 5, y: 5, w: 10, h: 10 })).toBe(true);
+  });
+
+  test('edge-touching rectangles → false (strict overlap)', () => {
+    expect(intersects({ x: 0, y: 0, w: 10, h: 10 }, { x: 10, y: 0, w: 10, h: 10 })).toBe(false);
+  });
+
+  test('zero-size → false', () => {
+    expect(intersects({ x: 0, y: 0, w: 0, h: 10 }, VIEWPORT)).toBe(false);
+    expect(intersects({ x: 0, y: 0, w: 10, h: 10 }, { x: 0, y: 0, w: 0, h: 10 })).toBe(false);
+  });
+});
+
+describe('computePerceptualMetadata — effectiveDisplay enum', () => {
+  test('plain visible block → rendered + ok', () => {
+    const r = computePerceptualMetadata(probe(), VIEWPORT);
+    expect(r.effectiveDisplay).toBe('rendered');
+    expect(r.interactionFeasibility).toBe('ok');
+    expect(r.viewportVisible).toBe(true);
+  });
+
+  test('display:none on the node → hidden_display_none', () => {
+    const r = computePerceptualMetadata(probe({ display: 'none' }), VIEWPORT);
+    expect(r.effectiveDisplay).toBe('hidden_display_none');
+  });
+
+  test('ancestor display:none → hidden_display_none', () => {
+    const r = computePerceptualMetadata(probe({ ancestorDisplayNone: true }), VIEWPORT);
+    expect(r.effectiveDisplay).toBe('hidden_display_none');
+  });
+
+  test('visibility:hidden → hidden_visibility', () => {
+    const r = computePerceptualMetadata(probe({ visibility: 'hidden' }), VIEWPORT);
+    expect(r.effectiveDisplay).toBe('hidden_visibility');
+  });
+
+  test('visibility:collapse → hidden_visibility', () => {
+    const r = computePerceptualMetadata(probe({ visibility: 'collapse' }), VIEWPORT);
+    expect(r.effectiveDisplay).toBe('hidden_visibility');
+  });
+
+  test('display:contents WITH child boxes → rendered (#709 v2 fix)', () => {
+    const r = computePerceptualMetadata(probe({ display: 'contents', hasChildBoxes: true }), VIEWPORT);
+    expect(r.effectiveDisplay).toBe('rendered');
+  });
+
+  test('display:contents WITHOUT child boxes → display_contents_no_box (#709 v2 fix)', () => {
+    const r = computePerceptualMetadata(
+      probe({ display: 'contents', hasChildBoxes: false, pixelBox: null }),
+      VIEWPORT,
+    );
+    expect(r.effectiveDisplay).toBe('display_contents_no_box');
+    expect(r.interactionFeasibility).toBe('outside_viewport');
+  });
+
+  test('off_screen — viewport intersection fails', () => {
+    const r = computePerceptualMetadata(
+      probe({ pixelBox: { x: -500, y: -500, w: 100, h: 100 } }),
+      VIEWPORT,
+    );
+    expect(r.effectiveDisplay).toBe('off_screen');
+    expect(r.interactionFeasibility).toBe('outside_viewport');
+  });
+
+  test('covered_by — different topElementBackendNodeId at center', () => {
+    const r = computePerceptualMetadata(probe({ topElementBackendNodeId: 999 }), VIEWPORT);
+    expect(r.effectiveDisplay).toBe('covered_by');
+    expect(r.coveredByNodeId).toBe(999);
+    expect(r.interactionFeasibility).toBe('blocked_by_overlay');
+  });
+
+  test('off_screen takes priority over covered_by', () => {
+    const r = computePerceptualMetadata(
+      probe({
+        pixelBox: { x: -500, y: -500, w: 100, h: 100 },
+        topElementBackendNodeId: 999,
+      }),
+      VIEWPORT,
+    );
+    expect(r.effectiveDisplay).toBe('off_screen');
+    expect(r.coveredByNodeId).toBeUndefined();
+  });
+
+  test('null topElementBackendNodeId → conservatively reports rendered (host did not query)', () => {
+    const r = computePerceptualMetadata(probe({ topElementBackendNodeId: null }), VIEWPORT);
+    expect(r.effectiveDisplay).toBe('rendered');
+    expect(r.interactionFeasibility).toBe('ok');
+  });
+});
+
+describe('computePerceptualMetadata — interactionFeasibility', () => {
+  test('zero-size box → zero_size', () => {
+    const r = computePerceptualMetadata(
+      probe({ pixelBox: { x: 0, y: 0, w: 0, h: 10 } }),
+      VIEWPORT,
+    );
+    expect(r.interactionFeasibility).toBe('zero_size');
+  });
+
+  test('null pixelBox → zero_size', () => {
+    const r = computePerceptualMetadata(probe({ pixelBox: null }), VIEWPORT);
+    expect(r.interactionFeasibility).toBe('zero_size');
+  });
+
+  test('outside viewport → outside_viewport (no overlay needed)', () => {
+    const r = computePerceptualMetadata(
+      probe({ pixelBox: { x: 5000, y: 5000, w: 100, h: 100 } }),
+      VIEWPORT,
+    );
+    expect(r.interactionFeasibility).toBe('outside_viewport');
+  });
+
+  test('hidden by ancestor → outside_viewport (cannot interact)', () => {
+    const r = computePerceptualMetadata(probe({ ancestorVisibilityHidden: true }), VIEWPORT);
+    expect(r.interactionFeasibility).toBe('outside_viewport');
+  });
+});
+
+describe('computePerceptualMetadata — opacity propagation', () => {
+  test('opacity surfaces to effectiveOpacity', () => {
+    const r = computePerceptualMetadata(probe({ opacityChain: [1, 0.4] }), VIEWPORT);
+    expect(r.effectiveOpacity).toBeCloseTo(0.4);
+  });
+
+  test('zero ancestor opacity → effectiveOpacity 0 but rendering classification unaffected', () => {
+    // (Per #709 v2 we report the metadata raw; the cross-check / hint
+    // engine in #710 decides whether opacity-zero is "honeypot" or
+    // intentional UI.)
+    const r = computePerceptualMetadata(probe({ opacityChain: [0] }), VIEWPORT);
+    expect(r.effectiveOpacity).toBe(0);
+    expect(r.effectiveDisplay).toBe('rendered');
+  });
+});


### PR DESCRIPTION
## Summary

- Re-implements perceptual DOM metadata classifier and per-frame in-process cache as a **core-tier, no-flag, pure-compute** feature.
- Code lives at `src/core/perception/` (re-routed from `src/perception/` in closed #757 per portability-harness contract — perception primitives are core tier, no flag, pure compute).
- Tests live at `tests/core/perception/` (2 suites, 31 tests, all passing).

## Relation to other PRs

- Replaces closed #757 (`pr/m3-pr16-perceptual-meta`).
- Related: #774 (contract DSL), #780 (tracker).
- No imports from `src/pilot/**` or any contract-runtime modules — fully self-contained within `src/core/perception/`.

## Files carried from reference branch

| File | Action |
|------|--------|
| `src/perception/types.ts` | Carried → `src/core/perception/types.ts` (no changes) |
| `src/perception/metadata.ts` | Carried → `src/core/perception/metadata.ts` (no changes) |
| `src/perception/cache.ts` | Carried → `src/core/perception/cache.ts` (no changes) |
| `src/perception/index.ts` | Carried → `src/core/perception/index.ts` (no changes) |
| `tests/perception/metadata.test.ts` | Carried → `tests/core/perception/metadata.test.ts` (import paths updated) |
| `tests/perception/cache.test.ts` | Carried → `tests/core/perception/cache.test.ts` (import paths updated) |

No files dropped. No files from `src/contracts/idempotency.ts` or `src/contracts/runtime.ts` referenced — the perception module has zero external dependencies.

## Verification gates

- `npm run build` — clean
- `npm run lint` — clean
- `npm run lint:tier` — 0 violations (303 modules, 623 dependencies cruised)
- `npx jest tests/core/perception/` — 31/31 passed (2 suites)

## Test plan

- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] `npm run lint:tier` reports 0 violations
- [ ] `npx jest tests/core/perception/` — all 31 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)