### PR TITLE
feat(pilot): curator Pass 2 — structural sibling merge (Phase 4, replaces #764)

### DIFF
--- a/src/pilot/curator/index.ts
+++ b/src/pilot/curator/index.ts
@@ -42,3 +42,19 @@ export type {
   SkillSidecar,
   SkillStatus,
 } from './types';
+
+export {
+  clusterSkills,
+  jaccard,
+  runMerge,
+  tokenize,
+} from './merge';
+export type {
+  ClusterCandidate,
+  MergeAction,
+  MergeActionKind,
+  MergeOutcome,
+  RunMergeOptions,
+} from './merge';
+
+export { STOP_WORDS } from './stop-words';

--- a/src/pilot/curator/merge.ts
+++ b/src/pilot/curator/merge.ts
@@ -1,0 +1,310 @@
+/**
+ * Skill curator Pass 2 — structural sibling merge (Phase 4, #764).
+ *
+ * Two skills under the same domain that share a graph-anchor prefix AND
+ * a meaningful Jaccard intent overlap likely document the same underlying
+ * flow at different points in its evolution. Pass 2 clusters them and
+ * merges the cluster in-place: the seed (highest verified_runs) becomes
+ * the umbrella, non-seed siblings are archived.
+ *
+ * Structural-only — no LLM. LLM-augmented semantic merge is out of scope
+ * per P3 (separate package tracked in #776).
+ *
+ * Gated by `OPENCHROME_SKILL_MEM_MERGE=1` (checked by the caller).
+ *
+ * Per #715 v2 P0/P1:
+ *   - Clustering input: same graph_node_anchor prefix (first N chars,
+ *     default 3) AND Jaccard ≥ 0.70 over stop-word-stripped intent
+ *     tokens AND same contract_id.
+ *   - On merge: umbrella inherits seed name/intent/body; archived run
+ *     histories are unioned and sorted oldest-first so subsequent
+ *     recordSuccessfulRun slice(-N) evicts the oldest entry on overflow.
+ *   - Never modifies user-authored skills (author !== 'agent').
+ *   - Never deletes — only archives.
+ *   - Idempotent: re-running on a clean state produces no actions.
+ *
+ * `runMerge()` is associative — merge order doesn't matter for the
+ * structural-only path.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { computeSkillId, listSkillsForDomain } from './extractor';
+import { parseSkillMd, stringifySkillMd } from './skill-md';
+import { STOP_WORDS } from './stop-words';
+import { SKILL_RUN_LOG_MAX, SKILL_SCHEMA_VERSION, type SkillRecord, type SkillSidecar } from './types';
+
+// ---- Types -----------------------------------------------------------------
+
+export type MergeActionKind = 'merge' | 'merge_skipped';
+
+export interface MergeAction {
+  kind: MergeActionKind;
+  skill_id: string;
+  domain: string;
+  reason: string;
+  timestamp: number;
+}
+
+export interface MergeOutcome {
+  actions: MergeAction[];
+  errors: string[];
+}
+
+export interface RunMergeOptions {
+  rootDir: string;
+  domain: string;
+  jaccardThreshold?: number;
+  prefixChars?: number;
+  now?: () => number;
+}
+
+export interface ClusterCandidate {
+  records: SkillRecord[];
+}
+
+// ---- Public helpers (exported for tests) -----------------------------------
+
+/** Tokenize an intent string for Jaccard comparison. */
+export function tokenize(intent: string): Set<string> {
+  return new Set(
+    intent
+      .toLowerCase()
+      .split(/\s+/)
+      .map((w) => w.replace(/[^\p{L}\p{N}_]+/gu, ''))
+      .filter((w) => w.length > 0 && !STOP_WORDS.has(w)),
+  );
+}
+
+/** Jaccard similarity between two sets. */
+export function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  let intersection = 0;
+  for (const v of a) if (b.has(v)) intersection++;
+  const unionSize = a.size + b.size - intersection;
+  return unionSize === 0 ? 0 : intersection / unionSize;
+}
+
+/**
+ * Greedy clustering: the cluster seed is the highest-`verified_runs`
+ * record. Candidates joining the cluster must share the seed's
+ * graph_node_anchor prefix AND clear `jaccardThreshold` against the
+ * seed's intent AND share the same `contract_id`.
+ *
+ * Two skills sharing a prefix-of-zero is meaningless, so `prefixChars`
+ * is clamped to a minimum of 1.
+ */
+export function clusterSkills(
+  records: SkillRecord[],
+  opts: { jaccardThreshold?: number; prefixChars?: number } = {},
+): ClusterCandidate[] {
+  const jacc = opts.jaccardThreshold ?? 0.7;
+  const prefix = Math.max(1, opts.prefixChars ?? 3);
+  const eligible = records
+    .filter((r) => r.frontmatter.author === 'agent')
+    .filter((r) => r.frontmatter.status !== 'archived');
+  const seen = new Set<string>();
+  const ranked = [...eligible].sort(
+    (a, b) => b.frontmatter.verified_runs - a.frontmatter.verified_runs,
+  );
+  const clusters: ClusterCandidate[] = [];
+  for (const seed of ranked) {
+    if (seen.has(seed.skill_id)) continue;
+    const seedTokens = tokenize(seed.frontmatter.intent);
+    const seedPrefix = seed.frontmatter.graph_node_anchor.slice(0, prefix);
+    const cluster: SkillRecord[] = [seed];
+    seen.add(seed.skill_id);
+    for (const cand of ranked) {
+      if (seen.has(cand.skill_id)) continue;
+      // Enforce contract_id homogeneity — skills from different contracts
+      // must not be merged even if intent/anchor prefix aligns.
+      if (cand.sidecar.contract_id !== seed.sidecar.contract_id) continue;
+      // Anchor-prefix gate: coarse pre-filter before Jaccard.
+      if (cand.frontmatter.graph_node_anchor.slice(0, prefix) !== seedPrefix) continue;
+      if (jaccard(seedTokens, tokenize(cand.frontmatter.intent)) < jacc) continue;
+      cluster.push(cand);
+      seen.add(cand.skill_id);
+    }
+    if (cluster.length >= 2) clusters.push({ records: cluster });
+  }
+  return clusters;
+}
+
+// ---- Private helpers -------------------------------------------------------
+
+function isoUtc(ms: number): string {
+  return new Date(ms).toISOString().replace(/\.\d+Z$/, 'Z');
+}
+
+function archiveSibling(args: {
+  rootDir: string;
+  domain: string;
+  record: SkillRecord;
+  mergedIntoSkillId: string;
+  ts: number;
+}): void {
+  const archiveDir = path.join(args.rootDir, args.domain, '.archive', args.record.skill_id);
+  fs.mkdirSync(archiveDir, { recursive: true });
+  const newMdPath = path.join(archiveDir, path.basename(args.record.filePath));
+  const newSidecarPath = path.join(archiveDir, path.basename(args.record.sidecarPath));
+
+  const parsed = parseSkillMd(fs.readFileSync(args.record.filePath, 'utf8'));
+  parsed.frontmatter.status = 'archived';
+  fs.writeFileSync(newMdPath, stringifySkillMd(parsed), { mode: 0o644 });
+  fs.copyFileSync(args.record.sidecarPath, newSidecarPath);
+  fs.writeFileSync(
+    path.join(archiveDir, 'reason.json'),
+    JSON.stringify(
+      {
+        archived_at: isoUtc(args.ts),
+        archived_by: 'curator',
+        reason: 'merged_into',
+        merged_into_skill_id: args.mergedIntoSkillId,
+        prior_status: args.record.frontmatter.status,
+      },
+      null,
+      2,
+    ),
+    { mode: 0o644 },
+  );
+
+  fs.unlinkSync(args.record.filePath);
+  fs.unlinkSync(args.record.sidecarPath);
+}
+
+// ---- Runner ----------------------------------------------------------------
+
+/**
+ * Run Pass 2 (structural sibling merge) across one domain. Idempotent:
+ * re-running on a clean state produces no actions.
+ *
+ * Gating on `OPENCHROME_SKILL_MEM_MERGE=1` is the caller's responsibility.
+ */
+export function runMerge(opts: RunMergeOptions): MergeOutcome {
+  const ts = (opts.now ?? Date.now)();
+  const records = listSkillsForDomain(opts.domain, { rootDir: opts.rootDir });
+  const clusters = clusterSkills(records, {
+    jaccardThreshold: opts.jaccardThreshold,
+    prefixChars: opts.prefixChars,
+  });
+  const actions: MergeAction[] = [];
+  const errors: string[] = [];
+
+  for (const cluster of clusters) {
+    const seed = cluster.records[0];
+    const newSkillId = computeSkillId(seed.frontmatter.graph_node_anchor, seed.sidecar.contract_id);
+    const writePath = path.join(opts.rootDir, opts.domain, `${newSkillId}.md`);
+    const sidecarPath = path.join(opts.rootDir, opts.domain, `${newSkillId}.json`);
+
+    const aggregateRuns = cluster.records.reduce(
+      (sum, r) => sum + r.frontmatter.verified_runs,
+      0,
+    );
+
+    // Preserve verification provenance from the sibling with the most
+    // recent last_verified_at. Using curator runtime ts would make stale
+    // clusters appear freshly verified, biasing recall ranking.
+    const freshest = cluster.records.reduce((best, r) =>
+      Date.parse(r.frontmatter.last_verified_at) > Date.parse(best.frontmatter.last_verified_at)
+        ? r
+        : best,
+    );
+
+    // Structural merge: seed name/intent/body become the umbrella.
+    // Re-read the seed's body from disk — SkillRecord carries only
+    // frontmatter + sidecar, not the markdown body.
+    let umbrellaBody: string;
+    let serialized: string;
+    try {
+      const seedText = fs.readFileSync(seed.filePath, 'utf8');
+      const seedParsed = parseSkillMd(seedText);
+      umbrellaBody = seedParsed.body;
+      const umbrellaFm = {
+        schema_version: SKILL_SCHEMA_VERSION as 1,
+        name: seed.frontmatter.name,
+        domain: opts.domain,
+        intent: seed.frontmatter.intent,
+        status: seed.frontmatter.status,
+        verified_runs: aggregateRuns,
+        last_verified_at: freshest.frontmatter.last_verified_at,
+        contract_ref: freshest.frontmatter.contract_ref,
+        graph_node_anchor: seed.frontmatter.graph_node_anchor,
+        author: 'agent' as const,
+      };
+      serialized = stringifySkillMd({ frontmatter: umbrellaFm, body: umbrellaBody });
+    } catch (e) {
+      const reason = `merge_parse_failure: ${(e as Error).message}`;
+      errors.push(reason);
+      actions.push({
+        kind: 'merge_skipped',
+        skill_id: seed.skill_id,
+        domain: opts.domain,
+        reason,
+        timestamp: ts,
+      });
+      continue;
+    }
+
+    // Write umbrella .md atomically (tmp + rename).
+    const tmpMd = writePath + '.tmp';
+    fs.writeFileSync(tmpMd, serialized, { mode: 0o644 });
+    fs.renameSync(tmpMd, writePath);
+
+    // Union sibling run histories, sorted oldest-first so that a
+    // subsequent recordSuccessfulRun slice(-SKILL_RUN_LOG_MAX) evicts the
+    // oldest entries on overflow rather than the newest.
+    const mergedRecent: SkillSidecar['runs']['recent'] = cluster.records
+      .flatMap((r) => r.sidecar.runs.recent)
+      .sort((a, b) => a.ts - b.ts)
+      .slice(-SKILL_RUN_LOG_MAX);
+
+    const sidecarBody = JSON.stringify(
+      {
+        schema_version: SKILL_SCHEMA_VERSION,
+        skill_id: newSkillId,
+        graph_node_anchor: seed.frontmatter.graph_node_anchor,
+        contract_id: seed.sidecar.contract_id,
+        runs: {
+          count: aggregateRuns,
+          window_start: isoUtc(ts),
+          recent: mergedRecent,
+        },
+        merged_from: cluster.records.map((r) => r.skill_id),
+      },
+      null,
+      2,
+    );
+    const tmpSidecar = sidecarPath + '.tmp';
+    fs.writeFileSync(tmpSidecar, sidecarBody, { mode: 0o644 });
+    fs.renameSync(tmpSidecar, sidecarPath);
+
+    for (const sibling of cluster.records) {
+      // The sibling whose skill_id equals newSkillId is the seed — its
+      // file was overwritten in place above. Archiving it would delete
+      // the file we just wrote, so skip it.
+      if (sibling.skill_id === newSkillId) continue;
+      try {
+        archiveSibling({
+          rootDir: opts.rootDir,
+          domain: opts.domain,
+          record: sibling,
+          mergedIntoSkillId: newSkillId,
+          ts,
+        });
+      } catch (e) {
+        errors.push(`archive failed for ${sibling.skill_id}: ${(e as Error).message}`);
+      }
+    }
+
+    actions.push({
+      kind: 'merge',
+      skill_id: newSkillId,
+      domain: opts.domain,
+      reason: `merged ${cluster.records.length} siblings (Jaccard structural match, intent="${seed.frontmatter.intent.slice(0, 80)}")`,
+      timestamp: ts,
+    });
+  }
+
+  return { actions, errors };
+}

--- a/src/pilot/curator/stop-words.ts
+++ b/src/pilot/curator/stop-words.ts
@@ -1,0 +1,38 @@
+/**
+ * Tiny English stop-words list used by Pass 2 (#715 v2) when computing
+ * Jaccard similarity over skill `intent` strings. Intentionally
+ * minimal — we only need to drop the words that show up in nearly
+ * every intent ("the", "a", "to") and would otherwise inflate
+ * similarity scores. Larger lists belong in a real NLP dep we don't
+ * want to take.
+ */
+
+export const STOP_WORDS: ReadonlySet<string> = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'by',
+  'do',
+  'for',
+  'from',
+  'has',
+  'have',
+  'in',
+  'is',
+  'it',
+  'of',
+  'on',
+  'or',
+  'that',
+  'the',
+  'this',
+  'to',
+  'was',
+  'were',
+  'will',
+  'with',
+]);

--- a/tests/pilot/curator/merge.test.ts
+++ b/tests/pilot/curator/merge.test.ts
@@ -1,0 +1,570 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  clusterSkills,
+  jaccard,
+  runMerge,
+  tokenize,
+} from '../../../src/pilot/curator/merge';
+import {
+  computeSkillId,
+  listSkillsForDomain,
+  recordSuccessfulRun,
+} from '../../../src/pilot/curator/extractor';
+import { parseSkillMd } from '../../../src/pilot/curator/skill-md';
+import { SKILL_RUN_LOG_MAX } from '../../../src/pilot/curator/types';
+import type { SkillRecord } from '../../../src/pilot/curator/types';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-merge-'));
+}
+
+const FIXED_NOW = Date.parse('2026-05-08T12:00:00Z');
+
+/* ------------------------------------------------------------------ */
+/* tokenize / jaccard                                                  */
+/* ------------------------------------------------------------------ */
+
+describe('tokenize', () => {
+  test('lowercases + strips punctuation + removes stop-words', () => {
+    expect(tokenize('Add a Cart Item! And Pay.')).toEqual(new Set(['add', 'cart', 'item', 'pay']));
+  });
+
+  test('empty string → empty set', () => {
+    expect(tokenize('').size).toBe(0);
+  });
+
+  test('all stop-words → empty set', () => {
+    expect(tokenize('the a an and to of').size).toBe(0);
+  });
+
+  test('Unicode letters preserved', () => {
+    expect(tokenize('카트에 추가').has('카트에')).toBe(true);
+  });
+});
+
+describe('jaccard', () => {
+  test('identical sets → 1.0', () => {
+    expect(jaccard(new Set(['a', 'b']), new Set(['a', 'b']))).toBe(1);
+  });
+
+  test('disjoint sets → 0', () => {
+    expect(jaccard(new Set(['a']), new Set(['b']))).toBe(0);
+  });
+
+  test('overlap formula matches expected', () => {
+    // {a,b,c} vs {b,c,d} → intersection 2, union 4 → 0.5
+    expect(jaccard(new Set(['a', 'b', 'c']), new Set(['b', 'c', 'd']))).toBeCloseTo(0.5);
+  });
+
+  test('two empty sets → 1.0 (vacuously equal)', () => {
+    expect(jaccard(new Set(), new Set())).toBe(1);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* clusterSkills                                                       */
+/* ------------------------------------------------------------------ */
+
+function rec(
+  over: Partial<SkillRecord['frontmatter']> = {},
+  sidecarOver: Partial<SkillRecord['sidecar']> = {},
+): SkillRecord {
+  const skill_id = (over.name ?? 'sk') + '-' + Math.random().toString(36).slice(2, 6);
+  return {
+    skill_id,
+    filePath: `/tmp/${skill_id}.md`,
+    sidecarPath: `/tmp/${skill_id}.json`,
+    frontmatter: {
+      schema_version: 1,
+      name: over.name ?? 'sk-x',
+      domain: 'amazon.com',
+      intent: 'Add cart item and pay',
+      status: 'promoted',
+      verified_runs: 5,
+      last_verified_at: '2026-05-08T12:00:00Z',
+      contract_ref: 'txn',
+      graph_node_anchor: 'aaaa1234',
+      author: 'agent',
+      ...over,
+    },
+    sidecar: {
+      schema_version: 1,
+      skill_id,
+      graph_node_anchor: over.graph_node_anchor ?? 'aaaa1234',
+      contract_id: 'cid',
+      runs: { count: 5, window_start: '2026-04-01T00:00:00Z', recent: [] },
+      ...sidecarOver,
+    },
+  };
+}
+
+describe('clusterSkills — clustering', () => {
+  test('skills with same prefix + ≥0.70 Jaccard cluster together', () => {
+    const records = [
+      rec({ graph_node_anchor: 'aaaa1234', intent: 'Add cart item and pay' }),
+      rec({ graph_node_anchor: 'aaaa9999', intent: 'Add cart item, then pay' }),
+      rec({ graph_node_anchor: 'bbbb1111', intent: 'Add cart item and pay' }), // diff prefix
+    ];
+    const clusters = clusterSkills(records, { jaccardThreshold: 0.7, prefixChars: 4 });
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].records).toHaveLength(2);
+  });
+
+  test('skills below Jaccard threshold do not cluster', () => {
+    const records = [
+      rec({ graph_node_anchor: 'aaaa1234', intent: 'Add cart item and pay' }),
+      rec({ graph_node_anchor: 'aaaa9999', intent: 'Search for product' }),
+    ];
+    expect(clusterSkills(records, { jaccardThreshold: 0.7, prefixChars: 4 })).toHaveLength(0);
+  });
+
+  test('user-authored skills are excluded from clustering', () => {
+    const records = [
+      rec({ graph_node_anchor: 'aaaa1234', intent: 'Add cart item' }),
+      rec({ graph_node_anchor: 'aaaa9999', intent: 'Add cart item', author: 'user' }),
+    ];
+    expect(clusterSkills(records, { jaccardThreshold: 0.7, prefixChars: 4 })).toHaveLength(0);
+  });
+
+  test('archived skills are excluded', () => {
+    const records = [
+      rec({ graph_node_anchor: 'aaaa1234', intent: 'Add cart item' }),
+      rec({ graph_node_anchor: 'aaaa9999', intent: 'Add cart item', status: 'archived' }),
+    ];
+    expect(clusterSkills(records, { jaccardThreshold: 0.7, prefixChars: 4 })).toHaveLength(0);
+  });
+
+  test('seed picks highest verified_runs first', () => {
+    const records = [
+      rec({ graph_node_anchor: 'aaaa1', intent: 'low', verified_runs: 1 }),
+      rec({ graph_node_anchor: 'aaaa2', intent: 'low', verified_runs: 5 }),
+      rec({ graph_node_anchor: 'aaaa3', intent: 'low', verified_runs: 3 }),
+    ];
+    const clusters = clusterSkills(records, { jaccardThreshold: 0.7, prefixChars: 4 });
+    expect(clusters[0].records[0].frontmatter.verified_runs).toBe(5);
+  });
+
+  test('singleton clusters (only seed matches its own prefix) are dropped', () => {
+    const records = [rec({ graph_node_anchor: 'aaaa1234', intent: 'unique' })];
+    expect(clusterSkills(records)).toHaveLength(0);
+  });
+
+  test('skills with same intent/anchor prefix but different contract_id do NOT cluster', () => {
+    const records = [
+      rec(
+        { graph_node_anchor: 'aaaa1234', intent: 'Add cart item and pay' },
+        { contract_id: 'contract-A' },
+      ),
+      rec(
+        { graph_node_anchor: 'aaaa9999', intent: 'Add cart item, then pay' },
+        { contract_id: 'contract-B' },
+      ),
+    ];
+    expect(clusterSkills(records, { jaccardThreshold: 0.7, prefixChars: 4 })).toHaveLength(0);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* runMerge — structural merge (no LLM)                               */
+/* ------------------------------------------------------------------ */
+
+// Shared contract_id so siblings cluster together.
+const SHARED_CONTRACT_ID = 'contract-cart-checkout-v1';
+
+function seedTwoSiblingsOnDisk(rootDir: string): void {
+  let now = FIXED_NOW;
+  for (const [anchor, intent] of [
+    ['aaaaffff0001', 'Add cart item and pay'],
+    ['aaaaffff0002', 'Add cart item, then pay'],
+  ] as const) {
+    for (let i = 0; i < 4; i++) {
+      // 4 successful runs ⇒ promoted (threshold 3)
+      recordSuccessfulRun(
+        {
+          txn_id: `t-${anchor}-${i}`,
+          contract_id: SHARED_CONTRACT_ID,
+          intent,
+          domain: 'amazon.com',
+          graph_node_anchor: anchor,
+        },
+        { rootDir, now: () => now++ },
+      );
+    }
+  }
+}
+
+describe('runMerge', () => {
+  let root: string;
+  beforeEach(() => {
+    root = tempRoot();
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('happy path: cluster merges into umbrella, non-seed siblings archived', () => {
+    seedTwoSiblingsOnDisk(root);
+    const out = runMerge({
+      rootDir: root,
+      domain: 'amazon.com',
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => FIXED_NOW,
+    });
+    expect(out.actions.find((a) => a.kind === 'merge')).toBeDefined();
+    const list = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(list).toHaveLength(1);
+    // Only the non-seed sibling gets an archive entry.
+    const archiveDir = path.join(root, 'amazon.com', '.archive');
+    expect(fs.readdirSync(archiveDir).length).toBe(1);
+  });
+
+  test('umbrella inherits seed name and intent', () => {
+    seedTwoSiblingsOnDisk(root);
+    const preList = listSkillsForDomain('amazon.com', { rootDir: root });
+    const seedBefore = [...preList].sort(
+      (a, b) => b.frontmatter.verified_runs - a.frontmatter.verified_runs,
+    )[0];
+
+    runMerge({
+      rootDir: root,
+      domain: 'amazon.com',
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => FIXED_NOW,
+    });
+
+    const list = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(list).toHaveLength(1);
+    expect(list[0].frontmatter.name).toBe(seedBefore.frontmatter.name);
+    expect(list[0].frontmatter.intent).toBe(seedBefore.frontmatter.intent);
+  });
+
+  test('archive reason.json carries merged_into_skill_id', () => {
+    seedTwoSiblingsOnDisk(root);
+    const out = runMerge({
+      rootDir: root,
+      domain: 'amazon.com',
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => FIXED_NOW,
+    });
+    const mergedId = out.actions.find((a) => a.kind === 'merge')!.skill_id;
+    const archiveDir = path.join(root, 'amazon.com', '.archive');
+    for (const sub of fs.readdirSync(archiveDir)) {
+      const reason = JSON.parse(
+        fs.readFileSync(path.join(archiveDir, sub, 'reason.json'), 'utf8'),
+      );
+      expect(reason.reason).toBe('merged_into');
+      expect(reason.merged_into_skill_id).toBe(mergedId);
+    }
+  });
+
+  test('umbrella SKILL.md frontmatter has aggregate verified_runs', () => {
+    seedTwoSiblingsOnDisk(root);
+    runMerge({
+      rootDir: root,
+      domain: 'amazon.com',
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => FIXED_NOW,
+    });
+    const list = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(list).toHaveLength(1);
+    const text = fs.readFileSync(list[0].filePath, 'utf8');
+    const parsed = parseSkillMd(text);
+    expect(parsed.frontmatter.verified_runs).toBe(8); // 4 + 4
+  });
+
+  test('does nothing when no clusters exist', () => {
+    let now = FIXED_NOW;
+    recordSuccessfulRun(
+      {
+        txn_id: 't1',
+        contract_id: 'A',
+        intent: 'lone skill',
+        domain: 'amazon.com',
+        graph_node_anchor: 'aaaa1111',
+      },
+      { rootDir: root, now: () => now++ },
+    );
+    const out = runMerge({
+      rootDir: root,
+      domain: 'amazon.com',
+      jaccardThreshold: 0.7,
+      prefixChars: 4,
+      now: () => FIXED_NOW,
+    });
+    expect(out.actions).toHaveLength(0);
+    expect(out.errors).toHaveLength(0);
+  });
+
+  test('umbrella filename equals computeSkillId(seed.graph_node_anchor, seed.contract_id)', () => {
+    seedTwoSiblingsOnDisk(root);
+    const preList = listSkillsForDomain('amazon.com', { rootDir: root });
+    const expectedIds = preList.map((r) =>
+      computeSkillId(r.frontmatter.graph_node_anchor, r.sidecar.contract_id),
+    );
+
+    runMerge({
+      rootDir: root,
+      domain: 'amazon.com',
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => FIXED_NOW,
+    });
+
+    const postList = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(postList).toHaveLength(1);
+    const umbrellaSkillId = postList[0].skill_id;
+    expect(expectedIds).toContain(umbrellaSkillId);
+
+    const sidecar = postList[0].sidecar;
+    expect(computeSkillId(sidecar.graph_node_anchor, sidecar.contract_id)).toBe(umbrellaSkillId);
+  });
+
+  test('merged umbrella runs.recent carries sibling histories sorted oldest-first', () => {
+    const SIBLING_RUNS = 5;
+    const anchors = ['aaaaffff0001', 'aaaaffff0002'] as const;
+    let tick = FIXED_NOW;
+
+    for (const anchor of anchors) {
+      for (let i = 0; i < SIBLING_RUNS; i++) {
+        recordSuccessfulRun(
+          {
+            txn_id: `reg-${anchor}-${i}`,
+            contract_id: SHARED_CONTRACT_ID,
+            intent: 'Add cart item and pay',
+            domain: 'amazon.com',
+            graph_node_anchor: anchor,
+          },
+          { rootDir: root, now: () => tick++ },
+        );
+      }
+    }
+
+    runMerge({
+      rootDir: root,
+      domain: 'amazon.com',
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => tick,
+    });
+
+    const postList = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(postList).toHaveLength(1);
+    const umbrella = postList[0];
+    const recent = umbrella.sidecar.runs.recent;
+
+    const totalSiblingRuns = anchors.length * SIBLING_RUNS; // 10, under cap
+    expect(recent.length).toBe(Math.min(totalSiblingRuns, SKILL_RUN_LOG_MAX));
+
+    // Oldest-first sort.
+    for (let i = 1; i < recent.length; i++) {
+      expect(recent[i - 1].ts).toBeLessThanOrEqual(recent[i].ts);
+    }
+  });
+
+  test('follow-up recordSuccessfulRun does not regress verified_runs below merged aggregate', () => {
+    const SIBLING_RUNS = 5;
+    const anchors = ['aaaaffff0001', 'aaaaffff0002'] as const;
+    let tick = FIXED_NOW;
+
+    for (const anchor of anchors) {
+      for (let i = 0; i < SIBLING_RUNS; i++) {
+        recordSuccessfulRun(
+          {
+            txn_id: `reg-${anchor}-${i}`,
+            contract_id: SHARED_CONTRACT_ID,
+            intent: 'Add cart item and pay',
+            domain: 'amazon.com',
+            graph_node_anchor: anchor,
+          },
+          { rootDir: root, now: () => tick++ },
+        );
+      }
+    }
+
+    runMerge({
+      rootDir: root,
+      domain: 'amazon.com',
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => tick,
+    });
+
+    const umbrella = listSkillsForDomain('amazon.com', { rootDir: root })[0];
+    const mergedVerifiedRuns = umbrella.frontmatter.verified_runs;
+    const followUpResult = recordSuccessfulRun(
+      {
+        txn_id: 'follow-up-txn',
+        contract_id: SHARED_CONTRACT_ID,
+        intent: 'Add cart item and pay',
+        domain: 'amazon.com',
+        graph_node_anchor: umbrella.frontmatter.graph_node_anchor,
+      },
+      { rootDir: root, now: () => tick + 1000 },
+    );
+    expect(followUpResult.record.frontmatter.verified_runs).toBeGreaterThanOrEqual(mergedVerifiedRuns);
+  });
+
+  test('overflow after merge: runs.recent capped at SKILL_RUN_LOG_MAX, oldest dropped', () => {
+    const anchors = ['bbbbffff0001', 'bbbbffff0002'] as const;
+    let tick = FIXED_NOW - 100_000;
+
+    for (const anchor of anchors) {
+      for (let i = 0; i < SKILL_RUN_LOG_MAX; i++) {
+        recordSuccessfulRun(
+          {
+            txn_id: `overflow-${anchor}-${i}`,
+            contract_id: SHARED_CONTRACT_ID,
+            intent: 'Add cart item and pay',
+            domain: 'amazon.com',
+            graph_node_anchor: anchor,
+          },
+          { rootDir: root, now: () => tick++ },
+        );
+      }
+    }
+
+    const oldestTs = FIXED_NOW - 100_000;
+
+    runMerge({
+      rootDir: root,
+      domain: 'amazon.com',
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => tick,
+    });
+
+    const postList = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(postList).toHaveLength(1);
+    const recentAfterMerge = postList[0].sidecar.runs.recent;
+
+    // Capped.
+    expect(recentAfterMerge.length).toBe(SKILL_RUN_LOG_MAX);
+
+    // Oldest-first.
+    for (let i = 1; i < recentAfterMerge.length; i++) {
+      expect(recentAfterMerge[i - 1].ts).toBeLessThanOrEqual(recentAfterMerge[i].ts);
+    }
+
+    // Oldest pre-merge entry dropped.
+    expect(recentAfterMerge.some((r) => r.ts === oldestTs)).toBe(false);
+
+    // Follow-up run: newest must survive, cap preserved.
+    const newRunTs = tick + 9_999_999;
+    const followUpResult = recordSuccessfulRun(
+      {
+        txn_id: 'overflow-follow-up',
+        contract_id: SHARED_CONTRACT_ID,
+        intent: 'Add cart item and pay',
+        domain: 'amazon.com',
+        graph_node_anchor: postList[0].frontmatter.graph_node_anchor,
+      },
+      { rootDir: root, now: () => newRunTs },
+    );
+
+    const recentAfterFollowUp = followUpResult.record.sidecar.runs.recent;
+    expect(recentAfterFollowUp.length).toBe(SKILL_RUN_LOG_MAX);
+    expect(recentAfterFollowUp.some((r) => r.ts === newRunTs)).toBe(true);
+    expect(followUpResult.record.frontmatter.verified_runs).toBe(SKILL_RUN_LOG_MAX);
+  });
+
+  test('umbrella adopts freshest sibling last_verified_at + contract_ref', () => {
+    const STALE_TS = '2026-01-01T00:00:00Z';
+    const FRESH_TS = '2026-04-30T00:00:00Z';
+    const STALE_CONTRACT = 'txn-stale-aaa';
+    const FRESH_CONTRACT = 'txn-fresh-bbb';
+
+    const anchors = ['ccccffff0001', 'ccccffff0002'] as const;
+    let tick = FIXED_NOW;
+    for (const anchor of anchors) {
+      for (let i = 0; i < 4; i++) {
+        recordSuccessfulRun(
+          {
+            txn_id: `prov-${anchor}-${i}`,
+            contract_id: SHARED_CONTRACT_ID,
+            intent: 'Add cart item and pay',
+            domain: 'amazon.com',
+            graph_node_anchor: anchor,
+          },
+          { rootDir: root, now: () => tick++ },
+        );
+      }
+    }
+
+    // Overwrite frontmatter of both siblings with controlled provenance.
+    const skills = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(skills).toHaveLength(2);
+    const [sibA, sibB] = skills;
+    for (const [sib, lva, cref] of [
+      [sibA, STALE_TS, STALE_CONTRACT],
+      [sibB, FRESH_TS, FRESH_CONTRACT],
+    ] as const) {
+      const text = fs.readFileSync(sib.filePath, 'utf8');
+      const patched = text
+        .replace(/last_verified_at: .+/, `last_verified_at: ${lva}`)
+        .replace(/contract_ref: .+/, `contract_ref: ${cref}`);
+      fs.writeFileSync(sib.filePath, patched);
+    }
+
+    const CURATOR_TS = FIXED_NOW + 99_999;
+    runMerge({
+      rootDir: root,
+      domain: 'amazon.com',
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => CURATOR_TS,
+    });
+
+    const list = listSkillsForDomain('amazon.com', { rootDir: root });
+    expect(list).toHaveLength(1);
+    const parsed = parseSkillMd(fs.readFileSync(list[0].filePath, 'utf8'));
+
+    expect(parsed.frontmatter.last_verified_at).toBe(FRESH_TS);
+    expect(parsed.frontmatter.contract_ref).toBe(FRESH_CONTRACT);
+
+    const curatorIso = new Date(CURATOR_TS).toISOString();
+    expect(parsed.frontmatter.last_verified_at).not.toBe(curatorIso);
+  });
+
+  test('idempotent: re-running on already-merged state produces no actions', () => {
+    seedTwoSiblingsOnDisk(root);
+    runMerge({
+      rootDir: root,
+      domain: 'amazon.com',
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => FIXED_NOW,
+    });
+    // Only one skill left — clusterSkills finds no cluster.
+    const out2 = runMerge({
+      rootDir: root,
+      domain: 'amazon.com',
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => FIXED_NOW + 1,
+    });
+    expect(out2.actions).toHaveLength(0);
+    expect(out2.errors).toHaveLength(0);
+  });
+
+  test('no LLM dependency: runMerge is synchronous and returns MergeOutcome directly', () => {
+    // Verify the return is not a Promise — structural-only path is sync.
+    seedTwoSiblingsOnDisk(root);
+    const result = runMerge({
+      rootDir: root,
+      domain: 'amazon.com',
+      jaccardThreshold: 0.5,
+      prefixChars: 4,
+      now: () => FIXED_NOW,
+    });
+    // If it were a Promise, it would not have an `actions` array directly.
+    expect(Array.isArray(result.actions)).toBe(true);
+    expect(Array.isArray(result.errors)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements curator Pass 2: detects two skills under the same `(domain, intent)` whose step graphs are structurally near-duplicate (shared `graph_node_anchor` prefix + Jaccard intent overlap) and merges them in-place.
- **Structural-only merge. LLM-augmented semantic merge is out of scope per P3 (separate package tracked in #776).**
- Gated behind `OPENCHROME_SKILL_MEM_MERGE=1` env flag (merge can be costlier than Pass 1/3).
- `runMerge()` is associative — merge order doesn't matter for the structural-only path.
- Replaces closed #764.

## Files

| File | Lines | Role |
|------|-------|------|
| `src/pilot/curator/merge.ts` | ~230 | `runMerge()`, `clusterSkills()`, `tokenize()`, `jaccard()` |
| `src/pilot/curator/stop-words.ts` | 35 | Minimal English stop-word set for intent Jaccard |
| `src/pilot/curator/index.ts` | +15 | Exports for new merge module |
| `tests/pilot/curator/merge.test.ts` | ~320 | 27 tests |

## Algorithm

1. `clusterSkills()`: greedy clustering keyed on `(contract_id, anchor-prefix, Jaccard ≥ 0.70)`. Seed = highest `verified_runs`. User-authored and archived skills excluded.
2. `runMerge()`: for each cluster — seed content (name, intent, body) becomes umbrella; `verified_runs` = aggregate sum; `runs.recent` = union sorted oldest-first (so `slice(-N)` evicts oldest on overflow); non-seed siblings archived under `.archive/<id>/reason.json { merged_into }`.
3. Idempotent: re-running on a clean state produces no actions.

## No LLM imports

`merge.ts` imports only `node:fs`, `node:path`, and sibling pilot/curator modules. Zero imports from `src/core/**` outside `src/contracts/` types, zero imports from `src/pilot/voting/`.

## Related PRs / Issues

- Replaces closed #764
- Contract types: #774
- Storage: #800
- Extractor sibling: #810
- LLM-augmented merge (separate package): #776
- Pass 1/3 curator: #780

## Test plan

- [x] `tsc --noEmit` — zero errors
- [x] `eslint` — zero warnings
- [x] `depcruise` — no dependency violations
- [x] `jest tests/pilot/curator/merge.test.ts` — 27 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)