### PR TITLE
Refactor HTTP transport internals for #687 Wave 2

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -13,10 +13,6 @@
 import * as http from 'node:http';
 import * as crypto from 'node:crypto';
 import { MCPResponse, MCPErrorCodes } from '../types/mcp';
-import {
-  DEFAULT_HTTP_JSON_RPC_BATCH_MAX_CONCURRENCY,
-  DEFAULT_HTTP_JSON_RPC_BATCH_MAX_SIZE,
-} from '../config/defaults';
 import { ClientDisconnectError } from '../errors/abort';
 import { MCPTransport, TransportMessageContext } from './index';
 import { renderPrometheusMetrics, type PrometheusMetric } from './prometheus';
@@ -42,126 +38,26 @@ import { authorizeDashboardEndpoint, canSeeTenant } from '../middleware/dashboar
 import { extractTenantId, TenantIdError } from '../middleware/tenant-extractor';
 import { isStrictTenantIsolationEnabled } from '../tenant/registry';
 import type { TenantId } from '../tenant/types';
+import {
+  HTTP_BODY_TIMEOUT_MS,
+  HTTP_HEADERS_TIMEOUT_MS,
+  HTTP_JSON_RPC_BATCH_MAX_CONCURRENCY,
+  HTTP_JSON_RPC_BATCH_MAX_SIZE,
+  HTTP_KEEPALIVE_TIMEOUT_MS,
+  HTTP_REQUEST_TIMEOUT_MS,
+  HTTP_SOCKET_TIMEOUT_MS,
+  MAX_BODY_BYTES,
+  SSE_KEEPALIVE_INTERVAL_MS,
+} from './http/config';
+import { applyCors, formatServerOriginHost, parseCorsOrigins } from './http/cors';
+import {
+  envFlag,
+  resolveAuthMode,
+  validateUnauthenticatedHttpPolicy,
+} from './http/auth';
+import { createBatchTooLargeError, mapBatchWithConcurrency } from './http/batch';
 
-/** Maximum allowed HTTP request body size (10 MB) to prevent OOM from oversized requests */
-const MAX_BODY_BYTES = 10 * 1024 * 1024;
-
-/** SSE keepalive ping interval in milliseconds */
-const SSE_KEEPALIVE_INTERVAL_MS = 30_000;
-
-// ─── Request/socket timeouts (Slowloris defense) ─────────────────────────
-// Node's http.Server has two of these built-in (requestTimeout,
-// headersTimeout, keepAliveTimeout) but their defaults vary across Node
-// versions and platforms. Explicit values make behavior deterministic.
-// All values in milliseconds; override via OPENCHROME_HTTP_* env vars.
-
-/** Max wall time between accepting the connection and finishing the request. */
-const DEFAULT_HTTP_REQUEST_TIMEOUT_MS = 30_000;
-/** Max time to receive the full request headers. */
-const DEFAULT_HTTP_HEADERS_TIMEOUT_MS = 10_000;
-/** Idle timeout between keep-alive requests on the same connection. */
-const DEFAULT_HTTP_KEEPALIVE_TIMEOUT_MS = 5_000;
-/** Per-socket idle timeout (triggers automatic socket destroy). */
-const DEFAULT_HTTP_SOCKET_TIMEOUT_MS = 60_000;
-/** Max time to receive the full request body after headers. */
-const DEFAULT_HTTP_BODY_TIMEOUT_MS = 15_000;
-
-function envInt(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (!raw) return fallback;
-  const parsed = parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
-}
-
-function envFlag(name: string): boolean {
-  const raw = process.env[name];
-  return raw === '1' || raw === 'true' || raw === 'yes';
-}
-
-function isLoopbackHost(host: string): boolean {
-  const normalized = host.trim().toLowerCase().replace(/^\[(.*)\]$/, '$1');
-  return normalized === '127.0.0.1' || normalized === 'localhost' || normalized === '::1';
-}
-
-function parseCorsOrigins(raw: string | undefined): Set<string> {
-  return new Set((raw || '').split(',').map((origin) => origin.trim()).filter(Boolean));
-}
-
-/**
- * Format the configured server bind into a canonical origin host (URL `host`
- * form: `hostname` or `hostname:port`, with IPv6 hostnames bracketed). This
- * value is what `isSameOriginRequest` compares against — it is derived from
- * operator configuration, not from the request, so it cannot be spoofed via
- * the Host header.
- */
-function formatServerOriginHost(host: string, port: number): string {
-  const trimmed = host.trim().toLowerCase();
-  const stripped = trimmed.replace(/^\[(.*)\]$/, '$1');
-  const isIPv6 = stripped.includes(':');
-  const hostPart = isIPv6 ? `[${stripped}]` : stripped;
-  // Default port 80 is the only http default; OpenChrome binds 3100 by
-  // default, but be explicit about what `URL.host` would produce.
-  return port === 80 ? hostPart : `${hostPart}:${port}`;
-}
-
-/**
- * Treat a request as same-origin when the full origin tuple (scheme, host,
- * port) in the `Origin` header matches the configured server bind. Browsers
- * send `Origin` on same-origin non-GET requests (POST/OPTIONS), so without
- * this bypass a browser app served from the OpenChrome origin would be
- * rejected by the CORS allowlist even though no cross-origin trust boundary
- * is crossed.
- *
- * The comparison uses the operator-configured `host:port`, NOT the client-
- * supplied `Host` header. Trusting the Host header here would let DNS-
- * rebinding attackers (whose page is served from a domain that was rebound
- * to loopback) match `Origin === Host` and bypass the allowlist — defeating
- * the very protection the allowlist provides for the unauthenticated
- * loopback development mode.
- *
- * Scheme is enforced because the HTTP transport speaks plain `http` only;
- * permitting an `https` Origin to bypass the allowlist would let cross-
- * origin `https` callers reach `/mcp` whenever the same host is also exposed
- * over `http`. Operators behind TLS termination must add the public origin
- * to the allowlist explicitly.
- */
-function isSameOriginRequest(originValue: string, serverOriginHost: string): boolean {
-  try {
-    const originUrl = new URL(originValue);
-    if (originUrl.protocol !== 'http:') return false;
-    return originUrl.host.toLowerCase() === serverOriginHost;
-  } catch {
-    return false;
-  }
-}
-
-const HTTP_REQUEST_TIMEOUT_MS  = envInt('OPENCHROME_HTTP_REQUEST_TIMEOUT_MS',  DEFAULT_HTTP_REQUEST_TIMEOUT_MS);
-const HTTP_HEADERS_TIMEOUT_MS  = envInt('OPENCHROME_HTTP_HEADERS_TIMEOUT_MS',  DEFAULT_HTTP_HEADERS_TIMEOUT_MS);
-const HTTP_KEEPALIVE_TIMEOUT_MS = envInt('OPENCHROME_HTTP_KEEPALIVE_TIMEOUT_MS', DEFAULT_HTTP_KEEPALIVE_TIMEOUT_MS);
-const HTTP_SOCKET_TIMEOUT_MS   = envInt('OPENCHROME_HTTP_SOCKET_TIMEOUT_MS',   DEFAULT_HTTP_SOCKET_TIMEOUT_MS);
-const HTTP_BODY_TIMEOUT_MS     = envInt('OPENCHROME_HTTP_BODY_TIMEOUT_MS',     DEFAULT_HTTP_BODY_TIMEOUT_MS);
-const HTTP_JSON_RPC_BATCH_MAX_SIZE = envInt(
-  'OPENCHROME_HTTP_JSON_RPC_BATCH_MAX_SIZE',
-  DEFAULT_HTTP_JSON_RPC_BATCH_MAX_SIZE,
-);
-const HTTP_JSON_RPC_BATCH_MAX_CONCURRENCY = Math.max(
-  1,
-  envInt(
-    'OPENCHROME_HTTP_JSON_RPC_BATCH_MAX_CONCURRENCY',
-    DEFAULT_HTTP_JSON_RPC_BATCH_MAX_CONCURRENCY,
-  ),
-);
-
-/** Exported for tests to assert current effective values. */
-export const HTTP_TIMEOUTS = Object.freeze({
-  requestTimeoutMs:   HTTP_REQUEST_TIMEOUT_MS,
-  headersTimeoutMs:   HTTP_HEADERS_TIMEOUT_MS,
-  keepAliveTimeoutMs: HTTP_KEEPALIVE_TIMEOUT_MS,
-  socketTimeoutMs:    HTTP_SOCKET_TIMEOUT_MS,
-  bodyTimeoutMs:      HTTP_BODY_TIMEOUT_MS,
-  jsonRpcBatchMaxSize: HTTP_JSON_RPC_BATCH_MAX_SIZE,
-  jsonRpcBatchMaxConcurrency: HTTP_JSON_RPC_BATCH_MAX_CONCURRENCY,
-});
+export { HTTP_TIMEOUTS } from './http/config';
 
 /** Active SSE connections for server-initiated notifications */
 interface SSEConnection {
@@ -213,9 +109,9 @@ export class HTTPTransport implements MCPTransport {
     this.host = host;
     this.authToken = authToken;
     const verifier = options.jwt ? createJwtVerifier(options.jwt) : undefined;
-    this.authMode = HTTPTransport.resolveAuthMode(authToken, options.apiKeyStore, verifier);
+    this.authMode = resolveAuthMode(authToken, options.apiKeyStore, verifier);
     const allowUnauthenticatedHttp = options.allowUnauthenticatedHttp ?? envFlag('OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP');
-    HTTPTransport.validateUnauthenticatedHttpPolicy(this.authMode, this.host, allowUnauthenticatedHttp);
+    validateUnauthenticatedHttpPolicy(this.authMode, this.host, allowUnauthenticatedHttp);
     this.corsAllowedOrigins = new Set([
       ...parseCorsOrigins(process.env.OPENCHROME_HTTP_CORS_ORIGINS),
       ...(options.corsAllowedOrigins || []),
@@ -225,87 +121,19 @@ export class HTTPTransport implements MCPTransport {
 
   /**
    * Resolve the runtime auth mode from env + ctor args.
-   * Precedence:
-   *   1. Explicit env OPENCHROME_AUTH_MODE=legacy-shared-token -> legacy
-   *      (fail-closed: throws if no token is configured; setting this env is
-   *      an explicit operator request to enforce auth, so we must not silently
-   *      downgrade to `disabled` on a wiring/secret-injection failure).
-   *   2. store && jwt -> api-key-or-jwt
-   *   3. ApiKeyStore provided -> api-key
-   *   4. jwt provided -> jwt
-   *   5. authToken provided (backwards compat) -> legacy
-   *   6. Nothing configured -> disabled
+   * Kept as a public facade for callers/tests while the implementation lives
+   * in `transports/http/auth` for issue #687's facade-preserving split.
    */
   static resolveAuthMode(
     authToken: string | undefined,
     store: ApiKeyStore | undefined,
     verifier?: JwtVerifier,
   ): AuthMode {
-    const envMode = process.env.OPENCHROME_AUTH_MODE;
-    if (envMode === 'legacy-shared-token') {
-      if (!authToken) {
-        throw new Error(
-          'OPENCHROME_AUTH_MODE=legacy-shared-token requires a shared token ' +
-            '(set OPENCHROME_AUTH_TOKEN or pass authToken to HTTPTransport). ' +
-            'Refusing to start with the env flag set but no token configured — ' +
-            'silently falling back to unauthenticated mode would be a security regression.',
-        );
-      }
-      return { kind: 'legacy-shared-token', token: authToken };
-    }
-    if (store && verifier) {
-      return { kind: 'api-key-or-jwt', store, verifier };
-    }
-    if (store) {
-      return { kind: 'api-key', store };
-    }
-    if (verifier) {
-      return { kind: 'jwt', verifier };
-    }
-    if (authToken) {
-      return { kind: 'legacy-shared-token', token: authToken };
-    }
-    return { kind: 'disabled' };
-  }
-
-  private static validateUnauthenticatedHttpPolicy(
-    authMode: AuthMode,
-    host: string,
-    allowUnauthenticatedHttp: boolean,
-  ): void {
-    if (authMode.kind !== 'disabled') return;
-
-    const migration = 'Configure HTTP auth (OPENCHROME_AUTH_TOKEN, API keys, or JWT), use stdio, ' +
-      'or set OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP=1 for loopback-only development.';
-    if (!allowUnauthenticatedHttp) {
-      throw new Error(`Refusing to start unauthenticated HTTP transport. ${migration}`);
-    }
-    if (!isLoopbackHost(host)) {
-      throw new Error(
-        `Refusing to start unauthenticated HTTP transport on non-loopback host ${host}. ${migration}`,
-      );
-    }
+    return resolveAuthMode(authToken, store, verifier);
   }
 
   private applyCors(req: http.IncomingMessage, res: http.ServerResponse, pathname: string): boolean {
-    const origin = req.headers.origin;
-    const originValue = typeof origin === 'string' ? origin : undefined;
-    const sameOrigin = originValue ? isSameOriginRequest(originValue, this.serverOriginHost) : false;
-    if (originValue && this.corsAllowedOrigins.has(originValue)) {
-      res.setHeader('Access-Control-Allow-Origin', originValue);
-      res.setHeader('Vary', 'Origin');
-    }
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', `Content-Type, Mcp-Session-Id, Authorization, X-Tenant-Id, ${REQUEST_ID_HEADER}`);
-    res.setHeader('Access-Control-Expose-Headers', `Mcp-Session-Id, ${REQUEST_ID_HEADER}`);
-
-    const isMcpEndpoint = pathname === '/mcp' || pathname === '/mcp/sse';
-    if (originValue && isMcpEndpoint && !sameOrigin && !this.corsAllowedOrigins.has(originValue)) {
-      res.writeHead(403, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'CORS origin not allowed' }));
-      return false;
-    }
-    return true;
+    return applyCors(req, res, pathname, this.corsAllowedOrigins, this.serverOriginHost);
   }
 
   /** Returns the resolved principal for a given request, if any. */
@@ -1442,17 +1270,7 @@ export class HTTPTransport implements MCPTransport {
   }
 
   private createBatchTooLargeError(): MCPResponse {
-    // id: null is the JSON-RPC 2.0 §5.1 sentinel for errors detected before a
-    // request id can be parsed (or, here, any meaningful per-element id can be
-    // chosen). It also avoids colliding with an active client-request id.
-    return {
-      jsonrpc: '2.0',
-      id: null,
-      error: {
-        code: MCPErrorCodes.INVALID_REQUEST,
-        message: `JSON-RPC batch size exceeds maximum of ${HTTP_JSON_RPC_BATCH_MAX_SIZE}`,
-      },
-    };
+    return createBatchTooLargeError(HTTP_JSON_RPC_BATCH_MAX_SIZE);
   }
 
   private async mapBatchWithConcurrency<T, R>(
@@ -1460,18 +1278,6 @@ export class HTTPTransport implements MCPTransport {
     concurrency: number,
     fn: (item: T) => Promise<R>,
   ): Promise<R[]> {
-    const results = new Array<R>(items.length);
-    let nextIndex = 0;
-
-    const workerCount = Math.min(concurrency, items.length);
-    const workers = Array.from({ length: workerCount }, async () => {
-      while (nextIndex < items.length) {
-        const currentIndex = nextIndex++;
-        results[currentIndex] = await fn(items[currentIndex]);
-      }
-    });
-
-    await Promise.all(workers);
-    return results;
+    return mapBatchWithConcurrency(items, concurrency, fn);
   }
 }

--- a/src/transports/http/auth.ts
+++ b/src/transports/http/auth.ts
@@ -1,0 +1,77 @@
+import type { ApiKeyStore } from '../../auth/api-key-store';
+import type { JwtVerifier } from '../../auth/jwt-verifier';
+import type { AuthMode } from '../../middleware/auth';
+
+export function envFlag(name: string): boolean {
+  const raw = process.env[name];
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
+function isLoopbackHost(host: string): boolean {
+  const normalized = host.trim().toLowerCase().replace(/^\[(.*)\]$/, '$1');
+  return normalized === '127.0.0.1' || normalized === 'localhost' || normalized === '::1';
+}
+
+/**
+ * Resolve the runtime auth mode from env + ctor args.
+ * Precedence:
+ *   1. Explicit env OPENCHROME_AUTH_MODE=legacy-shared-token -> legacy
+ *      (fail-closed: throws if no token is configured; setting this env is
+ *      an explicit operator request to enforce auth, so we must not silently
+ *      downgrade to `disabled` on a wiring/secret-injection failure).
+ *   2. store && jwt -> api-key-or-jwt
+ *   3. ApiKeyStore provided -> api-key
+ *   4. jwt provided -> jwt
+ *   5. authToken provided (backwards compat) -> legacy
+ *   6. Nothing configured -> disabled
+ */
+export function resolveAuthMode(
+  authToken: string | undefined,
+  store: ApiKeyStore | undefined,
+  verifier?: JwtVerifier,
+): AuthMode {
+  const envMode = process.env.OPENCHROME_AUTH_MODE;
+  if (envMode === 'legacy-shared-token') {
+    if (!authToken) {
+      throw new Error(
+        'OPENCHROME_AUTH_MODE=legacy-shared-token requires a shared token ' +
+          '(set OPENCHROME_AUTH_TOKEN or pass authToken to HTTPTransport). ' +
+          'Refusing to start with the env flag set but no token configured — ' +
+          'silently falling back to unauthenticated mode would be a security regression.',
+      );
+    }
+    return { kind: 'legacy-shared-token', token: authToken };
+  }
+  if (store && verifier) {
+    return { kind: 'api-key-or-jwt', store, verifier };
+  }
+  if (store) {
+    return { kind: 'api-key', store };
+  }
+  if (verifier) {
+    return { kind: 'jwt', verifier };
+  }
+  if (authToken) {
+    return { kind: 'legacy-shared-token', token: authToken };
+  }
+  return { kind: 'disabled' };
+}
+
+export function validateUnauthenticatedHttpPolicy(
+  authMode: AuthMode,
+  host: string,
+  allowUnauthenticatedHttp: boolean,
+): void {
+  if (authMode.kind !== 'disabled') return;
+
+  const migration = 'Configure HTTP auth (OPENCHROME_AUTH_TOKEN, API keys, or JWT), use stdio, ' +
+    'or set OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP=1 for loopback-only development.';
+  if (!allowUnauthenticatedHttp) {
+    throw new Error(`Refusing to start unauthenticated HTTP transport. ${migration}`);
+  }
+  if (!isLoopbackHost(host)) {
+    throw new Error(
+      `Refusing to start unauthenticated HTTP transport on non-loopback host ${host}. ${migration}`,
+    );
+  }
+}

--- a/src/transports/http/batch.ts
+++ b/src/transports/http/batch.ts
@@ -1,0 +1,35 @@
+import { MCPErrorCodes, type MCPResponse } from '../../types/mcp';
+
+export function createBatchTooLargeError(maxSize: number): MCPResponse {
+  // id: null is the JSON-RPC 2.0 §5.1 sentinel for errors detected before a
+  // request id can be parsed (or, here, any meaningful per-element id can be
+  // chosen). It also avoids colliding with an active client-request id.
+  return {
+    jsonrpc: '2.0',
+    id: null,
+    error: {
+      code: MCPErrorCodes.INVALID_REQUEST,
+      message: `JSON-RPC batch size exceeds maximum of ${maxSize}`,
+    },
+  };
+}
+
+export async function mapBatchWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  const workerCount = Math.min(concurrency, items.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex++;
+      results[currentIndex] = await fn(items[currentIndex]);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+}

--- a/src/transports/http/config.ts
+++ b/src/transports/http/config.ts
@@ -1,0 +1,62 @@
+import {
+  DEFAULT_HTTP_JSON_RPC_BATCH_MAX_CONCURRENCY,
+  DEFAULT_HTTP_JSON_RPC_BATCH_MAX_SIZE,
+} from '../../config/defaults';
+
+/** Maximum allowed HTTP request body size (10 MB) to prevent OOM from oversized requests */
+export const MAX_BODY_BYTES = 10 * 1024 * 1024;
+
+/** SSE keepalive ping interval in milliseconds */
+export const SSE_KEEPALIVE_INTERVAL_MS = 30_000;
+
+// ─── Request/socket timeouts (Slowloris defense) ─────────────────────────
+// Node's http.Server has two of these built-in (requestTimeout,
+// headersTimeout, keepAliveTimeout) but their defaults vary across Node
+// versions and platforms. Explicit values make behavior deterministic.
+// All values in milliseconds; override via OPENCHROME_HTTP_* env vars.
+
+/** Max wall time between accepting the connection and finishing the request. */
+const DEFAULT_HTTP_REQUEST_TIMEOUT_MS = 30_000;
+/** Max time to receive the full request headers. */
+const DEFAULT_HTTP_HEADERS_TIMEOUT_MS = 10_000;
+/** Idle timeout between keep-alive requests on the same connection. */
+const DEFAULT_HTTP_KEEPALIVE_TIMEOUT_MS = 5_000;
+/** Per-socket idle timeout (triggers automatic socket destroy). */
+const DEFAULT_HTTP_SOCKET_TIMEOUT_MS = 60_000;
+/** Max time to receive the full request body after headers. */
+const DEFAULT_HTTP_BODY_TIMEOUT_MS = 15_000;
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+export const HTTP_REQUEST_TIMEOUT_MS = envInt('OPENCHROME_HTTP_REQUEST_TIMEOUT_MS', DEFAULT_HTTP_REQUEST_TIMEOUT_MS);
+export const HTTP_HEADERS_TIMEOUT_MS = envInt('OPENCHROME_HTTP_HEADERS_TIMEOUT_MS', DEFAULT_HTTP_HEADERS_TIMEOUT_MS);
+export const HTTP_KEEPALIVE_TIMEOUT_MS = envInt('OPENCHROME_HTTP_KEEPALIVE_TIMEOUT_MS', DEFAULT_HTTP_KEEPALIVE_TIMEOUT_MS);
+export const HTTP_SOCKET_TIMEOUT_MS = envInt('OPENCHROME_HTTP_SOCKET_TIMEOUT_MS', DEFAULT_HTTP_SOCKET_TIMEOUT_MS);
+export const HTTP_BODY_TIMEOUT_MS = envInt('OPENCHROME_HTTP_BODY_TIMEOUT_MS', DEFAULT_HTTP_BODY_TIMEOUT_MS);
+export const HTTP_JSON_RPC_BATCH_MAX_SIZE = envInt(
+  'OPENCHROME_HTTP_JSON_RPC_BATCH_MAX_SIZE',
+  DEFAULT_HTTP_JSON_RPC_BATCH_MAX_SIZE,
+);
+export const HTTP_JSON_RPC_BATCH_MAX_CONCURRENCY = Math.max(
+  1,
+  envInt(
+    'OPENCHROME_HTTP_JSON_RPC_BATCH_MAX_CONCURRENCY',
+    DEFAULT_HTTP_JSON_RPC_BATCH_MAX_CONCURRENCY,
+  ),
+);
+
+/** Exported for tests to assert current effective values. */
+export const HTTP_TIMEOUTS = Object.freeze({
+  requestTimeoutMs: HTTP_REQUEST_TIMEOUT_MS,
+  headersTimeoutMs: HTTP_HEADERS_TIMEOUT_MS,
+  keepAliveTimeoutMs: HTTP_KEEPALIVE_TIMEOUT_MS,
+  socketTimeoutMs: HTTP_SOCKET_TIMEOUT_MS,
+  bodyTimeoutMs: HTTP_BODY_TIMEOUT_MS,
+  jsonRpcBatchMaxSize: HTTP_JSON_RPC_BATCH_MAX_SIZE,
+  jsonRpcBatchMaxConcurrency: HTTP_JSON_RPC_BATCH_MAX_CONCURRENCY,
+});

--- a/src/transports/http/cors.ts
+++ b/src/transports/http/cors.ts
@@ -1,0 +1,81 @@
+import type * as http from 'node:http';
+import { REQUEST_ID_HEADER } from '../../observability/request-id';
+
+export function parseCorsOrigins(raw: string | undefined): Set<string> {
+  return new Set((raw || '').split(',').map((origin) => origin.trim()).filter(Boolean));
+}
+
+/**
+ * Format the configured server bind into a canonical origin host (URL `host`
+ * form: `hostname` or `hostname:port`, with IPv6 hostnames bracketed). This
+ * value is what `isSameOriginRequest` compares against — it is derived from
+ * operator configuration, not from the request, so it cannot be spoofed via
+ * the Host header.
+ */
+export function formatServerOriginHost(host: string, port: number): string {
+  const trimmed = host.trim().toLowerCase();
+  const stripped = trimmed.replace(/^\[(.*)\]$/, '$1');
+  const isIPv6 = stripped.includes(':');
+  const hostPart = isIPv6 ? `[${stripped}]` : stripped;
+  // Default port 80 is the only http default; OpenChrome binds 3100 by
+  // default, but be explicit about what `URL.host` would produce.
+  return port === 80 ? hostPart : `${hostPart}:${port}`;
+}
+
+/**
+ * Treat a request as same-origin when the full origin tuple (scheme, host,
+ * port) in the `Origin` header matches the configured server bind. Browsers
+ * send `Origin` on same-origin non-GET requests (POST/OPTIONS), so without
+ * this bypass a browser app served from the OpenChrome origin would be
+ * rejected by the CORS allowlist even though no cross-origin trust boundary
+ * is crossed.
+ *
+ * The comparison uses the operator-configured `host:port`, NOT the client-
+ * supplied `Host` header. Trusting the Host header here would let DNS-
+ * rebinding attackers (whose page is served from a domain that was rebound
+ * to loopback) match `Origin === Host` and bypass the allowlist — defeating
+ * the very protection the allowlist provides for the unauthenticated
+ * loopback development mode.
+ *
+ * Scheme is enforced because the HTTP transport speaks plain `http` only;
+ * permitting an `https` Origin to bypass the allowlist would let cross-
+ * origin `https` callers reach `/mcp` whenever the same host is also exposed
+ * over `http`. Operators behind TLS termination must add the public origin
+ * to the allowlist explicitly.
+ */
+function isSameOriginRequest(originValue: string, serverOriginHost: string): boolean {
+  try {
+    const originUrl = new URL(originValue);
+    if (originUrl.protocol !== 'http:') return false;
+    return originUrl.host.toLowerCase() === serverOriginHost;
+  } catch {
+    return false;
+  }
+}
+
+export function applyCors(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  pathname: string,
+  corsAllowedOrigins: Set<string>,
+  serverOriginHost: string,
+): boolean {
+  const origin = req.headers.origin;
+  const originValue = typeof origin === 'string' ? origin : undefined;
+  const sameOrigin = originValue ? isSameOriginRequest(originValue, serverOriginHost) : false;
+  if (originValue && corsAllowedOrigins.has(originValue)) {
+    res.setHeader('Access-Control-Allow-Origin', originValue);
+    res.setHeader('Vary', 'Origin');
+  }
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', `Content-Type, Mcp-Session-Id, Authorization, X-Tenant-Id, ${REQUEST_ID_HEADER}`);
+  res.setHeader('Access-Control-Expose-Headers', `Mcp-Session-Id, ${REQUEST_ID_HEADER}`);
+
+  const isMcpEndpoint = pathname === '/mcp' || pathname === '/mcp/sse';
+  if (originValue && isMcpEndpoint && !sameOrigin && !corsAllowedOrigins.has(originValue)) {
+    res.writeHead(403, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'CORS origin not allowed' }));
+    return false;
+  }
+  return true;
+}

--- a/tests/transports/http-internals.test.ts
+++ b/tests/transports/http-internals.test.ts
@@ -1,0 +1,71 @@
+/// <reference types="jest" />
+
+import type * as http from 'node:http';
+import { HTTP_JSON_RPC_BATCH_MAX_SIZE } from '../../src/transports/http/config';
+import { createBatchTooLargeError, mapBatchWithConcurrency } from '../../src/transports/http/batch';
+import { applyCors, formatServerOriginHost, parseCorsOrigins } from '../../src/transports/http/cors';
+import { resolveAuthMode, validateUnauthenticatedHttpPolicy } from '../../src/transports/http/auth';
+
+describe('HTTP transport internals (#687 facade split)', () => {
+  const previousAuthMode = process.env.OPENCHROME_AUTH_MODE;
+
+  afterEach(() => {
+    if (previousAuthMode === undefined) delete process.env.OPENCHROME_AUTH_MODE;
+    else process.env.OPENCHROME_AUTH_MODE = previousAuthMode;
+  });
+
+  it('keeps auth mode precedence in the extracted auth helper', () => {
+    delete process.env.OPENCHROME_AUTH_MODE;
+    expect(resolveAuthMode('legacy-token', undefined).kind).toBe('legacy-shared-token');
+    expect(resolveAuthMode(undefined, {} as Parameters<typeof resolveAuthMode>[1]).kind).toBe('api-key');
+
+    process.env.OPENCHROME_AUTH_MODE = 'legacy-shared-token';
+    expect(() => resolveAuthMode(undefined, undefined)).toThrow(/requires a shared token/);
+  });
+
+  it('keeps unauthenticated HTTP loopback policy fail-closed', () => {
+    expect(() => validateUnauthenticatedHttpPolicy({ kind: 'disabled' }, '0.0.0.0', true)).toThrow(/non-loopback/);
+    expect(() => validateUnauthenticatedHttpPolicy({ kind: 'disabled' }, '127.0.0.1', false)).toThrow(/Refusing to start/);
+    expect(() => validateUnauthenticatedHttpPolicy({ kind: 'disabled' }, 'localhost', true)).not.toThrow();
+  });
+
+  it('keeps CORS same-origin and allowlist decisions in the extracted CORS helper', () => {
+    const headers: Record<string, string> = {};
+    const res = {
+      setHeader: jest.fn((key: string, value: string) => { headers[key] = value; }),
+      writeHead: jest.fn(),
+      end: jest.fn(),
+    } as unknown as http.ServerResponse;
+
+    const allowed = parseCorsOrigins('https://app.example, http://localhost:3100');
+    const sameOriginReq = { headers: { origin: 'http://127.0.0.1:3100' } } as http.IncomingMessage;
+    expect(applyCors(sameOriginReq, res, '/mcp', allowed, formatServerOriginHost('127.0.0.1', 3100))).toBe(true);
+    expect(res.writeHead).not.toHaveBeenCalled();
+
+    const blockedReq = { headers: { origin: 'https://evil.example' } } as http.IncomingMessage;
+    expect(applyCors(blockedReq, res, '/mcp', allowed, formatServerOriginHost('127.0.0.1', 3100))).toBe(false);
+    expect(res.writeHead).toHaveBeenCalledWith(403, { 'Content-Type': 'application/json' });
+  });
+
+  it('keeps batch helper error shape and bounded ordered concurrency', async () => {
+    expect(createBatchTooLargeError(HTTP_JSON_RPC_BATCH_MAX_SIZE)).toMatchObject({
+      jsonrpc: '2.0',
+      id: null,
+      error: { message: expect.stringContaining(`${HTTP_JSON_RPC_BATCH_MAX_SIZE}`) },
+    });
+
+    let active = 0;
+    let maxActive = 0;
+    const result = await mapBatchWithConcurrency([1, 2, 3, 4, 5], 2, async (item) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setImmediate(resolve));
+      active -= 1;
+      return item * 10;
+    });
+
+    expect(result).toEqual([10, 20, 30, 40, 50]);
+    expect(maxActive).toBeLessThanOrEqual(2);
+    expect(maxActive).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
## Summary

Refs #687 (Wave 2 / HTTP transport split).

This is a no-behavior-change facade-preserving slice for `src/transports/http.ts`. It extracts low-risk internals while keeping the public import surface stable:

- `src/transports/http.ts` remains the public facade exporting `HTTPTransport`, `HTTPTransportOptions`, and `HTTP_TIMEOUTS`.
- `src/transports/http/config.ts` owns timeout/body/batch size constants and `HTTP_TIMEOUTS`.
- `src/transports/http/auth.ts` owns auth-mode precedence and unauthenticated HTTP policy checks.
- `src/transports/http/cors.ts` owns CORS origin parsing, same-origin matching, and header application.
- `src/transports/http/batch.ts` owns JSON-RPC batch overflow/error and bounded concurrency helpers.
- `tests/transports/http-internals.test.ts` directly covers the extracted helpers.

## Old path → new path map

| Old symbol/concern | New path |
| --- | --- |
| `HTTP_TIMEOUTS`, `HTTP_*_TIMEOUT_MS`, batch max constants | `src/transports/http/config.ts` |
| `envFlag`, auth-mode resolution, unauthenticated HTTP policy | `src/transports/http/auth.ts` |
| CORS origin parsing/same-origin checks/header application | `src/transports/http/cors.ts` |
| batch-too-large response + concurrency mapper | `src/transports/http/batch.ts` |
| `HTTPTransport.resolveAuthMode()` | facade wrapper in `src/transports/http.ts` delegates to `http/auth.ts` |
| `HTTPTransport` request routing/dashboard/SSE/session behavior | unchanged in `src/transports/http.ts` |

## Verification

- `npm run build`
- `npm test -- tests/transports/http-abort-on-disconnect.test.ts tests/transports/http-auth-mode.test.ts tests/transports/http-batch-limits.test.ts tests/transports/http-bearer-auth.test.ts tests/transports/http-body-timeout-disable.test.ts tests/transports/http-body-timeout.test.ts tests/transports/http-socket-timeout-long-tool.test.ts tests/transports/http-streamable.test.ts tests/transports/http-tenant.test.ts tests/transports/http-transport-phase1.test.ts tests/transports/http-internals.test.ts --runInBand`
- `npm run lint -- --quiet`
- `npm run lint:tier`
- `npm run lint:tool-schemas`
- `git diff --check`

## Notes

This intentionally leaves dashboard route extraction for a later Wave 2 slice to keep this PR reviewable and revert-safe.
