### PR TITLE
feat(contracts): add execute_plan final verification gate (#1031)

### DIFF
--- a/src/orchestration/plan-executor.ts
+++ b/src/orchestration/plan-executor.ts
@@ -12,10 +12,108 @@ import {
   PlanErrorHandler,
   PlanExecutionOptions,
   PlanExecutionResult,
+  PlanFinalVerificationResult,
 } from '../types/plan-cache';
+import { evaluate } from '../contracts/evaluate';
+import type { EvalContext, NetworkLogEntry } from '../contracts/eval-context';
 import { evaluateTaskSignature, preflightAllowedTools } from '../contracts/task-signature';
 import type { TaskSignatureToolCallSummary } from '../contracts/task-signature';
 import { withTimeout } from '../utils/with-timeout';
+
+interface SnapshotInput {
+  url?: string;
+  dom_text?: string | null | Record<string, string | null>;
+  dom_count?: Record<string, number>;
+  network?: NetworkLogEntry[];
+  screenshot_png_base64?: string;
+  has_open_dialog?: boolean;
+  captured_at?: number;
+  timestamp?: number;
+}
+
+function buildSnapshotEvalContext(snapshot: SnapshotInput): EvalContext {
+  const domTextBySelector = typeof snapshot.dom_text === 'object' && snapshot.dom_text !== null
+    ? snapshot.dom_text as Record<string, string | null>
+    : undefined;
+  const bodyText = typeof snapshot.dom_text === 'string' || snapshot.dom_text === null
+    ? snapshot.dom_text
+    : undefined;
+  const screenshot = snapshot.screenshot_png_base64 ? Buffer.from(snapshot.screenshot_png_base64, 'base64') : null;
+  return {
+    async url() { return snapshot.url ?? ''; },
+    async domText(selector) {
+      if (domTextBySelector) return domTextBySelector[selector ?? 'body'] ?? domTextBySelector.body ?? null;
+      return bodyText ?? null;
+    },
+    async domCount(selector) { return snapshot.dom_count?.[selector] ?? 0; },
+    async networkSince() { return snapshot.network ?? []; },
+    async screenshotPng() { return screenshot; },
+    async hasOpenDialog() { return snapshot.has_open_dialog ?? false; },
+  };
+}
+
+function isSnapshotInput(value: unknown): value is SnapshotInput {
+  return typeof value === 'object' && value !== null;
+}
+
+async function runFinalVerification(
+  plan: CompiledPlan,
+  params: Record<string, unknown>,
+): Promise<PlanFinalVerificationResult | null> {
+  const gate = plan.finalVerification;
+  if (!gate) return null;
+  const snapshotParam = gate.snapshotParam || 'finalSnapshot';
+  const snapshot = params[snapshotParam];
+  if (!isSnapshotInput(snapshot)) {
+    return {
+      passed: false,
+      snapshotParam,
+      assertions: [],
+      error: `final verification snapshot param missing or invalid: ${snapshotParam}`,
+    };
+  }
+
+  const capturedAt = typeof snapshot.captured_at === 'number'
+    ? snapshot.captured_at
+    : typeof snapshot.timestamp === 'number'
+      ? snapshot.timestamp
+      : undefined;
+  if (gate.freshnessMs !== undefined && capturedAt !== undefined && Date.now() - capturedAt > gate.freshnessMs) {
+    return {
+      passed: false,
+      snapshotParam,
+      assertions: [],
+      error: `final verification snapshot is stale: age ${Date.now() - capturedAt}ms exceeds ${gate.freshnessMs}ms`,
+    };
+  }
+
+  const unsupportedEvidence = (gate.requiredEvidence || []).filter(kind => !['dom', 'url', 'network', 'screenshot'].includes(kind));
+  if (unsupportedEvidence.length > 0) {
+    return {
+      passed: false,
+      snapshotParam,
+      assertions: [],
+      error: `unsupported finalVerification.requiredEvidence: ${unsupportedEvidence.join(', ')}`,
+    };
+  }
+
+  const assertions: PlanFinalVerificationResult['assertions'] = [];
+  const ctx = buildSnapshotEvalContext(snapshot);
+  for (let i = 0; i < gate.finalAssertions.length; i++) {
+    const assertion = gate.finalAssertions[i];
+    const result = await evaluate(assertion, ctx);
+    assertions.push({ index: i, passed: result.passed, evidence: result.evidence });
+    if (!result.passed) {
+      return {
+        passed: false,
+        snapshotParam,
+        assertions,
+        failedAssertion: { index: i, assertion, evidence: result.evidence },
+      };
+    }
+  }
+  return { passed: true, snapshotParam, assertions };
+}
 
 /**
  * Recursively substitute ${varName} templates in a value using the params map.
@@ -340,7 +438,29 @@ export class PlanExecutor {
       };
     }
 
-    // 4. Return success with all collected params as data
+    // 4. Optional final Outcome Contract verification gate
+    const finalVerification = await runFinalVerification(plan, params);
+    if (finalVerification && !finalVerification.passed) {
+      return {
+        success: false,
+        planId: plan.id,
+        error: finalVerification.error || `Final verification failed at assertion ${finalVerification.failedAssertion?.index ?? 'unknown'}`,
+        durationMs: Date.now() - startTime,
+        stepsExecuted,
+        totalSteps: plan.steps.length,
+        finalVerification,
+        ...(options.taskSignature
+          ? { taskSignature: await evaluateTaskSignature({
+              signature: options.taskSignature,
+              recentTools,
+              elapsedMs: Date.now() - startTime,
+              toolCount: stepsExecuted,
+            }) }
+          : {}),
+      };
+    }
+
+    // 5. Return success with all collected params as data
     return {
       success: true,
       planId: plan.id,
@@ -348,6 +468,7 @@ export class PlanExecutor {
       durationMs: Date.now() - startTime,
       stepsExecuted,
       totalSteps: plan.steps.length,
+      ...(finalVerification ? { finalVerification } : {}),
       ...(options.taskSignature
         ? { taskSignature: await evaluateTaskSignature({
             signature: options.taskSignature,

--- a/src/orchestration/plan-executor.ts
+++ b/src/orchestration/plan-executor.ts
@@ -42,8 +42,12 @@ function buildSnapshotEvalContext(snapshot: SnapshotInput): EvalContext {
   return {
     async url() { return snapshot.url ?? ''; },
     async domText(selector) {
-      if (domTextBySelector) return domTextBySelector[selector ?? 'body'] ?? domTextBySelector.body ?? null;
-      return bodyText ?? null;
+      if (!domTextBySelector) return bodyText ?? null;
+      const requestedSelector = selector ?? 'body';
+      if (requestedSelector === 'body') return domTextBySelector.body ?? null;
+      return Object.prototype.hasOwnProperty.call(domTextBySelector, requestedSelector)
+        ? domTextBySelector[requestedSelector] ?? null
+        : null;
     },
     async domCount(selector) { return snapshot.dom_count?.[selector] ?? 0; },
     async networkSince() { return snapshot.network ?? []; },
@@ -397,7 +401,11 @@ export class PlanExecutor {
           Object.assign(params, recovered.params);
           continue;
         }
-        // No handler for empty — treat as non-fatal, just skip storing
+        // Compatibility/fail-safe (#1031): pre-existing cached plans treated an
+        // empty, non-error tool result as a completed step unless the plan
+        // explicitly supplied `stepN_empty_result` recovery. Keep that contract
+        // for optional observe/poll steps, but still run parseResult below so
+        // empty values are visible to successCriteria/finalVerification gates.
       }
 
       // f. Parse and store result if requested

--- a/src/types/plan-cache.ts
+++ b/src/types/plan-cache.ts
@@ -6,6 +6,7 @@
  */
 
 import type { BrowserTaskSignature, TaskSignatureStatus } from '../contracts/task-signature';
+import type { Assertion, Evidence } from '../contracts/types';
 
 /** A single step in a compiled plan */
 export interface CompiledStep {
@@ -49,6 +50,25 @@ export interface PlanSuccessCriteria {
   customCheck?: string;
 }
 
+export interface FinalVerificationGate {
+  /** Inline Outcome Contract assertions evaluated after successCriteria. */
+  finalAssertions: Assertion[];
+  /** Params key containing an oc_assert-compatible evidence.snapshot object. Default: finalSnapshot. */
+  snapshotParam?: string;
+  /** Maximum age in ms for snapshot.captured_at / timestamp when present. */
+  freshnessMs?: number;
+  /** Evidence kinds requested by caller. Currently supports bounded snapshot evidence only. */
+  requiredEvidence?: Array<'dom' | 'url' | 'network' | 'screenshot' | 'phash'>;
+}
+
+export interface PlanFinalVerificationResult {
+  passed: boolean;
+  snapshotParam: string;
+  assertions: Array<{ index: number; passed: boolean; evidence: Evidence }>;
+  failedAssertion?: { index: number; assertion: Assertion; evidence: Evidence };
+  error?: string;
+}
+
 /** Task pattern for matching incoming tasks to cached plans */
 export interface TaskPattern {
   /** URL regex pattern (e.g. "https://x\\.com/.*") */
@@ -80,6 +100,8 @@ export interface CompiledPlan {
   errorHandlers: PlanErrorHandler[];
   /** Success validation criteria */
   successCriteria: PlanSuccessCriteria;
+  /** Optional final Outcome Contract verification gate (#1031). */
+  finalVerification?: FinalVerificationGate;
 }
 
 /** Registry entry for a plan with usage statistics */
@@ -134,4 +156,6 @@ export interface PlanExecutionResult {
   totalSteps: number;
   /** Present only when execution was bound to a BrowserTaskSignature. */
   taskSignature?: TaskSignatureStatus;
+  /** Present when a plan opted into final verification. */
+  finalVerification?: PlanFinalVerificationResult;
 }

--- a/tests/orchestration/plan-cache.test.ts
+++ b/tests/orchestration/plan-cache.test.ts
@@ -841,3 +841,65 @@ describe('PlanExecutor task signatures', () => {
     });
   });
 });
+
+describe('PlanExecutor final verification gate', () => {
+  const SESSION_ID = 'test-session-001';
+  const handler: ToolHandler = jest.fn(async () => makeMCPResult(JSON.stringify({
+    url: 'https://example.com/done',
+    dom_text: { body: 'Done', '#status': 'Done' },
+    captured_at: Date.now(),
+  })));
+  const resolver = (toolName: string): ToolHandler | null => toolName === 'snapshot_tool' ? handler : null;
+
+  function planWithFinalAssertion(contains: string, extra: Partial<CompiledPlan['finalVerification']> = {}): CompiledPlan {
+    return buildPlan({
+      id: 'final-verification-plan',
+      steps: [buildStep({
+        order: 1,
+        tool: 'snapshot_tool',
+        args: {},
+        parseResult: { format: 'json', storeAs: 'finalSnapshot' },
+      })],
+      successCriteria: {},
+      finalVerification: {
+        finalAssertions: [{ kind: 'dom_text', selector: '#status', contains }],
+        snapshotParam: 'finalSnapshot',
+        ...extra,
+      },
+    });
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('passes when final assertion matches stored snapshot', async () => {
+    const executor = new PlanExecutor(resolver);
+    const result = await executor.execute(planWithFinalAssertion('Done'), SESSION_ID, {});
+
+    expect(result.success).toBe(true);
+    expect(result.finalVerification?.passed).toBe(true);
+    expect(result.finalVerification?.assertions[0].passed).toBe(true);
+  });
+
+  test('fails when final assertion does not match stored snapshot', async () => {
+    const executor = new PlanExecutor(resolver);
+    const result = await executor.execute(planWithFinalAssertion('Missing'), SESSION_ID, {});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Final verification failed');
+    expect(result.finalVerification?.failedAssertion?.index).toBe(0);
+  });
+
+  test('fails clearly when requested evidence kind is unsupported', async () => {
+    const executor = new PlanExecutor(resolver);
+    const result = await executor.execute(
+      planWithFinalAssertion('Done', { requiredEvidence: ['phash'] }),
+      SESSION_ID,
+      {},
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('unsupported finalVerification.requiredEvidence');
+  });
+});

--- a/tests/orchestration/plan-cache.test.ts
+++ b/tests/orchestration/plan-cache.test.ts
@@ -891,6 +891,24 @@ describe('PlanExecutor final verification gate', () => {
     expect(result.finalVerification?.failedAssertion?.index).toBe(0);
   });
 
+  test('does not fall back to body text for selector-specific final assertions', async () => {
+    const selectorMissingHandler: ToolHandler = jest.fn(async () => makeMCPResult(JSON.stringify({
+      url: 'https://example.com/done',
+      dom_text: { body: 'Done' },
+      captured_at: Date.now(),
+    })));
+    const selectorMissingResolver = (toolName: string): ToolHandler | null => (
+      toolName === 'snapshot_tool' ? selectorMissingHandler : null
+    );
+    const executor = new PlanExecutor(selectorMissingResolver);
+
+    const result = await executor.execute(planWithFinalAssertion('Done'), SESSION_ID, {});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Final verification failed');
+    expect(result.finalVerification?.failedAssertion?.index).toBe(0);
+  });
+
   test('fails clearly when requested evidence kind is unsupported', async () => {
     const executor = new PlanExecutor(resolver);
     const result = await executor.execute(


### PR DESCRIPTION
## Summary
- adds an opt-in `finalVerification` gate to compiled plans so `execute_plan` can evaluate final Outcome Contract assertions before reporting success
- supports caller-provided bounded snapshot evidence via `finalSnapshot` (or a custom `snapshotParam`) and reports structured pass/fail evidence
- adds regression coverage for passing assertions, failed final assertions, and unsupported evidence requests

## Scope
Partially fixes #1031 by adding the deterministic final gate contract and execution behavior. This PR does not yet capture live browser evidence inside `PlanExecutor`; callers must pass the final snapshot param.

## Verification
- `git diff --check`
- `npm test -- tests/orchestration/plan-cache.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`

## Not tested
- Real OpenChrome MCP server e2e
- Screenshot/phash evidence bundle capture
