### PR TITLE
feat(benchmark): agent-success metric core (#1257 — B core)

### DIFF
--- a/tests/benchmark/agent-success.test.ts
+++ b/tests/benchmark/agent-success.test.ts
@@ -1,0 +1,93 @@
+/// <reference types="jest" />
+
+import {
+  aggregateAgentMetrics,
+  perTaskBreakdown,
+  findUndersampledTasks,
+  AgentTaskRun,
+  MIN_RUNS_PER_TASK,
+  MIN_RUNS_FOR_PER_TASK_CLAIM,
+} from './agent-success';
+
+function run(overrides: Partial<AgentTaskRun> = {}): AgentTaskRun {
+  return {
+    taskName: 'task-01',
+    passed: true,
+    toolCalls: 5,
+    totalTokens: 4000,
+    wallTimeMs: 8000,
+    firstToolCorrect: true,
+    usd: 0.1,
+    ...overrides,
+  };
+}
+
+describe('aggregateAgentMetrics', () => {
+  test('reports success rate alongside steps, tokens, time, and cost', () => {
+    const runs = [
+      run({ passed: true, toolCalls: 4, totalTokens: 3000, usd: 0.1 }),
+      run({ passed: true, toolCalls: 6, totalTokens: 5000, usd: 0.2 }),
+      run({ passed: false, toolCalls: 20, totalTokens: 9000, usd: 0.3, firstToolCorrect: false }),
+    ];
+    const m = aggregateAgentMetrics(runs);
+    expect(m.totalRuns).toBe(3);
+    expect(m.successRate).toBeCloseTo(2 / 3);
+    expect(m.meanStepsPerTask).toBeCloseTo((4 + 6 + 20) / 3);
+    expect(m.meanTokensPerTask).toBeCloseTo((3000 + 5000 + 9000) / 3);
+    expect(m.firstAttemptAccuracy).toBeCloseTo(2 / 3);
+    expect(m.costPerSuccessfulTask).toBeCloseTo((0.1 + 0.2 + 0.3) / 2);
+  });
+
+  test('cost per successful task is Infinity when nothing passed', () => {
+    const m = aggregateAgentMetrics([run({ passed: false }), run({ passed: false })]);
+    expect(m.successRate).toBe(0);
+    expect(m.costPerSuccessfulTask).toBe(Infinity);
+  });
+
+  test('throws on empty input', () => {
+    expect(() => aggregateAgentMetrics([])).toThrow(/at least one run/);
+  });
+});
+
+describe('perTaskBreakdown', () => {
+  test('buckets runs by task and computes per-task metrics', () => {
+    const runs = [
+      run({ taskName: 'task-b', passed: true, toolCalls: 3 }),
+      run({ taskName: 'task-a', passed: true, toolCalls: 5 }),
+      run({ taskName: 'task-a', passed: false, toolCalls: 7 }),
+    ];
+    const breakdown = perTaskBreakdown(runs);
+    expect(breakdown.map((b) => b.taskName)).toEqual(['task-a', 'task-b']); // sorted
+    const taskA = breakdown.find((b) => b.taskName === 'task-a')!;
+    expect(taskA.runs).toBe(2);
+    expect(taskA.successRate).toBe(0.5);
+    expect(taskA.meanSteps).toBe(6);
+  });
+
+  test('flags per-task claims as unsupported below the rep threshold', () => {
+    const fewRuns = Array.from({ length: MIN_RUNS_FOR_PER_TASK_CLAIM - 1 }, () => run());
+    const enoughRuns = Array.from({ length: MIN_RUNS_FOR_PER_TASK_CLAIM }, () =>
+      run({ taskName: 'task-well-sampled' }),
+    );
+    const breakdown = perTaskBreakdown([...fewRuns, ...enoughRuns]);
+    expect(breakdown.find((b) => b.taskName === 'task-01')!.meetsPerTaskClaimThreshold).toBe(false);
+    expect(
+      breakdown.find((b) => b.taskName === 'task-well-sampled')!.meetsPerTaskClaimThreshold,
+    ).toBe(true);
+  });
+});
+
+describe('findUndersampledTasks', () => {
+  test('returns tasks with fewer than the minimum runs', () => {
+    const runs = [
+      ...Array.from({ length: MIN_RUNS_PER_TASK }, () => run({ taskName: 'well-sampled' })),
+      ...Array.from({ length: MIN_RUNS_PER_TASK - 1 }, () => run({ taskName: 'thin' })),
+    ];
+    expect(findUndersampledTasks(runs)).toEqual(['thin']);
+  });
+
+  test('returns empty when every task is adequately sampled', () => {
+    const runs = Array.from({ length: MIN_RUNS_PER_TASK }, () => run());
+    expect(findUndersampledTasks(runs)).toEqual([]);
+  });
+});

--- a/tests/benchmark/agent-success.ts
+++ b/tests/benchmark/agent-success.ts
@@ -1,0 +1,127 @@
+/**
+ * Agent-success metric core for the Agent Task Success axis (#1257).
+ *
+ * Pure aggregation over per-run records — the WebVoyager runner that produces
+ * the records (and the per-library adapters) are separate work units. This
+ * module computes the axis metrics the way the #1257 design requires: success
+ * rate is never reported alone, because a task "passed" in 50 steps is a loss.
+ */
+
+/** One execution of one WebVoyager task by one library. */
+export interface AgentTaskRun {
+  taskName: string;
+  /** Pass judged by contract postcondition eval. */
+  passed: boolean;
+  /** Tool calls taken to completion. */
+  toolCalls: number;
+  /** Cumulative prompt + completion tokens across all turns. */
+  totalTokens: number;
+  /** Wall-clock ms for the task. */
+  wallTimeMs: number;
+  /** Did the agent pick a sensible tool on its first call, no wasted call. */
+  firstToolCorrect: boolean;
+  /** USD spent on this run. */
+  usd: number;
+}
+
+/** Per-#1257 design: >= 10 reps per task; >= 20 for per-task chart claims. */
+export const MIN_RUNS_PER_TASK = 10;
+export const MIN_RUNS_FOR_PER_TASK_CLAIM = 20;
+
+export interface AgentSuiteMetrics {
+  totalRuns: number;
+  /** passed / total — never reported alone; the others qualify it. */
+  successRate: number;
+  /** Mean tool calls per task — fewer is better at equal success. */
+  meanStepsPerTask: number;
+  /** Mean cumulative tokens per task = the real $ driver. */
+  meanTokensPerTask: number;
+  meanWallTimeMs: number;
+  /** correctFirstTool / total. */
+  firstAttemptAccuracy: number;
+  /** total USD / passed runs — Infinity if nothing passed. */
+  costPerSuccessfulTask: number;
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+/**
+ * Aggregate suite-level agent metrics across every run. Reports success rate
+ * alongside steps / tokens / time / cost so a "passed but expensive" result
+ * cannot masquerade as a win.
+ */
+export function aggregateAgentMetrics(runs: AgentTaskRun[]): AgentSuiteMetrics {
+  if (runs.length === 0) {
+    throw new Error('aggregateAgentMetrics requires at least one run');
+  }
+  const passed = runs.filter((r) => r.passed);
+  const totalUsd = runs.reduce((s, r) => s + r.usd, 0);
+  return {
+    totalRuns: runs.length,
+    successRate: passed.length / runs.length,
+    meanStepsPerTask: mean(runs.map((r) => r.toolCalls)),
+    meanTokensPerTask: mean(runs.map((r) => r.totalTokens)),
+    meanWallTimeMs: mean(runs.map((r) => r.wallTimeMs)),
+    firstAttemptAccuracy: runs.filter((r) => r.firstToolCorrect).length / runs.length,
+    costPerSuccessfulTask: passed.length === 0 ? Infinity : totalUsd / passed.length,
+  };
+}
+
+export interface PerTaskMetrics {
+  taskName: string;
+  runs: number;
+  successRate: number;
+  meanSteps: number;
+  meanTokens: number;
+  /** False when runs < MIN_RUNS_FOR_PER_TASK_CLAIM — per-task numbers below
+   *  that threshold are too noisy to publish as a per-task claim. */
+  meetsPerTaskClaimThreshold: boolean;
+}
+
+/**
+ * Break the runs down per task. The `meetsPerTaskClaimThreshold` flag marks
+ * tasks that have enough reps to support a per-task published claim; the
+ * runner/report layer must not surface a per-task number when it is false.
+ */
+export function perTaskBreakdown(runs: AgentTaskRun[]): PerTaskMetrics[] {
+  const byTask = new Map<string, AgentTaskRun[]>();
+  for (const run of runs) {
+    const bucket = byTask.get(run.taskName) ?? [];
+    bucket.push(run);
+    byTask.set(run.taskName, bucket);
+  }
+
+  const result: PerTaskMetrics[] = [];
+  for (const [taskName, bucket] of byTask) {
+    const passed = bucket.filter((r) => r.passed).length;
+    result.push({
+      taskName,
+      runs: bucket.length,
+      successRate: passed / bucket.length,
+      meanSteps: mean(bucket.map((r) => r.toolCalls)),
+      meanTokens: mean(bucket.map((r) => r.totalTokens)),
+      meetsPerTaskClaimThreshold: bucket.length >= MIN_RUNS_FOR_PER_TASK_CLAIM,
+    });
+  }
+  return result.sort((a, b) => a.taskName.localeCompare(b.taskName));
+}
+
+/**
+ * Check that every task in the suite has at least `MIN_RUNS_PER_TASK` runs.
+ * Returns the task names that fall short — empty means the suite is adequately
+ * sampled for an aggregate claim.
+ */
+export function findUndersampledTasks(runs: AgentTaskRun[]): string[] {
+  const counts = new Map<string, number>();
+  for (const run of runs) {
+    counts.set(run.taskName, (counts.get(run.taskName) ?? 0) + 1);
+  }
+  const undersampled: string[] = [];
+  for (const [taskName, count] of counts) {
+    if (count < MIN_RUNS_PER_TASK) undersampled.push(taskName);
+  }
+  return undersampled.sort();
+}


### PR DESCRIPTION
## Summary

First work unit of **#1257** (Agent Task Success axis, Epic #1254). **Stacked on #1262** (`feat/1255-benchmark-harness-foundation`) — review/merge that first.

Pure aggregation over per-run records — the WebVoyager runner and per-library adapters that produce the records are separate work units.

- **`aggregateAgentMetrics`** — suite-level metrics. Success rate is computed **alongside** steps / tokens / time / cost, so a "passed but expensive" run cannot masquerade as a win (per the #1257 design — success rate is never reported alone).
- **`perTaskBreakdown`** — per-task aggregation; flags tasks below the **N ≥ 20** per-task-claim threshold so the report layer never surfaces a noisy per-task number.
- **`findUndersampledTasks`** — gate for the **N ≥ 10**-per-task minimum on aggregate claims.

## Test plan

- [x] `npx jest tests/benchmark/agent-success.test.ts` — 7/7 pass
- [ ] CI green
- [ ] Wire to the WebVoyager runner + per-library adapters (follow-up work units)

> Depends on #1262. Authored in an isolated git worktree due to concurrent sessions on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)