### PR TITLE
feat(benchmark): Puppeteer competitor adapter (#1255 — 0.2)

### DIFF
--- a/tests/benchmark/adapters/index.ts
+++ b/tests/benchmark/adapters/index.ts
@@ -15,3 +15,11 @@ export {
   OpenChromeRealAdapter,
   RealAdapterOptions,
 } from './openchrome-real-adapter';
+
+// Competitor adapters — same callTool surface, different library underneath.
+export {
+  PuppeteerAdapter,
+  PuppeteerAdapterOptions,
+  PuppeteerBrowserLike,
+  PuppeteerPageLike,
+} from './puppeteer-adapter';

--- a/tests/benchmark/adapters/puppeteer-adapter.test.ts
+++ b/tests/benchmark/adapters/puppeteer-adapter.test.ts
@@ -1,0 +1,126 @@
+/// <reference types="jest" />
+
+import {
+  PuppeteerAdapter,
+  PuppeteerBrowserLike,
+  PuppeteerPageLike,
+} from './puppeteer-adapter';
+
+/** Mock Puppeteer browser/page tree that records the operations driven. */
+function makeMockBrowser(opts: { pageHtml?: string } = {}): {
+  browser: PuppeteerBrowserLike;
+  log: string[];
+  disconnected: () => boolean;
+} {
+  const log: string[] = [];
+  let disconnected = false;
+  let pageSeq = 0;
+  const browser: PuppeteerBrowserLike = {
+    async newPage(): Promise<PuppeteerPageLike> {
+      const id = ++pageSeq;
+      log.push(`newPage:${id}`);
+      return {
+        async goto(url: string) {
+          log.push(`goto:${id}:${url}`);
+        },
+        async content() {
+          log.push(`content:${id}`);
+          return opts.pageHtml ?? `<html><body>page ${id}</body></html>`;
+        },
+        async close() {
+          log.push(`close:${id}`);
+        },
+      };
+    },
+    async disconnect() {
+      disconnected = true;
+    },
+  };
+  return { browser, log, disconnected: () => disconnected };
+}
+
+function adapterWithMock(mockHtml?: string) {
+  const mock = makeMockBrowser({ pageHtml: mockHtml });
+  const adapter = new PuppeteerAdapter({ connect: async () => mock.browser });
+  return { adapter, ...mock };
+}
+
+describe('PuppeteerAdapter', () => {
+  test('conforms to the LibraryAdapter identity contract', () => {
+    const adapter = new PuppeteerAdapter();
+    expect(adapter.name).toBe('Puppeteer');
+    expect(adapter.kind).toBe('library');
+    expect(adapter.mode).toBe('raw-html');
+  });
+
+  test('callTool before setup() reports an error result, does not throw', async () => {
+    const adapter = new PuppeteerAdapter({ connect: async () => makeMockBrowser().browser });
+    const res = await adapter.callTool('read_page', { tabId: 'x' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('setup() was not called');
+  });
+
+  test('tabs_create opens a page, navigates, and returns a tabId', async () => {
+    const { adapter, log } = adapterWithMock();
+    await adapter.setup();
+    const res = await adapter.callTool('tabs_create', { url: 'http://127.0.0.1/small' });
+    const tabId = JSON.parse(res.content[0].text as string).tabId;
+    expect(tabId).toMatch(/^puppeteer-tab-\d+$/);
+    expect(log).toEqual(['newPage:1', 'goto:1:http://127.0.0.1/small']);
+    expect(adapter.openTabCount).toBe(1);
+  });
+
+  test('about:blank is not navigated to (matches the OpenChrome adapters)', async () => {
+    const { adapter, log } = adapterWithMock();
+    await adapter.setup();
+    await adapter.callTool('tabs_create', { url: 'about:blank' });
+    expect(log).toEqual(['newPage:1']); // no goto
+  });
+
+  test('read_page returns the page raw HTML for the given tabId', async () => {
+    const { adapter } = adapterWithMock('<html><body>fixture</body></html>');
+    await adapter.setup();
+    const created = await adapter.callTool('tabs_create', { url: 'http://x/p' });
+    const tabId = JSON.parse(created.content[0].text as string).tabId;
+    const read = await adapter.callTool('read_page', { tabId, mode: 'dom' });
+    expect(read.isError).toBeFalsy();
+    expect(read.content[0].text).toBe('<html><body>fixture</body></html>');
+  });
+
+  test('read_page on an unknown tabId is an error result', async () => {
+    const { adapter } = adapterWithMock();
+    await adapter.setup();
+    const res = await adapter.callTool('read_page', { tabId: 'nope' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('unknown tabId');
+  });
+
+  test('tabs_close closes the page and drops it from the tab map', async () => {
+    const { adapter, log } = adapterWithMock();
+    await adapter.setup();
+    const created = await adapter.callTool('tabs_create', { url: 'http://x/p' });
+    const tabId = JSON.parse(created.content[0].text as string).tabId;
+    await adapter.callTool('tabs_close', { tabId });
+    expect(log).toContain('close:1');
+    expect(adapter.openTabCount).toBe(0);
+  });
+
+  test('unsupported tools return an error result rather than throwing', async () => {
+    const { adapter } = adapterWithMock();
+    await adapter.setup();
+    const res = await adapter.callTool('act', { instruction: 'click' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('unsupported tool');
+  });
+
+  test('teardown closes remaining pages and disconnects the browser', async () => {
+    const { adapter, log, disconnected } = adapterWithMock();
+    await adapter.setup();
+    await adapter.callTool('tabs_create', { url: 'http://x/a' });
+    await adapter.callTool('tabs_create', { url: 'http://x/b' });
+    await adapter.teardown();
+    expect(log.filter((l) => l.startsWith('close:'))).toHaveLength(2);
+    expect(disconnected()).toBe(true);
+    expect(adapter.openTabCount).toBe(0);
+  });
+});

--- a/tests/benchmark/adapters/puppeteer-adapter.ts
+++ b/tests/benchmark/adapters/puppeteer-adapter.ts
@@ -1,0 +1,154 @@
+/**
+ * Puppeteer competitor adapter for the competitive benchmark suite (#1255).
+ *
+ * Drives Puppeteer through the same `callTool(toolName, args)` surface the
+ * OpenChrome MCP adapters expose, so a benchmark task (e.g. measureLatency in
+ * tests/benchmark/latency.ts) runs against Puppeteer with byte-identical task
+ * code — the only variable is the library (Epic #1254, methodology #4).
+ *
+ * Puppeteer is not an MCP server; this adapter translates the small set of
+ * benchmark tool calls into Puppeteer operations:
+ *   tabs_create({ url })  -> newPage() + page.goto(url)  -> { tabId }
+ *   read_page({ tabId })  -> page.content()              -> raw HTML
+ *   tabs_close({ tabId }) -> page.close()
+ *
+ * `puppeteer-core` is already a project dependency; this adapter connects to
+ * an already-running Chrome over CDP (no bundled-browser download). The CDP
+ * `connect` is injected via a factory so the translation logic is unit-
+ * testable against a mock browser, with the real connection exercised behind
+ * an env-gated integration check.
+ */
+
+import { MCPAdapter, MCPToolResult } from '../benchmark-runner';
+
+/** Minimal Puppeteer Page surface this adapter uses. */
+export interface PuppeteerPageLike {
+  goto(url: string): Promise<unknown>;
+  content(): Promise<string>;
+  close(): Promise<void>;
+}
+
+/** Minimal Puppeteer Browser surface this adapter uses. */
+export interface PuppeteerBrowserLike {
+  newPage(): Promise<PuppeteerPageLike>;
+  disconnect(): Promise<void>;
+}
+
+export interface PuppeteerAdapterOptions {
+  /** CDP endpoint of an already-running Chrome, e.g. http://127.0.0.1:9222. */
+  browserURL?: string;
+  /**
+   * Connect factory — defaults to puppeteer-core's connect(). Injected so the
+   * translation logic can be unit-tested against a mock browser.
+   */
+  connect?: (browserURL: string) => Promise<PuppeteerBrowserLike>;
+}
+
+const DEFAULT_BROWSER_URL = 'http://127.0.0.1:9222';
+
+async function defaultConnect(browserURL: string): Promise<PuppeteerBrowserLike> {
+  // Lazy import: keeps the module loadable (and unit-testable with a mock
+  // connect) on machines without a reachable Chrome.
+  const puppeteer = (await import('puppeteer-core')).default;
+  const browser = await puppeteer.connect({ browserURL });
+  return browser as unknown as PuppeteerBrowserLike;
+}
+
+function textResult(text: string): MCPToolResult {
+  return { content: [{ type: 'text', text }] };
+}
+
+function errorResult(message: string): MCPToolResult {
+  return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+export class PuppeteerAdapter implements MCPAdapter {
+  readonly name = 'Puppeteer';
+  readonly mode = 'raw-html';
+  readonly kind = 'library' as const;
+
+  private readonly browserURL: string;
+  private readonly connect: (browserURL: string) => Promise<PuppeteerBrowserLike>;
+  private browser: PuppeteerBrowserLike | null = null;
+  private readonly pages = new Map<string, PuppeteerPageLike>();
+  private tabSeq = 0;
+
+  constructor(options: PuppeteerAdapterOptions = {}) {
+    this.browserURL = options.browserURL ?? DEFAULT_BROWSER_URL;
+    this.connect = options.connect ?? defaultConnect;
+  }
+
+  async setup(): Promise<void> {
+    this.browser = await this.connect(this.browserURL);
+  }
+
+  async teardown(): Promise<void> {
+    for (const page of this.pages.values()) {
+      await page.close().catch(() => undefined);
+    }
+    this.pages.clear();
+    if (this.browser) {
+      await this.browser.disconnect().catch(() => undefined);
+      this.browser = null;
+    }
+  }
+
+  async callTool(toolName: string, args: Record<string, unknown>): Promise<MCPToolResult> {
+    if (!this.browser) {
+      return errorResult('PuppeteerAdapter: setup() was not called');
+    }
+    try {
+      switch (toolName) {
+        case 'tabs_create':
+          return await this.createTab(args);
+        case 'read_page':
+          return await this.readPage(args);
+        case 'tabs_close':
+          return await this.closeTab(args);
+        default:
+          return errorResult(`PuppeteerAdapter: unsupported tool "${toolName}"`);
+      }
+    } catch (err) {
+      return errorResult(`PuppeteerAdapter: ${toolName} failed: ${(err as Error).message}`);
+    }
+  }
+
+  private async createTab(args: Record<string, unknown>): Promise<MCPToolResult> {
+    const page = await (this.browser as PuppeteerBrowserLike).newPage();
+    const url = typeof args.url === 'string' ? args.url : undefined;
+    if (url && url !== 'about:blank') {
+      await page.goto(url);
+    }
+    const tabId = `puppeteer-tab-${++this.tabSeq}`;
+    this.pages.set(tabId, page);
+    return textResult(JSON.stringify({ tabId }));
+  }
+
+  private async readPage(args: Record<string, unknown>): Promise<MCPToolResult> {
+    const tabId = typeof args.tabId === 'string' ? args.tabId : '';
+    const page = this.pages.get(tabId);
+    if (!page) {
+      return errorResult(`PuppeteerAdapter: unknown tabId "${tabId}"`);
+    }
+    // Puppeteer's idiomatic "give this to an LLM" surface is the raw HTML;
+    // the Token Efficiency axis (#1256) compares that against OpenChrome's
+    // compact DOM, so this adapter returns it unembellished.
+    return textResult(await page.content());
+  }
+
+  private async closeTab(args: Record<string, unknown>): Promise<MCPToolResult> {
+    const tabId = typeof args.tabId === 'string' ? args.tabId : '';
+    const page = this.pages.get(tabId);
+    if (!page) {
+      return errorResult(`PuppeteerAdapter: unknown tabId "${tabId}"`);
+    }
+    await page.close();
+    this.pages.delete(tabId);
+    return textResult(JSON.stringify({ closed: tabId }));
+  }
+
+  /** Number of pages this adapter currently tracks — for assertions. */
+  get openTabCount(): number {
+    return this.pages.size;
+  }
+}


### PR DESCRIPTION
## Summary

First **competitor adapter** for the benchmark suite (Epic #1254). Drives Puppeteer through the same `callTool(toolName, args)` surface the OpenChrome MCP adapters expose, so a benchmark task (e.g. `measureLatency`) runs against Puppeteer with **byte-identical task code** — the only variable is the library (methodology principle #4).

- `PuppeteerAdapter implements MCPAdapter` (`kind: 'library'`); translates the benchmark tool calls into Puppeteer ops: `tabs_create` → `newPage` + `goto`, `read_page` → `page.content()` (raw HTML — Puppeteer's idiomatic "give this to an LLM" surface, which #1256 compares against OpenChrome's compact DOM), `tabs_close` → `page.close()`.
- Uses the **existing `puppeteer-core` dependency** and connects to an already-running Chrome over CDP — no bundled-browser download. The `connect` call is injected via a factory so the translation logic is unit-testable against a mock browser.
- Exported from the adapters barrel.

## Test plan

- [x] `npx jest tests/benchmark/adapters/puppeteer-adapter.test.ts` — 9/9 pass (identity contract, pre-setup guard, tab create/read/close lifecycle, about:blank handling, unknown-tabId + unsupported-tool error results, teardown cleanup)
- [ ] CI green
- [ ] Env-gated integration run against a live Chrome (follow-up)

> Authored in an isolated git worktree due to concurrent sessions on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)