### PR TITLE
feat(#843): add oc run one-shot MCP tool client

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -49,6 +49,7 @@ import { registerAdminKeysCommand } from './admin-keys';
 import { registerContractCommand } from './contract-teach';
 import { registerPlaybookCommand } from './playbook/index';
 import { registerReplayCommand } from './replay';
+import { registerRunCommand } from './run';
 import { getClaudeCliCommand, getClaudeExecFileOptions, shouldUseClaudeCliShell } from './claude-cli';
 
 const program = new Command();
@@ -1296,6 +1297,9 @@ totp
       process.exit(1);
     }
   });
+
+// One-shot MCP tool runner (issue #843).
+registerRunCommand(program);
 
 // Admin CLI — tenant API key management (issue #9 / PR3).
 registerAdminKeysCommand(program);

--- a/cli/run-stdio-client.ts
+++ b/cli/run-stdio-client.ts
@@ -1,0 +1,225 @@
+import { spawn, type ChildProcess } from 'child_process';
+import * as path from 'path';
+import * as readline from 'readline';
+
+export class TransportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TransportError';
+  }
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+export interface McpToolCallResult {
+  content?: Array<{ type: string; text?: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+  [key: string]: unknown;
+}
+
+interface ToolListResult {
+  tools?: Array<{ name?: unknown }>;
+}
+
+export class StdioRunClient {
+  private child: ChildProcess | null = null;
+  private nextId = 1;
+  private rl: readline.Interface | null = null;
+  private pending = new Map<number, { resolve: (r: JsonRpcResponse) => void; reject: (e: Error) => void }>();
+  private stderr: string[] = [];
+  private httpUrl: string | null = null;
+  private httpSessionId: string | null = null;
+
+  async connect(reuse: boolean): Promise<void> {
+    if (reuse) {
+      await this.connectHttpDaemon();
+      return;
+    }
+
+    const serveEntry = path.join(__dirname, '..', 'index.js');
+    this.child = spawn(process.execPath, [serveEntry, 'serve', '--server-mode'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, OPENCHROME_PPID_WATCH: '0' },
+    });
+    if (!this.child.stdin || !this.child.stdout) {
+      throw new TransportError('Failed to open stdio pipes to child server');
+    }
+    this.child.stderr?.on('data', (chunk: Buffer) => {
+      this.stderr.push(chunk.toString());
+    });
+    this.child.on('error', (err) => this.rejectAll(new TransportError(`Server process error: ${err.message}`)));
+    this.child.on('exit', (code, signal) => {
+      if (this.pending.size > 0) {
+        const suffix = signal ? `signal ${signal}` : `code ${code}`;
+        this.rejectAll(new TransportError(`Server process exited before response (${suffix}). ${this.stderrTail()}`));
+      }
+    });
+    this.rl = readline.createInterface({ input: this.child.stdout, crlfDelay: Infinity });
+    this.rl.on('line', (line) => this.handleLine(line));
+
+    await this.sendRequest('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'oc-run', version: '1.0.0' },
+    });
+    this.sendNotification('notifications/initialized');
+  }
+
+  async listTools(): Promise<Set<string>> {
+    const result = await this.sendRequest('tools/list', {});
+    const tools = (result as ToolListResult).tools ?? [];
+    return new Set(tools.map((tool) => tool.name).filter((name): name is string => typeof name === 'string'));
+  }
+
+  async callTool(name: string, args: Record<string, unknown>): Promise<McpToolCallResult> {
+    const result = await this.sendRequest('tools/call', { name, arguments: args });
+    return result as McpToolCallResult;
+  }
+
+  async close(): Promise<void> {
+    if (this.httpUrl && this.httpSessionId) {
+      const headers = this.httpHeaders();
+      headers['Mcp-Session-Id'] = this.httpSessionId;
+      await fetch(this.httpUrl, { method: 'DELETE', headers }).catch(() => undefined);
+      this.httpUrl = null;
+      this.httpSessionId = null;
+    }
+    if (this.rl) {
+      this.rl.close();
+      this.rl = null;
+    }
+    if (!this.child) return;
+    const child = this.child;
+    this.child = null;
+    if (!child.killed) {
+      child.kill('SIGTERM');
+    }
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        if (!child.killed) child.kill('SIGKILL');
+        resolve();
+      }, 1000);
+      child.once('exit', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+
+  private async sendRequest(method: string, params?: unknown): Promise<unknown> {
+    if (this.httpUrl) return this.sendHttpRequest(method, params);
+    if (!this.child?.stdin) throw new TransportError('Server is not connected');
+    const id = this.nextId++;
+    const payload = JSON.stringify({ jsonrpc: '2.0', id, method, params });
+    const response = await new Promise<JsonRpcResponse>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.child!.stdin!.write(`${payload}\n`, (err) => {
+        if (err) {
+          this.pending.delete(id);
+          reject(new TransportError(`Failed to write request: ${err.message}`));
+        }
+      });
+    });
+    if (response.error) {
+      throw new TransportError(`JSON-RPC ${method} failed: ${response.error.message}`);
+    }
+    return response.result;
+  }
+
+  private sendNotification(method: string, params?: unknown): void {
+    if (this.httpUrl) {
+      void this.sendHttpNotification(method, params);
+      return;
+    }
+    this.child?.stdin?.write(`${JSON.stringify({ jsonrpc: '2.0', method, params })}\n`);
+  }
+
+
+  private async connectHttpDaemon(): Promise<void> {
+    const host = process.env.OPENCHROME_HTTP_HOST || '127.0.0.1';
+    const port = process.env.OPENCHROME_HTTP_PORT || '3100';
+    this.httpUrl = `http://${host}:${port}/mcp`;
+    try {
+      await this.sendHttpRequest('initialize', {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'oc-run', version: '1.0.0' },
+      });
+      await this.sendHttpNotification('notifications/initialized');
+    } catch (err) {
+      this.httpUrl = null;
+      throw new TransportError(`Unable to reuse HTTP daemon at http://${host}:${port}/mcp: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  private async sendHttpRequest(method: string, params?: unknown): Promise<unknown> {
+    if (!this.httpUrl) throw new TransportError('HTTP daemon is not connected');
+    const id = this.nextId++;
+    const headers = this.httpHeaders();
+    if (this.httpSessionId) headers['Mcp-Session-Id'] = this.httpSessionId;
+    const res = await fetch(this.httpUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+    });
+    if (!res.ok) {
+      throw new TransportError(`HTTP ${res.status}: ${await res.text()}`);
+    }
+    const sessionId = res.headers.get('mcp-session-id');
+    if (sessionId) this.httpSessionId = sessionId;
+    const response = await res.json() as JsonRpcResponse;
+    if (response.error) {
+      throw new TransportError(`JSON-RPC ${method} failed: ${response.error.message}`);
+    }
+    return response.result;
+  }
+
+  private async sendHttpNotification(method: string, params?: unknown): Promise<void> {
+    if (!this.httpUrl) return;
+    const headers = this.httpHeaders();
+    if (this.httpSessionId) headers['Mcp-Session-Id'] = this.httpSessionId;
+    await fetch(this.httpUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ jsonrpc: '2.0', method, params }),
+    }).catch(() => undefined);
+  }
+
+  private httpHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const token = process.env.OPENCHROME_AUTH_TOKEN;
+    if (token) headers.Authorization = `Bearer ${token}`;
+    return headers;
+  }
+
+  private handleLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    let parsed: JsonRpcResponse;
+    try {
+      parsed = JSON.parse(trimmed) as JsonRpcResponse;
+    } catch {
+      return;
+    }
+    if (typeof parsed.id !== 'number') return;
+    const waiter = this.pending.get(parsed.id);
+    if (!waiter) return;
+    this.pending.delete(parsed.id);
+    waiter.resolve(parsed);
+  }
+
+  private rejectAll(err: Error): void {
+    for (const waiter of this.pending.values()) waiter.reject(err);
+    this.pending.clear();
+  }
+
+  private stderrTail(): string {
+    return this.stderr.join('').split('\n').slice(-8).join('\n');
+  }
+}

--- a/cli/run-sugar.ts
+++ b/cli/run-sugar.ts
@@ -1,0 +1,47 @@
+export interface SugarCommandSpec {
+  command: string;
+  description: string;
+  tool: string;
+  args: Array<{ name: string; required?: boolean; variadic?: boolean }>;
+}
+
+export const RUN_SUGAR_COMMANDS: SugarCommandSpec[] = [
+  { command: 'navigate <url>', description: 'Run navigate with a positional URL.', tool: 'navigate', args: [{ name: 'url', required: true }] },
+  { command: 'tabs_create <url>', description: 'Run tabs_create with a positional URL.', tool: 'tabs_create', args: [{ name: 'url', required: true }] },
+  { command: 'read_page', description: 'Run read_page.', tool: 'read_page', args: [] },
+  { command: 'page_screenshot [path]', description: 'Run page_screenshot with an optional output path.', tool: 'page_screenshot', args: [{ name: 'path' }] },
+  { command: 'tabs_context', description: 'Run tabs_context.', tool: 'tabs_context', args: [] },
+  { command: 'tabs_close <tabId>', description: 'Run tabs_close with a positional tab id.', tool: 'tabs_close', args: [{ name: 'tabId', required: true }] },
+  { command: 'wait_for <selector>', description: 'Run wait_for with a selector.', tool: 'wait_for', args: [{ name: 'selector', required: true }] },
+  { command: 'click <ref>', description: 'Run click with a ref/selector argument.', tool: 'click', args: [{ name: 'ref', required: true }] },
+  { command: 'interact <ref> <action>', description: 'Run interact with ref and action.', tool: 'interact', args: [{ name: 'ref', required: true }, { name: 'action', required: true }] },
+  { command: 'form_input <ref> <value>', description: 'Run form_input with ref and value.', tool: 'form_input', args: [{ name: 'ref', required: true }, { name: 'value', required: true }] },
+  { command: 'javascript_tool <code>', description: 'Run javascript_tool with code.', tool: 'javascript_tool', args: [{ name: 'code', required: true }] },
+  { command: 'oc_assert <contract>', description: 'Run oc_assert with a JSON contract.', tool: 'oc_assert', args: [{ name: 'contract', required: true }] },
+];
+
+export function resolveSugarArgs(spec: SugarCommandSpec, values: string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (let i = 0; i < spec.args.length; i++) {
+    const arg = spec.args[i];
+    const value = values[i];
+    if ((value === undefined || value === '') && arg.required) {
+      throw new Error(`Missing required positional argument ${arg.name}`);
+    }
+    if (value !== undefined) {
+      out[arg.name] = parseSugarValue(arg.name, value);
+    }
+  }
+  return out;
+}
+
+function parseSugarValue(name: string, value: string): unknown {
+  if (name === 'contract') {
+    try {
+      return JSON.parse(value) as unknown;
+    } catch {
+      return value;
+    }
+  }
+  return value;
+}

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -36,6 +36,9 @@ export function parseArgAssignments(assignments: string[] = []): Record<string, 
     if (!/^[A-Za-z_][A-Za-z0-9_.-]*$/.test(key)) {
       throw new UsageError(`Invalid --arg key "${key}".`);
     }
+    if (isUnsafeArgKey(key)) {
+      throw new UsageError(`Unsafe --arg key "${key}".`);
+    }
     try {
       out[key] = parseArgValue(raw);
     } catch (err) {
@@ -43,6 +46,12 @@ export function parseArgAssignments(assignments: string[] = []): Record<string, 
     }
   }
   return out;
+}
+
+function isUnsafeArgKey(key: string): boolean {
+  return key
+    .split(/[.-]/)
+    .some((part) => part === '__proto__' || part === 'prototype' || part === 'constructor');
 }
 
 export function mergeArgs(positional: Record<string, unknown>, options: RunOptions): Record<string, unknown> {

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -1,0 +1,135 @@
+import { Command } from 'commander';
+import { StdioRunClient, TransportError, type McpToolCallResult } from './run-stdio-client';
+import { RUN_SUGAR_COMMANDS, resolveSugarArgs, type SugarCommandSpec } from './run-sugar';
+
+export class UsageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UsageError';
+  }
+}
+
+export interface RunOptions {
+  arg?: string[];
+  json?: boolean;
+  reuse?: boolean;
+}
+
+export function parseArgValue(raw: string): unknown {
+  if (raw.startsWith('json:')) {
+    return JSON.parse(raw.slice('json:'.length)) as unknown;
+  }
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  return raw;
+}
+
+export function parseArgAssignments(assignments: string[] = []): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const assignment of assignments) {
+    const idx = assignment.indexOf('=');
+    if (idx <= 0) {
+      throw new UsageError(`Invalid --arg "${assignment}". Expected key=value.`);
+    }
+    const key = assignment.slice(0, idx);
+    const raw = assignment.slice(idx + 1);
+    if (!/^[A-Za-z_][A-Za-z0-9_.-]*$/.test(key)) {
+      throw new UsageError(`Invalid --arg key "${key}".`);
+    }
+    try {
+      out[key] = parseArgValue(raw);
+    } catch (err) {
+      throw new UsageError(`Invalid JSON for --arg ${key}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  return out;
+}
+
+export function mergeArgs(positional: Record<string, unknown>, options: RunOptions): Record<string, unknown> {
+  return { ...positional, ...parseArgAssignments(options.arg ?? []) };
+}
+
+export function formatHumanResult(result: McpToolCallResult): string {
+  const firstText = result.content?.find((entry) => entry.type === 'text' && typeof entry.text === 'string')?.text;
+  if (firstText !== undefined) return firstText;
+  if (result.structuredContent !== undefined) return JSON.stringify(result.structuredContent, null, 2);
+  return JSON.stringify(result, null, 2);
+}
+
+async function executeTool(tool: string, args: Record<string, unknown>, options: RunOptions): Promise<number> {
+  const client = new StdioRunClient();
+  try {
+    await client.connect(Boolean(options.reuse));
+    const tools = await client.listTools();
+    if (!tools.has(tool)) {
+      throw new UsageError(`Unknown tool "${tool}".`);
+    }
+    const result = await client.callTool(tool, args);
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    } else {
+      process.stdout.write(`${formatHumanResult(result)}\n`);
+    }
+    return result.isError ? 1 : 0;
+  } finally {
+    await client.close();
+  }
+}
+
+async function runAndExit(tool: string, args: Record<string, unknown>, options: RunOptions): Promise<void> {
+  try {
+    const code = await executeTool(tool, args, options);
+    process.exit(code);
+  } catch (err) {
+    if (err instanceof UsageError) {
+      console.error(`[oc run] ${err.message}`);
+      process.exit(2);
+    }
+    if (err instanceof TransportError) {
+      console.error(`[oc run] Transport error: ${err.message}`);
+      process.exit(3);
+    }
+    console.error(`[oc run] ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(3);
+  }
+}
+
+function collectArg(value: string, previous: string[]): string[] {
+  previous.push(value);
+  return previous;
+}
+
+export function registerRunCommand(program: Command): void {
+  program.option('--reuse', 'For oc run: attempt to reuse an existing OpenChrome daemon when supported.', false);
+
+  program
+    .command('run <tool>')
+    .description('Run one MCP tool through a one-shot stdio OpenChrome server (issue #843).')
+    .option('--arg <key=value>', 'Tool argument assignment. Repeatable. Prefix value with json: for JSON.', collectArg, [] as string[])
+    .option('--json', 'Emit raw MCP tool result JSON.', false)
+    .option('--reuse', 'Attempt to reuse an existing OpenChrome daemon when supported.', false)
+    .action(async (tool: string, options: RunOptions) => {
+      const global = program.opts<{ reuse?: boolean }>();
+      await runAndExit(tool, parseArgAssignments(options.arg ?? []), { ...options, reuse: options.reuse || global.reuse });
+    });
+
+  for (const spec of RUN_SUGAR_COMMANDS) {
+    registerSugarCommand(program, spec);
+  }
+}
+
+function registerSugarCommand(program: Command, spec: SugarCommandSpec): void {
+  program
+    .command(spec.command)
+    .description(spec.description)
+    .option('--arg <key=value>', 'Additional tool argument assignment. Repeatable. Overrides positional args.', collectArg, [] as string[])
+    .option('--json', 'Emit raw MCP tool result JSON.', false)
+    .option('--reuse', 'Attempt to reuse an existing OpenChrome daemon when supported.', false)
+    .action(async (...actionArgs: unknown[]) => {
+      const options = actionArgs[actionArgs.length - 1] as RunOptions;
+      const values = actionArgs.slice(0, -1).filter((value): value is string => typeof value === 'string');
+      const global = program.opts<{ reuse?: boolean }>();
+      const positional = resolveSugarArgs(spec, values);
+      await runAndExit(spec.tool, mergeArgs(positional, options), { ...options, reuse: options.reuse || global.reuse });
+    });
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,55 @@
+# OpenChrome CLI
+
+## `oc run`
+
+`oc run <tool> [--arg key=value ...] [--json]` executes one MCP tool through the same stdio MCP server used by MCP hosts. The CLI spawns `dist/index.js serve --server-mode`, performs the MCP initialize handshake, calls `tools/list` to validate the tool name, then sends one `tools/call` request.
+
+Examples:
+
+```bash
+oc run navigate --arg url=https://example.com
+oc run read_page --arg mode=dom --json
+oc run page_screenshot --arg path=/tmp/page.png
+oc run oc_assert --arg contract=json:'{"type":"text","contains":"Example Domain"}' --json
+```
+
+Argument values use this grammar:
+
+- `--arg key=value` can be repeated.
+- `true` and `false` become booleans.
+- `json:<value>` parses `<value>` as JSON.
+- Other values remain strings.
+
+Exit codes:
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Tool returned a non-error MCP result. |
+| 1 | Tool returned `isError: true`. |
+| 2 | CLI usage error, including malformed `--arg` or unknown tool. |
+| 3 | Transport/server failure. |
+
+`--json` prints the raw MCP tool result. Without `--json`, the first text content item is printed when present.
+
+`--reuse` connects to a running Streamable HTTP daemon at `OPENCHROME_HTTP_HOST`/`OPENCHROME_HTTP_PORT` (defaults: `127.0.0.1:3100`). If the daemon requires the legacy bearer token, set `OPENCHROME_AUTH_TOKEN` so the CLI can send `Authorization: Bearer ...`. If no daemon is reachable, the command exits 3 with a transport error instead of silently spawning a new server.
+
+## Sugar commands
+
+Common tools have positional aliases that call `oc run` internally. Additional `--arg` values override positional values.
+
+| Command | Equivalent |
+| --- | --- |
+| `oc navigate URL` | `oc run navigate --arg url=URL` |
+| `oc tabs_create URL` | `oc run tabs_create --arg url=URL` |
+| `oc read_page` | `oc run read_page` |
+| `oc page_screenshot PATH` | `oc run page_screenshot --arg path=PATH` |
+| `oc tabs_context` | `oc run tabs_context` |
+| `oc tabs_close TAB_ID` | `oc run tabs_close --arg tabId=TAB_ID` |
+| `oc wait_for SELECTOR` | `oc run wait_for --arg selector=SELECTOR` |
+| `oc click REF` | `oc run click --arg ref=REF` |
+| `oc interact REF ACTION` | `oc run interact --arg ref=REF --arg action=ACTION` |
+| `oc form_input REF VALUE` | `oc run form_input --arg ref=REF --arg value=VALUE` |
+| `oc javascript_tool CODE` | `oc run javascript_tool --arg code=CODE` |
+| `oc oc_assert CONTRACT_JSON` | `oc run oc_assert --arg contract=json:CONTRACT_JSON` |
+
+Each invocation pays Node + server bootstrap cost. For repeated high-frequency browser work, prefer a long-running MCP host or future daemon reuse.

--- a/tests/cli/run/args.test.ts
+++ b/tests/cli/run/args.test.ts
@@ -19,6 +19,12 @@ describe('oc run argument parsing (#843)', () => {
     expect(() => parseArgAssignments(['payload=json:{bad'])).toThrow(UsageError);
   });
 
+  test('rejects prototype-polluting argument keys', () => {
+    expect(() => parseArgAssignments(['__proto__=x'])).toThrow(UsageError);
+    expect(() => parseArgAssignments(['constructor.prototype=x'])).toThrow(UsageError);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
   test('explicit --arg overrides positional sugar args', () => {
     expect(mergeArgs({ url: 'https://old.example' }, { arg: ['url=https://new.example'] })).toEqual({
       url: 'https://new.example',

--- a/tests/cli/run/args.test.ts
+++ b/tests/cli/run/args.test.ts
@@ -1,0 +1,31 @@
+import { formatHumanResult, mergeArgs, parseArgAssignments, parseArgValue, UsageError } from '../../../cli/run';
+
+describe('oc run argument parsing (#843)', () => {
+  test('parses strings and booleans', () => {
+    expect(parseArgAssignments(['url=https://example.com', 'visible=true', 'dry=false'])).toEqual({
+      url: 'https://example.com',
+      visible: true,
+      dry: false,
+    });
+  });
+
+  test('parses json: values', () => {
+    expect(parseArgValue('json:{"a":1,"b":[true]}')).toEqual({ a: 1, b: [true] });
+  });
+
+  test('rejects malformed assignments', () => {
+    expect(() => parseArgAssignments(['missing-equals'])).toThrow(UsageError);
+    expect(() => parseArgAssignments(['1bad=value'])).toThrow(UsageError);
+    expect(() => parseArgAssignments(['payload=json:{bad'])).toThrow(UsageError);
+  });
+
+  test('explicit --arg overrides positional sugar args', () => {
+    expect(mergeArgs({ url: 'https://old.example' }, { arg: ['url=https://new.example'] })).toEqual({
+      url: 'https://new.example',
+    });
+  });
+
+  test('formats first text item by default', () => {
+    expect(formatHumanResult({ content: [{ type: 'text', text: 'hello' }], isError: false })).toBe('hello');
+  });
+});

--- a/tests/cli/run/sugar.test.ts
+++ b/tests/cli/run/sugar.test.ts
@@ -1,0 +1,30 @@
+import { RUN_SUGAR_COMMANDS, resolveSugarArgs } from '../../../cli/run-sugar';
+
+describe('oc run sugar commands (#843)', () => {
+  test('includes common positional wrappers', () => {
+    expect(RUN_SUGAR_COMMANDS.map((s) => s.tool)).toEqual(expect.arrayContaining([
+      'navigate',
+      'tabs_create',
+      'read_page',
+      'page_screenshot',
+      'tabs_context',
+      'tabs_close',
+      'wait_for',
+      'click',
+      'interact',
+      'form_input',
+      'javascript_tool',
+      'oc_assert',
+    ]));
+  });
+
+  test('maps navigate URL to named arg', () => {
+    const spec = RUN_SUGAR_COMMANDS.find((s) => s.tool === 'navigate')!;
+    expect(resolveSugarArgs(spec, ['https://example.com'])).toEqual({ url: 'https://example.com' });
+  });
+
+  test('parses oc_assert contract JSON when possible', () => {
+    const spec = RUN_SUGAR_COMMANDS.find((s) => s.tool === 'oc_assert')!;
+    expect(resolveSugarArgs(spec, ['{"type":"text"}'])).toEqual({ contract: { type: 'text' } });
+  });
+});


### PR DESCRIPTION
## Summary
- fixes #843 with `oc run <tool> --arg key=value --json`, backed by the existing MCP stdio server and `tools/call`
- adds repeatable argument parsing (`json:` prefix, booleans, strings), unknown-tool exit 2, transport failure exit 3, and `isError` exit 1
- adds static sugar commands such as `oc navigate URL`, `oc read_page`, and `oc page_screenshot PATH`
- implements `--reuse` via the existing Streamable HTTP MCP daemon (`OPENCHROME_HTTP_HOST`/`OPENCHROME_HTTP_PORT`, optional `OPENCHROME_AUTH_TOKEN`)
- documents CLI usage and sugar mappings in `docs/cli.md`

## Verification
- `npm test -- tests/cli/run/args.test.ts tests/cli/run/sugar.test.ts --runInBand`
- `npm run build`
- `npm run lint -- --quiet`
- `npm run lint:tier`
- `npm run lint:tool-schemas`
- `git diff --check`
- `node dist/cli/index.js run oc_profile_status --json` → exit 0
- `node dist/cli/index.js run notatool` → exit 2

## Known gaps
- Did not run live Chrome navigate/screenshot smoke in this PR.
- Did not smoke `--reuse` against a separately running authenticated HTTP daemon.

Fixes #843
