### PR TITLE
feat(pilot): add bounded recovery runtime

### DIFF
--- a/docs/mcp/tool-annotations.md
+++ b/docs/mcp/tool-annotations.md
@@ -141,6 +141,7 @@ These tools combine network egress with destructive worst-case capability. They 
 | `network_capture_lite`  | Starts/stops passive network capture state                         |
 | `network_capture_full`  | Starts/stops passive network capture with body retention options    |
 | `oc_context_import`     | Imports cookies/storage/auth context into a tab                     |
+| `oc_pilot_run_with_recovery` | Pilot wrapper can invoke a mutating original action plus bounded recovery recipes |
 
 ### Virtual / runtime-only
 

--- a/docs/pilot/recovery-runtime.md
+++ b/docs/pilot/recovery-runtime.md
@@ -1,0 +1,39 @@
+# Pilot recovery runtime
+
+`oc_pilot_run_with_recovery` is a pilot-only wrapper for one host-selected tool
+call plus bounded deterministic recovery recipes. It is unavailable unless the
+pilot gate and contract runtime family are enabled:
+
+```bash
+OPENCHROME_PILOT=1 OPENCHROME_CONTRACT_RUNTIME=1 node dist/index.js serve
+```
+
+## Bounds
+
+- `maxRecoveryAttempts` defaults to 1 and must be `<= 3`.
+- Unsafe tools (`cookies`, `storage`, `http_auth`, `file_upload`, `tabs_close`,
+  `oc_stop`) are rejected.
+- No server-side LLM calls are made.
+- Recovery recipes are declared and deterministic.
+
+## Implemented recipes
+
+| Recipe | Behavior |
+| --- | --- |
+| `refresh_dom_state` | Calls `read_page` with bounded DOM output. |
+| `wait_for_page_ready` | Calls `wait_for` with a bounded timeout. |
+| `restore_checkpoint` | Emits metadata-only restore action evidence. |
+
+`reacquire_ref` and `switch_to_programmatic_click` are reserved names and return
+validation errors until a follow-up implements them.
+
+## Dry run
+
+`dryRun: true` proposes bounded recipes without executing the original action.
+Use it to inspect what the runtime would attempt before allowing side effects.
+
+## Output
+
+The tool returns JSON with `status`, `original`, `postcondition`, `recovery`, an
+optional redacted `checkpointId`, and `durationMs`. Every recovery attempt lists
+its recipe, reason, deterministic actions, and postcondition evaluation state.

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -143,7 +143,7 @@ import { getPerfTraceStore } from '../core/performance/insights/trace-store';
 // are set. The pilot module is loaded via `require()` only when the gate is
 // open — this preserves P2 (no module from `src/pilot/**` is loaded into the
 // process when `--pilot` is unset) while keeping `registerAllTools()` sync.
-import { isContractRuntimeEnabled, isProxyHookEnabled, isSkillReplayEnabled } from '../harness/flags';
+import { isContractRuntimeEnabled, isProxyHookEnabled, isSkillReplayEnabled, isTruthy } from '../harness/flags';
 // oc_observe (#866) — deterministic actionable-element enumeration
 import { registerOcObserveTool } from './oc-observe';
 // DevTools URL tool (#860) — expose Chrome DevTools inspector URLs
@@ -494,7 +494,7 @@ export function registerAllTools(server: MCPServer): void {
   }
 
   // Pilot contract runtime (#1061) — off unless --pilot and OPENCHROME_CONTRACT_RUNTIME are active.
-  if (isContractRuntimeEnabled()) {
+  if (isContractRuntimeEnabled() && isTruthy(process.env.OPENCHROME_CONTRACT_RUNTIME)) {
     registerOcPilotRunWithRecoveryTool(proxy);
   }
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -143,7 +143,7 @@ import { getPerfTraceStore } from '../core/performance/insights/trace-store';
 // are set. The pilot module is loaded via `require()` only when the gate is
 // open — this preserves P2 (no module from `src/pilot/**` is loaded into the
 // process when `--pilot` is unset) while keeping `registerAllTools()` sync.
-import { isProxyHookEnabled, isSkillReplayEnabled } from '../harness/flags';
+import { isContractRuntimeEnabled, isProxyHookEnabled, isSkillReplayEnabled } from '../harness/flags';
 // oc_observe (#866) — deterministic actionable-element enumeration
 import { registerOcObserveTool } from './oc-observe';
 // DevTools URL tool (#860) — expose Chrome DevTools inspector URLs
@@ -160,6 +160,7 @@ import { registerTaskRunTools } from './task-run';
 import { registerOcProgressStatusTool } from './oc-progress-status';
 // 2-stage large-output fetch (#887) — store + paging tool.
 import { registerOcOutputFetchTool } from './oc-output-fetch';
+import { registerOcPilotRunWithRecoveryTool } from './oc-pilot-run-with-recovery';
 import { getHandleStore } from '../core/output/handle-store';
 
 
@@ -284,6 +285,7 @@ export const TOOL_CAPABILITY_MAP: Record<string, ToolCapability> = {
 
   // pilot — experimental pilot-tier tools
   oc_pilot_handoff_create: 'pilot',
+  oc_pilot_run_with_recovery: 'pilot',
   oc_pilot_handoff_redeem: 'pilot',
   oc_proxy_hook: 'pilot',
 
@@ -489,6 +491,11 @@ export function registerAllTools(server: MCPServer): void {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { registerOcSkillReplayTool: _reg } = require('./oc-skill-replay') as typeof import('./oc-skill-replay');
     _reg(proxy);
+  }
+
+  // Pilot contract runtime (#1061) — off unless --pilot and OPENCHROME_CONTRACT_RUNTIME are active.
+  if (isContractRuntimeEnabled()) {
+    registerOcPilotRunWithRecoveryTool(proxy);
   }
 
   // P2 fix (#887): purge expired output handles every 5 minutes.

--- a/src/tools/oc-pilot-run-with-recovery.ts
+++ b/src/tools/oc-pilot-run-with-recovery.ts
@@ -9,7 +9,7 @@ const FUTURE_RECIPES = ['reacquire_ref', 'switch_to_programmatic_click'] as cons
 type SafeRecipeId = typeof SAFE_RECIPES[number];
 type RecoveryRecipeId = SafeRecipeId | typeof FUTURE_RECIPES[number];
 
-const UNSAFE_TOOLS = new Set(['cookies', 'storage', 'http_auth', 'file_upload', 'tabs_close', 'oc_stop']);
+const UNSAFE_TOOLS = new Set(['cookies', 'storage', 'http_auth', 'file_upload', 'tabs_close', 'oc_stop', 'oc_pilot_run_with_recovery']);
 const MAX_ATTEMPTS = 3;
 
 const definition: MCPToolDefinition = {

--- a/src/tools/oc-pilot-run-with-recovery.ts
+++ b/src/tools/oc-pilot-run-with-recovery.ts
@@ -1,0 +1,158 @@
+/** Pilot-only bounded contract-backed recovery runtime (#1061). */
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
+
+const SAFE_RECIPES = ['refresh_dom_state', 'wait_for_page_ready', 'restore_checkpoint'] as const;
+const FUTURE_RECIPES = ['reacquire_ref', 'switch_to_programmatic_click'] as const;
+type SafeRecipeId = typeof SAFE_RECIPES[number];
+type RecoveryRecipeId = SafeRecipeId | typeof FUTURE_RECIPES[number];
+
+const UNSAFE_TOOLS = new Set(['cookies', 'storage', 'http_auth', 'file_upload', 'tabs_close', 'oc_stop']);
+const MAX_ATTEMPTS = 3;
+
+const definition: MCPToolDefinition = {
+  name: 'oc_pilot_run_with_recovery',
+  description: 'Pilot-only bounded deterministic recovery wrapper for one tool call under declared safe recipes. Requires --pilot and OPENCHROME_CONTRACT_RUNTIME=1.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      tabId: { type: 'string', description: 'Optional tab id passed to recovery recipes.' },
+      action: {
+        type: 'object',
+        description: 'REQUIRED Single original tool call to execute or classify.',
+        properties: {
+          tool: { type: 'string' },
+          arguments: { type: 'object', additionalProperties: true },
+        },
+        required: ['tool', 'arguments'],
+      },
+      postcondition: { type: 'object', description: 'Optional Outcome Contract assertion metadata.', additionalProperties: true },
+      maxRecoveryAttempts: { type: 'number', description: 'Default 1, maximum 3.' },
+      checkpointBefore: { type: 'boolean', description: 'Default true. Records a redacted checkpoint reference in the response.' },
+      allowedRecipes: { type: 'array', items: { type: 'string', enum: [...SAFE_RECIPES, ...FUTURE_RECIPES] } },
+      dryRun: { type: 'boolean', description: 'Classify and propose recipes without executing the original action.' },
+    },
+    required: ['action'],
+  },
+  annotations: TOOL_ANNOTATIONS.oc_pilot_run_with_recovery,
+};
+
+interface RecoveryActionResult {
+  tool: string;
+  arguments: Record<string, unknown>;
+  ok: boolean;
+  error?: string;
+}
+
+function textOf(result: MCPResult): string {
+  return result.content?.map((item) => item.text || '').join('\n') || '';
+}
+
+function classifyFailure(tool: string, text: string): { reason: string; recipes: RecoveryRecipeId[] } | null {
+  const haystack = `${tool} ${text}`.toLowerCase();
+  if (/stale[_ -]?ref|node.*evicted|element.*not found|no elements found/.test(haystack)) {
+    return { reason: 'stale_or_missing_element', recipes: ['refresh_dom_state'] };
+  }
+  if (/timeout|deadline|not ready|loading|detached/.test(haystack)) {
+    return { reason: 'page_not_ready', recipes: ['wait_for_page_ready', 'refresh_dom_state'] };
+  }
+  if (/checkpoint|navigation|context lost/.test(haystack)) {
+    return { reason: 'checkpoint_metadata_available', recipes: ['restore_checkpoint'] };
+  }
+  return null;
+}
+
+function parseAttempts(raw: unknown): number | string {
+  const attempts = raw === undefined ? 1 : Number(raw);
+  if (!Number.isInteger(attempts) || attempts < 0) return 'maxRecoveryAttempts must be a non-negative integer';
+  if (attempts > MAX_ATTEMPTS) return `maxRecoveryAttempts must be <= ${MAX_ATTEMPTS}`;
+  return attempts;
+}
+
+function allowedRecipeSet(raw: unknown): Set<RecoveryRecipeId> {
+  if (!Array.isArray(raw) || raw.length === 0) return new Set(SAFE_RECIPES);
+  return new Set(raw as RecoveryRecipeId[]);
+}
+
+async function callTool(server: MCPServer, sessionId: string, tool: string, args: Record<string, unknown>): Promise<RecoveryActionResult> {
+  const handler = server.getToolHandler(tool);
+  if (!handler) return { tool, arguments: args, ok: false, error: `unknown tool: ${tool}` };
+  try {
+    const result = await handler(sessionId, args);
+    return { tool, arguments: args, ok: !result.isError, ...(result.isError ? { error: textOf(result) || 'tool returned error' } : {}) };
+  } catch (error) {
+    return { tool, arguments: args, ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+async function runRecipe(server: MCPServer, sessionId: string, recipe: RecoveryRecipeId, tabId: string | undefined): Promise<RecoveryActionResult[]> {
+  if (recipe === 'refresh_dom_state') {
+    return [await callTool(server, sessionId, 'read_page', { ...(tabId ? { tabId } : {}), mode: 'dom', limit: 2000 })];
+  }
+  if (recipe === 'wait_for_page_ready') {
+    return [await callTool(server, sessionId, 'wait_for', { ...(tabId ? { tabId } : {}), state: 'load', timeout: 5000 })];
+  }
+  if (recipe === 'restore_checkpoint') {
+    return [{ tool: 'restore_checkpoint', arguments: { metadataOnly: true, ...(tabId ? { tabId } : {}) }, ok: true }];
+  }
+  return [{ tool: recipe, arguments: {}, ok: false, error: `recipe ${recipe} is declared but not implemented yet` }];
+}
+
+export function registerOcPilotRunWithRecoveryTool(server: MCPServer): void {
+  const handler: ToolHandler = async (sessionId, args): Promise<MCPResult> => {
+    const start = Date.now();
+    const action = args.action as { tool?: string; arguments?: Record<string, unknown> } | undefined;
+    const tabId = args.tabId as string | undefined;
+    if (!action?.tool || typeof action.arguments !== 'object' || action.arguments === null) {
+      return { content: [{ type: 'text', text: 'INVALID_INPUT: action.tool and action.arguments are required' }], isError: true };
+    }
+    if (UNSAFE_TOOLS.has(action.tool)) {
+      return { content: [{ type: 'text', text: `UNSAFE_ACTION: ${action.tool} is excluded from pilot recovery runtime` }], isError: true };
+    }
+    const attempts = parseAttempts(args.maxRecoveryAttempts);
+    if (typeof attempts === 'string') {
+      return { content: [{ type: 'text', text: `INVALID_INPUT: ${attempts}` }], isError: true };
+    }
+
+    const checkpointId = args.checkpointBefore === false ? undefined : `pilot-checkpoint-${Date.now()}`;
+    const allowed = allowedRecipeSet(args.allowedRecipes);
+    const recovery: Array<{ attempt: number; recipe: RecoveryRecipeId; reason: string; actions: RecoveryActionResult[]; postcondition?: { evaluated: boolean; passed: boolean } }> = [];
+
+    if (args.dryRun === true) {
+      const proposal = [...allowed].filter((recipe): recipe is SafeRecipeId => SAFE_RECIPES.includes(recipe as SafeRecipeId));
+      const body = {
+        status: 'dry_run',
+        original: { ok: false, tool: action.tool },
+        postcondition: args.postcondition ? { evaluated: false, passed: false } : undefined,
+        recovery: proposal.slice(0, attempts).map((recipe, index) => ({ attempt: index + 1, recipe, reason: 'dry_run_proposal', actions: [] })),
+        checkpointId,
+        durationMs: Date.now() - start,
+      };
+      return { content: [{ type: 'text', text: JSON.stringify(body, null, 2) }], structuredContent: body };
+    }
+
+    const original = await callTool(server, sessionId, action.tool, action.arguments);
+    if (original.ok) {
+      const body = { status: 'passed', original, postcondition: args.postcondition ? { evaluated: false, passed: false } : undefined, recovery, checkpointId, durationMs: Date.now() - start };
+      return { content: [{ type: 'text', text: JSON.stringify(body, null, 2) }], structuredContent: body };
+    }
+
+    const classified = classifyFailure(action.tool, original.error || '');
+    if (classified && attempts > 0) {
+      for (const recipe of classified.recipes) {
+        if (recovery.length >= attempts) break;
+        if (!allowed.has(recipe)) continue;
+        const actions = await runRecipe(server, sessionId, recipe, tabId);
+        recovery.push({ attempt: recovery.length + 1, recipe, reason: classified.reason, actions, postcondition: { evaluated: false, passed: false } });
+      }
+    }
+
+    const status = recovery.some((entry) => entry.actions.some((actionResult) => actionResult.ok)) ? 'recovered' : 'failed';
+    const body = { status, original, postcondition: args.postcondition ? { evaluated: false, passed: false } : undefined, recovery, checkpointId, durationMs: Date.now() - start };
+    return { content: [{ type: 'text', text: JSON.stringify(body, null, 2) }], structuredContent: body, isError: status === 'failed' };
+  };
+
+  server.registerTool('oc_pilot_run_with_recovery', handler, definition);
+}

--- a/src/tools/oc-pilot-run-with-recovery.ts
+++ b/src/tools/oc-pilot-run-with-recovery.ts
@@ -50,6 +50,30 @@ function textOf(result: MCPResult): string {
   return result.content?.map((item) => item.text || '').join('\n') || '';
 }
 
+function redactString(value: string): string {
+  return value
+    .replace(/(password|passcode|token|secret|credential|api[_-]?key|authorization|cookie)\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED]')
+    .slice(0, 1000);
+}
+
+function redactValue(value: unknown, depth = 0): unknown {
+  if (depth > 4) return '[depth-limit]';
+  if (typeof value === 'string') return redactString(value);
+  if (Array.isArray(value)) return value.slice(0, 50).map((item) => redactValue(item, depth + 1));
+  if (!value || typeof value !== 'object') return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value as Record<string, unknown>).slice(0, 100)) {
+    out[key] = /password|passcode|token|secret|credential|api[_-]?key|authorization|cookie/i.test(key)
+      ? '[REDACTED]'
+      : redactValue(child, depth + 1);
+  }
+  return out;
+}
+
+function redactArgs(args: Record<string, unknown>): Record<string, unknown> {
+  return redactValue(args) as Record<string, unknown>;
+}
+
 function classifyFailure(tool: string, text: string): { reason: string; recipes: RecoveryRecipeId[] } | null {
   const haystack = `${tool} ${text}`.toLowerCase();
   if (/stale[_ -]?ref|node.*evicted|element.*not found|no elements found/.test(haystack)) {
@@ -78,12 +102,12 @@ function allowedRecipeSet(raw: unknown): Set<RecoveryRecipeId> {
 
 async function callTool(server: MCPServer, sessionId: string, tool: string, args: Record<string, unknown>): Promise<RecoveryActionResult> {
   const handler = server.getToolHandler(tool);
-  if (!handler) return { tool, arguments: args, ok: false, error: `unknown tool: ${tool}` };
+  if (!handler) return { tool, arguments: redactArgs(args), ok: false, error: `unknown tool: ${tool}` };
   try {
     const result = await handler(sessionId, args);
-    return { tool, arguments: args, ok: !result.isError, ...(result.isError ? { error: textOf(result) || 'tool returned error' } : {}) };
+    return { tool, arguments: redactArgs(args), ok: !result.isError, ...(result.isError ? { error: redactString(textOf(result) || 'tool returned error') } : {}) };
   } catch (error) {
-    return { tool, arguments: args, ok: false, error: error instanceof Error ? error.message : String(error) };
+    return { tool, arguments: redactArgs(args), ok: false, error: redactString(error instanceof Error ? error.message : String(error)) };
   }
 }
 

--- a/src/types/tool-annotations.ts
+++ b/src/types/tool-annotations.ts
@@ -95,6 +95,7 @@ export const TOOL_ANNOTATIONS = {
   oc_performance_analyze: READ_ONLY,
   oc_normalize_action: READ_ONLY,
   oc_progress_status: READ_ONLY,
+  oc_pilot_run_with_recovery: MUTATES,
 
   // ── Network egress (navigation, crawling) ───────────────────────────────
   //

--- a/tests/tools/oc-pilot-run-with-recovery.test.ts
+++ b/tests/tools/oc-pilot-run-with-recovery.test.ts
@@ -1,0 +1,117 @@
+import { registerOcPilotRunWithRecoveryTool } from '../../src/tools/oc-pilot-run-with-recovery';
+import type { MCPResult, ToolHandler } from '../../src/types/mcp';
+
+function result(text: string, isError = false): MCPResult {
+  return { content: [{ type: 'text', text }], isError };
+}
+
+function makeServer(handlers: Record<string, ToolHandler>) {
+  const tools = new Map<string, ToolHandler>();
+  return {
+    registerTool: (_name: string, handler: ToolHandler) => tools.set(_name, handler),
+    getToolHandler: (name: string) => tools.get(name) || handlers[name] || null,
+    call: async (args: Record<string, unknown>) => tools.get('oc_pilot_run_with_recovery')!('session', args),
+  };
+}
+
+function parse(result: MCPResult): Record<string, any> {
+  return JSON.parse(result.content?.[0]?.text || '{}');
+}
+
+describe('oc_pilot_run_with_recovery', () => {
+  it('dryRun proposes safe recipes without executing the original action', async () => {
+    const original = jest.fn(async () => result('should not run'));
+    const server = makeServer({ interact: original });
+    registerOcPilotRunWithRecoveryTool(server as any);
+
+    const out = parse(await server.call({
+      dryRun: true,
+      action: { tool: 'interact', arguments: { query: 'Submit' } },
+      allowedRecipes: ['refresh_dom_state', 'wait_for_page_ready'],
+      maxRecoveryAttempts: 2,
+    }));
+
+    expect(out.status).toBe('dry_run');
+    expect(out.recovery.map((entry: any) => entry.recipe)).toEqual(['refresh_dom_state', 'wait_for_page_ready']);
+    expect(original).not.toHaveBeenCalled();
+  });
+
+  it('recovers known stale element failures with refresh_dom_state evidence', async () => {
+    const server = makeServer({
+      interact: jest.fn(async () => result('STALE_REF: element not found', true)),
+      read_page: jest.fn(async () => result('fresh dom')),
+    });
+    registerOcPilotRunWithRecoveryTool(server as any);
+
+    const response = await server.call({
+      tabId: 'tab-1',
+      action: { tool: 'interact', arguments: { query: 'Submit' } },
+      allowedRecipes: ['refresh_dom_state'],
+      maxRecoveryAttempts: 1,
+    });
+    const out = parse(response);
+
+    expect(out.status).toBe('recovered');
+    expect(out.recovery[0]).toMatchObject({ recipe: 'refresh_dom_state', reason: 'stale_or_missing_element' });
+    expect(out.recovery[0].actions[0]).toMatchObject({ tool: 'read_page', ok: true });
+  });
+
+  it('rejects unsafe tools and hard bound violations', async () => {
+    const server = makeServer({});
+    registerOcPilotRunWithRecoveryTool(server as any);
+
+    const unsafe = await server.call({ action: { tool: 'cookies', arguments: {} } });
+    expect(unsafe.isError).toBe(true);
+    expect(unsafe.content?.[0]?.text).toContain('UNSAFE_ACTION');
+
+    const tooMany = await server.call({ action: { tool: 'interact', arguments: {} }, maxRecoveryAttempts: 99 });
+    expect(tooMany.isError).toBe(true);
+    expect(tooMany.content?.[0]?.text).toContain('maxRecoveryAttempts must be <= 3');
+  });
+
+  it('does not attempt recovery for unknown failure classes', async () => {
+    const server = makeServer({ interact: jest.fn(async () => result('unclassified failure', true)) });
+    registerOcPilotRunWithRecoveryTool(server as any);
+
+    const response = await server.call({ action: { tool: 'interact', arguments: { query: 'Submit' } } });
+    const out = parse(response);
+
+    expect(response.isError).toBe(true);
+    expect(out.status).toBe('failed');
+    expect(out.recovery).toEqual([]);
+  });
+});
+
+describe('oc_pilot_run_with_recovery registration gate', () => {
+  const originalPilot = process.env.OPENCHROME_PILOT;
+  const originalRuntime = process.env.OPENCHROME_CONTRACT_RUNTIME;
+
+  afterEach(() => {
+    if (originalPilot === undefined) delete process.env.OPENCHROME_PILOT;
+    else process.env.OPENCHROME_PILOT = originalPilot;
+    if (originalRuntime === undefined) delete process.env.OPENCHROME_CONTRACT_RUNTIME;
+    else process.env.OPENCHROME_CONTRACT_RUNTIME = originalRuntime;
+    jest.resetModules();
+  });
+
+  it('is absent by default and present only when pilot contract runtime is enabled', async () => {
+    let mod = await import('../../src/harness/flags');
+    mod.resetFlagsCache();
+    let tools = await import('../../src/tools');
+    let { MCPServer } = await import('../../src/mcp-server');
+    let server = new MCPServer(undefined as any);
+    tools.registerAllTools(server);
+    expect(server.getToolNames()).not.toContain('oc_pilot_run_with_recovery');
+
+    jest.resetModules();
+    process.env.OPENCHROME_PILOT = '1';
+    process.env.OPENCHROME_CONTRACT_RUNTIME = '1';
+    mod = await import('../../src/harness/flags');
+    mod.resetFlagsCache();
+    tools = await import('../../src/tools');
+    ({ MCPServer } = await import('../../src/mcp-server'));
+    server = new MCPServer(undefined as any);
+    tools.registerAllTools(server);
+    expect(server.getToolNames()).toContain('oc_pilot_run_with_recovery');
+  });
+});

--- a/tests/tools/oc-pilot-run-with-recovery.test.ts
+++ b/tests/tools/oc-pilot-run-with-recovery.test.ts
@@ -84,6 +84,35 @@ describe('oc_pilot_run_with_recovery', () => {
     expect(out.status).toBe('failed');
     expect(out.recovery).toEqual([]);
   });
+
+  it('redacts sensitive action arguments and tool errors in recovery reports', async () => {
+    const server = makeServer({
+      fill_form: jest.fn(async () => result('password: hunter2 token=abc123 stale ref', true)),
+      read_page: jest.fn(async () => result('fresh dom')),
+    });
+    registerOcPilotRunWithRecoveryTool(server as any);
+
+    const response = await server.call({
+      action: {
+        tool: 'fill_form',
+        arguments: { password: 'hunter2', nested: { apiKey: 'abc123' }, note: 'token=raw-secret stale ref' },
+      },
+      allowedRecipes: ['refresh_dom_state'],
+      maxRecoveryAttempts: 1,
+    });
+    const out = parse(response);
+    const text = JSON.stringify(out);
+
+    expect(text).not.toContain('hunter2');
+    expect(text).not.toContain('abc123');
+    expect(text).not.toContain('raw-secret');
+    expect(out.original.arguments).toMatchObject({
+      password: '[REDACTED]',
+      nested: { apiKey: '[REDACTED]' },
+      note: 'token=[REDACTED] stale ref',
+    });
+    expect(out.original.error).toContain('[REDACTED]');
+  });
 });
 
 describe('oc_pilot_run_with_recovery registration gate', () => {

--- a/tests/tools/oc-pilot-run-with-recovery.test.ts
+++ b/tests/tools/oc-pilot-run-with-recovery.test.ts
@@ -64,6 +64,10 @@ describe('oc_pilot_run_with_recovery', () => {
     expect(unsafe.isError).toBe(true);
     expect(unsafe.content?.[0]?.text).toContain('UNSAFE_ACTION');
 
+    const recursive = await server.call({ action: { tool: 'oc_pilot_run_with_recovery', arguments: { action: { tool: 'interact', arguments: {} } } } });
+    expect(recursive.isError).toBe(true);
+    expect(recursive.content?.[0]?.text).toContain('UNSAFE_ACTION');
+
     const tooMany = await server.call({ action: { tool: 'interact', arguments: {} }, maxRecoveryAttempts: 99 });
     expect(tooMany.isError).toBe(true);
     expect(tooMany.content?.[0]?.text).toContain('maxRecoveryAttempts must be <= 3');
@@ -100,6 +104,17 @@ describe('oc_pilot_run_with_recovery registration gate', () => {
     let tools = await import('../../src/tools');
     let { MCPServer } = await import('../../src/mcp-server');
     let server = new MCPServer(undefined as any);
+    tools.registerAllTools(server);
+    expect(server.getToolNames()).not.toContain('oc_pilot_run_with_recovery');
+
+    jest.resetModules();
+    process.env.OPENCHROME_PILOT = '1';
+    delete process.env.OPENCHROME_CONTRACT_RUNTIME;
+    mod = await import('../../src/harness/flags');
+    mod.resetFlagsCache();
+    tools = await import('../../src/tools');
+    ({ MCPServer } = await import('../../src/mcp-server'));
+    server = new MCPServer(undefined as any);
     tools.registerAllTools(server);
     expect(server.getToolNames()).not.toContain('oc_pilot_run_with_recovery');
 


### PR DESCRIPTION
## Summary
- Fixes #1061 by adding pilot-only `oc_pilot_run_with_recovery`, gated behind `--pilot`/`OPENCHROME_PILOT=1` and `OPENCHROME_CONTRACT_RUNTIME=1`.
- Adds dry-run recipe proposals, unsafe-tool rejection, `maxRecoveryAttempts <= 3`, deterministic failure classification, and safe recipe evidence for `refresh_dom_state`, `wait_for_page_ready`, and metadata-only `restore_checkpoint`.
- Documents the pilot recovery runtime safety model and updates tool annotation docs.

## Verification
- `npm ci`
- `npm test -- tests/tools/oc-pilot-run-with-recovery.test.ts --runInBand`
- `npm test -- tests/unit/tool-annotations.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint -- --quiet`
- `OPENCHROME_PILOT=1 OPENCHROME_CONTRACT_RUNTIME=1 npm run lint:tool-schemas`
- `git diff --check`

## Notes
- Default core tools/list remains unchanged; registration test asserts the tool is absent by default and present only with pilot contract runtime enabled.
- No server-side LLM/API/provider code is added.
