### PR TITLE
bench(webvoyager): validate transcript argument digests (#943)

### DIFF
--- a/docs/benchmarks/webvoyager.md
+++ b/docs/benchmarks/webvoyager.md
@@ -25,6 +25,23 @@ plus stable `latest.{json,md}` pointers.
 | `mock` | (default) | Replays JSONL transcripts under `transcripts/`. Deterministic, no network, no API key. CI uses this. |
 | `claude` | `OPENCHROME_BENCH_ADAPTER=claude`, `ANTHROPIC_API_KEY`, `OPENCHROME_BENCH_REAL=1` | Anthropic Messages API. Requires `@anthropic-ai/sdk` installed locally (`npm i -D @anthropic-ai/sdk`). The v1 scaffold throws a deliberate error explaining the recording workflow; the full tool-use loop lands in the follow-up PR that records the remaining 7 transcripts. |
 
+## Transcript determinism contract
+
+Frozen transcripts are JSONL files containing zero or more `tool_call` entries
+followed by a `final_state`. Every `tool_call` entry must include:
+
+- `tool` — the MCP tool name invoked by the recording adapter.
+- `args` — the exact JSON-compatible argument object sent to that tool.
+- `args_digest_sha256` — `sha256(deterministicStringify(args))`.
+- `response_kind` — a compact response classification used for report metrics.
+
+`deterministicStringify` sorts object keys recursively, preserves array order,
+drops `undefined` object fields the same way JSON does, and emits no whitespace.
+The mock adapter recomputes every digest before contract evaluation. A mismatch
+returns `replay_drift` with `{ expected, actual, tool, step_index }`, catching
+the case where a transcript keeps the same tool sequence but silently mutates
+arguments.
+
 ## Budget caps
 
 Defined in `llm/budget.ts`, applied by the claude adapter:
@@ -98,7 +115,7 @@ regressed score.
 1. Build `dist/` (`npm run build`).
 2. Set `ANTHROPIC_API_KEY` and `OPENCHROME_BENCH_REAL=1`.
 3. Run the claude adapter with the target task: `npm run bench:webvoyager:real -- --task <name>`.
-4. Capture the final page state and the per-step tool-call digests into
+4. Capture the final page state and the per-step tool-call `args` plus digests into
    `transcripts/<name>.jsonl`.
 5. Flip `pending: false` on the task spec and add the task name to
    `baseline.json` `transcripts_required`.

--- a/tests/benchmark/webvoyager/llm/mock-adapter.ts
+++ b/tests/benchmark/webvoyager/llm/mock-adapter.ts
@@ -6,11 +6,9 @@
  * an `EvalContext` over that frozen state, and lets the existing contract
  * evaluator decide pass/fail.
  *
- * `replay_drift` is emitted when the transcript is malformed or its tool
- * sequence diverges from what the runner expects — today that means a
- * missing/invalid final-state entry. Once the real adapter starts emitting
- * per-step tool-call traces, this will compare expected vs. actual call
- * digests and surface drift the same way.
+ * `replay_drift` is emitted when the transcript is malformed, lacks a usable
+ * final-state entry, or a per-step tool-call argument digest does not match
+ * the recorded argument object.
  *
  * The mock adapter is intentionally I/O-light: file reads only, no network.
  */
@@ -20,7 +18,8 @@ import path from 'node:path';
 
 import type { EvalContext, NetworkLogEntry } from '../../../../src/contracts/eval-context';
 import type { NetworkSinceMarker } from '../../../../src/contracts/types';
-import type { TranscriptEntry, TranscriptFinalState } from '../types';
+import { validateToolCallDigests } from '../transcript-digest';
+import type { TranscriptEntry, TranscriptFinalState, TranscriptToolCall } from '../types';
 
 export interface MockAdapterRunResult {
   context: EvalContext;
@@ -74,7 +73,18 @@ export async function runMockTask(taskName: string): Promise<MockAdapterRunResul
     }
   }
 
-  const toolCalls = entries.filter((e) => e.kind === 'tool_call').length;
+  const toolCallEntries = entries.filter((e): e is TranscriptToolCall => e.kind === 'tool_call');
+  const digestDrift = validateToolCallDigests(toolCallEntries);
+  if (digestDrift) {
+    return {
+      context: emptyContext(),
+      tool_calls: toolCallEntries.length,
+      response_bytes: raw.length,
+      drift: `replay_drift ${JSON.stringify(digestDrift)}`,
+    };
+  }
+
+  const toolCalls = toolCallEntries.length;
   const final = entries.find((e): e is TranscriptFinalState => e.kind === 'final_state');
   if (!final) {
     return {

--- a/tests/benchmark/webvoyager/runner.test.ts
+++ b/tests/benchmark/webvoyager/runner.test.ts
@@ -10,6 +10,11 @@
  * `/^[0-9a-f]{7,40}$/` and fall back to `'unknown'`.
  */
 
+import {
+  argsDigestSha256,
+  deterministicStringify,
+  validateToolCallDigests,
+} from './transcript-digest';
 import { gitSha } from './runner';
 
 describe('gitSha', () => {
@@ -73,5 +78,57 @@ describe('gitSha', () => {
     // Throw path is silent — no console.error — because "not a git repo"
     // is a legitimate dev-machine state (e.g. running from a tarball).
     expect(errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('WebVoyager transcript tool-call digests', () => {
+  test('deterministicStringify sorts object keys recursively without changing array order', () => {
+    expect(
+      deterministicStringify({ z: 1, a: { y: 2, b: 3 }, list: [{ c: 1, a: 2 }, 'x'] }),
+    ).toBe('{"a":{"b":3,"y":2},"list":[{"a":2,"c":1},"x"],"z":1}');
+  });
+
+  test('argsDigestSha256 is stable for semantically identical argument objects', () => {
+    const left = argsDigestSha256({ url: 'https://example.com/', options: { waitUntil: 'load', retries: 1 } });
+    const right = argsDigestSha256({ options: { retries: 1, waitUntil: 'load' }, url: 'https://example.com/' });
+    expect(left).toBe(right);
+    expect(left).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('validateToolCallDigests accepts matching recorded digests', () => {
+    const args = { mode: 'text', includeLinks: false };
+    expect(
+      validateToolCallDigests([
+        {
+          kind: 'tool_call',
+          tool: 'read_page',
+          args,
+          args_digest_sha256: argsDigestSha256(args),
+          response_kind: 'text_tree',
+        },
+      ]),
+    ).toBeUndefined();
+  });
+
+  test('validateToolCallDigests reports structured replay_drift for argument mutation', () => {
+    const expectedArgs = { url: 'https://example.com/' };
+    const actualArgs = { url: 'https://example.org/' };
+    expect(
+      validateToolCallDigests([
+        {
+          kind: 'tool_call',
+          tool: 'navigate',
+          args: actualArgs,
+          args_digest_sha256: argsDigestSha256(expectedArgs),
+          response_kind: 'ok',
+        },
+      ]),
+    ).toEqual({
+      expected: argsDigestSha256(expectedArgs),
+      actual: argsDigestSha256(actualArgs),
+      tool: 'navigate',
+      step_index: 0,
+      reason: 'digest_mismatch',
+    });
   });
 });

--- a/tests/benchmark/webvoyager/transcript-digest.ts
+++ b/tests/benchmark/webvoyager/transcript-digest.ts
@@ -1,0 +1,83 @@
+/**
+ * Deterministic transcript argument digests for WebVoyager mock replay.
+ *
+ * Contract for #943: tool-call transcript entries include the exact argument
+ * object observed by the recording adapter plus
+ * `args_digest_sha256 = sha256(deterministicStringify(args))`. The mock
+ * adapter recomputes the digest before evaluating the frozen final state so
+ * transcript argument drift fails as `replay_drift` instead of silently passing.
+ */
+
+import { createHash } from 'node:crypto';
+
+import type { TranscriptToolCall } from './types';
+
+export interface ToolCallDigestDrift {
+  expected?: string;
+  actual?: string;
+  tool: string;
+  step_index: number;
+  reason: 'missing_args' | 'missing_digest' | 'digest_mismatch';
+}
+
+export function deterministicStringify(value: unknown): string {
+  return JSON.stringify(normalizeForStableJson(value));
+}
+
+export function argsDigestSha256(args: unknown): string {
+  return createHash('sha256').update(deterministicStringify(args)).digest('hex');
+}
+
+export function validateToolCallDigests(entries: TranscriptToolCall[]): ToolCallDigestDrift | undefined {
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    if (!Object.prototype.hasOwnProperty.call(entry, 'args')) {
+      return {
+        tool: entry.tool,
+        step_index: i,
+        reason: 'missing_args',
+      };
+    }
+    if (!entry.args_digest_sha256) {
+      return {
+        actual: argsDigestSha256(entry.args),
+        tool: entry.tool,
+        step_index: i,
+        reason: 'missing_digest',
+      };
+    }
+
+    const actual = argsDigestSha256(entry.args);
+    if (actual !== entry.args_digest_sha256) {
+      return {
+        expected: entry.args_digest_sha256,
+        actual,
+        tool: entry.tool,
+        step_index: i,
+        reason: 'digest_mismatch',
+      };
+    }
+  }
+
+  return undefined;
+}
+
+function normalizeForStableJson(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeForStableJson(item));
+  }
+
+  if (value && typeof value === 'object') {
+    const input = value as Record<string, unknown>;
+    const output: Record<string, unknown> = {};
+    for (const key of Object.keys(input).sort()) {
+      const normalized = normalizeForStableJson(input[key]);
+      if (normalized !== undefined) {
+        output[key] = normalized;
+      }
+    }
+    return output;
+  }
+
+  return value;
+}

--- a/tests/benchmark/webvoyager/transcripts/task-01-example-com-title.jsonl
+++ b/tests/benchmark/webvoyager/transcripts/task-01-example-com-title.jsonl
@@ -1,3 +1,3 @@
-{"kind":"tool_call","tool":"navigate","response_kind":"ok"}
-{"kind":"tool_call","tool":"read_page","response_kind":"text_tree"}
+{"kind":"tool_call","tool":"navigate","args":{"url":"https://example.com/"},"args_digest_sha256":"fc3bcafb91730693484452065cac4cc17786f2307976d83295ada192d2f86e8e","response_kind":"ok"}
+{"kind":"tool_call","tool":"read_page","args":{"mode":"text"},"args_digest_sha256":"181d4fb55a1ec3c757a87d1b75f2fc9ae70083bc5b8729f4f63088dea7119835","response_kind":"text_tree"}
 {"kind":"final_state","url":"https://example.com/","dom_text":{"body":"Example Domain\n\nThis domain is for use in illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.\n\nMore information...","h1":"Example Domain","main":"Example Domain"},"dom_count":{"h1":1,"a":1,"main":0,"section":0},"network":[{"url":"https://example.com/","status":200,"ts":1730000000000}],"has_open_dialog":false}

--- a/tests/benchmark/webvoyager/transcripts/task-04-rfc-9110-section-9-title.jsonl
+++ b/tests/benchmark/webvoyager/transcripts/task-04-rfc-9110-section-9-title.jsonl
@@ -1,3 +1,3 @@
-{"kind":"tool_call","tool":"navigate","response_kind":"ok"}
-{"kind":"tool_call","tool":"read_page","response_kind":"text_tree"}
+{"kind":"tool_call","tool":"navigate","args":{"url":"https://www.rfc-editor.org/rfc/rfc9110.html"},"args_digest_sha256":"3ed83d88403d66651551d0b0f97c41d6a7d077369574e08182d170f873d15723","response_kind":"ok"}
+{"kind":"tool_call","tool":"read_page","args":{"mode":"text"},"args_digest_sha256":"181d4fb55a1ec3c757a87d1b75f2fc9ae70083bc5b8729f4f63088dea7119835","response_kind":"text_tree"}
 {"kind":"final_state","url":"https://www.rfc-editor.org/rfc/rfc9110.html","dom_text":{"body":"RFC 9110 HTTP Semantics June 2022 Table of Contents\n1. Introduction\n2. Conformance\n...\n9. Methods\n9.1. Overview\n9.2. Common Method Properties\n9.3. Method Definitions\n9.3.1. GET\n9.3.2. HEAD\n9.3.3. POST"},"dom_count":{"h1":1,"section":40},"network":[{"url":"https://www.rfc-editor.org/rfc/rfc9110.html","status":200,"ts":1730000001000}],"has_open_dialog":false}

--- a/tests/benchmark/webvoyager/transcripts/task-10-tc39-ecma262-strict-mode.jsonl
+++ b/tests/benchmark/webvoyager/transcripts/task-10-tc39-ecma262-strict-mode.jsonl
@@ -1,2 +1,2 @@
-{"kind":"tool_call","tool":"navigate","response_kind":"ok"}
+{"kind":"tool_call","tool":"navigate","args":{"url":"https://tc39.es/ecma262/"},"args_digest_sha256":"22d589bc81b4c6fe91f4a95a8dc3b2568aad364eab05f66a9e2424c695e2346c","response_kind":"ok"}
 {"kind":"final_state","url":"https://tc39.es/ecma262/","dom_text":{"body":"ECMAScript 2025 Language Specification Draft ECMA-262 / December 2024 Editors: ..."},"dom_count":{"h1":1},"network":[{"url":"https://tc39.es/ecma262/","status":200,"ts":1730000002000}],"has_open_dialog":false}

--- a/tests/benchmark/webvoyager/types.ts
+++ b/tests/benchmark/webvoyager/types.ts
@@ -37,10 +37,13 @@ export interface WebVoyagerTask {
  * adapter feeds these straight into the EvalContext.
  *
  * The transcript file is a JSONL with one JSON object per line; in v1 the
- * harness reads only the *last* line (the final state the contract should
- * be evaluated against). Earlier lines may carry per-step tool-call traces
- * recorded by the real adapter — they're informational and unused by the
- * mock runner today.
+ * harness reads the `final_state` line for contract evaluation and validates
+ * every preceding `tool_call` line for replay-drift protection. Each tool
+ * call stores its original argument object plus
+ * `args_digest_sha256 = sha256(deterministicStringify(args))` where
+ * deterministicStringify sorts object keys recursively and emits no
+ * whitespace. If a transcript is re-recorded with mutated arguments but the
+ * stored digest is not updated, mock replay reports `replay_drift`.
  */
 export interface TranscriptFinalState {
   kind: 'final_state';
@@ -52,16 +55,20 @@ export interface TranscriptFinalState {
 }
 
 /**
- * Per-step tool-call entry. v1 records only the tool name and the kind of
- * response we got back — enough for the mock adapter to compute
- * `tool_calls` count and `response_bytes`, but deliberately not enough to
- * detect argument drift. Argument-digest validation is tracked separately
- * in #943 (it requires a deterministic JSON serializer and a real-adapter
- * recorder; both land in the follow-up PR that records the remaining 7
- * transcripts).
+ * Per-step tool-call entry. `args` is the exact tool argument object observed
+ * by the recording adapter; `args_digest_sha256` is validated by the mock
+ * adapter before frozen-state contract evaluation.
  */
+export interface TranscriptToolCall {
+  kind: 'tool_call';
+  tool: string;
+  args: Record<string, unknown>;
+  args_digest_sha256: string;
+  response_kind: string;
+}
+
 export type TranscriptEntry =
-  | { kind: 'tool_call'; tool: string; response_kind: string }
+  | TranscriptToolCall
   | TranscriptFinalState;
 
 export interface TaskRunReport {


### PR DESCRIPTION
## Summary
- Adds deterministic JSON serialization plus SHA-256 argument digests for WebVoyager transcript tool calls.
- Validates recorded digests in the mock adapter before final-state contract evaluation and returns `replay_drift` on mismatch.
- Backfills the frozen transcripts with `args` + `args_digest_sha256` and documents the transcript determinism contract.

Closes #943.

## Verification
- `npm test -- tests/benchmark/webvoyager/runner.test.ts --runInBand`
- `npm run bench:webvoyager:mock`
- `npm run build`
- `npm run lint:tier`

## Notes
Real Claude transcript recording remains the existing opt-in follow-up path; this PR makes frozen mock replay reject argument drift now.
