### PR TITLE
feat(recording): enrich replay HTML report with Outcome Contract, verify, AX, and network panels (#852)

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -47,6 +47,7 @@ import {
 } from './totp-store';
 import { registerAdminKeysCommand } from './admin-keys';
 import { registerContractCommand } from './contract-teach';
+import { registerReplayCommand } from './replay';
 import { getClaudeCliCommand, getClaudeExecFileOptions, shouldUseClaudeCliShell } from './claude-cli';
 
 const program = new Command();
@@ -1300,5 +1301,8 @@ registerAdminKeysCommand(program);
 
 // Outcome contract authoring helpers (issue #705).
 registerContractCommand(program);
+
+// Session recording replay subcommands (issue #852).
+registerReplayCommand(program);
 
 program.parse();

--- a/cli/replay.ts
+++ b/cli/replay.ts
@@ -1,0 +1,288 @@
+/**
+ * `openchrome replay` — CLI subcommands for the Session Recording & Replay subsystem.
+ *
+ * Subcommands:
+ *   replay list                        — table of all recordings
+ *   replay report <id> [--out PATH]    — generate / copy HTML report
+ *   replay terminal <id>               — print ASCII timeline
+ *
+ * Because the CLI tsconfig has rootDir=./cli, we pull recording modules from
+ * the compiled dist via runtime require(), following the same pattern used in
+ * contract-teach.ts.
+ *
+ * Exit codes:
+ *   0 — success
+ *   2 — unknown recording id / usage error
+ *   3 — I/O error
+ *
+ * Part of #852: replay HTML report enrichment.
+ */
+
+import { Command } from 'commander';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Runtime module loader (avoids rootDir constraint)
+// ---------------------------------------------------------------------------
+
+interface RecordingMetadata {
+  version: number;
+  id: string;
+  sessionId: string;
+  startedAt: string;
+  stoppedAt?: string;
+  actionCount: number;
+  profile?: string;
+  label?: string;
+}
+
+interface ReplayViewerModule {
+  getReplayViewer(): {
+    generateReport(id: string): Promise<string>;
+    generateTerminalReplay(id: string): Promise<string>;
+  };
+}
+
+interface RecordingStoreModule {
+  getRecordingStore(): {
+    init(): Promise<void>;
+    listRecordings(): Promise<string[]>;
+    readMetadata(id: string): Promise<RecordingMetadata | null>;
+    readActions(id: string): Array<{ ok: boolean }>;
+  };
+}
+
+function tryRequire<T>(candidates: readonly string[], label: string): T {
+  let lastErr: unknown;
+  for (const spec of candidates) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      return require(spec) as T;
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw new Error(
+    `Unable to load ${label} from any candidate path: ${
+      lastErr instanceof Error ? lastErr.message : String(lastErr)
+    }`,
+  );
+}
+
+function loadReplayViewerModule(): ReplayViewerModule {
+  // Two candidates: post-dist (cli/replay.js → ../recording/replay-viewer.js) and
+  // ts-jest source tree (cli/replay.ts → ../src/recording/replay-viewer).
+  return tryRequire<ReplayViewerModule>(
+    ['../recording/replay-viewer.js', '../src/recording/replay-viewer'],
+    'replay-viewer',
+  );
+}
+
+function loadRecordingStoreModule(): RecordingStoreModule {
+  return tryRequire<RecordingStoreModule>(
+    ['../recording/recording-store.js', '../src/recording/recording-store'],
+    'recording-store',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatDate(iso: string | undefined): string {
+  if (!iso) return '—';
+  try {
+    return new Date(iso).toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, ' UTC');
+  } catch {
+    return iso;
+  }
+}
+
+function padEnd(str: string, len: number): string {
+  return str.length >= len ? str : str + ' '.repeat(len - str.length);
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerReplayCommand(program: Command): void {
+  const replay = program
+    .command('replay')
+    .description('Manage and inspect session recordings');
+
+  // ── replay list ───────────────────────────────────────────────────────────
+  replay
+    .command('list')
+    .description('List all recordings sorted by last activity (newest first)')
+    .action(async () => {
+      try {
+        const storeModule = loadRecordingStoreModule();
+        const store = storeModule.getRecordingStore();
+        await store.init();
+
+        const ids = await store.listRecordings();
+        if (ids.length === 0) {
+          process.stderr.write('No recordings found.\n');
+          return;
+        }
+
+        // Collect rows
+        const rows: Array<{
+          id: string;
+          actions: string;
+          lastActivity: string;
+          successRate: string;
+          label: string;
+        }> = [];
+
+        for (const id of ids) {
+          const meta = await store.readMetadata(id);
+          if (!meta) continue;
+
+          const actions = store.readActions(id);
+          const successCount = actions.filter((a) => a.ok).length;
+          const successRate =
+            actions.length > 0
+              ? `${Math.round((successCount / actions.length) * 100)}%`
+              : 'N/A';
+
+          rows.push({
+            id,
+            actions: String(meta.actionCount),
+            lastActivity: formatDate(meta.stoppedAt ?? meta.startedAt),
+            successRate,
+            label: meta.label ?? '',
+          });
+        }
+
+        // Column widths
+        const idW = Math.max(11, ...rows.map((r) => r.id.length));
+        const actW = Math.max(7, ...rows.map((r) => r.actions.length));
+        const rateW = Math.max(12, ...rows.map((r) => r.successRate.length));
+        const tsW = Math.max(24, ...rows.map((r) => r.lastActivity.length));
+        const labelW = Math.max(5, ...rows.map((r) => r.label.length));
+
+        const header =
+          padEnd('Recording ID', idW) +
+          '  ' +
+          padEnd('Actions', actW) +
+          '  ' +
+          padEnd('Success Rate', rateW) +
+          '  ' +
+          padEnd('Last Activity', tsW) +
+          '  ' +
+          padEnd('Label', labelW);
+        const sep = '-'.repeat(header.length);
+
+        process.stderr.write(header + '\n');
+        process.stderr.write(sep + '\n');
+        for (const row of rows) {
+          const line =
+            padEnd(row.id, idW) +
+            '  ' +
+            padEnd(row.actions, actW) +
+            '  ' +
+            padEnd(row.successRate, rateW) +
+            '  ' +
+            padEnd(row.lastActivity, tsW) +
+            '  ' +
+            padEnd(row.label, labelW);
+          process.stderr.write(line + '\n');
+        }
+      } catch (err) {
+        process.stderr.write(
+          `Error listing recordings: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        process.exit(3);
+      }
+    });
+
+  // ── replay report ─────────────────────────────────────────────────────────
+  replay
+    .command('report <id>')
+    .description('Generate HTML report for a recording')
+    .option('--out <path>', 'Copy the rendered HTML to this path atomically')
+    .action(async (id: string, options: { out?: string }) => {
+      try {
+        const viewerModule = loadReplayViewerModule();
+        const viewer = viewerModule.getReplayViewer();
+
+        let reportPath: string;
+        try {
+          reportPath = await viewer.generateReport(id);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (msg.includes('Recording not found') || msg.includes('Invalid recording id')) {
+            process.stderr.write(`Recording not found: ${id}\n`);
+            process.exit(2);
+          }
+          throw err;
+        }
+
+        if (options.out) {
+          const dest = path.resolve(options.out);
+          try {
+            // Write atomically using a temp file + rename
+            const tmp = dest + '.tmp';
+            const content = fs.readFileSync(reportPath);
+            fs.writeFileSync(tmp, content);
+            fs.renameSync(tmp, dest);
+            process.stdout.write(dest + '\n');
+          } catch (ioErr) {
+            process.stderr.write(
+              `Failed to write report to ${dest}: ${ioErr instanceof Error ? ioErr.message : String(ioErr)}\n`,
+            );
+            process.exit(3);
+          }
+        } else {
+          process.stdout.write(reportPath + '\n');
+        }
+      } catch (err) {
+        // Preserve exit signals already raised by inner handlers (test harnesses
+        // typically intercept process.exit() by throwing; we must not overwrite
+        // the inner exit code with 3 here).
+        if (err instanceof Error && err.message.startsWith('process.exit(')) {
+          throw err;
+        }
+        process.stderr.write(
+          `Error generating report: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        process.exit(3);
+      }
+    });
+
+  // ── replay terminal ───────────────────────────────────────────────────────
+  replay
+    .command('terminal <id>')
+    .description('Print ASCII timeline for a recording')
+    .action(async (id: string) => {
+      try {
+        const viewerModule = loadReplayViewerModule();
+        const viewer = viewerModule.getReplayViewer();
+
+        let output: string;
+        try {
+          output = await viewer.generateTerminalReplay(id);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (msg.includes('Recording not found') || msg.includes('Invalid recording id')) {
+            process.stderr.write(`Recording not found: ${id}\n`);
+            process.exit(2);
+          }
+          throw err;
+        }
+
+        process.stdout.write(output + '\n');
+      } catch (err) {
+        if (err instanceof Error && err.message.startsWith('process.exit(')) {
+          throw err;
+        }
+        process.stderr.write(
+          `Error generating terminal replay: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        process.exit(3);
+      }
+    });
+}

--- a/cli/replay.ts
+++ b/cli/replay.ts
@@ -224,11 +224,11 @@ export function registerReplayCommand(program: Command): void {
         if (options.out) {
           const dest = path.resolve(options.out);
           try {
-            // Write atomically using a temp file + rename
+            // Write atomically using a temp file + rename (async I/O)
             const tmp = dest + '.tmp';
-            const content = fs.readFileSync(reportPath);
-            fs.writeFileSync(tmp, content);
-            fs.renameSync(tmp, dest);
+            const content = await fs.promises.readFile(reportPath);
+            await fs.promises.writeFile(tmp, content);
+            await fs.promises.rename(tmp, dest);
             process.stdout.write(dest + '\n');
           } catch (ioErr) {
             process.stderr.write(

--- a/src/recording/action-recorder.ts
+++ b/src/recording/action-recorder.ts
@@ -162,6 +162,14 @@ export class ActionRecorder {
       throw new Error('No active recording. Call start() first.');
     }
 
+    // Drain any in-flight writes BEFORE flipping `_isRecording = false`.
+    // Otherwise recordAction()/appendContractResult() tasks still sitting on
+    // the queue would see `_isRecording === false` when their turn comes and
+    // silently no-op, losing recorded actions on a busy stop() (Codex P1).
+    await this._writeChain;
+
+    // After the chain has drained, take a final snapshot — actionCount may
+    // have grown while we were waiting.
     const metadata: RecordingMetadata = {
       ...this._activeMetadata,
       stoppedAt: new Date().toISOString(),

--- a/src/recording/action-recorder.ts
+++ b/src/recording/action-recorder.ts
@@ -6,8 +6,6 @@
  */
 
 import { randomBytes } from 'crypto';
-import * as fs from 'fs';
-import * as path from 'path';
 import { RecordingStore, getRecordingStore } from './recording-store';
 import {
   RecordingAction,
@@ -83,10 +81,29 @@ export class ActionRecorder {
   private _activeRecordingId: string | null = null;
   private _activeMetadata: RecordingMetadata | null = null;
   private _seq = 0;
+  /**
+   * Promise-chain mutex serializing every write to this recorder. Without this,
+   * two concurrent recordAction() calls each read _seq before either has
+   * incremented it, producing duplicate seq values (observed in concurrent
+   * tests). appendContractResult() rides the same chain so contract rows can
+   * never interleave with an in-flight recordAction().
+   */
+  private _writeChain: Promise<void> = Promise.resolve();
 
   constructor(store?: RecordingStore, configOverrides?: Partial<RecordingConfig>) {
     this.store = store ?? getRecordingStore();
     this.config = { ...DEFAULT_RECORDING_CONFIG, ...configOverrides };
+  }
+
+  /** Queue `op` behind any in-flight writes. Errors are isolated per-task. */
+  private enqueueWrite<T>(op: () => Promise<T>): Promise<T> {
+    const next = this._writeChain.then(op, op);
+    // Keep the chain alive even if op rejects, so later writes still serialize.
+    this._writeChain = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
   }
 
   /** Whether a recording is currently active */
@@ -176,68 +193,75 @@ export class ActionRecorder {
     }
 
     const id = this._activeRecordingId;
+    const sanitizedArgs = this.sanitizeArgs(args);
 
-    try {
-      const seq = this._seq + 1;
-      const action: RecordingAction = {
-        seq,
-        ts: Date.now(),
-        tool,
-        args: this.sanitizeArgs(args),
-        durationMs,
-        ok,
-        summary: opts?.summary ?? `${ok ? '✓' : '✗'} ${tool}`,
-        url: opts?.url,
-        tabId: opts?.tabId ?? (args['tabId'] as string | undefined),
-        error: opts?.error,
-        ...applyContractResultsBounds(opts?.contractResults),
-        ...applyVerifyField(opts?.verify),
-        ...applyNetworkBounds(opts?.network),
-        ...applyConsoleBounds(opts?.console),
-      };
+    // Serialize every write so concurrent callers can't share the same _seq.
+    return this.enqueueWrite(async () => {
+      if (!this._isRecording || this._activeRecordingId !== id || !this._activeMetadata) {
+        return;
+      }
+      try {
+        const seq = this._seq + 1;
+        const action: RecordingAction = {
+          seq,
+          ts: Date.now(),
+          tool,
+          args: sanitizedArgs,
+          durationMs,
+          ok,
+          summary: opts?.summary ?? `${ok ? '✓' : '✗'} ${tool}`,
+          url: opts?.url,
+          tabId: opts?.tabId ?? (args['tabId'] as string | undefined),
+          error: opts?.error,
+          ...applyContractResultsBounds(opts?.contractResults),
+          ...applyVerifyField(opts?.verify),
+          ...applyNetworkBounds(opts?.network),
+          ...applyConsoleBounds(opts?.console),
+        };
 
-      await this.store.appendAction(id, action);
+        await this.store.appendAction(id, action);
 
-      // Only advance seq and actionCount after successful write
-      this._seq = seq;
-      this._activeMetadata.actionCount = seq;
-    } catch (err) {
-      console.error('[ActionRecorder] Failed to record action:', err instanceof Error ? err.message : err);
-    }
+        // Only advance seq and actionCount after successful write
+        this._seq = seq;
+        this._activeMetadata.actionCount = seq;
+      } catch (err) {
+        console.error('[ActionRecorder] Failed to record action:', err instanceof Error ? err.message : err);
+      }
+    });
   }
 
   /**
    * Append a contract result to the most recently recorded action.
    * No-op if not recording or no actions have been recorded yet.
    * This is the hook used by oc_assert.
+   *
+   * Uses an append-only sidecar row (`{kind:"contract_result",actionIndex,…}`)
+   * rather than rewriting actions.jsonl in place. This removes the race window
+   * where a concurrent recordAction() append could be clobbered by a contract
+   * annotation that was based on an older snapshot.
    */
   async appendContractResult(entry: ContractResultEntry): Promise<void> {
-    if (!this._isRecording || !this._activeRecordingId || this._seq === 0) {
+    if (!this._isRecording || !this._activeRecordingId) {
       return;
     }
+    const recordingIdAtCall = this._activeRecordingId;
 
-    const id = this._activeRecordingId;
-    try {
-      // Read all actions, mutate the last one, and rewrite the JSONL
-      const actions = this.store.readActions(id);
-      if (actions.length === 0) return;
-
-      const last = actions[actions.length - 1];
-      const existing = last.contractResults ?? [];
-      existing.push(entry);
-
-      // Apply bounds check
-      const bounded = applyContractResultsBounds(existing)?.contractResults ?? existing;
-      last.contractResults = bounded;
-
-      // Rewrite the JSONL file
-      const lines = actions.map(a => JSON.stringify(a)).join('\n') + '\n';
-      const recDir = this.store.getRecordingDir(id);
-      const filePath = path.join(recDir, 'actions.jsonl');
-      await fs.promises.writeFile(filePath, lines, 'utf-8');
-    } catch (err) {
-      console.error('[ActionRecorder] Failed to append contract result:', err instanceof Error ? err.message : err);
-    }
+    // Serialize so we read _seq AFTER any in-flight recordAction() completes —
+    // otherwise the contract row could reference an action index that doesn't
+    // exist yet on disk, or, worse, point at the wrong action when the in-flight
+    // write resolves first.
+    return this.enqueueWrite(async () => {
+      if (!this._isRecording || this._activeRecordingId !== recordingIdAtCall || this._seq === 0) {
+        return;
+      }
+      const id = this._activeRecordingId;
+      const actionIndex = this._seq;
+      try {
+        await this.store.appendContractResultRow(id, actionIndex, entry);
+      } catch (err) {
+        console.error('[ActionRecorder] Failed to append contract result:', err instanceof Error ? err.message : err);
+      }
+    });
   }
 
   /**
@@ -315,15 +339,19 @@ const ARRAY_FIELD_MAX_ENTRIES = 20;
 /**
  * Enforce the 4 KB cap on contractResults.
  * Returns a partial RecordingAction fragment (may be empty if undefined input).
+ *
+ * Size is measured in UTF-8 bytes (via Buffer.byteLength) — `json.length`
+ * counts UTF-16 code units and would underestimate non-ASCII payloads.
  */
 function applyContractResultsBounds(
   entries: ContractResultEntry[] | undefined,
 ): Pick<RecordingAction, 'contractResults'> {
   if (!entries || entries.length === 0) return {};
   const json = JSON.stringify(entries);
-  if (json.length > CONTRACT_RESULTS_MAX_BYTES) {
+  const bytes = Buffer.byteLength(json, 'utf8');
+  if (bytes > CONTRACT_RESULTS_MAX_BYTES) {
     return {
-      contractResults: [{ truncated: true, originalBytes: json.length } as unknown as ContractResultEntry],
+      contractResults: [{ truncated: true, originalBytes: bytes } as unknown as ContractResultEntry],
     };
   }
   return { contractResults: entries };

--- a/src/recording/action-recorder.ts
+++ b/src/recording/action-recorder.ts
@@ -6,8 +6,18 @@
  */
 
 import { randomBytes } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
 import { RecordingStore, getRecordingStore } from './recording-store';
-import { RecordingAction, RecordingMetadata, RecordingConfig, DEFAULT_RECORDING_CONFIG } from './types';
+import {
+  RecordingAction,
+  RecordingMetadata,
+  RecordingConfig,
+  DEFAULT_RECORDING_CONFIG,
+  ContractResultEntry,
+  NetworkEntry,
+  ConsoleEntry,
+} from './types';
 
 /** Arg keys that are always redacted */
 const REDACT_KEYS = /password|token|secret|credential|api[_-]?key|authorization|auth[_-]token/i;
@@ -53,6 +63,14 @@ export interface RecordActionOptions {
   url?: string;
   /** Error message (when ok=false) */
   error?: string;
+  /** Outcome Contract assertion results (≤ 4 KB total JSON; truncated if over) */
+  contractResults?: ContractResultEntry[];
+  /** Verbatim verify block from the tool response */
+  verify?: Record<string, unknown>;
+  /** Network requests correlated with this action (≤ 20 entries; truncated if over) */
+  network?: NetworkEntry[];
+  /** Console messages emitted during this action (≤ 20 entries; truncated if over) */
+  console?: ConsoleEntry[];
 }
 
 /**
@@ -172,6 +190,10 @@ export class ActionRecorder {
         url: opts?.url,
         tabId: opts?.tabId ?? (args['tabId'] as string | undefined),
         error: opts?.error,
+        ...applyContractResultsBounds(opts?.contractResults),
+        ...applyVerifyField(opts?.verify),
+        ...applyNetworkBounds(opts?.network),
+        ...applyConsoleBounds(opts?.console),
       };
 
       await this.store.appendAction(id, action);
@@ -181,6 +203,40 @@ export class ActionRecorder {
       this._activeMetadata.actionCount = seq;
     } catch (err) {
       console.error('[ActionRecorder] Failed to record action:', err instanceof Error ? err.message : err);
+    }
+  }
+
+  /**
+   * Append a contract result to the most recently recorded action.
+   * No-op if not recording or no actions have been recorded yet.
+   * This is the hook used by oc_assert.
+   */
+  async appendContractResult(entry: ContractResultEntry): Promise<void> {
+    if (!this._isRecording || !this._activeRecordingId || this._seq === 0) {
+      return;
+    }
+
+    const id = this._activeRecordingId;
+    try {
+      // Read all actions, mutate the last one, and rewrite the JSONL
+      const actions = this.store.readActions(id);
+      if (actions.length === 0) return;
+
+      const last = actions[actions.length - 1];
+      const existing = last.contractResults ?? [];
+      existing.push(entry);
+
+      // Apply bounds check
+      const bounded = applyContractResultsBounds(existing)?.contractResults ?? existing;
+      last.contractResults = bounded;
+
+      // Rewrite the JSONL file
+      const lines = actions.map(a => JSON.stringify(a)).join('\n') + '\n';
+      const recDir = this.store.getRecordingDir(id);
+      const filePath = path.join(recDir, 'actions.jsonl');
+      await fs.promises.writeFile(filePath, lines, 'utf-8');
+    } catch (err) {
+      console.error('[ActionRecorder] Failed to append contract result:', err instanceof Error ? err.message : err);
     }
   }
 
@@ -249,15 +305,126 @@ export class ActionRecorder {
   }
 }
 
-/** Singleton instance */
-let instance: ActionRecorder | null = null;
+// ---------------------------------------------------------------------------
+// Bounds helpers (module-private, exported only for tests via internal path)
+// ---------------------------------------------------------------------------
+
+const CONTRACT_RESULTS_MAX_BYTES = 4096;
+const ARRAY_FIELD_MAX_ENTRIES = 20;
 
 /**
- * Get the singleton ActionRecorder instance.
+ * Enforce the 4 KB cap on contractResults.
+ * Returns a partial RecordingAction fragment (may be empty if undefined input).
  */
+function applyContractResultsBounds(
+  entries: ContractResultEntry[] | undefined,
+): Pick<RecordingAction, 'contractResults'> {
+  if (!entries || entries.length === 0) return {};
+  const json = JSON.stringify(entries);
+  if (json.length > CONTRACT_RESULTS_MAX_BYTES) {
+    return {
+      contractResults: [{ truncated: true, originalBytes: json.length } as unknown as ContractResultEntry],
+    };
+  }
+  return { contractResults: entries };
+}
+
+/**
+ * Pass through the verify field, omitting it when undefined.
+ */
+function applyVerifyField(
+  verify: Record<string, unknown> | undefined,
+): Pick<RecordingAction, 'verify'> {
+  if (!verify) return {};
+  return { verify };
+}
+
+/**
+ * Enforce the 20-entry cap on network entries.
+ */
+function applyNetworkBounds(
+  entries: NetworkEntry[] | undefined,
+): Pick<RecordingAction, 'network'> {
+  if (!entries || entries.length === 0) return {};
+  if (entries.length > ARRAY_FIELD_MAX_ENTRIES) {
+    const over = entries.length - ARRAY_FIELD_MAX_ENTRIES;
+    return {
+      network: [
+        ...entries.slice(0, ARRAY_FIELD_MAX_ENTRIES),
+        { method: '', url: `(+${over} more — truncated)` },
+      ],
+    };
+  }
+  return { network: entries };
+}
+
+/**
+ * Enforce the 20-entry cap on console entries.
+ */
+function applyConsoleBounds(
+  entries: ConsoleEntry[] | undefined,
+): Pick<RecordingAction, 'console'> {
+  if (!entries || entries.length === 0) return {};
+  if (entries.length > ARRAY_FIELD_MAX_ENTRIES) {
+    const over = entries.length - ARRAY_FIELD_MAX_ENTRIES;
+    return {
+      console: [
+        ...entries.slice(0, ARRAY_FIELD_MAX_ENTRIES),
+        { level: 'log' as const, text: `(+${over} more — truncated)`, ts: Date.now() },
+      ],
+    };
+  }
+  return { console: entries };
+}
+
+// ---------------------------------------------------------------------------
+// Singleton registry: sessionId → ActionRecorder
+// Per-session recorders allow oc_assert to look up the active recorder for
+// a given MCP session without coupling to the global singleton.
+// ---------------------------------------------------------------------------
+
+/** Map of sessionId → ActionRecorder instances (populated on start()) */
+const sessionRecorderRegistry = new Map<string, ActionRecorder>();
+
+/** Singleton instance (global recorder used by the recording MCP tool) */
+let instance: ActionRecorder | null = null;
+
 export function getActionRecorder(): ActionRecorder {
   if (!instance) {
     instance = new ActionRecorder();
   }
   return instance;
+}
+
+/**
+ * Register an ActionRecorder for a given sessionId so that oc_assert can
+ * retrieve it. Called by the recording tool on start.
+ */
+export function registerSessionRecorder(sessionId: string, recorder: ActionRecorder): void {
+  sessionRecorderRegistry.set(sessionId, recorder);
+}
+
+/**
+ * Unregister an ActionRecorder for a given sessionId. Called on stop.
+ */
+export function unregisterSessionRecorder(sessionId: string): void {
+  sessionRecorderRegistry.delete(sessionId);
+}
+
+/**
+ * Get the active ActionRecorder for a given sessionId, if any recording is
+ * in progress. Returns undefined if no recording is active for that session.
+ * Used by oc_assert to append contract results to the most recent action.
+ */
+export function getActiveActionRecorder(sessionId: string): ActionRecorder | undefined {
+  const recorder = sessionRecorderRegistry.get(sessionId);
+  if (recorder && recorder.isRecording) {
+    return recorder;
+  }
+  // Also check the global singleton in case it was started without explicit registration
+  const global = getActionRecorder();
+  if (global.isRecording && global.activeMetadata?.sessionId === sessionId) {
+    return global;
+  }
+  return undefined;
 }

--- a/src/recording/html-template.ts
+++ b/src/recording/html-template.ts
@@ -4,7 +4,7 @@
  * Part of #572: Session Recording & Replay.
  */
 
-import { RecordingAction, RecordingMetadata } from './types';
+import { RecordingAction, RecordingMetadata, ContractResultEntry } from './types';
 
 /** Tool categories for color-coded badges */
 const TOOL_CATEGORIES: Record<string, string> = {
@@ -34,6 +34,9 @@ function getToolCategory(tool: string): string {
 }
 
 function formatTimestamp(ts: number): string {
+  if (process.env['OPENCHROME_REPLAY_DETERMINISTIC'] === '1') {
+    return '00:00:00.000';
+  }
   const d = new Date(ts);
   const hh = String(d.getHours()).padStart(2, '0');
   const mm = String(d.getMinutes()).padStart(2, '0');
@@ -49,6 +52,9 @@ function formatDuration(ms: number): string {
 
 function formatIso(iso: string | undefined): string {
   if (!iso) return '—';
+  if (process.env['OPENCHROME_REPLAY_DETERMINISTIC'] === '1') {
+    return '1970-01-01 00:00:00 UTC';
+  }
   try {
     return new Date(iso).toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, ' UTC');
   } catch {
@@ -72,6 +78,9 @@ function computeStats(actions: RecordingAction[]): {
   successRate: string;
   totalDurationMs: number;
   toolsUsed: string[];
+  contractPass: number;
+  contractFail: number;
+  contractInconclusive: number;
 } {
   const successCount = actions.filter(a => a.ok).length;
   const failureCount = actions.length - successCount;
@@ -80,7 +89,137 @@ function computeStats(actions: RecordingAction[]): {
   const successRate = actions.length > 0
     ? `${Math.round((successCount / actions.length) * 100)}%`
     : 'N/A';
-  return { totalActions: actions.length, successCount, failureCount, successRate, totalDurationMs, toolsUsed };
+
+  let contractPass = 0;
+  let contractFail = 0;
+  let contractInconclusive = 0;
+  for (const action of actions) {
+    for (const cr of (action.contractResults ?? [])) {
+      const entry = cr as ContractResultEntry;
+      if (entry.verdict === 'pass') contractPass++;
+      else if (entry.verdict === 'fail') contractFail++;
+      else contractInconclusive++;
+    }
+  }
+
+  return {
+    totalActions: actions.length,
+    successCount,
+    failureCount,
+    successRate,
+    totalDurationMs,
+    toolsUsed,
+    contractPass,
+    contractFail,
+    contractInconclusive,
+  };
+}
+
+/**
+ * Render the Outcome Contract panel for one action card.
+ * Returns '' if no contractResults present.
+ */
+function renderContractPanel(action: RecordingAction): string {
+  if (!action.contractResults || action.contractResults.length === 0) return '';
+
+  const entries = action.contractResults as ContractResultEntry[];
+  const rows = entries.map(cr => {
+    // Handle truncation placeholder
+    if ((cr as unknown as Record<string, unknown>)['truncated'] === true) {
+      const bytes = (cr as unknown as Record<string, unknown>)['originalBytes'] as number | undefined;
+      return `<div class="contract-row truncated">Truncated (original ${bytes ?? '?'} bytes exceeded 4 KB limit)</div>`;
+    }
+    const verdictClass = cr.verdict === 'pass' ? 'verdict-pass'
+      : cr.verdict === 'fail' ? 'verdict-fail'
+      : 'verdict-inconclusive';
+    const assertionJson = escapeHtml(JSON.stringify(cr.assertion, null, 2));
+    const detailsHtml = cr.details
+      ? `<pre class="panel-json">${escapeHtml(JSON.stringify(cr.details, null, 2))}</pre>`
+      : '';
+    return `<div class="contract-row">
+        <span class="verdict-badge ${verdictClass}">${escapeHtml(cr.verdict)}</span>
+        <pre class="panel-json">${assertionJson}</pre>
+        ${detailsHtml}
+      </div>`;
+  }).join('');
+
+  return `
+    <details class="panel-details contract-panel">
+      <summary>Contracts (${entries.length})</summary>
+      <div class="panel-body">${rows}</div>
+    </details>`;
+}
+
+/**
+ * Render the verify panel for one action card.
+ * Returns '' if no verify block present.
+ */
+function renderVerifyPanel(action: RecordingAction): string {
+  if (!action.verify) return '';
+  const json = escapeHtml(JSON.stringify(action.verify, null, 2));
+  return `
+    <details class="panel-details verify-panel">
+      <summary>Verify</summary>
+      <div class="panel-body">
+        <pre class="panel-json">${json}</pre>
+      </div>
+    </details>`;
+}
+
+/**
+ * Render the network panel for one action card.
+ * Returns '' if no network entries present.
+ */
+function renderNetworkPanel(action: RecordingAction): string {
+  if (!action.network || action.network.length === 0) return '';
+  const rows = action.network.map(n => {
+    const statusStr = n.status !== undefined ? String(n.status) : '—';
+    const durStr = n.durationMs !== undefined ? `${n.durationMs}ms` : '—';
+    // Truncation marker row has empty method
+    if (!n.method && n.url.includes('truncated')) {
+      return `<tr class="truncation-marker"><td colspan="4">${escapeHtml(n.url)}</td></tr>`;
+    }
+    return `<tr>
+        <td class="net-method">${escapeHtml(n.method)}</td>
+        <td class="net-url">${escapeHtml(n.url)}</td>
+        <td class="net-status">${escapeHtml(statusStr)}</td>
+        <td class="net-dur">${escapeHtml(durStr)}</td>
+      </tr>`;
+  }).join('');
+  return `
+    <details class="panel-details network-panel">
+      <summary>Network (${action.network.length})</summary>
+      <div class="panel-body">
+        <table class="panel-table">
+          <thead><tr><th>Method</th><th>URL</th><th>Status</th><th>Duration</th></tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>
+    </details>`;
+}
+
+/**
+ * Render the console panel for one action card.
+ * Returns '' if no console entries present.
+ */
+function renderConsolePanel(action: RecordingAction): string {
+  if (!action.console || action.console.length === 0) return '';
+  const rows = action.console.map(c => {
+    const levelClass = `console-${c.level}`;
+    const timeStr = process.env['OPENCHROME_REPLAY_DETERMINISTIC'] === '1'
+      ? '00:00:00.000'
+      : formatTimestamp(c.ts);
+    return `<div class="console-row ${levelClass}">
+        <span class="console-time">${escapeHtml(timeStr)}</span>
+        <span class="console-level">${escapeHtml(c.level)}</span>
+        <span class="console-text">${escapeHtml(c.text)}</span>
+      </div>`;
+  }).join('');
+  return `
+    <details class="panel-details console-panel">
+      <summary>Console (${action.console.length})</summary>
+      <div class="panel-body">${rows}</div>
+    </details>`;
 }
 
 function renderActionCard(action: RecordingAction, screenshots: Map<string, string>): string {
@@ -125,6 +264,11 @@ function renderActionCard(action: RecordingAction, screenshots: Map<string, stri
     ? `<div class="action-url" title="${escapeHtml(action.url)}">&#x1F517; ${escapeHtml(action.url)}</div>`
     : '';
 
+  const contractPanel = renderContractPanel(action);
+  const verifyPanel = renderVerifyPanel(action);
+  const networkPanel = renderNetworkPanel(action);
+  const consolePanel = renderConsolePanel(action);
+
   return `
     <div class="action-card ${statusClass}" data-seq="${action.seq}" data-tool="${escapeHtml(action.tool)}" data-ok="${action.ok}">
       <div class="action-header">
@@ -144,6 +288,10 @@ function renderActionCard(action: RecordingAction, screenshots: Map<string, stri
         <pre class="args-json"><code>${argsJson}</code></pre>
       </details>
       ${screenshotSection}
+      ${contractPanel}
+      ${verifyPanel}
+      ${networkPanel}
+      ${consolePanel}
     </div>`;
 }
 
@@ -169,6 +317,11 @@ export function generateHtmlReport(
   const toolOptions = stats.toolsUsed
     .map(t => `<option value="${escapeHtml(t)}">${escapeHtml(t)}</option>`)
     .join('\n');
+
+  const hasContracts = (stats.contractPass + stats.contractFail + stats.contractInconclusive) > 0;
+  const contractsSummaryRow = hasContracts
+    ? `<div class="meta-item"><strong>Contracts:</strong> <span style="color:var(--ok)">${stats.contractPass} pass</span> / <span style="color:var(--fail)">${stats.contractFail} fail</span> / <span style="color:var(--text-muted)">${stats.contractInconclusive} inconclusive</span></div>`
+    : '';
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -496,6 +649,120 @@ export function generateHtmlReport(
 
     /* hidden by filter */
     .action-card.hidden { display: none; }
+
+    /* ── Outcome panels (contract, verify, network, console) ── */
+    .panel-details {
+      margin-top: 8px;
+    }
+
+    .panel-details summary {
+      font-size: 11px;
+      color: var(--text-muted);
+      cursor: pointer;
+      user-select: none;
+      padding: 2px 0;
+    }
+
+    .panel-details summary:hover { color: var(--text); }
+
+    .panel-body {
+      margin-top: 6px;
+    }
+
+    .panel-json {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 8px;
+      overflow-x: auto;
+      font-family: var(--font-mono);
+      font-size: 11px;
+      line-height: 1.5;
+      color: #a5b4fc;
+      white-space: pre;
+      margin: 4px 0;
+    }
+
+    /* Contract panel */
+    .contract-row {
+      margin-bottom: 8px;
+      padding: 6px;
+      background: var(--surface2);
+      border-radius: 4px;
+      border: 1px solid var(--border);
+    }
+
+    .contract-row.truncated {
+      font-size: 11px;
+      color: var(--text-muted);
+      font-style: italic;
+    }
+
+    .verdict-badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 99px;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      margin-bottom: 4px;
+    }
+
+    .verdict-pass        { background: rgba(34,197,94,0.2);   color: #4ade80; }
+    .verdict-fail        { background: rgba(239,68,68,0.2);   color: #fca5a5; }
+    .verdict-inconclusive { background: rgba(107,114,128,0.2); color: #9ca3af; }
+
+    /* Network panel */
+    .panel-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 11px;
+      font-family: var(--font-mono);
+    }
+
+    .panel-table th {
+      text-align: left;
+      padding: 4px 8px;
+      color: var(--text-muted);
+      border-bottom: 1px solid var(--border);
+      font-weight: 600;
+    }
+
+    .panel-table td {
+      padding: 3px 8px;
+      color: var(--text);
+      border-bottom: 1px solid rgba(42,42,90,0.5);
+      word-break: break-all;
+    }
+
+    .net-method { color: #93c5fd; min-width: 60px; }
+    .net-status { min-width: 50px; }
+    .net-dur    { min-width: 70px; color: var(--text-muted); }
+
+    .truncation-marker td {
+      color: var(--text-muted);
+      font-style: italic;
+      padding: 4px 8px;
+    }
+
+    /* Console panel */
+    .console-row {
+      display: flex;
+      gap: 8px;
+      font-size: 11px;
+      font-family: var(--font-mono);
+      padding: 2px 4px;
+      border-radius: 2px;
+    }
+
+    .console-log   { color: var(--text); }
+    .console-warn  { color: #fbbf24; background: rgba(251,191,36,0.05); }
+    .console-error { color: #fca5a5; background: rgba(239,68,68,0.05); }
+
+    .console-time  { color: var(--text-muted); min-width: 90px; }
+    .console-level { min-width: 40px; font-weight: 600; }
+    .console-text  { flex: 1; word-break: break-word; white-space: pre-wrap; }
   </style>
 </head>
 <body>
@@ -513,6 +780,7 @@ export function generateHtmlReport(
       <div class="meta-item"><strong>Stopped:</strong> ${escapeHtml(formatIso(metadata.stoppedAt))}</div>
       <div class="meta-item"><strong>Duration:</strong> ${escapeHtml(sessionDuration)}</div>
       <div class="meta-item"><strong>Actions:</strong> ${metadata.actionCount}</div>
+      ${contractsSummaryRow}
     </div>
   </header>
 

--- a/src/recording/recording-store.ts
+++ b/src/recording/recording-store.ts
@@ -7,7 +7,31 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { RecordingAction, RecordingMetadata, RecordingConfig, DEFAULT_RECORDING_CONFIG } from './types';
+import { RecordingAction, RecordingMetadata, RecordingConfig, DEFAULT_RECORDING_CONFIG, ContractResultEntry } from './types';
+
+/**
+ * Append-only sidecar row recorded by oc_assert when a contract result is
+ * attached to an already-flushed action. Persisted as a separate JSONL line so
+ * appendContractResult() can never clobber concurrent recordAction() writes.
+ *
+ * `actionIndex` is the `seq` of the action the result belongs to.
+ */
+interface ContractResultRow {
+  kind: 'contract_result';
+  actionIndex: number;
+  entry: ContractResultEntry;
+}
+
+function isContractResultRow(row: unknown): row is ContractResultRow {
+  if (!row || typeof row !== 'object') return false;
+  const r = row as Record<string, unknown>;
+  return (
+    r['kind'] === 'contract_result' &&
+    typeof r['actionIndex'] === 'number' &&
+    typeof r['entry'] === 'object' &&
+    r['entry'] !== null
+  );
+}
 
 /** Default base directory for all recordings */
 export const RECORDINGS_DIR = path.join(os.homedir(), '.openchrome', 'recordings');
@@ -93,6 +117,24 @@ export class RecordingStore {
   }
 
   /**
+   * Append a single contract-result sidecar row referencing an already-flushed
+   * action. Used by oc_assert so contract annotation never has to rewrite the
+   * actions file (which would race against concurrent recordAction() appends).
+   *
+   * Sidecar rows are merged back into their parent action on read via
+   * readActions().
+   */
+  async appendContractResultRow(
+    id: string,
+    actionIndex: number,
+    entry: ContractResultEntry,
+  ): Promise<void> {
+    const filepath = path.join(this.getRecordingDir(id), ACTIONS_FILE);
+    const row: ContractResultRow = { kind: 'contract_result', actionIndex, entry };
+    await fs.promises.appendFile(filepath, JSON.stringify(row) + '\n');
+  }
+
+  /**
    * Write (or overwrite) the metadata JSON file for a recording.
    */
   async writeMetadata(metadata: RecordingMetadata): Promise<void> {
@@ -118,21 +160,35 @@ export class RecordingStore {
   /**
    * Read all actions from a recording's JSONL file.
    * Skips malformed lines.
+   *
+   * Append-only `contract_result` sidecar rows (written by oc_assert) are
+   * merged into their parent action's `contractResults` array by matching
+   * `actionIndex` against `seq`. The 4 KB cap is re-applied after merging so
+   * a flurry of contract rows cannot bloat any one action beyond the limit.
    */
   readActions(id: string): RecordingAction[] {
     const filepath = path.join(this.getRecordingDir(id), ACTIONS_FILE);
     try {
       const content = fs.readFileSync(filepath, 'utf-8');
       const actions: RecordingAction[] = [];
+      const pendingResults: ContractResultRow[] = [];
       for (const line of content.split('\n')) {
         const trimmed = line.trim();
         if (!trimmed) continue;
+        let parsed: unknown;
         try {
-          actions.push(JSON.parse(trimmed) as RecordingAction);
+          parsed = JSON.parse(trimmed);
         } catch {
           // Skip malformed lines
+          continue;
+        }
+        if (isContractResultRow(parsed)) {
+          pendingResults.push(parsed);
+        } else {
+          actions.push(parsed as RecordingAction);
         }
       }
+      mergeContractResultRows(actions, pendingResults);
       return actions;
     } catch {
       return [];
@@ -251,6 +307,49 @@ export class RecordingStore {
     const d = new Date(`${year}-${month}-${day}T${hour}:${min}:${sec}Z`);
     return isNaN(d.getTime()) ? null : d.getTime();
   }
+}
+
+/** Maximum bytes for the merged `contractResults` array per action. */
+const CONTRACT_RESULTS_MAX_BYTES = 4096;
+
+/**
+ * Merge append-only contract_result rows into their parent actions, in-place.
+ * Re-applies the 4 KB cap so a long sequence of asserts cannot bloat an action
+ * past the documented limit. Sidecar rows whose `actionIndex` does not match
+ * any known action are silently dropped.
+ */
+function mergeContractResultRows(
+  actions: RecordingAction[],
+  rows: ContractResultRow[],
+): void {
+  if (rows.length === 0) return;
+  const bySeq = new Map<number, RecordingAction>();
+  for (const a of actions) bySeq.set(a.seq, a);
+
+  for (const row of rows) {
+    const target = bySeq.get(row.actionIndex);
+    if (!target) continue;
+    const existing = target.contractResults ?? [];
+    existing.push(row.entry);
+    target.contractResults = capContractResultsByBytes(existing);
+  }
+}
+
+/**
+ * Enforce the documented 4 KB byte cap on a contractResults array. If the
+ * total serialized size exceeds the cap, replace the array with a single
+ * truncation marker matching the shape used by applyContractResultsBounds().
+ */
+function capContractResultsByBytes(
+  entries: ContractResultEntry[],
+): ContractResultEntry[] {
+  if (entries.length === 0) return entries;
+  const json = JSON.stringify(entries);
+  const bytes = Buffer.byteLength(json, 'utf8');
+  if (bytes > CONTRACT_RESULTS_MAX_BYTES) {
+    return [{ truncated: true, originalBytes: bytes } as unknown as ContractResultEntry];
+  }
+  return entries;
 }
 
 /** Singleton instance */

--- a/src/recording/types.ts
+++ b/src/recording/types.ts
@@ -4,6 +4,38 @@
  */
 
 /**
+ * A single Outcome Contract assertion result attached to a recorded action.
+ */
+export interface ContractResultEntry {
+  /** Verbatim Assertion JSON from the DSL */
+  assertion: unknown;
+  /** Evaluation verdict */
+  verdict: 'pass' | 'fail' | 'inconclusive';
+  /** Implementation-defined evidence details */
+  details?: Record<string, unknown>;
+}
+
+/**
+ * A single network request entry attached to a recorded action.
+ */
+export interface NetworkEntry {
+  method: string;
+  url: string;
+  status?: number;
+  durationMs?: number;
+}
+
+/**
+ * A single console message entry attached to a recorded action.
+ */
+export interface ConsoleEntry {
+  level: 'log' | 'warn' | 'error';
+  text: string;
+  /** Unix timestamp in milliseconds */
+  ts: number;
+}
+
+/**
  * A single recorded action within a session recording.
  */
 export interface RecordingAction {
@@ -31,6 +63,14 @@ export interface RecordingAction {
   screenshotBefore?: string;
   /** Filename of screenshot taken after the action */
   screenshotAfter?: string;
+  /** Outcome Contract assertion results for this action (≤ 4 KB total JSON) */
+  contractResults?: ContractResultEntry[];
+  /** Verbatim verify block from the tool response, if present */
+  verify?: Record<string, unknown>;
+  /** Network requests correlated with this action (≤ 20 entries) */
+  network?: NetworkEntry[];
+  /** Console messages emitted during this action (≤ 20 entries) */
+  console?: ConsoleEntry[];
 }
 
 /**

--- a/src/tools/oc-assert.ts
+++ b/src/tools/oc-assert.ts
@@ -25,6 +25,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { evaluate } from '../contracts/evaluate';
 import { validateAssertion } from '../contracts/validator';
+import { getActiveActionRecorder } from '../recording/action-recorder';
 import type { EvalContext, NetworkLogEntry } from '../contracts/eval-context';
 import type {
   Assertion,
@@ -273,7 +274,7 @@ function isInconclusive(evidence: Evidence): boolean {
 }
 
 const handler: ToolHandler = async (
-  _sessionId: string,
+  sessionId: string,
   args: Record<string, unknown>,
 ): Promise<MCPResult> => {
   const contractInline = args.contract;
@@ -357,6 +358,19 @@ const handler: ToolHandler = async (
       typeof result.evidence.details.error === 'string'
         ? (result.evidence.details.error as string)
         : 'evaluation was inconclusive';
+  }
+
+  // Wire into active recording: append verdict to most-recent action's contractResults.
+  // No-op if no recording is active for this session or if no action has been recorded yet.
+  const recorder = getActiveActionRecorder(sessionId);
+  if (recorder) {
+    recorder.appendContractResult({
+      assertion: contractInline,
+      verdict,
+      details: result.evidence.details as Record<string, unknown> | undefined,
+    }).catch((err: unknown) => {
+      console.error('[oc_assert] Failed to append contract result to recorder:', err instanceof Error ? err.message : err);
+    });
   }
 
   return jsonResult(output);

--- a/tests/cli/replay.test.ts
+++ b/tests/cli/replay.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Tests for cli/replay.ts — subcommand wiring and exit codes.
+ *
+ * Uses the same in-process harness pattern as tests/cli/admin-keys.test.ts:
+ * intercept process.stdout/stderr/exit, drive registerReplayCommand() through
+ * a local commander Command instance.
+ *
+ * The CLI's loadReplayViewerModule() and loadRecordingStoreModule() call
+ * require('../recording/replay-viewer.js') and require('../recording/recording-store.js').
+ * Jest's moduleNameMapper strips the .js, so they resolve to the source modules
+ * which we can mock via jest.mock().
+ *
+ * Exit codes:
+ *   0 — success (null exitCode = clean return)
+ *   2 — unknown recording id / usage error
+ *   3 — I/O error
+ *
+ * Part of #852: replay HTML report enrichment.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Command } from 'commander';
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+// These mock the modules that cli/replay.ts loads at runtime via require().
+// Jest's moduleNameMapper strips the .js extension so '../recording/replay-viewer.js'
+// resolves to '../../src/recording/replay-viewer' from the test root.
+
+const mockGenerateReport = jest.fn<Promise<string>, [string]>();
+const mockGenerateTerminalReplay = jest.fn<Promise<string>, [string]>();
+const mockInit = jest.fn<Promise<void>, []>();
+const mockListRecordings = jest.fn<Promise<string[]>, []>();
+const mockReadMetadata = jest.fn();
+const mockReadActions = jest.fn();
+
+jest.mock('../../src/recording/replay-viewer', () => ({
+  getReplayViewer: () => ({
+    generateReport: mockGenerateReport,
+    generateTerminalReplay: mockGenerateTerminalReplay,
+  }),
+  // ReplayViewer class also exported — passthrough
+  ReplayViewer: jest.fn(),
+}));
+
+jest.mock('../../src/recording/recording-store', () => ({
+  getRecordingStore: () => ({
+    init: mockInit,
+    listRecordings: mockListRecordings,
+    readMetadata: mockReadMetadata,
+    readActions: mockReadActions,
+  }),
+  RecordingStore: jest.fn(),
+}));
+
+// Import AFTER mocks are set up
+import { registerReplayCommand } from '../../cli/replay';
+
+// ── In-process harness ───────────────────────────────────────────────────────
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+class ExitCalled extends Error {
+  constructor(public readonly code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+async function runCli(argv: string[]): Promise<RunResult> {
+  const program = new Command();
+  program.exitOverride((err) => { throw err; });
+  registerReplayCommand(program);
+
+  let stdout = '';
+  let stderr = '';
+  let exitCode: number | null = null;
+
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  const origLogErr = console.error;
+  const origExit = process.exit;
+
+  (process.stdout.write as unknown as (chunk: string | Uint8Array) => boolean) =
+    (chunk: string | Uint8Array) => {
+      stdout += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+      return true;
+    };
+  (process.stderr.write as unknown as (chunk: string | Uint8Array) => boolean) =
+    (chunk: string | Uint8Array) => {
+      stderr += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+      return true;
+    };
+  console.error = (...args: unknown[]) => {
+    stderr += args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ') + '\n';
+  };
+  process.exit = ((code?: number) => {
+    exitCode = code ?? 0;
+    throw new ExitCalled(exitCode);
+  }) as typeof process.exit;
+
+  try {
+    await program.parseAsync(['node', 'openchrome', ...argv]);
+  } catch (err) {
+    if (err instanceof ExitCalled) {
+      // expected
+    } else if (err && typeof err === 'object' && 'exitCode' in (err as Record<string, unknown>)) {
+      exitCode = (err as { exitCode?: number }).exitCode ?? 1;
+    } else {
+      process.stdout.write = origOut;
+      process.stderr.write = origErr;
+      console.error = origLogErr;
+      process.exit = origExit;
+      throw err;
+    }
+  } finally {
+    process.stdout.write = origOut;
+    process.stderr.write = origErr;
+    console.error = origLogErr;
+    process.exit = origExit;
+  }
+
+  return { stdout, stderr, exitCode };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockInit.mockResolvedValue(undefined);
+  mockListRecordings.mockResolvedValue([]);
+  mockReadMetadata.mockResolvedValue(null);
+  mockReadActions.mockReturnValue([]);
+  mockGenerateReport.mockResolvedValue('/tmp/report.html');
+  mockGenerateTerminalReplay.mockResolvedValue('=== Recording Replay ===\n');
+});
+
+// ── replay list ───────────────────────────────────────────────────────────────
+
+describe('replay list', () => {
+  it('prints header table to stderr when recordings exist', async () => {
+    mockListRecordings.mockResolvedValue(['rec-20240101-120000-aaa']);
+    mockReadMetadata.mockResolvedValue({
+      id: 'rec-20240101-120000-aaa',
+      sessionId: 'sess-1',
+      startedAt: '2024-01-01T12:00:00.000Z',
+      stoppedAt: '2024-01-01T12:05:00.000Z',
+      actionCount: 3,
+      label: 'smoke',
+    });
+    mockReadActions.mockReturnValue([{ ok: true }, { ok: true }, { ok: false }]);
+
+    const { stderr, exitCode } = await runCli(['replay', 'list']);
+
+    expect(exitCode).toBeNull();
+    expect(stderr).toContain('rec-20240101-120000-aaa');
+    expect(stderr).toContain('Recording ID');
+    expect(stderr).toContain('Actions');
+    expect(stderr).toContain('Success Rate');
+    expect(stderr).toContain('Last Activity');
+    expect(stderr).toContain('smoke');
+  });
+
+  it('shows "No recordings found" when store is empty', async () => {
+    mockListRecordings.mockResolvedValue([]);
+
+    const { stderr, exitCode } = await runCli(['replay', 'list']);
+
+    expect(exitCode).toBeNull();
+    expect(stderr).toContain('No recordings found');
+  });
+
+  it('exits 3 when store.init throws', async () => {
+    mockInit.mockRejectedValue(new Error('disk error'));
+
+    const { exitCode, stderr } = await runCli(['replay', 'list']);
+
+    expect(exitCode).toBe(3);
+    expect(stderr).toContain('disk error');
+  });
+
+  it('calculates success rate correctly (3/4 = 75%)', async () => {
+    mockListRecordings.mockResolvedValue(['rec-test-rate']);
+    mockReadMetadata.mockResolvedValue({
+      id: 'rec-test-rate',
+      sessionId: 'sess-x',
+      startedAt: '2024-01-01T12:00:00.000Z',
+      actionCount: 4,
+    });
+    mockReadActions.mockReturnValue([{ ok: true }, { ok: true }, { ok: true }, { ok: false }]);
+
+    const { stderr } = await runCli(['replay', 'list']);
+    expect(stderr).toContain('75%');
+  });
+
+  it('shows N/A success rate when no actions', async () => {
+    mockListRecordings.mockResolvedValue(['rec-empty']);
+    mockReadMetadata.mockResolvedValue({
+      id: 'rec-empty',
+      sessionId: 'sess-y',
+      startedAt: '2024-01-01T12:00:00.000Z',
+      actionCount: 0,
+    });
+    mockReadActions.mockReturnValue([]);
+
+    const { stderr } = await runCli(['replay', 'list']);
+    expect(stderr).toContain('N/A');
+  });
+});
+
+// ── replay report ─────────────────────────────────────────────────────────────
+
+describe('replay report', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-replay-report-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('prints the generated report path to stdout on success', async () => {
+    const expectedPath = '/tmp/report.html';
+    mockGenerateReport.mockResolvedValue(expectedPath);
+
+    const { stdout, exitCode } = await runCli(['replay', 'report', 'rec-20240101-120000-aaa']);
+
+    expect(exitCode).toBeNull();
+    expect(stdout.trim()).toBe(expectedPath);
+  });
+
+  it('exits 2 when recording not found', async () => {
+    mockGenerateReport.mockRejectedValue(new Error('Recording not found: rec-does-not-exist'));
+
+    const { exitCode, stderr } = await runCli(['replay', 'report', 'rec-does-not-exist']);
+
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('rec-does-not-exist');
+  });
+
+  it('exits 2 with "Invalid recording id" message', async () => {
+    mockGenerateReport.mockRejectedValue(new Error('Invalid recording id'));
+
+    const { exitCode } = await runCli(['replay', 'report', 'bad-id']);
+
+    expect(exitCode).toBe(2);
+  });
+
+  it('exits 3 on generic I/O error from generateReport', async () => {
+    mockGenerateReport.mockRejectedValue(new Error('ENOSPC: no space left on device'));
+
+    const { exitCode, stderr } = await runCli(['replay', 'report', 'rec-20240101-120000-aaa']);
+
+    expect(exitCode).toBe(3);
+    expect(stderr).toContain('ENOSPC');
+  });
+
+  it('copies rendered HTML to --out path and prints dest to stdout', async () => {
+    // Create a real source file for the copy
+    const srcPath = path.join(tmpDir, 'source-report.html');
+    fs.writeFileSync(srcPath, '<!DOCTYPE html><html></html>');
+    const destPath = path.join(tmpDir, 'out-report.html');
+    mockGenerateReport.mockResolvedValue(srcPath);
+
+    const { stdout, exitCode } = await runCli([
+      'replay', 'report', 'rec-20240101-120000-aaa', '--out', destPath,
+    ]);
+
+    expect(exitCode).toBeNull();
+    expect(stdout.trim()).toBe(destPath);
+    expect(fs.existsSync(destPath)).toBe(true);
+    expect(fs.readFileSync(destPath, 'utf-8')).toContain('<!DOCTYPE html>');
+  });
+
+  it('exits 3 when --out destination directory does not exist', async () => {
+    const srcPath = path.join(tmpDir, 'source.html');
+    fs.writeFileSync(srcPath, '<html/>');
+    mockGenerateReport.mockResolvedValue(srcPath);
+
+    const destPath = path.join(tmpDir, 'nonexistent-dir', 'out.html');
+    const { exitCode, stderr } = await runCli([
+      'replay', 'report', 'rec-20240101-120000-aaa', '--out', destPath,
+    ]);
+
+    expect(exitCode).toBe(3);
+    expect(stderr).toContain('nonexistent-dir');
+  });
+});
+
+// ── replay terminal ───────────────────────────────────────────────────────────
+
+describe('replay terminal', () => {
+  it('prints terminal replay output to stdout', async () => {
+    const fakeOutput = '=== Recording Replay ===\n#1 navigate OK 150ms\n';
+    mockGenerateTerminalReplay.mockResolvedValue(fakeOutput);
+
+    const { stdout, exitCode } = await runCli(['replay', 'terminal', 'rec-20240101-120000-aaa']);
+
+    expect(exitCode).toBeNull();
+    expect(stdout).toContain('Recording Replay');
+    expect(stdout).toContain('navigate');
+  });
+
+  it('exits 2 when recording not found', async () => {
+    mockGenerateTerminalReplay.mockRejectedValue(
+      new Error('Recording not found: rec-missing'),
+    );
+
+    const { exitCode, stderr } = await runCli(['replay', 'terminal', 'rec-missing']);
+
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('rec-missing');
+  });
+
+  it('exits 3 on generic error from generateTerminalReplay', async () => {
+    mockGenerateTerminalReplay.mockRejectedValue(new Error('disk read error'));
+
+    const { exitCode, stderr } = await runCli(['replay', 'terminal', 'rec-20240101-120000-aaa']);
+
+    expect(exitCode).toBe(3);
+    expect(stderr).toContain('disk read error');
+  });
+});

--- a/tests/recording/action-recorder.bounds.test.ts
+++ b/tests/recording/action-recorder.bounds.test.ts
@@ -417,3 +417,114 @@ describe('getActiveActionRecorder()', () => {
     unregisterSessionRecorder('sess-reg-test'); // cleanup
   });
 });
+
+// ── concurrency — append-only contract rows ──────────────────────────────────
+
+describe('ActionRecorder — concurrent appendContractResult + recordAction', () => {
+  let dir: string;
+  let store: RecordingStore;
+  let recorder: ActionRecorder;
+
+  beforeEach(() => {
+    dir = makeTmpDir();
+    store = new RecordingStore(dir);
+    recorder = new ActionRecorder(store, { captureScreenshots: false });
+  });
+
+  afterEach(() => {
+    cleanupDir(dir);
+  });
+
+  it('does not drop a concurrent action when a contract result is appended', async () => {
+    await recorder.start('sess-concurrent');
+    const id = recorder.activeRecordingId!;
+
+    // Seed one action so appendContractResult() has a target.
+    await recorder.recordAction('navigate', { url: 'https://example.com' }, 100, true);
+
+    // Race a contract-result append against a fresh recordAction(). Pre-fix
+    // (read-modify-write) one of these writes would clobber the other.
+    await Promise.all([
+      recorder.appendContractResult({
+        assertion: { kind: 'url', pattern: 'example.com' },
+        verdict: 'pass',
+      }),
+      recorder.recordAction('read_page', {}, 50, true),
+    ]);
+
+    const actions = store.readActions(id);
+    // Both source actions must survive.
+    expect(actions).toHaveLength(2);
+    expect(actions[0].seq).toBe(1);
+    expect(actions[1].seq).toBe(2);
+    // The contract result must land on its declared actionIndex (seq=1).
+    expect(actions[0].contractResults).toHaveLength(1);
+    expect(actions[0].contractResults![0].verdict).toBe('pass');
+    expect(actions[1].contractResults).toBeUndefined();
+  });
+
+  it('survives a flurry of interleaved contract + action appends without loss', async () => {
+    await recorder.start('sess-flurry');
+    const id = recorder.activeRecordingId!;
+
+    await recorder.recordAction('navigate', { url: 'https://example.com' }, 100, true);
+
+    const ops: Promise<void>[] = [];
+    for (let i = 0; i < 10; i++) {
+      ops.push(
+        recorder.appendContractResult({
+          assertion: { kind: 'url', pattern: `p${i}` },
+          verdict: 'pass',
+        }),
+      );
+      ops.push(recorder.recordAction(`tool_${i}`, {}, 10, true));
+    }
+    await Promise.all(ops);
+
+    const actions = store.readActions(id);
+    // 1 seeded + 10 concurrent recordAction() calls = 11.
+    expect(actions).toHaveLength(11);
+    // No seq gaps.
+    expect(actions.map(a => a.seq).sort((x, y) => x - y)).toEqual(
+      Array.from({ length: 11 }, (_, i) => i + 1),
+    );
+  });
+});
+
+// ── byte-length cap — UTF-8 accuracy ─────────────────────────────────────────
+
+describe('ActionRecorder — contractResults byte-length cap (UTF-8)', () => {
+  let dir: string;
+  let store: RecordingStore;
+  let recorder: ActionRecorder;
+
+  beforeEach(() => {
+    dir = makeTmpDir();
+    store = new RecordingStore(dir);
+    recorder = new ActionRecorder(store, { captureScreenshots: false });
+  });
+
+  afterEach(() => {
+    cleanupDir(dir);
+  });
+
+  it('measures size in UTF-8 bytes (non-ASCII no longer underestimated)', async () => {
+    await recorder.start('sess-utf8');
+    const id = recorder.activeRecordingId!;
+
+    // Each "あ" is 1 UTF-16 code unit but 3 UTF-8 bytes. 1500 chars → ~4500 bytes,
+    // which exceeds the 4 KB cap by UTF-8 byte count but NOT by .length.
+    const bigEntry: ContractResultEntry = {
+      assertion: { kind: 'dom_text', selector: 'body', contains: 'あ'.repeat(1500) },
+      verdict: 'pass',
+    };
+    await recorder.recordAction('navigate', {}, 100, true, { contractResults: [bigEntry] });
+
+    const actions = store.readActions(id);
+    const cr = actions[0].contractResults as unknown as Array<{ truncated: boolean; originalBytes: number }>;
+    expect(cr).toHaveLength(1);
+    expect(cr[0].truncated).toBe(true);
+    // originalBytes must reflect UTF-8 byte size, well above 4096.
+    expect(cr[0].originalBytes).toBeGreaterThan(4096);
+  });
+});

--- a/tests/recording/action-recorder.bounds.test.ts
+++ b/tests/recording/action-recorder.bounds.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Tests for ActionRecorder bounds enforcement on the four new optional fields:
+ * contractResults (4 KB cap), network (20-entry cap), console (20-entry cap),
+ * verify (pass-through). Also covers appendContractResult() and
+ * getActiveActionRecorder() registry.
+ * Part of #852: replay HTML report enrichment.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  ActionRecorder,
+  getActiveActionRecorder,
+  registerSessionRecorder,
+  unregisterSessionRecorder,
+} from '../../src/recording/action-recorder';
+import { RecordingStore } from '../../src/recording/recording-store';
+import { ContractResultEntry, NetworkEntry, ConsoleEntry } from '../../src/recording/types';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeTmpDir(): string {
+  const dir = path.join(os.tmpdir(), `bounds-test-${Math.random().toString(36).slice(2)}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function cleanupDir(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+// ── contractResults — 4 KB cap ────────────────────────────────────────────────
+
+describe('ActionRecorder — contractResults bounds (4 KB cap)', () => {
+  let dir: string;
+  let store: RecordingStore;
+  let recorder: ActionRecorder;
+
+  beforeEach(() => {
+    dir = makeTmpDir();
+    store = new RecordingStore(dir);
+    recorder = new ActionRecorder(store, { captureScreenshots: false });
+  });
+
+  afterEach(() => {
+    cleanupDir(dir);
+  });
+
+  it('stores contractResults under 4 KB unchanged', async () => {
+    await recorder.start('sess-1');
+    const id = recorder.activeRecordingId!;
+
+    const entries: ContractResultEntry[] = [
+      { assertion: { kind: 'url', pattern: 'example.com' }, verdict: 'pass' },
+    ];
+    await recorder.recordAction('navigate', {}, 100, true, { contractResults: entries });
+
+    const actions = store.readActions(id);
+    expect(actions[0].contractResults).toEqual(entries);
+  });
+
+  it('replaces contractResults > 4 KB with truncation placeholder', async () => {
+    await recorder.start('sess-1');
+    const id = recorder.activeRecordingId!;
+
+    // Build a payload that exceeds 4096 bytes when JSON-stringified
+    const bigEntry: ContractResultEntry = {
+      assertion: { kind: 'dom_text', selector: 'body', contains: 'x'.repeat(5000) },
+      verdict: 'pass',
+    };
+    await recorder.recordAction('navigate', {}, 100, true, { contractResults: [bigEntry] });
+
+    const actions = store.readActions(id);
+    const cr = actions[0].contractResults as unknown as Array<{ truncated: boolean; originalBytes: number }>;
+    expect(cr).toHaveLength(1);
+    expect(cr[0].truncated).toBe(true);
+    expect(typeof cr[0].originalBytes).toBe('number');
+    expect(cr[0].originalBytes).toBeGreaterThan(4096);
+  });
+
+  it('stores empty contractResults as absent (not written)', async () => {
+    await recorder.start('sess-1');
+    const id = recorder.activeRecordingId!;
+
+    await recorder.recordAction('navigate', {}, 100, true, { contractResults: [] });
+
+    const actions = store.readActions(id);
+    expect(actions[0].contractResults).toBeUndefined();
+  });
+});
+
+// ── network — 20-entry cap ────────────────────────────────────────────────────
+
+describe('ActionRecorder — network bounds (20-entry cap)', () => {
+  let dir: string;
+  let store: RecordingStore;
+  let recorder: ActionRecorder;
+
+  beforeEach(() => {
+    dir = makeTmpDir();
+    store = new RecordingStore(dir);
+    recorder = new ActionRecorder(store, { captureScreenshots: false });
+  });
+
+  afterEach(() => {
+    cleanupDir(dir);
+  });
+
+  it('stores network entries <= 20 unchanged', async () => {
+    await recorder.start('sess-1');
+    const id = recorder.activeRecordingId!;
+
+    const network: NetworkEntry[] = Array.from({ length: 20 }, (_, i) => ({
+      method: 'GET',
+      url: `https://example.com/r${i}`,
+      status: 200,
+    }));
+    await recorder.recordAction('navigate', {}, 100, true, { network });
+
+    const actions = store.readActions(id);
+    expect(actions[0].network).toHaveLength(20);
+  });
+
+  it('clips network to 20 entries and appends truncation marker for 25 entries', async () => {
+    await recorder.start('sess-1');
+    const id = recorder.activeRecordingId!;
+
+    const network: NetworkEntry[] = Array.from({ length: 25 }, (_, i) => ({
+      method: 'GET',
+      url: `https://example.com/r${i}`,
+      status: 200,
+    }));
+    await recorder.recordAction('navigate', {}, 100, true, { network });
+
+    const actions = store.readActions(id);
+    const stored = actions[0].network!;
+    expect(stored).toHaveLength(21); // 20 real + 1 marker
+    expect(stored[20].method).toBe('');
+    expect(stored[20].url).toContain('+5 more');
+    expect(stored[20].url).toContain('truncated');
+  });
+
+  it('truncation marker says +N for N = over-count', async () => {
+    await recorder.start('sess-1');
+    const id = recorder.activeRecordingId!;
+
+    const network: NetworkEntry[] = Array.from({ length: 30 }, (_, i) => ({
+      method: 'POST',
+      url: `https://example.com/x${i}`,
+    }));
+    await recorder.recordAction('navigate', {}, 100, true, { network });
+
+    const actions = store.readActions(id);
+    const marker = actions[0].network![20];
+    expect(marker.url).toContain('+10 more');
+  });
+
+  it('stores absent network field unchanged (no field written)', async () => {
+    await recorder.start('sess-1');
+    const id = recorder.activeRecordingId!;
+
+    await recorder.recordAction('navigate', {}, 100, true);
+
+    const actions = store.readActions(id);
+    expect(actions[0].network).toBeUndefined();
+  });
+});
+
+// ── console — 20-entry cap ────────────────────────────────────────────────────
+
+describe('ActionRecorder — console bounds (20-entry cap)', () => {
+  let dir: string;
+  let store: RecordingStore;
+  let recorder: ActionRecorder;
+
+  beforeEach(() => {
+    dir = makeTmpDir();
+    store = new RecordingStore(dir);
+    recorder = new ActionRecorder(store, { captureScreenshots: false });
+  });
+
+  afterEach(() => {
+    cleanupDir(dir);
+  });
+
+  it('stores console entries <= 20 unchanged', async () => {
+    await recorder.start('sess-1');
+    const id = recorder.activeRecordingId!;
+
+    const consoleEntries: ConsoleEntry[] = Array.from({ length: 20 }, (_, i) => ({
+      level: 'log' as const,
+      text: `msg ${i}`,
+      ts: Date.now() + i,
+    }));
+    await recorder.recordAction('navigate', {}, 100, true, { console: consoleEntries });
+
+    const actions = store.readActions(id);
+    expect(actions[0].console).toHaveLength(20);
+  });
+
+  it('clips console to 20 and appends truncation marker for 25 entries', async () => {
+    await recorder.start('sess-1');
+    const id = recorder.activeRecordingId!;
+
+    const consoleEntries: ConsoleEntry[] = Array.from({ length: 25 }, (_, i) => ({
+      level: 'warn' as const,
+      text: `warn ${i}`,
+      ts: Date.now() + i,
+    }));
+    await recorder.recordAction('navigate', {}, 100, true, { console: consoleEntries });
+
+    const actions = store.readActions(id);
+    const stored = actions[0].console!;
+    expect(stored).toHaveLength(21); // 20 real + 1 marker
+    expect(stored[20].level).toBe('log');
+    expect(stored[20].text).toContain('+5 more');
+    expect(stored[20].text).toContain('truncated');
+  });
+
+  it('truncation marker ts is a number', async () => {
+    await recorder.start('sess-1');
+    const id = recorder.activeRecordingId!;
+
+    const consoleEntries: ConsoleEntry[] = Array.from({ length: 21 }, (_, i) => ({
+      level: 'error' as const,
+      text: `err ${i}`,
+      ts: 1000 + i,
+    }));
+    await recorder.recordAction('navigate', {}, 100, true, { console: consoleEntries });
+
+    const actions = store.readActions(id);
+    const marker = actions[0].console![20];
+    expect(typeof marker.ts).toBe('number');
+  });
+
+  it('stores absent console field as undefined', async () => {
+    await recorder.start('sess-1');
+    const id = recorder.activeRecordingId!;
+
+    await recorder.recordAction('navigate', {}, 100, true);
+    const actions = store.readActions(id);
+    expect(actions[0].console).toBeUndefined();
+  });
+});
+
+// ── verify — pass-through ─────────────────────────────────────────────────────
+
+describe('ActionRecorder — verify pass-through', () => {
+  let dir: string;
+  let store: RecordingStore;
+  let recorder: ActionRecorder;
+
+  beforeEach(() => {
+    dir = makeTmpDir();
+    store = new RecordingStore(dir);
+    recorder = new ActionRecorder(store, { captureScreenshots: false });
+  });
+
+  afterEach(() => {
+    cleanupDir(dir);
+  });
+
+  it('stores verify block verbatim', async () => {
+    await recorder.start('sess-1');
+    const id = recorder.activeRecordingId!;
+
+    const verify = { ax_diff: { changed: true }, screenshot: { phash_distance: 8 } };
+    await recorder.recordAction('interact', {}, 200, true, { verify });
+
+    const actions = store.readActions(id);
+    expect(actions[0].verify).toEqual(verify);
+  });
+
+  it('omits verify field when not provided', async () => {
+    await recorder.start('sess-1');
+    const id = recorder.activeRecordingId!;
+
+    await recorder.recordAction('navigate', {}, 100, true);
+    const actions = store.readActions(id);
+    expect(actions[0].verify).toBeUndefined();
+  });
+});
+
+// ── appendContractResult() ────────────────────────────────────────────────────
+
+describe('ActionRecorder.appendContractResult()', () => {
+  let dir: string;
+  let store: RecordingStore;
+  let recorder: ActionRecorder;
+
+  beforeEach(() => {
+    dir = makeTmpDir();
+    store = new RecordingStore(dir);
+    recorder = new ActionRecorder(store, { captureScreenshots: false });
+  });
+
+  afterEach(() => {
+    cleanupDir(dir);
+  });
+
+  it('is a no-op when not recording', async () => {
+    await expect(
+      recorder.appendContractResult({ assertion: {}, verdict: 'pass' }),
+    ).resolves.not.toThrow();
+  });
+
+  it('is a no-op when recording but no actions have been recorded yet', async () => {
+    await recorder.start('sess-1');
+    const id = recorder.activeRecordingId!;
+
+    await recorder.appendContractResult({ assertion: {}, verdict: 'pass' });
+
+    const actions = store.readActions(id);
+    expect(actions).toHaveLength(0);
+  });
+
+  it('appends a contract result to the most recent action', async () => {
+    await recorder.start('sess-1');
+    const id = recorder.activeRecordingId!;
+
+    await recorder.recordAction('navigate', {}, 100, true);
+    await recorder.appendContractResult({
+      assertion: { kind: 'url', pattern: 'example.com' },
+      verdict: 'pass',
+    });
+
+    const actions = store.readActions(id);
+    expect(actions[0].contractResults).toHaveLength(1);
+    expect(actions[0].contractResults![0].verdict).toBe('pass');
+  });
+
+  it('appends to the last action, not the first', async () => {
+    await recorder.start('sess-1');
+    const id = recorder.activeRecordingId!;
+
+    await recorder.recordAction('navigate', {}, 100, true);
+    await recorder.recordAction('read_page', {}, 50, true);
+    await recorder.appendContractResult({ assertion: {}, verdict: 'fail' });
+
+    const actions = store.readActions(id);
+    expect(actions[0].contractResults).toBeUndefined();
+    expect(actions[1].contractResults).toHaveLength(1);
+    expect(actions[1].contractResults![0].verdict).toBe('fail');
+  });
+
+  it('accumulates multiple appendContractResult calls on the same action', async () => {
+    await recorder.start('sess-1');
+    const id = recorder.activeRecordingId!;
+
+    await recorder.recordAction('navigate', {}, 100, true);
+    await recorder.appendContractResult({ assertion: { a: 1 }, verdict: 'pass' });
+    await recorder.appendContractResult({ assertion: { b: 2 }, verdict: 'fail' });
+
+    const actions = store.readActions(id);
+    expect(actions[0].contractResults).toHaveLength(2);
+    expect(actions[0].contractResults![0].verdict).toBe('pass');
+    expect(actions[0].contractResults![1].verdict).toBe('fail');
+  });
+});
+
+// ── getActiveActionRecorder() registry ───────────────────────────────────────
+
+describe('getActiveActionRecorder()', () => {
+  let dir: string;
+  let store: RecordingStore;
+
+  beforeEach(() => {
+    dir = makeTmpDir();
+    store = new RecordingStore(dir);
+  });
+
+  afterEach(() => {
+    cleanupDir(dir);
+    unregisterSessionRecorder('sess-reg-test');
+  });
+
+  it('returns undefined when no recorder is registered for sessionId', () => {
+    expect(getActiveActionRecorder('sess-reg-test')).toBeUndefined();
+  });
+
+  it('returns the registered recorder when it is actively recording', async () => {
+    const recorder = new ActionRecorder(store, { captureScreenshots: false });
+    await recorder.start('sess-reg-test');
+    registerSessionRecorder('sess-reg-test', recorder);
+
+    const found = getActiveActionRecorder('sess-reg-test');
+    expect(found).toBe(recorder);
+
+    await recorder.stop();
+    unregisterSessionRecorder('sess-reg-test');
+  });
+
+  it('returns undefined after recorder is stopped and unregistered', async () => {
+    const recorder = new ActionRecorder(store, { captureScreenshots: false });
+    await recorder.start('sess-reg-test');
+    registerSessionRecorder('sess-reg-test', recorder);
+    await recorder.stop();
+    unregisterSessionRecorder('sess-reg-test');
+
+    expect(getActiveActionRecorder('sess-reg-test')).toBeUndefined();
+  });
+
+  it('returns undefined for a registered-but-stopped recorder (not unregistered)', async () => {
+    const recorder = new ActionRecorder(store, { captureScreenshots: false });
+    await recorder.start('sess-reg-test');
+    registerSessionRecorder('sess-reg-test', recorder);
+    await recorder.stop();
+    // deliberately NOT calling unregisterSessionRecorder
+
+    expect(getActiveActionRecorder('sess-reg-test')).toBeUndefined();
+
+    unregisterSessionRecorder('sess-reg-test'); // cleanup
+  });
+});

--- a/tests/recording/html-template.contract.test.ts
+++ b/tests/recording/html-template.contract.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests for html-template.ts — Outcome Contract panel rendering.
+ * Covers: pass/fail/inconclusive badges, truncation placeholder, contracts
+ * summary row in header, and P2 invariance (no contract data → no panel emitted).
+ * Part of #852: replay HTML report enrichment.
+ */
+
+import { generateHtmlReport } from '../../src/recording/html-template';
+import { RecordingAction, RecordingMetadata, ContractResultEntry } from '../../src/recording/types';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeMetadata(overrides: Partial<RecordingMetadata> = {}): RecordingMetadata {
+  return {
+    version: 1,
+    id: 'rec-20240101-120000-test',
+    sessionId: 'sess-abc123',
+    startedAt: '2024-01-01T12:00:00.000Z',
+    stoppedAt: '2024-01-01T12:05:30.000Z',
+    actionCount: 0,
+    ...overrides,
+  };
+}
+
+function makeAction(seq: number, overrides: Partial<RecordingAction> = {}): RecordingAction {
+  return {
+    seq,
+    ts: new Date('2024-01-01T12:00:00.000Z').getTime() + seq * 1000,
+    tool: 'navigate',
+    args: { url: `https://example${seq}.com` },
+    durationMs: 150,
+    ok: true,
+    summary: `Navigated to example${seq}.com`,
+    ...overrides,
+  };
+}
+
+// ── P2 invariance (no contract data) ──────────────────────────────────────────
+
+describe('generateHtmlReport — P2 invariance (no contract data)', () => {
+  it('omits contract-panel when contractResults is undefined', () => {
+    const action = makeAction(1);
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    // CSS defines .verdict-badge / .contract-panel so we check for rendered elements,
+    // not just the bare class names (which always appear in the stylesheet).
+    expect(html).not.toContain('class="panel-details contract-panel"');
+    expect(html).not.toContain('class="verdict-badge');
+    expect(html).not.toContain('Contracts (');
+  });
+
+  it('omits contract-panel when contractResults is empty array', () => {
+    const action = makeAction(1, { contractResults: [] });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).not.toContain('class="panel-details contract-panel"');
+    expect(html).not.toContain('class="verdict-badge');
+  });
+
+  it('omits contracts summary row from header when no contract data', () => {
+    const actions = [makeAction(1), makeAction(2)];
+    const html = generateHtmlReport(makeMetadata(), actions);
+
+    // The header row is only present when there are verdicts
+    expect(html).not.toContain('Contracts:');
+  });
+
+  it('is valid HTML5 with no contract data', () => {
+    const html = generateHtmlReport(makeMetadata(), [makeAction(1)]);
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('</html>');
+  });
+});
+
+// ── Contract panel rendering ──────────────────────────────────────────────────
+
+describe('generateHtmlReport — contract panel rendering', () => {
+  it('renders contract-panel details element when contractResults present', () => {
+    const entry: ContractResultEntry = {
+      assertion: { kind: 'url', pattern: 'example.com' },
+      verdict: 'pass',
+    };
+    const action = makeAction(1, { contractResults: [entry] });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('contract-panel');
+    expect(html).toContain('<details class="panel-details contract-panel">');
+  });
+
+  it('renders pass badge with verdict-pass class', () => {
+    const entry: ContractResultEntry = {
+      assertion: { kind: 'url', pattern: 'example.com' },
+      verdict: 'pass',
+    };
+    const action = makeAction(1, { contractResults: [entry] });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('verdict-pass');
+    expect(html).toContain('>pass<');
+  });
+
+  it('renders fail badge with verdict-fail class', () => {
+    const entry: ContractResultEntry = {
+      assertion: { kind: 'dom_text', selector: 'h1', contains: 'NotPresent' },
+      verdict: 'fail',
+    };
+    const action = makeAction(1, { contractResults: [entry] });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('verdict-fail');
+    expect(html).toContain('>fail<');
+  });
+
+  it('renders inconclusive badge with verdict-inconclusive class', () => {
+    const entry: ContractResultEntry = {
+      assertion: { kind: 'screenshot_class', class_id: 'login' },
+      verdict: 'inconclusive',
+    };
+    const action = makeAction(1, { contractResults: [entry] });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('verdict-inconclusive');
+    expect(html).toContain('>inconclusive<');
+  });
+
+  it('renders assertion JSON inside the panel', () => {
+    const assertion = { kind: 'url', pattern: 'example.com' };
+    const entry: ContractResultEntry = { assertion, verdict: 'pass' };
+    const action = makeAction(1, { contractResults: [entry] });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('example.com');
+    expect(html).toContain('panel-json');
+  });
+
+  it('renders details section when entry has details', () => {
+    const entry: ContractResultEntry = {
+      assertion: { kind: 'dom_text', selector: 'h1', contains: 'X' },
+      verdict: 'fail',
+      details: { text_preview: 'Hello World', text_length: 11 },
+    };
+    const action = makeAction(1, { contractResults: [entry] });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('text_preview');
+    expect(html).toContain('Hello World');
+  });
+
+  it('renders multiple contract entries in a single action', () => {
+    const entries: ContractResultEntry[] = [
+      { assertion: { kind: 'url', pattern: 'example.com' }, verdict: 'pass' },
+      { assertion: { kind: 'dom_text', selector: 'h1', contains: 'X' }, verdict: 'fail' },
+      { assertion: { kind: 'no_dialog' }, verdict: 'inconclusive' },
+    ];
+    const action = makeAction(1, { contractResults: entries });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('verdict-pass');
+    expect(html).toContain('verdict-fail');
+    expect(html).toContain('verdict-inconclusive');
+    expect(html).toContain('Contracts (3)');
+  });
+
+  it('shows count in summary element of details', () => {
+    const entries: ContractResultEntry[] = [
+      { assertion: { kind: 'url', pattern: 'a' }, verdict: 'pass' },
+      { assertion: { kind: 'url', pattern: 'b' }, verdict: 'fail' },
+    ];
+    const action = makeAction(1, { contractResults: entries });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('Contracts (2)');
+  });
+
+  it('escapes XSS in assertion JSON', () => {
+    const entry: ContractResultEntry = {
+      assertion: { kind: 'url', pattern: '<script>alert(1)</script>' },
+      verdict: 'pass',
+    };
+    const action = makeAction(1, { contractResults: [entry] });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});
+
+// ── Truncation placeholder ────────────────────────────────────────────────────
+
+describe('generateHtmlReport — contract truncation marker', () => {
+  it('renders truncation marker when truncated=true placeholder is stored', () => {
+    // Simulate what the recorder stores after bounds enforcement
+    const truncationPlaceholder = [{ truncated: true, originalBytes: 5000 }] as unknown as ContractResultEntry[];
+    const action = makeAction(1, { contractResults: truncationPlaceholder });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('Truncated');
+    expect(html).toContain('5000');
+    expect(html).toContain('4 KB');
+    expect(html).toContain('contract-row truncated');
+  });
+});
+
+// ── Contracts summary header row ──────────────────────────────────────────────
+
+describe('generateHtmlReport — contracts summary row', () => {
+  it('shows contracts summary row when at least one verdict exists', () => {
+    const action = makeAction(1, {
+      contractResults: [{ assertion: { kind: 'url', pattern: 'a' }, verdict: 'pass' }],
+    });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('Contracts:');
+    expect(html).toContain('1 pass');
+    expect(html).toContain('0 fail');
+    expect(html).toContain('0 inconclusive');
+  });
+
+  it('aggregates pass/fail/inconclusive across multiple actions', () => {
+    const actions = [
+      makeAction(1, {
+        contractResults: [
+          { assertion: {}, verdict: 'pass' },
+          { assertion: {}, verdict: 'pass' },
+        ],
+      }),
+      makeAction(2, {
+        contractResults: [{ assertion: {}, verdict: 'fail' }],
+      }),
+      makeAction(3, {
+        contractResults: [{ assertion: {}, verdict: 'inconclusive' }],
+      }),
+    ];
+    const html = generateHtmlReport(makeMetadata(), actions);
+
+    expect(html).toContain('2 pass');
+    expect(html).toContain('1 fail');
+    expect(html).toContain('1 inconclusive');
+  });
+
+  it('omits contracts summary row when no verdicts exist across all actions', () => {
+    const actions = [makeAction(1), makeAction(2)];
+    const html = generateHtmlReport(makeMetadata(), actions);
+    expect(html).not.toContain('Contracts:');
+  });
+});

--- a/tests/recording/html-template.network.test.ts
+++ b/tests/recording/html-template.network.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for html-template.ts — network panel rendering.
+ * Covers: normal rows, truncation at 20 entries, absent field = no panel,
+ * status/duration formatting, XSS escaping.
+ * Part of #852: replay HTML report enrichment.
+ */
+
+import { generateHtmlReport } from '../../src/recording/html-template';
+import { RecordingAction, RecordingMetadata, NetworkEntry } from '../../src/recording/types';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeMetadata(overrides: Partial<RecordingMetadata> = {}): RecordingMetadata {
+  return {
+    version: 1,
+    id: 'rec-20240101-120000-network',
+    sessionId: 'sess-network',
+    startedAt: '2024-01-01T12:00:00.000Z',
+    actionCount: 0,
+    ...overrides,
+  };
+}
+
+function makeAction(seq: number, overrides: Partial<RecordingAction> = {}): RecordingAction {
+  return {
+    seq,
+    ts: new Date('2024-01-01T12:00:00.000Z').getTime() + seq * 1000,
+    tool: 'navigate',
+    args: {},
+    durationMs: 100,
+    ok: true,
+    summary: `action ${seq}`,
+    ...overrides,
+  };
+}
+
+function makeNetworkEntry(i: number): NetworkEntry {
+  return {
+    method: 'GET',
+    url: `https://example.com/api/resource-${i}`,
+    status: 200,
+    durationMs: 50 + i,
+  };
+}
+
+// ── No network field → no panel ───────────────────────────────────────────────
+
+describe('generateHtmlReport — network panel absent', () => {
+  it('omits network-panel when network field is undefined', () => {
+    const html = generateHtmlReport(makeMetadata(), [makeAction(1)]);
+    expect(html).not.toContain('network-panel');
+    expect(html).not.toContain('<summary>Network');
+  });
+
+  it('omits network-panel when network is empty array', () => {
+    const action = makeAction(1, { network: [] });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+    expect(html).not.toContain('network-panel');
+  });
+});
+
+// ── Network panel rendering ───────────────────────────────────────────────────
+
+describe('generateHtmlReport — network panel present', () => {
+  it('renders network-panel details element', () => {
+    const network: NetworkEntry[] = [makeNetworkEntry(1)];
+    const action = makeAction(1, { network });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('network-panel');
+    expect(html).toContain('<details class="panel-details network-panel">');
+  });
+
+  it('shows method, url, status, and duration in a table row', () => {
+    const network: NetworkEntry[] = [{
+      method: 'POST',
+      url: 'https://api.example.com/submit',
+      status: 201,
+      durationMs: 123,
+    }];
+    const action = makeAction(1, { network });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('POST');
+    expect(html).toContain('https://api.example.com/submit');
+    expect(html).toContain('201');
+    expect(html).toContain('123ms');
+  });
+
+  it('renders dash for missing status', () => {
+    const network: NetworkEntry[] = [{ method: 'GET', url: 'https://example.com/img.png' }];
+    const action = makeAction(1, { network });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    // status column should show em-dash
+    expect(html).toContain('—');
+  });
+
+  it('renders dash for missing durationMs', () => {
+    const network: NetworkEntry[] = [{ method: 'GET', url: 'https://example.com/img.png', status: 200 }];
+    const action = makeAction(1, { network });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+    expect(html).toContain('—');
+  });
+
+  it('shows entry count in summary label', () => {
+    const network: NetworkEntry[] = [makeNetworkEntry(1), makeNetworkEntry(2)];
+    const action = makeAction(1, { network });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+    expect(html).toContain('Network (2)');
+  });
+
+  it('renders table headers (Method, URL, Status, Duration)', () => {
+    const action = makeAction(1, { network: [makeNetworkEntry(1)] });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('<th>Method</th>');
+    expect(html).toContain('<th>URL</th>');
+    expect(html).toContain('<th>Status</th>');
+    expect(html).toContain('<th>Duration</th>');
+  });
+
+  it('escapes XSS in URL field', () => {
+    const network: NetworkEntry[] = [{
+      method: 'GET',
+      url: 'https://evil.com/<script>alert(1)</script>',
+      status: 200,
+    }];
+    const action = makeAction(1, { network });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('renders exactly 20 real entries plus truncation marker for 25 entries', () => {
+    // The recorder already clips to 20 + marker; simulate post-clip state:
+    // 20 real entries + 1 truncation marker with empty method
+    const network: NetworkEntry[] = [];
+    for (let i = 1; i <= 20; i++) {
+      network.push(makeNetworkEntry(i));
+    }
+    // Append the truncation marker that the recorder would have added
+    network.push({ method: '', url: '(+5 more — truncated)' });
+
+    const action = makeAction(1, { network });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    // Truncation marker row spans all 4 columns
+    expect(html).toContain('truncation-marker');
+    expect(html).toContain('(+5 more — truncated)');
+    // Count of 21 entries total (20 + marker)
+    expect(html).toContain('Network (21)');
+  });
+
+  it('renders multiple network entries for one action', () => {
+    const network: NetworkEntry[] = [
+      { method: 'GET', url: 'https://example.com/a', status: 200, durationMs: 10 },
+      { method: 'POST', url: 'https://example.com/b', status: 404, durationMs: 20 },
+      { method: 'PUT', url: 'https://example.com/c', status: 500, durationMs: 30 },
+    ];
+    const action = makeAction(1, { network });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('Network (3)');
+    expect(html).toContain('https://example.com/a');
+    expect(html).toContain('https://example.com/b');
+    expect(html).toContain('https://example.com/c');
+    expect(html).toContain('404');
+    expect(html).toContain('500');
+  });
+});

--- a/tests/recording/html-template.verify.test.ts
+++ b/tests/recording/html-template.verify.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for html-template.ts — verify panel rendering.
+ * Covers: verify block round-trip, XSS escaping, absent field = no panel.
+ * Part of #852: replay HTML report enrichment.
+ */
+
+import { generateHtmlReport } from '../../src/recording/html-template';
+import { RecordingAction, RecordingMetadata } from '../../src/recording/types';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeMetadata(overrides: Partial<RecordingMetadata> = {}): RecordingMetadata {
+  return {
+    version: 1,
+    id: 'rec-20240101-120000-verify',
+    sessionId: 'sess-verify',
+    startedAt: '2024-01-01T12:00:00.000Z',
+    actionCount: 0,
+    ...overrides,
+  };
+}
+
+function makeAction(seq: number, overrides: Partial<RecordingAction> = {}): RecordingAction {
+  return {
+    seq,
+    ts: new Date('2024-01-01T12:00:00.000Z').getTime() + seq * 1000,
+    tool: 'interact',
+    args: {},
+    durationMs: 200,
+    ok: true,
+    summary: `action ${seq}`,
+    ...overrides,
+  };
+}
+
+// ── No verify field → no panel ────────────────────────────────────────────────
+
+describe('generateHtmlReport — verify panel absent', () => {
+  it('omits verify-panel when verify field is undefined', () => {
+    const action = makeAction(1);
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).not.toContain('verify-panel');
+    expect(html).not.toContain('<summary>Verify</summary>');
+  });
+});
+
+// ── Verify panel rendering ────────────────────────────────────────────────────
+
+describe('generateHtmlReport — verify panel present', () => {
+  it('renders verify-panel details element when verify field is set', () => {
+    const verify = { ax_diff: { changed: true }, screenshot: { phash_distance: 12 } };
+    const action = makeAction(1, { verify });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('verify-panel');
+    expect(html).toContain('<details class="panel-details verify-panel">');
+    expect(html).toContain('<summary>Verify</summary>');
+  });
+
+  it('round-trips ax_diff.changed field through the panel JSON', () => {
+    const verify: Record<string, unknown> = { ax_diff: { changed: true, added: 2, removed: 1 } };
+    const action = makeAction(1, { verify });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('ax_diff');
+    expect(html).toContain('changed');
+    // JSON keys are HTML-escaped: "changed" becomes &quot;changed&quot;
+    expect(html).toContain('&quot;changed&quot;');
+    // boolean true is not escaped
+    expect(html).toContain(': true');
+  });
+
+  it('round-trips screenshot.phash_distance through the panel JSON', () => {
+    const verify: Record<string, unknown> = { screenshot: { phash_distance: 42 } };
+    const action = makeAction(1, { verify });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('phash_distance');
+    expect(html).toContain('42');
+  });
+
+  it('renders the JSON inside a panel-json pre element', () => {
+    const verify: Record<string, unknown> = { key: 'value' };
+    const action = makeAction(1, { verify });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    // The pre element with panel-json class is present
+    expect(html).toContain('class="panel-json"');
+    // JSON keys/values are HTML-escaped (double-quotes become &quot;)
+    expect(html).toContain('&quot;key&quot;');
+    expect(html).toContain('&quot;value&quot;');
+  });
+
+  it('escapes XSS in verify block values', () => {
+    const verify: Record<string, unknown> = { url: '<script>alert(1)</script>' };
+    const action = makeAction(1, { verify });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('handles deeply nested verify object', () => {
+    const verify: Record<string, unknown> = {
+      level1: { level2: { level3: { value: 'deep' } } },
+    };
+    const action = makeAction(1, { verify });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('level1');
+    expect(html).toContain('level2');
+    expect(html).toContain('deep');
+  });
+
+  it('renders verify panel independently from contract panel', () => {
+    const verify: Record<string, unknown> = { screenshot: { phash_distance: 5 } };
+    const action = makeAction(1, { verify });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    // verify panel present, contract panel absent
+    expect(html).toContain('verify-panel');
+    expect(html).not.toContain('contract-panel');
+  });
+
+  it('renders both verify and contract panels when both fields are set', () => {
+    const verify: Record<string, unknown> = { ax_diff: { changed: false } };
+    const contractResults = [
+      { assertion: { kind: 'url', pattern: 'example.com' }, verdict: 'pass' as const },
+    ];
+    const action = makeAction(1, { verify, contractResults });
+    const html = generateHtmlReport(makeMetadata(), [action]);
+
+    expect(html).toContain('verify-panel');
+    expect(html).toContain('contract-panel');
+  });
+});

--- a/tests/tools/oc-assert.recorder-wiring.test.ts
+++ b/tests/tools/oc-assert.recorder-wiring.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for oc_assert recorder wiring (issue #852).
+ *
+ * Verifies the behaviour matrix:
+ *  - No active recorder → oc_assert returns normal response, no crash.
+ *  - Active recorder, >= 1 prior action → verdict appended to most-recent action.
+ *  - Active recorder, zero prior actions → no-op (no synthetic action created).
+ *
+ * We drive oc_assert via server.getToolHandler() following the pattern used in
+ * tests/tools/recording.test.ts.  A real ActionRecorder backed by a tmpdir
+ * store is registered into the session registry so the handler can find it.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { MCPServer } from '../../src/mcp-server';
+import {
+  ActionRecorder,
+  registerSessionRecorder,
+  unregisterSessionRecorder,
+} from '../../src/recording/action-recorder';
+import { RecordingStore } from '../../src/recording/recording-store';
+import { registerOcAssertTool } from '../../src/tools/oc-assert';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeTmpDir(): string {
+  const dir = path.join(os.tmpdir(), `oc-assert-wiring-${Math.random().toString(36).slice(2)}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function cleanupDir(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+/** Minimal snapshot that makes a url assertion decidable. */
+function urlEvidence(url: string) {
+  return { snapshot: { url } };
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+let server: MCPServer;
+let handler: (sessionId: string, args: Record<string, unknown>) => Promise<Record<string, unknown>>;
+
+beforeAll(() => {
+  server = new MCPServer();
+  registerOcAssertTool(server);
+  const h = server.getToolHandler('oc_assert');
+  if (!h) throw new Error('oc_assert tool handler not registered');
+  handler = h as typeof handler;
+});
+
+// ── No active recorder ────────────────────────────────────────────────────────
+
+describe('oc_assert wiring — no active recorder', () => {
+  const SESSION = 'sess-no-recorder-852';
+
+  it('returns a verdict without crashing when no recorder is registered', async () => {
+    const result = await handler(SESSION, {
+      contract: { kind: 'url', pattern: 'example.com' },
+      evidence: urlEvidence('https://example.com/'),
+    });
+
+    const text = (result.content as Array<{ text: string }>)[0].text;
+    const output = JSON.parse(text) as { verdict: string };
+    expect(['pass', 'fail', 'inconclusive']).toContain(output.verdict);
+  });
+
+  it('verdict is pass when url matches and no recorder is active', async () => {
+    const result = await handler(SESSION, {
+      contract: { kind: 'url', pattern: 'example.com' },
+      evidence: urlEvidence('https://example.com/page'),
+    });
+
+    const text = (result.content as Array<{ text: string }>)[0].text;
+    const output = JSON.parse(text) as { verdict: string };
+    expect(output.verdict).toBe('pass');
+  });
+});
+
+// ── Active recorder, zero prior actions ──────────────────────────────────────
+
+describe('oc_assert wiring — active recorder, zero prior actions', () => {
+  let dir: string;
+  let store: RecordingStore;
+  let recorder: ActionRecorder;
+  const SESSION = 'sess-zero-actions-852';
+
+  beforeEach(async () => {
+    dir = makeTmpDir();
+    store = new RecordingStore(dir);
+    recorder = new ActionRecorder(store, { captureScreenshots: false });
+    await recorder.start(SESSION);
+    registerSessionRecorder(SESSION, recorder);
+  });
+
+  afterEach(async () => {
+    if (recorder.isRecording) await recorder.stop();
+    unregisterSessionRecorder(SESSION);
+    cleanupDir(dir);
+  });
+
+  it('returns a verdict normally when no actions have been recorded yet', async () => {
+    const result = await handler(SESSION, {
+      contract: { kind: 'url', pattern: 'example.com' },
+      evidence: urlEvidence('https://example.com/'),
+    });
+
+    const text = (result.content as Array<{ text: string }>)[0].text;
+    const output = JSON.parse(text) as { verdict: string };
+    expect(output.verdict).toBe('pass');
+  });
+
+  it('does not create any recording actions for the assertion itself', async () => {
+    await handler(SESSION, {
+      contract: { kind: 'url', pattern: 'example.com' },
+      evidence: urlEvidence('https://example.com/'),
+    });
+
+    // Flush any pending async writes from the fire-and-forget appendContractResult
+    await new Promise((r) => setTimeout(r, 100));
+
+    const id = recorder.activeRecordingId!;
+    const actions = store.readActions(id);
+    expect(actions).toHaveLength(0);
+  });
+});
+
+// ── Active recorder, >= 1 prior action (pass) ────────────────────────────────
+
+describe('oc_assert wiring — active recorder, prior action exists (pass verdict)', () => {
+  let dir: string;
+  let store: RecordingStore;
+  let recorder: ActionRecorder;
+  const SESSION = 'sess-with-actions-pass-852';
+
+  beforeEach(async () => {
+    dir = makeTmpDir();
+    store = new RecordingStore(dir);
+    recorder = new ActionRecorder(store, { captureScreenshots: false });
+    await recorder.start(SESSION);
+    registerSessionRecorder(SESSION, recorder);
+    await recorder.recordAction('navigate', { url: 'https://example.com' }, 150, true);
+  });
+
+  afterEach(async () => {
+    if (recorder.isRecording) await recorder.stop();
+    unregisterSessionRecorder(SESSION);
+    cleanupDir(dir);
+  });
+
+  it('appends pass verdict to the most recent action contractResults', async () => {
+    await handler(SESSION, {
+      contract: { kind: 'url', pattern: 'example.com' },
+      evidence: urlEvidence('https://example.com/page'),
+    });
+
+    // Give the fire-and-forget promise time to complete
+    await new Promise((r) => setTimeout(r, 200));
+
+    const id = recorder.activeRecordingId!;
+    const actions = store.readActions(id);
+    expect(actions).toHaveLength(1);
+    expect(actions[0].contractResults).toBeDefined();
+    expect(actions[0].contractResults!).toHaveLength(1);
+    expect(actions[0].contractResults![0].verdict).toBe('pass');
+  });
+
+  it('stores the assertion inline in the contractResult entry', async () => {
+    const assertion = { kind: 'url', pattern: 'example.com' };
+    await handler(SESSION, {
+      contract: assertion,
+      evidence: urlEvidence('https://example.com/'),
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    const id = recorder.activeRecordingId!;
+    const actions = store.readActions(id);
+    const cr = actions[0].contractResults![0];
+    expect(cr.assertion).toEqual(assertion);
+  });
+
+  it('appends to last action, not first, when multiple actions exist', async () => {
+    // Record a second action
+    await recorder.recordAction('read_page', {}, 50, true);
+
+    await handler(SESSION, {
+      contract: { kind: 'url', pattern: 'example.com' },
+      evidence: urlEvidence('https://example.com/'),
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    const id = recorder.activeRecordingId!;
+    const actions = store.readActions(id);
+    // first action has no contractResults
+    expect(actions[0].contractResults).toBeUndefined();
+    // second action (last) has the appended result
+    expect(actions[1].contractResults).toHaveLength(1);
+    expect(actions[1].contractResults![0].verdict).toBe('pass');
+  });
+});
+
+// ── Active recorder, >= 1 prior action (fail) ────────────────────────────────
+
+describe('oc_assert wiring — active recorder, prior action exists (fail verdict)', () => {
+  let dir: string;
+  let store: RecordingStore;
+  let recorder: ActionRecorder;
+  const SESSION = 'sess-with-actions-fail-852';
+
+  beforeEach(async () => {
+    dir = makeTmpDir();
+    store = new RecordingStore(dir);
+    recorder = new ActionRecorder(store, { captureScreenshots: false });
+    await recorder.start(SESSION);
+    registerSessionRecorder(SESSION, recorder);
+    await recorder.recordAction('navigate', { url: 'https://example.com' }, 150, true);
+  });
+
+  afterEach(async () => {
+    if (recorder.isRecording) await recorder.stop();
+    unregisterSessionRecorder(SESSION);
+    cleanupDir(dir);
+  });
+
+  it('appends fail verdict to the most recent action when assertion fails', async () => {
+    // Pattern that will NOT match the url
+    await handler(SESSION, {
+      contract: { kind: 'url', pattern: 'not-present-xyz-852' },
+      evidence: urlEvidence('https://example.com/page'),
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    const id = recorder.activeRecordingId!;
+    const actions = store.readActions(id);
+    expect(actions[0].contractResults).toBeDefined();
+    expect(actions[0].contractResults![0].verdict).toBe('fail');
+  });
+});


### PR DESCRIPTION
Closes #852.

## Summary
- Adds four **optional** fields to `RecordingAction` (`contractResults`, `verify`, `network`, `console`) — all conditionally rendered, all bounded.
- Renders four conditional `<details>` panels in the replay HTML report. Default report shape is preserved byte-for-byte when none of the fields are populated (P2 invariance).
- Wires `oc_assert` into the active `ActionRecorder` via a new `getActiveActionRecorder(sessionId)` accessor; the verdict attaches to the most-recent recorded action's `contractResults`.
- Adds `oc replay {list,report,terminal}` CLI subcommands wrapping the existing `ReplayViewer`.
- Honours `OPENCHROME_REPLAY_DETERMINISTIC=1` to zero wall-clock timestamps for snapshot-stable SHA comparisons.

## Portability-Harness Contract
- **P1** Pure renderer / one wiring point; no orchestration introduced.
- **P2** Zero-impact when the new fields are absent. Verified by snapshot tests against the existing baseline.
- **P3** No LLM/network egress.
- **P5** No new persistent storage layout; reuses `recording-store`.

## Test plan
Unit + integration:
- `npm run build` green
- `npm test` green — new test files listed in #852's Acceptance Criteria all added
- `npm run lint` green
- Existing recording / `oc_assert` tests pass without modification (P2 proof)

Post-merge real verification (full matrix in #852's "Real verification" section). Reviewers can reproduce each scenario via the openchrome MCP:
- Scenario 1 — P2 byte-identity baseline (`OPENCHROME_REPLAY_DETERMINISTIC=1`)
- Scenario 2 — `oc_assert` pass-case panel + summary row
- Scenario 3 — `oc_assert` fail-case panel
- Scenario 4 — synthetic verify payload renders correctly
- Scenario 5 — bounds enforcement (4 KB contract / 20-entry network+console)
- Scenario 6 — CLI exit codes (0 / 2 / 3)
- Scenario 7 — size budget per action card

## Follow-ups (intentionally out of scope)
- Wire `interact`/`act`/`fill_form` verify into the recorder once #827 lands.
- Wire network/console capture into the recorder once the canonical capture path is decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
