### PR TITLE
feat(harness): add opt-in auto snapshot policy foundation (#1013)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,7 @@ program
       await new Promise<void>((resolve) => {
         process.stdout.write(JSON.stringify(manifest.tools) + '\n', () => resolve());
       });
+      });
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,6 @@ program
       await new Promise<void>((resolve) => {
         process.stdout.write(JSON.stringify(manifest.tools) + '\n', () => resolve());
       });
-      });
       return;
     }
 

--- a/src/self-healing.ts
+++ b/src/self-healing.ts
@@ -16,3 +16,20 @@ export type { EventLoopMonitorOptions, BlockEvent } from './watchdog/event-loop-
 
 export { HealthEndpoint } from './watchdog/health-endpoint';
 export type { HealthData, HealthDataProvider } from './watchdog/health-endpoint';
+
+export {
+  buildAutoSnapshotArgs,
+  markAutoSnapshotRecorded,
+  normalizeAutoSnapshotPolicy,
+  redactSnapshotText,
+  shouldTakeAutoSnapshot,
+} from './session-snapshot-policy';
+export type {
+  AutoSnapshotPolicyConfig,
+  NormalizedAutoSnapshotPolicy,
+  SessionSnapshotArgs,
+  SnapshotDecision,
+  SnapshotMemoInput,
+  SnapshotPolicyState,
+  SnapshotTrigger,
+} from './session-snapshot-policy';

--- a/src/session-snapshot-policy.ts
+++ b/src/session-snapshot-policy.ts
@@ -1,0 +1,241 @@
+/**
+ * Automatic session snapshot policy.
+ *
+ * This module is intentionally side-effect free: workflow/task runners can use it
+ * to decide when to call `oc_session_snapshot` without changing ordinary MCP tool
+ * behavior. The policy is opt-in, bounded, and only constructs compact snapshot
+ * memo arguments — it never captures raw page content, screenshots, cookies, or
+ * credentials.
+ */
+
+export type SnapshotTrigger =
+  | 'start'
+  | 'retry'
+  | 'reconnect'
+  | 'final'
+  | 'tool-count'
+  | 'elapsed';
+
+export interface AutoSnapshotPolicyConfig {
+  /** Disabled by default; callers must opt in. */
+  enabled?: boolean;
+  /** Best-effort by default. Strict mode is for future workflow integrations. */
+  mode?: 'best-effort' | 'strict';
+  /** Create an interval snapshot every N tool calls. 0 disables count triggers. */
+  everyToolCalls?: number;
+  /** Create an interval snapshot every N milliseconds. 0 disables time triggers. */
+  everyMs?: number;
+  /** Retention hint for integrations; clamped to a safe positive range. */
+  maxSnapshots?: number;
+}
+
+export interface NormalizedAutoSnapshotPolicy {
+  enabled: boolean;
+  mode: 'best-effort' | 'strict';
+  everyToolCalls: number;
+  everyMs: number;
+  maxSnapshots: number;
+}
+
+export interface SnapshotPolicyState {
+  /** Number of tool calls since the last recorded snapshot. */
+  toolCallsSinceSnapshot?: number;
+  /** Wall-clock ms when the last snapshot was recorded. */
+  lastSnapshotAt?: number;
+  /** Current wall-clock ms. Defaults to Date.now(). */
+  now?: number;
+}
+
+export interface SnapshotDecision {
+  shouldSnapshot: boolean;
+  trigger: SnapshotTrigger | null;
+  mode: 'best-effort' | 'strict';
+  reason: string;
+}
+
+export interface SnapshotMemoInput {
+  objective: string;
+  currentStep: string;
+  nextActions: string[];
+  completedSteps?: string[];
+  notes?: string;
+  label?: string;
+}
+
+export interface SessionSnapshotArgs {
+  objective: string;
+  currentStep: string;
+  nextActions: string[];
+  completedSteps?: string[];
+  notes?: string;
+  label?: string;
+}
+
+const DEFAULT_MAX_SNAPSHOTS = 10;
+const MAX_MAX_SNAPSHOTS = 100;
+
+const SECRET_VALUE_PATTERNS: RegExp[] = [
+  /\b(authorization)\s*[:=]\s*bearer\s+([a-z0-9._~+/-]+=*)/gi,
+  /\b(bearer)\s+([a-z0-9._~+/-]+=*)/gi,
+  /\b(password|passwd|pwd)\s*[:=]\s*([^\s,;]+)/gi,
+  /\b(api[_-]?key|token|secret|authorization)\s*[:=]\s*([^\s,;]+)/gi,
+];
+
+/**
+ * Normalize external config into safe numeric bounds.
+ */
+export function normalizeAutoSnapshotPolicy(
+  config: AutoSnapshotPolicyConfig | undefined,
+): NormalizedAutoSnapshotPolicy {
+  return {
+    enabled: config?.enabled === true,
+    mode: config?.mode === 'strict' ? 'strict' : 'best-effort',
+    everyToolCalls: normalizeNonNegativeInt(config?.everyToolCalls),
+    everyMs: normalizeNonNegativeInt(config?.everyMs),
+    maxSnapshots: normalizeMaxSnapshots(config?.maxSnapshots),
+  };
+}
+
+/**
+ * Decide whether a caller should take a session snapshot for the current event.
+ */
+export function shouldTakeAutoSnapshot(
+  config: AutoSnapshotPolicyConfig | undefined,
+  event: SnapshotTrigger,
+  state: SnapshotPolicyState = {},
+): SnapshotDecision {
+  const policy = normalizeAutoSnapshotPolicy(config);
+  if (!policy.enabled) {
+    return {
+      shouldSnapshot: false,
+      trigger: null,
+      mode: policy.mode,
+      reason: 'auto snapshot policy disabled',
+    };
+  }
+
+  if (event === 'start' || event === 'retry' || event === 'reconnect' || event === 'final') {
+    return {
+      shouldSnapshot: true,
+      trigger: event,
+      mode: policy.mode,
+      reason: `${event} snapshot trigger`,
+    };
+  }
+
+  if (event === 'tool-count') {
+    if (policy.everyToolCalls <= 0) {
+      return noIntervalSnapshot(policy.mode, 'tool-count interval disabled');
+    }
+    const calls = state.toolCallsSinceSnapshot ?? 0;
+    return calls >= policy.everyToolCalls
+      ? {
+          shouldSnapshot: true,
+          trigger: 'tool-count',
+          mode: policy.mode,
+          reason: `tool-call interval reached (${calls}/${policy.everyToolCalls})`,
+        }
+      : noIntervalSnapshot(policy.mode, `tool-call interval not reached (${calls}/${policy.everyToolCalls})`);
+  }
+
+  if (event === 'elapsed') {
+    if (policy.everyMs <= 0) {
+      return noIntervalSnapshot(policy.mode, 'elapsed interval disabled');
+    }
+    const last = state.lastSnapshotAt;
+    if (last === undefined) {
+      return {
+        shouldSnapshot: true,
+        trigger: 'elapsed',
+        mode: policy.mode,
+        reason: 'no previous snapshot timestamp',
+      };
+    }
+    const now = state.now ?? Date.now();
+    const elapsed = now - last;
+    return elapsed >= policy.everyMs
+      ? {
+          shouldSnapshot: true,
+          trigger: 'elapsed',
+          mode: policy.mode,
+          reason: `elapsed interval reached (${elapsed}ms/${policy.everyMs}ms)`,
+        }
+      : noIntervalSnapshot(policy.mode, `elapsed interval not reached (${elapsed}ms/${policy.everyMs}ms)`);
+  }
+
+  return noIntervalSnapshot(policy.mode, 'unknown snapshot trigger');
+}
+
+/**
+ * Construct sanitized args suitable for the existing `oc_session_snapshot` tool.
+ */
+export function buildAutoSnapshotArgs(
+  input: SnapshotMemoInput,
+  trigger: SnapshotTrigger,
+): SessionSnapshotArgs {
+  const args: SessionSnapshotArgs = {
+    objective: redactSnapshotText(input.objective),
+    currentStep: redactSnapshotText(input.currentStep),
+    nextActions: input.nextActions.map(redactSnapshotText),
+    label: input.label ? redactSnapshotText(input.label) : `auto-${trigger}`,
+  };
+
+  if (input.completedSteps !== undefined) {
+    args.completedSteps = input.completedSteps.map(redactSnapshotText);
+  }
+  if (input.notes !== undefined) {
+    args.notes = redactSnapshotText(input.notes);
+  }
+
+  return args;
+}
+
+/**
+ * Return the next in-memory state after a snapshot attempt.
+ * Call this only after the caller actually records (or attempts) a snapshot.
+ */
+export function markAutoSnapshotRecorded(
+  state: SnapshotPolicyState = {},
+  at: number = Date.now(),
+): Required<Pick<SnapshotPolicyState, 'toolCallsSinceSnapshot' | 'lastSnapshotAt'>> {
+  return {
+    toolCallsSinceSnapshot: 0,
+    lastSnapshotAt: at,
+  };
+}
+
+/**
+ * Compact redaction for snapshot memo fields. This is intentionally conservative
+ * and dependency-free; deeper redaction remains the responsibility of callers
+ * that have structured secrets.
+ */
+export function redactSnapshotText(value: string): string {
+  let redacted = value;
+  for (const pattern of SECRET_VALUE_PATTERNS) {
+    redacted = redacted.replace(pattern, (_match, key: string) => `${key}=<redacted>`);
+  }
+  return redacted;
+}
+
+function noIntervalSnapshot(mode: 'best-effort' | 'strict', reason: string): SnapshotDecision {
+  return {
+    shouldSnapshot: false,
+    trigger: null,
+    mode,
+    reason,
+  };
+}
+
+function normalizeNonNegativeInt(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.floor(value));
+}
+
+function normalizeMaxSnapshots(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_MAX_SNAPSHOTS;
+  }
+  const n = Math.floor(value);
+  if (n <= 0) return DEFAULT_MAX_SNAPSHOTS;
+  return Math.min(n, MAX_MAX_SNAPSHOTS);
+}

--- a/src/session-snapshot-policy.ts
+++ b/src/session-snapshot-policy.ts
@@ -78,7 +78,7 @@ const SECRET_VALUE_PATTERNS: RegExp[] = [
   /\b(authorization)\s*[:=]\s*bearer\s+([a-z0-9._~+/-]+=*)/gi,
   /\b(bearer)\s+([a-z0-9._~+/-]+=*)/gi,
   /\b(password|passwd|pwd)\s*[:=]\s*([^\s,;]+)/gi,
-  /\b(api[_-]?key|token|secret|authorization)\s*[:=]\s*([^\s,;]+)/gi,
+  /\b(api[_\s-]?key|token|secret|authorization)\s*[:=]\s*([^\s,;]+)/gi,
 ];
 
 /**

--- a/tests/tools/session-snapshot-policy.test.ts
+++ b/tests/tools/session-snapshot-policy.test.ts
@@ -1,0 +1,141 @@
+/// <reference types="jest" />
+
+import {
+  buildAutoSnapshotArgs,
+  markAutoSnapshotRecorded,
+  normalizeAutoSnapshotPolicy,
+  redactSnapshotText,
+  shouldTakeAutoSnapshot,
+} from '../../src/session-snapshot-policy';
+
+describe('auto session snapshot policy', () => {
+  test('is disabled by default', () => {
+    expect(normalizeAutoSnapshotPolicy(undefined)).toEqual({
+      enabled: false,
+      mode: 'best-effort',
+      everyToolCalls: 0,
+      everyMs: 0,
+      maxSnapshots: 10,
+    });
+
+    expect(shouldTakeAutoSnapshot(undefined, 'start')).toMatchObject({
+      shouldSnapshot: false,
+      trigger: null,
+      reason: 'auto snapshot policy disabled',
+    });
+  });
+
+  test.each(['start', 'retry', 'reconnect', 'final'] as const)(
+    'fires explicit %s trigger when enabled',
+    (trigger) => {
+      expect(shouldTakeAutoSnapshot({ enabled: true }, trigger)).toEqual({
+        shouldSnapshot: true,
+        trigger,
+        mode: 'best-effort',
+        reason: `${trigger} snapshot trigger`,
+      });
+    },
+  );
+
+  test('fires tool-count interval only after configured threshold', () => {
+    expect(
+      shouldTakeAutoSnapshot(
+        { enabled: true, everyToolCalls: 3 },
+        'tool-count',
+        { toolCallsSinceSnapshot: 2 },
+      ),
+    ).toMatchObject({
+      shouldSnapshot: false,
+      reason: 'tool-call interval not reached (2/3)',
+    });
+
+    expect(
+      shouldTakeAutoSnapshot(
+        { enabled: true, everyToolCalls: 3 },
+        'tool-count',
+        { toolCallsSinceSnapshot: 3 },
+      ),
+    ).toMatchObject({
+      shouldSnapshot: true,
+      trigger: 'tool-count',
+      reason: 'tool-call interval reached (3/3)',
+    });
+  });
+
+  test('fires elapsed interval based on last snapshot timestamp', () => {
+    expect(
+      shouldTakeAutoSnapshot(
+        { enabled: true, everyMs: 1000 },
+        'elapsed',
+        { lastSnapshotAt: 5000, now: 5500 },
+      ),
+    ).toMatchObject({
+      shouldSnapshot: false,
+      reason: 'elapsed interval not reached (500ms/1000ms)',
+    });
+
+    expect(
+      shouldTakeAutoSnapshot(
+        { enabled: true, everyMs: 1000 },
+        'elapsed',
+        { lastSnapshotAt: 5000, now: 6000 },
+      ),
+    ).toMatchObject({
+      shouldSnapshot: true,
+      trigger: 'elapsed',
+      reason: 'elapsed interval reached (1000ms/1000ms)',
+    });
+  });
+
+  test('normalizes invalid numeric options into safe bounds', () => {
+    expect(
+      normalizeAutoSnapshotPolicy({
+        enabled: true,
+        mode: 'strict',
+        everyToolCalls: 2.9,
+        everyMs: -1,
+        maxSnapshots: 1000,
+      }),
+    ).toEqual({
+      enabled: true,
+      mode: 'strict',
+      everyToolCalls: 2,
+      everyMs: 0,
+      maxSnapshots: 100,
+    });
+  });
+
+  test('builds compact redacted oc_session_snapshot args', () => {
+    const args = buildAutoSnapshotArgs(
+      {
+        objective: 'Log in with password: hunter2 and submit report',
+        currentStep: 'Use token=abc123 on confirmation',
+        nextActions: ['Click submit with api_key=secret-value', 'Verify success banner'],
+        completedSteps: ['Opened page with Authorization: Bearer eyJhbGciOiJI'],
+        notes: 'secret=my-secret should not persist',
+      },
+      'retry',
+    );
+
+    expect(args).toEqual({
+      objective: 'Log in with password=<redacted> and submit report',
+      currentStep: 'Use token=<redacted> on confirmation',
+      nextActions: ['Click submit with api_key=<redacted>', 'Verify success banner'],
+      completedSteps: ['Opened page with Authorization=<redacted>'],
+      notes: 'secret=<redacted> should not persist',
+      label: 'auto-retry',
+    });
+  });
+
+  test('redacts bearer tokens without mutating harmless text', () => {
+    expect(redactSnapshotText('Authorization Bearer abc.def.ghi')).toBe('Authorization Bearer=<redacted>');
+    expect(redactSnapshotText('Verify success banner')).toBe('Verify success banner');
+  });
+
+  test('markAutoSnapshotRecorded resets interval state', () => {
+    expect(markAutoSnapshotRecorded({ toolCallsSinceSnapshot: 5, lastSnapshotAt: 1 }, 42)).toEqual({
+      toolCallsSinceSnapshot: 0,
+      lastSnapshotAt: 42,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the foundation for #1013 with a small, opt-in automatic session snapshot policy module.

This PR intentionally avoids broad workflow/task-ledger wiring because several orchestration-adjacent PRs are already open. Instead it adds the reusable, side-effect-free policy layer that those surfaces can call safely.

## What changed

- Added `src/session-snapshot-policy.ts`:
  - opt-in policy normalization
  - trigger decisions for `start`, `retry`, `reconnect`, `final`, `tool-count`, and `elapsed`
  - compact `oc_session_snapshot` argument construction
  - conservative memo-field redaction for password/token/api key/secret/authorization text
  - interval state reset helper
- Exported the policy from `src/self-healing.ts` for harness consumers.
- Added focused unit tests in `tests/tools/session-snapshot-policy.test.ts`.

## Scope / non-goals

- Does not change ordinary single-tool behavior.
- Does not capture raw DOM, screenshots, cookies, credentials, or page dumps.
- Does not add new dependencies.
- Does not wire broad workflow auto-snapshot behavior in this PR to avoid overlap with active orchestration PRs.

## Directionality review

This is aligned with OpenChrome's harness/reliability direction because it strengthens long-running task continuity while keeping runtime behavior opt-in, bounded, and privacy-safe. It is intentionally the minimum necessary improvement for #1013's foundation and leaves live workflow integration to a follow-up PR using this policy.

## Verification

- [x] `npx jest tests/tools/session-snapshot-policy.test.ts --runInBand`
- [x] `npm run build`
- [x] `npx eslint src/session-snapshot-policy.ts src/self-healing.ts --ext .ts --quiet`

## Known validation gap

Full `npm run lint -- --quiet` currently fails on pre-existing unrelated findings:

- `src/session-manager.ts:959:7 no-useless-catch`
- `src/tools/connect.ts:43:69 @typescript-eslint/ban-types`

Live OpenChrome start/retry/final snapshot verification is not claimed in this foundation PR because no runtime workflow surface is wired here. The follow-up wiring PR should use this module and attach the `oc_session_resume` evidence requested in #1013.

Refs #1013. This is a foundation PR; runtime workflow wiring and live OpenChrome snapshot evidence remain follow-up work before closing the issue.
