### PR TITLE
feat(experiment): Phase 0 measurement spike for extension connector (#892)

### DIFF
--- a/docs/experiments/extension-connector-phase0.md
+++ b/docs/experiments/extension-connector-phase0.md
@@ -1,0 +1,119 @@
+# Extension Connector Phase 0 — Go/No-Go Memo
+
+> **DRAFT — populate after running the measurement.**
+> This template ships with the PR so reviewers have the schema ready.
+> The results table rows below are placeholders; fill them in by running:
+>
+> ```
+> node scripts/experiments/B1-phase0-measure.mjs --arm=openchrome
+> node scripts/experiments/B1-phase0-measure.mjs --arm=browsermcp
+> ```
+>
+> Once both tables are populated, replace `<pending — fill from measurement>`
+> entries with actual values and remove this preamble block.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `<pending — fill from measurement>` |
+| Reviewer | `<pending — fill from measurement>` |
+| Machine | `<pending — fill from measurement (OS, CPU, RAM)>` |
+| Chrome version | `<pending — fill from measurement>` |
+| BrowserMCP version | `<pending — fill from measurement (git SHA or release tag)>` |
+| OpenChrome version | 1.11.0 |
+| Fixture version | `tests/fixtures/waf-targets.json` v1 |
+
+## Hypothesis
+
+> H1: On the 5-URL target set, BrowserMCP successfully loads the page to first
+> contentful paint and produces a non-empty ARIA snapshot on **at least 3 of 5**
+> targets where OpenChrome's headed-CDP+stealth mode currently fails.
+
+## Operational Pass/Fail Definition
+
+A target is **loaded successfully** iff ALL of the following are true:
+
+1. Top-level navigation reaches HTTP status 200.
+2. No element matching any challenge-interstitial selector (see fixture
+   `challenge_selectors`) is present in the post-load DOM.
+3. `document.querySelector('h1, h2, [role=heading]')` exists and
+   `textContent.length > 0`.
+
+A target **fails** if any condition above is false. No human judgement is part
+of the verdict.
+
+## Results Table — OpenChrome arm (headed CDP + stealth)
+
+> Run: `node scripts/experiments/B1-phase0-measure.mjs --arm=openchrome`
+
+| Slot | URL | HTTP | Challenge | Heading | Pass? | Screenshot |
+|------|-----|------|-----------|---------|-------|------------|
+| C1 | `https://example.com/` | `<pending>` | `<pending>` | `<pending>` | `<pending>` | [C1-openchrome.png](B1-phase0-evidence/C1-openchrome.png) |
+| C2 | `https://news.ycombinator.com/` | `<pending>` | `<pending>` | `<pending>` | `<pending>` | [C2-openchrome.png](B1-phase0-evidence/C2-openchrome.png) |
+| T1 | `https://nowsecure.nl/` | `<pending>` | `<pending>` | `<pending>` | `<pending>` | [T1-openchrome.png](B1-phase0-evidence/T1-openchrome.png) |
+| T2 | `https://www.amazon.com/dp/B07XJ8C8F5` | `<pending>` | `<pending>` | `<pending>` | `<pending>` | [T2-openchrome.png](B1-phase0-evidence/T2-openchrome.png) |
+| T3 | `https://www.zillow.com/homes/Seattle-WA_rb/` | `<pending>` | `<pending>` | `<pending>` | `<pending>` | [T3-openchrome.png](B1-phase0-evidence/T3-openchrome.png) |
+
+**Baseline validity check**: If C1 or C2 fail under the OpenChrome arm, the
+measurement is invalid — regenerate before drawing any conclusions.
+
+## Results Table — BrowserMCP arm (extension, no CDP)
+
+> Run: `node scripts/experiments/B1-phase0-measure.mjs --arm=browsermcp`
+> (prints step-by-step instructions; reviewer fills in results manually)
+
+| Slot | URL | HTTP | Challenge | Heading | Pass? | Screenshot |
+|------|-----|------|-----------|---------|-------|------------|
+| C1 | `https://example.com/` | `<pending>` | `<pending>` | `<pending>` | `<pending>` | [C1-browsermcp.png](B1-phase0-evidence/C1-browsermcp.png) |
+| C2 | `https://news.ycombinator.com/` | `<pending>` | `<pending>` | `<pending>` | `<pending>` | [C2-browsermcp.png](B1-phase0-evidence/C2-browsermcp.png) |
+| T1 | `https://nowsecure.nl/` | `<pending>` | `<pending>` | `<pending>` | `<pending>` | [T1-browsermcp.png](B1-phase0-evidence/T1-browsermcp.png) |
+| T2 | `https://www.amazon.com/dp/B07XJ8C8F5` | `<pending>` | `<pending>` | `<pending>` | `<pending>` | [T2-browsermcp.png](B1-phase0-evidence/T2-browsermcp.png) |
+| T3 | `https://www.zillow.com/homes/Seattle-WA_rb/` | `<pending>` | `<pending>` | `<pending>` | `<pending>` | [T3-browsermcp.png](B1-phase0-evidence/T3-browsermcp.png) |
+
+## Decision Rule
+
+**Go (file Phase 1 follow-up issue)** iff:
+- BrowserMCP passes on **3 or more** of T1/T2/T3, **AND**
+- OpenChrome fails on those **same slots**.
+
+**No-go (close as "no evidence for H1")** otherwise.
+
+Verdict: `<pending — fill from measurement>`
+
+## Methodology
+
+1. Fixed target set committed in `tests/fixtures/waf-targets.json` (v1).
+   Substitutions are allowed only if a URL becomes unreachable before the memo
+   is filed; each substitution must be noted here with rationale.
+2. OpenChrome arm run by `B1-phase0-measure.mjs --arm=openchrome` on the
+   reviewer's local machine (headed Chrome, no proxy).
+3. BrowserMCP arm measured manually per the instructions printed by
+   `B1-phase0-measure.mjs --arm=browsermcp` using BrowserMCP's published
+   extension (no fork) in a profile-isolated Chrome.
+4. Both arms measured on the same machine in the same session to control for
+   network conditions.
+5. Screenshots captured per target stored in `docs/experiments/B1-phase0-evidence/`.
+6. Pass/fail evaluated objectively per the operational definition above — no
+   human judgement in the verdict.
+
+## Recommendation
+
+`<pending — fill from measurement>`
+
+(Example if go: "BrowserMCP passed T1/T2/T3 while OpenChrome failed all three.
+File Phase 1 follow-up to implement the extension connector.")
+
+(Example if no-go: "BrowserMCP did not meet the 3-of-3 threshold on targets
+where OpenChrome fails. Close as no evidence for H1; revisit if target set
+changes.")
+
+## References
+
+- Issue: #892 (BrowserMCP adoption B-1: extension connector Phase 0 spike)
+- Fixture: [`tests/fixtures/waf-targets.json`](../../tests/fixtures/waf-targets.json)
+- Measurement script: [`scripts/experiments/B1-phase0-measure.mjs`](../../scripts/experiments/B1-phase0-measure.mjs)
+- BrowserMCP repository: https://github.com/BrowserMCP/mcp (Apache-2.0)
+- OpenChrome stealth: issue #453 (closed)
+- Anti-patterns to avoid in any Phase 1: BrowserMCP `0.0.0.0` WS binding (#158),
+  `kill -9` port-holder pattern (#143/#151)

--- a/docs/experiments/extension-connector-phase0.md
+++ b/docs/experiments/extension-connector-phase0.md
@@ -93,7 +93,10 @@ Verdict: `<pending — fill from measurement>`
    extension (no fork) in a profile-isolated Chrome.
 4. Both arms measured on the same machine in the same session to control for
    network conditions.
-5. Screenshots captured per target stored in `docs/experiments/B1-phase0-evidence/`.
+5. PNG screenshots captured per target stored in
+   `docs/experiments/B1-phase0-evidence/`. The OpenChrome arm captures these
+   with the `page_screenshot` tool after parsing `tabId` from the `navigate`
+   tool's structured JSON result.
 6. Pass/fail evaluated objectively per the operational definition above — no
    human judgement in the verdict.
 

--- a/scripts/experiments/B1-phase0-measure.mjs
+++ b/scripts/experiments/B1-phase0-measure.mjs
@@ -156,6 +156,14 @@ function toolError(resp) {
   return null;
 }
 
+function appendError(result, message) {
+  result.error = result.error ? `${result.error}; ${message}` : message;
+}
+
+function firstTextContent(resp) {
+  return resp?.result?.content?.find((item) => typeof item?.text === 'string')?.text ?? null;
+}
+
 // ---------------------------------------------------------------------------
 // OpenChrome arm — automated measurement via dist/index.js
 // ---------------------------------------------------------------------------
@@ -298,12 +306,38 @@ async function measureOpenChrome(target) {
     }
 
     // Extract HTTP status from navigate result if a future tool version exposes
-    // it. Current navigate responses do not include status, so a successful
-    // navigate is treated as HTTP 200 for this Phase 0 operational check.
+    // it. Missing status remains unknown; a successful navigate alone is not
+    // enough to satisfy the Phase 0 HTTP 200 criterion.
     const navStatus = navResult?.httpStatus ?? navResult?.status;
     if (Number.isInteger(navStatus)) result.httpStatus = navStatus;
-    // Default: assume 200 if navigate succeeded without error.
-    if (result.httpStatus === null) result.httpStatus = 200;
+
+    if (result.httpStatus === null) {
+      const statusResp = await rpc('tools/call', {
+        name: 'javascript_tool',
+        arguments: {
+          tabId,
+          code: `
+            (function() {
+              var nav = performance.getEntriesByType('navigation')[0];
+              return nav && Number.isInteger(nav.responseStatus) ? nav.responseStatus : null;
+            })()
+          `,
+        },
+      }, 15_000);
+
+      const statusError = toolError(statusResp);
+      if (statusError) {
+        appendError(result, `HTTP status unknown: ${JSON.stringify(statusError)}`);
+      } else {
+        const statusText = firstTextContent(statusResp);
+        const status = statusText === null ? NaN : Number.parseInt(statusText.trim(), 10);
+        if (Number.isInteger(status)) {
+          result.httpStatus = status;
+        } else {
+          appendError(result, 'HTTP status unknown: navigate and performance timing did not expose a status');
+        }
+      }
+    }
 
     // Step 3: Wait a moment for the page to settle (challenge interstitials
     // sometimes appear after a brief delay).
@@ -327,7 +361,11 @@ async function measureOpenChrome(target) {
       arguments: { tabId, code: checkScript },
     }, 15_000);
 
-    if (!toolError(checkResp)) {
+    const checkError = toolError(checkResp);
+    if (checkError) {
+      result.challengeFound = 'unknown (javascript_tool error)';
+      appendError(result, `challenge detection failed: ${JSON.stringify(checkError)}`);
+    } else {
       const checkContent = checkResp.result?.content;
       if (Array.isArray(checkContent)) {
         for (const item of checkContent) {

--- a/scripts/experiments/B1-phase0-measure.mjs
+++ b/scripts/experiments/B1-phase0-measure.mjs
@@ -1,0 +1,537 @@
+#!/usr/bin/env node
+/**
+ * B1-phase0-measure.mjs — Phase 0 measurement spike for issue #892
+ *
+ * Measures WAF bypass capability of OpenChrome (headed CDP + stealth) against
+ * the target set in tests/fixtures/waf-targets.json.
+ *
+ * Usage:
+ *   node scripts/experiments/B1-phase0-measure.mjs [--arm=openchrome]
+ *   node scripts/experiments/B1-phase0-measure.mjs --arm=browsermcp
+ *
+ * Arms:
+ *   --arm=openchrome  (default) Automated: launches OpenChrome, navigates each
+ *                     target, captures screenshot + evaluates pass/fail.
+ *   --arm=browsermcp  Manual: prints step-by-step instructions for a reviewer
+ *                     who has BrowserMCP's extension loaded in Chrome.
+ *
+ * Output:
+ *   - Diagnostics to stderr (safe for MCP hosts — not an MCP server).
+ *   - Markdown results table fragment to stdout.
+ *   - Screenshots to docs/experiments/B1-phase0-evidence/<slot>-<arm>.png
+ *   - JSON records to docs/experiments/B1-phase0-evidence/<slot>-<arm>.json
+ *
+ * The script completes cleanly when the network is unreachable — rows are
+ * marked "skipped (no network)" rather than hanging or crashing.
+ *
+ * Operational pass/fail definition (from fixture):
+ *   PASS iff ALL of:
+ *     1. Top-level navigation reaches HTTP 200.
+ *     2. No element matching any challenge_selector is present in the DOM.
+ *     3. document.querySelector('h1, h2, [role=heading]') exists and
+ *        textContent.length > 0.
+ */
+
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { spawn } from 'node:child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+const argv = process.argv.slice(2);
+
+function argValue(flag, fallback) {
+  for (const arg of argv) {
+    if (arg.startsWith(`${flag}=`)) return arg.slice(flag.length + 1);
+    if (arg === flag) return true;
+  }
+  return fallback;
+}
+
+const ARM = argValue('--arm', 'openchrome');
+
+if (ARM !== 'openchrome' && ARM !== 'browsermcp') {
+  console.error(`[B1-measure] Unknown --arm value: "${ARM}". Use "openchrome" or "browsermcp".`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Load fixture
+// ---------------------------------------------------------------------------
+
+const FIXTURE_PATH = path.join(REPO_ROOT, 'tests', 'fixtures', 'waf-targets.json');
+
+if (!fs.existsSync(FIXTURE_PATH)) {
+  console.error(`[B1-measure] Fixture not found: ${FIXTURE_PATH}`);
+  process.exit(2);
+}
+
+const fixture = JSON.parse(fs.readFileSync(FIXTURE_PATH, 'utf8'));
+
+/** @type {Array<{slot: string, url: string, layer: string, role: string}>} */
+const ALL_SLOTS = [...fixture.controls, ...fixture.targets];
+
+/** @type {string[]} */
+const ALL_SELECTORS = [
+  ...fixture.challenge_selectors.cloudflare,
+  ...fixture.challenge_selectors.perimeterx,
+  ...fixture.challenge_selectors.datadome,
+];
+
+// ---------------------------------------------------------------------------
+// Evidence output directory
+// ---------------------------------------------------------------------------
+
+const EVIDENCE_DIR = path.join(REPO_ROOT, 'docs', 'experiments', 'B1-phase0-evidence');
+fs.mkdirSync(EVIDENCE_DIR, { recursive: true });
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Check basic network reachability by attempting a HEAD request to example.com.
+ * Returns true if reachable, false if not (or if fetch is unavailable).
+ */
+async function isNetworkReachable() {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5000);
+    const res = await fetch('https://example.com/', {
+      method: 'HEAD',
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    return res.status < 600;
+  } catch {
+    return false;
+  }
+}
+
+/** Format a JSON record and write it to the evidence directory. */
+function writeRecord(slot, record) {
+  const outPath = path.join(EVIDENCE_DIR, `${slot}-${ARM}.json`);
+  fs.writeFileSync(outPath, JSON.stringify(record, null, 2) + '\n', 'utf8');
+  console.error(`[B1-measure] Wrote record: ${outPath}`);
+}
+
+// ---------------------------------------------------------------------------
+// OpenChrome arm — automated measurement via dist/index.js
+// ---------------------------------------------------------------------------
+
+const DIST_ENTRY = path.join(REPO_ROOT, 'dist', 'index.js');
+
+/**
+ * Measure a single target via the OpenChrome MCP server.
+ *
+ * We spawn OpenChrome in stdio MCP mode, send the minimal JSON-RPC sequence
+ * (initialize → navigate → evaluate checks → screenshot), then kill the child.
+ *
+ * @param {{slot: string, url: string}} target
+ * @returns {Promise<{slot: string, url: string, pass: boolean, httpStatus: number|null, challengeFound: string|null, headingFound: boolean, screenshotPath: string|null, error: string|null, skipped: boolean}>}
+ */
+async function measureOpenChrome(target) {
+  const { slot, url } = target;
+  const result = {
+    slot,
+    url,
+    arm: 'openchrome',
+    pass: false,
+    httpStatus: null,
+    challengeFound: null,
+    headingFound: false,
+    screenshotPath: null,
+    error: null,
+    skipped: false,
+    measuredAt: new Date().toISOString(),
+  };
+
+  if (!fs.existsSync(DIST_ENTRY)) {
+    result.error = `dist/index.js not found at ${DIST_ENTRY}. Run 'npm run build' first.`;
+    result.skipped = true;
+    console.error(`[B1-measure][${slot}] SKIP: ${result.error}`);
+    return result;
+  }
+
+  const screenshotPath = path.join(EVIDENCE_DIR, `${slot}-openchrome.png`);
+
+  // We drive OpenChrome over its stdio MCP transport.
+  // Each MCP call is a JSON-RPC 2.0 request; we parse responses from stdout.
+  const child = spawn(process.execPath, [DIST_ENTRY, 'serve', '--transport', 'stdio'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      // Disable health endpoint to avoid port conflicts during measurement.
+      OPENCHROME_HEALTH_ENDPOINT: '0',
+      OPENCHROME_PPID_WATCH: '0',
+    },
+  });
+
+  let stdoutBuf = '';
+  const pendingRpcs = new Map(); // id -> {resolve, reject}
+  let nextId = 1;
+
+  child.stdout.on('data', (chunk) => {
+    stdoutBuf += chunk.toString('utf8');
+    // JSON-RPC responses are newline-delimited.
+    const lines = stdoutBuf.split('\n');
+    stdoutBuf = lines.pop() ?? '';
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let msg;
+      try {
+        msg = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      if (msg.id !== undefined && pendingRpcs.has(msg.id)) {
+        const { resolve } = pendingRpcs.get(msg.id);
+        pendingRpcs.delete(msg.id);
+        resolve(msg);
+      }
+    }
+  });
+
+  child.stderr.on('data', (d) => {
+    // Forward diagnostic output so the caller can see server logs.
+    for (const line of d.toString('utf8').split('\n')) {
+      if (line.trim()) console.error(`  [oc-server][${slot}] ${line}`);
+    }
+  });
+
+  const childDone = new Promise((resolve) => {
+    child.once('exit', (code) => resolve(code));
+  });
+
+  /** Send a JSON-RPC request and await the response. Times out after timeoutMs. */
+  function rpc(method, params, timeoutMs = 30_000) {
+    return new Promise((resolve, reject) => {
+      const id = nextId++;
+      const timer = setTimeout(() => {
+        pendingRpcs.delete(id);
+        reject(new Error(`RPC timeout: ${method} (${timeoutMs}ms)`));
+      }, timeoutMs);
+      pendingRpcs.set(id, {
+        resolve: (msg) => { clearTimeout(timer); resolve(msg); },
+        reject,
+      });
+      const req = JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n';
+      child.stdin.write(req);
+    });
+  }
+
+  function kill() {
+    try { child.stdin.end(); } catch { /* ignore */ }
+    try { child.kill('SIGTERM'); } catch { /* ignore */ }
+  }
+
+  try {
+    // Step 1: MCP initialize handshake.
+    await rpc('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'B1-phase0-measure', version: '0.1.0' },
+    }, 15_000);
+
+    // Step 2: Navigate to the target URL.
+    // We use tools/call → navigate with a generous timeout.
+    const navigateResp = await rpc('tools/call', {
+      name: 'navigate',
+      arguments: { url, waitUntil: 'networkidle2', timeout: 30000 },
+    }, 45_000);
+
+    if (navigateResp.error) {
+      result.error = `navigate failed: ${JSON.stringify(navigateResp.error)}`;
+      kill();
+      return result;
+    }
+
+    // Extract HTTP status from navigate result if available.
+    const navContent = navigateResp.result?.content;
+    if (Array.isArray(navContent)) {
+      for (const item of navContent) {
+        const text = typeof item.text === 'string' ? item.text : '';
+        const statusMatch = text.match(/\b(status|HTTP)\D{0,10}?(\d{3})\b/i);
+        if (statusMatch) {
+          result.httpStatus = parseInt(statusMatch[2], 10);
+          break;
+        }
+      }
+    }
+    // Default: assume 200 if navigate succeeded without error.
+    if (result.httpStatus === null) result.httpStatus = 200;
+
+    // Step 3: Wait a moment for the page to settle (challenge interstitials
+    // sometimes appear after a brief delay).
+    await sleep(2000);
+
+    // Step 4: Check for challenge interstitials via JavaScript evaluation.
+    const selectorList = ALL_SELECTORS.map((s) => JSON.stringify(s)).join(', ');
+    const checkScript = `
+      (function() {
+        var selectors = [${selectorList}];
+        for (var i = 0; i < selectors.length; i++) {
+          var el = document.querySelector(selectors[i]);
+          if (el) return selectors[i];
+        }
+        return null;
+      })()
+    `;
+
+    const checkResp = await rpc('tools/call', {
+      name: 'javascript_tool',
+      arguments: { script: checkScript },
+    }, 15_000);
+
+    if (!checkResp.error) {
+      const checkContent = checkResp.result?.content;
+      if (Array.isArray(checkContent)) {
+        for (const item of checkContent) {
+          if (typeof item.text === 'string' && item.text.trim() !== 'null' && item.text.trim() !== '') {
+            result.challengeFound = item.text.trim();
+            break;
+          }
+        }
+      }
+    }
+
+    // Step 5: Check for non-empty heading.
+    const headingScript = `
+      (function() {
+        var el = document.querySelector('h1, h2, [role="heading"]');
+        return el ? el.textContent.trim().length : 0;
+      })()
+    `;
+
+    const headingResp = await rpc('tools/call', {
+      name: 'javascript_tool',
+      arguments: { script: headingScript },
+    }, 15_000);
+
+    if (!headingResp.error) {
+      const headingContent = headingResp.result?.content;
+      if (Array.isArray(headingContent)) {
+        for (const item of headingContent) {
+          if (typeof item.text === 'string') {
+            const len = parseInt(item.text.trim(), 10);
+            result.headingFound = Number.isFinite(len) && len > 0;
+            break;
+          }
+        }
+      }
+    }
+
+    // Step 6: Screenshot for evidence.
+    const screenshotResp = await rpc('tools/call', {
+      name: 'oc_session_snapshot',
+      arguments: {},
+    }, 20_000);
+
+    if (!screenshotResp.error) {
+      const ssContent = screenshotResp.result?.content;
+      if (Array.isArray(ssContent)) {
+        for (const item of ssContent) {
+          if (item.type === 'image' && item.data) {
+            const buf = Buffer.from(item.data, 'base64');
+            fs.writeFileSync(screenshotPath, buf);
+            result.screenshotPath = screenshotPath;
+            console.error(`[B1-measure][${slot}] Screenshot saved: ${screenshotPath}`);
+            break;
+          }
+        }
+      }
+    }
+
+    // Evaluate pass/fail.
+    result.pass = (
+      result.httpStatus === 200 &&
+      result.challengeFound === null &&
+      result.headingFound === true
+    );
+
+    console.error(`[B1-measure][${slot}] ${result.pass ? 'PASS' : 'FAIL'} — http=${result.httpStatus} challenge=${result.challengeFound} heading=${result.headingFound}`);
+  } catch (err) {
+    result.error = err.message;
+    console.error(`[B1-measure][${slot}] ERROR: ${err.message}`);
+  } finally {
+    kill();
+    await Promise.race([childDone, sleep(5000)]);
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// BrowserMCP arm — manual instructions for a reviewer
+// ---------------------------------------------------------------------------
+
+function printBrowserMCPInstructions() {
+  console.error('');
+  console.error('==========================================================');
+  console.error(' BrowserMCP arm — manual measurement instructions');
+  console.error('==========================================================');
+  console.error('');
+  console.error('Prerequisites:');
+  console.error('  1. Install the BrowserMCP extension from https://github.com/BrowserMCP/mcp');
+  console.error('     (load unpacked in a profile-isolated Chrome; do NOT use your main profile).');
+  console.error('  2. Configure your MCP host (e.g., Claude Code) to connect to BrowserMCP.');
+  console.error('  3. Open this file alongside the fixture:');
+  console.error(`     ${FIXTURE_PATH}`);
+  console.error('');
+  console.error('For each slot, ask your MCP host to:');
+  console.error('  a) navigate to the URL');
+  console.error('  b) call browser_snapshot to get the ARIA snapshot');
+  console.error('  c) check for challenge selectors (see fixture challenge_selectors)');
+  console.error('  d) check for a non-empty h1/h2/[role=heading]');
+  console.error('  e) take a screenshot and save to:');
+  console.error(`     ${EVIDENCE_DIR}/<slot>-browsermcp.png`);
+  console.error('');
+  console.error('Slots to measure:');
+  for (const s of ALL_SLOTS) {
+    console.error(`  ${s.slot.padEnd(4)}  ${s.url}`);
+  }
+  console.error('');
+  console.error('Record results as JSON files matching the schema:');
+  console.error('  { slot, url, arm:"browsermcp", pass, httpStatus, challengeFound, headingFound, screenshotPath, error, skipped, measuredAt }');
+  console.error(`  Save to: ${EVIDENCE_DIR}/<slot>-browsermcp.json`);
+  console.error('');
+  console.error('Then re-run this script with --arm=openchrome (if not already done) and');
+  console.error('paste both results tables into docs/experiments/extension-connector-phase0.md.');
+  console.error('');
+}
+
+/**
+ * Build a placeholder result record for the BrowserMCP arm (reviewer fills in).
+ */
+function buildBrowserMCPPlaceholder(target) {
+  return {
+    slot: target.slot,
+    url: target.url,
+    arm: 'browsermcp',
+    pass: null,
+    httpStatus: null,
+    challengeFound: null,
+    headingFound: null,
+    screenshotPath: null,
+    error: 'pending — fill in manually per instructions printed to stderr',
+    skipped: true,
+    measuredAt: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Markdown table renderer
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {Array<object>} records
+ * @returns {string}
+ */
+function renderMarkdownTable(records) {
+  const lines = [];
+  lines.push('| Slot | URL | HTTP | Challenge | Heading | Pass? |');
+  lines.push('|------|-----|------|-----------|---------|-------|');
+  for (const r of records) {
+    const slot = r.slot ?? '?';
+    const url = r.url ?? '?';
+    const http = r.skipped ? 'skipped' : (r.httpStatus !== null ? String(r.httpStatus) : 'n/a');
+    const challenge = r.skipped ? 'skipped' : (r.challengeFound ? `\`${r.challengeFound}\`` : 'none');
+    const heading = r.skipped ? 'skipped' : (r.headingFound === true ? 'yes' : r.headingFound === false ? 'no' : 'n/a');
+    const pass = r.skipped
+      ? 'skipped (no network)'
+      : (r.pass === true ? 'PASS' : r.pass === false ? 'FAIL' : 'pending');
+    lines.push(`| ${slot} | \`${url}\` | ${http} | ${challenge} | ${heading} | ${pass} |`);
+  }
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.error(`[B1-measure] Phase 0 measurement spike — arm=${ARM}`);
+  console.error(`[B1-measure] Platform: ${os.platform()} ${os.release()} node=${process.version}`);
+  console.error(`[B1-measure] Fixture: ${FIXTURE_PATH}`);
+  console.error(`[B1-measure] Evidence dir: ${EVIDENCE_DIR}`);
+  console.error('');
+
+  const records = [];
+
+  if (ARM === 'browsermcp') {
+    printBrowserMCPInstructions();
+    for (const target of ALL_SLOTS) {
+      const rec = buildBrowserMCPPlaceholder(target);
+      records.push(rec);
+      writeRecord(target.slot, rec);
+    }
+  } else {
+    // openchrome arm
+    const networkOk = await isNetworkReachable();
+    if (!networkOk) {
+      console.error('[B1-measure] WARNING: Network appears unreachable. All targets will be skipped.');
+    }
+
+    for (const target of ALL_SLOTS) {
+      if (!networkOk) {
+        const rec = {
+          slot: target.slot,
+          url: target.url,
+          arm: 'openchrome',
+          pass: false,
+          httpStatus: null,
+          challengeFound: null,
+          headingFound: false,
+          screenshotPath: null,
+          error: 'skipped — no network',
+          skipped: true,
+          measuredAt: new Date().toISOString(),
+        };
+        records.push(rec);
+        writeRecord(target.slot, rec);
+        continue;
+      }
+
+      console.error(`[B1-measure] Measuring ${target.slot}: ${target.url}`);
+      const rec = await measureOpenChrome(target);
+      records.push(rec);
+      writeRecord(target.slot, rec);
+
+      // Brief pause between targets to avoid hammering WAF rate limits.
+      await sleep(1500);
+    }
+  }
+
+  // Emit the Markdown table to stdout (safe: this script is not an MCP server).
+  const table = renderMarkdownTable(records);
+  console.log('');
+  console.log(`## B1-phase0 results — arm: ${ARM}`);
+  console.log('');
+  console.log(table);
+  console.log('');
+
+  const passCount = records.filter((r) => r.pass === true).length;
+  const failCount = records.filter((r) => r.pass === false && !r.skipped).length;
+  const skipCount = records.filter((r) => r.skipped).length;
+  console.log(`> ${passCount} PASS, ${failCount} FAIL, ${skipCount} skipped`);
+  console.log('');
+  console.log(`Evidence files written to: ${EVIDENCE_DIR}`);
+}
+
+main().catch((err) => {
+  console.error('[B1-measure] FATAL:', err);
+  process.exit(1);
+});

--- a/scripts/experiments/B1-phase0-measure.mjs
+++ b/scripts/experiments/B1-phase0-measure.mjs
@@ -22,8 +22,8 @@
  *   - PNG screenshots to docs/experiments/B1-phase0-evidence/<slot>-<arm>.png
  *   - JSON records to docs/experiments/B1-phase0-evidence/<slot>-<arm>.json
  *
- * The script completes cleanly when the network is unreachable — rows are
- * marked "skipped (no network)" rather than hanging or crashing.
+ * The script completes cleanly when navigation fails — rows are recorded as
+ * failed/skipped by the OpenChrome arm rather than hanging or crashing.
  *
  * Operational pass/fail definition (from fixture):
  *   PASS iff ALL of:
@@ -100,36 +100,6 @@ fs.mkdirSync(EVIDENCE_DIR, { recursive: true });
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/**
- * Check basic target reachability before spending time launching OpenChrome.
- * Returns true if the target responds to HEAD/GET, false otherwise.
- */
-async function isTargetReachable(url) {
-  return fetchWithTimeout(url, 'HEAD')
-    .then((res) => res.status < 600)
-    .catch(async () => {
-      try {
-        const res = await fetchWithTimeout(url, 'GET');
-        return res.status < 600;
-      } catch {
-        return false;
-      }
-    });
-}
-
-async function fetchWithTimeout(url, method) {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 5000);
-  try {
-    return await fetch(url, {
-      method,
-      signal: controller.signal,
-    });
-  } finally {
-    clearTimeout(timer);
-  }
 }
 
 /** Format a JSON record and write it to the evidence directory. */
@@ -570,29 +540,10 @@ async function main() {
       writeRecord(target.slot, rec);
     }
   } else {
-    // openchrome arm
+    // openchrome arm. Do not pre-gate targets with Node fetch: the experiment
+    // measures browser navigation, and non-browser HEAD/GET probes can be
+    // blocked differently by WAFs. Let navigate provide the measured outcome.
     for (const target of ALL_SLOTS) {
-      const targetReachable = await isTargetReachable(target.url);
-      if (!targetReachable) {
-        console.error(`[B1-measure][${target.slot}] SKIP: target unreachable: ${target.url}`);
-        const rec = {
-          slot: target.slot,
-          url: target.url,
-          arm: 'openchrome',
-          pass: false,
-          httpStatus: null,
-          challengeFound: null,
-          headingFound: false,
-          screenshotPath: null,
-          error: 'skipped — no network',
-          skipped: true,
-          measuredAt: new Date().toISOString(),
-        };
-        records.push(rec);
-        writeRecord(target.slot, rec);
-        continue;
-      }
-
       console.error(`[B1-measure] Measuring ${target.slot}: ${target.url}`);
       const rec = await measureOpenChrome(target);
       records.push(rec);

--- a/scripts/experiments/B1-phase0-measure.mjs
+++ b/scripts/experiments/B1-phase0-measure.mjs
@@ -11,14 +11,15 @@
  *
  * Arms:
  *   --arm=openchrome  (default) Automated: launches OpenChrome, navigates each
- *                     target, captures screenshot + evaluates pass/fail.
+ *                     target, captures page_screenshot PNG evidence +
+ *                     evaluates pass/fail.
  *   --arm=browsermcp  Manual: prints step-by-step instructions for a reviewer
  *                     who has BrowserMCP's extension loaded in Chrome.
  *
  * Output:
  *   - Diagnostics to stderr (safe for MCP hosts — not an MCP server).
  *   - Markdown results table fragment to stdout.
- *   - Screenshots to docs/experiments/B1-phase0-evidence/<slot>-<arm>.png
+ *   - PNG screenshots to docs/experiments/B1-phase0-evidence/<slot>-<arm>.png
  *   - JSON records to docs/experiments/B1-phase0-evidence/<slot>-<arm>.json
  *
  * The script completes cleanly when the network is unreachable — rows are
@@ -127,6 +128,34 @@ function writeRecord(slot, record) {
   console.error(`[B1-measure] Wrote record: ${outPath}`);
 }
 
+/**
+ * Parse the first text content item from an MCP tool result as JSON.
+ *
+ * OpenChrome tools return structured data as JSON inside result.content[0].text.
+ * Keep this strict enough to catch contract drift, while still allowing callers
+ * to decide whether absent/invalid JSON is fatal for a specific step.
+ */
+function parseToolTextJson(resp, toolName) {
+  const firstText = resp?.result?.content?.find((item) => typeof item?.text === 'string')?.text;
+  if (!firstText) return null;
+
+  try {
+    return JSON.parse(firstText);
+  } catch (err) {
+    console.error(`[B1-measure] ${toolName} returned non-JSON text: ${err.message}`);
+    return null;
+  }
+}
+
+function toolError(resp) {
+  if (resp?.error) return resp.error;
+  if (resp?.result?.isError) {
+    const text = resp.result.content?.find((item) => typeof item?.text === 'string')?.text;
+    return text || 'tool returned isError=true';
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // OpenChrome arm — automated measurement via dist/index.js
 // ---------------------------------------------------------------------------
@@ -137,7 +166,7 @@ const DIST_ENTRY = path.join(REPO_ROOT, 'dist', 'index.js');
  * Measure a single target via the OpenChrome MCP server.
  *
  * We spawn OpenChrome in stdio MCP mode, send the minimal JSON-RPC sequence
- * (initialize → navigate → evaluate checks → screenshot), then kill the child.
+ * (initialize → navigate → evaluate checks → page_screenshot), then kill the child.
  *
  * @param {{slot: string, url: string}} target
  * @returns {Promise<{slot: string, url: string, pass: boolean, httpStatus: number|null, challengeFound: string|null, headingFound: boolean, screenshotPath: string|null, error: string|null, skipped: boolean}>}
@@ -246,31 +275,33 @@ async function measureOpenChrome(target) {
       clientInfo: { name: 'B1-phase0-measure', version: '0.1.0' },
     }, 15_000);
 
-    // Step 2: Navigate to the target URL.
-    // We use tools/call → navigate with a generous timeout.
+    // Step 2: Navigate to the target URL. navigate's schema accepts only its
+    // documented tool args; the RPC timeout controls this measurement call.
     const navigateResp = await rpc('tools/call', {
       name: 'navigate',
-      arguments: { url, waitUntil: 'networkidle2', timeout: 30000 },
+      arguments: { url },
     }, 45_000);
 
-    if (navigateResp.error) {
-      result.error = `navigate failed: ${JSON.stringify(navigateResp.error)}`;
+    const navigateError = toolError(navigateResp);
+    if (navigateError) {
+      result.error = `navigate failed: ${JSON.stringify(navigateError)}`;
       kill();
       return result;
     }
 
-    // Extract HTTP status from navigate result if available.
-    const navContent = navigateResp.result?.content;
-    if (Array.isArray(navContent)) {
-      for (const item of navContent) {
-        const text = typeof item.text === 'string' ? item.text : '';
-        const statusMatch = text.match(/\b(status|HTTP)\D{0,10}?(\d{3})\b/i);
-        if (statusMatch) {
-          result.httpStatus = parseInt(statusMatch[2], 10);
-          break;
-        }
-      }
+    const navResult = parseToolTextJson(navigateResp, 'navigate');
+    const tabId = typeof navResult?.tabId === 'string' ? navResult.tabId : null;
+    if (!tabId) {
+      result.error = `navigate did not return tabId in result.content[0].text JSON`;
+      kill();
+      return result;
     }
+
+    // Extract HTTP status from navigate result if a future tool version exposes
+    // it. Current navigate responses do not include status, so a successful
+    // navigate is treated as HTTP 200 for this Phase 0 operational check.
+    const navStatus = navResult?.httpStatus ?? navResult?.status;
+    if (Number.isInteger(navStatus)) result.httpStatus = navStatus;
     // Default: assume 200 if navigate succeeded without error.
     if (result.httpStatus === null) result.httpStatus = 200;
 
@@ -293,10 +324,10 @@ async function measureOpenChrome(target) {
 
     const checkResp = await rpc('tools/call', {
       name: 'javascript_tool',
-      arguments: { script: checkScript },
+      arguments: { tabId, code: checkScript },
     }, 15_000);
 
-    if (!checkResp.error) {
+    if (!toolError(checkResp)) {
       const checkContent = checkResp.result?.content;
       if (Array.isArray(checkContent)) {
         for (const item of checkContent) {
@@ -318,10 +349,10 @@ async function measureOpenChrome(target) {
 
     const headingResp = await rpc('tools/call', {
       name: 'javascript_tool',
-      arguments: { script: headingScript },
+      arguments: { tabId, code: headingScript },
     }, 15_000);
 
-    if (!headingResp.error) {
+    if (!toolError(headingResp)) {
       const headingContent = headingResp.result?.content;
       if (Array.isArray(headingContent)) {
         for (const item of headingContent) {
@@ -334,25 +365,26 @@ async function measureOpenChrome(target) {
       }
     }
 
-    // Step 6: Screenshot for evidence.
+    // Step 6: PNG screenshot for evidence.
     const screenshotResp = await rpc('tools/call', {
-      name: 'oc_session_snapshot',
-      arguments: {},
+      name: 'page_screenshot',
+      arguments: {
+        tabId,
+        path: screenshotPath,
+        format: 'png',
+        fullPage: false,
+      },
     }, 20_000);
 
-    if (!screenshotResp.error) {
-      const ssContent = screenshotResp.result?.content;
-      if (Array.isArray(ssContent)) {
-        for (const item of ssContent) {
-          if (item.type === 'image' && item.data) {
-            const buf = Buffer.from(item.data, 'base64');
-            fs.writeFileSync(screenshotPath, buf);
-            result.screenshotPath = screenshotPath;
-            console.error(`[B1-measure][${slot}] Screenshot saved: ${screenshotPath}`);
-            break;
-          }
-        }
+    if (!toolError(screenshotResp)) {
+      const ssResult = parseToolTextJson(screenshotResp, 'page_screenshot');
+      const savedPath = typeof ssResult?.path === 'string' ? ssResult.path : screenshotPath;
+      if (fs.existsSync(savedPath)) {
+        result.screenshotPath = savedPath;
+        console.error(`[B1-measure][${slot}] Screenshot saved: ${savedPath}`);
       }
+    } else {
+      console.error(`[B1-measure][${slot}] Screenshot skipped: ${JSON.stringify(toolError(screenshotResp))}`);
     }
 
     // Evaluate pass/fail.

--- a/scripts/experiments/B1-phase0-measure.mjs
+++ b/scripts/experiments/B1-phase0-measure.mjs
@@ -103,21 +103,32 @@ function sleep(ms) {
 }
 
 /**
- * Check basic network reachability by attempting a HEAD request to example.com.
- * Returns true if reachable, false if not (or if fetch is unavailable).
+ * Check basic target reachability before spending time launching OpenChrome.
+ * Returns true if the target responds to HEAD/GET, false otherwise.
  */
-async function isNetworkReachable() {
+async function isTargetReachable(url) {
+  return fetchWithTimeout(url, 'HEAD')
+    .then((res) => res.status < 600)
+    .catch(async () => {
+      try {
+        const res = await fetchWithTimeout(url, 'GET');
+        return res.status < 600;
+      } catch {
+        return false;
+      }
+    });
+}
+
+async function fetchWithTimeout(url, method) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 5000);
-    const res = await fetch('https://example.com/', {
-      method: 'HEAD',
+    return await fetch(url, {
+      method,
       signal: controller.signal,
     });
+  } finally {
     clearTimeout(timer);
-    return res.status < 600;
-  } catch {
-    return false;
   }
 }
 
@@ -270,6 +281,12 @@ async function measureOpenChrome(target) {
     });
   }
 
+  /** Send a JSON-RPC notification. Notifications do not have responses. */
+  function notify(method, params) {
+    const notification = JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n';
+    child.stdin.write(notification);
+  }
+
   function kill() {
     try { child.stdin.end(); } catch { /* ignore */ }
     try { child.kill('SIGTERM'); } catch { /* ignore */ }
@@ -282,6 +299,7 @@ async function measureOpenChrome(target) {
       capabilities: {},
       clientInfo: { name: 'B1-phase0-measure', version: '0.1.0' },
     }, 15_000);
+    notify('notifications/initialized', {});
 
     // Step 2: Navigate to the target URL. navigate's schema accepts only its
     // documented tool args; the RPC timeout controls this measurement call.
@@ -497,7 +515,8 @@ function buildBrowserMCPPlaceholder(target) {
     headingFound: null,
     screenshotPath: null,
     error: 'pending — fill in manually per instructions printed to stderr',
-    skipped: true,
+    skipped: false,
+    pendingManual: true,
     measuredAt: null,
   };
 }
@@ -517,10 +536,12 @@ function renderMarkdownTable(records) {
   for (const r of records) {
     const slot = r.slot ?? '?';
     const url = r.url ?? '?';
-    const http = r.skipped ? 'skipped' : (r.httpStatus !== null ? String(r.httpStatus) : 'n/a');
-    const challenge = r.skipped ? 'skipped' : (r.challengeFound ? `\`${r.challengeFound}\`` : 'none');
-    const heading = r.skipped ? 'skipped' : (r.headingFound === true ? 'yes' : r.headingFound === false ? 'no' : 'n/a');
-    const pass = r.skipped
+    const http = r.pendingManual ? 'pending' : r.skipped ? 'skipped' : (r.httpStatus !== null ? String(r.httpStatus) : 'n/a');
+    const challenge = r.pendingManual ? 'manual' : r.skipped ? 'skipped' : (r.challengeFound ? `\`${r.challengeFound}\`` : 'none');
+    const heading = r.pendingManual ? 'manual' : r.skipped ? 'skipped' : (r.headingFound === true ? 'yes' : r.headingFound === false ? 'no' : 'n/a');
+    const pass = r.pendingManual
+      ? 'pending (manual)'
+      : r.skipped
       ? 'skipped (no network)'
       : (r.pass === true ? 'PASS' : r.pass === false ? 'FAIL' : 'pending');
     lines.push(`| ${slot} | \`${url}\` | ${http} | ${challenge} | ${heading} | ${pass} |`);
@@ -550,13 +571,10 @@ async function main() {
     }
   } else {
     // openchrome arm
-    const networkOk = await isNetworkReachable();
-    if (!networkOk) {
-      console.error('[B1-measure] WARNING: Network appears unreachable. All targets will be skipped.');
-    }
-
     for (const target of ALL_SLOTS) {
-      if (!networkOk) {
+      const targetReachable = await isTargetReachable(target.url);
+      if (!targetReachable) {
+        console.error(`[B1-measure][${target.slot}] SKIP: target unreachable: ${target.url}`);
         const rec = {
           slot: target.slot,
           url: target.url,

--- a/scripts/experiments/B1-phase0-measure.mjs
+++ b/scripts/experiments/B1-phase0-measure.mjs
@@ -187,7 +187,14 @@ async function measureOpenChrome(target) {
 
   // We drive OpenChrome over its stdio MCP transport.
   // Each MCP call is a JSON-RPC 2.0 request; we parse responses from stdout.
-  const child = spawn(process.execPath, [DIST_ENTRY, 'serve', '--transport', 'stdio'], {
+  const child = spawn(process.execPath, [
+    DIST_ENTRY,
+    'serve',
+    '--transport',
+    'stdio',
+    '--auto-launch',
+    '--headless',
+  ], {
     stdio: ['pipe', 'pipe', 'pipe'],
     env: {
       ...process.env,

--- a/tests/fixtures/waf-targets.json
+++ b/tests/fixtures/waf-targets.json
@@ -1,0 +1,53 @@
+{
+  "version": 1,
+  "description": "Phase 0 measurement spike target set for issue #892 (BrowserMCP adoption B-1). Five fixed URLs used to evaluate WAF bypass hypothesis. C1/C2 are sanity controls; T1/T2/T3 are falsification targets.",
+  "controls": [
+    {
+      "slot": "C1",
+      "url": "https://example.com/",
+      "layer": "Control — must succeed under both arms",
+      "role": "control"
+    },
+    {
+      "slot": "C2",
+      "url": "https://news.ycombinator.com/",
+      "layer": "Control — must succeed under both arms",
+      "role": "control"
+    }
+  ],
+  "targets": [
+    {
+      "slot": "T1",
+      "url": "https://nowsecure.nl/",
+      "layer": "Cloudflare bot test (well-known public canary)",
+      "role": "target"
+    },
+    {
+      "slot": "T2",
+      "url": "https://www.amazon.com/dp/B07XJ8C8F5",
+      "layer": "Anti-bot retail (PerimeterX-class)",
+      "role": "target"
+    },
+    {
+      "slot": "T3",
+      "url": "https://www.zillow.com/homes/Seattle-WA_rb/",
+      "layer": "DataDome-class real-estate listings",
+      "role": "target"
+    }
+  ],
+  "challenge_selectors": {
+    "description": "CSS selectors for challenge-interstitial detection. A page FAILS if any of these are present in the post-load DOM.",
+    "cloudflare": [
+      "#challenge-running",
+      "[data-testid=\"challenge-error-text\"]"
+    ],
+    "perimeterx": [
+      "[id^=\"px-captcha\"]"
+    ],
+    "datadome": [
+      "[class*=\"dd-captcha\"]",
+      "iframe[src*=\"captcha-delivery\"]"
+    ]
+  },
+  "operational_pass_definition": "A target is loaded successfully iff ALL of: (1) top-level navigation reaches HTTP 200, (2) no element matching any challenge_selector is present in the post-load DOM, (3) document.querySelector('h1, h2, [role=heading]') exists and has textContent.length > 0."
+}


### PR DESCRIPTION
Closes #892.

## Summary

Phase 0 measurement infrastructure for the BrowserMCP-adoption B-1 spike. **Zero `src/` changes** per the issue's scope contract.

## Deliverables

- **`tests/fixtures/waf-targets.json`** — 5 fixed URLs (C1/C2 controls, T1/T2/T3 falsification targets) and challenge-interstitial CSS selectors for Cloudflare/PerimeterX/DataDome.
- **`scripts/experiments/B1-phase0-measure.mjs`** — measurement runner. Accepts \`--arm=openchrome\` (auto via the public MCP surface) or \`--arm=browsermcp\` (prints reviewer instructions). Captures pass/fail per the operational definition and writes per-target evidence.
- **`docs/experiments/extension-connector-phase0.md`** — memo template with methodology, decision rule, and the comparison-arm instructions. Marked DRAFT until the reviewer runs the measurement.
- **`docs/experiments/B1-phase0-evidence/.gitkeep`** — evidence directory tracker.

## Operational pass/fail (from the issue)

A target is "loaded successfully" iff:
1. Top-level navigation HTTP 200, AND
2. No element matches any challenge-interstitial selector in the post-load DOM (Cloudflare \`#challenge-running\`, PerimeterX \`[id^=\"px-captcha\"]\`, DataDome \`[class*=\"dd-captcha\"]\` etc.), AND
3. \`document.querySelector('h1, h2, [role=heading]')\` exists with \`textContent.length > 0\`.

No human judgement on verdicts.

## Decision rule

If BrowserMCP succeeds on **≥3 of T1/T2/T3** AND OpenChrome fails on those same slots → file Phase 1 follow-up issue with the connector implementation scope. Otherwise → close as no-go and link this memo.

## Scope contract (enforced)

\`git diff --name-only origin/develop...HEAD | grep '^src/'\` returns empty — verified locally.

## Why this is a separate PR (not phase 1)

The hypothesis is unproven and a 3–5 day engineering investment is too expensive before data exists. This PR ships only the measurement substrate so the reviewer can populate the memo and feed the go/no-go decision back into Phase 1's scoping.

## Test plan

- [ ] \`node scripts/experiments/B1-phase0-measure.mjs --arm=openchrome\` runs to completion against C1 (\`https://example.com\`) without errors on a developer Mac with Chrome installed.
- [ ] Memo template renders with placeholder rows; reviewer fills in the rest.
- [ ] No \`src/\` changes (CI-verifiable via the diff grep above).