### PR TITLE
feat(element-picker): register element_pick tool for #899

### DIFF
--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -21,6 +21,7 @@ export const TOOL_TIERS: Record<string, ToolTier> = {
   fill_form: 1,
   read_page: 1,
   oc_observe: 1,              // src/tools/oc-observe.ts — compact observable action map (#866)
+  element_pick: 1,             // src/tools/element-pick.ts — in-page picker facts (#899)
   inspect: 1,
   query_dom: 1,
   oc_query: 1, // src/tools/oc-query.ts — semantic refs for interaction workflows (#1045)

--- a/src/core/element-picker/overlay-script.ts
+++ b/src/core/element-picker/overlay-script.ts
@@ -21,6 +21,7 @@ export const ELEMENT_PICK_OVERLAY_SOURCE = String.raw`
     capture: null,
     timeoutId: null,
     lastHover: null,
+    waiters: [],
   };
 
   const zIndex = '2147483647';
@@ -115,6 +116,10 @@ export const ELEMENT_PICK_OVERLAY_SOURCE = String.raw`
   function setResult(result) {
     state.result = result;
     cleanup(result && result.error ? result.error : 'done');
+    const waiters = state.waiters.splice(0);
+    for (const resolve of waiters) {
+      try { resolve(result); } catch {}
+    }
   }
 
   function cleanup(reason) {
@@ -219,6 +224,19 @@ export const ELEMENT_PICK_OVERLAY_SOURCE = String.raw`
       const timeoutMs = Math.max(1, Math.min(Number(options && options.timeoutMs) || 60000, 300000));
       state.timeoutId = setTimeout(() => setResult({ success: false, error: 'timeout' }), timeoutMs);
       return { success: true, started: true };
+    },
+    startAsync(options) {
+      const started = this.start(options);
+      if (!started || started.success !== true) return Promise.resolve(started);
+      return new Promise((resolve) => {
+        if (state.result) {
+          const result = state.result;
+          state.result = null;
+          resolve(result);
+          return;
+        }
+        state.waiters.push(resolve);
+      });
     },
     cancel(reason) {
       if (!state.active) return { success: true, canceled: false };

--- a/src/tools/__tests__/__snapshots__/tools-list.v1.11.snap.json
+++ b/src/tools/__tests__/__snapshots__/tools-list.v1.11.snap.json
@@ -37,6 +37,9 @@
       "name": "drag_drop"
     },
     {
+      "name": "element_pick"
+    },
+    {
       "name": "emulate_device"
     },
     {

--- a/src/tools/element-pick.ts
+++ b/src/tools/element-pick.ts
@@ -24,7 +24,7 @@ const definition: MCPToolDefinition = {
   inputSchema: {
     type: 'object',
     properties: {
-      tabId: { type: 'string', description: 'Tab ID to pick from' },
+      tabId: { type: 'string', description: 'REQUIRED Tab ID to pick from' },
       action: { type: 'string', enum: ['start', 'cancel'], description: 'start waits for a picked element; cancel cancels an in-flight pick. Default: start.' },
       timeoutMs: { type: 'number', description: 'Max wait for a click in ms. Default 60000; capped at 300000.' },
       cancelOnEscape: { type: 'boolean', description: 'Reserved for compatibility; Escape cancellation is enabled by the overlay.' },

--- a/src/tools/element-pick.ts
+++ b/src/tools/element-pick.ts
@@ -1,0 +1,112 @@
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolContext, ToolHandler, throwIfAborted } from '../types/mcp';
+import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
+import { getSessionManager } from '../session-manager';
+import { withTimeout } from '../utils/with-timeout';
+import { buildPickedElement, elementPickInstallExpression, type ElementPickRecorderInput } from '../core/element-picker';
+
+interface ElementPickSuccess {
+  success: true;
+  element: ElementPickRecorderInput;
+}
+
+interface ElementPickFailure {
+  success: false;
+  error: string;
+  remediation?: string;
+}
+
+type ElementPickOverlayResult = ElementPickSuccess | ElementPickFailure | { success: true; started?: true; canceled?: boolean; installed?: true };
+
+const definition: MCPToolDefinition = {
+  name: 'element_pick',
+  description: 'Start or cancel an in-page human element picker overlay. Returns selector, DOM, style, and bounding-box facts; it does not persist skills directly.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      tabId: { type: 'string', description: 'Tab ID to pick from' },
+      action: { type: 'string', enum: ['start', 'cancel'], description: 'start waits for a picked element; cancel cancels an in-flight pick. Default: start.' },
+      timeoutMs: { type: 'number', description: 'Max wait for a click in ms. Default 60000; capped at 300000.' },
+      cancelOnEscape: { type: 'boolean', description: 'Reserved for compatibility; Escape cancellation is enabled by the overlay.' },
+    },
+    required: ['tabId'],
+  },
+  annotations: TOOL_ANNOTATIONS.element_pick,
+};
+
+const handler: ToolHandler = async (sessionId: string, args: Record<string, unknown>, context?: ToolContext): Promise<MCPResult> => {
+  throwIfAborted(context);
+  const tabId = args.tabId as string;
+  const action = (args.action as string | undefined) ?? 'start';
+  const timeoutMs = normalizeTimeout(args.timeoutMs);
+
+  if (!tabId) {
+    return { content: [{ type: 'text', text: 'Error: tabId is required' }], isError: true };
+  }
+  if (action !== 'start' && action !== 'cancel') {
+    return { content: [{ type: 'text', text: 'Error: action must be "start" or "cancel"' }], isError: true };
+  }
+
+  const sessionManager = getSessionManager();
+  const page = await sessionManager.getPage(sessionId, tabId, undefined, 'element_pick');
+  if (!page) {
+    return { content: [{ type: 'text', text: `Error: Tab ${tabId} not found` }], isError: true };
+  }
+
+  try {
+    await withTimeout(
+      page.evaluate(elementPickInstallExpression()),
+      5000,
+      'element_pick.install',
+      context,
+    );
+
+    if (action === 'cancel') {
+      const canceled = await withTimeout(
+        page.evaluate(`window.__openchromeElementPick && window.__openchromeElementPick.cancel('cancelled')`),
+        5000,
+        'element_pick.cancel',
+        context,
+      ) as ElementPickOverlayResult | null;
+      const payload = (canceled && typeof canceled === 'object') ? canceled : { success: true, canceled: false };
+      return jsonResult(payload);
+    }
+
+    const overlayResult = await withTimeout(
+      page.evaluate(`window.__openchromeElementPick.startAsync({ timeoutMs: ${timeoutMs} })`),
+      timeoutMs + 1000,
+      'element_pick.start',
+      context,
+    ) as ElementPickOverlayResult;
+
+    if (!overlayResult || overlayResult.success !== true || !('element' in overlayResult)) {
+      return jsonResult(overlayResult ?? { success: false, error: 'unknown' }, true);
+    }
+
+    const picked = buildPickedElement(overlayResult.element);
+    return jsonResult({ success: true, element: picked });
+  } catch (error) {
+    throwIfAborted(context);
+    return {
+      content: [{ type: 'text', text: `element_pick error: ${error instanceof Error ? error.message : String(error)}` }],
+      isError: true,
+    };
+  }
+};
+
+function normalizeTimeout(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 60000;
+  return Math.max(1, Math.min(300000, Math.floor(value)));
+}
+
+function jsonResult(payload: object, isError = false): MCPResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload) }],
+    structuredContent: payload as Record<string, unknown>,
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+export function registerElementPickTool(server: MCPServer): void {
+  server.registerTool('element_pick', handler, definition);
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -148,6 +148,7 @@ import { getPerfTraceStore } from '../core/performance/insights/trace-store';
 import { isContractRuntimeEnabled, isProxyHookEnabled, isSkillReplayEnabled, isTruthy } from '../harness/flags';
 // oc_observe (#866) — deterministic actionable-element enumeration
 import { registerOcObserveTool } from './oc-observe';
+import { registerElementPickTool } from './element-pick';
 // DevTools URL tool (#860) — expose Chrome DevTools inspector URLs
 import { registerOcDevToolsUrlTool } from './oc-devtools-url';
 // Portable context envelope (#873) — export/import surface
@@ -219,6 +220,7 @@ export const TOOL_CAPABILITY_MAP: Record<string, ToolCapability> = {
   oc_get_connection_info: 'core',
   oc_journal: 'core',
   oc_observe: 'core',
+  element_pick: 'core',
   oc_open_host_settings: 'core',
   oc_output_fetch: 'core',
   oc_performance_analyze: 'core',
@@ -571,6 +573,7 @@ export function registerAllTools(server: MCPServer): void {
   }
   // oc_observe (#866) — deterministic actionable-element enumeration
   registerOcObserveTool(proxy);
+  registerElementPickTool(proxy);
   // DevTools URL tool (#860) — gated by OPENCHROME_EXPOSE_DEVTOOLS_URL !== '0'
   registerOcDevToolsUrlTool(proxy);
   // Portable context envelope (#873) — oc_context_export / oc_context_import

--- a/src/types/tool-annotations.ts
+++ b/src/types/tool-annotations.ts
@@ -92,6 +92,7 @@ export const TOOL_ANNOTATIONS = {
   oc_devtools_url: READ_ONLY,
   oc_context_export: READ_ONLY,
   oc_observe: READ_ONLY,
+  element_pick: MUTATES,
   oc_performance_analyze: READ_ONLY,
   oc_normalize_action: READ_ONLY,
   oc_progress_status: READ_ONLY,

--- a/tests/core/element-picker/element-pick-tool.test.ts
+++ b/tests/core/element-picker/element-pick-tool.test.ts
@@ -1,0 +1,109 @@
+/// <reference types="jest" />
+
+import { createMockSessionManager } from '../../utils/mock-session';
+
+jest.mock('../../../src/session-manager', () => ({
+  getSessionManager: jest.fn(),
+}));
+
+import { getSessionManager } from '../../../src/session-manager';
+
+async function loadHandler(mockSessionManager: ReturnType<typeof createMockSessionManager>) {
+  jest.resetModules();
+  jest.doMock('../../../src/session-manager', () => ({
+    getSessionManager: () => mockSessionManager,
+  }));
+  const { registerElementPickTool } = await import('../../../src/tools/element-pick');
+  const tools = new Map<string, { handler: (sessionId: string, args: Record<string, unknown>) => Promise<any>; definition: any }>();
+  const server = {
+    registerTool: (name: string, handler: unknown, definition: unknown) => {
+      tools.set(name, { handler: handler as any, definition });
+    },
+  };
+  registerElementPickTool(server as any);
+  return tools.get('element_pick')!;
+}
+
+describe('element_pick tool (#899)', () => {
+  let mockSessionManager: ReturnType<typeof createMockSessionManager>;
+  let sessionId: string;
+  let tabId: string;
+
+  beforeEach(async () => {
+    mockSessionManager = createMockSessionManager();
+    (getSessionManager as jest.Mock).mockReturnValue(mockSessionManager);
+    sessionId = 'pick-session';
+    const target = await mockSessionManager.createTarget(sessionId, 'https://example.test');
+    tabId = target.targetId;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('registers start/cancel schema', async () => {
+    const { definition } = await loadHandler(mockSessionManager);
+    expect(definition.inputSchema.properties.action.enum).toEqual(['start', 'cancel']);
+    expect(definition.inputSchema.required).toEqual(['tabId']);
+  });
+
+  test('start installs overlay and returns a redacted PickedElement payload', async () => {
+    const { handler } = await loadHandler(mockSessionManager);
+    const page = mockSessionManager.pages.get(tabId)!;
+    (page.evaluate as jest.Mock)
+      .mockResolvedValueOnce({ success: true, installed: true })
+      .mockResolvedValueOnce({
+        success: true,
+        element: {
+          ancestry: [
+            { tagName: 'html', nthOfType: 1 },
+            { tagName: 'body', nthOfType: 1 },
+            { tagName: 'button', id: 'submit', nthOfType: 1 },
+          ],
+          role: 'button',
+          accessibleName: 'Submit',
+          text: 'Submit',
+          boundingBox: { x: 10, y: 20, width: 100, height: 30 },
+          viewport: { width: 300, height: 200 },
+          domSnippet: '<button id="submit" name="token" value="abc1234567890abcdef">Submit</button>',
+          computedStyle: { display: 'block', color: 'red', cursor: 'pointer' },
+          pageUrl: 'https://example.test',
+          pageTitle: 'Example',
+          pickedAt: 123,
+        },
+      });
+
+    const result = await handler(sessionId, { tabId, action: 'start', timeoutMs: 25 });
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0].text)).toEqual(result.structuredContent);
+    expect(result.structuredContent.element.selectors.cssPath).toContain('button#submit');
+    expect(result.structuredContent.element.domSnippet).toContain('[REDACTED]');
+    expect(result.structuredContent.element.computedStyle).toEqual({ display: 'block', cursor: 'pointer' });
+    expect(page.evaluate).toHaveBeenNthCalledWith(1, expect.stringContaining('__openchromeElementPick'));
+    expect(page.evaluate).toHaveBeenNthCalledWith(2, 'window.__openchromeElementPick.startAsync({ timeoutMs: 25 })');
+  });
+
+  test('cancel installs overlay controller and returns cancel result', async () => {
+    const { handler } = await loadHandler(mockSessionManager);
+    const page = mockSessionManager.pages.get(tabId)!;
+    (page.evaluate as jest.Mock)
+      .mockResolvedValueOnce({ success: true, installed: true })
+      .mockResolvedValueOnce({ success: true, canceled: true });
+
+    const result = await handler(sessionId, { tabId, action: 'cancel' });
+    expect(result.structuredContent).toEqual({ success: true, canceled: true });
+    expect(page.evaluate).toHaveBeenNthCalledWith(2, "window.__openchromeElementPick && window.__openchromeElementPick.cancel('cancelled')");
+  });
+
+  test('start failure is a structured tool error', async () => {
+    const { handler } = await loadHandler(mockSessionManager);
+    const page = mockSessionManager.pages.get(tabId)!;
+    (page.evaluate as jest.Mock)
+      .mockResolvedValueOnce({ success: true, installed: true })
+      .mockResolvedValueOnce({ success: false, error: 'timeout' });
+
+    const result = await handler(sessionId, { tabId, action: 'start', timeoutMs: 1 });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toEqual({ success: false, error: 'timeout' });
+  });
+});


### PR DESCRIPTION
## Summary
- Registers the first `element_pick` MCP tool surface for #899 with `start` and `cancel` actions.
- Makes the overlay source awaitable via `startAsync()` and returns recorder-normalized picked-element facts.
- Wires tool annotations, capability map, and tier config.
- Keeps persistence out of scope: this returns facts only and does not write skill memory.

Partial fix for #899.
Stacked on #1241.

## Verification
- npm test -- tests/core/element-picker/element-pick-tool.test.ts tests/core/element-picker/overlay-script.test.ts tests/core/element-picker/recorder.test.ts tests/unit/tool-annotations.test.ts --runInBand
- npm run build
- npm run lint:tier
- git diff --check

## Follow-ups
- Live Chrome E2E with synthetic click and CSP fixture.
- Navigation/target-destroy cancellation wiring.
- CDP screenshot clipping and backend nodeRef enrichment.
