### PR TITLE
docs(network): document bandwidth presets for #861

### DIFF
--- a/docs/mcp/request-intercept-presets.md
+++ b/docs/mcp/request-intercept-presets.md
@@ -1,0 +1,102 @@
+# `request_intercept` bandwidth presets
+
+`request_intercept` owns OpenChrome's CDP `Fetch` request-blocking path. Issue
+#861 adds two preset values so crawl and extraction workloads can reduce static
+asset transfer without hand-writing resource-type rules.
+
+## Presets
+
+| Preset | Blocked CDP resource types | Use when |
+| --- | --- | --- |
+| `optimize-bandwidth` | `Image`, `Media`, `Font`, `Stylesheet` | You only need DOM/AX/text extraction and want the largest bandwidth reduction. |
+| `optimize-bandwidth-light` | `Image`, `Media`, `Font` | You still need CSS layout fidelity for screenshots or layout-sensitive selectors. |
+
+The preset table is the implementation source of truth in
+`src/tools/request-intercept.ts` (`PRESET_RESOURCE_TYPES`) and is covered by
+`tests/tools/request-intercept-preset.test.ts`.
+
+## Basic usage
+
+Enable the heavy preset on a tab:
+
+```json
+{
+  "tabId": "<tab-id>",
+  "action": "enable",
+  "preset": "optimize-bandwidth"
+}
+```
+
+Enable the light preset:
+
+```json
+{
+  "tabId": "<tab-id>",
+  "action": "enable",
+  "preset": "optimize-bandwidth-light"
+}
+```
+
+Unknown preset values return a structured error instead of throwing:
+
+```json
+{
+  "error": "unknown_preset",
+  "supported": ["optimize-bandwidth", "optimize-bandwidth-light"]
+}
+```
+
+## Precedence and overrides
+
+Preset rules are expanded first, then user-supplied rules are appended. Matching
+uses the existing `request_intercept` precedence rules:
+
+1. `allow` wins over a preset `block`.
+2. User `modify` rules can override a preset block for the same request.
+3. User `block` rules continue to work as before.
+
+Example: block static assets except SVGs.
+
+```json
+{
+  "tabId": "<tab-id>",
+  "action": "enable",
+  "preset": "optimize-bandwidth",
+  "allow": ["*.svg"]
+}
+```
+
+Disabling interception removes preset rules. Re-enabling without `preset` does
+not keep stale preset rules.
+
+## Environment auto-apply
+
+Set `OPENCHROME_OPTIMIZE_BANDWIDTH` to apply a preset whenever
+`request_intercept` is enabled without an explicit per-call preset:
+
+```bash
+OPENCHROME_OPTIMIZE_BANDWIDTH=optimize-bandwidth openchrome serve --auto-launch
+```
+
+A per-call `preset` overrides the environment value. Invalid or empty environment
+values are ignored and behave like no preset.
+
+## Metrics
+
+Preset-blocked static assets increment deterministic estimate counters inside the
+existing request interception path:
+
+- `openchrome_intercept_estimated_response_bytes_total{resource_type,estimate_source}`
+- `openchrome_intercept_estimated_blocked_response_bytes_total{resource_type,estimate_source}`
+
+The estimates are intentionally deterministic by resource type because CDP does
+not expose final response bytes for requests that are aborted before transfer.
+The legacy observed/blocked byte counters remain unchanged for paths that have
+real byte counts.
+
+## Verification anchors
+
+- Unit coverage: `tests/tools/request-intercept-preset.test.ts`
+- Tool-list allow-list: `scripts/verify/A5-tools-parity.mjs`
+- Deterministic fixture for live/manual verification:
+  `tests/fixtures/pages/bandwidth-heavy.html`

--- a/docs/mcp/tool-annotations.md
+++ b/docs/mcp/tool-annotations.md
@@ -84,7 +84,7 @@ These tools combine network egress with destructive worst-case capability. They 
 | Tool                | Notes                                                                                                                                                                          |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `network`           | `Network.emulateNetworkConditions({ offline: true, ... })` blocks every request — destructive against network                                                                  |
-| `request_intercept` | Installs request-blocking rules                                                                                                                                                |
+| `request_intercept` | Installs request-blocking rules; see [`request-intercept-presets.md`](request-intercept-presets.md) for #861 bandwidth presets                                                 |
 | `javascript_tool`   | Arbitrary JS via `Runtime.evaluate` — worst case includes `document.cookie = ''`, `window.close()`, `fetch()` to any origin, or invoking a sibling destructive tool            |
 | `batch_execute`     | Batch dispatcher that can invoke arbitrary tools and evaluate arbitrary JS expressions — worst case is its worst sub-call                                                      |
 | `act`               | NL action router — click can trigger irreversible browser-side mutations (Delete-account, payment confirmation, etc.)                                                          |


### PR DESCRIPTION
## Summary
- Adds operator-facing docs for the #861 `request_intercept` bandwidth presets.
- Documents heavy/light preset resource types, unknown-preset error shape, allow-wins/override semantics, env auto-apply, and metrics.
- Links the preset guide from the MCP tool annotations page.

Fixes #861.

## Verification
- `npm test -- tests/tools/request-intercept-preset.test.ts --runInBand`
- `npm run build`
- `git diff --check`

## Not tested
- Live browser bandwidth reduction against `tests/fixtures/pages/bandwidth-heavy.html`.
