### PR TITLE
feat(actions): support secret-safe act variables

### DIFF
--- a/config/audit-redaction.json
+++ b/config/audit-redaction.json
@@ -35,6 +35,10 @@
     "form_input": [
       { "path": "value", "mode": "redact" }
     ],
+    "act": [
+      { "path": "variables", "mode": "redactScalar" },
+      { "path": "variables[*]", "mode": "redact" }
+    ],
     "type": [
       { "path": "text", "mode": "truncate", "maxBytes": 200 }
     ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,9 +110,9 @@ program
       const server = new MCPServer(undefined, { initialToolTier: 3 });
       registerAllTools(server);
       const manifest = server.getToolManifest();
-      const output = JSON.stringify(manifest.tools) + '\n';
+      const output = Buffer.from(JSON.stringify(manifest.tools) + '\n', 'utf8');
       for (let offset = 0; offset < output.length; offset += 16_384) {
-        const chunk = output.slice(offset, offset + 16_384);
+        const chunk = output.subarray(offset, Math.min(offset + 16_384, output.length));
         if (!process.stdout.write(chunk)) {
           await new Promise<void>((resolve) => process.stdout.once('drain', resolve));
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,9 +110,13 @@ program
       const server = new MCPServer(undefined, { initialToolTier: 3 });
       registerAllTools(server);
       const manifest = server.getToolManifest();
-      await new Promise<void>((resolve) => {
-        process.stdout.write(JSON.stringify(manifest.tools) + '\n', () => resolve());
-      });
+      const output = JSON.stringify(manifest.tools) + '\n';
+      for (let offset = 0; offset < output.length; offset += 16_384) {
+        const chunk = output.slice(offset, offset + 16_384);
+        if (!process.stdout.write(chunk)) {
+          await new Promise<void>((resolve) => process.stdout.once('drain', resolve));
+        }
+      }
       return;
     }
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -66,8 +66,14 @@ import type { TransportMessageContext } from './transports';
 
 
 function redactActVariablesForTelemetry(toolName: string, args: Record<string, unknown>): Record<string, unknown> {
-  if (toolName !== 'act' || !args.variables || typeof args.variables !== 'object' || Array.isArray(args.variables)) {
+  if (toolName !== 'act' || !('variables' in args)) {
     return args;
+  }
+  if (!args.variables || typeof args.variables !== 'object') {
+    return { ...args, variables: '[VARIABLE]' };
+  }
+  if (Array.isArray(args.variables)) {
+    return { ...args, variables: args.variables.map(() => '[VARIABLE]') };
   }
   const redactedVariables: Record<string, string> = {};
   for (const key of Object.keys(args.variables as Record<string, unknown>)) {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -64,6 +64,18 @@ import {
 import { currentRequestContext } from './observability/request-id';
 import type { TransportMessageContext } from './transports';
 
+
+function redactActVariablesForTelemetry(toolName: string, args: Record<string, unknown>): Record<string, unknown> {
+  if (toolName !== 'act' || !args.variables || typeof args.variables !== 'object' || Array.isArray(args.variables)) {
+    return args;
+  }
+  const redactedVariables: Record<string, string> = {};
+  for (const key of Object.keys(args.variables as Record<string, unknown>)) {
+    redactedVariables[key] = '[VARIABLE]';
+  }
+  return { ...args, variables: redactedVariables };
+}
+
 /** Recording tools excluded from session recording to prevent infinite loops */
 const SKIP_RECORDING_TOOLS = new Set([
   'oc_recording_start',
@@ -1262,6 +1274,7 @@ export class MCPServer {
 
     const toolName = params.name as string;
     const toolArgs = (params.arguments || {}) as Record<string, unknown>;
+    const telemetryToolArgs = redactActVariablesForTelemetry(toolName, toolArgs);
     // Use 'default' session if no sessionId is provided
     const sessionId = (toolArgs.sessionId || params.sessionId || 'default') as string;
 
@@ -1525,8 +1538,8 @@ export class MCPServer {
     }
 
     // Start activity tracking
-    const callId = this.activityTracker!.startCall(toolName, sessionId || 'default', toolArgs, requestId);
-    getDashboardState().recordToolStart(sessionId || 'default', toolName, toolArgs, callId);
+    const callId = this.activityTracker!.startCall(toolName, sessionId || 'default', telemetryToolArgs, requestId);
+    getDashboardState().recordToolStart(sessionId || 'default', toolName, telemetryToolArgs, callId);
     const toolStartTime = Date.now();
 
     // Adaptive heartbeat: switch to heavy mode during tool execution
@@ -1753,7 +1766,7 @@ export class MCPServer {
       // Record to task journal
       try {
         const journal = getTaskJournal();
-        const entry = journal.createEntry(toolName, sessionId, toolArgs, Date.now() - toolStartTime, true);
+        const entry = journal.createEntry(toolName, sessionId, telemetryToolArgs, Date.now() - toolStartTime, true);
         journal.record(entry);
       } catch {
         // Best-effort journal recording
@@ -1765,7 +1778,7 @@ export class MCPServer {
         if (recorder.isRecording && !SKIP_RECORDING_TOOLS.has(toolName)) {
           const tabId = toolArgs['tabId'] as string | undefined;
           const summary = (result as Record<string, unknown>)?._summary as string | undefined;
-          recorder.recordAction(toolName, toolArgs, Date.now() - toolStartTime, true, { tabId, summary }).catch(() => {});
+          recorder.recordAction(toolName, telemetryToolArgs, Date.now() - toolStartTime, true, { tabId, summary }).catch(() => {});
         }
       } catch {
         // Best-effort recording
@@ -1936,7 +1949,7 @@ export class MCPServer {
       // Record to task journal
       try {
         const journal = getTaskJournal();
-        const entry = journal.createEntry(toolName, sessionId, toolArgs, Date.now() - toolStartTime, false);
+        const entry = journal.createEntry(toolName, sessionId, telemetryToolArgs, Date.now() - toolStartTime, false);
         journal.record(entry);
       } catch {
         // Best-effort journal recording
@@ -1948,7 +1961,7 @@ export class MCPServer {
         if (recorder.isRecording && !SKIP_RECORDING_TOOLS.has(toolName)) {
           const tabId = toolArgs['tabId'] as string | undefined;
           const errMsg = message;
-          recorder.recordAction(toolName, toolArgs, Date.now() - toolStartTime, false, { tabId, error: errMsg }).catch(() => {});
+          recorder.recordAction(toolName, telemetryToolArgs, Date.now() - toolStartTime, false, { tabId, error: errMsg }).catch(() => {});
         }
       } catch {
         // Best-effort recording

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -14,7 +14,7 @@ import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-export type RedactionMode = 'redact' | 'hash' | 'truncate' | 'redactIfSensitiveName';
+export type RedactionMode = 'redact' | 'hash' | 'truncate' | 'redactIfSensitiveName' | 'redactScalar';
 
 export interface RedactionRule {
   /** Dot-path into args; `[*]` matches any array index. */
@@ -37,6 +37,7 @@ const VALID_REDACTION_MODES = new Set<RedactionMode>([
   'hash',
   'truncate',
   'redactIfSensitiveName',
+  'redactScalar',
 ]);
 
 /**
@@ -82,6 +83,7 @@ export const BUILTIN_REDACTION_CONFIG: RedactionConfig = {
       { path: 'value', mode: 'redact' },
     ],
     act: [
+      { path: 'variables', mode: 'redactScalar' },
       { path: 'variables[*]', mode: 'redact' },
     ],
     type: [
@@ -194,6 +196,8 @@ function applyMode(value: unknown, mode: RedactionMode, opts: { maxBytes?: numbe
       if (text.length <= max) return text;
       return { preview: text.slice(0, max), hash: sha256(text), truncated: true };
     }
+    case 'redactScalar':
+      return value && typeof value === 'object' ? value : REDACTED;
     case 'redactIfSensitiveName': {
       // Check the containing field name first (for rules like {path: 'password'})
       if (opts.name && isSensitiveName(opts.name, opts.sensitiveNames)) {

--- a/src/observability/redaction.ts
+++ b/src/observability/redaction.ts
@@ -81,6 +81,9 @@ export const BUILTIN_REDACTION_CONFIG: RedactionConfig = {
     form_input: [
       { path: 'value', mode: 'redact' },
     ],
+    act: [
+      { path: 'variables[*]', mode: 'redact' },
+    ],
     type: [
       { path: 'text', mode: 'truncate', maxBytes: 200 },
     ],
@@ -228,24 +231,42 @@ function applyRuleAt(target: Record<string, unknown> | unknown[], segments: Arra
   const [seg, ...rest] = segments;
 
   if (seg.index !== undefined) {
-    if (!Array.isArray(target)) return;
-    const indices: number[] = seg.index === '*'
-      ? target.map((_v, i) => i)
-      : (seg.index < target.length ? [seg.index] : []);
-    for (const i of indices) {
-      if (rest.length === 0) {
-        target[i] = applyMode(target[i], rule.mode, {
-          maxBytes: rule.maxBytes,
-          sensitiveNames: cfg.defaultSensitiveFieldNames,
-        });
-      } else if (target[i] && typeof target[i] === 'object') {
-        // Recurse, but stash sibling 'name' for `{name, value}` shapes so
-        // redactIfSensitiveName can consult the form field's declared name.
-        const child = target[i] as Record<string, unknown> | unknown[];
-        const siblingName = (!Array.isArray(child) && 'name' in child)
-          ? (child as Record<string, unknown>).name
-          : undefined;
-        applyRuleAt(child, rest, rule, cfg, siblingName);
+    if (Array.isArray(target)) {
+      const indices: number[] = seg.index === '*'
+        ? target.map((_v, i) => i)
+        : (seg.index < target.length ? [seg.index] : []);
+      for (const i of indices) {
+        if (rest.length === 0) {
+          target[i] = applyMode(target[i], rule.mode, {
+            maxBytes: rule.maxBytes,
+            sensitiveNames: cfg.defaultSensitiveFieldNames,
+          });
+        } else if (target[i] && typeof target[i] === 'object') {
+          // Recurse, but stash sibling 'name' for `{name, value}` shapes so
+          // redactIfSensitiveName can consult the form field's declared name.
+          const child = target[i] as Record<string, unknown> | unknown[];
+          const siblingName = (!Array.isArray(child) && 'name' in child)
+            ? (child as Record<string, unknown>).name
+            : undefined;
+          applyRuleAt(child, rest, rule, cfg, siblingName);
+        }
+      }
+      return;
+    }
+
+    // Support object wildcards for map-shaped args such as act.variables[*].
+    if (seg.index === '*' && target && typeof target === 'object') {
+      const obj = target as Record<string, unknown>;
+      for (const key of Object.keys(obj)) {
+        if (rest.length === 0) {
+          obj[key] = applyMode(obj[key], rule.mode, {
+            maxBytes: rule.maxBytes,
+            sensitiveNames: cfg.defaultSensitiveFieldNames,
+            name: key,
+          });
+        } else if (obj[key] && typeof obj[key] === 'object') {
+          applyRuleAt(obj[key] as Record<string, unknown> | unknown[], rest, rule, cfg);
+        }
       }
     }
     return;

--- a/src/recording/action-recorder.ts
+++ b/src/recording/action-recorder.ts
@@ -327,7 +327,11 @@ export class ActionRecorder {
     for (const [k, v] of Object.entries(args)) {
       if (REDACT_KEYS.test(k)) {
         sanitized[k] = '[REDACTED]';
-      } else if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+      } else if (k === 'variables' && v !== null && typeof v === 'object') {
+        sanitized[k] = Object.fromEntries(Object.keys(v as Record<string, unknown>).map((name) => [name, '[VARIABLE]']));
+      } else if (Array.isArray(v)) {
+        sanitized[k] = v.map((item) => item !== null && typeof item === 'object' ? this.sanitizeArgs(item as Record<string, unknown>) : item);
+      } else if (v !== null && typeof v === 'object') {
         sanitized[k] = this.sanitizeArgs(v as Record<string, unknown>);
       } else {
         sanitized[k] = v;

--- a/src/tools/act.ts
+++ b/src/tools/act.ts
@@ -59,13 +59,38 @@ function substituteActionVariables(action: ParsedAction, variables: Record<strin
 }
 
 function redactVariableValues(text: string, variables: Record<string, string>): string {
-  let redacted = text;
-  const replacements = Object.entries(variables)
-    .filter(([, value]) => value.length > 0)
-    .sort((a, b) => b[1].length - a[1].length);
-  for (const [name, value] of replacements) {
-    redacted = redacted.split(value).join(`%${name}%`);
+  const matches: Array<{ start: number; end: number; label: string }> = [];
+  for (const [name, value] of Object.entries(variables)) {
+    if (value.length === 0) continue;
+    let start = text.indexOf(value);
+    while (start !== -1) {
+      matches.push({ start, end: start + value.length, label: `%${name}%` });
+      start = text.indexOf(value, start + 1);
+    }
   }
+  if (matches.length === 0) return text;
+
+  matches.sort((a, b) => a.start - b.start || b.end - a.end);
+  const chunks: Array<{ start: number; end: number; label: string; ambiguous: boolean }> = [];
+  for (const match of matches) {
+    const last = chunks[chunks.length - 1];
+    if (!last || match.start >= last.end) {
+      chunks.push({ ...match, ambiguous: false });
+      continue;
+    }
+    if (match.end <= last.end) continue;
+    last.end = match.end;
+    last.ambiguous = true;
+  }
+
+  let redacted = '';
+  let offset = 0;
+  for (const chunk of chunks) {
+    redacted += text.slice(offset, chunk.start);
+    redacted += chunk.ambiguous ? '[REDACTED_VARIABLE]' : chunk.label;
+    offset = chunk.end;
+  }
+  redacted += text.slice(offset);
   return redacted;
 }
 

--- a/src/tools/act.ts
+++ b/src/tools/act.ts
@@ -23,6 +23,50 @@ import { matchTemplate } from '../actions/action-templates';
 import { getCachedSequence, cacheSequence, validateCachedSequence } from '../actions/action-cache';
 import { coerceVerifyMode, runVerify, VERIFY_FIELD_SCHEMA, VerifyReport } from '../core/perception/verify';
 
+
+const VARIABLE_RE = /%([A-Za-z_][A-Za-z0-9_]*)%/g;
+
+function normalizeVariables(raw: unknown): Record<string, string> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      out[key] = String(value);
+    }
+  }
+  return out;
+}
+
+function findMissingVariables(instruction: string, variables: Record<string, string>): string[] {
+  const names = new Set<string>();
+  for (const match of instruction.matchAll(VARIABLE_RE)) names.add(match[1]);
+  return Array.from(names).filter((name) => !(name in variables));
+}
+
+function substituteVariableText(text: string | undefined, variables: Record<string, string>): string | undefined {
+  if (text === undefined) return undefined;
+  return text.replace(VARIABLE_RE, (_m, name: string) => variables[name] ?? _m);
+}
+
+function substituteActionVariables(action: ParsedAction, variables: Record<string, string>): ParsedAction {
+  return {
+    ...action,
+    target: substituteVariableText(action.target, variables),
+    value: substituteVariableText(action.value, variables),
+    condition: substituteVariableText(action.condition, variables),
+  };
+}
+
+function redactVariableValues(text: string, variables: Record<string, string>): string {
+  let redacted = text;
+  for (const [name, value] of Object.entries(variables)) {
+    if (!value) continue;
+    redacted = redacted.split(value).join(`%${name}%`);
+  }
+  return redacted;
+}
+
 // ─── Types ───
 
 interface StepResult {
@@ -59,6 +103,10 @@ const definition: MCPToolDefinition = {
       timeout: {
         type: 'number',
         description: 'Max time in ms for entire sequence. Default: 30000',
+      },
+      variables: {
+        type: 'object',
+        description: 'Optional runtime values for %name% placeholders. Values are injected only at execution time and redacted from responses/cache.',
       },
     },
     required: ['tabId', 'instruction'],
@@ -419,12 +467,20 @@ const handler: ToolHandler = async (
   const verifyTextSummary =
     args.verify === undefined ? true : verifyMode !== 'none';
   const timeoutMs = Math.min(Math.max((args.timeout as number) || 30000, 1000), 120000);
+  const variables = normalizeVariables(args.variables);
+  const missingVariables = findMissingVariables(instruction || '', variables);
 
   if (!tabId) {
     return { content: [{ type: 'text', text: 'Error: tabId is required' }], isError: true };
   }
   if (!instruction || instruction.trim().length === 0) {
     return { content: [{ type: 'text', text: 'Error: instruction is required' }], isError: true };
+  }
+  if (missingVariables.length > 0) {
+    return {
+      content: [{ type: 'text', text: `Error: Missing variable(s): ${missingVariables.map((name) => `%${name}%`).join(', ')}` }],
+      isError: true,
+    };
   }
 
   const sessionManager = getSessionManager();
@@ -485,6 +541,8 @@ const handler: ToolHandler = async (
     }
   }
 
+  const executionActions = actions.map((action) => substituteActionVariables(action, variables));
+
   const cdpClient = sessionManager.getCDPClient();
   const isStealth = sessionManager.isStealthTarget(tabId);
   const stepResults: StepResult[] = [];
@@ -497,14 +555,14 @@ const handler: ToolHandler = async (
   // this returns `verify: undefined` and the result is byte-identical to
   // pre-#827 develop.
   const verifyOutcome = await runVerify(page, verifyMode, async () => {
-  for (let i = 0; i < actions.length; i++) {
+  for (let i = 0; i < executionActions.length; i++) {
     if (Date.now() >= deadline) {
       failedAt = i + 1;
-      stepResults.push({ step: i + 1, action: actions[i].action, outcome: 'TIMEOUT', error: 'Sequence timeout exceeded' });
+      stepResults.push({ step: i + 1, action: executionActions[i].action, outcome: 'TIMEOUT', error: 'Sequence timeout exceeded' });
       break;
     }
 
-    const parsedAction: ParsedAction = actions[i];
+    const parsedAction: ParsedAction = executionActions[i];
     let result: StepResult;
 
     try {
@@ -563,7 +621,7 @@ const handler: ToolHandler = async (
   await cleanupTags(page, DISCOVERY_TAG).catch(() => {});
 
   // Build response
-  const total = actions.length;
+  const total = executionActions.length;
   const executed = stepResults.length;
   const success = failedAt === null;
 
@@ -600,7 +658,7 @@ const handler: ToolHandler = async (
     const isFailed = r.outcome === 'ELEMENT_NOT_FOUND' || r.outcome === 'EXCEPTION' || r.outcome === 'TIMEOUT';
     const symbol = isFailed ? '\u2717' : '\u2713';
     const label = r.message || r.error || `${r.action}${r.target ? ` "${r.target}"` : ''}`;
-    stepLines.push(`Step ${r.step}: ${symbol} ${label}`);
+    stepLines.push(`Step ${r.step}: ${symbol} ${redactVariableValues(label, variables)}`);
   }
 
   const lines: string[] = [headerLine, '', ...stepLines];

--- a/src/tools/act.ts
+++ b/src/tools/act.ts
@@ -60,8 +60,10 @@ function substituteActionVariables(action: ParsedAction, variables: Record<strin
 
 function redactVariableValues(text: string, variables: Record<string, string>): string {
   let redacted = text;
-  for (const [name, value] of Object.entries(variables)) {
-    if (!value) continue;
+  const replacements = Object.entries(variables)
+    .filter(([, value]) => value.length > 0)
+    .sort((a, b) => b[1].length - a[1].length);
+  for (const [name, value] of replacements) {
     redacted = redacted.split(value).join(`%${name}%`);
   }
   return redacted;
@@ -671,7 +673,7 @@ const handler: ToolHandler = async (
         url: window.location.href,
         title: document.title,
       })), 3000, 'verify', context).catch(() => ({ url: '', title: '' })) as { url: string; title: string };
-      lines.push('', `[Verification] url: ${state.url} | title: ${state.title}`);
+      lines.push('', redactVariableValues(`[Verification] url: ${state.url} | title: ${state.title}`, variables));
     } catch { /* non-fatal */ }
   }
 

--- a/tests/observability/act-variable-redaction.test.ts
+++ b/tests/observability/act-variable-redaction.test.ts
@@ -1,0 +1,20 @@
+/// <reference types="jest" />
+
+import { redactArgs } from '../../src/observability/redaction';
+
+describe('act variable redaction', () => {
+  test('redacts all act variable values in audit args', () => {
+    const { redacted } = redactArgs('act', {
+      instruction: 'type %username% and %password%',
+      variables: {
+        username: 'alice@example.com',
+        password: 'S3cret-Value-Do-Not-Log',
+      },
+    });
+
+    const serialized = JSON.stringify(redacted);
+    expect(serialized).not.toContain('alice@example.com');
+    expect(serialized).not.toContain('S3cret-Value-Do-Not-Log');
+    expect(redacted.variables).toEqual({ username: '[REDACTED]', password: '[REDACTED]' });
+  });
+});

--- a/tests/observability/act-variable-redaction.test.ts
+++ b/tests/observability/act-variable-redaction.test.ts
@@ -17,4 +17,15 @@ describe('act variable redaction', () => {
     expect(serialized).not.toContain('S3cret-Value-Do-Not-Log');
     expect(redacted.variables).toEqual({ username: '[REDACTED]', password: '[REDACTED]' });
   });
+
+  test('redacts malformed scalar and array act variables in audit args', () => {
+    const scalar = redactArgs('act', { instruction: 'go', variables: 'raw-secret' }).redacted;
+    expect(JSON.stringify(scalar)).not.toContain('raw-secret');
+    expect(scalar.variables).toBe('[REDACTED]');
+
+    const array = redactArgs('act', { instruction: 'go', variables: ['raw-secret'] }).redacted;
+    expect(JSON.stringify(array)).not.toContain('raw-secret');
+    expect(array.variables).toEqual(['[REDACTED]']);
+  });
+
 });

--- a/tests/tools/act.test.ts
+++ b/tests/tools/act.test.ts
@@ -175,6 +175,23 @@ describe('ActTool', () => {
       expect(result.content[0].text).toContain('instruction is required');
     });
 
+
+
+    test('returns error before execution when placeholder variable is missing', async () => {
+      const handler = await getActHandler();
+      const page = await mockSessionManager.getPage(testSessionId, testTargetId);
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        instruction: 'type %password% in password',
+        variables: {},
+      }) as any;
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Missing variable');
+      expect(page!.keyboard.type).not.toHaveBeenCalled();
+    });
+
     test('returns error when tab is not found', async () => {
       const handler = await getActHandler();
       const result = await handler(testSessionId, {
@@ -396,6 +413,36 @@ describe('ActTool', () => {
 
       expect(result.isError).toBeFalsy();
       expect(page!.keyboard.type).toHaveBeenCalledWith('hello world', expect.any(Object));
+    });
+
+
+
+    test('substitutes variables at execution time but redacts them from response', async () => {
+      (resolveElementsByAXTree as jest.Mock).mockResolvedValue([{
+        backendDOMNodeId: 401,
+        role: 'textbox',
+        name: 'Password',
+        matchLevel: 1,
+        rect: { x: 200, y: 100, width: 200, height: 30 },
+        properties: {},
+        source: 'ax',
+      }]);
+      mockSessionManager.mockCDPClient.send.mockResolvedValue({ model: { content: [180, 85, 380, 85, 380, 115, 180, 115] } });
+
+      const page = await mockSessionManager.getPage(testSessionId, testTargetId);
+      (page!.evaluate as jest.Mock).mockResolvedValue({ url: 'https://example.com', title: 'Example' });
+
+      const handler = await getActHandler();
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        instruction: 'type %password% in password',
+        variables: { password: 'S3cret-Value-Do-Not-Log' },
+      }) as any;
+
+      expect(result.isError).toBeFalsy();
+      expect(page!.keyboard.type).toHaveBeenCalledWith('S3cret-Value-Do-Not-Log', expect.any(Object));
+      expect(result.content[0].text).not.toContain('S3cret-Value-Do-Not-Log');
+      expect(result.content[0].text).toContain('%password%');
     });
 
     test('type with target finds element first', async () => {

--- a/tests/tools/act.test.ts
+++ b/tests/tools/act.test.ts
@@ -465,6 +465,27 @@ describe('ActTool', () => {
       expect(result.content[0].text).toContain('%long%');
     });
 
+    test('redacts equal-length overlapping variable values without leaking fragments', async () => {
+      const page = await mockSessionManager.getPage(testSessionId, testTargetId);
+      (page!.evaluate as jest.Mock).mockResolvedValue({
+        url: 'https://example.com/callback?value=abcd',
+        title: 'overlap abcd',
+      });
+
+      const handler = await getActHandler();
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        instruction: 'navigate to https://example.com/callback?value=abcd',
+        variables: { first: 'abc', second: 'bcd' },
+      }) as any;
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).not.toContain('abcd');
+      expect(result.content[0].text).not.toContain('abc');
+      expect(result.content[0].text).not.toContain('bcd');
+      expect(result.content[0].text).toContain('[REDACTED_VARIABLE]');
+    });
+
     test('type with target finds element first', async () => {
       (resolveElementsByAXTree as jest.Mock).mockResolvedValue([{
         backendDOMNodeId: 400,

--- a/tests/tools/act.test.ts
+++ b/tests/tools/act.test.ts
@@ -445,6 +445,26 @@ describe('ActTool', () => {
       expect(result.content[0].text).toContain('%password%');
     });
 
+    test('redacts overlapping variable values and verification URL/title', async () => {
+      const page = await mockSessionManager.getPage(testSessionId, testTargetId);
+      (page!.evaluate as jest.Mock).mockResolvedValue({
+        url: 'https://example.com/callback?token=abc123',
+        title: 'session abc123',
+      });
+
+      const handler = await getActHandler();
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        instruction: 'navigate to https://example.com/callback?token=%long%',
+        variables: { short: 'abc', long: 'abc123' },
+      }) as any;
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).not.toContain('abc123');
+      expect(result.content[0].text).not.toContain('%short%123');
+      expect(result.content[0].text).toContain('%long%');
+    });
+
     test('type with target finds element first', async () => {
       (resolveElementsByAXTree as jest.Mock).mockResolvedValue([{
         backendDOMNodeId: 400,


### PR DESCRIPTION
## Summary

- adds `%name%` variable placeholders to `act` with execution-time substitution
- keeps cached/planned actions placeholder-based while typing real runtime values into the page
- redacts act variable values from responses, activity telemetry, task journal, recordings, and audit redaction paths

Closes #995.

## Alignment / scope review

This stays limited to `act` placeholders and redaction plumbing. It does not add credential-store integration, prompting, server-side LLM behavior, or changes to existing plain-text instructions.

## Verification

- `/Users/jh0927/openchrome/node_modules/.bin/tsc -p tsconfig.json --pretty false`
- `npx jest --config jest.config.js --runInBand tests/tools/act.test.ts tests/observability/act-variable-redaction.test.ts tests/recording/action-recorder.test.ts tests/observability/redaction.test.ts`

## Post-merge smoke

Use the #995 fixture flow: type `%username%`/`%password%` into a local login form, verify DOM receives real values, then grep OpenChrome artifacts for the raw secret value.