### PR TITLE
feat(extract): add semantic host extraction mode

### DIFF
--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -10,6 +10,7 @@ model composes them into prose.
 |---|---|---|
 | [multi-source-news-digest.md](multi-source-news-digest.md) | Pull headlines from several news sources and produce a one-screen daily digest. | `navigate`, `read_page`, `crawl` |
 | [docs-changelog-diff.md](docs-changelog-diff.md) | Compare two snapshots of a docs page (e.g. before/after a release) and explain what changed. | `navigate`, `read_page` |
+| [semantic-extract-data.md](semantic-extract-data.md) | Use query-based semantic `extract_data` host fallback with bounded chunks. | `extract_data` |
 | [competitive-feature-matrix.md](competitive-feature-matrix.md) | Build a structured feature-matrix table across several vendor pages. | `navigate`, `extract_data`, `read_page` |
 
 ## How recipes are structured

--- a/docs/recipes/semantic-extract-data.md
+++ b/docs/recipes/semantic-extract-data.md
@@ -1,0 +1,48 @@
+# Query-based semantic `extract_data`
+
+Use `extract_data` with `mode: "semantic"` when deterministic JSON-LD,
+Microdata, OpenGraph, and CSS heuristics are insufficient but the host LLM can
+extract from a small, relevant markdown chunk.
+
+Semantic mode is opt-in. Existing calls without `mode: "semantic"` keep the
+normal deterministic path.
+
+## Host-extraction fallback
+
+OpenChrome does not require or default to a server-side extraction LLM. When no
+server-side provider is configured, semantic mode returns:
+
+- `semanticProvider: "host"`
+- a bounded redacted markdown `chunk`
+- `schema` and `query`
+- `contentStats`
+- `chunkIndex`, `totalChunks`, and `nextStartChar` continuation metadata
+- `hostExtraction` instructions for the MCP host
+
+The host can perform extraction, then call again with `startFromChar:
+nextStartChar` and pass `alreadyCollected` to continue a long page.
+
+## Example
+
+```json
+{
+  "tabId": "tab-1",
+  "mode": "semantic",
+  "query": "latest release title, date, and token-related changes",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "title": { "type": "string" },
+      "date": { "type": "string" },
+      "changes": { "type": "array" }
+    }
+  },
+  "selector": "main",
+  "maxChars": 12000,
+  "includeLinks": true
+}
+```
+
+`maxChars` defaults to 12,000 and is capped at 50,000. Sensitive-looking lines
+(passwords, tokens, API keys, credentials, cookies, sessions) are redacted before
+chunks are returned or handed to a host.

--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -11,3 +11,5 @@ export {
 export type { StrategyResult } from './strategies';
 export { EXTRACTION_MODES, EXTRACTION_MODE_BUDGETS, parseExtractionMode } from './mode';
 export type { ExtractionMode, ExtractionModeBudget } from './mode';
+export { SEMANTIC_DEFAULT_MAX_CHARS, SEMANTIC_HARD_MAX_CHARS, buildSemanticHostExtractionPayload } from './semantic';
+export type { SemanticExtractionPayload } from './semantic';

--- a/src/extraction/mode.ts
+++ b/src/extraction/mode.ts
@@ -1,4 +1,4 @@
-export const EXTRACTION_MODES = ['fast', 'standard'] as const;
+export const EXTRACTION_MODES = ['fast', 'standard', 'semantic'] as const;
 export type ExtractionMode = (typeof EXTRACTION_MODES)[number];
 
 export interface ExtractionModeBudget {
@@ -33,10 +33,20 @@ export const EXTRACTION_MODE_BUDGETS: Record<ExtractionMode, ExtractionModeBudge
     maxCssNodes: 1000,
     maxStandardDomNodes: 2000,
   },
+  semantic: {
+    mode: 'semantic',
+    jsonLdTimeoutMs: 0,
+    microdataTimeoutMs: 0,
+    openGraphTimeoutMs: 0,
+    cssTimeoutMs: 0,
+    standardDomTimeoutMs: 0,
+    maxCssNodes: 0,
+    maxStandardDomNodes: 0,
+  },
 };
 
 export function parseExtractionMode(value: unknown): { ok: true; mode: ExtractionMode } | { ok: false; error: string } {
   if (value === undefined || value === null || value === '') return { ok: true, mode: 'fast' };
-  if (value === 'fast' || value === 'standard') return { ok: true, mode: value };
-  return { ok: false, error: 'Invalid mode. Use "fast" or "standard".' };
+  if (value === 'fast' || value === 'standard' || value === 'semantic') return { ok: true, mode: value };
+  return { ok: false, error: 'Invalid mode. Use "fast", "standard", or "semantic".' };
 }

--- a/src/extraction/semantic.ts
+++ b/src/extraction/semantic.ts
@@ -1,0 +1,174 @@
+import type { ExtractionSchema, SchemaProperty } from './schema-validator';
+
+export const SEMANTIC_DEFAULT_MAX_CHARS = 12000;
+export const SEMANTIC_HARD_MAX_CHARS = 50000;
+
+export interface SemanticExtractionOptions {
+  markdown: string;
+  schema: ExtractionSchema;
+  schemaProps: Record<string, SchemaProperty>;
+  query: string;
+  startFromChar?: number;
+  maxChars?: number;
+  alreadyCollected?: unknown[];
+}
+
+export interface SemanticExtractionPayload {
+  action: 'extract_data';
+  modeUsed: 'semantic';
+  semanticProvider: 'host';
+  query: string;
+  schema: ExtractionSchema;
+  chunk: string;
+  chunkIndex: number;
+  totalChunks: number;
+  nextStartChar: number | null;
+  contentStats: {
+    rawChars: number;
+    sanitizedChars: number;
+    filteredChars: number;
+    chunkChars: number;
+    maxChars: number;
+    startFromChar: number;
+    redactions: number;
+  };
+  fieldsFound: number;
+  fieldsTotal: number;
+  fieldsMissing: string[];
+  hostExtraction: {
+    instruction: string;
+    schema: ExtractionSchema;
+    query: string;
+    chunk: string;
+    alreadyCollected: unknown[];
+  };
+}
+
+interface RedactionResult {
+  text: string;
+  count: number;
+}
+
+const SENSITIVE_LINE = /\b(password|passcode|token|secret|api[_ -]?key|credential|authorization|cookie|session)\b/i;
+const SENSITIVE_ASSIGNMENT = /\b(password|passcode|token|secret|api[_ -]?key|credential|authorization|cookie|session)\b\s*[:=]\s*([^\n\r]+)/gi;
+
+export function normalizeSemanticMaxChars(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return SEMANTIC_DEFAULT_MAX_CHARS;
+  return Math.min(Math.floor(value), SEMANTIC_HARD_MAX_CHARS);
+}
+
+export function normalizeSemanticStart(value: unknown, rawLength: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return 0;
+  return Math.min(Math.floor(value), Math.max(0, rawLength));
+}
+
+export function redactSemanticContent(markdown: string): RedactionResult {
+  let count = 0;
+  const lines = markdown.split('\n').map(line => {
+    if (!SENSITIVE_LINE.test(line)) return line;
+    count += 1;
+    return line.replace(SENSITIVE_ASSIGNMENT, (_match, key) => `${key}: [REDACTED]`)
+      .replace(/value="[^"]*"/gi, 'value="[REDACTED]"')
+      .replace(/`[^`]{3,}`/g, '`[REDACTED]`');
+  });
+  return { text: lines.join('\n'), count };
+}
+
+export function buildSemanticHostExtractionPayload(options: SemanticExtractionOptions): SemanticExtractionPayload {
+  const query = options.query.trim();
+  const maxChars = normalizeSemanticMaxChars(options.maxChars);
+  const alreadyCollected = Array.isArray(options.alreadyCollected) ? options.alreadyCollected : [];
+  const redacted = redactSemanticContent(options.markdown);
+  const filtered = filterMarkdownForQuery(redacted.text, query, alreadyCollected);
+  const startFromChar = normalizeSemanticStart(options.startFromChar, filtered.length);
+  const chunk = filtered.slice(startFromChar, startFromChar + maxChars);
+  const nextStartChar = startFromChar + chunk.length < filtered.length ? startFromChar + chunk.length : null;
+  const totalChunks = Math.max(1, Math.ceil(filtered.length / maxChars));
+  const chunkIndex = Math.floor(startFromChar / maxChars);
+  const fieldNames = Object.keys(options.schemaProps);
+
+  return {
+    action: 'extract_data',
+    modeUsed: 'semantic',
+    semanticProvider: 'host',
+    query,
+    schema: options.schema,
+    chunk,
+    chunkIndex,
+    totalChunks,
+    nextStartChar,
+    contentStats: {
+      rawChars: options.markdown.length,
+      sanitizedChars: redacted.text.length,
+      filteredChars: filtered.length,
+      chunkChars: chunk.length,
+      maxChars,
+      startFromChar,
+      redactions: redacted.count,
+    },
+    fieldsFound: 0,
+    fieldsTotal: fieldNames.length,
+    fieldsMissing: fieldNames,
+    hostExtraction: {
+      instruction: 'Use this bounded markdown chunk to extract data matching schema and query. If nextStartChar is non-null, call extract_data again with startFromChar=nextStartChar to continue.',
+      schema: options.schema,
+      query,
+      chunk,
+      alreadyCollected,
+    },
+  };
+}
+
+function filterMarkdownForQuery(markdown: string, query: string, alreadyCollected: unknown[]): string {
+  const blocks = splitBlocks(markdown);
+  const queryTerms = tokenize(query);
+  const seenTerms = new Set(alreadyCollected.map(item => normalizeText(String(item))).filter(Boolean));
+  const scored = blocks.map((block, index) => ({ block, index, score: scoreBlock(block, queryTerms, index) }))
+    .filter(item => !seenTerms.has(normalizeText(item.block).slice(0, 160)));
+
+  const positive = scored.filter(item => item.score > 0);
+  const selected = positive.length > 0
+    ? positive.sort((a, b) => b.score - a.score || a.index - b.index).slice(0, 80).sort((a, b) => a.index - b.index)
+    : scored.slice(0, 80);
+
+  return selected.map(item => item.block.trim()).filter(Boolean).join('\n\n').trim();
+}
+
+function splitBlocks(markdown: string): string[] {
+  const lines = markdown.split('\n');
+  const blocks: string[] = [];
+  let current: string[] = [];
+  let inFence = false;
+
+  for (const line of lines) {
+    if (line.trim().startsWith('```')) inFence = !inFence;
+    if (!inFence && line.trim() === '') {
+      if (current.length > 0) {
+        blocks.push(current.join('\n'));
+        current = [];
+      }
+      continue;
+    }
+    current.push(line);
+  }
+  if (current.length > 0) blocks.push(current.join('\n'));
+  return blocks;
+}
+
+function scoreBlock(block: string, queryTerms: string[], index: number): number {
+  const text = normalizeText(block);
+  let score = block.startsWith('#') ? 2 : 0;
+  for (const term of queryTerms) {
+    if (text.includes(term)) score += 3;
+  }
+  if (index < 3) score += 1;
+  return score;
+}
+
+function tokenize(text: string): string[] {
+  return normalizeText(text).split(' ').filter(token => token.length >= 3).slice(0, 32);
+}
+
+function normalizeText(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, ' ').replace(/\s+/g, ' ').trim();
+}

--- a/src/tools/extract-data.ts
+++ b/src/tools/extract-data.ts
@@ -8,6 +8,8 @@ import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { withTimeout } from '../utils/with-timeout';
 import { waitForPageReady } from '../utils/page-ready-state';
+import { extractMainContent, toMarkdown } from '../core/extract/html-to-markdown';
+import { sanitizeContent } from '../security/content-sanitizer';
 import { getDomainMemory, extractDomainFromUrl } from '../memory/domain-memory';
 import {
   validateSchema,
@@ -20,6 +22,9 @@ import {
   buildMultipleItemExtractor,
   parseExtractionMode,
   EXTRACTION_MODE_BUDGETS,
+  buildSemanticHostExtractionPayload,
+  SEMANTIC_DEFAULT_MAX_CHARS,
+  SEMANTIC_HARD_MAX_CHARS,
 } from '../extraction';
 import type { ExtractionMode } from '../extraction';
 import type { ExtractionSchema, SchemaProperty } from '../extraction';
@@ -32,7 +37,7 @@ import {
 const definition: MCPToolDefinition = {
   name: 'extract_data',
   description:
-    'Extract structured data from page using a JSON Schema. Tries JSON-LD, Microdata, OpenGraph, and CSS heuristics. Use multiple:true for listings.\n\nWhen to use: Extracting typed structured data (products, articles, prices) from a page into a schema.\nWhen NOT to use: Use javascript_tool for ad-hoc extraction, or read_page to read raw page content.',
+    'Extract structured data from page using a JSON Schema. Tries JSON-LD, Microdata, OpenGraph, and CSS heuristics. Use multiple:true for listings. Use mode="semantic" with query for bounded host-side semantic extraction chunks.\n\nWhen to use: Extracting typed structured data (products, articles, prices) from a page into a schema.\nWhen NOT to use: Use javascript_tool for ad-hoc extraction, or read_page to read raw page content.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -49,6 +54,30 @@ const definition: MCPToolDefinition = {
       instruction: {
         type: 'string',
         description: 'Optional natural language hint (e.g., "product details")',
+      },
+      query: {
+        type: 'string',
+        description: 'Required for mode="semantic": query describing the information to extract from a bounded markdown chunk',
+      },
+      maxChars: {
+        type: 'number',
+        description: `Semantic mode only: max chunk chars returned to the host. Default ${SEMANTIC_DEFAULT_MAX_CHARS}, hard cap ${SEMANTIC_HARD_MAX_CHARS}.`,
+      },
+      startFromChar: {
+        type: 'number',
+        description: 'Semantic mode only: continuation offset into filtered markdown. Default: 0.',
+      },
+      includeLinks: {
+        type: 'boolean',
+        description: 'Semantic mode only: preserve markdown links. Default: true.',
+      },
+      includeImages: {
+        type: 'boolean',
+        description: 'Semantic mode only: reserved for image markdown inclusion. Default: false.',
+      },
+      alreadyCollected: {
+        type: 'array',
+        description: 'Semantic mode only: values already collected by the host, used for simple chunk dedupe hints.',
       },
       selector: {
         type: 'string',
@@ -95,6 +124,7 @@ const handler: ToolHandler = async (
   const tabId = args.tabId as string;
   const schema = args.schema as ExtractionSchema;
   const selector = args.selector as string | undefined;
+  const query = args.query as string | undefined;
   const multiple = (args.multiple as boolean) ?? false;
   const { mode: outputMode, inlineLimit } = parseOutputMode(args);
   const waitForReady = args.waitForReady === true;
@@ -138,6 +168,50 @@ const handler: ToolHandler = async (
 
     const pageUrl = page.url();
     const domain = extractDomainFromUrl(pageUrl);
+
+    if (extractionMode === 'semantic') {
+      if (!query || query.trim().length === 0) {
+        return { content: [{ type: 'text', text: 'Error: mode="semantic" requires a non-empty query' }], isError: true };
+      }
+      if (multiple) {
+        return { content: [{ type: 'text', text: 'Error: mode="semantic" does not support multiple=true; use continuation metadata and alreadyCollected instead.' }], isError: true };
+      }
+      const includeLinks = args.includeLinks !== false;
+      const html = selector
+        ? await withTimeout(page.evaluate((sel: string) => {
+          const el = document.querySelector(sel);
+          return el ? (el as HTMLElement).outerHTML : '';
+        }, selector) as Promise<string>, 15000, 'extract_data:semantic.selector', _context)
+        : await withTimeout(page.content(), 15000, 'extract_data:semantic.content', _context);
+      if (!html) {
+        return { content: [{ type: 'text', text: `Error: selector "${selector}" did not match content for semantic extraction` }], isError: true };
+      }
+      const { html: cleaned } = extractMainContent(html, { onlyMainContent: !selector });
+      const rawMarkdown = toMarkdown(cleaned, { includeLinks });
+      const sanitized = sanitizeContent(rawMarkdown);
+      const semanticPayload = buildSemanticHostExtractionPayload({
+        markdown: sanitized.text + sanitized.sanitizationNote,
+        schema,
+        schemaProps,
+        query,
+        startFromChar: args.startFromChar as number | undefined,
+        maxChars: args.maxChars as number | undefined,
+        alreadyCollected: args.alreadyCollected as unknown[] | undefined,
+      });
+      const payload: Record<string, unknown> = {
+        ...semanticPayload,
+        url: pageUrl,
+        selector: selector || undefined,
+        includeLinks,
+        includeImages: args.includeImages === true,
+        readiness,
+        metrics: { mode: 'semantic', outputChars: 0 },
+      };
+      const textWithoutMetrics = JSON.stringify(payload);
+      payload.metrics = { mode: 'semantic', outputChars: textWithoutMetrics.length };
+      const inlineResult: MCPResult = { content: [{ type: 'text', text: JSON.stringify(payload) }] };
+      return resolveOutputMode(outputMode, inlineLimit, inlineResult, payload, 'extract_data');
+    }
 
     // Multiple items mode
     if (multiple) {

--- a/src/tools/extract-data.ts
+++ b/src/tools/extract-data.ts
@@ -37,7 +37,7 @@ import {
 const definition: MCPToolDefinition = {
   name: 'extract_data',
   description:
-    'Extract structured data from page using a JSON Schema. Tries JSON-LD, Microdata, OpenGraph, and CSS heuristics. Use multiple:true for listings. Use mode="semantic" with query for bounded host-side semantic extraction chunks.\n\nWhen to use: Extracting typed structured data (products, articles, prices) from a page into a schema.\nWhen NOT to use: Use javascript_tool for ad-hoc extraction, or read_page to read raw page content.',
+    'Extract structured data with a JSON Schema from JSON-LD, Microdata, OpenGraph, or CSS. Use multiple:true for listings; mode="semantic" plus query for bounded host-side semantic chunks.\n\nWhen to use: Typed products, articles, prices, or semantic facts into a schema.\nWhen NOT to use: Use read_page for raw content or javascript_tool for ad-hoc scraping.',
   inputSchema: {
     type: 'object',
     properties: {

--- a/tests/tools/extract-data-modes.test.ts
+++ b/tests/tools/extract-data-modes.test.ts
@@ -35,7 +35,8 @@ describe('extract_data modes', () => {
     expect(parseExtractionMode(undefined)).toEqual({ ok: true, mode: 'fast' });
     expect(parseExtractionMode('fast')).toEqual({ ok: true, mode: 'fast' });
     expect(parseExtractionMode('standard')).toEqual({ ok: true, mode: 'standard' });
-    expect(parseExtractionMode('deep')).toEqual({ ok: false, error: 'Invalid mode. Use "fast" or "standard".' });
+    expect(parseExtractionMode('semantic')).toEqual({ ok: true, mode: 'semantic' });
+    expect(parseExtractionMode('deep')).toEqual({ ok: false, error: 'Invalid mode. Use "fast", "standard", or "semantic".' });
     expect(EXTRACTION_MODE_BUDGETS.fast.maxStandardDomNodes).toBe(0);
     expect(EXTRACTION_MODE_BUDGETS.standard.maxStandardDomNodes).toBeGreaterThan(EXTRACTION_MODE_BUDGETS.fast.maxStandardDomNodes);
   });

--- a/tests/tools/extract-data-semantic.test.ts
+++ b/tests/tools/extract-data-semantic.test.ts
@@ -1,0 +1,148 @@
+/// <reference types="jest" />
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(),
+}));
+
+jest.mock('../../src/memory/domain-memory', () => ({
+  extractDomainFromUrl: jest.fn(() => 'example.test'),
+  getDomainMemory: jest.fn(() => ({ record: jest.fn() })),
+}));
+
+import { getSessionManager } from '../../src/session-manager';
+import { extractDataHandler } from '../../src/tools/extract-data';
+
+const schema = {
+  type: 'object' as const,
+  properties: {
+    price: { type: 'string' },
+    availability: { type: 'string' },
+  },
+};
+
+function responseJson(result: Awaited<ReturnType<typeof extractDataHandler>>): Record<string, unknown> {
+  return JSON.parse(result.content?.[0]?.text ?? '{}') as Record<string, unknown>;
+}
+
+function installPage(html: string) {
+  const page = {
+    url: jest.fn(() => 'https://example.test/product'),
+    content: jest.fn(async () => html),
+    evaluate: jest.fn(async (fn: (selector: string) => string, selector: string) => {
+      if (selector === 'main') return '<main><h1>Scoped</h1><p>Enterprise price is $19.</p></main>';
+      return '';
+    }),
+  };
+  (getSessionManager as jest.Mock).mockReturnValue({
+    getPage: jest.fn(async () => page),
+    getAvailableTargets: jest.fn(async () => []),
+  });
+  return page;
+}
+
+describe('extract_data semantic mode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requires a query before returning host extraction payload', async () => {
+    installPage('<main><h1>Product</h1></main>');
+
+    const result = await extractDataHandler('s1', { tabId: 't1', schema, mode: 'semantic' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text).toContain('requires a non-empty query');
+  });
+
+  it('returns bounded host semantic extraction chunk and continuation metadata without an LLM', async () => {
+    installPage(`
+      <main>
+        <h1>Product</h1>
+        <p>Enterprise pricing is $99 and availability is in stock.</p>
+        <p>Unrelated company history should be less relevant.</p>
+        <p>Pricing details include annual discount and support.</p>
+      </main>
+    `);
+
+    const result = await extractDataHandler('s1', {
+      tabId: 't1',
+      schema,
+      mode: 'semantic',
+      query: 'enterprise pricing availability',
+      maxChars: 80,
+    });
+    const body = responseJson(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(body.modeUsed).toBe('semantic');
+    expect(body.semanticProvider).toBe('host');
+    expect(body.query).toBe('enterprise pricing availability');
+    expect(typeof body.nextStartChar === 'number' || body.nextStartChar === null).toBe(true);
+    expect((body.chunk as string).length).toBeLessThanOrEqual(80);
+    expect((body.chunk as string).toLowerCase()).toContain('pricing');
+    expect((body.contentStats as Record<string, unknown>).maxChars).toBe(80);
+    expect((body.hostExtraction as Record<string, unknown>).schema).toEqual(schema);
+    expect(body.fieldsMissing).toEqual(['price', 'availability']);
+  });
+
+  it('continues from startFromChar and caps maxChars at the hard limit', async () => {
+    installPage(`<main>${'<p>Enterprise pricing availability section.</p>'.repeat(2000)}</main>`);
+
+    const result = await extractDataHandler('s1', {
+      tabId: 't1',
+      schema,
+      mode: 'semantic',
+      query: 'enterprise pricing availability',
+      maxChars: 999999,
+      startFromChar: 20,
+    });
+    const body = responseJson(result);
+    const stats = body.contentStats as Record<string, unknown>;
+
+    expect(stats.maxChars).toBe(50000);
+    expect(stats.startFromChar).toBe(20);
+    expect((body.chunk as string).length).toBeLessThanOrEqual(50000);
+  });
+
+  it('redacts password-like content before returning chunks', async () => {
+    installPage(`
+      <main>
+        <h1>Credentials</h1>
+        <p>Password: hunter2-secret</p>
+        <p>API key: abcdefghijklmnopqrstuvwxyz123456</p>
+        <p>Enterprise pricing remains visible.</p>
+      </main>
+    `);
+
+    const result = await extractDataHandler('s1', {
+      tabId: 't1',
+      schema,
+      mode: 'semantic',
+      query: 'password api key enterprise pricing',
+    });
+    const text = result.content?.[0]?.text ?? '';
+    const body = responseJson(result);
+
+    expect(text).not.toContain('hunter2-secret');
+    expect(text).not.toContain('abcdefghijklmnopqrstuvwxyz123456');
+    expect(text).toContain('[REDACTED]');
+    expect((body.contentStats as Record<string, unknown>).redactions).toBeGreaterThan(0);
+  });
+
+  it('uses selector-scoped html when selector is provided', async () => {
+    const page = installPage('<main><h1>Ignored</h1></main>');
+
+    const result = await extractDataHandler('s1', {
+      tabId: 't1',
+      schema,
+      mode: 'semantic',
+      query: 'enterprise price',
+      selector: 'main',
+    });
+    const body = responseJson(result);
+
+    expect(page.evaluate).toHaveBeenCalled();
+    expect(body.selector).toBe('main');
+    expect(body.chunk).toContain('Enterprise price');
+  });
+});


### PR DESCRIPTION
## Summary
- adds opt-in `extract_data` `mode="semantic"` host-fallback path
- extracts clean markdown, filters it by query, redacts password/token-like content, and returns bounded chunks
- includes `semanticProvider: "host"`, `contentStats`, `chunkIndex`, `totalChunks`, `nextStartChar`, `fieldsMissing`, and host extraction instructions
- preserves deterministic `fast`/`standard` behavior as default
- documents semantic extraction workflow and adds targeted tests

Closes #975

## Verification
- `npm ci`
- `npm test -- tests/tools/extract-data-semantic.test.ts tests/tools/extract-data-modes.test.ts tests/tools/extract-data-ready.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint -- --quiet`
- `git diff --check`

## Notes
- No server-side LLM provider is introduced; this PR implements the safe host-extraction fallback.
- `maxChars` defaults to 12,000 and is capped at 50,000.
- Live MCP validation against GitHub releases was not run in this worktree.
