### PR TITLE
feat(benchmark): harness foundation for competitive benchmark suite (#1255)

### DIFF
--- a/benchmark/COMPETITORS.md
+++ b/benchmark/COMPETITORS.md
@@ -1,0 +1,62 @@
+# Benchmark Competitors — Version Pins
+
+Part of the Competitive Benchmark Suite (Epic #1254, harness foundation #1255).
+
+Every benchmark run records the exact version of each library it compares
+against. This file is the human-readable registry; each result JSON also embeds
+the same pins in its `competitors` block (see
+`tests/benchmark/schemas/result.schema.json`). A version that is not pinned here
+must not appear in a published benchmark number.
+
+## Why pinning matters
+
+The libraries in this list move fast. A comparison run in 2026-03 against a
+library that shipped a major release in 2026-05 is not a comparison anyone can
+defend or reproduce. Every row below carries a version, a commit (where
+applicable), and the date it was measured.
+
+## Scope — local open-source only
+
+Hosted/paid services (Vercel Agent Browser, Browserbase, Firecrawl Cloud) are
+intentionally **excluded**: their infrastructure differs from a local run, so
+they are not reproducible here. See Epic #1254 "Non-goals".
+
+## Competitor registry
+
+> Versions below are **placeholders** — each is pinned to an exact version +
+> commit + measurement date by the sub-issue that first benchmarks against it
+> (#1256–#1261). Until a row is pinned by a real run, treat it as TBD.
+
+| Library | npm package | Pinned version | Commit | Measured at | Used by axes |
+|---|---|---|---|---|---|
+| OpenChrome | `openchrome-mcp` (this repo) | _repo HEAD_ | _per-run git SHA_ | _per run_ | all |
+| Playwright | `playwright` | TBD | — | TBD | #A #C #D #E |
+| Puppeteer | `puppeteer` | TBD | — | TBD | #C #D #E #F |
+| playwright-mcp | `@playwright/mcp` | TBD | — | TBD | #A #B #F |
+| browser-use | `browser-use` (PyPI) | TBD | — | TBD | #A #B #D #E |
+| Crawlee | `crawlee` | TBD | — | TBD | #A #C |
+
+## Tokenizer
+
+All token counts in the suite use **`cl100k_base`** via
+[`js-tiktoken`](https://www.npmjs.com/package/js-tiktoken), wrapped by
+`tests/benchmark/utils/tokenizer.ts`.
+
+No vendor publishes the exact production tokenizer for current Claude models, so
+an "exact Claude token count" is not obtainable. What the benchmark needs is a
+single, deterministic, real tokenizer applied uniformly to every library's
+payload — the cross-library delta is the signal, not the absolute count.
+`cl100k_base` is a real BPE tokenizer, pure-JS (no native/wasm deps, works on
+every CI OS), and stable. Reports must describe "tokens" as
+"`cl100k_base` tokens", not "Claude tokens".
+
+## LLM pin (LLM-driven axes only)
+
+Axis #B (Agent Task Success) runs against a real Claude model. The exact model
+id + temperature are pinned per run and embedded in the result JSON's
+`environment.llm` block. A mid-benchmark model update invalidates the axis and
+forces a re-run.
+
+| Axis | Model id | Temperature | Notes |
+|---|---|---|---|
+| #B Agent Task Success | TBD | TBD | pinned when #1257 runs against the real Claude adapter |

--- a/benchmark/parallel-isolated.mjs
+++ b/benchmark/parallel-isolated.mjs
@@ -1,8 +1,15 @@
 /**
- * Isolated Parallel Benchmark
+ * Isolated Parallel Benchmark — Playwright only.
  *
  * Runs ONE strategy at a time (passed via CLI arg).
  * Must be run separately for each strategy to avoid contamination.
+ *
+ * NOTE: This script measures Playwright only. It does NOT run OpenChrome.
+ * It previously *estimated* OpenChrome token counts by dividing raw HTML by a
+ * hard-coded `OC_COMPRESSION_RATIO = 15.3` — an unverified guess, now removed
+ * (Epic #1254, sub-issue #1255). Real, measured OpenChrome vs competitor
+ * throughput numbers come from the unified harness in #1258 (Speed &
+ * Throughput); raw HTML is reported here only as a real Playwright measurement.
  *
  * Usage:
  *   node parallel-isolated.mjs 1    # sequential (1 tab)
@@ -16,7 +23,6 @@ import { writeFileSync } from 'fs';
 import { TARGETS, CDP_ENDPOINT, RESULTS_DIR } from './config.mjs';
 
 const BATCH_SIZE = parseInt(process.argv[2] || '1', 10);
-const OC_COMPRESSION_RATIO = 15.3;
 
 async function extractFromPage(page, target) {
   const start = Date.now();
@@ -38,7 +44,6 @@ async function extractFromPage(page, target) {
     });
 
     const totalTime = Date.now() - start;
-    const rawHtmlTokens = Math.ceil(data.rawHtmlChars / 4);
 
     return {
       handle: target.handle,
@@ -47,11 +52,10 @@ async function extractFromPage(page, target) {
       tweetCount: data.tweetCount,
       tweets: data.tweets,
       timing: { totalMs: totalTime },
+      // Real Playwright measurements only — no estimated OpenChrome figures.
       dataSize: {
         rawHtmlChars: data.rawHtmlChars,
-        rawHtmlTokens,
-        ocCompactTokens: Math.round(rawHtmlTokens / OC_COMPRESSION_RATIO),
-        ocCompactKB: parseFloat(((data.rawHtmlChars / OC_COMPRESSION_RATIO) / 1024).toFixed(1)),
+        rawTextChars: data.rawTextChars,
       },
     };
   } catch (err) {
@@ -59,7 +63,7 @@ async function extractFromPage(page, target) {
       handle: target.handle, name: target.name,
       success: false, tweetCount: 0, tweets: [],
       timing: { totalMs: Date.now() - start },
-      dataSize: { rawHtmlChars: 0, rawHtmlTokens: 0, ocCompactTokens: 0, ocCompactKB: 0 },
+      dataSize: { rawHtmlChars: 0, rawTextChars: 0 },
       error: err.message,
     };
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "dependency-cruiser": "^16.0.0",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
+        "js-tiktoken": "^1.0.21",
         "rimraf": "^5.0.0",
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.2",
@@ -4922,6 +4923,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "dependency-cruiser": "^16.0.0",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
+    "js-tiktoken": "^1.0.21",
     "rimraf": "^5.0.0",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.2",

--- a/tests/benchmark/benchmark-runner.ts
+++ b/tests/benchmark/benchmark-runner.ts
@@ -3,12 +3,33 @@
  * Self-contained - no project imports required.
  */
 
-export interface MCPAdapter {
+/**
+ * Base interface every benchmarked library implements — OpenChrome and every
+ * competitor (Playwright, Puppeteer, playwright-mcp, browser-use, Crawlee).
+ * Axis-specific capability interfaces (e.g. MCPAdapter) extend this. A common
+ * base is what lets task code stay identical across libraries, so the only
+ * variable is the library itself (Epic #1254, methodology principle #4).
+ */
+export interface LibraryAdapter {
+  /** Display name, e.g. "OpenChrome", "Playwright". */
   name: string;
+  /** Execution-mode label, e.g. "dom", "ax", "raw-html". */
   mode: string;
-  callTool(toolName: string, args: Record<string, unknown>): Promise<MCPToolResult>;
+  /** Adapter category, for fairness bookkeeping in reports. */
+  kind?: 'mcp' | 'library' | 'bridge';
+  /** Pinned version of the underlying library (see benchmark/COMPETITORS.md). */
+  version?: string;
   setup?(): Promise<void>;
   teardown?(): Promise<void>;
+}
+
+/**
+ * MCP-specific adapter — drives a library through MCP tool calls. Implemented
+ * by OpenChromeStubAdapter / OpenChromeRealAdapter and, later, the
+ * playwright-mcp adapter.
+ */
+export interface MCPAdapter extends LibraryAdapter {
+  callTool(toolName: string, args: Record<string, unknown>): Promise<MCPToolResult>;
 }
 
 export interface MCPToolResult {
@@ -203,7 +224,11 @@ export class BenchmarkRunner {
     const toolCallValues = runs.map((r) => r.toolCallCount);
     const wallTimeValues = runs.map((r) => r.wallTimeMs);
     const responseCharValues = runs.map((r) => r.responseChars ?? r.outputChars);
-    const estimatedTokenValues = runs.map((r) => r.estimatedOutputTokens ?? Math.ceil((r.responseChars ?? r.outputChars) / 4));
+    // Real token counts are owned by the task (via tests/benchmark/utils/tokenizer.ts),
+    // which is the only layer that still holds the response text. The runner sees
+    // only char counts, so a task that reports token metrics MUST set
+    // estimatedOutputTokens; absent that we report 0 rather than a chars/4 guess.
+    const estimatedTokenValues = runs.map((r) => r.estimatedOutputTokens ?? 0);
     const screenshotByteValues = runs.map((r) => r.screenshotBytes ?? 0);
     const nodeRssValues = runs.map((r) => r.nodeRssBytes ?? 0).filter((value) => value > 0);
 

--- a/tests/benchmark/matrix.test.ts
+++ b/tests/benchmark/matrix.test.ts
@@ -3,10 +3,10 @@
 import {
   createBenchmarkMatrix,
   createMatrixTasks,
-  estimateTokensFromChars,
   filterBenchmarkMatrix,
   responsePayloadSize,
 } from './matrix';
+import { countTokens } from './utils/tokenizer';
 
 const requiredScenarios = [
   'cold-start-first-tab',
@@ -35,11 +35,7 @@ describe('benchmark matrix', () => {
     expect(filterBenchmarkMatrix(createBenchmarkMatrix(), { category: 'warm-read-page-dom' })[0].name).toBe('warm-read-page-dom');
   });
 
-  test('estimates tokens and screenshot payload sizes safely', () => {
-    expect(estimateTokensFromChars(0)).toBe(0);
-    expect(estimateTokensFromChars(1)).toBe(1);
-    expect(estimateTokensFromChars(9)).toBe(3);
-
+  test('counts exact tokens and screenshot payload sizes safely', () => {
     const payload = responsePayloadSize({
       content: [
         { type: 'text', text: 'hello' },
@@ -48,6 +44,9 @@ describe('benchmark matrix', () => {
     });
     expect(payload.responseChars).toBeGreaterThan(5);
     expect(payload.screenshotBytes).toBe(5);
+    // Real tokenizer, not chars/4 — base64 image data is excluded from tokens.
+    expect(payload.responseTokens).toBe(countTokens('hello'));
+    expect(payload.responseTokens).toBeGreaterThan(0);
   });
 
   test('matrix tasks run without external network using an adapter', async () => {
@@ -69,7 +68,9 @@ describe('benchmark matrix', () => {
     expect(result.success).toBe(true);
     expect(result.toolCallCount).toBe(3);
     expect(result.responseChars).toBe(6);
-    expect(result.estimatedOutputTokens).toBe(Math.ceil(result.responseChars! / 4));
+    // Three steps each return the text 'ok'; estimatedOutputTokens is the
+    // exact tokenizer sum, not a chars/4 estimate.
+    expect(result.estimatedOutputTokens).toBe(countTokens('ok') * 3);
     expect(result.nodeRssBytes).toBeGreaterThan(0);
     expect(adapter.callTool).toHaveBeenLastCalledWith('tabs_close', { tabId: 'real-tab-1' });
   });

--- a/tests/benchmark/matrix.ts
+++ b/tests/benchmark/matrix.ts
@@ -1,5 +1,6 @@
 import { BenchmarkTask, MCPAdapter, MCPToolResult, TaskResult } from './benchmark-runner';
 import { measureCall } from './utils';
+import { countTokens } from './utils/tokenizer';
 
 export type BenchmarkCategory =
   | 'cold-start'
@@ -21,18 +22,20 @@ export interface MatrixFilter {
   category?: string;
 }
 
-export function estimateTokensFromChars(chars: number): number {
-  if (!Number.isFinite(chars) || chars <= 0) return 0;
-  return Math.ceil(chars / 4);
-}
-
-export function responsePayloadSize(result: MCPToolResult): { responseChars: number; screenshotBytes: number } {
+export function responsePayloadSize(
+  result: MCPToolResult,
+): { responseChars: number; responseTokens: number; screenshotBytes: number } {
   let responseChars = 0;
+  let responseTokens = 0;
   let screenshotBytes = 0;
 
   for (const item of result.content ?? []) {
     if (typeof item.text === 'string') {
       responseChars += item.text.length;
+      // Exact token count of the text payload an agent would receive.
+      // Base64 image data is intentionally excluded — it is measured in
+      // screenshotBytes, and tokenizing base64 is meaningless.
+      responseTokens += countTokens(item.text);
     }
     if (typeof item.data === 'string') {
       responseChars += item.data.length;
@@ -40,7 +43,7 @@ export function responsePayloadSize(result: MCPToolResult): { responseChars: num
     }
   }
 
-  return { responseChars, screenshotBytes };
+  return { responseChars, responseTokens, screenshotBytes };
 }
 
 function extractTabId(result: MCPToolResult): string | undefined {
@@ -157,6 +160,7 @@ export function createMatrixTask(scenario: BenchmarkMatrixScenario): BenchmarkTa
       let startTime = Date.now();
       const counters = { inputChars: 0, outputChars: 0, toolCallCount: 0 };
       let responseChars = 0;
+      let responseTokens = 0;
       let screenshotBytes = 0;
       const createdTabIds: string[] = [];
 
@@ -195,6 +199,7 @@ export function createMatrixTask(scenario: BenchmarkMatrixScenario): BenchmarkTa
           measureCall(result, args, counters);
           const payload = responsePayloadSize(result);
           responseChars += payload.responseChars;
+          responseTokens += payload.responseTokens;
           screenshotBytes += payload.screenshotBytes;
           if (step.tool === 'tabs_create') {
             const createdTabId = extractTabId(result);
@@ -224,7 +229,7 @@ export function createMatrixTask(scenario: BenchmarkMatrixScenario): BenchmarkTa
           inputChars: counters.inputChars,
           outputChars: counters.outputChars,
           responseChars,
-          estimatedOutputTokens: estimateTokensFromChars(responseChars || counters.outputChars),
+          estimatedOutputTokens: responseTokens,
           screenshotBytes,
           nodeRssBytes,
           chromeRssBytes: null,
@@ -242,7 +247,7 @@ export function createMatrixTask(scenario: BenchmarkMatrixScenario): BenchmarkTa
           inputChars: counters.inputChars,
           outputChars: counters.outputChars,
           responseChars,
-          estimatedOutputTokens: estimateTokensFromChars(responseChars || counters.outputChars),
+          estimatedOutputTokens: responseTokens,
           screenshotBytes,
           nodeRssBytes: process.memoryUsage().rss,
           chromeRssBytes: null,

--- a/tests/benchmark/schemas/result.schema.json
+++ b/tests/benchmark/schemas/result.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/shaun0927/openchrome/tests/benchmark/schemas/result.schema.json",
+  "title": "OpenChrome Competitive Benchmark Result",
+  "description": "Common envelope every benchmark axis (#A-#F) must emit. Guarantees every published number carries environment metadata and competitor version pins. See Epic #1254.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["axis", "environment", "competitors", "results"],
+  "properties": {
+    "axis": {
+      "description": "Which benchmark axis produced this file.",
+      "type": "string",
+      "enum": [
+        "foundation",
+        "token-efficiency",
+        "agent-success",
+        "speed-throughput",
+        "reliability",
+        "auth-usability",
+        "developer-experience"
+      ]
+    },
+    "schemaVersion": {
+      "description": "Version of this result schema the file was written against.",
+      "type": "string",
+      "default": "1.0.0"
+    },
+    "environment": {
+      "description": "Environment metadata captured by tests/benchmark/utils/environment.ts.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "capturedAt",
+        "gitSha",
+        "gitDirty",
+        "nodeVersion",
+        "os",
+        "arch",
+        "cpuModel",
+        "cpuCount",
+        "totalMemoryBytes",
+        "chromeVersion",
+        "networkProfile"
+      ],
+      "properties": {
+        "capturedAt": { "type": "string", "format": "date-time" },
+        "gitSha": { "type": "string" },
+        "gitDirty": { "type": "boolean" },
+        "nodeVersion": { "type": "string" },
+        "os": { "type": "string" },
+        "arch": { "type": "string" },
+        "cpuModel": { "type": "string" },
+        "cpuCount": { "type": "integer", "minimum": 1 },
+        "totalMemoryBytes": { "type": "integer", "minimum": 0 },
+        "chromeVersion": { "type": "string" },
+        "networkProfile": { "type": "string" },
+        "llm": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["model", "temperature"],
+          "properties": {
+            "model": { "type": "string" },
+            "temperature": { "type": "number" }
+          }
+        }
+      }
+    },
+    "competitors": {
+      "description": "Version pins for every library compared in this run. Mirrors benchmark/COMPETITORS.md.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "version"],
+        "properties": {
+          "name": { "type": "string" },
+          "version": { "type": "string" },
+          "commit": { "type": "string" },
+          "measuredAt": { "type": "string", "format": "date-time" }
+        }
+      }
+    },
+    "tokenizer": {
+      "description": "Tokenizer encoding used for any token counts in this file.",
+      "type": "string"
+    },
+    "results": {
+      "description": "Per-cell benchmark rows. Shape is axis-specific; only the presence of the array is enforced here.",
+      "type": "array"
+    }
+  }
+}

--- a/tests/benchmark/tasks/extraction-formats.ts
+++ b/tests/benchmark/tasks/extraction-formats.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { createHash } from 'crypto';
+import { countTokens } from '../utils/tokenizer';
 
 export interface ExtractionFormatEntry {
   fixture: string;
@@ -8,7 +9,8 @@ export interface ExtractionFormatEntry {
   wallTimeMs: number;
   inputChars: number;
   outputChars: number;
-  approxTokens: number;
+  /** Exact token count of the output payload (cl100k_base via js-tiktoken). */
+  tokens: number;
   fieldsFound: number;
   fieldsTotal: number;
   fallbackUsed: boolean;
@@ -37,10 +39,6 @@ export interface ExtractionWorkingDocument {
 
 function checksum(value: string): string {
   return createHash('sha256').update(value).digest('hex');
-}
-
-function approxTokens(chars: number): number {
-  return Math.ceil(chars / 4);
 }
 
 function stripNoise(html: string): string {
@@ -114,7 +112,7 @@ export function runExtractionFormatsBenchmark(options: { ciMode?: boolean } = {}
       wallTimeMs: dom.wallTimeMs,
       inputChars: html.length,
       outputChars: dom.value.length,
-      approxTokens: approxTokens(dom.value.length),
+      tokens: countTokens(dom.value),
       fieldsFound: 0,
       fieldsTotal: 0,
       fallbackUsed: false,
@@ -129,7 +127,7 @@ export function runExtractionFormatsBenchmark(options: { ciMode?: boolean } = {}
       wallTimeMs: extracted.wallTimeMs,
       inputChars: html.length,
       outputChars: extracted.value.output.length,
-      approxTokens: approxTokens(extracted.value.output.length),
+      tokens: countTokens(extracted.value.output),
       fieldsFound: extracted.value.fieldsFound,
       fieldsTotal: extracted.value.fieldsTotal,
       fallbackUsed: false,
@@ -144,7 +142,7 @@ export function runExtractionFormatsBenchmark(options: { ciMode?: boolean } = {}
       wallTimeMs: readable.wallTimeMs,
       inputChars: html.length,
       outputChars: readable.value.length,
-      approxTokens: approxTokens(readable.value.length),
+      tokens: countTokens(readable.value),
       fieldsFound: 0,
       fieldsTotal: 0,
       fallbackUsed: false,
@@ -159,7 +157,7 @@ export function runExtractionFormatsBenchmark(options: { ciMode?: boolean } = {}
         wallTimeMs: 0,
         inputChars: html.length,
         outputChars: 0,
-        approxTokens: 0,
+        tokens: 0,
         fieldsFound: 0,
         fieldsTotal: 0,
         fallbackUsed: mode === 'llm_fallback_mock',
@@ -187,13 +185,13 @@ export function runExtractionFormatsBenchmark(options: { ciMode?: boolean } = {}
 }
 
 export function formatExtractionFormatsReport(report: ExtractionFormatsReport): string {
-  const lines = ['Extraction format benchmark', 'fixture,mode,outputChars,approxTokens,fields,mutated,skip'];
+  const lines = ['Extraction format benchmark', 'fixture,mode,outputChars,tokens,fields,mutated,skip'];
   for (const e of report.entries) {
     lines.push([
       e.fixture,
       e.mode,
       e.outputChars,
-      e.approxTokens,
+      e.tokens,
       `${e.fieldsFound}/${e.fieldsTotal}`,
       e.contentMutated,
       e.skippedReason || '',

--- a/tests/benchmark/utils/environment.test.ts
+++ b/tests/benchmark/utils/environment.test.ts
@@ -1,0 +1,39 @@
+/// <reference types="jest" />
+
+import { captureEnvironment } from './environment';
+
+describe('benchmark environment capture', () => {
+  test('captures the required reproducibility fields', () => {
+    const env = captureEnvironment();
+
+    expect(typeof env.capturedAt).toBe('string');
+    expect(Number.isNaN(Date.parse(env.capturedAt))).toBe(false);
+    expect(typeof env.gitSha).toBe('string');
+    expect(env.gitSha.length).toBeGreaterThan(0);
+    expect(typeof env.gitDirty).toBe('boolean');
+    expect(env.nodeVersion).toBe(process.version);
+    expect(typeof env.os).toBe('string');
+    expect(typeof env.arch).toBe('string');
+    expect(typeof env.cpuModel).toBe('string');
+    expect(env.cpuCount).toBeGreaterThan(0);
+    expect(env.totalMemoryBytes).toBeGreaterThan(0);
+    expect(typeof env.chromeVersion).toBe('string');
+    expect(env.networkProfile).toBe('unthrottled');
+  });
+
+  test('records a custom network profile', () => {
+    expect(captureEnvironment({ networkProfile: 'fast-3g' }).networkProfile).toBe('fast-3g');
+  });
+
+  test('embeds LLM metadata only when provided', () => {
+    expect(captureEnvironment().llm).toBeUndefined();
+
+    const withLlm = captureEnvironment({ llm: { model: 'claude-test', temperature: 0 } });
+    expect(withLlm.llm).toEqual({ model: 'claude-test', temperature: 0 });
+  });
+
+  test('degrades gracefully — never throws', () => {
+    expect(() => captureEnvironment({ chromePath: '/nonexistent/chrome/binary' })).not.toThrow();
+    expect(captureEnvironment({ chromePath: '/nonexistent/chrome/binary' }).chromeVersion).toBe('unknown');
+  });
+});

--- a/tests/benchmark/utils/environment.ts
+++ b/tests/benchmark/utils/environment.ts
@@ -1,0 +1,116 @@
+/**
+ * Environment metadata capture for the competitive benchmark suite.
+ *
+ * Every result JSON produced by any benchmark axis MUST embed an
+ * `EnvironmentMetadata` block. Without it a result is not reproducible and
+ * cannot be compared across machines or across time — see Epic #1254
+ * methodology principle #3.
+ */
+
+import * as os from 'os';
+import { execFileSync } from 'child_process';
+
+export interface EnvironmentMetadata {
+  /** ISO-8601 timestamp of capture. */
+  capturedAt: string;
+  /** Short git SHA of the working tree, or 'unknown' if not a git checkout. */
+  gitSha: string;
+  /** True when the working tree had uncommitted changes at capture time. */
+  gitDirty: boolean;
+  /** Node.js version, e.g. 'v20.11.0'. */
+  nodeVersion: string;
+  /** OS platform + release, e.g. 'darwin 25.3.0'. */
+  os: string;
+  /** Architecture, e.g. 'arm64'. */
+  arch: string;
+  /** CPU model string of the first core. */
+  cpuModel: string;
+  /** Logical CPU count. */
+  cpuCount: number;
+  /** Total system RAM in bytes. */
+  totalMemoryBytes: number;
+  /** Detected Chrome / Chromium version, or 'unknown'. */
+  chromeVersion: string;
+  /** Free-form network profile label, e.g. 'unthrottled' or 'fast-3g'. */
+  networkProfile: string;
+  /** LLM model id + temperature, present only for LLM-driven axes (#B). */
+  llm?: { model: string; temperature: number };
+}
+
+export interface CaptureEnvironmentOptions {
+  /** Path to a Chrome/Chromium binary to version-probe. */
+  chromePath?: string;
+  /** Network profile label to record. Defaults to 'unthrottled'. */
+  networkProfile?: string;
+  /** LLM metadata for LLM-driven axes. */
+  llm?: { model: string; temperature: number };
+}
+
+function tryExec(file: string, args: string[]): string | null {
+  try {
+    return execFileSync(file, args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function captureGit(): { gitSha: string; gitDirty: boolean } {
+  const sha = tryExec('git', ['rev-parse', '--short', 'HEAD']);
+  if (sha === null) {
+    return { gitSha: 'unknown', gitDirty: false };
+  }
+  const status = tryExec('git', ['status', '--porcelain']);
+  return { gitSha: sha, gitDirty: status !== null && status.length > 0 };
+}
+
+function captureChromeVersion(chromePath?: string): string {
+  const candidates = chromePath
+    ? [chromePath]
+    : process.platform === 'darwin'
+      ? ['/Applications/Google Chrome.app/Contents/MacOS/Google Chrome', 'google-chrome', 'chromium']
+      : process.platform === 'win32'
+        ? ['chrome', 'chrome.exe']
+        : ['google-chrome', 'chromium', 'chromium-browser'];
+
+  for (const candidate of candidates) {
+    const out = tryExec(candidate, ['--version']);
+    if (out !== null && out.length > 0) {
+      return out;
+    }
+  }
+  return 'unknown';
+}
+
+/**
+ * Capture the current environment. Pure read-only — safe to call from any
+ * runner. Each individual probe degrades gracefully to 'unknown' rather than
+ * throwing, so a missing git or Chrome never aborts a benchmark.
+ */
+export function captureEnvironment(options: CaptureEnvironmentOptions = {}): EnvironmentMetadata {
+  const cpus = os.cpus();
+  const git = captureGit();
+
+  const metadata: EnvironmentMetadata = {
+    capturedAt: new Date().toISOString(),
+    gitSha: git.gitSha,
+    gitDirty: git.gitDirty,
+    nodeVersion: process.version,
+    os: `${os.platform()} ${os.release()}`,
+    arch: os.arch(),
+    cpuModel: cpus.length > 0 ? cpus[0].model.trim() : 'unknown',
+    cpuCount: cpus.length,
+    totalMemoryBytes: os.totalmem(),
+    chromeVersion: captureChromeVersion(options.chromePath),
+    networkProfile: options.networkProfile ?? 'unthrottled',
+  };
+
+  if (options.llm) {
+    metadata.llm = options.llm;
+  }
+
+  return metadata;
+}

--- a/tests/benchmark/utils/result-envelope.test.ts
+++ b/tests/benchmark/utils/result-envelope.test.ts
@@ -1,0 +1,86 @@
+/// <reference types="jest" />
+
+import { captureEnvironment } from './environment';
+import {
+  buildResultEnvelope,
+  validateResultEnvelope,
+  assertValidResultEnvelope,
+  RESULT_SCHEMA_VERSION,
+} from './result-envelope';
+
+const env = captureEnvironment();
+
+describe('benchmark result envelope', () => {
+  test('builds a schema-valid envelope', () => {
+    const envelope = buildResultEnvelope({
+      axis: 'foundation',
+      environment: env,
+      competitors: [{ name: 'OpenChrome', version: '1.12.0' }],
+      results: [{ smoke: 'ok' }],
+    });
+
+    expect(envelope.schemaVersion).toBe(RESULT_SCHEMA_VERSION);
+    expect(envelope.tokenizer).toBe('cl100k_base');
+    expect(validateResultEnvelope(envelope)).toEqual([]);
+  });
+
+  test('rejects a non-object', () => {
+    expect(validateResultEnvelope(null)).toContain('envelope is not an object');
+  });
+
+  test('rejects an unknown axis', () => {
+    const bad = buildResultEnvelope({
+      axis: 'foundation',
+      environment: env,
+      competitors: [{ name: 'OpenChrome', version: '1.12.0' }],
+      results: [],
+    });
+    (bad as { axis: string }).axis = 'not-an-axis';
+    expect(validateResultEnvelope(bad).some((p) => p.startsWith('axis must be'))).toBe(true);
+  });
+
+  test('rejects an empty competitors array — version pins are mandatory', () => {
+    const bad = buildResultEnvelope({
+      axis: 'token-efficiency',
+      environment: env,
+      competitors: [],
+      results: [],
+    });
+    expect(validateResultEnvelope(bad)).toContain('competitors must be a non-empty array');
+  });
+
+  test('rejects a competitor missing its version pin', () => {
+    const bad = buildResultEnvelope({
+      axis: 'token-efficiency',
+      environment: env,
+      competitors: [{ name: 'Playwright' } as unknown as { name: string; version: string }],
+      results: [],
+    });
+    expect(validateResultEnvelope(bad).some((p) => p.includes('version must be'))).toBe(true);
+  });
+
+  test('rejects an envelope missing environment fields', () => {
+    const bad = buildResultEnvelope({
+      axis: 'reliability',
+      environment: env,
+      competitors: [{ name: 'OpenChrome', version: '1.12.0' }],
+      results: [],
+    });
+    delete (bad.environment as Partial<typeof bad.environment>).chromeVersion;
+    expect(validateResultEnvelope(bad)).toContain('environment.chromeVersion is required');
+  });
+
+  test('assertValidResultEnvelope throws on invalid input', () => {
+    expect(() => assertValidResultEnvelope({})).toThrow(/failed schema validation/);
+  });
+
+  test('assertValidResultEnvelope passes a valid envelope', () => {
+    const ok = buildResultEnvelope({
+      axis: 'speed-throughput',
+      environment: env,
+      competitors: [{ name: 'OpenChrome', version: '1.12.0' }],
+      results: [],
+    });
+    expect(() => assertValidResultEnvelope(ok)).not.toThrow();
+  });
+});

--- a/tests/benchmark/utils/result-envelope.test.ts
+++ b/tests/benchmark/utils/result-envelope.test.ts
@@ -60,9 +60,11 @@ describe('benchmark result envelope', () => {
   });
 
   test('rejects an envelope missing environment fields', () => {
+    // Copy the environment first — buildResultEnvelope stores it by reference,
+    // and mutating the shared `env` would poison the other tests.
     const bad = buildResultEnvelope({
       axis: 'reliability',
-      environment: env,
+      environment: { ...env },
       competitors: [{ name: 'OpenChrome', version: '1.12.0' }],
       results: [],
     });

--- a/tests/benchmark/utils/result-envelope.ts
+++ b/tests/benchmark/utils/result-envelope.ts
@@ -1,0 +1,153 @@
+/**
+ * Result-envelope builder + validator for the competitive benchmark suite.
+ *
+ * Every benchmark axis (#A-#F) wraps its rows in this envelope before writing
+ * JSON, so every published number carries environment metadata and competitor
+ * version pins. The canonical spec is `tests/benchmark/schemas/result.schema.json`;
+ * this module enforces the same shape at runtime without pulling in a JSON-schema
+ * dependency.
+ */
+
+import type { EnvironmentMetadata } from './environment';
+import { TOKENIZER_ENCODING } from './tokenizer';
+
+export const RESULT_SCHEMA_VERSION = '1.0.0';
+
+export type BenchmarkAxis =
+  | 'foundation'
+  | 'token-efficiency'
+  | 'agent-success'
+  | 'speed-throughput'
+  | 'reliability'
+  | 'auth-usability'
+  | 'developer-experience';
+
+export interface CompetitorPin {
+  name: string;
+  version: string;
+  commit?: string;
+  measuredAt?: string;
+}
+
+export interface ResultEnvelope<TRow = unknown> {
+  axis: BenchmarkAxis;
+  schemaVersion: string;
+  environment: EnvironmentMetadata;
+  competitors: CompetitorPin[];
+  tokenizer: string;
+  results: TRow[];
+}
+
+export interface BuildResultEnvelopeInput<TRow> {
+  axis: BenchmarkAxis;
+  environment: EnvironmentMetadata;
+  competitors: CompetitorPin[];
+  results: TRow[];
+}
+
+export function buildResultEnvelope<TRow>(
+  input: BuildResultEnvelopeInput<TRow>,
+): ResultEnvelope<TRow> {
+  return {
+    axis: input.axis,
+    schemaVersion: RESULT_SCHEMA_VERSION,
+    environment: input.environment,
+    competitors: input.competitors,
+    tokenizer: TOKENIZER_ENCODING,
+    results: input.results,
+  };
+}
+
+const VALID_AXES: ReadonlySet<string> = new Set<BenchmarkAxis>([
+  'foundation',
+  'token-efficiency',
+  'agent-success',
+  'speed-throughput',
+  'reliability',
+  'auth-usability',
+  'developer-experience',
+]);
+
+const REQUIRED_ENV_KEYS = [
+  'capturedAt',
+  'gitSha',
+  'gitDirty',
+  'nodeVersion',
+  'os',
+  'arch',
+  'cpuModel',
+  'cpuCount',
+  'totalMemoryBytes',
+  'chromeVersion',
+  'networkProfile',
+] as const;
+
+/**
+ * Structural validation matching `result.schema.json`. Returns the list of
+ * problems found — empty array means valid. Runners should assert this is
+ * empty before writing the file.
+ */
+export function validateResultEnvelope(value: unknown): string[] {
+  const problems: string[] = [];
+  if (typeof value !== 'object' || value === null) {
+    return ['envelope is not an object'];
+  }
+  const env = value as Record<string, unknown>;
+
+  if (typeof env.axis !== 'string' || !VALID_AXES.has(env.axis)) {
+    problems.push(`axis must be one of ${[...VALID_AXES].join(', ')}`);
+  }
+  if (typeof env.schemaVersion !== 'string') {
+    problems.push('schemaVersion must be a string');
+  }
+  if (typeof env.tokenizer !== 'string' || env.tokenizer.length === 0) {
+    problems.push('tokenizer must be a non-empty string');
+  }
+
+  if (typeof env.environment !== 'object' || env.environment === null) {
+    problems.push('environment must be an object');
+  } else {
+    const envMeta = env.environment as Record<string, unknown>;
+    for (const key of REQUIRED_ENV_KEYS) {
+      if (!(key in envMeta)) {
+        problems.push(`environment.${key} is required`);
+      }
+    }
+  }
+
+  if (!Array.isArray(env.competitors) || env.competitors.length === 0) {
+    problems.push('competitors must be a non-empty array');
+  } else {
+    env.competitors.forEach((entry, i) => {
+      if (typeof entry !== 'object' || entry === null) {
+        problems.push(`competitors[${i}] must be an object`);
+        return;
+      }
+      const pin = entry as Record<string, unknown>;
+      if (typeof pin.name !== 'string' || pin.name.length === 0) {
+        problems.push(`competitors[${i}].name must be a non-empty string`);
+      }
+      if (typeof pin.version !== 'string' || pin.version.length === 0) {
+        problems.push(`competitors[${i}].version must be a non-empty string`);
+      }
+    });
+  }
+
+  if (!Array.isArray(env.results)) {
+    problems.push('results must be an array');
+  }
+
+  return problems;
+}
+
+/**
+ * Throwing wrapper for runners that want a hard gate before writing output.
+ */
+export function assertValidResultEnvelope(value: unknown): void {
+  const problems = validateResultEnvelope(value);
+  if (problems.length > 0) {
+    throw new Error(
+      `Benchmark result envelope failed schema validation:\n  - ${problems.join('\n  - ')}`,
+    );
+  }
+}

--- a/tests/benchmark/utils/tokenizer.test.ts
+++ b/tests/benchmark/utils/tokenizer.test.ts
@@ -1,0 +1,45 @@
+/// <reference types="jest" />
+
+import { countTokens, countTokensOfValue, TOKENIZER_ENCODING } from './tokenizer';
+
+describe('benchmark tokenizer', () => {
+  test('exposes the cl100k_base encoding name', () => {
+    expect(TOKENIZER_ENCODING).toBe('cl100k_base');
+  });
+
+  test('counts tokens of a known string deterministically', () => {
+    const a = countTokens('hello world');
+    const b = countTokens('hello world');
+    expect(a).toBe(b);
+    expect(a).toBeGreaterThan(0);
+  });
+
+  test('is a real tokenizer, not a chars/4 estimate', () => {
+    // ' a' repeated 8 times — 8 short repeated tokens. chars/4 would guess ~4;
+    // a real BPE tokenizer produces a different, exact count.
+    const text = ' a'.repeat(8);
+    const tokens = countTokens(text);
+    expect(tokens).toBe(8);
+    expect(tokens).not.toBe(Math.ceil(text.length / 4));
+  });
+
+  test('treats empty / nullish input as zero tokens', () => {
+    expect(countTokens('')).toBe(0);
+    expect(countTokens(null)).toBe(0);
+    expect(countTokens(undefined)).toBe(0);
+  });
+
+  test('longer text yields more tokens', () => {
+    expect(countTokens('word '.repeat(100))).toBeGreaterThan(countTokens('word '.repeat(10)));
+  });
+
+  test('countTokensOfValue stringifies non-string values', () => {
+    expect(countTokensOfValue(null)).toBe(0);
+    expect(countTokensOfValue(undefined)).toBe(0);
+    expect(countTokensOfValue('plain string')).toBe(countTokens('plain string'));
+
+    const obj = { tool: 'read_page', args: { mode: 'dom' } };
+    expect(countTokensOfValue(obj)).toBe(countTokens(JSON.stringify(obj)));
+    expect(countTokensOfValue(obj)).toBeGreaterThan(0);
+  });
+});

--- a/tests/benchmark/utils/tokenizer.ts
+++ b/tests/benchmark/utils/tokenizer.ts
@@ -1,0 +1,56 @@
+/**
+ * Exact token counting for the competitive benchmark suite.
+ *
+ * Replaces the `Math.ceil(chars / 4)` approximation that was scattered across
+ * the benchmark code (`benchmark-runner.ts`, `matrix.ts`, `extraction-formats.ts`).
+ * Every axis that reports a token count MUST go through `countTokens` so the
+ * numbers are comparable across libraries and across runs.
+ *
+ * Encoding choice — `cl100k_base` (js-tiktoken):
+ *   No vendor publishes the exact production tokenizer for current Claude
+ *   models, so an "exact Claude token count" is not obtainable. What the
+ *   benchmark actually needs is a *single, deterministic, real* tokenizer
+ *   applied uniformly to every library's payload — the cross-library delta is
+ *   the signal, not the absolute count. `cl100k_base` is a real BPE tokenizer,
+ *   pure-JS (no native/wasm deps — works on every CI OS), and stable. The
+ *   choice is documented in `benchmark/COMPETITORS.md` so the report is honest
+ *   about what "tokens" means.
+ */
+
+import { getEncoding, type Tiktoken } from 'js-tiktoken';
+
+export const TOKENIZER_ENCODING = 'cl100k_base' as const;
+
+let encoder: Tiktoken | null = null;
+
+function getEncoder(): Tiktoken {
+  if (encoder === null) {
+    encoder = getEncoding(TOKENIZER_ENCODING);
+  }
+  return encoder;
+}
+
+/**
+ * Exact token count for a string. Empty / non-string input counts as 0 so
+ * callers can pass possibly-undefined payloads without guarding.
+ */
+export function countTokens(text: string | null | undefined): number {
+  if (typeof text !== 'string' || text.length === 0) {
+    return 0;
+  }
+  return getEncoder().encode(text).length;
+}
+
+/**
+ * Token count for a structured value — JSON-stringified first. Used for tool
+ * responses and argument objects that are not already strings.
+ */
+export function countTokensOfValue(value: unknown): number {
+  if (value === null || value === undefined) {
+    return 0;
+  }
+  if (typeof value === 'string') {
+    return countTokens(value);
+  }
+  return countTokens(JSON.stringify(value));
+}


### PR DESCRIPTION
## Summary

Implements **#1255** — the shared foundation for the six-axis competitive benchmark suite (Epic #1254). This is PR 0.1; it unblocks the per-axis sub-issues (#1256–#1261).

- **`LibraryAdapter` base interface** in `benchmark-runner.ts` — every competitor (Playwright, Puppeteer, playwright-mcp, browser-use, Crawlee) and OpenChrome implement one shape so task code stays identical across libraries. `MCPAdapter` now extends it.
- **Exact tokenizer** (`tests/benchmark/utils/tokenizer.ts`, `cl100k_base` via `js-tiktoken`) — replaces the `Math.ceil(chars/4)` approximations in `matrix.ts` and `extraction-formats.ts`. The runner no longer guesses tokens; tasks own real counts.
- **Environment metadata + result envelope** — `utils/environment.ts` captures git SHA, OS, CPU, RAM, Chrome version, etc.; `utils/result-envelope.ts` + `schemas/result.schema.json` ensure every benchmark result carries reproducibility metadata and competitor version pins.
- **`benchmark/COMPETITORS.md`** — version-pin registry; documents the tokenizer choice (`cl100k_base` is a consistent, real, pure-JS tokenizer — no vendor publishes the exact Claude tokenizer, and the cross-library delta is the signal).
- **Removed `OC_COMPRESSION_RATIO = 15.3`** from `benchmark/parallel-isolated.mjs` — that file estimated OpenChrome token counts instead of measuring them; real OpenChrome throughput lands in #1258.
- Unit tests for all three new utilities.

## Test plan

- [ ] `npm install` (adds `js-tiktoken`)
- [ ] `npm test -- tests/benchmark` — tokenizer / environment / result-envelope / matrix suites pass
- [ ] `npm run build` succeeds (src unaffected; benchmark code is test-scoped)
- [ ] Verify no `chars/4` approximations remain in benchmark code

> Note: authored in an isolated git worktree due to concurrent sessions on this repo. CI is the authoritative validation for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)