### PR TITLE
fix(cdp): clear stale reconnect state follow-up

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -585,6 +585,12 @@ export class CDPClient {
       try {
         const connected = await this.connectInternal({ autoLaunch: false, generation });
         if (connected === false) {
+          this.reconnecting = false;
+          this.reconnectingAttempt = 0;
+          this.reconnectNextRetryAt = 0;
+          if (this.connectionState === 'reconnecting') {
+            this.connectionState = 'disconnected';
+          }
           return;
         }
         console.error('[CDPClient] Reconnection successful');

--- a/tests/src/cdp-connect-coalescing.test.ts
+++ b/tests/src/cdp-connect-coalescing.test.ts
@@ -423,4 +423,39 @@ describe('CDPClient – forceReconnect invalidates pending connects', () => {
     expect(staleBrowser.disconnect).toHaveBeenCalled();
     stopHeartbeat(client);
   });
+
+  test('stale disconnect reconnect abort clears reconnecting flags', async () => {
+    const client = new CDPClient({ port: 9222, maxReconnectAttempts: 1 });
+    const oldBrowser = createMockBrowser('ws://old');
+    const staleBrowser = createMockBrowser('ws://stale');
+
+    let resolveStaleConnect: (() => void) | null = null;
+    mockPuppeteerConnect.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveStaleConnect = () => resolve(staleBrowser);
+    }));
+
+    (client as any).browser = oldBrowser;
+    (client as any).connectionState = 'connected';
+
+    const staleReconnectPromise = (client as any).handleDisconnect();
+    for (let i = 0; i < 5 && mockPuppeteerConnect.mock.calls.length === 0; i++) {
+      await Promise.resolve();
+    }
+    expect(mockPuppeteerConnect).toHaveBeenCalledTimes(1);
+    expect(client.isReconnecting()).toBe(true);
+    expect((client as any).reconnectingAttempt).toBe(1);
+
+    (client as any).reconnectNextRetryAt = Date.now() + 1000;
+    (client as any).connectionGeneration += 1;
+
+    resolveStaleConnect!();
+    await staleReconnectPromise;
+
+    expect(client.isReconnecting()).toBe(false);
+    expect((client as any).reconnectingAttempt).toBe(0);
+    expect((client as any).reconnectNextRetryAt).toBe(0);
+    expect((client as any).browser).toBeNull();
+    expect(staleBrowser.disconnect).toHaveBeenCalled();
+    stopHeartbeat(client);
+  });
 });


### PR DESCRIPTION
## Summary
- Follow-up to bot review on PR #1128.
- Clear reconnecting bookkeeping when a stale disconnect reconnect aborts because a newer generation superseded it.
- Add focused regression coverage for the stale-abort path.

## Validation
- `git diff --check`
- Previous branch validation before review follow-up: `npm test -- tests/src/cdp-connect-coalescing.test.ts --runInBand && npm run build:cli && npm run build:src`

Note: A focused local rerun on the shared Fly worker was terminated by the environment before completion; CI is the source of truth for the final branch.
