### PR TITLE
test(skill): preserve replay verifier path for #856

### DIFF
--- a/scripts/verify/oc-skill-replay.mjs
+++ b/scripts/verify/oc-skill-replay.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+/**
+ * Compatibility entrypoint for issue #856.
+ *
+ * The original issue contract names `scripts/verify/oc-skill-replay.mjs`.
+ * Keep this thin wrapper so operators and PR descriptions can use that exact
+ * path while the canonical scenario printer remains `skill-replay.mjs`.
+ */
+
+await import('./skill-replay.mjs');


### PR DESCRIPTION
## Summary
- Adds `scripts/verify/oc-skill-replay.mjs`, the exact reproducer path named by #856.
- Keeps it as a thin wrapper around the existing canonical `scripts/verify/skill-replay.mjs` scenario printer to avoid duplicated scenario drift.

Fixes #856.

## Verification
- `node --check scripts/verify/skill-replay.mjs`
- `node --check scripts/verify/oc-skill-replay.mjs`
- `npm test -- tests/tools/oc-skill-replay.test.ts tests/pilot/skill/replay.test.ts tests/core/skill-memory/no-network.test.ts --runInBand`
- `npm run build`
- `git diff --check`

## Not tested
- Live MCP execution of the printed skill replay scenarios.
