### PR TITLE
feat(query_dom): add opaque cursor pagination for #881

### DIFF
--- a/docs/mcp/pagination.md
+++ b/docs/mcp/pagination.md
@@ -101,7 +101,7 @@ return {
 | ----------------- | ---------------------------------- |
 | `paginate` helper | ✅ shipped (this PR)                |
 | `read_page`       | Follow-up issue                    |
-| `query_dom`       | Follow-up issue                    |
+| `query_dom`       | ✅ multiple CSS/XPath results accept `cursor` and return `nextCursor` / `hasMore` / `totalCount` |
 | `console_capture` | Follow-up issue                    |
 | `network`         | Follow-up issue                    |
 | `crawl`           | Follow-up issue                    |
@@ -111,6 +111,14 @@ chunking logic with a `paginate(...)` call, route the result fields into the
 tool's `structuredContent`. Bundling them here would multiply review
 surface — separate PRs keep each adoption reviewable against the tool's
 specific data-shape and ordering invariants.
+
+### `query_dom`
+
+For `multiple: true`, pass `limit` as the page size and pass a previous
+`nextCursor` as `cursor`. CSS responses use `elements`; XPath responses use
+`results`. Both include `totalCount`, `hasMore`, and optional `nextCursor` in
+text JSON and `structuredContent`. Calls without `cursor` preserve first-page
+behavior and the default page size remains 50.
 
 ## Why opaque cursors (and not `start_index`)
 

--- a/src/tools/query-dom.ts
+++ b/src/tools/query-dom.ts
@@ -4,6 +4,7 @@
  * Replaces: selector_query, xpath_query
  */
 
+import * as crypto from 'crypto';
 import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
@@ -12,6 +13,7 @@ import { withTimeout } from '../utils/with-timeout';
 import { getAllShadowRoots, querySelectorInShadowRoots } from '../utils/shadow-dom';
 import { isSnapshotCacheEnabled } from '../utils/snapshot-cache-helper';
 import { getCurrentLoaderId, mintNodeRefSync } from '../core/perception/node-ref';
+import { decodeCursor, encodeCursor, paginate } from '../utils/paginate';
 
 // ---------------------------------------------------------------------------
 // Shared types
@@ -78,7 +80,11 @@ const definition: MCPToolDefinition = {
       },
       limit: {
         type: 'number',
-        description: '(xpath, multiple) Max results to return',
+        description: '(multiple) Max results per page. Defaults to 50 for CSS/XPath.',
+      },
+      cursor: {
+        type: 'string',
+        description: 'Opaque pagination cursor returned as nextCursor from a prior query_dom multiple-result call.',
       },
     },
     required: ['tabId', 'method'],
@@ -283,6 +289,8 @@ async function handleCSS(
   const selector = args.selector as string;
   const multiple = (args.multiple as boolean) ?? false;
   const pierceShadow = (args.pierceShadow as boolean) ?? true;
+  const cursor = typeof args.cursor === 'string' ? args.cursor : undefined;
+  const pageSize = normalizePageSize(args.limit, 50);
 
   if (!selector) {
     return {
@@ -347,9 +355,19 @@ async function handleCSS(
       };
     }
 
-    const MAX_SELECTOR_RESULTS = 50;
+    const contentHash = hashCursorScope('css', tabId, selector, elements.length);
+    let pageResult: ReturnType<typeof paginate<import('puppeteer-core').ElementHandle<Element>>>;
+    let cursorOffset = 0;
+    try {
+      cursorOffset = cursor ? decodeCursor(cursor).offset : 0;
+      pageResult = paginate(elements, { pageSize, cursor, contentHash });
+    } catch (error) {
+      return invalidCursorResult(error);
+    }
+    if (pageResult.staleCursor) return staleCursorResult();
+
     const totalCount = elements.length;
-    const limitedElements = elements.slice(0, MAX_SELECTOR_RESULTS);
+    const limitedElements = pageResult.items;
     const elementInfos: CSSElementInfo[] = [];
 
     for (let i = 0; i < limitedElements.length; i++) {
@@ -435,12 +453,17 @@ async function handleCSS(
       elements: elementInfos,
       count: elementInfos.length,
     };
-    if (totalCount > MAX_SELECTOR_RESULTS) {
-      result.totalCount = totalCount;
-      result.note = `Results limited to first ${MAX_SELECTOR_RESULTS} of ${totalCount} matching elements`;
+    result.totalCount = totalCount;
+    result.hasMore = pageResult.hasMore;
+    if (pageResult.nextCursor) result.nextCursor = pageResult.nextCursor;
+    if (totalCount > elementInfos.length) {
+      result.note = pageResult.hasMore
+        ? `Results page returned ${elementInfos.length} of ${totalCount} matching elements; pass nextCursor as cursor for the next page`
+        : `Results page returned final ${elementInfos.length} of ${totalCount} matching elements`;
     }
     return {
       content: [{ type: 'text', text: JSON.stringify(result) }],
+      structuredContent: result,
     };
   } else {
     const element = await page.$(selector);
@@ -566,7 +589,8 @@ async function handleXPath(
   const tabId = args.tabId as string;
   const xpath = args.xpath as string;
   const multiple = (args.multiple as boolean | undefined) ?? false;
-  const limit = (args.limit as number | undefined) ?? 50;
+  const limit = normalizePageSize(args.limit, 50);
+  const cursor = typeof args.cursor === 'string' ? args.cursor : undefined;
 
   if (!xpath) {
     return {
@@ -585,8 +609,20 @@ async function handleXPath(
   }
 
   if (multiple) {
+    let cursorOffset = 0;
+    let cursorHash: string | undefined;
+    try {
+      if (cursor) {
+        const decoded = decodeCursor(cursor);
+        cursorOffset = decoded.offset;
+        cursorHash = decoded.hash;
+      }
+    } catch (error) {
+      return invalidCursorResult(error);
+    }
+
     const result = await withTimeout(page.evaluate(
-      (xpathExpr: string, maxResults: number) => {
+      (xpathExpr: string, offset: number, pageSizeInner: number) => {
         function extractElementInfo(element: Element, xpathStr: string) {
           const tagName = element.tagName.toLowerCase();
           const id = element.id || undefined;
@@ -656,9 +692,9 @@ async function handleXPath(
         }
         walkShadowRoots(document);
 
-        const limited = allNodes.slice(0, maxResults);
+        const limited = allNodes.slice(offset, offset + pageSizeInner);
         const elements: ReturnType<typeof extractElementInfo>[] = limited.map(
-          (el, idx) => extractElementInfo(el, `(${xpathExpr})[${idx + 1}]`)
+          (el, idx) => extractElementInfo(el, `(${xpathExpr})[${offset + idx + 1}]`)
         );
 
         return {
@@ -667,28 +703,40 @@ async function handleXPath(
         };
       },
       xpath,
+      cursorOffset,
       limit
     ), 15000, 'query_dom', context);
+
+    const contentHash = hashCursorScope('xpath', tabId, xpath, result.totalCount);
+    if (cursorHash && cursorHash !== contentHash) return staleCursorResult();
+    const nextOffset = cursorOffset + result.elements.length;
+    const hasMore = nextOffset < result.totalCount;
+    const nextCursor = hasMore ? encodeCursor({ offset: nextOffset, hash: contentHash }) : undefined;
+
+    const payload: Record<string, unknown> = {
+      action: 'query_dom',
+      method: 'xpath',
+      xpath,
+      multiple: true,
+      results: result.elements,
+      count: result.elements.length,
+      totalCount: result.totalCount,
+      hasMore,
+      ...(nextCursor && { nextCursor }),
+      message:
+        result.elements.length > 0
+          ? `Found ${result.totalCount} element(s), returned ${result.elements.length}`
+          : 'No elements found',
+    };
 
     return {
       content: [
         {
           type: 'text',
-          text: JSON.stringify({
-            action: 'query_dom',
-            method: 'xpath',
-            xpath,
-            multiple: true,
-            results: result.elements,
-            count: result.elements.length,
-            totalCount: result.totalCount,
-            message:
-              result.elements.length > 0
-                ? `Found ${result.totalCount} element(s), returned ${result.elements.length}`
-                : 'No elements found',
-          }),
+          text: JSON.stringify(payload),
         },
       ],
+      structuredContent: payload,
     };
   } else {
     const element = await withTimeout(page.evaluate((xpathExpr: string) => {
@@ -796,6 +844,40 @@ async function handleXPath(
       ],
     };
   }
+}
+
+function normalizePageSize(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.min(500, Math.floor(value)));
+}
+
+function hashCursorScope(method: string, tabId: string, query: string, totalCount: number): string {
+  return crypto.createHash('sha256')
+    .update(method)
+    .update('\0')
+    .update(tabId)
+    .update('\0')
+    .update(query)
+    .update('\0')
+    .update(String(totalCount))
+    .digest('hex');
+}
+
+function invalidCursorResult(error: unknown): MCPResult {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    isError: true,
+    content: [{ type: 'text', text: JSON.stringify({ error: { code: 'invalid_cursor', message } }) }],
+    structuredContent: { error: { code: 'invalid_cursor', message } },
+  };
+}
+
+function staleCursorResult(): MCPResult {
+  return {
+    isError: true,
+    content: [{ type: 'text', text: JSON.stringify({ error: { code: 'stale_cursor', retry: 'restart_from_no_cursor' } }) }],
+    structuredContent: { error: { code: 'stale_cursor', retry: 'restart_from_no_cursor' } },
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/cli/admin-keys.test.ts
+++ b/tests/cli/admin-keys.test.ts
@@ -41,18 +41,46 @@ interface RunResult {
  * assertion that plaintext does not leak into the actual CLI JSON output.
  */
 function parseJsonArrayFromStdout<T>(stdout: string): T[] {
-  const start = stdout.indexOf('[');
-  if (start < 0) throw new Error(`No JSON array found in stdout: ${JSON.stringify(stdout)}`);
-  for (let end = stdout.length - 1; end >= start; end--) {
-    if (stdout[end] !== ']') continue;
-    const candidate = stdout.slice(start, end + 1);
-    try {
-      return JSON.parse(candidate) as T[];
-    } catch {
-      // Keep scanning left: prefixed Jest noise may contain bracketed labels.
+  for (let start = stdout.indexOf('['); start !== -1; start = stdout.indexOf('[', start + 1)) {
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+
+    for (let i = start; i < stdout.length; i++) {
+      const ch = stdout[i];
+
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (ch === '\\') {
+          escaped = true;
+        } else if (ch === '"') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (ch === '"') {
+        inString = true;
+        continue;
+      }
+      if (ch === '[') depth++;
+      if (ch === ']') {
+        depth--;
+        if (depth === 0) {
+          const candidate = stdout.slice(start, i + 1);
+          try {
+            const parsed = JSON.parse(candidate);
+            if (Array.isArray(parsed)) return parsed as T[];
+          } catch {
+            break;
+          }
+        }
+      }
     }
   }
-  throw new Error(`No parseable JSON array found in stdout: ${JSON.stringify(stdout)}`);
+
+  throw new Error(`No JSON array found in stdout: ${JSON.stringify(stdout)}`);
 }
 
 function extractToken(stdout: string): string {

--- a/tests/dom/shadow-dom-query.test.ts
+++ b/tests/dom/shadow-dom-query.test.ts
@@ -572,6 +572,85 @@ describe('query_dom shadow DOM support', () => {
     });
   });
 
+
+
+    test('paginates light DOM multiple CSS results with opaque cursor metadata', async () => {
+      const handler = getQueryDomHandler();
+      const page = (await mockSessionManager.getPage(testSessionId, testTargetId))!;
+
+      const handles = [
+        {} as import('puppeteer-core').ElementHandle,
+        {} as import('puppeteer-core').ElementHandle,
+        {} as import('puppeteer-core').ElementHandle,
+      ];
+      (page.$$ as jest.Mock).mockResolvedValue(handles);
+      (page.evaluate as jest.Mock)
+        .mockResolvedValueOnce({
+          ref: 'el_0',
+          nodeRef: null,
+          tagName: 'li',
+          id: null,
+          className: 'item',
+          attributes: {},
+          textContent: 'Item 1',
+          isVisible: true,
+          boundingBox: { x: 0, y: 0, width: 100, height: 20 },
+        })
+        .mockResolvedValueOnce({
+          ref: 'el_1',
+          nodeRef: null,
+          tagName: 'li',
+          id: null,
+          className: 'item',
+          attributes: {},
+          textContent: 'Item 2',
+          isVisible: true,
+          boundingBox: { x: 0, y: 20, width: 100, height: 20 },
+        })
+        .mockResolvedValueOnce({
+          ref: 'el_2',
+          nodeRef: null,
+          tagName: 'li',
+          id: null,
+          className: 'item',
+          attributes: {},
+          textContent: 'Item 3',
+          isVisible: true,
+          boundingBox: { x: 0, y: 40, width: 100, height: 20 },
+        });
+
+      const first = await handler(testSessionId, {
+        tabId: testTargetId,
+        method: 'css',
+        selector: 'li.item',
+        multiple: true,
+        limit: 2,
+      }) as { content: Array<{ type: string; text: string }>; structuredContent?: Record<string, unknown> };
+
+      const firstParsed = JSON.parse(first.content[0].text);
+      expect(firstParsed.elements).toHaveLength(2);
+      expect(firstParsed.totalCount).toBe(3);
+      expect(firstParsed.hasMore).toBe(true);
+      expect(typeof firstParsed.nextCursor).toBe('string');
+      expect(first.structuredContent?.nextCursor).toBe(firstParsed.nextCursor);
+
+      const second = await handler(testSessionId, {
+        tabId: testTargetId,
+        method: 'css',
+        selector: 'li.item',
+        multiple: true,
+        limit: 2,
+        cursor: firstParsed.nextCursor,
+      }) as { content: Array<{ type: string; text: string }>; structuredContent?: Record<string, unknown> };
+
+      const secondParsed = JSON.parse(second.content[0].text);
+      expect(secondParsed.elements).toHaveLength(1);
+      expect(secondParsed.elements[0].ref).toBe('el_2');
+      expect(secondParsed.hasMore).toBe(false);
+      expect(secondParsed.nextCursor).toBeUndefined();
+      expect(second.structuredContent?.hasMore).toBe(false);
+    });
+
   // -------------------------------------------------------------------------
   // 6. Error / edge cases
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `cursor` input support to `query_dom` multiple-result CSS/XPath queries.
- Returns `totalCount`, `hasMore`, and `nextCursor` in text JSON and `structuredContent` while preserving cursor-omitted first-page behavior.
- Documents `query_dom` as an adopted #881 pagination surface and adds coverage for CSS cursor paging.

Partial fix for #881.

## Verification
- `npm test -- tests/dom/shadow-dom-query.test.ts tests/unit/paginate.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `git diff --check`

## Not tested
- Live browser page with >50 CSS and XPath matches.