### PR TITLE
fix(element-picker): document backend node identity dependency

### DIFF
--- a/src/core/element-picker/recorder.ts
+++ b/src/core/element-picker/recorder.ts
@@ -31,6 +31,10 @@ export interface ScreenshotValidationResult {
 
 export function buildPickedElement(input: ElementPickRecorderInput): PickedElement {
   return {
+    // TODO(#844): populate these stable backend-node identity fields from the
+    // BackendNodeRegistry once the cross-snapshot nodeRef contract lands.
+    // Until then #899 intentionally returns null rather than inventing an
+    // unstable selector-derived identity.
     nodeRef: input.nodeRef ?? null,
     backendNodeId: input.backendNodeId ?? null,
     loaderId: input.loaderId ?? null,


### PR DESCRIPTION
## Summary
- document the temporary `nodeRef`/`backendNodeId`/`loaderId` null fallback while #844 remains open
- add an explicit TODO(#844) so future picker work wires `BackendNodeRegistry` identity instead of inventing unstable IDs

## Validation
- npm test -- tests/core/element-picker/recorder.test.ts tests/core/element-picker/element-pick-tool.test.ts --runInBand
- npm run build
- npm run lint:tier
- git diff --check

Stacked on #1247. Part of #899.
