### PR TITLE
fix(read_page): cap interactive ax depth overrides

### DIFF
--- a/extension/src/tools/read-page.ts
+++ b/extension/src/tools/read-page.ts
@@ -27,6 +27,15 @@ interface AccessibilityNode {
   interactive?: boolean;
 }
 
+const AX_DEFAULT_DEPTH = 8;
+const AX_INTERACTIVE_MAX_DEPTH = 5;
+
+function resolveDepth(depth: number | undefined, filter: 'interactive' | 'all'): number {
+  const defaultDepth = filter === 'interactive' ? AX_INTERACTIVE_MAX_DEPTH : AX_DEFAULT_DEPTH;
+  const resolvedDepth = depth ?? defaultDepth;
+  return filter === 'interactive' ? Math.min(resolvedDepth, AX_INTERACTIVE_MAX_DEPTH) : resolvedDepth;
+}
+
 export function createReadPageTool(sessionManager: SessionManager) {
   const MAX_OUTPUT_LENGTH = 50000;
   const refIdManager = getRefIdManager();
@@ -40,7 +49,8 @@ export function createReadPageTool(sessionManager: SessionManager) {
       filter?: 'interactive' | 'all';
     }
   ): Promise<string> {
-    const { depth = 15, refId, filter = 'all' } = options;
+    const { refId, filter = 'all' } = options;
+    const depth = resolveDepth(options.depth, filter);
 
     // Clear existing refs for this tab to start fresh
     // This ensures refs are consistent within a single read_page call
@@ -215,9 +225,9 @@ export function createReadPageTool(sessionManager: SessionManager) {
   return {
     handler: async (sessionId: string, params: Record<string, unknown>): Promise<MCPResult> => {
       const tabId = params.tabId as number;
-      const depth = (params.depth as number) ?? 15;
       const refId = params.ref_id as string | undefined;
-      const filter = params.filter as 'interactive' | 'all' | undefined;
+      const filter = (params.filter as 'interactive' | 'all' | undefined) ?? 'all';
+      const depth = resolveDepth(params.depth as number | undefined, filter);
 
       if (!sessionId) {
         return {
@@ -282,7 +292,7 @@ export function createReadPageTool(sessionManager: SessionManager) {
           },
           depth: {
             type: 'number',
-            description: 'Maximum depth of the tree to traverse (default: 15)',
+            description: 'Maximum depth of the tree to traverse (default: 8; capped at 5 when filter="interactive")',
           },
           ref_id: {
             type: 'string',

--- a/src/tools/read-page.ts
+++ b/src/tools/read-page.ts
@@ -183,7 +183,10 @@ const handler: ToolHandler = async (
   const tabId = args.tabId as string;
   const filter = (args.filter as string) || 'all';
   const defaultDepth = filter === 'interactive' ? 5 : 8;
-  const maxDepth = (args.depth as number) || defaultDepth;
+  const requestedDepth = typeof args.depth === 'number' ? args.depth : undefined;
+  const maxDepth = filter === 'interactive'
+    ? Math.min(requestedDepth ?? defaultDepth, defaultDepth)
+    : requestedDepth ?? defaultDepth;
   const fetchDepth = maxDepth;
 
   const sessionManager = getSessionManager();

--- a/tests/tools/read-page.test.ts
+++ b/tests/tools/read-page.test.ts
@@ -74,13 +74,6 @@ describe('ReadPageTool', () => {
       sampleAccessibilityTree
     );
 
-    // Set up CDP response for depth 5 (used with interactive filter)
-    mockSessionManager.mockCDPClient.setCDPResponse(
-      'Accessibility.getFullAXTree',
-      { depth: 5 },
-      sampleAccessibilityTree
-    );
-
     // Set up DOM.getDocument response for DOM mode (now the default)
     mockSessionManager.mockCDPClient.setCDPResponse(
       'DOM.getDocument',
@@ -210,6 +203,23 @@ describe('ReadPageTool', () => {
         expect.anything(),
         'Accessibility.getFullAXTree',
         { depth: 3 }
+      );
+    });
+
+    test('caps custom depth above limit for interactive filter', async () => {
+      const handler = await getReadPageHandler();
+
+      await handler(testSessionId, {
+        tabId: testTargetId,
+        mode: 'ax',
+        filter: 'interactive',
+        depth: 10,
+      });
+
+      expect(mockSessionManager.mockCDPClient.send).toHaveBeenCalledWith(
+        expect.anything(),
+        'Accessibility.getFullAXTree',
+        { depth: 5 }
       );
     });
 


### PR DESCRIPTION
## Summary
- cap `read_page(mode="ax", filter="interactive")` depth at 5 even when callers pass a larger custom depth
- keep smaller explicit interactive depths intact
- align the extension read_page mirror/default schema with server defaults (all=8, interactive cap=5)
- add regression coverage for oversized interactive depth overrides

## Background
Follow-up audit for merged PR set #24/#25/#27/#29/#30 found that PR #30's intended interactive AX depth cap could be bypassed by explicitly passing a larger `depth`, and the extension mirror still advertised/used the old depth 15 default.

## Validation
- PASS: `npx jest --runTestsByPath tests/tools/read-page.test.ts --runInBand` (31/31)
- PASS: `git diff --check`
- NOTE: host is currently CPU-contended by several unrelated long-running openchrome validations; full `npm run build` / `npm run lint` were started but hit local command time limits without diagnostic errors. GitHub CI is the source of truth for full-suite status.

Fixes #30 follow-up.
