### PR TITLE
fix(dom): polish attribute escaping follow-up

### DIFF
--- a/src/dom/dom-serializer.ts
+++ b/src/dom/dom-serializer.ts
@@ -119,11 +119,22 @@ function parseAttributes(attrs: string[] | undefined): Map<string, string> {
 }
 
 function escapeAttributeValue(value: string): string {
-  const escapedAmpersands = value.replace(/&/g, '&amp;');
-  return escapedAmpersands
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+  return value.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case "'":
+        return '&apos;';
+      default:
+        return char;
+    }
+  });
 }
 
 /**

--- a/tests/dom/dom-serializer.test.ts
+++ b/tests/dom/dom-serializer.test.ts
@@ -239,6 +239,7 @@ describe('DOM Serializer', () => {
           attributes: [
             'value', 'Tom & "Jerry" <Cartoon> > Show',
             'placeholder', 'Use "quotes" & <angle> brackets',
+            'title', "Bob's <special> label",
           ],
           children: [],
         }],
@@ -254,6 +255,7 @@ describe('DOM Serializer', () => {
     expect(line).toBeDefined();
     expect(line).toContain('value="Tom &amp; &quot;Jerry&quot; &lt;Cartoon&gt; &gt; Show"');
     expect(line).toContain('placeholder="Use &quot;quotes&quot; &amp; &lt;angle&gt; brackets"');
+    expect(line).toContain('title="Bob&apos;s &lt;special&gt; label"');
     expect(line).not.toContain('Tom & "Jerry" <Cartoon> > Show');
   });
 


### PR DESCRIPTION
## Summary
- Follow-up to bot review on PR #1127.
- Consolidate attribute escaping into a single pass.
- Add explicit apostrophe coverage for serialized DOM attributes.

## Validation
- `npm test -- tests/dom/dom-serializer.test.ts --runInBand --testNamePattern='escapes quotes and ampersands in kept attribute values'`
- `git diff --check`

Note: Full local build attempts on the shared Fly worker were intermittently terminated by the environment after the original PR validation had passed; CI is the source of truth for the final branch.
