### PR TITLE
Add real-world task completion benchmark scaffold

### DIFF
--- a/benchmark/EPIC-1254-STATUS.md
+++ b/benchmark/EPIC-1254-STATUS.md
@@ -24,6 +24,7 @@ This document tracks Epic #1254 against its committed success criteria. Update o
 | [#1259](https://github.com/shaun0927/openchrome/issues/1259) | Reliability & Fault-Recovery | ✅ `run-reliability.ts` + `run-longrun.ts` | (queued — direct envelope) | mock matrix landed; live cells scaffolded |
 | [#1260](https://github.com/shaun0927/openchrome/issues/1260) | Auth & Real-World Usability | ✅ `run-auth.ts` | (queued — direct envelope) | LOC measured; logged-in smoke pending live driver |
 | [#1261](https://github.com/shaun0927/openchrome/issues/1261) | Developer Experience | ✅ `run-dx.ts` | ✅ `generate-dx-section.mjs` + dual SVGs | 2/10 tasks × 3/6 libraries landed; schema + actionability rubrics queued |
+| [#1305](https://github.com/shaun0927/openchrome/issues/1305) | Complex Real-World Task Completion | ✅ `run-realworld-task-completion.ts` scaffold | ✅ `generate-realworld-task-completion-section.mjs` | deterministic fixture scaffold only; live competitive rows pending |
 
 ## Retired claims (must never reappear)
 

--- a/benchmark/generate-benchmark-report.mjs
+++ b/benchmark/generate-benchmark-report.mjs
@@ -40,6 +40,7 @@ const SECTIONS = [
   { id: '#D', axis: 'Reliability & Fault-Recovery', issue: '#1259', file: null },
   { id: '#E', axis: 'Auth & Real-World Usability', issue: '#1260', file: null },
   { id: '#F', axis: 'Developer Experience', issue: '#1261', file: 'DEVELOPER-EXPERIENCE-REPORT.md' },
+  { id: '#G', axis: 'Complex Real-World Task Completion', issue: '#1305', file: 'REALWORLD-TASK-COMPLETION-REPORT.md' },
 ];
 
 // Retired estimates that must never reappear in the unified report.

--- a/benchmark/generate-realworld-task-completion-section.mjs
+++ b/benchmark/generate-realworld-task-completion-section.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..');
+const INPUT_PATH = path.join(REPO_ROOT, 'benchmark', 'results', 'realworld-task-completion.json');
+const OUTPUT_PATH = path.join(REPO_ROOT, 'benchmark', 'results', 'REALWORLD-TASK-COMPLETION-REPORT.md');
+
+function pct(value) {
+  return value === null || value === undefined ? 'n/a' : `${(value * 100).toFixed(1)}%`;
+}
+
+function n(value) {
+  return value === null || value === undefined ? 'n/a' : Number(value).toFixed(1).replace(/\.0$/, '');
+}
+
+function main() {
+  if (!existsSync(INPUT_PATH)) {
+    process.stderr.write(`Missing ${path.relative(REPO_ROOT, INPUT_PATH)}. Run \`npm run bench:realworld\` first.\n`);
+    process.exit(1);
+  }
+
+  const envelope = JSON.parse(readFileSync(INPUT_PATH, 'utf8'));
+  const result = envelope.results?.[0];
+  if (!result) {
+    process.stderr.write('realworld-task-completion.json has no result payload.\n');
+    process.exit(1);
+  }
+
+  const lines = [];
+  lines.push('# Complex Real-World Task Completion (#1305)');
+  lines.push('');
+  lines.push(`Generated: ${new Date().toISOString()}`);
+  lines.push(`Source: \`benchmark/results/realworld-task-completion.json\` (axis: \`${envelope.axis}\`).`);
+  lines.push('');
+  lines.push('## Claim scope');
+  lines.push('');
+  lines.push(`- Measurement mode: \`${result.measurementMode}\``);
+  lines.push(`- Claim scope: **${result.claimScope}**`);
+  lines.push('- This report is the scaffold/local-fixture baseline for the real-world task-completion axis. It is **not** a live competitive win claim.');
+  lines.push('- #1261 remains the DX/supporting axis; this section is the primary task-completion axis.');
+  lines.push('');
+
+  lines.push('## Metrics by library');
+  lines.push('');
+  lines.push('| Library | Mode | Runs | Success | First-attempt success | Recovery success | Mean tool calls | Mean wall time ms | p95 wall time ms |');
+  lines.push('| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |');
+  for (const metric of result.metrics ?? []) {
+    lines.push(`| \`${metric.library}\` | \`${metric.mode}\` | ${metric.totalRuns} | ${pct(metric.successRate)} | ${pct(metric.firstAttemptSuccessRate)} | ${pct(metric.recoverySuccessRate)} | ${n(metric.meanToolCalls)} | ${n(metric.meanWallTimeMs)} | ${n(metric.p95WallTimeMs)} |`);
+  }
+  lines.push('');
+
+  lines.push('## Task corpus');
+  lines.push('');
+  lines.push('| Task | Tier | Max steps | Recovery? | Complexity tags |');
+  lines.push('| --- | --- | ---: | --- | --- |');
+  for (const task of result.tasks ?? []) {
+    lines.push(`| \`${task.id}\` ${task.title} | ${task.tier} | ${task.maxSteps} | ${task.requiresRecovery ? 'yes' : 'no'} | ${task.complexityTags.join(', ')} |`);
+  }
+  lines.push('');
+
+  lines.push('## Next measurement work');
+  lines.push('');
+  lines.push('- Add live OpenChrome / playwright-mcp / Puppeteer MCP / browsermcp adapter rows only after real execution.');
+  lines.push('- Pin competitor and LLM versions before publishing live comparisons.');
+  lines.push('- Keep local deterministic fixture rows separate from live-web rows.');
+  lines.push('');
+
+  writeFileSync(OUTPUT_PATH, lines.join('\n'));
+  process.stderr.write(`Wrote ${path.relative(REPO_ROOT, OUTPUT_PATH)}\n`);
+}
+
+main();

--- a/benchmark/results/BENCHMARK-REPORT.md
+++ b/benchmark/results/BENCHMARK-REPORT.md
@@ -1,6 +1,6 @@
 # OpenChrome Competitive Benchmark Report
 
-Generated: 2026-05-15T09:25:52.505Z
+Generated: 2026-05-15T23:53:20.784Z
 Source: per-axis section files under `benchmark/results/`.
 
 Part of [Epic #1254](https://github.com/shaun0927/openchrome/issues/1254) — the competitive benchmark suite. Each section below is generated from its axis runner's envelope; this top-level file is the union.
@@ -14,7 +14,8 @@ Part of [Epic #1254](https://github.com/shaun0927/openchrome/issues/1254) — th
 | #C | Speed & Throughput | [#1258](https://github.com/shaun0927/openchrome/issues/1258) | measured |
 | #D | Reliability & Fault-Recovery | [#1259](https://github.com/shaun0927/openchrome/issues/1259) | pending |
 | #E | Auth & Real-World Usability | [#1260](https://github.com/shaun0927/openchrome/issues/1260) | pending |
-| #F | Developer Experience | [#1261](https://github.com/shaun0927/openchrome/issues/1261) | pending |
+| #F | Developer Experience | [#1261](https://github.com/shaun0927/openchrome/issues/1261) | measured |
+| #G | Complex Real-World Task Completion | [#1305](https://github.com/shaun0927/openchrome/issues/1305) | measured |
 
 ## Methodology principles
 All sections honor Epic #1254's ten methodology principles:
@@ -167,4 +168,71 @@ See `chart-throughput.svg` and `chart-success-rate.svg` for the visual companion
 
 ## #F Developer Experience (#1261)
 
-*No data yet for #1261. Run the axis runner + `developer-experience` generator to populate.*
+Generated: 2026-05-15T09:23:53.402Z
+Source: `benchmark/results/dx.json` (axis: `developer-experience`).
+
+## Rule of two charts
+Issue #1261 forbids a single composite radar — LOC trivially favors MCP servers, schema metrics are N/A for non-MCP libraries. The DX section therefore splits into:
+- **MCP DX** (this chart): libraries that ship an MCP server, scored across all rubrics
+- **Framework DX** (next chart): all libraries including raw frameworks, **LOC only** (the only metric every library participates in)
+
+## MCP DX
+| Library | form-fill | navigate-and-read | Schema completeness | Error actionability |
+| --- | ---: | ---: | ---: | ---: |
+| `openchrome` | 10 | 7 | *pending* | *pending* |
+
+See `chart-dx-mcp.svg` for the visual companion.
+
+## Framework DX
+LOC per task. Composites computed only over axes where every library participates — here that's LOC alone.
+
+| Library | form-fill | navigate-and-read | median LOC |
+| --- | ---: | ---: | ---: |
+| `openchrome` | 10 | 7 | 8.5 |
+| `playwright` | 12 | 10 | 11 |
+| `puppeteer` | 16 | 10 | 13 |
+
+See `chart-dx-framework.svg` for the visual companion.
+
+## Pending rubrics
+- Schema completeness: requires MCP `tools/list` introspection per library (issue #1261 mentions `lint:tool-schemas` as the OpenChrome side). Lands in the next-session follow-up.
+- Error actionability: requires running induced failures through each library and scoring the returned errors against the rubric in `dx-rubrics.ts`. Same follow-up.
+
+## Headline
+Framework DX LOC winner (lower is better): **`openchrome`** at median 8.5 LOC.
+
+
+## #G Complex Real-World Task Completion (#1305)
+
+Generated: 2026-05-15T23:53:20.745Z
+Source: `benchmark/results/realworld-task-completion.json` (axis: `realworld-task-completion`).
+
+## Claim scope
+
+- Measurement mode: `deterministic-fixture`
+- Claim scope: **scaffold-only; not a live competitive measurement**
+- This report is the scaffold/local-fixture baseline for the real-world task-completion axis. It is **not** a live competitive win claim.
+- #1261 remains the DX/supporting axis; this section is the primary task-completion axis.
+
+## Metrics by library
+
+| Library | Mode | Runs | Success | First-attempt success | Recovery success | Mean tool calls | Mean wall time ms | p95 wall time ms |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `openchrome` | `deterministic-fixture` | 5 | 100.0% | 80.0% | 100.0% | 9.6 | 1640 | 2175 |
+
+## Task corpus
+
+| Task | Tier | Max steps | Recovery? | Complexity tags |
+| --- | --- | ---: | --- | --- |
+| `rw-001-checkout-update-address` Update a checkout shipping address and verify recalculated summary | local-fixture | 14 | no | form-fill, stateful-ui, verification |
+| `rw-002-search-filter-compare` Search, filter, compare two products, and extract the cheaper eligible item | local-fixture | 16 | no | search, filtering, extraction, decision |
+| `rw-003-tab-research-synthesis` Use multiple tabs to synthesize two reference pages into one answer | stable-public-reference | 18 | no | tabs, reading, synthesis |
+| `rw-004-selector-drift-recovery` Recover from selector drift while submitting a feedback form | recovery | 20 | yes | fault-recovery, form-fill, grounding |
+| `rw-005-long-horizon-itinerary` Build and verify a multi-step itinerary from constrained options | long-horizon | 28 | no | long-horizon, filtering, decision, stateful-ui |
+
+## Next measurement work
+
+- Add live OpenChrome / playwright-mcp / Puppeteer MCP / browsermcp adapter rows only after real execution.
+- Pin competitor and LLM versions before publishing live comparisons.
+- Keep local deterministic fixture rows separate from live-web rows.
+

--- a/benchmark/results/REALWORLD-TASK-COMPLETION-REPORT.md
+++ b/benchmark/results/REALWORLD-TASK-COMPLETION-REPORT.md
@@ -1,0 +1,33 @@
+# Complex Real-World Task Completion (#1305)
+
+Generated: 2026-05-15T23:53:20.745Z
+Source: `benchmark/results/realworld-task-completion.json` (axis: `realworld-task-completion`).
+
+## Claim scope
+
+- Measurement mode: `deterministic-fixture`
+- Claim scope: **scaffold-only; not a live competitive measurement**
+- This report is the scaffold/local-fixture baseline for the real-world task-completion axis. It is **not** a live competitive win claim.
+- #1261 remains the DX/supporting axis; this section is the primary task-completion axis.
+
+## Metrics by library
+
+| Library | Mode | Runs | Success | First-attempt success | Recovery success | Mean tool calls | Mean wall time ms | p95 wall time ms |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `openchrome` | `deterministic-fixture` | 5 | 100.0% | 80.0% | 100.0% | 9.6 | 1640 | 2175 |
+
+## Task corpus
+
+| Task | Tier | Max steps | Recovery? | Complexity tags |
+| --- | --- | ---: | --- | --- |
+| `rw-001-checkout-update-address` Update a checkout shipping address and verify recalculated summary | local-fixture | 14 | no | form-fill, stateful-ui, verification |
+| `rw-002-search-filter-compare` Search, filter, compare two products, and extract the cheaper eligible item | local-fixture | 16 | no | search, filtering, extraction, decision |
+| `rw-003-tab-research-synthesis` Use multiple tabs to synthesize two reference pages into one answer | stable-public-reference | 18 | no | tabs, reading, synthesis |
+| `rw-004-selector-drift-recovery` Recover from selector drift while submitting a feedback form | recovery | 20 | yes | fault-recovery, form-fill, grounding |
+| `rw-005-long-horizon-itinerary` Build and verify a multi-step itinerary from constrained options | long-horizon | 28 | no | long-horizon, filtering, decision, stateful-ui |
+
+## Next measurement work
+
+- Add live OpenChrome / playwright-mcp / Puppeteer MCP / browsermcp adapter rows only after real execution.
+- Pin competitor and LLM versions before publishing live comparisons.
+- Keep local deterministic fixture rows separate from live-web rows.

--- a/benchmark/results/realworld-task-completion.json
+++ b/benchmark/results/realworld-task-completion.json
@@ -1,0 +1,228 @@
+{
+  "axis": "realworld-task-completion",
+  "schemaVersion": "1.0.0",
+  "environment": {
+    "capturedAt": "2026-05-15T23:53:20.624Z",
+    "gitSha": "83d85b07",
+    "gitDirty": true,
+    "nodeVersion": "v20.19.6",
+    "os": "darwin 25.3.0",
+    "arch": "arm64",
+    "cpuModel": "Apple M5",
+    "cpuCount": 10,
+    "totalMemoryBytes": 17179869184,
+    "chromeVersion": "Google Chrome 148.0.7778.168",
+    "networkProfile": "unthrottled"
+  },
+  "competitors": [
+    {
+      "name": "openchrome",
+      "version": "1.12.2"
+    }
+  ],
+  "tokenizer": "cl100k_base",
+  "results": [
+    {
+      "suite": "complex-real-world-task-completion",
+      "issue": "#1305",
+      "measurementMode": "deterministic-fixture",
+      "claimScope": "scaffold-only; not a live competitive measurement",
+      "tasks": [
+        {
+          "id": "rw-001-checkout-update-address",
+          "title": "Update a checkout shipping address and verify recalculated summary",
+          "tier": "local-fixture",
+          "goal": "Find the checkout address form, update the shipping city/postal code, and verify the order summary reflects the new destination.",
+          "maxSteps": 14,
+          "successCriteria": [
+            "address fields saved",
+            "summary destination updated",
+            "tax/shipping recalculated"
+          ],
+          "complexityTags": [
+            "form-fill",
+            "stateful-ui",
+            "verification"
+          ],
+          "requiresRecovery": false
+        },
+        {
+          "id": "rw-002-search-filter-compare",
+          "title": "Search, filter, compare two products, and extract the cheaper eligible item",
+          "tier": "local-fixture",
+          "goal": "Search a product catalog, apply availability and rating filters, compare two candidates, and report the cheaper eligible item.",
+          "maxSteps": 16,
+          "successCriteria": [
+            "filters applied",
+            "two candidates compared",
+            "eligible cheaper item extracted"
+          ],
+          "complexityTags": [
+            "search",
+            "filtering",
+            "extraction",
+            "decision"
+          ],
+          "requiresRecovery": false
+        },
+        {
+          "id": "rw-003-tab-research-synthesis",
+          "title": "Use multiple tabs to synthesize two reference pages into one answer",
+          "tier": "stable-public-reference",
+          "goal": "Open two reference pages, extract the requested facts from each, and produce a synthesized answer with both facts.",
+          "maxSteps": 18,
+          "successCriteria": [
+            "two tabs used",
+            "fact from page A extracted",
+            "fact from page B extracted",
+            "combined answer produced"
+          ],
+          "complexityTags": [
+            "tabs",
+            "reading",
+            "synthesis"
+          ],
+          "requiresRecovery": false
+        },
+        {
+          "id": "rw-004-selector-drift-recovery",
+          "title": "Recover from selector drift while submitting a feedback form",
+          "tier": "recovery",
+          "goal": "Submit a feedback form after the primary submit selector changes during the run.",
+          "maxSteps": 20,
+          "successCriteria": [
+            "selector failure observed",
+            "fallback selector or semantic action used",
+            "form submitted"
+          ],
+          "complexityTags": [
+            "fault-recovery",
+            "form-fill",
+            "grounding"
+          ],
+          "requiresRecovery": true
+        },
+        {
+          "id": "rw-005-long-horizon-itinerary",
+          "title": "Build and verify a multi-step itinerary from constrained options",
+          "tier": "long-horizon",
+          "goal": "Filter itinerary options by date, budget, and transit time; add the best option; verify the final itinerary summary.",
+          "maxSteps": 28,
+          "successCriteria": [
+            "constraints applied",
+            "best option selected",
+            "itinerary added",
+            "summary verified"
+          ],
+          "complexityTags": [
+            "long-horizon",
+            "filtering",
+            "decision",
+            "stateful-ui"
+          ],
+          "requiresRecovery": false
+        }
+      ],
+      "runs": [
+        {
+          "library": "openchrome",
+          "taskId": "rw-001-checkout-update-address",
+          "mode": "deterministic-fixture",
+          "success": true,
+          "firstAttempt": true,
+          "recovered": null,
+          "wallTimeMs": 1200,
+          "toolCalls": 5,
+          "retries": 0,
+          "noProgressLoops": 0,
+          "tokens": null,
+          "usd": null,
+          "failureCategory": "none",
+          "notes": "deterministic scaffold row from local fixture contract; not a live competitive LLM/browser measurement"
+        },
+        {
+          "library": "openchrome",
+          "taskId": "rw-002-search-filter-compare",
+          "mode": "deterministic-fixture",
+          "success": true,
+          "firstAttempt": true,
+          "recovered": null,
+          "wallTimeMs": 1375,
+          "toolCalls": 7,
+          "retries": 0,
+          "noProgressLoops": 0,
+          "tokens": null,
+          "usd": null,
+          "failureCategory": "none",
+          "notes": "deterministic scaffold row from local fixture contract; not a live competitive LLM/browser measurement"
+        },
+        {
+          "library": "openchrome",
+          "taskId": "rw-003-tab-research-synthesis",
+          "mode": "deterministic-fixture",
+          "success": true,
+          "firstAttempt": true,
+          "recovered": null,
+          "wallTimeMs": 1550,
+          "toolCalls": 9,
+          "retries": 0,
+          "noProgressLoops": 0,
+          "tokens": null,
+          "usd": null,
+          "failureCategory": "none",
+          "notes": "deterministic scaffold row from local fixture contract; not a live competitive LLM/browser measurement"
+        },
+        {
+          "library": "openchrome",
+          "taskId": "rw-004-selector-drift-recovery",
+          "mode": "deterministic-fixture",
+          "success": true,
+          "firstAttempt": false,
+          "recovered": true,
+          "wallTimeMs": 2175,
+          "toolCalls": 14,
+          "retries": 1,
+          "noProgressLoops": 0,
+          "tokens": null,
+          "usd": null,
+          "failureCategory": "none",
+          "notes": "deterministic scaffold row from local fixture contract; not a live competitive LLM/browser measurement"
+        },
+        {
+          "library": "openchrome",
+          "taskId": "rw-005-long-horizon-itinerary",
+          "mode": "deterministic-fixture",
+          "success": true,
+          "firstAttempt": true,
+          "recovered": null,
+          "wallTimeMs": 1900,
+          "toolCalls": 13,
+          "retries": 0,
+          "noProgressLoops": 0,
+          "tokens": null,
+          "usd": null,
+          "failureCategory": "none",
+          "notes": "deterministic scaffold row from local fixture contract; not a live competitive LLM/browser measurement"
+        }
+      ],
+      "metrics": [
+        {
+          "library": "openchrome",
+          "mode": "deterministic-fixture",
+          "totalRuns": 5,
+          "successRate": 1,
+          "firstAttemptSuccessRate": 0.8,
+          "recoverySuccessRate": 1,
+          "meanWallTimeMs": 1640,
+          "p50WallTimeMs": 1550,
+          "p95WallTimeMs": 2175,
+          "meanToolCalls": 9.6,
+          "meanRetries": 0.2,
+          "meanNoProgressLoops": 0,
+          "meanTokens": null,
+          "costPerSuccessUsd": null
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmark/realworld-task-completion.md
+++ b/docs/benchmark/realworld-task-completion.md
@@ -1,0 +1,64 @@
+# Complex Real-World Task Completion Benchmark
+
+## Why this exists
+
+Issue #1261 measures Developer Experience (DX): lines of code per task, MCP tool-schema quality, zero-shot tool selection, and error actionability. Those are useful diagnostic signals, but they do **not** answer the primary product question:
+
+> Can an agent complete complex, realistic browser tasks more reliably with OpenChrome than with competing browser-control surfaces?
+
+This benchmark is the primary evidence axis for that question. DX remains a supporting explanation layer: if OpenChrome succeeds more often or recovers faster, schema quality, actionable errors, and lower interaction complexity can help explain why.
+
+## Scope
+
+The benchmark measures end-to-end task completion under identical instructions, budgets, and evaluation contracts.
+
+### Competitors
+
+- OpenChrome MCP
+- playwright-mcp
+- Puppeteer MCP or current maintained equivalent
+- browsermcp.io when a reproducible local runner is available
+- raw Playwright / Puppeteer agent harnesses as framework references
+
+### Task tiers
+
+1. **Local deterministic fixtures** — reproducible checkout/search/cart/form/tab tasks with contract assertions.
+2. **Stable public-reference tasks** — docs/spec lookup tasks with frozen expected answers and transcripts.
+3. **Recovery tasks** — induced selector drift, timeout, detached element, navigation failure, and stale-tab conditions.
+4. **Long-horizon tasks** — 8+ step workflows with extraction, decision, form entry, and verification.
+
+## Metrics
+
+Primary:
+
+- task success rate, with contract postconditions
+- first-attempt success rate
+- recovery success rate after induced failures
+
+Qualifying metrics:
+
+- mean / p50 / p95 wall time
+- tool calls / browser actions to success
+- retries and no-progress loops
+- token usage and cost where an LLM is involved
+- failure category: planning, navigation, grounding, extraction, form entry, auth/state, timeout, infrastructure
+
+## Controls
+
+- Same task definitions and postcondition contracts for every library.
+- Same LLM model, temperature, prompt budget, and max-step budget for LLM-driven cells.
+- Same browser/channel/profile/network profile where possible.
+- Local fixtures preferred for headline reproducibility; live tasks must be clearly labeled and isolated from local fixture claims.
+- Mock or scaffold rows must never be reported as live competitive wins.
+
+## Deliverables
+
+- `tests/benchmark/run-realworld-task-completion.ts`
+- `tests/benchmark/realworld-task-completion/` task definitions, scoring, and tests
+- `benchmark/results/realworld-task-completion.json`
+- `benchmark/results/REALWORLD-TASK-COMPLETION-REPORT.md`
+- unified report section and npm script `bench:realworld`
+
+## Relationship to #1261
+
+#1261 should stay focused on DX. This benchmark is the missing primary performance axis. Reports should cite #1261 only as a diagnostic appendix, not as proof of real-world task performance.

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "bench:episode:mock": "ts-node tests/benchmark/episode-harness/cli.ts --adapter mock",
     "bench:visual-grounding": "node scripts/bench/visual-grounding/run.mjs",
     "docs:capability-map": "ts-node scripts/gen-capability-map.ts",
-    "docs:capability-map:check": "ts-node scripts/gen-capability-map.ts --check"
+    "docs:capability-map:check": "ts-node scripts/gen-capability-map.ts --check",
+    "bench:realworld": "ts-node tests/benchmark/run-realworld-task-completion.ts && node benchmark/generate-realworld-task-completion-section.mjs"
   },
   "keywords": [
     "openchrome",

--- a/tests/benchmark/realworld-task-completion/fixtures.ts
+++ b/tests/benchmark/realworld-task-completion/fixtures.ts
@@ -1,0 +1,73 @@
+import type { RealWorldTaskRun, RealWorldTaskSpec } from './types';
+
+export const realWorldTaskSpecs: RealWorldTaskSpec[] = [
+  {
+    id: 'rw-001-checkout-update-address',
+    title: 'Update a checkout shipping address and verify recalculated summary',
+    tier: 'local-fixture',
+    goal: 'Find the checkout address form, update the shipping city/postal code, and verify the order summary reflects the new destination.',
+    maxSteps: 14,
+    successCriteria: ['address fields saved', 'summary destination updated', 'tax/shipping recalculated'],
+    complexityTags: ['form-fill', 'stateful-ui', 'verification'],
+    requiresRecovery: false,
+  },
+  {
+    id: 'rw-002-search-filter-compare',
+    title: 'Search, filter, compare two products, and extract the cheaper eligible item',
+    tier: 'local-fixture',
+    goal: 'Search a product catalog, apply availability and rating filters, compare two candidates, and report the cheaper eligible item.',
+    maxSteps: 16,
+    successCriteria: ['filters applied', 'two candidates compared', 'eligible cheaper item extracted'],
+    complexityTags: ['search', 'filtering', 'extraction', 'decision'],
+    requiresRecovery: false,
+  },
+  {
+    id: 'rw-003-tab-research-synthesis',
+    title: 'Use multiple tabs to synthesize two reference pages into one answer',
+    tier: 'stable-public-reference',
+    goal: 'Open two reference pages, extract the requested facts from each, and produce a synthesized answer with both facts.',
+    maxSteps: 18,
+    successCriteria: ['two tabs used', 'fact from page A extracted', 'fact from page B extracted', 'combined answer produced'],
+    complexityTags: ['tabs', 'reading', 'synthesis'],
+    requiresRecovery: false,
+  },
+  {
+    id: 'rw-004-selector-drift-recovery',
+    title: 'Recover from selector drift while submitting a feedback form',
+    tier: 'recovery',
+    goal: 'Submit a feedback form after the primary submit selector changes during the run.',
+    maxSteps: 20,
+    successCriteria: ['selector failure observed', 'fallback selector or semantic action used', 'form submitted'],
+    complexityTags: ['fault-recovery', 'form-fill', 'grounding'],
+    requiresRecovery: true,
+  },
+  {
+    id: 'rw-005-long-horizon-itinerary',
+    title: 'Build and verify a multi-step itinerary from constrained options',
+    tier: 'long-horizon',
+    goal: 'Filter itinerary options by date, budget, and transit time; add the best option; verify the final itinerary summary.',
+    maxSteps: 28,
+    successCriteria: ['constraints applied', 'best option selected', 'itinerary added', 'summary verified'],
+    complexityTags: ['long-horizon', 'filtering', 'decision', 'stateful-ui'],
+    requiresRecovery: false,
+  },
+];
+
+export function deterministicOpenChromeFixtureRuns(): RealWorldTaskRun[] {
+  return realWorldTaskSpecs.map((task, index) => ({
+    library: 'openchrome',
+    taskId: task.id,
+    mode: 'deterministic-fixture',
+    success: true,
+    firstAttempt: task.requiresRecovery ? false : true,
+    recovered: task.requiresRecovery ? true : null,
+    wallTimeMs: 1_200 + index * 175 + (task.requiresRecovery ? 450 : 0),
+    toolCalls: Math.min(task.maxSteps, 5 + index * 2 + (task.requiresRecovery ? 3 : 0)),
+    retries: task.requiresRecovery ? 1 : 0,
+    noProgressLoops: 0,
+    tokens: null,
+    usd: null,
+    failureCategory: 'none',
+    notes: 'deterministic scaffold row from local fixture contract; not a live competitive LLM/browser measurement',
+  }));
+}

--- a/tests/benchmark/realworld-task-completion/scoring.test.ts
+++ b/tests/benchmark/realworld-task-completion/scoring.test.ts
@@ -1,0 +1,30 @@
+/// <reference types="jest" />
+
+import { deterministicOpenChromeFixtureRuns } from './fixtures';
+import { aggregateRealWorldMetrics, assertHonestMeasurement } from './scoring';
+import type { RealWorldTaskRun } from './types';
+
+describe('real-world task completion scoring', () => {
+  test('aggregates success, first-attempt, recovery, and cost metrics', () => {
+    const runs = deterministicOpenChromeFixtureRuns();
+    const [metrics] = aggregateRealWorldMetrics(runs);
+    expect(metrics.library).toBe('openchrome');
+    expect(metrics.mode).toBe('deterministic-fixture');
+    expect(metrics.totalRuns).toBe(5);
+    expect(metrics.successRate).toBe(1);
+    expect(metrics.firstAttemptSuccessRate).toBe(4 / 5);
+    expect(metrics.recoverySuccessRate).toBe(1);
+    expect(metrics.meanTokens).toBeNull();
+    expect(metrics.costPerSuccessUsd).toBeNull();
+  });
+
+  test('honesty guard rejects deterministic rows with token/cost claims', () => {
+    const bad: RealWorldTaskRun = { ...deterministicOpenChromeFixtureRuns()[0], tokens: 100 };
+    expect(() => assertHonestMeasurement([bad])).toThrow(/must not claim token or cost/);
+  });
+
+  test('honesty guard requires deterministic notes to say deterministic', () => {
+    const bad: RealWorldTaskRun = { ...deterministicOpenChromeFixtureRuns()[0], notes: 'local row' };
+    expect(() => assertHonestMeasurement([bad])).toThrow(/identify itself/);
+  });
+});

--- a/tests/benchmark/realworld-task-completion/scoring.ts
+++ b/tests/benchmark/realworld-task-completion/scoring.ts
@@ -1,0 +1,63 @@
+import type { MeasurementMode, RealWorldLibraryMetrics, RealWorldTaskRun } from './types';
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.min(sorted.length - 1, Math.max(0, idx))];
+}
+
+export function aggregateRealWorldMetrics(runs: RealWorldTaskRun[]): RealWorldLibraryMetrics[] {
+  const byKey = new Map<string, RealWorldTaskRun[]>();
+  for (const run of runs) {
+    const key = `${run.library}\0${run.mode}`;
+    const bucket = byKey.get(key) ?? [];
+    bucket.push(run);
+    byKey.set(key, bucket);
+  }
+
+  return Array.from(byKey.entries()).map(([key, bucket]) => {
+    const [library, mode] = key.split('\0') as [string, MeasurementMode];
+    const successes = bucket.filter((run) => run.success);
+    const recoveryRuns = bucket.filter((run) => run.recovered !== null);
+    const tokenRuns = bucket.filter((run) => typeof run.tokens === 'number') as Array<RealWorldTaskRun & { tokens: number }>;
+    const usdRuns = bucket.filter((run) => typeof run.usd === 'number') as Array<RealWorldTaskRun & { usd: number }>;
+    const totalUsd = usdRuns.reduce((sum, run) => sum + run.usd, 0);
+
+    return {
+      library,
+      mode,
+      totalRuns: bucket.length,
+      successRate: successes.length / bucket.length,
+      firstAttemptSuccessRate: bucket.filter((run) => run.success && run.firstAttempt).length / bucket.length,
+      recoverySuccessRate:
+        recoveryRuns.length === 0 ? null : recoveryRuns.filter((run) => run.success && run.recovered === true).length / recoveryRuns.length,
+      meanWallTimeMs: mean(bucket.map((run) => run.wallTimeMs)),
+      p50WallTimeMs: percentile(bucket.map((run) => run.wallTimeMs), 50),
+      p95WallTimeMs: percentile(bucket.map((run) => run.wallTimeMs), 95),
+      meanToolCalls: mean(bucket.map((run) => run.toolCalls)),
+      meanRetries: mean(bucket.map((run) => run.retries)),
+      meanNoProgressLoops: mean(bucket.map((run) => run.noProgressLoops)),
+      meanTokens: tokenRuns.length === 0 ? null : mean(tokenRuns.map((run) => run.tokens)),
+      costPerSuccessUsd: successes.length === 0 || usdRuns.length === 0 ? null : totalUsd / successes.length,
+    };
+  }).sort((a, b) => a.library.localeCompare(b.library) || a.mode.localeCompare(b.mode));
+}
+
+export function assertHonestMeasurement(runs: RealWorldTaskRun[]): void {
+  for (const run of runs) {
+    if (run.mode === 'deterministic-fixture') {
+      if (run.tokens !== null || run.usd !== null) {
+        throw new Error(`deterministic run ${run.library}/${run.taskId} must not claim token or cost measurements`);
+      }
+      if (!run.notes.toLowerCase().includes('deterministic')) {
+        throw new Error(`deterministic run ${run.library}/${run.taskId} must identify itself in notes`);
+      }
+    }
+  }
+}

--- a/tests/benchmark/realworld-task-completion/types.ts
+++ b/tests/benchmark/realworld-task-completion/types.ts
@@ -1,0 +1,59 @@
+export type RealWorldTaskTier = 'local-fixture' | 'stable-public-reference' | 'recovery' | 'long-horizon';
+
+export type MeasurementMode = 'deterministic-fixture' | 'live-llm';
+
+export type FailureCategory =
+  | 'planning'
+  | 'navigation'
+  | 'grounding'
+  | 'extraction'
+  | 'form-entry'
+  | 'auth-state'
+  | 'timeout'
+  | 'infrastructure'
+  | 'none';
+
+export interface RealWorldTaskSpec {
+  id: string;
+  title: string;
+  tier: RealWorldTaskTier;
+  goal: string;
+  maxSteps: number;
+  successCriteria: string[];
+  complexityTags: string[];
+  requiresRecovery: boolean;
+}
+
+export interface RealWorldTaskRun {
+  library: string;
+  taskId: string;
+  mode: MeasurementMode;
+  success: boolean;
+  firstAttempt: boolean;
+  recovered: boolean | null;
+  wallTimeMs: number;
+  toolCalls: number;
+  retries: number;
+  noProgressLoops: number;
+  tokens: number | null;
+  usd: number | null;
+  failureCategory: FailureCategory;
+  notes: string;
+}
+
+export interface RealWorldLibraryMetrics {
+  library: string;
+  mode: MeasurementMode;
+  totalRuns: number;
+  successRate: number;
+  firstAttemptSuccessRate: number;
+  recoverySuccessRate: number | null;
+  meanWallTimeMs: number;
+  p50WallTimeMs: number;
+  p95WallTimeMs: number;
+  meanToolCalls: number;
+  meanRetries: number;
+  meanNoProgressLoops: number;
+  meanTokens: number | null;
+  costPerSuccessUsd: number | null;
+}

--- a/tests/benchmark/run-realworld-task-completion.ts
+++ b/tests/benchmark/run-realworld-task-completion.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env ts-node
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { buildResultEnvelope, assertValidResultEnvelope } from './utils/result-envelope';
+import { captureEnvironment } from './utils/environment';
+import { deterministicOpenChromeFixtureRuns, realWorldTaskSpecs } from './realworld-task-completion/fixtures';
+import { aggregateRealWorldMetrics, assertHonestMeasurement } from './realworld-task-completion/scoring';
+
+const OUTPUT_PATH = path.join(process.cwd(), 'benchmark', 'results', 'realworld-task-completion.json');
+
+function readRepoVersion(): string {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
+    return typeof pkg.version === 'string' ? pkg.version : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+export function buildRealWorldTaskCompletionResult() {
+  const runs = deterministicOpenChromeFixtureRuns();
+  assertHonestMeasurement(runs);
+  const metrics = aggregateRealWorldMetrics(runs);
+  const envelope = buildResultEnvelope({
+    axis: 'realworld-task-completion',
+    environment: captureEnvironment(),
+    competitors: [
+      {
+        name: 'openchrome',
+        version: readRepoVersion(),
+      },
+    ],
+    results: [
+      {
+        suite: 'complex-real-world-task-completion',
+        issue: '#1305',
+        measurementMode: 'deterministic-fixture',
+        claimScope: 'scaffold-only; not a live competitive measurement',
+        tasks: realWorldTaskSpecs,
+        runs,
+        metrics,
+      },
+    ],
+  });
+  assertValidResultEnvelope(envelope);
+  return envelope;
+}
+
+export function main(): void {
+  const envelope = buildRealWorldTaskCompletionResult();
+  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(envelope, null, 2) + '\n');
+
+  const result = envelope.results[0];
+  const metric = result.metrics[0];
+  console.error('Complex Real-World Task Completion (#1305)');
+  console.error(`mode: ${result.measurementMode}`);
+  console.error(`claim: ${result.claimScope}`);
+  console.error(`openchrome deterministic pass: ${(metric.successRate * 100).toFixed(1)}% (${metric.totalRuns}/${metric.totalRuns})`);
+  console.error(`first-attempt: ${(metric.firstAttemptSuccessRate * 100).toFixed(1)}%; recovery: ${metric.recoverySuccessRate === null ? 'n/a' : `${(metric.recoverySuccessRate * 100).toFixed(1)}%`}`);
+  console.error(`Saved: ${path.relative(process.cwd(), OUTPUT_PATH)}`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    console.error('real-world task-completion benchmark failed:', err);
+    process.exit(1);
+  }
+}

--- a/tests/benchmark/schemas/result.schema.json
+++ b/tests/benchmark/schemas/result.schema.json
@@ -17,7 +17,8 @@
         "speed-throughput",
         "reliability",
         "auth-usability",
-        "developer-experience"
+        "developer-experience",
+        "realworld-task-completion"
       ]
     },
     "schemaVersion": {

--- a/tests/benchmark/utils/result-envelope.ts
+++ b/tests/benchmark/utils/result-envelope.ts
@@ -20,7 +20,8 @@ export type BenchmarkAxis =
   | 'speed-throughput'
   | 'reliability'
   | 'auth-usability'
-  | 'developer-experience';
+  | 'developer-experience'
+  | 'realworld-task-completion';
 
 export interface CompetitorPin {
   name: string;
@@ -66,6 +67,7 @@ const VALID_AXES: ReadonlySet<string> = new Set<BenchmarkAxis>([
   'reliability',
   'auth-usability',
   'developer-experience',
+  'realworld-task-completion',
 ]);
 
 const REQUIRED_ENV_KEYS = [


### PR DESCRIPTION
## Summary

- Add #1305 as the primary complex real-world task-completion benchmark axis, keeping #1261 as a DX/supporting metric.
- Add a deterministic scaffold runner/report for the new axis with explicit honesty guards so fixture rows are not reported as live competitive wins.
- Wire the new axis into the benchmark result envelope, npm scripts, generated section, unified benchmark report, and Epic status tracker.

## Issue links

- Closes #1305
- Complements #1261

## Measurement scope

This PR intentionally publishes only `deterministic-fixture` scaffold rows. It does **not** claim live OpenChrome-vs-competitor performance. Future live rows must pin competitor versions and LLM settings before publication.

## Verification

- `npm run bench:realworld`
- `node benchmark/generate-benchmark-report.mjs`
- `npm test -- --runTestsByPath tests/benchmark/realworld-task-completion/scoring.test.ts tests/benchmark/utils/result-envelope.test.ts`
- `npm run build`
