### PR TITLE
feat(hints): rank recovery candidates for #1018

### DIFF
--- a/src/hints/hint-engine.ts
+++ b/src/hints/hint-engine.ts
@@ -19,6 +19,7 @@ import type { ActivityTracker } from '../dashboard/activity-tracker';
 import { PatternLearner } from './pattern-learner';
 import { buildFailureEpisodeContext, type FailureEpisodeContext } from './failure-episode-store';
 import { ProgressTracker } from './progress-tracker.js';
+import { formatRecoveryCandidates, rankRecoveryCandidates, type RecoveryCandidate } from './recovery-candidates';
 import { RepeatedCallDetector } from './repeated-call-detector.js';
 import { errorRecoveryRules } from './rules/error-recovery';
 import { blockingPageRules } from './rules/blocking-page';
@@ -87,6 +88,7 @@ export interface HintResult {
     tool?: string;
     reason: string;
   };
+  recoveryCandidates?: RecoveryCandidate[];
   context?: {
     element?: string;
     coordinates?: string;
@@ -241,9 +243,11 @@ export class HintEngine {
       const key = escalationKey('progress-tracker-stuck');
       const fireCount = (this.hintEscalation.get(key) || 0) + 1;
       this.hintEscalation.set(key, fireCount);
+      const recoveryCandidates = rankRecoveryCandidates({ toolName, resultText, isError, recentCalls });
       const rawHintText = 'STOP — you are stuck. The last several tool calls made no meaningful progress ' +
         '(errors, stale refs, auth redirects, or timeouts). ' +
         'Step back and try a completely different approach, or ask the user for help.' +
+        formatRecoveryCandidates(recoveryCandidates) +
         (ledgerHint ? ` ${ledgerHint}` : '');
       const severity = fireCount >= 2 ? 'critical' as const : 'warning' as const;
       this.log({ timestamp: Date.now(), toolName, isError, matchedRule: 'progress-tracker-stuck', hint: rawHintText, severity, fireCount });
@@ -254,6 +258,7 @@ export class HintEngine {
         fireCount,
         hint: this.formatHintMessage(severity, rawHintText, fireCount),
         rawHint: rawHintText,
+        ...(recoveryCandidates.length > 0 && { recoveryCandidates }),
       };
     }
 
@@ -261,8 +266,10 @@ export class HintEngine {
       const key = escalationKey('progress-tracker-stalling');
       const fireCount = (this.hintEscalation.get(key) || 0) + 1;
       this.hintEscalation.set(key, fireCount);
+      const recoveryCandidates = rankRecoveryCandidates({ toolName, resultText, isError, recentCalls });
       const rawHintText = 'Warning: recent tool calls are not making progress. ' +
         'Consider trying a different approach before getting stuck.' +
+        formatRecoveryCandidates(recoveryCandidates) +
         (ledgerHint ? ` ${ledgerHint}` : '');
       const severity = this.getSeverity(fireCount);
       this.log({ timestamp: Date.now(), toolName, isError, matchedRule: 'progress-tracker-stalling', hint: rawHintText, severity, fireCount });
@@ -273,6 +280,7 @@ export class HintEngine {
         fireCount,
         hint: this.formatHintMessage(severity, rawHintText, fireCount),
         rawHint: rawHintText,
+        ...(recoveryCandidates.length > 0 && { recoveryCandidates }),
       };
     }
 

--- a/src/hints/recovery-candidates.ts
+++ b/src/hints/recovery-candidates.ts
@@ -1,0 +1,118 @@
+import type { ToolCallEvent } from '../dashboard/types';
+import { scoreRecoveryOutcome } from '../recovery';
+
+export type RecoveryCandidateRisk = 'read_only' | 'reversible' | 'side_effect_possible';
+
+export interface RecoveryCandidate {
+  tool: string;
+  description: string;
+  reason: string;
+  score: number;
+  risk: RecoveryCandidateRisk;
+  blockedReason?: string;
+}
+
+const RISK_ORDER: Record<RecoveryCandidateRisk, number> = {
+  read_only: 0,
+  reversible: 1,
+  side_effect_possible: 2,
+};
+
+const BLOCKING_TEXT = /captcha|access denied|forbidden|login page detected|blocking page detected|authredirect|bot-check/i;
+const STALE_TEXT = /stale[_ -]?ref|stale|element not found|no elements found|no longer available/i;
+const TIMEOUT_TEXT = /timeout|timed out|deadline|not ready|loading|detached/i;
+const SECRET_KEY = /password|passcode|token|secret|credential|api[_-]?key|authorization|cookie/i;
+
+export function rankRecoveryCandidates(args: {
+  toolName: string;
+  resultText: string;
+  isError: boolean;
+  recentCalls: ToolCallEvent[];
+  maxCandidates?: number;
+}): RecoveryCandidate[] {
+  const maxCandidates = Math.max(1, Math.min(args.maxCandidates ?? 3, 5));
+  const candidates: RecoveryCandidate[] = [];
+  const text = args.resultText || '';
+  const repeatedSameTool = countLeadingSameTool(args.recentCalls, args.toolName);
+
+  if (BLOCKING_TEXT.test(text)) {
+    candidates.push(candidate('read_page', 'Classify the current page state before retrying.', 'Blocking/auth/CAPTCHA signals detected; observe and classify instead of blind retries.', 'read_only', 0.82));
+    candidates.push(candidate('tabs_context', 'Confirm the live tab and URL.', 'Blocked flows often redirect or replace tabs; verify location before mutating.', 'read_only', 0.72));
+    return sortAndBound(candidates, maxCandidates);
+  }
+
+  if (STALE_TEXT.test(text)) {
+    candidates.push(candidate('read_page', 'Refresh page state and refs.', 'Stale/missing element evidence means old refs are unsafe; get fresh refs first.', 'read_only', 0.9));
+    candidates.push(candidate('find', 'Re-resolve the target by visible text or role.', 'A fresh query can locate the replacement element after DOM mutation.', 'read_only', 0.72));
+    candidates.push(candidate(args.toolName, 'Retry only after refreshing refs.', 'Repeating the same failed tool/ref is down-ranked until new state is observed.', 'reversible', 0.2, repeatedSameTool > 0 ? 'same tool recently failed' : undefined));
+    return sortAndBound(candidates, maxCandidates);
+  }
+
+  if (TIMEOUT_TEXT.test(text)) {
+    candidates.push(candidate('wait_for', 'Wait for page readiness with a bounded timeout.', 'Timeout/loading evidence suggests waiting once before retrying.', 'read_only', 0.78));
+    candidates.push(candidate('read_page', 'Observe current DOM after the wait.', 'Verify whether the page changed before another mutation.', 'read_only', 0.7));
+  } else {
+    candidates.push(candidate('tabs_context', 'Confirm the active tab and URL.', 'Stuck state may be caused by acting on the wrong tab.', 'read_only', 0.64));
+    candidates.push(candidate('read_page', 'Refresh observable page state.', 'Observation can reveal new refs or blocking state before changing strategy.', 'read_only', 0.62));
+  }
+
+  if (args.isError && repeatedSameTool > 0) {
+    candidates.push(candidate(args.toolName, 'Avoid immediate identical retry.', 'Same failed tool appears in recent calls; choose a different strategy first.', 'reversible', -0.2, 'repeated failed strategy'));
+  }
+
+  return sortAndBound(candidates, maxCandidates);
+}
+
+export function formatRecoveryCandidates(candidates: RecoveryCandidate[]): string {
+  if (candidates.length === 0) return '';
+  const rendered = candidates.map((c, index) => {
+    const blocked = c.blockedReason ? `; blocked: ${c.blockedReason}` : '';
+    return `${index + 1}. ${c.tool} (${c.risk}, score=${c.score.toFixed(2)}): ${sanitize(c.reason)}${blocked}`;
+  });
+  return ` Ranked recovery candidates: ${rendered.join(' | ')}`;
+}
+
+function candidate(
+  tool: string,
+  description: string,
+  reason: string,
+  risk: RecoveryCandidateRisk,
+  baseScore: number,
+  blockedReason?: string,
+): RecoveryCandidate {
+  const reward = scoreRecoveryOutcome({
+    toolName: tool,
+    observationOnly: risk === 'read_only',
+    freshRefsDiscovered: tool === 'read_page' && /ref|state/i.test(reason),
+    repeatedFailureCount: blockedReason ? 1 : 0,
+  });
+  return {
+    tool,
+    description: sanitize(description),
+    reason: sanitize(reason),
+    risk,
+    score: Math.max(-1, Math.min(1, Number(((baseScore + reward.score * 0.2) / (blockedReason ? 1.5 : 1)).toFixed(3)))),
+    ...(blockedReason ? { blockedReason: sanitize(blockedReason) } : {}),
+  };
+}
+
+function sortAndBound(candidates: RecoveryCandidate[], max: number): RecoveryCandidate[] {
+  return candidates
+    .sort((a, b) => RISK_ORDER[a.risk] - RISK_ORDER[b.risk] || b.score - a.score || a.tool.localeCompare(b.tool))
+    .slice(0, max);
+}
+
+function countLeadingSameTool(calls: ToolCallEvent[], toolName: string): number {
+  let count = 0;
+  for (const call of calls) {
+    if (call.toolName !== toolName) break;
+    count += 1;
+  }
+  return count;
+}
+
+function sanitize(value: string): string {
+  return value
+    .replace(new RegExp(`(${SECRET_KEY.source})\\s*[:=]\\s*[^\\s,;]+`, 'gi'), '$1=[REDACTED]')
+    .slice(0, 240);
+}

--- a/tests/hints/hint-engine.test.ts
+++ b/tests/hints/hint-engine.test.ts
@@ -780,6 +780,35 @@ describe('HintEngine', () => {
   });
 
   describe('Progress Tracking Integration', () => {
+
+
+    it('adds ranked recovery candidates to stuck stale-ref hints', () => {
+      const tracker = makeTracker([
+        { toolName: 'interact', result: 'error' },
+        { toolName: 'interact', result: 'error' },
+      ]);
+      const engine = new HintEngine(tracker as any);
+      const hint = engine.getHint('interact', makeResult('STALE_REF: element not found', true), true, undefined, { tabId: 'tab-1', ref: 'ref_1' });
+
+      expect(hint!.rule).toBe('progress-tracker-stuck');
+      expect(hint!.recoveryCandidates?.[0]).toMatchObject({ tool: 'read_page', risk: 'read_only' });
+      expect(hint!.hint).toContain('Ranked recovery candidates');
+      expect(hint!.hint).not.toContain('ref_1');
+    });
+
+    it('does not suggest blind interaction candidates for blocking pages', () => {
+      const tracker = makeTracker([
+        { toolName: 'click', result: 'error' },
+        { toolName: 'click', result: 'error' },
+      ]);
+      const engine = new HintEngine(tracker as any);
+      const hint = engine.getHint('click', makeResult('CAPTCHA Access Denied', true), true);
+
+      expect(hint!.rule).toBe('progress-tracker-stuck');
+      expect(hint!.recoveryCandidates?.map(c => c.tool)).toEqual(['read_page', 'tabs_context']);
+      expect(hint!.recoveryCandidates?.every(c => c.risk === 'read_only')).toBe(true);
+    });
+
     it('returns stuck hint when 3+ consecutive errors', () => {
       const tracker = makeTracker([
         { toolName: 'navigate', result: 'error', error: 'timed out' },

--- a/tests/hints/recovery-candidates.test.ts
+++ b/tests/hints/recovery-candidates.test.ts
@@ -1,0 +1,38 @@
+import { rankRecoveryCandidates } from '../../src/hints/recovery-candidates';
+
+describe('rankRecoveryCandidates', () => {
+  it('ranks fresh read_page first for stale refs and down-ranks the repeated tool', () => {
+    const candidates = rankRecoveryCandidates({
+      toolName: 'interact',
+      resultText: 'STALE_REF: element not found for ref_1',
+      isError: true,
+      recentCalls: [{ toolName: 'interact', args: { ref: 'ref_1' }, result: 'error' } as any],
+    });
+
+    expect(candidates[0]).toMatchObject({ tool: 'read_page', risk: 'read_only' });
+    expect(candidates.find(c => c.tool === 'interact')?.score).toBeLessThan(candidates[0].score);
+  });
+
+  it('filters blocking pages to read-only classification candidates', () => {
+    const candidates = rankRecoveryCandidates({
+      toolName: 'click',
+      resultText: 'CAPTCHA Access Denied',
+      isError: true,
+      recentCalls: [],
+    });
+
+    expect(candidates.map(c => c.tool)).toEqual(['read_page', 'tabs_context']);
+    expect(candidates.every(c => c.risk === 'read_only')).toBe(true);
+  });
+
+  it('orders read-only candidates before side-effect possible candidates', () => {
+    const candidates = rankRecoveryCandidates({
+      toolName: 'interact',
+      resultText: 'timeout waiting for page ready',
+      isError: true,
+      recentCalls: [{ toolName: 'interact', result: 'error' } as any],
+    });
+
+    expect(candidates[0].risk).toBe('read_only');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a deterministic advisory recovery-candidate ranker for stuck/stalling hints.
- Stale refs rank fresh `read_page` first and down-rank repeated same-tool retries; blocking/CAPTCHA/auth signals are limited to read-only classification candidates.
- Extends `HintResult` with compact `recoveryCandidates` while keeping existing readable hint text.

Fixes #1018.

## Verification
- `npm test -- tests/hints/recovery-candidates.test.ts tests/hints/hint-engine.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `git diff --check`

## Not tested
- Live stale-ref/browser fixture transcript.
