### PR TITLE
feat(benchmark): expand WebVoyager task corpus to 18 + structural validation (#1257 — B.1)

### DIFF
--- a/tests/benchmark/webvoyager/tasks-corpus.test.ts
+++ b/tests/benchmark/webvoyager/tasks-corpus.test.ts
@@ -1,0 +1,82 @@
+/// <reference types="jest" />
+
+/**
+ * Structural validation of the WebVoyager task corpus.
+ *
+ * The runner's loadTasks() filters tasks/*.ts purely by filename and only
+ * checks `typeof t.name === 'string'` before use — so a malformed task spec
+ * would slip through to a real run. This test loads every task file the same
+ * way the runner does and asserts the full WebVoyagerTask shape, so a broken
+ * spec fails fast in CI instead of mid-benchmark.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { WebVoyagerTask } from './types';
+
+const TASKS_DIR = path.join(__dirname, 'tasks');
+
+function taskFiles(): string[] {
+  // Mirror runner.ts loadTasks() filtering exactly.
+  return fs
+    .readdirSync(TASKS_DIR)
+    .filter((e) => e.endsWith('.ts') && !e.startsWith('_') && e !== 'README.md')
+    .sort();
+}
+
+function isAssertion(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const a = value as Record<string, unknown>;
+  if (typeof a.kind !== 'string') return false;
+  if (a.kind === 'and' || a.kind === 'or') {
+    return Array.isArray(a.children) && a.children.every(isAssertion);
+  }
+  return true; // leaf assertion — kind-specific fields are checked by the contract DSL itself
+}
+
+describe('WebVoyager task corpus', () => {
+  const files = taskFiles();
+
+  test('the corpus has expanded beyond the original 10 tasks', () => {
+    expect(files.length).toBeGreaterThanOrEqual(18);
+  });
+
+  test.each(files)('%s exports a structurally valid WebVoyagerTask', async (file) => {
+    const mod = await import(path.join(TASKS_DIR, file));
+    const task = (mod.default ?? mod.task) as WebVoyagerTask | undefined;
+
+    expect(task).toBeDefined();
+    expect(typeof task!.name).toBe('string');
+    expect(task!.name.length).toBeGreaterThan(0);
+    // The runner sorts by filename and keys reports by name — they must agree.
+    expect(file).toBe(`${task!.name}.ts`);
+    expect(typeof task!.instruction).toBe('string');
+    expect(task!.instruction.length).toBeGreaterThan(0);
+    expect(typeof task!.timeout_ms).toBe('number');
+    expect(task!.timeout_ms).toBeGreaterThan(0);
+    expect(task!.contract).toBeDefined();
+    expect(isAssertion(task!.contract.postconditions)).toBe(true);
+  });
+
+  test('task names are unique across the corpus', async () => {
+    const names = await Promise.all(
+      files.map(async (f) => {
+        const mod = await import(path.join(TASKS_DIR, f));
+        return ((mod.default ?? mod.task) as WebVoyagerTask).name;
+      }),
+    );
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test('newly added tasks (task-11..task-18) are marked pending until transcripts exist', async () => {
+    const newFiles = files.filter((f) => /^task-1[1-8]-/.test(f));
+    expect(newFiles.length).toBe(8);
+    for (const f of newFiles) {
+      const mod = await import(path.join(TASKS_DIR, f));
+      const task = (mod.default ?? mod.task) as WebVoyagerTask;
+      // Honest flag: no frozen transcript recorded yet, so the mock runner
+      // must skip them rather than report a false pass/fail.
+      expect(task.pending).toBe(true);
+    }
+  });
+});

--- a/tests/benchmark/webvoyager/tasks/task-11-example-org-title.ts
+++ b/tests/benchmark/webvoyager/tasks/task-11-example-org-title.ts
@@ -1,0 +1,23 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-11-example-org-title',
+  instruction: 'Visit https://example.org and report the page heading.',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https://example\\.org/?$' },
+        { kind: 'dom_text', selector: 'h1', contains: 'Example Domain' },
+        { kind: 'dom_count', selector: 'h1', op: 'gte', value: 1 },
+      ],
+    },
+  },
+  timeout_ms: 60_000,
+  pending: true,
+  rationale:
+    'example.org is RFC-2606 reserved and serves the same effectively-immutable ' +
+    '"Example Domain" page as example.com — a second near-zero-brittleness smoke task.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-12-wikipedia-everest-height.ts
+++ b/tests/benchmark/webvoyager/tasks/task-12-wikipedia-everest-height.ts
@@ -1,0 +1,23 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-12-wikipedia-everest-height',
+  instruction:
+    'Open the Wikipedia article for Mount Everest and confirm its elevation is listed as 8,849 metres.',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https://en\\.wikipedia\\.org/wiki/Mount_Everest$' },
+        { kind: 'dom_text', selector: 'body', contains: '8,849' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Mount Everest\'s official elevation (8,849 m, the 2020 China-Nepal joint survey) is a ' +
+    'stable, sourced fact in the article infobox and lead.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-13-mdn-array-length.ts
+++ b/tests/benchmark/webvoyager/tasks/task-13-mdn-array-length.ts
@@ -1,0 +1,27 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-13-mdn-array-length',
+  instruction:
+    'Open the MDN reference for Array.prototype.length and confirm it describes the ' +
+    'number of elements in the array.',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        {
+          kind: 'url',
+          pattern: '^https://developer\\.mozilla\\.org/.*Array/length',
+        },
+        { kind: 'dom_text', selector: 'body', contains: 'number of elements in that array' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'MDN reference page. The normative description of Array.prototype.length has been ' +
+    'stable for years and the page is a long-lived canonical URL.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-14-rfc-2606-reserved-domains.ts
+++ b/tests/benchmark/webvoyager/tasks/task-14-rfc-2606-reserved-domains.ts
@@ -1,0 +1,23 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-14-rfc-2606-reserved-domains',
+  instruction:
+    'Open RFC 2606 on the IETF datatracker and confirm it reserves the .example top-level domain.',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https://datatracker\\.ietf\\.org/doc/.*rfc2606' },
+        { kind: 'dom_text', selector: 'body', contains: 'Reserved Top Level DNS Names' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC 2606 is a published, immutable IETF document; its title "Reserved Top Level DNS ' +
+    'Names" will never change.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-15-whatwg-article-element.ts
+++ b/tests/benchmark/webvoyager/tasks/task-15-whatwg-article-element.ts
@@ -1,0 +1,24 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-15-whatwg-article-element',
+  instruction:
+    'Open the WHATWG HTML Living Standard section on the <article> element and confirm ' +
+    'it describes a complete, self-contained composition.',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https://html\\.spec\\.whatwg\\.org/.*sections.*' },
+        { kind: 'dom_text', selector: 'body', contains: 'self-contained composition' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'WHATWG Living Standard. The normative description of <article> as a "self-contained ' +
+    'composition" is long-standing canonical text.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-16-rust-option-enum.ts
+++ b/tests/benchmark/webvoyager/tasks/task-16-rust-option-enum.ts
@@ -1,0 +1,25 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-16-rust-option-enum',
+  instruction:
+    'Open the Rust standard library documentation for the Option enum and confirm it ' +
+    'represents an optional value with the variants Some and None.',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https://doc\\.rust-lang\\.org/.*option/enum\\.Option\\.html' },
+        { kind: 'dom_text', selector: 'body', contains: 'Some' },
+        { kind: 'dom_text', selector: 'body', contains: 'None' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Rust std docs. Option\'s Some/None variants are foundational and stable; the canonical ' +
+    'doc URL has not moved across releases.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-17-python-len-builtin.ts
+++ b/tests/benchmark/webvoyager/tasks/task-17-python-len-builtin.ts
@@ -1,0 +1,24 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-17-python-len-builtin',
+  instruction:
+    'Open the Python documentation for the built-in len() function and confirm it returns ' +
+    'the length (the number of items) of an object.',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https://docs\\.python\\.org/3/library/functions\\.html' },
+        { kind: 'dom_text', selector: 'body', contains: 'the number of items of an object' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Python docs. The wording of the len() builtin description is long-stable and the ' +
+    'functions.html reference URL is canonical.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-18-rfc-8259-json-title.ts
+++ b/tests/benchmark/webvoyager/tasks/task-18-rfc-8259-json-title.ts
@@ -1,0 +1,27 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-18-rfc-8259-json-title',
+  instruction:
+    'Open RFC 8259 on the IETF datatracker and confirm it is titled "The JavaScript Object ' +
+    'Notation (JSON) Data Interchange Format".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https://datatracker\\.ietf\\.org/doc/.*rfc8259' },
+        {
+          kind: 'dom_text',
+          selector: 'body',
+          contains: 'JavaScript Object Notation (JSON) Data Interchange Format',
+        },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC 8259 is a published, immutable IETF standard (STD 90); its title is permanent.',
+};
+
+export default task;


### PR DESCRIPTION
## Summary

Work unit of **#1257** (Agent Task Success axis, Epic #1254). Grows the WebVoyager corpus from 10 → 18 tasks toward the 50–100 target.

- **8 new task specs** (`task-11`..`task-18`): example.org, Wikipedia (Everest elevation), MDN (`Array.length`), RFC 2606, WHATWG (`<article>`), Rust `Option`, Python `len()`, RFC 8259. All target **long-stable, low-brittleness** pages and use only the proven contract assertion kinds (`and` / `url` / `dom_text` / `dom_count`).
- Every new task is marked **`pending: true`** — the honest flag: no frozen transcript has been recorded yet, so the mock runner skips them rather than reporting a false pass/fail. Transcript recording is a later work unit.
- **`tasks-corpus.test.ts`** — structural validation of the whole corpus, loaded exactly the way `runner.ts` `loadTasks()` does. The runner only checks `typeof name === 'string'` before use; this test asserts the full `WebVoyagerTask` shape, filename/name agreement, name uniqueness, and the `pending` flag on the new tasks — so a malformed spec fails fast in CI instead of mid-benchmark.

## Test plan

- [x] `npx jest tests/benchmark/webvoyager/tasks-corpus.test.ts` — 21/21 pass (18 task files + 3 corpus-level checks)
- [ ] CI green
- [ ] Record frozen transcripts for the new tasks + per-library adapters (later work units)

> Authored in an isolated git worktree due to concurrent sessions on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)