### PR TITLE
fix: clear title and timeout guard timers

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -1574,15 +1574,18 @@ export class CDPClient {
           );
         }
         if (cookieScan.targetId) {
+          let cookieCopyTid: ReturnType<typeof setTimeout> | undefined;
           await Promise.race([
             this.copyCookiesViaCDP(cookieScan.targetId, page),
-            new Promise<void>((resolve) =>
-              setTimeout(() => {
+            new Promise<void>((resolve) => {
+              cookieCopyTid = setTimeout(() => {
                 console.error(`[CDPClient] Cookie copy timed out after ${DEFAULT_COOKIE_COPY_TIMEOUT_MS}ms, proceeding without cookies`);
                 resolve();
-              }, DEFAULT_COOKIE_COPY_TIMEOUT_MS),
-            ),
-          ]);
+              }, DEFAULT_COOKIE_COPY_TIMEOUT_MS);
+            }),
+          ]).finally(() => {
+            if (cookieCopyTid) clearTimeout(cookieCopyTid);
+          });
         }
       }
     }
@@ -1597,10 +1600,15 @@ export class CDPClient {
     this.configurePageDefenses(page);
 
     // Set default viewport for consistent debugging experience (non-critical; swallow timeout)
+    let pageConfigTid: ReturnType<typeof setTimeout> | undefined;
     await Promise.race([
       page.setViewport(CDPClient.DEFAULT_VIEWPORT),
-      new Promise<void>((resolve) => setTimeout(resolve, DEFAULT_PAGE_CONFIG_TIMEOUT_MS)),
-    ]);
+      new Promise<void>((resolve) => {
+        pageConfigTid = setTimeout(resolve, DEFAULT_PAGE_CONFIG_TIMEOUT_MS);
+      }),
+    ]).finally(() => {
+      if (pageConfigTid) clearTimeout(pageConfigTid);
+    });
 
     if (url) {
       try {
@@ -2077,10 +2085,15 @@ export class CDPClient {
 
     for (const target of targets) {
       if (getTargetId(target) === targetId && target.type() === 'page') {
+        let targetPageTid: ReturnType<typeof setTimeout> | undefined;
         const page = await Promise.race([
           target.page(),
-          new Promise<null>((resolve) => setTimeout(() => resolve(null), 5000)),
-        ]);
+          new Promise<null>((resolve) => {
+            targetPageTid = setTimeout(() => resolve(null), 5000);
+          }),
+        ]).finally(() => {
+          if (targetPageTid) clearTimeout(targetPageTid);
+        });
         if (page) {
           // Populate index for future lookups
           this.targetIdIndex.set(targetId, page);

--- a/src/tools/checkpoint.ts
+++ b/src/tools/checkpoint.ts
@@ -11,6 +11,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { writeFileAtomicSafe, readFileSafe } from '../utils/atomic-file';
 import { getSessionManager } from '../session-manager';
+import { safeTitle } from '../utils/safe-title';
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -94,7 +95,7 @@ async function collectTabStates(): Promise<Array<{ tabId: string; url: string; t
             if (page) {
               url = page.url() || 'about:blank';
               try {
-                title = await page.title();
+                title = await safeTitle(page);
               } catch {
                 title = '';
               }

--- a/src/tools/session-snapshot.ts
+++ b/src/tools/session-snapshot.ts
@@ -10,6 +10,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
 import { writeFileAtomicSafe } from '../utils/atomic-file';
+import { safeTitle } from '../utils/safe-title';
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -119,7 +120,7 @@ export async function collectTabs(): Promise<SnapshotTab[]> {
             if (page) {
               url = page.url() || 'about:blank';
               try {
-                title = await page.title();
+                title = await safeTitle(page);
               } catch {
                 title = '';
               }

--- a/src/utils/dom-delta.ts
+++ b/src/utils/dom-delta.ts
@@ -8,6 +8,7 @@
 
 import type { Page } from 'puppeteer-core';
 import { safeTitle } from './safe-title';
+import { withTimeout } from './with-timeout';
 
 export interface DomDeltaOptions {
   /**
@@ -293,10 +294,7 @@ export async function withDomDelta<T>(
 
   // Inject the MutationObserver
   try {
-    await Promise.race([
-      page.evaluate(INJECT_OBSERVER_SCRIPT),
-      new Promise<void>((resolve) => setTimeout(resolve, 5000)),
-    ]);
+    await withTimeout(page.evaluate(INJECT_OBSERVER_SCRIPT), 5000, 'inject DOM delta observer');
   } catch {
     // If injection fails (e.g., page not ready), just run the action without delta
     const result = await action();
@@ -349,10 +347,11 @@ export async function withDomDelta<T>(
 
   // Collect mutations
   try {
-    const collected = await Promise.race([
+    const collected = await withTimeout(
       page.evaluate(COLLECT_DELTA_SCRIPT) as Promise<CollectedDelta | null>,
-      new Promise<null>((resolve) => setTimeout(() => resolve(null), 5000)),
-    ]);
+      5000,
+      'collect DOM delta',
+    );
     if (!collected) {
       return { result, delta: '' };
     }

--- a/src/utils/safe-title.ts
+++ b/src/utils/safe-title.ts
@@ -8,19 +8,14 @@
 
 import type { Page } from 'puppeteer-core';
 import { DEFAULT_SAFE_TITLE_TIMEOUT_MS } from '../config/defaults';
+import { withTimeout } from './with-timeout';
 
 export async function safeTitle(
   page: Page,
   timeoutMs: number = DEFAULT_SAFE_TITLE_TIMEOUT_MS,
 ): Promise<string> {
   try {
-    const result = await Promise.race([
-      page.title(),
-      new Promise<string>((_, reject) =>
-        setTimeout(() => reject(new Error('title timeout')), timeoutMs),
-      ),
-    ]);
-    return result;
+    return await withTimeout(page.title(), timeoutMs, 'page.title()');
   } catch {
     return '';
   }

--- a/tests/utils/safe-title.test.ts
+++ b/tests/utils/safe-title.test.ts
@@ -1,0 +1,37 @@
+/// <reference types="jest" />
+import type { Page } from 'puppeteer-core';
+import { safeTitle } from '../../src/utils/safe-title';
+
+describe('safeTitle', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('returns the page title and clears the timeout timer', async () => {
+    jest.useFakeTimers();
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+    const page = {
+      title: jest.fn().mockResolvedValue('Example'),
+    } as unknown as Page;
+
+    await expect(safeTitle(page, 1000)).resolves.toBe('Example');
+
+    expect(page.title).toHaveBeenCalledTimes(1);
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  test('returns an empty title when page.title times out', async () => {
+    jest.useFakeTimers();
+    const page = {
+      title: jest.fn(() => new Promise<string>(() => {})),
+    } as unknown as Page;
+
+    const title = safeTitle(page, 1000);
+    jest.advanceTimersByTime(1000);
+
+    await expect(title).resolves.toBe('');
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up cleanup from the audit of #88, #91, and #92-related PRs (#93/#94):

- route `safeTitle()` through the shared `withTimeout()` helper so its timeout handle is cleared when `page.title()` completes quickly
- replace the remaining raw `page.title()` metadata collection call sites in checkpoint/session snapshot tools with `safeTitle(page)`
- clear losing timers in localized CDP timeout races
- replace DOM delta timeout races with `withTimeout()`
- add focused `safeTitle()` tests for success cleanup and timeout fallback

## Validation

- `npm run build:src` passed in Codex autopilot before final commit
- `npm test -- --runInBand --runTestsByPath tests/utils/safe-title.test.ts` passed
- TypeScript diagnostics for changed files: 0 errors
- `git diff --check` passed

Note: a combined local run including `tests/utils/with-timeout.test.ts` hit an existing wall-clock sensitivity on this busy Fly worker (`Date.now() - start < 500`) while the repo already had unrelated long-running `tsc`/`jest` jobs. The new `safeTitle` test itself passes quickly.
