### PR TITLE
feat(security): constrain session snapshots with MCP roots for #880

### DIFF
--- a/src/tools/session-snapshot.ts
+++ b/src/tools/session-snapshot.ts
@@ -14,6 +14,8 @@ import { getExistingChromeLauncher } from '../chrome/launcher';
 import { getGlobalConfig } from '../config/global';
 import { writeFileAtomicSafe } from '../utils/atomic-file';
 import { safeTitle } from '../utils/safe-title';
+import { currentRequestContext } from '../observability/request-id';
+import { assertFilePathAllowedBySessionRoots } from '../security/mcp-roots';
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -224,15 +226,17 @@ async function ensureDir(): Promise<void> {
   await fs.promises.mkdir(SNAPSHOT_DIR, { recursive: true });
 }
 
-export async function saveSnapshot(snapshot: SessionSnapshot): Promise<void> {
+export async function saveSnapshot(snapshot: SessionSnapshot, mcpSessionId?: string): Promise<void> {
   await ensureDir();
 
   // Save as latest.json (atomic overwrite)
   const latestPath = path.join(SNAPSHOT_DIR, 'latest.json');
+  if (mcpSessionId) assertFilePathAllowedBySessionRoots(mcpSessionId, latestPath);
   await writeFileAtomicSafe(latestPath, snapshot);
 
   // Save history copy
   const historyPath = path.join(SNAPSHOT_DIR, `${snapshot.id}.json`);
+  if (mcpSessionId) assertFilePathAllowedBySessionRoots(mcpSessionId, historyPath);
   await writeFileAtomicSafe(historyPath, snapshot);
 
   // Prune old snapshots
@@ -275,7 +279,7 @@ export async function pruneSnapshots(): Promise<void> {
 // ─── Handler ───────────────────────────────────────────────────────────────
 
 const handler: ToolHandler = async (
-  _sessionId: string,
+  sessionId: string,
   args: Record<string, unknown>,
 ): Promise<MCPResult> => {
   const memo: SnapshotMemo = {
@@ -299,7 +303,14 @@ const handler: ToolHandler = async (
     label: (args.label as string) || undefined,
   };
 
-  await saveSnapshot(snapshot);
+  try {
+    await saveSnapshot(snapshot, currentRequestContext()?.mcpSessionId ?? sessionId);
+  } catch (error) {
+    return {
+      content: [{ type: 'text', text: `Error saving snapshot: ${error instanceof Error ? error.message : String(error)}` }],
+      isError: true,
+    };
+  }
 
   const text = [
     `Snapshot saved: ${snapshotId}`,

--- a/tests/tools/session-snapshot.test.ts
+++ b/tests/tools/session-snapshot.test.ts
@@ -20,6 +20,8 @@ jest.mock('../../src/utils/atomic-file', () => ({
 // fs.promises is mocked selectively per test via jest.spyOn
 import { getSessionManager } from '../../src/session-manager';
 import { writeFileAtomicSafe } from '../../src/utils/atomic-file';
+import { runWithRequestContext } from '../../src/observability/request-id';
+import { clearAllSessionMcpRoots, setSessionMcpRoots } from '../../src/security/mcp-roots';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -106,6 +108,11 @@ describe('oc_session_snapshot', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (writeFileAtomicSafe as jest.Mock).mockResolvedValue(undefined);
+    clearAllSessionMcpRoots();
+  });
+
+  afterEach(() => {
+    clearAllSessionMcpRoots();
   });
 
   // ── Snapshot ID format ───────────────────────────────────────────────────
@@ -521,6 +528,27 @@ describe('oc_session_snapshot', () => {
       // Should succeed with empty tabs
       expect(result.content[0].text).toContain('Tabs: 0');
       expect(result.content[0].text).toContain('Snapshot saved:');
+    });
+
+    test('denies snapshot writes when MCP file roots exclude the snapshot directory', async () => {
+      const mockSM = makeMockSessionManager([]);
+      (getSessionManager as jest.Mock).mockReturnValue(mockSM);
+      setSessionMcpRoots('mcp-snapshot-deny', { roots: [{ uri: 'file:///tmp/allowed-snapshots' }] });
+
+      const handler = await getSnapshotHandler();
+
+      const result = await runWithRequestContext(
+        { requestId: 'req-snapshot-roots-deny', mcpSessionId: 'mcp-snapshot-deny' },
+        () => handler('session-1', {
+          objective: 'Blocked snapshot',
+          currentStep: 'Checking roots',
+          nextActions: [],
+        }),
+      ) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('MCP roots narrowing');
+      expect(writeFileAtomicSafe).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/tools/session-snapshot.test.ts
+++ b/tests/tools/session-snapshot.test.ts
@@ -6,6 +6,7 @@
 
 import * as path from 'path';
 import * as os from 'os';
+import { pathToFileURL } from 'url';
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
@@ -533,7 +534,9 @@ describe('oc_session_snapshot', () => {
     test('denies snapshot writes when MCP file roots exclude the snapshot directory', async () => {
       const mockSM = makeMockSessionManager([]);
       (getSessionManager as jest.Mock).mockReturnValue(mockSM);
-      setSessionMcpRoots('mcp-snapshot-deny', { roots: [{ uri: 'file:///tmp/allowed-snapshots' }] });
+      const { SNAPSHOT_DIR } = await import('../../src/tools/session-snapshot');
+      const allowedRoot = path.resolve(path.dirname(SNAPSHOT_DIR), 'allowed-snapshots');
+      setSessionMcpRoots('mcp-snapshot-deny', { roots: [{ uri: pathToFileURL(allowedRoot).href }] });
 
       const handler = await getSnapshotHandler();
 


### PR DESCRIPTION
## Summary
- Stacks on #1231 to reuse the #880 file-root policy chain.
- Applies MCP `file://` roots to `oc_session_snapshot` before writing `latest.json` or the history snapshot file.
- Returns a bounded tool error when roots deny the snapshot path and prevents atomic writes from running.

Partial fix for #880: this covers `oc_session_snapshot` file outputs. Live MCP `roots/list_changed` smoke remains before closing the issue.

## Verification
- `npm test -- tests/tools/session-snapshot.test.ts tests/security/mcp-roots.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `git diff --check`

## Not tested
- Live MCP `roots/list_changed` client saving snapshots over HTTP.
