### PR TITLE
Expose pollable run events for long tasks

### DIFF
--- a/docs/harness/run-events.md
+++ b/docs/harness/run-events.md
@@ -1,0 +1,29 @@
+# Long-task run events
+
+The run harness provides an opt-in, pollable event ledger for browser workflows
+that can outlive a single short interaction. Start a run with `oc_run_start`,
+pass the returned `run_id` (or `runId`) to supported tool calls, and poll
+`oc_run_status` / `oc_run_events` or the equivalent URI
+`openchrome://runs/<run_id>` shown in status responses.
+
+Default tool behavior remains synchronous: callers still receive the normal MCP
+result from `execute_plan`, `crawl`, `crawl_sitemap`, `batch_paginate`, and
+`batch_execute`. When those long-task tools include a run id, OpenChrome also
+writes bounded ledger events:
+
+- `run_started` from `oc_run_start`.
+- `tool_call_started` with a redacted stable argument hash.
+- `progress` with `metadata.stage: "started"` before the long task runs.
+- `tool_call_finished` when the synchronous tool returns.
+- `partial_result` for a normal/error MCP response, or `warning` when the tool
+  throws through the server error path.
+- `run_finished` only when the caller explicitly calls `oc_run_finish`, or when
+  `oc_run_status` marks a budget breach as `needs_strategy_change`.
+
+Retention is bounded. Run records are stored under `~/.openchrome/runs` by
+default and pruned to `OPENCHROME_RUN_MAX_RECORDS` records (default `500`).
+Cleanup removes older terminal records first and preserves active runs.
+
+The ledger is best-effort observability only: it performs no LLM calls, does not
+make tools asynchronous by default, and never changes the underlying tool result
+if event persistence fails.

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -217,6 +217,14 @@ export function isConnectionError(error: unknown): boolean {
  *  sleep/wake). Skip session initialization so recovery handlers can always run. */
 const SKIP_SESSION_INIT_TOOLS = new Set(['oc_stop', 'oc_reap_orphans', 'oc_profile_status', 'oc_session_snapshot', 'oc_session_resume', 'oc_journal', 'oc_run_start', 'oc_run_status', 'oc_run_events', 'oc_run_finish', 'oc_progress_status']);
 
+const RUN_HARNESS_LONG_TASK_TOOLS = new Set([
+  'execute_plan',
+  'crawl',
+  'crawl_sitemap',
+  'batch_paginate',
+  'batch_execute',
+]);
+
 /** Tools that may legitimately block the event loop longer than the normal fatal threshold. */
 const HEAVY_TOOLS = new Set(['computer', 'read_page', 'query_dom', 'cookies', 'javascript_tool']);
 
@@ -1713,13 +1721,26 @@ export class MCPServer {
     const runHarnessId = isRunHarnessEnabled() ? extractRunId(toolArgs) : undefined;
     if (runHarnessId && !toolName.startsWith('oc_run_')) {
       try {
-        getRunStore().appendToolStarted({
+        const runStore = getRunStore();
+        const runTabId = typeof toolArgs.tabId === 'string' ? toolArgs.tabId : undefined;
+        runStore.appendToolStarted({
           run_id: runHarnessId,
           session_id: sessionId,
-          tab_id: typeof toolArgs.tabId === 'string' ? toolArgs.tabId : undefined,
+          tab_id: runTabId,
           tool: toolName,
           args: toolArgs,
         });
+        if (RUN_HARNESS_LONG_TASK_TOOLS.has(toolName)) {
+          runStore.appendRunEvent({
+            run_id: runHarnessId,
+            session_id: sessionId,
+            tab_id: runTabId,
+            kind: 'progress',
+            tool: toolName,
+            message: 'long task started',
+            metadata: { stage: 'started' },
+          });
+        }
       } catch {
         // best-effort run ledger; never alter tool behavior
       }
@@ -2102,15 +2123,31 @@ export class MCPServer {
 
       if (runHarnessId && !toolName.startsWith('oc_run_')) {
         try {
-          getRunStore().appendToolFinished({
+          const runStore = getRunStore();
+          const runTabId = typeof toolArgs.tabId === 'string' ? toolArgs.tabId : undefined;
+          const durationMs = Date.now() - toolStartTime;
+          runStore.appendToolFinished({
             run_id: runHarnessId,
             session_id: sessionId,
-            tab_id: typeof toolArgs.tabId === 'string' ? toolArgs.tabId : undefined,
+            tab_id: runTabId,
             tool: toolName,
             args: toolArgs,
             ok: !result.isError,
-            duration_ms: Date.now() - toolStartTime,
+            duration_ms: durationMs,
           });
+          if (RUN_HARNESS_LONG_TASK_TOOLS.has(toolName)) {
+            runStore.appendRunEvent({
+              run_id: runHarnessId,
+              session_id: sessionId,
+              tab_id: runTabId,
+              kind: 'partial_result',
+              tool: toolName,
+              ok: !result.isError,
+              duration_ms: durationMs,
+              message: result.isError ? 'long task returned an error result' : 'long task returned a synchronous final result',
+              metadata: { stage: 'final_response' },
+            });
+          }
         } catch {
           // best-effort run ledger; never alter tool behavior
         }
@@ -2289,16 +2326,32 @@ export class MCPServer {
 
       if (runHarnessId && !toolName.startsWith('oc_run_')) {
         try {
-          getRunStore().appendToolFinished({
+          const runStore = getRunStore();
+          const runTabId = typeof toolArgs.tabId === 'string' ? toolArgs.tabId : undefined;
+          const durationMs = Date.now() - toolStartTime;
+          runStore.appendToolFinished({
             run_id: runHarnessId,
             session_id: sessionId,
-            tab_id: typeof toolArgs.tabId === 'string' ? toolArgs.tabId : undefined,
+            tab_id: runTabId,
             tool: toolName,
             args: toolArgs,
             ok: false,
-            duration_ms: Date.now() - toolStartTime,
+            duration_ms: durationMs,
             message: displayMessage,
           });
+          if (RUN_HARNESS_LONG_TASK_TOOLS.has(toolName)) {
+            runStore.appendRunEvent({
+              run_id: runHarnessId,
+              session_id: sessionId,
+              tab_id: runTabId,
+              kind: 'warning',
+              tool: toolName,
+              ok: false,
+              duration_ms: durationMs,
+              message: displayMessage,
+              metadata: { stage: 'failed_response' },
+            });
+          }
         } catch {
           // best-effort run ledger; never alter tool behavior
         }

--- a/src/run-harness/store.ts
+++ b/src/run-harness/store.ts
@@ -12,6 +12,7 @@ export interface RunStoreOptions {
   now?: () => number;
   idFactory?: () => string;
   evidenceRootDir?: string;
+  maxRecords?: number;
 }
 
 export interface StartRunInput {
@@ -23,6 +24,18 @@ export interface StartRunInput {
 
 export interface FinishRunInput {
   status: RunStatus;
+  message?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RunEventInput {
+  run_id: string;
+  session_id?: string;
+  tab_id?: string;
+  kind: 'progress' | 'warning' | 'partial_result' | 'hint' | 'evidence' | 'failure';
+  tool?: string;
+  ok?: boolean;
+  duration_ms?: number;
   message?: string;
   metadata?: Record<string, unknown>;
 }
@@ -52,12 +65,14 @@ export class RunStore {
   private readonly now: () => number;
   private readonly idFactory: () => string;
   private readonly evidenceCapture: RunEvidenceCapture;
+  private readonly maxRecords: number;
 
   constructor(opts: RunStoreOptions = {}) {
     this.rootDir = opts.rootDir ?? defaultRunRootDir();
     this.now = opts.now ?? Date.now;
     this.idFactory = opts.idFactory ?? (() => crypto.randomUUID());
     this.evidenceCapture = new RunEvidenceCapture({ rootDir: opts.evidenceRootDir, now: this.now, idFactory: this.idFactory });
+    this.maxRecords = opts.maxRecords ?? maxRecordsFromEnv();
   }
 
   startRun(input: StartRunInput = {}): RunRecord {
@@ -97,6 +112,25 @@ export class RunStore {
 
   appendToolFinished(input: ToolEventInput): RunEvent | null {
     return this.appendToolEvent('tool_call_finished', input);
+  }
+
+  appendRunEvent(input: RunEventInput): RunEvent | null {
+    const safeRunId = sanitizeRunId(input.run_id);
+    const record = this.readRun(safeRunId);
+    if (!record || TERMINAL_RUN_STATUSES.has(record.status)) return null;
+    const event = this.event(safeRunId, input.kind, {
+      session_id: input.session_id,
+      tab_id: input.tab_id,
+      tool: input.tool,
+      ok: input.ok,
+      duration_ms: input.duration_ms,
+      message: sanitizeText(input.message),
+      metadata: sanitizeMetadata(input.metadata),
+    });
+    record.events.push(event);
+    record.updated_at = event.ts;
+    this.writeRun(record);
+    return event;
   }
 
   finishRun(run_id: string, input: FinishRunInput): RunRecord | null {
@@ -191,6 +225,38 @@ export class RunStore {
     const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
     fs.writeFileSync(tmp, JSON.stringify(record, null, 2));
     fs.renameSync(tmp, file);
+    this.cleanupRetainedRuns(record.run_id);
+  }
+
+  private cleanupRetainedRuns(currentRunId: string): void {
+    if (!Number.isFinite(this.maxRecords) || this.maxRecords <= 0) return;
+    let files: Array<{ file: string; mtimeMs: number; runId: string; terminal: boolean }> = [];
+    try {
+      files = fs.readdirSync(this.rootDir)
+        .filter((file) => file.endsWith('.json'))
+        .map((file) => {
+          const runId = file.slice(0, -'.json'.length);
+          const fullPath = path.join(this.rootDir, file);
+          const stat = fs.statSync(fullPath);
+          const record = this.readRun(runId);
+          return {
+            file: fullPath,
+            mtimeMs: stat.mtimeMs,
+            runId,
+            terminal: record ? TERMINAL_RUN_STATUSES.has(record.status) : true,
+          };
+        });
+    } catch {
+      return;
+    }
+    if (files.length <= this.maxRecords) return;
+
+    const removable = files
+      .filter((entry) => entry.runId !== currentRunId && entry.terminal)
+      .sort((a, b) => a.mtimeMs - b.mtimeMs);
+    for (const entry of removable.slice(0, files.length - this.maxRecords)) {
+      try { fs.unlinkSync(entry.file); } catch { /* best-effort retention cleanup */ }
+    }
   }
 }
 
@@ -222,6 +288,13 @@ function sanitizeText(value: string | undefined): string | undefined {
 
 function stringMetadata(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function maxRecordsFromEnv(): number {
+  const raw = process.env.OPENCHROME_RUN_MAX_RECORDS;
+  if (!raw) return 500;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : 500;
 }
 
 function sanitizeRunLedgerValue(value: unknown): unknown {

--- a/src/run-harness/tools.ts
+++ b/src/run-harness/tools.ts
@@ -137,7 +137,6 @@ export function registerRunHarnessTools(server: MCPServer): void {
 function recordSummary(record: RunRecord): Record<string, unknown> {
   return {
     run_id: record.run_id,
-    resource_uri: `openchrome://runs/${encodeURIComponent(record.run_id)}`,
     status: record.status,
     created_at: record.created_at,
     updated_at: record.updated_at,

--- a/src/run-harness/tools.ts
+++ b/src/run-harness/tools.ts
@@ -137,12 +137,14 @@ export function registerRunHarnessTools(server: MCPServer): void {
 function recordSummary(record: RunRecord): Record<string, unknown> {
   return {
     run_id: record.run_id,
+    resource_uri: `openchrome://runs/${encodeURIComponent(record.run_id)}`,
     status: record.status,
     created_at: record.created_at,
     updated_at: record.updated_at,
     session_id: record.session_id,
     tab_id: record.tab_id,
     event_count: record.events.length,
+    retention: { max_records_env: 'OPENCHROME_RUN_MAX_RECORDS', default_max_records: 500 },
     terminal: TERMINAL_RUN_STATUSES.has(record.status),
   };
 }

--- a/src/run-harness/types.ts
+++ b/src/run-harness/types.ts
@@ -26,6 +26,9 @@ export type RunEventKind =
   | 'run_finished'
   | 'tool_call_started'
   | 'tool_call_finished'
+  | 'progress'
+  | 'warning'
+  | 'partial_result'
   | 'hint'
   | 'evidence'
   | 'failure';

--- a/tests/run-harness/store.test.ts
+++ b/tests/run-harness/store.test.ts
@@ -161,3 +161,53 @@ describe('run evidence auto-capture', () => {
     expect(parsed.metadata.console.included).toBe(false);
   });
 });
+
+describe('run long-task events and retention', () => {
+  it('appends pollable progress and partial-result events', () => {
+    const { store } = tempStoreForBudget();
+    store.startRun({ run_id: 'run-long' });
+    store.appendRunEvent({
+      run_id: 'run-long',
+      kind: 'progress',
+      tool: 'crawl',
+      message: 'long task started',
+      metadata: { stage: 'started', token: 'abc123' },
+    });
+    store.appendRunEvent({
+      run_id: 'run-long',
+      kind: 'partial_result',
+      tool: 'crawl',
+      ok: true,
+      metadata: { collected: 2 },
+    });
+
+    const run = store.getRun('run-long')!;
+    expect(run.events.map((event) => event.kind)).toEqual([
+      'run_started',
+      'progress',
+      'partial_result',
+    ]);
+    expect(JSON.stringify(run)).not.toContain('abc123');
+  });
+
+  it('retains active runs while pruning older terminal run records', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-run-retain-'));
+    let now = 1000;
+    let seq = 0;
+    const store = new RunStore({
+      rootDir: dir,
+      maxRecords: 2,
+      now: () => now++,
+      idFactory: () => `retain-${seq++}`,
+    });
+    store.startRun({ run_id: 'run-old-terminal' });
+    store.finishRun('run-old-terminal', { status: 'completed' });
+    store.startRun({ run_id: 'run-active' });
+    store.startRun({ run_id: 'run-new-terminal' });
+    store.finishRun('run-new-terminal', { status: 'failed' });
+
+    expect(store.getRun('run-active')).not.toBeNull();
+    expect(store.getRun('run-new-terminal')).not.toBeNull();
+    expect(store.getRun('run-old-terminal')).toBeNull();
+  });
+});

--- a/tests/run-harness/tools-budget.test.ts
+++ b/tests/run-harness/tools-budget.test.ts
@@ -20,7 +20,7 @@ describe('oc_run_status budget guard', () => {
     registerRunHarnessTools({ registerTool: (name: string, handler: any) => handlers.set(name, handler) } as any);
     const start = JSON.parse((await handlers.get('oc_run_start')('s1', { run_id: 'budget-tool' })).content[0].text);
     expect(start.status).toBe('running');
-    expect(start.resource_uri).toBe('openchrome://runs/budget-tool');
+    expect(start.resource_uri).toBeUndefined();
 
     const store = (jest.requireMock('../../src/run-harness/store').getRunStore() as RunStore);
     store.appendToolFinished({ run_id: 'budget-tool', tool: 'interact', ok: false, message: 'element not found' });

--- a/tests/run-harness/tools-budget.test.ts
+++ b/tests/run-harness/tools-budget.test.ts
@@ -20,6 +20,7 @@ describe('oc_run_status budget guard', () => {
     registerRunHarnessTools({ registerTool: (name: string, handler: any) => handlers.set(name, handler) } as any);
     const start = JSON.parse((await handlers.get('oc_run_start')('s1', { run_id: 'budget-tool' })).content[0].text);
     expect(start.status).toBe('running');
+    expect(start.resource_uri).toBe('openchrome://runs/budget-tool');
 
     const store = (jest.requireMock('../../src/run-harness/store').getRunStore() as RunStore);
     store.appendToolFinished({ run_id: 'budget-tool', tool: 'interact', ok: false, message: 'element not found' });


### PR DESCRIPTION
## Summary
- add pollable `progress`, `partial_result`, and `warning` run events for long-task tools when callers pass a run id
- keep long-task tools synchronous by default while exposing `openchrome://runs/<run_id>` in run summaries
- bound run-ledger retention with `OPENCHROME_RUN_MAX_RECORDS` and document the opt-in event protocol

## Verification
- `npm ci`
- `npm test -- tests/run-harness/store.test.ts tests/run-harness/tools-budget.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint -- --quiet`
- `git diff --check`

Closes #1002
