### PR TITLE
Rank skill recall by task relevance

### DIFF
--- a/docs/tools/skill-recall-ranking.md
+++ b/docs/tools/skill-recall-ranking.md
@@ -1,0 +1,12 @@
+# Ranked skill recall
+
+`oc_skill_recall` remains backward-compatible by default: without `task` or `ranked: true`, it returns the existing replay-aware deterministic order.
+
+For task-aware recall, pass `task` (or `ranked: true`) with `domain` and optional `contract_id`. Ranked results include:
+
+- `score`: deterministic lexical score with success/replay/contract boosts.
+- `reason`: human-readable scoring explanation.
+- `stepsPreview`: bounded first-step preview with secret-like keys and values redacted.
+- `replaySignal`: `1`, `0`, or `-1` based on replay history.
+
+No recalled skill is auto-executed. Hosts must inspect the result, validate any contract, and explicitly call replay/action tools.

--- a/src/tools/oc-skill-recall.ts
+++ b/src/tools/oc-skill-recall.ts
@@ -2,10 +2,9 @@
  * oc_skill_recall — retrieve skills from the JSON skill memory store (issue #785).
  *
  * Core-tier MCP tool. Returns a recency-sorted, optionally filtered listing
- * of skills stored via oc_skill_record. No LLM ranking is applied — the
- * deterministic order (last_used_at desc, skill_id asc on ties) is produced
- * directly by the store. The pilot recall layer is responsible for any
- * relevance reranking above this surface.
+ * of skills stored via oc_skill_record by default. Callers can opt in to
+ * deterministic task-aware ranking with `task` / `query` or `ranked: true`;
+ * no LLM, network call, or automatic skill execution is involved.
  *
  * Filtering: `contract_id` restricts to skills bound to that contract;
  * `limit` caps the result count (default 20).
@@ -16,8 +15,15 @@ import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { SkillMemoryStore, type SkillRecord } from '../core/skill-memory';
 
+export interface RankedSkillRecord extends SkillRecord {
+  score?: number;
+  reason?: string;
+  stepsPreview?: unknown;
+  replaySignal?: -1 | 0 | 1;
+}
+
 interface OcSkillRecallOutput {
-  skills: SkillRecord[];
+  skills: RankedSkillRecord[];
   error?: string;
 }
 
@@ -29,7 +35,8 @@ const definition: MCPToolDefinition = {
     'Retrieve skills from the JSON skill memory store for a given domain. ' +
     'Returns a recency-sorted list (last_used_at desc). Optionally filter by ' +
     '`contract_id` and cap results with `limit` (default 20). No LLM ranking — ' +
-    'deterministic store order is returned as-is. Use oc_skill_record to write skills.',
+    'deterministic store order is returned as-is unless task/query or ranked ' +
+    'is supplied. Use oc_skill_record to write skills.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -44,6 +51,19 @@ const definition: MCPToolDefinition = {
         description:
           'Optional. Restrict results to skills whose contract_id matches ' +
           'this value exactly. Omit to return skills across all contracts.',
+      },
+      task: {
+        type: 'string',
+        description:
+          'Optional task text. When present, recall is ranked by deterministic task relevance.',
+      },
+      query: {
+        type: 'string',
+        description: 'Optional alias for task. Ignored when task is also provided.',
+      },
+      ranked: {
+        type: 'boolean',
+        description: 'Opt in to deterministic ranked recall. Also enabled when task is provided.',
       },
       limit: {
         type: 'number',
@@ -64,6 +84,12 @@ const handler: ToolHandler = async (
   const domain = args.domain as string | undefined;
   const contractId = args.contract_id as string | undefined;
   const rawLimit = args.limit;
+  const task = typeof args.task === 'string'
+    ? args.task
+    : typeof args.query === 'string'
+      ? args.query
+      : '';
+  const rankedRecall = args.ranked === true || task.trim().length > 0;
 
   if (typeof domain !== 'string' || domain.length === 0) {
     const output: OcSkillRecallOutput = {
@@ -107,23 +133,43 @@ const handler: ToolHandler = async (
     return jsonResult(output);
   }
 
+  const ordered = rankedRecall
+    ? rankSkillsForTask(skills, { task, contractId })
+    : applyRecallRanking(skills);
+
+  const capped = limit === 0 ? [] : ordered.slice(0, limit);
+  return jsonResult({ skills: capped });
+};
+
+export function applyRecallRanking(skills: SkillRecord[]): SkillRecord[] {
   // Replay-aware ranking (#856 invariant #4): bucket each skill into
   // replay_signal ∈ {+1, 0, -1} and sort
   //   (signal desc, lastUsedAt desc, skillId asc)
   // so passed-replay skills surface first, never-replayed in the middle,
   // and failed-replay skills sink to the bottom. Recency breaks within-
   // bucket ties; skillId provides a deterministic final tiebreak.
-  const ranked = skills.slice().sort((a, b) => {
+  return skills.slice().sort((a, b) => {
     const sa = computeReplaySignal(a);
     const sb = computeReplaySignal(b);
     if (sa !== sb) return sb - sa; // signal desc
     if (b.lastUsedAt !== a.lastUsedAt) return b.lastUsedAt - a.lastUsedAt;
     return a.skillId < b.skillId ? -1 : a.skillId > b.skillId ? 1 : 0;
   });
+}
 
-  const capped = limit === 0 ? [] : ranked.slice(0, limit);
-  return jsonResult({ skills: capped });
-};
+export function rankSkillsForTask(
+  skills: SkillRecord[],
+  opts: { task?: string; contractId?: string } = {},
+): RankedSkillRecord[] {
+  const queryTokens = [...tokenize(opts.task || '')];
+  return skills
+    .map((skill) => scoreSkillForTask(skill, queryTokens, opts.contractId))
+    .sort((a, b) => {
+      if ((b.score ?? 0) !== (a.score ?? 0)) return (b.score ?? 0) - (a.score ?? 0);
+      if (b.lastUsedAt !== a.lastUsedAt) return b.lastUsedAt - a.lastUsedAt;
+      return a.skillId < b.skillId ? -1 : a.skillId > b.skillId ? 1 : 0;
+    });
+}
 
 /**
  * Replay signal for #856 ranking. See SkillRecord.lastReplayPassedAt /
@@ -137,6 +183,90 @@ export function computeReplaySignal(s: SkillRecord): -1 | 0 | 1 {
   if (passedAt > failedAt) return 1;
   if (failedAt > passedAt) return -1;
   return 0;
+}
+
+export function scoreSkillForTask(
+  skill: SkillRecord,
+  queryTokens: string[],
+  contractId?: string,
+): RankedSkillRecord {
+  const searchable = buildRecallText(skill);
+  const skillTokens = tokenize(searchable);
+  const overlapCount = queryTokens.filter((token) => skillTokens.has(token)).length;
+  const overlap = queryTokens.length === 0 ? 0 : overlapCount / queryTokens.length;
+  const replaySignal = computeReplaySignal(skill);
+  const successBoost = Math.min(Math.max(skill.successCount, 0), 10) * 0.025;
+  const replayBoost = replaySignal * 0.2;
+  const contractBoost = contractId && skill.contractId === contractId ? 0.15 : 0;
+  const score = Math.max(0, Math.min(1, overlap + successBoost + replayBoost + contractBoost));
+  const reasons = [
+    `${overlapCount}/${queryTokens.length || 0} task-token matches`,
+    `success_count=${skill.successCount}`,
+    `replay_signal=${replaySignal}`,
+  ];
+  if (contractBoost > 0) reasons.push(`contract_id=${contractId}`);
+  return {
+    ...skill,
+    score: Number(score.toFixed(4)),
+    reason: reasons.join('; '),
+    stepsPreview: previewSteps(skill.steps),
+    replaySignal,
+  };
+}
+
+export function buildRecallText(skill: SkillRecord): string {
+  return [
+    skill.name,
+    skill.contractId,
+    JSON.stringify(redactPreviewValue(skill.steps) ?? ''),
+  ].join(' ');
+}
+
+function tokenize(text: string): Set<string> {
+  const stop = new Set([
+    'the',
+    'and',
+    'for',
+    'with',
+    'this',
+    'that',
+    'into',
+    'from',
+    'then',
+    'task',
+    'verify',
+    'success',
+  ]);
+  const tokens = text
+    .toLowerCase()
+    .replace(/[^a-z0-9_ -]+/g, ' ')
+    .split(/[\s_-]+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 3 && !stop.has(token));
+  return new Set(tokens);
+}
+
+function previewSteps(steps: unknown): unknown {
+  if (!Array.isArray(steps)) return undefined;
+  return steps.slice(0, 3).map((step) => redactPreviewValue(step));
+}
+
+function redactPreviewValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    if (/password|token|secret|cookie|authorization/i.test(value)) return '[REDACTED]';
+    return value.length > 160 ? `${value.slice(0, 159)}…` : value;
+  }
+  if (Array.isArray(value)) return value.slice(0, 5).map((item) => redactPreviewValue(item));
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value as Record<string, unknown>).slice(0, 12)) {
+      out[key] = /password|token|secret|cookie|authorization/i.test(key)
+        ? '[REDACTED]'
+        : redactPreviewValue(child);
+    }
+    return out;
+  }
+  return value;
 }
 
 function jsonResult(payload: OcSkillRecallOutput): MCPResult {

--- a/tests/tools/oc-skill-recall-task-ranking.test.ts
+++ b/tests/tools/oc-skill-recall-task-ranking.test.ts
@@ -1,0 +1,101 @@
+import type { SkillRecord } from '../../src/core/skill-memory';
+import { buildRecallText, rankSkillsForTask } from '../../src/tools/oc-skill-recall';
+
+const DOMAIN = 'ranking.test';
+
+describe('rankSkillsForTask (#1009)', () => {
+  test('ranks task-similar skills above unrelated skills with reasons', () => {
+    const ranked = rankSkillsForTask(
+      [
+        skill('settings', [
+          { tool: 'interact', args: { description: 'open settings panel' } },
+        ]),
+        skill(
+          'contact form',
+          [
+            { tool: 'form_input', args: { label: 'email' } },
+            { tool: 'interact', args: { description: 'submit contact form' } },
+          ],
+          { successCount: 2 },
+        ),
+      ],
+      { task: 'submit the contact form and verify success' },
+    );
+
+    expect(ranked[0].name).toBe('contact form');
+    expect(ranked[0].score).toBeGreaterThan(ranked[1].score || 0);
+    expect(ranked[0].reason).toContain('task-token matches');
+    expect(ranked[0].stepsPreview).toBeDefined();
+  });
+
+  test('redacts sensitive values from ranked step previews and scoring text', () => {
+    const ranked = rankSkillsForTask(
+      [
+        skill('login', [
+          {
+            tool: 'form_input',
+            args: { password: 'super-secret-fixture-password', token: 'abc' },
+          },
+        ]),
+      ],
+      { task: 'login form' },
+    );
+
+    const text = JSON.stringify(ranked[0].stepsPreview);
+    expect(text).not.toContain('super-secret-fixture-password');
+    expect(text).not.toContain('abc');
+    expect(text).toContain('[REDACTED]');
+    expect(buildRecallText(ranked[0])).not.toContain('super-secret-fixture-password');
+    expect(buildRecallText(ranked[0])).not.toContain('abc');
+  });
+
+  test('replay and success break otherwise similar task matches deterministically', () => {
+    const ranked = rankSkillsForTask(
+      [
+        skill('checkout flow a', [{ tool: 'click', args: { label: 'checkout' } }], {
+          lastReplayPassedAt: 200,
+          successCount: 1,
+        }),
+        skill('checkout flow b', [{ tool: 'click', args: { label: 'checkout' } }], {
+          lastReplayFailedAt: 300,
+          successCount: 10,
+        }),
+      ],
+      { task: 'checkout flow' },
+    );
+
+    expect(ranked[0].name).toBe('checkout flow a');
+    expect(ranked[0].replaySignal).toBe(1);
+  });
+
+  test('contract match contributes deterministic score when provided', () => {
+    const ranked = rankSkillsForTask(
+      [
+        skill('same contract', [], { contractId: 'contract-a' }),
+        skill('other contract', [], { contractId: 'contract-b' }),
+      ],
+      { contractId: 'contract-a' },
+    );
+
+    expect(ranked[0].name).toBe('same contract');
+    expect(ranked[0].reason).toContain('contract_id=contract-a');
+  });
+});
+
+function skill(
+  name: string,
+  steps: unknown[],
+  overrides: Partial<SkillRecord> = {},
+): SkillRecord {
+  return {
+    skillId: `${name.replace(/\W+/g, '').padEnd(16, 'x').slice(0, 16)}`,
+    domain: DOMAIN,
+    name,
+    steps,
+    contractId: 'noop',
+    successCount: 0,
+    lastUsedAt: 0,
+    frozenSnapshotPath: null,
+    ...overrides,
+  } as SkillRecord;
+}


### PR DESCRIPTION
## Summary
- add opt-in deterministic task/query ranking to `oc_skill_recall`
- preserve default replay-aware ordering when callers do not request ranked recall
- include bounded redacted step previews, score reasons, replay signal, and docs for safe host usage

## Verification
- `npm ci`
- `npm test -- tests/tools/oc-skill-recall-ranking.test.ts tests/tools/oc-skill-recall-task-ranking.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint -- --quiet`
- `git diff --check`

Closes #1009
