### PR TITLE
test(recovery): document reward scorer for #1019

### DIFF
--- a/docs/recovery/reward-scorer.md
+++ b/docs/recovery/reward-scorer.md
@@ -1,0 +1,32 @@
+# Recovery reward scorer
+
+`src/recovery/reward-scorer.ts` is a pure deterministic scorer for recovery telemetry (#1019). It converts lightweight evidence into a bounded score from `-1` to `1` plus a classification, reasons, and confidence.
+
+## Safety contract
+
+- No LLM/API/provider calls.
+- No browser actions, retries, or replay.
+- No raw DOM/screenshot/network blobs are required.
+- Same input must produce byte-identical output.
+- Contract verdicts dominate heuristic evidence: pass is the strongest positive signal, fail is a strong negative reason.
+
+## Intended consumers
+
+- `MCPServer` recovery trajectory telemetry records the numeric reward for later inspection.
+- #1018 candidate ranking may sort recovery candidates by this score.
+- #1020 bounded recovery search may use scores as evidence, not as permission to execute.
+- #1022 policy learning may aggregate scores, but the scorer itself remains stateless.
+
+## Score bands
+
+| Classification | Meaning |
+| --- | --- |
+| `contract_pass` | Outcome contract passed; strongest positive evidence. |
+| `progress` | URL/DOM/network/data/ref evidence moved in the intended direction. |
+| `observation` | Observation produced information but no strong progress signal. |
+| `no_progress` | No meaningful delta or repeated observation without new evidence. |
+| `failure` | Stale ref, timeout, missing element, target closed, or tool error. |
+| `blocked` | Auth/CAPTCHA/access-denied/blocking-page signal. |
+| `destructive_blocked` | Ungated destructive/transactional action; hard negative. |
+
+The score is advisory telemetry. Hosts decide whether to retry, change strategy, ask the user, or stop.

--- a/tests/recovery/reward-scorer.test.ts
+++ b/tests/recovery/reward-scorer.test.ts
@@ -55,6 +55,28 @@ describe('scoreRecoveryOutcome', () => {
     expect(score.score).toBe(-1);
   });
 
+
+
+  it('scores recovery via fresh read above repeating the same failed action', () => {
+    const repeatedFailure = scoreRecoveryOutcome({
+      toolName: 'interact',
+      isError: true,
+      errorText: 'STALE_REF: element not found',
+      repeatedFailureCount: 1,
+    });
+    const freshReadRecovery = scoreRecoveryOutcome({
+      toolName: 'read_page',
+      resultText: '[ref_1] Submit button',
+      observationOnly: true,
+      freshRefsDiscovered: true,
+    });
+
+    expect(repeatedFailure.classification).toBe('failure');
+    expect(freshReadRecovery.classification).toBe('progress');
+    expect(freshReadRecovery.score).toBeGreaterThan(repeatedFailure.score);
+    expect(freshReadRecovery.reasons).toContain('fresh actionable refs discovered');
+  });
+
   it('handles missing evidence deterministically', () => {
     const a = scoreRecoveryOutcome({ toolName: 'unknown_tool' });
     const b = scoreRecoveryOutcome({ toolName: 'unknown_tool' });


### PR DESCRIPTION
## Summary
- Adds recovery reward scorer documentation covering safety, score bands, and intended consumers (#1018/#1020/#1022).
- Adds the required recovery comparison test: a failed stale interaction followed by a fresh `read_page` with actionable refs scores higher than repeating the failed action.
- Confirms the scorer remains pure telemetry: no LLM calls, no browser actions, no automatic recovery execution.

Fixes #1019.

## Verification
- `npm test -- tests/recovery/reward-scorer.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `git diff --check`

## Not tested
- Real OpenChrome fixture transcript for scorer telemetry.
