### PR TITLE
feat(core): add fit markdown content filters

### DIFF
--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -9,6 +9,7 @@ model composes them into prose.
 | Recipe | Goal | Tools touched |
 |---|---|---|
 | [multi-source-news-digest.md](multi-source-news-digest.md) | Pull headlines from several news sources and produce a one-screen daily digest. | `navigate`, `read_page`, `crawl` |
+| [fit-markdown.md](fit-markdown.md) | Return raw and fit markdown with deterministic prune/BM25 filters. | `read_page`, `crawl`, `crawl_sitemap` |
 | [docs-changelog-diff.md](docs-changelog-diff.md) | Compare two snapshots of a docs page (e.g. before/after a release) and explain what changed. | `navigate`, `read_page` |
 | [competitive-feature-matrix.md](competitive-feature-matrix.md) | Build a structured feature-matrix table across several vendor pages. | `navigate`, `extract_data`, `read_page` |
 

--- a/docs/recipes/fit-markdown.md
+++ b/docs/recipes/fit-markdown.md
@@ -1,0 +1,46 @@
+# fit_markdown filters
+
+Use deterministic `fit_markdown` filtering when markdown output contains
+boilerplate that wastes host context. The feature is opt-in; existing markdown
+and markdown-clean defaults remain unchanged.
+
+## read_page
+
+```json
+{
+  "tabId": "tab-1",
+  "mode": "markdown",
+  "contentFilter": "prune",
+  "returnRaw": true,
+  "returnFit": true
+}
+```
+
+For query-aware filtering:
+
+```json
+{
+  "tabId": "tab-1",
+  "mode": "markdown",
+  "contentFilter": "bm25",
+  "query": "enterprise pricing",
+  "returnFit": true
+}
+```
+
+## crawl / crawl_sitemap
+
+```json
+{
+  "url": "https://example.com",
+  "output_format": "markdown-clean",
+  "content_filter": "prune",
+  "return_raw": false,
+  "return_fit": true
+}
+```
+
+Each filtered response includes `filter` metrics: raw/fit character counts,
+reduction ratio, sections seen/kept, filter type, and query when applicable.
+`bm25` requires a non-empty query and fails clearly instead of silently falling
+back.

--- a/src/core/extract/content-filter.ts
+++ b/src/core/extract/content-filter.ts
@@ -1,0 +1,162 @@
+export type ContentFilterType = 'none' | 'prune' | 'bm25';
+
+export interface ContentFilterOptions {
+  type?: ContentFilterType;
+  query?: string;
+  returnRaw?: boolean;
+  returnFit?: boolean;
+  minWords?: number;
+  maxSections?: number;
+  bm25Threshold?: number;
+  pruneThreshold?: number;
+}
+
+export interface ContentFilterMetrics {
+  type: ContentFilterType;
+  raw_chars: number;
+  fit_chars: number;
+  reduction_ratio: number;
+  sections_seen: number;
+  sections_kept: number;
+  query?: string;
+}
+
+export interface ContentFilterResult {
+  content: string;
+  raw_markdown?: string;
+  fit_markdown?: string;
+  filter: ContentFilterMetrics;
+}
+
+interface Section {
+  index: number;
+  text: string;
+  headingDepth: number;
+  words: number;
+  score: number;
+}
+
+export function parseContentFilterType(value: unknown): ContentFilterType {
+  return value === 'prune' || value === 'bm25' ? value : 'none';
+}
+
+export function applyContentFilter(markdown: string, options: ContentFilterOptions = {}): ContentFilterResult {
+  const type = options.type ?? 'none';
+  const sections = splitSections(markdown);
+  const maxSections = clampInt(options.maxSections, 80, 1, 500);
+  const minWords = clampInt(options.minWords, 5, 0, 100);
+  const query = (options.query || '').trim();
+
+  if (type === 'bm25' && !query) {
+    throw new Error('content_filter="bm25" requires a non-empty query');
+  }
+
+  const kept = type === 'none'
+    ? sections
+    : rankSections(sections, { type, query, minWords, maxSections, bm25Threshold: options.bm25Threshold, pruneThreshold: options.pruneThreshold });
+  const fit = kept.map(section => section.text.trim()).filter(Boolean).join('\n\n').trim();
+  const content = type !== 'none' && options.returnFit !== false ? fit : markdown;
+  const metrics: ContentFilterMetrics = {
+    type,
+    raw_chars: markdown.length,
+    fit_chars: fit.length,
+    reduction_ratio: markdown.length > 0 ? roundRatio(1 - fit.length / markdown.length) : 0,
+    sections_seen: sections.length,
+    sections_kept: kept.length,
+    ...(query ? { query } : {}),
+  };
+
+  return {
+    content,
+    ...(options.returnRaw ? { raw_markdown: markdown } : {}),
+    ...(type !== 'none' && options.returnFit !== false ? { fit_markdown: fit } : {}),
+    filter: metrics,
+  };
+}
+
+function rankSections(
+  sections: Section[],
+  opts: { type: ContentFilterType; query: string; minWords: number; maxSections: number; bm25Threshold?: number; pruneThreshold?: number },
+): Section[] {
+  const terms = tokenize(opts.query);
+  const scored = sections.map(section => ({ ...section, score: opts.type === 'bm25' ? bm25Score(section, terms, sections) : pruneScore(section) }));
+  const threshold = opts.type === 'bm25' ? (opts.bm25Threshold ?? 0) : (opts.pruneThreshold ?? 0.15);
+  const alwaysKeep = scored.filter(section => section.index === 0 || section.headingDepth === 1);
+  const selected = scored
+    .filter(section => section.words >= opts.minWords || section.headingDepth > 0 || isCodeOrTable(section.text))
+    .filter(section => section.score >= threshold || isCodeOrTable(section.text))
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .slice(0, opts.maxSections);
+  const byIndex = new Map<number, Section>();
+  for (const section of [...alwaysKeep, ...selected]) byIndex.set(section.index, section);
+  return Array.from(byIndex.values()).sort((a, b) => a.index - b.index);
+}
+
+function splitSections(markdown: string): Section[] {
+  const blocks: string[] = [];
+  let current: string[] = [];
+  let inFence = false;
+  for (const line of markdown.split('\n')) {
+    if (line.trim().startsWith('```')) inFence = !inFence;
+    if (!inFence && line.trim() === '') {
+      if (current.length) blocks.push(current.join('\n'));
+      current = [];
+      continue;
+    }
+    if (!inFence && /^#{1,6}\s+/.test(line) && current.length) {
+      blocks.push(current.join('\n'));
+      current = [];
+    }
+    current.push(line);
+  }
+  if (current.length) blocks.push(current.join('\n'));
+  return blocks.map((text, index) => ({ index, text, headingDepth: headingDepth(text), words: tokenize(text).length, score: 0 }));
+}
+
+function pruneScore(section: Section): number {
+  if (isCodeOrTable(section.text)) return 0.9;
+  const text = section.text.toLowerCase();
+  const navPenalty = /\b(home|login|sign up|subscribe|cookie|privacy policy|terms|advertis|sidebar|footer|navigation)\b/.test(text) ? 0.35 : 0;
+  const linkCount = (section.text.match(/\]\(/g) || []).length;
+  const linkPenalty = Math.min(0.3, linkCount * 0.05);
+  const density = Math.min(0.7, section.words / 30);
+  const headingBoost = section.headingDepth > 0 ? 0.15 : 0;
+  return Math.max(0, density + headingBoost - navPenalty - linkPenalty);
+}
+
+function bm25Score(section: Section, terms: string[], all: Section[]): number {
+  if (terms.length === 0) return 0;
+  const tokens = tokenize(section.text);
+  const avgLen = all.reduce((sum, item) => sum + Math.max(1, item.words), 0) / Math.max(1, all.length);
+  let score = section.headingDepth > 0 ? 0.25 : 0;
+  for (const term of terms) {
+    const tf = tokens.filter(token => token === term).length;
+    if (!tf) continue;
+    const df = all.filter(item => tokenize(item.text).includes(term)).length || 1;
+    const idf = Math.log(1 + (all.length - df + 0.5) / (df + 0.5));
+    score += idf * ((tf * 2.2) / (tf + 1.2 * (0.25 + 0.75 * (tokens.length / Math.max(1, avgLen)))));
+  }
+  return score;
+}
+
+function tokenize(text: string): string[] {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, ' ').split(/\s+/).filter(token => token.length >= 2);
+}
+
+function headingDepth(text: string): number {
+  const match = text.match(/^(#{1,6})\s+/);
+  return match ? match[1].length : 0;
+}
+
+function isCodeOrTable(text: string): boolean {
+  return text.trim().startsWith('```') || /^\|.+\|/m.test(text);
+}
+
+function clampInt(value: unknown, fallback: number, min: number, max: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  return Math.max(min, Math.min(max, Math.floor(value)));
+}
+
+function roundRatio(value: number): number {
+  return Math.max(0, Math.min(1, Math.round(value * 1000) / 1000));
+}

--- a/src/tools/crawl-sitemap.ts
+++ b/src/tools/crawl-sitemap.ts
@@ -29,6 +29,7 @@ import {
 } from '../utils/static-fetch';
 import { buildTextMetrics } from '../core/metrics/token-estimate';
 import { extractMainContent, toMarkdown } from '../core/extract/html-to-markdown';
+import { applyContentFilter, ContentFilterMetrics, parseContentFilterType, ContentFilterType } from '../core/extract/content-filter';
 import { sanitizeContent } from '../security/content-sanitizer';
 import { getGlobalConfig } from '../config/global';
 
@@ -67,6 +68,23 @@ const definition: MCPToolDefinition = {
       includeLinks: {
         type: 'boolean',
         description: 'markdown-clean only: preserve <a> as markdown links. Default: true.',
+      },
+      query: {
+        type: 'string',
+        description: 'markdown-clean content_filter="bm25" query terms.',
+      },
+      content_filter: {
+        type: 'string',
+        enum: ['none', 'prune', 'bm25'],
+        description: 'markdown-clean only: deterministic fit_markdown filter. Default: none.',
+      },
+      return_raw: {
+        type: 'boolean',
+        description: 'markdown-clean only: include raw_markdown in each page. Default: false.',
+      },
+      return_fit: {
+        type: 'boolean',
+        description: 'markdown-clean only: include fit_markdown and use it as content when filtering. Default: true when filtered.',
       },
       concurrency: {
         type: 'number',
@@ -121,6 +139,9 @@ interface CrawledPage {
   url: string;
   title: string;
   content: string;
+  raw_markdown?: string;
+  fit_markdown?: string;
+  filter?: ContentFilterMetrics;
   links_found: number;
   error?: string;
   engine_used?: 'static' | 'cdp';
@@ -270,8 +291,8 @@ async function resolveSitemapPageUrls(
 
 function cleanMarkdownFromHtml(
   html: string,
-  cleanOpts: { onlyMainContent: boolean; includeLinks: boolean },
-): string {
+  cleanOpts: { onlyMainContent: boolean; includeLinks: boolean; contentFilter?: ContentFilterType; query?: string; returnRaw?: boolean; returnFit?: boolean },
+): { content: string; raw_markdown?: string; fit_markdown?: string; filter?: ContentFilterMetrics } {
   const { html: cleaned } = extractMainContent(html, { onlyMainContent: cleanOpts.onlyMainContent });
   let cleanMd = toMarkdown(cleaned, { includeLinks: cleanOpts.includeLinks });
   const cfg = getGlobalConfig();
@@ -279,7 +300,16 @@ function cleanMarkdownFromHtml(
     const sanitized = sanitizeContent(cleanMd);
     cleanMd = sanitized.text + sanitized.sanitizationNote;
   }
-  return cleanMd;
+  const filterType = cleanOpts.contentFilter ?? 'none';
+  if (filterType !== 'none' || cleanOpts.returnRaw || cleanOpts.returnFit === true) {
+    return applyContentFilter(cleanMd, {
+      type: filterType,
+      query: cleanOpts.query,
+      returnRaw: cleanOpts.returnRaw,
+      returnFit: cleanOpts.returnFit !== false,
+    });
+  }
+  return { content: cleanMd };
 }
 
 function staticBuildContent(html: string): { title: string; content: string } {
@@ -318,7 +348,7 @@ function staticCountLinks(html: string, baseUrl: string): number {
 async function fetchPageStatic(
   url: string,
   outputFormat: string,
-  cleanOpts: { onlyMainContent: boolean; includeLinks: boolean },
+  cleanOpts: { onlyMainContent: boolean; includeLinks: boolean; contentFilter?: ContentFilterType; query?: string; returnRaw?: boolean; returnFit?: boolean },
   context?: ToolContext,
 ): Promise<
   | { ok: true; page: CrawledPage }
@@ -335,6 +365,7 @@ async function fetchPageStatic(
 
     let title = '';
     let content = '';
+    let cleanExtra: { raw_markdown?: string; fit_markdown?: string; filter?: ContentFilterMetrics } = {};
     if (outputFormat === 'structured') {
       const titleMatch = html.match(/<title\b[^>]*>([\s\S]*?)<\/title\s*>/i);
       title = titleMatch ? titleMatch[1].trim() : '';
@@ -343,7 +374,15 @@ async function fetchPageStatic(
     } else if (outputFormat === 'markdown-clean') {
       const titleMatch = html.match(/<title\b[^>]*>([\s\S]*?)<\/title\s*>/i);
       title = titleMatch ? titleMatch[1].trim() : '';
-      content = cleanMarkdownFromHtml(html, cleanOpts);
+      {
+        const cleanResult = cleanMarkdownFromHtml(html, cleanOpts);
+        content = cleanResult.content;
+        cleanExtra = {
+          ...(cleanResult.raw_markdown ? { raw_markdown: cleanResult.raw_markdown } : {}),
+          ...(cleanResult.fit_markdown ? { fit_markdown: cleanResult.fit_markdown } : {}),
+          ...(cleanResult.filter ? { filter: cleanResult.filter } : {}),
+        };
+      }
     } else {
       const built = staticBuildContent(html);
       title = built.title;
@@ -360,6 +399,7 @@ async function fetchPageStatic(
         url,
         title,
         content,
+        ...cleanExtra,
         links_found: staticCountLinks(html, finalUrl),
       },
     };
@@ -382,7 +422,7 @@ async function fetchPage(
   sessionId: string,
   url: string,
   outputFormat: string,
-  cleanOpts: { onlyMainContent: boolean; includeLinks: boolean },
+  cleanOpts: { onlyMainContent: boolean; includeLinks: boolean; contentFilter?: ContentFilterType; query?: string; returnRaw?: boolean; returnFit?: boolean },
   context?: ToolContext,
 ): Promise<CrawledPage> {
   const sessionManager = getSessionManager();
@@ -421,7 +461,8 @@ async function fetchPage(
       await sessionManager.closeTarget(sessionId, tid);
       targetId = null;
 
-      let cleanMd = cleanMarkdownFromHtml(fullHtml, cleanOpts);
+      const cleanResult = cleanMarkdownFromHtml(fullHtml, cleanOpts);
+      let cleanMd = cleanResult.content;
       if (cleanMd.length > MAX_OUTPUT_CHARS) {
         cleanMd = cleanMd.slice(0, MAX_OUTPUT_CHARS) + '...[truncated]';
       }
@@ -429,6 +470,9 @@ async function fetchPage(
         url,
         title: linkResult.title,
         content: cleanMd,
+        ...(cleanResult.raw_markdown ? { raw_markdown: cleanResult.raw_markdown } : {}),
+        ...(cleanResult.fit_markdown ? { fit_markdown: cleanResult.fit_markdown } : {}),
+        ...(cleanResult.filter ? { filter: cleanResult.filter } : {}),
         links_found: linkResult.linksCount,
       };
     }
@@ -582,6 +626,10 @@ const handler: ToolHandler = async (
   const cleanOpts = {
     onlyMainContent: args.onlyMainContent !== false,
     includeLinks: args.includeLinks !== false,
+    contentFilter: parseContentFilterType(args.content_filter),
+    query: args.query as string | undefined,
+    returnRaw: args.return_raw === true,
+    returnFit: args.return_fit !== false,
   };
   const concurrency = args.concurrency != null ? Math.max(1, Math.min(10, Number(args.concurrency))) : 3;
 

--- a/src/tools/crawl.ts
+++ b/src/tools/crawl.ts
@@ -32,6 +32,7 @@ import {
 import { buildTextMetrics } from '../core/metrics/token-estimate';
 import { buildUrlScoreOptions, scoreUrl, UrlScoreOptions } from '../core/crawl/url-scorer';
 import { extractMainContent, toMarkdown } from '../core/extract/html-to-markdown';
+import { applyContentFilter, ContentFilterMetrics, parseContentFilterType, ContentFilterType } from '../core/extract/content-filter';
 import { sanitizeContent } from '../security/content-sanitizer';
 import { getGlobalConfig } from '../config/global';
 import { AdaptiveCrawlDispatcher, DispatcherMode, parseAdaptiveDispatcherOptions } from '../core/crawl/dispatcher';
@@ -82,6 +83,19 @@ const definition: MCPToolDefinition = {
       includeLinks: {
         type: 'boolean',
         description: 'markdown-clean only: preserve <a> as markdown links. Default: true.',
+      },
+      content_filter: {
+        type: 'string',
+        enum: ['none', 'prune', 'bm25'],
+        description: 'markdown-clean only: deterministic fit_markdown filter. Default: none.',
+      },
+      return_raw: {
+        type: 'boolean',
+        description: 'markdown-clean only: include raw_markdown in each page. Default: false.',
+      },
+      return_fit: {
+        type: 'boolean',
+        description: 'markdown-clean only: include fit_markdown and use it as content when filtering. Default: true when filtered.',
       },
       respect_robots: {
         type: 'boolean',
@@ -172,6 +186,9 @@ interface CrawledPage {
   url: string;
   title: string;
   content: string;
+  raw_markdown?: string;
+  fit_markdown?: string;
+  filter?: ContentFilterMetrics;
   depth: number;
   links_found: number;
   error?: string;
@@ -246,8 +263,8 @@ async function fetchRobotsTxt(
 
 function cleanMarkdownFromHtml(
   html: string,
-  cleanOpts: { onlyMainContent: boolean; includeLinks: boolean },
-): string {
+  cleanOpts: { onlyMainContent: boolean; includeLinks: boolean; contentFilter?: ContentFilterType; query?: string; returnRaw?: boolean; returnFit?: boolean },
+): { content: string; raw_markdown?: string; fit_markdown?: string; filter?: ContentFilterMetrics } {
   const { html: cleaned } = extractMainContent(html, { onlyMainContent: cleanOpts.onlyMainContent });
   let cleanMd = toMarkdown(cleaned, { includeLinks: cleanOpts.includeLinks });
   const cfg = getGlobalConfig();
@@ -255,7 +272,16 @@ function cleanMarkdownFromHtml(
     const sanitized = sanitizeContent(cleanMd);
     cleanMd = sanitized.text + sanitized.sanitizationNote;
   }
-  return cleanMd;
+  const filterType = cleanOpts.contentFilter ?? 'none';
+  if (filterType !== 'none' || cleanOpts.returnRaw || cleanOpts.returnFit === true) {
+    return applyContentFilter(cleanMd, {
+      type: filterType,
+      query: cleanOpts.query,
+      returnRaw: cleanOpts.returnRaw,
+      returnFit: cleanOpts.returnFit !== false,
+    });
+  }
+  return { content: cleanMd };
 }
 
 function buildMarkdownFromHtml(html: string): { title: string; content: string } {
@@ -295,7 +321,7 @@ async function fetchPageStatic(
   url: string,
   depth: number,
   outputFormat: string,
-  cleanOpts: { onlyMainContent: boolean; includeLinks: boolean },
+  cleanOpts: { onlyMainContent: boolean; includeLinks: boolean; contentFilter?: ContentFilterType; query?: string; returnRaw?: boolean; returnFit?: boolean },
   context?: ToolContext,
 ): Promise<
   | { ok: true; page: CrawledPage & { _links?: string[] } }
@@ -314,6 +340,7 @@ async function fetchPageStatic(
 
     let title = '';
     let content = '';
+    let cleanExtra: { raw_markdown?: string; fit_markdown?: string; filter?: ContentFilterMetrics } = {};
     if (outputFormat === 'structured') {
       const titleMatch = html.match(/<title\b[^>]*>([\s\S]*?)<\/title\s*>/i);
       title = titleMatch ? titleMatch[1].trim() : '';
@@ -322,7 +349,15 @@ async function fetchPageStatic(
     } else if (outputFormat === 'markdown-clean') {
       const titleMatch = html.match(/<title\b[^>]*>([\s\S]*?)<\/title\s*>/i);
       title = titleMatch ? titleMatch[1].trim() : '';
-      content = cleanMarkdownFromHtml(html, cleanOpts);
+      {
+        const cleanResult = cleanMarkdownFromHtml(html, cleanOpts);
+        content = cleanResult.content;
+        cleanExtra = {
+          ...(cleanResult.raw_markdown ? { raw_markdown: cleanResult.raw_markdown } : {}),
+          ...(cleanResult.fit_markdown ? { fit_markdown: cleanResult.fit_markdown } : {}),
+          ...(cleanResult.filter ? { filter: cleanResult.filter } : {}),
+        };
+      }
     } else {
       const built = buildMarkdownFromHtml(html);
       title = built.title;
@@ -339,6 +374,7 @@ async function fetchPageStatic(
         url,
         title,
         content,
+        ...cleanExtra,
         depth,
         links_found: links.length,
         ...(links.length > 0 ? { _links: links } : {}),
@@ -393,7 +429,7 @@ async function fetchPage(
   url: string,
   depth: number,
   outputFormat: string,
-  cleanOpts: { onlyMainContent: boolean; includeLinks: boolean },
+  cleanOpts: { onlyMainContent: boolean; includeLinks: boolean; contentFilter?: ContentFilterType; query?: string; returnRaw?: boolean; returnFit?: boolean },
   context?: ToolContext,
 ): Promise<CrawledPage> {
   const sessionManager = getSessionManager();
@@ -440,7 +476,8 @@ async function fetchPage(
       await sessionManager.closeTarget(sessionId, tid);
       targetId = null;
 
-      let cleanMd = cleanMarkdownFromHtml(fullHtml, cleanOpts);
+      const cleanResult = cleanMarkdownFromHtml(fullHtml, cleanOpts);
+      let cleanMd = cleanResult.content;
       if (cleanMd.length > MAX_OUTPUT_CHARS) {
         cleanMd = cleanMd.slice(0, MAX_OUTPUT_CHARS) + '...[truncated]';
       }
@@ -448,6 +485,9 @@ async function fetchPage(
         url,
         title: linkResult.title,
         content: cleanMd,
+        ...(cleanResult.raw_markdown ? { raw_markdown: cleanResult.raw_markdown } : {}),
+        ...(cleanResult.fit_markdown ? { fit_markdown: cleanResult.fit_markdown } : {}),
+        ...(cleanResult.filter ? { filter: cleanResult.filter } : {}),
         depth,
         links_found: linkResult.links.length,
         ...(linkResult.links.length > 0 ? { _links: linkResult.links } as Record<string, unknown> : {}),
@@ -615,6 +655,10 @@ const handler: ToolHandler = async (
   const cleanOpts = {
     onlyMainContent: args.onlyMainContent !== false,
     includeLinks: args.includeLinks !== false,
+    contentFilter: parseContentFilterType(args.content_filter),
+    query: args.query as string | undefined,
+    returnRaw: args.return_raw === true,
+    returnFit: args.return_fit !== false,
   };
   const respectRobots = args.respect_robots !== false;
   const delayMs = args.delay_ms != null ? Number(args.delay_ms) : 1000;

--- a/src/tools/read-page.ts
+++ b/src/tools/read-page.ts
@@ -16,6 +16,7 @@ import { sanitizeContent } from '../security/content-sanitizer';
 import { appendMetricsFooter, buildTextMetrics } from '../core/metrics/token-estimate';
 import { getGlobalConfig } from '../config/global';
 import { extractMainContent, toMarkdown } from '../core/extract/html-to-markdown';
+import { applyContentFilter, parseContentFilterType } from '../core/extract/content-filter';
 import { getCurrentLoaderId, mintNodeRefSync } from '../core/perception/node-ref';
 import { isStateHeaderEnabled, mergeHeaderJson, prependHeaderText } from './_shared/state-header';
 
@@ -122,6 +123,27 @@ const definition: MCPToolDefinition = {
       includeLinks: {
         type: 'boolean',
         description: 'Markdown mode only: preserve <a> as markdown links. Default: true.',
+      },
+      contentFilter: {
+        type: 'string',
+        enum: ['none', 'prune', 'bm25'],
+        description: 'Markdown mode only: deterministic fit_markdown filter. Default: none.',
+      },
+      query: {
+        type: 'string',
+        description: 'Markdown mode only: required when contentFilter="bm25".',
+      },
+      returnRaw: {
+        type: 'boolean',
+        description: 'Markdown mode only: include raw_markdown in JSON response. Default: false.',
+      },
+      returnFit: {
+        type: 'boolean',
+        description: 'Markdown mode only: include fit_markdown and use it as content when filtering. Default: true when filtered.',
+      },
+      filterOptions: {
+        type: 'object',
+        description: 'Markdown mode only: minWords, maxSections, bm25Threshold, pruneThreshold.',
       },
       includePagination: {
         type: 'boolean',
@@ -352,6 +374,10 @@ const handler: ToolHandler = async (
       const onlyMainContent = args.onlyMainContent !== false;
       const includeLinks = args.includeLinks !== false;
       const includePaginationMarkdown = args.includePagination !== false;
+      const contentFilter = parseContentFilterType(args.contentFilter);
+      const returnRaw = args.returnRaw === true;
+      const returnFit = args.returnFit !== false;
+      const filterOptions = (args.filterOptions && typeof args.filterOptions === 'object') ? args.filterOptions as Record<string, unknown> : {};
       const refIdNote = args.ref_id
         ? '[Note: ref_id is not supported in markdown mode — full-page content returned. Use mode "ax" for ref_id subtree scoping.]\n\n'
         : '';
@@ -375,8 +401,28 @@ const handler: ToolHandler = async (
         truncated = true;
       }
       const suffix = truncated ? '\n\n[Output truncated — exceeded MAX_OUTPUT_CHARS]' : '';
+      const rawMarkdown = md + suffix;
+      if (contentFilter !== 'none' || returnRaw || args.returnFit === true) {
+        try {
+          const filtered = applyContentFilter(rawMarkdown, {
+            type: contentFilter,
+            query: args.query as string | undefined,
+            returnRaw,
+            returnFit,
+            minWords: filterOptions.minWords as number | undefined,
+            maxSections: filterOptions.maxSections as number | undefined,
+            bm25Threshold: filterOptions.bm25Threshold as number | undefined,
+            pruneThreshold: filterOptions.pruneThreshold as number | undefined,
+          });
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ ...filtered, content: withTextMetrics(filtered.content, 'markdown', truncated) }) }],
+          };
+        } catch (error) {
+          return { content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+        }
+      }
       return {
-        content: [{ type: 'text', text: withTextMetrics(md + suffix, 'markdown', truncated) }],
+        content: [{ type: 'text', text: withTextMetrics(rawMarkdown, 'markdown', truncated) }],
       };
     }
 

--- a/tests/core/extract/content-filter.test.ts
+++ b/tests/core/extract/content-filter.test.ts
@@ -1,0 +1,53 @@
+import { applyContentFilter } from '../../../src/core/extract/content-filter';
+
+describe('fit_markdown content filter', () => {
+  const fixture = [
+    '# Product Docs',
+    '',
+    'Home Login Subscribe Cookie settings Privacy Policy Terms',
+    '',
+    '## Enterprise Pricing',
+    '',
+    'Enterprise pricing includes annual discounts, support, and SSO.',
+    '',
+    '## API Example',
+    '',
+    '```ts\nconst price = "enterprise";\n```',
+    '',
+    '| Plan | Price |\n| --- | --- |\n| Enterprise | Contact us |',
+    '',
+    'Footer navigation and advertising links.',
+  ].join('\n');
+
+  it('prunes boilerplate while preserving headings, paragraphs, code, and tables', () => {
+    const result = applyContentFilter(fixture, { type: 'prune', returnRaw: true, returnFit: true });
+
+    expect(result.raw_markdown).toBe(fixture);
+    expect(result.fit_markdown).toContain('# Product Docs');
+    expect(result.fit_markdown).toContain('Enterprise pricing');
+    expect(result.fit_markdown).toContain('```ts');
+    expect(result.fit_markdown).toContain('| Enterprise | Contact us |');
+    expect(result.fit_markdown).not.toContain('Cookie settings');
+    expect(result.filter.type).toBe('prune');
+    expect(result.filter.raw_chars).toBe(fixture.length);
+    expect(result.filter.fit_chars).toBe(result.fit_markdown!.length);
+    expect(result.filter.reduction_ratio).toBeGreaterThan(0);
+  });
+
+  it('bm25 keeps query-relevant sections and rejects missing query', () => {
+    const result = applyContentFilter(fixture, { type: 'bm25', query: 'enterprise pricing support', maxSections: 3 });
+
+    expect(result.content).toContain('Enterprise Pricing');
+    expect(result.filter.query).toBe('enterprise pricing support');
+    expect(() => applyContentFilter(fixture, { type: 'bm25' })).toThrow('requires a non-empty query');
+  });
+
+  it('content_filter none preserves raw content and omits fit markdown unless filtered', () => {
+    const result = applyContentFilter(fixture, { type: 'none', returnRaw: true, returnFit: true });
+
+    expect(result.content).toBe(fixture);
+    expect(result.raw_markdown).toBe(fixture);
+    expect(result.fit_markdown).toBeUndefined();
+    expect(result.filter.type).toBe('none');
+  });
+});

--- a/tests/tools/read-page.test.ts
+++ b/tests/tools/read-page.test.ts
@@ -620,6 +620,55 @@ describe('ReadPageTool', () => {
       expect(text).toContain('Pages: 1 / 3');
     });
 
+
+
+    test('markdown contentFilter=prune returns raw and fit markdown with metrics', async () => {
+      const handler = await getReadPageHandler();
+      const page = mockSessionManager.pages.get(testTargetId);
+      (page!.content as jest.Mock).mockResolvedValue(`
+        <main>
+          <h1>Article</h1>
+          <p>Home Login Cookie settings Privacy Policy</p>
+          <p>Enterprise pricing includes annual discounts and support.</p>
+          <table><tr><th>Plan</th><th>Price</th></tr><tr><td>Enterprise</td><td>Contact us</td></tr></table>
+        </main>
+      `);
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        mode: 'markdown',
+        contentFilter: 'prune',
+        returnRaw: true,
+        returnFit: true,
+        includePagination: false,
+      }) as { content: Array<{ type: string; text: string }> };
+      const jsonStart = result.content[0].text.indexOf('{');
+      const body = JSON.parse(result.content[0].text.slice(jsonStart));
+
+      expect(body.content).toContain('Enterprise pricing');
+      expect(body.raw_markdown).toContain('Cookie settings');
+      expect(body.fit_markdown).toContain('Enterprise pricing');
+      expect(body.fit_markdown).not.toContain('Cookie settings');
+      expect(body.filter.type).toBe('prune');
+      expect(body.filter.raw_chars).toBeGreaterThan(body.filter.fit_chars);
+    });
+
+    test('markdown contentFilter=bm25 requires query', async () => {
+      const handler = await getReadPageHandler();
+      const page = mockSessionManager.pages.get(testTargetId);
+      (page!.content as jest.Mock).mockResolvedValue('<main><h1>Article</h1></main>');
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        mode: 'markdown',
+        contentFilter: 'bm25',
+        includePagination: false,
+      }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('requires a non-empty query');
+    });
+
     test('can suppress markdown pagination metadata', async () => {
       const handler = await getReadPageHandler();
       const page = mockSessionManager.pages.get(testTargetId)!;


### PR DESCRIPTION
## Summary
- adds deterministic `content_filter: none|prune|bm25` / `contentFilter` fit_markdown filtering
- wires filtering into `read_page(mode="markdown")`, `crawl(output_format="markdown-clean")`, and `crawl_sitemap(output_format="markdown-clean")`
- preserves default behavior when filtering/return flags are not requested
- returns `raw_markdown`, `fit_markdown`, and `filter` metrics when requested/filtered
- requires a non-empty query for BM25 filtering

Closes #980

## Verification
- `npm ci`
- `npm test -- tests/core/extract/content-filter.test.ts tests/tools/read-page.test.ts --runInBand`
- `npm test -- tests/core/tools/crawl.engine.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint -- --quiet`
- `git diff --check`

## Notes
- No LLM/provider dependency and no new runtime dependency.
- Live OpenChrome verification against Wikipedia/Crawl4AI from the issue checklist was not run in this worktree.
