### PR TITLE
fix(element-picker): return no-human error in headless mode

### DIFF
--- a/src/tools/element-pick.ts
+++ b/src/tools/element-pick.ts
@@ -4,6 +4,7 @@ import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { withTimeout } from '../utils/with-timeout';
 import { buildPickedElement, elementPickInstallExpression, type ElementPickRecorderInput } from '../core/element-picker';
+import { getGlobalConfig } from '../config/global';
 
 interface ElementPickSuccess {
   success: true;
@@ -45,6 +46,13 @@ const handler: ToolHandler = async (sessionId: string, args: Record<string, unkn
   }
   if (action !== 'start' && action !== 'cancel') {
     return { content: [{ type: 'text', text: 'Error: action must be "start" or "cancel"' }], isError: true };
+  }
+  if (action === 'start' && getGlobalConfig().headless === true) {
+    return jsonResult({
+      success: false,
+      error: 'no_human_attached',
+      remediation: 'Run openchrome without --server-mode or --headless so a human can click the in-page picker overlay.',
+    }, true);
   }
 
   const sessionManager = getSessionManager();

--- a/tests/core/element-picker/element-pick-tool.test.ts
+++ b/tests/core/element-picker/element-pick-tool.test.ts
@@ -107,6 +107,23 @@ describe('element_pick tool (#899)', () => {
     expect(result.structuredContent).toEqual({ success: false, error: 'timeout' });
   });
 
+  test('start returns no_human_attached in headless mode', async () => {
+    const { handler } = await loadHandler(mockSessionManager);
+    const { setGlobalConfig } = await import('../../../src/config/global');
+    setGlobalConfig({ headless: true });
+    const page = mockSessionManager.pages.get(tabId)!;
+
+    const result = await handler(sessionId, { tabId, action: 'start', timeoutMs: 25 });
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toEqual({
+      success: false,
+      error: 'no_human_attached',
+      remediation: expect.stringContaining('without --server-mode'),
+    });
+    expect(page.evaluate).not.toHaveBeenCalled();
+  });
+
   test('start returns navigated when the main frame navigates before a pick resolves', async () => {
     const { handler } = await loadHandler(mockSessionManager);
     const page = mockSessionManager.pages.get(tabId)!;


### PR DESCRIPTION
## Summary
- return structured `{ success: false, error: "no_human_attached" }` for `element_pick start` when OpenChrome is headless/server-mode-derived
- include remediation text telling operators to run without `--server-mode`/`--headless`
- avoid injecting the interactive overlay when no human can click it

## Validation
- npm test -- tests/core/element-picker/element-pick-tool.test.ts tests/tools/element-pick-registration.test.ts --runInBand
- npm run build
- npm run lint:tier
- git diff --check

Stacked on #1244. Part of #899.
