### PR TITLE
chore(ci): cross-platform browser-use bridge smoke (#1259 PR-15)

### DIFF
--- a/.github/workflows/benchmark-browser-use.yml
+++ b/.github/workflows/benchmark-browser-use.yml
@@ -1,8 +1,9 @@
 name: benchmark — browser-use bridge smoke
 
-# Ubuntu-only smoke for the browser-use Python bridge (#1255 — 0.4).
-# Cross-platform expansion to macOS/Windows is queued for Sprint 3 (#1259
-# PR-15) where the reliability CI matrix is hardened.
+# Cross-platform smoke for the browser-use Python bridge.
+# Originally ubuntu-only (Sprint 0 #1255 — 0.4); Sprint 3 #1259 PR-15 expands
+# the matrix to macOS + Windows so the bridge gets the same cross-platform
+# coverage as the benchmark-suite workflow.
 #
 # This workflow exercises only the bridge *protocol* — `ping` + `shutdown` —
 # so it does not need the full browser-use install (no Chromium download,
@@ -26,7 +27,15 @@ on:
 
 jobs:
   bridge-smoke:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Cross-platform pass rate is itself a reliability metric (#1259), so
+      # every cell must run to completion — single-OS failure does not abort
+      # the rest of the matrix.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
     steps:
       - uses: actions/checkout@v4
 
@@ -48,12 +57,9 @@ jobs:
         run: npx jest tests/benchmark/adapters/browser-use-adapter.test.ts
 
       - name: Smoke-test the Python bridge protocol (no browser-use install)
-        # Exercises ping + shutdown via stdio. browser-use itself is lazy-
-        # imported inside open_tab/read_page only, so this smoke does not
-        # require Chromium or browser-use to be installed.
-        run: |
-          printf '%s\n%s\n' '{"id":1,"method":"ping","args":{}}' '{"id":2,"method":"shutdown","args":{}}' \
-            | python3 tests/benchmark/bridges/browser_use_bridge.py \
-            | tee bridge-smoke.out
-          grep -q '"pong": true' bridge-smoke.out
-          grep -q '"shutdown": true' bridge-smoke.out
+        # Cross-platform smoke: drive the bridge via Node's child_process so
+        # we don't depend on bash / printf / grep being identical across
+        # ubuntu / macOS / Windows. browser-use itself is lazy-imported
+        # inside open_tab/read_page only, so this smoke does not require
+        # Chromium or browser-use to be installed.
+        run: node scripts/bench/bridge-smoke.mjs

--- a/scripts/bench/bridge-smoke.mjs
+++ b/scripts/bench/bridge-smoke.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform smoke for the browser-use Python bridge.
+ *
+ * Drives `tests/benchmark/bridges/browser_use_bridge.py` over stdio via
+ * Node's child_process so the smoke does not depend on bash / printf / grep
+ * being identical across ubuntu / macOS / Windows runners. The bridge's
+ * protocol guarantees:
+ *
+ *   1. A `ping` request returns `{"ok": true, "result": {"pong": true, ...}}`
+ *   2. A `shutdown` request returns `{"ok": true, "result": {"shutdown": true}}`
+ *      and the process exits cleanly.
+ *
+ * Sprint 3 #1259 PR-15 added this script when the bridge-smoke workflow
+ * expanded from ubuntu-only to a 3-OS matrix.
+ */
+
+import { spawn } from 'node:child_process';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const BRIDGE = path.join(REPO_ROOT, 'tests', 'benchmark', 'bridges', 'browser_use_bridge.py');
+
+const PYTHON = process.platform === 'win32' ? 'python' : 'python3';
+
+const stdoutLines = [];
+let stderrBuf = '';
+
+const child = spawn(PYTHON, [BRIDGE], { stdio: ['pipe', 'pipe', 'pipe'] });
+
+let buffer = '';
+child.stdout.on('data', (chunk) => {
+  buffer += chunk.toString();
+  const lines = buffer.split('\n');
+  buffer = lines.pop() ?? '';
+  for (const line of lines) {
+    if (line.trim()) stdoutLines.push(line);
+  }
+});
+
+child.stderr.on('data', (chunk) => {
+  stderrBuf += chunk.toString();
+  process.stderr.write(chunk);
+});
+
+let readyReceived = false;
+const sendReady = (resolve) => {
+  // Wait until the bridge prints "browser-use bridge ready" on stderr.
+  const check = () => {
+    if (stderrBuf.includes('browser-use bridge ready')) {
+      readyReceived = true;
+      resolve();
+      return;
+    }
+    setTimeout(check, 50);
+  };
+  check();
+};
+
+function send(req) {
+  child.stdin.write(JSON.stringify(req) + '\n');
+}
+
+const exitCode = await new Promise((resolve) => {
+  child.on('exit', (code) => resolve(code ?? 0));
+  child.on('error', (err) => {
+    console.error(`[bridge-smoke] spawn error: ${err.message}`);
+    resolve(1);
+  });
+
+  // Drive the protocol once the bridge announces ready.
+  new Promise(sendReady).then(() => {
+    send({ id: 1, method: 'ping', args: {} });
+    setTimeout(() => send({ id: 2, method: 'shutdown', args: {} }), 200);
+  });
+});
+
+if (!readyReceived) {
+  console.error('[bridge-smoke] FAILED: bridge never printed "browser-use bridge ready"');
+  process.exit(1);
+}
+
+const allOutput = stdoutLines.join('\n');
+if (!allOutput.includes('"pong": true')) {
+  console.error('[bridge-smoke] FAILED: did not observe "pong": true');
+  console.error('stdout:\n' + allOutput);
+  process.exit(1);
+}
+if (!allOutput.includes('"shutdown": true')) {
+  console.error('[bridge-smoke] FAILED: did not observe "shutdown": true');
+  console.error('stdout:\n' + allOutput);
+  process.exit(1);
+}
+
+console.error(`[bridge-smoke] OK on ${process.platform} (exit ${exitCode})`);
+process.exit(exitCode === null ? 0 : exitCode);


### PR DESCRIPTION
## Summary
- Expands `.github/workflows/benchmark-browser-use.yml` from ubuntu-only to a 3-OS matrix (ubuntu, macOS, Windows)
- Replaces the bash-based smoke (printf + grep) with a portable Node driver `scripts/bench/bridge-smoke.mjs` so the same protocol assertions run identically on every platform
- `fail-fast: false` preserved so a single-OS failure does not hide the cross-platform pass rate

## Why
Issue #1259 success criterion: "Cross-platform pass-rate table published for all 3 OSes." The benchmark-suite workflow already covered all three; this PR brings the browser-use bridge under the same coverage so the Python bridge does not become the lone ubuntu-only blind spot.

## Verify
- `node scripts/bench/bridge-smoke.mjs` ⇒ "[bridge-smoke] OK on darwin"
- Existing adapter unit tests unchanged (mock transport)

Part of Epic #1254 → Sprint 3 PR-15 of 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)