### PR TITLE
test(bench): add perception token and fallback regression suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,13 +541,15 @@ Measure token efficiency and parallel performance:
 ```bash
 npm run benchmark                                    # Stub mode: AX vs DOM token efficiency (interactive)
 npm run benchmark:ci                                 # Stub mode: AX vs DOM with JSON + regression detection
+npm run benchmark:perception                         # Stub mode: perception latency/token/fallback guards
+npm run benchmark:perception -- --ci --json          # CI-friendly JSON output for perception regression checks
 npm run benchmark -- --mode real                     # Real mode: actual MCP server (requires Chrome)
 npx ts-node tests/benchmark/run-parallel.ts          # Stub mode: all parallel benchmark categories
 npx ts-node tests/benchmark/run-parallel.ts --mode real --category batch-js --runs 1  # Real mode
 npx ts-node tests/benchmark/run-parallel.ts --mode real --category realworld --runs 1  # Real-world benchmarks
 ```
 
-By default, benchmarks run in **stub mode** — measuring protocol correctness and tool-call counts with mock responses. Use `--mode real` to spawn an actual MCP server subprocess and measure real performance (requires Chrome to be available).
+By default, benchmarks run in **stub mode** — measuring protocol correctness and tool-call counts with mock responses. Use `--mode real` to spawn an actual MCP server subprocess and measure real performance (requires Chrome to be available). The perception benchmark is intentionally stub-only: it guards token-output caps, fallback-path accounting, and pending spatial-mode reporting without requiring OCR, network pages, or a live browser.
 
 **Parallel benchmark categories:**
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lint:tier": "depcruise --config .dependency-cruiser.cjs src",
     "clean": "rimraf dist",
     "prepare": "npm run build",
-    "lint:changed": "node scripts/lint-changed-src.js"
+    "lint:changed": "node scripts/lint-changed-src.js",
+    "benchmark:perception": "ts-node tests/benchmark/run-perception.ts"
   },
   "keywords": [
     "openchrome",

--- a/tests/benchmark/perception.test.ts
+++ b/tests/benchmark/perception.test.ts
@@ -1,0 +1,94 @@
+/// <reference types="jest" />
+
+import { BenchmarkRunner, MCPAdapter, MCPToolResult } from './benchmark-runner';
+import {
+  createPerceptionTasks,
+  formatPerceptionReport,
+  hasPerceptionFailures,
+  PerceptionStubAdapter,
+} from './perception';
+
+function jsonToolResult(text: string, metadata: Record<string, unknown>): MCPToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify({ text, metadata }) }] };
+}
+
+async function runTask(name: string, adapter: MCPAdapter) {
+  const task = createPerceptionTasks().find((candidate) => candidate.name === name);
+  if (!task) throw new Error(`Missing task ${name}`);
+  return task.run(adapter);
+}
+
+describe('perception benchmark', () => {
+  test('registers token, fallback, and pending spatial guard tasks', () => {
+    expect(createPerceptionTasks().map((task) => task.name)).toEqual([
+      'read_page.dom.large-capped',
+      'read_page.dom.repeated-delta',
+      'read_page.spatial.pending',
+      'find.ax.simple-no-vision',
+      'find.vision.explicit-dense-icon',
+    ]);
+  });
+
+  test('default stub passes guards while marking spatial mode pending', async () => {
+    const runner = new BenchmarkRunner({ runsPerTask: 1, ciMode: true });
+    for (const task of createPerceptionTasks()) runner.addTask(task);
+
+    const report = await runner.run(new PerceptionStubAdapter());
+
+    expect(hasPerceptionFailures(report)).toBe(false);
+    const spatialRun = report.tasks.find((task) => task.name === 'read_page.spatial.pending')?.runs[0];
+    expect(spatialRun?.metadata).toMatchObject({ guard: 'pending', fallbackPath: 'pending', pending: true });
+    expect(formatPerceptionReport(report)).toContain('PERCEPTION BENCHMARK REPORT');
+  });
+
+  test('large DOM guard fails when output exceeds the configured cap', async () => {
+    const adapter: MCPAdapter = {
+      name: 'broken',
+      mode: 'uncapped',
+      async callTool() {
+        return jsonToolResult('x'.repeat(12_500), {
+          fixture: 'large-repeated-dom',
+          fallbackPath: 'dom',
+          truncated: true,
+          capped: true,
+          visionUsed: false,
+        });
+      },
+    };
+
+    const result = await runTask('read_page.dom.large-capped', adapter);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('exceeds cap');
+    expect(result.metadata).toMatchObject({ guard: 'fail' });
+  });
+
+  test('simple find guard fails if it uses vision fallback', async () => {
+    const adapter: MCPAdapter = {
+      name: 'broken',
+      mode: 'vision-first',
+      async callTool() {
+        return jsonToolResult('% [ref_1] Submit', {
+          fixture: 'simple-named-button',
+          fallbackPath: 'vision',
+          truncated: false,
+          capped: false,
+          visionUsed: true,
+        });
+      },
+    };
+
+    const result = await runTask('find.ax.simple-no-vision', adapter);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('must not use vision fallback');
+    expect(result.metadata).toMatchObject({ guard: 'fail', fallbackPath: 'vision' });
+  });
+
+  test('explicit dense-icon fixture records vision fallback separately', async () => {
+    const result = await runTask('find.vision.explicit-dense-icon', new PerceptionStubAdapter());
+
+    expect(result.success).toBe(true);
+    expect(result.metadata).toMatchObject({ guard: 'pass', fallbackPath: 'vision', visionUsed: true });
+  });
+});

--- a/tests/benchmark/perception.test.ts
+++ b/tests/benchmark/perception.test.ts
@@ -18,6 +18,16 @@ async function runTask(name: string, adapter: MCPAdapter) {
   return task.run(adapter);
 }
 
+async function runTaskWithOptions(
+  name: string,
+  adapter: MCPAdapter,
+  options: Parameters<typeof createPerceptionTasks>[0],
+) {
+  const task = createPerceptionTasks(options).find((candidate) => candidate.name === name);
+  if (!task) throw new Error(`Missing task ${name}`);
+  return task.run(adapter);
+}
+
 describe('perception benchmark', () => {
   test('registers token, fallback, and pending spatial guard tasks', () => {
     expect(createPerceptionTasks().map((task) => task.name)).toEqual([
@@ -83,6 +93,36 @@ describe('perception benchmark', () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain('must not use vision fallback');
     expect(result.metadata).toMatchObject({ guard: 'fail', fallbackPath: 'vision' });
+  });
+
+  test('custom wall-time threshold applies to makeResult-based tasks', async () => {
+    const adapter: MCPAdapter = {
+      name: 'slow',
+      mode: 'find',
+      async callTool() {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return jsonToolResult('$ [ref_submit] Submit button', {
+          fixture: 'simple-named-button',
+          fallbackPath: 'ax',
+          truncated: false,
+          capped: false,
+          visionUsed: false,
+        });
+      },
+    };
+
+    const result = await runTaskWithOptions('find.ax.simple-no-vision', adapter, {
+      thresholds: {
+        readPageDomLargeMaxOutputChars: 20_000,
+        readPageRepeatedDeltaMaxOutputChars: 500,
+        findSimpleMaxOutputChars: 400,
+        findVisionMaxOutputChars: 1_200,
+        maxWallTimeMs: 1,
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('above 1ms benchmark guard');
   });
 
   test('explicit dense-icon fixture records vision fallback separately', async () => {

--- a/tests/benchmark/perception.ts
+++ b/tests/benchmark/perception.ts
@@ -30,8 +30,12 @@ export interface PerceptionMetadata {
   reason?: string;
 }
 
+type PerceptionThresholds = {
+  [Key in keyof typeof PERCEPTION_THRESHOLDS]: number;
+};
+
 interface PerceptionTaskOptions {
-  thresholds?: typeof PERCEPTION_THRESHOLDS;
+  thresholds?: PerceptionThresholds;
 }
 
 interface ToolTextAndMetadata {
@@ -72,6 +76,7 @@ function makeResult(
   result: MCPToolResult,
   guard: Omit<PerceptionMetadata, 'outputChars' | 'guard'>,
   check: (outputChars: number, metadata: Partial<PerceptionMetadata>) => string | undefined,
+  maxWallTimeMs: number,
 ): TaskResult {
   const counters = createCounters();
   measureCall(result, args, counters);
@@ -79,8 +84,8 @@ function makeResult(
   const outputChars = text.length;
   const wallTimeMs = Date.now() - startMs;
   let error = result.isError ? text : check(outputChars, metadata);
-  if (!error && wallTimeMs > PERCEPTION_THRESHOLDS.maxWallTimeMs) {
-    error = `tool path took ${wallTimeMs}ms, above ${PERCEPTION_THRESHOLDS.maxWallTimeMs}ms benchmark guard`;
+  if (!error && wallTimeMs > maxWallTimeMs) {
+    error = `tool path took ${wallTimeMs}ms, above ${maxWallTimeMs}ms benchmark guard`;
   }
 
   return {
@@ -234,6 +239,7 @@ export function createPerceptionTasks(options: PerceptionTaskOptions = {}): Benc
             }
             return undefined;
           },
+          thresholds.maxWallTimeMs,
         );
       },
     },
@@ -293,6 +299,7 @@ export function createPerceptionTasks(options: PerceptionTaskOptions = {}): Benc
           result,
           { fixture: 'layout-grid', fallbackPath: 'pending', truncated: false, capped: false, visionUsed: false, pending: true },
           () => undefined,
+          thresholds.maxWallTimeMs,
         );
       },
     },
@@ -317,6 +324,7 @@ export function createPerceptionTasks(options: PerceptionTaskOptions = {}): Benc
             }
             return undefined;
           },
+          thresholds.maxWallTimeMs,
         );
       },
     },
@@ -341,6 +349,7 @@ export function createPerceptionTasks(options: PerceptionTaskOptions = {}): Benc
             }
             return undefined;
           },
+          thresholds.maxWallTimeMs,
         );
       },
     },

--- a/tests/benchmark/perception.ts
+++ b/tests/benchmark/perception.ts
@@ -1,0 +1,397 @@
+import {
+  BenchmarkReport,
+  BenchmarkRunner,
+  BenchmarkTask,
+  MCPAdapter,
+  MCPToolResult,
+  TaskResult,
+} from './benchmark-runner';
+import { createCounters, measureCall } from './utils';
+
+export const PERCEPTION_THRESHOLDS = {
+  readPageDomLargeMaxOutputChars: 12_000,
+  readPageRepeatedDeltaMaxOutputChars: 1_200,
+  findSimpleMaxOutputChars: 2_000,
+  findVisionMaxOutputChars: 4_000,
+  maxWallTimeMs: 1_000,
+} as const;
+
+export type PerceptionFallbackPath = 'ax' | 'dom' | 'vision' | 'pending';
+
+export interface PerceptionMetadata {
+  fixture: string;
+  fallbackPath: PerceptionFallbackPath;
+  outputChars: number;
+  truncated: boolean;
+  capped: boolean;
+  visionUsed: boolean;
+  pending?: boolean;
+  guard: 'pass' | 'fail' | 'pending';
+  reason?: string;
+}
+
+interface PerceptionTaskOptions {
+  thresholds?: typeof PERCEPTION_THRESHOLDS;
+}
+
+interface ToolTextAndMetadata {
+  text: string;
+  metadata: Partial<PerceptionMetadata>;
+}
+
+function resultText(result: MCPToolResult): string {
+  return result.content
+    .map((entry) => entry.text ?? entry.data ?? '')
+    .join('\n');
+}
+
+function resultMetadata(result: MCPToolResult): Partial<PerceptionMetadata> {
+  const first = result.content[0];
+  if (!first?.text) return {};
+  try {
+    const parsed = JSON.parse(first.text) as { text?: string; metadata?: Partial<PerceptionMetadata> };
+    return parsed.metadata ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function unpackResult(result: MCPToolResult): ToolTextAndMetadata {
+  const text = resultText(result);
+  try {
+    const parsed = JSON.parse(text) as { text?: string; metadata?: Partial<PerceptionMetadata> };
+    return { text: parsed.text ?? text, metadata: parsed.metadata ?? {} };
+  } catch {
+    return { text, metadata: resultMetadata(result) };
+  }
+}
+
+function makeResult(
+  startMs: number,
+  args: Record<string, unknown>,
+  result: MCPToolResult,
+  guard: Omit<PerceptionMetadata, 'outputChars' | 'guard'>,
+  check: (outputChars: number, metadata: Partial<PerceptionMetadata>) => string | undefined,
+): TaskResult {
+  const counters = createCounters();
+  measureCall(result, args, counters);
+  const { text, metadata } = unpackResult(result);
+  const outputChars = text.length;
+  const wallTimeMs = Date.now() - startMs;
+  let error = result.isError ? text : check(outputChars, metadata);
+  if (!error && wallTimeMs > PERCEPTION_THRESHOLDS.maxWallTimeMs) {
+    error = `tool path took ${wallTimeMs}ms, above ${PERCEPTION_THRESHOLDS.maxWallTimeMs}ms benchmark guard`;
+  }
+
+  return {
+    success: !error,
+    inputChars: counters.inputChars,
+    outputChars,
+    toolCallCount: counters.toolCallCount,
+    wallTimeMs,
+    error,
+    metadata: {
+      ...guard,
+      ...metadata,
+      outputChars,
+      guard: error ? 'fail' : guard.pending ? 'pending' : 'pass',
+    },
+  };
+}
+
+function jsonToolResult(text: string, metadata: Partial<PerceptionMetadata>): MCPToolResult {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({ text, metadata }),
+      },
+    ],
+  };
+}
+
+export class PerceptionStubAdapter implements MCPAdapter {
+  name = 'openchrome';
+  mode = 'perception-stub';
+  private readCount = 0;
+
+  async callTool(toolName: string, args: Record<string, unknown>): Promise<MCPToolResult> {
+    if (toolName === 'read_page') {
+      return this.readPage(args);
+    }
+    if (toolName === 'find') {
+      return this.find(args);
+    }
+    return { isError: true, content: [{ type: 'text', text: `Unsupported tool: ${toolName}` }] };
+  }
+
+  private async readPage(args: Record<string, unknown>): Promise<MCPToolResult> {
+    const mode = String(args.mode ?? 'dom');
+    const fixture = String(args.fixture ?? 'simple');
+
+    if (mode === 'spatial') {
+      return jsonToolResult('spatial read_page mode is pending behind issue #964', {
+        fixture,
+        fallbackPath: 'pending',
+        truncated: false,
+        capped: false,
+        visionUsed: false,
+        pending: true,
+        reason: 'spatial mode is not implemented yet (#964)',
+      });
+    }
+
+    if (fixture === 'large-repeated-dom') {
+      const repeatedRows = Array.from({ length: 500 }, (_, i) => `[node_${i}] Row ${i} OpenChrome benchmark repeated content`).join('\n');
+      const cap = 10_500;
+      const text = `${repeatedRows.slice(0, cap)}\n[Output truncated: large DOM fixture capped for token budget]`;
+      return jsonToolResult(text, {
+        fixture,
+        fallbackPath: 'dom',
+        truncated: true,
+        capped: true,
+        visionUsed: false,
+      });
+    }
+
+    if (fixture === 'repeated-read-delta') {
+      this.readCount += 1;
+      const text = this.readCount === 1
+        ? '[node_1] Dashboard\n[node_2] Orders\n[node_3] Customers\n[node_4] Settings'
+        : '[delta] changed: [node_3] Customers badge 4 -> 5';
+      return jsonToolResult(text, {
+        fixture,
+        fallbackPath: 'dom',
+        truncated: false,
+        capped: false,
+        visionUsed: false,
+      });
+    }
+
+    return jsonToolResult('[node_1] Submit button\n[node_2] Email textbox', {
+      fixture,
+      fallbackPath: 'dom',
+      truncated: false,
+      capped: false,
+      visionUsed: false,
+    });
+  }
+
+  private async find(args: Record<string, unknown>): Promise<MCPToolResult> {
+    const fixture = String(args.fixture ?? 'simple-named-button');
+    if (fixture === 'simple-named-button') {
+      return jsonToolResult('$ [ref_submit] Submit button', {
+        fixture,
+        fallbackPath: 'ax',
+        truncated: false,
+        capped: false,
+        visionUsed: false,
+      });
+    }
+
+    if (fixture === 'dense-icon-grid') {
+      return jsonToolResult('% [ref_icon_17] icon-only settings target', {
+        fixture,
+        fallbackPath: 'vision',
+        truncated: false,
+        capped: false,
+        visionUsed: true,
+      });
+    }
+
+    return jsonToolResult('[node_9] DOM text match', {
+      fixture,
+      fallbackPath: 'dom',
+      truncated: false,
+      capped: false,
+      visionUsed: false,
+    });
+  }
+}
+
+export function createPerceptionTasks(options: PerceptionTaskOptions = {}): BenchmarkTask[] {
+  const thresholds = options.thresholds ?? PERCEPTION_THRESHOLDS;
+
+  return [
+    {
+      name: 'read_page.dom.large-capped',
+      description: 'Large DOM fixture stays below the token-output cap and reports truncation metadata.',
+      async run(adapter) {
+        const args = { mode: 'dom', fixture: 'large-repeated-dom' };
+        const start = Date.now();
+        const result = await adapter.callTool('read_page', args);
+        return makeResult(
+          start,
+          args,
+          result,
+          { fixture: 'large-repeated-dom', fallbackPath: 'dom', truncated: true, capped: true, visionUsed: false },
+          (outputChars, metadata) => {
+            if (outputChars > thresholds.readPageDomLargeMaxOutputChars) {
+              return `read_page output ${outputChars} chars exceeds cap ${thresholds.readPageDomLargeMaxOutputChars}`;
+            }
+            if (!metadata.truncated || !metadata.capped) {
+              return 'large DOM read_page must report truncated=true and capped=true';
+            }
+            return undefined;
+          },
+        );
+      },
+    },
+    {
+      name: 'read_page.dom.repeated-delta',
+      description: 'Repeated read fixture exposes compact changed output after an initial read.',
+      async run(adapter) {
+        const start = Date.now();
+        const counters = createCounters();
+        const warmupArgs = { mode: 'dom', fixture: 'repeated-read-delta', phase: 'warmup' };
+        const warmupResult = await adapter.callTool('read_page', warmupArgs);
+        measureCall(warmupResult, warmupArgs, counters);
+
+        const args = { mode: 'dom', fixture: 'repeated-read-delta', phase: 'delta' };
+        const result = await adapter.callTool('read_page', args);
+        measureCall(result, args, counters);
+        const { text, metadata } = unpackResult(result);
+        const outputChars = text.length;
+        const wallTimeMs = Date.now() - start;
+        let error = outputChars > thresholds.readPageRepeatedDeltaMaxOutputChars
+          ? `repeated read delta ${outputChars} chars exceeds cap ${thresholds.readPageRepeatedDeltaMaxOutputChars}`
+          : undefined;
+        if (!error && wallTimeMs > thresholds.maxWallTimeMs) {
+          error = `repeated read path took ${wallTimeMs}ms, above ${thresholds.maxWallTimeMs}ms benchmark guard`;
+        }
+
+        return {
+          success: !error,
+          inputChars: counters.inputChars,
+          outputChars,
+          toolCallCount: counters.toolCallCount,
+          wallTimeMs,
+          error,
+          metadata: {
+            fixture: 'repeated-read-delta',
+            fallbackPath: 'dom',
+            truncated: false,
+            capped: false,
+            visionUsed: false,
+            ...metadata,
+            outputChars,
+            guard: error ? 'fail' : 'pass',
+          },
+        };
+      },
+    },
+    {
+      name: 'read_page.spatial.pending',
+      description: 'Spatial mode is reported as pending until issue #964 lands, without failing this suite.',
+      async run(adapter) {
+        const args = { mode: 'spatial', fixture: 'layout-grid' };
+        const start = Date.now();
+        const result = await adapter.callTool('read_page', args);
+        return makeResult(
+          start,
+          args,
+          result,
+          { fixture: 'layout-grid', fallbackPath: 'pending', truncated: false, capped: false, visionUsed: false, pending: true },
+          () => undefined,
+        );
+      },
+    },
+    {
+      name: 'find.ax.simple-no-vision',
+      description: 'Simple named controls resolve through AX/text paths and must not spend a vision fallback.',
+      async run(adapter) {
+        const args = { query: 'Submit', fixture: 'simple-named-button' };
+        const start = Date.now();
+        const result = await adapter.callTool('find', args);
+        return makeResult(
+          start,
+          args,
+          result,
+          { fixture: 'simple-named-button', fallbackPath: 'ax', truncated: false, capped: false, visionUsed: false },
+          (outputChars, metadata) => {
+            if (metadata.visionUsed || metadata.fallbackPath === 'vision') {
+              return 'simple named controls must not use vision fallback';
+            }
+            if (outputChars > thresholds.findSimpleMaxOutputChars) {
+              return `simple find output ${outputChars} chars exceeds cap ${thresholds.findSimpleMaxOutputChars}`;
+            }
+            return undefined;
+          },
+        );
+      },
+    },
+    {
+      name: 'find.vision.explicit-dense-icon',
+      description: 'Explicit dense-icon fixture records the costly vision fallback separately.',
+      async run(adapter) {
+        const args = { query: 'settings icon', fixture: 'dense-icon-grid', vision_fallback: true };
+        const start = Date.now();
+        const result = await adapter.callTool('find', args);
+        return makeResult(
+          start,
+          args,
+          result,
+          { fixture: 'dense-icon-grid', fallbackPath: 'vision', truncated: false, capped: false, visionUsed: true },
+          (outputChars, metadata) => {
+            if (!metadata.visionUsed || metadata.fallbackPath !== 'vision') {
+              return 'dense icon fixture must report explicit vision fallback';
+            }
+            if (outputChars > thresholds.findVisionMaxOutputChars) {
+              return `vision find output ${outputChars} chars exceeds cap ${thresholds.findVisionMaxOutputChars}`;
+            }
+            return undefined;
+          },
+        );
+      },
+    },
+  ];
+}
+
+export function hasPerceptionFailures(report: BenchmarkReport): boolean {
+  return report.tasks.some((task) => task.runs.some((run) => !run.success));
+}
+
+export function formatPerceptionReport(report: BenchmarkReport): string {
+  const lines = [
+    '='.repeat(80),
+    'PERCEPTION BENCHMARK REPORT',
+    '='.repeat(80),
+    `adapter=${report.adapter}/${report.mode}`,
+    'Task'.padEnd(36) + 'Chars'.padStart(10) + 'Calls'.padStart(8) + 'Guard'.padStart(10) + 'Path'.padStart(10),
+    '-'.repeat(80),
+  ];
+
+  for (const task of report.tasks) {
+    const run = task.runs[0];
+    const metadata = (run.metadata ?? {}) as Partial<PerceptionMetadata>;
+    lines.push(
+      task.name.padEnd(36) +
+        String(Math.round(task.stats.meanOutputChars)).padStart(10) +
+        String(Math.round(task.stats.meanToolCalls)).padStart(8) +
+        String(metadata.guard ?? (run.success ? 'pass' : 'fail')).padStart(10) +
+        String(metadata.fallbackPath ?? 'n/a').padStart(10),
+    );
+    if (run.error) {
+      lines.push(`  error: ${run.error}`);
+    }
+    if (metadata.pending && metadata.reason) {
+      lines.push(`  pending: ${metadata.reason}`);
+    }
+  }
+
+  lines.push('='.repeat(80));
+  lines.push(
+    `summary totalOutput=${report.summary.totalOutputChars.toFixed(0)} ` +
+      `totalToolCalls=${report.summary.totalToolCalls.toFixed(0)}`,
+  );
+  lines.push('='.repeat(80));
+  return lines.join('\n');
+}
+
+export async function runPerceptionBenchmark(options: { runs?: number } = {}): Promise<BenchmarkReport> {
+  const runner = new BenchmarkRunner({ runsPerTask: options.runs ?? 1, ciMode: true });
+  for (const task of createPerceptionTasks()) {
+    runner.addTask(task);
+  }
+  return runner.run(new PerceptionStubAdapter());
+}

--- a/tests/benchmark/run-perception.ts
+++ b/tests/benchmark/run-perception.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env ts-node
+/**
+ * Perception benchmark CLI.
+ *
+ * Usage:
+ *   npm run benchmark:perception
+ *   npm run benchmark:perception -- --ci --json
+ */
+
+import { formatPerceptionReport, hasPerceptionFailures, runPerceptionBenchmark } from './perception';
+
+function numberFlag(name: string, fallback: number): number {
+  const idx = process.argv.indexOf(name);
+  if (idx === -1 || idx + 1 >= process.argv.length) return fallback;
+  const parsed = Number(process.argv[idx + 1]);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+async function main(): Promise<void> {
+  const json = process.argv.includes('--json');
+  const ci = process.argv.includes('--ci');
+  const runs = numberFlag('--runs', 1);
+  const report = await runPerceptionBenchmark({ runs });
+
+  if (json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(formatPerceptionReport(report));
+  }
+
+  if (ci && hasPerceptionFailures(report)) {
+    console.error('Perception benchmark guard failed. See task errors above.');
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('Perception benchmark failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds a deterministic `benchmark:perception` script for perception token/latency/fallback regression checks.
- Covers large DOM output caps, repeated-read delta compactness, simple AX/text lookup avoiding vision fallback, explicit dense-icon vision fallback accounting, and pending spatial-mode reporting for #964.
- Documents the new benchmark command in the existing benchmark section.

Closes #972.

## Pre-PR scope review
- Direction fit: this is an observability/guardrail PR only; it does not introduce a new perception mode or alter live browser behavior.
- Duplicate check: `gh pr list --search 'perception benchmark OR benchmark:perception OR issue:972'` returned no open PRs.
- Conflict avoidance: leaves #964 spatial mode and #966/#932 vision overlay work untouched; the benchmark marks spatial mode pending until the feature exists.
- Necessity: gives future perception PRs merge-time evidence for token caps, fallback choice, and regression visibility without external pages, OCR vendors, or Chrome availability.

## Validation
- `npx jest tests/benchmark/perception.test.ts --runInBand`
- `npm run benchmark:perception`
- `npm run benchmark:perception -- --ci --json`
- `npm run build`
- `npm run lint -- --quiet`
- `npm run lint:tier`
- `git diff --check`

## Merge-after OpenChrome verification
After merge, run:

```bash
npm run benchmark:perception -- --ci --json
```

Expected evidence:
- `read_page.dom.large-capped` succeeds with `truncated=true`, `capped=true`, and output below the configured cap.
- `read_page.dom.repeated-delta` reports two tool calls and compact delta output.
- `find.ax.simple-no-vision` succeeds with `fallbackPath=ax` and `visionUsed=false`.
- `find.vision.explicit-dense-icon` succeeds with `fallbackPath=vision` and `visionUsed=true`.
- `read_page.spatial.pending` remains non-failing/pending until #964 implements the feature.
