### PR TITLE
feat(security): expose irreversible policy decisions (#1038)

### DIFF
--- a/docs/security/irreversible-action-policy.md
+++ b/docs/security/irreversible-action-policy.md
@@ -31,3 +31,13 @@ Every denial includes `policy`, `reason`, `missing`, and `suggested_next_action`
 ## Operator guidance
 
 Use this matrix as the common policy source for ToolAnnotations, dry-run previews, elicitation hooks, and TaskRun checkpoints. Future tool integrations should call the shared helper before executing a destructive commit path and should include the returned decision in structured tool output when blocked.
+
+## Inspecting policy at runtime
+
+Use the read-only `oc_policy` tool to inspect or evaluate the effective policy without executing the target action.
+
+- `oc_policy({"action":"matrix"})` returns the static policy matrix.
+- `oc_policy({"action":"evaluate","tool":"cookies","args":{"action":"delete-all"}})` returns the same structured decision helper used by policy consumers, for example `preview_required` with missing `dryRun`.
+- `oc_policy({"action":"evaluate","tool":"navigate","args":{"url":"https://example.com"},"allowedDomains":["localhost"]})` shows the deterministic allowed-domain decision.
+
+`oc_policy` is read-only and never performs the high-risk action it evaluates.

--- a/src/auth/scope-policy.ts
+++ b/src/auth/scope-policy.ts
@@ -38,6 +38,7 @@ export const READ_TOOLS: ReadonlySet<ToolId> = new Set<ToolId>([
   'oc_profile_status',
   'oc_get_connection_info',
   'oc_connection_health',
+  'oc_policy',
   'oc_journal',
   'oc_devtools_url',
 

--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -83,6 +83,7 @@ export const TOOL_TIERS: Record<string, ToolTier> = {
   // Internal/diagnostic tools (exposed at Tier 1 but explicitly declared)
   // Names must match the 'name' field in each tool's definition
   oc_connection_health: 1,  // src/tools/connection-health.ts
+  oc_policy: 1,             // src/tools/oc-policy.ts
   oc_checkpoint: 1,         // src/tools/checkpoint.ts
   list_profiles: 1,         // src/tools/list-profiles.ts
   oc_devtools_url: 1,       // src/tools/oc-devtools-url.ts (#860) — gated by env

--- a/src/tools/__tests__/__snapshots__/tools-list.v1.11.snap.json
+++ b/src/tools/__tests__/__snapshots__/tools-list.v1.11.snap.json
@@ -145,6 +145,9 @@
       "name": "oc_performance_insights"
     },
     {
+      "name": "oc_policy"
+    },
+    {
       "name": "oc_profile_status"
     },
     {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -80,6 +80,7 @@ import { registerOcReflectTool } from './oc-reflect';
 
 // Self-healing tools (#347)
 import { registerConnectionHealthTool } from './connection-health';
+import { registerOcPolicyTool } from './oc-policy';
 
 // AI Agent Continuity tools (#347 Phase 4)
 import { registerCheckpointTool } from './checkpoint';
@@ -206,6 +207,7 @@ export const TOOL_CAPABILITY_MAP: Record<string, ToolCapability> = {
   oc_context_export: 'core',
   oc_context_import: 'core',
   oc_connection_health: 'core',
+  oc_policy: 'core',
   oc_copy_to_clipboard: 'core',
   oc_devtools_url: 'core',
   oc_doctor_report: 'core',
@@ -425,6 +427,7 @@ export function registerAllTools(server: MCPServer): void {
 
   // Self-healing tools (#347)
   registerConnectionHealthTool(proxy);
+  registerOcPolicyTool(proxy);
 
   // AI Agent Continuity tools (#347 Phase 4)
   registerCheckpointTool(proxy);

--- a/src/tools/oc-policy.ts
+++ b/src/tools/oc-policy.ts
@@ -1,0 +1,80 @@
+import { MCPServer } from '../mcp-server';
+import { MCPResult, MCPToolDefinition, ToolHandler } from '../types/mcp';
+import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
+import {
+  DEFAULT_TOOL_RISK_POLICIES,
+  evaluateToolRiskPolicy,
+  getEffectiveToolRiskPolicy,
+} from '../security/tool-risk-policy';
+
+const definition: MCPToolDefinition = {
+  name: 'oc_policy',
+  description: 'Inspect deterministic OpenChrome safety policy. Use action="matrix" to list irreversible-action rules or action="evaluate" to preview a policy decision for a tool/args context.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      action: { type: 'string', enum: ['matrix', 'evaluate'], description: 'matrix lists policies; evaluate returns a decision for tool/args. Default: matrix.' },
+      tool: { type: 'string', description: '(evaluate) Tool name to evaluate.' },
+      args: { type: 'object', description: '(evaluate) Tool arguments to classify.', additionalProperties: true },
+      dryRun: { type: 'boolean', description: '(evaluate) Whether the caller requested a dry-run/preview path.' },
+      elicitationSupported: { type: 'boolean', description: '(evaluate) Whether client-side elicitation/confirmation is available.' },
+      allowedDomains: { type: 'array', items: { type: 'string' }, description: '(evaluate) Optional task allowedDomains policy.' },
+      checkpoint: {
+        type: 'object',
+        description: '(evaluate) Optional checkpoint evidence with createdAt, now, and taskId.',
+        properties: {
+          taskId: { type: 'string' },
+          createdAt: { type: 'number' },
+          now: { type: 'number' },
+        },
+      },
+    },
+    required: [],
+  },
+  annotations: TOOL_ANNOTATIONS.oc_policy,
+};
+
+const handler: ToolHandler = async (_sessionId: string, args: Record<string, unknown>): Promise<MCPResult> => {
+  const action = (args.action as string | undefined) ?? 'matrix';
+  if (action === 'matrix') {
+    return jsonResult({ status: 'ok', policies: DEFAULT_TOOL_RISK_POLICIES });
+  }
+  if (action !== 'evaluate') {
+    return jsonResult({ status: 'error', error: `Unknown action: ${action}` }, true);
+  }
+  const tool = args.tool as string | undefined;
+  if (!tool) return jsonResult({ status: 'error', error: 'tool is required for action=evaluate' }, true);
+  const toolArgs = (args.args ?? {}) as Record<string, unknown>;
+  const checkpoint = args.checkpoint && typeof args.checkpoint === 'object'
+    ? args.checkpoint as { taskId?: string; createdAt: number; now?: number }
+    : undefined;
+  const allowedDomains = Array.isArray(args.allowedDomains) ? args.allowedDomains.map(String) : undefined;
+  const decision = evaluateToolRiskPolicy({
+    tool,
+    args: toolArgs,
+    dryRun: args.dryRun === true,
+    elicitationSupported: args.elicitationSupported === true,
+    allowedDomains,
+    checkpoint,
+  });
+  return jsonResult({
+    status: 'ok',
+    effectivePolicy: getEffectiveToolRiskPolicy(tool, toolArgs, allowedDomains),
+    decision,
+  });
+};
+
+function jsonResult(payload: Record<string, unknown>, isError = false): MCPResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
+    structuredContent: payload,
+    isError,
+    ...payload,
+  };
+}
+
+export function registerOcPolicyTool(server: MCPServer): void {
+  server.registerTool(definition.name, handler, definition);
+}
+
+export const ocPolicyToolHandler = handler;

--- a/src/types/tool-annotations.ts
+++ b/src/types/tool-annotations.ts
@@ -77,6 +77,7 @@ export const TOOL_ANNOTATIONS = {
   oc_profile_status: READ_ONLY,
   oc_get_connection_info: READ_ONLY,
   oc_connection_health: READ_ONLY,
+  oc_policy: READ_ONLY,
   oc_skill_recall: READ_ONLY,
   vision_find: READ_ONLY,
   oc_assert: READ_ONLY,

--- a/tests/security/oc-policy-tool.test.ts
+++ b/tests/security/oc-policy-tool.test.ts
@@ -1,0 +1,46 @@
+import { ocPolicyToolHandler } from '../../src/tools/oc-policy';
+
+function parse(result: Awaited<ReturnType<typeof ocPolicyToolHandler>>): Record<string, unknown> {
+  return JSON.parse(result.content?.[0]?.text as string) as Record<string, unknown>;
+}
+
+describe('oc_policy tool', () => {
+  it('returns the documented policy matrix by default', async () => {
+    const result = await ocPolicyToolHandler('sess', {});
+    const body = parse(result);
+    expect(body.status).toBe('ok');
+    expect(Array.isArray(body.policies)).toBe(true);
+    expect(JSON.stringify(body.policies)).toContain('cookies');
+  });
+
+  it('evaluates preview-required destructive decisions in structured form', async () => {
+    const result = await ocPolicyToolHandler('sess', {
+      action: 'evaluate',
+      tool: 'cookies',
+      args: { action: 'delete-all' },
+    });
+    const body = parse(result) as { decision: { decision: string; missing: string[] } };
+    expect(body.decision.decision).toBe('preview_required');
+    expect(body.decision.missing).toContain('dryRun');
+  });
+
+  it('blocks navigation outside allowedDomains', async () => {
+    const result = await ocPolicyToolHandler('sess', {
+      action: 'evaluate',
+      tool: 'navigate',
+      args: { url: 'https://example.com' },
+      allowedDomains: ['localhost'],
+      elicitationSupported: true,
+    });
+    const body = parse(result) as { decision: { decision: string; missing: string[] } };
+    expect(body.decision.decision).toBe('blocked');
+    expect(body.decision.missing).toContain('allowedDomain');
+  });
+
+  it('returns validation errors without throwing', async () => {
+    const result = await ocPolicyToolHandler('sess', { action: 'evaluate' });
+    const body = parse(result);
+    expect(result.isError).toBe(true);
+    expect(body.error).toContain('tool is required');
+  });
+});


### PR DESCRIPTION
## Summary
- adds read-only `oc_policy` to list the irreversible-action policy matrix or evaluate a tool/args context without executing it
- wires the tool into annotations, tiering, capability map, and read scopes
- documents runtime inspection examples for dry-run, elicitation/checkpoint, and allowed-domain decisions

## Scope
Follow-up for #1038. The prior merged PR added the matrix/helper; this PR exposes the effective policy as a compact host-facing read-only surface.

## Verification
- `npm test -- tests/security/tool-risk-policy.test.ts tests/security/oc-policy-tool.test.ts --runInBand`
- `npm test -- tests/unit/tool-annotations.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint:tool-schemas`
- `git diff --check`

## Not tested
- Live OpenChrome destructive-tool transcript with policy denial
