### PR TITLE
feat(http-daemon): Prometheus /metrics endpoint (#839 Part A)

### DIFF
--- a/src/desktop/dashboard-state.ts
+++ b/src/desktop/dashboard-state.ts
@@ -86,10 +86,27 @@ class PerSessionRingBuffer {
   }
 }
 
+/**
+ * Process-lifetime monotonic count, keyed by (sessionId, toolName, result).
+ * Backs the Prometheus `openchrome_tool_calls_total` counter (#839, P2):
+ * the dashboard ring buffer is bounded so counts derived from it can shrink
+ * as old entries age out, which violates Prometheus counter monotonicity.
+ * Tenant resolution happens at scrape time via `sessionManager.getSession`,
+ * which matches the filter applied by `handleToolCalls` (#839, P1).
+ */
+export interface ToolCallCounterRow {
+  sessionId: string;
+  toolName: string;
+  result: 'success' | 'error';
+  count: number;
+}
+
 export class DashboardState {
   private calls = new PerSessionRingBuffer(MAX_CALLS_PER_SESSION);
   private activeCalls = new Map<string, DashboardToolCall>();
   private startTime = Date.now();
+  /** Monotonic counts keyed as `${sessionId}${toolName}${result}`. */
+  private toolCallTotals = new Map<string, number>();
 
   /**
    * Record the start of a tool call. Returns the call ID for later completion.
@@ -122,6 +139,31 @@ export class DashboardState {
       call.error = error;
     }
     this.activeCalls.delete(callId);
+
+    // Increment the monotonic Prometheus counter. `aborted` is folded into
+    // `error` to match the dashboard's two-bucket exposition.
+    // Use  (Unit Separator) as the field delimiter: it cannot appear
+    // in session UUIDs or tool-name identifiers, so the key is unambiguously
+    // parseable in getToolCallTotals.
+    const bucket: 'success' | 'error' = status === 'success' ? 'success' : 'error';
+    const key = `${call.sessionId}${call.toolName}${bucket}`;
+    this.toolCallTotals.set(key, (this.toolCallTotals.get(key) ?? 0) + 1);
+  }
+
+  /**
+   * Snapshot of every (sessionId, toolName, result) cell ever observed in
+   * this process. Counts only increase; aging out of the ring buffer does
+   * not decrement these values.
+   */
+  getToolCallTotals(): ToolCallCounterRow[] {
+    const rows: ToolCallCounterRow[] = [];
+    for (const [key, count] of this.toolCallTotals) {
+      const [sessionId, toolName, result] = key.split('\u001f');
+      if (sessionId === undefined || toolName === undefined) continue;
+      if (result !== 'success' && result !== 'error') continue;
+      rows.push({ sessionId, toolName, result, count });
+    }
+    return rows;
   }
 
   /**

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -898,25 +898,43 @@ export class HTTPTransport implements MCPTransport {
       }
     }
 
-    // DashboardState exposes a bounded per-session call history (capacity
-    // MAX_CALLS_PER_SESSION × N sessions). We aggregate the visible window
-    // by toolName + status so the exposition includes per-tool totals (the
-    // bulk of operator interest). Sessions invisible to this principal are
-    // already filtered out above; the dashboard ring is the same view.
-    let activeCount = 0;
-    for (const call of dashboardState.getToolCalls(undefined, 1000)) {
-      if (!call.toolName) continue;
-      if (call.status === 'running') {
-        activeCount++;
+    // `openchrome_tool_calls_total` is read from the process-lifetime
+    // monotonic counter in DashboardState (#839, P2) — the ring buffer
+    // is bounded so deriving counts from it would let values shrink as
+    // old entries age out, violating Prometheus counter semantics.
+    //
+    // Each counter row carries the session that produced the call; we
+    // resolve that session's tenant and skip rows the principal cannot
+    // see, mirroring `handleToolCalls` (#839, P1). Sessions that have
+    // been deleted cannot be attributed to a tenant and are hidden.
+    const sm = this.sessionManager;
+    for (const row of dashboardState.getToolCallTotals()) {
+      if (!row.toolName) continue;
+      if (sm) {
+        const sessionTenantId = sm.getSession(row.sessionId)?.tenantId;
+        if (!canSeeTenant(authz.principal, sessionTenantId)) continue;
+      } else if (!canSeeTenant(authz.principal, undefined)) {
         continue;
       }
-      const slot = toolCallCounts[call.toolName] ?? { success: 0, error: 0 };
-      if (call.status === 'error' || call.status === 'aborted') {
-        slot.error++;
-      } else if (call.status === 'success') {
-        slot.success++;
+      const slot = toolCallCounts[row.toolName] ?? { success: 0, error: 0 };
+      slot[row.result] += row.count;
+      toolCallCounts[row.toolName] = slot;
+    }
+
+    // `openchrome_tool_calls_active` is an inherently transient gauge: it
+    // reflects in-flight calls at scrape time. We read it from the dashboard
+    // ring (the only place active calls are tracked) and apply the same
+    // tenant filter as above.
+    let activeCount = 0;
+    for (const call of dashboardState.getToolCalls(undefined, 1000)) {
+      if (call.status !== 'running') continue;
+      if (sm) {
+        const sessionTenantId = sm.getSession(call.sessionId)?.tenantId;
+        if (!canSeeTenant(authz.principal, sessionTenantId)) continue;
+      } else if (!canSeeTenant(authz.principal, undefined)) {
+        continue;
       }
-      toolCallCounts[call.toolName] = slot;
+      activeCount++;
     }
 
     const toolCallSamples: Array<{ labels: Record<string, string>; value: number }> = [];

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -19,6 +19,7 @@ import {
 } from '../config/defaults';
 import { ClientDisconnectError } from '../errors/abort';
 import { MCPTransport } from './index';
+import { renderPrometheusMetrics, type PrometheusMetric } from './prometheus';
 import { getDashboardState } from '../desktop/dashboard-state';
 import type { SessionManager } from '../session-manager';
 import {
@@ -532,6 +533,13 @@ export class HTTPTransport implements MCPTransport {
       this.handleMetrics(req, res);
       return;
     }
+    // Prometheus text exposition format (#839). Auth-required via the same
+    // bearer/api-key flow as /api/metrics. Hand-rolled — no prom-client
+    // dependency per P5.
+    if (pathname === '/metrics' && req.method === 'GET') {
+      this.handlePrometheusMetrics(req, res);
+      return;
+    }
 
     // Explicit /mcp/sse endpoint (MCP spec alias for GET /mcp SSE stream)
     if (pathname === '/mcp/sse') {
@@ -858,6 +866,112 @@ export class HTTPTransport implements MCPTransport {
 
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify(metrics));
+  }
+
+  /**
+   * GET /metrics — Prometheus text exposition format (#839).
+   *
+   * Auth-required via the existing bearer/api-key chain used by
+   * /api/metrics. Counters are read-only views over already-tracked
+   * in-process state; no new persistence is introduced. Hand-rolled
+   * exposition format avoids the prom-client dependency (P5).
+   */
+  private handlePrometheusMetrics(req: http.IncomingMessage, res: http.ServerResponse): void {
+    const authz = authorizeDashboardEndpoint(req, 'metrics');
+    if (!authz.ok) {
+      this.writeDashboardAuthzFailure(res, 'metrics', 'anonymous', authz.status, authz.error);
+      return;
+    }
+
+    const mem = process.memoryUsage();
+    const dashboardState = getDashboardState();
+
+    let tabCount = 0;
+    let sessionCount = 0;
+    const toolCallCounts: Record<string, { success: number; error: number }> = {};
+    if (this.sessionManager) {
+      const visible = this.sessionManager.getAllSessionInfos()
+        .filter((info) => canSeeTenant(authz.principal, info.tenantId));
+      sessionCount = visible.length;
+      for (const info of visible) {
+        tabCount += info.targetCount;
+      }
+    }
+
+    // DashboardState exposes a bounded per-session call history (capacity
+    // MAX_CALLS_PER_SESSION × N sessions). We aggregate the visible window
+    // by toolName + status so the exposition includes per-tool totals (the
+    // bulk of operator interest). Sessions invisible to this principal are
+    // already filtered out above; the dashboard ring is the same view.
+    let activeCount = 0;
+    for (const call of dashboardState.getToolCalls(undefined, 1000)) {
+      if (!call.toolName) continue;
+      if (call.status === 'running') {
+        activeCount++;
+        continue;
+      }
+      const slot = toolCallCounts[call.toolName] ?? { success: 0, error: 0 };
+      if (call.status === 'error' || call.status === 'aborted') {
+        slot.error++;
+      } else if (call.status === 'success') {
+        slot.success++;
+      }
+      toolCallCounts[call.toolName] = slot;
+    }
+
+    const toolCallSamples: Array<{ labels: Record<string, string>; value: number }> = [];
+    for (const [tool, counts] of Object.entries(toolCallCounts)) {
+      if (counts.success > 0) {
+        toolCallSamples.push({ labels: { tool, result: 'success' }, value: counts.success });
+      }
+      if (counts.error > 0) {
+        toolCallSamples.push({ labels: { tool, result: 'error' }, value: counts.error });
+      }
+    }
+
+    const metrics: PrometheusMetric[] = [
+      {
+        name: 'openchrome_uptime_seconds',
+        help: 'Server uptime in seconds since process start.',
+        type: 'gauge',
+        value: dashboardState.getUptimeSecs(),
+      },
+      {
+        name: 'openchrome_ram_bytes',
+        help: 'Resident set size (RSS) of the openchrome server process.',
+        type: 'gauge',
+        value: mem.rss,
+      },
+      {
+        name: 'openchrome_tab_count',
+        help: 'Number of Chrome tabs currently tracked across visible sessions.',
+        type: 'gauge',
+        value: tabCount,
+      },
+      {
+        name: 'openchrome_session_count',
+        help: 'Number of active MCP sessions visible to the requesting principal.',
+        type: 'gauge',
+        value: sessionCount,
+      },
+      {
+        name: 'openchrome_tool_calls_total',
+        help: 'Cumulative tool call count, labelled by tool name and result.',
+        type: 'counter',
+        samples: toolCallSamples,
+      },
+      {
+        name: 'openchrome_tool_calls_active',
+        help: 'Tool calls currently in flight (status="running" in the dashboard ring).',
+        type: 'gauge',
+        value: activeCount,
+      },
+    ];
+
+    res.writeHead(200, {
+      'Content-Type': 'text/plain; version=0.0.4; charset=utf-8',
+    });
+    res.end(renderPrometheusMetrics(metrics));
   }
 
   /**

--- a/src/transports/prometheus.ts
+++ b/src/transports/prometheus.ts
@@ -1,0 +1,86 @@
+/**
+ * Hand-rolled Prometheus text exposition format (#839).
+ *
+ * Lives in `src/transports/` (tier:core) and intentionally avoids the
+ * `prom-client` dependency per P5 of the Portability-Harness Contract.
+ * The exposition format follows the Prometheus spec
+ * (https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format):
+ *   - `# HELP <name> <text>` (one per metric)
+ *   - `# TYPE <name> counter|gauge`
+ *   - `<name>{label1="value"} <value>`
+ *
+ * Numeric values are emitted without locale formatting. Label values are
+ * escaped per spec (backslash, double-quote, newline). The endpoint is
+ * read-only — counters are sourced from existing in-process state, never
+ * persisted to disk.
+ */
+
+const ALLOWED_LABEL_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+export interface PrometheusMetric {
+  /** snake_case metric name, must match Prometheus naming rules. */
+  name: string;
+  /** Free-text help line. */
+  help: string;
+  /** Prometheus type. */
+  type: 'counter' | 'gauge';
+  /** Single value (gauge / counter total) — exclusive with `samples`. */
+  value?: number;
+  /** Multiple samples (e.g. per-tool counters). */
+  samples?: Array<{ labels?: Record<string, string>; value: number }>;
+}
+
+/** Render a complete exposition document from the supplied metrics. */
+export function renderPrometheusMetrics(metrics: PrometheusMetric[]): string {
+  const lines: string[] = [];
+  for (const m of metrics) {
+    if (!ALLOWED_LABEL_RE.test(m.name)) {
+      // Skip illegal names rather than poison the entire exposition.
+      continue;
+    }
+    lines.push(`# HELP ${m.name} ${escapeHelp(m.help)}`);
+    lines.push(`# TYPE ${m.name} ${m.type}`);
+    if (m.samples && m.samples.length > 0) {
+      for (const s of m.samples) {
+        lines.push(`${m.name}${formatLabels(s.labels)} ${formatValue(s.value)}`);
+      }
+    } else if (typeof m.value === 'number') {
+      lines.push(`${m.name} ${formatValue(m.value)}`);
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+function escapeHelp(s: string): string {
+  // Per spec: `\` → `\\`, `\n` → `\\n`. Help lines do not require quote
+  // escaping (they are unquoted).
+  return s.replace(/\\/g, '\\\\').replace(/\n/g, '\\n');
+}
+
+function formatLabels(labels?: Record<string, string>): string {
+  if (!labels) return '';
+  const parts: string[] = [];
+  for (const [k, v] of Object.entries(labels)) {
+    if (!ALLOWED_LABEL_RE.test(k)) continue;
+    parts.push(`${k}="${escapeLabelValue(v)}"`);
+  }
+  return parts.length === 0 ? '' : `{${parts.join(',')}}`;
+}
+
+function escapeLabelValue(s: string): string {
+  // Per spec: `\` → `\\`, `"` → `\\"`, `\n` → `\\n`.
+  return s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n');
+}
+
+function formatValue(v: number): string {
+  if (!Number.isFinite(v)) {
+    if (Number.isNaN(v)) return 'NaN';
+    return v > 0 ? '+Inf' : '-Inf';
+  }
+  // Integers without a decimal point, floats trimmed.
+  return Number.isInteger(v) ? String(v) : String(v);
+}

--- a/tests/security/dashboard-rest-authz.test.ts
+++ b/tests/security/dashboard-rest-authz.test.ts
@@ -258,6 +258,68 @@ describe('dashboard REST authorization', () => {
     }
   });
 
+  it('filters Prometheus /metrics tool_calls_total by tenant visibility (#839 P1)', async () => {
+    const booted = await boot(
+      undefined,
+      fakeStore({ [adminAlpha]: { tenantId: 'alpha', scopes: ['admin'] } }),
+    );
+    transport = booted.transport;
+
+    const { getDashboardState } = await import('../../src/desktop/dashboard-state');
+    const state = getDashboardState();
+    // Use suffixed session IDs unique to this test so the monotonic
+    // counter is isolated from the preceding `hides cross-tenant tool
+    // calls` test that touches `alpha-session` / `beta-session` with the
+    // same singleton dashboardState.
+    state.recordToolStart('alpha-session-metrics', 'navigate', { url: 'https://alpha.example' }, 'metrics-call-alpha-success');
+    state.recordToolEnd('metrics-call-alpha-success', 'success');
+    state.recordToolStart('beta-session-metrics', 'click', { selector: 'a' }, 'metrics-call-beta-error');
+    state.recordToolEnd('metrics-call-beta-error', 'error', 'boom');
+    state.recordToolStart('beta-session-metrics', 'screenshot', undefined, 'metrics-call-beta-success');
+    state.recordToolEnd('metrics-call-beta-success', 'success');
+
+    const res = await request(booted.port, '/metrics', { Authorization: `Bearer ${adminAlpha}` });
+
+    expect(res.status).toBe(200);
+    // Tenant-alpha admin scraping /metrics must see only the navigate sample
+    // produced under alpha-session, not the click/screenshot calls from
+    // beta-session. Asserting against the rendered label sets makes any
+    // cross-tenant leak (tool name, count, result class) visible.
+    expect(res.body).toContain('openchrome_tool_calls_total{tool="navigate",result="success"} 1');
+    expect(res.body).not.toMatch(/openchrome_tool_calls_total\{tool="click"/);
+    expect(res.body).not.toMatch(/openchrome_tool_calls_total\{tool="screenshot"/);
+  });
+
+  it('exposes a monotonic openchrome_tool_calls_total counter (#839 P2)', async () => {
+    const booted = await boot();
+    transport = booted.transport;
+
+    const { getDashboardState } = await import('../../src/desktop/dashboard-state');
+    const state = getDashboardState();
+    state.recordToolStart('alpha-session', 'monotonic_tool', undefined, 'mono-call-1');
+    state.recordToolEnd('mono-call-1', 'success');
+
+    const first = await request(booted.port, '/metrics');
+    expect(first.status).toBe(200);
+    const firstMatch = first.body.match(/openchrome_tool_calls_total\{tool="monotonic_tool",result="success"\} (\d+)/);
+    expect(firstMatch).not.toBeNull();
+    const firstValue = Number(firstMatch![1]);
+
+    state.recordToolStart('alpha-session', 'monotonic_tool', undefined, 'mono-call-2');
+    state.recordToolEnd('mono-call-2', 'success');
+
+    const second = await request(booted.port, '/metrics');
+    expect(second.status).toBe(200);
+    const secondMatch = second.body.match(/openchrome_tool_calls_total\{tool="monotonic_tool",result="success"\} (\d+)/);
+    expect(secondMatch).not.toBeNull();
+    const secondValue = Number(secondMatch![1]);
+
+    // The defining property of a Prometheus counter: subsequent scrapes are
+    // never less than earlier ones for the same label set.
+    expect(secondValue).toBeGreaterThanOrEqual(firstValue);
+    expect(secondValue - firstValue).toBe(1);
+  });
+
   it('rejects tool-call requests targeting another tenant\'s session', async () => {
     const booted = await boot(
       undefined,

--- a/tests/transports/prometheus.test.ts
+++ b/tests/transports/prometheus.test.ts
@@ -1,0 +1,107 @@
+/// <reference types="jest" />
+/**
+ * Hand-rolled Prometheus exposition format tests (#839).
+ */
+
+import { renderPrometheusMetrics, type PrometheusMetric } from '../../src/transports/prometheus';
+
+describe('renderPrometheusMetrics', () => {
+  test('emits HELP, TYPE, and a single value line for a gauge', () => {
+    const out = renderPrometheusMetrics([
+      { name: 'openchrome_uptime_seconds', help: 'Uptime', type: 'gauge', value: 42 },
+    ]);
+    expect(out).toContain('# HELP openchrome_uptime_seconds Uptime');
+    expect(out).toContain('# TYPE openchrome_uptime_seconds gauge');
+    expect(out).toContain('openchrome_uptime_seconds 42');
+  });
+
+  test('emits a sample line per label set for a counter', () => {
+    const out = renderPrometheusMetrics([
+      {
+        name: 'openchrome_tool_calls_total',
+        help: 'Per-tool totals.',
+        type: 'counter',
+        samples: [
+          { labels: { tool: 'navigate', result: 'success' }, value: 12 },
+          { labels: { tool: 'navigate', result: 'error' }, value: 1 },
+          { labels: { tool: 'read_page', result: 'success' }, value: 7 },
+        ],
+      },
+    ]);
+    expect(out).toContain('openchrome_tool_calls_total{tool="navigate",result="success"} 12');
+    expect(out).toContain('openchrome_tool_calls_total{tool="navigate",result="error"} 1');
+    expect(out).toContain('openchrome_tool_calls_total{tool="read_page",result="success"} 7');
+  });
+
+  test('escapes label values per spec (quotes, backslashes, newlines)', () => {
+    const out = renderPrometheusMetrics([
+      {
+        name: 'openchrome_label_escape_demo',
+        help: 'Escape demo.',
+        type: 'gauge',
+        samples: [
+          { labels: { src: 'a"b\\c\nd' }, value: 1 },
+        ],
+      },
+    ]);
+    expect(out).toContain('openchrome_label_escape_demo{src="a\\"b\\\\c\\nd"} 1');
+  });
+
+  test('omits illegal metric names entirely (no partial leak)', () => {
+    const out = renderPrometheusMetrics([
+      { name: '1bad-name', help: 'Bad', type: 'gauge', value: 1 },
+      { name: 'good_name', help: 'Good', type: 'gauge', value: 2 },
+    ]);
+    expect(out).not.toContain('1bad-name');
+    expect(out).toContain('good_name 2');
+  });
+
+  test('omits illegal label keys but preserves the sample line', () => {
+    const out = renderPrometheusMetrics([
+      {
+        name: 'm',
+        help: 'X',
+        type: 'gauge',
+        samples: [{ labels: { 'bad-key': 'v', good_key: 'ok' }, value: 9 }],
+      },
+    ]);
+    expect(out).toContain('m{good_key="ok"} 9');
+    expect(out).not.toContain('bad-key');
+  });
+
+  test('handles NaN / Infinity per Prometheus spec', () => {
+    const out = renderPrometheusMetrics([
+      { name: 'nan_metric', help: 'X', type: 'gauge', value: NaN },
+      { name: 'inf_metric', help: 'X', type: 'gauge', value: Infinity },
+      { name: 'neg_inf_metric', help: 'X', type: 'gauge', value: -Infinity },
+    ]);
+    expect(out).toContain('nan_metric NaN');
+    expect(out).toContain('inf_metric +Inf');
+    expect(out).toContain('neg_inf_metric -Inf');
+  });
+
+  test('emits an empty samples block as just HELP + TYPE (no value line)', () => {
+    const out = renderPrometheusMetrics([
+      {
+        name: 'empty_counter',
+        help: 'No samples yet.',
+        type: 'counter',
+        samples: [],
+      },
+    ]);
+    expect(out).toContain('# HELP empty_counter No samples yet.');
+    expect(out).toContain('# TYPE empty_counter counter');
+    expect(out).not.toMatch(/^empty_counter /m);
+  });
+
+  test('full exposition contains a trailing blank line between metrics', () => {
+    const metrics: PrometheusMetric[] = [
+      { name: 'a', help: 'A', type: 'gauge', value: 1 },
+      { name: 'b', help: 'B', type: 'gauge', value: 2 },
+    ];
+    const out = renderPrometheusMetrics(metrics);
+    // Each metric block is followed by a blank line; the exposition ends
+    // without a stray double-blank.
+    expect(out).toMatch(/a 1\n\n# HELP b/);
+  });
+});


### PR DESCRIPTION
## Summary
- New hand-rolled Prometheus text exposition endpoint at `GET /metrics`
- Authenticated via the same bearer/api-key chain as the existing `/api/metrics` (tenant-aware: only sessions visible to the requesting principal are aggregated)
- No `prom-client` dependency (P5)
- Tenant-aware tool-call totals labelled by `tool` and `result`

Closes part of #839. The pilot-tier workspace tenancy (`--tenancy`, `--workspace-idle-seconds`) is intentionally deferred to a follow-up PR.

## Tier
`core` — `src/transports/` only. P5-compliant (no new native deps).

## Scope clarification
Issue #839 originally bundled three things:
1. **Streamable HTTP transport at `/mcp`** — already exists in `src/transports/http.ts` (spec 2025-03-26), no new code needed.
2. **Ops endpoints (`/health`, `/metrics`)** — `/health` already exists. This PR adds `/metrics` in Prometheus format.
3. **Pilot workspace tenancy** — deferred to a follow-up. The current HTTP transport's tenant-extractor middleware already provides isolation; idle-shutdown and workspace-hash sharing are pilot-tier features that need separate design and should not block the metrics endpoint.

## Metrics exposed
| Metric | Type | Labels | Description |
|---|---|---|---|
| `openchrome_uptime_seconds` | gauge | — | Uptime since process start |
| `openchrome_ram_bytes` | gauge | — | RSS of the openchrome server process |
| `openchrome_tab_count` | gauge | — | Chrome tabs currently tracked across visible sessions |
| `openchrome_session_count` | gauge | — | Active MCP sessions visible to the principal |
| `openchrome_tool_calls_total` | counter | `tool`, `result` | Cumulative tool calls (result ∈ success/error) |
| `openchrome_tool_calls_active` | gauge | — | Tool calls currently in flight |

## Test plan
- [x] `renderPrometheusMetrics` emits HELP + TYPE + value lines per spec
- [x] Counter samples render with label escaping (quotes, backslashes, newlines per spec)
- [x] Illegal metric names are dropped entirely (no partial leak)
- [x] Illegal label keys are filtered but the sample line still emits
- [x] NaN / +Inf / -Inf rendered per Prometheus spec
- [x] Empty counter emits just HELP + TYPE (no value line)
- [x] Trailing blank line between metrics (Prometheus convention)
- [x] `npm run build` green
- [x] `npm run lint:tier` green (no new dependency-cruiser violations)
- [x] Prometheus suite: 8/8 pass
- [x] Transport regression: 11 suites / 69 tests pass

## Manual verification (post-merge)
```bash
node dist/index.js --http 9876 --auth-bearer <token> &
curl -H "Authorization: Bearer <token>" http://localhost:9876/metrics
# → text/plain; version=0.0.4; charset=utf-8 with Prometheus exposition
curl -o /dev/null -w "%{http_code}\n" http://localhost:9876/metrics
# → 401 (no auth)
```
Validate the output with `promtool check metrics` or `prom2json`.

## Out of scope (deferred to follow-up issues)
- Pilot workspace tenancy (`--tenancy=shared-workspace`, `--workspace-idle-seconds`)
- `--tenancy=shared-all` — dropped per #839 refinement
- `POST /shutdown` — `oc_stop` already exists
- OAuth/SSO providers
- Horizontal scaling

🤖 Generated with [Claude Code](https://claude.com/claude-code)