### PR TITLE
fix(element-picker): cancel picks when target closes

### DIFF
--- a/src/tools/element-pick.ts
+++ b/src/tools/element-pick.ts
@@ -111,16 +111,22 @@ function jsonResult(payload: object, isError = false): MCPResult {
 }
 
 async function startElementPick(page: any, timeoutMs: number, context?: ToolContext): Promise<ElementPickOverlayResult> {
-  let cleanupNavigationListener = () => {};
-  const navigationResult = new Promise<ElementPickFailure>((resolve) => {
+  let cleanupLifecycleListeners = () => {};
+  const lifecycleResult = new Promise<ElementPickFailure>((resolve) => {
     const onFrameNavigated = (frame: unknown) => {
       if (!isMainFrameNavigation(page, frame)) return;
-      cleanupNavigationListener();
+      cleanupLifecycleListeners();
       resolve({ success: false, error: 'navigated' });
     };
+    const onTargetClosed = () => {
+      cleanupLifecycleListeners();
+      resolve({ success: false, error: 'target_destroyed' });
+    };
     page.on?.('framenavigated', onFrameNavigated);
-    cleanupNavigationListener = () => {
+    page.on?.('close', onTargetClosed);
+    cleanupLifecycleListeners = () => {
       page.off?.('framenavigated', onFrameNavigated);
+      page.off?.('close', onTargetClosed);
     };
   });
 
@@ -130,6 +136,9 @@ async function startElementPick(page: any, timeoutMs: number, context?: ToolCont
     'element_pick.start',
     context,
   ).catch((error) => {
+    if (isTargetDestroyedAbort(error)) {
+      return { success: false, error: 'target_destroyed' };
+    }
     if (isNavigationAbort(error)) {
       return { success: false, error: 'navigated' };
     }
@@ -137,9 +146,9 @@ async function startElementPick(page: any, timeoutMs: number, context?: ToolCont
   }) as Promise<ElementPickOverlayResult>;
 
   try {
-    return await Promise.race([overlayResult, navigationResult]);
+    return await Promise.race([overlayResult, lifecycleResult]);
   } finally {
-    cleanupNavigationListener();
+    cleanupLifecycleListeners();
   }
 }
 
@@ -154,7 +163,12 @@ function isMainFrameNavigation(page: any, frame: unknown): boolean {
 
 function isNavigationAbort(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return /execution context was destroyed|cannot find context|frame was detached|navigation|target closed/i.test(message);
+  return /execution context was destroyed|cannot find context|frame was detached|navigation/i.test(message);
+}
+
+function isTargetDestroyedAbort(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /target closed|session closed|target destroyed|page closed/i.test(message);
 }
 
 export function registerElementPickTool(server: MCPServer): void {

--- a/tests/core/element-picker/element-pick-tool.test.ts
+++ b/tests/core/element-picker/element-pick-tool.test.ts
@@ -152,6 +152,32 @@ describe('element_pick tool (#899)', () => {
     expect(page.off).toHaveBeenCalledWith('framenavigated', expect.any(Function));
   });
 
+  test('start returns target_destroyed when the page closes before a pick resolves', async () => {
+    const { handler } = await loadHandler(mockSessionManager);
+    const page = mockSessionManager.pages.get(tabId)!;
+    let closeListener: (() => void) | undefined;
+
+    (page.on as jest.Mock).mockImplementation((event: string, listener: () => void) => {
+      if (event === 'close') closeListener = listener;
+      return page;
+    });
+    (page.off as jest.Mock).mockImplementation((event: string, listener: () => void) => {
+      if (event === 'close' && closeListener === listener) closeListener = undefined;
+      return page;
+    });
+    (page.evaluate as jest.Mock)
+      .mockResolvedValueOnce({ success: true, installed: true })
+      .mockImplementationOnce(() => new Promise(() => {
+        setTimeout(() => closeListener?.(), 0);
+      }));
+
+    const result = await handler(sessionId, { tabId, action: 'start', timeoutMs: 25 });
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toEqual({ success: false, error: 'target_destroyed' });
+    expect(page.off).toHaveBeenCalledWith('close', expect.any(Function));
+  });
+
   test('start maps execution-context navigation failures to a structured navigated error', async () => {
     const { handler } = await loadHandler(mockSessionManager);
     const page = mockSessionManager.pages.get(tabId)!;
@@ -162,5 +188,17 @@ describe('element_pick tool (#899)', () => {
     const result = await handler(sessionId, { tabId, action: 'start', timeoutMs: 25 });
     expect(result.isError).toBe(true);
     expect(result.structuredContent).toEqual({ success: false, error: 'navigated' });
+  });
+
+  test('start maps target closure failures to a structured target_destroyed error', async () => {
+    const { handler } = await loadHandler(mockSessionManager);
+    const page = mockSessionManager.pages.get(tabId)!;
+    (page.evaluate as jest.Mock)
+      .mockResolvedValueOnce({ success: true, installed: true })
+      .mockRejectedValueOnce(new Error('Target closed'));
+
+    const result = await handler(sessionId, { tabId, action: 'start', timeoutMs: 25 });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toEqual({ success: false, error: 'target_destroyed' });
   });
 });


### PR DESCRIPTION
## Summary
- race active `element_pick start` calls against page `close` lifecycle events
- map target/page/session closure errors to structured `{ success: false, error: "target_destroyed" }`
- keep navigation cancellation distinct from target destruction

## Validation
- npm test -- tests/core/element-picker/element-pick-tool.test.ts --runInBand
- npm run build
- npm run lint:tier
- git diff --check

Stacked on #1245. Part of #899.
