### PR TITLE
feat(harness): connect semantic query refs to plan verification

### DIFF
--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -11,6 +11,7 @@ model composes them into prose.
 | [multi-source-news-digest.md](multi-source-news-digest.md) | Pull headlines from several news sources and produce a one-screen daily digest. | `navigate`, `read_page`, `crawl` |
 | [docs-changelog-diff.md](docs-changelog-diff.md) | Compare two snapshots of a docs page (e.g. before/after a release) and explain what changed. | `navigate`, `read_page` |
 | [competitive-feature-matrix.md](competitive-feature-matrix.md) | Build a structured feature-matrix table across several vendor pages. | `navigate`, `extract_data`, `read_page` |
+| [semantic-login-flow.md](semantic-login-flow.md) | Resolve semantic query refs, drive plan actions, and verify with an Outcome Contract. | `oc_query`, `fill_form`, `interact`, `oc_assert`, `oc_evidence_bundle`, `execute_plan` |
 
 ## How recipes are structured
 

--- a/docs/recipes/semantic-login-flow.md
+++ b/docs/recipes/semantic-login-flow.md
@@ -1,0 +1,138 @@
+# Semantic query plan flow
+
+This recipe shows how a compiled plan can connect `oc_query` results to
+deterministic actions and an `oc_assert` postcondition without adding a new
+planner runtime.
+
+## Goal
+
+Resolve semantic page targets once, reuse their refs in later plan steps, and
+settle with evidence-backed success or bounded failure.
+
+## Inputs
+
+- A local login fixture or application page.
+- A compiled plan registered in the plan registry.
+- Runtime credentials supplied by the host through `params`.
+
+## Plan
+
+```json
+{
+  "id": "semantic-login-flow",
+  "version": "1.0.0",
+  "description": "Resolve login fields semantically, act on refs, then assert outcome.",
+  "parameters": {
+    "email": { "source": "runtime" },
+    "password": { "source": "runtime" }
+  },
+  "steps": [
+    {
+      "order": 1,
+      "tool": "oc_query",
+      "args": {
+        "query": "login form with email, password, and submit button",
+        "purpose": "interaction",
+        "debug": false
+      },
+      "timeout": 10000,
+      "parseResult": { "format": "json", "storeAs": "login" }
+    },
+    {
+      "order": 2,
+      "tool": "fill_form",
+      "args": {
+        "ref": "${login.matches.login_form.email_box.ref}",
+        "value": "${email}"
+      },
+      "timeout": 10000
+    },
+    {
+      "order": 3,
+      "tool": "fill_form",
+      "args": {
+        "ref": "${login.matches.login_form.password_box.ref}",
+        "value": "${password}"
+      },
+      "timeout": 10000
+    },
+    {
+      "order": 4,
+      "tool": "interact",
+      "args": {
+        "ref": "${login.matches.login_form.submit_btn.ref}",
+        "action": "click"
+      },
+      "timeout": 10000
+    },
+    {
+      "order": 5,
+      "tool": "oc_assert",
+      "args": {
+        "assertion": { "kind": "dom_text", "contains": "Welcome" }
+      },
+      "timeout": 10000,
+      "parseResult": { "format": "json", "storeAs": "postcondition" }
+    }
+  ],
+  "errorHandlers": [
+    {
+      "condition": "step1_empty_result",
+      "action": "capture-query-debug",
+      "steps": [
+        {
+          "order": 1,
+          "tool": "oc_query",
+          "args": {
+            "query": "login form with email, password, and submit button",
+            "purpose": "interaction",
+            "debug": true
+          },
+          "timeout": 10000,
+          "parseResult": { "format": "json", "storeAs": "queryDebug" }
+        },
+        {
+          "order": 2,
+          "tool": "oc_evidence_bundle",
+          "args": { "includeScreenshot": false, "includeDom": true },
+          "timeout": 10000,
+          "parseResult": { "format": "json", "storeAs": "evidenceBundle" }
+        }
+      ]
+    }
+  ],
+  "successCriteria": {
+    "requiredFields": ["login", "postcondition"]
+  }
+}
+```
+
+## Path binding
+
+Plan templates support dotted params such as
+`${login.matches.login_form.submit_btn.ref}`. Missing paths are left unchanged
+so the downstream tool can fail with its normal bounded error instead of the
+executor evaluating arbitrary expressions.
+
+`parseResult.extractField` also accepts dotted paths when a plan wants to store
+only one semantic query ref:
+
+```json
+{
+  "parseResult": {
+    "format": "json",
+    "extractField": "matches.login_form.submit_btn.ref",
+    "storeAs": "submitRef"
+  }
+}
+```
+
+## Verification
+
+Use `execute_plan` against the fixture and assert:
+
+- `success === true`
+- `stepsExecuted === totalSteps`
+- `data.login` contains the semantic query result
+- `data.postcondition.verdict` is `pass`
+- any failure path records `queryDebug` or `evidenceBundle` before settling

--- a/src/orchestration/plan-executor.ts
+++ b/src/orchestration/plan-executor.ts
@@ -120,14 +120,42 @@ async function runFinalVerification(
 }
 
 /**
+ * Resolve a dotted path from a parsed plan value. Numeric path segments address
+ * array indexes so plans can bind values like matches.login.submit.ref or
+ * results.0.ref without evaluating arbitrary expressions.
+ */
+function getPathValue(value: unknown, path: string): unknown {
+  if (!path) return value;
+  let current = value;
+  for (const segment of path.split('.')) {
+    if (current === null || current === undefined) return undefined;
+    if (Array.isArray(current)) {
+      if (!/^\d+$/.test(segment)) return undefined;
+      current = current[Number(segment)];
+      continue;
+    }
+    if (typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+function resolveParamPath(params: Record<string, unknown>, path: string): unknown {
+  if (Object.prototype.hasOwnProperty.call(params, path)) return params[path];
+  const [root, ...rest] = path.split('.');
+  if (!Object.prototype.hasOwnProperty.call(params, root)) return undefined;
+  return getPathValue(params[root], rest.join('.'));
+}
+
+/**
  * Recursively substitute ${varName} templates in a value using the params map.
- * Handles strings, objects, and arrays. Non-string primitives are returned as-is.
+ * Handles strings, objects, arrays, and dotted paths. Non-string primitives are returned as-is.
  * Missing vars are left as-is (no crash).
  */
 function substituteParams(value: unknown, params: Record<string, unknown>): unknown {
   if (typeof value === 'string') {
     return value.replace(/\$\{([^}]+)\}/g, (match, varName) => {
-      const resolved = params[varName];
+      const resolved = resolveParamPath(params, varName);
       if (resolved === undefined) return match;
       if (typeof resolved === 'string') return resolved;
       return JSON.stringify(resolved);
@@ -171,8 +199,7 @@ function extractResult(
   }
 
   if (parseResult.extractField) {
-    const obj = parsed as Record<string, unknown>;
-    parsed = obj?.[parseResult.extractField];
+    parsed = getPathValue(parsed, parseResult.extractField);
   }
 
   return parsed;

--- a/src/types/plan-cache.ts
+++ b/src/types/plan-cache.ts
@@ -14,7 +14,7 @@ export interface CompiledStep {
   order: number;
   /** MCP tool name (e.g. "javascript_tool", "computer") */
   tool: string;
-  /** Tool arguments — supports ${param} template variables */
+  /** Tool arguments — supports ${param} and ${param.path.to.value} template variables */
   args: Record<string, unknown>;
   /** Step-level timeout in milliseconds */
   timeout: number;
@@ -23,7 +23,7 @@ export interface CompiledStep {
   /** How to parse and store the result for subsequent steps */
   parseResult?: {
     format: 'json' | 'text';
-    /** JSON field to extract from result */
+    /** JSON field/path to extract from result */
     extractField?: string;
     /** Variable name to store result for later steps */
     storeAs?: string;

--- a/tests/orchestration/plan-cache.test.ts
+++ b/tests/orchestration/plan-cache.test.ts
@@ -467,6 +467,67 @@ describePlanExecutor('PlanExecutor', () => {
     expect(options['port']).toBe('8080');
   });
 
+  test('substitutes dotted paths from stored query results into later step args', async () => {
+    const queryHandler = makeMockHandler(makeMCPResult(JSON.stringify({
+      matches: {
+        login_form: {
+          email_box: { ref: 'oc_ref_email' },
+          submit_btn: { ref: 'oc_ref_submit' },
+        },
+      },
+    })));
+    const fillHandler = makeMockHandler(makeMCPResult('filled'));
+    const clickHandler = makeMockHandler(makeMCPResult('clicked'));
+    const assertHandler = makeMockHandler(makeMCPResult(JSON.stringify({
+      verdict: 'pass',
+      evidence: { kind: 'dom_text', contains: 'Welcome' },
+    })));
+    const executor = new PlanExecutor(makeResolverWith({
+      oc_query: queryHandler,
+      fill_form: fillHandler,
+      interact: clickHandler,
+      oc_assert: assertHandler,
+    }));
+    const plan = buildPlan({
+      id: 'semantic-login-plan',
+      steps: [
+        buildStep({
+          order: 1,
+          tool: 'oc_query',
+          args: { query: 'login form' },
+          parseResult: { format: 'json', storeAs: 'login' },
+        }),
+        buildStep({
+          order: 2,
+          tool: 'fill_form',
+          args: { ref: '${login.matches.login_form.email_box.ref}', value: 'agent@example.com' },
+        }),
+        buildStep({
+          order: 3,
+          tool: 'interact',
+          args: { ref: '${login.matches.login_form.submit_btn.ref}', action: 'click' },
+        }),
+        buildStep({
+          order: 4,
+          tool: 'oc_assert',
+          args: { assertion: { kind: 'dom_text', contains: 'Welcome' } },
+          parseResult: { format: 'json', storeAs: 'postcondition' },
+        }),
+      ],
+      successCriteria: { requiredFields: ['login', 'postcondition'] },
+    });
+
+    const result = await executor.execute(plan, SESSION_ID, {});
+
+    expect(result.success).toBe(true);
+    expect((fillHandler as jest.Mock).mock.calls[0][1]).toMatchObject({ ref: 'oc_ref_email' });
+    expect((clickHandler as jest.Mock).mock.calls[0][1]).toMatchObject({ ref: 'oc_ref_submit' });
+    expect(result.data?.postcondition).toMatchObject({
+      verdict: 'pass',
+      evidence: { kind: 'dom_text', contains: 'Welcome' },
+    });
+  });
+
   // -----------------------------------------------------------------------
   // Result parsing / storeAs
   // -----------------------------------------------------------------------
@@ -506,6 +567,28 @@ describePlanExecutor('PlanExecutor', () => {
     const step2Args = (step2Handler as jest.Mock).mock.calls[0][1] as Record<string, unknown>;
     // The stored value should be the parsed object (or its stringified form)
     expect(step2Args['data']).toBeDefined();
+  });
+
+  test('extracts dotted JSON paths with parseResult.extractField', async () => {
+    const handler = makeMockHandler(makeMCPResult(JSON.stringify({
+      matches: { login_form: { submit_btn: { ref: 'oc_ref_submit' } } },
+    })));
+    const executor = new PlanExecutor(makeResolverWith({ oc_query: handler }));
+    const plan = buildPlan({
+      id: 'extract-dotted-path-plan',
+      steps: [buildStep({
+        order: 1,
+        tool: 'oc_query',
+        args: {},
+        parseResult: { format: 'json', extractField: 'matches.login_form.submit_btn.ref', storeAs: 'submitRef' },
+      })],
+      successCriteria: { requiredFields: ['submitRef'] },
+    });
+
+    const result = await executor.execute(plan, SESSION_ID, {});
+
+    expect(result.success).toBe(true);
+    expect(result.data?.submitRef).toBe('oc_ref_submit');
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes #1046 by adding safe dotted-path binding for compiled plan params and `parseResult.extractField`.
- Covers the reusable `oc_query` → action ref → `oc_assert` postcondition pattern in `PlanExecutor` tests.
- Documents a semantic login flow recipe, including query debug/evidence-bundle recovery guidance.

## Verification
- `npm ci`
- `npm test -- tests/orchestration/plan-cache.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint -- --quiet`
- `git diff --check`

## Notes
- The path resolver is expression-free: it only traverses object keys and numeric array indices.
- Missing paths remain unresolved so downstream tools keep their existing bounded failure behavior.
