### PR TITLE
feat(tools): add request_intercept dry-run for #878

### DIFF
--- a/src/tools/request-intercept.ts
+++ b/src/tools/request-intercept.ts
@@ -219,6 +219,59 @@ function estimatedStaticAssetResponseBytes(resourceType: string): number {
   return STATIC_ASSET_RESPONSE_BYTE_ESTIMATES[resourceType.toLowerCase()] ?? 0;
 }
 
+function ruleMatchesLog(rule: InterceptRule, log: RequestLogEntry): boolean {
+  if (!matchesPattern(log.url, rule.pattern)) return false;
+  if (rule.resourceTypes && rule.resourceTypes.length > 0) {
+    return rule.resourceTypes.includes(log.resourceType.toLowerCase()) ||
+      rule.resourceTypes.includes(log.resourceType);
+  }
+  return true;
+}
+
+function dryRunPreviewResult(args: {
+  action: 'enable' | 'addRule';
+  rules: InterceptRule[];
+  existingRulesCount: number;
+  loggedRequests: RequestLogEntry[];
+  preset?: BandwidthPreset | null;
+}): MCPResult {
+  const matchedLogs = args.loggedRequests.filter((log) => args.rules.some((rule) => ruleMatchesLog(rule, log)));
+  const samples = matchedLogs.slice(0, 10).map((log) => ({
+    url: log.url,
+    resourceType: log.resourceType,
+    method: log.method,
+  }));
+  const wouldAffect = {
+    count: matchedLogs.length,
+    samples,
+    details: {
+      action: args.action,
+      parsedRules: args.rules,
+      parsedRuleCount: args.rules.length,
+      existingRulesCount: args.existingRulesCount,
+      observedRequestCount: args.loggedRequests.length,
+      preset: args.preset ?? null,
+    },
+  };
+  return {
+    content: [{
+      type: 'text',
+      text: JSON.stringify({
+        action: 'request_intercept',
+        dryRun: true,
+        wouldAffect,
+        message: `Dry-run preview: ${args.rules.length} rule(s) would be installed; ${matchedLogs.length} observed request(s) would match.`,
+      }),
+    }],
+    structuredContent: {
+      dryRun: true,
+      wouldAffect,
+      guidance: 'Pass dryRun:false (or omit) to execute.',
+    },
+    isError: false,
+  };
+}
+
 const definition: MCPToolDefinition = {
   name: 'request_intercept',
   annotations: TOOL_ANNOTATIONS.request_intercept,
@@ -284,6 +337,11 @@ const definition: MCPToolDefinition = {
         type: 'number',
         description: 'Max logs to return (getLogs)',
       },
+      dryRun: {
+        type: 'boolean',
+        default: false,
+        description: 'Preview enable/addRule rule installation without enabling interception, installing listeners, or mutating rules.',
+      },
     },
     required: ['tabId', 'action'],
   },
@@ -327,6 +385,7 @@ const handler: ToolHandler = async (
   const ruleId = args.ruleId as string | undefined;
   const limit = args.limit as number | undefined;
   const presetArg = args.preset as string | undefined;
+  const dryRun = args.dryRun === true;
 
   // Validate preset before any other work
   if (presetArg !== undefined) {
@@ -371,7 +430,7 @@ const handler: ToolHandler = async (
       };
     }
 
-    // Get or create state
+    // Get or create state. dryRun must not create per-tab state by itself.
     let state = interceptStates.get(tabId);
     if (!state) {
       state = {
@@ -381,7 +440,9 @@ const handler: ToolHandler = async (
         loggedRequests: [],
         maxLogs: 500,
       };
-      interceptStates.set(tabId, state);
+      if (!dryRun) {
+        interceptStates.set(tabId, state);
+      }
     }
 
     switch (action) {
@@ -391,6 +452,21 @@ const handler: ToolHandler = async (
           (ENV_PRESET && SUPPORTED_PRESETS.includes(ENV_PRESET as BandwidthPreset)
             ? (ENV_PRESET as BandwidthPreset)
             : undefined);
+
+        if (dryRun) {
+          const nextRules = state.rules.filter((r) => !r.id.startsWith('preset-'));
+          if (activePreset) {
+            nextRules.unshift(...presetToRules(activePreset));
+          }
+          const installedRules = nextRules.filter((rule) => !state.rules.includes(rule));
+          return dryRunPreviewResult({
+            action: 'enable',
+            rules: installedRules.length > 0 ? installedRules : nextRules,
+            existingRulesCount: state.rules.length,
+            loggedRequests: state.loggedRequests,
+            preset: activePreset ?? null,
+          });
+        }
 
         if (state.enabled) {
           // Re-enable with an explicit `preset` arg replaces the previously
@@ -630,12 +706,21 @@ const handler: ToolHandler = async (
         }
 
         const newRule: InterceptRule = {
-          id: `rule-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          id: dryRun ? 'dry-run-rule' : `rule-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
           pattern: ruleArg.pattern,
           resourceTypes: ruleArg.resourceTypes,
           action: ruleArg.action,
           modifyOptions: ruleArg.modifyOptions,
         };
+
+        if (dryRun) {
+          return dryRunPreviewResult({
+            action: 'addRule',
+            rules: [newRule],
+            existingRulesCount: state.rules.length,
+            loggedRequests: state.loggedRequests,
+          });
+        }
 
         state.rules.push(newRule);
 

--- a/tests/cli/admin-keys.test.ts
+++ b/tests/cli/admin-keys.test.ts
@@ -33,27 +33,6 @@ interface RunResult {
  * emits exactly one token, so a regex match is both sufficient and robust.
  */
 
-/**
- * Parse the CLI JSON payload from captured stdout while ignoring unrelated
- * Jest console-rendering noise that can be captured by the in-process stdout
- * hook when another timer logs in the same worker. The admin list command emits
- * one top-level array, so selecting the first complete JSON array preserves the
- * assertion that plaintext does not leak into the actual CLI JSON output.
- */
-function parseJsonArrayFromStdout<T>(stdout: string): T[] {
-  const start = stdout.indexOf('[');
-  if (start < 0) throw new Error(`No JSON array found in stdout: ${JSON.stringify(stdout)}`);
-  for (let end = stdout.length - 1; end >= start; end--) {
-    if (stdout[end] !== ']') continue;
-    const candidate = stdout.slice(start, end + 1);
-    try {
-      return JSON.parse(candidate) as T[];
-    } catch {
-      // Keep scanning left: prefixed Jest noise may contain bracketed labels.
-    }
-  }
-  throw new Error(`No parseable JSON array found in stdout: ${JSON.stringify(stdout)}`);
-}
 
 function extractToken(stdout: string): string {
   const m = stdout.match(/oc_live_[A-Za-z0-9_]+/);

--- a/tests/tools/request-intercept-preset.test.ts
+++ b/tests/tools/request-intercept-preset.test.ts
@@ -680,3 +680,89 @@ describe('OPENCHROME_OPTIMIZE_BANDWIDTH env auto-apply', () => {
     expect(parsed.preset).toBeNull();
   });
 });
+
+describe('dryRun preview (#878)', () => {
+  test('enable dryRun previews preset rules without enabling interception', async () => {
+    const handler = await loadHandler();
+    const page = await getMockPage() as unknown as { setRequestInterception: jest.Mock };
+
+    const result = (await handler(testSessionId, {
+      tabId: testTargetId,
+      action: 'enable',
+      preset: 'optimize-bandwidth-light',
+      dryRun: true,
+    })) as { content: Array<{ text: string }>; structuredContent?: Record<string, unknown>; isError?: boolean };
+
+    expect(result.isError).toBe(false);
+    expect(page.setRequestInterception).not.toHaveBeenCalled();
+    const parsed = parseToolResult(result);
+    expect(parsed.dryRun).toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      dryRun: true,
+      wouldAffect: {
+        count: 0,
+        details: {
+          action: 'enable',
+          parsedRuleCount: 3,
+          existingRulesCount: 0,
+          observedRequestCount: 0,
+          preset: 'optimize-bandwidth-light',
+        },
+      },
+      guidance: 'Pass dryRun:false (or omit) to execute.',
+    });
+  });
+
+  test('addRule dryRun previews matched observed requests without mutating rules', async () => {
+    const handler = await loadHandler();
+    await addRule(handler, { pattern: '*', action: 'log' });
+    await handler(testSessionId, { tabId: testTargetId, action: 'enable' });
+
+    await (await getRequestListener())(createMockRequest({
+      url: 'https://cdn.example.com/hero.png',
+      resourceType: 'image',
+    }));
+    await (await getRequestListener())(createMockRequest({
+      url: 'https://api.example.com/data',
+      resourceType: 'xhr',
+    }));
+
+    const before = parseToolResult(await handler(testSessionId, {
+      tabId: testTargetId,
+      action: 'listRules',
+    }));
+
+    const result = (await handler(testSessionId, {
+      tabId: testTargetId,
+      action: 'addRule',
+      dryRun: true,
+      rule: {
+        pattern: '*://cdn.example.com/*',
+        resourceTypes: ['image'],
+        action: 'block',
+      },
+    })) as { content: Array<{ text: string }>; structuredContent?: Record<string, unknown>; isError?: boolean };
+
+    const after = parseToolResult(await handler(testSessionId, {
+      tabId: testTargetId,
+      action: 'listRules',
+    }));
+
+    expect(result.isError).toBe(false);
+    expect(after).toEqual(before);
+    expect(result.structuredContent).toMatchObject({
+      dryRun: true,
+      wouldAffect: {
+        count: 1,
+        samples: [{ url: 'https://cdn.example.com/hero.png', resourceType: 'image', method: 'GET' }],
+        details: {
+          action: 'addRule',
+          parsedRuleCount: 1,
+          existingRulesCount: 1,
+          observedRequestCount: 2,
+        },
+      },
+      guidance: 'Pass dryRun:false (or omit) to execute.',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `dryRun` to `request_intercept` for rule-installation paths.
- Previews `enable` preset rules and `addRule` parsed rules using the #878 `structuredContent.dryRun/wouldAffect/guidance` envelope.
- Keeps dry-run non-mutating: no request interception enablement, listener install, or rule mutation.

Partial fix for #878: this covers the remaining `request_intercept` dry-run surface after cookies/storage/oc_reap_orphans/oc_stop.

## Verification
- `npm test -- tests/tools/request-intercept-preset.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `git diff --check`

## Not tested
- Live browser request_intercept dry-run against active XHR traffic.
