### PR TITLE
fix(security): gate cookie destruction with elicitation

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -708,6 +708,14 @@ export class MCPServer {
     });
   }
 
+  private getCurrentClientCapabilities(): { roots?: object; sampling?: object; elicitation?: object } {
+    const mcpSessionId = currentRequestContext()?.mcpSessionId;
+    if (mcpSessionId) {
+      return this.clientCapabilitiesBySession.get(mcpSessionId) ?? {};
+    }
+    return this.clientCapabilities;
+  }
+
   /**
    * Reject every pending server→client request. Called when the transport
    * tears down (HTTP DELETE / stdio EOF) so callers don't hang forever.
@@ -1815,6 +1823,8 @@ export class MCPServer {
           deadlineMs: DEFAULT_TOOL_EXECUTION_TIMEOUT_MS,
           signal,
           principal,
+          clientCapabilities: this.getCurrentClientCapabilities(),
+          requestClient: this.requestFromClient.bind(this),
           reportProgress,
         };
         let tid: ReturnType<typeof setTimeout>;
@@ -1853,6 +1863,8 @@ export class MCPServer {
               deadlineMs: DEFAULT_TOOL_EXECUTION_TIMEOUT_MS,
               signal,
               principal,
+              clientCapabilities: this.getCurrentClientCapabilities(),
+              requestClient: this.requestFromClient.bind(this),
               reportProgress,
             };
             let tid2: ReturnType<typeof setTimeout>;
@@ -1897,6 +1909,8 @@ export class MCPServer {
               deadlineMs: DEFAULT_TOOL_EXECUTION_TIMEOUT_MS,
               signal,
               principal,
+              clientCapabilities: this.getCurrentClientCapabilities(),
+              requestClient: this.requestFromClient.bind(this),
               reportProgress,
             };
             result = await Promise.resolve(tool.handler(sessionId, substitutedArgs, swallowedRetryContext));

--- a/src/tools/cookies.ts
+++ b/src/tools/cookies.ts
@@ -3,7 +3,7 @@
  */
 
 import { MCPServer } from '../mcp-server';
-import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import { MCPToolDefinition, MCPResult, ToolContext, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { assertDomainAllowed } from '../security/domain-guard';
@@ -59,6 +59,98 @@ function formatCookiesCompact(cookies: any[]): string {
   }
 
   return sections.join('\n\n');
+}
+
+interface CookieElicitationDetails {
+  action: 'delete' | 'clear';
+  tabId: string;
+  name?: string;
+  domain?: string;
+  path?: string;
+  count?: number;
+  domains?: string[];
+}
+
+interface ElicitationResponse {
+  action?: string;
+  state?: string;
+  status?: string;
+  content?: { confirm?: boolean };
+}
+
+async function requireElicitationForDestructiveCookieAction(
+  context: ToolContext | undefined,
+  details: CookieElicitationDetails,
+): Promise<MCPResult | null> {
+  if (!context?.clientCapabilities?.elicitation || !context.requestClient) {
+    return null;
+  }
+
+  const requested = details.action === 'delete'
+    ? `delete cookie "${details.name}" for ${details.domain}${details.path ?? '/'}`
+    : `clear ${details.count ?? 0} cookie(s) across ${(details.domains ?? []).length} domain(s)`;
+
+  let response: ElicitationResponse;
+  try {
+    response = await context.requestClient<ElicitationResponse>(
+      'elicitation/create',
+      {
+        message: `Confirm destructive cookies action: ${requested}.`,
+        requestedSchema: {
+          type: 'object',
+          properties: {
+            confirm: {
+              type: 'boolean',
+              description: 'REQUIRED: true to allow this destructive cookies action.',
+            },
+          },
+          required: ['confirm'],
+        },
+        metadata: {
+          tool: 'cookies',
+          ...details,
+        },
+      },
+      { timeoutMs: 30_000, signal: context.signal },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const code = /timeout/i.test(message)
+      ? 'elicitation_timeout'
+      : context.signal?.aborted || /abort|closed|cancel/i.test(message)
+        ? 'user_cancelled'
+        : 'elicitation_failed';
+    const payload = {
+      success: false,
+      code,
+      error: code,
+      action: details.action,
+      message: `Destructive cookies action was not confirmed: ${message}`,
+    };
+    return {
+      content: [{ type: 'text', text: JSON.stringify(payload) }],
+      structuredContent: payload,
+      isError: true,
+    };
+  }
+
+  const decision = String(response.action ?? response.state ?? response.status ?? '').toLowerCase();
+  if (decision === 'accept' && response.content?.confirm === true) return null;
+
+  const code = decision === 'cancel' ? 'user_cancelled' : 'user_declined';
+
+  const payload = {
+    success: false,
+    code,
+    error: code,
+    action: details.action,
+    message: 'Destructive cookies action was not accepted by the client/user.',
+  };
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload) }],
+    structuredContent: payload,
+    isError: true,
+  };
 }
 
 const definition: MCPToolDefinition = {
@@ -126,7 +218,8 @@ const definition: MCPToolDefinition = {
 
 const handler: ToolHandler = async (
   sessionId: string,
-  args: Record<string, unknown>
+  args: Record<string, unknown>,
+  context?: ToolContext,
 ): Promise<MCPResult> => {
   const tabId = args.tabId as string;
   const action = args.action as string;
@@ -344,6 +437,15 @@ const handler: ToolHandler = async (
           };
         }
 
+        const confirmation = await requireElicitationForDestructiveCookieAction(context, {
+          action: 'delete',
+          tabId,
+          name,
+          domain: cookieToDelete.domain,
+          path: cookieToDelete.path,
+        });
+        if (confirmation) return confirmation;
+
         await page.deleteCookie(cookieToDelete);
 
         return {
@@ -393,6 +495,14 @@ const handler: ToolHandler = async (
             },
           };
         }
+
+        const confirmation = await requireElicitationForDestructiveCookieAction(context, {
+          action: 'clear',
+          tabId,
+          count: cookies.length,
+          domains: Array.from(new Set(cookies.map((c) => c.domain))).sort(),
+        });
+        if (confirmation) return confirmation;
 
         // Delete all cookies
         for (const cookie of cookies) {

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -185,6 +185,18 @@ export interface ToolContext {
   signal?: AbortSignal;
   /** Transport-authenticated caller principal. Not forgeable via tool args. */
   principal?: Principal;
+  /** Client capabilities advertised during initialize, scoped to this MCP session when known. */
+  clientCapabilities?: { roots?: object; sampling?: object; elicitation?: object };
+  /**
+   * Send a request back to the connected MCP client (for spec features such
+   * as roots, sampling, and elicitation). Tools must check clientCapabilities
+   * and provide a safe fallback when the relevant capability is absent.
+   */
+  requestClient?: <T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    options?: { timeoutMs?: number; signal?: AbortSignal },
+  ) => Promise<T>;
   /**
    * Emit a progress update for the in-flight tool call.
    *

--- a/tests/cli/admin-keys.test.ts
+++ b/tests/cli/admin-keys.test.ts
@@ -33,28 +33,6 @@ interface RunResult {
  * emits exactly one token, so a regex match is both sufficient and robust.
  */
 
-/**
- * Parse the CLI JSON payload from captured stdout while ignoring unrelated
- * Jest console-rendering noise that can be captured by the in-process stdout
- * hook when another timer logs in the same worker. The admin list command emits
- * one top-level array, so selecting the first complete JSON array preserves the
- * assertion that plaintext does not leak into the actual CLI JSON output.
- */
-function parseJsonArrayFromStdout<T>(stdout: string): T[] {
-  const start = stdout.indexOf('[');
-  if (start < 0) throw new Error(`No JSON array found in stdout: ${JSON.stringify(stdout)}`);
-  for (let end = stdout.length - 1; end >= start; end--) {
-    if (stdout[end] !== ']') continue;
-    const candidate = stdout.slice(start, end + 1);
-    try {
-      return JSON.parse(candidate) as T[];
-    } catch {
-      // Keep scanning left: prefixed Jest noise may contain bracketed labels.
-    }
-  }
-  throw new Error(`No parseable JSON array found in stdout: ${JSON.stringify(stdout)}`);
-}
-
 function extractToken(stdout: string): string {
   const m = stdout.match(/oc_live_[A-Za-z0-9_]+/);
   if (!m) throw new Error(`No oc_live_* token found in stdout: ${JSON.stringify(stdout)}`);

--- a/tests/unit/cookies-elicitation.test.ts
+++ b/tests/unit/cookies-elicitation.test.ts
@@ -1,0 +1,233 @@
+/// <reference types="jest" />
+
+import { registerCookiesTool } from '../../src/tools/cookies';
+import { getSessionManager } from '../../src/session-manager';
+import type { MCPResult, MCPToolDefinition, ToolContext, ToolHandler } from '../../src/types/mcp';
+
+jest.mock('../../src/session-manager', () => ({ getSessionManager: jest.fn() }));
+
+interface RegisteredTool {
+  name: string;
+  handler: ToolHandler;
+  definition: MCPToolDefinition;
+}
+
+class CapturingServer {
+  public tools = new Map<string, RegisteredTool>();
+
+  registerTool(name: string, handler: ToolHandler, definition: MCPToolDefinition): void {
+    this.tools.set(name, { name, handler, definition });
+  }
+}
+
+interface CookieRecord {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+}
+
+function collectCookiesHandler(): ToolHandler {
+  const server = new CapturingServer();
+  registerCookiesTool(server as unknown as Parameters<typeof registerCookiesTool>[0]);
+  return server.tools.get('cookies')!.handler;
+}
+
+function makePage(cookies: CookieRecord[]) {
+  return {
+    url: jest.fn(() => 'https://example.com/path'),
+    cookies: jest.fn().mockResolvedValue(cookies),
+    deleteCookie: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function mockSessionPage(page: ReturnType<typeof makePage>): void {
+  (getSessionManager as jest.Mock).mockReturnValue({
+    getPage: jest.fn().mockResolvedValue(page),
+  });
+}
+
+function parseResult(result: MCPResult): Record<string, unknown> {
+  return JSON.parse((result.content![0] as { text: string }).text) as Record<string, unknown>;
+}
+
+describe('cookies elicitation gate (#877)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('clear declines destructive mutation when client elicitation rejects it', async () => {
+    const handler = collectCookiesHandler();
+    const page = makePage([
+      { name: 'sid', value: '1', domain: 'example.com', path: '/' },
+      { name: 'prefs', value: 'dark', domain: 'example.com', path: '/' },
+    ]);
+    mockSessionPage(page);
+    const requestClient = jest.fn().mockResolvedValue({ action: 'decline' });
+
+    const result = await handler(
+      'session-1',
+      { tabId: 'tab-1', action: 'clear' },
+      {
+        startTime: Date.now(),
+        deadlineMs: 30_000,
+        clientCapabilities: { elicitation: {} },
+        requestClient,
+      } satisfies ToolContext,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      success: false,
+      code: 'user_declined',
+      error: 'user_declined',
+      action: 'clear',
+    });
+    expect(parseResult(result)).toMatchObject(result.structuredContent!);
+    expect(requestClient).toHaveBeenCalledWith(
+      'elicitation/create',
+      expect.objectContaining({
+        message: expect.stringContaining('clear 2 cookie(s)'),
+        metadata: expect.objectContaining({ tool: 'cookies', action: 'clear', tabId: 'tab-1', count: 2 }),
+      }),
+      expect.objectContaining({ timeoutMs: 30_000 }),
+    );
+    expect(page.deleteCookie).not.toHaveBeenCalled();
+  });
+
+  test('delete proceeds after client elicitation accepts it', async () => {
+    const handler = collectCookiesHandler();
+    const page = makePage([{ name: 'sid', value: '1', domain: 'example.com', path: '/' }]);
+    mockSessionPage(page);
+    const requestClient = jest.fn().mockResolvedValue({ action: 'accept', content: { confirm: true } });
+
+    const result = await handler(
+      'session-1',
+      { tabId: 'tab-1', action: 'delete', name: 'sid' },
+      {
+        startTime: Date.now(),
+        deadlineMs: 30_000,
+        clientCapabilities: { elicitation: {} },
+        requestClient,
+      } satisfies ToolContext,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(requestClient).toHaveBeenCalledWith(
+      'elicitation/create',
+      expect.objectContaining({
+        message: expect.stringContaining('delete cookie "sid"'),
+        metadata: expect.objectContaining({
+          tool: 'cookies',
+          action: 'delete',
+          tabId: 'tab-1',
+          name: 'sid',
+          domain: 'example.com',
+          path: '/',
+        }),
+      }),
+      expect.objectContaining({ timeoutMs: 30_000 }),
+    );
+    expect(page.deleteCookie).toHaveBeenCalledWith({ name: 'sid', domain: 'example.com', path: '/' });
+  });
+
+  test('cancel maps to a user_cancelled error without mutation', async () => {
+    const handler = collectCookiesHandler();
+    const page = makePage([{ name: 'sid', value: '1', domain: 'example.com', path: '/' }]);
+    mockSessionPage(page);
+    const requestClient = jest.fn().mockResolvedValue({ action: 'cancel' });
+
+    const result = await handler(
+      'session-1',
+      { tabId: 'tab-1', action: 'delete', name: 'sid' },
+      {
+        startTime: Date.now(),
+        deadlineMs: 30_000,
+        clientCapabilities: { elicitation: {} },
+        requestClient,
+      } satisfies ToolContext,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      code: 'user_cancelled',
+      error: 'user_cancelled',
+      action: 'delete',
+    });
+    expect(page.deleteCookie).not.toHaveBeenCalled();
+  });
+
+  test('elicitation timeout maps to elicitation_timeout without mutation', async () => {
+    const handler = collectCookiesHandler();
+    const page = makePage([{ name: 'sid', value: '1', domain: 'example.com', path: '/' }]);
+    mockSessionPage(page);
+    const requestClient = jest.fn().mockRejectedValue(new Error('s2c_timeout:elicitation/create'));
+
+    const result = await handler(
+      'session-1',
+      { tabId: 'tab-1', action: 'delete', name: 'sid' },
+      {
+        startTime: Date.now(),
+        deadlineMs: 30_000,
+        clientCapabilities: { elicitation: {} },
+        requestClient,
+      } satisfies ToolContext,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      code: 'elicitation_timeout',
+      error: 'elicitation_timeout',
+      action: 'delete',
+    });
+    expect(page.deleteCookie).not.toHaveBeenCalled();
+  });
+
+  test('legacy clients without elicitation capability keep the existing destructive path', async () => {
+    const handler = collectCookiesHandler();
+    const page = makePage([{ name: 'sid', value: '1', domain: 'example.com', path: '/' }]);
+    mockSessionPage(page);
+    const requestClient = jest.fn();
+
+    const result = await handler(
+      'session-1',
+      { tabId: 'tab-1', action: 'delete', name: 'sid' },
+      {
+        startTime: Date.now(),
+        deadlineMs: 30_000,
+        clientCapabilities: {},
+        requestClient,
+      } satisfies ToolContext,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(requestClient).not.toHaveBeenCalled();
+    expect(page.deleteCookie).toHaveBeenCalledWith({ name: 'sid', domain: 'example.com', path: '/' });
+  });
+
+  test('dryRun previews bypass elicitation and do not mutate cookies', async () => {
+    const handler = collectCookiesHandler();
+    const page = makePage([{ name: 'sid', value: '1', domain: 'example.com', path: '/' }]);
+    mockSessionPage(page);
+    const requestClient = jest.fn();
+
+    const result = await handler(
+      'session-1',
+      { tabId: 'tab-1', action: 'clear', dryRun: true },
+      {
+        startTime: Date.now(),
+        deadlineMs: 30_000,
+        clientCapabilities: { elicitation: {} },
+        requestClient,
+      } satisfies ToolContext,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(result.structuredContent).toMatchObject({
+      dryRun: true,
+      wouldAffect: expect.objectContaining({ count: 1 }),
+    });
+    expect(requestClient).not.toHaveBeenCalled();
+    expect(page.deleteCookie).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Pass per-session client capabilities and the server→client request primitive through `ToolContext`.
- Gate destructive `cookies delete` / `cookies clear` calls with `elicitation/create` when the client advertises elicitation support.
- Preserve legacy clients and `dryRun:true` behavior; add unit coverage for accept, decline, cancel, timeout, legacy, and dry-run paths.

## Validation
- `npm test -- tests/unit/cookies-elicitation.test.ts tests/unit/s2c-request.test.ts tests/unit/dry-run-destructive.test.ts --runInBand`
- `npm run build`
- `npm run lint:tier`
- `git diff --check`

## Notes
- First focused slice of #877 after #960 landed.
- Remaining #877 slices: storage, oc_stop, oc_reap_orphans, request_intercept, and audit-log coverage.

Refs #877
