### PR TITLE
test(harness): add deterministic episode runner (#1058)

### DIFF
--- a/docs/benchmarks/episode-harness.md
+++ b/docs/benchmarks/episode-harness.md
@@ -1,0 +1,54 @@
+# Episode harness benchmark
+
+The episode harness is a test/tooling layer for repeatable browser-task evaluation. It is intentionally outside production `src/**` behavior: no server-side LLM calls, no credentials, no autonomous runtime loop.
+
+Each episode follows this shape:
+
+1. normalize a task spec and hard caps,
+2. reset browser state,
+3. navigate to the task `startUrl`,
+4. ask an adapter for deterministic tool calls,
+5. evaluate the task's Outcome Contract assertion,
+6. write JSONL events plus JSON/Markdown reports.
+
+## Task authoring
+
+Task specs use the existing Outcome Contract assertion vocabulary from `src/contracts/types.ts`:
+
+```ts
+{
+  id: 'example-h1',
+  title: 'Example H1 fixture',
+  startUrl: 'mock://example',
+  goal: 'Verify the heading.',
+  maxSteps: 5,
+  maxDurationMs: 30000,
+  success: { kind: 'dom_text', selector: 'h1', contains: 'Example Domain' }
+}
+```
+
+Caps are mandatory after defaults are applied: `maxSteps` defaults to 30 and is capped at 100; `maxDurationMs` defaults to 120 seconds and is capped at 600 seconds.
+
+Public tasks must avoid login, payment, CAPTCHA, live prices, news/current dates, and user-specific state.
+
+## Adapter boundary
+
+`--adapter mock` is the default CI adapter and never calls an LLM provider. Real LLM adapters must remain opt-in and credential-gated. Adapters return one tool call at a time or `done`; the runner owns stop conditions and contract evaluation.
+
+## Commands
+
+```bash
+npm run bench:episode:mock
+npm run bench:episode -- --adapter mock --task example-h1 --out /tmp/openchrome-episode-harness
+npm run bench:episode:mock -- --task local-recovery-stall --max-steps 2 --out /tmp/openchrome-stall
+```
+
+Outputs are written under the selected output directory:
+
+- `report.json` / `report.md` aggregate suite reports,
+- `events/<run-id>.jsonl` per-step event streams,
+- `reports/<run-id>.json` / `.md` per-episode reports.
+
+## Relation to WebVoyager benchmark work
+
+Issue #851 owns WebVoyager-style tasks and real/mock LLM adapters. This harness owns the reusable episode substrate: `EpisodeTaskSpec`, `EpisodeResult`, reporter, stop conditions, and mock-adapter contract. WebVoyager and future benchmark suites should reuse these shapes rather than adding duplicate runners.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "prepare": "npm run build",
     "lint:changed": "node scripts/lint-changed-src.js",
     "harness:parallel-smoke": "ts-node tests/harness/parallel-smoke.ts",
-    "harness:evaluate-candidates": "ts-node tests/harness/candidates/evaluator.ts"
+    "harness:evaluate-candidates": "ts-node tests/harness/candidates/evaluator.ts",
+    "bench:episode": "ts-node tests/benchmark/episode-harness/cli.ts",
+    "bench:episode:mock": "ts-node tests/benchmark/episode-harness/cli.ts --adapter mock"
   },
   "keywords": [
     "openchrome",

--- a/tests/benchmark/episode-harness/cli.ts
+++ b/tests/benchmark/episode-harness/cli.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env ts-node
+import * as fs from 'fs';
+import * as path from 'path';
+import { fixtureTasks } from './fixtures/tasks';
+import { MockEpisodeAdapter } from './mock-adapter';
+import { MockOpenChromeClient } from './mock-client';
+import { normalizeTaskSpec } from './spec';
+import { runEpisode } from './runner';
+import type { EpisodeResult, EpisodeTaskSpec } from './types';
+
+interface CliArgs {
+  out: string;
+  task?: string;
+  tasks?: string;
+  adapter: string;
+  maxSteps?: number;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.adapter !== 'mock') throw new Error('Only --adapter mock is available without credentials');
+  const taskInputs = loadTasks(args);
+  const results: EpisodeResult[] = [];
+  for (const input of taskInputs) {
+    const withOverrides = args.maxSteps ? { ...input, maxSteps: args.maxSteps } : input;
+    const task = normalizeTaskSpec(withOverrides);
+    const { result } = await runEpisode(task, new MockEpisodeAdapter(), new MockOpenChromeClient(), {
+      outDir: args.out,
+    });
+    results.push(result);
+  }
+  const aggregate = {
+    runId: `episode-suite-${Date.now().toString(36)}`,
+    adapter: args.adapter,
+    total: results.length,
+    passed: results.filter(r => r.status === 'passed').length,
+    failed: results.filter(r => r.status !== 'passed').length,
+    results,
+  };
+  fs.mkdirSync(args.out, { recursive: true });
+  fs.writeFileSync(path.join(args.out, 'report.json'), JSON.stringify(aggregate, null, 2) + '\n');
+  fs.writeFileSync(path.join(args.out, 'report.md'), renderSuiteMarkdown(aggregate));
+  console.log(`Episode harness complete: ${aggregate.passed}/${aggregate.total} passed`);
+  console.log(`Report: ${path.join(args.out, 'report.json')}`);
+  const hardFailures = results.filter(r => ['adapter_error', 'tool_error', 'timeout'].includes(r.status));
+  if (hardFailures.length > 0) process.exitCode = 1;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    out: path.join(process.cwd(), 'tests', 'benchmark', 'episode-harness'),
+    adapter: 'mock',
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--out') args.out = path.resolve(argv[++i]);
+    else if (arg === '--task') args.task = argv[++i];
+    else if (arg === '--tasks') args.tasks = argv[++i];
+    else if (arg === '--adapter') args.adapter = argv[++i];
+    else if (arg === '--max-steps') args.maxSteps = Number(argv[++i]);
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+function loadTasks(args: CliArgs): EpisodeTaskSpec[] {
+  let tasks = fixtureTasks;
+  if (args.tasks) {
+    const stat = fs.statSync(args.tasks);
+    if (stat.isFile()) tasks = JSON.parse(fs.readFileSync(args.tasks, 'utf-8')) as EpisodeTaskSpec[];
+  }
+  return args.task ? tasks.filter(task => task.id === args.task) : tasks;
+}
+
+function renderSuiteMarkdown(aggregate: { adapter: string; total: number; passed: number; failed: number; results: EpisodeResult[] }): string {
+  const lines = [
+    '# Episode harness report',
+    '',
+    `- Adapter: ${aggregate.adapter}`,
+    `- Passed: ${aggregate.passed}/${aggregate.total}`,
+    `- Failed: ${aggregate.failed}`,
+    '',
+    '| Task | Status | Steps | Tool calls | No-progress | Final URL |',
+    '| --- | --- | ---: | ---: | ---: | --- |',
+  ];
+  for (const result of aggregate.results) {
+    lines.push(`| ${result.taskId} | ${result.status} | ${result.steps} | ${result.toolCalls} | ${result.noProgressEpisodes} | ${result.finalUrl} |`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+main().catch(err => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exitCode = 1;
+});

--- a/tests/benchmark/episode-harness/fixtures/tasks.ts
+++ b/tests/benchmark/episode-harness/fixtures/tasks.ts
@@ -1,0 +1,35 @@
+import type { EpisodeTaskSpec } from '../types';
+
+export const fixtureTasks: EpisodeTaskSpec[] = [
+  {
+    id: 'example-h1',
+    title: 'Example H1 fixture',
+    startUrl: 'mock://example',
+    goal: 'Verify the page contains the Example Domain heading.',
+    maxSteps: 5,
+    maxDurationMs: 30_000,
+    success: { kind: 'dom_text', selector: 'h1', contains: 'Example Domain' },
+    tags: ['fixture', 'read-only'],
+  },
+  {
+    id: 'local-form-submit',
+    title: 'Local form submit fixture',
+    startUrl: 'mock://form',
+    goal: 'Fill and submit the local fixture form.',
+    maxSteps: 8,
+    maxDurationMs: 30_000,
+    success: { kind: 'dom_text', selector: '.success', contains: 'Form submitted successfully' },
+    setup: { clearCookies: true, viewport: { width: 1280, height: 800 } },
+    tags: ['fixture', 'form'],
+  },
+  {
+    id: 'local-recovery-stall',
+    title: 'Local recovery stall fixture',
+    startUrl: 'mock://stall',
+    goal: 'Intentionally repeat page reads to exercise max-step and no-progress metrics.',
+    maxSteps: 3,
+    maxDurationMs: 30_000,
+    success: { kind: 'dom_text', selector: '.success', contains: 'Recovered' },
+    tags: ['fixture', 'stall'],
+  },
+];

--- a/tests/benchmark/episode-harness/index.ts
+++ b/tests/benchmark/episode-harness/index.ts
@@ -1,0 +1,6 @@
+export * from './types';
+export * from './spec';
+export * from './runner';
+export * from './reporter';
+export * from './mock-adapter';
+export * from './mock-client';

--- a/tests/benchmark/episode-harness/mock-adapter.ts
+++ b/tests/benchmark/episode-harness/mock-adapter.ts
@@ -1,0 +1,28 @@
+import type { EpisodeAdapter, EpisodeAdapterInput, EpisodeToolCall } from './types';
+
+const TASK_PLANS: Record<string, EpisodeToolCall[]> = {
+  'example-h1': [
+    { tool: 'read_page', args: {} },
+  ],
+  'local-form-submit': [
+    { tool: 'read_page', args: {} },
+    { tool: 'form_input', args: { selector: '#name', value: 'OpenChrome' } },
+    { tool: 'form_input', args: { selector: '#email', value: 'test@example.invalid' } },
+    { tool: 'click', args: { selector: 'button[type=submit]' } },
+  ],
+  'local-recovery-stall': [
+    { tool: 'read_page', args: {} },
+    { tool: 'read_page', args: {} },
+    { tool: 'read_page', args: {} },
+    { tool: 'read_page', args: {} },
+  ],
+};
+
+export class MockEpisodeAdapter implements EpisodeAdapter {
+  name = 'mock';
+
+  async next(input: EpisodeAdapterInput): Promise<EpisodeToolCall | { done: true }> {
+    const plan = TASK_PLANS[input.task.id] ?? [];
+    return plan[input.step] ?? { done: true };
+  }
+}

--- a/tests/benchmark/episode-harness/mock-client.ts
+++ b/tests/benchmark/episode-harness/mock-client.ts
@@ -1,0 +1,137 @@
+import type { Assertion, EvaluationResult, Evidence } from '../../../src/contracts/types';
+import type { EpisodeClient, EpisodeToolCall, EpisodeToolResult, NormalizedEpisodeTaskSpec } from './types';
+
+interface PageState {
+  url: string;
+  title: string;
+  text: string;
+  counts: Record<string, number>;
+  formSubmitted?: boolean;
+}
+
+const PAGES: Record<string, PageState> = {
+  'mock://example': {
+    url: 'mock://example',
+    title: 'Example Domain',
+    text: 'Example Domain This domain is for use in illustrative examples.',
+    counts: { h1: 1, form: 0, '.success': 0 },
+  },
+  'mock://form': {
+    url: 'mock://form',
+    title: 'Local form',
+    text: 'Name Email Submit',
+    counts: { h1: 1, form: 1, '.success': 0 },
+  },
+  'mock://stall': {
+    url: 'mock://stall',
+    title: 'Recovery stall',
+    text: 'Keep trying will not change this page.',
+    counts: { h1: 1, '.success': 0 },
+  },
+};
+
+export class MockOpenChromeClient implements EpisodeClient {
+  private page: PageState = { ...PAGES['mock://example'] };
+  private fields = new Map<string, string>();
+
+  async reset(task: NormalizedEpisodeTaskSpec): Promise<void> {
+    this.fields.clear();
+    this.page = clonePage(PAGES[task.startUrl] ?? {
+      url: task.startUrl,
+      title: task.title,
+      text: '',
+      counts: {},
+    });
+  }
+
+  async callTool(call: EpisodeToolCall): Promise<EpisodeToolResult> {
+    switch (call.tool) {
+      case 'navigate': {
+        const url = String(call.args.url ?? '');
+        this.page = clonePage(PAGES[url] ?? { url, title: url, text: '', counts: {} });
+        return { ok: true, text: `navigated ${url}`, data: { url } };
+      }
+      case 'read_page':
+      case 'tabs_context':
+        return { ok: true, text: `${this.page.title}\n${this.page.text}`, data: { url: this.page.url, title: this.page.title } };
+      case 'form_input': {
+        const selector = String(call.args.selector ?? call.args.ref ?? 'field');
+        const value = String(call.args.value ?? '');
+        this.fields.set(selector, value);
+        return { ok: true, text: `filled ${selector}` };
+      }
+      case 'interact':
+      case 'click': {
+        const target = String(call.args.selector ?? call.args.ref ?? call.args.text ?? '');
+        if (this.page.url === 'mock://form' && /submit/i.test(target)) {
+          this.page.formSubmitted = true;
+          this.page.text = 'Form submitted successfully';
+          this.page.counts['.success'] = 1;
+          return { ok: true, text: 'submitted form' };
+        }
+        return { ok: false, error: `No actionable element matched ${target}` };
+      }
+      case 'oc_progress_status':
+        return { ok: true, text: 'unknown', data: { status: 'unknown' } };
+      default:
+        return { ok: false, error: `Unsupported mock tool: ${call.tool}` };
+    }
+  }
+
+  async evaluate(assertion: Assertion): Promise<EvaluationResult> {
+    return evaluateAssertion(assertion, this.page);
+  }
+
+  async currentUrl(): Promise<string> {
+    return this.page.url;
+  }
+}
+
+function clonePage(page: PageState): PageState {
+  return { ...page, counts: { ...page.counts } };
+}
+
+function evaluateAssertion(assertion: Assertion, page: PageState): EvaluationResult {
+  switch (assertion.kind) {
+    case 'url': {
+      const passed = new RegExp(assertion.pattern).test(page.url);
+      return result(passed, 'url', { observed: page.url, pattern: assertion.pattern });
+    }
+    case 'dom_text': {
+      const passed = page.text.includes(assertion.contains);
+      return result(passed, 'dom_text', { selector: assertion.selector ?? 'body', observed: page.text.slice(0, 200), contains: assertion.contains });
+    }
+    case 'dom_count': {
+      const observed = page.counts[assertion.selector] ?? 0;
+      const passed = assertion.op === 'eq' ? observed === assertion.value : assertion.op === 'gte' ? observed >= assertion.value : observed <= assertion.value;
+      return result(passed, 'dom_count', { selector: assertion.selector, observed, op: assertion.op, expected: assertion.value });
+    }
+    case 'and': {
+      const children = assertion.children.map(child => evaluateAssertion(child, page));
+      const passed = children.every(child => child.passed);
+      return result(passed, 'and', { children });
+    }
+    case 'or': {
+      const children = assertion.children.map(child => evaluateAssertion(child, page));
+      const passed = children.some(child => child.passed);
+      return result(passed, 'or', { children });
+    }
+    case 'not': {
+      const child = evaluateAssertion(assertion.child, page);
+      return result(!child.passed, 'not', { child });
+    }
+    default:
+      return result(false, assertion.kind, { error: `unsupported mock assertion ${assertion.kind}` });
+  }
+}
+
+function result(passed: boolean, assertionKind: Evidence['assertion_kind'], details: Record<string, unknown>): EvaluationResult {
+  return {
+    passed,
+    evidence: {
+      passed,
+      assertion_kind: assertionKind,
+      details,
+    },
+  };
+}

--- a/tests/benchmark/episode-harness/reporter.ts
+++ b/tests/benchmark/episode-harness/reporter.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { EpisodeEvent, EpisodeResult } from './types';
+
+export interface EpisodeReportPaths {
+  eventsJsonl: string;
+  reportJson: string;
+  reportMarkdown: string;
+}
+
+export function ensureReportDirs(outDir: string): { eventsDir: string; reportsDir: string } {
+  const eventsDir = path.join(outDir, 'events');
+  const reportsDir = path.join(outDir, 'reports');
+  fs.mkdirSync(eventsDir, { recursive: true });
+  fs.mkdirSync(reportsDir, { recursive: true });
+  return { eventsDir, reportsDir };
+}
+
+export function writeEpisodeArtifacts(outDir: string, runId: string, events: EpisodeEvent[], result: EpisodeResult): EpisodeReportPaths {
+  const { eventsDir, reportsDir } = ensureReportDirs(outDir);
+  const eventsJsonl = path.join(eventsDir, `${runId}.jsonl`);
+  const reportJson = path.join(reportsDir, `${runId}.json`);
+  const reportMarkdown = path.join(reportsDir, `${runId}.md`);
+  fs.writeFileSync(eventsJsonl, events.map(event => JSON.stringify(event)).join('\n') + '\n');
+  fs.writeFileSync(reportJson, JSON.stringify(result, null, 2) + '\n');
+  fs.writeFileSync(reportMarkdown, renderMarkdown(result));
+  fs.writeFileSync(path.join(reportsDir, 'latest.json'), JSON.stringify(result, null, 2) + '\n');
+  fs.writeFileSync(path.join(reportsDir, 'latest.md'), renderMarkdown(result));
+  return { eventsJsonl, reportJson, reportMarkdown };
+}
+
+export function renderMarkdown(result: EpisodeResult): string {
+  return [
+    `# Episode ${result.taskId}`,
+    '',
+    `- Status: ${result.status}`,
+    `- Success: ${result.success}`,
+    `- Steps: ${result.steps}`,
+    `- Tool calls: ${result.toolCalls}`,
+    `- OpenChrome errors: ${result.openchromeErrors}`,
+    `- No-progress episodes: ${result.noProgressEpisodes}`,
+    `- Duration: ${result.durationMs} ms`,
+    `- Final URL: ${result.finalUrl}`,
+    `- Events: ${result.artifacts.eventsJsonl}`,
+    '',
+    result.failedContract ? '## Failed contract\n\n```json\n' + JSON.stringify(result.failedContract, null, 2) + '\n```\n' : '',
+  ].join('\n');
+}

--- a/tests/benchmark/episode-harness/runner.test.ts
+++ b/tests/benchmark/episode-harness/runner.test.ts
@@ -1,0 +1,96 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { MockEpisodeAdapter } from './mock-adapter';
+import { MockOpenChromeClient } from './mock-client';
+import { fixtureTasks } from './fixtures/tasks';
+import { normalizeTaskSpec } from './spec';
+import { countNoProgressEpisodes, runEpisode } from './runner';
+
+function tmpdir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'episode-harness-'));
+}
+
+describe('episode harness spec validation', () => {
+  it('applies bounded defaults', () => {
+    const task = normalizeTaskSpec({
+      id: 'minimal',
+      title: 'Minimal',
+      startUrl: 'mock://example',
+      goal: 'Read example',
+      success: { kind: 'dom_text', contains: 'Example Domain' },
+    });
+    expect(task.maxSteps).toBe(30);
+    expect(task.maxDurationMs).toBe(120_000);
+  });
+
+  it('rejects unknown task fields', () => {
+    expect(() => normalizeTaskSpec({
+      id: 'bad',
+      title: 'Bad',
+      startUrl: 'mock://example',
+      goal: 'Nope',
+      success: { kind: 'dom_text', contains: 'Example Domain' },
+      llmProvider: 'forbidden',
+    })).toThrow(/unknown field/);
+  });
+
+  it('rejects unsupported assertion shapes', () => {
+    expect(() => normalizeTaskSpec({
+      id: 'bad-assert',
+      title: 'Bad assertion',
+      startUrl: 'mock://example',
+      goal: 'Nope',
+      success: { kind: 'made_up', value: true },
+    })).toThrow(/unsupported assertion/);
+  });
+
+  it('rejects non-positive budgets', () => {
+    expect(() => normalizeTaskSpec({
+      ...fixtureTasks[0],
+      maxSteps: 0,
+    })).toThrow(/maxSteps/);
+  });
+});
+
+describe('runEpisode', () => {
+  it('passes deterministic read-only fixture and writes artifacts', async () => {
+    const outDir = tmpdir();
+    const { result, events } = await runEpisode(fixtureTasks[0], new MockEpisodeAdapter(), new MockOpenChromeClient(), { outDir, runId: 'read-fixture' });
+
+    expect(result.status).toBe('passed');
+    expect(result.success).toBe(true);
+    expect(result.toolCalls).toBeGreaterThanOrEqual(1);
+    expect(result.openchromeErrors).toBe(0);
+    expect(events.some(event => event.type === 'contract_eval')).toBe(true);
+    expect(fs.existsSync(result.artifacts.eventsJsonl)).toBe(true);
+    expect(fs.existsSync(result.artifacts.reportJson)).toBe(true);
+  });
+
+  it('runs form fixture through deterministic mock tool calls', async () => {
+    const { result } = await runEpisode(fixtureTasks[1], new MockEpisodeAdapter(), new MockOpenChromeClient(), { outDir: tmpdir(), runId: 'form-fixture' });
+
+    expect(result.status).toBe('passed');
+    expect(result.steps).toBe(4);
+    expect(result.finalUrl).toBe('mock://form');
+  });
+
+  it('reports max_steps and failed contract evidence for stalled fixture', async () => {
+    const { result } = await runEpisode({ ...fixtureTasks[2], maxSteps: 3 }, new MockEpisodeAdapter(), new MockOpenChromeClient(), { outDir: tmpdir(), runId: 'stall-fixture' });
+
+    expect(result.status).toBe('max_steps');
+    expect(result.success).toBe(false);
+    expect(result.steps).toBe(3);
+    expect(result.noProgressEpisodes).toBeGreaterThanOrEqual(1);
+    expect(result.failedContract).toEqual(expect.objectContaining({ assertion_kind: 'dom_text' }));
+  });
+
+  it('counts repeated successful calls as one no-progress episode', () => {
+    expect(countNoProgressEpisodes([
+      { ts: 1, type: 'tool_result', tool: 'read_page', ok: true, text: 'same' },
+      { ts: 2, type: 'tool_result', tool: 'read_page', ok: true, text: 'same' },
+      { ts: 3, type: 'tool_result', tool: 'read_page', ok: true, text: 'same' },
+      { ts: 4, type: 'tool_result', tool: 'read_page', ok: true, text: 'same' },
+    ])).toBe(1);
+  });
+});

--- a/tests/benchmark/episode-harness/runner.ts
+++ b/tests/benchmark/episode-harness/runner.ts
@@ -1,0 +1,158 @@
+import * as path from 'path';
+import type { EpisodeAdapter, EpisodeClient, EpisodeEvent, EpisodeResult, EpisodeStatus, EpisodeToolCall, EpisodeToolResult, NormalizedEpisodeTaskSpec } from './types';
+import { normalizeTaskSpec } from './spec';
+import { writeEpisodeArtifacts } from './reporter';
+
+export interface RunEpisodeOptions {
+  runId?: string;
+  outDir?: string;
+  now?: () => number;
+}
+
+export async function runEpisode(taskInput: unknown, adapter: EpisodeAdapter, client: EpisodeClient, options: RunEpisodeOptions = {}): Promise<{ result: EpisodeResult; events: EpisodeEvent[] }> {
+  const task = normalizeTaskSpec(taskInput);
+  const now = options.now ?? Date.now;
+  const runId = options.runId ?? makeRunId(task.id, now());
+  const outDir = options.outDir ?? path.join(process.cwd(), 'tests', 'benchmark', 'episode-harness');
+  const events: EpisodeEvent[] = [];
+  const startedAt = now();
+  let steps = 0;
+  let toolCalls = 0;
+  let openchromeErrors = 0;
+  let status: EpisodeStatus = 'failed';
+  let success = false;
+  let failedContract: unknown;
+  let finalUrl = '';
+  let lastResult: EpisodeToolResult | undefined;
+  let lastToolCall: EpisodeToolCall | undefined;
+
+  await client.reset(task);
+  events.push({ ts: now(), type: 'reset', url: task.startUrl });
+  const nav = await client.callTool({ tool: 'navigate', args: { url: task.startUrl } });
+  toolCalls++;
+  events.push({ ts: now(), type: 'tool_call', step: 0, tool: 'navigate', args: { url: task.startUrl } });
+  events.push({ ts: now(), type: 'tool_result', step: 0, tool: 'navigate', ok: nav.ok, text: nav.text, error: nav.error });
+  if (!nav.ok) openchromeErrors++;
+
+  while (true) {
+    const elapsed = now() - startedAt;
+    if (elapsed >= task.maxDurationMs) {
+      status = 'timeout';
+      break;
+    }
+    const evalResult = await client.evaluate(task.success);
+    events.push({ ts: now(), type: 'contract_eval', step: steps, evaluation: evalResult });
+    if (evalResult.passed) {
+      status = 'passed';
+      success = true;
+      break;
+    }
+    failedContract = evalResult.evidence;
+    if (steps >= task.maxSteps) {
+      status = 'max_steps';
+      break;
+    }
+
+    let next: EpisodeToolCall | { done: true };
+    try {
+      next = await adapter.next({ task, step: steps, lastResult, events });
+    } catch (err) {
+      status = 'adapter_error';
+      failedContract = { adapter: adapter.name, error: err instanceof Error ? err.message : String(err) };
+      break;
+    }
+    if ('done' in next) {
+      status = 'failed';
+      break;
+    }
+
+    steps++;
+    toolCalls++;
+    lastToolCall = next;
+    events.push({ ts: now(), type: 'tool_call', step: steps, tool: next.tool, args: next.args });
+    lastResult = await client.callTool(next);
+    events.push({ ts: now(), type: 'tool_result', step: steps, tool: next.tool, ok: lastResult.ok, text: lastResult.text, error: lastResult.error });
+    if (!lastResult.ok) {
+      openchromeErrors++;
+      status = 'tool_error';
+      failedContract = { tool: next.tool, error: lastResult.error };
+      break;
+    }
+  }
+
+  finalUrl = await client.currentUrl();
+  events.push({ ts: now(), type: 'stop', status, url: finalUrl, ...(lastToolCall && { tool: lastToolCall.tool }) });
+
+  const durationMs = now() - startedAt;
+  const placeholderArtifacts = {
+    eventsJsonl: path.join(outDir, 'events', `${runId}.jsonl`),
+    reportJson: path.join(outDir, 'reports', `${runId}.json`),
+  };
+  const result: EpisodeResult = {
+    runId,
+    taskId: task.id,
+    status,
+    success,
+    steps,
+    durationMs,
+    toolCalls,
+    openchromeErrors,
+    noProgressEpisodes: countNoProgressEpisodes(events),
+    finalUrl,
+    ...(success ? {} : { failedContract }),
+    artifacts: placeholderArtifacts,
+  };
+  const paths = writeEpisodeArtifacts(outDir, runId, events, result);
+  result.artifacts.eventsJsonl = paths.eventsJsonl;
+  result.artifacts.reportJson = paths.reportJson;
+  writeEpisodeArtifacts(outDir, runId, events, result);
+  return { result, events };
+}
+
+export async function runEpisodes(tasks: NormalizedEpisodeTaskSpec[] | unknown[], adapter: EpisodeAdapter, makeClient: () => EpisodeClient, options: RunEpisodeOptions = {}): Promise<EpisodeResult[]> {
+  const results: EpisodeResult[] = [];
+  for (const task of tasks) {
+    const { result } = await runEpisode(task, adapter, makeClient(), options);
+    results.push(result);
+  }
+  return results;
+}
+
+export function countNoProgressEpisodes(events: EpisodeEvent[]): number {
+  let count = 0;
+  let consecutiveErrors = 0;
+  let previousSuccessSignature: string | null = null;
+  let repeatedSuccesses = 0;
+  let countedErrorRun = false;
+  let countedRepeatRun = false;
+
+  for (const event of events) {
+    if (event.type !== 'tool_result') continue;
+    if (!event.ok) {
+      consecutiveErrors++;
+      if (consecutiveErrors >= 3 && !countedErrorRun) {
+        count++;
+        countedErrorRun = true;
+      }
+      previousSuccessSignature = null;
+      repeatedSuccesses = 0;
+      countedRepeatRun = false;
+      continue;
+    }
+    consecutiveErrors = 0;
+    countedErrorRun = false;
+    const signature = `${event.tool ?? ''}:${event.text ?? ''}`;
+    if (signature === previousSuccessSignature) repeatedSuccesses++;
+    else repeatedSuccesses = 1;
+    previousSuccessSignature = signature;
+    if (repeatedSuccesses >= 3 && !countedRepeatRun) {
+      count++;
+      countedRepeatRun = true;
+    }
+  }
+  return count;
+}
+
+function makeRunId(taskId: string, now: number): string {
+  return `${taskId}-${now.toString(36)}`.replace(/[^a-z0-9_-]/gi, '-');
+}

--- a/tests/benchmark/episode-harness/spec.ts
+++ b/tests/benchmark/episode-harness/spec.ts
@@ -1,0 +1,115 @@
+import type { Assertion } from '../../../src/contracts/types';
+import type { EpisodeTaskSpec, NormalizedEpisodeTaskSpec } from './types';
+
+const DEFAULT_MAX_STEPS = 30;
+const DEFAULT_MAX_DURATION_MS = 120_000;
+const MAX_STEPS = 100;
+const MAX_DURATION_MS = 600_000;
+
+const TASK_KEYS = new Set(['id', 'title', 'startUrl', 'goal', 'maxSteps', 'maxDurationMs', 'success', 'setup', 'tags']);
+const SETUP_KEYS = new Set(['clearCookies', 'viewport']);
+const VIEWPORT_KEYS = new Set(['width', 'height']);
+
+export function normalizeTaskSpec(input: unknown): NormalizedEpisodeTaskSpec {
+  if (!isRecord(input)) throw new Error('Episode task must be an object');
+  rejectUnknownKeys(input, TASK_KEYS, 'task');
+
+  const maxSteps = numberWithDefault(input.maxSteps, DEFAULT_MAX_STEPS, 'maxSteps');
+  const maxDurationMs = numberWithDefault(input.maxDurationMs, DEFAULT_MAX_DURATION_MS, 'maxDurationMs');
+  if (maxSteps > MAX_STEPS) throw new Error(`maxSteps must be <= ${MAX_STEPS}`);
+  if (maxDurationMs > MAX_DURATION_MS) throw new Error(`maxDurationMs must be <= ${MAX_DURATION_MS}`);
+
+  const task: NormalizedEpisodeTaskSpec = {
+    id: requiredString(input.id, 'id'),
+    title: requiredString(input.title, 'title'),
+    startUrl: requiredString(input.startUrl, 'startUrl'),
+    goal: requiredString(input.goal, 'goal'),
+    maxSteps,
+    maxDurationMs,
+    success: validateAssertion(input.success),
+  };
+
+  if (input.setup !== undefined) task.setup = validateSetup(input.setup);
+  if (input.tags !== undefined) {
+    if (!Array.isArray(input.tags) || input.tags.some(t => typeof t !== 'string')) throw new Error('tags must be string[]');
+    task.tags = input.tags;
+  }
+  return task;
+}
+
+export function normalizeTaskSpecs(inputs: EpisodeTaskSpec[]): NormalizedEpisodeTaskSpec[] {
+  return inputs.map(normalizeTaskSpec);
+}
+
+function validateSetup(input: unknown): NonNullable<EpisodeTaskSpec['setup']> {
+  if (!isRecord(input)) throw new Error('setup must be an object');
+  rejectUnknownKeys(input, SETUP_KEYS, 'setup');
+  const setup: NonNullable<EpisodeTaskSpec['setup']> = {};
+  if (input.clearCookies !== undefined) {
+    if (typeof input.clearCookies !== 'boolean') throw new Error('setup.clearCookies must be boolean');
+    setup.clearCookies = input.clearCookies;
+  }
+  if (input.viewport !== undefined) {
+    if (!isRecord(input.viewport)) throw new Error('setup.viewport must be an object');
+    rejectUnknownKeys(input.viewport, VIEWPORT_KEYS, 'setup.viewport');
+    const width = numberWithDefault(input.viewport.width, 0, 'setup.viewport.width');
+    const height = numberWithDefault(input.viewport.height, 0, 'setup.viewport.height');
+    setup.viewport = { width, height };
+  }
+  return setup;
+}
+
+function validateAssertion(input: unknown): Assertion {
+  if (!isRecord(input)) throw new Error('success must be an assertion object');
+  if (typeof input.kind !== 'string') throw new Error('success.kind is required');
+  switch (input.kind) {
+    case 'url':
+      rejectUnknownKeys(input, new Set(['kind', 'pattern']), 'url assertion');
+      requiredString(input.pattern, 'pattern');
+      break;
+    case 'dom_text':
+      rejectUnknownKeys(input, new Set(['kind', 'selector', 'contains']), 'dom_text assertion');
+      if (input.selector !== undefined) requiredString(input.selector, 'selector');
+      requiredString(input.contains, 'contains');
+      break;
+    case 'dom_count':
+      rejectUnknownKeys(input, new Set(['kind', 'selector', 'op', 'value']), 'dom_count assertion');
+      requiredString(input.selector, 'selector');
+      if (!['eq', 'gte', 'lte'].includes(String(input.op))) throw new Error('dom_count.op is invalid');
+      numberWithDefault(input.value, 0, 'dom_count.value');
+      break;
+    case 'and':
+    case 'or':
+      rejectUnknownKeys(input, new Set(['kind', 'children']), `${input.kind} assertion`);
+      if (!Array.isArray(input.children) || input.children.length === 0) throw new Error(`${input.kind}.children must be non-empty`);
+      input.children.forEach(validateAssertion);
+      break;
+    case 'not':
+      rejectUnknownKeys(input, new Set(['kind', 'child']), 'not assertion');
+      validateAssertion(input.child);
+      break;
+    default:
+      throw new Error(`unsupported assertion kind: ${input.kind}`);
+  }
+  return input as unknown as Assertion;
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim() === '') throw new Error(`${field} must be a non-empty string`);
+  return value;
+}
+
+function numberWithDefault(value: unknown, fallback: number, field: string): number {
+  const resolved = value === undefined ? fallback : value;
+  if (typeof resolved !== 'number' || !Number.isFinite(resolved) || resolved <= 0) throw new Error(`${field} must be a positive number`);
+  return resolved;
+}
+
+function rejectUnknownKeys(input: Record<string, unknown>, allowed: Set<string>, label: string): void {
+  const unknown = Object.keys(input).filter(key => !allowed.has(key));
+  if (unknown.length > 0) throw new Error(`${label} has unknown field(s): ${unknown.join(', ')}`);
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return typeof input === 'object' && input !== null && !Array.isArray(input);
+}

--- a/tests/benchmark/episode-harness/types.ts
+++ b/tests/benchmark/episode-harness/types.ts
@@ -1,0 +1,87 @@
+import type { Assertion, EvaluationResult } from '../../../src/contracts/types';
+
+export interface EpisodeTaskSpec {
+  id: string;
+  title: string;
+  startUrl: string;
+  goal: string;
+  maxSteps?: number;
+  maxDurationMs?: number;
+  success: Assertion;
+  setup?: {
+    clearCookies?: boolean;
+    viewport?: { width: number; height: number };
+  };
+  tags?: string[];
+}
+
+export interface NormalizedEpisodeTaskSpec extends EpisodeTaskSpec {
+  maxSteps: number;
+  maxDurationMs: number;
+}
+
+export interface EpisodeToolCall {
+  tool: string;
+  args: Record<string, unknown>;
+}
+
+export interface EpisodeAdapter {
+  name: string;
+  next(input: EpisodeAdapterInput): Promise<EpisodeToolCall | { done: true }>;
+}
+
+export interface EpisodeAdapterInput {
+  task: NormalizedEpisodeTaskSpec;
+  step: number;
+  lastResult?: EpisodeToolResult;
+  events: EpisodeEvent[];
+}
+
+export interface EpisodeToolResult {
+  ok: boolean;
+  text?: string;
+  data?: Record<string, unknown>;
+  error?: string;
+}
+
+export interface EpisodeClient {
+  reset(task: NormalizedEpisodeTaskSpec): Promise<void>;
+  callTool(call: EpisodeToolCall): Promise<EpisodeToolResult>;
+  evaluate(assertion: Assertion): Promise<EvaluationResult>;
+  currentUrl(): Promise<string>;
+}
+
+export type EpisodeStatus = 'passed' | 'failed' | 'timeout' | 'max_steps' | 'adapter_error' | 'tool_error';
+
+export interface EpisodeEvent {
+  ts: number;
+  type: 'reset' | 'tool_call' | 'tool_result' | 'contract_eval' | 'stop';
+  step?: number;
+  tool?: string;
+  args?: Record<string, unknown>;
+  ok?: boolean;
+  status?: EpisodeStatus;
+  text?: string;
+  error?: string;
+  url?: string;
+  evaluation?: EvaluationResult;
+}
+
+export interface EpisodeResult {
+  runId: string;
+  taskId: string;
+  status: EpisodeStatus;
+  success: boolean;
+  steps: number;
+  durationMs: number;
+  toolCalls: number;
+  openchromeErrors: number;
+  noProgressEpisodes: number;
+  finalUrl: string;
+  failedContract?: unknown;
+  artifacts: {
+    eventsJsonl: string;
+    reportJson: string;
+    screenshotDir?: string;
+  };
+}


### PR DESCRIPTION
## Summary
- Fixes #1058 with a reusable test-only episode harness under `tests/benchmark/episode-harness/`.
- Adds typed `EpisodeTaskSpec` / `EpisodeResult`, bounded spec validation, deterministic mock adapter/client, per-step JSONL events, and JSON/Markdown reports.
- Adds fixture tasks for read-only success, form-submit success, and bounded stall/max-step reporting.
- Documents task authoring, adapter boundaries, output artifacts, and the relationship to #851.

## Verification
- `npm test -- tests/benchmark/episode-harness/runner.test.ts --runInBand`
- `npm run bench:episode:mock -- --out /tmp/openchrome-episode-harness-1058`
- `npm run bench:episode:mock -- --task local-recovery-stall --max-steps 2 --out /tmp/openchrome-episode-stall-1058`
- `npm run build`
- `npm run lint:tier`

## Notes
- Mock mode is deterministic and credential-free; it does not import or invoke any LLM provider.
- This PR intentionally does not change production `src/**` behavior or add runtime dependencies.
- Live MCP server-backed episode clients and real LLM adapters are left for follow-up integration work.
