### PR TITLE
feat(pilot): skill recall ranking (Phase 4, replaces #762 ranking half)

### DIFF
--- a/src/pilot/curator/index.ts
+++ b/src/pilot/curator/index.ts
@@ -1,14 +1,14 @@
 /**
- * Pilot curator barrel (#712 epic, Phase 4 — verified skill extractor).
+ * Pilot curator barrel (#712 epic, Phase 4 — verified skill extractor
+ * + recall ranking).
  *
  * The extractor turns successful, contract-verified runs into reusable
  * SKILL.md candidates. It is a deterministic transform (no LLM calls).
+ * The recall layer ranks stored skills for LLM-facing payloads.
  *
  * Call sites that integrate with the contract runtime MUST gate on
  * `isSkillCuratorEnabled()` from `src/harness/flags.ts` before
  * invoking any export from this module.
- *
- * Recall (#714) + curator stats (#715) ride follow-up commits.
  */
 
 export {
@@ -42,3 +42,15 @@ export type {
   SkillSidecar,
   SkillStatus,
 } from './types';
+
+export {
+  SkillRecallStore,
+  buildRecallPayload,
+  rankSkillsForRecall,
+} from './recall';
+export type {
+  RankSkillsInput,
+  RankSkillsOptions,
+  SkillRecallPayload,
+  SkillRecallResult,
+} from './recall';

--- a/src/pilot/curator/recall.ts
+++ b/src/pilot/curator/recall.ts
@@ -1,0 +1,222 @@
+/**
+ * Skill recall ranking (#714 v2, Phase 4 — replaces the ranking half of
+ * closed PR #762).
+ *
+ * On every navigate, the host asks the recall layer for the ranked index
+ * of skills that apply to the destination domain. The first answer per
+ * `(session_id, domain)` pair is **frozen** for that session — preserves
+ * provider prefix-cache, makes recall payloads deterministic, and matches
+ * the Hermes-Agent pattern (#714 v2).
+ *
+ * Wire format (compact JSON, kept under the 8 KB cap so the LLM eats
+ * tokens only when there's something to know):
+ *
+ *   {
+ *     domain: "amazon.com",
+ *     ranked_skills: [
+ *       { skillId, name, successCount, lastUsedAt, frozenSnapshotPath }
+ *     ]
+ *   }
+ *
+ * Ordering: `successCount DESC, lastUsedAt DESC, skillId ASC`
+ * (the `skillId ASC` tiebreak makes the payload byte-stable).
+ *
+ * Drop policy when the top-N don't fit: drop from the BOTTOM of the
+ * ranked list one at a time until the payload fits the cap.
+ * Minimum 1 skill is always included — even if that skill alone
+ * exceeds the cap, in which case `oversized: true` is set so the host
+ * can emit the `skill_recall_oversized` audit event (#714 v2 PR plan).
+ *
+ * Gated by `isSkillCuratorEnabled()` — callers MUST check before use.
+ */
+
+import { isSkillCuratorEnabled } from '../../harness/flags.js';
+import { SkillMemoryStore } from '../../core/skill-memory/store.js';
+import type { SkillRecord } from '../../core/skill-memory/types.js';
+
+export { isSkillCuratorEnabled };
+
+const RECALL_URI_PREFIX = 'openchrome://skills/';
+
+const DEFAULT_TOP_K = 5;
+const DEFAULT_MAX_BYTES = 8 * 1024;
+
+/** Wire entry for a single skill in the recall payload. */
+export interface SkillRecallResult {
+  skillId: string;
+  name: string;
+  successCount: number;
+  lastUsedAt: number;
+  frozenSnapshotPath: string | null;
+  /** MCP-resource URI for the skill. */
+  expand_via: string;
+}
+
+export interface SkillRecallPayload {
+  domain: string;
+  ranked_skills: SkillRecallResult[];
+  /** True iff the payload was forcibly truncated below `topK` to fit `maxBytes`. */
+  oversized?: boolean;
+}
+
+export interface RankSkillsOptions {
+  /** Root directory for per-domain skills.json files. */
+  rootDir?: string;
+  /** Top N skills considered before drop policy. Default 5. */
+  topK?: number;
+  /** Hard byte cap on the rendered JSON. Default 8 KB. */
+  maxBytes?: number;
+}
+
+export interface RankSkillsInput {
+  domain: string;
+  /** Current state hash — reserved for future graph-aware ranking. */
+  currentStateHash?: string;
+  /** Current URL — reserved for future URL-aware ranking. */
+  currentUrl?: string;
+  /** Cap the number of results returned. */
+  limit?: number;
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function rank(records: SkillRecord[]): SkillRecord[] {
+  return [...records].sort((a, b) => {
+    if (a.successCount !== b.successCount) return b.successCount - a.successCount;
+    if (a.lastUsedAt !== b.lastUsedAt) return b.lastUsedAt - a.lastUsedAt;
+    return a.skillId.localeCompare(b.skillId);
+  });
+}
+
+function buildEntry(rec: SkillRecord): SkillRecallResult {
+  return {
+    skillId: rec.skillId,
+    name: rec.name,
+    successCount: rec.successCount,
+    lastUsedAt: rec.lastUsedAt,
+    frozenSnapshotPath: rec.frozenSnapshotPath,
+    expand_via: `${RECALL_URI_PREFIX}${rec.domain}/${rec.skillId}`,
+  };
+}
+
+/**
+ * Build the recall payload for `domain` from a pre-fetched list of records.
+ * Returns null when the curator flag is disabled or when there are no skills.
+ *
+ * Hosts that already have records in memory should call this directly.
+ * End-to-end callers should use `rankSkillsForRecall` which handles store
+ * access and flag gating.
+ */
+export function buildRecallPayload(
+  domain: string,
+  records: SkillRecord[],
+  opts: RankSkillsOptions = {},
+): SkillRecallPayload | null {
+  if (!isSkillCuratorEnabled()) return null;
+  if (records.length === 0) return null;
+
+  const topK = Math.max(1, opts.topK ?? envInt('OPENCHROME_SKILL_RECALL_TOPK', DEFAULT_TOP_K));
+  // Honor caller-provided `maxBytes` as a hard cap. Only env / default
+  // fall-throughs are clamped (to a small positive minimum); any
+  // explicit caller value — including very small ones — is respected
+  // so embeddings into fixed-size envelopes can rely on the cap.
+  const maxBytes =
+    opts.maxBytes !== undefined
+      ? Math.max(1, opts.maxBytes)
+      : Math.max(1, envInt('OPENCHROME_SKILL_RECALL_BYTES', DEFAULT_MAX_BYTES));
+
+  const ranked = rank(records).slice(0, topK);
+  const entries = ranked.map(buildEntry);
+
+  // Drop from the bottom until the payload fits, but always keep ≥1.
+  // The serialized `,"oversized":true` adds ~18 bytes; we set the flag
+  // BEFORE the truncation loop in any case where dropping happens, so
+  // the size check accounts for the flag's overhead and we can never
+  // return an over-cap payload merely because the flag was appended
+  // after truncation finished. (The intentional escape hatch is the
+  // single-entry case: even one skill plus the flag may exceed
+  // maxBytes — we ship it anyway with `oversized: true` set.)
+  let payload: SkillRecallPayload = { domain, ranked_skills: entries };
+  const size = () => Buffer.byteLength(JSON.stringify(payload), 'utf8');
+  if (size() > maxBytes) {
+    payload = { ...payload, oversized: true };
+    while (size() > maxBytes && payload.ranked_skills.length > 1) {
+      payload.ranked_skills = payload.ranked_skills.slice(0, -1);
+    }
+  }
+  return payload;
+}
+
+/** Frozen-snapshot store keyed on `(sessionId, domain)`. */
+export class SkillRecallStore {
+  private readonly snapshots = new Map<string, SkillRecallPayload | null>();
+
+  /**
+   * Resolve a frozen snapshot. The first call computes via
+   * `compute()`; subsequent calls for the same key return the same
+   * reference (or null when recall was disabled / empty).
+   */
+  resolve(
+    sessionId: string,
+    domain: string,
+    compute: () => SkillRecallPayload | null,
+  ): SkillRecallPayload | null {
+    const key = `${sessionId}|${domain}`;
+    if (this.snapshots.has(key)) return this.snapshots.get(key) ?? null;
+    const fresh = compute();
+    this.snapshots.set(key, fresh);
+    return fresh;
+  }
+
+  /** Drop snapshots for a session (e.g., session deleted by the manager). */
+  invalidateSession(sessionId: string): void {
+    const prefix = `${sessionId}|`;
+    for (const k of [...this.snapshots.keys()]) {
+      if (k.startsWith(prefix)) this.snapshots.delete(k);
+    }
+  }
+
+  /** Test hook: drop everything. */
+  clear(): void {
+    this.snapshots.clear();
+  }
+
+  /** For tests / inspection. */
+  size(): number {
+    return this.snapshots.size;
+  }
+}
+
+/**
+ * Rank skills for recall by reading from the `SkillMemoryStore` and
+ * applying recency × success_count scoring.
+ *
+ * Returns null when:
+ * - `isSkillCuratorEnabled()` is false, OR
+ * - no skills are stored for the domain.
+ *
+ * This function is *read-only over the store* — it does not mutate any
+ * skill record.
+ */
+export function rankSkillsForRecall(
+  input: RankSkillsInput,
+  opts: RankSkillsOptions = {},
+): SkillRecallPayload | null {
+  if (!isSkillCuratorEnabled()) return null;
+
+  const store = new SkillMemoryStore({
+    domain: input.domain,
+    ...(opts.rootDir !== undefined ? { rootDir: opts.rootDir } : {}),
+  });
+
+  const limit = input.limit !== undefined ? input.limit : undefined;
+  const records = store.list(limit !== undefined ? { limit } : {});
+  if (records.length === 0) return null;
+
+  return buildRecallPayload(input.domain, records, opts);
+}

--- a/tests/pilot/curator/recall.test.ts
+++ b/tests/pilot/curator/recall.test.ts
@@ -1,0 +1,302 @@
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { resetFlagsCache } from '../../../src/harness/flags';
+import { SkillMemoryStore } from '../../../src/core/skill-memory/store';
+import type { SkillRecord } from '../../../src/core/skill-memory/types';
+import {
+  SkillRecallStore,
+  buildRecallPayload,
+  rankSkillsForRecall,
+} from '../../../src/pilot/curator/recall';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-recall-'));
+}
+
+function mkRec(
+  skillId: string,
+  successCount: number,
+  lastUsedAt: number,
+  domain = 'x.com',
+): SkillRecord {
+  return {
+    skillId,
+    domain,
+    name: `skill-${skillId}`,
+    steps: [],
+    contractId: 'cid',
+    successCount,
+    lastUsedAt,
+    frozenSnapshotPath: null,
+  };
+}
+
+// Ensure pilot flag is active for all tests
+beforeEach(() => {
+  resetFlagsCache();
+  process.env.OPENCHROME_PILOT = '1';
+});
+
+afterEach(() => {
+  resetFlagsCache();
+  delete process.env.OPENCHROME_PILOT;
+});
+
+/* ------------------------------------------------------------------ */
+/* buildRecallPayload — ordering                                       */
+/* ------------------------------------------------------------------ */
+
+describe('buildRecallPayload — ordering', () => {
+  test('successCount DESC, lastUsedAt DESC, skillId ASC', () => {
+    const records: SkillRecord[] = [
+      mkRec('aaa', 5, 1000),
+      mkRec('bbb', 5, 2000),
+      mkRec('ccc', 9, 1000),
+    ];
+    const r = buildRecallPayload('x.com', records, { topK: 5 });
+    expect(r!.ranked_skills.map((e) => e.skillId)).toEqual(['ccc', 'bbb', 'aaa']);
+  });
+
+  test('tiebreak by skillId ASC for stability', () => {
+    const records: SkillRecord[] = [
+      mkRec('zzz', 3, 1000),
+      mkRec('aaa', 3, 1000),
+    ];
+    const r = buildRecallPayload('x.com', records, {});
+    expect(r!.ranked_skills.map((e) => e.skillId)).toEqual(['aaa', 'zzz']);
+  });
+
+  test('entries include expand_via URI', () => {
+    const records: SkillRecord[] = [mkRec('abc', 5, 1000)];
+    const r = buildRecallPayload('x.com', records, {});
+    expect(r!.ranked_skills[0].expand_via).toBe('openchrome://skills/x.com/abc');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* buildRecallPayload — flag gating                                    */
+/* ------------------------------------------------------------------ */
+
+describe('buildRecallPayload — flag gating', () => {
+  test('returns null when pilot disabled', () => {
+    resetFlagsCache();
+    delete process.env.OPENCHROME_PILOT;
+    const records: SkillRecord[] = [mkRec('aaa', 5, 1000)];
+    const r = buildRecallPayload('x.com', records, {});
+    expect(r).toBeNull();
+    // restore
+    process.env.OPENCHROME_PILOT = '1';
+    resetFlagsCache();
+  });
+
+  test('returns null for empty records list', () => {
+    expect(buildRecallPayload('x.com', [], {})).toBeNull();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* buildRecallPayload — drop policy                                    */
+/* ------------------------------------------------------------------ */
+
+describe('buildRecallPayload — drop policy', () => {
+  test('drops from bottom until under maxBytes', () => {
+    const records: SkillRecord[] = [];
+    for (let i = 0; i < 5; i++) {
+      records.push(mkRec(`s${i}`, 5 - i, 1000));
+    }
+    const r = buildRecallPayload('x.com', records, { maxBytes: 200 });
+    expect(r).not.toBeNull();
+    expect(r!.ranked_skills[0].skillId).toBe('s0');
+    expect(r!.oversized).toBe(true);
+  });
+
+  test('always keeps at least 1 skill and flags oversized', () => {
+    const records: SkillRecord[] = [mkRec('only-one', 5, 1000)];
+    const r = buildRecallPayload('x.com', records, { maxBytes: 1 });
+    expect(r!.ranked_skills).toHaveLength(1);
+    expect(r!.oversized).toBe(true);
+  });
+
+  test('no oversized flag when payload fits cleanly', () => {
+    const records: SkillRecord[] = [mkRec('aaa', 5, 1000)];
+    const r = buildRecallPayload('x.com', records, { maxBytes: 8 * 1024 });
+    expect(r!.oversized).toBeUndefined();
+  });
+
+  test('truncated payload with oversized flag stays within maxBytes', () => {
+    const records: SkillRecord[] = [];
+    for (let i = 0; i < 8; i++) {
+      records.push(mkRec(`skill${i}`, 8 - i, 1000));
+    }
+    for (let cap = 250; cap <= 600; cap += 5) {
+      const r = buildRecallPayload('x.com', records, { maxBytes: cap });
+      expect(r).not.toBeNull();
+      const size = Buffer.byteLength(JSON.stringify(r), 'utf8');
+      if (r!.ranked_skills.length > 1) {
+        expect(size).toBeLessThanOrEqual(cap);
+      }
+      if (r!.ranked_skills.length < records.length) {
+        expect(r!.oversized).toBe(true);
+      }
+    }
+  });
+
+  test('honors caller maxBytes below default floor', () => {
+    const records: SkillRecord[] = [];
+    for (let i = 0; i < 4; i++) {
+      records.push(mkRec(`s${i}`, 4 - i, 1000));
+    }
+    const tiny = buildRecallPayload('x.com', records, { maxBytes: 10 });
+    expect(tiny).not.toBeNull();
+    expect(tiny!.oversized).toBe(true);
+    expect(tiny!.ranked_skills).toHaveLength(1);
+  });
+
+  test('topK caps the candidate pool', () => {
+    const records: SkillRecord[] = [];
+    for (let i = 0; i < 10; i++) {
+      records.push(mkRec(`s${i}`, 10 - i, 1000));
+    }
+    const r = buildRecallPayload('x.com', records, { topK: 3 });
+    expect(r!.ranked_skills).toHaveLength(3);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* SkillRecallStore — frozen snapshot                                  */
+/* ------------------------------------------------------------------ */
+
+describe('SkillRecallStore — frozen snapshot', () => {
+  test('first resolve invokes compute; subsequent calls return same reference', () => {
+    const store = new SkillRecallStore();
+    let calls = 0;
+    const r1 = store.resolve('s1', 'amazon.com', () => {
+      calls++;
+      return { domain: 'amazon.com', ranked_skills: [] };
+    });
+    const r2 = store.resolve('s1', 'amazon.com', () => {
+      calls++;
+      return { domain: 'amazon.com', ranked_skills: [{ skillId: 'updated' } as never] };
+    });
+    expect(calls).toBe(1);
+    expect(r1).toBe(r2);
+  });
+
+  test('different sessions get independent snapshots', () => {
+    const store = new SkillRecallStore();
+    const a = store.resolve('s1', 'amazon.com', () => ({ domain: 'amazon.com', ranked_skills: [] }));
+    const b = store.resolve('s2', 'amazon.com', () => ({ domain: 'amazon.com', ranked_skills: [] }));
+    expect(a).not.toBe(b);
+    expect(store.size()).toBe(2);
+  });
+
+  test('different domains get independent snapshots within one session', () => {
+    const store = new SkillRecallStore();
+    store.resolve('s1', 'a.com', () => ({ domain: 'a.com', ranked_skills: [] }));
+    store.resolve('s1', 'b.com', () => ({ domain: 'b.com', ranked_skills: [] }));
+    expect(store.size()).toBe(2);
+  });
+
+  test('null payloads are also memoized (no recompute)', () => {
+    const store = new SkillRecallStore();
+    let calls = 0;
+    store.resolve('s1', 'a.com', () => { calls++; return null; });
+    store.resolve('s1', 'a.com', () => { calls++; return null; });
+    expect(calls).toBe(1);
+  });
+
+  test('invalidateSession drops all snapshots for that session', () => {
+    const store = new SkillRecallStore();
+    store.resolve('s1', 'a.com', () => ({ domain: 'a.com', ranked_skills: [] }));
+    store.resolve('s1', 'b.com', () => ({ domain: 'b.com', ranked_skills: [] }));
+    store.resolve('s2', 'a.com', () => ({ domain: 'a.com', ranked_skills: [] }));
+    store.invalidateSession('s1');
+    expect(store.size()).toBe(1);
+  });
+
+  test('clear() drops all snapshots', () => {
+    const store = new SkillRecallStore();
+    store.resolve('s1', 'a.com', () => ({ domain: 'a.com', ranked_skills: [] }));
+    store.resolve('s2', 'b.com', () => ({ domain: 'b.com', ranked_skills: [] }));
+    store.clear();
+    expect(store.size()).toBe(0);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* rankSkillsForRecall — integration with SkillMemoryStore            */
+/* ------------------------------------------------------------------ */
+
+describe('rankSkillsForRecall — store integration', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = tempRoot();
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  async function seedStore(domain: string, count: number, baseSuccess = 1): Promise<void> {
+    const store = new SkillMemoryStore({ domain, rootDir: root });
+    for (let i = 0; i < count; i++) {
+      const result = await store.record({
+        domain,
+        name: `skill-${i}`,
+        steps: [],
+        contractId: `cid-${i}`,
+        successCount: baseSuccess + i,
+        lastUsedAt: Date.now() + i * 1000,
+        frozenSnapshotPath: null,
+      });
+      // bump success so list returns non-trivial ordering
+      await store.markUsed(result.skill_id, Date.now() + i * 1000, true);
+    }
+  }
+
+  test('returns null when no skills stored', () => {
+    const r = rankSkillsForRecall({ domain: 'empty.com' }, { rootDir: root });
+    expect(r).toBeNull();
+  });
+
+  test('returns null when pilot disabled', () => {
+    resetFlagsCache();
+    delete process.env.OPENCHROME_PILOT;
+    const r = rankSkillsForRecall({ domain: 'x.com' }, { rootDir: root });
+    expect(r).toBeNull();
+    process.env.OPENCHROME_PILOT = '1';
+    resetFlagsCache();
+  });
+
+  test('returns ranked payload for stored skills', async () => {
+    await seedStore('amazon.com', 3);
+    const r = rankSkillsForRecall({ domain: 'amazon.com' }, { rootDir: root });
+    expect(r).not.toBeNull();
+    expect(r!.domain).toBe('amazon.com');
+    expect(r!.ranked_skills.length).toBeGreaterThan(0);
+    // Top skill should be highest successCount
+    const scores = r!.ranked_skills.map((s) => s.successCount);
+    for (let i = 1; i < scores.length; i++) {
+      expect(scores[i - 1]).toBeGreaterThanOrEqual(scores[i]);
+    }
+  });
+
+  test('respects topK option', async () => {
+    await seedStore('x.com', 10);
+    const r = rankSkillsForRecall({ domain: 'x.com' }, { rootDir: root, topK: 3 });
+    expect(r).not.toBeNull();
+    expect(r!.ranked_skills.length).toBeLessThanOrEqual(3);
+  });
+
+  test('each entry has expand_via URI', async () => {
+    await seedStore('y.com', 2);
+    const r = rankSkillsForRecall({ domain: 'y.com' }, { rootDir: root });
+    expect(r).not.toBeNull();
+    for (const entry of r!.ranked_skills) {
+      expect(entry.expand_via).toMatch(/^openchrome:\/\/skills\/y\.com\//);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Lands `src/pilot/curator/recall.ts` — deterministic recall ranking over the `SkillMemoryStore` (already merged via #800)
- Ranking: `successCount DESC, lastUsedAt DESC, skillId ASC` (tiebreak keeps payload byte-stable)
- Byte-cap drop policy: drops from bottom of ranked list until payload ≤ 8 KB; always keeps ≥1 skill; sets `oversized: true` when truncated
- `SkillRecallStore` frozen-snapshot memoisation per `(sessionId, domain)` — preserves provider prefix-cache
- `rankSkillsForRecall({ domain, currentStateHash?, currentUrl?, limit })` as the primary public entry point
- Gated by `isSkillCuratorEnabled()` from `src/harness/flags.ts`; read-only over the store (no mutations)
- Barrel exports added to `src/pilot/curator/index.ts`

## References

- Closes the ranking half of #762 (storage half already landed via #800)
- Builds on extractor landed in #774 and #780
- Storage layer: #800

## Test plan

- [ ] `npx jest tests/pilot/curator/recall.test.ts` — 22 tests, all passing
- [ ] `tsc --noEmit` — zero type errors
- [ ] `depcruise --config .dependency-cruiser.cjs src` — 0 tier violations
- [ ] Ordering: `successCount DESC, lastUsedAt DESC, skillId ASC` verified
- [ ] Drop policy: `oversized` flag set before truncation loop so byte-cap accounting is exact
- [ ] Frozen-snapshot store: null payloads memoised, `invalidateSession` scoped correctly
- [ ] Flag gating: returns null when `isSkillCuratorEnabled()` is false

🤖 Generated with [Claude Code](https://claude.com/claude-code)