### PR TITLE
fix(lint): remove useless try/catch + dead intersection type from develop

### DIFF
--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -956,14 +956,10 @@ export class SessionManager {
     // context, so we bypass it for named contexts.
     let namedContext: import('puppeteer-core').BrowserContext | null = null;
     if (useNamedContext) {
-      try {
-        namedContext = await this.namedContextRegistry.getOrCreate(
-          cdpClient.getBrowser(),
-          isolatedContext!,
-        );
-      } catch (err) {
-        throw err;
-      }
+      namedContext = await this.namedContextRegistry.getOrCreate(
+        cdpClient.getBrowser(),
+        isolatedContext!,
+      );
     }
 
     // Snapshot existing target IDs before page creation.

--- a/src/tools/connect.ts
+++ b/src/tools/connect.ts
@@ -40,7 +40,7 @@ export function isDevToolsExposureEnabled(): boolean {
  * Returns undefined if unreachable or exposure is disabled.
  */
 export async function collectDevToolsInfo(): Promise<
-  { instances: Awaited<ReturnType<typeof getDevToolsInstanceInfo> & {}>[] } | undefined
+  { instances: Awaited<ReturnType<typeof getDevToolsInstanceInfo>>[] } | undefined
 > {
   if (!isDevToolsExposureEnabled()) {
     return undefined;


### PR DESCRIPTION
Two lint errors landed via recent PR merges. This unblocks develop CI.

- `src/session-manager.ts:959` — `no-useless-catch`
- `src/tools/connect.ts:43` — `ban-types` (dead `& {}`)

`npm run lint` → 0 errors. `npm run build` → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)