### PR TITLE
fix(element-picker): gate picker registration for byte parity

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -573,7 +573,11 @@ export function registerAllTools(server: MCPServer): void {
   }
   // oc_observe (#866) — deterministic actionable-element enumeration
   registerOcObserveTool(proxy);
-  registerElementPickTool(proxy);
+  // element_pick (#899) — default-on for deterministic clients, but allow
+  // strict byte-parity operators to suppress it from tools/list.
+  if (process.env.OPENCHROME_ELEMENT_PICK !== '0') {
+    registerElementPickTool(proxy);
+  }
   // DevTools URL tool (#860) — gated by OPENCHROME_EXPOSE_DEVTOOLS_URL !== '0'
   registerOcDevToolsUrlTool(proxy);
   // Portable context envelope (#873) — oc_context_export / oc_context_import

--- a/tests/capability-filter.test.ts
+++ b/tests/capability-filter.test.ts
@@ -81,13 +81,20 @@ async function getToolNames(server: MCPServer): Promise<string[]> {
 
 describe('capability-filter: default surface (P2 compliance)', () => {
   let server: MCPServer;
+  const originalElementPickFlag = process.env.OPENCHROME_ELEMENT_PICK;
 
   beforeEach(() => {
+    process.env.OPENCHROME_ELEMENT_PICK = '0';
     server = makeServer();
     registerAllTools(server);
   });
 
   afterEach(() => {
+    if (originalElementPickFlag === undefined) {
+      delete process.env.OPENCHROME_ELEMENT_PICK;
+    } else {
+      process.env.OPENCHROME_ELEMENT_PICK = originalElementPickFlag;
+    }
     jest.clearAllMocks();
   });
 

--- a/tests/tools/element-pick-registration.test.ts
+++ b/tests/tools/element-pick-registration.test.ts
@@ -1,0 +1,55 @@
+/// <reference types="jest" />
+
+import { createMockSessionManager } from '../utils/mock-session';
+
+jest.mock('../../src/cdp/client', () => ({
+  getCDPClient: jest.fn(() => ({
+    forceReconnect: jest.fn().mockResolvedValue(undefined),
+    isConnected: jest.fn().mockReturnValue(false),
+  })),
+}));
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(),
+}));
+
+import { getSessionManager } from '../../src/session-manager';
+import { MCPServer } from '../../src/mcp-server';
+import { registerAllTools } from '../../src/tools';
+
+describe('element_pick registration gate (#899)', () => {
+  const originalFlag = process.env.OPENCHROME_ELEMENT_PICK;
+
+  afterEach(() => {
+    if (originalFlag === undefined) {
+      delete process.env.OPENCHROME_ELEMENT_PICK;
+    } else {
+      process.env.OPENCHROME_ELEMENT_PICK = originalFlag;
+    }
+    jest.clearAllMocks();
+  });
+
+  test('registers element_pick by default', () => {
+    delete process.env.OPENCHROME_ELEMENT_PICK;
+    const server = makeServer();
+
+    registerAllTools(server);
+
+    expect(server.getToolNames()).toContain('element_pick');
+  });
+
+  test('suppresses element_pick when OPENCHROME_ELEMENT_PICK=0', () => {
+    process.env.OPENCHROME_ELEMENT_PICK = '0';
+    const server = makeServer();
+
+    registerAllTools(server);
+
+    expect(server.getToolNames()).not.toContain('element_pick');
+  });
+});
+
+function makeServer(): MCPServer {
+  const mockSessionManager = createMockSessionManager();
+  (getSessionManager as jest.Mock).mockReturnValue(mockSessionManager);
+  return new MCPServer(mockSessionManager as any);
+}


### PR DESCRIPTION
## Summary
- keep `element_pick` registered by default
- allow strict v1.11 tools/list byte-parity with `OPENCHROME_ELEMENT_PICK=0`
- add registration-gate tests and keep the v1.11 capability snapshot test running under the off-switch

## Validation
- npm test -- tests/capability-filter.test.ts tests/tools/element-pick-registration.test.ts tests/core/element-picker/element-pick-tool.test.ts --runInBand
- npm run build
- npm run lint:tier
- git diff --check

Stacked on #1243. Part of #899.
