### PR TITLE
fix(pilot): validate recovery recipes for #1061

### DIFF
--- a/src/tools/oc-pilot-run-with-recovery.ts
+++ b/src/tools/oc-pilot-run-with-recovery.ts
@@ -6,6 +6,7 @@ import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 
 const SAFE_RECIPES = ['refresh_dom_state', 'wait_for_page_ready', 'restore_checkpoint'] as const;
 const FUTURE_RECIPES = ['reacquire_ref', 'switch_to_programmatic_click'] as const;
+const ALL_RECIPES = [...SAFE_RECIPES, ...FUTURE_RECIPES] as const;
 type SafeRecipeId = typeof SAFE_RECIPES[number];
 type RecoveryRecipeId = SafeRecipeId | typeof FUTURE_RECIPES[number];
 
@@ -31,7 +32,7 @@ const definition: MCPToolDefinition = {
       postcondition: { type: 'object', description: 'Optional Outcome Contract assertion metadata.', additionalProperties: true },
       maxRecoveryAttempts: { type: 'number', description: 'Default 1, maximum 3.' },
       checkpointBefore: { type: 'boolean', description: 'Default true. Records a redacted checkpoint reference in the response.' },
-      allowedRecipes: { type: 'array', items: { type: 'string', enum: [...SAFE_RECIPES, ...FUTURE_RECIPES] } },
+      allowedRecipes: { type: 'array', items: { type: 'string', enum: [...ALL_RECIPES] } },
       dryRun: { type: 'boolean', description: 'Classify and propose recipes without executing the original action.' },
     },
     required: ['action'],
@@ -95,9 +96,20 @@ function parseAttempts(raw: unknown): number | string {
   return attempts;
 }
 
-function allowedRecipeSet(raw: unknown): Set<RecoveryRecipeId> {
-  if (!Array.isArray(raw) || raw.length === 0) return new Set(SAFE_RECIPES);
-  return new Set(raw as RecoveryRecipeId[]);
+function allowedRecipeSet(raw: unknown): { recipes: Set<RecoveryRecipeId>; error?: string } {
+  if (!Array.isArray(raw) || raw.length === 0) return { recipes: new Set(SAFE_RECIPES) };
+
+  const recipes = new Set<RecoveryRecipeId>();
+  for (const value of raw) {
+    if (typeof value !== 'string' || !(ALL_RECIPES as readonly string[]).includes(value)) {
+      return { recipes, error: `unknown recovery recipe: ${String(value)}` };
+    }
+    if ((FUTURE_RECIPES as readonly string[]).includes(value)) {
+      return { recipes, error: `recipe ${value} is declared but not implemented yet` };
+    }
+    recipes.add(value as RecoveryRecipeId);
+  }
+  return { recipes };
 }
 
 async function callTool(server: MCPServer, sessionId: string, tool: string, args: Record<string, unknown>): Promise<RecoveryActionResult> {
@@ -141,7 +153,11 @@ export function registerOcPilotRunWithRecoveryTool(server: MCPServer): void {
     }
 
     const checkpointId = args.checkpointBefore === false ? undefined : `pilot-checkpoint-${Date.now()}`;
-    const allowed = allowedRecipeSet(args.allowedRecipes);
+    const allowedResult = allowedRecipeSet(args.allowedRecipes);
+    if (allowedResult.error) {
+      return { content: [{ type: 'text', text: `INVALID_INPUT: ${allowedResult.error}` }], isError: true };
+    }
+    const allowed = allowedResult.recipes;
     const recovery: Array<{ attempt: number; recipe: RecoveryRecipeId; reason: string; actions: RecoveryActionResult[]; postcondition?: { evaluated: boolean; passed: boolean } }> = [];
 
     if (args.dryRun === true) {

--- a/tests/tools/oc-pilot-run-with-recovery.test.ts
+++ b/tests/tools/oc-pilot-run-with-recovery.test.ts
@@ -56,6 +56,39 @@ describe('oc_pilot_run_with_recovery', () => {
     expect(out.recovery[0].actions[0]).toMatchObject({ tool: 'read_page', ok: true });
   });
 
+  it('recovers page-not-ready failures with wait_for_page_ready evidence', async () => {
+    const server = makeServer({
+      interact: jest.fn(async () => result('timeout waiting for page ready', true)),
+      wait_for: jest.fn(async () => result('loaded')),
+    });
+    registerOcPilotRunWithRecoveryTool(server as any);
+
+    const response = await server.call({
+      tabId: 'tab-1',
+      action: { tool: 'interact', arguments: { query: 'Delayed button' } },
+      allowedRecipes: ['wait_for_page_ready'],
+      maxRecoveryAttempts: 1,
+    });
+    const out = parse(response);
+
+    expect(out.status).toBe('recovered');
+    expect(out.recovery[0]).toMatchObject({ recipe: 'wait_for_page_ready', reason: 'page_not_ready' });
+    expect(out.recovery[0].actions[0]).toMatchObject({ tool: 'wait_for', ok: true });
+  });
+
+  it('rejects declared future recipes until their follow-up implementations land', async () => {
+    const server = makeServer({});
+    registerOcPilotRunWithRecoveryTool(server as any);
+
+    const response = await server.call({
+      action: { tool: 'interact', arguments: { query: 'Submit' } },
+      allowedRecipes: ['reacquire_ref'],
+    });
+
+    expect(response.isError).toBe(true);
+    expect(response.content?.[0]?.text).toContain('recipe reacquire_ref is declared but not implemented yet');
+  });
+
   it('rejects unsafe tools and hard bound violations', async () => {
     const server = makeServer({});
     registerOcPilotRunWithRecoveryTool(server as any);


### PR DESCRIPTION
## Summary
- Rejects declared future recovery recipes (`reacquire_ref`, `switch_to_programmatic_click`) with explicit validation errors until their follow-up implementations land.
- Adds focused coverage that `wait_for_page_ready` actually executes as the second safe #1061 recipe.
- Keeps the existing pilot-only gate, hard attempt bound, unsafe-tool rejection, and redacted reporting behavior unchanged.

Fixes #1061.

## Verification
- `npm test -- tests/tools/oc-pilot-run-with-recovery.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `git diff --check`

## Not tested
- Live OpenChrome delayed-button fixture.
