### PR TITLE
fix(session): close external target evictions safely

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -850,7 +850,7 @@ export class CDPClient {
       // Register in the same worker as opener and inherit the opener's
       // named-context mapping (#848 Codex P1) so popups count toward the
       // same context's tab total instead of slipping into the default.
-      sessionManager.registerExternalTarget(targetId, ownerInfo.sessionId, ownerInfo.workerId, {
+      await sessionManager.registerExternalTarget(targetId, ownerInfo.sessionId, ownerInfo.workerId, {
         inheritContextFromTargetId: openerTargetId,
       });
 

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -130,6 +130,7 @@ export class SessionManager {
   private storageStateManagers = new Map<string, StorageStateManager>();
   private storageStateConfig: StorageStateConfig | null = null;
   private pendingCreations = new Map<string, Promise<Session>>();
+  private externalTargetRegistrationLocks = new Map<string, Promise<void>>();
 
   // Stealth mode tracking — targets opened via createTargetStealth
   private stealthTargets = new Set<string>();
@@ -1416,9 +1417,9 @@ export class SessionManager {
    * Injects the page into the main CDPClient's targetIdIndex so all tools
    * (read_page, interact, screenshot, etc.) work without a separate connection. (#485)
    */
-  registerHeadedPage(targetId: string, sessionId: string, workerId: string, page: Page): void {
+  async registerHeadedPage(targetId: string, sessionId: string, workerId: string, page: Page): Promise<void> {
     // Register target ownership (no parent — headed pages are top-level navigations).
-    this.registerExternalTarget(targetId, sessionId, workerId);
+    await this.registerExternalTarget(targetId, sessionId, workerId);
 
     // Inject the page into the main CDPClient's index so getPageByTargetId()
     // returns it and the stale-target guards in getCDPSession()/send() pass.
@@ -1435,12 +1436,34 @@ export class SessionManager {
    * count is bumped so closing the parent tab cannot trigger
    * `maybeDestroy` on a context that still has popups attached.
    */
-  registerExternalTarget(
+  async registerExternalTarget(
     targetId: string,
     sessionId: string,
     workerId: string,
     opts?: { inheritContextFromTargetId?: string },
-  ): void {
+  ): Promise<void> {
+    const lockKey = `${sessionId}:${workerId}`;
+    const previous = this.externalTargetRegistrationLocks.get(lockKey) ?? Promise.resolve();
+    const next = previous.catch(() => undefined).then(() =>
+      this.registerExternalTargetLocked(targetId, sessionId, workerId, opts),
+    );
+
+    this.externalTargetRegistrationLocks.set(lockKey, next);
+    try {
+      await next;
+    } finally {
+      if (this.externalTargetRegistrationLocks.get(lockKey) === next) {
+        this.externalTargetRegistrationLocks.delete(lockKey);
+      }
+    }
+  }
+
+  private async registerExternalTargetLocked(
+    targetId: string,
+    sessionId: string,
+    workerId: string,
+    opts?: { inheritContextFromTargetId?: string },
+  ): Promise<void> {
     // Don't overwrite existing entries
     if (this.targetToWorker.has(targetId)) return;
 
@@ -1452,11 +1475,15 @@ export class SessionManager {
 
     // Enforce per-worker tab limit for externally-created targets too
     // (popups, headed fallback pages, and other out-of-band registrations).
+    // Use closeTarget(), not evictTarget(), so the browser tab is actually
+    // closed and cannot leak after the ownership record is removed. The public
+    // wrapper serializes this block per worker so concurrent popups cannot all
+    // close the same oldest target and then overfill the worker.
     if (worker.targets.size >= this.config.maxTargetsPerWorker) {
       const oldestTargetId = worker.targets.values().next().value;
       if (oldestTargetId) {
-        console.error(`[SessionManager] Worker ${worker.id} reached tab limit (${this.config.maxTargetsPerWorker}), evicting oldest external tab ${oldestTargetId}`);
-        this.evictTarget(oldestTargetId, 'target_limit');
+        console.error(`[SessionManager] Worker ${worker.id} reached tab limit (${this.config.maxTargetsPerWorker}), closing oldest external tab ${oldestTargetId}`);
+        await this.closeTarget(sessionId, oldestTargetId);
       }
     }
 

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -304,10 +304,10 @@ async function headedAutoRetry(
         // Get the live Page object from HeadedFallbackManager and register it
         const page = headedFallback.getPage(result.targetId);
         if (page) {
-          sessionManager.registerHeadedPage(result.targetId, sessionId, resolvedWorkerId, page);
+          await sessionManager.registerHeadedPage(result.targetId, sessionId, resolvedWorkerId, page);
         } else {
           // Fallback: register without page injection (navigation-only, no tool access)
-          sessionManager.registerExternalTarget(result.targetId, sessionId, resolvedWorkerId);
+          await sessionManager.registerExternalTarget(result.targetId, sessionId, resolvedWorkerId);
         }
 
         tabId = result.targetId;
@@ -379,9 +379,9 @@ async function headedNavigateDirect(
 
         const page = headedFallback.getPage(result.targetId);
         if (page) {
-          sessionManager.registerHeadedPage(result.targetId, sessionId, resolvedWorkerId, page);
+          await sessionManager.registerHeadedPage(result.targetId, sessionId, resolvedWorkerId, page);
         } else {
-          sessionManager.registerExternalTarget(result.targetId, sessionId, resolvedWorkerId);
+          await sessionManager.registerExternalTarget(result.targetId, sessionId, resolvedWorkerId);
         }
 
         tabId = result.targetId;

--- a/tests/session-manager-evict-target.test.ts
+++ b/tests/session-manager-evict-target.test.ts
@@ -72,7 +72,7 @@ describe('SessionManager.evictTarget', () => {
     });
 
     await sm.createSession({ id: 's1' });
-    sm.registerExternalTarget('target-1', 's1', 'default');
+    await sm.registerExternalTarget('target-1', 's1', 'default');
     expect(sm.getTargetOwner('target-1')).toEqual({ sessionId: 's1', workerId: 'default' });
 
     const before = counterValueFor('listener_error');
@@ -90,7 +90,7 @@ describe('SessionManager.evictTarget', () => {
     expect(sm.evictTarget('missing-target')).toBe(false);
   });
 
-  test('registerExternalTarget enforces maxTargetsPerWorker and evicts oldest ownership', async () => {
+  test('registerExternalTarget enforces maxTargetsPerWorker and closes oldest browser target', async () => {
     const sm = new SessionManager(undefined, {
       autoCleanup: false,
       useConnectionPool: false,
@@ -99,13 +99,53 @@ describe('SessionManager.evictTarget', () => {
     });
 
     await sm.createSession({ id: 's1' });
-    sm.registerExternalTarget('target-1', 's1', 'default');
-    sm.registerExternalTarget('target-2', 's1', 'default');
-    sm.registerExternalTarget('target-3', 's1', 'default');
+    const closeTargetSpy = jest.spyOn(sm, 'closeTarget').mockImplementation(async (_sessionId, targetId) => {
+      sm.evictTarget(targetId);
+      return true;
+    });
 
+    await sm.registerExternalTarget('target-1', 's1', 'default');
+    await sm.registerExternalTarget('target-2', 's1', 'default');
+    await sm.registerExternalTarget('target-3', 's1', 'default');
+
+    expect(closeTargetSpy).toHaveBeenCalledWith('s1', 'target-1');
     expect(sm.getTargetOwner('target-1')).toBeUndefined();
     expect(sm.getTargetOwner('target-2')).toEqual({ sessionId: 's1', workerId: 'default' });
     expect(sm.getTargetOwner('target-3')).toEqual({ sessionId: 's1', workerId: 'default' });
+    expect(sm.getSessionInfo('s1')?.targetCount).toBe(2);
+    expect(sm.getSessionInfo('s1')?.workers[0].targetCount).toBe(2);
+  });
+
+  test('serializes concurrent external registrations so cap cannot be overfilled', async () => {
+    const sm = new SessionManager(undefined, {
+      autoCleanup: false,
+      useConnectionPool: false,
+      useDefaultContext: true,
+      maxTargetsPerWorker: 2,
+    });
+
+    await sm.createSession({ id: 's1' });
+    await sm.registerExternalTarget('target-1', 's1', 'default');
+    await sm.registerExternalTarget('target-2', 's1', 'default');
+
+    const closedTargets: string[] = [];
+    jest.spyOn(sm, 'closeTarget').mockImplementation(async (_sessionId, targetId) => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      closedTargets.push(targetId);
+      sm.evictTarget(targetId);
+      return true;
+    });
+
+    await Promise.all([
+      sm.registerExternalTarget('target-3', 's1', 'default'),
+      sm.registerExternalTarget('target-4', 's1', 'default'),
+    ]);
+
+    expect(closedTargets).toEqual(['target-1', 'target-2']);
+    expect(sm.getTargetOwner('target-1')).toBeUndefined();
+    expect(sm.getTargetOwner('target-2')).toBeUndefined();
+    expect(sm.getTargetOwner('target-3')).toEqual({ sessionId: 's1', workerId: 'default' });
+    expect(sm.getTargetOwner('target-4')).toEqual({ sessionId: 's1', workerId: 'default' });
     expect(sm.getSessionInfo('s1')?.targetCount).toBe(2);
     expect(sm.getSessionInfo('s1')?.workers[0].targetCount).toBe(2);
   });

--- a/tests/tools/computer.test.ts
+++ b/tests/tools/computer.test.ts
@@ -14,6 +14,8 @@ jest.mock('../../src/session-manager', () => ({
 
 jest.mock('../../src/utils/ref-id-manager', () => ({
   getRefIdManager: jest.fn(),
+  makeStaleRefError: (refId: string) => ({ code: 'STALE_REF', ref_id: refId, hint: "call read_page (mode='ax') to get fresh refs" }),
+  formatStaleRefError: (refId: string) => `STALE_REF: ref_id="${refId}" — call read_page (mode='ax') to get fresh refs`,
 }));
 
 import { getSessionManager } from '../../src/session-manager';
@@ -33,6 +35,8 @@ describe('ComputerTool', () => {
     }));
     jest.doMock('../../src/utils/ref-id-manager', () => ({
       getRefIdManager: () => mockRefIdManager,
+      makeStaleRefError: (refId: string) => ({ code: 'STALE_REF', ref_id: refId, hint: "call read_page (mode='ax') to get fresh refs" }),
+      formatStaleRefError: (refId: string) => `STALE_REF: ref_id="${refId}" — call read_page (mode='ax') to get fresh refs`,
     }));
     jest.doMock('../../src/utils/pagination-detector', () => ({
       detectPagination: mockDetectPagination,


### PR DESCRIPTION
## Progress / Review status

_Auto-refreshed 2026-05-13 — owner comments cleaned up to reduce review noise._

| Field | Value |
| --- | --- |
| Branch | `fix/pr1126-external-target-close-race` → `develop` |
| Draft | no |
| CI | ⏳ 7/9 passing — 2 pending |
| Mergeable | ✅ MERGEABLE |
| Review decision | — |
| Codex (latest) | — |
| Other reviewers (latest) | — |
| Head | `b21c891` — fix(session): close external target evictions safely |
| Commits | 1 |

<sub>Owner comment cleanup: 0 issue + 0 inline review comments deleted. Outstanding feedback from automated/external reviewers above is unchanged.</sub>
<!-- progress-status:end -->
---

---

Follow-up for merged PR #1126.\n\nAddresses Gemini/Codex review feedback that external target cap enforcement must close the actual browser target instead of only evicting ownership bookkeeping. Also serializes concurrent external registrations per session/worker to avoid overfilling the cap when multiple popups register concurrently.\n\nValidation:\n- npm run build\n- npm test -- --runTestsByPath tests/chrome/launcher-port-race.test.ts tests/tools/computer.test.ts tests/tools/stale-ref-recovery.test.ts tests/session-manager-evict-target.test.ts tests/ref-id-manager.test.ts --runInBand --forceExit\n- Codex pre-commit review: APPROVE