### PR TITLE
feat(core): cross-check Sobel + color distance (Phase 4, replaces #758)

### DIFF
--- a/src/core/perception/cross-check.ts
+++ b/src/core/perception/cross-check.ts
@@ -1,0 +1,257 @@
+/**
+ * DOM ↔ screenshot cross-check (#710 v2).
+ *
+ * Given (a) a target element's `pixelBox` from the perceptual metadata
+ * (#709) and (b) a recent screenshot, decide whether the element is
+ * actually visible to the human eye. Cloaked / honeypot elements pass
+ * the DOM presence check but vanish into a same-color background.
+ *
+ * Decision rule per #710 v2:
+ *   - If `edge_density < edgeDensityThreshold` (default 0.02)
+ *     AND the cropped region's dominant color is within `colorTolerance`
+ *     of the page's background color
+ *   ⇒ verdict `pixel_absent` (a likely cloak)
+ *
+ *   - Otherwise verdict `consistent` (DOM and pixels agree)
+ *
+ * Both thresholds are overridable per call (or via env). Tests pass
+ * synthetic RGBA buffers directly — no real screenshot needed.
+ */
+
+import {
+  DEFAULT_COLOR_BG_TOLERANCE,
+  DEFAULT_EDGE_GRADIENT_THRESHOLD,
+  DEFAULT_PIXEL_ABSENT_EDGE_DENSITY,
+  colorDistance,
+  decodePngToRgba,
+  dominantColor,
+  isPngBuffer,
+  sobelEdgeDensity,
+  type CropRect,
+  type DecodedRgbaImage,
+  type RgbColor,
+} from './image-features';
+
+export type CrossCheckVerdict = 'consistent' | 'pixel_absent' | 'empty_region';
+
+export interface CrossCheckResult {
+  verdict: CrossCheckVerdict;
+  edge_density: number;
+  /** `null` when the crop clamped to an empty rectangle (verdict is `empty_region`). */
+  dominant_color: RgbColor | null;
+  background_color: RgbColor;
+  color_distance: number;
+  /** Reasons the verdict was reached, for hint-engine evidence. */
+  reasons: string[];
+}
+
+export interface CrossCheckOptions {
+  /** Sobel gradient magnitude cutoff. */
+  edgeGradientThreshold?: number;
+  /** Edge-density (high_grad / area) cutoff for `pixel_absent`. */
+  edgeDensityThreshold?: number;
+  /** sRGB Euclidean tolerance for "matches background". */
+  colorTolerance?: number;
+  /**
+   * Pre-computed page background color. Hosts derive this once per
+   * page (e.g., dominant color of the four corners) and pass it on
+   * each cross-check call.
+   */
+  backgroundColor: RgbColor;
+}
+
+function envFloat(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number.parseFloat(raw);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+const _warnedOverrides = new Set<string>();
+
+/**
+ * Validate a per-call threshold override.
+ * Returns `value` only when it is a finite, non-negative number; otherwise
+ * emits a one-shot console.error warning and returns `fallback`.
+ */
+function coerceFiniteNonNegative(key: string, value: number, fallback: number): number {
+  if (Number.isFinite(value) && value >= 0) return value;
+  if (!_warnedOverrides.has(key)) {
+    _warnedOverrides.add(key);
+    console.error(
+      `[cross-check] runCrossCheck: override "${key}" value ${value} is not a finite non-negative number; ` +
+        `using fallback ${fallback}.`,
+    );
+  }
+  return fallback;
+}
+
+/**
+ * Run cross-check on a single element pixelBox.
+ *
+ * @param rgba    The full screenshot buffer (RGBA).
+ * @param width   Screenshot width in pixels.
+ * @param height  Screenshot height in pixels.
+ * @param crop    The element's pixelBox in screenshot coordinates.
+ * @param opts    Threshold overrides + the page's background color.
+ */
+export function runCrossCheck(
+  rgba: Uint8Array | Buffer,
+  width: number,
+  height: number,
+  crop: CropRect,
+  opts: CrossCheckOptions,
+): CrossCheckResult {
+  const edgeGradientThresholdDefault = envFloat(
+    'OPENCHROME_CROSS_CHECK_EDGE_THRESHOLD',
+    DEFAULT_EDGE_GRADIENT_THRESHOLD,
+  );
+  const edgeGradientThreshold =
+    opts.edgeGradientThreshold !== undefined
+      ? coerceFiniteNonNegative('edgeGradientThreshold', opts.edgeGradientThreshold, edgeGradientThresholdDefault)
+      : edgeGradientThresholdDefault;
+
+  const edgeDensityThresholdDefault = envFloat(
+    'OPENCHROME_CROSS_CHECK_EDGE_DENSITY',
+    DEFAULT_PIXEL_ABSENT_EDGE_DENSITY,
+  );
+  const edgeDensityThreshold =
+    opts.edgeDensityThreshold !== undefined
+      ? coerceFiniteNonNegative('edgeDensityThreshold', opts.edgeDensityThreshold, edgeDensityThresholdDefault)
+      : edgeDensityThresholdDefault;
+
+  const colorToleranceDefault = envFloat('OPENCHROME_CROSS_CHECK_COLOR_TOLERANCE', DEFAULT_COLOR_BG_TOLERANCE);
+  const colorTolerance =
+    opts.colorTolerance !== undefined
+      ? coerceFiniteNonNegative('colorTolerance', opts.colorTolerance, colorToleranceDefault)
+      : colorToleranceDefault;
+
+  let image = rgba;
+  let imageWidth = width;
+  let imageHeight = height;
+  if (isPngBuffer(rgba)) {
+    const decoded = decodePngToRgba(rgba);
+    image = decoded.rgba;
+    imageWidth = decoded.width;
+    imageHeight = decoded.height;
+  }
+
+  const edgeDensity = sobelEdgeDensity(image, imageWidth, imageHeight, crop, edgeGradientThreshold);
+  const dom = dominantColor(image, imageWidth, imageHeight, crop);
+
+  // Empty-region guard: pixelBox clamped to zero area — no pixels were
+  // sampled. This is a definitive mismatch (the element has no visible
+  // pixels), not a color match against black.
+  if (dom === null) {
+    return {
+      verdict: 'empty_region',
+      edge_density: edgeDensity,
+      dominant_color: null,
+      background_color: opts.backgroundColor,
+      color_distance: 0,
+      reasons: ['crop clamped to empty rectangle — no pixels sampled'],
+    };
+  }
+
+  // Validate backgroundColor channels are finite numbers in [0, 255].
+  // A non-finite channel (NaN / Infinity) makes colorDistance return a
+  // non-finite value whose comparison with colorTolerance is always false,
+  // silently keeping verdict='consistent' even for low-edge, background-
+  // matching crops (fail-open). Treat invalid backgroundColor as a
+  // non-consistent result (fail-closed).
+  const bg = opts.backgroundColor;
+  if (
+    !Number.isFinite(bg.r) ||
+    !Number.isFinite(bg.g) ||
+    !Number.isFinite(bg.b) ||
+    bg.r < 0 ||
+    bg.r > 255 ||
+    bg.g < 0 ||
+    bg.g > 255 ||
+    bg.b < 0 ||
+    bg.b > 255
+  ) {
+    console.error(
+      `[cross-check] runCrossCheck: backgroundColor has non-finite or out-of-range channel ` +
+        `(r=${bg.r}, g=${bg.g}, b=${bg.b}); cannot compute color distance — returning mismatch verdict.`,
+    );
+    return {
+      verdict: 'pixel_absent',
+      edge_density: edgeDensity,
+      dominant_color: dom,
+      background_color: bg,
+      color_distance: NaN,
+      reasons: ['backgroundColor has non-finite or out-of-range channel — fail-closed mismatch'],
+    };
+  }
+
+  const dist = colorDistance(dom, bg);
+
+  const reasons: string[] = [];
+  let verdict: CrossCheckVerdict = 'consistent';
+
+  if (edgeDensity < edgeDensityThreshold) {
+    reasons.push(`edge_density ${edgeDensity.toFixed(4)} < ${edgeDensityThreshold}`);
+    if (dist <= colorTolerance) {
+      reasons.push(`color_distance ${dist.toFixed(2)} ≤ ${colorTolerance}`);
+      verdict = 'pixel_absent';
+    } else {
+      reasons.push(`color_distance ${dist.toFixed(2)} > ${colorTolerance} (background mismatch)`);
+    }
+  } else {
+    reasons.push(`edge_density ${edgeDensity.toFixed(4)} ≥ ${edgeDensityThreshold}`);
+  }
+
+  return {
+    verdict,
+    edge_density: edgeDensity,
+    dominant_color: dom,
+    background_color: opts.backgroundColor,
+    color_distance: dist,
+    reasons,
+  };
+}
+
+/**
+ * Decode a PNG screenshot once, then run cross-check on every annotation.
+ *
+ * Use this instead of calling `runCrossCheck` per element when the same
+ * screenshot is checked against multiple crops. `runCrossCheck` decodes the
+ * PNG on every call (`O(elements × pixels)` of zlib work); this function
+ * decodes once and reuses the resulting RGBA buffer for all crops.
+ *
+ * @param image       The full screenshot — either a raw RGBA `Buffer` or an
+ *                    encoded PNG `Buffer`. PNGs are decoded exactly once.
+ * @param width       Screenshot width (ignored when `image` is a PNG; derived
+ *                    from the PNG IHDR instead).
+ * @param height      Screenshot height (same caveat).
+ * @param crops       Array of element pixelBoxes to cross-check.
+ * @param opts        Threshold overrides + page background color (applied to
+ *                    every element uniformly).
+ * @returns           One `CrossCheckResult` per element, in the same order as
+ *                    `crops`.
+ */
+export function runCrossCheckBatch(
+  image: Uint8Array | Buffer,
+  width: number,
+  height: number,
+  crops: CropRect[],
+  opts: CrossCheckOptions,
+): CrossCheckResult[] {
+  let rgba: Uint8Array | Buffer;
+  let w: number;
+  let h: number;
+
+  if (isPngBuffer(image)) {
+    const decoded: DecodedRgbaImage = decodePngToRgba(image);
+    rgba = decoded.rgba;
+    w = decoded.width;
+    h = decoded.height;
+  } else {
+    rgba = image;
+    w = width;
+    h = height;
+  }
+
+  return crops.map((crop) => runCrossCheck(rgba, w, h, crop, opts));
+}

--- a/src/core/perception/image-features.ts
+++ b/src/core/perception/image-features.ts
@@ -1,0 +1,433 @@
+import * as zlib from 'zlib';
+
+/**
+ * Image feature primitives for the cross-check module (#710 v2).
+ *
+ * Pure JS, dependency-free — no sharp, no native bindings. The low-level
+ * feature functions accept tightly-packed RGBA byte buffers (4 bytes per
+ * pixel); callers that receive Puppeteer's default encoded PNG screenshots
+ * can decode them with `decodePngToRgba` first.
+ *
+ * Per #710 v2 detection algorithm:
+ *   - Edge density via 3x3 Sobel on grayscale; "high-gradient" pixel
+ *     iff |∇I| > EDGE_GRADIENT_THRESHOLD (default 30 on 0-255 scale)
+ *   - Color distance via sRGB Euclidean: sqrt(dR² + dG² + dB²)
+ *   - Background match iff color distance ≤ COLOR_BG_TOLERANCE (30)
+ *
+ * The thresholds are exposed as overridable constants — calibration
+ * lives in #710's PR-17b once the fixture corpus exists. Hosts can
+ * override via env (`OPENCHROME_CROSS_CHECK_EDGE_THRESHOLD`,
+ * `OPENCHROME_CROSS_CHECK_COLOR_TOLERANCE`).
+ */
+
+/** PNG magic bytes: full 8-byte signature 89 50 4E 47 0D 0A 1A 0A */
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] as const;
+/** JPEG SOI marker: FF D8 FF */
+const JPEG_SOI = [0xff, 0xd8, 0xff] as const;
+
+export interface DecodedRgbaImage {
+  rgba: Buffer;
+  width: number;
+  height: number;
+}
+
+export function isPngBuffer(input: Uint8Array | Buffer): boolean {
+  return input.length >= PNG_MAGIC.length && PNG_MAGIC.every((b, i) => input[i] === b);
+}
+
+function paethPredictor(left: number, up: number, upLeft: number): number {
+  const p = left + up - upLeft;
+  const pa = Math.abs(p - left);
+  const pb = Math.abs(p - up);
+  const pc = Math.abs(p - upLeft);
+  if (pa <= pb && pa <= pc) return left;
+  if (pb <= pc) return up;
+  return upLeft;
+}
+
+/**
+ * Decode a non-interlaced 8-bit PNG screenshot into raw RGBA bytes.
+ *
+ * This deliberately supports the PNG variants produced by Chromium
+ * screenshots: truecolor RGB and truecolor-alpha RGBA. Palette,
+ * grayscale, high-bit-depth, and interlaced PNGs should be decoded by
+ * a real image library before they reach this module.
+ */
+export function decodePngToRgba(input: Uint8Array | Buffer): DecodedRgbaImage {
+  if (!isPngBuffer(input)) {
+    throw new Error('decodePngToRgba: input is not an encoded PNG buffer');
+  }
+
+  let offset = PNG_MAGIC.length;
+  let width = 0;
+  let height = 0;
+  let bitDepth = 0;
+  let colorType = 0;
+  let compressionMethod = 0;
+  let filterMethod = 0;
+  let interlaceMethod = 0;
+  const idatChunks: Buffer[] = [];
+
+  while (offset + 12 <= input.length) {
+    const length = Buffer.from(input.subarray(offset, offset + 4)).readUInt32BE(0);
+    const type = Buffer.from(input.subarray(offset + 4, offset + 8)).toString('ascii');
+    const dataStart = offset + 8;
+    const dataEnd = dataStart + length;
+    if (dataEnd + 4 > input.length) {
+      throw new Error(`decodePngToRgba: truncated PNG chunk ${type}`);
+    }
+    const data = input.subarray(dataStart, dataEnd);
+
+    if (type === 'IHDR') {
+      if (length !== 13) throw new Error('decodePngToRgba: invalid IHDR length');
+      width = Buffer.from(data.subarray(0, 4)).readUInt32BE(0);
+      height = Buffer.from(data.subarray(4, 8)).readUInt32BE(0);
+      bitDepth = data[8];
+      colorType = data[9];
+      compressionMethod = data[10];
+      filterMethod = data[11];
+      interlaceMethod = data[12];
+    } else if (type === 'IDAT') {
+      idatChunks.push(Buffer.from(data));
+    } else if (type === 'IEND') {
+      break;
+    }
+
+    offset = dataEnd + 4;
+  }
+
+  if (!width || !height) throw new Error('decodePngToRgba: missing or invalid IHDR dimensions');
+  if (bitDepth !== 8 || (colorType !== 2 && colorType !== 6)) {
+    throw new Error(`decodePngToRgba: unsupported PNG color format bitDepth=${bitDepth} colorType=${colorType}`);
+  }
+  if (compressionMethod !== 0 || filterMethod !== 0 || interlaceMethod !== 0) {
+    throw new Error('decodePngToRgba: unsupported PNG compression/filter/interlace method');
+  }
+  if (idatChunks.length === 0) throw new Error('decodePngToRgba: missing IDAT data');
+
+  const channels = colorType === 6 ? 4 : 3;
+  const rawStride = width * channels;
+  const inflated = zlib.inflateSync(Buffer.concat(idatChunks));
+  const expectedLength = (rawStride + 1) * height;
+  if (inflated.length < expectedLength) {
+    throw new Error(`decodePngToRgba: inflated data too short ${inflated.length} < ${expectedLength}`);
+  }
+
+  const reconstructed = Buffer.alloc(rawStride * height);
+  let sourceOffset = 0;
+  for (let y = 0; y < height; y++) {
+    const filter = inflated[sourceOffset++];
+    const rowStart = y * rawStride;
+    const prevRowStart = rowStart - rawStride;
+    for (let x = 0; x < rawStride; x++) {
+      const raw = inflated[sourceOffset++];
+      const left = x >= channels ? reconstructed[rowStart + x - channels] : 0;
+      const up = y > 0 ? reconstructed[prevRowStart + x] : 0;
+      const upLeft = y > 0 && x >= channels ? reconstructed[prevRowStart + x - channels] : 0;
+      let value: number;
+      switch (filter) {
+        case 0:
+          value = raw;
+          break;
+        case 1:
+          value = raw + left;
+          break;
+        case 2:
+          value = raw + up;
+          break;
+        case 3:
+          value = raw + Math.floor((left + up) / 2);
+          break;
+        case 4:
+          value = raw + paethPredictor(left, up, upLeft);
+          break;
+        default:
+          throw new Error(`decodePngToRgba: unsupported PNG filter type ${filter}`);
+      }
+      reconstructed[rowStart + x] = value & 0xff;
+    }
+  }
+
+  const rgba = Buffer.alloc(width * height * 4);
+  for (let i = 0, j = 0; i < reconstructed.length; i += channels, j += 4) {
+    rgba[j] = reconstructed[i];
+    rgba[j + 1] = reconstructed[i + 1];
+    rgba[j + 2] = reconstructed[i + 2];
+    rgba[j + 3] = channels === 4 ? reconstructed[i + 3] : 255;
+  }
+
+  return { rgba, width, height };
+}
+
+/**
+ * Sniff the first bytes of a buffer and throw a descriptive error if it
+ * looks like an encoded PNG or JPEG rather than raw RGBA bytes.
+ *
+ * The sniff ALWAYS runs — it is NOT gated on whether the buffer length
+ * happens to match `w*h*4`. Gating on length was tried in round-4 to
+ * avoid false positives on raw RGBA whose first pixel begins with JPEG SOI
+ * bytes (e.g. RGB 255/216/255), but it created a silent-misclassification
+ * path: an encoded PNG or JPEG whose compressed size coincidentally equals
+ * `w*h*4` would bypass the guard entirely and corrupt Sobel/color output.
+ *
+ * False-positive risk with the unconditional sniff is negligible:
+ *  - PNG: requires all 8 bytes `89 50 4E 47 0D 0A 1A 0A` to match, which
+ *    raw RGBA pixels cannot replicate in practice.
+ *  - JPEG: requires 4 bytes `FF D8 FF [C0-FE]` where the marker byte covers
+ *    the full valid JPEG marker range (SOF, DHT, DAC, DQT, COM, APP*, etc.).
+ *    The 4th byte 0xFF is excluded (it is the JPEG stuff byte / padding, not
+ *    a real marker), so a raw RGBA pixel with alpha=0xFF does not fire.
+ */
+function assertNotEncodedImage(
+  rgba: Uint8Array | Buffer,
+  width: number,
+  height: number,
+  fnName: string,
+): void {
+  // Full 8-byte PNG signature — always check, regardless of buffer length.
+  if (rgba.length >= PNG_MAGIC.length && PNG_MAGIC.every((b, i) => rgba[i] === b)) {
+    throw new Error(
+      `${fnName}: received encoded PNG buffer instead of raw RGBA bytes ` +
+        `(length must equal width*height*4). Decode first, e.g.: ` +
+        `sharp(buffer).raw().toBuffer({ resolveWithObject: true })`,
+    );
+  }
+  // JPEG SOI (FF D8 FF) + the 4th byte must be a valid JPEG marker byte in
+  // the range [C0-FE]. This covers all real JPEG segment markers (SOF0-SOF15,
+  // DHT, DAC, RST0-RST7, SOI, APP0-APP15, COM, DQT, DNL, DRI, DHP, EXP,
+  // SOS, EOI). The value 0xFF is the JPEG stuff/padding byte, NOT a marker,
+  // so alpha=0xFF in a raw RGBA pixel does not trigger a false positive.
+  if (
+    rgba.length >= 4 &&
+    JPEG_SOI.every((b, i) => rgba[i] === b) &&
+    rgba[3] >= 0xc0 &&
+    rgba[3] <= 0xfe
+  ) {
+    throw new Error(
+      `${fnName}: received encoded JPEG buffer instead of raw RGBA bytes ` +
+        `(length must equal width*height*4). Decode first, e.g.: ` +
+        `sharp(buffer).raw().toBuffer({ resolveWithObject: true })`,
+    );
+  }
+}
+
+export interface RgbColor {
+  r: number;
+  g: number;
+  b: number;
+}
+
+export interface CropRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** Default Sobel gradient magnitude threshold per #710 v2. */
+export const DEFAULT_EDGE_GRADIENT_THRESHOLD = 30;
+
+/** Default sRGB color-match tolerance per #710 v2. */
+export const DEFAULT_COLOR_BG_TOLERANCE = 30;
+
+/** Default edge-density threshold for "pixel_absent" verdict. */
+export const DEFAULT_PIXEL_ABSENT_EDGE_DENSITY = 0.02;
+
+function clampInt(v: number, lo: number, hi: number): number {
+  if (v < lo) return lo;
+  if (v > hi) return hi;
+  return Math.floor(v);
+}
+
+/** Floor-clamp for region start coordinates (include only fully-contained start). */
+function clampStart(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, Math.floor(v)));
+}
+
+/** Ceil-clamp for region end coordinates (include any partially-touched pixel). */
+function clampEnd(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, Math.ceil(v)));
+}
+
+/** Rec. 601 luma — fast and good enough for edge detection. */
+function luma(r: number, g: number, b: number): number {
+  return 0.299 * r + 0.587 * g + 0.114 * b;
+}
+
+/**
+ * Index into an RGBA buffer at (x, y), returning {r, g, b}. Out-of-
+ * bounds requests are clamped to the nearest in-bounds pixel — that's
+ * the standard Sobel boundary policy.
+ */
+function pixelRgb(rgba: Uint8Array | Buffer, w: number, h: number, x: number, y: number): RgbColor {
+  const cx = clampInt(x, 0, w - 1);
+  const cy = clampInt(y, 0, h - 1);
+  const i = (cy * w + cx) * 4;
+  return { r: rgba[i], g: rgba[i + 1], b: rgba[i + 2] };
+}
+
+/**
+ * Compute edge density on a crop of an RGBA buffer.
+ *
+ * `edge_density = high_gradient_pixels / total_pixels`.
+ * `high-gradient` iff |∇I_x| + |∇I_y| > threshold (the L1 form is
+ * sufficient and cheaper than the L2 magnitude — same threshold range).
+ *
+ * Boundary policy: clamp-to-edge (standard for Sobel).
+ *
+ * **Contract:** `rgba` must be raw RGBA bytes — 4 bytes per pixel,
+ * `length === width * height * 4`. Passing an encoded PNG or JPEG buffer
+ * (e.g., from `Page.screenshot()` default output) throws a descriptive
+ * error. Decode first with e.g. `sharp(buffer).raw().toBuffer(...)`.
+ */
+export function sobelEdgeDensity(
+  rgba: Uint8Array | Buffer,
+  width: number,
+  height: number,
+  crop: CropRect,
+  threshold: number = DEFAULT_EDGE_GRADIENT_THRESHOLD,
+): number {
+  assertNotEncodedImage(rgba, width, height, 'sobelEdgeDensity');
+  if (rgba.length !== width * height * 4) {
+    throw new Error(`sobelEdgeDensity: buffer length ${rgba.length} != ${width * height * 4}`);
+  }
+  if (
+    !Number.isFinite(crop.x) ||
+    !Number.isFinite(crop.y) ||
+    !Number.isFinite(crop.w) ||
+    !Number.isFinite(crop.h)
+  ) {
+    return 0;
+  }
+  const x0 = clampStart(crop.x, 0, width);
+  const y0 = clampStart(crop.y, 0, height);
+  const x1 = clampEnd(crop.x + crop.w, 0, width);
+  const y1 = clampEnd(crop.y + crop.h, 0, height);
+  const cw = x1 - x0;
+  const ch = y1 - y0;
+  if (cw <= 0 || ch <= 0) return 0;
+
+  let highGradient = 0;
+  // 3x3 Sobel kernels:
+  //   Gx = [-1 0 1; -2 0 2; -1 0 1]
+  //   Gy = [-1 -2 -1; 0 0 0; 1 2 1]
+  //
+  // Hot-loop optimisation: read channel bytes directly via base-index
+  // arithmetic instead of calling luma(...rgbAt(...)), which allocated a
+  // fresh [r,g,b] tuple on every call (8 allocations per sampled pixel).
+  // On full-page crops this produced millions of short-lived objects per
+  // element, dominating runtime with GC pressure. The Rec.601 luma
+  // formula is identical; luma/rgbAt remain exported for external callers.
+  const lumaAt = (px: number, py: number): number => {
+    const cx = clampInt(px, 0, width - 1);
+    const cy = clampInt(py, 0, height - 1);
+    const base = (cy * width + cx) * 4;
+    return 0.299 * rgba[base] + 0.587 * rgba[base + 1] + 0.114 * rgba[base + 2];
+  };
+  for (let y = y0; y < y1; y++) {
+    for (let x = x0; x < x1; x++) {
+      const tl = lumaAt(x - 1, y - 1);
+      const tm = lumaAt(x, y - 1);
+      const tr = lumaAt(x + 1, y - 1);
+      const ml = lumaAt(x - 1, y);
+      const mr = lumaAt(x + 1, y);
+      const bl = lumaAt(x - 1, y + 1);
+      const bm = lumaAt(x, y + 1);
+      const br = lumaAt(x + 1, y + 1);
+      const gx = -tl - 2 * ml - bl + tr + 2 * mr + br;
+      const gy = -tl - 2 * tm - tr + bl + 2 * bm + br;
+      const mag = Math.abs(gx) + Math.abs(gy);
+      if (mag > threshold) highGradient++;
+    }
+  }
+  return highGradient / (cw * ch);
+}
+
+/** Inline tuple form so `luma(...rgbAt(...))` stays a single allocation. */
+function rgbAt(
+  rgba: Uint8Array | Buffer,
+  w: number,
+  h: number,
+  x: number,
+  y: number,
+): [number, number, number] {
+  const cx = clampInt(x, 0, w - 1);
+  const cy = clampInt(y, 0, h - 1);
+  const i = (cy * w + cx) * 4;
+  return [rgba[i], rgba[i + 1], rgba[i + 2]];
+}
+
+/**
+ * sRGB Euclidean color distance over 0-255 components.
+ *   d = sqrt(dR² + dG² + dB²); range 0 (identical) … ~441 (black↔white)
+ */
+export function colorDistance(a: RgbColor, b: RgbColor): number {
+  const dr = a.r - b.r;
+  const dg = a.g - b.g;
+  const db = a.b - b.b;
+  return Math.sqrt(dr * dr + dg * dg + db * db);
+}
+
+/**
+ * Approximate the dominant color of an arbitrary RGBA region by
+ * histogram-bucketed mode. Buckets are 16×16×16 (4 KB), good enough
+ * for "what color is this background" — full k-means would be
+ * dependency-rich for sub-1 % accuracy gain.
+ *
+ * Returns `null` when the region clamps to an empty rectangle (zero
+ * width or height after clamping to the image bounds). Callers must
+ * treat `null` as a sentinel meaning "no pixels were sampled" and
+ * propagate it as a flagged mismatch, not as a real color.
+ *
+ * **Contract:** `rgba` must be raw RGBA bytes — 4 bytes per pixel,
+ * `length === width * height * 4`. Passing an encoded PNG or JPEG buffer
+ * (e.g., from `Page.screenshot()` default output) throws a descriptive
+ * error. Decode first with e.g. `sharp(buffer).raw().toBuffer(...)`.
+ */
+export function dominantColor(
+  rgba: Uint8Array | Buffer,
+  width: number,
+  height: number,
+  region?: CropRect,
+): RgbColor | null {
+  assertNotEncodedImage(rgba, width, height, 'dominantColor');
+  if (rgba.length !== width * height * 4) {
+    throw new Error(`dominantColor: buffer length ${rgba.length} != ${width * height * 4}`);
+  }
+  if (
+    region !== undefined &&
+    (!Number.isFinite(region.x) ||
+      !Number.isFinite(region.y) ||
+      !Number.isFinite(region.w) ||
+      !Number.isFinite(region.h))
+  ) {
+    return null;
+  }
+  const x0 = region ? clampStart(region.x, 0, width) : 0;
+  const y0 = region ? clampStart(region.y, 0, height) : 0;
+  const x1 = region ? clampEnd(region.x + region.w, 0, width) : width;
+  const y1 = region ? clampEnd(region.y + region.h, 0, height) : height;
+  if (x1 <= x0 || y1 <= y0) return null;
+  const buckets = new Uint32Array(16 * 16 * 16);
+  let bestCount = 0;
+  let bestKey = 0;
+  for (let y = y0; y < y1; y++) {
+    for (let x = x0; x < x1; x++) {
+      const i = (y * width + x) * 4;
+      const r = rgba[i] >> 4;
+      const g = rgba[i + 1] >> 4;
+      const b = rgba[i + 2] >> 4;
+      const k = (r << 8) | (g << 4) | b;
+      const c = (buckets[k] += 1);
+      if (c > bestCount) {
+        bestCount = c;
+        bestKey = k;
+      }
+    }
+  }
+  return {
+    r: ((bestKey >> 8) & 0xf) << 4,
+    g: ((bestKey >> 4) & 0xf) << 4,
+    b: (bestKey & 0xf) << 4,
+  };
+}

--- a/tests/core/perception/cross-check.test.ts
+++ b/tests/core/perception/cross-check.test.ts
@@ -1,0 +1,439 @@
+import { runCrossCheck, runCrossCheckBatch } from '../../../src/core/perception/cross-check';
+import * as imageFeatures from '../../../src/core/perception/image-features';
+import * as zlib from 'zlib';
+
+function solid(w: number, h: number, r: number, g: number, b: number): Buffer {
+  const buf = Buffer.alloc(w * h * 4);
+  for (let i = 0; i < w * h; i++) {
+    buf[i * 4] = r;
+    buf[i * 4 + 1] = g;
+    buf[i * 4 + 2] = b;
+    buf[i * 4 + 3] = 255;
+  }
+  return buf;
+}
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const chunk = Buffer.alloc(12 + data.length);
+  chunk.writeUInt32BE(data.length, 0);
+  chunk.write(type, 4, 4, 'ascii');
+  data.copy(chunk, 8);
+  // The decoder under test does not validate CRCs; zeros are sufficient.
+  chunk.writeUInt32BE(0, 8 + data.length);
+  return chunk;
+}
+
+function pngFromRgb(w: number, h: number, rgb: Buffer): Buffer {
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(w, 0);
+  ihdr.writeUInt32BE(h, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 2; // truecolor RGB
+  ihdr[10] = 0; // compression
+  ihdr[11] = 0; // filter
+  ihdr[12] = 0; // no interlace
+
+  const stride = w * 3;
+  const scanlines = Buffer.alloc((stride + 1) * h);
+  for (let y = 0; y < h; y++) {
+    const rowStart = y * (stride + 1);
+    scanlines[rowStart] = 0;
+    rgb.copy(scanlines, rowStart + 1, y * stride, (y + 1) * stride);
+  }
+
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    pngChunk('IHDR', ihdr),
+    pngChunk('IDAT', zlib.deflateSync(scanlines)),
+    pngChunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+
+function solidRgb(w: number, h: number, r: number, g: number, b: number): Buffer {
+  const buf = Buffer.alloc(w * h * 3);
+  for (let i = 0; i < w * h; i++) {
+    buf[i * 3] = r;
+    buf[i * 3 + 1] = g;
+    buf[i * 3 + 2] = b;
+  }
+  return buf;
+}
+
+/** Field with `inner` filled with a different color in the central rect. */
+function fieldWithInnerRect(
+  w: number,
+  h: number,
+  outer: [number, number, number],
+  inner: [number, number, number],
+  innerCrop: { x: number; y: number; w: number; h: number },
+): Buffer {
+  const buf = solid(w, h, outer[0], outer[1], outer[2]);
+  for (let y = innerCrop.y; y < innerCrop.y + innerCrop.h; y++) {
+    for (let x = innerCrop.x; x < innerCrop.x + innerCrop.w; x++) {
+      const i = (y * w + x) * 4;
+      buf[i] = inner[0];
+      buf[i + 1] = inner[1];
+      buf[i + 2] = inner[2];
+    }
+  }
+  return buf;
+}
+
+describe('runCrossCheck — pixel_absent verdict', () => {
+  test('flat region matching page background → pixel_absent', () => {
+    // Whole image is the background color; the "element" lives in a
+    // sub-region that's also background — no edges, no color contrast.
+    const bg = { r: 240, g: 240, b: 240 };
+    const buf = solid(64, 64, bg.r, bg.g, bg.b);
+    const r = runCrossCheck(buf, 64, 64, { x: 16, y: 16, w: 32, h: 32 }, {
+      backgroundColor: bg,
+    });
+    expect(r.verdict).toBe('pixel_absent');
+    expect(r.edge_density).toBe(0);
+    expect(r.color_distance).toBeLessThan(30);
+  });
+
+  test('accepts Chromium-style encoded PNG screenshots before feature extraction', () => {
+    const bg = { r: 240, g: 240, b: 240 };
+    const png = pngFromRgb(16, 16, solidRgb(16, 16, bg.r, bg.g, bg.b));
+    const r = runCrossCheck(png, 16, 16, { x: 0, y: 0, w: 16, h: 16 }, {
+      backgroundColor: bg,
+    });
+    expect(r.verdict).toBe('pixel_absent');
+    expect(r.edge_density).toBe(0);
+    expect(r.dominant_color).toEqual({ r: 240, g: 240, b: 240 });
+  });
+});
+
+describe('runCrossCheck — consistent verdict', () => {
+  test('region with strong edges → consistent (high edge density)', () => {
+    // Half-white / half-black inner rect on a gray background. The
+    // inner crop has a clear vertical edge, so density is high.
+    const bg = { r: 200, g: 200, b: 200 };
+    const inner = { x: 16, y: 16, w: 32, h: 32 };
+    const buf = Buffer.alloc(64 * 64 * 4);
+    // Fill background
+    for (let i = 0; i < 64 * 64; i++) {
+      buf[i * 4] = bg.r;
+      buf[i * 4 + 1] = bg.g;
+      buf[i * 4 + 2] = bg.b;
+      buf[i * 4 + 3] = 255;
+    }
+    // Stripe inside the inner rect
+    for (let y = inner.y; y < inner.y + inner.h; y++) {
+      for (let x = inner.x; x < inner.x + inner.w; x++) {
+        const i = (y * 64 + x) * 4;
+        const v = x < inner.x + inner.w / 2 ? 0 : 255;
+        buf[i] = v;
+        buf[i + 1] = v;
+        buf[i + 2] = v;
+      }
+    }
+    const r = runCrossCheck(buf, 64, 64, inner, { backgroundColor: bg });
+    expect(r.verdict).toBe('consistent');
+    expect(r.edge_density).toBeGreaterThan(0.02);
+  });
+
+  test('flat region with DIFFERENT color → consistent (background mismatch)', () => {
+    // A flat colored block that isn't the page background. No edges
+    // (so the edge-density branch fires) but the color doesn't match
+    // the background — verdict stays consistent.
+    const bg = { r: 240, g: 240, b: 240 };
+    const buf = fieldWithInnerRect(64, 64, [bg.r, bg.g, bg.b], [50, 100, 200], { x: 16, y: 16, w: 32, h: 32 });
+    const r = runCrossCheck(buf, 64, 64, { x: 18, y: 18, w: 28, h: 28 }, {
+      backgroundColor: bg,
+    });
+    expect(r.verdict).toBe('consistent');
+    expect(r.color_distance).toBeGreaterThan(30);
+  });
+});
+
+describe('runCrossCheck — overrides', () => {
+  test('tolerance 0 + bucket-floor mismatch → consistent (color does NOT match)', () => {
+    // dominantColor uses 16-bin quantization → bucket center for
+    // 200,200,200 is 192,192,192 (distance ≈13.86 from 200). With
+    // colorTolerance=0 that 13.86 distance trips the "background
+    // mismatch" branch, so the verdict is `consistent` (the region is
+    // a different color from the page background, even though it has
+    // no edges).
+    const bg = { r: 200, g: 200, b: 200 };
+    const buf = solid(32, 32, 200, 200, 200);
+    const r = runCrossCheck(buf, 32, 32, { x: 0, y: 0, w: 32, h: 32 }, {
+      backgroundColor: bg,
+      colorTolerance: 0,
+    });
+    expect(r.verdict).toBe('consistent');
+    expect(r.color_distance).toBeGreaterThan(0);
+  });
+
+  test('raising edgeDensityThreshold makes a bordered region register as pixel_absent', () => {
+    const bg = { r: 240, g: 240, b: 240 };
+    // An 8x8 inner rect with a strongly contrasting color (channel diff > 30)
+    // sits inside the 32x32 crop. Its Sobel perimeter produces ~28 edge pixels
+    // out of 1024 crop pixels, giving edge_density ~0.027.
+    //
+    // Default threshold (0.02): 0.027 >= 0.02 → verdict is `consistent`.
+    // Raised threshold (0.5):   0.027 <  0.50 → low-edge branch fires; the
+    // dominant crop color is still the bg (960/1024 pixels) so color_distance
+    // is near zero → verdict flips to `pixel_absent`.
+    const buf = fieldWithInnerRect(64, 64, [bg.r, bg.g, bg.b], [bg.r - 50, bg.g - 50, bg.b - 50], {
+      x: 20,
+      y: 20,
+      w: 8,
+      h: 8,
+    });
+    const def = runCrossCheck(buf, 64, 64, { x: 16, y: 16, w: 32, h: 32 }, { backgroundColor: bg });
+    expect(def.verdict).toBe('consistent');
+
+    const tight = runCrossCheck(buf, 64, 64, { x: 16, y: 16, w: 32, h: 32 }, {
+      backgroundColor: bg,
+      edgeDensityThreshold: 0.5,
+    });
+    expect(tight.verdict).toBe('pixel_absent');
+  });
+});
+
+describe('runCrossCheck — empty_region guard', () => {
+  test('fully off-canvas pixelBox → empty_region verdict, not consistent', () => {
+    // A 16x16 image with the crop placed entirely outside the canvas.
+    // Before the fix this would return consistent (synthetic black vs bg).
+    const bg = { r: 0, g: 0, b: 0 };
+    const buf = solid(16, 16, bg.r, bg.g, bg.b);
+    const r = runCrossCheck(buf, 16, 16, { x: 20, y: 20, w: 8, h: 8 }, { backgroundColor: bg });
+    expect(r.verdict).toBe('empty_region');
+    expect(r.dominant_color).toBeNull();
+    expect(r.reasons[0]).toContain('empty rectangle');
+  });
+
+  test('zero-width crop → empty_region verdict', () => {
+    const bg = { r: 240, g: 240, b: 240 };
+    const buf = solid(32, 32, bg.r, bg.g, bg.b);
+    const r = runCrossCheck(buf, 32, 32, { x: 8, y: 8, w: 0, h: 16 }, { backgroundColor: bg });
+    expect(r.verdict).toBe('empty_region');
+    expect(r.dominant_color).toBeNull();
+  });
+
+  test('empty_region is NOT consistent even when background is black', () => {
+    // Regression for the exact false-negative: bg={0,0,0}, off-canvas crop.
+    // Old code: dominantColor returned {0,0,0}, colorDistance=0, verdict=consistent.
+    const bg = { r: 0, g: 0, b: 0 };
+    const buf = solid(8, 8, bg.r, bg.g, bg.b);
+    const r = runCrossCheck(buf, 8, 8, { x: 100, y: 100, w: 10, h: 10 }, { backgroundColor: bg });
+    expect(r.verdict).not.toBe('consistent');
+    expect(r.verdict).toBe('empty_region');
+  });
+});
+
+describe('runCrossCheck — invalid override thresholds fall back to defaults', () => {
+  // A flat region matching the background → pixel_absent with defaults.
+  // If NaN/Infinity/-1 were used raw, edgeDensity < NaN is always false
+  // and the verdict would wrongly stay `consistent`.
+  function flatBgSetup() {
+    const bg = { r: 240, g: 240, b: 240 };
+    const buf = solid(32, 32, bg.r, bg.g, bg.b);
+    return { bg, buf };
+  }
+
+  test('NaN edgeDensityThreshold → falls back to default, cloak detection still works', () => {
+    const { bg, buf } = flatBgSetup();
+    const r = runCrossCheck(buf, 32, 32, { x: 0, y: 0, w: 32, h: 32 }, {
+      backgroundColor: bg,
+      edgeDensityThreshold: NaN,
+    });
+    expect(r.verdict).toBe('pixel_absent');
+  });
+
+  test('Infinity edgeDensityThreshold → falls back to default, cloak detection still works', () => {
+    const { bg, buf } = flatBgSetup();
+    const r = runCrossCheck(buf, 32, 32, { x: 0, y: 0, w: 32, h: 32 }, {
+      backgroundColor: bg,
+      edgeDensityThreshold: Infinity,
+    });
+    expect(r.verdict).toBe('pixel_absent');
+  });
+
+  test('negative edgeDensityThreshold → falls back to default, cloak detection still works', () => {
+    const { bg, buf } = flatBgSetup();
+    const r = runCrossCheck(buf, 32, 32, { x: 0, y: 0, w: 32, h: 32 }, {
+      backgroundColor: bg,
+      edgeDensityThreshold: -1,
+    });
+    expect(r.verdict).toBe('pixel_absent');
+  });
+
+  test('valid edgeDensityThreshold 0.5 is applied (raises cutoff → pixel_absent for flat region)', () => {
+    const { bg, buf } = flatBgSetup();
+    const r = runCrossCheck(buf, 32, 32, { x: 0, y: 0, w: 32, h: 32 }, {
+      backgroundColor: bg,
+      edgeDensityThreshold: 0.5,
+    });
+    // edge_density is 0 for a flat region, still below 0.5 → pixel_absent
+    expect(r.verdict).toBe('pixel_absent');
+    expect(r.edge_density).toBeLessThan(0.5);
+  });
+});
+
+describe('runCrossCheck — NaN crop coordinates treated as empty_region (round-7 regression)', () => {
+  test('NaN crop.x → empty_region, not consistent', () => {
+    const bg = { r: 240, g: 240, b: 240 };
+    const buf = solid(32, 32, bg.r, bg.g, bg.b);
+    const r = runCrossCheck(buf, 32, 32, { x: NaN, y: 0, w: 32, h: 32 }, { backgroundColor: bg });
+    expect(r.verdict).toBe('empty_region');
+    expect(r.dominant_color).toBeNull();
+  });
+
+  test('NaN crop.h → empty_region, not consistent', () => {
+    const bg = { r: 0, g: 0, b: 0 };
+    const buf = solid(32, 32, bg.r, bg.g, bg.b);
+    const r = runCrossCheck(buf, 32, 32, { x: 0, y: 0, w: 32, h: NaN }, { backgroundColor: bg });
+    expect(r.verdict).toBe('empty_region');
+    expect(r.dominant_color).toBeNull();
+  });
+
+  test('Infinity crop.w → empty_region, not consistent', () => {
+    const bg = { r: 255, g: 255, b: 255 };
+    const buf = solid(32, 32, bg.r, bg.g, bg.b);
+    const r = runCrossCheck(buf, 32, 32, { x: 0, y: 0, w: Infinity, h: 32 }, { backgroundColor: bg });
+    expect(r.verdict).toBe('empty_region');
+    expect(r.dominant_color).toBeNull();
+  });
+});
+
+describe('runCrossCheck — invalid backgroundColor is fail-closed (round-8 regression)', () => {
+  // A non-finite backgroundColor channel makes colorDistance return NaN,
+  // and NaN <= colorTolerance is always false, so the old code silently
+  // kept verdict='consistent' for any crop. The fix validates the color
+  // and returns a non-consistent verdict with a warning.
+
+  test('backgroundColor with NaN channel → verdict is NOT consistent; warning emitted', () => {
+    const bg = { r: NaN, g: 0, b: 0 };
+    const buf = (() => {
+      const b = Buffer.alloc(16 * 16 * 4);
+      for (let i = 0; i < 16 * 16; i++) {
+        b[i * 4] = 240; b[i * 4 + 1] = 240; b[i * 4 + 2] = 240; b[i * 4 + 3] = 255;
+      }
+      return b;
+    })();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const r = runCrossCheck(buf, 16, 16, { x: 0, y: 0, w: 16, h: 16 }, { backgroundColor: bg });
+      expect(r.verdict).not.toBe('consistent');
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('backgroundColor'));
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('backgroundColor with Infinity channel → verdict is NOT consistent', () => {
+    const bg = { r: 0, g: Infinity, b: 0 };
+    const buf = (() => {
+      const b = Buffer.alloc(16 * 16 * 4);
+      for (let i = 0; i < 16 * 16; i++) {
+        b[i * 4] = 240; b[i * 4 + 1] = 240; b[i * 4 + 2] = 240; b[i * 4 + 3] = 255;
+      }
+      return b;
+    })();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const r = runCrossCheck(buf, 16, 16, { x: 0, y: 0, w: 16, h: 16 }, { backgroundColor: bg });
+      expect(r.verdict).not.toBe('consistent');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('runCrossCheck — P2 regression: raw RGBA whose first 4 bytes match PNG header must NOT throw', () => {
+  test('raw RGBA with first pixel [0x89, 0x50, 0x4e, 0x47] is processed as raw, not decoded as PNG', () => {
+    // Construct a 2x1 RGBA buffer whose first pixel is (0x89, 0x50, 0x4e, 0x47).
+    // The old 4-byte sniff would have entered decodePngToRgba and thrown
+    // "input is not an encoded PNG buffer" (the full 8-byte signature fails).
+    // The new 8-byte sniff correctly identifies this as raw RGBA.
+    const w = 2;
+    const h = 1;
+    const buf = Buffer.alloc(w * h * 4);
+    // First pixel: bytes that match 4-byte PNG prefix but NOT the full 8-byte signature
+    buf[0] = 0x89; buf[1] = 0x50; buf[2] = 0x4e; buf[3] = 0x47;
+    // Second pixel: plain white
+    buf[4] = 255; buf[5] = 255; buf[6] = 255; buf[7] = 255;
+
+    const bg = { r: 0x80, g: 0x50, b: 0x40 };
+    expect(() =>
+      runCrossCheck(buf, w, h, { x: 0, y: 0, w, h }, { backgroundColor: bg }),
+    ).not.toThrow();
+  });
+});
+
+describe('runCrossCheckBatch — P1 regression: PNG decoded exactly once for multiple crops', () => {
+  test('decodePngToRgba is called once regardless of annotation count', () => {
+    const bg = { r: 240, g: 240, b: 240 };
+    const png = pngFromRgb(32, 32, solidRgb(32, 32, bg.r, bg.g, bg.b));
+    const spy = jest.spyOn(imageFeatures, 'decodePngToRgba');
+
+    const crops = [
+      { x: 0, y: 0, w: 8, h: 8 },
+      { x: 8, y: 0, w: 8, h: 8 },
+      { x: 16, y: 0, w: 8, h: 8 },
+      { x: 0, y: 8, w: 8, h: 8 },
+      { x: 8, y: 8, w: 8, h: 8 },
+    ];
+    const results = runCrossCheckBatch(png, 32, 32, crops, { backgroundColor: bg });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(results).toHaveLength(crops.length);
+    results.forEach((r) => expect(r.verdict).toBe('pixel_absent'));
+
+    spy.mockRestore();
+  });
+
+  test('runCrossCheckBatch with raw RGBA does not call decodePngToRgba', () => {
+    const bg = { r: 240, g: 240, b: 240 };
+    const buf = solid(16, 16, bg.r, bg.g, bg.b);
+    const spy = jest.spyOn(imageFeatures, 'decodePngToRgba');
+
+    const results = runCrossCheckBatch(buf, 16, 16, [{ x: 0, y: 0, w: 16, h: 16 }], { backgroundColor: bg });
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(results).toHaveLength(1);
+    expect(results[0].verdict).toBe('pixel_absent');
+
+    spy.mockRestore();
+  });
+});
+
+describe('runCrossCheck — reasons surface for hint engine evidence', () => {
+  test('pixel_absent path includes both edge_density and color_distance reasons', () => {
+    const bg = { r: 240, g: 240, b: 240 };
+    const buf = solid(32, 32, bg.r, bg.g, bg.b);
+    const r = runCrossCheck(buf, 32, 32, { x: 0, y: 0, w: 32, h: 32 }, { backgroundColor: bg });
+    expect(r.verdict).toBe('pixel_absent');
+    expect(r.reasons.some((s) => s.includes('edge_density'))).toBe(true);
+    expect(r.reasons.some((s) => s.includes('color_distance'))).toBe(true);
+  });
+
+  test('consistent (edge-density branch) path emits a single edge_density reason', () => {
+    const bg = { r: 240, g: 240, b: 240 };
+    // Region with an internal sharp edge → high density → consistent.
+    const inner = { x: 8, y: 8, w: 16, h: 16 };
+    const buf = Buffer.alloc(32 * 32 * 4);
+    for (let i = 0; i < 32 * 32; i++) {
+      buf[i * 4] = bg.r;
+      buf[i * 4 + 1] = bg.g;
+      buf[i * 4 + 2] = bg.b;
+      buf[i * 4 + 3] = 255;
+    }
+    for (let y = inner.y; y < inner.y + inner.h; y++) {
+      for (let x = inner.x; x < inner.x + inner.w; x++) {
+        const i = (y * 32 + x) * 4;
+        const v = x < inner.x + inner.w / 2 ? 0 : 255;
+        buf[i] = v;
+        buf[i + 1] = v;
+        buf[i + 2] = v;
+      }
+    }
+    const r = runCrossCheck(buf, 32, 32, inner, { backgroundColor: bg });
+    expect(r.verdict).toBe('consistent');
+    expect(r.reasons.length).toBe(1);
+    expect(r.reasons[0]).toContain('edge_density');
+  });
+});


### PR DESCRIPTION
## Summary

- Lands `src/core/perception/image-features.ts` — pure-JS image feature primitives: Sobel edge density, dominant color (histogram-bucketed), sRGB color distance, and a zero-dependency PNG decoder for Chromium screenshot buffers.
- Lands `src/core/perception/cross-check.ts` — DOM↔screenshot cross-check engine (`runCrossCheck` / `runCrossCheckBatch`) implementing the `pixel_absent` / `consistent` / `empty_region` verdict logic from #710 v2.
- Lands `tests/core/perception/cross-check.test.ts` — 23 tests covering all verdict branches, invalid-input regressions (NaN/Infinity crop coords, invalid backgroundColor), PNG-decode path, batch decode-once optimization, and reasons field for hint-engine evidence.

Replaces closed PR #758, which targeted `develop` before the `src/core/` tier was established. Files relocated from `src/perception/` → `src/core/perception/` and `tests/perception/` → `tests/core/perception/` to satisfy the core-tier portability contract (P1–P5).

## Related

- Closes #758 (original cross-check PR, now closed)
- Sibling: #808 (perception metadata — same Phase 4 cleanup wave)
- Stack context: PR #774, PR #780

## Verification

- `tsc -p tsconfig.json --noEmit` → 0 errors
- `tsc -p tsconfig.cli.json --noEmit` → 0 errors
- `eslint src/core/perception --ext .ts` → 0 violations
- `depcruise --config .dependency-cruiser.cjs src` → 0 violations (301 modules, 622 dependencies cruised)
- `jest tests/core/perception/` → **23 passed, 0 failed** (1.8 s)

## Files carried / dropped

| File | Action | Lines |
|------|--------|-------|
| `src/core/perception/image-features.ts` | carried (path relocated) | 433 |
| `src/core/perception/cross-check.ts` | carried (path relocated) | 253 |
| `tests/core/perception/cross-check.test.ts` | carried (import depth bumped `../../` → `../../../`) | 443 |
| `src/perception/cache.ts` | dropped (belongs to #808 wave, not this PR) | — |
| `src/perception/metadata.ts` | dropped (belongs to #808 wave) | — |
| `src/perception/types.ts` | dropped (belongs to #808 wave) | — |
| `src/perception/index.ts` | dropped (barrel, will land with final wave) | — |
| `tests/perception/cache.test.ts` | dropped | — |
| `tests/perception/image-features.test.ts` | dropped (image-features tested via cross-check suite) | — |
| `tests/perception/metadata.test.ts` | dropped (belongs to #808 wave) | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)