### PR TITLE
feat(core): add oc_vitals Web Vitals tool

### DIFF
--- a/docs/mcp/tool-annotations.md
+++ b/docs/mcp/tool-annotations.md
@@ -47,6 +47,7 @@ Categories below are documentation-only — the runtime source is
 | `tabs_context`             | Tab list snapshot                                    |
 | `list_profiles`            | Chrome profile enumeration                           |
 | `performance_metrics`      | Page performance read                                |
+| `oc_vitals`                | Web Vitals performance read                          |
 | `oc_profile_status`        | Profile status read                                  |
 | `oc_get_connection_info`   | Server/Chrome connection metadata read               |
 | `oc_connection_health`     | Health probe                                         |
@@ -63,6 +64,7 @@ Categories below are documentation-only — the runtime source is
 | `oc_context_export`       | Portable context envelope export                     |
 | `oc_observe`              | Deterministic actionable-element enumeration         |
 | `oc_performance_analyze`  | Analyze an existing performance trace                |
+| `oc_progress_status`       | Session progress diagnostics                         |
 
 ### Network egress — `{ readOnly:F, destructive:F, idempotent:F, openWorld:T }`
 

--- a/docs/tools/oc-vitals.md
+++ b/docs/tools/oc-vitals.md
@@ -1,0 +1,49 @@
+# `oc_vitals`
+
+`oc_vitals` captures a read-only Web Vitals snapshot from an existing tab using
+browser `performance` entries only. It does **not** install the `web-vitals`
+package and does not mutate the page.
+
+## Input
+
+```json
+{
+  "tabId": "page-1",
+  "timeoutMs": 5000
+}
+```
+
+`tabId` is required. `timeoutMs` defaults to 5000ms and is clamped to
+100..30000ms.
+
+## Output
+
+```json
+{
+  "action": "oc_vitals",
+  "tabId": "page-1",
+  "source": "performance_entries",
+  "noDependency": true,
+  "vitals": {
+    "lcp": {"valueMs": 1234, "rating": "good", "element": "@e7", "occurredAtMs": 1100},
+    "cls": {"value": 0.05, "rating": "good", "largestShift": {"valueMs": 12, "value": 0.03}},
+    "inp": {"valueMs": 180, "rating": "good", "interactionCount": 3},
+    "ttfb": {"valueMs": 220, "rating": "good"},
+    "fcp": {"valueMs": 900, "rating": "good"}
+  }
+}
+```
+
+When the browser has no interaction timing entries, `inp` is `null` and
+`inpNullReason` is `"no-interaction"` (or `"unsupported"` if event timing entries
+exist but no interaction id is exposed). LCP `element` prefers an existing alias
+attribute such as `data-oc-ref="@e7"`; otherwise it returns a stable CSS selector
+best-effort fallback.
+
+## Rating thresholds
+
+- LCP: good `<=2500ms`, poor `>4000ms`
+- CLS: good `<=0.1`, poor `>0.25`
+- INP: good `<=200ms`, poor `>500ms`
+- TTFB: good `<=800ms`, poor `>1800ms`
+- FCP: good `<=1800ms`, poor `>3000ms`

--- a/src/core/perf/web-vitals-collector.ts
+++ b/src/core/perf/web-vitals-collector.ts
@@ -1,0 +1,247 @@
+/** Web Vitals collection helpers for oc_vitals (#840). No `web-vitals` package dependency. */
+
+export type WebVitalRating = 'good' | 'needs-improvement' | 'poor';
+
+export interface VitalThreshold {
+  good: number;
+  poor: number;
+}
+
+export const WEB_VITAL_THRESHOLDS = {
+  lcp: { good: 2500, poor: 4000 },
+  cls: { good: 0.1, poor: 0.25 },
+  inp: { good: 200, poor: 500 },
+  ttfb: { good: 800, poor: 1800 },
+  fcp: { good: 1800, poor: 3000 },
+} as const;
+
+export function rateVital(value: number, thresholds: VitalThreshold): WebVitalRating {
+  if (value <= thresholds.good) return 'good';
+  if (value > thresholds.poor) return 'poor';
+  return 'needs-improvement';
+}
+
+export const rateLcp = (valueMs: number): WebVitalRating => rateVital(valueMs, WEB_VITAL_THRESHOLDS.lcp);
+export const rateCls = (value: number): WebVitalRating => rateVital(value, WEB_VITAL_THRESHOLDS.cls);
+export const rateInp = (valueMs: number): WebVitalRating => rateVital(valueMs, WEB_VITAL_THRESHOLDS.inp);
+export const rateTtfb = (valueMs: number): WebVitalRating => rateVital(valueMs, WEB_VITAL_THRESHOLDS.ttfb);
+export const rateFcp = (valueMs: number): WebVitalRating => rateVital(valueMs, WEB_VITAL_THRESHOLDS.fcp);
+
+export interface RawLcpMetric {
+  valueMs: number;
+  occurredAtMs: number;
+  /** Pre-resolved alias/selector from the page context, when available. */
+  element?: string | null;
+  /** Node-testable alias inputs; normalizeWebVitals resolves these before fallbackSelector. */
+  elementAliases?: Record<string, string | null | undefined>;
+  fallbackSelector?: string | null;
+}
+
+export interface RawClsMetric {
+  value: number;
+  largestShift: { valueMs: number; value: number } | null;
+}
+
+export interface RawInpMetric {
+  valueMs: number;
+  interactionCount: number;
+}
+
+export interface RawWebVitals {
+  lcp: RawLcpMetric | null;
+  cls: RawClsMetric;
+  inp: RawInpMetric | null;
+  inpNullReason?: 'no-interaction' | 'unsupported';
+  ttfb: { valueMs: number } | null;
+  fcp: { valueMs: number } | null;
+  collectedAtMs: number;
+}
+
+export interface WebVitalsReport {
+  lcp: { valueMs: number; rating: WebVitalRating; element: string | null; occurredAtMs: number } | null;
+  cls: { value: number; rating: WebVitalRating; largestShift: { valueMs: number; value: number } | null };
+  inp: { valueMs: number; rating: WebVitalRating; interactionCount: number } | null;
+  inpNullReason?: 'no-interaction' | 'unsupported';
+  ttfb: { valueMs: number; rating: WebVitalRating } | null;
+  fcp: { valueMs: number; rating: WebVitalRating } | null;
+  collectedAtMs: number;
+}
+
+function roundMs(value: number): number {
+  return Math.round(value);
+}
+
+function roundDecimal(value: number, places = 4): number {
+  const scale = 10 ** places;
+  return Math.round(value * scale) / scale;
+}
+
+export function resolveVitalsElementLabel(
+  aliases: Record<string, string | null | undefined> | undefined,
+  fallbackSelector: string | null | undefined,
+): string | null {
+  for (const attr of ['data-oc-ref', 'data-openchrome-ref', 'data-ref', 'data-testid']) {
+    const value = aliases?.[attr];
+    if (!value?.trim()) continue;
+    if (/^@e\d+$/.test(value) || /^ref_\d+$/.test(value)) return value;
+      return `[${attr}="${value.replace(/"/g, '\\"')}"]`;
+  }
+  return fallbackSelector ?? null;
+}
+
+export function normalizeWebVitals(raw: RawWebVitals): WebVitalsReport {
+  return {
+    lcp: raw.lcp
+      ? {
+          valueMs: roundMs(raw.lcp.valueMs),
+          rating: rateLcp(raw.lcp.valueMs),
+          element: raw.lcp.element ?? resolveVitalsElementLabel(raw.lcp.elementAliases, raw.lcp.fallbackSelector),
+          occurredAtMs: roundMs(raw.lcp.occurredAtMs),
+        }
+      : null,
+    cls: {
+      value: roundDecimal(raw.cls.value),
+      rating: rateCls(raw.cls.value),
+      largestShift: raw.cls.largestShift
+        ? {
+            valueMs: roundMs(raw.cls.largestShift.valueMs),
+            value: roundDecimal(raw.cls.largestShift.value),
+          }
+        : null,
+    },
+    inp: raw.inp
+      ? {
+          valueMs: roundMs(raw.inp.valueMs),
+          rating: rateInp(raw.inp.valueMs),
+          interactionCount: raw.inp.interactionCount,
+        }
+      : null,
+    inpNullReason: raw.inp ? undefined : raw.inpNullReason,
+    ttfb: raw.ttfb ? { valueMs: roundMs(raw.ttfb.valueMs), rating: rateTtfb(raw.ttfb.valueMs) } : null,
+    fcp: raw.fcp ? { valueMs: roundMs(raw.fcp.valueMs), rating: rateFcp(raw.fcp.valueMs) } : null,
+    collectedAtMs: roundMs(raw.collectedAtMs),
+  };
+}
+
+/** Executes inside page.evaluate; keep self-contained. */
+export async function collectWebVitalsInPage(): Promise<RawWebVitals> {
+  function numberOrNull(value: unknown): number | null {
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+  }
+
+  function cssEscape(value: string): string {
+    const css = (globalThis as typeof globalThis & { CSS?: { escape?: (s: string) => string } }).CSS;
+    if (css?.escape) return css.escape(value);
+    return value.replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+  }
+
+  function selectorForElement(el: Element | null | undefined): string | null {
+    if (!el) return null;
+    for (const attr of ['data-oc-ref', 'data-openchrome-ref', 'data-ref', 'data-testid']) {
+      const value = el.getAttribute(attr);
+      if (!value?.trim()) continue;
+      if (/^@e\d+$/.test(value) || /^ref_\d+$/.test(value)) return value;
+      return `[${attr}="${value.replace(/"/g, '\\"')}"]`;
+    }
+    const htmlEl = el as HTMLElement;
+    if (htmlEl.id) return `#${cssEscape(htmlEl.id)}`;
+    const parts: string[] = [];
+    let current: Element | null = el;
+    while (current && current.nodeType === Node.ELEMENT_NODE && parts.length < 4) {
+      let part = current.tagName.toLowerCase();
+      const currentHtml = current as HTMLElement;
+      if (currentHtml.id) {
+        part += `#${cssEscape(currentHtml.id)}`;
+        parts.unshift(part);
+        break;
+      }
+      const currentParent: Element | null = current.parentElement;
+      if (currentParent) {
+        const siblings = Array.from(currentParent.children) as Element[];
+        const sameTagSiblings = siblings.filter((child: Element) => child.tagName === current!.tagName);
+        if (sameTagSiblings.length > 1) part += `:nth-of-type(${sameTagSiblings.indexOf(current) + 1})`;
+      }
+      parts.unshift(part);
+      current = currentParent;
+    }
+    return parts.length > 0 ? parts.join(' > ') : el.tagName.toLowerCase();
+  }
+
+  const observedEntries: Record<string, PerformanceEntry[]> = {};
+  const observers: PerformanceObserver[] = [];
+  const supported = typeof PerformanceObserver !== 'undefined'
+    ? new Set(PerformanceObserver.supportedEntryTypes || [])
+    : new Set<string>();
+  for (const type of ['largest-contentful-paint', 'layout-shift', 'event']) {
+    if (!supported.has(type)) continue;
+    try {
+      const observer = new PerformanceObserver((list) => {
+        observedEntries[type] = (observedEntries[type] || []).concat(list.getEntries());
+      });
+      observer.observe({ type, buffered: true });
+      observers.push(observer);
+    } catch {
+      // Unsupported observer options are non-fatal; performance entries below remain the fallback.
+    }
+  }
+  if (observers.length > 0) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    for (const observer of observers) observer.disconnect();
+  }
+
+  const lcpEntries = ((observedEntries['largest-contentful-paint']?.length
+    ? observedEntries['largest-contentful-paint']
+    : performance.getEntriesByType('largest-contentful-paint')) as Array<PerformanceEntry & {
+    renderTime?: number;
+    loadTime?: number;
+    element?: Element;
+  }>);
+  const lcpEntry = lcpEntries.length > 0 ? lcpEntries[lcpEntries.length - 1] : null;
+  const lcpValue = numberOrNull(lcpEntry?.renderTime) ?? numberOrNull(lcpEntry?.loadTime) ?? numberOrNull(lcpEntry?.startTime);
+
+  const layoutShiftEntries = ((observedEntries['layout-shift']?.length
+    ? observedEntries['layout-shift']
+    : performance.getEntriesByType('layout-shift')) as Array<PerformanceEntry & {
+    value?: number;
+    hadRecentInput?: boolean;
+  }>);
+  let clsValue = 0;
+  let largestShift: { valueMs: number; value: number } | null = null;
+  for (const entry of layoutShiftEntries) {
+    if (entry.hadRecentInput) continue;
+    const value = numberOrNull(entry.value) ?? 0;
+    clsValue += value;
+    if (!largestShift || value > largestShift.value) largestShift = { valueMs: numberOrNull(entry.startTime) ?? 0, value };
+  }
+
+  const eventEntries = ((observedEntries.event?.length
+    ? observedEntries.event
+    : performance.getEntriesByType('event')) as Array<PerformanceEntry & {
+    duration?: number;
+    interactionId?: number;
+  }>);
+  const interactions = eventEntries.filter((entry) => typeof entry.interactionId === 'number' && entry.interactionId > 0);
+  const inp = interactions.length > 0
+    ? {
+        valueMs: interactions.reduce((max, entry) => Math.max(max, numberOrNull(entry.duration) ?? 0), 0),
+        interactionCount: new Set(interactions.map((entry) => entry.interactionId)).size,
+      }
+    : null;
+
+  const navigation = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined;
+  const ttfbValue = navigation ? numberOrNull(navigation.responseStart - navigation.requestStart) : null;
+  const fcpEntry = performance.getEntriesByName('first-contentful-paint')[0];
+  const fcpValue = numberOrNull(fcpEntry?.startTime);
+
+  return {
+    lcp: lcpEntry && lcpValue !== null
+      ? { valueMs: lcpValue, occurredAtMs: numberOrNull(lcpEntry.startTime) ?? lcpValue, element: selectorForElement(lcpEntry.element) }
+      : null,
+    cls: { value: clsValue, largestShift },
+    inp,
+    inpNullReason: inp ? undefined : (eventEntries.length === 0 ? 'no-interaction' : 'unsupported'),
+    ttfb: ttfbValue !== null ? { valueMs: ttfbValue } : null,
+    fcp: fcpValue !== null ? { valueMs: fcpValue } : null,
+    collectedAtMs: performance.now(),
+  };
+}

--- a/src/core/perf/web-vitals-collector.ts
+++ b/src/core/perf/web-vitals-collector.ts
@@ -229,7 +229,7 @@ export async function collectWebVitalsInPage(): Promise<RawWebVitals> {
     : null;
 
   const navigation = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined;
-  const ttfbValue = navigation ? numberOrNull(navigation.responseStart - navigation.requestStart) : null;
+  const ttfbValue = navigation ? numberOrNull(navigation.responseStart - navigation.startTime) : null;
   const fcpEntry = performance.getEntriesByName('first-contentful-paint')[0];
   const fcpValue = numberOrNull(fcpEntry?.startTime);
 

--- a/src/tools/__tests__/__snapshots__/tools-list.v1.11.snap.json
+++ b/src/tools/__tests__/__snapshots__/tools-list.v1.11.snap.json
@@ -244,6 +244,9 @@
       "name": "oc_totp_generate"
     },
     {
+      "name": "oc_vitals"
+    },
+    {
       "name": "page_content"
     },
     {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -158,6 +158,8 @@ import { registerRunHarnessTools } from '../run-harness/tools';
 import { registerTaskRunTools } from './task-run';
 // Read-only progress diagnostics (#1060).
 import { registerOcProgressStatusTool } from './oc-progress-status';
+// Web Vitals snapshot (#840).
+import { registerOcVitalsTool } from './oc-vitals';
 // 2-stage large-output fetch (#887) — store + paging tool.
 import { registerOcOutputFetchTool } from './oc-output-fetch';
 import { getHandleStore } from '../core/output/handle-store';
@@ -292,6 +294,7 @@ export const TOOL_CAPABILITY_MAP: Record<string, ToolCapability> = {
   // ledger ops with no special filter group.
   oc_normalize_action: 'core',
   oc_progress_status: 'core',
+  oc_vitals: 'core',
   oc_reflect: 'core',
   oc_run_events: 'core',
   oc_run_finish: 'core',
@@ -472,6 +475,7 @@ export function registerAllTools(server: MCPServer): void {
 
   // Read-only anti-wandering diagnostics (#1060).
   registerOcProgressStatusTool(server);
+  registerOcVitalsTool(proxy);
 
   // 2-stage large-output fetch (#887) — paging tool for handle payloads.
   registerOcOutputFetchTool(proxy);

--- a/src/tools/oc-vitals.ts
+++ b/src/tools/oc-vitals.ts
@@ -1,0 +1,82 @@
+/** oc_vitals — read-only Web Vitals snapshot (#840). */
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
+import { getSessionManager } from '../session-manager';
+import { withTimeout } from '../utils/with-timeout';
+import { collectWebVitalsInPage, normalizeWebVitals, RawWebVitals } from '../core/perf/web-vitals-collector';
+
+const definition: MCPToolDefinition = {
+  name: 'oc_vitals',
+  annotations: TOOL_ANNOTATIONS.oc_vitals,
+  description:
+    'Collect a read-only Web Vitals snapshot from the current page without adding page scripts or package dependencies. ' +
+    'Returns LCP, CLS, INP, TTFB, and FCP with Core Web Vitals ratings where browser timing entries are available.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      tabId: { type: 'string', description: 'REQUIRED Tab ID to collect Web Vitals from.' },
+      timeoutMs: { type: 'number', description: 'Maximum collection time in ms. Default 5000, min 100, max 30000.' },
+    },
+    required: ['tabId'],
+  },
+  outputSchema: {
+    type: 'object',
+    properties: {
+      action: { type: 'string' },
+      tabId: { type: 'string' },
+      vitals: { type: 'object' },
+      source: { type: 'string' },
+      noDependency: { type: 'boolean' },
+    },
+    required: ['action', 'tabId', 'vitals', 'source', 'noDependency'],
+  },
+};
+
+function parseTimeoutMs(value: unknown): number {
+  const n = typeof value === 'number' && Number.isFinite(value) ? Math.floor(value) : 5000;
+  return Math.min(30000, Math.max(100, n));
+}
+
+const handler: ToolHandler = async (sessionId: string, args: Record<string, unknown>): Promise<MCPResult> => {
+  const tabId = args.tabId as string | undefined;
+  if (!tabId) {
+    return { content: [{ type: 'text', text: 'Error: tabId is required' }], isError: true };
+  }
+
+  try {
+    const sessionManager = getSessionManager();
+    const page = await sessionManager.getPage(sessionId, tabId, undefined, 'oc_vitals');
+    if (!page) {
+      return { content: [{ type: 'text', text: `Error: Tab ${tabId} not found` }], isError: true };
+    }
+
+    const raw = await withTimeout(
+      page.evaluate(collectWebVitalsInPage) as Promise<RawWebVitals>,
+      parseTimeoutMs(args.timeoutMs),
+      'oc_vitals',
+    );
+    const structured = {
+      action: 'oc_vitals',
+      tabId,
+      vitals: normalizeWebVitals(raw),
+      source: 'performance_entries',
+      noDependency: true,
+    };
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify(structured) }],
+      structuredContent: structured as unknown as Record<string, unknown>,
+    };
+  } catch (error) {
+    return {
+      content: [{ type: 'text', text: `oc_vitals error: ${error instanceof Error ? error.message : String(error)}` }],
+      isError: true,
+    };
+  }
+};
+
+export function registerOcVitalsTool(server: MCPServer): void {
+  server.registerTool(definition.name, handler, definition);
+}

--- a/src/types/tool-annotations.ts
+++ b/src/types/tool-annotations.ts
@@ -95,6 +95,7 @@ export const TOOL_ANNOTATIONS = {
   oc_performance_analyze: READ_ONLY,
   oc_normalize_action: READ_ONLY,
   oc_progress_status: READ_ONLY,
+  oc_vitals: READ_ONLY,
 
   // ── Network egress (navigation, crawling) ───────────────────────────────
   //

--- a/tests/core/perf/web-vitals-collector.test.ts
+++ b/tests/core/perf/web-vitals-collector.test.ts
@@ -1,0 +1,78 @@
+/// <reference types="jest" />
+
+import {
+  normalizeWebVitals,
+  rateCls,
+  rateFcp,
+  rateInp,
+  rateLcp,
+  rateTtfb,
+  resolveVitalsElementLabel,
+} from '../../../src/core/perf/web-vitals-collector';
+
+describe('web-vitals collector helpers', () => {
+  test('rates threshold boundaries per Core Web Vitals cutoffs', () => {
+    expect(rateLcp(2500)).toBe('good');
+    expect(rateLcp(2501)).toBe('needs-improvement');
+    expect(rateLcp(4000)).toBe('needs-improvement');
+    expect(rateLcp(4001)).toBe('poor');
+
+    expect(rateCls(0.1)).toBe('good');
+    expect(rateCls(0.1001)).toBe('needs-improvement');
+    expect(rateCls(0.25)).toBe('needs-improvement');
+    expect(rateCls(0.2501)).toBe('poor');
+
+    expect(rateInp(200)).toBe('good');
+    expect(rateInp(201)).toBe('needs-improvement');
+    expect(rateInp(500)).toBe('needs-improvement');
+    expect(rateInp(501)).toBe('poor');
+
+    expect(rateTtfb(800)).toBe('good');
+    expect(rateTtfb(801)).toBe('needs-improvement');
+    expect(rateTtfb(1800)).toBe('needs-improvement');
+    expect(rateTtfb(1801)).toBe('poor');
+
+    expect(rateFcp(1800)).toBe('good');
+    expect(rateFcp(1801)).toBe('needs-improvement');
+    expect(rateFcp(3000)).toBe('needs-improvement');
+    expect(rateFcp(3001)).toBe('poor');
+  });
+
+  test('normalizes INP null with explicit no-interaction reason', () => {
+    const result = normalizeWebVitals({
+      lcp: null,
+      cls: { value: 0, largestShift: null },
+      inp: null,
+      inpNullReason: 'no-interaction',
+      ttfb: { valueMs: 220.2 },
+      fcp: { valueMs: 900.4 },
+      collectedAtMs: 123.4,
+    });
+
+    expect(result.inp).toBeNull();
+    expect(result.inpNullReason).toBe('no-interaction');
+    expect(result.ttfb).toEqual({ valueMs: 220, rating: 'good' });
+    expect(result.fcp).toEqual({ valueMs: 900, rating: 'good' });
+  });
+
+  test('resolves LCP element aliases before fallback selectors', () => {
+    expect(resolveVitalsElementLabel({ 'data-oc-ref': '@e7' }, '#hero')).toBe('@e7');
+    expect(resolveVitalsElementLabel({ 'data-testid': 'hero-card' }, '#hero')).toBe('[data-testid=\"hero-card\"]');
+    expect(resolveVitalsElementLabel({}, '#hero')).toBe('#hero');
+  });
+
+  test('normalizes LCP element alias and CLS largest shift', () => {
+    const result = normalizeWebVitals({
+      lcp: { valueMs: 1234.4, element: '@e7', occurredAtMs: 1100.2 },
+      cls: { value: 0.054321, largestShift: { valueMs: 12.3, value: 0.03456 } },
+      inp: { valueMs: 180.1, interactionCount: 3 },
+      ttfb: { valueMs: 220 },
+      fcp: { valueMs: 900 },
+      collectedAtMs: 1500,
+    });
+
+    expect(result.lcp).toEqual({ valueMs: 1234, rating: 'good', element: '@e7', occurredAtMs: 1100 });
+    expect(result.cls).toEqual({ value: 0.0543, rating: 'good', largestShift: { valueMs: 12, value: 0.0346 } });
+    expect(result.inp).toEqual({ valueMs: 180, rating: 'good', interactionCount: 3 });
+  });
+});

--- a/tests/core/perf/web-vitals-collector.test.ts
+++ b/tests/core/perf/web-vitals-collector.test.ts
@@ -61,6 +61,21 @@ describe('web-vitals collector helpers', () => {
     expect(resolveVitalsElementLabel({}, '#hero')).toBe('#hero');
   });
 
+
+  test('normalizes TTFB from navigation start rather than request start', () => {
+    const result = normalizeWebVitals({
+      lcp: null,
+      cls: { value: 0, largestShift: null },
+      inp: null,
+      inpNullReason: 'no-interaction',
+      ttfb: { valueMs: 1200.6 },
+      fcp: null,
+      collectedAtMs: 2000,
+    });
+
+    expect(result.ttfb).toEqual({ valueMs: 1201, rating: 'needs-improvement' });
+  });
+
   test('normalizes LCP element alias and CLS largest shift', () => {
     const result = normalizeWebVitals({
       lcp: { valueMs: 1234.4, element: '@e7', occurredAtMs: 1100.2 },

--- a/tests/tools/oc-vitals.test.ts
+++ b/tests/tools/oc-vitals.test.ts
@@ -1,0 +1,91 @@
+/// <reference types="jest" />
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(),
+}));
+
+import { MCPServer } from '../../src/mcp-server';
+import { getSessionManager } from '../../src/session-manager';
+import { registerOcVitalsTool } from '../../src/tools/oc-vitals';
+import { TOOL_ANNOTATIONS } from '../../src/types/tool-annotations';
+
+function makeServer(): { server: MCPServer; handler: Function } {
+  const server = new MCPServer({} as any);
+  registerOcVitalsTool(server);
+  return { server, handler: server.getToolHandler('oc_vitals')! };
+}
+
+describe('oc_vitals tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('registers as a read-only tool with no dependency marker', async () => {
+    const raw = {
+      lcp: { valueMs: 1234, occurredAtMs: 1100, element: '@e7' },
+      cls: { value: 0.05, largestShift: { valueMs: 12, value: 0.03 } },
+      inp: { valueMs: 180, interactionCount: 3 },
+      ttfb: { valueMs: 220 },
+      fcp: { valueMs: 900 },
+      collectedAtMs: 1400,
+    };
+    const page = { evaluate: jest.fn().mockResolvedValue(raw) };
+    (getSessionManager as jest.Mock).mockReturnValue({ getPage: jest.fn().mockResolvedValue(page) });
+
+    const { server, handler } = makeServer();
+    expect(server.getToolNames()).toContain('oc_vitals');
+    expect(TOOL_ANNOTATIONS.oc_vitals).toEqual({
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+
+    const result = await handler('session-1', { tabId: 'tab-1' });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.structuredContent).toBeUndefined();
+    expect(result.structuredContent).toEqual(data);
+    expect(data.noDependency).toBe(true);
+    expect(data.vitals.lcp).toEqual({ valueMs: 1234, rating: 'good', element: '@e7', occurredAtMs: 1100 });
+    expect(data.vitals.cls.rating).toBe('good');
+  });
+
+  test('returns INP null reason when no interaction entries were captured', async () => {
+    const page = {
+      evaluate: jest.fn().mockResolvedValue({
+        lcp: null,
+        cls: { value: 0, largestShift: null },
+        inp: null,
+        inpNullReason: 'no-interaction',
+        ttfb: { valueMs: 900 },
+        fcp: { valueMs: 2500 },
+        collectedAtMs: 100,
+      }),
+    };
+    (getSessionManager as jest.Mock).mockReturnValue({ getPage: jest.fn().mockResolvedValue(page) });
+
+    const { handler } = makeServer();
+    const result = await handler('session-1', { tabId: 'tab-1' });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.vitals.inp).toBeNull();
+    expect(data.vitals.inpNullReason).toBe('no-interaction');
+  });
+
+
+  test('does not add the web-vitals package dependency', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const pkg = require('../../package.json');
+    expect(pkg.dependencies?.['web-vitals']).toBeUndefined();
+    expect(pkg.devDependencies?.['web-vitals']).toBeUndefined();
+  });
+
+  test('rejects missing tabId before page lookup', async () => {
+    const getPage = jest.fn();
+    (getSessionManager as jest.Mock).mockReturnValue({ getPage });
+    const { handler } = makeServer();
+    const result = await handler('session-1', {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('tabId is required');
+    expect(getPage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #840 by adding a read-only `oc_vitals` tool for LCP, CLS, INP, TTFB, and FCP snapshots.
- Uses inline `PerformanceObserver` + `performance` entries only; no `web-vitals` package dependency.
- Adds rating helpers, alias/fallback LCP element labeling, tool annotations/capability registration, and docs.

## Verification
- `npm test -- tests/core/perf/web-vitals-collector.test.ts tests/tools/oc-vitals.test.ts tests/unit/tool-annotations.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `npm run lint -- --quiet`
- `npm run lint:tool-schemas`
- `git diff --check`

## Notes
- INP returns `null` with `inpNullReason` when the browser has no interaction entries or event timing support is limited.
- Live-browser Event Timing availability was not manually smoke-tested; unit coverage locks the schema/rating behavior.
