### PR TITLE
feat(session): clarify profile recovery lifecycle (#1032)

### DIFF
--- a/docs/harness/session-profile-lifecycle.md
+++ b/docs/harness/session-profile-lifecycle.md
@@ -1,0 +1,51 @@
+# Long-running session/profile recovery lifecycle
+
+OpenChrome tracks three related identities during long-running runs:
+
+| Layer | What it represents | Survives server restart? | Survives browser/profile restart? |
+| --- | --- | --- | --- |
+| Session id | OpenChrome's in-memory grouping of workers and target ids. | Only when the browser targets are still reachable and `oc_session_resume` can remap them. | No; stale targets need a fresh tab/context. |
+| Profile identity | Chrome `userDataDir` plus optional `profileDirectory`. This owns cookies, localStorage, IndexedDB, and extensions depending on profile type. | Yes when the same profile is reused. | Persistent/real/explicit profiles can preserve storage; temporary profiles cannot be relied on. |
+| Storage-state | Optional OpenChrome storage-state persistence (`OC_PERSIST_STORAGE`, `OC_STORAGE_DIR`). | Yes when enabled and the same storage-state directory is reused. | Yes for persisted state; it does not resurrect closed CDP targets. |
+| Target id/tab id | CDP page target captured in `oc_session_snapshot`. | Maybe; exact target ids may be live, remapped by URL, or closed. | No; create a fresh tab for closed targets. |
+
+## Snapshot and resume contract
+
+`oc_session_snapshot` now stores lifecycle metadata with each snapshot:
+
+- `recoverySource`: always `oc_session_snapshot` for these artifacts.
+- `profile`: current profile type plus `userDataDir`, `profileDirectory`, and cookie-sync timestamp when available.
+- `storageState`: whether storage-state persistence was enabled and the configured directory.
+- per-tab metadata: `sessionId`, `workerId`, `targetId`, URL/title, optional `profileDirectory`, and session/worker last activity timestamps.
+
+`oc_session_resume` reads that metadata and separates what can be reused from what cannot:
+
+- `LIVE`: the original target id is still reachable; verify with `read_page` or `tabs_context` before mutating.
+- `REMAPPED`: the original target is gone, but another live target with the same URL was found; use the reported current target id.
+- `CLOSED`: the target is stale. Open a fresh tab/context with the same URL and profile/storage identity before continuing.
+
+## Recovery policy by restart type
+
+- **Context compaction only:** call `oc_session_resume`; live targets should remain reusable.
+- **OpenChrome server restart with Chrome still running:** call `oc_session_resume`; expect a mix of `LIVE`, `REMAPPED`, and `CLOSED` depending on CDP target reachability.
+- **Chrome/browser restart:** target ids are stale. Reuse the same `profileDirectory` and storage-state settings, then open fresh tabs for the saved URLs.
+- **Temporary profile:** do not assume authenticated cookies/localStorage survive process restart. Use a persistent, real, or explicit profile when auth reuse is required.
+
+## Auth/session reuse guidance
+
+For authenticated tasks, prefer one of these explicit identities:
+
+1. `profileDirectory` on `navigate`/`tabs_create` for a Chrome profile-backed worker.
+2. A persistent or explicit `userDataDir` at server startup.
+3. Enabled storage-state persistence with a stable `OC_STORAGE_DIR`.
+
+The resume guide intentionally does not embed cookies or storage payloads. It only records bounded identity metadata so an operator can restart with the same profile/storage settings.
+
+## Merge/live verification checklist
+
+1. Start OpenChrome with a stable profile or storage-state directory.
+2. Open a tab with `navigate` or `tabs_create`.
+3. Run `oc_session_snapshot` and inspect the saved JSON for `lifecycle.profile`, `lifecycle.storageState`, and per-tab session/profile ids.
+4. Restart the OpenChrome server while leaving Chrome running, then run `oc_session_resume`.
+5. Confirm the guide reports `LIVE`, `REMAPPED`, or `CLOSED` for each saved tab.
+6. For every `CLOSED` tab, verify the guide recommends a fresh tab/context and preserving profile/storage identity.

--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -1396,6 +1396,13 @@ export function getChromeLauncher(port?: number): ChromeLauncher {
   return launcherInstance;
 }
 
+
+export function getExistingChromeLauncher(port?: number): ChromeLauncher | null {
+  const resolvedPort = port || DEFAULT_PORT;
+  if (!launcherInstance || launcherInstance.getPort() !== resolvedPort) return null;
+  return launcherInstance;
+}
+
 /** Reset the launcher singleton — for testing and programmatic server lifecycle only. */
 export function _resetChromeLauncherForTesting(): void {
   launcherInstance = null;

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -820,6 +820,7 @@ export class SessionManager {
         targetCount: worker.targets.size,
         createdAt: worker.createdAt,
         lastActivityAt: worker.lastActivityAt,
+        ...(worker.profileDirectory && { profileDirectory: worker.profileDirectory }),
       });
     }
 

--- a/src/tools/session-resume.ts
+++ b/src/tools/session-resume.ts
@@ -21,6 +21,24 @@ interface SnapshotTab {
   sessionId: string;
   url: string;
   title: string;
+  lastActivityAt?: number;
+  workerLastActivityAt?: number;
+  profileDirectory?: string;
+}
+
+interface SessionLifecycleMetadata {
+  capturedAt: number;
+  recoverySource: 'oc_session_snapshot';
+  profile: {
+    type: string;
+    userDataDir?: string;
+    profileDirectory?: string;
+    cookieCopiedAt?: number;
+  };
+  storageState: {
+    enabled: boolean;
+    dir?: string;
+  };
 }
 
 interface SnapshotMemo {
@@ -38,6 +56,7 @@ interface SessionSnapshot {
   tabs: SnapshotTab[];
   memo: SnapshotMemo;
   label?: string;
+  lifecycle?: SessionLifecycleMetadata;
 }
 
 
@@ -262,6 +281,15 @@ export function generateResumeGuide(snapshot: SessionSnapshot, tabAnalysis: TabA
   lines.push(`Last step: ${snapshot.memo.currentStep}`);
   lines.push(`Snapshot age: ${ageStr}${snapshot.label ? ` (${snapshot.label})` : ''}`);
 
+  if (snapshot.lifecycle) {
+    const profile = snapshot.lifecycle.profile;
+    lines.push(`Recovery source: ${snapshot.lifecycle.recoverySource}`);
+    lines.push(`Profile/storage identity: profile=${profile.type}${profile.profileDirectory ? `/${profile.profileDirectory}` : ''}; storage-state=${snapshot.lifecycle.storageState.enabled ? 'enabled' : 'disabled'}`);
+    if (profile.cookieCopiedAt) {
+      lines.push(`Cookie sync age: ${formatRelativeAge(Date.now() - profile.cookieCopiedAt)}`);
+    }
+  }
+
   if (age > 24 * 3600000) {
     lines.push('WARNING: Snapshot is over 24 hours old. Tab states may be inaccurate.');
   }
@@ -282,13 +310,19 @@ export function generateResumeGuide(snapshot: SessionSnapshot, tabAnalysis: TabA
                           'CLOSED  ';
       const url = tab.saved.url;
       const title = tab.saved.title ? ` "${tab.saved.title}"` : '';
+      const workerContext = [
+        `session=${tab.saved.sessionId}`,
+        `worker=${tab.saved.workerId}`,
+        ...(tab.saved.profileDirectory ? [`profile=${tab.saved.profileDirectory}`] : []),
+        ...(tab.saved.workerLastActivityAt ? [`lastActivity=${formatRelativeAge(Date.now() - tab.saved.workerLastActivityAt)} ago`] : []),
+      ].join(', ');
 
       if (tab.status === 'REMAPPED') {
-        lines.push(`  [${statusLabel}] ${tab.saved.targetId} -> ${tab.currentTargetId} ${url}${title}`);
+        lines.push(`  [${statusLabel}] ${tab.saved.targetId} -> ${tab.currentTargetId} ${url}${title} (${workerContext})`);
       } else if (tab.status === 'CLOSED') {
-        lines.push(`  [${statusLabel}] ${url}${title}`);
+        lines.push(`  [${statusLabel}] ${url}${title} (${workerContext}; stale target — open a fresh tab/context before mutating)`);
       } else {
-        lines.push(`  [${statusLabel}] ${tab.currentTargetId} ${url}${title}`);
+        lines.push(`  [${statusLabel}] ${tab.currentTargetId} ${url}${title} (${workerContext})`);
       }
     }
   }
@@ -363,6 +397,16 @@ export function generateResumeGuide(snapshot: SessionSnapshot, tabAnalysis: TabA
   }
 
   lines.push('');
+  if (closed.length > 0) {
+    lines.push('Recovery guidance: CLOSED targets cannot be reused after restart/reconnect; create a fresh tab with the same URL and profileDirectory/storage-state identity before continuing.');
+  } else if (remapped.length > 0) {
+    lines.push('Recovery guidance: REMAPPED targets survived under a new target id; prefer the currentTargetId shown above.');
+  }
+  if (snapshot.lifecycle?.profile.type === 'temp') {
+    lines.push('Auth guidance: this snapshot used a temporary profile, so cookies/localStorage may not survive process restart. Use a persistent/real profile or storage-state for auth reuse.');
+  } else if (snapshot.lifecycle) {
+    lines.push('Auth guidance: reuse the same profileDirectory and storage-state setting when continuing authenticated work.');
+  }
   lines.push('Recommended next safe action: verify the live tab state with read_page or tabs_context before mutating the page.');
 
   return lines.join('\n');

--- a/src/tools/session-snapshot.ts
+++ b/src/tools/session-snapshot.ts
@@ -10,7 +10,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
-import { getChromeLauncher } from '../chrome/launcher';
+import { getExistingChromeLauncher } from '../chrome/launcher';
 import { getGlobalConfig } from '../config/global';
 import { writeFileAtomicSafe } from '../utils/atomic-file';
 import { safeTitle } from '../utils/safe-title';
@@ -184,7 +184,19 @@ export function collectLifecycleMetadata(): SessionLifecycleMetadata {
   let profile: SessionLifecycleMetadata['profile'] = { type: 'unknown' };
 
   try {
-    const state = getChromeLauncher(config.port).getProfileState();
+    const launcher = getExistingChromeLauncher(config.port);
+    if (!launcher) {
+      return {
+        capturedAt: Date.now(),
+        recoverySource: 'oc_session_snapshot',
+        profile,
+        storageState: {
+          enabled: process.env.OC_PERSIST_STORAGE !== '0',
+          ...(process.env.OC_STORAGE_DIR && { dir: process.env.OC_STORAGE_DIR }),
+        },
+      };
+    }
+    const state = launcher.getProfileState();
     profile = {
       type: state.type,
       ...(state.userDataDir && { userDataDir: state.userDataDir }),

--- a/src/tools/session-snapshot.ts
+++ b/src/tools/session-snapshot.ts
@@ -10,6 +10,8 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
+import { getChromeLauncher } from '../chrome/launcher';
+import { getGlobalConfig } from '../config/global';
 import { writeFileAtomicSafe } from '../utils/atomic-file';
 import { safeTitle } from '../utils/safe-title';
 
@@ -21,6 +23,27 @@ export interface SnapshotTab {
   sessionId: string;
   url: string;
   title: string;
+  /** Last observed activity for the owning OpenChrome session. */
+  lastActivityAt?: number;
+  /** Last observed activity for the owning worker/context. */
+  workerLastActivityAt?: number;
+  /** Chrome profile directory when this tab belongs to a profile-scoped worker. */
+  profileDirectory?: string;
+}
+
+export interface SessionLifecycleMetadata {
+  capturedAt: number;
+  recoverySource: 'oc_session_snapshot';
+  profile: {
+    type: string;
+    userDataDir?: string;
+    profileDirectory?: string;
+    cookieCopiedAt?: number;
+  };
+  storageState: {
+    enabled: boolean;
+    dir?: string;
+  };
 }
 
 export interface SnapshotMemo {
@@ -38,6 +61,8 @@ export interface SessionSnapshot {
   tabs: SnapshotTab[];
   memo: SnapshotMemo;
   label?: string;
+  /** Session/profile/storage-state identity captured for long-running recovery. */
+  lifecycle?: SessionLifecycleMetadata;
 }
 
 // ─── Tool Definition ───────────────────────────────────────────────────────
@@ -137,6 +162,11 @@ export async function collectTabs(): Promise<SnapshotTab[]> {
             sessionId,
             url,
             title,
+            lastActivityAt: sessionInfo.lastActivityAt,
+            workerLastActivityAt: workerInfo.lastActivityAt,
+            ...((workerInfo as { profileDirectory?: string }).profileDirectory && {
+              profileDirectory: (workerInfo as { profileDirectory?: string }).profileDirectory,
+            }),
           });
         }
       }
@@ -147,6 +177,33 @@ export async function collectTabs(): Promise<SnapshotTab[]> {
   }
 
   return tabs;
+}
+
+export function collectLifecycleMetadata(): SessionLifecycleMetadata {
+  const config = getGlobalConfig();
+  let profile: SessionLifecycleMetadata['profile'] = { type: 'unknown' };
+
+  try {
+    const state = getChromeLauncher(config.port).getProfileState();
+    profile = {
+      type: state.type,
+      ...(state.userDataDir && { userDataDir: state.userDataDir }),
+      ...(state.profileDirectory && { profileDirectory: state.profileDirectory }),
+      ...(state.cookieCopiedAt && { cookieCopiedAt: state.cookieCopiedAt }),
+    };
+  } catch {
+    // Profile state is best-effort: snapshots must still work before Chrome launches.
+  }
+
+  return {
+    capturedAt: Date.now(),
+    recoverySource: 'oc_session_snapshot',
+    profile,
+    storageState: {
+      enabled: process.env.OC_PERSIST_STORAGE !== '0',
+      ...(process.env.OC_STORAGE_DIR && { dir: process.env.OC_STORAGE_DIR }),
+    },
+  };
 }
 
 // ─── File Management ───────────────────────────────────────────────────────
@@ -226,6 +283,7 @@ const handler: ToolHandler = async (
     timestamp: Date.now(),
     tabs,
     memo,
+    lifecycle: collectLifecycleMetadata(),
     label: (args.label as string) || undefined,
   };
 

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -28,6 +28,8 @@ export interface WorkerInfo {
   targetCount: number;
   createdAt: number;
   lastActivityAt: number;
+  /** Chrome profile directory when the worker is backed by a profile-scoped browser. */
+  profileDirectory?: string;
 }
 
 export interface WorkerCreateOptions {

--- a/tests/tools/session-resume.test.ts
+++ b/tests/tools/session-resume.test.ts
@@ -32,6 +32,7 @@ function makeSnapshot(overrides: Partial<{
   memo: unknown;
   label: string;
   version: number;
+  lifecycle: unknown;
 }> = {}) {
   return {
     version: 1,
@@ -56,6 +57,8 @@ function makeTab(overrides: Partial<{
   sessionId: string;
   url: string;
   title: string;
+  workerLastActivityAt: number;
+  profileDirectory: string;
 }> = {}) {
   return {
     targetId: 'target-aaa',
@@ -358,6 +361,63 @@ describe('generateResumeGuide', () => {
 
     expect(guide).toContain('CLOSED');
     expect(guide).toContain('https://closed.example.com');
+    expect(guide).toContain('stale target');
+    expect(guide).toContain('Recovery guidance: CLOSED targets cannot be reused');
+  });
+
+  test('includes lifecycle profile/storage identity and auth guidance', () => {
+    const snap = makeSnapshot({
+      lifecycle: {
+        capturedAt: Date.now() - 1000,
+        recoverySource: 'oc_session_snapshot',
+        profile: {
+          type: 'persistent',
+          profileDirectory: 'Profile 1',
+          cookieCopiedAt: Date.now() - 60_000,
+        },
+        storageState: {
+          enabled: true,
+          dir: '/tmp/openchrome-storage-state',
+        },
+      },
+    });
+    const tabAnalysis = [
+      {
+        saved: makeTab({
+          profileDirectory: 'Profile 1',
+          workerLastActivityAt: Date.now() - 2000,
+        }),
+        status: 'LIVE' as const,
+        currentTargetId: 'target-aaa',
+        currentUrl: 'https://example.com/form',
+      },
+    ];
+
+    const guide = generateResumeGuide(snap as any, tabAnalysis);
+
+    expect(guide).toContain('Recovery source: oc_session_snapshot');
+    expect(guide).toContain('Profile/storage identity: profile=persistent/Profile 1; storage-state=enabled');
+    expect(guide).toContain('Cookie sync age:');
+    expect(guide).toContain('profile=Profile 1');
+    expect(guide).toContain('lastActivity=');
+    expect(guide).toContain('Auth guidance: reuse the same profileDirectory and storage-state setting');
+  });
+
+  test('warns when auth recovery used a temporary profile', () => {
+    const snap = makeSnapshot({
+      lifecycle: {
+        capturedAt: Date.now(),
+        recoverySource: 'oc_session_snapshot',
+        profile: { type: 'temp' },
+        storageState: { enabled: false },
+      },
+    });
+
+    const guide = generateResumeGuide(snap as any, []);
+
+    expect(guide).toContain('profile=temp; storage-state=disabled');
+    expect(guide).toContain('temporary profile');
+    expect(guide).toContain('may not survive process restart');
   });
 
   test('includes completed steps', () => {

--- a/tests/tools/session-snapshot.test.ts
+++ b/tests/tools/session-snapshot.test.ts
@@ -33,7 +33,8 @@ function makeMockPage(url: string, title: string) {
 
 function makeMockSessionManager(sessions: Array<{
   id: string;
-  workers: Array<{ id: string; targetIds: string[] }>;
+  workers: Array<{ id: string; targetIds: string[]; profileDirectory?: string; lastActivityAt?: number }>;
+  lastActivityAt?: number;
   pages?: Record<string, { url: string; title: string }>;
 }>) {
   const sessionInfos = sessions.map(s => ({
@@ -42,13 +43,14 @@ function makeMockSessionManager(sessions: Array<{
     workerCount: s.workers.length,
     targetCount: s.workers.reduce((sum, w) => sum + w.targetIds.length, 0),
     createdAt: Date.now(),
-    lastActivityAt: Date.now(),
+    lastActivityAt: s.lastActivityAt ?? Date.now(),
     workers: s.workers.map(w => ({
       id: w.id,
       name: `Worker ${w.id}`,
       targetCount: w.targetIds.length,
       createdAt: Date.now(),
-      lastActivityAt: Date.now(),
+      lastActivityAt: w.lastActivityAt ?? Date.now(),
+      ...(w.profileDirectory && { profileDirectory: w.profileDirectory }),
     })),
   }));
 
@@ -136,10 +138,13 @@ describe('oc_session_snapshot', () => {
     });
 
     test('returns tabs for a single session with one worker', async () => {
+      const sessionActivity = Date.now() - 5000;
+      const workerActivity = Date.now() - 3000;
       const mockSM = makeMockSessionManager([
         {
           id: 'session-1',
-          workers: [{ id: 'default', targetIds: ['target-1', 'target-2'] }],
+          lastActivityAt: sessionActivity,
+          workers: [{ id: 'default', targetIds: ['target-1', 'target-2'], profileDirectory: 'Profile 1', lastActivityAt: workerActivity }],
           pages: {
             'target-1': { url: 'https://example.com', title: 'Example' },
             'target-2': { url: 'https://google.com', title: 'Google' },
@@ -158,6 +163,9 @@ describe('oc_session_snapshot', () => {
         sessionId: 'session-1',
         url: 'https://example.com',
         title: 'Example',
+        lastActivityAt: sessionActivity,
+        workerLastActivityAt: workerActivity,
+        profileDirectory: 'Profile 1',
       });
       expect(tabs[1]).toMatchObject({
         targetId: 'target-2',
@@ -166,6 +174,29 @@ describe('oc_session_snapshot', () => {
         url: 'https://google.com',
         title: 'Google',
       });
+    });
+
+    test('captures profile and storage-state lifecycle metadata', async () => {
+      const originalPersist = process.env.OC_PERSIST_STORAGE;
+      const originalStorageDir = process.env.OC_STORAGE_DIR;
+      process.env.OC_PERSIST_STORAGE = '1';
+      process.env.OC_STORAGE_DIR = '/tmp/openchrome-storage-state';
+
+      const { collectLifecycleMetadata } = await import('../../src/tools/session-snapshot');
+      const lifecycle = collectLifecycleMetadata();
+
+      expect(lifecycle.recoverySource).toBe('oc_session_snapshot');
+      expect(lifecycle.capturedAt).toEqual(expect.any(Number));
+      expect(lifecycle.profile.type).toEqual(expect.any(String));
+      expect(lifecycle.storageState).toMatchObject({
+        enabled: true,
+        dir: '/tmp/openchrome-storage-state',
+      });
+
+      if (originalPersist === undefined) delete process.env.OC_PERSIST_STORAGE;
+      else process.env.OC_PERSIST_STORAGE = originalPersist;
+      if (originalStorageDir === undefined) delete process.env.OC_STORAGE_DIR;
+      else process.env.OC_STORAGE_DIR = originalStorageDir;
     });
 
     test('returns tabs for multiple sessions and workers', async () => {

--- a/tests/tools/session-snapshot.test.ts
+++ b/tests/tools/session-snapshot.test.ts
@@ -187,7 +187,7 @@ describe('oc_session_snapshot', () => {
 
       expect(lifecycle.recoverySource).toBe('oc_session_snapshot');
       expect(lifecycle.capturedAt).toEqual(expect.any(Number));
-      expect(lifecycle.profile.type).toEqual(expect.any(String));
+      expect(lifecycle.profile.type).toBe('unknown');
       expect(lifecycle.storageState).toMatchObject({
         enabled: true,
         dir: '/tmp/openchrome-storage-state',


### PR DESCRIPTION
## Summary
- Fixes #1032 by documenting session/profile/storage-state lifecycle boundaries for long-running recovery.
- Adds bounded lifecycle metadata to `oc_session_snapshot`: recovery source, profile identity, storage-state identity, per-tab session/worker/profile ids, and last activity timestamps.
- Updates `oc_session_resume` guidance so restart/reconnect output distinguishes `LIVE`, `REMAPPED`, and stale `CLOSED` targets and explains when to reuse profile/storage identity versus opening a fresh tab/context.

## Verification
- `npm test -- tests/tools/session-snapshot.test.ts tests/tools/session-resume.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run test:e2e -- tests/e2e/scenarios/compaction-resume.e2e.ts --runInBand`

## Live restart evidence
Targeted e2e restarted the MCP server with Chrome still running and confirmed `oc_session_resume` returned lifecycle metadata and stale-target guidance:

```text
Recovery source: oc_session_snapshot
Profile/storage identity: profile=persistent; storage-state=enabled
Tabs: 0 LIVE, 0 REMAPPED, 2 CLOSED
[CLOSED] ... stale target — open a fresh tab/context before mutating
```

## Notes
- No cookies, localStorage, or credential payloads are persisted in snapshots.
- Real third-party account auth reuse was not manually tested; the PR validates the local restart/resume recovery contract with the checked-in fixture e2e.
