### PR TITLE
feat(core): audit-log-backed SkillStatsResolver (Phase 4, replaces #766)

### DIFF
--- a/src/core/skill-memory/stats-resolver.ts
+++ b/src/core/skill-memory/stats-resolver.ts
@@ -1,0 +1,293 @@
+/**
+ * Audit-log-backed SkillStatsResolver (Phase 4, replaces #766).
+ *
+ * Derives canonical (successCount, lastUsedAt) per skill by walking the
+ * audit log JSONL in a single streaming pass. Defensive against in-DB counter
+ * races — this module only reads; callers decide what to do with disagreements.
+ *
+ * Design:
+ *   - Streams ~/.openchrome/audit.log (or configured path) in 64 KB chunks.
+ *   - Filters `tool === 'skill_run'` entries within the configured windows.
+ *   - Groups by skill_id → (successesInWindow, failuresInWindow, lastRunAt).
+ *   - Index is built lazily on first call and shared across all per-skill
+ *     lookups: O(M+N) rather than O(N×M).
+ *   - Demote-history fields deferred to a future history store; default
+ *     conservatively to 0 / false so the curator's double-demote path stays
+ *     inactive.
+ *
+ * Core-tier: no pilot imports, no flag gate (read-only fact computation).
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
+
+import { getGlobalConfig } from '../../config/global';
+import type { SkillRecord } from './types';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Per-skill run statistics derived from the audit log. */
+export interface SkillRunStats {
+  /** Number of successful runs within the fail window. */
+  successesInWindow: number;
+  /** Number of postcondition-violation runs within the fail window. */
+  failuresInWindow: number;
+  /**
+   * Most-recent skill_run timestamp (ms epoch) within the stats window,
+   * or null when the skill has no recorded runs in that window.
+   */
+  lastRunAt: number | null;
+  /**
+   * Demotions within the double-demote archive window. Deferred to the
+   * curator's own history store — defaults to 0 until that lands.
+   */
+  demotesInDoubleDemoteWindow: number;
+  /**
+   * Whether there was an intervening promotion between the last two
+   * demotions. Deferred — defaults to false.
+   */
+  hadInterveningPromotion: boolean;
+}
+
+/** A function that maps a SkillRecord to its run statistics. */
+export type SkillStatsResolver = (record: SkillRecord) => SkillRunStats;
+
+/** Options for createAuditLogStatsResolver. */
+export interface AuditStatsResolverOptions {
+  /** Path to the audit log JSONL. Default: global config, then ~/.openchrome/audit.log. */
+  auditLogPath?: string;
+  /** Failure-rate window in ms. Default: 30 days. */
+  failWindowMs?: number;
+  /**
+   * Full scan window in days (controls how far back lastRunAt searches).
+   * Defaults to OPENCHROME_SKILL_MEM_STATS_WINDOW_DAYS env var, then 60 days.
+   *
+   * Must be >= the curator's untouched-archive horizon (60 days) so a skill
+   * last run 31-60 days ago is not mistakenly treated as "never touched" and
+   * archived prematurely. Decoupled from failWindowMs so success/failure
+   * tallies can use a tighter window while lastRunAt uses the full horizon.
+   */
+  statsWindowDays?: number;
+  /** Test hook: clock for "now". */
+  now?: () => number;
+  /**
+   * Override the line reader — tests inject in-memory iterables; the
+   * default uses an fs-backed streaming reader.
+   */
+  readLines?: (filePath: string) => Iterable<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_FAIL_WINDOW_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+// Must be >= curator's untouched-archive horizon (60 days). See comment on
+// statsWindowDays above.
+const DEFAULT_STATS_WINDOW_DAYS = 60;
+
+// ---------------------------------------------------------------------------
+// Audit log path
+// ---------------------------------------------------------------------------
+
+export function defaultAuditLogPath(): string {
+  const config = getGlobalConfig();
+  return (
+    config.security?.audit_log_path ||
+    path.join(os.homedir(), '.openchrome', 'audit.log')
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Streaming line reader
+// ---------------------------------------------------------------------------
+
+/**
+ * Synchronous line-by-line iterator over a possibly-large file.
+ * Reads in 64 KB chunks, feeds them through a StringDecoder so
+ * multi-byte UTF-8 code points crossing chunk boundaries are handled
+ * correctly, splits on `\n`, and yields complete lines.
+ */
+function* readLinesFromFile(filePath: string): Iterable<string> {
+  if (!fs.existsSync(filePath)) return;
+  const fd = fs.openSync(filePath, 'r');
+  const CHUNK = 64 * 1024;
+  const buf = Buffer.alloc(CHUNK);
+  const decoder = new StringDecoder('utf8');
+  let leftover = '';
+  try {
+    while (true) {
+      const n = fs.readSync(fd, buf, 0, CHUNK, null);
+      if (n <= 0) break;
+      const text = leftover + decoder.write(buf.slice(0, n));
+      const lines = text.split('\n');
+      leftover = lines.pop() ?? '';
+      for (const line of lines) yield line;
+    }
+    const tail = decoder.end();
+    if (tail) leftover += tail;
+    if (leftover.length > 0) yield leftover;
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Audit row shape (subset we care about)
+// ---------------------------------------------------------------------------
+
+interface SkillRunAuditRow {
+  ts?: unknown;
+  tool?: string;
+  args?: {
+    skill_id?: string;
+    verdict?: string;
+    contract_id?: string;
+  };
+}
+
+function parseTs(value: unknown): number | null {
+  if (typeof value === 'string') {
+    const n = Date.parse(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Index building
+// ---------------------------------------------------------------------------
+
+interface AuditIndex {
+  /** Win/loss tallies within failWindowMs, keyed by skill_id. */
+  verdicts: Map<string, { successesInWindow: number; failuresInWindow: number }>;
+  /** Most-recent skill_run timestamp within statsWindowMs, keyed by skill_id. */
+  lastRunBySkill: Map<string, number>;
+}
+
+function buildIndex(
+  lines: Iterable<string>,
+  now: number,
+  failWindowMs: number,
+  statsWindowMs: number,
+): AuditIndex {
+  const failCutoff = now - failWindowMs;
+  const statsCutoff = now - statsWindowMs;
+  // Use the wider of the two cutoffs so rows relevant to EITHER metric are
+  // not dropped before per-metric accounting runs. Without this, a narrow
+  // statsWindowDays could silently truncate failure tallies (P2 regression).
+  const wideCutoff = Math.min(statsCutoff, failCutoff);
+
+  const verdicts = new Map<string, { successesInWindow: number; failuresInWindow: number }>();
+  const lastRunBySkill = new Map<string, number>();
+
+  for (const line of lines) {
+    if (!line || line[0] !== '{') continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== 'object') continue;
+    const entry = parsed as SkillRunAuditRow;
+    const ts = parseTs(entry.ts);
+    if (ts === null || ts < wideCutoff) continue;
+
+    if (entry.tool === 'skill_run' && entry.args) {
+      const sid = entry.args.skill_id;
+      if (typeof sid !== 'string') continue;
+
+      // lastRunAt: keyed by skill_id, only within the stats window.
+      if (ts >= statsCutoff) {
+        const prev = lastRunBySkill.get(sid);
+        if (prev === undefined || ts > prev) lastRunBySkill.set(sid, ts);
+      }
+
+      // Verdict tallies: keyed by skill_id, only within the fail window.
+      // Scoping by skill_id prevents sibling skills sharing the same
+      // contract_id from polluting each other's stats (P1 regression).
+      if (ts >= failCutoff) {
+        let tally = verdicts.get(sid);
+        if (!tally) {
+          tally = { successesInWindow: 0, failuresInWindow: 0 };
+          verdicts.set(sid, tally);
+        }
+        if (entry.args.verdict === 'success') tally.successesInWindow++;
+        else if (entry.args.verdict === 'postcondition_violation') tally.failuresInWindow++;
+      }
+    }
+  }
+
+  return { verdicts, lastRunBySkill };
+}
+
+// ---------------------------------------------------------------------------
+// Public factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a SkillStatsResolver bound to a given audit-log path. The index is
+ * built lazily on first call — the audit log is scanned once and the result
+ * is shared across all per-skill lookups (O(M+N) rather than O(N×M)).
+ */
+export function createAuditLogStatsResolver(
+  opts: AuditStatsResolverOptions = {},
+): SkillStatsResolver {
+  const auditLogPath = opts.auditLogPath ?? defaultAuditLogPath();
+  const failWindowMs = opts.failWindowMs ?? DEFAULT_FAIL_WINDOW_MS;
+  const statsWindowDays =
+    opts.statsWindowDays ??
+    (() => {
+      const raw = process.env['OPENCHROME_SKILL_MEM_STATS_WINDOW_DAYS'];
+      if (!raw) return DEFAULT_STATS_WINDOW_DAYS;
+      const n = Number.parseInt(raw, 10);
+      return Number.isFinite(n) && n > 0 ? n : DEFAULT_STATS_WINDOW_DAYS;
+    })();
+  const statsWindowMs = statsWindowDays * 24 * 60 * 60 * 1000;
+  const nowFn = opts.now ?? Date.now;
+  const readLines = opts.readLines ?? readLinesFromFile;
+
+  let index: AuditIndex | null = null;
+
+  return (record: SkillRecord): SkillRunStats => {
+    if (!index) {
+      index = buildIndex(readLines(auditLogPath), nowFn(), failWindowMs, statsWindowMs);
+    }
+
+    const tally = index.verdicts.get(record.skillId) ?? {
+      successesInWindow: 0,
+      failuresInWindow: 0,
+    };
+    const lastRunAt = index.lastRunBySkill.get(record.skillId) ?? null;
+
+    return {
+      successesInWindow: tally.successesInWindow,
+      failuresInWindow: tally.failuresInWindow,
+      lastRunAt,
+      demotesInDoubleDemoteWindow: 0,
+      hadInterveningPromotion: false,
+    };
+  };
+}
+
+/**
+ * Convenience: build a resolver backed by an in-memory line array.
+ * Useful when the caller wants to amortize one file read across many
+ * skills, or in tests that inject pre-built log lines.
+ */
+export function createInMemoryStatsResolver(
+  lines: string[],
+  opts: Omit<AuditStatsResolverOptions, 'readLines' | 'auditLogPath'> = {},
+): SkillStatsResolver {
+  return createAuditLogStatsResolver({
+    ...opts,
+    auditLogPath: '<in-memory>',
+    readLines: () => lines,
+  });
+}

--- a/tests/core/skill-memory/stats-resolver.test.ts
+++ b/tests/core/skill-memory/stats-resolver.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Tests for src/core/skill-memory/stats-resolver.ts
+ *
+ * All assertions use the core-tier SkillRecord shape (flat fields:
+ * skillId, successCount, lastUsedAt, etc.) — NOT the pilot-tier
+ * frontmatter/sidecar shape used in #766's original branch.
+ */
+import {
+  createAuditLogStatsResolver,
+  createInMemoryStatsResolver,
+} from '../../../src/core/skill-memory/stats-resolver';
+import type { SkillRecord } from '../../../src/core/skill-memory/types';
+
+const NOW = Date.parse('2026-05-08T12:00:00Z');
+
+function rec(overrides: Partial<SkillRecord> = {}): SkillRecord {
+  return {
+    skillId: 'sk-001',
+    domain: 'amazon.com',
+    name: 'add-to-cart',
+    steps: [],
+    contractId: 'amazon.checkout',
+    successCount: 5,
+    lastUsedAt: NOW,
+    frozenSnapshotPath: null,
+    ...overrides,
+  };
+}
+
+function audit(ts: string, tool: string, args: Record<string, unknown>): string {
+  return JSON.stringify({ ts, tool, args });
+}
+
+// ---------------------------------------------------------------------------
+// skill_run tallies (keyed by skill_id)
+// ---------------------------------------------------------------------------
+
+describe('createAuditLogStatsResolver — skill_run tallies (keyed by skill_id)', () => {
+  test('counts successes + failures within window for the matching skill_id', () => {
+    const lines = [
+      audit('2026-05-01T12:00:00Z', 'skill_run', { skill_id: 'sk-001', verdict: 'success' }),
+      audit('2026-05-02T12:00:00Z', 'skill_run', { skill_id: 'sk-001', verdict: 'success' }),
+      audit('2026-05-03T12:00:00Z', 'skill_run', { skill_id: 'sk-001', verdict: 'postcondition_violation' }),
+      // Different skill_id — must NOT count
+      audit('2026-05-04T12:00:00Z', 'skill_run', { skill_id: 'sk-OTHER', verdict: 'success' }),
+    ];
+    const resolver = createInMemoryStatsResolver(lines, { now: () => NOW });
+    const stats = resolver(rec());
+    expect(stats.successesInWindow).toBe(2);
+    expect(stats.failuresInWindow).toBe(1);
+  });
+
+  test('drops entries older than failWindowMs cutoff', () => {
+    const lines = [
+      audit('2026-04-01T12:00:00Z', 'skill_run', { skill_id: 'sk-001', verdict: 'success' }), // > 30d ago
+      audit('2026-05-05T12:00:00Z', 'skill_run', { skill_id: 'sk-001', verdict: 'success' }),
+    ];
+    const resolver = createInMemoryStatsResolver(lines, { now: () => NOW });
+    const stats = resolver(rec());
+    expect(stats.successesInWindow).toBe(1);
+  });
+
+  test('lastRunAt = max ts of skill_run entries for this skill_id (contract_runtime entries are ignored)', () => {
+    const lines = [
+      // contract_runtime must NOT contribute to lastRunAt
+      audit('2026-05-07T03:00:00Z', 'contract_runtime', { contract_id: 'amazon.checkout', verdict: 'postcondition_violation' }),
+      audit('2026-05-01T12:00:00Z', 'skill_run', { skill_id: 'sk-001', verdict: 'success' }),
+      audit('2026-05-06T09:00:00Z', 'skill_run', { skill_id: 'sk-001', verdict: 'postcondition_violation' }),
+    ];
+    const resolver = createInMemoryStatsResolver(lines, { now: () => NOW });
+    const stats = resolver(rec());
+    expect(stats.lastRunAt).toBe(Date.parse('2026-05-06T09:00:00Z'));
+  });
+
+  test('contract_runtime entries alone do NOT advance lastRunAt', () => {
+    const lines = [
+      audit('2026-05-01T12:00:00Z', 'contract_runtime', { contract_id: 'amazon.checkout', verdict: 'success' }),
+      audit('2026-05-08T11:00:00Z', 'contract_runtime', { contract_id: 'amazon.checkout', verdict: 'success' }),
+    ];
+    const resolver = createInMemoryStatsResolver(lines, { now: () => NOW });
+    const stats = resolver(rec());
+    expect(stats.lastRunAt).toBeNull();
+  });
+
+  test('skill_run for a different skill_id does NOT advance lastRunAt', () => {
+    const lines = [
+      audit('2026-05-08T11:00:00Z', 'skill_run', { skill_id: 'OTHER' }),
+    ];
+    const resolver = createInMemoryStatsResolver(lines, { now: () => NOW });
+    const stats = resolver(rec());
+    expect(stats.lastRunAt).toBeNull();
+  });
+
+  test('returns lastRunAt=null and zero tallies when no relevant entries exist', () => {
+    const lines = [
+      audit('2026-05-01T12:00:00Z', 'unrelated_tool', { whatever: 1 }),
+    ];
+    const resolver = createInMemoryStatsResolver(lines, { now: () => NOW });
+    const stats = resolver(rec());
+    expect(stats.lastRunAt).toBeNull();
+    expect(stats.successesInWindow).toBe(0);
+    expect(stats.failuresInWindow).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defensive parsing
+// ---------------------------------------------------------------------------
+
+describe('createAuditLogStatsResolver — defensive parsing', () => {
+  test('skips empty lines', () => {
+    const lines = [
+      '',
+      audit('2026-05-05T12:00:00Z', 'skill_run', { skill_id: 'sk-001', verdict: 'success' }),
+      '',
+      '   ',
+    ];
+    const stats = createInMemoryStatsResolver(lines, { now: () => NOW })(rec());
+    expect(stats.successesInWindow).toBe(1);
+  });
+
+  test('skips malformed JSON lines without throwing', () => {
+    const lines = [
+      'not json {{',
+      audit('2026-05-05T12:00:00Z', 'skill_run', { skill_id: 'sk-001', verdict: 'success' }),
+      '} also not json',
+    ];
+    const stats = createInMemoryStatsResolver(lines, { now: () => NOW })(rec());
+    expect(stats.successesInWindow).toBe(1);
+  });
+
+  test('skips non-`{` lines (defensive against log noise)', () => {
+    const lines = [
+      '[{not an audit row}]',
+      audit('2026-05-05T12:00:00Z', 'skill_run', { skill_id: 'sk-001', verdict: 'success' }),
+    ];
+    const stats = createInMemoryStatsResolver(lines, { now: () => NOW })(rec());
+    expect(stats.successesInWindow).toBe(1);
+  });
+
+  test('skips entries with malformed ts', () => {
+    const lines = [
+      JSON.stringify({ ts: 'not-a-date', tool: 'skill_run', args: { skill_id: 'sk-001', verdict: 'success' } }),
+      audit('2026-05-05T12:00:00Z', 'skill_run', { skill_id: 'sk-001', verdict: 'success' }),
+    ];
+    const stats = createInMemoryStatsResolver(lines, { now: () => NOW })(rec());
+    expect(stats.successesInWindow).toBe(1);
+  });
+
+  test('numeric ts is also accepted (legacy / extended audit shape)', () => {
+    const lines = [
+      JSON.stringify({ ts: Date.parse('2026-05-06T12:00:00Z'), tool: 'skill_run', args: { skill_id: 'sk-001', verdict: 'success' } }),
+    ];
+    const stats = createInMemoryStatsResolver(lines, { now: () => NOW })(rec());
+    expect(stats.successesInWindow).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defaults for deferred fields
+// ---------------------------------------------------------------------------
+
+describe('createAuditLogStatsResolver — defaults for deferred fields', () => {
+  test('demotesInDoubleDemoteWindow defaults to 0 (history store deferred)', () => {
+    const stats = createInMemoryStatsResolver([], { now: () => NOW })(rec());
+    expect(stats.demotesInDoubleDemoteWindow).toBe(0);
+    expect(stats.hadInterveningPromotion).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// File-backed reader smoke test
+// ---------------------------------------------------------------------------
+
+describe('createAuditLogStatsResolver — file-backed reader (smoke)', () => {
+  test('returns empty stats when audit log path does not exist', () => {
+    const resolver = createAuditLogStatsResolver({
+      auditLogPath: '/tmp/definitely-not-a-real-audit-log-766.jsonl',
+      now: () => NOW,
+    });
+    const stats = resolver(rec());
+    expect(stats.successesInWindow).toBe(0);
+    expect(stats.failuresInWindow).toBe(0);
+    expect(stats.lastRunAt).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lastRunAt window decoupled from failWindowMs
+// ---------------------------------------------------------------------------
+
+describe('createAuditLogStatsResolver — lastRunAt window decoupled from failWindowMs (#3 regression)', () => {
+  test('lastRunAt is non-null for a skill last run between failWindowMs and statsWindowMs ago', () => {
+    const FAIL_WINDOW_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+    const STATS_WINDOW_DAYS = 60;
+    // 45 days ago: outside 30d fail window but inside 60d stats window
+    const fortyFiveDaysAgo = new Date(NOW - 45 * 24 * 60 * 60 * 1000).toISOString();
+    const lines = [
+      audit(fortyFiveDaysAgo, 'skill_run', { skill_id: 'sk-001', verdict: 'success' }),
+    ];
+    const resolver = createInMemoryStatsResolver(lines, {
+      now: () => NOW,
+      failWindowMs: FAIL_WINDOW_MS,
+      statsWindowDays: STATS_WINDOW_DAYS,
+    });
+    const stats = resolver(rec());
+    // Outside fail window — no tallies
+    expect(stats.successesInWindow).toBe(0);
+    expect(stats.failuresInWindow).toBe(0);
+    // Inside stats window — lastRunAt must be populated
+    expect(stats.lastRunAt).toBe(Date.parse(fortyFiveDaysAgo));
+  });
+
+  test('lastRunAt is null when skill_run entry is outside statsWindowMs', () => {
+    const sixtyOneDaysAgo = new Date(NOW - 61 * 24 * 60 * 60 * 1000).toISOString();
+    const lines = [
+      audit(sixtyOneDaysAgo, 'skill_run', { skill_id: 'sk-001', verdict: 'success' }),
+    ];
+    const resolver = createInMemoryStatsResolver(lines, {
+      now: () => NOW,
+      failWindowMs: 30 * 24 * 60 * 60 * 1000,
+      statsWindowDays: 60,
+    });
+    const stats = resolver(rec());
+    expect(stats.successesInWindow).toBe(0);
+    expect(stats.lastRunAt).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Default stats window covers curator untouched horizon (P1 regression)
+// ---------------------------------------------------------------------------
+
+describe('createAuditLogStatsResolver — default stats window covers curator untouched horizon (P1 regression)', () => {
+  test('50-day-old skill_run is visible with default options (no statsWindowDays override)', () => {
+    const fiftyDaysAgo = new Date(NOW - 50 * 24 * 60 * 60 * 1000).toISOString();
+    const lines = [audit(fiftyDaysAgo, 'skill_run', { skill_id: 'sk-001' })];
+    const resolver = createInMemoryStatsResolver(lines, { now: () => NOW });
+    expect(resolver(rec()).lastRunAt).toBe(Date.parse(fiftyDaysAgo));
+  });
+
+  test('contract_runtime alone yields null even within the default 60-day window', () => {
+    const fiftyDaysAgo = new Date(NOW - 50 * 24 * 60 * 60 * 1000).toISOString();
+    const lines = [
+      audit(fiftyDaysAgo, 'contract_runtime', { contract_id: 'amazon.checkout', verdict: 'success' }),
+    ];
+    const resolver = createInMemoryStatsResolver(lines, { now: () => NOW });
+    expect(resolver(rec()).lastRunAt).toBeNull();
+  });
+
+  test('61-day-old skill_run entry is NOT visible with default options', () => {
+    const sixtyOneDaysAgo = new Date(NOW - 61 * 24 * 60 * 60 * 1000).toISOString();
+    const lines = [audit(sixtyOneDaysAgo, 'skill_run', { skill_id: 'sk-001' })];
+    const resolver = createInMemoryStatsResolver(lines, { now: () => NOW });
+    expect(resolver(rec()).lastRunAt).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failure tally via skill_run verdict (P1 regression)
+// ---------------------------------------------------------------------------
+
+describe('createAuditLogStatsResolver — failure tally via skill_run verdict (P1 regression)', () => {
+  test('skill_run with verdict=postcondition_violation increments failuresInWindow', () => {
+    const lines = [
+      audit('2026-05-01T12:00:00Z', 'skill_run', { skill_id: 'sk-001', verdict: 'success' }),
+      audit('2026-05-02T12:00:00Z', 'skill_run', { skill_id: 'sk-001', verdict: 'postcondition_violation' }),
+      audit('2026-05-03T12:00:00Z', 'skill_run', { skill_id: 'sk-001', verdict: 'postcondition_violation' }),
+    ];
+    const resolver = createInMemoryStatsResolver(lines, { now: () => NOW });
+    const stats = resolver(rec());
+    expect(stats.successesInWindow).toBe(1);
+    expect(stats.failuresInWindow).toBe(2);
+  });
+
+  test('failuresInWindow stays 0 when only contract_runtime failure events exist', () => {
+    const lines = [
+      audit('2026-05-01T12:00:00Z', 'skill_run', { skill_id: 'sk-001', verdict: 'success' }),
+      audit('2026-05-02T12:00:00Z', 'contract_runtime', { contract_id: 'amazon.checkout', verdict: 'postcondition_violation' }),
+    ];
+    const resolver = createInMemoryStatsResolver(lines, { now: () => NOW });
+    const stats = resolver(rec());
+    expect(stats.successesInWindow).toBe(1);
+    expect(stats.failuresInWindow).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fail-window independent of stats-window (P2 regression)
+// ---------------------------------------------------------------------------
+
+describe('createAuditLogStatsResolver — fail-window independent of stats-window (P2 regression)', () => {
+  test('7-day stats window + 30-day fail window counts same failures as 30-day stats window', () => {
+    const FAIL_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+    const fifteenDaysAgo = new Date(NOW - 15 * 24 * 60 * 60 * 1000).toISOString();
+    const lines = [
+      // 15 days ago: within fail window (30d), but OUTSIDE a 7-day stats window
+      audit(fifteenDaysAgo, 'skill_run', { skill_id: 'sk-001', verdict: 'postcondition_violation' }),
+    ];
+
+    const narrowStats = createInMemoryStatsResolver(lines, {
+      now: () => NOW,
+      failWindowMs: FAIL_WINDOW_MS,
+      statsWindowDays: 7,
+    });
+    const wideStats = createInMemoryStatsResolver(lines, {
+      now: () => NOW,
+      failWindowMs: FAIL_WINDOW_MS,
+      statsWindowDays: 30,
+    });
+
+    const sNarrow = narrowStats(rec());
+    const sWide = wideStats(rec());
+
+    // Both must report the failure regardless of statsWindowDays
+    expect(sNarrow.failuresInWindow).toBe(1);
+    expect(sWide.failuresInWindow).toBe(1);
+
+    // Narrow stats window: entry is outside 7d so lastRunAt is null
+    expect(sNarrow.lastRunAt).toBeNull();
+    // Wide stats window: entry is within 30d so lastRunAt is populated
+    expect(sWide.lastRunAt).toBe(Date.parse(fifteenDaysAgo));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sibling skill isolation (P1 regression)
+// ---------------------------------------------------------------------------
+
+describe('createAuditLogStatsResolver — sibling skill isolation (P1 regression)', () => {
+  test('two siblings sharing a contractId report independent success/failure stats', () => {
+    const lines = [
+      audit('2026-05-01T12:00:00Z', 'skill_run', { skill_id: 'skill-anchor-A', verdict: 'success', contract_id: 'shared.contract' }),
+      audit('2026-05-02T12:00:00Z', 'skill_run', { skill_id: 'skill-anchor-A', verdict: 'success', contract_id: 'shared.contract' }),
+      audit('2026-05-03T12:00:00Z', 'skill_run', { skill_id: 'skill-anchor-A', verdict: 'success', contract_id: 'shared.contract' }),
+      audit('2026-05-04T12:00:00Z', 'skill_run', { skill_id: 'skill-anchor-B', verdict: 'postcondition_violation', contract_id: 'shared.contract' }),
+      audit('2026-05-05T12:00:00Z', 'skill_run', { skill_id: 'skill-anchor-B', verdict: 'postcondition_violation', contract_id: 'shared.contract' }),
+      audit('2026-05-06T12:00:00Z', 'skill_run', { skill_id: 'skill-anchor-B', verdict: 'postcondition_violation', contract_id: 'shared.contract' }),
+      audit('2026-05-07T12:00:00Z', 'skill_run', { skill_id: 'skill-anchor-B', verdict: 'postcondition_violation', contract_id: 'shared.contract' }),
+      audit('2026-05-08T10:00:00Z', 'skill_run', { skill_id: 'skill-anchor-B', verdict: 'postcondition_violation', contract_id: 'shared.contract' }),
+    ];
+
+    const resolver = createInMemoryStatsResolver(lines, { now: () => NOW });
+
+    const recA: SkillRecord = rec({ skillId: 'skill-anchor-A', contractId: 'shared.contract' });
+    const recB: SkillRecord = rec({ skillId: 'skill-anchor-B', contractId: 'shared.contract' });
+
+    const statsA = resolver(recA);
+    const statsB = resolver(recB);
+
+    // Skill A: 3 successes, 0 failures — must not be contaminated by B's failures
+    expect(statsA.successesInWindow).toBe(3);
+    expect(statsA.failuresInWindow).toBe(0);
+
+    // Skill B: 0 successes, 5 failures — must not be contaminated by A's successes
+    expect(statsB.successesInWindow).toBe(0);
+    expect(statsB.failuresInWindow).toBe(5);
+  });
+
+  test('sibling with no skill_run entries returns lastRunAt=null regardless of sibling activity', () => {
+    const recentTs = '2026-05-07T10:00:00Z';
+    const lines = [
+      audit(recentTs, 'skill_run', { skill_id: 'sibling-A', verdict: 'success', contract_id: 'shared.contract' }),
+    ];
+    const resolver = createInMemoryStatsResolver(lines, { now: () => NOW });
+
+    const recA = rec({ skillId: 'sibling-A', contractId: 'shared.contract' });
+    const recB = rec({ skillId: 'sibling-B', contractId: 'shared.contract' });
+
+    // Sibling A has activity — must report it
+    expect(resolver(recA).lastRunAt).toBe(Date.parse(recentTs));
+    // Sibling B has no skill_run entries — must be null
+    expect(resolver(recB).lastRunAt).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lazy index: built once, shared across calls
+// ---------------------------------------------------------------------------
+
+describe('createAuditLogStatsResolver — lazy index (built once)', () => {
+  test('calling resolver twice uses the same index (readLines called once)', () => {
+    let callCount = 0;
+    const lines = [
+      audit('2026-05-05T12:00:00Z', 'skill_run', { skill_id: 'sk-001', verdict: 'success' }),
+    ];
+    const resolver = createAuditLogStatsResolver({
+      auditLogPath: '<in-memory>',
+      now: () => NOW,
+      readLines: () => {
+        callCount++;
+        return lines;
+      },
+    });
+
+    resolver(rec());
+    resolver(rec());
+
+    expect(callCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `src/core/skill-memory/stats-resolver.ts`: a read-only audit-log walker that derives canonical `(successesInWindow, failuresInWindow, lastRunAt)` per skill by streaming `~/.openchrome/audit.log` in a single lazy pass.
- Adds `tests/core/skill-memory/stats-resolver.test.ts` with 24 tests covering all regression guards from the original #766 review rounds.
- Replaces closed PR #766; design aligns with the Phase 4 stack (#774, #780, #800).

## Design

| Concern | Approach |
|---|---|
| Performance | Lazy index built once on first resolver call; O(M+N) across all per-skill lookups |
| Correctness | `skill_run` entries only — `contract_runtime` does NOT advance `lastRunAt` or tallies |
| Sibling isolation (P1) | Tallies and `lastRunAt` keyed strictly by `skill_id`, not `contract_id` |
| Window independence (P2) | Wide cutoff (`min(statsCutoff, failCutoff)`) used for early-skip fence so narrow `statsWindowDays` never truncates failure counts |
| Untouched-archive horizon (P1) | Default `statsWindowDays=60` matches `curator.ts DEFAULTS.untouchedArchiveMs` |
| Deferred fields | `demotesInDoubleDemoteWindow=0`, `hadInterveningPromotion=false` until history store lands |
| Tier safety | Core-tier: no `src/pilot/**` imports; `lint:tier` clean |

## Verification

- `tsc --noEmit`: clean
- `depcruise --config .dependency-cruiser.cjs src/core/skill-memory/stats-resolver.ts`: no violations
- `npx jest tests/core/skill-memory/stats-resolver.test.ts`: **24 passed, 0 failed**

## Related

Replaces: #766
Phase 4 stack: #774, #780, #800

## Test plan

- [x] `npm run build` (tsc) passes with no errors
- [x] `npm run lint:tier` — no core→pilot violations
- [x] `npx jest tests/core/skill-memory/` — all 24 new tests pass
- [x] Existing `tests/core/skill-memory/store.test.ts` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)