### PR TITLE
fix(element-picker): return navigated on picker navigation cancel

### DIFF
--- a/src/tools/element-pick.ts
+++ b/src/tools/element-pick.ts
@@ -72,12 +72,7 @@ const handler: ToolHandler = async (sessionId: string, args: Record<string, unkn
       return jsonResult(payload);
     }
 
-    const overlayResult = await withTimeout(
-      page.evaluate(`window.__openchromeElementPick.startAsync({ timeoutMs: ${timeoutMs} })`),
-      timeoutMs + 1000,
-      'element_pick.start',
-      context,
-    ) as ElementPickOverlayResult;
+    const overlayResult = await startElementPick(page, timeoutMs, context);
 
     if (!overlayResult || overlayResult.success !== true || !('element' in overlayResult)) {
       return jsonResult(overlayResult ?? { success: false, error: 'unknown' }, true);
@@ -105,6 +100,53 @@ function jsonResult(payload: object, isError = false): MCPResult {
     structuredContent: payload as Record<string, unknown>,
     ...(isError ? { isError: true } : {}),
   };
+}
+
+async function startElementPick(page: any, timeoutMs: number, context?: ToolContext): Promise<ElementPickOverlayResult> {
+  let cleanupNavigationListener = () => {};
+  const navigationResult = new Promise<ElementPickFailure>((resolve) => {
+    const onFrameNavigated = (frame: unknown) => {
+      if (!isMainFrameNavigation(page, frame)) return;
+      cleanupNavigationListener();
+      resolve({ success: false, error: 'navigated' });
+    };
+    page.on?.('framenavigated', onFrameNavigated);
+    cleanupNavigationListener = () => {
+      page.off?.('framenavigated', onFrameNavigated);
+    };
+  });
+
+  const overlayResult = withTimeout(
+    page.evaluate(`window.__openchromeElementPick.startAsync({ timeoutMs: ${timeoutMs} })`),
+    timeoutMs + 1000,
+    'element_pick.start',
+    context,
+  ).catch((error) => {
+    if (isNavigationAbort(error)) {
+      return { success: false, error: 'navigated' };
+    }
+    throw error;
+  }) as Promise<ElementPickOverlayResult>;
+
+  try {
+    return await Promise.race([overlayResult, navigationResult]);
+  } finally {
+    cleanupNavigationListener();
+  }
+}
+
+function isMainFrameNavigation(page: any, frame: unknown): boolean {
+  try {
+    const mainFrame = typeof page.mainFrame === 'function' ? page.mainFrame() : undefined;
+    return !mainFrame || frame === mainFrame;
+  } catch {
+    return true;
+  }
+}
+
+function isNavigationAbort(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /execution context was destroyed|cannot find context|frame was detached|navigation|target closed/i.test(message);
 }
 
 export function registerElementPickTool(server: MCPServer): void {

--- a/tests/core/element-picker/element-pick-tool.test.ts
+++ b/tests/core/element-picker/element-pick-tool.test.ts
@@ -106,4 +106,44 @@ describe('element_pick tool (#899)', () => {
     expect(result.isError).toBe(true);
     expect(result.structuredContent).toEqual({ success: false, error: 'timeout' });
   });
+
+  test('start returns navigated when the main frame navigates before a pick resolves', async () => {
+    const { handler } = await loadHandler(mockSessionManager);
+    const page = mockSessionManager.pages.get(tabId)!;
+    const mainFrame = { url: jest.fn().mockReturnValue('https://example.test/next') };
+    let frameNavigated: ((frame: unknown) => void) | undefined;
+
+    (page.mainFrame as jest.Mock).mockReturnValue(mainFrame);
+    (page.on as jest.Mock).mockImplementation((event: string, listener: (frame: unknown) => void) => {
+      if (event === 'framenavigated') frameNavigated = listener;
+      return page;
+    });
+    (page.off as jest.Mock).mockImplementation((event: string, listener: (frame: unknown) => void) => {
+      if (event === 'framenavigated' && frameNavigated === listener) frameNavigated = undefined;
+      return page;
+    });
+    (page.evaluate as jest.Mock)
+      .mockResolvedValueOnce({ success: true, installed: true })
+      .mockImplementationOnce(() => new Promise(() => {
+        setTimeout(() => frameNavigated?.(mainFrame), 0);
+      }));
+
+    const result = await handler(sessionId, { tabId, action: 'start', timeoutMs: 25 });
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toEqual({ success: false, error: 'navigated' });
+    expect(page.off).toHaveBeenCalledWith('framenavigated', expect.any(Function));
+  });
+
+  test('start maps execution-context navigation failures to a structured navigated error', async () => {
+    const { handler } = await loadHandler(mockSessionManager);
+    const page = mockSessionManager.pages.get(tabId)!;
+    (page.evaluate as jest.Mock)
+      .mockResolvedValueOnce({ success: true, installed: true })
+      .mockRejectedValueOnce(new Error('Execution context was destroyed, most likely because of a navigation.'));
+
+    const result = await handler(sessionId, { tabId, action: 'start', timeoutMs: 25 });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toEqual({ success: false, error: 'navigated' });
+  });
 });


### PR DESCRIPTION
## Summary
- return a structured `{ success: false, error: "navigated" }` result when main-frame navigation interrupts an active `element_pick`
- map Puppeteer execution-context/navigation aborts to the same stable picker failure contract
- add regression coverage for both event-race and execution-context-destroyed paths

## Validation
- npm test -- tests/core/element-picker/element-pick-tool.test.ts tests/core/element-picker/overlay-script.test.ts tests/core/element-picker/recorder.test.ts --runInBand
- npm run build
- npm run lint:tier
- git diff --check

Stacked on #1242. Part of #899.
