### PR TITLE
feat(orchestration): add reflection strategy controls (#1014)

### DIFF
--- a/docs/reliability/reflection-strategy.md
+++ b/docs/reliability/reflection-strategy.md
@@ -1,0 +1,10 @@
+# Reflection strategy controls
+
+`execute_plan` accepts an optional `reflectionStrategy` field:
+
+- `none` — no reflection ids and no last-attempt summary.
+- `last_attempt` — response metadata includes a bounded, redacted last-attempt summary when supplied in `params.lastAttemptSummary` / `params.lastAttempt`.
+- `reflection` — response metadata lists at most three matching passive reflection ids from `ReflectionStore`.
+- `last_attempt_and_reflection` — combines both bounded surfaces.
+
+When omitted, `execute_plan` keeps the legacy response shape and does not add reflection metadata. Invalid values return `INVALID_REFLECTION_STRATEGY` rather than throwing. Reflections remain passive metadata; OpenChrome does not execute stored `nextPlan` entries.

--- a/src/orchestration/reflection-strategy.ts
+++ b/src/orchestration/reflection-strategy.ts
@@ -1,0 +1,78 @@
+import { ReflectionStore } from '../reflection';
+
+export type ReflectionStrategy = 'none' | 'last_attempt' | 'reflection' | 'last_attempt_and_reflection';
+
+export interface ReflectionStrategyMetadata {
+  strategy: ReflectionStrategy;
+  reflectionIdsConsidered: string[];
+  noMatchingReflections?: boolean;
+  lastAttemptSummary?: string;
+  limits: { maxReflections: number; maxSummaryChars: number };
+}
+
+const STRATEGIES = new Set<ReflectionStrategy>(['none', 'last_attempt', 'reflection', 'last_attempt_and_reflection']);
+const DEFAULT_MAX_REFLECTIONS = 3;
+const DEFAULT_MAX_SUMMARY_CHARS = 500;
+
+export function parseReflectionStrategy(value: unknown): { ok: true; value: ReflectionStrategy } | { ok: false; error: string } {
+  if (value === undefined || value === null) return { ok: true, value: 'none' };
+  if (typeof value !== 'string' || !STRATEGIES.has(value as ReflectionStrategy)) {
+    return { ok: false, error: `Invalid reflectionStrategy: ${String(value)}. Use none, last_attempt, reflection, or last_attempt_and_reflection.` };
+  }
+  return { ok: true, value: value as ReflectionStrategy };
+}
+
+export function buildLastAttemptSummary(params: Record<string, unknown>, maxChars = DEFAULT_MAX_SUMMARY_CHARS): string | undefined {
+  const raw = params.lastAttemptSummary ?? params.last_attempt_summary ?? params.lastAttempt ?? params.last_attempt;
+  if (raw === undefined) return undefined;
+  const text = typeof raw === 'string' ? raw : JSON.stringify(raw);
+  return bound(redact(text), maxChars);
+}
+
+export function buildReflectionStrategyMetadata(input: {
+  strategy: ReflectionStrategy;
+  planId: string;
+  params: Record<string, unknown>;
+  scope?: { domain?: string; taskFingerprint?: string; contractId?: string };
+  store?: ReflectionStore;
+  maxReflections?: number;
+  maxSummaryChars?: number;
+}): ReflectionStrategyMetadata {
+  const maxReflections = Math.max(0, Math.min(input.maxReflections ?? DEFAULT_MAX_REFLECTIONS, 10));
+  const maxSummaryChars = Math.max(80, Math.min(input.maxSummaryChars ?? DEFAULT_MAX_SUMMARY_CHARS, 2000));
+  const includeLastAttempt = input.strategy === 'last_attempt' || input.strategy === 'last_attempt_and_reflection';
+  const includeReflection = input.strategy === 'reflection' || input.strategy === 'last_attempt_and_reflection';
+  const taskFingerprint = input.scope?.taskFingerprint ?? stringParam(input.params.taskFingerprint) ?? input.planId;
+  const store = input.store ?? new ReflectionStore();
+  const reflections = includeReflection
+    ? store.list({
+        domain: input.scope?.domain,
+        taskFingerprint,
+        contractId: input.scope?.contractId,
+        limit: maxReflections,
+      })
+    : [];
+
+  return {
+    strategy: input.strategy,
+    reflectionIdsConsidered: reflections.map(reflection => reflection.id),
+    ...(includeReflection && reflections.length === 0 ? { noMatchingReflections: true } : {}),
+    ...(includeLastAttempt ? { lastAttemptSummary: buildLastAttemptSummary(input.params, maxSummaryChars) ?? '' } : {}),
+    limits: { maxReflections, maxSummaryChars },
+  };
+}
+
+function stringParam(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function bound(text: string, maxChars: number): string {
+  const normalised = text.replace(/\s+/g, ' ').trim();
+  return normalised.length > maxChars ? `${normalised.slice(0, maxChars - 1)}…` : normalised;
+}
+
+function redact(text: string): string {
+  return text
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [REDACTED]')
+    .replace(/(password|passwd|secret|token|api[_-]?key|authorization|cookie)(["'\s:=]+)([^\s,"'}]+)/gi, '$1$2[REDACTED]');
+}

--- a/src/tools/orchestration.ts
+++ b/src/tools/orchestration.ts
@@ -13,6 +13,10 @@ import { getPlanRegistry } from '../orchestration/plan-registry';
 import { PlanExecutor } from '../orchestration/plan-executor';
 import { formatError } from '../utils/format-error';
 import { validateBrowserTaskSignature } from '../contracts/task-signature';
+import {
+  buildReflectionStrategyMetadata,
+  parseReflectionStrategy,
+} from '../orchestration/reflection-strategy';
 
 const dnsResolve = promisify(dns.resolve);
 
@@ -687,6 +691,17 @@ const executePlanDefinition: MCPToolDefinition = {
         properties: {},
         additionalProperties: true,
       },
+      reflectionStrategy: {
+        type: 'string',
+        enum: ['none', 'last_attempt', 'reflection', 'last_attempt_and_reflection'],
+        description: 'Opt-in bounded reflection metadata strategy. Default omitted path preserves legacy output.',
+      },
+      reflectionScope: {
+        type: 'object',
+        description: 'Optional reflection recall scope: domain, taskFingerprint, contractId.',
+        properties: {},
+        additionalProperties: true,
+      },
     },
     required: ['planId', 'tabId'],
   },
@@ -701,10 +716,19 @@ const executePlanHandler: ToolHandler = async (
   const tabId = args.tabId as string;
   const runtimeParams = (args.params as Record<string, unknown>) || {};
   const rawTaskSignature = args.taskSignature;
+  const rawReflectionStrategy = args.reflectionStrategy;
 
   if (!planId || !tabId) {
     return {
       content: [{ type: 'text', text: 'Error: planId and tabId are required' }],
+      isError: true,
+    };
+  }
+
+  const reflectionStrategyResult = parseReflectionStrategy(rawReflectionStrategy);
+  if (!reflectionStrategyResult.ok) {
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ status: 'INVALID_REFLECTION_STRATEGY', error: reflectionStrategyResult.error }) }],
       isError: true,
     };
   }
@@ -793,6 +817,14 @@ const executePlanHandler: ToolHandler = async (
 
     // Update stats
     registry.updateStats(planId, result.success, result.durationMs);
+    const reflectionStrategy = rawReflectionStrategy === undefined
+      ? undefined
+      : buildReflectionStrategyMetadata({
+          strategy: reflectionStrategyResult.value,
+          planId,
+          params: runtimeParams,
+          scope: args.reflectionScope as { domain?: string; taskFingerprint?: string; contractId?: string } | undefined,
+        });
 
     return {
       content: [{
@@ -806,6 +838,7 @@ const executePlanHandler: ToolHandler = async (
           data: result.data,
           error: result.error,
           ...(result.taskSignature ? { taskSignature: result.taskSignature } : {}),
+          ...(reflectionStrategy ? { reflectionStrategy } : {}),
           message: result.success
             ? `Plan "${planId}" executed successfully in ${result.durationMs}ms (${result.stepsExecuted}/${result.totalSteps} steps)`
             : `Plan "${planId}" failed: ${result.error}. Consider manual execution.`,

--- a/tests/orchestration/reflection-strategy.test.ts
+++ b/tests/orchestration/reflection-strategy.test.ts
@@ -1,0 +1,81 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  buildLastAttemptSummary,
+  buildReflectionStrategyMetadata,
+  parseReflectionStrategy,
+} from '../../src/orchestration/reflection-strategy';
+import { ReflectionStore } from '../../src/reflection';
+
+describe('reflection strategy controls', () => {
+  test('validates all enum values and rejects invalid values deterministically', () => {
+    for (const value of ['none', 'last_attempt', 'reflection', 'last_attempt_and_reflection']) {
+      expect(parseReflectionStrategy(value)).toEqual({ ok: true, value });
+    }
+    const invalid = parseReflectionStrategy('always_on');
+    expect(invalid.ok).toBe(false);
+    if (!invalid.ok) expect(invalid.error).toContain('Invalid reflectionStrategy');
+  });
+
+  test('default omitted strategy parses to none for callers that opt into validation', () => {
+    expect(parseReflectionStrategy(undefined)).toEqual({ ok: true, value: 'none' });
+  });
+
+  test('last_attempt summary is bounded and redacted', () => {
+    const summary = buildLastAttemptSummary({ lastAttempt: `token=abc123 ${'x'.repeat(1000)}` }, 80);
+    expect(summary).not.toContain('abc123');
+    expect(summary?.length).toBeLessThanOrEqual(80);
+  });
+
+  test('last_attempt_and_reflection caps journal summary and reflection ids', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'reflection-strategy-'));
+    try {
+      const store = new ReflectionStore(root);
+      for (let i = 0; i < 5; i++) {
+        await store.create({
+          scope: { taskFingerprint: 'plan-a', domain: 'example.test' },
+          trigger: 'plan_failed',
+          evidence: { lastTools: ['navigate', 'interact'] },
+          diagnosis: `diagnosis ${i}`,
+          confidence: 0.5 + i / 100,
+        });
+      }
+
+      const metadata = buildReflectionStrategyMetadata({
+        strategy: 'last_attempt_and_reflection',
+        planId: 'plan-a',
+        params: { lastAttemptSummary: 'failed click '.repeat(100) },
+        scope: { domain: 'example.test', taskFingerprint: 'plan-a' },
+        store,
+        maxReflections: 3,
+        maxSummaryChars: 120,
+      });
+
+      expect(metadata.strategy).toBe('last_attempt_and_reflection');
+      expect(metadata.reflectionIdsConsidered).toHaveLength(3);
+      expect(metadata.lastAttemptSummary?.length).toBeLessThanOrEqual(120);
+      expect(metadata.limits).toEqual({ maxReflections: 3, maxSummaryChars: 120 });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('reflection strategy reports no matching reflections without throwing', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'reflection-strategy-empty-'));
+    try {
+      const metadata = buildReflectionStrategyMetadata({
+        strategy: 'reflection',
+        planId: 'plan-missing',
+        params: {},
+        store: new ReflectionStore(root),
+      });
+      expect(metadata.reflectionIdsConsidered).toEqual([]);
+      expect(metadata.noMatchingReflections).toBe(true);
+      expect(metadata.lastAttemptSummary).toBeUndefined();
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- adds explicit `ReflectionStrategy` validation for `none`, `last_attempt`, `reflection`, and `last_attempt_and_reflection`
- wires `execute_plan` to include bounded reflection metadata only when `reflectionStrategy` is supplied, preserving omitted/default response shape
- caps/redacts last-attempt summaries and limits passive reflection ids considered from `ReflectionStore`

## Scope
Fixes #1014 for deterministic strategy controls on `execute_plan`. Reflections remain passive metadata; stored `nextPlan` entries are not executed or injected into low-level tools.

## Verification
- `npm test -- tests/orchestration/reflection-strategy.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint:tool-schemas`
- `git diff --check`

## Not tested
- Live OpenChrome e2e with seeded reflection artifact and execute_plan browser fixture
