### PR TITLE
feat(benchmark): playwright-mcp competitor adapter (#1255 — 0.3)

### DIFF
--- a/benchmark/COMPETITORS.md
+++ b/benchmark/COMPETITORS.md
@@ -32,7 +32,7 @@ they are not reproducible here. See Epic #1254 "Non-goals".
 | OpenChrome | `openchrome-mcp` (this repo) | _repo HEAD_ | _per-run git SHA_ | _per run_ | all |
 | Playwright | `playwright` | TBD | — | TBD | #A #C #D #E |
 | Puppeteer | `puppeteer` | TBD | — | TBD | #C #D #E #F |
-| playwright-mcp | `@playwright/mcp` | TBD | — | TBD | #A #B #F |
+| playwright-mcp | `@playwright/mcp` | `0.0.75` | `8116437ffcfee1309cebc07dd30cee37720d2d19` | 2026-05-15 | #A #B #F |
 | browser-use | `browser-use` (PyPI) | TBD | — | TBD | #A #B #D #E |
 | Crawlee | `crawlee` | TBD | — | TBD | #A #C |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "openchrome": "dist/cli/index.js"
       },
       "devDependencies": {
+        "@playwright/mcp": "^0.0.75",
         "@types/chrome": "^0.1.36",
         "@types/jest": "^29.5.0",
         "@types/node": "^20.0.0",
@@ -1375,6 +1376,70 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/mcp": {
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/@playwright/mcp/-/mcp-0.0.75.tgz",
+      "integrity": "sha512-oBjzVXfEGZ9Ev45tKKQULNDVdF83B82lg0uPejEK3xsp/zWmdNdNVnPi032fmd/o20ZZXs+LX7cr77qRNbV4VA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0-alpha-1778188671000",
+        "playwright-core": "1.61.0-alpha-1778188671000"
+      },
+      "bin": {
+        "playwright-mcp": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/mcp/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/@playwright/mcp/node_modules/playwright": {
+      "version": "1.61.0-alpha-1778188671000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0-alpha-1778188671000.tgz",
+      "integrity": "sha512-A6fFc7ExLRmvm0ZHqCyY2uHXSvEdpb8W+/HyIPK4ecRqNil8Mc1Vig1WFYoqk82x3+U9Qb571fQE95wgKqIQ1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0-alpha-1778188671000"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@playwright/mcp/node_modules/playwright-core": {
+      "version": "1.61.0-alpha-1778188671000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0-alpha-1778188671000.tgz",
+      "integrity": "sha512-nsw2Crz0uZS3IRHiEcOXUt+RaKB/Hna+GAD4oD6cPqCHfJfW77cJdgktC0jzp3Ndyv23EJI3bcWSqFIiqSNE5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@puppeteer/browsers": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   },
   "homepage": "https://github.com/shaun0927/openchrome#readme",
   "devDependencies": {
+    "@playwright/mcp": "^0.0.75",
     "@types/chrome": "^0.1.36",
     "@types/jest": "^29.5.0",
     "@types/node": "^20.0.0",

--- a/tests/benchmark/adapters/index.ts
+++ b/tests/benchmark/adapters/index.ts
@@ -31,3 +31,9 @@ export {
   PlaywrightContextLike,
   PlaywrightPageLike,
 } from './playwright-adapter';
+
+export {
+  PlaywrightMcpAdapter,
+  PlaywrightMcpAdapterOptions,
+  PlaywrightMcpTransport,
+} from './playwright-mcp-adapter';

--- a/tests/benchmark/adapters/playwright-mcp-adapter.test.ts
+++ b/tests/benchmark/adapters/playwright-mcp-adapter.test.ts
@@ -1,0 +1,177 @@
+/// <reference types="jest" />
+
+import {
+  PlaywrightMcpAdapter,
+  PlaywrightMcpTransport,
+} from './playwright-mcp-adapter';
+import { MCPToolResult } from '../benchmark-runner';
+
+/** Mock transport that records calls and returns canned responses. */
+function makeMockTransport(opts: { snapshot?: string } = {}): {
+  transport: PlaywrightMcpTransport;
+  log: Array<{ tool: string; args: Record<string, unknown> }>;
+  started: () => boolean;
+  stopped: () => boolean;
+} {
+  const log: Array<{ tool: string; args: Record<string, unknown> }> = [];
+  let started = false;
+  let stopped = false;
+
+  const transport: PlaywrightMcpTransport = {
+    async start() {
+      started = true;
+    },
+    async callTool(toolName, args): Promise<MCPToolResult> {
+      log.push({ tool: toolName, args });
+      switch (toolName) {
+        case 'browser_navigate':
+          return { content: [{ type: 'text', text: 'navigated' }] };
+        case 'browser_tab_new':
+          return { content: [{ type: 'text', text: 'tab opened' }] };
+        case 'browser_tab_select':
+          return { content: [{ type: 'text', text: 'tab selected' }] };
+        case 'browser_snapshot':
+          return {
+            content: [
+              { type: 'text', text: opts.snapshot ?? '- page:\n  - heading "Fixture"' },
+            ],
+          };
+        case 'browser_tab_close':
+          return { content: [{ type: 'text', text: 'tab closed' }] };
+        default:
+          return { content: [{ type: 'text', text: `unsupported ${toolName}` }], isError: true };
+      }
+    },
+    async stop() {
+      stopped = true;
+    },
+  };
+
+  return { transport, log, started: () => started, stopped: () => stopped };
+}
+
+describe('PlaywrightMcpAdapter', () => {
+  test('conforms to the LibraryAdapter identity contract', () => {
+    const adapter = new PlaywrightMcpAdapter();
+    expect(adapter.name).toBe('playwright-mcp');
+    expect(adapter.kind).toBe('mcp');
+    expect(adapter.mode).toBe('a11y-snapshot');
+  });
+
+  test('callTool before setup() returns an error result, does not throw', async () => {
+    const adapter = new PlaywrightMcpAdapter();
+    const res = await adapter.callTool('read_page', { tabId: 'x' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('setup() was not called');
+  });
+
+  test('setup() starts the injected transport', async () => {
+    const mock = makeMockTransport();
+    const adapter = new PlaywrightMcpAdapter({ transport: mock.transport });
+    await adapter.setup();
+    expect(mock.started()).toBe(true);
+  });
+
+  test('tabs_create on first call uses browser_navigate and returns a tabId', async () => {
+    const mock = makeMockTransport();
+    const adapter = new PlaywrightMcpAdapter({ transport: mock.transport });
+    await adapter.setup();
+    const res = await adapter.callTool('tabs_create', { url: 'http://127.0.0.1/p' });
+    expect(res.isError).toBeFalsy();
+    const tabId = JSON.parse(res.content[0].text as string).tabId;
+    expect(tabId).toMatch(/^playwright-mcp-tab-\d+$/);
+    expect(mock.log.map((c) => c.tool)).toEqual(['browser_navigate']);
+    expect(mock.log[0].args).toEqual({ url: 'http://127.0.0.1/p' });
+    expect(adapter.openTabCount).toBe(1);
+  });
+
+  test('tabs_create on subsequent calls uses browser_tab_new', async () => {
+    const mock = makeMockTransport();
+    const adapter = new PlaywrightMcpAdapter({ transport: mock.transport });
+    await adapter.setup();
+    await adapter.callTool('tabs_create', { url: 'http://x/a' });
+    await adapter.callTool('tabs_create', { url: 'http://x/b' });
+    const tools = mock.log.map((c) => c.tool);
+    expect(tools).toEqual(['browser_navigate', 'browser_tab_new']);
+    expect(adapter.openTabCount).toBe(2);
+  });
+
+  test('about:blank does not trigger a navigation', async () => {
+    const mock = makeMockTransport();
+    const adapter = new PlaywrightMcpAdapter({ transport: mock.transport });
+    await adapter.setup();
+    await adapter.callTool('tabs_create', { url: 'about:blank' });
+    // First-tab path is taken but browser_navigate is suppressed for about:blank.
+    expect(mock.log.map((c) => c.tool)).toEqual([]);
+    expect(adapter.openTabCount).toBe(1);
+  });
+
+  test('read_page returns the accessibility-snapshot text for the given tabId', async () => {
+    const mock = makeMockTransport({ snapshot: '- page:\n  - heading "Fixture"' });
+    const adapter = new PlaywrightMcpAdapter({ transport: mock.transport });
+    await adapter.setup();
+    const created = await adapter.callTool('tabs_create', { url: 'http://x/p' });
+    const tabId = JSON.parse(created.content[0].text as string).tabId;
+    const read = await adapter.callTool('read_page', { tabId });
+    expect(read.isError).toBeFalsy();
+    expect(read.content[0].text).toBe('- page:\n  - heading "Fixture"');
+    // Single-tab read does NOT call browser_tab_select (no need to switch).
+    expect(mock.log.some((c) => c.tool === 'browser_tab_select')).toBe(false);
+  });
+
+  test('read_page on the second tab routes through browser_tab_select first', async () => {
+    const mock = makeMockTransport();
+    const adapter = new PlaywrightMcpAdapter({ transport: mock.transport });
+    await adapter.setup();
+    await adapter.callTool('tabs_create', { url: 'http://x/a' });
+    const created2 = await adapter.callTool('tabs_create', { url: 'http://x/b' });
+    const tabId2 = JSON.parse(created2.content[0].text as string).tabId;
+    await adapter.callTool('read_page', { tabId: tabId2 });
+    const tools = mock.log.map((c) => c.tool);
+    expect(tools).toEqual([
+      'browser_navigate',
+      'browser_tab_new',
+      'browser_tab_select',
+      'browser_snapshot',
+    ]);
+  });
+
+  test('read_page on an unknown tabId is an error result', async () => {
+    const mock = makeMockTransport();
+    const adapter = new PlaywrightMcpAdapter({ transport: mock.transport });
+    await adapter.setup();
+    const res = await adapter.callTool('read_page', { tabId: 'nope' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('unknown tabId');
+  });
+
+  test('tabs_close closes the tab and drops it from the tab map', async () => {
+    const mock = makeMockTransport();
+    const adapter = new PlaywrightMcpAdapter({ transport: mock.transport });
+    await adapter.setup();
+    const created = await adapter.callTool('tabs_create', { url: 'http://x/p' });
+    const tabId = JSON.parse(created.content[0].text as string).tabId;
+    await adapter.callTool('tabs_close', { tabId });
+    expect(mock.log.some((c) => c.tool === 'browser_tab_close')).toBe(true);
+    expect(adapter.openTabCount).toBe(0);
+  });
+
+  test('unsupported tools return an error result rather than throwing', async () => {
+    const mock = makeMockTransport();
+    const adapter = new PlaywrightMcpAdapter({ transport: mock.transport });
+    await adapter.setup();
+    const res = await adapter.callTool('act', { instruction: 'click' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('unsupported tool');
+  });
+
+  test('teardown stops the transport and clears tab state', async () => {
+    const mock = makeMockTransport();
+    const adapter = new PlaywrightMcpAdapter({ transport: mock.transport });
+    await adapter.setup();
+    await adapter.callTool('tabs_create', { url: 'http://x/a' });
+    await adapter.teardown();
+    expect(mock.stopped()).toBe(true);
+    expect(adapter.openTabCount).toBe(0);
+  });
+});

--- a/tests/benchmark/adapters/playwright-mcp-adapter.test.ts
+++ b/tests/benchmark/adapters/playwright-mcp-adapter.test.ts
@@ -145,6 +145,43 @@ describe('PlaywrightMcpAdapter', () => {
     expect(res.content[0].text).toContain('unknown tabId');
   });
 
+  test('closing a non-last tab renumbers higher-indexed tabs (playwright-mcp shifts them down)', async () => {
+    const mock = makeMockTransport();
+    const adapter = new PlaywrightMcpAdapter({ transport: mock.transport });
+    await adapter.setup();
+    // Open three tabs: indices 0, 1, 2.
+    const t1 = await adapter.callTool('tabs_create', { url: 'http://x/a' });
+    const t2 = await adapter.callTool('tabs_create', { url: 'http://x/b' });
+    const t3 = await adapter.callTool('tabs_create', { url: 'http://x/c' });
+    const id1 = JSON.parse(t1.content[0].text as string).tabId;
+    const id2 = JSON.parse(t2.content[0].text as string).tabId;
+    const id3 = JSON.parse(t3.content[0].text as string).tabId;
+
+    // Close the middle tab (index 1). playwright-mcp now has two tabs at
+    // indices 0 and 1; id3 was at 2 and must shift down to 1.
+    await adapter.callTool('tabs_close', { tabId: id2 });
+    mock.log.length = 0; // reset call log
+
+    await adapter.callTool('read_page', { tabId: id3 });
+    const selectAfterShift = mock.log.find((c) => c.tool === 'browser_tab_select');
+    expect(selectAfterShift).toBeDefined();
+    expect(selectAfterShift!.args).toEqual({ index: 1 });
+
+    // id1 must still route to index 0.
+    mock.log.length = 0;
+    await adapter.callTool('read_page', { tabId: id1 });
+    const selectFirst = mock.log.find((c) => c.tool === 'browser_tab_select');
+    expect(selectFirst!.args).toEqual({ index: 0 });
+  });
+
+  test('teardown is idempotent — a second teardown does not throw', async () => {
+    const mock = makeMockTransport();
+    const adapter = new PlaywrightMcpAdapter({ transport: mock.transport });
+    await adapter.setup();
+    await adapter.teardown();
+    await expect(adapter.teardown()).resolves.toBeUndefined();
+  });
+
   test('tabs_close closes the tab and drops it from the tab map', async () => {
     const mock = makeMockTransport();
     const adapter = new PlaywrightMcpAdapter({ transport: mock.transport });

--- a/tests/benchmark/adapters/playwright-mcp-adapter.ts
+++ b/tests/benchmark/adapters/playwright-mcp-adapter.ts
@@ -366,13 +366,21 @@ export class PlaywrightMcpAdapter implements MCPAdapter {
 
   private async closeTab(args: Record<string, unknown>): Promise<MCPToolResult> {
     const tabId = typeof args.tabId === 'string' ? args.tabId : '';
-    const tabIndex = this.tabIndexById.get(tabId);
-    if (tabIndex === undefined) {
+    const closedIndex = this.tabIndexById.get(tabId);
+    if (closedIndex === undefined) {
       return errorResult(`PlaywrightMcpAdapter: unknown tabId "${tabId}"`);
     }
     const transport = this.transport as PlaywrightMcpTransport;
-    const res = await transport.callTool('browser_tab_close', { index: tabIndex });
+    const res = await transport.callTool('browser_tab_close', { index: closedIndex });
     this.tabIndexById.delete(tabId);
+    // playwright-mcp re-numbers tabs after a close: every tab whose index was
+    // greater than the closed one shifts down by one. Mirror that here so
+    // subsequent read_page / tabs_close calls target the correct tab.
+    for (const [id, idx] of this.tabIndexById) {
+      if (idx > closedIndex) {
+        this.tabIndexById.set(id, idx - 1);
+      }
+    }
     if (res.isError) return res;
     return textResult(JSON.stringify({ closed: tabId }));
   }

--- a/tests/benchmark/adapters/playwright-mcp-adapter.ts
+++ b/tests/benchmark/adapters/playwright-mcp-adapter.ts
@@ -1,0 +1,384 @@
+/**
+ * playwright-mcp competitor adapter for the competitive benchmark suite (#1255).
+ *
+ * Drives the upstream `@playwright/mcp` server through the same
+ * `callTool(toolName, args)` surface every other competitor implements, so
+ * benchmark task code stays identical across libraries (Epic #1254,
+ * methodology #4). The only thing that differs is the library under the hood.
+ *
+ * playwright-mcp IS an MCP server, so unlike the raw Playwright adapter this
+ * one speaks JSON-RPC to it rather than calling Playwright APIs directly.
+ * Translation map (OpenChrome tool names -> playwright-mcp tool names):
+ *
+ *   tabs_create({ url })   -> first call:  browser_navigate({ url })
+ *                          -> later calls: browser_tab_new({ url })
+ *                          (returns { tabId } -- a synthetic id the adapter owns)
+ *   read_page({ tabId })   -> browser_tab_select({ index }) + browser_snapshot()
+ *                          (returns the accessibility snapshot text -- that is
+ *                          playwright-mcp's idiomatic "hand this to an LLM"
+ *                          payload, equivalent to Playwright's
+ *                          accessibility.snapshot() and the right comparison
+ *                          baseline for the Token Efficiency axis #1256)
+ *   tabs_close({ tabId })  -> browser_tab_close({ index })
+ *
+ * Default transport spawns the `@playwright/mcp` CLI (resolved via
+ * `require.resolve('@playwright/mcp/cli.js')`) and speaks JSON-RPC over
+ * stdio, mirroring `OpenChromeRealAdapter`. The transport is injected so the
+ * translation logic stays unit-testable without spawning a real MCP server.
+ */
+
+import { spawn, ChildProcess } from 'child_process';
+import * as path from 'path';
+import { MCPAdapter, MCPToolResult } from '../benchmark-runner';
+
+interface MCPRequest {
+  jsonrpc: '2.0';
+  id: number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface MCPResponse {
+  jsonrpc: '2.0';
+  id: number;
+  result?: {
+    content?: Array<{ type: string; text?: string; data?: string }>;
+    isError?: boolean;
+  };
+  error?: { code: number; message: string };
+}
+
+/**
+ * Low-level transport the adapter uses to talk to playwright-mcp. The default
+ * implementation spawns a subprocess; tests pass a mock implementation.
+ */
+export interface PlaywrightMcpTransport {
+  start(): Promise<void>;
+  callTool(toolName: string, args: Record<string, unknown>): Promise<MCPToolResult>;
+  stop(): Promise<void>;
+}
+
+export interface PlaywrightMcpAdapterOptions {
+  /** CDP endpoint of an already-running Chrome; passed to `playwright-mcp --cdp-endpoint`. */
+  cdpEndpoint?: string;
+  /** Override the resolved path to `@playwright/mcp/cli.js`. */
+  serverPath?: string;
+  /** Per-call timeout in ms (default 30s). */
+  callTimeoutMs?: number;
+  /** Startup timeout in ms (default 15s). */
+  startupTimeoutMs?: number;
+  /**
+   * Inject the transport directly. When provided, the default subprocess
+   * transport is NOT constructed — keeps the translation logic unit-testable
+   * without spawning a real MCP server.
+   */
+  transport?: PlaywrightMcpTransport;
+}
+
+const DEFAULT_CDP_ENDPOINT = 'http://127.0.0.1:9222';
+const DEFAULT_CALL_TIMEOUT_MS = 30000;
+const DEFAULT_STARTUP_TIMEOUT_MS = 15000;
+
+function textResult(text: string): MCPToolResult {
+  return { content: [{ type: 'text', text }] };
+}
+
+function errorResult(message: string): MCPToolResult {
+  return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+/**
+ * Extract a plain-text payload from an MCPToolResult. playwright-mcp's
+ * snapshot tool returns one text content block; this helper joins all
+ * text blocks defensively in case a future version returns multiple.
+ */
+function joinText(result: MCPToolResult): string {
+  return (result.content || [])
+    .map((c) => (typeof c.text === 'string' ? c.text : ''))
+    .filter((s) => s.length > 0)
+    .join('\n');
+}
+
+/**
+ * Default subprocess transport. Lazy because `require.resolve` against a not-
+ * yet-installed dep would throw at module import time and break test
+ * discovery.
+ */
+class SubprocessPlaywrightMcpTransport implements PlaywrightMcpTransport {
+  private process: ChildProcess | null = null;
+  private requestId = 0;
+  private buffer = '';
+  private readonly pending = new Map<
+    number,
+    { resolve: (r: MCPResponse) => void; reject: (e: Error) => void; timer: NodeJS.Timeout }
+  >();
+
+  constructor(
+    private readonly cdpEndpoint: string,
+    private readonly serverPath: string,
+    private readonly callTimeoutMs: number,
+    private readonly startupTimeoutMs: number,
+  ) {}
+
+  async start(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.process = spawn(
+        'node',
+        [this.serverPath, '--cdp-endpoint', this.cdpEndpoint],
+        { stdio: ['pipe', 'pipe', 'pipe'] },
+      );
+
+      let ready = false;
+
+      this.process.stdout?.on('data', (data: Buffer) => {
+        this.buffer += data.toString();
+        const lines = this.buffer.split('\n');
+        this.buffer = lines.pop() || '';
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const response = JSON.parse(line) as MCPResponse;
+            const slot = this.pending.get(response.id);
+            if (slot) {
+              clearTimeout(slot.timer);
+              this.pending.delete(response.id);
+              slot.resolve(response);
+            }
+          } catch {
+            // playwright-mcp may emit non-JSON banner lines on stdout. Ignore.
+          }
+        }
+      });
+
+      this.process.stderr?.on('data', (data: Buffer) => {
+        // playwright-mcp prints "Listening on ..." or similar to stderr.
+        if (ready) return;
+        const msg = data.toString();
+        if (
+          msg.includes('Listening') ||
+          msg.includes('listening') ||
+          msg.includes('ready') ||
+          msg.includes('Ready')
+        ) {
+          ready = true;
+          this.send('initialize', {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            clientInfo: { name: 'openchrome-benchmark', version: '1.0.0' },
+          })
+            .then(() => resolve())
+            .catch(reject);
+        }
+      });
+
+      this.process.on('error', (err) => {
+        if (!ready) reject(err);
+      });
+      this.process.on('exit', (code) => {
+        if (!ready) reject(new Error(`playwright-mcp exited with code ${code} before startup`));
+      });
+
+      const startupTimer = setTimeout(() => {
+        if (!ready) {
+          // Some playwright-mcp builds do not print a readiness banner; fall
+          // back to attempting initialize once the startup timer fires.
+          ready = true;
+          this.send('initialize', {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            clientInfo: { name: 'openchrome-benchmark', version: '1.0.0' },
+          })
+            .then(() => resolve())
+            .catch(reject);
+        }
+      }, this.startupTimeoutMs);
+      startupTimer.unref();
+    });
+  }
+
+  async callTool(toolName: string, args: Record<string, unknown>): Promise<MCPToolResult> {
+    const response = await this.send('tools/call', { name: toolName, arguments: args });
+    if (response.error) {
+      return errorResult(`playwright-mcp ${toolName} failed: ${response.error.message}`);
+    }
+    const result = response.result || {};
+    return { content: result.content || [], isError: result.isError };
+  }
+
+  async stop(): Promise<void> {
+    for (const [, slot] of this.pending) {
+      clearTimeout(slot.timer);
+      slot.reject(new Error('playwright-mcp transport stopped'));
+    }
+    this.pending.clear();
+    if (this.process) {
+      this.process.stdin?.end();
+      this.process.kill();
+      this.process = null;
+    }
+  }
+
+  private send(method: string, params?: Record<string, unknown>): Promise<MCPResponse> {
+    if (!this.process?.stdin) {
+      return Promise.reject(new Error('playwright-mcp process not started'));
+    }
+    const id = ++this.requestId;
+    const req: MCPRequest = { jsonrpc: '2.0', id, method, params };
+    return new Promise<MCPResponse>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (this.pending.has(id)) {
+          this.pending.delete(id);
+          reject(new Error(`playwright-mcp "${method}" timed out after ${this.callTimeoutMs}ms`));
+        }
+      }, this.callTimeoutMs);
+      timer.unref();
+      this.pending.set(id, { resolve, reject, timer });
+      this.process!.stdin!.write(JSON.stringify(req) + '\n');
+    });
+  }
+}
+
+/**
+ * Resolve the path to the bundled playwright-mcp CLI. The package's `exports`
+ * field only allows `.` and `./package.json`, so we resolve via package.json
+ * and join `cli.js` (its `bin` entry) ourselves. Lazy: the call only happens
+ * at setup() so test discovery still works on a fresh checkout where the dep
+ * is not yet installed.
+ */
+function defaultServerPath(): string {
+  const pkgPath = require.resolve('@playwright/mcp/package.json');
+  return path.join(path.dirname(pkgPath), 'cli.js');
+}
+
+export class PlaywrightMcpAdapter implements MCPAdapter {
+  readonly name = 'playwright-mcp';
+  readonly mode = 'a11y-snapshot';
+  readonly kind = 'mcp' as const;
+
+  private readonly cdpEndpoint: string;
+  private readonly callTimeoutMs: number;
+  private readonly startupTimeoutMs: number;
+  private readonly serverPathOverride?: string;
+  private readonly injectedTransport?: PlaywrightMcpTransport;
+
+  private transport: PlaywrightMcpTransport | null = null;
+  // playwright-mcp manages tab order internally; we expose a stable synthetic
+  // tabId to the benchmark and map it to a tab index for routing.
+  private readonly tabIndexById = new Map<string, number>();
+  private tabSeq = 0;
+  // playwright-mcp's first tab is opened by `browser_navigate`; subsequent
+  // tabs use `browser_tab_new`. This flag tracks whether we have established
+  // the first one yet.
+  private hasNavigatedOnce = false;
+
+  constructor(options: PlaywrightMcpAdapterOptions = {}) {
+    this.cdpEndpoint = options.cdpEndpoint ?? DEFAULT_CDP_ENDPOINT;
+    this.callTimeoutMs = options.callTimeoutMs ?? DEFAULT_CALL_TIMEOUT_MS;
+    this.startupTimeoutMs = options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS;
+    this.serverPathOverride = options.serverPath;
+    this.injectedTransport = options.transport;
+  }
+
+  async setup(): Promise<void> {
+    this.transport =
+      this.injectedTransport ??
+      new SubprocessPlaywrightMcpTransport(
+        this.cdpEndpoint,
+        this.serverPathOverride ?? defaultServerPath(),
+        this.callTimeoutMs,
+        this.startupTimeoutMs,
+      );
+    await this.transport.start();
+  }
+
+  async teardown(): Promise<void> {
+    if (this.transport) {
+      await this.transport.stop();
+      this.transport = null;
+    }
+    this.tabIndexById.clear();
+    this.hasNavigatedOnce = false;
+    this.tabSeq = 0;
+  }
+
+  async callTool(toolName: string, args: Record<string, unknown>): Promise<MCPToolResult> {
+    if (!this.transport) {
+      return errorResult('PlaywrightMcpAdapter: setup() was not called');
+    }
+    try {
+      switch (toolName) {
+        case 'tabs_create':
+          return await this.createTab(args);
+        case 'read_page':
+          return await this.readPage(args);
+        case 'tabs_close':
+          return await this.closeTab(args);
+        default:
+          return errorResult(`PlaywrightMcpAdapter: unsupported tool "${toolName}"`);
+      }
+    } catch (err) {
+      return errorResult(`PlaywrightMcpAdapter: ${toolName} failed: ${(err as Error).message}`);
+    }
+  }
+
+  private async createTab(args: Record<string, unknown>): Promise<MCPToolResult> {
+    const url = typeof args.url === 'string' ? args.url : '';
+    const transport = this.transport as PlaywrightMcpTransport;
+
+    let tabIndex: number;
+    if (!this.hasNavigatedOnce) {
+      // First tab: drive the existing context's first page via browser_navigate.
+      if (url && url !== 'about:blank') {
+        const res = await transport.callTool('browser_navigate', { url });
+        if (res.isError) return res;
+      }
+      this.hasNavigatedOnce = true;
+      tabIndex = 0;
+    } else {
+      const res = await transport.callTool('browser_tab_new', url ? { url } : {});
+      if (res.isError) return res;
+      tabIndex = this.tabIndexById.size; // append
+    }
+
+    const tabId = `playwright-mcp-tab-${++this.tabSeq}`;
+    this.tabIndexById.set(tabId, tabIndex);
+    return textResult(JSON.stringify({ tabId }));
+  }
+
+  private async readPage(args: Record<string, unknown>): Promise<MCPToolResult> {
+    const tabId = typeof args.tabId === 'string' ? args.tabId : '';
+    const tabIndex = this.tabIndexById.get(tabId);
+    if (tabIndex === undefined) {
+      return errorResult(`PlaywrightMcpAdapter: unknown tabId "${tabId}"`);
+    }
+    const transport = this.transport as PlaywrightMcpTransport;
+    if (this.tabIndexById.size > 1) {
+      const sel = await transport.callTool('browser_tab_select', { index: tabIndex });
+      if (sel.isError) return sel;
+    }
+    // playwright-mcp's idiomatic "hand this to an LLM" payload is the
+    // accessibility snapshot — the right comparison baseline for the Token
+    // Efficiency axis (#1256).
+    const snap = await transport.callTool('browser_snapshot', {});
+    if (snap.isError) return snap;
+    return textResult(joinText(snap));
+  }
+
+  private async closeTab(args: Record<string, unknown>): Promise<MCPToolResult> {
+    const tabId = typeof args.tabId === 'string' ? args.tabId : '';
+    const tabIndex = this.tabIndexById.get(tabId);
+    if (tabIndex === undefined) {
+      return errorResult(`PlaywrightMcpAdapter: unknown tabId "${tabId}"`);
+    }
+    const transport = this.transport as PlaywrightMcpTransport;
+    const res = await transport.callTool('browser_tab_close', { index: tabIndex });
+    this.tabIndexById.delete(tabId);
+    if (res.isError) return res;
+    return textResult(JSON.stringify({ closed: tabId }));
+  }
+
+  /** Number of tabs the adapter currently tracks — for assertions. */
+  get openTabCount(): number {
+    return this.tabIndexById.size;
+  }
+}


### PR DESCRIPTION
## Summary
- 4th competitor adapter for the competitive benchmark suite (Epic #1254). Spawns the upstream `@playwright/mcp` CLI as a subprocess and speaks JSON-RPC over stdio, exposing the same `callTool(toolName, args)` surface the OpenChrome / Playwright / Puppeteer adapters expose
- Translation map: `tabs_create` → `browser_navigate` / `browser_tab_new`, `read_page` → `browser_tab_select` + `browser_snapshot` (the accessibility snapshot, playwright-mcp's idiomatic LLM payload), `tabs_close` → `browser_tab_close`
- The low-level subprocess transport is injectable, so the translation logic is fully unit-tested without spawning anything — same pattern the playwright/puppeteer adapters use for their CDP connect factory
- `@playwright/mcp@0.0.75` pinned in `benchmark/COMPETITORS.md` with commit `8116437ffcfee1309cebc07dd30cee37720d2d19` and measurement date 2026-05-15

## Why
Unblocks #1256 (Token Efficiency — playwright-mcp accessibility snapshot is the right comparison baseline against OpenChrome's compact DOM), #1257 (Agent Task Success — playwright-mcp is one of the three native-mode libraries), and #1261 (Developer Experience — MCP DX chart). Issue #1255 success criterion #1 requires all 5 competitor adapters to pass the shared smoke task; this is the 4th.

## Architecture notes
- `@playwright/mcp@0.0.75` has a tight `exports` map (no `./cli.js`), so `require.resolve('@playwright/mcp/cli.js')` throws on Node ≥ 20. The default transport resolves via the allowed `./package.json` and `path.join`s `cli.js` itself — matches the package's `bin` entry
- Startup detects either the readiness banner on stderr OR falls back to attempting `initialize` once the startup timer fires (some playwright-mcp builds emit no banner)
- Per-call timeout (default 30s) + startup timeout (15s); pending promises are rejected on teardown so a stuck call cannot leak
- `kind: 'mcp'`, `mode: 'a11y-snapshot'` — reports that bucket by category (MCP DX in #1261, payload shape in #1256) classify it automatically

## Verify
- `npm install` ⇒ `package-lock.json` synced (CLAUDE.md hard rule)
- `npm run build` ⇒ exit 0
- `npx jest tests/benchmark/adapters/` ⇒ 32/32 passing (12 new + 20 preexisting)

## Test plan
- [x] Build green
- [x] Adapter unit tests green (identity contract, pre-setup safety, first-tab / multi-tab routing, about:blank suppression, snapshot read, tab-select routing on multi-tab reads, error pathways, teardown)
- [ ] Real-subprocess smoke against playwright-mcp CLI — deferred to the integration runs in #1256/#1257/#1261 where it actually contributes a benchmark number
- [ ] CI green on `develop`

Part of Epic #1254. Independent of PR #1277 (15.3× cleanup) and the upcoming Crawlee + browser-use adapter PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)