### PR TITLE
feat(config): add opt-in fast runtime profile

### DIFF
--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -8,6 +8,7 @@ model composes them into prose.
 
 | Recipe | Goal | Tools touched |
 |---|---|---|
+| [fast-profile.md](fast-profile.md) | Enable and verify the opt-in low-token runtime profile. | `oc_get_connection_info`, `read_page` |
 | [multi-source-news-digest.md](multi-source-news-digest.md) | Pull headlines from several news sources and produce a one-screen daily digest. | `navigate`, `read_page`, `crawl` |
 | [docs-changelog-diff.md](docs-changelog-diff.md) | Compare two snapshots of a docs page (e.g. before/after a release) and explain what changed. | `navigate`, `read_page` |
 | [competitive-feature-matrix.md](competitive-feature-matrix.md) | Build a structured feature-matrix table across several vendor pages. | `navigate`, `extract_data`, `read_page` |

--- a/docs/recipes/fast-profile.md
+++ b/docs/recipes/fast-profile.md
@@ -1,0 +1,27 @@
+# Fast runtime profile
+
+Set `OPENCHROME_PROFILE=fast` to opt into lower-token browser sessions without
+changing the default OpenChrome behavior.
+
+```bash
+OPENCHROME_PROFILE=fast node dist/cli/index.js serve
+```
+
+Detect it with:
+
+```jsonc
+oc_get_connection_info({ "host": "openchrome" })
+```
+
+The response includes `runtimeProfile.profile: "fast"` and guidance for hosts.
+
+Fast profile behavior in this PR:
+
+- `read_page({ mode: "ax" })` defaults to compact AX output unless the caller
+  explicitly passes `compact: false`.
+- Security warnings, destructive-action gates, stale-ref guidance, and structured
+  errors are not reduced.
+- Screenshot tools remain available but are not implicitly enabled by the profile.
+
+Use normal/default profile for visual QA, flaky interaction debugging, security
+review, or any task that needs exhaustive page context.

--- a/src/config/runtime-profile.ts
+++ b/src/config/runtime-profile.ts
@@ -1,0 +1,29 @@
+export type OpenChromeRuntimeProfile = 'default' | 'fast';
+
+export interface RuntimeProfileInfo {
+  profile: OpenChromeRuntimeProfile;
+  source: 'env' | 'default';
+  fast: boolean;
+  guidance: string[];
+}
+
+export function getRuntimeProfile(): RuntimeProfileInfo {
+  const raw = (process.env.OPENCHROME_PROFILE || '').trim().toLowerCase();
+  const fast = raw === 'fast';
+  return {
+    profile: fast ? 'fast' : 'default',
+    source: raw ? 'env' : 'default',
+    fast,
+    guidance: fast
+      ? [
+        'Prefer inspect/query_dom/extract_data over full read_page output.',
+        'read_page AX defaults to compact unless compact=false is explicit.',
+        'Screenshots remain explicit; safety and recovery warnings are not reduced.',
+      ]
+      : [],
+  };
+}
+
+export function isFastProfile(): boolean {
+  return getRuntimeProfile().fast;
+}

--- a/src/tools/connect.ts
+++ b/src/tools/connect.ts
@@ -15,6 +15,7 @@ import { getAutoConnectState } from '../chrome/auto-connect-state';
 import { getChromePool } from '../chrome/pool';
 import { getDevToolsInstanceInfo } from '../chrome/devtools-info';
 import { getGlobalConfig } from '../config/global';
+import { getRuntimeProfile } from '../config/runtime-profile';
 
 function getServerState(): ServerConnectionState {
   const httpPort = process.env.OPENCHROME_HTTP_PORT || '3100';
@@ -113,6 +114,7 @@ const getConnectionInfoHandler: ToolHandler = async (
                 port: autoConnect.port,
                 wsEndpoint: autoConnect.wsEndpoint,
                 attachedAt: new Date(autoConnect.attachedAt).toISOString(),
+                runtimeProfile: getRuntimeProfile(),
               },
               null,
               2,
@@ -125,7 +127,7 @@ const getConnectionInfoHandler: ToolHandler = async (
       content: [
         {
           type: 'text',
-          text: JSON.stringify({ mode: 'managed' }, null, 2),
+          text: JSON.stringify({ mode: 'managed', runtimeProfile: getRuntimeProfile() }, null, 2),
         },
       ],
     };

--- a/src/tools/read-page.ts
+++ b/src/tools/read-page.ts
@@ -10,6 +10,7 @@ import { getRefIdManager, REF_TTL_MS, type SnapshotRefMetadata } from '../utils/
 import { serializeDOM } from '../dom';
 import { detectPagination, PaginationInfo } from '../utils/pagination-detector';
 import { MAX_OUTPUT_CHARS } from '../config/defaults';
+import { isFastProfile } from '../config/runtime-profile';
 import { withTimeout } from '../utils/with-timeout';
 import { SnapshotStore } from '../compression/snapshot-store';
 import { sanitizeContent } from '../security/content-sanitizer';
@@ -144,7 +145,7 @@ const definition: MCPToolDefinition = {
       },
       compact: {
         type: 'boolean',
-        description: 'AX mode only: return a compact AX snapshot that keeps actionable/ref-bearing nodes, value/state nodes, and ancestors. Default: false.',
+        description: 'AX mode only: return a compact AX snapshot that keeps actionable/ref-bearing nodes, value/state nodes, and ancestors. Default: false, or true when OPENCHROME_PROFILE=fast.',
       },
       diagnostics: {
         type: 'boolean',
@@ -330,7 +331,7 @@ const handler: ToolHandler = async (
     };
 
     const axOverflowFallback = (args.fallback as string | undefined) || 'none';
-    const compactAX = args.compact === true;
+    const compactAX = args.compact === true || (args.compact === undefined && isFastProfile());
     if (axOverflowFallback !== 'none' && axOverflowFallback !== 'dom') {
       return {
         content: [{ type: 'text', text: `Error: Invalid fallback "${axOverflowFallback}". Must be "none" or "dom".` }],

--- a/tests/tools/oc-get-connection-info-devtools-field.test.ts
+++ b/tests/tools/oc-get-connection-info-devtools-field.test.ts
@@ -87,6 +87,21 @@ describe('oc_get_connection_info devtools field (#860)', () => {
 
   afterEach(() => {
     delete process.env.OPENCHROME_EXPOSE_DEVTOOLS_URL;
+    delete process.env.OPENCHROME_PROFILE;
+  });
+
+
+
+  test('host=openchrome reports fast runtime profile when enabled', async () => {
+    process.env.OPENCHROME_PROFILE = 'fast';
+
+    const result = await handler('default', { host: 'openchrome' });
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.mode).toBe('managed');
+    expect(data.runtimeProfile).toMatchObject({ profile: 'fast', source: 'env', fast: true });
+    expect(data.runtimeProfile.guidance.join(' ')).toContain('read_page AX defaults to compact');
   });
 
   test('tool is registered', () => {

--- a/tests/tools/read-page.test.ts
+++ b/tests/tools/read-page.test.ts
@@ -117,6 +117,7 @@ describe('ReadPageTool', () => {
   });
 
   afterEach(() => {
+    delete process.env.OPENCHROME_PROFILE;
     jest.clearAllMocks();
     // Keep delta snapshot cache isolated between read_page tests.
     // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -656,6 +657,31 @@ describe('ReadPageTool', () => {
       expect(matchingCall).toBeDefined();
       expect(typeof matchingCall![2]).toBe('number');
       expect(typeof matchingCall![3]).toBe('string');
+    });
+
+
+
+    test('OPENCHROME_PROFILE=fast defaults AX reads to compact output and explicit compact=false disables it', async () => {
+      process.env.OPENCHROME_PROFILE = 'fast';
+      const handler = await getReadPageHandler();
+      mockSessionManager.mockCDPClient.setCDPResponse(
+        'Accessibility.getFullAXTree',
+        { depth: 8 },
+        {
+          nodes: [
+            { nodeId: 1, backendDOMNodeId: 100, role: { value: 'document' }, name: { value: 'Fast Page' }, childIds: [2, 3] },
+            { nodeId: 2, role: { value: 'StaticText' }, name: { value: 'Decorative copy' } },
+            { nodeId: 3, backendDOMNodeId: 101, role: { value: 'button' }, name: { value: 'Submit' } },
+          ],
+        }
+      );
+
+      const fast = await handler(testSessionId, { tabId: testTargetId, mode: 'ax' }) as { content: Array<{ type: string; text: string }> };
+      expect(fast.content[0].text).toContain('button: "Submit"');
+      expect(fast.content[0].text).not.toContain('Decorative copy');
+
+      const explicitFull = await handler(testSessionId, { tabId: testTargetId, mode: 'ax', compact: false }) as { content: Array<{ type: string; text: string }> };
+      expect(explicitFull.content[0].text).toContain('Decorative copy');
     });
 
     test('compact AX mode omits non-actionable no-ref leaves while preserving actionable nodes', async () => {


### PR DESCRIPTION
## Summary
- adds `OPENCHROME_PROFILE=fast` runtime profile detection
- surfaces `runtimeProfile` from `oc_get_connection_info({ host: "openchrome" })`
- makes `read_page(mode="ax")` default to compact output only when fast profile is active, while preserving explicit `compact: false`
- documents fast-profile tradeoffs and adds activation/default-resolution tests

Closes #984

## Verification
- `npm ci`
- `npm test -- tests/tools/read-page.test.ts tests/tools/oc-get-connection-info-devtools-field.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint -- --quiet`
- `git diff --check`

## Notes
- Normal mode behavior is unchanged when `OPENCHROME_PROFILE` is unset.
- Safety/recovery warnings are not reduced by this profile.
- Live MCP baseline-vs-fast output-size validation was not run in this worktree.
