### PR TITLE
feat(journal): classify failures in session summaries (#1008)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,9 +110,9 @@ program
       const server = new MCPServer(undefined, { initialToolTier: 3 });
       registerAllTools(server);
       const manifest = server.getToolManifest();
-      const output = JSON.stringify(manifest.tools) + '\n';
+      const output = Buffer.from(JSON.stringify(manifest.tools) + '\n', 'utf8');
       for (let offset = 0; offset < output.length; offset += 16_384) {
-        const chunk = output.slice(offset, offset + 16_384);
+        const chunk = output.subarray(offset, Math.min(offset + 16_384, output.length));
         if (!process.stdout.write(chunk)) {
           await new Promise<void>((resolve) => process.stdout.once('drain', resolve));
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,9 +110,13 @@ program
       const server = new MCPServer(undefined, { initialToolTier: 3 });
       registerAllTools(server);
       const manifest = server.getToolManifest();
-      await new Promise<void>((resolve) => {
-        process.stdout.write(JSON.stringify(manifest.tools) + '\n', () => resolve());
-      });
+      const output = JSON.stringify(manifest.tools) + '\n';
+      for (let offset = 0; offset < output.length; offset += 16_384) {
+        const chunk = output.slice(offset, offset + 16_384);
+        if (!process.stdout.write(chunk)) {
+          await new Promise<void>((resolve) => process.stdout.once('drain', resolve));
+        }
+      }
       return;
     }
 

--- a/src/journal/task-journal.ts
+++ b/src/journal/task-journal.ts
@@ -332,7 +332,7 @@ export class TaskJournal {
     )
       return "stale_ref";
     if (
-      /(authredirect|login page detected|redirected to login|sign in|signin|unauthorized|401)/i.test(
+      /(authredirect|auth_redirect_required|login page detected|redirected to login|sign in|signin|unauthorized|401)/i.test(
         text,
       )
     )
@@ -474,7 +474,7 @@ function emptyFailureClassCounts(): Record<JournalFailureClass, number> {
 }
 
 function hasNonProgressSignal(text: string): boolean {
-  return /(authredirect|login page detected|captcha|waf|stale|timed out|timeout|empty result|not making progress|stuck|stalling|contract.*fail|assertion.*fail)/i.test(
+  return /(authredirect|auth_redirect_required|login page detected|captcha|waf|stale|timed out|timeout|empty result|not making progress|stuck|stalling|contract.*fail|assertion.*fail|auth_redirect_required|failed_assertions|inconclusive)/i.test(
     text,
   );
 }

--- a/src/journal/task-journal.ts
+++ b/src/journal/task-journal.ts
@@ -4,32 +4,74 @@
  * Part of #356: AI Agent Continuity.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+export type JournalFailureClass =
+  | "stale_ref"
+  | "auth_redirect"
+  | "captcha_or_waf"
+  | "timeout"
+  | "network_error"
+  | "empty_result"
+  | "contract_failed"
+  | "non_progress_loop"
+  | "unknown";
 
 export interface JournalEntry {
-  ts: number;                    // Unix ms timestamp
-  tool: string;                  // Tool name (e.g., "navigate", "read_page")
-  sessionId: string;             // MCP session identifier
-  tabId?: string;                // Target tab if applicable
+  ts: number; // Unix ms timestamp
+  tool: string; // Tool name (e.g., "navigate", "read_page")
+  sessionId: string; // MCP session identifier
+  tabId?: string; // Target tab if applicable
   args: Record<string, unknown>; // Sanitized tool arguments
-  durationMs: number;            // Execution time
-  ok: boolean;                   // Success/failure
-  summary: string;               // Human-readable 1-line summary
-  milestone?: boolean;           // True for significant actions
+  durationMs: number; // Execution time
+  ok: boolean; // Success/failure
+  summary: string; // Human-readable 1-line summary
+  milestone?: boolean; // True for significant actions
+  failureClass?: JournalFailureClass; // Deterministic failure class for failed/non-progress calls
+  errorFingerprint?: string; // Normalized, secret-safe error/result fingerprint
+  resultSummary?: string; // Optional sanitized result/error summary for classification
 }
 
 /** Tools whose entire args are redacted */
-const REDACT_TOOLS = new Set(['http_auth', 'cookies']);
+const REDACT_TOOLS = new Set(["http_auth", "cookies"]);
 
 /** Arg keys that are always redacted */
 const REDACT_KEYS = /password|token|secret|credential|api[_-]?key/i;
 
 /** Tools marked as milestones for priority in resume summaries */
 const MILESTONE_TOOLS = new Set([
-  'navigate', 'fill_form', 'workflow_init', 'execute_plan',
-  'oc_session_snapshot', 'oc_stop', 'tabs_create', 'tabs_close',
+  "navigate",
+  "fill_form",
+  "workflow_init",
+  "execute_plan",
+  "oc_session_snapshot",
+  "oc_stop",
+  "tabs_create",
+  "tabs_close",
+]);
+
+const PROGRESS_TOOLS = new Set([
+  "navigate",
+  "tabs_create",
+  "tabs_close",
+  "fill_form",
+  "interact",
+  "form_input",
+  "javascript_tool",
+  "execute_plan",
+  "workflow_init",
+  "worker_complete",
+  "oc_session_snapshot",
+  "oc_checkpoint",
+]);
+
+const OBSERVATION_TOOLS = new Set([
+  "read_page",
+  "tabs_context",
+  "page_content",
+  "page_screenshot",
 ]);
 
 export class TaskJournal {
@@ -37,7 +79,7 @@ export class TaskJournal {
   private readonly maxAgeDays: number;
 
   constructor(opts?: { dir?: string; maxAgeDays?: number }) {
-    this.dir = opts?.dir || path.join(os.homedir(), '.openchrome', 'journal');
+    this.dir = opts?.dir || path.join(os.homedir(), ".openchrome", "journal");
     this.maxAgeDays = opts?.maxAgeDays ?? 7;
   }
 
@@ -57,10 +99,13 @@ export class TaskJournal {
     try {
       const filename = `journal-${this.dateString()}.jsonl`;
       const filepath = path.join(this.dir, filename);
-      fs.appendFileSync(filepath, JSON.stringify(entry) + '\n');
+      fs.appendFileSync(filepath, JSON.stringify(entry) + "\n");
     } catch (err) {
       // Best-effort — don't crash the server if journal write fails
-      console.error('[TaskJournal] Write failed:', err instanceof Error ? err.message : err);
+      console.error(
+        "[TaskJournal] Write failed:",
+        err instanceof Error ? err.message : err,
+      );
     }
   }
 
@@ -73,8 +118,12 @@ export class TaskJournal {
     args: Record<string, unknown>,
     durationMs: number,
     ok: boolean,
+    resultSummary?: string,
   ): JournalEntry {
-    return {
+    const sanitizedResult = resultSummary
+      ? this.sanitizeResultSummary(resultSummary)
+      : undefined;
+    const entry: JournalEntry = {
       ts: Date.now(),
       tool,
       sessionId,
@@ -84,7 +133,16 @@ export class TaskJournal {
       ok,
       summary: this.generateSummary(tool, args, ok),
       milestone: MILESTONE_TOOLS.has(tool) || undefined,
+      resultSummary: sanitizedResult,
     };
+
+    const failureClass = this.classifyFailure(entry);
+    if (failureClass) {
+      entry.failureClass = failureClass;
+      entry.errorFingerprint = this.fingerprintEntry(entry);
+    }
+
+    return entry;
   }
 
   /**
@@ -98,8 +156,8 @@ export class TaskJournal {
     for (const dateStr of [yesterday, today]) {
       const filepath = path.join(this.dir, `journal-${dateStr}.jsonl`);
       try {
-        const content = fs.readFileSync(filepath, 'utf-8');
-        for (const line of content.split('\n')) {
+        const content = fs.readFileSync(filepath, "utf-8");
+        for (const line of content.split("\n")) {
           const trimmed = line.trim();
           if (!trimmed) continue;
           try {
@@ -121,9 +179,9 @@ export class TaskJournal {
    */
   getMilestones(opts?: { since?: number; limit?: number }): JournalEntry[] {
     const entries = this.getRecent(500);
-    let milestones = entries.filter(e => e.milestone);
+    let milestones = entries.filter((e) => e.milestone);
     if (opts?.since) {
-      milestones = milestones.filter(e => e.ts > opts.since!);
+      milestones = milestones.filter((e) => e.ts > opts.since!);
     }
     return milestones.slice(-(opts?.limit ?? 20));
   }
@@ -137,28 +195,95 @@ export class TaskJournal {
     failed: number;
     toolCounts: Record<string, number>;
     milestones: JournalEntry[];
+    failureClasses: Record<JournalFailureClass, number>;
+    repeatedErrorFingerprints: Array<{
+      fingerprint: string;
+      count: number;
+      failureClass: JournalFailureClass;
+    }>;
+    lastProgressTool?: { tool: string; summary: string; ts: number };
+    recentNonProgressTools: Array<{
+      tool: string;
+      summary: string;
+      failureClass: JournalFailureClass;
+      ts: number;
+    }>;
+    candidateRecoveryHints: string[];
     period: { start: number; end: number };
   } {
     let entries = this.getRecent(1000);
     if (opts?.since) {
-      entries = entries.filter(e => e.ts > opts.since!);
+      entries = entries.filter((e) => e.ts > opts.since!);
     }
 
     const toolCounts: Record<string, number> = {};
+    const failureClasses = emptyFailureClassCounts();
+    const fingerprintCounts = new Map<
+      string,
+      { count: number; failureClass: JournalFailureClass }
+    >();
+    const recentNonProgressTools: Array<{
+      tool: string;
+      summary: string;
+      failureClass: JournalFailureClass;
+      ts: number;
+    }> = [];
+    let lastProgressTool:
+      | { tool: string; summary: string; ts: number }
+      | undefined;
     let succeeded = 0;
     let failed = 0;
 
     for (const e of entries) {
       toolCounts[e.tool] = (toolCounts[e.tool] || 0) + 1;
-      if (e.ok) succeeded++; else failed++;
+      if (e.ok) succeeded++;
+      else failed++;
+
+      if (this.isProgressEntry(e)) {
+        lastProgressTool = { tool: e.tool, summary: e.summary, ts: e.ts };
+      }
+
+      const failureClass = e.failureClass ?? this.classifyFailure(e);
+      if (failureClass) {
+        failureClasses[failureClass]++;
+        recentNonProgressTools.push({
+          tool: e.tool,
+          summary: e.summary,
+          failureClass,
+          ts: e.ts,
+        });
+        const fingerprint =
+          e.errorFingerprint ?? this.fingerprintEntry({ ...e, failureClass });
+        const current = fingerprintCounts.get(fingerprint) ?? {
+          count: 0,
+          failureClass,
+        };
+        current.count++;
+        fingerprintCounts.set(fingerprint, current);
+      }
     }
+
+    const repeatedErrorFingerprints = Array.from(fingerprintCounts.entries())
+      .filter(([, value]) => value.count > 1)
+      .sort((a, b) => b[1].count - a[1].count)
+      .slice(0, 5)
+      .map(([fingerprint, value]) => ({
+        fingerprint,
+        count: value.count,
+        failureClass: value.failureClass,
+      }));
 
     return {
       total: entries.length,
       succeeded,
       failed,
       toolCounts,
-      milestones: entries.filter(e => e.milestone),
+      milestones: entries.filter((e) => e.milestone),
+      failureClasses,
+      repeatedErrorFingerprints,
+      lastProgressTool,
+      recentNonProgressTools: recentNonProgressTools.slice(-5),
+      candidateRecoveryHints: buildCandidateRecoveryHints(failureClasses),
       period: {
         start: entries[0]?.ts || Date.now(),
         end: entries[entries.length - 1]?.ts || Date.now(),
@@ -169,12 +294,25 @@ export class TaskJournal {
   /**
    * Sanitize tool arguments — redact sensitive fields.
    */
-  sanitizeArgs(tool: string, args: Record<string, unknown>): Record<string, unknown> {
+  sanitizeResultSummary(text: string): string {
+    return text
+      .replace(
+        /(password|token|secret|credential|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi,
+        "$1=[REDACTED]",
+      )
+      .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [REDACTED]")
+      .slice(0, 500);
+  }
+
+  sanitizeArgs(
+    tool: string,
+    args: Record<string, unknown>,
+  ): Record<string, unknown> {
     if (REDACT_TOOLS.has(tool)) return { _redacted: true };
     const sanitized: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(args)) {
       if (REDACT_KEYS.test(k)) {
-        sanitized[k] = '[REDACTED]';
+        sanitized[k] = "[REDACTED]";
       } else {
         sanitized[k] = v;
       }
@@ -182,27 +320,114 @@ export class TaskJournal {
     return sanitized;
   }
 
+  classifyFailure(entry: JournalEntry): JournalFailureClass | null {
+    const text =
+      `${entry.tool} ${entry.summary} ${entry.resultSummary ?? ""}`.toLowerCase();
+    if (entry.ok && !hasNonProgressSignal(text)) return null;
+
+    if (
+      /(stale|no longer available|target .*not found|tab .*not found|ref_\d+|backendnodeid)/i.test(
+        text,
+      )
+    )
+      return "stale_ref";
+    if (
+      /(authredirect|login page detected|redirected to login|sign in|signin|unauthorized|401)/i.test(
+        text,
+      )
+    )
+      return "auth_redirect";
+    if (
+      /(captcha|waf|cloudflare|access denied|bot-check|bot verification|been blocked|forbidden|403)/i.test(
+        text,
+      )
+    )
+      return "captcha_or_waf";
+    if (/(timed out|timeout|navigation timeout)/i.test(text)) return "timeout";
+    if (
+      /(net::err_|network error|connection reset|econnreset|enotfound|eai_again|socket hang up)/i.test(
+        text,
+      )
+    )
+      return "network_error";
+    if (
+      /(oc_assert|assertion|contract|verdict.*fail|failed_assertions|inconclusive)/i.test(
+        text,
+      )
+    )
+      return "contract_failed";
+    if (
+      /(empty result|no data|no rows|no matches|not found|missing selector|selector .*missing)/i.test(
+        text,
+      )
+    )
+      return "empty_result";
+    if (
+      /(not making progress|stuck|stalling|non-progress|same action|repeated)/i.test(
+        text,
+      )
+    )
+      return "non_progress_loop";
+
+    return entry.ok ? null : "unknown";
+  }
+
+  private isProgressEntry(entry: JournalEntry): boolean {
+    if (!entry.ok) return false;
+    if (OBSERVATION_TOOLS.has(entry.tool)) return false;
+    if (!PROGRESS_TOOLS.has(entry.tool)) return false;
+    return !this.classifyFailure(entry);
+  }
+
+  private fingerprintEntry(entry: JournalEntry): string {
+    const raw = `${entry.failureClass ?? "unknown"}:${entry.tool}:${entry.resultSummary ?? entry.summary}`;
+    return raw
+      .toLowerCase()
+      .replace(/https?:\/\/[^\s)]+/g, "{url}")
+      .replace(/ref_\d+/g, "ref_{n}")
+      .replace(/\b[0-9a-f]{8,}\b/g, "{id}")
+      .replace(/\d+/g, "{n}")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 120);
+  }
+
   /**
    * Generate human-readable 1-line summary.
    */
-  generateSummary(tool: string, args: Record<string, unknown>, ok: boolean): string {
-    const s = ok ? '✓' : '✗';
+  generateSummary(
+    tool: string,
+    args: Record<string, unknown>,
+    ok: boolean,
+  ): string {
+    const s = ok ? "✓" : "✗";
     switch (tool) {
-      case 'navigate': return `${s} → ${args.url || 'unknown'}`;
-      case 'read_page': return `${s} Read page`;
-      case 'interact': return `${s} Click "${args.description || args.selector || ''}"`;
-      case 'fill_form': {
+      case "navigate":
+        return `${s} → ${args.url || "unknown"}`;
+      case "read_page":
+        return `${s} Read page`;
+      case "interact":
+        return `${s} Click "${args.description || args.selector || ""}"`;
+      case "fill_form": {
         const fields = args.fields as Record<string, unknown> | undefined;
         return `${s} Fill form (${fields ? Object.keys(fields).length : 0} fields)`;
       }
-      case 'find': return `${s} Find "${args.description || args.selector || ''}"`;
-      case 'javascript_tool': return `${s} JS eval`;
-      case 'tabs_create': return `${s} New tab${args.url ? ` → ${args.url}` : ''}`;
-      case 'tabs_close': return `${s} Close tab`;
-      case 'oc_stop': return `${s} Stop OpenChrome`;
-      case 'oc_session_snapshot': return `${s} Snapshot saved`;
-      case 'workflow_init': return `${s} Workflow started`;
-      default: return `${s} ${tool}`;
+      case "find":
+        return `${s} Find "${args.description || args.selector || ""}"`;
+      case "javascript_tool":
+        return `${s} JS eval`;
+      case "tabs_create":
+        return `${s} New tab${args.url ? ` → ${args.url}` : ""}`;
+      case "tabs_close":
+        return `${s} Close tab`;
+      case "oc_stop":
+        return `${s} Stop OpenChrome`;
+      case "oc_session_snapshot":
+        return `${s} Snapshot saved`;
+      case "workflow_init":
+        return `${s} Workflow started`;
+      default:
+        return `${s} ${tool}`;
     }
   }
 
@@ -212,10 +437,10 @@ export class TaskJournal {
   private async pruneOldFiles(): Promise<void> {
     try {
       const files = await fs.promises.readdir(this.dir);
-      const cutoff = Date.now() - (this.maxAgeDays * 86400000);
+      const cutoff = Date.now() - this.maxAgeDays * 86400000;
 
       for (const file of files) {
-        if (!file.startsWith('journal-') || !file.endsWith('.jsonl')) continue;
+        if (!file.startsWith("journal-") || !file.endsWith(".jsonl")) continue;
         const dateStr = file.slice(8, 18); // journal-YYYY-MM-DD.jsonl
         const fileDate = new Date(dateStr).getTime();
         if (fileDate && fileDate < cutoff) {
@@ -232,6 +457,63 @@ export class TaskJournal {
     const d = date || new Date();
     return d.toISOString().slice(0, 10); // YYYY-MM-DD
   }
+}
+
+function emptyFailureClassCounts(): Record<JournalFailureClass, number> {
+  return {
+    stale_ref: 0,
+    auth_redirect: 0,
+    captcha_or_waf: 0,
+    timeout: 0,
+    network_error: 0,
+    empty_result: 0,
+    contract_failed: 0,
+    non_progress_loop: 0,
+    unknown: 0,
+  };
+}
+
+function hasNonProgressSignal(text: string): boolean {
+  return /(authredirect|login page detected|captcha|waf|stale|timed out|timeout|empty result|not making progress|stuck|stalling|contract.*fail|assertion.*fail)/i.test(
+    text,
+  );
+}
+
+function buildCandidateRecoveryHints(
+  counts: Record<JournalFailureClass, number>,
+): string[] {
+  const hints: string[] = [];
+  if (counts.stale_ref > 0)
+    hints.push("Refresh page state with read_page before retrying stale refs.");
+  if (counts.auth_redirect > 0)
+    hints.push(
+      "Verify authentication in a headed or persistent-profile session before retrying protected pages.",
+    );
+  if (counts.captcha_or_waf > 0)
+    hints.push(
+      "Stop repeated automation and use headed fallback or user-assisted verification for CAPTCHA/WAF blocks.",
+    );
+  if (counts.timeout > 0)
+    hints.push(
+      "Check partial page state with read_page and use shorter wait conditions before retrying timeout-prone actions.",
+    );
+  if (counts.network_error > 0)
+    hints.push(
+      "Retry after network recovery and inspect connection health before continuing.",
+    );
+  if (counts.empty_result > 0)
+    hints.push(
+      "Re-read the page and verify selectors or extraction criteria before repeating the same query.",
+    );
+  if (counts.contract_failed > 0)
+    hints.push(
+      "Inspect failed assertions and collect fresh evidence before continuing the plan.",
+    );
+  if (counts.non_progress_loop > 0)
+    hints.push(
+      "Change strategy instead of repeating the same observe/retry loop.",
+    );
+  return hints.slice(0, 5);
 }
 
 /** Singleton */

--- a/src/journal/task-journal.ts
+++ b/src/journal/task-journal.ts
@@ -323,7 +323,7 @@ export class TaskJournal {
   classifyFailure(entry: JournalEntry): JournalFailureClass | null {
     const text =
       `${entry.tool} ${entry.summary} ${entry.resultSummary ?? ""}`.toLowerCase();
-    if (entry.ok && !hasNonProgressSignal(text)) return null;
+    if (entry.ok && !hasOkNonProgressSignal(text)) return null;
 
     if (
       /(stale|no longer available|target .*not found|tab .*not found|ref_\d+|backendnodeid)/i.test(
@@ -473,10 +473,8 @@ function emptyFailureClassCounts(): Record<JournalFailureClass, number> {
   };
 }
 
-function hasNonProgressSignal(text: string): boolean {
-  return /(authredirect|auth_redirect_required|login page detected|captcha|waf|stale|timed out|timeout|empty result|not making progress|stuck|stalling|contract.*fail|assertion.*fail|auth_redirect_required|failed_assertions|inconclusive)/i.test(
-    text,
-  );
+function hasOkNonProgressSignal(text: string): boolean {
+  return /(auth_redirect_required|failed_assertions|inconclusive|contract_failed|assertion_failed)/i.test(text);
 }
 
 function buildCandidateRecoveryHints(

--- a/src/journal/task-journal.ts
+++ b/src/journal/task-journal.ts
@@ -337,7 +337,7 @@ export class TaskJournal {
     )
       return "stale_ref";
     if (
-      /(authredirect|auth_redirect_required|login page detected|redirected to login|sign in|signin|unauthorized|401)/i.test(
+      /(authredirect|auth_redirect_required|login page detected|redirected to (?:login|sign[- ]?in)|please sign[- ]?in|sign[- ]?in required|sign[- ]?in to continue|must sign[- ]?in|sign[- ]?in to (?:access|view)|unauthorized|\b401\b)/i.test(
         text,
       )
     )

--- a/src/journal/task-journal.ts
+++ b/src/journal/task-journal.ts
@@ -322,7 +322,7 @@ export class TaskJournal {
 
   classifyFailure(entry: JournalEntry): JournalFailureClass | null {
     const text =
-      `${entry.tool} ${entry.summary} ${entry.resultSummary ?? ""}`.toLowerCase();
+      `${entry.tool} ${stripUrls(entry.summary)} ${entry.resultSummary ?? ""}`.toLowerCase();
     if (entry.ok && !hasOkNonProgressSignal(text)) return null;
 
     if (
@@ -471,6 +471,10 @@ function emptyFailureClassCounts(): Record<JournalFailureClass, number> {
     non_progress_loop: 0,
     unknown: 0,
   };
+}
+
+function stripUrls(text: string): string {
+  return text.replace(/https?:\/\/[^\s)]+/gi, '[url]');
 }
 
 function hasOkNonProgressSignal(text: string): boolean {

--- a/src/journal/task-journal.ts
+++ b/src/journal/task-journal.ts
@@ -297,6 +297,11 @@ export class TaskJournal {
   sanitizeResultSummary(text: string): string {
     return text
       .replace(
+        /(["'])(password|token|secret|credential|api[_-]?key)\1\s*:\s*(["'])(?:\\.|(?!\3).)*\3/gi,
+        (_match, keyQuote: string, key: string, valueQuote: string) =>
+          `${keyQuote}${key}${keyQuote}:${valueQuote}[REDACTED]${valueQuote}`,
+      )
+      .replace(
         /(password|token|secret|credential|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi,
         "$1=[REDACTED]",
       )

--- a/src/journal/task-journal.ts
+++ b/src/journal/task-journal.ts
@@ -326,7 +326,7 @@ export class TaskJournal {
     if (entry.ok && !hasOkNonProgressSignal(text)) return null;
 
     if (
-      /(stale|no longer available|target .*not found|tab .*not found|ref_\d+|backendnodeid)/i.test(
+      /(no longer available|target .*not found|tab .*not found|ref_\d+|backendnodeid|stale\s+(?:ref|reference|element|node)|(?:ref|reference|element|node)\s+(?:is\s+)?stale)/i.test(
         text,
       )
     )

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -58,6 +58,7 @@ import { getActionRecorder } from './recording/action-recorder';
 import {
   substituteSecrets,
   redactSecrets,
+  redactSecretString,
   MissingSecretError,
   getSecretStore,
 } from './core/secrets';
@@ -1920,6 +1921,7 @@ export class MCPServer {
       return finalResult;
     } catch (error) {
       const message = formatError(error);
+      const redactedMessage = redactSecretString(message);
       const abortReason = isClientDisconnect(error) ? 'client_disconnect' : null;
       const aborted = abortReason !== null;
 
@@ -1964,7 +1966,7 @@ export class MCPServer {
           toolArgs,
           Date.now() - toolStartTime,
           false,
-          message,
+          redactedMessage,
         );
         journal.record(entry);
       } catch {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1763,22 +1763,6 @@ export class MCPServer {
         // Best-effort metrics
       }
 
-      // Record to task journal
-      try {
-        const journal = getTaskJournal();
-        const entry = journal.createEntry(
-          toolName,
-          sessionId,
-          toolArgs,
-          Date.now() - toolStartTime,
-          !(result as MCPResult).isError,
-          summarizeMcpResultForJournal(result as MCPResult),
-        );
-        journal.record(entry);
-      } catch {
-        // Best-effort journal recording
-      }
-
       // Record to session recording (best-effort, skip recording tools themselves)
       try {
         const recorder = getActionRecorder();
@@ -1915,6 +1899,24 @@ export class MCPServer {
       // when --secrets was not passed.
       const finalResult = redactSecrets(result);
       this.recordToolOutputObservability(toolName, finalResult);
+
+      // Record to task journal after response redaction so arbitrary literal
+      // secret values cannot be persisted in journal result summaries.
+      try {
+        const journal = getTaskJournal();
+        const entry = journal.createEntry(
+          toolName,
+          sessionId,
+          toolArgs,
+          Date.now() - toolStartTime,
+          !(finalResult as MCPResult).isError,
+          summarizeMcpResultForJournal(finalResult as MCPResult),
+        );
+        journal.record(entry);
+      } catch {
+        // Best-effort journal recording
+      }
+
       return finalResult;
     } catch (error) {
       const message = formatError(error);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -306,12 +306,18 @@ export interface MCPServerOptions {
 }
 
 
-function summarizeMcpResultForJournal(result: MCPResult): string | undefined {
+export function summarizeMcpResultForJournal(result: MCPResult): string | undefined {
   const content = result.content;
   if (!Array.isArray(content)) return undefined;
+  const injectedHint = typeof (result as Record<string, unknown>)._hint === 'string'
+    ? String((result as Record<string, unknown>)._hint).trim()
+    : undefined;
   const text = content
     .map((part) => (part && part.type === 'text' ? part.text : ''))
-    .filter(Boolean)
+    .filter((textPart) => {
+      if (!textPart) return false;
+      return injectedHint === undefined || textPart.trim() !== injectedHint;
+    })
     .join(' ')
     .replace(/\s+/g, ' ')
     .trim();

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -304,6 +304,19 @@ export interface MCPServerOptions {
   initialToolTier?: ToolTier;
 }
 
+
+function summarizeMcpResultForJournal(result: MCPResult): string | undefined {
+  const content = result.content;
+  if (!Array.isArray(content)) return undefined;
+  const text = content
+    .map((part) => (part && part.type === 'text' ? part.text : ''))
+    .filter(Boolean)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return text ? text.slice(0, 500) : undefined;
+}
+
 export class MCPServer {
   private tools: Map<string, ToolRegistry> = new Map();
   private resources: Map<string, MCPResourceDefinition> = new Map();
@@ -1753,7 +1766,14 @@ export class MCPServer {
       // Record to task journal
       try {
         const journal = getTaskJournal();
-        const entry = journal.createEntry(toolName, sessionId, toolArgs, Date.now() - toolStartTime, true);
+        const entry = journal.createEntry(
+          toolName,
+          sessionId,
+          toolArgs,
+          Date.now() - toolStartTime,
+          !(result as MCPResult).isError,
+          summarizeMcpResultForJournal(result as MCPResult),
+        );
         journal.record(entry);
       } catch {
         // Best-effort journal recording
@@ -1936,7 +1956,14 @@ export class MCPServer {
       // Record to task journal
       try {
         const journal = getTaskJournal();
-        const entry = journal.createEntry(toolName, sessionId, toolArgs, Date.now() - toolStartTime, false);
+        const entry = journal.createEntry(
+          toolName,
+          sessionId,
+          toolArgs,
+          Date.now() - toolStartTime,
+          false,
+          message,
+        );
         journal.record(entry);
       } catch {
         // Best-effort journal recording

--- a/src/tools/journal.ts
+++ b/src/tools/journal.ts
@@ -88,7 +88,7 @@ const handler: ToolHandler = async (
       lines.push(`Tools: ${sorted.map(([t, c]) => `${t}(${c})`).join(', ')}`);
     }
 
-    const failureClasses = Object.entries(summary.failureClasses)
+    const failureClasses = Object.entries(summary.failureClasses ?? {})
       .filter(([, count]) => count > 0)
       .sort((a, b) => b[1] - a[1]);
     if (failureClasses.length > 0) {
@@ -101,24 +101,27 @@ const handler: ToolHandler = async (
       lines.push(`Last progress: ${time} ${summary.lastProgressTool.summary}`);
     }
 
-    if (summary.recentNonProgressTools.length > 0) {
+    const recentNonProgressTools = summary.recentNonProgressTools ?? [];
+    if (recentNonProgressTools.length > 0) {
       lines.push('Recent non-progress:');
-      for (const item of summary.recentNonProgressTools) {
+      for (const item of recentNonProgressTools) {
         const time = new Date(item.ts).toLocaleTimeString();
         lines.push(`  ${time} [${item.failureClass}] ${item.summary}`);
       }
     }
 
-    if (summary.repeatedErrorFingerprints.length > 0) {
+    const repeatedErrorFingerprints = summary.repeatedErrorFingerprints ?? [];
+    if (repeatedErrorFingerprints.length > 0) {
       lines.push('Repeated error fingerprints:');
-      for (const item of summary.repeatedErrorFingerprints) {
+      for (const item of repeatedErrorFingerprints) {
         lines.push(`  ${item.fingerprint} ×${item.count} (${item.failureClass})`);
       }
     }
 
-    if (summary.candidateRecoveryHints.length > 0) {
+    const candidateRecoveryHints = summary.candidateRecoveryHints ?? [];
+    if (candidateRecoveryHints.length > 0) {
       lines.push('Candidate recovery hints:');
-      for (const hint of summary.candidateRecoveryHints) {
+      for (const hint of candidateRecoveryHints) {
         lines.push(`  - ${hint}`);
       }
     }

--- a/src/tools/journal.ts
+++ b/src/tools/journal.ts
@@ -88,6 +88,41 @@ const handler: ToolHandler = async (
       lines.push(`Tools: ${sorted.map(([t, c]) => `${t}(${c})`).join(', ')}`);
     }
 
+    const failureClasses = Object.entries(summary.failureClasses)
+      .filter(([, count]) => count > 0)
+      .sort((a, b) => b[1] - a[1]);
+    if (failureClasses.length > 0) {
+      lines.push('');
+      lines.push(`Failure classes: ${failureClasses.map(([klass, count]) => `${klass}(${count})`).join(', ')}`);
+    }
+
+    if (summary.lastProgressTool) {
+      const time = new Date(summary.lastProgressTool.ts).toLocaleTimeString();
+      lines.push(`Last progress: ${time} ${summary.lastProgressTool.summary}`);
+    }
+
+    if (summary.recentNonProgressTools.length > 0) {
+      lines.push('Recent non-progress:');
+      for (const item of summary.recentNonProgressTools) {
+        const time = new Date(item.ts).toLocaleTimeString();
+        lines.push(`  ${time} [${item.failureClass}] ${item.summary}`);
+      }
+    }
+
+    if (summary.repeatedErrorFingerprints.length > 0) {
+      lines.push('Repeated error fingerprints:');
+      for (const item of summary.repeatedErrorFingerprints) {
+        lines.push(`  ${item.fingerprint} ×${item.count} (${item.failureClass})`);
+      }
+    }
+
+    if (summary.candidateRecoveryHints.length > 0) {
+      lines.push('Candidate recovery hints:');
+      for (const hint of summary.candidateRecoveryHints) {
+        lines.push(`  - ${hint}`);
+      }
+    }
+
     if (summary.total > 0) {
       const failRate = ((summary.failed / summary.total) * 100).toFixed(1);
       lines.push(`Failure rate: ${failRate}%`);

--- a/tests/journal/task-journal.test.ts
+++ b/tests/journal/task-journal.test.ts
@@ -574,6 +574,26 @@ describe('TaskJournal failure summaries', () => {
     expect(entry.resultSummary).not.toContain('secret-token');
   });
 
+  it('classifies known non-progress signals even when the tool result was ok', () => {
+    for (const [tool, resultSummary, expected] of [
+      ['validate_page', 'auth_redirect_required', 'auth_redirect'],
+      ['oc_assert', 'failed_assertions contained missing text', 'contract_failed'],
+      ['oc_assert', 'assertion inconclusive after retries', 'contract_failed'],
+    ] as const) {
+      const entry: JournalEntry = {
+        ts: Date.now(),
+        tool,
+        sessionId: 'sess',
+        args: {},
+        durationMs: 10,
+        ok: true,
+        summary: `✓ ${tool}`,
+        resultSummary,
+      };
+      expect(journal.classifyFailure(entry)).toBe(expected);
+    }
+  });
+
   it('derives classes for older entries without stored failureClass fields', () => {
     const oldEntry: JournalEntry = {
       ts: Date.now(),

--- a/tests/journal/task-journal.test.ts
+++ b/tests/journal/task-journal.test.ts
@@ -574,6 +574,22 @@ describe('TaskJournal failure summaries', () => {
     expect(entry.resultSummary).not.toContain('secret-token');
   });
 
+  it('redacts quoted JSON-style sensitive fields from result summaries', () => {
+    const entry = journal.createEntry(
+      'extract_data',
+      'sess',
+      {},
+      10,
+      false,
+      'payload {"token":"abc123", "password":"hunter2", "ok":true}',
+    );
+
+    expect(entry.resultSummary).toContain('"token":"[REDACTED]"');
+    expect(entry.resultSummary).toContain('"password":"[REDACTED]"');
+    expect(entry.resultSummary).not.toContain('abc123');
+    expect(entry.resultSummary).not.toContain('hunter2');
+  });
+
   it('does not classify unrelated stale wording as stale_ref', () => {
     const entry = journal.createEntry(
       'extract_data',

--- a/tests/journal/task-journal.test.ts
+++ b/tests/journal/task-journal.test.ts
@@ -603,6 +603,46 @@ describe('TaskJournal failure summaries', () => {
     expect(entry.failureClass).toBe('empty_result');
   });
 
+  it('does not classify stale_ref failures whose summary mentions a Sign in label as auth_redirect', () => {
+    const entry = journal.createEntry(
+      'interact',
+      'sess',
+      { description: 'Sign in button' },
+      10,
+      false,
+      'Element ref_7 is stale and no longer available',
+    );
+
+    expect(entry.summary).toContain('Sign in');
+    expect(entry.failureClass).toBe('stale_ref');
+  });
+
+  it('classifies auth-flow phrases as auth_redirect', () => {
+    const cases: Array<[string, string]> = [
+      ['navigate', 'redirected to sign in'],
+      ['navigate', 'please sign in to continue'],
+      ['navigate', 'sign-in required before proceeding'],
+    ];
+    for (const [tool, message] of cases) {
+      const entry = journal.createEntry(tool, 'sess', {}, 10, false, message);
+      expect(entry.failureClass).toBe('auth_redirect');
+    }
+  });
+
+  it('does not classify a bare Sign in button label as auth_redirect when there is no auth-flow error', () => {
+    const entry = journal.createEntry(
+      'interact',
+      'sess',
+      { description: 'Sign in' },
+      10,
+      false,
+      'click intercepted by overlay',
+    );
+
+    expect(entry.summary).toContain('Sign in');
+    expect(entry.failureClass).not.toBe('auth_redirect');
+  });
+
   it('does not derive auth_redirect solely from destination URL path', () => {
     const entry = journal.createEntry(
       'navigate',

--- a/tests/journal/task-journal.test.ts
+++ b/tests/journal/task-journal.test.ts
@@ -574,6 +574,20 @@ describe('TaskJournal failure summaries', () => {
     expect(entry.resultSummary).not.toContain('secret-token');
   });
 
+  it('does not classify benign ok summaries that mention broad failure words', () => {
+    const entry: JournalEntry = {
+      ts: Date.now(),
+      tool: 'navigate',
+      sessionId: 'sess',
+      args: {},
+      durationMs: 10,
+      ok: true,
+      summary: '✓ navigate to https://example.com/timeout-guide',
+      resultSummary: 'page explains timeout handling but loaded successfully',
+    };
+    expect(journal.classifyFailure(entry)).toBeNull();
+  });
+
   it('classifies known non-progress signals even when the tool result was ok', () => {
     for (const [tool, resultSummary, expected] of [
       ['validate_page', 'auth_redirect_required', 'auth_redirect'],

--- a/tests/journal/task-journal.test.ts
+++ b/tests/journal/task-journal.test.ts
@@ -502,3 +502,92 @@ describe('TaskJournal', () => {
     });
   });
 });
+
+describe('TaskJournal failure summaries', () => {
+  let dir: string;
+  let journal: TaskJournal;
+
+  beforeEach(() => {
+    dir = makeTmpDir();
+    journal = new TaskJournal({ dir });
+  });
+
+  afterEach(() => {
+    cleanupDir(dir);
+  });
+
+  it('classifies representative failure classes deterministically', () => {
+    const cases: Array<[string, string, string]> = [
+      ['interact', 'Element ref_12 is stale and no longer available', 'stale_ref'],
+      ['navigate', 'Login page detected after authRedirect', 'auth_redirect'],
+      ['navigate', 'Cloudflare CAPTCHA / Access Denied', 'captcha_or_waf'],
+      ['wait_for', 'Navigation timeout after 100ms', 'timeout'],
+      ['navigate', 'net::ERR_CONNECTION_RESET network error', 'network_error'],
+      ['extract_data', 'empty result: no matches for selector', 'empty_result'],
+      ['oc_assert', 'contract assertion verdict fail', 'contract_failed'],
+      ['interact', 'not making progress; repeated same action', 'non_progress_loop'],
+    ];
+
+    for (const [tool, message, expected] of cases) {
+      const entry = journal.createEntry(tool, 'sess', {}, 10, false, message);
+      expect(entry.failureClass).toBe(expected);
+      expect(entry.errorFingerprint).toBeTruthy();
+    }
+  });
+
+  it('summarizes failure classes, repeated fingerprints, progress, and recovery hints', () => {
+    journal.record(journal.createEntry('navigate', 'sess', { url: 'https://example.com' }, 10, true));
+    journal.record(journal.createEntry('interact', 'sess', { ref: 'ref_1' }, 10, false, 'Element ref_1 is stale'));
+    journal.record(journal.createEntry('interact', 'sess', { ref: 'ref_2' }, 10, false, 'Element ref_2 is stale'));
+    journal.record(journal.createEntry('wait_for', 'sess', {}, 10, false, 'Timed out waiting for text'));
+
+    const summary = journal.getSummary();
+    expect(summary.failureClasses.stale_ref).toBe(2);
+    expect(summary.failureClasses.timeout).toBe(1);
+    expect(summary.lastProgressTool?.tool).toBe('navigate');
+    expect(summary.recentNonProgressTools.map((item) => item.failureClass)).toEqual([
+      'stale_ref',
+      'stale_ref',
+      'timeout',
+    ]);
+    expect(summary.repeatedErrorFingerprints[0]).toMatchObject({
+      count: 2,
+      failureClass: 'stale_ref',
+    });
+    expect(summary.candidateRecoveryHints.join('\n')).toContain('read_page');
+  });
+
+  it('redacts sensitive data from result summaries before persistence', () => {
+    const entry = journal.createEntry(
+      'navigate',
+      'sess',
+      { url: 'https://example.com' },
+      10,
+      false,
+      'request failed token=abc123 password=hunter2 Authorization: Bearer secret-token',
+    );
+
+    expect(entry.resultSummary).toContain('token=[REDACTED]');
+    expect(entry.resultSummary).toContain('password=[REDACTED]');
+    expect(entry.resultSummary).toContain('Bearer [REDACTED]');
+    expect(entry.resultSummary).not.toContain('hunter2');
+    expect(entry.resultSummary).not.toContain('secret-token');
+  });
+
+  it('derives classes for older entries without stored failureClass fields', () => {
+    const oldEntry: JournalEntry = {
+      ts: Date.now(),
+      tool: 'oc_assert',
+      sessionId: 'sess',
+      args: {},
+      durationMs: 10,
+      ok: false,
+      summary: '✗ oc_assert',
+      resultSummary: 'failed_assertions contained missing text',
+    };
+    journal.record(oldEntry);
+
+    const summary = journal.getSummary();
+    expect(summary.failureClasses.contract_failed).toBe(1);
+  });
+});

--- a/tests/journal/task-journal.test.ts
+++ b/tests/journal/task-journal.test.ts
@@ -574,6 +574,19 @@ describe('TaskJournal failure summaries', () => {
     expect(entry.resultSummary).not.toContain('secret-token');
   });
 
+  it('does not derive auth_redirect solely from destination URL path', () => {
+    const entry = journal.createEntry(
+      'navigate',
+      'sess',
+      { url: 'https://example.com/sign-in-help' },
+      10,
+      false,
+      'Navigation timeout after 100ms',
+    );
+
+    expect(entry.failureClass).toBe('timeout');
+  });
+
   it('does not classify benign ok summaries that mention broad failure words', () => {
     const entry: JournalEntry = {
       ts: Date.now(),

--- a/tests/journal/task-journal.test.ts
+++ b/tests/journal/task-journal.test.ts
@@ -574,6 +574,19 @@ describe('TaskJournal failure summaries', () => {
     expect(entry.resultSummary).not.toContain('secret-token');
   });
 
+  it('does not classify unrelated stale wording as stale_ref', () => {
+    const entry = journal.createEntry(
+      'extract_data',
+      'sess',
+      {},
+      10,
+      false,
+      'empty result; stale cache warning was informational',
+    );
+
+    expect(entry.failureClass).toBe('empty_result');
+  });
+
   it('does not derive auth_redirect solely from destination URL path', () => {
     const entry = journal.createEntry(
       'navigate',

--- a/tests/security/audit-logger-extended.test.ts
+++ b/tests/security/audit-logger-extended.test.ts
@@ -25,7 +25,12 @@ function waitForFlush(): Promise<void> {
 async function waitForAuditEntries(
   logPath: string,
   expectedCount: number,
-  timeoutMs = 1000,
+  // Heavier CI hosts (notably ubuntu-20 / windows-20) sometimes miss the 1s
+  // budget while the audit append is queued behind unrelated I/O. The default
+  // is now 5s so a slow flush surfaces as a deterministic length assertion
+  // rather than as `Cannot read properties of undefined (reading 'args')` on
+  // entries[0].
+  timeoutMs = 5000,
 ): Promise<Array<Record<string, unknown>>> {
   const deadline = Date.now() + timeoutMs;
   let lines: Array<Record<string, unknown>> = [];
@@ -125,8 +130,9 @@ describe('audit-logger extended fields', () => {
     try {
       __resetAuditLoggerCachesForTests();
       logAuditEntry('cookies.set', 'sess_1', { name: 'session', value: 'super-secret' });
-      const entry = (await waitForAuditEntries(logPath, 1))[0];
-      const args = entry.args as Record<string, unknown>;
+      const entries = await waitForAuditEntries(logPath, 1);
+      expect(entries).toHaveLength(1);
+      const args = entries[0].args as Record<string, unknown>;
       expect(typeof args.value).toBe('string');
       expect(args.value as string).toMatch(/^sha256:/);
       expect(args.value).not.toContain('super-secret');

--- a/tests/tools/journal.test.ts
+++ b/tests/tools/journal.test.ts
@@ -39,7 +39,7 @@ jest.mock('../../src/chrome/launcher', () => ({
   })),
 }));
 
-import { MCPServer } from '../../src/mcp-server';
+import { MCPServer, summarizeMcpResultForJournal } from '../../src/mcp-server';
 import { registerJournalTool } from '../../src/tools/journal';
 import { JournalEntry } from '../../src/journal/task-journal';
 
@@ -60,6 +60,25 @@ function makeEntry(overrides: Partial<JournalEntry> = {}): JournalEntry {
 }
 
 // ─── parseSince ──────────────────────────────────────────────────────────────
+
+
+
+describe('summarizeMcpResultForJournal', () => {
+  it('excludes MCP-injected hint text from result summaries', () => {
+    const summary = summarizeMcpResultForJournal({
+      isError: true,
+      _hint: 'Try read_page for stale refs, auth redirects, and timeouts.',
+      content: [
+        { type: 'text', text: 'Error: selector missing' },
+        { type: 'text', text: '\nTry read_page for stale refs, auth redirects, and timeouts.' },
+      ],
+    } as any);
+
+    expect(summary).toBe('Error: selector missing');
+    expect(summary).not.toContain('stale refs');
+    expect(summary).not.toContain('auth redirects');
+  });
+});
 
 describe('parseSince', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Progress / Review status

_Auto-refreshed 2026-05-13 — owner comments cleaned up to reduce review noise._

| Field | Value |
| --- | --- |
| Branch | `feat/1008-journal-failure-summary` → `develop` |
| Draft | no |
| CI | ❌ 8/9 passing — 1 failing |
| Mergeable | ✅ MERGEABLE |
| Review decision | — |
| Codex (latest) | 💡 suggestions posted |
| Other reviewers (latest) | chatgpt-codex-connector: commented |
| Head | `de4b845` — Merge develop into feat/1008-journal-failure-summary |
| Commits | 13 |

<sub>Owner comment cleanup: 12 issue + 0 inline review comments deleted. Outstanding feedback from automated/external reviewers above is unchanged.</sub>
<!-- progress-status:end -->
---

## Summary
- Adds deterministic failure classes to task journal entries and summary derivation.
- Surfaces failure-class counts, repeated fingerprints, last progress, recent non-progress calls, and passive recovery hints in `oc_journal summary`.
- Records sanitized result/error summaries from MCP tool calls so future summaries can classify failures without LLM inference.

Closes #1008.

## Direction / duplication check
- Checked open PRs for reflection/reflexion/journal failure/failure-class/plan-failure work before implementation; no direct duplicate found.
- Scope is intentionally limited to deterministic observability and passive guidance. It does not create reflection artifacts, mutate plans, or execute recovery actions.

## Validation
- ✅ `npm test -- tests/journal/task-journal.test.ts --runInBand`
- ✅ `npm run build`
- ✅ `npx eslint src/journal/task-journal.ts src/tools/journal.ts src/mcp-server.ts --ext .ts --quiet`
- ⚠️ `npm run lint -- --quiet` still fails on pre-existing unrelated errors in `src/session-manager.ts` and `src/tools/connect.ts`.

## OpenChrome live validation plan
Not run in this pass. Merge verifier can run:
1. Start OpenChrome with isolated state.
2. Navigate to a local fixture successfully.
3. Trigger deterministic failures such as missing assertion text or stale/missing ref.
4. Call `oc_journal summary` and verify expected failure classes plus last progress.
5. Run `navigate` + `read_page` again to confirm browser operation is unaffected.