### PR TITLE
feat(pilot): emit banner_injection + handoff_token_resume audit events (refs #733)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,32 @@ openchrome update
 
 ---
 
+## What's new in v1.11
+
+v1.11 establishes a **core / pilot tier split** inside the same npm package. Existing v1.10 configurations work bit-identically; new harness capabilities are additive.
+
+**Core tier** (active by default, no flag):
+
+- **Trace recorder** — JSONL session capture with credential redactor
+- **Skill state graph** — JSON-per-domain graph storage + `openchrome://skill-graph/<domain>` MCP resource
+- **Skill memory** — JSON store + audit-log-backed stats; `oc_skill_record`, `oc_skill_recall` MCP tools
+- **Outcome contracts** — DSL + evaluators (DOM, network, screenshot-class, perceptual hash); `oc_assert`, `oc_evidence_bundle` MCP tools
+- **Perception primitives** — perceptual DOM metadata + DOM↔screenshot cross-check (Sobel + color)
+
+**Pilot tier** (opt-in via `--pilot`):
+
+```bash
+openchrome serve --pilot
+```
+
+Adds: contract runtime (retry + idempotency + `beforeIrreversibleAction`), handoff token + AES-256-GCM persistence (ephemeral key default), multi-model voting framework (deterministic voters), skill curator (extractor + recall ranking + structural merge + PID lock + background runner).
+
+Pilot families are individually gated by `OPENCHROME_TRACE`, `OPENCHROME_STATE_GRAPH`, `OPENCHROME_CONTRACT_RUNTIME`, `OPENCHROME_HANDOFF_PERSIST`, `OPENCHROME_PERCEPTION_VOTING`, `OPENCHROME_SKILL_CURATOR`. All default *active* inside `--pilot`; set the env to `0` to turn one family off.
+
+**Design contract**: portability-harness policy at [`docs/roadmap/portability-harness-contract.md`](docs/roadmap/portability-harness-contract.md). Architecture overview at [`docs/architecture.md`](docs/architecture.md). End-to-end walkthrough at [`docs/getting-started.md`](docs/getting-started.md). Full v1.11 release notes at [`docs/releases/v1.11.1.md`](docs/releases/v1.11.1.md).
+
+---
+
 ## Examples
 
 **Parallel monitoring:**
@@ -309,7 +335,7 @@ oc compare prices for "AirPods Pro" across Amazon, eBay, Walmart, Best Buy
 
 ---
 
-## 46 Tools
+## 50 Tools
 
 | Category | Tools |
 |----------|-------|
@@ -319,11 +345,16 @@ oc compare prices for "AirPods Pro" across Amazon, eBay, Walmart, Best Buy
 | **Storage & Debug** | `cookies`, `storage`, `console_capture`, `performance_metrics`, `request_intercept` |
 | **Parallel Workflows** | `workflow_init`, `workflow_collect`, `worker_create`, `batch_execute` |
 | **Memory** | `memory_record`, `memory_query`, `memory_validate` |
+| **Contracts & Skills** *(v1.11)* | `oc_assert`, `oc_evidence_bundle`, `oc_skill_record`, `oc_skill_recall` |
+
+**MCP resources**: `openchrome://skill-graph/<domain>` (read-only JSON snapshot of the per-domain skill graph; v1.11).
 
 <details>
-<summary>Full tool list (46)</summary>
+<summary>Full tool list (50)</summary>
 
-`navigate` `interact` `computer` `read_page` `find` `form_input` `fill_form` `javascript_tool` `page_reload` `page_content` `page_pdf` `wait_for` `user_agent` `geolocation` `emulate_device` `network` `selector_query` `xpath_query` `cookies` `storage` `console_capture` `performance_metrics` `request_intercept` `drag_drop` `file_upload` `http_auth` `worker_create` `worker_list` `worker_update` `worker_complete` `worker_delete` `tabs_create` `tabs_context` `tabs_close` `workflow_init` `workflow_status` `workflow_collect` `workflow_collect_partial` `workflow_cleanup` `execute_plan` `batch_execute` `lightweight_scroll` `memory_record` `memory_query` `memory_validate` `oc_stop`
+`navigate` `interact` `computer` `read_page` `find` `form_input` `fill_form` `javascript_tool` `page_reload` `page_content` `page_pdf` `wait_for` `user_agent` `geolocation` `emulate_device` `network` `selector_query` `xpath_query` `cookies` `storage` `console_capture` `performance_metrics` `request_intercept` `drag_drop` `file_upload` `http_auth` `worker_create` `worker_list` `worker_update` `worker_complete` `worker_delete` `tabs_create` `tabs_context` `tabs_close` `workflow_init` `workflow_status` `workflow_collect` `workflow_collect_partial` `workflow_cleanup` `execute_plan` `batch_execute` `lightweight_scroll` `memory_record` `memory_query` `memory_validate` `oc_stop` `oc_assert` `oc_evidence_bundle` `oc_skill_record` `oc_skill_recall`
+
+With `--pilot` flag, additional pilot-tier tools are registered under the `oc_pilot_*` namespace (handoff, voting, curator). See [`docs/architecture.md`](docs/architecture.md).
 
 </details>
 
@@ -334,10 +365,13 @@ oc compare prices for "AirPods Pro" across Amazon, eBay, Walmart, Best Buy
 ```bash
 openchrome setup                    # Auto-configure
 openchrome serve --auto-launch      # Start server
+openchrome serve --pilot            # Opt into pilot tier (v1.11+)
 openchrome serve --headless-shell   # Headless mode
 openchrome doctor                   # Diagnose issues
 openchrome update                   # Update CLI
 ```
+
+Window placement (v1.11): `--window-size <w,h>`, `--window-position <x,y>`, `--window-bounds <x,y,w,h>`, `--start-maximized`, or set `OPENCHROME_WINDOW_*` env. Default is `0,0` + `1280×900` (previously `--start-maximized` + `1920×1080`).
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,184 @@
+# OpenChrome Architecture
+
+This document gives a one-page overview of how OpenChrome is structured at the
+v1.11 line. For the rationale behind the structure, read
+[`docs/roadmap/portability-harness-contract.md`](roadmap/portability-harness-contract.md).
+For end-to-end usage, see [`docs/getting-started.md`](getting-started.md).
+
+## One-line summary
+
+> OpenChrome is an MCP server that exposes Chrome via the Chrome DevTools
+> Protocol. It captures facts (DOM, screenshots, network, traces, skills,
+> contracts); a host agent uses those facts to decide what to do next.
+
+## Two tiers
+
+```
+openchrome-mcp (one npm package, one binary, one CLI)
+│
+├── src/core/           ← active by default, no flag
+│   │                     P1–P5 strictly enforced
+│   │
+│   ├── trace/          JSONL session capture + credential redactor
+│   ├── skill/          JSON-per-domain state graph + URL normalizer
+│   ├── skill-memory/   JSON-per-domain skill store + audit-log stats
+│   ├── contracts/      Outcome contract DSL + 7 evaluators + pHash
+│   ├── perception/     Perceptual DOM metadata + Sobel/color cross-check
+│   ├── cli/            Replay UI and inspection commands
+│   ├── mcp/            Server, transports, tool dispatch
+│   └── resources/      openchrome://skill-graph/<domain>
+│
+└── src/pilot/          ← opt-in via --pilot
+                          Relaxes P1 (background work) and P4 (policy);
+                          still enforces P3 (no LLM API calls).
+    │
+    ├── runtime/        Contract runtime: retry, verdict taxonomy,
+    │                   idempotency cache, beforeIrreversibleAction hook
+    ├── handoff/        Token + manager + AES-256-GCM persistence
+    │                   (ephemeral key default)
+    ├── voting/         Voter interface + orchestrator (deterministic;
+    │                   LLM-backed voters live in host-side libraries)
+    └── curator/        Verified skill extractor + recall ranking +
+                        Pass 1 prune + Pass 2 structural merge +
+                        Pass 3 promote + PID lock + background runner
+```
+
+### Import boundary
+
+The directory split is enforced by a `dependency-cruiser` rule
+(`.dependency-cruiser.cjs`):
+
+- `src/core/**` **must not** import from `src/pilot/**`.
+- `src/pilot/**` **may** import from `src/core/**`.
+
+CI fails on any PR that violates the rule (`npm run lint:tier`).
+
+### Shared helper module
+
+`src/harness/flags.ts` lives at neither tier; both can import it. It exposes:
+
+- `isPilotEnabled()` — true iff `--pilot` argv flag or `OPENCHROME_PILOT` env
+  is set
+- `isTraceEnabled()`, `isStateGraphEnabled()`, `isContractRuntimeEnabled()`,
+  `isHandoffPersistEnabled()`, `isPerceptionVotingEnabled()`,
+  `isSkillCuratorEnabled()` — per-family getters
+- `bootstrapPilot()` — dynamic `import('../pilot/index.js')`, returns null
+  when `--pilot` is unset (proof that no pilot module enters the process)
+- `logActiveFlags()` — single `[harness] core only` or
+  `[harness] core+pilot enabled (...)` line to **stderr** at startup
+
+## The five principles
+
+The contract that governs every PR landing on `develop`:
+
+- **P1. Tool server identity** — accept tool calls, return results. Long-lived
+  background work only in pilot, only when an operator enables it.
+- **P2. Zero-impact harness extension** — when `--pilot` is unset, every
+  optional native dep fails to load gracefully, every storage directory may
+  be missing, and the 1.10.4 tool surface still returns bit-identical
+  responses.
+- **P3. Anywhere-compatible MCP** — no outbound LLM API calls, no mandatory
+  API keys at boot, no platform-specific compile toolchains, no OS keychains.
+  Applies to **both tiers**.
+- **P4. Facts versus decisions** — the server stores and computes facts.
+  LLM judgment lives outside the server (host agent or separate package).
+- **P5. Native dependency discipline** — `argon2` is the only mandatory
+  native runtime dep. Future native deps go into `optionalDependencies`
+  with a documented fallback.
+
+## Data flow for a typical agent loop
+
+```
+                 ┌──────────────────────────────────────────────────────────┐
+                 │                  HOST AGENT (Claude Code, etc.)          │
+                 │                                                          │
+                 │   1. Reads tools/list                                    │
+                 │   2. Decides which tool to call                          │
+                 │   3. Calls oc_assert / oc_skill_recall / navigate / ...  │
+                 │   4. Receives facts; runs its own model to decide next   │
+                 └──────────────────────────────────────────────────────────┘
+                                              │
+                                  JSON-RPC over stdio (or HTTP)
+                                              ▼
+                 ┌──────────────────────────────────────────────────────────┐
+                 │                    openchrome-mcp                        │
+                 │                                                          │
+                 │   ┌─────────┐    ┌────────────────────┐                  │
+                 │   │ core/   │ ←─ │ mcp dispatcher     │                  │
+                 │   │ tools   │    │ + tier-1 gating    │                  │
+                 │   └────┬────┘    └──────┬─────────────┘                  │
+                 │        │                │                                │
+                 │        │   --pilot? ─── ▼                                │
+                 │        │           ┌─────────┐                           │
+                 │        │           │ pilot/  │                           │
+                 │        │           └────┬────┘                           │
+                 │        │                │                                │
+                 │   ┌────▼────────────────▼──────┐                         │
+                 │   │   CDP client + Chrome      │                         │
+                 │   │   process supervision      │                         │
+                 │   └────────────┬───────────────┘                         │
+                 └────────────────┼─────────────────────────────────────────┘
+                                  │
+                              CDP / DevTools Protocol
+                                  ▼
+                          ┌──────────────────┐
+                          │   real Chrome    │
+                          │  (your profile)  │
+                          └──────────────────┘
+```
+
+### Where the LLM lives
+
+> The LLM is in the **host agent**, not in `openchrome-mcp`. The server
+> never calls Anthropic / OpenAI / Google directly. If you want LLM-powered
+> voting or merge, the host agent calls its own model and then calls the
+> appropriate openchrome-mcp tool to record the result.
+
+## Storage policy
+
+Everything new in v1.11 stores to JSONL or JSON files coordinated by
+[`proper-lockfile`](https://www.npmjs.com/package/proper-lockfile). No
+SQLite. Concrete paths:
+
+```
+~/.openchrome/
+├── trace/<sessionId>/<ts>-<seq>.jsonl       trace events
+├── trace/<sessionId>/meta.json              session metadata
+├── skill-graph/<encodedDomain>.json         JSON-per-domain skill graph
+├── skill-memory/<encodedDomain>/skills.json skill records
+├── skill-memory/<encodedDomain>/snapshots/  gzipped frozen snapshots
+├── audit.log                                JSONL audit log
+└── handoff/<sha256(token)>.enc              AES-256-GCM encrypted token
+                                             (ephemeral key, lost on restart
+                                             unless OPENCHROME_HANDOFF_KEY_FILE)
+```
+
+`src/utils/atomic-file.ts` provides `writeFileAtomicSafe`,
+`readFileSafe`, and `acquireLock` helpers that every new storage layer
+uses.
+
+## Dependency footprint
+
+Mandatory native runtime dep: **`argon2`** (authentication). Pure-JS deps:
+`commander`, `jose`, `proper-lockfile`, `puppeteer-core`
+(`rebrowser-puppeteer-core` re-namespaced), `uuid`, `write-file-atomic`.
+Top-level `npm overrides` for `basic-ftp` and `ip-address` neutralize
+transitive advisories.
+
+## Out of scope for the server
+
+Things that explicitly do **not** live in `openchrome-mcp`:
+
+- Server-side LLM API calls (Anthropic / OpenAI / Google etc.) — see P3
+- Multi-step task orchestration — host agent's job
+- AI agent lifecycle management — host process's job
+- 24/7 uptime SLA — operator infrastructure
+- OS keychain / Secret Service / Credential Manager integration —
+  use `OPENCHROME_HANDOFF_KEY_FILE` instead
+
+## Reference
+
+- Contract: [`docs/roadmap/portability-harness-contract.md`](roadmap/portability-harness-contract.md)
+- Reliability contract: [`docs/roadmap/issue-reliability-guarantee.md`](roadmap/issue-reliability-guarantee.md)
+- v1.11 cleanup history: [`docs/roadmap/history/openchrome-1.11-cleanup.md`](roadmap/history/openchrome-1.11-cleanup.md)
+- v1.11.1 release notes: [`docs/releases/v1.11.1.md`](releases/v1.11.1.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,192 @@
+# Getting Started with OpenChrome
+
+A single-page walkthrough from installation to running your first verifiable
+contract and recalling your first skill. Targets v1.11+.
+
+## 1. Install
+
+```bash
+npm install -g openchrome-mcp@latest
+openchrome --version    # should print 1.11.1 or newer
+openchrome setup        # auto-configures your MCP client (Claude Code by default)
+```
+
+For other MCP clients:
+
+```bash
+openchrome setup --client codex      # Codex CLI
+openchrome setup --client opencode   # OpenCode
+```
+
+Restart your MCP client. That's it for the core install — the next sections
+are optional.
+
+## 2. Confirm core tier is live
+
+Open a fresh chat in your MCP client and ask it to navigate somewhere:
+
+```
+"oc navigate https://example.com and read the page title"
+```
+
+You should see the agent call `navigate` and `read_page`. The default v1.11
+install brings four extra MCP tools beyond v1.10:
+
+- `oc_assert` — run a single contract assertion against page state
+- `oc_evidence_bundle` — capture DOM + screenshot + network + console snapshot
+- `oc_skill_record` — store a reusable skill record
+- `oc_skill_recall` — retrieve skill records for a domain
+
+…plus one new MCP resource: `openchrome://skill-graph/<domain>` (read-only).
+
+## 3. Your first contract
+
+A contract is a small JSON declaring what "success" looks like on a page.
+Below is a minimal example you can pass inline to `oc_assert`:
+
+```json
+{
+  "id": "homepage_loaded",
+  "domain": "example.com",
+  "assertions": [
+    { "kind": "url", "equals": "https://example.com/" },
+    { "kind": "dom_count", "selector": "h1", "gte": 1 },
+    { "kind": "dom_text", "selector": "h1", "contains": "Example Domain" }
+  ]
+}
+```
+
+Ask your agent:
+
+```
+"oc, navigate to https://example.com then oc_assert this contract"
+```
+
+Expected verdict: `pass`. If you change `dom_text` to look for
+`"Different Domain"`, the verdict is `fail` and `failed_assertions` shows
+exactly which check failed and what was actually observed.
+
+## 4. Capture an evidence bundle
+
+When you want a richer record of page state (for debugging or for replay):
+
+```
+"oc, run oc_evidence_bundle with include=['dom','screenshot','network','phash']"
+```
+
+Returns:
+
+```json
+{
+  "bundle_id": "evb_2026-05-12T05-30-22_abc123",
+  "path": "/Users/<you>/.openchrome/evidence/evb_.../",
+  "size_bytes": 184320,
+  "parts": ["dom.txt", "screenshot.png", "network.jsonl", "phash.txt"]
+}
+```
+
+The bundle directory is a flat collection of files. No SQL or special tooling
+needed to inspect them.
+
+## 5. Record and recall a skill
+
+Skills are reusable named recipes for accomplishing a goal on a domain:
+
+```
+"oc, on https://example.com, save a skill named 'open-homepage' with these steps:
+ 1. navigate to https://example.com
+ 2. wait for h1
+ 3. oc_assert {<homepage_loaded contract>}"
+```
+
+The agent calls `oc_skill_record({ domain, name, steps, contract_id })`. Later:
+
+```
+"oc, oc_skill_recall for example.com"
+```
+
+Returns up to 20 skills for the domain, ordered by recency.
+
+## 6. Inspect the skill graph
+
+The skill state graph is a read-only MCP resource:
+
+```
+openchrome://skill-graph/example.com
+```
+
+Any MCP client that supports resources can subscribe / fetch the JSON
+snapshot. Useful for dashboards or for the agent to plan a multi-step
+recovery path.
+
+## 7. (Optional) Enable the pilot tier
+
+Pilot adds: contract runtime with retry, handoff token + encrypted
+persistence, multi-model voting framework, and a background skill curator.
+
+Edit your MCP client config to add `--pilot`:
+
+```json
+{
+  "mcpServers": {
+    "openchrome": {
+      "command": "openchrome",
+      "args": ["serve", "--auto-launch", "--pilot"]
+    }
+  }
+}
+```
+
+Restart your MCP client. When the server boots, **stderr** prints:
+
+```
+[harness] core+pilot enabled (trace,state_graph,contract_runtime,handoff_persist,perception_voting,skill_curator)
+```
+
+You can turn an individual family off without losing the rest:
+
+```bash
+OPENCHROME_PERCEPTION_VOTING=0 openchrome serve --pilot
+```
+
+## 8. (Optional) Persist handoff tokens across restarts
+
+By default, the pilot handoff persistence layer uses an **ephemeral** key
+generated at boot. Persisted tokens are invalidated on every restart, which
+is the safer default for laptops and CI.
+
+For long-running servers where cross-restart persistence matters, point at
+a key file you manage:
+
+```bash
+# Generate a 32-byte key once
+openssl rand -out ~/.openchrome/handoff-key.bin 32
+chmod 600 ~/.openchrome/handoff-key.bin
+
+# Tell the server to use it
+export OPENCHROME_HANDOFF_KEY_FILE=~/.openchrome/handoff-key.bin
+openchrome serve --pilot
+```
+
+The file is never logged and never embedded in audit records. If the file
+size is anything other than exactly 32 bytes, the server falls back to
+ephemeral mode and prints a warning to stderr.
+
+## 9. Update later
+
+```bash
+openchrome update
+```
+
+This runs `npm install -g openchrome-mcp@latest` and re-runs setup against
+your MCP client config so the runtime path stays in sync.
+
+## What next
+
+- [`docs/architecture.md`](architecture.md) — one-page overview of the
+  core / pilot tier split and where each subsystem lives
+- [`docs/roadmap/portability-harness-contract.md`](roadmap/portability-harness-contract.md) —
+  the durable design contract every future PR must satisfy
+- [`docs/releases/v1.11.1.md`](releases/v1.11.1.md) — full release notes
+  with the cumulative v1.10.4 → v1.11.1 diff
+- `openchrome doctor` — diagnose installation issues

--- a/src/pilot/handoff/tool.ts
+++ b/src/pilot/handoff/tool.ts
@@ -22,9 +22,28 @@
 import { MCPServer } from '../../mcp-server.js';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../../types/mcp.js';
 import { isHandoffPersistEnabled } from '../../harness/flags.js';
+import { logAuditEntry } from '../../security/audit-logger.js';
 import { HandoffManager } from './manager.js';
 import { renderHandoffBanner } from './banner.js';
 import { verifyHandoffToken, DEFAULT_TOKEN_TTL_MS } from './token.js';
+
+/**
+ * Best-effort wrapper around {@link logAuditEntry}. Audit emission is
+ * additive — a failing audit sink must never change the tool's verdict
+ * or leak through to the caller. Mirrors the contract-runtime emitter
+ * pattern in `src/pilot/runtime/runtime.ts`.
+ */
+function safeAudit(
+  tool: string,
+  sessionId: string,
+  args: Record<string, unknown>,
+): void {
+  try {
+    logAuditEntry(tool, sessionId, args, undefined, { status: 'success' });
+  } catch {
+    // best-effort — never let the audit pipeline change the verdict
+  }
+}
 
 /**
  * Process-wide handoff store. The singleton is intentional — pilot
@@ -166,6 +185,17 @@ const createHandler: ToolHandler = async (
     scope: scopeArg,
     expiresAt: result.expiresAt,
   });
+  // Semantic audit event for the user-observable banner surface. Distinct
+  // from the automatic `oc_pilot_handoff_create` audit entry emitted by
+  // the MCP request pipeline — that one records the tool call; this one
+  // records the operator-facing handoff banner that was just rendered.
+  // The raw token is intentionally omitted; the banner string itself
+  // never carries the token, so this matches that surface.
+  safeAudit('banner_injection', sessionIdArg, {
+    scope: scopeArg,
+    expires_at: result.expiresAt,
+    surface: 'handoff_create',
+  });
   return jsonResult<CreateOutput>({
     ok: true,
     token: result.token,
@@ -222,6 +252,23 @@ const redeemHandler: ToolHandler = async (
     scope: redemption.scope,
     expiresAt: redemption.expiresAt,
     now: () => redemption.redeemedAt,
+  });
+  // Semantic audit events. `handoff_token_resume` marks the moment the
+  // single-use token actually transferred its scope to a redeeming
+  // agent; `banner_injection` marks the redemption-side banner surface.
+  // Both are additive to the automatic `oc_pilot_handoff_redeem` audit
+  // row the MCP request pipeline emits — that records the tool call,
+  // these record the lifecycle transitions inside it.
+  safeAudit('handoff_token_resume', redemption.sessionId, {
+    scope: redemption.scope,
+    expires_at: redemption.expiresAt,
+    created_at: redemption.createdAt,
+    redeemed_at: redemption.redeemedAt,
+  });
+  safeAudit('banner_injection', redemption.sessionId, {
+    scope: redemption.scope,
+    expires_at: redemption.expiresAt,
+    surface: 'handoff_redeem',
   });
   return jsonResult<RedeemOutput>({
     ok: true,

--- a/tests/pilot/handoff/tool-audit.test.ts
+++ b/tests/pilot/handoff/tool-audit.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Tests for the semantic audit events emitted by the pilot handoff MCP
+ * tools (issue #733 verification surface).
+ *
+ * Two named events are exercised:
+ *
+ *   banner_injection
+ *     - emitted by `oc_pilot_handoff_create` on success, carrying the
+ *       freshly minted record's session/scope/expiry but never the raw
+ *       token (the banner string also omits the token; we keep parity).
+ *     - emitted by `oc_pilot_handoff_redeem` on success, marking the
+ *       redemption-side banner surface.
+ *
+ *   handoff_token_resume
+ *     - emitted by `oc_pilot_handoff_redeem` on success only. This is
+ *       the moment the single-use token actually transferred its scope
+ *       to a redeeming agent — auditors look for this kind to confirm
+ *       a session was resumed by an external party.
+ *
+ * Both kinds are ADDITIVE to the automatic per-tool audit row emitted
+ * by the MCP request pipeline; the tests therefore mock `logAuditEntry`
+ * and assert ONLY against the calls made from inside the handoff tool
+ * implementations. A lightweight stub server captures the registered
+ * handlers so the suite does not instantiate the full MCPServer.
+ */
+
+import { jest } from '@jest/globals';
+
+jest.mock('../../../src/security/audit-logger.js', () => ({
+  logAuditEntry: jest.fn(),
+}));
+
+// `isHandoffPersistEnabled` is consulted on every call; default it to
+// `true` so the handlers reach the audit emission paths. Individual
+// tests can override per-call.
+jest.mock('../../../src/harness/flags.js', () => ({
+  isHandoffPersistEnabled: jest.fn(() => true),
+}));
+
+import { logAuditEntry } from '../../../src/security/audit-logger.js';
+import { isHandoffPersistEnabled } from '../../../src/harness/flags.js';
+import type { MCPServer } from '../../../src/mcp-server.js';
+import type { MCPToolDefinition, ToolHandler } from '../../../src/types/mcp.js';
+import {
+  registerOcPilotHandoffTool,
+  _resetHandoffManagerForTesting,
+} from '../../../src/pilot/handoff/tool.js';
+
+interface AuditCall {
+  tool: string;
+  sessionId: string;
+  args: Record<string, unknown>;
+}
+
+function recordedAuditCalls(): AuditCall[] {
+  const mock = logAuditEntry as unknown as jest.Mock;
+  return mock.mock.calls.map((call) => ({
+    tool: call[0] as string,
+    sessionId: call[1] as string,
+    args: call[2] as Record<string, unknown>,
+  }));
+}
+
+function semanticOnly(calls: AuditCall[]): AuditCall[] {
+  // We own the `banner_injection` + `handoff_token_resume` kinds. Any
+  // other audit row in the mock would be unexpected — assert presence by
+  // filtering down to ours rather than locking the negative-space list.
+  return calls.filter(
+    (c) => c.tool === 'banner_injection' || c.tool === 'handoff_token_resume',
+  );
+}
+
+/**
+ * Minimal MCPServer stub that captures whatever the handoff tool barrel
+ * registers. Avoids constructing the real MCPServer (which would pull in
+ * session-manager wiring, transport stubs, etc.) just to test two
+ * audit emission call sites.
+ */
+class CapturingServer {
+  readonly handlers = new Map<
+    string,
+    { handler: ToolHandler; definition: MCPToolDefinition }
+  >();
+  registerTool(name: string, handler: ToolHandler, definition: MCPToolDefinition): void {
+    this.handlers.set(name, { handler, definition });
+  }
+}
+
+function makeServer(): { server: MCPServer; capture: CapturingServer } {
+  const capture = new CapturingServer();
+  return { server: capture as unknown as MCPServer, capture };
+}
+
+function findHandler(capture: CapturingServer, name: string): ToolHandler {
+  const entry = capture.handlers.get(name);
+  if (!entry) throw new Error(`tool '${name}' not registered`);
+  return entry.handler;
+}
+
+function parseOutput(result: unknown): Record<string, unknown> {
+  const r = result as {
+    content?: Array<{ type: string; text?: string }>;
+  } & Record<string, unknown>;
+  // Both shapes (content[0].text JSON, or the flat top-level spread copy)
+  // are produced by the handler. Prefer the JSON text to assert exactly
+  // what the agent receives over the wire.
+  const text = r.content?.[0]?.text;
+  if (typeof text === 'string') {
+    return JSON.parse(text) as Record<string, unknown>;
+  }
+  return r as Record<string, unknown>;
+}
+
+describe('pilot handoff MCP tools — semantic audit emissions', () => {
+  let capture: CapturingServer;
+
+  beforeEach(() => {
+    (logAuditEntry as unknown as jest.Mock).mockClear();
+    (isHandoffPersistEnabled as unknown as jest.Mock).mockReturnValue(true);
+    _resetHandoffManagerForTesting();
+    const made = makeServer();
+    capture = made.capture;
+    registerOcPilotHandoffTool(made.server);
+  });
+
+  afterEach(() => {
+    _resetHandoffManagerForTesting();
+  });
+
+  it('registers both handoff tools', () => {
+    expect(capture.handlers.has('oc_pilot_handoff_create')).toBe(true);
+    expect(capture.handlers.has('oc_pilot_handoff_redeem')).toBe(true);
+  });
+
+  it('emits banner_injection on successful handoff_create with surface=handoff_create', async () => {
+    const create = findHandler(capture, 'oc_pilot_handoff_create');
+    const out = parseOutput(
+      await create('caller-sess', { session_id: 'sess-A', scope: 'checkout' }),
+    );
+    expect(out.ok).toBe(true);
+
+    const semantic = semanticOnly(recordedAuditCalls());
+    expect(semantic).toHaveLength(1);
+    expect(semantic[0]).toMatchObject({
+      tool: 'banner_injection',
+      sessionId: 'sess-A',
+      args: { scope: 'checkout', surface: 'handoff_create' },
+    });
+    expect(typeof semantic[0].args.expires_at).toBe('number');
+    expect(JSON.stringify(semantic[0].args)).not.toContain(out.token as string);
+  });
+
+  it('emits handoff_token_resume + banner_injection on successful handoff_redeem', async () => {
+    const create = findHandler(capture, 'oc_pilot_handoff_create');
+    const redeem = findHandler(capture, 'oc_pilot_handoff_redeem');
+
+    const created = parseOutput(
+      await create('caller-sess', { session_id: 'sess-B', scope: 'read-only' }),
+    );
+    expect(created.ok).toBe(true);
+
+    (logAuditEntry as unknown as jest.Mock).mockClear();
+    const out = parseOutput(await redeem('caller-sess', { token: created.token }));
+    expect(out.ok).toBe(true);
+
+    const semantic = semanticOnly(recordedAuditCalls());
+    const kinds = semantic.map((c) => c.tool).sort();
+    expect(kinds).toEqual(['banner_injection', 'handoff_token_resume']);
+
+    const resume = semantic.find((c) => c.tool === 'handoff_token_resume')!;
+    expect(resume.sessionId).toBe('sess-B');
+    expect(resume.args).toMatchObject({ scope: 'read-only' });
+    expect(typeof resume.args.created_at).toBe('number');
+    expect(typeof resume.args.redeemed_at).toBe('number');
+
+    const banner = semantic.find(
+      (c) => c.tool === 'banner_injection' && c.args.surface === 'handoff_redeem',
+    )!;
+    expect(banner.sessionId).toBe('sess-B');
+    expect(banner.args).toMatchObject({ scope: 'read-only', surface: 'handoff_redeem' });
+
+    for (const call of semantic) {
+      expect(JSON.stringify(call.args)).not.toContain(created.token as string);
+    }
+  });
+
+  it('does NOT emit semantic audits when handoff_persist family is disabled', async () => {
+    (isHandoffPersistEnabled as unknown as jest.Mock).mockReturnValue(false);
+    const create = findHandler(capture, 'oc_pilot_handoff_create');
+    const out = parseOutput(
+      await create('caller-sess', { session_id: 'sess-C', scope: 'noop' }),
+    );
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe('disabled');
+    expect(semanticOnly(recordedAuditCalls())).toHaveLength(0);
+  });
+
+  it('does NOT emit semantic audits on invalid_args (handoff_create)', async () => {
+    const create = findHandler(capture, 'oc_pilot_handoff_create');
+    const out = parseOutput(await create('caller-sess', { scope: 'x' }));
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe('invalid_args');
+    expect(semanticOnly(recordedAuditCalls())).toHaveLength(0);
+  });
+
+  it('does NOT emit semantic audits on unknown_token (handoff_redeem)', async () => {
+    const redeem = findHandler(capture, 'oc_pilot_handoff_redeem');
+    const out = parseOutput(
+      await redeem('caller-sess', { token: 'definitely-not-a-real-token' }),
+    );
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe('unknown_token');
+    expect(semanticOnly(recordedAuditCalls())).toHaveLength(0);
+  });
+
+  it('redeem of an already-consumed token does not double-emit', async () => {
+    const create = findHandler(capture, 'oc_pilot_handoff_create');
+    const redeem = findHandler(capture, 'oc_pilot_handoff_redeem');
+
+    const created = parseOutput(
+      await create('caller-sess', { session_id: 'sess-D', scope: 'once' }),
+    );
+    expect(created.ok).toBe(true);
+    expect(await redeem('caller-sess', { token: created.token })).toBeDefined();
+    (logAuditEntry as unknown as jest.Mock).mockClear();
+
+    const out = parseOutput(await redeem('caller-sess', { token: created.token }));
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe('unknown_token');
+    expect(semanticOnly(recordedAuditCalls())).toHaveLength(0);
+  });
+
+  it('audit failure does not break the verdict (best-effort)', async () => {
+    (logAuditEntry as unknown as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('synthetic audit sink failure');
+    });
+    const create = findHandler(capture, 'oc_pilot_handoff_create');
+    const out = parseOutput(
+      await create('caller-sess', { session_id: 'sess-E', scope: 'best-effort' }),
+    );
+    expect(out.ok).toBe(true);
+    expect(typeof out.token).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary

Add two semantic audit kinds at the pilot handoff MCP tool boundary so the contract-runtime audit log carries lifecycle transitions auditors (and #733's e2e test) currently have to infer from raw tool-call rows.

- `banner_injection` — fired from `oc_pilot_handoff_create` and `oc_pilot_handoff_redeem` after `renderHandoffBanner()` succeeds, carrying `{ scope, expires_at, surface }` (`surface` distinguishes the create-side vs redeem-side banner).
- `handoff_token_resume` — fired from `oc_pilot_handoff_redeem` on a successful redemption, carrying `{ scope, expires_at, created_at, redeemed_at }`. Never carries the raw token.

Both emissions are wrapped in a best-effort `safeAudit()` helper that swallows audit-sink failures, mirroring the contract-runtime emitter pattern in `src/pilot/runtime/runtime.ts` — an unhealthy audit pipeline cannot flip a verdict.

## Why this is a generalized fix (not a #733-specific shim)

The verification issue #733 lists `banner-injection` and `handoff-token-resume` in its expected audit sequence, but the audit events themselves are useful to **every** operator running `--pilot` with the `handoff_persist` family enabled — not just to the (unwritten) checkout e2e test:

- The automatic per-tool audit row from `mcp-server.ts` already tells you "the redeem tool was called". The new events tell you what happened *inside* the call (a single-use token transferred scope; a banner was shown to the operator). Auditors building dashboards / SIEM queries on handoff lifecycle currently have to grep / regex the redacted args to infer this; the new kinds make them first-class.
- Disabled-family, invalid-args, and unknown-token paths short-circuit before emission, so no-op semantics are preserved.
- No call-site is checkout-specific; any handoff caller benefits.

## What this PR does NOT do

Several #733 acceptance items still depend on infrastructure that is not in `develop` yet — they are deliberately out of scope here so this PR stays narrow:

- `skill_recall_inject` audit event — `src/pilot/curator/recall.ts` produces ranked recall payloads, but no module *injects* the recall into a running contract today, so there is no honest call site to attach an emission to. Belongs in the PR that wires the inject path.
- Banner injection into a live page DOM (vs. the operator-facing banner string we render today). Today the runtime emits `verdict: escalated` and the caller surfaces the banner; pushing the banner into the page DOM during a `headed-handoff` escalation is a separate orchestration concern.
- The `tests/e2e/critical-contract/checkout.spec.ts` e2e harness itself.

## Test plan

- [x] `npx jest tests/pilot/handoff/tool-audit.test.ts` — **8/8 new tests pass**, covering: registration, both success-path emissions, surface-label correctness, no token leakage, disabled-family no-op, invalid-args no-op, unknown-token no-op, double-redeem no-op, audit-sink-failure best-effort guard.
- [x] `npx jest tests/pilot/handoff/` — **42/42 existing handoff tests still green** (no regression in manager/persistence/token suites).
- [x] `npm run build` — **clean**.
- [x] `npx eslint src/pilot/handoff/tool.ts` — **0 errors**.

## Files

- `src/pilot/handoff/tool.ts` (+47 lines): import `logAuditEntry`, add `safeAudit()` helper, emit at the two natural call sites.
- `tests/pilot/handoff/tool-audit.test.ts` (new): 8 tests, lightweight stub server (no real `MCPServer` instantiation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)