### PR TITLE
feat(resume): compose checkpoints and journal into session resume guide

### DIFF
--- a/src/tools/session-resume.ts
+++ b/src/tools/session-resume.ts
@@ -10,6 +10,7 @@ import * as os from 'os';
 import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
+import { CHECKPOINT_DIR, CHECKPOINT_FILE } from './checkpoint';
 
 // ─── Shared Types (same as session-snapshot.ts) ────────────────────────────
 
@@ -36,6 +37,31 @@ interface SessionSnapshot {
   tabs: SnapshotTab[];
   memo: SnapshotMemo;
   label?: string;
+}
+
+
+interface AutomationCheckpoint {
+  version: 1;
+  timestamp: number;
+  taskDescription: string;
+  completedSteps: string[];
+  pendingSteps: string[];
+  currentUrl: string | null;
+  tabStates: Array<{ tabId: string; url: string; title: string }>;
+  extractedData: Record<string, unknown>;
+}
+
+interface RecentJournalEntry {
+  ts: number;
+  tool: string;
+  ok: boolean;
+  summary: string;
+}
+
+export interface ResumeGuideContext {
+  checkpoint?: AutomationCheckpoint | null;
+  recentJournal?: RecentJournalEntry[];
+  evidenceBundles?: Array<{ id?: string; path: string }>;
 }
 
 // ─── Tab Status Analysis ───────────────────────────────────────────────────
@@ -86,6 +112,59 @@ export function loadSnapshot(snapshotId?: string): SessionSnapshot | null {
   } catch {
     return null;
   }
+}
+
+
+// ─── Supplemental Artifact Loading ────────────────────────────────────────
+
+export function loadCheckpoint(): AutomationCheckpoint | null {
+  try {
+    const filepath = path.join(CHECKPOINT_DIR, CHECKPOINT_FILE);
+    const content = fs.readFileSync(filepath, 'utf-8');
+    const checkpoint = JSON.parse(content) as AutomationCheckpoint;
+    if (checkpoint.version !== 1) return null;
+    if (!Array.isArray(checkpoint.completedSteps) || !Array.isArray(checkpoint.pendingSteps)) return null;
+    if (!Array.isArray(checkpoint.tabStates) || typeof checkpoint.timestamp !== 'number') return null;
+    return checkpoint;
+  } catch {
+    return null;
+  }
+}
+
+export function loadRecentJournalEntries(limit = 8): RecentJournalEntry[] {
+  const journalDir = path.join(os.homedir(), '.openchrome', 'journal');
+  const dates = [
+    new Date(Date.now() - 86400000).toISOString().slice(0, 10),
+    new Date().toISOString().slice(0, 10),
+  ];
+  const entries: RecentJournalEntry[] = [];
+
+  for (const date of dates) {
+    try {
+      const content = fs.readFileSync(path.join(journalDir, `journal-${date}.jsonl`), 'utf-8');
+      for (const line of content.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const parsed = JSON.parse(trimmed) as RecentJournalEntry;
+          if (typeof parsed.ts === 'number' && typeof parsed.tool === 'string') {
+            entries.push({
+              ts: parsed.ts,
+              tool: parsed.tool,
+              ok: parsed.ok !== false,
+              summary: typeof parsed.summary === 'string' ? parsed.summary : parsed.tool,
+            });
+          }
+        } catch {
+          // Skip malformed journal rows.
+        }
+      }
+    } catch {
+      // Missing journal files are normal.
+    }
+  }
+
+  return entries.sort((a, b) => a.ts - b.ts).slice(-limit);
 }
 
 // ─── Tab Analysis ──────────────────────────────────────────────────────────
@@ -161,7 +240,13 @@ export async function analyzeTabs(savedTabs: SnapshotTab[]): Promise<TabAnalysis
 
 // ─── Resume Guide Generation ───────────────────────────────────────────────
 
-export function generateResumeGuide(snapshot: SessionSnapshot, tabAnalysis: TabAnalysis[]): string {
+function formatRelativeAge(age: number): string {
+  return age < 60000 ? `${Math.round(age / 1000)}s` :
+         age < 3600000 ? `${Math.round(age / 60000)}m` :
+         `${Math.round(age / 3600000)}h`;
+}
+
+export function generateResumeGuide(snapshot: SessionSnapshot, tabAnalysis: TabAnalysis[], context: ResumeGuideContext = {}): string {
   const lines: string[] = [];
 
   const age = Date.now() - snapshot.timestamp;
@@ -230,6 +315,54 @@ export function generateResumeGuide(snapshot: SessionSnapshot, tabAnalysis: TabA
     lines.push(`Notes: ${snapshot.memo.notes}`);
   }
 
+  if (context.checkpoint) {
+    const checkpointAge = Date.now() - context.checkpoint.timestamp;
+    lines.push('');
+    lines.push('Checkpoint:');
+    lines.push(`  Task: ${context.checkpoint.taskDescription || '(not specified)'}`);
+    lines.push(`  Age: ${formatRelativeAge(checkpointAge)}`);
+    if (context.checkpoint.currentUrl) lines.push(`  Current URL: ${context.checkpoint.currentUrl}`);
+    if (context.checkpoint.completedSteps.length > 0) {
+      lines.push('  Completed from checkpoint:');
+      context.checkpoint.completedSteps.slice(-5).forEach(step => lines.push(`    - ${step}`));
+    }
+    if (context.checkpoint.pendingSteps.length > 0) {
+      lines.push('  Pending from checkpoint:');
+      context.checkpoint.pendingSteps.slice(0, 5).forEach((step, i) => lines.push(`    ${i + 1}. ${step}`));
+    }
+    if (checkpointAge > 24 * 3600000) {
+      lines.push('  WARNING: Checkpoint is over 24 hours old; verify live browser state before acting.');
+    }
+  }
+
+  const recentJournal = context.recentJournal ?? [];
+  if (recentJournal.length > 0) {
+    const lastFailure = [...recentJournal].reverse().find(entry => !entry.ok);
+    const lastSuccess = [...recentJournal].reverse().find(entry => entry.ok);
+    lines.push('');
+    lines.push('Recent tool activity:');
+    if (lastSuccess) lines.push(`  Last success: ${lastSuccess.summary}`);
+    if (lastFailure) lines.push(`  Last failure: ${lastFailure.summary}`);
+    lines.push('  Recent entries:');
+    recentJournal.slice(-5).forEach(entry => {
+      lines.push(`    ${entry.ok ? '✓' : '✗'} ${entry.tool}: ${entry.summary}`);
+    });
+    if (lastFailure) {
+      lines.push('  Avoid: repeating the last failed call with identical arguments until page state is refreshed or a different strategy is chosen.');
+    }
+  }
+
+  if (context.evidenceBundles && context.evidenceBundles.length > 0) {
+    lines.push('');
+    lines.push('Evidence bundles:');
+    for (const bundle of context.evidenceBundles.slice(-5)) {
+      lines.push(`  - ${bundle.id ? `${bundle.id}: ` : ''}${bundle.path}`);
+    }
+  }
+
+  lines.push('');
+  lines.push('Recommended next safe action: verify the live tab state with read_page or tabs_context before mutating the page.');
+
   return lines.join('\n');
 }
 
@@ -264,7 +397,10 @@ const handler: ToolHandler = async (
     }));
   }
 
-  const guide = generateResumeGuide(snapshot, tabAnalysis);
+  const guide = generateResumeGuide(snapshot, tabAnalysis, {
+    checkpoint: loadCheckpoint(),
+    recentJournal: loadRecentJournalEntries(),
+  });
 
   return {
     content: [{ type: 'text', text: guide }],

--- a/tests/tools/session-resume.test.ts
+++ b/tests/tools/session-resume.test.ts
@@ -593,3 +593,53 @@ describe('registerSessionResumeTool', () => {
     );
   });
 });
+
+describe('generateResumeGuide supplemental artifacts', () => {
+  test('includes checkpoint completed and pending steps', () => {
+    const snap = makeSnapshot();
+    const guide = generateResumeGuide(snap as any, [], {
+      checkpoint: {
+        version: 1,
+        timestamp: Date.now() - 60_000,
+        taskDescription: 'Research product prices',
+        completedSteps: ['Opened dashboard', 'Collected first page'],
+        pendingSteps: ['Collect second page', 'Export CSV'],
+        currentUrl: 'https://example.com/dashboard',
+        tabStates: [],
+        extractedData: {},
+      },
+    } as any);
+
+    expect(guide).toContain('Checkpoint:');
+    expect(guide).toContain('Research product prices');
+    expect(guide).toContain('Opened dashboard');
+    expect(guide).toContain('Collect second page');
+    expect(guide).toContain('https://example.com/dashboard');
+  });
+
+  test('includes recent success and failure with avoid guidance', () => {
+    const snap = makeSnapshot();
+    const guide = generateResumeGuide(snap as any, [], {
+      recentJournal: [
+        { ts: Date.now() - 2000, tool: 'navigate', ok: true, summary: '✓ → https://example.com' },
+        { ts: Date.now() - 1000, tool: 'interact', ok: false, summary: '✗ Click "missing"' },
+      ],
+    });
+
+    expect(guide).toContain('Recent tool activity:');
+    expect(guide).toContain('Last success: ✓ → https://example.com');
+    expect(guide).toContain('Last failure: ✗ Click "missing"');
+    expect(guide).toContain('Avoid: repeating the last failed call');
+  });
+
+  test('links evidence bundles without embedding blobs', () => {
+    const snap = makeSnapshot();
+    const guide = generateResumeGuide(snap as any, [], {
+      evidenceBundles: [{ id: 'bundle-1', path: '/tmp/openchrome/bundle-1' }],
+    });
+
+    expect(guide).toContain('Evidence bundles:');
+    expect(guide).toContain('bundle-1: /tmp/openchrome/bundle-1');
+    expect(guide).toContain('Recommended next safe action');
+  });
+});


### PR DESCRIPTION
## Summary
- Extends `session_resume` to compose the existing session snapshot with checkpoint and journal artifacts.
- Adds checkpoint task/completed/pending/current URL details, recent success/failure summaries, avoid guidance after failure, and optional evidence-bundle links.
- Keeps the final recommendation conservative: verify live tab state before mutating the page.

## Direction / necessity check
- Fits the repo's long-running harness direction by improving restart/compaction recovery from artifacts OpenChrome already writes.
- Avoids a new state store or orchestration layer; it only summarizes existing checkpoint, journal, and snapshot data.
- Does not overlap open crawl/job progress PRs (#937/#940/#954): this is resume-time guidance, not a background job/progress API.
- No new dependency and no evidence blob embedding.

## Validation
- [x] `npm test -- --runTestsByPath tests/tools/session-resume.test.ts`
- [x] `npm run build:src`
- [x] `npm run lint:tier`

## Post-merge live verification with OpenChrome
1. Run a browser task that writes `~/.openchrome/checkpoints/current-checkpoint.json` with at least one completed and pending step.
2. Call `session_resume` and verify the guide includes `Checkpoint:`, task description, completed steps, pending steps, and current URL.
3. Produce one successful and one failed tool call so the journal has recent entries; call `session_resume` again and verify `Recent tool activity`, `Last success`, `Last failure`, and `Avoid: repeating the last failed call...` appear.
4. If evidence bundle paths are passed by future callers, verify links are listed without embedding binary/blob payloads.
5. Verify the recommended next action remains a non-mutating live-state check (`read_page` or `tabs_context`).

Closes #1004
