### PR TITLE
feat(ralph): gate visual grounding before HITL

### DIFF
--- a/docs/perception/ralph-visual-grounding.md
+++ b/docs/perception/ralph-visual-grounding.md
@@ -1,0 +1,37 @@
+# Ralph visual grounding fallback
+
+Ralph keeps DOM/AX/CDP strategies first. Visual grounding is an opt-in fallback
+that can run after `S6_CDP_RAW` and before HITL when a caller supplies a
+provider-neutral `PerceptionSnapshot`.
+
+## Strategy order
+
+```text
+S1_AX -> S2_CSS -> S3_CDP_COORD -> S4_JS_INJECT -> S5_KEYBOARD -> S6_CDP_RAW -> S7_VISUAL_GROUNDING -> S8_HITL
+```
+
+`S7_VISUAL_GROUNDING` is skipped unless both `visualGrounding: true` and
+`visualSnapshot` are present in `RalphOptions`.
+
+## Safety gates
+
+- Only `click`, `double_click`, and `hover` are eligible.
+- Candidate must be interactive and have a credible bounding box.
+- Deterministic label/role token score must pass the threshold.
+- The top candidate must have a clear margin over the second candidate.
+- Unsafe visual-only labels such as delete, pay, transfer, password, MFA, or
+  secrets are skipped and Ralph escalates to HITL.
+
+## Evidence
+
+When the visual fallback succeeds, the normal Ralph response includes:
+
+- `strategyUsed: "S7_VISUAL_GROUNDING"`
+- `strategiesTried` containing the visual strategy
+- a response line that names the visual provider and deterministic score
+
+## Current boundary
+
+This is the engine-level fallback hook. Tool-level callers can wire a
+`PerceptionSnapshot` from `vision_find` or an optional provider in follow-up
+integration without changing the deterministic safety gates.

--- a/src/utils/ralph/ralph-engine.ts
+++ b/src/utils/ralph/ralph-engine.ts
@@ -10,7 +10,8 @@
  * S4 JS injection        → element.click() + dispatchEvent
  * S5 Keyboard navigation → DOM.focus + keyboard.press('Enter'/'Space')
  * S6 CDP raw events      → Full mousePressed + mouseReleased sequence
- * S7 HITL               → Return structured context for human intervention
+ * S7 Visual grounding   → Gated provider-neutral visual bbox click
+ * S8 HITL               → Return structured context for human intervention
  */
 
 import type { Page } from 'puppeteer-core';
@@ -23,10 +24,11 @@ import { FoundElement, scoreElement, tokenizeQuery } from '../element-finder';
 import { classifyOutcome, formatOutcomeLine, InteractionOutcome } from './outcome-classifier';
 import { getTargetId } from '../puppeteer-helpers';
 import { DEFAULT_DOM_SETTLE_DELAY_MS } from '../../config/defaults';
+import type { PerceptionElement, PerceptionSnapshot } from '../../vision/types';
 
 // ─── Types ───
 
-export type StrategyId = 'S1_AX' | 'S2_CSS' | 'S3_CDP_COORD' | 'S4_JS_INJECT' | 'S5_KEYBOARD' | 'S6_CDP_RAW' | 'S7_HITL';
+export type StrategyId = 'S1_AX' | 'S2_CSS' | 'S3_CDP_COORD' | 'S4_JS_INJECT' | 'S5_KEYBOARD' | 'S6_CDP_RAW' | 'S7_VISUAL_GROUNDING' | 'S8_HITL';
 
 export interface RalphResult {
   success: boolean;
@@ -46,6 +48,10 @@ export interface RalphOptions {
   waitAfter?: number;
   /** Maximum total time for all strategies in ms (default: 15000) */
   budgetMs?: number;
+  /** Opt-in visual fallback snapshot. Disabled unless explicitly supplied. */
+  visualSnapshot?: PerceptionSnapshot;
+  /** Enables S7 visual grounding when visualSnapshot is present. */
+  visualGrounding?: boolean;
 }
 
 // ─── Strategy Implementations ───
@@ -56,6 +62,7 @@ interface StrategyContext {
   query: string;
   action: 'click' | 'double_click' | 'hover';
   waitAfter: number;
+  visualSnapshot?: PerceptionSnapshot;
 }
 
 interface StrategyResult {
@@ -284,6 +291,52 @@ const strategyCDPRaw: StrategyFn = async (ctx) => {
   };
 };
 
+const UNSAFE_VISUAL_LABEL = /\b(delete|remove|destroy|confirm|pay|purchase|transfer|password|mfa|otp|credential|secret)\b/i;
+
+function scoreVisualElement(el: PerceptionElement, query: string): number {
+  if (el.interactive !== true) return 0;
+  if (el.bbox.width < 4 || el.bbox.height < 4 || el.bbox.width > 2000 || el.bbox.height > 2000) return 0;
+  const label = `${el.label} ${el.role || ''}`.toLowerCase();
+  const tokens = tokenizeQuery(query).filter((token) => token.length > 1);
+  if (tokens.length === 0) return 0;
+  let score = 0;
+  for (const token of tokens) {
+    if (label.includes(token)) score += 25;
+  }
+  if (el.type === 'control') score += 15;
+  if (typeof el.confidence === 'number') score += Math.max(0, Math.min(20, el.confidence * 20));
+  return score;
+}
+
+/** S7: Provider-neutral visual grounding candidate click. */
+const strategyVisualGrounding: StrategyFn = async (ctx) => {
+  const snapshot = ctx.visualSnapshot;
+  if (!snapshot || (ctx.action !== 'click' && ctx.action !== 'hover' && ctx.action !== 'double_click')) return null;
+  if (UNSAFE_VISUAL_LABEL.test(ctx.query)) return null;
+
+  const candidates = snapshot.elements
+    .map((element) => ({ element, score: scoreVisualElement(element, ctx.query) }))
+    .filter((candidate) => candidate.score >= 45)
+    .sort((a, b) => b.score - a.score);
+  if (candidates.length === 0) return null;
+  if (candidates.length > 1 && candidates[0].score - candidates[1].score < 15) return null;
+
+  const best = candidates[0].element;
+  const x = Math.round(best.bbox.x + best.bbox.width / 2);
+  const y = Math.round(best.bbox.y + best.bbox.height / 2);
+  const { delta } = await performAction(ctx.page, ctx.action, x, y, ctx.waitAfter);
+
+  return {
+    delta,
+    backendDOMNodeId: best.backendDOMNodeId,
+    role: best.role || best.type,
+    name: best.label,
+    elementDesc: `visual ${best.type} "${best.label}"`,
+    refInfo: '',
+    sourceInfo: `[via visual grounding provider=${snapshot.provider} score=${candidates[0].score.toFixed(1)}]`,
+  };
+};
+
 // ─── Strategy Registry ───
 
 const STRATEGIES: Array<{ id: StrategyId; fn: StrategyFn; label: string }> = [
@@ -347,10 +400,13 @@ export async function ralphClick(
   const budgetMs = options?.budgetMs || 15000;
   const startTime = Date.now();
 
-  const ctx: StrategyContext = { page, cdpClient, query, action, waitAfter };
+  const ctx: StrategyContext = { page, cdpClient, query, action, waitAfter, visualSnapshot: options?.visualSnapshot };
   const strategiesTried: StrategyId[] = [];
+  const strategies = options?.visualGrounding && options.visualSnapshot
+    ? [...STRATEGIES, { id: 'S7_VISUAL_GROUNDING' as const, fn: strategyVisualGrounding, label: 'Visual grounding' }]
+    : STRATEGIES;
 
-  for (const strategy of STRATEGIES) {
+  for (const strategy of strategies) {
     // Check timeout budget
     if (Date.now() - startTime > budgetMs) {
       break;
@@ -392,19 +448,19 @@ export async function ralphClick(
     }
   }
 
-  // S7: All automated strategies exhausted — HITL
-  strategiesTried.push('S7_HITL');
-  const triedSummary = strategiesTried.filter(s => s !== 'S7_HITL').map(s => {
-    const strat = STRATEGIES.find(st => st.id === s);
+  // S8: All automated strategies exhausted — HITL
+  strategiesTried.push('S8_HITL');
+  const triedSummary = strategiesTried.filter(s => s !== 'S8_HITL').map(s => {
+    const strat = strategies.find(st => st.id === s);
     return strat ? strat.label : s;
   }).join(', ');
 
-  const hitlLine = `\u26a0 All ${STRATEGIES.length} strategies exhausted for "${query}". Tried: ${triedSummary}. Please interact with the element manually, or try a different approach (javascript_tool, navigate to a different URL).`;
+  const hitlLine = `\u26a0 All ${strategies.length} strategies exhausted for "${query}". Tried: ${triedSummary}. Please interact with the element manually, or try a different approach (javascript_tool, navigate to a different URL).`;
 
   return {
     success: false,
     outcome: 'ELEMENT_NOT_FOUND',
-    strategyUsed: 'S7_HITL',
+    strategyUsed: 'S8_HITL',
     strategiesTried,
     responseLine: hitlLine,
     hitlRequired: true,

--- a/src/utils/ralph/strategy-learner.ts
+++ b/src/utils/ralph/strategy-learner.ts
@@ -12,7 +12,7 @@
 import { getDomainMemory, extractDomainFromUrl } from '../../memory/domain-memory';
 
 /** Strategy identifiers matching ralph-engine.ts */
-export type StrategyId = 'S1_AX' | 'S2_CSS' | 'S3_CDP_COORD' | 'S4_JS_INJECT' | 'S5_KEYBOARD' | 'S6_CDP_RAW' | 'S7_HITL';
+export type StrategyId = 'S1_AX' | 'S2_CSS' | 'S3_CDP_COORD' | 'S4_JS_INJECT' | 'S5_KEYBOARD' | 'S6_CDP_RAW' | 'S7_VISUAL_GROUNDING' | 'S8_HITL';
 
 /** Key prefix for strategy entries in domain memory */
 const STRATEGY_KEY_PREFIX = 'ralph:strategy';
@@ -29,7 +29,7 @@ const STRATEGY_KEY_PREFIX = 'ralph:strategy';
  */
 export function learnStrategy(url: string, role: string, strategyId: StrategyId): void {
   // Only learn non-default strategies
-  if (strategyId === 'S1_AX' || strategyId === 'S2_CSS' || strategyId === 'S7_HITL') {
+  if (strategyId === 'S1_AX' || strategyId === 'S2_CSS' || strategyId === 'S8_HITL') {
     return;
   }
 

--- a/tests/utils/ralph/ralph-engine.test.ts
+++ b/tests/utils/ralph/ralph-engine.test.ts
@@ -41,6 +41,7 @@ jest.mock('../../../src/config/defaults', () => ({
 
 import { resolveElementsByAXTree } from '../../../src/utils/ax-element-resolver';
 import { discoverElements } from '../../../src/utils/element-discovery';
+import { scoreElement, tokenizeQuery } from '../../../src/utils/element-finder';
 import { withDomDelta } from '../../../src/utils/dom-delta';
 
 describe('Ralph Engine', () => {
@@ -49,6 +50,14 @@ describe('Ralph Engine', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (resolveElementsByAXTree as jest.Mock).mockResolvedValue([]);
+    (discoverElements as jest.Mock).mockResolvedValue([]);
+    (scoreElement as jest.Mock).mockReturnValue(50);
+    (tokenizeQuery as jest.Mock).mockReturnValue(['test']);
+    (withDomDelta as jest.Mock).mockImplementation(async (_page: any, fn: () => Promise<void>) => {
+      await fn();
+      return { delta: '' };
+    });
 
     mockPage = {
       mouse: {
@@ -71,11 +80,11 @@ describe('Ralph Engine', () => {
       const result = await ralphClick(mockPage, mockCDPClient, 'nonexistent element');
 
       expect(result.success).toBe(false);
-      expect(result.strategyUsed).toBe('S7_HITL');
+      expect(result.strategyUsed).toBe('S8_HITL');
       expect(result.hitlRequired).toBe(true);
       expect(result.strategiesTried).toContain('S1_AX');
       expect(result.strategiesTried).toContain('S2_CSS');
-      expect(result.strategiesTried).toContain('S7_HITL');
+      expect(result.strategiesTried).toContain('S8_HITL');
     });
 
     test('should succeed on S1 when AX finds element and DOM changes', async () => {
@@ -139,6 +148,81 @@ describe('Ralph Engine', () => {
       // Should have tried multiple strategies since all return SILENT_CLICK
       expect(result.strategiesTried.length).toBeGreaterThan(1);
       expect(result.strategiesTried).toContain('S1_AX');
+    });
+
+    test('should use gated visual grounding before HITL when deterministic visual candidate is clear', async () => {
+      (resolveElementsByAXTree as jest.Mock).mockResolvedValue([]);
+      (discoverElements as jest.Mock).mockResolvedValue([]);
+      (tokenizeQuery as jest.Mock).mockReturnValue(['launch', 'report']);
+      (withDomDelta as jest.Mock).mockImplementationOnce(async (_page: any, fn: () => Promise<void>) => {
+        await fn();
+        return { delta: '+ main: "Report launched"' };
+      });
+
+      const result = await ralphClick(mockPage, mockCDPClient, 'Launch report', {
+        visualGrounding: true,
+        visualSnapshot: {
+          version: 1,
+          provider: 'mock',
+          tabId: 'tab-1',
+          url: 'https://example.test',
+          capturedAt: Date.now(),
+          viewport: { width: 800, height: 600 },
+          latencyMs: 12,
+          warnings: [],
+          elements: [{
+            id: 'v1',
+            type: 'control',
+            label: 'Launch report',
+            role: 'button',
+            interactive: true,
+            bbox: { x: 100, y: 120, width: 160, height: 40 },
+            bboxRatio: { x: 0.125, y: 0.2, width: 0.2, height: 0.067 },
+            confidence: 0.95,
+            source: 'mock',
+          }],
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.strategyUsed).toBe('S7_VISUAL_GROUNDING');
+      expect(result.strategiesTried).toContain('S7_VISUAL_GROUNDING');
+      expect(mockPage.mouse.click).toHaveBeenCalledWith(180, 140);
+      expect(result.responseLine).toContain('visual grounding');
+    });
+
+    test('should skip visual grounding for unsafe visual-only targets and escalate to HITL', async () => {
+      (resolveElementsByAXTree as jest.Mock).mockResolvedValue([]);
+      (discoverElements as jest.Mock).mockResolvedValue([]);
+      const result = await ralphClick(mockPage, mockCDPClient, 'Delete account', {
+        visualGrounding: true,
+        visualSnapshot: {
+          version: 1,
+          provider: 'mock',
+          tabId: 'tab-1',
+          url: 'https://example.test',
+          capturedAt: Date.now(),
+          viewport: { width: 800, height: 600 },
+          latencyMs: 12,
+          warnings: [],
+          elements: [{
+            id: 'v1',
+            type: 'control',
+            label: 'Delete account',
+            role: 'button',
+            interactive: true,
+            bbox: { x: 100, y: 120, width: 160, height: 40 },
+            bboxRatio: { x: 0.125, y: 0.2, width: 0.2, height: 0.067 },
+            confidence: 0.99,
+            source: 'mock',
+          }],
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.strategyUsed).toBe('S8_HITL');
+      expect(result.strategiesTried).toContain('S7_VISUAL_GROUNDING');
+      expect(mockPage.mouse.click).not.toHaveBeenCalled();
     });
 
     test('should succeed on S4 (JS inject) when earlier strategies fail', async () => {
@@ -208,7 +292,7 @@ describe('Ralph Engine', () => {
 
       // Should not have tried all 6 strategies due to budget
       expect(result.strategiesTried.length).toBeLessThanOrEqual(7);
-      expect(result.strategiesTried).toContain('S7_HITL');
+      expect(result.strategiesTried).toContain('S8_HITL');
     });
   });
 

--- a/tests/utils/ralph/strategy-learner.test.ts
+++ b/tests/utils/ralph/strategy-learner.test.ts
@@ -68,8 +68,8 @@ describe('Strategy Learner', () => {
       expect(mockRecord).not.toHaveBeenCalled();
     });
 
-    test('should NOT record S7 HITL', () => {
-      learnStrategy('https://example.com', 'button', 'S7_HITL');
+    test('should NOT record S8 HITL', () => {
+      learnStrategy('https://example.com', 'button', 'S8_HITL');
       expect(mockRecord).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary
- Fixes #1054 by adding an opt-in `S7_VISUAL_GROUNDING` strategy before `S8_HITL` in Ralph's deterministic waterfall.
- Scores provider-neutral `PerceptionSnapshot` candidates with deterministic label/role/interactivity/bbox/confidence gates.
- Blocks unsafe visual-only targets and keeps visual grounding disabled unless a caller explicitly supplies `visualGrounding` and a snapshot.

## Verification
- `npm ci`
- `npm test -- tests/utils/ralph/ralph-engine.test.ts tests/utils/ralph/strategy-learner.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint -- --quiet`
- `git diff --check`

## Notes
- This PR exposes the gated Ralph engine hook and documents the boundary.
- Tool-level interact/provider wiring should reuse this hook rather than duplicating scoring logic.
