### PR TITLE
Add explicit crawl content cache modes

### DIFF
--- a/docs/harness/crawl-cache-modes.md
+++ b/docs/harness/crawl-cache-modes.md
@@ -1,0 +1,36 @@
+# Crawl content cache modes
+
+`crawl`, `crawl_sitemap`, and resumable crawl jobs (`crawl_start`/`crawl_status`)
+support an explicit, default-off URL content cache for repeated public crawl
+workloads.
+
+Arguments:
+
+- `cache_mode`: `disabled` (default), `enabled`, `read_only`, `write_only`, or `bypass`
+- `cache_ttl_ms`: optional max age for `enabled`/`read_only` hits
+- `cache_scope`: `public` (default) or `session`
+
+Mode semantics:
+
+| Mode | Read existing cache | Write fetched result | Fetch when absent/stale |
+| --- | --- | --- | --- |
+| `disabled` | no | no | yes |
+| `enabled` | yes | yes | yes |
+| `read_only` | yes | no | yes |
+| `write_only` | no | yes | yes |
+| `bypass` | no | yes, overwrites | yes |
+
+Entries are stored under `~/.openchrome/cache/crawl/` by default. Set
+`OPENCHROME_CRAWL_CACHE_DIR` to override the directory. Each entry records schema
+version, creation time, source URL, final URL, content length, cache key, page
+content, and discovered links where applicable. Cleanup is invoked only during
+cache writes; there is no background timer.
+
+Public-scope writes are skipped for obvious authenticated/session-sensitive
+pages such as account, dashboard, billing, admin, settings, checkout, cart,
+profile, and login paths/titles, or content containing password/token-like form
+signals. Skipped writes still return the fetched page with
+`page.cache.write_skipped_reason`.
+
+Default behavior is unchanged: omitting `cache_mode` produces no cache metadata
+and writes no files.

--- a/src/core/crawl/content-cache.ts
+++ b/src/core/crawl/content-cache.ts
@@ -164,7 +164,9 @@ export function canWriteCache(mode: CrawlCacheMode): boolean {
 }
 
 export function defaultCrawlCacheRootDir(): string {
-  return process.env.OPENCHROME_CRAWL_CACHE_DIR || path.join(process.env.OPENCHROME_HOME || os.homedir(), '.openchrome', 'cache', 'crawl');
+  if (process.env.OPENCHROME_CRAWL_CACHE_DIR) return process.env.OPENCHROME_CRAWL_CACHE_DIR;
+  if (process.env.OPENCHROME_HOME) return path.join(process.env.OPENCHROME_HOME, 'cache', 'crawl');
+  return path.join(os.homedir(), '.openchrome', 'cache', 'crawl');
 }
 
 function publicWriteSkipReason(page: { url: string; title: string; content: string }, scope: CrawlCacheScope): string | undefined {

--- a/src/core/crawl/content-cache.ts
+++ b/src/core/crawl/content-cache.ts
@@ -1,0 +1,207 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export type CrawlCacheMode = 'disabled' | 'enabled' | 'read_only' | 'write_only' | 'bypass';
+export type CrawlCacheScope = 'public' | 'session';
+export type CrawlCacheStatus = 'disabled' | 'hit' | 'miss' | 'stale' | 'write_only' | 'bypass';
+
+export interface CrawlCacheMetadata {
+  status: CrawlCacheStatus;
+  key?: string;
+  scope?: CrawlCacheScope;
+  hit?: boolean;
+  write?: 'stored' | 'skipped' | 'disabled';
+  write_skipped_reason?: string;
+  createdAt?: number;
+  content_length?: number;
+}
+
+export interface CrawlCacheKeyInput {
+  url: string;
+  finalUrl?: string;
+  outputFormat: string;
+  engine?: string;
+  cacheScope: CrawlCacheScope;
+  sessionFingerprint?: string;
+  dimensions?: Record<string, unknown>;
+}
+
+export interface CrawlCacheEntry<TPage extends { url: string; title: string; content: string }> {
+  schema_version: 1;
+  createdAt: number;
+  sourceUrl: string;
+  finalUrl: string;
+  contentLength: number;
+  key: string;
+  page: TPage;
+  links: string[];
+}
+
+export interface CrawlContentCacheOptions {
+  rootDir?: string;
+  now?: () => number;
+  maxEntries?: number;
+}
+
+const SCHEMA_VERSION = 1;
+const DEFAULT_MAX_ENTRIES = 500;
+const SENSITIVE_PATH = /\b(account|dashboard|billing|admin|settings|checkout|cart|profile|login|signin|sign-in)\b/i;
+const SENSITIVE_CONTENT = /<input\b[^>]*(type=["']?password|name=["']?(password|token|secret|credential))|\b(password|token|secret|api[_-]?key)\s*[:=]/i;
+
+export class CrawlContentCache<TPage extends { url: string; title: string; content: string }> {
+  private readonly rootDir: string;
+  private readonly now: () => number;
+  private readonly maxEntries: number;
+
+  constructor(options: CrawlContentCacheOptions = {}) {
+    this.rootDir = options.rootDir ?? defaultCrawlCacheRootDir();
+    this.now = options.now ?? Date.now;
+    this.maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  }
+
+  key(input: CrawlCacheKeyInput): string {
+    const normalized = {
+      schema_version: SCHEMA_VERSION,
+      url: normalizeUrlForKey(input.finalUrl ?? input.url),
+      outputFormat: input.outputFormat,
+      engine: input.engine ?? 'default',
+      cacheScope: input.cacheScope,
+      sessionFingerprint: input.cacheScope === 'session' ? hashText(input.sessionFingerprint ?? 'default') : undefined,
+      dimensions: sortKeys(input.dimensions ?? {}),
+    };
+    return crypto.createHash('sha256').update(JSON.stringify(normalized)).digest('hex');
+  }
+
+  read(key: string, ttlMs?: number): { entry: CrawlCacheEntry<TPage>; stale: boolean } | null {
+    try {
+      const raw = fs.readFileSync(this.filePath(key), 'utf8');
+      const entry = JSON.parse(raw) as CrawlCacheEntry<TPage>;
+      if (!entry || entry.schema_version !== SCHEMA_VERSION || entry.key !== key) return null;
+      const stale = typeof ttlMs === 'number' && ttlMs >= 0 && this.now() - entry.createdAt > ttlMs;
+      return { entry, stale };
+    } catch {
+      return null;
+    }
+  }
+
+  write(input: {
+    key: string;
+    sourceUrl: string;
+    finalUrl?: string;
+    page: TPage;
+    links?: string[];
+    cacheScope: CrawlCacheScope;
+  }): { stored: boolean; reason?: string; entry?: CrawlCacheEntry<TPage> } {
+    const reason = publicWriteSkipReason(input.page, input.cacheScope);
+    if (reason) return { stored: false, reason };
+
+    const entry: CrawlCacheEntry<TPage> = {
+      schema_version: SCHEMA_VERSION,
+      createdAt: this.now(),
+      sourceUrl: input.sourceUrl,
+      finalUrl: input.finalUrl ?? input.page.url,
+      contentLength: input.page.content.length,
+      key: input.key,
+      page: input.page,
+      links: input.links ?? [],
+    };
+    try {
+      fs.mkdirSync(this.rootDir, { recursive: true });
+      const file = this.filePath(input.key);
+      const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+      fs.writeFileSync(tmp, JSON.stringify(entry, null, 2));
+      fs.renameSync(tmp, file);
+      this.prune();
+      return { stored: true, entry };
+    } catch (err) {
+      return { stored: false, reason: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  metadata(status: CrawlCacheStatus, input: Partial<CrawlCacheMetadata> = {}): CrawlCacheMetadata {
+    return { status, ...input };
+  }
+
+  private filePath(key: string): string {
+    return path.join(this.rootDir, `${key}.json`);
+  }
+
+  private prune(): void {
+    try {
+      const entries = fs.readdirSync(this.rootDir)
+        .filter((file) => file.endsWith('.json'))
+        .map((file) => ({ file: path.join(this.rootDir, file), mtimeMs: fs.statSync(path.join(this.rootDir, file)).mtimeMs }))
+        .sort((a, b) => b.mtimeMs - a.mtimeMs);
+      for (const entry of entries.slice(this.maxEntries)) {
+        try { fs.unlinkSync(entry.file); } catch { /* best-effort cleanup */ }
+      }
+    } catch {
+      // Best-effort pruning only.
+    }
+  }
+}
+
+export function parseCrawlCacheMode(value: unknown): CrawlCacheMode {
+  if (value === undefined || value === null || value === '') return 'disabled';
+  if (value === 'disabled' || value === 'enabled' || value === 'read_only' || value === 'write_only' || value === 'bypass') return value;
+  throw new Error('cache_mode must be one of disabled, enabled, read_only, write_only, bypass');
+}
+
+export function parseCrawlCacheScope(value: unknown): CrawlCacheScope {
+  if (value === undefined || value === null || value === '') return 'public';
+  if (value === 'public' || value === 'session') return value;
+  throw new Error('cache_scope must be one of public, session');
+}
+
+export function canReadCache(mode: CrawlCacheMode): boolean {
+  return mode === 'enabled' || mode === 'read_only';
+}
+
+export function canWriteCache(mode: CrawlCacheMode): boolean {
+  return mode === 'enabled' || mode === 'write_only' || mode === 'bypass';
+}
+
+export function defaultCrawlCacheRootDir(): string {
+  return process.env.OPENCHROME_CRAWL_CACHE_DIR || path.join(process.env.OPENCHROME_HOME || os.homedir(), '.openchrome', 'cache', 'crawl');
+}
+
+function publicWriteSkipReason(page: { url: string; title: string; content: string }, scope: CrawlCacheScope): string | undefined {
+  if (scope !== 'public') return undefined;
+  try {
+    const parsed = new URL(page.url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return 'non-http-url';
+    if (SENSITIVE_PATH.test(parsed.pathname) || SENSITIVE_PATH.test(page.title)) return 'auth-sensitive-url-or-title';
+  } catch {
+    return 'invalid-url';
+  }
+  if (SENSITIVE_CONTENT.test(page.content)) return 'auth-sensitive-content';
+  return undefined;
+}
+
+function normalizeUrlForKey(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.hash = '';
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+function hashText(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      out[key] = sortKeys((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}

--- a/src/core/crawl/job-store.ts
+++ b/src/core/crawl/job-store.ts
@@ -28,6 +28,7 @@ import * as path from 'node:path';
 import { acquireLock } from '../../utils/atomic-file';
 import { normalizeUrl } from '../../utils/crawl-utils';
 import { redactValue } from '../trace/redactor';
+import type { CrawlCacheMetadata, CrawlCacheMode, CrawlCacheScope } from './content-cache';
 
 /** A page recorded in the job log (mirrors the legacy `crawl` tool shape). */
 export interface CrawledPage {
@@ -43,6 +44,7 @@ export interface CrawledPage {
    * on-disk growth of a single job to a predictable size.
    */
   truncated?: boolean;
+  cache?: CrawlCacheMetadata;
 }
 
 /** Public crawl configuration (mirrors legacy `crawl` tool args). */
@@ -59,6 +61,9 @@ export interface JobConfig {
   respect_robots: boolean;
   delay_ms: number;
   concurrency: number;
+  cache_mode?: CrawlCacheMode;
+  cache_ttl_ms?: number;
+  cache_scope?: CrawlCacheScope;
 }
 
 export type JobStatus =

--- a/src/core/crawl/runner.ts
+++ b/src/core/crawl/runner.ts
@@ -44,6 +44,7 @@ import {
   type QueueEntry,
 } from './job-store';
 import { redactValue } from '../trace/redactor';
+import { canReadCache, canWriteCache, CrawlContentCache } from './content-cache';
 
 /** Default `advance` value when callers omit it. */
 export function defaultAdvance(): number {
@@ -239,6 +240,10 @@ export async function advanceJob(
   const includeLinks = state.config.includeLinks;
   const delayMs = state.config.delay_ms;
   const respectRobots = state.config.respect_robots;
+  const cacheMode = state.config.cache_mode ?? 'disabled';
+  const cacheScope = state.config.cache_scope ?? 'public';
+  const cacheTtlMs = state.config.cache_ttl_ms;
+  const crawlCache = new CrawlContentCache<FetchOnePageResult>();
   const robotsCache = new Map<string, RobotsRules | null>();
 
   let fetched = 0;
@@ -305,8 +310,30 @@ export async function advanceJob(
         }
       }
 
+      const cacheKey = crawlCache.key({
+        url: fetchUrl,
+        outputFormat,
+        engine: 'crawl_job',
+        cacheScope,
+        sessionFingerprint: sessionId,
+        dimensions: { onlyMainContent, includeLinks, scope, includePatterns, excludePatterns },
+      });
+
       let result: FetchOnePageResult;
-      try {
+      const cached = canReadCache(cacheMode) ? crawlCache.read(cacheKey, cacheTtlMs) : null;
+      if (cached && !cached.stale) {
+        result = {
+          ...cached.entry.page,
+          depth: next.depth,
+          cache: crawlCache.metadata('hit', {
+            key: cacheKey,
+            scope: cacheScope,
+            hit: true,
+            createdAt: cached.entry.createdAt,
+            content_length: cached.entry.contentLength,
+          }),
+        };
+      } else try {
         result = await fetcher(
           sessionId,
           fetchUrl,
@@ -341,6 +368,23 @@ export async function advanceJob(
       }
 
       const links = result._links ?? [];
+      if (cacheMode !== 'disabled' && !(cached && !cached.stale)) {
+        const cacheStatus = cacheMode === 'write_only' ? 'write_only' : cacheMode === 'bypass' ? 'bypass' : 'miss';
+        let cacheMeta = crawlCache.metadata(cacheStatus, { key: cacheKey, scope: cacheScope, hit: false, write: 'disabled' });
+        if (canWriteCache(cacheMode) && !result.error) {
+          const written = crawlCache.write({ key: cacheKey, sourceUrl: fetchUrl, finalUrl: result.url, page: result, links, cacheScope });
+          cacheMeta = crawlCache.metadata(cacheStatus, {
+            key: cacheKey,
+            scope: cacheScope,
+            hit: false,
+            write: written.stored ? 'stored' : 'skipped',
+            write_skipped_reason: written.reason,
+            createdAt: written.entry?.createdAt,
+            content_length: result.content.length,
+          });
+        }
+        result.cache = cacheMeta;
+      }
       // Redact url/title/content before they hit disk: page bodies routinely
       // contain Bearer tokens, JWTs, AWS keys, etc. The redactor also runs at
       // the job-store boundary (defence-in-depth), but doing it here keeps
@@ -358,6 +402,7 @@ export async function advanceJob(
         links_found: result.links_found,
         ...(truncated ? { truncated: true } : {}),
         ...(result.error !== undefined ? { error: scrubString(result.error) } : {}),
+        ...(result.cache ? { cache: result.cache } : {}),
       };
       appendEventUnlocked(jobId, {
         kind: 'fetched',

--- a/src/tools/crawl-sitemap.ts
+++ b/src/tools/crawl-sitemap.ts
@@ -30,6 +30,16 @@ import {
 import { extractMainContent, toMarkdown } from '../core/extract/html-to-markdown';
 import { sanitizeContent } from '../security/content-sanitizer';
 import { getGlobalConfig } from '../config/global';
+import {
+  canReadCache,
+  canWriteCache,
+  CrawlCacheMetadata,
+  CrawlCacheMode,
+  CrawlCacheScope,
+  CrawlContentCache,
+  parseCrawlCacheMode,
+  parseCrawlCacheScope,
+} from '../core/crawl/content-cache';
 
 const definition: MCPToolDefinition = {
   name: 'crawl_sitemap',
@@ -77,6 +87,20 @@ const definition: MCPToolDefinition = {
         description:
           'Fetch engine: "cdp" (default, opens a Chrome tab per page), "static" (Node fetch only, fails closed on insufficient pages), or "auto" (static first, fall back to CDP when static is insufficient).',
       },
+      cache_mode: {
+        type: 'string',
+        enum: ['disabled', 'enabled', 'read_only', 'write_only', 'bypass'],
+        description: 'Opt-in crawl content cache mode. Default: disabled.',
+      },
+      cache_ttl_ms: {
+        type: 'number',
+        description: 'Maximum age for enabled/read_only cache hits. Omit for no TTL expiry.',
+      },
+      cache_scope: {
+        type: 'string',
+        enum: ['public', 'session'],
+        description: 'Cache namespace/safety scope. Default: public.',
+      },
     },
     required: ['url'],
   },
@@ -120,6 +144,7 @@ interface CrawledPage {
   error?: string;
   engine_used?: 'static' | 'cdp';
   static_reason?: StaticReason;
+  cache?: CrawlCacheMetadata;
 }
 
 type EngineMode = 'auto' | 'static' | 'cdp';
@@ -575,6 +600,18 @@ const handler: ToolHandler = async (
   const filterPattern = args.filter as string | undefined;
   const maxPages = args.max_pages != null ? Number(args.max_pages) : 50;
   const outputFormat = (args.output_format as string) || 'markdown';
+  let cacheMode: CrawlCacheMode;
+  let cacheScope: CrawlCacheScope;
+  try {
+    cacheMode = parseCrawlCacheMode(args.cache_mode);
+    cacheScope = parseCrawlCacheScope(args.cache_scope);
+  } catch (err) {
+    return {
+      content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+      isError: true,
+    };
+  }
+  const cacheTtlMs = typeof args.cache_ttl_ms === 'number' ? args.cache_ttl_ms : undefined;
   const cleanOpts = {
     onlyMainContent: args.onlyMainContent !== false,
     includeLinks: args.includeLinks !== false,
@@ -595,6 +632,7 @@ const handler: ToolHandler = async (
 
   const startTime = Date.now();
   const tracker = new CrawlTracker();
+  const crawlCache = new CrawlContentCache<CrawledPage>();
   const pages: CrawledPage[] = [];
   let sitemapSource = '';
 
@@ -708,6 +746,34 @@ const handler: ToolHandler = async (
             if (tracker.hasVisited(pageUrl)) {
               return null;
             }
+            const cacheKey = crawlCache.key({
+              url: pageUrl,
+              outputFormat,
+              engine,
+              cacheScope,
+              sessionFingerprint: sessionId,
+              dimensions: {
+                filter: filterPattern,
+                onlyMainContent: cleanOpts.onlyMainContent,
+                includeLinks: cleanOpts.includeLinks,
+              },
+            });
+            if (canReadCache(cacheMode)) {
+              const cached = crawlCache.read(cacheKey, cacheTtlMs);
+              if (cached && !cached.stale) {
+                tracker.visit(pageUrl);
+                return {
+                  ...cached.entry.page,
+                  cache: crawlCache.metadata('hit', {
+                    key: cacheKey,
+                    scope: cacheScope,
+                    hit: true,
+                    createdAt: cached.entry.createdAt,
+                    content_length: cached.entry.contentLength,
+                  }),
+                };
+              }
+            }
             tracker.visit(pageUrl);
 
             let page: CrawledPage;
@@ -744,6 +810,39 @@ const handler: ToolHandler = async (
             }
             if (staticReason) {
               page.static_reason = staticReason;
+            }
+            if (cacheMode !== 'disabled') {
+              const cacheStatus = cacheMode === 'write_only'
+                ? 'write_only'
+                : cacheMode === 'bypass'
+                  ? 'bypass'
+                  : 'miss';
+              let cacheMeta = crawlCache.metadata(cacheStatus, {
+                key: cacheKey,
+                scope: cacheScope,
+                hit: false,
+                write: 'disabled',
+              });
+              if (canWriteCache(cacheMode) && !page.error) {
+                const written = crawlCache.write({
+                  key: cacheKey,
+                  sourceUrl: pageUrl,
+                  finalUrl: page.url,
+                  page,
+                  links: [],
+                  cacheScope,
+                });
+                cacheMeta = crawlCache.metadata(cacheStatus, {
+                  key: cacheKey,
+                  scope: cacheScope,
+                  hit: false,
+                  write: written.stored ? 'stored' : 'skipped',
+                  write_skipped_reason: written.reason,
+                  createdAt: written.entry?.createdAt,
+                  content_length: page.content.length,
+                });
+              }
+              page.cache = cacheMeta;
             }
 
             return page;

--- a/src/tools/crawl-start.ts
+++ b/src/tools/crawl-start.ts
@@ -9,6 +9,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { createJob, type JobConfig } from '../core/crawl/job-store';
+import { parseCrawlCacheMode, parseCrawlCacheScope } from '../core/crawl/content-cache';
 import { emitCrawlTrace } from '../core/crawl/trace-emit';
 
 const definition: MCPToolDefinition = {
@@ -34,6 +35,9 @@ const definition: MCPToolDefinition = {
       respect_robots: { type: 'boolean', description: 'Whether to obey robots.txt. Default: true' },
       delay_ms: { type: 'number', description: 'Delay between page fetches (ms). Default: 1000' },
       concurrency: { type: 'number', description: 'Max parallel fetches. Default: 3' },
+      cache_mode: { type: 'string', enum: ['disabled', 'enabled', 'read_only', 'write_only', 'bypass'], description: 'Opt-in crawl content cache mode. Default: disabled.' },
+      cache_ttl_ms: { type: 'number', description: 'Maximum age for enabled/read_only cache hits. Omit for no TTL expiry.' },
+      cache_scope: { type: 'string', enum: ['public', 'session'], description: 'Cache namespace/safety scope. Default: public.' },
     },
     required: ['url'],
   },
@@ -71,6 +75,15 @@ const handler: ToolHandler = async (
     ? Math.max(0, Math.floor(rawMaxDepth))
     : 2;
 
+  let cacheMode;
+  let cacheScope;
+  try {
+    cacheMode = parseCrawlCacheMode(args.cache_mode);
+    cacheScope = parseCrawlCacheScope(args.cache_scope);
+  } catch (err) {
+    return errorResult(err instanceof Error ? err.message : String(err));
+  }
+
   const config: JobConfig = {
     url,
     max_depth: clampedMaxDepth,
@@ -87,6 +100,9 @@ const handler: ToolHandler = async (
       args.concurrency != null
         ? Math.max(1, Math.min(10, Number(args.concurrency)))
         : 3,
+    cache_mode: cacheMode,
+    cache_ttl_ms: typeof args.cache_ttl_ms === 'number' ? args.cache_ttl_ms : undefined,
+    cache_scope: cacheScope,
   };
 
   let jobId: string;

--- a/src/tools/crawl.ts
+++ b/src/tools/crawl.ts
@@ -858,7 +858,9 @@ const handler: ToolHandler = async (
               },
             });
 
-            if (canReadCache(cacheMode)) {
+            // Check robots.txt before fetching or serving cached content.
+            const allowed = await isRobotsAllowed(item.url);
+            if (allowed && canReadCache(cacheMode)) {
               const cached = crawlCache.read(cacheKey, cacheTtlMs);
               if (cached && !cached.stale) {
                 tracker.visit(item.url);
@@ -880,8 +882,6 @@ const handler: ToolHandler = async (
               }
             }
 
-            // Check robots.txt before fetching
-            const allowed = await isRobotsAllowed(item.url);
             if (!allowed) {
               console.error(`[crawl] Blocked by robots.txt: ${item.url}`);
               return {

--- a/src/tools/crawl.ts
+++ b/src/tools/crawl.ts
@@ -34,6 +34,14 @@ import { extractMainContent, toMarkdown } from '../core/extract/html-to-markdown
 import { sanitizeContent } from '../security/content-sanitizer';
 import { getGlobalConfig } from '../config/global';
 import { AdaptiveCrawlDispatcher, DispatcherMode, parseAdaptiveDispatcherOptions } from '../core/crawl/dispatcher';
+import {
+  canReadCache,
+  canWriteCache,
+  CrawlContentCache,
+  CrawlCacheMetadata,
+  parseCrawlCacheMode,
+  parseCrawlCacheScope,
+} from '../core/crawl/content-cache';
 
 const definition: MCPToolDefinition = {
   name: 'crawl',
@@ -128,6 +136,20 @@ const definition: MCPToolDefinition = {
         type: 'object',
         description: 'dispatcher=adaptive options: min_concurrency, max_concurrency, memory_pressure_mb, origin_backoff_ms, rate_limit_statuses.',
       },
+      cache_mode: {
+        type: 'string',
+        enum: ['disabled', 'enabled', 'read_only', 'write_only', 'bypass'],
+        description: 'Opt-in crawl content cache mode. Default: disabled.',
+      },
+      cache_ttl_ms: {
+        type: 'number',
+        description: 'Maximum age for enabled/read_only cache hits. Negative or omitted means no TTL expiry.',
+      },
+      cache_scope: {
+        type: 'string',
+        enum: ['public', 'session'],
+        description: 'Cache namespace/safety scope. Default: public; session adds a session fingerprint to the key.',
+      },
     },
     required: ['url'],
   },
@@ -174,6 +196,7 @@ interface CrawledPage {
   static_reason?: StaticReason;
   score?: number;
   score_reasons?: string[];
+  cache?: CrawlCacheMetadata;
 }
 
 type EngineMode = 'auto' | 'static' | 'cdp';
@@ -185,6 +208,7 @@ interface CrawlQueueItem {
   order: number;
   score?: number;
   score_reasons?: string[];
+  cache?: CrawlCacheMetadata;
 }
 
 interface CrawlSummary {
@@ -606,6 +630,18 @@ const handler: ToolHandler = async (
   const includePatterns = args.include_patterns as string[] | undefined;
   const excludePatterns = args.exclude_patterns as string[] | undefined;
   const outputFormat = (args.output_format as string) || 'markdown';
+  let cacheMode;
+  let cacheScope;
+  try {
+    cacheMode = parseCrawlCacheMode(args.cache_mode);
+    cacheScope = parseCrawlCacheScope(args.cache_scope);
+  } catch (err) {
+    return {
+      content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+      isError: true,
+    };
+  }
+  const cacheTtlMs = typeof args.cache_ttl_ms === 'number' ? args.cache_ttl_ms : undefined;
   const cleanOpts = {
     onlyMainContent: args.onlyMainContent !== false,
     includeLinks: args.includeLinks !== false,
@@ -711,6 +747,7 @@ const handler: ToolHandler = async (
   const adaptiveDispatcher = dispatcherMode === 'adaptive'
     ? new AdaptiveCrawlDispatcher(concurrency, parseAdaptiveDispatcherOptions(args.dispatcher_options, concurrency))
     : null;
+  const crawlCache = new CrawlContentCache<CrawledPage & { _links?: string[] }>();
 
   const startTime = Date.now();
   const tracker = new CrawlTracker();
@@ -807,6 +844,42 @@ const handler: ToolHandler = async (
         batch.map((item) =>
           limiter(async () => {
             const runFetch = async () => {
+            const cacheKey = crawlCache.key({
+              url: item.url,
+              outputFormat,
+              engine,
+              cacheScope,
+              sessionFingerprint: sessionId,
+              dimensions: {
+                onlyMainContent: cleanOpts.onlyMainContent,
+                includeLinks: cleanOpts.includeLinks,
+                query: args.query,
+                url_score: args.url_score,
+              },
+            });
+
+            if (canReadCache(cacheMode)) {
+              const cached = crawlCache.read(cacheKey, cacheTtlMs);
+              if (cached && !cached.stale) {
+                tracker.visit(item.url);
+                return {
+                  page: {
+                    ...cached.entry.page,
+                    depth: item.depth,
+                    cache: crawlCache.metadata('hit', {
+                      key: cacheKey,
+                      scope: cacheScope,
+                      hit: true,
+                      createdAt: cached.entry.createdAt,
+                      content_length: cached.entry.contentLength,
+                    }),
+                  },
+                  links: cached.entry.links,
+                  depth: item.depth,
+                };
+              }
+            }
+
             // Check robots.txt before fetching
             const allowed = await isRobotsAllowed(item.url);
             if (!allowed) {
@@ -893,6 +966,40 @@ const handler: ToolHandler = async (
             if (strategy === 'best_first') {
               result.score = item.score ?? 0;
               result.score_reasons = item.score_reasons ?? [];
+            }
+
+            if (cacheMode !== 'disabled') {
+              const cacheStatus = cacheMode === 'write_only'
+                ? 'write_only'
+                : cacheMode === 'bypass'
+                  ? 'bypass'
+                  : 'miss';
+              let cacheMeta = crawlCache.metadata(cacheStatus, {
+                key: cacheKey,
+                scope: cacheScope,
+                hit: false,
+                write: 'disabled',
+              });
+              if (canWriteCache(cacheMode) && !result.error) {
+                const written = crawlCache.write({
+                  key: cacheKey,
+                  sourceUrl: item.url,
+                  finalUrl: result.url,
+                  page: { ...result, _links: links },
+                  links,
+                  cacheScope,
+                });
+                cacheMeta = crawlCache.metadata(cacheStatus, {
+                  key: cacheKey,
+                  scope: cacheScope,
+                  hit: false,
+                  write: written.stored ? 'stored' : 'skipped',
+                  write_skipped_reason: written.reason,
+                  createdAt: written.entry?.createdAt,
+                  content_length: result.content.length,
+                });
+              }
+              result.cache = cacheMeta;
             }
 
             // Apply delay between fetches

--- a/tests/core/crawl/tools.test.ts
+++ b/tests/core/crawl/tools.test.ts
@@ -382,6 +382,6 @@ describe('crawl cache root resolution', () => {
     delete process.env.OPENCHROME_CRAWL_CACHE_DIR;
     const { defaultCrawlCacheRootDir } = await import('../../../src/core/crawl/content-cache');
 
-    expect(defaultCrawlCacheRootDir()).toBe('/tmp/openchrome-home-test/cache/crawl');
+    expect(defaultCrawlCacheRootDir()).toBe(path.join('/tmp/openchrome-home-test', 'cache', 'crawl'));
   });
 });

--- a/tests/core/crawl/tools.test.ts
+++ b/tests/core/crawl/tools.test.ts
@@ -366,3 +366,22 @@ describe('legacy crawl snapshot — runner CrawledPage shape', () => {
     }
   });
 });
+
+
+describe('crawl cache root resolution', () => {
+  const OLD_ENV = process.env;
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    jest.resetModules();
+  });
+
+  test('uses OPENCHROME_HOME as the OpenChrome root, not the user home', async () => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV, OPENCHROME_HOME: '/tmp/openchrome-home-test' };
+    delete process.env.OPENCHROME_CRAWL_CACHE_DIR;
+    const { defaultCrawlCacheRootDir } = await import('../../../src/core/crawl/content-cache');
+
+    expect(defaultCrawlCacheRootDir()).toBe('/tmp/openchrome-home-test/cache/crawl');
+  });
+});

--- a/tests/core/tools/crawl.engine.test.ts
+++ b/tests/core/tools/crawl.engine.test.ts
@@ -423,3 +423,180 @@ describe('crawl_sitemap engine=static', () => {
     expect(mockSessionManager.createTarget).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// crawl content cache modes (#987)
+// ---------------------------------------------------------------------------
+
+describe('crawl cache modes', () => {
+  let cacheDir: string;
+
+  beforeEach(() => {
+    cacheDir = require('fs').mkdtempSync(require('path').join(require('os').tmpdir(), 'openchrome-crawl-cache-'));
+    process.env.OPENCHROME_CRAWL_CACHE_DIR = cacheDir;
+    server.setRoute('/cache.html', {
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+      body: RICH_HTML('Cacheable', `<h1>Cacheable</h1><p>${PARA}</p>`),
+    });
+    server.setRoute('/account.html', {
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+      body: RICH_HTML('Account Settings', '<form><input type="password" name="password" /></form>' + PARA),
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.OPENCHROME_CRAWL_CACHE_DIR;
+    require('fs').rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  test('default cache_mode disabled preserves output shape and does not write files', async () => {
+    const handler = await loadHandler('crawl');
+    const result = await handler('cache-default', {
+      url: `${server.origin}/cache.html`,
+      max_pages: 1,
+      max_depth: 0,
+      delay_ms: 0,
+      engine: 'static',
+      respect_robots: false,
+    });
+    const parsed = parseResult(result);
+    expect(parsed.pages[0].cache).toBeUndefined();
+    expect(require('fs').readdirSync(cacheDir)).toEqual([]);
+  });
+
+  test('enabled mode stores then serves a hit without fetching the page again', async () => {
+    const handler = await loadHandler('crawl');
+    const before = server.hitCount('/cache.html');
+    const first = parseResult(await handler('cache-enabled', {
+      url: `${server.origin}/cache.html`,
+      max_pages: 1,
+      max_depth: 0,
+      delay_ms: 0,
+      engine: 'static',
+      respect_robots: false,
+      cache_mode: 'enabled',
+      cache_ttl_ms: 60_000,
+    }));
+    expect(first.pages[0].cache).toMatchObject({ status: 'miss', write: 'stored', hit: false });
+    expect(server.hitCount('/cache.html')).toBe(before + 1);
+
+    const second = parseResult(await handler('cache-enabled', {
+      url: `${server.origin}/cache.html`,
+      max_pages: 1,
+      max_depth: 0,
+      delay_ms: 0,
+      engine: 'static',
+      respect_robots: false,
+      cache_mode: 'enabled',
+      cache_ttl_ms: 60_000,
+    }));
+    expect(second.pages[0].cache).toMatchObject({ status: 'hit', hit: true });
+    expect(server.hitCount('/cache.html')).toBe(before + 1);
+  });
+
+  test('read_only does not create entries on miss and write_only never serves hits', async () => {
+    const handler = await loadHandler('crawl');
+    const before = server.hitCount('/cache.html');
+    const readOnly = parseResult(await handler('cache-read-only', {
+      url: `${server.origin}/cache.html`,
+      max_pages: 1,
+      max_depth: 0,
+      delay_ms: 0,
+      engine: 'static',
+      respect_robots: false,
+      cache_mode: 'read_only',
+    }));
+    expect(readOnly.pages[0].cache).toMatchObject({ status: 'miss', write: 'disabled' });
+    expect(require('fs').readdirSync(cacheDir)).toEqual([]);
+
+    const writeOnlyA = parseResult(await handler('cache-write-only', {
+      url: `${server.origin}/cache.html`,
+      max_pages: 1,
+      max_depth: 0,
+      delay_ms: 0,
+      engine: 'static',
+      respect_robots: false,
+      cache_mode: 'write_only',
+    }));
+    const writeOnlyB = parseResult(await handler('cache-write-only', {
+      url: `${server.origin}/cache.html`,
+      max_pages: 1,
+      max_depth: 0,
+      delay_ms: 0,
+      engine: 'static',
+      respect_robots: false,
+      cache_mode: 'write_only',
+    }));
+    expect(writeOnlyA.pages[0].cache).toMatchObject({ status: 'write_only', write: 'stored' });
+    expect(writeOnlyB.pages[0].cache).toMatchObject({ status: 'write_only', write: 'stored' });
+    expect(server.hitCount('/cache.html')).toBe(before + 3);
+  });
+
+  test('bypass overwrites and public scope skips auth-sensitive pages', async () => {
+    const handler = await loadHandler('crawl');
+    const bypass = parseResult(await handler('cache-bypass', {
+      url: `${server.origin}/cache.html`,
+      max_pages: 1,
+      max_depth: 0,
+      delay_ms: 0,
+      engine: 'static',
+      respect_robots: false,
+      cache_mode: 'bypass',
+    }));
+    expect(bypass.pages[0].cache).toMatchObject({ status: 'bypass', write: 'stored' });
+
+    const sensitive = parseResult(await handler('cache-sensitive', {
+      url: `${server.origin}/account.html`,
+      max_pages: 1,
+      max_depth: 0,
+      delay_ms: 0,
+      engine: 'static',
+      respect_robots: false,
+      cache_mode: 'enabled',
+    }));
+    expect(sensitive.pages[0].cache).toMatchObject({ status: 'miss', write: 'skipped' });
+    expect(String((sensitive.pages[0].cache as Record<string, unknown>).write_skipped_reason)).toMatch(/auth-sensitive/);
+  });
+});
+
+describe('crawl_sitemap cache_mode=enabled', () => {
+  let cacheDir: string;
+
+  beforeEach(() => {
+    cacheDir = require('fs').mkdtempSync(require('path').join(require('os').tmpdir(), 'openchrome-sitemap-cache-'));
+    process.env.OPENCHROME_CRAWL_CACHE_DIR = cacheDir;
+  });
+
+  afterEach(() => {
+    delete process.env.OPENCHROME_CRAWL_CACHE_DIR;
+    require('fs').rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  test('stores sitemap page content and serves later page hits from cache', async () => {
+    const handler = await loadHandler('crawl_sitemap');
+    const before = server.hitCount('/page-a.html');
+    const first = parseResult(await handler('sitemap-cache', {
+      url: server.origin,
+      max_pages: 1,
+      concurrency: 1,
+      engine: 'static',
+      cache_mode: 'enabled',
+      cache_ttl_ms: 60_000,
+    }));
+    expect(first.pages[0].cache).toMatchObject({ status: 'miss', write: 'stored' });
+    expect(server.hitCount('/page-a.html')).toBe(before + 1);
+
+    const second = parseResult(await handler('sitemap-cache', {
+      url: server.origin,
+      max_pages: 1,
+      concurrency: 1,
+      engine: 'static',
+      cache_mode: 'enabled',
+      cache_ttl_ms: 60_000,
+    }));
+    expect(second.pages[0].cache).toMatchObject({ status: 'hit', hit: true });
+    expect(server.hitCount('/page-a.html')).toBe(before + 1);
+  });
+});

--- a/tests/core/tools/crawl.engine.test.ts
+++ b/tests/core/tools/crawl.engine.test.ts
@@ -496,6 +496,45 @@ describe('crawl cache modes', () => {
     expect(server.hitCount('/cache.html')).toBe(before + 1);
   });
 
+
+  test('enabled cache still enforces robots.txt before serving a hit', async () => {
+    const handler = await loadHandler('crawl');
+    server.setRoute('/robots.txt', {
+      status: 200,
+      contentType: 'text/plain',
+      body: 'User-agent: *\nDisallow:\n',
+    });
+    parseResult(await handler('cache-robots', {
+      url: `${server.origin}/cache.html`,
+      max_pages: 1,
+      max_depth: 0,
+      delay_ms: 0,
+      engine: 'static',
+      respect_robots: true,
+      cache_mode: 'enabled',
+      cache_ttl_ms: 60_000,
+    }));
+
+    server.setRoute('/robots.txt', {
+      status: 200,
+      contentType: 'text/plain',
+      body: 'User-agent: *\nDisallow: /cache.html\n',
+    });
+    const blocked = parseResult(await handler('cache-robots', {
+      url: `${server.origin}/cache.html`,
+      max_pages: 1,
+      max_depth: 0,
+      delay_ms: 0,
+      engine: 'static',
+      respect_robots: true,
+      cache_mode: 'enabled',
+      cache_ttl_ms: 60_000,
+    }));
+
+    expect(blocked.pages[0]).toMatchObject({ error: 'Blocked by robots.txt' });
+    expect(blocked.pages[0].cache).toBeUndefined();
+  });
+
   test('read_only does not create entries on miss and write_only never serves hits', async () => {
     const handler = await loadHandler('crawl');
     const before = server.hitCount('/cache.html');


### PR DESCRIPTION
## Summary
- add default-off crawl content cache modes (`enabled`, `disabled`, `read_only`, `write_only`, `bypass`) with public/session scope keys
- wire cache metadata and safety guards into `crawl`, `crawl_sitemap`, and resumable crawl jobs
- document cache semantics, retention behavior, and auth-sensitive public write skips

## Verification
- `npm ci`
- `npm test -- tests/core/tools/crawl.engine.test.ts tests/core/crawl/tools.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint -- --quiet`
- `git diff --check`

Closes #987
