### PR TITLE
feat(benchmark): WebVoyager --mode native/passive + N-gate helpers (#1257)

### DIFF
--- a/tests/benchmark/webvoyager/llm/execution-mode.test.ts
+++ b/tests/benchmark/webvoyager/llm/execution-mode.test.ts
@@ -1,0 +1,79 @@
+/// <reference types="jest" />
+
+import {
+  EXECUTION_MODES,
+  AGGREGATE_MIN_N,
+  PER_TASK_MIN_N,
+  gateClaim,
+  bootstrapPassRateCi95,
+} from './execution-mode';
+
+describe('execution-mode constants', () => {
+  test('exposes native + passive in stable order; native is the headline', () => {
+    expect(EXECUTION_MODES).toEqual(['native', 'passive']);
+  });
+
+  test('per-task threshold is the issue-mandated N>=20; aggregate is N>=10', () => {
+    expect(PER_TASK_MIN_N).toBe(20);
+    expect(AGGREGATE_MIN_N).toBe(10);
+  });
+});
+
+describe('gateClaim', () => {
+  test('aggregate claim with N>=10 is allowed', () => {
+    const g = gateClaim('aggregate', 10);
+    expect(g.allowed).toBe(true);
+    expect(g.annotation).toBe('');
+  });
+
+  test('aggregate claim with N<10 is flagged underpowered', () => {
+    const g = gateClaim('aggregate', 5);
+    expect(g.allowed).toBe(false);
+    expect(g.annotation).toContain('underpowered');
+    expect(g.annotation).toContain('N=5');
+    expect(g.annotation).toContain('10');
+    expect(g.annotation).toContain('aggregate');
+  });
+
+  test('per-task claim demands N>=20, not 10', () => {
+    expect(gateClaim('per-task', 19).allowed).toBe(false);
+    expect(gateClaim('per-task', 20).allowed).toBe(true);
+  });
+
+  test('rejects fractional or negative sample counts', () => {
+    expect(() => gateClaim('aggregate', 1.5)).toThrow(/sampleCount/);
+    expect(() => gateClaim('aggregate', -1)).toThrow(/sampleCount/);
+  });
+});
+
+describe('bootstrapPassRateCi95', () => {
+  test('all-pass outcomes yield a [1, 1] CI', () => {
+    const ci = bootstrapPassRateCi95(Array.from({ length: 20 }, () => true));
+    expect(ci[0]).toBe(1);
+    expect(ci[1]).toBe(1);
+  });
+
+  test('all-fail outcomes yield a [0, 0] CI', () => {
+    const ci = bootstrapPassRateCi95(Array.from({ length: 20 }, () => false));
+    expect(ci[0]).toBe(0);
+    expect(ci[1]).toBe(0);
+  });
+
+  test('a 50/50 sample produces a CI that brackets 0.5', () => {
+    const outcomes = Array.from({ length: 30 }, (_, i) => i % 2 === 0);
+    const [lo, hi] = bootstrapPassRateCi95(outcomes);
+    expect(lo).toBeLessThan(0.6);
+    expect(hi).toBeGreaterThan(0.4);
+  });
+
+  test('is deterministic with a seeded RNG', () => {
+    const outcomes = [true, false, true, true, false, true, false, true, true, true];
+    const a = bootstrapPassRateCi95(outcomes, 500, 17);
+    const b = bootstrapPassRateCi95(outcomes, 500, 17);
+    expect(a).toEqual(b);
+  });
+
+  test('handles an empty sample without throwing', () => {
+    expect(bootstrapPassRateCi95([])).toEqual([0, 0]);
+  });
+});

--- a/tests/benchmark/webvoyager/llm/execution-mode.ts
+++ b/tests/benchmark/webvoyager/llm/execution-mode.ts
@@ -1,0 +1,113 @@
+/**
+ * Execution modes for the Agent Task Success axis (#1257).
+ *
+ * Issue #1257 distinguishes two ways a library can be measured against the
+ * same task corpus:
+ *
+ * - `native`: each library runs in its idiomatic execution mode. OpenChrome
+ *   and playwright-mcp inside a Claude tool-calling loop (their natural MCP
+ *   shape). browser-use inside its own native agent loop with the pinned
+ *   Claude model. This is the HEADLINE comparison.
+ *
+ * - `passive`: every library wrapped as a passive tool surface inside an
+ *   identical Claude tool-calling loop. Isolates the tool surface itself,
+ *   but for browser-use this strips the library's planning loop — so it is
+ *   reported as a SECONDARY data point, never the headline.
+ *
+ * Epic #1254 fairness principle: passive results MUST appear in their own
+ * envelope section with the "secondary" tag so a reader cannot mistake
+ * "Claude + a hobbled browser-use" for browser-use's real native-mode
+ * score.
+ *
+ * Per-task chart claims are gated at N >= 20 samples; aggregate (suite-
+ * level) claims use bootstrap 95% CI over the task set with N >= 10. The
+ * `gateClaim()` helper below is the small, unit-testable enforcer the
+ * report renderer calls.
+ */
+
+export type ExecutionMode = 'native' | 'passive';
+
+export const EXECUTION_MODES: readonly ExecutionMode[] = ['native', 'passive'];
+
+/**
+ * Minimum samples per (library, task) cell for an aggregate / suite-level
+ * claim ("OpenChrome passes X / 60 tasks at 95% CI"). Below this threshold
+ * the suite number is reported with the explicit "underpowered (N<10)"
+ * annotation.
+ */
+export const AGGREGATE_MIN_N = 10;
+
+/**
+ * Minimum samples per (library, task) cell for a PER-TASK claim in the
+ * breakdown chart ("OpenChrome passes task-42 95% of the time"). Issue
+ * #1257 mandates N >= 20 here because binary pass/fail at lower N has
+ * observed-rate error ≥ ±20 percentage points.
+ */
+export const PER_TASK_MIN_N = 20;
+
+export type ClaimScope = 'aggregate' | 'per-task';
+
+export interface ClaimGateResult {
+  scope: ClaimScope;
+  sampleCount: number;
+  /** Threshold the scope requires. */
+  required: number;
+  /** True when the claim is allowed; false ⇒ render with "underpowered" tag. */
+  allowed: boolean;
+  /** Annotation for the report renderer when allowed === false. */
+  annotation: string;
+}
+
+/**
+ * Decide whether a claim of `scope` can be rendered given `sampleCount`
+ * samples. The renderer always emits the row; this gate only decides
+ * whether the row should carry the "underpowered" annotation.
+ */
+export function gateClaim(scope: ClaimScope, sampleCount: number): ClaimGateResult {
+  if (!Number.isInteger(sampleCount) || sampleCount < 0) {
+    throw new Error(`sampleCount must be a non-negative integer, got ${sampleCount}`);
+  }
+  const required = scope === 'per-task' ? PER_TASK_MIN_N : AGGREGATE_MIN_N;
+  const allowed = sampleCount >= required;
+  const annotation = allowed
+    ? ''
+    : `underpowered (N=${sampleCount} < ${required} required for ${scope})`;
+  return { scope, sampleCount, required, allowed, annotation };
+}
+
+/**
+ * Bootstrap 95% CI of a binary pass/fail mean using percentile bootstrap.
+ * Exported as a pure function so the report renderer can compute it without
+ * spinning up the real `BenchmarkRunner` orchestration.
+ *
+ * `iterations` defaults to 1000 (cheap; deterministic with a seeded RNG).
+ * Returns [lower, upper] in the range [0, 1].
+ */
+export function bootstrapPassRateCi95(
+  outcomes: readonly boolean[],
+  iterations = 1000,
+  seed = 42,
+): [number, number] {
+  if (outcomes.length === 0) return [0, 0];
+  const n = outcomes.length;
+  // Tiny LCG so the CI is deterministic across runs without pulling in a
+  // dep. Not crypto, just reproducibility.
+  let state = seed >>> 0;
+  const rand = (): number => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0xffffffff;
+  };
+  const means: number[] = [];
+  for (let i = 0; i < iterations; i++) {
+    let sum = 0;
+    for (let j = 0; j < n; j++) {
+      const idx = Math.floor(rand() * n);
+      if (outcomes[idx]) sum += 1;
+    }
+    means.push(sum / n);
+  }
+  means.sort((a, b) => a - b);
+  const lo = means[Math.floor(0.025 * iterations)];
+  const hi = means[Math.floor(0.975 * iterations)];
+  return [lo, hi];
+}

--- a/tests/benchmark/webvoyager/runner.ts
+++ b/tests/benchmark/webvoyager/runner.ts
@@ -28,6 +28,10 @@ import {
   projectCost,
   formatProjection,
 } from './llm/library-routing';
+import {
+  EXECUTION_MODES,
+  ExecutionMode,
+} from './llm/execution-mode';
 import type {
   Baseline,
   BenchReport,
@@ -52,6 +56,13 @@ interface CliOptions {
    */
   library: WebVoyagerLibrary;
   /**
+   * Execution mode (#1257). `native` is the headline comparison; `passive`
+   * wraps every library as a passive tool surface — surfaces drift between
+   * the two but for browser-use is a SECONDARY data point (it strips the
+   * library's planning loop).
+   */
+  mode: ExecutionMode;
+  /**
    * --dry-run: print the cost projection and exit 0 WITHOUT making any LLM
    * API call. The runner refuses to run real tasks in this mode regardless
    * of OPENCHROME_BENCH_REAL.
@@ -65,10 +76,15 @@ function isLibrary(v: string): v is WebVoyagerLibrary {
   return (WEBVOYAGER_LIBRARIES as readonly string[]).includes(v);
 }
 
+function isMode(v: string): v is ExecutionMode {
+  return (EXECUTION_MODES as readonly string[]).includes(v);
+}
+
 function parseArgs(argv: string[]): CliOptions {
   const opts: CliOptions = {
     adapter: 'mock',
     library: 'openchrome',
+    mode: 'native',
     dryRun: false,
     repetitions: 1,
   };
@@ -96,6 +112,18 @@ function parseArgs(argv: string[]): CliOptions {
       opts.repetitions = n;
     } else if (a === '--dry-run') {
       opts.dryRun = true;
+    } else if (a === '--mode') {
+      const v = argv[++i];
+      if (!isMode(v)) {
+        throw new Error(`unknown --mode: ${v}. Choose one of ${EXECUTION_MODES.join(', ')}`);
+      }
+      opts.mode = v;
+    } else if (a.startsWith('--mode=')) {
+      const v = a.slice('--mode='.length);
+      if (!isMode(v)) {
+        throw new Error(`unknown --mode: ${v}. Choose one of ${EXECUTION_MODES.join(', ')}`);
+      }
+      opts.mode = v;
     } else if (a.startsWith('--adapter=')) {
       const v = a.slice('--adapter='.length);
       if (v !== 'mock' && v !== 'claude') {
@@ -313,9 +341,17 @@ export async function main(argv: string[] = process.argv): Promise<number> {
     });
     console.error(formatProjection(projection));
     console.error(
-      `\n[webvoyager] library=${opts.library} wired=${LIBRARY_ROUTING[opts.library].nativeLoopWired} ` +
+      `\n[webvoyager] library=${opts.library} mode=${opts.mode} ` +
+        `wired=${LIBRARY_ROUTING[opts.library].nativeLoopWired} ` +
         `adapter-requested=${opts.adapter} (no run performed; --dry-run is set)`,
     );
+    if (opts.mode === 'passive') {
+      console.error(
+        `[webvoyager] note: --mode passive is the SECONDARY data point per #1257. ` +
+          `Headline numbers come from --mode native; for browser-use, passive strips ` +
+          `the library's planning loop and is reported separately, never as the headline.`,
+      );
+    }
     return 0;
   }
 

--- a/tests/benchmark/webvoyager/runner.ts
+++ b/tests/benchmark/webvoyager/runner.ts
@@ -402,6 +402,9 @@ export async function main(argv: string[] = process.argv): Promise<number> {
   const benchReport: BenchReport = {
     git_sha: sha,
     adapter: opts.adapter,
+    mode: opts.mode,
+    library: opts.library,
+    repetitions: opts.repetitions,
     total_tasks: totalCount,
     pass_count: passCount,
     fail_count: failCount,

--- a/tests/benchmark/webvoyager/types.ts
+++ b/tests/benchmark/webvoyager/types.ts
@@ -84,6 +84,18 @@ export interface TaskRunReport {
 export interface BenchReport {
   git_sha: string;
   adapter: string;
+  /** Execution mode the runner was invoked with. Identifies the methodology
+   *  that produced the results so downstream tools can split native vs
+   *  passive measurements without re-parsing the CLI. */
+  mode: 'native' | 'passive';
+  /** Library under test. Same shape constraint, but kept as the raw string
+   *  so the envelope does not have to import the `WebVoyagerLibrary` union
+   *  (and stays stable if the union grows). */
+  library: string;
+  /** Repetitions requested for this run. Records what was asked even if the
+   *  live loop has not been wired yet — readers can spot a `repetitions: 10`
+   *  report with N=10 task entries vs `repetitions: 10` with N=1 entries. */
+  repetitions: number;
   total_tasks: number;
   pass_count: number;
   fail_count: number;


### PR DESCRIPTION
## Summary
- Adds the second axis Issue #1257 requires: `--mode native` (headline) vs `--mode passive` (secondary). For browser-use, passive strips the library's planning loop — so the dry-run output and the renderer always annotate passive as the SECONDARY data point
- New `tests/benchmark/webvoyager/llm/execution-mode.ts` exports the issue-mandated N thresholds (`AGGREGATE_MIN_N=10`, `PER_TASK_MIN_N=20`) and the small helpers the report renderer will call (`gateClaim`, `bootstrapPassRateCi95`)
- `bootstrapPassRateCi95` is deterministic (seeded LCG) so the report CIs are reproducible across runs without pulling in a stat lib

## Why
Issue #1257 fairness clause: "Per-task chart claims have N ≥ 20; aggregate claims use bootstrap 95% CI." This PR ships the small enforcers that the report renderer needs so a future per-task chart row can never silently render an underpowered claim — the gate either allows it or flags `underpowered (N=K < J required for scope)`.

## Commits
1. **`feat(benchmark): WebVoyager --mode native/passive + N-gate helpers`** — `execution-mode.ts` + 11 unit tests + `runner.ts` flag wiring + SECONDARY annotation on passive dry-runs.

## Sample passive-mode dry-run output
```
[webvoyager] library=browser-use mode=passive wired=false ...
[webvoyager] note: --mode passive is the SECONDARY data point per
  #1257. Headline numbers come from --mode native; for browser-use,
  passive strips the library's planning loop and is reported
  separately, never as the headline.
```

## Scope this PR
- **Infrastructure only.** No real LLM API calls.
- Both modes are plumbed end-to-end through the CLI, dry-run, and helper layer. The next-session real-LLM run consumes them via PR-14's baseline + regression gate.

## Verify
- `npx jest tests/benchmark/webvoyager/` ⇒ 96/96 passing
- `npx tsc --noEmit` ⇒ exit 0
- `--mode passive --dry-run` emits the SECONDARY warning so a reader cannot mistake passive for the headline

## Test plan
- [x] Build green
- [x] WebVoyager test suites green (96/96)
- [x] Bootstrap CI helper deterministic with seeded LCG
- [x] gateClaim returns underpowered annotation when N < required threshold
- [ ] CI green on `develop`

Part of Epic #1254 → Sprint 2 PR-13 of 4. Builds on PR-11 (#1287) + PR-12 (#1288).

🤖 Generated with [Claude Code](https://claude.com/claude-code)