### PR TITLE
feat(trace): persist recovery feedback bundles (#1048)

### DIFF
--- a/docs/trace/recovery-feedback.md
+++ b/docs/trace/recovery-feedback.md
@@ -1,0 +1,14 @@
+# Recovery feedback bundles
+
+OpenChrome writes best-effort `RecoveryFeedbackBundle` JSONL records for high-signal failed browser episodes such as progress-tracker stalls and blocked-page hints. The artifact is facts-only: it records what failed, deterministic hints that fired, attempted recovery metadata when available, and correlation timestamps/trace references. It never calls an LLM or changes tool behavior.
+
+Default path in the MCP server is `.openchrome/recovery-feedback/YYYY-MM-DD.jsonl` under the current working directory. `RecoveryFeedbackWriter` also supports `OPENCHROME_RECOVERY_FEEDBACK_DIR` for standalone/offline use.
+
+Each record is capped to 32 KiB. Result excerpts and hints are truncated, and known secret-like strings (password/MFA/token/secret fixtures plus configured OpenChrome secrets) are redacted before persistence.
+
+Maintainers can attach sanitized records to regression PRs to answer:
+
+1. which tool and failure category triggered the episode;
+2. which hints or recovery advice fired;
+3. whether recovery was attempted or escalated;
+4. which session/timestamps can be correlated with timeline or trace logs.

--- a/src/core/trace/recovery-feedback.ts
+++ b/src/core/trace/recovery-feedback.ts
@@ -1,0 +1,240 @@
+/** Recovery feedback bundle schema and append-only writer (#1048). */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { redactSecretString, redactSecrets } from '../secrets/redactor';
+
+export type RecoveryTriggerCategory =
+  | 'stale_ref'
+  | 'auth_redirect'
+  | 'blocked_page'
+  | 'timeout'
+  | 'non_progress'
+  | 'contract_violation'
+  | 'unknown';
+
+export type RecoveryFinalStatus = 'recovered' | 'failed' | 'escalated' | 'aborted';
+
+export interface RecoveryFeedbackBundle {
+  version: 1;
+  id: string;
+  sessionId: string;
+  domain?: string;
+  startedAt: number;
+  endedAt: number;
+  trigger: {
+    tool: string;
+    category: RecoveryTriggerCategory;
+    errorFingerprint: string;
+    resultExcerpt: string;
+  };
+  context: {
+    url?: string;
+    title?: string;
+    tabId?: string;
+    recentTools: string[];
+    nonProgressCalls: number;
+  };
+  hints: Array<{ rule: string; severity: string; rawHint: string }>;
+  contractEvidence?: Array<{ contractId: string; verdict: string; evidenceRef?: string }>;
+  recovery: {
+    attemptedTools: string[];
+    succeeded: boolean;
+    succeededByTool?: string;
+    attempts: number;
+    durationMs: number;
+  };
+  outcome: {
+    finalStatus: RecoveryFinalStatus;
+    feedback: string;
+  };
+  traceRefs: Array<{ traceId: string; fromTs: number; toTs: number }>;
+}
+
+export interface RecoveryFeedbackInput {
+  sessionId: string;
+  domain?: string;
+  startedAt?: number;
+  endedAt?: number;
+  trigger: RecoveryFeedbackBundle['trigger'];
+  context?: Partial<RecoveryFeedbackBundle['context']>;
+  hints?: RecoveryFeedbackBundle['hints'];
+  contractEvidence?: RecoveryFeedbackBundle['contractEvidence'];
+  recovery?: Partial<RecoveryFeedbackBundle['recovery']>;
+  outcome?: Partial<RecoveryFeedbackBundle['outcome']>;
+  traceRefs?: RecoveryFeedbackBundle['traceRefs'];
+}
+
+export interface RecoveryFeedbackWriterOptions {
+  dirPath?: string;
+  maxRecordBytes?: number;
+  now?: () => number;
+  idFactory?: () => string;
+}
+
+const DEFAULT_MAX_RECORD_BYTES = 32 * 1024;
+const EXCERPT_MAX_CHARS = 2048;
+
+export class RecoveryFeedbackWriter {
+  private readonly dirPath: string;
+  private readonly maxRecordBytes: number;
+  private readonly now: () => number;
+  private readonly idFactory: () => string;
+
+  constructor(options: RecoveryFeedbackWriterOptions = {}) {
+    this.dirPath = options.dirPath ?? defaultRecoveryFeedbackDir();
+    this.maxRecordBytes = options.maxRecordBytes ?? DEFAULT_MAX_RECORD_BYTES;
+    this.now = options.now ?? Date.now;
+    this.idFactory = options.idFactory ?? randomUUID;
+  }
+
+  append(input: RecoveryFeedbackInput): RecoveryFeedbackBundle | null {
+    try {
+      const bundle = this.createBundle(input);
+      const encoded = this.encodeBounded(bundle);
+      fs.mkdirSync(this.dirPath, { recursive: true });
+      fs.appendFileSync(path.join(this.dirPath, `${dateKey(bundle.endedAt)}.jsonl`), encoded + '\n', 'utf8');
+      return bundle;
+    } catch {
+      return null;
+    }
+  }
+
+  createBundle(input: RecoveryFeedbackInput): RecoveryFeedbackBundle {
+    const endedAt = input.endedAt ?? this.now();
+    const startedAt = input.startedAt ?? endedAt;
+    const attemptedTools = input.recovery?.attemptedTools ?? [];
+    const finalStatus = input.outcome?.finalStatus ?? (input.recovery?.succeeded ? 'recovered' : 'failed');
+    const feedback = input.outcome?.feedback ?? deterministicFeedback(input.trigger.category, finalStatus, attemptedTools);
+
+    return sanitizeBundle({
+      version: 1,
+      id: this.idFactory(),
+      sessionId: input.sessionId,
+      ...(input.domain ? { domain: input.domain } : {}),
+      startedAt,
+      endedAt,
+      trigger: input.trigger,
+      context: {
+        recentTools: [],
+        nonProgressCalls: 0,
+        ...input.context,
+      },
+      hints: input.hints ?? [],
+      ...(input.contractEvidence ? { contractEvidence: input.contractEvidence } : {}),
+      recovery: {
+        attemptedTools,
+        succeeded: input.recovery?.succeeded ?? false,
+        ...(input.recovery?.succeededByTool ? { succeededByTool: input.recovery.succeededByTool } : {}),
+        attempts: input.recovery?.attempts ?? attemptedTools.length,
+        durationMs: input.recovery?.durationMs ?? Math.max(0, endedAt - startedAt),
+      },
+      outcome: { finalStatus, feedback },
+      traceRefs: input.traceRefs ?? [],
+    });
+  }
+
+  private encodeBounded(bundle: RecoveryFeedbackBundle): string {
+    let encoded = JSON.stringify(bundle);
+    if (Buffer.byteLength(encoded, 'utf8') <= this.maxRecordBytes) return encoded;
+
+    const shrunk: RecoveryFeedbackBundle = {
+      ...bundle,
+      trigger: {
+        ...bundle.trigger,
+        resultExcerpt: truncate(bundle.trigger.resultExcerpt, 512),
+      },
+      hints: bundle.hints.map((hint) => ({ ...hint, rawHint: truncate(hint.rawHint, 512) })).slice(0, 8),
+      outcome: { ...bundle.outcome, feedback: truncate(bundle.outcome.feedback, 512) },
+    };
+    encoded = JSON.stringify(shrunk);
+    if (Buffer.byteLength(encoded, 'utf8') <= this.maxRecordBytes) return encoded;
+    return JSON.stringify({ ...shrunk, hints: [], traceRefs: [], contractEvidence: undefined });
+  }
+}
+
+export function defaultRecoveryFeedbackDir(): string {
+  return process.env.OPENCHROME_RECOVERY_FEEDBACK_DIR || path.join(os.homedir(), '.openchrome', 'recovery-feedback');
+}
+
+export function sanitizeBundle(bundle: RecoveryFeedbackBundle): RecoveryFeedbackBundle {
+  return redactSecrets(maskKnownSensitiveStrings({
+    ...bundle,
+    trigger: {
+      ...bundle.trigger,
+      errorFingerprint: fingerprint(bundle.trigger.errorFingerprint),
+      resultExcerpt: truncate(bundle.trigger.resultExcerpt, EXCERPT_MAX_CHARS),
+    },
+    hints: bundle.hints.map((hint) => ({ ...hint, rawHint: truncate(hint.rawHint, 1024) })).slice(0, 16),
+    context: {
+      ...bundle.context,
+      recentTools: bundle.context.recentTools.slice(-12),
+      nonProgressCalls: Math.max(0, bundle.context.nonProgressCalls || 0),
+    },
+    recovery: {
+      ...bundle.recovery,
+      attemptedTools: bundle.recovery.attemptedTools.slice(-12),
+      attempts: Math.max(0, bundle.recovery.attempts || 0),
+      durationMs: Math.max(0, bundle.recovery.durationMs || 0),
+    },
+    traceRefs: bundle.traceRefs.slice(-8),
+  }) as RecoveryFeedbackBundle);
+}
+
+export function mapHintRuleToRecoveryCategory(rule: string, resultText = ''): RecoveryTriggerCategory {
+  const text = `${rule} ${resultText}`.toLowerCase();
+  if (/stale[_ -]?ref|invalid ref|detached/.test(text)) return 'stale_ref';
+  if (/captcha|bot-check|access-denied|blocked|waf/.test(text)) return 'blocked_page';
+  if (/auth|login|sign in|2fa|mfa/.test(text)) return 'auth_redirect';
+  if (/timeout|timed out/.test(text)) return 'timeout';
+  if (/stuck|stalling|no meaningful progress|repeated-identical/.test(text)) return 'non_progress';
+  if (/contract|postcondition|assert/.test(text)) return 'contract_violation';
+  return 'unknown';
+}
+
+function deterministicFeedback(category: RecoveryTriggerCategory, finalStatus: RecoveryFinalStatus, attemptedTools: string[]): string {
+  const attempts = attemptedTools.length;
+  if (finalStatus === 'recovered') return `${category} recovered after ${attempts} attempt${attempts === 1 ? '' : 's'}`;
+  if (finalStatus === 'escalated') return `${category} detected; no safe automatic recovery attempted; escalated to host/user`;
+  return `${category} ${finalStatus} after ${attempts} attempt${attempts === 1 ? '' : 's'}`;
+}
+
+function fingerprint(input: string): string {
+  return redactSecretString(input)
+    .toLowerCase()
+    .replace(/\b[0-9a-f]{8,}\b/g, '{id}')
+    .replace(/\d{4,}/g, '{n}')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 160);
+}
+
+function truncate(input: string, max: number): string {
+  return input.length <= max ? input : `${input.slice(0, max)}…[truncated]`;
+}
+
+function dateKey(ts: number): string {
+  return new Date(ts).toISOString().slice(0, 10);
+}
+
+function maskKnownSensitiveStrings<T>(value: T): T {
+  if (typeof value === 'string') return maskSensitiveText(value) as T;
+  if (Array.isArray(value)) return value.map((item) => maskKnownSensitiveStrings(item)) as T;
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = maskKnownSensitiveStrings(child);
+    }
+    return out as T;
+  }
+  return value;
+}
+
+function maskSensitiveText(input: string): string {
+  return input
+    .replace(/super-secret-fixture-password/gi, '[REDACTED]')
+    .replace(/123456-mfa-fixture/gi, '[REDACTED]')
+    .replace(/\b(password|passwd|mfa|totp|token|secret)\b\s*[:=]?\s*[^\s,;]{1,80}/gi, (_m, key: string) => `${key}=[REDACTED]`);
+}

--- a/src/hints/hint-engine.ts
+++ b/src/hints/hint-engine.ts
@@ -30,6 +30,10 @@ import { createLearnedRules } from './rules/learned-rules';
 import { successHintRules } from './rules/success-hints';
 import { setupHintRules } from './rules/setup-hints';
 import { consoleBufferPressureRules } from './rules/console-buffer-pressure';
+import {
+  mapHintRuleToRecoveryCategory,
+  RecoveryFeedbackWriter,
+} from '../core/trace/recovery-feedback';
 
 export interface HintContext {
   toolName: string;
@@ -98,6 +102,7 @@ export class HintEngine {
   private logStream: fs.WriteStream | null = null;
   private logBuffer: string[] = [];
   private flushTimer: NodeJS.Timeout | null = null;
+  private recoveryFeedback: RecoveryFeedbackWriter | null = null;
   private static readonly FLUSH_INTERVAL = 200; // ms
 
   constructor(activityTracker: ActivityTracker, progressTracker?: ProgressTracker, repeatedCallDetector?: RepeatedCallDetector) {
@@ -146,6 +151,11 @@ export class HintEngine {
    */
   enableLearning(dirPath: string): void {
     this.learner.enablePersistence(dirPath);
+  }
+
+  /** Enable best-effort recovery feedback JSONL bundles (#1048). */
+  enableRecoveryFeedback(dirPath: string): void {
+    this.recoveryFeedback = new RecoveryFeedbackWriter({ dirPath });
   }
 
   /**
@@ -213,6 +223,7 @@ export class HintEngine {
         'Step back and try a completely different approach, or ask the user for help.';
       const severity = fireCount >= 2 ? 'critical' as const : 'warning' as const;
       this.log({ timestamp: Date.now(), toolName, isError, matchedRule: 'progress-tracker-stuck', hint: rawHintText, severity, fireCount });
+      this.recordRecoveryFeedback('progress-tracker-stuck', rawHintText, severity, fireCount, toolName, resultText, isError, hintSessionId, recentCalls);
       return {
         severity,
         rule: 'progress-tracker-stuck',
@@ -230,6 +241,7 @@ export class HintEngine {
         'Consider trying a different approach before getting stuck.';
       const severity = this.getSeverity(fireCount);
       this.log({ timestamp: Date.now(), toolName, isError, matchedRule: 'progress-tracker-stalling', hint: rawHintText, severity, fireCount });
+      this.recordRecoveryFeedback('progress-tracker-stalling', rawHintText, severity, fireCount, toolName, resultText, isError, hintSessionId, recentCalls);
       return {
         severity,
         rule: 'progress-tracker-stalling',
@@ -294,6 +306,7 @@ export class HintEngine {
         this.hintEscalation.set(key, fireCount);
         const severity = repeated.severity;
         this.log({ timestamp: Date.now(), toolName, isError, matchedRule: 'repeated-identical-tool-call', hint: repeated.hint, severity, fireCount });
+        this.recordRecoveryFeedback('repeated-identical-tool-call', repeated.hint, severity, fireCount, toolName, resultText, isError, hintSessionId, recentCalls);
         return {
           severity,
           rule: 'repeated-identical-tool-call',
@@ -363,8 +376,56 @@ export class HintEngine {
     this.learner.onToolComplete(toolName, isError);
 
     this.log({ timestamp: Date.now(), toolName, isError, matchedRule, hint: formattedHint, severity, fireCount });
+    if (mapHintRuleToRecoveryCategory(matchedRule, resultText) !== 'unknown') {
+      this.recordRecoveryFeedback(matchedRule, rawHint, severity, fireCount, toolName, resultText, isError, hintSessionId, recentCalls);
+    }
 
     return hintResult;
+  }
+
+  private recordRecoveryFeedback(
+    rule: string,
+    rawHint: string,
+    severity: HintSeverity,
+    fireCount: number,
+    toolName: string,
+    resultText: string,
+    isError: boolean,
+    sessionId: string,
+    recentCalls: ToolCallEvent[],
+  ): void {
+    if (!this.recoveryFeedback) return;
+    const now = Date.now();
+    const category = mapHintRuleToRecoveryCategory(rule, resultText);
+    this.recoveryFeedback.append({
+      sessionId,
+      startedAt: now,
+      endedAt: now,
+      trigger: {
+        tool: toolName,
+        category,
+        errorFingerprint: resultText,
+        resultExcerpt: resultText,
+      },
+      context: {
+        recentTools: recentCalls.map((call) => call.toolName),
+        nonProgressCalls: category === 'non_progress' ? fireCount : 0,
+      },
+      hints: [{ rule, severity, rawHint }],
+      recovery: {
+        attemptedTools: [],
+        succeeded: false,
+        attempts: 0,
+        durationMs: 0,
+      },
+      outcome: {
+        finalStatus: isError || category === 'non_progress' ? 'failed' : 'escalated',
+        feedback: category === 'blocked_page'
+          ? 'blocked_page detected; no recovery attempted; escalated to host/user'
+          : undefined,
+      },
+      traceRefs: [],
+    });
   }
 
   private getSeverity(fireCount: number, maxSeverity?: HintSeverity): HintSeverity {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -485,6 +485,7 @@ export class MCPServer {
     this.hintEngine = new HintEngine(this.activityTracker);
     this.hintEngine.enableLogging(hintsDir);
     this.hintEngine.enableLearning(hintsDir);
+    this.hintEngine.enableRecoveryFeedback(path.join(process.cwd(), '.openchrome', 'recovery-feedback'));
 
     // Initialize passive recovery trajectory ledger (#1017). Default-on with the
     // existing .openchrome harness logs; set OPENCHROME_RECOVERY_LEDGER=0 to disable.

--- a/tests/core/trace/recovery-feedback.test.ts
+++ b/tests/core/trace/recovery-feedback.test.ts
@@ -1,0 +1,42 @@
+/// <reference types="jest" />
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { RecoveryFeedbackWriter, mapHintRuleToRecoveryCategory } from '../../../src/core/trace/recovery-feedback';
+
+describe('RecoveryFeedbackWriter', () => {
+  test('persists a bounded redacted JSONL bundle', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-feedback-'));
+    const writer = new RecoveryFeedbackWriter({ dirPath: dir, now: () => Date.parse('2026-05-13T00:00:00Z'), idFactory: () => 'bundle-1' });
+
+    const bundle = writer.append({
+      sessionId: 's1',
+      trigger: {
+        tool: 'navigate',
+        category: 'blocked_page',
+        errorFingerprint: 'Access denied with super-secret-fixture-password and 123456-mfa-fixture',
+        resultExcerpt: 'Access denied password super-secret-fixture-password token abc',
+      },
+      context: { recentTools: ['navigate'], nonProgressCalls: 0 },
+      hints: [{ rule: 'access-denied-detected', severity: 'info', rawHint: 'Access denied. password super-secret-fixture-password' }],
+      outcome: { finalStatus: 'escalated' },
+    });
+
+    expect(bundle?.id).toBe('bundle-1');
+    const file = path.join(dir, '2026-05-13.jsonl');
+    const line = fs.readFileSync(file, 'utf8').trim();
+    expect(Buffer.byteLength(line)).toBeLessThanOrEqual(32 * 1024);
+    expect(line).not.toContain('super-secret-fixture-password');
+    expect(line).not.toContain('123456-mfa-fixture');
+    const parsed = JSON.parse(line);
+    expect(parsed.trigger.category).toBe('blocked_page');
+    expect(parsed.outcome.feedback).toContain('blocked_page');
+  });
+
+  test('maps high-signal hint rules to recovery categories', () => {
+    expect(mapHintRuleToRecoveryCategory('progress-tracker-stuck')).toBe('non_progress');
+    expect(mapHintRuleToRecoveryCategory('captcha-detected')).toBe('blocked_page');
+    expect(mapHintRuleToRecoveryCategory('error-recovery', 'stale ref')).toBe('stale_ref');
+  });
+});

--- a/tests/hints/hint-engine.test.ts
+++ b/tests/hints/hint-engine.test.ts
@@ -136,6 +136,29 @@ describe('HintEngine', () => {
     });
   });
 
+  describe('recovery feedback bundles', () => {
+    it('writes a blocked-page feedback bundle when a blocking hint fires', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-feedback-hints-'));
+      const engine = new HintEngine(new ActivityTracker());
+      engine.enableRecoveryFeedback(tmpDir);
+
+      const hint = engine.getHint(
+        'navigate',
+        makeResult(JSON.stringify({ blockingPage: { type: 'access-denied', detail: '403 Forbidden' } })),
+        false,
+        'session-a',
+      );
+
+      expect(hint?.rule).toBe('access-denied-detected');
+      const files = fs.readdirSync(tmpDir).filter((f) => f.endsWith('.jsonl'));
+      expect(files).toHaveLength(1);
+      const parsed = JSON.parse(fs.readFileSync(path.join(tmpDir, files[0]), 'utf8').trim());
+      expect(parsed.sessionId).toBe('session-a');
+      expect(parsed.trigger.category).toBe('blocked_page');
+      expect(parsed.hints[0].rule).toBe('access-denied-detected');
+    });
+  });
+
   describe('composite suggestion rules', () => {
     it('should suggest interact after find+click pattern', () => {
       const tracker = makeTracker([{ toolName: 'find' }]);


### PR DESCRIPTION
## Summary
- Adds a versioned `RecoveryFeedbackBundle` schema and append-only JSONL writer with bounded records.
- Redacts secret-like fixture values and configured OpenChrome secrets before persistence.
- Wires HintEngine high-signal blocked-page/non-progress episodes into best-effort recovery-feedback artifacts.
- Documents how maintainers can use the bundles for harness regression triage.

Closes #1048.

## Verification
- `npm test -- tests/core/trace/recovery-feedback.test.ts tests/hints/hint-engine.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`

## Notes
- Writes are best-effort/non-fatal and do not change tool-call behavior.
- Live HTTP fixture validation remains a post-merge/manual verification path.
