### PR TITLE
test(chrome): add auto-connect verifier for #849

### DIFF
--- a/scripts/verify/E-auto-connect.mjs
+++ b/scripts/verify/E-auto-connect.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Reproducer helper for issue #849 (`--auto-connect` via DevToolsActivePort).
+ *
+ * The full verification requires a human/reviewer to launch Chrome manually and
+ * then run OpenChrome/MCP calls. This script prints platform-specific commands
+ * and validates a provided DevToolsActivePort file when OC_AUTO_CONNECT_DIR is
+ * set. It is intentionally side-effect-light: no Chrome process is launched by
+ * default.
+ *
+ * Usage:
+ *   node scripts/verify/E-auto-connect.mjs
+ *   OC_AUTO_CONNECT_DIR=/tmp/oc-verify-E node scripts/verify/E-auto-connect.mjs
+ */
+
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+
+const dir = process.env.OC_AUTO_CONNECT_DIR;
+
+function chromeCommand(userDataDir) {
+  const url = 'https://en.wikipedia.org/wiki/Main_Page';
+  if (process.platform === 'darwin') {
+    return `/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --remote-debugging-port=0 --user-data-dir=${userDataDir} ${url}`;
+  }
+  if (process.platform === 'win32') {
+    return `"%ProgramFiles%\\Google\\Chrome\\Application\\chrome.exe" --remote-debugging-port=0 --user-data-dir=${userDataDir} ${url}`;
+  }
+  return `google-chrome --remote-debugging-port=0 --user-data-dir=${userDataDir} ${url}`;
+}
+
+function parseActivePort(raw) {
+  const [portLine, pathLine = '/devtools/browser'] = raw.trim().split(/\r?\n/);
+  const port = Number(portLine);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(`invalid DevToolsActivePort port: ${JSON.stringify(portLine)}`);
+  }
+  const browserTargetPath = pathLine.startsWith('/') ? pathLine : `/${pathLine}`;
+  return { port, browserTargetPath, wsEndpoint: `ws://127.0.0.1:${port}${browserTargetPath}` };
+}
+
+function probePort(port) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host: '127.0.0.1', port, timeout: 1000 });
+    socket.on('connect', () => { socket.destroy(); resolve(true); });
+    socket.on('timeout', () => { socket.destroy(); resolve(false); });
+    socket.on('error', () => resolve(false));
+  });
+}
+
+function printChecklist(userDataDir) {
+  console.log('# #849 auto-connect verification');
+  console.log(`mkdir -p ${userDataDir}`);
+  console.log(chromeCommand(userDataDir));
+  console.log(`\n# wait until ${path.join(userDataDir, 'DevToolsActivePort')} exists`);
+  console.log(`openchrome serve --auto-connect=${userDataDir}`);
+  console.log('\n# MCP checks:');
+  console.log('- oc_get_connection_info(host="openchrome") => {mode:"auto-connect", userDataDir, port}');
+  console.log('- tabs_context lists the manually opened Wikipedia tab');
+  console.log('- navigate that tab to https://example.com succeeds');
+  console.log('- oc_connection_health reports lifecycleMode:"attach"');
+  console.log('- stopping OpenChrome leaves the manual Chrome process alive');
+  console.log('- --auto-connect combined with --launch-mode=auto or isolated exits non-zero');
+  console.log('- stale DevToolsActivePort with closed port fails within the timeout');
+}
+
+const defaultDir = path.join(os.tmpdir(), 'oc-verify-E');
+printChecklist(dir ?? defaultDir);
+
+if (dir) {
+  const file = path.join(dir, 'DevToolsActivePort');
+  if (!fs.existsSync(file)) {
+    console.error(`\n[E-auto-connect] FAIL: ${file} does not exist`);
+    process.exit(2);
+  }
+  const parsed = parseActivePort(fs.readFileSync(file, 'utf8'));
+  const bound = await probePort(parsed.port);
+  console.log(`\n[E-auto-connect] Parsed ${file}: ${JSON.stringify(parsed)}`);
+  console.log(`[E-auto-connect] Port bound: ${bound}`);
+  process.exit(bound ? 0 : 3);
+}

--- a/tests/transports/http-bearer-auth.test.ts
+++ b/tests/transports/http-bearer-auth.test.ts
@@ -6,17 +6,27 @@
 
 import * as http from 'node:http';
 import * as net from 'node:net';
+import type { AddressInfo } from 'node:net';
 
 // Inline require to avoid TS module resolution issues with dynamic transport loading
 const { HTTPTransport } = require('../../src/transports/http');
 
-const TEST_PORT_START = 20_000 + (process.pid % 400) * 100;
-let nextTestPort = TEST_PORT_START;
-let activePort = TEST_PORT_START;
+let activePort = 0;
 
-function allocatePort(): number {
-  activePort = nextTestPort++;
-  return activePort;
+async function allocatePort(): Promise<number> {
+  const port = await new Promise<number>((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address() as AddressInfo;
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve(address.port);
+      });
+    });
+  });
+  activePort = port;
+  return port;
 }
 const TEST_TOKEN = 'test-s...c123';
 const TRUSTED_ORIGIN = 'http://127.0.0.1:5173';
@@ -149,7 +159,7 @@ describe('HTTP Bearer Token Auth', () => {
 
   describe('with auth token configured', () => {
     beforeEach(async () => {
-      transport = new HTTPTransport(allocatePort(), '127.0.0.1', TEST_TOKEN);
+      transport = new HTTPTransport(await allocatePort(), '127.0.0.1', TEST_TOKEN);
       await startTransport(transport);
     });
 
@@ -200,12 +210,13 @@ describe('HTTP Bearer Token Auth', () => {
   });
 
   describe('unauthenticated HTTP policy', () => {
-    it('fails closed by default when no auth is configured', () => {
-      expect(() => new HTTPTransport(allocatePort(), '127.0.0.1')).toThrow(/Refusing to start unauthenticated HTTP transport/);
+    it('fails closed by default when no auth is configured', async () => {
+      const port = await allocatePort();
+      expect(() => new HTTPTransport(port, '127.0.0.1')).toThrow(/Refusing to start unauthenticated HTTP transport/);
     });
 
     it('allows explicit loopback-only development mode', async () => {
-      transport = new HTTPTransport(allocatePort(), '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
+      transport = new HTTPTransport(await allocatePort(), '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
       await startTransport(transport);
       const res = await request('/mcp', 'POST', { 'Content-Type': 'application/json' },
         JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: {} }));
@@ -214,14 +225,15 @@ describe('HTTP Bearer Token Auth', () => {
 
     it('allows explicit loopback development mode via env flag', async () => {
       process.env.OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP = '1';
-      transport = new HTTPTransport(allocatePort(), '127.0.0.1');
+      transport = new HTTPTransport(await allocatePort(), '127.0.0.1');
       await startTransport(transport);
       const res = await request('/health');
       expect(res.status).toBe(200);
     });
 
-    it('refuses external bind without auth even with development opt-in', () => {
-      expect(() => new HTTPTransport(allocatePort(), '0.0.0.0', undefined, { allowUnauthenticatedHttp: true }))
+    it('refuses external bind without auth even with development opt-in', async () => {
+      const port = await allocatePort();
+      expect(() => new HTTPTransport(port, '0.0.0.0', undefined, { allowUnauthenticatedHttp: true }))
         .toThrow(/non-loopback host/);
     });
   });
@@ -229,7 +241,7 @@ describe('HTTP Bearer Token Auth', () => {
   describe('CORS allowlist', () => {
     beforeEach(async () => {
       process.env.OPENCHROME_HTTP_CORS_ORIGINS = TRUSTED_ORIGIN;
-      transport = new HTTPTransport(allocatePort(), '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
+      transport = new HTTPTransport(await allocatePort(), '127.0.0.1', undefined, { allowUnauthenticatedHttp: true });
       await startTransport(transport);
     });
 


### PR DESCRIPTION
## Summary
- Adds the missing `scripts/verify/E-auto-connect.mjs` helper named by #849.
- The helper prints platform-specific manual Chrome startup steps and validates `OC_AUTO_CONNECT_DIR/DevToolsActivePort` when a reviewer provides a live directory.

Fixes #849.

## Verification
- `node --check scripts/verify/E-auto-connect.mjs`
- `npm test -- tests/chrome/auto-connect.test.ts --runInBand`
- `npm run build`
- `git diff --check`

## Not tested
- Live manual Chrome auto-connect flow.
