### PR TITLE
Fix stale CDP reconnect completions

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -559,6 +559,8 @@ export class CDPClient {
     }
     this.browser = null;
 
+    const generation = ++this.connectionGeneration;
+
     // Attempt reconnection — do NOT auto-launch Chrome.
     // If Chrome was closed by the user, we should stay disconnected and only
     // re-launch when the next tool call arrives (lazy launch). This prevents
@@ -581,7 +583,10 @@ export class CDPClient {
       });
 
       try {
-        await this.connectInternal({ autoLaunch: false });
+        const connected = await this.connectInternal({ autoLaunch: false, generation });
+        if (connected === false) {
+          return;
+        }
         console.error('[CDPClient] Reconnection successful');
         this.reconnectAttempts = 0;
         this.reconnecting = false;
@@ -1011,6 +1016,9 @@ export class CDPClient {
       }
       this.lastVerifiedAt = Date.now();
       this.consecutiveHeartbeatFailures = 0;
+      this.reconnecting = false;
+      this.reconnectingAttempt = 0;
+      this.reconnectNextRetryAt = 0;
       this.startHeartbeat();
       this.emitConnectionEvent({ type: 'reconnected', timestamp: Date.now() });
       console.error('[CDPClient] Reconnected to Chrome');

--- a/tests/src/cdp-connect-coalescing.test.ts
+++ b/tests/src/cdp-connect-coalescing.test.ts
@@ -378,6 +378,48 @@ describe('CDPClient – forceReconnect invalidates pending connects', () => {
     await connectPromise;
 
     expect((client as any).browser).toBe(newBrowser);
+    expect(client.isReconnecting()).toBe(false);
+    expect(staleBrowser.disconnect).toHaveBeenCalled();
+    stopHeartbeat(client);
+  });
+
+  test('stale disconnect reconnect result cannot overwrite newer forceReconnect browser', async () => {
+    const client = new CDPClient({ port: 9222, maxReconnectAttempts: 1 });
+    const oldBrowser = createMockBrowser('ws://old');
+    const staleBrowser = createMockBrowser('ws://stale');
+    const newBrowser = createMockBrowser('ws://new');
+
+    let resolveStaleConnect: (() => void) | null = null;
+    let resolveNewConnect: (() => void) | null = null;
+
+    mockPuppeteerConnect
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveStaleConnect = () => resolve(staleBrowser);
+      }))
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveNewConnect = () => resolve(newBrowser);
+      }));
+
+    (client as any).browser = oldBrowser;
+    (client as any).connectionState = 'connected';
+
+    const staleReconnectPromise = (client as any).handleDisconnect();
+    await Promise.resolve();
+    expect(mockPuppeteerConnect).toHaveBeenCalledTimes(1);
+
+    const forceReconnectPromise = client.forceReconnect();
+    await Promise.resolve();
+    expect(mockPuppeteerConnect).toHaveBeenCalledTimes(2);
+
+    resolveNewConnect!();
+    await forceReconnectPromise;
+    expect((client as any).browser).toBe(newBrowser);
+
+    resolveStaleConnect!();
+    await staleReconnectPromise;
+
+    expect((client as any).browser).toBe(newBrowser);
+    expect(client.isReconnecting()).toBe(false);
     expect(staleBrowser.disconnect).toHaveBeenCalled();
     stopHeartbeat(client);
   });


### PR DESCRIPTION
## Summary
- Follow-up to PR #95.
- Guard CDP connection assignment with connection generations so stale in-flight `connectInternal()` completions cannot overwrite newer reconnect state.
- Add regression coverage for stale pending connects and disconnect-driven reconnects racing with `forceReconnect()`.

## Validation
- `npm test -- tests/src/cdp-connect-coalescing.test.ts --runInBand`
- `npm run build:cli`
- `npm run build:src`

## Notes
- Full combined `npm run build` was previously killed externally without TypeScript diagnostics in this worktree, while `build:cli` and `build:src` passed separately.
- PRs #11, #12, and #15 were audited and did not show current code-grounded follow-up defects.
