### PR TITLE
Refactor session target ownership registry for #687 Wave 3

### DIFF
--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -6,6 +6,7 @@
 import path from 'path';
 import { Page, Target, BrowserContext, Browser } from 'puppeteer-core';
 import { Session, SessionInfo, SessionCreateOptions, SessionEvent, Worker, WorkerInfo, WorkerCreateOptions } from './types/session';
+import { TargetOwnershipRegistry } from './session/target-registry';
 import { CDPClient, getCDPClient, CDPClientFactory, getCDPClientFactory } from './cdp/client';
 import { CDPConnectionPool, getCDPConnectionPool, PoolStats } from './cdp/connection-pool';
 import { ChromePool, getChromePool } from './chrome/pool';
@@ -109,7 +110,7 @@ const DEFAULT_CONFIG: Required<Omit<SessionManagerConfig, 'tenantManager' | 'str
 
 export class SessionManager {
   private sessions: Map<string, Session> = new Map();
-  private targetToWorker: Map<string, { sessionId: string; workerId: string }> = new Map();
+  private targetToWorker = new TargetOwnershipRegistry();
   /**
    * Maps targetId → `{browser, name}` for the owning named context (#848).
    * Targets opened in the default Chrome context are not present here;

--- a/src/session/target-registry.ts
+++ b/src/session/target-registry.ts
@@ -1,0 +1,40 @@
+/** Ownership information for a browser target tracked by SessionManager. */
+export interface TargetOwnerInfo {
+  sessionId: string;
+  workerId: string;
+}
+
+/**
+ * Tracks target ownership independently from SessionManager orchestration.
+ *
+ * The public methods intentionally mirror the Map operations SessionManager
+ * already used so Wave 3 can move ownership storage behind a small internal
+ * service without changing caller-visible behavior.
+ */
+export class TargetOwnershipRegistry {
+  private readonly owners = new Map<string, TargetOwnerInfo>();
+
+  get(targetId: string): TargetOwnerInfo | undefined {
+    return this.owners.get(targetId);
+  }
+
+  set(targetId: string, owner: TargetOwnerInfo): void {
+    this.owners.set(targetId, owner);
+  }
+
+  delete(targetId: string): boolean {
+    return this.owners.delete(targetId);
+  }
+
+  has(targetId: string): boolean {
+    return this.owners.has(targetId);
+  }
+
+  keys(): IterableIterator<string> {
+    return this.owners.keys();
+  }
+
+  values(): IterableIterator<TargetOwnerInfo> {
+    return this.owners.values();
+  }
+}

--- a/tests/session/target-registry.test.ts
+++ b/tests/session/target-registry.test.ts
@@ -1,0 +1,28 @@
+/// <reference types="jest" />
+
+import { TargetOwnershipRegistry } from '../../src/session/target-registry';
+
+describe('TargetOwnershipRegistry', () => {
+  test('tracks target ownership by session and worker', () => {
+    const registry = new TargetOwnershipRegistry();
+
+    registry.set('target-1', { sessionId: 'session-1', workerId: 'worker-a' });
+
+    expect(registry.has('target-1')).toBe(true);
+    expect(registry.get('target-1')).toEqual({ sessionId: 'session-1', workerId: 'worker-a' });
+    expect(Array.from(registry.keys())).toEqual(['target-1']);
+    expect(Array.from(registry.values())).toEqual([{ sessionId: 'session-1', workerId: 'worker-a' }]);
+  });
+
+  test('overwrites ownership atomically and reports deletion', () => {
+    const registry = new TargetOwnershipRegistry();
+    registry.set('target-1', { sessionId: 'session-1', workerId: 'worker-a' });
+
+    registry.set('target-1', { sessionId: 'session-2', workerId: 'worker-b' });
+
+    expect(registry.get('target-1')).toEqual({ sessionId: 'session-2', workerId: 'worker-b' });
+    expect(registry.delete('target-1')).toBe(true);
+    expect(registry.delete('target-1')).toBe(false);
+    expect(registry.has('target-1')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Extracts SessionManager target ownership storage into `src/session/target-registry.ts` for #687 Wave 3.
- Keeps the public SessionManager facade and existing target ownership call sites behavior-compatible.
- Adds focused registry tests for ownership lookup, overwrite, iteration, and deletion.

Refs #687

## Old path → new path map
- `src/session-manager.ts` target ownership `Map` storage → `src/session/target-registry.ts` `TargetOwnershipRegistry`
- `src/session-manager.ts` ownership call sites → unchanged facade calls through the registry-compatible methods (`get`, `set`, `delete`, `has`, `keys`, `values`)

## Verification
- `npm test -- --runTestsByPath tests/session/target-registry.test.ts tests/session-manager-evict-target.test.ts tests/session-manager.test.ts --runInBand`
- `npm run build`
- `npm run lint -- --quiet`
- `npm run lint:tier`
- `git diff --check`