### PR TITLE
fix(crawl): paginate returned pages with cursors

### DIFF
--- a/docs/mcp/pagination.md
+++ b/docs/mcp/pagination.md
@@ -104,7 +104,7 @@ return {
 | `console_capture` `get` | `entries` / `logs` | 200 when cursoring; no-cursor output remains legacy-compatible | ✅ cursor support in PR #1234 |
 | `network_capture_lite/full` `getLogs` | `requests` / `entries` | 100 | ✅ cursor support in PR #1235 |
 | `read_page` markdown | `text` | 5,000 chars after the legacy first chunk | ✅ markdown cursor support in this PR |
-| `crawl` | pages | 25 pages | Follow-up slice |
+| `crawl` | `pages` | 25 pages | ✅ cursor support in this PR |
 
 Each adoption should stay a small per-tool PR: import `paginate`, preserve
 cursor-omitted compatibility for one minor version, and route cursor page
@@ -142,6 +142,15 @@ truncation marker, while adding `structuredContent.nextCursor` / `hasMore` /
 `cursor` to retrieve the next 5,000-character markdown chunk as JSON text plus
 matching `structuredContent`. Cursor hashes cover the full generated markdown so
 stale page content is rejected with `stale_cursor` instead of silently resetting.
+
+### `crawl`
+
+Pass a previous `nextCursor` as `cursor` to paginate the returned `pages` array
+after the crawl completes. Cursor pages use 25 crawl pages per response and
+return JSON text plus matching `structuredContent` with `offset`, `total`,
+`hasMore`, and optional `nextCursor`. Calls without `cursor` keep the legacy
+JSON text output while also exposing a first structured 25-page slice for
+clients that want to continue without changing the no-cursor text contract.
 
 ## Why opaque cursors (and not `start_index`)
 

--- a/src/tools/crawl.ts
+++ b/src/tools/crawl.ts
@@ -7,6 +7,7 @@
  * @see https://github.com/shaun0927/openchrome/issues/576
  */
 
+import crypto from 'crypto';
 import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
@@ -44,6 +45,9 @@ import {
   parseCrawlCacheMode,
   parseCrawlCacheScope,
 } from '../core/crawl/content-cache';
+import { decodeCursor, encodeCursor } from '../utils/paginate';
+
+const CRAWL_CURSOR_PAGE_SIZE = 25;
 
 const definition: MCPToolDefinition = {
   name: 'crawl',
@@ -63,6 +67,10 @@ const definition: MCPToolDefinition = {
       max_pages: {
         type: 'number',
         description: 'Maximum number of pages to crawl. Default: 20',
+      },
+      cursor: {
+        type: 'string',
+        description: 'Opaque pagination cursor returned as nextCursor from a prior crawl call. Cursoring paginates returned pages after the crawl completes.',
       },
       scope: {
         type: 'string',
@@ -243,6 +251,74 @@ interface CrawlSummary {
   strategy?: CrawlStrategy;
   scored_urls?: number;
   skipped_below_threshold?: number;
+}
+
+interface CrawlPageSlice {
+  pages: CrawledPage[];
+  offset: number;
+  total: number;
+  hasMore: boolean;
+  nextCursor?: string;
+  staleCursor?: true;
+}
+
+function hashCrawlPages(pages: readonly CrawledPage[]): string {
+  return crypto.createHash('sha256')
+    .update(JSON.stringify(pages.map((page) => ({
+      url: page.url,
+      title: page.title,
+      content: page.content,
+      raw_markdown: page.raw_markdown,
+      fit_markdown: page.fit_markdown,
+      filter: page.filter,
+      depth: page.depth,
+      links_found: page.links_found,
+      error: page.error,
+      engine_used: page.engine_used,
+      static_reason: page.static_reason,
+      score: page.score,
+      score_reasons: page.score_reasons,
+      cache: page.cache,
+    }))), 'utf8')
+    .digest('hex');
+}
+
+function paginateCrawlPages(pages: readonly CrawledPage[], cursor: string | undefined): CrawlPageSlice {
+  const hash = hashCrawlPages(pages);
+  let offset = 0;
+  if (cursor !== undefined) {
+    const state = decodeCursor(cursor);
+    if (state.hash !== undefined && state.hash !== hash) {
+      return { pages: [], offset: state.offset, total: pages.length, hasMore: false, staleCursor: true };
+    }
+    offset = Math.min(state.offset, pages.length);
+  }
+  const end = Math.min(offset + CRAWL_CURSOR_PAGE_SIZE, pages.length);
+  const hasMore = end < pages.length;
+  return {
+    pages: pages.slice(offset, end),
+    offset,
+    total: pages.length,
+    hasMore,
+    ...(hasMore ? { nextCursor: encodeCursor({ offset: end, hash }) } : {}),
+  };
+}
+
+function invalidCursorResult(error: unknown): MCPResult {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    isError: true,
+    content: [{ type: 'text', text: JSON.stringify({ error: { code: 'invalid_cursor', message } }) }],
+    structuredContent: { error: { code: 'invalid_cursor', message } },
+  };
+}
+
+function staleCursorResult(): MCPResult {
+  return {
+    isError: true,
+    content: [{ type: 'text', text: JSON.stringify({ error: { code: 'stale_cursor', retry: 'restart_from_no_cursor' } }) }],
+    structuredContent: { error: { code: 'stale_cursor', retry: 'restart_from_no_cursor' } },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -1137,6 +1213,30 @@ const handler: ToolHandler = async (
         }
       : { summary, pages: outputPages };
 
+    const cursor = args.cursor as string | undefined;
+    if (cursor !== undefined) {
+      let pageSlice: CrawlPageSlice;
+      try {
+        pageSlice = paginateCrawlPages(pages, cursor);
+      } catch (error) {
+        return invalidCursorResult(error);
+      }
+      if (pageSlice.staleCursor) {
+        return staleCursorResult();
+      }
+      const payload = {
+        ...buildOutput(pageSlice.pages),
+        offset: pageSlice.offset,
+        total: pageSlice.total,
+        hasMore: pageSlice.hasMore,
+        ...(pageSlice.nextCursor ? { nextCursor: pageSlice.nextCursor } : {}),
+      };
+      return {
+        content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
+        structuredContent: payload,
+      };
+    }
+
     // Ensure output fits within limits
     let outputJson = JSON.stringify(buildOutput(pages), null, 2);
     if (outputJson.length > MAX_OUTPUT_CHARS) {
@@ -1193,8 +1293,17 @@ const handler: ToolHandler = async (
       }
     }
 
+    const structuredPageSlice = paginateCrawlPages(pages, undefined);
+    const structuredPayload = {
+      ...buildOutput(structuredPageSlice.pages),
+      offset: structuredPageSlice.offset,
+      total: structuredPageSlice.total,
+      hasMore: structuredPageSlice.hasMore,
+      ...(structuredPageSlice.nextCursor ? { nextCursor: structuredPageSlice.nextCursor } : {}),
+    };
     return {
       content: [{ type: 'text', text: outputJson }],
+      structuredContent: structuredPayload,
     };
   } catch (error) {
     return {

--- a/tests/core/tools/crawl.engine.test.ts
+++ b/tests/core/tools/crawl.engine.test.ts
@@ -192,6 +192,112 @@ describe('crawl engine=static', () => {
     expect(mockSessionManager.createTarget).not.toHaveBeenCalled();
   });
 
+  test('paginates returned pages with crawl cursor metadata', async () => {
+    const links = Array.from({ length: 29 }, (_, i) => {
+      const n = i + 1;
+      server.setRoute(`/many-${n}.html`, {
+        status: 200,
+        contentType: 'text/html; charset=utf-8',
+        body: RICH_HTML(`Many ${n}`, `<h1>Many ${n}</h1><p>${PARA}</p>`),
+      });
+      return `<a href="/many-${n}.html">Many ${n}</a>`;
+    }).join('');
+    server.setRoute('/many-start.html', {
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+      body: RICH_HTML('Many Start', `<h1>Many Start</h1><p>${PARA}</p>${links}`),
+    });
+
+    const handler = await loadHandler('crawl');
+    const first = await handler('s-cursor-1', {
+      url: `${server.origin}/many-start.html`,
+      max_pages: 30,
+      max_depth: 1,
+      delay_ms: 0,
+      engine: 'static',
+      respect_robots: false,
+    }) as any;
+
+    expect(first.isError).not.toBe(true);
+    expect(first.structuredContent.pages).toHaveLength(25);
+    expect(first.structuredContent.offset).toBe(0);
+    expect(first.structuredContent.total).toBe(30);
+    expect(first.structuredContent.hasMore).toBe(true);
+    expect(first.structuredContent.nextCursor).toEqual(expect.any(String));
+    // Legacy no-cursor text remains the full crawl result.
+    expect(parseResult(first).pages).toHaveLength(30);
+
+    const second = await handler('s-cursor-2', {
+      url: `${server.origin}/many-start.html`,
+      max_pages: 30,
+      max_depth: 1,
+      delay_ms: 0,
+      engine: 'static',
+      respect_robots: false,
+      cursor: first.structuredContent.nextCursor,
+    }) as any;
+
+    expect(JSON.parse(second.content[0].text)).toEqual(second.structuredContent);
+    expect(second.structuredContent.pages).toHaveLength(5);
+    expect(second.structuredContent.offset).toBe(25);
+    expect(second.structuredContent.total).toBe(30);
+    expect(second.structuredContent.hasMore).toBe(false);
+  });
+
+  test('rejects malformed and stale crawl cursors', async () => {
+    server.setRoute('/stale-start.html', {
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+      body: RICH_HTML('Stale Start', `<h1>Stale Start</h1><p>${PARA}</p>${Array.from({ length: 25 }, (_, i) => `<a href="/stale-${i}.html">S${i}</a>`).join('')}`),
+    });
+    for (let i = 0; i < 25; i++) {
+      server.setRoute(`/stale-${i}.html`, {
+        status: 200,
+        contentType: 'text/html; charset=utf-8',
+        body: RICH_HTML(`Stale ${i}`, `<h1>Stale ${i}</h1><p>${PARA}</p>`),
+      });
+    }
+
+    const handler = await loadHandler('crawl');
+    const malformed = await handler('s-cursor-bad', {
+      url: `${server.origin}/stale-start.html`,
+      max_pages: 26,
+      max_depth: 1,
+      delay_ms: 0,
+      engine: 'static',
+      respect_robots: false,
+      cursor: 'bad-cursor',
+    }) as any;
+    expect(malformed.isError).toBe(true);
+    expect(malformed.structuredContent.error.code).toBe('invalid_cursor');
+
+    const first = await handler('s-cursor-stale-1', {
+      url: `${server.origin}/stale-start.html`,
+      max_pages: 26,
+      max_depth: 1,
+      delay_ms: 0,
+      engine: 'static',
+      respect_robots: false,
+    }) as any;
+    server.setRoute('/stale-24.html', {
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+      body: RICH_HTML('Stale changed', `<h1>Stale changed</h1><p>${PARA}</p>`),
+    });
+
+    const stale = await handler('s-cursor-stale-2', {
+      url: `${server.origin}/stale-start.html`,
+      max_pages: 26,
+      max_depth: 1,
+      delay_ms: 0,
+      engine: 'static',
+      respect_robots: false,
+      cursor: first.structuredContent.nextCursor,
+    }) as any;
+    expect(stale.isError).toBe(true);
+    expect(stale.structuredContent.error).toEqual({ code: 'stale_cursor', retry: 'restart_from_no_cursor' });
+  });
+
 
   test('include_metrics adds summary and per-page token estimates without changing default', async () => {
     const handler = await loadHandler('crawl');


### PR DESCRIPTION
## Summary
- Adds `crawl.cursor` pagination for returned `pages` slices using the shared opaque cursor primitives.
- Preserves legacy no-cursor crawl JSON text while exposing a first 25-page structured slice with continuation metadata.
- Returns cursor follow-up pages as JSON text plus matching `structuredContent`, with malformed/stale cursor guards.
- Updates the #881 pagination adoption docs for the crawl slice.

Fixes part of #881.
Stacked on #1237.

## Verification
- npm test -- tests/core/tools/crawl.engine.test.ts --runInBand
- npm run build
- npm run lint:tier
- git diff --check
