### PR TITLE
fix(cdp): avoid stale reconnect state downgrade

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -588,9 +588,6 @@ export class CDPClient {
           this.reconnecting = false;
           this.reconnectingAttempt = 0;
           this.reconnectNextRetryAt = 0;
-          if (this.connectionState === 'reconnecting') {
-            this.connectionState = 'disconnected';
-          }
           return;
         }
         console.error('[CDPClient] Reconnection successful');

--- a/tests/src/cdp-connect-coalescing.test.ts
+++ b/tests/src/cdp-connect-coalescing.test.ts
@@ -451,7 +451,8 @@ describe('CDPClient – forceReconnect invalidates pending connects', () => {
     resolveStaleConnect!();
     await staleReconnectPromise;
 
-    expect(client.isReconnecting()).toBe(false);
+    expect((client as any).reconnecting).toBe(false);
+    expect((client as any).connectionState).toBe('reconnecting');
     expect((client as any).reconnectingAttempt).toBe(0);
     expect((client as any).reconnectNextRetryAt).toBe(0);
     expect((client as any).browser).toBeNull();


### PR DESCRIPTION
## Summary
- Follow-up to Codex review on PR #1131.
- Keep a stale reconnect abort from downgrading an active newer reconnect state to disconnected.
- Retain clearing of stale reconnect bookkeeping and add a focused regression assertion for that behavior.

## Validation
- `npm test -- tests/src/cdp-connect-coalescing.test.ts --runInBand --testNamePattern='stale disconnect reconnect abort clears reconnecting flags'`
- `git diff --check`
