### PR TITLE
fix: preserve DOM delta soft timeout behavior

### DIFF
--- a/src/utils/dom-delta.ts
+++ b/src/utils/dom-delta.ts
@@ -292,9 +292,20 @@ export async function withDomDelta<T>(
     preUrl = '';
   }
 
-  // Inject the MutationObserver
+  // Inject the MutationObserver. Preserve the historical soft-timeout
+  // behavior: if injection is slow, proceed with the action and allow a
+  // late observer injection to be collected below, while still clearing the
+  // guard timer when injection wins quickly.
   try {
-    await withTimeout(page.evaluate(INJECT_OBSERVER_SCRIPT), 5000, 'inject DOM delta observer');
+    let injectTimeout: ReturnType<typeof setTimeout> | undefined;
+    await Promise.race([
+      page.evaluate(INJECT_OBSERVER_SCRIPT),
+      new Promise<void>((resolve) => {
+        injectTimeout = setTimeout(resolve, 5000);
+      }),
+    ]).finally(() => {
+      if (injectTimeout) clearTimeout(injectTimeout);
+    });
   } catch {
     // If injection fails (e.g., page not ready), just run the action without delta
     const result = await action();


### PR DESCRIPTION
## Summary

Follow-up to #1122 after Codex review feedback:

- preserve DOM delta observer injection's historical soft-timeout behavior
- still clear the injection guard timer when `page.evaluate(INJECT_OBSERVER_SCRIPT)` wins quickly
- keep the action/delta collection path available after a slow observer injection instead of falling back immediately to `delta: ''`

## Context

Codex correctly noted on #1122 that changing observer injection to `withTimeout()` made the 5s guard reject and take the no-delta fallback path. This PR restores the previous soft-timeout semantics while retaining the timer cleanup goal from the #88/#91/#92 audit follow-up.

## Validation

- `git diff --check` passed
- TypeScript diagnostics for `src/utils/dom-delta.ts`: 0 errors
