### PR TITLE
feat(read_page): expose opt-in snapshot diagnostics

### DIFF
--- a/src/tools/read-page.ts
+++ b/src/tools/read-page.ts
@@ -168,6 +168,20 @@ function compactAXLines(lines: string[]): string[] {
   return lines.filter((_, index) => keep.has(index));
 }
 
+interface ReadPageDiagnostics {
+  mode: string;
+  requestedMode?: string;
+  pageStatsMs?: number;
+  domGetDocumentMs?: number;
+  axGetFullTreeMs?: number;
+  formatMs?: number;
+  paginationMs?: number;
+  sanitizeMs?: number;
+  deltaMs?: number;
+}
+
+type ReadPageDiagnosticTimingKey = Exclude<keyof ReadPageDiagnostics, 'mode' | 'requestedMode'>;
+
 
 interface AXNode {
   nodeId: number;
@@ -230,7 +244,10 @@ const handler: ToolHandler = async (
       };
     }
     const diagnosticsEnabled = args.diagnostics === true;
-    const diagnostics: ReadPageDiagnostics = { mode };
+    const diagnostics: ReadPageDiagnostics = {
+      mode,
+      ...(requestedMode !== undefined && requestedMode !== mode ? { requestedMode } : {}),
+    };
     const mark = () => Date.now();
     const measure = async <T>(key: ReadPageDiagnosticTimingKey, fn: () => Promise<T>): Promise<T> => {
       const start = mark();
@@ -1007,6 +1024,10 @@ const handler: ToolHandler = async (
           '\n\n[AX tree exceeded output limit (' + charCount + ' chars). ' +
           'Switched to DOM mode because fallback: "dom" was requested. ' +
           'Use mode: "ax" with smaller depth / ref_id to scope specific subtrees for AX format.]';
+
+        // Update diagnostics to reflect the effective output mode (DOM), not the requested one (AX).
+        diagnostics.requestedMode = diagnostics.requestedMode ?? diagnostics.mode;
+        diagnostics.mode = 'dom';
 
         return withDiagnostics({
           content: [

--- a/src/tools/read-page.ts
+++ b/src/tools/read-page.ts
@@ -129,6 +129,10 @@ const definition: MCPToolDefinition = {
         type: 'boolean',
         description: 'AX mode only: return a compact AX snapshot that keeps actionable/ref-bearing nodes, value/state nodes, and ancestors. Default: false.',
       },
+      diagnostics: {
+        type: 'boolean',
+        description: 'Include structured read_page timing diagnostics in the MCP result metadata. Default: false.',
+      },
     },
     required: ['tabId'],
   },
@@ -163,6 +167,7 @@ function compactAXLines(lines: string[]): string[] {
 
   return lines.filter((_, index) => keep.has(index));
 }
+
 
 interface AXNode {
   nodeId: number;
@@ -224,6 +229,21 @@ const handler: ToolHandler = async (
         isError: true,
       };
     }
+    const diagnosticsEnabled = args.diagnostics === true;
+    const diagnostics: ReadPageDiagnostics = { mode };
+    const mark = () => Date.now();
+    const measure = async <T>(key: ReadPageDiagnosticTimingKey, fn: () => Promise<T>): Promise<T> => {
+      const start = mark();
+      try {
+        return await fn();
+      } finally {
+        diagnostics[key] = mark() - start;
+      }
+    };
+    const withDiagnostics = (result: MCPResult): MCPResult => (
+      diagnosticsEnabled ? { ...result, _diagnostics: diagnostics } : result
+    );
+
     const axOverflowFallback = (args.fallback as string | undefined) || 'none';
     const compactAX = args.compact === true;
     if (axOverflowFallback !== 'none' && axOverflowFallback !== 'dom') {
@@ -600,11 +620,12 @@ const handler: ToolHandler = async (
       try {
         const refId = args.ref_id as string | undefined;
         const depth = args.depth as number | undefined;
-        const result = await serializeDOM(page, cdpClient, {
+        const result = await measure('domGetDocumentMs', () => serializeDOM(page, cdpClient, {
           maxDepth: depth ?? -1,
           filter: filter,
           interactiveOnly: filter === 'interactive',
-        });
+        }));
+        diagnostics.formatMs = diagnostics.domGetDocumentMs;
 
         let outputText = result.content;
         if (refId) {
@@ -628,7 +649,7 @@ const handler: ToolHandler = async (
           const previous = snapshotStore.get(sessionId, tabId);
 
           if (previous) {
-            const delta = snapshotStore.computeDelta(previous, outputText, currentUrl);
+            const delta = await measure('deltaMs', async () => snapshotStore.computeDelta(previous, outputText, currentUrl));
             // Always update cache with current content
             snapshotStore.set(sessionId, tabId, outputText, currentUrl);
 
@@ -636,16 +657,16 @@ const handler: ToolHandler = async (
               // Return delta instead of full content, but keep page stats header
               const statsLine = `[page_stats] url: ${result.pageStats.url} | title: ${result.pageStats.title} | scroll: ${result.pageStats.scrollX},${result.pageStats.scrollY} | viewport: ${result.pageStats.viewportWidth}x${result.pageStats.viewportHeight} | docSize: ${result.pageStats.scrollWidth}x${result.pageStats.scrollHeight}\n\n`;
               const includePaginationDom = args.includePagination !== false;
-              const domPaginationSection = includePaginationDom ? formatPaginationSection(await detectPagination(page, tabId)) : '';
+              const domPaginationSection = includePaginationDom ? await measure('paginationMs', async () => formatPaginationSection(await detectPagination(page, tabId))) : '';
               const compressedText = statsLine + delta.content + nodeRefsBlock + domPaginationSection;
-              return {
+              return withDiagnostics({
                 content: [{ type: 'text', text: compressedText }],
                 _compression: {
                   level: 'delta',
                   originalChars: outputText.length,
                   compressedChars: compressedText.length,
                 },
-              };
+              });
             }
             // If not delta (too many changes), fall through to full response
           } else {
@@ -655,13 +676,13 @@ const handler: ToolHandler = async (
         }
 
         const includePaginationDom = args.includePagination !== false;
-        const domPaginationSection = includePaginationDom ? formatPaginationSection(await detectPagination(page, tabId)) : '';
-        return {
+        const domPaginationSection = includePaginationDom ? await measure('paginationMs', async () => formatPaginationSection(await detectPagination(page, tabId))) : '';
+        return withDiagnostics({
           content: [{ type: 'text', text: outputText + nodeRefsBlock + domPaginationSection }],
-        };
+        });
       } catch (error) {
         if (isExplicitDomMode) {
-          return {
+          return withDiagnostics({
             content: [
               {
                 type: 'text',
@@ -669,8 +690,9 @@ const handler: ToolHandler = async (
               },
             ],
             isError: true,
-          };
+          });
         }
+        // DOM serialization failed — fall through to AX mode as fallback
       }
     }
 
@@ -702,15 +724,15 @@ const handler: ToolHandler = async (
       : undefined;
 
     // Get the accessibility tree
-    const { nodes } = await withTimeout(
+    const { nodes } = await measure('axGetFullTreeMs', () => withTimeout(
       cdpClient.send<{ nodes: AXNode[] }>(page, 'Accessibility.getFullAXTree', { depth: fetchDepth }),
       15000,
       'Accessibility.getFullAXTree',
       context,
-    );
+    ));
 
     // Add page stats header for AX mode after the AX snapshot so stats are not older than the tree.
-    const axPageStats = await withTimeout(page.evaluate(() => ({
+    const axPageStats = await measure('pageStatsMs', () => withTimeout(page.evaluate(() => ({
       url: window.location.href,
       title: document.title,
       scrollX: Math.round(window.scrollX),
@@ -719,8 +741,10 @@ const handler: ToolHandler = async (
       scrollHeight: document.documentElement.scrollHeight,
       viewportWidth: window.innerWidth,
       viewportHeight: window.innerHeight,
-    })), 15000, 'read_page', context);
+    })), 15000, 'read_page', context));
     const pageStatsLine = `[page_stats] url: ${axPageStats.url} | title: ${axPageStats.title} | scroll: ${axPageStats.scrollX},${axPageStats.scrollY} | viewport: ${axPageStats.viewportWidth}x${axPageStats.viewportHeight} | docSize: ${axPageStats.scrollWidth}x${axPageStats.scrollHeight}\n\n`;
+
+    const formatStart = mark();
 
     // Clear previous refs for this target
     refIdManager.clearTargetRefs(sessionId, tabId);
@@ -902,10 +926,10 @@ const handler: ToolHandler = async (
         });
       }
       if (!scopedNode) {
-        return {
+        return withDiagnostics({
           content: [{ type: 'text', text: `Error: ref_id or node ID "${refIdParam}" not found or expired` }],
           isError: true,
-        };
+        });
       }
       startNodes = [scopedNode];
     } else {
@@ -918,8 +942,9 @@ const handler: ToolHandler = async (
     const outputLines = compactAX ? compactAXLines(lines) : lines;
     const output = outputLines.join('\n');
     const outputCharCount = output.length;
+    diagnostics.formatMs = mark() - formatStart;
     const includePaginationAx = args.includePagination !== false;
-    const axPaginationSection = includePaginationAx ? formatPaginationSection(await detectPagination(page, tabId)) : '';
+    const axPaginationSection = includePaginationAx ? await measure('paginationMs', async () => formatPaginationSection(await detectPagination(page, tabId))) : '';
 
     const compression = args.compression as string | undefined;
     if (compression === 'delta') {
@@ -944,7 +969,7 @@ const handler: ToolHandler = async (
       // the caller explicitly opts into that fallback. Otherwise preserve AX
       // intent and return the bounded/truncated AX representation.
       if (axOverflowFallback !== 'dom') {
-        return {
+        return withDiagnostics({
           content: [
             {
               type: 'text',
@@ -956,7 +981,7 @@ const handler: ToolHandler = async (
             },
           ],
           refs: refsMap,
-        };
+        });
       }
 
       // Explicit fallback: DOM mode often produces equivalent page structure at
@@ -982,17 +1007,17 @@ const handler: ToolHandler = async (
           'Switched to DOM mode because fallback: "dom" was requested. ' +
           'Use mode: "ax" with smaller depth / ref_id to scope specific subtrees for AX format.]';
 
-        return {
+        return withDiagnostics({
           content: [
             {
               type: 'text',
               text: domResult.content + fallbackNote + fallbackNodeRefsBlock + axPaginationSection,
             },
           ],
-        };
+        });
       } catch {
         // If DOM serialization fails, fall back to truncated AX (original behavior)
-        return {
+        return withDiagnostics({
           content: [
             {
               type: 'text',
@@ -1004,14 +1029,14 @@ const handler: ToolHandler = async (
             },
           ],
           refs: refsMap,
-        };
+        });
       }
     }
 
-    return {
+    return withDiagnostics({
       content: [{ type: 'text', text: pageStatsLine + output + axPaginationSection }],
       refs: refsMap,
-    };
+    });
   } catch (error) {
     return {
       content: [
@@ -1085,6 +1110,8 @@ const sanitizedHandler: ToolHandler = async (sessionId, args, context) => {
     return value;
   }
 
+  const sanitizeStart = Date.now();
+
   // Sanitize all text content blocks
   const sanitizedContent = result.content.map((block) => {
     if (block.type === 'text' && typeof block.text === 'string') {
@@ -1117,7 +1144,11 @@ const sanitizedHandler: ToolHandler = async (sessionId, args, context) => {
     return block;
   });
 
-  return { ...result, content: sanitizedContent };
+  const sanitizedResult: MCPResult = { ...result, content: sanitizedContent };
+  if (args.diagnostics === true && sanitizedResult._diagnostics && typeof sanitizedResult._diagnostics === 'object') {
+    (sanitizedResult._diagnostics as ReadPageDiagnostics).sanitizeMs = Date.now() - sanitizeStart;
+  }
+  return sanitizedResult;
 };
 
 export function registerReadPageTool(server: MCPServer): void {

--- a/src/tools/read-page.ts
+++ b/src/tools/read-page.ts
@@ -693,6 +693,7 @@ const handler: ToolHandler = async (
           });
         }
         // DOM serialization failed — fall through to AX mode as fallback
+        diagnostics.mode = 'ax';
       }
     }
 

--- a/tests/tools/read-page-dom.test.ts
+++ b/tests/tools/read-page-dom.test.ts
@@ -162,6 +162,23 @@ describe('ReadPageTool - DOM Mode', () => {
       expect(text).toContain('Click Me');
     });
 
+    test('diagnostics are omitted by default and exposed only when requested', async () => {
+      const handler = await getReadPageHandler();
+
+      const normal = await handler(testSessionId, { tabId: testTargetId, mode: 'dom' }) as any;
+      expect(normal._diagnostics).toBeUndefined();
+
+      const diagnostic = await handler(testSessionId, { tabId: testTargetId, mode: 'dom', diagnostics: true }) as any;
+      expect(diagnostic._diagnostics).toEqual(expect.objectContaining({
+        mode: 'dom',
+        domGetDocumentMs: expect.any(Number),
+        formatMs: expect.any(Number),
+        paginationMs: expect.any(Number),
+        sanitizeMs: expect.any(Number),
+      }));
+      expect(diagnostic.content[0].text).toContain('[page_stats]');
+    });
+
     test('mode=dom does NOT clear ref IDs', async () => {
       const handler = await getReadPageHandler();
       await handler(testSessionId, { tabId: testTargetId, mode: 'dom' });

--- a/tests/tools/read-page.test.ts
+++ b/tests/tools/read-page.test.ts
@@ -467,6 +467,30 @@ describe('ReadPageTool', () => {
       );
     });
 
+    test('diagnostics.mode reflects DOM when AX-overflow triggers fallback=dom', async () => {
+      const mockSerializeDOM = jest.fn().mockResolvedValue({
+        content: '[page_stats] url: https://example.com\n\n<body></body>',
+      });
+      const handler = await getReadPageHandler(mockSerializeDOM);
+
+      mockSessionManager.mockCDPClient.setCDPResponse(
+        'Accessibility.getFullAXTree',
+        { depth: 8 },
+        generateLargeAXTree(600)
+      );
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        mode: 'ax',
+        fallback: 'dom',
+        diagnostics: true,
+      }) as any;
+
+      // effective mode must reflect the actual output format, not the requested one
+      expect(result._diagnostics.mode).toBe('dom');
+      expect(result._diagnostics.requestedMode).toBe('ax');
+    });
+
     test('falls back to truncated AX output when DOM serialization fails', async () => {
       const mockSerializeDOM = jest.fn().mockRejectedValue(new Error('DOM serialization failed'));
       const handler = await getReadPageHandler(mockSerializeDOM);


### PR DESCRIPTION
## Progress / Review status

_Auto-refreshed 2026-05-13 — owner comments cleaned up to reduce review noise._

| Field | Value |
| --- | --- |
| Branch | `feat/971-read-page-diagnostics` → `develop` |
| Draft | no |
| CI | ⏳ 8/9 passing — 1 pending |
| Mergeable | ✅ MERGEABLE |
| Review decision | — |
| Codex (latest) | 💡 suggestions posted |
| Other reviewers (latest) | chatgpt-codex-connector: commented |
| Head | `a4517a3` — fix(read_page): report effective mode in diagnostics after DOM→AX fal… |
| Commits | 3 |

<sub>Owner comment cleanup: 6 issue + 0 inline review comments deleted. Outstanding feedback from automated/external reviewers above is unchanged.</sub>
<!-- progress-status:end -->
---

## Summary
- Adds an opt-in `read_page.diagnostics` flag for DOM and AX snapshot hot-path timing.
- Emits timings only in MCP result metadata (`_diagnostics`) so default text output and token shape stay unchanged.
- Covers page stats, DOM document fetch/format aggregate, AX full-tree fetch, formatting, pagination, sanitize, and delta timing fields where applicable.

Closes #971

## Fit / non-overlap review
- Fits the repo direction by measuring OpenChrome's current TypeScript snapshot path before considering native rewrites.
- Does not overlap with open PR #948 canonical snapshot refs or #929 snapshot cache; this PR only adds opt-in telemetry metadata.
- Avoids any default behavior change or new dependency.

## Tests
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/jest tests/tools/read-page-dom.test.ts --runInBand`

## OpenChrome real-validation checklist
After merge, validate with OpenChrome itself:
1. Open a stable page (for example `https://example.com`).
2. Call `read_page` without `diagnostics`; confirm no `_diagnostics` field is returned.
3. Call `read_page` with `{ "mode": "dom", "diagnostics": true }`; confirm `_diagnostics.mode === "dom"` and timing fields are non-negative numbers.
4. Call `read_page` with `{ "mode": "ax", "diagnostics": true }`; confirm `_diagnostics.mode === "ax"` and `axGetFullTreeMs`/`formatMs` are present.
5. Repeat with `compression: "delta"`; confirm existing delta output still works and `deltaMs` is present.