### PR TITLE
fix: resolve screenshot context review follow-ups

### DIFF
--- a/src/cdp/screenshot-scheduler.ts
+++ b/src/cdp/screenshot-scheduler.ts
@@ -105,9 +105,12 @@ export class ScreenshotScheduler {
 
       const params: Record<string, unknown> = {
         format,
-        quality,
-        optimizeForSpeed: options.optimizeForSpeed ?? true,
       };
+
+      if (format === 'webp' || format === 'jpeg') {
+        params.quality = quality;
+        params.optimizeForSpeed = options.optimizeForSpeed ?? true;
+      }
 
       if (options.clip) {
         params.clip = options.clip;

--- a/src/tools/batch-paginate.ts
+++ b/src/tools/batch-paginate.ts
@@ -10,6 +10,7 @@ import { KeyInput } from 'puppeteer-core';
 import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
+import { getScreenshotScheduler } from '../cdp/screenshot-scheduler';
 import { DEFAULT_SCREENSHOT_QUALITY, DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS, DEFAULT_SCREENSHOT_TIMEOUT_MS, MAX_OUTPUT_CHARS } from '../config/defaults';
 import { withDomDelta } from '../utils/dom-delta';
 import { withTimeout } from '../utils/with-timeout';
@@ -187,17 +188,16 @@ const handler: ToolHandler = async (
         try {
           const screenshotData = await Promise.race([
             (async () => {
-              const cdpSession = await (page as any).target().createCDPSession();
-              try {
-                const { data } = await cdpSession.send('Page.captureScreenshot', {
+              const { data } = await getScreenshotScheduler().capture(
+                page,
+                sessionManager.getCDPClient(),
+                {
                   format: 'webp',
                   quality: DEFAULT_SCREENSHOT_QUALITY,
                   optimizeForSpeed: true,
-                });
-                return data as string;
-              } finally {
-                await cdpSession.detach().catch(() => {});
-              }
+                }
+              );
+              return data;
             })(),
             new Promise<null>((resolve) => setTimeout(() => resolve(null), DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS)),
           ]);
@@ -207,17 +207,24 @@ const handler: ToolHandler = async (
           } else {
             throw new Error('Screenshot timed out');
           }
-        } catch {
-          // Fallback to Puppeteer PNG with timeout
-          let fallbackTimer: NodeJS.Timeout;
-          const screenshotData = await Promise.race([
-            page.screenshot({ encoding: 'base64', type: 'png' }).finally(() => clearTimeout(fallbackTimer)),
-            new Promise<never>((_, reject) => {
-              fallbackTimer = setTimeout(() => reject(new Error('Fallback screenshot timed out')), DEFAULT_SCREENSHOT_TIMEOUT_MS);
-            }),
-          ]);
-          result.screenshot = screenshotData as string;
-          result.screenshotMimeType = 'image/png';
+        } catch (err) {
+          // Do not start a second screenshot if the primary CDP capture is
+          // merely still running after the race timeout; it may complete later.
+          // Only use Puppeteer's PNG fallback for immediate CDP failures.
+          if (err instanceof Error && err.message === 'Screenshot timed out') {
+            result.error = err.message;
+          } else {
+            // Fallback to Puppeteer PNG with timeout
+            let fallbackTimer: NodeJS.Timeout;
+            const screenshotData = await Promise.race([
+              page.screenshot({ encoding: 'base64', type: 'png' }).finally(() => clearTimeout(fallbackTimer)),
+              new Promise<never>((_, reject) => {
+                fallbackTimer = setTimeout(() => reject(new Error('Fallback screenshot timed out')), DEFAULT_SCREENSHOT_TIMEOUT_MS);
+              }),
+            ]);
+            result.screenshot = screenshotData as string;
+            result.screenshotMimeType = 'image/png';
+          }
         }
       }
 

--- a/src/tools/computer.ts
+++ b/src/tools/computer.ts
@@ -6,6 +6,7 @@ import { KeyInput } from 'puppeteer-core';
 import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, MCPContent, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
+import { getScreenshotScheduler } from '../cdp/screenshot-scheduler';
 import { getRefIdManager } from '../utils/ref-id-manager';
 import { DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS } from '../config/defaults';
 import { withDomDelta } from '../utils/dom-delta';
@@ -225,24 +226,23 @@ const handler: ToolHandler = async (
           try {
             const screenshotData = await Promise.race([
               (async () => {
-                const cdpSession = await (page as any).target().createCDPSession();
-                try {
-                  // PNG is lossless: omit the quality field (CDP rejects
-                  // quality for png) and skip optimizeForSpeed (it only
-                  // applies to lossy encoders).
-                  const captureParams: Record<string, unknown> =
-                    effectiveFormat === 'png'
-                      ? { format: 'png' }
-                      : {
-                          format: effectiveFormat,
-                          quality: preset.quality,
-                          optimizeForSpeed: true,
-                        };
-                  const { data } = await cdpSession.send('Page.captureScreenshot', captureParams);
-                  return data as string;
-                } finally {
-                  await cdpSession.detach().catch(() => {});
-                }
+                // PNG is lossless: omit the quality field (CDP rejects
+                // quality for png) and skip optimizeForSpeed (it only
+                // applies to lossy encoders).
+                const captureParams: Record<string, unknown> =
+                  effectiveFormat === 'png'
+                    ? { format: 'png' }
+                    : {
+                        format: effectiveFormat,
+                        quality: preset.quality,
+                        optimizeForSpeed: true,
+                      };
+                const { data } = await getScreenshotScheduler().capture(
+                  page,
+                  sessionManager.getCDPClient(),
+                  captureParams
+                );
+                return data;
               })(),
               new Promise<null>((resolve) => setTimeout(() => resolve(null), DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS)),
             ]);

--- a/src/tools/read-page.ts
+++ b/src/tools/read-page.ts
@@ -386,19 +386,6 @@ const handler: ToolHandler = async (
       }
     }
 
-    // Add page stats header for AX mode (matching DOM mode format)
-    const axPageStats = await withTimeout(page.evaluate(() => ({
-      url: window.location.href,
-      title: document.title,
-      scrollX: Math.round(window.scrollX),
-      scrollY: Math.round(window.scrollY),
-      scrollWidth: document.documentElement.scrollWidth,
-      scrollHeight: document.documentElement.scrollHeight,
-      viewportWidth: window.innerWidth,
-      viewportHeight: window.innerHeight,
-    })), 15000, 'read_page', context);
-    const pageStatsLine = `[page_stats] url: ${axPageStats.url} | title: ${axPageStats.title} | scroll: ${axPageStats.scrollX},${axPageStats.scrollY} | viewport: ${axPageStats.viewportWidth}x${axPageStats.viewportHeight} | docSize: ${axPageStats.scrollWidth}x${axPageStats.scrollHeight}\n\n`;
-
     // Snapshot ref entry BEFORE clearing refs (needed for post-clear recovery)
     const refEntrySnapshot = refIdParam
       ? refIdManager.getRef(sessionId, tabId, refIdParam)
@@ -411,6 +398,19 @@ const handler: ToolHandler = async (
       'Accessibility.getFullAXTree',
       context,
     );
+
+    // Add page stats header for AX mode after the AX snapshot so stats are not older than the tree.
+    const axPageStats = await withTimeout(page.evaluate(() => ({
+      url: window.location.href,
+      title: document.title,
+      scrollX: Math.round(window.scrollX),
+      scrollY: Math.round(window.scrollY),
+      scrollWidth: document.documentElement.scrollWidth,
+      scrollHeight: document.documentElement.scrollHeight,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    })), 15000, 'read_page', context);
+    const pageStatsLine = `[page_stats] url: ${axPageStats.url} | title: ${axPageStats.title} | scroll: ${axPageStats.scrollX},${axPageStats.scrollY} | viewport: ${axPageStats.viewportWidth}x${axPageStats.viewportHeight} | docSize: ${axPageStats.scrollWidth}x${axPageStats.scrollHeight}\n\n`;
 
     // Clear previous refs for this target
     refIdManager.clearTargetRefs(sessionId, tabId);

--- a/tests/cdp/screenshot-scheduler-timeout.test.ts
+++ b/tests/cdp/screenshot-scheduler-timeout.test.ts
@@ -63,6 +63,50 @@ describe('ScreenshotScheduler - queue wait timeout', () => {
     expect(stats.active).toBe(0);
   });
 
+  test('omits lossy-only screenshot params for png but keeps them for jpeg', async () => {
+    const scheduler = new ScreenshotScheduler(2);
+    const cdpClient = makeMockCDPClient();
+    const page = makeMockPage();
+
+    const pngPromise = scheduler.capture(page, cdpClient, {
+      format: 'png',
+      quality: 40,
+      optimizeForSpeed: true,
+      clip: { x: 1, y: 2, width: 300, height: 200 },
+      fullPage: true,
+    });
+    jest.runAllTimers();
+    await pngPromise;
+
+    expect(cdpClient.send).toHaveBeenLastCalledWith(
+      page,
+      'Page.captureScreenshot',
+      {
+        format: 'png',
+        clip: { x: 1, y: 2, width: 300, height: 200 },
+        captureBeyondViewport: true,
+      }
+    );
+
+    const jpegPromise = scheduler.capture(page, cdpClient, {
+      format: 'jpeg',
+      quality: 75,
+      optimizeForSpeed: false,
+    });
+    jest.runAllTimers();
+    await jpegPromise;
+
+    expect(cdpClient.send).toHaveBeenLastCalledWith(
+      page,
+      'Page.captureScreenshot',
+      {
+        format: 'jpeg',
+        quality: 75,
+        optimizeForSpeed: false,
+      }
+    );
+  });
+
   // ---------------------------------------------------------------------------
   // 2. Queue wait resolves when a slot opens
   // ---------------------------------------------------------------------------

--- a/tests/utils/mock-cdp.ts
+++ b/tests/utils/mock-cdp.ts
@@ -150,6 +150,14 @@ export function createMockCDPClient() {
           return { result: { value: { success: true, message: 'Mock success' } } };
         case 'DOM.describeNode':
           return { node: { backendNodeId: 12345 } };
+        case 'Page.captureScreenshot': {
+          const target = (page as any).target?.();
+          const session = await (target?.createCDPSession?.() ?? (page as any).createCDPSession?.());
+          if (session?.send) {
+            return session.send(method, params);
+          }
+          return { data: 'base64-screenshot-data' };
+        }
         default:
           return {};
       }


### PR DESCRIPTION
## Summary
- Follow-up for issue/PR audit of #54, #55, and #56 (implemented across merged PRs #53/#55/#56)
- Avoid duplicate screenshot captures after race timeout by sharing the scheduler path and limiting fallback to immediate CDP failures
- Omit lossy-only CDP screenshot params for PNG and refresh read_page stats after AX snapshot
- Add regression coverage for scheduler timeout cleanup and PNG params

## Validation
- npm test -- --runInBand tests/tools/computer.test.ts tests/cdp/screenshot-scheduler-timeout.test.ts tests/tools/screenshot-fallback-timeout.test.ts tests/tools/read-page.test.ts --json --outputFile=/tmp/openchrome-pr-audit-54-56/jest-targeted-5.json
- npm run build
- Codex local P1 review: P1_VERDICT: NONE

Refs: #54, #55, #56, #53