### PR TITLE
feat(benchmark): throughput runner with --skip-live mode (#1258)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "bench:webvoyager:real": "ts-node tests/benchmark/webvoyager/runner.ts --adapter claude",
     "bench:latency": "ts-node tests/benchmark/run-latency.ts",
     "bench:tokens": "ts-node tests/benchmark/run-token-efficiency.ts",
+    "bench:throughput": "ts-node tests/benchmark/run-throughput.ts",
     "test": "jest",
     "test:e2e": "node --expose-gc node_modules/.bin/jest --config tests/e2e/jest.e2e.config.js",
     "test:coverage": "jest --coverage",

--- a/tests/benchmark/fixtures/static-server.ts
+++ b/tests/benchmark/fixtures/static-server.ts
@@ -15,6 +15,14 @@ export type PageWeight = 'small' | 'medium' | 'large';
 
 export const PAGE_WEIGHTS: readonly PageWeight[] = ['small', 'medium', 'large'];
 
+/**
+ * The throughput axis (#1258) uses a 50-page mirror — same byte-identical
+ * server, distinct page indices so HTTP caching and DOM keys do not collapse
+ * the workload to a single response. Each page is a small fixture (~25 nodes)
+ * so the measurement is concurrency-bound, not parse-bound.
+ */
+export const THROUGHPUT_PAGE_COUNT = 50;
+
 /** Number of repeated content nodes per weight tier. */
 const WEIGHT_NODE_COUNT: Record<PageWeight, number> = {
   small: 25,
@@ -54,11 +62,45 @@ function isPageWeight(value: string): value is PageWeight {
   return (PAGE_WEIGHTS as readonly string[]).includes(value);
 }
 
+/**
+ * Deterministic per-page HTML for the throughput mirror. Page bodies vary
+ * by `index` so HTTP caches and DOM identity caches cannot collapse all 50
+ * pages into one response — but every page is small (~25 nodes) so the
+ * measurement is dominated by concurrency / wall-clock cost, not parse cost.
+ */
+export function generateThroughputPageHtml(index: number): string {
+  const rows: string[] = [];
+  for (let i = 0; i < 25; i++) {
+    rows.push(
+      `<article class="item" data-page="${index}" data-index="${i}">` +
+        `<h2>Page ${index} · Item ${i}</h2>` +
+        `<p>Deterministic body text for page ${index} item ${i}.</p>` +
+        `<a href="/page/${index}/item/${i}">link ${i}</a>` +
+        '</article>',
+    );
+  }
+  return (
+    '<!doctype html><html lang="en"><head>' +
+    `<meta charset="utf-8"><title>Throughput mirror page ${index}</title>` +
+    '</head><body>' +
+    `<header><h1>Throughput fixture page ${index}</h1></header>` +
+    `<main>${rows.join('')}</main>` +
+    '<footer><p>openchrome benchmark throughput mirror</p></footer>' +
+    '</body></html>'
+  );
+}
+
+const PAGE_PATH_RE = /^page\/(\d+)$/;
+
 export interface StaticFixtureServer {
   /** Port the server is listening on (ephemeral). */
   readonly port: number;
-  /** Absolute URL for a given page weight. */
+  /** Absolute URL for a given page weight (latency mode). */
   url(weight: PageWeight): string;
+  /** Absolute URL for one of the throughput mirror pages (`/page/N`). */
+  pageUrl(index: number): string;
+  /** All `THROUGHPUT_PAGE_COUNT` mirror URLs in index order. */
+  pageUrls(): string[];
   /** Stop the server. Safe to call more than once. */
   close(): Promise<void>;
 }
@@ -74,6 +116,12 @@ export async function startStaticFixtureServer(): Promise<StaticFixtureServer> {
   for (const weight of PAGE_WEIGHTS) {
     bodies.set(weight, generateFixtureHtml(weight));
   }
+  // Same idea for the throughput mirror: pre-generate the 50 distinct pages
+  // so per-request work is just send-bytes, not generate-bytes.
+  const pageBodies = new Map<number, string>();
+  for (let i = 0; i < THROUGHPUT_PAGE_COUNT; i++) {
+    pageBodies.set(i, generateThroughputPageHtml(i));
+  }
 
   const server = http.createServer((req, res) => {
     const pathname = (req.url ?? '/').replace(/^\/+/, '').split('?')[0];
@@ -86,6 +134,20 @@ export async function startStaticFixtureServer(): Promise<StaticFixtureServer> {
       });
       res.end(body);
       return;
+    }
+    const pageMatch = PAGE_PATH_RE.exec(pathname);
+    if (pageMatch) {
+      const idx = Number(pageMatch[1]);
+      const body = pageBodies.get(idx);
+      if (body) {
+        res.writeHead(200, {
+          'content-type': 'text/html; charset=utf-8',
+          'content-length': Buffer.byteLength(body),
+          'cache-control': 'no-store',
+        });
+        res.end(body);
+        return;
+      }
     }
     res.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
     res.end('not a benchmark fixture route');
@@ -103,6 +165,16 @@ export async function startStaticFixtureServer(): Promise<StaticFixtureServer> {
     port,
     url(weight: PageWeight): string {
       return `http://127.0.0.1:${port}/${weight}`;
+    },
+    pageUrl(index: number): string {
+      return `http://127.0.0.1:${port}/page/${index}`;
+    },
+    pageUrls(): string[] {
+      const urls: string[] = [];
+      for (let i = 0; i < THROUGHPUT_PAGE_COUNT; i++) {
+        urls.push(`http://127.0.0.1:${port}/page/${i}`);
+      }
+      return urls;
     },
     close(): Promise<void> {
       if (closed) return Promise.resolve();

--- a/tests/benchmark/run-throughput.ts
+++ b/tests/benchmark/run-throughput.ts
@@ -1,0 +1,225 @@
+#!/usr/bin/env ts-node
+/**
+ * Throughput runner for the Speed & Throughput axis (#1258).
+ *
+ * Drives the static fixture server's 50-page mirror at concurrency 1 / 5 /
+ * 10 / 20 against the OpenChrome adapter and records both the raw
+ * throughput + success-rate PRIMARIES and the effective-throughput
+ * SECONDARY composite into the standard result envelope.
+ *
+ * Modes:
+ *
+ *   npm run bench:throughput
+ *     deterministic stub adapter (no Chrome). Always available — this is
+ *     what CI runs. Sprint 1 ships this mode; the live competitor cells
+ *     are gated behind OPENCHROME_BENCH_LIVE=1 and land in a follow-up
+ *     when the live Chrome + Playwright / Puppeteer / Crawlee
+ *     integrations are wired through `tests/benchmark/adapters/`.
+ *
+ *   OPENCHROME_BENCH_LIVE=1 npm run bench:throughput
+ *     real OpenChrome adapter against a Chrome on port 9222. Surfaces a
+ *     clear error if Chrome is not reachable rather than silently
+ *     falling back to stub.
+ *
+ *   npm run bench:throughput -- --ci
+ *     CI mode = stub, with the minimum iteration count that still
+ *     respects the warm-up discard.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { MCPAdapter } from './benchmark-runner';
+import { OpenChromeStubAdapter, OpenChromeRealAdapter } from './adapters';
+import { startStaticFixtureServer } from './fixtures/static-server';
+import {
+  measureThroughput,
+  ThroughputSummary,
+  DEFAULT_THROUGHPUT_CONCURRENCIES,
+  DEFAULT_THROUGHPUT_WARMUP_DISCARD,
+} from './throughput';
+import { captureEnvironment } from './utils/environment';
+import { buildResultEnvelope, assertValidResultEnvelope } from './utils/result-envelope';
+
+const OUTPUT_PATH = path.join(process.cwd(), 'benchmark', 'results', 'speed-throughput.json');
+
+export interface ThroughputRunOptions {
+  /** When true, use the deterministic stub adapter (no Chrome). */
+  ciMode: boolean;
+  /** Total passes per concurrency cell, including warm-up. */
+  iterations: number;
+  /** Warm-up passes to discard. */
+  warmupDiscard: number;
+  /** Concurrency cells to measure. */
+  concurrencies: readonly number[];
+  /** When true, force the live (real) adapter regardless of `ciMode`. */
+  live: boolean;
+}
+
+export interface ThroughputRow {
+  library: string;
+  mode: string;
+  concurrency: number;
+  pagesPerPass: number;
+  sampleCount: number;
+  warmupDiscarded: number;
+  rawPagesPerSecond: number;
+  successRate: number;
+  effectivePagesPerSecond: number;
+  meanWallMs: number;
+  p50WallMs: number;
+  p95WallMs: number;
+}
+
+export function parseThroughputArgs(argv: string[]): ThroughputRunOptions {
+  const ciMode = argv.includes('--ci');
+  const liveFlag = argv.includes('--live') || process.env.OPENCHROME_BENCH_LIVE === '1';
+  let iterations = ciMode
+    ? DEFAULT_THROUGHPUT_WARMUP_DISCARD + 1
+    : DEFAULT_THROUGHPUT_WARMUP_DISCARD + 3;
+  const idx = argv.indexOf('--iterations');
+  if (idx !== -1 && idx + 1 < argv.length) {
+    const raw = argv[idx + 1].trim();
+    const n = parseInt(raw, 10);
+    if (!Number.isInteger(n) || n <= 0 || String(n) !== raw) {
+      throw new Error(`--iterations must be a positive integer; got: ${argv[idx + 1]}`);
+    }
+    iterations = n;
+  }
+  if (iterations <= DEFAULT_THROUGHPUT_WARMUP_DISCARD) {
+    throw new Error(
+      `--iterations (${iterations}) must exceed the warm-up discard (${DEFAULT_THROUGHPUT_WARMUP_DISCARD})`,
+    );
+  }
+  let concurrencies: readonly number[] = DEFAULT_THROUGHPUT_CONCURRENCIES;
+  const cIdx = argv.indexOf('--concurrency');
+  if (cIdx !== -1 && cIdx + 1 < argv.length) {
+    const parsed = argv[cIdx + 1]
+      .split(',')
+      .map((s) => parseInt(s.trim(), 10));
+    if (parsed.some((n) => !Number.isInteger(n) || n <= 0)) {
+      throw new Error(`--concurrency must be a comma-separated list of positive integers`);
+    }
+    concurrencies = parsed;
+  }
+  return {
+    ciMode,
+    iterations,
+    warmupDiscard: DEFAULT_THROUGHPUT_WARMUP_DISCARD,
+    concurrencies,
+    live: liveFlag,
+  };
+}
+
+function toRow(library: string, mode: string, summary: ThroughputSummary): ThroughputRow {
+  return {
+    library,
+    mode,
+    concurrency: summary.concurrency,
+    pagesPerPass: summary.pagesPerPass,
+    sampleCount: summary.sampleCount,
+    warmupDiscarded: summary.warmupDiscarded,
+    rawPagesPerSecond: summary.rawPagesPerSecond,
+    successRate: summary.successRate,
+    effectivePagesPerSecond: summary.effectivePagesPerSecond,
+    meanWallMs: summary.meanWallMs,
+    p50WallMs: summary.p50WallMs,
+    p95WallMs: summary.p95WallMs,
+  };
+}
+
+function readRepoVersion(): string {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
+    return typeof pkg.version === 'string' ? pkg.version : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+/**
+ * Build the OpenChrome adapter the runner should use. Stub by default
+ * (CI / no Chrome); live adapter when `--live` or `OPENCHROME_BENCH_LIVE=1`.
+ * Competitor adapters (Playwright / Puppeteer / Crawlee) plug into this
+ * function in a follow-up PR; today the runner deliberately measures only
+ * OpenChrome so the headline number is honest about what landed in Sprint 1.
+ */
+function buildAdapter(options: ThroughputRunOptions): { adapter: MCPAdapter; mode: string } {
+  if (options.live && !options.ciMode) {
+    return { adapter: new OpenChromeRealAdapter({ mode: 'dom' }), mode: 'dom-live' };
+  }
+  return { adapter: new OpenChromeStubAdapter({ mode: 'dom' }), mode: 'dom-stub' };
+}
+
+export async function runThroughputBenchmark(options: ThroughputRunOptions): Promise<ThroughputRow[]> {
+  const server = await startStaticFixtureServer();
+  const urls = server.pageUrls();
+  const { adapter, mode } = buildAdapter(options);
+  const rows: ThroughputRow[] = [];
+  try {
+    if (adapter.setup) await adapter.setup();
+    for (const concurrency of options.concurrencies) {
+      const summary = await measureThroughput(adapter, {
+        urls,
+        concurrency,
+        iterations: options.iterations,
+        warmupDiscard: options.warmupDiscard,
+      });
+      rows.push(toRow('OpenChrome', mode, summary));
+    }
+  } finally {
+    if (adapter.teardown) await adapter.teardown();
+    await server.close();
+  }
+  return rows;
+}
+
+function formatReport(rows: ThroughputRow[]): string {
+  const lines = [
+    'Throughput benchmark (#1258) — raw + success + effective (labeled secondary)',
+    'library      mode       conc   raw pg/s   success   effective   p50(ms)   p95(ms)   samples',
+  ];
+  for (const r of rows) {
+    lines.push(
+      [
+        r.library.padEnd(12),
+        r.mode.padEnd(10),
+        String(r.concurrency).padStart(4),
+        r.rawPagesPerSecond.toFixed(1).padStart(10),
+        (r.successRate * 100).toFixed(1).padStart(7) + '%',
+        r.effectivePagesPerSecond.toFixed(1).padStart(11),
+        r.p50WallMs.toFixed(1).padStart(9),
+        r.p95WallMs.toFixed(1).padStart(9),
+        String(r.sampleCount).padStart(8),
+      ].join(' '),
+    );
+  }
+  return lines.join('\n');
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  const options = parseThroughputArgs(argv);
+  const rows = await runThroughputBenchmark(options);
+
+  const envelope = buildResultEnvelope({
+    axis: 'speed-throughput',
+    environment: captureEnvironment(),
+    competitors: [{ name: 'OpenChrome', version: readRepoVersion() }],
+    results: rows,
+  });
+  assertValidResultEnvelope(envelope);
+
+  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(envelope, null, 2) + '\n');
+
+  // console.error: stdout carries MCP JSON-RPC in this codebase; never log there.
+  console.error(formatReport(rows));
+  console.error(`\nSaved: ${path.relative(process.cwd(), OUTPUT_PATH)}`);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('Throughput benchmark failed:', err);
+    process.exit(1);
+  });
+}

--- a/tests/benchmark/throughput.test.ts
+++ b/tests/benchmark/throughput.test.ts
@@ -1,0 +1,145 @@
+/// <reference types="jest" />
+
+import {
+  measureThroughput,
+  summarizeThroughput,
+  ThroughputPass,
+  DEFAULT_THROUGHPUT_CONCURRENCIES,
+  DEFAULT_THROUGHPUT_WARMUP_DISCARD,
+} from './throughput';
+import { MCPAdapter, MCPToolResult } from './benchmark-runner';
+
+class FakeThroughputAdapter implements MCPAdapter {
+  readonly name = 'fake';
+  readonly mode = 'fake';
+
+  private tabSeq = 0;
+  private readonly tabs = new Map<string, string>();
+  private readonly opts: { failRate: number; latencyMs: number };
+
+  constructor(opts: { failRate?: number; latencyMs?: number } = {}) {
+    this.opts = { failRate: opts.failRate ?? 0, latencyMs: opts.latencyMs ?? 0 };
+  }
+
+  async callTool(toolName: string, args: Record<string, unknown>): Promise<MCPToolResult> {
+    if (this.opts.latencyMs > 0) {
+      await new Promise((r) => setTimeout(r, this.opts.latencyMs));
+    }
+    if (toolName === 'tabs_create') {
+      const url = typeof args.url === 'string' ? args.url : '';
+      // Stable failure pattern: every Nth URL fails. Lets tests assert the
+      // success-rate column independently of the wall-clock cell.
+      if (this.opts.failRate > 0 && this.tabSeq % Math.round(1 / this.opts.failRate) === 0) {
+        this.tabSeq += 1;
+        return { content: [{ type: 'text', text: 'forced failure' }], isError: true };
+      }
+      const tabId = `fake-tab-${++this.tabSeq}`;
+      this.tabs.set(tabId, url);
+      return { content: [{ type: 'text', text: JSON.stringify({ tabId }) }] };
+    }
+    if (toolName === 'read_page') {
+      const tabId = typeof args.tabId === 'string' ? args.tabId : '';
+      if (!this.tabs.has(tabId)) {
+        return { content: [{ type: 'text', text: 'unknown tab' }], isError: true };
+      }
+      return { content: [{ type: 'text', text: '<html>ok</html>' }] };
+    }
+    if (toolName === 'tabs_close') {
+      const tabId = typeof args.tabId === 'string' ? args.tabId : '';
+      this.tabs.delete(tabId);
+      return { content: [{ type: 'text', text: 'closed' }] };
+    }
+    return { content: [{ type: 'text', text: `unsupported ${toolName}` }], isError: true };
+  }
+}
+
+describe('summarizeThroughput', () => {
+  function pass(wallMs: number, successCount: number, failureCount = 0): ThroughputPass {
+    return { wallMs, successCount, failureCount };
+  }
+
+  test('discards the warm-up prefix and reports kept count', () => {
+    const passes = [pass(1000, 10), pass(500, 10), pass(400, 10), pass(420, 10)];
+    const s = summarizeThroughput(2, 10, passes, 2);
+    expect(s.warmupDiscarded).toBe(2);
+    expect(s.sampleCount).toBe(2);
+    expect(s.concurrency).toBe(2);
+    expect(s.pagesPerPass).toBe(10);
+  });
+
+  test('raw pages/sec uses pagesPerPass and the mean wall time', () => {
+    // 10 pages / 500 ms mean = 20 pages/s
+    const passes = [pass(500, 10), pass(500, 10)];
+    const s = summarizeThroughput(2, 10, passes, 0);
+    expect(s.rawPagesPerSecond).toBeCloseTo(20);
+  });
+
+  test('success rate and effective throughput are reported separately from raw', () => {
+    // 10 pages each pass, 5 succeed → successRate=0.5, raw=20 pg/s, effective=10 pg/s
+    const passes = [pass(500, 5, 5), pass(500, 5, 5)];
+    const s = summarizeThroughput(2, 10, passes, 0);
+    expect(s.successRate).toBe(0.5);
+    expect(s.rawPagesPerSecond).toBeCloseTo(20);
+    expect(s.effectivePagesPerSecond).toBeCloseTo(10);
+  });
+
+  test('rejects non-integer or negative concurrency', () => {
+    expect(() => summarizeThroughput(0, 10, [pass(100, 10)], 0)).toThrow(/concurrency/);
+    expect(() => summarizeThroughput(1.5, 10, [pass(100, 10)], 0)).toThrow(/concurrency/);
+  });
+
+  test('rejects warm-up that consumes every sample', () => {
+    expect(() => summarizeThroughput(1, 10, [pass(100, 10), pass(100, 10)], 2)).toThrow(/no throughput samples left/);
+  });
+});
+
+describe('measureThroughput', () => {
+  test('drives the adapter once per URL per pass and reports success rate', async () => {
+    const adapter = new FakeThroughputAdapter({ failRate: 0 });
+    const urls = ['http://x/0', 'http://x/1', 'http://x/2', 'http://x/3', 'http://x/4'];
+    const summary = await measureThroughput(adapter, {
+      urls,
+      concurrency: 2,
+      iterations: 2,
+      warmupDiscard: 0,
+    });
+    expect(summary.sampleCount).toBe(2);
+    expect(summary.pagesPerPass).toBe(5);
+    expect(summary.successRate).toBe(1);
+  });
+
+  test('honors the warm-up discard contract', async () => {
+    const adapter = new FakeThroughputAdapter();
+    const summary = await measureThroughput(adapter, {
+      urls: ['http://x/0', 'http://x/1'],
+      concurrency: 1,
+      iterations: DEFAULT_THROUGHPUT_WARMUP_DISCARD + 1,
+      warmupDiscard: DEFAULT_THROUGHPUT_WARMUP_DISCARD,
+    });
+    expect(summary.warmupDiscarded).toBe(DEFAULT_THROUGHPUT_WARMUP_DISCARD);
+    expect(summary.sampleCount).toBe(1);
+  });
+
+  test('rejects iterations that do not exceed the warm-up', async () => {
+    const adapter = new FakeThroughputAdapter();
+    await expect(
+      measureThroughput(adapter, {
+        urls: ['http://x/0'],
+        concurrency: 1,
+        iterations: 3,
+        warmupDiscard: 3,
+      }),
+    ).rejects.toThrow(/iterations.*warmupDiscard/);
+  });
+
+  test('default concurrency cells span the issue-mandated 1/5/10/20', () => {
+    expect(DEFAULT_THROUGHPUT_CONCURRENCIES).toEqual([1, 5, 10, 20]);
+  });
+
+  test('rejects empty URL sets at boundary', async () => {
+    const adapter = new FakeThroughputAdapter();
+    await expect(
+      measureThroughput(adapter, { urls: [], concurrency: 1, iterations: 1, warmupDiscard: 0 }),
+    ).rejects.toThrow(/urls/);
+  });
+});

--- a/tests/benchmark/throughput.ts
+++ b/tests/benchmark/throughput.ts
@@ -1,0 +1,206 @@
+/**
+ * Throughput measurement for the Speed & Throughput axis (#1258).
+ *
+ * Issue #1258 requires raw throughput and success rate as the two PRIMARY
+ * columns, with effective throughput as a labeled SECONDARY composite. This
+ * module is the unit-testable core; the runner in `run-throughput.ts` plumbs
+ * options, drives the static mirror, and serializes the result envelope.
+ *
+ * For each (library × concurrency) cell:
+ *   - run `iterations` independent passes over the URL set
+ *   - discard the first `warmupDiscard` passes (JIT / GC settling)
+ *   - record per-pass wall time + per-pass success count
+ *   - summarize across the kept passes
+ *
+ * "Effective throughput" is reported separately and clearly labeled — the
+ * existing report's "20 tabs = 18.9s but 10% success" cautionary tale is the
+ * reason this metric is secondary. A reader must always be able to see the
+ * two primaries before reaching the composite.
+ */
+
+import { MCPAdapter } from './benchmark-runner';
+
+export const DEFAULT_THROUGHPUT_WARMUP_DISCARD = 3;
+/** Default concurrency cells per issue #1258. */
+export const DEFAULT_THROUGHPUT_CONCURRENCIES: readonly number[] = [1, 5, 10, 20];
+
+export interface MeasureThroughputOptions {
+  /** All target URLs visited per pass. */
+  urls: readonly string[];
+  /** Concurrency for this cell. Must be >= 1. */
+  concurrency: number;
+  /** Total passes to run, including the warm-up prefix. */
+  iterations: number;
+  /** Number of warm-up passes to discard before timing. */
+  warmupDiscard: number;
+}
+
+export interface ThroughputPass {
+  /** Wall-clock ms for this whole pass. */
+  wallMs: number;
+  /** URLs that read_page succeeded for. */
+  successCount: number;
+  /** URLs that failed (read_page error or no tabId). */
+  failureCount: number;
+}
+
+export interface ThroughputSummary {
+  concurrency: number;
+  /** Passes kept after discarding the warm-up prefix. */
+  sampleCount: number;
+  /** Warm-up passes discarded before timing. */
+  warmupDiscarded: number;
+  pagesPerPass: number;
+  /** Mean pages-per-second across kept passes — the raw-throughput PRIMARY. */
+  rawPagesPerSecond: number;
+  /** Mean success rate across kept passes — the success-rate PRIMARY. */
+  successRate: number;
+  /** Mean successful-pages-per-second — secondary composite, labeled. */
+  effectivePagesPerSecond: number;
+  meanWallMs: number;
+  p50WallMs: number;
+  p95WallMs: number;
+  /** Raw per-pass wall ms in measurement order. */
+  passes: ThroughputPass[];
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return sorted[idx];
+}
+
+/**
+ * Summarize raw per-pass results — drop the warm-up prefix, compute the
+ * distribution. Pure function so the runner stays unit-testable independent
+ * of the actual adapter / server.
+ */
+export function summarizeThroughput(
+  concurrency: number,
+  pagesPerPass: number,
+  rawPasses: readonly ThroughputPass[],
+  warmupDiscard: number,
+): ThroughputSummary {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error(`concurrency must be a positive integer, got ${concurrency}`);
+  }
+  if (!Number.isInteger(warmupDiscard) || warmupDiscard < 0) {
+    throw new Error(`warmupDiscard must be a non-negative integer, got ${warmupDiscard}`);
+  }
+  const kept = rawPasses.slice(warmupDiscard);
+  if (kept.length === 0) {
+    throw new Error(
+      `no throughput samples left after discarding ${warmupDiscard} warm-up of ${rawPasses.length}`,
+    );
+  }
+  const wallSamples = kept.map((p) => p.wallMs);
+  const meanWall = wallSamples.reduce((a, b) => a + b, 0) / kept.length;
+  const meanSuccess = kept.reduce((a, b) => a + b.successCount, 0) / kept.length;
+  const meanFailure = kept.reduce((a, b) => a + b.failureCount, 0) / kept.length;
+  const meanPagesPerSecond = meanWall > 0 ? (pagesPerPass / meanWall) * 1000 : 0;
+  const successRate = pagesPerPass > 0 ? meanSuccess / pagesPerPass : 0;
+  const effectivePagesPerSecond = meanWall > 0 ? (meanSuccess / meanWall) * 1000 : 0;
+  void meanFailure; // explicitly noted; future report may surface failures.
+  return {
+    concurrency,
+    sampleCount: kept.length,
+    warmupDiscarded: Math.min(warmupDiscard, rawPasses.length),
+    pagesPerPass,
+    rawPagesPerSecond: meanPagesPerSecond,
+    successRate,
+    effectivePagesPerSecond,
+    meanWallMs: meanWall,
+    p50WallMs: percentile(wallSamples, 50),
+    p95WallMs: percentile(wallSamples, 95),
+    passes: [...kept],
+  };
+}
+
+/**
+ * Execute a single pass over `urls` with the given concurrency. Returns the
+ * pass's wall time + per-URL success count. The adapter must be set up
+ * already; this function does not call setup/teardown.
+ */
+async function runPass(
+  adapter: MCPAdapter,
+  urls: readonly string[],
+  concurrency: number,
+): Promise<ThroughputPass> {
+  let successCount = 0;
+  let failureCount = 0;
+  const queue = [...urls];
+  const start = Date.now();
+
+  async function worker(): Promise<void> {
+    for (;;) {
+      const url = queue.shift();
+      if (url === undefined) return;
+      try {
+        const created = await adapter.callTool('tabs_create', { url });
+        if (created.isError) {
+          failureCount += 1;
+          continue;
+        }
+        let tabId: string | undefined;
+        try {
+          const parsed = JSON.parse((created.content[0]?.text as string) ?? '{}') as {
+            tabId?: string;
+          };
+          tabId = parsed.tabId;
+        } catch {
+          failureCount += 1;
+          continue;
+        }
+        if (!tabId) {
+          failureCount += 1;
+          continue;
+        }
+        const read = await adapter.callTool('read_page', { tabId });
+        if (read.isError) {
+          failureCount += 1;
+        } else {
+          successCount += 1;
+        }
+        // Best-effort tab close; do not count its outcome against success.
+        await adapter.callTool('tabs_close', { tabId }).catch(() => undefined);
+      } catch {
+        failureCount += 1;
+      }
+    }
+  }
+
+  const workers: Array<Promise<void>> = [];
+  for (let i = 0; i < concurrency; i++) workers.push(worker());
+  await Promise.all(workers);
+
+  return { wallMs: Date.now() - start, successCount, failureCount };
+}
+
+/**
+ * Measure throughput at a given concurrency. Runs `iterations` passes,
+ * discards the warm-up prefix, summarizes the rest.
+ */
+export async function measureThroughput(
+  adapter: MCPAdapter,
+  options: MeasureThroughputOptions,
+): Promise<ThroughputSummary> {
+  if (options.urls.length === 0) {
+    throw new Error('measureThroughput: urls must be non-empty');
+  }
+  if (options.iterations <= options.warmupDiscard) {
+    throw new Error(
+      `iterations (${options.iterations}) must exceed warmupDiscard (${options.warmupDiscard})`,
+    );
+  }
+  const passes: ThroughputPass[] = [];
+  for (let i = 0; i < options.iterations; i++) {
+    passes.push(await runPass(adapter, options.urls, options.concurrency));
+  }
+  return summarizeThroughput(
+    options.concurrency,
+    options.urls.length,
+    passes,
+    options.warmupDiscard,
+  );
+}


### PR DESCRIPTION
## Summary
- Lands the Speed & Throughput axis (#1258) infrastructure: a 50-page mirror on the existing `startStaticFixtureServer()`, a throughput measurement core (`throughput.ts`), a CLI runner (`run-throughput.ts`), and a `bench:throughput` npm script
- CI gets a deterministic stub run today; real Chrome cells are gated behind `OPENCHROME_BENCH_LIVE=1` so they don't block the PR but ship the moment a Chrome instance is available
- Result envelope writes to `benchmark/results/speed-throughput.json` and validates against the existing `result.schema.json`

## Why
Issue #1258 success criterion #1: "Raw throughput AND success rate reported as separate primaries; effective throughput shown only as a labeled secondary composite." This PR sets up that exact contract — every row carries `rawPagesPerSecond`, `successRate`, and `effectivePagesPerSecond` as three independent fields, and the ASCII report header explicitly labels effective as a secondary so a reader never mistakes it for the headline.

## Commits (3, each independently reviewable)
1. **`feat(benchmark): extend static fixture server with a 50-page mirror`** — adds `/page/N` routes (N=0..49) + `pageUrl(N)` / `pageUrls()` helpers to the existing server. Backwards-compatible with the latency runner.
2. **`feat(benchmark): throughput measurement core`** — pure `summarizeThroughput()` + adapter-driven `measureThroughput()` mirroring the `latency.ts` pattern. 10 unit tests cover discard, pass/fail accounting, the three-primary-column separation, and parameter validation.
3. **`feat(benchmark): throughput CLI runner with --skip-live mode`** — `tests/benchmark/run-throughput.ts`, `bench:throughput` npm script, default concurrency 1/5/10/20, env-gated `OPENCHROME_BENCH_LIVE=1` for the live adapter.

## Scope this PR
Today the runner measures the OpenChrome stub adapter (deterministic; what CI runs) and, when `--live` is set, the OpenChrome real adapter against a running Chrome. **Competitor cells (Playwright / Puppeteer / Crawlee) are scoped out of this PR by design** — the issue spec lists them but Sprint 1's plan is to land the framework + the OpenChrome path first, then plug in the competitor adapters (#1278 / #1279 — already merged) in a follow-up. This PR's `buildAdapter()` is the extension point.

## Verify
- `npm run build` ⇒ exit 0
- `npm run bench:throughput -- --ci` ⇒ produces `benchmark/results/speed-throughput.json` with 4 rows + a valid envelope
- `npx jest tests/benchmark/throughput.test.ts tests/benchmark/latency.test.ts` ⇒ 20/20 passing
- The ASCII report header literally says "raw + success + effective (labeled secondary)" so the column meaning is on every printout, not buried in docs

## Test plan
- [x] Build green
- [x] Throughput core unit tests green (10/10)
- [x] Latency tests still green (10/10) — confirms the static-server extension is backwards-compatible
- [x] `bench:throughput -- --ci` produces a schema-valid result envelope
- [ ] CI green on `develop`
- [ ] Follow-up: live mode against Chrome :9222 (manual + a follow-up PR for Playwright / Puppeteer / Crawlee adapter integration)

Part of Epic #1254 → Sprint 1 PR-8 of 6. PR-5 (#1281) is the other Sprint-1 deliverable that lands this session; the remaining PR-6 / PR-7 / PR-9 / PR-10 defer to next sessions per the agreed scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)