### PR TITLE
feat(benchmark): local login-wall app fixture (#1260 — E.1)

### DIFF
--- a/tests/benchmark/fixtures/auth-app/server.test.ts
+++ b/tests/benchmark/fixtures/auth-app/server.test.ts
@@ -1,0 +1,117 @@
+/// <reference types="jest" />
+
+import * as http from 'http';
+import { startAuthApp, AuthApp, AUTH_APP_CREDENTIALS } from './server';
+
+interface Response {
+  status: number;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+}
+
+/** Minimal HTTP client that does NOT follow redirects, so tests can assert
+ *  on the 302s the login wall returns. */
+function request(
+  url: string,
+  options: { method?: string; headers?: Record<string, string>; body?: string } = {},
+): Promise<Response> {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const req = http.request(
+      {
+        hostname: u.hostname,
+        port: u.port,
+        path: u.pathname + u.search,
+        method: options.method ?? 'GET',
+        headers: options.headers,
+      },
+      (res) => {
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', (c) => (body += c));
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, headers: res.headers, body }));
+      },
+    );
+    req.on('error', reject);
+    if (options.body) req.write(options.body);
+    req.end();
+  });
+}
+
+function sessionCookie(res: Response): string {
+  const setCookie = res.headers['set-cookie']?.[0] ?? '';
+  return setCookie.split(';')[0];
+}
+
+describe('auth-app login-wall fixture', () => {
+  let app: AuthApp;
+
+  beforeAll(async () => {
+    app = await startAuthApp();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  test('the dashboard is gated — unauthenticated GET / redirects to /login', async () => {
+    const res = await request(app.url + '/');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/login');
+  });
+
+  test('GET /login serves the login form', async () => {
+    const res = await request(app.url + '/login');
+    expect(res.status).toBe(200);
+    expect(res.body).toContain('<form method="POST" action="/login">');
+  });
+
+  test('wrong credentials are rejected with 401', async () => {
+    const res = await request(app.url + '/login', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: 'username=bench-user&password=wrong',
+    });
+    expect(res.status).toBe(401);
+    expect(app.activeSessions).toBe(0);
+  });
+
+  test('correct credentials set a session cookie and unlock the dashboard', async () => {
+    const login = await request(app.url + '/login', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: `username=${AUTH_APP_CREDENTIALS.username}&password=${AUTH_APP_CREDENTIALS.password}`,
+    });
+    expect(login.status).toBe(302);
+    expect(login.headers.location).toBe('/');
+    const cookie = sessionCookie(login);
+    expect(cookie).toContain('oc_bench_sid=');
+
+    const dashboard = await request(app.url + '/', { headers: { cookie } });
+    expect(dashboard.status).toBe(200);
+    expect(dashboard.body).toContain('data-testid="protected-content"');
+    expect(dashboard.body).toContain(AUTH_APP_CREDENTIALS.username);
+  });
+
+  test('logout clears the session and re-locks the dashboard', async () => {
+    const login = await request(app.url + '/login', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: `username=${AUTH_APP_CREDENTIALS.username}&password=${AUTH_APP_CREDENTIALS.password}`,
+    });
+    const cookie = sessionCookie(login);
+
+    await request(app.url + '/logout', { headers: { cookie } });
+    const afterLogout = await request(app.url + '/', { headers: { cookie } });
+    expect(afterLogout.status).toBe(302);
+    expect(afterLogout.headers.location).toBe('/login');
+  });
+
+  test('a forged / unknown session cookie does not unlock the dashboard', async () => {
+    const res = await request(app.url + '/', {
+      headers: { cookie: 'oc_bench_sid=not-a-real-session' },
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/login');
+  });
+});

--- a/tests/benchmark/fixtures/auth-app/server.ts
+++ b/tests/benchmark/fixtures/auth-app/server.ts
@@ -1,0 +1,173 @@
+/**
+ * Local login-wall app for the Auth & Real-World Usability axis (#1260).
+ *
+ * The reproducible tier of the auth benchmark: a self-hosted app with a real
+ * login wall and a seeded test account. Running auth scenarios against this —
+ * rather than live third-party sites — keeps #1260 reproducible and avoids any
+ * ToS concern. The live tier (real sites, operator's own accounts) is a
+ * separate, clearly-labeled, best-effort work unit.
+ *
+ * Routes:
+ *   GET  /login      -> login form
+ *   POST /login      -> validate credentials, set a session cookie, redirect /
+ *   GET  /           -> protected dashboard when authenticated, else 302 /login
+ *   GET  /logout     -> clear the session, redirect /login
+ *
+ * No credentials are committed beyond the throwaway seeded test account below;
+ * it only ever exists in-process.
+ */
+
+import * as http from 'http';
+import * as crypto from 'crypto';
+import type { AddressInfo } from 'net';
+
+/** The seeded throwaway test account — in-process only, never persisted. */
+export const AUTH_APP_CREDENTIALS = {
+  username: 'bench-user',
+  password: 'bench-pass-2026',
+} as const;
+
+const SESSION_COOKIE = 'oc_bench_sid';
+
+function parseCookies(header: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!header) return out;
+  for (const part of header.split(';')) {
+    const idx = part.indexOf('=');
+    if (idx === -1) continue;
+    out[part.slice(0, idx).trim()] = decodeURIComponent(part.slice(idx + 1).trim());
+  }
+  return out;
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', () => resolve(body));
+    req.on('error', reject);
+  });
+}
+
+const LOGIN_PAGE =
+  '<!doctype html><html lang="en"><head><meta charset="utf-8">' +
+  '<title>Benchmark Login</title></head><body>' +
+  '<h1>Sign in</h1>' +
+  '<form method="POST" action="/login">' +
+  '<label>Username <input name="username" type="text"></label>' +
+  '<label>Password <input name="password" type="password"></label>' +
+  '<button type="submit">Sign in</button>' +
+  '</form></body></html>';
+
+function dashboardPage(username: string): string {
+  return (
+    '<!doctype html><html lang="en"><head><meta charset="utf-8">' +
+    '<title>Benchmark Dashboard</title></head><body>' +
+    `<h1>Welcome, ${username}</h1>` +
+    '<p data-testid="protected-content">This content is only visible when authenticated.</p>' +
+    '<a href="/logout">Log out</a>' +
+    '</body></html>'
+  );
+}
+
+export interface AuthApp {
+  readonly port: number;
+  readonly url: string;
+  readonly credentials: typeof AUTH_APP_CREDENTIALS;
+  /** Number of currently active sessions — useful for assertions. */
+  readonly activeSessions: number;
+  close(): Promise<void>;
+}
+
+/**
+ * Start the login-wall app on an ephemeral loopback port. The caller owns the
+ * lifecycle and must call `close()`.
+ */
+export async function startAuthApp(): Promise<AuthApp> {
+  // session id -> username
+  const sessions = new Map<string, string>();
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    const cookies = parseCookies(req.headers.cookie);
+    const sessionUser = cookies[SESSION_COOKIE]
+      ? sessions.get(cookies[SESSION_COOKIE])
+      : undefined;
+
+    if (req.method === 'GET' && url.pathname === '/login') {
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      res.end(LOGIN_PAGE);
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/login') {
+      const body = await readBody(req);
+      const form = new URLSearchParams(body);
+      const username = form.get('username') ?? '';
+      const password = form.get('password') ?? '';
+      if (
+        username === AUTH_APP_CREDENTIALS.username &&
+        password === AUTH_APP_CREDENTIALS.password
+      ) {
+        const sid = crypto.randomBytes(16).toString('hex');
+        sessions.set(sid, username);
+        res.writeHead(302, {
+          'set-cookie': `${SESSION_COOKIE}=${sid}; HttpOnly; Path=/`,
+          location: '/',
+        });
+        res.end();
+      } else {
+        res.writeHead(401, { 'content-type': 'text/html; charset=utf-8' });
+        res.end('<!doctype html><html><body><h1>Invalid credentials</h1></body></html>');
+      }
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/logout') {
+      if (cookies[SESSION_COOKIE]) sessions.delete(cookies[SESSION_COOKIE]);
+      res.writeHead(302, {
+        'set-cookie': `${SESSION_COOKIE}=; HttpOnly; Path=/; Max-Age=0`,
+        location: '/login',
+      });
+      res.end();
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/') {
+      if (!sessionUser) {
+        res.writeHead(302, { location: '/login' });
+        res.end();
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      res.end(dashboardPage(sessionUser));
+      return;
+    }
+
+    res.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
+    res.end('not found');
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  const { port } = server.address() as AddressInfo;
+  let closed = false;
+
+  return {
+    port,
+    url: `http://127.0.0.1:${port}`,
+    credentials: AUTH_APP_CREDENTIALS,
+    get activeSessions(): number {
+      return sessions.size;
+    },
+    close(): Promise<void> {
+      if (closed) return Promise.resolve();
+      closed = true;
+      return new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}


### PR DESCRIPTION
## Summary

First work unit of **#1260** (Auth & Real-World Usability axis, Epic #1254).

The **reproducible tier** of the auth benchmark: a self-hosted HTTP app with a real login wall and a seeded throwaway test account. Running auth scenarios against this — rather than live third-party sites — keeps #1260 reproducible and avoids any ToS concern. The live tier (real sites, operator's own accounts) is a separate, clearly-labeled work unit.

- `GET /login` serves a form; `POST /login` validates credentials, sets an `HttpOnly` session cookie, redirects to `/`.
- `GET /` serves the protected dashboard only with a valid session, else `302 → /login`. `GET /logout` clears the session.
- `startAuthApp()` listens on an ephemeral loopback port and exposes the seeded credentials + active-session count for assertions.
- No credentials committed beyond the in-process throwaway account.

## Test plan

- [x] `npx jest tests/benchmark/fixtures/auth-app/server.test.ts` — 6/6 pass (gate, form, wrong-credential rejection, full login → dashboard → logout flow, forged-cookie rejection)
- [ ] CI green
- [ ] Wire to the auth runner + setup-cost measurement (follow-up work unit E.2)

> Authored in an isolated git worktree due to concurrent sessions on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)