### PR TITLE
feat(pilot): verified skill extractor (Phase 4, replaces #761)

### DIFF
--- a/src/pilot/curator/extractor.ts
+++ b/src/pilot/curator/extractor.ts
@@ -1,0 +1,514 @@
+/**
+ * Verified Skill Extractor (#713 v2).
+ *
+ * Triggered on `transaction.verdict === 'success'` from the contract
+ * runtime. Distills the trajectory into a SKILL.md candidate (or
+ * increments `verified_runs` on an existing skill).
+ *
+ * Identity per #713 v2: `(graph_node_anchor, contract_id)`. Two
+ * settlements with both fields equal increment the same skill —
+ * intent text is informational only.
+ *
+ * Promotion rule: `verified_runs >= N` (default 3) within a trailing
+ * 30-day window flips status from `candidate` to `promoted`. The
+ * window is sliding — failures don't reset the counter, they're
+ * simply not counted.
+ *
+ * Storage layout (per #713 v2 `### Storage layout`):
+ *
+ *   ~/.openchrome/skills/<domain>/<skill_id>.md   (frontmatter + body)
+ *                                  /<skill_id>.json (sidecar)
+ *
+ * `<skill_id>` is `sha256(graph_node_anchor + '|' + contract_id)` truncated
+ * to 12 hex chars — short enough for filesystem readability, long
+ * enough to avoid collisions across thousands of skills per domain.
+ *
+ * Gated by `isSkillCuratorEnabled()` at call sites that integrate with
+ * the contract runtime. The extractor itself is a deterministic transform
+ * (no LLM calls — per Phase 4 / PR-20 scope).
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { parseSkillMd, stringifySkillMd } from './skill-md';
+import {
+  SKILL_RUN_LOG_MAX,
+  SKILL_SCHEMA_VERSION,
+  type SkillFrontmatter,
+  type SkillRecord,
+  type SkillSidecar,
+  type SkillStatus,
+} from './types';
+
+const PROMOTION_RUN_THRESHOLD = 3;
+const ROLLING_WINDOW_DAYS = 30;
+const ROLLING_WINDOW_MS = ROLLING_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+const SKILL_LOCK_WAIT_MS = 5_000;
+const SKILL_LOCK_STALE_MS = 30_000;
+const SKILL_LOCK_POLL_MS = 10;
+
+export interface ExtractionInputs {
+  /** Settled transaction id used as `contract_ref`. */
+  txn_id: string;
+  /** The contract-id this transaction settled under. */
+  contract_id: string;
+  /** Whatever short label the operator wants to remember the skill by. */
+  intent: string;
+  /** eTLD+1 host this skill applies to. */
+  domain: string;
+  /** Hex state-hash from #702 — entry node in the skill graph. */
+  graph_node_anchor: string;
+  /** Optional rolled-up budget hint for the SKILL.md body. */
+  budget?: { tokens_typical?: number; wall_ms_typical?: number };
+  /**
+   * Body of the SKILL.md — the LLM distillation in PR-20b. PR-20 ships
+   * a deterministic placeholder body so the system is end-to-end
+   * testable without an LLM.
+   */
+  body?: string;
+  /** Operator-supplied skill name. Optional; auto-derived from intent. */
+  name?: string;
+}
+
+export interface ExtractorOptions {
+  rootDir?: string;
+  /** Promotion threshold (count of successful re-runs). */
+  promotionThreshold?: number;
+  /** Test hook: clock. */
+  now?: () => number;
+}
+
+export interface ExtractionResult {
+  record: SkillRecord;
+  /** True iff this call created a new file (vs. incrementing). */
+  created: boolean;
+  /** True iff status transitioned candidate → promoted. */
+  promoted: boolean;
+}
+
+export function defaultSkillRootDir(): string {
+  return path.join(os.homedir(), '.openchrome', 'skills');
+}
+
+/**
+ * Reject any `domain` value that could escape the skill-storage tree
+ * via `path.join`. The frontmatter schema documents domain as the
+ * eTLD+1 host (e.g. `amazon.com`); this guard is the load-bearing
+ * check that keeps a malformed or hostile transaction record from
+ * writing files outside `~/.openchrome/skills/`.
+ *
+ * The character set is intentionally narrow: alphanumerics, dot,
+ * dash, underscore, and colon (so explicit non-default ports survive).
+ * Anything else — path separators, parent-directory tokens, null
+ * bytes — is a hard error.
+ */
+function assertSafeDomain(domain: string): void {
+  if (typeof domain !== 'string' || domain.length === 0) {
+    throw new Error('skill-memory: domain must be a non-empty string');
+  }
+  if (domain.length > 253) {
+    throw new Error('skill-memory: domain is implausibly long');
+  }
+  if (!/^[A-Za-z0-9._:-]+$/.test(domain)) {
+    throw new Error(`skill-memory: domain "${domain}" contains forbidden characters`);
+  }
+  // Reject parent-traversal segments even if individually valid chars.
+  if (domain === '.' || domain === '..' || domain.split(/[./\\]/).some((seg) => seg === '..')) {
+    throw new Error(`skill-memory: domain "${domain}" includes parent-directory traversal`);
+  }
+}
+
+export function computeSkillId(graphNodeAnchor: string, contractId: string): string {
+  return crypto
+    .createHash('sha256')
+    .update(`${graphNodeAnchor}|${contractId}`)
+    .digest('hex')
+    .slice(0, 12);
+}
+
+function deriveName(intent: string, fallback: string): string {
+  const cleaned = intent
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+  if (cleaned.length === 0) return fallback;
+  return cleaned;
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function isoUtc(ms: number): string {
+  const d = new Date(ms);
+  const ts = `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}T${pad(
+    d.getUTCHours(),
+  )}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}Z`;
+  return ts;
+}
+
+function trimRollingLog(
+  recent: SkillSidecar['runs']['recent'],
+  windowStartMs: number,
+): SkillSidecar['runs']['recent'] {
+  return recent.filter((e) => e.ts >= windowStartMs).slice(-SKILL_RUN_LOG_MAX);
+}
+
+function readJson<T>(file: string): T | undefined {
+  if (!fs.existsSync(file)) return undefined;
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8')) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Structural guard for `SkillSidecar` — `readJson` only proves the
+ * file is parseable JSON, not that it matches the expected shape.
+ * Without this, a sidecar containing `{}` or an older schema missing
+ * `runs.recent` would silently pass the existence check and then
+ * crash inside the merge path at `sidecar.runs.recent`.
+ */
+function isValidSidecar(v: unknown): v is SkillSidecar {
+  if (!v || typeof v !== 'object') return false;
+  const s = v as Partial<SkillSidecar>;
+  if (s.schema_version !== SKILL_SCHEMA_VERSION) return false;
+  if (typeof s.skill_id !== 'string') return false;
+  if (typeof s.graph_node_anchor !== 'string') return false;
+  if (typeof s.contract_id !== 'string') return false;
+  if (!s.runs || typeof s.runs !== 'object') return false;
+  if (!Array.isArray(s.runs.recent)) return false;
+  if (typeof s.runs.count !== 'number') return false;
+  if (typeof s.runs.window_start !== 'string') return false;
+  // Each entry must carry a numeric timestamp so `trimRollingLog`
+  // can compare against the rolling-window cutoff. A `null` /
+  // `{}` / older-schema entry would otherwise pass the array check
+  // and then throw at `e.ts` inside the merge path, blocking
+  // future successful runs from being recorded.
+  for (const e of s.runs.recent) {
+    if (!e || typeof e !== 'object') return false;
+    const entry = e as { txn_id?: unknown; ok?: unknown; ts?: unknown };
+    if (typeof entry.ts !== 'number' || !Number.isFinite(entry.ts)) return false;
+    if (typeof entry.ok !== 'boolean') return false;
+    if (typeof entry.txn_id !== 'string') return false;
+  }
+  return true;
+}
+
+/**
+ * Atomic file write using a per-call unique temp path so concurrent
+ * writers for the same target never race on a shared `.tmp` file.
+ * Without uniqueness, two parallel `recordSuccessfulRun` calls on the
+ * same `(graph_node_anchor, contract_id)` could clobber each other's
+ * temp file and one of the renames would either fail or destroy the
+ * other writer's data.
+ */
+function writeAtomic(target: string, body: string): void {
+  const tmp = `${target}.${process.pid}.${crypto.randomBytes(6).toString('hex')}.tmp`;
+  try {
+    fs.writeFileSync(tmp, body, { mode: 0o644 });
+    fs.renameSync(tmp, target);
+  } catch (err) {
+    // Best-effort cleanup on failure — never let a stray .tmp leak.
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      /* file already gone or never created */
+    }
+    throw err;
+  }
+}
+
+function sleepSync(ms: number): void {
+  const shared = new SharedArrayBuffer(4);
+  const view = new Int32Array(shared);
+  Atomics.wait(view, 0, 0, ms);
+}
+
+function withSkillLock<T>(lockDir: string, fn: () => T): T {
+  const started = Date.now();
+
+  for (;;) {
+    try {
+      fs.mkdirSync(lockDir);
+      break;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'EEXIST') throw err;
+
+      let stale = false;
+      try {
+        const stat = fs.statSync(lockDir);
+        stale = Date.now() - stat.mtimeMs > SKILL_LOCK_STALE_MS;
+      } catch (statErr) {
+        const statCode = (statErr as NodeJS.ErrnoException).code;
+        if (statCode === 'ENOENT') continue;
+        throw statErr;
+      }
+
+      if (stale) {
+        fs.rmSync(lockDir, { recursive: true, force: true });
+        continue;
+      }
+      if (Date.now() - started >= SKILL_LOCK_WAIT_MS) {
+        throw new Error(`skill-memory: timed out waiting for lock ${lockDir}`);
+      }
+      sleepSync(SKILL_LOCK_POLL_MS);
+    }
+  }
+
+  try {
+    fs.writeFileSync(path.join(lockDir, 'owner'), `${process.pid}\n`, { mode: 0o644 });
+    return fn();
+  } finally {
+    fs.rmSync(lockDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Resolve the sidecar to merge against for an update.
+ *
+ * - No prior markdown on disk → returns null (fresh-creation path).
+ * - Markdown present, sidecar valid → returns the parsed sidecar.
+ * - Markdown present, sidecar missing or schema-invalid → reconstructs
+ *   a usable sidecar from the frontmatter so transient JSON-read
+ *   issues, partial syncs, or older sidecar schemas never reset
+ *   `verified_runs` and demote a previously-promoted skill back to
+ *   candidate.
+ *
+ * This is the single source of truth that proves "if `existing`
+ * is non-null then the merge path always sees a valid sidecar",
+ * removing the need for any subsequent existence guard.
+ */
+function loadPriorSidecar(
+  sidecarPath: string,
+  existing: ReturnType<typeof parseSkillMd> | null,
+  skillId: string,
+  contractId: string,
+  windowStartMs: number,
+  nowMs: number,
+): SkillSidecar | null {
+  if (existing === null) return null;
+  const raw = readJson<unknown>(sidecarPath);
+  if (isValidSidecar(raw)) return raw;
+
+  const priorTs = Date.parse(existing.frontmatter.last_verified_at);
+  const priorMs = Number.isFinite(priorTs) ? priorTs : nowMs;
+  const priorRuns = Math.max(0, existing.frontmatter.verified_runs);
+  // Seed one synthetic recent entry per prior verified run so the
+  // success-count recomputation in the merge path lands on the same
+  // verified_runs total, which preserves promoted status across a
+  // missing or malformed sidecar. Capped at SKILL_RUN_LOG_MAX-1 to
+  // leave room for the new entry the merge path appends. The exact
+  // timestamps are unknown — anchor at `last_verified_at` so the
+  // rolling-window eventually drops them naturally.
+  const seedCount = Math.min(priorRuns, SKILL_RUN_LOG_MAX - 1);
+  const recent: SkillSidecar['runs']['recent'] = [];
+  for (let i = 0; i < seedCount; i++) {
+    recent.push({
+      txn_id: existing.frontmatter.contract_ref,
+      ok: true,
+      ts: priorMs,
+    });
+  }
+  return {
+    schema_version: SKILL_SCHEMA_VERSION,
+    skill_id: skillId,
+    graph_node_anchor: existing.frontmatter.graph_node_anchor,
+    contract_id: contractId,
+    runs: {
+      count: priorRuns,
+      window_start: isoUtc(windowStartMs),
+      recent,
+    },
+  };
+}
+
+/**
+ * Process one successful settlement. Idempotent: subsequent calls with
+ * the same `(graph_node_anchor, contract_id)` increment counters in
+ * place rather than producing a new file.
+ */
+export function recordSuccessfulRun(
+  inputs: ExtractionInputs,
+  opts: ExtractorOptions = {},
+): ExtractionResult {
+  const rootDir = opts.rootDir ?? defaultSkillRootDir();
+  const now = opts.now ?? Date.now;
+  const promotionThreshold = opts.promotionThreshold ?? PROMOTION_RUN_THRESHOLD;
+  // The rolling-window log is capped at SKILL_RUN_LOG_MAX entries,
+  // so a threshold above that cap could never be reached: skills
+  // would silently saturate at 50 verified_runs and never promote.
+  // Refuse the misconfiguration loudly rather than letting it look
+  // like the promotion gate just never fires.
+  if (promotionThreshold < 1 || promotionThreshold > SKILL_RUN_LOG_MAX) {
+    throw new Error(
+      `skill-memory: promotionThreshold ${promotionThreshold} must be in [1, ${SKILL_RUN_LOG_MAX}]`,
+    );
+  }
+  assertSafeDomain(inputs.domain);
+  const skillId = computeSkillId(inputs.graph_node_anchor, inputs.contract_id);
+  const domainDir = path.join(rootDir, inputs.domain);
+  fs.mkdirSync(domainDir, { recursive: true });
+  const lockPath = path.join(domainDir, `${skillId}.lock`);
+  return withSkillLock(lockPath, () => {
+  const filePath = path.join(domainDir, `${skillId}.md`);
+  const sidecarPath = path.join(domainDir, `${skillId}.json`);
+  const t = now();
+  const tsIso = isoUtc(t);
+  const windowStartMs = t - ROLLING_WINDOW_MS;
+
+  const existing = fs.existsSync(filePath) ? parseSkillMd(fs.readFileSync(filePath, 'utf8')) : null;
+
+  // Pick the prior sidecar to merge against. Read + shape-validate
+  // first; if validation fails BUT the markdown is present, rebuild
+  // from the frontmatter so a transient JSON read issue or older
+  // schema never resets verified_runs / promotion state. Returns null
+  // only when there is no prior skill at all (the fresh-creation
+  // path).
+  const priorSidecar = loadPriorSidecar(
+    sidecarPath,
+    existing,
+    skillId,
+    inputs.contract_id,
+    windowStartMs,
+    t,
+  );
+
+  let frontmatter: SkillFrontmatter;
+  let sidecar: SkillSidecar;
+  let promoted = false;
+  const created = existing === null;
+
+  if (existing !== null) {
+    // Update path. `priorSidecar` is guaranteed non-null here because
+    // `loadPriorSidecar` always returns a usable sidecar when the
+    // markdown is present (rebuilding from frontmatter when needed),
+    // so no further nullability check is required against the
+    // markdown+sidecar product — the rebuild path closes that gap.
+    const prior = priorSidecar as SkillSidecar;
+    const recent = trimRollingLog(
+      [...prior.runs.recent, { txn_id: inputs.txn_id, ok: true, ts: t }],
+      windowStartMs,
+    );
+    const successes = recent.filter((e) => e.ok).length;
+    const newStatus: SkillStatus =
+      existing.frontmatter.status === 'archived'
+        ? 'archived'
+        : successes >= promotionThreshold
+          ? 'promoted'
+          : 'candidate';
+    if (existing.frontmatter.status !== 'promoted' && newStatus === 'promoted') {
+      promoted = true;
+    }
+    frontmatter = {
+      ...existing.frontmatter,
+      verified_runs: successes,
+      last_verified_at: tsIso,
+      contract_ref: inputs.txn_id,
+      status: newStatus,
+    };
+    sidecar = {
+      schema_version: SKILL_SCHEMA_VERSION,
+      skill_id: skillId,
+      graph_node_anchor: inputs.graph_node_anchor,
+      contract_id: inputs.contract_id,
+      runs: {
+        count: successes,
+        window_start: isoUtc(windowStartMs),
+        recent,
+      },
+    };
+  } else {
+    // Creation path — fresh skill, no prior on disk.
+    const fallbackName = `skill-${skillId}`;
+    frontmatter = {
+      schema_version: SKILL_SCHEMA_VERSION,
+      name: inputs.name ? inputs.name : deriveName(inputs.intent, fallbackName),
+      domain: inputs.domain,
+      intent: inputs.intent.slice(0, 512),
+      status: 'candidate',
+      verified_runs: 1,
+      last_verified_at: tsIso,
+      contract_ref: inputs.txn_id,
+      graph_node_anchor: inputs.graph_node_anchor,
+      author: 'agent',
+      ...(inputs.budget ? { budget: inputs.budget } : {}),
+    };
+    sidecar = {
+      schema_version: SKILL_SCHEMA_VERSION,
+      skill_id: skillId,
+      graph_node_anchor: inputs.graph_node_anchor,
+      contract_id: inputs.contract_id,
+      runs: {
+        count: 1,
+        window_start: isoUtc(windowStartMs),
+        recent: [{ txn_id: inputs.txn_id, ok: true, ts: t }],
+      },
+    };
+  }
+
+  const body =
+    inputs.body ??
+    existing?.body ??
+    `## Steps (LLM distillation lands in PR-20b)
+
+This SKILL.md was extracted from a contract-verified successful
+trajectory.  Until the LLM distiller is wired, the body is the literal
+intent string.
+
+> ${inputs.intent}
+`;
+
+  writeAtomic(filePath, stringifySkillMd({ frontmatter, body }));
+  writeAtomic(sidecarPath, JSON.stringify(sidecar, null, 2));
+
+  return {
+    created,
+    promoted,
+    record: {
+      skill_id: skillId,
+      filePath,
+      sidecarPath,
+      frontmatter,
+      sidecar,
+    },
+  };
+  });
+}
+
+/** Read every SKILL.md under a domain (recall + curator consume this). */
+export function listSkillsForDomain(domain: string, opts: ExtractorOptions = {}): SkillRecord[] {
+  assertSafeDomain(domain);
+  const rootDir = opts.rootDir ?? defaultSkillRootDir();
+  const domainDir = path.join(rootDir, domain);
+  if (!fs.existsSync(domainDir)) return [];
+  const out: SkillRecord[] = [];
+  for (const file of fs.readdirSync(domainDir)) {
+    if (!file.endsWith('.md')) continue;
+    const filePath = path.join(domainDir, file);
+    const skill_id = file.replace(/\.md$/, '');
+    const sidecarPath = path.join(domainDir, `${skill_id}.json`);
+    let parsed;
+    try {
+      parsed = parseSkillMd(fs.readFileSync(filePath, 'utf8'));
+    } catch {
+      continue;
+    }
+    const sidecar = readJson<unknown>(sidecarPath);
+    if (!isValidSidecar(sidecar)) continue;
+    out.push({
+      skill_id,
+      filePath,
+      sidecarPath,
+      frontmatter: parsed.frontmatter,
+      sidecar,
+    });
+  }
+  return out;
+}

--- a/src/pilot/curator/index.ts
+++ b/src/pilot/curator/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Pilot curator barrel (#712 epic, Phase 4 — verified skill extractor).
+ *
+ * The extractor turns successful, contract-verified runs into reusable
+ * SKILL.md candidates. It is a deterministic transform (no LLM calls).
+ *
+ * Call sites that integrate with the contract runtime MUST gate on
+ * `isSkillCuratorEnabled()` from `src/harness/flags.ts` before
+ * invoking any export from this module.
+ *
+ * Recall (#714) + curator stats (#715) ride follow-up commits.
+ */
+
+export {
+  computeSkillId,
+  defaultSkillRootDir,
+  listSkillsForDomain,
+  recordSuccessfulRun,
+} from './extractor';
+export type {
+  ExtractionInputs,
+  ExtractionResult,
+  ExtractorOptions,
+} from './extractor';
+
+export {
+  FrontmatterError,
+  parseSkillMd,
+  stringifySkillMd,
+  validateFrontmatter,
+} from './skill-md';
+
+export {
+  SKILL_RUN_LOG_MAX,
+  SKILL_SCHEMA_VERSION,
+} from './types';
+export type {
+  SkillAuthor,
+  SkillFile,
+  SkillFrontmatter,
+  SkillRecord,
+  SkillSidecar,
+  SkillStatus,
+} from './types';

--- a/src/pilot/curator/skill-md.ts
+++ b/src/pilot/curator/skill-md.ts
@@ -1,0 +1,251 @@
+/**
+ * SKILL.md frontmatter parser/serializer (#713 v2).
+ *
+ * Tiny, deliberately not-yaml: the canonical schema is a closed
+ * key-value set with primitive types. Pulling in a YAML dep just to
+ * round-trip `name: foo` is overkill — and the extractor + curator
+ * are the only writers, so format stability is enforceable in code.
+ *
+ * Handles:
+ *   - leading frontmatter delimited by `---` lines
+ *   - `key: value` entries (string, number, boolean, ISO-8601)
+ *   - nested `budget:` object via dotted keys (`budget.tokens_typical: 4200`)
+ *
+ * Anything richer should not appear in this schema — the body is
+ * plain Markdown.
+ */
+
+import {
+  SKILL_SCHEMA_VERSION,
+  type SkillFile,
+  type SkillFrontmatter,
+} from './types';
+
+const NAME_PATTERN = /^[a-z0-9._-]{1,64}$/;
+const ISO_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+const HEX_PATTERN = /^[0-9a-f]+$/;
+const DELIMITER = '---';
+
+export class FrontmatterError extends Error {}
+
+/** Parse a SKILL.md text. Throws FrontmatterError on shape problems. */
+export function parseSkillMd(text: string): SkillFile {
+  if (!text.startsWith(DELIMITER)) {
+    throw new FrontmatterError('SKILL.md must start with `---` frontmatter delimiter');
+  }
+  const lines = text.split('\n');
+  // Find closing delimiter (not at index 0).
+  let close = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === DELIMITER) {
+      close = i;
+      break;
+    }
+  }
+  if (close < 0) {
+    throw new FrontmatterError('SKILL.md frontmatter has no closing `---`');
+  }
+  const fmLines = lines.slice(1, close);
+  const body = lines.slice(close + 1).join('\n').replace(/^\n+/, '');
+
+  const raw = parseSimpleYaml(fmLines);
+  const frontmatter = validateFrontmatter(raw);
+  return { frontmatter, body };
+}
+
+/** Build a SKILL.md text from a frontmatter + body. */
+export function stringifySkillMd(file: SkillFile): string {
+  validateFrontmatter(file.frontmatter as unknown as Record<string, unknown>);
+  const fm = file.frontmatter;
+  const lines: string[] = [DELIMITER];
+  lines.push(`schema_version: ${fm.schema_version}`);
+  lines.push(`name: ${fm.name}`);
+  lines.push(`domain: ${fm.domain}`);
+  lines.push(`intent: ${escapeStr(fm.intent)}`);
+  lines.push(`status: ${fm.status}`);
+  lines.push(`verified_runs: ${fm.verified_runs}`);
+  lines.push(`last_verified_at: ${fm.last_verified_at}`);
+  lines.push(`contract_ref: ${fm.contract_ref}`);
+  lines.push(`graph_node_anchor: ${fm.graph_node_anchor}`);
+  lines.push(`author: ${fm.author}`);
+  if (fm.budget) {
+    if (typeof fm.budget.tokens_typical === 'number') {
+      lines.push(`budget.tokens_typical: ${fm.budget.tokens_typical}`);
+    }
+    if (typeof fm.budget.wall_ms_typical === 'number') {
+      lines.push(`budget.wall_ms_typical: ${fm.budget.wall_ms_typical}`);
+    }
+  }
+  lines.push(DELIMITER);
+  lines.push('');
+  lines.push(file.body.trimStart());
+  if (!lines[lines.length - 1].endsWith('\n')) lines.push('');
+  return lines.join('\n');
+}
+
+/* ------------------------------------------------------------------ */
+/* helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function escapeStr(value: string): string {
+  // Quote only when the value contains a leading/trailing space, a
+  // colon, a hash, or a double-quote — keeps the output tidy for
+  // typical strings.
+  if (/[:#"\r\n]|^\s|\s$/.test(value)) return JSON.stringify(value);
+  return value;
+}
+
+function unescapeStr(raw: string): string {
+  if (raw.startsWith('"') && raw.endsWith('"')) {
+    try {
+      return JSON.parse(raw) as string;
+    } catch {
+      return raw.slice(1, -1);
+    }
+  }
+  return raw;
+}
+
+/**
+ * Reserved property names that cannot appear as keys in parsed
+ * frontmatter — they would either mutate `Object.prototype` (whole-
+ * process pollution) or alias `Object`'s constructor / prototype slot
+ * on the parsed map and propagate through downstream property access.
+ * The frontmatter schema does not legitimately use any of these.
+ */
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/** Minimal `key: value` parser with dotted-path support. */
+function parseSimpleYaml(lines: string[]): Record<string, unknown> {
+  // Use a null-prototype map so even if a forbidden key slipped past
+  // the explicit guard below, it could only land on this object — it
+  // could never reach `Object.prototype`.
+  const out = Object.create(null) as Record<string, unknown>;
+  for (const line of lines) {
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+    const colon = line.indexOf(':');
+    if (colon < 0) {
+      throw new FrontmatterError(`malformed frontmatter line: ${line}`);
+    }
+    const key = line.slice(0, colon).trim();
+    const value = unescapeStr(line.slice(colon + 1).trim());
+    setNested(out, key, coerce(value));
+  }
+  return out;
+}
+
+function setNested(target: Record<string, unknown>, dottedKey: string, value: unknown): void {
+  const parts = dottedKey.split('.');
+  for (const seg of parts) {
+    if (FORBIDDEN_KEYS.has(seg)) {
+      // Refuse the whole assignment rather than partially writing the
+      // path. A crafted frontmatter cannot mutate `Object.prototype`
+      // through this parser.
+      throw new FrontmatterError(`forbidden frontmatter key segment: "${seg}"`);
+    }
+  }
+  let cursor: Record<string, unknown> = target;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const k = parts[i];
+    const existing = cursor[k];
+    if (!existing || typeof existing !== 'object') {
+      cursor[k] = Object.create(null);
+    }
+    cursor = cursor[k] as Record<string, unknown>;
+  }
+  cursor[parts[parts.length - 1]] = value;
+}
+
+function coerce(raw: string): unknown {
+  // Strings stay strings — type coercion is deferred to validation
+  // time for the small closed set of non-string fields:
+  //   number-typed: schema_version, verified_runs, budget.*
+  //   none of the schema fields are boolean
+  // Eager Number.parseInt() destroyed string-typed fields like
+  // contract_ref / graph_node_anchor when they happened to be all
+  // digits, and eager `true`/`false` → boolean coercion likewise
+  // destroyed string-typed fields like `name: true` (a SKILL.md
+  // written through `stringifySkillMd` does not quote those tokens
+  // because the writer does not know they are reserved literals;
+  // the next read then turned the value into a boolean and
+  // `validateFrontmatter` threw). Returning the raw string lets
+  // both writers and validators stay in charge of their own
+  // type expectations.
+  return raw;
+}
+
+/** Best-effort coerce-to-number used inside validateFrontmatter. */
+function asNumber(v: unknown): number | undefined {
+  if (typeof v === 'number') return Number.isFinite(v) ? v : undefined;
+  if (typeof v !== 'string') return undefined;
+  if (!/^-?\d+(?:\.\d+)?$/.test(v)) return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function isObj(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** Validate + cast unknown → SkillFrontmatter. */
+export function validateFrontmatter(raw: unknown): SkillFrontmatter {
+  if (!isObj(raw)) throw new FrontmatterError('frontmatter must be an object');
+  const fm = raw as Record<string, unknown>;
+  const schemaVersion = asNumber(fm.schema_version);
+  must(schemaVersion === SKILL_SCHEMA_VERSION, `schema_version must be ${SKILL_SCHEMA_VERSION}`);
+  const name = mustString(fm, 'name');
+  must(NAME_PATTERN.test(name), `name "${name}" must match ${NAME_PATTERN.source}`);
+  const domain = mustString(fm, 'domain');
+  const intent = mustString(fm, 'intent');
+  must(intent.length <= 512, `intent must be ≤ 512 chars (got ${intent.length})`);
+  const status = mustString(fm, 'status');
+  must(
+    status === 'candidate' || status === 'promoted' || status === 'archived',
+    `status must be one of candidate|promoted|archived (got "${status}")`,
+  );
+  const verifiedRuns = asNumber(fm.verified_runs);
+  if (verifiedRuns === undefined) {
+    throw new FrontmatterError('field "verified_runs" must be a finite number');
+  }
+  must(verifiedRuns >= 0, 'verified_runs must be ≥0');
+  const lastVerifiedAt = mustString(fm, 'last_verified_at');
+  must(ISO_PATTERN.test(lastVerifiedAt), `last_verified_at must be ISO-8601 with Z suffix`);
+  const contractRef = mustString(fm, 'contract_ref');
+  const graphNodeAnchor = mustString(fm, 'graph_node_anchor');
+  must(HEX_PATTERN.test(graphNodeAnchor), 'graph_node_anchor must be hex');
+  const author = mustString(fm, 'author');
+  must(author === 'agent' || author === 'user', `author must be agent|user (got "${author}")`);
+  const out: SkillFrontmatter = {
+    schema_version: SKILL_SCHEMA_VERSION,
+    name,
+    domain,
+    intent,
+    status: status as SkillFrontmatter['status'],
+    verified_runs: verifiedRuns,
+    last_verified_at: lastVerifiedAt,
+    contract_ref: contractRef,
+    graph_node_anchor: graphNodeAnchor,
+    author: author as SkillFrontmatter['author'],
+  };
+  if (isObj(fm.budget)) {
+    const b = fm.budget;
+    out.budget = {};
+    const tokens = asNumber(b.tokens_typical);
+    if (tokens !== undefined) out.budget.tokens_typical = tokens;
+    const wall = asNumber(b.wall_ms_typical);
+    if (wall !== undefined) out.budget.wall_ms_typical = wall;
+  }
+  return out;
+}
+
+function mustString(obj: Record<string, unknown>, field: string): string {
+  const v = obj[field];
+  if (typeof v !== 'string' || v.length === 0) {
+    throw new FrontmatterError(`field "${field}" must be a non-empty string`);
+  }
+  return v;
+}
+
+function must(cond: boolean, message: string): void {
+  if (!cond) throw new FrontmatterError(message);
+}

--- a/src/pilot/curator/types.ts
+++ b/src/pilot/curator/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Verified Skill Memory types (#712, #713).
+ *
+ * The on-disk schema is a YAML-frontmatter Markdown file at
+ * `~/.openchrome/skills/<domain>/<skill_id>.md` with a sidecar
+ * `<skill_id>.json` that mirrors machine-readable fields plus a
+ * rolling success log.
+ *
+ * `schema_version: 1` is mandatory. Future field additions bump this
+ * value; the curator (#715) ignores files with an unknown schema and
+ * surfaces a warning rather than crashing the load path.
+ */
+
+export const SKILL_SCHEMA_VERSION = 1;
+
+export type SkillStatus = 'candidate' | 'promoted' | 'archived';
+export type SkillAuthor = 'agent' | 'user';
+
+/** YAML frontmatter — the canonical contract between extractor + curator. */
+export interface SkillFrontmatter {
+  schema_version: typeof SKILL_SCHEMA_VERSION;
+  /** [a-z0-9._-]{1,64} */
+  name: string;
+  /** eTLD+1 host. */
+  domain: string;
+  /** Free-text description (≤ 512 chars). Informational only. */
+  intent: string;
+  status: SkillStatus;
+  verified_runs: number;
+  /** ISO-8601 UTC timestamp ending in Z. */
+  last_verified_at: string;
+  /** Audit-log txn_id pointing at the most recent verification. */
+  contract_ref: string;
+  /** Hex `state_hash` from #702 — entry node in the skill graph. */
+  graph_node_anchor: string;
+  author: SkillAuthor;
+  budget?: {
+    tokens_typical?: number;
+    wall_ms_typical?: number;
+  };
+}
+
+/** Sidecar JSON shape (read by the curator's stats passes). */
+export interface SkillSidecar {
+  schema_version: typeof SKILL_SCHEMA_VERSION;
+  skill_id: string;
+  graph_node_anchor: string;
+  contract_id: string;
+  /** Rolling-window success log capped at SKILL_RUN_LOG_MAX entries. */
+  runs: {
+    count: number;
+    window_start: string;
+    recent: Array<{ txn_id: string; ok: boolean; ts: number }>;
+  };
+}
+
+/** Maximum entries kept in the sidecar's rolling log. */
+export const SKILL_RUN_LOG_MAX = 50;
+
+/** A parsed SKILL.md (frontmatter + body). */
+export interface SkillFile {
+  frontmatter: SkillFrontmatter;
+  body: string;
+}
+
+/** Combined view used by recall (#714) + curator (#715). */
+export interface SkillRecord {
+  skill_id: string;
+  filePath: string;
+  sidecarPath: string;
+  frontmatter: SkillFrontmatter;
+  sidecar: SkillSidecar;
+}

--- a/src/pilot/index.ts
+++ b/src/pilot/index.ts
@@ -31,3 +31,8 @@ export * as runtime from './runtime/index.js';
 
 // Phase 3 (issue #793): pilot-tier handoff token + manager.
 export * as handoff from './handoff/index.js';
+
+// Phase 4 (issue #713): verified skill extractor — deterministic transform,
+// no LLM calls. Gate call sites on `isSkillCuratorEnabled()` from
+// `src/harness/flags.ts` before invoking any export from this namespace.
+export * as curator from './curator/index.js';

--- a/tests/pilot/curator/extractor.test.ts
+++ b/tests/pilot/curator/extractor.test.ts
@@ -1,0 +1,454 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawn } from 'node:child_process';
+
+import {
+  computeSkillId,
+  listSkillsForDomain,
+  recordSuccessfulRun,
+} from '../../../src/pilot/curator/extractor';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-skmem-'));
+}
+
+const FIXED_NOW = Date.parse('2026-05-08T12:00:00Z');
+
+function record(over: Partial<Parameters<typeof recordSuccessfulRun>[0]> = {}) {
+  return {
+    txn_id: 'txn-001',
+    contract_id: 'amazon.cart-add',
+    intent: 'Add specific item to cart',
+    domain: 'amazon.com',
+    graph_node_anchor: 'a1b2c3d4',
+    ...over,
+  };
+}
+
+describe('computeSkillId', () => {
+  test('deterministic + stable across calls', () => {
+    const a = computeSkillId('a1b2c3', 'cid');
+    const b = computeSkillId('a1b2c3', 'cid');
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  test('different inputs → different ids', () => {
+    expect(computeSkillId('a', 'cid')).not.toBe(computeSkillId('b', 'cid'));
+    expect(computeSkillId('a', 'cidA')).not.toBe(computeSkillId('a', 'cidB'));
+  });
+});
+
+describe('recordSuccessfulRun — first run', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('creates SKILL.md + sidecar with status=candidate, verified_runs=1', () => {
+    const r = recordSuccessfulRun(record(), { rootDir: root, now: () => FIXED_NOW });
+    expect(r.created).toBe(true);
+    expect(r.promoted).toBe(false);
+    expect(r.record.frontmatter.status).toBe('candidate');
+    expect(r.record.frontmatter.verified_runs).toBe(1);
+    expect(fs.existsSync(r.record.filePath)).toBe(true);
+    expect(fs.existsSync(r.record.sidecarPath)).toBe(true);
+  });
+
+  test('SKILL.md ends up at <rootDir>/<domain>/<skill_id>.md', () => {
+    const r = recordSuccessfulRun(record(), { rootDir: root, now: () => FIXED_NOW });
+    const expectedDir = path.join(root, 'amazon.com');
+    expect(r.record.filePath.startsWith(expectedDir)).toBe(true);
+  });
+
+  test('derives a kebab-cased name from intent when none supplied', () => {
+    const r = recordSuccessfulRun(record({ intent: 'Click "Add to Cart" button' }), {
+      rootDir: root,
+      now: () => FIXED_NOW,
+    });
+    expect(r.record.frontmatter.name).toBe('click-add-to-cart-button');
+  });
+
+  test('honors an operator-supplied name', () => {
+    const r = recordSuccessfulRun(record({ name: 'amazon.cart-add' }), {
+      rootDir: root,
+      now: () => FIXED_NOW,
+    });
+    expect(r.record.frontmatter.name).toBe('amazon.cart-add');
+  });
+
+  test('truncates intent to 512 chars', () => {
+    const r = recordSuccessfulRun(record({ intent: 'x'.repeat(1000) }), {
+      rootDir: root,
+      now: () => FIXED_NOW,
+    });
+    expect(r.record.frontmatter.intent.length).toBe(512);
+  });
+});
+
+describe('recordSuccessfulRun — re-runs (dedup)', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('same (graph_node_anchor, contract_id) increments verified_runs in place', () => {
+    const a = recordSuccessfulRun(record({ txn_id: 't1' }), { rootDir: root, now: () => FIXED_NOW });
+    const b = recordSuccessfulRun(record({ txn_id: 't2' }), {
+      rootDir: root,
+      now: () => FIXED_NOW + 60_000,
+    });
+    expect(a.record.skill_id).toBe(b.record.skill_id);
+    expect(b.record.frontmatter.verified_runs).toBe(2);
+    expect(b.record.frontmatter.contract_ref).toBe('t2');
+    expect(b.created).toBe(false);
+    // Still only ONE SKILL.md on disk for this domain.
+    expect(listSkillsForDomain('amazon.com', { rootDir: root })).toHaveLength(1);
+  });
+
+  test('promotes from candidate → promoted at threshold (default 3)', () => {
+    let t = FIXED_NOW;
+    const ids: boolean[] = [];
+    for (let i = 1; i <= 4; i++) {
+      const r = recordSuccessfulRun(record({ txn_id: `t${i}` }), {
+        rootDir: root,
+        now: () => (t += 60_000),
+      });
+      ids.push(r.promoted);
+    }
+    // Transition fires on the third run; subsequent runs report promoted=false.
+    expect(ids).toEqual([false, false, true, false]);
+    const final = listSkillsForDomain('amazon.com', { rootDir: root })[0];
+    expect(final.frontmatter.status).toBe('promoted');
+    expect(final.frontmatter.verified_runs).toBe(4);
+  });
+
+  test('different contract_id → distinct skill files', () => {
+    recordSuccessfulRun(record({ contract_id: 'A' }), { rootDir: root, now: () => FIXED_NOW });
+    recordSuccessfulRun(record({ contract_id: 'B' }), { rootDir: root, now: () => FIXED_NOW });
+    expect(listSkillsForDomain('amazon.com', { rootDir: root })).toHaveLength(2);
+  });
+
+  test('different graph_node_anchor → distinct skill files', () => {
+    recordSuccessfulRun(record({ graph_node_anchor: 'aaaa' }), { rootDir: root, now: () => FIXED_NOW });
+    recordSuccessfulRun(record({ graph_node_anchor: 'bbbb' }), { rootDir: root, now: () => FIXED_NOW });
+    expect(listSkillsForDomain('amazon.com', { rootDir: root })).toHaveLength(2);
+  });
+
+  test('rolling 30-day window: a run outside the window does NOT count toward promotion', () => {
+    const old = FIXED_NOW - 31 * 24 * 60 * 60 * 1000;
+    recordSuccessfulRun(record({ txn_id: 'old' }), { rootDir: root, now: () => old });
+    recordSuccessfulRun(record({ txn_id: 'fresh' }), { rootDir: root, now: () => FIXED_NOW });
+    const list = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(list).toHaveLength(1);
+    expect(list[0].frontmatter.verified_runs).toBe(1);
+    expect(list[0].frontmatter.status).toBe('candidate');
+  });
+
+  test('archived skill stays archived even when re-run succeeds', () => {
+    // First run creates it as candidate, then we archive it manually.
+    const first = recordSuccessfulRun(record({ txn_id: 't1' }), { rootDir: root, now: () => FIXED_NOW });
+    const archived = first.record.frontmatter;
+    fs.writeFileSync(
+      first.record.filePath,
+      fs.readFileSync(first.record.filePath, 'utf8').replace('status: candidate', 'status: archived'),
+    );
+    const second = recordSuccessfulRun(record({ txn_id: 't2' }), {
+      rootDir: root,
+      now: () => FIXED_NOW + 60_000,
+      promotionThreshold: 1,
+    });
+    expect(second.record.frontmatter.status).toBe('archived');
+    expect(archived.status).toBe('candidate'); // sanity — original was candidate
+  });
+
+  test('preserves an existing distilled body when a re-run omits body', () => {
+    const distilledBody = '## Steps\n\n1. Open cart.\n2. Confirm the saved item.\n';
+    const first = recordSuccessfulRun(record({ txn_id: 't1', body: distilledBody }), {
+      rootDir: root,
+      now: () => FIXED_NOW,
+    });
+
+    const second = recordSuccessfulRun(record({ txn_id: 't2' }), {
+      rootDir: root,
+      now: () => FIXED_NOW + 60_000,
+    });
+
+    expect(second.created).toBe(false);
+    expect(fs.readFileSync(first.record.filePath, 'utf8')).toContain(distilledBody.trim());
+    expect(fs.readFileSync(first.record.filePath, 'utf8')).not.toContain(
+      'LLM distillation lands in PR-20b',
+    );
+  });
+});
+
+describe('recordSuccessfulRun — sidecar recovery', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('preserves verified_runs when sidecar disappears between runs', () => {
+    // First two runs to build up verified_runs=2.
+    let t = FIXED_NOW;
+    recordSuccessfulRun(record({ txn_id: 't1' }), { rootDir: root, now: () => t });
+    t += 60_000;
+    const second = recordSuccessfulRun(record({ txn_id: 't2' }), { rootDir: root, now: () => t });
+    expect(second.record.frontmatter.verified_runs).toBe(2);
+
+    // Sidecar is lost (e.g., partial fs sync, accidental delete).
+    fs.rmSync(second.record.sidecarPath);
+
+    // Next run must NOT reset to 1 — it should rebuild from frontmatter.
+    t += 60_000;
+    const third = recordSuccessfulRun(record({ txn_id: 't3' }), { rootDir: root, now: () => t });
+    expect(third.created).toBe(false);
+    expect(third.record.frontmatter.verified_runs).toBeGreaterThanOrEqual(2);
+    expect(fs.existsSync(third.record.sidecarPath)).toBe(true);
+  });
+
+  test('structurally malformed sidecar is treated as missing (no crash)', () => {
+    let t = FIXED_NOW;
+    const first = recordSuccessfulRun(record({ txn_id: 't1' }), { rootDir: root, now: () => t });
+    expect(first.record.frontmatter.verified_runs).toBe(1);
+
+    // Sidecar exists but is structurally invalid (older schema, partial write, etc.).
+    fs.writeFileSync(first.record.sidecarPath, '{}');
+
+    t += 60_000;
+    expect(() => recordSuccessfulRun(record({ txn_id: 't2' }), { rootDir: root, now: () => t })).not.toThrow();
+    const list = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(list).toHaveLength(1);
+    expect(list[0].frontmatter.verified_runs).toBeGreaterThanOrEqual(1);
+  });
+
+  test('preserves promoted status when sidecar is missing', () => {
+    let t = FIXED_NOW;
+    // 3 runs → promoted at default threshold.
+    for (let i = 1; i <= 3; i++) {
+      recordSuccessfulRun(record({ txn_id: `t${i}` }), { rootDir: root, now: () => t });
+      t += 60_000;
+    }
+    const list = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(list[0].frontmatter.status).toBe('promoted');
+    fs.rmSync(list[0].sidecarPath);
+
+    const next = recordSuccessfulRun(record({ txn_id: 't4' }), { rootDir: root, now: () => t });
+    expect(next.record.frontmatter.status).toBe('promoted');
+  });
+});
+
+describe('recordSuccessfulRun — concurrent writes', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('parallel calls for the same skill do not collide on a shared .tmp file', async () => {
+    // Drive several concurrent record calls. With a fixed `.tmp`
+    // path, two writers could clobber each other and at least one
+    // rename would either fail or destroy the other writer's data.
+    // With per-call unique temp paths, all calls succeed and the
+    // final state is consistent with N completed runs.
+    const N = 12;
+    const t = FIXED_NOW;
+    const promises: Promise<unknown>[] = [];
+    for (let i = 0; i < N; i++) {
+      promises.push(
+        Promise.resolve().then(() =>
+          recordSuccessfulRun(record({ txn_id: `t${i}` }), {
+            rootDir: root,
+            now: () => t + i,
+          }),
+        ),
+      );
+    }
+    const results = await Promise.all(promises);
+    expect(results).toHaveLength(N);
+    const list = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(list).toHaveLength(1);
+    expect(list[0].frontmatter.verified_runs).toBe(N);
+    // No stray `.tmp` files left in the domain dir.
+    const dir = path.dirname(list[0].filePath);
+    const stragglers = fs.readdirSync(dir).filter((f) => f.endsWith('.tmp'));
+    expect(stragglers).toEqual([]);
+  });
+
+  test('separate writer processes serialize read/merge/write updates', async () => {
+    const N = 8;
+    const script = `
+      const { recordSuccessfulRun } = require('./src/pilot/curator/extractor');
+      const [root, txn, now] = process.argv.slice(1);
+      recordSuccessfulRun({
+        txn_id: txn,
+        contract_id: 'amazon.cart-add',
+        intent: 'Add specific item to cart',
+        domain: 'amazon.com',
+        graph_node_anchor: 'a1b2c3d4',
+      }, { rootDir: root, now: () => Number(now) });
+    `;
+
+    await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        new Promise<void>((resolve, reject) => {
+          const child = spawn(
+            process.execPath,
+            [
+              '-r',
+              'ts-node/register/transpile-only',
+              '-e',
+              script,
+              root,
+              `process-${i}`,
+              String(FIXED_NOW + i),
+            ],
+            { cwd: process.cwd(), stdio: ['ignore', 'pipe', 'pipe'] },
+          );
+          let stderr = '';
+          child.stderr.on('data', (chunk) => {
+            stderr += chunk.toString();
+          });
+          child.on('error', reject);
+          child.on('close', (code) => {
+            if (code === 0) resolve();
+            else reject(new Error(stderr || `child exited ${code}`));
+          });
+        }),
+      ),
+    );
+
+    const list = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(list).toHaveLength(1);
+    expect(list[0].frontmatter.verified_runs).toBe(N);
+  });
+});
+
+describe('recordSuccessfulRun — domain validation', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test.each([
+    ['../escape'],
+    ['..'],
+    ['amazon.com/../etc'],
+    ['amazon.com/sub'],
+    ['amazon.com\\sub'],
+    ['has spaces'],
+    [''],
+  ])('rejects malformed domain "%s"', (badDomain) => {
+    expect(() =>
+      recordSuccessfulRun(record({ domain: badDomain }), { rootDir: root, now: () => FIXED_NOW }),
+    ).toThrow();
+    // No state should be left on disk for a rejected domain.
+    expect(fs.readdirSync(root)).toEqual([]);
+  });
+
+  test('listSkillsForDomain rejects malformed domain', () => {
+    expect(() => listSkillsForDomain('../escape', { rootDir: root })).toThrow();
+  });
+});
+
+describe('recordSuccessfulRun — sidecar entry validation', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('sidecar with malformed recent entries is treated as missing (no crash)', () => {
+    let t = FIXED_NOW;
+    const first = recordSuccessfulRun(record({ txn_id: 't1' }), { rootDir: root, now: () => t });
+
+    // Corrupt the sidecar so the array is present but contains garbage.
+    fs.writeFileSync(
+      first.record.sidecarPath,
+      JSON.stringify({
+        schema_version: 1,
+        skill_id: first.record.skill_id,
+        graph_node_anchor: 'a1b2c3d4',
+        contract_id: 'amazon.cart-add',
+        runs: {
+          count: 5,
+          window_start: '2026-04-01T00:00:00Z',
+          recent: [null, {}, { txn_id: 'no-ts', ok: true }],
+        },
+      }),
+    );
+
+    t += 60_000;
+    expect(() => recordSuccessfulRun(record({ txn_id: 't2' }), { rootDir: root, now: () => t })).not.toThrow();
+    const list = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(list).toHaveLength(1);
+  });
+});
+
+describe('recordSuccessfulRun — promotionThreshold bounds', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('rejects threshold above SKILL_RUN_LOG_MAX (would never promote)', () => {
+    expect(() =>
+      recordSuccessfulRun(record(), { rootDir: root, now: () => FIXED_NOW, promotionThreshold: 51 }),
+    ).toThrow();
+  });
+
+  test('rejects threshold below 1', () => {
+    expect(() =>
+      recordSuccessfulRun(record(), { rootDir: root, now: () => FIXED_NOW, promotionThreshold: 0 }),
+    ).toThrow();
+  });
+
+  test('accepts threshold equal to SKILL_RUN_LOG_MAX', () => {
+    expect(() =>
+      recordSuccessfulRun(record(), { rootDir: root, now: () => FIXED_NOW, promotionThreshold: 50 }),
+    ).not.toThrow();
+  });
+});
+
+describe('listSkillsForDomain', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('returns [] for an unseen domain', () => {
+    expect(listSkillsForDomain('nope.example', { rootDir: root })).toEqual([]);
+  });
+
+  test('skips files whose sidecar is missing or malformed', () => {
+    recordSuccessfulRun(record(), { rootDir: root, now: () => FIXED_NOW });
+    // Corrupt the sidecar
+    const list = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(list).toHaveLength(1);
+    fs.writeFileSync(list[0].sidecarPath, '{not json');
+    expect(listSkillsForDomain('amazon.com', { rootDir: root })).toEqual([]);
+  });
+});

--- a/tests/pilot/curator/skill-md.test.ts
+++ b/tests/pilot/curator/skill-md.test.ts
@@ -1,0 +1,200 @@
+import {
+  FrontmatterError,
+  parseSkillMd,
+  stringifySkillMd,
+  validateFrontmatter,
+} from '../../../src/pilot/curator/skill-md';
+import { SKILL_SCHEMA_VERSION, type SkillFrontmatter } from '../../../src/pilot/curator/types';
+
+function fm(over: Partial<SkillFrontmatter> = {}): SkillFrontmatter {
+  return {
+    schema_version: SKILL_SCHEMA_VERSION,
+    name: 'amazon.cart-add',
+    domain: 'amazon.com',
+    intent: 'Add specific item to cart',
+    status: 'candidate',
+    verified_runs: 1,
+    last_verified_at: '2026-05-08T12:00:00Z',
+    contract_ref: 'txn-001',
+    graph_node_anchor: 'a1b2',
+    author: 'agent',
+    ...over,
+  };
+}
+
+describe('parseSkillMd', () => {
+  test('round-trips a minimal valid SKILL.md', () => {
+    const text = stringifySkillMd({ frontmatter: fm(), body: '## Steps\nClick.' });
+    const parsed = parseSkillMd(text);
+    expect(parsed.frontmatter.name).toBe('amazon.cart-add');
+    expect(parsed.frontmatter.status).toBe('candidate');
+    expect(parsed.body).toContain('## Steps');
+  });
+
+  test('round-trips budget under dotted-path format', () => {
+    const text = stringifySkillMd({
+      frontmatter: fm({ budget: { tokens_typical: 4200, wall_ms_typical: 31000 } }),
+      body: '',
+    });
+    const parsed = parseSkillMd(text);
+    expect(parsed.frontmatter.budget?.tokens_typical).toBe(4200);
+    expect(parsed.frontmatter.budget?.wall_ms_typical).toBe(31000);
+  });
+
+  test('throws when the file does not start with `---`', () => {
+    expect(() => parseSkillMd('# missing frontmatter')).toThrow(FrontmatterError);
+  });
+
+  test('throws when the closing `---` is missing', () => {
+    const malformed = '---\nname: x\nstatus: candidate\n';
+    expect(() => parseSkillMd(malformed)).toThrow(FrontmatterError);
+  });
+
+  test('quoted strings round-trip through colons', () => {
+    const text = stringifySkillMd({
+      frontmatter: fm({ intent: 'colon: in the middle' }),
+      body: '',
+    });
+    const parsed = parseSkillMd(text);
+    expect(parsed.frontmatter.intent).toBe('colon: in the middle');
+  });
+
+  test('multiline strings are quoted and round-trip as one frontmatter value', () => {
+    const text = stringifySkillMd({
+      frontmatter: fm({ intent: 'step 1\nstep 2' }),
+      body: '',
+    });
+    expect(text).toContain('intent: "step 1\\nstep 2"');
+    const parsed = parseSkillMd(text);
+    expect(parsed.frontmatter.intent).toBe('step 1\nstep 2');
+  });
+
+  test('comments and blank lines in frontmatter are tolerated', () => {
+    const text = `---
+# top comment
+schema_version: 1
+name: amazon.cart-add
+domain: amazon.com
+
+intent: simple
+status: candidate
+verified_runs: 1
+last_verified_at: 2026-05-08T12:00:00Z
+contract_ref: txn-001
+graph_node_anchor: a1b2
+author: agent
+---
+body here
+`;
+    const parsed = parseSkillMd(text);
+    expect(parsed.frontmatter.intent).toBe('simple');
+  });
+});
+
+describe('validateFrontmatter — schema rules', () => {
+  test('rejects schema_version != 1', () => {
+    expect(() => validateFrontmatter({ ...fm(), schema_version: 2 })).toThrow(/schema_version/);
+  });
+
+  test('rejects illegal name', () => {
+    expect(() => validateFrontmatter({ ...fm(), name: 'has spaces' })).toThrow(/name/);
+    expect(() => validateFrontmatter({ ...fm(), name: 'a'.repeat(65) })).toThrow(/name/);
+  });
+
+  test('rejects intent over 512 chars', () => {
+    expect(() => validateFrontmatter({ ...fm(), intent: 'x'.repeat(513) })).toThrow(/intent/);
+  });
+
+  test('rejects bad status value', () => {
+    expect(() => validateFrontmatter({ ...fm(), status: 'bogus' })).toThrow(/status/);
+  });
+
+  test('rejects negative verified_runs', () => {
+    expect(() => validateFrontmatter({ ...fm(), verified_runs: -1 })).toThrow(/verified_runs/);
+  });
+
+  test('rejects last_verified_at without Z suffix', () => {
+    expect(() =>
+      validateFrontmatter({ ...fm(), last_verified_at: '2026-05-08T12:00:00+09:00' }),
+    ).toThrow(/last_verified_at/);
+  });
+
+  test('rejects non-hex graph_node_anchor', () => {
+    expect(() => validateFrontmatter({ ...fm(), graph_node_anchor: 'not-hex!' })).toThrow(
+      /graph_node_anchor/,
+    );
+  });
+
+  test('rejects bogus author', () => {
+    expect(() => validateFrontmatter({ ...fm(), author: 'admin' })).toThrow(/author/);
+  });
+
+  test('accepts every valid status', () => {
+    expect(() => validateFrontmatter({ ...fm(), status: 'candidate' })).not.toThrow();
+    expect(() => validateFrontmatter({ ...fm(), status: 'promoted' })).not.toThrow();
+    expect(() => validateFrontmatter({ ...fm(), status: 'archived' })).not.toThrow();
+  });
+});
+
+describe('parseSkillMd — prototype pollution defense', () => {
+  test.each([
+    ['__proto__.polluted: 1'],
+    ['constructor.polluted: 2'],
+    ['prototype.polluted: 3'],
+    ['budget.__proto__.polluted: 4'],
+  ])('rejects forbidden key "%s"', (line) => {
+    const text =
+      '---\n' +
+      'schema_version: 1\n' +
+      'name: amazon.cart-add\n' +
+      'domain: amazon.com\n' +
+      'intent: x\n' +
+      'status: candidate\n' +
+      'verified_runs: 1\n' +
+      'last_verified_at: 2026-05-08T12:00:00Z\n' +
+      'contract_ref: txn-001\n' +
+      'graph_node_anchor: a1b2\n' +
+      'author: agent\n' +
+      line +
+      '\n---\n\nbody\n';
+    expect(() => parseSkillMd(text)).toThrow(FrontmatterError);
+    // Sanity: Object.prototype was not polluted as a side effect.
+    expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});
+
+describe('parseSkillMd — preserves digit-only string fields', () => {
+  test('contract_ref written as digits round-trips as a string', () => {
+    const text = stringifySkillMd({
+      frontmatter: fm({ contract_ref: '12345' }),
+      body: '',
+    });
+    const parsed = parseSkillMd(text);
+    expect(parsed.frontmatter.contract_ref).toBe('12345');
+    expect(typeof parsed.frontmatter.contract_ref).toBe('string');
+  });
+
+  test('graph_node_anchor with only digits round-trips as a string', () => {
+    const text = stringifySkillMd({
+      frontmatter: fm({ graph_node_anchor: '0123456789' }),
+      body: '',
+    });
+    const parsed = parseSkillMd(text);
+    expect(parsed.frontmatter.graph_node_anchor).toBe('0123456789');
+    expect(typeof parsed.frontmatter.graph_node_anchor).toBe('string');
+  });
+
+  test('boolean-like string field "true" round-trips as a string (not coerced)', () => {
+    // `name` is documented as a string and the NAME_PATTERN regex
+    // accepts the literal token "true". Without preserving raw
+    // strings, `coerce` turned this into a boolean and the next read
+    // tripped `mustString`, breaking re-record for the skill.
+    const text = stringifySkillMd({
+      frontmatter: fm({ name: 'true' }),
+      body: '',
+    });
+    const parsed = parseSkillMd(text);
+    expect(parsed.frontmatter.name).toBe('true');
+    expect(typeof parsed.frontmatter.name).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary

- Re-implements closed PR #761 under `src/pilot/curator/` (pilot tier, not `src/skill-memory/`).
- The extractor is a **deterministic transform — no LLM calls** (P4 compliant). LLM distillation is scoped to the separate PR-20b / #776 package.
- Turns contract-verified successful runs into `SKILL.md` candidates under `~/.openchrome/skills/<domain>/` with candidate→promoted promotion after N re-runs in a 30-day rolling window.
- Multi-process safe: per-skill directory lock + unique-tmp atomic writes.
- Sidecar recovery: missing or schema-invalid JSON is rebuilt from frontmatter so `verified_runs` and promotion state are never silently reset.

## Files changed

| File | Role |
|------|------|
| `src/pilot/curator/types.ts` | `SkillFrontmatter`, `SkillSidecar`, `SkillRecord` types |
| `src/pilot/curator/skill-md.ts` | SKILL.md frontmatter parser/serializer (no YAML dep, prototype-pollution hardened) |
| `src/pilot/curator/extractor.ts` | `recordSuccessfulRun` + `listSkillsForDomain` |
| `src/pilot/curator/index.ts` | Barrel with gate comment re `isSkillCuratorEnabled()` |
| `src/pilot/index.ts` | Registers `curator` namespace (Phase 4) |
| `tests/pilot/curator/extractor.test.ts` | 33 tests |
| `tests/pilot/curator/skill-md.test.ts` | 23 tests |

## Verification

- `tsc --noEmit` → clean (0 errors)
- `lint:tier` (depcruise) → ✔ no violations (303 modules, 627 deps)
- `jest tests/pilot/curator/` → **56 passed, 0 failed**

## References

- Replaces: #761 (closed)
- Epic: #712
- Related: #774, #780
- Flag gate: `isSkillCuratorEnabled()` in `src/harness/flags.ts` (`OPENCHROME_SKILL_CURATOR`)

## Test plan

- [ ] `npx jest tests/pilot/curator/` passes locally
- [ ] `tsc --noEmit` clean
- [ ] `lint:tier` no violations
- [ ] Confirm no LLM API calls in `src/pilot/curator/extractor.ts` (grep for `fetch`, `openai`, `anthropic` → none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)