### PR TITLE
Add checkpoint timeline navigation

### DIFF
--- a/docs/tools/checkpoint-timeline.md
+++ b/docs/tools/checkpoint-timeline.md
@@ -1,0 +1,16 @@
+# Checkpoint timeline
+
+`oc_checkpoint` keeps its original `save`, `load`, and `delete` behavior, and now also writes a bounded append-only timeline under the checkpoint directory.
+
+## Actions
+
+- `save`: writes `current-checkpoint.json` and a timeline entry under `timeline/<checkpointId>.json`. The response includes `checkpointId` and, when available, `parentId`.
+- `list`: returns recent checkpoints newest-first with labels, age, current URL, step counts, tab count, journal range, and retention limits. Empty directories return an empty list.
+- `load`: without `checkpointId`, loads the latest/current checkpoint for backward compatibility. With `checkpointId`, loads that timeline entry.
+- `delete`: without `checkpointId`, deletes the current checkpoint. With `checkpointId`, deletes that timeline entry and also clears current if it points at the same id.
+
+## Bounds and recovery model
+
+Timeline retention defaults to 10 entries and can be adjusted with `OPENCHROME_CHECKPOINT_TIMELINE_MAX` (1..100). Corrupt timeline entries are skipped with warnings in `list`; they do not crash the server.
+
+The timeline is a read model for caller-controlled recovery. OpenChrome does not replay actions, roll back website side effects, or choose a new plan.

--- a/src/tools/checkpoint.ts
+++ b/src/tools/checkpoint.ts
@@ -320,6 +320,18 @@ const handler: ToolHandler = async (
   const action = args.action as string;
 
   if (action === 'save') {
+    if (args.completedSteps !== undefined && !isStringArray(args.completedSteps)) {
+      return { content: [{ type: 'text', text: 'completedSteps must be an array of strings.' }], isError: true };
+    }
+    if (args.pendingSteps !== undefined && !isStringArray(args.pendingSteps)) {
+      return { content: [{ type: 'text', text: 'pendingSteps must be an array of strings.' }], isError: true };
+    }
+    if (args.extractedData !== undefined && (!args.extractedData || typeof args.extractedData !== 'object' || Array.isArray(args.extractedData))) {
+      return { content: [{ type: 'text', text: 'extractedData must be an object.' }], isError: true };
+    }
+    const completedSteps = args.completedSteps === undefined ? [] : args.completedSteps;
+    const pendingSteps = args.pendingSteps === undefined ? [] : args.pendingSteps;
+    const extractedData = (args.extractedData as Record<string, unknown> | undefined) ?? {};
     const tabStates = await collectTabStates();
     const currentUrl = tabStates.length > 0 ? tabStates[0].url : null;
     const timestamp = Date.now();
@@ -335,12 +347,12 @@ const handler: ToolHandler = async (
       sessionId,
       ...(typeof args.label === 'string' && args.label.trim() ? { label: args.label.trim().slice(0, 120) } : {}),
       taskDescription: (args.taskDescription as string) || '',
-      completedSteps: (args.completedSteps as string[]) || [],
-      pendingSteps: (args.pendingSteps as string[]) || [],
+      completedSteps,
+      pendingSteps,
       currentUrl,
       tabStates,
       journalRange: { fromTs: previous?.timestamp ?? timestamp, toTs: timestamp },
-      extractedData: (args.extractedData as Record<string, unknown>) || {},
+      extractedData,
     };
 
     await fs.promises.mkdir(getCheckpointDir(), { recursive: true });

--- a/src/tools/checkpoint.ts
+++ b/src/tools/checkpoint.ts
@@ -141,6 +141,12 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item) => typeof item === 'string');
 }
 
+function isValidCheckpointTimestamp(value: unknown): value is number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return false;
+  if (value < 0 || Math.abs(value) > 8.64e15) return false;
+  return !Number.isNaN(new Date(value).getTime());
+}
+
 function isTabStateArray(value: unknown): value is AutomationCheckpoint['tabStates'] {
   return Array.isArray(value) && value.every((tab) => (
     tab &&
@@ -155,8 +161,8 @@ function isAutomationCheckpoint(value: unknown): value is AutomationCheckpoint {
   if (!value || typeof value !== 'object') return false;
   const cp = value as Record<string, unknown>;
   return cp.version === 1 &&
-    typeof cp.timestamp === 'number' &&
-    Number.isFinite(cp.timestamp) &&
+    isValidCheckpointTimestamp(cp.timestamp) &&
+    (cp.createdAt === undefined || isValidCheckpointTimestamp(cp.createdAt)) &&
     typeof cp.taskDescription === 'string' &&
     isStringArray(cp.completedSteps) &&
     isStringArray(cp.pendingSteps) &&
@@ -170,7 +176,7 @@ function isAutomationCheckpoint(value: unknown): value is AutomationCheckpoint {
 function toListEntry(cp: AutomationCheckpoint, now = Date.now()): CheckpointListEntry | null {
   if (!isAutomationCheckpoint(cp) || !cp.checkpointId) return null;
   const createdAt = cp.createdAt ?? cp.timestamp;
-  if (!Number.isFinite(createdAt)) return null;
+  if (!isValidCheckpointTimestamp(createdAt)) return null;
   return {
     checkpointId: cp.checkpointId,
     ...(cp.parentId ? { parentId: cp.parentId } : {}),
@@ -229,14 +235,17 @@ async function pruneTimeline(): Promise<void> {
   const { checkpoints } = await readTimelineEntries();
   for (const cp of checkpoints.slice(limit)) {
     if (!cp.checkpointId) continue;
-    await fs.promises.unlink(timelinePathFor(cp.checkpointId)).catch(() => undefined);
+    const safeId = sanitizeCheckpointId(cp.checkpointId);
+    if (!safeId) continue;
+    await fs.promises.unlink(timelinePathFor(safeId)).catch(() => undefined);
   }
 }
 
 async function writeCheckpointTimeline(checkpoint: AutomationCheckpoint): Promise<void> {
-  if (!checkpoint.checkpointId) return;
+  const safeId = checkpoint.checkpointId ? sanitizeCheckpointId(checkpoint.checkpointId) : null;
+  if (!safeId) return;
   await fs.promises.mkdir(getTimelineDir(), { recursive: true });
-  await writeFileAtomicSafe(timelinePathFor(checkpoint.checkpointId), checkpoint);
+  await writeFileAtomicSafe(timelinePathFor(safeId), checkpoint);
   await pruneTimeline();
 }
 

--- a/src/tools/checkpoint.ts
+++ b/src/tools/checkpoint.ts
@@ -216,7 +216,11 @@ async function readTimelineEntries(): Promise<{ checkpoints: AutomationCheckpoin
     if (warning) warnings.push(warning);
     if (checkpoint?.checkpointId) checkpoints.push(checkpoint);
   }
-  checkpoints.sort((a, b) => (b.createdAt ?? b.timestamp) - (a.createdAt ?? a.timestamp));
+  checkpoints.sort((a, b) => {
+    const timeDiff = (b.createdAt ?? b.timestamp) - (a.createdAt ?? a.timestamp);
+    if (timeDiff !== 0) return timeDiff;
+    return (b.checkpointId ?? '').localeCompare(a.checkpointId ?? '');
+  });
   return { checkpoints, warnings };
 }
 

--- a/src/tools/checkpoint.ts
+++ b/src/tools/checkpoint.ts
@@ -137,9 +137,40 @@ function parseRetentionLimit(): number {
   return Math.min(Math.max(Math.floor(raw), 1), 100);
 }
 
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function isTabStateArray(value: unknown): value is AutomationCheckpoint['tabStates'] {
+  return Array.isArray(value) && value.every((tab) => (
+    tab &&
+    typeof tab === 'object' &&
+    typeof (tab as Record<string, unknown>).tabId === 'string' &&
+    typeof (tab as Record<string, unknown>).url === 'string' &&
+    typeof (tab as Record<string, unknown>).title === 'string'
+  ));
+}
+
+function isAutomationCheckpoint(value: unknown): value is AutomationCheckpoint {
+  if (!value || typeof value !== 'object') return false;
+  const cp = value as Record<string, unknown>;
+  return cp.version === 1 &&
+    typeof cp.timestamp === 'number' &&
+    Number.isFinite(cp.timestamp) &&
+    typeof cp.taskDescription === 'string' &&
+    isStringArray(cp.completedSteps) &&
+    isStringArray(cp.pendingSteps) &&
+    (typeof cp.currentUrl === 'string' || cp.currentUrl === null) &&
+    isTabStateArray(cp.tabStates) &&
+    Boolean(cp.extractedData) &&
+    typeof cp.extractedData === 'object' &&
+    (cp.checkpointId === undefined || typeof cp.checkpointId === 'string');
+}
+
 function toListEntry(cp: AutomationCheckpoint, now = Date.now()): CheckpointListEntry | null {
-  if (!cp.checkpointId) return null;
+  if (!isAutomationCheckpoint(cp) || !cp.checkpointId) return null;
   const createdAt = cp.createdAt ?? cp.timestamp;
+  if (!Number.isFinite(createdAt)) return null;
   return {
     checkpointId: cp.checkpointId,
     ...(cp.parentId ? { parentId: cp.parentId } : {}),
@@ -157,9 +188,12 @@ function toListEntry(cp: AutomationCheckpoint, now = Date.now()): CheckpointList
 }
 
 async function readTimelineCheckpoint(filePath: string): Promise<{ checkpoint: AutomationCheckpoint | null; warning?: string }> {
-  const result = await readFileSafe<AutomationCheckpoint>(filePath);
+  const result = await readFileSafe<unknown>(filePath);
   if (!result.success || !result.data) {
     return { checkpoint: null, warning: `Skipped corrupt checkpoint timeline entry: ${path.basename(filePath)}` };
+  }
+  if (!isAutomationCheckpoint(result.data) || !result.data.checkpointId) {
+    return { checkpoint: null, warning: `Skipped invalid checkpoint timeline entry: ${path.basename(filePath)}` };
   }
   return { checkpoint: result.data };
 }
@@ -351,7 +385,11 @@ const handler: ToolHandler = async (
 
   if (action === 'load') {
     const checkpointId = typeof args.checkpointId === 'string' ? args.checkpointId : undefined;
-    const cp = checkpointId ? await readCheckpointById(checkpointId) : await readCurrentCheckpoint();
+    let cp = checkpointId ? await readCheckpointById(checkpointId) : await readCurrentCheckpoint();
+    if (!cp && !checkpointId) {
+      const timeline = await readTimelineEntries();
+      cp = timeline.checkpoints[0] ?? null;
+    }
     if (!cp) {
       return {
         content: [

--- a/src/tools/checkpoint.ts
+++ b/src/tools/checkpoint.ts
@@ -288,15 +288,16 @@ async function collectTabStates(): Promise<Array<{ tabId: string; url: string; t
 // ─── Handler ───────────────────────────────────────────────────────────────
 
 export async function readCurrentCheckpoint(): Promise<AutomationCheckpoint | null> {
-  const result = await readFileSafe<AutomationCheckpoint>(getCurrentCheckpointPath());
-  return result.success && result.data ? result.data : null;
+  const result = await readFileSafe<unknown>(getCurrentCheckpointPath());
+  return result.success && isAutomationCheckpoint(result.data) ? result.data : null;
 }
 
 export async function readCheckpointById(checkpointId: string): Promise<AutomationCheckpoint | null> {
   const safeId = sanitizeCheckpointId(checkpointId);
   if (!safeId) return null;
-  const result = await readFileSafe<AutomationCheckpoint>(timelinePathFor(safeId));
-  return result.success && result.data ? result.data : null;
+  const result = await readFileSafe<unknown>(timelinePathFor(safeId));
+  if (!result.success || !isAutomationCheckpoint(result.data)) return null;
+  return result.data.checkpointId === safeId ? result.data : null;
 }
 
 const handler: ToolHandler = async (
@@ -450,19 +451,27 @@ const handler: ToolHandler = async (
       return { content: [{ type: 'text', text: `Checkpoint ${safeId} deleted.` }] };
     }
 
+    const current = await readCurrentCheckpoint();
+    const fallbackTimeline = current?.checkpointId ? null : (await readTimelineEntries()).checkpoints[0] ?? null;
+    const timelineId = current?.checkpointId ?? fallbackTimeline?.checkpointId;
+    let deleted = false;
+
     try {
       await fs.promises.unlink(getCurrentCheckpointPath());
-      return {
-        content: [{ type: 'text', text: 'Checkpoint deleted.' }],
-      };
+      deleted = true;
     } catch (error: unknown) {
-      if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
-        return {
-          content: [{ type: 'text', text: 'No checkpoint to delete.' }],
-        };
-      }
-      throw error;
+      if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') throw error;
     }
+
+    if (timelineId) {
+      await fs.promises.unlink(timelinePathFor(timelineId)).then(() => { deleted = true; }).catch((error: NodeJS.ErrnoException) => {
+        if (error.code !== 'ENOENT') throw error;
+      });
+    }
+
+    return {
+      content: [{ type: 'text', text: deleted ? 'Checkpoint deleted.' : 'No checkpoint to delete.' }],
+    };
   }
 
   return {

--- a/src/tools/checkpoint.ts
+++ b/src/tools/checkpoint.ts
@@ -20,34 +20,65 @@ import { getActiveActionRecorder } from '../recording/action-recorder';
 export interface AutomationCheckpoint {
   version: 1;
   timestamp: number;
+  checkpointId?: string;
+  parentId?: string;
+  createdAt?: number;
+  sessionId?: string;
+  label?: string;
   taskDescription: string;
   completedSteps: string[];
   pendingSteps: string[];
   currentUrl: string | null;
-  tabStates: Array<{ tabId: string; url: string; title: string }>;
+  tabStates: Array<{ tabId: string; url: string; title: string; health?: 'unknown' }>;
+  journalRange?: { fromTs: number; toTs: number };
   extractedData: Record<string, unknown>;
+}
+
+export interface CheckpointListEntry {
+  checkpointId: string;
+  parentId?: string;
+  createdAt: number;
+  savedAt: string;
+  ageMs: number;
+  sessionId?: string;
+  label?: string;
+  currentUrl: string | null;
+  pendingSteps: number;
+  completedSteps: number;
+  tabs: number;
+  journalRange?: { fromTs: number; toTs: number };
 }
 
 // ─── Constants ─────────────────────────────────────────────────────────────
 
 export const CHECKPOINT_DIR = path.join(os.homedir(), '.openchrome', 'checkpoints');
 export const CHECKPOINT_FILE = 'current-checkpoint.json';
+const TIMELINE_DIR = 'timeline';
+const DEFAULT_MAX_TIMELINE_CHECKPOINTS = 10;
 
 // ─── Tool Definition ───────────────────────────────────────────────────────
 
 const definition: MCPToolDefinition = {
   name: 'oc_checkpoint',
   description:
-    'Save or load an automation checkpoint for long-running session continuity. ' +
-    'Use "save" to persist current task state, "load" to restore after context compaction, ' +
-    '"delete" to clean up.',
+    'Save, load, list, or delete automation checkpoints for long-running session continuity. ' +
+    'Use "save" to persist current task state, "list" to inspect the bounded checkpoint timeline, ' +
+    '"load" to restore metadata after context compaction, and "delete" to clean up.',
   inputSchema: {
     type: 'object',
     properties: {
       action: {
         type: 'string',
-        enum: ['save', 'load', 'delete'],
+        enum: ['save', 'load', 'list', 'delete'],
         description: 'Action to perform',
+      },
+      checkpointId: {
+        type: 'string',
+        description: 'Specific checkpoint id for load/delete. Omit to use latest/current checkpoint.',
+      },
+      label: {
+        type: 'string',
+        description: 'Optional short label for timeline inspection (save only).',
       },
       taskDescription: {
         type: 'string',
@@ -73,10 +104,108 @@ const definition: MCPToolDefinition = {
   annotations: TOOL_ANNOTATIONS.oc_checkpoint,
 };
 
+// ─── Persistence Helpers ───────────────────────────────────────────────────
+
+export function getCheckpointDir(): string {
+  return process.env.OPENCHROME_CHECKPOINT_DIR || CHECKPOINT_DIR;
+}
+
+function getCurrentCheckpointPath(): string {
+  return path.join(getCheckpointDir(), CHECKPOINT_FILE);
+}
+
+function getTimelineDir(): string {
+  return path.join(getCheckpointDir(), TIMELINE_DIR);
+}
+
+function sanitizeCheckpointId(id: string): string | null {
+  if (!/^cp_[a-z0-9]+_[a-z0-9]+$/i.test(id)) return null;
+  return id;
+}
+
+function generateCheckpointId(timestamp: number): string {
+  return `cp_${timestamp.toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function timelinePathFor(checkpointId: string): string {
+  return path.join(getTimelineDir(), `${checkpointId}.json`);
+}
+
+function parseRetentionLimit(): number {
+  const raw = Number(process.env.OPENCHROME_CHECKPOINT_TIMELINE_MAX || DEFAULT_MAX_TIMELINE_CHECKPOINTS);
+  if (!Number.isFinite(raw)) return DEFAULT_MAX_TIMELINE_CHECKPOINTS;
+  return Math.min(Math.max(Math.floor(raw), 1), 100);
+}
+
+function toListEntry(cp: AutomationCheckpoint, now = Date.now()): CheckpointListEntry | null {
+  if (!cp.checkpointId) return null;
+  const createdAt = cp.createdAt ?? cp.timestamp;
+  return {
+    checkpointId: cp.checkpointId,
+    ...(cp.parentId ? { parentId: cp.parentId } : {}),
+    createdAt,
+    savedAt: new Date(createdAt).toISOString(),
+    ageMs: Math.max(0, now - createdAt),
+    ...(cp.sessionId ? { sessionId: cp.sessionId } : {}),
+    ...(cp.label ? { label: cp.label } : {}),
+    currentUrl: cp.currentUrl,
+    pendingSteps: cp.pendingSteps.length,
+    completedSteps: cp.completedSteps.length,
+    tabs: cp.tabStates.length,
+    ...(cp.journalRange ? { journalRange: cp.journalRange } : {}),
+  };
+}
+
+async function readTimelineCheckpoint(filePath: string): Promise<{ checkpoint: AutomationCheckpoint | null; warning?: string }> {
+  const result = await readFileSafe<AutomationCheckpoint>(filePath);
+  if (!result.success || !result.data) {
+    return { checkpoint: null, warning: `Skipped corrupt checkpoint timeline entry: ${path.basename(filePath)}` };
+  }
+  return { checkpoint: result.data };
+}
+
+async function readTimelineEntries(): Promise<{ checkpoints: AutomationCheckpoint[]; warnings: string[] }> {
+  const dir = getTimelineDir();
+  const warnings: string[] = [];
+  let names: string[] = [];
+  try {
+    names = await fs.promises.readdir(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { checkpoints: [], warnings };
+    throw err;
+  }
+
+  const checkpoints: AutomationCheckpoint[] = [];
+  for (const name of names) {
+    if (!name.endsWith('.json')) continue;
+    const { checkpoint, warning } = await readTimelineCheckpoint(path.join(dir, name));
+    if (warning) warnings.push(warning);
+    if (checkpoint?.checkpointId) checkpoints.push(checkpoint);
+  }
+  checkpoints.sort((a, b) => (b.createdAt ?? b.timestamp) - (a.createdAt ?? a.timestamp));
+  return { checkpoints, warnings };
+}
+
+async function pruneTimeline(): Promise<void> {
+  const limit = parseRetentionLimit();
+  const { checkpoints } = await readTimelineEntries();
+  for (const cp of checkpoints.slice(limit)) {
+    if (!cp.checkpointId) continue;
+    await fs.promises.unlink(timelinePathFor(cp.checkpointId)).catch(() => undefined);
+  }
+}
+
+async function writeCheckpointTimeline(checkpoint: AutomationCheckpoint): Promise<void> {
+  if (!checkpoint.checkpointId) return;
+  await fs.promises.mkdir(getTimelineDir(), { recursive: true });
+  await writeFileAtomicSafe(timelinePathFor(checkpoint.checkpointId), checkpoint);
+  await pruneTimeline();
+}
+
 // ─── Tab Collection ────────────────────────────────────────────────────────
 
-async function collectTabStates(): Promise<Array<{ tabId: string; url: string; title: string }>> {
-  const tabStates: Array<{ tabId: string; url: string; title: string }> = [];
+async function collectTabStates(): Promise<Array<{ tabId: string; url: string; title: string; health: 'unknown' }>> {
+  const tabStates: Array<{ tabId: string; url: string; title: string; health: 'unknown' }> = [];
 
   try {
     const sessionManager = getSessionManager();
@@ -107,7 +236,7 @@ async function collectTabStates(): Promise<Array<{ tabId: string; url: string; t
             // Page may be closed or crashed
           }
 
-          tabStates.push({ tabId: targetId, url, title });
+          tabStates.push({ tabId: targetId, url, title, health: 'unknown' });
         }
       }
     }
@@ -125,8 +254,14 @@ async function collectTabStates(): Promise<Array<{ tabId: string; url: string; t
 // ─── Handler ───────────────────────────────────────────────────────────────
 
 export async function readCurrentCheckpoint(): Promise<AutomationCheckpoint | null> {
-  const checkpointPath = path.join(CHECKPOINT_DIR, CHECKPOINT_FILE);
-  const result = await readFileSafe<AutomationCheckpoint>(checkpointPath);
+  const result = await readFileSafe<AutomationCheckpoint>(getCurrentCheckpointPath());
+  return result.success && result.data ? result.data : null;
+}
+
+export async function readCheckpointById(checkpointId: string): Promise<AutomationCheckpoint | null> {
+  const safeId = sanitizeCheckpointId(checkpointId);
+  if (!safeId) return null;
+  const result = await readFileSafe<AutomationCheckpoint>(timelinePathFor(safeId));
   return result.success && result.data ? result.data : null;
 }
 
@@ -134,27 +269,35 @@ const handler: ToolHandler = async (
   sessionId: string,
   args: Record<string, unknown>,
 ): Promise<MCPResult> => {
-  const checkpointPath = path.join(CHECKPOINT_DIR, CHECKPOINT_FILE);
   const action = args.action as string;
 
   if (action === 'save') {
     const tabStates = await collectTabStates();
     const currentUrl = tabStates.length > 0 ? tabStates[0].url : null;
+    const timestamp = Date.now();
+    const previous = await readCurrentCheckpoint();
+    const checkpointId = generateCheckpointId(timestamp);
 
     const checkpoint: AutomationCheckpoint = {
       version: 1,
-      timestamp: Date.now(),
+      timestamp,
+      checkpointId,
+      ...(previous?.checkpointId ? { parentId: previous.checkpointId } : {}),
+      createdAt: timestamp,
+      sessionId,
+      ...(typeof args.label === 'string' && args.label.trim() ? { label: args.label.trim().slice(0, 120) } : {}),
       taskDescription: (args.taskDescription as string) || '',
       completedSteps: (args.completedSteps as string[]) || [],
       pendingSteps: (args.pendingSteps as string[]) || [],
       currentUrl,
       tabStates,
+      journalRange: { fromTs: previous?.timestamp ?? timestamp, toTs: timestamp },
       extractedData: (args.extractedData as Record<string, unknown>) || {},
     };
 
-    // Ensure directory exists (writeFileAtomicSafe also does this, but explicit for clarity)
-    await fs.promises.mkdir(CHECKPOINT_DIR, { recursive: true });
-    await writeFileAtomicSafe(checkpointPath, checkpoint);
+    await fs.promises.mkdir(getCheckpointDir(), { recursive: true });
+    await writeFileAtomicSafe(getCurrentCheckpointPath(), checkpoint);
+    await writeCheckpointTimeline(checkpoint);
 
     try {
       await getActiveActionRecorder(sessionId)?.appendCheckpoint(checkpoint as unknown as Record<string, unknown>);
@@ -169,6 +312,8 @@ const handler: ToolHandler = async (
           text: JSON.stringify(
             {
               status: 'saved',
+              checkpointId,
+              parentId: checkpoint.parentId,
               timestamp: new Date(checkpoint.timestamp).toISOString(),
               completedSteps: checkpoint.completedSteps.length,
               pendingSteps: checkpoint.pendingSteps.length,
@@ -182,14 +327,39 @@ const handler: ToolHandler = async (
     };
   }
 
+  if (action === 'list') {
+    const { checkpoints, warnings } = await readTimelineEntries();
+    const entries = checkpoints.map((cp) => toListEntry(cp)).filter((entry): entry is CheckpointListEntry => Boolean(entry));
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              status: 'listed',
+              checkpoints: entries,
+              warnings,
+              limits: { maxCheckpoints: parseRetentionLimit() },
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  }
+
   if (action === 'load') {
-    const cp = await readCurrentCheckpoint();
+    const checkpointId = typeof args.checkpointId === 'string' ? args.checkpointId : undefined;
+    const cp = checkpointId ? await readCheckpointById(checkpointId) : await readCurrentCheckpoint();
     if (!cp) {
       return {
         content: [
           {
             type: 'text',
-            text: 'No checkpoint found. Start fresh or save a checkpoint first.',
+            text: checkpointId
+              ? `No checkpoint found for checkpointId "${checkpointId}".`
+              : 'No checkpoint found. Start fresh or save a checkpoint first.',
           },
         ],
       };
@@ -205,13 +375,18 @@ const handler: ToolHandler = async (
           text: JSON.stringify(
             {
               status: 'loaded',
+              checkpointId: cp.checkpointId,
+              parentId: cp.parentId,
               savedAt: new Date(cp.timestamp).toISOString(),
               ageHours,
+              sessionId: cp.sessionId,
+              label: cp.label,
               taskDescription: cp.taskDescription,
               completedSteps: cp.completedSteps,
               pendingSteps: cp.pendingSteps,
               currentUrl: cp.currentUrl,
               tabStates: cp.tabStates,
+              journalRange: cp.journalRange,
               extractedData: cp.extractedData,
             },
             null,
@@ -223,8 +398,22 @@ const handler: ToolHandler = async (
   }
 
   if (action === 'delete') {
+    const checkpointId = typeof args.checkpointId === 'string' ? args.checkpointId : undefined;
+    if (checkpointId) {
+      const safeId = sanitizeCheckpointId(checkpointId);
+      if (!safeId) {
+        return { content: [{ type: 'text', text: `Invalid checkpointId: ${checkpointId}` }], isError: true };
+      }
+      await fs.promises.unlink(timelinePathFor(safeId)).catch((error: NodeJS.ErrnoException) => {
+        if (error.code !== 'ENOENT') throw error;
+      });
+      const current = await readCurrentCheckpoint();
+      if (current?.checkpointId === safeId) await fs.promises.unlink(getCurrentCheckpointPath()).catch(() => undefined);
+      return { content: [{ type: 'text', text: `Checkpoint ${safeId} deleted.` }] };
+    }
+
     try {
-      await fs.promises.unlink(checkpointPath);
+      await fs.promises.unlink(getCurrentCheckpointPath());
       return {
         content: [{ type: 'text', text: 'Checkpoint deleted.' }],
       };
@@ -242,7 +431,7 @@ const handler: ToolHandler = async (
     content: [
       {
         type: 'text',
-        text: `Unknown action: ${action}. Use save, load, or delete.`,
+        text: `Unknown action: ${action}. Use save, load, list, or delete.`,
       },
     ],
     isError: true,

--- a/tests/tools/checkpoint-timeline.test.ts
+++ b/tests/tools/checkpoint-timeline.test.ts
@@ -205,6 +205,51 @@ describe('oc_checkpoint timeline (#1025)', () => {
     }
   });
 
+  test('list rejects out-of-range checkpoint timestamps without throwing', async () => {
+    const handler = await loadHandler();
+    const timelineDir = path.join(tmpDir, 'timeline');
+    fs.mkdirSync(timelineDir, { recursive: true });
+    fs.writeFileSync(path.join(timelineDir, 'cp_bad_time.json'), JSON.stringify({
+      version: 1,
+      timestamp: Number.MAX_VALUE,
+      checkpointId: 'cp_bad_time',
+      taskDescription: 'bad time',
+      completedSteps: [],
+      pendingSteps: [],
+      currentUrl: null,
+      tabStates: [],
+      extractedData: {},
+    }));
+
+    const listed = readJson(await handler('sess-1', { action: 'list' }));
+    expect(listed.checkpoints).toEqual([]);
+    expect(listed.warnings.join('\n')).toContain('Skipped invalid checkpoint timeline entry');
+  });
+
+  test('retention sanitizes checkpoint ids before pruning timeline files', async () => {
+    process.env.OPENCHROME_CHECKPOINT_TIMELINE_MAX = '1';
+    const handler = await loadHandler();
+    const timelineDir = path.join(tmpDir, 'timeline');
+    fs.mkdirSync(timelineDir, { recursive: true });
+    const outsidePath = path.join(tmpDir, 'outside.json');
+    fs.writeFileSync(outsidePath, JSON.stringify({ keep: true }));
+    fs.writeFileSync(path.join(timelineDir, 'malicious.json'), JSON.stringify({
+      version: 1,
+      timestamp: 1,
+      checkpointId: '../outside',
+      taskDescription: 'malicious',
+      completedSteps: [],
+      pendingSteps: [],
+      currentUrl: null,
+      tabStates: [],
+      extractedData: {},
+    }));
+
+    await handler('sess-1', { action: 'save', taskDescription: 'newest' });
+
+    expect(fs.existsSync(outsidePath)).toBe(true);
+  });
+
   test('retention prunes old timeline artifacts only', async () => {
     process.env.OPENCHROME_CHECKPOINT_TIMELINE_MAX = '2';
     const handler = await loadHandler();

--- a/tests/tools/checkpoint-timeline.test.ts
+++ b/tests/tools/checkpoint-timeline.test.ts
@@ -1,0 +1,144 @@
+/// <reference types="jest" />
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(() => ({
+    getAllSessionInfos: jest.fn(() => []),
+    getWorkerTargetIds: jest.fn(() => []),
+    getPage: jest.fn(),
+  })),
+}));
+
+jest.mock('../../src/recording/action-recorder', () => ({
+  getActiveActionRecorder: jest.fn(() => undefined),
+}));
+
+type Handler = (sessionId: string, args: Record<string, unknown>) => Promise<{ content?: Array<{ type: string; text?: string }>; isError?: boolean }>;
+
+async function loadHandler(): Promise<Handler> {
+  jest.resetModules();
+  const { registerCheckpointTool } = await import('../../src/tools/checkpoint');
+  let handler: Handler | undefined;
+  registerCheckpointTool({
+    registerTool: (_name: string, h: Handler) => {
+      handler = h;
+    },
+  } as any);
+  if (!handler) throw new Error('handler not registered');
+  return handler;
+}
+
+function readJson(result: Awaited<ReturnType<Handler>>): any {
+  return JSON.parse(result.content?.[0]?.text || '{}');
+}
+
+describe('oc_checkpoint timeline (#1025)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-checkpoint-timeline-'));
+    process.env.OPENCHROME_CHECKPOINT_DIR = tmpDir;
+    process.env.OPENCHROME_CHECKPOINT_TIMELINE_MAX = '10';
+  });
+
+  afterEach(() => {
+    delete process.env.OPENCHROME_CHECKPOINT_DIR;
+    delete process.env.OPENCHROME_CHECKPOINT_TIMELINE_MAX;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  test('save returns checkpoint id and list returns newest-first timeline entries', async () => {
+    const handler = await loadHandler();
+
+    const first = readJson(await handler('sess-1', {
+      action: 'save',
+      label: 'first',
+      taskDescription: 'task',
+      completedSteps: ['one'],
+      pendingSteps: ['two'],
+    }));
+    const second = readJson(await handler('sess-1', {
+      action: 'save',
+      label: 'second',
+      taskDescription: 'task',
+      completedSteps: ['one', 'two'],
+      pendingSteps: [],
+    }));
+
+    expect(first.status).toBe('saved');
+    expect(first.checkpointId).toMatch(/^cp_/);
+    expect(second.parentId).toBe(first.checkpointId);
+
+    const listed = readJson(await handler('sess-1', { action: 'list' }));
+    expect(listed.status).toBe('listed');
+    expect(listed.checkpoints.map((entry: any) => entry.checkpointId)).toEqual([
+      second.checkpointId,
+      first.checkpointId,
+    ]);
+    expect(listed.checkpoints[0].label).toBe('second');
+    expect(listed.checkpoints[0].pendingSteps).toBe(0);
+  });
+
+  test('load supports latest compatibility and specific checkpoint id', async () => {
+    const handler = await loadHandler();
+
+    const first = readJson(await handler('sess-1', {
+      action: 'save',
+      taskDescription: 'first task',
+      completedSteps: ['a'],
+      pendingSteps: ['b'],
+    }));
+    const second = readJson(await handler('sess-1', {
+      action: 'save',
+      taskDescription: 'second task',
+      completedSteps: ['c'],
+      pendingSteps: [],
+    }));
+
+    const latest = readJson(await handler('sess-1', { action: 'load' }));
+    expect(latest.checkpointId).toBe(second.checkpointId);
+    expect(latest.taskDescription).toBe('second task');
+
+    const older = readJson(await handler('sess-1', { action: 'load', checkpointId: first.checkpointId }));
+    expect(older.checkpointId).toBe(first.checkpointId);
+    expect(older.taskDescription).toBe('first task');
+    expect(older.pendingSteps).toEqual(['b']);
+  });
+
+  test('list handles empty and corrupt timeline entries without throwing', async () => {
+    const handler = await loadHandler();
+
+    expect(readJson(await handler('sess-1', { action: 'list' })).checkpoints).toEqual([]);
+
+    const timelineDir = path.join(tmpDir, 'timeline');
+    fs.mkdirSync(timelineDir, { recursive: true });
+    fs.writeFileSync(path.join(timelineDir, 'bad.json'), '{not json');
+
+    const listed = readJson(await handler('sess-1', { action: 'list' }));
+    expect(listed.checkpoints).toEqual([]);
+    expect(listed.warnings.join('\n')).toContain('Skipped corrupt checkpoint timeline entry');
+  });
+
+  test('retention prunes old timeline artifacts only', async () => {
+    process.env.OPENCHROME_CHECKPOINT_TIMELINE_MAX = '2';
+    const handler = await loadHandler();
+
+    const ids: string[] = [];
+    for (let i = 0; i < 4; i += 1) {
+      ids.push(readJson(await handler('sess-1', {
+        action: 'save',
+        label: `cp-${i}`,
+        taskDescription: `task ${i}`,
+      })).checkpointId);
+    }
+
+    const listed = readJson(await handler('sess-1', { action: 'list' }));
+    expect(listed.checkpoints).toHaveLength(2);
+    expect(listed.checkpoints.map((entry: any) => entry.checkpointId)).toEqual(ids.slice(2).reverse());
+    expect(fs.existsSync(path.join(tmpDir, 'current-checkpoint.json'))).toBe(true);
+  });
+});

--- a/tests/tools/checkpoint-timeline.test.ts
+++ b/tests/tools/checkpoint-timeline.test.ts
@@ -152,6 +152,43 @@ describe('oc_checkpoint timeline (#1025)', () => {
     expect(loaded.taskDescription).toBe('timeline fallback');
   });
 
+
+  test('load by checkpoint id rejects schema-invalid timeline files', async () => {
+    const handler = await loadHandler();
+    const timelineDir = path.join(tmpDir, 'timeline');
+    fs.mkdirSync(timelineDir, { recursive: true });
+    fs.writeFileSync(path.join(timelineDir, 'cp_bad.json'), JSON.stringify({
+      version: 1,
+      timestamp: Date.now(),
+      checkpointId: 'cp_bad',
+      taskDescription: 'bad',
+      completedSteps: 'not-an-array',
+      pendingSteps: [],
+      currentUrl: null,
+      tabStates: [],
+      extractedData: {},
+    }));
+
+    const loaded = await handler('sess-1', { action: 'load', checkpointId: 'cp_bad' });
+    expect(loaded.content?.[0]?.text).toContain('No checkpoint found for checkpointId "cp_bad"');
+  });
+
+  test('legacy delete removes current checkpoint and its timeline entry', async () => {
+    const handler = await loadHandler();
+    const saved = readJson(await handler('sess-1', {
+      action: 'save',
+      taskDescription: 'delete me',
+      completedSteps: ['done'],
+      pendingSteps: [],
+    }));
+
+    const deleted = await handler('sess-1', { action: 'delete' });
+    expect(deleted.content?.[0]?.text).toBe('Checkpoint deleted.');
+    expect(fs.existsSync(path.join(tmpDir, 'current-checkpoint.json'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, 'timeline', `${saved.checkpointId}.json`))).toBe(false);
+    expect(readJson(await handler('sess-1', { action: 'list' })).checkpoints).toEqual([]);
+  });
+
   test('retention prunes old timeline artifacts only', async () => {
     process.env.OPENCHROME_CHECKPOINT_TIMELINE_MAX = '2';
     const handler = await loadHandler();

--- a/tests/tools/checkpoint-timeline.test.ts
+++ b/tests/tools/checkpoint-timeline.test.ts
@@ -117,10 +117,39 @@ describe('oc_checkpoint timeline (#1025)', () => {
     const timelineDir = path.join(tmpDir, 'timeline');
     fs.mkdirSync(timelineDir, { recursive: true });
     fs.writeFileSync(path.join(timelineDir, 'bad.json'), '{not json');
+    fs.writeFileSync(path.join(timelineDir, 'invalid.json'), JSON.stringify({
+      version: 1,
+      timestamp: Date.now(),
+      checkpointId: 'cp_invalid_shape',
+      taskDescription: 'bad',
+      completedSteps: 'not-an-array',
+      pendingSteps: [],
+      currentUrl: null,
+      tabStates: [],
+      extractedData: {},
+    }));
 
     const listed = readJson(await handler('sess-1', { action: 'list' }));
     expect(listed.checkpoints).toEqual([]);
     expect(listed.warnings.join('\n')).toContain('Skipped corrupt checkpoint timeline entry');
+    expect(listed.warnings.join('\n')).toContain('Skipped invalid checkpoint timeline entry');
+  });
+
+  test('load falls back to newest timeline entry when current checkpoint is missing', async () => {
+    const handler = await loadHandler();
+
+    const first = readJson(await handler('sess-1', {
+      action: 'save',
+      taskDescription: 'timeline fallback',
+      completedSteps: ['saved'],
+      pendingSteps: [],
+    }));
+    fs.unlinkSync(path.join(tmpDir, 'current-checkpoint.json'));
+
+    const loaded = readJson(await handler('sess-1', { action: 'load' }));
+    expect(loaded.status).toBe('loaded');
+    expect(loaded.checkpointId).toBe(first.checkpointId);
+    expect(loaded.taskDescription).toBe('timeline fallback');
   });
 
   test('retention prunes old timeline artifacts only', async () => {

--- a/tests/tools/checkpoint-timeline.test.ts
+++ b/tests/tools/checkpoint-timeline.test.ts
@@ -135,6 +135,27 @@ describe('oc_checkpoint timeline (#1025)', () => {
     expect(listed.warnings.join('\n')).toContain('Skipped invalid checkpoint timeline entry');
   });
 
+  test('save rejects schema-invalid step and data payloads before writing checkpoints', async () => {
+    const handler = await loadHandler();
+
+    const badSteps = await handler('sess-1', {
+      action: 'save',
+      taskDescription: 'bad save',
+      completedSteps: 'done',
+    });
+    const badData = await handler('sess-1', {
+      action: 'save',
+      taskDescription: 'bad save',
+      extractedData: ['not-object'],
+    });
+
+    expect(badSteps.isError).toBe(true);
+    expect(badSteps.content?.[0]?.text).toContain('completedSteps must be an array of strings');
+    expect(badData.isError).toBe(true);
+    expect(badData.content?.[0]?.text).toContain('extractedData must be an object');
+    expect(fs.existsSync(path.join(tmpDir, 'current-checkpoint.json'))).toBe(false);
+  });
+
   test('load falls back to newest timeline entry when current checkpoint is missing', async () => {
     const handler = await loadHandler();
 

--- a/tests/tools/checkpoint-timeline.test.ts
+++ b/tests/tools/checkpoint-timeline.test.ts
@@ -189,6 +189,22 @@ describe('oc_checkpoint timeline (#1025)', () => {
     expect(readJson(await handler('sess-1', { action: 'list' })).checkpoints).toEqual([]);
   });
 
+
+  test('list ordering is deterministic for same-millisecond checkpoints', async () => {
+    const handler = await loadHandler();
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1234567890);
+    try {
+      const first = readJson(await handler('sess-1', { action: 'save', taskDescription: 'same ms one' }));
+      const second = readJson(await handler('sess-1', { action: 'save', taskDescription: 'same ms two' }));
+      const listed = readJson(await handler('sess-1', { action: 'list' }));
+      const expected = [first.checkpointId, second.checkpointId].sort().reverse();
+
+      expect(listed.checkpoints.map((entry: any) => entry.checkpointId)).toEqual(expected);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   test('retention prunes old timeline artifacts only', async () => {
     process.env.OPENCHROME_CHECKPOINT_TIMELINE_MAX = '2';
     const handler = await loadHandler();


### PR DESCRIPTION
## Summary
- Extends `oc_checkpoint` with a bounded append-only timeline while preserving latest/current checkpoint compatibility.
- Adds `action: "list"` and `load({ checkpointId })`/`delete({ checkpointId })` paths for timeline navigation.
- Saves stable `checkpointId`, optional `parentId`, label, session id, tab summaries with `health: "unknown"`, and journal range metadata.
- Adds retention via `OPENCHROME_CHECKPOINT_TIMELINE_MAX` and skips corrupt timeline entries with warnings.
- Documents the recovery model and non-goals.

## Issue coverage
- Closes #1025.
- Keeps recovery explicit: no action replay, rollback, autonomous planning, navigation, or browser mutation is introduced.

## Verification
- `npm ci`
- `npm test -- tests/tools/checkpoint-timeline.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint -- --quiet`
- `git diff --check`

## Not tested
- Real OpenChrome MCP restart fixture. Unit tests cover save/list/load-by-id/latest compatibility, corrupt entry handling, and retention in a temporary checkpoint directory.
