### PR TITLE
feat(core): oc_devtools_url + DevTools field on oc_get_connection_info (#860)

### DIFF
--- a/src/auth/scope-policy.ts
+++ b/src/auth/scope-policy.ts
@@ -39,6 +39,7 @@ export const READ_TOOLS: ReadonlySet<ToolId> = new Set<ToolId>([
   'oc_get_connection_info',
   'oc_connection_health',
   'oc_journal',
+  'oc_devtools_url',
 
   // Diagnostics / metrics
   'performance_metrics',

--- a/src/chrome/devtools-info.ts
+++ b/src/chrome/devtools-info.ts
@@ -4,6 +4,10 @@
  */
 
 import * as http from 'http';
+import { isDomainBlocked } from '../security/domain-guard';
+
+/** Reject Chrome /json/* responses larger than 1 MiB to bound memory use. */
+const MAX_RESPONSE_BYTES = 1_048_576;
 
 export interface ChromePageInfo {
   id: string;
@@ -42,8 +46,18 @@ export async function fetchJsonList(port: number): Promise<ChromePageInfo[] | nu
       },
       (res) => {
         let data = '';
-        res.on('data', (chunk) => (data += chunk));
+        let aborted = false;
+        res.on('data', (chunk) => {
+          if (aborted) return;
+          data += chunk;
+          if (data.length > MAX_RESPONSE_BYTES) {
+            aborted = true;
+            req.destroy();
+            resolve(null);
+          }
+        });
         res.on('end', () => {
+          if (aborted) return;
           try {
             const parsed = JSON.parse(data);
             if (!Array.isArray(parsed)) {
@@ -82,8 +96,18 @@ export async function fetchJsonVersion(port: number): Promise<string | null> {
       },
       (res) => {
         let data = '';
-        res.on('data', (chunk) => (data += chunk));
+        let aborted = false;
+        res.on('data', (chunk) => {
+          if (aborted) return;
+          data += chunk;
+          if (data.length > MAX_RESPONSE_BYTES) {
+            aborted = true;
+            req.destroy();
+            resolve(null);
+          }
+        });
         res.on('end', () => {
+          if (aborted) return;
           try {
             const parsed = JSON.parse(data);
             // e.g. { "webSocketDebuggerUrl": "ws://127.0.0.1:9222/json/version" }
@@ -144,12 +168,17 @@ export async function getDevToolsInstanceInfo(port: number): Promise<DevToolsIns
   return {
     instancePort: port,
     browserInspectorUrl,
-    pages: pages.map((p) => ({
-      targetId: p.id,
-      instancePort: port,
-      url: p.url,
-      title: p.title,
-      devtoolsFrontendUrl: p.devtoolsFrontendUrl,
-    })),
+    // Block exposure of pages hosted on blocked domains. A leaked
+    // devtoolsFrontendUrl would grant full CDP control over the page, bypassing
+    // the domain guard that assertDomainAllowed() enforces on navigate.
+    pages: pages
+      .filter((p) => !isDomainBlocked(p.url))
+      .map((p) => ({
+        targetId: p.id,
+        instancePort: port,
+        url: p.url,
+        title: p.title,
+        devtoolsFrontendUrl: p.devtoolsFrontendUrl,
+      })),
   };
 }

--- a/src/chrome/devtools-info.ts
+++ b/src/chrome/devtools-info.ts
@@ -1,0 +1,155 @@
+/**
+ * DevTools info fetcher — queries Chrome's /json/list and /json/version endpoints.
+ * Uses the same http.request pattern as src/chrome/pool.ts#checkDebugPort.
+ */
+
+import * as http from 'http';
+
+export interface ChromePageInfo {
+  id: string;
+  url: string;
+  title: string;
+  devtoolsFrontendUrl: string;
+  webSocketDebuggerUrl: string;
+  type: string;
+}
+
+export interface DevToolsInstanceInfo {
+  instancePort: number;
+  browserInspectorUrl: string;
+  pages: Array<{
+    targetId: string;
+    instancePort: number;
+    url: string;
+    title: string;
+    devtoolsFrontendUrl: string;
+  }>;
+}
+
+/**
+ * Fetch /json/list from a Chrome debug port.
+ * Returns null when the port is unreachable or returns malformed JSON.
+ */
+export async function fetchJsonList(port: number): Promise<ChromePageInfo[] | null> {
+  return new Promise((resolve) => {
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: '/json/list',
+        method: 'GET',
+        timeout: 2000,
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk) => (data += chunk));
+        res.on('end', () => {
+          try {
+            const parsed = JSON.parse(data);
+            if (!Array.isArray(parsed)) {
+              resolve(null);
+              return;
+            }
+            resolve(parsed as ChromePageInfo[]);
+          } catch {
+            resolve(null);
+          }
+        });
+      }
+    );
+    req.on('error', () => resolve(null));
+    req.on('timeout', () => {
+      req.destroy();
+      resolve(null);
+    });
+    req.end();
+  });
+}
+
+/**
+ * Fetch /json/version to get the browser-level WebSocket URL.
+ * Returns null on failure.
+ */
+export async function fetchJsonVersion(port: number): Promise<string | null> {
+  return new Promise((resolve) => {
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: '/json/version',
+        method: 'GET',
+        timeout: 2000,
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk) => (data += chunk));
+        res.on('end', () => {
+          try {
+            const parsed = JSON.parse(data);
+            // e.g. { "webSocketDebuggerUrl": "ws://127.0.0.1:9222/json/version" }
+            resolve(typeof parsed?.webSocketDebuggerUrl === 'string' ? parsed.webSocketDebuggerUrl : null);
+          } catch {
+            resolve(null);
+          }
+        });
+      }
+    );
+    req.on('error', () => resolve(null));
+    req.on('timeout', () => {
+      req.destroy();
+      resolve(null);
+    });
+    req.end();
+  });
+}
+
+/**
+ * Build a browser inspector URL from a Chrome debug port.
+ * Chrome's /json/version returns `webSocketDebuggerUrl` like:
+ *   ws://127.0.0.1:9222/json/version
+ * The HTTP DevTools inspector equivalent is:
+ *   http://127.0.0.1:9222/devtools/browser/<id>
+ *
+ * Falls back to constructing a deterministic URL from /json/version data.
+ * Returns a placeholder string on failure (so callers can still build partial info).
+ */
+export async function getBrowserInspectorUrl(port: number): Promise<string> {
+  const wsUrl = await fetchJsonVersion(port);
+  if (wsUrl) {
+    // ws://127.0.0.1:9222/json/version  ->  http://127.0.0.1:9222/devtools/browser/<uuid>
+    // Some Chrome builds give: ws://127.0.0.1:9222/devtools/browser/<uuid>
+    const devtoolsBrowserMatch = wsUrl.match(/devtools\/browser\/([0-9a-f-]+)/i);
+    if (devtoolsBrowserMatch) {
+      return `http://127.0.0.1:${port}/devtools/browser/${devtoolsBrowserMatch[1]}`;
+    }
+  }
+  // Fallback: canonical-form URL; still useful as a human-readable hint
+  return `http://127.0.0.1:${port}/devtools/browser/`;
+}
+
+/**
+ * Query a single Chrome instance and return its DevToolsInstanceInfo.
+ * Returns null if the instance is unreachable.
+ */
+export async function getDevToolsInstanceInfo(port: number): Promise<DevToolsInstanceInfo | null> {
+  const [pages, browserInspectorUrl] = await Promise.all([
+    fetchJsonList(port),
+    getBrowserInspectorUrl(port),
+  ]);
+
+  if (pages === null) {
+    return null;
+  }
+
+  return {
+    instancePort: port,
+    browserInspectorUrl,
+    pages: pages.map((p) => ({
+      targetId: p.id,
+      instancePort: port,
+      url: p.url,
+      title: p.title,
+      devtoolsFrontendUrl: p.devtoolsFrontendUrl,
+    })),
+  };
+}

--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -80,6 +80,7 @@ export const TOOL_TIERS: Record<string, ToolTier> = {
   oc_connection_health: 1,  // src/tools/connection-health.ts
   oc_checkpoint: 1,         // src/tools/checkpoint.ts
   list_profiles: 1,         // src/tools/list-profiles.ts
+  oc_devtools_url: 1,       // src/tools/oc-devtools-url.ts (#860) — gated by env
 
   // Tier 3: Orchestration only
   workflow_init: 3,

--- a/src/tools/connect.ts
+++ b/src/tools/connect.ts
@@ -1,6 +1,7 @@
 /**
  * Connect tools — expose web AI host connection info via MCP protocol.
  * Part of #523: Desktop App Web host connection guide.
+ * Part of #860: DevTools URL exposure via devtools field + oc_devtools_url tool.
  */
 
 import { MCPServer } from '../mcp-server';
@@ -9,6 +10,9 @@ import { generateConnectionInfo, generateAllConnectionInfo, getHostIds } from '.
 import { copyToClipboard } from '../connect/clipboard';
 import { openInBrowser } from '../connect/open-url';
 import type { WebAIHostId, ServerConnectionState } from '../connect/types';
+import { getChromePool } from '../chrome/pool';
+import { getDevToolsInstanceInfo } from '../chrome/devtools-info';
+import { getGlobalConfig } from '../config/global';
 
 function getServerState(): ServerConnectionState {
   const httpPort = process.env.OPENCHROME_HTTP_PORT || '3100';
@@ -22,10 +26,48 @@ function getServerState(): ServerConnectionState {
   };
 }
 
+/**
+ * Returns true when DevTools URL exposure is enabled (default: on).
+ * Gated by OPENCHROME_EXPOSE_DEVTOOLS_URL !== '0'.
+ */
+export function isDevToolsExposureEnabled(): boolean {
+  return process.env.OPENCHROME_EXPOSE_DEVTOOLS_URL !== '0';
+}
+
+/**
+ * Collect DevTools instance info from all active Chrome pool instances.
+ * Also queries the default single-instance port when the pool has no entries.
+ * Returns undefined if unreachable or exposure is disabled.
+ */
+export async function collectDevToolsInfo(): Promise<
+  { instances: Awaited<ReturnType<typeof getDevToolsInstanceInfo> & {}>[] } | undefined
+> {
+  if (!isDevToolsExposureEnabled()) {
+    return undefined;
+  }
+
+  // Collect ports: prefer pool instances; fall back to default port
+  const pool = getChromePool();
+  const poolInstances = pool.getInstances();
+  const ports: number[] =
+    poolInstances.size > 0
+      ? Array.from(poolInstances.values()).map((inst) => inst.port)
+      : [getGlobalConfig().port];
+
+  const results = await Promise.all(ports.map((p) => getDevToolsInstanceInfo(p)));
+  const reachable = results.filter((r) => r !== null) as NonNullable<typeof results[number]>[];
+
+  if (reachable.length === 0) {
+    return undefined;
+  }
+
+  return { instances: reachable };
+}
+
 const getConnectionInfoDef: MCPToolDefinition = {
   name: 'oc_get_connection_info',
   description:
-    'Get connection configuration for a web AI host (Claude Web, ChatGPT, Gemini, or custom). Returns the MCP server URL, bearer token, settings page URL, and step-by-step instructions.',
+    'Get connection configuration for a web AI host (Claude Web, ChatGPT, Gemini, or custom). Returns the MCP server URL, bearer token, settings page URL, step-by-step instructions, and (when Chrome is reachable) a devtools block with live DevTools inspector URLs for all open pages.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -46,9 +88,16 @@ const getConnectionInfoHandler: ToolHandler = async (
   const hostArg = args.host as string;
   const state = getServerState();
 
+  // Fetch devtools info in parallel with host-info generation
+  const devToolsPromise = collectDevToolsInfo();
+
   if (hostArg === 'all') {
-    const all = generateAllConnectionInfo(state);
-    return { content: [{ type: 'text', text: JSON.stringify(all, null, 2) }] };
+    const [all, devtools] = await Promise.all([
+      Promise.resolve(generateAllConnectionInfo(state)),
+      devToolsPromise,
+    ]);
+    const response = devtools ? { ...all, devtools } : all;
+    return { content: [{ type: 'text', text: JSON.stringify(response, null, 2) }] };
   }
 
   const validHosts = getHostIds();
@@ -59,8 +108,12 @@ const getConnectionInfoHandler: ToolHandler = async (
     };
   }
 
-  const info = generateConnectionInfo(hostArg as WebAIHostId, state);
-  return { content: [{ type: 'text', text: JSON.stringify(info, null, 2) }] };
+  const [info, devtools] = await Promise.all([
+    Promise.resolve(generateConnectionInfo(hostArg as WebAIHostId, state)),
+    devToolsPromise,
+  ]);
+  const response = devtools ? { ...info, devtools } : info;
+  return { content: [{ type: 'text', text: JSON.stringify(response, null, 2) }] };
 };
 
 const copyToClipboardDef: MCPToolDefinition = {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -107,6 +107,9 @@ import { registerOcEvidenceBundleTool } from './oc-evidence-bundle';
 import { registerOcSkillRecordTool } from './oc-skill-record';
 import { registerOcSkillRecallTool } from './oc-skill-recall';
 
+// DevTools URL tool (#860) — expose Chrome DevTools inspector URLs
+import { registerOcDevToolsUrlTool } from './oc-devtools-url';
+
 export function registerAllTools(server: MCPServer): void {
   // Core browser tools
   registerNavigateTool(server);
@@ -217,6 +220,9 @@ export function registerAllTools(server: MCPServer): void {
   // Skill memory tools (#785) — record + recall
   registerOcSkillRecordTool(server);
   registerOcSkillRecallTool(server);
+
+  // DevTools URL tool (#860) — gated by OPENCHROME_EXPOSE_DEVTOOLS_URL !== '0'
+  registerOcDevToolsUrlTool(server);
 
   console.error(`[Tools] Registered ${server.getToolNames().length} tools`);
 }

--- a/src/tools/oc-devtools-url.ts
+++ b/src/tools/oc-devtools-url.ts
@@ -166,10 +166,12 @@ const handler: ToolHandler = async (
 
   // Resolve the Chrome instance port for this target
   const portResult = await resolvePortForTarget(resolvedTargetId);
+  // Sanitize user-controlled targetId before reflecting in error messages.
+  const safeId = String(resolvedTargetId).slice(0, 128).replace(/[^\w-]/g, '_');
   if ('error' in portResult) {
     const message = portResult.error === 'chrome_unreachable'
-      ? `Chrome is unreachable — could not query any debug port for target '${resolvedTargetId}'.`
-      : `Target '${resolvedTargetId}' not found in any reachable Chrome instance.`;
+      ? `Chrome is unreachable — could not query any debug port for target '${safeId}'.`
+      : `Target '${safeId}' not found in any reachable Chrome instance.`;
     return {
       content: [{ type: 'text', text: JSON.stringify({ error: portResult.error, message }) }],
     };
@@ -183,7 +185,7 @@ const handler: ToolHandler = async (
           type: 'text',
           text: JSON.stringify({
             error: 'not_found',
-            message: `Target '${resolvedTargetId}' not found in Chrome's /json/list on port ${portResult.port}.`,
+            message: `Target '${safeId}' not found in Chrome's /json/list on port ${portResult.port}.`,
           }),
         },
       ],

--- a/src/tools/oc-devtools-url.ts
+++ b/src/tools/oc-devtools-url.ts
@@ -1,0 +1,210 @@
+/**
+ * oc_devtools_url — return the Chrome DevTools inspector URL for a target.
+ * Part of #860: DevTools URL exposure.
+ *
+ * Target resolution order:
+ *   1. targetId provided → look up directly; not_found if missing.
+ *   2. workerId provided → use that worker's current (last) target.
+ *   3. default → default session's default worker's current target.
+ *   4. No current target → not_found.
+ *
+ * Off-switch: when OPENCHROME_EXPOSE_DEVTOOLS_URL=0, always returns {error:'disabled'}.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import { getSessionManager } from '../session-manager';
+import { getChromePool } from '../chrome/pool';
+import { fetchJsonList } from '../chrome/devtools-info';
+import { getGlobalConfig } from '../config/global';
+
+function isDevToolsExposureEnabled(): boolean {
+  return process.env.OPENCHROME_EXPOSE_DEVTOOLS_URL !== '0';
+}
+
+const definition: MCPToolDefinition = {
+  name: 'oc_devtools_url',
+  description:
+    'Get the Chrome DevTools inspector URL for the current worker\'s active page. ' +
+    'Returns a URL you can paste into any local browser to attach live DevTools to the running page. ' +
+    'Use targetId to select a specific open tab, or workerId to select a specific worker\'s current page.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      targetId: {
+        type: 'string',
+        description: 'Optional CDP target ID. When provided, returns the DevTools URL for that specific tab.',
+      },
+      workerId: {
+        type: 'string',
+        description: 'Optional worker ID. When provided (and targetId is omitted), returns the DevTools URL for that worker\'s current page.',
+      },
+    },
+    required: [],
+  },
+};
+
+type ResolvePortResult =
+  | { port: number }
+  | { error: 'not_found' }
+  | { error: 'chrome_unreachable' };
+
+/**
+ * Resolve the Chrome port for a given CDP targetId.
+ * Walks pool instances: for each, fetch /json/list and check if the target appears there.
+ * Falls back to the default port when pool is empty.
+ *
+ * Returns:
+ *   { port }               — target found on this port
+ *   { error: 'not_found' } — Chrome responded but target is not in any instance
+ *   { error: 'chrome_unreachable' } — all ports failed to respond
+ */
+async function resolvePortForTarget(targetId: string): Promise<ResolvePortResult> {
+  const pool = getChromePool();
+  const poolInstances = pool.getInstances();
+  const ports: number[] =
+    poolInstances.size > 0
+      ? Array.from(poolInstances.values()).map((inst) => inst.port)
+      : [getGlobalConfig().port];
+
+  let anyReachable = false;
+  for (const port of ports) {
+    const pages = await fetchJsonList(port);
+    if (pages === null) continue; // this port is unreachable
+    anyReachable = true;
+    if (pages.some((p) => p.id === targetId)) {
+      return { port };
+    }
+  }
+  return anyReachable ? { error: 'not_found' } : { error: 'chrome_unreachable' };
+}
+
+/**
+ * Fetch the devtoolsFrontendUrl for a specific targetId from Chrome's /json/list.
+ */
+async function getDevToolsFrontendUrl(
+  targetId: string,
+  port: number,
+): Promise<string | null> {
+  const pages = await fetchJsonList(port);
+  if (!pages) return null;
+  const page = pages.find((p) => p.id === targetId);
+  return page?.devtoolsFrontendUrl ?? null;
+}
+
+const handler: ToolHandler = async (
+  sessionId: string,
+  args: Record<string, unknown>,
+): Promise<MCPResult> => {
+  // Off-switch
+  if (!isDevToolsExposureEnabled()) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({ error: 'disabled', message: 'DevTools URL exposure is disabled (OPENCHROME_EXPOSE_DEVTOOLS_URL=0).' }),
+        },
+      ],
+    };
+  }
+
+  const targetIdArg = args.targetId as string | undefined;
+  const workerIdArg = args.workerId as string | undefined;
+
+  const sessionManager = getSessionManager();
+
+  let resolvedTargetId: string | undefined;
+
+  if (targetIdArg) {
+    // Path 1: explicit targetId
+    resolvedTargetId = targetIdArg;
+  } else {
+    // Path 2 or 3: resolve via worker
+    const effectiveSessionId = sessionId || 'default';
+    const session = sessionManager.getSession(effectiveSessionId);
+
+    if (!session) {
+      // Try to find any session that has the requested worker
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ error: 'not_found', message: `Session '${effectiveSessionId}' not found.` }),
+          },
+        ],
+      };
+    }
+
+    const workerId = workerIdArg || session.defaultWorkerId;
+    const worker = sessionManager.getWorker(effectiveSessionId, workerId);
+
+    if (!worker) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ error: 'not_found', message: `Worker '${workerId}' not found in session '${effectiveSessionId}'.` }),
+          },
+        ],
+      };
+    }
+
+    // Use the last (most recently added) target in this worker
+    const targets = Array.from(worker.targets);
+    if (targets.length === 0) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ error: 'not_found', message: `Worker '${workerId}' has no active targets.` }),
+          },
+        ],
+      };
+    }
+    resolvedTargetId = targets[targets.length - 1];
+  }
+
+  // Resolve the Chrome instance port for this target
+  const portResult = await resolvePortForTarget(resolvedTargetId);
+  if ('error' in portResult) {
+    const message = portResult.error === 'chrome_unreachable'
+      ? `Chrome is unreachable — could not query any debug port for target '${resolvedTargetId}'.`
+      : `Target '${resolvedTargetId}' not found in any reachable Chrome instance.`;
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ error: portResult.error, message }) }],
+    };
+  }
+
+  const url = await getDevToolsFrontendUrl(resolvedTargetId, portResult.port);
+  if (!url) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            error: 'not_found',
+            message: `Target '${resolvedTargetId}' not found in Chrome's /json/list on port ${portResult.port}.`,
+          }),
+        },
+      ],
+    };
+  }
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({ targetId: resolvedTargetId, url }),
+      },
+    ],
+  };
+};
+
+export function registerOcDevToolsUrlTool(server: MCPServer): void {
+  if (!isDevToolsExposureEnabled()) {
+    // When off-switch is active, do NOT register the tool so tools/list SHA
+    // matches the v1.11 baseline.
+    return;
+  }
+  server.registerTool('oc_devtools_url', handler, definition);
+}

--- a/tests/tools/oc-devtools-url.test.ts
+++ b/tests/tools/oc-devtools-url.test.ts
@@ -1,0 +1,223 @@
+/// <reference types="jest" />
+/**
+ * Tests for oc_devtools_url tool (#860)
+ */
+
+import { createMockSessionManager } from '../utils/mock-session';
+
+// Mock getChromePool
+const mockGetInstances = jest.fn();
+jest.mock('../../src/chrome/pool', () => ({
+  getChromePool: jest.fn(() => ({ getInstances: mockGetInstances })),
+}));
+
+// Mock fetchJsonList
+const mockFetchJsonList = jest.fn();
+jest.mock('../../src/chrome/devtools-info', () => ({
+  fetchJsonList: mockFetchJsonList,
+}));
+
+// Mock getGlobalConfig
+jest.mock('../../src/config/global', () => ({
+  getGlobalConfig: jest.fn(() => ({ port: 9222 })),
+}));
+
+// Mock session manager
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(),
+}));
+
+import { getSessionManager } from '../../src/session-manager';
+import { MCPServer } from '../../src/mcp-server';
+import { registerOcDevToolsUrlTool } from '../../src/tools/oc-devtools-url';
+
+const FIXTURE_PAGES = [
+  {
+    id: 'target-abc',
+    url: 'https://example.com',
+    title: 'Example Domain',
+    devtoolsFrontendUrl: 'http://127.0.0.1:9222/devtools/inspector.html?ws=127.0.0.1:9222/devtools/page/target-abc',
+    webSocketDebuggerUrl: 'ws://127.0.0.1:9222/devtools/page/target-abc',
+    type: 'page',
+  },
+  {
+    id: 'target-wiki',
+    url: 'https://en.wikipedia.org/wiki/Main_Page',
+    title: 'Wikipedia',
+    devtoolsFrontendUrl: 'http://127.0.0.1:9222/devtools/inspector.html?ws=127.0.0.1:9222/devtools/page/target-wiki',
+    webSocketDebuggerUrl: 'ws://127.0.0.1:9222/devtools/page/target-wiki',
+    type: 'page',
+  },
+];
+
+function makeServer(sessionManager: any): { server: MCPServer; handler: Function } {
+  const server = new MCPServer(sessionManager as any);
+  registerOcDevToolsUrlTool(server);
+  const handler = server.getToolHandler('oc_devtools_url')!;
+  return { server, handler };
+}
+
+describe('oc_devtools_url tool', () => {
+  let mockSessionManager: ReturnType<typeof createMockSessionManager>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.OPENCHROME_EXPOSE_DEVTOOLS_URL;
+
+    mockGetInstances.mockReturnValue(new Map()); // empty pool → fall back to default port
+    mockFetchJsonList.mockResolvedValue(FIXTURE_PAGES);
+
+    mockSessionManager = createMockSessionManager();
+    (getSessionManager as jest.Mock).mockReturnValue(mockSessionManager);
+  });
+
+  afterEach(() => {
+    delete process.env.OPENCHROME_EXPOSE_DEVTOOLS_URL;
+  });
+
+  // --- registration ---
+
+  test('tool is registered when enabled (default)', () => {
+    const { server } = makeServer(mockSessionManager);
+    expect(server.getToolNames()).toContain('oc_devtools_url');
+  });
+
+  test('tool is NOT registered when OPENCHROME_EXPOSE_DEVTOOLS_URL=0', () => {
+    process.env.OPENCHROME_EXPOSE_DEVTOOLS_URL = '0';
+    const { server } = makeServer(mockSessionManager);
+    expect(server.getToolNames()).not.toContain('oc_devtools_url');
+  });
+
+  // --- off-switch: handler returns disabled when called directly ---
+
+  test('handler returns {error: disabled} when env set to 0 after registration', async () => {
+    // Register while enabled, then flip env — handler must honour runtime check
+    const { handler } = makeServer(mockSessionManager);
+    process.env.OPENCHROME_EXPOSE_DEVTOOLS_URL = '0';
+    const result = await handler('default', {});
+    const data = JSON.parse(result.content[0].text);
+    expect(data.error).toBe('disabled');
+  });
+
+  // --- explicit targetId ---
+
+  test('returns url for explicit targetId found in /json/list', async () => {
+    const { handler } = makeServer(mockSessionManager);
+    const result = await handler('default', { targetId: 'target-abc' });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.targetId).toBe('target-abc');
+    expect(data.url).toBe(FIXTURE_PAGES[0].devtoolsFrontendUrl);
+  });
+
+  test('returns {error: not_found} for unknown targetId (Chrome reachable, target absent)', async () => {
+    const { handler } = makeServer(mockSessionManager);
+    mockFetchJsonList.mockResolvedValue([]); // Chrome responds but target not present
+    const result = await handler('default', { targetId: 'does-not-exist' });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.error).toBe('not_found');
+    expect(data.message).toBeDefined();
+  });
+
+  test('returns {error: chrome_unreachable} when /json/list returns null', async () => {
+    const { handler } = makeServer(mockSessionManager);
+    mockFetchJsonList.mockResolvedValue(null);
+    const result = await handler('default', { targetId: 'target-abc' });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.error).toBe('chrome_unreachable');
+  });
+
+  // --- no URL rewriting ---
+
+  test('devtoolsFrontendUrl is character-for-character identical to fixture value', async () => {
+    const { handler } = makeServer(mockSessionManager);
+    const result = await handler('default', { targetId: 'target-wiki' });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.url).toBe(FIXTURE_PAGES[1].devtoolsFrontendUrl);
+  });
+
+  // --- worker-based resolution ---
+
+  test('returns url for default worker current target when no args given', async () => {
+    await mockSessionManager.createSession({ id: 'default' });
+    const session = mockSessionManager.getSession('default')!;
+    const worker = session.workers.get('default')!;
+    worker.targets.add('target-abc');
+
+    const { handler } = makeServer(mockSessionManager);
+    const result = await handler('default', {});
+    const data = JSON.parse(result.content[0].text);
+    expect(data.targetId).toBe('target-abc');
+    expect(data.url).toBeDefined();
+    expect(data.url).toContain('devtools');
+  });
+
+  test('returns url for explicit workerId current target', async () => {
+    await mockSessionManager.createSession({ id: 'default' });
+    await mockSessionManager.createWorker('default', { id: 'worker-2' });
+    const session = mockSessionManager.getSession('default')!;
+    session.workers.get('worker-2')!.targets.add('target-wiki');
+
+    const { handler } = makeServer(mockSessionManager);
+    const result = await handler('default', { workerId: 'worker-2' });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.targetId).toBe('target-wiki');
+    expect(data.url).toBe(FIXTURE_PAGES[1].devtoolsFrontendUrl);
+  });
+
+  test('returns {error: not_found} when worker has no targets', async () => {
+    await mockSessionManager.createSession({ id: 'default' });
+    // default worker has no targets
+
+    const { handler } = makeServer(mockSessionManager);
+    const result = await handler('default', {});
+    const data = JSON.parse(result.content[0].text);
+    expect(data.error).toBe('not_found');
+  });
+
+  test('returns {error: not_found} for unknown workerId', async () => {
+    await mockSessionManager.createSession({ id: 'default' });
+
+    const { handler } = makeServer(mockSessionManager);
+    const result = await handler('default', { workerId: 'nonexistent-worker' });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.error).toBe('not_found');
+  });
+
+  // --- multi-instance pool ---
+
+  test('walks pool instances to find target port', async () => {
+    mockGetInstances.mockReturnValue(
+      new Map([
+        [9222, { port: 9222 }],
+        [9223, { port: 9223 }],
+      ])
+    );
+    // 9222 returns empty, 9223 has the target; second call for getDevToolsFrontendUrl also from 9223
+    mockFetchJsonList
+      .mockResolvedValueOnce([])           // resolvePortForTarget → port 9222, no match
+      .mockResolvedValueOnce(FIXTURE_PAGES) // resolvePortForTarget → port 9223, match
+      .mockResolvedValueOnce(FIXTURE_PAGES); // getDevToolsFrontendUrl → port 9223
+
+    const { handler } = makeServer(mockSessionManager);
+    const result = await handler('default', { targetId: 'target-abc' });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.targetId).toBe('target-abc');
+    expect(data.url).toBeDefined();
+  });
+
+  // --- edge cases ---
+
+  test('returns {error: chrome_unreachable} when /json/list returns malformed data (null)', async () => {
+    const { handler } = makeServer(mockSessionManager);
+    mockFetchJsonList.mockResolvedValue(null);
+    const result = await handler('default', { targetId: 'target-abc' });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.error).toBe('chrome_unreachable');
+  });
+
+  test('output is valid JSON', async () => {
+    const { handler } = makeServer(mockSessionManager);
+    const result = await handler('default', { targetId: 'target-abc' });
+    expect(() => JSON.parse(result.content[0].text)).not.toThrow();
+  });
+});

--- a/tests/tools/oc-get-connection-info-devtools-field.test.ts
+++ b/tests/tools/oc-get-connection-info-devtools-field.test.ts
@@ -1,0 +1,175 @@
+/// <reference types="jest" />
+/**
+ * Tests for devtools field on oc_get_connection_info (#860)
+ */
+
+import { createMockSessionManager } from '../utils/mock-session';
+
+// Mock getChromePool
+const mockGetInstances = jest.fn();
+jest.mock('../../src/chrome/pool', () => ({
+  getChromePool: jest.fn(() => ({ getInstances: mockGetInstances })),
+  resetChromePool: jest.fn(),
+}));
+
+// Mock devtools-info helpers
+const mockGetDevToolsInstanceInfo = jest.fn();
+jest.mock('../../src/chrome/devtools-info', () => ({
+  getDevToolsInstanceInfo: mockGetDevToolsInstanceInfo,
+  fetchJsonList: jest.fn(),
+}));
+
+// Mock getGlobalConfig
+jest.mock('../../src/config/global', () => ({
+  getGlobalConfig: jest.fn(() => ({ port: 9222 })),
+}));
+
+// Mock session manager
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(),
+}));
+
+// Mock connect helpers (generateConnectionInfo etc.)
+jest.mock('../../src/connect/index', () => ({
+  generateConnectionInfo: jest.fn(() => ({
+    hostName: 'Claude Web',
+    mcpUrl: 'http://127.0.0.1:3100/mcp',
+    bearerToken: null,
+    settingsUrl: 'https://claude.ai/settings/integrations',
+    instructions: [],
+  })),
+  generateAllConnectionInfo: jest.fn(() => ({})),
+  getHostIds: jest.fn(() => ['claude', 'chatgpt', 'gemini', 'custom']),
+}));
+
+jest.mock('../../src/connect/clipboard', () => ({ copyToClipboard: jest.fn() }));
+jest.mock('../../src/connect/open-url', () => ({ openInBrowser: jest.fn() }));
+
+import { getSessionManager } from '../../src/session-manager';
+import { MCPServer } from '../../src/mcp-server';
+import { registerConnectTools } from '../../src/tools/connect';
+
+const FIXTURE_INSTANCE = {
+  instancePort: 9222,
+  browserInspectorUrl: 'http://127.0.0.1:9222/devtools/browser/abc123',
+  pages: [
+    {
+      targetId: 'target-abc',
+      instancePort: 9222,
+      url: 'https://example.com',
+      title: 'Example Domain',
+      devtoolsFrontendUrl:
+        'http://127.0.0.1:9222/devtools/inspector.html?ws=127.0.0.1:9222/devtools/page/target-abc',
+    },
+  ],
+};
+
+describe('oc_get_connection_info devtools field (#860)', () => {
+  let server: MCPServer;
+  let handler: (sessionId: string, args: Record<string, unknown>) => Promise<any>;
+  let mockSessionManager: ReturnType<typeof createMockSessionManager>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGetInstances.mockReturnValue(new Map()); // empty pool → default port
+    mockGetDevToolsInstanceInfo.mockResolvedValue(FIXTURE_INSTANCE);
+
+    delete process.env.OPENCHROME_EXPOSE_DEVTOOLS_URL;
+
+    mockSessionManager = createMockSessionManager();
+    (getSessionManager as jest.Mock).mockReturnValue(mockSessionManager);
+
+    server = new MCPServer(mockSessionManager as any);
+    registerConnectTools(server);
+    handler = server.getToolHandler('oc_get_connection_info')!;
+  });
+
+  afterEach(() => {
+    delete process.env.OPENCHROME_EXPOSE_DEVTOOLS_URL;
+  });
+
+  test('tool is registered', () => {
+    expect(server.getToolNames()).toContain('oc_get_connection_info');
+  });
+
+  test('response includes devtools block when Chrome is reachable', async () => {
+    const result = await handler('default', { host: 'claude' });
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text);
+    expect(data.devtools).toBeDefined();
+    expect(data.devtools.instances).toHaveLength(1);
+    expect(data.devtools.instances[0].instancePort).toBe(9222);
+    expect(data.devtools.instances[0].browserInspectorUrl).toBe(
+      'http://127.0.0.1:9222/devtools/browser/abc123'
+    );
+    expect(data.devtools.instances[0].pages[0].targetId).toBe('target-abc');
+  });
+
+  test('devtoolsFrontendUrl is character-for-character identical to fixture', async () => {
+    const result = await handler('default', { host: 'claude' });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.devtools.instances[0].pages[0].devtoolsFrontendUrl).toBe(
+      FIXTURE_INSTANCE.pages[0].devtoolsFrontendUrl
+    );
+  });
+
+  test('devtools field is omitted (not error) when Chrome is unreachable', async () => {
+    mockGetDevToolsInstanceInfo.mockResolvedValue(null);
+
+    const result = await handler('default', { host: 'claude' });
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text);
+    expect(data.devtools).toBeUndefined();
+    expect(data.hostName).toBeDefined();
+  });
+
+  test('devtools field is omitted when OPENCHROME_EXPOSE_DEVTOOLS_URL=0', async () => {
+    process.env.OPENCHROME_EXPOSE_DEVTOOLS_URL = '0';
+
+    const result = await handler('default', { host: 'claude' });
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text);
+    expect(data.devtools).toBeUndefined();
+  });
+
+  test('host=all response also includes devtools block', async () => {
+    const result = await handler('default', { host: 'all' });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.devtools).toBeDefined();
+    expect(data.devtools.instances).toHaveLength(1);
+  });
+
+  test('multi-instance pool: one entry per reachable instance', async () => {
+    const instance2 = {
+      ...FIXTURE_INSTANCE,
+      instancePort: 9223,
+      browserInspectorUrl: 'http://127.0.0.1:9223/devtools/browser/def456',
+    };
+    mockGetInstances.mockReturnValue(
+      new Map([
+        [9222, { port: 9222 }],
+        [9223, { port: 9223 }],
+      ])
+    );
+    mockGetDevToolsInstanceInfo
+      .mockResolvedValueOnce(FIXTURE_INSTANCE)
+      .mockResolvedValueOnce(instance2);
+
+    const result = await handler('default', { host: 'claude' });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.devtools.instances).toHaveLength(2);
+    expect(data.devtools.instances[0].instancePort).toBe(9222);
+    expect(data.devtools.instances[1].instancePort).toBe(9223);
+  });
+
+  test('returns isError for invalid host', async () => {
+    const result = await handler('default', { host: 'invalid-host' });
+    expect(result.isError).toBe(true);
+  });
+
+  test('output is valid JSON', async () => {
+    const result = await handler('default', { host: 'claude' });
+    expect(() => JSON.parse(result.content[0].text)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- **New helper** `src/chrome/devtools-info.ts`: `fetchJsonList` / `fetchJsonVersion` / `getDevToolsInstanceInfo` — queries Chrome's `/json/list` HTTP endpoint using the same `http.request` pattern as `pool.ts`.
- **New tool** `oc_devtools_url({targetId?, workerId?})`: resolves target → Chrome port → `devtoolsFrontendUrl` with closed-enum error shape (`disabled | not_found | chrome_unreachable`). No URL rewriting — verbatim from Chrome. Registration gated on `OPENCHROME_EXPOSE_DEVTOOLS_URL !== '0'` so `tools/list` SHA matches v1.11 baseline when off.
- **Extended** `oc_get_connection_info`: response gains optional `devtools.instances[]` block (queried from all pool ports in parallel); field omitted (not error) when Chrome unreachable; also gated by off-switch.
- **Registered** in `tools/index.ts`, declared tier-1 in `tool-tiers.ts`, added to `READ_TOOLS` in `scope-policy.ts`.

## Test plan

- [x] `npm run build` — clean (tsc exit 0)
- [x] 23 unit tests pass across two new test files:
  - `tests/tools/oc-devtools-url.test.ts` — registration gate, off-switch, explicit targetId, worker-based resolution, multi-instance pool routing, all error shapes, no-URL-rewriting assertion
  - `tests/tools/oc-get-connection-info-devtools-field.test.ts` — devtools block present/absent, off-switch, multi-instance pool, character-for-character URL identity
- [ ] Real verification (post-merge): run `scripts/verify/A3-devtools-url.mjs` per issue steps 1–10 (navigate → oc_get_connection_info devtools block → oc_devtools_url → paste URL in browser → per-tab routing → worker isolation → unknown target → off-switch → auth surface)

## Deferred / out of scope

- `scripts/verify/A3-devtools-url.mjs` reproducer script (referenced in issue, not required for merge)
- Auth surface integration test (issue step 10 — requires live HTTP transport; covered by existing auth middleware tests)

Closes #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)