### PR TITLE
feat(benchmark): WebVoyager task corpus 18→61 (#1257)

### DIFF
--- a/scripts/bench/generate-webvoyager-tasks.mjs
+++ b/scripts/bench/generate-webvoyager-tasks.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Generate WebVoyager task files for the Agent Task Success axis (#1257).
+ *
+ * Emits TypeScript task files under
+ * `tests/benchmark/webvoyager/tasks/task-NN-<slug>.ts`. Each generated task
+ * is shipped with `pending: true` until a transcript is recorded — the
+ * mock runner skips pending tasks and the baseline.json only lists tasks
+ * whose transcript has been frozen. This keeps the corpus honest: structural
+ * schema validation passes today, real LLM-driven measurements record the
+ * transcripts in the next session.
+ *
+ * Run:
+ *
+ *   node scripts/bench/generate-webvoyager-tasks.mjs
+ *
+ * Sources are license-safe / low-volatility: RFC-2606 example domains,
+ * Wikipedia article facts that have been stable for years, MDN reference
+ * pages, IETF RFCs, WHATWG/W3C specs, TC39 ECMAScript spec, Rust std docs,
+ * Python docs. Volatile sources (live weather APIs, search engines, social
+ * sites) are deliberately excluded so site drift doesn't pollute the
+ * benchmark headline.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const TASKS_DIR = path.join(REPO_ROOT, 'tests', 'benchmark', 'webvoyager', 'tasks');
+
+/**
+ * Manifest of 42 new tasks (existing 18 → 60 total). Each entry generates one
+ * task file. The `volatile` flag is for the per-source-volatility annotation
+ * recorded in the rationale; the actual `volatile` task tag in the bucket
+ * sense uses a name suffix (`-volatile`) that the runner inspects.
+ *
+ * Keep this list license-safe: RFC-2606 example domains, public reference
+ * docs (RFC, W3C, WHATWG, TC39), public Wikipedia article facts, MDN.
+ */
+const TASKS = [
+  // ---- example domains (RFC-2606 reserved) — smoke ----
+  { slug: 'example-com-h1', url: 'https://example.com', text: 'Example Domain', label: 'h1 contains Example Domain on example.com' },
+  { slug: 'example-org-h1', url: 'https://example.org', text: 'Example Domain', label: 'h1 contains Example Domain on example.org' },
+  { slug: 'example-net-h1', url: 'https://example.net', text: 'Example Domain', label: 'h1 contains Example Domain on example.net' },
+
+  // ---- Wikipedia (high-stability article facts) ----
+  { slug: 'wikipedia-light-speed', url: 'https://en.wikipedia.org/wiki/Speed_of_light', text: '299792458', label: 'Speed-of-light article cites 299,792,458 m/s' },
+  { slug: 'wikipedia-everest', url: 'https://en.wikipedia.org/wiki/Mount_Everest', text: '8,848', label: 'Mount Everest height cited as 8,848 m' },
+  { slug: 'wikipedia-mariana-trench', url: 'https://en.wikipedia.org/wiki/Mariana_Trench', text: 'deepest', label: 'Mariana Trench described as deepest oceanic trench' },
+  { slug: 'wikipedia-eiffel-tower', url: 'https://en.wikipedia.org/wiki/Eiffel_Tower', text: 'Paris', label: 'Eiffel Tower located in Paris' },
+  { slug: 'wikipedia-statue-of-liberty', url: 'https://en.wikipedia.org/wiki/Statue_of_Liberty', text: 'New York', label: 'Statue of Liberty located in New York' },
+  { slug: 'wikipedia-internet-protocol', url: 'https://en.wikipedia.org/wiki/Internet_Protocol', text: 'datagram', label: 'Internet Protocol article mentions datagram' },
+  { slug: 'wikipedia-ascii', url: 'https://en.wikipedia.org/wiki/ASCII', text: '128', label: 'ASCII character set described as 128 code points' },
+  { slug: 'wikipedia-pi', url: 'https://en.wikipedia.org/wiki/Pi', text: '3.14', label: 'Pi article cites 3.14...' },
+  { slug: 'wikipedia-utf8', url: 'https://en.wikipedia.org/wiki/UTF-8', text: 'variable-width', label: 'UTF-8 described as variable-width' },
+  { slug: 'wikipedia-tim-berners-lee', url: 'https://en.wikipedia.org/wiki/Tim_Berners-Lee', text: 'World Wide Web', label: 'Tim Berners-Lee credited with inventing the World Wide Web' },
+  { slug: 'wikipedia-rfc-editor', url: 'https://en.wikipedia.org/wiki/Request_for_Comments', text: 'IETF', label: 'RFC document series associated with IETF' },
+
+  // ---- RFCs (immutable once published) ----
+  { slug: 'rfc-2606-reserved', url: 'https://www.rfc-editor.org/rfc/rfc2606', text: 'example', label: 'RFC 2606 lists example as a reserved TLD' },
+  { slug: 'rfc-2119-keywords', url: 'https://www.rfc-editor.org/rfc/rfc2119', text: 'MUST', label: 'RFC 2119 defines MUST keyword' },
+  { slug: 'rfc-8259-json', url: 'https://www.rfc-editor.org/rfc/rfc8259', text: 'JavaScript Object Notation', label: 'RFC 8259 titled JavaScript Object Notation' },
+  { slug: 'rfc-9110-http', url: 'https://www.rfc-editor.org/rfc/rfc9110', text: 'HTTP Semantics', label: 'RFC 9110 titled HTTP Semantics' },
+  { slug: 'rfc-7231-http-methods', url: 'https://www.rfc-editor.org/rfc/rfc7231', text: 'method', label: 'RFC 7231 defines HTTP methods' },
+  { slug: 'rfc-3986-uri', url: 'https://www.rfc-editor.org/rfc/rfc3986', text: 'Uniform Resource Identifier', label: 'RFC 3986 defines URI syntax' },
+  { slug: 'rfc-5321-smtp', url: 'https://www.rfc-editor.org/rfc/rfc5321', text: 'Simple Mail Transfer Protocol', label: 'RFC 5321 defines SMTP' },
+  { slug: 'rfc-6749-oauth', url: 'https://www.rfc-editor.org/rfc/rfc6749', text: 'OAuth 2.0', label: 'RFC 6749 defines OAuth 2.0' },
+
+  // ---- MDN (reference pages, stable URLs) ----
+  { slug: 'mdn-fetch', url: 'https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API', text: 'Fetch API', label: 'MDN Fetch API reference' },
+  { slug: 'mdn-array-map', url: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map', text: 'map', label: 'MDN Array.prototype.map reference' },
+  { slug: 'mdn-array-filter', url: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter', text: 'filter', label: 'MDN Array.prototype.filter reference' },
+  { slug: 'mdn-promise-then', url: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then', text: 'then', label: 'MDN Promise.prototype.then reference' },
+  { slug: 'mdn-async-await', url: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await', text: 'await', label: 'MDN await operator reference' },
+  { slug: 'mdn-css-grid', url: 'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout', text: 'grid', label: 'MDN CSS Grid Layout reference' },
+  { slug: 'mdn-css-flexbox', url: 'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flexible_box_layout', text: 'flex', label: 'MDN CSS Flexbox reference' },
+  { slug: 'mdn-html-img', url: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img', text: 'img', label: 'MDN HTML img element reference' },
+
+  // ---- TC39 / ECMAScript ----
+  { slug: 'tc39-ecma262-syntax', url: 'https://tc39.es/ecma262/', text: 'ECMAScript', label: 'TC39 ECMAScript spec home' },
+  { slug: 'tc39-proposals', url: 'https://github.com/tc39/proposals', text: 'proposals', label: 'TC39 proposals repo' },
+
+  // ---- W3C / WHATWG ----
+  { slug: 'whatwg-html-spec', url: 'https://html.spec.whatwg.org/', text: 'HTML', label: 'WHATWG HTML living standard' },
+  { slug: 'whatwg-fetch-spec', url: 'https://fetch.spec.whatwg.org/', text: 'Fetch', label: 'WHATWG Fetch standard' },
+  { slug: 'w3c-css-spec', url: 'https://www.w3.org/Style/CSS/', text: 'CSS', label: 'W3C CSS home' },
+
+  // ---- Rust std ----
+  { slug: 'rust-string-trim', url: 'https://doc.rust-lang.org/std/string/struct.String.html', text: 'String', label: 'Rust std::string::String docs' },
+  { slug: 'rust-option-enum', url: 'https://doc.rust-lang.org/std/option/enum.Option.html', text: 'Option', label: 'Rust std::option::Option docs' },
+  { slug: 'rust-result-enum', url: 'https://doc.rust-lang.org/std/result/enum.Result.html', text: 'Result', label: 'Rust std::result::Result docs' },
+  { slug: 'rust-vec', url: 'https://doc.rust-lang.org/std/vec/struct.Vec.html', text: 'Vec', label: 'Rust std::vec::Vec docs' },
+
+  // ---- Python docs ----
+  { slug: 'python-len-builtin', url: 'https://docs.python.org/3/library/functions.html', text: 'len', label: 'Python built-in functions reference' },
+  { slug: 'python-list-stdtypes', url: 'https://docs.python.org/3/library/stdtypes.html', text: 'list', label: 'Python stdtypes reference (list)' },
+  { slug: 'python-dict-stdtypes', url: 'https://docs.python.org/3/library/stdtypes.html', text: 'dict', label: 'Python stdtypes reference (dict)' },
+  { slug: 'python-pep-8', url: 'https://peps.python.org/pep-0008/', text: 'Style Guide', label: 'PEP 8 Style Guide' },
+];
+
+const STARTING_INDEX = 19; // existing tasks are task-01 .. task-18
+
+function pad(n) {
+  return String(n).padStart(2, '0');
+}
+
+function buildTaskTs(task, index) {
+  const name = `task-${pad(index)}-${task.slug}`;
+  // Escape the URL for the regex pattern (escape dot + slashes).
+  const escapedUrl = task.url
+    .replace(/[.\\?+*$^()[\]{}|]/g, (m) => `\\\\${m}`)
+    .replace(/\//g, '\\\\/');
+  const escapedText = task.text.replace(/[\\'`]/g, '\\$&');
+  const rationale = `${task.label}. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.`;
+  return `import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: '${name}',
+  instruction: 'Visit ${task.url} and confirm the page mentions "${task.text}".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^${escapedUrl}' },
+        { kind: 'dom_text', selector: 'body', contains: '${escapedText}' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    '${rationale}',
+};
+
+export default task;
+`;
+}
+
+function main() {
+  let written = 0;
+  for (let i = 0; i < TASKS.length; i++) {
+    const index = STARTING_INDEX + i;
+    const task = TASKS[i];
+    const name = `task-${pad(index)}-${task.slug}`;
+    const filename = `${name}.ts`;
+    const filepath = path.join(TASKS_DIR, filename);
+    if (fs.existsSync(filepath)) {
+      process.stderr.write(`Skip (already exists): ${filename}\n`);
+      continue;
+    }
+    fs.writeFileSync(filepath, buildTaskTs(task, index));
+    written += 1;
+    process.stderr.write(`Wrote ${filename}\n`);
+  }
+  process.stderr.write(`\nGenerated ${written} new task files (existing kept). Target total: ${STARTING_INDEX - 1 + TASKS.length}.\n`);
+}
+
+main();

--- a/tests/benchmark/webvoyager/tasks-corpus.test.ts
+++ b/tests/benchmark/webvoyager/tasks-corpus.test.ts
@@ -79,4 +79,23 @@ describe('WebVoyager task corpus', () => {
       expect(task.pending).toBe(true);
     }
   });
+
+  test('Sprint-2 corpus expansion (task-19..) is also marked pending', async () => {
+    // The 43 tasks added in Sprint 2 (#1257 — PR-11) all ship pending until
+    // their transcripts are recorded in the next-session real-LLM run. This
+    // is the same honesty guard as the task-11..18 batch — without it, a
+    // task could silently default to `pending: false` and the mock runner
+    // would report a false pass/fail for a task that has no ground truth.
+    const sprint2Files = files.filter((f) => {
+      const match = /^task-(\d+)-/.exec(f);
+      if (!match) return false;
+      return parseInt(match[1], 10) >= 19;
+    });
+    expect(sprint2Files.length).toBeGreaterThanOrEqual(40);
+    for (const f of sprint2Files) {
+      const mod = await import(path.join(TASKS_DIR, f));
+      const task = (mod.default ?? mod.task) as WebVoyagerTask;
+      expect(task.pending).toBe(true);
+    }
+  });
 });

--- a/tests/benchmark/webvoyager/tasks/task-19-example-com-h1.ts
+++ b/tests/benchmark/webvoyager/tasks/task-19-example-com-h1.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-19-example-com-h1',
+  instruction: 'Visit https://example.com and confirm the page mentions "Example Domain".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/example\\.com' },
+        { kind: 'dom_text', selector: 'body', contains: 'Example Domain' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'h1 contains Example Domain on example.com. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-20-example-org-h1.ts
+++ b/tests/benchmark/webvoyager/tasks/task-20-example-org-h1.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-20-example-org-h1',
+  instruction: 'Visit https://example.org and confirm the page mentions "Example Domain".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/example\\.org' },
+        { kind: 'dom_text', selector: 'body', contains: 'Example Domain' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'h1 contains Example Domain on example.org. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-21-example-net-h1.ts
+++ b/tests/benchmark/webvoyager/tasks/task-21-example-net-h1.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-21-example-net-h1',
+  instruction: 'Visit https://example.net and confirm the page mentions "Example Domain".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/example\\.net' },
+        { kind: 'dom_text', selector: 'body', contains: 'Example Domain' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'h1 contains Example Domain on example.net. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-22-wikipedia-light-speed.ts
+++ b/tests/benchmark/webvoyager/tasks/task-22-wikipedia-light-speed.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-22-wikipedia-light-speed',
+  instruction: 'Visit https://en.wikipedia.org/wiki/Speed_of_light and confirm the page mentions "299792458".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/Speed_of_light' },
+        { kind: 'dom_text', selector: 'body', contains: '299792458' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Speed-of-light article cites 299,792,458 m/s. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-23-wikipedia-everest.ts
+++ b/tests/benchmark/webvoyager/tasks/task-23-wikipedia-everest.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-23-wikipedia-everest',
+  instruction: 'Visit https://en.wikipedia.org/wiki/Mount_Everest and confirm the page mentions "8,848".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/Mount_Everest' },
+        { kind: 'dom_text', selector: 'body', contains: '8,848' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Mount Everest height cited as 8,848 m. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-24-wikipedia-mariana-trench.ts
+++ b/tests/benchmark/webvoyager/tasks/task-24-wikipedia-mariana-trench.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-24-wikipedia-mariana-trench',
+  instruction: 'Visit https://en.wikipedia.org/wiki/Mariana_Trench and confirm the page mentions "deepest".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/Mariana_Trench' },
+        { kind: 'dom_text', selector: 'body', contains: 'deepest' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Mariana Trench described as deepest oceanic trench. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-25-wikipedia-eiffel-tower.ts
+++ b/tests/benchmark/webvoyager/tasks/task-25-wikipedia-eiffel-tower.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-25-wikipedia-eiffel-tower',
+  instruction: 'Visit https://en.wikipedia.org/wiki/Eiffel_Tower and confirm the page mentions "Paris".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/Eiffel_Tower' },
+        { kind: 'dom_text', selector: 'body', contains: 'Paris' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Eiffel Tower located in Paris. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-26-wikipedia-statue-of-liberty.ts
+++ b/tests/benchmark/webvoyager/tasks/task-26-wikipedia-statue-of-liberty.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-26-wikipedia-statue-of-liberty',
+  instruction: 'Visit https://en.wikipedia.org/wiki/Statue_of_Liberty and confirm the page mentions "New York".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/Statue_of_Liberty' },
+        { kind: 'dom_text', selector: 'body', contains: 'New York' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Statue of Liberty located in New York. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-27-wikipedia-internet-protocol.ts
+++ b/tests/benchmark/webvoyager/tasks/task-27-wikipedia-internet-protocol.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-27-wikipedia-internet-protocol',
+  instruction: 'Visit https://en.wikipedia.org/wiki/Internet_Protocol and confirm the page mentions "datagram".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/Internet_Protocol' },
+        { kind: 'dom_text', selector: 'body', contains: 'datagram' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Internet Protocol article mentions datagram. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-28-wikipedia-ascii.ts
+++ b/tests/benchmark/webvoyager/tasks/task-28-wikipedia-ascii.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-28-wikipedia-ascii',
+  instruction: 'Visit https://en.wikipedia.org/wiki/ASCII and confirm the page mentions "128".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/ASCII' },
+        { kind: 'dom_text', selector: 'body', contains: '128' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'ASCII character set described as 128 code points. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-29-wikipedia-pi.ts
+++ b/tests/benchmark/webvoyager/tasks/task-29-wikipedia-pi.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-29-wikipedia-pi',
+  instruction: 'Visit https://en.wikipedia.org/wiki/Pi and confirm the page mentions "3.14".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/Pi' },
+        { kind: 'dom_text', selector: 'body', contains: '3.14' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Pi article cites 3.14.... Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-30-wikipedia-utf8.ts
+++ b/tests/benchmark/webvoyager/tasks/task-30-wikipedia-utf8.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-30-wikipedia-utf8',
+  instruction: 'Visit https://en.wikipedia.org/wiki/UTF-8 and confirm the page mentions "variable-width".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/UTF-8' },
+        { kind: 'dom_text', selector: 'body', contains: 'variable-width' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'UTF-8 described as variable-width. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-31-wikipedia-tim-berners-lee.ts
+++ b/tests/benchmark/webvoyager/tasks/task-31-wikipedia-tim-berners-lee.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-31-wikipedia-tim-berners-lee',
+  instruction: 'Visit https://en.wikipedia.org/wiki/Tim_Berners-Lee and confirm the page mentions "World Wide Web".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/Tim_Berners-Lee' },
+        { kind: 'dom_text', selector: 'body', contains: 'World Wide Web' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Tim Berners-Lee credited with inventing the World Wide Web. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-32-wikipedia-rfc-editor.ts
+++ b/tests/benchmark/webvoyager/tasks/task-32-wikipedia-rfc-editor.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-32-wikipedia-rfc-editor',
+  instruction: 'Visit https://en.wikipedia.org/wiki/Request_for_Comments and confirm the page mentions "IETF".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/Request_for_Comments' },
+        { kind: 'dom_text', selector: 'body', contains: 'IETF' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC document series associated with IETF. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-33-rfc-2606-reserved.ts
+++ b/tests/benchmark/webvoyager/tasks/task-33-rfc-2606-reserved.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-33-rfc-2606-reserved',
+  instruction: 'Visit https://www.rfc-editor.org/rfc/rfc2606 and confirm the page mentions "example".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/www\\.rfc-editor\\.org\\/rfc\\/rfc2606' },
+        { kind: 'dom_text', selector: 'body', contains: 'example' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC 2606 lists example as a reserved TLD. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-34-rfc-2119-keywords.ts
+++ b/tests/benchmark/webvoyager/tasks/task-34-rfc-2119-keywords.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-34-rfc-2119-keywords',
+  instruction: 'Visit https://www.rfc-editor.org/rfc/rfc2119 and confirm the page mentions "MUST".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/www\\.rfc-editor\\.org\\/rfc\\/rfc2119' },
+        { kind: 'dom_text', selector: 'body', contains: 'MUST' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC 2119 defines MUST keyword. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-35-rfc-8259-json.ts
+++ b/tests/benchmark/webvoyager/tasks/task-35-rfc-8259-json.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-35-rfc-8259-json',
+  instruction: 'Visit https://www.rfc-editor.org/rfc/rfc8259 and confirm the page mentions "JavaScript Object Notation".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/www\\.rfc-editor\\.org\\/rfc\\/rfc8259' },
+        { kind: 'dom_text', selector: 'body', contains: 'JavaScript Object Notation' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC 8259 titled JavaScript Object Notation. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-36-rfc-9110-http.ts
+++ b/tests/benchmark/webvoyager/tasks/task-36-rfc-9110-http.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-36-rfc-9110-http',
+  instruction: 'Visit https://www.rfc-editor.org/rfc/rfc9110 and confirm the page mentions "HTTP Semantics".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/www\\.rfc-editor\\.org\\/rfc\\/rfc9110' },
+        { kind: 'dom_text', selector: 'body', contains: 'HTTP Semantics' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC 9110 titled HTTP Semantics. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-37-rfc-7231-http-methods.ts
+++ b/tests/benchmark/webvoyager/tasks/task-37-rfc-7231-http-methods.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-37-rfc-7231-http-methods',
+  instruction: 'Visit https://www.rfc-editor.org/rfc/rfc7231 and confirm the page mentions "method".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/www\\.rfc-editor\\.org\\/rfc\\/rfc7231' },
+        { kind: 'dom_text', selector: 'body', contains: 'method' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC 7231 defines HTTP methods. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-38-rfc-3986-uri.ts
+++ b/tests/benchmark/webvoyager/tasks/task-38-rfc-3986-uri.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-38-rfc-3986-uri',
+  instruction: 'Visit https://www.rfc-editor.org/rfc/rfc3986 and confirm the page mentions "Uniform Resource Identifier".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/www\\.rfc-editor\\.org\\/rfc\\/rfc3986' },
+        { kind: 'dom_text', selector: 'body', contains: 'Uniform Resource Identifier' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC 3986 defines URI syntax. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-39-rfc-5321-smtp.ts
+++ b/tests/benchmark/webvoyager/tasks/task-39-rfc-5321-smtp.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-39-rfc-5321-smtp',
+  instruction: 'Visit https://www.rfc-editor.org/rfc/rfc5321 and confirm the page mentions "Simple Mail Transfer Protocol".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/www\\.rfc-editor\\.org\\/rfc\\/rfc5321' },
+        { kind: 'dom_text', selector: 'body', contains: 'Simple Mail Transfer Protocol' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC 5321 defines SMTP. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-40-rfc-6749-oauth.ts
+++ b/tests/benchmark/webvoyager/tasks/task-40-rfc-6749-oauth.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-40-rfc-6749-oauth',
+  instruction: 'Visit https://www.rfc-editor.org/rfc/rfc6749 and confirm the page mentions "OAuth 2.0".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/www\\.rfc-editor\\.org\\/rfc\\/rfc6749' },
+        { kind: 'dom_text', selector: 'body', contains: 'OAuth 2.0' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC 6749 defines OAuth 2.0. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-41-mdn-fetch.ts
+++ b/tests/benchmark/webvoyager/tasks/task-41-mdn-fetch.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-41-mdn-fetch',
+  instruction: 'Visit https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API and confirm the page mentions "Fetch API".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/developer\\.mozilla\\.org\\/en-US\\/docs\\/Web\\/API\\/Fetch_API' },
+        { kind: 'dom_text', selector: 'body', contains: 'Fetch API' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'MDN Fetch API reference. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-42-mdn-array-map.ts
+++ b/tests/benchmark/webvoyager/tasks/task-42-mdn-array-map.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-42-mdn-array-map',
+  instruction: 'Visit https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map and confirm the page mentions "map".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/developer\\.mozilla\\.org\\/en-US\\/docs\\/Web\\/JavaScript\\/Reference\\/Global_Objects\\/Array\\/map' },
+        { kind: 'dom_text', selector: 'body', contains: 'map' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'MDN Array.prototype.map reference. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-43-mdn-array-filter.ts
+++ b/tests/benchmark/webvoyager/tasks/task-43-mdn-array-filter.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-43-mdn-array-filter',
+  instruction: 'Visit https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter and confirm the page mentions "filter".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/developer\\.mozilla\\.org\\/en-US\\/docs\\/Web\\/JavaScript\\/Reference\\/Global_Objects\\/Array\\/filter' },
+        { kind: 'dom_text', selector: 'body', contains: 'filter' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'MDN Array.prototype.filter reference. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-44-mdn-promise-then.ts
+++ b/tests/benchmark/webvoyager/tasks/task-44-mdn-promise-then.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-44-mdn-promise-then',
+  instruction: 'Visit https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then and confirm the page mentions "then".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/developer\\.mozilla\\.org\\/en-US\\/docs\\/Web\\/JavaScript\\/Reference\\/Global_Objects\\/Promise\\/then' },
+        { kind: 'dom_text', selector: 'body', contains: 'then' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'MDN Promise.prototype.then reference. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-45-mdn-async-await.ts
+++ b/tests/benchmark/webvoyager/tasks/task-45-mdn-async-await.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-45-mdn-async-await',
+  instruction: 'Visit https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await and confirm the page mentions "await".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/developer\\.mozilla\\.org\\/en-US\\/docs\\/Web\\/JavaScript\\/Reference\\/Operators\\/await' },
+        { kind: 'dom_text', selector: 'body', contains: 'await' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'MDN await operator reference. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-46-mdn-css-grid.ts
+++ b/tests/benchmark/webvoyager/tasks/task-46-mdn-css-grid.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-46-mdn-css-grid',
+  instruction: 'Visit https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout and confirm the page mentions "grid".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/developer\\.mozilla\\.org\\/en-US\\/docs\\/Web\\/CSS\\/CSS_grid_layout' },
+        { kind: 'dom_text', selector: 'body', contains: 'grid' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'MDN CSS Grid Layout reference. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-47-mdn-css-flexbox.ts
+++ b/tests/benchmark/webvoyager/tasks/task-47-mdn-css-flexbox.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-47-mdn-css-flexbox',
+  instruction: 'Visit https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flexible_box_layout and confirm the page mentions "flex".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/developer\\.mozilla\\.org\\/en-US\\/docs\\/Web\\/CSS\\/CSS_flexible_box_layout' },
+        { kind: 'dom_text', selector: 'body', contains: 'flex' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'MDN CSS Flexbox reference. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-48-mdn-html-img.ts
+++ b/tests/benchmark/webvoyager/tasks/task-48-mdn-html-img.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-48-mdn-html-img',
+  instruction: 'Visit https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img and confirm the page mentions "img".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/developer\\.mozilla\\.org\\/en-US\\/docs\\/Web\\/HTML\\/Element\\/img' },
+        { kind: 'dom_text', selector: 'body', contains: 'img' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'MDN HTML img element reference. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-49-tc39-ecma262-syntax.ts
+++ b/tests/benchmark/webvoyager/tasks/task-49-tc39-ecma262-syntax.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-49-tc39-ecma262-syntax',
+  instruction: 'Visit https://tc39.es/ecma262/ and confirm the page mentions "ECMAScript".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/tc39\\.es\\/ecma262\\/' },
+        { kind: 'dom_text', selector: 'body', contains: 'ECMAScript' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'TC39 ECMAScript spec home. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-50-tc39-proposals.ts
+++ b/tests/benchmark/webvoyager/tasks/task-50-tc39-proposals.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-50-tc39-proposals',
+  instruction: 'Visit https://github.com/tc39/proposals and confirm the page mentions "proposals".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/github\\.com\\/tc39\\/proposals' },
+        { kind: 'dom_text', selector: 'body', contains: 'proposals' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'TC39 proposals repo. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-51-whatwg-html-spec.ts
+++ b/tests/benchmark/webvoyager/tasks/task-51-whatwg-html-spec.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-51-whatwg-html-spec',
+  instruction: 'Visit https://html.spec.whatwg.org/ and confirm the page mentions "HTML".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/html\\.spec\\.whatwg\\.org\\/' },
+        { kind: 'dom_text', selector: 'body', contains: 'HTML' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'WHATWG HTML living standard. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-52-whatwg-fetch-spec.ts
+++ b/tests/benchmark/webvoyager/tasks/task-52-whatwg-fetch-spec.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-52-whatwg-fetch-spec',
+  instruction: 'Visit https://fetch.spec.whatwg.org/ and confirm the page mentions "Fetch".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/fetch\\.spec\\.whatwg\\.org\\/' },
+        { kind: 'dom_text', selector: 'body', contains: 'Fetch' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'WHATWG Fetch standard. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-53-w3c-css-spec.ts
+++ b/tests/benchmark/webvoyager/tasks/task-53-w3c-css-spec.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-53-w3c-css-spec',
+  instruction: 'Visit https://www.w3.org/Style/CSS/ and confirm the page mentions "CSS".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/www\\.w3\\.org\\/Style\\/CSS\\/' },
+        { kind: 'dom_text', selector: 'body', contains: 'CSS' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'W3C CSS home. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-54-rust-string-trim.ts
+++ b/tests/benchmark/webvoyager/tasks/task-54-rust-string-trim.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-54-rust-string-trim',
+  instruction: 'Visit https://doc.rust-lang.org/std/string/struct.String.html and confirm the page mentions "String".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/doc\\.rust-lang\\.org\\/std\\/string\\/struct\\.String\\.html' },
+        { kind: 'dom_text', selector: 'body', contains: 'String' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Rust std::string::String docs. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-55-rust-option-enum.ts
+++ b/tests/benchmark/webvoyager/tasks/task-55-rust-option-enum.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-55-rust-option-enum',
+  instruction: 'Visit https://doc.rust-lang.org/std/option/enum.Option.html and confirm the page mentions "Option".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/doc\\.rust-lang\\.org\\/std\\/option\\/enum\\.Option\\.html' },
+        { kind: 'dom_text', selector: 'body', contains: 'Option' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Rust std::option::Option docs. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-56-rust-result-enum.ts
+++ b/tests/benchmark/webvoyager/tasks/task-56-rust-result-enum.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-56-rust-result-enum',
+  instruction: 'Visit https://doc.rust-lang.org/std/result/enum.Result.html and confirm the page mentions "Result".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/doc\\.rust-lang\\.org\\/std\\/result\\/enum\\.Result\\.html' },
+        { kind: 'dom_text', selector: 'body', contains: 'Result' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Rust std::result::Result docs. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-57-rust-vec.ts
+++ b/tests/benchmark/webvoyager/tasks/task-57-rust-vec.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-57-rust-vec',
+  instruction: 'Visit https://doc.rust-lang.org/std/vec/struct.Vec.html and confirm the page mentions "Vec".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/doc\\.rust-lang\\.org\\/std\\/vec\\/struct\\.Vec\\.html' },
+        { kind: 'dom_text', selector: 'body', contains: 'Vec' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Rust std::vec::Vec docs. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-58-python-len-builtin.ts
+++ b/tests/benchmark/webvoyager/tasks/task-58-python-len-builtin.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-58-python-len-builtin',
+  instruction: 'Visit https://docs.python.org/3/library/functions.html and confirm the page mentions "len".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/docs\\.python\\.org\\/3\\/library\\/functions\\.html' },
+        { kind: 'dom_text', selector: 'body', contains: 'len' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Python built-in functions reference. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-59-python-list-stdtypes.ts
+++ b/tests/benchmark/webvoyager/tasks/task-59-python-list-stdtypes.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-59-python-list-stdtypes',
+  instruction: 'Visit https://docs.python.org/3/library/stdtypes.html and confirm the page mentions "list".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/docs\\.python\\.org\\/3\\/library\\/stdtypes\\.html' },
+        { kind: 'dom_text', selector: 'body', contains: 'list' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Python stdtypes reference (list). Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-60-python-dict-stdtypes.ts
+++ b/tests/benchmark/webvoyager/tasks/task-60-python-dict-stdtypes.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-60-python-dict-stdtypes',
+  instruction: 'Visit https://docs.python.org/3/library/stdtypes.html and confirm the page mentions "dict".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/docs\\.python\\.org\\/3\\/library\\/stdtypes\\.html' },
+        { kind: 'dom_text', selector: 'body', contains: 'dict' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Python stdtypes reference (dict). Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-61-python-pep-8.ts
+++ b/tests/benchmark/webvoyager/tasks/task-61-python-pep-8.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-61-python-pep-8',
+  instruction: 'Visit https://peps.python.org/pep-0008/ and confirm the page mentions "Style Guide".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/peps\\.python\\.org\\/pep-0008\\/' },
+        { kind: 'dom_text', selector: 'body', contains: 'Style Guide' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'PEP 8 Style Guide. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;


### PR DESCRIPTION
## Summary
- Expands `tests/benchmark/webvoyager/tasks/` from 18 to **61** tasks (the issue mandate is ≥60). 43 new task files added.
- Sources are license-safe + low-volatility: 3 RFC-2606 example domains, 11 Wikipedia article facts, 8 RFCs (immutable once published), 8 MDN reference pages, 2 TC39/ECMAScript pages, 3 W3C/WHATWG specs, 4 Rust std pages, 4 Python docs pages.
- Every new task ships with `pending: true` — no transcript recorded yet. The mock runner skips them; `baseline.json` does not list them. The next-session real-LLM run records transcripts and flips `pending` off.
- Generator: `scripts/bench/generate-webvoyager-tasks.mjs` — single manifest, deterministic output, easy to extend.

## Why
Issue #1257 success criterion #1: "expand the corpus from ~10 to a fixed 50–100 tasks". This PR sets up the corpus shape that the Sprint-2 matrix runner (PR-12) and the real-LLM baseline (PR-14) consume.

## What's in each task
```ts
{
  name: 'task-NN-<slug>',
  instruction: 'Visit <url> and confirm the page mentions "<text>".',
  contract: {
    postconditions: {
      kind: 'and',
      children: [
        { kind: 'url', pattern: '^<escaped url>' },
        { kind: 'dom_text', selector: 'body', contains: '<text>' },
      ],
    },
  },
  timeout_ms: 90_000,
  pending: true,                 // ← honest flag; flips when transcript recorded
  rationale: '<one-line justification>',
}
```

## Sources by category
| Category | Count | Examples |
|---|---|---|
| RFC-2606 example domains | 3 | example.com / .org / .net |
| Wikipedia article facts | 11 | Speed of light, Everest, ASCII, Tim Berners-Lee, ... |
| RFCs | 8 | RFC 2606 / 2119 / 8259 / 9110 / 7231 / 3986 / 5321 / 6749 |
| MDN reference | 8 | Fetch API, Array.map, CSS Grid, ... |
| TC39 / ECMAScript | 2 | ECMA-262 spec, proposals |
| W3C / WHATWG | 3 | HTML living standard, Fetch standard, CSS home |
| Rust std | 4 | String, Option, Result, Vec |
| Python docs | 4 | built-ins, stdtypes (list, dict), PEP 8 |

## Verify
- `npx jest tests/benchmark/webvoyager/` ⇒ 76/76 passing (75 existing + 1 new regression guard for the Sprint-2 expansion)
- `npx tsc --noEmit` ⇒ exit 0 (every task type-checks against `WebVoyagerTask`)
- 61 task files under `tests/benchmark/webvoyager/tasks/`

## Test plan
- [x] Build green
- [x] WebVoyager test suite green (76/76)
- [x] Every new task is `pending: true` so mock runner skips it
- [ ] CI green on `develop`
- [ ] Real transcripts recorded in the next session (PR-12 wires the library matrix; PR-14 records and freezes `baseline.json`)

Part of Epic #1254 → Sprint 2 PR-11 of 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)