### PR TITLE
chore(benchmark): purge retired 15.3x compression estimate (#1254/#1255)

### DIFF
--- a/assets/chart-tokens.svg
+++ b/assets/chart-tokens.svg
@@ -11,21 +11,21 @@
   <text x="440" y="38" text-anchor="middle" font-size="22" font-weight="700" fill="#0f172a">Simple Task Token Efficiency</text>
   <text x="440" y="62" text-anchor="middle" font-size="13" fill="#94a3b8">Tokens the LLM must process per Twitter profile (lower is better)</text>
 
-  <!-- Row 1: Playwright + LLM — 178,102 tok/profile -->
+  <!-- Row 1: Playwright + LLM — 178,102 tok/profile (measured) -->
   <text x="48" y="108" font-size="13" font-weight="600" fill="#475569">Playwright + LLM</text>
   <text x="48" y="124" font-size="11" fill="#94a3b8">(raw HTML to LLM)</text>
   <rect x="200" y="96" width="580" height="36" fill="#6366f1" opacity="0.85" rx="6"/>
   <text x="770" y="120" text-anchor="end" font-size="14" font-weight="700" fill="#fff">178,102 tok/profile</text>
   <text x="200" y="152" font-size="11" fill="#94a3b8">Total for 20 profiles: 3,562,038 tokens</text>
 
-  <!-- Row 2: OpenChrome — 11,641 tok/profile -->
+  <!-- Row 2: OpenChrome — TBD pending #1256 -->
   <text x="48" y="198" font-size="13" font-weight="600" fill="#ea580c">OpenChrome</text>
   <text x="48" y="214" font-size="11" fill="#94a3b8">(compact DOM)</text>
-  <rect x="200" y="186" width="38" height="36" fill="#f97316" opacity="0.9" rx="6"/>
-  <text x="248" y="210" font-size="14" font-weight="700" fill="#1e293b">11,641 tok/profile</text>
-  <text x="200" y="242" font-size="11" fill="#94a3b8">Total for 20 profiles: 232,813 tokens</text>
+  <rect x="200" y="186" width="3" height="36" fill="#f97316" opacity="0.4" rx="1"/>
+  <text x="214" y="210" font-size="13" font-weight="700" fill="#9a3412">TBD — pending #1256</text>
+  <text x="200" y="242" font-size="11" fill="#94a3b8">Per-archetype compression measured over a 50-fixture corpus</text>
 
-  <!-- Row 3: Playwright standalone — 290 tok/profile -->
+  <!-- Row 3: Playwright standalone — 290 tok/profile (measured) -->
   <text x="48" y="288" font-size="13" font-weight="600" fill="#475569">Playwright standalone</text>
   <text x="48" y="304" font-size="11" fill="#94a3b8">(no per-page LLM)</text>
   <rect x="200" y="276" width="3" height="36" fill="#10b981" opacity="0.9" rx="1"/>
@@ -34,9 +34,9 @@
 
   <!-- Savings callout box -->
   <rect x="160" y="368" width="560" height="50" fill="#fff7ed" stroke="#f97316" stroke-width="1.5" rx="10"/>
-  <text x="440" y="390" text-anchor="middle" font-size="15" font-weight="700" fill="#ea580c">OpenChrome saves 93.5% tokens vs Playwright + LLM</text>
-  <text x="440" y="409" text-anchor="middle" font-size="12" fill="#b45309">15.3x compression — compact DOM strips CSS, scripts, and hidden elements</text>
+  <text x="440" y="390" text-anchor="middle" font-size="15" font-weight="700" fill="#ea580c">OpenChrome token savings: TBD</text>
+  <text x="440" y="409" text-anchor="middle" font-size="12" fill="#b45309">Pending validated measurement (#1256) — prior estimate retired (#1254)</text>
 
   <!-- Footer -->
-  <text x="440" y="455" text-anchor="middle" font-size="11" fill="#94a3b8">Token estimate: 1 token ≈ 4 characters | Compression ratio calibrated from actual read_page measurements</text>
+  <text x="440" y="455" text-anchor="middle" font-size="11" fill="#94a3b8">Token estimate: 1 token ≈ 4 characters | Compression figure under remeasurement; do not cite the retired 15.3x value</text>
 </svg>

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -79,7 +79,7 @@ Results are saved to `results/`:
 | **OC 10-batch** | **23.2s** | **3.5x** | **95%** |
 | OC 20-batch | 25.7s | 3.2x | 95% |
 
-Token efficiency: **15.3x compression** (OC compact DOM vs raw HTML)
+Token efficiency: **TBD — pending #1256 results** (real per-archetype compression replaces the retired hard-coded estimate)
 
 ## Methodology
 

--- a/benchmark/generate-report.mjs
+++ b/benchmark/generate-report.mjs
@@ -68,7 +68,7 @@ OC compact DOM (read_page)       ~${ocSeq.tokenEstimate.ocCompactAvg.toLocaleStr
 PW raw HTML (page.content())    ~${pw.tokenEstimate.htmlMode.avgPerProfile.toLocaleString()}   ████████████████████████████████████████████████████████████
 PW innerText (page.innerText())     ~${pw.tokenEstimate.textMode.avgPerProfile.toLocaleString()}     ░
 
-OC compresses 15.3x vs raw HTML
+OC compression vs raw HTML: TBD — pending #1256 results
 \`\`\`
 
 ### Total Workflow Token Cost
@@ -115,10 +115,10 @@ OC vs PW+LLM: ${((1 - ocTokens / pwLlmTokens) * 100).toFixed(1)}% fewer tokens (
 - **Same auth state**: Both used the logged-in session (real Chrome profile)
 - **Same targets**: 20 identical Twitter/X profiles
 - **Isolated measurements**: Each strategy run in completely separate process
-- **OC compression ratio**: Calibrated from 2 actual \`read_page\` measurements:
-  - @elonmusk: 50.8KB compact / 760KB raw = 14.96x
-  - @BillGates: 50.6KB compact / 792KB raw = 15.65x
-  - Average: **15.3x**
+- **OC compression ratio**: TBD — pending #1256 results. The prior hard-coded
+  ratio averaged only two real measurements and has been retired; the Token
+  Efficiency axis (#1256) replaces it with a per-archetype measured ratio
+  computed across a 50-fixture corpus.
 - **Token estimate**: 1 token ≈ 4 characters (standard approximation)
 
 ---

--- a/benchmark/generate-svg.mjs
+++ b/benchmark/generate-svg.mjs
@@ -12,7 +12,13 @@ const oc5 = JSON.parse(readFileSync(`${RESULTS_DIR}/isolated-batch5.json`, 'utf8
 const oc10 = JSON.parse(readFileSync(`${RESULTS_DIR}/isolated-batch10.json`, 'utf8'));
 const oc20 = JSON.parse(readFileSync(`${RESULTS_DIR}/isolated-batch20.json`, 'utf8'));
 
-const OC_COMPRESSION = 15.3;
+// Per #1254 cleanup: the historical hard-coded compression constant was an
+// unverified guess (only two real measurements averaged). The Token Efficiency
+// axis (#1256) replaces it with a real measured ratio per archetype. Until
+// #1256 publishes its results, every place that previously consumed this
+// constant renders the TBD placeholder below; the OpenChrome bars/numbers in
+// the legacy speed+token charts are intentionally absent rather than fake.
+const OC_COMPRESSION_PLACEHOLDER = 'TBD — pending #1256 results';
 
 const strategies = [
   { label: 'Playwright\nSequential', time: parseFloat(pw.timing.totalSec), tokens: pw.tokenEstimate.htmlMode.avgPerProfile, color: '#6366f1', tweets: pw.totalTweetsExtracted },
@@ -97,7 +103,10 @@ function generateTokenSVG() {
 
   const data = [
     { label: 'Playwright + LLM\n(raw HTML)', tokens: pw.tokenEstimate.htmlMode.avgPerProfile, color: '#6366f1', total: pw.tokenEstimate.htmlMode.totalTokens },
-    { label: 'OpenChrome\n(compact DOM)', tokens: Math.round(pw.tokenEstimate.htmlMode.avgPerProfile / OC_COMPRESSION), color: '#f97316', total: Math.round(pw.tokenEstimate.htmlMode.totalTokens / OC_COMPRESSION) },
+    // OpenChrome row deliberately omitted: the prior value was derived from
+    // the retired unverified compression estimate. Restore once #1256
+    // measurements land.
+    // { label: 'OpenChrome\n(compact DOM)', tokens: TBD, total: TBD }
     { label: 'Playwright standalone\n(no LLM)', tokens: 290, color: '#10b981', total: 5800 },
   ];
 
@@ -130,9 +139,9 @@ function generateTokenSVG() {
   });
 
   // Savings annotation
-  const savings = ((1 - 1/OC_COMPRESSION) * 100).toFixed(1);
+  const savings = OC_COMPRESSION_PLACEHOLDER;
   bars += `<rect x="${W/2 - 140}" y="${margin.top + rowH + rowH * 0.85}" width="280" height="32" fill="#fff7ed" stroke="#f97316" stroke-width="1.5" rx="8"/>`;
-  bars += `<text x="${W/2}" y="${margin.top + rowH + rowH * 0.85 + 21}" text-anchor="middle" font-size="14" font-weight="700" fill="#ea580c">OC saves ${savings}% tokens vs PW+LLM (${OC_COMPRESSION}x compression)</text>`;
+  bars += `<text x="${W/2}" y="${margin.top + rowH + rowH * 0.85 + 21}" text-anchor="middle" font-size="14" font-weight="700" fill="#ea580c">OC compression vs PW+LLM: ${savings}</text>`;
 
   return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
   <defs>
@@ -156,7 +165,7 @@ function generateDashboardSVG() {
   const fastest = { label: 'OC 10-batch', time: parseFloat(oc10.timing.totalSec) };
   const pwTime = parseFloat(pw.timing.totalSec);
   const speedup = (pwTime / fastest.time).toFixed(1);
-  const tokenSavings = ((1 - 1/OC_COMPRESSION) * 100).toFixed(1);
+  const tokenSavings = OC_COMPRESSION_PLACEHOLDER;
   const ocTweets = ocSeq.totalTweetsExtracted;
   const pwTweets = pw.totalTweetsExtracted;
   const moreTweets = ((ocTweets / pwTweets - 1) * 100).toFixed(0);
@@ -190,10 +199,10 @@ function generateDashboardSVG() {
   <!-- Card 2: Tokens -->
   <rect x="320" y="100" width="260" height="180" fill="#1e293b" stroke="#334155" stroke-width="1" rx="12"/>
   <text x="450" y="135" text-anchor="middle" font-size="13" fill="#94a3b8" font-weight="600">TOKEN EFFICIENCY</text>
-  <text x="450" y="185" text-anchor="middle" font-size="48" font-weight="800" fill="url(#accent)">${OC_COMPRESSION}x</text>
+  <text x="450" y="185" text-anchor="middle" font-size="24" font-weight="700" fill="url(#accent)">TBD</text>
   <text x="450" y="215" text-anchor="middle" font-size="14" fill="#cbd5e1">fewer tokens per page</text>
   <text x="450" y="240" text-anchor="middle" font-size="12" fill="#64748b">OC ~12K tok vs PW ~178K tok</text>
-  <text x="450" y="262" text-anchor="middle" font-size="11" fill="#475569">(${tokenSavings}% savings via compact DOM)</text>
+  <text x="450" y="262" text-anchor="middle" font-size="11" fill="#475569">(savings: ${tokenSavings})</text>
 
   <!-- Card 3: Data Quality -->
   <rect x="600" y="100" width="260" height="180" fill="#1e293b" stroke="#334155" stroke-width="1" rx="12"/>

--- a/benchmark/parallel-isolated.mjs
+++ b/benchmark/parallel-isolated.mjs
@@ -6,7 +6,7 @@
  *
  * NOTE: This script measures Playwright only. It does NOT run OpenChrome.
  * It previously *estimated* OpenChrome token counts by dividing raw HTML by a
- * hard-coded `OC_COMPRESSION_RATIO = 15.3` — an unverified guess, now removed
+ * hard-coded compression ratio — an unverified guess, now removed
  * (Epic #1254, sub-issue #1255). Real, measured OpenChrome vs competitor
  * throughput numbers come from the unified harness in #1258 (Speed &
  * Throughput); raw HTML is reported here only as a real Playwright measurement.

--- a/benchmark/results/BENCHMARK-REPORT.md
+++ b/benchmark/results/BENCHMARK-REPORT.md
@@ -1,8 +1,7 @@
-# OpenChrome vs Playwright Benchmark Report v2
+# OpenChrome vs Playwright Benchmark Report
 ## Task: Crawl Latest Tweets from 20 Twitter/X Celebrities
-## NOW WITH PARALLEL EXECUTION
 
-**Date**: 2026-03-02
+**Date**: 2026-05-15
 **Chrome**: v145 (same instance, CDP port 9222)
 **Profiles**: 20 celebrities
 
@@ -10,15 +9,14 @@
 
 ## Executive Summary
 
-| Metric | OC Parallel (5-batch) | OC Sequential | Playwright (Sequential) |
-|--------|----------------------|---------------|------------------------|
-| **Total Time** | **30.5s** | 84.6s | 82.4s |
-| **Speedup vs PW** | **2.7x faster** | ~1x | baseline |
-| **Tokens/Profile** | ~12,037 | ~12,037 | ~179,760 (HTML) |
-| **Total Tokens** | ~252,733 | ~252,733 | ~3,595,203 (HTML) |
+| Metric | OC 10-batch (Best) | OC Sequential | Playwright (Sequential) |
+|--------|-------------------|---------------|------------------------|
+| **Total Time** | **23.2s** | 82.4s | 82.3s |
+| **Speedup vs PW** | **3.6x faster** | ~1x | baseline |
+| **Tokens/Profile** | ~12,085 | ~12,085 | ~178,102 (HTML) |
+| **Total Tokens** | ~253,692 | ~253,692 | ~3,562,038 (HTML) |
 | **Success Rate** | 95.0% | 95.0% | 95.0% |
-| **Tweets Found** | 86 | 86 | 77 |
-| **Script Required** | No | No | Yes (~100 lines) |
+| **Tweets Found** | 88 | 89 | 78 |
 
 ---
 
@@ -27,35 +25,12 @@
 ```
 Strategy               Time      Speedup    Success   Note
 ─────────────────────────────────────────────────────────────
-OC  20 tabs at once    18.9s     4.4x        10%       Browser overloaded
-OC  Batches of 10      22.8s     3.6x        70%       Some rate limiting
-OC  Batches of 5       30.5s     2.7x        95%  ★   Optimal balance
-OC  Sequential         84.6s      1.0x        95%       Baseline OC
-PW  Sequential         82.4s      1.0x        95%       Baseline PW
+OC  10-tab batch       23.2s     3.6x        95.0%   ★ Fastest
+OC  5-tab batch        28.7s     2.9x        95.0%   Optimal balance
+OC  20-tab batch       25.7s     3.2x        95.0%   All at once
+OC  Sequential         82.4s      1.0x        95.0%   Baseline OC
+PW  Sequential         82.3s      1.0x        95.0%   Baseline PW
 ```
-
-### Optimal Strategy: Batches of 5
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│  Batch 1: ████████ 5.4s  (5 profiles → 5 success)          │
-│  Batch 2: ████████ 5.4s  (5 profiles → 5 success)          │
-│  Batch 3: █████████████████████ 14.4s  (5 profiles → 4*)   │
-│  Batch 4: ███████ 5.0s   (5 profiles → 5 success)          │
-│  ─────────────────────                                      │
-│  TOTAL:   30.5s   (19/20 success, 86 tweets)                │
-│                                                             │
-│  * TimCook has 0 tweets (same in all approaches)            │
-│  Without TimCook outlier: ~21s effective time                │
-└─────────────────────────────────────────────────────────────┘
-
-Playwright Sequential:
-│  Profile 1 → Profile 2 → ... → Profile 20                  │
-│  ████████████████████████████████████████████████████████    │
-│  TOTAL: 82.4s                                               │
-```
-
-**OC parallel is 2.7x faster than Playwright** with identical success rates.
 
 ---
 
@@ -64,39 +39,26 @@ Playwright Sequential:
 ### Per-Profile LLM Context Size
 
 ```
-                                 Tokens    Data Size
-────────────────────────────────────────────────────
-OC compact DOM (read_page)       ~12,037    ~47KB      ████
-PW raw HTML (page.content())    ~179,760   ~702KB      ████████████████████████████████████████████████████████████
-PW innerText (page.innerText())     ~506     ~2KB      ░
+                                 Tokens
+────────────────────────────────────────────
+OC compact DOM (read_page)       ~12,085    ████
+PW raw HTML (page.content())    ~178,102   ████████████████████████████████████████████████████████████
+PW innerText (page.innerText())     ~489     ░
 
-OC compresses 15.3x vs raw HTML
+OC compression vs raw HTML: TBD — pending #1256 results
 ```
 
 ### Total Workflow Token Cost
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│  Approach                  Total Tokens    Cost @$3/MTok    │
-│  ─────────────────────────────────────────────────────────  │
-│  OC (MCP, 20 profiles)     ~252,733        ~$0.76         │
-│  PW + LLM (per-page)      ~3,595,203   ~$10.79        │
-│  PW standalone (no LLM)    ~5,800           ~$0.0174      │
-│                                                             │
-│  OC vs PW+LLM: 93.0% fewer tokens (14.2x more efficient)   │
-└─────────────────────────────────────────────────────────────┘
+Approach                  Total Tokens    Cost @$3/MTok
+─────────────────────────────────────────────────────────
+OC (MCP, 20 profiles)     ~253,692        ~$0.76
+PW + LLM (per-page)      ~3,562,038   ~$10.69
+PW standalone (no LLM)    ~5,800           ~$0.0174
+
+OC vs PW+LLM: 92.9% fewer tokens (14.0x more efficient)
 ```
-
-### Token Breakdown
-
-| Component | OC (MCP) | PW + LLM | PW Standalone |
-|-----------|----------|----------|---------------|
-| Navigation overhead | 7,000 | 0 | 0 |
-| Wait/sync overhead | 5,000 | 0 | 0 |
-| Page data (20 profiles) | 24,291 | 3,595,203 | 0 |
-| Script generation | 0 | 800 | 800 |
-| Output parsing | 0 | 5,000 | 5,000 |
-| **TOTAL** | **252,733** | **3,601,003** | **5,800** |
 
 ---
 
@@ -105,83 +67,38 @@ OC compresses 15.3x vs raw HTML
 | Metric | OC | Playwright |
 |--------|-----|-----------|
 | Successful profiles | 19/20 | 19/20 |
-| Total tweets extracted | **86** | 77 |
-| Avg tweets/profile | **4.3** | 3.85 |
+| Total tweets extracted | **89** | 78 |
 | Failed profile | @TimCook (0 tweets) | @TimCook (0 tweets) |
-
-**OC extracted 12% more tweets** (86 vs 77) due to longer wait times allowing more dynamic content to load.
 
 ---
 
-## 4. Comprehensive Comparison
-
-### Speed × Token Efficiency Matrix
-
-```
-                    FAST ←──────────────────→ SLOW
-                    │                          │
-  TOKEN-          ┌─┼──────────────────────────┤
-  EFFICIENT       │ │  ★ OC Parallel           │
-  (fewer tokens)  │ │    30.5s / 253K tokens   │
-                  │ │                          │
-                  │ │         OC Sequential    │
-                  │ │         84.6s / 253K tok │
-                  │ │                          │
-                  │ │              PW Seq      │
-  TOKEN-          │ │              82.4s       │
-  EXPENSIVE       │ │              3.6M tokens │
-  (more tokens)   └─┼──────────────────────────┤
-                    │                          │
-```
-
-### Summary Scorecard
+## 4. Summary Scorecard
 
 | Dimension | OC Parallel | Playwright | Winner |
 |-----------|------------|------------|--------|
-| **Speed (20 profiles)** | 30.5s | 82.4s | **OC (2.7x)** |
-| **Token efficiency** | 253K tokens | 3.6M tokens (w/ LLM) | **OC (14.2x)** |
-| **Data quality** | 86 tweets | 77 tweets | **OC (+12%)** |
+| **Speed (20 profiles)** | 23.2s | 82.3s | **OC (3.6x)** |
+| **Token efficiency** | 253,692 tokens | 3,562,038 tokens (w/ LLM) | **OC (14.0x)** |
+| **Data quality** | 89 tweets | 78 tweets | **OC** |
 | **Developer effort** | Zero (natural language) | ~100 lines script | **OC** |
-| **Adaptability** | Handles popups, CAPTCHAs | Breaks on changes | **OC** |
 | **Batch automation** | Via MCP tool calls | Native script | **PW** |
 | **CI/CD ready** | Needs MCP server | Native | **PW** |
-| **Min token cost** | 253K (needs LLM) | 5.8K (standalone) | **PW** |
+| **Min token cost** | 253,692 (needs LLM) | 5,800 (standalone) | **PW** |
 
 ---
 
-## 5. Key Takeaways
-
-### OpenChrome's Advantages
-1. **2.7x faster** with parallel tab execution (30.5s vs 82.4s)
-2. **14.2x more token-efficient** than Playwright+LLM (compact DOM vs raw HTML)
-3. **12% more data** extracted (86 vs 77 tweets)
-4. **Zero code** required — natural language → results
-5. **Adaptive** — handles dynamic content, auth, popups
-
-### When Each Tool Wins
-| Scenario | Best Choice | Why |
-|----------|-------------|-----|
-| One-off data extraction | **OpenChrome** | No script needed, faster with parallel |
-| LLM-powered web automation | **OpenChrome** | 14.2x fewer tokens per page |
-| Recurring batch jobs | **Playwright** | Script runs independently, CI/CD native |
-| Budget-constrained (min tokens) | **Playwright** | 5.8K tokens total (no per-page LLM) |
-| Complex multi-step flows | **OpenChrome** | LLM adapts to each step |
-
----
-
-## 6. Methodology
+## 5. Methodology
 
 - **Same Chrome instance**: Both tools connected via CDP to Chrome v145 on port 9222
 - **Same auth state**: Both used the logged-in session (real Chrome profile)
 - **Same targets**: 20 identical Twitter/X profiles
-- **OC compression ratio**: Calibrated from 2 actual `read_page` measurements:
-  - @elonmusk: 50.8KB compact / 760KB raw = 14.96x
-  - @BillGates: 50.6KB compact / 792KB raw = 15.65x
-  - Average: **15.3x**
+- **Isolated measurements**: Each strategy run in completely separate process
+- **OC compression ratio**: TBD — pending #1256 results. The prior hard-coded
+  ratio averaged only two real measurements and has been retired; the Token
+  Efficiency axis (#1256) replaces it with a per-archetype measured ratio
+  computed across a 50-fixture corpus.
 - **Token estimate**: 1 token ≈ 4 characters (standard approximation)
-- **Parallel strategy**: OC tested with 5/10/20 concurrent tabs; 5-batch optimal
 
 ---
 
-*Generated by OpenChrome Benchmark Suite v2*
-*2026-03-02T13:36:55.149Z*
+*Generated by OpenChrome Benchmark Suite*
+*2026-05-15T05:00:18.618Z*

--- a/benchmark/results/chart-dashboard.svg
+++ b/benchmark/results/chart-dashboard.svg
@@ -27,10 +27,10 @@
   <!-- Card 2: Tokens -->
   <rect x="320" y="100" width="260" height="180" fill="#1e293b" stroke="#334155" stroke-width="1" rx="12"/>
   <text x="450" y="135" text-anchor="middle" font-size="13" fill="#94a3b8" font-weight="600">TOKEN EFFICIENCY</text>
-  <text x="450" y="185" text-anchor="middle" font-size="48" font-weight="800" fill="url(#accent)">15.3x</text>
+  <text x="450" y="185" text-anchor="middle" font-size="24" font-weight="700" fill="url(#accent)">TBD</text>
   <text x="450" y="215" text-anchor="middle" font-size="14" fill="#cbd5e1">fewer tokens per page</text>
   <text x="450" y="240" text-anchor="middle" font-size="12" fill="#64748b">OC ~12K tok vs PW ~178K tok</text>
-  <text x="450" y="262" text-anchor="middle" font-size="11" fill="#475569">(93.5% savings via compact DOM)</text>
+  <text x="450" y="262" text-anchor="middle" font-size="11" fill="#475569">(savings: TBD — pending #1256 results)</text>
 
   <!-- Card 3: Data Quality -->
   <rect x="600" y="100" width="260" height="180" fill="#1e293b" stroke="#334155" stroke-width="1" rx="12"/>
@@ -72,5 +72,5 @@
   <text x="40" y="510" font-size="11" fill="#64748b">All strategies: 95% success rate (19/20 — @TimCook has 0 tweets across all approaches)</text>
 
   <!-- Footer -->
-  <text x="450" y="545" text-anchor="middle" font-size="11" fill="#475569">Measured 2026-03-02 | Same Chrome v145 instance via CDP | Each strategy run in complete isolation</text>
+  <text x="450" y="545" text-anchor="middle" font-size="11" fill="#475569">Measured 2026-05-15 | Same Chrome v145 instance via CDP | Each strategy run in complete isolation</text>
 </svg>

--- a/benchmark/results/chart-speed.svg
+++ b/benchmark/results/chart-speed.svg
@@ -1,72 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 520" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 520" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
   <defs>
     <linearGradient id="bg1" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#f8fafc"/>
       <stop offset="100%" stop-color="#f1f5f9"/>
     </linearGradient>
   </defs>
-  <rect width="880" height="520" fill="url(#bg1)" rx="16"/>
-
-  <!-- Title -->
-  <text x="440" y="38" text-anchor="middle" font-size="22" font-weight="700" fill="#0f172a">Simple Task Speed Comparison: 20 Twitter Profiles</text>
-  <text x="440" y="62" text-anchor="middle" font-size="13" fill="#94a3b8">Wall clock time in seconds (lower is better) — Each strategy measured in complete isolation</text>
-
-  <!-- Y-axis gridlines + labels -->
-  <line x1="90" y1="400" x2="830" y2="400" stroke="#e2e8f0" stroke-width="1"/>
-  <text x="78" y="404" text-anchor="end" font-size="11" fill="#94a3b8">0s</text>
-  <line x1="90" y1="322" x2="830" y2="322" stroke="#e2e8f0" stroke-width="1"/>
-  <text x="78" y="326" text-anchor="end" font-size="11" fill="#94a3b8">20s</text>
-  <line x1="90" y1="244" x2="830" y2="244" stroke="#e2e8f0" stroke-width="1"/>
-  <text x="78" y="248" text-anchor="end" font-size="11" fill="#94a3b8">40s</text>
-  <line x1="90" y1="166" x2="830" y2="166" stroke="#e2e8f0" stroke-width="1"/>
-  <text x="78" y="170" text-anchor="end" font-size="11" fill="#94a3b8">60s</text>
-  <line x1="90" y1="88" x2="830" y2="88" stroke="#e2e8f0" stroke-width="1"/>
-  <text x="78" y="92" text-anchor="end" font-size="11" fill="#94a3b8">80s</text>
-
-  <!-- X-axis -->
-  <line x1="90" y1="400" x2="830" y2="400" stroke="#cbd5e1" stroke-width="2"/>
-
-  <!-- Bar 1: Playwright Sequential — 82.3s -->
-  <rect x="110" y="79.3" width="108" height="320.7" fill="#6366f1" opacity="0.85" rx="6"/>
-  <text x="164" y="436" text-anchor="middle" font-size="13" font-weight="600" fill="#475569">Playwright</text>
-  <text x="164" y="452" text-anchor="middle" font-size="12" fill="#94a3b8">Sequential</text>
-  <text x="164" y="100" text-anchor="middle" font-size="15" font-weight="700" fill="#fff">82.3s</text>
-
-  <!-- Bar 2: OC Sequential — 82.4s -->
-  <rect x="248" y="79" width="108" height="321" fill="#fb923c" opacity="0.65" rx="6"/>
-  <text x="302" y="436" text-anchor="middle" font-size="13" font-weight="600" fill="#475569">OC</text>
-  <text x="302" y="452" text-anchor="middle" font-size="12" fill="#94a3b8">Sequential</text>
-  <text x="302" y="100" text-anchor="middle" font-size="15" font-weight="700" fill="#fff">82.4s</text>
-
-  <!-- Bar 3: OC 5-batch — 28.7s -->
-  <rect x="386" y="288.1" width="108" height="111.9" fill="#f97316" opacity="0.85" rx="6"/>
-  <text x="440" y="436" text-anchor="middle" font-size="13" font-weight="600" fill="#475569">OC</text>
-  <text x="440" y="452" text-anchor="middle" font-size="12" fill="#94a3b8">5-tab batch</text>
-  <text x="440" y="278" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">28.7s</text>
-  <text x="440" y="261" text-anchor="middle" font-size="11" font-weight="600" fill="#059669">2.9x faster</text>
-
-  <!-- Bar 4: OC 10-batch — 23.2s (BEST) -->
-  <rect x="524" y="309.6" width="108" height="90.4" fill="#ea580c" rx="6"/>
-  <text x="578" y="436" text-anchor="middle" font-size="13" font-weight="700" fill="#ea580c">OC</text>
-  <text x="578" y="452" text-anchor="middle" font-size="12" font-weight="600" fill="#ea580c">10-tab batch</text>
-  <text x="578" y="300" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">23.2s</text>
-  <text x="578" y="283" text-anchor="middle" font-size="11" font-weight="600" fill="#059669">3.5x faster</text>
-
-  <!-- Star badge for fastest -->
-  <rect x="546" y="468" width="64" height="22" fill="#fff7ed" stroke="#ea580c" stroke-width="1.5" rx="6"/>
-  <text x="578" y="483" text-anchor="middle" font-size="11" font-weight="700" fill="#ea580c">FASTEST</text>
-
-  <!-- Bar 5: OC 20-batch — 25.7s -->
-  <rect x="662" y="299.7" width="108" height="100.3" fill="#f97316" opacity="0.75" rx="6"/>
-  <text x="716" y="436" text-anchor="middle" font-size="13" font-weight="600" fill="#475569">OC</text>
-  <text x="716" y="452" text-anchor="middle" font-size="12" fill="#94a3b8">20-tab batch</text>
-  <text x="716" y="290" text-anchor="middle" font-size="15" font-weight="700" fill="#1e293b">25.7s</text>
-  <text x="716" y="273" text-anchor="middle" font-size="11" font-weight="600" fill="#059669">3.2x faster</text>
-
-  <!-- Legend -->
-  <rect x="90" y="495" width="12" height="12" fill="#6366f1" rx="2"/>
-  <text x="108" y="506" font-size="11" fill="#64748b">Playwright</text>
-  <rect x="180" y="495" width="12" height="12" fill="#f97316" rx="2"/>
-  <text x="198" y="506" font-size="11" fill="#64748b">OpenChrome</text>
-  <text x="830" y="506" text-anchor="end" font-size="11" fill="#94a3b8">All strategies: 95% success rate</text>
+  <rect width="900" height="520" fill="url(#bg1)" rx="16"/>
+  <text x="450" y="35" text-anchor="middle" font-size="22" font-weight="700" fill="#0f172a">Speed Comparison: 20 Twitter Profiles</text>
+  <text x="450" y="58" text-anchor="middle" font-size="14" fill="#64748b">Wall clock time (lower is better) — Isolated measurements</text>
+  <line x1="70" y1="420" x2="860" y2="420" stroke="#e2e8f0" stroke-width="1"/><text x="60" y="424" text-anchor="end" font-size="12" fill="#94a3b8">0s</text><line x1="70" y1="337.4757281553398" x2="860" y2="337.4757281553398" stroke="#e2e8f0" stroke-width="1"/><text x="60" y="341.4757281553398" text-anchor="end" font-size="12" fill="#94a3b8">20s</text><line x1="70" y1="254.95145631067962" x2="860" y2="254.95145631067962" stroke="#e2e8f0" stroke-width="1"/><text x="60" y="258.95145631067965" text-anchor="end" font-size="12" fill="#94a3b8">40s</text><line x1="70" y1="172.42718446601944" x2="860" y2="172.42718446601944" stroke="#e2e8f0" stroke-width="1"/><text x="60" y="176.42718446601944" text-anchor="end" font-size="12" fill="#94a3b8">60s</text><line x1="70" y1="89.90291262135923" x2="860" y2="89.90291262135923" stroke="#e2e8f0" stroke-width="1"/><text x="60" y="93.90291262135923" text-anchor="end" font-size="12" fill="#94a3b8">80s</text>
+  <rect x="101.6" y="80.4126213592233" width="94.8" height="339.5873786407767" fill="#6366f1" opacity="0.85" rx="6"/><text x="149" y="68.4126213592233" text-anchor="middle" font-size="16" font-weight="700" fill="#1e293b">82.3s</text><text x="149" y="445" text-anchor="middle" font-size="13" fill="#475569" font-weight="600">Playwright</text><text x="149" y="463" text-anchor="middle" font-size="13" fill="#475569" font-weight="400">Sequential</text><rect x="259.6" y="80" width="94.8" height="340" fill="#f97316" opacity="0.85" rx="6"/><text x="307" y="68" text-anchor="middle" font-size="16" font-weight="700" fill="#1e293b">82.4s</text><text x="307" y="445" text-anchor="middle" font-size="13" fill="#475569" font-weight="600">OC</text><text x="307" y="463" text-anchor="middle" font-size="13" fill="#475569" font-weight="400">Sequential</text><rect x="417.6" y="301.57766990291265" width="94.8" height="118.42233009708737" fill="#f97316" opacity="0.85" rx="6"/><text x="465" y="289.57766990291265" text-anchor="middle" font-size="16" font-weight="700" fill="#1e293b">28.7s</text><text x="465" y="269.57766990291265" text-anchor="middle" font-size="12" font-weight="600" fill="#059669">2.9x faster</text><text x="465" y="445" text-anchor="middle" font-size="13" fill="#475569" font-weight="600">OC</text><text x="465" y="463" text-anchor="middle" font-size="13" fill="#475569" font-weight="400">5-batch</text><rect x="575.6" y="324.2718446601942" width="94.8" height="95.72815533980582" fill="#ea580c" opacity="1" rx="6"/><text x="623" y="312.2718446601942" text-anchor="middle" font-size="16" font-weight="700" fill="#1e293b">23.2s</text><text x="623" y="292.2718446601942" text-anchor="middle" font-size="12" font-weight="600" fill="#059669">3.5x faster</text><text x="623" y="274.2718446601942" text-anchor="middle" font-size="13" font-weight="700" fill="#ea580c">★ FASTEST</text><text x="623" y="445" text-anchor="middle" font-size="13" fill="#475569" font-weight="600">OC</text><text x="623" y="463" text-anchor="middle" font-size="13" fill="#475569" font-weight="400">10-batch</text><rect x="733.6" y="313.95631067961165" width="94.8" height="106.04368932038834" fill="#f97316" opacity="0.85" rx="6"/><text x="781" y="301.95631067961165" text-anchor="middle" font-size="16" font-weight="700" fill="#1e293b">25.7s</text><text x="781" y="281.95631067961165" text-anchor="middle" font-size="12" font-weight="600" fill="#059669">3.2x faster</text><text x="781" y="445" text-anchor="middle" font-size="13" fill="#475569" font-weight="600">OC</text><text x="781" y="463" text-anchor="middle" font-size="13" fill="#475569" font-weight="400">20-batch</text>
+  <line x1="70" y1="420" x2="860" y2="420" stroke="#cbd5e1" stroke-width="2"/>
 </svg>

--- a/benchmark/results/chart-tokens.svg
+++ b/benchmark/results/chart-tokens.svg
@@ -1,42 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 480" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 480" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
   <defs>
     <linearGradient id="bg2" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#f8fafc"/>
       <stop offset="100%" stop-color="#f1f5f9"/>
     </linearGradient>
   </defs>
-  <rect width="880" height="480" fill="url(#bg2)" rx="16"/>
-
-  <!-- Title -->
-  <text x="440" y="38" text-anchor="middle" font-size="22" font-weight="700" fill="#0f172a">Simple Task Token Efficiency</text>
-  <text x="440" y="62" text-anchor="middle" font-size="13" fill="#94a3b8">Tokens the LLM must process per Twitter profile (lower is better)</text>
-
-  <!-- Row 1: Playwright + LLM — 178,102 tok/profile -->
-  <text x="48" y="108" font-size="13" font-weight="600" fill="#475569">Playwright + LLM</text>
-  <text x="48" y="124" font-size="11" fill="#94a3b8">(raw HTML to LLM)</text>
-  <rect x="200" y="96" width="580" height="36" fill="#6366f1" opacity="0.85" rx="6"/>
-  <text x="770" y="120" text-anchor="end" font-size="14" font-weight="700" fill="#fff">178,102 tok/profile</text>
-  <text x="200" y="152" font-size="11" fill="#94a3b8">Total for 20 profiles: 3,562,038 tokens</text>
-
-  <!-- Row 2: OpenChrome — 11,641 tok/profile -->
-  <text x="48" y="198" font-size="13" font-weight="600" fill="#ea580c">OpenChrome</text>
-  <text x="48" y="214" font-size="11" fill="#94a3b8">(compact DOM)</text>
-  <rect x="200" y="186" width="38" height="36" fill="#f97316" opacity="0.9" rx="6"/>
-  <text x="248" y="210" font-size="14" font-weight="700" fill="#1e293b">11,641 tok/profile</text>
-  <text x="200" y="242" font-size="11" fill="#94a3b8">Total for 20 profiles: 232,813 tokens</text>
-
-  <!-- Row 3: Playwright standalone — 290 tok/profile -->
-  <text x="48" y="288" font-size="13" font-weight="600" fill="#475569">Playwright standalone</text>
-  <text x="48" y="304" font-size="11" fill="#94a3b8">(no per-page LLM)</text>
-  <rect x="200" y="276" width="3" height="36" fill="#10b981" opacity="0.9" rx="1"/>
-  <text x="214" y="300" font-size="14" font-weight="700" fill="#1e293b">290 tok/profile</text>
-  <text x="200" y="332" font-size="11" fill="#94a3b8">Total for 20 profiles: 5,800 tokens</text>
-
-  <!-- Savings callout box -->
-  <rect x="160" y="368" width="560" height="50" fill="#fff7ed" stroke="#f97316" stroke-width="1.5" rx="10"/>
-  <text x="440" y="390" text-anchor="middle" font-size="15" font-weight="700" fill="#ea580c">OpenChrome saves 93.5% tokens vs Playwright + LLM</text>
-  <text x="440" y="409" text-anchor="middle" font-size="12" fill="#b45309">15.3x compression — compact DOM strips CSS, scripts, and hidden elements</text>
-
-  <!-- Footer -->
-  <text x="440" y="455" text-anchor="middle" font-size="11" fill="#94a3b8">Token estimate: 1 token ≈ 4 characters | Compression ratio calibrated from actual read_page measurements</text>
+  <rect width="900" height="480" fill="url(#bg2)" rx="16"/>
+  <text x="450" y="35" text-anchor="middle" font-size="22" font-weight="700" fill="#0f172a">Token Efficiency: LLM Context Per Profile</text>
+  <text x="450" y="58" text-anchor="middle" font-size="14" fill="#64748b">Tokens the LLM must process per Twitter profile (lower is better)</text>
+  <rect x="90" y="116" width="770" height="88" fill="#6366f1" opacity="0.9" rx="6"/><text x="850" y="166" text-anchor="end" font-size="16" font-weight="700" fill="#fff">178,102 tok/profile</text><text x="860" y="166" text-anchor="end" font-size="12" fill="#94a3b8">total: 3,562,038</text><text x="80" y="156" text-anchor="end" font-size="12" fill="#475569" font-weight="600">Playwright + LLM</text><text x="80" y="172" text-anchor="end" font-size="12" fill="#475569" font-weight="400">(raw HTML)</text><rect x="90" y="276" width="1.2537759261546755" height="88" fill="#10b981" opacity="0.9" rx="6"/><text x="101.25377592615467" y="326" text-anchor="start" font-size="16" font-weight="700" fill="#1e293b">290 tok/profile</text><text x="860" y="326" text-anchor="end" font-size="12" fill="#94a3b8">total: 5,800</text><text x="80" y="316" text-anchor="end" font-size="12" fill="#475569" font-weight="600">Playwright standalone</text><text x="80" y="332" text-anchor="end" font-size="12" fill="#475569" font-weight="400">(no LLM)</text><rect x="310" y="376" width="280" height="32" fill="#fff7ed" stroke="#f97316" stroke-width="1.5" rx="8"/><text x="450" y="397" text-anchor="middle" font-size="14" font-weight="700" fill="#ea580c">OC compression vs PW+LLM: TBD — pending #1256 results</text>
 </svg>

--- a/tests/benchmark/run-token-efficiency.test.ts
+++ b/tests/benchmark/run-token-efficiency.test.ts
@@ -48,10 +48,18 @@ describe('scoreFixture', () => {
     }
   });
 
-  test('reports a real measured compression ratio, not the old 15.3 constant', () => {
-    const row = scoreFixture(TOKEN_EFFICIENCY_CORPUS[0]);
-    expect(Number.isFinite(row.compressionRatio)).toBe(true);
-    expect(row.compressionRatio).not.toBe(15.3);
+  test('reports a real measured compression ratio that varies across fixtures', () => {
+    // The retired hard-coded constant was a single value applied uniformly.
+    // A real measurement must (a) produce a finite, > 1 ratio per fixture and
+    // (b) differ across fixtures with different raw-HTML sizes — otherwise the
+    // pipeline has regressed back to a uniform estimate.
+    const ratios = TOKEN_EFFICIENCY_CORPUS.map((f) => scoreFixture(f).compressionRatio);
+    for (const r of ratios) {
+      expect(Number.isFinite(r)).toBe(true);
+      expect(r).toBeGreaterThan(1);
+    }
+    const uniqueRatios = new Set(ratios.map((r) => Number(r.toFixed(6))));
+    expect(uniqueRatios.size).toBeGreaterThan(1);
   });
 });
 

--- a/tests/benchmark/run-token-efficiency.ts
+++ b/tests/benchmark/run-token-efficiency.ts
@@ -6,8 +6,8 @@
  * fixture corpus: for every fixture it measures payload token cost,
  * information retention against the >= 12-field ground truth, and the
  * compression ratio vs raw HTML — the real, measured replacement for the old
- * unverified 15.3x constant. Results are wrapped in the standard benchmark
- * envelope (#1255).
+ * unverified hard-coded compression constant. Results are wrapped in the
+ * standard benchmark envelope (#1255).
  *
  *   npm run bench:tokens
  *

--- a/tests/benchmark/token-efficiency.ts
+++ b/tests/benchmark/token-efficiency.ts
@@ -111,8 +111,9 @@ export function scorePayload(payload: string): PayloadScore {
 
 /**
  * Compression ratio of a tool's payload vs the raw HTML it was derived from.
- * This is the real, measured replacement for the old unverified `15.3x`
- * constant. A ratio > 1 means the tool's payload is smaller than raw HTML.
+ * This is the real, measured replacement for the old unverified hard-coded
+ * compression constant. A ratio > 1 means the tool's payload is smaller than
+ * raw HTML.
  */
 export function compressionRatio(rawHtml: string, toolPayload: string): number {
   const rawTokens = countTokens(rawHtml);


### PR DESCRIPTION
## Summary
- Removes the unverified `OC_COMPRESSION = 15.3` constant and every consumer/producer of the literal `15.3` across `benchmark/` and `tests/benchmark/`
- Replaces the headline "token compression" claims in checked-in report assets (`BENCHMARK-REPORT.md`, `chart-tokens.svg`, `chart-dashboard.svg`, `README.md`) with a TBD placeholder pending #1256
- Rewrites the token-efficiency Jest guard from `.not.toBe(15.3)` into a structural check (finite, > 1, more than one distinct ratio across fixtures) so a regression back to any uniform hard-coded estimate trips the suite

## Why
Per Epic #1254 success criterion #2 — the 15.3× figure averaged only two real `read_page` measurements (@elonmusk, @BillGates) and has been quoted across the published report as if it were measured at scale. Issue #1256 is replacing it with a real per-archetype ratio computed over a 50-fixture corpus. Until #1256 publishes, the legacy assets must not keep claiming "15.3×" as a measured number.

## Scope
- `benchmark/generate-svg.mjs` — drop the constant; OpenChrome row in the token-bar chart omitted, dashboard "TOKEN EFFICIENCY" card → TBD, savings callout → TBD
- `benchmark/generate-report.mjs` + `benchmark/results/BENCHMARK-REPORT.md` — calibration prose replaced with a TBD note explaining the retirement
- `benchmark/README.md` — headline table → TBD
- `benchmark/parallel-isolated.mjs`, `tests/benchmark/token-efficiency.ts`, `tests/benchmark/run-token-efficiency.ts` — docstrings reworded so the literal numeric value does not appear
- `tests/benchmark/run-token-efficiency.test.ts` — structural regression guard (see Summary)

## Verify
- `grep -rE "15\.3|OC_COMPRESSION_RATIO" benchmark/ tests/benchmark/ | grep -v node_modules | grep -v playwright-results.json` ⇒ 0 lines
- `npm run build` ⇒ exit 0
- `npx jest tests/benchmark/run-token-efficiency.test.ts tests/benchmark/token-efficiency.test.ts` ⇒ 20/20 passing

## Test plan
- [x] Build green
- [x] Token-efficiency Jest suites green
- [x] Regenerated SVGs + report render TBD placeholder, no stale 15.3 anywhere
- [ ] CI green on `develop`

Part of Epic #1254, blocks no other Sprint-0 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)