### PR TITLE
feat(harness): add deterministic task evidence digest (#1036)

### DIFF
--- a/src/core/task-ledger/digest.ts
+++ b/src/core/task-ledger/digest.ts
@@ -129,12 +129,17 @@ function pageStateFrom(meta: TaskMeta, result: unknown): TaskEvidenceDigest['pag
   const args = recordFrom(meta.args_summary);
   const data = recordFrom(result);
   const structured = recordFrom(data.structuredContent);
-  const page = recordFrom(data.page_state) ?? recordFrom(data.pageState) ?? structured;
+  const page = firstNonEmptyRecord(data.page_state, data.pageState, structured);
   const capturedAt = numberField(page.capturedAt) ?? numberField(page.captured_at) ?? meta.ended_at ?? meta.started_at;
+  const tabId = stringField(data.tabId)
+    ?? stringField(data.tab_id)
+    ?? stringField(page.tabId)
+    ?? stringField(page.tab_id)
+    ?? stringField(args.tabId);
   return {
     ...(stringField(data.url) ?? stringField(page.url) ?? stringField(args.url) ? { url: stringField(data.url) ?? stringField(page.url) ?? stringField(args.url) } : {}),
     ...(stringField(data.title) ?? stringField(page.title) ? { title: stringField(data.title) ?? stringField(page.title) } : {}),
-    ...(stringField(data.tabId) ?? stringField(data.tab_id) ?? stringField(args.tabId) ? { tabId: stringField(data.tabId) ?? stringField(data.tab_id) ?? stringField(args.tabId) } : {}),
+    ...(tabId ? { tabId } : {}),
     ...(capturedAt ? { capturedAt } : {}),
   };
 }
@@ -256,6 +261,15 @@ function redactValue(value: unknown): unknown {
   }
   if (typeof value === 'string') return redact(value);
   return value;
+}
+
+
+function firstNonEmptyRecord(...values: unknown[]): Record<string, unknown> {
+  for (const value of values) {
+    const record = recordFrom(value);
+    if (Object.keys(record).length > 0) return record;
+  }
+  return {};
 }
 
 function recordFrom(value: unknown): Record<string, unknown> {

--- a/src/core/task-ledger/digest.ts
+++ b/src/core/task-ledger/digest.ts
@@ -1,0 +1,279 @@
+import * as crypto from 'node:crypto';
+
+import type { TaskEvent, TaskMeta } from './types';
+import type { TaskStore } from './store';
+
+export type TaskEvidenceCategory = 'navigation' | 'observation' | 'interaction' | 'assertion' | 'recovery' | 'checkpoint';
+
+export interface TaskEvidenceDigestEvent {
+  ts: number;
+  tool: string;
+  ok: boolean;
+  category: TaskEvidenceCategory;
+  summary: string;
+  evidence_ref?: string;
+}
+
+export interface TaskEvidenceDigest {
+  task_id: string;
+  updated_at: number;
+  objective: string;
+  phase: string;
+  page_state: {
+    url?: string;
+    title?: string;
+    tabId?: string;
+    capturedAt?: number;
+  };
+  recent_meaningful_events: TaskEvidenceDigestEvent[];
+  latest_assertions?: Array<{ contract_id?: string; passed: boolean; summary: string }>;
+  latest_failures?: Array<{ tool: string; normalized_error: string; suggested_recovery?: string }>;
+  budget_status?: string;
+}
+
+export interface BuildTaskEvidenceDigestOptions {
+  maxEvents?: number;
+  maxSummaryChars?: number;
+}
+
+const DEFAULT_MAX_EVENTS = 20;
+const DEFAULT_MAX_SUMMARY_CHARS = 240;
+const SECRET_KEY_RE = /(password|passwd|secret|token|api[_-]?key|authorization|cookie)/i;
+
+export function buildTaskEvidenceDigest(
+  store: TaskStore,
+  taskId: string,
+  options: BuildTaskEvidenceDigestOptions = {},
+): TaskEvidenceDigest | undefined {
+  const meta = store.readMetaSync(taskId);
+  if (!meta) return undefined;
+  const events = store.readEventsSync(taskId);
+  const result = store.readResultSync(taskId);
+  return digestFromParts(meta, events, result, options);
+}
+
+export function digestFromParts(
+  meta: TaskMeta,
+  events: TaskEvent[],
+  result: unknown,
+  options: BuildTaskEvidenceDigestOptions = {},
+): TaskEvidenceDigest {
+  const maxEvents = options.maxEvents ?? DEFAULT_MAX_EVENTS;
+  const maxSummaryChars = options.maxSummaryChars ?? DEFAULT_MAX_SUMMARY_CHARS;
+  const pageState = pageStateFrom(meta, result);
+  const meaningfulEvents = events
+    .map((event, index) => eventToDigestEvent(meta, event, index, maxSummaryChars))
+    .filter((event): event is TaskEvidenceDigestEvent => event !== null)
+    .slice(-maxEvents);
+
+  const latestAssertions = assertionsFrom(result, maxSummaryChars);
+  const latestFailures = failuresFrom(meta, events, result, maxSummaryChars);
+  const budgetStatus = budgetStatusFrom(result, maxSummaryChars);
+
+  return {
+    task_id: meta.task_id,
+    updated_at: meta.ended_at ?? lastEventTs(events) ?? meta.started_at ?? meta.created_at,
+    objective: objectiveFrom(meta),
+    phase: phaseFrom(meta),
+    page_state: pageState,
+    recent_meaningful_events: meaningfulEvents,
+    ...(latestAssertions.length > 0 ? { latest_assertions: latestAssertions } : {}),
+    ...(latestFailures.length > 0 ? { latest_failures: latestFailures } : {}),
+    ...(budgetStatus ? { budget_status: budgetStatus } : {}),
+  };
+}
+
+function eventToDigestEvent(meta: TaskMeta, event: TaskEvent, index: number, maxSummaryChars: number): TaskEvidenceDigestEvent | null {
+  const data = recordFrom(event.data);
+  const tool = stringField(data.tool) ?? stringField(data.toolName) ?? meta.kind;
+  const ok = event.kind !== 'failed' && event.kind !== 'cancelled' && !booleanField(data.isError);
+  const category = categoryFor(tool, event, data);
+  const rawSummary = stringField(data.summary)
+    ?? stringField(data.message)
+    ?? stringField(data.error)
+    ?? defaultSummary(event, tool, ok);
+  return {
+    ts: event.ts,
+    tool,
+    ok,
+    category,
+    summary: clamp(redact(rawSummary), maxSummaryChars),
+    evidence_ref: evidenceRef(meta.task_id, index, event),
+  };
+}
+
+function defaultSummary(event: TaskEvent, tool: string, ok: boolean): string {
+  if (event.kind === 'started') return `Started ${tool}`;
+  if (event.kind === 'completed') return `Completed ${tool}`;
+  if (event.kind === 'failed') return `${tool} failed`;
+  if (event.kind === 'cancelled') return `${tool} cancelled`;
+  if (event.kind === 'cancel_requested') return `${tool} cancellation requested`;
+  return `${tool} ${ok ? 'event' : 'error'}`;
+}
+
+function categoryFor(tool: string, event: TaskEvent, data: Record<string, unknown>): TaskEvidenceCategory {
+  const explicit = stringField(data.category);
+  if (explicit && ['navigation', 'observation', 'interaction', 'assertion', 'recovery', 'checkpoint'].includes(explicit)) {
+    return explicit as TaskEvidenceCategory;
+  }
+  if (/navigate|goto|crawl|sitemap/i.test(tool)) return 'navigation';
+  if (/read|snapshot|extract|observe|find|context|console|network/i.test(tool)) return 'observation';
+  if (/assert|verify/i.test(tool)) return 'assertion';
+  if (/recover|hint|ralph|handoff/i.test(tool)) return 'recovery';
+  if (/interact|click|fill|type|input|act|computer/i.test(tool)) return 'interaction';
+  if (event.kind === 'progress') return 'checkpoint';
+  return 'checkpoint';
+}
+
+function pageStateFrom(meta: TaskMeta, result: unknown): TaskEvidenceDigest['page_state'] {
+  const args = recordFrom(meta.args_summary);
+  const data = recordFrom(result);
+  const structured = recordFrom(data.structuredContent);
+  const page = recordFrom(data.page_state) ?? recordFrom(data.pageState) ?? structured;
+  const capturedAt = numberField(page.capturedAt) ?? numberField(page.captured_at) ?? meta.ended_at ?? meta.started_at;
+  return {
+    ...(stringField(data.url) ?? stringField(page.url) ?? stringField(args.url) ? { url: stringField(data.url) ?? stringField(page.url) ?? stringField(args.url) } : {}),
+    ...(stringField(data.title) ?? stringField(page.title) ? { title: stringField(data.title) ?? stringField(page.title) } : {}),
+    ...(stringField(data.tabId) ?? stringField(data.tab_id) ?? stringField(args.tabId) ? { tabId: stringField(data.tabId) ?? stringField(data.tab_id) ?? stringField(args.tabId) } : {}),
+    ...(capturedAt ? { capturedAt } : {}),
+  };
+}
+
+function assertionsFrom(
+  result: unknown,
+  maxSummaryChars: number,
+): NonNullable<TaskEvidenceDigest['latest_assertions']> {
+  const data = recordFrom(result);
+  const candidates = arrayField(data.assertions) ?? arrayField(data.latest_assertions) ?? arrayField(recordFrom(data.structuredContent).assertions);
+  if (!candidates) return [];
+  return candidates.slice(-10).map((item) => {
+    const row = recordFrom(item);
+    const summary = stringField(row.summary) ?? stringField(row.message) ?? JSON.stringify(redactValue(row));
+    return {
+      ...(stringField(row.contract_id) ?? stringField(row.contractId) ? { contract_id: stringField(row.contract_id) ?? stringField(row.contractId) } : {}),
+      passed: booleanField(row.passed) ?? booleanField(row.ok) ?? false,
+      summary: clamp(redact(summary), maxSummaryChars),
+    };
+  });
+}
+
+function failuresFrom(
+  meta: TaskMeta,
+  events: TaskEvent[],
+  result: unknown,
+  maxSummaryChars: number,
+): NonNullable<TaskEvidenceDigest['latest_failures']> {
+  const failures: NonNullable<TaskEvidenceDigest['latest_failures']> = [];
+  if (meta.error?.message) {
+    failures.push({ tool: meta.kind, normalized_error: clamp(redact(meta.error.message), maxSummaryChars), suggested_recovery: recoveryFor(meta.error.message) });
+  }
+  for (const event of events.slice(-20)) {
+    const data = recordFrom(event.data);
+    const message = stringField(data.error) ?? stringField(recordFrom(data.error).message);
+    if (event.kind === 'failed' && message) {
+      const tool = stringField(data.tool) ?? stringField(data.toolName) ?? meta.kind;
+      failures.push({ tool, normalized_error: clamp(redact(message), maxSummaryChars), suggested_recovery: recoveryFor(message) });
+    }
+  }
+  const data = recordFrom(result);
+  if (booleanField(data.isError) === true) {
+    const text = extractContentText(result) ?? stringField(data.error) ?? 'MCP result marked isError';
+    failures.push({ tool: meta.kind, normalized_error: clamp(redact(text), maxSummaryChars), suggested_recovery: recoveryFor(text) });
+  }
+  return failures.slice(-10);
+}
+
+function budgetStatusFrom(result: unknown, maxSummaryChars: number): string | undefined {
+  const data = recordFrom(result);
+  const raw = stringField(data.budget_status) ?? stringField(data.budgetStatus) ?? stringField(recordFrom(data.structuredContent).budget_status);
+  return raw ? clamp(redact(raw), maxSummaryChars) : undefined;
+}
+
+function objectiveFrom(meta: TaskMeta): string {
+  const args = recordFrom(meta.args_summary);
+  return clamp(redact(stringField(args.objective) ?? stringField(args.task) ?? stringField(args.query) ?? `${meta.kind} task`), 240);
+}
+
+function phaseFrom(meta: TaskMeta): string {
+  if (meta.status === 'PENDING') return 'pending';
+  if (meta.status === 'RUNNING') return 'running';
+  if (meta.status === 'COMPLETED') return 'completed';
+  if (meta.status === 'CANCELLED') return 'cancelled';
+  return 'failed';
+}
+
+function evidenceRef(taskId: string, index: number, event: TaskEvent): string {
+  const hash = crypto.createHash('sha256').update(JSON.stringify(event)).digest('hex').slice(0, 12);
+  return `task://${taskId}/events/${index}#${hash}`;
+}
+
+function recoveryFor(text: string): string | undefined {
+  if (/stale|no longer available/i.test(text)) return 'Refresh page state and reacquire element refs before retrying.';
+  if (/timeout|timed out/i.test(text)) return 'Check progress and narrow the wait condition or task budget.';
+  if (/not found|no match/i.test(text)) return 'Inspect current page state and try a broader selector or semantic query.';
+  if (/auth|login|captcha|forbidden|access denied/i.test(text)) return 'Request user assistance or a valid authenticated session.';
+  return undefined;
+}
+
+function lastEventTs(events: TaskEvent[]): number | undefined {
+  return events.length > 0 ? events[events.length - 1].ts : undefined;
+}
+
+function extractContentText(value: unknown): string | undefined {
+  const data = recordFrom(value);
+  const content = arrayField(data.content);
+  if (!content) return undefined;
+  const text = content
+    .map(item => stringField(recordFrom(item).text))
+    .filter((item): item is string => Boolean(item))
+    .join('\n');
+  return text || undefined;
+}
+
+function clamp(value: string, max: number): string {
+  const text = normalise(value);
+  return text.length > max ? `${text.slice(0, Math.max(0, max - 1))}…` : text;
+}
+
+function normalise(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function redact(value: string): string {
+  return value
+    .replace(/Bearer\s+[A-Za-z0-9._~+/-]+=*/gi, 'Bearer [redacted]')
+    .replace(/(password|passwd|secret|token|api[_-]?key|authorization|cookie)(["'\s:=]+)([^\s,"'}]+)/gi, '$1$2[redacted]');
+}
+
+function redactValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactValue);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = SECRET_KEY_RE.test(key) ? '[redacted]' : redactValue(child);
+    }
+    return out;
+  }
+  if (typeof value === 'string') return redact(value);
+  return value;
+}
+
+function recordFrom(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function arrayField(value: unknown): unknown[] | undefined {
+  return Array.isArray(value) ? value : undefined;
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function numberField(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function booleanField(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}

--- a/src/core/task-ledger/index.ts
+++ b/src/core/task-ledger/index.ts
@@ -20,6 +20,16 @@ export {
   assertSafeTaskId,
 } from './store';
 export type { TaskStoreOptions } from './store';
+export type {
+  BuildTaskEvidenceDigestOptions,
+  TaskEvidenceCategory,
+  TaskEvidenceDigest,
+  TaskEvidenceDigestEvent,
+} from './digest';
+export {
+  buildTaskEvidenceDigest,
+  digestFromParts,
+} from './digest';
 export type { RunInput, RunOutcome } from './runner';
 export {
   runTask,

--- a/src/core/task-ledger/store.ts
+++ b/src/core/task-ledger/store.ts
@@ -299,6 +299,25 @@ export class TaskStore {
     fs.appendFileSync(this.eventsPath(taskId), line, 'utf8');
   }
 
+  readEventsSync(taskId: string): TaskEvent[] {
+    try {
+      assertSafeTaskId(taskId);
+    } catch {
+      return [];
+    }
+    const file = this.eventsPath(taskId);
+    if (!fs.existsSync(file)) return [];
+    try {
+      return fs.readFileSync(file, 'utf8')
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as TaskEvent)
+        .filter((event) => typeof event.ts === 'number' && typeof event.kind === 'string');
+    } catch {
+      return [];
+    }
+  }
+
   /** Persist the tool's terminal result blob. Idempotent. */
   async writeResult(taskId: string, result: unknown): Promise<void> {
     assertSafeTaskId(taskId);

--- a/src/tools/oc-task-get.ts
+++ b/src/tools/oc-task-get.ts
@@ -7,6 +7,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPResult, MCPToolDefinition, ToolContext, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { canAccessTask, getTaskStore, taskAccessDeniedResult, waitForTaskStartupReap } from './oc-task-start';
+import { buildTaskEvidenceDigest } from '../core/task-ledger';
 
 const definition: MCPToolDefinition = {
   name: 'oc_task_get',
@@ -21,6 +22,14 @@ const definition: MCPToolDefinition = {
       include_result: {
         type: 'boolean',
         description: 'When true, also returns the persisted result.json contents.',
+      },
+      includeDigest: {
+        type: 'boolean',
+        description: 'When true, also returns a deterministic bounded task evidence digest.',
+      },
+      include_digest: {
+        type: 'boolean',
+        description: 'Alias for includeDigest.',
       },
     },
     required: ['task_id'],
@@ -47,7 +56,9 @@ const handler: ToolHandler = async (
   }
   if (!canAccessTask(meta, sessionId, context?.principal)) return taskAccessDeniedResult(taskId);
   const includeResult = params.include_result === true;
+  const includeDigest = params.includeDigest === true || params.include_digest === true;
   const result = includeResult ? store.readResultSync(taskId) : undefined;
+  const digest = includeDigest ? buildTaskEvidenceDigest(store, taskId) : undefined;
   return {
     content: [
       {
@@ -57,6 +68,7 @@ const handler: ToolHandler = async (
     ],
     meta,
     ...(includeResult ? { result } : {}),
+    ...(includeDigest ? { digest } : {}),
   };
 };
 

--- a/tests/core/task-ledger/digest.test.ts
+++ b/tests/core/task-ledger/digest.test.ts
@@ -1,0 +1,117 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { TaskStore, buildTaskEvidenceDigest, computeTaskId } from '../../../src/core/task-ledger';
+import type { TaskMeta } from '../../../src/core/task-ledger';
+import { registerOcTaskGetTool } from '../../../src/tools/oc-task-get';
+import { setTaskStoreForTests } from '../../../src/tools/oc-task-start';
+import type { MCPResult, ToolHandler } from '../../../src/types/mcp';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-task-digest-'));
+}
+
+function metaFor(kind = 'navigate', args: Record<string, unknown> = {}): TaskMeta {
+  const created = 1234;
+  return {
+    task_id: computeTaskId(kind, args, created),
+    kind,
+    status: 'COMPLETED',
+    pid: process.pid,
+    created_at: created,
+    started_at: created + 1,
+    ended_at: created + 10,
+    args_summary: args,
+    owner: { session_id: 'sess-1' },
+  };
+}
+
+describe('Task evidence digest', () => {
+  let root: string;
+  let store: TaskStore;
+
+  beforeEach(() => {
+    root = tempRoot();
+    store = new TaskStore({ rootDir: root });
+    setTaskStoreForTests(store);
+  });
+
+  afterEach(() => {
+    setTaskStoreForTests(undefined);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('summarizes navigation, observation, interaction, assertion, failure, and unknown events deterministically', async () => {
+    const meta = metaFor('navigate', { objective: 'Buy test item', url: 'https://example.test/start', tabId: 'tab-a' });
+    await store.create(meta);
+    await store.writeResult(meta.task_id, {
+      url: 'https://example.test/done',
+      title: 'Done',
+      tabId: 'tab-a',
+      assertions: [{ contract_id: 'done-visible', passed: true, summary: 'Done text visible' }],
+      budget_status: 'within budget',
+    });
+    store.appendEvent(meta.task_id, { ts: 1, kind: 'started' });
+    store.appendEvent(meta.task_id, { ts: 2, kind: 'progress', data: { tool: 'navigate', summary: 'navigated to /start' } });
+    store.appendEvent(meta.task_id, { ts: 3, kind: 'progress', data: { tool: 'read_page', summary: 'observed checkout page' } });
+    store.appendEvent(meta.task_id, { ts: 4, kind: 'progress', data: { tool: 'interact', summary: 'clicked submit button' } });
+    store.appendEvent(meta.task_id, { ts: 5, kind: 'progress', data: { tool: 'oc_assert', summary: 'contract passed', category: 'assertion' } });
+    store.appendEvent(meta.task_id, { ts: 6, kind: 'failed', data: { tool: 'interact', error: 'stale ref for @e1' } });
+    store.appendEvent(meta.task_id, { ts: 7, kind: 'progress', data: { tool: 'custom_tool', summary: 'custom checkpoint' } });
+
+    const a = buildTaskEvidenceDigest(store, meta.task_id);
+    const b = buildTaskEvidenceDigest(store, meta.task_id);
+
+    expect(a).toEqual(b);
+    expect(a?.objective).toBe('Buy test item');
+    expect(a?.phase).toBe('completed');
+    expect(a?.page_state).toMatchObject({ url: 'https://example.test/done', title: 'Done', tabId: 'tab-a' });
+    expect(a?.recent_meaningful_events.map(e => e.category)).toEqual([
+      'navigation', 'navigation', 'observation', 'interaction', 'assertion', 'interaction', 'checkpoint',
+    ]);
+    expect(a?.latest_assertions?.[0]).toEqual({ contract_id: 'done-visible', passed: true, summary: 'Done text visible' });
+    expect(a?.latest_failures?.[0].normalized_error).toContain('stale ref');
+    expect(a?.latest_failures?.[0].suggested_recovery).toContain('reacquire');
+    expect(a?.budget_status).toBe('within budget');
+    expect(a?.recent_meaningful_events.every(e => e.evidence_ref?.startsWith(`task://${meta.task_id}/events/`))).toBe(true);
+  });
+
+  test('bounds summaries and redacts credential-bearing fields', async () => {
+    const meta = metaFor('read_page', { objective: 'Inspect token=super-secret-value', url: 'https://example.test' });
+    await store.create(meta);
+    store.appendEvent(meta.task_id, {
+      ts: 1,
+      kind: 'progress',
+      data: {
+        tool: 'read_page',
+        summary: `authorization: Bearer abc.def.ghi ${'x'.repeat(500)}`,
+      },
+    });
+
+    const digest = buildTaskEvidenceDigest(store, meta.task_id, { maxSummaryChars: 80 });
+    const serialized = JSON.stringify(digest);
+
+    expect(serialized).not.toContain('abc.def.ghi');
+    expect(serialized).not.toContain('super-secret-value');
+    expect(digest?.recent_meaningful_events[0].summary.length).toBeLessThanOrEqual(80);
+  });
+
+  test('oc_task_get returns digest only when includeDigest is requested', async () => {
+    const meta = metaFor('navigate', { objective: 'Open page', url: 'https://example.test' });
+    await store.create(meta);
+    store.appendEvent(meta.task_id, { ts: 1, kind: 'completed', data: { tool: 'navigate', summary: 'done' } });
+
+    const handlers = new Map<string, (sessionId: string, args: Record<string, unknown>) => Promise<MCPResult>>();
+    registerOcTaskGetTool({
+      registerTool: (name: string, handler: ToolHandler) => handlers.set(name, handler),
+    } as never);
+    const get = handlers.get('oc_task_get')!;
+
+    const plain = await get('sess-1', { task_id: meta.task_id });
+    expect(plain.digest).toBeUndefined();
+
+    const withDigest = await get('sess-1', { task_id: meta.task_id, includeDigest: true });
+    expect(withDigest.digest).toMatchObject({ task_id: meta.task_id, objective: 'Open page' });
+  });
+});

--- a/tests/core/task-ledger/digest.test.ts
+++ b/tests/core/task-ledger/digest.test.ts
@@ -77,6 +77,39 @@ describe('Task evidence digest', () => {
     expect(a?.recent_meaningful_events.every(e => e.evidence_ref?.startsWith(`task://${meta.task_id}/events/`))).toBe(true);
   });
 
+  test('uses camelCase and structured page-state fallbacks, including nested tab id', async () => {
+    const meta = metaFor('read_page', { objective: 'Inspect page' });
+    await store.create(meta);
+
+    await store.writeResult(meta.task_id, {
+      pageState: {
+        url: 'https://example.test/camel',
+        title: 'Camel',
+        tabId: 'tab-camel',
+        capturedAt: 2222,
+      },
+    });
+    expect(buildTaskEvidenceDigest(store, meta.task_id)?.page_state).toMatchObject({
+      url: 'https://example.test/camel',
+      title: 'Camel',
+      tabId: 'tab-camel',
+      capturedAt: 2222,
+    });
+
+    await store.writeResult(meta.task_id, {
+      structuredContent: {
+        url: 'https://example.test/structured',
+        title: 'Structured',
+        tab_id: 'tab-structured',
+      },
+    });
+    expect(buildTaskEvidenceDigest(store, meta.task_id)?.page_state).toMatchObject({
+      url: 'https://example.test/structured',
+      title: 'Structured',
+      tabId: 'tab-structured',
+    });
+  });
+
   test('bounds summaries and redacts credential-bearing fields', async () => {
     const meta = metaFor('read_page', { objective: 'Inspect token=super-secret-value', url: 'https://example.test' });
     await store.create(meta);


### PR DESCRIPTION
## Summary
- adds a deterministic task evidence digest builder over task meta, events, and persisted result payloads
- exposes `oc_task_get({ task_id, includeDigest: true })` with a stable `digest` field, plus `include_digest` alias
- bounds summaries, redacts credential-shaped content, emits event evidence refs, and covers assertions/failures/budget state where present

## Scope
Fixes #1036 for the task-ledger retrieval surface. This derives digest state from existing task facts; it does not add LLM summarization or new raw evidence storage.

## Verification
- `npm test -- tests/core/task-ledger/digest.test.ts tests/core/task-ledger/store.test.ts tests/core/task-ledger/tools.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint:tool-schemas`
- `git diff --check`

## Not tested
- Live OpenChrome MCP fixture transcript with navigate/read/interact/oc_assert and stale-ref failure
