### PR TITLE
feat(harness): auto-capture run evidence on failures (#1023)

### DIFF
--- a/docs/harness/run-evidence.md
+++ b/docs/harness/run-evidence.md
@@ -1,0 +1,7 @@
+# Run harness auto evidence
+
+The opt-in run harness automatically writes a lightweight evidence bundle when a recorded tool call finishes with `ok:false` or carries progress metadata with `status: "stuck"`/`"stalling"`.
+
+Artifacts are written under `~/.openchrome/run-evidence/<run_id>/<evidence_id>/metadata.json` by default. Set `OPENCHROME_RUN_EVIDENCE_DIR` or construct `RunStore({ evidenceRootDir })` in tests to redirect output.
+
+The metadata includes `run_id`, `session_id`, `tab_id`, trigger, failure category, URL/title when supplied in event metadata, screenshot/network/console omitted reasons, and the last 10 tool-call summaries. Screenshot capture is disabled in this safe-mode writer; use `oc_evidence_bundle` for full live page snapshots. Evidence write failure is best-effort and never changes the original tool event result.

--- a/src/run-harness/evidence.ts
+++ b/src/run-harness/evidence.ts
@@ -1,0 +1,134 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { redactValue } from '../core/trace/redactor.js';
+import type { RunEvent, RunRecord } from './types.js';
+
+export interface RunEvidenceOptions {
+  rootDir?: string;
+  now?: () => number;
+  idFactory?: () => string;
+  includeScreenshot?: boolean;
+}
+
+export interface CaptureRunEvidenceInput {
+  record: RunRecord;
+  trigger: 'tool_error' | 'stuck' | 'postcondition_violation' | 'tab_eviction' | 'reconnect_failure' | 'max_budget_exceeded';
+  failureCategory?: string;
+  event?: RunEvent;
+  message?: string;
+}
+
+export interface RunEvidenceBundle {
+  version: 1;
+  evidence_id: string;
+  run_id: string;
+  session_id?: string;
+  tab_id?: string;
+  trigger: CaptureRunEvidenceInput['trigger'];
+  failure_category: string;
+  captured_at: number;
+  metadata: {
+    url?: string;
+    title?: string;
+    screenshot: { included: boolean; reason?: string };
+    network: { included: boolean; reason?: string };
+    console: { included: boolean; reason?: string };
+  };
+  recent_tool_calls: Array<{ tool?: string; ok?: boolean; duration_ms?: number; message?: string }>;
+  message?: string;
+}
+
+export function defaultRunEvidenceRootDir(): string {
+  return process.env.OPENCHROME_RUN_EVIDENCE_DIR || path.join(os.homedir(), '.openchrome', 'run-evidence');
+}
+
+export class RunEvidenceCapture {
+  private readonly rootDir: string;
+  private readonly now: () => number;
+  private readonly idFactory: () => string;
+  private readonly includeScreenshot: boolean;
+
+  constructor(options: RunEvidenceOptions = {}) {
+    this.rootDir = options.rootDir ?? defaultRunEvidenceRootDir();
+    this.now = options.now ?? Date.now;
+    this.idFactory = options.idFactory ?? (() => crypto.randomUUID());
+    this.includeScreenshot = options.includeScreenshot === true;
+  }
+
+  capture(input: CaptureRunEvidenceInput): { path: string; bundle: RunEvidenceBundle } | null {
+    try {
+      const bundle = this.buildBundle(input);
+      const dir = path.join(this.rootDir, sanitizePathSegment(input.record.run_id), bundle.evidence_id);
+      fs.mkdirSync(dir, { recursive: true });
+      const file = path.join(dir, 'metadata.json');
+      fs.writeFileSync(file, JSON.stringify(bundle, null, 2));
+      return { path: file, bundle };
+    } catch {
+      return null;
+    }
+  }
+
+  buildBundle(input: CaptureRunEvidenceInput): RunEvidenceBundle {
+    const eventMetadata = input.event?.metadata ?? {};
+    const url = stringMetadata(eventMetadata.url);
+    const title = stringMetadata(eventMetadata.title);
+    return redactValue({
+      version: 1,
+      evidence_id: `evidence-${this.idFactory()}`,
+      run_id: input.record.run_id,
+      session_id: input.event?.session_id ?? input.record.session_id,
+      tab_id: input.event?.tab_id ?? input.record.tab_id,
+      trigger: input.trigger,
+      failure_category: input.failureCategory ?? inferFailureCategory(input),
+      captured_at: this.now(),
+      metadata: {
+        ...(url ? { url } : {}),
+        ...(title ? { title } : {}),
+        screenshot: this.includeScreenshot
+          ? { included: false, reason: 'screenshot capture requires live page context; use oc_evidence_bundle for full snapshot' }
+          : { included: false, reason: 'disabled by run evidence safe mode' },
+        network: { included: false, reason: 'no network slice was attached to the run event' },
+        console: { included: false, reason: 'no console slice was attached to the run event' },
+      },
+      recent_tool_calls: input.record.events
+        .filter((event) => event.kind === 'tool_call_finished')
+        .slice(-10)
+        .map((event) => ({ tool: event.tool, ok: event.ok, duration_ms: event.duration_ms, message: event.message })),
+      ...(input.message ? { message: input.message } : {}),
+    } satisfies RunEvidenceBundle) as RunEvidenceBundle;
+  }
+}
+
+export function shouldAutoCaptureRunEvidence(event: RunEvent): boolean {
+  if (event.kind !== 'tool_call_finished') return false;
+  if (event.ok === false) return true;
+  const status = String((event.metadata?.progress as Record<string, unknown> | undefined)?.status ?? '');
+  return status === 'stuck' || status === 'stalling';
+}
+
+export function evidenceTriggerForEvent(event: RunEvent): CaptureRunEvidenceInput['trigger'] {
+  if (event.ok === false) return 'tool_error';
+  const status = String((event.metadata?.progress as Record<string, unknown> | undefined)?.status ?? '');
+  if (status === 'stuck' || status === 'stalling') return 'stuck';
+  return 'tool_error';
+}
+
+function inferFailureCategory(input: CaptureRunEvidenceInput): string {
+  if (input.failureCategory) return input.failureCategory;
+  const text = `${input.message ?? ''} ${input.event?.message ?? ''} ${JSON.stringify(input.event?.metadata ?? {})}`;
+  if (/stuck|stall|no.progress/i.test(text)) return 'NO_PROGRESS';
+  if (/timeout|timed out/i.test(text)) return 'MAX_STEPS_EXCEEDED';
+  if (/stale|not found|selector|element/i.test(text)) return 'ELEMENT_NOT_FOUND';
+  return 'UNKNOWN';
+}
+
+function stringMetadata(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.slice(0, 1000) : undefined;
+}
+
+function sanitizePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 160) || 'run';
+}

--- a/src/run-harness/index.ts
+++ b/src/run-harness/index.ts
@@ -2,3 +2,4 @@ export * from './types.js';
 export * from './store.js';
 export * from './tools.js';
 export * from './flags.js';
+export * from './evidence.js';

--- a/src/run-harness/store.ts
+++ b/src/run-harness/store.ts
@@ -4,12 +4,14 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { redactValue } from '../core/trace/redactor.js';
+import { evidenceTriggerForEvent, RunEvidenceCapture, shouldAutoCaptureRunEvidence } from './evidence.js';
 import { TERMINAL_RUN_STATUSES, type RunEvent, type RunRecord, type RunStatus } from './types.js';
 
 export interface RunStoreOptions {
   rootDir?: string;
   now?: () => number;
   idFactory?: () => string;
+  evidenceRootDir?: string;
 }
 
 export interface StartRunInput {
@@ -49,11 +51,13 @@ export class RunStore {
   private readonly rootDir: string;
   private readonly now: () => number;
   private readonly idFactory: () => string;
+  private readonly evidenceCapture: RunEvidenceCapture;
 
   constructor(opts: RunStoreOptions = {}) {
     this.rootDir = opts.rootDir ?? defaultRunRootDir();
     this.now = opts.now ?? Date.now;
     this.idFactory = opts.idFactory ?? (() => crypto.randomUUID());
+    this.evidenceCapture = new RunEvidenceCapture({ rootDir: opts.evidenceRootDir, now: this.now, idFactory: this.idFactory });
   }
 
   startRun(input: StartRunInput = {}): RunRecord {
@@ -129,6 +133,28 @@ export class RunStore {
       metadata: sanitizeMetadata(input.metadata),
     });
     record.events.push(event);
+    if (shouldAutoCaptureRunEvidence(event)) {
+      const captured = this.evidenceCapture.capture({
+        record,
+        event,
+        trigger: evidenceTriggerForEvent(event),
+        failureCategory: stringMetadata(input.metadata?.failureCategory),
+        message: input.message,
+      });
+      if (captured) {
+        record.events.push(this.event(safeRunId, 'evidence', {
+          session_id: input.session_id,
+          tab_id: input.tab_id,
+          tool: input.tool,
+          message: 'auto-captured run evidence bundle',
+          metadata: {
+            path: captured.path,
+            trigger: captured.bundle.trigger,
+            failureCategory: captured.bundle.failure_category,
+          },
+        }));
+      }
+    }
     record.updated_at = event.ts;
     this.writeRun(record);
     return event;
@@ -192,6 +218,10 @@ function sanitizeMetadata(value: Record<string, unknown> | undefined): Record<st
 
 function sanitizeText(value: string | undefined): string | undefined {
   return value === undefined ? undefined : String(redactValue(sanitizeRunLedgerString(value)));
+}
+
+function stringMetadata(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
 }
 
 function sanitizeRunLedgerValue(value: unknown): unknown {

--- a/tests/run-harness/evidence.test.ts
+++ b/tests/run-harness/evidence.test.ts
@@ -1,0 +1,24 @@
+/// <reference types="jest" />
+
+import { RunEvidenceCapture, shouldAutoCaptureRunEvidence } from '../../src/run-harness/evidence';
+import type { RunEvent, RunRecord } from '../../src/run-harness/types';
+
+describe('RunEvidenceCapture', () => {
+  test('builds graceful safe-mode bundle with omitted screenshot/network/console reasons', () => {
+    const capture = new RunEvidenceCapture({ now: () => 1234, idFactory: () => 'x' });
+    const record: RunRecord = { run_id: 'run-1', status: 'running', created_at: 1, updated_at: 2, events: [] };
+    const event: RunEvent = { id: 'evt-1', run_id: 'run-1', ts: 2, kind: 'tool_call_finished', tool: 'wait_for', ok: false, metadata: { url: 'https://example.test' } };
+    const bundle = capture.buildBundle({ record, event, trigger: 'tool_error' });
+    expect(bundle.evidence_id).toBe('evidence-x');
+    expect(bundle.trigger).toBe('tool_error');
+    expect(bundle.metadata.screenshot.included).toBe(false);
+    expect(bundle.metadata.network.included).toBe(false);
+    expect(bundle.metadata.console.included).toBe(false);
+  });
+
+  test('identifies tool errors and stuck progress as capture triggers', () => {
+    expect(shouldAutoCaptureRunEvidence({ id: '1', run_id: 'r', ts: 1, kind: 'tool_call_finished', ok: false })).toBe(true);
+    expect(shouldAutoCaptureRunEvidence({ id: '2', run_id: 'r', ts: 1, kind: 'tool_call_finished', ok: true, metadata: { progress: { status: 'stuck' } } })).toBe(true);
+    expect(shouldAutoCaptureRunEvidence({ id: '3', run_id: 'r', ts: 1, kind: 'tool_call_finished', ok: true })).toBe(false);
+  });
+});

--- a/tests/run-harness/store.test.ts
+++ b/tests/run-harness/store.test.ts
@@ -79,3 +79,46 @@ describe('RunStore', () => {
     expect(() => store.startRun({ run_id: '../escape' })).toThrow(/run_id/);
   });
 });
+
+describe('run evidence auto-capture', () => {
+  it('captures evidence metadata for failed tool calls and redacts secrets', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-run-evidence-store-'));
+    const evidenceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-run-evidence-out-'));
+    let now = 1000;
+    let seq = 0;
+    const store = new RunStore({ rootDir: dir, evidenceRootDir: evidenceDir, now: () => now++, idFactory: () => `ev-${seq++}` });
+    store.startRun({ run_id: 'run-evidence', session_id: 's1', tab_id: 't1' });
+    store.appendToolFinished({
+      run_id: 'run-evidence',
+      session_id: 's1',
+      tab_id: 't1',
+      tool: 'interact',
+      ok: false,
+      message: 'selector not found password=hunter2',
+      metadata: { url: 'https://example.test', title: 'Example', failureCategory: 'ELEMENT_NOT_FOUND', token: 'abc123' },
+    });
+
+    const run = store.getRun('run-evidence')!;
+    const evidenceEvent = run.events.find((event) => event.kind === 'evidence')!;
+    expect(evidenceEvent).toBeTruthy();
+    const evidencePath = (evidenceEvent.metadata as any).path as string;
+    const raw = fs.readFileSync(evidencePath, 'utf8');
+    expect(raw).toContain('ELEMENT_NOT_FOUND');
+    expect(raw).toContain('disabled by run evidence safe mode');
+    expect(raw).not.toContain('hunter2');
+    expect(raw).not.toContain('abc123');
+  });
+
+  it('captures evidence for stuck progress metadata without network or console slices', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-run-stuck-store-'));
+    const evidenceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-run-stuck-evidence-'));
+    const store = new RunStore({ rootDir: dir, evidenceRootDir: evidenceDir, now: () => 2000, idFactory: () => 'stuck-id' });
+    store.startRun({ run_id: 'run-stuck' });
+    store.appendToolFinished({ run_id: 'run-stuck', tool: 'read_page', ok: true, metadata: { progress: { status: 'stuck' } } });
+    const evidenceEvent = store.getRun('run-stuck')!.events.find((event) => event.kind === 'evidence')!;
+    const parsed = JSON.parse(fs.readFileSync((evidenceEvent.metadata as any).path, 'utf8'));
+    expect(parsed.trigger).toBe('stuck');
+    expect(parsed.metadata.network.included).toBe(false);
+    expect(parsed.metadata.console.included).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a run-harness safe-mode evidence writer for failed tool events and stuck/stalling progress metadata.
- Auto-captures trigger, failure category, run/session/tab IDs, URL/title metadata, omitted screenshot/network/console reasons, and last tool-call summaries.
- Wires best-effort capture into `RunStore.appendToolFinished`; write failures never mask the original tool event.
- Redacts sensitive metadata/messages in persisted evidence.
- Documents where artifacts are written and when to use `oc_evidence_bundle` for full live snapshots.

Closes #1023.

## Verification
- `npm test -- tests/run-harness/store.test.ts tests/run-harness/evidence.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`

## Notes
Screenshot capture is intentionally disabled in this safe-mode automatic writer. Full DOM/screenshot/network capture remains the job of explicit `oc_evidence_bundle` calls where privacy policy allows live page snapshots.
