### PR TITLE
fix(element-picker): capture clipped screenshots for picks

### DIFF
--- a/src/tools/element-pick.ts
+++ b/src/tools/element-pick.ts
@@ -3,7 +3,13 @@ import { MCPToolDefinition, MCPResult, ToolContext, ToolHandler, throwIfAborted 
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { withTimeout } from '../utils/with-timeout';
-import { buildPickedElement, elementPickInstallExpression, type ElementPickRecorderInput } from '../core/element-picker';
+import {
+  buildPickedElement,
+  clampBoundingBox,
+  elementPickInstallExpression,
+  validateScreenshotPng,
+  type ElementPickRecorderInput,
+} from '../core/element-picker';
 import { getGlobalConfig } from '../config/global';
 
 interface ElementPickSuccess {
@@ -86,7 +92,15 @@ const handler: ToolHandler = async (sessionId: string, args: Record<string, unkn
       return jsonResult(overlayResult ?? { success: false, error: 'unknown' }, true);
     }
 
-    const picked = buildPickedElement(overlayResult.element);
+    const screenshot = await captureElementScreenshot(page, overlayResult.element, context);
+    if (screenshot && !screenshot.success) {
+      return jsonResult(screenshot, true);
+    }
+
+    const picked = buildPickedElement({
+      ...overlayResult.element,
+      ...(screenshot?.screenshotPng ? { screenshotPng: screenshot.screenshotPng } : {}),
+    });
     return jsonResult({ success: true, element: picked });
   } catch (error) {
     throwIfAborted(context);
@@ -169,6 +183,57 @@ function isNavigationAbort(error: unknown): boolean {
 function isTargetDestroyedAbort(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return /target closed|session closed|target destroyed|page closed/i.test(message);
+}
+
+async function captureElementScreenshot(
+  page: any,
+  element: ElementPickRecorderInput,
+  context?: ToolContext,
+): Promise<{ success: true; screenshotPng?: string } | ElementPickFailure> {
+  const clip = clampBoundingBox(element.boundingBox, element.viewport);
+  if (clip.width <= 0 || clip.height <= 0) {
+    return { success: true };
+  }
+
+  let session: { send: (method: string, params?: unknown) => Promise<unknown>; detach?: () => Promise<void> } | undefined;
+  try {
+    session = await withTimeout(
+      page.createCDPSession(),
+      5000,
+      'element_pick.screenshot_session',
+      context,
+    ) as typeof session;
+    if (!session) return { success: true };
+    const response = await withTimeout(
+      session.send('Page.captureScreenshot', {
+        format: 'png',
+        clip: {
+          x: clip.x,
+          y: clip.y,
+          width: clip.width,
+          height: clip.height,
+          scale: 1,
+        },
+      }),
+      5000,
+      'element_pick.screenshot',
+      context,
+    ) as { data?: string } | undefined;
+    const data = response?.data;
+    if (!data) return { success: true };
+    const validation = validateScreenshotPng(data);
+    if (!validation.ok) {
+      return { success: false, error: validation.error ?? 'snapshot_too_large' };
+    }
+    return { success: true, screenshotPng: data };
+  } finally {
+    try {
+      await session?.detach?.();
+    } catch {
+      // Best effort cleanup only; screenshot capture should not fail after a
+      // successful pick just because the temporary CDP session already closed.
+    }
+  }
 }
 
 export function registerElementPickTool(server: MCPServer): void {

--- a/tests/core/element-picker/element-pick-tool.test.ts
+++ b/tests/core/element-picker/element-pick-tool.test.ts
@@ -50,6 +50,8 @@ describe('element_pick tool (#899)', () => {
   test('start installs overlay and returns a redacted PickedElement payload', async () => {
     const { handler } = await loadHandler(mockSessionManager);
     const page = mockSessionManager.pages.get(tabId)!;
+    const cdpSession = await page.createCDPSession();
+    (cdpSession.send as jest.Mock).mockResolvedValueOnce({ data: Buffer.from('png').toString('base64') });
     (page.evaluate as jest.Mock)
       .mockResolvedValueOnce({ success: true, installed: true })
       .mockResolvedValueOnce({
@@ -79,8 +81,42 @@ describe('element_pick tool (#899)', () => {
     expect(result.structuredContent.element.selectors.cssPath).toContain('button#submit');
     expect(result.structuredContent.element.domSnippet).toContain('[REDACTED]');
     expect(result.structuredContent.element.computedStyle).toEqual({ display: 'block', cursor: 'pointer' });
+    expect(result.structuredContent.element.screenshotPng).toBe(Buffer.from('png').toString('base64'));
     expect(page.evaluate).toHaveBeenNthCalledWith(1, expect.stringContaining('__openchromeElementPick'));
     expect(page.evaluate).toHaveBeenNthCalledWith(2, 'window.__openchromeElementPick.startAsync({ timeoutMs: 25 })');
+    expect(cdpSession.send).toHaveBeenCalledWith('Page.captureScreenshot', {
+      format: 'png',
+      clip: { x: 2, y: 12, width: 116, height: 46, scale: 1 },
+    });
+    expect(cdpSession.detach).toHaveBeenCalled();
+  });
+
+  test('start returns snapshot_too_large when the clipped screenshot exceeds the cap', async () => {
+    const { handler } = await loadHandler(mockSessionManager);
+    const page = mockSessionManager.pages.get(tabId)!;
+    const cdpSession = await page.createCDPSession();
+    (cdpSession.send as jest.Mock).mockResolvedValueOnce({
+      data: Buffer.alloc((200 * 1024) + 1).toString('base64'),
+    });
+    (page.evaluate as jest.Mock)
+      .mockResolvedValueOnce({ success: true, installed: true })
+      .mockResolvedValueOnce({
+        success: true,
+        element: {
+          ancestry: [{ tagName: 'button', nthOfType: 1 }],
+          boundingBox: { x: 0, y: 0, width: 10, height: 10 },
+          viewport: { width: 100, height: 100 },
+          domSnippet: '<button>Submit</button>',
+          pageUrl: 'https://example.test',
+          pageTitle: 'Example',
+        },
+      });
+
+    const result = await handler(sessionId, { tabId, action: 'start', timeoutMs: 25 });
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toEqual({ success: false, error: 'snapshot_too_large' });
+    expect(cdpSession.detach).toHaveBeenCalled();
   });
 
   test('cancel installs overlay controller and returns cancel result', async () => {


### PR DESCRIPTION
## Summary
- capture a clipped PNG via CDP `Page.captureScreenshot` after a successful `element_pick`
- use the recorder's bbox+8px clamp for clip dimensions and include `screenshotPng` in the returned `PickedElement`
- reject oversize captures with structured `{ success: false, error: "snapshot_too_large" }`
- detach the temporary CDP session after capture

## Validation
- npm test -- tests/core/element-picker/element-pick-tool.test.ts tests/core/element-picker/recorder.test.ts --runInBand
- npm run build
- npm run lint:tier
- git diff --check

Stacked on #1246. Part of #899.
