### PR TITLE
feat(harness): add task-scoped browser lanes

### DIFF
--- a/src/core/browser-lanes.ts
+++ b/src/core/browser-lanes.ts
@@ -1,0 +1,164 @@
+/**
+ * Task-scoped browser lanes (#1037).
+ *
+ * A lane is deliberately a thin task-ledger overlay over existing
+ * SessionManager worker/target ownership. It does not create agent workers or
+ * new Chrome processes by itself; it allocates a deterministic worker id and
+ * records the targets that belong to that lane so hosts can keep parallel
+ * browser branches isolated.
+ */
+
+import crypto from 'node:crypto';
+
+import { getSessionManager } from '../session-manager';
+import { getTaskStore } from '../tools/oc-task-start';
+import type { BrowserLane, TaskMeta } from './task-ledger/types';
+
+const LANE_ID_RE = /^[a-z0-9][a-z0-9_-]{0,39}$/;
+
+export function assertLaneId(laneId: string): void {
+  if (!LANE_ID_RE.test(laneId)) {
+    throw new Error(`laneId ${JSON.stringify(laneId)} must match ${LANE_ID_RE}`);
+  }
+}
+
+export function makeLaneId(seed = crypto.randomUUID()): string {
+  return `lane_${crypto.createHash('sha256').update(seed).digest('hex').slice(0, 10)}`;
+}
+
+export function laneWorkerId(taskId: string, laneId: string): string {
+  assertLaneId(laneId);
+  return `task:${taskId}:lane:${laneId}`;
+}
+
+function cloneLane(lane: BrowserLane): BrowserLane {
+  return { ...lane, targetIds: [...lane.targetIds], counters: { ...lane.counters } };
+}
+
+export function getTaskLanes(meta: TaskMeta): BrowserLane[] {
+  return Array.isArray(meta.lanes) ? meta.lanes.map(cloneLane) : [];
+}
+
+export function findTaskLane(meta: TaskMeta, laneId: string): BrowserLane | undefined {
+  return getTaskLanes(meta).find((lane) => lane.lane_id === laneId);
+}
+
+export async function createBrowserLane(input: {
+  sessionId: string;
+  taskId: string;
+  name?: string;
+  purpose?: string;
+  initialUrl?: string;
+  budget?: unknown;
+}): Promise<BrowserLane> {
+  const { sessionId, taskId } = input;
+  const store = getTaskStore();
+  const meta = store.readMetaSync(taskId);
+  if (!meta) throw new Error(`unknown task ${taskId}`);
+  if (meta.owner?.session_id && meta.owner.session_id !== sessionId) {
+    throw new Error(`task ${taskId} is not visible in this session`);
+  }
+
+  const laneId = makeLaneId(crypto.randomUUID());
+  const now = Date.now();
+  const workerId = laneWorkerId(taskId, laneId);
+  const lane: BrowserLane = {
+    lane_id: laneId,
+    task_id: taskId,
+    ...(input.name ? { name: input.name } : {}),
+    ...(input.purpose ? { purpose: input.purpose } : {}),
+    status: 'open',
+    sessionId,
+    workerId,
+    targetIds: [],
+    created_at: now,
+    last_activity_at: now,
+    counters: { toolCalls: 0, failures: 0 },
+  };
+
+  if (input.initialUrl) {
+    const result = await getSessionManager().createTarget(sessionId, input.initialUrl, workerId);
+    lane.targetIds.push(result.targetId);
+    lane.workerId = result.workerId;
+  } else {
+    await getSessionManager().getOrCreateWorker(sessionId, workerId);
+  }
+
+  await store.update(taskId, (cur) => ({
+    ...cur,
+    lanes: [...getTaskLanes(cur).filter((existing) => existing.lane_id !== laneId), lane],
+    last_activity_at: now,
+  }));
+  store.appendEvent(taskId, { ts: now, kind: 'log', data: { event: 'lane_created', laneId, workerId, targetIds: lane.targetIds } });
+  return cloneLane(lane);
+}
+
+export function listBrowserLanes(taskId: string): BrowserLane[] {
+  const meta = getTaskStore().readMetaSync(taskId);
+  if (!meta) throw new Error(`unknown task ${taskId}`);
+  return getTaskLanes(meta);
+}
+
+export function getBrowserLane(taskId: string, laneId: string): BrowserLane {
+  assertLaneId(laneId);
+  const meta = getTaskStore().readMetaSync(taskId);
+  if (!meta) throw new Error(`unknown task ${taskId}`);
+  const lane = findTaskLane(meta, laneId);
+  if (!lane) throw new Error(`unknown lane ${laneId} for task ${taskId}`);
+  return lane;
+}
+
+export async function closeBrowserLane(taskId: string, laneId: string, sessionId: string): Promise<BrowserLane> {
+  const lane = getBrowserLane(taskId, laneId);
+  if (lane.sessionId !== sessionId) throw new Error(`lane ${laneId} is not visible in this session`);
+  const sm = getSessionManager();
+  for (const targetId of lane.targetIds) {
+    await sm.closeTarget(sessionId, targetId).catch(() => false);
+  }
+  const now = Date.now();
+  const closed: BrowserLane = { ...lane, status: 'closed', last_activity_at: now, targetIds: [] };
+  await getTaskStore().update(taskId, (cur) => ({
+    ...cur,
+    lanes: getTaskLanes(cur).map((existing) => existing.lane_id === laneId ? closed : existing),
+    last_activity_at: now,
+  }));
+  getTaskStore().appendEvent(taskId, { ts: now, kind: 'log', data: { event: 'lane_closed', laneId } });
+  return cloneLane(closed);
+}
+
+export function resolveLaneForTool(args: Record<string, unknown>): { taskId?: string; laneId?: string } {
+  const taskId = typeof args.taskId === 'string' ? args.taskId : typeof args.task_id === 'string' ? args.task_id : undefined;
+  const laneId = typeof args.laneId === 'string' ? args.laneId : typeof args.lane_id === 'string' ? args.lane_id : undefined;
+  return { taskId, laneId };
+}
+
+export function applyLaneTarget(args: Record<string, unknown>): Record<string, unknown> {
+  const { taskId, laneId } = resolveLaneForTool(args);
+  if (!taskId && !laneId) return args;
+  if (!taskId || !laneId) throw new Error('taskId and laneId must be supplied together');
+  const lane = getBrowserLane(taskId, laneId);
+  const tabId = typeof args.tabId === 'string' && args.tabId ? args.tabId : lane.targetIds[lane.targetIds.length - 1];
+  if (!tabId) throw new Error(`lane ${laneId} has no target; call oc_lane_create with initialUrl or navigate with taskId/laneId first`);
+  if (!lane.targetIds.includes(tabId)) throw new Error(`tabId ${tabId} does not belong to lane ${laneId}`);
+  return { ...args, tabId, workerId: lane.workerId };
+}
+
+export async function recordLaneToolCall(args: Record<string, unknown>, ok: boolean, targetId?: string): Promise<void> {
+  const { taskId, laneId } = resolveLaneForTool(args);
+  if (!taskId || !laneId) return;
+  const now = Date.now();
+  await getTaskStore().update(taskId, (cur) => ({
+    ...cur,
+    lanes: getTaskLanes(cur).map((lane) => {
+      if (lane.lane_id !== laneId) return lane;
+      const targetIds = targetId && !lane.targetIds.includes(targetId) ? [...lane.targetIds, targetId] : lane.targetIds;
+      return {
+        ...lane,
+        targetIds,
+        last_activity_at: now,
+        counters: { toolCalls: lane.counters.toolCalls + 1, failures: lane.counters.failures + (ok ? 0 : 1) },
+      };
+    }),
+    last_activity_at: now,
+  }));
+}

--- a/src/core/task-ledger/types.ts
+++ b/src/core/task-ledger/types.ts
@@ -106,6 +106,21 @@ export interface TaskOwner {
   mode?: string;
 }
 
+export interface BrowserLane {
+  lane_id: string;
+  task_id: string;
+  name?: string;
+  purpose?: string;
+  status: 'open' | 'closing' | 'closed' | 'failed';
+  sessionId: string;
+  workerId: string;
+  targetIds: string[];
+  created_at: number;
+  last_activity_at: number;
+  counters: { toolCalls: number; failures: number };
+  recovery?: 'target_missing';
+}
+
 export interface TaskMeta {
   /** 16-hex SHA-256(kind\x00args_json\x00created_at) */
   task_id: string;
@@ -137,6 +152,8 @@ export interface TaskMeta {
   budget_exceeded?: string[];
   recommended_next?: string;
   recent_events?: TaskRecentEvent[];
+  /** Task-scoped browser lanes owned by this task (#1037). */
+  lanes?: BrowserLane[];
   last_tool_name?: string;
   last_activity_at?: number;
 }

--- a/src/tools/__tests__/__snapshots__/tools-list.v1.11.snap.json
+++ b/src/tools/__tests__/__snapshots__/tools-list.v1.11.snap.json
@@ -208,6 +208,18 @@
       "name": "oc_stop"
     },
     {
+      "name": "oc_lane_close"
+    },
+    {
+      "name": "oc_lane_create"
+    },
+    {
+      "name": "oc_lane_get"
+    },
+    {
+      "name": "oc_lane_list"
+    },
+    {
       "name": "oc_task_cancel"
     },
     {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -133,6 +133,7 @@ import { registerOcTaskCancelTool } from './oc-task-cancel';
 import { registerOcTaskWaitTool } from './oc-task-wait';
 import { registerOcTaskUpdateTool } from './oc-task-update';
 import { registerOcTaskFinishTool } from './oc-task-finish';
+import { registerOcLaneTools } from './oc-lane';
 // Doctor report tool (#898) — read cached `openchrome doctor` output
 import { registerOcDoctorReportTool } from './oc-doctor-report';
 // Performance insights two-step API (#846)
@@ -320,6 +321,10 @@ export const TOOL_CAPABILITY_MAP: Record<string, ToolCapability> = {
   oc_task_cancel: 'core',
   oc_task_finish: 'core',
   oc_task_get: 'core',
+  oc_lane_create: 'core',
+  oc_lane_list: 'core',
+  oc_lane_get: 'core',
+  oc_lane_close: 'core',
   oc_task_list: 'core',
   oc_task_run_checkpoint: 'core',
   oc_task_run_complete: 'core',
@@ -545,6 +550,7 @@ export function registerAllTools(server: MCPServer): void {
   registerOcTaskWaitTool(server);
   registerOcTaskUpdateTool(server);
   registerOcTaskFinishTool(server);
+  registerOcLaneTools(server);
 
   // Reap any RUNNING task whose owner pid is no longer alive. Runs
   // once at server start (issue #855 invariant #2) so a crash on a

--- a/src/tools/interact.ts
+++ b/src/tools/interact.ts
@@ -33,6 +33,7 @@ import {
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { isPilotEnabled } from '../harness/flags';
 import { captureBackendNodeReplayStep, shouldCaptureReplayArtifact } from './_shared/replay-recorder';
+import { applyLaneTarget, recordLaneToolCall } from '../core/browser-lanes';
 import { appendReturnAfterState, parseReturnAfterState, RETURN_AFTER_STATE_SCHEMA } from './_shared/return-after-state';
 
 
@@ -76,6 +77,8 @@ const definition: MCPToolDefinition = {
         type: 'string',
         description: 'Tab ID to execute on',
       },
+      taskId: { type: 'string', description: 'Task id when using a task-scoped browser lane.' },
+      laneId: { type: 'string', description: 'Task-scoped browser lane id; validates tabId or defaults to the lane current target.' },
       query: {
         type: 'string',
         description: 'Element to act on (natural language). Required when mode is "ref" (default).',
@@ -152,7 +155,7 @@ const definition: MCPToolDefinition = {
         },
       },
     },
-    required: ['tabId'],
+
   },
 };
 
@@ -232,7 +235,9 @@ const coreHandler: ToolHandler = async (
   context?: ToolContext
 ): Promise<MCPResult> => {
   throwIfAborted(context);
-  const tabId = args.tabId as string;
+  let scopedArgs: Record<string, unknown>;
+  try { scopedArgs = applyLaneTarget(args); } catch (error) { return { content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }], isError: true }; }
+  const tabId = scopedArgs.tabId as string;
   const mode = (args.mode as string) || 'ref';
   const query = args.query as string;
   const coordinateArg = args.coordinate as Record<string, unknown> | undefined;
@@ -553,6 +558,7 @@ const coreHandler: ToolHandler = async (
 
   try {
     const page = await sessionManager.getPage(sessionId, tabId, undefined, 'interact');
+    await recordLaneToolCall(args, !!page, tabId);
     if (!page) {
       const available = await sessionManager.getAvailableTargets(sessionId);
       const availableInfo = available.length > 0

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -24,6 +24,7 @@ import { autoRecallForUrl } from '../core/skill-memory/auto-recall';
 import type { Page } from 'puppeteer-core';
 import { wrapMutatingHandler } from '../utils/snapshot-cache-helper';
 import { captureNavigationReplayStep, shouldCaptureReplayArtifact } from './_shared/replay-recorder';
+import { getBrowserLane, recordLaneToolCall, resolveLaneForTool } from '../core/browser-lanes';
 
 /** Blocking types that warrant automatic stealth retry (#459) */
 const RETRYABLE_BLOCK_TYPES: ReadonlySet<string> = new Set(['access-denied', 'bot-check', 'captcha']);
@@ -454,6 +455,8 @@ const definition: MCPToolDefinition = {
         type: 'string',
         description: 'Worker ID for parallel ops. Default: default',
       },
+      taskId: { type: 'string', description: 'Task id when routing through a task-scoped browser lane.' },
+      laneId: { type: 'string', description: 'Task-scoped browser lane id. When supplied with taskId, navigate uses/records the lane-owned target.' },
       stealth: {
         type: 'boolean',
         description: 'CDP-free mode: opens tab via Chrome debug API without CDP attachment during page load. Use for Cloudflare Turnstile or similar anti-bot pages. CDP attaches after page settles.',
@@ -495,7 +498,7 @@ const handler: ToolHandler = async (
   context?: ToolContext
 ): Promise<MCPResult> => {
   throwIfAborted(context);
-  const tabId = args.tabId as string | undefined;
+  let tabId = args.tabId as string | undefined;
   const url = args.url as string;
   const profileDirectory = args.profileDirectory as string | undefined;
   const recallArg = args.recall as boolean | undefined;
@@ -506,8 +509,28 @@ const handler: ToolHandler = async (
       isError: true,
     };
   }
-  // Auto-generate a profile-scoped workerId when profileDirectory is specified
-  const workerId = (args.workerId as string | undefined) || (profileDirectory ? `profile:${profileDirectory}` : undefined);
+  // Auto-generate a profile-scoped workerId when profileDirectory is specified.
+  // If taskId+laneId are supplied, route creation through the lane worker and
+  // default tabId to the lane's most recent target. This is additive: callers
+  // that omit laneId keep the existing worker/tab semantics.
+  const laneRef = resolveLaneForTool(args);
+  let laneWorkerId: string | undefined;
+  if (laneRef.taskId || laneRef.laneId) {
+    if (!laneRef.taskId || !laneRef.laneId) {
+      return { content: [{ type: 'text', text: 'Error: taskId and laneId must be supplied together' }], isError: true };
+    }
+    try {
+      const lane = getBrowserLane(laneRef.taskId, laneRef.laneId);
+      laneWorkerId = lane.workerId;
+      if (!tabId) tabId = lane.targetIds[lane.targetIds.length - 1];
+      if (tabId && !lane.targetIds.includes(tabId)) {
+        return { content: [{ type: 'text', text: `Error: tabId ${tabId} does not belong to lane ${laneRef.laneId}` }], isError: true };
+      }
+    } catch (error) {
+      return { content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+    }
+  }
+  const workerId = laneWorkerId || (args.workerId as string | undefined) || (profileDirectory ? `profile:${profileDirectory}` : undefined);
   const stealth = args.stealth as boolean | undefined;
   const stealthSettleMs = Math.min(Math.max((args.stealthSettleMs as number) || 8000, 1000), 30000);
   const autoFallback = args.autoFallback !== false; // default: true
@@ -660,6 +683,7 @@ const handler: ToolHandler = async (
               title: reuseTitle,
               tabId: existingTabId,
               workerId: resolvedWorkerId,
+              ...(laneRef.laneId ? { laneId: laneRef.laneId, taskId: laneRef.taskId } : {}),
               reused: true,
               elementCount: reuseElementCount,
               readiness: reuseReadiness,
@@ -670,6 +694,7 @@ const handler: ToolHandler = async (
               ...(reuseAuthGuidance ?? {}),
               ...(reuseDomainSkills !== undefined && { domain_skills: reuseDomainSkills }),
             });
+            await recordLaneToolCall(args, true, existingTabId);
             return {
               content: [{ type: 'text', text: reuseResultText }],
             };
@@ -732,6 +757,7 @@ const handler: ToolHandler = async (
         title: newTabTitle,
         tabId: targetId,
         workerId: assignedWorkerId,
+        ...(laneRef.laneId ? { laneId: laneRef.laneId, taskId: laneRef.taskId } : {}),
         created: true,
         elementCount: newTabElementCount,
         readiness: newTabReadiness,

--- a/src/tools/oc-lane.ts
+++ b/src/tools/oc-lane.ts
@@ -1,0 +1,77 @@
+import { MCPServer } from '../mcp-server';
+import { MCPResult, MCPToolDefinition, ToolHandler } from '../types/mcp';
+import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
+import { closeBrowserLane, createBrowserLane, getBrowserLane, listBrowserLanes } from '../core/browser-lanes';
+
+const laneShape: MCPToolDefinition['inputSchema'] = {
+  type: 'object',
+  properties: {
+    taskId: { type: 'string', description: '16-hex task id returned by oc_task_start.' },
+    task_id: { type: 'string', description: 'Alias for taskId.' },
+    laneId: { type: 'string', description: 'Lane id returned by oc_lane_create.' },
+    lane_id: { type: 'string', description: 'Alias for laneId.' },
+  },
+};
+
+function jsonResult(payload: unknown): MCPResult {
+  return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }], structuredContent: payload as Record<string, unknown> };
+}
+function err(message: string): MCPResult { return { isError: true, content: [{ type: 'text', text: message }] }; }
+function taskId(args: Record<string, unknown>): string { return String(args.taskId ?? args.task_id ?? ''); }
+function laneId(args: Record<string, unknown>): string { return String(args.laneId ?? args.lane_id ?? ''); }
+
+const createDefinition: MCPToolDefinition = {
+  name: 'oc_lane_create',
+  description: 'Create a task-scoped browser lane backed by existing SessionManager worker/target primitives. Lanes isolate refs, tabs, and trace metadata for host-driven parallel work without spawning LLM subagents.',
+  annotations: TOOL_ANNOTATIONS.oc_task_start,
+  inputSchema: {
+    type: 'object',
+    properties: {
+      taskId: { type: 'string', description: 'REQUIRED 16-hex task id returned by oc_task_start.' },
+      task_id: { type: 'string', description: 'Alias for taskId.' },
+      name: { type: 'string', description: 'Optional human label.' },
+      purpose: { type: 'string', description: 'Optional bounded purpose for audit/debugging.' },
+      initialUrl: { type: 'string', description: 'Optional URL to open as the first lane target.' },
+      budget: { type: 'object', description: 'Optional host-owned lane budget metadata; recorded only.' },
+    },
+  },
+};
+const listDefinition: MCPToolDefinition = { name: 'oc_lane_list', description: 'List task-scoped browser lanes for a task.', annotations: TOOL_ANNOTATIONS.oc_task_list, inputSchema: laneShape };
+const getDefinition: MCPToolDefinition = { name: 'oc_lane_get', description: 'Fetch one task-scoped browser lane including live target ids and counters.', annotations: TOOL_ANNOTATIONS.oc_task_get, inputSchema: laneShape };
+const closeDefinition: MCPToolDefinition = { name: 'oc_lane_close', description: 'Close a task-scoped browser lane and its lane-owned targets without closing unrelated task tabs.', annotations: TOOL_ANNOTATIONS.oc_task_cancel, inputSchema: laneShape };
+
+const createHandler: ToolHandler = async (sessionId, args) => {
+  try {
+    const tid = taskId(args);
+    if (!tid) return err('oc_lane_create: taskId is required');
+    const lane = await createBrowserLane({
+      sessionId,
+      taskId: tid,
+      name: typeof args.name === 'string' ? args.name : undefined,
+      purpose: typeof args.purpose === 'string' ? args.purpose : undefined,
+      initialUrl: typeof args.initialUrl === 'string' ? args.initialUrl : undefined,
+      budget: args.budget,
+    });
+    return jsonResult({ ok: true, lane });
+  } catch (e) { return err(`oc_lane_create: ${e instanceof Error ? e.message : String(e)}`); }
+};
+const listHandler: ToolHandler = async (_sessionId, args) => {
+  try { const tid = taskId(args); if (!tid) return err('oc_lane_list: taskId is required'); return jsonResult({ ok: true, lanes: listBrowserLanes(tid) }); }
+  catch (e) { return err(`oc_lane_list: ${e instanceof Error ? e.message : String(e)}`); }
+};
+const getHandler: ToolHandler = async (_sessionId, args) => {
+  try { const tid = taskId(args); const lid = laneId(args); if (!tid || !lid) return err('oc_lane_get: taskId and laneId are required'); return jsonResult({ ok: true, lane: getBrowserLane(tid, lid) }); }
+  catch (e) { return err(`oc_lane_get: ${e instanceof Error ? e.message : String(e)}`); }
+};
+const closeHandler: ToolHandler = async (sessionId, args) => {
+  try { const tid = taskId(args); const lid = laneId(args); if (!tid || !lid) return err('oc_lane_close: taskId and laneId are required'); return jsonResult({ ok: true, lane: await closeBrowserLane(tid, lid, sessionId) }); }
+  catch (e) { return err(`oc_lane_close: ${e instanceof Error ? e.message : String(e)}`); }
+};
+
+export function registerOcLaneTools(server: MCPServer): void {
+  server.registerTool(createDefinition.name, createHandler, createDefinition);
+  server.registerTool(listDefinition.name, listHandler, listDefinition);
+  server.registerTool(getDefinition.name, getHandler, getDefinition);
+  server.registerTool(closeDefinition.name, closeHandler, closeDefinition);
+}
+export const __test__ = { createHandler, listHandler, getHandler, closeHandler };

--- a/src/tools/oc-lane.ts
+++ b/src/tools/oc-lane.ts
@@ -23,7 +23,7 @@ function laneId(args: Record<string, unknown>): string { return String(args.lane
 const createDefinition: MCPToolDefinition = {
   name: 'oc_lane_create',
   description: 'Create a task-scoped browser lane backed by existing SessionManager worker/target primitives. Lanes isolate refs, tabs, and trace metadata for host-driven parallel work without spawning LLM subagents.',
-  annotations: TOOL_ANNOTATIONS.oc_task_start,
+  annotations: TOOL_ANNOTATIONS.oc_lane_create,
   inputSchema: {
     type: 'object',
     properties: {
@@ -36,9 +36,9 @@ const createDefinition: MCPToolDefinition = {
     },
   },
 };
-const listDefinition: MCPToolDefinition = { name: 'oc_lane_list', description: 'List task-scoped browser lanes for a task.', annotations: TOOL_ANNOTATIONS.oc_task_list, inputSchema: laneShape };
-const getDefinition: MCPToolDefinition = { name: 'oc_lane_get', description: 'Fetch one task-scoped browser lane including live target ids and counters.', annotations: TOOL_ANNOTATIONS.oc_task_get, inputSchema: laneShape };
-const closeDefinition: MCPToolDefinition = { name: 'oc_lane_close', description: 'Close a task-scoped browser lane and its lane-owned targets without closing unrelated task tabs.', annotations: TOOL_ANNOTATIONS.oc_task_cancel, inputSchema: laneShape };
+const listDefinition: MCPToolDefinition = { name: 'oc_lane_list', description: 'List task-scoped browser lanes for a task.', annotations: TOOL_ANNOTATIONS.oc_lane_list, inputSchema: laneShape };
+const getDefinition: MCPToolDefinition = { name: 'oc_lane_get', description: 'Fetch one task-scoped browser lane including live target ids and counters.', annotations: TOOL_ANNOTATIONS.oc_lane_get, inputSchema: laneShape };
+const closeDefinition: MCPToolDefinition = { name: 'oc_lane_close', description: 'Close a task-scoped browser lane and its lane-owned targets without closing unrelated task tabs.', annotations: TOOL_ANNOTATIONS.oc_lane_close, inputSchema: laneShape };
 
 const createHandler: ToolHandler = async (sessionId, args) => {
   try {

--- a/src/tools/oc-task-get.ts
+++ b/src/tools/oc-task-get.ts
@@ -72,6 +72,7 @@ const handler: ToolHandler = async (
     budget_exceeded: meta.budget_exceeded,
     recommended_next: meta.recommended_next,
     recent_events: meta.recent_events ?? [],
+    lanes: meta.lanes ?? [],
     phase: meta.phase,
     objective: meta.objective,
     ...(includeResult ? { result } : {}),

--- a/src/tools/read-page.ts
+++ b/src/tools/read-page.ts
@@ -23,6 +23,7 @@ import { getCurrentLoaderId, mintNodeRefSync } from '../core/perception/node-ref
 import { isStateHeaderEnabled, mergeHeaderJson, prependHeaderText } from './_shared/state-header';
 import { areBoundaryMarkersEnabled, wrapBoundaryMarker } from '../core/perception/boundary-markers';
 import { decodeCursor, encodeCursor } from '../utils/paginate';
+import { applyLaneTarget, recordLaneToolCall } from '../core/browser-lanes';
 
 const READ_PAGE_CURSOR_CHARS = 5000;
 
@@ -100,6 +101,8 @@ const definition: MCPToolDefinition = {
         type: 'string',
         description: 'Tab ID to read from',
       },
+      taskId: { type: 'string', description: 'Task id when using a task-scoped browser lane.' },
+      laneId: { type: 'string', description: 'Task-scoped browser lane id; validates tabId or defaults to the lane current target.' },
       depth: {
         type: 'number',
         description: 'Max tree depth. Default: 8 (all), 5 (interactive)',
@@ -191,7 +194,7 @@ const definition: MCPToolDefinition = {
         description: 'Wrap page-origin plaintext in <oc:page>. Default true; false disables.',
       },
     },
-    required: ['tabId'],
+
   },
   annotations: TOOL_ANNOTATIONS.read_page,
 };
@@ -327,7 +330,9 @@ const handler: ToolHandler = async (
   context?: ToolContext
 ): Promise<MCPResult> => {
   throwIfAborted(context);
-  const tabId = args.tabId as string;
+  let scopedArgs: Record<string, unknown>;
+  try { scopedArgs = applyLaneTarget(args); } catch (error) { return { content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }], isError: true }; }
+  const tabId = scopedArgs.tabId as string;
   const filter = (args.filter as string) || 'all';
   const defaultDepth = filter === 'interactive' ? 5 : 8;
   const requestedDepth = typeof args.depth === 'number' ? args.depth : undefined;
@@ -348,6 +353,7 @@ const handler: ToolHandler = async (
 
   try {
     const page = await sessionManager.getPage(sessionId, tabId);
+    await recordLaneToolCall(args, !!page, tabId);
     if (!page) {
       const available = await sessionManager.getAvailableTargets(sessionId);
       const availableInfo = available.length > 0

--- a/src/types/tool-annotations.ts
+++ b/src/types/tool-annotations.ts
@@ -218,6 +218,10 @@ export const TOOL_ANNOTATIONS = {
   oc_task_get: READ_ONLY,
   oc_task_list: READ_ONLY,
   oc_task_wait: READ_ONLY,
+  oc_lane_create: MUTATES,
+  oc_lane_list: READ_ONLY,
+  oc_lane_get: READ_ONLY,
+  oc_lane_close: DESTRUCTIVE,
 
   // ── Skill replay (develop-era addition) ────────────────────────────────
   // `oc_skill_replay` performs the recorded CDP step sequence; the contract

--- a/tests/core/browser-lanes.test.ts
+++ b/tests/core/browser-lanes.test.ts
@@ -1,0 +1,64 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { applyLaneTarget, getBrowserLane, recordLaneToolCall } from '../../src/core/browser-lanes';
+import { TaskStore } from '../../src/core/task-ledger/store';
+import type { TaskMeta } from '../../src/core/task-ledger/types';
+import { setTaskStoreForTests } from '../../src/tools/oc-task-start';
+
+describe('browser lanes (#1037)', () => {
+  let dir: string;
+  let store: TaskStore;
+  const taskId = '0123456789abcdef';
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-lanes-'));
+    store = new TaskStore({ rootDir: dir });
+    setTaskStoreForTests(store);
+    const meta: TaskMeta = {
+      task_id: taskId,
+      kind: 'browser_task',
+      status: 'RUNNING',
+      pid: process.pid,
+      created_at: Date.now(),
+      args_summary: {},
+      owner: { session_id: 'session-a' },
+      lanes: [{
+        lane_id: 'lane_alpha',
+        task_id: taskId,
+        status: 'open',
+        sessionId: 'session-a',
+        workerId: 'task:0123456789abcdef:lane:lane_alpha',
+        targetIds: ['tab-a'],
+        created_at: Date.now(),
+        last_activity_at: Date.now(),
+        counters: { toolCalls: 0, failures: 0 },
+      }],
+    };
+    await store.create(meta);
+  });
+
+  afterEach(() => {
+    setTaskStoreForTests(undefined);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('applyLaneTarget defaults tabId and workerId from lane', () => {
+    expect(applyLaneTarget({ taskId, laneId: 'lane_alpha' })).toEqual(expect.objectContaining({
+      tabId: 'tab-a',
+      workerId: 'task:0123456789abcdef:lane:lane_alpha',
+    }));
+  });
+
+  test('applyLaneTarget rejects cross-lane tabId', () => {
+    expect(() => applyLaneTarget({ taskId, laneId: 'lane_alpha', tabId: 'tab-b' })).toThrow(/does not belong/);
+  });
+
+  test('recordLaneToolCall increments lane counters and appends new target', async () => {
+    await recordLaneToolCall({ taskId, laneId: 'lane_alpha' }, false, 'tab-b');
+    const lane = getBrowserLane(taskId, 'lane_alpha');
+    expect(lane.targetIds).toEqual(['tab-a', 'tab-b']);
+    expect(lane.counters).toEqual({ toolCalls: 1, failures: 1 });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `oc_lane_create/list/get/close` as task-scoped browser lane tools for host-driven parallel work.
- Store lane state on existing task ledger metadata and reuse SessionManager worker/target primitives instead of spawning extra Chrome processes or agent workers.
- Add optional `taskId`/`laneId` routing metadata to `navigate`, `read_page`, and `interact` so lane-owned targets can be validated/defaulted without changing callers that omit lane args.

## Positive impact
- Improves reliability for parallel browser branches by preventing accidental cross-lane tab/ref usage.
- Keeps default OpenChrome behavior unchanged; lane isolation is opt-in.

## Validation
- `npm run build`
- `npm test -- --runInBand tests/core/browser-lanes.test.ts`
- `npm run lint:tier`
- `npm run lint:tool-schemas`

Closes #1037