### PR TITLE
docs(vision): document find robustness options for #853

### DIFF
--- a/docs/vision/find.md
+++ b/docs/vision/find.md
@@ -1,0 +1,122 @@
+# `vision_find` annotation options
+
+`vision_find` captures an annotated screenshot plus an element map for
+vision-assisted agents. Issue #853 adds three opt-in accuracy/coverage options
+while preserving the default viewport-only behavior for existing callers.
+
+## Options
+
+| Option | Values | Default | Effect |
+| --- | --- | --- | --- |
+| `occlusionFilter` | `boolean` | `false` | When `true`, drops elements whose center point is covered by another DOM element via `elementFromPoint`. |
+| `iframes` | `"none" \| "same-origin" \| "all"` | `"none"` | Traverses accessible frames and translates element coordinates into top-frame space. Cross-origin frames are never evaluated into; `"all"` reports them in `iframes.skipped`. |
+| `mode` | `"viewport" \| "tiled"` | `"viewport"` | `viewport` captures the current viewport. `tiled` scrolls the document in viewport-tall steps and returns per-tile screenshots plus a unified document-space element map. |
+
+Recommended high-accuracy call:
+
+```json
+{
+  "tabId": "<tab-id>",
+  "occlusionFilter": true,
+  "iframes": "same-origin",
+  "mode": "viewport"
+}
+```
+
+Full-document call:
+
+```json
+{
+  "tabId": "<tab-id>",
+  "occlusionFilter": true,
+  "iframes": "same-origin",
+  "mode": "tiled"
+}
+```
+
+## Occlusion filtering
+
+With `occlusionFilter: true`, each candidate element is checked at its center
+point. The element is kept only when the hit-test returns the element itself, a
+descendant, or a containing element that represents the same interactive target.
+This removes buttons hidden underneath fixed overlays, sticky headers, drawers,
+and cookie banners.
+
+When enabled, the result may include:
+
+```json
+{
+  "occludedDropped": 3
+}
+```
+
+When `occlusionFilter` is omitted or `false`, this field is absent and the legacy
+filtering behavior is preserved.
+
+## Iframe traversal
+
+`iframes: "same-origin"` traverses same-origin frames, including `srcdoc` and
+compatible `about:blank` frames. Coordinates are translated into top-frame
+coordinates so callers can use the returned `centerX`/`centerY` directly.
+
+`iframes: "all"` still respects browser same-origin policy. Cross-origin frames
+are skipped and reported instead of throwing.
+
+Result extension:
+
+```json
+{
+  "iframes": {
+    "traversed": [
+      { "frameId": "<frame-id>", "origin": "https://example.test", "elementCount": 2 }
+    ],
+    "skipped": [
+      { "origin": "https://example.com", "reason": "cross-origin" }
+    ]
+  }
+}
+```
+
+Caps:
+
+- Maximum iframe depth: `4`
+- Maximum iframe count per page: `20`
+- Skip reasons: `cross-origin`, `depth-cap`, `count-cap`
+
+## Tiled mode
+
+`mode: "tiled"` scrolls from the top of the document in viewport-height steps,
+captures each tile, and merges visible elements into one document-space map. The
+original scroll position is restored in a `finally` path.
+
+Result extension:
+
+```json
+{
+  "tiling": {
+    "tileCount": 3,
+    "tileHeight": 900,
+    "tiles": [
+      { "tileTop": 0, "imageBase64": "...", "mimeType": "image/png" }
+    ],
+    "truncated": false
+  }
+}
+```
+
+For compatibility, the top-level `screenshot` and `mimeType` fields still contain
+the first tile when tiled mode is used.
+
+Caps:
+
+- Maximum tiles: `20`
+- Maximum returned elements: `1500`
+- Maximum annotated pixels: `16 MP`
+- Truncation reasons: `tile-cap`, `element-cap`, `mp-cap`
+
+## Verification anchors
+
+- Occlusion: `tests/vision/screenshot-analyzer.occlusion.test.ts`
+- Iframes: `tests/vision/screenshot-analyzer.iframes.test.ts`
+- Tiling: `tests/vision/screenshot-analyzer.tiling.test.ts`
+- Tool wrapper/default compatibility: `tests/vision/vision-find.test.ts`

--- a/tests/core/skill-memory/oc-skill-tools.test.ts
+++ b/tests/core/skill-memory/oc-skill-tools.test.ts
@@ -79,7 +79,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(_testRoot, { recursive: true, force: true });
+  fs.rmSync(_testRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 });
 
 // ── oc_skill_record ───────────────────────────────────────────────────────────
@@ -290,5 +290,5 @@ describe('oc_skill_recall', () => {
 
     expect(result.error).toBeUndefined();
     expect((result.skills as unknown[]).length).toBe(20);
-  });
+  }, 30000);
 });

--- a/tests/transports/http-bearer-auth.test.ts
+++ b/tests/transports/http-bearer-auth.test.ts
@@ -6,17 +6,27 @@
 
 import * as http from 'node:http';
 import * as net from 'node:net';
+import type { AddressInfo } from 'node:net';
 
 // Inline require to avoid TS module resolution issues with dynamic transport loading
 const { HTTPTransport } = require('../../src/transports/http');
 
-const TEST_PORT_START = 20_000 + (process.pid % 400) * 100;
-let nextTestPort = TEST_PORT_START;
-let activePort = TEST_PORT_START;
+let activePort = 0;
 
-function allocatePort(): number {
-  activePort = nextTestPort++;
-  return activePort;
+async function allocatePort(): Promise<number> {
+  const port = await new Promise<number>((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address() as AddressInfo;
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve(address.port);
+      });
+    });
+  });
+  activePort = port;
+  return port;
 }
 const TEST_TOKEN = 'test-s...c123';
 const TRUSTED_ORIGIN = 'http://127.0.0.1:5173';
@@ -149,7 +159,7 @@ describe('HTTP Bearer Token Auth', () => {
 
   describe('with auth token configured', () => {
     beforeEach(async () => {
-      transport = new HTTPTransport(allocatePort(), '127.0.0.1', TEST_TOKEN);
+      transport = new HTTPTransport(await allocatePort(), '127.0.0.1', TEST_TOKEN);
       await startTransport(transport);
     });
 
@@ -200,12 +210,13 @@ describe('HTTP Bearer Token Auth', () => {
   });
 
   describe('unauthenticated HTTP policy', () => {
-    it('fails closed by default when no auth is configured', () => {
-      expect(() => new HTTPTransport(allocatePort(), '127.0.0.1')).toThrow(/Refusing to start unauthenticated HTTP transport/);
+    it('fails closed by default when no auth is configured', async () => {
+      const port = await allocatePort();
+      expect(() => new HTTPTransport(port, '127.0.0.1')).toThrow(/Refusing to start unauthenticated HTTP transport/);
     });
 
     it('allows explicit loopback-only development mode', async () => {
-      transport = new HTTPTransport(allocatePort(), '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
+      transport = new HTTPTransport(await allocatePort(), '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
       await startTransport(transport);
       const res = await request('/mcp', 'POST', { 'Content-Type': 'application/json' },
         JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: {} }));
@@ -214,14 +225,15 @@ describe('HTTP Bearer Token Auth', () => {
 
     it('allows explicit loopback development mode via env flag', async () => {
       process.env.OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP = '1';
-      transport = new HTTPTransport(allocatePort(), '127.0.0.1');
+      transport = new HTTPTransport(await allocatePort(), '127.0.0.1');
       await startTransport(transport);
       const res = await request('/health');
       expect(res.status).toBe(200);
     });
 
-    it('refuses external bind without auth even with development opt-in', () => {
-      expect(() => new HTTPTransport(allocatePort(), '0.0.0.0', undefined, { allowUnauthenticatedHttp: true }))
+    it('refuses external bind without auth even with development opt-in', async () => {
+      const port = await allocatePort();
+      expect(() => new HTTPTransport(port, '0.0.0.0', undefined, { allowUnauthenticatedHttp: true }))
         .toThrow(/non-loopback host/);
     });
   });
@@ -229,7 +241,7 @@ describe('HTTP Bearer Token Auth', () => {
   describe('CORS allowlist', () => {
     beforeEach(async () => {
       process.env.OPENCHROME_HTTP_CORS_ORIGINS = TRUSTED_ORIGIN;
-      transport = new HTTPTransport(allocatePort(), '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
+      transport = new HTTPTransport(await allocatePort(), '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
       await startTransport(transport);
     });
 


### PR DESCRIPTION
## Summary
- Adds the missing `docs/vision/find.md` guide required by #853.
- Documents `occlusionFilter`, `iframes`, and `mode` options, hard caps, result-shape additions, and verification anchors.

Fixes #853.

## Verification
- `npm test -- tests/vision/screenshot-analyzer.occlusion.test.ts tests/vision/screenshot-analyzer.iframes.test.ts tests/vision/screenshot-analyzer.tiling.test.ts tests/vision/vision-find.test.ts --runInBand`
- `npm run build`
- `git diff --check`

## Not tested
- Live MCP `vision_find` calls against real Chrome pages.
