### PR TITLE
fix(lifecycle): expose bus on embedded server for #857

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -12,7 +12,7 @@
  *  - `start()` is idempotent (second call is a no-op).
  *  - `stop()` is idempotent (second call is a no-op).
  *  - HTTP `port: 0` selects an ephemeral port; resolved URL returned from `start()`.
- *  - `events` is `null` until A1 (lifecycle bus) lands.
+ *  - `events` exposes the process-wide lifecycle bus when A1 is present.
  */
 
 import * as net from 'net';
@@ -38,6 +38,7 @@ import { resolveHealthEndpointEnabled } from '../utils/health-endpoint-gating';
 import { DiskMonitor } from '../watchdog/disk-monitor';
 import { ChromeProcessMonitor } from '../watchdog/chrome-monitor';
 import { SessionStatePersistence } from '../session-state-persistence';
+import { getLifecycleBus, type LifecycleEventBus } from './lifecycle';
 import { writePidFile, cleanOrphanedChromeProcesses } from '../utils/pid-manager';
 import { installParentWatcher } from '../utils/parent-watcher';
 import { installIdleTimeout } from '../utils/idle-timeout';
@@ -108,8 +109,8 @@ export interface ServerStartResult {
 export interface OpenChromeServer {
   start(): Promise<ServerStartResult>;
   stop(reason?: 'sigterm' | 'idle' | 'caller'): Promise<void>;
-  /** null until A1 (lifecycle bus) lands. */
-  readonly events: null;
+  /** Process-wide browser lifecycle bus for embedders and in-tree subscribers. */
+  readonly events: LifecycleEventBus;
   readonly mcp: MCPServer;
 }
 
@@ -155,7 +156,7 @@ async function resolveEphemeralPort(): Promise<number> {
 // ---------------------------------------------------------------------------
 
 class OpenChromeServerImpl implements OpenChromeServer {
-  readonly events: null = null;
+  readonly events: LifecycleEventBus;
   readonly mcp: MCPServer;
 
   private _startResult: ServerStartResult | null = null;
@@ -176,6 +177,7 @@ class OpenChromeServerImpl implements OpenChromeServer {
 
   constructor(opts: CreateServerOptions) {
     this._opts = opts;
+    this.events = getLifecycleBus();
     this.mcp = getMCPServer();
   }
 

--- a/tests/integration/embedded-server.test.ts
+++ b/tests/integration/embedded-server.test.ts
@@ -11,7 +11,7 @@
  *  - stop() idempotency: second call resolves without error
  *  - stop() clears the singleton so a fresh factory call succeeds (cycle test)
  *  - HTTP port:0 is resolved to a non-zero URL before start() returns
- *  - events field is null (A1 lifecycle bus not yet landed)
+ *  - events field exposes the lifecycle bus now that A1 has landed
  */
 
 // ---------------------------------------------------------------------------
@@ -302,10 +302,12 @@ describe('createOpenChromeServer() — HTTP transport with port:0', () => {
 
 // ---------------------------------------------------------------------------
 describe('createOpenChromeServer() — events field', () => {
-  test('events is null (A1 lifecycle bus not yet landed)', async () => {
+  test('events exposes the lifecycle bus for embedded hosts', async () => {
     const server = await createOpenChromeServer(STDIO_OPTS);
     try {
-      expect(server.events).toBeNull();
+      expect(server.events).toBeDefined();
+      expect(typeof server.events.emit).toBe('function');
+      expect(typeof server.events.on).toBe('function');
     } finally {
       await server.stop('caller');
     }


### PR DESCRIPTION
## Summary
- Wires `OpenChromeServer.events` to the process-wide lifecycle bus now that #857/A1 exists.
- Updates the embedded-server contract test from the old `null` placeholder to the active lifecycle bus surface.

Fixes #857.

## Verification
- `npm test -- tests/core/lifecycle/event-bus.test.ts tests/integration/embedded-server.test.ts --runInBand` (passes; Jest still prints the existing open-handle warning after the pass summary)
- `npm run build`
- `npm run lint:tier`
- `git diff --check`

## Not tested
- Full live lifecycle JSONL trace scenario from `scripts/verify/A1-lifecycle-bus.mjs`.
