### PR TITLE
feat(core): performance insight 2-step API — oc_performance_insights / oc_performance_analyze (#846)

### DIFF
--- a/src/core/performance/insights/evaluators.ts
+++ b/src/core/performance/insights/evaluators.ts
@@ -1,0 +1,536 @@
+/**
+ * v1 hand-rolled performance-insight evaluators (#846).
+ *
+ * Six evaluators consume a CDP trace document and produce a one-line
+ * summary plus a Markdown drill-down. The evaluators are intentionally
+ * conservative — they extract a small number of well-known events and
+ * derive a single causal narrative each, rather than attempting to
+ * replicate the full chrome-devtools-frontend Insight engine.
+ *
+ * The follow-up PR vendoring `chrome-devtools-frontend` will replace the
+ * bodies of these functions with calls into the upstream insight modules.
+ * The public surface (one_line + details_md + evidence[]) is designed so
+ * that swap is a non-breaking change for the MCP tool layer.
+ */
+
+import { scrubString } from '../../trace/redactor';
+import type {
+  EvaluatorFn,
+  EvaluatorResult,
+  InsightDetails,
+  InsightName,
+  InsightSummary,
+  TraceDocument,
+  TraceEventRecord,
+} from './types';
+
+/** Microseconds → milliseconds, rounded to 1 decimal. */
+function usToMs(us: number): number {
+  return Math.round(us / 100) / 10;
+}
+
+/** Milliseconds → "1.2s" or "950ms" for human-readable summaries. */
+function fmtMs(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+  return `${Math.round(ms)}ms`;
+}
+
+/** Pick a tier label from a numeric ms threshold. */
+function severityForMs(
+  ms: number,
+  warnAt: number,
+  critAt: number,
+): InsightSummary['severity'] {
+  if (ms >= critAt) return 'critical';
+  if (ms >= warnAt) return 'warn';
+  return 'info';
+}
+
+/** Filter helper: events whose category list contains `wanted`. */
+function eventsInCategory(events: TraceEventRecord[], wanted: string): TraceEventRecord[] {
+  return events.filter((e) => {
+    if (!e.cat) return false;
+    return e.cat.split(',').some((c) => c.trim() === wanted);
+  });
+}
+
+/** Filter helper: events with a matching `name`. */
+function eventsByName(events: TraceEventRecord[], name: string): TraceEventRecord[] {
+  return events.filter((e) => e.name === name);
+}
+
+/** Try to extract a hostname from a URL string; falls back to the input. */
+function hostnameOf(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Redact a URL before embedding it in a Markdown details string. The
+ * trace redactor scrubs query-string credentials, JWTs, and other
+ * patterns; the result is safe to surface back to the agent.
+ */
+function safeUrl(url: string): string {
+  return scrubString(url);
+}
+
+/** Build a no-data placeholder result for a given insight. */
+function noData(insight: InsightName): EvaluatorResult {
+  const summary: InsightSummary = {
+    name: insight,
+    severity: 'info',
+    one_line: 'no data',
+  };
+  const details: InsightDetails = {
+    insight,
+    details_md: `# ${insight}\n\nNo trace events matched this insight.`,
+    evidence: [],
+  };
+  return { summary, details };
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* LCPBreakdown                                                         */
+/* ──────────────────────────────────────────────────────────────────── */
+
+interface LcpCandidate {
+  ts: number;
+  size: number;
+  url?: string;
+  nodeName?: string;
+}
+
+function extractLcpCandidates(trace: TraceDocument): LcpCandidate[] {
+  const out: LcpCandidate[] = [];
+  for (const e of trace.traceEvents) {
+    if (
+      e.name === 'largestContentfulPaint::Candidate' ||
+      e.name === 'LargestContentfulPaint::Candidate'
+    ) {
+      const args = (e.args ?? {}) as Record<string, unknown>;
+      const data = (args.data ?? args) as Record<string, unknown>;
+      const size =
+        typeof data.size === 'number'
+          ? data.size
+          : typeof data.candidateSize === 'number'
+            ? (data.candidateSize as number)
+            : 0;
+      const url = typeof data.url === 'string' ? data.url : undefined;
+      const nodeName = typeof data.nodeName === 'string' ? data.nodeName : undefined;
+      out.push({ ts: typeof e.ts === 'number' ? e.ts : 0, size, url, nodeName });
+    }
+  }
+  return out;
+}
+
+const lcpBreakdown: EvaluatorFn = (trace) => {
+  const candidates = extractLcpCandidates(trace);
+  if (candidates.length === 0) return null;
+  // Last candidate is the final LCP (CDP convention).
+  const winner = candidates[candidates.length - 1];
+  const lcpMs = usToMs(winner.ts);
+  const severity = severityForMs(lcpMs, 2500, 4000);
+  const target = winner.url
+    ? safeUrl(winner.url)
+    : winner.nodeName
+      ? `<${winner.nodeName}>`
+      : 'unknown element';
+  const summary: InsightSummary = {
+    name: 'LCPBreakdown',
+    severity,
+    one_line: `LCP ${fmtMs(lcpMs)} — largest contributor: ${target}`,
+  };
+  const lines: string[] = [
+    `# LCPBreakdown`,
+    ``,
+    `**LCP**: ${fmtMs(lcpMs)} (${severity})`,
+    ``,
+    `**Largest contributor**: ${target}`,
+  ];
+  if (typeof winner.size === 'number' && winner.size > 0) {
+    lines.push(`**Element size**: ${winner.size}px`);
+  }
+  if (candidates.length > 1) {
+    lines.push(``, `**Candidates seen**: ${candidates.length}`);
+  }
+  const evidence: InsightDetails['evidence'] = [];
+  if (winner.url) {
+    evidence.push({ kind: 'request', ref: safeUrl(winner.url) });
+  }
+  evidence.push({ kind: 'metric', ref: `LCP=${fmtMs(lcpMs)}` });
+  return {
+    summary,
+    details: { insight: 'LCPBreakdown', details_md: lines.join('\n'), evidence },
+  };
+};
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* DocumentLatency                                                      */
+/* ──────────────────────────────────────────────────────────────────── */
+
+const documentLatency: EvaluatorFn = (trace) => {
+  // Look for the main resourceSendRequest + resourceReceiveResponse pair
+  // for the top-level navigation document. We identify the document
+  // request via `args.data.resourceType === 'Document'` if present, else
+  // by being the earliest resourceSendRequest.
+  const sends = eventsByName(trace.traceEvents, 'ResourceSendRequest');
+  const receives = eventsByName(trace.traceEvents, 'ResourceReceiveResponse');
+  if (sends.length === 0 && receives.length === 0) return null;
+
+  let docSend: TraceEventRecord | undefined;
+  for (const ev of sends) {
+    const data = ((ev.args ?? {}) as Record<string, unknown>).data as
+      | Record<string, unknown>
+      | undefined;
+    if (data && (data.resourceType === 'Document' || data.requestPriority === 'VeryHigh')) {
+      docSend = ev;
+      break;
+    }
+  }
+  if (!docSend && sends.length > 0) {
+    docSend = sends.reduce((a, b) => ((a.ts ?? 0) <= (b.ts ?? 0) ? a : b));
+  }
+  if (!docSend) return null;
+
+  const sendData = ((docSend.args ?? {}) as Record<string, unknown>).data as
+    | Record<string, unknown>
+    | undefined;
+  const requestId = sendData && typeof sendData.requestId === 'string' ? sendData.requestId : undefined;
+  const url = sendData && typeof sendData.url === 'string' ? sendData.url : undefined;
+
+  let docReceive: TraceEventRecord | undefined;
+  if (requestId) {
+    docReceive = receives.find((r) => {
+      const d = ((r.args ?? {}) as Record<string, unknown>).data as
+        | Record<string, unknown>
+        | undefined;
+      return d && d.requestId === requestId;
+    });
+  }
+  docReceive ??= receives[0];
+
+  const sendTs = typeof docSend.ts === 'number' ? docSend.ts : 0;
+  const recvTs = docReceive && typeof docReceive.ts === 'number' ? docReceive.ts : sendTs;
+  const ttfbMs = usToMs(Math.max(0, recvTs - sendTs));
+  const severity = severityForMs(ttfbMs, 600, 1500);
+
+  const summary: InsightSummary = {
+    name: 'DocumentLatency',
+    severity,
+    one_line: `Document TTFB ${fmtMs(ttfbMs)}${url ? ` for ${hostnameOf(url)}` : ''}`,
+  };
+
+  const lines = [
+    `# DocumentLatency`,
+    ``,
+    `**TTFB**: ${fmtMs(ttfbMs)} (${severity})`,
+  ];
+  if (url) lines.push(`**Document URL host**: ${hostnameOf(url)}`);
+  if (requestId) lines.push(`**Request ID**: ${requestId}`);
+
+  const evidence: InsightDetails['evidence'] = [];
+  if (url) evidence.push({ kind: 'request', ref: safeUrl(url) });
+  evidence.push({ kind: 'metric', ref: `TTFB=${fmtMs(ttfbMs)}` });
+
+  return {
+    summary,
+    details: { insight: 'DocumentLatency', details_md: lines.join('\n'), evidence },
+  };
+};
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* RenderBlocking                                                       */
+/* ──────────────────────────────────────────────────────────────────── */
+
+const renderBlocking: EvaluatorFn = (trace) => {
+  // Render-blocking resources are reported via ResourceSendRequest with
+  // `args.data.renderBlocking === 'blocking'` (Chrome ≥ 110). Older
+  // traces use `args.data.renderBlocking === true`. We accept both.
+  const sends = eventsByName(trace.traceEvents, 'ResourceSendRequest');
+  const blocking: { url: string; type: string }[] = [];
+  for (const ev of sends) {
+    const data = ((ev.args ?? {}) as Record<string, unknown>).data as
+      | Record<string, unknown>
+      | undefined;
+    if (!data) continue;
+    const rb = data.renderBlocking;
+    const isBlocking = rb === 'blocking' || rb === 'in_body_parser_blocking' || rb === true;
+    if (!isBlocking) continue;
+    const url = typeof data.url === 'string' ? data.url : '';
+    if (!url) continue;
+    const type = typeof data.resourceType === 'string' ? (data.resourceType as string) : 'Other';
+    blocking.push({ url, type });
+  }
+
+  if (blocking.length === 0) {
+    return {
+      summary: {
+        name: 'RenderBlocking',
+        severity: 'info',
+        one_line: 'no render-blocking resources detected',
+      },
+      details: {
+        insight: 'RenderBlocking',
+        details_md: `# RenderBlocking\n\nNo render-blocking resources detected in this trace.`,
+        evidence: [],
+      },
+    };
+  }
+
+  const severity = blocking.length >= 5 ? 'critical' : blocking.length >= 2 ? 'warn' : 'info';
+  const summary: InsightSummary = {
+    name: 'RenderBlocking',
+    severity,
+    one_line: `${blocking.length} render-blocking resource${blocking.length === 1 ? '' : 's'}`,
+  };
+  const lines = [`# RenderBlocking`, ``, `**Count**: ${blocking.length}`, ``, `## Resources`, ``];
+  for (const r of blocking.slice(0, 20)) {
+    lines.push(`- (${r.type}) ${safeUrl(r.url)}`);
+  }
+  if (blocking.length > 20) lines.push(`- … and ${blocking.length - 20} more`);
+  const evidence: InsightDetails['evidence'] = blocking.slice(0, 20).map((r) => ({
+    kind: 'request' as const,
+    ref: safeUrl(r.url),
+  }));
+  return {
+    summary,
+    details: { insight: 'RenderBlocking', details_md: lines.join('\n'), evidence },
+  };
+};
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* CLSCulprits                                                          */
+/* ──────────────────────────────────────────────────────────────────── */
+
+const clsCulprits: EvaluatorFn = (trace) => {
+  // Layout-shift events arrive as `LayoutShift` with `args.data.score`.
+  const shifts = eventsByName(trace.traceEvents, 'LayoutShift');
+  if (shifts.length === 0) return null;
+  let cls = 0;
+  const culprits: { score: number; ts: number }[] = [];
+  for (const ev of shifts) {
+    const data = ((ev.args ?? {}) as Record<string, unknown>).data as
+      | Record<string, unknown>
+      | undefined;
+    const score =
+      data && typeof data.score === 'number' ? (data.score as number) :
+      data && typeof data.weighted_score_delta === 'number' ? (data.weighted_score_delta as number) :
+      0;
+    cls += score;
+    culprits.push({ score, ts: typeof ev.ts === 'number' ? ev.ts : 0 });
+  }
+  const clsRounded = Math.round(cls * 1000) / 1000;
+  const severity = clsRounded >= 0.25 ? 'critical' : clsRounded >= 0.1 ? 'warn' : 'info';
+  const summary: InsightSummary = {
+    name: 'CLSCulprits',
+    severity,
+    one_line: `CLS ${clsRounded.toFixed(3)} from ${culprits.length} shift${culprits.length === 1 ? '' : 's'}`,
+  };
+  culprits.sort((a, b) => b.score - a.score);
+  const top = culprits.slice(0, 5);
+  const lines = [
+    `# CLSCulprits`,
+    ``,
+    `**Total CLS**: ${clsRounded.toFixed(3)} (${severity})`,
+    `**Shift count**: ${culprits.length}`,
+    ``,
+    `## Top contributors`,
+    ``,
+  ];
+  for (const c of top) {
+    lines.push(`- score=${c.score.toFixed(3)} at ${fmtMs(usToMs(c.ts))}`);
+  }
+  const evidence: InsightDetails['evidence'] = [
+    { kind: 'metric', ref: `CLS=${clsRounded.toFixed(3)}` },
+    ...top.map((c) => ({
+      kind: 'event' as const,
+      ref: `LayoutShift score=${c.score.toFixed(3)}@${fmtMs(usToMs(c.ts))}`,
+    })),
+  ];
+  return {
+    summary,
+    details: { insight: 'CLSCulprits', details_md: lines.join('\n'), evidence },
+  };
+};
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* LongTasks                                                            */
+/* ──────────────────────────────────────────────────────────────────── */
+
+const longTasks: EvaluatorFn = (trace) => {
+  // Main-thread "RunTask" events with dur > 50000 us (50 ms) are the
+  // PerformanceObserver definition of a long task.
+  const tasks = eventsByName(trace.traceEvents, 'RunTask').concat(
+    eventsByName(trace.traceEvents, 'Task'),
+  );
+  const long = tasks
+    .filter((e) => typeof e.dur === 'number' && (e.dur as number) >= 50_000)
+    .sort((a, b) => (b.dur as number) - (a.dur as number));
+  if (long.length === 0) {
+    return {
+      summary: {
+        name: 'LongTasks',
+        severity: 'info',
+        one_line: 'no long tasks (>50ms) detected',
+      },
+      details: {
+        insight: 'LongTasks',
+        details_md: `# LongTasks\n\nNo long tasks (>50ms) detected in this trace.`,
+        evidence: [],
+      },
+    };
+  }
+  const totalBlockingMs = long.reduce(
+    (acc, t) => acc + Math.max(0, usToMs((t.dur as number) - 50_000)),
+    0,
+  );
+  const severity = totalBlockingMs >= 600 ? 'critical' : totalBlockingMs >= 200 ? 'warn' : 'info';
+  const summary: InsightSummary = {
+    name: 'LongTasks',
+    severity,
+    one_line: `${long.length} long task${long.length === 1 ? '' : 's'}, ~${fmtMs(totalBlockingMs)} blocking`,
+  };
+  const lines = [
+    `# LongTasks`,
+    ``,
+    `**Long tasks**: ${long.length}`,
+    `**Total blocking time**: ${fmtMs(totalBlockingMs)} (${severity})`,
+    ``,
+    `## Top tasks`,
+    ``,
+  ];
+  for (const t of long.slice(0, 5)) {
+    lines.push(`- ${fmtMs(usToMs(t.dur as number))} at ${fmtMs(usToMs(t.ts ?? 0))}`);
+  }
+  const evidence: InsightDetails['evidence'] = [
+    { kind: 'metric', ref: `TBT=${fmtMs(totalBlockingMs)}` },
+    ...long.slice(0, 5).map((t) => ({
+      kind: 'event' as const,
+      ref: `LongTask dur=${fmtMs(usToMs(t.dur as number))}@${fmtMs(usToMs(t.ts ?? 0))}`,
+    })),
+  ];
+  return {
+    summary,
+    details: { insight: 'LongTasks', details_md: lines.join('\n'), evidence },
+  };
+};
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* ThirdParties                                                         */
+/* ──────────────────────────────────────────────────────────────────── */
+
+const thirdParties: EvaluatorFn = (trace) => {
+  const sends = eventsByName(trace.traceEvents, 'ResourceSendRequest');
+  if (sends.length === 0) return null;
+  // Determine first-party host from the first Document request, fall
+  // back to the most-frequently-seen host if the document isn't tagged.
+  let firstPartyHost: string | undefined;
+  for (const ev of sends) {
+    const data = ((ev.args ?? {}) as Record<string, unknown>).data as
+      | Record<string, unknown>
+      | undefined;
+    if (data && data.resourceType === 'Document' && typeof data.url === 'string') {
+      firstPartyHost = hostnameOf(data.url);
+      break;
+    }
+  }
+  // Tally bytes per host. CDP supplies `encodedDataLength` on
+  // `ResourceFinish`, but for portability we first count requests; then
+  // augment with bytes when present.
+  const byHost = new Map<string, { count: number; bytes: number }>();
+  const finishMap = new Map<string, number>();
+  for (const ev of eventsByName(trace.traceEvents, 'ResourceFinish')) {
+    const data = ((ev.args ?? {}) as Record<string, unknown>).data as
+      | Record<string, unknown>
+      | undefined;
+    if (!data) continue;
+    const rid = typeof data.requestId === 'string' ? data.requestId : undefined;
+    const bytes = typeof data.encodedDataLength === 'number' ? (data.encodedDataLength as number) : 0;
+    if (rid) finishMap.set(rid, bytes);
+  }
+  for (const ev of sends) {
+    const data = ((ev.args ?? {}) as Record<string, unknown>).data as
+      | Record<string, unknown>
+      | undefined;
+    if (!data || typeof data.url !== 'string') continue;
+    const host = hostnameOf(data.url);
+    if (!host) continue;
+    const rid = typeof data.requestId === 'string' ? data.requestId : '';
+    const bytes = finishMap.get(rid) ?? 0;
+    const cur = byHost.get(host) ?? { count: 0, bytes: 0 };
+    cur.count += 1;
+    cur.bytes += bytes;
+    byHost.set(host, cur);
+  }
+  if (!firstPartyHost) {
+    let max = 0;
+    for (const [h, v] of byHost.entries()) {
+      if (v.count > max) {
+        max = v.count;
+        firstPartyHost = h;
+      }
+    }
+  }
+  const thirdPartyEntries = Array.from(byHost.entries())
+    .filter(([h]) => h !== firstPartyHost)
+    .sort((a, b) => b[1].count - a[1].count);
+  if (thirdPartyEntries.length === 0) {
+    return {
+      summary: {
+        name: 'ThirdParties',
+        severity: 'info',
+        one_line: 'no third-party origins detected',
+      },
+      details: {
+        insight: 'ThirdParties',
+        details_md: `# ThirdParties\n\nAll resources were served from the first-party host${firstPartyHost ? ` \`${firstPartyHost}\`` : ''}.`,
+        evidence: [],
+      },
+    };
+  }
+  const totalRequests = thirdPartyEntries.reduce((a, [, v]) => a + v.count, 0);
+  const severity = thirdPartyEntries.length >= 10 ? 'warn' : 'info';
+  const summary: InsightSummary = {
+    name: 'ThirdParties',
+    severity,
+    one_line: `${thirdPartyEntries.length} third-party origin${thirdPartyEntries.length === 1 ? '' : 's'}, ${totalRequests} request${totalRequests === 1 ? '' : 's'}`,
+  };
+  const lines = [
+    `# ThirdParties`,
+    ``,
+    `**First-party host**: \`${firstPartyHost ?? 'unknown'}\``,
+    `**Third-party origins**: ${thirdPartyEntries.length}`,
+    `**Third-party requests**: ${totalRequests}`,
+    ``,
+    `## Top origins`,
+    ``,
+  ];
+  for (const [host, v] of thirdPartyEntries.slice(0, 10)) {
+    const bytesPart = v.bytes > 0 ? `, ${(v.bytes / 1024).toFixed(1)} KB` : '';
+    lines.push(`- \`${host}\` — ${v.count} request${v.count === 1 ? '' : 's'}${bytesPart}`);
+  }
+  const evidence: InsightDetails['evidence'] = thirdPartyEntries.slice(0, 10).map(([host, v]) => ({
+    kind: 'request' as const,
+    ref: `${host} (${v.count})`,
+  }));
+  return {
+    summary,
+    details: { insight: 'ThirdParties', details_md: lines.join('\n'), evidence },
+  };
+};
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Engine entry points                                                  */
+/* ──────────────────────────────────────────────────────────────────── */
+
+export const EVALUATORS: Record<InsightName, EvaluatorFn> = {
+  LCPBreakdown: lcpBreakdown,
+  DocumentLatency: documentLatency,
+  RenderBlocking: renderBlocking,
+  CLSCulprits: clsCulprits,
+  LongTasks: longTasks,
+  ThirdParties: thirdParties,
+};

--- a/src/core/performance/insights/evaluators.ts
+++ b/src/core/performance/insights/evaluators.ts
@@ -78,18 +78,50 @@ function safeUrl(url: string): string {
 }
 
 /** Build a no-data placeholder result for a given insight. */
-function noData(insight: InsightName): EvaluatorResult {
+function noData(insight: InsightName, reason?: string): EvaluatorResult {
+  const reasonSuffix = reason ? ` (${reason})` : '';
   const summary: InsightSummary = {
     name: insight,
     severity: 'info',
-    one_line: 'no data',
+    one_line: `no data${reasonSuffix}`,
   };
+  const reasonLine = reason ? `\n\n**Reason**: \`${reason}\`` : '';
   const details: InsightDetails = {
     insight,
-    details_md: `# ${insight}\n\nNo trace events matched this insight.`,
-    evidence: [],
+    details_md: `# ${insight}\n\nNo trace events matched this insight.${reasonLine}`,
+    evidence: reason ? [{ kind: 'metric', ref: `reason=${reason}` }] : [],
   };
   return { summary, details };
+}
+
+/**
+ * Find the trace-clock timestamp of the first `navigationStart` event.
+ * Chrome trace events use a tracing-clock (μs since an arbitrary epoch),
+ * NOT elapsed time since navigation. To convert a raw `ts` into an
+ * elapsed-since-nav value, callers must subtract this navStart.
+ *
+ * Returns `undefined` if no navigationStart marker is present — in that
+ * case evaluators that depend on a nav-relative timeline (LCP, FCP)
+ * should surface `no_data` with reason `unknown_navigation_start` rather
+ * than emit a multi-billion-millisecond bogus value.
+ */
+function findNavigationStartTs(trace: TraceDocument): number | undefined {
+  for (const e of trace.traceEvents) {
+    if (e.name !== 'navigationStart') continue;
+    if (typeof e.ts !== 'number') continue;
+    // Accept the conventional categories: blink.user_timing, loading,
+    // and the bare event (older traces). The first matching event wins.
+    const cats = typeof e.cat === 'string' ? e.cat.split(',').map((c) => c.trim()) : [];
+    if (
+      cats.length === 0 ||
+      cats.includes('blink.user_timing') ||
+      cats.includes('loading') ||
+      cats.includes('navigation')
+    ) {
+      return e.ts;
+    }
+  }
+  return undefined;
 }
 
 /* ──────────────────────────────────────────────────────────────────── */
@@ -131,7 +163,14 @@ const lcpBreakdown: EvaluatorFn = (trace) => {
   if (candidates.length === 0) return null;
   // Last candidate is the final LCP (CDP convention).
   const winner = candidates[candidates.length - 1];
-  const lcpMs = usToMs(winner.ts);
+  // Chrome trace `ts` values are tracing-clock μs, not elapsed-since-nav.
+  // We must normalize to navigation-start so reported LCP is a sane
+  // millisecond figure (vs. multi-billion μs from the tracing-clock epoch).
+  const navStart = findNavigationStartTs(trace);
+  if (navStart === undefined || winner.ts <= navStart) {
+    return noData('LCPBreakdown', 'unknown_navigation_start');
+  }
+  const lcpMs = usToMs(winner.ts - navStart);
   const severity = severityForMs(lcpMs, 2500, 4000);
   const target = winner.url
     ? safeUrl(winner.url)

--- a/src/core/performance/insights/index.ts
+++ b/src/core/performance/insights/index.ts
@@ -1,0 +1,104 @@
+/**
+ * Public surface for the v1 performance-insight engine (#846).
+ *
+ * This module is the entry point used by the MCP tools. It does not
+ * import any chrome-devtools-frontend types so that the planned
+ * vendoring follow-up can swap in the real engine without touching the
+ * MCP tool layer.
+ */
+
+import { EVALUATORS } from './evaluators';
+import {
+  INSIGHT_NAMES,
+  type EvaluatorResult,
+  type InsightDetails,
+  type InsightName,
+  type InsightSummary,
+  type TraceDocument,
+  type TraceEventRecord,
+} from './types';
+
+export {
+  INSIGHT_NAMES,
+  type EvaluatorResult,
+  type InsightDetails,
+  type InsightName,
+  type InsightSummary,
+  type TraceDocument,
+  type TraceEventRecord,
+};
+
+/**
+ * Run every v1 evaluator over a trace document. Evaluators that return
+ * `null` (no relevant trace events) are mapped to an `info`/`no data`
+ * placeholder so the closed-set surface stays predictable for the
+ * agent. Returns both the per-insight summary list (for
+ * `oc_performance_insights`) and the keyed details map (for
+ * `oc_performance_analyze`).
+ */
+export function evaluateInsights(trace: TraceDocument): {
+  summaries: InsightSummary[];
+  details: Record<InsightName, InsightDetails>;
+} {
+  const summaries: InsightSummary[] = [];
+  const details = {} as Record<InsightName, InsightDetails>;
+  for (const name of INSIGHT_NAMES) {
+    const evaluator = EVALUATORS[name];
+    let result: EvaluatorResult | null = null;
+    try {
+      result = evaluator(trace);
+    } catch (err) {
+      // A misbehaving evaluator must not take down the others. Surface
+      // a placeholder so the agent sees the closed-set list intact.
+      const message = err instanceof Error ? err.message : String(err);
+      summaries.push({
+        name,
+        severity: 'info',
+        one_line: `evaluator failed: ${message}`,
+      });
+      details[name] = {
+        insight: name,
+        details_md: `# ${name}\n\nEvaluator threw: ${message}`,
+        evidence: [],
+      };
+      continue;
+    }
+    if (!result) {
+      summaries.push({ name, severity: 'info', one_line: 'no data' });
+      details[name] = {
+        insight: name,
+        details_md: `# ${name}\n\nNo trace events matched this insight.`,
+        evidence: [],
+      };
+      continue;
+    }
+    summaries.push(result.summary);
+    details[name] = result.details;
+  }
+  return { summaries, details };
+}
+
+/**
+ * Build the human-readable Markdown summary surfaced as `summary_md`
+ * from `oc_performance_insights`. Layout:
+ *
+ *   # Performance insights
+ *
+ *   - **LCPBreakdown** [warn] — LCP 3.2s — largest contributor: …
+ *   - **DocumentLatency** [info] — Document TTFB 240ms for example.com
+ *   - …
+ */
+export function buildSummaryMarkdown(summaries: InsightSummary[]): string {
+  const lines = [`# Performance insights`, ``];
+  for (const s of summaries) {
+    lines.push(`- **${s.name}** [${s.severity}] — ${s.one_line}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Type guard: is `name` one of the v1 insight names?
+ */
+export function isInsightName(name: string): name is InsightName {
+  return (INSIGHT_NAMES as readonly string[]).includes(name);
+}

--- a/src/core/performance/insights/trace-store.ts
+++ b/src/core/performance/insights/trace-store.ts
@@ -1,0 +1,244 @@
+/**
+ * Performance trace handle store (#846).
+ *
+ * `oc_performance_insights` writes a CDP trace to disk and returns a
+ * `trace_id` handle. `oc_performance_analyze` reads that trace back by
+ * handle. Handles are scoped to a SessionManager session; on session
+ * close (`session:deleted`) every handle owned by the session is
+ * invalidated and the underlying file is deleted.
+ *
+ * Files live under `path.join(os.homedir(), '.openchrome', 'perf-traces')`
+ * (per CLAUDE.md: never `process.env.HOME`). Each trace is gzip-encoded
+ * JSONL where every line is one trace event — this matches the layout
+ * the trace recorder already uses (see `src/core/trace/storage.ts`) and
+ * keeps the on-disk footprint small for the typical multi-megabyte
+ * Tracing.dataCollected stream.
+ *
+ * The store does not poll the SessionManager; tools subscribe to its
+ * event listener once on first use. This mirrors the cleanup pattern
+ * that `console-capture.ts` uses for per-tab CDP sessions.
+ */
+
+import { gunzipSync, gzipSync } from 'node:zlib';
+import { randomUUID } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type { TraceDocument, TraceEventRecord } from './types';
+
+export interface PerfTraceHandle {
+  trace_id: string;
+  session_id: string;
+  trace_path: string;
+  created_at: number;
+  byte_size: number;
+}
+
+export interface PerfTraceStoreOptions {
+  /** Override root dir (tests). Defaults to `~/.openchrome/perf-traces`. */
+  rootDir?: string;
+}
+
+export function defaultPerfTraceRootDir(): string {
+  return path.join(os.homedir(), '.openchrome', 'perf-traces');
+}
+
+/**
+ * Per-trace on-disk filename. The `trace_id` is a UUID and is therefore
+ * already filesystem-safe; we still constrain to the literal v4 hyphen
+ * shape so a malicious caller cannot inject a path component.
+ */
+const TRACE_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function assertSafeTraceId(id: string): void {
+  if (!TRACE_ID_RE.test(id)) {
+    throw new Error(`PerfTraceStore: trace_id "${id}" is not a valid UUID`);
+  }
+}
+
+export class PerfTraceStore {
+  private readonly rootDir: string;
+  /** trace_id -> handle metadata. */
+  private readonly handles = new Map<string, PerfTraceHandle>();
+  /** session_id -> Set<trace_id> for fast eviction on session close. */
+  private readonly bySession = new Map<string, Set<string>>();
+  private rootEnsured = false;
+
+  constructor(opts: PerfTraceStoreOptions = {}) {
+    this.rootDir = opts.rootDir ?? defaultPerfTraceRootDir();
+  }
+
+  private ensureRoot(): void {
+    if (this.rootEnsured) return;
+    fs.mkdirSync(this.rootDir, { recursive: true });
+    this.rootEnsured = true;
+  }
+
+  private filePath(traceId: string): string {
+    assertSafeTraceId(traceId);
+    return path.join(this.rootDir, `${traceId}.jsonl.gz`);
+  }
+
+  /**
+   * Persist a trace event stream and register a session-scoped handle.
+   * Caller-supplied `metadata` is merged into the JSONL envelope as the
+   * first line so analyze() can reconstruct the trace document without a
+   * second round trip.
+   */
+  store(args: {
+    sessionId: string;
+    events: TraceEventRecord[];
+    metadata?: Record<string, unknown>;
+  }): PerfTraceHandle {
+    if (!args.sessionId) {
+      throw new Error('PerfTraceStore.store: sessionId is required');
+    }
+    this.ensureRoot();
+    const traceId = randomUUID();
+    const filePath = this.filePath(traceId);
+    // Build a JSONL stream: line 0 = metadata envelope, then one event
+    // per line. We gzip the whole buffer so the on-disk file is one
+    // atomic write (`writeFileSync` is sufficient — no concurrent
+    // writers per trace_id).
+    const lines: string[] = [];
+    lines.push(JSON.stringify({ kind: 'metadata', metadata: args.metadata ?? {} }));
+    for (const ev of args.events) {
+      lines.push(JSON.stringify(ev));
+    }
+    const raw = Buffer.from(lines.join('\n') + '\n', 'utf8');
+    const compressed = gzipSync(raw);
+    fs.writeFileSync(filePath, compressed);
+    const handle: PerfTraceHandle = {
+      trace_id: traceId,
+      session_id: args.sessionId,
+      trace_path: filePath,
+      created_at: Date.now(),
+      byte_size: compressed.byteLength,
+    };
+    this.handles.set(traceId, handle);
+    let owned = this.bySession.get(args.sessionId);
+    if (!owned) {
+      owned = new Set();
+      this.bySession.set(args.sessionId, owned);
+    }
+    owned.add(traceId);
+    return handle;
+  }
+
+  /** Look up a handle without loading the trace. */
+  getHandle(traceId: string): PerfTraceHandle | undefined {
+    return this.handles.get(traceId);
+  }
+
+  /**
+   * Load a trace document by handle. Throws if the trace is unknown
+   * or the file disappeared.
+   */
+  load(traceId: string): TraceDocument {
+    const handle = this.handles.get(traceId);
+    if (!handle) {
+      throw new Error(`PerfTraceStore.load: unknown trace_id=${traceId}`);
+    }
+    const filePath = this.filePath(traceId);
+    if (!fs.existsSync(filePath)) {
+      // Drift between in-memory state and disk — fail loudly so the
+      // caller can surface an inconclusive_reason rather than silently
+      // dropping data.
+      throw new Error(`PerfTraceStore.load: trace file missing at ${filePath}`);
+    }
+    const compressed = fs.readFileSync(filePath);
+    const raw = gunzipSync(compressed).toString('utf8');
+    const events: TraceEventRecord[] = [];
+    let metadata: Record<string, unknown> | undefined;
+    for (const line of raw.split('\n')) {
+      if (!line) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        (parsed as { kind?: string }).kind === 'metadata'
+      ) {
+        metadata = (parsed as { metadata?: Record<string, unknown> }).metadata;
+        continue;
+      }
+      events.push(parsed as TraceEventRecord);
+    }
+    return { traceEvents: events, metadata };
+  }
+
+  /**
+   * Evict every handle owned by a session, deleting the underlying
+   * files. Used when SessionManager emits `session:deleted`.
+   */
+  evictSession(sessionId: string): number {
+    const owned = this.bySession.get(sessionId);
+    if (!owned) return 0;
+    let removed = 0;
+    for (const traceId of owned) {
+      this.handles.delete(traceId);
+      try {
+        fs.unlinkSync(this.filePath(traceId));
+      } catch {
+        // Best-effort: file may already be gone.
+      }
+      removed += 1;
+    }
+    this.bySession.delete(sessionId);
+    return removed;
+  }
+
+  /** Drop one trace by id (for tests / explicit cleanup). */
+  evictTrace(traceId: string): boolean {
+    const handle = this.handles.get(traceId);
+    if (!handle) return false;
+    this.handles.delete(traceId);
+    const owned = this.bySession.get(handle.session_id);
+    if (owned) {
+      owned.delete(traceId);
+      if (owned.size === 0) this.bySession.delete(handle.session_id);
+    }
+    try {
+      fs.unlinkSync(this.filePath(traceId));
+    } catch {
+      // best-effort
+    }
+    return true;
+  }
+
+  /** Number of handles currently retained (for tests). */
+  size(): number {
+    return this.handles.size;
+  }
+
+  /** Reset all in-memory state (tests only — does NOT delete files). */
+  clearForTests(): void {
+    this.handles.clear();
+    this.bySession.clear();
+  }
+}
+
+/**
+ * Process-wide singleton. Tools share one store so a trace captured by
+ * `oc_performance_insights` is reachable from `oc_performance_analyze`.
+ * Lazy-initialised so test code can override `rootDir` via DI before
+ * the first `getPerfTraceStore()` call by passing `setPerfTraceStore()`.
+ */
+let singleton: PerfTraceStore | null = null;
+
+export function getPerfTraceStore(): PerfTraceStore {
+  if (!singleton) {
+    singleton = new PerfTraceStore();
+  }
+  return singleton;
+}
+
+/** Tests / advanced wiring: replace the singleton. */
+export function setPerfTraceStoreForTests(store: PerfTraceStore | null): void {
+  singleton = store;
+}

--- a/src/core/performance/insights/types.ts
+++ b/src/core/performance/insights/types.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared types for the performance-insights v1 engine (#846).
+ *
+ * The engine consumes a CDP `Tracing.dataCollected` event stream — a flat
+ * array of trace events shaped according to the
+ * Trace Event Format (https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU).
+ * Every event has at minimum:
+ *   - `name: string`            — e.g. `firstContentfulPaint`, `largestContentfulPaint::Candidate`
+ *   - `cat: string`             — comma-separated categories
+ *   - `ph: string`              — phase ('I' instant, 'X' complete, 'B' begin, 'E' end)
+ *   - `ts: number`              — wall-clock microseconds (relative to trace start)
+ *   - `args?: Record<string, unknown>`
+ *
+ * v1 keeps the schema permissive (`Record<string, unknown>`) and lets each
+ * evaluator narrow what it needs. This avoids importing
+ * `chrome-devtools-frontend` types ahead of the planned vendoring follow-up.
+ */
+
+export type InsightSeverity = 'info' | 'warn' | 'critical';
+
+/** Closed enumeration of the v1 insight names. */
+export const INSIGHT_NAMES = [
+  'LCPBreakdown',
+  'DocumentLatency',
+  'RenderBlocking',
+  'CLSCulprits',
+  'LongTasks',
+  'ThirdParties',
+] as const;
+
+export type InsightName = (typeof INSIGHT_NAMES)[number];
+
+/** A single trace event as captured from `Tracing.dataCollected`. */
+export interface TraceEventRecord {
+  name: string;
+  cat?: string;
+  ph?: string;
+  ts?: number;
+  dur?: number;
+  pid?: number;
+  tid?: number;
+  args?: Record<string, unknown>;
+  [extra: string]: unknown;
+}
+
+/** The trace JSON document — a `{ traceEvents: TraceEventRecord[] }` envelope. */
+export interface TraceDocument {
+  traceEvents: TraceEventRecord[];
+  metadata?: Record<string, unknown>;
+}
+
+/** Per-insight one-line summary returned in `oc_performance_insights`. */
+export interface InsightSummary {
+  name: InsightName;
+  severity: InsightSeverity;
+  one_line: string;
+}
+
+/** Detail evidence ref returned in `oc_performance_analyze`. */
+export interface InsightEvidence {
+  kind: 'request' | 'event' | 'metric';
+  ref: string;
+}
+
+/** Drill-down detail returned in `oc_performance_analyze`. */
+export interface InsightDetails {
+  insight: InsightName;
+  details_md: string;
+  evidence: InsightEvidence[];
+}
+
+/**
+ * Output of a single evaluator. The evaluator is allowed to return `null`
+ * to signal "this insight does not apply to the supplied trace" — for
+ * example, `LCPBreakdown` returns null when the trace has no LCP events.
+ *
+ * When `null`, the engine still surfaces an `info`-severity placeholder
+ * with `one_line: 'no data'` so the closed-set surface stays predictable
+ * for the agent.
+ */
+export interface EvaluatorResult {
+  summary: InsightSummary;
+  details: InsightDetails;
+}
+
+export type EvaluatorFn = (trace: TraceDocument) => EvaluatorResult | null;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -107,6 +107,13 @@ import { registerOcEvidenceBundleTool } from './oc-evidence-bundle';
 import { registerOcSkillRecordTool } from './oc-skill-record';
 import { registerOcSkillRecallTool } from './oc-skill-recall';
 
+// Performance insights two-step API (#846)
+// TODO(#844): use isCoreFeatureEnabled() helper once #844 lands
+import { registerOcPerformanceInsightsTool } from './oc-performance-insights';
+import { registerOcPerformanceAnalyzeTool } from './oc-performance-analyze';
+import { getSessionManager } from '../session-manager';
+import { getPerfTraceStore } from '../core/performance/insights/trace-store';
+
 export function registerAllTools(server: MCPServer): void {
   // Core browser tools
   registerNavigateTool(server);
@@ -217,6 +224,30 @@ export function registerAllTools(server: MCPServer): void {
   // Skill memory tools (#785) — record + recall
   registerOcSkillRecordTool(server);
   registerOcSkillRecallTool(server);
+
+  // Performance insights two-step API (#846).
+  // TODO(#844): use isCoreFeatureEnabled() helper once #844 lands.
+  // Off-switch: when OPENCHROME_PERF_INSIGHTS=0 the two tools are NOT
+  // registered, preserving v1.10.4 tools/list parity (P2). Default on.
+  if (process.env.OPENCHROME_PERF_INSIGHTS !== '0') {
+    registerOcPerformanceInsightsTool(server);
+    registerOcPerformanceAnalyzeTool(server);
+    // Wire session-scoped trace eviction once. The store keeps an
+    // in-memory map of session_id -> trace_ids; on session deletion we
+    // delete every trace file owned by that session.
+    const sm = getSessionManager();
+    const store = getPerfTraceStore();
+    sm.addEventListener((event) => {
+      if (event.type === 'session:deleted' && event.sessionId) {
+        const removed = store.evictSession(event.sessionId);
+        if (removed > 0) {
+          console.error(
+            `[PerfInsights] Evicted ${removed} trace handle(s) for session ${event.sessionId}`,
+          );
+        }
+      }
+    });
+  }
 
   console.error(`[Tools] Registered ${server.getToolNames().length} tools`);
 }

--- a/src/tools/oc-performance-analyze.ts
+++ b/src/tools/oc-performance-analyze.ts
@@ -1,0 +1,114 @@
+/**
+ * oc_performance_analyze — Step 2 of the two-step performance flow (#846).
+ *
+ * Drills into one named insight from a previously captured trace. The
+ * `trace_id` argument is a handle returned by `oc_performance_insights`;
+ * the `insight` argument must be one of the closed-set names exported
+ * by the v1 engine. Unknown insight names return a structured
+ * `{ error: 'unknown_insight', supported: [...] }` so the agent can
+ * recover without crashing the server.
+ *
+ * Tier: core. Off-switch: `OPENCHROME_PERF_INSIGHTS=0` skips registration.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import {
+  INSIGHT_NAMES,
+  evaluateInsights,
+  isInsightName,
+} from '../core/performance/insights';
+import { getPerfTraceStore } from '../core/performance/insights/trace-store';
+
+const definition: MCPToolDefinition = {
+  name: 'oc_performance_analyze',
+  description:
+    'Drill into one named insight from a trace captured by ' +
+    'oc_performance_insights. Returns Markdown details and an evidence ' +
+    'list. Unknown insight names return ' +
+    "{ error: 'unknown_insight', supported: [...] } without crashing.",
+  inputSchema: {
+    type: 'object',
+    properties: {
+      trace_id: {
+        type: 'string',
+        description: 'Trace handle returned by oc_performance_insights.',
+      },
+      insight: {
+        type: 'string',
+        enum: [...INSIGHT_NAMES],
+        description: 'Name of the insight to drill into.',
+      },
+    },
+    required: ['trace_id', 'insight'],
+  },
+};
+
+function jsonResult(payload: Record<string, unknown>, opts?: { isError?: boolean }): MCPResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload) }],
+    ...payload,
+    ...(opts?.isError ? { isError: true } : {}),
+  };
+}
+
+const handler: ToolHandler = async (
+  _sessionId: string,
+  rawArgs: Record<string, unknown>,
+): Promise<MCPResult> => {
+  const traceId = typeof rawArgs.trace_id === 'string' ? rawArgs.trace_id : '';
+  const insight = typeof rawArgs.insight === 'string' ? rawArgs.insight : '';
+
+  if (!traceId) {
+    return jsonResult({ error: 'trace_id is required' }, { isError: true });
+  }
+  if (!insight) {
+    return jsonResult(
+      { error: 'unknown_insight', supported: [...INSIGHT_NAMES] },
+      { isError: true },
+    );
+  }
+  if (!isInsightName(insight)) {
+    // Closed-set protection — the agent gets the supported list back so
+    // it can self-correct instead of guessing more names.
+    return jsonResult(
+      { error: 'unknown_insight', supported: [...INSIGHT_NAMES] },
+      { isError: true },
+    );
+  }
+
+  const store = getPerfTraceStore();
+  const handle = store.getHandle(traceId);
+  if (!handle) {
+    return jsonResult(
+      { error: 'unknown_trace_id', trace_id: traceId },
+      { isError: true },
+    );
+  }
+
+  let trace;
+  try {
+    trace = store.load(traceId);
+  } catch (err) {
+    return jsonResult(
+      {
+        error: 'trace_load_failed',
+        trace_id: traceId,
+        message: err instanceof Error ? err.message : String(err),
+      },
+      { isError: true },
+    );
+  }
+
+  const { details } = evaluateInsights(trace);
+  const result = details[insight];
+  return jsonResult({
+    insight: result.insight,
+    details_md: result.details_md,
+    evidence: result.evidence,
+  });
+};
+
+export function registerOcPerformanceAnalyzeTool(server: MCPServer): void {
+  server.registerTool('oc_performance_analyze', handler, definition);
+}

--- a/src/tools/oc-performance-analyze.ts
+++ b/src/tools/oc-performance-analyze.ts
@@ -53,7 +53,7 @@ function jsonResult(payload: Record<string, unknown>, opts?: { isError?: boolean
 }
 
 const handler: ToolHandler = async (
-  _sessionId: string,
+  sessionId: string,
   rawArgs: Record<string, unknown>,
 ): Promise<MCPResult> => {
   const traceId = typeof rawArgs.trace_id === 'string' ? rawArgs.trace_id : '';
@@ -79,7 +79,11 @@ const handler: ToolHandler = async (
 
   const store = getPerfTraceStore();
   const handle = store.getHandle(traceId);
-  if (!handle) {
+  // Session ownership check: trace handles are session-scoped. If the
+  // handle is missing OR belongs to a different session, return the
+  // same `unknown_trace_id` error so cross-session probers cannot
+  // confirm the existence of another session's trace.
+  if (!handle || handle.session_id !== sessionId) {
     return jsonResult(
       { error: 'unknown_trace_id', trace_id: traceId },
       { isError: true },

--- a/src/tools/oc-performance-insights.ts
+++ b/src/tools/oc-performance-insights.ts
@@ -239,15 +239,26 @@ const handler: ToolHandler = async (
   if (!page) return jsonError(`Tab ${args.tabId} not found`);
 
   let cdp: CDPSession | undefined;
+  // Track which emulation overrides were actually applied so the
+  // finally block resets ONLY what we set. Without this, a throw
+  // mid-trace would either skip the reset entirely (poisoning the tab
+  // for subsequent tool calls in the same session) or reset overrides
+  // that were never applied.
+  let cpuApplied = false;
+  let networkApplied = false;
   try {
     cdp = await page.createCDPSession();
 
     if (typeof args.cpuThrottling === 'number' && args.cpuThrottling > 1) {
       await cdp.send('Emulation.setCPUThrottlingRate', { rate: args.cpuThrottling });
+      cpuApplied = true;
     }
     if (args.network && args.network !== 'none') {
       const preset = NETWORK_PRESETS[args.network];
-      if (preset) await cdp.send('Network.emulateNetworkConditions', preset);
+      if (preset) {
+        await cdp.send('Network.emulateNetworkConditions', preset);
+        networkApplied = true;
+      }
     }
 
     if (args.url) {
@@ -273,34 +284,12 @@ const handler: ToolHandler = async (
     await waitForAutoStop(page, args.autoStop);
 
     // Stopping triggers the tracingComplete event the collector awaits.
-    try {
-      await cdp.send('Tracing.end');
-    } catch {
-      // best-effort — collector will resolve via tracingComplete or hang
-      // if Chrome dropped the session, which we mitigate with the race
-      // below.
-    }
+    await cdp.send('Tracing.end');
 
     const events = await Promise.race([
       collectPromise,
       new Promise<TraceEventRecord[]>((resolve) => setTimeout(() => resolve([]), 5000)),
     ]);
-
-    // Clean up emulation overrides regardless of outcome.
-    if (typeof args.cpuThrottling === 'number' && args.cpuThrottling > 1) {
-      try {
-        await cdp.send('Emulation.setCPUThrottlingRate', { rate: 1 });
-      } catch {
-        /* best-effort */
-      }
-    }
-    if (args.network && args.network !== 'none') {
-      try {
-        await cdp.send('Network.emulateNetworkConditions', NETWORK_PRESETS.none);
-      } catch {
-        /* best-effort */
-      }
-    }
 
     const trace = { traceEvents: events };
     const { summaries } = evaluateInsights(trace);
@@ -329,7 +318,25 @@ const handler: ToolHandler = async (
       `oc_performance_insights failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   } finally {
+    // Always reset emulation overrides we applied — a throw between
+    // `setCPUThrottlingRate(rate>1)` / `emulateNetworkConditions(...)`
+    // and the end of the success block would otherwise leave the tab
+    // throttled for subsequent tool calls in this session.
     if (cdp) {
+      if (cpuApplied) {
+        try {
+          await cdp.send('Emulation.setCPUThrottlingRate', { rate: 1 });
+        } catch {
+          /* best-effort */
+        }
+      }
+      if (networkApplied) {
+        try {
+          await cdp.send('Network.emulateNetworkConditions', NETWORK_PRESETS.none);
+        } catch {
+          /* best-effort */
+        }
+      }
       try {
         await cdp.detach();
       } catch {

--- a/src/tools/oc-performance-insights.ts
+++ b/src/tools/oc-performance-insights.ts
@@ -147,6 +147,45 @@ function jsonError(message: string): MCPResult {
   };
 }
 
+function jsonStructuredError(payload: Record<string, unknown>): MCPResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload) }],
+    isError: true,
+    ...payload,
+  };
+}
+
+/**
+ * Tagged error used by the trace-collection branch when
+ * `Tracing.tracingComplete` fails to fire within the configured budget.
+ * The outer try/catch maps this to a structured tool result and the
+ * `finally` block still runs (resetting emulation overrides).
+ *
+ * Distinct error class so the catch block can detect-and-shape the
+ * payload without parsing message strings.
+ */
+class TracingCompleteTimeoutError extends Error {
+  readonly elapsedMs: number;
+  constructor(elapsedMs: number) {
+    super(`Tracing.tracingComplete did not fire within ${elapsedMs}ms`);
+    this.name = 'TracingCompleteTimeoutError';
+    this.elapsedMs = elapsedMs;
+  }
+}
+
+/**
+ * Resolve the tracing-complete wait budget. Defaults to 5000ms; operators
+ * can raise it for heavier pages via the env var. Values below 1000ms or
+ * non-numeric are treated as the default to prevent foot-guns.
+ */
+function getTracingCompleteTimeoutMs(): number {
+  const raw = process.env.OC_PERF_TRACING_COMPLETE_TIMEOUT_MS;
+  if (!raw) return 5000;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 1000) return 5000;
+  return Math.floor(parsed);
+}
+
 /**
  * Wait for either the page load event (`autoStop === 'load'`), the
  * network-idle marker (`autoStop === 'idle'`), or a fixed timeout. The
@@ -286,9 +325,16 @@ const handler: ToolHandler = async (
     // Stopping triggers the tracingComplete event the collector awaits.
     await cdp.send('Tracing.end');
 
+    // If tracingComplete doesn't fire within the configured budget,
+    // surface a structured timeout error instead of persisting a
+    // half-built trace handle. Callers were previously fed an empty
+    // event list and saw misleading "no data" insights for every metric.
+    const timeoutMs = getTracingCompleteTimeoutMs();
     const events = await Promise.race([
       collectPromise,
-      new Promise<TraceEventRecord[]>((resolve) => setTimeout(() => resolve([]), 5000)),
+      new Promise<TraceEventRecord[]>((_resolve, reject) =>
+        setTimeout(() => reject(new TracingCompleteTimeoutError(timeoutMs)), timeoutMs),
+      ),
     ]);
 
     const trace = { traceEvents: events };
@@ -314,6 +360,15 @@ const handler: ToolHandler = async (
       insights: summaries,
     });
   } catch (err) {
+    if (err instanceof TracingCompleteTimeoutError) {
+      // Crucially: NO trace handle is created here — callers should not
+      // see a half-built handle that yields empty insights.
+      return jsonStructuredError({
+        error: 'tracing_complete_timeout',
+        elapsed_ms: err.elapsedMs,
+        hint: 'Increase OC_PERF_TRACING_COMPLETE_TIMEOUT_MS for heavy pages',
+      });
+    }
     return jsonError(
       `oc_performance_insights failed: ${err instanceof Error ? err.message : String(err)}`,
     );

--- a/src/tools/oc-performance-insights.ts
+++ b/src/tools/oc-performance-insights.ts
@@ -1,0 +1,344 @@
+/**
+ * oc_performance_insights — Step 1 of the two-step performance flow (#846).
+ *
+ * Captures a CDP performance trace for the current page and turns it
+ * into a list of named, severity-tagged insights. Returns a `trace_id`
+ * handle the agent can drill into via `oc_performance_analyze`.
+ *
+ * Trace handles are scoped to the SessionManager session (NOT the OS
+ * process). On `session:deleted`, the underlying trace files are
+ * removed. See `src/core/performance/insights/trace-store.ts`.
+ *
+ * Tier: core. Off-switch: `OPENCHROME_PERF_INSIGHTS=0` skips registration.
+ *
+ * Scope reduction (vs. issue spec): this PR ships a hand-rolled v1
+ * insights engine. The `chrome-devtools-frontend` vendoring +
+ * `MANIFEST.txt` CI lint will land as a follow-up PR.
+ */
+
+import { CDPSession } from 'puppeteer-core';
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import { getSessionManager } from '../session-manager';
+import {
+  buildSummaryMarkdown,
+  evaluateInsights,
+  type TraceEventRecord,
+} from '../core/performance/insights';
+import { getPerfTraceStore } from '../core/performance/insights/trace-store';
+
+/* Default categories — chrome-devtools-frontend's recording profile.
+ * We omit the heavyweight `disabled-by-default-*` categories the
+ * frontend uses for flame charts; v1 only consumes high-level
+ * navigation, paint, layout-shift, and resource events. */
+const DEFAULT_CATEGORIES = [
+  'devtools.timeline',
+  'loading',
+  'navigation',
+  'blink.user_timing',
+  'latencyInfo',
+  'v8.execute',
+  'disabled-by-default-devtools.timeline',
+];
+
+interface InsightsToolArgs {
+  tabId?: string;
+  url?: string;
+  reload?: boolean;
+  cpuThrottling?: number;
+  network?: 'none' | 'slow-3g' | 'fast-3g' | 'slow-4g' | 'fast-4g';
+  autoStop?: 'load' | 'idle' | { ms: number };
+}
+
+const definition: MCPToolDefinition = {
+  name: 'oc_performance_insights',
+  description:
+    'Capture a CDP performance trace and return named insights ' +
+    '(LCPBreakdown, DocumentLatency, RenderBlocking, CLSCulprits, ' +
+    'LongTasks, ThirdParties). Returns a trace_id usable by ' +
+    'oc_performance_analyze. Core-tier; trace handles are ' +
+    'session-scoped and evicted on session close. Disable via ' +
+    'OPENCHROME_PERF_INSIGHTS=0.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      tabId: {
+        type: 'string',
+        description: 'Tab ID to trace. Required.',
+      },
+      url: {
+        type: 'string',
+        description: 'If set, navigate the tab to this URL before tracing.',
+      },
+      reload: {
+        type: 'boolean',
+        description: 'Reload the page after starting the trace (cold-load capture).',
+      },
+      cpuThrottling: {
+        type: 'number',
+        description: 'CPU throttling rate. 1 = none, 4 = mid-tier mobile.',
+      },
+      network: {
+        type: 'string',
+        enum: ['none', 'slow-3g', 'fast-3g', 'slow-4g', 'fast-4g'],
+        description: 'Network throttling profile.',
+      },
+      autoStop: {
+        oneOf: [
+          { type: 'string', enum: ['load', 'idle'] },
+          { type: 'object', properties: { ms: { type: 'number' } }, required: ['ms'] },
+        ],
+        description:
+          'When to stop tracing. "load" = page load event, "idle" = network idle, ' +
+          '{ ms: N } = fixed timeout. Default 3000ms.',
+      },
+    },
+    required: ['tabId'],
+  },
+};
+
+interface NetworkConditions {
+  offline: boolean;
+  downloadThroughput: number;
+  uploadThroughput: number;
+  latency: number;
+}
+
+const NETWORK_PRESETS: Record<NonNullable<InsightsToolArgs['network']>, NetworkConditions> = {
+  none: { offline: false, downloadThroughput: -1, uploadThroughput: -1, latency: 0 },
+  'slow-3g': {
+    offline: false,
+    downloadThroughput: (500 * 1024) / 8,
+    uploadThroughput: (500 * 1024) / 8,
+    latency: 400,
+  },
+  'fast-3g': {
+    offline: false,
+    downloadThroughput: (1.6 * 1024 * 1024) / 8,
+    uploadThroughput: (750 * 1024) / 8,
+    latency: 150,
+  },
+  'slow-4g': {
+    offline: false,
+    downloadThroughput: (3 * 1024 * 1024) / 8,
+    uploadThroughput: (1 * 1024 * 1024) / 8,
+    latency: 100,
+  },
+  'fast-4g': {
+    offline: false,
+    downloadThroughput: (9 * 1024 * 1024) / 8,
+    uploadThroughput: (2 * 1024 * 1024) / 8,
+    latency: 40,
+  },
+};
+
+function jsonResult(payload: Record<string, unknown>): MCPResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload) }],
+    ...payload,
+  };
+}
+
+function jsonError(message: string): MCPResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ error: message }) }],
+    isError: true,
+  };
+}
+
+/**
+ * Wait for either the page load event (`autoStop === 'load'`), the
+ * network-idle marker (`autoStop === 'idle'`), or a fixed timeout. The
+ * autoStop default is intentionally short (3000ms) so the tool stays
+ * within the harness's tool-call timeout envelope.
+ */
+async function waitForAutoStop(
+  page: {
+    waitForNavigation: (opts: { waitUntil: 'load' | 'networkidle2'; timeout: number }) => Promise<unknown>;
+  },
+  autoStop: InsightsToolArgs['autoStop'],
+): Promise<void> {
+  const defaultMs = 3000;
+  if (!autoStop) {
+    await new Promise((r) => setTimeout(r, defaultMs));
+    return;
+  }
+  if (typeof autoStop === 'object' && typeof autoStop.ms === 'number') {
+    await new Promise((r) => setTimeout(r, autoStop.ms));
+    return;
+  }
+  // 'load' | 'idle' — best-effort; on timeout we fall back to the
+  // fixed window so the tool always returns within budget.
+  const waitUntil: 'load' | 'networkidle2' = autoStop === 'idle' ? 'networkidle2' : 'load';
+  try {
+    await Promise.race([
+      page.waitForNavigation({ waitUntil, timeout: 8000 }),
+      new Promise((r) => setTimeout(r, 8000)),
+    ]);
+  } catch {
+    // ignore — we'll stop the trace regardless
+  }
+}
+
+/**
+ * Drive the CDP `Tracing` domain and collect every `dataCollected`
+ * batch into a single TraceEventRecord array. Caller is responsible
+ * for starting/stopping any extra emulation (CPU/network throttling).
+ */
+async function captureTrace(
+  cdp: CDPSession,
+  options: { categories: string[] },
+): Promise<TraceEventRecord[]> {
+  const events: TraceEventRecord[] = [];
+  const onData = (msg: { value: TraceEventRecord[] }) => {
+    if (Array.isArray(msg.value)) events.push(...msg.value);
+  };
+  cdp.on('Tracing.dataCollected', onData as never);
+  const stoppedOnce = new Promise<void>((resolve) => {
+    cdp.once('Tracing.tracingComplete', () => resolve());
+  });
+  try {
+    await cdp.send('Tracing.start', {
+      transferMode: 'ReportEvents',
+      categories: options.categories.join(','),
+    });
+  } catch (err) {
+    cdp.off('Tracing.dataCollected', onData as never);
+    throw err;
+  }
+  return new Promise((resolve, reject) => {
+    // Caller will trigger Tracing.end via the returned closure pattern;
+    // here we just resolve when tracingComplete fires.
+    stoppedOnce
+      .then(() => {
+        cdp.off('Tracing.dataCollected', onData as never);
+        resolve(events);
+      })
+      .catch((err) => {
+        cdp.off('Tracing.dataCollected', onData as never);
+        reject(err);
+      });
+  });
+}
+
+const handler: ToolHandler = async (
+  sessionId: string,
+  rawArgs: Record<string, unknown>,
+): Promise<MCPResult> => {
+  const args = rawArgs as InsightsToolArgs;
+  if (!args.tabId) return jsonError('tabId is required');
+
+  const sm = getSessionManager();
+  let page;
+  try {
+    page = await sm.getPage(sessionId, args.tabId, undefined, 'oc_performance_insights');
+  } catch (err) {
+    return jsonError(`getPage failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (!page) return jsonError(`Tab ${args.tabId} not found`);
+
+  let cdp: CDPSession | undefined;
+  try {
+    cdp = await page.createCDPSession();
+
+    if (typeof args.cpuThrottling === 'number' && args.cpuThrottling > 1) {
+      await cdp.send('Emulation.setCPUThrottlingRate', { rate: args.cpuThrottling });
+    }
+    if (args.network && args.network !== 'none') {
+      const preset = NETWORK_PRESETS[args.network];
+      if (preset) await cdp.send('Network.emulateNetworkConditions', preset);
+    }
+
+    if (args.url) {
+      try {
+        await page.goto(args.url, { waitUntil: 'domcontentloaded', timeout: 15000 });
+      } catch {
+        // Continue — partial load still produces useful trace data.
+      }
+    }
+
+    // Start tracing AFTER any pre-navigation so the trace covers the
+    // observed cold-load window when reload=true is set.
+    const collectPromise = captureTrace(cdp, { categories: DEFAULT_CATEGORIES });
+
+    if (args.reload) {
+      try {
+        await page.reload({ waitUntil: 'domcontentloaded', timeout: 15000 });
+      } catch {
+        // ignore
+      }
+    }
+
+    await waitForAutoStop(page, args.autoStop);
+
+    // Stopping triggers the tracingComplete event the collector awaits.
+    try {
+      await cdp.send('Tracing.end');
+    } catch {
+      // best-effort — collector will resolve via tracingComplete or hang
+      // if Chrome dropped the session, which we mitigate with the race
+      // below.
+    }
+
+    const events = await Promise.race([
+      collectPromise,
+      new Promise<TraceEventRecord[]>((resolve) => setTimeout(() => resolve([]), 5000)),
+    ]);
+
+    // Clean up emulation overrides regardless of outcome.
+    if (typeof args.cpuThrottling === 'number' && args.cpuThrottling > 1) {
+      try {
+        await cdp.send('Emulation.setCPUThrottlingRate', { rate: 1 });
+      } catch {
+        /* best-effort */
+      }
+    }
+    if (args.network && args.network !== 'none') {
+      try {
+        await cdp.send('Network.emulateNetworkConditions', NETWORK_PRESETS.none);
+      } catch {
+        /* best-effort */
+      }
+    }
+
+    const trace = { traceEvents: events };
+    const { summaries } = evaluateInsights(trace);
+    const summaryMd = buildSummaryMarkdown(summaries);
+
+    const handle = getPerfTraceStore().store({
+      sessionId,
+      events,
+      metadata: {
+        url: args.url,
+        reload: args.reload,
+        cpuThrottling: args.cpuThrottling,
+        network: args.network,
+        autoStop: args.autoStop,
+      },
+    });
+
+    return jsonResult({
+      trace_id: handle.trace_id,
+      trace_path: handle.trace_path,
+      summary_md: summaryMd,
+      insights: summaries,
+    });
+  } catch (err) {
+    return jsonError(
+      `oc_performance_insights failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  } finally {
+    if (cdp) {
+      try {
+        await cdp.detach();
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+};
+
+export function registerOcPerformanceInsightsTool(server: MCPServer): void {
+  server.registerTool('oc_performance_insights', handler, definition);
+}

--- a/tests/core/performance/fixtures/sample-trace.ts
+++ b/tests/core/performance/fixtures/sample-trace.ts
@@ -13,6 +13,14 @@ import type { TraceDocument } from '../../../../src/core/performance/insights/ty
 export function richTrace(): TraceDocument {
   return {
     traceEvents: [
+      // Navigation start — anchor for trace-relative timestamps.
+      // Subtracted from each event's `ts` to derive elapsed-since-nav.
+      {
+        name: 'navigationStart',
+        cat: 'blink.user_timing',
+        ph: 'I',
+        ts: 0,
+      },
       // Document request — first ResourceSendRequest with resourceType=Document.
       {
         name: 'ResourceSendRequest',
@@ -143,6 +151,12 @@ export function emptyTrace(): TraceDocument {
 export function fastTrace(): TraceDocument {
   return {
     traceEvents: [
+      {
+        name: 'navigationStart',
+        cat: 'blink.user_timing',
+        ph: 'I',
+        ts: 0,
+      },
       {
         name: 'largestContentfulPaint::Candidate',
         cat: 'loading',

--- a/tests/core/performance/fixtures/sample-trace.ts
+++ b/tests/core/performance/fixtures/sample-trace.ts
@@ -1,0 +1,175 @@
+/**
+ * Synthetic trace fixtures for the v1 performance-insights engine (#846).
+ *
+ * These are intentionally minimal — just enough event shapes that each
+ * evaluator either has data to chew on or returns a no-data placeholder.
+ * Real traces are megabytes; the engine's contract is "small evaluator
+ * surface, robust to missing fields", which we exercise here.
+ */
+
+import type { TraceDocument } from '../../../../src/core/performance/insights/types';
+
+/** A trace that contains examples for every insight. */
+export function richTrace(): TraceDocument {
+  return {
+    traceEvents: [
+      // Document request — first ResourceSendRequest with resourceType=Document.
+      {
+        name: 'ResourceSendRequest',
+        cat: 'devtools.timeline',
+        ph: 'I',
+        ts: 1_000_000,
+        args: {
+          data: {
+            requestId: 'req-doc-1',
+            url: 'https://example.com/',
+            resourceType: 'Document',
+            requestPriority: 'VeryHigh',
+          },
+        },
+      },
+      // Document response — 800 ms TTFB (warn).
+      {
+        name: 'ResourceReceiveResponse',
+        cat: 'devtools.timeline',
+        ph: 'I',
+        ts: 1_800_000,
+        args: { data: { requestId: 'req-doc-1' } },
+      },
+      // Render-blocking CSS.
+      {
+        name: 'ResourceSendRequest',
+        cat: 'devtools.timeline',
+        ph: 'I',
+        ts: 1_900_000,
+        args: {
+          data: {
+            requestId: 'req-css-1',
+            url: 'https://example.com/styles.css?v=token=abc12345secretvalue',
+            resourceType: 'Stylesheet',
+            renderBlocking: 'blocking',
+          },
+        },
+      },
+      {
+        name: 'ResourceFinish',
+        cat: 'devtools.timeline',
+        ph: 'I',
+        ts: 2_000_000,
+        args: { data: { requestId: 'req-css-1', encodedDataLength: 12_345 } },
+      },
+      // Third-party script (different host).
+      {
+        name: 'ResourceSendRequest',
+        cat: 'devtools.timeline',
+        ph: 'I',
+        ts: 2_100_000,
+        args: {
+          data: {
+            requestId: 'req-3p-1',
+            url: 'https://cdn.thirdparty.example/lib.js',
+            resourceType: 'Script',
+          },
+        },
+      },
+      {
+        name: 'ResourceFinish',
+        cat: 'devtools.timeline',
+        ph: 'I',
+        ts: 2_200_000,
+        args: { data: { requestId: 'req-3p-1', encodedDataLength: 50_000 } },
+      },
+      // LCP candidates — last one wins.
+      {
+        name: 'largestContentfulPaint::Candidate',
+        cat: 'loading',
+        ph: 'I',
+        ts: 2_300_000,
+        args: { data: { size: 5000, nodeName: 'IMG' } },
+      },
+      {
+        name: 'largestContentfulPaint::Candidate',
+        cat: 'loading',
+        ph: 'I',
+        ts: 3_200_000, // 3.2s LCP — warn
+        args: {
+          data: {
+            size: 9000,
+            url: 'https://example.com/hero.jpg',
+            nodeName: 'IMG',
+          },
+        },
+      },
+      // Layout shifts.
+      {
+        name: 'LayoutShift',
+        cat: 'loading',
+        ph: 'I',
+        ts: 2_400_000,
+        args: { data: { score: 0.05 } },
+      },
+      {
+        name: 'LayoutShift',
+        cat: 'loading',
+        ph: 'I',
+        ts: 2_700_000,
+        args: { data: { score: 0.12 } }, // Total 0.17 = warn
+      },
+      // Long task.
+      {
+        name: 'RunTask',
+        cat: 'devtools.timeline',
+        ph: 'X',
+        ts: 2_500_000,
+        dur: 250_000, // 250ms
+      },
+      {
+        name: 'RunTask',
+        cat: 'devtools.timeline',
+        ph: 'X',
+        ts: 2_800_000,
+        dur: 60_000, // 60ms
+      },
+    ],
+  };
+}
+
+/** Trace with no events — every evaluator should yield no-data. */
+export function emptyTrace(): TraceDocument {
+  return { traceEvents: [] };
+}
+
+/** Trace where LCP is well under 2.5s — should be `info`. */
+export function fastTrace(): TraceDocument {
+  return {
+    traceEvents: [
+      {
+        name: 'largestContentfulPaint::Candidate',
+        cat: 'loading',
+        ph: 'I',
+        ts: 1_800_000, // 1.8s LCP
+        args: { data: { size: 4000, nodeName: 'H1' } },
+      },
+      {
+        name: 'ResourceSendRequest',
+        cat: 'devtools.timeline',
+        ph: 'I',
+        ts: 100_000,
+        args: {
+          data: {
+            requestId: 'r1',
+            url: 'https://fast.example/',
+            resourceType: 'Document',
+          },
+        },
+      },
+      {
+        name: 'ResourceReceiveResponse',
+        cat: 'devtools.timeline',
+        ph: 'I',
+        ts: 250_000, // 150ms TTFB
+        args: { data: { requestId: 'r1' } },
+      },
+    ],
+  };
+}

--- a/tests/core/performance/insights/evaluators.test.ts
+++ b/tests/core/performance/insights/evaluators.test.ts
@@ -1,0 +1,149 @@
+/// <reference types="jest" />
+
+/**
+ * Tests for the v1 performance-insights evaluators (#846).
+ *
+ * Each test exercises one evaluator against a synthetic trace fixture.
+ * The fixtures are intentionally minimal so the test stays focused on
+ * the evaluator's branch logic (severity tiers, no-data fallback,
+ * ordering of contributors) rather than the trace event format itself.
+ */
+
+import {
+  INSIGHT_NAMES,
+  buildSummaryMarkdown,
+  evaluateInsights,
+  isInsightName,
+} from '../../../../src/core/performance/insights';
+import {
+  emptyTrace,
+  fastTrace,
+  richTrace,
+} from '../fixtures/sample-trace';
+
+describe('evaluateInsights — closed-set surface', () => {
+  test('always returns one summary per closed-set insight', () => {
+    const { summaries, details } = evaluateInsights(emptyTrace());
+    expect(summaries.map((s) => s.name).sort()).toEqual([...INSIGHT_NAMES].sort());
+    for (const n of INSIGHT_NAMES) {
+      expect(details[n]).toBeDefined();
+      expect(details[n].insight).toBe(n);
+    }
+  });
+
+  test('empty trace yields info / no data for every insight', () => {
+    const { summaries } = evaluateInsights(emptyTrace());
+    for (const s of summaries) {
+      expect(s.severity).toBe('info');
+    }
+  });
+});
+
+describe('LCPBreakdown', () => {
+  test('uses the last LCP candidate as the winner', () => {
+    const { summaries, details } = evaluateInsights(richTrace());
+    const lcp = summaries.find((s) => s.name === 'LCPBreakdown')!;
+    expect(lcp.severity).toBe('warn');
+    expect(lcp.one_line).toMatch(/3\.20s/);
+    expect(details.LCPBreakdown.details_md).toMatch(/hero\.jpg/);
+    expect(details.LCPBreakdown.evidence.some((e) => e.kind === 'metric')).toBe(true);
+  });
+
+  test('fast trace yields info severity', () => {
+    const { summaries } = evaluateInsights(fastTrace());
+    const lcp = summaries.find((s) => s.name === 'LCPBreakdown')!;
+    expect(lcp.severity).toBe('info');
+  });
+});
+
+describe('DocumentLatency', () => {
+  test('computes TTFB from doc send/receive pair', () => {
+    const { summaries, details } = evaluateInsights(richTrace());
+    const dl = summaries.find((s) => s.name === 'DocumentLatency')!;
+    expect(dl.severity).toBe('warn');
+    expect(dl.one_line).toMatch(/example\.com/);
+    expect(details.DocumentLatency.details_md).toMatch(/TTFB/);
+  });
+
+  test('fast trace yields info severity', () => {
+    const { summaries } = evaluateInsights(fastTrace());
+    const dl = summaries.find((s) => s.name === 'DocumentLatency')!;
+    expect(dl.severity).toBe('info');
+  });
+});
+
+describe('RenderBlocking', () => {
+  test('counts render-blocking resources', () => {
+    const { summaries, details } = evaluateInsights(richTrace());
+    const rb = summaries.find((s) => s.name === 'RenderBlocking')!;
+    expect(rb.one_line).toMatch(/1 render-blocking/);
+    // URL with credential param should be redacted in details_md.
+    expect(details.RenderBlocking.details_md).not.toMatch(/secretvalue/);
+    expect(details.RenderBlocking.details_md).toMatch(/\[REDACTED\]/);
+  });
+
+  test('reports zero blocking when none present', () => {
+    const { summaries } = evaluateInsights(fastTrace());
+    const rb = summaries.find((s) => s.name === 'RenderBlocking')!;
+    expect(rb.severity).toBe('info');
+    expect(rb.one_line).toMatch(/no render-blocking/);
+  });
+});
+
+describe('CLSCulprits', () => {
+  test('sums layout shifts and ranks contributors', () => {
+    const { summaries, details } = evaluateInsights(richTrace());
+    const cls = summaries.find((s) => s.name === 'CLSCulprits')!;
+    expect(cls.severity).toBe('warn');
+    expect(cls.one_line).toMatch(/0\.170/);
+    expect(details.CLSCulprits.details_md).toMatch(/Top contributors/);
+  });
+
+  test('returns no-data when no LayoutShift events present', () => {
+    const { summaries } = evaluateInsights(fastTrace());
+    const cls = summaries.find((s) => s.name === 'CLSCulprits')!;
+    expect(cls.one_line).toBe('no data');
+  });
+});
+
+describe('LongTasks', () => {
+  test('flags tasks > 50ms and computes blocking time', () => {
+    const { summaries, details } = evaluateInsights(richTrace());
+    const lt = summaries.find((s) => s.name === 'LongTasks')!;
+    // 250ms task: blocking = 200ms; 60ms task: blocking = 10ms => 210ms total
+    expect(lt.severity).toBe('warn');
+    expect(lt.one_line).toMatch(/2 long tasks/);
+    expect(details.LongTasks.details_md).toMatch(/Top tasks/);
+  });
+});
+
+describe('ThirdParties', () => {
+  test('detects third-party host vs first-party document host', () => {
+    const { summaries, details } = evaluateInsights(richTrace());
+    const tp = summaries.find((s) => s.name === 'ThirdParties')!;
+    expect(tp.one_line).toMatch(/1 third-party origin/);
+    expect(details.ThirdParties.details_md).toMatch(/cdn\.thirdparty\.example/);
+  });
+});
+
+describe('isInsightName', () => {
+  test('accepts every closed-set name', () => {
+    for (const n of INSIGHT_NAMES) expect(isInsightName(n)).toBe(true);
+  });
+  test('rejects unknown names', () => {
+    expect(isInsightName('NotARealInsight')).toBe(false);
+    expect(isInsightName('')).toBe(false);
+    expect(isInsightName('lcpbreakdown')).toBe(false); // case-sensitive
+  });
+});
+
+describe('buildSummaryMarkdown', () => {
+  test('renders one bullet per insight with severity tag', () => {
+    const { summaries } = evaluateInsights(richTrace());
+    const md = buildSummaryMarkdown(summaries);
+    expect(md.startsWith('# Performance insights')).toBe(true);
+    for (const s of summaries) {
+      expect(md).toContain(`**${s.name}** [${s.severity}]`);
+    }
+  });
+});

--- a/tests/core/performance/insights/evaluators.test.ts
+++ b/tests/core/performance/insights/evaluators.test.ts
@@ -54,6 +54,89 @@ describe('LCPBreakdown', () => {
     const lcp = summaries.find((s) => s.name === 'LCPBreakdown')!;
     expect(lcp.severity).toBe('info');
   });
+
+  // P1 codex finding: trace `ts` is tracing-clock μs, not elapsed-since-nav.
+  // Without normalizing against navigationStart, LCP from a real Chrome
+  // trace lands in the multi-billion-millisecond range (i.e. ~hours).
+  test('normalizes LCP to navigation-start (trace-relative time)', () => {
+    const trace = {
+      traceEvents: [
+        // navigationStart at 1s on the tracing clock.
+        {
+          name: 'navigationStart',
+          cat: 'blink.user_timing',
+          ph: 'I',
+          ts: 1_000_000_000,
+        },
+        // LCP candidate 2.5s later on the tracing clock.
+        {
+          name: 'largestContentfulPaint::Candidate',
+          cat: 'loading',
+          ph: 'I',
+          ts: 1_002_500_000,
+          args: { data: { size: 5000, nodeName: 'IMG' } },
+        },
+      ],
+    };
+    const { summaries } = evaluateInsights(trace);
+    const lcp = summaries.find((s) => s.name === 'LCPBreakdown')!;
+    // 2500 ms = "2.50s". Must NOT contain the raw tracing-clock value
+    // (1_002_500_000 ms or anything in the billions).
+    expect(lcp.one_line).toMatch(/2\.50s/);
+    expect(lcp.one_line).not.toMatch(/1002500000/);
+    expect(lcp.one_line).not.toMatch(/[0-9]{10,}/);
+  });
+
+  test('returns no_data with unknown_navigation_start when navStart is missing', () => {
+    const trace = {
+      traceEvents: [
+        // LCP candidate but no navigationStart marker — we cannot
+        // compute elapsed-since-nav, so report no_data with reason.
+        {
+          name: 'largestContentfulPaint::Candidate',
+          cat: 'loading',
+          ph: 'I',
+          ts: 1_002_500_000,
+          args: { data: { size: 5000, nodeName: 'IMG' } },
+        },
+      ],
+    };
+    const { summaries, details } = evaluateInsights(trace);
+    const lcp = summaries.find((s) => s.name === 'LCPBreakdown')!;
+    expect(lcp.severity).toBe('info');
+    expect(lcp.one_line).toMatch(/no data/);
+    expect(lcp.one_line).toMatch(/unknown_navigation_start/);
+    expect(details.LCPBreakdown.details_md).toMatch(/unknown_navigation_start/);
+    expect(
+      details.LCPBreakdown.evidence.some(
+        (e) => e.kind === 'metric' && e.ref.includes('unknown_navigation_start'),
+      ),
+    ).toBe(true);
+  });
+
+  test('returns no_data when winner.ts is before navStart (pathological trace)', () => {
+    const trace = {
+      traceEvents: [
+        {
+          name: 'navigationStart',
+          cat: 'blink.user_timing',
+          ph: 'I',
+          ts: 2_000_000_000,
+        },
+        // LCP candidate before navigationStart — pathological.
+        {
+          name: 'largestContentfulPaint::Candidate',
+          cat: 'loading',
+          ph: 'I',
+          ts: 1_000_000_000,
+          args: { data: { size: 5000, nodeName: 'IMG' } },
+        },
+      ],
+    };
+    const { summaries } = evaluateInsights(trace);
+    const lcp = summaries.find((s) => s.name === 'LCPBreakdown')!;
+    expect(lcp.one_line).toMatch(/unknown_navigation_start/);
+  });
 });
 
 describe('DocumentLatency', () => {

--- a/tests/core/performance/insights/trace-store.test.ts
+++ b/tests/core/performance/insights/trace-store.test.ts
@@ -1,0 +1,91 @@
+/// <reference types="jest" />
+
+/**
+ * Tests for the session-scoped performance trace store (#846).
+ *
+ * Covers:
+ *  - store() persists a gzipped JSONL file under the configured rootDir
+ *  - load() round-trips events and metadata
+ *  - getHandle() returns the byte_size + trace_path
+ *  - evictSession() removes every handle owned by the session and
+ *    deletes the underlying files
+ *  - evictTrace() removes one handle and its file
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { PerfTraceStore } from '../../../../src/core/performance/insights/trace-store';
+
+function mkRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'perf-trace-store-'));
+}
+
+describe('PerfTraceStore.store / load round-trip', () => {
+  test('persists events and reloads them in order', () => {
+    const rootDir = mkRoot();
+    const store = new PerfTraceStore({ rootDir });
+    const events = [
+      { name: 'A', cat: 'x', ph: 'I', ts: 1 },
+      { name: 'B', cat: 'x', ph: 'I', ts: 2 },
+    ];
+    const handle = store.store({ sessionId: 's-1', events, metadata: { url: 'https://x.test' } });
+    expect(handle.session_id).toBe('s-1');
+    expect(handle.byte_size).toBeGreaterThan(0);
+    expect(fs.existsSync(handle.trace_path)).toBe(true);
+    expect(handle.trace_path.startsWith(rootDir)).toBe(true);
+
+    const trace = store.load(handle.trace_id);
+    expect(trace.traceEvents.map((e) => e.name)).toEqual(['A', 'B']);
+    expect(trace.metadata).toEqual({ url: 'https://x.test' });
+  });
+
+  test('store() rejects empty session_id', () => {
+    const store = new PerfTraceStore({ rootDir: mkRoot() });
+    expect(() => store.store({ sessionId: '', events: [] })).toThrow(/sessionId is required/);
+  });
+
+  test('load() throws on unknown trace_id', () => {
+    const store = new PerfTraceStore({ rootDir: mkRoot() });
+    expect(() => store.load('00000000-0000-0000-0000-000000000000')).toThrow(/unknown trace_id/);
+  });
+});
+
+describe('PerfTraceStore.evictSession', () => {
+  test('removes every handle owned by the session and deletes files', () => {
+    const rootDir = mkRoot();
+    const store = new PerfTraceStore({ rootDir });
+    const a = store.store({ sessionId: 's-1', events: [{ name: 'a' }] });
+    const b = store.store({ sessionId: 's-1', events: [{ name: 'b' }] });
+    const c = store.store({ sessionId: 's-2', events: [{ name: 'c' }] });
+
+    expect(store.size()).toBe(3);
+    const removed = store.evictSession('s-1');
+    expect(removed).toBe(2);
+    expect(store.size()).toBe(1);
+
+    expect(fs.existsSync(a.trace_path)).toBe(false);
+    expect(fs.existsSync(b.trace_path)).toBe(false);
+    expect(fs.existsSync(c.trace_path)).toBe(true);
+    expect(store.getHandle(c.trace_id)).toBeDefined();
+    expect(store.getHandle(a.trace_id)).toBeUndefined();
+  });
+
+  test('evicting an unknown session is a no-op', () => {
+    const store = new PerfTraceStore({ rootDir: mkRoot() });
+    expect(store.evictSession('does-not-exist')).toBe(0);
+  });
+});
+
+describe('PerfTraceStore.evictTrace', () => {
+  test('removes the named handle and its file', () => {
+    const rootDir = mkRoot();
+    const store = new PerfTraceStore({ rootDir });
+    const a = store.store({ sessionId: 's-1', events: [{ name: 'a' }] });
+    expect(store.evictTrace(a.trace_id)).toBe(true);
+    expect(fs.existsSync(a.trace_path)).toBe(false);
+    expect(store.getHandle(a.trace_id)).toBeUndefined();
+    expect(store.evictTrace(a.trace_id)).toBe(false);
+  });
+});

--- a/tests/tools/oc-performance-analyze.test.ts
+++ b/tests/tools/oc-performance-analyze.test.ts
@@ -104,4 +104,34 @@ describe('oc_performance_analyze handler', () => {
     const payload = parsePayload(result);
     expect(payload.error).toMatch(/trace_id/);
   });
+
+  test('same-session call resolves trace details', async () => {
+    const handle = store.store({ sessionId: 's-1', events: richTrace().traceEvents });
+    const result = await handler('s-1', { trace_id: handle.trace_id, insight: 'LCPBreakdown' });
+    expect(result.isError).toBeFalsy();
+    const payload = parsePayload(result);
+    expect(payload.insight).toBe('LCPBreakdown');
+    expect(typeof payload.details_md).toBe('string');
+  });
+
+  test('cross-session trace_id is rejected as unknown_trace_id (no detail leak)', async () => {
+    // Owner session 's-owner' captured the trace.
+    const handle = store.store({ sessionId: 's-owner', events: richTrace().traceEvents });
+    // A different session 's-other' attempts to read it.
+    const result = await handler('s-other', {
+      trace_id: handle.trace_id,
+      insight: 'LCPBreakdown',
+    });
+    expect(result.isError).toBe(true);
+    const payload = parsePayload(result);
+    // Deliberate: same error shape as a truly-missing trace, so a
+    // probing caller cannot confirm the trace exists under another
+    // session. No details / evidence / paths should leak.
+    expect(payload.error).toBe('unknown_trace_id');
+    expect(payload.trace_id).toBe(handle.trace_id);
+    expect(payload.details_md).toBeUndefined();
+    expect(payload.evidence).toBeUndefined();
+    expect(payload.trace_path).toBeUndefined();
+    expect(payload.insight).toBeUndefined();
+  });
 });

--- a/tests/tools/oc-performance-analyze.test.ts
+++ b/tests/tools/oc-performance-analyze.test.ts
@@ -1,0 +1,107 @@
+/// <reference types="jest" />
+
+/**
+ * Tests for the oc_performance_analyze MCP tool (#846).
+ *
+ * Direct-handler tests — no real Chrome required. We populate the
+ * shared PerfTraceStore singleton, invoke the tool's registered
+ * handler via a stub MCPServer, and assert on the JSON payload.
+ */
+
+import {
+  PerfTraceStore,
+  setPerfTraceStoreForTests,
+} from '../../src/core/performance/insights/trace-store';
+import { INSIGHT_NAMES } from '../../src/core/performance/insights';
+import { registerOcPerformanceAnalyzeTool } from '../../src/tools/oc-performance-analyze';
+import { richTrace } from '../core/performance/fixtures/sample-trace';
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+interface RegisteredTool {
+  handler: (sessionId: string, args: Record<string, unknown>) => Promise<{
+    content: { type: string; text: string }[];
+    isError?: boolean;
+    [key: string]: unknown;
+  }>;
+}
+
+class StubServer {
+  tools = new Map<string, RegisteredTool>();
+  registerTool(name: string, handler: RegisteredTool['handler']): void {
+    this.tools.set(name, { handler });
+  }
+}
+
+function mkStore(): PerfTraceStore {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'perf-analyze-test-'));
+  return new PerfTraceStore({ rootDir: root });
+}
+
+function parsePayload(result: { content: { text: string }[] }): Record<string, unknown> {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('oc_performance_analyze handler', () => {
+  let store: PerfTraceStore;
+  let server: StubServer;
+  let handler: RegisteredTool['handler'];
+
+  beforeEach(() => {
+    store = mkStore();
+    setPerfTraceStoreForTests(store);
+    server = new StubServer();
+    registerOcPerformanceAnalyzeTool(server as unknown as Parameters<typeof registerOcPerformanceAnalyzeTool>[0]);
+    handler = server.tools.get('oc_performance_analyze')!.handler;
+  });
+
+  afterEach(() => {
+    setPerfTraceStoreForTests(null);
+  });
+
+  test('returns details + evidence for a valid trace_id + insight', async () => {
+    const handle = store.store({ sessionId: 's-1', events: richTrace().traceEvents });
+    const result = await handler('s-1', { trace_id: handle.trace_id, insight: 'LCPBreakdown' });
+    expect(result.isError).toBeFalsy();
+    const payload = parsePayload(result);
+    expect(payload.insight).toBe('LCPBreakdown');
+    expect(typeof payload.details_md).toBe('string');
+    expect(Array.isArray(payload.evidence)).toBe(true);
+  });
+
+  test('unknown insight returns structured error with supported list', async () => {
+    const handle = store.store({ sessionId: 's-1', events: richTrace().traceEvents });
+    const result = await handler('s-1', { trace_id: handle.trace_id, insight: 'NotARealInsight' });
+    expect(result.isError).toBe(true);
+    const payload = parsePayload(result);
+    expect(payload.error).toBe('unknown_insight');
+    expect(payload.supported).toEqual([...INSIGHT_NAMES]);
+  });
+
+  test('missing insight argument is treated as unknown_insight', async () => {
+    const handle = store.store({ sessionId: 's-1', events: richTrace().traceEvents });
+    const result = await handler('s-1', { trace_id: handle.trace_id });
+    expect(result.isError).toBe(true);
+    const payload = parsePayload(result);
+    expect(payload.error).toBe('unknown_insight');
+  });
+
+  test('unknown trace_id returns structured error', async () => {
+    const result = await handler('s-1', {
+      trace_id: '00000000-0000-0000-0000-000000000000',
+      insight: 'LCPBreakdown',
+    });
+    expect(result.isError).toBe(true);
+    const payload = parsePayload(result);
+    expect(payload.error).toBe('unknown_trace_id');
+  });
+
+  test('missing trace_id returns trace_id-required error', async () => {
+    const result = await handler('s-1', { insight: 'LCPBreakdown' });
+    expect(result.isError).toBe(true);
+    const payload = parsePayload(result);
+    expect(payload.error).toMatch(/trace_id/);
+  });
+});

--- a/tests/tools/oc-performance-insights-registration.test.ts
+++ b/tests/tools/oc-performance-insights-registration.test.ts
@@ -1,0 +1,69 @@
+/// <reference types="jest" />
+
+/**
+ * Off-switch parity test for oc_performance_insights / oc_performance_analyze (#846).
+ *
+ * When OPENCHROME_PERF_INSIGHTS=0, the two tools must NOT be
+ * registered. This guards the v1.10.4 tools/list parity invariant from
+ * the portability-harness contract (P2 — Zero-impact harness extension).
+ *
+ * The test isolates the registration call by using a stub MCPServer
+ * that records only the tool names it was asked to register; we never
+ * touch the real Chrome process or the SessionManager event bus.
+ */
+
+class StubServer {
+  registered: string[] = [];
+  registerTool(name: string): void {
+    this.registered.push(name);
+  }
+  // Stubs to satisfy the registerAllTools imports — none of them are
+  // actually called in this test because we drive `registerTool` only.
+  // The real MCPServer also implements `getToolNames`; we keep that
+  // stubbed so the trailing `console.error(...)` line in tools/index.ts
+  // doesn't blow up.
+  getToolNames(): string[] {
+    return this.registered;
+  }
+}
+
+describe('oc_performance_insights tool registration', () => {
+  // The two registration helpers each call `server.registerTool(name, ...)`
+  // so we can assert the off-switch behaviour by spying directly on the
+  // exported `registerOcPerformanceInsightsTool` / `registerOcPerformanceAnalyzeTool`
+  // functions instead of bringing in the full `registerAllTools` pipeline
+  // (which pulls in real puppeteer, the chrome pool, and other heavy deps).
+
+  test('registerOcPerformanceInsightsTool registers the tool by name', async () => {
+    const { registerOcPerformanceInsightsTool } = await import(
+      '../../src/tools/oc-performance-insights'
+    );
+    const server = new StubServer();
+    registerOcPerformanceInsightsTool(server as unknown as Parameters<typeof registerOcPerformanceInsightsTool>[0]);
+    expect(server.registered).toEqual(['oc_performance_insights']);
+  });
+
+  test('registerOcPerformanceAnalyzeTool registers the tool by name', async () => {
+    const { registerOcPerformanceAnalyzeTool } = await import(
+      '../../src/tools/oc-performance-analyze'
+    );
+    const server = new StubServer();
+    registerOcPerformanceAnalyzeTool(server as unknown as Parameters<typeof registerOcPerformanceAnalyzeTool>[0]);
+    expect(server.registered).toEqual(['oc_performance_analyze']);
+  });
+
+  test('off-switch contract: tools/index.ts gates on OPENCHROME_PERF_INSIGHTS !== "0"', async () => {
+    // Verify the literal env-check the index file uses. We do this by
+    // reading the source rather than booting the full registration
+    // pipeline — that pipeline depends on a working Chrome.
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const indexPath = path.join(__dirname, '..', '..', 'src', 'tools', 'index.ts');
+    const src = fs.readFileSync(indexPath, 'utf8');
+    expect(src).toMatch(/OPENCHROME_PERF_INSIGHTS\s*!==\s*'0'/);
+    expect(src).toMatch(/registerOcPerformanceInsightsTool\(server\)/);
+    expect(src).toMatch(/registerOcPerformanceAnalyzeTool\(server\)/);
+    // TODO(#844) marker is preserved at the gate.
+    expect(src).toMatch(/TODO\(#844\)/);
+  });
+});

--- a/tests/tools/oc-performance-insights-reset.test.ts
+++ b/tests/tools/oc-performance-insights-reset.test.ts
@@ -1,0 +1,173 @@
+/// <reference types="jest" />
+
+/**
+ * Emulation-reset test for oc_performance_insights (#846, P1 codex finding).
+ *
+ * Asserts that CPU / network throttling overrides are always reset on
+ * the error path. If `Tracing.end` throws mid-collection, the handler
+ * must still issue the corresponding `Emulation.setCPUThrottlingRate`
+ * (with `rate: 1`) and `Network.emulateNetworkConditions` (with the
+ * `NETWORK_PRESETS.none` reset payload) before rejecting — otherwise
+ * the tab stays throttled for subsequent tool calls in the same
+ * session.
+ *
+ * The test uses jest.mock on `../../src/session-manager` so we never
+ * touch a real Chrome process; we feed our own stub page + stub CDP
+ * session in.
+ */
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(),
+}));
+
+import { getSessionManager } from '../../src/session-manager';
+import { registerOcPerformanceInsightsTool } from '../../src/tools/oc-performance-insights';
+
+interface RegisteredTool {
+  handler: (sessionId: string, args: Record<string, unknown>) => Promise<{
+    content: { type: string; text: string }[];
+    isError?: boolean;
+    [key: string]: unknown;
+  }>;
+}
+
+class StubServer {
+  tools = new Map<string, RegisteredTool>();
+  registerTool(name: string, handler: RegisteredTool['handler']): void {
+    this.tools.set(name, { handler });
+  }
+}
+
+interface SendCall {
+  method: string;
+  params: unknown;
+}
+
+function makeStubCdp(opts: { throwOn?: string } = {}) {
+  const calls: SendCall[] = [];
+  const cdp = {
+    calls,
+    send: jest.fn(async (method: string, params?: unknown) => {
+      calls.push({ method, params: params ?? null });
+      if (opts.throwOn && method === opts.throwOn) {
+        throw new Error(`stub CDP: forced throw on ${method}`);
+      }
+      return undefined as unknown;
+    }),
+    on: jest.fn(),
+    off: jest.fn(),
+    once: jest.fn(),
+    detach: jest.fn(async () => undefined),
+  };
+  return cdp;
+}
+
+function makeStubPage(cdp: ReturnType<typeof makeStubCdp>) {
+  return {
+    createCDPSession: jest.fn(async () => cdp),
+    goto: jest.fn(async () => undefined),
+    reload: jest.fn(async () => undefined),
+    waitForNavigation: jest.fn(async () => undefined),
+  };
+}
+
+describe('oc_performance_insights emulation reset on error path', () => {
+  let server: StubServer;
+  let handler: RegisteredTool['handler'];
+
+  beforeEach(() => {
+    server = new StubServer();
+    registerOcPerformanceInsightsTool(server as unknown as Parameters<typeof registerOcPerformanceInsightsTool>[0]);
+    handler = server.tools.get('oc_performance_insights')!.handler;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('resets CPU + network overrides when Tracing.end throws mid-collection', async () => {
+    const cdp = makeStubCdp({ throwOn: 'Tracing.end' });
+    const page = makeStubPage(cdp);
+    (getSessionManager as jest.Mock).mockReturnValue({
+      getPage: jest.fn(async () => page),
+    });
+
+    const result = await handler('s-1', {
+      tabId: 'tab-1',
+      cpuThrottling: 4,
+      network: 'slow-3g',
+      autoStop: { ms: 1 },
+    });
+
+    // The handler returns a structured error (not a throw) — but the
+    // important assertion is that emulation overrides are reset.
+    expect(result.isError).toBe(true);
+
+    const sentMethods = cdp.calls.map((c) => c.method);
+    // CPU + network were applied at the top of the try block.
+    expect(sentMethods).toContain('Emulation.setCPUThrottlingRate');
+    expect(sentMethods).toContain('Network.emulateNetworkConditions');
+
+    // The final cleanup must have been sent even though Tracing.end threw.
+    const cpuResetCall = [...cdp.calls]
+      .reverse()
+      .find((c) => c.method === 'Emulation.setCPUThrottlingRate');
+    expect(cpuResetCall).toBeDefined();
+    expect(cpuResetCall!.params).toEqual({ rate: 1 });
+
+    const netResetCall = [...cdp.calls]
+      .reverse()
+      .find((c) => c.method === 'Network.emulateNetworkConditions');
+    expect(netResetCall).toBeDefined();
+    expect(netResetCall!.params).toEqual({
+      offline: false,
+      latency: 0,
+      downloadThroughput: -1,
+      uploadThroughput: -1,
+    });
+  });
+
+  test('does NOT issue resets that were never applied', async () => {
+    // No cpuThrottling, no network — both overrides stay un-applied.
+    // A throw mid-trace must not surface phantom resets.
+    const cdp = makeStubCdp({ throwOn: 'Tracing.end' });
+    const page = makeStubPage(cdp);
+    (getSessionManager as jest.Mock).mockReturnValue({
+      getPage: jest.fn(async () => page),
+    });
+
+    const result = await handler('s-1', {
+      tabId: 'tab-1',
+      autoStop: { ms: 1 },
+    });
+
+    expect(result.isError).toBe(true);
+    const sentMethods = cdp.calls.map((c) => c.method);
+    expect(sentMethods).not.toContain('Emulation.setCPUThrottlingRate');
+    expect(sentMethods).not.toContain('Network.emulateNetworkConditions');
+  });
+
+  test('resets ONLY CPU when only CPU throttling was applied', async () => {
+    const cdp = makeStubCdp({ throwOn: 'Tracing.end' });
+    const page = makeStubPage(cdp);
+    (getSessionManager as jest.Mock).mockReturnValue({
+      getPage: jest.fn(async () => page),
+    });
+
+    const result = await handler('s-1', {
+      tabId: 'tab-1',
+      cpuThrottling: 4,
+      autoStop: { ms: 1 },
+    });
+
+    expect(result.isError).toBe(true);
+    const sentMethods = cdp.calls.map((c) => c.method);
+    expect(sentMethods).toContain('Emulation.setCPUThrottlingRate');
+    expect(sentMethods).not.toContain('Network.emulateNetworkConditions');
+
+    const cpuResetCall = [...cdp.calls]
+      .reverse()
+      .find((c) => c.method === 'Emulation.setCPUThrottlingRate');
+    expect(cpuResetCall!.params).toEqual({ rate: 1 });
+  });
+});

--- a/tests/tools/oc-performance-insights-reset.test.ts
+++ b/tests/tools/oc-performance-insights-reset.test.ts
@@ -147,6 +147,87 @@ describe('oc_performance_insights emulation reset on error path', () => {
     expect(sentMethods).not.toContain('Network.emulateNetworkConditions');
   });
 
+  // P1 codex finding: the 5-second wait for Tracing.tracingComplete
+  // used to fall back to an empty event list, so the tool persisted
+  // and analyzed an empty trace as if it were valid. The handler now
+  // surfaces a structured error and does NOT create a trace handle.
+  describe('tracing_complete_timeout structured error', () => {
+    const ORIGINAL_ENV = process.env.OC_PERF_TRACING_COMPLETE_TIMEOUT_MS;
+    beforeEach(() => {
+      // Keep the test fast — minimum allowed value is 1000ms.
+      process.env.OC_PERF_TRACING_COMPLETE_TIMEOUT_MS = '1000';
+    });
+    afterEach(() => {
+      if (ORIGINAL_ENV === undefined) {
+        delete process.env.OC_PERF_TRACING_COMPLETE_TIMEOUT_MS;
+      } else {
+        process.env.OC_PERF_TRACING_COMPLETE_TIMEOUT_MS = ORIGINAL_ENV;
+      }
+    });
+
+    test('returns structured error when tracingComplete never fires', async () => {
+      const cdp = makeStubCdp(); // No throwOn — Tracing.end succeeds.
+      // `once('Tracing.tracingComplete', cb)` is a jest mock that does
+      // NOT invoke its callback, so the collectPromise never resolves
+      // and our timeout branch must fire.
+      const page = makeStubPage(cdp);
+      (getSessionManager as jest.Mock).mockReturnValue({
+        getPage: jest.fn(async () => page),
+      });
+
+      const result = await handler('s-1', {
+        tabId: 'tab-1',
+        cpuThrottling: 4,
+        network: 'slow-3g',
+        autoStop: { ms: 1 },
+      });
+
+      expect(result.isError).toBe(true);
+      const body = JSON.parse(result.content[0].text);
+      expect(body.error).toBe('tracing_complete_timeout');
+      expect(typeof body.elapsed_ms).toBe('number');
+      expect(body.elapsed_ms).toBeGreaterThanOrEqual(1000);
+      expect(typeof body.hint).toBe('string');
+      expect(body.hint).toMatch(/OC_PERF_TRACING_COMPLETE_TIMEOUT_MS/);
+
+      // No trace handle (no trace_id) is surfaced on this path.
+      expect(body.trace_id).toBeUndefined();
+      expect(body.trace_path).toBeUndefined();
+
+      // Crucially, emulation overrides are still reset (finally block).
+      const sentMethods = cdp.calls.map((c) => c.method);
+      expect(sentMethods).toContain('Emulation.setCPUThrottlingRate');
+      expect(sentMethods).toContain('Network.emulateNetworkConditions');
+      const cpuResetCall = [...cdp.calls]
+        .reverse()
+        .find((c) => c.method === 'Emulation.setCPUThrottlingRate');
+      expect(cpuResetCall!.params).toEqual({ rate: 1 });
+    }, 10_000);
+
+    test('does not persist a trace handle on timeout', async () => {
+      const cdp = makeStubCdp();
+      const page = makeStubPage(cdp);
+      (getSessionManager as jest.Mock).mockReturnValue({
+        getPage: jest.fn(async () => page),
+      });
+
+      // Spy on the store to assert nothing is persisted on this path.
+      const traceStore = await import('../../src/core/performance/insights/trace-store');
+      const storeSpy = jest.spyOn(traceStore.getPerfTraceStore(), 'store');
+
+      const result = await handler('s-1', {
+        tabId: 'tab-1',
+        autoStop: { ms: 1 },
+      });
+
+      expect(result.isError).toBe(true);
+      const body = JSON.parse(result.content[0].text);
+      expect(body.error).toBe('tracing_complete_timeout');
+      expect(storeSpy).not.toHaveBeenCalled();
+      storeSpy.mockRestore();
+    }, 10_000);
+  });
+
   test('resets ONLY CPU when only CPU throttling was applied', async () => {
     const cdp = makeStubCdp({ throwOn: 'Tracing.end' });
     const page = makeStubPage(cdp);


### PR DESCRIPTION
## Summary

Implements issue #846 (r2) — chrome-devtools-mcp adoption epic, item B.

Adds `oc_performance_insights` and `oc_performance_analyze` MCP tools that turn raw CDP performance traces into named, drill-downable insights (LCPBreakdown, DocumentLatency, RenderBlocking, CLSCulprits, LongTasks, ThirdParties). Trace handles are `SessionManager`-scoped; files live under `path.join(os.homedir(), '.openchrome', 'perf-traces')` and are evicted on session close.

## Scope reduction (declared)

The issue spec called for vendoring a subset of `chrome-devtools-frontend`'s trace insight modules. This PR ships a **hand-rolled v1 engine** instead — equivalent insight surface, smaller diff, no vendoring lint to ship at the same time. The vendoring + `MANIFEST.txt` CI lint will land as a follow-up PR. Rationale: get the user-facing two-step API into the hands of agents quickly; refine the engine source once the API surface is stable.

## What changed

### Engine (`src/core/performance/insights/`)
- `types.ts` — `INSIGHT_NAMES` closed set, `TraceDocument`/`TraceEventRecord`, evaluator surface
- `evaluators.ts` — 6 hand-rolled evaluators (LCPBreakdown, DocumentLatency, RenderBlocking, CLSCulprits, LongTasks, ThirdParties). Each yields `{ summary, details_md, evidence }`; URLs scrubbed via `src/core/trace/redactor.ts`
- `index.ts` — `evaluateInsights()`, `buildSummaryMarkdown()`, `isInsightName()` public API
- `trace-store.ts` — `PerfTraceStore` with gzipped JSONL persistence, session-scoped handles, `evictSession()`

### Tools (`src/tools/`)
- `oc-performance-insights.ts` — captures via CDP `Tracing.start`/`Tracing.end` with optional CPU + network throttling. Args: `url`, `reload`, `autoStop` (`load`|`idle`|`{ms}`). Returns `{trace_id, trace_path, summary_md, insights[]}`.
- `oc-performance-analyze.ts` — drill-down by `trace_id` + `insight`. Unknown insight → `{error: 'unknown_insight', supported: [...]}` (closed-set self-correction).

### Wiring (`src/tools/index.ts`)
- Inline env-flag gate `process.env.OPENCHROME_PERF_INSIGHTS !== '0'` with `TODO(#844): use isCoreFeatureEnabled()` marker pointing at the planned helper. When `OPENCHROME_PERF_INSIGHTS=0`, neither tool is registered (P2 `tools/list` parity preserved).
- Single-registration `addEventListener('session:deleted')` to evict trace handles + files on session close.

12 files, +2050 / -minimal.

## Test plan

- [x] `npm run build` — PASS (one TS error caught + fixed in QA cycle 1)
- [x] `npm test -- --testPathPattern="performance/insights|oc-performance"` — 4 suites, **29/29** PASS
  - `evaluators.test.ts` — 13 cases across all 6 evaluators incl. severity tiers + redaction proof
  - `trace-store.test.ts` — 6 cases: round-trip, evictSession, evictTrace, error paths
  - `oc-performance-analyze.test.ts` — 5 cases: handler success + 4 error shapes
  - `oc-performance-insights-registration.test.ts` — 3 cases: registration + source-level off-switch contract
- [ ] Real verification per issue #846 §"Real verification" — `mcp__openchrome__oc_performance_insights` against `https://web.dev/performance/`, drill-down via `oc_performance_analyze`, response-size budget check.

## P2 parity

- `OPENCHROME_PERF_INSIGHTS=0` (or any future deprecation): both tools skipped at registration; cleanup listener never wired; `tools/list` parity preserved.
- No `package.json` changes (P5).

## Cross-PR coordination

This PR uses an inline env check `process.env.OPENCHROME_PERF_INSIGHTS !== '0'` with a `TODO(#844)` marker. Once #844 (`isCoreFeatureEnabled()` helper) lands on develop, a small follow-up rewrites this to `isCoreFeatureEnabled('OPENCHROME_PERF_INSIGHTS', true)`. Intentional duplication for now to keep this PR independent of #844's review cadence.

Closes #846.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
