### PR TITLE
feat(obs): add opt-in visual trajectory evidence

### DIFF
--- a/docs/observability/visual-trajectory.md
+++ b/docs/observability/visual-trajectory.md
@@ -1,0 +1,53 @@
+# Visual trajectory evidence bundles
+
+Visual trajectory capture is disabled by default. Enable it only for debugging,
+benchmarking, or PR verification where visual/perception artifacts are needed.
+
+## Enablement
+
+- Per call: pass `recordTrajectory: true` to `vision_find`.
+- Environment: set `OPENCHROME_VISUAL_TRAJECTORY=1`.
+- Artifact root: set `OPENCHROME_VISUAL_TRAJECTORY_DIR=/path/to/artifacts`.
+
+When no root is configured, artifacts are written under:
+
+```text
+~/.openchrome/trajectories/visual/
+```
+
+## Artifact shape
+
+Each enabled `vision_find` call creates a trace directory containing:
+
+- `events.jsonl` — one JSON event with perception/action/outcome metadata.
+- `annotated.png` — annotated screenshot artifact, referenced by path.
+
+The JSON event records:
+
+- `sessionId`, `tabId`, `url`, `toolName`, and timestamp.
+- optional visual query/action target.
+- provider, element count, latency, and warnings.
+- screenshot file path, not inline image data.
+- redaction metadata: `{ "inlineImages": false, "secretsRedacted": true }`.
+
+## Privacy and safety model
+
+- No visual artifacts are written unless explicitly enabled.
+- Images are stored as files and referenced by path; they are not inlined in
+  JSONL events.
+- The event schema is metadata-first so maintainers can share sanitized event
+  rows without attaching screenshots.
+- Capture failure is best effort and never fails the underlying `vision_find`
+  call.
+
+## Verification
+
+Run `vision_find` once with `recordTrajectory: true`, then inspect:
+
+```bash
+find "$OPENCHROME_VISUAL_TRAJECTORY_DIR" -maxdepth 2 -type f
+jq . "$OPENCHROME_VISUAL_TRAJECTORY_DIR"/visual-*/events.jsonl
+```
+
+Run the same call without `recordTrajectory` or
+`OPENCHROME_VISUAL_TRAJECTORY=1`; the directory should remain empty.

--- a/src/observability/visual-trajectory.ts
+++ b/src/observability/visual-trajectory.ts
@@ -1,0 +1,130 @@
+/** Opt-in visual trajectory evidence bundles for perception/debug workflows. */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { randomBytes } from 'crypto';
+
+export interface VisualTrajectoryEntry {
+  version: 1;
+  traceId: string;
+  sessionId: string;
+  tabId: string;
+  url: string;
+  timestamp: number;
+  toolName: string;
+  action?: {
+    kind: string;
+    target?: string;
+    strategy?: string;
+  };
+  perception?: {
+    provider: string;
+    snapshotPath?: string;
+    elementCount: number;
+    latencyMs?: number;
+    warnings: string[];
+  };
+  screenshots?: {
+    annotatedPath?: string;
+  };
+  outcome: 'success' | 'failure' | 'skipped' | 'blocked' | 'unknown';
+  recovery?: {
+    hintRule?: string;
+    nextSuggestedTool?: string;
+  };
+  durationsMs: Record<string, number>;
+  redaction: {
+    inlineImages: false;
+    secretsRedacted: true;
+  };
+}
+
+export interface VisualTrajectoryRecordInput {
+  enabled?: boolean;
+  rootDir?: string;
+  sessionId: string;
+  tabId: string;
+  url: string;
+  toolName: string;
+  instruction?: string;
+  provider: string;
+  elementCount: number;
+  latencyMs?: number;
+  warnings?: string[];
+  outcome: VisualTrajectoryEntry['outcome'];
+  annotatedImageBase64?: string;
+  mimeType?: string;
+}
+
+export interface VisualTrajectoryRecordResult {
+  traceId: string;
+  dir: string;
+  entryPath: string;
+  annotatedPath?: string;
+}
+
+const DEFAULT_ROOT = path.join(os.homedir(), '.openchrome', 'trajectories', 'visual');
+
+export function isVisualTrajectoryEnabled(explicit?: boolean): boolean {
+  if (explicit === true) return true;
+  const raw = process.env.OPENCHROME_VISUAL_TRAJECTORY;
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
+export function getVisualTrajectoryRoot(explicit?: string): string {
+  return explicit || process.env.OPENCHROME_VISUAL_TRAJECTORY_DIR || DEFAULT_ROOT;
+}
+
+function newTraceId(): string {
+  return `visual-${Date.now()}-${randomBytes(3).toString('hex')}`;
+}
+
+function imageExtension(mimeType: string | undefined): string {
+  if (mimeType === 'image/jpeg') return 'jpg';
+  if (mimeType === 'image/webp') return 'webp';
+  return 'png';
+}
+
+export async function recordVisualTrajectory(input: VisualTrajectoryRecordInput): Promise<VisualTrajectoryRecordResult | null> {
+  if (!isVisualTrajectoryEnabled(input.enabled)) return null;
+
+  const traceId = newTraceId();
+  const root = getVisualTrajectoryRoot(input.rootDir);
+  const dir = path.join(root, traceId);
+  await fs.promises.mkdir(dir, { recursive: true });
+
+  let annotatedPath: string | undefined;
+  if (input.annotatedImageBase64) {
+    const filename = `annotated.${imageExtension(input.mimeType)}`;
+    annotatedPath = path.join(dir, filename);
+    await fs.promises.writeFile(annotatedPath, Buffer.from(input.annotatedImageBase64, 'base64'));
+  }
+
+  const entry: VisualTrajectoryEntry = {
+    version: 1,
+    traceId,
+    sessionId: input.sessionId,
+    tabId: input.tabId,
+    url: input.url,
+    timestamp: Date.now(),
+    toolName: input.toolName,
+    ...(input.instruction ? { action: { kind: 'visual_query', target: input.instruction, strategy: 'vision_find' } } : {}),
+    perception: {
+      provider: input.provider,
+      elementCount: input.elementCount,
+      latencyMs: input.latencyMs,
+      warnings: input.warnings || [],
+    },
+    ...(annotatedPath ? { screenshots: { annotatedPath } } : {}),
+    outcome: input.outcome,
+    durationsMs: input.latencyMs !== undefined ? { perception: input.latencyMs } : {},
+    redaction: {
+      inlineImages: false,
+      secretsRedacted: true,
+    },
+  };
+  const entryPath = path.join(dir, 'events.jsonl');
+  await fs.promises.appendFile(entryPath, JSON.stringify(entry) + '\n');
+  return { traceId, dir, entryPath, annotatedPath };
+}

--- a/src/tools/vision-find.ts
+++ b/src/tools/vision-find.ts
@@ -16,6 +16,7 @@ import { formatElementMapAsText } from '../vision/screenshot-analyzer';
 import { formatPerceptionSnapshotAsText } from '../vision/perception-provider';
 import { DomAnnotatorPerceptionProvider } from '../vision/providers/dom-annotator-provider';
 import { trackVisionUsage } from '../vision/config';
+import { recordVisualTrajectory } from '../observability/visual-trajectory';
 
 const definition: MCPToolDefinition = {
   name: 'vision_find',
@@ -68,6 +69,10 @@ const definition: MCPToolDefinition = {
         enum: ['viewport', 'tiled'],
         default: 'viewport',
         description: 'viewport: today\'s single-shot capture. tiled: full document scrolled in viewport-tall steps; returns per-tile screenshots and a unified element map.',
+      },
+      recordTrajectory: {
+        type: 'boolean',
+        description: 'Opt-in visual trajectory artifact capture for this call. Also enabled by OPENCHROME_VISUAL_TRAJECTORY=1.',
       },
     },
     required: ['tabId'],
@@ -145,6 +150,24 @@ const handler: ToolHandler = async (
     trackVisionUsage(result.annotationTimeMs);
     const textMap = formatElementMapAsText(result.elementMap);
     console.error(`[vision_find] Analyzed tab ${tabId}: ${result.elementCount} elements in ${result.annotationTimeMs}ms`);
+    const trajectory = await recordVisualTrajectory({
+      enabled: args.recordTrajectory === true,
+      sessionId,
+      tabId,
+      url: page.url(),
+      toolName: 'vision_find',
+      instruction: typeof args.instruction === 'string' ? args.instruction : undefined,
+      provider: 'dom-annotator',
+      elementCount: result.elementCount,
+      latencyMs: result.annotationTimeMs,
+      warnings: snapshot.warnings,
+      outcome: 'success',
+      annotatedImageBase64: result.screenshot,
+      mimeType: result.mimeType,
+    }).catch((err) => {
+      console.error('[vision_find] visual trajectory capture failed:', err instanceof Error ? err.message : err);
+      return null;
+    });
 
     const tiles = mode === 'tiled' ? (result.tiling?.tiles ?? []) : [];
     const tileNote =
@@ -163,6 +186,7 @@ Tiled mode: ${tiles.length} tile screenshot(s) attached below in document-Y orde
       content.push({
         type: 'text',
         text: `Vision analysis: ${result.elementCount} elements found (${result.viewport.width}x${result.viewport.height} viewport, ${result.annotationTimeMs}ms)${tileNote}
+${trajectory ? `\nTrajectory: ${trajectory.traceId} (${trajectory.dir})\n` : ''}
 
 ${textMap}`,
       });

--- a/tests/vision/vision-find.test.ts
+++ b/tests/vision/vision-find.test.ts
@@ -3,6 +3,10 @@
  * Tests for Vision Find Tool and Vision Config (Phase 2: Vision Hybrid Mode #577)
  */
 
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
 // ─── getVisionMode config tests ───
 
 describe('getVisionMode', () => {
@@ -86,6 +90,8 @@ describe('VisionFindTool', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    delete process.env.OPENCHROME_VISUAL_TRAJECTORY;
+    delete process.env.OPENCHROME_VISUAL_TRAJECTORY_DIR;
   });
 
   it('returns annotated screenshot and element map', async () => {
@@ -111,6 +117,72 @@ describe('VisionFindTool', () => {
     expect(result.content[1].type).toBe('image');
     expect(result.content[1].data).toBeTruthy();
     expect(result.content[1].mimeType).toMatch(/^image\//);
+  });
+
+  it('writes opt-in visual trajectory artifacts without inline images', async () => {
+    const trajectoryDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-visual-trajectory-'));
+    process.env.OPENCHROME_VISUAL_TRAJECTORY_DIR = trajectoryDir;
+    const mockElements = [
+      { role: 'button', name: 'Submit', x: 100, y: 200, width: 80, height: 30 },
+    ];
+    const page = createMockPage(mockElements);
+    const mockSessionManager = {
+      getPage: jest.fn().mockResolvedValue(page),
+      getAvailableTargets: jest.fn().mockResolvedValue([]),
+    };
+
+    try {
+      const handler = await getVisionFindHandler(mockSessionManager);
+      const context = { startTime: Date.now(), deadlineMs: 60000 };
+      const result = await handler('session-visual', {
+        tabId: 'tab-visual',
+        instruction: 'find submit',
+        recordTrajectory: true,
+      }, context) as any;
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Trajectory: visual-');
+      const traceDirs = fs.readdirSync(trajectoryDir);
+      expect(traceDirs).toHaveLength(1);
+      const eventPath = path.join(trajectoryDir, traceDirs[0], 'events.jsonl');
+      const event = JSON.parse(fs.readFileSync(eventPath, 'utf8').trim());
+      expect(event).toMatchObject({
+        version: 1,
+        sessionId: 'session-visual',
+        tabId: 'tab-visual',
+        toolName: 'vision_find',
+        outcome: 'success',
+        redaction: { inlineImages: false, secretsRedacted: true },
+        perception: { provider: 'dom-annotator', elementCount: 1 },
+      });
+      expect(event.screenshots.annotatedPath).toMatch(/annotated\.(png|jpg|webp)$/);
+      expect(fs.existsSync(event.screenshots.annotatedPath)).toBe(true);
+    } finally {
+      fs.rmSync(trajectoryDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not write visual trajectory artifacts by default', async () => {
+    const trajectoryDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-visual-trajectory-off-'));
+    process.env.OPENCHROME_VISUAL_TRAJECTORY_DIR = trajectoryDir;
+    const page = createMockPage([
+      { role: 'button', name: 'Submit', x: 100, y: 200, width: 80, height: 30 },
+    ]);
+    const mockSessionManager = {
+      getPage: jest.fn().mockResolvedValue(page),
+      getAvailableTargets: jest.fn().mockResolvedValue([]),
+    };
+
+    try {
+      const handler = await getVisionFindHandler(mockSessionManager);
+      const context = { startTime: Date.now(), deadlineMs: 60000 };
+      const result = await handler('session-visual', { tabId: 'tab-visual' }, context) as any;
+
+      expect(result.isError).toBeUndefined();
+      expect(fs.readdirSync(trajectoryDir)).toEqual([]);
+    } finally {
+      fs.rmSync(trajectoryDir, { recursive: true, force: true });
+    }
   });
 
   it('errors on missing tabId', async () => {


### PR DESCRIPTION
## Summary
- Fixes #1055 by adding default-off visual trajectory capture for `vision_find`.
- Persists JSONL metadata plus annotated screenshot files when `recordTrajectory:true` or `OPENCHROME_VISUAL_TRAJECTORY=1` is enabled.
- Documents privacy boundaries: no default capture, no inline image data in JSONL, best-effort writes.

## Verification
- `npm ci`
- `npm test -- tests/vision/vision-find.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint -- --quiet`
- `npm run lint:tool-schemas`
- `git diff --check`

## Notes
- Artifacts default to `~/.openchrome/trajectories/visual/` and can be redirected with `OPENCHROME_VISUAL_TRAJECTORY_DIR`.
- Capture failure is logged but does not fail the underlying visual query.
