### PR TITLE
Learn privacy-safe recovery episodes

### DIFF
--- a/docs/harness/failure-episode-memory.md
+++ b/docs/harness/failure-episode-memory.md
@@ -1,0 +1,30 @@
+# Privacy-safe failure episode memory
+
+OpenChrome's hint learner records a bounded, privacy-safe failure episode when a
+failed tool call is followed by a different successful tool call inside the
+existing `PatternLearner` watch window. The episode is evidence-backed by that
+successful follow-up; it is not created from speculative hints alone.
+
+Persisted data lives next to `learned-patterns.json` as
+`failure-episodes.json` when `PatternLearner.enablePersistence()` is enabled.
+Each record stores only compact summaries:
+
+- domain, task intent, and coarse state fingerprint
+- failed tool and redacted failed action summary
+- normalized error fingerprint
+- recovery summary, recovery tool list, success evidence summary
+- confidence, attempts, success count, and timestamps
+
+The store redacts emails, bearer tokens, password/token/secret/API-key style
+text, and long opaque tokens before writing. It never stores raw DOM dumps,
+cookies, screenshots, credentials, form values, or network payloads.
+
+Future matching requires the same failed tool, a compatible error fingerprint,
+and compatible domain/task/state context when available. Matching produces an
+advisory `learned-pattern` hint such as a suggested recovery tool and summary;
+OpenChrome does not auto-execute the recovery.
+
+Confidence starts at `0.60`, increases on repeated verified recovery, decreases
+when callers report failed reuse through the store API, and is pruned below
+`0.30`. The default cap is 100 recent/high-confidence episodes, with stale
+entries pruned after 90 days.

--- a/src/hints/failure-episode-store.ts
+++ b/src/hints/failure-episode-store.ts
@@ -282,11 +282,13 @@ function sanitizeText(value: unknown, limit: number): string {
 function normalizeDomain(value: unknown): string {
   const raw = stringFrom(value);
   if (!raw) return UNKNOWN;
+  const looksUrlLike = raw.includes('://') || /^[a-z0-9.-]+\.[a-z]{2,}(?::\d+)?(?:[/?#]|$)/i.test(raw);
+  if (!looksUrlLike) return UNKNOWN;
   try {
     const parsed = raw.includes('://') ? new URL(raw) : new URL(`https://${raw}`);
     return parsed.hostname.toLowerCase();
   } catch {
-    return raw.toLowerCase().replace(/[^a-z0-9.-]/g, '').slice(0, 120) || UNKNOWN;
+    return UNKNOWN;
   }
 }
 

--- a/src/hints/failure-episode-store.ts
+++ b/src/hints/failure-episode-store.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -326,7 +327,9 @@ function overlapScore(left: Set<string>, right: Set<string>): number {
 }
 
 function stableSlug(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 48) || 'failure';
+  const slug = value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40) || 'failure';
+  const hash = crypto.createHash('sha256').update(value).digest('hex').slice(0, 8);
+  return `${slug}-${hash}`;
 }
 
 function clampConfidence(value: number): number {

--- a/src/hints/failure-episode-store.ts
+++ b/src/hints/failure-episode-store.ts
@@ -1,0 +1,335 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface FailureEpisodeContext {
+  domain?: string;
+  taskIntent?: string;
+  stateFingerprint?: string;
+  actionSummary?: string;
+  evidenceSummary?: string;
+}
+
+export interface FailureEpisode {
+  id: string;
+  domain: string;
+  task_intent: string;
+  state_fingerprint: string;
+  failed_tool: string;
+  failed_action_summary: string;
+  error_fingerprint: string;
+  recovery_summary: string;
+  recovery_tools: string[];
+  success_evidence_summary: string;
+  confidence: number;
+  attempts: number;
+  successes: number;
+  created_at: number;
+  updated_at: number;
+}
+
+interface FailureEpisodeFile {
+  version: 1;
+  episodes: FailureEpisode[];
+  updatedAt: number;
+}
+
+export interface FailureEpisodeStoreOptions {
+  filePath?: string;
+  now?: () => number;
+  maxEpisodes?: number;
+  staleAfterMs?: number;
+}
+
+const DEFAULT_MAX_EPISODES = 100;
+const DEFAULT_STALE_AFTER_MS = 90 * 24 * 60 * 60 * 1000;
+const UNKNOWN = 'unknown';
+
+export class FailureEpisodeStore {
+  private readonly now: () => number;
+  private readonly maxEpisodes: number;
+  private readonly staleAfterMs: number;
+  private filePath: string | null;
+  private episodes: FailureEpisode[] = [];
+
+  constructor(options: FailureEpisodeStoreOptions = {}) {
+    this.filePath = options.filePath ?? null;
+    this.now = options.now ?? Date.now;
+    this.maxEpisodes = options.maxEpisodes ?? DEFAULT_MAX_EPISODES;
+    this.staleAfterMs = options.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
+    if (this.filePath) this.load();
+  }
+
+  enablePersistence(dirPath: string): void {
+    fs.mkdirSync(dirPath, { recursive: true });
+    this.filePath = path.join(dirPath, 'failure-episodes.json');
+    this.load();
+  }
+
+  recordVerifiedRecovery(input: {
+    failedTool: string;
+    errorFingerprint: string;
+    recoveryTool: string;
+    failure?: FailureEpisodeContext;
+    recovery?: FailureEpisodeContext;
+  }): FailureEpisode {
+    const now = this.now();
+    const domain = normalizeDomain(input.failure?.domain ?? input.recovery?.domain);
+    const errorFingerprint = sanitizeText(input.errorFingerprint, 120) || UNKNOWN;
+    const failedTool = sanitizeText(input.failedTool, 80) || UNKNOWN;
+    const recoveryTool = sanitizeText(input.recoveryTool, 80) || UNKNOWN;
+    const existing = this.episodes.find((episode) =>
+      episode.domain === domain &&
+      episode.failed_tool === failedTool &&
+      episode.error_fingerprint === errorFingerprint &&
+      episode.recovery_tools.includes(recoveryTool),
+    );
+
+    if (existing) {
+      existing.task_intent = chooseMoreSpecific(existing.task_intent, input.failure?.taskIntent);
+      existing.state_fingerprint = chooseMoreSpecific(existing.state_fingerprint, input.failure?.stateFingerprint);
+      existing.failed_action_summary = chooseMoreSpecific(existing.failed_action_summary, input.failure?.actionSummary);
+      existing.recovery_summary = chooseMoreSpecific(existing.recovery_summary, input.recovery?.actionSummary ?? recoveryTool);
+      existing.success_evidence_summary = chooseMoreSpecific(existing.success_evidence_summary, input.recovery?.evidenceSummary);
+      existing.confidence = clampConfidence(existing.confidence + 0.1);
+      existing.attempts++;
+      existing.successes++;
+      existing.updated_at = now;
+      this.pruneAndSave();
+      return existing;
+    }
+
+    const episode: FailureEpisode = {
+      id: `episode-${now}-${stableSlug(`${domain}-${failedTool}-${recoveryTool}`)}`,
+      domain,
+      task_intent: sanitizeText(input.failure?.taskIntent, 160) || UNKNOWN,
+      state_fingerprint: sanitizeText(input.failure?.stateFingerprint, 160) || UNKNOWN,
+      failed_tool: failedTool,
+      failed_action_summary: sanitizeText(input.failure?.actionSummary, 160) || failedTool,
+      error_fingerprint: errorFingerprint,
+      recovery_summary: sanitizeText(input.recovery?.actionSummary ?? recoveryTool, 160) || recoveryTool,
+      recovery_tools: [recoveryTool],
+      success_evidence_summary: sanitizeText(input.recovery?.evidenceSummary, 160) || 'verified successful follow-up tool call',
+      confidence: 0.6,
+      attempts: 1,
+      successes: 1,
+      created_at: now,
+      updated_at: now,
+    };
+    this.episodes.push(episode);
+    this.pruneAndSave();
+    return episode;
+  }
+
+  recordFailedReuse(episodeId: string): void {
+    const episode = this.episodes.find((candidate) => candidate.id === episodeId);
+    if (!episode) return;
+    episode.attempts++;
+    episode.confidence = clampConfidence(episode.confidence - 0.2);
+    episode.updated_at = this.now();
+    this.pruneAndSave();
+  }
+
+  match(input: {
+    failedTool: string;
+    errorFingerprint: string;
+    domain?: string;
+    taskIntent?: string;
+    stateFingerprint?: string;
+  }): FailureEpisode | null {
+    const now = this.now();
+    const domain = normalizeDomain(input.domain);
+    const errorFingerprint = sanitizeText(input.errorFingerprint, 120) || UNKNOWN;
+    const taskTokens = tokenize(input.taskIntent ?? '');
+    const stateTokens = tokenize(input.stateFingerprint ?? '');
+
+    let best: { episode: FailureEpisode; score: number } | null = null;
+    for (const episode of this.episodes) {
+      if (now - episode.updated_at > this.staleAfterMs) continue;
+      if (episode.confidence < 0.3) continue;
+      if (episode.failed_tool !== input.failedTool) continue;
+      if (episode.domain !== UNKNOWN && domain !== UNKNOWN && episode.domain !== domain) continue;
+      if (!compatibleFingerprint(episode.error_fingerprint, errorFingerprint)) continue;
+
+      const score = episode.confidence +
+        overlapScore(taskTokens, tokenize(episode.task_intent)) * 0.25 +
+        overlapScore(stateTokens, tokenize(episode.state_fingerprint)) * 0.15;
+      if (!best || score > best.score) best = { episode, score };
+    }
+    return best?.episode ?? null;
+  }
+
+  buildHint(episode: FailureEpisode): string {
+    return 'Hint: Similar failure episode learned on ' + episode.domain +
+      ` (${episode.error_fingerprint}). Suggested recovery: ${episode.recovery_summary}` +
+      ` using ${episode.recovery_tools.join(', ')}; confidence=${episode.confidence.toFixed(2)}.` +
+      ' Validate before acting; no recovery was auto-executed.';
+  }
+
+  list(): FailureEpisode[] {
+    this.prune();
+    return this.episodes.slice();
+  }
+
+  private load(): void {
+    if (!this.filePath) return;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.filePath, 'utf8')) as FailureEpisodeFile;
+      this.episodes = Array.isArray(parsed.episodes) ? parsed.episodes.map(normalizeEpisode).filter(Boolean) as FailureEpisode[] : [];
+      this.prune();
+    } catch {
+      this.episodes = [];
+    }
+  }
+
+  private pruneAndSave(): void {
+    this.prune();
+    this.save();
+  }
+
+  private prune(): void {
+    const cutoff = this.now() - this.staleAfterMs;
+    this.episodes = this.episodes
+      .filter((episode) => episode.confidence >= 0.3 && episode.updated_at >= cutoff)
+      .sort((a, b) => b.confidence - a.confidence || b.updated_at - a.updated_at)
+      .slice(0, this.maxEpisodes);
+  }
+
+  private save(): void {
+    if (!this.filePath) return;
+    try {
+      fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+      const payload: FailureEpisodeFile = { version: 1, episodes: this.episodes, updatedAt: this.now() };
+      const tmp = `${this.filePath}.${process.pid}.${Date.now()}.tmp`;
+      fs.writeFileSync(tmp, JSON.stringify(payload, null, 2));
+      fs.renameSync(tmp, this.filePath);
+    } catch {
+      // Best-effort memory; never break hinting.
+    }
+  }
+}
+
+export function buildFailureEpisodeContext(input: {
+  args?: Record<string, unknown>;
+  resultText?: string;
+}): FailureEpisodeContext {
+  const args = input.args ?? {};
+  return {
+    domain: extractDomain(args.url) ?? extractDomain(input.resultText),
+    taskIntent: stringFrom(args.task ?? args.intent ?? args.description ?? args.query ?? args.goal),
+    stateFingerprint: summarizeState(input.resultText),
+    actionSummary: summarizeAction(args),
+    evidenceSummary: summarizeEvidence(input.resultText),
+  };
+}
+
+function normalizeEpisode(raw: FailureEpisode): FailureEpisode | null {
+  if (!raw || typeof raw !== 'object') return null;
+  return {
+    id: sanitizeText(raw.id, 120) || `episode-${Date.now()}`,
+    domain: normalizeDomain(raw.domain),
+    task_intent: sanitizeText(raw.task_intent, 160) || UNKNOWN,
+    state_fingerprint: sanitizeText(raw.state_fingerprint, 160) || UNKNOWN,
+    failed_tool: sanitizeText(raw.failed_tool, 80) || UNKNOWN,
+    failed_action_summary: sanitizeText(raw.failed_action_summary, 160) || UNKNOWN,
+    error_fingerprint: sanitizeText(raw.error_fingerprint, 120) || UNKNOWN,
+    recovery_summary: sanitizeText(raw.recovery_summary, 160) || UNKNOWN,
+    recovery_tools: Array.isArray(raw.recovery_tools) ? raw.recovery_tools.map((tool) => sanitizeText(tool, 80)).filter(Boolean) : [],
+    success_evidence_summary: sanitizeText(raw.success_evidence_summary, 160) || UNKNOWN,
+    confidence: clampConfidence(Number(raw.confidence)),
+    attempts: Number.isFinite(raw.attempts) ? Math.max(0, Math.floor(raw.attempts)) : 0,
+    successes: Number.isFinite(raw.successes) ? Math.max(0, Math.floor(raw.successes)) : 0,
+    created_at: Number.isFinite(raw.created_at) ? raw.created_at : Date.now(),
+    updated_at: Number.isFinite(raw.updated_at) ? raw.updated_at : Date.now(),
+  };
+}
+
+function summarizeAction(args: Record<string, unknown>): string | undefined {
+  const description = stringFrom(args.description ?? args.action ?? args.selector ?? args.text ?? args.url);
+  return description ? sanitizeText(description, 160) : undefined;
+}
+
+function summarizeState(text: string | undefined): string | undefined {
+  if (!text) return undefined;
+  const flags = [
+    /overlay|modal|dialog/i.test(text) ? 'overlay-present' : '',
+    /login|auth|sign in/i.test(text) ? 'auth-visible' : '',
+    /stale|detached|not found/i.test(text) ? 'stale-or-missing-element' : '',
+    /timeout|timed out/i.test(text) ? 'timeout' : '',
+  ].filter(Boolean);
+  return flags.length > 0 ? flags.join(':') : sanitizeText(text, 120);
+}
+
+function summarizeEvidence(text: string | undefined): string | undefined {
+  if (!text) return undefined;
+  if (/success|done|completed|saved|visible|clicked|submitted/i.test(text)) return sanitizeText(text, 160);
+  return 'successful follow-up tool call';
+}
+
+function sanitizeText(value: unknown, limit: number): string {
+  const raw = stringFrom(value);
+  if (!raw) return '';
+  const redacted = raw
+    .replace(/([\w.+-]+)@([\w.-]+\.[a-z]{2,})/gi, '[REDACTED_EMAIL]')
+    .replace(/Bearer\s+[^\s,;]+/gi, 'Bearer [REDACTED]')
+    .replace(/(password|token|secret|credential|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]')
+    .replace(/\b(?:[A-Za-z0-9+/]{32,}={0,2}|[a-f0-9]{32,})\b/g, '[REDACTED]')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return redacted.slice(0, limit);
+}
+
+function normalizeDomain(value: unknown): string {
+  const raw = stringFrom(value);
+  if (!raw) return UNKNOWN;
+  try {
+    const parsed = raw.includes('://') ? new URL(raw) : new URL(`https://${raw}`);
+    return parsed.hostname.toLowerCase();
+  } catch {
+    return raw.toLowerCase().replace(/[^a-z0-9.-]/g, '').slice(0, 120) || UNKNOWN;
+  }
+}
+
+function extractDomain(value: unknown): string | undefined {
+  const raw = stringFrom(value);
+  if (!raw) return undefined;
+  const url = raw.match(/https?:\/\/[^\s"')]+/i)?.[0] ?? raw;
+  const domain = normalizeDomain(url);
+  return domain === UNKNOWN ? undefined : domain;
+}
+
+function stringFrom(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim()) return value.trim();
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return undefined;
+}
+
+function chooseMoreSpecific(current: string, next: unknown): string {
+  const sanitized = sanitizeText(next, 160);
+  if (!sanitized || sanitized === UNKNOWN) return current;
+  if (!current || current === UNKNOWN || sanitized.length > current.length) return sanitized;
+  return current;
+}
+
+function compatibleFingerprint(left: string, right: string): boolean {
+  return left.includes(right) || right.includes(left) || overlapScore(tokenize(left), tokenize(right)) >= 0.5;
+}
+
+function tokenize(text: string): Set<string> {
+  return new Set(text.toLowerCase().split(/[^a-z0-9]+/).filter((token) => token.length >= 3));
+}
+
+function overlapScore(left: Set<string>, right: Set<string>): number {
+  if (left.size === 0 || right.size === 0) return 0;
+  let matches = 0;
+  for (const token of left) if (right.has(token)) matches++;
+  return matches / Math.max(left.size, right.size);
+}
+
+function stableSlug(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 48) || 'failure';
+}
+
+function clampConfidence(value: number): number {
+  if (!Number.isFinite(value)) return 0.6;
+  return Math.max(0, Math.min(1, Number(value.toFixed(3))));
+}

--- a/src/hints/failure-episode-store.ts
+++ b/src/hints/failure-episode-store.ts
@@ -99,7 +99,7 @@ export class FailureEpisodeStore {
     }
 
     const episode: FailureEpisode = {
-      id: `episode-${now}-${stableSlug(`${domain}-${failedTool}-${recoveryTool}`)}`,
+      id: `episode-${now}-${stableSlug(`${domain}-${failedTool}-${errorFingerprint}-${recoveryTool}`)}`,
       domain,
       task_intent: sanitizeText(input.failure?.taskIntent, 160) || UNKNOWN,
       state_fingerprint: sanitizeText(input.failure?.stateFingerprint, 160) || UNKNOWN,

--- a/src/hints/failure-episode-store.ts
+++ b/src/hints/failure-episode-store.ts
@@ -76,8 +76,8 @@ export class FailureEpisodeStore {
     const now = this.now();
     const domain = normalizeDomain(input.failure?.domain ?? input.recovery?.domain);
     const errorFingerprint = sanitizeText(input.errorFingerprint, 120) || UNKNOWN;
-    const failedTool = sanitizeText(input.failedTool, 80) || UNKNOWN;
-    const recoveryTool = sanitizeText(input.recoveryTool, 80) || UNKNOWN;
+    const failedTool = normalizeToolName(input.failedTool);
+    const recoveryTool = normalizeToolName(input.recoveryTool);
     const existing = this.episodes.find((episode) =>
       episode.domain === domain &&
       episode.failed_tool === failedTool &&
@@ -140,6 +140,7 @@ export class FailureEpisodeStore {
     const now = this.now();
     const domain = normalizeDomain(input.domain);
     const errorFingerprint = sanitizeText(input.errorFingerprint, 120) || UNKNOWN;
+    const failedTool = normalizeToolName(input.failedTool);
     const taskTokens = tokenize(input.taskIntent ?? '');
     const stateTokens = tokenize(input.stateFingerprint ?? '');
 
@@ -147,7 +148,7 @@ export class FailureEpisodeStore {
     for (const episode of this.episodes) {
       if (now - episode.updated_at > this.staleAfterMs) continue;
       if (episode.confidence < 0.3) continue;
-      if (episode.failed_tool !== input.failedTool) continue;
+      if (episode.failed_tool !== failedTool) continue;
       if (episode.domain !== UNKNOWN && domain !== UNKNOWN && episode.domain !== domain) continue;
       if (!compatibleFingerprint(episode.error_fingerprint, errorFingerprint)) continue;
 
@@ -230,11 +231,11 @@ function normalizeEpisode(raw: FailureEpisode): FailureEpisode | null {
     domain: normalizeDomain(raw.domain),
     task_intent: sanitizeText(raw.task_intent, 160) || UNKNOWN,
     state_fingerprint: sanitizeText(raw.state_fingerprint, 160) || UNKNOWN,
-    failed_tool: sanitizeText(raw.failed_tool, 80) || UNKNOWN,
+    failed_tool: normalizeToolName(raw.failed_tool),
     failed_action_summary: sanitizeText(raw.failed_action_summary, 160) || UNKNOWN,
     error_fingerprint: sanitizeText(raw.error_fingerprint, 120) || UNKNOWN,
     recovery_summary: sanitizeText(raw.recovery_summary, 160) || UNKNOWN,
-    recovery_tools: Array.isArray(raw.recovery_tools) ? raw.recovery_tools.map((tool) => sanitizeText(tool, 80)).filter(Boolean) : [],
+    recovery_tools: Array.isArray(raw.recovery_tools) ? raw.recovery_tools.map((tool) => normalizeToolName(tool)).filter((tool) => tool !== UNKNOWN) : [],
     success_evidence_summary: sanitizeText(raw.success_evidence_summary, 160) || UNKNOWN,
     confidence: clampConfidence(Number(raw.confidence)),
     attempts: Number.isFinite(raw.attempts) ? Math.max(0, Math.floor(raw.attempts)) : 0,
@@ -277,6 +278,12 @@ function sanitizeText(value: unknown, limit: number): string {
     .replace(/\s+/g, ' ')
     .trim();
   return redacted.slice(0, limit);
+}
+
+function normalizeToolName(value: unknown): string {
+  const sanitized = sanitizeText(value, 80).toLowerCase();
+  const normalized = sanitized.replace(/[^a-z0-9_-]+/g, '_').replace(/^_+|_+$/g, '');
+  return normalized || UNKNOWN;
 }
 
 function normalizeDomain(value: unknown): string {

--- a/src/hints/hint-engine.ts
+++ b/src/hints/hint-engine.ts
@@ -17,6 +17,7 @@ import * as path from 'path';
 import type { ToolCallEvent } from '../dashboard/types';
 import type { ActivityTracker } from '../dashboard/activity-tracker';
 import { PatternLearner } from './pattern-learner';
+import { buildFailureEpisodeContext, type FailureEpisodeContext } from './failure-episode-store';
 import { ProgressTracker } from './progress-tracker.js';
 import { RepeatedCallDetector } from './repeated-call-detector.js';
 import { errorRecoveryRules } from './rules/error-recovery';
@@ -47,6 +48,7 @@ export interface HintContext {
   isError: boolean;
   recentCalls: ToolCallEvent[];
   fireCounts: Map<string, number>;
+  episodeContext?: FailureEpisodeContext;
 }
 
 export interface HintRule {
@@ -201,6 +203,7 @@ export class HintEngine {
     currentCallId?: string,
   ): HintResult | null {
     const resultText = this.extractText(result);
+    const episodeContext = buildFailureEpisodeContext({ args: currentArgs, resultText });
     const hintSessionId = sessionId ?? 'default';
     const recentCalls = this.activityTracker
       .getRecentCalls(6, sessionId)
@@ -273,7 +276,14 @@ export class HintEngine {
       };
     }
 
-    const ctx: HintContext = { toolName, resultText, isError, recentCalls, fireCounts: this.hintEscalation };
+    const ctx: HintContext = {
+      toolName,
+      resultText,
+      isError,
+      recentCalls,
+      fireCounts: this.hintEscalation,
+      episodeContext,
+    };
 
     let matchedRule: string | null = null;
     let rawHint: string | null = null;
@@ -365,9 +375,9 @@ export class HintEngine {
 
     if (!rawHint || !matchedRule) {
       // Feed the learner even on miss
-      this.learner.onToolComplete(toolName, isError);
+      this.learner.onToolComplete(toolName, isError, episodeContext);
       if (isError) {
-        this.learner.onMiss(toolName, resultText);
+        this.learner.onMiss(toolName, resultText, episodeContext);
       }
       this.log({ timestamp: Date.now(), toolName, isError, matchedRule: null, hint: null, severity: null, fireCount: 0 });
       return null;
@@ -411,8 +421,13 @@ export class HintEngine {
       ...(context && { context }),
     };
 
-    // Feed the learner
-    this.learner.onToolComplete(toolName, isError);
+    // Feed the learner. Learned episode hints are advisory, so keep watching
+    // whether the caller's next different successful tool verifies that
+    // recovery path again. Static rules remain non-authoritative hints only.
+    this.learner.onToolComplete(toolName, isError, episodeContext);
+    if (isError && matchedRule === 'learned-pattern') {
+      this.learner.onMiss(toolName, resultText, episodeContext);
+    }
 
     this.log({ timestamp: Date.now(), toolName, isError, matchedRule, hint: formattedHint, severity, fireCount });
     if (mapHintRuleToRecoveryCategory(matchedRule, resultText) !== 'unknown') {

--- a/src/hints/pattern-learner.ts
+++ b/src/hints/pattern-learner.ts
@@ -10,6 +10,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { FailureEpisodeStore, type FailureEpisode, type FailureEpisodeContext } from './failure-episode-store';
 
 export interface LearnedPattern {
   id: string;
@@ -28,6 +29,7 @@ interface PendingObservation {
   errorFingerprint: string;
   timestamp: number;
   remainingSlots: number;
+  context?: FailureEpisodeContext;
 }
 
 interface RawObservation {
@@ -49,6 +51,7 @@ export class PatternLearner {
   private patterns: LearnedPattern[] = [];
   private filePath: string | null = null;
   private dirty = false;
+  private episodeStore = new FailureEpisodeStore();
 
   static readonly WATCH_WINDOW = 3;
   static readonly PROMOTE_THRESHOLD = 3;
@@ -62,6 +65,7 @@ export class PatternLearner {
     try {
       fs.mkdirSync(dirPath, { recursive: true });
       this.filePath = path.join(dirPath, 'learned-patterns.json');
+      this.episodeStore.enablePersistence(dirPath);
       this.load();
     } catch {
       // Best-effort
@@ -72,7 +76,7 @@ export class PatternLearner {
    * Called when a hint miss occurs on an error (no static rule matched).
    * Starts observing subsequent calls to detect recovery pattern.
    */
-  onMiss(toolName: string, errorText: string): void {
+  onMiss(toolName: string, errorText: string, context?: FailureEpisodeContext): void {
     const fingerprint = this.normalizeError(errorText);
     if (!fingerprint) return;
 
@@ -86,21 +90,29 @@ export class PatternLearner {
       errorFingerprint: fingerprint,
       timestamp: Date.now(),
       remainingSlots: PatternLearner.WATCH_WINDOW,
+      context,
     });
   }
 
   /**
    * Called on every tool completion to observe potential recovery patterns.
    */
-  onToolComplete(toolName: string, isError: boolean): void {
+  onToolComplete(toolName: string, isError: boolean, context?: FailureEpisodeContext): void {
     const resolved: number[] = [];
 
     for (let i = 0; i < this.pending.length; i++) {
       const obs = this.pending[i];
 
       if (!isError && toolName !== obs.errorTool) {
-        // Success with different tool = potential recovery
+        // Success with different tool = potential verified recovery
         this.recordRecovery(obs.errorFingerprint, obs.errorTool, toolName);
+        this.episodeStore.recordVerifiedRecovery({
+          failedTool: obs.errorTool,
+          errorFingerprint: obs.errorFingerprint,
+          recoveryTool: toolName,
+          failure: obs.context,
+          recovery: context,
+        });
         resolved.push(i);
       } else if (!isError && toolName === obs.errorTool) {
         // Same tool succeeded = self-resolved, discard
@@ -199,6 +211,28 @@ export class PatternLearner {
       }
     }
     return null;
+  }
+
+
+  /**
+   * Match an error against privacy-safe verified failure episodes.
+   */
+  matchEpisode(errorText: string, toolName: string, context?: FailureEpisodeContext): FailureEpisode | null {
+    return this.episodeStore.match({
+      failedTool: toolName,
+      errorFingerprint: this.normalizeError(errorText),
+      domain: context?.domain,
+      taskIntent: context?.taskIntent,
+      stateFingerprint: context?.stateFingerprint,
+    });
+  }
+
+  buildEpisodeHint(episode: FailureEpisode): string {
+    return this.episodeStore.buildHint(episode);
+  }
+
+  getFailureEpisodes(): FailureEpisode[] {
+    return this.episodeStore.list();
   }
 
   /**

--- a/src/hints/rules/learned-rules.ts
+++ b/src/hints/rules/learned-rules.ts
@@ -18,6 +18,8 @@ export function createLearnedRules(learner: PatternLearner): HintRule[] {
       priority: 350,
       match(ctx) {
         if (!ctx.isError) return null;
+        const episode = learner.matchEpisode(ctx.resultText, ctx.toolName, ctx.episodeContext);
+        if (episode) return learner.buildEpisodeHint(episode);
         const pattern = learner.matchPattern(ctx.resultText, ctx.toolName);
         return pattern ? pattern.hint : null;
       },

--- a/tests/hints/failure-episode-store.test.ts
+++ b/tests/hints/failure-episode-store.test.ts
@@ -82,4 +82,26 @@ describe('FailureEpisodeStore', () => {
     store.recordFailedReuse(first.id);
     expect(store.match({ failedTool: 'interact', errorFingerprint: 'first failure' })).toBeNull();
   });
+
+  it('includes error fingerprint in generated episode ids', () => {
+    const store = new FailureEpisodeStore({ now: () => 1000 });
+
+    const timeout = store.recordVerifiedRecovery({
+      failedTool: 'interact',
+      errorFingerprint: 'timeout waiting for element',
+      recoveryTool: 'read_page',
+      failure: { domain: 'example.test' },
+    });
+    const staleRef = store.recordVerifiedRecovery({
+      failedTool: 'interact',
+      errorFingerprint: 'stale ref for element',
+      recoveryTool: 'read_page',
+      failure: { domain: 'example.test' },
+    });
+
+    expect(timeout.id).not.toBe(staleRef.id);
+    expect(timeout.id).toContain('timeout-waiting-for-elemen');
+    expect(staleRef.id).toContain('stale-ref-for-element');
+  });
+
 });

--- a/tests/hints/failure-episode-store.test.ts
+++ b/tests/hints/failure-episode-store.test.ts
@@ -100,8 +100,29 @@ describe('FailureEpisodeStore', () => {
     });
 
     expect(timeout.id).not.toBe(staleRef.id);
-    expect(timeout.id).toContain('timeout-waiting-for-elemen');
-    expect(staleRef.id).toContain('stale-ref-for-element');
+    expect(timeout.id).toMatch(/timeout-waiting-fo-[0-9a-f]{8}$/);
+    expect(staleRef.id).toMatch(/stale-ref-for-elem-[0-9a-f]{8}$/);
+  });
+
+
+  it('uses a hash suffix so truncated slugs remain collision-resistant', () => {
+    const store = new FailureEpisodeStore({ now: () => 2000 });
+    const first = store.recordVerifiedRecovery({
+      failedTool: 'interact',
+      errorFingerprint: 'alpha beta gamma delta epsilon '.repeat(6) + 'first unique tail',
+      recoveryTool: 'read_page',
+      failure: { domain: 'example.test' },
+    });
+    const second = store.recordVerifiedRecovery({
+      failedTool: 'interact',
+      errorFingerprint: 'zulu yankee xray whiskey victor '.repeat(6) + 'second unique tail',
+      recoveryTool: 'read_page',
+      failure: { domain: 'example.test' },
+    });
+
+    expect(first.id).not.toBe(second.id);
+    expect(first.id).toMatch(/-[0-9a-f]{8}$/);
+    expect(second.id).toMatch(/-[0-9a-f]{8}$/);
   });
 
 });

--- a/tests/hints/failure-episode-store.test.ts
+++ b/tests/hints/failure-episode-store.test.ts
@@ -1,0 +1,85 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { FailureEpisodeStore } from '../../src/hints/failure-episode-store';
+
+describe('FailureEpisodeStore', () => {
+  it('persists verified recovery episodes with redacted bounded summaries', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'failure-episodes-'));
+    const filePath = path.join(dir, 'failure-episodes.json');
+    const store = new FailureEpisodeStore({ filePath, now: () => 1000 });
+
+    store.recordVerifiedRecovery({
+      failedTool: 'interact',
+      errorFingerprint: 'element not interactive password=hunter2 user@example.com',
+      recoveryTool: 'read_page',
+      failure: {
+        domain: 'https://example.test/form',
+        taskIntent: 'submit contact form token=abc123',
+        stateFingerprint: 'overlay-present',
+        actionSummary: 'click submit',
+      },
+      recovery: {
+        actionSummary: 'dismiss overlay then retry',
+        evidenceSummary: 'success banner visible api_key=secret123',
+      },
+    });
+
+    const raw = fs.readFileSync(filePath, 'utf8');
+    expect(raw).toContain('example.test');
+    expect(raw).toContain('[REDACTED]');
+    expect(raw).not.toContain('hunter2');
+    expect(raw).not.toContain('user@example.com');
+    expect(raw).not.toContain('secret123');
+  });
+
+  it('matches by domain, tool, error, task/state context and builds advisory hints', () => {
+    const store = new FailureEpisodeStore({ now: () => 1000 });
+    const episode = store.recordVerifiedRecovery({
+      failedTool: 'interact',
+      errorFingerprint: 'element not interactive',
+      recoveryTool: 'read_page',
+      failure: { domain: 'example.test', taskIntent: 'submit form', stateFingerprint: 'overlay-present' },
+      recovery: { actionSummary: 'inspect page and dismiss overlay' },
+    });
+
+    const match = store.match({
+      failedTool: 'interact',
+      errorFingerprint: 'element not interactive on button',
+      domain: 'example.test',
+      taskIntent: 'submit contact form',
+      stateFingerprint: 'overlay-present',
+    });
+
+    expect(match?.id).toBe(episode.id);
+    const hint = store.buildHint(match!);
+    expect(hint).toContain('Suggested recovery');
+    expect(hint).toContain('no recovery was auto-executed');
+  });
+
+  it('prunes low-confidence and over-cap stale/noisy episodes', () => {
+    let now = 1000;
+    const store = new FailureEpisodeStore({ now: () => now, maxEpisodes: 1, staleAfterMs: 50 });
+    const first = store.recordVerifiedRecovery({
+      failedTool: 'interact',
+      errorFingerprint: 'first failure',
+      recoveryTool: 'read_page',
+    });
+    now += 10;
+    const second = store.recordVerifiedRecovery({
+      failedTool: 'interact',
+      errorFingerprint: 'second failure',
+      recoveryTool: 'find',
+    });
+
+    expect(store.list().map((episode) => episode.id)).toEqual([second.id]);
+    store.recordFailedReuse(second.id);
+    store.recordFailedReuse(second.id);
+    expect(store.list()).toHaveLength(0);
+
+    now += 100;
+    store.recordFailedReuse(first.id);
+    expect(store.match({ failedTool: 'interact', errorFingerprint: 'first failure' })).toBeNull();
+  });
+});

--- a/tests/hints/failure-episode-store.test.ts
+++ b/tests/hints/failure-episode-store.test.ts
@@ -125,4 +125,17 @@ describe('FailureEpisodeStore', () => {
     expect(second.id).toMatch(/-[0-9a-f]{8}$/);
   });
 
+
+  it('does not infer domains from non-URL task text', () => {
+    const store = new FailureEpisodeStore({ now: () => 3000 });
+    const episode = store.recordVerifiedRecovery({
+      failedTool: 'interact',
+      errorFingerprint: 'button missing',
+      recoveryTool: 'read_page',
+      failure: { domain: 'checkout flow step' },
+    });
+
+    expect(episode.domain).toBe('unknown');
+  });
+
 });

--- a/tests/hints/failure-episode-store.test.ts
+++ b/tests/hints/failure-episode-store.test.ts
@@ -34,6 +34,25 @@ describe('FailureEpisodeStore', () => {
     expect(raw).not.toContain('secret123');
   });
 
+  it('normalizes failed tool names before matching episodes', () => {
+    const store = new FailureEpisodeStore({ now: () => 1000 });
+    const episode = store.recordVerifiedRecovery({
+      failedTool: 'Interact Tool',
+      errorFingerprint: 'element not interactive',
+      recoveryTool: 'Read Page',
+      failure: { domain: 'example.test' },
+      recovery: { actionSummary: 'inspect page' },
+    });
+
+    expect(store.match({
+      failedTool: 'interact_tool',
+      errorFingerprint: 'element not interactive',
+      domain: 'example.test',
+    })?.id).toBe(episode.id);
+    expect(episode.failed_tool).toBe('interact_tool');
+    expect(episode.recovery_tools).toEqual(['read_page']);
+  });
+
   it('matches by domain, tool, error, task/state context and builds advisory hints', () => {
     const store = new FailureEpisodeStore({ now: () => 1000 });
     const episode = store.recordVerifiedRecovery({

--- a/tests/hints/hint-engine.test.ts
+++ b/tests/hints/hint-engine.test.ts
@@ -900,3 +900,40 @@ describe('HintEngine', () => {
     });
   });
 });
+
+describe('failure episode memory', () => {
+  it('records a verified recovery episode and emits a future advisory hint', () => {
+    const tracker = new ActivityTracker();
+    const engine = new HintEngine(tracker);
+
+    const first = engine.getHint(
+      'custom_action',
+      makeResult('opaque widget failure on https://example.test/form', true),
+      true,
+      's-episode',
+      { url: 'https://example.test/form', description: 'submit contact form' },
+    );
+    expect(first).toBeNull();
+
+    engine.getHint(
+      'read_page',
+      makeResult('success banner visible after dismiss overlay'),
+      false,
+      's-episode',
+      { url: 'https://example.test/form', description: 'inspect page and dismiss overlay' },
+    );
+
+    const hint = engine.getHint(
+      'custom_action',
+      makeResult('opaque widget failure on https://example.test/form', true),
+      true,
+      's-episode',
+      { url: 'https://example.test/form', description: 'submit contact form' },
+    );
+
+    expect(hint?.rule).toBe('learned-pattern');
+    expect(hint?.hint).toContain('Similar failure episode');
+    expect(hint?.hint).toContain('no recovery was auto-executed');
+    expect(engine.getLearner().getFailureEpisodes()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add bounded `FailureEpisodeStore` for redacted domain/task/error recovery episodes
- integrate episodes with `PatternLearner` so verified different-tool follow-ups can produce future advisory learned hints
- document the privacy model, pruning/confidence behavior, and no-auto-execution contract

## Verification
- `npm ci`
- `npm test -- tests/hints/failure-episode-store.test.ts tests/hints/hint-engine.test.ts tests/hints/pattern-learner.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint -- --quiet`
- `git diff --check`

Closes #1011
