### PR TITLE
docs(recipes): three runnable research recipes under docs/recipes/ (#858)

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,12 @@ OpenChrome supports per-tenant API keys, JWT/OAuth, a legacy shared token, and a
 
 ---
 
+## Research recipes
+
+Composable multi-source research workflows over the MCP surface — host-LLM driven, no server-side model calls. See **[docs/recipes/](docs/recipes/README.md)** for runnable patterns (news digest, docs changelog diff, competitive feature matrix).
+
+---
+
 ## Under the Hood: 8-Layer Reliability
 
 OpenChrome has **49 distinct reliability mechanisms** across 8 defense layers — ensuring no single failure can hang the MCP server.

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -1,0 +1,32 @@
+# Research recipes
+
+Composable recipes for multi-source research workflows over the openchrome
+MCP surface. Each recipe lists the exact MCP tool calls a host LLM should
+make and where its own synthesis happens. openchrome never calls an LLM
+itself (P3): the server emits structured browser observations; the host
+model composes them into prose.
+
+| Recipe | Goal | Tools touched |
+|---|---|---|
+| [multi-source-news-digest.md](multi-source-news-digest.md) | Pull headlines from several news sources and produce a one-screen daily digest. | `navigate`, `read_page`, `crawl` |
+| [docs-changelog-diff.md](docs-changelog-diff.md) | Compare two snapshots of a docs page (e.g. before/after a release) and explain what changed. | `navigate`, `read_page` |
+| [competitive-feature-matrix.md](competitive-feature-matrix.md) | Build a structured feature-matrix table across several vendor pages. | `navigate`, `extract_data`, `read_page` |
+
+## How recipes are structured
+
+Every recipe follows the same shape so they stay copy-paste-runnable:
+
+1. **Goal** — one paragraph stating the research question.
+2. **Inputs** — what the host LLM needs from the user (URLs, schema, etc.).
+3. **Plan** — numbered list of MCP tool calls with input shapes and expected output shapes.
+4. **Synthesis** — what the host LLM does with the observations (no server-side LLM).
+5. **Verification** — a step the operator can run by hand to confirm the recipe still works against the current site.
+
+## Why this is docs and not a tool
+
+A dedicated `oc_research_plan` tool was considered (see issue #858) and
+rejected: a competent host LLM produces the same plan ad-hoc from the
+existing tool descriptions, and `src/orchestration/plan-registry.ts`
+already covers the deterministic-template case. Documenting the recipes
+keeps the value (concrete, runnable patterns) without adding surface area
+to the server.

--- a/docs/recipes/competitive-feature-matrix.md
+++ b/docs/recipes/competitive-feature-matrix.md
@@ -1,0 +1,76 @@
+# Recipe: competitive feature matrix
+
+## Goal
+
+Build a structured table where rows are vendors and columns are
+features, then hand it to the host LLM for prose commentary. The
+extraction is deterministic and server-side; the prose is host-side.
+
+## Inputs
+
+- `vendors: { name: string; url: string }[]` — typically 3 to 8.
+- `feature_schema: { feature: string; selector_hint?: string }[]` — the
+  columns you want filled. `selector_hint` is optional natural-language
+  guidance for `extract_data`.
+
+## Plan
+
+For each `vendor` in `vendors`:
+
+1. `mcp__openchrome__navigate` `{ url: vendor.url }`.
+2. `mcp__openchrome__extract_data` `{ instruction, schema }` where:
+   - `instruction` describes what to find. Example: "Extract whether
+     this vendor's pricing page advertises a free tier, SSO support,
+     and per-seat vs per-usage billing."
+   - `schema` is a JSON schema matching `feature_schema`. Example:
+     ```json
+     {
+       "type": "object",
+       "properties": {
+         "free_tier": { "type": "boolean" },
+         "sso_support": { "type": "boolean" },
+         "billing_model": { "type": "string", "enum": ["per-seat", "per-usage", "hybrid", "unknown"] }
+       },
+       "required": ["free_tier", "sso_support", "billing_model"]
+     }
+     ```
+   - Returns: `{ extracted: <object matching schema>, source_url }`.
+3. **Optional** — when `extract_data` returns a low-confidence value
+   (e.g. `billing_model: "unknown"`), fall back to
+   `mcp__openchrome__read_page` `{ mode: "markdown", max_chars: 6000 }`
+   and let the host LLM read the raw prose.
+
+## Synthesis (host LLM)
+
+The host receives an array of `{ vendor, extracted }` records. It
+assembles the matrix locally (a literal table — no server help needed)
+and writes commentary on patterns: which features are table stakes,
+which are differentiators, which are outliers.
+
+No server-side LLM. The structured extraction comes from
+`extract_data`, which is deterministic given the same schema and page.
+
+## Verification
+
+Use three stable vendor pages where the matrix answer is
+well-known:
+
+1. `mcp__openchrome__navigate` to `https://www.anthropic.com/pricing`.
+2. `mcp__openchrome__extract_data` with the schema above. Confirm
+   `free_tier`, `sso_support`, and `billing_model` come back populated.
+3. Repeat for `https://openai.com/pricing` and
+   `https://stripe.com/pricing`.
+4. Confirm the three rows of the matrix differ from each other in at
+   least one column — if they're identical, the schema is wrong or
+   the pages are being JS-gated.
+
+If step 2 returns an empty `extracted` object, the page is rendered
+post-load; combine with `mcp__openchrome__wait_for` against a
+known-stable selector before re-running `extract_data`.
+
+## Out of scope
+
+- Multilingual matrices — translate downstream in the host.
+- Behind-login pages — pair with `oc_skill_recall` and re-run.
+- Live price tracking — schedule the recipe externally; openchrome
+  itself does not run cron.

--- a/docs/recipes/docs-changelog-diff.md
+++ b/docs/recipes/docs-changelog-diff.md
@@ -1,0 +1,60 @@
+# Recipe: docs changelog diff
+
+## Goal
+
+Given two URLs that point at the same conceptual docs page at different
+points in time (a "before" and an "after"), explain what changed in
+plain prose. Typical use: release-notes drafting, regression triage,
+or auditing a vendor's silently-edited terms page.
+
+## Inputs
+
+- `before_url: string` — the older snapshot (e.g. an archive.org capture, or a `?ref=v1.10` branch URL).
+- `after_url: string` — the newer snapshot.
+- `focus?: string` — optional hint for the host LLM (e.g. "auth flow", "pricing tiers"). Server ignores this.
+
+## Plan
+
+1. `mcp__openchrome__navigate` `{ url: before_url }`. Expect navigation status.
+2. `mcp__openchrome__read_page` `{ mode: "markdown", max_chars: 8000 }`. Returns the rendered markdown.
+3. `mcp__openchrome__navigate` `{ url: after_url }`.
+4. `mcp__openchrome__read_page` `{ mode: "markdown", max_chars: 8000 }`.
+
+   Both reads in markdown mode so paragraph breaks line up — diffing
+   AX trees against each other is unreliable when one snapshot loaded
+   a navigation update and the other did not.
+
+5. **Optional** — when prose alone is ambiguous (e.g. you suspect a
+   table cell changed but the markdown rendered both versions the
+   same), repeat steps 2 and 4 with `mode: "dom"` and a CSS selector
+   scoped to the suspect region.
+
+## Synthesis (host LLM)
+
+The host receives two markdown blobs. It computes the textual diff
+locally (any host can do this without a tool call) and writes a prose
+summary. If `focus` was provided, the summary leads with that section;
+otherwise the summary groups changes by markdown heading.
+
+No server-side LLM call. No serial network reads beyond the two
+`navigate` + `read_page` pairs above.
+
+## Verification
+
+Use a stable changelog page that you know historical content for:
+
+1. `mcp__openchrome__navigate` to `https://nodejs.org/en/blog/release/v20.0.0`.
+2. `mcp__openchrome__read_page` `{ mode: "markdown", max_chars: 8000 }`. Confirm the response includes the v20.0.0 release notes prose.
+3. Repeat for `https://nodejs.org/en/blog/release/v21.0.0`.
+4. Confirm the two markdown blobs differ (sanity check that the
+   navigate actually moved off the first URL).
+
+If step 2 returns boilerplate / login wall / empty content, the site
+is gating the rendered text; fall back to `extract_data` with a CSS
+selector for the `<article>` body and re-run.
+
+## Out of scope
+
+- Image diffs (use `oc_evidence_bundle` for screenshot pairs).
+- Server-rendered SPAs that need authenticated session — combine with
+  `oc_skill_recall` first.

--- a/docs/recipes/multi-source-news-digest.md
+++ b/docs/recipes/multi-source-news-digest.md
@@ -1,0 +1,65 @@
+# Recipe: multi-source news digest
+
+## Goal
+
+Produce a one-screen daily digest of the top stories from a small set
+of news sources. The host LLM picks the sources and decides what counts
+as "top," but openchrome never calls a model — it only navigates, reads
+the rendered pages, and returns structured snapshots.
+
+## Inputs (from the user / host context)
+
+- `sources: string[]` — 2 to 5 source URLs (e.g. `["https://news.ycombinator.com/", "https://techcrunch.com/"]`).
+- `max_stories_per_source: number` — typically 5.
+- `digest_length_words: number` — typically 200.
+
+## Plan
+
+For each `source` in `sources`:
+
+1. `mcp__openchrome__navigate` with `{ url: source }`. Expect: `{ url, title, status }`.
+2. `mcp__openchrome__read_page` with `{ mode: "ax", max_chars: 4000 }`. Expect: an accessibility-tree snapshot containing the visible headline / story-row structure.
+
+   Why `mode: "ax"` and not `mode: "dom"`: headline lists are
+   list/heading items in the accessibility tree, and the AX snapshot
+   strips ad and chrome boilerplate the host would otherwise have to
+   filter out.
+3. Host LLM picks the top `max_stories_per_source` headlines from each
+   snapshot. Discard items missing a link or whose text is empty.
+4. **Optional** — for any headline whose linked detail page the host
+   wants to summarise individually: `mcp__openchrome__navigate` to the
+   story URL, then `mcp__openchrome__read_page` with
+   `{ mode: "markdown", max_chars: 3000 }`.
+
+   Use markdown mode here, not AX: the body of an article is prose,
+   not structure, and the markdown formatter preserves paragraph breaks.
+
+## Synthesis (host LLM)
+
+The host receives one snapshot per source and (optionally) one body per
+story. It composes the final digest in `digest_length_words` words,
+grouping by source and bolding headlines. No server-side LLM call.
+
+## Verification
+
+Run by hand against `https://news.ycombinator.com/` and
+`https://lobste.rs/`:
+
+1. `mcp__openchrome__navigate` to each URL.
+2. `mcp__openchrome__read_page` with `{ mode: "ax", max_chars: 4000 }`.
+3. Confirm the AX snapshot lists at least the top 10 stories on each
+   site (story rows surface as link / heading items).
+4. Pick one story from HN, navigate to it, `read_page` in markdown
+   mode, confirm the article body is present and not the HN comment
+   thread.
+
+If step 3 fails, the source markup has changed; update the recipe with
+the new selectors or switch to `find` to locate the story list before
+calling `read_page`.
+
+## Out of scope
+
+- Server-side summarisation (P3 forbids outbound LLM).
+- Login-gated sources — those need `oc_skill_recall` for credentials,
+  which is a different recipe.
+- Translated digests — host LLM handles that downstream.


### PR DESCRIPTION
## Summary

Three runnable, operator-verifiable recipes under `docs/recipes/`:

- **multi-source-news-digest.md** — `navigate` + `read_page` (ax) per source, optional markdown body per story; host composes the digest.
- **docs-changelog-diff.md** — `navigate` + `read_page` (markdown) per snapshot; host computes the textual diff.
- **competitive-feature-matrix.md** — `navigate` + `extract_data` (schema) per vendor; host assembles the matrix.

Plus a `docs/recipes/README.md` index and a one-line pointer from the main README.

## Why this is docs, not a tool

The originally-proposed `oc_research_plan` MCP tool was rejected in critic review. A competent host LLM produces the same plan ad-hoc from existing tool descriptions, and `src/orchestration/plan-registry.ts` already covers the deterministic-template case. Documenting the recipes captures the value without adding to the tool surface (P3 stays clean).

## Acceptance criteria

- [x] Three recipes with Goal / Inputs / Plan / Synthesis / Verification sections
- [x] Every `mcp__openchrome__` tool referenced exists in `src/tools/index.ts`
- [x] Each recipe ends with an operator-runnable verification step against public URLs
- [x] No server-side LLM recommended (P3)
- [x] README links to the recipes index
- [x] No source code changes

Closes #858

Part of the `mcp-browser-use adoption` series (C, downgraded from a proposed MCP tool to docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)