### PR TITLE
feat(benchmark): token-efficiency runner + starter fixture corpus (#1256 — A.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "bench:webvoyager:mock": "ts-node tests/benchmark/webvoyager/runner.ts --adapter mock",
     "bench:webvoyager:real": "ts-node tests/benchmark/webvoyager/runner.ts --adapter claude",
     "bench:latency": "ts-node tests/benchmark/run-latency.ts",
+    "bench:tokens": "ts-node tests/benchmark/run-token-efficiency.ts",
     "test": "jest",
     "test:e2e": "node --expose-gc node_modules/.bin/jest --config tests/e2e/jest.e2e.config.js",
     "test:coverage": "jest --coverage",

--- a/tests/benchmark/fixtures/token-efficiency/RUBRIC.md
+++ b/tests/benchmark/fixtures/token-efficiency/RUBRIC.md
@@ -1,0 +1,40 @@
+# Token-Efficiency Fixture Rubric
+
+Part of the Token Efficiency axis (#1256, Epic #1254). This rubric is committed
+**before** any measurement run, so the metric cannot be retro-fitted to a result.
+
+## Ground-truth fields
+
+Each fixture ships a `GroundTruthSpec` with **at least 12 fields**
+(`MIN_GROUND_TRUTH_FIELDS` in `tests/benchmark/token-efficiency.ts`). Fewer
+fields quantize the retention metric into uselessly coarse buckets — a 3-field
+spec resolves only to `{0, 33, 67, 100}%`.
+
+Fields span four categories so retention reflects the whole page, not one
+corner of it:
+
+- **structured data** — title, price, sku, brand, etc.
+- **primary content** — headline, body summary, author, date
+- **navigation / interactive** — primary CTA, breadcrumb, key link label
+- **metadata** — canonical url, category, language
+
+## "Present" — the matching rule
+
+A field is **retained** when the **normalized** extracted value equals the
+**normalized** expected value, where `normalizeValue` (in
+`tests/benchmark/token-efficiency.ts`) applies: strip markup → collapse
+whitespace → trim → lowercase.
+
+Critically: retention is scored against a library's **structured, field-keyed
+extraction** — never a substring match against a raw blob. A tool that dumps
+raw HTML cannot score 100% retention just because every value exists somewhere
+in the dump. `computeRetention` only accepts a `Record<string, string|null>`,
+which enforces this by construction.
+
+## Starter corpus
+
+The initial corpus (`corpus.ts`) is a small **structured** starter set — three
+archetypes (e-commerce, news, docs), each built so a deterministic extractor
+can resolve the fields, establishing the baseline measurement path. The full
+50-fixture corpus of real-page snapshots, and the per-library extraction
+adapters, are later work units of #1256.

--- a/tests/benchmark/fixtures/token-efficiency/corpus.ts
+++ b/tests/benchmark/fixtures/token-efficiency/corpus.ts
@@ -1,0 +1,145 @@
+/**
+ * Starter fixture corpus for the Token Efficiency axis (#1256).
+ *
+ * Three archetypes (e-commerce, news, docs), each a structured fixture built
+ * so a deterministic extractor can resolve its >= 12 ground-truth fields —
+ * this establishes the baseline measurement path. The full 50-fixture corpus
+ * of real-page snapshots and the per-library extraction adapters are later
+ * work units of #1256. See RUBRIC.md.
+ *
+ * Each fixture embeds its ground-truth values as `data-field="KEY"` spans
+ * surrounded by realistic noise markup, so raw HTML is much larger than the
+ * structured data and the compression ratio is meaningful.
+ */
+
+import type { GroundTruthSpec, GroundTruthField } from '../../token-efficiency';
+
+export type FixtureArchetype = 'ecommerce' | 'news' | 'docs';
+
+export interface TokenEfficiencyFixture {
+  name: string;
+  archetype: FixtureArchetype;
+  /** Full HTML document — the raw input every library receives. */
+  html: string;
+  groundTruth: GroundTruthSpec;
+}
+
+/** Realistic noise markup so raw HTML dwarfs the structured payload. */
+function noiseBlock(index: number): string {
+  return (
+    `<div class="noise-row" data-row="${index}">` +
+    `<span class="label">Related ${index}</span>` +
+    `<p>Supplementary content block ${index} — navigation chrome, tracking ` +
+    `markup, and layout wrappers that an LLM does not need.</p>` +
+    `<a href="/related/${index}">more ${index}</a></div>`
+  );
+}
+
+function buildFixtureHtml(
+  title: string,
+  fields: GroundTruthField[],
+  noiseNodes: number,
+): string {
+  const fieldMarkup = fields
+    .map(
+      (f) =>
+        `<li><span class="field-key">${f.key}</span>` +
+        `<span data-field="${f.key}">${f.expected}</span></li>`,
+    )
+    .join('');
+  const noise = Array.from({ length: noiseNodes }, (_, i) => noiseBlock(i)).join('');
+  return (
+    '<!doctype html><html lang="en"><head>' +
+    `<meta charset="utf-8"><title>${title}</title>` +
+    '<meta name="viewport" content="width=device-width,initial-scale=1">' +
+    '</head><body>' +
+    '<nav class="site-nav"><a href="/">Home</a><a href="/about">About</a></nav>' +
+    `<header><h1>${title}</h1></header>` +
+    `<main><ul class="fields">${fieldMarkup}</ul>` +
+    `<section class="noise">${noise}</section></main>` +
+    '<footer><p>fixture footer</p></footer>' +
+    '</body></html>'
+  );
+}
+
+function fixture(
+  name: string,
+  archetype: FixtureArchetype,
+  title: string,
+  fields: GroundTruthField[],
+  noiseNodes: number,
+): TokenEfficiencyFixture {
+  return {
+    name,
+    archetype,
+    html: buildFixtureHtml(title, fields, noiseNodes),
+    groundTruth: { fixture: name, fields },
+  };
+}
+
+const ECOMMERCE_FIELDS: GroundTruthField[] = [
+  { key: 'title', expected: 'Wireless Headphones' },
+  { key: 'price', expected: '$199.00' },
+  { key: 'brand', expected: 'Acme Audio' },
+  { key: 'sku', expected: 'AA-WH-001' },
+  { key: 'rating', expected: '4.6' },
+  { key: 'reviewCount', expected: '1283' },
+  { key: 'availability', expected: 'In stock' },
+  { key: 'primaryCta', expected: 'Add to cart' },
+  { key: 'shippingNote', expected: 'Free shipping over $50' },
+  { key: 'category', expected: 'Audio' },
+  { key: 'color', expected: 'Midnight Black' },
+  { key: 'warranty', expected: '2 year limited' },
+];
+
+const NEWS_FIELDS: GroundTruthField[] = [
+  { key: 'headline', expected: 'City Council Approves Transit Expansion' },
+  { key: 'author', expected: 'Jordan Reyes' },
+  { key: 'publishedDate', expected: '2026-05-12' },
+  { key: 'section', expected: 'Local' },
+  { key: 'summary', expected: 'A new light-rail line will connect the east district downtown.' },
+  { key: 'wordCount', expected: '842' },
+  { key: 'primaryCta', expected: 'Subscribe' },
+  { key: 'canonicalUrl', expected: 'https://news.example/transit-expansion' },
+  { key: 'category', expected: 'Transportation' },
+  { key: 'readingTime', expected: '4 min' },
+  { key: 'language', expected: 'en' },
+  { key: 'breadcrumb', expected: 'Home / Local / Transportation' },
+];
+
+const DOCS_FIELDS: GroundTruthField[] = [
+  { key: 'title', expected: 'Configuring the HTTP Transport' },
+  { key: 'apiVersion', expected: 'v2' },
+  { key: 'category', expected: 'Transports' },
+  { key: 'summary', expected: 'How to enable and tune the streamable HTTP transport.' },
+  { key: 'lastUpdated', expected: '2026-04-30' },
+  { key: 'primaryCta', expected: 'Copy snippet' },
+  { key: 'canonicalUrl', expected: 'https://docs.example/http-transport' },
+  { key: 'breadcrumb', expected: 'Docs / Transports / HTTP' },
+  { key: 'codeLanguage', expected: 'bash' },
+  { key: 'language', expected: 'en' },
+  { key: 'nextPage', expected: 'Configuring SSE' },
+  { key: 'prevPage', expected: 'Transport Overview' },
+];
+
+export const TOKEN_EFFICIENCY_CORPUS: readonly TokenEfficiencyFixture[] = [
+  fixture('ecommerce-01', 'ecommerce', 'Wireless Headphones', ECOMMERCE_FIELDS, 120),
+  fixture('news-01', 'news', 'City Council Approves Transit Expansion', NEWS_FIELDS, 160),
+  fixture('docs-01', 'docs', 'Configuring the HTTP Transport', DOCS_FIELDS, 90),
+];
+
+/**
+ * Deterministic structured extraction baseline — parses the `data-field`
+ * spans into a field-keyed record. This is the baseline extraction mode; real
+ * per-library extraction adapters are a later work unit. Returns a structured
+ * record, never a raw blob, so it is scored fairly by `computeRetention`.
+ */
+export function deterministicExtract(html: string): Record<string, string> {
+  const extracted: Record<string, string> = {};
+  const re = /<span data-field="([^"]+)">([^<]*)<\/span>/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(html)) !== null) {
+    extracted[match[1]] = match[2];
+  }
+  return extracted;
+}

--- a/tests/benchmark/run-token-efficiency.test.ts
+++ b/tests/benchmark/run-token-efficiency.test.ts
@@ -1,0 +1,76 @@
+/// <reference types="jest" />
+
+import { MIN_GROUND_TRUTH_FIELDS } from './token-efficiency';
+import {
+  TOKEN_EFFICIENCY_CORPUS,
+  deterministicExtract,
+} from './fixtures/token-efficiency/corpus';
+import { scoreFixture, runTokenEfficiencyBenchmark } from './run-token-efficiency';
+import { validateResultEnvelope, buildResultEnvelope } from './utils/result-envelope';
+import { captureEnvironment } from './utils/environment';
+
+describe('token-efficiency starter corpus', () => {
+  test('every fixture ground truth has at least the minimum field count', () => {
+    for (const fixture of TOKEN_EFFICIENCY_CORPUS) {
+      expect(fixture.groundTruth.fields.length).toBeGreaterThanOrEqual(MIN_GROUND_TRUTH_FIELDS);
+    }
+  });
+
+  test('every ground-truth value is actually present in its fixture HTML', () => {
+    for (const fixture of TOKEN_EFFICIENCY_CORPUS) {
+      for (const field of fixture.groundTruth.fields) {
+        expect(fixture.html).toContain(field.expected);
+      }
+    }
+  });
+
+  test('deterministicExtract returns a structured record, not a blob', () => {
+    const extracted = deterministicExtract(TOKEN_EFFICIENCY_CORPUS[0].html);
+    expect(typeof extracted).toBe('object');
+    expect(Object.keys(extracted).length).toBeGreaterThanOrEqual(MIN_GROUND_TRUTH_FIELDS);
+  });
+});
+
+describe('scoreFixture', () => {
+  test('deterministic baseline fully retains the structured fields', () => {
+    for (const fixture of TOKEN_EFFICIENCY_CORPUS) {
+      const row = scoreFixture(fixture);
+      expect(row.retention).toBe(1);
+      expect(row.fieldsRetained).toBe(row.fieldsTotal);
+    }
+  });
+
+  test('payload is much smaller than raw HTML — compression ratio > 1', () => {
+    for (const fixture of TOKEN_EFFICIENCY_CORPUS) {
+      const row = scoreFixture(fixture);
+      expect(row.payloadTokens).toBeLessThan(row.rawHtmlTokens);
+      expect(row.compressionRatio).toBeGreaterThan(1);
+    }
+  });
+
+  test('reports a real measured compression ratio, not the old 15.3 constant', () => {
+    const row = scoreFixture(TOKEN_EFFICIENCY_CORPUS[0]);
+    expect(Number.isFinite(row.compressionRatio)).toBe(true);
+    expect(row.compressionRatio).not.toBe(15.3);
+  });
+});
+
+describe('runTokenEfficiencyBenchmark', () => {
+  test('produces one row per fixture', () => {
+    const rows = runTokenEfficiencyBenchmark();
+    expect(rows).toHaveLength(TOKEN_EFFICIENCY_CORPUS.length);
+    expect(rows.map((r) => r.fixture).sort()).toEqual(
+      TOKEN_EFFICIENCY_CORPUS.map((f) => f.name).sort(),
+    );
+  });
+
+  test('rows wrap into a schema-valid result envelope', () => {
+    const envelope = buildResultEnvelope({
+      axis: 'token-efficiency',
+      environment: captureEnvironment(),
+      competitors: [{ name: 'OpenChrome', version: '1.12.0' }],
+      results: runTokenEfficiencyBenchmark(),
+    });
+    expect(validateResultEnvelope(envelope)).toEqual([]);
+  });
+});

--- a/tests/benchmark/run-token-efficiency.ts
+++ b/tests/benchmark/run-token-efficiency.ts
@@ -1,0 +1,134 @@
+#!/usr/bin/env ts-node
+/**
+ * Token-efficiency runner for the Token Efficiency axis (#1256).
+ *
+ * Scores the deterministic-static extraction baseline against the starter
+ * fixture corpus: for every fixture it measures payload token cost,
+ * information retention against the >= 12-field ground truth, and the
+ * compression ratio vs raw HTML — the real, measured replacement for the old
+ * unverified 15.3x constant. Results are wrapped in the standard benchmark
+ * envelope (#1255).
+ *
+ *   npm run bench:tokens
+ *
+ * Per-library extraction adapters (OpenChrome read_page, playwright-mcp a11y
+ * snapshot, Crawlee, etc.) and the full 50-fixture corpus are later work
+ * units; this runner establishes the baseline measurement path.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {
+  computeRetention,
+  scorePayload,
+  compressionRatio,
+  efficiencyPoint,
+  EfficiencyPoint,
+} from './token-efficiency';
+import {
+  TOKEN_EFFICIENCY_CORPUS,
+  deterministicExtract,
+  TokenEfficiencyFixture,
+} from './fixtures/token-efficiency/corpus';
+import { captureEnvironment } from './utils/environment';
+import { buildResultEnvelope, assertValidResultEnvelope } from './utils/result-envelope';
+
+const OUTPUT_PATH = path.join(process.cwd(), 'benchmark', 'results', 'token-efficiency.json');
+
+/** The extraction mode this runner measures. */
+const EXTRACTION_LIBRARY = 'deterministic-static';
+
+export interface TokenEfficiencyRow {
+  fixture: string;
+  archetype: string;
+  library: string;
+  rawHtmlChars: number;
+  payloadTokens: number;
+  rawHtmlTokens: number;
+  compressionRatio: number;
+  retention: number;
+  fieldsRetained: number;
+  fieldsTotal: number;
+  efficiencyPoint: EfficiencyPoint;
+}
+
+export function scoreFixture(fixture: TokenEfficiencyFixture): TokenEfficiencyRow {
+  const extracted = deterministicExtract(fixture.html);
+  const payload = JSON.stringify(extracted);
+  const retention = computeRetention(extracted, fixture.groundTruth);
+  const payloadScore = scorePayload(payload);
+  const rawScore = scorePayload(fixture.html);
+  return {
+    fixture: fixture.name,
+    archetype: fixture.archetype,
+    library: EXTRACTION_LIBRARY,
+    rawHtmlChars: rawScore.chars,
+    payloadTokens: payloadScore.tokens,
+    rawHtmlTokens: rawScore.tokens,
+    compressionRatio: compressionRatio(fixture.html, payload),
+    retention: retention.retention,
+    fieldsRetained: retention.fieldsRetained,
+    fieldsTotal: retention.fieldsTotal,
+    efficiencyPoint: efficiencyPoint(EXTRACTION_LIBRARY, fixture.groundTruth, extracted, payload),
+  };
+}
+
+export function runTokenEfficiencyBenchmark(): TokenEfficiencyRow[] {
+  return TOKEN_EFFICIENCY_CORPUS.map(scoreFixture);
+}
+
+function readRepoVersion(): string {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
+    return typeof pkg.version === 'string' ? pkg.version : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function formatReport(rows: TokenEfficiencyRow[]): string {
+  const lines = ['Token-efficiency benchmark (#1256) — deterministic-static baseline'];
+  lines.push('fixture        archetype   tokens   raw-tokens   compression   retention');
+  for (const r of rows) {
+    lines.push(
+      [
+        r.fixture.padEnd(14),
+        r.archetype.padEnd(11),
+        String(r.payloadTokens).padStart(6),
+        String(r.rawHtmlTokens).padStart(11),
+        `${r.compressionRatio.toFixed(1)}x`.padStart(13),
+        `${(r.retention * 100).toFixed(0)}%`.padStart(11),
+      ].join(' '),
+    );
+  }
+  return lines.join('\n');
+}
+
+export function main(): void {
+  const rows = runTokenEfficiencyBenchmark();
+
+  const envelope = buildResultEnvelope({
+    axis: 'token-efficiency',
+    environment: captureEnvironment(),
+    competitors: [{ name: 'OpenChrome', version: readRepoVersion() }],
+    results: rows,
+  });
+  assertValidResultEnvelope(envelope);
+
+  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(envelope, null, 2) + '\n');
+
+  // console.error: stdout carries MCP JSON-RPC in this codebase; never log there.
+  console.error(formatReport(rows));
+  console.error(`\nSaved: ${path.relative(process.cwd(), OUTPUT_PATH)}`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    console.error('Token-efficiency benchmark failed:', err);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary

Work unit of **#1256** (Token Efficiency axis, Epic #1254), building on the merged scoring core (#1264).

- **Starter fixture corpus** (`tests/benchmark/fixtures/token-efficiency/`) — three archetypes (e-commerce, news, docs), each a structured fixture with a **≥ 12-field** ground truth and realistic noise markup so raw HTML dwarfs the structured payload. **`RUBRIC.md`** commits the field categories and the "present" matching rule *before* any measurement.
- **`run-token-efficiency.ts`** — scores the deterministic-static extraction baseline: payload token cost, information retention against ground truth, and the **real measured compression ratio** vs raw HTML (replacing the old unverified `15.3x` constant). Wraps results in the standard envelope (#1255).
- `npm run bench:tokens`.

Smoke run produces real compression ratios — 103x / 120x / 68x across the three archetypes — not a hard-coded constant.

## Test plan

- [x] `npx jest tests/benchmark/run-token-efficiency.test.ts` — 8/8 pass (≥12 fields per fixture, ground-truth values present in HTML, full retention for the deterministic baseline, compression > 1, schema-valid envelope)
- [x] `npx ts-node tests/benchmark/run-token-efficiency.ts` — produces a schema-valid envelope
- [ ] CI green
- [ ] Per-library extraction adapters + full 50-fixture real-page corpus (later work units)

> Authored in an isolated git worktree due to concurrent sessions on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)