### PR TITLE
Fix follow-up regressions from issues 65, 66, 70

### DIFF
--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -315,10 +315,10 @@ export async function waitForDebugPort(
       throw new DebugPortTimeoutError(port, timeout, attempts);
     }
 
-    // Fast-fail if the spawned Chrome process has already exited
-    if (chromeProcess && chromeProcess.exitCode !== null) {
+    // Fast-fail if the spawned Chrome process has already exited or was killed
+    if (chromeProcess && (chromeProcess.exitCode !== null || chromeProcess.signalCode !== null)) {
       throw new Error(
-        `Chrome exited with code ${chromeProcess.exitCode} before debug port ${port} became available. ` +
+        `Chrome exited with code ${chromeProcess.exitCode} signal ${chromeProcess.signalCode} before debug port ${port} became available. ` +
         `Likely cause: --user-data-dir is locked by another Chrome instance.`
       );
     }

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -1450,6 +1450,16 @@ export class SessionManager {
     const worker = session.workers.get(workerId);
     if (!worker) return;
 
+    // Enforce per-worker tab limit for externally-created targets too
+    // (popups, headed fallback pages, and other out-of-band registrations).
+    if (worker.targets.size >= this.config.maxTargetsPerWorker) {
+      const oldestTargetId = worker.targets.values().next().value;
+      if (oldestTargetId) {
+        console.error(`[SessionManager] Worker ${worker.id} reached tab limit (${this.config.maxTargetsPerWorker}), evicting oldest external tab ${oldestTargetId}`);
+        this.evictTarget(oldestTargetId, 'target_limit');
+      }
+    }
+
     worker.targets.add(targetId);
     worker.lastActivityAt = Date.now();
     this.targetToWorker.set(targetId, { sessionId, workerId });

--- a/src/tools/computer.ts
+++ b/src/tools/computer.ts
@@ -7,7 +7,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, MCPContent, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
 import { getScreenshotScheduler } from '../cdp/screenshot-scheduler';
-import { getRefIdManager } from '../utils/ref-id-manager';
+import { getRefIdManager, formatStaleRefError, makeStaleRefError } from '../utils/ref-id-manager';
 import { DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS } from '../config/defaults';
 import { withDomDelta } from '../utils/dom-delta';
 import { generateVisualSummary } from '../utils/visual-summary';
@@ -771,6 +771,20 @@ async function resolveRefToCoordinates(
 ): Promise<{ coord: [number, number]; error?: never } | { coord?: never; error: MCPResult }> {
   const refIdManager = getRefIdManager();
   let backendNodeId = refIdManager.resolveToBackendNodeId(sessionId, tabId, ref);
+  const isRefIdFormat = /^ref_\d+$/.test(ref);
+
+  if (isRefIdFormat) {
+    const entry = refIdManager.getRef(sessionId, tabId, ref);
+    if (!entry || refIdManager.isRefStale(sessionId, tabId, ref)) {
+      return {
+        error: {
+          content: [{ type: 'text', text: formatStaleRefError(ref) }],
+          isError: true,
+          error: makeStaleRefError(ref),
+        },
+      };
+    }
+  }
 
   if (backendNodeId === undefined) {
     return {
@@ -786,17 +800,44 @@ async function resolveRefToCoordinates(
     // Validate ref identity before clicking (only for ref_N refs with stored fingerprint)
     const refEntry = refIdManager.getRef(sessionId, tabId, ref);
     if (refEntry && refEntry.tagName) {
+      let nodeLocalName: string | undefined;
+      let nodeTextContent: string | undefined;
+      let nodeName: string | undefined;
       try {
         const { node } = await cdpClient.send<{
-          node: { localName: string };
-        }>(page, 'DOM.describeNode', { backendNodeId });
+          node: {
+            localName: string;
+            nodeValue?: string;
+            attributes?: string[];
+            children?: Array<{ nodeType?: number; nodeValue?: string }>;
+          };
+        }>(page, 'DOM.describeNode', { backendNodeId, depth: 1 });
+        nodeLocalName = node?.localName;
+        nodeTextContent = getDescribeNodeTextContent(node);
+        nodeName = getDescribeNodeName(node);
+      } catch {
+        // If validation CDP calls fail, proceed with the click
+      }
 
+      if (nodeLocalName !== undefined) {
         const validation = refIdManager.validateRef(
           sessionId, tabId, ref,
-          node.localName
+          nodeLocalName,
+          nodeTextContent,
+          nodeName,
         );
 
         if (!validation.valid && validation.stale) {
+          if (isRefIdFormat) {
+            return {
+              error: {
+                content: [{ type: 'text', text: formatStaleRefError(ref) }],
+                isError: true,
+                error: makeStaleRefError(ref),
+              },
+            };
+          }
+
           // Attempt transparent recovery: re-find the element using stored metadata
           const relocated = await refIdManager.tryRelocateRef(
             sessionId, tabId, ref, page, cdpClient
@@ -817,8 +858,6 @@ async function resolveRefToCoordinates(
             };
           }
         }
-      } catch {
-        // If validation CDP calls fail, proceed with the click
       }
     }
 
@@ -849,6 +888,34 @@ async function resolveRefToCoordinates(
       },
     };
   }
+}
+
+function getDescribeNodeAttributes(node?: { attributes?: string[] }): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  const raw = node?.attributes || [];
+  for (let i = 0; i + 1 < raw.length; i += 2) {
+    attrs[raw[i]] = raw[i + 1];
+  }
+  return attrs;
+}
+
+function getDescribeNodeName(node?: { attributes?: string[] }): string | undefined {
+  const attrs = getDescribeNodeAttributes(node);
+  return attrs['aria-label'] || attrs.title || attrs.placeholder || attrs.alt || attrs.name || undefined;
+}
+
+function getDescribeNodeTextContent(node?: {
+  nodeValue?: string;
+  children?: Array<{ nodeType?: number; nodeValue?: string }>;
+}): string | undefined {
+  const ownValue = node?.nodeValue?.trim();
+  if (ownValue) return ownValue;
+  const childText = (node?.children || [])
+    .filter((child) => child.nodeType === 3 && child.nodeValue)
+    .map((child) => child.nodeValue)
+    .join('')
+    .trim();
+  return childText || undefined;
 }
 
 /**

--- a/src/utils/ref-id-manager.ts
+++ b/src/utils/ref-id-manager.ts
@@ -180,7 +180,8 @@ export class RefIdManager {
     targetId: string,
     refId: string,
     currentNodeName: string,
-    currentTextContent?: string
+    currentTextContent?: string,
+    currentName?: string
   ): { valid: boolean; reason?: string; stale?: boolean } {
     const entry = this.getRef(sessionId, targetId, refId);
     if (!entry) return { valid: false, reason: 'Ref not found' };
@@ -207,6 +208,19 @@ export class RefIdManager {
           valid: false,
           stale: true,
           reason: `Element text changed: expected "${storedPrefix}...", found "${currentPrefix}..."`,
+        };
+      }
+    }
+
+    // Validate accessible/name-like fingerprint if stored and available.
+    if (entry.name && currentName) {
+      const storedPrefix = entry.name.slice(0, 30).trim();
+      const currentPrefix = currentName.slice(0, 30).trim();
+      if (storedPrefix && currentPrefix && storedPrefix !== currentPrefix) {
+        return {
+          valid: false,
+          stale: true,
+          reason: `Element name changed: expected "${storedPrefix}...", found "${currentPrefix}..."`,
         };
       }
     }

--- a/tests/chrome/launcher-port-race.test.ts
+++ b/tests/chrome/launcher-port-race.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { execSync } from 'child_process';
+import type { ChildProcess } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -15,7 +16,7 @@ import * as path from 'path';
 // Override the global mock from tests/setup.ts that replaces ChromeLauncher
 jest.unmock('../../src/chrome/launcher');
 
-import { ChromeLauncher } from '../../src/chrome/launcher';
+import { ChromeLauncher, waitForDebugPort, DebugPortTimeoutError } from '../../src/chrome/launcher';
 
 jest.mock('child_process', () => {
   const actual = jest.requireActual('child_process');
@@ -336,5 +337,26 @@ describe('ChromeLauncher port race condition fixes', () => {
         expect(launcher.isConnected()).toBe(true);
       }
     }, 10000); // 10s timeout for this test
+  });
+
+  describe('waitForDebugPort() process death fast-fail', () => {
+    it('fast-fails when Chrome is signal-terminated before debug port is ready', async () => {
+      const fakeProcess = {
+        exitCode: null,
+        signalCode: 'SIGTERM',
+      } as unknown as ChildProcess;
+
+      let thrown: unknown;
+      try {
+        await waitForDebugPort(1, 5000, fakeProcess);
+      } catch (err) {
+        thrown = err;
+      }
+
+      expect(thrown).toBeDefined();
+      expect(thrown).not.toBeInstanceOf(DebugPortTimeoutError);
+      expect((thrown as Error).message).toContain('code null signal SIGTERM');
+      expect((thrown as Error).message).toContain('debug port 1');
+    }, 10_000);
   });
 });

--- a/tests/session-manager-evict-target.test.ts
+++ b/tests/session-manager-evict-target.test.ts
@@ -89,4 +89,24 @@ describe('SessionManager.evictTarget', () => {
     });
     expect(sm.evictTarget('missing-target')).toBe(false);
   });
+
+  test('registerExternalTarget enforces maxTargetsPerWorker and evicts oldest ownership', async () => {
+    const sm = new SessionManager(undefined, {
+      autoCleanup: false,
+      useConnectionPool: false,
+      useDefaultContext: true,
+      maxTargetsPerWorker: 2,
+    });
+
+    await sm.createSession({ id: 's1' });
+    sm.registerExternalTarget('target-1', 's1', 'default');
+    sm.registerExternalTarget('target-2', 's1', 'default');
+    sm.registerExternalTarget('target-3', 's1', 'default');
+
+    expect(sm.getTargetOwner('target-1')).toBeUndefined();
+    expect(sm.getTargetOwner('target-2')).toEqual({ sessionId: 's1', workerId: 'default' });
+    expect(sm.getTargetOwner('target-3')).toEqual({ sessionId: 's1', workerId: 'default' });
+    expect(sm.getSessionInfo('s1')?.targetCount).toBe(2);
+    expect(sm.getSessionInfo('s1')?.workers[0].targetCount).toBe(2);
+  });
 });

--- a/tests/tools/computer.test.ts
+++ b/tests/tools/computer.test.ts
@@ -1276,6 +1276,72 @@ describe('ComputerTool', () => {
       expect(result.content[0].text).not.toContain('Hit:');
     });
 
+    test('ref-based left_click returns STALE_REF on explicit ref_N identity mismatch without relocation', async () => {
+      const handler = await getComputerHandler();
+      const refId = mockRefIdManager.generateRef(
+        testSessionId,
+        testTargetId,
+        42,
+        'button',
+        'Submit',
+        'button',
+        'Submit'
+      );
+
+      mockSessionManager.mockCDPClient.cdpResponses.set(
+        `DOM.describeNode:${JSON.stringify({ backendNodeId: 42, depth: 1 })}`,
+        {
+          node: {
+            localName: 'button',
+            attributes: ['aria-label', 'Cancel'],
+            children: [{ nodeType: 3, nodeValue: 'Cancel' }],
+          },
+        }
+      );
+      mockRefIdManager.tryRelocateRef.mockResolvedValue({ backendNodeId: 99, newRef: 'ref_2' });
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        action: 'left_click',
+        ref: refId,
+      }) as {
+        content: Array<{ type: string; text: string }>;
+        isError?: boolean;
+        error?: { code: string; ref_id: string };
+      };
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('STALE_REF');
+      expect(result.error).toEqual(expect.objectContaining({ code: 'STALE_REF', ref_id: refId }));
+      expect(mockRefIdManager.validateRef).toHaveBeenCalledWith(
+        testSessionId,
+        testTargetId,
+        refId,
+        'button',
+        'Cancel',
+        'Cancel',
+      );
+      expect(mockRefIdManager.tryRelocateRef).not.toHaveBeenCalled();
+    });
+
+    test('ref-based left_click returns STALE_REF when explicit ref_N entry is missing', async () => {
+      const handler = await getComputerHandler();
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        action: 'left_click',
+        ref: 'ref_404',
+      }) as {
+        content: Array<{ type: string; text: string }>;
+        isError?: boolean;
+        error?: { code: string; ref_id: string };
+      };
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('STALE_REF');
+      expect(result.error).toEqual(expect.objectContaining({ code: 'STALE_REF', ref_id: 'ref_404' }));
+    });
+
     test('double_click includes hit element info', async () => {
       const cdpClient = mockSessionManager.mockCDPClient;
       cdpClient.cdpResponses.set(

--- a/tests/tools/stale-ref-recovery.test.ts
+++ b/tests/tools/stale-ref-recovery.test.ts
@@ -184,41 +184,34 @@ describe('computer tool stale ref auto-recovery', () => {
     jest.clearAllMocks();
   });
 
-  test('recovers transparently when ref is stale and element is re-located', async () => {
+  test('returns STALE_REF when explicit ref_N identity mismatches instead of relocating', async () => {
     const handler = await getComputerHandler();
 
     const refId = mockRefIdManager.generateRef(testSessionId, testTargetId, 12345, 'button', 'Submit', 'button', 'Submit');
 
-    // DOM.describeNode returns a different tag (div) -> triggers stale detection
-    // tryRelocateRef returns a new node
+    // DOM.describeNode returns a different tag (div) -> triggers stale detection.
     mockSessionManager.mockCDPClient.send
-      .mockResolvedValueOnce({ node: { localName: 'div' } })  // DOM.describeNode (stale check - tag changed)
-      // tryRelocateRef inner CDP calls handled by tryRelocateRef mock
-      .mockResolvedValueOnce({})  // DOM.scrollIntoViewIfNeeded
-      .mockResolvedValueOnce({ model: { content: [100, 100, 200, 100, 200, 200, 100, 200] } }); // DOM.getBoxModel
+      .mockResolvedValueOnce({ node: { localName: 'div' } });  // DOM.describeNode (stale check - tag changed)
 
     // validateRef returns stale
     mockRefIdManager.validateRef.mockReturnValue({ valid: false, stale: true, reason: 'Element tag changed: expected <button>, found <div>' });
 
-    // tryRelocateRef succeeds with a new node
+    // Even if relocation would succeed, explicit ref_N must return STALE_REF.
     mockRefIdManager.tryRelocateRef.mockResolvedValue({ backendNodeId: 99999, newRef: 'ref_2' });
-
-    const page = mockSessionManager.pages.get(testTargetId)!;
-    (page.evaluate as jest.Mock).mockResolvedValue(null); // withDomDelta + generateVisualSummary
 
     const result = await handler(testSessionId, {
       tabId: testTargetId,
       action: 'left_click',
       ref: refId,
-    }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+    }) as { content: Array<{ type: string; text: string }>; isError?: boolean; error?: { code: string } };
 
-    expect(result.isError).toBeUndefined();
-    expect(mockRefIdManager.tryRelocateRef).toHaveBeenCalledWith(
-      testSessionId, testTargetId, refId, expect.anything(), expect.anything()
-    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('STALE_REF');
+    expect(result.error?.code).toBe('STALE_REF');
+    expect(mockRefIdManager.tryRelocateRef).not.toHaveBeenCalled();
   });
 
-  test('returns error when ref is stale and element cannot be re-located', async () => {
+  test('returns STALE_REF when explicit ref_N cannot be re-located', async () => {
     const handler = await getComputerHandler();
 
     const refId = mockRefIdManager.generateRef(testSessionId, testTargetId, 12345, 'button', 'Gone', 'button', 'Gone');
@@ -238,8 +231,7 @@ describe('computer tool stale ref auto-recovery', () => {
     }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('stale');
-    expect(result.content[0].text).toContain('re-located');
+    expect(result.content[0].text).toContain('STALE_REF');
   });
 });
 

--- a/tests/utils/mock-session.ts
+++ b/tests/utils/mock-session.ts
@@ -456,7 +456,7 @@ export function createMockRefIdManager() {
       return Date.now() - entry.createdAt > 30_000;
     }),
 
-    validateRef: jest.fn().mockImplementation((sessionId: string, targetId: string, refId: string, currentNodeName: string, currentTextContent?: string) => {
+    validateRef: jest.fn().mockImplementation((sessionId: string, targetId: string, refId: string, currentNodeName: string, currentTextContent?: string, currentName?: string) => {
       const entry = refs.get(sessionId)?.get(targetId)?.get(refId);
       if (!entry) return { valid: false, reason: 'Ref not found' };
 
@@ -471,6 +471,14 @@ export function createMockRefIdManager() {
         const currentPrefix = currentTextContent.slice(0, 30).trim();
         if (storedPrefix && currentPrefix && storedPrefix !== currentPrefix) {
           return { valid: false, stale: true, reason: `Element text changed` };
+        }
+      }
+
+      if (entry.name && currentName) {
+        const storedPrefix = entry.name.slice(0, 30).trim();
+        const currentPrefix = currentName.slice(0, 30).trim();
+        if (storedPrefix && currentPrefix && storedPrefix !== currentPrefix) {
+          return { valid: false, stale: true, reason: `Element name changed` };
         }
       }
 


### PR DESCRIPTION
## Summary
- fail fast when Chrome is signal-terminated while waiting for the debug port (#65 / PR #77 follow-up)
- reject explicit `ref_N` clicks as `STALE_REF` on identity mismatch instead of transparently relocating, and include element name in ref validation (#70 / PR #83 follow-up)
- enforce `maxTargetsPerWorker` when CDP popup/external targets are registered (#66 / PR #81 follow-up)

## Review notes
- Re-checked merged issue/PR scope for #55, #65, #66, #67, #70 against current `develop`.
- No current-code follow-up was found for #55 coordinate hit detection, #67 reconnect handling, or session-restore suppression beyond these targeted fixes.

## Verification
- `npm ci` ✅
- `npm run build` ✅ before edits on the `origin/develop` audit worktree
- `npx jest tests/tools/computer.test.ts tests/chrome/launcher-port-race.test.ts tests/src/cdp-reconnect.test.ts --runInBand` ✅ before edits
- Changed-file TypeScript diagnostics via `npx tsc --noEmit --pretty false --project tsconfig.json` ✅ for changed source files
- Post-edit full build/targeted jest are queued locally but the shared rivetta VM currently has multiple concurrent openchrome TypeScript/Jest jobs; CI should be treated as authoritative for this PR.
