### PR TITLE
fix: address profile and hint review followups

### DIFF
--- a/src/chrome/profile-manager.ts
+++ b/src/chrome/profile-manager.ts
@@ -57,7 +57,7 @@ export interface ChromeProfileInfo {
  * - Track whether the persistent profile is stale relative to the real
  *   Chrome profile using lightweight file-stat hashing.
  * - Perform atomic cookie sync via the `sqlite3` CLI `.backup` command when
- *   available, falling back to a plain file copy otherwise.
+ *   available.
  * - Decide which profile directory Chrome should use (`resolveProfile`).
  */
 export class ProfileManager {
@@ -232,14 +232,16 @@ export class ProfileManager {
    * `sourceDir` into `destDir`.
    *
    * Uses the `sqlite3` CLI `.backup` command for an atomic, consistent
-   * snapshot of the Cookies database. Falls back to a plain file copy when
-   * `sqlite3` is not available.
+   * snapshot of the Cookies database. When `sqlite3` is not available,
+   * cookie sync is skipped because copying Cookies/WAL/SHM files sequentially
+   * can produce an inconsistent snapshot. Non-cookie profile data is still
+   * copied.
    *
    * After a successful sync the metadata file is updated via
    * `updateSyncMetadata`.
    *
    * @returns `{ atomic: true, success: true }` when sqlite3 backup was used,
-   *          `{ atomic: false, success: true }` when the plain-copy fallback was used,
+   *          `{ atomic: false, success: false }` when cookie sync was skipped,
    *          `{ atomic: false, success: false }` when all methods failed.
    */
   syncProfileData(
@@ -295,30 +297,9 @@ export class ProfileManager {
 
           atomic = true;
         } else {
-          // sqlite3 not available — fall back to plain file copy (same as
-          // the legacy copyEssentialProfileData behaviour).
           console.error(
-            '[ProfileManager] sqlite3 not found, falling back to non-atomic cookie copy'
+            '[ProfileManager] sqlite3 not found, skipping cookie sync to avoid non-atomic WAL snapshot'
           );
-
-          const cookieFiles = [
-            'Cookies',
-            'Cookies-wal',
-            'Cookies-shm',
-            'Cookies-journal',
-          ];
-          for (const file of cookieFiles) {
-            const src = path.join(sourceDir, profileSubdir, file);
-            if (fs.existsSync(src)) {
-              try {
-                fs.copyFileSync(src, path.join(destDefault, file));
-              } catch {
-                // Individual file copy failure is non-fatal
-              }
-            }
-          }
-
-          atomic = false;
         }
       }
 
@@ -372,13 +353,15 @@ export class ProfileManager {
         }
       }
 
-      // --- 4. Update metadata -----------------------------------------------
-      this.updateSyncMetadata(sourceDir, profileSubdir);
+      // --- 4. Update cookie sync metadata -----------------------------------
+      if (atomic) {
+        this.updateSyncMetadata(sourceDir, profileSubdir);
+      }
 
       console.error(
         `[ProfileManager] Profile data sync complete (atomic=${atomic}) from ${sourceDir} → ${destDir}`
       );
-      return { atomic, success: true };
+      return { atomic, success: atomic };
     } catch (err) {
       console.error(
         '[ProfileManager] syncProfileData failed (non-fatal):',
@@ -540,7 +523,7 @@ export class ProfileManager {
       return {
         userDataDir: persistentDir,
         profileType: 'persistent',
-        syncPerformed: syncResult.atomic || syncResult.success,
+        syncPerformed: syncResult.atomic,
         ...(profileDirectory && { profileDirectory }),
       };
     }

--- a/src/hints/hint-engine.ts
+++ b/src/hints/hint-engine.ts
@@ -375,7 +375,7 @@ export class HintEngine {
    * Write a log entry via buffered async stream (best-effort, non-blocking).
    */
   private log(entry: HintLogEntry): void {
-    if (!this.logStream) return;
+    if (!this.logFilePath) return;
     this.logBuffer.push(JSON.stringify(entry) + '\n');
     if (!this.flushTimer) {
       this.flushTimer = setTimeout(() => {
@@ -385,12 +385,16 @@ export class HintEngine {
   }
 
   /**
-   * Flush buffered log entries to the write stream.
+   * Flush buffered log entries to disk.
+   *
+   * Use a synchronous append for the tiny buffered JSONL payloads so destroy()
+   * is deterministic for shutdown and tests. A WriteStream may acknowledge
+   * end() asynchronously, which can leave readers racing an empty/missing file.
    */
   private flushBuffer(): void {
-    if (this.logBuffer.length > 0 && this.logStream) {
+    if (this.logBuffer.length > 0 && this.logFilePath) {
       const data = this.logBuffer.join('');
-      this.logStream.write(data);
+      fs.appendFileSync(this.logFilePath, data, 'utf-8');
       this.logBuffer = [];
     }
     this.flushTimer = null;

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -2493,7 +2493,7 @@ export class MCPServer {
     warning: string | null;
   } | null {
     try {
-      const launcher = getChromeLauncher();
+      const launcher = getChromeLauncher(getGlobalConfig().port);
       const state = launcher.getProfileState();
 
       const profile: Record<string, unknown> = {

--- a/src/tools/profile-status.ts
+++ b/src/tools/profile-status.ts
@@ -10,6 +10,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { getChromeLauncher } from '../chrome/launcher';
 import { getChromePool } from '../chrome/pool';
+import { getGlobalConfig } from '../config/global';
 import { formatAge } from '../utils/format-age';
 
 const definition: MCPToolDefinition = {
@@ -27,7 +28,7 @@ const handler: ToolHandler = async (
   _args: Record<string, unknown>
 ): Promise<MCPResult> => {
   try {
-    const launcher = getChromeLauncher();
+    const launcher = getChromeLauncher(getGlobalConfig().port);
     const state = launcher.getProfileState();
 
     const capabilities = {

--- a/tests/chrome/persistent-profile.test.ts
+++ b/tests/chrome/persistent-profile.test.ts
@@ -250,8 +250,15 @@ describe('ProfileManager', () => {
       expect(result.atomic).toBe(true);
     });
 
-    it('should fall back to fs.copyFileSync when sqlite3 not available', () => {
+    it('should skip cookie copy when sqlite3 is not available', () => {
       fs.writeFileSync(path.join(sourceDir, 'Default', 'Cookies'), 'cookie-db');
+      fs.writeFileSync(path.join(sourceDir, 'Default', 'Cookies-wal'), 'wal-data');
+      fs.writeFileSync(path.join(sourceDir, 'Default', 'Cookies-shm'), 'shm-data');
+      fs.writeFileSync(path.join(sourceDir, 'Default', 'Cookies-journal'), 'journal-data');
+      fs.writeFileSync(
+        path.join(sourceDir, 'Default', 'Preferences'),
+        JSON.stringify({ profile: { exit_type: 'Crashed' } })
+      );
 
       // Mock: `which sqlite3` fails
       mockExecFileSync.mockImplementation((file: unknown) => {
@@ -265,8 +272,12 @@ describe('ProfileManager', () => {
       const result = manager.syncProfileData(sourceDir, destDir);
 
       expect(result.atomic).toBe(false);
-      // Cookies should have been copied via fs.copyFileSync
-      expect(fs.existsSync(path.join(destDir, 'Default', 'Cookies'))).toBe(true);
+      expect(result.success).toBe(false);
+      expect(fs.existsSync(path.join(destDir, 'Default', 'Cookies'))).toBe(false);
+      expect(fs.existsSync(path.join(destDir, 'Default', 'Cookies-wal'))).toBe(false);
+      expect(fs.existsSync(path.join(destDir, 'Default', 'Cookies-shm'))).toBe(false);
+      expect(fs.existsSync(path.join(destDir, 'Default', 'Cookies-journal'))).toBe(false);
+      expect(fs.existsSync(path.join(destDir, 'Default', 'Preferences'))).toBe(true);
     });
 
     it('should clean up WAL/SHM/journal files after atomic backup', () => {
@@ -360,7 +371,30 @@ describe('ProfileManager', () => {
       expect(() => manager.syncProfileData(sourceDir, destDir)).not.toThrow();
     });
 
-    it('should update sync metadata after successful sync', () => {
+    it('should update sync metadata after successful atomic cookie sync', () => {
+      fs.writeFileSync(path.join(sourceDir, 'Default', 'Cookies'), 'cookie-db');
+
+      mockExecFileSync.mockImplementation((file: unknown) => {
+        if (String(file) === 'which' || String(file) === 'where') {
+          return Buffer.from('/usr/bin/sqlite3');
+        }
+        if (String(file) === 'sqlite3') {
+          fs.mkdirSync(path.join(destDir, 'Default'), { recursive: true });
+          fs.writeFileSync(path.join(destDir, 'Default', 'Cookies'), 'backed-up-db');
+        }
+        return Buffer.from('');
+      });
+
+      const manager = new ProfileManager();
+      manager.syncProfileData(sourceDir, destDir);
+
+      const metadata = manager.getSyncMetadata();
+      expect(metadata).not.toBeNull();
+      expect(metadata!.syncCount).toBe(1);
+      expect(metadata!.sourceProfileDir).toBe(sourceDir);
+    });
+
+    it('should not update sync metadata when sqlite3 is unavailable', () => {
       fs.writeFileSync(path.join(sourceDir, 'Default', 'Cookies'), 'cookie-db');
 
       mockExecFileSync.mockImplementation((file: unknown) => {
@@ -373,10 +407,7 @@ describe('ProfileManager', () => {
       const manager = new ProfileManager();
       manager.syncProfileData(sourceDir, destDir);
 
-      const metadata = manager.getSyncMetadata();
-      expect(metadata).not.toBeNull();
-      expect(metadata!.syncCount).toBe(1);
-      expect(metadata!.sourceProfileDir).toBe(sourceDir);
+      expect(manager.getSyncMetadata()).toBeNull();
     });
   });
 
@@ -547,6 +578,21 @@ describe('ProfileManager', () => {
       expect(result.userDataDir).toBe('/mock/persistent');
       expect(result.syncPerformed).toBe(true);
       expect(manager.syncProfileData).toHaveBeenCalledWith('/real/chrome/profile', '/mock/persistent');
+    });
+
+    it('should not mark sync performed when cookie sync is not atomic', () => {
+      const manager = new ProfileManager();
+      jest.spyOn(manager, 'needsSync').mockReturnValue(true);
+      jest.spyOn(manager, 'syncProfileData').mockReturnValue({ atomic: false, success: false });
+      jest.spyOn(manager, 'getOrCreatePersistentProfile').mockReturnValue('/mock/persistent');
+
+      const result = manager.resolveProfile({
+        realProfileDir: '/real/chrome/profile',
+        isProfileLocked: true,
+      });
+
+      expect(result.profileType).toBe('persistent');
+      expect(result.syncPerformed).toBe(false);
     });
 
     it('should return persistent profile without sync when locked but fresh', () => {

--- a/tests/hints/hint-engine.test.ts
+++ b/tests/hints/hint-engine.test.ts
@@ -382,6 +382,28 @@ describe('HintEngine', () => {
       expect(hint?.hint).toContain('read_page');
     });
 
+    it('empty-result-streak: treats undefined javascript_tool output as empty', () => {
+      const tracker = makeTracker([
+        { toolName: 'javascript_tool' },
+        { toolName: 'javascript_tool' },
+      ]);
+      const engine = new HintEngine(tracker);
+      const hint = engine.getHint('javascript_tool', makeResult('undefined'), false);
+      expect(hint).not.toBeNull();
+      expect(hint?.hint).toContain('empty/null results');
+    });
+
+    it('empty-result-streak: treats empty string javascript_tool output as empty', () => {
+      const tracker = makeTracker([
+        { toolName: 'javascript_tool' },
+        { toolName: 'javascript_tool' },
+      ]);
+      const engine = new HintEngine(tracker);
+      const hint = engine.getHint('javascript_tool', makeResult(''), false);
+      expect(hint).not.toBeNull();
+      expect(hint?.hint).toContain('empty/null results');
+    });
+
     it('empty-result-streak: does NOT trigger when current result is non-empty', () => {
       const tracker = makeTracker([
         { toolName: 'javascript_tool' },

--- a/tests/mcp-server-profile.test.ts
+++ b/tests/mcp-server-profile.test.ts
@@ -32,6 +32,8 @@ jest.mock('../src/session-manager', () => ({
 }));
 
 import { getSessionManager } from '../src/session-manager';
+import { getChromeLauncher } from '../src/chrome/launcher';
+import { setGlobalConfig } from '../src/config/global';
 import { MCPServer } from '../src/mcp-server';
 import { MCPRequest, MCPToolDefinition } from '../src/types/mcp';
 
@@ -60,6 +62,7 @@ describe('MCPServer _profile injection', () => {
   });
 
   afterEach(() => {
+    setGlobalConfig({ port: 9222 });
     jest.clearAllMocks();
   });
 
@@ -94,6 +97,20 @@ describe('MCPServer _profile injection', () => {
     expect(response.result._profile).toBeDefined();
     expect(response.result._profile!.type).toBe('real');
     expect(response.result._profile!.extensions).toBe(true);
+  });
+
+  test('uses configured port when reading _profile state', async () => {
+    setGlobalConfig({ port: 9333 });
+    mockGetProfileState.mockReturnValue({
+      type: 'real',
+      extensionsAvailable: true,
+    });
+
+    await registerAndCall('configured_port_tool', () => ({
+      content: [{ type: 'text', text: 'OK' }],
+    }));
+
+    expect(getChromeLauncher).toHaveBeenCalledWith(9333);
   });
 
   test('includes _profile in error tool response', async () => {

--- a/tests/tools/profile-status.test.ts
+++ b/tests/tools/profile-status.test.ts
@@ -25,6 +25,8 @@ jest.mock('../../src/session-manager', () => ({
 }));
 
 import { getSessionManager } from '../../src/session-manager';
+import { getChromeLauncher } from '../../src/chrome/launcher';
+import { setGlobalConfig } from '../../src/config/global';
 import { MCPServer } from '../../src/mcp-server';
 import { registerProfileStatusTool } from '../../src/tools/profile-status';
 
@@ -42,6 +44,7 @@ describe('oc_profile_status tool', () => {
   });
 
   afterEach(() => {
+    setGlobalConfig({ port: 9222 });
     jest.clearAllMocks();
   });
 
@@ -60,6 +63,18 @@ describe('oc_profile_status tool', () => {
     expect(data.capabilities.savedPasswords).toBe(true);
     expect(data.capabilities.localStorage).toBe(true);
     expect(result.content[1].text).toContain('Real Chrome profile');
+  });
+
+  test('uses configured port when reading profile state', async () => {
+    setGlobalConfig({ port: 9334 });
+    mockGetProfileState.mockReturnValue({
+      type: 'real',
+      extensionsAvailable: true,
+    });
+
+    await handler('default', {});
+
+    expect(getChromeLauncher).toHaveBeenCalledWith(9334);
   });
 
   test('reports persistent profile with cookie age', async () => {


### PR DESCRIPTION
## Summary
- Follow up on audit findings for issues/PRs #73, #75/#89, #76/#88, #77, and #78.
- Remove the unsafe non-atomic SQLite Cookies/WAL/SHM fallback when sqlite3 is unavailable; cookie sync metadata and syncPerformed are now only marked after atomic backup.
- Ensure profile status reads the configured Chrome launcher port so degraded profile state is reported for the active singleton.
- Make hint hit/miss logging flush deterministically on destroy to avoid missing JSONL entries.

## Validation
- `npm install` (passes; runs prepare/build)
- `npm run build` (passes)
- `npm test -- --runTestsByPath tests/hints/hint-engine.test.ts tests/chrome/persistent-profile.test.ts tests/mcp-server-profile.test.ts tests/tools/profile-status.test.ts --runInBand` (passes: 4 suites, 134 tests)
- Full `npm test` was attempted locally but the Fly worker killed the long-running Jest process after ~30 minutes with exit 137; no assertion failure was observed before termination.

## Notes
- Targets `develop` per project instructions.
- Existing merged PRs remain merged; this PR carries the necessary follow-up corrections on top of current `develop`.
