### PR TITLE
feat(pilot): gate risky interact clicks with irreversible-action hook

### DIFF
--- a/src/harness/irreversible-action.ts
+++ b/src/harness/irreversible-action.ts
@@ -31,11 +31,19 @@ function normalize(value: string | undefined): string {
   return (value ?? '').toLowerCase().replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
 }
 
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function containsPhrase(text: string, phrase: string): boolean {
+  return new RegExp(`(?:^|\\s)${escapeRegex(phrase)}(?:\\s|$)`).test(text);
+}
+
 export function classifyBrowserActionRisk(input: BrowserActionRiskInput): BrowserActionRisk {
   const text = normalize(`${input.action} ${input.labelText ?? ''}`);
-  const evidence = CRITICAL_ACTION_WORDS.filter((word) => text.includes(word));
-  const negated = SAFE_NEGATIONS.some((word) => text.includes(word));
-  const mutatingClick = ['click', 'double_click'].includes(normalize(input.action));
+  const evidence = CRITICAL_ACTION_WORDS.filter((word) => containsPhrase(text, word));
+  const negated = SAFE_NEGATIONS.some((word) => containsPhrase(text, word));
+  const mutatingClick = ['click', 'double click'].includes(normalize(input.action));
 
   if (!mutatingClick || evidence.length === 0 || negated) {
     return {

--- a/src/harness/irreversible-action.ts
+++ b/src/harness/irreversible-action.ts
@@ -1,0 +1,124 @@
+import type { MCPResult } from '../types/mcp';
+import { isContractRuntimeEnabled } from './flags';
+
+export interface BrowserActionRiskInput {
+  toolName: string;
+  action: string;
+  labelText?: string;
+  pageUrl?: string;
+}
+
+export interface BrowserActionRisk {
+  critical: boolean;
+  actionLabel: string;
+  reason: string;
+  evidence: string[];
+}
+
+const CRITICAL_ACTION_WORDS = [
+  'delete', 'remove', 'destroy', 'erase', 'reset account', 'close account',
+  'submit payment', 'pay', 'purchase', 'checkout', 'buy now', 'place order',
+  'transfer', 'withdraw', 'send money', 'wire',
+  'publish', 'post now', 'send message', 'send email',
+  'disable security', 'change password', 'change email', 'revoke',
+];
+
+const SAFE_NEGATIONS = [
+  'cancel', 'back', 'dismiss', 'close dialog', 'not now', 'learn more', 'preview', 'view', 'read',
+];
+
+function normalize(value: string | undefined): string {
+  return (value ?? '').toLowerCase().replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+export function classifyBrowserActionRisk(input: BrowserActionRiskInput): BrowserActionRisk {
+  const text = normalize(`${input.action} ${input.labelText ?? ''}`);
+  const evidence = CRITICAL_ACTION_WORDS.filter((word) => text.includes(word));
+  const negated = SAFE_NEGATIONS.some((word) => text.includes(word));
+  const mutatingClick = ['click', 'double_click'].includes(normalize(input.action));
+
+  if (!mutatingClick || evidence.length === 0 || negated) {
+    return {
+      critical: false,
+      actionLabel: `${input.toolName}:${input.action}`,
+      reason: negated ? 'matched safe/negating action text' : 'no critical side-effect keyword matched',
+      evidence,
+    };
+  }
+
+  return {
+    critical: true,
+    actionLabel: `${input.toolName}:${evidence[0].replace(/\s+/g, '-')}`,
+    reason: `Matched irreversible-action keyword "${evidence[0]}" in browser action text.`,
+    evidence,
+  };
+}
+
+export async function guardIrreversibleBrowserAction<T>(
+  input: BrowserActionRiskInput,
+  skill: () => Promise<T>,
+): Promise<{ value?: T; blocked?: MCPResult; risk: BrowserActionRisk }> {
+  const risk = classifyBrowserActionRisk(input);
+  if (!risk.critical || !isContractRuntimeEnabled()) {
+    return { value: await skill(), risk };
+  }
+
+  const { runWithContract } = await import('../pilot/runtime/runtime');
+  const record = await runWithContract({
+    contract: {
+      id: `browser-action:${risk.actionLabel}`,
+      domain: input.pageUrl ? safeHost(input.pageUrl) : undefined,
+      critical: true,
+      action: risk.actionLabel,
+      pre: { kind: 'no_dialog' },
+      post: { kind: 'no_dialog' },
+      on_fail: { escalate: 'abort' },
+    },
+    args: {
+      toolName: input.toolName,
+      action: input.action,
+      labelText: input.labelText,
+      pageUrl: input.pageUrl,
+      riskEvidence: risk.evidence,
+    },
+    snapshot: async () => ({
+      async url() { return input.pageUrl ?? ''; },
+      async domText() { return input.labelText ?? ''; },
+      async domCount() { return 0; },
+      async networkSince() { return []; },
+      async screenshotPng() { return null; },
+      async hasOpenDialog() { return false; },
+    }),
+    skill,
+  });
+
+  if (record.verdict === 'success') {
+    return { value: record.skill_result as T, risk };
+  }
+
+  const text = JSON.stringify({
+    status: record.verdict,
+    action: risk.actionLabel,
+    reason: record.error_message ?? record.hook_decision?.reason ?? risk.reason,
+    externalToken: record.hook_decision?.external_token,
+    evidence: risk.evidence,
+  }, null, 2);
+
+  return {
+    risk,
+    blocked: {
+      content: [{ type: 'text', text }],
+      isError: true,
+      _irreversibleAction: {
+        status: record.verdict,
+        action: risk.actionLabel,
+        evidence: risk.evidence,
+        hookDecision: record.hook_decision,
+      },
+    },
+  };
+}
+
+function safeHost(url: string): string | undefined {
+  try { return new URL(url).hostname; } catch { return undefined; }
+}

--- a/src/tools/interact.ts
+++ b/src/tools/interact.ts
@@ -29,6 +29,7 @@ import {
 } from '../core/perception/node-ref';
 import { dispatchCoordinateClick } from '../cdp/input';
 import { coerceVerifyMode, runVerify, VERIFY_FIELD_SCHEMA, VerifyReport } from '../core/perception/verify';
+import { guardIrreversibleBrowserAction } from '../harness/irreversible-action';
 
 /**
  * Inject the structured {@link VerifyReport} onto an MCPResult under
@@ -742,18 +743,28 @@ const handler: ToolHandler = async (
         // Perform action with DOM delta — wrapped in runVerify so the per-action
         // verify report (AX-hash + pHash) is captured around the actual click.
         const isStealth = sessionManager.isStealthTarget(tabId);
-        const { verify: axVerifyReport, result: axActionResult } = await runVerify(
-          page,
-          verifyMode,
-          async () =>
-            withDomDelta(page, async () => {
-              // Stealth: use Bézier curve mouse path to avoid bot detection
-              if (isStealth) await humanMouseMove(page, axX, axY);
-              if (action === 'double_click') await page.mouse.click(axX, axY, { clickCount: 2 });
-              else if (action === 'hover') { if (!isStealth) await page.mouse.move(axX, axY); }
-              else await page.mouse.click(axX, axY);
-            }, { settleMs: Math.max(150, waitAfter) }),
+        const axGuard = await guardIrreversibleBrowserAction(
+          {
+            toolName: 'interact',
+            action,
+            labelText: `${query} ${ax.role} ${ax.name}`,
+            pageUrl: page.url(),
+          },
+          () => runVerify(
+            page,
+            verifyMode,
+            async () =>
+              withDomDelta(page, async () => {
+                // Stealth: use Bézier curve mouse path to avoid bot detection
+                if (isStealth) await humanMouseMove(page, axX, axY);
+                if (action === 'double_click') await page.mouse.click(axX, axY, { clickCount: 2 });
+                else if (action === 'hover') { if (!isStealth) await page.mouse.move(axX, axY); }
+                else await page.mouse.click(axX, axY);
+              }, { settleMs: Math.max(150, waitAfter) }),
+          ),
         );
+        if (axGuard.blocked) return axGuard.blocked;
+        const { verify: axVerifyReport, result: axActionResult } = axGuard.value!;
         const axDelta = axActionResult.delta;
 
         // Invalidate AX cache after interaction
@@ -932,26 +943,36 @@ const handler: ToolHandler = async (
     // Perform the action with DOM delta capture, wrapped in runVerify so the
     // structured verify report (AX-hash + pHash) covers the actual click.
     const isStealthCSS = sessionManager.isStealthTarget(tabId);
-    const { result: cssDomResult, verify: cssVerifyReport } = await runVerify(
-      page,
-      verifyMode,
-      async () =>
-        withDomDelta(
-          page,
-          async () => {
-            // Stealth: use Bézier curve mouse path to avoid bot detection
-            if (isStealthCSS) await humanMouseMove(page, finalX, finalY);
-            if (action === 'double_click') {
-              await page.mouse.click(finalX, finalY, { clickCount: 2 });
-            } else if (action === 'hover') {
-              if (!isStealthCSS) await page.mouse.move(finalX, finalY);
-            } else {
-              await page.mouse.click(finalX, finalY);
-            }
-          },
-          { settleMs: Math.max(150, waitAfter) }
-        ),
+    const cssGuard = await guardIrreversibleBrowserAction(
+      {
+        toolName: 'interact',
+        action,
+        labelText: `${query} ${bestMatch.role} ${bestMatch.name} ${bestMatch.textContent ?? ''}`,
+        pageUrl: page.url(),
+      },
+      () => runVerify(
+        page,
+        verifyMode,
+        async () =>
+          withDomDelta(
+            page,
+            async () => {
+              // Stealth: use Bézier curve mouse path to avoid bot detection
+              if (isStealthCSS) await humanMouseMove(page, finalX, finalY);
+              if (action === 'double_click') {
+                await page.mouse.click(finalX, finalY, { clickCount: 2 });
+              } else if (action === 'hover') {
+                if (!isStealthCSS) await page.mouse.move(finalX, finalY);
+              } else {
+                await page.mouse.click(finalX, finalY);
+              }
+            },
+            { settleMs: Math.max(150, waitAfter) }
+          ),
+      ),
     );
+    if (cssGuard.blocked) return cssGuard.blocked;
+    const { result: cssDomResult, verify: cssVerifyReport } = cssGuard.value!;
     const { delta } = cssDomResult;
 
     // Generate ref for the interacted element

--- a/tests/harness/irreversible-action.test.ts
+++ b/tests/harness/irreversible-action.test.ts
@@ -1,0 +1,60 @@
+import { classifyBrowserActionRisk, guardIrreversibleBrowserAction } from '../../src/harness/irreversible-action';
+import { resetFlagsCache } from '../../src/harness/flags';
+import { registerBeforeIrreversibleHook, resetBeforeIrreversibleHookForTests } from '../../src/pilot/runtime/before-irreversible';
+
+describe('irreversible browser action guard', () => {
+  const oldEnv = process.env.OPENCHROME_PILOT;
+  const oldContract = process.env.OPENCHROME_CONTRACT_RUNTIME;
+
+  afterEach(() => {
+    if (oldEnv === undefined) delete process.env.OPENCHROME_PILOT; else process.env.OPENCHROME_PILOT = oldEnv;
+    if (oldContract === undefined) delete process.env.OPENCHROME_CONTRACT_RUNTIME; else process.env.OPENCHROME_CONTRACT_RUNTIME = oldContract;
+    resetFlagsCache();
+    resetBeforeIrreversibleHookForTests();
+  });
+
+  it('classifies destructive click text as critical', () => {
+    const risk = classifyBrowserActionRisk({ toolName: 'interact', action: 'click', labelText: 'Delete account permanently' });
+
+    expect(risk.critical).toBe(true);
+    expect(risk.evidence).toContain('delete');
+  });
+
+  it('does not classify non-mutating hover or safe cancel text as critical', () => {
+    expect(classifyBrowserActionRisk({ toolName: 'interact', action: 'hover', labelText: 'Delete account' }).critical).toBe(false);
+    expect(classifyBrowserActionRisk({ toolName: 'interact', action: 'click', labelText: 'Cancel delete dialog' }).critical).toBe(false);
+  });
+
+  it('passes through risky actions when pilot contract runtime is disabled', async () => {
+    delete process.env.OPENCHROME_PILOT;
+    resetFlagsCache();
+    let ran = false;
+
+    const result = await guardIrreversibleBrowserAction(
+      { toolName: 'interact', action: 'click', labelText: 'Delete account', pageUrl: 'https://example.com/settings' },
+      async () => { ran = true; return 'clicked'; },
+    );
+
+    expect(ran).toBe(true);
+    expect(result.value).toBe('clicked');
+    expect(result.blocked).toBeUndefined();
+  });
+
+  it('blocks critical actions when pilot hook denies', async () => {
+    process.env.OPENCHROME_PILOT = '1';
+    process.env.OPENCHROME_CONTRACT_RUNTIME = '1';
+    resetFlagsCache();
+    registerBeforeIrreversibleHook(() => ({ proceed: false, reason: 'test policy deny' }));
+    let ran = false;
+
+    const result = await guardIrreversibleBrowserAction(
+      { toolName: 'interact', action: 'click', labelText: 'Submit payment', pageUrl: 'https://shop.example/checkout' },
+      async () => { ran = true; return 'clicked'; },
+    );
+
+    expect(ran).toBe(false);
+    expect(result.blocked?.isError).toBe(true);
+    expect(result.blocked?.content?.[0].text).toContain('test policy deny');
+    expect((result.blocked as any)._irreversibleAction.action).toContain('submit-payment');
+  });
+});

--- a/tests/harness/irreversible-action.test.ts
+++ b/tests/harness/irreversible-action.test.ts
@@ -25,6 +25,18 @@ describe('irreversible browser action guard', () => {
     expect(classifyBrowserActionRisk({ toolName: 'interact', action: 'click', labelText: 'Cancel delete dialog' }).critical).toBe(false);
   });
 
+  it('matches negation tokens on word boundaries (not substring of larger words)', () => {
+    const reviewAndPay = classifyBrowserActionRisk({ toolName: 'interact', action: 'click', labelText: 'Review and pay' });
+    expect(reviewAndPay.critical).toBe(true);
+    expect(reviewAndPay.evidence).toContain('pay');
+  });
+
+  it('treats double_click on critical text as mutating after normalization', () => {
+    const risk = classifyBrowserActionRisk({ toolName: 'interact', action: 'double_click', labelText: 'Delete account permanently' });
+    expect(risk.critical).toBe(true);
+    expect(risk.evidence).toContain('delete');
+  });
+
   it('passes through risky actions when pilot contract runtime is disabled', async () => {
     delete process.env.OPENCHROME_PILOT;
     resetFlagsCache();


### PR DESCRIPTION
## Progress / Review status

_Auto-refreshed 2026-05-13 — owner comments cleaned up to reduce review noise._

| Field | Value |
| --- | --- |
| Branch | `feat/1003-irreversible-confirmation` → `develop` |
| Draft | no |
| CI | ✅ all 9 checks passing |
| Mergeable | ✅ MERGEABLE |
| Review decision | — |
| Codex (latest) | 💡 suggestions posted |
| Other reviewers (latest) | chatgpt-codex-connector: commented |
| Head | `ba1b6b4` — fix(pilot): match risk keywords on word boundaries |
| Commits | 2 |

<sub>Owner comment cleanup: 1 issue + 0 inline review comments deleted. Outstanding feedback from automated/external reviewers above is unchanged.</sub>
<!-- progress-status:end -->
---

## Summary
- Adds a deterministic browser-action risk classifier for irreversible click labels such as delete, payment, purchase, transfer, publish, and account/security changes.
- Wraps `interact` AX/CSS click paths with the pilot contract runtime only when a critical action is detected and `OPENCHROME_PILOT` + `OPENCHROME_CONTRACT_RUNTIME` are enabled.
- Keeps default OpenChrome interaction behavior pass-through when pilot contract runtime is disabled.

## Direction / necessity check
- Fits OpenChrome's safety/portability-harness direction by adding a narrow pre-mutation hook for high-risk browser actions.
- Avoids broad confirmation prompts that would hurt long-running automation; only critical keyword-classified mutating clicks are gated.
- Does not overlap open pilot skill replay/synthesis PRs (#928/#930): this PR only bridges live `interact` clicks to the existing before-irreversible contract gate.
- No new dependency and no change to coordinate interactions or normal non-critical clicks.

## Validation
- [x] `npm test -- --runTestsByPath tests/harness/irreversible-action.test.ts`
- [x] `npm run build:src`
- [x] `npm run lint:tier`

## Post-merge live verification with OpenChrome
1. Start OpenChrome without pilot contract flags and click a fixture button labeled `Delete account`; verify the click proceeds exactly as before.
2. Start with `OPENCHROME_PILOT=1 OPENCHROME_CONTRACT_RUNTIME=1` and register/enable a before-irreversible hook that denies critical actions.
3. Click the same `Delete account` fixture through `interact`; verify the result is `isError: true`, includes `_irreversibleAction.status`, action evidence, and does not mutate the page.
4. Click a safe negation label such as `Cancel delete dialog`; verify it is not gated.
5. Click non-mutating `hover` on destructive text; verify it is not gated.

Closes #1003