### PR TITLE
Expose stale ref snapshot provenance

### DIFF
--- a/docs/tools/dom-ref-staleness.md
+++ b/docs/tools/dom-ref-staleness.md
@@ -1,0 +1,10 @@
+# DOM/ref staleness metadata
+
+`read_page(mode: "ax")` returns lightweight snapshot metadata with the refs it mints:
+
+- top-level `snapshot`: `{ snapshotId, capturedAt, url, tabId }`
+- per-ref fields: `snapshot_id`, `snapshot_captured_at`, `snapshot_url`, `created_at`, and `stale_after_ms`
+
+Action tools that consume explicit refs still fail closed with `STALE_REF` when a ref is missing or TTL-expired. When available, the error includes a bounded `stale_warning` object so hosts can distinguish a missing/navigated snapshot from an old snapshot and refresh page state before retrying.
+
+This is advisory metadata only. OpenChrome does not automatically re-click, re-resolve, navigate, or recover from stale refs; callers should run `read_page` or `find` again and use the fresh ref.

--- a/src/tools/interact.ts
+++ b/src/tools/interact.ts
@@ -157,10 +157,16 @@ const handler: ToolHandler = async (
   if (refArg) {
     // Check if the ref is stale (missing or TTL-expired).
     if (refIdManager.isRefStale(sessionId, tabId, refArg)) {
+      const staleWarning = typeof refIdManager.getRefStalenessWarning === 'function'
+        ? refIdManager.getRefStalenessWarning(sessionId, tabId, refArg)
+        : undefined;
+      const warningText = staleWarning
+        ? `\nWarning: ${staleWarning.code}: ${staleWarning.message}`
+        : '';
       return {
-        content: [{ type: 'text', text: `STALE_REF: ref "${refArg}" is no longer valid (element may have changed or page navigated). Call read_page to get fresh refs.` }],
+        content: [{ type: 'text', text: `STALE_REF: ref "${refArg}" is no longer valid (element may have changed or page navigated). Call read_page to get fresh refs.${warningText}` }],
         isError: true,
-        error: { code: 'STALE_REF', ref_id: refArg },
+        error: { code: 'STALE_REF', ref_id: refArg, stale_warning: staleWarning },
       } as MCPResult;
     }
 

--- a/src/tools/read-page.ts
+++ b/src/tools/read-page.ts
@@ -6,7 +6,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, throwIfAborted } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
-import { getRefIdManager, REF_TTL_MS } from '../utils/ref-id-manager';
+import { getRefIdManager, REF_TTL_MS, type SnapshotRefMetadata } from '../utils/ref-id-manager';
 import { serializeDOM } from '../dom';
 import { detectPagination, PaginationInfo } from '../utils/pagination-detector';
 import { MAX_OUTPUT_CHARS } from '../config/defaults';
@@ -207,6 +207,16 @@ interface AXNode {
   value?: { value: string };
   childIds?: number[];
   properties?: Array<{ name: string; value: { value: unknown } }>;
+}
+
+
+function createReadPageSnapshotMetadata(tabId: string, url: string, capturedAt = Date.now()): SnapshotRefMetadata {
+  return {
+    snapshotId: `snap_${capturedAt.toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
+    capturedAt,
+    url,
+    tabId,
+  };
 }
 
 const handler: ToolHandler = async (
@@ -873,7 +883,11 @@ const handler: ToolHandler = async (
       frame_id?: string;
       created_at: number;
       stale_after_ms: number;
+      snapshot_id: string;
+      snapshot_captured_at: number;
+      snapshot_url: string;
     }> = {};
+    const snapshotMetadata = createReadPageSnapshotMetadata(tabId, axPageStats.url);
 
     function formatNode(node: AXNode, indent: number): void {
       if (charCount > MAX_OUTPUT) return;
@@ -925,7 +939,9 @@ const handler: ToolHandler = async (
           node.backendDOMNodeId,
           role,
           name,
-          tagName
+          tagName,
+          undefined,
+          { snapshot: snapshotMetadata }
         );
 
         // #831: record the structured ref entry for the response `refs` map.
@@ -940,6 +956,9 @@ const handler: ToolHandler = async (
           ...(entry?.frameId ? { frame_id: entry.frameId } : {}),
           created_at: entry?.createdAt ?? Date.now(),
           stale_after_ms: entry?.staleAfterMs ?? REF_TTL_MS,
+          snapshot_id: snapshotMetadata.snapshotId,
+          snapshot_captured_at: snapshotMetadata.capturedAt,
+          snapshot_url: snapshotMetadata.url,
         };
       }
 
@@ -1051,6 +1070,7 @@ const handler: ToolHandler = async (
             },
           ],
           refs: refsMap,
+          snapshot: snapshotMetadata,
         });
       }
 
@@ -1103,6 +1123,7 @@ const handler: ToolHandler = async (
             },
           ],
           refs: refsMap,
+          snapshot: snapshotMetadata,
         });
       }
     }
@@ -1110,6 +1131,7 @@ const handler: ToolHandler = async (
     return withDiagnostics({
       content: [{ type: 'text', text: pageStatsLine + output + axPaginationSection }],
       refs: refsMap,
+      snapshot: snapshotMetadata,
     });
   } catch (error) {
     return {

--- a/src/utils/ref-id-manager.ts
+++ b/src/utils/ref-id-manager.ts
@@ -37,6 +37,23 @@ export function formatStaleRefError(refId: string): string {
   return `STALE_REF: ref_id="${refId}" — ${STALE_REF_HINT}`;
 }
 
+export interface SnapshotRefMetadata {
+  snapshotId: string;
+  capturedAt: number;
+  url: string;
+  tabId: string;
+}
+
+export interface StaleSnapshotWarning {
+  code: 'stale_snapshot' | 'possibly_stale_snapshot';
+  message: string;
+  ref_id: string;
+  snapshot_id?: string;
+  captured_at?: number;
+  age_ms?: number;
+  hint: string;
+}
+
 export interface RefEntry {
   refId: string;
   backendDOMNodeId: number;
@@ -55,6 +72,8 @@ export interface RefEntry {
    * Refs resolve via backendDOMNodeId; frameId is metadata for clients.
    */
   frameId?: string;
+  /** Snapshot metadata from the page-state-producing call that minted this ref. */
+  snapshot?: SnapshotRefMetadata;
 }
 
 export class RefIdManager {
@@ -76,7 +95,7 @@ export class RefIdManager {
     name?: string,
     tagName?: string,
     textContent?: string,
-    options?: { staleAfterMs?: number; frameId?: string }
+    options?: { staleAfterMs?: number; frameId?: string; snapshot?: SnapshotRefMetadata }
   ): string {
     let sessionRefs = this.refs.get(sessionId);
     if (!sessionRefs) {
@@ -111,6 +130,7 @@ export class RefIdManager {
       createdAt: Date.now(),
       staleAfterMs: options?.staleAfterMs ?? REF_TTL_MS,
       frameId: options?.frameId,
+      snapshot: options?.snapshot,
     };
 
     targetRefs.set(refId, entry);
@@ -168,6 +188,36 @@ export class RefIdManager {
     const entry = this.getRef(sessionId, targetId, refId);
     if (!entry) return true;
     return Date.now() - entry.createdAt > entry.staleAfterMs;
+  }
+
+
+  getRefStalenessWarning(
+    sessionId: string,
+    targetId: string,
+    refId: string,
+    now = Date.now()
+  ): StaleSnapshotWarning | undefined {
+    const entry = this.getRef(sessionId, targetId, refId);
+    if (!entry) {
+      return {
+        code: 'stale_snapshot',
+        message: `Ref ${refId} is no longer present for tab ${targetId}; the page likely navigated, reloaded, or refreshed refs.`,
+        ref_id: refId,
+        hint: STALE_REF_HINT,
+      };
+    }
+
+    const ageMs = now - entry.createdAt;
+    if (ageMs <= entry.staleAfterMs) return undefined;
+    return {
+      code: 'possibly_stale_snapshot',
+      message: `Ref ${refId} is ${ageMs}ms old and exceeds stale_after_ms=${entry.staleAfterMs}.`,
+      ref_id: refId,
+      snapshot_id: entry.snapshot?.snapshotId,
+      captured_at: entry.snapshot?.capturedAt ?? entry.createdAt,
+      age_ms: ageMs,
+      hint: STALE_REF_HINT,
+    };
   }
 
   /**
@@ -411,7 +461,7 @@ export class RefIdManager {
         entry.name,
         entry.tagName,
         entry.textContent,
-        { staleAfterMs: entry.staleAfterMs, frameId: entry.frameId }
+        { staleAfterMs: entry.staleAfterMs, frameId: entry.frameId, snapshot: entry.snapshot }
       );
 
       return { backendNodeId: node.backendNodeId, newRef };

--- a/tests/tools/snapshot-refs.test.ts
+++ b/tests/tools/snapshot-refs.test.ts
@@ -147,9 +147,12 @@ describe('Snapshot Refs (#831)', () => {
       const result = await handler(testSessionId, {
         tabId: testTargetId,
         mode: 'ax',
-      }) as { content: Array<{ type: string; text: string }>; refs?: Record<string, unknown> };
+      }) as { content: Array<{ type: string; text: string }>; refs?: Record<string, unknown>; snapshot?: { snapshotId: string; capturedAt: number; url: string; tabId: string } };
 
       expect(result.refs).toBeDefined();
+      expect(result.snapshot).toBeDefined();
+      expect(result.snapshot?.tabId).toBe(testTargetId);
+      expect(result.snapshot?.url).toBe('https://example.com');
       const refs = result.refs as Record<string, {
         role: string;
         name?: string;
@@ -158,6 +161,9 @@ describe('Snapshot Refs (#831)', () => {
         frame_id?: string;
         created_at: number;
         stale_after_ms: number;
+        snapshot_id: string;
+        snapshot_captured_at: number;
+        snapshot_url: string;
       }>;
       // At least one ref produced from sampleAccessibilityTree
       const refKeys = Object.keys(refs);
@@ -168,6 +174,9 @@ describe('Snapshot Refs (#831)', () => {
         expect(typeof entry.role).toBe('string');
         expect(typeof entry.created_at).toBe('number');
         expect(typeof entry.stale_after_ms).toBe('number');
+        expect(entry.snapshot_id).toBe(result.snapshot?.snapshotId);
+        expect(entry.snapshot_captured_at).toBe(result.snapshot?.capturedAt);
+        expect(entry.snapshot_url).toBe(result.snapshot?.url);
         // Default TTL is 30s
         expect(entry.stale_after_ms).toBeGreaterThan(0);
       }
@@ -217,6 +226,12 @@ describe('Snapshot Refs (#831)', () => {
       (mockRefIdManager.isRefStale as jest.Mock).mockImplementation(
         (sid: string, tid: string, r: string) => r === refId,
       );
+      (mockRefIdManager.getRefStalenessWarning as jest.Mock).mockReturnValue({
+        code: 'possibly_stale_snapshot',
+        message: 'Ref exceeded stale_after_ms.',
+        ref_id: refId,
+        hint: "call read_page (mode='ax') to get fresh refs",
+      });
 
       const result = await handler(testSessionId, {
         tabId: testTargetId,
@@ -224,7 +239,7 @@ describe('Snapshot Refs (#831)', () => {
         action: 'click',
       }) as {
         content: Array<{ type: string; text: string }>;
-        error?: { code: string; ref_id: string };
+        error?: { code: string; ref_id: string; stale_warning?: { code: string; ref_id: string } };
         isError?: boolean;
       };
 
@@ -234,6 +249,7 @@ describe('Snapshot Refs (#831)', () => {
       expect(result.error).toBeDefined();
       expect(result.error?.code).toBe('STALE_REF');
       expect(result.error?.ref_id).toBe(refId);
+      expect(result.error?.stale_warning?.ref_id).toBe(refId);
     });
 
     test('stale ref (post-navigation, entry cleared) → STALE_REF error', async () => {
@@ -249,13 +265,14 @@ describe('Snapshot Refs (#831)', () => {
         action: 'click',
       }) as {
         content: Array<{ type: string; text: string }>;
-        error?: { code: string; ref_id: string };
+        error?: { code: string; ref_id: string; stale_warning?: { code: string; ref_id: string } };
         isError?: boolean;
       };
 
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('STALE_REF');
       expect(result.error?.code).toBe('STALE_REF');
+      expect(result.error?.stale_warning?.code).toBe('stale_snapshot');
     });
   });
 

--- a/tests/utils/mock-session.ts
+++ b/tests/utils/mock-session.ts
@@ -367,12 +367,12 @@ export function createMockSessionManager(options: MockSessionManagerOptions = {}
  * Creates a simple mock RefIdManager for testing
  */
 export function createMockRefIdManager() {
-  const refs: Map<string, Map<string, Map<string, { refId: string; backendDOMNodeId: number; role: string; name?: string; tagName?: string; textContent?: string; createdAt: number }>>> = new Map();
+  const refs: Map<string, Map<string, Map<string, { refId: string; backendDOMNodeId: number; role: string; name?: string; tagName?: string; textContent?: string; createdAt: number; staleAfterMs: number; snapshot?: { snapshotId: string; capturedAt: number; url: string; tabId: string } }>>> = new Map();
   const counters: Map<string, Map<string, number>> = new Map();
 
   return {
     generateRef: jest.fn().mockImplementation(
-      (sessionId: string, targetId: string, backendDOMNodeId: number, role: string, name?: string, tagName?: string, textContent?: string) => {
+      (sessionId: string, targetId: string, backendDOMNodeId: number, role: string, name?: string, tagName?: string, textContent?: string, options?: { staleAfterMs?: number; snapshot?: { snapshotId: string; capturedAt: number; url: string; tabId: string } }) => {
         if (!refs.has(sessionId)) {
           refs.set(sessionId, new Map());
         }
@@ -398,6 +398,8 @@ export function createMockRefIdManager() {
           tagName,
           textContent,
           createdAt: Date.now(),
+          staleAfterMs: options?.staleAfterMs ?? 30_000,
+          snapshot: options?.snapshot,
         });
 
         return refId;
@@ -449,7 +451,31 @@ export function createMockRefIdManager() {
     isRefStale: jest.fn().mockImplementation((sessionId: string, targetId: string, refId: string) => {
       const entry = refs.get(sessionId)?.get(targetId)?.get(refId);
       if (!entry) return true;
-      return Date.now() - entry.createdAt > 30_000;
+      return Date.now() - entry.createdAt > entry.staleAfterMs;
+    }),
+
+
+    getRefStalenessWarning: jest.fn().mockImplementation((sessionId: string, targetId: string, refId: string) => {
+      const entry = refs.get(sessionId)?.get(targetId)?.get(refId);
+      if (!entry) {
+        return {
+          code: 'stale_snapshot',
+          message: `Ref ${refId} is no longer present for tab ${targetId}; the page likely navigated, reloaded, or refreshed refs.`,
+          ref_id: refId,
+          hint: "call read_page (mode='ax') to get fresh refs",
+        };
+      }
+      const ageMs = Date.now() - entry.createdAt;
+      if (ageMs <= entry.staleAfterMs) return undefined;
+      return {
+        code: 'possibly_stale_snapshot',
+        message: `Ref ${refId} is ${ageMs}ms old and exceeds stale_after_ms=${entry.staleAfterMs}.`,
+        ref_id: refId,
+        snapshot_id: entry.snapshot?.snapshotId,
+        captured_at: entry.snapshot?.capturedAt ?? entry.createdAt,
+        age_ms: ageMs,
+        hint: "call read_page (mode='ax') to get fresh refs",
+      };
     }),
 
     validateRef: jest.fn().mockImplementation((sessionId: string, targetId: string, refId: string, currentNodeName: string, currentTextContent?: string) => {
@@ -470,7 +496,7 @@ export function createMockRefIdManager() {
         }
       }
 
-      return { valid: true, stale: Date.now() - entry.createdAt > 30_000 };
+      return { valid: true, stale: Date.now() - entry.createdAt > entry.staleAfterMs };
     }),
 
     tryRelocateRef: jest.fn().mockResolvedValue(null),


### PR DESCRIPTION
## Summary
- Adds `read_page(mode: "ax")` snapshot provenance (`snapshotId`, `capturedAt`, `url`, `tabId`) alongside minted refs.
- Stores that provenance in `RefEntry` and includes per-ref `snapshot_id`, `snapshot_captured_at`, and `snapshot_url` metadata.
- Returns bounded `stale_warning` details on explicit `interact(ref: ...)` STALE_REF failures so hosts know to refresh page state instead of repeating stale context.
- Documents the advisory stale-ref metadata contract.

## Issue coverage
- Closes #1033.
- Keeps behavior lightweight/advisory: no automatic retry, re-click, re-resolve, navigation, or recovery.
- Existing hard fail-closed `STALE_REF` behavior remains intact for missing/expired refs.

## Verification
- `npm ci`
- `npm test -- tests/tools/snapshot-refs.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint -- --quiet`
- `git diff --check`

## Not tested
- Live MCP fixture scenario for navigation/DOM replacement staleness. Unit coverage verifies AX snapshot metadata and stale warning propagation.
