### PR TITLE
feat(benchmark): WebVoyager library matrix runner + dry-run gate (#1257)

### DIFF
--- a/scripts/bench/generate-webvoyager-tasks.mjs
+++ b/scripts/bench/generate-webvoyager-tasks.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Generate WebVoyager task files for the Agent Task Success axis (#1257).
+ *
+ * Emits TypeScript task files under
+ * `tests/benchmark/webvoyager/tasks/task-NN-<slug>.ts`. Each generated task
+ * is shipped with `pending: true` until a transcript is recorded — the
+ * mock runner skips pending tasks and the baseline.json only lists tasks
+ * whose transcript has been frozen. This keeps the corpus honest: structural
+ * schema validation passes today, real LLM-driven measurements record the
+ * transcripts in the next session.
+ *
+ * Run:
+ *
+ *   node scripts/bench/generate-webvoyager-tasks.mjs
+ *
+ * Sources are license-safe / low-volatility: RFC-2606 example domains,
+ * Wikipedia article facts that have been stable for years, MDN reference
+ * pages, IETF RFCs, WHATWG/W3C specs, TC39 ECMAScript spec, Rust std docs,
+ * Python docs. Volatile sources (live weather APIs, search engines, social
+ * sites) are deliberately excluded so site drift doesn't pollute the
+ * benchmark headline.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const TASKS_DIR = path.join(REPO_ROOT, 'tests', 'benchmark', 'webvoyager', 'tasks');
+
+/**
+ * Manifest of 42 new tasks (existing 18 → 60 total). Each entry generates one
+ * task file. The `volatile` flag is for the per-source-volatility annotation
+ * recorded in the rationale; the actual `volatile` task tag in the bucket
+ * sense uses a name suffix (`-volatile`) that the runner inspects.
+ *
+ * Keep this list license-safe: RFC-2606 example domains, public reference
+ * docs (RFC, W3C, WHATWG, TC39), public Wikipedia article facts, MDN.
+ */
+const TASKS = [
+  // ---- example domains (RFC-2606 reserved) — smoke ----
+  { slug: 'example-com-h1', url: 'https://example.com', text: 'Example Domain', label: 'h1 contains Example Domain on example.com' },
+  { slug: 'example-org-h1', url: 'https://example.org', text: 'Example Domain', label: 'h1 contains Example Domain on example.org' },
+  { slug: 'example-net-h1', url: 'https://example.net', text: 'Example Domain', label: 'h1 contains Example Domain on example.net' },
+
+  // ---- Wikipedia (high-stability article facts) ----
+  { slug: 'wikipedia-light-speed', url: 'https://en.wikipedia.org/wiki/Speed_of_light', text: '299792458', label: 'Speed-of-light article cites 299,792,458 m/s' },
+  { slug: 'wikipedia-everest', url: 'https://en.wikipedia.org/wiki/Mount_Everest', text: '8,848', label: 'Mount Everest height cited as 8,848 m' },
+  { slug: 'wikipedia-mariana-trench', url: 'https://en.wikipedia.org/wiki/Mariana_Trench', text: 'deepest', label: 'Mariana Trench described as deepest oceanic trench' },
+  { slug: 'wikipedia-eiffel-tower', url: 'https://en.wikipedia.org/wiki/Eiffel_Tower', text: 'Paris', label: 'Eiffel Tower located in Paris' },
+  { slug: 'wikipedia-statue-of-liberty', url: 'https://en.wikipedia.org/wiki/Statue_of_Liberty', text: 'New York', label: 'Statue of Liberty located in New York' },
+  { slug: 'wikipedia-internet-protocol', url: 'https://en.wikipedia.org/wiki/Internet_Protocol', text: 'datagram', label: 'Internet Protocol article mentions datagram' },
+  { slug: 'wikipedia-ascii', url: 'https://en.wikipedia.org/wiki/ASCII', text: '128', label: 'ASCII character set described as 128 code points' },
+  { slug: 'wikipedia-pi', url: 'https://en.wikipedia.org/wiki/Pi', text: '3.14', label: 'Pi article cites 3.14...' },
+  { slug: 'wikipedia-utf8', url: 'https://en.wikipedia.org/wiki/UTF-8', text: 'variable-width', label: 'UTF-8 described as variable-width' },
+  { slug: 'wikipedia-tim-berners-lee', url: 'https://en.wikipedia.org/wiki/Tim_Berners-Lee', text: 'World Wide Web', label: 'Tim Berners-Lee credited with inventing the World Wide Web' },
+  { slug: 'wikipedia-rfc-editor', url: 'https://en.wikipedia.org/wiki/Request_for_Comments', text: 'IETF', label: 'RFC document series associated with IETF' },
+
+  // ---- RFCs (immutable once published) ----
+  { slug: 'rfc-2606-reserved', url: 'https://www.rfc-editor.org/rfc/rfc2606', text: 'example', label: 'RFC 2606 lists example as a reserved TLD' },
+  { slug: 'rfc-2119-keywords', url: 'https://www.rfc-editor.org/rfc/rfc2119', text: 'MUST', label: 'RFC 2119 defines MUST keyword' },
+  { slug: 'rfc-8259-json', url: 'https://www.rfc-editor.org/rfc/rfc8259', text: 'JavaScript Object Notation', label: 'RFC 8259 titled JavaScript Object Notation' },
+  { slug: 'rfc-9110-http', url: 'https://www.rfc-editor.org/rfc/rfc9110', text: 'HTTP Semantics', label: 'RFC 9110 titled HTTP Semantics' },
+  { slug: 'rfc-7231-http-methods', url: 'https://www.rfc-editor.org/rfc/rfc7231', text: 'method', label: 'RFC 7231 defines HTTP methods' },
+  { slug: 'rfc-3986-uri', url: 'https://www.rfc-editor.org/rfc/rfc3986', text: 'Uniform Resource Identifier', label: 'RFC 3986 defines URI syntax' },
+  { slug: 'rfc-5321-smtp', url: 'https://www.rfc-editor.org/rfc/rfc5321', text: 'Simple Mail Transfer Protocol', label: 'RFC 5321 defines SMTP' },
+  { slug: 'rfc-6749-oauth', url: 'https://www.rfc-editor.org/rfc/rfc6749', text: 'OAuth 2.0', label: 'RFC 6749 defines OAuth 2.0' },
+
+  // ---- MDN (reference pages, stable URLs) ----
+  { slug: 'mdn-fetch', url: 'https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API', text: 'Fetch API', label: 'MDN Fetch API reference' },
+  { slug: 'mdn-array-map', url: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map', text: 'map', label: 'MDN Array.prototype.map reference' },
+  { slug: 'mdn-array-filter', url: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter', text: 'filter', label: 'MDN Array.prototype.filter reference' },
+  { slug: 'mdn-promise-then', url: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then', text: 'then', label: 'MDN Promise.prototype.then reference' },
+  { slug: 'mdn-async-await', url: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await', text: 'await', label: 'MDN await operator reference' },
+  { slug: 'mdn-css-grid', url: 'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout', text: 'grid', label: 'MDN CSS Grid Layout reference' },
+  { slug: 'mdn-css-flexbox', url: 'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flexible_box_layout', text: 'flex', label: 'MDN CSS Flexbox reference' },
+  { slug: 'mdn-html-img', url: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img', text: 'img', label: 'MDN HTML img element reference' },
+
+  // ---- TC39 / ECMAScript ----
+  { slug: 'tc39-ecma262-syntax', url: 'https://tc39.es/ecma262/', text: 'ECMAScript', label: 'TC39 ECMAScript spec home' },
+  { slug: 'tc39-proposals', url: 'https://github.com/tc39/proposals', text: 'proposals', label: 'TC39 proposals repo' },
+
+  // ---- W3C / WHATWG ----
+  { slug: 'whatwg-html-spec', url: 'https://html.spec.whatwg.org/', text: 'HTML', label: 'WHATWG HTML living standard' },
+  { slug: 'whatwg-fetch-spec', url: 'https://fetch.spec.whatwg.org/', text: 'Fetch', label: 'WHATWG Fetch standard' },
+  { slug: 'w3c-css-spec', url: 'https://www.w3.org/Style/CSS/', text: 'CSS', label: 'W3C CSS home' },
+
+  // ---- Rust std ----
+  { slug: 'rust-string-trim', url: 'https://doc.rust-lang.org/std/string/struct.String.html', text: 'String', label: 'Rust std::string::String docs' },
+  { slug: 'rust-option-enum', url: 'https://doc.rust-lang.org/std/option/enum.Option.html', text: 'Option', label: 'Rust std::option::Option docs' },
+  { slug: 'rust-result-enum', url: 'https://doc.rust-lang.org/std/result/enum.Result.html', text: 'Result', label: 'Rust std::result::Result docs' },
+  { slug: 'rust-vec', url: 'https://doc.rust-lang.org/std/vec/struct.Vec.html', text: 'Vec', label: 'Rust std::vec::Vec docs' },
+
+  // ---- Python docs ----
+  { slug: 'python-len-builtin', url: 'https://docs.python.org/3/library/functions.html', text: 'len', label: 'Python built-in functions reference' },
+  { slug: 'python-list-stdtypes', url: 'https://docs.python.org/3/library/stdtypes.html', text: 'list', label: 'Python stdtypes reference (list)' },
+  { slug: 'python-dict-stdtypes', url: 'https://docs.python.org/3/library/stdtypes.html', text: 'dict', label: 'Python stdtypes reference (dict)' },
+  { slug: 'python-pep-8', url: 'https://peps.python.org/pep-0008/', text: 'Style Guide', label: 'PEP 8 Style Guide' },
+];
+
+const STARTING_INDEX = 19; // existing tasks are task-01 .. task-18
+
+function pad(n) {
+  return String(n).padStart(2, '0');
+}
+
+function buildTaskTs(task, index) {
+  const name = `task-${pad(index)}-${task.slug}`;
+  // Escape the URL for the regex pattern (escape dot + slashes).
+  const escapedUrl = task.url
+    .replace(/[.\\?+*$^()[\]{}|]/g, (m) => `\\\\${m}`)
+    .replace(/\//g, '\\\\/');
+  const escapedText = task.text.replace(/[\\'`]/g, '\\$&');
+  const rationale = `${task.label}. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.`;
+  return `import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: '${name}',
+  instruction: 'Visit ${task.url} and confirm the page mentions "${task.text}".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^${escapedUrl}' },
+        { kind: 'dom_text', selector: 'body', contains: '${escapedText}' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    '${rationale}',
+};
+
+export default task;
+`;
+}
+
+function main() {
+  let written = 0;
+  for (let i = 0; i < TASKS.length; i++) {
+    const index = STARTING_INDEX + i;
+    const task = TASKS[i];
+    const name = `task-${pad(index)}-${task.slug}`;
+    const filename = `${name}.ts`;
+    const filepath = path.join(TASKS_DIR, filename);
+    if (fs.existsSync(filepath)) {
+      process.stderr.write(`Skip (already exists): ${filename}\n`);
+      continue;
+    }
+    fs.writeFileSync(filepath, buildTaskTs(task, index));
+    written += 1;
+    process.stderr.write(`Wrote ${filename}\n`);
+  }
+  process.stderr.write(`\nGenerated ${written} new task files (existing kept). Target total: ${STARTING_INDEX - 1 + TASKS.length}.\n`);
+}
+
+main();

--- a/tests/benchmark/webvoyager/llm/library-routing.test.ts
+++ b/tests/benchmark/webvoyager/llm/library-routing.test.ts
@@ -1,0 +1,75 @@
+/// <reference types="jest" />
+
+import {
+  WEBVOYAGER_LIBRARIES,
+  LIBRARY_ROUTING,
+  projectCost,
+  formatProjection,
+} from './library-routing';
+
+describe('WebVoyager library routing', () => {
+  test('exposes the three Issue #1257 libraries in stable order', () => {
+    expect(WEBVOYAGER_LIBRARIES).toEqual(['openchrome', 'playwright-mcp', 'browser-use']);
+  });
+
+  test('every library has a routing entry with a non-empty pin + note', () => {
+    for (const lib of WEBVOYAGER_LIBRARIES) {
+      const routing = LIBRARY_ROUTING[lib];
+      expect(routing.library).toBe(lib);
+      expect(routing.competitorPin.length).toBeGreaterThan(0);
+      expect(routing.note.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('only openchrome is wired today; the other two ship as scaffolds', () => {
+    expect(LIBRARY_ROUTING.openchrome.nativeLoopWired).toBe(true);
+    expect(LIBRARY_ROUTING['playwright-mcp'].nativeLoopWired).toBe(false);
+    expect(LIBRARY_ROUTING['browser-use'].nativeLoopWired).toBe(false);
+  });
+});
+
+describe('projectCost', () => {
+  test('uses the WEBVOYAGER_BUDGET cap by default and multiplies through', () => {
+    const p = projectCost({ taskCount: 60, libraries: WEBVOYAGER_LIBRARIES, repetitions: 10 });
+    expect(p.taskCount).toBe(60);
+    expect(p.librariesRun).toBe(3);
+    expect(p.repetitions).toBe(10);
+    expect(p.maxUsdPerTask).toBe(0.5);
+    expect(p.worstCaseUsd).toBe(60 * 3 * 10 * 0.5);
+  });
+
+  test('reports only wired libraries as cells that would actually run', () => {
+    const p = projectCost({ taskCount: 60, libraries: WEBVOYAGER_LIBRARIES, repetitions: 10 });
+    // Only openchrome is wired today; would-run = 60 * 10 = 600 cells.
+    expect(p.cellsWouldRunTotal).toBe(600);
+    expect(p.perLibrary.filter((l) => l.wired).length).toBe(1);
+    expect(p.perLibrary.filter((l) => !l.wired).map((l) => l.library))
+      .toEqual(expect.arrayContaining(['playwright-mcp', 'browser-use']));
+  });
+
+  test('honors a maxUsdPerTask override', () => {
+    const p = projectCost({ taskCount: 10, libraries: ['openchrome'], repetitions: 5, maxUsdPerTask: 0.1 });
+    expect(p.maxUsdPerTask).toBe(0.1);
+    expect(p.worstCaseUsd).toBe(10 * 1 * 5 * 0.1);
+  });
+
+  test('rejects empty libraries list', () => {
+    expect(() => projectCost({ taskCount: 60, libraries: [], repetitions: 10 })).toThrow(/libraries/);
+  });
+
+  test('rejects non-integer reps', () => {
+    expect(() => projectCost({ taskCount: 60, libraries: WEBVOYAGER_LIBRARIES, repetitions: 0 }))
+      .toThrow(/repetitions/);
+    expect(() => projectCost({ taskCount: 60, libraries: WEBVOYAGER_LIBRARIES, repetitions: 1.5 }))
+      .toThrow(/repetitions/);
+  });
+
+  test('formatProjection emits a no-API-call notice so the operator cannot mistake it for a real run', () => {
+    const p = projectCost({ taskCount: 60, libraries: WEBVOYAGER_LIBRARIES, repetitions: 10 });
+    const text = formatProjection(p);
+    expect(text).toContain('--dry-run');
+    expect(text).toContain('No API calls');
+    expect(text).toContain('OPENCHROME_BENCH_REAL=1');
+    expect(text).toContain('worst-case total USD');
+  });
+});

--- a/tests/benchmark/webvoyager/llm/library-routing.ts
+++ b/tests/benchmark/webvoyager/llm/library-routing.ts
@@ -1,0 +1,168 @@
+/**
+ * Library matrix routing + dry-run cost projection for the Agent Task Success
+ * axis (#1257).
+ *
+ * The WebVoyager runner today drives OpenChrome through a Claude tool-calling
+ * loop. Issue #1257 expands that to a three-library matrix — OpenChrome,
+ * playwright-mcp, browser-use (native agent loop via the Python bridge from
+ * #1280). Each library runs against the same task corpus + same LLM model,
+ * so the only variable is the tool surface (or, for browser-use, the native
+ * agent's planning loop). This module is the small uniform abstraction over
+ * the three.
+ *
+ * The real per-library loops swap in next session. Today the module ships
+ * the routing identity and the cost projection so PR-12 can land
+ * infrastructure-only — no API calls, no surprise budget hits.
+ */
+
+import { WEBVOYAGER_BUDGET } from './budget';
+
+/**
+ * The three libraries Issue #1257 requires for the headline native-mode
+ * comparison. A passive-tool mode (Claude + each library's tool surface) is
+ * a separate axis that lands in PR-13.
+ */
+export type WebVoyagerLibrary = 'openchrome' | 'playwright-mcp' | 'browser-use';
+
+export const WEBVOYAGER_LIBRARIES: readonly WebVoyagerLibrary[] = [
+  'openchrome',
+  'playwright-mcp',
+  'browser-use',
+];
+
+export interface LibraryRouting {
+  library: WebVoyagerLibrary;
+  /**
+   * Per-library identity label used in the result envelope's `competitors`
+   * pin block. Wider than the library name so the report can distinguish
+   * "openchrome (native MCP)" from a future "openchrome (passive tool)".
+   */
+  competitorPin: string;
+  /**
+   * True when the library's native-mode loop is wired to a real driver. Today
+   * only `openchrome` is wired (re-uses the existing Claude tool-call loop);
+   * playwright-mcp and browser-use ship as scaffolds with a clear "not yet
+   * wired" surface that the runner displays as a skip annotation.
+   */
+  nativeLoopWired: boolean;
+  /** One-line note for the report. */
+  note: string;
+}
+
+/** Today's wiring status — updated as each library's loop lands. */
+export const LIBRARY_ROUTING: Record<WebVoyagerLibrary, LibraryRouting> = {
+  openchrome: {
+    library: 'openchrome',
+    competitorPin: 'OpenChrome (native MCP)',
+    nativeLoopWired: true,
+    note: 'OpenChrome MCP server driven by Claude tool-calling. Existing claude-adapter.ts.',
+  },
+  'playwright-mcp': {
+    library: 'playwright-mcp',
+    competitorPin: 'playwright-mcp (native MCP)',
+    nativeLoopWired: false,
+    note: 'playwright-mcp MCP server driven by the same Claude tool-calling loop. Loop wiring lands next session.',
+  },
+  'browser-use': {
+    library: 'browser-use',
+    competitorPin: 'browser-use (native agent loop)',
+    nativeLoopWired: false,
+    note: 'browser-use Python agent loop with the pinned Claude model via the #1280 bridge. Loop wiring lands next session.',
+  },
+};
+
+export interface DryRunInputs {
+  taskCount: number;
+  libraries: readonly WebVoyagerLibrary[];
+  /** Repetitions per task per library (issue #1257 minimum N=10). */
+  repetitions: number;
+  /** Optional override; defaults to the WEBVOYAGER_BUDGET cap. */
+  maxUsdPerTask?: number;
+}
+
+export interface DryRunProjection {
+  taskCount: number;
+  librariesRun: number;
+  repetitions: number;
+  /** Per-task USD cap from the budget (or override). */
+  maxUsdPerTask: number;
+  /** Worst-case total USD: taskCount × librariesRun × repetitions × cap. */
+  worstCaseUsd: number;
+  /** Per-library breakdown of "cells that would actually run today". */
+  perLibrary: Array<{
+    library: WebVoyagerLibrary;
+    wired: boolean;
+    cellsWouldRun: number;
+    note: string;
+  }>;
+  /** Sum of cells that would actually issue API calls if --dry-run is dropped. */
+  cellsWouldRunTotal: number;
+}
+
+/**
+ * Project the worst-case dollar exposure for a planned real-LLM run. The
+ * runner refuses to issue any API call when `--dry-run` is set; this
+ * projection is the only output of that mode so the operator can decide
+ * whether to lift the gate.
+ *
+ * `worstCaseUsd` assumes every task hits the per-task USD cap. In practice
+ * tasks abort early on contract pass or budget exhaustion, so the realized
+ * spend is typically a fraction of this number — but the worst case is the
+ * number the operator must be ready to authorize.
+ */
+export function projectCost(inputs: DryRunInputs): DryRunProjection {
+  if (!Number.isInteger(inputs.taskCount) || inputs.taskCount < 0) {
+    throw new Error(`taskCount must be a non-negative integer, got ${inputs.taskCount}`);
+  }
+  if (!Number.isInteger(inputs.repetitions) || inputs.repetitions < 1) {
+    throw new Error(`repetitions must be a positive integer, got ${inputs.repetitions}`);
+  }
+  if (inputs.libraries.length === 0) {
+    throw new Error('libraries must be non-empty');
+  }
+  const cap = inputs.maxUsdPerTask ?? WEBVOYAGER_BUDGET.max_usd_per_task;
+  if (!Number.isFinite(cap) || cap <= 0) {
+    throw new Error(`maxUsdPerTask must be > 0, got ${cap}`);
+  }
+  const perLibrary = inputs.libraries.map((library) => {
+    const routing = LIBRARY_ROUTING[library];
+    return {
+      library,
+      wired: routing.nativeLoopWired,
+      cellsWouldRun: routing.nativeLoopWired ? inputs.taskCount * inputs.repetitions : 0,
+      note: routing.note,
+    };
+  });
+  const cellsWouldRunTotal = perLibrary.reduce((s, l) => s + l.cellsWouldRun, 0);
+  const worstCaseUsd = inputs.taskCount * inputs.libraries.length * inputs.repetitions * cap;
+  return {
+    taskCount: inputs.taskCount,
+    librariesRun: inputs.libraries.length,
+    repetitions: inputs.repetitions,
+    maxUsdPerTask: cap,
+    worstCaseUsd,
+    perLibrary,
+    cellsWouldRunTotal,
+  };
+}
+
+/** Format a dry-run projection as a human-readable ASCII block. */
+export function formatProjection(p: DryRunProjection): string {
+  const lines = [
+    'WebVoyager dry-run cost projection (#1257)',
+    `  tasks                  : ${p.taskCount}`,
+    `  libraries              : ${p.librariesRun} (${p.perLibrary.map((l) => l.library).join(', ')})`,
+    `  reps per (task,lib)    : ${p.repetitions}`,
+    `  max USD per task cap   : $${p.maxUsdPerTask.toFixed(2)}`,
+    `  worst-case total USD   : $${p.worstCaseUsd.toFixed(2)}`,
+    `  cells that would run   : ${p.cellsWouldRunTotal} (rest are scaffolded, no API call)`,
+    '',
+    'Per-library:',
+  ];
+  for (const l of p.perLibrary) {
+    lines.push(`  ${l.library.padEnd(15)} wired=${String(l.wired).padEnd(5)} would-run=${l.cellsWouldRun}  ${l.note}`);
+  }
+  lines.push('');
+  lines.push('No API calls are made in --dry-run mode. To proceed, drop --dry-run and set OPENCHROME_BENCH_REAL=1.');
+  return lines.join('\n');
+}

--- a/tests/benchmark/webvoyager/runner.ts
+++ b/tests/benchmark/webvoyager/runner.ts
@@ -21,6 +21,13 @@ import type { EvalContext } from '../../../src/contracts/eval-context';
 import { runMockTask } from './llm/mock-adapter';
 import { renderMarkdown } from './report';
 import { WEBVOYAGER_BUDGET } from './llm/budget';
+import {
+  WEBVOYAGER_LIBRARIES,
+  WebVoyagerLibrary,
+  LIBRARY_ROUTING,
+  projectCost,
+  formatProjection,
+} from './llm/library-routing';
 import type {
   Baseline,
   BenchReport,
@@ -37,10 +44,34 @@ type AdapterName = 'mock' | 'claude';
 interface CliOptions {
   adapter: AdapterName;
   taskFilter?: string;
+  /**
+   * Library matrix selection (#1257). Today only openchrome's native loop is
+   * wired; selecting playwright-mcp or browser-use surfaces a clear skip
+   * notice when --dry-run is omitted. The flag exists today so PR-12 can
+   * land the routing + dry-run gate without touching the adapter dispatch.
+   */
+  library: WebVoyagerLibrary;
+  /**
+   * --dry-run: print the cost projection and exit 0 WITHOUT making any LLM
+   * API call. The runner refuses to run real tasks in this mode regardless
+   * of OPENCHROME_BENCH_REAL.
+   */
+  dryRun: boolean;
+  /** Repetitions per task; issue #1257 mandates N >= 10 for native-mode runs. */
+  repetitions: number;
+}
+
+function isLibrary(v: string): v is WebVoyagerLibrary {
+  return (WEBVOYAGER_LIBRARIES as readonly string[]).includes(v);
 }
 
 function parseArgs(argv: string[]): CliOptions {
-  const opts: CliOptions = { adapter: 'mock' };
+  const opts: CliOptions = {
+    adapter: 'mock',
+    library: 'openchrome',
+    dryRun: false,
+    repetitions: 1,
+  };
   for (let i = 2; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--adapter') {
@@ -51,6 +82,20 @@ function parseArgs(argv: string[]): CliOptions {
       opts.adapter = v;
     } else if (a === '--task') {
       opts.taskFilter = argv[++i];
+    } else if (a === '--library') {
+      const v = argv[++i];
+      if (!isLibrary(v)) {
+        throw new Error(`unknown --library: ${v}. Choose one of ${WEBVOYAGER_LIBRARIES.join(', ')}`);
+      }
+      opts.library = v;
+    } else if (a === '--repetitions' || a === '--reps') {
+      const n = parseInt(argv[++i], 10);
+      if (!Number.isInteger(n) || n < 1) {
+        throw new Error(`--repetitions must be a positive integer; got ${argv[i]}`);
+      }
+      opts.repetitions = n;
+    } else if (a === '--dry-run') {
+      opts.dryRun = true;
     } else if (a.startsWith('--adapter=')) {
       const v = a.slice('--adapter='.length);
       if (v !== 'mock' && v !== 'claude') {
@@ -59,6 +104,12 @@ function parseArgs(argv: string[]): CliOptions {
       opts.adapter = v;
     } else if (a.startsWith('--task=')) {
       opts.taskFilter = a.slice('--task='.length);
+    } else if (a.startsWith('--library=')) {
+      const v = a.slice('--library='.length);
+      if (!isLibrary(v)) {
+        throw new Error(`unknown --library: ${v}. Choose one of ${WEBVOYAGER_LIBRARIES.join(', ')}`);
+      }
+      opts.library = v;
     }
   }
   // env override (e.g. OPENCHROME_BENCH_ADAPTER=claude)
@@ -68,6 +119,8 @@ function parseArgs(argv: string[]): CliOptions {
   }
   return opts;
 }
+
+export { parseArgs as parseRunnerArgs };
 
 async function loadTasks(): Promise<WebVoyagerTask[]> {
   const entries = await fs.readdir(TASKS_DIR);
@@ -245,6 +298,38 @@ export async function main(argv: string[] = process.argv): Promise<number> {
   const tasks = opts.taskFilter ? allTasks.filter((t) => t.name === opts.taskFilter) : allTasks;
   if (tasks.length === 0) {
     console.error('[webvoyager] no tasks selected');
+    return 1;
+  }
+
+  // Dry-run gate (#1257): print the worst-case cost projection and exit 0
+  // WITHOUT making any LLM API call. The gate runs before adapter dispatch
+  // so even `--adapter claude` with OPENCHROME_BENCH_REAL=1 is honored as
+  // dry-run when --dry-run is set.
+  if (opts.dryRun) {
+    const projection = projectCost({
+      taskCount: tasks.length,
+      libraries: [opts.library],
+      repetitions: opts.repetitions,
+    });
+    console.error(formatProjection(projection));
+    console.error(
+      `\n[webvoyager] library=${opts.library} wired=${LIBRARY_ROUTING[opts.library].nativeLoopWired} ` +
+        `adapter-requested=${opts.adapter} (no run performed; --dry-run is set)`,
+    );
+    return 0;
+  }
+
+  // Live library gate (#1257): the runner today only wires OpenChrome's
+  // native loop. Selecting an unwired library without --dry-run is a config
+  // error — refuse to silently fall back to OpenChrome and surface the
+  // routing's note so the operator knows what needs to land.
+  const routing = LIBRARY_ROUTING[opts.library];
+  if (!routing.nativeLoopWired) {
+    console.error(
+      `[webvoyager] GATE FAILED: library "${opts.library}" native loop is not yet wired. ` +
+        `Use --dry-run for the cost projection, or run with --library openchrome. ` +
+        `Note: ${routing.note}`,
+    );
     return 1;
   }
 

--- a/tests/benchmark/webvoyager/tasks-corpus.test.ts
+++ b/tests/benchmark/webvoyager/tasks-corpus.test.ts
@@ -79,4 +79,23 @@ describe('WebVoyager task corpus', () => {
       expect(task.pending).toBe(true);
     }
   });
+
+  test('Sprint-2 corpus expansion (task-19..) is also marked pending', async () => {
+    // The 43 tasks added in Sprint 2 (#1257 — PR-11) all ship pending until
+    // their transcripts are recorded in the next-session real-LLM run. This
+    // is the same honesty guard as the task-11..18 batch — without it, a
+    // task could silently default to `pending: false` and the mock runner
+    // would report a false pass/fail for a task that has no ground truth.
+    const sprint2Files = files.filter((f) => {
+      const match = /^task-(\d+)-/.exec(f);
+      if (!match) return false;
+      return parseInt(match[1], 10) >= 19;
+    });
+    expect(sprint2Files.length).toBeGreaterThanOrEqual(40);
+    for (const f of sprint2Files) {
+      const mod = await import(path.join(TASKS_DIR, f));
+      const task = (mod.default ?? mod.task) as WebVoyagerTask;
+      expect(task.pending).toBe(true);
+    }
+  });
 });

--- a/tests/benchmark/webvoyager/tasks/task-19-example-com-h1.ts
+++ b/tests/benchmark/webvoyager/tasks/task-19-example-com-h1.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-19-example-com-h1',
+  instruction: 'Visit https://example.com and confirm the page mentions "Example Domain".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/example\\.com' },
+        { kind: 'dom_text', selector: 'body', contains: 'Example Domain' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'h1 contains Example Domain on example.com. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-20-example-org-h1.ts
+++ b/tests/benchmark/webvoyager/tasks/task-20-example-org-h1.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-20-example-org-h1',
+  instruction: 'Visit https://example.org and confirm the page mentions "Example Domain".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/example\\.org' },
+        { kind: 'dom_text', selector: 'body', contains: 'Example Domain' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'h1 contains Example Domain on example.org. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-21-example-net-h1.ts
+++ b/tests/benchmark/webvoyager/tasks/task-21-example-net-h1.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-21-example-net-h1',
+  instruction: 'Visit https://example.net and confirm the page mentions "Example Domain".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/example\\.net' },
+        { kind: 'dom_text', selector: 'body', contains: 'Example Domain' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'h1 contains Example Domain on example.net. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-22-wikipedia-light-speed.ts
+++ b/tests/benchmark/webvoyager/tasks/task-22-wikipedia-light-speed.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-22-wikipedia-light-speed',
+  instruction: 'Visit https://en.wikipedia.org/wiki/Speed_of_light and confirm the page mentions "299792458".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/Speed_of_light' },
+        { kind: 'dom_text', selector: 'body', contains: '299792458' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Speed-of-light article cites 299,792,458 m/s. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-23-wikipedia-everest.ts
+++ b/tests/benchmark/webvoyager/tasks/task-23-wikipedia-everest.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-23-wikipedia-everest',
+  instruction: 'Visit https://en.wikipedia.org/wiki/Mount_Everest and confirm the page mentions "8,848".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/Mount_Everest' },
+        { kind: 'dom_text', selector: 'body', contains: '8,848' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Mount Everest height cited as 8,848 m. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-24-wikipedia-mariana-trench.ts
+++ b/tests/benchmark/webvoyager/tasks/task-24-wikipedia-mariana-trench.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-24-wikipedia-mariana-trench',
+  instruction: 'Visit https://en.wikipedia.org/wiki/Mariana_Trench and confirm the page mentions "deepest".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/Mariana_Trench' },
+        { kind: 'dom_text', selector: 'body', contains: 'deepest' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Mariana Trench described as deepest oceanic trench. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-25-wikipedia-eiffel-tower.ts
+++ b/tests/benchmark/webvoyager/tasks/task-25-wikipedia-eiffel-tower.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-25-wikipedia-eiffel-tower',
+  instruction: 'Visit https://en.wikipedia.org/wiki/Eiffel_Tower and confirm the page mentions "Paris".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/Eiffel_Tower' },
+        { kind: 'dom_text', selector: 'body', contains: 'Paris' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Eiffel Tower located in Paris. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-26-wikipedia-statue-of-liberty.ts
+++ b/tests/benchmark/webvoyager/tasks/task-26-wikipedia-statue-of-liberty.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-26-wikipedia-statue-of-liberty',
+  instruction: 'Visit https://en.wikipedia.org/wiki/Statue_of_Liberty and confirm the page mentions "New York".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/Statue_of_Liberty' },
+        { kind: 'dom_text', selector: 'body', contains: 'New York' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Statue of Liberty located in New York. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-27-wikipedia-internet-protocol.ts
+++ b/tests/benchmark/webvoyager/tasks/task-27-wikipedia-internet-protocol.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-27-wikipedia-internet-protocol',
+  instruction: 'Visit https://en.wikipedia.org/wiki/Internet_Protocol and confirm the page mentions "datagram".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/Internet_Protocol' },
+        { kind: 'dom_text', selector: 'body', contains: 'datagram' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Internet Protocol article mentions datagram. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-28-wikipedia-ascii.ts
+++ b/tests/benchmark/webvoyager/tasks/task-28-wikipedia-ascii.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-28-wikipedia-ascii',
+  instruction: 'Visit https://en.wikipedia.org/wiki/ASCII and confirm the page mentions "128".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/ASCII' },
+        { kind: 'dom_text', selector: 'body', contains: '128' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'ASCII character set described as 128 code points. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-29-wikipedia-pi.ts
+++ b/tests/benchmark/webvoyager/tasks/task-29-wikipedia-pi.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-29-wikipedia-pi',
+  instruction: 'Visit https://en.wikipedia.org/wiki/Pi and confirm the page mentions "3.14".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/Pi' },
+        { kind: 'dom_text', selector: 'body', contains: '3.14' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Pi article cites 3.14.... Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-30-wikipedia-utf8.ts
+++ b/tests/benchmark/webvoyager/tasks/task-30-wikipedia-utf8.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-30-wikipedia-utf8',
+  instruction: 'Visit https://en.wikipedia.org/wiki/UTF-8 and confirm the page mentions "variable-width".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/UTF-8' },
+        { kind: 'dom_text', selector: 'body', contains: 'variable-width' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'UTF-8 described as variable-width. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-31-wikipedia-tim-berners-lee.ts
+++ b/tests/benchmark/webvoyager/tasks/task-31-wikipedia-tim-berners-lee.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-31-wikipedia-tim-berners-lee',
+  instruction: 'Visit https://en.wikipedia.org/wiki/Tim_Berners-Lee and confirm the page mentions "World Wide Web".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/Tim_Berners-Lee' },
+        { kind: 'dom_text', selector: 'body', contains: 'World Wide Web' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Tim Berners-Lee credited with inventing the World Wide Web. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-32-wikipedia-rfc-editor.ts
+++ b/tests/benchmark/webvoyager/tasks/task-32-wikipedia-rfc-editor.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-32-wikipedia-rfc-editor',
+  instruction: 'Visit https://en.wikipedia.org/wiki/Request_for_Comments and confirm the page mentions "IETF".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/en\\.wikipedia\\.org\\/wiki\\/Request_for_Comments' },
+        { kind: 'dom_text', selector: 'body', contains: 'IETF' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC document series associated with IETF. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-33-rfc-2606-reserved.ts
+++ b/tests/benchmark/webvoyager/tasks/task-33-rfc-2606-reserved.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-33-rfc-2606-reserved',
+  instruction: 'Visit https://www.rfc-editor.org/rfc/rfc2606 and confirm the page mentions "example".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/www\\.rfc-editor\\.org\\/rfc\\/rfc2606' },
+        { kind: 'dom_text', selector: 'body', contains: 'example' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC 2606 lists example as a reserved TLD. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-34-rfc-2119-keywords.ts
+++ b/tests/benchmark/webvoyager/tasks/task-34-rfc-2119-keywords.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-34-rfc-2119-keywords',
+  instruction: 'Visit https://www.rfc-editor.org/rfc/rfc2119 and confirm the page mentions "MUST".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/www\\.rfc-editor\\.org\\/rfc\\/rfc2119' },
+        { kind: 'dom_text', selector: 'body', contains: 'MUST' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC 2119 defines MUST keyword. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-35-rfc-8259-json.ts
+++ b/tests/benchmark/webvoyager/tasks/task-35-rfc-8259-json.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-35-rfc-8259-json',
+  instruction: 'Visit https://www.rfc-editor.org/rfc/rfc8259 and confirm the page mentions "JavaScript Object Notation".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/www\\.rfc-editor\\.org\\/rfc\\/rfc8259' },
+        { kind: 'dom_text', selector: 'body', contains: 'JavaScript Object Notation' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC 8259 titled JavaScript Object Notation. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-36-rfc-9110-http.ts
+++ b/tests/benchmark/webvoyager/tasks/task-36-rfc-9110-http.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-36-rfc-9110-http',
+  instruction: 'Visit https://www.rfc-editor.org/rfc/rfc9110 and confirm the page mentions "HTTP Semantics".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/www\\.rfc-editor\\.org\\/rfc\\/rfc9110' },
+        { kind: 'dom_text', selector: 'body', contains: 'HTTP Semantics' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC 9110 titled HTTP Semantics. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-37-rfc-7231-http-methods.ts
+++ b/tests/benchmark/webvoyager/tasks/task-37-rfc-7231-http-methods.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-37-rfc-7231-http-methods',
+  instruction: 'Visit https://www.rfc-editor.org/rfc/rfc7231 and confirm the page mentions "method".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/www\\.rfc-editor\\.org\\/rfc\\/rfc7231' },
+        { kind: 'dom_text', selector: 'body', contains: 'method' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC 7231 defines HTTP methods. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-38-rfc-3986-uri.ts
+++ b/tests/benchmark/webvoyager/tasks/task-38-rfc-3986-uri.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-38-rfc-3986-uri',
+  instruction: 'Visit https://www.rfc-editor.org/rfc/rfc3986 and confirm the page mentions "Uniform Resource Identifier".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/www\\.rfc-editor\\.org\\/rfc\\/rfc3986' },
+        { kind: 'dom_text', selector: 'body', contains: 'Uniform Resource Identifier' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC 3986 defines URI syntax. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-39-rfc-5321-smtp.ts
+++ b/tests/benchmark/webvoyager/tasks/task-39-rfc-5321-smtp.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-39-rfc-5321-smtp',
+  instruction: 'Visit https://www.rfc-editor.org/rfc/rfc5321 and confirm the page mentions "Simple Mail Transfer Protocol".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/www\\.rfc-editor\\.org\\/rfc\\/rfc5321' },
+        { kind: 'dom_text', selector: 'body', contains: 'Simple Mail Transfer Protocol' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC 5321 defines SMTP. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-40-rfc-6749-oauth.ts
+++ b/tests/benchmark/webvoyager/tasks/task-40-rfc-6749-oauth.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-40-rfc-6749-oauth',
+  instruction: 'Visit https://www.rfc-editor.org/rfc/rfc6749 and confirm the page mentions "OAuth 2.0".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/www\\.rfc-editor\\.org\\/rfc\\/rfc6749' },
+        { kind: 'dom_text', selector: 'body', contains: 'OAuth 2.0' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'RFC 6749 defines OAuth 2.0. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-41-mdn-fetch.ts
+++ b/tests/benchmark/webvoyager/tasks/task-41-mdn-fetch.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-41-mdn-fetch',
+  instruction: 'Visit https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API and confirm the page mentions "Fetch API".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/developer\\.mozilla\\.org\\/en-US\\/docs\\/Web\\/API\\/Fetch_API' },
+        { kind: 'dom_text', selector: 'body', contains: 'Fetch API' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'MDN Fetch API reference. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-42-mdn-array-map.ts
+++ b/tests/benchmark/webvoyager/tasks/task-42-mdn-array-map.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-42-mdn-array-map',
+  instruction: 'Visit https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map and confirm the page mentions "map".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/developer\\.mozilla\\.org\\/en-US\\/docs\\/Web\\/JavaScript\\/Reference\\/Global_Objects\\/Array\\/map' },
+        { kind: 'dom_text', selector: 'body', contains: 'map' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'MDN Array.prototype.map reference. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-43-mdn-array-filter.ts
+++ b/tests/benchmark/webvoyager/tasks/task-43-mdn-array-filter.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-43-mdn-array-filter',
+  instruction: 'Visit https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter and confirm the page mentions "filter".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/developer\\.mozilla\\.org\\/en-US\\/docs\\/Web\\/JavaScript\\/Reference\\/Global_Objects\\/Array\\/filter' },
+        { kind: 'dom_text', selector: 'body', contains: 'filter' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'MDN Array.prototype.filter reference. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-44-mdn-promise-then.ts
+++ b/tests/benchmark/webvoyager/tasks/task-44-mdn-promise-then.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-44-mdn-promise-then',
+  instruction: 'Visit https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then and confirm the page mentions "then".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/developer\\.mozilla\\.org\\/en-US\\/docs\\/Web\\/JavaScript\\/Reference\\/Global_Objects\\/Promise\\/then' },
+        { kind: 'dom_text', selector: 'body', contains: 'then' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'MDN Promise.prototype.then reference. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-45-mdn-async-await.ts
+++ b/tests/benchmark/webvoyager/tasks/task-45-mdn-async-await.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-45-mdn-async-await',
+  instruction: 'Visit https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await and confirm the page mentions "await".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/developer\\.mozilla\\.org\\/en-US\\/docs\\/Web\\/JavaScript\\/Reference\\/Operators\\/await' },
+        { kind: 'dom_text', selector: 'body', contains: 'await' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'MDN await operator reference. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-46-mdn-css-grid.ts
+++ b/tests/benchmark/webvoyager/tasks/task-46-mdn-css-grid.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-46-mdn-css-grid',
+  instruction: 'Visit https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout and confirm the page mentions "grid".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/developer\\.mozilla\\.org\\/en-US\\/docs\\/Web\\/CSS\\/CSS_grid_layout' },
+        { kind: 'dom_text', selector: 'body', contains: 'grid' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'MDN CSS Grid Layout reference. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-47-mdn-css-flexbox.ts
+++ b/tests/benchmark/webvoyager/tasks/task-47-mdn-css-flexbox.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-47-mdn-css-flexbox',
+  instruction: 'Visit https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flexible_box_layout and confirm the page mentions "flex".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/developer\\.mozilla\\.org\\/en-US\\/docs\\/Web\\/CSS\\/CSS_flexible_box_layout' },
+        { kind: 'dom_text', selector: 'body', contains: 'flex' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'MDN CSS Flexbox reference. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-48-mdn-html-img.ts
+++ b/tests/benchmark/webvoyager/tasks/task-48-mdn-html-img.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-48-mdn-html-img',
+  instruction: 'Visit https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img and confirm the page mentions "img".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/developer\\.mozilla\\.org\\/en-US\\/docs\\/Web\\/HTML\\/Element\\/img' },
+        { kind: 'dom_text', selector: 'body', contains: 'img' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'MDN HTML img element reference. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-49-tc39-ecma262-syntax.ts
+++ b/tests/benchmark/webvoyager/tasks/task-49-tc39-ecma262-syntax.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-49-tc39-ecma262-syntax',
+  instruction: 'Visit https://tc39.es/ecma262/ and confirm the page mentions "ECMAScript".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/tc39\\.es\\/ecma262\\/' },
+        { kind: 'dom_text', selector: 'body', contains: 'ECMAScript' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'TC39 ECMAScript spec home. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-50-tc39-proposals.ts
+++ b/tests/benchmark/webvoyager/tasks/task-50-tc39-proposals.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-50-tc39-proposals',
+  instruction: 'Visit https://github.com/tc39/proposals and confirm the page mentions "proposals".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/github\\.com\\/tc39\\/proposals' },
+        { kind: 'dom_text', selector: 'body', contains: 'proposals' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'TC39 proposals repo. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-51-whatwg-html-spec.ts
+++ b/tests/benchmark/webvoyager/tasks/task-51-whatwg-html-spec.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-51-whatwg-html-spec',
+  instruction: 'Visit https://html.spec.whatwg.org/ and confirm the page mentions "HTML".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/html\\.spec\\.whatwg\\.org\\/' },
+        { kind: 'dom_text', selector: 'body', contains: 'HTML' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'WHATWG HTML living standard. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-52-whatwg-fetch-spec.ts
+++ b/tests/benchmark/webvoyager/tasks/task-52-whatwg-fetch-spec.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-52-whatwg-fetch-spec',
+  instruction: 'Visit https://fetch.spec.whatwg.org/ and confirm the page mentions "Fetch".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/fetch\\.spec\\.whatwg\\.org\\/' },
+        { kind: 'dom_text', selector: 'body', contains: 'Fetch' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'WHATWG Fetch standard. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-53-w3c-css-spec.ts
+++ b/tests/benchmark/webvoyager/tasks/task-53-w3c-css-spec.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-53-w3c-css-spec',
+  instruction: 'Visit https://www.w3.org/Style/CSS/ and confirm the page mentions "CSS".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/www\\.w3\\.org\\/Style\\/CSS\\/' },
+        { kind: 'dom_text', selector: 'body', contains: 'CSS' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'W3C CSS home. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-54-rust-string-trim.ts
+++ b/tests/benchmark/webvoyager/tasks/task-54-rust-string-trim.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-54-rust-string-trim',
+  instruction: 'Visit https://doc.rust-lang.org/std/string/struct.String.html and confirm the page mentions "String".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/doc\\.rust-lang\\.org\\/std\\/string\\/struct\\.String\\.html' },
+        { kind: 'dom_text', selector: 'body', contains: 'String' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Rust std::string::String docs. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-55-rust-option-enum.ts
+++ b/tests/benchmark/webvoyager/tasks/task-55-rust-option-enum.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-55-rust-option-enum',
+  instruction: 'Visit https://doc.rust-lang.org/std/option/enum.Option.html and confirm the page mentions "Option".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/doc\\.rust-lang\\.org\\/std\\/option\\/enum\\.Option\\.html' },
+        { kind: 'dom_text', selector: 'body', contains: 'Option' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Rust std::option::Option docs. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-56-rust-result-enum.ts
+++ b/tests/benchmark/webvoyager/tasks/task-56-rust-result-enum.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-56-rust-result-enum',
+  instruction: 'Visit https://doc.rust-lang.org/std/result/enum.Result.html and confirm the page mentions "Result".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/doc\\.rust-lang\\.org\\/std\\/result\\/enum\\.Result\\.html' },
+        { kind: 'dom_text', selector: 'body', contains: 'Result' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Rust std::result::Result docs. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-57-rust-vec.ts
+++ b/tests/benchmark/webvoyager/tasks/task-57-rust-vec.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-57-rust-vec',
+  instruction: 'Visit https://doc.rust-lang.org/std/vec/struct.Vec.html and confirm the page mentions "Vec".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/doc\\.rust-lang\\.org\\/std\\/vec\\/struct\\.Vec\\.html' },
+        { kind: 'dom_text', selector: 'body', contains: 'Vec' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Rust std::vec::Vec docs. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-58-python-len-builtin.ts
+++ b/tests/benchmark/webvoyager/tasks/task-58-python-len-builtin.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-58-python-len-builtin',
+  instruction: 'Visit https://docs.python.org/3/library/functions.html and confirm the page mentions "len".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/docs\\.python\\.org\\/3\\/library\\/functions\\.html' },
+        { kind: 'dom_text', selector: 'body', contains: 'len' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Python built-in functions reference. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-59-python-list-stdtypes.ts
+++ b/tests/benchmark/webvoyager/tasks/task-59-python-list-stdtypes.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-59-python-list-stdtypes',
+  instruction: 'Visit https://docs.python.org/3/library/stdtypes.html and confirm the page mentions "list".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/docs\\.python\\.org\\/3\\/library\\/stdtypes\\.html' },
+        { kind: 'dom_text', selector: 'body', contains: 'list' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Python stdtypes reference (list). Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-60-python-dict-stdtypes.ts
+++ b/tests/benchmark/webvoyager/tasks/task-60-python-dict-stdtypes.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-60-python-dict-stdtypes',
+  instruction: 'Visit https://docs.python.org/3/library/stdtypes.html and confirm the page mentions "dict".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/docs\\.python\\.org\\/3\\/library\\/stdtypes\\.html' },
+        { kind: 'dom_text', selector: 'body', contains: 'dict' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'Python stdtypes reference (dict). Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;

--- a/tests/benchmark/webvoyager/tasks/task-61-python-pep-8.ts
+++ b/tests/benchmark/webvoyager/tasks/task-61-python-pep-8.ts
@@ -1,0 +1,21 @@
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'task-61-python-pep-8',
+  instruction: 'Visit https://peps.python.org/pep-0008/ and confirm the page mentions "Style Guide".',
+  contract: {
+    postconditions: {
+      kind: 'and',
+      children: [
+        { kind: 'url', pattern: '^https:\\/\\/peps\\.python\\.org\\/pep-0008\\/' },
+        { kind: 'dom_text', selector: 'body', contains: 'Style Guide' },
+      ],
+    },
+  },
+  timeout_ms: 90_000,
+  pending: true,
+  rationale:
+    'PEP 8 Style Guide. Source is a low-volatility public reference page (license-safe). Task ships as pending until the next-session real-LLM run records a transcript.',
+};
+
+export default task;


### PR DESCRIPTION
## Summary
- Adds the small uniform abstraction over the three Issue #1257 libraries (OpenChrome / playwright-mcp / browser-use) and wires it into the WebVoyager runner CLI
- New `--library` flag selects which native-mode loop runs; default OpenChrome
- New `--dry-run` flag prints the worst-case cost projection and exits 0 WITHOUT any LLM API call — gate runs BEFORE adapter dispatch so `--adapter claude` + `OPENCHROME_BENCH_REAL=1` is honored as dry-run when --dry-run is set
- Live library gate: selecting an unwired library without --dry-run fails with a clear "native loop not yet wired" error pointing the operator at --dry-run or `--library openchrome`. No silent fallback to OpenChrome.

## Commits
1. **`feat(benchmark): WebVoyager library routing + dry-run cost projection`** — `tests/benchmark/webvoyager/llm/library-routing.ts` + tests. `WebVoyagerLibrary` type, `LIBRARY_ROUTING` map, `projectCost()`, `formatProjection()`. 9 unit tests.
2. **`feat(benchmark): WebVoyager runner --library + --dry-run flags`** — adds the CLI flags to `runner.ts`, exports `parseRunnerArgs` for tests, dry-run early-return + live-library gate.

## Sample output
```
$ npx ts-node tests/benchmark/webvoyager/runner.ts --library playwright-mcp --reps 10 --dry-run
WebVoyager dry-run cost projection (#1257)
  tasks                  : 61
  libraries              : 1 (playwright-mcp)
  reps per (task,lib)    : 10
  max USD per task cap   : $0.50
  worst-case total USD   : $305.00
  cells that would run   : 0 (rest are scaffolded, no API call)

Per-library:
  playwright-mcp  wired=false would-run=0  playwright-mcp MCP server driven by the same Claude tool-calling loop. Loop wiring lands next session.

No API calls are made in --dry-run mode. To proceed, drop --dry-run and set OPENCHROME_BENCH_REAL=1.
```

## Scope this PR
- **Infrastructure only.** No real LLM API calls. The dry-run projection is the only output an operator can use to authorize a real run.
- Only OpenChrome's native loop is wired today; playwright-mcp and browser-use ship as scaffolds. Wiring those two lands in a follow-up commit when the per-library adapter dispatches plug into `runTask()`.

## Verify
- `npx jest tests/benchmark/webvoyager/` ⇒ 65/65 corpus + 9/9 library-routing = 74 tests pass
- `npx tsc --noEmit` ⇒ exit 0
- Dry-run runs end-to-end against all 3 library options, prints the projection, exits 0

## Test plan
- [x] Build green
- [x] Library-routing unit tests green (9/9)
- [x] Dry-run prints projection and exits 0 for all 3 libraries
- [x] Live-library gate refuses to silently fall back when an unwired library is selected
- [ ] CI green on `develop`

Part of Epic #1254 → Sprint 2 PR-12 of 4. Builds on PR-11 (#1287). Next: PR-13 adds the passive-tool mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)