### PR TITLE
feat(orchestration): strengthen safe plan contracts

### DIFF
--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -11,6 +11,7 @@ model composes them into prose.
 | [multi-source-news-digest.md](multi-source-news-digest.md) | Pull headlines from several news sources and produce a one-screen daily digest. | `navigate`, `read_page`, `crawl` |
 | [docs-changelog-diff.md](docs-changelog-diff.md) | Compare two snapshots of a docs page (e.g. before/after a release) and explain what changed. | `navigate`, `read_page` |
 | [competitive-feature-matrix.md](competitive-feature-matrix.md) | Build a structured feature-matrix table across several vendor pages. | `navigate`, `extract_data`, `read_page` |
+| [safe-plan-contract.md](safe-plan-contract.md) | Run reusable compiled browser workflows with v2 allow-list validation and bounded execution evidence. | `execute_plan` |
 
 ## How recipes are structured
 

--- a/docs/recipes/safe-plan-contract.md
+++ b/docs/recipes/safe-plan-contract.md
@@ -1,0 +1,69 @@
+# Safe plan contract
+
+Use compiled plans for repeatable browser workflows only when the plan can prove
+its execution boundary before any tool runs. Safe plans opt into the v2 contract
+with `contractVersion: 2`.
+
+## Goal
+
+Run a reusable browser workflow through `execute_plan` while preserving a clear
+tool allow-list, bounded recovery, deterministic success criteria, and step
+evidence for review.
+
+## Inputs
+
+- A registry plan whose compiled JSON includes:
+  - `contractVersion: 2`
+  - non-empty `allowedTools`
+  - explicit `successCriteria`
+  - positive `timeout` on every plan and recovery step
+- Runtime `params` required by the plan templates.
+- Optional `taskSignature` when the host also wants deterministic runtime budget
+  and loop guards.
+
+## Safe contract fields
+
+```json
+{
+  "contractVersion": 2,
+  "allowedTools": ["navigate", "read_page", "extract_data"],
+  "steps": [
+    {
+      "order": 1,
+      "tool": "navigate",
+      "args": { "tabId": "${tabId}", "url": "${targetUrl}" },
+      "timeout": 10000,
+      "risk": "interactive"
+    }
+  ],
+  "errorHandlers": [],
+  "successCriteria": { "requiredFields": ["targetUrl"] }
+}
+```
+
+`risk` is descriptive metadata for reviewers. Enforcement is based on the
+allow-list, handler existence, timeouts, bounded recovery steps, and template
+syntax.
+
+## Plan
+
+1. Store the compiled plan through the plan registry.
+2. Call `execute_plan` with `planId`, `tabId`, and required `params`.
+3. If the v2 contract is invalid, execution fails before the first tool call.
+4. Inspect the response `evidence` array:
+   - `source: "plan"` for primary steps
+   - `source: "recovery"` for recovery-handler steps
+   - `outcome: "success" | "error" | "empty"`
+
+## Verification
+
+Safe plans reject:
+
+- unknown tools
+- tools not present in `allowedTools`
+- missing or non-positive step timeouts
+- malformed `${param}` substitutions
+- missing `successCriteria`
+- recovery handlers with more than 10 steps
+
+Legacy plans without `contractVersion: 2` keep the previous compatibility path.

--- a/src/orchestration/plan-executor.ts
+++ b/src/orchestration/plan-executor.ts
@@ -13,12 +13,82 @@ import {
   PlanExecutionOptions,
   PlanExecutionResult,
   PlanFinalVerificationResult,
+  PlanStepEvidence,
 } from '../types/plan-cache';
 import { evaluate } from '../contracts/evaluate';
 import type { EvalContext, NetworkLogEntry } from '../contracts/eval-context';
 import { evaluateTaskSignature, preflightAllowedTools } from '../contracts/task-signature';
 import type { TaskSignatureToolCallSummary } from '../contracts/task-signature';
 import { withTimeout } from '../utils/with-timeout';
+
+const SAFE_CONTRACT_MAX_RECOVERY_STEPS = 10;
+
+function isSafeContractPlan(plan: CompiledPlan): boolean {
+  return plan.contractVersion === 2 || Array.isArray(plan.allowedTools);
+}
+
+function validateCompiledPlanContract(plan: CompiledPlan, toolResolver: (toolName: string) => ToolHandler | null): string | null {
+  if (!isSafeContractPlan(plan)) return null;
+  const allowedTools = new Set(plan.allowedTools || []);
+  const allSteps = [
+    ...plan.steps.map(step => ({ step, source: 'plan' })),
+    ...plan.errorHandlers.flatMap(handler => handler.steps.map(step => ({ step, source: `errorHandler:${handler.condition}` }))),
+  ];
+
+  if (plan.allowedTools && plan.allowedTools.length === 0) return 'allowedTools must not be empty for safe contract plans';
+  if (!plan.successCriteria || Object.keys(plan.successCriteria).length === 0) {
+    return 'safe contract plans require explicit successCriteria';
+  }
+
+  for (const { step, source } of allSteps) {
+    if (!toolResolver(step.tool)) {
+      return `unknown tool "${step.tool}" in ${source}`;
+    }
+    if (allowedTools.size > 0 && !allowedTools.has(step.tool)) {
+      return `tool "${step.tool}" in ${source} is not in allowedTools`;
+    }
+    if (typeof step.timeout !== 'number' || !Number.isFinite(step.timeout) || step.timeout <= 0) {
+      return `step ${step.order} in ${source} is missing a positive timeout`;
+    }
+    const badTemplate = findMalformedTemplate(step.args);
+    if (badTemplate) return `malformed substitution "${badTemplate}" in step ${step.order}`;
+  }
+
+  for (const handler of plan.errorHandlers) {
+    if (handler.steps.length > SAFE_CONTRACT_MAX_RECOVERY_STEPS) {
+      return `recovery handler "${handler.condition}" exceeds ${SAFE_CONTRACT_MAX_RECOVERY_STEPS} steps`;
+    }
+  }
+
+  return null;
+}
+
+function findMalformedTemplate(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const matches = value.match(/\$\{[^}]*\}?/g) || [];
+    for (const match of matches) {
+      if (!/^\$\{[A-Za-z_][A-Za-z0-9_]*\}$/.test(match)) return match;
+    }
+    return null;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const bad = findMalformedTemplate(item);
+      if (bad) return bad;
+    }
+  } else if (value !== null && typeof value === 'object') {
+    for (const item of Object.values(value as Record<string, unknown>)) {
+      const bad = findMalformedTemplate(item);
+      if (bad) return bad;
+    }
+  }
+  return null;
+}
+
+function summarizeMcpResult(mcpResult: MCPResult): string {
+  const text = mcpResult.content?.[0]?.text || '';
+  return text.replace(/\s+/g, ' ').trim().slice(0, 240);
+}
 
 interface SnapshotInput {
   url?: string;
@@ -251,6 +321,20 @@ export class PlanExecutor {
     const startTime = Date.now();
     let stepsExecuted = 0;
     const recentTools: TaskSignatureToolCallSummary[] = [];
+    const evidence: PlanStepEvidence[] = [];
+
+    const contractError = validateCompiledPlanContract(plan, this.toolResolver);
+    if (contractError) {
+      return {
+        success: false,
+        planId: plan.id,
+        error: `Plan contract validation failed: ${contractError}`,
+        durationMs: Date.now() - startTime,
+        stepsExecuted,
+        totalSteps: plan.steps.length,
+        evidence,
+      };
+    }
 
     if (options.taskSignature) {
       const preflight = preflightAllowedTools(
@@ -270,6 +354,7 @@ export class PlanExecutor {
           durationMs: Date.now() - startTime,
           stepsExecuted,
           totalSteps: plan.steps.length,
+          evidence,
           taskSignature: preflight,
         };
       }
@@ -291,6 +376,7 @@ export class PlanExecutor {
       durationMs: Date.now() - startTime,
       stepsExecuted,
       totalSteps: plan.steps.length,
+      evidence,
       ...(taskSignature ? { taskSignature } : {}),
     });
 
@@ -311,6 +397,7 @@ export class PlanExecutor {
 
       // c. Call handler with timeout
       let mcpResult: MCPResult;
+      const stepStart = Date.now();
       try {
         mcpResult = await withTimeout(
           handler(sessionId, substitutedArgs),
@@ -318,7 +405,16 @@ export class PlanExecutor {
           stepLabel
         );
         stepsExecuted++;
-        recentTools.push({ tool: step.tool, progressed: !isEmptyResult(mcpResult) && !mcpResult.isError });
+        const empty = isEmptyResult(mcpResult);
+        evidence.push({
+          step: step.order,
+          tool: step.tool,
+          source: 'plan',
+          outcome: mcpResult.isError ? 'error' : empty ? 'empty' : 'success',
+          durationMs: Date.now() - stepStart,
+          summary: summarizeMcpResult(mcpResult),
+        });
+        recentTools.push({ tool: step.tool, progressed: !empty && !mcpResult.isError });
         if (options.taskSignature) {
           const taskStatus = await evaluateTaskSignature({
             signature: options.taskSignature,
@@ -335,6 +431,7 @@ export class PlanExecutor {
               stepsExecuted,
               totalSteps: plan.steps.length,
               taskSignature: taskStatus,
+              evidence,
             };
           }
           if (taskStatus.status !== 'continue') {
@@ -343,6 +440,14 @@ export class PlanExecutor {
         }
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err);
+        evidence.push({
+          step: step.order,
+          tool: step.tool,
+          source: 'plan',
+          outcome: 'error',
+          durationMs: Date.now() - stepStart,
+          summary: errMsg.slice(0, 240),
+        });
         console.error(`[PlanExecutor] Step failed at ${stepLabel}: ${errMsg}`);
 
         // Check for a matching error handler
@@ -352,7 +457,8 @@ export class PlanExecutor {
           plan.errorHandlers,
           sessionId,
           params,
-          stepsExecuted
+          stepsExecuted,
+          evidence
         );
         if (recovered !== null) {
           stepsExecuted = recovered.stepsExecuted;
@@ -375,7 +481,8 @@ export class PlanExecutor {
           plan.errorHandlers,
           sessionId,
           params,
-          stepsExecuted
+          stepsExecuted,
+          evidence
         );
         if (recovered !== null) {
           stepsExecuted = recovered.stepsExecuted;
@@ -394,7 +501,8 @@ export class PlanExecutor {
           plan.errorHandlers,
           sessionId,
           params,
-          stepsExecuted
+          stepsExecuted,
+          evidence
         );
         if (recovered !== null) {
           stepsExecuted = recovered.stepsExecuted;
@@ -435,6 +543,7 @@ export class PlanExecutor {
         durationMs: Date.now() - startTime,
         stepsExecuted,
         totalSteps: plan.steps.length,
+        evidence,
         ...(options.taskSignature
           ? { taskSignature: await evaluateTaskSignature({
               signature: options.taskSignature,
@@ -456,6 +565,7 @@ export class PlanExecutor {
         durationMs: Date.now() - startTime,
         stepsExecuted,
         totalSteps: plan.steps.length,
+        evidence,
         finalVerification,
         ...(options.taskSignature
           ? { taskSignature: await evaluateTaskSignature({
@@ -476,6 +586,7 @@ export class PlanExecutor {
       durationMs: Date.now() - startTime,
       stepsExecuted,
       totalSteps: plan.steps.length,
+      evidence,
       ...(finalVerification ? { finalVerification } : {}),
       ...(options.taskSignature
         ? { taskSignature: await evaluateTaskSignature({
@@ -497,7 +608,8 @@ export class PlanExecutor {
     errorHandlers: PlanErrorHandler[],
     sessionId: string,
     params: Record<string, unknown>,
-    currentStepsExecuted: number
+    currentStepsExecuted: number,
+    evidence?: PlanStepEvidence[]
   ): Promise<{ stepsExecuted: number; params: Record<string, unknown> } | null> {
     const handler = errorHandlers.find((h) => h.condition === conditionKey);
     if (!handler) return null;
@@ -520,6 +632,7 @@ export class PlanExecutor {
       const substitutedArgs = substituteParams(step.args, params) as Record<string, unknown>;
 
       let mcpResult: MCPResult;
+      const stepStart = Date.now();
       try {
         mcpResult = await withTimeout(
           toolHandler(sessionId, substitutedArgs),
@@ -527,6 +640,15 @@ export class PlanExecutor {
           stepLabel
         );
         stepsExecuted++;
+        const empty = isEmptyResult(mcpResult);
+        evidence?.push({
+          step: step.order,
+          tool: step.tool,
+          source: 'recovery',
+          outcome: mcpResult.isError ? 'error' : empty ? 'empty' : 'success',
+          durationMs: Date.now() - stepStart,
+          summary: summarizeMcpResult(mcpResult),
+        });
       } catch (err) {
         console.error(
           `[PlanExecutor] Recovery step failed at ${stepLabel}: ${

--- a/src/tools/orchestration.ts
+++ b/src/tools/orchestration.ts
@@ -851,6 +851,7 @@ const executePlanHandler: ToolHandler = async (
           durationMs: result.durationMs,
           data: result.data,
           error: result.error,
+          evidence: result.evidence,
           ...(result.taskSignature ? { taskSignature: result.taskSignature } : {}),
           ...(reflectionStrategy ? { reflectionStrategy } : {}),
           message: result.success

--- a/src/types/plan-cache.ts
+++ b/src/types/plan-cache.ts
@@ -9,6 +9,8 @@ import type { BrowserTaskSignature, TaskSignatureStatus } from '../contracts/tas
 import type { Assertion, Evidence } from '../contracts/types';
 
 /** A single step in a compiled plan */
+export type PlanStepRisk = 'low' | 'interactive' | 'destructive';
+
 export interface CompiledStep {
   /** Execution order (1-based) */
   order: number;
@@ -20,6 +22,8 @@ export interface CompiledStep {
   timeout: number;
   /** Whether to retry this step on failure */
   retryOnFail?: boolean;
+  /** Risk classification for safe plan-as-code validation. */
+  risk?: PlanStepRisk;
   /** How to parse and store the result for subsequent steps */
   parseResult?: {
     format: 'json' | 'text';
@@ -82,7 +86,20 @@ export interface TaskPattern {
 }
 
 /** A complete compiled plan — a cached sequence of tool calls */
+export interface PlanStepEvidence {
+  step: number;
+  tool: string;
+  source: 'plan' | 'recovery';
+  outcome: 'success' | 'error' | 'empty';
+  durationMs: number;
+  summary: string;
+}
+
 export interface CompiledPlan {
+  /** Optional v2 safe contract gate. Legacy plans without this remain backward compatible. */
+  contractVersion?: 2;
+  /** Explicit allow-list for tools that plan and recovery steps may invoke. */
+  allowedTools?: string[];
   /** Unique plan identifier */
   id: string;
   /** Plan version for cache invalidation */
@@ -158,4 +175,6 @@ export interface PlanExecutionResult {
   taskSignature?: TaskSignatureStatus;
   /** Present when a plan opted into final verification. */
   finalVerification?: PlanFinalVerificationResult;
+  /** Bounded execution evidence suitable for critic/outcome validation. */
+  evidence?: PlanStepEvidence[];
 }

--- a/tests/orchestration/plan-cache.test.ts
+++ b/tests/orchestration/plan-cache.test.ts
@@ -409,6 +409,111 @@ describePlanExecutor('PlanExecutor', () => {
   }
 
   // -----------------------------------------------------------------------
+
+  describe('safe plan-as-code contract validation', () => {
+    function safePlan(overrides: Partial<CompiledPlan> = {}): CompiledPlan {
+      return buildPlan({
+        id: 'safe-plan',
+        contractVersion: 2,
+        allowedTools: ['mock_tool', 'recovery_tool'],
+        steps: [buildStep({ order: 1, tool: 'mock_tool', timeout: 5000 })],
+        successCriteria: { requiredFields: ['ok'] },
+        ...overrides,
+      });
+    }
+
+    test('rejects tools outside allowedTools before execution', async () => {
+      const handler = makeMockHandler(makeMCPResult('ok'));
+      const executor = new PlanExecutor(makeResolverWith({ mock_tool: handler, javascript_tool: handler }));
+      const plan = safePlan({ steps: [buildStep({ tool: 'javascript_tool' })] });
+
+      const result = await executor.execute(plan, SESSION_ID, { ok: true });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not in allowedTools');
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    test('rejects unknown tools, missing timeouts, malformed substitutions, and missing success criteria', async () => {
+      const executor = new PlanExecutor(makeResolverWith({ mock_tool: makeMockHandler(makeMCPResult('ok')) }));
+
+      await expect(executor.execute(safePlan({ steps: [buildStep({ tool: 'ghost_tool' })] }), SESSION_ID, { ok: true }))
+        .resolves.toMatchObject({ success: false, error: expect.stringContaining('unknown tool') });
+      await expect(executor.execute(safePlan({ steps: [buildStep({ tool: 'mock_tool', timeout: 0 })] }), SESSION_ID, { ok: true }))
+        .resolves.toMatchObject({ success: false, error: expect.stringContaining('positive timeout') });
+      await expect(executor.execute(safePlan({ steps: [buildStep({ tool: 'mock_tool', args: { url: '${bad-name}' } })] }), SESSION_ID, { ok: true }))
+        .resolves.toMatchObject({ success: false, error: expect.stringContaining('malformed substitution') });
+      await expect(executor.execute(safePlan({ successCriteria: {} }), SESSION_ID, { ok: true }))
+        .resolves.toMatchObject({ success: false, error: expect.stringContaining('explicit successCriteria') });
+    });
+
+    test('bounds recovery handler length for safe contract plans', async () => {
+      const executor = new PlanExecutor(makeResolverWith({ mock_tool: makeMockHandler(makeMCPResult('ok')) }));
+      const tooManySteps = Array.from({ length: 11 }, (_, index) => buildStep({ order: index + 1, tool: 'mock_tool' }));
+      const plan = safePlan({ errorHandlers: [{ condition: 'step1_error', action: 'too-much', steps: tooManySteps }] });
+
+      const result = await executor.execute(plan, SESSION_ID, { ok: true });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('exceeds 10 steps');
+    });
+
+    test('successful safe contract execution includes bounded evidence', async () => {
+      const handler = makeMockHandler(makeMCPResult('ok'));
+      const executor = new PlanExecutor(makeResolverWith({ mock_tool: handler }));
+      const plan = safePlan();
+
+      const result = await executor.execute(plan, SESSION_ID, { ok: true });
+
+      expect(result.success).toBe(true);
+      expect(result.evidence).toEqual([expect.objectContaining({
+        step: 1,
+        tool: 'mock_tool',
+        source: 'plan',
+        outcome: 'success',
+        summary: 'ok',
+      })]);
+    });
+
+    test('safe contract execution includes recovery evidence', async () => {
+      const failHandler = makeErrorHandler('boom');
+      const recoveryHandler = makeMockHandler(makeMCPResult('recovered'));
+      const executor = new PlanExecutor(makeResolverWith({ fail_tool: failHandler, recovery_tool: recoveryHandler }));
+      const plan = safePlan({
+        allowedTools: ['fail_tool', 'recovery_tool'],
+        steps: [buildStep({ order: 1, tool: 'fail_tool', timeout: 5000 })],
+        errorHandlers: [{
+          condition: 'step1_error',
+          action: 'recover',
+          steps: [buildStep({ order: 1, tool: 'recovery_tool', timeout: 5000 })],
+        }],
+      });
+
+      const result = await executor.execute(plan, SESSION_ID, { ok: true });
+
+      expect(result.success).toBe(true);
+      expect(result.evidence).toEqual([
+        expect.objectContaining({ step: 1, tool: 'fail_tool', source: 'plan', outcome: 'error' }),
+        expect.objectContaining({ step: 1, tool: 'recovery_tool', source: 'recovery', outcome: 'success', summary: 'recovered' }),
+      ]);
+    });
+
+    test('legacy plans without contractVersion remain backward compatible', async () => {
+      const handler = makeMockHandler(makeMCPResult('ok'));
+      const executor = new PlanExecutor(makeResolverWith({ mock_tool: handler }));
+      const legacy = buildPlan({
+        steps: [buildStep({ tool: 'mock_tool', timeout: 0 })],
+        successCriteria: {},
+      });
+
+      const result = await executor.execute(legacy, SESSION_ID, {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).not.toContain('Plan contract validation failed');
+      expect(handler).toHaveBeenCalled();
+    });
+  });
+
   // Basic execution
   // -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Fixes #1016 by adding an opt-in `contractVersion: 2` safe plan-as-code contract for reusable compiled browser plans.
- Validates unknown tools, allow-list membership, positive timeouts, malformed `${param}` substitutions, explicit success criteria, and bounded recovery handlers before execution.
- Adds bounded plan/recovery step evidence to `PlanExecutionResult` and the `execute_plan` response, plus a safe-plan recipe document.

## Verification
- `npm test -- tests/orchestration/plan-cache.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint -- --quiet`
- `git diff --check`

## Notes
- Legacy compiled plans without `contractVersion: 2` or `allowedTools` stay on the existing compatibility path.
