### PR TITLE
feat(skill): capture navigate replay artifacts for #988

### DIFF
--- a/src/tools/_shared/replay-recorder.ts
+++ b/src/tools/_shared/replay-recorder.ts
@@ -17,6 +17,11 @@ interface BackendNodeCaptureInput {
   args?: Record<string, unknown>;
 }
 
+interface NavigationCaptureInput {
+  page: any;
+  url: string;
+}
+
 /**
  * Default-off gate for #988 replay-artifact capture hooks. Only literal true
  * enables side effects so omitted / false remains byte-identical to the old
@@ -24,6 +29,23 @@ interface BackendNodeCaptureInput {
  */
 export function shouldCaptureReplayArtifact(value: unknown): boolean {
   return value === true;
+}
+
+/**
+ * Capture a navigation replay step for the page's current target.
+ */
+export function captureNavigationReplayStep(input: NavigationCaptureInput): void {
+  try {
+    if (typeof input.url !== 'string' || input.url.length === 0) return;
+    const target = (input.page as { target?: () => unknown }).target?.();
+    captureReplayStep(target ? getTargetId(target as never) : '', {
+      kind: 'navigate',
+      selectors: [],
+      args: { url: input.url },
+    });
+  } catch {
+    // Best-effort recorder hook: never change action tool behaviour.
+  }
 }
 
 /**

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -23,6 +23,7 @@ import { getGlobalConfig } from '../config/global';
 import { autoRecallForUrl } from '../core/skill-memory/auto-recall';
 import type { Page } from 'puppeteer-core';
 import { wrapMutatingHandler } from '../utils/snapshot-cache-helper';
+import { captureNavigationReplayStep, shouldCaptureReplayArtifact } from './_shared/replay-recorder';
 
 /** Blocking types that warrant automatic stealth retry (#459) */
 const RETRYABLE_BLOCK_TYPES: ReadonlySet<string> = new Set(['access-denied', 'bot-check', 'captcha']);
@@ -476,6 +477,11 @@ const definition: MCPToolDefinition = {
       recall: {
         type: 'boolean',
         description: 'Override OPENCHROME_AUTO_RECALL for this call. true forces domain skill injection; false suppresses it even when the flag is on.',
+      },
+      capture_artifact: {
+        type: 'boolean',
+        default: false,
+        description: 'When true, stage a replay artifact navigation step for oc_skill_record after a successful URL navigation. Default false is a strict no-op.',
       },
     },
     required: ['url'],
@@ -1050,7 +1056,9 @@ const handler: ToolHandler = async (
  */
 const wrappedHandler: ToolHandler = async (sessionId, args, context) => {
   const result = await handler(sessionId, args, context);
-  if (result.isError !== true && isDynamicSkillsEnabled()) {
+  const captureArtifact = shouldCaptureReplayArtifact(args.capture_artifact);
+  const dynamicSkillsEnabled = isDynamicSkillsEnabled();
+  if (result.isError !== true && (captureArtifact || dynamicSkillsEnabled)) {
     // Best-effort: parse the response payload to recover the final
     // URL. We do not throw on parse failure — the navigate response
     // is already on its way back to the client.
@@ -1065,7 +1073,15 @@ const wrappedHandler: ToolHandler = async (sessionId, args, context) => {
         // construction, no new synthesis surface to gain).
         const isAuthRedirect = parsed.authRedirect === true;
         const action = typeof parsed.action === 'string' ? parsed.action : undefined;
-        if (finalUrl && !isAuthRedirect && action !== 'back' && action !== 'forward') {
+        const shouldRecordNavigation = finalUrl && !isAuthRedirect && action === 'navigate';
+        if (shouldRecordNavigation && captureArtifact) {
+          const tabId = typeof parsed.tabId === 'string' ? parsed.tabId : args.tabId as string | undefined;
+          if (tabId) {
+            const page = await getSessionManager().getPage(sessionId, tabId, undefined, 'navigate');
+            if (page) captureNavigationReplayStep({ page, url: finalUrl });
+          }
+        }
+        if (shouldRecordNavigation && dynamicSkillsEnabled) {
           void emitDomainEnteredIfActive(sessionId, finalUrl);
         }
       }

--- a/tests/tools/replay-recorder.test.ts
+++ b/tests/tools/replay-recorder.test.ts
@@ -2,10 +2,29 @@ import {
   peekRecorderBuffer,
   resetRecorderBuffers,
 } from '../../src/core/skill-memory';
-import { captureBackendNodeReplayStep } from '../../src/tools/_shared/replay-recorder';
+import {
+  captureBackendNodeReplayStep,
+  captureNavigationReplayStep,
+} from '../../src/tools/_shared/replay-recorder';
 
 describe('replay recorder shared helpers', () => {
   afterEach(() => resetRecorderBuffers());
+
+  test('captures a navigation replay step for the page target', () => {
+    const page = {
+      target: () => ({ _targetId: 'target-nav' }),
+    };
+
+    captureNavigationReplayStep({ page, url: 'https://example.test/checkout' });
+
+    expect(peekRecorderBuffer('target-nav')).toEqual([
+      {
+        kind: 'navigate',
+        selectors: [],
+        args: { url: 'https://example.test/checkout' },
+      },
+    ]);
+  });
 
   test('captures a replay step from backendNodeId using generated CSS selectors', async () => {
     const cdpClient = {


### PR DESCRIPTION
## Summary
- Stacks on #1228 to keep the #988 recorder hook chain ordered.
- Adds default-off `capture_artifact` to `navigate`.
- Records successful URL navigations as selector-free replay `navigate` steps, while skipping auth redirects and history back/forward actions.
- Preserves the previous no-op path when both dynamic skills and `capture_artifact` are disabled.

Partial fix for #988: this covers the `navigate` tool hook after #1222/#1227/#1228 cover shared plumbing, `form_input`, `interact`, and `fill_form`.

## Verification
- `npm test -- tests/tools/replay-recorder.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `git diff --check`

## Not tested
- Live browser `navigate` capture followed by `oc_skill_record`/`oc_skill_replay`.
