### PR TITLE
feat(cli): oc playbook — declarative YAML scenario runner with inline Outcome Contracts (#854)

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -47,6 +47,7 @@ import {
 } from './totp-store';
 import { registerAdminKeysCommand } from './admin-keys';
 import { registerContractCommand } from './contract-teach';
+import { registerPlaybookCommand } from './playbook/index';
 import { getClaudeCliCommand, getClaudeExecFileOptions, shouldUseClaudeCliShell } from './claude-cli';
 
 const program = new Command();
@@ -1300,5 +1301,8 @@ registerAdminKeysCommand(program);
 
 // Outcome contract authoring helpers (issue #705).
 registerContractCommand(program);
+
+// Declarative YAML/JSON scenario runner (issue #854).
+registerPlaybookCommand(program);
 
 program.parse();

--- a/cli/playbook/expand.ts
+++ b/cli/playbook/expand.ts
@@ -1,0 +1,67 @@
+/**
+ * Step expansion — maps playbook verb + args to MCP tool name + call args.
+ *
+ * Static map of 9 verbs. `assert` maps to `oc_assert` with the YAML node
+ * passed verbatim as the `assertion` field (including nested and/or/not).
+ */
+
+import type { Verb } from './parse';
+
+export interface ExpandedStep {
+  tool: string;
+  callArgs: Record<string, unknown>;
+}
+
+type ArgMapper = (args: Record<string, unknown>) => Record<string, unknown>;
+
+const VERB_MAP: Record<Verb, { tool: string; mapArgs: ArgMapper }> = {
+  navigate: {
+    tool: 'navigate',
+    mapArgs: (args) => args,
+  },
+  interact: {
+    tool: 'interact',
+    mapArgs: (args) => args,
+  },
+  act: {
+    tool: 'act',
+    mapArgs: (args) => args,
+  },
+  fill_form: {
+    tool: 'fill_form',
+    mapArgs: (args) => args,
+  },
+  wait_for: {
+    tool: 'wait_for',
+    mapArgs: (args) => args,
+  },
+  page_screenshot: {
+    tool: 'page_screenshot',
+    mapArgs: (args) => args,
+  },
+  read_page: {
+    tool: 'read_page',
+    mapArgs: (args) => args,
+  },
+  javascript_tool: {
+    tool: 'javascript_tool',
+    mapArgs: (args) => args,
+  },
+  assert: {
+    tool: 'oc_assert',
+    // Pass the entire YAML node verbatim as the `assertion` field.
+    mapArgs: (args) => ({ assertion: args }),
+  },
+};
+
+export function expandStep(verb: Verb, args: Record<string, unknown>): ExpandedStep {
+  const entry = VERB_MAP[verb];
+  // VERB_MAP covers all 9 verbs — this is a type-level guarantee, but guard anyway
+  if (!entry) {
+    throw new Error(`Unknown verb "${verb}"`);
+  }
+  return {
+    tool: entry.tool,
+    callArgs: entry.mapArgs(args),
+  };
+}

--- a/cli/playbook/index.ts
+++ b/cli/playbook/index.ts
@@ -1,0 +1,92 @@
+/**
+ * Playbook subcommand registration.
+ *
+ * Registers `oc playbook run <file> [--vars k=v] [--out PATH] [--reuse] [--json]`
+ * onto the given Commander program.
+ *
+ * Exit codes:
+ *   0 — all steps + all asserts pass
+ *   1 — at least one step or assert failed
+ *   2 — usage / parse / unknown-var
+ *   3 — io / spawn / transport failure
+ */
+
+import { Command } from 'commander';
+import * as path from 'path';
+import { loadPlaybook, ParseError } from './parse';
+import { buildVarMap, parseCliVars, VarError } from './vars';
+import { runPlaybook } from './run';
+import { writeReport } from './report';
+import { TransportError } from './stdio-client';
+
+export function registerPlaybookCommand(program: Command): void {
+  const playbook = program
+    .command('playbook')
+    .description('Declarative YAML/JSON scenario runner (issue #854).');
+
+  playbook
+    .command('run <file>')
+    .description('Execute a playbook file against the MCP server.')
+    .option('--vars <k=v...>', 'Variable overrides (repeatable). CLI values override the vars: block.', (val: string, acc: string[]) => { acc.push(val); return acc; }, [] as string[])
+    .option('--out <path>', 'Write a Markdown report to this file.')
+    .option('--reuse', 'Connect to an existing openchrome serve daemon instead of spawning a new one.', false)
+    .option('--json', 'Output the full run report as JSON on stdout.', false)
+    .action(async (file: string, options: { vars: string[]; out?: string; reuse: boolean; json: boolean }) => {
+      const filePath = path.resolve(file);
+
+      // Phase 1: parse
+      let playbook;
+      try {
+        playbook = loadPlaybook(filePath);
+      } catch (err) {
+        if (err instanceof ParseError) {
+          const lineInfo = err.line !== undefined ? ` (line ${err.line})` : '';
+          console.error(`[playbook] Parse error${lineInfo}: ${err.message}`);
+        } else {
+          console.error(`[playbook] Failed to load playbook: ${err instanceof Error ? err.message : String(err)}`);
+        }
+        process.exit(2);
+      }
+
+      // Phase 2: build var map
+      let cliVars: Record<string, string>;
+      try {
+        cliVars = parseCliVars(options.vars);
+      } catch (err) {
+        console.error(`[playbook] --vars error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(2);
+      }
+
+      const varMap = buildVarMap(playbook.vars, cliVars);
+
+      // Phase 3: run
+      let result;
+      try {
+        result = await runPlaybook(playbook, {
+          reuse: options.reuse,
+          varMap,
+        });
+      } catch (err) {
+        if (err instanceof TransportError) {
+          console.error(`[playbook] Transport error: ${err.message}`);
+          process.exit(3);
+        }
+        if (err instanceof VarError) {
+          console.error(`[playbook] Variable error: ${err.message}`);
+          process.exit(2);
+        }
+        console.error(`[playbook] Unexpected error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(3);
+      }
+
+      // Phase 4: report
+      try {
+        writeReport(result, { json: options.json, outPath: options.out });
+      } catch (err) {
+        console.error(`[playbook] Report error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(3);
+      }
+
+      process.exit(result.summary.ok ? 0 : 1);
+    });
+}

--- a/cli/playbook/parse.ts
+++ b/cli/playbook/parse.ts
@@ -1,0 +1,157 @@
+/**
+ * Playbook parser — accepts .yaml/.yml (via eemeli/yaml) and .json (via JSON.parse).
+ *
+ * Validates:
+ *   { name?: string, vars?: Record<string,string>, steps: Step[] }
+ * Each step must have exactly one verb key from SUPPORTED_VERBS.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { parse as yamlParse, parseDocument } from 'yaml';
+
+export const SUPPORTED_VERBS = [
+  'navigate',
+  'interact',
+  'act',
+  'fill_form',
+  'wait_for',
+  'page_screenshot',
+  'read_page',
+  'javascript_tool',
+  'assert',
+] as const;
+
+export type Verb = (typeof SUPPORTED_VERBS)[number];
+
+export interface Step {
+  verb: Verb;
+  args: Record<string, unknown>;
+}
+
+export interface Playbook {
+  name?: string;
+  vars?: Record<string, string>;
+  steps: Step[];
+}
+
+export class ParseError extends Error {
+  constructor(
+    message: string,
+    public readonly line?: number,
+  ) {
+    super(message);
+    this.name = 'ParseError';
+  }
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function parseRawStep(raw: unknown, index: number): Step {
+  if (!isRecord(raw)) {
+    throw new ParseError(`Step ${index} is not an object`);
+  }
+  const keys = Object.keys(raw);
+  const verbKeys = keys.filter((k) => SUPPORTED_VERBS.includes(k as Verb));
+  const unknownKeys = keys.filter((k) => !SUPPORTED_VERBS.includes(k as Verb));
+
+  if (verbKeys.length === 0) {
+    if (unknownKeys.length > 0) {
+      throw new ParseError(
+        `Step ${index}: unknown verb "${unknownKeys[0]}". Supported: ${SUPPORTED_VERBS.join(', ')}`,
+      );
+    }
+    throw new ParseError(`Step ${index}: no verb key found. Supported: ${SUPPORTED_VERBS.join(', ')}`);
+  }
+
+  if (verbKeys.length > 1) {
+    throw new ParseError(
+      `Step ${index}: multiple verb keys found (${verbKeys.join(', ')}). Each step must have exactly one verb.`,
+    );
+  }
+
+  const verb = verbKeys[0] as Verb;
+  const args = raw[verb];
+
+  // args can be an object or null (for verbs with no params)
+  if (args !== null && args !== undefined && !isRecord(args)) {
+    throw new ParseError(`Step ${index}: args for verb "${verb}" must be an object or null`);
+  }
+
+  return { verb, args: (isRecord(args) ? args : {}) as Record<string, unknown> };
+}
+
+function validateRawPlaybook(raw: unknown): Playbook {
+  if (!isRecord(raw)) {
+    throw new ParseError('Playbook must be an object at the top level');
+  }
+
+  if (!Array.isArray(raw['steps'])) {
+    throw new ParseError('Playbook must have a "steps" array');
+  }
+
+  if (raw['vars'] !== undefined && raw['vars'] !== null) {
+    if (!isRecord(raw['vars'])) {
+      throw new ParseError('"vars" must be a key-value object');
+    }
+    for (const [k, v] of Object.entries(raw['vars'])) {
+      if (typeof v !== 'string') {
+        throw new ParseError(`vars["${k}"] must be a string`);
+      }
+    }
+  }
+
+  if (raw['name'] !== undefined && typeof raw['name'] !== 'string') {
+    throw new ParseError('"name" must be a string');
+  }
+
+  const steps: Step[] = (raw['steps'] as unknown[]).map((s, i) => parseRawStep(s, i));
+
+  return {
+    name: raw['name'] as string | undefined,
+    vars: raw['vars'] as Record<string, string> | undefined,
+    steps,
+  };
+}
+
+export function parsePlaybookContent(content: string, filePath: string): Playbook {
+  const ext = path.extname(filePath).toLowerCase();
+  let raw: unknown;
+
+  if (ext === '.json') {
+    try {
+      raw = JSON.parse(content);
+    } catch (err) {
+      throw new ParseError(
+        `JSON parse error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  } else if (ext === '.yaml' || ext === '.yml') {
+    // Use parseDocument to surface YAML parse errors with line info
+    const doc = parseDocument(content);
+    if (doc.errors && doc.errors.length > 0) {
+      const first = doc.errors[0];
+      const line = first.linePos?.[0]?.line;
+      throw new ParseError(`YAML parse error: ${first.message}`, line);
+    }
+    raw = yamlParse(content);
+  } else {
+    throw new ParseError(`Unsupported file extension "${ext}". Use .yaml, .yml, or .json.`);
+  }
+
+  return validateRawPlaybook(raw);
+}
+
+export function loadPlaybook(filePath: string): Playbook {
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    throw new ParseError(
+      `Cannot read file "${filePath}": ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  return parsePlaybookContent(content, filePath);
+}

--- a/cli/playbook/parse.ts
+++ b/cli/playbook/parse.ts
@@ -72,6 +72,18 @@ function parseRawStep(raw: unknown, index: number): Step {
     );
   }
 
+  // P2 codex fix: strict validation — reject extra non-verb keys even when a
+  // valid verb is present. Without this, typos or misplaced fields at the step
+  // top level (e.g. `args:` alongside `navigate:`) would be silently dropped,
+  // making playbooks harder to debug. A step is exactly { <verb>: <args> }.
+  if (unknownKeys.length > 0) {
+    throw new ParseError(
+      `Step ${index}: unexpected key "${unknownKeys[0]}" alongside verb "${verbKeys[0]}". ` +
+        `Each step must contain exactly one verb key; put step parameters inside the verb's value. ` +
+        `Supported verbs: ${SUPPORTED_VERBS.join(', ')}`,
+    );
+  }
+
   const verb = verbKeys[0] as Verb;
   const args = raw[verb];
 

--- a/cli/playbook/report.ts
+++ b/cli/playbook/report.ts
@@ -1,0 +1,95 @@
+/**
+ * Playbook reporter — formats a RunResult as JSON, Markdown, or plain stdout.
+ *
+ * --json  : JSON shape { name, steps, summary }
+ * --out   : Markdown table written to file
+ * default : One-liner per step + final summary on stdout
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { RunResult, StepResult } from './run';
+
+const STATUS_ICON: Record<string, string> = {
+  ok: 'PASS',
+  failed: 'FAIL',
+  skipped: 'SKIP',
+};
+
+function formatPlain(result: RunResult): string {
+  const lines: string[] = [];
+  const name = result.name ?? '(unnamed playbook)';
+  lines.push(`Playbook: ${name}`);
+  lines.push('');
+
+  for (const step of result.steps) {
+    const icon = STATUS_ICON[step.status] ?? step.status.toUpperCase();
+    const dur = step.status === 'skipped' ? '-' : `${step.durationMs}ms`;
+    lines.push(`  [${icon}] step ${step.index}: ${step.verb} (${dur})`);
+    if (step.error) {
+      lines.push(`         ${step.error}`);
+    }
+  }
+
+  lines.push('');
+  const { ok, total, passed, failed, skipped } = result.summary;
+  lines.push(`Summary: ${ok ? 'PASS' : 'FAIL'} — ${passed}/${total} passed, ${failed} failed, ${skipped} skipped`);
+  return lines.join('\n');
+}
+
+function formatMarkdown(result: RunResult): string {
+  const name = result.name ?? '(unnamed playbook)';
+  const lines: string[] = [];
+  lines.push(`# Playbook: ${name}`);
+  lines.push('');
+  lines.push('| # | Verb | Tool | Status | Duration |');
+  lines.push('|---|------|------|--------|----------|');
+
+  for (const step of result.steps) {
+    const dur = step.status === 'skipped' ? '-' : `${step.durationMs}ms`;
+    lines.push(`| ${step.index} | \`${step.verb}\` | \`${step.tool || '-'}\` | ${step.status.toUpperCase()} | ${dur} |`);
+  }
+
+  lines.push('');
+  const { ok, total, passed, failed, skipped } = result.summary;
+  lines.push(`**Result:** ${ok ? 'PASS' : 'FAIL'} — ${passed}/${total} passed, ${failed} failed, ${skipped} skipped`);
+
+  return lines.join('\n');
+}
+
+export interface ReportOptions {
+  json: boolean;
+  outPath?: string;
+}
+
+export function writeReport(result: RunResult, options: ReportOptions): void {
+  if (options.json) {
+    // JSON output to stdout
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (options.outPath) {
+    const md = formatMarkdown(result);
+    const dir = path.dirname(options.outPath);
+    if (dir && dir !== '.') {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(options.outPath, md + '\n', 'utf8');
+    // Also print plain summary to stdout
+    const { ok, total, passed, failed, skipped } = result.summary;
+    console.log(`Report written to ${options.outPath}`);
+    console.log(`Result: ${ok ? 'PASS' : 'FAIL'} — ${passed}/${total} passed, ${failed} failed, ${skipped} skipped`);
+    return;
+  }
+
+  // Plain stdout
+  console.log(formatPlain(result));
+}
+
+// Re-export for use in tests
+export { formatPlain, formatMarkdown };
+
+export function buildStepResult(step: StepResult): StepResult {
+  return step;
+}

--- a/cli/playbook/run.ts
+++ b/cli/playbook/run.ts
@@ -98,6 +98,16 @@ export async function runPlaybook(playbook: Playbook, options: RunOptions): Prom
           }
         }
       } catch (err) {
+        // P1 codex fix: distinguish transport-class failures from step/assertion
+        // failures. TransportError indicates the MCP client could not deliver
+        // the call (timeout, broken pipe, child exit). These must surface as
+        // exit code 3 in the CLI, not exit code 1 (test/assert failure), so we
+        // re-throw and let the CLI's outer handler map TransportError -> 3.
+        // Note: stepResults so far are intentionally discarded — the run is
+        // aborted at the transport boundary, not reported as a failed scenario.
+        if (err instanceof TransportError) {
+          throw err;
+        }
         status = 'failed';
         failed = true;
         error = `Step ${i} (${step.verb}): ${err instanceof Error ? err.message : String(err)}`;

--- a/cli/playbook/run.ts
+++ b/cli/playbook/run.ts
@@ -1,0 +1,136 @@
+/**
+ * Playbook runner — executes a parsed+substituted playbook against the MCP server.
+ *
+ * Sequential, fail-fast execution. On step failure all subsequent steps
+ * are marked 'skipped'. Returns a structured RunResult.
+ */
+
+import type { Playbook, Step } from './parse';
+import { expandStep } from './expand';
+import { substituteValue } from './vars';
+import { StdioMcpClient, TransportError } from './stdio-client';
+
+export type StepStatus = 'ok' | 'failed' | 'skipped';
+
+export interface StepResult {
+  index: number;
+  verb: string;
+  tool: string;
+  args: Record<string, unknown>;
+  status: StepStatus;
+  durationMs: number;
+  result?: unknown;
+  error?: string;
+}
+
+export interface RunSummary {
+  ok: boolean;
+  total: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+}
+
+export interface RunResult {
+  name: string | undefined;
+  steps: StepResult[];
+  summary: RunSummary;
+}
+
+export interface RunOptions {
+  reuse: boolean;
+  /** Pre-built var map (merged playbook vars + CLI vars). */
+  varMap: Record<string, string>;
+  /** Optional injectable client for testing. */
+  client?: Pick<StdioMcpClient, 'connect' | 'callTool' | 'disconnect'>;
+}
+
+export async function runPlaybook(playbook: Playbook, options: RunOptions): Promise<RunResult> {
+  const client = options.client ?? new StdioMcpClient();
+
+  try {
+    await client.connect(options.reuse);
+  } catch (err) {
+    throw new TransportError(
+      `Failed to connect to MCP server: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const stepResults: StepResult[] = [];
+  let failed = false;
+
+  try {
+    for (let i = 0; i < playbook.steps.length; i++) {
+      const step: Step = playbook.steps[i];
+
+      if (failed) {
+        stepResults.push({
+          index: i,
+          verb: step.verb,
+          tool: '',
+          args: {},
+          status: 'skipped',
+          durationMs: 0,
+        });
+        continue;
+      }
+
+      // Substitute vars in args
+      const substitutedArgs = substituteValue(step.args, options.varMap, i) as Record<string, unknown>;
+
+      // Expand to MCP tool call
+      const expanded = expandStep(step.verb, substitutedArgs);
+
+      const start = Date.now();
+      let status: StepStatus = 'ok';
+      let result: unknown;
+      let error: string | undefined;
+
+      try {
+        const callResult = await client.callTool(expanded.tool, expanded.callArgs);
+        result = callResult.result;
+        if (!callResult.success) {
+          status = 'failed';
+          failed = true;
+          error = `Step ${i} (${step.verb}): tool call returned failure`;
+          if (callResult.verdict) {
+            error = `Step ${i} (${step.verb}): assert verdict="${callResult.verdict}"`;
+          }
+        }
+      } catch (err) {
+        status = 'failed';
+        failed = true;
+        error = `Step ${i} (${step.verb}): ${err instanceof Error ? err.message : String(err)}`;
+      }
+
+      stepResults.push({
+        index: i,
+        verb: step.verb,
+        tool: expanded.tool,
+        args: expanded.callArgs,
+        status,
+        durationMs: Date.now() - start,
+        result,
+        error,
+      });
+    }
+  } finally {
+    await client.disconnect();
+  }
+
+  const passed = stepResults.filter((s) => s.status === 'ok').length;
+  const failedCount = stepResults.filter((s) => s.status === 'failed').length;
+  const skipped = stepResults.filter((s) => s.status === 'skipped').length;
+
+  return {
+    name: playbook.name,
+    steps: stepResults,
+    summary: {
+      ok: failedCount === 0 && skipped === 0,
+      total: playbook.steps.length,
+      passed,
+      failed: failedCount,
+      skipped,
+    },
+  };
+}

--- a/cli/playbook/stdio-client.ts
+++ b/cli/playbook/stdio-client.ts
@@ -1,0 +1,223 @@
+/**
+ * Minimal MCP stdio client for the playbook runner.
+ *
+ * Spawns `openchrome serve` (or connects to an existing daemon via --reuse)
+ * and sends JSON-RPC 2.0 `tools/call` requests, returning the parsed result.
+ *
+ * This is a self-contained ~100-LOC client. When #843 (oc run) lands, the
+ * shared stdio transport can be extracted here and this file becomes a
+ * thin wrapper.
+ *
+ * Transport: newline-delimited JSON over stdin/stdout of the child process
+ * (or the reuse socket, which is not yet wired — see TODO below).
+ */
+
+import { spawn, ChildProcess } from 'child_process';
+import * as path from 'path';
+import * as readline from 'readline';
+
+export class TransportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TransportError';
+  }
+}
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id: number;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+interface McpToolCallResult {
+  content?: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+  [key: string]: unknown;
+}
+
+export interface CallResult {
+  success: boolean;
+  result: unknown;
+  /** For assert steps: 'pass' | 'fail' | 'inconclusive' */
+  verdict?: string;
+}
+
+export class StdioMcpClient {
+  private child: ChildProcess | null = null;
+  private nextId = 1;
+  private pendingRequests = new Map<
+    number,
+    { resolve: (r: JsonRpcResponse) => void; reject: (e: Error) => void }
+  >();
+  private rl: readline.Interface | null = null;
+  private initialized = false;
+  private stderr: string[] = [];
+
+  async connect(reuse: boolean): Promise<void> {
+    if (reuse) {
+      // TODO: connect to existing daemon socket when #843 transport lands.
+      // For now, fall through to one-shot spawn with a warning.
+      console.error('[playbook] --reuse not yet wired to daemon socket; spawning one-shot server.');
+    }
+
+    // Resolve the serve entry — from dist/cli/playbook/ go up three levels to root.
+    const serveEntry = path.join(__dirname, '..', '..', '..', 'dist', 'index.js');
+
+    this.child = spawn(process.execPath, [serveEntry, 'serve', '--server-mode'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    if (!this.child.stdout || !this.child.stdin) {
+      throw new TransportError('Failed to open stdio pipes to child process');
+    }
+
+    // Capture stderr for diagnostics
+    this.child.stderr?.on('data', (chunk: Buffer) => {
+      this.stderr.push(chunk.toString());
+    });
+
+    this.child.on('error', (err) => {
+      this.rejectAll(new TransportError(`Server process error: ${err.message}`));
+    });
+
+    this.child.on('exit', (code) => {
+      if (code !== 0 && code !== null) {
+        this.rejectAll(new TransportError(`Server process exited with code ${code}`));
+      }
+    });
+
+    // Wire up JSON-RPC response reader
+    this.rl = readline.createInterface({ input: this.child.stdout, crlfDelay: Infinity });
+    this.rl.on('line', (line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+      let msg: JsonRpcResponse;
+      try {
+        msg = JSON.parse(trimmed) as JsonRpcResponse;
+      } catch {
+        // Not JSON — ignore (server may emit non-JSON startup lines)
+        return;
+      }
+      const pending = this.pendingRequests.get(msg.id);
+      if (pending) {
+        this.pendingRequests.delete(msg.id);
+        pending.resolve(msg);
+      }
+    });
+
+    // MCP initialization handshake
+    await this.sendRequest('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'oc-playbook', version: '1.0.0' },
+    });
+
+    await this.sendRequest('notifications/initialized', undefined);
+    this.initialized = true;
+  }
+
+  async callTool(tool: string, args: Record<string, unknown>): Promise<CallResult> {
+    if (!this.initialized) {
+      throw new TransportError('Client not initialized. Call connect() first.');
+    }
+
+    const response = await this.sendRequest('tools/call', {
+      name: tool,
+      arguments: args,
+    });
+
+    if (response.error) {
+      return { success: false, result: response.error };
+    }
+
+    const rawResult = response.result as McpToolCallResult | undefined;
+
+    // Parse text content for verdict (assert steps)
+    let verdict: string | undefined;
+    let parsedContent: unknown = rawResult;
+
+    if (rawResult?.content) {
+      const textBlock = rawResult.content.find((c) => c.type === 'text' && c.text);
+      if (textBlock?.text) {
+        try {
+          parsedContent = JSON.parse(textBlock.text);
+          const pc = parsedContent as Record<string, unknown>;
+          if (typeof pc['verdict'] === 'string') {
+            verdict = pc['verdict'] as string;
+          }
+        } catch {
+          parsedContent = textBlock.text;
+        }
+      }
+    }
+
+    const success = rawResult?.isError !== true && (verdict === undefined || verdict === 'pass');
+
+    return { success, result: parsedContent, verdict };
+  }
+
+  async disconnect(): Promise<void> {
+    this.rl?.close();
+    if (this.child && !this.child.killed) {
+      this.child.kill('SIGTERM');
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(() => {
+          this.child?.kill('SIGKILL');
+          resolve();
+        }, 3000);
+        this.child?.on('exit', () => {
+          clearTimeout(timeout);
+          resolve();
+        });
+      });
+    }
+    this.pendingRequests.clear();
+  }
+
+  private async sendRequest(method: string, params: unknown): Promise<JsonRpcResponse> {
+    return new Promise<JsonRpcResponse>((resolve, reject) => {
+      const id = this.nextId++;
+      const req: JsonRpcRequest = { jsonrpc: '2.0', id, method };
+      if (params !== undefined) {
+        req.params = params;
+      }
+
+      this.pendingRequests.set(id, { resolve, reject });
+
+      const line = JSON.stringify(req) + '\n';
+      this.child?.stdin?.write(line, (err) => {
+        if (err) {
+          this.pendingRequests.delete(id);
+          reject(new TransportError(`Write error: ${err.message}`));
+        }
+      });
+
+      // Timeout after 30s per request
+      setTimeout(() => {
+        if (this.pendingRequests.has(id)) {
+          this.pendingRequests.delete(id);
+          reject(new TransportError(`Timeout waiting for response to "${method}" (id=${id})`));
+        }
+      }, 30000);
+    });
+  }
+
+  private rejectAll(err: Error): void {
+    for (const pending of this.pendingRequests.values()) {
+      pending.reject(err);
+    }
+    this.pendingRequests.clear();
+  }
+
+  getStderr(): string {
+    return this.stderr.join('');
+  }
+}

--- a/cli/playbook/vars.ts
+++ b/cli/playbook/vars.ts
@@ -1,0 +1,106 @@
+/**
+ * Var substitution for playbook steps.
+ *
+ * Regex: /\$\{([A-Za-z_][A-Za-z0-9_:]*)\}/g
+ * - Plain identifiers (${url}, ${BASE_URL}) resolved from merged var map.
+ * - ${SECRET:NAME} passed through with a stderr warning (until #834 lands).
+ * - Unknown var → throws VarError (exit code 2).
+ * CLI --vars override the playbook vars: block.
+ */
+
+export class VarError extends Error {
+  constructor(
+    message: string,
+    public readonly varName: string,
+    public readonly stepIndex?: number,
+  ) {
+    super(message);
+    this.name = 'VarError';
+  }
+}
+
+const VAR_RE = /\$\{([A-Za-z_][A-Za-z0-9_:]*)\}/g;
+
+/**
+ * Build merged var map: playbook vars: block is the base; CLI --vars override.
+ */
+export function buildVarMap(
+  playbookVars: Record<string, string> | undefined,
+  cliVars: Record<string, string>,
+): Record<string, string> {
+  return { ...(playbookVars ?? {}), ...cliVars };
+}
+
+/**
+ * Substitute ${VAR} in a single string. Returns the substituted string.
+ * Throws VarError for unknown vars. Warns (stderr) for SECRET: namespace.
+ */
+export function substituteString(
+  value: string,
+  varMap: Record<string, string>,
+  stepIndex?: number,
+): string {
+  return value.replace(VAR_RE, (_match, name: string) => {
+    if (name.startsWith('SECRET:')) {
+      // Pass-through with warning — masking layer from #834 not yet merged.
+      console.error(
+        `[playbook] WARNING: ${name} is a secret reference; masking layer (#834) not yet merged. Value will be used as-is from var map if present.`,
+      );
+      // Fall through to normal lookup
+    }
+    if (Object.prototype.hasOwnProperty.call(varMap, name)) {
+      return varMap[name];
+    }
+    const stepMsg = stepIndex !== undefined ? ` (step ${stepIndex})` : '';
+    throw new VarError(
+      `Unknown variable "\${${name}}"${stepMsg}. Define it in the vars: block or pass --vars ${name}=<value>.`,
+      name,
+      stepIndex,
+    );
+  });
+}
+
+/**
+ * Recursively walk the step args tree and substitute all string scalars.
+ */
+export function substituteValue(
+  value: unknown,
+  varMap: Record<string, string>,
+  stepIndex?: number,
+): unknown {
+  if (typeof value === 'string') {
+    return substituteString(value, varMap, stepIndex);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => substituteValue(item, varMap, stepIndex));
+  }
+  if (typeof value === 'object' && value !== null) {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      result[k] = substituteValue(v, varMap, stepIndex);
+    }
+    return result;
+  }
+  return value;
+}
+
+/**
+ * Parse --vars CLI arguments of the form KEY=VALUE.
+ * Returns a Record<string, string>.
+ */
+export function parseCliVars(vars: string[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const entry of vars) {
+    const eqIdx = entry.indexOf('=');
+    if (eqIdx === -1) {
+      throw new VarError(
+        `Invalid --vars entry "${entry}". Expected format: KEY=VALUE`,
+        entry,
+      );
+    }
+    const key = entry.slice(0, eqIdx);
+    const val = entry.slice(eqIdx + 1);
+    result[key] = val;
+  }
+  return result;
+}

--- a/docs/cli/playbook.md
+++ b/docs/cli/playbook.md
@@ -1,0 +1,291 @@
+# oc playbook — Declarative YAML Scenario Runner
+
+`oc playbook run` executes a declarative YAML (or JSON) scenario file against the OpenChrome MCP server. Each step maps to exactly one MCP tool call; the runner is a thin client, not a new orchestration tier.
+
+Inspired by [Midscene's YAML scripting](https://midscenejs.com/). Unlike Midscene, OpenChrome's substrate is deterministic, so each step carries an inline **Outcome Contract** assertion instead of an LLM judgement.
+
+---
+
+## Quick start
+
+```bash
+# One-shot run (spawns a dedicated server child, then terminates it)
+oc playbook run tests/fixtures/playbook/sanity.yaml
+
+# Reuse a running daemon
+oc playbook run sanity.yaml --reuse --json | jq '.summary'
+
+# Variable override + Markdown report
+oc playbook run sanity.yaml --vars url=https://iana.org --out report.md
+```
+
+---
+
+## Grammar reference
+
+```yaml
+name: <string>           # optional — appears in reports
+vars:                    # optional — key/value defaults; CLI --vars override these
+  KEY: value
+steps:
+  - <verb>:              # exactly one verb per step
+      <arg>: <value>     # verb-specific args (see table below)
+```
+
+### Minimal example
+
+```yaml
+steps:
+  - navigate:
+      url: https://example.com
+```
+
+### Full example
+
+```yaml
+name: example.com sanity
+vars:
+  url: https://example.com
+  heading: Example
+steps:
+  - navigate:
+      url: ${url}
+  - assert:
+      kind: dom_text
+      selector: h1
+      pattern: ${heading}
+  - interact:
+      ref: "More information…"
+  - wait_for:
+      condition: "navigation"
+  - assert:
+      kind: url
+      pattern: "iana\\.org"
+  - page_screenshot:
+      path: /tmp/sanity.png
+  - read_page:
+      mode: ax
+  - javascript_tool:
+      code: "document.title"
+  - act:
+      action: "scroll down"
+```
+
+---
+
+## Supported verbs (9 total)
+
+| Verb | MCP tool | Key args | Notes |
+|------|----------|----------|-------|
+| `navigate` | `navigate` | `url` | Navigates the active tab |
+| `interact` | `interact` | `ref` | Clicks/activates an element by accessibility label |
+| `act` | `act` | `action` | Free-form action string (e.g. `"scroll down"`) |
+| `fill_form` | `fill_form` | `fields` | Fills multiple form fields at once |
+| `wait_for` | `wait_for` | `condition` | Waits for a condition (e.g. `"navigation"`, `"networkidle"`) |
+| `page_screenshot` | `page_screenshot` | `path` | Captures a screenshot to disk |
+| `read_page` | `read_page` | `mode` | Reads page content (`"ax"` for accessibility tree, `"html"` for raw HTML) |
+| `javascript_tool` | `javascript_tool` | `code` | Evaluates JavaScript in the page context and returns the result |
+| `assert` | `oc_assert` | `kind`, `pattern`, … | Inline Outcome Contract assertion; see [Assertions](#assertions) |
+
+All non-`assert` verbs forward their YAML args object directly to the MCP tool unchanged.
+
+---
+
+## Assertions
+
+`assert` steps expand to `oc_assert` with the YAML node forwarded verbatim as the `assertion` field. The step passes iff the server returns `verdict === "pass"`. Any other verdict (`"fail"`, `"inconclusive"`) counts as a failure for exit-code purposes.
+
+### dom_text
+
+```yaml
+- assert:
+    kind: dom_text
+    selector: h1
+    pattern: "Example"   # substring or regex
+```
+
+Expands to:
+```json
+{ "assertion": { "kind": "dom_text", "selector": "h1", "pattern": "Example" } }
+```
+
+### url
+
+```yaml
+- assert:
+    kind: url
+    pattern: "iana\\.org"   # regex; escape backslashes in YAML
+```
+
+### Compound: and / or / not
+
+```yaml
+- assert:
+    kind: and
+    children:
+      - { kind: dom_text, selector: "h1", pattern: "Example" }
+      - { kind: url, pattern: "example\\.com" }
+```
+
+The playbook layer does **not** parse the assertion DSL — the YAML subtree is forwarded verbatim.
+
+---
+
+## Variable substitution
+
+Syntax: `${IDENTIFIER}` in any string scalar.
+
+Rules:
+
+1. **Merge order**: the `vars:` block in the playbook is the base; CLI `--vars KEY=VALUE` overrides.
+2. **Plain identifiers** (`${url}`, `${BASE_URL}`) are resolved from the merged map.
+3. **`${SECRET:NAME}`** — looked up from the secrets layer (issue #834) when that feature has merged. Until then, the value is looked up from the merged var map and a warning is emitted to stderr:
+   ```
+   [playbook] WARNING: SECRET:MY_TOKEN is a secret reference; masking layer (#834) not yet merged. Value will be used as-is from var map if present.
+   ```
+   **Security caveat**: do **not** commit playbook files that contain literal secret values in the `vars:` block. Use `${SECRET:NAME}` with the secrets layer, or supply secrets via `--vars SECRET:NAME=<value>` from a shell secret (e.g. `$(op read op://vault/item/field)`).
+4. **Unknown variable** — exits with code `2` and an error naming the missing var and step index.
+
+### Examples
+
+```yaml
+vars:
+  base: https://example.com
+
+steps:
+  - navigate:
+      url: ${base}/login       # → https://example.com/login
+  - fill_form:
+      fields:
+        username: ${USER}      # → must be supplied via --vars USER=alice
+        password: ${SECRET:DB_PASS}  # → resolved from secrets layer
+```
+
+CLI override:
+```bash
+oc playbook run login.yaml --vars base=https://staging.example.com --vars USER=bob
+```
+
+---
+
+## Fail-fast semantics
+
+The playbook executes **sequentially**. When a step fails:
+
+1. The step is marked `failed` in the report.
+2. All subsequent steps are marked `skipped` — their MCP tools are **not** called.
+3. The runner disconnects and exits with code `1`.
+
+Example output (`--json`) after step 1 fails in a 3-step playbook:
+
+```json
+{
+  "name": "fail-fast fixture",
+  "steps": [
+    { "index": 0, "verb": "navigate", "status": "ok",      "durationMs": 45 },
+    { "index": 1, "verb": "assert",   "status": "failed",  "durationMs": 12, "error": "Step 1 (assert): assert verdict=\"fail\"" },
+    { "index": 2, "verb": "interact", "status": "skipped", "durationMs": 0  }
+  ],
+  "summary": { "ok": false, "total": 3, "passed": 1, "failed": 1, "skipped": 1 }
+}
+```
+
+A `--continue-on-error` flag (to collect all failures before stopping) is tracked in a follow-up issue.
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All steps and all asserts passed. |
+| `1` | At least one step or assert failed (structured failure report on stdout under `--json`). |
+| `2` | Usage / parse error / unknown variable. |
+| `3` | I/O, spawn, or transport failure (MCP server unreachable). |
+
+---
+
+## CLI flags
+
+```
+oc playbook run <file> [options]
+
+Options:
+  --vars <k=v>   Variable override (repeatable). CLI values override the vars: block.
+  --out <path>   Write a Markdown report to this file path.
+  --reuse        Connect to an existing `openchrome serve` daemon instead of
+                 spawning a new one-shot server.
+  --json         Print the full RunResult as JSON on stdout (see schema below).
+```
+
+### JSON output schema (`--json`)
+
+```ts
+{
+  name: string | undefined,
+  steps: Array<{
+    index:      number,           // 0-based
+    verb:       string,           // playbook verb (e.g. "navigate")
+    tool:       string,           // MCP tool name (e.g. "oc_assert")
+    args:       object,           // args sent to the MCP tool
+    status:     "ok" | "failed" | "skipped",
+    durationMs: number,           // 0 for skipped steps
+    result?:    unknown,          // raw MCP response content
+    error?:     string            // present on failed steps
+  }>,
+  summary: {
+    ok:      boolean,  // true iff failed === 0 && skipped === 0
+    total:   number,
+    passed:  number,
+    failed:  number,
+    skipped: number
+  }
+}
+```
+
+---
+
+## JSON-format playbooks
+
+The same parser accepts `.json` files using the identical top-level shape:
+
+```json
+{
+  "name": "example.com sanity (JSON)",
+  "vars": { "url": "https://example.com" },
+  "steps": [
+    { "navigate": { "url": "${url}" } },
+    { "assert": { "kind": "dom_text", "selector": "h1", "pattern": "Example" } }
+  ]
+}
+```
+
+Dispatch is based on file extension (`.yaml`/`.yml` → YAML parser; `.json` → `JSON.parse`).
+
+---
+
+## Server reuse (`--reuse`)
+
+Without `--reuse`, the runner spawns its own `openchrome serve --server-mode` child process for the duration of the playbook and terminates it on completion.
+
+With `--reuse`, the runner connects to an existing daemon. The daemon socket path from issue #843 (`oc run`) will be wired here when that PR lands. Until then, `--reuse` falls through to one-shot spawn with a stderr warning.
+
+---
+
+## Security caveats
+
+- **`${SECRET:NAME}` masking**: Until issue #834 (secrets layer) merges, secret values are passed through in plaintext. Under `--json` output, secret values will appear unmasked in the `args` field of each step.
+- **Playbook files in version control**: Treat playbook files like code. Do not embed credentials in the `vars:` block; use `${SECRET:NAME}` references or supply values at runtime via `--vars`.
+- **Untrusted playbooks**: `javascript_tool` steps execute arbitrary JavaScript in the browser context. Only run playbook files from trusted sources.
+- **Scope**: The playbook runner is a client of the MCP server. It does not gain capabilities beyond what `openchrome serve` exposes.
+
+---
+
+## Out of scope (follow-up issues)
+
+- `if` / `loop` / `parallel` constructs
+- Importing or chaining playbooks
+- `--continue-on-error` flag
+- Recording a playbook from a live session
+- Built-in Jest integration
+- Web UI for editing playbooks

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "proper-lockfile": "^4.1.2",
         "puppeteer-core": "npm:rebrowser-puppeteer-core@23.10.3",
         "uuid": "^9.0.0",
-        "write-file-atomic": "^5.0.1"
+        "write-file-atomic": "^5.0.1",
+        "yaml": "^2.9.0"
       },
       "bin": {
         "oc": "dist/cli/index.js",
@@ -6775,6 +6776,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "proper-lockfile": "^4.1.2",
     "puppeteer-core": "npm:rebrowser-puppeteer-core@23.10.3",
     "uuid": "^9.0.0",
-    "write-file-atomic": "^5.0.1"
+    "write-file-atomic": "^5.0.1",
+    "yaml": "^2.9.0"
   },
   "overrides": {
     "basic-ftp": "^5.3.1",

--- a/tests/cli/playbook/expand.test.ts
+++ b/tests/cli/playbook/expand.test.ts
@@ -1,0 +1,98 @@
+/// <reference types="jest" />
+/**
+ * Tests for cli/playbook/expand.ts
+ *
+ * Verifies that each of the 9 verbs maps to the expected tool name and args shape.
+ */
+
+import { expandStep, ExpandedStep } from '../../../cli/playbook/expand';
+import type { Verb } from '../../../cli/playbook/parse';
+
+describe('expandStep', () => {
+  test('navigate → navigate tool, args pass-through', () => {
+    const result = expandStep('navigate', { url: 'https://example.com' });
+    expect(result.tool).toBe('navigate');
+    expect(result.callArgs).toEqual({ url: 'https://example.com' });
+  });
+
+  test('interact → interact tool, args pass-through', () => {
+    const result = expandStep('interact', { ref: 'Submit button' });
+    expect(result.tool).toBe('interact');
+    expect(result.callArgs).toEqual({ ref: 'Submit button' });
+  });
+
+  test('act → act tool, args pass-through', () => {
+    const result = expandStep('act', { action: 'scroll down' });
+    expect(result.tool).toBe('act');
+    expect(result.callArgs).toEqual({ action: 'scroll down' });
+  });
+
+  test('fill_form → fill_form tool, args pass-through', () => {
+    const result = expandStep('fill_form', { fields: { email: 'a@b.com' } });
+    expect(result.tool).toBe('fill_form');
+    expect(result.callArgs).toEqual({ fields: { email: 'a@b.com' } });
+  });
+
+  test('wait_for → wait_for tool, args pass-through', () => {
+    const result = expandStep('wait_for', { condition: 'navigation' });
+    expect(result.tool).toBe('wait_for');
+    expect(result.callArgs).toEqual({ condition: 'navigation' });
+  });
+
+  test('page_screenshot → page_screenshot tool, args pass-through', () => {
+    const result = expandStep('page_screenshot', { path: '/tmp/ss.png' });
+    expect(result.tool).toBe('page_screenshot');
+    expect(result.callArgs).toEqual({ path: '/tmp/ss.png' });
+  });
+
+  test('read_page → read_page tool, args pass-through', () => {
+    const result = expandStep('read_page', { mode: 'ax' });
+    expect(result.tool).toBe('read_page');
+    expect(result.callArgs).toEqual({ mode: 'ax' });
+  });
+
+  test('javascript_tool → javascript_tool tool, args pass-through', () => {
+    const result = expandStep('javascript_tool', { code: 'document.title' });
+    expect(result.tool).toBe('javascript_tool');
+    expect(result.callArgs).toEqual({ code: 'document.title' });
+  });
+
+  test('assert → oc_assert tool, YAML node wrapped in assertion field', () => {
+    const assertArgs = { kind: 'dom_text', selector: 'h1', pattern: 'Example' };
+    const result = expandStep('assert', assertArgs);
+    expect(result.tool).toBe('oc_assert');
+    expect(result.callArgs).toEqual({ assertion: assertArgs });
+  });
+
+  test('assert: nested and/or/not passes verbatim', () => {
+    const assertArgs = {
+      kind: 'and',
+      children: [
+        { kind: 'dom_text', selector: 'h1', pattern: 'Example' },
+        { kind: 'url', pattern: 'example\\.com' },
+      ],
+    };
+    const result = expandStep('assert', assertArgs);
+    expect(result.tool).toBe('oc_assert');
+    expect(result.callArgs).toEqual({ assertion: assertArgs });
+  });
+
+  test('assert: url pattern passes verbatim', () => {
+    const assertArgs = { kind: 'url', pattern: 'iana\\.org' };
+    const result = expandStep('assert', assertArgs);
+    expect(result.tool).toBe('oc_assert');
+    expect(result.callArgs).toEqual({ assertion: { kind: 'url', pattern: 'iana\\.org' } });
+  });
+
+  test('all 9 verbs produce non-empty tool names', () => {
+    const verbs: Verb[] = [
+      'navigate', 'interact', 'act', 'fill_form', 'wait_for',
+      'page_screenshot', 'read_page', 'javascript_tool', 'assert',
+    ];
+    for (const verb of verbs) {
+      const result = expandStep(verb, {});
+      expect(result.tool).toBeTruthy();
+      expect(typeof result.callArgs).toBe('object');
+    }
+  });
+});

--- a/tests/cli/playbook/parse.test.ts
+++ b/tests/cli/playbook/parse.test.ts
@@ -1,0 +1,98 @@
+/// <reference types="jest" />
+/**
+ * Tests for cli/playbook/parse.ts
+ */
+
+import * as path from 'path';
+import { parsePlaybookContent, loadPlaybook, ParseError, SUPPORTED_VERBS } from '../../../cli/playbook/parse';
+
+const FIXTURES = path.join(__dirname, '..', '..', 'fixtures', 'playbook');
+
+describe('parsePlaybookContent — YAML', () => {
+  test('round-trips sanity.yaml fixture', () => {
+    const fs = require('fs');
+    const content = fs.readFileSync(path.join(FIXTURES, 'sanity.yaml'), 'utf8');
+    const pb = parsePlaybookContent(content, 'sanity.yaml');
+    expect(pb.name).toBe('example.com sanity');
+    expect(pb.vars).toEqual({ url: 'https://example.com', heading: 'Example' });
+    expect(pb.steps).toHaveLength(9);
+    expect(pb.steps[0].verb).toBe('navigate');
+    expect(pb.steps[0].args).toEqual({ url: '${url}' });
+    expect(pb.steps[1].verb).toBe('assert');
+    expect(pb.steps[1].args).toEqual({ kind: 'dom_text', selector: 'h1', pattern: '${heading}' });
+  });
+
+  test('round-trips sanity.json fixture', () => {
+    const fs = require('fs');
+    const content = fs.readFileSync(path.join(FIXTURES, 'sanity.json'), 'utf8');
+    const pb = parsePlaybookContent(content, 'sanity.json');
+    expect(pb.name).toBe('example.com sanity (JSON)');
+    expect(pb.steps).toHaveLength(9);
+    expect(pb.steps[0].verb).toBe('navigate');
+  });
+
+  test('accepts playbook without name and vars', () => {
+    const yaml = `steps:\n  - navigate:\n      url: https://example.com\n`;
+    const pb = parsePlaybookContent(yaml, 'test.yaml');
+    expect(pb.name).toBeUndefined();
+    expect(pb.vars).toBeUndefined();
+    expect(pb.steps).toHaveLength(1);
+  });
+
+  test('rejects unknown verb', () => {
+    const yaml = `steps:\n  - unknown_verb:\n      foo: bar\n`;
+    expect(() => parsePlaybookContent(yaml, 'test.yaml')).toThrow(ParseError);
+    expect(() => parsePlaybookContent(yaml, 'test.yaml')).toThrow(/unknown verb/i);
+  });
+
+  test('rejects multi-verb step', () => {
+    const yaml = `steps:\n  - navigate:\n      url: https://example.com\n    interact:\n      ref: foo\n`;
+    expect(() => parsePlaybookContent(yaml, 'test.yaml')).toThrow(ParseError);
+    expect(() => parsePlaybookContent(yaml, 'test.yaml')).toThrow(/multiple verb/i);
+  });
+
+  test('rejects missing steps array', () => {
+    const yaml = `name: bad\n`;
+    expect(() => parsePlaybookContent(yaml, 'test.yaml')).toThrow(ParseError);
+    expect(() => parsePlaybookContent(yaml, 'test.yaml')).toThrow(/steps/i);
+  });
+
+  test('rejects non-object top level', () => {
+    const yaml = `- navigate:\n    url: https://example.com\n`;
+    expect(() => parsePlaybookContent(yaml, 'test.yaml')).toThrow(ParseError);
+  });
+
+  test('rejects unsupported file extension', () => {
+    expect(() => parsePlaybookContent('{}', 'test.txt')).toThrow(ParseError);
+    expect(() => parsePlaybookContent('{}', 'test.txt')).toThrow(/unsupported/i);
+  });
+
+  test('all 9 supported verbs are recognized', () => {
+    for (const verb of SUPPORTED_VERBS) {
+      const yaml = `steps:\n  - ${verb}:\n      url: https://example.com\n`;
+      const pb = parsePlaybookContent(yaml, 'test.yaml');
+      expect(pb.steps[0].verb).toBe(verb);
+    }
+  });
+
+  test('rejects invalid YAML syntax', () => {
+    const yaml = `steps:\n  - navigate:\n    url: [unclosed\n`;
+    expect(() => parsePlaybookContent(yaml, 'test.yaml')).toThrow(ParseError);
+  });
+});
+
+describe('loadPlaybook', () => {
+  test('loads sanity.yaml from disk', () => {
+    const pb = loadPlaybook(path.join(FIXTURES, 'sanity.yaml'));
+    expect(pb.steps).toHaveLength(9);
+  });
+
+  test('loads sanity.json from disk', () => {
+    const pb = loadPlaybook(path.join(FIXTURES, 'sanity.json'));
+    expect(pb.steps).toHaveLength(9);
+  });
+
+  test('throws ParseError for missing file', () => {
+    expect(() => loadPlaybook('/nonexistent/path/playbook.yaml')).toThrow(ParseError);
+  });
+});

--- a/tests/cli/playbook/run.test.ts
+++ b/tests/cli/playbook/run.test.ts
@@ -1,0 +1,389 @@
+/// <reference types="jest" />
+/**
+ * Tests for cli/playbook/run.ts
+ *
+ * Uses an in-process mock MCP client to verify:
+ *   1. Call ordering — tools are called in step order with correct args
+ *   2. Fail-fast skip — steps after a failure are skipped, not executed
+ *   3. Exit code semantics — summary.ok reflects pass/fail/skip correctly
+ *   4. JSON output shape — RunResult matches the documented snapshot schema
+ *   5. Assert verdict propagation — 'pass' vs 'fail' verdict drives step status
+ *   6. Transport error escalation — connect() rejection throws TransportError
+ */
+
+import { runPlaybook, RunResult, RunOptions } from '../../../cli/playbook/run';
+import type { Playbook } from '../../../cli/playbook/parse';
+import { TransportError } from '../../../cli/playbook/stdio-client';
+import type { CallResult } from '../../../cli/playbook/stdio-client';
+
+// ---------------------------------------------------------------------------
+// Mock client factory
+// ---------------------------------------------------------------------------
+
+type ToolCall = { tool: string; args: Record<string, unknown> };
+
+interface MockClientOptions {
+  /** Map of tool name → result to return. Missing tools return success:true. */
+  results?: Record<string, CallResult>;
+  /** If set, connect() will reject with this error. */
+  connectError?: Error;
+}
+
+function makeMockClient(opts: MockClientOptions = {}): {
+  client: RunOptions['client'];
+  calls: ToolCall[];
+  disconnected: boolean;
+} {
+  const calls: ToolCall[] = [];
+  let disconnected = false;
+
+  const client: RunOptions['client'] = {
+    async connect(_reuse: boolean): Promise<void> {
+      if (opts.connectError) throw opts.connectError;
+    },
+    async callTool(tool: string, args: Record<string, unknown>): Promise<CallResult> {
+      calls.push({ tool, args });
+      if (opts.results && Object.prototype.hasOwnProperty.call(opts.results, tool)) {
+        return opts.results[tool];
+      }
+      return { success: true, result: { content: [{ type: 'text', text: '{}' }] } };
+    },
+    async disconnect(): Promise<void> {
+      disconnected = true;
+    },
+  };
+
+  return { client, calls, disconnected: false };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture playbooks
+// ---------------------------------------------------------------------------
+
+const sanityPlaybook: Playbook = {
+  name: 'sanity',
+  vars: { url: 'https://example.com' },
+  steps: [
+    { verb: 'navigate', args: { url: '${url}' } },
+    { verb: 'assert', args: { kind: 'dom_text', selector: 'h1', pattern: 'Example' } },
+    { verb: 'interact', args: { ref: 'More information…' } },
+  ],
+};
+
+const failFastPlaybook: Playbook = {
+  name: 'fail-fast fixture',
+  steps: [
+    { verb: 'navigate', args: { url: 'https://example.com' } },
+    { verb: 'assert', args: { kind: 'url', pattern: 'WILL_NOT_MATCH' } },
+    { verb: 'interact', args: { ref: 'should be skipped' } },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Test 1: Call ordering
+// ---------------------------------------------------------------------------
+
+describe('runPlaybook — call ordering', () => {
+  test('calls MCP tools in step order with correct tool names and args', async () => {
+    const { client, calls } = makeMockClient();
+    const varMap = { url: 'https://example.com' };
+
+    await runPlaybook(sanityPlaybook, { reuse: false, varMap, client });
+
+    expect(calls).toHaveLength(3);
+
+    // Step 0: navigate → tool 'navigate', url substituted
+    expect(calls[0].tool).toBe('navigate');
+    expect(calls[0].args).toEqual({ url: 'https://example.com' });
+
+    // Step 1: assert → tool 'oc_assert', wrapped in assertion field
+    expect(calls[1].tool).toBe('oc_assert');
+    expect(calls[1].args).toEqual({
+      assertion: { kind: 'dom_text', selector: 'h1', pattern: 'Example' },
+    });
+
+    // Step 2: interact → tool 'interact', args pass-through
+    expect(calls[2].tool).toBe('interact');
+    expect(calls[2].args).toEqual({ ref: 'More information…' });
+  });
+
+  test('calls disconnect after run regardless of outcome', async () => {
+    const mock = makeMockClient();
+    const { client } = mock;
+    let disconnectCalled = false;
+    const wrappedClient: RunOptions['client'] = {
+      connect: client!.connect.bind(client),
+      callTool: client!.callTool.bind(client),
+      disconnect: async () => { disconnectCalled = true; },
+    };
+
+    await runPlaybook(sanityPlaybook, { reuse: false, varMap: { url: 'https://example.com' }, client: wrappedClient });
+    expect(disconnectCalled).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: Fail-fast skip
+// ---------------------------------------------------------------------------
+
+describe('runPlaybook — fail-fast semantics', () => {
+  test('skips steps after a failed step — does not call their tools', async () => {
+    const { client, calls } = makeMockClient({
+      results: {
+        // navigate succeeds
+        navigate: { success: true, result: null },
+        // oc_assert fails (verdict=fail)
+        oc_assert: { success: false, result: null, verdict: 'fail' },
+      },
+    });
+
+    const result = await runPlaybook(failFastPlaybook, { reuse: false, varMap: {}, client });
+
+    // Only navigate + oc_assert should have been called; interact must be skipped
+    expect(calls).toHaveLength(2);
+    expect(calls[0].tool).toBe('navigate');
+    expect(calls[1].tool).toBe('oc_assert');
+
+    // Step 2 (interact) must be 'skipped' in the result
+    expect(result.steps[2].status).toBe('skipped');
+    expect(result.steps[2].durationMs).toBe(0);
+  });
+
+  test('marks failed step as failed and all subsequent as skipped', async () => {
+    const { client } = makeMockClient({
+      results: {
+        navigate: { success: true, result: null },
+        oc_assert: { success: false, result: null, verdict: 'fail' },
+      },
+    });
+
+    const result = await runPlaybook(failFastPlaybook, { reuse: false, varMap: {}, client });
+
+    expect(result.steps[0].status).toBe('ok');
+    expect(result.steps[1].status).toBe('failed');
+    expect(result.steps[2].status).toBe('skipped');
+  });
+
+  test('summary reflects failed + skipped counts', async () => {
+    const { client } = makeMockClient({
+      results: {
+        navigate: { success: true, result: null },
+        oc_assert: { success: false, result: null },
+      },
+    });
+
+    const result = await runPlaybook(failFastPlaybook, { reuse: false, varMap: {}, client });
+
+    expect(result.summary.ok).toBe(false);
+    expect(result.summary.total).toBe(3);
+    expect(result.summary.passed).toBe(1);
+    expect(result.summary.failed).toBe(1);
+    expect(result.summary.skipped).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3: Exit code semantics via summary.ok
+// ---------------------------------------------------------------------------
+
+describe('runPlaybook — exit code semantics (summary.ok)', () => {
+  test('summary.ok === true when all steps pass (exit 0 path)', async () => {
+    const { client } = makeMockClient({
+      results: {
+        navigate: { success: true, result: null },
+        oc_assert: { success: true, result: null, verdict: 'pass' },
+        interact: { success: true, result: null },
+      },
+    });
+    const varMap = { url: 'https://example.com' };
+
+    const result = await runPlaybook(sanityPlaybook, { reuse: false, varMap, client });
+
+    expect(result.summary.ok).toBe(true);
+    expect(result.summary.failed).toBe(0);
+    expect(result.summary.skipped).toBe(0);
+  });
+
+  test('summary.ok === false when any step fails (exit 1 path)', async () => {
+    const { client } = makeMockClient({
+      results: {
+        navigate: { success: false, result: null },
+      },
+    });
+
+    const result = await runPlaybook(failFastPlaybook, { reuse: false, varMap: {}, client });
+
+    expect(result.summary.ok).toBe(false);
+  });
+
+  test('summary.ok === false when skipped steps exist (partial run)', async () => {
+    const { client } = makeMockClient({
+      results: {
+        navigate: { success: true, result: null },
+        oc_assert: { success: false, result: null },
+        // interact is skipped — never called
+      },
+    });
+
+    const result = await runPlaybook(failFastPlaybook, { reuse: false, varMap: {}, client });
+
+    expect(result.summary.ok).toBe(false);
+    expect(result.summary.skipped).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: JSON output shape (snapshot)
+// ---------------------------------------------------------------------------
+
+describe('runPlaybook — JSON output shape', () => {
+  test('RunResult matches documented schema shape', async () => {
+    const { client } = makeMockClient({
+      results: {
+        navigate: { success: true, result: { url: 'https://example.com' } },
+        oc_assert: { success: true, result: { verdict: 'pass' }, verdict: 'pass' },
+        interact: { success: true, result: null },
+      },
+    });
+    const varMap = { url: 'https://example.com' };
+
+    const result = await runPlaybook(sanityPlaybook, { reuse: false, varMap, client });
+
+    // Top-level fields
+    expect(result).toHaveProperty('name', 'sanity');
+    expect(result).toHaveProperty('steps');
+    expect(result).toHaveProperty('summary');
+    expect(Array.isArray(result.steps)).toBe(true);
+
+    // Each step matches the StepResult shape
+    for (const step of result.steps) {
+      expect(typeof step.index).toBe('number');
+      expect(typeof step.verb).toBe('string');
+      expect(typeof step.tool).toBe('string');
+      expect(typeof step.args).toBe('object');
+      expect(['ok', 'failed', 'skipped']).toContain(step.status);
+      expect(typeof step.durationMs).toBe('number');
+    }
+
+    // Summary shape
+    const { summary } = result;
+    expect(typeof summary.ok).toBe('boolean');
+    expect(typeof summary.total).toBe('number');
+    expect(typeof summary.passed).toBe('number');
+    expect(typeof summary.failed).toBe('number');
+    expect(typeof summary.skipped).toBe('number');
+    expect(summary.total).toBe(3);
+    expect(summary.passed + summary.failed + summary.skipped).toBe(summary.total);
+  });
+
+  test('JSON-serialisable — round-trips through JSON.parse(JSON.stringify())', async () => {
+    const { client } = makeMockClient();
+    const varMap = { url: 'https://example.com' };
+
+    const result = await runPlaybook(sanityPlaybook, { reuse: false, varMap, client });
+    const serialised = JSON.parse(JSON.stringify(result)) as RunResult;
+
+    expect(serialised.name).toBe(result.name);
+    expect(serialised.summary.total).toBe(result.summary.total);
+    expect(serialised.steps).toHaveLength(result.steps.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 5: Assert verdict propagation
+// ---------------------------------------------------------------------------
+
+describe('runPlaybook — assert verdict propagation', () => {
+  test('assert step with verdict=pass is ok', async () => {
+    const assertPlaybook: Playbook = {
+      name: 'assert-pass',
+      steps: [{ verb: 'assert', args: { kind: 'url', pattern: 'example\\.com' } }],
+    };
+
+    const { client } = makeMockClient({
+      results: {
+        oc_assert: { success: true, result: { verdict: 'pass' }, verdict: 'pass' },
+      },
+    });
+
+    const result = await runPlaybook(assertPlaybook, { reuse: false, varMap: {}, client });
+
+    expect(result.steps[0].status).toBe('ok');
+    expect(result.summary.ok).toBe(true);
+  });
+
+  test('assert step with verdict=fail marks step failed', async () => {
+    const assertPlaybook: Playbook = {
+      name: 'assert-fail',
+      steps: [{ verb: 'assert', args: { kind: 'url', pattern: 'WILL_NOT_MATCH' } }],
+    };
+
+    const { client } = makeMockClient({
+      results: {
+        oc_assert: { success: false, result: null, verdict: 'fail' },
+      },
+    });
+
+    const result = await runPlaybook(assertPlaybook, { reuse: false, varMap: {}, client });
+
+    expect(result.steps[0].status).toBe('failed');
+    expect(result.steps[0].error).toMatch(/assert/i);
+    expect(result.summary.ok).toBe(false);
+  });
+
+  test('assert step with verdict=inconclusive counts as failure', async () => {
+    const assertPlaybook: Playbook = {
+      name: 'assert-inconclusive',
+      steps: [{ verb: 'assert', args: { kind: 'dom_text', selector: 'h1', pattern: 'X' } }],
+    };
+
+    const { client } = makeMockClient({
+      results: {
+        // success:false signals non-pass regardless of verdict string
+        oc_assert: { success: false, result: null, verdict: 'inconclusive' },
+      },
+    });
+
+    const result = await runPlaybook(assertPlaybook, { reuse: false, varMap: {}, client });
+
+    expect(result.steps[0].status).toBe('failed');
+    expect(result.summary.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 6: Transport error escalation
+// ---------------------------------------------------------------------------
+
+describe('runPlaybook — transport error escalation', () => {
+  test('connect() failure throws TransportError (exit 3 path)', async () => {
+    const { client } = makeMockClient({
+      connectError: new Error('ECONNREFUSED'),
+    });
+
+    await expect(
+      runPlaybook(sanityPlaybook, { reuse: false, varMap: { url: 'https://example.com' }, client }),
+    ).rejects.toThrow(TransportError);
+  });
+
+  test('callTool() rejection marks step failed and stops playbook', async () => {
+    let callCount = 0;
+    const client: RunOptions['client'] = {
+      async connect() {},
+      async callTool(tool) {
+        callCount++;
+        if (tool === 'oc_assert') throw new Error('network timeout');
+        return { success: true, result: null };
+      },
+      async disconnect() {},
+    };
+
+    const result = await runPlaybook(failFastPlaybook, { reuse: false, varMap: {}, client });
+
+    // navigate + oc_assert called; interact must be skipped
+    expect(callCount).toBe(2);
+    expect(result.steps[1].status).toBe('failed');
+    expect(result.steps[1].error).toContain('network timeout');
+    expect(result.steps[2].status).toBe('skipped');
+  });
+});

--- a/tests/cli/playbook/vars.test.ts
+++ b/tests/cli/playbook/vars.test.ts
@@ -1,0 +1,126 @@
+/// <reference types="jest" />
+/**
+ * Tests for cli/playbook/vars.ts
+ */
+
+import {
+  buildVarMap,
+  substituteString,
+  substituteValue,
+  parseCliVars,
+  VarError,
+} from '../../../cli/playbook/vars';
+
+describe('buildVarMap', () => {
+  test('merges playbook vars and CLI vars', () => {
+    const result = buildVarMap({ url: 'https://example.com', heading: 'Hello' }, { heading: 'World' });
+    expect(result).toEqual({ url: 'https://example.com', heading: 'World' });
+  });
+
+  test('CLI vars override playbook vars', () => {
+    const result = buildVarMap({ url: 'orig' }, { url: 'override' });
+    expect(result.url).toBe('override');
+  });
+
+  test('handles undefined playbookVars', () => {
+    const result = buildVarMap(undefined, { url: 'https://example.com' });
+    expect(result).toEqual({ url: 'https://example.com' });
+  });
+});
+
+describe('substituteString', () => {
+  const varMap = { url: 'https://example.com', heading: 'World' };
+
+  test('substitutes a single variable', () => {
+    expect(substituteString('${url}', varMap)).toBe('https://example.com');
+  });
+
+  test('substitutes multiple variables', () => {
+    expect(substituteString('Visit ${url} and say ${heading}', varMap)).toBe(
+      'Visit https://example.com and say World',
+    );
+  });
+
+  test('returns string unchanged when no vars present', () => {
+    expect(substituteString('no vars here', varMap)).toBe('no vars here');
+  });
+
+  test('throws VarError for unknown variable', () => {
+    expect(() => substituteString('${unknown}', varMap)).toThrow(VarError);
+    expect(() => substituteString('${unknown}', varMap)).toThrow(/unknown/i);
+  });
+
+  test('throws VarError and includes step index in message', () => {
+    try {
+      substituteString('${missing}', varMap, 3);
+      fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(VarError);
+      const varErr = err as VarError;
+      expect(varErr.stepIndex).toBe(3);
+      expect(varErr.message).toContain('step 3');
+    }
+  });
+
+  test('SECRET: namespace emits warning and resolves from varMap', () => {
+    const stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const map = { 'SECRET:MY_TOKEN': 'secret-value' };
+    const result = substituteString('${SECRET:MY_TOKEN}', map);
+    expect(result).toBe('secret-value');
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('SECRET:MY_TOKEN'));
+    stderrSpy.mockRestore();
+  });
+
+  test('SECRET: namespace with missing var throws VarError with warning', () => {
+    const stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => substituteString('${SECRET:MISSING}', {})).toThrow(VarError);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('SECRET:MISSING'));
+    stderrSpy.mockRestore();
+  });
+});
+
+describe('substituteValue', () => {
+  const varMap = { base: 'https://example.com' };
+
+  test('substitutes in a flat object', () => {
+    const result = substituteValue({ url: '${base}/path' }, varMap);
+    expect(result).toEqual({ url: 'https://example.com/path' });
+  });
+
+  test('substitutes in nested object', () => {
+    const result = substituteValue({ a: { b: '${base}' } }, varMap);
+    expect(result).toEqual({ a: { b: 'https://example.com' } });
+  });
+
+  test('substitutes in arrays', () => {
+    const result = substituteValue(['${base}', 'literal'], varMap);
+    expect(result).toEqual(['https://example.com', 'literal']);
+  });
+
+  test('passes through non-string values unchanged', () => {
+    const result = substituteValue({ count: 42, flag: true, nil: null }, varMap);
+    expect(result).toEqual({ count: 42, flag: true, nil: null });
+  });
+});
+
+describe('parseCliVars', () => {
+  test('parses KEY=VALUE entries', () => {
+    expect(parseCliVars(['url=https://example.com', 'name=Alice'])).toEqual({
+      url: 'https://example.com',
+      name: 'Alice',
+    });
+  });
+
+  test('handles value with = sign', () => {
+    expect(parseCliVars(['expr=a=b'])).toEqual({ expr: 'a=b' });
+  });
+
+  test('handles empty array', () => {
+    expect(parseCliVars([])).toEqual({});
+  });
+
+  test('throws VarError for missing = sign', () => {
+    expect(() => parseCliVars(['noequals'])).toThrow(VarError);
+    expect(() => parseCliVars(['noequals'])).toThrow(/KEY=VALUE/i);
+  });
+});

--- a/tests/fixtures/playbook/fail-fast.yaml
+++ b/tests/fixtures/playbook/fail-fast.yaml
@@ -1,0 +1,9 @@
+name: fail-fast fixture
+steps:
+  - navigate:
+      url: https://example.com
+  - assert:
+      kind: url
+      pattern: "WILL_NOT_MATCH"
+  - interact:
+      ref: "should be skipped"

--- a/tests/fixtures/playbook/sanity.json
+++ b/tests/fixtures/playbook/sanity.json
@@ -1,0 +1,18 @@
+{
+  "name": "example.com sanity (JSON)",
+  "vars": {
+    "url": "https://example.com",
+    "heading": "Example"
+  },
+  "steps": [
+    { "navigate": { "url": "${url}" } },
+    { "assert": { "kind": "dom_text", "selector": "h1", "pattern": "${heading}" } },
+    { "interact": { "ref": "More information…" } },
+    { "wait_for": { "condition": "navigation" } },
+    { "assert": { "kind": "url", "pattern": "iana\\.org" } },
+    { "page_screenshot": { "path": "/tmp/sanity.png" } },
+    { "read_page": { "mode": "ax" } },
+    { "javascript_tool": { "code": "document.title" } },
+    { "act": { "action": "scroll down" } }
+  ]
+}

--- a/tests/fixtures/playbook/sanity.yaml
+++ b/tests/fixtures/playbook/sanity.yaml
@@ -1,0 +1,26 @@
+name: example.com sanity
+vars:
+  url: https://example.com
+  heading: Example
+steps:
+  - navigate:
+      url: ${url}
+  - assert:
+      kind: dom_text
+      selector: h1
+      pattern: ${heading}
+  - interact:
+      ref: "More information…"
+  - wait_for:
+      condition: "navigation"
+  - assert:
+      kind: url
+      pattern: "iana\\.org"
+  - page_screenshot:
+      path: /tmp/sanity.png
+  - read_page:
+      mode: ax
+  - javascript_tool:
+      code: "document.title"
+  - act:
+      action: "scroll down"


### PR DESCRIPTION
Closes #854.

## Summary
- New CLI subcommand: `oc playbook run <file> [--vars k=v] [--out PATH] [--reuse] [--json]`.
- Accepts YAML (`.yaml`/`.yml`) and JSON (`.json`) playbooks. Both share the same validation path.
- 9 supported step verbs: `navigate`, `interact`, `act`, `fill_form`, `wait_for`, `page_screenshot`, `read_page`, `javascript_tool`, `assert` (→ `oc_assert`, including nested `and`/`or`/`not`).
- Variable substitution: `${var}` (any case-letter identifier) from CLI `--vars` (overrides) and the `vars:` block. `${SECRET:NAME}` pass-through with stderr warning until #834 lands.
- Linear, fail-fast execution. Subsequent steps marked `skipped` after first failure.
- Structured JSON output schema (snapshot-tested), markdown report, plain stdout default.
- Exit codes: `0` all pass, `1` failure, `2` usage/parse/unknown-var, `3` io/spawn/transport.
- One new dependency: `yaml@^2` (eemeli/yaml, MIT, zero transitive deps).

## Portability-Harness Contract
- **P1** Runner is a *client of* the MCP server; each YAML step expands to exactly one MCP tool call. No new orchestration tier inside the server.
- **P2** Existing CLI subcommands and MCP wire format untouched. New behavior exclusively under `oc playbook ...`.
- **P3** No LLM calls. Pure file → MCP call expansion.
- **P4** Encodes *user-authored* workflow; no autonomous decisions. No `if`/`loop`/`parallel` constructs (deferred follow-up).
- **P5** No new persistent storage. Output is stdout / `--out` file.

## Test plan
Unit + integration:
- `tests/cli/playbook/parse.test.ts` — round-trip + reject unknown verb / multi-verb step / unknown var
- `tests/cli/playbook/vars.test.ts` — substitution matrix
- `tests/cli/playbook/expand.test.ts` — verb → tool mapping, including nested assertions
- `tests/cli/playbook/run.test.ts` — call ordering, fail-fast skip, exit codes, JSON shape
- Fixtures: `tests/fixtures/playbook/sanity.yaml`, `sanity.json`, fail-fast fixture
- `npm run build && npm test && npm run lint` green

Post-merge real verification (full matrix in #854's "Real verification" section):
- Happy path: `oc playbook run /tmp/sanity.yaml --reuse --json` → exit 0, 5/5 pass, deterministic across 5 runs
- Failure path: `pattern:"NotPresent"` → exit 1, summary shows 1 failed + 3 skipped
- Parse failures: multi-verb step, unknown var, unknown verb → exit 2
- Var override via `--vars`
- Secrets pass-through (warning until #834)
- `--reuse` vs one-shot spawn
- JSON-format playbook code-path parity
- Recording integration (depends on #852 merging)

## Follow-ups (out of scope)
- `if`/`loop`/`parallel` constructs.
- `--continue-on-error` flag.
- Recording a playbook from a live session (build on #836 codegen output).
- Test-runner integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
