### PR TITLE
perf(actions): add page-fingerprint action cache v2

### DIFF
--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -8,6 +8,7 @@ model composes them into prose.
 
 | Recipe | Goal | Tools touched |
 |---|---|---|
+| [action-cache-v2.md](action-cache-v2.md) | Interpret `act` cache status and verify page-fingerprint drift behavior. | `act` |
 | [multi-source-news-digest.md](multi-source-news-digest.md) | Pull headlines from several news sources and produce a one-screen daily digest. | `navigate`, `read_page`, `crawl` |
 | [docs-changelog-diff.md](docs-changelog-diff.md) | Compare two snapshots of a docs page (e.g. before/after a release) and explain what changed. | `navigate`, `read_page` |
 | [competitive-feature-matrix.md](competitive-feature-matrix.md) | Build a structured feature-matrix table across several vendor pages. | `navigate`, `extract_data`, `read_page` |

--- a/docs/recipes/action-cache-v2.md
+++ b/docs/recipes/action-cache-v2.md
@@ -1,0 +1,36 @@
+# Action cache v2 status
+
+`act` records successful deterministic parsed action sequences with a v2 cache
+key that includes page state, action kinds, viewport, locale/user-agent class,
+and action-relevant options. This keeps repeat actions fast without replaying a
+sequence against materially different page structure.
+
+Every `act` text response includes a stable cache line:
+
+```text
+[cache] status=MISS keyVersion=2 reason=no_candidate
+```
+
+Statuses:
+
+- `MISS`: no matching v2 cache entry exists; `act` parses and executes normally.
+- `HIT`: a matching v2 key (or safe v1 migration fallback) supplied the sequence.
+- `STALE`: an entry exists for the same instruction, but the page/option
+  fingerprint changed, so the cached sequence is not replayed.
+- `BYPASS`: cache keying could not run or another explicit path (template or
+  workflow cache) handled the request.
+
+The persisted v2 entry stores bounded hashes of action-relevant page structure;
+it does not store screenshots, raw full HTML, cookies, passwords, timestamps, or
+backend node ids as key material.
+
+## Manual drift check
+
+1. Serve a fixture with a visible `Save` button and call `act` with
+   `instruction: "click Save"`.
+2. Repeat against the identical fixture and confirm the response shows
+   `status=HIT` once the cache is warm.
+3. Change the fixture so the actionable labels differ, then call the same
+   instruction again.
+4. Confirm the response shows `status=STALE` or a miss/bypass, and that the old
+   cached sequence was not blindly replayed.

--- a/src/actions/action-cache.ts
+++ b/src/actions/action-cache.ts
@@ -175,8 +175,8 @@ export function getCachedSequenceV2(
   for (const knowledge of entries) {
     const entry = parseCachedSequenceV2(knowledge.value);
     if (!entry) continue;
+    if (knowledge.confidence < MIN_CONFIDENCE) continue;
     sawCandidate = true;
-    if (Math.min(knowledge.confidence, MIN_CONFIDENCE + 0.4) < MIN_CONFIDENCE) continue;
     if (entry.keyHash === keyHash) {
       return { status: 'HIT', keyVersion: 2, reason: 'key_match', keyHash, entry, actions: entry.actions };
     }

--- a/src/actions/action-cache.ts
+++ b/src/actions/action-cache.ts
@@ -5,13 +5,54 @@
  * On repeat visits to the same domain, tries the cached sequence first.
  */
 
+import { createHash } from 'crypto';
+
 import { getDomainMemory, extractDomainFromUrl } from '../memory/domain-memory';
 import { ParsedAction } from './action-parser';
 
 const CACHE_KEY_PREFIX = 'act-sequence:';
 const WORKFLOW_CACHE_KEY_PREFIX = 'act-workflow:';
+const CACHE_V2_KEY_PREFIX = 'act-sequence-v2:';
 const MIN_CONFIDENCE = 0.6;
 const DEFAULT_SIGNATURE_THRESHOLD = 0.75;
+
+
+export type ActionCacheStatus = 'HIT' | 'MISS' | 'STALE' | 'BYPASS';
+
+export interface ActionCacheKeyV2Parts {
+  version: 2;
+  domain: string;
+  urlPattern: string;
+  normalizedInstruction: string;
+  actionKinds: string[];
+  viewport: { width: number; height: number };
+  locale?: string;
+  userAgentClass?: 'chrome' | 'chromium' | 'unknown';
+  pageFingerprint: string;
+  optionFingerprint: string;
+}
+
+export interface CachedSequenceV2 extends CachedSequence {
+  version: 2;
+  keyVersion: 2;
+  keyHash: string;
+  keyParts: ActionCacheKeyV2Parts;
+  metadata: {
+    status?: ActionCacheStatus;
+    createdAt: number;
+    lastUsedAt?: number;
+  };
+}
+
+export interface ActionCacheV2LookupDecision {
+  status: ActionCacheStatus;
+  keyVersion: 2 | 1;
+  reason: string;
+  keyHash?: string;
+  entry?: CachedSequenceV2;
+  legacy?: CachedSequence;
+  actions?: ParsedAction[];
+}
 
 export interface CachedSequence {
   instruction: string;
@@ -79,6 +120,114 @@ export interface WorkflowCacheDecision {
   safety?: WorkflowCacheEntry['safety'];
   entry?: WorkflowCacheEntry;
   actions?: ParsedAction[];
+}
+
+
+export function buildActionCacheKeyV2Parts(input: {
+  url: string;
+  instruction: string;
+  actionKinds: string[];
+  viewport: { width: number; height: number };
+  pageFingerprint: string;
+  optionFingerprint?: string;
+  locale?: string;
+  userAgent?: string;
+}): ActionCacheKeyV2Parts | null {
+  const domain = extractDomainFromUrl(input.url);
+  const urlPattern = buildUrlPattern(input.url);
+  if (!domain || !urlPattern) return null;
+
+  return {
+    version: 2,
+    domain,
+    urlPattern,
+    normalizedInstruction: normalizeForCache(input.instruction),
+    actionKinds: stableList(input.actionKinds),
+    viewport: {
+      width: Math.max(0, Math.round(input.viewport.width || 0)),
+      height: Math.max(0, Math.round(input.viewport.height || 0)),
+    },
+    ...(input.locale ? { locale: normalizeForCache(input.locale).slice(0, 24) } : {}),
+    userAgentClass: classifyUserAgent(input.userAgent),
+    pageFingerprint: boundedHash(input.pageFingerprint),
+    optionFingerprint: boundedHash(input.optionFingerprint || 'default'),
+  };
+}
+
+export function getActionCacheKeyV2Hash(parts: ActionCacheKeyV2Parts): string {
+  return boundedHash(JSON.stringify(parts));
+}
+
+export function getCachedSequenceV2(
+  url: string,
+  instruction: string,
+  keyParts: ActionCacheKeyV2Parts,
+  options: { allowLegacyFallback?: boolean } = {}
+): ActionCacheV2LookupDecision {
+  const domain = extractDomainFromUrl(url);
+  if (!domain) return { status: 'BYPASS', keyVersion: 2, reason: 'invalid_url' };
+
+  const keyHash = getActionCacheKeyV2Hash(keyParts);
+  const memory = getDomainMemory();
+  const entries = memory.query(domain, CACHE_V2_KEY_PREFIX + normalizeForCache(instruction));
+  let sawCandidate = false;
+
+  for (const knowledge of entries) {
+    const entry = parseCachedSequenceV2(knowledge.value);
+    if (!entry) continue;
+    sawCandidate = true;
+    if (Math.min(knowledge.confidence, MIN_CONFIDENCE + 0.4) < MIN_CONFIDENCE) continue;
+    if (entry.keyHash === keyHash) {
+      return { status: 'HIT', keyVersion: 2, reason: 'key_match', keyHash, entry, actions: entry.actions };
+    }
+  }
+
+  if (sawCandidate) {
+    return { status: 'STALE', keyVersion: 2, reason: 'page_or_option_fingerprint_mismatch', keyHash };
+  }
+
+  if (options.allowLegacyFallback) {
+    const legacy = getCachedSequence(url, instruction);
+    if (legacy) {
+      return { status: 'HIT', keyVersion: 1, reason: 'legacy_v1_fallback', keyHash, legacy, actions: legacy.actions };
+    }
+  }
+
+  return { status: 'MISS', keyVersion: 2, reason: 'no_candidate', keyHash };
+}
+
+export function cacheSequenceV2(url: string, instruction: string, actions: ParsedAction[], keyParts: ActionCacheKeyV2Parts): CachedSequenceV2 | null {
+  const domain = extractDomainFromUrl(url);
+  if (!domain) return null;
+
+  const keyHash = getActionCacheKeyV2Hash(keyParts);
+  const value: CachedSequenceV2 = {
+    version: 2,
+    keyVersion: 2,
+    keyHash,
+    keyParts,
+    instruction,
+    actions,
+    cachedAt: Date.now(),
+    metadata: { createdAt: Date.now() },
+  };
+
+  const memory = getDomainMemory();
+  const key = CACHE_V2_KEY_PREFIX + normalizeForCache(instruction);
+  memory.record(domain, key, JSON.stringify(value));
+  memory.validate(memory.query(domain, key)[0]?.id ?? '', true);
+  return value;
+}
+
+export function validateCachedSequenceV2(url: string, instruction: string, keyHash: string, success: boolean): void {
+  const domain = extractDomainFromUrl(url);
+  if (!domain) return;
+
+  const key = CACHE_V2_KEY_PREFIX + normalizeForCache(instruction);
+  const memory = getDomainMemory();
+  const entries = memory.query(domain, key);
+  const matched = entries.find(entry => parseCachedSequenceV2(entry.value)?.keyHash === keyHash);
+  if (matched) memory.validate(matched.id, success);
 }
 
 /**
@@ -291,6 +440,28 @@ export function validateWorkflowCachedSequence(
     cacheAction: success ? undefined : 'decrement_confidence',
     entry,
   };
+}
+
+
+function parseCachedSequenceV2(value: string): CachedSequenceV2 | null {
+  try {
+    const parsed = JSON.parse(value) as CachedSequenceV2;
+    if (parsed?.version !== 2 || parsed?.keyVersion !== 2 || !parsed.keyHash || !Array.isArray(parsed.actions)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function boundedHash(input: string): string {
+  return createHash('sha256').update(String(input).slice(0, 20_000)).digest('hex').slice(0, 24);
+}
+
+function classifyUserAgent(userAgent?: string): 'chrome' | 'chromium' | 'unknown' {
+  const ua = (userAgent || '').toLowerCase();
+  if (ua.includes('chromium')) return 'chromium';
+  if (ua.includes('chrome')) return 'chrome';
+  return 'unknown';
 }
 
 /**

--- a/src/tools/act.ts
+++ b/src/tools/act.ts
@@ -25,6 +25,12 @@ import {
   getCachedSequence,
   cacheSequence,
   validateCachedSequence,
+  ActionCacheKeyV2Parts,
+  ActionCacheV2LookupDecision,
+  buildActionCacheKeyV2Parts,
+  cacheSequenceV2,
+  getCachedSequenceV2,
+  validateCachedSequenceV2,
   buildWorkflowPageSignature,
   cacheWorkflowSequence,
   getWorkflowCachedSequence,
@@ -135,6 +141,72 @@ async function collectWorkflowPageSignature(page: any): Promise<WorkflowPageSign
   } catch {
     return null;
   }
+}
+
+
+async function collectActionCacheKeyParts(
+  page: any,
+  pageUrl: string,
+  instruction: string,
+  actions: ParsedAction[],
+  optionFingerprint: string,
+): Promise<ActionCacheKeyV2Parts | null> {
+  try {
+    const projection = await page.evaluate(() => {
+      const nodes = Array.from(document.querySelectorAll(
+        'button, a, input, select, textarea, [role], [aria-label], [placeholder]'
+      )).slice(0, 120).map((el) => {
+        const element = el as HTMLElement;
+        const input = element as HTMLInputElement;
+        const rect = element.getBoundingClientRect();
+        const tag = element.tagName.toLowerCase();
+        const type = (input.getAttribute?.('type') || '').toLowerCase();
+        const role = element.getAttribute('role') || (tag === 'a' ? 'link' : tag === 'button' ? 'button' : tag === 'input' ? 'textbox' : tag);
+        const rawName = element.getAttribute('aria-label')
+          || element.getAttribute('title')
+          || element.getAttribute('placeholder')
+          || (type === 'password' ? '' : (element.innerText || element.textContent || ''))
+          || (type === 'password' ? '' : (input.name || input.id || ''));
+        return {
+          role,
+          name: String(rawName || '').replace(/\s+/g, ' ').trim().slice(0, 80),
+          tag,
+          type,
+          disabled: Boolean((input as { disabled?: boolean }).disabled),
+          visible: rect.width > 0 && rect.height > 0,
+        };
+      }).filter(node => node.visible);
+
+      return {
+        title: document.title,
+        path: window.location.pathname,
+        locale: navigator.language,
+        userAgent: navigator.userAgent,
+        viewport: { width: window.innerWidth, height: window.innerHeight },
+        nodes,
+      };
+    });
+
+    return buildActionCacheKeyV2Parts({
+      url: pageUrl,
+      instruction,
+      actionKinds: actions.map(action => action.action),
+      viewport: projection.viewport,
+      locale: projection.locale,
+      userAgent: projection.userAgent,
+      pageFingerprint: JSON.stringify({ title: projection.title, path: projection.path, nodes: projection.nodes }),
+      optionFingerprint,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function formatActionCacheStatus(decision: ActionCacheV2LookupDecision | null): string {
+  if (!decision) return '[cache] status=BYPASS keyVersion=2 reason=unavailable';
+  const parts = [`status=${decision.status}`, `keyVersion=${decision.keyVersion}`, `reason=${decision.reason}`];
+  if (decision.keyHash) parts.push(`key=${decision.keyHash.slice(0, 12)}`);
+  return `[cache] ${parts.join(' ')}`;
 }
 
 function formatWorkflowDebug(decision: WorkflowCacheDecision): string {
@@ -541,6 +613,8 @@ const handler: ToolHandler = async (
   let parseWarning: string | undefined;
   let workflowSignature: WorkflowPageSignature | null = null;
   let workflowDecision: WorkflowCacheDecision | null = null;
+  let actionCacheKeyParts: ActionCacheKeyV2Parts | null = null;
+  let actionCacheDecision: ActionCacheV2LookupDecision | null = null;
 
   if (templateMatch) {
     actions = templateMatch.actions;
@@ -559,28 +633,35 @@ const handler: ToolHandler = async (
     if (workflowDecision?.decision === 'accepted' && workflowDecision.actions) {
       actions = workflowDecision.actions;
       source = 'workflow_cache';
+      actionCacheDecision = { status: 'BYPASS', keyVersion: 2, reason: 'workflow_cache_accepted' };
     } else {
-      // 3. Preserve existing legacy action cache behavior for compatibility.
-      const cached = getCachedSequence(pageUrl, instruction);
-      if (cached) {
-        actions = cached.actions;
+      // 3. Parse deterministically, then use parsed action kinds to build the
+      // safer page-fingerprint action cache v2 key.
+      const parseResult = parseInstruction(instruction);
+      if (!parseResult.success || parseResult.actions.length === 0) {
+        const errMsg = parseResult.error || 'Could not parse instruction';
+        const suggestion = parseResult.suggestion || 'Try individual steps like "click X", "type Y in Z".';
+        return {
+          content: [{
+            type: 'text',
+            text: `[act] Parse error: ${errMsg}
+
+Suggestion: ${suggestion}`,
+          }],
+          isError: true,
+        };
+      }
+
+      actions = parseResult.actions;
+      parseWarning = parseResult.suggestion;
+      actionCacheKeyParts = await collectActionCacheKeyParts(page, pageUrl, instruction, actions, `verify=${verifyMode}`);
+      actionCacheDecision = actionCacheKeyParts
+        ? getCachedSequenceV2(pageUrl, instruction, actionCacheKeyParts, { allowLegacyFallback: true })
+        : { status: 'BYPASS', keyVersion: 2, reason: 'fingerprint_unavailable' };
+
+      if (actionCacheDecision.actions && actionCacheDecision.status === 'HIT') {
+        actions = actionCacheDecision.actions;
         source = 'cache';
-      } else {
-        // 4. Fall back to NL parsing
-        const parseResult = parseInstruction(instruction);
-        if (!parseResult.success || parseResult.actions.length === 0) {
-          const errMsg = parseResult.error || 'Could not parse instruction';
-          const suggestion = parseResult.suggestion || 'Try individual steps like "click X", "type Y in Z".';
-          return {
-            content: [{
-              type: 'text',
-              text: `[act] Parse error: ${errMsg}\n\nSuggestion: ${suggestion}`,
-            }],
-            isError: true,
-          };
-        }
-        actions = parseResult.actions;
-        parseWarning = parseResult.suggestion;
       }
     }
   }
@@ -671,6 +752,7 @@ const handler: ToolHandler = async (
   if (success && source === 'parsed') {
     try {
       cacheSequence(page.url(), instruction, actions);
+      if (actionCacheKeyParts) cacheSequenceV2(page.url(), instruction, actions, actionCacheKeyParts);
       // Boost confidence above MIN_CONFIDENCE so the entry is retrievable immediately
       validateCachedSequence(page.url(), instruction, true);
     } catch { /* non-fatal */ }
@@ -691,7 +773,11 @@ const handler: ToolHandler = async (
   // Boost confidence on successful cache hit
   if (success && source === 'cache') {
     try {
-      validateCachedSequence(page.url(), instruction, true);
+      if (actionCacheDecision?.keyVersion === 2 && actionCacheDecision.keyHash) {
+        validateCachedSequenceV2(page.url(), instruction, actionCacheDecision.keyHash, true);
+      } else {
+        validateCachedSequence(page.url(), instruction, true);
+      }
     } catch { /* non-fatal */ }
   }
 
@@ -704,7 +790,11 @@ const handler: ToolHandler = async (
   // If cached sequence failed, reduce confidence
   if (!success && source === 'cache') {
     try {
-      validateCachedSequence(page.url(), instruction, false);
+      if (actionCacheDecision?.keyVersion === 2 && actionCacheDecision.keyHash) {
+        validateCachedSequenceV2(page.url(), instruction, actionCacheDecision.keyHash, false);
+      } else {
+        validateCachedSequence(page.url(), instruction, false);
+      }
     } catch { /* non-fatal */ }
   }
 
@@ -728,7 +818,7 @@ const handler: ToolHandler = async (
     stepLines.push(`Step ${r.step}: ${symbol} ${label}`);
   }
 
-  const lines: string[] = [headerLine, '', ...stepLines];
+  const lines: string[] = [headerLine, formatActionCacheStatus(actionCacheDecision), '', ...stepLines];
 
   // Verification — legacy text summary. Preserved verbatim so default
   // (`verify` absent or `true`) callers see the same `[Verification] …` line.

--- a/src/tools/act.ts
+++ b/src/tools/act.ts
@@ -614,6 +614,7 @@ const handler: ToolHandler = async (
   let workflowSignature: WorkflowPageSignature | null = null;
   let workflowDecision: WorkflowCacheDecision | null = null;
   let actionCacheKeyParts: ActionCacheKeyV2Parts | null = null;
+  let actionCacheUrl: string | null = null;
   let actionCacheDecision: ActionCacheV2LookupDecision | null = null;
 
   if (templateMatch) {
@@ -655,6 +656,7 @@ Suggestion: ${suggestion}`,
       actions = parseResult.actions;
       parseWarning = parseResult.suggestion;
       actionCacheKeyParts = await collectActionCacheKeyParts(page, pageUrl, instruction, actions, `verify=${verifyMode}`);
+      actionCacheUrl = actionCacheKeyParts ? pageUrl : null;
       actionCacheDecision = actionCacheKeyParts
         ? getCachedSequenceV2(pageUrl, instruction, actionCacheKeyParts, { allowLegacyFallback: true })
         : { status: 'BYPASS', keyVersion: 2, reason: 'fingerprint_unavailable' };
@@ -752,7 +754,7 @@ Suggestion: ${suggestion}`,
   if (success && source === 'parsed') {
     try {
       cacheSequence(page.url(), instruction, actions);
-      if (actionCacheKeyParts) cacheSequenceV2(page.url(), instruction, actions, actionCacheKeyParts);
+      if (actionCacheKeyParts && actionCacheUrl) cacheSequenceV2(actionCacheUrl, instruction, actions, actionCacheKeyParts);
       // Boost confidence above MIN_CONFIDENCE so the entry is retrievable immediately
       validateCachedSequence(page.url(), instruction, true);
     } catch { /* non-fatal */ }

--- a/tests/actions/action-cache.test.ts
+++ b/tests/actions/action-cache.test.ts
@@ -247,6 +247,23 @@ describe('action-cache', () => {
       expect(decision.actions).toBeUndefined();
     });
 
+    it('ignores low-confidence v2 rows when deciding stale state', () => {
+      const cache = getCache();
+      const keyParts = cache.buildActionCacheKeyV2Parts(keyInput)!;
+      const entry = cache.cacheSequenceV2(TEST_URL, TEST_INSTRUCTION, TEST_ACTIONS, keyParts)!;
+      cache.validateCachedSequenceV2(TEST_URL, TEST_INSTRUCTION, entry.keyHash, false);
+
+      const drifted = cache.buildActionCacheKeyV2Parts({
+        ...keyInput,
+        pageFingerprint: JSON.stringify({ title: 'Login', nodes: [{ role: 'button', name: 'Cancel', tag: 'button' }] }),
+      })!;
+      const decision = cache.getCachedSequenceV2(TEST_URL, TEST_INSTRUCTION, drifted);
+
+      expect(decision.status).toBe('MISS');
+      expect(decision.reason).toBe('no_candidate');
+      expect(decision.actions).toBeUndefined();
+    });
+
     it('keeps v1 entries readable as migration fallback when no v2 candidate exists', () => {
       const cache = getCache();
       cache.cacheSequence(TEST_URL, TEST_INSTRUCTION, TEST_ACTIONS);

--- a/tests/actions/action-cache.test.ts
+++ b/tests/actions/action-cache.test.ts
@@ -198,6 +198,80 @@ describe('action-cache', () => {
     });
   });
 
+
+
+  describe('action cache v2 page fingerprint keys', () => {
+    const keyInput = {
+      url: TEST_URL,
+      instruction: TEST_INSTRUCTION,
+      actionKinds: ['click'],
+      viewport: { width: 1280, height: 720 },
+      pageFingerprint: JSON.stringify({ title: 'Login', nodes: [{ role: 'button', name: 'Login', tag: 'button' }] }),
+      optionFingerprint: 'verify=both',
+      locale: 'en-US',
+      userAgent: 'Chrome/120',
+    };
+
+    it('misses before record, hits after record, and includes bounded v2 metadata', () => {
+      const cache = getCache();
+      const keyParts = cache.buildActionCacheKeyV2Parts(keyInput)!;
+
+      const miss = cache.getCachedSequenceV2(TEST_URL, TEST_INSTRUCTION, keyParts);
+      expect(miss.status).toBe('MISS');
+      expect(miss.keyVersion).toBe(2);
+
+      const entry = cache.cacheSequenceV2(TEST_URL, TEST_INSTRUCTION, TEST_ACTIONS, keyParts)!;
+      const hit = cache.getCachedSequenceV2(TEST_URL, TEST_INSTRUCTION, keyParts);
+
+      expect(entry.version).toBe(2);
+      expect(entry.keyParts.pageFingerprint).toHaveLength(24);
+      expect(hit.status).toBe('HIT');
+      expect(hit.keyVersion).toBe(2);
+      expect(hit.actions).toEqual(TEST_ACTIONS);
+      expect(JSON.stringify(entry)).not.toContain('<html');
+    });
+
+    it('reports stale instead of replaying when the page fingerprint changes', () => {
+      const cache = getCache();
+      const keyParts = cache.buildActionCacheKeyV2Parts(keyInput)!;
+      cache.cacheSequenceV2(TEST_URL, TEST_INSTRUCTION, TEST_ACTIONS, keyParts);
+
+      const drifted = cache.buildActionCacheKeyV2Parts({
+        ...keyInput,
+        pageFingerprint: JSON.stringify({ title: 'Login', nodes: [{ role: 'button', name: 'Cancel', tag: 'button' }] }),
+      })!;
+      const decision = cache.getCachedSequenceV2(TEST_URL, TEST_INSTRUCTION, drifted);
+
+      expect(decision.status).toBe('STALE');
+      expect(decision.reason).toBe('page_or_option_fingerprint_mismatch');
+      expect(decision.actions).toBeUndefined();
+    });
+
+    it('keeps v1 entries readable as migration fallback when no v2 candidate exists', () => {
+      const cache = getCache();
+      cache.cacheSequence(TEST_URL, TEST_INSTRUCTION, TEST_ACTIONS);
+      cache.validateCachedSequence(TEST_URL, TEST_INSTRUCTION, true);
+
+      const keyParts = cache.buildActionCacheKeyV2Parts(keyInput)!;
+      const decision = cache.getCachedSequenceV2(TEST_URL, TEST_INSTRUCTION, keyParts, { allowLegacyFallback: true });
+
+      expect(decision.status).toBe('HIT');
+      expect(decision.keyVersion).toBe(1);
+      expect(decision.reason).toBe('legacy_v1_fallback');
+      expect(decision.actions).toEqual(TEST_ACTIONS);
+    });
+
+    it('changes the key for viewport and option drift', () => {
+      const cache = getCache();
+      const base = cache.buildActionCacheKeyV2Parts(keyInput)!;
+      const changedViewport = cache.buildActionCacheKeyV2Parts({ ...keyInput, viewport: { width: 800, height: 600 } })!;
+      const changedOptions = cache.buildActionCacheKeyV2Parts({ ...keyInput, optionFingerprint: 'verify=none' })!;
+
+      expect(cache.getActionCacheKeyV2Hash(changedViewport)).not.toBe(cache.getActionCacheKeyV2Hash(base));
+      expect(cache.getActionCacheKeyV2Hash(changedOptions)).not.toBe(cache.getActionCacheKeyV2Hash(base));
+    });
+  });
+
   describe('guarded workflow cache', () => {
     const signature = {
       titleHash: 'title-a',

--- a/tests/cli/admin-keys.test.ts
+++ b/tests/cli/admin-keys.test.ts
@@ -32,6 +32,29 @@ interface RunResult {
  * block ahead of the CLI's own single-line token emission. The CLI only ever
  * emits exactly one token, so a regex match is both sufficient and robust.
  */
+
+/**
+ * Parse the CLI JSON payload from captured stdout while ignoring unrelated
+ * Jest console-rendering noise that can be captured by the in-process stdout
+ * hook when another timer logs in the same worker. The admin list command emits
+ * one top-level array, so selecting the first complete JSON array preserves the
+ * assertion that plaintext does not leak into the actual CLI JSON output.
+ */
+function parseJsonArrayFromStdout<T>(stdout: string): T[] {
+  const start = stdout.indexOf('[');
+  if (start < 0) throw new Error(`No JSON array found in stdout: ${JSON.stringify(stdout)}`);
+  for (let end = stdout.length - 1; end >= start; end--) {
+    if (stdout[end] !== ']') continue;
+    const candidate = stdout.slice(start, end + 1);
+    try {
+      return JSON.parse(candidate) as T[];
+    } catch {
+      // Keep scanning left: prefixed Jest noise may contain bracketed labels.
+    }
+  }
+  throw new Error(`No parseable JSON array found in stdout: ${JSON.stringify(stdout)}`);
+}
+
 function extractToken(stdout: string): string {
   const m = stdout.match(/oc_live_[A-Za-z0-9_]+/);
   if (!m) throw new Error(`No oc_live_* token found in stdout: ${JSON.stringify(stdout)}`);
@@ -191,7 +214,7 @@ describe('admin keys CLI', () => {
 
     const listed = await runCli(['admin', 'keys', 'list', '--json']);
     expect(listed.exitCode).toBeNull();
-    const parsed = JSON.parse(listed.stdout) as Array<{ keyId: string; tenantId: string }>;
+    const parsed = parseJsonArrayFromStdout<{ keyId: string; tenantId: string }>(listed.stdout);
     expect(Array.isArray(parsed)).toBe(true);
     expect(parsed).toHaveLength(1);
     expect(parsed[0].tenantId).toBe('acme');
@@ -212,7 +235,7 @@ describe('admin keys CLI', () => {
     expect(revoked.stderr).toContain('Revoked');
 
     const listed = await runCli(['admin', 'keys', 'list', '--json']);
-    const parsed = JSON.parse(listed.stdout) as Array<{ keyId: string; revokedAt?: number }>;
+    const parsed = parseJsonArrayFromStdout<{ keyId: string; revokedAt?: number }>(listed.stdout);
     const row = parsed.find((r) => r.keyId === keyId);
     expect(row).toBeDefined();
     expect(typeof row!.revokedAt).toBe('number');
@@ -238,7 +261,7 @@ describe('admin keys CLI', () => {
     expect(rotated.stdout + rotated.stderr).not.toContain(firstPlaintext);
 
     const listed = await runCli(['admin', 'keys', 'list', '--json']);
-    const parsed = JSON.parse(listed.stdout) as Array<{ keyId: string; revokedAt?: number }>;
+    const parsed = parseJsonArrayFromStdout<{ keyId: string; revokedAt?: number }>(listed.stdout);
     const oldRow = parsed.find((r) => r.keyId === firstKeyId);
     expect(oldRow).toBeDefined();
     expect(typeof oldRow!.revokedAt).toBe('number');

--- a/tests/core/crawl/tools.test.ts
+++ b/tests/core/crawl/tools.test.ts
@@ -202,7 +202,7 @@ describe('crawl_status', () => {
     expect(body.completed).toBe(25);
     expect((body.pages as CrawledPage[]).length).toBe(10);
     expect(body.pagesOmitted).toBe(15);
-  });
+  }, 30000);
 
   test('expired job reports status=expired, performs zero fetches', async () => {
     mkTmpRoot();

--- a/tests/tools/act.test.ts
+++ b/tests/tools/act.test.ts
@@ -416,6 +416,64 @@ describe('ActTool', () => {
       expect(result.content[0].text).toContain('[cache] status=');
     });
 
+    test('stores action-cache v2 entries under the pre-action page URL', async () => {
+      (resolveElementsByAXTree as jest.Mock).mockResolvedValue([{
+        backendDOMNodeId: 302,
+        role: 'button',
+        name: 'Navigation target',
+        matchLevel: 1,
+        rect: { x: 10, y: 10, width: 50, height: 20 },
+        properties: {},
+        source: 'ax',
+      }]);
+      mockSessionManager.mockCDPClient.send.mockResolvedValue({ model: { content: [0, 0, 50, 0, 50, 20, 0, 20] } });
+
+      const page = await mockSessionManager.getPage(testSessionId, testTargetId);
+      const preActionUrl = 'https://example.com/start';
+      const postActionUrl = 'https://example.com/after-click';
+      let currentUrl = preActionUrl;
+      (page!.url as jest.Mock).mockImplementation(() => currentUrl);
+      (page!.mainFrame as jest.Mock).mockReturnValue({ url: jest.fn(() => currentUrl) });
+      (page!.evaluate as jest.Mock).mockResolvedValue({
+        title: 'Start',
+        path: '/start',
+        locale: 'en-US',
+        userAgent: 'Chrome/120',
+        viewport: { width: 1280, height: 720 },
+        nodes: [{ role: 'button', name: 'Navigation target', tag: 'button', type: '', disabled: false, visible: true }],
+      });
+      (page!.mouse.click as jest.Mock).mockImplementation(async () => {
+        currentUrl = postActionUrl;
+      });
+
+      const handler = await getActHandler();
+      const instruction = 'click navigation target';
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        instruction,
+        verify: false,
+      }) as any;
+
+      expect(result.isError).toBeFalsy();
+
+      const cache = await import('../../src/actions/action-cache');
+      const preActionKey = cache.buildActionCacheKeyV2Parts({
+        url: preActionUrl,
+        instruction,
+        actionKinds: ['click'],
+        viewport: { width: 1280, height: 720 },
+        pageFingerprint: JSON.stringify({ title: 'Start', path: '/start', nodes: [{ role: 'button', name: 'Navigation target', tag: 'button', type: '', disabled: false, visible: true }] }),
+        optionFingerprint: 'verify=none',
+        locale: 'en-US',
+        userAgent: 'Chrome/120',
+      })!;
+
+      const hit = cache.getCachedSequenceV2(preActionUrl, instruction, preActionKey);
+      expect(hit.status).toBe('HIT');
+      expect(hit.keyVersion).toBe(2);
+      expect(hit.actions).toEqual([{ action: 'click', target: 'navigation target' }]);
+    });
+
     test('verify=true (default) calls page.evaluate for state summary', async () => {
       (resolveElementsByAXTree as jest.Mock).mockResolvedValue([{
         backendDOMNodeId: 301,

--- a/tests/tools/act.test.ts
+++ b/tests/tools/act.test.ts
@@ -307,6 +307,7 @@ describe('ActTool', () => {
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('Could not find');
       expect(result.content[0].text).toContain('[WorkflowCache] decision=miss reason=no_candidate');
+      expect(result.content[0].text).toContain('[cache] status=');
     });
 
     test('navigate step calls page.goto', async () => {
@@ -403,14 +404,16 @@ describe('ActTool', () => {
       const page = await mockSessionManager.getPage(testSessionId, testTargetId);
 
       const handler = await getActHandler();
-      await handler(testSessionId, {
+      const result = await handler(testSessionId, {
         tabId: testTargetId,
         instruction: 'click go',
         verify: false,
       }) as any;
 
-      // page.evaluate should NOT have been called for verification
-      expect(page!.evaluate).not.toHaveBeenCalled();
+      // page.evaluate may be used for cache fingerprinting, but verify=false
+      // must still suppress the legacy [Verification] summary line.
+      expect(result.content[0].text).not.toContain('[Verification]');
+      expect(result.content[0].text).toContain('[cache] status=');
     });
 
     test('verify=true (default) calls page.evaluate for state summary', async () => {


### PR DESCRIPTION
## Summary
- adds action-cache v2 key parts with bounded page fingerprint, viewport, URL pattern, action kinds, option fingerprint, locale, and UA class
- makes `act` report a stable `[cache] status=... keyVersion=...` line for HIT/MISS/STALE/BYPASS
- rejects v2 replay on page/option fingerprint drift and keeps v1 entries readable as migration fallback
- documents cache statuses and adds regression coverage for HIT, MISS, STALE, v1 fallback, viewport/option drift, and bounded persisted metadata

Closes #994

## Verification
- `npm ci`
- `npm test -- tests/actions/action-cache.test.ts tests/tools/act.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint -- --quiet`
- `git diff --check`

## Notes
- No new runtime dependency; uses Node `crypto`.
- Live MCP fixture/timing verification from the issue checklist was not run in this worktree.
