### PR TITLE
feat(read_page): surface custom interactive controls

### DIFF
--- a/src/dom/dom-serializer.ts
+++ b/src/dom/dom-serializer.ts
@@ -97,6 +97,12 @@ const INTERACTIVE_HINT_OWNED_ATTR = `${INTERACTIVE_HINT_ATTR}-owned`;
 const INTERACTIVE_HINT_SCAN_MAX_MS = 100;
 const INTERACTIVE_HINT_SCAN_MAX_ELEMENTS = 2500;
 
+interface CursorInteractiveScanResult {
+  completed: boolean;
+  inspected: number;
+  marked: number;
+}
+
 /**
  * Parse flat attributes array into a map
  */
@@ -538,12 +544,12 @@ function serializeNode(
   }
 }
 
-async function markCursorInteractiveElements(page: Page): Promise<void> {
+async function markCursorInteractiveElements(page: Page): Promise<CursorInteractiveScanResult> {
   // Bound the browser-side scan from inside the evaluated function. Racing
   // page.evaluate with a timeout does not abort the in-page work and can leave
   // marker mutations running after cleanup; an in-page deadline/node cap exits
   // cooperatively without orphaning background DOM changes.
-  await page.evaluate((hintAttr: string, ownedAttr: string, maxMs: number, maxElements: number) => {
+  return await page.evaluate((hintAttr: string, ownedAttr: string, maxMs: number, maxElements: number) => {
       const interactiveRoles = new Set([
         'button', 'link', 'textbox', 'checkbox', 'radio', 'combobox', 'listbox',
         'menu', 'menuitem', 'tab', 'switch', 'slider',
@@ -556,6 +562,7 @@ async function markCursorInteractiveElements(page: Page): Promise<void> {
       const deadline = now() + maxMs;
       let inspected = 0;
       let budgetExceeded = false;
+      let marked = 0;
 
       for (let i = 0; i < roots.length; i++) {
         const root = roots[i];
@@ -613,10 +620,13 @@ async function markCursorInteractiveElements(page: Page): Promise<void> {
           if (!el.hasAttribute(hintAttr)) {
             el.setAttribute(hintAttr, hints.join(', '));
             el.setAttribute(ownedAttr, 'true');
+            marked += 1;
           }
         }
         if (budgetExceeded) break;
       }
+
+      return { completed: !budgetExceeded, inspected, marked };
     }, INTERACTIVE_HINT_ATTR, INTERACTIVE_HINT_OWNED_ATTR, INTERACTIVE_HINT_SCAN_MAX_MS, INTERACTIVE_HINT_SCAN_MAX_ELEMENTS);
 }
 
@@ -689,11 +699,17 @@ export async function serializeDOM(
 
   if (interactiveOnly) {
     try {
-      await markCursorInteractiveElements(page);
+      const scanResult = await markCursorInteractiveElements(page);
+      if (!scanResult.completed) {
+        await clearCursorInteractiveMarkers(page);
+      }
     } catch {
       // Cursor/onclick hint discovery is opportunistic. Large or hostile pages
       // should still serialize using native tags and ARIA roles if this pre-scan
-      // times out or throws.
+      // times out or throws. If the scan threw after setting any owned markers,
+      // clear them before taking the CDP snapshot so reads degrade without
+      // partial custom hints.
+      await clearCursorInteractiveMarkers(page);
     }
   }
 

--- a/src/dom/dom-serializer.ts
+++ b/src/dom/dom-serializer.ts
@@ -536,8 +536,10 @@ function serializeNode(
 }
 
 async function markCursorInteractiveElements(page: Page): Promise<void> {
-  await withTimeout(
-    page.evaluate((hintAttr: string) => {
+  // Await the browser-side scan directly. page.evaluate cannot be aborted by
+  // racing its promise with a timeout; doing so could let background marker
+  // mutations continue after serializeDOM has already run cleanup.
+  await page.evaluate((hintAttr: string) => {
       const interactiveRoles = new Set([
         'button', 'link', 'textbox', 'checkbox', 'radio', 'combobox', 'listbox',
         'menu', 'menuitem', 'tab', 'switch', 'slider',
@@ -594,10 +596,7 @@ async function markCursorInteractiveElements(page: Page): Promise<void> {
           }
         }
       }
-    }, INTERACTIVE_HINT_ATTR),
-    5000,
-    'serializeDOM:markCursorInteractiveElements',
-  );
+    }, INTERACTIVE_HINT_ATTR);
 }
 
 async function clearCursorInteractiveMarkers(page: Page): Promise<void> {

--- a/src/dom/dom-serializer.ts
+++ b/src/dom/dom-serializer.ts
@@ -93,6 +93,9 @@ const CONTAINER_TAGS = new Set([
 ]);
 
 const INTERACTIVE_HINT_ATTR = 'data-oc-interactive-hints';
+const INTERACTIVE_HINT_OWNED_ATTR = `${INTERACTIVE_HINT_ATTR}-owned`;
+const INTERACTIVE_HINT_SCAN_MAX_MS = 100;
+const INTERACTIVE_HINT_SCAN_MAX_ELEMENTS = 2500;
 
 /**
  * Parse flat attributes array into a map
@@ -536,22 +539,39 @@ function serializeNode(
 }
 
 async function markCursorInteractiveElements(page: Page): Promise<void> {
-  // Await the browser-side scan directly. page.evaluate cannot be aborted by
-  // racing its promise with a timeout; doing so could let background marker
-  // mutations continue after serializeDOM has already run cleanup.
-  await page.evaluate((hintAttr: string) => {
+  // Bound the browser-side scan from inside the evaluated function. Racing
+  // page.evaluate with a timeout does not abort the in-page work and can leave
+  // marker mutations running after cleanup; an in-page deadline/node cap exits
+  // cooperatively without orphaning background DOM changes.
+  await page.evaluate((hintAttr: string, ownedAttr: string, maxMs: number, maxElements: number) => {
       const interactiveRoles = new Set([
         'button', 'link', 'textbox', 'checkbox', 'radio', 'combobox', 'listbox',
         'menu', 'menuitem', 'tab', 'switch', 'slider',
       ]);
       const interactiveTags = new Set(['a', 'button', 'input', 'select', 'textarea', 'details', 'summary']);
       const roots: Array<Document | ShadowRoot> = [document];
+      const now = () => (typeof performance !== 'undefined' && typeof performance.now === 'function')
+        ? performance.now()
+        : Date.now();
+      const deadline = now() + maxMs;
+      let inspected = 0;
+      let budgetExceeded = false;
 
       for (let i = 0; i < roots.length; i++) {
         const root = roots[i];
-        const all = Array.from(root.querySelectorAll('*')) as HTMLElement[];
-        for (const el of all) {
+        const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+        let current = walker.nextNode();
+        while (current) {
+          inspected += 1;
+          if (inspected > maxElements || now() > deadline) {
+            budgetExceeded = true;
+            break;
+          }
+
+          const el = current as HTMLElement;
           if (el.shadowRoot) roots.push(el.shadowRoot);
+          current = walker.nextNode();
+
           if (el.closest('[hidden], [aria-hidden="true"]')) continue;
 
           const tag = el.tagName.toLowerCase();
@@ -592,30 +612,31 @@ async function markCursorInteractiveElements(page: Page): Promise<void> {
 
           if (!el.hasAttribute(hintAttr)) {
             el.setAttribute(hintAttr, hints.join(', '));
-            el.setAttribute(`${hintAttr}-owned`, 'true');
+            el.setAttribute(ownedAttr, 'true');
           }
         }
+        if (budgetExceeded) break;
       }
-    }, INTERACTIVE_HINT_ATTR);
+    }, INTERACTIVE_HINT_ATTR, INTERACTIVE_HINT_OWNED_ATTR, INTERACTIVE_HINT_SCAN_MAX_MS, INTERACTIVE_HINT_SCAN_MAX_ELEMENTS);
 }
 
 async function clearCursorInteractiveMarkers(page: Page): Promise<void> {
   try {
     await withTimeout(
-      page.evaluate((hintAttr: string) => {
+      page.evaluate((hintAttr: string, ownedAttr: string) => {
         const roots: Array<Document | ShadowRoot> = [document];
         for (let i = 0; i < roots.length; i++) {
           const root = roots[i];
           const all = Array.from(root.querySelectorAll('*')) as HTMLElement[];
           for (const el of all) {
             if (el.shadowRoot) roots.push(el.shadowRoot);
-            if (el.getAttribute(`${hintAttr}-owned`) === 'true') {
+            if (el.getAttribute(ownedAttr) === 'true') {
               el.removeAttribute(hintAttr);
-              el.removeAttribute(`${hintAttr}-owned`);
+              el.removeAttribute(ownedAttr);
             }
           }
         }
-      }, INTERACTIVE_HINT_ATTR),
+      }, INTERACTIVE_HINT_ATTR, INTERACTIVE_HINT_OWNED_ATTR),
       5000,
       'serializeDOM:clearCursorInteractiveMarkers',
     );

--- a/src/dom/dom-serializer.ts
+++ b/src/dom/dom-serializer.ts
@@ -563,7 +563,7 @@ async function markCursorInteractiveElements(page: Page): Promise<void> {
           const tabIndex = el.getAttribute('tabindex');
           const hasTabIndex = tabIndex !== null && tabIndex !== '-1';
           const editable = el.getAttribute('contenteditable');
-          const isEditable = editable === '' || editable === 'true';
+          const isEditable = el.isContentEditable || editable === '' || editable === 'true' || editable === 'plaintext-only';
 
           if (!hasCursorPointer && !hasOnClick && !hasTabIndex && !isEditable) continue;
           if (hasCursorPointer && !hasOnClick && !hasTabIndex && !isEditable) {

--- a/src/dom/dom-serializer.ts
+++ b/src/dom/dom-serializer.ts
@@ -92,15 +92,18 @@ const CONTAINER_TAGS = new Set([
   'div', 'section', 'article', 'main', 'aside', 'header', 'footer', 'nav', 'span',
 ]);
 
-const INTERACTIVE_HINT_ATTR = 'data-oc-interactive-hints';
-const INTERACTIVE_HINT_OWNED_ATTR = `${INTERACTIVE_HINT_ATTR}-owned`;
 const INTERACTIVE_HINT_SCAN_MAX_MS = 100;
 const INTERACTIVE_HINT_SCAN_MAX_ELEMENTS = 2500;
+
+interface CustomInteractiveHint {
+  path: string;
+  hints: string;
+}
 
 interface CursorInteractiveScanResult {
   completed: boolean;
   inspected: number;
-  marked: number;
+  hints: CustomInteractiveHint[];
 }
 
 /**
@@ -126,26 +129,30 @@ function escapeAttributeValue(value: string): string {
 /**
  * Check if a node is interactive
  */
-function isInteractive(tagName: string, attrMap: Map<string, string>): boolean {
-  if (attrMap.has(INTERACTIVE_HINT_ATTR)) return true;
+function isNativeInteractive(tagName: string, attrMap: Map<string, string>): boolean {
   if (INTERACTIVE_TAGS.has(tagName)) return true;
   const role = attrMap.get('role');
   if (role && INTERACTIVE_ROLES.has(role)) return true;
   return false;
 }
 
+function isInteractive(tagName: string, attrMap: Map<string, string>, customHints?: string): boolean {
+  return Boolean(customHints) || isNativeInteractive(tagName, attrMap);
+}
+
 /**
  * Check if a DOM node or any descendant contains interactive elements.
  * Prevents sibling dedup from collapsing groups with clickable elements.
  */
-function containsInteractive(node: DOMNode): boolean {
+function containsInteractive(node: DOMNode, path: string, ctx: SerializeContext): boolean {
   if (node.nodeType !== NODE_TYPE_ELEMENT) return false;
   const tag = (node.localName || node.nodeName).toLowerCase();
   const attrMap = parseAttributes(node.attributes);
-  if (isInteractive(tag, attrMap)) return true;
+  if (isInteractive(tag, attrMap, ctx.customInteractiveHints.get(path))) return true;
   if (node.children) {
+    const childPaths = createChildPathMap(node.children, path);
     for (const child of node.children) {
-      if (containsInteractive(child)) return true;
+      if (containsInteractive(child, childPaths.get(child) ?? path, ctx)) return true;
     }
   }
   return false;
@@ -176,6 +183,7 @@ function formatElement(
   indent: string,
   textContent: string,
   interactive: boolean,
+  hints?: string,
 ): string {
   const tagName = node.localName || node.nodeName.toLowerCase();
 
@@ -188,7 +196,6 @@ function formatElement(
   }
   const attrStr = attrParts.length > 0 ? ' ' + attrParts.join(' ') : '';
 
-  const hints = attrMap.get(INTERACTIVE_HINT_ATTR);
   const interactiveMarker = interactive
     ? ` ★${hints ? ` [${hints}]` : ''}`
     : '';
@@ -203,13 +210,13 @@ function formatElement(
  * - Has no meaningful text content
  * - Is NOT interactive
  */
-function isCollapsibleContainer(node: DOMNode): boolean {
+function isCollapsibleContainer(node: DOMNode, path: string, ctx: SerializeContext): boolean {
   if (!node.children) return false;
   const tagName = (node.localName || node.nodeName).toLowerCase();
   if (!CONTAINER_TAGS.has(tagName)) return false;
 
   const attrMap = parseAttributes(node.attributes);
-  if (isInteractive(tagName, attrMap)) return false;
+  if (isInteractive(tagName, attrMap, ctx.customInteractiveHints.get(path))) return false;
 
   const text = getDirectTextContent(node);
   if (text.length > 0) return false;
@@ -222,9 +229,10 @@ function isCollapsibleContainer(node: DOMNode): boolean {
  * Collect a chain of single-child containers starting from node.
  * Returns the chain nodes and the leaf (first non-container or multi-child node).
  */
-function collectContainerChain(node: DOMNode): { chain: DOMNode[], leaf: DOMNode } {
+function collectContainerChain(node: DOMNode, path: string, ctx: SerializeContext): { chain: DOMNode[], leaf: DOMNode, leafPath: string } {
   const chain: DOMNode[] = [node];
   let current = node;
+  let currentPath = path;
 
   while (chain.length < MAX_CONTAINER_CHAIN) {
     const elementChildren = (current.children || []).filter(
@@ -233,15 +241,18 @@ function collectContainerChain(node: DOMNode): { chain: DOMNode[], leaf: DOMNode
     if (elementChildren.length !== 1) break;
 
     const child = elementChildren[0];
+    const childPaths = createChildPathMap(current.children || [], currentPath);
+    const childPath = childPaths.get(child) ?? currentPath;
     const childTag = (child.localName || child.nodeName).toLowerCase();
     if (!CONTAINER_TAGS.has(childTag)) break;
 
     const childAttrMap = parseAttributes(child.attributes);
-    if (isInteractive(childTag, childAttrMap)) break;
+    if (isInteractive(childTag, childAttrMap, ctx.customInteractiveHints.get(childPath))) break;
     if (getDirectTextContent(child).length > 0) break;
 
     chain.push(child);
     current = child;
+    currentPath = childPath;
   }
 
   // The leaf is the deepest container's single element child, or the last container itself
@@ -249,13 +260,15 @@ function collectContainerChain(node: DOMNode): { chain: DOMNode[], leaf: DOMNode
     c => c.nodeType === NODE_TYPE_ELEMENT && !SKIP_TAGS.has(c.nodeName.toUpperCase())
   );
   const leaf = lastChildren.length === 1 ? lastChildren[0] : current;
+  const lastChildPaths = createChildPathMap(current.children || [], currentPath);
+  const leafPath = lastChildPaths.get(leaf) ?? currentPath;
 
   // If leaf is same as last chain entry, the chain didn't find a true leaf
   if (leaf === current) {
-    return { chain: [], leaf: node }; // no collapse
+    return { chain: [], leaf: node, leafPath: path }; // no collapse
   }
 
-  return { chain, leaf };
+  return { chain, leaf, leafPath };
 }
 
 interface SiblingGroup {
@@ -301,12 +314,24 @@ interface SerializeContext {
   includeUserAgentShadowDOM: boolean;
   nodesVisited: number;
   maxNodes: number;
+  customInteractiveHints: Map<string, string>;
   /**
    * Tracks every backendNodeId emitted in the output so the caller can mint
    * a `[node_refs]` block for the #844 backend-node uid contract. Insertion
    * order is preserved so the output map mirrors the visual order of lines.
    */
   emittedBackendNodeIds: Set<number>;
+}
+
+function createChildPathMap(children: DOMNode[], parentPath: string): Map<DOMNode, string> {
+  const paths = new Map<DOMNode, string>();
+  let elementIndex = 0;
+  for (const child of children) {
+    if (child.nodeType !== NODE_TYPE_ELEMENT) continue;
+    paths.set(child, `${parentPath}/c:${elementIndex}`);
+    elementIndex += 1;
+  }
+  return paths;
 }
 
 function appendTruncationMarker(ctx: SerializeContext): void {
@@ -333,6 +358,7 @@ function serializeNode(
   node: DOMNode,
   depth: number,
   ctx: SerializeContext,
+  path = 'd',
 ): void {
   if (ctx.truncated) return;
 
@@ -349,8 +375,9 @@ function serializeNode(
   // Handle document node - just recurse into children
   if (node.nodeType === NODE_TYPE_DOCUMENT) {
     if (node.children) {
+      const childPaths = createChildPathMap(node.children, path);
       for (const child of node.children) {
-        serializeNode(child, depth, ctx);
+        serializeNode(child, depth, ctx, childPaths.get(child) ?? path);
         if (ctx.truncated) return;
       }
     }
@@ -370,13 +397,14 @@ function serializeNode(
 
   const tagName = node.localName || node.nodeName.toLowerCase();
   const attrMap = parseAttributes(node.attributes);
-  const interactive = isInteractive(tagName, attrMap);
+  const customHints = ctx.customInteractiveHints.get(path);
+  const interactive = isInteractive(tagName, attrMap, customHints);
 
   const indent = '  '.repeat(depth);
 
   // Container chain collapse (only in non-'none' compression mode, non-interactive containers)
-  if (ctx.compression !== 'none' && !interactive && isCollapsibleContainer(node)) {
-    const { chain, leaf } = collectContainerChain(node);
+  if (ctx.compression !== 'none' && !interactive && isCollapsibleContainer(node, path, ctx)) {
+    const { chain, leaf, leafPath } = collectContainerChain(node, path, ctx);
     if (chain.length >= 2) {
       // Build chain prefix: [10]div>[11]section>[12]div>
       const chainPrefix = chain.map(n => {
@@ -387,9 +415,10 @@ function serializeNode(
       // Serialize the leaf: format its line but with chain prefix prepended
       const leafTag = leaf.localName || leaf.nodeName.toLowerCase();
       const leafAttrMap = parseAttributes(leaf.attributes);
-      const leafInteractive = isInteractive(leafTag, leafAttrMap);
+      const leafHints = ctx.customInteractiveHints.get(leafPath);
+      const leafInteractive = isInteractive(leafTag, leafAttrMap, leafHints);
       const leafText = getDirectTextContent(leaf);
-      const leafLine = formatElement(leaf, leafAttrMap, '', leafText, leafInteractive);
+      const leafLine = formatElement(leaf, leafAttrMap, '', leafText, leafInteractive, leafHints);
       const fullLine = `${indent}${chainPrefix}${leafLine}\n`;
 
       if (ctx.totalChars + fullLine.length > ctx.maxOutputChars) {
@@ -407,8 +436,9 @@ function serializeNode(
 
       // Recurse into leaf's children
       if (leaf.children) {
+        const childPaths = createChildPathMap(leaf.children, leafPath);
         for (const child of leaf.children) {
-          serializeNode(child, depth + 1, ctx);
+          serializeNode(child, depth + 1, ctx, childPaths.get(child) ?? leafPath);
           if (ctx.truncated) return;
         }
       }
@@ -418,7 +448,7 @@ function serializeNode(
 
   if (!ctx.interactiveOnly || interactive) {
     const textContent = getDirectTextContent(node);
-    const line = formatElement(node, attrMap, indent, textContent, interactive);
+    const line = formatElement(node, attrMap, indent, textContent, interactive, customHints);
     const lineWithNewline = line + '\n';
 
     if (ctx.totalChars + lineWithNewline.length > ctx.maxOutputChars) {
@@ -442,7 +472,7 @@ function serializeNode(
       ctx.lines.push(separator);
       ctx.totalChars += separator.length;
     }
-    serializeNode(node.contentDocument, depth + 1, ctx);
+    serializeNode(node.contentDocument, depth + 1, ctx, `${path}/f`);
     return; // children are inside contentDocument
   }
 
@@ -468,8 +498,10 @@ function serializeNode(
 
       // Shadow root children at depth+2 (inside shadow root boundary)
       if (shadowRoot.children) {
+        const shadowPath = `${path}/s:${node.shadowRoots.indexOf(shadowRoot)}`;
+        const childPaths = createChildPathMap(shadowRoot.children, shadowPath);
         for (const child of shadowRoot.children) {
-          serializeNode(child, depth + 2, ctx);
+          serializeNode(child, depth + 2, ctx, childPaths.get(child) ?? shadowPath);
           if (ctx.truncated) return;
         }
       }
@@ -478,6 +510,7 @@ function serializeNode(
 
   // Recurse into children
   if (node.children && ctx.compression !== 'none') {
+    const childPaths = createChildPathMap(node.children, path);
     const groups = groupConsecutiveSiblings(node.children);
     const threshold = ctx.compression === 'aggressive'
       ? SIBLING_COLLAPSE_THRESHOLD_AGGRESSIVE
@@ -488,13 +521,13 @@ function serializeNode(
 
       // Skip dedup for groups containing interactive elements to avoid
       // hiding clickable buttons/links/inputs from the LLM
-      const groupHasInteractive = group.nodes.some(n => containsInteractive(n));
+      const groupHasInteractive = group.nodes.some(n => containsInteractive(n, childPaths.get(n) ?? path, ctx));
 
       if (group.nodes.length >= threshold && !groupHasInteractive) {
         // Emit first SIBLING_SAMPLE_COUNT with full detail
         const samples = group.nodes.slice(0, SIBLING_SAMPLE_COUNT);
         for (const sampleNode of samples) {
-          serializeNode(sampleNode, depth + 1, ctx);
+          serializeNode(sampleNode, depth + 1, ctx, childPaths.get(sampleNode) ?? path);
           if (ctx.truncated) return;
         }
 
@@ -517,12 +550,12 @@ function serializeNode(
         // Emit last node if not already shown
         if (group.nodes.length > SIBLING_SAMPLE_COUNT) {
           const lastNode = group.nodes[group.nodes.length - 1];
-          serializeNode(lastNode, depth + 1, ctx);
+          serializeNode(lastNode, depth + 1, ctx, childPaths.get(lastNode) ?? path);
         }
       } else {
         // Small group — emit all normally
         for (const groupNode of group.nodes) {
-          serializeNode(groupNode, depth + 1, ctx);
+          serializeNode(groupNode, depth + 1, ctx, childPaths.get(groupNode) ?? path);
           if (ctx.truncated) return;
         }
       }
@@ -537,37 +570,39 @@ function serializeNode(
     }
   } else if (node.children) {
     // Original behavior when compression is 'none'
+    const childPaths = createChildPathMap(node.children, path);
     for (const child of node.children) {
-      serializeNode(child, depth + 1, ctx);
+      serializeNode(child, depth + 1, ctx, childPaths.get(child) ?? path);
       if (ctx.truncated) return;
     }
   }
 }
 
-async function markCursorInteractiveElements(page: Page): Promise<CursorInteractiveScanResult> {
+async function scanCustomInteractiveElements(page: Page, pierceIframes: boolean): Promise<CursorInteractiveScanResult> {
   // Bound the browser-side scan from inside the evaluated function. Racing
-  // page.evaluate with a timeout does not abort the in-page work and can leave
-  // marker mutations running after cleanup; an in-page deadline/node cap exits
-  // cooperatively without orphaning background DOM changes.
-  return await page.evaluate((hintAttr: string, ownedAttr: string, maxMs: number, maxElements: number) => {
+  // page.evaluate with a timeout does not abort the in-page work.
+  return await page.evaluate((maxMs: number, maxElements: number, includeIframes: boolean) => {
       const interactiveRoles = new Set([
         'button', 'link', 'textbox', 'checkbox', 'radio', 'combobox', 'listbox',
         'menu', 'menuitem', 'tab', 'switch', 'slider',
       ]);
       const interactiveTags = new Set(['a', 'button', 'input', 'select', 'textarea', 'details', 'summary']);
-      const roots: Array<Document | ShadowRoot> = [document];
+      type RootEntry = { root: Document | ShadowRoot; path: string };
+      const roots: RootEntry[] = [{ root: document, path: 'd' }];
       const now = () => (typeof performance !== 'undefined' && typeof performance.now === 'function')
         ? performance.now()
         : Date.now();
       const deadline = now() + maxMs;
       let inspected = 0;
       let budgetExceeded = false;
-      let marked = 0;
+      const hintsByPath: Array<{ path: string; hints: string }> = [];
 
       for (let i = 0; i < roots.length; i++) {
-        const root = roots[i];
+        const { root, path: rootPath } = roots[i];
         const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
         let current = walker.nextNode();
+        const paths = new WeakMap<Node, string>();
+        const childIndexes = new WeakMap<Node, number>();
         while (current) {
           inspected += 1;
           if (inspected > maxElements || now() > deadline) {
@@ -576,7 +611,25 @@ async function markCursorInteractiveElements(page: Page): Promise<CursorInteract
           }
 
           const el = current as HTMLElement;
-          if (el.shadowRoot) roots.push(el.shadowRoot);
+          const parent = el.parentNode;
+          const siblingIndex = childIndexes.get(parent as Node) ?? 0;
+          childIndexes.set(parent as Node, siblingIndex + 1);
+          const parentPath = parent === root
+            ? rootPath
+            : (paths.get(parent as Node) ?? rootPath);
+          const path = `${parentPath}/c:${siblingIndex}`;
+          paths.set(el, path);
+
+          if (el.shadowRoot) roots.push({ root: el.shadowRoot, path: `${path}/s:0` });
+          if (includeIframes && el.tagName.toLowerCase() === 'iframe') {
+            try {
+              const frame = el as HTMLIFrameElement;
+              if (frame.contentDocument) roots.push({ root: frame.contentDocument, path: `${path}/f` });
+            } catch {
+              // Cross-origin frames are represented by CDP when possible; page
+              // script cannot inspect them, so custom hints are best-effort.
+            }
+          }
           current = walker.nextNode();
 
           if (el.closest('[hidden], [aria-hidden="true"]')) continue;
@@ -617,42 +670,13 @@ async function markCursorInteractiveElements(page: Page): Promise<CursorInteract
             }
           }
 
-          if (!el.hasAttribute(hintAttr)) {
-            el.setAttribute(hintAttr, hints.join(', '));
-            el.setAttribute(ownedAttr, 'true');
-            marked += 1;
-          }
+          hintsByPath.push({ path, hints: hints.join(', ') });
         }
         if (budgetExceeded) break;
       }
 
-      return { completed: !budgetExceeded, inspected, marked };
-    }, INTERACTIVE_HINT_ATTR, INTERACTIVE_HINT_OWNED_ATTR, INTERACTIVE_HINT_SCAN_MAX_MS, INTERACTIVE_HINT_SCAN_MAX_ELEMENTS);
-}
-
-async function clearCursorInteractiveMarkers(page: Page): Promise<void> {
-  try {
-    await withTimeout(
-      page.evaluate((hintAttr: string, ownedAttr: string) => {
-        const roots: Array<Document | ShadowRoot> = [document];
-        for (let i = 0; i < roots.length; i++) {
-          const root = roots[i];
-          const all = Array.from(root.querySelectorAll('*')) as HTMLElement[];
-          for (const el of all) {
-            if (el.shadowRoot) roots.push(el.shadowRoot);
-            if (el.getAttribute(ownedAttr) === 'true') {
-              el.removeAttribute(hintAttr);
-              el.removeAttribute(ownedAttr);
-            }
-          }
-        }
-      }, INTERACTIVE_HINT_ATTR, INTERACTIVE_HINT_OWNED_ATTR),
-      5000,
-      'serializeDOM:clearCursorInteractiveMarkers',
-    );
-  } catch {
-    // Best-effort cleanup only; a failed cleanup must not break read_page.
-  }
+      return { completed: !budgetExceeded, inspected, hints: hintsByPath };
+    }, INTERACTIVE_HINT_SCAN_MAX_MS, INTERACTIVE_HINT_SCAN_MAX_ELEMENTS, pierceIframes);
 }
 
 /**
@@ -697,19 +721,18 @@ export async function serializeDOM(
     'serializeDOM:pageStats',
   ) as PageStats;
 
+  let customInteractiveHints = new Map<string, string>();
   if (interactiveOnly) {
     try {
-      const scanResult = await markCursorInteractiveElements(page);
-      if (!scanResult.completed) {
-        await clearCursorInteractiveMarkers(page);
+      const scanResult = await scanCustomInteractiveElements(page, pierceIframes);
+      if (scanResult.completed) {
+        customInteractiveHints = new Map(scanResult.hints.map(({ path, hints }) => [path, hints]));
       }
     } catch {
       // Cursor/onclick hint discovery is opportunistic. Large or hostile pages
       // should still serialize using native tags and ARIA roles if this pre-scan
-      // times out or throws. If the scan threw after setting any owned markers,
-      // clear them before taking the CDP snapshot so reads degrade without
-      // partial custom hints.
-      await clearCursorInteractiveMarkers(page);
+      // times out or throws.
+      customInteractiveHints = new Map();
     }
   }
 
@@ -725,18 +748,11 @@ export async function serializeDOM(
   // fall back to an unbounded CDP fetch in that case so iframe body content
   // within maxDepth is not silently dropped.
   const documentDepth = maxDepth >= 0 && !pierceIframes ? maxDepth + 1 : -1;
-  let root: DOMNode;
-  try {
-    ({ root } = await cdpClient.send<{ root: DOMNode }>(
-      page,
-      'DOM.getDocument',
-      { depth: documentDepth, pierce: true },
-    ));
-  } finally {
-    if (interactiveOnly) {
-      await clearCursorInteractiveMarkers(page);
-    }
-  }
+  const { root } = await cdpClient.send<{ root: DOMNode }>(
+    page,
+    'DOM.getDocument',
+    { depth: documentDepth, pierce: true },
+  );
 
   const ctx: SerializeContext = {
     lines: [],
@@ -750,6 +766,7 @@ export async function serializeDOM(
     includeUserAgentShadowDOM,
     nodesVisited: 0,
     maxNodes: DEFAULT_MAX_SERIALIZER_NODES,
+    customInteractiveHints,
     emittedBackendNodeIds: new Set<number>(),
   };
 

--- a/src/dom/dom-serializer.ts
+++ b/src/dom/dom-serializer.ts
@@ -92,6 +92,8 @@ const CONTAINER_TAGS = new Set([
   'div', 'section', 'article', 'main', 'aside', 'header', 'footer', 'nav', 'span',
 ]);
 
+const INTERACTIVE_HINT_ATTR = 'data-oc-interactive-hints';
+
 /**
  * Parse flat attributes array into a map
  */
@@ -116,6 +118,7 @@ function escapeAttributeValue(value: string): string {
  * Check if a node is interactive
  */
 function isInteractive(tagName: string, attrMap: Map<string, string>): boolean {
+  if (attrMap.has(INTERACTIVE_HINT_ATTR)) return true;
   if (INTERACTIVE_TAGS.has(tagName)) return true;
   const role = attrMap.get('role');
   if (role && INTERACTIVE_ROLES.has(role)) return true;
@@ -176,7 +179,10 @@ function formatElement(
   }
   const attrStr = attrParts.length > 0 ? ' ' + attrParts.join(' ') : '';
 
-  const interactiveMarker = interactive ? ' ★' : '';
+  const hints = attrMap.get(INTERACTIVE_HINT_ATTR);
+  const interactiveMarker = interactive
+    ? ` ★${hints ? ` [${hints}]` : ''}`
+    : '';
   const line = `${indent}[${node.backendNodeId}]<${tagName}${attrStr}/>${textContent}${interactiveMarker}`;
   return line;
 }
@@ -529,6 +535,90 @@ function serializeNode(
   }
 }
 
+async function markCursorInteractiveElements(page: Page): Promise<void> {
+  await withTimeout(
+    page.evaluate((hintAttr: string) => {
+      const interactiveRoles = new Set([
+        'button', 'link', 'textbox', 'checkbox', 'radio', 'combobox', 'listbox',
+        'menu', 'menuitem', 'tab', 'switch', 'slider',
+      ]);
+      const interactiveTags = new Set(['a', 'button', 'input', 'select', 'textarea', 'details', 'summary']);
+      const roots: Array<Document | ShadowRoot> = [document];
+
+      for (let i = 0; i < roots.length; i++) {
+        const root = roots[i];
+        const all = Array.from(root.querySelectorAll('*')) as HTMLElement[];
+        for (const el of all) {
+          if (el.shadowRoot) roots.push(el.shadowRoot);
+          if (el.closest('[hidden], [aria-hidden="true"]')) continue;
+
+          const tag = el.tagName.toLowerCase();
+          if (interactiveTags.has(tag)) continue;
+          const role = el.getAttribute('role');
+          if (role && interactiveRoles.has(role.toLowerCase())) continue;
+
+          const style = getComputedStyle(el);
+          const hasCursorPointer = style.cursor === 'pointer';
+          const hasOnClick = el.hasAttribute('onclick') || typeof el.onclick === 'function';
+          const tabIndex = el.getAttribute('tabindex');
+          const hasTabIndex = tabIndex !== null && tabIndex !== '-1';
+          const editable = el.getAttribute('contenteditable');
+          const isEditable = editable === '' || editable === 'true';
+
+          if (!hasCursorPointer && !hasOnClick && !hasTabIndex && !isEditable) continue;
+          if (hasCursorPointer && !hasOnClick && !hasTabIndex && !isEditable) {
+            const parent = el.parentElement;
+            if (parent && getComputedStyle(parent).cursor === 'pointer') continue;
+          }
+          const rect = el.getBoundingClientRect();
+          if (rect.width === 0 || rect.height === 0) continue;
+
+          const hints: string[] = [];
+          if (hasCursorPointer) hints.push('cursor:pointer');
+          if (hasOnClick) hints.push('onclick');
+          if (hasTabIndex) hints.push('tabindex');
+          if (isEditable) hints.push('contenteditable');
+
+          const hiddenInput = el.querySelector('input[type="radio"], input[type="checkbox"]') as HTMLInputElement | null;
+          if (hiddenInput) {
+            const inputStyle = getComputedStyle(hiddenInput);
+            const hidden = inputStyle.display === 'none' || inputStyle.visibility === 'hidden' || hiddenInput.hidden;
+            if (hidden) {
+              hints.push(`${hiddenInput.type}:${hiddenInput.indeterminate ? 'mixed' : String(hiddenInput.checked)}`);
+            }
+          }
+
+          el.setAttribute(hintAttr, hints.join(', '));
+        }
+      }
+    }, INTERACTIVE_HINT_ATTR),
+    5000,
+    'serializeDOM:markCursorInteractiveElements',
+  );
+}
+
+async function clearCursorInteractiveMarkers(page: Page): Promise<void> {
+  try {
+    await withTimeout(
+      page.evaluate((hintAttr: string) => {
+        const roots: Array<Document | ShadowRoot> = [document];
+        for (let i = 0; i < roots.length; i++) {
+          const root = roots[i];
+          const all = Array.from(root.querySelectorAll('*')) as HTMLElement[];
+          for (const el of all) {
+            if (el.shadowRoot) roots.push(el.shadowRoot);
+            if (el.hasAttribute(hintAttr)) el.removeAttribute(hintAttr);
+          }
+        }
+      }, INTERACTIVE_HINT_ATTR),
+      5000,
+      'serializeDOM:clearCursorInteractiveMarkers',
+    );
+  } catch {
+    // Best-effort cleanup only; a failed cleanup must not break read_page.
+  }
+}
+
 /**
  * Serialize a page's DOM into a compact text representation
  */
@@ -571,6 +661,10 @@ export async function serializeDOM(
     'serializeDOM:pageStats',
   ) as PageStats;
 
+  if (interactiveOnly) {
+    await markCursorInteractiveElements(page);
+  }
+
   // Get DOM tree via CDP. Always pierce at the CDP layer so shadowRoots are
   // present; ctx.pierceIframes below controls whether iframe contentDocument
   // subtrees are emitted. When callers request bounded output depth, avoid
@@ -583,11 +677,18 @@ export async function serializeDOM(
   // fall back to an unbounded CDP fetch in that case so iframe body content
   // within maxDepth is not silently dropped.
   const documentDepth = maxDepth >= 0 && !pierceIframes ? maxDepth + 1 : -1;
-  const { root } = await cdpClient.send<{ root: DOMNode }>(
-    page,
-    'DOM.getDocument',
-    { depth: documentDepth, pierce: true },
-  );
+  let root: DOMNode;
+  try {
+    ({ root } = await cdpClient.send<{ root: DOMNode }>(
+      page,
+      'DOM.getDocument',
+      { depth: documentDepth, pierce: true },
+    ));
+  } finally {
+    if (interactiveOnly) {
+      await clearCursorInteractiveMarkers(page);
+    }
+  }
 
   const ctx: SerializeContext = {
     lines: [],

--- a/src/dom/dom-serializer.ts
+++ b/src/dom/dom-serializer.ts
@@ -588,7 +588,10 @@ async function markCursorInteractiveElements(page: Page): Promise<void> {
             }
           }
 
-          el.setAttribute(hintAttr, hints.join(', '));
+          if (!el.hasAttribute(hintAttr)) {
+            el.setAttribute(hintAttr, hints.join(', '));
+            el.setAttribute(`${hintAttr}-owned`, 'true');
+          }
         }
       }
     }, INTERACTIVE_HINT_ATTR),
@@ -607,7 +610,10 @@ async function clearCursorInteractiveMarkers(page: Page): Promise<void> {
           const all = Array.from(root.querySelectorAll('*')) as HTMLElement[];
           for (const el of all) {
             if (el.shadowRoot) roots.push(el.shadowRoot);
-            if (el.hasAttribute(hintAttr)) el.removeAttribute(hintAttr);
+            if (el.getAttribute(`${hintAttr}-owned`) === 'true') {
+              el.removeAttribute(hintAttr);
+              el.removeAttribute(`${hintAttr}-owned`);
+            }
           }
         }
       }, INTERACTIVE_HINT_ATTR),
@@ -662,7 +668,13 @@ export async function serializeDOM(
   ) as PageStats;
 
   if (interactiveOnly) {
-    await markCursorInteractiveElements(page);
+    try {
+      await markCursorInteractiveElements(page);
+    } catch {
+      // Cursor/onclick hint discovery is opportunistic. Large or hostile pages
+      // should still serialize using native tags and ARIA roles if this pre-scan
+      // times out or throws.
+    }
   }
 
   // Get DOM tree via CDP. Always pierce at the CDP layer so shadowRoots are

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,7 @@ program
       await new Promise<void>((resolve) => {
         process.stdout.write(JSON.stringify(manifest.tools) + '\n', () => resolve());
       });
+      });
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,6 @@ program
       await new Promise<void>((resolve) => {
         process.stdout.write(JSON.stringify(manifest.tools) + '\n', () => resolve());
       });
-      });
       return;
     }
 

--- a/tests/dom/dom-serializer-cursor-budget.test.ts
+++ b/tests/dom/dom-serializer-cursor-budget.test.ts
@@ -3,7 +3,12 @@
 import { serializeDOM } from '../../src/dom/dom-serializer';
 
 function createMockElement(overrides: Record<string, unknown> = {}) {
-  return {
+  const initialAttributes = new Map<string, string>(Object.entries(
+    (overrides.attributes as Record<string, string> | undefined) ?? {},
+  ));
+  const element: any = {
+    attributes: initialAttributes,
+    removedAttributes: [] as string[],
     tagName: 'DIV',
     shadowRoot: null,
     onclick: null,
@@ -11,13 +16,19 @@ function createMockElement(overrides: Record<string, unknown> = {}) {
     isContentEditable: false,
     computedStyle: { cursor: 'default', display: 'block', visibility: 'visible' },
     closest: jest.fn(() => null),
-    getAttribute: jest.fn(() => null),
-    hasAttribute: jest.fn(() => false),
-    setAttribute: jest.fn(),
+    getAttribute: jest.fn((name: string) => initialAttributes.get(name) ?? null),
+    hasAttribute: jest.fn((name: string) => initialAttributes.has(name)),
+    setAttribute: jest.fn((name: string, value: string) => { initialAttributes.set(name, value); }),
+    removeAttribute: jest.fn((name: string) => {
+      initialAttributes.delete(name);
+      element.removedAttributes.push(name);
+    }),
     querySelector: jest.fn(() => null),
     getBoundingClientRect: jest.fn(() => ({ width: 10, height: 10 })),
     ...overrides,
   };
+  element.attributes = initialAttributes;
+  return element;
 }
 
 async function withMockTreeWalker(elements: any[], run: () => void | Promise<void>) {
@@ -34,6 +45,7 @@ async function withMockTreeWalker(elements: any[], run: () => void | Promise<voi
         nextNode: () => nodes[++index] ?? null,
       };
     },
+    querySelectorAll: () => elements,
     nodes: elements,
   };
   (global as any).NodeFilter = { SHOW_ELEMENT: 1 };
@@ -45,13 +57,37 @@ async function withMockTreeWalker(elements: any[], run: () => void | Promise<voi
   });
 
   try {
-    await run();
+    return await run();
   } finally {
     (global as any).document = previousDocument;
     (global as any).NodeFilter = previousNodeFilter;
     (global as any).performance = previousPerformance;
     (global as any).getComputedStyle = previousGetComputedStyle;
   }
+}
+
+function createStats() {
+  return {
+    url: 'https://example.com',
+    title: 'Test Page',
+    scrollX: 0,
+    scrollY: 0,
+    scrollWidth: 1920,
+    scrollHeight: 3000,
+    viewportWidth: 1920,
+    viewportHeight: 1080,
+  };
+}
+
+function createDoc(children: any[]) {
+  return {
+    nodeId: 1, backendNodeId: 1, nodeType: 9, nodeName: '#document', localName: '',
+    children: [{
+      nodeId: 2, backendNodeId: 2, nodeType: 1, nodeName: 'BODY', localName: 'body',
+      attributes: [],
+      children,
+    }],
+  };
 }
 
 describe('DOM serializer cursor hint scan budget', () => {
@@ -70,16 +106,7 @@ describe('DOM serializer cursor hint scan budget', () => {
     };
     const page = {
       evaluate: jest.fn()
-        .mockResolvedValueOnce({
-          url: 'https://example.com',
-          title: 'Test Page',
-          scrollX: 0,
-          scrollY: 0,
-          scrollWidth: 1920,
-          scrollHeight: 3000,
-          viewportWidth: 1920,
-          viewportHeight: 1080,
-        })
+        .mockResolvedValueOnce(createStats())
         .mockImplementationOnce(async (
           fn: Function,
           hintAttr: string,
@@ -97,8 +124,14 @@ describe('DOM serializer cursor hint scan budget', () => {
           expect(elements[maxElements - 1].setAttribute).toHaveBeenCalledWith(hintAttr, 'cursor:pointer');
           expect(elements[maxElements - 1].setAttribute).toHaveBeenCalledWith(ownedAttr, 'true');
           expect(skippedElement.setAttribute).not.toHaveBeenCalled();
+          return { completed: false, inspected: maxElements + 1, marked: maxElements };
         })
-        .mockResolvedValueOnce(undefined),
+        .mockImplementationOnce(async (fn: Function, hintAttr: string, ownedAttr: string) => {
+          await withMockTreeWalker([], () => fn(hintAttr, ownedAttr));
+        })
+        .mockImplementationOnce(async (fn: Function, hintAttr: string, ownedAttr: string) => {
+          await withMockTreeWalker([], () => fn(hintAttr, ownedAttr));
+        }),
     };
     const cdpClient = {
       send: jest.fn().mockResolvedValue({ root: nativeInteractiveDoc }),
@@ -108,5 +141,139 @@ describe('DOM serializer cursor hint scan budget', () => {
 
     expect(result.content).toContain('[930]<button/> ★');
     expect(cdpClient.send).toHaveBeenCalledWith(page, 'DOM.getDocument', { depth: -1, pierce: true });
+  });
+
+  it('falls back without custom hints and removes owned markers when the scan budget is exceeded', async () => {
+    let cursorElement: any;
+    const page = {
+      evaluate: jest.fn()
+        .mockResolvedValueOnce(createStats())
+        .mockImplementationOnce(async (
+          fn: Function,
+          hintAttr: string,
+          ownedAttr: string,
+          maxMs: number,
+          maxElements: number,
+        ) => {
+          cursorElement = createMockElement({
+            computedStyle: { cursor: 'pointer', display: 'block', visibility: 'visible' },
+          });
+          const elements = [
+            cursorElement,
+            ...Array.from({ length: maxElements }, () => createMockElement()),
+          ];
+          return await withMockTreeWalker(elements, () => fn(hintAttr, ownedAttr, maxMs, maxElements));
+        })
+        .mockImplementationOnce(async (fn: Function, hintAttr: string, ownedAttr: string) => {
+          await withMockTreeWalker([cursorElement], () => fn(hintAttr, ownedAttr));
+        })
+        .mockImplementationOnce(async (fn: Function, hintAttr: string, ownedAttr: string) => {
+          await withMockTreeWalker([cursorElement], () => fn(hintAttr, ownedAttr));
+        }),
+    };
+    const cdpClient = {
+      send: jest.fn().mockImplementation(async () => {
+        expect(cursorElement.getAttribute('data-oc-interactive-hints')).toBeNull();
+        expect(cursorElement.getAttribute('data-oc-interactive-hints-owned')).toBeNull();
+        return {
+          root: createDoc([
+            {
+              nodeId: 3, backendNodeId: 940, nodeType: 1, nodeName: 'DIV', localName: 'div',
+              attributes: [],
+              children: [],
+            },
+            {
+              nodeId: 4, backendNodeId: 941, nodeType: 1, nodeName: 'BUTTON', localName: 'button',
+              attributes: [],
+              children: [],
+            },
+          ]),
+        };
+      }),
+    };
+
+    const result = await serializeDOM(page as never, cdpClient as never, { includePageStats: false, interactiveOnly: true });
+
+    expect(result.content).not.toContain('[940]');
+    expect(result.content).toContain('[941]<button/> ★');
+    expect(cursorElement.removeAttribute).toHaveBeenCalledWith('data-oc-interactive-hints');
+    expect(cursorElement.removeAttribute).toHaveBeenCalledWith('data-oc-interactive-hints-owned');
+    expect(cursorElement.getAttribute('data-oc-interactive-hints')).toBeNull();
+    expect(cursorElement.getAttribute('data-oc-interactive-hints-owned')).toBeNull();
+  });
+
+  it('preserves pre-existing interactive hint attributes during cleanup', async () => {
+    const existingElement = createMockElement({
+      attributes: { 'data-oc-interactive-hints': 'existing' },
+      computedStyle: { cursor: 'pointer', display: 'block', visibility: 'visible' },
+    });
+    const page = {
+      evaluate: jest.fn()
+        .mockResolvedValueOnce(createStats())
+        .mockImplementationOnce(async (
+          fn: Function,
+          hintAttr: string,
+          ownedAttr: string,
+          maxMs: number,
+          maxElements: number,
+        ) => await withMockTreeWalker([existingElement], () => fn(hintAttr, ownedAttr, maxMs, maxElements)))
+        .mockImplementationOnce(async (fn: Function, hintAttr: string, ownedAttr: string) => {
+          await withMockTreeWalker([existingElement], () => fn(hintAttr, ownedAttr));
+        }),
+    };
+    const cdpClient = {
+      send: jest.fn().mockResolvedValue({
+        root: createDoc([{
+          nodeId: 3, backendNodeId: 950, nodeType: 1, nodeName: 'DIV', localName: 'div',
+          attributes: ['data-oc-interactive-hints', 'existing'],
+          children: [],
+        }]),
+      }),
+    };
+
+    const result = await serializeDOM(page as never, cdpClient as never, { includePageStats: false, interactiveOnly: true });
+
+    expect(result.content).toContain('[950]<div/> ★ [existing]');
+    expect(existingElement.setAttribute).not.toHaveBeenCalledWith('data-oc-interactive-hints', expect.any(String));
+    expect(existingElement.getAttribute('data-oc-interactive-hints')).toBe('existing');
+    expect(existingElement.removeAttribute).not.toHaveBeenCalled();
+  });
+
+  it('includes regular cursor custom controls when the scan completes', async () => {
+    const cursorElement = createMockElement({
+      computedStyle: { cursor: 'pointer', display: 'block', visibility: 'visible' },
+    });
+    const page = {
+      evaluate: jest.fn()
+        .mockResolvedValueOnce(createStats())
+        .mockImplementationOnce(async (
+          fn: Function,
+          hintAttr: string,
+          ownedAttr: string,
+          maxMs: number,
+          maxElements: number,
+        ) => await withMockTreeWalker([cursorElement], () => fn(hintAttr, ownedAttr, maxMs, maxElements)))
+        .mockImplementationOnce(async (fn: Function, hintAttr: string, ownedAttr: string) => {
+          await withMockTreeWalker([cursorElement], () => fn(hintAttr, ownedAttr));
+        }),
+    };
+    const cdpClient = {
+      send: jest.fn().mockImplementation(async () => ({
+        root: createDoc([{
+          nodeId: 3, backendNodeId: 960, nodeType: 1, nodeName: 'DIV', localName: 'div',
+          attributes: ['data-oc-interactive-hints', cursorElement.getAttribute('data-oc-interactive-hints')],
+          children: [{
+            nodeId: 4, backendNodeId: 4, nodeType: 3, nodeName: '#text', localName: '',
+            nodeValue: 'Open menu',
+          }],
+        }]),
+      })),
+    };
+
+    const result = await serializeDOM(page as never, cdpClient as never, { includePageStats: false, interactiveOnly: true });
+
+    expect(result.content).toContain('[960]<div/>Open menu ★ [cursor:pointer]');
+    expect(cursorElement.getAttribute('data-oc-interactive-hints')).toBeNull();
+    expect(cursorElement.getAttribute('data-oc-interactive-hints-owned')).toBeNull();
   });
 });

--- a/tests/dom/dom-serializer-cursor-budget.test.ts
+++ b/tests/dom/dom-serializer-cursor-budget.test.ts
@@ -1,0 +1,112 @@
+/// <reference types="jest" />
+
+import { serializeDOM } from '../../src/dom/dom-serializer';
+
+function createMockElement(overrides: Record<string, unknown> = {}) {
+  return {
+    tagName: 'DIV',
+    shadowRoot: null,
+    onclick: null,
+    parentElement: null,
+    isContentEditable: false,
+    computedStyle: { cursor: 'default', display: 'block', visibility: 'visible' },
+    closest: jest.fn(() => null),
+    getAttribute: jest.fn(() => null),
+    hasAttribute: jest.fn(() => false),
+    setAttribute: jest.fn(),
+    querySelector: jest.fn(() => null),
+    getBoundingClientRect: jest.fn(() => ({ width: 10, height: 10 })),
+    ...overrides,
+  };
+}
+
+async function withMockTreeWalker(elements: any[], run: () => void | Promise<void>) {
+  const previousDocument = (global as any).document;
+  const previousNodeFilter = (global as any).NodeFilter;
+  const previousPerformance = (global as any).performance;
+  const previousGetComputedStyle = (global as any).getComputedStyle;
+
+  (global as any).document = {
+    createTreeWalker: (root: { nodes?: any[] }) => {
+      const nodes = root.nodes ?? [];
+      let index = -1;
+      return {
+        nextNode: () => nodes[++index] ?? null,
+      };
+    },
+    nodes: elements,
+  };
+  (global as any).NodeFilter = { SHOW_ELEMENT: 1 };
+  (global as any).performance = { now: jest.fn(() => 0) };
+  (global as any).getComputedStyle = jest.fn((el: any) => el.computedStyle ?? {
+    cursor: 'default',
+    display: 'block',
+    visibility: 'visible',
+  });
+
+  try {
+    await run();
+  } finally {
+    (global as any).document = previousDocument;
+    (global as any).NodeFilter = previousNodeFilter;
+    (global as any).performance = previousPerformance;
+    (global as any).getComputedStyle = previousGetComputedStyle;
+  }
+}
+
+describe('DOM serializer cursor hint scan budget', () => {
+  it('stops cursor hint discovery at the node cap and keeps native interactive fallback', async () => {
+    const nativeInteractiveDoc = {
+      nodeId: 1, backendNodeId: 1, nodeType: 9, nodeName: '#document', localName: '',
+      children: [{
+        nodeId: 2, backendNodeId: 2, nodeType: 1, nodeName: 'BODY', localName: 'body',
+        attributes: [],
+        children: [{
+          nodeId: 3, backendNodeId: 930, nodeType: 1, nodeName: 'BUTTON', localName: 'button',
+          attributes: [],
+          children: [],
+        }],
+      }],
+    };
+    const page = {
+      evaluate: jest.fn()
+        .mockResolvedValueOnce({
+          url: 'https://example.com',
+          title: 'Test Page',
+          scrollX: 0,
+          scrollY: 0,
+          scrollWidth: 1920,
+          scrollHeight: 3000,
+          viewportWidth: 1920,
+          viewportHeight: 1080,
+        })
+        .mockImplementationOnce(async (
+          fn: Function,
+          hintAttr: string,
+          ownedAttr: string,
+          maxMs: number,
+          maxElements: number,
+        ) => {
+          const elements = Array.from({ length: maxElements + 5 }, () => createMockElement({
+            computedStyle: { cursor: 'pointer', display: 'block', visibility: 'visible' },
+          }));
+          const skippedElement = elements[maxElements];
+
+          await withMockTreeWalker(elements, () => fn(hintAttr, ownedAttr, maxMs, maxElements));
+
+          expect(elements[maxElements - 1].setAttribute).toHaveBeenCalledWith(hintAttr, 'cursor:pointer');
+          expect(elements[maxElements - 1].setAttribute).toHaveBeenCalledWith(ownedAttr, 'true');
+          expect(skippedElement.setAttribute).not.toHaveBeenCalled();
+        })
+        .mockResolvedValueOnce(undefined),
+    };
+    const cdpClient = {
+      send: jest.fn().mockResolvedValue({ root: nativeInteractiveDoc }),
+    };
+
+    const result = await serializeDOM(page as never, cdpClient as never, { interactiveOnly: true });
+
+    expect(result.content).toContain('[930]<button/> ★');
+    expect(cdpClient.send).toHaveBeenCalledWith(page, 'DOM.getDocument', { depth: -1, pierce: true });
+  });
+});

--- a/tests/dom/dom-serializer-cursor-budget.test.ts
+++ b/tests/dom/dom-serializer-cursor-budget.test.ts
@@ -37,6 +37,11 @@ async function withMockTreeWalker(elements: any[], run: () => void | Promise<voi
   const previousPerformance = (global as any).performance;
   const previousGetComputedStyle = (global as any).getComputedStyle;
 
+  const documentRoot: any = { nodes: elements };
+  for (const element of elements) {
+    if (!element.parentNode) element.parentNode = documentRoot;
+  }
+
   (global as any).document = {
     createTreeWalker: (root: { nodes?: any[] }) => {
       const nodes = root.nodes ?? [];
@@ -109,28 +114,17 @@ describe('DOM serializer cursor hint scan budget', () => {
         .mockResolvedValueOnce(createStats())
         .mockImplementationOnce(async (
           fn: Function,
-          hintAttr: string,
-          ownedAttr: string,
           maxMs: number,
           maxElements: number,
+          includeIframes: boolean,
         ) => {
           const elements = Array.from({ length: maxElements + 5 }, () => createMockElement({
             computedStyle: { cursor: 'pointer', display: 'block', visibility: 'visible' },
           }));
-          const skippedElement = elements[maxElements];
-
-          await withMockTreeWalker(elements, () => fn(hintAttr, ownedAttr, maxMs, maxElements));
-
-          expect(elements[maxElements - 1].setAttribute).toHaveBeenCalledWith(hintAttr, 'cursor:pointer');
-          expect(elements[maxElements - 1].setAttribute).toHaveBeenCalledWith(ownedAttr, 'true');
-          expect(skippedElement.setAttribute).not.toHaveBeenCalled();
-          return { completed: false, inspected: maxElements + 1, marked: maxElements };
-        })
-        .mockImplementationOnce(async (fn: Function, hintAttr: string, ownedAttr: string) => {
-          await withMockTreeWalker([], () => fn(hintAttr, ownedAttr));
-        })
-        .mockImplementationOnce(async (fn: Function, hintAttr: string, ownedAttr: string) => {
-          await withMockTreeWalker([], () => fn(hintAttr, ownedAttr));
+          const result = await withMockTreeWalker(elements, () => fn(maxMs, maxElements, includeIframes));
+          expect(elements[maxElements - 1].setAttribute).not.toHaveBeenCalled();
+          expect(elements[maxElements].setAttribute).not.toHaveBeenCalled();
+          return result;
         }),
     };
     const cdpClient = {
@@ -143,17 +137,16 @@ describe('DOM serializer cursor hint scan budget', () => {
     expect(cdpClient.send).toHaveBeenCalledWith(page, 'DOM.getDocument', { depth: -1, pierce: true });
   });
 
-  it('falls back without custom hints and removes owned markers when the scan budget is exceeded', async () => {
+  it('falls back without custom hints and leaves the page untouched when the scan budget is exceeded', async () => {
     let cursorElement: any;
     const page = {
       evaluate: jest.fn()
         .mockResolvedValueOnce(createStats())
         .mockImplementationOnce(async (
           fn: Function,
-          hintAttr: string,
-          ownedAttr: string,
           maxMs: number,
           maxElements: number,
+          includeIframes: boolean,
         ) => {
           cursorElement = createMockElement({
             computedStyle: { cursor: 'pointer', display: 'block', visibility: 'visible' },
@@ -162,19 +155,13 @@ describe('DOM serializer cursor hint scan budget', () => {
             cursorElement,
             ...Array.from({ length: maxElements }, () => createMockElement()),
           ];
-          return await withMockTreeWalker(elements, () => fn(hintAttr, ownedAttr, maxMs, maxElements));
-        })
-        .mockImplementationOnce(async (fn: Function, hintAttr: string, ownedAttr: string) => {
-          await withMockTreeWalker([cursorElement], () => fn(hintAttr, ownedAttr));
-        })
-        .mockImplementationOnce(async (fn: Function, hintAttr: string, ownedAttr: string) => {
-          await withMockTreeWalker([cursorElement], () => fn(hintAttr, ownedAttr));
+          return await withMockTreeWalker(elements, () => fn(maxMs, maxElements, includeIframes));
         }),
     };
     const cdpClient = {
       send: jest.fn().mockImplementation(async () => {
-        expect(cursorElement.getAttribute('data-oc-interactive-hints')).toBeNull();
-        expect(cursorElement.getAttribute('data-oc-interactive-hints-owned')).toBeNull();
+        expect(cursorElement.setAttribute).not.toHaveBeenCalled();
+        expect(cursorElement.removeAttribute).not.toHaveBeenCalled();
         return {
           root: createDoc([
             {
@@ -196,30 +183,24 @@ describe('DOM serializer cursor hint scan budget', () => {
 
     expect(result.content).not.toContain('[940]');
     expect(result.content).toContain('[941]<button/> ★');
-    expect(cursorElement.removeAttribute).toHaveBeenCalledWith('data-oc-interactive-hints');
-    expect(cursorElement.removeAttribute).toHaveBeenCalledWith('data-oc-interactive-hints-owned');
-    expect(cursorElement.getAttribute('data-oc-interactive-hints')).toBeNull();
-    expect(cursorElement.getAttribute('data-oc-interactive-hints-owned')).toBeNull();
+    expect(cursorElement.setAttribute).not.toHaveBeenCalled();
+    expect(cursorElement.removeAttribute).not.toHaveBeenCalled();
   });
 
-  it('preserves pre-existing interactive hint attributes during cleanup', async () => {
+  it('ignores pre-existing page-authored interactive hint attributes', async () => {
     const existingElement = createMockElement({
       attributes: { 'data-oc-interactive-hints': 'existing' },
-      computedStyle: { cursor: 'pointer', display: 'block', visibility: 'visible' },
+      computedStyle: { cursor: 'default', display: 'block', visibility: 'visible' },
     });
     const page = {
       evaluate: jest.fn()
         .mockResolvedValueOnce(createStats())
         .mockImplementationOnce(async (
           fn: Function,
-          hintAttr: string,
-          ownedAttr: string,
           maxMs: number,
           maxElements: number,
-        ) => await withMockTreeWalker([existingElement], () => fn(hintAttr, ownedAttr, maxMs, maxElements)))
-        .mockImplementationOnce(async (fn: Function, hintAttr: string, ownedAttr: string) => {
-          await withMockTreeWalker([existingElement], () => fn(hintAttr, ownedAttr));
-        }),
+          includeIframes: boolean,
+        ) => await withMockTreeWalker([existingElement], () => fn(maxMs, maxElements, includeIframes))),
     };
     const cdpClient = {
       send: jest.fn().mockResolvedValue({
@@ -233,9 +214,9 @@ describe('DOM serializer cursor hint scan budget', () => {
 
     const result = await serializeDOM(page as never, cdpClient as never, { includePageStats: false, interactiveOnly: true });
 
-    expect(result.content).toContain('[950]<div/> ★ [existing]');
-    expect(existingElement.setAttribute).not.toHaveBeenCalledWith('data-oc-interactive-hints', expect.any(String));
-    expect(existingElement.getAttribute('data-oc-interactive-hints')).toBe('existing');
+    expect(result.content).not.toContain('[950]');
+    expect(result.content).not.toContain('existing');
+    expect(existingElement.setAttribute).not.toHaveBeenCalled();
     expect(existingElement.removeAttribute).not.toHaveBeenCalled();
   });
 
@@ -246,22 +227,13 @@ describe('DOM serializer cursor hint scan budget', () => {
     const page = {
       evaluate: jest.fn()
         .mockResolvedValueOnce(createStats())
-        .mockImplementationOnce(async (
-          fn: Function,
-          hintAttr: string,
-          ownedAttr: string,
-          maxMs: number,
-          maxElements: number,
-        ) => await withMockTreeWalker([cursorElement], () => fn(hintAttr, ownedAttr, maxMs, maxElements)))
-        .mockImplementationOnce(async (fn: Function, hintAttr: string, ownedAttr: string) => {
-          await withMockTreeWalker([cursorElement], () => fn(hintAttr, ownedAttr));
-        }),
+        .mockResolvedValueOnce({ completed: true, inspected: 1, hints: [{ path: 'd/c:0/c:0', hints: 'cursor:pointer' }] }),
     };
     const cdpClient = {
       send: jest.fn().mockImplementation(async () => ({
         root: createDoc([{
           nodeId: 3, backendNodeId: 960, nodeType: 1, nodeName: 'DIV', localName: 'div',
-          attributes: ['data-oc-interactive-hints', cursorElement.getAttribute('data-oc-interactive-hints')],
+          attributes: [],
           children: [{
             nodeId: 4, backendNodeId: 4, nodeType: 3, nodeName: '#text', localName: '',
             nodeValue: 'Open menu',
@@ -273,7 +245,7 @@ describe('DOM serializer cursor hint scan budget', () => {
     const result = await serializeDOM(page as never, cdpClient as never, { includePageStats: false, interactiveOnly: true });
 
     expect(result.content).toContain('[960]<div/>Open menu ★ [cursor:pointer]');
-    expect(cursorElement.getAttribute('data-oc-interactive-hints')).toBeNull();
-    expect(cursorElement.getAttribute('data-oc-interactive-hints-owned')).toBeNull();
+    expect(cursorElement.setAttribute).not.toHaveBeenCalled();
+    expect(cursorElement.removeAttribute).not.toHaveBeenCalled();
   });
 });

--- a/tests/dom/dom-serializer.test.ts
+++ b/tests/dom/dom-serializer.test.ts
@@ -884,4 +884,30 @@ describe('DOM Serializer', () => {
     expect(result.content).toEqual(expect.any(String));
     expect(cdpClient.send).toHaveBeenCalledWith(page, 'DOM.getDocument', { depth: -1, pierce: true });
   });
+
+  it('treats computed contenteditable controls as interactive hints', async () => {
+    const page = createMockPageForDOM();
+    const cdpClient = createMockCDPClientForDOM(simpleDoc);
+    page.evaluate = jest.fn()
+      .mockResolvedValueOnce({ nodeCount: 1, textLength: 4, truncated: false })
+      .mockImplementationOnce(async (fn: Function, hintAttr: string) => {
+        const el = {
+          tagName: 'DIV',
+          shadowRoot: null,
+          onclick: null,
+          isContentEditable: true,
+          getAttribute: (name: string) => name === 'contenteditable' ? 'plaintext-only' : null,
+          hasAttribute: () => false,
+          setAttribute: jest.fn(),
+        };
+        const root = { querySelectorAll: () => [el] };
+        const previousDocument = (global as any).document;
+        (global as any).document = root;
+        try { await fn(hintAttr); } finally { (global as any).document = previousDocument; }
+        expect(el.setAttribute).toHaveBeenCalledWith(hintAttr, 'editable');
+      })
+      .mockResolvedValueOnce(undefined);
+
+    await serializeDOM(page as never, cdpClient as never, { interactiveOnly: true });
+  });
 });

--- a/tests/dom/dom-serializer.test.ts
+++ b/tests/dom/dom-serializer.test.ts
@@ -870,4 +870,18 @@ describe('DOM Serializer', () => {
     expect(result.content).toMatch(/--page-separator--[\s\S]*\[12\]<body/);
     expect(result.content).not.toContain('id="iframe-content"');
   });
+
+  it('continues when cursor hint discovery fails', async () => {
+    const page = createMockPageForDOM();
+    const cdpClient = createMockCDPClientForDOM(simpleDoc);
+    page.evaluate = jest.fn()
+      .mockResolvedValueOnce({ nodeCount: 1, textLength: 4, truncated: false })
+      .mockRejectedValueOnce(new Error('hint scan failed'))
+      .mockResolvedValueOnce(undefined);
+
+    const result = await serializeDOM(page as never, cdpClient as never, { interactiveOnly: true });
+
+    expect(result.content).toEqual(expect.any(String));
+    expect(cdpClient.send).toHaveBeenCalledWith(page, 'DOM.getDocument', { depth: -1, pierce: true });
+  });
 });

--- a/tests/dom/dom-serializer.test.ts
+++ b/tests/dom/dom-serializer.test.ts
@@ -4,19 +4,23 @@ import { serializeDOM } from '../../src/dom/dom-serializer';
 
 // ─── Mock helpers ────────────────────────────────────────────────────────────
 
+function createStats(stats: Record<string, unknown> = {}) {
+  return {
+    url: 'https://example.com',
+    title: 'Test Page',
+    scrollX: 0,
+    scrollY: 0,
+    scrollWidth: 1920,
+    scrollHeight: 3000,
+    viewportWidth: 1920,
+    viewportHeight: 1080,
+    ...stats,
+  };
+}
+
 function createMockPageForDOM(stats: Record<string, unknown> = {}) {
   return {
-    evaluate: jest.fn().mockResolvedValue({
-      url: 'https://example.com',
-      title: 'Test Page',
-      scrollX: 0,
-      scrollY: 0,
-      scrollWidth: 1920,
-      scrollHeight: 3000,
-      viewportWidth: 1920,
-      viewportHeight: 1080,
-      ...stats,
-    }),
+    evaluate: jest.fn().mockResolvedValue(createStats(stats)),
   };
 }
 
@@ -448,7 +452,7 @@ describe('DOM Serializer', () => {
         children: [
           {
             nodeId: 3, backendNodeId: 910, nodeType: 1, nodeName: 'DIV', localName: 'div',
-            attributes: ['data-oc-interactive-hints', 'cursor:pointer, onclick', 'class', 'card'],
+            attributes: ['class', 'card'],
             children: [{
               nodeId: 4, backendNodeId: 4, nodeType: 3, nodeName: '#text', localName: '',
               nodeValue: 'Open settings',
@@ -463,7 +467,11 @@ describe('DOM Serializer', () => {
       }],
     };
 
-    const page = createMockPageForDOM();
+    const page = {
+      evaluate: jest.fn()
+        .mockResolvedValueOnce(createStats())
+        .mockResolvedValueOnce({ completed: true, inspected: 1, hints: [{ path: 'd/c:0/c:0', hints: 'cursor:pointer, onclick' }] }),
+    };
     const cdpClient = createMockCDPClientForDOM(customDoc);
 
     const result = await serializeDOM(page as never, cdpClient as never, { includePageStats: false, interactiveOnly: true });
@@ -473,6 +481,31 @@ describe('DOM Serializer', () => {
     expect(result.content).not.toContain('data-oc-interactive-hints');
   });
 
+  test('ignores page-authored interactive hint attributes without scan ownership', async () => {
+    const forgedDoc = {
+      nodeId: 1, backendNodeId: 1, nodeType: 9, nodeName: '#document', localName: '',
+      children: [{
+        nodeId: 2, backendNodeId: 2, nodeType: 1, nodeName: 'BODY', localName: 'body',
+        attributes: [],
+        children: [{
+          nodeId: 3, backendNodeId: 912, nodeType: 1, nodeName: 'DIV', localName: 'div',
+          attributes: ['data-oc-interactive-hints', 'cursor:pointer'],
+          children: [],
+        }],
+      }],
+    };
+    const page = {
+      evaluate: jest.fn()
+        .mockResolvedValueOnce(createStats())
+        .mockResolvedValueOnce({ completed: true, inspected: 1, hints: [] }),
+    };
+    const cdpClient = createMockCDPClientForDOM(forgedDoc);
+
+    const result = await serializeDOM(page as never, cdpClient as never, { includePageStats: false, interactiveOnly: true });
+
+    expect(result.content).not.toContain('[912]');
+    expect(result.content).not.toContain('data-oc-interactive-hints');
+  });
 
   // 8. Output truncation
   test('truncates output at maxOutputChars', async () => {

--- a/tests/dom/dom-serializer.test.ts
+++ b/tests/dom/dom-serializer.test.ts
@@ -439,6 +439,41 @@ describe('DOM Serializer', () => {
     expect(result.content).not.toContain('[902]');  // plain div
   });
 
+  test('includes cursor/onClick hints for custom interactive elements without leaking marker attrs', async () => {
+    const customDoc = {
+      nodeId: 1, backendNodeId: 1, nodeType: 9, nodeName: '#document', localName: '',
+      children: [{
+        nodeId: 2, backendNodeId: 2, nodeType: 1, nodeName: 'BODY', localName: 'body',
+        attributes: [],
+        children: [
+          {
+            nodeId: 3, backendNodeId: 910, nodeType: 1, nodeName: 'DIV', localName: 'div',
+            attributes: ['data-oc-interactive-hints', 'cursor:pointer, onclick', 'class', 'card'],
+            children: [{
+              nodeId: 4, backendNodeId: 4, nodeType: 3, nodeName: '#text', localName: '',
+              nodeValue: 'Open settings',
+            }],
+          },
+          {
+            nodeId: 5, backendNodeId: 911, nodeType: 1, nodeName: 'DIV', localName: 'div',
+            attributes: ['class', 'plain'],
+            children: [],
+          },
+        ],
+      }],
+    };
+
+    const page = createMockPageForDOM();
+    const cdpClient = createMockCDPClientForDOM(customDoc);
+
+    const result = await serializeDOM(page as never, cdpClient as never, { includePageStats: false, interactiveOnly: true });
+
+    expect(result.content).toContain('[910]<div class="card"/>Open settings ★ [cursor:pointer, onclick]');
+    expect(result.content).not.toContain('[911]');
+    expect(result.content).not.toContain('data-oc-interactive-hints');
+  });
+
+
   // 8. Output truncation
   test('truncates output at maxOutputChars', async () => {
     // Build a large DOM with many nodes


### PR DESCRIPTION
## Summary
- Extends DOM `read_page` interactive filtering to surface custom controls that are clickable but lack semantic tags/roles.
- Detects cursor-pointer, inline/JS onclick, valid tabindex, contenteditable, and hidden radio/checkbox state hints only when `interactiveOnly`/`filter: "interactive"` is active.
- Annotates discovered elements with compact reasons like `★ [cursor:pointer, onclick]` while keeping temporary marker attributes out of output and cleaning them after snapshot capture.

Closes #967

## Fit / non-overlap review
- Fits OpenChrome's browser-agent direction by improving action target discovery without adding a runtime dependency or changing default snapshots.
- Does not overlap with open PR #948 canonical snapshot refs, #929 snapshot cache, or #938 output handles; this PR only improves DOM serializer interactive discovery.
- Keeps the heuristic scoped to interactive reads to avoid token bloat on normal `read_page` calls.

## Tests
- `./node_modules/.bin/jest tests/dom/dom-serializer.test.ts --runInBand`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`

## OpenChrome real-validation checklist
After merge, validate with OpenChrome itself:
1. Navigate to a fixture/page containing `<div style="cursor:pointer" onclick="...">Open settings</div>` without `role` or `tabindex`.
2. Call `read_page` with `{ "mode": "dom", "filter": "interactive" }`.
3. Confirm the custom div appears with a star marker and hint text such as `[cursor:pointer, onclick]`.
4. Confirm a plain sibling div without interactive cues remains omitted.
5. Call default `read_page` without `filter: "interactive"`; confirm the output is not bloated with the discovery marker attribute.
