### PR TITLE
feat(pilot): curator Pass 1 (prune) + Pass 3 (promote) + PID lock (Phase 4, replaces #763)

### DIFF
--- a/src/pilot/curator/index.ts
+++ b/src/pilot/curator/index.ts
@@ -1,14 +1,15 @@
 /**
- * Pilot curator barrel (#712 epic, Phase 4 — verified skill extractor).
+ * Pilot curator barrel (#712 epic, Phase 4 — extractor + curator passes).
  *
  * The extractor turns successful, contract-verified runs into reusable
- * SKILL.md candidates. It is a deterministic transform (no LLM calls).
+ * SKILL.md candidates. The curator (Pass 1 prune + Pass 3 promote) runs
+ * as a background timer and keeps the skill tree healthy.
+ *
+ * All exports are deterministic transforms (no LLM calls).
  *
  * Call sites that integrate with the contract runtime MUST gate on
  * `isSkillCuratorEnabled()` from `src/harness/flags.ts` before
  * invoking any export from this module.
- *
- * Recall (#714) + curator stats (#715) ride follow-up commits.
  */
 
 export {
@@ -42,3 +43,26 @@ export type {
   SkillSidecar,
   SkillStatus,
 } from './types';
+
+// Curator Pass 1: prune (demote + archive)
+export { runPrune } from './prune';
+export type {
+  PruneAction,
+  PruneActionKind,
+  PruneOptions,
+  PruneReport,
+  SkillRunStats,
+  SkillStatsResolver,
+} from './prune';
+
+// Curator Pass 3: promote / recall ranking recompute
+export { runPromote } from './promote';
+export type { PromoteOptions, PromoteReport } from './promote';
+
+// PID lock
+export { CuratorLock, defaultCuratorLockDir } from './lock';
+export type { CuratorLockOptions } from './lock';
+
+// Background runner
+export { startCuratorRunner } from './runner';
+export type { CuratorRunner, CuratorRunnerOptions } from './runner';

--- a/src/pilot/curator/lock.ts
+++ b/src/pilot/curator/lock.ts
@@ -1,0 +1,199 @@
+/**
+ * Curator single-instance PID lock (Phase 4, #763).
+ *
+ * The curator runs as a background task; multiple `oc serve` processes on
+ * the same machine must not run it concurrently against the same domain
+ * root. Lock lives at `~/.openchrome/skills/.curator/lock`:
+ *
+ *   1. If absent → write own PID + start_ts. Acquired.
+ *   2. If present → read PID. Probe with `process.kill(pid, 0)` — if
+ *      the holder is dead, reclaim.
+ *   3. Hard TTL: if mtime > 1 h old, reclaim regardless of liveness
+ *      (the holder may be hung).
+ *   4. Atomicity: write via temp + rename so partial files cannot look
+ *      like a valid lockfile.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const LOCK_TTL_MS = 60 * 60 * 1_000; // 1 hour
+
+export interface CuratorLockOptions {
+  rootDir?: string;
+  /** TTL for stale lock reclamation. Default 1 hour. */
+  ttlMs?: number;
+  /** Test hook: pid liveness probe. */
+  isAlive?: (pid: number) => boolean;
+  /** Test hook: clock for mtime comparisons. */
+  now?: () => number;
+}
+
+interface LockData {
+  pid: number;
+  start_ts: number;
+}
+
+export function defaultCuratorLockDir(): string {
+  return path.join(os.homedir(), '.openchrome', 'skills', '.curator');
+}
+
+function defaultIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException).code;
+    // EPERM → process exists but we lack permission to signal it → alive.
+    if (code === 'EPERM') return true;
+    return false;
+  }
+}
+
+/**
+ * Acquire / release semantics. The lock object is single-use:
+ * acquire() → release() then discard. Re-using a released instance throws.
+ */
+export class CuratorLock {
+  private readonly target: string;
+  private readonly ttlMs: number;
+  private readonly isAlive: (pid: number) => boolean;
+  private readonly now: () => number;
+  private acquired = false;
+  private released = false;
+
+  constructor(opts: CuratorLockOptions = {}) {
+    const root = opts.rootDir ?? defaultCuratorLockDir();
+    fs.mkdirSync(root, { recursive: true });
+    this.target = path.join(root, 'lock');
+    this.ttlMs = opts.ttlMs ?? LOCK_TTL_MS;
+    this.isAlive = opts.isAlive ?? defaultIsAlive;
+    this.now = opts.now ?? Date.now;
+  }
+
+  /** Attempt to acquire. Returns true on success, false otherwise. */
+  acquire(): boolean {
+    if (this.released) {
+      throw new Error('CuratorLock: cannot reuse a released instance');
+    }
+    if (this.acquired) return true;
+    if (this.tryWrite()) {
+      this.acquired = true;
+      return true;
+    }
+    // Lock file exists — decide whether to reclaim.
+    if (this.shouldReclaim()) {
+      if (!this.reclaimStaleLock()) return false;
+      const verify = this.read();
+      if (!verify || verify.pid !== process.pid) return false;
+      this.acquired = true;
+      return true;
+    }
+    return false;
+  }
+
+  /** Release a previously-acquired lock. Idempotent. */
+  release(): void {
+    if (!this.acquired || this.released) return;
+    this.released = true;
+    this.acquired = false;
+    try {
+      const onDisk = this.read();
+      // Only remove if it's still ours — another reclaimer may have
+      // already taken over between our acquire and release.
+      if (onDisk && onDisk.pid === process.pid) {
+        fs.unlinkSync(this.target);
+      }
+    } catch {
+      // best-effort
+    }
+  }
+
+  /** Inspect whoever currently holds (or stale-holds) the lock. */
+  readHolder(): LockData | null {
+    return this.read();
+  }
+
+  private read(): LockData | null {
+    try {
+      const txt = fs.readFileSync(this.target, 'utf8');
+      const parsed = JSON.parse(txt) as Partial<LockData>;
+      if (typeof parsed.pid === 'number' && typeof parsed.start_ts === 'number') {
+        return { pid: parsed.pid, start_ts: parsed.start_ts };
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Attempt an exclusive-create write via temp + link.
+   * Fails fast if the target already exists.
+   */
+  private tryWrite(): boolean {
+    const tmp = this.target + '.' + process.pid + '.tmp';
+    try {
+      fs.writeFileSync(tmp, JSON.stringify({ pid: process.pid, start_ts: this.now() }), {
+        flag: 'wx',
+        mode: 0o600,
+      });
+      try {
+        fs.linkSync(tmp, this.target);
+        fs.unlinkSync(tmp);
+        return true;
+      } catch {
+        try { fs.unlinkSync(tmp); } catch { /* ignore */ }
+        return false;
+      }
+    } catch {
+      return false;
+    }
+  }
+
+  /** Overwrite stale lock with our PID via temp + unlink + link. */
+  private reclaimStaleLock(): boolean {
+    const tmp = this.target + '.' + process.pid + '.tmp';
+    try {
+      fs.writeFileSync(tmp, JSON.stringify({ pid: process.pid, start_ts: this.now() }), {
+        flag: 'wx',
+        mode: 0o600,
+      });
+      // Re-check staleness inside the critical section.
+      if (!this.shouldReclaim()) return false;
+      try {
+        fs.unlinkSync(this.target);
+      } catch (e) {
+        const code = (e as NodeJS.ErrnoException).code;
+        if (code !== 'ENOENT') return false;
+      }
+      try {
+        fs.linkSync(tmp, this.target);
+        return true;
+      } catch {
+        return false;
+      }
+    } catch {
+      return false;
+    } finally {
+      try { fs.unlinkSync(tmp); } catch { /* ignore */ }
+    }
+  }
+
+  private shouldReclaim(): boolean {
+    const holder = this.read();
+    // Malformed or missing lockfile → reclaim.
+    if (!holder) return true;
+    // Stale via TTL: mtime > ttlMs ago.
+    try {
+      const stat = fs.statSync(this.target);
+      if (this.now() - stat.mtimeMs > this.ttlMs) return true;
+    } catch {
+      return true;
+    }
+    // Holder dead.
+    if (!this.isAlive(holder.pid)) return true;
+    return false;
+  }
+}

--- a/src/pilot/curator/promote.ts
+++ b/src/pilot/curator/promote.ts
@@ -1,0 +1,136 @@
+/**
+ * Curator Pass 3 — Promote / recall ranking recompute (Phase 4, #763).
+ *
+ * Deterministic, no LLM calls.
+ *
+ * Walks every active (non-archived) skill under `rootDir` and mirrors the
+ * latest success counts and last-used timestamps into the `SkillMemoryStore`
+ * so the recall layer always sees up-to-date ranking weights without waiting
+ * for an explicit `markUsed` call from the contract runtime.
+ *
+ * Concretely, for each skill record whose sidecar `runs.count` or
+ * `sidecar.runs.recent` newest-entry timestamp differs from the store's
+ * persisted `successCount` / `lastUsedAt`, Pass 3 calls
+ * `store.markUsed(skillId, lastSuccessTs, success)` to flush the delta.
+ *
+ * This is a best-effort synchronisation — if the store has no record for
+ * a skill, the pass skips it rather than creating a new entry (creation
+ * belongs to the extractor). Errors per skill are collected and surfaced
+ * via `PromoteReport.errors` without aborting the rest of the pass.
+ */
+
+import * as fs from 'node:fs';
+import * as crypto from 'node:crypto';
+
+import { SkillMemoryStore } from '../../core/skill-memory/store.js';
+import { listSkillsForDomain } from './extractor.js';
+
+export interface PromoteOptions {
+  rootDir?: string;
+  /** Test hook: clock. */
+  now?: () => number;
+}
+
+export interface PromoteReport {
+  run_id: string;
+  started_at: number;
+  ended_at: number;
+  /** Number of skill-store records updated. */
+  updated: number;
+  /** Number of skills skipped because they have no store record. */
+  skipped_no_record: number;
+  errors: string[];
+  stats: {
+    domains_seen: number;
+    skills_seen: number;
+  };
+}
+
+function listDomains(rootDir: string): string[] {
+  if (!fs.existsSync(rootDir)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(rootDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith('.')) continue;
+    out.push(entry.name);
+  }
+  return out;
+}
+
+/**
+ * Run Pass 3 across every domain under `rootDir`.
+ *
+ * For each promoted or candidate skill, updates `SkillMemoryStore` with
+ * the latest success count and timestamp derived from the sidecar's rolling
+ * run log. The caller (runner.ts) is responsible for holding the CuratorLock
+ * before invoking this.
+ */
+export async function runPromote(opts: PromoteOptions = {}): Promise<PromoteReport> {
+  const rootDir = opts.rootDir ?? '';
+  if (!rootDir) {
+    throw new Error('runPromote: rootDir is required');
+  }
+  const ts = (opts.now ?? Date.now)();
+
+  const report: PromoteReport = {
+    run_id: crypto.randomBytes(6).toString('hex'),
+    started_at: ts,
+    ended_at: ts,
+    updated: 0,
+    skipped_no_record: 0,
+    errors: [],
+    stats: { domains_seen: 0, skills_seen: 0 },
+  };
+
+  const domains = listDomains(rootDir);
+  report.stats.domains_seen = domains.length;
+
+  for (const domain of domains) {
+    const store = new SkillMemoryStore({ rootDir, domain });
+    const records = listSkillsForDomain(domain, { rootDir });
+
+    for (const rec of records) {
+      report.stats.skills_seen++;
+
+      // Only sync active skills; archived ones are frozen.
+      if (rec.frontmatter.status === 'archived') continue;
+
+      try {
+        const existing = store.get(rec.skill_id);
+        if (!existing) {
+          report.skipped_no_record++;
+          continue;
+        }
+
+        // Derive the latest success timestamp from the sidecar's rolling log.
+        const recent = rec.sidecar.runs.recent;
+        const successEntries = recent.filter((e) => e.ok);
+        const latestSuccessTs =
+          successEntries.length > 0
+            ? Math.max(...successEntries.map((e) => e.ts))
+            : null;
+
+        const newSuccessCount = rec.sidecar.runs.count;
+        const newLastUsedAt =
+          latestSuccessTs !== null ? latestSuccessTs : existing.lastUsedAt;
+
+        // Only flush when something changed — keeps writes minimal.
+        const changed =
+          newSuccessCount !== existing.successCount ||
+          newLastUsedAt !== existing.lastUsedAt;
+
+        if (!changed) continue;
+
+        await store.markUsed(rec.skill_id, newLastUsedAt, newSuccessCount > existing.successCount);
+        report.updated++;
+      } catch (e) {
+        report.errors.push(
+          `promote: error updating ${domain}/${rec.skill_id}: ${(e as Error).message}`,
+        );
+      }
+    }
+  }
+
+  report.ended_at = (opts.now ?? Date.now)();
+  return report;
+}

--- a/src/pilot/curator/prune.ts
+++ b/src/pilot/curator/prune.ts
@@ -1,0 +1,350 @@
+/**
+ * Curator Pass 1 — Prune (Phase 4, #763).
+ *
+ * Deterministic, no LLM calls.
+ *
+ * Two sub-passes run sequentially over every agent-authored, v1 skill:
+ *
+ *   Sub-pass A — confidence floor
+ *     fail_rate = postcondition_violations / total_runs (30-day window)
+ *     when fail_rate > 0.30 AND total_runs ≥ 5 AND status === 'promoted'
+ *       → demote (status = 'candidate', reset verified_runs to 1)
+ *     when demoted twice within 60 days WITHOUT intervening promotion
+ *       → archive (move to .archive/ + write reason.json)
+ *
+ *   Sub-pass B — TTL
+ *     last_verified_at older than 30 days AND 0 successes in window
+ *       → archive as 'archive_stale'
+ *     no skill_run event for 60 days (lastRunAt null or beyond threshold)
+ *       → archive as 'archive_untouched'
+ *
+ * Safety rails:
+ *   - Never deletes; only moves to <domain>/.archive/<skill_id>/
+ *   - Only touches skills with author === 'agent'
+ *   - Idempotent: rerunning on identical state produces an empty action list
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { listSkillsForDomain } from './extractor.js';
+import { parseSkillMd, stringifySkillMd } from './skill-md.js';
+import {
+  SKILL_SCHEMA_VERSION,
+  type SkillRecord,
+  type SkillSidecar,
+} from './types.js';
+
+export type PruneActionKind =
+  | 'demote'
+  | 'archive_stale'
+  | 'archive_untouched'
+  | 'archive_double_demote'
+  | 'skip_user_authored'
+  | 'skip_unknown_schema';
+
+export interface PruneAction {
+  kind: PruneActionKind;
+  skill_id: string;
+  domain: string;
+  reason: string;
+  timestamp: number;
+}
+
+export interface PruneReport {
+  run_id: string;
+  started_at: number;
+  ended_at: number;
+  actions: PruneAction[];
+  errors: string[];
+  stats: {
+    domains_seen: number;
+    skills_seen: number;
+    actions_count: number;
+  };
+}
+
+/** Per-skill runtime stats the host resolves from its audit log. */
+export interface SkillRunStats {
+  /** Successful contract runs (verdict === 'success') in the window. */
+  successesInWindow: number;
+  /** Failed runs (postcondition_violation) in the window. */
+  failuresInWindow: number;
+  /** ms epoch of the most recent skill_run event (any outcome), or null. */
+  lastRunAt: number | null;
+  /** Demote events for this skill within doubleDemoteWindowMs. */
+  demotesInDoubleDemoteWindow: number;
+  /** True iff the last status transition was a promote (resets demote counter). */
+  hadInterveningPromotion?: boolean;
+}
+
+export type SkillStatsResolver = (record: SkillRecord, windowMs?: number) => SkillRunStats;
+
+export interface PruneOptions {
+  rootDir?: string;
+  /** Fail-rate cutoff triggering demote. Default 0.30. */
+  failRateThreshold?: number;
+  /** Minimum total runs before fail-rate is considered. Default 5. */
+  failRateMinRuns?: number;
+  /** Window for fail-rate measurement. Default 30 days. */
+  failWindowMs?: number;
+  /** Window for double-demote detection. Default 60 days. */
+  doubleDemoteWindowMs?: number;
+  /** Archive when last_verified_at is older than this. Default 30 days. */
+  staleArchiveMs?: number;
+  /** Archive when no skill_run for this duration. Default 60 days. */
+  untouchedArchiveMs?: number;
+  /** Test hook: clock. */
+  now?: () => number;
+}
+
+const DEFAULTS = {
+  failRateThreshold: 0.3,
+  failRateMinRuns: 5,
+  failWindowMs: 30 * 24 * 60 * 60 * 1_000,
+  doubleDemoteWindowMs: 60 * 24 * 60 * 60 * 1_000,
+  staleArchiveMs: 30 * 24 * 60 * 60 * 1_000,
+  untouchedArchiveMs: 60 * 24 * 60 * 60 * 1_000,
+};
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function listDomains(rootDir: string): string[] {
+  if (!fs.existsSync(rootDir)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(rootDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith('.')) continue; // skip .curator, .archive
+    out.push(entry.name);
+  }
+  return out;
+}
+
+interface MutationCtx {
+  rootDir: string;
+  domain: string;
+  record: SkillRecord;
+  ts: number;
+}
+
+function archiveSkill(ctx: MutationCtx, reason: PruneActionKind, detail: string): void {
+  const archiveDir = path.join(ctx.rootDir, ctx.domain, '.archive', ctx.record.skill_id);
+  fs.mkdirSync(archiveDir, { recursive: true });
+
+  const mdDest = path.join(archiveDir, path.basename(ctx.record.filePath));
+  const sidecarDest = path.join(archiveDir, path.basename(ctx.record.sidecarPath));
+
+  // Update frontmatter status to 'archived' so the file is self-describing.
+  const parsed = parseSkillMd(fs.readFileSync(ctx.record.filePath, 'utf8'));
+  parsed.frontmatter.status = 'archived';
+  fs.writeFileSync(mdDest, stringifySkillMd(parsed), { mode: 0o644 });
+  fs.copyFileSync(ctx.record.sidecarPath, sidecarDest);
+  fs.writeFileSync(
+    path.join(archiveDir, 'reason.json'),
+    JSON.stringify(
+      {
+        archived_at: new Date(ctx.ts).toISOString(),
+        archived_by: 'curator',
+        reason,
+        detail,
+        prior_status: ctx.record.frontmatter.status,
+      },
+      null,
+      2,
+    ),
+    { mode: 0o644 },
+  );
+
+  fs.unlinkSync(ctx.record.filePath);
+  fs.unlinkSync(ctx.record.sidecarPath);
+}
+
+function demoteSkill(ctx: MutationCtx): void {
+  const parsed = parseSkillMd(fs.readFileSync(ctx.record.filePath, 'utf8'));
+  parsed.frontmatter.status = 'candidate';
+  parsed.frontmatter.verified_runs = 1;
+  parsed.frontmatter.last_verified_at = new Date(ctx.ts).toISOString();
+  fs.writeFileSync(ctx.record.filePath, stringifySkillMd(parsed), { mode: 0o644 });
+
+  const sidecar: SkillSidecar = {
+    schema_version: SKILL_SCHEMA_VERSION,
+    skill_id: ctx.record.skill_id,
+    graph_node_anchor: ctx.record.sidecar.graph_node_anchor,
+    contract_id: ctx.record.sidecar.contract_id,
+    runs: {
+      count: 1,
+      window_start: new Date(ctx.ts).toISOString(),
+      recent: [{ txn_id: ctx.record.frontmatter.contract_ref, ok: true, ts: ctx.ts }],
+    },
+  };
+  fs.writeFileSync(ctx.record.sidecarPath, JSON.stringify(sidecar, null, 2), { mode: 0o644 });
+}
+
+/**
+ * Run Pass 1 prune across every domain under `rootDir`.
+ *
+ * Returns a PruneReport summarising all mutations. The caller (runner.ts)
+ * is responsible for acquiring the CuratorLock before calling this.
+ */
+export function runPrune(
+  statsResolver: SkillStatsResolver,
+  opts: PruneOptions = {},
+): PruneReport {
+  const rootDir = opts.rootDir ?? '';
+  if (!rootDir) {
+    throw new Error('runPrune: rootDir is required');
+  }
+  const ts = (opts.now ?? Date.now)();
+  const failRateThreshold = opts.failRateThreshold ?? DEFAULTS.failRateThreshold;
+  const failRateMinRuns = opts.failRateMinRuns ?? DEFAULTS.failRateMinRuns;
+  const failWindowMs = opts.failWindowMs ?? envInt('OPENCHROME_CURATOR_FAIL_WINDOW_MS', DEFAULTS.failWindowMs);
+  const doubleDemoteWindowMs =
+    opts.doubleDemoteWindowMs ?? envInt('OPENCHROME_CURATOR_DOUBLE_DEMOTE_MS', DEFAULTS.doubleDemoteWindowMs);
+  const staleArchiveMs = opts.staleArchiveMs ?? envInt('OPENCHROME_CURATOR_STALE_MS', DEFAULTS.staleArchiveMs);
+  const untouchedArchiveMs =
+    opts.untouchedArchiveMs ?? envInt('OPENCHROME_CURATOR_UNTOUCHED_MS', DEFAULTS.untouchedArchiveMs);
+
+  const report: PruneReport = {
+    run_id: crypto.randomBytes(6).toString('hex'),
+    started_at: ts,
+    ended_at: ts,
+    actions: [],
+    errors: [],
+    stats: { domains_seen: 0, skills_seen: 0, actions_count: 0 },
+  };
+
+  const domains = listDomains(rootDir);
+  report.stats.domains_seen = domains.length;
+
+  for (const domain of domains) {
+    const records = listSkillsForDomain(domain, { rootDir });
+    for (const rec of records) {
+      report.stats.skills_seen++;
+
+      // Safety rail: never touch user-authored skills.
+      if (rec.frontmatter.author !== 'agent') {
+        report.actions.push({
+          kind: 'skip_user_authored',
+          skill_id: rec.skill_id,
+          domain,
+          reason: 'author is not agent',
+          timestamp: ts,
+        });
+        continue;
+      }
+
+      // Safety rail: skip unknown schema versions.
+      if (rec.frontmatter.schema_version !== 1) {
+        report.actions.push({
+          kind: 'skip_unknown_schema',
+          skill_id: rec.skill_id,
+          domain,
+          reason: `schema_version=${rec.frontmatter.schema_version}`,
+          timestamp: ts,
+        });
+        continue;
+      }
+
+      let stats: SkillRunStats;
+      try {
+        stats = statsResolver(rec, failWindowMs);
+      } catch (e) {
+        report.errors.push(
+          `statsResolver threw for ${domain}/${rec.skill_id}: ${(e as Error).message}`,
+        );
+        continue;
+      }
+
+      const ctx: MutationCtx = { rootDir, domain, record: rec, ts };
+
+      // ----- Sub-pass A: confidence floor -----
+      const totalRuns = stats.successesInWindow + stats.failuresInWindow;
+      const failRate = totalRuns > 0 ? stats.failuresInWindow / totalRuns : 0;
+
+      if (
+        rec.frontmatter.status === 'promoted' &&
+        totalRuns >= failRateMinRuns &&
+        failRate > failRateThreshold
+      ) {
+        if (stats.demotesInDoubleDemoteWindow >= 1 && !stats.hadInterveningPromotion) {
+          archiveSkill(
+            ctx,
+            'archive_double_demote',
+            `fail_rate=${failRate.toFixed(2)} after prior demote within ${doubleDemoteWindowMs}ms`,
+          );
+          report.actions.push({
+            kind: 'archive_double_demote',
+            skill_id: rec.skill_id,
+            domain,
+            reason: 'double demote without intervening promotion',
+            timestamp: ts,
+          });
+          continue;
+        }
+        demoteSkill(ctx);
+        report.actions.push({
+          kind: 'demote',
+          skill_id: rec.skill_id,
+          domain,
+          reason: `fail_rate=${failRate.toFixed(2)} over ${totalRuns} runs`,
+          timestamp: ts,
+        });
+        continue; // skip TTL pass in same cycle
+      }
+
+      // ----- Sub-pass B: TTL -----
+      const lastVerifiedMs = Date.parse(rec.frontmatter.last_verified_at);
+      const ageVerified = Number.isFinite(lastVerifiedMs)
+        ? ts - lastVerifiedMs
+        : Number.POSITIVE_INFINITY;
+
+      if (
+        ageVerified > staleArchiveMs &&
+        stats.successesInWindow === 0 &&
+        rec.frontmatter.status !== 'archived'
+      ) {
+        archiveSkill(
+          ctx,
+          'archive_stale',
+          `last_verified_at older than ${staleArchiveMs}ms with 0 successes in window`,
+        );
+        report.actions.push({
+          kind: 'archive_stale',
+          skill_id: rec.skill_id,
+          domain,
+          reason: `stale: last_verified_at age ${ageVerified}ms`,
+          timestamp: ts,
+        });
+        continue;
+      }
+
+      const ageTouched =
+        stats.lastRunAt !== null ? ts - stats.lastRunAt : Number.POSITIVE_INFINITY;
+      if (ageTouched > untouchedArchiveMs && rec.frontmatter.status !== 'archived') {
+        archiveSkill(
+          ctx,
+          'archive_untouched',
+          `no skill_run audit for ${untouchedArchiveMs}ms`,
+        );
+        report.actions.push({
+          kind: 'archive_untouched',
+          skill_id: rec.skill_id,
+          domain,
+          reason: `untouched: lastRunAt age ${ageTouched}ms`,
+          timestamp: ts,
+        });
+        continue;
+      }
+    }
+  }
+
+  report.ended_at = (opts.now ?? Date.now)();
+  report.stats.actions_count = report.actions.length;
+  return report;
+}

--- a/src/pilot/curator/runner.ts
+++ b/src/pilot/curator/runner.ts
@@ -1,0 +1,146 @@
+/**
+ * Curator background runner (Phase 4, #763).
+ *
+ * Starts a `setInterval` timer that fires Pass 1 (prune) + Pass 3
+ * (promote) on a configurable cadence. The interval is `.unref()`-ed so
+ * it never prevents the Node process from exiting naturally.
+ *
+ * A `CuratorLock` is acquired before each cycle and released after.
+ * If the lock cannot be acquired (another `oc serve` already holds it),
+ * the cycle is silently skipped.
+ *
+ * Call sites MUST gate on `isSkillCuratorEnabled()` before calling
+ * `startCuratorRunner()`.
+ *
+ * Example:
+ *
+ *   import { isSkillCuratorEnabled } from '../../harness/flags.js';
+ *   import { startCuratorRunner } from './runner.js';
+ *
+ *   if (isSkillCuratorEnabled()) {
+ *     startCuratorRunner({ rootDir: defaultSkillRootDir() });
+ *   }
+ */
+
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { CuratorLock, defaultCuratorLockDir, type CuratorLockOptions } from './lock.js';
+import { runPrune, type SkillStatsResolver } from './prune.js';
+import { runPromote } from './promote.js';
+
+/** Default interval: 30 minutes. */
+const DEFAULT_INTERVAL_MS = 30 * 60 * 1_000;
+
+export interface CuratorRunnerOptions {
+  /** Root of the skill file tree (e.g. `~/.openchrome/skills`). */
+  rootDir?: string;
+  /** Override the PID lock directory. Default: `~/.openchrome/skills/.curator`. */
+  lockDir?: string;
+  /** Interval between curator cycles in ms. Default: 30 min. */
+  intervalMs?: number;
+  /**
+   * Stats resolver for Pass 1 prune. When omitted, a no-op resolver is
+   * used — all skills are treated as healthy (0 failures in window,
+   * touched recently). Callers should supply a real resolver that reads
+   * the audit log.
+   */
+  statsResolver?: SkillStatsResolver;
+  /** Test hook: clock. */
+  now?: () => number;
+  /**
+   * Test hook: called after each completed cycle with any errors that
+   * occurred. Useful for surfacing cycle failures in tests without
+   * coupling to stderr.
+   */
+  onCycleComplete?: (errors: string[]) => void;
+  /**
+   * Test hook: extra options forwarded to `CuratorLock` constructor.
+   * Use to inject `isAlive` or `ttlMs` in unit tests without spawning
+   * real competing processes.
+   */
+  lockOptions?: Pick<CuratorLockOptions, 'isAlive' | 'ttlMs'>;
+}
+
+export interface CuratorRunner {
+  /** Stop the background timer. Idempotent. */
+  stop(): void;
+}
+
+function defaultRootDir(): string {
+  return path.join(os.homedir(), '.openchrome', 'skills');
+}
+
+/**
+ * No-op stats resolver: treats every skill as healthy so Pass 1 does
+ * nothing when no audit-log adapter is wired. The real adapter lives
+ * in a follow-up.
+ */
+const noopStatsResolver: SkillStatsResolver = (_record) => ({
+  successesInWindow: 1,
+  failuresInWindow: 0,
+  lastRunAt: Date.now(),
+  demotesInDoubleDemoteWindow: 0,
+});
+
+/**
+ * Start the curator background runner. Returns a handle to stop it.
+ *
+ * The first cycle runs after `intervalMs`; it does not fire immediately
+ * so the hosting process can finish startup before the curator begins
+ * touching the skill tree.
+ */
+export function startCuratorRunner(opts: CuratorRunnerOptions = {}): CuratorRunner {
+  const rootDir = opts.rootDir ?? defaultRootDir();
+  const lockDir = opts.lockDir ?? defaultCuratorLockDir();
+  const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const statsResolver = opts.statsResolver ?? noopStatsResolver;
+  const now = opts.now ?? Date.now;
+
+  async function runCycle(): Promise<void> {
+    const lock = new CuratorLock({ rootDir: lockDir, now, ...opts.lockOptions });
+    if (!lock.acquire()) {
+      // Another process holds the lock — skip this cycle.
+      opts.onCycleComplete?.([]);
+      return;
+    }
+    const cycleErrors: string[] = [];
+    try {
+      // Pass 1: prune (deterministic, sync).
+      const pruneReport = runPrune(statsResolver, { rootDir, now });
+      cycleErrors.push(...pruneReport.errors);
+
+      // Pass 3: promote / recall ranking recompute (async store writes).
+      const promoteReport = await runPromote({ rootDir, now });
+      cycleErrors.push(...promoteReport.errors);
+    } catch (e) {
+      cycleErrors.push(`curator cycle error: ${(e as Error).message}`);
+    } finally {
+      lock.release();
+    }
+
+    if (cycleErrors.length > 0) {
+      for (const err of cycleErrors) {
+        console.error(`[curator] ${err}`);
+      }
+    }
+
+    opts.onCycleComplete?.(cycleErrors);
+  }
+
+  const timer = setInterval(() => {
+    runCycle().catch((e: Error) => {
+      console.error(`[curator] unhandled cycle error: ${e.message}`);
+    });
+  }, intervalMs);
+
+  // Do not prevent the process from exiting when this is the only
+  // remaining pending work.
+  timer.unref();
+
+  return {
+    stop(): void {
+      clearInterval(timer);
+    },
+  };
+}

--- a/tests/pilot/curator/lock.test.ts
+++ b/tests/pilot/curator/lock.test.ts
@@ -1,0 +1,136 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { CuratorLock } from '../../../src/pilot/curator/lock';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-cur-lock-'));
+}
+
+describe('CuratorLock — basic acquire/release', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('acquire on a fresh root succeeds and writes a lockfile', () => {
+    const lock = new CuratorLock({ rootDir: root });
+    expect(lock.acquire()).toBe(true);
+    expect(fs.existsSync(path.join(root, 'lock'))).toBe(true);
+    const holder = lock.readHolder();
+    expect(holder?.pid).toBe(process.pid);
+    lock.release();
+  });
+
+  test('release removes the lockfile when we still hold it', () => {
+    const lock = new CuratorLock({ rootDir: root });
+    lock.acquire();
+    lock.release();
+    expect(fs.existsSync(path.join(root, 'lock'))).toBe(false);
+  });
+
+  test('a second instance fails to acquire while first still holds', () => {
+    const a = new CuratorLock({ rootDir: root });
+    const b = new CuratorLock({ rootDir: root, isAlive: () => true });
+    expect(a.acquire()).toBe(true);
+    expect(b.acquire()).toBe(false);
+    a.release();
+  });
+
+  test('reusing a released instance throws', () => {
+    const lock = new CuratorLock({ rootDir: root });
+    lock.acquire();
+    lock.release();
+    expect(() => lock.acquire()).toThrow(/cannot reuse/);
+  });
+
+  test('acquire is idempotent on the same instance', () => {
+    const lock = new CuratorLock({ rootDir: root });
+    expect(lock.acquire()).toBe(true);
+    expect(lock.acquire()).toBe(true); // second call returns true without error
+    lock.release();
+  });
+});
+
+describe('CuratorLock — stale reclamation', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('reclaims when prior holder PID is dead', () => {
+    const lockPath = path.join(root, 'lock');
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: 0xfffffe, start_ts: Date.now() }));
+    const lock = new CuratorLock({ rootDir: root, isAlive: () => false });
+    expect(lock.acquire()).toBe(true);
+    expect(lock.readHolder()?.pid).toBe(process.pid);
+    lock.release();
+  });
+
+  test('reclaims when lockfile mtime is older than ttl, even if isAlive says true', () => {
+    const lockPath = path.join(root, 'lock');
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid + 1, start_ts: 0 }));
+    // Wind mtime 1 h + 1 min into the past.
+    const ancient = new Date(Date.now() - (60 * 60 * 1_000 + 60 * 1_000));
+    fs.utimesSync(lockPath, ancient, ancient);
+
+    const lock = new CuratorLock({ rootDir: root, isAlive: () => true });
+    expect(lock.acquire()).toBe(true);
+    lock.release();
+  });
+
+  test('does NOT reclaim when holder is alive and within ttl', () => {
+    const lockPath = path.join(root, 'lock');
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid + 1, start_ts: Date.now() }));
+    const lock = new CuratorLock({ rootDir: root, isAlive: () => true });
+    expect(lock.acquire()).toBe(false);
+  });
+
+  test('reclaims when lockfile is malformed (not JSON)', () => {
+    const lockPath = path.join(root, 'lock');
+    fs.writeFileSync(lockPath, 'not-json');
+    const lock = new CuratorLock({ rootDir: root, isAlive: () => true });
+    expect(lock.acquire()).toBe(true);
+    lock.release();
+  });
+
+  test('reclaims when lockfile has no pid field', () => {
+    const lockPath = path.join(root, 'lock');
+    fs.writeFileSync(lockPath, JSON.stringify({ start_ts: Date.now() }));
+    const lock = new CuratorLock({ rootDir: root, isAlive: () => true });
+    expect(lock.acquire()).toBe(true);
+    lock.release();
+  });
+});
+
+describe('CuratorLock — readHolder', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('returns null when no lock file exists', () => {
+    const lock = new CuratorLock({ rootDir: root });
+    expect(lock.readHolder()).toBeNull();
+  });
+
+  test('returns pid and start_ts after acquire', () => {
+    const before = Date.now();
+    const lock = new CuratorLock({ rootDir: root });
+    lock.acquire();
+    const holder = lock.readHolder();
+    expect(holder?.pid).toBe(process.pid);
+    expect(holder?.start_ts).toBeGreaterThanOrEqual(before);
+    lock.release();
+  });
+});

--- a/tests/pilot/curator/promote.test.ts
+++ b/tests/pilot/curator/promote.test.ts
@@ -1,0 +1,139 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { runPromote } from '../../../src/pilot/curator/promote';
+import { recordSuccessfulRun, listSkillsForDomain } from '../../../src/pilot/curator/extractor';
+import { SkillMemoryStore } from '../../../src/core/skill-memory/store';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-promote-'));
+}
+
+const FIXED_NOW = Date.parse('2026-05-08T12:00:00Z');
+
+function seedSkill(rootDir: string, domain: string, contractId: string, runs: number): void {
+  let now = FIXED_NOW;
+  const anchor = Buffer.from(contractId).toString('hex');
+  for (let i = 0; i < runs; i++) {
+    recordSuccessfulRun(
+      {
+        txn_id: `t-${contractId}-${i}`,
+        contract_id: contractId,
+        intent: `Test ${contractId}`,
+        domain,
+        graph_node_anchor: anchor,
+      },
+      { rootDir, now: () => now++ },
+    );
+  }
+}
+
+/**
+ * Seed a matching record in the SkillMemoryStore so Pass 3 can find it.
+ */
+async function seedStore(
+  rootDir: string,
+  domain: string,
+  skillId: string,
+  name: string,
+  contractId: string,
+): Promise<void> {
+  const store = new SkillMemoryStore({ rootDir, domain });
+  await store.record({
+    skillId,
+    domain,
+    name,
+    steps: [],
+    contractId,
+    successCount: 0,
+    lastUsedAt: 0,
+    frozenSnapshotPath: null,
+  });
+}
+
+describe('runPromote — updates store ranking weights', () => {
+  let root: string;
+  beforeEach(() => { root = tempRoot(); });
+  afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+  test('updates successCount and lastUsedAt when sidecar diverges from store', async () => {
+    seedSkill(root, 'amazon.com', 'A', 3);
+    const skills = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(skills).toHaveLength(1);
+    const rec = skills[0];
+
+    await seedStore(root, 'amazon.com', rec.skill_id, rec.frontmatter.name, 'A');
+
+    const report = await runPromote({ rootDir: root, now: () => FIXED_NOW });
+    expect(report.errors).toHaveLength(0);
+    expect(report.updated).toBe(1);
+
+    const store = new SkillMemoryStore({ rootDir: root, domain: 'amazon.com' });
+    const updated = store.get(rec.skill_id);
+    // markUsed increments successCount by 1 per call; after one promote cycle
+    // the count goes from 0 → 1 (one call with success=true).
+    expect(updated?.successCount).toBeGreaterThanOrEqual(1);
+  });
+
+  test('skips skills with no store record (skipped_no_record incremented)', async () => {
+    seedSkill(root, 'amazon.com', 'A', 3);
+    // No store.record() call — skill is unknown to the store.
+    const report = await runPromote({ rootDir: root, now: () => FIXED_NOW });
+    expect(report.skipped_no_record).toBe(1);
+    expect(report.updated).toBe(0);
+  });
+
+  test('does not update when successCount and lastUsedAt already match', async () => {
+    seedSkill(root, 'amazon.com', 'A', 3);
+    const skills = listSkillsForDomain('amazon.com', { rootDir: root });
+    const rec = skills[0];
+
+    // Pre-populate the store with the exact same values the promote would set.
+    const successEntries = rec.sidecar.runs.recent.filter((e) => e.ok);
+    const latestTs = Math.max(...successEntries.map((e) => e.ts));
+    const store = new SkillMemoryStore({ rootDir: root, domain: 'amazon.com' });
+    await store.record({
+      skillId: rec.skill_id,
+      domain: 'amazon.com',
+      name: rec.frontmatter.name,
+      steps: [],
+      contractId: 'A',
+      successCount: rec.sidecar.runs.count,
+      lastUsedAt: latestTs,
+      frozenSnapshotPath: null,
+    });
+
+    const report = await runPromote({ rootDir: root, now: () => FIXED_NOW });
+    expect(report.updated).toBe(0);
+  });
+
+  test('skips archived skills', async () => {
+    seedSkill(root, 'amazon.com', 'A', 1);
+    const skills = listSkillsForDomain('amazon.com', { rootDir: root });
+    const rec = skills[0];
+    // Manually set status to archived.
+    const content = fs.readFileSync(rec.filePath, 'utf8').replace('status: candidate', 'status: archived');
+    fs.writeFileSync(rec.filePath, content);
+
+    await seedStore(root, 'amazon.com', rec.skill_id, rec.frontmatter.name, 'A');
+
+    const report = await runPromote({ rootDir: root, now: () => FIXED_NOW });
+    expect(report.updated).toBe(0);
+  });
+
+  test('throws when rootDir is empty string', async () => {
+    await expect(runPromote({ rootDir: '' })).rejects.toThrow(/rootDir/);
+  });
+
+  test('returns correct stats counts', async () => {
+    seedSkill(root, 'amazon.com', 'A', 1);
+    seedSkill(root, 'github.com', 'B', 1);
+    fs.mkdirSync(path.join(root, '.curator'), { recursive: true });
+
+    const report = await runPromote({ rootDir: root, now: () => FIXED_NOW });
+    expect(report.stats.domains_seen).toBe(2);
+    expect(report.stats.skills_seen).toBe(2);
+    expect(report.run_id).toMatch(/^[0-9a-f]{12}$/);
+  });
+});

--- a/tests/pilot/curator/prune.test.ts
+++ b/tests/pilot/curator/prune.test.ts
@@ -1,0 +1,279 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { runPrune, type SkillRunStats } from '../../../src/pilot/curator/prune';
+import { recordSuccessfulRun, listSkillsForDomain } from '../../../src/pilot/curator/extractor';
+import { parseSkillMd } from '../../../src/pilot/curator/skill-md';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-prune-'));
+}
+
+const FIXED_NOW = Date.parse('2026-05-08T12:00:00Z');
+
+/**
+ * Seed a domain with N successful runs of a single skill.
+ * After 3 runs the skill reaches 'promoted' status.
+ */
+function seedSkill(rootDir: string, domain: string, contractId: string, runs: number): void {
+  let now = FIXED_NOW;
+  const anchor = Buffer.from(contractId).toString('hex');
+  for (let i = 0; i < runs; i++) {
+    recordSuccessfulRun(
+      {
+        txn_id: `t-${contractId}-${i}`,
+        contract_id: contractId,
+        intent: `Test ${contractId}`,
+        domain,
+        graph_node_anchor: anchor,
+      },
+      { rootDir, now: () => now++ },
+    );
+  }
+}
+
+function statsForFailingPromoted(): SkillRunStats {
+  return {
+    successesInWindow: 1,
+    failuresInWindow: 9, // fail_rate = 0.90
+    lastRunAt: FIXED_NOW,
+    demotesInDoubleDemoteWindow: 0,
+  };
+}
+
+function statsForHealthy(): SkillRunStats {
+  return {
+    successesInWindow: 5,
+    failuresInWindow: 0,
+    lastRunAt: FIXED_NOW,
+    demotesInDoubleDemoteWindow: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pass 1A — confidence floor
+// ---------------------------------------------------------------------------
+
+describe('runPrune — demote', () => {
+  let root: string;
+  beforeEach(() => { root = tempRoot(); });
+  afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+  test('demotes promoted skill with fail_rate > 0.30 and >= 5 runs', () => {
+    seedSkill(root, 'amazon.com', 'A', 3); // promoted after 3 successes
+    const before = listSkillsForDomain('amazon.com', { rootDir: root })[0];
+    expect(before.frontmatter.status).toBe('promoted');
+
+    const report = runPrune(() => statsForFailingPromoted(), {
+      rootDir: root,
+      now: () => FIXED_NOW + 1_000_000,
+    });
+    expect(report.actions).toHaveLength(1);
+    expect(report.actions[0].kind).toBe('demote');
+
+    const after = listSkillsForDomain('amazon.com', { rootDir: root })[0];
+    expect(after.frontmatter.status).toBe('candidate');
+    expect(after.frontmatter.verified_runs).toBe(1);
+    expect(after.sidecar.runs.count).toBe(1);
+    expect(after.sidecar.runs.recent).toHaveLength(1);
+  });
+
+  test('does NOT demote when total runs < failRateMinRuns (5)', () => {
+    seedSkill(root, 'amazon.com', 'A', 3);
+    const stats: SkillRunStats = {
+      successesInWindow: 1,
+      failuresInWindow: 3, // total = 4, below min
+      lastRunAt: FIXED_NOW,
+      demotesInDoubleDemoteWindow: 0,
+    };
+    const report = runPrune(() => stats, { rootDir: root, now: () => FIXED_NOW });
+    expect(report.actions.filter((a) => a.kind === 'demote')).toHaveLength(0);
+  });
+
+  test('does NOT demote when fail_rate <= 0.30 (boundary)', () => {
+    seedSkill(root, 'amazon.com', 'A', 3);
+    const stats: SkillRunStats = {
+      successesInWindow: 7,
+      failuresInWindow: 3, // exactly 30%
+      lastRunAt: FIXED_NOW,
+      demotesInDoubleDemoteWindow: 0,
+    };
+    const report = runPrune(() => stats, { rootDir: root, now: () => FIXED_NOW });
+    expect(report.actions.filter((a) => a.kind === 'demote')).toHaveLength(0);
+  });
+
+  test('archives on double-demote without intervening promotion', () => {
+    seedSkill(root, 'amazon.com', 'A', 3);
+    const stats: SkillRunStats = {
+      ...statsForFailingPromoted(),
+      demotesInDoubleDemoteWindow: 1,
+      hadInterveningPromotion: false,
+    };
+    const report = runPrune(() => stats, { rootDir: root, now: () => FIXED_NOW + 1_000_000 });
+    expect(report.actions[0].kind).toBe('archive_double_demote');
+    expect(listSkillsForDomain('amazon.com', { rootDir: root })).toHaveLength(0);
+    expect(fs.existsSync(path.join(root, 'amazon.com', '.archive'))).toBe(true);
+  });
+
+  test('does NOT archive on double-demote when hadInterveningPromotion is true', () => {
+    seedSkill(root, 'amazon.com', 'A', 3);
+    const stats: SkillRunStats = {
+      ...statsForFailingPromoted(),
+      demotesInDoubleDemoteWindow: 1,
+      hadInterveningPromotion: true,
+    };
+    const report = runPrune(() => stats, { rootDir: root, now: () => FIXED_NOW + 1_000_000 });
+    expect(report.actions[0].kind).toBe('demote');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pass 1B — TTL archival
+// ---------------------------------------------------------------------------
+
+describe('runPrune — TTL archive', () => {
+  let root: string;
+  beforeEach(() => { root = tempRoot(); });
+  afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+  test('archives stale skill (last_verified_at > staleArchiveMs + 0 successes)', () => {
+    seedSkill(root, 'amazon.com', 'A', 1);
+    const stats: SkillRunStats = {
+      successesInWindow: 0,
+      failuresInWindow: 0,
+      lastRunAt: FIXED_NOW,
+      demotesInDoubleDemoteWindow: 0,
+    };
+    const future = FIXED_NOW + 31 * 24 * 60 * 60 * 1_000;
+    const report = runPrune(() => stats, { rootDir: root, now: () => future });
+    expect(report.actions[0].kind).toBe('archive_stale');
+    expect(listSkillsForDomain('amazon.com', { rootDir: root })).toHaveLength(0);
+  });
+
+  test('archives untouched skill (no skill_run for > untouchedArchiveMs)', () => {
+    seedSkill(root, 'amazon.com', 'A', 1);
+    const stats: SkillRunStats = {
+      successesInWindow: 0,
+      failuresInWindow: 0,
+      lastRunAt: null,
+      demotesInDoubleDemoteWindow: 0,
+    };
+    const future = FIXED_NOW + 61 * 24 * 60 * 60 * 1_000;
+    const report = runPrune(() => stats, { rootDir: root, now: () => future });
+    expect(['archive_stale', 'archive_untouched']).toContain(report.actions[0].kind);
+    expect(listSkillsForDomain('amazon.com', { rootDir: root })).toHaveLength(0);
+  });
+
+  test('does NOT archive when skill is healthy', () => {
+    seedSkill(root, 'amazon.com', 'A', 3);
+    const report = runPrune(() => statsForHealthy(), { rootDir: root, now: () => FIXED_NOW });
+    expect(report.actions).toHaveLength(0);
+    expect(listSkillsForDomain('amazon.com', { rootDir: root })).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Safety rails
+// ---------------------------------------------------------------------------
+
+describe('runPrune — safety rails', () => {
+  let root: string;
+  beforeEach(() => { root = tempRoot(); });
+  afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+  test('skips user-authored skills', () => {
+    seedSkill(root, 'amazon.com', 'A', 3);
+    const list = listSkillsForDomain('amazon.com', { rootDir: root });
+    const content = fs.readFileSync(list[0].filePath, 'utf8').replace('author: agent', 'author: user');
+    fs.writeFileSync(list[0].filePath, content);
+
+    const report = runPrune(() => statsForFailingPromoted(), {
+      rootDir: root,
+      now: () => FIXED_NOW + 1_000_000,
+    });
+    expect(report.actions[0].kind).toBe('skip_user_authored');
+    expect(listSkillsForDomain('amazon.com', { rootDir: root })).toHaveLength(1);
+  });
+
+  test('writes reason.json under .archive/ on archival', () => {
+    seedSkill(root, 'amazon.com', 'A', 1);
+    const stats: SkillRunStats = {
+      successesInWindow: 0,
+      failuresInWindow: 0,
+      lastRunAt: null,
+      demotesInDoubleDemoteWindow: 0,
+    };
+    const future = FIXED_NOW + 61 * 24 * 60 * 60 * 1_000;
+    runPrune(() => stats, { rootDir: root, now: () => future });
+
+    const archived = fs.readdirSync(path.join(root, 'amazon.com', '.archive'));
+    expect(archived).toHaveLength(1);
+    const reasonPath = path.join(root, 'amazon.com', '.archive', archived[0], 'reason.json');
+    const reason = JSON.parse(fs.readFileSync(reasonPath, 'utf8'));
+    expect(reason.archived_by).toBe('curator');
+    expect(reason.archived_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test('archived SKILL.md has frontmatter status updated to archived', () => {
+    seedSkill(root, 'amazon.com', 'A', 1);
+    const stats: SkillRunStats = {
+      successesInWindow: 0,
+      failuresInWindow: 0,
+      lastRunAt: null,
+      demotesInDoubleDemoteWindow: 0,
+    };
+    const future = FIXED_NOW + 61 * 24 * 60 * 60 * 1_000;
+    runPrune(() => stats, { rootDir: root, now: () => future });
+
+    const archiveDir = fs.readdirSync(path.join(root, 'amazon.com', '.archive'))[0];
+    const archivedPath = path.join(root, 'amazon.com', '.archive', archiveDir);
+    const mdFile = fs.readdirSync(archivedPath).find((f) => f.endsWith('.md'))!;
+    const parsed = parseSkillMd(fs.readFileSync(path.join(archivedPath, mdFile), 'utf8'));
+    expect(parsed.frontmatter.status).toBe('archived');
+  });
+
+  test('idempotent — second run on same state produces empty action list', () => {
+    seedSkill(root, 'amazon.com', 'A', 3);
+    runPrune(() => statsForHealthy(), { rootDir: root, now: () => FIXED_NOW });
+    const second = runPrune(() => statsForHealthy(), { rootDir: root, now: () => FIXED_NOW });
+    expect(second.actions).toHaveLength(0);
+  });
+
+  test('surfaces statsResolver errors in report.errors without crashing', () => {
+    seedSkill(root, 'amazon.com', 'A', 3);
+    const report = runPrune(
+      () => { throw new Error('audit log unavailable'); },
+      { rootDir: root, now: () => FIXED_NOW },
+    );
+    expect(report.errors[0]).toContain('audit log unavailable');
+    expect(listSkillsForDomain('amazon.com', { rootDir: root })).toHaveLength(1);
+  });
+
+  test('throws when rootDir is empty string', () => {
+    expect(() => runPrune(() => statsForHealthy(), { rootDir: '' })).toThrow(/rootDir/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-domain
+// ---------------------------------------------------------------------------
+
+describe('runPrune — multi-domain', () => {
+  let root: string;
+  beforeEach(() => { root = tempRoot(); });
+  afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+  test('walks every domain dir and skips dot-prefixed dirs', () => {
+    seedSkill(root, 'amazon.com', 'A', 1);
+    seedSkill(root, 'github.com', 'B', 1);
+    fs.mkdirSync(path.join(root, '.curator'), { recursive: true });
+    const report = runPrune(() => statsForHealthy(), { rootDir: root, now: () => FIXED_NOW });
+    expect(report.stats.domains_seen).toBe(2);
+  });
+
+  test('report run_id is a 12-char hex string', () => {
+    const report = runPrune(() => statsForHealthy(), { rootDir: root, now: () => FIXED_NOW });
+    expect(report.run_id).toMatch(/^[0-9a-f]{12}$/);
+  });
+});

--- a/tests/pilot/curator/runner.test.ts
+++ b/tests/pilot/curator/runner.test.ts
@@ -1,0 +1,103 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { startCuratorRunner } from '../../../src/pilot/curator/runner';
+import { recordSuccessfulRun } from '../../../src/pilot/curator/extractor';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-runner-'));
+}
+
+const FIXED_NOW = Date.parse('2026-05-08T12:00:00Z');
+
+describe('startCuratorRunner', () => {
+  let root: string;
+  let lockDir: string;
+
+  beforeEach(() => {
+    root = tempRoot();
+    lockDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-runner-lock-'));
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(lockDir, { recursive: true, force: true });
+  });
+
+  test('returns a runner with a stop() method', () => {
+    const runner = startCuratorRunner({
+      rootDir: root,
+      lockDir,
+      intervalMs: 60_000,
+    });
+    expect(typeof runner.stop).toBe('function');
+    runner.stop();
+  });
+
+  test('stop() is idempotent', () => {
+    const runner = startCuratorRunner({
+      rootDir: root,
+      lockDir,
+      intervalMs: 60_000,
+    });
+    runner.stop();
+    expect(() => runner.stop()).not.toThrow();
+  });
+
+  test('fires a cycle and calls onCycleComplete with empty errors for healthy tree', async () => {
+    // Seed a skill so the runner has something to walk.
+    const anchor = Buffer.from('C').toString('hex');
+    recordSuccessfulRun(
+      {
+        txn_id: 'txn-r-0',
+        contract_id: 'C',
+        intent: 'test runner',
+        domain: 'runner.test',
+        graph_node_anchor: anchor,
+      },
+      { rootDir: root, now: () => FIXED_NOW },
+    );
+
+    const errors = await new Promise<string[]>((resolve) => {
+      const runner = startCuratorRunner({
+        rootDir: root,
+        lockDir,
+        intervalMs: 20, // fire quickly in test
+        now: () => FIXED_NOW,
+        onCycleComplete: (errs) => {
+          runner.stop();
+          resolve(errs);
+        },
+      });
+    });
+
+    expect(errors).toHaveLength(0);
+  }, 5_000);
+
+  test('cycle skips gracefully when another process holds the lock', async () => {
+    // Plant a lock file with an arbitrary PID.
+    fs.mkdirSync(lockDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(lockDir, 'lock'),
+      JSON.stringify({ pid: 99999, start_ts: Date.now() }),
+    );
+
+    // The runner should fire, fail to acquire (isAlive always true, TTL
+    // very long so mtime reclaim doesn't fire), and still call
+    // onCycleComplete with empty errors.
+    const errors = await new Promise<string[]>((resolve) => {
+      const runner = startCuratorRunner({
+        rootDir: root,
+        lockDir,
+        intervalMs: 20,
+        lockOptions: { isAlive: () => true, ttlMs: 24 * 60 * 60 * 1_000 },
+        onCycleComplete: (errs) => {
+          runner.stop();
+          resolve(errs);
+        },
+      });
+    });
+
+    expect(errors).toHaveLength(0);
+  }, 10_000);
+});


### PR DESCRIPTION
## Summary

- **`lock.ts`**: `CuratorLock` — PID-file lock with atomic temp+`link` write, stale TTL reclamation (1 h), and `process.kill(pid, 0)` liveness probe; prevents two curator instances running against the same domain root
- **`prune.ts`**: Pass 1 prune — confidence-floor demote (fail_rate > 30% over ≥5 runs → demote promoted→candidate; double-demote without intervening promotion → archive) and TTL archival (last_verified_at > 30 d with 0 successes → `archive_stale`; no `skill_run` for > 60 d → `archive_untouched`); never deletes, only moves to `<domain>/.archive/` with `reason.json`; safety rails skip user-authored and unknown-schema skills; idempotent
- **`promote.ts`**: Pass 3 promote — mirrors sidecar `runs.count` and latest success timestamp into `SkillMemoryStore.markUsed` so recall ranking weights stay current without requiring a runtime `markUsed` call; skips archived and store-unknown skills; best-effort (errors collected, not thrown)
- **`runner.ts`**: `startCuratorRunner()` — `setInterval(.unref())` background timer; acquires `CuratorLock` each cycle (skips silently if contested), runs Pass 1 then Pass 3, releases lock; gated by `isSkillCuratorEnabled()` at call sites; no LLM calls

All four modules are exported from `src/pilot/curator/index.ts`.

## References

- Replaces closed #763 (original curator PR)
- Sibling: #810 (extractor, already merged), #800 (storage), #774, #780

## Test plan

- [ ] `tests/pilot/curator/lock.test.ts` — 12 tests: acquire/release, stale reclamation (dead PID, TTL, malformed), idempotency, `readHolder`
- [ ] `tests/pilot/curator/prune.test.ts` — 16 tests: demote, double-demote archive, TTL archive (stale + untouched), safety rails (user-authored skip, reason.json, archived frontmatter, idempotency, resolver errors, empty rootDir), multi-domain walk
- [ ] `tests/pilot/curator/promote.test.ts` — 6 tests: updates store weights, skips no-record skills, no-op when already in sync, skips archived, throws on empty rootDir, stats counts
- [ ] `tests/pilot/curator/runner.test.ts` — 4 tests: returns stop handle, stop idempotent, cycle fires + onCycleComplete, skips gracefully when lock is held

**Total: 94 tests, all passing. Build and lint:tier clean.**

```
Test Suites: 6 passed, 6 total
Tests:       94 passed, 94 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)