### PR TITLE
chore(benchmark): retire parallel-isolated.mjs estimation path (#1258)

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,5 +1,13 @@
 # OpenChrome Benchmark Suite
 
+> **Note on history:** This directory is the legacy Twitter/X scraping benchmark. The competitive benchmark suite ([Epic #1254](https://github.com/shaun0927/openchrome/issues/1254)) replaces it with a per-axis structure under `tests/benchmark/`, exposed via the `bench:*` npm scripts at the repo root:
+>
+> - `npm run bench:tokens` — Token Efficiency axis (#1256)
+> - `npm run bench:throughput` — Speed & Throughput axis (#1258)
+> - `npm run bench:latency` — single-action latency (#1258)
+>
+> The scripts below remain functional for the legacy Twitter/X scenario (real Playwright measurements, no estimation). New axes should land in `tests/benchmark/` instead of here.
+
 Real-world benchmark comparing OpenChrome vs Playwright for Twitter/X profile scraping.
 
 ## Task
@@ -79,11 +87,11 @@ Results are saved to `results/`:
 | **OC 10-batch** | **23.2s** | **3.5x** | **95%** |
 | OC 20-batch | 25.7s | 3.2x | 95% |
 
-Token efficiency: **TBD — pending #1256 results** (real per-archetype compression replaces the retired hard-coded estimate)
+Token efficiency: see [`TOKEN-EFFICIENCY-REPORT.md`](./results/TOKEN-EFFICIENCY-REPORT.md) — produced by `npm run bench:tokens` and a per-archetype compression measurement over a 50-fixture corpus, replacing the retired hard-coded estimate.
 
 ## Methodology
 
 - Same Chrome v145 instance via CDP for both tools
 - Same logged-in session (real Chrome profile)
 - Each strategy run in a completely separate process
-- OC compression ratio calibrated from actual `read_page` measurements
+- Token compression: real per-archetype measurement (#1256); legacy hard-coded estimate retired

--- a/benchmark/parallel-isolated.mjs
+++ b/benchmark/parallel-isolated.mjs
@@ -1,15 +1,24 @@
 /**
- * Isolated Parallel Benchmark — Playwright only.
+ * Isolated Parallel Benchmark — Playwright only. **LEGACY.**
  *
- * Runs ONE strategy at a time (passed via CLI arg).
- * Must be run separately for each strategy to avoid contamination.
+ * This file is the original Twitter/X scraping benchmark — Playwright
+ * measurements only, no estimation. It is **superseded** by the unified
+ * competitive benchmark harness (#1258 / Epic #1254):
  *
- * NOTE: This script measures Playwright only. It does NOT run OpenChrome.
- * It previously *estimated* OpenChrome token counts by dividing raw HTML by a
- * hard-coded compression ratio — an unverified guess, now removed
- * (Epic #1254, sub-issue #1255). Real, measured OpenChrome vs competitor
- * throughput numbers come from the unified harness in #1258 (Speed &
- * Throughput); raw HTML is reported here only as a real Playwright measurement.
+ *   For OpenChrome vs competitor throughput, use:
+ *     npm run bench:throughput            (deterministic stub, CI)
+ *     OPENCHROME_BENCH_LIVE=1 \
+ *       npm run bench:throughput          (real Chrome on :9222)
+ *
+ * The unified harness covers the same throughput question and produces a
+ * schema-valid result envelope at `benchmark/results/speed-throughput.json`
+ * that the next-session report generator consumes.
+ *
+ * This script remains functional for the legacy Twitter/X scenario. It
+ * previously *estimated* OpenChrome token counts via a hard-coded
+ * compression ratio — that estimation was removed by Epic #1254 sub-issue
+ * #1255. Today it measures only real Playwright wall-clock + raw HTML
+ * sizes.
  *
  * Usage:
  *   node parallel-isolated.mjs 1    # sequential (1 tab)


### PR DESCRIPTION
## Summary
- Locks in the #1258 exit criterion "no \`OC_COMPRESSION_RATIO\` / \`15.3\` references in \`benchmark/\` or \`tests/benchmark/\`" — the cleanup itself shipped in PR #1277; this PR adds the README + parallel-isolated.mjs pointers so future readers know which script is canonical
- \`benchmark/parallel-isolated.mjs\` keeps working for the legacy Twitter/X scenario but is explicitly marked LEGACY in its docblock with a pointer at \`npm run bench:throughput\` as the unified successor
- README.md headers point new readers at the per-axis \`bench:*\` scripts under \`tests/benchmark/\`

## Why
Issue #1258 required retiring the estimation path; PR #1277 deleted the constant; this PR ensures the in-repo documentation reflects that retirement so a reader who lands on \`benchmark/parallel-isolated.mjs\` knows where to find the canonical OpenChrome throughput numbers.

## Verify
- \`grep -rE "OC_COMPRESSION_RATIO|15\\.3" benchmark/ tests/benchmark/ | grep -v node_modules | grep -v results/playwright-results.json\` ⇒ 0 lines
- \`npm run bench:throughput -- --ci\` still produces a schema-valid envelope
- \`benchmark/parallel-isolated.mjs\` still runnable as before (no behavior changes, docblock only)

## Test plan
- [x] Grep verification clean
- [x] Throughput runner still functional
- [ ] CI green on \`develop\`

Part of Epic #1254 → Sprint 1 PR-9 of 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)