### PR TITLE
feat(core): opaque-cursor pagination helper + convention doc (#881 partial)

### DIFF
--- a/docs/mcp/pagination.md
+++ b/docs/mcp/pagination.md
@@ -1,0 +1,121 @@
+# Pagination convention
+
+This document is the human-readable companion to `src/utils/paginate.ts`. It
+defines the opaque-cursor convention every paginated tool result in
+OpenChrome will follow. The convention mirrors the MCP-spec opaque-cursor
+pagination already used by `tools/list`, `resources/list`, etc., so clients
+that implement spec-level cursor handling can reuse it unchanged.
+
+## Wire format
+
+**Input** (any paginated tool):
+
+- `cursor?: string` — opaque to the client. Absent ⇒ start of the underlying
+  stable set.
+
+**Output** (inside `structuredContent`):
+
+```jsonc
+{
+  // The page slice. Tools may rename `items` to a domain-specific key
+  // (`matches`, `entries`, `requests`, `text`, …) — the wire-format shape
+  // for the pagination metadata stays the same.
+  "items": [ ... ],
+
+  // Present iff there are more pages. Opaque to the caller.
+  "nextCursor": "...",
+
+  // Duplicates `nextCursor != null` for clarity. Always present.
+  "hasMore": false,
+
+  // Total items in the underlying set, including pages already consumed.
+  // Cheap-to-compute total; omitted only when computing the total is more
+  // expensive than the call itself.
+  "total": 42
+}
+```
+
+## Cursor encoding
+
+Cursors are base64url-encoded JSON of the form
+`{ v: 1, offset: number, hash?: string }`.
+
+- `v` — version (currently `1`; future versions can carry new fields).
+- `offset` — non-negative integer; the next position to read in the stable
+  ordering.
+- `hash` — optional content hash of the underlying input set. When a tool
+  passes a hash, the helper compares it to the cursor's recorded hash on
+  decode and signals `staleCursor: true` on divergence.
+
+## Stale cursor handling
+
+A cursor referring to a stale view (the underlying set changed between
+calls) MUST be reported as a JSON-RPC error, not a `MCPResult.isError`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": <id>,
+  "error": {
+    "code": -32003,
+    "message": "stale_cursor",
+    "data": { "code": "stale_cursor", "retry": "restart_from_no_cursor" }
+  }
+}
+```
+
+Rationale: stale-cursor errors are mechanical — clients should auto-retry
+from the start, not surface a tool error to the orchestrating LLM. Using
+the JSON-RPC channel makes the error machine-readable and keeps the
+LLM-visible response free of recoverable failures.
+
+## Helper API
+
+Use `paginate` / `encodeCursor` / `decodeCursor` from
+`src/utils/paginate.ts`. Example:
+
+```ts
+import { paginate } from '../utils/paginate';
+
+const allMatches = /* stable, deterministic ordering required */;
+const { items, hasMore, nextCursor, total, staleCursor } = paginate(allMatches, {
+  pageSize: 50,
+  cursor: args.cursor,
+  contentHash: hashOf(allMatches), // optional; enable stale-cursor detection
+});
+
+if (staleCursor) {
+  // Return JSON-RPC -32003 — see "Stale cursor handling" above.
+  throw new StaleCursorError();
+}
+
+return {
+  content: [{ type: 'text', text: JSON.stringify({ matches: items, total, hasMore, nextCursor }) }],
+  structuredContent: { matches: items, total, hasMore, nextCursor },
+};
+```
+
+## Tool adoption status
+
+| Tool              | Status                             |
+| ----------------- | ---------------------------------- |
+| `paginate` helper | ✅ shipped (this PR)                |
+| `read_page`       | Follow-up issue                    |
+| `query_dom`       | Follow-up issue                    |
+| `console_capture` | Follow-up issue                    |
+| `network`         | Follow-up issue                    |
+| `crawl`           | Follow-up issue                    |
+
+Each adoption is a small per-tool PR: import `paginate`, replace existing
+chunking logic with a `paginate(...)` call, route the result fields into the
+tool's `structuredContent`. Bundling them here would multiply review
+surface — separate PRs keep each adoption reviewable against the tool's
+specific data-shape and ordering invariants.
+
+## Why opaque cursors (and not `start_index`)
+
+The MCP spec already uses opaque cursors for `tools/list` / `resources/list`.
+Standardizing on the same convention for tool results means clients that
+implement spec-level cursor handling can reuse it unchanged, and lets the
+server change pagination strategy (e.g. switch from offset to seek-after) in
+the future without breaking the wire contract.

--- a/src/utils/paginate.ts
+++ b/src/utils/paginate.ts
@@ -1,0 +1,161 @@
+/**
+ * Standard pagination helper for paginated tool results (#881).
+ *
+ * Convention (mirrors MCP spec opaque-cursor pagination already used for
+ * `tools/list` / `resources/list`):
+ *
+ *   input:  optional `cursor: string` (opaque to clients)
+ *   output (inside `structuredContent`):
+ *     {
+ *       items: T[],          // or a tool-specific top-level key
+ *       nextCursor?: string, // present iff hasMore is true
+ *       hasMore: boolean,    // duplicates "nextCursor != null" for clarity
+ *       total: number,       // cheap-to-compute total of the underlying set
+ *     }
+ *
+ * Cursor encoding: base64url JSON `{ v: 1, offset: number, hash?: string }`.
+ * Including an optional content hash lets the server detect cursor reuse on
+ * stale data and reject explicitly — a stale cursor returns a JSON-RPC
+ * `-32003` error rather than a silent reset (clients should auto-retry from
+ * the start instead of surfacing a tool error to the LLM).
+ *
+ * The helper is intentionally `T[]`-only at this layer — cursor semantics
+ * for char-offset paginated outputs (e.g. `read_page` text) live in the
+ * adopting tool, using the same encode/decode primitives.
+ */
+
+const CURSOR_VERSION = 1;
+const DEFAULT_MAX_SAMPLES = 10;
+
+export interface PaginateOpts {
+  /** Caller-provided cursor; absent for the first page. */
+  cursor?: string;
+  /** Items per page. Must be > 0. */
+  pageSize: number;
+  /**
+   * Optional content hash of the underlying input set. When supplied, the
+   * helper compares it to the cursor's recorded hash; a mismatch surfaces as
+   * `staleCursor: true` so the dispatcher can convert it to a JSON-RPC
+   * `-32003` error. Skip the hash for unstable / streamed datasets — the
+   * cursor becomes a pure offset reference.
+   */
+  contentHash?: string;
+}
+
+export interface CursorState {
+  v: 1;
+  offset: number;
+  hash?: string;
+}
+
+export interface PaginateResult<T> {
+  items: T[];
+  /** Present iff there are more pages. Opaque to callers. */
+  nextCursor?: string;
+  /** Duplicates `nextCursor != null` for clarity in the wire format. */
+  hasMore: boolean;
+  /** Total items in the underlying set, including pages already consumed. */
+  total: number;
+  /**
+   * Set when the incoming cursor referenced a different content hash than the
+   * current input set. The dispatcher should reject the call with JSON-RPC
+   * code `-32003` (data: `{ code: 'stale_cursor', retry: 'restart_from_no_cursor' }`).
+   */
+  staleCursor?: true;
+}
+
+/** Stable base64url encode (Node 16+). */
+function toBase64Url(s: string): string {
+  return Buffer.from(s, 'utf8').toString('base64url');
+}
+
+/** Stable base64url decode. Throws on malformed input. */
+function fromBase64Url(s: string): string {
+  return Buffer.from(s, 'base64url').toString('utf8');
+}
+
+export function encodeCursor(state: { offset: number; hash?: string }): string {
+  if (!Number.isInteger(state.offset) || state.offset < 0) {
+    throw new Error(`encodeCursor: offset must be a non-negative integer, got ${state.offset}`);
+  }
+  const obj: CursorState = { v: CURSOR_VERSION, offset: state.offset };
+  if (state.hash !== undefined) obj.hash = state.hash;
+  return toBase64Url(JSON.stringify(obj));
+}
+
+/**
+ * Decode a previously-emitted cursor. Throws `Error('invalid_cursor')` on
+ * any structural problem (bad base64, bad JSON, missing/wrong version,
+ * non-integer offset). The caller should map that error to JSON-RPC
+ * `-32602` (Invalid params).
+ */
+export function decodeCursor(cursor: string): CursorState {
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(fromBase64Url(cursor));
+  } catch {
+    throw new Error('invalid_cursor');
+  }
+  if (
+    !decoded ||
+    typeof decoded !== 'object' ||
+    (decoded as { v?: unknown }).v !== CURSOR_VERSION ||
+    !Number.isInteger((decoded as { offset?: unknown }).offset) ||
+    (decoded as { offset: number }).offset < 0
+  ) {
+    throw new Error('invalid_cursor');
+  }
+  const out: CursorState = { v: CURSOR_VERSION, offset: (decoded as { offset: number }).offset };
+  if (typeof (decoded as { hash?: unknown }).hash === 'string') {
+    out.hash = (decoded as { hash: string }).hash;
+  }
+  return out;
+}
+
+/**
+ * Slice a stable array into a page. The caller is responsible for ensuring
+ * the input ordering is deterministic across pages (the cursor records only
+ * the offset, not the ordering rule).
+ */
+export function paginate<T>(items: readonly T[], opts: PaginateOpts): PaginateResult<T> {
+  if (!Number.isInteger(opts.pageSize) || opts.pageSize <= 0) {
+    throw new Error(`paginate: pageSize must be a positive integer, got ${opts.pageSize}`);
+  }
+
+  let offset = 0;
+  if (opts.cursor !== undefined) {
+    const state = decodeCursor(opts.cursor);
+    // Stale-cursor detection: if the caller is tracking content hash and the
+    // cursor's recorded hash diverges, the underlying set has changed.
+    if (opts.contentHash !== undefined && state.hash !== undefined && state.hash !== opts.contentHash) {
+      return { items: [], hasMore: false, total: items.length, staleCursor: true };
+    }
+    offset = state.offset;
+  }
+
+  const end = Math.min(offset + opts.pageSize, items.length);
+  const slice = items.slice(offset, end);
+  const hasMore = end < items.length;
+  const result: PaginateResult<T> = {
+    items: slice,
+    hasMore,
+    total: items.length,
+  };
+  if (hasMore) {
+    result.nextCursor = encodeCursor({ offset: end, hash: opts.contentHash });
+  }
+  return result;
+}
+
+/** Convenience for telemetry / debug-only summarization. */
+export function summarizeCursor(cursor: string | undefined): string {
+  if (!cursor) return '(none)';
+  try {
+    const s = decodeCursor(cursor);
+    return `cursor(v${s.v}, offset=${s.offset}${s.hash ? `, hash=${s.hash.slice(0, 8)}` : ''})`;
+  } catch {
+    return `cursor(invalid)`;
+  }
+}
+
+export const DEFAULT_MAX_PAGINATE_SAMPLES = DEFAULT_MAX_SAMPLES;

--- a/tests/unit/paginate.test.ts
+++ b/tests/unit/paginate.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for the standard pagination helper (#881).
+ *
+ * Validates the contract documented in src/utils/paginate.ts:
+ *   - Cursor round-trip (encode → decode preserves offset/hash).
+ *   - Page slicing is correct and yields concat-reconstruction.
+ *   - hasMore correctly mirrors nextCursor presence.
+ *   - Stale-cursor detection when contentHash diverges.
+ *   - Malformed cursor throws `invalid_cursor`.
+ *   - Edge cases: empty input, pageSize > total, last-page exactness.
+ */
+
+import {
+  encodeCursor,
+  decodeCursor,
+  paginate,
+  summarizeCursor,
+} from '../../src/utils/paginate';
+
+describe('cursor encode/decode', () => {
+  test('round-trip preserves offset', () => {
+    const c = encodeCursor({ offset: 42 });
+    expect(decodeCursor(c).offset).toBe(42);
+  });
+
+  test('round-trip preserves hash', () => {
+    const c = encodeCursor({ offset: 100, hash: 'abc123' });
+    const s = decodeCursor(c);
+    expect(s.offset).toBe(100);
+    expect(s.hash).toBe('abc123');
+  });
+
+  test('rejects negative offset on encode', () => {
+    expect(() => encodeCursor({ offset: -1 })).toThrow(/non-negative/);
+  });
+
+  test('rejects non-integer offset on encode', () => {
+    expect(() => encodeCursor({ offset: 1.5 })).toThrow(/non-negative integer/);
+  });
+
+  test('rejects malformed cursor on decode', () => {
+    expect(() => decodeCursor('not-a-base64-json')).toThrow('invalid_cursor');
+    // Valid base64 but bad JSON
+    const badJson = Buffer.from('not json', 'utf8').toString('base64url');
+    expect(() => decodeCursor(badJson)).toThrow('invalid_cursor');
+    // Valid JSON but wrong shape
+    const wrongShape = Buffer.from(JSON.stringify({ foo: 'bar' }), 'utf8').toString('base64url');
+    expect(() => decodeCursor(wrongShape)).toThrow('invalid_cursor');
+    // Valid JSON but old version
+    const oldVer = Buffer.from(JSON.stringify({ v: 0, offset: 1 }), 'utf8').toString('base64url');
+    expect(() => decodeCursor(oldVer)).toThrow('invalid_cursor');
+  });
+});
+
+describe('paginate()', () => {
+  const items = Array.from({ length: 25 }, (_, i) => `item-${i}`);
+
+  test('first page (no cursor)', () => {
+    const r = paginate(items, { pageSize: 10 });
+    expect(r.items).toEqual(items.slice(0, 10));
+    expect(r.hasMore).toBe(true);
+    expect(r.total).toBe(25);
+    expect(r.nextCursor).toBeDefined();
+  });
+
+  test('mid page (with cursor)', () => {
+    const r1 = paginate(items, { pageSize: 10 });
+    const r2 = paginate(items, { pageSize: 10, cursor: r1.nextCursor });
+    expect(r2.items).toEqual(items.slice(10, 20));
+    expect(r2.hasMore).toBe(true);
+  });
+
+  test('last page — hasMore=false, nextCursor undefined', () => {
+    const r1 = paginate(items, { pageSize: 10 });
+    const r2 = paginate(items, { pageSize: 10, cursor: r1.nextCursor });
+    const r3 = paginate(items, { pageSize: 10, cursor: r2.nextCursor });
+    expect(r3.items).toEqual(items.slice(20, 25));
+    expect(r3.hasMore).toBe(false);
+    expect(r3.nextCursor).toBeUndefined();
+  });
+
+  test('reconstruction — concatenating pages restores the full set', () => {
+    const collected: string[] = [];
+    let cursor: string | undefined = undefined;
+    let safety = 100;
+    while (safety-- > 0) {
+      const r: ReturnType<typeof paginate<string>> = paginate(items, { pageSize: 7, cursor });
+      collected.push(...r.items);
+      if (!r.hasMore) break;
+      cursor = r.nextCursor;
+    }
+    expect(collected).toEqual(items);
+  });
+
+  test('empty input — total=0, hasMore=false', () => {
+    const r = paginate([], { pageSize: 10 });
+    expect(r.items).toEqual([]);
+    expect(r.hasMore).toBe(false);
+    expect(r.total).toBe(0);
+    expect(r.nextCursor).toBeUndefined();
+  });
+
+  test('pageSize > total — single page, no continuation', () => {
+    const r = paginate(items, { pageSize: 1000 });
+    expect(r.items.length).toBe(25);
+    expect(r.hasMore).toBe(false);
+  });
+
+  test('rejects pageSize <= 0', () => {
+    expect(() => paginate(items, { pageSize: 0 })).toThrow(/positive integer/);
+    expect(() => paginate(items, { pageSize: -5 })).toThrow(/positive integer/);
+  });
+
+  test('stale cursor — content hash mismatch surfaces staleCursor:true', () => {
+    const r1 = paginate(items, { pageSize: 10, contentHash: 'v1' });
+    expect(r1.nextCursor).toBeDefined();
+    // Underlying input changes; caller now passes the SAME cursor but a NEW hash.
+    const r2 = paginate(items, { pageSize: 10, cursor: r1.nextCursor, contentHash: 'v2' });
+    expect(r2.staleCursor).toBe(true);
+    expect(r2.items).toEqual([]);
+  });
+
+  test('matching content hash does NOT trigger staleCursor', () => {
+    const r1 = paginate(items, { pageSize: 10, contentHash: 'v1' });
+    const r2 = paginate(items, { pageSize: 10, cursor: r1.nextCursor, contentHash: 'v1' });
+    expect(r2.staleCursor).toBeUndefined();
+    expect(r2.items.length).toBeGreaterThan(0);
+  });
+});
+
+describe('summarizeCursor()', () => {
+  test('returns "(none)" for undefined', () => {
+    expect(summarizeCursor(undefined)).toBe('(none)');
+  });
+
+  test('formats a real cursor', () => {
+    const c = encodeCursor({ offset: 100, hash: 'abcdef0123' });
+    expect(summarizeCursor(c)).toContain('offset=100');
+    expect(summarizeCursor(c)).toContain('hash=abcdef01');
+  });
+
+  test('returns "(invalid)" for malformed input', () => {
+    expect(summarizeCursor('not-a-cursor')).toBe('cursor(invalid)');
+  });
+});


### PR DESCRIPTION
Closes #881 (partial — ships the helper + convention; per-tool adoption is a follow-up).

## Summary

Standardizes paginated tool results on MCP-spec opaque cursors. This PR delivers the **helper module + convention doc**. The 5 tools listed in the original issue (`read_page`, `query_dom`, `console_capture`, `network`, `crawl`) each adopt the helper in separate follow-up PRs so they can be reviewed against their specific data-shape and ordering invariants.

## Changes

- `src/utils/paginate.ts` (NEW) — `encodeCursor`, `decodeCursor`, `paginate<T>`, `summarizeCursor`. Opaque base64url-JSON cursors carrying `{ v: 1, offset, hash? }`. Stale-cursor detection via optional `contentHash`.
- `docs/mcp/pagination.md` (NEW) — human-readable mirror of the convention: wire format, cursor encoding, stale-cursor handling, helper API, per-tool adoption status.
- `tests/unit/paginate.test.ts` (NEW) — 17 cases covering: cursor round-trip (offset + hash), encode validation (negative / non-integer), decode validation (bad base64 / bad JSON / wrong shape / old version), page slicing (first / mid / last), full-set reconstruction, empty / oversize page, pageSize validation, stale-cursor detection, summarizeCursor formatting.

## Wire format

```jsonc
{
  "items": [ ... ],          // page slice (tool may rename: matches/entries/etc.)
  "nextCursor": "...",       // present iff hasMore
  "hasMore": false,
  "total": 42
}
```

## Stale cursor handling

Stale cursors return a JSON-RPC `-32003` error (not `isError: true`), with `data: { code: "stale_cursor", retry: "restart_from_no_cursor" }`. Rationale: stale-cursor is mechanical — clients should auto-retry from the start, not surface a tool error to the LLM. Using the JSON-RPC channel keeps the LLM-visible response free of recoverable failures.

## Verification

- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors (3 pre-existing warnings, unrelated)
- [x] `npm test -- tests/unit/paginate.test.ts` — 17/17 pass

### Post-merge real verification with openchrome

Helper-only PR — no live MCP server invocation needed. Verification of per-tool adoption happens in each follow-up.

## Out of scope — separate follow-up issue to file

Per-tool adoption (each is a small, focused PR):

- `read_page` — char-offset cursor over the captured text
- `query_dom` — item-offset cursor over matches
- `console_capture` — item-offset cursor over entries
- `network` — item-offset cursor over requests
- `crawl` — page-offset cursor over crawled pages

Each adoption: import `paginate`, replace existing chunking logic, route results into `structuredContent` (the type added by #871). The convention is now fixed by `docs/mcp/pagination.md`, so the per-tool diffs are mechanical.

## Portability-Harness Contract compliance

- P1 (tool server identity): pure helper module + convention doc. No orchestration.
- P3 (anywhere-compatible MCP): no new dependencies, no outbound traffic, no native modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
