### PR TITLE
feat(benchmark): CDP-level fault injectors (#1259 — D.1 cont.)

### DIFF
--- a/tests/benchmark/fault-injection/cdp-injectors.test.ts
+++ b/tests/benchmark/fault-injection/cdp-injectors.test.ts
@@ -1,0 +1,144 @@
+/// <reference types="jest" />
+
+import {
+  buildCdpFaultCommands,
+  buildCdpRecoveryCommands,
+  applyCdpFault,
+  CdpClientLike,
+  CdpFault,
+} from './cdp-injectors';
+
+function makeMockClient(): {
+  client: CdpClientLike;
+  sent: Array<{ method: string; params?: Record<string, unknown> }>;
+  closed: () => boolean;
+} {
+  const sent: Array<{ method: string; params?: Record<string, unknown> }> = [];
+  let isClosed = false;
+  return {
+    sent,
+    closed: () => isClosed,
+    client: {
+      async send(method, params) {
+        sent.push({ method, params });
+        return {};
+      },
+      async close() {
+        isClosed = true;
+      },
+    },
+  };
+}
+
+describe('buildCdpFaultCommands', () => {
+  test('tab-crash maps to Page.crash', () => {
+    expect(buildCdpFaultCommands({ kind: 'tab-crash' })).toEqual([{ method: 'Page.crash' }]);
+  });
+
+  test('network-offline enables Network and emulates offline conditions', () => {
+    const cmds = buildCdpFaultCommands({ kind: 'network-offline' });
+    expect(cmds[0]).toEqual({ method: 'Network.enable' });
+    expect(cmds[1].method).toBe('Network.emulateNetworkConditions');
+    expect(cmds[1].params).toMatchObject({ offline: true });
+  });
+
+  test('network-throttle passes through the throughput + latency values', () => {
+    const cmds = buildCdpFaultCommands({
+      kind: 'network-throttle',
+      downloadBytesPerSec: 50_000,
+      uploadBytesPerSec: 20_000,
+      latencyMs: 150,
+    });
+    expect(cmds[1].params).toMatchObject({
+      offline: false,
+      latency: 150,
+      downloadThroughput: 50_000,
+      uploadThroughput: 20_000,
+    });
+  });
+
+  test('cdp-drop has no command sequence', () => {
+    expect(buildCdpFaultCommands({ kind: 'cdp-drop' })).toEqual([]);
+  });
+
+  test('rejects negative network-throttle values', () => {
+    const bad: CdpFault = {
+      kind: 'network-throttle',
+      downloadBytesPerSec: -1,
+      uploadBytesPerSec: 0,
+      latencyMs: 0,
+    };
+    expect(() => buildCdpFaultCommands(bad)).toThrow(/non-negative/);
+  });
+});
+
+describe('buildCdpRecoveryCommands', () => {
+  test('network faults are cleared by restoring unthrottled conditions', () => {
+    for (const fault of [
+      { kind: 'network-offline' } as const,
+      {
+        kind: 'network-throttle',
+        downloadBytesPerSec: 1,
+        uploadBytesPerSec: 1,
+        latencyMs: 1,
+      } as const,
+    ]) {
+      const recovery = buildCdpRecoveryCommands(fault);
+      expect(recovery).toHaveLength(1);
+      expect(recovery[0].params).toMatchObject({ offline: false });
+    }
+  });
+
+  test('tab-crash and cdp-drop are not clearable — caller must recreate', () => {
+    expect(buildCdpRecoveryCommands({ kind: 'tab-crash' })).toEqual([]);
+    expect(buildCdpRecoveryCommands({ kind: 'cdp-drop' })).toEqual([]);
+  });
+});
+
+describe('applyCdpFault', () => {
+  test('network-offline sends the full command sequence', async () => {
+    const { client, sent } = makeMockClient();
+    const result = await applyCdpFault(client, { kind: 'network-offline' });
+    expect(sent.map((s) => s.method)).toEqual(['Network.enable', 'Network.emulateNetworkConditions']);
+    expect(result.connectionClosed).toBe(false);
+    expect(result.commandsSent).toHaveLength(2);
+  });
+
+  test('cdp-drop closes the connection and sends nothing', async () => {
+    const { client, sent, closed } = makeMockClient();
+    const result = await applyCdpFault(client, { kind: 'cdp-drop' });
+    expect(closed()).toBe(true);
+    expect(sent).toHaveLength(0);
+    expect(result.connectionClosed).toBe(true);
+  });
+
+  test('tab-crash tolerates the send rejecting as the target dies', async () => {
+    const sent: string[] = [];
+    const client: CdpClientLike = {
+      async send(method) {
+        sent.push(method);
+        throw new Error('target closed'); // Page.crash kills the connection
+      },
+      async close() {
+        /* noop */
+      },
+    };
+    const result = await applyCdpFault(client, { kind: 'tab-crash' });
+    expect(sent).toEqual(['Page.crash']);
+    expect(result.connectionClosed).toBe(false);
+  });
+
+  test('a rejecting send for a non-crash fault propagates', async () => {
+    const client: CdpClientLike = {
+      async send() {
+        throw new Error('protocol error');
+      },
+      async close() {
+        /* noop */
+      },
+    };
+    await expect(applyCdpFault(client, { kind: 'network-offline' })).rejects.toThrow(
+      /protocol error/,
+    );
+  });
+});

--- a/tests/benchmark/fault-injection/cdp-injectors.ts
+++ b/tests/benchmark/fault-injection/cdp-injectors.ts
@@ -1,0 +1,145 @@
+/**
+ * CDP-level fault injectors for the Reliability axis (#1259).
+ *
+ * The HTTP-layer faults live in ./proxy.ts; some failure modes can only be
+ * injected through the DevTools Protocol — a tab crash, a forced-offline /
+ * throttled network condition, a dropped CDP connection. These builders
+ * return plain { method, params } command descriptors so they are
+ * unit-testable without a live browser, and applyCdpFault drives a minimal
+ * CDP client interface so the same code works against a real connection or a
+ * mock. Faults are injected at the protocol layer — no library internals are
+ * touched (the #1259 fairness rule).
+ */
+
+export interface CdpCommand {
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+/** Minimal CDP client surface the injectors need. */
+export interface CdpClientLike {
+  send(method: string, params?: Record<string, unknown>): Promise<unknown>;
+  /** Close the underlying CDP connection. */
+  close(): Promise<void>;
+}
+
+export type CdpFault =
+  | { kind: 'tab-crash' }
+  | { kind: 'network-offline' }
+  | {
+      kind: 'network-throttle';
+      downloadBytesPerSec: number;
+      uploadBytesPerSec: number;
+      latencyMs: number;
+    }
+  | { kind: 'cdp-drop' };
+
+function validateCdpFault(fault: CdpFault): void {
+  if (fault.kind === 'network-throttle') {
+    if (
+      !Number.isFinite(fault.downloadBytesPerSec) ||
+      !Number.isFinite(fault.uploadBytesPerSec) ||
+      !Number.isFinite(fault.latencyMs) ||
+      fault.downloadBytesPerSec < 0 ||
+      fault.uploadBytesPerSec < 0 ||
+      fault.latencyMs < 0
+    ) {
+      throw new Error('network-throttle values must be finite and non-negative');
+    }
+  }
+}
+
+/**
+ * Build the CDP command sequence that injects a fault. `cdp-drop` has no
+ * command sequence — it is enacted by closing the client (see applyCdpFault).
+ */
+export function buildCdpFaultCommands(fault: CdpFault): CdpCommand[] {
+  validateCdpFault(fault);
+  switch (fault.kind) {
+    case 'tab-crash':
+      return [{ method: 'Page.crash' }];
+    case 'network-offline':
+      return [
+        { method: 'Network.enable' },
+        {
+          method: 'Network.emulateNetworkConditions',
+          params: { offline: true, latency: 0, downloadThroughput: -1, uploadThroughput: -1 },
+        },
+      ];
+    case 'network-throttle':
+      return [
+        { method: 'Network.enable' },
+        {
+          method: 'Network.emulateNetworkConditions',
+          params: {
+            offline: false,
+            latency: fault.latencyMs,
+            downloadThroughput: fault.downloadBytesPerSec,
+            uploadThroughput: fault.uploadBytesPerSec,
+          },
+        },
+      ];
+    case 'cdp-drop':
+      return [];
+  }
+}
+
+/**
+ * Build the CDP command sequence that clears a fault. Network faults are
+ * cleared by restoring unthrottled conditions; a crashed tab or a dropped
+ * connection is not "clearable" — it must be recreated by the caller.
+ */
+export function buildCdpRecoveryCommands(fault: CdpFault): CdpCommand[] {
+  switch (fault.kind) {
+    case 'network-offline':
+    case 'network-throttle':
+      return [
+        {
+          method: 'Network.emulateNetworkConditions',
+          params: { offline: false, latency: 0, downloadThroughput: -1, uploadThroughput: -1 },
+        },
+      ];
+    case 'tab-crash':
+    case 'cdp-drop':
+      return [];
+  }
+}
+
+export interface ApplyCdpFaultResult {
+  fault: CdpFault;
+  /** Commands actually sent to the client. */
+  commandsSent: CdpCommand[];
+  /** True when the fault was enacted by closing the connection (cdp-drop). */
+  connectionClosed: boolean;
+}
+
+/**
+ * Apply a CDP fault against a client.
+ *  - cdp-drop:   closes the connection.
+ *  - tab-crash:  sends Page.crash; the send may reject as the target dies —
+ *                that rejection IS the fault landing, not an error.
+ *  - network-*:  sends the emulateNetworkConditions sequence.
+ */
+export async function applyCdpFault(
+  client: CdpClientLike,
+  fault: CdpFault,
+): Promise<ApplyCdpFaultResult> {
+  validateCdpFault(fault);
+
+  if (fault.kind === 'cdp-drop') {
+    await client.close();
+    return { fault, commandsSent: [], connectionClosed: true };
+  }
+
+  const commands = buildCdpFaultCommands(fault);
+  const tolerateRejection = fault.kind === 'tab-crash';
+  for (const cmd of commands) {
+    const sent = client.send(cmd.method, cmd.params);
+    if (tolerateRejection) {
+      await sent.catch(() => undefined);
+    } else {
+      await sent;
+    }
+  }
+  return { fault, commandsSent: commands, connectionClosed: false };
+}


### PR DESCRIPTION
## Summary

Work unit of **#1259** (Reliability & Fault-Recovery axis, Epic #1254). Completes the fault-injection harness alongside the HTTP-layer proxy (**#1268**).

Some failure modes can only be injected through the DevTools Protocol:

- **`tab-crash`** — `Page.crash`
- **`network-offline`** — `Network.emulateNetworkConditions { offline: true }`
- **`network-throttle`** — `Network.emulateNetworkConditions` with throughput/latency
- **`cdp-drop`** — close the CDP connection

`buildCdpFaultCommands` / `buildCdpRecoveryCommands` return plain `{ method, params }` descriptors so they are **unit-testable without a live browser**; `applyCdpFault` drives a minimal `CdpClientLike` interface so the same code runs against a real connection or a mock. `tab-crash` tolerates the send rejecting as the target dies — that rejection *is* the fault landing, not an error. Faults are injected at the protocol layer, no library internals touched (the #1259 fairness rule).

## Test plan

- [x] `npx jest tests/benchmark/fault-injection/cdp-injectors.test.ts` — 11/11 pass
- [ ] CI green
- [ ] Wire to the reliability runner against a real CDP connection (follow-up)

> Authored in an isolated git worktree due to concurrent sessions on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)