### PR TITLE
feat(benchmark): library-agnostic fault-injection proxy (#1259 — D.1)

### DIFF
--- a/tests/benchmark/fault-injection/proxy.test.ts
+++ b/tests/benchmark/fault-injection/proxy.test.ts
@@ -1,0 +1,117 @@
+/// <reference types="jest" />
+
+import * as http from 'http';
+import type { AddressInfo } from 'net';
+import { startFaultInjectionProxy, FaultInjectionProxy } from './proxy';
+
+/** Trivial upstream that always returns the same HTML. */
+function startUpstream(body: string): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    res.end(body);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        baseUrl: `http://127.0.0.1:${port}`,
+        close: () => new Promise<void>((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+interface FetchResult {
+  status: number;
+  body: string;
+  error?: string;
+}
+
+function fetchVia(url: string): Promise<FetchResult> {
+  return new Promise((resolve) => {
+    const req = http.get(url, (res) => {
+      let body = '';
+      res.setEncoding('utf8');
+      res.on('data', (c) => (body += c));
+      res.on('end', () => resolve({ status: res.statusCode ?? 0, body }));
+    });
+    req.on('error', (err) => resolve({ status: 0, body: '', error: err.message }));
+  });
+}
+
+describe('fault-injection proxy', () => {
+  const UPSTREAM_BODY = '<html><body><button class="submit">Go</button></body></html>';
+  let upstream: { baseUrl: string; close: () => Promise<void> };
+  let proxy: FaultInjectionProxy;
+
+  beforeAll(async () => {
+    upstream = await startUpstream(UPSTREAM_BODY);
+    proxy = await startFaultInjectionProxy({ upstreamBaseUrl: upstream.baseUrl });
+  });
+
+  afterAll(async () => {
+    await proxy.close();
+    await upstream.close();
+  });
+
+  afterEach(() => {
+    proxy.setFault({ kind: 'none' });
+  });
+
+  test('with no fault, forwards the upstream response unchanged', async () => {
+    const res = await fetchVia(proxy.url + '/');
+    expect(res.status).toBe(200);
+    expect(res.body).toBe(UPSTREAM_BODY);
+  });
+
+  test('network-drop destroys the socket with no response', async () => {
+    proxy.setFault({ kind: 'network-drop' });
+    const res = await fetchVia(proxy.url + '/');
+    expect(res.status).toBe(0);
+    expect(res.error).toBeDefined();
+  });
+
+  test('http-error responds with the forced status, never reaching upstream', async () => {
+    proxy.setFault({ kind: 'http-error', status: 503 });
+    const res = await fetchVia(proxy.url + '/');
+    expect(res.status).toBe(503);
+    expect(res.body).toContain('503');
+  });
+
+  test('latency delays the response but still forwards it', async () => {
+    proxy.setFault({ kind: 'latency', delayMs: 120 });
+    const start = Date.now();
+    const res = await fetchVia(proxy.url + '/');
+    expect(Date.now() - start).toBeGreaterThanOrEqual(110);
+    expect(res.status).toBe(200);
+    expect(res.body).toBe(UPSTREAM_BODY);
+  });
+
+  test('body-mutation rewrites the response body (e.g. strips a selector)', async () => {
+    proxy.setFault({ kind: 'body-mutation', find: 'class="submit"', replace: 'class="gone"' });
+    const res = await fetchVia(proxy.url + '/');
+    expect(res.status).toBe(200);
+    expect(res.body).not.toContain('class="submit"');
+    expect(res.body).toContain('class="gone"');
+  });
+
+  test('clearing the fault restores normal forwarding', async () => {
+    proxy.setFault({ kind: 'http-error', status: 500 });
+    proxy.setFault({ kind: 'none' });
+    const res = await fetchVia(proxy.url + '/');
+    expect(res.status).toBe(200);
+    expect(res.body).toBe(UPSTREAM_BODY);
+  });
+
+  test('counts every request it handles', async () => {
+    const before = proxy.requestCount;
+    await fetchVia(proxy.url + '/');
+    await fetchVia(proxy.url + '/');
+    expect(proxy.requestCount).toBe(before + 2);
+  });
+
+  test('rejects invalid fault specs', () => {
+    expect(() => proxy.setFault({ kind: 'latency', delayMs: -5 })).toThrow(/non-negative/);
+    expect(() => proxy.setFault({ kind: 'http-error', status: 200 })).toThrow(/>= 400/);
+  });
+});

--- a/tests/benchmark/fault-injection/proxy.ts
+++ b/tests/benchmark/fault-injection/proxy.ts
@@ -1,0 +1,206 @@
+/**
+ * Library-agnostic fault-injection proxy for the Reliability axis (#1259).
+ *
+ * Sits between a benchmarked library and an upstream HTTP server and injects
+ * faults at the HTTP layer. Two properties this guarantees, both required by
+ * the #1259 design:
+ *   - library-agnostic: faults are injected at the transport, never via any
+ *     library's internals, so every library faces the identical fault.
+ *   - deterministic: faults are armed/cleared via setFault(), so injection
+ *     happens at an exact, chosen point in a flow.
+ *
+ * The CDP-level injectors (tab crash, CDP-connection drop) are a separate
+ * work unit — they cannot be done at the HTTP layer.
+ */
+
+import * as http from 'http';
+import type { AddressInfo } from 'net';
+
+/**
+ * A fault to inject into proxied responses.
+ *  - none:          forward normally.
+ *  - network-drop:  destroy the socket with no response (simulates a dropped
+ *                   connection / unreachable upstream).
+ *  - latency:       wait `delayMs` before forwarding the real response.
+ *  - http-error:    respond with `status` and a short body, never reaching
+ *                   the upstream.
+ *  - body-mutation: forward the real response but rewrite the body, replacing
+ *                   every occurrence of `find` with `replace` (used to e.g.
+ *                   strip an element and simulate a stale selector).
+ */
+export type FaultSpec =
+  | { kind: 'none' }
+  | { kind: 'network-drop' }
+  | { kind: 'latency'; delayMs: number }
+  | { kind: 'http-error'; status: number }
+  | { kind: 'body-mutation'; find: string; replace: string };
+
+export interface FaultInjectionProxy {
+  readonly port: number;
+  readonly url: string;
+  /** Arm a fault for subsequent requests; { kind: 'none' } clears it. */
+  setFault(fault: FaultSpec): void;
+  /** The currently armed fault. */
+  getFault(): FaultSpec;
+  /** Number of requests handled since start (across all fault states). */
+  readonly requestCount: number;
+  close(): Promise<void>;
+}
+
+export interface StartProxyOptions {
+  /** Upstream origin to forward to, e.g. "http://127.0.0.1:54321". */
+  upstreamBaseUrl: string;
+  /** Fault armed at start. Defaults to { kind: 'none' }. */
+  initialFault?: FaultSpec;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Hop-by-hop and framing headers that must NOT be copied verbatim from the
+ * upstream response onto the proxy response — the proxy sets its own framing
+ * (content-length), and passing through e.g. `transfer-encoding: chunked`
+ * alongside a `content-length` is a protocol conflict that breaks the client.
+ */
+const STRIPPED_RESPONSE_HEADERS = new Set([
+  'connection',
+  'keep-alive',
+  'transfer-encoding',
+  'content-length',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'upgrade',
+]);
+
+function sanitizeUpstreamHeaders(
+  upstreamHeaders: http.IncomingHttpHeaders,
+  body: string,
+): http.OutgoingHttpHeaders {
+  const headers: http.OutgoingHttpHeaders = {};
+  for (const [key, value] of Object.entries(upstreamHeaders)) {
+    if (value === undefined) continue;
+    if (STRIPPED_RESPONSE_HEADERS.has(key.toLowerCase())) continue;
+    headers[key] = value;
+  }
+  // The proxy owns framing — body length may differ from upstream after a
+  // body-mutation fault.
+  headers['content-length'] = String(Buffer.byteLength(body));
+  return headers;
+}
+
+function validateFault(fault: FaultSpec): void {
+  if (fault.kind === 'latency' && (!Number.isFinite(fault.delayMs) || fault.delayMs < 0)) {
+    throw new Error(`latency fault delayMs must be a non-negative number, got ${fault.delayMs}`);
+  }
+  if (fault.kind === 'http-error' && (!Number.isInteger(fault.status) || fault.status < 400)) {
+    throw new Error(`http-error fault status must be an integer >= 400, got ${fault.status}`);
+  }
+}
+
+/**
+ * Forward one request to the upstream and resolve with the full response
+ * (status, headers, body as a string).
+ */
+function forward(
+  upstream: URL,
+  req: http.IncomingMessage,
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: string }> {
+  return new Promise((resolve, reject) => {
+    const upstreamReq = http.request(
+      {
+        hostname: upstream.hostname,
+        port: upstream.port,
+        path: req.url ?? '/',
+        method: req.method ?? 'GET',
+        headers: { ...req.headers, host: upstream.host },
+      },
+      (upstreamRes) => {
+        let body = '';
+        upstreamRes.setEncoding('utf8');
+        upstreamRes.on('data', (chunk) => (body += chunk));
+        upstreamRes.on('end', () =>
+          resolve({ status: upstreamRes.statusCode ?? 502, headers: upstreamRes.headers, body }),
+        );
+      },
+    );
+    upstreamReq.on('error', reject);
+    req.pipe(upstreamReq);
+  });
+}
+
+/**
+ * Start the fault-injection proxy on an ephemeral loopback port. The caller
+ * owns the lifecycle and must call `close()`.
+ */
+export async function startFaultInjectionProxy(
+  options: StartProxyOptions,
+): Promise<FaultInjectionProxy> {
+  const upstream = new URL(options.upstreamBaseUrl);
+  let fault: FaultSpec = options.initialFault ?? { kind: 'none' };
+  validateFault(fault);
+  let requestCount = 0;
+
+  const server = http.createServer(async (req, res) => {
+    requestCount += 1;
+    const active = fault;
+
+    if (active.kind === 'network-drop') {
+      req.socket.destroy();
+      return;
+    }
+
+    if (active.kind === 'http-error') {
+      res.writeHead(active.status, { 'content-type': 'text/plain; charset=utf-8' });
+      res.end(`fault-injection: forced HTTP ${active.status}`);
+      return;
+    }
+
+    try {
+      if (active.kind === 'latency') {
+        await delay(active.delayMs);
+      }
+      const upstreamRes = await forward(upstream, req);
+      let body = upstreamRes.body;
+      if (active.kind === 'body-mutation') {
+        body = body.split(active.find).join(active.replace);
+      }
+      res.writeHead(upstreamRes.status, sanitizeUpstreamHeaders(upstreamRes.headers, body));
+      res.end(body);
+    } catch (err) {
+      res.writeHead(502, { 'content-type': 'text/plain; charset=utf-8' });
+      res.end(`fault-injection proxy: upstream error: ${(err as Error).message}`);
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  const { port } = server.address() as AddressInfo;
+  let closed = false;
+
+  return {
+    port,
+    url: `http://127.0.0.1:${port}`,
+    setFault(next: FaultSpec): void {
+      validateFault(next);
+      fault = next;
+    },
+    getFault(): FaultSpec {
+      return fault;
+    },
+    get requestCount(): number {
+      return requestCount;
+    },
+    close(): Promise<void> {
+      if (closed) return Promise.resolve();
+      closed = true;
+      return new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Work unit of **#1259** (Reliability & Fault-Recovery axis, Epic #1254). Independent of #1265 (the reliability metric core) — different files, both target `develop`.

A controllable HTTP proxy that sits between a benchmarked library and an upstream server and injects faults **at the transport layer**:

- **`network-drop`** — destroy the socket with no response
- **`latency`** — delay before forwarding the real response
- **`http-error`** — respond with a forced ≥400 status, never reaching upstream
- **`body-mutation`** — rewrite the response body (e.g. strip a selector to simulate a stale-selector fault)

Faults are armed/cleared via `setFault()` so injection happens at a **deterministic point** in a flow, and they are applied at the HTTP layer so **every library faces the identical fault with no library internals touched** — the #1259 fairness rule. CDP-level injectors (tab crash, CDP-drop) are a separate work unit.

## Test plan

- [x] `npx jest tests/benchmark/fault-injection/proxy.test.ts` — 8/8 pass (every fault kind, clearing, request counting, spec validation)
- [ ] CI green
- [ ] Wire to the reliability runner + CDP injectors (follow-up work units)

> Authored in an isolated git worktree due to concurrent sessions on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)