### PR TITLE
docs(#732): README v1.11 section + getting-started + architecture pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,32 @@ openchrome update
 
 ---
 
+## What's new in v1.11
+
+v1.11 establishes a **core / pilot tier split** inside the same npm package. Existing v1.10 configurations work bit-identically; new harness capabilities are additive.
+
+**Core tier** (active by default, no flag):
+
+- **Trace recorder** — JSONL session capture with credential redactor
+- **Skill state graph** — JSON-per-domain graph storage + `openchrome://skill-graph/<domain>` MCP resource
+- **Skill memory** — JSON store + audit-log-backed stats; `oc_skill_record`, `oc_skill_recall` MCP tools
+- **Outcome contracts** — DSL + evaluators (DOM, network, screenshot-class, perceptual hash); `oc_assert`, `oc_evidence_bundle` MCP tools
+- **Perception primitives** — perceptual DOM metadata + DOM↔screenshot cross-check (Sobel + color)
+
+**Pilot tier** (opt-in via `--pilot`):
+
+```bash
+openchrome serve --pilot
+```
+
+Adds: contract runtime (retry + idempotency + `beforeIrreversibleAction`), handoff token + AES-256-GCM persistence (ephemeral key default), multi-model voting framework (deterministic voters), skill curator (extractor + recall ranking + structural merge + PID lock + background runner).
+
+Pilot families are individually gated by `OPENCHROME_TRACE`, `OPENCHROME_STATE_GRAPH`, `OPENCHROME_CONTRACT_RUNTIME`, `OPENCHROME_HANDOFF_PERSIST`, `OPENCHROME_PERCEPTION_VOTING`, `OPENCHROME_SKILL_CURATOR`. All default *active* inside `--pilot`; set the env to `0` to turn one family off.
+
+**Design contract**: portability-harness policy at [`docs/roadmap/portability-harness-contract.md`](docs/roadmap/portability-harness-contract.md). Architecture overview at [`docs/architecture.md`](docs/architecture.md). End-to-end walkthrough at [`docs/getting-started.md`](docs/getting-started.md). Full v1.11 release notes at [`docs/releases/v1.11.1.md`](docs/releases/v1.11.1.md).
+
+---
+
 ## Examples
 
 **Parallel monitoring:**
@@ -309,7 +335,7 @@ oc compare prices for "AirPods Pro" across Amazon, eBay, Walmart, Best Buy
 
 ---
 
-## 46 Tools
+## 50 Tools
 
 | Category | Tools |
 |----------|-------|
@@ -319,11 +345,16 @@ oc compare prices for "AirPods Pro" across Amazon, eBay, Walmart, Best Buy
 | **Storage & Debug** | `cookies`, `storage`, `console_capture`, `performance_metrics`, `request_intercept` |
 | **Parallel Workflows** | `workflow_init`, `workflow_collect`, `worker_create`, `batch_execute` |
 | **Memory** | `memory_record`, `memory_query`, `memory_validate` |
+| **Contracts & Skills** *(v1.11)* | `oc_assert`, `oc_evidence_bundle`, `oc_skill_record`, `oc_skill_recall` |
+
+**MCP resources**: `openchrome://skill-graph/<domain>` (read-only JSON snapshot of the per-domain skill graph; v1.11).
 
 <details>
-<summary>Full tool list (46)</summary>
+<summary>Full tool list (50)</summary>
 
-`navigate` `interact` `computer` `read_page` `find` `form_input` `fill_form` `javascript_tool` `page_reload` `page_content` `page_pdf` `wait_for` `user_agent` `geolocation` `emulate_device` `network` `selector_query` `xpath_query` `cookies` `storage` `console_capture` `performance_metrics` `request_intercept` `drag_drop` `file_upload` `http_auth` `worker_create` `worker_list` `worker_update` `worker_complete` `worker_delete` `tabs_create` `tabs_context` `tabs_close` `workflow_init` `workflow_status` `workflow_collect` `workflow_collect_partial` `workflow_cleanup` `execute_plan` `batch_execute` `lightweight_scroll` `memory_record` `memory_query` `memory_validate` `oc_stop`
+`navigate` `interact` `computer` `read_page` `find` `form_input` `fill_form` `javascript_tool` `page_reload` `page_content` `page_pdf` `wait_for` `user_agent` `geolocation` `emulate_device` `network` `selector_query` `xpath_query` `cookies` `storage` `console_capture` `performance_metrics` `request_intercept` `drag_drop` `file_upload` `http_auth` `worker_create` `worker_list` `worker_update` `worker_complete` `worker_delete` `tabs_create` `tabs_context` `tabs_close` `workflow_init` `workflow_status` `workflow_collect` `workflow_collect_partial` `workflow_cleanup` `execute_plan` `batch_execute` `lightweight_scroll` `memory_record` `memory_query` `memory_validate` `oc_stop` `oc_assert` `oc_evidence_bundle` `oc_skill_record` `oc_skill_recall`
+
+With `--pilot` flag, additional pilot-tier tools are registered under the `oc_pilot_*` namespace (handoff, voting, curator). See [`docs/architecture.md`](docs/architecture.md).
 
 </details>
 
@@ -334,10 +365,13 @@ oc compare prices for "AirPods Pro" across Amazon, eBay, Walmart, Best Buy
 ```bash
 openchrome setup                    # Auto-configure
 openchrome serve --auto-launch      # Start server
+openchrome serve --pilot            # Opt into pilot tier (v1.11+)
 openchrome serve --headless-shell   # Headless mode
 openchrome doctor                   # Diagnose issues
 openchrome update                   # Update CLI
 ```
+
+Window placement (v1.11): `--window-size <w,h>`, `--window-position <x,y>`, `--window-bounds <x,y,w,h>`, `--start-maximized`, or set `OPENCHROME_WINDOW_*` env. Default is `0,0` + `1280×900` (previously `--start-maximized` + `1920×1080`).
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,184 @@
+# OpenChrome Architecture
+
+This document gives a one-page overview of how OpenChrome is structured at the
+v1.11 line. For the rationale behind the structure, read
+[`docs/roadmap/portability-harness-contract.md`](roadmap/portability-harness-contract.md).
+For end-to-end usage, see [`docs/getting-started.md`](getting-started.md).
+
+## One-line summary
+
+> OpenChrome is an MCP server that exposes Chrome via the Chrome DevTools
+> Protocol. It captures facts (DOM, screenshots, network, traces, skills,
+> contracts); a host agent uses those facts to decide what to do next.
+
+## Two tiers
+
+```
+openchrome-mcp (one npm package, one binary, one CLI)
+│
+├── src/core/           ← active by default, no flag
+│   │                     P1–P5 strictly enforced
+│   │
+│   ├── trace/          JSONL session capture + credential redactor
+│   ├── skill/          JSON-per-domain state graph + URL normalizer
+│   ├── skill-memory/   JSON-per-domain skill store + audit-log stats
+│   ├── contracts/      Outcome contract DSL + 7 evaluators + pHash
+│   ├── perception/     Perceptual DOM metadata + Sobel/color cross-check
+│   ├── cli/            Replay UI and inspection commands
+│   ├── mcp/            Server, transports, tool dispatch
+│   └── resources/      openchrome://skill-graph/<domain>
+│
+└── src/pilot/          ← opt-in via --pilot
+                          Relaxes P1 (background work) and P4 (policy);
+                          still enforces P3 (no LLM API calls).
+    │
+    ├── runtime/        Contract runtime: retry, verdict taxonomy,
+    │                   idempotency cache, beforeIrreversibleAction hook
+    ├── handoff/        Token + manager + AES-256-GCM persistence
+    │                   (ephemeral key default)
+    ├── voting/         Voter interface + orchestrator (deterministic;
+    │                   LLM-backed voters live in host-side libraries)
+    └── curator/        Verified skill extractor + recall ranking +
+                        Pass 1 prune + Pass 2 structural merge +
+                        Pass 3 promote + PID lock + background runner
+```
+
+### Import boundary
+
+The directory split is enforced by a `dependency-cruiser` rule
+(`.dependency-cruiser.cjs`):
+
+- `src/core/**` **must not** import from `src/pilot/**`.
+- `src/pilot/**` **may** import from `src/core/**`.
+
+CI fails on any PR that violates the rule (`npm run lint:tier`).
+
+### Shared helper module
+
+`src/harness/flags.ts` lives at neither tier; both can import it. It exposes:
+
+- `isPilotEnabled()` — true iff `--pilot` argv flag or `OPENCHROME_PILOT` env
+  is set
+- `isTraceEnabled()`, `isStateGraphEnabled()`, `isContractRuntimeEnabled()`,
+  `isHandoffPersistEnabled()`, `isPerceptionVotingEnabled()`,
+  `isSkillCuratorEnabled()` — per-family getters
+- `bootstrapPilot()` — dynamic `import('../pilot/index.js')`, returns null
+  when `--pilot` is unset (proof that no pilot module enters the process)
+- `logActiveFlags()` — single `[harness] core only` or
+  `[harness] core+pilot enabled (...)` line to **stderr** at startup
+
+## The five principles
+
+The contract that governs every PR landing on `develop`:
+
+- **P1. Tool server identity** — accept tool calls, return results. Long-lived
+  background work only in pilot, only when an operator enables it.
+- **P2. Zero-impact harness extension** — when `--pilot` is unset, every
+  optional native dep fails to load gracefully, every storage directory may
+  be missing, and the 1.10.4 tool surface still returns bit-identical
+  responses.
+- **P3. Anywhere-compatible MCP** — no outbound LLM API calls, no mandatory
+  API keys at boot, no platform-specific compile toolchains, no OS keychains.
+  Applies to **both tiers**.
+- **P4. Facts versus decisions** — the server stores and computes facts.
+  LLM judgment lives outside the server (host agent or separate package).
+- **P5. Native dependency discipline** — `argon2` is the only mandatory
+  native runtime dep. Future native deps go into `optionalDependencies`
+  with a documented fallback.
+
+## Data flow for a typical agent loop
+
+```
+                 ┌──────────────────────────────────────────────────────────┐
+                 │                  HOST AGENT (Claude Code, etc.)          │
+                 │                                                          │
+                 │   1. Reads tools/list                                    │
+                 │   2. Decides which tool to call                          │
+                 │   3. Calls oc_assert / oc_skill_recall / navigate / ...  │
+                 │   4. Receives facts; runs its own model to decide next   │
+                 └──────────────────────────────────────────────────────────┘
+                                              │
+                                  JSON-RPC over stdio (or HTTP)
+                                              ▼
+                 ┌──────────────────────────────────────────────────────────┐
+                 │                    openchrome-mcp                        │
+                 │                                                          │
+                 │   ┌─────────┐    ┌────────────────────┐                  │
+                 │   │ core/   │ ←─ │ mcp dispatcher     │                  │
+                 │   │ tools   │    │ + tier-1 gating    │                  │
+                 │   └────┬────┘    └──────┬─────────────┘                  │
+                 │        │                │                                │
+                 │        │   --pilot? ─── ▼                                │
+                 │        │           ┌─────────┐                           │
+                 │        │           │ pilot/  │                           │
+                 │        │           └────┬────┘                           │
+                 │        │                │                                │
+                 │   ┌────▼────────────────▼──────┐                         │
+                 │   │   CDP client + Chrome      │                         │
+                 │   │   process supervision      │                         │
+                 │   └────────────┬───────────────┘                         │
+                 └────────────────┼─────────────────────────────────────────┘
+                                  │
+                              CDP / DevTools Protocol
+                                  ▼
+                          ┌──────────────────┐
+                          │   real Chrome    │
+                          │  (your profile)  │
+                          └──────────────────┘
+```
+
+### Where the LLM lives
+
+> The LLM is in the **host agent**, not in `openchrome-mcp`. The server
+> never calls Anthropic / OpenAI / Google directly. If you want LLM-powered
+> voting or merge, the host agent calls its own model and then calls the
+> appropriate openchrome-mcp tool to record the result.
+
+## Storage policy
+
+Everything new in v1.11 stores to JSONL or JSON files coordinated by
+[`proper-lockfile`](https://www.npmjs.com/package/proper-lockfile). No
+SQLite. Concrete paths:
+
+```
+~/.openchrome/
+├── trace/<sessionId>/<ts>-<seq>.jsonl       trace events
+├── trace/<sessionId>/meta.json              session metadata
+├── skill-graph/<encodedDomain>.json         JSON-per-domain skill graph
+├── skill-memory/<encodedDomain>/skills.json skill records
+├── skill-memory/<encodedDomain>/snapshots/  gzipped frozen snapshots
+├── audit.log                                JSONL audit log
+└── handoff/<sha256(token)>.enc              AES-256-GCM encrypted token
+                                             (ephemeral key, lost on restart
+                                             unless OPENCHROME_HANDOFF_KEY_FILE)
+```
+
+`src/utils/atomic-file.ts` provides `writeFileAtomicSafe`,
+`readFileSafe`, and `acquireLock` helpers that every new storage layer
+uses.
+
+## Dependency footprint
+
+Mandatory native runtime dep: **`argon2`** (authentication). Pure-JS deps:
+`commander`, `jose`, `proper-lockfile`, `puppeteer-core`
+(`rebrowser-puppeteer-core` re-namespaced), `uuid`, `write-file-atomic`.
+Top-level `npm overrides` for `basic-ftp` and `ip-address` neutralize
+transitive advisories.
+
+## Out of scope for the server
+
+Things that explicitly do **not** live in `openchrome-mcp`:
+
+- Server-side LLM API calls (Anthropic / OpenAI / Google etc.) — see P3
+- Multi-step task orchestration — host agent's job
+- AI agent lifecycle management — host process's job
+- 24/7 uptime SLA — operator infrastructure
+- OS keychain / Secret Service / Credential Manager integration —
+  use `OPENCHROME_HANDOFF_KEY_FILE` instead
+
+## Reference
+
+- Contract: [`docs/roadmap/portability-harness-contract.md`](roadmap/portability-harness-contract.md)
+- Reliability contract: [`docs/roadmap/issue-reliability-guarantee.md`](roadmap/issue-reliability-guarantee.md)
+- v1.11 cleanup history: [`docs/roadmap/history/openchrome-1.11-cleanup.md`](roadmap/history/openchrome-1.11-cleanup.md)
+- v1.11.1 release notes: [`docs/releases/v1.11.1.md`](releases/v1.11.1.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,192 @@
+# Getting Started with OpenChrome
+
+A single-page walkthrough from installation to running your first verifiable
+contract and recalling your first skill. Targets v1.11+.
+
+## 1. Install
+
+```bash
+npm install -g openchrome-mcp@latest
+openchrome --version    # should print 1.11.1 or newer
+openchrome setup        # auto-configures your MCP client (Claude Code by default)
+```
+
+For other MCP clients:
+
+```bash
+openchrome setup --client codex      # Codex CLI
+openchrome setup --client opencode   # OpenCode
+```
+
+Restart your MCP client. That's it for the core install — the next sections
+are optional.
+
+## 2. Confirm core tier is live
+
+Open a fresh chat in your MCP client and ask it to navigate somewhere:
+
+```
+"oc navigate https://example.com and read the page title"
+```
+
+You should see the agent call `navigate` and `read_page`. The default v1.11
+install brings four extra MCP tools beyond v1.10:
+
+- `oc_assert` — run a single contract assertion against page state
+- `oc_evidence_bundle` — capture DOM + screenshot + network + console snapshot
+- `oc_skill_record` — store a reusable skill record
+- `oc_skill_recall` — retrieve skill records for a domain
+
+…plus one new MCP resource: `openchrome://skill-graph/<domain>` (read-only).
+
+## 3. Your first contract
+
+A contract is a small JSON declaring what "success" looks like on a page.
+Below is a minimal example you can pass inline to `oc_assert`:
+
+```json
+{
+  "id": "homepage_loaded",
+  "domain": "example.com",
+  "assertions": [
+    { "kind": "url", "equals": "https://example.com/" },
+    { "kind": "dom_count", "selector": "h1", "gte": 1 },
+    { "kind": "dom_text", "selector": "h1", "contains": "Example Domain" }
+  ]
+}
+```
+
+Ask your agent:
+
+```
+"oc, navigate to https://example.com then oc_assert this contract"
+```
+
+Expected verdict: `pass`. If you change `dom_text` to look for
+`"Different Domain"`, the verdict is `fail` and `failed_assertions` shows
+exactly which check failed and what was actually observed.
+
+## 4. Capture an evidence bundle
+
+When you want a richer record of page state (for debugging or for replay):
+
+```
+"oc, run oc_evidence_bundle with include=['dom','screenshot','network','phash']"
+```
+
+Returns:
+
+```json
+{
+  "bundle_id": "evb_2026-05-12T05-30-22_abc123",
+  "path": "/Users/<you>/.openchrome/evidence/evb_.../",
+  "size_bytes": 184320,
+  "parts": ["dom.txt", "screenshot.png", "network.jsonl", "phash.txt"]
+}
+```
+
+The bundle directory is a flat collection of files. No SQL or special tooling
+needed to inspect them.
+
+## 5. Record and recall a skill
+
+Skills are reusable named recipes for accomplishing a goal on a domain:
+
+```
+"oc, on https://example.com, save a skill named 'open-homepage' with these steps:
+ 1. navigate to https://example.com
+ 2. wait for h1
+ 3. oc_assert {<homepage_loaded contract>}"
+```
+
+The agent calls `oc_skill_record({ domain, name, steps, contract_id })`. Later:
+
+```
+"oc, oc_skill_recall for example.com"
+```
+
+Returns up to 20 skills for the domain, ordered by recency.
+
+## 6. Inspect the skill graph
+
+The skill state graph is a read-only MCP resource:
+
+```
+openchrome://skill-graph/example.com
+```
+
+Any MCP client that supports resources can subscribe / fetch the JSON
+snapshot. Useful for dashboards or for the agent to plan a multi-step
+recovery path.
+
+## 7. (Optional) Enable the pilot tier
+
+Pilot adds: contract runtime with retry, handoff token + encrypted
+persistence, multi-model voting framework, and a background skill curator.
+
+Edit your MCP client config to add `--pilot`:
+
+```json
+{
+  "mcpServers": {
+    "openchrome": {
+      "command": "openchrome",
+      "args": ["serve", "--auto-launch", "--pilot"]
+    }
+  }
+}
+```
+
+Restart your MCP client. When the server boots, **stderr** prints:
+
+```
+[harness] core+pilot enabled (trace,state_graph,contract_runtime,handoff_persist,perception_voting,skill_curator)
+```
+
+You can turn an individual family off without losing the rest:
+
+```bash
+OPENCHROME_PERCEPTION_VOTING=0 openchrome serve --pilot
+```
+
+## 8. (Optional) Persist handoff tokens across restarts
+
+By default, the pilot handoff persistence layer uses an **ephemeral** key
+generated at boot. Persisted tokens are invalidated on every restart, which
+is the safer default for laptops and CI.
+
+For long-running servers where cross-restart persistence matters, point at
+a key file you manage:
+
+```bash
+# Generate a 32-byte key once
+openssl rand -out ~/.openchrome/handoff-key.bin 32
+chmod 600 ~/.openchrome/handoff-key.bin
+
+# Tell the server to use it
+export OPENCHROME_HANDOFF_KEY_FILE=~/.openchrome/handoff-key.bin
+openchrome serve --pilot
+```
+
+The file is never logged and never embedded in audit records. If the file
+size is anything other than exactly 32 bytes, the server falls back to
+ephemeral mode and prints a warning to stderr.
+
+## 9. Update later
+
+```bash
+openchrome update
+```
+
+This runs `npm install -g openchrome-mcp@latest` and re-runs setup against
+your MCP client config so the runtime path stays in sync.
+
+## What next
+
+- [`docs/architecture.md`](architecture.md) — one-page overview of the
+  core / pilot tier split and where each subsystem lives
+- [`docs/roadmap/portability-harness-contract.md`](roadmap/portability-harness-contract.md) —
+  the durable design contract every future PR must satisfy
+- [`docs/releases/v1.11.1.md`](releases/v1.11.1.md) — full release notes
+  with the cumulative v1.10.4 → v1.11.1 diff
+- `openchrome doctor` — diagnose installation issues


### PR DESCRIPTION
## Summary

Documentation refresh aligned with the v1.11.1 surface and the portability-harness contract.

Closes #732.

## What changes

- **`README.md`** (+50 lines):
  - New **"What's new in v1.11"** section under Quick Start enumerating core vs pilot subsystems and the per-family `OPENCHROME_*` env flags.
  - **Tools table** bumped **46 → 50** with a new "Contracts & Skills (v1.11)" row covering `oc_assert` / `oc_evidence_bundle` / `oc_skill_record` / `oc_skill_recall`. Full tool list updated.
  - **MCP resources** note for `openchrome://skill-graph/<domain>`.
  - **CLI cheatsheet** adds `--pilot` and the new window placement flags (`--window-size`, `--window-position`, `--window-bounds`, `--start-maximized`), plus a note about the default flip (`0,0` + `1280×900`, away from `--start-maximized` + `1920×1080`).
- **`docs/architecture.md`** (new, 184 lines): one-page architecture overview — two-tier directory layout, import boundary (dependency-cruiser rule), shared `src/harness/flags.ts` helper, the five principles in shorthand, a data-flow diagram (host → MCP → Chrome), on-disk storage layout under `~/.openchrome/`, and an explicit "out of scope for the server" list.
- **`docs/getting-started.md`** (new, 192 lines): 9-step walkthrough from install through pilot opt-in, including a copy-pasteable inline contract example targeting `example.com`.

## What does NOT change

- No source code touched. `npm run build` clean.
- Existing `docs/roadmap/` content unchanged.
- Existing `docs/releases/*` files unchanged.

## Verification

- `npm run build`: clean (docs-only PR, but sanity check passed)
- `git diff --stat main..HEAD`: 3 files, +413 / -3
- All internal Markdown links use relative paths and target files that exist (`docs/roadmap/portability-harness-contract.md`, `docs/roadmap/history/openchrome-1.11-cleanup.md`, `docs/releases/v1.11.1.md`)

## Test plan

- [ ] Reviewer pulls the branch and opens `docs/getting-started.md` end-to-end on a fresh `openchrome-mcp@1.11.1` install; confirm steps 1–6 work.
- [ ] Reviewer spot-checks the "Tools" table count (50) against `src/config/tool-tiers.ts`.
- [ ] Reviewer confirms `--pilot` startup line on stderr is reproducible per `docs/getting-started.md` step 7.

## References

- Issue: #732
- Contract: `docs/roadmap/portability-harness-contract.md` (PR #774)
- v1.11.1 release notes: `docs/releases/v1.11.1.md`
- Cleanup history: `docs/roadmap/history/openchrome-1.11-cleanup.md`

🤖 Closes the docs gap from #732 as part of the post-v1.11.1 cleanup wrap-up.