### PR TITLE
test(element-picker): add live verification fixtures

### DIFF
--- a/scripts/verify/A5-element-pick.mjs
+++ b/scripts/verify/A5-element-pick.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * scripts/verify/A5-element-pick.mjs
+ *
+ * Reproducer plan for issue #899 (`element_pick`). It is intentionally
+ * dependency-free and prints the live MCP/CDP verification sequence unless an
+ * MCP transport is provided by a future harness.
+ *
+ * Usage:
+ *   node scripts/verify/A5-element-pick.mjs [--mcp-url ws://host:port]
+ */
+
+import { argv, env, exit, stderr, stdout } from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const args = argv.slice(2);
+const mcpUrl =
+  args.find((a) => a.startsWith('--mcp-url='))?.slice('--mcp-url='.length) ||
+  env.OPENCHROME_MCP_URL ||
+  '';
+
+const fixturePath = resolve(repoRoot, 'tests/fixtures/element-pick/index.html');
+const cspFixturePath = resolve(repoRoot, 'tests/fixtures/element-pick/csp-strict.html');
+
+const steps = [
+  {
+    n: 1,
+    description: `Serve or navigate to file://${fixturePath}`,
+    predicate: 'navigate succeeds and page title is Element Pick Fixture',
+  },
+  {
+    n: 2,
+    description: 'Call element_pick action=start timeoutMs=60000 and concurrently dispatch CDP mousePressed/mouseReleased at #pick-target center',
+    predicate: 'returns success=true with selectors.cssPath containing #pick-target and boundingBox width/height > 0',
+  },
+  {
+    n: 3,
+    description: 'Assert screenshotPng is base64 PNG evidence for bbox+8px clip',
+    predicate: 'screenshotPng decodes and is below 200KB',
+  },
+  {
+    n: 4,
+    description: 'Assert DOM redaction on fixture secret input when picked',
+    predicate: 'domSnippet never contains fixture-secret-token and contains [REDACTED]',
+  },
+  {
+    n: 5,
+    description: 'Start element_pick timeoutMs=1000 without clicking',
+    predicate: 'returns {success:false,error:"timeout"} after about 1s',
+  },
+  {
+    n: 6,
+    description: 'Start element_pick and concurrently navigate away from the same tab',
+    predicate: 'navigate returns within 5s and the in-flight pick returns {success:false,error:"navigated"}',
+  },
+  {
+    n: 7,
+    description: 'Start element_pick and concurrently call oc_journal plus oc_connection_health',
+    predicate: 'both calls return within 1s while the pick is pending',
+  },
+  {
+    n: 8,
+    description: `Navigate to CSP-strict fixture file://${cspFixturePath} and synthetic-click #csp-target`,
+    predicate: 'element_pick succeeds despite default-src none because injection uses CDP Runtime.evaluate',
+  },
+];
+
+function log(line = '') {
+  stderr.write(`${line}\n`);
+}
+
+async function main() {
+  log('# openchrome A5 reproducer — element_pick (#899)');
+  log(`# MCP URL: ${mcpUrl || '(none provided — printing plan only)'}`);
+  log('');
+
+  if (!mcpUrl) {
+    log('No --mcp-url given. This script stays runnable without adding a test dependency.');
+    log('Use it as the authoritative live verification checklist for #899.');
+    log('');
+    for (const step of steps) {
+      log(`Step ${step.n}: ${step.description}`);
+      log(`  Pass when: ${step.predicate}`);
+    }
+    exit(0);
+  }
+
+  log('Live MCP transport execution is not implemented in this dependency-free stub.');
+  log('Wire this sequence to the local MCP client harness when a reusable client is in scope.');
+  exit(0);
+}
+
+main().catch((error) => {
+  log(`fatal: ${error instanceof Error ? error.message : String(error)}`);
+  exit(1);
+});
+
+void stdout;

--- a/tests/fixtures/element-pick/csp-strict.html
+++ b/tests/fixtures/element-pick/csp-strict.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'" />
+  <title>Element Pick CSP Strict Fixture</title>
+  <style>
+    body { font-family: sans-serif; margin: 32px; }
+    #csp-target { display: inline-block; padding: 14px 20px; border: 1px solid #555; }
+  </style>
+</head>
+<body>
+  <h1>CSP Strict Element Pick Fixture</h1>
+  <div id="csp-target" role="button" aria-label="CSP pick target" data-testid="csp-pick-target">CSP Pick Target</div>
+</body>
+</html>

--- a/tests/fixtures/element-pick/index.html
+++ b/tests/fixtures/element-pick/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Element Pick Fixture</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 32px; }
+    #pick-target { display: inline-block; padding: 12px 18px; cursor: pointer; }
+    #secret-input { display: block; margin-top: 24px; }
+  </style>
+</head>
+<body>
+  <h1>Element Pick Fixture</h1>
+  <button id="pick-target" aria-label="Pick target action" data-testid="pick-target">Pick Target</button>
+  <input id="secret-input" name="api_token" value="fixture-secret-token" aria-label="Secret fixture input" />
+  <p id="status">ready</p>
+  <script>
+    document.getElementById('pick-target').addEventListener('click', () => {
+      document.getElementById('status').textContent = 'underlying click should be blocked by picker';
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `tests/fixtures/element-pick/index.html` and `csp-strict.html`
- add dependency-free `scripts/verify/A5-element-pick.mjs` reproducer checklist for the #899 live Chrome phases
- cover planned verification for synthetic click, timeout, navigation cancel, responsiveness, screenshot evidence, redaction, and CSP-strict injection

## Validation
- node scripts/verify/A5-element-pick.mjs
- npm run build
- npm run lint:tier
- git diff --check

Stacked on #1248. Part of #899.
