### PR TITLE
feat(benchmark): Playwright competitor adapter (#1255 — 0.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
         "js-tiktoken": "^1.0.21",
+        "playwright": "^1.49.0",
         "rimraf": "^5.0.0",
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.2",
@@ -5710,6 +5711,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
     "js-tiktoken": "^1.0.21",
+    "playwright": "^1.49.0",
     "rimraf": "^5.0.0",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.2",

--- a/tests/benchmark/adapters/index.ts
+++ b/tests/benchmark/adapters/index.ts
@@ -15,3 +15,12 @@ export {
   OpenChromeRealAdapter,
   RealAdapterOptions,
 } from './openchrome-real-adapter';
+
+// Competitor adapters — same callTool surface, different library underneath.
+export {
+  PlaywrightAdapter,
+  PlaywrightAdapterOptions,
+  PlaywrightBrowserLike,
+  PlaywrightContextLike,
+  PlaywrightPageLike,
+} from './playwright-adapter';

--- a/tests/benchmark/adapters/playwright-adapter.test.ts
+++ b/tests/benchmark/adapters/playwright-adapter.test.ts
@@ -1,0 +1,153 @@
+/// <reference types="jest" />
+
+import {
+  PlaywrightAdapter,
+  PlaywrightBrowserLike,
+  PlaywrightContextLike,
+  PlaywrightPageLike,
+} from './playwright-adapter';
+
+/** Mock Playwright browser/context/page tree that records driven operations. */
+function makeMockBrowser(opts: { pageHtml?: string; withExistingContext?: boolean } = {}): {
+  browser: PlaywrightBrowserLike;
+  log: string[];
+  closed: () => boolean;
+} {
+  const log: string[] = [];
+  let browserClosed = false;
+  let pageSeq = 0;
+
+  const makeContext = (): PlaywrightContextLike => ({
+    async newPage(): Promise<PlaywrightPageLike> {
+      const id = ++pageSeq;
+      log.push(`newPage:${id}`);
+      return {
+        async goto(url: string) {
+          log.push(`goto:${id}:${url}`);
+        },
+        async content() {
+          log.push(`content:${id}`);
+          return opts.pageHtml ?? `<html><body>page ${id}</body></html>`;
+        },
+        async close() {
+          log.push(`close:${id}`);
+        },
+      };
+    },
+  });
+
+  const existing = opts.withExistingContext === false ? [] : [makeContext()];
+  const browser: PlaywrightBrowserLike = {
+    contexts: () => existing,
+    async newContext() {
+      log.push('newContext');
+      return makeContext();
+    },
+    async close() {
+      browserClosed = true;
+    },
+  };
+  return { browser, log, closed: () => browserClosed };
+}
+
+function adapterWithMock(opts: { pageHtml?: string; withExistingContext?: boolean } = {}) {
+  const mock = makeMockBrowser(opts);
+  const adapter = new PlaywrightAdapter({ connect: async () => mock.browser });
+  return { adapter, ...mock };
+}
+
+describe('PlaywrightAdapter', () => {
+  test('conforms to the LibraryAdapter identity contract', () => {
+    const adapter = new PlaywrightAdapter();
+    expect(adapter.name).toBe('Playwright');
+    expect(adapter.kind).toBe('library');
+    expect(adapter.mode).toBe('raw-html');
+  });
+
+  test('callTool before setup() reports an error result, does not throw', async () => {
+    const adapter = new PlaywrightAdapter({ connect: async () => makeMockBrowser().browser });
+    const res = await adapter.callTool('read_page', { tabId: 'x' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('setup() was not called');
+  });
+
+  test('setup reuses the existing CDP browser context', async () => {
+    const { adapter, log } = adapterWithMock();
+    await adapter.setup();
+    await adapter.callTool('tabs_create', { url: 'about:blank' });
+    // newPage came from the existing context — newContext was never called.
+    expect(log).not.toContain('newContext');
+    expect(log).toContain('newPage:1');
+  });
+
+  test('setup falls back to newContext when none exists', async () => {
+    const { adapter, log } = adapterWithMock({ withExistingContext: false });
+    await adapter.setup();
+    await adapter.callTool('tabs_create', { url: 'about:blank' });
+    expect(log).toContain('newContext');
+  });
+
+  test('tabs_create opens a page, navigates, and returns a tabId', async () => {
+    const { adapter, log } = adapterWithMock();
+    await adapter.setup();
+    const res = await adapter.callTool('tabs_create', { url: 'http://127.0.0.1/small' });
+    const tabId = JSON.parse(res.content[0].text as string).tabId;
+    expect(tabId).toMatch(/^playwright-tab-\d+$/);
+    expect(log).toContain('goto:1:http://127.0.0.1/small');
+    expect(adapter.openTabCount).toBe(1);
+  });
+
+  test('about:blank is not navigated to', async () => {
+    const { adapter, log } = adapterWithMock();
+    await adapter.setup();
+    await adapter.callTool('tabs_create', { url: 'about:blank' });
+    expect(log.some((l) => l.startsWith('goto:'))).toBe(false);
+  });
+
+  test('read_page returns the page raw HTML for the given tabId', async () => {
+    const { adapter } = adapterWithMock({ pageHtml: '<html><body>fixture</body></html>' });
+    await adapter.setup();
+    const created = await adapter.callTool('tabs_create', { url: 'http://x/p' });
+    const tabId = JSON.parse(created.content[0].text as string).tabId;
+    const read = await adapter.callTool('read_page', { tabId, mode: 'dom' });
+    expect(read.isError).toBeFalsy();
+    expect(read.content[0].text).toBe('<html><body>fixture</body></html>');
+  });
+
+  test('read_page on an unknown tabId is an error result', async () => {
+    const { adapter } = adapterWithMock();
+    await adapter.setup();
+    const res = await adapter.callTool('read_page', { tabId: 'nope' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('unknown tabId');
+  });
+
+  test('tabs_close closes the page and drops it from the tab map', async () => {
+    const { adapter, log } = adapterWithMock();
+    await adapter.setup();
+    const created = await adapter.callTool('tabs_create', { url: 'http://x/p' });
+    const tabId = JSON.parse(created.content[0].text as string).tabId;
+    await adapter.callTool('tabs_close', { tabId });
+    expect(log).toContain('close:1');
+    expect(adapter.openTabCount).toBe(0);
+  });
+
+  test('unsupported tools return an error result rather than throwing', async () => {
+    const { adapter } = adapterWithMock();
+    await adapter.setup();
+    const res = await adapter.callTool('act', { instruction: 'click' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('unsupported tool');
+  });
+
+  test('teardown closes remaining pages and the browser', async () => {
+    const { adapter, log, closed } = adapterWithMock();
+    await adapter.setup();
+    await adapter.callTool('tabs_create', { url: 'http://x/a' });
+    await adapter.callTool('tabs_create', { url: 'http://x/b' });
+    await adapter.teardown();
+    expect(log.filter((l) => l.startsWith('close:'))).toHaveLength(2);
+    expect(closed()).toBe(true);
+    expect(adapter.openTabCount).toBe(0);
+  });
+});

--- a/tests/benchmark/adapters/playwright-adapter.ts
+++ b/tests/benchmark/adapters/playwright-adapter.ts
@@ -1,0 +1,167 @@
+/**
+ * Playwright competitor adapter for the competitive benchmark suite (#1255).
+ *
+ * Drives Playwright through the same `callTool(toolName, args)` surface the
+ * OpenChrome MCP adapters expose, so a benchmark task runs against Playwright
+ * with byte-identical task code — the only variable is the library (Epic
+ * #1254, methodology #4).
+ *
+ * Playwright is not an MCP server; this adapter translates the benchmark tool
+ * calls into Playwright operations:
+ *   tabs_create({ url })  -> context.newPage() + page.goto(url) -> { tabId }
+ *   read_page({ tabId })  -> page.content()                     -> raw HTML
+ *   tabs_close({ tabId }) -> page.close()
+ *
+ * The adapter connects to an already-running Chrome over CDP
+ * (`chromium.connectOverCDP`), so Playwright's bundled browsers are NOT
+ * required — the `playwright` package is a devDependency for its API + types
+ * only. The connect call is injected via a factory so the translation logic
+ * is unit-testable against a mock browser.
+ */
+
+import { MCPAdapter, MCPToolResult } from '../benchmark-runner';
+
+/** Minimal Playwright Page surface this adapter uses. */
+export interface PlaywrightPageLike {
+  goto(url: string): Promise<unknown>;
+  content(): Promise<string>;
+  close(): Promise<void>;
+}
+
+/** Minimal Playwright BrowserContext surface this adapter uses. */
+export interface PlaywrightContextLike {
+  newPage(): Promise<PlaywrightPageLike>;
+}
+
+/** Minimal Playwright Browser surface this adapter uses. */
+export interface PlaywrightBrowserLike {
+  contexts(): PlaywrightContextLike[];
+  newContext(): Promise<PlaywrightContextLike>;
+  close(): Promise<void>;
+}
+
+export interface PlaywrightAdapterOptions {
+  /** CDP endpoint of an already-running Chrome, e.g. http://127.0.0.1:9222. */
+  cdpEndpoint?: string;
+  /**
+   * Connect factory — defaults to playwright's chromium.connectOverCDP().
+   * Injected so the translation logic can be unit-tested against a mock.
+   */
+  connect?: (cdpEndpoint: string) => Promise<PlaywrightBrowserLike>;
+}
+
+const DEFAULT_CDP_ENDPOINT = 'http://127.0.0.1:9222';
+
+async function defaultConnect(cdpEndpoint: string): Promise<PlaywrightBrowserLike> {
+  // Lazy import: keeps the module loadable (and unit-testable with a mock
+  // connect) on machines without a reachable Chrome.
+  const { chromium } = await import('playwright');
+  const browser = await chromium.connectOverCDP(cdpEndpoint);
+  return browser as unknown as PlaywrightBrowserLike;
+}
+
+function textResult(text: string): MCPToolResult {
+  return { content: [{ type: 'text', text }] };
+}
+
+function errorResult(message: string): MCPToolResult {
+  return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+export class PlaywrightAdapter implements MCPAdapter {
+  readonly name = 'Playwright';
+  readonly mode = 'raw-html';
+  readonly kind = 'library' as const;
+
+  private readonly cdpEndpoint: string;
+  private readonly connect: (cdpEndpoint: string) => Promise<PlaywrightBrowserLike>;
+  private browser: PlaywrightBrowserLike | null = null;
+  private context: PlaywrightContextLike | null = null;
+  private readonly pages = new Map<string, PlaywrightPageLike>();
+  private tabSeq = 0;
+
+  constructor(options: PlaywrightAdapterOptions = {}) {
+    this.cdpEndpoint = options.cdpEndpoint ?? DEFAULT_CDP_ENDPOINT;
+    this.connect = options.connect ?? defaultConnect;
+  }
+
+  async setup(): Promise<void> {
+    this.browser = await this.connect(this.cdpEndpoint);
+    // connectOverCDP exposes the existing browser's default context; reuse it
+    // so the adapter shares auth state with the running Chrome, matching how
+    // benchmark/parallel-isolated.mjs operates.
+    const existing = this.browser.contexts();
+    this.context = existing.length > 0 ? existing[0] : await this.browser.newContext();
+  }
+
+  async teardown(): Promise<void> {
+    for (const page of this.pages.values()) {
+      await page.close().catch(() => undefined);
+    }
+    this.pages.clear();
+    this.context = null;
+    if (this.browser) {
+      await this.browser.close().catch(() => undefined);
+      this.browser = null;
+    }
+  }
+
+  async callTool(toolName: string, args: Record<string, unknown>): Promise<MCPToolResult> {
+    if (!this.context) {
+      return errorResult('PlaywrightAdapter: setup() was not called');
+    }
+    try {
+      switch (toolName) {
+        case 'tabs_create':
+          return await this.createTab(args);
+        case 'read_page':
+          return await this.readPage(args);
+        case 'tabs_close':
+          return await this.closeTab(args);
+        default:
+          return errorResult(`PlaywrightAdapter: unsupported tool "${toolName}"`);
+      }
+    } catch (err) {
+      return errorResult(`PlaywrightAdapter: ${toolName} failed: ${(err as Error).message}`);
+    }
+  }
+
+  private async createTab(args: Record<string, unknown>): Promise<MCPToolResult> {
+    const page = await (this.context as PlaywrightContextLike).newPage();
+    const url = typeof args.url === 'string' ? args.url : undefined;
+    if (url && url !== 'about:blank') {
+      await page.goto(url);
+    }
+    const tabId = `playwright-tab-${++this.tabSeq}`;
+    this.pages.set(tabId, page);
+    return textResult(JSON.stringify({ tabId }));
+  }
+
+  private async readPage(args: Record<string, unknown>): Promise<MCPToolResult> {
+    const tabId = typeof args.tabId === 'string' ? args.tabId : '';
+    const page = this.pages.get(tabId);
+    if (!page) {
+      return errorResult(`PlaywrightAdapter: unknown tabId "${tabId}"`);
+    }
+    // Playwright's idiomatic "give this to an LLM" surface is the raw HTML;
+    // the Token Efficiency axis (#1256) compares that against OpenChrome's
+    // compact DOM, so this adapter returns it unembellished.
+    return textResult(await page.content());
+  }
+
+  private async closeTab(args: Record<string, unknown>): Promise<MCPToolResult> {
+    const tabId = typeof args.tabId === 'string' ? args.tabId : '';
+    const page = this.pages.get(tabId);
+    if (!page) {
+      return errorResult(`PlaywrightAdapter: unknown tabId "${tabId}"`);
+    }
+    await page.close();
+    this.pages.delete(tabId);
+    return textResult(JSON.stringify({ closed: tabId }));
+  }
+
+  /** Number of pages this adapter currently tracks — for assertions. */
+  get openTabCount(): number {
+    return this.pages.size;
+  }
+}


### PR DESCRIPTION
## Summary

Competitor adapter for the benchmark suite (Epic #1254), same pattern as the Puppeteer adapter (#1274) — drives Playwright through the OpenChrome `callTool` surface so benchmark tasks run against it with **byte-identical task code**.

- `PlaywrightAdapter implements MCPAdapter` (`kind: 'library'`); translates `tabs_create` → `context.newPage` + `goto`, `read_page` → `page.content()` (raw HTML — Playwright's idiomatic LLM surface), `tabs_close` → `page.close()`.
- Connects to an already-running Chrome over CDP via `chromium.connectOverCDP`, **reusing the existing browser context** — so Playwright's bundled browsers are NOT required and `playwright` is a devDependency for its API + types only. `connect` is injected via a factory so the translation logic is unit-tested against a mock.
- Exported from the adapters barrel.
- `package.json` + `package-lock.json` updated together (per CLAUDE.md).

## Test plan

- [x] `npx jest tests/benchmark/adapters/playwright-adapter.test.ts` — 11/11 pass (identity contract, pre-setup guard, existing-context reuse + newContext fallback, tab lifecycle, about:blank handling, error results, teardown cleanup)
- [ ] CI green
- [ ] Env-gated integration run against a live Chrome (follow-up)

> Trivial expected conflict with #1274 in `adapters/index.ts` (both add a competitor-adapter export block) — resolves to keeping both. Authored in an isolated git worktree due to concurrent sessions on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)