### PR TITLE
feat(harness): add task drift ledger guard (#1057)

### DIFF
--- a/docs/reliability/task-drift-ledger.md
+++ b/docs/reliability/task-drift-ledger.md
@@ -1,0 +1,27 @@
+# Task drift ledger
+
+OpenChrome can keep an opt-in, bounded task drift ledger for long-running browser work. Enable runtime hint recording with `OPENCHROME_TASK_LEDGER=1`.
+
+The ledger is not a planner and does not call a model. It records compact session/tab-scoped tool outcomes so existing hints can tell the host when repeated attempts are drifting instead of making progress.
+
+## Contract
+
+Each ledger row contains:
+
+- `sessionId` and optional `tabId`
+- bounded `recentAttempts` with `toolName`, optional `action`/`target`, `outcome`, `reason`, and timestamp
+- bounded `triedRecoveries` for Ralph/strategy attempts
+- `driftSignals` such as `repeated_action`, `same_error`, `observation_loop`, `auth_loop`, `stale_ref_loop`, `timeout_loop`, and `visual_ambiguity`
+- optional `suggestedNextStep` and `stopCondition`
+
+Default responses are unchanged unless `OPENCHROME_TASK_LEDGER=1` is set and drift is detected. Debug output is explicit:
+
+```json
+{"includeLedger": true}
+```
+
+with `workflow_status` returns compact `taskLedger` rows for the current MCP session.
+
+## Cleanup
+
+The in-memory ledger is removed on `session:deleted` and per-tab rows are removed on `session:target-closed` / `session:target-removed`.

--- a/src/harness/task-ledger.ts
+++ b/src/harness/task-ledger.ts
@@ -1,0 +1,269 @@
+import type { ToolCallEvent } from '../dashboard/types';
+import { NON_PROGRESS_SIGNALS } from '../hints/progress-tracker';
+
+export type TaskLedgerAttemptOutcome = 'progress' | 'non_progress' | 'error' | 'blocked';
+export type TaskLedgerDriftSignal =
+  | 'repeated_action'
+  | 'same_error'
+  | 'auth_loop'
+  | 'stale_ref_loop'
+  | 'visual_ambiguity'
+  | 'timeout_loop'
+  | 'observation_loop';
+
+export interface TaskLedgerAttempt {
+  toolName: string;
+  action?: string;
+  target?: string;
+  outcome: TaskLedgerAttemptOutcome;
+  reason?: string;
+  at: number;
+}
+
+export interface TaskLedgerRecovery {
+  strategy: string;
+  outcome: string;
+  at: number;
+}
+
+export interface TaskLedger {
+  version: 1;
+  sessionId: string;
+  tabId?: string;
+  objective?: string;
+  startedAt: number;
+  updatedAt: number;
+  lastMeaningfulProgress?: {
+    toolName: string;
+    summary: string;
+    at: number;
+  };
+  recentAttempts: TaskLedgerAttempt[];
+  triedRecoveries: TaskLedgerRecovery[];
+  driftSignals: TaskLedgerDriftSignal[];
+  suggestedNextStep?: {
+    tool: string;
+    reason: string;
+  };
+  stopCondition?: string;
+}
+
+export interface TaskLedgerUpdateInput {
+  sessionId: string;
+  tabId?: string;
+  objective?: string;
+  toolName: string;
+  args?: Record<string, unknown>;
+  resultText: string;
+  isError: boolean;
+  recentCalls?: ToolCallEvent[];
+  now?: number;
+}
+
+const MAX_ATTEMPTS = 12;
+const MAX_RECOVERIES = 8;
+const OBSERVATION_TOOLS = new Set(['read_page', 'tabs_context', 'oc_progress_status', 'workflow_status']);
+const ERROR_FINGERPRINT_RE = /(?:error|failed|timeout|timed out|not found|stale|captcha|auth|forbidden|blocked)[^\n.]*/i;
+
+function isObservation(toolName: string, args?: Record<string, unknown>): boolean {
+  if (OBSERVATION_TOOLS.has(toolName)) return true;
+  return toolName === 'computer' && args?.action === 'screenshot';
+}
+
+function normaliseText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+function resultReason(resultText: string, isError: boolean): string | undefined {
+  const text = normaliseText(resultText);
+  if (!text) return isError ? 'empty error response' : undefined;
+  const matchedSignal = NON_PROGRESS_SIGNALS.find(signal => text.toLowerCase().includes(signal.toLowerCase()));
+  if (matchedSignal) return matchedSignal;
+  const errorMatch = text.match(ERROR_FINGERPRINT_RE);
+  if (errorMatch) return errorMatch[0].slice(0, 160);
+  return isError ? text.slice(0, 160) : undefined;
+}
+
+function classifyOutcome(toolName: string, args: Record<string, unknown> | undefined, resultText: string, isError: boolean): TaskLedgerAttemptOutcome {
+  const lower = resultText.toLowerCase();
+  if (/captcha|auth|login|forbidden|access denied|blocked/.test(lower)) return 'blocked';
+  if (isError) return 'error';
+  if (isObservation(toolName, args)) return 'non_progress';
+  if (NON_PROGRESS_SIGNALS.some(signal => lower.includes(signal.toLowerCase()))) return 'non_progress';
+  return 'progress';
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function makeAttempt(input: TaskLedgerUpdateInput): TaskLedgerAttempt {
+  return {
+    toolName: input.toolName,
+    action: readString(input.args?.action),
+    target: readString(input.args?.target) ?? readString(input.args?.selector) ?? readString(input.args?.ref),
+    outcome: classifyOutcome(input.toolName, input.args, input.resultText, input.isError),
+    reason: resultReason(input.resultText, input.isError),
+    at: input.now ?? Date.now(),
+  };
+}
+
+function sameAction(a: TaskLedgerAttempt, b: TaskLedgerAttempt): boolean {
+  return a.toolName === b.toolName && (a.action ?? '') === (b.action ?? '') && (a.target ?? '') === (b.target ?? '');
+}
+
+function sameReason(a: TaskLedgerAttempt, b: TaskLedgerAttempt): boolean {
+  if (!a.reason || !b.reason) return false;
+  return a.reason.toLowerCase() === b.reason.toLowerCase();
+}
+
+function uniqueSignals(signals: TaskLedgerDriftSignal[]): TaskLedgerDriftSignal[] {
+  return Array.from(new Set(signals));
+}
+
+function detectSignals(attempts: TaskLedgerAttempt[]): TaskLedgerDriftSignal[] {
+  const signals: TaskLedgerDriftSignal[] = [];
+  const last = attempts.slice(-6);
+  const actionable = last.filter(a => !isObservation(a.toolName, { action: a.action }) && a.outcome !== 'progress');
+  if (actionable.length >= 3) {
+    const tail = actionable.slice(-3);
+    if (tail.every(a => sameAction(a, tail[0]))) signals.push('repeated_action');
+    if (tail.every(a => sameReason(a, tail[0]))) signals.push('same_error');
+  }
+
+  const nonProgressSeen = last.some(a => a.outcome === 'error' || a.outcome === 'non_progress' || a.outcome === 'blocked');
+  const observationCount = last.filter(a => isObservation(a.toolName, { action: a.action })).length;
+  if (nonProgressSeen && observationCount >= 2 && actionable.length >= 1) signals.push('observation_loop');
+
+  const reasons = last.map(a => a.reason ?? '').join(' ').toLowerCase();
+  if (/auth|login|captcha/.test(reasons) && last.length >= 2) signals.push('auth_loop');
+  if (/stale|no longer available/.test(reasons) && last.filter(a => /stale|no longer available/i.test(a.reason ?? '')).length >= 2) signals.push('stale_ref_loop');
+  if (/timeout|timed out|navigation timeout/.test(reasons) && last.filter(a => /timeout|timed out/i.test(a.reason ?? '')).length >= 2) signals.push('timeout_loop');
+  if (/visual|ambiguous|no significant visual change/.test(reasons)) signals.push('visual_ambiguity');
+  return uniqueSignals(signals);
+}
+
+function suggestionFor(signals: TaskLedgerDriftSignal[]): TaskLedger['suggestedNextStep'] | undefined {
+  if (signals.includes('auth_loop')) return { tool: 'handoff', reason: 'Authentication or CAPTCHA loop detected; request user assistance or a valid session.' };
+  if (signals.includes('stale_ref_loop')) return { tool: 'read_page', reason: 'Refresh page state and reacquire refs before another interaction.' };
+  if (signals.includes('repeated_action')) return { tool: 'read_page', reason: 'Stop repeating the same action; inspect current state and choose a different target or strategy.' };
+  if (signals.includes('observation_loop')) return { tool: 'interact', reason: 'Observation-only calls did not reset drift; make a different state-changing attempt or change strategy.' };
+  if (signals.includes('timeout_loop')) return { tool: 'oc_progress_status', reason: 'Timeout loop detected; check progress and reduce the task or wait condition.' };
+  if (signals.includes('visual_ambiguity')) return { tool: 'vision_find', reason: 'Visual ambiguity detected; use a visual grounding fallback before another blind action.' };
+  if (signals.includes('same_error')) return { tool: 'oc_progress_status', reason: 'Same error is repeating; inspect drift state and change recovery strategy.' };
+  return undefined;
+}
+
+export class TaskDriftLedgerStore {
+  private ledgers = new Map<string, TaskLedger>();
+
+  updateFromToolResult(input: TaskLedgerUpdateInput): TaskLedger {
+    const now = input.now ?? Date.now();
+    const key = this.key(input.sessionId, input.tabId ?? readString(input.args?.tabId));
+    let ledger = this.ledgers.get(key);
+    if (!ledger) {
+      ledger = {
+        version: 1,
+        sessionId: input.sessionId,
+        tabId: input.tabId ?? readString(input.args?.tabId),
+        objective: input.objective,
+        startedAt: now,
+        updatedAt: now,
+        recentAttempts: [],
+        triedRecoveries: [],
+        driftSignals: [],
+      };
+      this.ledgers.set(key, ledger);
+    }
+
+    const attempt = makeAttempt({ ...input, now });
+    ledger.updatedAt = now;
+    ledger.objective = input.objective ?? ledger.objective;
+    ledger.recentAttempts.push(attempt);
+    if (ledger.recentAttempts.length > MAX_ATTEMPTS) ledger.recentAttempts.splice(0, ledger.recentAttempts.length - MAX_ATTEMPTS);
+
+    if (attempt.outcome === 'progress' && !isObservation(attempt.toolName, { action: attempt.action })) {
+      ledger.lastMeaningfulProgress = {
+        toolName: attempt.toolName,
+        summary: normaliseText(input.resultText).slice(0, 180),
+        at: now,
+      };
+      ledger.stopCondition = undefined;
+    }
+
+    ledger.driftSignals = detectSignals(ledger.recentAttempts);
+    ledger.suggestedNextStep = suggestionFor(ledger.driftSignals);
+    if (ledger.driftSignals.length >= 2 || ledger.recentAttempts.slice(-5).every(a => a.outcome !== 'progress')) {
+      ledger.stopCondition = 'Change strategy before continuing; recent attempts show task drift.';
+    }
+    return ledger;
+  }
+
+  recordRecovery(sessionId: string, recovery: Omit<TaskLedgerRecovery, 'at'> & { at?: number }, tabId?: string): TaskLedger {
+    const now = recovery.at ?? Date.now();
+    const key = this.key(sessionId, tabId);
+    let ledger = this.ledgers.get(key);
+    if (!ledger) {
+      ledger = { version: 1, sessionId, tabId, startedAt: now, updatedAt: now, recentAttempts: [], triedRecoveries: [], driftSignals: [] };
+      this.ledgers.set(key, ledger);
+    }
+    ledger.updatedAt = now;
+    ledger.triedRecoveries.push({ strategy: recovery.strategy, outcome: recovery.outcome, at: now });
+    if (ledger.triedRecoveries.length > MAX_RECOVERIES) ledger.triedRecoveries.splice(0, ledger.triedRecoveries.length - MAX_RECOVERIES);
+    return ledger;
+  }
+
+  buildHint(ledger: TaskLedger): string | null {
+    if (ledger.driftSignals.length === 0) return null;
+    const recent = ledger.recentAttempts.slice(-3).map(a => `${a.toolName}${a.target ? `(${a.target})` : ''}:${a.outcome}`).join(', ');
+    const suggestion = ledger.suggestedNextStep ? ` Suggested next: ${ledger.suggestedNextStep.tool} — ${ledger.suggestedNextStep.reason}` : '';
+    return `Task ledger drift detected (${ledger.driftSignals.join(', ')}). Recent attempts: ${recent}.${suggestion}`;
+  }
+
+  snapshot(sessionId?: string): TaskLedger[] {
+    const rows = Array.from(this.ledgers.values());
+    return (sessionId ? rows.filter(row => row.sessionId === sessionId) : rows)
+      .map(row => ({ ...row, recentAttempts: row.recentAttempts.slice(-MAX_ATTEMPTS), triedRecoveries: row.triedRecoveries.slice(-MAX_RECOVERIES) }));
+  }
+
+  cleanupSession(sessionId: string): number {
+    let removed = 0;
+    for (const [key, ledger] of this.ledgers) {
+      if (ledger.sessionId === sessionId) {
+        this.ledgers.delete(key);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
+  cleanupTab(sessionId: string, tabId: string): boolean {
+    return this.ledgers.delete(this.key(sessionId, tabId));
+  }
+
+  clear(): void {
+    this.ledgers.clear();
+  }
+
+  private key(sessionId: string, tabId?: string): string {
+    return `${sessionId}\u0000${tabId ?? '*'}`;
+  }
+}
+
+let singleton: TaskDriftLedgerStore | null = null;
+let forcedEnabled = false;
+
+export function isTaskDriftLedgerEnabled(): boolean {
+  const env = process.env.OPENCHROME_TASK_LEDGER;
+  return forcedEnabled || env === '1' || env === 'true' || env === 'yes';
+}
+
+export function getTaskDriftLedger(): TaskDriftLedgerStore {
+  if (!singleton) singleton = new TaskDriftLedgerStore();
+  return singleton;
+}
+
+export function setTaskDriftLedger(store: TaskDriftLedgerStore): void {
+  singleton = store;
+  forcedEnabled = true;
+}

--- a/src/hints/hint-engine.ts
+++ b/src/hints/hint-engine.ts
@@ -34,6 +34,12 @@ import {
   mapHintRuleToRecoveryCategory,
   RecoveryFeedbackWriter,
 } from '../core/trace/recovery-feedback';
+import {
+  getTaskDriftLedger,
+  isTaskDriftLedgerEnabled,
+  type TaskDriftLedgerStore,
+  type TaskLedger,
+} from '../harness/task-ledger';
 
 export interface HintContext {
   toolName: string;
@@ -92,6 +98,7 @@ export class HintEngine {
   private learner: PatternLearner;
   private progressTracker: ProgressTracker;
   private repeatedCallDetector: RepeatedCallDetector;
+  private taskLedger: TaskDriftLedgerStore;
   private logFilePath: string | null = null;
   /** Session IDs for which tools/list has been served — suppresses rules tagged redundant_with_description */
   private toolsListServedSessions: Set<string> = new Set();
@@ -109,6 +116,7 @@ export class HintEngine {
     this.activityTracker = activityTracker;
     this.progressTracker = progressTracker ?? new ProgressTracker();
     this.repeatedCallDetector = repeatedCallDetector ?? new RepeatedCallDetector();
+    this.taskLedger = getTaskDriftLedger();
     this.learner = new PatternLearner();
 
     // Collect all rules and sort by priority (ascending = highest priority first)
@@ -208,6 +216,18 @@ export class HintEngine {
     // for individual rules is intentionally frozen during stuck/stalling phases —
     // we don't want to spuriously reset escalating rule fire counts while the
     // agent is not making progress.
+    const ledger = isTaskDriftLedgerEnabled()
+      ? this.taskLedger.updateFromToolResult({
+          sessionId: hintSessionId,
+          tabId: typeof currentArgs?.tabId === 'string' ? currentArgs.tabId : undefined,
+          toolName,
+          args: currentArgs,
+          resultText,
+          isError,
+          recentCalls,
+        })
+      : null;
+    const ledgerHint = ledger ? this.formatLedgerHint(ledger) : null;
     const status = this.progressTracker.evaluate(recentCalls, toolName, resultText, isError);
 
     // Scope escalation keys by sessionId when available to prevent cross-session pollution
@@ -220,7 +240,8 @@ export class HintEngine {
       this.hintEscalation.set(key, fireCount);
       const rawHintText = 'STOP — you are stuck. The last several tool calls made no meaningful progress ' +
         '(errors, stale refs, auth redirects, or timeouts). ' +
-        'Step back and try a completely different approach, or ask the user for help.';
+        'Step back and try a completely different approach, or ask the user for help.' +
+        (ledgerHint ? ` ${ledgerHint}` : '');
       const severity = fireCount >= 2 ? 'critical' as const : 'warning' as const;
       this.log({ timestamp: Date.now(), toolName, isError, matchedRule: 'progress-tracker-stuck', hint: rawHintText, severity, fireCount });
       this.recordRecoveryFeedback('progress-tracker-stuck', rawHintText, severity, fireCount, toolName, resultText, isError, hintSessionId, recentCalls);
@@ -238,7 +259,8 @@ export class HintEngine {
       const fireCount = (this.hintEscalation.get(key) || 0) + 1;
       this.hintEscalation.set(key, fireCount);
       const rawHintText = 'Warning: recent tool calls are not making progress. ' +
-        'Consider trying a different approach before getting stuck.';
+        'Consider trying a different approach before getting stuck.' +
+        (ledgerHint ? ` ${ledgerHint}` : '');
       const severity = this.getSeverity(fireCount);
       this.log({ timestamp: Date.now(), toolName, isError, matchedRule: 'progress-tracker-stalling', hint: rawHintText, severity, fireCount });
       this.recordRecoveryFeedback('progress-tracker-stalling', rawHintText, severity, fireCount, toolName, resultText, isError, hintSessionId, recentCalls);
@@ -315,6 +337,23 @@ export class HintEngine {
           rawHint: repeated.hint,
         };
       }
+    }
+
+    if (!rawHint && ledger && ledgerHint) {
+      const key = escalationKey('task-ledger-drift');
+      const fireCount = (this.hintEscalation.get(key) || 0) + 1;
+      this.hintEscalation.set(key, fireCount);
+      const severity = fireCount >= 2 || ledger.stopCondition ? 'warning' as const : 'info' as const;
+      this.log({ timestamp: Date.now(), toolName, isError, matchedRule: 'task-ledger-drift', hint: ledgerHint, severity, fireCount });
+      this.recordRecoveryFeedback('task-ledger-drift', ledgerHint, severity, fireCount, toolName, resultText, isError, hintSessionId, recentCalls);
+      return {
+        severity,
+        rule: 'task-ledger-drift',
+        fireCount,
+        hint: this.formatHintMessage(severity, ledgerHint, fireCount),
+        rawHint: ledgerHint,
+        ...(ledger.suggestedNextStep && { suggestion: ledger.suggestedNextStep }),
+      };
     }
 
     if (!rawHint) {
@@ -426,6 +465,10 @@ export class HintEngine {
       },
       traceRefs: [],
     });
+  }
+
+  private formatLedgerHint(ledger: TaskLedger): string | null {
+    return this.taskLedger.buildHint(ledger);
   }
 
   private getSeverity(fireCount: number, maxSeverity?: HintSeverity): HintSeverity {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -29,6 +29,7 @@ import {
 } from './resources/skill-graph';
 import { HintEngine } from './hints';
 import { buildAutomationInsight, formatAutomationFallback, shouldInjectAutomationFallback } from './hints/result-guidance';
+import { getTaskDriftLedger } from './harness/task-ledger';
 import { validateToolSchema } from './utils/schema-validator';
 import { formatAge } from './utils/format-age';
 import { formatError } from './utils/format-error';
@@ -459,6 +460,9 @@ export class MCPServer {
       this.sessionManager.addEventListener((event) => {
         if (event.type === 'session:deleted') {
           this.sessionTenants.delete(event.sessionId);
+          getTaskDriftLedger().cleanupSession(event.sessionId);
+        } else if ((event.type === 'session:target-closed' || event.type === 'session:target-removed') && event.sessionId && event.targetId) {
+          getTaskDriftLedger().cleanupTab(event.sessionId, event.targetId);
         }
       });
     }

--- a/src/tools/orchestration.ts
+++ b/src/tools/orchestration.ts
@@ -13,6 +13,7 @@ import { getPlanRegistry } from '../orchestration/plan-registry';
 import { PlanExecutor } from '../orchestration/plan-executor';
 import { formatError } from '../utils/format-error';
 import { validateBrowserTaskSignature } from '../contracts/task-signature';
+import { getTaskDriftLedger } from '../harness/task-ledger';
 
 const dnsResolve = promisify(dns.resolve);
 
@@ -224,6 +225,10 @@ const workflowStatusDefinition: MCPToolDefinition = {
         type: 'boolean',
         description: 'Include worker scratchpad details. Default: false',
       },
+      includeLedger: {
+        type: 'boolean',
+        description: 'Include compact task drift ledger diagnostics. Default: false',
+      },
     },
     required: [],
   },
@@ -231,20 +236,25 @@ const workflowStatusDefinition: MCPToolDefinition = {
 };
 
 const workflowStatusHandler: ToolHandler = async (
-  _sessionId: string,
+  sessionId: string,
   args: Record<string, unknown>
 ): Promise<MCPResult> => {
   const engine = getWorkflowEngine();
   const includeWorkerDetails = args.includeWorkerDetails as boolean ?? false;
+  const includeLedger = args.includeLedger as boolean ?? false;
 
   try {
     const orch = await engine.getOrchestrationStatus();
     if (!orch) {
+      const noWorkflow: Record<string, unknown> = { status: 'NO_WORKFLOW', message: 'No active workflow found' };
+      if (includeLedger) {
+        noWorkflow.taskLedger = getTaskDriftLedger().snapshot(sessionId);
+      }
       return {
         content: [
           {
             type: 'text',
-            text: JSON.stringify({ status: 'NO_WORKFLOW', message: 'No active workflow found' }),
+            text: JSON.stringify(noWorkflow),
           },
         ],
       };
@@ -270,6 +280,10 @@ const workflowStatusHandler: ToolHandler = async (
         extractedData: w.extractedData,
         errors: w.errors,
       }));
+    }
+
+    if (includeLedger) {
+      result.taskLedger = getTaskDriftLedger().snapshot(sessionId);
     }
 
     return {

--- a/tests/harness/task-ledger.test.ts
+++ b/tests/harness/task-ledger.test.ts
@@ -1,0 +1,88 @@
+import { ActivityTracker } from '../../src/dashboard/activity-tracker';
+import { HintEngine } from '../../src/hints/hint-engine';
+import { TaskDriftLedgerStore, setTaskDriftLedger } from '../../src/harness/task-ledger';
+
+function result(text: string) {
+  return { content: [{ type: 'text', text }] };
+}
+
+describe('TaskDriftLedgerStore', () => {
+  let store: TaskDriftLedgerStore;
+
+  beforeEach(() => {
+    store = new TaskDriftLedgerStore();
+    setTaskDriftLedger(store);
+  });
+
+  test('records bounded attempts and detects repeated action drift', () => {
+    for (let i = 0; i < 16; i++) {
+      store.updateFromToolResult({
+        sessionId: 's1',
+        tabId: 't1',
+        toolName: 'interact',
+        args: { tabId: 't1', action: 'click', target: 'Checkout' },
+        resultText: 'Error: element not found',
+        isError: true,
+        now: 1000 + i,
+      });
+    }
+
+    const [ledger] = store.snapshot('s1');
+    expect(ledger.recentAttempts).toHaveLength(12);
+    expect(ledger.driftSignals).toContain('repeated_action');
+    expect(ledger.driftSignals).toContain('same_error');
+    expect(ledger.suggestedNextStep?.reason).toContain('same action');
+  });
+
+  test('read-only observations do not reset prior non-progress drift', () => {
+    store.updateFromToolResult({ sessionId: 's1', tabId: 't1', toolName: 'interact', args: { tabId: 't1', action: 'click', target: 'Checkout' }, resultText: 'element not found', isError: true, now: 1 });
+    store.updateFromToolResult({ sessionId: 's1', tabId: 't1', toolName: 'read_page', args: { tabId: 't1' }, resultText: 'page text', isError: false, now: 2 });
+    store.updateFromToolResult({ sessionId: 's1', tabId: 't1', toolName: 'read_page', args: { tabId: 't1' }, resultText: 'page text', isError: false, now: 3 });
+    store.updateFromToolResult({ sessionId: 's1', tabId: 't1', toolName: 'interact', args: { tabId: 't1', action: 'click', target: 'Checkout' }, resultText: 'element not found', isError: true, now: 4 });
+
+    const [ledger] = store.snapshot('s1');
+    expect(ledger.driftSignals).toContain('observation_loop');
+  });
+
+  test('records Ralph recovery attempts and cleans up session/tab state', () => {
+    store.updateFromToolResult({ sessionId: 's1', tabId: 't1', toolName: 'interact', args: { tabId: 't1' }, resultText: 'stale ref', isError: true, now: 1 });
+    store.recordRecovery('s1', { strategy: 'S3_CDP_COORD', outcome: 'failed', at: 2 }, 't1');
+
+    expect(store.snapshot('s1')[0].triedRecoveries).toEqual([{ strategy: 'S3_CDP_COORD', outcome: 'failed', at: 2 }]);
+    expect(store.cleanupTab('s1', 't1')).toBe(true);
+    expect(store.snapshot('s1')).toHaveLength(0);
+
+    store.updateFromToolResult({ sessionId: 's1', tabId: 't2', toolName: 'interact', args: { tabId: 't2' }, resultText: 'timeout', isError: true, now: 3 });
+    expect(store.cleanupSession('s1')).toBe(1);
+    expect(store.snapshot('s1')).toHaveLength(0);
+  });
+});
+
+describe('HintEngine task ledger integration', () => {
+  beforeEach(() => {
+    setTaskDriftLedger(new TaskDriftLedgerStore());
+  });
+
+  test('includes concise ledger-derived hint when repeated action drift is detected', () => {
+    const tracker = new ActivityTracker();
+    const engine = new HintEngine(tracker);
+
+    for (let i = 0; i < 3; i++) {
+      const hint = engine.getHint(
+        'interact',
+        result('Error: element not found'),
+        true,
+        's1',
+        { tabId: 't1', action: 'click', target: 'Checkout' },
+      );
+      if (i < 2) {
+        const callId = tracker.startCall('interact', 's1', { tabId: 't1', action: 'click', target: 'Checkout' });
+        tracker.endCall(callId, 'error', 'element not found');
+      }
+      if (i === 2) {
+        expect(hint?.hint).toContain('Task ledger drift detected');
+        expect(hint?.hint).toContain('repeated_action');
+      }
+    }
+  });
+});

--- a/tests/orchestration/orchestration-tools.test.ts
+++ b/tests/orchestration/orchestration-tools.test.ts
@@ -13,6 +13,7 @@ import { OrchestrationStateManager } from '../../src/orchestration/state-manager
 import { WorkflowEngine } from '../../src/orchestration/workflow-engine';
 import { createMockSessionManager } from '../mocks/orchestration-fixtures';
 import { getResultText, parseResultJSON, isErrorResult } from '../utils/test-helpers';
+import { TaskDriftLedgerStore, setTaskDriftLedger } from '../../src/harness/task-ledger';
 
 // Mock the session manager module
 jest.mock('../../src/session-manager', () => ({
@@ -88,6 +89,7 @@ describe('Orchestration MCP Tools', () => {
   beforeEach(async () => {
     // Create tool handlers map
     toolHandlers = new Map();
+    setTaskDriftLedger(new TaskDriftLedgerStore());
 
     // Create mock server that captures tool registrations
     mockServer = {
@@ -236,6 +238,25 @@ describe('Orchestration MCP Tools', () => {
 
       const data = parseResultJSON<{ status: string }>(result);
       expect(data.status).toBe('NO_WORKFLOW');
+    });
+
+    test('should include compact task ledger only when requested', async () => {
+      const store = new TaskDriftLedgerStore();
+      setTaskDriftLedger(store);
+      store.updateFromToolResult({
+        sessionId: testSessionId,
+        tabId: 'tab-1',
+        toolName: 'interact',
+        args: { tabId: 'tab-1', action: 'click', target: 'Checkout' },
+        resultText: 'element not found',
+        isError: true,
+      });
+
+      const defaultResult = parseResultJSON<{ taskLedger?: unknown }>(await callStatus());
+      expect(defaultResult.taskLedger).toBeUndefined();
+
+      const debugResult = parseResultJSON<{ taskLedger: unknown[] }>(await callStatus({ includeLedger: true }));
+      expect(debugResult.taskLedger).toHaveLength(1);
     });
 
     test('should return current workflow status', async () => {


### PR DESCRIPTION
## Summary
- adds an opt-in session/tab-scoped task drift ledger for bounded recent attempts, recovery attempts, drift signals, suggested next steps, and cleanup
- wires ledger-derived hints into `HintEngine` only when `OPENCHROME_TASK_LEDGER=1` (or tests inject a store), preserving default response size
- exposes compact diagnostics through `workflow_status({ includeLedger: true })` and documents the contract

## Scope
Fixes #1057 for the deterministic harness/hint/debug-output surface. It does not add a planner and does not persist prompts/screenshots.

## Verification
- `npm test -- tests/harness/task-ledger.test.ts tests/hints/hint-engine.test.ts tests/orchestration/orchestration-tools.test.ts --runInBand`
- `npm test -- tests/hints/progress-tracker.test.ts tests/tools/oc-progress-status.test.ts tests/utils/ralph tests/harness/task-ledger.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint:tool-schemas`
- `git diff --check`

## Not tested
- Live OpenChrome MCP browser fixture scenarios under `scripts/verify/omniparser-adoption-F-task-ledger/`
