### PR TITLE
Refactor CDP target page index for #687 Wave 4

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -34,6 +34,7 @@ import { getMetricsCollector } from '../metrics/collector';
 import { OpenChromeConnectionError } from '../errors/connection';
 import { getStealthFingerprintDefenseScript, getStealthStackSanitizationScript } from '../stealth/fingerprint-defense';
 import { getIdleState } from '../utils/idle-state';
+import { TargetPageIndex } from './target-page-index';
 
 // Cookie type shared across methods
 type CookieEntry = {
@@ -110,7 +111,7 @@ export class CDPClient {
   private autoLaunch: boolean;
   private cookieSourceCache: Map<string, { targetId: string; timestamp: number }> = new Map();
   private cookieDataCache: Map<string, { cookies: CookieEntry[]; timestamp: number }> = new Map();
-  private targetIdIndex: Map<string, Page> = new Map();
+  private targetIdIndex = new TargetPageIndex();
   private targetActivityAt: Map<string, number> = new Map();
   private inFlightCookieScans: Map<string, Promise<CookieScanResult>> = new Map();
   private lastCookieScanResult: CookieScanResult | null = null;
@@ -2059,7 +2060,7 @@ export class CDPClient {
   async rebuildTargetIdIndex(): Promise<number> {
     // Build into a fresh Map, then swap atomically to avoid a window
     // where concurrent getPageByTargetId() calls miss the fast path.
-    const newIndex = new Map<string, Page>();
+    const newIndex = new TargetPageIndex();
     let indexed = 0;
     try {
       const browser = this.getBrowser();

--- a/src/cdp/target-page-index.ts
+++ b/src/cdp/target-page-index.ts
@@ -1,0 +1,37 @@
+import type { Page } from 'puppeteer-core';
+
+/**
+ * Small page lookup index for targetId → Puppeteer Page associations.
+ *
+ * It mirrors the Map surface CDPClient historically used, keeping the first
+ * #687 Wave 4 extraction intentionally behavior-preserving while giving the
+ * index a dedicated module for future lifecycle logic.
+ */
+export class TargetPageIndex {
+  private readonly pages = new Map<string, Page>();
+
+  get size(): number {
+    return this.pages.size;
+  }
+
+  get(targetId: string): Page | undefined {
+    return this.pages.get(targetId);
+  }
+
+  set(targetId: string, page: Page): this {
+    this.pages.set(targetId, page);
+    return this;
+  }
+
+  delete(targetId: string): boolean {
+    return this.pages.delete(targetId);
+  }
+
+  has(targetId: string): boolean {
+    return this.pages.has(targetId);
+  }
+
+  clear(): void {
+    this.pages.clear();
+  }
+}

--- a/tests/cdp/target-page-index.test.ts
+++ b/tests/cdp/target-page-index.test.ts
@@ -1,0 +1,35 @@
+/// <reference types="jest" />
+
+import { TargetPageIndex } from '../../src/cdp/target-page-index';
+
+describe('TargetPageIndex', () => {
+  const page = { isClosed: jest.fn().mockReturnValue(false) } as any;
+
+  test('mirrors the Map operations CDPClient uses for target page lookup', () => {
+    const index = new TargetPageIndex();
+
+    expect(index.size).toBe(0);
+    expect(index.has('target-1')).toBe(false);
+
+    expect(index.set('target-1', page)).toBe(index);
+    expect(index.size).toBe(1);
+    expect(index.has('target-1')).toBe(true);
+    expect(index.get('target-1')).toBe(page);
+
+    expect(index.delete('target-1')).toBe(true);
+    expect(index.delete('target-1')).toBe(false);
+    expect(index.size).toBe(0);
+  });
+
+  test('clears all indexed pages', () => {
+    const index = new TargetPageIndex();
+    index.set('target-1', page);
+    index.set('target-2', page);
+
+    index.clear();
+
+    expect(index.size).toBe(0);
+    expect(index.get('target-1')).toBeUndefined();
+    expect(index.get('target-2')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Extracts CDPClient targetId → Page storage into `src/cdp/target-page-index.ts` for #687 Wave 4.
- Keeps `targetIdIndex` Map-like behavior (`get`, `set`, `delete`, `has`, `clear`, `size`) so stale-page and reconnect call sites remain behavior-compatible.
- Adds focused TargetPageIndex unit tests.

Refs #687

## Old path → new path map
- `src/cdp/client.ts` targetIdIndex `Map<string, Page>` storage → `src/cdp/target-page-index.ts` `TargetPageIndex`
- `src/cdp/client.ts` CDPClient lookup/reconnect/stale-page call sites → unchanged Map-like calls through `TargetPageIndex`

## Verification
- `npm test -- tests/cdp/target-page-index.test.ts tests/src/cdp-active-probe.test.ts tests/src/cdp-client-optimization.test.ts --runInBand`
- `npm run build`
- `npm run lint -- --quiet`
- `npm run lint:tier`
- `git diff --check`
