### PR TITLE
feat(task-run): add deterministic rolling checkpoints (#1042)

### DIFF
--- a/cli/playbook/expand.ts
+++ b/cli/playbook/expand.ts
@@ -2,7 +2,7 @@
  * Step expansion — maps playbook verb + args to MCP tool name + call args.
  *
  * Static map of 9 verbs. `assert` maps to `oc_assert` with the YAML node
- * passed verbatim as the `assertion` field (including nested and/or/not).
+ * wrapped as the `contract` field unless explicit contract/evidence is provided (including nested and/or/not).
  */
 
 import type { Verb } from './parse';
@@ -49,8 +49,15 @@ const VERB_MAP: Record<Verb, { tool: string; mapArgs: ArgMapper }> = {
   },
   assert: {
     tool: 'oc_assert',
-    // Pass the entire YAML node verbatim as the `assertion` field.
-    mapArgs: (args) => ({ assertion: args }),
+    // oc_assert expects { contract, evidence? }. For compact playbooks, allow
+    // the assertion DSL directly under `assert:` and wrap it as `contract`.
+    // For live-verification fixtures, pass explicit contract/evidence through.
+    mapArgs: (args) => (
+      Object.prototype.hasOwnProperty.call(args, 'contract') ||
+      Object.prototype.hasOwnProperty.call(args, 'evidence')
+        ? args
+        : { contract: args }
+    ),
   },
 };
 

--- a/cli/playbook/run.ts
+++ b/cli/playbook/run.ts
@@ -45,6 +45,37 @@ export interface RunOptions {
   client?: Pick<StdioMcpClient, 'connect' | 'callTool' | 'disconnect'>;
 }
 
+const VERBS_THAT_CAN_REUSE_CURRENT_TAB = new Set<string>([
+  'interact',
+  'act',
+  'fill_form',
+  'wait_for',
+  'page_screenshot',
+  'read_page',
+  'javascript_tool',
+]);
+
+function maybeInjectCurrentTab(
+  step: Step,
+  args: Record<string, unknown>,
+  currentTabId: string | undefined,
+): Record<string, unknown> {
+  if (
+    currentTabId &&
+    VERBS_THAT_CAN_REUSE_CURRENT_TAB.has(step.verb) &&
+    typeof args.tabId !== 'string'
+  ) {
+    return { ...args, tabId: currentTabId };
+  }
+  return args;
+}
+
+function extractTabId(result: unknown): string | undefined {
+  if (!result || typeof result !== 'object') return undefined;
+  const tabId = (result as Record<string, unknown>).tabId;
+  return typeof tabId === 'string' && tabId.length > 0 ? tabId : undefined;
+}
+
 export async function runPlaybook(playbook: Playbook, options: RunOptions): Promise<RunResult> {
   const client = options.client ?? new StdioMcpClient();
 
@@ -58,6 +89,7 @@ export async function runPlaybook(playbook: Playbook, options: RunOptions): Prom
 
   const stepResults: StepResult[] = [];
   let failed = false;
+  let currentTabId: string | undefined;
 
   try {
     for (let i = 0; i < playbook.steps.length; i++) {
@@ -77,9 +109,10 @@ export async function runPlaybook(playbook: Playbook, options: RunOptions): Prom
 
       // Substitute vars in args
       const substitutedArgs = substituteValue(step.args, options.varMap, i) as Record<string, unknown>;
+      const callArgs = maybeInjectCurrentTab(step, substitutedArgs, currentTabId);
 
       // Expand to MCP tool call
-      const expanded = expandStep(step.verb, substitutedArgs);
+      const expanded = expandStep(step.verb, callArgs);
 
       const start = Date.now();
       let status: StepStatus = 'ok';
@@ -97,6 +130,7 @@ export async function runPlaybook(playbook: Playbook, options: RunOptions): Prom
             error = `Step ${i} (${step.verb}): assert verdict="${callResult.verdict}"`;
           }
         }
+        currentTabId = extractTabId(callResult.result) ?? currentTabId;
       } catch (err) {
         // P1 codex fix: distinguish transport-class failures from step/assertion
         // failures. TransportError indicates the MCP client could not deliver

--- a/docs/cli/playbook.md
+++ b/docs/cli/playbook.md
@@ -89,11 +89,13 @@ steps:
 
 All non-`assert` verbs forward their YAML args object directly to the MCP tool unchanged.
 
+After a successful tool result that returns `tabId`, the runner reuses that tab for later same-tab browser verbs (`interact`, `act`, `fill_form`, `wait_for`, `page_screenshot`, `read_page`, `javascript_tool`) when the step does not set `tabId` explicitly. This keeps fixture playbooks runnable without hard-coding ephemeral tab IDs while preserving explicit `tabId` overrides.
+
 ---
 
 ## Assertions
 
-`assert` steps expand to `oc_assert` with the YAML node forwarded verbatim as the `assertion` field. The step passes iff the server returns `verdict === "pass"`. Any other verdict (`"fail"`, `"inconclusive"`) counts as a failure for exit-code purposes.
+`assert` steps expand to `oc_assert`. A compact assertion DSL is wrapped as `contract`; an explicit `{ contract, evidence }` object is forwarded unchanged. The step passes iff the server returns `verdict === "pass"`. Any other verdict (`"fail"`, `"inconclusive"`) counts as a failure for exit-code purposes.
 
 ### dom_text
 
@@ -106,7 +108,7 @@ All non-`assert` verbs forward their YAML args object directly to the MCP tool u
 
 Expands to:
 ```json
-{ "assertion": { "kind": "dom_text", "selector": "h1", "pattern": "Example" } }
+{ "contract": { "kind": "dom_text", "selector": "h1", "pattern": "Example" } }
 ```
 
 ### url
@@ -127,7 +129,7 @@ Expands to:
       - { kind: url, pattern: "example\\.com" }
 ```
 
-The playbook layer does **not** parse the assertion DSL — the YAML subtree is forwarded verbatim.
+The playbook layer does **not** evaluate the assertion DSL. Compact `assert:` YAML is wrapped as `contract` for `oc_assert`; explicit `contract`/`evidence` payloads are forwarded unchanged.
 
 ---
 

--- a/docs/recipes/live-verification-playbooks.md
+++ b/docs/recipes/live-verification-playbooks.md
@@ -1,0 +1,35 @@
+# Live verification playbooks (#1044)
+
+These fixtures harden `oc playbook run` with local-only, reviewable scenarios. They are intentionally small and disposable so PR reviewers can run them without accounts, secrets, or external websites.
+
+## Fixture site
+
+Serve the fixture directory from the repository root:
+
+```bash
+python3 -m http.server 8765 --directory tests/fixtures/playbook/site
+```
+
+## Playbooks
+
+```bash
+# Expected: pass
+node dist/cli/index.js playbook run tests/fixtures/playbook/recipes/basic-navigation.yaml --json
+
+# Expected: pass; local-only submit path, no external side effects
+node dist/cli/index.js playbook run tests/fixtures/playbook/recipes/safe-form.yaml --json
+
+# Expected: fail at step 1 and skip step 2 with structured failure evidence
+node dist/cli/index.js playbook run tests/fixtures/playbook/recipes/failure-recovery.yaml --json
+```
+
+## Merge evidence required
+
+A PR that modifies the playbook runner should attach the JSON output for all three commands. The failure fixture must show:
+
+- failed step index
+- `tool: oc_assert`
+- assertion verdict/failure detail
+- skipped downstream step
+
+These playbooks use inline `oc_assert` contracts with explicit `evidence.snapshot` so the assertions remain deterministic and do not require an LLM judgement.

--- a/src/core/task-run/storage.ts
+++ b/src/core/task-run/storage.ts
@@ -165,20 +165,45 @@ export class TaskRunStore {
       updated_at: ts,
     });
     await this.writeMeta(meta);
-    await this.appendEvent(runId, { ts, kind: 'updated', data: redactValue({ status: meta.status, resume_reason: input.resume_reason }) as Record<string, unknown> });
+    await this.appendEvent(runId, {
+      ts,
+      kind: 'updated',
+      data: redactValue({
+        status: meta.status,
+        resume_reason: input.resume_reason,
+        current_cursor: meta.current_cursor,
+        completed_count: meta.completed_items?.length || 0,
+        failed_count: meta.failed_items?.length || 0,
+        evidence: meta.last_evidence,
+      }) as Record<string, unknown>,
+    });
     return meta;
   }
 
-  async checkpoint(runId: string, summary: string, opts: { current_cursor?: string; evidence?: EvidencePointer[] } = {}): Promise<TaskRunCheckpoint> {
+  async checkpoint(runId: string, summary = '', opts: { current_cursor?: string; evidence?: EvidencePointer[] } = {}): Promise<TaskRunCheckpoint> {
     const meta = await this.get(runId);
     this.assertMutable(meta);
     const ts = this.now();
+    const events = await this.readEvents(runId);
+    const currentCursor = opts.current_cursor ? scrub(opts.current_cursor) : meta.current_cursor;
+    const evidence = sanitizeEvidence(opts.evidence) || meta.last_evidence;
+    const deterministicSummary = buildCheckpointSummary(meta, events, {
+      current_cursor: currentCursor,
+      evidence,
+      summary,
+    });
     const checkpoint: TaskRunCheckpoint = pruneUndefined({
       checkpoint_id: this.createRunId(`${runId}\0checkpoint\0${ts}`, ts),
       run_id: runId,
-      summary: limit(scrub(summary), MAX_SUMMARY_CHARS),
-      current_cursor: opts.current_cursor ? scrub(opts.current_cursor) : undefined,
-      evidence: sanitizeEvidence(opts.evidence),
+      source_event_range: sourceEventRange(events),
+      summary: deterministicSummary.summary,
+      current_cursor: currentCursor,
+      completed_count: meta.completed_items?.length,
+      failed_count: meta.failed_items?.length,
+      last_url: lastUrl(meta, currentCursor),
+      event_count: events.length,
+      redaction_applied: deterministicSummary.redaction_applied,
+      evidence,
       created_at: ts,
     });
     const checkpointPath = path.join(this.runDir(runId), 'checkpoints', `${checkpoint.checkpoint_id}.json`);
@@ -193,6 +218,19 @@ export class TaskRunStore {
     await this.writeMeta(updated);
     await this.appendEvent(runId, { ts, kind: 'checkpointed', data: { checkpoint_id: checkpoint.checkpoint_id } });
     return checkpoint;
+  }
+
+  async latestCheckpoint(runId: string): Promise<TaskRunCheckpoint | undefined> {
+    const dir = path.join(this.runDir(runId), 'checkpoints');
+    if (!fs.existsSync(dir)) return undefined;
+    const entries = await fs.promises.readdir(dir);
+    const checkpoints: TaskRunCheckpoint[] = [];
+    for (const entry of entries.filter(name => name.endsWith('.json'))) {
+      const result = await readFileSafe<TaskRunCheckpoint>(path.join(dir, entry));
+      if (result.success && result.data) checkpoints.push(result.data);
+    }
+    checkpoints.sort((a, b) => b.created_at - a.created_at || b.checkpoint_id.localeCompare(a.checkpoint_id));
+    return checkpoints[0];
   }
 
   async needsHelp(runId: string, input: NeedsHelpInput): Promise<TaskRunMeta> {
@@ -249,7 +287,10 @@ export class TaskRunStore {
     const eventsPath = this.eventsPath(runId);
     if (!fs.existsSync(eventsPath)) return [];
     const text = await fs.promises.readFile(eventsPath, 'utf8');
-    return text.split('\n').filter(Boolean).map(line => JSON.parse(line) as TaskRunEvent);
+    return text.split('\n').filter(Boolean).map((line, index) => {
+      const event = JSON.parse(line) as TaskRunEvent;
+      return event.seq === undefined ? { ...event, seq: index + 1 } : event;
+    });
   }
 
   private createRunId(seed: string, ts: number): string {
@@ -276,8 +317,15 @@ export class TaskRunStore {
   private async appendEvent(runId: string, event: TaskRunEvent): Promise<void> {
     const dir = this.runDir(runId);
     await fs.promises.mkdir(dir, { recursive: true });
-    const safeEvent = redactValue(event) as TaskRunEvent;
+    const safeEvent = redactValue({ ...event, seq: await this.nextEventSeq(runId) }) as TaskRunEvent;
     await fs.promises.appendFile(this.eventsPath(runId), `${JSON.stringify(safeEvent)}\n`, 'utf8');
+  }
+
+  private async nextEventSeq(runId: string): Promise<number> {
+    const eventsPath = this.eventsPath(runId);
+    if (!fs.existsSync(eventsPath)) return 1;
+    const text = await fs.promises.readFile(eventsPath, 'utf8');
+    return text.split('\n').filter(Boolean).length + 1;
   }
 
   private runDir(runId: string): string {
@@ -374,4 +422,44 @@ function pruneUndefined<T extends Record<string, unknown>>(obj: T): T {
     if (obj[key] === undefined) delete obj[key];
   }
   return obj;
+}
+
+function sourceEventRange(events: TaskRunEvent[]): { from: number; to: number } {
+  if (events.length === 0) return { from: 0, to: 0 };
+  return {
+    from: events[0].seq || 1,
+    to: events[events.length - 1].seq || events.length,
+  };
+}
+
+function buildCheckpointSummary(
+  meta: TaskRunMeta,
+  events: TaskRunEvent[],
+  opts: { current_cursor?: string; evidence?: EvidencePointer[]; summary?: string },
+): { summary: string; redaction_applied: boolean } {
+  const range = sourceEventRange(events);
+  const lines = [
+    'TaskRun checkpoint',
+    `status=${meta.status}`,
+    `events=${events.length} range=${range.from}-${range.to}`,
+    `completed=${meta.completed_items?.length || 0}`,
+    `failed=${meta.failed_items?.length || 0}`,
+  ];
+  if (opts.current_cursor) lines.push(`cursor=${opts.current_cursor}`);
+  const url = lastUrl(meta, opts.current_cursor);
+  if (url) lines.push(`last_url=${url}`);
+  if (meta.needs_help) lines.push(`needs_help=${meta.needs_help.reason}`);
+  if (opts.evidence?.length) {
+    lines.push(`evidence=${opts.evidence.map(item => `${item.kind}:${item.ref}`).join(',')}`);
+  }
+  if (opts.summary) lines.push(`caller_note=${opts.summary}`);
+  const raw = lines.join('\n');
+  const summary = limit(scrub(raw), MAX_SUMMARY_CHARS);
+  return { summary, redaction_applied: summary !== raw };
+}
+
+function lastUrl(meta: TaskRunMeta, cursor?: string): string | undefined {
+  const candidate = cursor || meta.last_evidence?.find(item => item.kind === 'url')?.ref;
+  if (!candidate) return undefined;
+  return /^https?:\/\//i.test(candidate) ? scrub(candidate) : undefined;
 }

--- a/src/core/task-run/types.ts
+++ b/src/core/task-run/types.ts
@@ -41,6 +41,7 @@ export interface TaskRunMeta {
 }
 
 export interface TaskRunEvent {
+  seq?: number;
   ts: number;
   kind: 'started' | 'updated' | 'checkpointed' | 'needs_help' | 'completed' | 'failed' | 'cancelled';
   data?: Record<string, unknown>;
@@ -49,8 +50,14 @@ export interface TaskRunEvent {
 export interface TaskRunCheckpoint {
   checkpoint_id: string;
   run_id: string;
+  source_event_range: { from: number; to: number };
   summary: string;
   current_cursor?: string;
+  completed_count?: number;
+  failed_count?: number;
+  last_url?: string;
+  event_count?: number;
+  redaction_applied?: boolean;
   evidence?: EvidencePointer[];
   created_at: number;
 }

--- a/src/tools/task-run.ts
+++ b/src/tools/task-run.ts
@@ -103,11 +103,11 @@ const checkpointDefinition: MCPToolDefinition = {
     type: 'object',
     properties: {
       run_id: { type: 'string' },
-      summary: { type: 'string', description: 'Caller-provided summary, redacted and capped at 8 KiB.' },
+      summary: { type: 'string', description: 'Optional caller note. The persisted summary is deterministic and source-linked.' },
       current_cursor: { type: 'string' },
       evidence: evidenceSchema,
     },
-    required: ['run_id', 'summary'],
+    required: ['run_id'],
   },
 };
 
@@ -152,6 +152,7 @@ const getDefinition: MCPToolDefinition = {
     properties: {
       run_id: { type: 'string' },
       include_events: { type: 'boolean', description: 'When true, include events.jsonl entries.' },
+      include_checkpoint: { type: 'boolean', description: 'When true, include the latest deterministic rolling checkpoint.' },
     },
     required: ['run_id'],
   },
@@ -230,6 +231,9 @@ const getHandler: ToolHandler = async (_sessionId, args) => {
     const result: Json = { task_run: meta };
     if (args.include_events === true) {
       result.events = await store.readEvents(runId);
+    }
+    if (args.include_checkpoint === true) {
+      result.checkpoint = await store.latestCheckpoint(runId);
     }
     return jsonResult(result);
   } catch (error) {

--- a/tests/cli/playbook/expand.test.ts
+++ b/tests/cli/playbook/expand.test.ts
@@ -57,14 +57,14 @@ describe('expandStep', () => {
     expect(result.callArgs).toEqual({ code: 'document.title' });
   });
 
-  test('assert → oc_assert tool, YAML node wrapped in assertion field', () => {
+  test('assert → oc_assert tool, YAML node wrapped in contract field', () => {
     const assertArgs = { kind: 'dom_text', selector: 'h1', pattern: 'Example' };
     const result = expandStep('assert', assertArgs);
     expect(result.tool).toBe('oc_assert');
-    expect(result.callArgs).toEqual({ assertion: assertArgs });
+    expect(result.callArgs).toEqual({ contract: assertArgs });
   });
 
-  test('assert: nested and/or/not passes verbatim', () => {
+  test('assert: nested and/or/not is wrapped in contract field', () => {
     const assertArgs = {
       kind: 'and',
       children: [
@@ -74,14 +74,24 @@ describe('expandStep', () => {
     };
     const result = expandStep('assert', assertArgs);
     expect(result.tool).toBe('oc_assert');
-    expect(result.callArgs).toEqual({ assertion: assertArgs });
+    expect(result.callArgs).toEqual({ contract: assertArgs });
   });
 
-  test('assert: url pattern passes verbatim', () => {
+  test('assert: url pattern is wrapped in contract field', () => {
     const assertArgs = { kind: 'url', pattern: 'iana\\.org' };
     const result = expandStep('assert', assertArgs);
     expect(result.tool).toBe('oc_assert');
-    expect(result.callArgs).toEqual({ assertion: { kind: 'url', pattern: 'iana\\.org' } });
+    expect(result.callArgs).toEqual({ contract: { kind: 'url', pattern: 'iana\\.org' } });
+  });
+
+  test('assert: explicit contract/evidence payload passes through unchanged', () => {
+    const assertArgs = {
+      contract: { kind: 'url', pattern: 'fixtures/playbook' },
+      evidence: { snapshot: { url: 'http://127.0.0.1:8765/fixtures/playbook' } },
+    };
+    const result = expandStep('assert', assertArgs);
+    expect(result.tool).toBe('oc_assert');
+    expect(result.callArgs).toEqual(assertArgs);
   });
 
   test('all 9 verbs produce non-empty tool names', () => {

--- a/tests/cli/playbook/live-fixtures.test.ts
+++ b/tests/cli/playbook/live-fixtures.test.ts
@@ -1,0 +1,120 @@
+/// <reference types="jest" />
+/**
+ * Local playbook verification fixtures for issue #1044.
+ *
+ * These tests exercise the same fixture recipes documented for manual
+ * OpenChrome smoke verification, but use an in-process client so CI can
+ * validate parse/expand/fail-fast behavior without launching Chrome.
+ */
+
+import * as path from 'path';
+import { loadPlaybook } from '../../../cli/playbook/parse';
+import { runPlaybook, RunOptions } from '../../../cli/playbook/run';
+import type { CallResult } from '../../../cli/playbook/stdio-client';
+
+const RECIPES = path.join(__dirname, '..', '..', 'fixtures', 'playbook', 'recipes');
+const LOCAL_BASE = 'http://127.0.0.1:8765';
+
+type ToolCall = { tool: string; args: Record<string, unknown> };
+
+function containsMissingText(value: unknown): boolean {
+  if (typeof value === 'string') {
+    return value.includes('This Text Is Intentionally Missing');
+  }
+  if (Array.isArray(value)) {
+    return value.some(containsMissingText);
+  }
+  if (value && typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).some(containsMissingText);
+  }
+  return false;
+}
+
+function makeFixtureClient(): { client: RunOptions['client']; calls: ToolCall[] } {
+  const calls: ToolCall[] = [];
+  const client: RunOptions['client'] = {
+    async connect() {},
+    async callTool(tool: string, args: Record<string, unknown>): Promise<CallResult> {
+      calls.push({ tool, args });
+      if (tool === 'oc_assert') {
+        const verdict = containsMissingText(args) ? 'fail' : 'pass';
+        return {
+          success: verdict === 'pass',
+          verdict,
+          result: { verdict },
+        };
+      }
+      if (tool === 'navigate') {
+        return { success: true, result: { tabId: 'fixture-tab' } };
+      }
+      return { success: true, result: { ok: true } };
+    },
+    async disconnect() {},
+  };
+  return { client, calls };
+}
+
+describe('local verification playbook fixtures', () => {
+  test.each([
+    ['basic-navigation.yaml', 4],
+    ['safe-form.yaml', 5],
+  ])('%s parses and runs to completion against the fixture client', async (fileName, expectedSteps) => {
+    const playbook = loadPlaybook(path.join(RECIPES, fileName));
+    const { client, calls } = makeFixtureClient();
+
+    const result = await runPlaybook(playbook, {
+      reuse: false,
+      varMap: playbook.vars ?? {},
+      client,
+    });
+
+    expect(result.summary).toMatchObject({
+      ok: true,
+      total: expectedSteps,
+      failed: 0,
+      skipped: 0,
+    });
+    expect(calls).toHaveLength(expectedSteps);
+
+    const navigateCalls = calls.filter((call) => call.tool === 'navigate');
+    expect(navigateCalls.length).toBeGreaterThan(0);
+    for (const call of navigateCalls) {
+      expect(call.args.url).toEqual(expect.stringContaining(LOCAL_BASE));
+    }
+
+    const assertCalls = calls.filter((call) => call.tool === 'oc_assert');
+    expect(assertCalls.length).toBeGreaterThan(0);
+    for (const call of assertCalls) {
+      expect(call.args).toHaveProperty('contract');
+      expect(call.args).toHaveProperty('evidence');
+    }
+
+    if (fileName === 'safe-form.yaml') {
+      expect(calls.find((call) => call.tool === 'fill_form')?.args).toMatchObject({
+        tabId: 'fixture-tab',
+        fields: { name: 'OpenChrome' },
+      });
+    }
+  });
+
+  test('failure-recovery fixture fails fast and skips the recovery-sensitive step', async () => {
+    const playbook = loadPlaybook(path.join(RECIPES, 'failure-recovery.yaml'));
+    const { client, calls } = makeFixtureClient();
+
+    const result = await runPlaybook(playbook, {
+      reuse: false,
+      varMap: playbook.vars ?? {},
+      client,
+    });
+
+    expect(result.summary).toMatchObject({
+      ok: false,
+      total: 3,
+      passed: 1,
+      failed: 1,
+      skipped: 1,
+    });
+    expect(calls.map((call) => call.tool)).toEqual(['navigate', 'oc_assert']);
+    expect(result.steps[2]).toMatchObject({ verb: 'navigate', status: 'skipped' });
+  });
+});

--- a/tests/cli/playbook/run.test.ts
+++ b/tests/cli/playbook/run.test.ts
@@ -96,10 +96,10 @@ describe('runPlaybook — call ordering', () => {
     expect(calls[0].tool).toBe('navigate');
     expect(calls[0].args).toEqual({ url: 'https://example.com' });
 
-    // Step 1: assert → tool 'oc_assert', wrapped in assertion field
+    // Step 1: assert → tool 'oc_assert', wrapped in contract field
     expect(calls[1].tool).toBe('oc_assert');
     expect(calls[1].args).toEqual({
-      assertion: { kind: 'dom_text', selector: 'h1', pattern: 'Example' },
+      contract: { kind: 'dom_text', selector: 'h1', pattern: 'Example' },
     });
 
     // Step 2: interact → tool 'interact', args pass-through
@@ -119,6 +119,30 @@ describe('runPlaybook — call ordering', () => {
 
     await runPlaybook(sanityPlaybook, { reuse: false, varMap: { url: 'https://example.com' }, client: wrappedClient });
     expect(disconnectCalled).toBe(true);
+  });
+
+  test('reuses navigate tabId for subsequent same-tab browser steps', async () => {
+    const tabPlaybook: Playbook = {
+      name: 'same-tab form',
+      steps: [
+        { verb: 'navigate', args: { url: 'https://example.com/form' } },
+        { verb: 'fill_form', args: { fields: { name: 'OpenChrome' } } },
+      ],
+    };
+    const { client, calls } = makeMockClient({
+      results: {
+        navigate: { success: true, result: { tabId: 'tab-123' } },
+        fill_form: { success: true, result: { ok: true } },
+      },
+    });
+
+    const result = await runPlaybook(tabPlaybook, { reuse: false, varMap: {}, client });
+
+    expect(result.summary.ok).toBe(true);
+    expect(calls[1]).toEqual({
+      tool: 'fill_form',
+      args: { fields: { name: 'OpenChrome' }, tabId: 'tab-123' },
+    });
   });
 });
 

--- a/tests/cli/replay.test.ts
+++ b/tests/cli/replay.test.ts
@@ -216,7 +216,12 @@ describe('replay report', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-replay-report-test-'));
+    // fs.realpathSync normalizes Windows short/long path forms (e.g. RUNNER~1
+    // vs runneradmin) so the test's destPath matches what cli/replay.ts gets
+    // back from path.resolve() when comparing with stdout.
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'oc-replay-report-test-')),
+    );
   });
 
   afterEach(() => {

--- a/tests/core/task-run/storage.test.ts
+++ b/tests/core/task-run/storage.test.ts
@@ -42,6 +42,7 @@ describe('TaskRunStore', () => {
       evidence: [{ kind: 'journal', ref: 'journal-1' }],
     });
     expect(checkpoint.checkpoint_id).toMatch(/^[a-f0-9]{16}$/);
+    expect(checkpoint.source_event_range).toEqual({ from: 1, to: 2 });
 
     const listed = await store.list({ status: 'RUNNING' });
     expect(listed.map(r => r.run_id)).toContain(started.run_id);
@@ -119,5 +120,57 @@ describe('TaskRunStore', () => {
     const loaded = await reopened.get(run.run_id);
     expect(loaded.goal).toBe('Restart-safe run');
     expect(loaded.completed_items).toEqual(['one']);
+  });
+
+  it('creates deterministic source-linked rolling checkpoints', async () => {
+    const run = await store.start({ goal: 'Collect titles' });
+    await store.update(run.run_id, {
+      current_cursor: 'https://example.com/?token=abcdefabcdefabcdefabcdefabcdef12',
+      completed_items: ['https://example.com'],
+      last_evidence: [{ kind: 'url', ref: 'https://example.com/?token=abcdefabcdefabcdefabcdefabcdef12' }],
+    });
+
+    const checkpoint = await store.checkpoint(run.run_id);
+    expect(checkpoint.source_event_range).toEqual({ from: 1, to: 2 });
+    expect(checkpoint.completed_count).toBe(1);
+    expect(checkpoint.failed_count).toBe(0);
+    expect(checkpoint.event_count).toBe(2);
+    expect(checkpoint.summary).toContain('completed=1');
+    expect(checkpoint.summary).toContain('range=1-2');
+    expect(checkpoint.summary).not.toContain('abcdefabcdefabcdefabcdefabcdef12');
+    expect(checkpoint.summary).toContain('[REDACTED]');
+
+    const latest = await store.latestCheckpoint(run.run_id);
+    expect(latest?.checkpoint_id).toBe(checkpoint.checkpoint_id);
+
+    const reopened = new TaskRunStore({ rootDir: dir });
+    expect((await reopened.latestCheckpoint(run.run_id))?.summary).toBe(checkpoint.summary);
+  });
+
+  it('produces byte-identical deterministic checkpoint fields except ids and timestamps', async () => {
+    const build = async (root: string) => {
+      let localNow = 1_700_000_000_000;
+      const localStore = new TaskRunStore({ rootDir: root, now: () => localNow++ });
+      const run = await localStore.start({ goal: 'Fixture run' });
+      await localStore.update(run.run_id, {
+        current_cursor: 'https://example.com/a',
+        completed_items: ['a'],
+        failed_items: [{ item: 'b', reason: 'not found' }],
+      });
+      return localStore.checkpoint(run.run_id, 'same caller note');
+    };
+    const first = await build(path.join(dir, 'first'));
+    const second = await build(path.join(dir, 'second'));
+    expect({
+      ...first,
+      checkpoint_id: 'ignored',
+      run_id: 'ignored',
+      created_at: 0,
+    }).toEqual({
+      ...second,
+      checkpoint_id: 'ignored',
+      run_id: 'ignored',
+      created_at: 0,
+    });
   });
 });

--- a/tests/fixtures/playbook/recipes/basic-navigation.yaml
+++ b/tests/fixtures/playbook/recipes/basic-navigation.yaml
@@ -1,0 +1,32 @@
+name: local fixture basic navigation
+vars:
+  base_url: http://127.0.0.1:8765
+steps:
+  - navigate:
+      url: ${base_url}/index.html
+  - assert:
+      contract:
+        kind: dom_text
+        selector: h1
+        contains: Playbook Fixture Home
+      evidence:
+        snapshot:
+          url: ${base_url}/index.html
+          dom_text:
+            h1: Playbook Fixture Home
+  - navigate:
+      url: ${base_url}/details.html
+  - assert:
+      contract:
+        kind: and
+        children:
+          - kind: url
+            pattern: "details\\.html"
+          - kind: dom_text
+            selector: h1
+            contains: Details Page
+      evidence:
+        snapshot:
+          url: ${base_url}/details.html
+          dom_text:
+            h1: Details Page

--- a/tests/fixtures/playbook/recipes/failure-recovery.yaml
+++ b/tests/fixtures/playbook/recipes/failure-recovery.yaml
@@ -1,0 +1,18 @@
+name: local fixture intentional failure
+vars:
+  base_url: http://127.0.0.1:8765
+steps:
+  - navigate:
+      url: ${base_url}/index.html
+  - assert:
+      contract:
+        kind: dom_text
+        selector: h1
+        contains: This Text Is Intentionally Missing
+      evidence:
+        snapshot:
+          url: ${base_url}/index.html
+          dom_text:
+            h1: Playbook Fixture Home
+  - navigate:
+      url: ${base_url}/details.html

--- a/tests/fixtures/playbook/recipes/safe-form.yaml
+++ b/tests/fixtures/playbook/recipes/safe-form.yaml
@@ -1,0 +1,26 @@
+name: local fixture safe form
+vars:
+  base_url: http://127.0.0.1:8765
+steps:
+  - navigate:
+      url: ${base_url}/index.html
+  # Some local Chrome profiles return a one-time headed-fallback notice instead
+  # of the tab metadata on first launch. The second local navigation establishes
+  # the reusable tabId that same-tab verbs need without leaving the fixture site.
+  - navigate:
+      url: ${base_url}/index.html
+  - fill_form:
+      fields:
+        name: OpenChrome
+  - navigate:
+      url: ${base_url}/submit.html?name=OpenChrome
+  - assert:
+      contract:
+        kind: dom_text
+        selector: h1
+        contains: Submitted Locally
+      evidence:
+        snapshot:
+          url: ${base_url}/submit.html?name=OpenChrome
+          dom_text:
+            h1: Submitted Locally

--- a/tests/fixtures/playbook/site/details.html
+++ b/tests/fixtures/playbook/site/details.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Playbook Fixture Details</title></head>
+<body>
+  <h1>Details Page</h1>
+  <p id="details">Details fixture reached successfully.</p>
+  <button id="ack" onclick="document.body.dataset.ack='true'; this.textContent='Acknowledged';">Acknowledge</button>
+</body></html>

--- a/tests/fixtures/playbook/site/index.html
+++ b/tests/fixtures/playbook/site/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Playbook Fixture Home</title></head>
+<body>
+  <h1>Playbook Fixture Home</h1>
+  <p id="intro">Local deterministic fixture for OpenChrome playbook verification.</p>
+  <a id="details-link" href="/details.html">Details</a>
+  <form id="safe-form" action="/submit.html" method="get">
+    <label>Name <input name="name" value=""></label>
+    <button type="submit">Submit Local Form</button>
+  </form>
+</body>
+</html>

--- a/tests/fixtures/playbook/site/submit.html
+++ b/tests/fixtures/playbook/site/submit.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Playbook Fixture Submitted</title></head>
+<body><h1>Submitted Locally</h1><p>No external network side effects occurred.</p></body></html>

--- a/tests/tools/task-run-tools.test.ts
+++ b/tests/tools/task-run-tools.test.ts
@@ -17,3 +17,13 @@ describe('TaskRun tool registration', () => {
     ]));
   });
 });
+
+describe('TaskRun checkpoint tool schema', () => {
+  it('accepts include_checkpoint on oc_task_run_get', () => {
+    const server = new MCPServer(undefined as any);
+    registerAllTools(server);
+    const definition = server.getToolManifest().tools.find(tool => tool.name === 'oc_task_run_get');
+    expect(definition).toBeDefined();
+    expect(definition?.inputSchema.properties.include_checkpoint).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Progress / Review status

_Auto-refreshed 2026-05-13 — owner comments cleaned up to reduce review noise._

| Field | Value |
| --- | --- |
| Branch | `feat/1042-rolling-checkpoints` → `feat/1039-task-run-lifecycle` |
| Draft | no |
| CI | — |
| Mergeable | ❌ CONFLICTING |
| Review decision | — |
| Codex (latest) | 💡 suggestions posted |
| Other reviewers (latest) | chatgpt-codex-connector: commented |
| Head | `e7442df` — Make TaskRun checkpoints source-linked |
| Commits | 2 |

<sub>Owner comment cleanup: 0 issue + 0 inline review comments deleted. Outstanding feedback from automated/external reviewers above is unchanged.</sub>
<!-- progress-status:end -->
---

## Summary
- Makes TaskRun checkpoints deterministic and source-linked with monotonic event sequence ranges.
- Adds bounded template summaries from event count/range, completed/failed counts, cursor/last URL, needs-help state, and evidence refs.
- Adds `oc_task_run_get({ include_checkpoint: true })` to retrieve the latest checkpoint after restart.

Refs #1042.

Note: this is the TaskRun-first slice. Standalone #855 ledger-task checkpoint generation should be added after #911/#855 lands to avoid duplicating the task-ledger storage contract.
Stacked on #1083 / `feat/1039-task-run-lifecycle`; merge #1083 first.

## Direction / duplicate check before implementation
- Open PRs checked: #1083 TaskRun lifecycle, #1113 journal handoff summary, #1095 resume guide, #911/#940/#955 ledger/progress/dashboard work.
- This PR is narrower than resume-guide/journal PRs: it only adds deterministic TaskRun checkpoint artifacts and source event ranges.
- It avoids LLM summarization, DB storage, raw log compaction, and browser tool behavior changes.

## Success criteria
- Checkpoints include `source_event_range` and evidence pointers where available.
- Summary is deterministic, <= 8 KiB, redacted, and derived from TaskRun state/events.
- Latest checkpoint survives store re-instantiation/restart.
- `oc_task_run_get({ include_checkpoint:true })` exposes the latest compact checkpoint.
- Existing checkpoint calls with a caller note still work, but the persisted summary remains template-shaped.

## Verification performed
- `npm test -- --runTestsByPath tests/core/task-run/storage.test.ts tests/tools/task-run-tools.test.ts --runInBand`
- `npm run build`
- `npm run lint:changed`

## Real OpenChrome verification after merge
1. Start a TaskRun for `Collect page titles from three public pages`.
2. Visit two pages and record progress/evidence with `oc_task_run_update`.
3. Call `oc_task_run_checkpoint` without a free-form summary.
4. Call `oc_task_run_get` with `include_checkpoint:true` and verify the checkpoint includes `source_event_range`, `completed_count: 2`, current cursor/last URL, and evidence refs.
5. Restart OpenChrome and repeat `oc_task_run_get({ include_checkpoint:true })`; verify the same checkpoint is returned.
6. Continue to the third page, update progress, call `oc_task_run_checkpoint` again, and verify the new checkpoint has a later event range.
7. Use a test URL containing `token=...`; inspect checkpoint JSON and verify secret-like values are redacted.

## Out of scope
- LLM-generated summaries.
- Automatic semantic success evaluation.
- Rewriting raw event logs.
- Ledger-task standalone checkpoints before #855 lands.