### PR TITLE
feat(benchmark): DX runner + playwright/puppeteer scripts + bench:dx (#1261)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "bench:throughput": "ts-node tests/benchmark/run-throughput.ts",
     "bench:longrun": "ts-node tests/benchmark/run-longrun.ts",
     "bench:reliability": "ts-node tests/benchmark/run-reliability.ts",
+    "bench:dx": "ts-node tests/benchmark/run-dx.ts",
     "test": "jest",
     "test:e2e": "node --expose-gc node_modules/.bin/jest --config tests/e2e/jest.e2e.config.js",
     "test:coverage": "jest --coverage",

--- a/tests/benchmark/dx-scripts/README.md
+++ b/tests/benchmark/dx-scripts/README.md
@@ -1,0 +1,27 @@
+# Developer Experience scripts (#1261)
+
+Per-library minimal idiomatic scripts measured for axis #1261:
+
+| Library | Path | Tasks today |
+|---|---|---|
+| OpenChrome MCP | `openchrome/` | navigate-and-read, form-fill |
+| Playwright (raw) | `playwright/` | navigate-and-read, form-fill |
+| Puppeteer (raw) | `puppeteer/` | navigate-and-read, form-fill |
+
+Each task implements the same observable behavior across libraries. The LOC of each script is measured by `dx-rubrics.countLoc` and reported in the #F section of the benchmark report.
+
+## Rules — committed up front
+
+1. **Idiomatic best practice** — each script uses the library's documented preferred API. No hand-padding, no hand-optimizing for OpenChrome.
+2. **LOC counting** — imports counted; blank lines + `//` + `/* */` comments excluded.
+3. **No composite radar** — the report splits into "MCP DX" (libraries that ship an MCP server, scored across all 4 rubrics) vs "Framework DX" (LOC only). Composites are computed only over axes where every compared library participates.
+
+## Expansion
+
+The 2-tasks-per-library set committed today is the floor. Adding a task means:
+
+1. Implementing the same observable behavior in each library's directory
+2. Re-running `npm run bench:dx`
+3. The runner picks up new tasks automatically (filesystem scan)
+
+The eventual 10-task × 6-library = 60-script matrix is the issue's headline number; this PR ships the harness + 2 tasks × 3 libraries to prove the shape.

--- a/tests/benchmark/dx-scripts/playwright/form-fill.ts
+++ b/tests/benchmark/dx-scripts/playwright/form-fill.ts
@@ -1,0 +1,17 @@
+/**
+ * Raw Playwright — fill a form and submit.
+ * Idiomatic: page.fill per field + page.click submit + wait for navigation.
+ */
+import { chromium } from 'playwright';
+
+export async function formFill(url: string, fields: Record<string, string>): Promise<void> {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.goto(url);
+  for (const [name, value] of Object.entries(fields)) {
+    await page.fill(`input[name="${name}"]`, value);
+  }
+  await Promise.all([page.waitForNavigation(), page.click('button[type="submit"]')]);
+  await browser.close();
+}

--- a/tests/benchmark/dx-scripts/playwright/navigate-and-read.ts
+++ b/tests/benchmark/dx-scripts/playwright/navigate-and-read.ts
@@ -1,0 +1,15 @@
+/**
+ * Raw Playwright — navigate to a URL and read the page text.
+ * Idiomatic: browser/context/page lifecycle + page.textContent('body').
+ */
+import { chromium } from 'playwright';
+
+export async function navigateAndRead(url: string): Promise<string> {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.goto(url);
+  const text = (await page.textContent('body')) ?? '';
+  await browser.close();
+  return text;
+}

--- a/tests/benchmark/dx-scripts/puppeteer/form-fill.ts
+++ b/tests/benchmark/dx-scripts/puppeteer/form-fill.ts
@@ -1,0 +1,21 @@
+/**
+ * Raw Puppeteer — fill a form and submit.
+ * Idiomatic: page.type per field + page.click + waitForNavigation.
+ */
+import puppeteer from 'puppeteer-core';
+
+export async function formFill(
+  url: string,
+  fields: Record<string, string>,
+  browserURL = 'http://127.0.0.1:9222',
+): Promise<void> {
+  const browser = await puppeteer.connect({ browserURL });
+  const page = await browser.newPage();
+  await page.goto(url);
+  for (const [name, value] of Object.entries(fields)) {
+    await page.type(`input[name="${name}"]`, value);
+  }
+  await Promise.all([page.waitForNavigation(), page.click('button[type="submit"]')]);
+  await page.close();
+  await browser.disconnect();
+}

--- a/tests/benchmark/dx-scripts/puppeteer/navigate-and-read.ts
+++ b/tests/benchmark/dx-scripts/puppeteer/navigate-and-read.ts
@@ -1,0 +1,15 @@
+/**
+ * Raw Puppeteer — navigate to a URL and read the page text.
+ * Idiomatic: launch + page.evaluate to extract body text.
+ */
+import puppeteer from 'puppeteer-core';
+
+export async function navigateAndRead(url: string, browserURL = 'http://127.0.0.1:9222'): Promise<string> {
+  const browser = await puppeteer.connect({ browserURL });
+  const page = await browser.newPage();
+  await page.goto(url);
+  const text = await page.evaluate(() => document.body.innerText);
+  await page.close();
+  await browser.disconnect();
+  return text;
+}

--- a/tests/benchmark/run-dx.ts
+++ b/tests/benchmark/run-dx.ts
@@ -1,0 +1,143 @@
+#!/usr/bin/env ts-node
+/**
+ * Developer Experience runner for axis #1261.
+ *
+ * Reads each DX script under `tests/benchmark/dx-scripts/<library>/<task>.ts`
+ * and reports LOC per (library × task) cell. Schema-completeness +
+ * error-actionability rubrics ship as the next-session integration when the
+ * MCP servers can be introspected; today the runner emits the LOC matrix +
+ * placeholder fields for the other two rubrics so the report renderer's
+ * shape is fixed.
+ *
+ *   npm run bench:dx
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { countLoc } from './dx-rubrics';
+import { captureEnvironment } from './utils/environment';
+import { buildResultEnvelope, assertValidResultEnvelope } from './utils/result-envelope';
+
+const OUTPUT_PATH = path.join(process.cwd(), 'benchmark', 'results', 'dx.json');
+const SCRIPTS_DIR = path.join(__dirname, 'dx-scripts');
+
+export interface DxRow {
+  library: string;
+  task: string;
+  scriptPath: string;
+  loc: number;
+  blankLines: number;
+  commentLines: number;
+  totalLines: number;
+  /** Schema completeness 0..1; null today (next-session integration). */
+  schemaCompleteness: number | null;
+  /** Error actionability 0..3; null today (next-session integration). */
+  errorActionability: number | null;
+  /** True when the library ships its tools as an MCP server (gates schema/error rubrics). */
+  isMcp: boolean;
+}
+
+const MCP_LIBRARIES = new Set(['openchrome', 'playwright-mcp', 'puppeteer-mcp', 'browsermcp']);
+
+function listLibraries(): string[] {
+  if (!fs.existsSync(SCRIPTS_DIR)) return [];
+  return fs
+    .readdirSync(SCRIPTS_DIR)
+    .filter((d) => fs.statSync(path.join(SCRIPTS_DIR, d)).isDirectory());
+}
+
+function listTasks(library: string): string[] {
+  const dir = path.join(SCRIPTS_DIR, library);
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'))
+    .map((f) => f.replace(/\.ts$/, ''));
+}
+
+export function runDxBenchmark(): DxRow[] {
+  const rows: DxRow[] = [];
+  for (const library of listLibraries().sort()) {
+    for (const task of listTasks(library).sort()) {
+      const scriptPath = path.join(SCRIPTS_DIR, library, `${task}.ts`);
+      const source = fs.readFileSync(scriptPath, 'utf8');
+      const loc = countLoc(source);
+      rows.push({
+        library,
+        task,
+        scriptPath: path.relative(process.cwd(), scriptPath),
+        loc: loc.loc,
+        blankLines: loc.blankLines,
+        commentLines: loc.commentLines,
+        totalLines: loc.totalLines,
+        schemaCompleteness: null,
+        errorActionability: null,
+        isMcp: MCP_LIBRARIES.has(library),
+      });
+    }
+  }
+  return rows;
+}
+
+function readRepoVersion(): string {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
+    return typeof pkg.version === 'string' ? pkg.version : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function formatReport(rows: DxRow[]): string {
+  const lines = ['Developer Experience (#1261) — LOC per (library × task)'];
+  lines.push('library         task                    LOC   kind');
+  for (const r of rows) {
+    lines.push(
+      [
+        r.library.padEnd(14),
+        r.task.padEnd(22),
+        String(r.loc).padStart(5),
+        r.isMcp ? 'MCP' : 'framework',
+      ].join(' '),
+    );
+  }
+  return lines.join('\n');
+}
+
+export function main(): void {
+  const rows = runDxBenchmark();
+  if (rows.length === 0) {
+    console.error('No DX scripts found under tests/benchmark/dx-scripts/');
+    process.exit(1);
+  }
+  const libraries = Array.from(new Set(rows.map((r) => r.library)));
+  const envelope = buildResultEnvelope({
+    axis: 'developer-experience',
+    environment: captureEnvironment(),
+    competitors: libraries.map((lib) => ({
+      name: lib,
+      version: lib === 'openchrome' ? readRepoVersion() : 'idiomatic-script-only',
+    })),
+    results: rows,
+  });
+  assertValidResultEnvelope(envelope);
+
+  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(envelope, null, 2) + '\n');
+
+  console.error(formatReport(rows));
+  console.error(`\nSaved: ${path.relative(process.cwd(), OUTPUT_PATH)}`);
+  console.error(
+    '\nNote: schema-completeness + error-actionability rubrics ship as null until\n' +
+      'the MCP introspection wiring lands. The LOC matrix above is fully measured.',
+  );
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    console.error('DX benchmark failed:', err);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `run-dx.ts` + 4 raw-framework DX scripts (Playwright + Puppeteer × 2 tasks each) on top of the dx-rubrics module + OpenChrome scripts already on develop
- LOC + library-kind matrix runner + `bench:dx` npm script
- README documents the rules and expansion plan

## Sample output
```
library         task                    LOC   kind
openchrome     form-fill                 10 MCP
openchrome     navigate-and-read          7 MCP
playwright     form-fill                 12 framework
playwright     navigate-and-read         10 framework
puppeteer      form-fill                 16 framework
puppeteer      navigate-and-read         10 framework
```

OpenChrome MCP wins LOC on both tasks; the natural-language `act` tool collapses "click submit and wait for navigation" into one step.

## Scope
- LOC rubric fully measured today (real numbers from real scripts)
- Schema-completeness + error-actionability emit `null` — the MCP introspection wiring lands in a follow-up
- The 2-tasks × 3-libraries matrix is the floor; the eventual 10×6 set is queued

Part of Epic #1254 → Sprint 4 PR-19 of 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)