### PR TITLE
Stabilize perception snapshot contract

### DIFF
--- a/docs/vision/perception-snapshot.md
+++ b/docs/vision/perception-snapshot.md
@@ -1,0 +1,20 @@
+# Provider-neutral perception snapshots
+
+`vision_find` keeps its legacy annotated screenshot output by default, but it also builds a provider-neutral `PerceptionSnapshot` internally. Callers can request that contract with `format: "snapshot"` or `format: "both"`.
+
+The snapshot contract is exported from `src/vision/perception-types.ts` and is intentionally provider-neutral: DOM annotation, future OmniParser-compatible HTTP providers, and tests can all describe visible elements with stable snapshot-local IDs, labels, viewport-relative CSS pixel boxes, normalized ratios, provenance, and bounded warnings.
+
+## Validation expectations
+
+Provider output should pass `validatePerceptionSnapshot` before it is trusted by downstream grounding code. Validation diagnostics are bounded with `maxErrors` so malformed or hostile providers cannot flood MCP responses or model context. A failed validation should be surfaced as an actionable warning or an `isError` tool response instead of an uncaught MCP-server exception.
+
+## Bounds and privacy
+
+- `buildPerceptionSnapshotFromAnnotatedResult` caps element count with `maxElements`.
+- `sanitizePerceptionLabel` truncates labels with `maxLabelLength`.
+- Secret-like labels, including password fixture values, are redacted before entering the snapshot.
+- Coordinates are clamped to the live viewport and emitted as both CSS pixels and `0..1` ratios.
+
+## Non-goals
+
+This layer does not add OmniParser, Python, Torch, model weights, persistent screenshot storage, or automatic clicking from visual elements. External perception providers should remain optional and adapt to this contract.

--- a/src/vision/perception-provider.ts
+++ b/src/vision/perception-provider.ts
@@ -124,3 +124,98 @@ export function buildPerceptionSnapshotFromAnnotatedResult(
 export function formatPerceptionSnapshotAsText(snapshot: PerceptionSnapshot): string {
   return JSON.stringify(snapshot, null, 2);
 }
+
+export interface PerceptionValidationOptions {
+  maxErrors?: number;
+  maxElements?: number;
+}
+
+export interface PerceptionValidationResult {
+  ok: boolean;
+  errors: string[];
+  truncated: boolean;
+}
+
+export function validatePerceptionSnapshot(
+  snapshot: unknown,
+  options: PerceptionValidationOptions = {}
+): PerceptionValidationResult {
+  const maxErrors = Math.max(1, options.maxErrors ?? 25);
+  const errors: string[] = [];
+  const addError = (message: string): void => {
+    if (errors.length < maxErrors) errors.push(message);
+  };
+
+  if (!snapshot || typeof snapshot !== 'object') {
+    return { ok: false, errors: ['snapshot must be an object'], truncated: false };
+  }
+
+  const row = snapshot as Record<string, unknown>;
+  if (row.version !== 1) addError('version must be 1');
+  if (typeof row.provider !== 'string' || row.provider.length === 0) addError('provider is required');
+  if (typeof row.tabId !== 'string' || row.tabId.length === 0) addError('tabId is required');
+  if (typeof row.url !== 'string') addError('url must be a string');
+  if (typeof row.capturedAt !== 'number' || !Number.isFinite(row.capturedAt)) addError('capturedAt must be a finite number');
+
+  const viewport = row.viewport as Record<string, unknown> | undefined;
+  if (!viewport || !isPositiveFinite(viewport.width) || !isPositiveFinite(viewport.height)) {
+    addError('viewport width/height must be positive finite numbers');
+  }
+
+  if (!Array.isArray(row.elements)) {
+    addError('elements must be an array');
+  } else if (options.maxElements !== undefined && row.elements.length > options.maxElements) {
+    addError(`elements length must be <= ${options.maxElements}`);
+  }
+
+  if (!Array.isArray(row.warnings) || row.warnings.some((warning) => typeof warning !== 'string')) {
+    addError('warnings must be an array of strings');
+  }
+  if (typeof row.latencyMs !== 'number' || !Number.isFinite(row.latencyMs) || row.latencyMs < 0) {
+    addError('latencyMs must be a non-negative finite number');
+  }
+
+  if (Array.isArray(row.elements)) {
+    for (let index = 0; index < row.elements.length && errors.length < maxErrors; index += 1) {
+      const element = row.elements[index];
+      const prefix = `elements[${index}]`;
+      if (!element || typeof element !== 'object') {
+        addError(`${prefix} must be an object`);
+        continue;
+      }
+      const el = element as Record<string, unknown>;
+      if (typeof el.id !== 'string' || el.id.length === 0) addError(`${prefix}.id is required`);
+      if (!['text', 'icon', 'control', 'image', 'unknown'].includes(String(el.type))) addError(`${prefix}.type is invalid`);
+      if (typeof el.label !== 'string') addError(`${prefix}.label must be a string`);
+      if (!(typeof el.interactive === 'boolean' || el.interactive === 'unknown')) addError(`${prefix}.interactive is invalid`);
+      if (typeof el.source !== 'string' || el.source.length === 0) addError(`${prefix}.source is required`);
+      validateBox(el.bbox, `${prefix}.bbox`, addError, false);
+      validateBox(el.bboxRatio, `${prefix}.bboxRatio`, addError, true);
+      if (el.confidence !== undefined && (typeof el.confidence !== 'number' || !Number.isFinite(el.confidence) || el.confidence < 0 || el.confidence > 1)) {
+        addError(`${prefix}.confidence must be 0..1`);
+      }
+    }
+  }
+
+  return { ok: errors.length === 0, errors, truncated: errors.length >= maxErrors };
+}
+
+function validateBox(value: unknown, prefix: string, addError: (message: string) => void, ratio: boolean): void {
+  if (!value || typeof value !== 'object') {
+    addError(`${prefix} is required`);
+    return;
+  }
+  const box = value as Record<string, unknown>;
+  for (const key of ['x', 'y', 'width', 'height']) {
+    const n = box[key];
+    if (typeof n !== 'number' || !Number.isFinite(n) || n < 0) {
+      addError(`${prefix}.${key} must be a non-negative finite number`);
+    } else if (ratio && n > 1) {
+      addError(`${prefix}.${key} must be <= 1`);
+    }
+  }
+}
+
+function isPositiveFinite(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}

--- a/src/vision/perception-provider.ts
+++ b/src/vision/perception-provider.ts
@@ -136,11 +136,17 @@ export interface PerceptionValidationResult {
   truncated: boolean;
 }
 
+
+function sanitizePositiveInteger(value: unknown, fallback: number, cap: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  return Math.min(cap, Math.max(1, Math.floor(value)));
+}
+
 export function validatePerceptionSnapshot(
   snapshot: unknown,
   options: PerceptionValidationOptions = {}
 ): PerceptionValidationResult {
-  const maxErrors = Math.max(1, options.maxErrors ?? 25);
+  const maxErrors = sanitizePositiveInteger(options.maxErrors, 25, 100);
   const errors: string[] = [];
   const addError = (message: string): void => {
     if (errors.length < maxErrors) errors.push(message);

--- a/src/vision/perception-provider.ts
+++ b/src/vision/perception-provider.ts
@@ -144,6 +144,13 @@ function sanitizePositiveInteger(value: unknown, fallback: number, cap: number):
   return Math.min(cap, Math.max(1, Math.floor(value)));
 }
 
+function sanitizeNonNegativeInteger(value: unknown, fallback: number, cap: number): number {
+  if (typeof value !== 'number') return fallback;
+  if (value === Number.POSITIVE_INFINITY) return cap;
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(cap, Math.max(0, Math.floor(value)));
+}
+
 export function validatePerceptionSnapshot(
   snapshot: unknown,
   options: PerceptionValidationOptions = {}
@@ -151,7 +158,7 @@ export function validatePerceptionSnapshot(
   const maxErrors = sanitizePositiveInteger(options.maxErrors, 25, 100);
   const maxElements = options.maxElements === undefined
     ? undefined
-    : sanitizePositiveInteger(options.maxElements, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER);
+    : sanitizeNonNegativeInteger(options.maxElements, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER);
   const errors: string[] = [];
   const addError = (message: string): void => {
     if (errors.length < maxErrors) errors.push(message);

--- a/src/vision/perception-provider.ts
+++ b/src/vision/perception-provider.ts
@@ -138,7 +138,9 @@ export interface PerceptionValidationResult {
 
 
 function sanitizePositiveInteger(value: unknown, fallback: number, cap: number): number {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  if (typeof value !== 'number') return fallback;
+  if (value === Number.POSITIVE_INFINITY) return cap;
+  if (!Number.isFinite(value)) return fallback;
   return Math.min(cap, Math.max(1, Math.floor(value)));
 }
 
@@ -147,6 +149,9 @@ export function validatePerceptionSnapshot(
   options: PerceptionValidationOptions = {}
 ): PerceptionValidationResult {
   const maxErrors = sanitizePositiveInteger(options.maxErrors, 25, 100);
+  const maxElements = options.maxElements === undefined
+    ? undefined
+    : sanitizePositiveInteger(options.maxElements, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER);
   const errors: string[] = [];
   const addError = (message: string): void => {
     if (errors.length < maxErrors) errors.push(message);
@@ -170,8 +175,8 @@ export function validatePerceptionSnapshot(
 
   if (!Array.isArray(row.elements)) {
     addError('elements must be an array');
-  } else if (options.maxElements !== undefined && row.elements.length > options.maxElements) {
-    addError(`elements length must be <= ${options.maxElements}`);
+  } else if (maxElements !== undefined && row.elements.length > maxElements) {
+    addError(`elements length must be <= ${maxElements}`);
   }
 
   if (!Array.isArray(row.warnings) || row.warnings.some((warning) => typeof warning !== 'string')) {
@@ -182,7 +187,8 @@ export function validatePerceptionSnapshot(
   }
 
   if (Array.isArray(row.elements)) {
-    for (let index = 0; index < row.elements.length && errors.length < maxErrors; index += 1) {
+    const validationLimit = maxElements === undefined ? row.elements.length : Math.min(row.elements.length, maxElements);
+    for (let index = 0; index < validationLimit && errors.length < maxErrors; index += 1) {
       const element = row.elements[index];
       const prefix = `elements[${index}]`;
       if (!element || typeof element !== 'object') {

--- a/src/vision/perception-provider.ts
+++ b/src/vision/perception-provider.ts
@@ -185,7 +185,7 @@ export function validatePerceptionSnapshot(
       }
       const el = element as Record<string, unknown>;
       if (typeof el.id !== 'string' || el.id.length === 0) addError(`${prefix}.id is required`);
-      if (!['text', 'icon', 'control', 'image', 'unknown'].includes(String(el.type))) addError(`${prefix}.type is invalid`);
+      if (typeof el.type !== 'string' || !['text', 'icon', 'control', 'image', 'unknown'].includes(el.type)) addError(`${prefix}.type is invalid`);
       if (typeof el.label !== 'string') addError(`${prefix}.label must be a string`);
       if (!(typeof el.interactive === 'boolean' || el.interactive === 'unknown')) addError(`${prefix}.interactive is invalid`);
       if (typeof el.source !== 'string' || el.source.length === 0) addError(`${prefix}.source is required`);

--- a/src/vision/perception-types.ts
+++ b/src/vision/perception-types.ts
@@ -1,0 +1,4 @@
+export type {
+  PerceptionElement,
+  PerceptionSnapshot,
+} from './types';

--- a/tests/vision/perception-snapshot.test.ts
+++ b/tests/vision/perception-snapshot.test.ts
@@ -4,6 +4,7 @@ import {
   buildPerceptionSnapshotFromAnnotatedResult,
   formatPerceptionSnapshotAsText,
   sanitizePerceptionLabel,
+  validatePerceptionSnapshot,
   visionElementToPerceptionElement,
 } from '../../src/vision/perception-provider';
 import type { AnnotatedScreenshotResult, VisionElement } from '../../src/vision/types';
@@ -114,5 +115,71 @@ describe('perception snapshot helpers', () => {
 
     const parsed = JSON.parse(formatPerceptionSnapshotAsText(snapshot));
     expect(parsed).toEqual(snapshot);
+  });
+});
+
+
+describe('perception snapshot schema validation', () => {
+  test('accepts valid provider-neutral snapshots', () => {
+    const snapshot = buildPerceptionSnapshotFromAnnotatedResult(annotated({
+      1: { number: 1, x: 10, y: 10, width: 20, height: 20, centerX: 20, centerY: 20, type: 'button', name: 'OK' },
+    }), { tabId: 'tab', url: 'https://example.test' });
+
+    expect(validatePerceptionSnapshot(snapshot)).toEqual({ ok: true, errors: [], truncated: false });
+  });
+
+  test('rejects malformed provider output with bounded errors', () => {
+    const result = validatePerceptionSnapshot({
+      version: 1,
+      provider: 'mock',
+      tabId: 'tab',
+      url: 'https://example.test',
+      capturedAt: 1,
+      viewport: { width: 100, height: 100 },
+      warnings: [],
+      latencyMs: 1,
+      elements: [{
+        id: '',
+        type: 'bad',
+        label: 123,
+        interactive: 'maybe',
+        source: '',
+        bbox: { x: -1, y: 0, width: 10, height: 10 },
+        bboxRatio: { x: 2, y: 0, width: 0.5, height: 0.5 },
+      }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.join('\n')).toContain('elements[0].id');
+    expect(result.errors.join('\n')).toContain('elements[0].type');
+    expect(result.errors.join('\n')).toContain('bbox.x');
+    expect(result.errors.join('\n')).toContain('bboxRatio.x');
+  });
+
+
+  test('limits validation diagnostics for hostile provider output', () => {
+    const result = validatePerceptionSnapshot({
+      version: 1,
+      provider: 'mock',
+      tabId: 'tab',
+      url: 'https://example.test',
+      capturedAt: 1,
+      viewport: { width: 100, height: 100 },
+      warnings: [],
+      latencyMs: 1,
+      elements: Array.from({ length: 100 }, () => ({
+        id: '',
+        type: 'bad',
+        label: 123,
+        interactive: 'maybe',
+        source: '',
+        bbox: { x: -1, y: -1, width: -1, height: -1 },
+        bboxRatio: { x: 2, y: 2, width: 2, height: 2 },
+      })),
+    }, { maxErrors: 5, maxElements: 500 });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toHaveLength(5);
+    expect(result.truncated).toBe(true);
   });
 });

--- a/tests/vision/perception-snapshot.test.ts
+++ b/tests/vision/perception-snapshot.test.ts
@@ -208,6 +208,43 @@ describe('perception snapshot schema validation', () => {
   });
 
 
+
+  test('does not validate elements beyond the configured element cap', () => {
+    const result = validatePerceptionSnapshot({
+      version: 1,
+      provider: 'mock',
+      tabId: 'tab',
+      url: 'https://example.test',
+      capturedAt: 1,
+      viewport: { width: 100, height: 100 },
+      warnings: [],
+      latencyMs: 1,
+      elements: [
+        {
+          id: 'v1',
+          type: 'control',
+          label: 'OK',
+          interactive: true,
+          source: 'mock',
+          bbox: { x: 0, y: 0, width: 10, height: 10 },
+          bboxRatio: { x: 0, y: 0, width: 0.1, height: 0.1 },
+        },
+        {
+          id: '',
+          type: 'bad-after-cap',
+          label: 123,
+          interactive: 'maybe',
+          source: '',
+          bbox: { x: -1, y: -1, width: -1, height: -1 },
+          bboxRatio: { x: 2, y: 2, width: 2, height: 2 },
+        },
+      ],
+    }, { maxElements: 1, maxErrors: 25 });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(['elements length must be <= 1']);
+  });
+
   test('sanitizes hostile maxErrors bounds before collecting diagnostics', () => {
     const malformed = {
       version: 'bad',

--- a/tests/vision/perception-snapshot.test.ts
+++ b/tests/vision/perception-snapshot.test.ts
@@ -156,6 +156,30 @@ describe('perception snapshot schema validation', () => {
     expect(result.errors.join('\n')).toContain('bboxRatio.x');
   });
 
+  test('rejects non-string element type even when string-coercible', () => {
+    const result = validatePerceptionSnapshot({
+      version: 1,
+      provider: 'mock',
+      tabId: 'tab',
+      url: 'https://example.test',
+      capturedAt: 1,
+      viewport: { width: 100, height: 100 },
+      warnings: [],
+      latencyMs: 1,
+      elements: [{
+        id: 'v1',
+        type: { toString: () => 'control' },
+        label: 'OK',
+        interactive: true,
+        source: 'mock',
+        bbox: { x: 0, y: 0, width: 10, height: 10 },
+        bboxRatio: { x: 0, y: 0, width: 0.1, height: 0.1 },
+      }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.join('\n')).toContain('elements[0].type');
+  });
 
   test('limits validation diagnostics for hostile provider output', () => {
     const result = validatePerceptionSnapshot({

--- a/tests/vision/perception-snapshot.test.ts
+++ b/tests/vision/perception-snapshot.test.ts
@@ -245,6 +245,32 @@ describe('perception snapshot schema validation', () => {
     expect(result.errors).toEqual(['elements length must be <= 1']);
   });
 
+  test('honors zero maxElements as a strict validation cap', () => {
+    const result = validatePerceptionSnapshot({
+      version: 1,
+      provider: 'fixture',
+      tabId: 'tab-1',
+      url: 'https://example.test',
+      capturedAt: Date.now(),
+      viewport: { width: 100, height: 100 },
+      screenshotMimeType: 'image/png',
+      warnings: [],
+      latencyMs: 0,
+      elements: [{
+        id: '',
+        type: 'bad-after-cap',
+        label: 123,
+        interactive: 'maybe',
+        source: '',
+        bbox: { x: -1, y: -1, width: -1, height: -1 },
+        bboxRatio: { x: 2, y: 2, width: 2, height: 2 },
+      }],
+    }, { maxElements: 0, maxErrors: 25 });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(['elements length must be <= 0']);
+  });
+
   test('sanitizes hostile maxErrors bounds before collecting diagnostics', () => {
     const malformed = {
       version: 'bad',

--- a/tests/vision/perception-snapshot.test.ts
+++ b/tests/vision/perception-snapshot.test.ts
@@ -116,94 +116,27 @@ describe('perception snapshot helpers', () => {
     const parsed = JSON.parse(formatPerceptionSnapshotAsText(snapshot));
     expect(parsed).toEqual(snapshot);
   });
-});
 
+  test('sanitizes hostile maxErrors bounds before collecting diagnostics', () => {
+    const malformed = {
+      version: 'bad',
+      provider: '',
+      tabId: '',
+      url: 42,
+      capturedAt: Number.NaN,
+      viewport: { width: 0, height: 0 },
+      elements: 'not-an-array',
+    };
 
-describe('perception snapshot schema validation', () => {
-  test('accepts valid provider-neutral snapshots', () => {
-    const snapshot = buildPerceptionSnapshotFromAnnotatedResult(annotated({
-      1: { number: 1, x: 10, y: 10, width: 20, height: 20, centerX: 20, centerY: 20, type: 'button', name: 'OK' },
-    }), { tabId: 'tab', url: 'https://example.test' });
+    const nanBound = validatePerceptionSnapshot(malformed, { maxErrors: Number.NaN });
+    const infiniteBound = validatePerceptionSnapshot(malformed, { maxErrors: Number.POSITIVE_INFINITY });
 
-    expect(validatePerceptionSnapshot(snapshot)).toEqual({ ok: true, errors: [], truncated: false });
+    expect(nanBound.ok).toBe(false);
+    expect(nanBound.errors.length).toBeGreaterThan(0);
+    expect(nanBound.errors.length).toBeLessThanOrEqual(25);
+    expect(infiniteBound.ok).toBe(false);
+    expect(infiniteBound.errors.length).toBeGreaterThan(0);
+    expect(infiniteBound.errors.length).toBeLessThanOrEqual(25);
   });
 
-  test('rejects malformed provider output with bounded errors', () => {
-    const result = validatePerceptionSnapshot({
-      version: 1,
-      provider: 'mock',
-      tabId: 'tab',
-      url: 'https://example.test',
-      capturedAt: 1,
-      viewport: { width: 100, height: 100 },
-      warnings: [],
-      latencyMs: 1,
-      elements: [{
-        id: '',
-        type: 'bad',
-        label: 123,
-        interactive: 'maybe',
-        source: '',
-        bbox: { x: -1, y: 0, width: 10, height: 10 },
-        bboxRatio: { x: 2, y: 0, width: 0.5, height: 0.5 },
-      }],
-    });
-
-    expect(result.ok).toBe(false);
-    expect(result.errors.join('\n')).toContain('elements[0].id');
-    expect(result.errors.join('\n')).toContain('elements[0].type');
-    expect(result.errors.join('\n')).toContain('bbox.x');
-    expect(result.errors.join('\n')).toContain('bboxRatio.x');
-  });
-
-  test('rejects non-string element type even when string-coercible', () => {
-    const result = validatePerceptionSnapshot({
-      version: 1,
-      provider: 'mock',
-      tabId: 'tab',
-      url: 'https://example.test',
-      capturedAt: 1,
-      viewport: { width: 100, height: 100 },
-      warnings: [],
-      latencyMs: 1,
-      elements: [{
-        id: 'v1',
-        type: { toString: () => 'control' },
-        label: 'OK',
-        interactive: true,
-        source: 'mock',
-        bbox: { x: 0, y: 0, width: 10, height: 10 },
-        bboxRatio: { x: 0, y: 0, width: 0.1, height: 0.1 },
-      }],
-    });
-
-    expect(result.ok).toBe(false);
-    expect(result.errors.join('\n')).toContain('elements[0].type');
-  });
-
-  test('limits validation diagnostics for hostile provider output', () => {
-    const result = validatePerceptionSnapshot({
-      version: 1,
-      provider: 'mock',
-      tabId: 'tab',
-      url: 'https://example.test',
-      capturedAt: 1,
-      viewport: { width: 100, height: 100 },
-      warnings: [],
-      latencyMs: 1,
-      elements: Array.from({ length: 100 }, () => ({
-        id: '',
-        type: 'bad',
-        label: 123,
-        interactive: 'maybe',
-        source: '',
-        bbox: { x: -1, y: -1, width: -1, height: -1 },
-        bboxRatio: { x: 2, y: 2, width: 2, height: 2 },
-      })),
-    }, { maxErrors: 5, maxElements: 500 });
-
-    expect(result.ok).toBe(false);
-    expect(result.errors).toHaveLength(5);
-    expect(result.truncated).toBe(true);
-  });
 });

--- a/tests/vision/perception-snapshot.test.ts
+++ b/tests/vision/perception-snapshot.test.ts
@@ -116,6 +116,97 @@ describe('perception snapshot helpers', () => {
     const parsed = JSON.parse(formatPerceptionSnapshotAsText(snapshot));
     expect(parsed).toEqual(snapshot);
   });
+});
+
+
+describe('perception snapshot schema validation', () => {
+  test('accepts valid provider-neutral snapshots', () => {
+    const snapshot = buildPerceptionSnapshotFromAnnotatedResult(annotated({
+      1: { number: 1, x: 10, y: 10, width: 20, height: 20, centerX: 20, centerY: 20, type: 'button', name: 'OK' },
+    }), { tabId: 'tab', url: 'https://example.test' });
+
+    expect(validatePerceptionSnapshot(snapshot)).toEqual({ ok: true, errors: [], truncated: false });
+  });
+
+  test('rejects malformed provider output with bounded errors', () => {
+    const result = validatePerceptionSnapshot({
+      version: 1,
+      provider: 'mock',
+      tabId: 'tab',
+      url: 'https://example.test',
+      capturedAt: 1,
+      viewport: { width: 100, height: 100 },
+      warnings: [],
+      latencyMs: 1,
+      elements: [{
+        id: '',
+        type: 'bad',
+        label: 123,
+        interactive: 'maybe',
+        source: '',
+        bbox: { x: -1, y: 0, width: 10, height: 10 },
+        bboxRatio: { x: 2, y: 0, width: 0.5, height: 0.5 },
+      }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.join('\n')).toContain('elements[0].id');
+    expect(result.errors.join('\n')).toContain('elements[0].type');
+    expect(result.errors.join('\n')).toContain('bbox.x');
+    expect(result.errors.join('\n')).toContain('bboxRatio.x');
+  });
+
+  test('rejects non-string element type even when string-coercible', () => {
+    const result = validatePerceptionSnapshot({
+      version: 1,
+      provider: 'mock',
+      tabId: 'tab',
+      url: 'https://example.test',
+      capturedAt: 1,
+      viewport: { width: 100, height: 100 },
+      warnings: [],
+      latencyMs: 1,
+      elements: [{
+        id: 'v1',
+        type: { toString: () => 'control' },
+        label: 'OK',
+        interactive: true,
+        source: 'mock',
+        bbox: { x: 0, y: 0, width: 10, height: 10 },
+        bboxRatio: { x: 0, y: 0, width: 0.1, height: 0.1 },
+      }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.join('\n')).toContain('elements[0].type');
+  });
+
+  test('limits validation diagnostics for hostile provider output', () => {
+    const result = validatePerceptionSnapshot({
+      version: 1,
+      provider: 'mock',
+      tabId: 'tab',
+      url: 'https://example.test',
+      capturedAt: 1,
+      viewport: { width: 100, height: 100 },
+      warnings: [],
+      latencyMs: 1,
+      elements: Array.from({ length: 100 }, () => ({
+        id: '',
+        type: 'bad',
+        label: 123,
+        interactive: 'maybe',
+        source: '',
+        bbox: { x: -1, y: -1, width: -1, height: -1 },
+        bboxRatio: { x: 2, y: 2, width: 2, height: 2 },
+      })),
+    }, { maxErrors: 5, maxElements: 500 });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toHaveLength(5);
+    expect(result.truncated).toBe(true);
+  });
+
 
   test('sanitizes hostile maxErrors bounds before collecting diagnostics', () => {
     const malformed = {
@@ -138,5 +229,4 @@ describe('perception snapshot helpers', () => {
     expect(infiniteBound.errors.length).toBeGreaterThan(0);
     expect(infiniteBound.errors.length).toBeLessThanOrEqual(25);
   });
-
 });

--- a/tests/vision/perception-types-export.test.ts
+++ b/tests/vision/perception-types-export.test.ts
@@ -1,0 +1,28 @@
+import type { PerceptionElement, PerceptionSnapshot } from '../../src/vision/perception-types';
+
+describe('perception type export surface', () => {
+  test('exports provider-neutral perception snapshot types', () => {
+    const element: PerceptionElement = {
+      id: 'v1',
+      type: 'control',
+      label: 'Continue',
+      interactive: true,
+      bbox: { x: 0, y: 0, width: 10, height: 10 },
+      bboxRatio: { x: 0, y: 0, width: 0.1, height: 0.1 },
+      source: 'mock',
+    };
+    const snapshot: PerceptionSnapshot = {
+      version: 1,
+      provider: 'mock',
+      tabId: 'tab',
+      url: 'https://example.test',
+      capturedAt: 1,
+      viewport: { width: 100, height: 100 },
+      elements: [element],
+      warnings: [],
+      latencyMs: 1,
+    };
+
+    expect(snapshot.elements[0].id).toBe('v1');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an explicit `src/vision/perception-types.ts` export surface for the provider-neutral perception schema.
- Adds bounded `validatePerceptionSnapshot` diagnostics for future providers and malformed snapshot output.
- Documents the snapshot contract, validation expectations, bounds, privacy, and non-goals for future OmniParser-compatible providers.

## Issue coverage
- Closes #1052 as a contract-hardening follow-up to the existing `vision_find(format: "snapshot")` DOM-provider implementation already present on `develop`.
- Keeps the current DOM annotator as the default and does not add OmniParser/Python/model dependencies.

## Verification
- `npm test -- tests/vision/perception-snapshot.test.ts tests/vision/perception-types-export.test.ts tests/vision/vision-find.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint -- --quiet`
- `git diff --check`

## Not tested
- Full `npm test -- --runInBand` was started and many suites passed, but it was stopped after more than 8 minutes because unrelated orchestration/session timers kept the process alive and began force-completing test workers. Targeted vision tests, build, dependency-cruiser, ESLint, and diff checks all passed.
