### PR TITLE
feat(security): add irreversible action policy matrix (#1038)

### DIFF
--- a/docs/security/irreversible-action-policy.md
+++ b/docs/security/irreversible-action-policy.md
@@ -1,0 +1,33 @@
+# Irreversible action policy matrix
+
+OpenChrome classifies high-risk browser actions deterministically so host agents can preview, checkpoint, or elicit confirmation before committing side effects. The policy is not an LLM judge and does not gate read-only browsing.
+
+## Default matrix
+
+| Tool/action | Risk | Trigger | Required prerequisite |
+| --- | --- | --- | --- |
+| `read_page`, `tabs_context`, `query_dom` | read_only | always | none |
+| `cookies` | destructive | delete/delete-all/clear/remove | `dryRun:true`, then elicitation |
+| `storage` | destructive | clear/delete/remove | `dryRun:true`, then elicitation |
+| `oc_stop` | destructive | always | elicitation and checkpoint ≤ 5 minutes old |
+| `oc_reap_orphans` | destructive | always | `dryRun:true`, then elicitation |
+| `request_intercept` | external_side_effect | broad block/abort rules | `dryRun:true` preview |
+| `file_upload` | external_side_effect | always | elicitation and checkpoint ≤ 5 minutes old |
+| `act`/`interact` | irreversible | deterministic submit/payment/delete text | elicitation, checkpoint ≤ 5 minutes old, contract precheck |
+| `navigate` | external_side_effect | URL outside task `allowedDomains` | blocked until URL/domain policy changes |
+
+## Structured decisions
+
+`evaluateToolRiskPolicy()` returns one of:
+
+- `allow` — no gate required or all prerequisites are satisfied.
+- `preview_required` — run the documented dry-run/preview path before commit.
+- `elicitation_required` — host confirmation support is required.
+- `checkpoint_required` — create or refresh a task/session checkpoint first.
+- `blocked` — deterministic policy forbids this action, such as navigation outside `allowedDomains`.
+
+Every denial includes `policy`, `reason`, `missing`, and `suggested_next_action` fields for auditability.
+
+## Operator guidance
+
+Use this matrix as the common policy source for ToolAnnotations, dry-run previews, elicitation hooks, and TaskRun checkpoints. Future tool integrations should call the shared helper before executing a destructive commit path and should include the returned decision in structured tool output when blocked.

--- a/src/security/tool-risk-policy.ts
+++ b/src/security/tool-risk-policy.ts
@@ -1,0 +1,157 @@
+import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
+
+export type ActionRisk = 'read_only' | 'browser_mutation' | 'external_side_effect' | 'destructive' | 'irreversible';
+export type PolicyDecision = 'allow' | 'preview_required' | 'elicitation_required' | 'checkpoint_required' | 'blocked';
+
+export interface ToolRiskPolicy {
+  tool: string;
+  risk: ActionRisk;
+  trigger?: string;
+  requiresDryRun?: boolean;
+  requiresElicitation?: boolean;
+  requiresCheckpoint?: boolean;
+  requiresContractPrecheck?: boolean;
+}
+
+export interface PolicyEvaluationInput {
+  tool: string;
+  args?: Record<string, unknown>;
+  dryRun?: boolean;
+  elicitationSupported?: boolean;
+  checkpoint?: {
+    taskId?: string;
+    createdAt: number;
+    now?: number;
+  };
+  allowedDomains?: string[];
+}
+
+export interface PolicyEvaluationResult {
+  decision: PolicyDecision;
+  policy: ToolRiskPolicy;
+  reason: string;
+  missing?: Array<'dryRun' | 'elicitation' | 'checkpoint' | 'allowedDomain'>;
+  checkpointMaxAgeMs?: number;
+  suggested_next_action?: string;
+}
+
+const CHECKPOINT_MAX_AGE_MS = 5 * 60 * 1000;
+
+export const DEFAULT_TOOL_RISK_POLICIES: ToolRiskPolicy[] = [
+  { tool: 'read_page', risk: 'read_only' },
+  { tool: 'tabs_context', risk: 'read_only' },
+  { tool: 'query_dom', risk: 'read_only' },
+  { tool: 'cookies', risk: 'destructive', trigger: 'action in delete/delete-all/clear', requiresDryRun: true, requiresElicitation: true },
+  { tool: 'storage', risk: 'destructive', trigger: 'action in clear/delete/remove', requiresDryRun: true, requiresElicitation: true },
+  { tool: 'oc_stop', risk: 'destructive', trigger: 'always', requiresElicitation: true, requiresCheckpoint: true },
+  { tool: 'oc_reap_orphans', risk: 'destructive', trigger: 'always', requiresDryRun: true, requiresElicitation: true },
+  { tool: 'request_intercept', risk: 'external_side_effect', trigger: 'broad block/abort rules', requiresDryRun: true },
+  { tool: 'file_upload', risk: 'external_side_effect', trigger: 'always', requiresElicitation: true, requiresCheckpoint: true },
+  { tool: 'act', risk: 'irreversible', trigger: 'submit/payment/delete form action text', requiresElicitation: true, requiresCheckpoint: true, requiresContractPrecheck: true },
+  { tool: 'interact', risk: 'irreversible', trigger: 'submit/payment/delete form action text', requiresElicitation: true, requiresCheckpoint: true, requiresContractPrecheck: true },
+  { tool: 'navigate', risk: 'external_side_effect', trigger: 'url host outside allowedDomains', requiresElicitation: true },
+];
+
+export function getEffectiveToolRiskPolicy(tool: string, args: Record<string, unknown> = {}, allowedDomains?: string[]): ToolRiskPolicy {
+  if (tool === 'navigate' && allowedDomains && !isAllowedDomain(String(args.url || ''), allowedDomains)) {
+    return DEFAULT_TOOL_RISK_POLICIES.find(p => p.tool === 'navigate')!;
+  }
+  if (tool === 'cookies' && /^(delete|delete-all|clear|remove)$/i.test(String(args.action || args.operation || ''))) {
+    return DEFAULT_TOOL_RISK_POLICIES.find(p => p.tool === 'cookies')!;
+  }
+  if (tool === 'storage' && /^(clear|delete|remove)$/i.test(String(args.action || args.operation || ''))) {
+    return DEFAULT_TOOL_RISK_POLICIES.find(p => p.tool === 'storage')!;
+  }
+  if (tool === 'request_intercept' && hasBroadBlockRule(args)) {
+    return DEFAULT_TOOL_RISK_POLICIES.find(p => p.tool === 'request_intercept')!;
+  }
+  if ((tool === 'act' || tool === 'interact') && hasIrreversibleText(args)) {
+    return DEFAULT_TOOL_RISK_POLICIES.find(p => p.tool === tool)!;
+  }
+  const explicit = DEFAULT_TOOL_RISK_POLICIES.find(p => p.tool === tool && p.trigger === 'always');
+  if (explicit) return explicit;
+  const annotations = (TOOL_ANNOTATIONS as Record<string, { readOnlyHint?: boolean; destructiveHint?: boolean; openWorldHint?: boolean } | undefined>)[tool];
+  if (annotations?.readOnlyHint) return { tool, risk: 'read_only' };
+  if (annotations?.destructiveHint) return { tool, risk: 'destructive', requiresElicitation: true };
+  if (annotations?.openWorldHint) return { tool, risk: 'external_side_effect' };
+  return { tool, risk: 'browser_mutation' };
+}
+
+export function evaluateToolRiskPolicy(input: PolicyEvaluationInput): PolicyEvaluationResult {
+  const args = input.args ?? {};
+  const policy = getEffectiveToolRiskPolicy(input.tool, args, input.allowedDomains);
+  if (policy.risk === 'read_only') {
+    return { decision: 'allow', policy, reason: 'read-only policy does not require a gate' };
+  }
+
+  const missing: PolicyEvaluationResult['missing'] = [];
+  if (policy.requiresDryRun && input.dryRun !== true) missing.push('dryRun');
+  if (policy.requiresElicitation && input.elicitationSupported !== true) missing.push('elicitation');
+  if (policy.requiresCheckpoint && !hasFreshCheckpoint(input.checkpoint)) missing.push('checkpoint');
+  if (input.tool === 'navigate' && input.allowedDomains && !isAllowedDomain(String(args.url || ''), input.allowedDomains)) missing.push('allowedDomain');
+
+  if (missing.includes('allowedDomain')) {
+    return {
+      decision: 'blocked',
+      policy,
+      reason: 'navigation target is outside allowedDomains',
+      missing,
+      suggested_next_action: 'Use an allowed localhost/domain URL or update the task allowedDomains policy.',
+    };
+  }
+  if (missing.includes('dryRun')) {
+    return {
+      decision: 'preview_required',
+      policy,
+      reason: 'policy requires a dry-run preview before this high-risk action can commit',
+      missing,
+      suggested_next_action: `Call ${input.tool} with dryRun:true or use the documented preview path first.`,
+    };
+  }
+  if (missing.includes('checkpoint')) {
+    return {
+      decision: 'checkpoint_required',
+      policy,
+      reason: 'policy requires a fresh task checkpoint before this irreversible action',
+      missing,
+      checkpointMaxAgeMs: CHECKPOINT_MAX_AGE_MS,
+      suggested_next_action: 'Create or refresh a task/session checkpoint, then retry with the same policy context.',
+    };
+  }
+  if (missing.includes('elicitation')) {
+    return {
+      decision: 'elicitation_required',
+      policy,
+      reason: 'policy requires client elicitation/confirmation support before this action',
+      missing,
+      suggested_next_action: 'Ask the host to confirm or enable the elicitation/irreversible-action hook.',
+    };
+  }
+  return { decision: 'allow', policy, reason: 'all policy prerequisites are satisfied' };
+}
+
+function hasFreshCheckpoint(checkpoint: PolicyEvaluationInput['checkpoint']): boolean {
+  if (!checkpoint) return false;
+  const now = checkpoint.now ?? Date.now();
+  return now - checkpoint.createdAt <= CHECKPOINT_MAX_AGE_MS;
+}
+
+function isAllowedDomain(url: string, allowedDomains: string[]): boolean {
+  if (!url || allowedDomains.length === 0) return true;
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return allowedDomains.some(domain => host === domain.toLowerCase() || host.endsWith(`.${domain.toLowerCase()}`));
+  } catch {
+    return false;
+  }
+}
+
+function hasBroadBlockRule(args: Record<string, unknown>): boolean {
+  const text = JSON.stringify(args).toLowerCase();
+  return /block|abort|deny/.test(text) && (/\*|all|resource|image|script|stylesheet/.test(text));
+}
+
+function hasIrreversibleText(args: Record<string, unknown>): boolean {
+  const text = JSON.stringify(args).toLowerCase();
+  return /submit|payment|pay|purchase|checkout|delete|remove|transfer|send money|place order/.test(text);
+}

--- a/tests/security/tool-risk-policy.test.ts
+++ b/tests/security/tool-risk-policy.test.ts
@@ -1,0 +1,58 @@
+import { evaluateToolRiskPolicy, getEffectiveToolRiskPolicy } from '../../src/security/tool-risk-policy';
+
+describe('tool risk policy matrix', () => {
+  it('allows read-only tools without gates', () => {
+    const decision = evaluateToolRiskPolicy({ tool: 'read_page' });
+    expect(decision.decision).toBe('allow');
+    expect(decision.policy.risk).toBe('read_only');
+  });
+
+  it('requires dry-run preview for destructive cookie deletes', () => {
+    const decision = evaluateToolRiskPolicy({ tool: 'cookies', args: { action: 'delete-all' } });
+    expect(decision.decision).toBe('preview_required');
+    expect(decision.missing).toContain('dryRun');
+  });
+
+  it('requires elicitation after dry-run for cookie deletes', () => {
+    const decision = evaluateToolRiskPolicy({ tool: 'cookies', args: { action: 'delete-all' }, dryRun: true });
+    expect(decision.decision).toBe('elicitation_required');
+    expect(decision.missing).toContain('elicitation');
+  });
+
+  it('requires a fresh checkpoint for irreversible form submits', () => {
+    const decision = evaluateToolRiskPolicy({
+      tool: 'act',
+      args: { action: 'click submit payment' },
+      elicitationSupported: true,
+    });
+    expect(decision.decision).toBe('checkpoint_required');
+    expect(decision.missing).toContain('checkpoint');
+  });
+
+  it('allows irreversible form submits once prerequisites are satisfied', () => {
+    const decision = evaluateToolRiskPolicy({
+      tool: 'act',
+      args: { action: 'click submit payment' },
+      elicitationSupported: true,
+      checkpoint: { createdAt: 1_000, now: 1_000 + 60_000, taskId: 'task-1' },
+    });
+    expect(decision.decision).toBe('allow');
+  });
+
+  it('blocks navigation outside allowed domains', () => {
+    const decision = evaluateToolRiskPolicy({
+      tool: 'navigate',
+      args: { url: 'https://example.com' },
+      allowedDomains: ['localhost'],
+      elicitationSupported: true,
+    });
+    expect(decision.decision).toBe('blocked');
+    expect(decision.missing).toContain('allowedDomain');
+  });
+
+  it('uses ToolAnnotations fallback for unknown destructive tools', () => {
+    const policy = getEffectiveToolRiskPolicy('javascript_tool');
+    expect(policy.risk).toBe('destructive');
+    expect(policy.requiresElicitation).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Partially fixes #1038 by adding a deterministic irreversible-action policy matrix and shared evaluation helper.
- Covers read-only allow, dry-run preview required, elicitation required, checkpoint required, domain block, and ToolAnnotations fallback decisions.
- Documents the default matrix and structured decision vocabulary in `docs/security/irreversible-action-policy.md`.

## Verification
- `npm test -- tests/security/tool-risk-policy.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `git diff --check`

## Notes
- This PR does not add an LLM risk judge and does not gate read-only tools.
- The helper is intentionally isolated so high-risk tools can wire it before destructive commit paths without rewriting existing ToolAnnotations/dryRun/elicitation primitives.
- Live destructive-tool transcript and per-tool enforcement integration remain follow-up work.
