### PR TITLE
Add session-manager ownership contracts for #687 Wave 3

### DIFF
--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -1253,13 +1253,17 @@ export class SessionManager {
   async getPage(sessionId: string, targetId: string, workerId?: string, toolName?: string): Promise<Page | null> {
     const ownerInfo = this.targetToWorker.get(targetId);
 
-    if (!ownerInfo || ownerInfo.sessionId !== sessionId) {
+    if (!ownerInfo) {
       // Fallback: target may exist in Chrome but not in our tracking map.
       // This happens after cross-origin navigation (e.g., OAuth redirect) where
       // Chrome replaces the renderer process, creating a new target that we missed
       // (we skip targetcreated indexing to prevent ghost tabs).
       const recovered = await this.tryRecoverTarget(sessionId, targetId, workerId);
       if (recovered) return recovered;
+      throw new Error(this.buildStaleTargetError(sessionId, targetId));
+    }
+
+    if (ownerInfo.sessionId !== sessionId) {
       throw new Error(this.buildStaleTargetError(sessionId, targetId));
     }
 

--- a/tests/session-manager-contracts.test.ts
+++ b/tests/session-manager-contracts.test.ts
@@ -1,0 +1,119 @@
+/// <reference types="jest" />
+
+const pages = new Map<string, { isClosed: jest.Mock<boolean, []>; url: jest.Mock<string, []> }>();
+
+const mockCdpClientInstance = {
+  connect: jest.fn().mockResolvedValue(undefined),
+  isConnected: jest.fn().mockReturnValue(true),
+  addConnectionListener: jest.fn(),
+  addTargetDestroyedListener: jest.fn(),
+  createBrowserContext: jest.fn(),
+  closeBrowserContext: jest.fn().mockResolvedValue(undefined),
+  closePage: jest.fn().mockResolvedValue(undefined),
+  getPageByTargetId: jest.fn(async (targetId: string) => pages.get(targetId) ?? null),
+  getBrowser: jest.fn().mockReturnValue({ targets: jest.fn().mockReturnValue([]) }),
+};
+
+jest.mock('../src/cdp/client', () => ({
+  CDPClient: jest.fn().mockImplementation(() => mockCdpClientInstance),
+  getCDPClient: jest.fn().mockReturnValue(mockCdpClientInstance),
+  getCDPClientFactory: jest.fn().mockReturnValue({
+    get: jest.fn().mockReturnValue(mockCdpClientInstance),
+    getOrCreate: jest.fn().mockReturnValue(mockCdpClientInstance),
+    getAll: jest.fn().mockReturnValue([mockCdpClientInstance]),
+    disconnectAll: jest.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+jest.mock('../src/cdp/connection-pool', () => ({
+  CDPConnectionPool: jest.fn(),
+  getCDPConnectionPool: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../src/utils/request-queue', () => ({
+  RequestQueueManager: jest.fn().mockImplementation(() => ({
+    enqueue: jest.fn((_, fn) => fn()),
+    deleteQueue: jest.fn(),
+  })),
+}));
+
+jest.mock('../src/utils/ref-id-manager', () => ({
+  getRefIdManager: jest.fn(() => ({
+    clearSessionRefs: jest.fn(),
+    clearTargetRefs: jest.fn(),
+  })),
+}));
+
+import { SessionManager } from '../src/session-manager';
+
+function page(url: string) {
+  return {
+    isClosed: jest.fn(() => false),
+    url: jest.fn(() => url),
+  };
+}
+
+describe('SessionManager ownership and stale-target contracts (#687 Wave 3 prereq)', () => {
+  let sm: SessionManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    pages.clear();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    sm = new SessionManager(undefined, {
+      autoCleanup: false,
+      useConnectionPool: false,
+      useDefaultContext: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not recover or reassign a target already owned by another session', async () => {
+    await sm.createSession({ id: 'owner-session' });
+    await sm.createSession({ id: 'other-session' });
+    await sm.registerExternalTarget('owner-target', 'owner-session', 'default');
+    await sm.registerExternalTarget('other-target', 'other-session', 'default');
+    pages.set('owner-target', page('https://example.test/owned'));
+
+    await expect(sm.getPage('other-session', 'owner-target')).rejects.toThrow(/not found in session/);
+
+    expect(sm.getTargetOwner('owner-target')).toEqual({ sessionId: 'owner-session', workerId: 'default' });
+    expect(sm.getSessionTargetIds('other-session')).toEqual(['other-target']);
+  });
+
+  it('recovers an untracked non-internal target only into an already-active worker', async () => {
+    await sm.createSession({ id: 'active-session' });
+    await sm.registerExternalTarget('known-target', 'active-session', 'default');
+    pages.set('oauth-replacement-target', page('https://idp.example.test/callback'));
+
+    const recovered = await sm.getPage('active-session', 'oauth-replacement-target');
+
+    expect(recovered).toBe(pages.get('oauth-replacement-target'));
+    expect(sm.getTargetOwner('oauth-replacement-target')).toEqual({ sessionId: 'active-session', workerId: 'default' });
+    expect(sm.getSessionTargetIds('active-session')).toEqual(['known-target', 'oauth-replacement-target']);
+  });
+
+  it('rejects stale recovery into an empty session and leaves ownership unset', async () => {
+    await sm.createSession({ id: 'empty-session' });
+    pages.set('stray-target', page('https://example.test/stray'));
+
+    await expect(sm.getPage('empty-session', 'stray-target')).rejects.toThrow(/not found in session/);
+
+    expect(sm.getTargetOwner('stray-target')).toBeUndefined();
+    expect(sm.getSessionTargetIds('empty-session')).toEqual([]);
+  });
+
+  it('rejects internal Chrome pages during stale recovery', async () => {
+    await sm.createSession({ id: 'active-session' });
+    await sm.registerExternalTarget('known-target', 'active-session', 'default');
+    pages.set('chrome-target', page('chrome://settings'));
+
+    await expect(sm.getPage('active-session', 'chrome-target')).rejects.toThrow(/not found in session/);
+
+    expect(sm.getTargetOwner('chrome-target')).toBeUndefined();
+    expect(sm.getSessionTargetIds('active-session')).toEqual(['known-target']);
+  });
+});


### PR DESCRIPTION
## Summary

Refs #687 (Wave 3 prereq / session-manager contract tests).

This adds focused ownership and stale-target recovery contracts before any larger `src/session-manager.ts` extraction. It also fixes a narrow safety bug found while locking those contracts: `getPage()` must not run stale-target recovery for a target that is already tracked as owned by a different session.

## Contract coverage

- Cross-session requests for an already-owned target do not reassign ownership.
- Untracked OAuth/cross-origin replacement targets may be recovered only into an already-active worker.
- Empty sessions cannot claim arbitrary untracked Chrome targets.
- Internal Chrome pages (`chrome://`, extension pages) remain rejected during recovery.

## Behavior change

The only intentional behavior change is fail-closed ownership handling:

- Before: a cross-session `getPage(otherSession, targetOwnedByOwner)` could enter stale-target recovery.
- After: if a target has an owner and the owner is not the requested session, `getPage()` throws the existing stale-target diagnostic without attempting recovery.

## Verification

- `npm test -- tests/session-manager-contracts.test.ts tests/session-manager-evict-target.test.ts --runInBand`
- `npm run build`
- `npm run lint -- --quiet`
- `npm run lint:tier`
- `git diff --check`
