### PR TITLE
feat(benchmark): static fixture server + latency runner (#1258 — C.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "benchmark:ci": "ts-node tests/benchmark/run.ts --ci",
     "bench:webvoyager:mock": "ts-node tests/benchmark/webvoyager/runner.ts --adapter mock",
     "bench:webvoyager:real": "ts-node tests/benchmark/webvoyager/runner.ts --adapter claude",
+    "bench:latency": "ts-node tests/benchmark/run-latency.ts",
     "test": "jest",
     "test:e2e": "node --expose-gc node_modules/.bin/jest --config tests/e2e/jest.e2e.config.js",
     "test:coverage": "jest --coverage",

--- a/tests/benchmark/fixtures/static-server.test.ts
+++ b/tests/benchmark/fixtures/static-server.test.ts
@@ -1,0 +1,89 @@
+/// <reference types="jest" />
+
+import * as http from 'http';
+import {
+  generateFixtureHtml,
+  startStaticFixtureServer,
+  PAGE_WEIGHTS,
+  StaticFixtureServer,
+} from './static-server';
+
+function get(url: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    http
+      .get(url, (res) => {
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => (body += chunk));
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body }));
+      })
+      .on('error', reject);
+  });
+}
+
+describe('static fixture server', () => {
+  describe('generateFixtureHtml', () => {
+    test('is deterministic — byte-identical for a given weight', () => {
+      for (const weight of PAGE_WEIGHTS) {
+        expect(generateFixtureHtml(weight)).toBe(generateFixtureHtml(weight));
+      }
+    });
+
+    test('weights are strictly ordered by size', () => {
+      const small = generateFixtureHtml('small').length;
+      const medium = generateFixtureHtml('medium').length;
+      const large = generateFixtureHtml('large').length;
+      expect(small).toBeLessThan(medium);
+      expect(medium).toBeLessThan(large);
+    });
+
+    test('produces valid-looking HTML documents', () => {
+      const html = generateFixtureHtml('small');
+      expect(html).toContain('<!doctype html>');
+      expect(html).toContain('</html>');
+      expect(html).toContain('<article class="item"');
+    });
+  });
+
+  describe('server lifecycle', () => {
+    let server: StaticFixtureServer;
+
+    beforeAll(async () => {
+      server = await startStaticFixtureServer();
+    });
+
+    afterAll(async () => {
+      await server.close();
+    });
+
+    test('listens on an ephemeral loopback port', () => {
+      expect(server.port).toBeGreaterThan(0);
+      expect(server.url('small')).toBe(`http://127.0.0.1:${server.port}/small`);
+    });
+
+    test('serves each page weight with matching deterministic body', async () => {
+      for (const weight of PAGE_WEIGHTS) {
+        const res = await get(server.url(weight));
+        expect(res.status).toBe(200);
+        expect(res.body).toBe(generateFixtureHtml(weight));
+      }
+    });
+
+    test('returns identical bytes on repeated requests — no per-request variance', async () => {
+      const a = await get(server.url('medium'));
+      const b = await get(server.url('medium'));
+      expect(a.body).toBe(b.body);
+    });
+
+    test('404s unknown routes', async () => {
+      const res = await get(`http://127.0.0.1:${server.port}/not-a-fixture`);
+      expect(res.status).toBe(404);
+    });
+
+    test('close() is idempotent', async () => {
+      const temp = await startStaticFixtureServer();
+      await temp.close();
+      await expect(temp.close()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/tests/benchmark/fixtures/static-server.ts
+++ b/tests/benchmark/fixtures/static-server.ts
@@ -1,0 +1,115 @@
+/**
+ * Local static fixture server for the competitive benchmark suite.
+ *
+ * Latency and throughput measurements (#1258) must have zero network variance
+ * and byte-identical input across every library, so they run against this
+ * local server rather than live sites. Each route serves a deterministically
+ * generated HTML page of a controlled DOM weight — no timestamps, no random,
+ * so a given weight is byte-identical on every request and every run.
+ */
+
+import * as http from 'http';
+import type { AddressInfo } from 'net';
+
+export type PageWeight = 'small' | 'medium' | 'large';
+
+export const PAGE_WEIGHTS: readonly PageWeight[] = ['small', 'medium', 'large'];
+
+/** Number of repeated content nodes per weight tier. */
+const WEIGHT_NODE_COUNT: Record<PageWeight, number> = {
+  small: 25,
+  medium: 500,
+  large: 5000,
+};
+
+/**
+ * Deterministically generate a fixture HTML page of the given weight.
+ * Byte-identical for a given weight on every call.
+ */
+export function generateFixtureHtml(weight: PageWeight): string {
+  const count = WEIGHT_NODE_COUNT[weight];
+  const rows: string[] = [];
+  for (let i = 0; i < count; i++) {
+    rows.push(
+      `<article class="item" data-index="${i}">` +
+        `<h2>Item ${i}</h2>` +
+        `<p>Deterministic body text for benchmark item ${i}. ` +
+        `Stable content so latency and throughput have no input variance.</p>` +
+        `<a href="/item/${i}">link ${i}</a>` +
+        '</article>',
+    );
+  }
+  return (
+    '<!doctype html><html lang="en"><head>' +
+    `<meta charset="utf-8"><title>Benchmark fixture - ${weight}</title>` +
+    '</head><body>' +
+    `<header><h1>Benchmark fixture: ${weight}</h1></header>` +
+    `<main>${rows.join('')}</main>` +
+    '<footer><p>openchrome benchmark static fixture</p></footer>' +
+    '</body></html>'
+  );
+}
+
+function isPageWeight(value: string): value is PageWeight {
+  return (PAGE_WEIGHTS as readonly string[]).includes(value);
+}
+
+export interface StaticFixtureServer {
+  /** Port the server is listening on (ephemeral). */
+  readonly port: number;
+  /** Absolute URL for a given page weight. */
+  url(weight: PageWeight): string;
+  /** Stop the server. Safe to call more than once. */
+  close(): Promise<void>;
+}
+
+/**
+ * Start the local static fixture server on an ephemeral loopback port. The
+ * caller owns the lifecycle and must call `close()` when done.
+ */
+export async function startStaticFixtureServer(): Promise<StaticFixtureServer> {
+  // Pre-generate each body once — every request for a weight returns the
+  // identical bytes, so the server adds no per-request variance.
+  const bodies = new Map<PageWeight, string>();
+  for (const weight of PAGE_WEIGHTS) {
+    bodies.set(weight, generateFixtureHtml(weight));
+  }
+
+  const server = http.createServer((req, res) => {
+    const pathname = (req.url ?? '/').replace(/^\/+/, '').split('?')[0];
+    if (isPageWeight(pathname)) {
+      const body = bodies.get(pathname) as string;
+      res.writeHead(200, {
+        'content-type': 'text/html; charset=utf-8',
+        'content-length': Buffer.byteLength(body),
+        'cache-control': 'no-store',
+      });
+      res.end(body);
+      return;
+    }
+    res.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
+    res.end('not a benchmark fixture route');
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  const { port } = server.address() as AddressInfo;
+  let closed = false;
+
+  return {
+    port,
+    url(weight: PageWeight): string {
+      return `http://127.0.0.1:${port}/${weight}`;
+    },
+    close(): Promise<void> {
+      if (closed) return Promise.resolve();
+      closed = true;
+      return new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    },
+  };
+}

--- a/tests/benchmark/latency.test.ts
+++ b/tests/benchmark/latency.test.ts
@@ -1,0 +1,128 @@
+/// <reference types="jest" />
+
+import { MCPAdapter, MCPToolResult } from './benchmark-runner';
+import {
+  summarizeLatencies,
+  measureLatency,
+  DEFAULT_WARMUP_DISCARD,
+} from './latency';
+
+describe('summarizeLatencies', () => {
+  test('discards the warm-up prefix before computing the distribution', () => {
+    // First 3 samples are inflated warm-up; only [10,10,10,10] should count.
+    const summary = summarizeLatencies('warm', [999, 999, 999, 10, 10, 10, 10], 3);
+    expect(summary.warmupDiscarded).toBe(3);
+    expect(summary.sampleCount).toBe(4);
+    expect(summary.meanMs).toBe(10);
+    expect(summary.maxMs).toBe(10);
+    expect(summary.samples).toEqual([10, 10, 10, 10]);
+  });
+
+  test('computes p50 and p95 from kept samples', () => {
+    const raw = Array.from({ length: 100 }, (_, i) => i + 1); // 1..100
+    const summary = summarizeLatencies('cold', raw, 0);
+    expect(summary.p50Ms).toBe(50);
+    expect(summary.p95Ms).toBe(95);
+    expect(summary.minMs).toBe(1);
+    expect(summary.maxMs).toBe(100);
+  });
+
+  test('bootstrap CI brackets the mean', () => {
+    const summary = summarizeLatencies('warm', [8, 9, 10, 11, 12, 13], 0);
+    const [lo, hi] = summary.ci95Ms;
+    expect(lo).toBeLessThanOrEqual(summary.meanMs);
+    expect(hi).toBeGreaterThanOrEqual(summary.meanMs);
+  });
+
+  test('throws when warm-up discard leaves no samples', () => {
+    expect(() => summarizeLatencies('cold', [1, 2, 3], 3)).toThrow(/no latency samples left/);
+  });
+
+  test('rejects a negative or non-integer warm-up discard', () => {
+    expect(() => summarizeLatencies('cold', [1, 2, 3], -1)).toThrow(/non-negative integer/);
+    expect(() => summarizeLatencies('cold', [1, 2, 3], 1.5)).toThrow(/non-negative integer/);
+  });
+});
+
+/**
+ * Records the tool-call sequence so the test can assert cold vs warm drive
+ * the adapter differently.
+ */
+function makeRecordingAdapter(): { adapter: MCPAdapter; calls: string[] } {
+  const calls: string[] = [];
+  let tabSeq = 0;
+  const adapter: MCPAdapter = {
+    name: 'recording-stub',
+    mode: 'dom',
+    async callTool(tool: string): Promise<MCPToolResult> {
+      calls.push(tool);
+      if (tool === 'tabs_create') {
+        return { content: [{ type: 'text', text: JSON.stringify({ tabId: `tab-${++tabSeq}` }) }] };
+      }
+      return { content: [{ type: 'text', text: 'ok' }] };
+    },
+  };
+  return { adapter, calls };
+}
+
+describe('measureLatency', () => {
+  test('warm mode creates one tab and re-reads it each iteration', async () => {
+    const { adapter, calls } = makeRecordingAdapter();
+    const summary = await measureLatency(adapter, {
+      mode: 'warm',
+      url: 'http://127.0.0.1/small',
+      iterations: 5,
+      warmupDiscard: 2,
+    });
+    expect(calls.filter((c) => c === 'tabs_create')).toHaveLength(1);
+    expect(calls.filter((c) => c === 'read_page')).toHaveLength(5);
+    expect(calls.filter((c) => c === 'tabs_close')).toHaveLength(1);
+    expect(summary.sampleCount).toBe(3); // 5 iterations - 2 warm-up
+    expect(summary.mode).toBe('warm');
+  });
+
+  test('cold mode creates a fresh tab for every iteration', async () => {
+    const { adapter, calls } = makeRecordingAdapter();
+    const summary = await measureLatency(adapter, {
+      mode: 'cold',
+      url: 'http://127.0.0.1/small',
+      iterations: 4,
+      warmupDiscard: 1,
+    });
+    expect(calls.filter((c) => c === 'tabs_create')).toHaveLength(4);
+    expect(calls.filter((c) => c === 'read_page')).toHaveLength(4);
+    expect(calls.filter((c) => c === 'tabs_close')).toHaveLength(4);
+    expect(summary.sampleCount).toBe(3); // 4 iterations - 1 warm-up
+  });
+
+  test('defaults to DEFAULT_WARMUP_DISCARD when not specified', async () => {
+    const { adapter } = makeRecordingAdapter();
+    const summary = await measureLatency(adapter, {
+      mode: 'warm',
+      url: 'http://127.0.0.1/small',
+      iterations: DEFAULT_WARMUP_DISCARD + 2,
+    });
+    expect(summary.warmupDiscarded).toBe(DEFAULT_WARMUP_DISCARD);
+    expect(summary.sampleCount).toBe(2);
+  });
+
+  test('rejects iterations that do not exceed the warm-up discard', async () => {
+    const { adapter } = makeRecordingAdapter();
+    await expect(
+      measureLatency(adapter, { mode: 'cold', url: 'http://x/small', iterations: 3, warmupDiscard: 3 }),
+    ).rejects.toThrow(/must be an integer greater than warmupDiscard/);
+  });
+
+  test('throws when tabs_create yields no tabId', async () => {
+    const adapter: MCPAdapter = {
+      name: 'bad-stub',
+      mode: 'dom',
+      async callTool(): Promise<MCPToolResult> {
+        return { content: [{ type: 'text', text: 'no tab here' }] };
+      },
+    };
+    await expect(
+      measureLatency(adapter, { mode: 'warm', url: 'http://x/small', iterations: 5 }),
+    ).rejects.toThrow(/could not resolve tabId/);
+  });
+});

--- a/tests/benchmark/latency.ts
+++ b/tests/benchmark/latency.ts
@@ -1,0 +1,149 @@
+/**
+ * Single-action latency measurement for the Speed & Throughput axis (#1258).
+ *
+ * Two measurement modes, reported separately (Epic #1254 / issue #1258):
+ *   - cold: new tab -> navigate -> read_page  (first-touch cost)
+ *   - warm: read_page on an already-loaded page
+ *
+ * Warm-up iterations are discarded before timing — JIT warm-up, GC settling,
+ * and OS file-cache priming inflate the first runs. The discard count is
+ * recorded in the summary so the result is honest about what was dropped.
+ */
+
+import { MCPAdapter, MCPToolResult, BenchmarkRunner } from './benchmark-runner';
+
+export type LatencyMode = 'cold' | 'warm';
+
+export const DEFAULT_WARMUP_DISCARD = 3;
+
+export interface LatencySummary {
+  mode: LatencyMode;
+  /** Samples kept after discarding the warm-up prefix. */
+  sampleCount: number;
+  /** Warm-up iterations discarded before timing. */
+  warmupDiscarded: number;
+  p50Ms: number;
+  p95Ms: number;
+  meanMs: number;
+  minMs: number;
+  maxMs: number;
+  /** Bootstrap 95% CI of the mean. */
+  ci95Ms: [number, number];
+  /** Wall-clock ms of each kept sample, in measurement order. */
+  samples: number[];
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return sorted[idx];
+}
+
+/**
+ * Summarize raw latency samples: drop the warm-up prefix, then compute the
+ * distribution. Pure function — the unit-testable core of the runner.
+ */
+export function summarizeLatencies(
+  mode: LatencyMode,
+  rawSamples: number[],
+  warmupDiscard: number,
+): LatencySummary {
+  if (!Number.isInteger(warmupDiscard) || warmupDiscard < 0) {
+    throw new Error(`warmupDiscard must be a non-negative integer, got ${warmupDiscard}`);
+  }
+  const kept = rawSamples.slice(warmupDiscard);
+  if (kept.length === 0) {
+    throw new Error(
+      `no latency samples left after discarding ${warmupDiscard} warm-up of ${rawSamples.length}`,
+    );
+  }
+  const mean = kept.reduce((a, b) => a + b, 0) / kept.length;
+  return {
+    mode,
+    sampleCount: kept.length,
+    warmupDiscarded: Math.min(warmupDiscard, rawSamples.length),
+    p50Ms: percentile(kept, 50),
+    p95Ms: percentile(kept, 95),
+    meanMs: mean,
+    minMs: Math.min(...kept),
+    maxMs: Math.max(...kept),
+    ci95Ms: BenchmarkRunner.bootstrapCI(kept),
+    samples: kept,
+  };
+}
+
+export interface MeasureLatencyOptions {
+  mode: LatencyMode;
+  /** Target URL — navigated to via tabs_create. */
+  url: string;
+  /** Total iterations to run, including the warm-up prefix. */
+  iterations: number;
+  /** Warm-up iterations discarded before timing. Default 3. */
+  warmupDiscard?: number;
+  /** read_page mode passed to the adapter. Default 'dom'. */
+  readMode?: string;
+}
+
+function extractTabId(result: MCPToolResult): string {
+  for (const item of result.content ?? []) {
+    if (typeof item.text !== 'string') continue;
+    try {
+      const parsed = JSON.parse(item.text) as { tabId?: unknown };
+      if (typeof parsed.tabId === 'string' && parsed.tabId.length > 0) {
+        return parsed.tabId;
+      }
+    } catch {
+      // non-JSON text payload — keep looking
+    }
+  }
+  throw new Error('could not resolve tabId from tabs_create response');
+}
+
+/**
+ * Drive an adapter to measure single-action latency against `url`.
+ *
+ * cold: each iteration creates a fresh tab (new tab + navigate), reads it,
+ *       then closes it — so every sample pays the first-touch cost.
+ * warm: one tab is created + navigated once, then each iteration only
+ *       re-reads the already-loaded page.
+ */
+export async function measureLatency(
+  adapter: MCPAdapter,
+  options: MeasureLatencyOptions,
+): Promise<LatencySummary> {
+  const warmupDiscard = options.warmupDiscard ?? DEFAULT_WARMUP_DISCARD;
+  const readMode = options.readMode ?? 'dom';
+  if (!Number.isInteger(options.iterations) || options.iterations <= warmupDiscard) {
+    throw new Error(
+      `iterations (${options.iterations}) must be an integer greater than warmupDiscard (${warmupDiscard})`,
+    );
+  }
+
+  const raw: number[] = [];
+
+  if (options.mode === 'warm') {
+    const created = await adapter.callTool('tabs_create', { url: options.url });
+    const tabId = extractTabId(created);
+    try {
+      for (let i = 0; i < options.iterations; i++) {
+        const start = process.hrtime.bigint();
+        await adapter.callTool('read_page', { tabId, mode: readMode });
+        raw.push(Number(process.hrtime.bigint() - start) / 1e6);
+      }
+    } finally {
+      await adapter.callTool('tabs_close', { tabId }).catch(() => undefined);
+    }
+  } else {
+    for (let i = 0; i < options.iterations; i++) {
+      const start = process.hrtime.bigint();
+      const created = await adapter.callTool('tabs_create', { url: options.url });
+      const tabId = extractTabId(created);
+      await adapter.callTool('read_page', { tabId, mode: readMode });
+      raw.push(Number(process.hrtime.bigint() - start) / 1e6);
+      await adapter.callTool('tabs_close', { tabId }).catch(() => undefined);
+    }
+  }
+
+  return summarizeLatencies(options.mode, raw, warmupDiscard);
+}

--- a/tests/benchmark/run-latency.ts
+++ b/tests/benchmark/run-latency.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env ts-node
+/**
+ * Latency runner for the Speed & Throughput axis (#1258).
+ *
+ * Measures single-action latency (cold + warm, reported separately) against
+ * the local static fixture server — zero network variance, byte-identical
+ * input. Warm-up iterations are discarded. Results are wrapped in the standard
+ * benchmark envelope (#1255) so they carry environment metadata + version pins.
+ *
+ *   npm run bench:latency                 # real OpenChrome adapter (needs build)
+ *   npm run bench:latency -- --ci          # stub adapter, deterministic, no Chrome
+ *   npm run bench:latency -- --iterations 20
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { MCPAdapter } from './benchmark-runner';
+import { OpenChromeStubAdapter, OpenChromeRealAdapter } from './adapters';
+import { startStaticFixtureServer, PAGE_WEIGHTS, PageWeight } from './fixtures/static-server';
+import { measureLatency, LatencyMode, LatencySummary, DEFAULT_WARMUP_DISCARD } from './latency';
+import { captureEnvironment } from './utils/environment';
+import { buildResultEnvelope, assertValidResultEnvelope } from './utils/result-envelope';
+
+const OUTPUT_PATH = path.join(process.cwd(), 'benchmark', 'results', 'speed-latency.json');
+const MODES: readonly LatencyMode[] = ['cold', 'warm'];
+
+export interface LatencyRunOptions {
+  ciMode: boolean;
+  iterations: number;
+  warmupDiscard: number;
+}
+
+export interface LatencyRow {
+  weight: PageWeight;
+  mode: LatencyMode;
+  p50Ms: number;
+  p95Ms: number;
+  meanMs: number;
+  minMs: number;
+  maxMs: number;
+  ci95Ms: [number, number];
+  sampleCount: number;
+  warmupDiscarded: number;
+}
+
+export function parseLatencyArgs(argv: string[]): LatencyRunOptions {
+  const ciMode = argv.includes('--ci');
+  let iterations = ciMode ? DEFAULT_WARMUP_DISCARD + 3 : DEFAULT_WARMUP_DISCARD + 9;
+  const idx = argv.indexOf('--iterations');
+  if (idx !== -1 && idx + 1 < argv.length) {
+    const raw = argv[idx + 1].trim();
+    const n = parseInt(raw, 10);
+    if (!Number.isInteger(n) || n <= 0 || String(n) !== raw) {
+      throw new Error(`--iterations must be a positive integer; got: ${argv[idx + 1]}`);
+    }
+    iterations = n;
+  }
+  if (iterations <= DEFAULT_WARMUP_DISCARD) {
+    throw new Error(
+      `--iterations (${iterations}) must exceed the warm-up discard (${DEFAULT_WARMUP_DISCARD})`,
+    );
+  }
+  return { ciMode, iterations, warmupDiscard: DEFAULT_WARMUP_DISCARD };
+}
+
+function toRow(weight: PageWeight, summary: LatencySummary): LatencyRow {
+  return {
+    weight,
+    mode: summary.mode,
+    p50Ms: summary.p50Ms,
+    p95Ms: summary.p95Ms,
+    meanMs: summary.meanMs,
+    minMs: summary.minMs,
+    maxMs: summary.maxMs,
+    ci95Ms: summary.ci95Ms,
+    sampleCount: summary.sampleCount,
+    warmupDiscarded: summary.warmupDiscarded,
+  };
+}
+
+function readRepoVersion(): string {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
+    return typeof pkg.version === 'string' ? pkg.version : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+export async function runLatencyBenchmark(options: LatencyRunOptions): Promise<LatencyRow[]> {
+  const server = await startStaticFixtureServer();
+  const adapter: MCPAdapter = options.ciMode
+    ? new OpenChromeStubAdapter({ mode: 'dom' })
+    : new OpenChromeRealAdapter({ mode: 'dom' });
+
+  const rows: LatencyRow[] = [];
+  try {
+    if (adapter.setup) await adapter.setup();
+    for (const weight of PAGE_WEIGHTS) {
+      for (const mode of MODES) {
+        const summary = await measureLatency(adapter, {
+          mode,
+          url: server.url(weight),
+          iterations: options.iterations,
+          warmupDiscard: options.warmupDiscard,
+        });
+        rows.push(toRow(weight, summary));
+      }
+    }
+  } finally {
+    if (adapter.teardown) await adapter.teardown();
+    await server.close();
+  }
+  return rows;
+}
+
+function formatReport(rows: LatencyRow[]): string {
+  const lines = ['Latency benchmark (#1258) — single-action, warm-up discarded'];
+  lines.push('weight   mode   p50(ms)   p95(ms)   mean(ms)   samples');
+  for (const r of rows) {
+    lines.push(
+      [
+        r.weight.padEnd(7),
+        r.mode.padEnd(5),
+        r.p50Ms.toFixed(1).padStart(8),
+        r.p95Ms.toFixed(1).padStart(9),
+        r.meanMs.toFixed(1).padStart(10),
+        String(r.sampleCount).padStart(9),
+      ].join(' '),
+    );
+  }
+  return lines.join('\n');
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  const options = parseLatencyArgs(argv);
+  const rows = await runLatencyBenchmark(options);
+
+  const envelope = buildResultEnvelope({
+    axis: 'speed-throughput',
+    environment: captureEnvironment(),
+    competitors: [{ name: 'OpenChrome', version: readRepoVersion() }],
+    results: rows,
+  });
+  assertValidResultEnvelope(envelope);
+
+  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(envelope, null, 2) + '\n');
+
+  // console.error: stdout carries MCP JSON-RPC in this codebase; never log there.
+  console.error(formatReport(rows));
+  console.error(`\nSaved: ${path.relative(process.cwd(), OUTPUT_PATH)}`);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('Latency benchmark failed:', err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

First work unit of **#1258** (Speed & Throughput axis, Epic #1254). **Stacked on #1262** (`feat/1255-benchmark-harness-foundation`) — review/merge that first.

- **Local static fixture server** (`tests/benchmark/fixtures/static-server.ts`) — serves deterministically generated HTML at `small`/`medium`/`large` DOM weights on an ephemeral loopback port. Zero network variance, byte-identical input across every library and run.
- **Latency measurement core** (`tests/benchmark/latency.ts`) — `cold` (new tab → navigate → read_page) and `warm` (re-read a loaded page) modes reported separately; warm-up iterations discarded before timing with the discard count recorded; p50/p95 + bootstrap 95% CI.
- **Latency runner** (`tests/benchmark/run-latency.ts`) — wraps results in the standard envelope (#1255), writes `benchmark/results/speed-latency.json`. `--ci` uses the stub adapter for a deterministic, Chrome-free smoke run.
- `npm run bench:latency` script.

## Test plan

- [x] `npx jest tests/benchmark/latency.test.ts tests/benchmark/fixtures/static-server.test.ts` — 18/18 pass locally
- [x] `npx ts-node tests/benchmark/run-latency.ts --ci` — produces a schema-valid envelope with environment metadata
- [ ] CI green
- [ ] Real-adapter run against Chrome produces non-zero latencies (follow-up; C.2 wires competitor adapters)

> Note: depends on #1262. Authored in an isolated git worktree due to concurrent sessions on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)