### PR TITLE
feat(security): constrain recording exports with MCP roots for #880

### DIFF
--- a/src/tools/recording.ts
+++ b/src/tools/recording.ts
@@ -11,6 +11,8 @@ import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getActionRecorder, registerSessionRecorder, unregisterSessionRecorder } from '../recording/action-recorder';
 import { getRecordingStore } from '../recording/recording-store';
 import { RecordingAction, RecordingMetadata } from '../recording/types';
+import { currentRequestContext } from '../observability/request-id';
+import { assertFilePathAllowedBySessionRoots } from '../security/mcp-roots';
 
 /** Matches the RECORDING_ID_PATTERN exported from recording-store */
 const RECORDING_ID_PATTERN = /^rec-\d{8}-\d{6}-[a-z0-9]{4,6}$/;
@@ -274,7 +276,7 @@ const exportDefinition: MCPToolDefinition = {
 };
 
 const exportHandler: ToolHandler = async (
-  _sessionId: string,
+  sessionId: string,
   args: Record<string, unknown>,
 ): Promise<MCPResult> => {
   const recordingId = args.recordingId as string;
@@ -309,6 +311,7 @@ const exportHandler: ToolHandler = async (
       const html = await generateHtmlReport(metadata, actions, store);
       const dir = store.getRecordingDir(recordingId);
       const filepath = path.join(dir, 'report.html');
+      assertFilePathAllowedBySessionRoots(currentRequestContext()?.mcpSessionId ?? sessionId, filepath);
       await fs.promises.writeFile(filepath, html, 'utf-8');
       return {
         content: [{ type: 'text', text: `HTML report saved to: ${filepath}` }],

--- a/tests/tools/recording.test.ts
+++ b/tests/tools/recording.test.ts
@@ -6,6 +6,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { pathToFileURL } from 'url';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -389,7 +390,8 @@ describe('recording tools', () => {
       const actions = [makeAction()];
       mockReadMetadata.mockResolvedValue(metadata);
       mockReadActions.mockReturnValue(actions);
-      setSessionMcpRoots('mcp-rec-deny', { roots: [{ uri: 'file:///tmp/allowed-recordings' }] });
+      const allowedRoot = path.resolve(path.dirname(tmpDir), 'allowed-recordings');
+      setSessionMcpRoots('mcp-rec-deny', { roots: [{ uri: pathToFileURL(allowedRoot).href }] });
 
       const result = await runWithRequestContext(
         { requestId: 'req-recording-roots-deny', mcpSessionId: 'mcp-rec-deny' },

--- a/tests/tools/recording.test.ts
+++ b/tests/tools/recording.test.ts
@@ -66,6 +66,8 @@ jest.mock('../../src/chrome/launcher', () => ({
 
 import { MCPServer } from '../../src/mcp-server';
 import { registerRecordingTools } from '../../src/tools/recording';
+import { runWithRequestContext } from '../../src/observability/request-id';
+import { clearAllSessionMcpRoots, setSessionMcpRoots } from '../../src/security/mcp-roots';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -116,9 +118,14 @@ describe('recording tools', () => {
     mockGetRecordingSize.mockResolvedValue(0);
     mockGetRecordingDir.mockReturnValue('/tmp/recordings/rec-test');
     mockReadScreenshot.mockResolvedValue(null);
+    clearAllSessionMcpRoots();
 
     server = new MCPServer();
     registerRecordingTools(server);
+  });
+
+  afterEach(() => {
+    clearAllSessionMcpRoots();
   });
 
   // ─── Registration ──────────────────────────────────────────────────────────
@@ -375,6 +382,26 @@ describe('recording tools', () => {
       expect(html).toContain('<!DOCTYPE html>');
       expect(html).toContain('rec-20240101-120000-abcd');
       expect(html).toContain('navigate');
+    });
+
+    test('HTML export is denied when MCP file roots exclude the report path', async () => {
+      const metadata = makeMetadata();
+      const actions = [makeAction()];
+      mockReadMetadata.mockResolvedValue(metadata);
+      mockReadActions.mockReturnValue(actions);
+      setSessionMcpRoots('mcp-rec-deny', { roots: [{ uri: 'file:///tmp/allowed-recordings' }] });
+
+      const result = await runWithRequestContext(
+        { requestId: 'req-recording-roots-deny', mcpSessionId: 'mcp-rec-deny' },
+        () => handler('default', {
+          recordingId: 'rec-20240101-120000-abcd',
+          format: 'html',
+        }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('MCP roots narrowing');
+      expect(fs.existsSync(path.join(tmpDir, 'report.html'))).toBe(false);
     });
 
     test('HTML includes action details', async () => {


### PR DESCRIPTION
## Summary
- Stacks on #1230 to reuse file-root parsing and output-path policy.
- Applies MCP `file://` roots to `oc_recording_export(format: "html")` at the resolved `report.html` path.
- Leaves inline JSON export and sessions without applicable file roots unchanged.
- Adds coverage that denied roots prevent the HTML report file from being created.

Partial fix for #880: this covers recording HTML export. `oc_session_snapshot` file-root coverage and live roots/list_changed file smoke remain follow-ups before closing the issue.

## Verification
- `npm test -- tests/tools/recording.test.ts tests/security/mcp-roots.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `git diff --check`

## Not tested
- Live MCP `roots/list_changed` client exporting a real recording over HTTP.
