### PR TITLE
docs(#890): transport lifecycle policy — stdio/http/both stability + deprecation policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to OpenChrome are documented here. For full release notes see `docs/releases/`.
+
+---
+
+## v1.11.x
+
+### Transport policy
+
+A formal transport lifecycle policy has been established in
+[`docs/transport-lifecycle.md`](docs/transport-lifecycle.md). The document
+covers:
+
+- The three supported transport modes (`stdio`, `http`, `both`) with stability
+  status and recommended use cases.
+- Stability commitments: message-shape compatibility, guaranteed notification
+  types, and what minor versions are permitted to change.
+- Deprecation policy: minimum 3 minor versions **or** 6 months overlap between
+  announcement and removal, whichever is longer.
+- Boot-time deprecation warning contract (implementation deferred to a follow-up
+  code PR; no warning is emitted yet).
+- Migration recipes: stdio → HTTP, and HTTP → Streamable HTTP (when #839 lands).
+
+**No transport is currently deprecated.** All three transport modes remain
+stable with no sunset date. This section will be updated when a transport is
+first marked deprecated.
+
+---
+
+## v1.11.0 — portability-harness contract (2026-05-12)
+
+See [`docs/releases/v1.11.0.md`](docs/releases/v1.11.0.md) for the full release
+notes.
+
+---
+
+## Earlier releases
+
+See the release notes in [`docs/releases/`](docs/releases/) for v1.10.x and
+earlier.

--- a/README.md
+++ b/README.md
@@ -534,6 +534,8 @@ By default, benchmarks run in **stub mode** — measuring protocol correctness a
 
 OpenChrome works on servers and in CI/CD pipelines without Chrome login. All 46 tools function with unauthenticated Chrome — navigation, scraping, screenshots, form filling, and parallel workflows all work in clean sessions.
 
+OpenChrome supports three transport modes (`stdio`, `http`, `both`). For stability guarantees, deprecation policy, and migration recipes, see **[docs/transport-lifecycle.md](docs/transport-lifecycle.md)**.
+
 ### Quick start
 
 ```bash

--- a/docs/transport-lifecycle.md
+++ b/docs/transport-lifecycle.md
@@ -6,13 +6,13 @@ This document is the authoritative reference for which transport modes OpenChrom
 
 ## Supported transports
 
-OpenChrome exposes three transport modes via the `--transport <mode>` CLI flag (or the `OPENCHROME_TRANSPORT` environment variable).
+OpenChrome exposes three transport modes. The package CLI uses stdio by default, enables HTTP with `--http [port]`, and can select explicit modes with the `OPENCHROME_TRANSPORT` environment variable.
 
-| Transport | `--transport` value | Status | Since | Sunset | Recommended use case |
-|-----------|---------------------|--------|-------|--------|----------------------|
-| stdio | `stdio` | **stable** | v1.0.0 | — | Default. Single MCP client over stdin/stdout. Use for Claude Code, Codex CLI, Cursor, Windsurf, and any stdio-native MCP client. |
-| HTTP daemon | `http` | **stable** | v1.0.0 | — | Long-running daemon serving multiple MCP clients. Binds a local port; auth via bearer token or per-tenant API key. |
-| Dual (stdio + HTTP) | `both` | **stable** | v1.0.0 | — | Run stdio and HTTP simultaneously. Intended for dashboard integrations that need both a direct MCP pipe and an HTTP fan-out endpoint. |
+| Transport | Selector | Status | Since | Sunset | Recommended use case |
+|-----------|----------|--------|-------|--------|----------------------|
+| stdio | default or `OPENCHROME_TRANSPORT=stdio` | **stable** | v1.0.0 | — | Default. Single MCP client over stdin/stdout. Use for Claude Code, Codex CLI, Cursor, Windsurf, and any stdio-native MCP client. |
+| HTTP daemon | `--http [port]` or `OPENCHROME_TRANSPORT=http` | **stable** | v1.0.0 | — | Long-running daemon serving multiple MCP clients. Binds a local port; auth via bearer token or per-tenant API key. |
+| Dual (stdio + HTTP) | `OPENCHROME_TRANSPORT=both` | **stable** | v1.0.0 | — | Run stdio and HTTP simultaneously. Intended for dashboard integrations that need both a direct MCP pipe and an HTTP fan-out endpoint. |
 
 > **Note on SSE:** The `/mcp/sse` endpoint is the _notification delivery channel_ inside the HTTP transport — it is not a separate transport mode. When a client connects via `GET /mcp/sse`, it receives server-initiated notifications over a persistent SSE stream while issuing requests via `POST /mcp`. Operators should not conflate `/mcp/sse` with a distinct transport; the lifecycle of that endpoint is tied to the `http` transport above.
 
@@ -71,7 +71,7 @@ When a transport (or a specific transport feature) is deprecated:
 When the server starts with a deprecated transport selected, it emits a single line to stderr:
 
 ```
-[openchrome] DEPRECATION WARNING: transport "<name>" is deprecated as of v<announcement-version>. Sunset: v<sunset-version>. Migrate before that release. See: https://github.com/openchrome/openchrome-mcp/blob/main/docs/transport-lifecycle.md
+[openchrome] DEPRECATION WARNING: transport "<name>" is deprecated as of v<announcement-version>. Sunset: v<sunset-version>. Migrate before that release. See: https://github.com/shaun0927/openchrome/blob/main/docs/transport-lifecycle.md
 ```
 
 This line:
@@ -101,13 +101,13 @@ openchrome serve --auto-launch
 **After (HTTP daemon):**
 ```bash
 # Start the HTTP daemon on port 3100 (default)
-openchrome serve --auto-launch --transport http
+openchrome serve --auto-launch --http
 
 # Or specify a custom port and bind address
-openchrome serve --auto-launch --transport http --http 4000 --http-host 0.0.0.0
+OPENCHROME_HTTP_HOST=0.0.0.0 openchrome serve --auto-launch --http 4000
 
 # With bearer-token authentication (recommended for non-loopback)
-openchrome serve --auto-launch --transport http --http 4000 --auth-token "$(openssl rand -hex 32)"
+OPENCHROME_AUTH_TOKEN="$(openssl rand -hex 32)" openchrome serve --auto-launch --http 4000
 ```
 
 Configure your MCP client to connect over HTTP:
@@ -125,21 +125,16 @@ Configure your MCP client to connect over HTTP:
 
 For unauthenticated loopback-only development:
 ```bash
-openchrome serve --auto-launch --transport http --allow-unauthenticated-http
+OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP=1 openchrome serve --auto-launch --http
 ```
 
 ### HTTP → Streamable HTTP (future)
 
 Streamable HTTP is the next-generation MCP transport (tracked in issue #839). It replaces the current HTTP transport with a fully bidirectional streaming protocol that is OAuth-capable and aligns with the broader MCP ecosystem direction.
 
-This recipe will be filled in when issue #839 lands. At that point, the migration will look like:
+This recipe will be filled in when issue #839 lands. At that point, this section will be updated with the supported command form.
 
-```bash
-# Anticipated command form — not yet available
-openchrome serve --auto-launch --transport streamable-http --http 3100
-```
-
-Until #839 is merged, continue using `--transport http`. The `http` transport is stable and has no sunset date.
+Until #839 is merged, continue using `--http`. The `http` transport is stable and has no sunset date.
 
 ---
 
@@ -147,4 +142,4 @@ Until #839 is merged, continue using `--transport http`. The `http` transport is
 
 - [docs/auth.md](auth.md) — API key store, bearer tokens, OAuth
 - [docs/roadmap/portability-harness-contract.md](roadmap/portability-harness-contract.md) — core/pilot tier split and portability principles
-- Issue [#839](https://github.com/openchrome/openchrome-mcp/issues/839) — Streamable HTTP transport implementation
+- Issue [#839](https://github.com/shaun0927/openchrome/issues/839) — Streamable HTTP transport implementation

--- a/docs/transport-lifecycle.md
+++ b/docs/transport-lifecycle.md
@@ -99,14 +99,11 @@ openchrome serve --auto-launch
 
 **After (Streamable HTTP daemon):**
 ```bash
-# Start the HTTP daemon on port 3100 (default)
-openchrome serve --auto-launch --http
+# Start the HTTP daemon on port 3100 (default) with bearer-token authentication
+OPENCHROME_AUTH_TOKEN="$(openssl rand -hex 32)" openchrome serve --auto-launch --http
 
-# Or specify a custom port and bind address
-OPENCHROME_HTTP_HOST=0.0.0.0 openchrome serve --auto-launch --http 4000
-
-# With bearer-token authentication (recommended for non-loopback)
-OPENCHROME_AUTH_TOKEN="$(openssl rand -hex 32)" openchrome serve --auto-launch --http 4000
+# Or specify a custom port and non-loopback bind address
+OPENCHROME_AUTH_TOKEN="$(openssl rand -hex 32)" OPENCHROME_HTTP_HOST=0.0.0.0 openchrome serve --auto-launch --http 4000
 ```
 
 Configure your MCP client to connect over Streamable HTTP:
@@ -122,7 +119,7 @@ Configure your MCP client to connect over Streamable HTTP:
 }
 ```
 
-For unauthenticated loopback-only development:
+For unauthenticated loopback-only development, explicitly opt in and keep the bind address on loopback. Non-loopback HTTP binds require authentication.
 ```bash
 OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP=1 openchrome serve --auto-launch --http
 ```

--- a/docs/transport-lifecycle.md
+++ b/docs/transport-lifecycle.md
@@ -11,12 +11,12 @@ OpenChrome exposes three transport modes. The package CLI uses stdio by default,
 | Transport | Selector | Status | Since | Sunset | Recommended use case |
 |-----------|----------|--------|-------|--------|----------------------|
 | stdio | default or `OPENCHROME_TRANSPORT=stdio` | **stable** | v1.0.0 | — | Default. Single MCP client over stdin/stdout. Use for Claude Code, Codex CLI, Cursor, Windsurf, and any stdio-native MCP client. |
-| HTTP daemon | `--http [port]` or `OPENCHROME_TRANSPORT=http` | **stable** | v1.0.0 | — | Long-running daemon serving multiple MCP clients. Binds a local port; auth via bearer token or per-tenant API key. |
+| Streamable HTTP daemon | `--http [port]` or `OPENCHROME_TRANSPORT=http` | **stable** | v1.0.0 | — | Long-running daemon serving multiple MCP clients over Streamable HTTP. Binds a local port; auth via bearer token or per-tenant API key. |
 | Dual (stdio + HTTP) | `OPENCHROME_TRANSPORT=both` | **stable** | v1.0.0 | — | Run stdio and HTTP simultaneously. Intended for dashboard integrations that need both a direct MCP pipe and an HTTP fan-out endpoint. |
 
 > **Note on SSE:** The `/mcp/sse` endpoint is the _notification delivery channel_ inside the HTTP transport — it is not a separate transport mode. When a client connects via `GET /mcp/sse`, it receives server-initiated notifications over a persistent SSE stream while issuing requests via `POST /mcp`. Operators should not conflate `/mcp/sse` with a distinct transport; the lifecycle of that endpoint is tied to the `http` transport above.
 
-> **Streamable HTTP** (tracked in issue #839) will appear as a fourth row in this table when it lands. It is not yet available.
+> **Streamable HTTP:** `--http` is OpenChrome's current Streamable HTTP transport surface. Use `POST /mcp` for JSON-RPC requests and `GET /mcp` or `GET /mcp/sse` for server-sent event streams.
 
 ---
 
@@ -28,7 +28,6 @@ A transport listed as **stable** carries the following guarantees across all pat
 
 2. **Guaranteed events.** The following server-initiated notification types are guaranteed to remain available on all stable transports:
    - `notifications/tools/list_changed` — emitted when the tool list changes at runtime.
-   - `notifications/resources/list_changed` — emitted when the resource list changes.
    - Lifecycle error notifications emitted via `console.error` to stderr (never to stdout, which carries MCP JSON-RPC).
 
 3. **Minor-version allowance.** Within a major version, minor releases may:
@@ -88,9 +87,9 @@ This line:
 
 ## Migration recipes
 
-### stdio → HTTP
+### stdio → Streamable HTTP
 
-Switch from the default stdio mode to an HTTP daemon for multi-client or IDE use cases.
+Switch from the default stdio mode to the Streamable HTTP daemon for multi-client or IDE use cases.
 
 **Before (stdio):**
 ```bash
@@ -98,7 +97,7 @@ Switch from the default stdio mode to an HTTP daemon for multi-client or IDE use
 openchrome serve --auto-launch
 ```
 
-**After (HTTP daemon):**
+**After (Streamable HTTP daemon):**
 ```bash
 # Start the HTTP daemon on port 3100 (default)
 openchrome serve --auto-launch --http
@@ -110,7 +109,7 @@ OPENCHROME_HTTP_HOST=0.0.0.0 openchrome serve --auto-launch --http 4000
 OPENCHROME_AUTH_TOKEN="$(openssl rand -hex 32)" openchrome serve --auto-launch --http 4000
 ```
 
-Configure your MCP client to connect over HTTP:
+Configure your MCP client to connect over Streamable HTTP:
 ```json
 {
   "mcpServers": {
@@ -128,13 +127,9 @@ For unauthenticated loopback-only development:
 OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP=1 openchrome serve --auto-launch --http
 ```
 
-### HTTP → Streamable HTTP (future)
+### Streamable HTTP endpoint behavior
 
-Streamable HTTP is the next-generation MCP transport (tracked in issue #839). It replaces the current HTTP transport with a fully bidirectional streaming protocol that is OAuth-capable and aligns with the broader MCP ecosystem direction.
-
-This recipe will be filled in when issue #839 lands. At that point, this section will be updated with the supported command form.
-
-Until #839 is merged, continue using `--http`. The `http` transport is stable and has no sunset date.
+`--http` starts OpenChrome's current Streamable HTTP transport. Clients issue JSON-RPC requests with `POST /mcp`. Clients that need server-initiated notifications can open `GET /mcp` or `GET /mcp/sse` as an SSE stream. No additional migration flag is required; the `http` transport selector remains stable and has no sunset date.
 
 ---
 
@@ -142,4 +137,4 @@ Until #839 is merged, continue using `--http`. The `http` transport is stable an
 
 - [docs/auth.md](auth.md) — API key store, bearer tokens, OAuth
 - [docs/roadmap/portability-harness-contract.md](roadmap/portability-harness-contract.md) — core/pilot tier split and portability principles
-- Issue [#839](https://github.com/shaun0927/openchrome/issues/839) — Streamable HTTP transport implementation
+- Issue [#839](https://github.com/shaun0927/openchrome/issues/839) — Streamable HTTP transport implementation history

--- a/docs/transport-lifecycle.md
+++ b/docs/transport-lifecycle.md
@@ -1,0 +1,150 @@
+# Transport Lifecycle Policy
+
+This document is the authoritative reference for which transport modes OpenChrome supports, what stability guarantees apply to each, and how deprecations are announced and enforced.
+
+---
+
+## Supported transports
+
+OpenChrome exposes three transport modes via the `--transport <mode>` CLI flag (or the `OPENCHROME_TRANSPORT` environment variable).
+
+| Transport | `--transport` value | Status | Since | Sunset | Recommended use case |
+|-----------|---------------------|--------|-------|--------|----------------------|
+| stdio | `stdio` | **stable** | v1.0.0 | — | Default. Single MCP client over stdin/stdout. Use for Claude Code, Codex CLI, Cursor, Windsurf, and any stdio-native MCP client. |
+| HTTP daemon | `http` | **stable** | v1.0.0 | — | Long-running daemon serving multiple MCP clients. Binds a local port; auth via bearer token or per-tenant API key. |
+| Dual (stdio + HTTP) | `both` | **stable** | v1.0.0 | — | Run stdio and HTTP simultaneously. Intended for dashboard integrations that need both a direct MCP pipe and an HTTP fan-out endpoint. |
+
+> **Note on SSE:** The `/mcp/sse` endpoint is the _notification delivery channel_ inside the HTTP transport — it is not a separate transport mode. When a client connects via `GET /mcp/sse`, it receives server-initiated notifications over a persistent SSE stream while issuing requests via `POST /mcp`. Operators should not conflate `/mcp/sse` with a distinct transport; the lifecycle of that endpoint is tied to the `http` transport above.
+
+> **Streamable HTTP** (tracked in issue #839) will appear as a fourth row in this table when it lands. It is not yet available.
+
+---
+
+## Stability commitments
+
+A transport listed as **stable** carries the following guarantees across all patch and minor releases within the same major version:
+
+1. **Message-shape compatibility.** The JSON-RPC 2.0 wire format, method names, and parameter shapes for all requests and responses remain unchanged. A client that works against v1.x.0 will continue to work against v1.x.y and v1.(x+1).0 without modification.
+
+2. **Guaranteed events.** The following server-initiated notification types are guaranteed to remain available on all stable transports:
+   - `notifications/tools/list_changed` — emitted when the tool list changes at runtime.
+   - `notifications/resources/list_changed` — emitted when the resource list changes.
+   - Lifecycle error notifications emitted via `console.error` to stderr (never to stdout, which carries MCP JSON-RPC).
+
+3. **Minor-version allowance.** Within a major version, minor releases may:
+   - Add new optional fields to existing messages (additive change, backward-compatible).
+   - Add new notification types (clients that do not handle them ignore them per the MCP spec).
+   - Change default port bindings, keepalive intervals, or internal routing — provided the observable wire protocol is unchanged.
+   - Update authentication mechanisms in an additive way (new auth scheme available; existing scheme continues to work until a separate deprecation notice).
+
+4. **What is NOT guaranteed.** Internal implementation details — HTTP handler internals, keepalive ping interval, rate-limiter queue depth, SSE connection book-keeping — are not part of the stability contract and may change in any release.
+
+---
+
+## Deprecation policy
+
+**Minimum overlap window: 3 minor versions or 6 months, whichever is longer.**
+
+When a transport (or a specific transport feature) is deprecated:
+
+1. A GitHub issue is opened announcing the deprecation, the sunset version, and the recommended migration target.
+2. The transport row in the [Supported transports](#supported-transports) table above is updated to `deprecated`, and the `Sunset` column is filled in.
+3. Starting with the release that announces the deprecation, the server emits a boot-time deprecation warning on stderr whenever the deprecated transport is selected (see [Boot-time deprecation warnings](#boot-time-deprecation-warnings)).
+4. The transport is removed no earlier than the later of:
+   - Three minor version increments after the deprecation announcement (e.g., deprecated in v1.11.0 → earliest removal is v1.14.0), **or**
+   - Six calendar months after the deprecation announcement date.
+
+### Concrete example
+
+> Suppose `http` were deprecated in v1.11.0 on 2026-05-12.
+>
+> - Earliest removal by minor-version rule: v1.14.0 (three increments: v1.11 → v1.12 → v1.13 → v1.14).
+> - Earliest removal by calendar rule: 2026-11-12 (six months later).
+> - Actual earliest removal: whichever date is later. If v1.14.0 ships on 2026-08-01 (before the 6-month mark), removal is deferred to a release on or after 2026-11-12. If v1.14.0 ships on 2026-12-01 (after the 6-month mark), removal may proceed in v1.14.0.
+>
+> No transport is currently deprecated. This example is illustrative only.
+
+---
+
+## Boot-time deprecation warnings
+
+When the server starts with a deprecated transport selected, it emits a single line to stderr:
+
+```
+[openchrome] DEPRECATION WARNING: transport "<name>" is deprecated as of v<announcement-version>. Sunset: v<sunset-version>. Migrate before that release. See: https://github.com/openchrome/openchrome-mcp/blob/main/docs/transport-lifecycle.md
+```
+
+This line:
+- Is emitted via `console.error()` (stderr), never `console.log()` (stdout). stdout carries MCP JSON-RPC and must not be polluted.
+- Contains the marker string `DEPRECATION WARNING` for easy `grep` in CI log scanners.
+- Names the exact sunset version so operators have a concrete calendar target.
+- Links to this document for migration instructions.
+
+**Implementation note:** The warning emitter is not yet present in the codebase (as of v1.11.0). It will be added in a follow-up code PR when the first transport is actually deprecated. This section specifies the contract that implementation must satisfy.
+
+**Current state:** No transport is deprecated in v1.11.0. Zero deprecation warnings are emitted at boot for any supported transport.
+
+---
+
+## Migration recipes
+
+### stdio → HTTP
+
+Switch from the default stdio mode to an HTTP daemon for multi-client or IDE use cases.
+
+**Before (stdio):**
+```bash
+# Claude Code auto-configures stdio by default
+openchrome serve --auto-launch
+```
+
+**After (HTTP daemon):**
+```bash
+# Start the HTTP daemon on port 3100 (default)
+openchrome serve --auto-launch --transport http
+
+# Or specify a custom port and bind address
+openchrome serve --auto-launch --transport http --http 4000 --http-host 0.0.0.0
+
+# With bearer-token authentication (recommended for non-loopback)
+openchrome serve --auto-launch --transport http --http 4000 --auth-token "$(openssl rand -hex 32)"
+```
+
+Configure your MCP client to connect over HTTP:
+```json
+{
+  "mcpServers": {
+    "openchrome": {
+      "type": "http",
+      "url": "http://localhost:4000/mcp",
+      "headers": { "Authorization": "Bearer YOUR_TOKEN" }
+    }
+  }
+}
+```
+
+For unauthenticated loopback-only development:
+```bash
+openchrome serve --auto-launch --transport http --allow-unauthenticated-http
+```
+
+### HTTP → Streamable HTTP (future)
+
+Streamable HTTP is the next-generation MCP transport (tracked in issue #839). It replaces the current HTTP transport with a fully bidirectional streaming protocol that is OAuth-capable and aligns with the broader MCP ecosystem direction.
+
+This recipe will be filled in when issue #839 lands. At that point, the migration will look like:
+
+```bash
+# Anticipated command form — not yet available
+openchrome serve --auto-launch --transport streamable-http --http 3100
+```
+
+Until #839 is merged, continue using `--transport http`. The `http` transport is stable and has no sunset date.
+
+---
+
+## See also
+
+- [docs/auth.md](auth.md) — API key store, bearer tokens, OAuth
+- [docs/roadmap/portability-harness-contract.md](roadmap/portability-harness-contract.md) — core/pilot tier split and portability principles
+- Issue [#839](https://github.com/openchrome/openchrome-mcp/issues/839) — Streamable HTTP transport implementation


### PR DESCRIPTION
**Tier**: documentation-only
**PR target**: `develop`
**Series**: apify-mcp adoption D

## Summary

Adds the authoritative reference for OpenChrome's transport surface as a single normative document. Pure docs change — no `src/` touch, no behavior change. Out of scope per `docs/roadmap/portability-harness-contract.md` §Scope.

### Files

- **New** `docs/transport-lifecycle.md` (150 lines) — 6 sections:
  1. Supported transports table (`stdio`, `http`, `both` with `--transport` value, Status, Since, Sunset, recommended use case).
  2. Stability commitments (message-shape compatibility, guaranteed notification types, minor-version allowance).
  3. Deprecation policy: **3 minor versions OR 6 months overlap, whichever is longer**, between announcement and removal.
  4. Boot-time deprecation warnings contract (implementation deferred to a follow-up code PR).
  5. Migration recipes: stdio→HTTP, HTTP→Streamable HTTP (when #839 lands).
  6. See also.
- **Modified** `README.md` — one paragraph linking to the new doc, immediately before the Quick start.
- **New** `CHANGELOG.md` — `## Transport policy` section under v1.11.x. No transport is currently deprecated.

## Supported transports table (quoted verbatim for in-PR audit)

| Transport | `--transport` value | Status | Since | Sunset | Recommended use case |
|-----------|---------------------|--------|-------|--------|----------------------|
| stdio | `stdio` | **stable** | v1.0.0 | — | Default. Single MCP client over stdin/stdout. |
| HTTP daemon | `http` | **stable** | v1.0.0 | — | Long-running daemon serving multiple MCP clients. |
| Dual (stdio + HTTP) | `both` | **stable** | v1.0.0 | — | Run stdio and HTTP simultaneously. Dashboard integrations. |

> SSE at \`/mcp/sse\` is the notification channel inside the HTTP transport — not a separate transport mode. Streamable HTTP (issue #839) will appear as a fourth row when it lands.

## Acceptance criteria

- [x] \`docs/transport-lifecycle.md\` exists with all five required sections.
- [x] Status table lists every currently-supported transport. Sunset column is \`—\` for all entries.
- [x] Deprecation policy explicitly states the minimum overlap window.
- [x] Migration recipes contain runnable command lines.
- [x] README links to the new doc.
- [x] CHANGELOG records the doc landing.
- [x] No source code under \`src/\` is modified.
- [x] PR description quotes the table verbatim (above).

## Verification

Per the issue spec:

- **Scenario 1** (doc reachable + links resolve) — verified locally (\`test -f\`, \`grep\` for sections, README link present, CHANGELOG ref present). Markdown-link-check skipped (not configured in this repo).
- **Scenario 2** (no new deprecation warnings at boot for current transports) — applies post-merge: the policy is in place but no transport is yet marked deprecated, so no warnings should be emitted by stdio, http, or both modes. Reviewer can confirm by booting locally; nothing in this PR adds the warning emitter (that's a follow-up code PR per §Boot-time deprecation warnings).
- **Scenario 3** (manual table content audit) — reviewer signs off that every transport actually supported by v1.11.x is listed and no transport is marked deprecated yet.

Closes #890