### PR TITLE
feat(dashboard): task & skill ledger views (#865)

### DIFF
--- a/src/dashboard/index.ts
+++ b/src/dashboard/index.ts
@@ -14,6 +14,8 @@ import { MainView, MainViewData } from './views/main-view.js';
 import { SessionsView, SessionsViewData } from './views/sessions-view.js';
 import { TabsView, TabsViewData } from './views/tabs-view.js';
 import { ConnectView, ConnectViewData } from './views/connect-view.js';
+import { TasksView, type TasksViewData, readTasksSnapshot } from './views/tasks-view.js';
+import { SkillsView, type SkillsViewData, readSkillsSnapshot } from './views/skills-view.js';
 import type { ViewMode, DashboardStats, SessionInfo, TabInfo } from './types.js';
 import type { SessionManager } from '../session-manager.js';
 
@@ -34,6 +36,10 @@ export class Dashboard extends EventEmitter {
   private sessionsView: SessionsView;
   private tabsView: TabsView;
   private connectView: ConnectView;
+  private tasksView: TasksView;
+  private skillsView: SkillsView;
+  private tasksViewData: TasksViewData = { tasks: [], version: '1' };
+  private skillsViewData: SkillsViewData = { rows: [], version: '1' };
 
   private sessionManager: SessionManager | null = null;
   private config: DashboardOptions;
@@ -66,6 +72,8 @@ export class Dashboard extends EventEmitter {
     this.sessionsView = new SessionsView(this.renderer);
     this.tabsView = new TabsView(this.renderer);
     this.connectView = new ConnectView(this.renderer);
+    this.tasksView = new TasksView(this.renderer);
+    this.skillsView = new SkillsView(this.renderer);
   }
 
   /**
@@ -197,6 +205,8 @@ export class Dashboard extends EventEmitter {
       this.handleConnectViewKey(key, event);
     } else if (this.currentView === 'tabs') {
       this.handleTabsViewKey(key, event);
+    } else if (this.currentView === 'tasks' || this.currentView === 'skills') {
+      this.handleLedgerViewKey(key);
     }
 
     // Refresh after key handling
@@ -223,7 +233,45 @@ export class Dashboard extends EventEmitter {
       case 'c':
         this.cancelCurrentOperation();
         break;
+      case 'j':
+        // Tasks ledger view (#865). Refresh on entry so the first paint
+        // shows current data; subsequent ticks update via refreshLedgers.
+        this.currentView = 'tasks';
+        this.selectedIndex = 0;
+        void this.refreshLedgers();
+        break;
+      case 'k':
+        // Skills ledger view (#865).
+        this.currentView = 'skills';
+        this.selectedIndex = 0;
+        void this.refreshLedgers();
+        break;
     }
+  }
+
+  /**
+   * Ledger-view key handling (#865). `escape` returns to the activity
+   * (main) view. The ledger views are otherwise read-only.
+   */
+  private handleLedgerViewKey(key: string): void {
+    if (key === 'escape') {
+      this.currentView = 'activity';
+      this.selectedIndex = 0;
+    }
+  }
+
+  /**
+   * Refresh ledger view snapshots. Called when entering a ledger view
+   * and on regular dashboard ticks. Read-only; errors surface in the
+   * view's `errorMessage` field rather than throwing.
+   */
+  private async refreshLedgers(): Promise<void> {
+    if (this.currentView === 'tasks') {
+      this.tasksViewData = await readTasksSnapshot();
+    } else if (this.currentView === 'skills') {
+      this.skillsViewData = await readSkillsSnapshot();
+    }
+    this.refresh();
   }
 
   private handleSessionsViewKey(key: string, _event: KeyEvent): void {
@@ -328,6 +376,12 @@ export class Dashboard extends EventEmitter {
         break;
       case 'tabs':
         lines = this.tabsView.render(this.getTabsViewData(), size);
+        break;
+      case 'tasks':
+        lines = this.tasksView.render(this.tasksViewData, size);
+        break;
+      case 'skills':
+        lines = this.skillsView.render(this.skillsViewData, size);
         break;
     }
 

--- a/src/dashboard/index.ts
+++ b/src/dashboard/index.ts
@@ -239,13 +239,13 @@ export class Dashboard extends EventEmitter {
         // shows current data; subsequent ticks update via refreshLedgers.
         this.currentView = 'tasks';
         this.selectedIndex = 0;
-        void this.refreshLedgers();
+        this.scheduleLedgerRefresh();
         break;
       case 'k':
         // Skills ledger view (#865).
         this.currentView = 'skills';
         this.selectedIndex = 0;
-        void this.refreshLedgers();
+        this.scheduleLedgerRefresh();
         break;
     }
   }
@@ -287,10 +287,11 @@ export class Dashboard extends EventEmitter {
       return;
     }
 
-    if (this.ledgerRefreshInFlight) {
-      return;
-    }
+    this.scheduleLedgerRefresh();
+  }
 
+  private scheduleLedgerRefresh(): void {
+    if (this.ledgerRefreshInFlight) return;
     this.ledgerRefreshInFlight = this.refreshLedgers()
       .catch(() => {
         // refreshLedgers/readers are expected to convert IO failures into

--- a/src/dashboard/index.ts
+++ b/src/dashboard/index.ts
@@ -48,6 +48,7 @@ export class Dashboard extends EventEmitter {
   private currentView: ViewMode = 'activity';
   private selectedIndex: number = 0;
   private refreshTimer: NodeJS.Timeout | null = null;
+  private ledgerRefreshInFlight: Promise<void> | null = null;
   private spinnerFrame: number = 0;
   private startTime: number = Date.now();
   private isRunning: boolean = false;
@@ -139,7 +140,7 @@ export class Dashboard extends EventEmitter {
 
     // Start refresh timer
     this.refreshTimer = setInterval(() => {
-      this.refresh();
+      this.refreshTick();
     }, this.config.refreshInterval);
     this.refreshTimer.unref();
 
@@ -272,6 +273,32 @@ export class Dashboard extends EventEmitter {
       this.skillsViewData = await readSkillsSnapshot();
     }
     this.refresh();
+  }
+
+  /**
+   * Timer-driven refresh path. Ledger views re-read their backing snapshots on
+   * each dashboard tick so task status/skill rows stay live while the user
+   * remains on the read-only view. Guard async reads to avoid overlapping disk
+   * walks when the refresh interval is shorter than filesystem latency.
+   */
+  private refreshTick(): void {
+    if (this.currentView !== 'tasks' && this.currentView !== 'skills') {
+      this.refresh();
+      return;
+    }
+
+    if (this.ledgerRefreshInFlight) {
+      return;
+    }
+
+    this.ledgerRefreshInFlight = this.refreshLedgers()
+      .catch(() => {
+        // refreshLedgers/readers are expected to convert IO failures into
+        // view data, but keep the timer resilient if a future reader throws.
+      })
+      .finally(() => {
+        this.ledgerRefreshInFlight = null;
+      });
   }
 
   private handleSessionsViewKey(key: string, _event: KeyEvent): void {

--- a/src/dashboard/types.ts
+++ b/src/dashboard/types.ts
@@ -8,7 +8,7 @@ export interface DashboardConfig {
   maxLogEntries: number;    // default: 50
 }
 
-export type ViewMode = 'activity' | 'sessions' | 'tabs' | 'connect';
+export type ViewMode = 'activity' | 'sessions' | 'tabs' | 'connect' | 'tasks' | 'skills';
 
 export type ToolCallResult = 'success' | 'error' | 'aborted' | 'pending';
 

--- a/src/dashboard/views/skills-view.ts
+++ b/src/dashboard/views/skills-view.ts
@@ -1,0 +1,179 @@
+/**
+ * Skills View — read-only ANSI rendering of the skill memory store (#865).
+ *
+ * Walks `~/.openchrome/skill-memory/<encodedDomain>/skills.json` for all
+ * known domains and surfaces each skill row with its replay signal
+ * (from #856 if present). Strictly read-only.
+ */
+
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+import { ANSI, BOX, horizontalLine, pad, truncate } from '../ansi.js';
+import type { ScreenSize } from '../types.js';
+import { Renderer } from '../renderer.js';
+import { SkillMemoryStore } from '../../core/skill-memory/index.js';
+import type { SkillRecord } from '../../core/skill-memory/index.js';
+
+export interface SkillRow {
+  domain: string;
+  skill: SkillRecord;
+}
+
+export interface SkillsViewData {
+  rows: SkillRow[];
+  version: string;
+  errorMessage?: string;
+}
+
+function colorize(text: string, code: string | undefined): string {
+  if (!code) return text;
+  return code + text + ANSI.reset;
+}
+
+export class SkillsView {
+  private renderer: Renderer;
+
+  constructor(renderer: Renderer) {
+    this.renderer = renderer;
+  }
+
+  render(data: SkillsViewData, size: ScreenSize): string[] {
+    const lines: string[] = [];
+    const width = size.columns;
+
+    lines.push(this.renderer.header('Skill Ledger', width));
+    lines.push(this.renderColumnHeaders(width));
+    lines.push(BOX.teeRight + horizontalLine(width - 2) + BOX.teeLeft);
+
+    if (data.errorMessage) {
+      lines.push(this.renderer.contentLine(colorize(`error: ${data.errorMessage}`, ANSI.red), width));
+    } else if (data.rows.length === 0) {
+      lines.push(
+        this.renderer.contentLine(
+          colorize('(no skills recorded — write some via oc_skill_record)', ANSI.dim),
+          width,
+        ),
+      );
+    } else {
+      const visibleRows = Math.max(0, size.rows - 7);
+      for (const r of data.rows.slice(0, visibleRows)) {
+        lines.push(this.renderSkillRow(r, width));
+      }
+    }
+
+    while (lines.length < size.rows - 2) {
+      lines.push(this.renderer.emptyLine(width));
+    }
+
+    lines.push(BOX.teeRight + horizontalLine(width - 2) + BOX.teeLeft);
+    lines.push(
+      this.renderer.contentLine(colorize('esc: back  q: quit  (read-only view)', ANSI.dim), width),
+    );
+    lines.push(this.renderer.footer(width));
+    return lines;
+  }
+
+  private renderColumnHeaders(width: number): string {
+    const header = colorize(
+      pad('domain', 24) +
+        ' ' +
+        pad('name', 22) +
+        ' ' +
+        pad('used', 6) +
+        ' ' +
+        pad('replay', 8) +
+        ' ' +
+        'last_used',
+      ANSI.bold,
+    );
+    return this.renderer.contentLine(header, width);
+  }
+
+  private renderSkillRow(r: SkillRow, width: number): string {
+    const replay = computeReplayBadge(r.skill);
+    const lastUsed =
+      r.skill.lastUsedAt > 0 ? formatRelative(Date.now() - r.skill.lastUsedAt) : '—';
+    const row =
+      pad(truncate(r.domain, 24), 24) +
+      ' ' +
+      pad(truncate(r.skill.name, 22), 22) +
+      ' ' +
+      pad(String(r.skill.successCount), 6) +
+      ' ' +
+      pad(replay, 8) +
+      ' ' +
+      lastUsed;
+    return this.renderer.contentLine(row, width);
+  }
+}
+
+/**
+ * Read the optional replay-outcome timestamps without assuming the fields
+ * exist on the SkillRecord type. The replay path (#856) adds these fields
+ * but lands as a separate PR — when this PR is stacked on A (#855) only,
+ * the fields are not yet on the type. Once #856 is in develop, the cast
+ * becomes redundant and can be removed.
+ */
+function computeReplayBadge(s: SkillRecord): string {
+  const replay = s as SkillRecord & {
+    lastReplayPassedAt?: number;
+    lastReplayFailedAt?: number;
+  };
+  const passed = replay.lastReplayPassedAt ?? 0;
+  const failed = replay.lastReplayFailedAt ?? 0;
+  if (passed === 0 && failed === 0) return colorize('—', ANSI.dim);
+  if (passed > failed) return colorize('PASS', ANSI.green);
+  if (failed > passed) return colorize('FAIL', ANSI.red);
+  return colorize('—', ANSI.dim);
+}
+
+function formatRelative(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '—';
+  if (ms < 60000) return `${Math.floor(ms / 1000)}s ago`;
+  if (ms < 3600000) return `${Math.floor(ms / 60000)}m ago`;
+  if (ms < 86400000) return `${Math.floor(ms / 3600000)}h ago`;
+  return `${Math.floor(ms / 86400000)}d ago`;
+}
+
+/**
+ * Walk the default skill-memory rootDir and return a flat skill row
+ * list. Read-only; any IO error is captured in `errorMessage` rather
+ * than thrown.
+ */
+export async function readSkillsSnapshot(): Promise<SkillsViewData> {
+  const root = join(homedir(), '.openchrome', 'skill-memory');
+  try {
+    let entries: import('node:fs').Dirent[];
+    try {
+      entries = await fs.readdir(root, { withFileTypes: true });
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { rows: [], version: '1' };
+      }
+      throw e;
+    }
+
+    const rows: SkillRow[] = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const encodedDomain = entry.name;
+      const domain = encodedDomain;
+      try {
+        const store = new SkillMemoryStore({ domain });
+        for (const skill of store.list({})) {
+          rows.push({ domain, skill });
+        }
+      } catch {
+        // Skip malformed domain dirs; the view stays best-effort.
+      }
+    }
+
+    rows.sort((a, b) => b.skill.lastUsedAt - a.skill.lastUsedAt);
+    return { rows, version: '1' };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { rows: [], version: '1', errorMessage: msg };
+  }
+}

--- a/src/dashboard/views/skills-view.ts
+++ b/src/dashboard/views/skills-view.ts
@@ -158,8 +158,11 @@ export async function readSkillsSnapshot(): Promise<SkillsViewData> {
     const rows: SkillRow[] = [];
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
-      const encodedDomain = entry.name;
-      const domain = encodedDomain;
+      // entry.name is the filesystem-encoded directory basename produced by
+      // encodeDomain() inside SkillMemoryStore. Decode it back to the raw
+      // domain string before constructing the store, which re-encodes
+      // internally — passing an already-encoded name would double-encode it.
+      const domain = decodeURIComponent(entry.name);
       try {
         const store = new SkillMemoryStore({ domain });
         for (const skill of store.list({})) {

--- a/src/dashboard/views/tasks-view.ts
+++ b/src/dashboard/views/tasks-view.ts
@@ -1,0 +1,144 @@
+/**
+ * Tasks View — read-only ANSI rendering of the task ledger (#865).
+ *
+ * Surfaces the ledger backing `oc_task_*` (#855) inside the terminal
+ * dashboard. The view is strictly read-only: it never mutates the
+ * ledger files. Refresh cadence matches the rest of the dashboard's
+ * 1–2s tick.
+ */
+
+import { ANSI, BOX, horizontalLine, pad, truncate } from '../ansi.js';
+import type { ScreenSize } from '../types.js';
+import { Renderer } from '../renderer.js';
+import { TaskStore, defaultTaskRootDir } from '../../core/task-ledger/index.js';
+import type { TaskMeta, TaskStatus } from '../../core/task-ledger/index.js';
+
+export interface TasksViewData {
+  tasks: TaskMeta[];
+  version: string;
+  /** Last error encountered while reading the ledger, if any. */
+  errorMessage?: string;
+}
+
+const STATUS_COLORS: Record<TaskStatus, string> = {
+  PENDING: ANSI.dim,
+  RUNNING: ANSI.cyan,
+  COMPLETED: ANSI.green,
+  FAILED: ANSI.red,
+  CANCELLED: ANSI.yellow,
+};
+
+function colorize(text: string, code: string | undefined): string {
+  if (!code) return text;
+  return code + text + ANSI.reset;
+}
+
+export class TasksView {
+  private renderer: Renderer;
+
+  constructor(renderer: Renderer) {
+    this.renderer = renderer;
+  }
+
+  render(data: TasksViewData, size: ScreenSize): string[] {
+    const lines: string[] = [];
+    const width = size.columns;
+
+    lines.push(this.renderer.header('Task Ledger', width));
+    lines.push(this.renderColumnHeaders(width));
+    lines.push(BOX.teeRight + horizontalLine(width - 2) + BOX.teeLeft);
+
+    if (data.errorMessage) {
+      lines.push(this.renderer.contentLine(colorize(`error: ${data.errorMessage}`, ANSI.red), width));
+    } else if (data.tasks.length === 0) {
+      lines.push(
+        this.renderer.contentLine(
+          colorize('(no tasks recorded — kick one off via oc_task_start)', ANSI.dim),
+          width,
+        ),
+      );
+    } else {
+      const visibleRows = Math.max(0, size.rows - 7);
+      for (const t of data.tasks.slice(0, visibleRows)) {
+        lines.push(this.renderTaskRow(t, width));
+      }
+    }
+
+    while (lines.length < size.rows - 2) {
+      lines.push(this.renderer.emptyLine(width));
+    }
+
+    lines.push(BOX.teeRight + horizontalLine(width - 2) + BOX.teeLeft);
+    lines.push(
+      this.renderer.contentLine(colorize('esc: back  q: quit  (read-only view)', ANSI.dim), width),
+    );
+    lines.push(this.renderer.footer(width));
+    return lines;
+  }
+
+  private renderColumnHeaders(width: number): string {
+    const header = colorize(
+      pad('task_id', 10) +
+        ' ' +
+        pad('kind', 22) +
+        ' ' +
+        pad('status', 10) +
+        ' ' +
+        pad('age', 10) +
+        ' ' +
+        'duration_ms',
+      ANSI.bold,
+    );
+    return this.renderer.contentLine(header, width);
+  }
+
+  private renderTaskRow(t: TaskMeta, width: number): string {
+    const shortId = t.task_id.slice(0, 8);
+    const startedAt = t.started_at ?? 0;
+    const endedAt = t.ended_at ?? null;
+    const ageMs = startedAt > 0 ? Date.now() - startedAt : -1;
+    const ageStr = formatAge(ageMs);
+    const durStr =
+      endedAt !== null && startedAt > 0 ? String(Math.max(0, endedAt - startedAt)) : '—';
+    const row =
+      pad(shortId, 10) +
+      ' ' +
+      pad(truncate(t.kind, 22), 22) +
+      ' ' +
+      colorize(pad(t.status, 10), STATUS_COLORS[t.status]) +
+      ' ' +
+      pad(ageStr, 10) +
+      ' ' +
+      durStr;
+    return this.renderer.contentLine(row, width);
+  }
+}
+
+function formatAge(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '—';
+  if (ms < 1000) return `${ms}ms`;
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  return `${h}h`;
+}
+
+/**
+ * Snapshot reader for the dashboard tick. Reads the default task root
+ * (`~/.openchrome/tasks/` or `OPENCHROME_TASK_ROOT`) and returns up to
+ * `limit` most-recently-started tasks. Read-only; any IO error is
+ * captured in `errorMessage` rather than thrown.
+ */
+export async function readTasksSnapshot(limit = 200): Promise<TasksViewData> {
+  try {
+    const store = new TaskStore({ rootDir: defaultTaskRootDir() });
+    const tasks = await store.list({ limit });
+    tasks.sort((a, b) => (b.started_at ?? 0) - (a.started_at ?? 0));
+    return { tasks, version: '1' };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { tasks: [], version: '1', errorMessage: msg };
+  }
+}

--- a/src/dashboard/views/tasks-view.ts
+++ b/src/dashboard/views/tasks-view.ts
@@ -12,12 +12,43 @@ import type { ScreenSize } from '../types.js';
 import { Renderer } from '../renderer.js';
 import { TaskStore, defaultTaskRootDir } from '../../core/task-ledger/index.js';
 import type { TaskMeta, TaskStatus } from '../../core/task-ledger/index.js';
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 
 export interface TasksViewData {
   tasks: TaskMeta[];
   version: string;
+  recovery?: RecoveryViewData;
   /** Last error encountered while reading the ledger, if any. */
   errorMessage?: string;
+}
+
+export interface RecoveryViewData {
+  taskRuns: TaskRunRecovery[];
+  handoffs: HandoffRecovery[];
+  errorMessage?: string;
+}
+
+export interface TaskRunRecovery {
+  run_id: string;
+  status: string;
+  reason?: string;
+  requested_at?: number;
+  resume_hint?: string;
+  current_cursor?: string;
+  last_checkpoint?: string;
+  evidence?: Array<{ kind: string; ref: string; summary?: string }>;
+}
+
+export interface HandoffRecovery {
+  handoff_id: string;
+  status: string;
+  reason?: string;
+  run_id?: string;
+  expires_at?: number;
+  before_url?: string;
+  before_title?: string;
 }
 
 const STATUS_COLORS: Record<TaskStatus, string> = {
@@ -26,6 +57,11 @@ const STATUS_COLORS: Record<TaskStatus, string> = {
   COMPLETED: ANSI.green,
   FAILED: ANSI.red,
   CANCELLED: ANSI.yellow,
+};
+
+const RECOVERY_STATUS_COLORS: Record<string, string> = {
+  NEEDS_HELP: ANSI.brightYellow,
+  ACTIVE: ANSI.brightMagenta,
 };
 
 function colorize(text: string, code: string | undefined): string {
@@ -58,13 +94,15 @@ export class TasksView {
         ),
       );
     } else {
-      const visibleRows = Math.max(0, size.rows - 7);
+      const recoveryLines = this.renderRecovery(data.recovery, width);
+      const visibleRows = Math.max(0, size.rows - 7 - recoveryLines.length);
       for (const t of data.tasks.slice(0, visibleRows)) {
         lines.push(this.renderTaskRow(t, width));
       }
+      lines.push(...recoveryLines);
     }
 
-    while (lines.length < size.rows - 2) {
+    while (lines.length < size.rows - 3) {
       lines.push(this.renderer.emptyLine(width));
     }
 
@@ -73,6 +111,51 @@ export class TasksView {
       this.renderer.contentLine(colorize('esc: back  q: quit  (read-only view)', ANSI.dim), width),
     );
     lines.push(this.renderer.footer(width));
+    return lines;
+  }
+
+  private renderRecovery(recovery: RecoveryViewData | undefined, width: number): string[] {
+    if (!recovery) return [];
+    const lines: string[] = [];
+    if (recovery.errorMessage) {
+      lines.push(BOX.teeRight + horizontalLine(width - 2) + BOX.teeLeft);
+      lines.push(this.renderer.contentLine(colorize(`recovery metadata unavailable: ${recovery.errorMessage}`, ANSI.dim), width));
+      return lines;
+    }
+    const needsHelp = recovery.taskRuns.filter(run => run.status === 'NEEDS_HELP');
+    const activeHandoffs = recovery.handoffs.filter(handoff => handoff.status === 'ACTIVE');
+    if (needsHelp.length === 0 && activeHandoffs.length === 0) return [];
+
+    lines.push(BOX.teeRight + horizontalLine(width - 2) + BOX.teeLeft);
+    lines.push(this.renderer.contentLine(colorize('Recovery / Human Help', ANSI.bold), width));
+    for (const run of needsHelp.slice(0, 3)) {
+      const status = colorize('NEEDS_HELP', RECOVERY_STATUS_COLORS.NEEDS_HELP);
+      lines.push(this.renderer.contentLine(
+        truncate(`${status} run=${run.run_id.slice(0, 8)} reason=${run.reason || '—'}`, width - 4),
+        width,
+      ));
+      lines.push(this.renderer.contentLine(
+        truncate(`  cursor=${run.current_cursor || '—'} resume=${run.resume_hint || '—'}`, width - 4),
+        width,
+      ));
+      const evidence = (run.evidence || []).slice(0, 3).map(item => `${item.kind}:${item.ref}`).join(', ') || '—';
+      lines.push(this.renderer.contentLine(
+        truncate(`  checkpoint=${run.last_checkpoint || '—'} evidence=${evidence}`, width - 4),
+        width,
+      ));
+    }
+    for (const handoff of activeHandoffs.slice(0, 3)) {
+      const remaining = handoff.expires_at ? formatAge(Math.max(0, handoff.expires_at - Date.now())) : '—';
+      const status = colorize('ACTIVE', RECOVERY_STATUS_COLORS.ACTIVE);
+      lines.push(this.renderer.contentLine(
+        truncate(`${status} handoff=${handoff.handoff_id.slice(0, 8)} run=${handoff.run_id?.slice(0, 8) || '—'} timeout=${remaining}`, width - 4),
+        width,
+      ));
+      lines.push(this.renderer.contentLine(
+        truncate(`  reason=${handoff.reason || '—'} before=${handoff.before_url || handoff.before_title || '—'}`, width - 4),
+        width,
+      ));
+    }
     return lines;
   }
 
@@ -136,9 +219,95 @@ export async function readTasksSnapshot(limit = 200): Promise<TasksViewData> {
     const store = new TaskStore({ rootDir: defaultTaskRootDir() });
     const tasks = await store.list({ limit });
     tasks.sort((a, b) => (b.started_at ?? 0) - (a.started_at ?? 0));
-    return { tasks, version: '1' };
+    const recovery = await readRecoverySnapshot();
+    return { tasks, version: '1', recovery };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return { tasks: [], version: '1', errorMessage: msg };
+  }
+}
+
+export async function readRecoverySnapshot(limit = 50): Promise<RecoveryViewData> {
+  try {
+    const home = process.env.OPENCHROME_HOME || join(homedir(), '.openchrome');
+    const taskRuns = await readTaskRuns(join(home, 'task-runs'), limit);
+    const handoffs = await readHandoffs(join(home, 'handoffs'), limit);
+    return { taskRuns, handoffs };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { taskRuns: [], handoffs: [], errorMessage: msg };
+  }
+}
+
+async function readTaskRuns(root: string, limit: number): Promise<TaskRunRecovery[]> {
+  const entries = await readdirSafe(root);
+  const rows: TaskRunRecovery[] = [];
+  for (const entry of entries.slice(0, limit)) {
+    const meta = await readJsonSafe<Record<string, unknown>>(join(root, entry, 'meta.json'));
+    if (!meta) continue;
+    const needsHelp = meta.needs_help as Record<string, unknown> | undefined;
+    rows.push({
+      run_id: String(meta.run_id || entry),
+      status: String(meta.status || 'UNKNOWN'),
+      reason: typeof needsHelp?.reason === 'string' ? needsHelp.reason : undefined,
+      requested_at: typeof needsHelp?.requested_at === 'number' ? needsHelp.requested_at : undefined,
+      resume_hint: typeof needsHelp?.resume_hint === 'string' ? needsHelp.resume_hint : undefined,
+      current_cursor: typeof meta.current_cursor === 'string' ? meta.current_cursor : undefined,
+      last_checkpoint: await readLatestCheckpointId(join(root, entry, 'checkpoints')),
+      evidence: Array.isArray(meta.last_evidence) ? meta.last_evidence as TaskRunRecovery['evidence'] : undefined,
+    });
+  }
+  return rows.sort((a, b) => (b.requested_at || 0) - (a.requested_at || 0));
+}
+
+async function readHandoffs(root: string, limit: number): Promise<HandoffRecovery[]> {
+  const entries = await readdirSafe(root);
+  const rows: HandoffRecovery[] = [];
+  for (const entry of entries.slice(0, limit)) {
+    const meta = await readJsonSafe<Record<string, unknown>>(join(root, entry, 'meta.json'));
+    if (!meta) continue;
+    const before = meta.before as Record<string, unknown> | undefined;
+    rows.push({
+      handoff_id: String(meta.handoff_id || entry),
+      status: String(meta.status || 'UNKNOWN'),
+      reason: typeof meta.reason === 'string' ? meta.reason : undefined,
+      run_id: typeof meta.run_id === 'string' ? meta.run_id : undefined,
+      expires_at: typeof meta.expires_at === 'number' ? meta.expires_at : undefined,
+      before_url: typeof before?.url === 'string' ? before.url : undefined,
+      before_title: typeof before?.title === 'string' ? before.title : undefined,
+    });
+  }
+  return rows.sort((a, b) => (b.expires_at || 0) - (a.expires_at || 0));
+}
+
+async function readLatestCheckpointId(root: string): Promise<string | undefined> {
+  const entries = await readdirSafe(root);
+  const checkpoints: Array<{ id: string; created_at: number }> = [];
+  for (const entry of entries.filter(name => name.endsWith('.json'))) {
+    const json = await readJsonSafe<Record<string, unknown>>(join(root, entry));
+    if (!json) continue;
+    checkpoints.push({
+      id: String(json.checkpoint_id || entry.replace(/\.json$/, '')),
+      created_at: typeof json.created_at === 'number' ? json.created_at : 0,
+    });
+  }
+  checkpoints.sort((a, b) => b.created_at - a.created_at);
+  return checkpoints[0]?.id;
+}
+
+async function readdirSafe(root: string): Promise<string[]> {
+  try {
+    const entries = await fs.readdir(root, { withFileTypes: true });
+    return entries.filter(entry => entry.isDirectory() || entry.isFile()).map(entry => entry.name);
+  } catch {
+    return [];
+  }
+}
+
+async function readJsonSafe<T>(file: string): Promise<T | undefined> {
+  try {
+    return JSON.parse(await fs.readFile(file, 'utf8')) as T;
+  } catch {
+    return undefined;
   }
 }

--- a/tests/dashboard/views/ledger-views.test.ts
+++ b/tests/dashboard/views/ledger-views.test.ts
@@ -15,6 +15,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { Renderer } from '../../../src/dashboard/renderer.js';
+import { Dashboard } from '../../../src/dashboard/index.js';
 import { TasksView, type TasksViewData } from '../../../src/dashboard/views/tasks-view.js';
 import { SkillsView, type SkillsViewData } from '../../../src/dashboard/views/skills-view.js';
 import type { TaskMeta } from '../../../src/core/task-ledger/index.js';
@@ -150,5 +151,52 @@ describe('snapshot readers — read-only behavior', () => {
       process.env.HOME = prev;
       await fs.rm(fakeHome, { recursive: true, force: true });
     }
+  });
+});
+
+describe('Dashboard ledger refresh ticks', () => {
+  test('timer path refreshes ledgers while staying on tasks or skills view', async () => {
+    const dashboard = new Dashboard({ enabled: false }) as unknown as {
+      currentView: string;
+      refreshTick: () => void;
+      refreshLedgers: jest.Mock<Promise<void>, []>;
+      refresh: jest.Mock<void, []>;
+    };
+    dashboard.refreshLedgers = jest.fn().mockResolvedValue(undefined);
+    dashboard.refresh = jest.fn();
+
+    dashboard.currentView = 'tasks';
+    dashboard.refreshTick();
+    await dashboard.refreshLedgers.mock.results[0].value;
+    expect(dashboard.refreshLedgers).toHaveBeenCalledTimes(1);
+    expect(dashboard.refresh).not.toHaveBeenCalled();
+
+    dashboard.currentView = 'activity';
+    dashboard.refreshTick();
+    expect(dashboard.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  test('timer path avoids overlapping ledger snapshot reads', async () => {
+    let resolveRefresh!: () => void;
+    const dashboard = new Dashboard({ enabled: false }) as unknown as {
+      currentView: string;
+      refreshTick: () => void;
+      refreshLedgers: jest.Mock<Promise<void>, []>;
+    };
+    dashboard.currentView = 'skills';
+    dashboard.refreshLedgers = jest.fn(() => new Promise<void>((resolve) => {
+      resolveRefresh = resolve;
+    }));
+
+    dashboard.refreshTick();
+    dashboard.refreshTick();
+    expect(dashboard.refreshLedgers).toHaveBeenCalledTimes(1);
+
+    resolveRefresh();
+    await dashboard.refreshLedgers.mock.results[0].value;
+    await Promise.resolve();
+
+    dashboard.refreshTick();
+    expect(dashboard.refreshLedgers).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/dashboard/views/ledger-views.test.ts
+++ b/tests/dashboard/views/ledger-views.test.ts
@@ -15,7 +15,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { Renderer } from '../../../src/dashboard/renderer.js';
-import { TasksView, type TasksViewData } from '../../../src/dashboard/views/tasks-view.js';
+import { TasksView, readRecoverySnapshot, type TasksViewData } from '../../../src/dashboard/views/tasks-view.js';
 import { SkillsView, type SkillsViewData } from '../../../src/dashboard/views/skills-view.js';
 import type { TaskMeta } from '../../../src/core/task-ledger/index.js';
 import type { SkillRecord } from '../../../src/core/skill-memory/index.js';
@@ -94,6 +94,68 @@ describe('TasksView', () => {
     );
     expect(lines.join('\n')).toMatch(/permission denied/);
   });
+
+  test('renders NEEDS_HELP and active handoff recovery details read-only', () => {
+    const renderer = new Renderer();
+    const view = new TasksView(renderer);
+    const data: TasksViewData = {
+      version: '1',
+      tasks: [mkTaskMeta({ task_id: 'r'.repeat(16), status: 'RUNNING' })],
+      recovery: {
+        taskRuns: [{
+          run_id: '1'.repeat(16),
+          status: 'NEEDS_HELP',
+          reason: 'Manual login required before continuing',
+          requested_at: Date.now(),
+          resume_hint: 'Continue after login',
+          current_cursor: 'https://the-internet.herokuapp.com/login',
+          last_checkpoint: 'c'.repeat(16),
+          evidence: [{ kind: 'url', ref: 'https://the-internet.herokuapp.com/login' }],
+        }],
+        handoffs: [{
+          handoff_id: 'h'.repeat(16),
+          status: 'ACTIVE',
+          reason: 'Manual login required before continuing',
+          run_id: '1'.repeat(16),
+          expires_at: Date.now() + 10_000,
+          before_url: 'https://the-internet.herokuapp.com/login',
+          before_title: 'Login Page',
+        }],
+      },
+    };
+    const joined = view.render(data, SIZE).join('\n');
+    expect(joined).toMatch(/Recovery \/ Human Help/);
+    expect(joined).toMatch(/NEEDS_HELP/);
+    expect(joined).toMatch(/Manual login required/);
+    expect(joined).toMatch(/Continue after login/);
+    expect(joined).toMatch(/ACTIVE/);
+    expect(joined).toMatch(/handoff=hhhhhhhh/);
+  });
+
+  test.each([
+    { rows: 24, columns: 80 },
+    { rows: 40, columns: 120 },
+    { rows: 60, columns: 200 },
+  ])('recovery pane renders within terminal size %o', (size) => {
+    const renderer = new Renderer();
+    const view = new TasksView(renderer);
+    const lines = view.render({
+      version: '1',
+      tasks: [mkTaskMeta({ task_id: 'r'.repeat(16), status: 'RUNNING' })],
+      recovery: {
+        taskRuns: [{
+          run_id: '1'.repeat(16),
+          status: 'NEEDS_HELP',
+          reason: 'Manual login required before continuing',
+          current_cursor: 'https://example.com/login',
+          resume_hint: 'resume',
+        }],
+        handoffs: [],
+      },
+    }, size);
+    expect(lines.length).toBe(size.rows);
+    expect(lines.join('\n')).toMatch(/NEEDS_HELP/);
+  });
 });
 
 describe('SkillsView', () => {
@@ -151,4 +213,65 @@ describe('snapshot readers — read-only behavior', () => {
       await fs.rm(fakeHome, { recursive: true, force: true });
     }
   });
+
+  test('readRecoverySnapshot reads TaskRun and handoff metadata without mutating files', async () => {
+    const fakeHome = await mkdtemp(join(tmpdir(), 'oc-recovery-home-'));
+    const prev = process.env.OPENCHROME_HOME;
+    process.env.OPENCHROME_HOME = fakeHome;
+    try {
+      const runDir = join(fakeHome, 'task-runs', '1'.repeat(16));
+      const handoffDir = join(fakeHome, 'handoffs', 'h'.repeat(16));
+      const checkpointDir = join(runDir, 'checkpoints');
+      await fs.mkdir(checkpointDir, { recursive: true });
+      await fs.mkdir(handoffDir, { recursive: true });
+      await fs.writeFile(join(runDir, 'meta.json'), JSON.stringify({
+        run_id: '1'.repeat(16),
+        status: 'NEEDS_HELP',
+        current_cursor: 'https://example.com/login',
+        needs_help: {
+          reason: 'Manual login required',
+          requested_at: 1_700_000_000_000,
+          resume_hint: 'Continue after login',
+        },
+        last_evidence: [{ kind: 'url', ref: 'https://example.com/login' }],
+      }));
+      await fs.writeFile(join(checkpointDir, 'c.json'), JSON.stringify({
+        checkpoint_id: 'c'.repeat(16),
+        created_at: 1_700_000_000_001,
+      }));
+      await fs.writeFile(join(handoffDir, 'meta.json'), JSON.stringify({
+        handoff_id: 'h'.repeat(16),
+        status: 'ACTIVE',
+        reason: 'Manual login required',
+        run_id: '1'.repeat(16),
+        expires_at: 1_700_000_010_000,
+        before: { url: 'https://example.com/login', title: 'Login' },
+      }));
+      const before = JSON.stringify(await tree(fakeHome));
+      for (let i = 0; i < 3; i++) {
+        const snapshot = await readRecoverySnapshot();
+        expect(snapshot.taskRuns[0].status).toBe('NEEDS_HELP');
+        expect(snapshot.taskRuns[0].last_checkpoint).toBe('c'.repeat(16));
+        expect(snapshot.handoffs[0].status).toBe('ACTIVE');
+      }
+      expect(JSON.stringify(await tree(fakeHome))).toBe(before);
+    } finally {
+      process.env.OPENCHROME_HOME = prev;
+      await fs.rm(fakeHome, { recursive: true, force: true });
+    }
+  });
 });
+
+async function tree(root: string): Promise<string[]> {
+  const out: string[] = [];
+  async function walk(dir: string): Promise<void> {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      out.push(full.replace(root, ''));
+      if (entry.isDirectory()) await walk(full);
+    }
+  }
+  await walk(root);
+  return out.sort();
+}

--- a/tests/dashboard/views/ledger-views.test.ts
+++ b/tests/dashboard/views/ledger-views.test.ts
@@ -199,4 +199,29 @@ describe('Dashboard ledger refresh ticks', () => {
     dashboard.refreshTick();
     expect(dashboard.refreshLedgers).toHaveBeenCalledTimes(2);
   });
+
+  test('entry refresh and timer refresh share one in-flight guard', async () => {
+    let resolveRefresh!: () => void;
+    const dashboard = new Dashboard({ enabled: false }) as unknown as {
+      currentView: string;
+      handleMainViewKey: (key: string) => void;
+      refreshTick: () => void;
+      refreshLedgers: jest.Mock<Promise<void>, []>;
+    };
+    dashboard.currentView = 'activity';
+    dashboard.refreshLedgers = jest.fn(() => new Promise<void>((resolve) => {
+      resolveRefresh = resolve;
+    }));
+
+    dashboard.handleMainViewKey('j');
+    dashboard.refreshTick();
+    expect(dashboard.refreshLedgers).toHaveBeenCalledTimes(1);
+
+    resolveRefresh();
+    await dashboard.refreshLedgers.mock.results[0].value;
+    await Promise.resolve();
+
+    dashboard.refreshTick();
+    expect(dashboard.refreshLedgers).toHaveBeenCalledTimes(2);
+  });
 });

--- a/tests/dashboard/views/ledger-views.test.ts
+++ b/tests/dashboard/views/ledger-views.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Smoke tests for the read-only ledger views (#865).
+ *
+ * Verify that:
+ *   - TasksView and SkillsView render without throwing on representative
+ *     fixture data,
+ *   - their snapshot readers degrade gracefully when the backing
+ *     directories are absent (no crash, error captured in viewdata),
+ *   - readers do NOT mutate the on-disk state (no files added/removed).
+ */
+
+import { promises as fs } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Renderer } from '../../../src/dashboard/renderer.js';
+import { TasksView, type TasksViewData } from '../../../src/dashboard/views/tasks-view.js';
+import { SkillsView, type SkillsViewData } from '../../../src/dashboard/views/skills-view.js';
+import type { TaskMeta } from '../../../src/core/task-ledger/index.js';
+import type { SkillRecord } from '../../../src/core/skill-memory/index.js';
+
+const SIZE = { rows: 30, columns: 100 };
+
+function mkTaskMeta(over: Partial<TaskMeta>): TaskMeta {
+  return {
+    task_id: 'a'.repeat(16),
+    kind: 'crawl',
+    args_summary: '{}',
+    status: 'RUNNING',
+    started_at: Date.now() - 1500,
+    ended_at: null,
+    pid: process.pid,
+    last_event_at: Date.now(),
+    error_code: null,
+    error_message: null,
+    ...over,
+  } as TaskMeta;
+}
+
+function mkSkill(over: Partial<SkillRecord>): SkillRecord {
+  return {
+    skillId: 'b'.repeat(16),
+    domain: 'example.com',
+    name: 'login',
+    steps: [],
+    contractId: 'noop',
+    successCount: 3,
+    lastUsedAt: Date.now() - 60_000,
+    frozenSnapshotPath: null,
+    ...over,
+  } as SkillRecord;
+}
+
+describe('TasksView', () => {
+  test('renders header + rows for a mixed-status ledger', () => {
+    const renderer = new Renderer();
+    const view = new TasksView(renderer);
+    const data: TasksViewData = {
+      version: '1',
+      tasks: [
+        mkTaskMeta({ task_id: 'r'.repeat(16), status: 'RUNNING' }),
+        mkTaskMeta({
+          task_id: 'c'.repeat(16),
+          status: 'COMPLETED',
+          ended_at: Date.now(),
+        }),
+        mkTaskMeta({ task_id: 'x'.repeat(16), status: 'CANCELLED' }),
+      ],
+    };
+    const lines = view.render(data, SIZE);
+    expect(Array.isArray(lines)).toBe(true);
+    expect(lines.length).toBeGreaterThan(5);
+    const joined = lines.join('\n');
+    expect(joined).toMatch(/Task Ledger/);
+    expect(joined).toMatch(/RUNNING/);
+    expect(joined).toMatch(/COMPLETED/);
+    expect(joined).toMatch(/CANCELLED/);
+  });
+
+  test('renders the empty-state hint when no tasks exist', () => {
+    const renderer = new Renderer();
+    const view = new TasksView(renderer);
+    const lines = view.render({ version: '1', tasks: [] }, SIZE);
+    expect(lines.join('\n')).toMatch(/no tasks recorded/);
+  });
+
+  test('renders the error message when the snapshot reader failed', () => {
+    const renderer = new Renderer();
+    const view = new TasksView(renderer);
+    const lines = view.render(
+      { version: '1', tasks: [], errorMessage: 'permission denied' },
+      SIZE,
+    );
+    expect(lines.join('\n')).toMatch(/permission denied/);
+  });
+});
+
+describe('SkillsView', () => {
+  test('renders rows with replay badges', () => {
+    const renderer = new Renderer();
+    const view = new SkillsView(renderer);
+    const data: SkillsViewData = {
+      version: '1',
+      rows: [
+        {
+          domain: 'app.example.com',
+          skill: { ...mkSkill({ name: 'happy-login' }), lastReplayPassedAt: Date.now() } as SkillRecord,
+        },
+        {
+          domain: 'app.example.com',
+          skill: { ...mkSkill({ name: 'tampered' }), lastReplayFailedAt: Date.now() } as SkillRecord,
+        },
+        { domain: 'never-replayed.example.com', skill: mkSkill({ name: 'pristine' }) },
+      ],
+    };
+    const lines = view.render(data, SIZE);
+    const joined = lines.join('\n');
+    expect(joined).toMatch(/Skill Ledger/);
+    expect(joined).toMatch(/PASS/);
+    expect(joined).toMatch(/FAIL/);
+    expect(joined).toMatch(/happy-login/);
+    expect(joined).toMatch(/tampered/);
+  });
+
+  test('empty-state when no rows', () => {
+    const renderer = new Renderer();
+    const view = new SkillsView(renderer);
+    const lines = view.render({ version: '1', rows: [] }, SIZE);
+    expect(lines.join('\n')).toMatch(/no skills recorded/);
+  });
+});
+
+describe('snapshot readers — read-only behavior', () => {
+  test('readSkillsSnapshot tolerates a missing skill-memory directory', async () => {
+    // Point HOME at a clean tmp dir so the reader walks an empty tree.
+    const fakeHome = await mkdtemp(join(tmpdir(), 'oc-views-home-'));
+    const prev = process.env.HOME;
+    process.env.HOME = fakeHome;
+    try {
+      const { readSkillsSnapshot } = await import(
+        '../../../src/dashboard/views/skills-view.js'
+      );
+      const out = await readSkillsSnapshot();
+      expect(out.rows).toEqual([]);
+      // No state file should have been created by the reader.
+      const dirAfter = await fs.readdir(fakeHome);
+      expect(dirAfter).toEqual([]);
+    } finally {
+      process.env.HOME = prev;
+      await fs.rm(fakeHome, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Progress / Review status

_Auto-refreshed 2026-05-13 — owner comments cleaned up to reduce review noise._

| Field | Value |
| --- | --- |
| Branch | `feat/865-dashboard-ledger-views` → `feat/855-task-ledger` |
| Draft | no |
| CI | — |
| Mergeable | ✅ MERGEABLE |
| Review decision | — |
| Codex (latest) | 💡 suggestions posted |
| Other reviewers (latest) | chatgpt-codex-connector: commented |
| Head | `bb73160` — fix(dashboard): decode skill domain before constructing store |
| Commits | 4 |

<sub>Owner comment cleanup: 1 issue + 0 inline review comments deleted. Outstanding feedback from automated/external reviewers above is unchanged.</sub>
<!-- progress-status:end -->
---

## Summary

Adds two read-only ANSI views to the existing terminal dashboard. Stacked on top of [#911](https://github.com/shaun0927/openchrome/pull/911) (task ledger). PR base is `feat/855-task-ledger` so the diff shows only F's lines; once #911 merges to `develop` this branch can be re-targeted at `develop` (or fast-forwarded by GitHub).

## What's in this PR

- **TasksView** (`src/dashboard/views/tasks-view.ts`) — surfaces the task ledger from #855. Reads `~/.openchrome/tasks/` (honors `OPENCHROME_TASK_ROOT`). Renders `task_id`, `kind`, `status`, `age`, `duration_ms`. Status colour-coded.
- **SkillsView** (`src/dashboard/views/skills-view.ts`) — walks `~/.openchrome/skill-memory/<domain>/skills.json` across all known domains. Renders domain, name, use count, replay badge (PASS/FAIL/—), relative last-used timestamp. **Replay-badge fields are read defensively** so the PR builds on A alone; the cast becomes redundant once #856 (B) is in develop.
- **Wiring** (`src/dashboard/index.ts`, `src/dashboard/types.ts`):
  - `ViewMode` extended with `'tasks' | 'skills'`.
  - Main-view keys: `j` → tasks, `k` → skills. (Existing `t` is taken for tabs, `s` for sessions.)
  - Ledger-view key handler: `escape` returns to activity.
  - Ledger snapshot re-read on entry + on dashboard ticks via `refreshLedgers()`. Read-only — IO errors surface in `errorMessage` rather than thrown.

## P-principle compliance

- **P2** — `os.homedir()` + `path.join` everywhere; no platform-specific paths.
- **P4** — views never mutate ledger files; snapshot readers only open files for read.
- **P5** — no new native deps; `package.json` is untouched.

## Tests (6 new)

- `TasksView`: header + mixed-status rows render; empty-state; error message surfaces.
- `SkillsView`: rows + PASS/FAIL replay badges; empty-state.
- `readSkillsSnapshot` tolerates a missing skill-memory directory and does not write any state.

## Coordination

- **Hard dep on #911 (#855)** for the task ledger reader.
- **Soft dep on #928 (#856)** for the replay-badge data. Today the badge falls back to `—` when those fields are absent — no test breakage, just less information until #928 lands.

## Test plan (post-merge)

- [ ] Launch dashboard, press `j` → see live counts of running/completed/cancelled jobs after exercising `oc_task_start`
- [ ] Press `k` → see per-domain skill rows with replay badge reflecting #856's outcomes (once it lands)
- [ ] Press `escape` → returns to activity view

Closes #865

Part of the `mcp-browser-use adoption` series (F).

🤖 Generated with [Claude Code](https://claude.com/claude-code)