### PR TITLE
feat(core): add semantic oc_query refs (#1045)

### DIFF
--- a/src/auth/scope-policy.ts
+++ b/src/auth/scope-policy.ts
@@ -28,6 +28,7 @@ export const READ_TOOLS: ReadonlySet<ToolId> = new Set<ToolId>([
   'page_screenshot',
   'page_pdf',
   'query_dom',
+  'oc_query',
   'find',
   'vision_find',
   'inspect',

--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -23,6 +23,7 @@ export const TOOL_TIERS: Record<string, ToolTier> = {
   oc_observe: 1,              // src/tools/oc-observe.ts — compact observable action map (#866)
   inspect: 1,
   query_dom: 1,
+  oc_query: 1, // src/tools/oc-query.ts — semantic refs for interaction workflows (#1045)
   javascript_tool: 1,
   tabs_context: 1,
   tabs_create: 1,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -2664,7 +2664,7 @@ export class MCPServer {
   private inferToolCategory(toolName: string): ToolCategory {
     if (['navigate', 'page_reload'].includes(toolName)) return 'navigation';
     if (['computer', 'form_input', 'drag_drop'].includes(toolName)) return 'interaction';
-    if (['read_page', 'find', 'page_content', 'query_dom'].includes(toolName)) return 'content';
+    if (['read_page', 'find', 'page_content', 'query_dom', 'oc_query'].includes(toolName)) return 'content';
     if (toolName === 'javascript_tool') return 'javascript';
     if (['network', 'cookies', 'storage', 'request_intercept', 'http_auth'].includes(toolName)) return 'network';
     if (['tabs_context', 'tabs_create', 'tabs_close'].includes(toolName)) return 'tabs';

--- a/src/tools/__tests__/__snapshots__/tools-list.v1.11.snap.json
+++ b/src/tools/__tests__/__snapshots__/tools-list.v1.11.snap.json
@@ -151,6 +151,9 @@
       "name": "oc_progress_status"
     },
     {
+      "name": "oc_query"
+    },
+    {
       "name": "oc_reap_orphans"
     },
     {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -65,6 +65,7 @@ import { registerMemoryTools } from './memory';
 
 // Consolidated DOM query tool
 import { registerQueryDomTool } from './query-dom';
+import { registerOcQueryTool } from './oc-query';
 
 // Lifecycle tools
 import { registerShutdownTool } from './shutdown';
@@ -230,6 +231,7 @@ export const TOOL_CAPABILITY_MAP: Record<string, ToolCapability> = {
   page_screenshot: 'core',
   performance_metrics: 'core',
   query_dom: 'core',
+  oc_query: 'core',
   read_page: 'core',
   request_intercept: 'core',
   tabs_close: 'core',
@@ -410,6 +412,9 @@ export function registerAllTools(server: MCPServer): void {
 
   // Memory tools (domain knowledge persistence)
   registerMemoryTools(proxy);
+
+  // Semantic query tool (#1045)
+  registerOcQueryTool(proxy);
 
   // Lifecycle tools
   registerShutdownTool(proxy);

--- a/src/tools/oc-query.ts
+++ b/src/tools/oc-query.ts
@@ -1,0 +1,225 @@
+/**
+ * oc_query — provider-neutral semantic element resolution for interaction workflows.
+ *
+ * This is a deterministic local query layer over existing OpenChrome AX/DOM
+ * resolution primitives. It does not call external AgentQL/LLM services.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
+import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
+import { getSessionManager } from '../session-manager';
+import { getRefIdManager } from '../utils/ref-id-manager';
+import { discoverElements, cleanupTags, DISCOVERY_TAG } from '../utils/element-discovery';
+import { FoundElement, normalizeQuery, scoreElement, tokenizeQuery } from '../utils/element-finder';
+import { resolveElementsByAXTree } from '../utils/ax-element-resolver';
+
+export interface OcQueryResult {
+  path: string;
+  ref: string;
+  source: 'ax' | 'dom';
+  role: string;
+  name: string;
+  score: number;
+  tagName?: string;
+  text?: string;
+  backendDOMNodeId?: number;
+  rect?: { x: number; y: number; width: number; height: number };
+  useWith: string[];
+}
+
+export interface OcQueryResponse {
+  query: string;
+  purpose: 'interaction' | 'extraction' | 'verification';
+  count: number;
+  results: OcQueryResult[];
+  nextAction: string;
+}
+
+const definition: MCPToolDefinition = {
+  name: 'oc_query',
+  description:
+    'Resolve a semantic element query into stable refs for interaction workflows. ' +
+    'Uses local AX/DOM matching only; no external AgentQL or LLM provider is called. ' +
+    'Pass returned refs to interact, act, fill_form, read_page(ref_id), or plan parseResult.storeAs paths.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      tabId: { type: 'string', description: 'REQUIRED Tab id to query.' },
+      query: { type: 'string', description: 'REQUIRED Semantic query such as "checkout button" or "email field".' },
+      purpose: { type: 'string', enum: ['interaction', 'extraction', 'verification'], description: 'How the caller intends to use the result. Default: interaction.' },
+      limit: { type: 'number', description: 'Maximum refs to return. Default 5, max 20.' },
+      includeCandidates: { type: 'boolean', description: 'When true, include lower-scored DOM candidates as well as AX matches. Default true.' },
+    },
+    required: ['tabId', 'query'],
+  },
+  annotations: TOOL_ANNOTATIONS.oc_query,
+};
+
+const handler: ToolHandler = async (
+  sessionId: string,
+  args: Record<string, unknown>,
+  context?: ToolContext,
+): Promise<MCPResult> => {
+  const tabId = String(args.tabId || '');
+  const query = String(args.query || '').trim();
+  const purpose = normalizePurpose(args.purpose);
+  const limit = clampLimit(args.limit);
+  const includeCandidates = args.includeCandidates !== false;
+
+  if (!tabId) return errorResult('tabId is required');
+  if (!query) return errorResult('query is required');
+  if (context && !hasBudget(context, 8_000)) {
+    return errorResult('oc_query: deadline approaching — skipped semantic query resolution');
+  }
+
+  try {
+    const sessionManager = getSessionManager();
+    const page = await sessionManager.getPage(sessionId, tabId, undefined, 'oc_query');
+    if (!page) {
+      return errorResult(`Tab ${tabId} not found or no longer available`);
+    }
+
+    const cdpClient = sessionManager.getCDPClient();
+    const refIdManager = getRefIdManager();
+    const results: OcQueryResult[] = [];
+
+    try {
+      const axMatches = await resolveElementsByAXTree(page, cdpClient, query, {
+        useCenter: false,
+        maxResults: limit,
+      });
+      for (const match of axMatches) {
+        const ref = refIdManager.generateRef(
+          sessionId,
+          tabId,
+          match.backendDOMNodeId,
+          match.role,
+          match.name,
+        );
+        results.push({
+          path: `results.${results.length}`,
+          ref,
+          source: 'ax',
+          role: match.role,
+          name: match.name,
+          score: axScore(match.matchLevel),
+          backendDOMNodeId: match.backendDOMNodeId,
+          rect: match.rect,
+          useWith: recommendedTools(purpose),
+        });
+      }
+    } catch {
+      // AX lookup is best-effort; DOM discovery below is the deterministic fallback.
+    }
+
+    if (includeCandidates && results.length < limit) {
+      const queryLower = normalizeQuery(query);
+      const queryTokens = tokenizeQuery(query);
+      const domMatches = await discoverElements(page, cdpClient, queryLower, {
+        maxResults: Math.max(limit * 2, 10),
+        useCenter: false,
+        timeout: 10_000,
+        toolName: 'oc_query',
+      });
+      const existingBackendIds = new Set(results.map(r => r.backendDOMNodeId).filter((id): id is number => typeof id === 'number'));
+      const scored = domMatches
+        .filter(match => match.backendDOMNodeId > 0 && !existingBackendIds.has(match.backendDOMNodeId))
+        .map(match => ({ ...match, score: scoreElement(match as FoundElement, queryLower, queryTokens) }))
+        .filter(match => match.score > 0)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, limit - results.length);
+
+      for (const match of scored) {
+        const ref = refIdManager.generateRef(
+          sessionId,
+          tabId,
+          match.backendDOMNodeId,
+          match.role,
+          match.name,
+          match.tagName,
+          match.textContent,
+        );
+        results.push({
+          path: `results.${results.length}`,
+          ref,
+          source: 'dom',
+          role: match.role,
+          name: match.name,
+          tagName: match.tagName,
+          text: match.textContent,
+          score: match.score,
+          backendDOMNodeId: match.backendDOMNodeId,
+          rect: match.rect,
+          useWith: recommendedTools(purpose),
+        });
+      }
+    }
+
+    await cleanupTags(page, DISCOVERY_TAG).catch(() => {});
+
+    const response = buildResponse(query, purpose, results);
+    return {
+      structuredContent: response as unknown as Record<string, unknown>,
+      content: [{ type: 'text', text: formatResponse(response) }],
+    };
+  } catch (error) {
+    return errorResult(error instanceof Error ? error.message : String(error));
+  }
+};
+
+export function buildResponse(query: string, purpose: OcQueryResponse['purpose'], results: OcQueryResult[]): OcQueryResponse {
+  return {
+    query,
+    purpose,
+    count: results.length,
+    results,
+    nextAction: results.length > 0
+      ? `Use ${results[0].path}.ref (${results[0].ref}) with ${recommendedTools(purpose).join(' or ')}.`
+      : 'No semantic matches found. Try a more specific query, read_page(mode="ax"), or query_dom with a known selector.',
+  };
+}
+
+export function formatResponse(response: OcQueryResponse): string {
+  const lines = [`oc_query: ${response.count} result(s) for "${response.query}"`, `Purpose: ${response.purpose}`];
+  for (const result of response.results) {
+    const label = result.name ? ` "${result.name}"` : '';
+    const tag = result.tagName ? ` <${result.tagName}>` : '';
+    lines.push(`- ${result.path}.ref=${result.ref} [${result.source}] ${result.role}${tag}${label} score=${result.score}`);
+  }
+  lines.push(`Next: ${response.nextAction}`);
+  return lines.join('\n');
+}
+
+function recommendedTools(purpose: OcQueryResponse['purpose']): string[] {
+  if (purpose === 'extraction') return ['read_page(ref_id)', 'extract_data'];
+  if (purpose === 'verification') return ['oc_assert', 'read_page(ref_id)'];
+  return ['interact', 'act', 'fill_form'];
+}
+
+function normalizePurpose(value: unknown): OcQueryResponse['purpose'] {
+  return value === 'extraction' || value === 'verification' ? value : 'interaction';
+}
+
+function clampLimit(value: unknown): number {
+  const n = typeof value === 'number' && Number.isFinite(value) ? Math.floor(value) : 5;
+  return Math.max(1, Math.min(20, n));
+}
+
+function axScore(matchLevel: number): number {
+  return matchLevel === 1 ? 130 : matchLevel === 2 ? 100 : 80;
+}
+
+function errorResult(message: string): MCPResult {
+  return {
+    isError: true,
+    structuredContent: { error: { code: 'oc_query_error', message } },
+    content: [{ type: 'text', text: `Error: ${message}` }],
+  };
+}
+
+export function registerOcQueryTool(server: MCPServer): void {
+  server.registerTool('oc_query', handler, definition);
+}
+
+export const ocQueryToolHandler = handler;

--- a/src/types/tool-annotations.ts
+++ b/src/types/tool-annotations.ts
@@ -64,6 +64,7 @@ export const TOOL_ANNOTATIONS = {
   // ── Pure reads ──────────────────────────────────────────────────────────
   inspect: READ_ONLY,
   query_dom: READ_ONLY,
+  oc_query: READ_ONLY,
   find: READ_ONLY,
   read_page: READ_ONLY,
   page_content: READ_ONLY,

--- a/tests/tools/oc-query.test.ts
+++ b/tests/tools/oc-query.test.ts
@@ -1,0 +1,42 @@
+import { buildResponse, formatResponse, registerOcQueryTool } from '../../src/tools/oc-query';
+
+describe('oc_query response helpers', () => {
+  it('formats refs and parseable paths for interaction workflows', () => {
+    const response = buildResponse('checkout button', 'interaction', [{
+      path: 'results.0',
+      ref: 'ref_1',
+      source: 'dom',
+      role: 'button',
+      name: 'Checkout',
+      score: 90,
+      useWith: ['interact', 'act', 'fill_form'],
+    }]);
+
+    expect(response.nextAction).toContain('results.0.ref');
+    expect(response.results[0].useWith).toContain('interact');
+    expect(formatResponse(response)).toContain('results.0.ref=ref_1');
+  });
+
+  it('returns extraction-specific next tools', () => {
+    const response = buildResponse('product card', 'extraction', []);
+
+    expect(response.count).toBe(0);
+    expect(response.nextAction).toContain('read_page');
+  });
+});
+
+describe('registerOcQueryTool', () => {
+  it('registers oc_query with annotations', () => {
+    const registerTool = jest.fn();
+    registerOcQueryTool({ registerTool } as any);
+
+    expect(registerTool).toHaveBeenCalledWith(
+      'oc_query',
+      expect.any(Function),
+      expect.objectContaining({
+        name: 'oc_query',
+        annotations: expect.objectContaining({ readOnlyHint: true }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #1045 by adding `oc_query`, a provider-free semantic element resolver for interaction workflows.
- Reuses existing AX tree resolution and DOM element discovery/scoring to return refs, parseable `results.N.ref` paths, roles, names, scores, source (`ax`/`dom`), and recommended downstream tools.
- Registers `oc_query` as a read-only core/tier-1 tool with schema lint and ToolAnnotations coverage.

## Verification
- `npm test -- tests/tools/oc-query.test.ts tests/unit/tool-annotations.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint:tool-schemas`
- `git diff --check`

## Notes
- No external AgentQL/LLM provider is called.
- `oc_query` does not execute interactions; callers pass returned refs to existing `interact`, `act`, `fill_form`, `read_page(ref_id)`, or plan `parseResult.storeAs` paths.
- Live dynamic-page fixture verification is left as a follow-up; this PR validates registration, annotations, schema, and response contract.
