### PR TITLE
feat(benchmark): developer-experience scoring core (#1261 — F core)

### DIFF
--- a/tests/benchmark/dx.test.ts
+++ b/tests/benchmark/dx.test.ts
@@ -1,0 +1,108 @@
+/// <reference types="jest" />
+
+import {
+  countSourceLines,
+  scoreErrorActionability,
+  meanActionability,
+} from './dx';
+
+describe('countSourceLines', () => {
+  test('counts code lines, excluding blank and full-comment lines', () => {
+    const source = [
+      'const a = 1;',
+      '',
+      '// a line comment',
+      'const b = 2;',
+      '   ',
+      'doThing(a, b);',
+    ].join('\n');
+    const result = countSourceLines(source);
+    expect(result.code).toBe(3);
+    expect(result.comment).toBe(1);
+    expect(result.blank).toBe(2);
+    expect(result.total).toBe(6);
+  });
+
+  test('a trailing comment still counts the line as code', () => {
+    const result = countSourceLines('const x = 1; // assign x');
+    expect(result.code).toBe(1);
+    expect(result.comment).toBe(0);
+  });
+
+  test('handles multi-line block comments', () => {
+    const source = [
+      'const a = 1;',
+      '/* this is',
+      '   a block comment */',
+      'const b = 2;',
+    ].join('\n');
+    const result = countSourceLines(source);
+    expect(result.code).toBe(2);
+    expect(result.comment).toBe(2);
+  });
+
+  test('code before a block comment opener still counts as code', () => {
+    const result = countSourceLines('doThing(); /* trailing block');
+    expect(result.code).toBe(1);
+  });
+
+  test('an empty source has zero code lines', () => {
+    expect(countSourceLines('').code).toBe(0);
+  });
+});
+
+describe('scoreErrorActionability', () => {
+  test('a fully actionable error scores 3', () => {
+    const error =
+      'Click failed: selector ".submit-btn" not found on https://example.com — ' +
+      'try waiting for the element or use a more specific selector';
+    const result = scoreErrorActionability(error);
+    expect(result.hasCause).toBe(true);
+    expect(result.hasLocation).toBe(true);
+    expect(result.hasNextStep).toBe(true);
+    expect(result.score).toBe(3);
+  });
+
+  test('a bare error with no cause/location/next-step scores 0', () => {
+    expect(scoreErrorActionability('Something went wrong').score).toBe(0);
+  });
+
+  test('cause only scores 1', () => {
+    const result = scoreErrorActionability('the operation timed out');
+    expect(result.hasCause).toBe(true);
+    expect(result.hasLocation).toBe(false);
+    expect(result.hasNextStep).toBe(false);
+    expect(result.score).toBe(1);
+  });
+
+  test('detects a location from a url, selector, or file:line', () => {
+    expect(scoreErrorActionability('error at https://site.test/page').hasLocation).toBe(true);
+    expect(scoreErrorActionability('no node matched #main .row').hasLocation).toBe(true);
+    expect(scoreErrorActionability('thrown at runner.ts:42').hasLocation).toBe(true);
+  });
+
+  test('detects a next step from rubric keywords', () => {
+    expect(scoreErrorActionability('did you mean #submit?').hasNextStep).toBe(true);
+    expect(scoreErrorActionability('retry the navigation').hasNextStep).toBe(true);
+  });
+
+  test('is deterministic — same input, same score', () => {
+    const e = 'navigation failed: timeout at https://x.test — try increasing the wait';
+    expect(scoreErrorActionability(e)).toEqual(scoreErrorActionability(e));
+  });
+});
+
+describe('meanActionability', () => {
+  test('averages scores across a set of induced-failure errors', () => {
+    const errors = [
+      'Something went wrong', // 0
+      'request timed out', // 1 (cause)
+      'selector ".x" not found — try a broader selector', // 3
+    ];
+    expect(meanActionability(errors)).toBeCloseTo((0 + 1 + 3) / 3);
+  });
+
+  test('an empty error set scores 0', () => {
+    expect(meanActionability([])).toBe(0);
+  });
+});

--- a/tests/benchmark/dx.ts
+++ b/tests/benchmark/dx.ts
@@ -1,0 +1,150 @@
+/**
+ * Developer-experience scoring core for the Developer Experience axis (#1261).
+ *
+ * Two pure, rubric-fixed-up-front scorers (the per-library task scripts and
+ * the MCP tool-schema audit are separate work units):
+ *
+ *   - countSourceLines:        LOC of a task script, comments/blank excluded.
+ *   - scoreErrorActionability: 0-3 score for whether a failure's error tells
+ *                              an agent what to do next.
+ *
+ * Both rubrics are defined here, in code, before any measurement — so the
+ * metric cannot be retro-fitted to favour a result.
+ */
+
+export interface SourceLineCount {
+  /** Lines with code after stripping comments and blank lines. */
+  code: number;
+  /** Lines that are entirely comment. */
+  comment: number;
+  /** Blank / whitespace-only lines. */
+  blank: number;
+  /** Raw total line count. */
+  total: number;
+}
+
+/**
+ * Count the lines of code in a source string, cloc-style: comments and blank
+ * lines are excluded from `code`. Handles `//` line comments and `/* ... *​/`
+ * block comments (including multi-line). `//` or block markers inside string
+ * literals are a known, documented edge case — minimal benchmark task scripts
+ * do not rely on them, and the rule is applied uniformly to every library.
+ */
+export function countSourceLines(source: string): SourceLineCount {
+  const lines = source.split('\n');
+  let code = 0;
+  let comment = 0;
+  let blank = 0;
+  let inBlockComment = false;
+
+  for (const rawLine of lines) {
+    let line = rawLine;
+    let sawCode = false;
+    let sawComment = false;
+
+    let i = 0;
+    while (i < line.length) {
+      if (inBlockComment) {
+        const end = line.indexOf('*/', i);
+        if (end === -1) {
+          sawComment = sawComment || line.slice(i).trim().length > 0;
+          i = line.length;
+        } else {
+          sawComment = true;
+          inBlockComment = false;
+          i = end + 2;
+        }
+        continue;
+      }
+      const blockStart = line.indexOf('/*', i);
+      const lineStart = line.indexOf('//', i);
+      if (lineStart !== -1 && (blockStart === -1 || lineStart < blockStart)) {
+        if (line.slice(i, lineStart).trim().length > 0) sawCode = true;
+        sawComment = true;
+        i = line.length;
+      } else if (blockStart !== -1) {
+        if (line.slice(i, blockStart).trim().length > 0) sawCode = true;
+        sawComment = true;
+        inBlockComment = true;
+        i = blockStart + 2;
+      } else {
+        if (line.slice(i).trim().length > 0) sawCode = true;
+        i = line.length;
+      }
+    }
+
+    if (sawCode) {
+      code += 1;
+    } else if (sawComment) {
+      comment += 1;
+    } else {
+      blank += 1;
+    }
+  }
+
+  return { code, comment, blank, total: lines.length };
+}
+
+/**
+ * The error-actionability rubric, fixed up front. An error is scored 0-3, one
+ * point each for whether it surfaces:
+ *   1. a cause     — why it failed
+ *   2. a location  — where (selector, url, tool, file:line)
+ *   3. a next step — what the agent should do about it
+ *
+ * Keyword sets are deliberately explicit so the rubric is reproducible and
+ * applied identically to every library's errors.
+ */
+export const ACTIONABILITY_RUBRIC = {
+  causeKeywords: [
+    'because', 'failed', 'not found', 'timeout', 'timed out', 'invalid',
+    'missing', 'rejected', 'refused', 'unreachable', 'denied', 'crashed',
+  ],
+  nextStepKeywords: [
+    'try ', 'retry', 'use ', 'check ', 'ensure ', 'did you mean', 'instead',
+    'consider ', 'verify ', 'make sure',
+  ],
+} as const;
+
+export interface ActionabilityScore {
+  /** 0-3 total. */
+  score: number;
+  hasCause: boolean;
+  hasLocation: boolean;
+  hasNextStep: boolean;
+}
+
+/**
+ * Score whether a returned error message is actionable for an agent. Pure and
+ * deterministic — same input always yields the same score.
+ */
+export function scoreErrorActionability(error: string): ActionabilityScore {
+  const text = error.toLowerCase();
+
+  const hasCause = ACTIONABILITY_RUBRIC.causeKeywords.some((kw) => text.includes(kw));
+
+  // A location is a selector, a url, a file:line, a quoted identifier, or an
+  // explicit "at <something>" frame.
+  const hasLocation =
+    /https?:\/\//.test(error) || // url
+    /[.#][a-z][\w-]*/i.test(error) || // css selector
+    /\b\w[\w./-]*:\d+/.test(error) || // file:line
+    /["'`][^"'`]+["'`]/.test(error) || // quoted identifier
+    /\bat\s+\S/.test(text); // stack-frame style
+
+  const hasNextStep = ACTIONABILITY_RUBRIC.nextStepKeywords.some((kw) => text.includes(kw));
+
+  return {
+    score: Number(hasCause) + Number(hasLocation) + Number(hasNextStep),
+    hasCause,
+    hasLocation,
+    hasNextStep,
+  };
+}
+
+/** Mean actionability score over a set of induced-failure errors. */
+export function meanActionability(errors: string[]): number {
+  if (errors.length === 0) return 0;
+  const total = errors.reduce((sum, e) => sum + scoreErrorActionability(e).score, 0);
+  return total / errors.length;
+}


### PR DESCRIPTION
## Summary

First work unit of **#1261** (Developer Experience axis, Epic #1254). **Stacked on #1262** (`feat/1255-benchmark-harness-foundation`) — review/merge that first.

Two pure, rubric-fixed-up-front scorers — the per-library task scripts and the MCP tool-schema audit are separate work units.

- **`countSourceLines`** — cloc-style LOC of a task script; comments and blank lines excluded from the code count. Handles `//` line comments and multi-line block comments. The string-literal edge case is documented and applied uniformly to every library.
- **`scoreErrorActionability`** — 0-3 score for whether a failure's error surfaces a **cause**, a **location**, and a **next step**. The keyword rubric is defined in code, **before any measurement**, so it cannot be retro-fitted to a result (per the #1261 fairness note).
- **`meanActionability`** — mean score over a set of induced-failure errors.

## Test plan

- [x] `npx jest tests/benchmark/dx.test.ts` — 13/13 pass
- [ ] CI green
- [ ] Wire to per-library task scripts + induced-failure corpus (follow-up work units)

> Depends on #1262. Authored in an isolated git worktree due to concurrent sessions on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)