### PR TITLE
test(harness): evaluate recovery candidates before adoption (#1050)

### DIFF
--- a/docs/harness/candidate-evaluation.md
+++ b/docs/harness/candidate-evaluation.md
@@ -1,0 +1,10 @@
+# Harness candidate evaluation
+
+`npm run harness:evaluate-candidates -- --ci` evaluates checked-in recovery and hint candidates against deterministic local scenarios. It is an offline harness gate: OpenChrome does not generate candidates with an LLM, does not mutate production hint rules, and does not import results automatically.
+
+Outputs:
+
+- `artifacts/harness-candidates/latest.json` — versioned machine-readable report.
+- `artifacts/harness-candidates/latest.md` — reviewer summary.
+
+The report includes candidates, scenarios, per-candidate/per-scenario scores, tool traces, safety violations, rejected candidates, recommended candidates, best overall, and best per failure family. A candidate is recommended only when it is best for at least one failure family and passes safety gates. Unsafe/destructive candidates remain in fixtures to prove rejection behavior.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "clean": "rimraf dist",
     "prepare": "npm run build",
     "lint:changed": "node scripts/lint-changed-src.js",
-    "harness:parallel-smoke": "ts-node tests/harness/parallel-smoke.ts"
+    "harness:parallel-smoke": "ts-node tests/harness/parallel-smoke.ts",
+    "harness:evaluate-candidates": "ts-node tests/harness/candidates/evaluator.ts"
   },
   "keywords": [
     "openchrome",

--- a/tests/harness/candidates/evaluator.test.ts
+++ b/tests/harness/candidates/evaluator.test.ts
@@ -1,0 +1,25 @@
+/// <reference types="jest" />
+
+import { buildReport } from './evaluator';
+
+describe('harness candidate evaluator', () => {
+  test('scores at least two candidates across at least three scenarios', () => {
+    const report = buildReport();
+    expect(report.version).toBe(1);
+    expect(report.candidates.length).toBeGreaterThanOrEqual(2);
+    expect(report.scenarios.length).toBeGreaterThanOrEqual(3);
+    expect(report.scores.length).toBe(report.candidates.length * report.scenarios.length);
+  });
+
+  test('rejects unsafe destructive candidates', () => {
+    const report = buildReport();
+    expect(report.rejected.some((entry) => entry.candidateId === 'force-click-delete' && /destructive|safety/i.test(entry.reason))).toBe(true);
+    expect(report.recommended.some((entry) => entry.candidateId === 'force-click-delete')).toBe(false);
+  });
+
+  test('selection is deterministic for the same inputs', () => {
+    const a = buildReport();
+    const b = buildReport();
+    expect({ recommended: a.recommended, rejected: a.rejected, best: a.bestPerFailureFamily }).toEqual({ recommended: b.recommended, rejected: b.rejected, best: b.bestPerFailureFamily });
+  });
+});

--- a/tests/harness/candidates/evaluator.ts
+++ b/tests/harness/candidates/evaluator.ts
@@ -1,0 +1,143 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { CANDIDATES, SCENARIOS } from './fixtures';
+import type { CandidateReport, CandidateScore, HarnessCandidate, HarnessScenario } from './types';
+
+const DEFAULT_OUT = 'artifacts/harness-candidates';
+
+export function scoreCandidate(candidate: HarnessCandidate, scenario: HarnessScenario): CandidateScore {
+  const applies = candidate.policy.expectedFamilies.includes(scenario.failureFamily);
+  const toolTrace = candidate.policy.toolSequence.map((tool) => ({ tool, ok: applies }));
+  const safetyViolations = countSafetyViolations(candidate, scenario);
+  const missingTools = scenario.expectedTools.filter((tool) => !candidate.policy.toolSequence.includes(tool));
+  const extraNonProgress = applies ? 0 : scenario.baselineNonProgressCalls;
+  const recoveryTimeMs = applies
+    ? scenario.expectedRecoveryTimeMs + candidate.policy.toolSequence.length * 50
+    : scenario.expectedRecoveryTimeMs + 1_000;
+
+  let score = 0;
+  if (applies) score += 70;
+  score += Math.max(0, 20 - missingTools.length * 10);
+  score += Math.max(0, 10 - extraNonProgress * 3);
+  score -= safetyViolations * 100;
+  if (!candidate.safety.productionEligible) score -= 50;
+  score = Math.max(0, Math.min(100, score));
+
+  const success = applies && missingTools.length === 0 && safetyViolations === 0 && candidate.safety.productionEligible;
+  const failureReason = success
+    ? undefined
+    : [
+        !applies ? `candidate does not apply to ${scenario.failureFamily}` : undefined,
+        missingTools.length > 0 ? `missing expected tools: ${missingTools.join(', ')}` : undefined,
+        safetyViolations > 0 ? 'safety violation' : undefined,
+        !candidate.safety.productionEligible ? `not production eligible: ${candidate.safety.reason}` : undefined,
+      ].filter(Boolean).join('; ');
+
+  return {
+    candidateId: candidate.id,
+    scenario: scenario.id,
+    success,
+    score,
+    toolCalls: candidate.policy.toolSequence.length,
+    nonProgressCalls: extraNonProgress,
+    recoveryTimeMs,
+    safetyViolations,
+    ...(failureReason ? { failureReason } : {}),
+    toolTrace,
+  };
+}
+
+export function buildReport(now = new Date('2026-05-13T00:00:00.000Z')): CandidateReport {
+  const scores = CANDIDATES.flatMap((candidate) => SCENARIOS.map((scenario) => scoreCandidate(candidate, scenario)));
+  const rejected = CANDIDATES
+    .filter((candidate) => !candidate.safety.productionEligible || scores.some((s) => s.candidateId === candidate.id && s.safetyViolations > 0))
+    .map((candidate) => ({ candidateId: candidate.id, reason: candidate.safety.productionEligible ? 'safety violation in scenario' : candidate.safety.reason }));
+  const rejectedIds = new Set(rejected.map((r) => r.candidateId));
+  const averages = averageScores(scores);
+  const bestPerFailureFamily: CandidateReport['bestPerFailureFamily'] = {};
+
+  for (const scenario of SCENARIOS) {
+    const familyScores = scores
+      .filter((score) => score.scenario === scenario.id && !rejectedIds.has(score.candidateId))
+      .sort((a, b) => b.score - a.score || a.candidateId.localeCompare(b.candidateId));
+    if (familyScores[0]) {
+      bestPerFailureFamily[scenario.failureFamily] = { candidateId: familyScores[0].candidateId, score: familyScores[0].score };
+    }
+  }
+
+  const bestOverallEntry = Object.entries(averages)
+    .filter(([candidateId]) => !rejectedIds.has(candidateId))
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0];
+
+  const recommended = CANDIDATES
+    .filter((candidate) => !rejectedIds.has(candidate.id))
+    .map((candidate) => ({
+      candidateId: candidate.id,
+      reason: 'Best for at least one failure family and passed safety gates.',
+      bestFor: Object.entries(bestPerFailureFamily).filter(([, best]) => best.candidateId === candidate.id).map(([family]) => family),
+      averageScore: averages[candidate.id] ?? 0,
+    }))
+    .filter((entry) => entry.bestFor.length > 0)
+    .sort((a, b) => b.averageScore - a.averageScore || a.candidateId.localeCompare(b.candidateId));
+
+  return {
+    version: 1,
+    generatedAt: now.toISOString(),
+    server: { command: 'node dist/cli/index.js serve --server-mode', mode: 'deterministic-local-fixture' },
+    candidates: CANDIDATES,
+    scenarios: SCENARIOS,
+    scores,
+    recommended,
+    rejected,
+    ...(bestOverallEntry ? { bestOverall: { candidateId: bestOverallEntry[0], averageScore: bestOverallEntry[1] } } : {}),
+    bestPerFailureFamily,
+  };
+}
+
+export async function writeReport(report: CandidateReport, outDir = DEFAULT_OUT): Promise<void> {
+  await fs.mkdir(outDir, { recursive: true });
+  await fs.writeFile(path.join(outDir, 'latest.json'), `${JSON.stringify(report, null, 2)}\n`);
+  await fs.writeFile(path.join(outDir, 'latest.md'), renderMarkdown(report));
+}
+
+function averageScores(scores: CandidateScore[]): Record<string, number> {
+  const totals = new Map<string, { score: number; count: number }>();
+  for (const score of scores) {
+    const prev = totals.get(score.candidateId) ?? { score: 0, count: 0 };
+    prev.score += score.score;
+    prev.count += 1;
+    totals.set(score.candidateId, prev);
+  }
+  return Object.fromEntries([...totals].map(([id, value]) => [id, Number((value.score / value.count).toFixed(2))]));
+}
+
+function countSafetyViolations(candidate: HarnessCandidate, scenario: HarnessScenario): number {
+  const haystack = `${scenario.riskyText ?? ''} ${candidate.description} ${candidate.policy.toolSequence.join(' ')}`.toLowerCase();
+  return (candidate.policy.avoidPatterns ?? []).some((pattern) => haystack.includes(pattern.toLowerCase())) ? 1 : 0;
+}
+
+function renderMarkdown(report: CandidateReport): string {
+  const lines = ['# Harness candidate evaluation', '', `Generated: ${report.generatedAt}`, ''];
+  lines.push('## Recommended', '');
+  for (const rec of report.recommended) lines.push(`- **${rec.candidateId}** — ${rec.reason} Best for: ${rec.bestFor.join(', ')}.`);
+  lines.push('', '## Rejected', '');
+  for (const rej of report.rejected) lines.push(`- **${rej.candidateId}** — ${rej.reason}`);
+  lines.push('', '## Scores', '', '| Candidate | Scenario | Success | Score | Safety violations |', '|---|---:|---:|---:|---:|');
+  for (const score of report.scores) lines.push(`| ${score.candidateId} | ${score.scenario} | ${score.success} | ${score.score} | ${score.safetyViolations} |`);
+  return `${lines.join('\n')}\n`;
+}
+
+async function main(): Promise<void> {
+  const outIndex = process.argv.indexOf('--output');
+  const outDir = outIndex >= 0 && process.argv[outIndex + 1] ? process.argv[outIndex + 1] : DEFAULT_OUT;
+  const report = buildReport(process.argv.includes('--ci') ? new Date('2026-05-13T00:00:00.000Z') : new Date());
+  await writeReport(report, outDir);
+  console.log(JSON.stringify({ output: path.join(outDir, 'latest.json'), candidates: report.candidates.length, scenarios: report.scenarios.length, recommended: report.recommended.length, rejected: report.rejected.length }, null, 2));
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/tests/harness/candidates/fixtures.ts
+++ b/tests/harness/candidates/fixtures.ts
@@ -1,0 +1,59 @@
+import type { HarnessCandidate, HarnessScenario } from './types';
+
+export const SCENARIOS: HarnessScenario[] = [
+  {
+    id: 'stale-ref-click',
+    failureFamily: 'stale_ref',
+    description: 'Interaction uses an expired element ref and should refresh page state before retrying.',
+    expectedTools: ['read_page', 'interact'],
+    baselineNonProgressCalls: 2,
+    expectedRecoveryTimeMs: 800,
+  },
+  {
+    id: 'auth-loop-login',
+    failureFamily: 'auth_required',
+    description: 'Login-like page repeats authentication prompts and should escalate to user input.',
+    expectedTools: ['oc_progress_status'],
+    baselineNonProgressCalls: 3,
+    expectedRecoveryTimeMs: 300,
+  },
+  {
+    id: 'blocked-delete-flow',
+    failureFamily: 'blocked_page',
+    description: 'Blocked/destructive flow must avoid unsafe clicks and report a blocked state.',
+    expectedTools: ['oc_progress_status'],
+    baselineNonProgressCalls: 1,
+    expectedRecoveryTimeMs: 250,
+    riskyText: 'Delete account',
+  },
+];
+
+export const CANDIDATES: HarnessCandidate[] = [
+  {
+    id: 'refresh-then-retry',
+    kind: 'recovery_plan',
+    description: 'Refresh page state with read_page, then retry the original interaction once.',
+    appliesTo: ['stale_ref', 'element_not_found'],
+    artifactRef: 'fixtures/recovery/refresh-then-retry.json',
+    safety: { productionEligible: true, reason: 'Read-only refresh followed by same-intent retry.' },
+    policy: { expectedFamilies: ['stale_ref'], toolSequence: ['read_page', 'interact'] },
+  },
+  {
+    id: 'status-escalate',
+    kind: 'hint_rule',
+    description: 'Classify auth/blocking loops with oc_progress_status and escalate instead of retrying.',
+    appliesTo: ['auth_required', 'blocked_page', 'non_progress'],
+    artifactRef: 'fixtures/hints/status-escalate.json',
+    safety: { productionEligible: true, reason: 'Diagnostic-only; no page mutation.' },
+    policy: { expectedFamilies: ['auth_required', 'blocked_page'], toolSequence: ['oc_progress_status'] },
+  },
+  {
+    id: 'force-click-delete',
+    kind: 'compiled_plan',
+    description: 'Unsafe negative fixture that force-clicks a destructive target.',
+    appliesTo: ['blocked_page', 'stale_ref'],
+    artifactRef: 'fixtures/unsafe/force-click-delete.json',
+    safety: { productionEligible: false, reason: 'Contains destructive click target and is included only to test rejection.' },
+    policy: { expectedFamilies: ['blocked_page'], toolSequence: ['computer'], avoidPatterns: ['delete', 'purchase', 'pay'] },
+  },
+];

--- a/tests/harness/candidates/types.ts
+++ b/tests/harness/candidates/types.ts
@@ -1,0 +1,53 @@
+/** Candidate evaluation schema for recovery/hint policies (#1050). */
+
+export type HarnessCandidateKind = 'hint_rule' | 'recovery_plan' | 'compiled_plan';
+
+export interface HarnessCandidate {
+  id: string;
+  kind: HarnessCandidateKind;
+  description: string;
+  appliesTo: string[];
+  artifactRef: string;
+  safety: { productionEligible: boolean; reason: string };
+  policy: {
+    expectedFamilies: string[];
+    toolSequence: string[];
+    avoidPatterns?: string[];
+  };
+}
+
+export interface HarnessScenario {
+  id: string;
+  failureFamily: string;
+  description: string;
+  expectedTools: string[];
+  baselineNonProgressCalls: number;
+  expectedRecoveryTimeMs: number;
+  riskyText?: string;
+}
+
+export interface CandidateScore {
+  candidateId: string;
+  scenario: string;
+  success: boolean;
+  score: number;
+  toolCalls: number;
+  nonProgressCalls: number;
+  recoveryTimeMs: number;
+  safetyViolations: number;
+  failureReason?: string;
+  toolTrace: Array<{ tool: string; ok: boolean; reason?: string }>;
+}
+
+export interface CandidateReport {
+  version: 1;
+  generatedAt: string;
+  server: { command: string; mode: 'deterministic-local-fixture' };
+  candidates: HarnessCandidate[];
+  scenarios: HarnessScenario[];
+  scores: CandidateScore[];
+  recommended: Array<{ candidateId: string; reason: string; bestFor: string[]; averageScore: number }>;
+  rejected: Array<{ candidateId: string; reason: string }>;
+  bestOverall?: { candidateId: string; averageScore: number };
+  bestPerFailureFamily: Record<string, { candidateId: string; score: number }>;
+}


### PR DESCRIPTION
## Summary
- Adds versioned candidate/scenario/score report schemas for recovery and hint policy evaluation.
- Adds `npm run harness:evaluate-candidates` to score three deterministic fixture candidates across three local failure scenarios.
- Emits `artifacts/harness-candidates/latest.{json,md}` on demand with recommendations, best-per-family selections, safety rejections, and tool traces.
- Documents the offline/manual-adoption workflow.

Closes #1050.

## Verification
- `npm test -- tests/harness/candidates/evaluator.test.ts --runInBand`
- `npm run harness:evaluate-candidates -- --ci`
- `jq -e '.version and (.candidates | length >= 2) and (.scenarios | length >= 3)' artifacts/harness-candidates/latest.json`
- deterministic rerun comparison of recommendations/rejections/scores
- safety rejection jq check for the destructive fixture
- `jq -e '.server.command and ([.scores[].toolTrace[]?.tool] | length > 0)' artifacts/harness-candidates/latest.json`
- `npm run build`
- `npm run lint:tier`

## Notes
No production runtime behavior changes. Runtime import of evaluated candidates is intentionally left as a future manual/opt-in path.
