### PR TITLE
fix(element-picker): hint skill recording after picks

### DIFF
--- a/src/hints/hint-engine.ts
+++ b/src/hints/hint-engine.ts
@@ -48,6 +48,7 @@ export interface HintContext {
   isError: boolean;
   recentCalls: ToolCallEvent[];
   fireCounts: Map<string, number>;
+  currentArgs?: Record<string, unknown>;
   episodeContext?: FailureEpisodeContext;
 }
 
@@ -282,6 +283,7 @@ export class HintEngine {
       isError,
       recentCalls,
       fireCounts: this.hintEscalation,
+      currentArgs,
       episodeContext,
     };
 

--- a/src/hints/rules/success-hints.ts
+++ b/src/hints/rules/success-hints.ts
@@ -6,6 +6,20 @@ import type { HintRule } from '../hint-engine';
 
 export const successHintRules: HintRule[] = [
   {
+    name: 'element-pick-skill-record',
+    priority: 394,
+    match(ctx) {
+      if ((ctx.fireCounts.get('element-pick-skill-record') ?? 0) > 0) return null;
+      if (ctx.toolName !== 'interact') return null;
+      if (ctx.isError) return null;
+      const nodeRef = extractNodeRef(ctx.currentArgs);
+      if (!nodeRef) return null;
+      const recentPick = ctx.recentCalls.find((call) => call.toolName === 'element_pick' && call.result === 'success');
+      if (!recentPick) return null;
+      return `Hint: You just successfully interacted with nodeRef ${nodeRef} after an element_pick. Consider oc_skill_record with the picker output so this selector/AX context can seed skill memory.`;
+    },
+  },
+  {
     name: 'navigate-error-page',
     priority: 400,
     match(ctx) {
@@ -59,3 +73,19 @@ export const successHintRules: HintRule[] = [
     },
   },
 ];
+
+function extractNodeRef(args: Record<string, unknown> | undefined): string | null {
+  if (!args) return null;
+  for (const key of ['nodeRef', 'ref']) {
+    const value = args[key];
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  for (const key of ['target', 'element']) {
+    const value = args[key];
+    if (value && typeof value === 'object') {
+      const nested = (value as Record<string, unknown>).nodeRef ?? (value as Record<string, unknown>).ref;
+      if (typeof nested === 'string' && nested.trim()) return nested;
+    }
+  }
+  return null;
+}

--- a/tests/hints/hint-engine.test.ts
+++ b/tests/hints/hint-engine.test.ts
@@ -240,6 +240,24 @@ describe('HintEngine', () => {
       expect(hint?.hint).toContain('wait_for');
     });
 
+    it('should hint to record skill memory after element_pick followed by successful same-node interact', () => {
+      const tracker = makeTracker([
+        { toolName: 'element_pick', args: { tabId: 'tab-1', action: 'start' }, result: 'success' },
+      ]);
+      const engine = new HintEngine(tracker);
+      const result = makeResult('Clicked picked element successfully');
+      const hint = engine.getHint(
+        'interact',
+        result,
+        false,
+        'test',
+        { target: { nodeRef: 'bnr:loader-1:42' } },
+      );
+      expect(hint?.rule).toBe('element-pick-skill-record');
+      expect(hint?.hint).toContain('oc_skill_record');
+      expect(hint?.hint).toContain('bnr:loader-1:42');
+    });
+
     it('should hint after form submission', () => {
       const engine = new HintEngine(new ActivityTracker());
       const result = makeResult('Form submitted successfully');


### PR DESCRIPTION
## Summary
- expose `currentArgs` to hint rules
- add an element-picker success hint that nudges `oc_skill_record` after a recent `element_pick` is followed by a successful `interact` on a `nodeRef` target
- keep persistence explicit: the hint recommends recording, but the picker still never writes skills directly

## Validation
- npm test -- tests/hints/hint-engine.test.ts --runInBand
- npm run build
- npm run lint:tier
- git diff --check

Stacked on #1249. Part of #899.
