### PR TITLE
feat(benchmark): token-efficiency scoring core (#1256 — A.2 core)

### DIFF
--- a/tests/benchmark/token-efficiency.test.ts
+++ b/tests/benchmark/token-efficiency.test.ts
@@ -1,0 +1,136 @@
+/// <reference types="jest" />
+
+import {
+  normalizeValue,
+  computeRetention,
+  scorePayload,
+  compressionRatio,
+  efficiencyPoint,
+  GroundTruthSpec,
+  MIN_GROUND_TRUTH_FIELDS,
+} from './token-efficiency';
+
+/** A valid >= 12-field ground truth for a synthetic product-page fixture. */
+function productGroundTruth(): GroundTruthSpec {
+  const fields = [
+    { key: 'title', expected: 'Wireless Headphones' },
+    { key: 'price', expected: '$199.00' },
+    { key: 'brand', expected: 'Acme Audio' },
+    { key: 'sku', expected: 'AA-WH-001' },
+    { key: 'rating', expected: '4.6' },
+    { key: 'reviewCount', expected: '1283' },
+    { key: 'availability', expected: 'In stock' },
+    { key: 'primaryCta', expected: 'Add to cart' },
+    { key: 'shippingNote', expected: 'Free shipping over $50' },
+    { key: 'category', expected: 'Audio' },
+    { key: 'color', expected: 'Midnight Black' },
+    { key: 'warranty', expected: '2 year limited' },
+  ];
+  return { fixture: 'product-01', fields };
+}
+
+describe('normalizeValue', () => {
+  test('strips markup, collapses whitespace, trims, lowercases', () => {
+    expect(normalizeValue('  <b>Hello</b>   World  ')).toBe('hello world');
+    expect(normalizeValue('PRICE:\n  $9.99')).toBe('price: $9.99');
+  });
+
+  test('two values that differ only in markup/whitespace/case normalize equal', () => {
+    expect(normalizeValue('<span>Add to Cart</span>')).toBe(normalizeValue('ADD TO   CART'));
+  });
+});
+
+describe('computeRetention', () => {
+  test('full structured extraction retains every field', () => {
+    const gt = productGroundTruth();
+    const extracted = Object.fromEntries(gt.fields.map((f) => [f.key, f.expected]));
+    const result = computeRetention(extracted, gt);
+    expect(result.fieldsTotal).toBe(12);
+    expect(result.fieldsRetained).toBe(12);
+    expect(result.retention).toBe(1);
+    expect(result.missingKeys).toEqual([]);
+  });
+
+  test('missing, null, and mismatched fields all count as not retained', () => {
+    const gt = productGroundTruth();
+    const extracted: Record<string, string | null> = Object.fromEntries(
+      gt.fields.map((f) => [f.key, f.expected]),
+    );
+    extracted.price = null; // null
+    extracted.brand = 'Wrong Brand'; // mismatch
+    delete extracted.sku; // missing
+    const result = computeRetention(extracted, gt);
+    expect(result.fieldsRetained).toBe(9);
+    expect(result.retention).toBeCloseTo(9 / 12);
+    expect(result.missingKeys.sort()).toEqual(['brand', 'price', 'sku']);
+  });
+
+  test('matches values that differ only in markup/whitespace/case', () => {
+    const gt = productGroundTruth();
+    const extracted = Object.fromEntries(gt.fields.map((f) => [f.key, f.expected]));
+    extracted.primaryCta = '  <button>ADD TO CART</button> ';
+    const result = computeRetention(extracted, gt);
+    expect(result.fieldsRetained).toBe(12);
+  });
+
+  test('a raw-blob dump cannot game retention — only structured keys count', () => {
+    const gt = productGroundTruth();
+    // Every expected value exists as a substring of this blob, but it is not
+    // a structured, field-keyed extraction, so it retains nothing.
+    const blob = gt.fields.map((f) => f.expected).join(' | ');
+    const result = computeRetention({ rawHtml: blob }, gt);
+    expect(result.fieldsRetained).toBe(0);
+    expect(result.retention).toBe(0);
+  });
+
+  test('throws when ground truth has fewer than the minimum fields', () => {
+    const tooFew: GroundTruthSpec = {
+      fixture: 'thin',
+      fields: [
+        { key: 'title', expected: 'a' },
+        { key: 'price', expected: 'b' },
+        { key: 'image', expected: 'c' },
+      ],
+    };
+    expect(() => computeRetention({}, tooFew)).toThrow(
+      new RegExp(`>= ${MIN_GROUND_TRUTH_FIELDS} required`),
+    );
+  });
+});
+
+describe('scorePayload', () => {
+  test('reports exact token count and char length', () => {
+    const score = scorePayload('hello world');
+    expect(score.chars).toBe(11);
+    expect(score.tokens).toBeGreaterThan(0);
+  });
+
+  test('empty payload scores zero', () => {
+    expect(scorePayload('')).toEqual({ tokens: 0, chars: 0 });
+  });
+});
+
+describe('compressionRatio', () => {
+  test('a smaller payload than raw HTML yields a ratio > 1', () => {
+    const rawHtml = '<html><body>' + '<div class="x">content</div>'.repeat(200) + '</body></html>';
+    const compact = 'content '.repeat(20);
+    expect(compressionRatio(rawHtml, compact)).toBeGreaterThan(1);
+  });
+
+  test('handles an empty payload without dividing by zero', () => {
+    expect(compressionRatio('something', '')).toBe(Infinity);
+    expect(compressionRatio('', '')).toBe(1);
+  });
+});
+
+describe('efficiencyPoint', () => {
+  test('assembles tokens + retention for one (library, fixture) cell', () => {
+    const gt = productGroundTruth();
+    const extracted = Object.fromEntries(gt.fields.map((f) => [f.key, f.expected]));
+    const point = efficiencyPoint('OpenChrome', gt, extracted, '{"title":"Wireless Headphones"}');
+    expect(point.library).toBe('OpenChrome');
+    expect(point.fixture).toBe('product-01');
+    expect(point.retention).toBe(1);
+    expect(point.tokens).toBeGreaterThan(0);
+  });
+});

--- a/tests/benchmark/token-efficiency.ts
+++ b/tests/benchmark/token-efficiency.ts
@@ -1,0 +1,150 @@
+/**
+ * Token-efficiency scoring core for the Token Efficiency axis (#1256).
+ *
+ * Every library's page payload is scored on two things:
+ *   1. token cost — exact cl100k_base token count of the payload (#1255)
+ *   2. retention  — did the payload actually preserve the page's key fields?
+ *
+ * Retention is the metric that stops "innerText is smallest, so it wins" from
+ * being a false conclusion. Critically (a P0 fix from the #1256 design
+ * review): retention is scored against a library's *structured / parsed*
+ * extraction, NOT a substring match against a raw blob — a tool that dumps raw
+ * HTML must not score 100% retention just because every value happens to exist
+ * somewhere in the dump. This module only accepts structured, field-keyed
+ * extractions, which enforces that rule by construction.
+ */
+
+import { countTokens } from './utils/tokenizer';
+
+/** A single expected field of a fixture's ground truth. */
+export interface GroundTruthField {
+  /** Stable field key, e.g. "title", "price", "primaryCta". */
+  key: string;
+  /** Expected value, pre-normalization. */
+  expected: string;
+}
+
+/**
+ * The ground-truth spec for one fixture. Per the #1256 design review, this
+ * must carry >= 12 fields so the retention metric is not quantized into
+ * uselessly coarse buckets (3 fields => only {0, 33, 67, 100}%).
+ */
+export interface GroundTruthSpec {
+  fixture: string;
+  fields: GroundTruthField[];
+}
+
+export const MIN_GROUND_TRUTH_FIELDS = 12;
+
+/**
+ * Documented normalization applied to BOTH the expected value and the
+ * extracted value before comparison: strip markup, collapse whitespace, trim,
+ * lowercase. Committed up front so "present" has one precise, uniform meaning.
+ */
+export function normalizeValue(value: string): string {
+  return value
+    .replace(/<[^>]+>/g, ' ') // strip markup
+    .replace(/\s+/g, ' ') // collapse whitespace
+    .trim()
+    .toLowerCase();
+}
+
+export interface RetentionResult {
+  fixture: string;
+  fieldsTotal: number;
+  fieldsRetained: number;
+  /** fieldsRetained / fieldsTotal, in [0, 1]. */
+  retention: number;
+  /** Keys that were expected but missing, null, or mismatched. */
+  missingKeys: string[];
+}
+
+/**
+ * Compute the information-retention rate of a library's *structured*
+ * extraction against a fixture's ground truth.
+ *
+ * `extracted` is a field-keyed record — the library's parsed output, never a
+ * raw blob. A field is "retained" when its normalized extracted value equals
+ * the normalized expected value. Missing keys, null/undefined values, and
+ * mismatches all count as not-retained.
+ */
+export function computeRetention(
+  extracted: Record<string, string | null | undefined>,
+  groundTruth: GroundTruthSpec,
+): RetentionResult {
+  if (groundTruth.fields.length < MIN_GROUND_TRUTH_FIELDS) {
+    throw new Error(
+      `ground truth for "${groundTruth.fixture}" has ${groundTruth.fields.length} fields; ` +
+        `>= ${MIN_GROUND_TRUTH_FIELDS} required so retention is not coarsely quantized`,
+    );
+  }
+  const missingKeys: string[] = [];
+  let retained = 0;
+  for (const field of groundTruth.fields) {
+    const actual = extracted[field.key];
+    if (typeof actual === 'string' && normalizeValue(actual) === normalizeValue(field.expected)) {
+      retained += 1;
+    } else {
+      missingKeys.push(field.key);
+    }
+  }
+  return {
+    fixture: groundTruth.fixture,
+    fieldsTotal: groundTruth.fields.length,
+    fieldsRetained: retained,
+    retention: retained / groundTruth.fields.length,
+    missingKeys,
+  };
+}
+
+export interface PayloadScore {
+  /** Exact cl100k_base token count of the payload. */
+  tokens: number;
+  /** Character length of the payload. */
+  chars: number;
+}
+
+/** Score the size of a payload a library would hand to an LLM. */
+export function scorePayload(payload: string): PayloadScore {
+  return { tokens: countTokens(payload), chars: payload.length };
+}
+
+/**
+ * Compression ratio of a tool's payload vs the raw HTML it was derived from.
+ * This is the real, measured replacement for the old unverified `15.3x`
+ * constant. A ratio > 1 means the tool's payload is smaller than raw HTML.
+ */
+export function compressionRatio(rawHtml: string, toolPayload: string): number {
+  const rawTokens = countTokens(rawHtml);
+  const payloadTokens = countTokens(toolPayload);
+  if (payloadTokens === 0) {
+    return rawTokens === 0 ? 1 : Infinity;
+  }
+  return rawTokens / payloadTokens;
+}
+
+/** One point on the tokens-vs-retention scatter — the upper-left wins. */
+export interface EfficiencyPoint {
+  library: string;
+  fixture: string;
+  tokens: number;
+  retention: number;
+}
+
+/**
+ * Build the efficiency point for one (library, fixture) cell. The winner of
+ * the axis sits in the upper-left of the scatter: few tokens, high retention.
+ */
+export function efficiencyPoint(
+  library: string,
+  groundTruth: GroundTruthSpec,
+  extracted: Record<string, string | null | undefined>,
+  payload: string,
+): EfficiencyPoint {
+  return {
+    library,
+    fixture: groundTruth.fixture,
+    tokens: scorePayload(payload).tokens,
+    retention: computeRetention(extracted, groundTruth).retention,
+  };
+}


### PR DESCRIPTION
## Summary

First work unit of **#1256** (Token Efficiency axis, Epic #1254). **Stacked on #1262** (`feat/1255-benchmark-harness-foundation`) — review/merge that first.

The pure scoring core of the axis — decoupled from the 50-fixture corpus (a later work unit) so the metric logic can be validated on its own.

- **`normalizeValue`** — the documented, uniform normalization (strip markup, collapse whitespace, trim, lowercase) applied to both expected and extracted values.
- **`computeRetention`** — information-retention rate against a **≥ 12-field** ground-truth spec. Enforces the #1256 design-review **P0 fix**: retention is scored against a library's *structured, field-keyed* extraction — **never a substring match against a raw blob** — so a tool that dumps raw HTML cannot score 100%. Throws on `< 12` fields (avoids the coarse `{0,33,67,100}%` quantization a 3-field spec produces).
- **`scorePayload` / `compressionRatio`** — exact `cl100k_base` token cost and compression ratio vs raw HTML: the real, measured replacement for the unverified `15.3x` constant removed in #1255.
- **`efficiencyPoint`** — assembles the `(tokens, retention)` scatter point; axis winner sits upper-left.

## Test plan

- [x] `npx jest tests/benchmark/token-efficiency.test.ts` — 12/12 pass, including a guard that a raw-blob dump scores 0% retention
- [ ] CI green
- [ ] Wire to the 50-fixture corpus + runner (follow-up work unit A.1/A.2)

> Depends on #1262. Authored in an isolated git worktree due to concurrent sessions on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)