### PR TITLE
feat(task-run): add bounded critic loop helper (#1006)

### DIFF
--- a/docs/reliability/task-critic-loop.md
+++ b/docs/reliability/task-critic-loop.md
@@ -1,0 +1,26 @@
+# Bounded task critic loop
+
+The task critic loop is an opt-in helper above existing browser tools. It does not change direct `navigate`, `act`, `interact`, or `execute_plan` behavior.
+
+Contract:
+
+1. Run at most `maxAttempts` attempts.
+2. Treat raw tool success as evidence, not task success.
+3. Require a structured critic verdict before retrying or completing.
+4. Stop on `success`, `terminal_failure`, or `needs_user`.
+5. Retry only on `retryable_failure` while budget remains.
+6. Return a compact final result with attempts, verdict, evidence used/missing, and next safe action.
+
+Critic verdict schema:
+
+```ts
+{
+  status: 'success' | 'retryable_failure' | 'terminal_failure' | 'needs_user',
+  reason: string,
+  evidence_used: string[],
+  missing_evidence: string[],
+  next_strategy: string,
+}
+```
+
+Malformed verdicts become terminal failures instead of throwing or looping.

--- a/src/core/task-run/critic-loop.ts
+++ b/src/core/task-run/critic-loop.ts
@@ -33,6 +33,15 @@ export interface CriticLoopResult {
 const STATUSES = new Set<CriticVerdictStatus>(['success', 'retryable_failure', 'terminal_failure', 'needs_user']);
 const DEFAULT_MAX_ATTEMPTS = 3;
 
+function normaliseMaxAttempts(value: number | undefined): number {
+  const raw = typeof value === 'number' && Number.isFinite(value) ? value : DEFAULT_MAX_ATTEMPTS;
+  return Math.max(1, Math.min(Math.floor(raw), 10));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export function validateCriticVerdict(value: unknown): { ok: true; value: CriticVerdict } | { ok: false; error: string } {
   if (!value || typeof value !== 'object') return { ok: false, error: 'critic verdict must be an object' };
   const row = value as Record<string, unknown>;
@@ -59,20 +68,54 @@ export async function runBoundedCriticLoop(input: CriticLoopInput, opts: {
   executeAttempt: (attempt: number, nextStrategy: string) => Promise<{ tool: string; ok: boolean; evidence: Record<string, unknown> }>;
   critique: (attempt: { attempt: number; tool: string; ok: boolean; evidence: Record<string, unknown>; objective: string; successCriteria: string[] }) => Promise<unknown>;
 }): Promise<CriticLoopResult> {
-  const maxAttempts = Math.max(1, Math.min(input.maxAttempts ?? DEFAULT_MAX_ATTEMPTS, 10));
+  const maxAttempts = normaliseMaxAttempts(input.maxAttempts);
   const attempts: CriticAttempt[] = [];
   let nextStrategy = 'initial_attempt';
 
   for (let attemptNo = 1; attemptNo <= maxAttempts; attemptNo++) {
-    const evidence = await opts.executeAttempt(attemptNo, nextStrategy);
-    const rawVerdict = await opts.critique({
-      attempt: attemptNo,
-      tool: evidence.tool,
-      ok: evidence.ok,
-      evidence: evidence.evidence,
-      objective: input.objective,
-      successCriteria: input.successCriteria,
-    });
+    let evidence: { tool: string; ok: boolean; evidence: Record<string, unknown> };
+    try {
+      evidence = await opts.executeAttempt(attemptNo, nextStrategy);
+    } catch (error) {
+      const verdict: CriticVerdict = {
+        status: 'terminal_failure',
+        reason: bound(`executeAttempt failed: ${errorMessage(error)}`, 500),
+        evidence_used: [],
+        missing_evidence: ['attempt_evidence'],
+        next_strategy: 'stop and inspect tool failure',
+      };
+      attempts.push({
+        attempt: attemptNo,
+        tool: 'unknown',
+        ok: false,
+        evidence: { stage: 'executeAttempt', error: errorMessage(error) },
+        verdict,
+      });
+      return { status: verdict.status, attempts, finalVerdict: verdict, nextSafeAction: nextSafeAction(verdict) };
+    }
+
+    let rawVerdict: unknown;
+    try {
+      rawVerdict = await opts.critique({
+        attempt: attemptNo,
+        tool: evidence.tool,
+        ok: evidence.ok,
+        evidence: evidence.evidence,
+        objective: input.objective,
+        successCriteria: input.successCriteria,
+      });
+    } catch (error) {
+      const verdict: CriticVerdict = {
+        status: 'terminal_failure',
+        reason: bound(`critique failed: ${errorMessage(error)}`, 500),
+        evidence_used: [],
+        missing_evidence: ['critic_verdict'],
+        next_strategy: 'fix critic callback before retrying',
+      };
+      attempts.push({ attempt: attemptNo, tool: evidence.tool, ok: evidence.ok, evidence: evidence.evidence, verdict });
+      return { status: verdict.status, attempts, finalVerdict: verdict, nextSafeAction: nextSafeAction(verdict) };
+    }
+
     const parsed = validateCriticVerdict(rawVerdict);
     const verdict: CriticVerdict = parsed.ok
       ? parsed.value

--- a/src/core/task-run/critic-loop.ts
+++ b/src/core/task-run/critic-loop.ts
@@ -1,0 +1,114 @@
+export type CriticVerdictStatus = 'success' | 'retryable_failure' | 'terminal_failure' | 'needs_user';
+
+export interface CriticVerdict {
+  status: CriticVerdictStatus;
+  reason: string;
+  evidence_used: string[];
+  missing_evidence: string[];
+  next_strategy: string;
+}
+
+export interface CriticAttempt {
+  attempt: number;
+  tool: string;
+  ok: boolean;
+  evidence: Record<string, unknown>;
+  verdict: CriticVerdict;
+}
+
+export interface CriticLoopInput {
+  objective: string;
+  successCriteria: string[];
+  maxAttempts?: number;
+  allowedTools?: string[];
+}
+
+export interface CriticLoopResult {
+  status: CriticVerdictStatus | 'max_attempts_exhausted';
+  attempts: CriticAttempt[];
+  finalVerdict: CriticVerdict;
+  nextSafeAction: string;
+}
+
+const STATUSES = new Set<CriticVerdictStatus>(['success', 'retryable_failure', 'terminal_failure', 'needs_user']);
+const DEFAULT_MAX_ATTEMPTS = 3;
+
+export function validateCriticVerdict(value: unknown): { ok: true; value: CriticVerdict } | { ok: false; error: string } {
+  if (!value || typeof value !== 'object') return { ok: false, error: 'critic verdict must be an object' };
+  const row = value as Record<string, unknown>;
+  if (typeof row.status !== 'string' || !STATUSES.has(row.status as CriticVerdictStatus)) {
+    return { ok: false, error: 'critic verdict status must be success, retryable_failure, terminal_failure, or needs_user' };
+  }
+  if (typeof row.reason !== 'string' || row.reason.trim() === '') return { ok: false, error: 'critic verdict reason is required' };
+  if (!Array.isArray(row.evidence_used)) return { ok: false, error: 'critic verdict evidence_used must be an array' };
+  if (!Array.isArray(row.missing_evidence)) return { ok: false, error: 'critic verdict missing_evidence must be an array' };
+  if (typeof row.next_strategy !== 'string') return { ok: false, error: 'critic verdict next_strategy is required' };
+  return {
+    ok: true,
+    value: {
+      status: row.status as CriticVerdictStatus,
+      reason: bound(row.reason, 500),
+      evidence_used: row.evidence_used.slice(0, 20).map(String).map(item => bound(item, 200)),
+      missing_evidence: row.missing_evidence.slice(0, 20).map(String).map(item => bound(item, 200)),
+      next_strategy: bound(row.next_strategy, 500),
+    },
+  };
+}
+
+export async function runBoundedCriticLoop(input: CriticLoopInput, opts: {
+  executeAttempt: (attempt: number, nextStrategy: string) => Promise<{ tool: string; ok: boolean; evidence: Record<string, unknown> }>;
+  critique: (attempt: { attempt: number; tool: string; ok: boolean; evidence: Record<string, unknown>; objective: string; successCriteria: string[] }) => Promise<unknown>;
+}): Promise<CriticLoopResult> {
+  const maxAttempts = Math.max(1, Math.min(input.maxAttempts ?? DEFAULT_MAX_ATTEMPTS, 10));
+  const attempts: CriticAttempt[] = [];
+  let nextStrategy = 'initial_attempt';
+
+  for (let attemptNo = 1; attemptNo <= maxAttempts; attemptNo++) {
+    const evidence = await opts.executeAttempt(attemptNo, nextStrategy);
+    const rawVerdict = await opts.critique({
+      attempt: attemptNo,
+      tool: evidence.tool,
+      ok: evidence.ok,
+      evidence: evidence.evidence,
+      objective: input.objective,
+      successCriteria: input.successCriteria,
+    });
+    const parsed = validateCriticVerdict(rawVerdict);
+    const verdict: CriticVerdict = parsed.ok
+      ? parsed.value
+      : {
+          status: 'terminal_failure',
+          reason: parsed.error,
+          evidence_used: [],
+          missing_evidence: ['valid_critic_verdict'],
+          next_strategy: 'fix critic output before retrying',
+        };
+    attempts.push({ attempt: attemptNo, tool: evidence.tool, ok: evidence.ok, evidence: evidence.evidence, verdict });
+
+    if (verdict.status === 'success' || verdict.status === 'terminal_failure' || verdict.status === 'needs_user') {
+      return { status: verdict.status, attempts, finalVerdict: verdict, nextSafeAction: nextSafeAction(verdict) };
+    }
+    nextStrategy = verdict.next_strategy || `retry_after_attempt_${attemptNo}`;
+  }
+
+  const finalVerdict: CriticVerdict = {
+    status: 'terminal_failure',
+    reason: `max attempts exhausted (${maxAttempts})`,
+    evidence_used: attempts.flatMap(attempt => attempt.verdict.evidence_used).slice(0, 20),
+    missing_evidence: ['successful_verified_outcome'],
+    next_strategy: 'stop and report max_attempts_exhausted',
+  };
+  return { status: 'max_attempts_exhausted', attempts, finalVerdict, nextSafeAction: nextSafeAction(finalVerdict) };
+}
+
+function nextSafeAction(verdict: CriticVerdict): string {
+  if (verdict.status === 'success') return 'stop_success';
+  if (verdict.status === 'needs_user') return 'ask_user';
+  if (verdict.status === 'retryable_failure') return 'retry_with_next_strategy';
+  return 'stop_failure';
+}
+
+function bound(text: string, maxChars: number): string {
+  const normalised = text.replace(/\s+/g, ' ').trim();
+  return normalised.length > maxChars ? `${normalised.slice(0, maxChars - 1)}…` : normalised;
+}

--- a/src/core/task-run/index.ts
+++ b/src/core/task-run/index.ts
@@ -1,2 +1,4 @@
 export * from './types';
 export * from './storage';
+
+export * from './critic-loop';

--- a/tests/core/task-run/critic-loop.test.ts
+++ b/tests/core/task-run/critic-loop.test.ts
@@ -51,6 +51,50 @@ describe('bounded task critic loop', () => {
     expect(terminal.nextSafeAction).toBe('ask_user');
   });
 
+
+  test('non-finite maxAttempts uses the default bounded retry count', async () => {
+    const executeAttempt = jest.fn(async () => ({ tool: 'act', ok: false, evidence: {} }));
+    const result = await runBoundedCriticLoop(
+      { objective: 'x', successCriteria: ['y'], maxAttempts: Number.NaN },
+      {
+        executeAttempt,
+        critique: async () => ({ status: 'retryable_failure', reason: 'not yet', evidence_used: [], missing_evidence: ['y'], next_strategy: 'retry' }),
+      },
+    );
+
+    expect(result.status).toBe('max_attempts_exhausted');
+    expect(executeAttempt).toHaveBeenCalledTimes(3);
+  });
+
+  test('callback errors are returned as terminal verdicts with attempt evidence', async () => {
+    const executeFailure = await runBoundedCriticLoop(
+      { objective: 'x', successCriteria: ['y'], maxAttempts: 3 },
+      {
+        executeAttempt: async () => { throw new Error('browser crashed'); },
+        critique: async () => ({ status: 'success', reason: 'unused', evidence_used: [], missing_evidence: [], next_strategy: 'stop' }),
+      },
+    );
+
+    expect(executeFailure.status).toBe('terminal_failure');
+    expect(executeFailure.attempts).toHaveLength(1);
+    expect(executeFailure.finalVerdict.reason).toContain('executeAttempt failed');
+    expect(executeFailure.finalVerdict.missing_evidence).toContain('attempt_evidence');
+
+    const critiqueFailure = await runBoundedCriticLoop(
+      { objective: 'x', successCriteria: ['y'], maxAttempts: 3 },
+      {
+        executeAttempt: async () => ({ tool: 'act', ok: false, evidence: { text: 'clicked' } }),
+        critique: async () => { throw new Error('critic unavailable'); },
+      },
+    );
+
+    expect(critiqueFailure.status).toBe('terminal_failure');
+    expect(critiqueFailure.attempts).toHaveLength(1);
+    expect(critiqueFailure.attempts[0].tool).toBe('act');
+    expect(critiqueFailure.finalVerdict.reason).toContain('critique failed');
+    expect(critiqueFailure.finalVerdict.missing_evidence).toContain('critic_verdict');
+  });
+
   test('malformed critic output becomes terminal failure', async () => {
     const result = await runBoundedCriticLoop(
       { objective: 'x', successCriteria: ['y'], maxAttempts: 3 },

--- a/tests/core/task-run/critic-loop.test.ts
+++ b/tests/core/task-run/critic-loop.test.ts
@@ -1,0 +1,65 @@
+import { runBoundedCriticLoop, validateCriticVerdict } from '../../../src/core/task-run';
+
+describe('bounded task critic loop', () => {
+  test('validates critic verdict schema', () => {
+    expect(validateCriticVerdict({ status: 'success', reason: 'done', evidence_used: ['banner'], missing_evidence: [], next_strategy: 'stop' }).ok).toBe(true);
+    const invalid = validateCriticVerdict({ status: 'maybe' });
+    expect(invalid.ok).toBe(false);
+  });
+
+  test('raw tool success is insufficient without critic success verdict', async () => {
+    const result = await runBoundedCriticLoop(
+      { objective: 'submit form', successCriteria: ['success banner'], maxAttempts: 1 },
+      {
+        executeAttempt: async () => ({ tool: 'interact', ok: true, evidence: { text: 'clicked' } }),
+        critique: async () => ({ status: 'retryable_failure', reason: 'banner missing', evidence_used: ['clicked'], missing_evidence: ['success banner'], next_strategy: 'read page then retry' }),
+      },
+    );
+
+    expect(result.status).toBe('max_attempts_exhausted');
+    expect(result.attempts[0].ok).toBe(true);
+    expect(result.finalVerdict.reason).toContain('max attempts');
+  });
+
+  test('retries retryable failures and stops on success', async () => {
+    const result = await runBoundedCriticLoop(
+      { objective: 'submit form', successCriteria: ['success banner'], maxAttempts: 3 },
+      {
+        executeAttempt: async (attempt, strategy) => ({ tool: 'act', ok: attempt === 2, evidence: { strategy } }),
+        critique: async ({ attempt }) => attempt === 1
+          ? { status: 'retryable_failure', reason: 'overlay blocked click', evidence_used: ['overlay'], missing_evidence: ['success banner'], next_strategy: 'dismiss overlay then submit' }
+          : { status: 'success', reason: 'success banner visible', evidence_used: ['success banner'], missing_evidence: [], next_strategy: 'stop' },
+      },
+    );
+
+    expect(result.status).toBe('success');
+    expect(result.attempts).toHaveLength(2);
+    expect(result.attempts[1].evidence.strategy).toBe('dismiss overlay then submit');
+    expect(result.nextSafeAction).toBe('stop_success');
+  });
+
+  test('terminal failure and needs_user stop immediately', async () => {
+    const terminal = await runBoundedCriticLoop(
+      { objective: 'login', successCriteria: ['dashboard'], maxAttempts: 3 },
+      {
+        executeAttempt: async () => ({ tool: 'act', ok: false, evidence: {} }),
+        critique: async () => ({ status: 'needs_user', reason: 'captcha', evidence_used: ['captcha'], missing_evidence: [], next_strategy: 'ask user' }),
+      },
+    );
+    expect(terminal.status).toBe('needs_user');
+    expect(terminal.attempts).toHaveLength(1);
+    expect(terminal.nextSafeAction).toBe('ask_user');
+  });
+
+  test('malformed critic output becomes terminal failure', async () => {
+    const result = await runBoundedCriticLoop(
+      { objective: 'x', successCriteria: ['y'], maxAttempts: 3 },
+      {
+        executeAttempt: async () => ({ tool: 'act', ok: false, evidence: {} }),
+        critique: async () => ({ status: 'bad' }),
+      },
+    );
+    expect(result.status).toBe('terminal_failure');
+    expect(result.finalVerdict.missing_evidence).toContain('valid_critic_verdict');
+  });
+});


### PR DESCRIPTION
## Summary
- adds a bounded task-run critic loop helper with hard max-attempt enforcement
- validates critic verdicts (`success`, `retryable_failure`, `terminal_failure`, `needs_user`) before retry/completion decisions
- ensures raw tool success is not enough to mark task success without a critic success verdict

## Scope
Partially fixes #1006 as a deterministic core helper and tests. This does not add an autonomous planner or change existing single-tool semantics.

## Verification
- `npm test -- tests/core/task-run/critic-loop.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `git diff --check`

## Not tested
- Live OpenChrome fixture transcript showing fail → critic retry → success
