### PR TITLE
fix(devtools): include self-info URLs for #860

### DIFF
--- a/src/tools/connect.ts
+++ b/src/tools/connect.ts
@@ -98,43 +98,46 @@ const getConnectionInfoHandler: ToolHandler = async (
   const hostArg = args.host as string;
   const state = getServerState();
 
+  // Fetch devtools info in parallel with host-info generation. This is also
+  // used by host="openchrome" so self-introspection includes the same #860
+  // live DevTools metadata as external host config responses.
+  const devToolsPromise = collectDevToolsInfo();
+
   if (hostArg === 'openchrome') {
     // Issue #849: surface the auto-connect state so MCP clients can verify
     // they are talking to an externally-launched Chrome.
     const autoConnect = getAutoConnectState();
+    const devtools = await devToolsPromise;
     if (autoConnect) {
+      const response = {
+        mode: autoConnect.mode,
+        userDataDir: autoConnect.userDataDir,
+        port: autoConnect.port,
+        wsEndpoint: autoConnect.wsEndpoint,
+        attachedAt: new Date(autoConnect.attachedAt).toISOString(),
+        runtimeProfile: getRuntimeProfile(),
+        ...(devtools ? { devtools } : {}),
+      };
       return {
         content: [
           {
             type: 'text',
-            text: JSON.stringify(
-              {
-                mode: autoConnect.mode,
-                userDataDir: autoConnect.userDataDir,
-                port: autoConnect.port,
-                wsEndpoint: autoConnect.wsEndpoint,
-                attachedAt: new Date(autoConnect.attachedAt).toISOString(),
-                runtimeProfile: getRuntimeProfile(),
-              },
-              null,
-              2,
-            ),
+            text: JSON.stringify(response, null, 2),
           },
         ],
       };
     }
+    const response = { mode: 'managed', runtimeProfile: getRuntimeProfile(), ...(devtools ? { devtools } : {}) };
     return {
       content: [
         {
           type: 'text',
-          text: JSON.stringify({ mode: 'managed', runtimeProfile: getRuntimeProfile() }, null, 2),
+          text: JSON.stringify(response, null, 2),
         },
       ],
     };
   }
 
-  // Fetch devtools info in parallel with host-info generation
-  const devToolsPromise = collectDevToolsInfo();
 
   if (hostArg === 'all') {
     const [all, devtools] = await Promise.all([

--- a/tests/tools/oc-get-connection-info-devtools-field.test.ts
+++ b/tests/tools/oc-get-connection-info-devtools-field.test.ts
@@ -104,6 +104,28 @@ describe('oc_get_connection_info devtools field (#860)', () => {
     expect(data.runtimeProfile.guidance.join(' ')).toContain('read_page AX defaults to compact');
   });
 
+
+  test('host=openchrome managed response includes devtools block when Chrome is reachable', async () => {
+    const result = await handler('default', { host: 'openchrome' });
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text);
+    expect(data.mode).toBe('managed');
+    expect(data.devtools).toBeDefined();
+    expect(data.devtools.instances[0].pages[0].devtoolsFrontendUrl).toBe(
+      FIXTURE_INSTANCE.pages[0].devtoolsFrontendUrl
+    );
+  });
+
+  test('host=openchrome omits devtools block when exposure is disabled', async () => {
+    process.env.OPENCHROME_EXPOSE_DEVTOOLS_URL = '0';
+
+    const result = await handler('default', { host: 'openchrome' });
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text);
+    expect(data.mode).toBe('managed');
+    expect(data.devtools).toBeUndefined();
+  });
+
   test('tool is registered', () => {
     expect(server.getToolNames()).toContain('oc_get_connection_info');
   });


### PR DESCRIPTION
## Summary
- Adds the #860 devtools block to `oc_get_connection_info` when `host="openchrome"` is used for self-introspection.
- Keeps the existing off-switch behavior: `OPENCHROME_EXPOSE_DEVTOOLS_URL=0` omits the block.
- Reuses the same `collectDevToolsInfo()` path used by external host responses, preserving verbatim Chrome URLs.

Fixes #860.

## Verification
- `npm test -- tests/tools/oc-get-connection-info-devtools-field.test.ts tests/tools/oc-devtools-url.test.ts --runInBand`
- `npm run build`
- `git diff --check`

## Not tested
- Live manual paste of a returned DevTools URL into a browser.
