### PR TITLE
feat(orchestration): opt-in bounded recovery search (#1020)

### DIFF
--- a/src/orchestration/plan-executor.ts
+++ b/src/orchestration/plan-executor.ts
@@ -10,8 +10,11 @@ import {
   CompiledPlan,
   CompiledStep,
   PlanErrorHandler,
+  PlanExecutionOptions,
   PlanExecutionResult,
+  PlanRecoveryAttempt,
 } from '../types/plan-cache';
+import { rankRecoveryCandidates } from '../recovery';
 import { withTimeout } from '../utils/with-timeout';
 
 /**
@@ -140,10 +143,12 @@ export class PlanExecutor {
   async execute(
     plan: CompiledPlan,
     sessionId: string,
-    runtimeParams: Record<string, unknown>
+    runtimeParams: Record<string, unknown>,
+    options: PlanExecutionOptions = {}
   ): Promise<PlanExecutionResult> {
     const startTime = Date.now();
     let stepsExecuted = 0;
+    const recoveryAttempts: PlanRecoveryAttempt[] = [];
 
     // 1. Build params map: plan defaults first, runtime overrides on top
     const params: Record<string, unknown> = {};
@@ -154,7 +159,18 @@ export class PlanExecutor {
     }
     Object.assign(params, runtimeParams);
 
-    const failure = (error: string): PlanExecutionResult => ({
+    const withRecovery = <T extends PlanExecutionResult>(result: T): T => {
+      if (options.boundedRecovery?.enabled) {
+        result.recovery = {
+          enabled: true,
+          attempts: recoveryAttempts,
+          exhausted: countExecutedRecoveryAttempts(recoveryAttempts) >= (options.boundedRecovery.maxToolCalls ?? 2),
+        };
+      }
+      return result;
+    };
+
+    const failure = (error: string): PlanExecutionResult => withRecovery({
       success: false,
       planId: plan.id,
       error,
@@ -207,6 +223,10 @@ export class PlanExecutor {
           continue;
         }
 
+        const bounded = await this.tryBoundedRecovery(step, errMsg, sessionId, params, options, recoveryAttempts);
+        stepsExecuted += bounded.stepsExecuted;
+        if (bounded.recovered) continue;
+
         return failure(`Step ${step.order} (${step.tool}) failed: ${errMsg}`);
       }
 
@@ -229,6 +249,10 @@ export class PlanExecutor {
           continue;
         }
 
+        const bounded = await this.tryBoundedRecovery(step, errMsg, sessionId, params, options, recoveryAttempts);
+        stepsExecuted += bounded.stepsExecuted;
+        if (bounded.recovered) continue;
+
         return failure(`Step ${step.order} (${step.tool}) returned error: ${errMsg}`);
       }
 
@@ -247,6 +271,9 @@ export class PlanExecutor {
           Object.assign(params, recovered.params);
           continue;
         }
+        const bounded = await this.tryBoundedRecovery(step, 'empty result', sessionId, params, options, recoveryAttempts);
+        stepsExecuted += bounded.stepsExecuted;
+        if (bounded.recovered) continue;
         // No handler for empty — treat as non-fatal, just skip storing
       }
 
@@ -270,25 +297,99 @@ export class PlanExecutor {
     const criteriaError = validateSuccessCriteria(plan.successCriteria, params);
     if (criteriaError) {
       console.error(`[PlanExecutor] Success criteria failed for plan=${plan.id}: ${criteriaError}`);
-      return {
+      return withRecovery({
         success: false,
         planId: plan.id,
         error: `Success criteria not met: ${criteriaError}`,
         durationMs: Date.now() - startTime,
         stepsExecuted,
         totalSteps: plan.steps.length,
-      };
+      });
     }
 
     // 4. Return success with all collected params as data
-    return {
+    return withRecovery({
       success: true,
       planId: plan.id,
       data: params,
       durationMs: Date.now() - startTime,
       stepsExecuted,
       totalSteps: plan.steps.length,
-    };
+    });
+  }
+
+  private async tryBoundedRecovery(
+    failedStep: CompiledStep,
+    errorText: string,
+    sessionId: string,
+    params: Record<string, unknown>,
+    options: PlanExecutionOptions,
+    recoveryAttempts: PlanRecoveryAttempt[],
+  ): Promise<{ recovered: boolean; stepsExecuted: number }> {
+    const config = options.boundedRecovery;
+    if (!config?.enabled) return { recovered: false, stepsExecuted: 0 };
+
+    const maxToolCalls = Math.max(0, config.maxToolCalls ?? 2);
+    if (countExecutedRecoveryAttempts(recoveryAttempts) >= maxToolCalls) {
+      return { recovered: false, stepsExecuted: 0 };
+    }
+
+    const candidates = rankRecoveryCandidates({
+      toolName: failedStep.tool,
+      resultText: errorText,
+      isError: true,
+      recentCalls: [{ toolName: failedStep.tool, result: 'error', error: errorText }],
+      maxCandidates: config.maxCandidates ?? 3,
+    });
+
+    let executed = 0;
+    for (const candidate of candidates) {
+      if (countExecutedRecoveryAttempts(recoveryAttempts) >= maxToolCalls) break;
+      if (candidate.risk !== 'read_only' || candidate.blockedReason) {
+        recoveryAttempts.push({
+          tool: candidate.tool,
+          status: 'blocked',
+          reason: candidate.blockedReason ?? `risk ${candidate.risk} is not allowed for bounded recovery`,
+        });
+        continue;
+      }
+
+      const handler = this.toolResolver(candidate.tool);
+      if (!handler) {
+        recoveryAttempts.push({ tool: candidate.tool, status: 'failed', reason: 'tool handler not found' });
+        continue;
+      }
+
+      const args = buildSafeRecoveryArgs(candidate.tool, params);
+      if (!args) {
+        recoveryAttempts.push({ tool: candidate.tool, status: 'blocked', reason: 'no safe argument template available' });
+        continue;
+      }
+
+      try {
+        const result = await withTimeout(
+          handler(sessionId, args),
+          config.perCandidateTimeoutMs ?? 5000,
+          `bounded recovery tool=${candidate.tool} for step=${failedStep.order}`,
+        );
+        executed++;
+        if (!result.isError && !isEmptyResult(result)) {
+          recoveryAttempts.push({ tool: candidate.tool, status: 'success', reason: candidate.reason });
+          return { recovered: true, stepsExecuted: executed };
+        }
+        recoveryAttempts.push({ tool: candidate.tool, status: 'failed', reason: 'candidate returned empty or error result' });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        recoveryAttempts.push({
+          tool: candidate.tool,
+          status: /timed out/i.test(message) ? 'timeout' : 'failed',
+          reason: candidate.reason,
+          error: message,
+        });
+      }
+    }
+
+    return { recovered: false, stepsExecuted: executed };
   }
 
   /**
@@ -363,5 +464,20 @@ export class PlanExecutor {
     }
 
     return { stepsExecuted, params };
+  }
+}
+
+function countExecutedRecoveryAttempts(attempts: PlanRecoveryAttempt[]): number {
+  return attempts.filter((attempt) => attempt.status !== 'blocked').length;
+}
+
+function buildSafeRecoveryArgs(tool: string, params: Record<string, unknown>): Record<string, unknown> | null {
+  const tabId = typeof params.tabId === 'string' ? params.tabId : undefined;
+  switch (tool) {
+    case 'read_page':
+    case 'tabs_context':
+      return tabId ? { tabId } : {};
+    default:
+      return null;
   }
 }

--- a/src/tools/orchestration.ts
+++ b/src/tools/orchestration.ts
@@ -666,6 +666,10 @@ const executePlanDefinition: MCPToolDefinition = {
         type: 'string',
         description: 'Tab ID to execute the plan against',
       },
+      boundedRecovery: {
+        type: 'boolean',
+        description: 'Opt-in: try a small, safety-gated read-only recovery search when a plan step fails',
+      },
       params: {
         type: 'object',
         description: 'Runtime params merged with plan defaults',
@@ -684,6 +688,7 @@ const executePlanHandler: ToolHandler = async (
   const planId = args.planId as string;
   const tabId = args.tabId as string;
   const runtimeParams = (args.params as Record<string, unknown>) || {};
+  const boundedRecovery = args.boundedRecovery === true;
 
   if (!planId || !tabId) {
     return {
@@ -749,7 +754,11 @@ const executePlanHandler: ToolHandler = async (
 
     // Execute the plan
     const mergedParams = { tabId, ...runtimeParams };
-    const result = await executor.execute(plan, sessionId, mergedParams);
+    const result = await executor.execute(plan, sessionId, mergedParams, {
+      boundedRecovery: boundedRecovery
+        ? { enabled: true, maxCandidates: 3, maxToolCalls: 2, perCandidateTimeoutMs: 5000 }
+        : undefined,
+    });
 
     // Update stats
     registry.updateStats(planId, result.success, result.durationMs);
@@ -765,6 +774,7 @@ const executePlanHandler: ToolHandler = async (
           durationMs: result.durationMs,
           data: result.data,
           error: result.error,
+          recovery: result.recovery,
           message: result.success
             ? `Plan "${planId}" executed successfully in ${result.durationMs}ms (${result.stepsExecuted}/${result.totalSteps} steps)`
             : `Plan "${planId}" failed: ${result.error}. Consider manual execution.`,

--- a/src/types/plan-cache.ts
+++ b/src/types/plan-cache.ts
@@ -109,6 +109,29 @@ export interface PlanRegistryData {
   updatedAt: number;
 }
 
+/** Bounded recovery telemetry for plan execution. */
+export interface PlanRecoveryAttempt {
+  tool: string;
+  status: 'success' | 'failed' | 'blocked' | 'timeout';
+  reason: string;
+  error?: string;
+}
+
+export interface PlanRecoverySummary {
+  enabled: boolean;
+  attempts: PlanRecoveryAttempt[];
+  exhausted: boolean;
+}
+
+export interface PlanExecutionOptions {
+  boundedRecovery?: {
+    enabled: boolean;
+    maxCandidates?: number;
+    maxToolCalls?: number;
+    perCandidateTimeoutMs?: number;
+  };
+}
+
 /** Result of plan execution */
 export interface PlanExecutionResult {
   /** Whether the plan executed successfully */
@@ -125,4 +148,6 @@ export interface PlanExecutionResult {
   stepsExecuted: number;
   /** Total steps in plan */
   totalSteps: number;
+  /** Optional bounded recovery summary when opt-in recovery is enabled. */
+  recovery?: PlanRecoverySummary;
 }

--- a/tests/orchestration/plan-executor-bounded-recovery.test.ts
+++ b/tests/orchestration/plan-executor-bounded-recovery.test.ts
@@ -1,0 +1,72 @@
+import { PlanExecutor } from '../../src/orchestration/plan-executor';
+import type { CompiledPlan } from '../../src/types/plan-cache';
+import type { MCPResult, ToolHandler } from '../../src/types/mcp';
+
+const text = (value: string, isError = false): MCPResult => ({ content: [{ type: 'text', text: value }], isError });
+
+function plan(): CompiledPlan {
+  return {
+    id: 'test-plan',
+    version: '1',
+    description: 'test',
+    parameters: {},
+    steps: [
+      { order: 1, tool: 'interact', args: { ref: 'old', tabId: '${tabId}' }, timeout: 1000 },
+      { order: 2, tool: 'read_page', args: { tabId: '${tabId}' }, timeout: 1000, parseResult: { format: 'text', storeAs: 'page' } },
+    ],
+    errorHandlers: [],
+    successCriteria: { requiredFields: ['page'] },
+  };
+}
+
+describe('PlanExecutor bounded recovery', () => {
+  it('is disabled by default and preserves original failure', async () => {
+    const handlers = new Map<string, ToolHandler>([
+      ['interact', async () => text('ref is stale', true)],
+      ['read_page', async () => text('fresh page')],
+    ]);
+    const executor = new PlanExecutor((name) => handlers.get(name) ?? null);
+
+    const result = await executor.execute(plan(), 's1', { tabId: 'tab-1' });
+
+    expect(result.success).toBe(false);
+    expect(result.recovery).toBeUndefined();
+  });
+
+  it('tries bounded read-only recovery and continues on success', async () => {
+    const calls: string[] = [];
+    const handlers = new Map<string, ToolHandler>([
+      ['interact', async () => { calls.push('interact'); return text('ref is stale', true); }],
+      ['read_page', async () => { calls.push('read_page'); return text('fresh page with refs'); }],
+    ]);
+    const executor = new PlanExecutor((name) => handlers.get(name) ?? null);
+
+    const result = await executor.execute(plan(), 's1', { tabId: 'tab-1' }, {
+      boundedRecovery: { enabled: true, maxCandidates: 2, maxToolCalls: 1, perCandidateTimeoutMs: 1000 },
+    });
+
+    expect(result.success).toBe(true);
+    expect(calls).toEqual(['interact', 'read_page', 'read_page']);
+    expect(result.recovery?.attempts[0]).toMatchObject({ tool: 'read_page', status: 'success' });
+  });
+
+  it('blocks side-effect candidates and enforces max tool-call budget', async () => {
+    const handlers = new Map<string, ToolHandler>([
+      ['click', async () => text('CAPTCHA Access Denied Login page detected', true)],
+      ['read_page', async () => text('', false)],
+      ['tabs_context', async () => text('tab state')],
+    ]);
+    const captchaPlan = plan();
+    captchaPlan.steps[0] = { order: 1, tool: 'click', args: { tabId: '${tabId}' }, timeout: 1000 };
+    const executor = new PlanExecutor((name) => handlers.get(name) ?? null);
+
+    const result = await executor.execute(captchaPlan, 's1', { tabId: 'tab-1' }, {
+      boundedRecovery: { enabled: true, maxCandidates: 3, maxToolCalls: 1, perCandidateTimeoutMs: 1000 },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.recovery?.attempts.length).toBe(1);
+    expect(result.recovery?.exhausted).toBe(true);
+    expect(result.recovery?.attempts[0].tool).toBe('read_page');
+  });
+});


### PR DESCRIPTION
## Progress / Review status

_Auto-refreshed 2026-05-13 — owner comments cleaned up to reduce review noise._

| Field | Value |
| --- | --- |
| Branch | `feat/1020-bounded-recovery-search` → `feat/1018-recovery-candidate-ranking` |
| Draft | no |
| CI | — |
| Mergeable | ✅ MERGEABLE |
| Review decision | — |
| Codex (latest) | — |
| Other reviewers (latest) | — |
| Head | `5cc0227` — Recover failed plans with opt-in safe candidates |
| Commits | 1 |

<sub>Owner comment cleanup: 0 issue + 0 inline review comments deleted. Outstanding feedback from automated/external reviewers above is unchanged.</sub>
<!-- progress-status:end -->
---

## Summary\n- Adds opt-in bounded recovery for compiled plan execution.\n- Executes only read-only candidate tools under strict candidate/tool-call/time budgets.\n- Returns structured recovery attempts in execute_plan results.\n\nCloses #1020.\n\nStacked on #1088 because it consumes ranked recovery candidates.\n\n## Validation\n- npm test -- --runTestsByPath tests/orchestration/plan-executor-bounded-recovery.test.ts\n- npm run build\n\n## Live OpenChrome verification\n- Not run in this PR session; requires execute_plan transcript against the stale-ref fixture added in #1073.\n\n## Safety\n- Disabled unless execute_plan receives boundedRecovery: true.\n- Only read_only candidates are executed; side-effect candidates are recorded as blocked.\n- Small default budgets: maxCandidates=3, maxToolCalls=2, perCandidateTimeoutMs=5000.