### PR TITLE
fix(tests): unblock tabs.test.ts — mock getTargetContextName + 5-arg createTarget

### DIFF
--- a/tests/tools/tabs.test.ts
+++ b/tests/tools/tabs.test.ts
@@ -225,8 +225,8 @@ describe('TabsCreateTool', () => {
 
       await handler(testSessionId, { url: 'https://google.com' });
 
-      // Now includes optional workerId parameter
-      expect(mockSessionManager.createTarget).toHaveBeenCalledWith(testSessionId, 'https://google.com', undefined, undefined);
+      // Now includes optional workerId + isolatedContext parameters (#848 / #946).
+      expect(mockSessionManager.createTarget).toHaveBeenCalledWith(testSessionId, 'https://google.com', undefined, undefined, undefined);
     });
 
     test('returns error when URL is not provided', async () => {
@@ -246,7 +246,8 @@ describe('TabsCreateTool', () => {
       await handler(testSessionId, { url: 'https://example.com' });
 
       // createTarget implicitly creates/uses session, now with optional workerId
-      expect(mockSessionManager.createTarget).toHaveBeenCalledWith(testSessionId, 'https://example.com', undefined, undefined);
+      // + isolatedContext parameters (#848 / #946).
+      expect(mockSessionManager.createTarget).toHaveBeenCalledWith(testSessionId, 'https://example.com', undefined, undefined, undefined);
     });
   });
 

--- a/tests/utils/mock-session.ts
+++ b/tests/utils/mock-session.ts
@@ -198,6 +198,11 @@ export function createMockSessionManager(options: MockSessionManagerOptions = {}
       return Array.from(worker.targets);
     }),
 
+    // #946: real SessionManager returns the BrowserContext name for tabs
+    // created with isolatedContext, or undefined for the default context.
+    // Tests don't exercise the named-context path, so always return undefined.
+    getTargetContextName: jest.fn().mockReturnValue(undefined),
+
     registerExternalTarget: jest.fn().mockImplementation((targetId: string, sessionId: string, workerId: string) => {
       const session = sessions.get(sessionId);
       if (!session) return;


### PR DESCRIPTION
Unblocks develop CI after #946 (isolatedContext) merge.

- `tests/utils/mock-session.ts` — add `getTargetContextName` mock returning `undefined`.
- `tests/tools/tabs.test.ts` — update 2 `toHaveBeenCalledWith` assertions to the new 5-arg `createTarget` signature.

Local: 18/18 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)