### PR TITLE
fix(core): restore include snapshot chaining for #845

### DIFF
--- a/scripts/verify/A2-include-snapshot.mjs
+++ b/scripts/verify/A2-include-snapshot.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * scripts/verify/A2-include-snapshot.mjs
+ *
+ * Issue #845 reproducer for the opt-in post-action snapshot chain
+ * (`returnAfterState`, the OpenChrome equivalent of includeSnapshot).
+ *
+ * Default mode is hermetic: verify source/test anchors and print the live MCP
+ * checklist. Use --unit to run the focused return-after-state/hint coverage.
+ *
+ * Usage:
+ *   node scripts/verify/A2-include-snapshot.mjs
+ *   node scripts/verify/A2-include-snapshot.mjs --unit
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { exit, stderr } from 'node:process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..', '..');
+const args = new Set(process.argv.slice(2));
+
+const inputTools = [
+  'src/tools/interact.ts',
+  'src/tools/form-input.ts',
+  'src/tools/fill-form.ts',
+  'src/tools/act.ts',
+  'src/tools/computer.ts',
+];
+
+function log(line = '') {
+  stderr.write(`${line}\n`);
+}
+
+function fail(message) {
+  log(`[A2-include-snapshot] FAIL: ${message}`);
+  exit(1);
+}
+
+function ok(message) {
+  log(`[A2-include-snapshot] OK: ${message}`);
+}
+
+function read(relPath) {
+  const path = join(repoRoot, relPath);
+  if (!existsSync(path)) fail(`missing required file: ${relPath}`);
+  return readFileSync(path, 'utf8');
+}
+
+function requireContains(relPath, needle, reason) {
+  const text = read(relPath);
+  if (!text.includes(needle)) {
+    fail(`${relPath} missing ${JSON.stringify(needle)} (${reason})`);
+  }
+  ok(`${relPath}: ${reason}`);
+}
+
+function runUnitSuites() {
+  log('# running focused #845 Jest suites');
+  const result = spawnSync(
+    'npm',
+    [
+      'test',
+      '--',
+      'tests/e2e/return-after-state.test.ts',
+      'tests/hints/hint-engine.test.ts',
+      '--runInBand',
+    ],
+    { cwd: repoRoot, stdio: 'inherit' },
+  );
+  if (result.status !== 0) fail(`focused Jest suites exited ${result.status}`);
+  ok('focused #845 Jest suites passed');
+}
+
+function printChecklist() {
+  log('');
+  log('# OpenChrome MCP live checklist for #845');
+  log('1. Build and start openchrome, then navigate to https://news.ycombinator.com/.');
+  log('2. interact action=click target={text:"new"} returnAfterState=dom.');
+  log('   Expect result.success=true plus state.mode=dom and a post-click snapshot for /newest.');
+  log('3. Repeat baseline without returnAfterState, then call read_page mode=dom.');
+  log('   Expect chained response bytes < standalone interact + standalone read_page bytes.');
+  log('4. fill_form on https://httpbin.org/forms/post with returnAfterState=ax.');
+  log('   Expect AX snapshot containing the filled custname/custtel/custemail values.');
+  log('5. Trigger an action failure with returnAfterState=dom.');
+  log('   Expect no misleading success snapshot.');
+  log('6. oc_journal filter="tool=interact AND returnAfterState=dom".');
+  log('   Expect args summary records the option.');
+  log('7. Compare hint behavior: omitted returnAfterState may suggest read_page; opt-in returnAfterState suppresses that stale-observation hint.');
+  log('');
+}
+
+log('# A2-include-snapshot verifier — issue #845');
+
+requireContains('src/tools/_shared/return-after-state.ts', "export type ReturnAfterState = 'none' | 'ax' | 'dom'", 'shared enum exists');
+requireContains('src/tools/_shared/return-after-state.ts', 'readPageHandlerForReuse', 'snapshot uses read_page code path');
+requireContains('src/tools/_shared/return-after-state.ts', 'appendReturnAfterState', 'shared response appender exists');
+requireContains('src/tools/read-page.ts', 'readPageHandlerForReuse', 'read_page exposes reusable handler');
+
+for (const toolPath of inputTools) {
+  requireContains(toolPath, 'returnAfterState', 'input tool accepts returnAfterState');
+}
+
+requireContains('src/hints/rules/sequence-detection.ts', 'returnAfterState', 'sequence hints observe returnAfterState');
+requireContains('src/hints/rules/composite-suggestions.ts', 'returnAfterState', 'composite hints observe returnAfterState');
+requireContains('tests/e2e/return-after-state.test.ts', 'token-cost guard (combined < a + b)', 'token-cost guard exists');
+requireContains('tests/e2e/return-after-state.test.ts', 'returnAfterState helper (issue #845)', 'focused helper coverage exists');
+requireContains('tests/fixtures/return-after-state/index.html', 'return-after-state fixture', 'deterministic fixture exists');
+
+printChecklist();
+
+if (args.has('--unit')) {
+  runUnitSuites();
+} else {
+  log('Run with --unit for focused Jest verification.');
+  ok('static #845 contract anchors verified');
+}

--- a/src/tools/act.ts
+++ b/src/tools/act.ts
@@ -39,6 +39,7 @@ import {
   WorkflowPageSignature,
 } from '../actions/action-cache';
 import { coerceVerifyMode, runVerify, VERIFY_FIELD_SCHEMA, VerifyReport } from '../core/perception/verify';
+import { appendReturnAfterState, parseReturnAfterState, RETURN_AFTER_STATE_SCHEMA } from './_shared/return-after-state';
 
 // ─── Types ───
 
@@ -93,6 +94,7 @@ const definition: MCPToolDefinition = {
         type: 'boolean',
         description: 'Include concise workflow cache accept/reject metadata in the response. Default: false',
       },
+      returnAfterState: RETURN_AFTER_STATE_SCHEMA,
     },
     required: ['tabId', 'instruction'],
   },
@@ -551,7 +553,7 @@ async function executeCheckUncheck(
 
 // ─── Handler ───
 
-const handler: ToolHandler = async (
+const coreHandler: ToolHandler = async (
   sessionId: string,
   args: Record<string, unknown>,
   context?: ToolContext
@@ -851,6 +853,26 @@ Suggestion: ${suggestion}`,
 };
 
 // ─── Registration ───
+
+
+const handler: ToolHandler = async (sessionId, args, context): Promise<MCPResult> => {
+  const result = await coreHandler(sessionId, args, context);
+  const returnAfterState = parseReturnAfterState(args.returnAfterState);
+  if (returnAfterState === 'none' || result.isError) return result;
+
+  const tabId = args.tabId as string | undefined;
+  if (!tabId) return result;
+
+  try {
+    const page = await getSessionManager().getPage(sessionId, tabId, undefined, 'act');
+    if (page) {
+      await appendReturnAfterState(result, page, sessionId, tabId, returnAfterState, context);
+    }
+  } catch {
+    // Snapshot chaining is best-effort; never mask the successful action result.
+  }
+  return result;
+};
 
 export function registerActTool(server: MCPServer): void {
   server.registerTool('act', handler, definition);

--- a/src/tools/fill-form.ts
+++ b/src/tools/fill-form.ts
@@ -20,6 +20,7 @@ import { humanType, humanMouseMove } from '../stealth/human-behavior';
 import { detectLoginOutcome, LoginDetectResult } from './login-detector';
 import { wrapMutatingHandler } from '../utils/snapshot-cache-helper';
 import { coerceVerifyMode, runVerify, VERIFY_FIELD_SCHEMA } from '../core/perception/verify';
+import { appendReturnAfterState, parseReturnAfterState, RETURN_AFTER_STATE_SCHEMA } from './_shared/return-after-state';
 
 const definition: MCPToolDefinition = {
   name: 'fill_form',
@@ -73,6 +74,7 @@ const definition: MCPToolDefinition = {
         description: 'Human-readable label for this action in audit logs (≤120 chars)',
         maxLength: 120,
       },
+      returnAfterState: RETURN_AFTER_STATE_SCHEMA,
     },
     required: ['tabId'],
   },
@@ -80,7 +82,7 @@ const definition: MCPToolDefinition = {
 };
 
 
-const handler: ToolHandler = async (
+const coreHandler: ToolHandler = async (
   sessionId: string,
   args: Record<string, unknown>,
   context?: ToolContext
@@ -671,6 +673,26 @@ const handler: ToolHandler = async (
       isError: true,
     };
   }
+};
+
+
+const handler: ToolHandler = async (sessionId, args, context): Promise<MCPResult> => {
+  const result = await coreHandler(sessionId, args, context);
+  const returnAfterState = parseReturnAfterState(args.returnAfterState);
+  if (returnAfterState === 'none' || result.isError) return result;
+
+  const tabId = args.tabId as string | undefined;
+  if (!tabId) return result;
+
+  try {
+    const page = await getSessionManager().getPage(sessionId, tabId, undefined, 'fill_form');
+    if (page) {
+      await appendReturnAfterState(result, page, sessionId, tabId, returnAfterState, context);
+    }
+  } catch {
+    // Snapshot chaining is best-effort; never mask the successful action result.
+  }
+  return result;
 };
 
 export function registerFillFormTool(server: MCPServer): void {

--- a/src/tools/form-input.ts
+++ b/src/tools/form-input.ts
@@ -8,6 +8,7 @@ import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { getRefIdManager, formatStaleRefError, makeStaleRefError } from '../utils/ref-id-manager';
 import { withDomDelta } from '../utils/dom-delta';
+import { appendReturnAfterState, parseReturnAfterState, RETURN_AFTER_STATE_SCHEMA } from './_shared/return-after-state';
 
 const definition: MCPToolDefinition = {
   name: 'form_input',
@@ -32,13 +33,14 @@ const definition: MCPToolDefinition = {
         description: 'Human-readable label for this action in audit logs (≤120 chars)',
         maxLength: 120,
       },
+      returnAfterState: RETURN_AFTER_STATE_SCHEMA,
     },
     required: ['ref', 'value', 'tabId'],
   },
   annotations: TOOL_ANNOTATIONS.form_input,
 };
 
-const handler: ToolHandler = async (
+const coreHandler: ToolHandler = async (
   sessionId: string,
   args: Record<string, unknown>,
   context?: ToolContext
@@ -453,6 +455,26 @@ const handler: ToolHandler = async (
       isError: true,
     };
   }
+};
+
+
+const handler: ToolHandler = async (sessionId, args, context): Promise<MCPResult> => {
+  const result = await coreHandler(sessionId, args, context);
+  const returnAfterState = parseReturnAfterState(args.returnAfterState);
+  if (returnAfterState === 'none' || result.isError) return result;
+
+  const tabId = args.tabId as string | undefined;
+  if (!tabId) return result;
+
+  try {
+    const page = await getSessionManager().getPage(sessionId, tabId, undefined, 'form_input');
+    if (page) {
+      await appendReturnAfterState(result, page, sessionId, tabId, returnAfterState, context);
+    }
+  } catch {
+    // Snapshot chaining is best-effort; never mask the successful action result.
+  }
+  return result;
 };
 
 export function registerFormInputTool(server: MCPServer): void {

--- a/src/tools/interact.ts
+++ b/src/tools/interact.ts
@@ -31,6 +31,7 @@ import {
   type ValidatedLocatorFallbackCandidate,
 } from '../core/perception/locator-fallback';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
+import { appendReturnAfterState, parseReturnAfterState, RETURN_AFTER_STATE_SCHEMA } from './_shared/return-after-state';
 
 /**
  * Inject the structured {@link VerifyReport} onto an MCPResult under
@@ -94,6 +95,7 @@ const definition: MCPToolDefinition = {
         description: 'Response content. Default: both',
       },
       verify: VERIFY_FIELD_SCHEMA,
+      returnAfterState: RETURN_AFTER_STATE_SCHEMA,
       waitForMs: {
         type: 'number',
         description: 'Poll timeout for element in ms. Max: 30000',
@@ -194,7 +196,7 @@ async function validateLocatorCandidate(
   return { ...candidate, selector: candidate.selector, rect };
 }
 
-const handler: ToolHandler = async (
+const coreHandler: ToolHandler = async (
   sessionId: string,
   args: Record<string, unknown>,
   context?: ToolContext
@@ -972,6 +974,26 @@ const handler: ToolHandler = async (
       isError: true,
     };
   }
+};
+
+
+const handler: ToolHandler = async (sessionId, args, context): Promise<MCPResult> => {
+  const result = await coreHandler(sessionId, args, context);
+  const returnAfterState = parseReturnAfterState(args.returnAfterState);
+  if (returnAfterState === 'none' || result.isError) return result;
+
+  const tabId = args.tabId as string | undefined;
+  if (!tabId) return result;
+
+  try {
+    const page = await getSessionManager().getPage(sessionId, tabId, undefined, 'interact');
+    if (page) {
+      await appendReturnAfterState(result, page, sessionId, tabId, returnAfterState, context);
+    }
+  } catch {
+    // Snapshot chaining is best-effort; never mask the successful action result.
+  }
+  return result;
 };
 
 export function registerInteractTool(server: MCPServer): void {


### PR DESCRIPTION
## Summary
- Restores `returnAfterState` schema/plumbing for `interact`, `form_input`, `fill_form`, and `act`; `computer` already had the shared path on `develop`.
- Adds the missing `scripts/verify/A2-include-snapshot.mjs` reproducer named by #845.
- Keeps the default/absent option byte-compatible by only appending state when `returnAfterState` parses to `ax` or `dom` and the action result succeeded.

Fixes #845.

## Verification
- `node scripts/verify/A2-include-snapshot.mjs`
- `node --check scripts/verify/A2-include-snapshot.mjs`
- `npm test -- tests/e2e/return-after-state.test.ts tests/hints/hint-engine.test.ts --runInBand`
- `npm run build`
- `git diff --check`

## Not tested
- Live MCP click/fill flow against external sites.
