### PR TITLE
fix(interact): use verifyMode for coordinate-path verify branch (unbreak develop after #891)

### DIFF
--- a/src/tools/interact.ts
+++ b/src/tools/interact.ts
@@ -196,7 +196,7 @@ const handler: ToolHandler = async (
         { type: 'text' as const, text: lines.join('\n') },
       ];
 
-      if (verify) {
+      if (verifyMode !== 'none') {
         try {
           const screenshotBuf = await withTimeout(
             page.screenshot({ type: 'webp', quality: 60, encoding: 'base64' }),


### PR DESCRIPTION
Restores develop tsc after PR #891 merged on top of #926's verify upgrade. The coordinate-mode branch still referenced the removed legacy `verify` identifier; this 1-line patch retargets it to `verifyMode !== 'none'` which uses the already-coerced enum at line 112.

Local `npm run build` is green (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)