### PR TITLE
fix: surface pagination guidance in screenshots

### DIFF
--- a/src/tools/computer.ts
+++ b/src/tools/computer.ts
@@ -14,12 +14,30 @@ import { generateVisualSummary } from '../utils/visual-summary';
 import { AdaptiveScreenshot } from '../utils/adaptive-screenshot';
 import { withTimeout } from '../utils/with-timeout';
 import { retryWithFallback } from '../utils/retry-with-fallback';
+import { detectPagination, type PaginationInfo } from '../utils/pagination-detector';
 import {
   getBase64EncodedByteLength,
   resolveViewportDimensions,
   validateCaptureArea,
   validateInlineImagePayload,
 } from '../utils/screenshot-guards';
+
+function formatPaginationGuidance(pagination: PaginationInfo): string {
+  const detail = pagination.type === 'none'
+    ? ''
+    : ` detected (${pagination.type}${pagination.currentPage !== undefined ? ` page ${pagination.currentPage}` : ''}${pagination.totalPages !== undefined ? ` of ${pagination.totalPages}` : ''})`;
+  return `[Pagination Detected] Pagination${detail}. Use batch_paginate to collect pages/items; avoid manual next/scroll loops.`;
+}
+
+async function getPaginationGuidance(page: import('puppeteer-core').Page, tabId: string): Promise<string | null> {
+  try {
+    const pagination = await detectPagination(page, tabId);
+    if (pagination.type === 'none' || !pagination.hasNext) return null;
+    return formatPaginationGuidance(pagination);
+  } catch {
+    return null;
+  }
+}
 
 const definition: MCPToolDefinition = {
   name: 'computer',
@@ -279,6 +297,11 @@ const handler: ToolHandler = async (
           const content: MCPContent[] = [
             { type: 'image', data: screenshot.data, mimeType: screenshot.mimeType },
           ];
+
+          const paginationGuidance = await getPaginationGuidance(page, tabId);
+          if (paginationGuidance) {
+            content.push({ type: 'text', text: paginationGuidance });
+          }
 
           // annotated mode: append note about repeated screenshot
           if (effectiveMode === 'annotated') {

--- a/tests/tools/computer.test.ts
+++ b/tests/tools/computer.test.ts
@@ -20,6 +20,7 @@ import { getSessionManager } from '../../src/session-manager';
 import { getRefIdManager } from '../../src/utils/ref-id-manager';
 
 describe('ComputerTool', () => {
+  const mockDetectPagination = jest.fn();
   let mockSessionManager: ReturnType<typeof createMockSessionManager>;
   let mockRefIdManager: ReturnType<typeof createMockRefIdManager>;
   let testSessionId: string;
@@ -32,6 +33,9 @@ describe('ComputerTool', () => {
     }));
     jest.doMock('../../src/utils/ref-id-manager', () => ({
       getRefIdManager: () => mockRefIdManager,
+    }));
+    jest.doMock('../../src/utils/pagination-detector', () => ({
+      detectPagination: mockDetectPagination,
     }));
 
     const { registerComputerTool } = await import('../../src/tools/computer');
@@ -48,6 +52,13 @@ describe('ComputerTool', () => {
   };
 
   beforeEach(async () => {
+    mockDetectPagination.mockReset();
+    mockDetectPagination.mockResolvedValue({
+      type: 'none',
+      hasNext: false,
+      hasPrev: false,
+      suggestedStrategy: 'No pagination detected',
+    });
     mockSessionManager = createMockSessionManager();
     mockRefIdManager = createMockRefIdManager();
     (getSessionManager as jest.Mock).mockReturnValue(mockSessionManager);
@@ -469,6 +480,40 @@ describe('ComputerTool', () => {
       }) as { content: Array<{ type: string; mimeType?: string }> };
 
       expect(result.content[0].mimeType).toBe('image/webp');
+    });
+
+    test('appends batch_paginate guidance when screenshot detects pagination', async () => {
+      mockDetectPagination.mockResolvedValueOnce({
+        type: 'infinite_scroll',
+        hasNext: true,
+        hasPrev: false,
+        suggestedStrategy: 'Use batch_paginate',
+      });
+      const handler = await getComputerHandler();
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        action: 'screenshot',
+      }) as { content: Array<{ type: string; data?: string; text?: string }> };
+
+      expect(result.content[0]).toMatchObject({ type: 'image', data: 'base64-screenshot-data' });
+      expect(result.content[1]).toMatchObject({ type: 'text' });
+      expect(result.content[1].text).toContain('[Pagination Detected]');
+      expect(result.content[1].text).toContain('batch_paginate');
+      expect(result.content[1].text).toContain('manual next/scroll loops');
+    });
+
+    test('ignores pagination detection failures during screenshot', async () => {
+      mockDetectPagination.mockRejectedValueOnce(new Error('detector failed'));
+      const handler = await getComputerHandler();
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        action: 'screenshot',
+      }) as { content: Array<{ type: string; data?: string }> };
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0]).toMatchObject({ type: 'image', data: 'base64-screenshot-data' });
     });
 
     test('uses CDP Page.captureScreenshot', async () => {


### PR DESCRIPTION
## Summary
- Restore PR #49 / issue #47 guidance coverage outside `read_page` by surfacing pagination detection in `computer` screenshot responses.
- Add a screenshot response warning that tells agents to use `batch_paginate` for paginated/lazy-loaded/infinite-scroll lists instead of manual next/scroll loops.
- Add regression tests for screenshot pagination guidance and detector failure fallback.

## Verification
- `npm test -- --runTestsByPath tests/tools/computer.test.ts -t 'appends batch_paginate guidance|ignores pagination detection failures' --runInBand` ✅
- `./node_modules/.bin/eslint src/tools/computer.ts --ext .ts` ✅
- Independent review subagent: PASS (no security concerns or logic errors)

Notes: full project `tsc`/`lint:changed` and broader Jest invocations exceeded local worktree timeouts, so GitHub CI is the source of truth for the full matrix.

Follow-up coverage for #47 after #49.
