### PR TITLE
feat(benchmark): reliability metric core (#1259 — D core)

### DIFF
--- a/tests/benchmark/reliability.test.ts
+++ b/tests/benchmark/reliability.test.ts
@@ -1,0 +1,127 @@
+/// <reference types="jest" />
+
+import {
+  computeFlakyRate,
+  aggregateRecoveryRate,
+  summarizeStability,
+  MIN_FLAKY_SAMPLE_SIZE,
+  RecoveryRecord,
+  StabilitySample,
+} from './reliability';
+
+describe('computeFlakyRate', () => {
+  test('a perfectly deterministic run has flaky rate 0', () => {
+    const allPass = computeFlakyRate(Array(60).fill(true));
+    expect(allPass.flakyRate).toBe(0);
+    expect(allPass.successRate).toBe(1);
+
+    const allFail = computeFlakyRate(Array(60).fill(false));
+    expect(allFail.flakyRate).toBe(0);
+    expect(allFail.successRate).toBe(0);
+  });
+
+  test('a 50/50 split is maximally flaky', () => {
+    const outcomes = [...Array(30).fill(true), ...Array(30).fill(false)];
+    const result = computeFlakyRate(outcomes);
+    expect(result.flakyRate).toBeCloseTo(0.5);
+    expect(result.modeOutcomeCount).toBe(30);
+  });
+
+  test('mostly-passing run has a small flaky rate', () => {
+    const outcomes = [...Array(57).fill(true), ...Array(3).fill(false)];
+    const result = computeFlakyRate(outcomes);
+    expect(result.n).toBe(60);
+    expect(result.successCount).toBe(57);
+    expect(result.flakyRate).toBeCloseTo(3 / 60);
+  });
+
+  test('enforces the >= 50 sample minimum by default', () => {
+    expect(() => computeFlakyRate(Array(20).fill(true))).toThrow(
+      new RegExp(`>= ${MIN_FLAKY_SAMPLE_SIZE} samples`),
+    );
+  });
+
+  test('minSamples override allows direct arithmetic tests', () => {
+    const result = computeFlakyRate([true, false, true], { minSamples: 1 });
+    expect(result.n).toBe(3);
+    expect(result.flakyRate).toBeCloseTo(1 / 3);
+  });
+});
+
+describe('aggregateRecoveryRate', () => {
+  test('computes per-fault-type recovery rate', () => {
+    const records: RecoveryRecord[] = [
+      { faultType: 'stale-selector', recovered: true, stepsToRecover: 2, timeToRecoverMs: 100 },
+      { faultType: 'stale-selector', recovered: true, stepsToRecover: 4, timeToRecoverMs: 300 },
+      { faultType: 'stale-selector', recovered: false },
+      { faultType: 'tab-crash', recovered: false },
+      { faultType: 'tab-crash', recovered: false },
+    ];
+    const agg = aggregateRecoveryRate(records);
+    const stale = agg.find((a) => a.faultType === 'stale-selector')!;
+    expect(stale.injected).toBe(3);
+    expect(stale.recovered).toBe(2);
+    expect(stale.recoveryRate).toBeCloseTo(2 / 3);
+    expect(stale.meanStepsToRecover).toBe(3);
+    expect(stale.meanTimeToRecoverMs).toBe(200);
+
+    const crash = agg.find((a) => a.faultType === 'tab-crash')!;
+    expect(crash.recoveryRate).toBe(0);
+    expect(crash.meanStepsToRecover).toBeNull();
+  });
+
+  test('a competitor that always throws yields recoveryRate 0, not an error', () => {
+    const records: RecoveryRecord[] = [
+      { faultType: 'network-drop', recovered: false },
+      { faultType: 'network-drop', recovered: false },
+    ];
+    const agg = aggregateRecoveryRate(records);
+    expect(agg).toHaveLength(1);
+    expect(agg[0].recoveryRate).toBe(0);
+  });
+
+  test('only fault types present in the input are returned', () => {
+    const agg = aggregateRecoveryRate([{ faultType: 'cdp-drop', recovered: true }]);
+    expect(agg.map((a) => a.faultType)).toEqual(['cdp-drop']);
+  });
+
+  test('empty input yields no rows', () => {
+    expect(aggregateRecoveryRate([])).toEqual([]);
+  });
+});
+
+describe('summarizeStability', () => {
+  test('a flat RSS series shows no leak', () => {
+    const samples: StabilitySample[] = [
+      { tMs: 0, rssBytes: 100_000_000 },
+      { tMs: 30_000, rssBytes: 101_000_000 },
+      { tMs: 60_000, rssBytes: 100_500_000 },
+    ];
+    const summary = summarizeStability(samples);
+    expect(summary.suspectedLeak).toBe(false);
+    expect(Math.abs(summary.rssGrowthRatio)).toBeLessThan(0.5);
+  });
+
+  test('a steadily growing RSS series is flagged as a suspected leak', () => {
+    const samples: StabilitySample[] = Array.from({ length: 10 }, (_, i) => ({
+      tMs: i * 60_000,
+      rssBytes: 100_000_000 + i * 20_000_000, // +20MB every minute
+    }));
+    const summary = summarizeStability(samples);
+    expect(summary.suspectedLeak).toBe(true);
+    expect(summary.rssSlopeBytesPerSec).toBeGreaterThan(0);
+    expect(summary.rssGrowthRatio).toBeCloseTo(1.8);
+  });
+
+  test('sorts unordered samples before computing duration', () => {
+    const summary = summarizeStability([
+      { tMs: 60_000, rssBytes: 100_000_000 },
+      { tMs: 0, rssBytes: 100_000_000 },
+    ]);
+    expect(summary.durationMs).toBe(60_000);
+  });
+
+  test('requires at least two samples', () => {
+    expect(() => summarizeStability([{ tMs: 0, rssBytes: 1 }])).toThrow(/at least 2 samples/);
+  });
+});

--- a/tests/benchmark/reliability.ts
+++ b/tests/benchmark/reliability.ts
@@ -1,0 +1,199 @@
+/**
+ * Reliability metric core for the Reliability & Fault-Recovery axis (#1259).
+ *
+ * Pure scoring functions — the fault-injection harness that feeds them (CDP +
+ * proxy injectors) is a separate work unit. This module turns raw run
+ * outcomes into the three headline reliability numbers:
+ *   - flaky rate          (determinism of repeated runs)
+ *   - fault-recovery rate (per injected fault type)
+ *   - long-run stability  (memory-leak detection from an RSS sample series)
+ */
+
+/** Fault types injected by the reliability harness — chosen from first
+ *  principles as the failure modes any browser automation faces. */
+export type FaultType =
+  | 'stale-selector'
+  | 'network-drop'
+  | 'tab-crash'
+  | 'unexpected-modal'
+  | 'cdp-drop';
+
+export const FAULT_TYPES: readonly FaultType[] = [
+  'stale-selector',
+  'network-drop',
+  'tab-crash',
+  'unexpected-modal',
+  'cdp-drop',
+];
+
+/**
+ * Minimum sample size for a flaky-rate measurement. Per the #1259 design
+ * review, N must be >= 50 — at N=20 the metric resolves only to ~5pp.
+ */
+export const MIN_FLAKY_SAMPLE_SIZE = 50;
+
+export interface FlakyRateResult {
+  n: number;
+  successCount: number;
+  /** Count of the most common outcome (whichever of success/failure dominates). */
+  modeOutcomeCount: number;
+  /** 1 - modeOutcomeCount/N. 0 = perfectly deterministic; 0.5 = maximally flaky. */
+  flakyRate: number;
+  successRate: number;
+}
+
+/**
+ * Flaky rate over N repetitions of the same task. Lower is better — 0 means
+ * every run agreed. `minSamples` defaults to MIN_FLAKY_SAMPLE_SIZE; pass a
+ * lower value only in unit tests that exercise the arithmetic directly.
+ */
+export function computeFlakyRate(
+  outcomes: boolean[],
+  options: { minSamples?: number } = {},
+): FlakyRateResult {
+  const n = outcomes.length;
+  const minSamples = options.minSamples ?? MIN_FLAKY_SAMPLE_SIZE;
+  if (n < Math.max(1, minSamples)) {
+    throw new Error(
+      `flaky rate needs >= ${minSamples} samples (got ${n}); a smaller N cannot ` +
+        'resolve the metric finely enough to compare libraries',
+    );
+  }
+  const successCount = outcomes.filter(Boolean).length;
+  const failureCount = n - successCount;
+  const modeOutcomeCount = Math.max(successCount, failureCount);
+  return {
+    n,
+    successCount,
+    modeOutcomeCount,
+    flakyRate: 1 - modeOutcomeCount / n,
+    successRate: successCount / n,
+  };
+}
+
+export interface RecoveryRecord {
+  faultType: FaultType;
+  recovered: boolean;
+  /** Tool calls taken to recover, when recovered. */
+  stepsToRecover?: number;
+  /** Wall-clock ms taken to recover, when recovered. */
+  timeToRecoverMs?: number;
+}
+
+export interface RecoveryRateByFault {
+  faultType: FaultType;
+  injected: number;
+  recovered: number;
+  /** recovered / injected, in [0, 1]. */
+  recoveryRate: number;
+  /** Mean steps over recovered runs only, or null if none recovered. */
+  meanStepsToRecover: number | null;
+  /** Mean time over recovered runs only, or null if none recovered. */
+  meanTimeToRecoverMs: number | null;
+}
+
+function meanOrNull(values: number[]): number | null {
+  if (values.length === 0) return null;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+/**
+ * Aggregate per-fault-type recovery rate from a flat list of recovery
+ * records. A competitor that simply throws on a fault yields recovered=false
+ * records — a legitimate result, recorded as recoveryRate 0, not an error.
+ * Only fault types that actually appear in the input are returned.
+ */
+export function aggregateRecoveryRate(records: RecoveryRecord[]): RecoveryRateByFault[] {
+  const byType = new Map<FaultType, RecoveryRecord[]>();
+  for (const record of records) {
+    const bucket = byType.get(record.faultType) ?? [];
+    bucket.push(record);
+    byType.set(record.faultType, bucket);
+  }
+
+  const result: RecoveryRateByFault[] = [];
+  for (const faultType of FAULT_TYPES) {
+    const bucket = byType.get(faultType);
+    if (!bucket || bucket.length === 0) continue;
+    const recoveredRecords = bucket.filter((r) => r.recovered);
+    result.push({
+      faultType,
+      injected: bucket.length,
+      recovered: recoveredRecords.length,
+      recoveryRate: recoveredRecords.length / bucket.length,
+      meanStepsToRecover: meanOrNull(
+        recoveredRecords
+          .map((r) => r.stepsToRecover)
+          .filter((v): v is number => typeof v === 'number'),
+      ),
+      meanTimeToRecoverMs: meanOrNull(
+        recoveredRecords
+          .map((r) => r.timeToRecoverMs)
+          .filter((v): v is number => typeof v === 'number'),
+      ),
+    });
+  }
+  return result;
+}
+
+export interface StabilitySample {
+  /** Milliseconds since the run started. */
+  tMs: number;
+  /** Process RSS in bytes at that moment. */
+  rssBytes: number;
+}
+
+export interface StabilitySummary {
+  sampleCount: number;
+  durationMs: number;
+  firstRssBytes: number;
+  lastRssBytes: number;
+  /** Least-squares slope of RSS over time, in bytes/sec. > 0 suggests a leak. */
+  rssSlopeBytesPerSec: number;
+  /** (last - first) / first. */
+  rssGrowthRatio: number;
+  /** True when growth exceeds the leak threshold over the run. */
+  suspectedLeak: boolean;
+}
+
+/**
+ * Summarize a long-run RSS sample series for memory-leak detection. Uses a
+ * least-squares fit of RSS over time plus an end-to-end growth ratio; a leak
+ * is flagged when growth exceeds `leakThresholdRatio` (default 0.5 = +50%).
+ */
+export function summarizeStability(
+  samples: StabilitySample[],
+  options: { leakThresholdRatio?: number } = {},
+): StabilitySummary {
+  if (samples.length < 2) {
+    throw new Error('summarizeStability requires at least 2 samples');
+  }
+  const leakThresholdRatio = options.leakThresholdRatio ?? 0.5;
+  const ordered = [...samples].sort((a, b) => a.tMs - b.tMs);
+  const n = ordered.length;
+
+  // Least-squares slope of rssBytes over tMs.
+  const meanT = ordered.reduce((s, p) => s + p.tMs, 0) / n;
+  const meanR = ordered.reduce((s, p) => s + p.rssBytes, 0) / n;
+  let num = 0;
+  let den = 0;
+  for (const p of ordered) {
+    num += (p.tMs - meanT) * (p.rssBytes - meanR);
+    den += (p.tMs - meanT) ** 2;
+  }
+  const slopeBytesPerMs = den === 0 ? 0 : num / den;
+
+  const firstRssBytes = ordered[0].rssBytes;
+  const lastRssBytes = ordered[n - 1].rssBytes;
+  const rssGrowthRatio = firstRssBytes === 0 ? 0 : (lastRssBytes - firstRssBytes) / firstRssBytes;
+
+  return {
+    sampleCount: n,
+    durationMs: ordered[n - 1].tMs - ordered[0].tMs,
+    firstRssBytes,
+    lastRssBytes,
+    rssSlopeBytesPerSec: slopeBytesPerMs * 1000,
+    rssGrowthRatio,
+    suspectedLeak: rssGrowthRatio > leakThresholdRatio,
+  };
+}


### PR DESCRIPTION
## Summary

First work unit of **#1259** (Reliability & Fault-Recovery axis, Epic #1254). **Stacked on #1262** (`feat/1255-benchmark-harness-foundation`) — review/merge that first.

Pure scoring functions — the fault-injection harness that feeds them (CDP + proxy injectors) is a separate work unit. This module turns raw run outcomes into the axis's three headline numbers:

- **`computeFlakyRate`** — determinism of N repeated runs (`1 - modeOutcome/N`). Enforces the #1259 design-review **N ≥ 50** minimum by default (at N=20 the metric resolves only to ~5pp); a `minSamples` override exists for unit tests.
- **`aggregateRecoveryRate`** — per-fault-type recovery rate from recovery records. A competitor that simply throws on a fault yields `recovered=false` records, recorded as `recoveryRate 0` — a **legitimate result, never an error** (per the #1259 fairness note).
- **`summarizeStability`** — long-run RSS leak detection via least-squares slope + end-to-end growth ratio over a sample series.

## Test plan

- [x] `npx jest tests/benchmark/reliability.test.ts` — 13/13 pass
- [ ] CI green
- [ ] Wire to the fault-injection harness (follow-up work unit D.1)

> Depends on #1262. Authored in an isolated git worktree due to concurrent sessions on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)