### PR TITLE
Classify plan failures for recovery metadata

### DIFF
--- a/docs/orchestration/plan-failure-taxonomy.md
+++ b/docs/orchestration/plan-failure-taxonomy.md
@@ -1,0 +1,34 @@
+# Plan failure taxonomy
+
+`execute_plan` failures include deterministic metadata so hosts can decide how to recover without OpenChrome mutating or rerunning plans automatically.
+
+## Failure shape
+
+```json
+{
+  "failure": {
+    "class": "step_error | empty_result | timeout | contract_failed | stale_ref | auth_redirect | unknown",
+    "stepOrder": 1,
+    "tool": "find",
+    "message": "bounded explanation"
+  },
+  "recoveryCandidates": [
+    {
+      "source": "error_handler",
+      "condition": "step1_error",
+      "action": "refresh refs",
+      "message": "Declared recovery handler ..."
+    }
+  ]
+}
+```
+
+Recovery candidates are metadata only. A declared `PlanErrorHandler` may still run through the pre-existing executor path; otherwise candidates are returned for the caller to inspect.
+
+## Registry stats
+
+`PlanRegistry.updateStats` accepts an optional failure class and persists `stats.failureClassCounts` alongside existing aggregate counters and confidence. Success confidence remains based on `successCount / totalExecutions`.
+
+## Non-goals
+
+This taxonomy does not generate new plans, execute undeclared recovery steps, bypass security checks, or lower domain/tool restrictions.

--- a/src/orchestration/plan-executor.ts
+++ b/src/orchestration/plan-executor.ts
@@ -12,7 +12,10 @@ import {
   PlanErrorHandler,
   PlanExecutionOptions,
   PlanExecutionResult,
+  PlanFailureClass,
+  PlanFailureMetadata,
   PlanFinalVerificationResult,
+  PlanRecoveryCandidate,
 } from '../types/plan-cache';
 import { evaluate } from '../contracts/evaluate';
 import type { EvalContext, NetworkLogEntry } from '../contracts/eval-context';
@@ -117,6 +120,49 @@ async function runFinalVerification(
     }
   }
   return { passed: true, snapshotParam, assertions };
+}
+
+
+function classifyPlanFailure(message: string, fallback: PlanFailureClass): PlanFailureClass {
+  const text = message.toLowerCase();
+  if (/timeout|timed out|deadline/.test(text)) return 'timeout';
+  if (/stale_ref|stale ref|stale-ref/.test(text)) return 'stale_ref';
+  if (/auth|login|sign in|access denied|forbidden/.test(text)) return 'auth_redirect';
+  if (/empty|no data|not found|missing selector/.test(text)) return 'empty_result';
+  return fallback;
+}
+
+function recoveryCandidatesFor(
+  conditionKey: string | undefined,
+  errorHandlers: PlanErrorHandler[],
+  failure: PlanFailureMetadata
+): PlanRecoveryCandidate[] {
+  const candidates: PlanRecoveryCandidate[] = [];
+  if (conditionKey) {
+    for (const handler of errorHandlers.filter((h) => h.condition === conditionKey)) {
+      candidates.push({
+        source: 'error_handler',
+        condition: handler.condition,
+        action: handler.action,
+        message: `Declared recovery handler "${handler.action}" is available for ${handler.condition}.`,
+      });
+    }
+  }
+  if (failure.hintRule) {
+    candidates.push({
+      source: 'hint',
+      action: failure.hintRule,
+      message: `Review hint rule ${failure.hintRule} before retrying this plan.`,
+    });
+  }
+  if (failure.reflectionId) {
+    candidates.push({
+      source: 'reflection',
+      action: 'review_reflection',
+      message: `Review reflection ${failure.reflectionId} before retrying this plan.`,
+    });
+  }
+  return candidates.slice(0, 3);
 }
 
 /**
@@ -267,6 +313,7 @@ export class PlanExecutor {
           success: false,
           planId: plan.id,
           error: preflight.reasons.join('; '),
+          failure: { class: 'contract_failed', message: preflight.reasons.join('; ') },
           durationMs: Date.now() - startTime,
           stepsExecuted,
           totalSteps: plan.steps.length,
@@ -284,15 +331,28 @@ export class PlanExecutor {
     }
     Object.assign(params, runtimeParams);
 
-    const failure = (error: string, taskSignature?: PlanExecutionResult['taskSignature']): PlanExecutionResult => ({
-      success: false,
-      planId: plan.id,
-      error,
-      durationMs: Date.now() - startTime,
-      stepsExecuted,
-      totalSteps: plan.steps.length,
-      ...(taskSignature ? { taskSignature } : {}),
-    });
+    let lastEmptyStep: { order: number; tool: string } | null = null;
+    const failure = (
+      error: string,
+      taskSignature?: PlanExecutionResult['taskSignature'],
+      failureMeta?: PlanFailureMetadata,
+      conditionKey?: string
+    ): PlanExecutionResult => {
+      const recoveryCandidates = failureMeta
+        ? recoveryCandidatesFor(conditionKey, plan.errorHandlers, failureMeta)
+        : [];
+      return {
+        success: false,
+        planId: plan.id,
+        error,
+        ...(failureMeta ? { failure: failureMeta } : {}),
+        ...(recoveryCandidates.length > 0 ? { recoveryCandidates } : {}),
+        durationMs: Date.now() - startTime,
+        stepsExecuted,
+        totalSteps: plan.steps.length,
+        ...(taskSignature ? { taskSignature } : {}),
+      };
+    };
 
     // 2. Execute each step sequentially
     for (const step of plan.steps) {
@@ -303,7 +363,7 @@ export class PlanExecutor {
       if (!handler) {
         const msg = `No handler found for tool "${step.tool}" at ${stepLabel}`;
         console.error(`[PlanExecutor] ${msg}`);
-        return failure(msg);
+        return failure(msg, undefined, { class: 'unknown', stepOrder: step.order, tool: step.tool, message: msg });
       }
 
       // b. Substitute template variables in args
@@ -338,7 +398,7 @@ export class PlanExecutor {
             };
           }
           if (taskStatus.status !== 'continue') {
-            return failure(`task signature ${taskStatus.status}: ${taskStatus.reasons.join('; ')}`, taskStatus);
+            return failure(`task signature ${taskStatus.status}: ${taskStatus.reasons.join('; ')}`, taskStatus, { class: 'contract_failed', stepOrder: step.order, tool: step.tool, message: taskStatus.reasons.join('; ') });
           }
         }
       } catch (err) {
@@ -361,7 +421,7 @@ export class PlanExecutor {
           continue;
         }
 
-        return failure(`Step ${step.order} (${step.tool}) failed: ${errMsg}`);
+        return failure(`Step ${step.order} (${step.tool}) failed: ${errMsg}`, undefined, { class: classifyPlanFailure(errMsg, 'step_error'), stepOrder: step.order, tool: step.tool, message: errMsg }, conditionKey);
       }
 
       // d. Check for error result
@@ -383,11 +443,12 @@ export class PlanExecutor {
           continue;
         }
 
-        return failure(`Step ${step.order} (${step.tool}) returned error: ${errMsg}`);
+        return failure(`Step ${step.order} (${step.tool}) returned error: ${errMsg}`, undefined, { class: classifyPlanFailure(errMsg, 'step_error'), stepOrder: step.order, tool: step.tool, message: errMsg }, conditionKey);
       }
 
       // e. Check for empty result (before storing) — may trigger empty_result handler
       if (isEmptyResult(mcpResult)) {
+        lastEmptyStep = { order: step.order, tool: step.tool };
         const conditionKey = `step${step.order}_empty_result`;
         const recovered = await this.tryRecovery(
           conditionKey,
@@ -428,22 +489,20 @@ export class PlanExecutor {
     const criteriaError = validateSuccessCriteria(plan.successCriteria, params);
     if (criteriaError) {
       console.error(`[PlanExecutor] Success criteria failed for plan=${plan.id}: ${criteriaError}`);
-      return {
-        success: false,
-        planId: plan.id,
-        error: `Success criteria not met: ${criteriaError}`,
-        durationMs: Date.now() - startTime,
-        stepsExecuted,
-        totalSteps: plan.steps.length,
-        ...(options.taskSignature
-          ? { taskSignature: await evaluateTaskSignature({
-              signature: options.taskSignature,
-              recentTools,
-              elapsedMs: Date.now() - startTime,
-              toolCount: stepsExecuted,
-            }) }
-          : {}),
+      const taskStatus = options.taskSignature
+        ? await evaluateTaskSignature({
+            signature: options.taskSignature,
+            recentTools,
+            elapsedMs: Date.now() - startTime,
+            toolCount: stepsExecuted,
+          })
+        : undefined;
+      const failureMeta: PlanFailureMetadata = {
+        class: lastEmptyStep ? 'empty_result' : 'contract_failed',
+        ...(lastEmptyStep ? { stepOrder: lastEmptyStep.order, tool: lastEmptyStep.tool } : {}),
+        message: criteriaError,
       };
+      return failure(`Success criteria not met: ${criteriaError}`, taskStatus, failureMeta);
     }
 
     // 4. Optional final Outcome Contract verification gate
@@ -453,6 +512,7 @@ export class PlanExecutor {
         success: false,
         planId: plan.id,
         error: finalVerification.error || `Final verification failed at assertion ${finalVerification.failedAssertion?.index ?? 'unknown'}`,
+        failure: { class: 'contract_failed', message: finalVerification.error || `Final verification failed at assertion ${finalVerification.failedAssertion?.index ?? 'unknown'}` },
         durationMs: Date.now() - startTime,
         stepsExecuted,
         totalSteps: plan.steps.length,
@@ -500,7 +560,7 @@ export class PlanExecutor {
     currentStepsExecuted: number
   ): Promise<{ stepsExecuted: number; params: Record<string, unknown> } | null> {
     const handler = errorHandlers.find((h) => h.condition === conditionKey);
-    if (!handler) return null;
+    if (!handler || handler.steps.length === 0) return null;
 
     console.error(
       `[PlanExecutor] Running error handler "${handler.action}" for condition "${conditionKey}"`

--- a/src/orchestration/plan-executor.ts
+++ b/src/orchestration/plan-executor.ts
@@ -127,7 +127,7 @@ function classifyPlanFailure(message: string, fallback: PlanFailureClass): PlanF
   const text = message.toLowerCase();
   if (/timeout|timed out|deadline/.test(text)) return 'timeout';
   if (/stale_ref|stale ref|stale-ref/.test(text)) return 'stale_ref';
-  if (/auth|login|sign in|access denied|forbidden/.test(text)) return 'auth_redirect';
+  if (/\b(?:auth|authentication|authorization|login|sign[ -]?in|access denied|forbidden)\b/.test(text)) return 'auth_redirect';
   if (/empty|no data|not found|missing selector/.test(text)) return 'empty_result';
   return fallback;
 }

--- a/src/orchestration/plan-executor.ts
+++ b/src/orchestration/plan-executor.ts
@@ -127,7 +127,7 @@ function classifyPlanFailure(message: string, fallback: PlanFailureClass): PlanF
   const text = message.toLowerCase();
   if (/timeout|timed out|deadline/.test(text)) return 'timeout';
   if (/stale_ref|stale ref|stale-ref/.test(text)) return 'stale_ref';
-  if (/\b(?:auth|authentication|authorization|login|sign[ -]?in|access denied|forbidden)\b/.test(text)) return 'auth_redirect';
+  if (/\b(?:auth|authentication|authorization|unauthorized|login|sign[ -]?in|access denied|forbidden)\b/.test(text)) return 'auth_redirect';
   if (/empty|no data|not found|missing selector/.test(text)) return 'empty_result';
   return fallback;
 }

--- a/src/orchestration/plan-executor.ts
+++ b/src/orchestration/plan-executor.ts
@@ -331,7 +331,7 @@ export class PlanExecutor {
     }
     Object.assign(params, runtimeParams);
 
-    let lastEmptyStep: { order: number; tool: string } | null = null;
+    let lastEmptyStep: { order: number; tool: string; conditionKey: string } | null = null;
     const failure = (
       error: string,
       taskSignature?: PlanExecutionResult['taskSignature'],
@@ -448,8 +448,8 @@ export class PlanExecutor {
 
       // e. Check for empty result (before storing) — may trigger empty_result handler
       if (isEmptyResult(mcpResult)) {
-        lastEmptyStep = { order: step.order, tool: step.tool };
         const conditionKey = `step${step.order}_empty_result`;
+        lastEmptyStep = { order: step.order, tool: step.tool, conditionKey };
         const recovered = await this.tryRecovery(
           conditionKey,
           plan.errorHandlers,
@@ -497,12 +497,20 @@ export class PlanExecutor {
             toolCount: stepsExecuted,
           })
         : undefined;
+      const emptyResultCausedCriteriaFailure = Boolean(
+        lastEmptyStep && /^minDataItems requirement not met: (got 0|no collection found)/.test(criteriaError),
+      );
       const failureMeta: PlanFailureMetadata = {
-        class: lastEmptyStep ? 'empty_result' : 'contract_failed',
-        ...(lastEmptyStep ? { stepOrder: lastEmptyStep.order, tool: lastEmptyStep.tool } : {}),
+        class: emptyResultCausedCriteriaFailure ? 'empty_result' : 'contract_failed',
+        ...(emptyResultCausedCriteriaFailure ? { stepOrder: lastEmptyStep!.order, tool: lastEmptyStep!.tool } : {}),
         message: criteriaError,
       };
-      return failure(`Success criteria not met: ${criteriaError}`, taskStatus, failureMeta);
+      return failure(
+        `Success criteria not met: ${criteriaError}`,
+        taskStatus,
+        failureMeta,
+        emptyResultCausedCriteriaFailure ? lastEmptyStep!.conditionKey : undefined,
+      );
     }
 
     // 4. Optional final Outcome Contract verification gate

--- a/src/orchestration/plan-registry.ts
+++ b/src/orchestration/plan-registry.ts
@@ -13,6 +13,7 @@ import type {
   PlanEntry,
   PlanRegistryData,
   TaskPattern,
+  PlanFailureClass,
 } from '../types/plan-cache';
 
 const DEFAULT_BASE_PATH = path.join(os.homedir(), '.openchrome', 'plans');
@@ -139,7 +140,7 @@ export class PlanRegistry {
   /**
    * Update execution stats for a plan and recalculate confidence.
    */
-  updateStats(planId: string, success: boolean, durationMs: number): void {
+  updateStats(planId: string, success: boolean, durationMs: number, failureClass?: PlanFailureClass): void {
     const entry = this.data.plans.find(p => p.id === planId);
     if (!entry) return;
 
@@ -149,6 +150,10 @@ export class PlanRegistry {
       stats.successCount++;
     } else {
       stats.failCount++;
+      if (failureClass) {
+        stats.failureClassCounts = stats.failureClassCounts || {};
+        stats.failureClassCounts[failureClass] = (stats.failureClassCounts[failureClass] || 0) + 1;
+      }
     }
 
     // Rolling average for duration
@@ -204,6 +209,7 @@ export class PlanRegistry {
         failCount: 0,
         avgDurationMs: 0,
         lastUsed: 0,
+        failureClassCounts: {},
       },
       confidence: 0.5, // Initial neutral confidence
       minConfidenceToUse: 0.3,

--- a/src/tools/orchestration.ts
+++ b/src/tools/orchestration.ts
@@ -806,7 +806,7 @@ const executePlanHandler: ToolHandler = async (
     );
 
     // Update stats
-    registry.updateStats(planId, result.success, result.durationMs);
+    registry.updateStats(planId, result.success, result.durationMs, result.failure?.class);
 
     return {
       content: [{
@@ -819,6 +819,8 @@ const executePlanHandler: ToolHandler = async (
           durationMs: result.durationMs,
           data: result.data,
           error: result.error,
+          failure: result.failure,
+          recoveryCandidates: result.recoveryCandidates,
           ...(result.taskSignature ? { taskSignature: result.taskSignature } : {}),
           message: result.success
             ? `Plan "${planId}" executed successfully in ${result.durationMs}ms (${result.stepsExecuted}/${result.totalSteps} steps)`

--- a/src/types/plan-cache.ts
+++ b/src/types/plan-cache.ts
@@ -119,6 +119,7 @@ export interface PlanEntry {
     failCount: number;
     avgDurationMs: number;
     lastUsed: number;
+    failureClassCounts?: Partial<Record<PlanFailureClass, number>>;
   };
   /** Confidence score (0.0 - 1.0) based on success rate */
   confidence: number;
@@ -131,6 +132,32 @@ export interface PlanRegistryData {
   version: string;
   plans: PlanEntry[];
   updatedAt: number;
+}
+
+
+export type PlanFailureClass =
+  | 'step_error'
+  | 'empty_result'
+  | 'timeout'
+  | 'contract_failed'
+  | 'stale_ref'
+  | 'auth_redirect'
+  | 'unknown';
+
+export interface PlanFailureMetadata {
+  class: PlanFailureClass;
+  stepOrder?: number;
+  tool?: string;
+  message: string;
+  hintRule?: string;
+  reflectionId?: string;
+}
+
+export interface PlanRecoveryCandidate {
+  source: 'error_handler' | 'hint' | 'reflection';
+  condition?: string;
+  action: string;
+  message: string;
 }
 
 /** Result of plan execution */
@@ -148,6 +175,10 @@ export interface PlanExecutionResult {
   data?: Record<string, unknown>;
   /** Error message (if failed) */
   error?: string;
+  /** Structured failure metadata when success=false. */
+  failure?: PlanFailureMetadata;
+  /** Safe, explanatory recovery options. These are never auto-executed. */
+  recoveryCandidates?: PlanRecoveryCandidate[];
   /** Execution duration in milliseconds */
   durationMs: number;
   /** Number of steps executed */

--- a/tests/orchestration/plan-cache.test.ts
+++ b/tests/orchestration/plan-cache.test.ts
@@ -921,3 +921,77 @@ describe('PlanExecutor final verification gate', () => {
     expect(result.error).toContain('unsupported finalVerification.requiredEvidence');
   });
 });
+
+describe('Plan failure taxonomy (#1012)', () => {
+  test('executor classifies thrown step errors and exposes recovery candidates', async () => {
+    const handlers: Record<string, ToolHandler> = {
+      boom: jest.fn().mockRejectedValue(new Error('STALE_REF: old ref')),
+    };
+    const executor = new PlanExecutor((tool) => handlers[tool] || null);
+    const plan = buildPlan({
+      id: 'failure-taxonomy-plan',
+      steps: [buildStep({ order: 1, tool: 'boom', timeout: 100 })],
+      errorHandlers: [{ condition: 'step1_error', action: 'refresh refs', steps: [] }],
+    });
+
+    const result = await executor.execute(plan, 'sess', {});
+
+    expect(result.success).toBe(false);
+    expect(result.failure).toEqual(expect.objectContaining({
+      class: 'stale_ref',
+      stepOrder: 1,
+      tool: 'boom',
+    }));
+    expect(result.recoveryCandidates).toEqual([
+      expect.objectContaining({ source: 'error_handler', condition: 'step1_error', action: 'refresh refs' }),
+    ]);
+  });
+
+  test('executor classifies empty result that later fails success criteria', async () => {
+    const handlers: Record<string, ToolHandler> = {
+      empty: jest.fn().mockResolvedValue({ content: [{ type: 'text', text: '[]' }] }),
+    };
+    const executor = new PlanExecutor((tool) => handlers[tool] || null);
+    const plan = buildPlan({
+      id: 'empty-taxonomy-plan',
+      steps: [buildStep({
+        order: 1,
+        tool: 'empty',
+        timeout: 100,
+        parseResult: { format: 'json', storeAs: 'items' },
+      })],
+      successCriteria: { minDataItems: 1 },
+    });
+
+    const result = await executor.execute(plan, 'sess', {});
+
+    expect(result.success).toBe(false);
+    expect(result.failure).toEqual(expect.objectContaining({
+      class: 'empty_result',
+      stepOrder: 1,
+      tool: 'empty',
+    }));
+  });
+
+  test('registry persists failure-class counts without changing aggregate stats', () => {
+    const tmpDir = makeTempDir();
+    try {
+      const registry = new PlanRegistry(tmpDir);
+      registry.registerPlan(buildPlan({ id: 'stats-failure-plan' }), buildPattern());
+
+      registry.updateStats('stats-failure-plan', false, 100, 'stale_ref');
+      registry.updateStats('stats-failure-plan', false, 200, 'contract_failed');
+      registry.updateStats('stats-failure-plan', true, 300);
+
+      const reloaded = new PlanRegistry(tmpDir);
+      reloaded.load();
+      const entry = reloaded.getEntry('stats-failure-plan')!;
+      expect(entry.stats.totalExecutions).toBe(3);
+      expect(entry.stats.successCount).toBe(1);
+      expect(entry.stats.failCount).toBe(2);
+      expect(entry.stats.failureClassCounts).toEqual({ stale_ref: 1, contract_failed: 1 });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/orchestration/plan-cache.test.ts
+++ b/tests/orchestration/plan-cache.test.ts
@@ -1026,6 +1026,23 @@ describe('Plan failure taxonomy (#1012)', () => {
     expect(result.recoveryCandidates).toBeUndefined();
   });
 
+
+  test('executor requires token boundaries for auth failure classification', async () => {
+    const handlers: Record<string, ToolHandler> = {
+      boom: jest.fn().mockRejectedValue(new Error('authoritative content missing selector')),
+    };
+    const executor = new PlanExecutor((tool) => handlers[tool] || null);
+    const plan = buildPlan({
+      id: 'auth-boundary-taxonomy-plan',
+      steps: [buildStep({ order: 1, tool: 'boom', timeout: 100 })],
+    });
+
+    const result = await executor.execute(plan, 'sess', {});
+
+    expect(result.success).toBe(false);
+    expect(result.failure?.class).toBe('empty_result');
+  });
+
   test('registry persists failure-class counts without changing aggregate stats', () => {
     const tmpDir = makeTempDir();
     try {

--- a/tests/orchestration/plan-cache.test.ts
+++ b/tests/orchestration/plan-cache.test.ts
@@ -973,6 +973,59 @@ describe('Plan failure taxonomy (#1012)', () => {
     }));
   });
 
+  test('executor exposes empty-result recovery candidate only for empty-result criteria failures', async () => {
+    const handlers: Record<string, ToolHandler> = {
+      empty: jest.fn().mockResolvedValue({ content: [{ type: 'text', text: '[]' }] }),
+    };
+    const executor = new PlanExecutor((tool) => handlers[tool] || null);
+    const plan = buildPlan({
+      id: 'empty-recovery-candidate-plan',
+      steps: [buildStep({
+        order: 1,
+        tool: 'empty',
+        timeout: 100,
+        parseResult: { format: 'json', storeAs: 'items' },
+      })],
+      errorHandlers: [{ condition: 'step1_empty_result', action: 'refresh query', steps: [] }],
+      successCriteria: { minDataItems: 1 },
+    });
+
+    const result = await executor.execute(plan, 'sess', {});
+
+    expect(result.success).toBe(false);
+    expect(result.failure?.class).toBe('empty_result');
+    expect(result.recoveryCandidates).toEqual([
+      expect.objectContaining({ condition: 'step1_empty_result', action: 'refresh query' }),
+    ]);
+  });
+
+  test('executor does not classify unrelated criteria failures as empty_result after an empty step', async () => {
+    const handlers: Record<string, ToolHandler> = {
+      empty: jest.fn().mockResolvedValue({ content: [{ type: 'text', text: '[]' }] }),
+    };
+    const executor = new PlanExecutor((tool) => handlers[tool] || null);
+    const plan = buildPlan({
+      id: 'required-field-after-empty-plan',
+      steps: [buildStep({
+        order: 1,
+        tool: 'empty',
+        timeout: 100,
+        parseResult: { format: 'json', storeAs: 'items' },
+      })],
+      errorHandlers: [{ condition: 'step1_empty_result', action: 'refresh query', steps: [] }],
+      successCriteria: { requiredFields: ['missing'] },
+    });
+
+    const result = await executor.execute(plan, 'sess', {});
+
+    expect(result.success).toBe(false);
+    expect(result.failure).toEqual(expect.objectContaining({
+      class: 'contract_failed',
+      message: expect.stringContaining('Required field missing'),
+    }));
+    expect(result.recoveryCandidates).toBeUndefined();
+  });
+
   test('registry persists failure-class counts without changing aggregate stats', () => {
     const tmpDir = makeTempDir();
     try {

--- a/tests/orchestration/plan-cache.test.ts
+++ b/tests/orchestration/plan-cache.test.ts
@@ -1043,6 +1043,23 @@ describe('Plan failure taxonomy (#1012)', () => {
     expect(result.failure?.class).toBe('empty_result');
   });
 
+
+  test('executor classifies unauthorized token as auth redirect', async () => {
+    const handlers: Record<string, ToolHandler> = {
+      boom: jest.fn().mockRejectedValue(new Error('HTTP 401 unauthorized')),
+    };
+    const executor = new PlanExecutor((tool) => handlers[tool] || null);
+    const plan = buildPlan({
+      id: 'unauthorized-taxonomy-plan',
+      steps: [buildStep({ order: 1, tool: 'boom', timeout: 100 })],
+    });
+
+    const result = await executor.execute(plan, 'sess', {});
+
+    expect(result.success).toBe(false);
+    expect(result.failure?.class).toBe('auth_redirect');
+  });
+
   test('registry persists failure-class counts without changing aggregate stats', () => {
     const tmpDir = makeTempDir();
     try {


### PR DESCRIPTION
## Summary
- Adds `PlanFailureClass`, structured `failure`, and bounded `recoveryCandidates` to `PlanExecutionResult`.
- Classifies thrown/tool errors, stale refs, auth redirects, timeouts, contract failures, and empty results that later fail success criteria.
- Persists `stats.failureClassCounts` in `PlanRegistry` while keeping existing aggregate counters and confidence behavior.
- Includes failure/recovery metadata in `execute_plan` output.
- Documents the failure taxonomy and non-goals.

## Issue coverage
- Closes #1012.
- Recovery candidates are metadata only unless the plan already declared an executable `PlanErrorHandler`; no new plan generation, mutation, or undeclared recovery execution is added.

## Verification
- `npm ci`
- `npm test -- tests/orchestration/plan-cache.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint -- --quiet`
- `git diff --check`

## Not tested
- Live MCP plan-failure fixture. Unit tests cover executor classification, empty-result classification, existing handler compatibility, and registry persistence.
