### PR TITLE
feat(task-run): wire auto session snapshots for #1013

### DIFF
--- a/docs/harness/task-run-auto-session-snapshots.md
+++ b/docs/harness/task-run-auto-session-snapshots.md
@@ -1,0 +1,47 @@
+# TaskRun automatic session snapshots
+
+Issue #1013 adds an opt-in continuity policy for long-running TaskRun workflows. The default remains unchanged: ordinary browser tools and TaskRun tools do not write session snapshots unless the caller explicitly enables the policy when starting a TaskRun.
+
+## Enable the policy
+
+Pass `auto_session_snapshot.enabled=true` to `oc_task_run_start`:
+
+```json
+{
+  "goal": "Verify checkout flow across three pages",
+  "success_criteria": ["Cart reviewed", "Order confirmation captured"],
+  "auto_session_snapshot": {
+    "enabled": true,
+    "mode": "best-effort",
+    "max_snapshots": 10
+  }
+}
+```
+
+Supported knobs:
+
+- `enabled`: must be `true` to activate lifecycle snapshots.
+- `mode`: `best-effort` by default. Snapshot failures are returned in metadata but do not fail the TaskRun tool call. `strict` rethrows snapshot failures after recording the error on the TaskRun.
+- `max_snapshots`: number of snapshot ids retained on TaskRun metadata, clamped to `1..100`.
+
+## Lifecycle triggers
+
+When enabled, TaskRun lifecycle tools create compact `oc_session_snapshot` artifacts at these boundaries:
+
+- `oc_task_run_start` → `auto-start`
+- `oc_task_run_checkpoint` → `auto-retry`
+- `oc_task_run_needs_help` → `auto-retry`
+- `oc_task_run_complete` → `auto-final`
+
+The snapshot memo is built from TaskRun metadata: goal, current progress/summary, completed items, success criteria or resume hint, and a compact TaskRun note. It does not include raw page content, screenshots, cookies, headers, or secrets.
+
+## Resume behavior
+
+`oc_session_resume` reads the latest snapshot or a specific snapshot id and reports objective, last step, completed steps, next actions, and live/remapped/closed tab status. TaskRun metadata also retains recent auto snapshot ids under `auto_session_snapshot_state.snapshot_ids` so hosts can choose a specific snapshot after compaction or reconnect.
+
+## Failure handling and bounds
+
+- Best-effort snapshot errors are recorded as `auto_session_snapshot_state.last_error` and an `auto_session_snapshot` event.
+- Successful snapshots append an `auto_session_snapshot` event with the snapshot id.
+- Retained ids are bounded by `max_snapshots`; the underlying `oc_session_snapshot` pruning still applies to snapshot files.
+- Snapshot writes are additive and do not grant planning, replay, or browser-action authority.

--- a/src/core/task-run/storage.ts
+++ b/src/core/task-run/storage.ts
@@ -8,6 +8,7 @@ import {
   EvidencePointer,
   FailedItem,
   NeedsHelpState,
+  TaskRunAutoSessionSnapshotPolicy,
   TaskRunCheckpoint,
   TaskRunEvent,
   TaskRunListFilter,
@@ -35,6 +36,11 @@ export interface StartTaskRunInput {
   session_id?: string;
   workflow_id?: string;
   ledger_task_ids?: string[];
+  auto_session_snapshot?: {
+    enabled?: boolean;
+    mode?: 'best-effort' | 'strict';
+    max_snapshots?: number;
+  };
 }
 
 export interface UpdateTaskRunInput {
@@ -92,6 +98,8 @@ export class TaskRunStore {
       session_id: optionalString(input.session_id),
       workflow_id: optionalString(input.workflow_id),
       ledger_task_ids: uniqueStrings(input.ledger_task_ids),
+      auto_session_snapshot_policy: sanitizeAutoSessionSnapshotPolicy(input.auto_session_snapshot),
+      auto_session_snapshot_state: sanitizeAutoSessionSnapshotPolicy(input.auto_session_snapshot) ? { snapshot_ids: [] } : undefined,
       created_at: ts,
       updated_at: ts,
     };
@@ -258,6 +266,45 @@ export class TaskRunStore {
     });
   }
 
+  async recordAutoSessionSnapshot(runId: string, snapshotId: string): Promise<TaskRunMeta> {
+    return this.withRunLock(runId, async () => {
+      const current = await this.get(runId);
+      const ts = this.now();
+      const maxSnapshots = current.auto_session_snapshot_policy?.max_snapshots || 10;
+      const ids = [...(current.auto_session_snapshot_state?.snapshot_ids || []), scrub(snapshotId)].slice(-maxSnapshots);
+      const meta: TaskRunMeta = pruneUndefined({
+        ...current,
+        auto_session_snapshot_state: {
+          snapshot_ids: ids,
+          last_snapshot_at: ts,
+        },
+        updated_at: ts,
+      });
+      await this.writeMeta(meta);
+      await this.appendEvent(runId, { ts, kind: 'auto_session_snapshot', data: { snapshot_id: snapshotId } });
+      return meta;
+    });
+  }
+
+  async recordAutoSessionSnapshotFailure(runId: string, error: unknown): Promise<TaskRunMeta> {
+    return this.withRunLock(runId, async () => {
+      const current = await this.get(runId);
+      const ts = this.now();
+      const meta: TaskRunMeta = pruneUndefined({
+        ...current,
+        auto_session_snapshot_state: {
+          snapshot_ids: current.auto_session_snapshot_state?.snapshot_ids || [],
+          last_snapshot_at: current.auto_session_snapshot_state?.last_snapshot_at,
+          last_error: limit(error instanceof Error ? error.message : String(error), 1024),
+        },
+        updated_at: ts,
+      });
+      await this.writeMeta(meta);
+      await this.appendEvent(runId, { ts, kind: 'auto_session_snapshot', data: { error: meta.auto_session_snapshot_state?.last_error } });
+      return meta;
+    });
+  }
+
   async readEvents(runId: string): Promise<TaskRunEvent[]> {
     const eventsPath = this.eventsPath(runId);
     if (!fs.existsSync(eventsPath)) return [];
@@ -370,6 +417,20 @@ function sanitizeStringArray(values: unknown, maxItems: number, maxChars: number
 function uniqueStrings(values: unknown): string[] {
   if (!Array.isArray(values)) return [];
   return Array.from(new Set(values.filter((v): v is string => typeof v === 'string' && v.trim().length > 0).map(v => scrub(v.trim()))));
+}
+
+function sanitizeAutoSessionSnapshotPolicy(value: unknown): TaskRunAutoSessionSnapshotPolicy | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const input = value as { enabled?: unknown; mode?: unknown; max_snapshots?: unknown };
+  if (input.enabled !== true) return undefined;
+  const max = typeof input.max_snapshots === 'number' && Number.isFinite(input.max_snapshots)
+    ? Math.max(1, Math.min(100, Math.floor(input.max_snapshots)))
+    : 10;
+  return {
+    enabled: true,
+    mode: input.mode === 'strict' ? 'strict' : 'best-effort',
+    max_snapshots: max,
+  };
 }
 
 function sanitizeEvidence(values: unknown): EvidencePointer[] | undefined {

--- a/src/core/task-run/types.ts
+++ b/src/core/task-run/types.ts
@@ -19,6 +19,18 @@ export interface NeedsHelpState {
   resume_hint?: string;
 }
 
+export interface TaskRunAutoSessionSnapshotPolicy {
+  enabled: boolean;
+  mode: 'best-effort' | 'strict';
+  max_snapshots: number;
+}
+
+export interface TaskRunAutoSessionSnapshotState {
+  snapshot_ids: string[];
+  last_snapshot_at?: number;
+  last_error?: string;
+}
+
 export interface TaskRunMeta {
   run_id: string;
   status: TaskRunStatus;
@@ -27,6 +39,8 @@ export interface TaskRunMeta {
   session_id?: string;
   workflow_id?: string;
   ledger_task_ids: string[];
+  auto_session_snapshot_policy?: TaskRunAutoSessionSnapshotPolicy;
+  auto_session_snapshot_state?: TaskRunAutoSessionSnapshotState;
   progress_summary?: string;
   completed_items?: string[];
   failed_items?: FailedItem[];
@@ -42,7 +56,7 @@ export interface TaskRunMeta {
 
 export interface TaskRunEvent {
   ts: number;
-  kind: 'started' | 'updated' | 'checkpointed' | 'needs_help' | 'completed' | 'failed' | 'cancelled';
+  kind: 'started' | 'updated' | 'checkpointed' | 'needs_help' | 'completed' | 'failed' | 'cancelled' | 'auto_session_snapshot';
   data?: Record<string, unknown>;
 }
 

--- a/src/tools/task-run.ts
+++ b/src/tools/task-run.ts
@@ -11,6 +11,8 @@ import {
   TaskRunTransitionError,
   UpdateTaskRunInput,
 } from '../core/task-run';
+import { buildAutoSnapshotArgs, SnapshotTrigger } from '../session-snapshot-policy';
+import { collectTabs, generateSnapshotId, saveSnapshot, SessionSnapshot } from './session-snapshot';
 
 const store = new TaskRunStore();
 
@@ -72,6 +74,15 @@ const startDefinition: MCPToolDefinition = {
       session_id: { type: 'string', description: 'Optional OpenChrome session id to associate.' },
       workflow_id: { type: 'string', description: 'Optional workflow id to associate.' },
       ledger_task_ids: { type: 'array', items: { type: 'string' }, description: 'Optional #855 async ledger task ids to link when available.' },
+      auto_session_snapshot: {
+        type: 'object',
+        description: 'Optional #1013 policy. When enabled, TaskRun lifecycle tools write compact oc_session_snapshot artifacts without changing ordinary browser tools.',
+        properties: {
+          enabled: { type: 'boolean' },
+          mode: { type: 'string', enum: ['best-effort', 'strict'] },
+          max_snapshots: { type: 'number', description: 'Maximum snapshot ids to retain on the TaskRun metadata; default 10, max 100.' },
+        },
+      },
     },
     required: ['goal'],
   },
@@ -182,7 +193,8 @@ const listDefinition: MCPToolDefinition = {
 const startHandler: ToolHandler = async (_sessionId, args) => {
   try {
     const meta = await store.start(args as unknown as StartTaskRunInput);
-    return jsonResult({ task_run: meta });
+    const snapshot = await takeTaskRunAutoSessionSnapshot(meta, 'start');
+    return jsonResult({ task_run: snapshot?.task_run || meta, ...(snapshot ? { auto_session_snapshot: snapshot.auto_session_snapshot } : {}) });
   } catch (error) {
     return errorResult(error);
   }
@@ -205,7 +217,9 @@ const checkpointHandler: ToolHandler = async (_sessionId, args) => {
       current_cursor: args.current_cursor as string | undefined,
       evidence: args.evidence as never,
     });
-    return jsonResult({ checkpoint });
+    const meta = await store.get(runId);
+    const snapshot = await takeTaskRunAutoSessionSnapshot(meta, 'retry', checkpoint.summary);
+    return jsonResult({ checkpoint, ...(snapshot ? { task_run: snapshot.task_run, auto_session_snapshot: snapshot.auto_session_snapshot } : {}) });
   } catch (error) {
     return errorResult(error);
   }
@@ -215,7 +229,8 @@ const needsHelpHandler: ToolHandler = async (_sessionId, args) => {
   try {
     const runId = String(args.run_id || '');
     const meta = await store.needsHelp(runId, args as unknown as NeedsHelpInput);
-    return jsonResult({ task_run: meta });
+    const snapshot = await takeTaskRunAutoSessionSnapshot(meta, 'retry', meta.needs_help?.reason);
+    return jsonResult({ task_run: snapshot?.task_run || meta, ...(snapshot ? { auto_session_snapshot: snapshot.auto_session_snapshot } : {}) });
   } catch (error) {
     return errorResult(error);
   }
@@ -225,7 +240,8 @@ const completeHandler: ToolHandler = async (_sessionId, args) => {
   try {
     const runId = String(args.run_id || '');
     const meta = await store.complete(runId, args as CompleteInput);
-    return jsonResult({ task_run: meta });
+    const snapshot = await takeTaskRunAutoSessionSnapshot(meta, 'final', meta.progress_summary);
+    return jsonResult({ task_run: snapshot?.task_run || meta, ...(snapshot ? { auto_session_snapshot: snapshot.auto_session_snapshot } : {}) });
   } catch (error) {
     return errorResult(error);
   }
@@ -253,6 +269,57 @@ const listHandler: ToolHandler = async (_sessionId, args) => {
     return errorResult(error);
   }
 };
+
+
+async function takeTaskRunAutoSessionSnapshot(
+  meta: Awaited<ReturnType<TaskRunStore['get']>>,
+  trigger: SnapshotTrigger,
+  currentStep?: string,
+): Promise<{ task_run: Awaited<ReturnType<TaskRunStore['get']>>; auto_session_snapshot: { snapshot_id?: string; trigger: SnapshotTrigger; error?: string } } | null> {
+  const policy = meta.auto_session_snapshot_policy;
+  if (!policy?.enabled) return null;
+
+  try {
+    const args = buildAutoSnapshotArgs({
+      objective: meta.goal,
+      currentStep: currentStep || meta.progress_summary || `TaskRun ${meta.status}`,
+      completedSteps: meta.completed_items,
+      nextActions: buildTaskRunNextActions(meta),
+      notes: `TaskRun ${meta.run_id} status=${meta.status}`,
+    }, trigger);
+    const snapshotId = generateSnapshotId();
+    const snapshot: SessionSnapshot = {
+      version: 1,
+      id: snapshotId,
+      timestamp: Date.now(),
+      tabs: await collectTabs(),
+      memo: {
+        objective: args.objective,
+        currentStep: args.currentStep,
+        nextActions: args.nextActions,
+        completedSteps: args.completedSteps,
+        notes: args.notes,
+      },
+      label: args.label,
+    };
+    await saveSnapshot(snapshot);
+    const updated = await store.recordAutoSessionSnapshot(meta.run_id, snapshotId);
+    return { task_run: updated, auto_session_snapshot: { snapshot_id: snapshotId, trigger } };
+  } catch (error) {
+    const updated = await store.recordAutoSessionSnapshotFailure(meta.run_id, error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (policy.mode === 'strict') throw error;
+    return { task_run: updated, auto_session_snapshot: { trigger, error: message } };
+  }
+}
+
+function buildTaskRunNextActions(meta: Awaited<ReturnType<TaskRunStore['get']>>): string[] {
+  if (meta.status === 'COMPLETED') return ['Review completion evidence or call oc_session_resume after compaction.'];
+  if (meta.status === 'FAILED' || meta.status === 'CANCELLED') return ['Review failure evidence before restarting or retrying the task.'];
+  if (meta.needs_help?.resume_hint) return [meta.needs_help.resume_hint];
+  if (meta.success_criteria && meta.success_criteria.length > 0) return meta.success_criteria.slice(0, 5);
+  return ['Continue the TaskRun and update progress with oc_task_run_update or oc_task_run_checkpoint.'];
+}
 
 export function registerTaskRunTools(server: MCPServer): void {
   server.registerTool('oc_task_run_start', startHandler, startDefinition);

--- a/tests/core/task-run/storage.test.ts
+++ b/tests/core/task-run/storage.test.ts
@@ -111,6 +111,43 @@ describe('TaskRunStore', () => {
     expect(meta.completed_items?.[0]).toBe('item-5');
   });
 
+
+  it('stores bounded opt-in auto session snapshot metadata and events', async () => {
+    const run = await store.start({
+      goal: 'Long task continuity',
+      auto_session_snapshot: { enabled: true, mode: 'strict', max_snapshots: 2 },
+    });
+
+    expect(run.auto_session_snapshot_policy).toEqual({
+      enabled: true,
+      mode: 'strict',
+      max_snapshots: 2,
+    });
+    expect(run.auto_session_snapshot_state).toEqual({ snapshot_ids: [] });
+
+    await store.recordAutoSessionSnapshot(run.run_id, 'snap-1');
+    await store.recordAutoSessionSnapshot(run.run_id, 'snap-2');
+    const recorded = await store.recordAutoSessionSnapshot(run.run_id, 'snap-3');
+
+    expect(recorded.auto_session_snapshot_state?.snapshot_ids).toEqual(['snap-2', 'snap-3']);
+    expect(recorded.auto_session_snapshot_state?.last_snapshot_at).toBeDefined();
+
+    const events = await store.readEvents(run.run_id);
+    expect(events.filter(e => e.kind === 'auto_session_snapshot')).toHaveLength(3);
+  });
+
+  it('records best-effort auto session snapshot failures without clearing previous ids', async () => {
+    const run = await store.start({
+      goal: 'Failure-tolerant continuity',
+      auto_session_snapshot: { enabled: true },
+    });
+    await store.recordAutoSessionSnapshot(run.run_id, 'snap-ok');
+    const failed = await store.recordAutoSessionSnapshotFailure(run.run_id, new Error('disk full'));
+
+    expect(failed.auto_session_snapshot_state?.snapshot_ids).toEqual(['snap-ok']);
+    expect(failed.auto_session_snapshot_state?.last_error).toBe('disk full');
+  });
+
   it('persists records across store instances', async () => {
     const run = await store.start({ goal: 'Restart-safe run' });
     await store.update(run.run_id, { completed_items: ['one'] });


### PR DESCRIPTION
## Summary
- Adds opt-in `auto_session_snapshot` policy metadata to TaskRun start records.
- Writes compact `oc_session_snapshot` artifacts at TaskRun lifecycle boundaries: start, checkpoint/needs-help retry, and final completion.
- Records bounded snapshot ids or best-effort errors on TaskRun metadata/events and documents the policy.

Fixes #1013.

## Verification
- `npm test -- tests/core/task-run/storage.test.ts tests/tools/task-run-tools.test.ts tests/tools/session-snapshot-policy.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `git diff --check`

## Not tested
- Live OpenChrome multi-step page with forced retry and closed-tab remap.