### PR TITLE
feat(core): add batch idempotency and inter-item waits

### DIFF
--- a/docs/tools/batch-execute-idempotency.md
+++ b/docs/tools/batch-execute-idempotency.md
@@ -1,0 +1,60 @@
+# `batch_execute` idempotency and inter-item waits
+
+`batch_execute` keeps its default behavior unchanged when the new fields are
+omitted. `failFast` remains the existing stop-on-first-failure flag; this change
+does not rename or replace it.
+
+## Per-item idempotency
+
+Each task may include `idempotencyKey`:
+
+```json
+{
+  "concurrency": 1,
+  "tasks": [
+    { "tabId": "page-1", "script": "window.stepA()", "idempotencyKey": "step-A" }
+  ]
+}
+```
+
+Successful results are cached in memory per MCP session. A later task with the
+same key within the TTL returns the prior `BatchTaskResult` plus
+`"skipped": "idempotent"` and does not execute the script again. Failed results
+are not cached.
+
+Configuration:
+
+- `OPENCHROME_BATCH_IDEMPOTENCY_TTL_MS` — default 10 minutes.
+- `OPENCHROME_BATCH_IDEMPOTENCY_MAX` — default 256 entries per session.
+
+Eviction is TTL + LRU bounded. The cache is not persisted across processes or
+shared across sessions.
+
+## Inter-item waits
+
+Sequential batches (`concurrency: 1`) may wait after an item before the next
+sibling starts:
+
+```json
+{
+  "concurrency": 1,
+  "tasks": [
+    {
+      "tabId": "page-1",
+      "script": "document.querySelector('button').click()",
+      "interItemWaitFor": { "type": "function", "value": "window.__loaded === true" }
+    },
+    { "tabId": "page-1", "script": "document.body.innerText" }
+  ]
+}
+```
+
+`interItemWaitMs` provides a fixed delay. `interItemWaitFor` accepts the same
+condition families as `wait_for`: `selector`, `selector_hidden`, `function`,
+`navigation`, `url_match`, and `timeout`. Waits require `concurrency: 1`; higher
+concurrency returns a structured `invalid_input` error before executing any item.
+
+## Metrics
+
+- `openchrome_batch_items_total{result="ok|err|skipped|failfast-skip"}`
+- `openchrome_batch_idempotency_evictions_total{reason="ttl|lru"}`

--- a/src/core/idempotency/lru.ts
+++ b/src/core/idempotency/lru.ts
@@ -1,0 +1,56 @@
+/** Small TTL + LRU cache for per-session idempotency maps (#842). */
+
+export interface LruTtlCacheOptions {
+  maxEntries: number;
+  ttlMs: number;
+  now?: () => number;
+  onEvict?: (reason: 'ttl' | 'lru') => void;
+}
+
+interface Entry<V> {
+  value: V;
+  expiresAt: number;
+}
+
+export class LruTtlCache<V> {
+  private readonly maxEntries: number;
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+  private readonly onEvict?: (reason: 'ttl' | 'lru') => void;
+  private readonly entries = new Map<string, Entry<V>>();
+
+  constructor(options: LruTtlCacheOptions) {
+    this.maxEntries = Math.max(1, Math.floor(options.maxEntries));
+    this.ttlMs = Math.max(1, Math.floor(options.ttlMs));
+    this.now = options.now ?? Date.now;
+    this.onEvict = options.onEvict;
+  }
+
+  get(key: string): V | undefined {
+    const entry = this.entries.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= this.now()) {
+      this.entries.delete(key);
+      this.onEvict?.('ttl');
+      return undefined;
+    }
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    return entry.value;
+  }
+
+  set(key: string, value: V): void {
+    if (this.entries.has(key)) this.entries.delete(key);
+    this.entries.set(key, { value, expiresAt: this.now() + this.ttlMs });
+    while (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next().value as string | undefined;
+      if (!oldest) break;
+      this.entries.delete(oldest);
+      this.onEvict?.('lru');
+    }
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+}

--- a/src/metrics/collector.ts
+++ b/src/metrics/collector.ts
@@ -254,6 +254,8 @@ export function getMetricsCollector(): MetricsCollector {
     instance.registerHistogram('openchrome_tool_compression_saved_bytes', 'Estimated response bytes saved by response compression or delta modes',
       [128, 512, 1024, 4096, 16384, 65536, 262144]);
     instance.registerCounter('openchrome_cache_status_total', 'Cache status observations by tool and key version');
+    instance.registerCounter('openchrome_batch_items_total', 'batch_execute item outcomes by result');
+    instance.registerCounter('openchrome_batch_idempotency_evictions_total', 'batch_execute idempotency cache evictions by reason');
     instance.registerCounter('openchrome_reconnect_total', 'Total successful CDP reconnections');
     instance.registerGauge('openchrome_heap_bytes', 'Node.js heap usage in bytes');
     instance.registerGauge('openchrome_active_sessions', 'Current active MCP sessions');

--- a/src/tools/batch-execute.ts
+++ b/src/tools/batch-execute.ts
@@ -367,7 +367,16 @@ const handler: ToolHandler = async (
           await new Promise((resolve) => setTimeout(resolve, Math.max(0, task.interItemWaitMs!)));
         }
         const wait = await runWaitSpec(task, task.interItemWaitFor);
-        if (wait) result.wait = wait;
+        if (wait) {
+          result.wait = wait;
+          if (!wait.success) {
+            result.success = false;
+            result.error = `interItemWaitFor failed: ${wait.error ?? wait.type}`;
+            recordBatchItemMetric('err');
+            results.push(result);
+            break;
+          }
+        }
       }
       results.push(result);
     }

--- a/src/tools/batch-execute.ts
+++ b/src/tools/batch-execute.ts
@@ -12,6 +12,8 @@ import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { formatCDPResult, CDPEvalResult } from './javascript';
+import { getMetricsCollector } from '../metrics/collector';
+import { LruTtlCache } from '../core/idempotency/lru';
 
 const definition: MCPToolDefinition = {
   name: 'batch_execute',
@@ -41,6 +43,18 @@ const definition: MCPToolDefinition = {
               type: 'number',
               description: 'Timeout in ms. Default: 30000',
             },
+            idempotencyKey: {
+              type: 'string',
+              description: 'Optional per-session key. Successful prior result is reused within TTL.',
+            },
+            interItemWaitMs: {
+              type: 'number',
+              description: 'Sequential mode only: wait this many ms after this item before next item.',
+            },
+            interItemWaitFor: {
+              type: 'object',
+              description: 'Sequential mode only: wait_for-like condition after this item before next item.',
+            },
           },
           required: ['tabId', 'script'],
         },
@@ -59,11 +73,22 @@ const definition: MCPToolDefinition = {
   annotations: TOOL_ANNOTATIONS.batch_execute,
 };
 
+interface WaitForSpec {
+  type: 'selector' | 'selector_hidden' | 'function' | 'navigation' | 'url_match' | 'timeout';
+  value?: string;
+  timeout?: number;
+  visible?: boolean;
+  pollIntervalMs?: number;
+}
+
 interface BatchTask {
   tabId: string;
   workerId?: string;
   script: string;
   timeout?: number;
+  idempotencyKey?: string;
+  interItemWaitMs?: number;
+  interItemWaitFor?: WaitForSpec;
 }
 
 interface BatchTaskResult {
@@ -73,6 +98,52 @@ interface BatchTaskResult {
   data?: unknown;
   error?: string;
   durationMs: number;
+  skipped?: 'idempotent' | 'failfast-skip';
+  wait?: { success: boolean; elapsedMs: number; type: string; error?: string };
+}
+
+type CachedBatchTaskResult = Omit<BatchTaskResult, 'skipped'>;
+
+const DEFAULT_IDEMPOTENCY_TTL_MS = 10 * 60 * 1000;
+const DEFAULT_IDEMPOTENCY_MAX = 256;
+const idempotencyCaches = new Map<string, LruTtlCache<CachedBatchTaskResult>>();
+
+function getConfigNumber(name: string, fallback: number): number {
+  const n = Number(process.env[name]);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+function recordBatchItemMetric(result: 'ok' | 'err' | 'skipped' | 'failfast-skip'): void {
+  try {
+    getMetricsCollector().inc('openchrome_batch_items_total', { result });
+  } catch {
+    // Best-effort metrics only.
+  }
+}
+
+function recordIdempotencyEviction(reason: 'ttl' | 'lru'): void {
+  try {
+    getMetricsCollector().inc('openchrome_batch_idempotency_evictions_total', { reason });
+  } catch {
+    // Best-effort metrics only.
+  }
+}
+
+function getIdempotencyCache(sessionId: string): LruTtlCache<CachedBatchTaskResult> {
+  let cache = idempotencyCaches.get(sessionId);
+  if (!cache) {
+    cache = new LruTtlCache<CachedBatchTaskResult>({
+      ttlMs: getConfigNumber('OPENCHROME_BATCH_IDEMPOTENCY_TTL_MS', DEFAULT_IDEMPOTENCY_TTL_MS),
+      maxEntries: getConfigNumber('OPENCHROME_BATCH_IDEMPOTENCY_MAX', DEFAULT_IDEMPOTENCY_MAX),
+      onEvict: recordIdempotencyEviction,
+    });
+    idempotencyCaches.set(sessionId, cache);
+  }
+  return cache;
+}
+
+export function clearBatchIdempotencyCachesForTests(): void {
+  idempotencyCaches.clear();
 }
 
 /**
@@ -114,36 +185,106 @@ const handler: ToolHandler = async (
     };
   }
 
+  const hasInterItemWait = tasks.some((task) => task.interItemWaitMs !== undefined || task.interItemWaitFor !== undefined);
+  if (hasInterItemWait && concurrency !== 1) {
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          action: 'batch_execute',
+          error: 'invalid_input',
+          message: 'interItemWaitMs/interItemWaitFor require concurrency: 1',
+        }),
+      }],
+      isError: true,
+    };
+  }
+
   const sessionManager = getSessionManager();
   const cdpClient = sessionManager.getCDPClient();
   const limiter = createLimiter(concurrency);
   const startTime = Date.now();
+  const idempotencyCache = getIdempotencyCache(sessionId);
   let aborted = false;
+
+  const runWaitSpec = async (task: BatchTask, spec: WaitForSpec | undefined): Promise<BatchTaskResult['wait'] | undefined> => {
+    if (!spec) return undefined;
+    const waitStart = Date.now();
+    const timeout = spec.timeout ?? 30000;
+    const page = await sessionManager.getPage(sessionId, task.tabId, undefined, 'batch_execute.wait');
+    if (!page) return { success: false, elapsedMs: Date.now() - waitStart, type: spec.type, error: `Tab ${task.tabId} not found` };
+    try {
+      switch (spec.type) {
+        case 'selector':
+          if (!spec.value) throw new Error('value is required for selector wait');
+          await page.waitForSelector(spec.value, { timeout, visible: spec.visible ?? false });
+          break;
+        case 'selector_hidden':
+          if (!spec.value) throw new Error('value is required for selector_hidden wait');
+          await page.waitForSelector(spec.value, { timeout, hidden: true });
+          break;
+        case 'function':
+          if (!spec.value) throw new Error('value is required for function wait');
+          await page.waitForFunction(spec.value, { timeout, polling: Math.min(5000, Math.max(50, Math.floor(spec.pollIntervalMs ?? 200))) });
+          break;
+        case 'url_match':
+          if (!spec.value) throw new Error('value is required for url_match wait');
+          await page.waitForFunction((pattern: string) => {
+            try { return new RegExp(pattern).test(window.location.href); } catch { return window.location.href.includes(pattern); }
+          }, { timeout }, spec.value);
+          break;
+        case 'navigation':
+          await page.waitForNavigation({ timeout, waitUntil: 'domcontentloaded' });
+          break;
+        case 'timeout':
+          await new Promise((resolve) => setTimeout(resolve, Math.min(60000, Math.max(0, parseInt(spec.value || String(timeout), 10)))));
+          break;
+        default:
+          throw new Error(`Unknown wait type ${(spec as { type?: string }).type}`);
+      }
+      return { success: true, elapsedMs: Date.now() - waitStart, type: spec.type };
+    } catch (error) {
+      return { success: false, elapsedMs: Date.now() - waitStart, type: spec.type, error: error instanceof Error ? error.message : String(error) };
+    }
+  };
 
   const executeTask = async (task: BatchTask): Promise<BatchTaskResult> => {
     const taskStart = Date.now();
     const workerId = task.workerId || task.tabId;
 
     if (aborted) {
-      return {
+      const skipped: BatchTaskResult = {
         tabId: task.tabId,
         workerId,
         success: false,
         error: 'Aborted due to failFast',
         durationMs: 0,
+        skipped: 'failfast-skip',
       };
+      recordBatchItemMetric('failfast-skip');
+      return skipped;
+    }
+
+    if (task.idempotencyKey) {
+      const cached = idempotencyCache.get(task.idempotencyKey);
+      if (cached?.success) {
+        recordBatchItemMetric('skipped');
+        return { ...cached, skipped: 'idempotent' };
+      }
     }
 
     try {
       const page = await sessionManager.getPage(sessionId, task.tabId, undefined, 'batch_execute');
       if (!page) {
-        return {
+        const failed: BatchTaskResult = {
           tabId: task.tabId,
           workerId,
           success: false,
           error: `Tab ${task.tabId} not found`,
           durationMs: Date.now() - taskStart,
         };
+        recordBatchItemMetric('err');
+        return failed;
       }
 
       const timeout = task.timeout || 30000;
@@ -168,13 +309,15 @@ const handler: ToolHandler = async (
           cdpResult.exceptionDetails.text ||
           'Unknown error';
         if (failFast) aborted = true;
-        return {
+        const failed: BatchTaskResult = {
           tabId: task.tabId,
           workerId,
           success: false,
           error: errorMsg,
           durationMs: Date.now() - taskStart,
         };
+        recordBatchItemMetric('err');
+        return failed;
       }
 
       // Format result value using shared formatter (same as javascript_tool)
@@ -188,29 +331,49 @@ const handler: ToolHandler = async (
         data = resultValue;
       }
 
-      return {
+      const succeeded: BatchTaskResult = {
         tabId: task.tabId,
         workerId,
         success: true,
         data,
         durationMs: Date.now() - taskStart,
       };
+      if (task.idempotencyKey) idempotencyCache.set(task.idempotencyKey, succeeded);
+      recordBatchItemMetric('ok');
+      return succeeded;
     } catch (error) {
       if (failFast) aborted = true;
-      return {
+      const failed: BatchTaskResult = {
         tabId: task.tabId,
         workerId,
         success: false,
         error: error instanceof Error ? error.message : String(error),
         durationMs: Date.now() - taskStart,
       };
+      recordBatchItemMetric('err');
+      return failed;
     }
   };
 
-  // Execute all tasks with concurrency control
-  const results = await Promise.all(
-    tasks.map((task) => limiter(() => executeTask(task)))
-  );
+  // Execute all tasks with concurrency control. Inter-item waits require sequential mode
+  // so the wait happens after an item before the next sibling starts.
+  const results: BatchTaskResult[] = [];
+  if (concurrency === 1) {
+    for (let i = 0; i < tasks.length; i++) {
+      const task = tasks[i];
+      const result = await executeTask(task);
+      if (i < tasks.length - 1 && !result.skipped) {
+        if (typeof task.interItemWaitMs === 'number') {
+          await new Promise((resolve) => setTimeout(resolve, Math.max(0, task.interItemWaitMs!)));
+        }
+        const wait = await runWaitSpec(task, task.interItemWaitFor);
+        if (wait) result.wait = wait;
+      }
+      results.push(result);
+    }
+  } else {
+    results.push(...await Promise.all(tasks.map((task) => limiter(() => executeTask(task)))));
+  }
 
   const wallClockMs = Date.now() - startTime;
   const succeeded = results.filter((r) => r.success).length;

--- a/tests/core/idempotency/lru.test.ts
+++ b/tests/core/idempotency/lru.test.ts
@@ -1,0 +1,31 @@
+/// <reference types="jest" />
+
+import { LruTtlCache } from '../../../src/core/idempotency/lru';
+
+describe('LruTtlCache', () => {
+  test('expires entries by TTL', () => {
+    let now = 1000;
+    const evictions: string[] = [];
+    const cache = new LruTtlCache<string>({ maxEntries: 2, ttlMs: 100, now: () => now, onEvict: (r) => evictions.push(r) });
+    cache.set('a', 'A');
+    now = 1099;
+    expect(cache.get('a')).toBe('A');
+    now = 1200;
+    expect(cache.get('a')).toBeUndefined();
+    expect(evictions).toContain('ttl');
+  });
+
+  test('evicts least recently used entry at bound', () => {
+    let now = 0;
+    const evictions: string[] = [];
+    const cache = new LruTtlCache<string>({ maxEntries: 2, ttlMs: 1000, now: () => now, onEvict: (r) => evictions.push(r) });
+    cache.set('a', 'A');
+    cache.set('b', 'B');
+    expect(cache.get('a')).toBe('A');
+    now = 1;
+    cache.set('c', 'C');
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('a')).toBe('A');
+    expect(evictions).toContain('lru');
+  });
+});

--- a/tests/tools/batch-execute-idempotency.test.ts
+++ b/tests/tools/batch-execute-idempotency.test.ts
@@ -1,0 +1,106 @@
+/// <reference types="jest" />
+
+jest.mock('../../src/session-manager', () => ({ getSessionManager: jest.fn() }));
+
+import { MCPServer } from '../../src/mcp-server';
+import { getSessionManager } from '../../src/session-manager';
+import { clearBatchIdempotencyCachesForTests, registerBatchExecuteTool } from '../../src/tools/batch-execute';
+
+const mockSend = jest.fn();
+const page = {
+  waitForSelector: jest.fn().mockResolvedValue(undefined),
+  waitForFunction: jest.fn().mockResolvedValue(undefined),
+  waitForNavigation: jest.fn().mockResolvedValue(undefined),
+};
+
+function makeHandler(): Function {
+  (getSessionManager as jest.Mock).mockReturnValue({
+    getCDPClient: () => ({ send: mockSend }),
+    getPage: jest.fn().mockResolvedValue(page),
+  });
+  const server = new MCPServer({} as any);
+  registerBatchExecuteTool(server);
+  return server.getToolHandler('batch_execute')!;
+}
+
+function ok(value: unknown) {
+  return { result: { type: 'string', value: JSON.stringify(value) } };
+}
+
+function parse(result: any): any {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('batch_execute idempotency and inter-item waits', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearBatchIdempotencyCachesForTests();
+    delete process.env.OPENCHROME_BATCH_IDEMPOTENCY_TTL_MS;
+    delete process.env.OPENCHROME_BATCH_IDEMPOTENCY_MAX;
+    mockSend.mockResolvedValue(ok({ value: 'ran' }));
+  });
+
+  test('idempotency hit returns cached success without re-executing script', async () => {
+    const handler = makeHandler();
+    const args = {
+      concurrency: 1,
+      tasks: [{ tabId: 'tab-1', script: 'window.count++', idempotencyKey: 'step-A' }],
+    };
+
+    const first = parse(await handler('session-1', args));
+    const second = parse(await handler('session-1', args));
+
+    expect(first.results[0]).toMatchObject({ success: true, data: { value: 'ran' } });
+    expect(second.results[0]).toMatchObject({ success: true, skipped: 'idempotent', data: { value: 'ran' } });
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  test('failed prior run is not cached', async () => {
+    mockSend
+      .mockResolvedValueOnce({ exceptionDetails: { text: 'boom' }, result: { type: 'undefined' } })
+      .mockResolvedValueOnce(ok({ value: 'retry-ok' }));
+    const handler = makeHandler();
+    const args = { concurrency: 1, tasks: [{ tabId: 'tab-1', script: 'mayFail()', idempotencyKey: 'step-B' }] };
+
+    const first = parse(await handler('session-1', args));
+    const second = parse(await handler('session-1', args));
+
+    expect(first.results[0].success).toBe(false);
+    expect(second.results[0]).toMatchObject({ success: true, data: { value: 'retry-ok' } });
+    expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not add package dependencies for idempotency support', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const pkg = require('../../package.json');
+    expect(pkg.dependencies?.['lru-cache']).toBeUndefined();
+    expect(pkg.devDependencies?.['lru-cache']).toBeUndefined();
+  });
+
+  test('inter-item wait rejects concurrency above one before executing', async () => {
+    const handler = makeHandler();
+    const result = await handler('session-1', {
+      concurrency: 2,
+      tasks: [{ tabId: 'tab-1', script: '1', interItemWaitMs: 10 }],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parse(result).error).toBe('invalid_input');
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  test('sequential interItemWaitFor runs between sibling items', async () => {
+    const handler = makeHandler();
+    const result = parse(await handler('session-1', {
+      concurrency: 1,
+      tasks: [
+        { tabId: 'tab-1', script: 'click()', interItemWaitFor: { type: 'function', value: 'window.__ready === true', pollIntervalMs: 100 } },
+        { tabId: 'tab-1', script: 'read()' },
+      ],
+    }));
+
+    expect(result.results[0].wait).toMatchObject({ success: true, type: 'function' });
+    expect(page.waitForFunction).toHaveBeenCalledWith('window.__ready === true', { timeout: 30000, polling: 100 });
+    expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/tools/batch-execute-idempotency.test.ts
+++ b/tests/tools/batch-execute-idempotency.test.ts
@@ -103,4 +103,26 @@ describe('batch_execute idempotency and inter-item waits', () => {
     expect(page.waitForFunction).toHaveBeenCalledWith('window.__ready === true', { timeout: 30000, polling: 100 });
     expect(mockSend).toHaveBeenCalledTimes(2);
   });
+
+  test('failed interItemWaitFor stops before the next sibling starts', async () => {
+    page.waitForFunction.mockRejectedValueOnce(new Error('not ready'));
+    const handler = makeHandler();
+    const result = parse(await handler('session-1', {
+      concurrency: 1,
+      tasks: [
+        { tabId: 'tab-1', script: 'click()', interItemWaitFor: { type: 'function', value: 'window.__ready === true', pollIntervalMs: 100 } },
+        { tabId: 'tab-1', script: 'read()' },
+      ],
+    }));
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toMatchObject({
+      success: false,
+      error: 'interItemWaitFor failed: not ready',
+      wait: { success: false, type: 'function', error: 'not ready' },
+    });
+    expect(result.summary).toMatchObject({ total: 1, succeeded: 0, failed: 1 });
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
 });


### PR DESCRIPTION
## Summary
- Fixes #842 by adding opt-in per-item `idempotencyKey` support to `batch_execute`.
- Adds in-memory per-session TTL/LRU cache (default 10 min, 256 entries) with successful-result reuse and `skipped: "idempotent"` marker.
- Adds sequential-only `interItemWaitMs` / `interItemWaitFor` and validates waits require `concurrency: 1` before executing any item.
- Keeps `failFast` behavior and default batch behavior unchanged when new fields are omitted.
- Adds batch item / idempotency eviction metrics and docs.

## Verification
- `npm ci`
- `npm test -- tests/core/idempotency/lru.test.ts tests/tools/batch-execute-idempotency.test.ts --runInBand`
- `npm run build`
- `npm run lint -- --quiet`
- `npm run lint:tier`
- `npm run lint:tool-schemas`
- `git diff --check`

## Notes
- Idempotency is in-memory and per session only; failed task results are not cached.
- Live trace proof for “no CDP traffic on idempotency hit” was not run in this PR; unit coverage asserts the CDP send mock is not invoked on hit.
