### PR TITLE
Bound DOM page stats output budget

### DIFF
--- a/src/dom/dom-serializer.ts
+++ b/src/dom/dom-serializer.ts
@@ -280,6 +280,23 @@ interface SerializeContext {
   maxNodes: number;
 }
 
+function appendTruncationMarker(ctx: SerializeContext): void {
+  const truncationMsg = `\n\n[Output truncated at ${ctx.maxOutputChars} chars. Use depth parameter to limit scope.]`;
+  ctx.lines.push(truncationMsg);
+  ctx.truncated = true;
+}
+
+function appendBoundedLine(ctx: SerializeContext, line: string): boolean {
+  if (ctx.totalChars + line.length > ctx.maxOutputChars) {
+    appendTruncationMarker(ctx);
+    return false;
+  }
+
+  ctx.lines.push(line);
+  ctx.totalChars += line.length;
+  return true;
+}
+
 /**
  * Recursively serialize a DOM node
  */
@@ -347,9 +364,7 @@ function serializeNode(
       const fullLine = `${indent}${chainPrefix}${leafLine}\n`;
 
       if (ctx.totalChars + fullLine.length > ctx.maxOutputChars) {
-        const truncationMsg = `\n\n[Output truncated at ${ctx.maxOutputChars} chars. Use depth parameter to limit scope.]`;
-        ctx.lines.push(truncationMsg);
-        ctx.truncated = true;
+        appendTruncationMarker(ctx);
         return;
       }
 
@@ -373,9 +388,7 @@ function serializeNode(
     const lineWithNewline = line + '\n';
 
     if (ctx.totalChars + lineWithNewline.length > ctx.maxOutputChars) {
-      const truncationMsg = `\n\n[Output truncated at ${ctx.maxOutputChars} chars. Use depth parameter to limit scope.]`;
-      ctx.lines.push(truncationMsg);
-      ctx.truncated = true;
+      appendTruncationMarker(ctx);
       return;
     }
 
@@ -409,9 +422,7 @@ function serializeNode(
       const separator = `${childIndent}--shadow-root-- (${shadowType})\n`;
 
       if (ctx.totalChars + separator.length > ctx.maxOutputChars) {
-        const truncationMsg = `\n\n[Output truncated at ${ctx.maxOutputChars} chars. Use depth parameter to limit scope.]`;
-        ctx.lines.push(truncationMsg);
-        ctx.truncated = true;
+        appendTruncationMarker(ctx);
         return;
       }
 
@@ -541,17 +552,9 @@ export async function serializeDOM(
     { depth: documentDepth, pierce: true },
   );
 
-  const lines: string[] = [];
-
-  // Add page stats header
-  if (includePageStats) {
-    const statsLine = `[page_stats] url: ${pageStats.url} | title: ${pageStats.title} | scroll: ${pageStats.scrollX},${pageStats.scrollY} | viewport: ${pageStats.viewportWidth}x${pageStats.viewportHeight} | docSize: ${pageStats.scrollWidth}x${pageStats.scrollHeight}\n\n`;
-    lines.push(statsLine);
-  }
-
   const ctx: SerializeContext = {
-    lines,
-    totalChars: lines.reduce((acc, l) => acc + l.length, 0),
+    lines: [],
+    totalChars: 0,
     truncated: false,
     maxOutputChars,
     maxDepth,
@@ -563,8 +566,16 @@ export async function serializeDOM(
     maxNodes: DEFAULT_MAX_SERIALIZER_NODES,
   };
 
+  // Add page stats header through the same bounded append path as DOM lines.
+  if (includePageStats) {
+    const statsLine = `[page_stats] url: ${pageStats.url} | title: ${pageStats.title} | scroll: ${pageStats.scrollX},${pageStats.scrollY} | viewport: ${pageStats.viewportWidth}x${pageStats.viewportHeight} | docSize: ${pageStats.scrollWidth}x${pageStats.scrollHeight}\n\n`;
+    appendBoundedLine(ctx, statsLine);
+  }
+
   // Serialize from root
-  serializeNode(root, 0, ctx);
+  if (!ctx.truncated) {
+    serializeNode(root, 0, ctx);
+  }
 
   const content = ctx.lines.join('');
 

--- a/tests/dom/dom-serializer.test.ts
+++ b/tests/dom/dom-serializer.test.ts
@@ -441,6 +441,22 @@ describe('DOM Serializer', () => {
     expect(result.content).toContain('[Output truncated at 500 chars. Use depth parameter to limit scope.]');
   });
 
+  test('bounds page_stats header with huge URL and title', async () => {
+    const page = createMockPageForDOM({
+      url: `https://example.com/${'u'.repeat(1000)}`,
+      title: 't'.repeat(1000),
+    });
+    const cdpClient = createMockCDPClientForDOM(simpleDoc);
+
+    const result = await serializeDOM(page as never, cdpClient as never, { maxOutputChars: 120 });
+
+    expect(result.truncated).toBe(true);
+    expect(result.content.length).toBeLessThanOrEqual(120);
+    expect(result.content).toBe('\n\n[Output truncated at 120 chars. Use depth parameter to limit scope.]');
+    expect(result.content).not.toContain('u'.repeat(100));
+    expect(result.content).not.toContain('t'.repeat(100));
+  });
+
   test('sets truncated to false when output fits', async () => {
     const page = createMockPageForDOM();
     const cdpClient = createMockCDPClientForDOM(simpleDoc);


### PR DESCRIPTION
## Summary
- Follow-up for merged PR #23 audit: enforce `maxOutputChars` across the generated `page_stats` header instead of allowing huge URL/title values to exceed the output budget.
- Keep the existing truncation marker behavior and add regression coverage for oversized page stats.

## Verification
- `git diff --check HEAD~1..HEAD`
- Combined branch verification previously passed: focused Jest for DOM serializer + CDP reconnect suites, `npm run build`, `npm run lint`, `npm run lint:tier`, and LSP diagnostics on changed source files.
- Split worktree focused Jest/build re-run was blocked by unrelated high-load stale npm/tsc/jest processes on the shared VM; this split commit is the DOM-only subset of the already-passing combined diff.
- Codex P1-only split review: `NO_P1_FINDINGS`.

Fixes follow-up audit item for #23.