### PR TITLE
ci(benchmark): cross-platform benchmark workflow (#1259 — D.3)

### DIFF
--- a/.github/workflows/benchmark-reliability.yml
+++ b/.github/workflows/benchmark-reliability.yml
@@ -1,0 +1,55 @@
+# Benchmark CI — cross-platform pass rate for the competitive benchmark suite.
+#
+# Part of the Reliability & Fault-Recovery axis (#1259, Epic #1254): one of
+# that axis's headline metrics is the cross-platform pass rate, so the
+# benchmark suites must be exercised on macOS / Linux / Windows. This workflow
+# also gives every other axis's pure-logic cores + fixtures continuous
+# cross-platform coverage.
+#
+# Scoped to benchmark code via path filters so it does not duplicate the main
+# ci.yml run on unrelated changes.
+
+name: Benchmark
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'tests/benchmark/**'
+      - 'benchmark/**'
+      - '.github/workflows/benchmark-reliability.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'tests/benchmark/**'
+      - 'benchmark/**'
+      - '.github/workflows/benchmark-reliability.yml'
+
+jobs:
+  benchmark-suite:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Do not cancel the whole matrix on a single-OS failure — the
+      # cross-platform pass rate is itself a benchmark metric, so every cell
+      # must run to completion and be recorded.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [18, 20, 22]
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run benchmark suites
+        run: npx jest tests/benchmark
+        env:
+          CI: true


### PR DESCRIPTION
## Summary

Work unit of **#1259** (Reliability & Fault-Recovery axis, Epic #1254). One of #1259's headline metrics is the **cross-platform pass rate**, so the benchmark suites must run on macOS / Linux / Windows.

Adds `.github/workflows/benchmark-reliability.yml`:
- Runs the `tests/benchmark` suites across an os × node-version matrix (`ubuntu/macos/windows` × `18/20/22`).
- `fail-fast: false` — every cell runs to completion and is recorded, because the cross-platform pass rate is itself a benchmark metric.
- Path-filtered to `tests/benchmark/**` / `benchmark/**` so it does not duplicate the main `ci.yml` run on unrelated changes.
- Action SHAs pinned to match `ci.yml`.

## Test plan

- [x] YAML validated (`yaml.safe_load`) — well-formed, matrix correct
- [ ] CI green (the workflow triggers on this PR, since it touches `.github/workflows/benchmark-reliability.yml`)

> Authored in an isolated git worktree due to concurrent sessions on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)