### PR TITLE
feat(core): add read-only progress diagnostics (#1060)

### DIFF
--- a/docs/tools/progress-status.md
+++ b/docs/tools/progress-status.md
@@ -1,0 +1,21 @@
+# `oc_progress_status`
+
+`oc_progress_status` reports read-only anti-wandering diagnostics for a session. It summarizes recent completed tool calls as `progressing`, `stalling`, or `stuck`, and returns bounded advisory next-call suggestions.
+
+The tool never stops an episode, retries a failed action, restores a checkpoint, clicks, types, navigates, or calls an LLM. Host agents and benchmark harnesses decide whether to follow the advisory policy.
+
+## Thresholds
+
+- `stuck`: `consecutiveErrors >= 3` or `consecutiveNonProgress >= 5`.
+- `stalling`: `consecutiveNonProgress >= 3`.
+- `stop_episode` advisory: `consecutiveNonProgress >= 8` or `consecutiveErrors >= 5`.
+- `switch_strategy` advisory: coordinate-click streak, tool oscillation, or repeated same-tool streak.
+
+Observation-only calls such as `read_page`, `tabs_context`, and `computer` screenshots count as non-progress for streak purposes.
+
+## Privacy and bounds
+
+- `window` defaults to 10 and is clamped to 3–50.
+- `suggestedNextCalls` is capped at 3 entries.
+- `includeRecentCalls:true` returns compact redacted call summaries only; no raw page text or screenshots are included.
+- Arguments with keys matching password/token/secret/credential/api-key are redacted.

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -180,7 +180,7 @@ export function isConnectionError(error: unknown): boolean {
 
 /** Lifecycle tools that must work even when the CDP connection is broken (e.g., after
  *  sleep/wake). Skip session initialization so recovery handlers can always run. */
-const SKIP_SESSION_INIT_TOOLS = new Set(['oc_stop', 'oc_reap_orphans', 'oc_profile_status', 'oc_session_snapshot', 'oc_session_resume', 'oc_journal', 'oc_run_start', 'oc_run_status', 'oc_run_events', 'oc_run_finish']);
+const SKIP_SESSION_INIT_TOOLS = new Set(['oc_stop', 'oc_reap_orphans', 'oc_profile_status', 'oc_session_snapshot', 'oc_session_resume', 'oc_journal', 'oc_run_start', 'oc_run_status', 'oc_run_events', 'oc_run_finish', 'oc_progress_status']);
 
 /** Tools that may legitimately block the event loop longer than the normal fatal threshold. */
 const HEAVY_TOOLS = new Set(['computer', 'read_page', 'query_dom', 'cookies', 'javascript_tool']);
@@ -199,6 +199,7 @@ const STATE_STABLE_HIGH_FREQ_TOOLS = new Set([
   'wait_for',
   'page_content',
   'tabs_context',
+  'oc_progress_status',
 ]);
 
 /**

--- a/src/progress/progress-status.ts
+++ b/src/progress/progress-status.ts
@@ -1,0 +1,202 @@
+/**
+ * Deterministic read-only progress diagnostics for oc_progress_status (#1060).
+ */
+
+import type { ToolCallEvent } from '../dashboard/types';
+import { ProgressTracker } from '../hints/progress-tracker';
+
+export type ProgressStatus = 'progressing' | 'stalling' | 'stuck';
+export type SuggestedPolicy = 'continue' | 'refresh_state' | 'switch_strategy' | 'checkpoint_and_recover' | 'stop_episode';
+
+export interface ProgressDiagnosticResult {
+  sessionId: string;
+  status: ProgressStatus;
+  window: number;
+  counters: {
+    recentCalls: number;
+    consecutiveErrors: number;
+    consecutiveNonProgress: number;
+    repeatedToolStreak: number;
+    screenshotLoopCount: number;
+    coordinateClickStreak: number;
+    oscillationDetected: boolean;
+  };
+  topSignal?: {
+    rule: string;
+    severity: 'info' | 'warning' | 'critical';
+    message: string;
+  };
+  suggestedPolicy: SuggestedPolicy;
+  suggestedNextCalls: Array<{ tool: string; arguments: Record<string, unknown>; why: string }>;
+  recentCalls?: Array<{ tool: string; ok: boolean; durationMs?: number; argsSummary?: Record<string, unknown> }>;
+}
+
+const REDACT_KEYS = /password|token|secret|credential|api[_-]?key/i;
+const REDACT_TOOLS = new Set(['http_auth', 'cookies']);
+const OBSERVATION_TOOLS = new Set(['read_page', 'tabs_context']);
+const NON_PROGRESS_ERROR = /stale|not found|timeout|timed out|captcha|blocked|forbidden|access denied|not interactive|protocol error|net::err_/i;
+
+function isObservation(call: ToolCallEvent): boolean {
+  if (OBSERVATION_TOOLS.has(call.toolName)) return true;
+  return call.toolName === 'computer' && call.args?.action === 'screenshot';
+}
+
+function isNonProgress(call: ToolCallEvent): boolean {
+  if (call.result === 'error' || call.result === 'aborted') return true;
+  if (isObservation(call)) return true;
+  if (call.error && NON_PROGRESS_ERROR.test(call.error)) return true;
+  return false;
+}
+
+function isCoordinateClick(call: ToolCallEvent): boolean {
+  if (call.toolName !== 'computer') return false;
+  const action = call.args?.action;
+  return typeof action === 'string'
+    && ['left_click', 'right_click', 'double_click', 'triple_click'].includes(action);
+}
+
+function countConsecutive(calls: ToolCallEvent[], predicate: (c: ToolCallEvent) => boolean): number {
+  let count = 0;
+  for (const call of calls) {
+    if (!predicate(call)) break;
+    count++;
+  }
+  return count;
+}
+
+function repeatedToolStreak(calls: ToolCallEvent[]): number {
+  const first = calls[0];
+  if (!first) return 0;
+  return countConsecutive(calls, (c) => c.toolName === first.toolName);
+}
+
+function screenshotLoopCount(calls: ToolCallEvent[]): number {
+  return calls.filter((c) => c.toolName === 'computer' && c.args?.action === 'screenshot').length;
+}
+
+function detectOscillation(calls: ToolCallEvent[]): boolean {
+  if (calls.length < 4) return false;
+  const [a, b, c, d] = calls;
+  return a.toolName === c.toolName && b.toolName === d.toolName && a.toolName !== b.toolName;
+}
+
+function resultTextForTracker(call: ToolCallEvent): string {
+  if (call.result === 'error' || call.result === 'aborted') return call.error || '';
+  if (isObservation(call)) return '';
+  return call.error || 'ok';
+}
+
+function statusFromProgressTracker(calls: ToolCallEvent[]): ProgressStatus {
+  const current = calls[0];
+  if (!current) return 'progressing';
+  const tracker = new ProgressTracker();
+  return tracker.evaluate(
+    calls.slice(1),
+    current.toolName,
+    resultTextForTracker(current),
+    current.result === 'error' || current.result === 'aborted',
+  );
+}
+
+function topSignal(status: ProgressStatus, counters: ProgressDiagnosticResult['counters']): ProgressDiagnosticResult['topSignal'] | undefined {
+  if (counters.coordinateClickStreak >= 3) {
+    return { rule: 'coordinate-click-stall', severity: status === 'stuck' ? 'critical' : 'warning', message: 'Multiple coordinate clicks without progress.' };
+  }
+  if (counters.oscillationDetected) {
+    return { rule: 'tool-oscillation', severity: 'warning', message: 'Recent tool calls oscillate between two tools.' };
+  }
+  if (counters.consecutiveErrors >= 3) {
+    return { rule: 'repeated-error-streak', severity: 'critical', message: 'Three or more consecutive tool errors.' };
+  }
+  if (counters.consecutiveNonProgress >= 3) {
+    return { rule: 'non-progress-streak', severity: status === 'stuck' ? 'critical' : 'warning', message: 'Recent calls are not producing meaningful progress.' };
+  }
+  if (counters.screenshotLoopCount >= 2) {
+    return { rule: 'screenshot-verification-loop', severity: 'warning', message: 'Multiple screenshots appear in the recent window.' };
+  }
+  return undefined;
+}
+
+function policyFor(status: ProgressStatus, counters: ProgressDiagnosticResult['counters']): SuggestedPolicy {
+  if (counters.consecutiveNonProgress >= 8 || counters.consecutiveErrors >= 5) return 'stop_episode';
+  if (counters.consecutiveErrors >= 3) return 'checkpoint_and_recover';
+  if (counters.coordinateClickStreak >= 3 || counters.oscillationDetected || counters.repeatedToolStreak >= 3) return 'switch_strategy';
+  if (status === 'progressing') return 'continue';
+  if (status === 'stuck') return 'checkpoint_and_recover';
+  return 'refresh_state';
+}
+
+function suggestionsFor(policy: SuggestedPolicy): ProgressDiagnosticResult['suggestedNextCalls'] {
+  switch (policy) {
+    case 'refresh_state':
+      return [
+        { tool: 'read_page', arguments: { mode: 'dom' }, why: 'Refresh structured page state before retrying.' },
+        { tool: 'tabs_context', arguments: {}, why: 'Confirm the active tab and URL before continuing.' },
+      ];
+    case 'switch_strategy':
+      return [
+        { tool: 'read_page', arguments: { mode: 'dom' }, why: 'Use DOM/ref state instead of repeating the same action.' },
+        { tool: 'query_dom', arguments: { method: 'css', selector: 'button, a, input, [role=button]', limit: 50 }, why: 'Narrow search to actionable controls.' },
+      ];
+    case 'checkpoint_and_recover':
+    case 'stop_episode':
+      return [
+        { tool: 'oc_checkpoint', arguments: { action: 'save' }, why: 'Persist current state before recovery or episode stop.' },
+        { tool: 'read_page', arguments: { mode: 'dom' }, why: 'Collect fresh state for recovery planning.' },
+      ];
+    case 'continue':
+    default:
+      return [];
+  }
+}
+
+export function sanitizeArgs(toolName: string, args: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  if (!args) return undefined;
+  if (REDACT_TOOLS.has(toolName)) return { _redacted: true };
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(args)) {
+    out[key] = REDACT_KEYS.test(key) ? '[REDACTED]' : value;
+  }
+  return out;
+}
+
+export function buildProgressStatus(input: {
+  sessionId: string;
+  calls: ToolCallEvent[];
+  window: number;
+  includeRecentCalls?: boolean;
+}): ProgressDiagnosticResult {
+  const calls = input.calls.slice(0, input.window);
+  const counters = {
+    recentCalls: calls.length,
+    consecutiveErrors: countConsecutive(calls, (c) => c.result === 'error' || c.result === 'aborted'),
+    consecutiveNonProgress: countConsecutive(calls, isNonProgress),
+    repeatedToolStreak: repeatedToolStreak(calls),
+    screenshotLoopCount: screenshotLoopCount(calls),
+    coordinateClickStreak: countConsecutive(calls, isCoordinateClick),
+    oscillationDetected: detectOscillation(calls),
+  };
+  // Keep the core status aligned with the existing hint-engine ProgressTracker.
+  // Additional counters below only explain the status and shape host-side policy hints.
+  const status = statusFromProgressTracker(calls);
+  const signal = topSignal(status, counters);
+  const suggestedPolicy = policyFor(status, counters);
+  const result: ProgressDiagnosticResult = {
+    sessionId: input.sessionId,
+    status,
+    window: input.window,
+    counters,
+    ...(signal ? { topSignal: signal } : {}),
+    suggestedPolicy,
+    suggestedNextCalls: suggestionsFor(suggestedPolicy).slice(0, 3),
+  };
+  if (input.includeRecentCalls) {
+    result.recentCalls = calls.map((c) => ({
+      tool: c.toolName,
+      ok: c.result === 'success',
+      ...(c.duration !== undefined ? { durationMs: c.duration } : {}),
+      ...(sanitizeArgs(c.toolName, c.args) ? { argsSummary: sanitizeArgs(c.toolName, c.args) } : {}),
+    }));
+  }
+  return result;
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -144,6 +144,8 @@ import { registerOcDevToolsUrlTool } from './oc-devtools-url';
 import { registerOcContextTools } from './oc-context';
 import { isRunHarnessEnabled } from '../run-harness/flags';
 import { registerRunHarnessTools } from '../run-harness/tools';
+// Read-only progress diagnostics (#1060).
+import { registerOcProgressStatusTool } from './oc-progress-status';
 
 export function registerAllTools(server: MCPServer): void {
   // Core browser tools
@@ -259,6 +261,9 @@ export function registerAllTools(server: MCPServer): void {
 
   // Outcome Contracts (#784) — single-call assertion verifier
   registerOcAssertTool(server);
+
+  // Read-only anti-wandering diagnostics (#1060).
+  registerOcProgressStatusTool(server);
 
   // Outcome Contracts (#792) — evidence bundle capture
   registerOcEvidenceBundleTool(server);

--- a/src/tools/oc-progress-status.ts
+++ b/src/tools/oc-progress-status.ts
@@ -1,0 +1,61 @@
+/** oc_progress_status — read-only anti-wandering diagnostics (#1060). */
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import { getActivityTracker } from '../dashboard/activity-tracker';
+import { buildProgressStatus } from '../progress/progress-status';
+
+const DEFAULT_WINDOW = 10;
+const MIN_WINDOW = 3;
+const MAX_WINDOW = 50;
+
+function parseWindow(value: unknown): number {
+  const n = typeof value === 'number' && Number.isFinite(value) ? Math.floor(value) : DEFAULT_WINDOW;
+  return Math.min(MAX_WINDOW, Math.max(MIN_WINDOW, n));
+}
+
+const definition: MCPToolDefinition = {
+  name: 'oc_progress_status',
+  description:
+    'Read-only diagnostics for whether the current OpenChrome session appears to be progressing, stalling, or stuck. ' +
+    'Returns bounded counters and advisory next-call suggestions; it never stops, retries, recovers, or executes browser actions.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      sessionId: { type: 'string', description: 'Optional session ID. Defaults to the current MCP session.' },
+      window: { type: 'number', description: `Recent completed calls to inspect. Default ${DEFAULT_WINDOW}, min ${MIN_WINDOW}, max ${MAX_WINDOW}.` },
+      includeRecentCalls: { type: 'boolean', description: 'Include redacted compact recent call summaries. Default false.' },
+    },
+    required: [],
+  },
+  outputSchema: {
+    type: 'object',
+    properties: {
+      sessionId: { type: 'string' },
+      status: { type: 'string', enum: ['progressing', 'stalling', 'stuck'] },
+      window: { type: 'number' },
+      counters: { type: 'object' },
+      topSignal: { type: 'object' },
+      suggestedPolicy: { type: 'string' },
+      suggestedNextCalls: { type: 'array' },
+      recentCalls: { type: 'array' },
+    },
+    required: ['sessionId', 'status', 'window', 'counters', 'suggestedPolicy', 'suggestedNextCalls'],
+  },
+};
+
+const handler: ToolHandler = async (currentSessionId, args): Promise<MCPResult> => {
+  const sessionId = (args.sessionId as string | undefined) || currentSessionId || 'default';
+  const window = parseWindow(args.window);
+  const includeRecentCalls = args.includeRecentCalls === true;
+  const calls = getActivityTracker().getRecentCalls(window, sessionId);
+  const structured = buildProgressStatus({ sessionId, calls, window, includeRecentCalls });
+  return {
+    content: [{ type: 'text', text: JSON.stringify(structured) }],
+    structuredContent: structured as unknown as Record<string, unknown>,
+  };
+};
+
+export function registerOcProgressStatusTool(server: MCPServer): void {
+  server.registerTool(definition.name, handler, definition);
+}

--- a/tests/tools/oc-progress-status.test.ts
+++ b/tests/tools/oc-progress-status.test.ts
@@ -1,0 +1,99 @@
+/// <reference types="jest" />
+
+import { ActivityTracker, setActivityTracker } from '../../src/dashboard/activity-tracker';
+import { MCPServer } from '../../src/mcp-server';
+import { buildProgressStatus } from '../../src/progress/progress-status';
+import { registerOcProgressStatusTool } from '../../src/tools/oc-progress-status';
+
+function seed(calls: Array<{ tool: string; result?: 'success' | 'error'; args?: Record<string, unknown>; error?: string }>): ActivityTracker {
+  const tracker = new ActivityTracker();
+  for (const call of [...calls].reverse()) {
+    const id = tracker.startCall(call.tool, 'test', call.args);
+    tracker.endCall(id, call.result || 'success', call.error);
+  }
+  return tracker;
+}
+
+function parse(result: any): any {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('oc_progress_status', () => {
+  test('classifies progressing baseline', () => {
+    const tracker = seed([{ tool: 'navigate' }, { tool: 'interact' }]);
+    const result = buildProgressStatus({ sessionId: 'test', calls: tracker.getRecentCalls(10, 'test'), window: 10 });
+    expect(result.status).toBe('progressing');
+    expect(result.suggestedPolicy).toBe('continue');
+  });
+
+  test('classifies stalling on observation-only calls', () => {
+    const tracker = seed([{ tool: 'read_page' }, { tool: 'tabs_context' }, { tool: 'computer', args: { action: 'screenshot' } }]);
+    const result = buildProgressStatus({ sessionId: 'test', calls: tracker.getRecentCalls(10, 'test'), window: 10 });
+    expect(result.status).toBe('stalling');
+    expect(result.counters.consecutiveNonProgress).toBe(3);
+    expect(result.suggestedPolicy).toBe('refresh_state');
+  });
+
+  test('classifies stuck on repeated errors', () => {
+    const tracker = seed([
+      { tool: 'interact', result: 'error', error: 'stale ref' },
+      { tool: 'interact', result: 'error', error: 'stale ref' },
+      { tool: 'interact', result: 'error', error: 'stale ref' },
+    ]);
+    const result = buildProgressStatus({ sessionId: 'test', calls: tracker.getRecentCalls(10, 'test'), window: 10 });
+    expect(result.status).toBe('stuck');
+    expect(result.counters.consecutiveErrors).toBe(3);
+    expect(result.suggestedPolicy).toBe('checkpoint_and_recover');
+  });
+
+  test('detects coordinate-click stall and switches strategy', () => {
+    const tracker = seed([
+      { tool: 'computer', args: { action: 'left_click', x: 1, y: 1 } },
+      { tool: 'computer', args: { action: 'left_click', x: 1, y: 1 } },
+      { tool: 'computer', args: { action: 'left_click', x: 1, y: 1 } },
+    ]);
+    const result = buildProgressStatus({ sessionId: 'test', calls: tracker.getRecentCalls(10, 'test'), window: 10 });
+    expect(result.counters.coordinateClickStreak).toBe(3);
+    expect(result.suggestedPolicy).toBe('switch_strategy');
+    expect(result.topSignal?.rule).toBe('coordinate-click-stall');
+  });
+
+  test('detects tool oscillation', () => {
+    const tracker = seed([
+      { tool: 'read_page' },
+      { tool: 'javascript_tool' },
+      { tool: 'read_page' },
+      { tool: 'javascript_tool' },
+    ]);
+    const result = buildProgressStatus({ sessionId: 'test', calls: tracker.getRecentCalls(10, 'test'), window: 10 });
+    expect(result.counters.oscillationDetected).toBe(true);
+    expect(result.suggestedPolicy).toBe('switch_strategy');
+  });
+
+  test('returns stop_episode advisory at hard non-progress threshold', () => {
+    const tracker = seed(Array.from({ length: 8 }, () => ({ tool: 'read_page' })));
+    const result = buildProgressStatus({ sessionId: 'test', calls: tracker.getRecentCalls(10, 'test'), window: 10 });
+    expect(result.status).toBe('stuck');
+    expect(result.suggestedPolicy).toBe('stop_episode');
+  });
+
+  test('redacts recent call args', async () => {
+    const tracker = seed([{ tool: 'form_input', args: { password: 'super-secret-fixture-password', username: 'alice' } }]);
+    setActivityTracker(tracker);
+    const server = new MCPServer({} as any);
+    registerOcProgressStatusTool(server);
+    const handler = server.getToolHandler('oc_progress_status')!;
+    const result = parse(await handler('test', { includeRecentCalls: true }));
+    expect(JSON.stringify(result)).not.toContain('super-secret-fixture-password');
+    expect(result.recentCalls[0].argsSummary.password).toBe('[REDACTED]');
+  });
+
+  test('wire-format invariant: content JSON equals structuredContent', async () => {
+    setActivityTracker(seed([{ tool: 'navigate' }]));
+    const server = new MCPServer({} as any);
+    registerOcProgressStatusTool(server);
+    const handler = server.getToolHandler('oc_progress_status')!;
+    const result: any = await handler('test', {});
+    expect(JSON.parse(result.content[0].text)).toEqual(result.structuredContent);
+  });
+});


### PR DESCRIPTION
Closes #1060.

## Directionality / overlap check
- Builds on existing `ProgressTracker` and activity-tracker telemetry instead of adding a new autonomous harness loop.
- Read-only and advisory only: no stop, retry, checkpoint restore, navigation, browser action, or LLM call is executed by this tool.
- Checked current open PRs before implementation; no open PR adds an `oc_progress_status` surface or equivalent anti-wandering diagnostic endpoint.

## Summary
- Adds `oc_progress_status` with structured `progressing | stalling | stuck` diagnostics.
- Reports bounded counters for repeated errors, non-progress streaks, screenshot loops, coordinate-click streaks, repeated tool calls, and two-tool oscillation.
- Returns capped advisory next-call hints such as `refresh_state`, `switch_strategy`, `checkpoint_and_recover`, or `stop_episode` without performing those actions.
- Redacts sensitive recent-call argument summaries when `includeRecentCalls` is requested.
- Keeps the tool available during unhealthy sessions by skipping session initialization and treating it as state-stable/high-frequency.

## Verification
- `npm test -- --runInBand tests/tools/oc-progress-status.test.ts`
- `npm run lint:changed`
- `npm run build` (after `npm install` to restore `yaml` from current `develop` dependencies)

## Merge-after validation with OpenChrome
1. Start OpenChrome MCP and perform three observation-only calls (`read_page`, `tabs_context`, `computer` screenshot), then call `oc_progress_status({ includeRecentCalls: true })`; expect `status: "stalling"`, redacted compact call summaries, and `suggestedPolicy: "refresh_state"`.
2. Perform three failed stale-ref interactions, then call `oc_progress_status`; expect `status: "stuck"`, `consecutiveErrors >= 3`, and `suggestedPolicy: "checkpoint_and_recover"`.
3. Perform three repeated coordinate clicks without a DOM/ref-based action, then call `oc_progress_status`; expect `coordinateClickStreak >= 3`, `topSignal.rule: "coordinate-click-stall"`, and `suggestedPolicy: "switch_strategy"`.
4. Confirm none of the above calls closes tabs, restores checkpoints, retries actions, or mutates browser state beyond recording the diagnostic call itself.

## Not tested
- Live browser smoke was not run in this worktree; the PR includes deterministic unit coverage for the same scenarios.
