### PR TITLE
feat(run-harness): persist wandering budgets for #1026

### DIFF
--- a/docs/harness/run-budgets.md
+++ b/docs/harness/run-budgets.md
@@ -1,6 +1,6 @@
 # Run harness wandering budgets
 
-`oc_run_status` accepts an optional `budget` object for opt-in run-level wandering guards. When omitted, run status remains the existing hint-only ledger behavior.
+`oc_run_start` and `oc_run_status` accept an optional `budget` object for opt-in run-level wandering guards. A budget supplied at start is persisted on the run and reused by later `oc_run_status` calls; a status-call budget can still override it for one check. When omitted everywhere, run status remains the existing hint-only ledger behavior.
 
 Supported budget keys:
 
@@ -11,3 +11,19 @@ Supported budget keys:
 - `max_wall_ms`
 
 When a budget is exceeded, OpenChrome records a `run_finished` event, marks the run `needs_strategy_change`, attaches a deterministic failure category (`MAX_STEPS_EXCEEDED`, `NO_PROGRESS`, or `LLM_WANDERING`), and returns a suggested next step. Batch tools such as `batch_execute`, `batch_paginate`, and crawl/task polling tools are exempt from same-tool retry counting to avoid blocking intentional batch workflows.
+
+
+Example:
+
+```json
+{
+  "run_id": "checkout-smoke",
+  "budget": {
+    "max_same_tool_retries": 2,
+    "max_no_progress_streak": 3,
+    "max_wall_ms": 60000
+  }
+}
+```
+
+After starting with this payload, callers can pass only `{ "run_id": "checkout-smoke" }` to `oc_run_status`; the stored budget is evaluated automatically.

--- a/src/run-harness/store.ts
+++ b/src/run-harness/store.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 
 import { redactValue } from '../core/trace/redactor.js';
 import { evidenceTriggerForEvent, RunEvidenceCapture, shouldAutoCaptureRunEvidence } from './evidence.js';
-import { TERMINAL_RUN_STATUSES, type RunEvent, type RunRecord, type RunStatus } from './types.js';
+import { TERMINAL_RUN_STATUSES, type RunBudgets, type RunEvent, type RunRecord, type RunStatus } from './types.js';
 
 export interface RunStoreOptions {
   rootDir?: string;
@@ -20,6 +20,7 @@ export interface StartRunInput {
   session_id?: string;
   tab_id?: string;
   metadata?: Record<string, unknown>;
+  budget?: RunBudgets;
 }
 
 export interface FinishRunInput {
@@ -91,6 +92,7 @@ export class RunStore {
       session_id: input.session_id,
       tab_id: input.tab_id,
       metadata: sanitizeMetadata(input.metadata),
+      budget: sanitizeBudgets(input.budget),
       events: [],
     };
     record.events.push(this.event(run_id, 'run_started', {
@@ -194,6 +196,7 @@ export class RunStore {
     return event;
   }
 
+
   private event(run_id: string, kind: RunEvent['kind'], partial: Partial<RunEvent>): RunEvent {
     return {
       id: `evt-${this.idFactory()}`,
@@ -276,6 +279,23 @@ const RUN_LEDGER_REDACTED = '[REDACTED]';
 const RUN_LEDGER_SENSITIVE_KEY = /password|token|secret|credential|api[_-]?key/i;
 const RUN_LEDGER_SENSITIVE_TEXT = /(password|token|secret|credential|api[_-]?key)\s*[:=]\s*[^\s,;]+/gi;
 const RUN_LEDGER_BEARER_TEXT = /Bearer\s+[^\s,;]+/gi;
+
+function sanitizeBudgets(value: RunBudgets | undefined): RunBudgets | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const budgets: RunBudgets = {};
+  setPositiveIntBudget(budgets, 'max_tool_calls', value.max_tool_calls);
+  setPositiveIntBudget(budgets, 'max_same_tool_retries', value.max_same_tool_retries);
+  setPositiveIntBudget(budgets, 'max_observation_only_calls', value.max_observation_only_calls);
+  setPositiveIntBudget(budgets, 'max_no_progress_streak', value.max_no_progress_streak);
+  setPositiveIntBudget(budgets, 'max_wall_ms', value.max_wall_ms);
+  return Object.keys(budgets).length > 0 ? budgets : undefined;
+}
+
+function setPositiveIntBudget(target: RunBudgets, key: keyof RunBudgets, value: unknown): void {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return;
+  const n = Math.floor(value);
+  if (n > 0) target[key] = n;
+}
 
 function sanitizeMetadata(value: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
   if (!value) return undefined;

--- a/src/run-harness/tools.ts
+++ b/src/run-harness/tools.ts
@@ -3,11 +3,23 @@ import type { MCPResult, MCPToolDefinition, ToolHandler } from '../types/mcp.js'
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations.js';
 import { evaluateRunBudget, normalizeRunBudget } from './budget.js';
 import { getRunStore } from './store.js';
-import { RUN_STATUSES, TERMINAL_RUN_STATUSES, type RunRecord, type RunStatus } from './types.js';
+import { RUN_STATUSES, TERMINAL_RUN_STATUSES, type RunBudgets, type RunRecord, type RunStatus } from './types.js';
 
 const runIdProperty = {
   type: 'string',
   description: 'REQUIRED Run identifier returned by oc_run_start.',
+};
+
+const budgetSchema = {
+  type: 'object',
+  description: 'Optional run-level wandering budget. When exceeded, oc_run_status records a needs_strategy_change finish event.',
+  properties: {
+    max_tool_calls: { type: 'number', description: 'Maximum finished tool calls before stopping.' },
+    max_same_tool_retries: { type: 'number', description: 'Maximum consecutive same-tool finished calls, excluding batch tools.' },
+    max_observation_only_calls: { type: 'number', description: 'Maximum trailing read-only observation calls.' },
+    max_no_progress_streak: { type: 'number', description: 'Maximum trailing no-progress/error calls.' },
+    max_wall_ms: { type: 'number', description: 'Maximum run age in milliseconds.' },
+  },
 };
 
 const startDefinition: MCPToolDefinition = {
@@ -21,20 +33,9 @@ const startDefinition: MCPToolDefinition = {
       session_id: { type: 'string', description: 'Optional session id to associate with the run.' },
       tab_id: { type: 'string', description: 'Optional tab id to associate with the run.' },
       metadata: { type: 'object', description: 'Optional JSON metadata.' },
+      budget: budgetSchema,
     },
     required: [],
-  },
-};
-
-const budgetSchema = {
-  type: 'object',
-  description: 'Optional run-level wandering budget. When exceeded, oc_run_status records a needs_strategy_change finish event.',
-  properties: {
-    max_tool_calls: { type: 'number', description: 'Maximum finished tool calls before stopping.' },
-    max_same_tool_retries: { type: 'number', description: 'Maximum consecutive same-tool finished calls, excluding batch tools.' },
-    max_observation_only_calls: { type: 'number', description: 'Maximum trailing read-only observation calls.' },
-    max_no_progress_streak: { type: 'number', description: 'Maximum trailing no-progress/error calls.' },
-    max_wall_ms: { type: 'number', description: 'Maximum run age in milliseconds.' },
   },
 };
 
@@ -81,6 +82,7 @@ const startHandler: ToolHandler = async (_sessionId, args): Promise<MCPResult> =
     session_id: stringArg(args.session_id),
     tab_id: stringArg(args.tab_id),
     metadata: objectArg(args.metadata),
+    budget: normalizeRunBudget(args.budget) as RunBudgets | undefined,
   });
   return json(recordSummary(record));
 };
@@ -90,7 +92,7 @@ const statusHandler: ToolHandler = async (_sessionId, args): Promise<MCPResult> 
   const store = getRunStore();
   let record = store.getRun(run_id);
   if (!record) return json({ run_id, found: false }, true);
-  const budget = normalizeRunBudget(args.budget);
+  const budget = normalizeRunBudget(args.budget) ?? record.budget;
   const budgetVerdict = budget ? evaluateRunBudget(record, budget) : undefined;
   if (budgetVerdict?.exceeded && !TERMINAL_RUN_STATUSES.has(record.status)) {
     record = store.finishRun(run_id, {
@@ -143,6 +145,7 @@ function recordSummary(record: RunRecord): Record<string, unknown> {
     session_id: record.session_id,
     tab_id: record.tab_id,
     event_count: record.events.length,
+    budget: record.budget,
     retention: { max_records_env: 'OPENCHROME_RUN_MAX_RECORDS', default_max_records: 500 },
     terminal: TERMINAL_RUN_STATUSES.has(record.status),
   };

--- a/src/run-harness/types.ts
+++ b/src/run-harness/types.ts
@@ -48,6 +48,14 @@ export interface RunEvent {
   metadata?: Record<string, unknown>;
 }
 
+export interface RunBudgets {
+  max_tool_calls?: number;
+  max_same_tool_retries?: number;
+  max_observation_only_calls?: number;
+  max_no_progress_streak?: number;
+  max_wall_ms?: number;
+}
+
 export interface RunRecord {
   run_id: string;
   status: RunStatus;
@@ -56,5 +64,6 @@ export interface RunRecord {
   session_id?: string;
   tab_id?: string;
   metadata?: Record<string, unknown>;
+  budget?: RunBudgets;
   events: RunEvent[];
 }

--- a/tests/run-harness/tools-budget.test.ts
+++ b/tests/run-harness/tools-budget.test.ts
@@ -18,9 +18,13 @@ describe('oc_run_status budget guard', () => {
   it('finishes the run as needs_strategy_change and records evidence metadata', async () => {
     const handlers = new Map<string, any>();
     registerRunHarnessTools({ registerTool: (name: string, handler: any) => handlers.set(name, handler) } as any);
-    const start = JSON.parse((await handlers.get('oc_run_start')('s1', { run_id: 'budget-tool' })).content[0].text);
+    const start = JSON.parse((await handlers.get('oc_run_start')('s1', {
+      run_id: 'budget-tool',
+      budget: { max_same_tool_retries: 1 },
+    })).content[0].text);
     expect(start.status).toBe('running');
     expect(start.resource_uri).toBeUndefined();
+    expect(start.budget).toEqual({ max_same_tool_retries: 1 });
 
     const store = (jest.requireMock('../../src/run-harness/store').getRunStore() as RunStore);
     store.appendToolFinished({ run_id: 'budget-tool', tool: 'interact', ok: false, message: 'element not found' });
@@ -28,7 +32,6 @@ describe('oc_run_status budget guard', () => {
 
     const statusResult = await handlers.get('oc_run_status')('s1', {
       run_id: 'budget-tool',
-      budget: { max_same_tool_retries: 1 },
     });
     const status = JSON.parse(statusResult.content[0].text);
     expect(statusResult.isError).toBe(true);


### PR DESCRIPTION
## Summary
- Lets `oc_run_start` accept and persist a normalized run-level `budget`.
- Makes `oc_run_status` evaluate the stored budget when callers do not re-send one.
- Returns the stored budget in run summaries and documents start-time budget usage.

Partial fix for #1026.

## Verification
- `npm test -- tests/run-harness/store.test.ts tests/run-harness/tools-budget.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `git diff --check`

## Not tested
- Live OpenChrome run with repeated failed interaction through HTTP MCP.