### PR TITLE
Gate real-world headline claims on eligibility metadata

### DIFF
--- a/benchmark/claim-eligibility.mjs
+++ b/benchmark/claim-eligibility.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * Shared report-time claim eligibility gate (#1310).
+ *
+ * Generated benchmark reports may contain diagnostic rows, but a publishable
+ * headline claim must carry explicit claimEligibility metadata and be eligible.
+ */
+
+export function findClaimEligibilityFailures(envelope) {
+  const failures = [];
+  const results = Array.isArray(envelope?.results) ? envelope.results : [];
+  results.forEach((result, index) => {
+    const eligibility = result?.claimEligibility;
+    if (!eligibility) {
+      failures.push(`results[${index}] missing claimEligibility`);
+      return;
+    }
+    if (eligibility.eligible !== true) {
+      const reasons = Array.isArray(eligibility.reasons) ? eligibility.reasons.join('; ') : 'unknown reason';
+      failures.push(`results[${index}] not headline eligible: ${reasons}`);
+    }
+  });
+  return failures;
+}
+
+export function requireHeadlineEligibility(envelope, label = 'benchmark result') {
+  const failures = findClaimEligibilityFailures(envelope);
+  if (failures.length > 0) {
+    throw new Error(`${label} cannot be used for headline claims:\n- ${failures.join('\n- ')}`);
+  }
+}

--- a/benchmark/claim-eligibility.test.mjs
+++ b/benchmark/claim-eligibility.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { findClaimEligibilityFailures, requireHeadlineEligibility } from './claim-eligibility.mjs';
+
+const eligible = { results: [{ claimEligibility: { eligible: true, reasons: [] } }] };
+const missing = { results: [{}] };
+const diagnostic = { results: [{ claimEligibility: { eligible: false, reasons: ['mock mode'] } }] };
+
+assert.deepEqual(findClaimEligibilityFailures(eligible), []);
+assert.match(findClaimEligibilityFailures(missing)[0], /missing claimEligibility/);
+assert.match(findClaimEligibilityFailures(diagnostic)[0], /mock mode/);
+assert.doesNotThrow(() => requireHeadlineEligibility(eligible, 'eligible'));
+assert.throws(() => requireHeadlineEligibility(diagnostic, 'diagnostic'), /cannot be used for headline claims/);

--- a/benchmark/generate-realworld-task-completion-section.mjs
+++ b/benchmark/generate-realworld-task-completion-section.mjs
@@ -2,6 +2,7 @@
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
+import { findClaimEligibilityFailures, requireHeadlineEligibility } from './claim-eligibility.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -17,7 +18,8 @@ function n(value) {
   return value === null || value === undefined ? 'n/a' : Number(value).toFixed(1).replace(/\.0$/, '');
 }
 
-function main() {
+function main(argv = process.argv.slice(2)) {
+  const requireHeadline = argv.includes('--require-headline');
   if (!existsSync(INPUT_PATH)) {
     process.stderr.write(`Missing ${path.relative(REPO_ROOT, INPUT_PATH)}. Run \`npm run bench:realworld\` first.\n`);
     process.exit(1);
@@ -30,6 +32,11 @@ function main() {
     process.exit(1);
   }
 
+  if (requireHeadline) {
+    requireHeadlineEligibility(envelope, 'realworld-task-completion');
+  }
+  const eligibilityFailures = findClaimEligibilityFailures(envelope);
+
   const lines = [];
   lines.push('# Complex Real-World Task Completion (#1305)');
   lines.push('');
@@ -41,6 +48,13 @@ function main() {
   lines.push(`- Measurement mode: \`${result.measurementMode}\``);
   lines.push(`- Claim scope: **${result.claimScope}**`);
   lines.push('- This report is the scaffold/local-fixture baseline for the real-world task-completion axis. It is **not** a live competitive win claim.');
+  if (result.claimEligibility) {
+    lines.push(`- Claim eligibility tier: **${result.claimEligibility.tier}**; eligible: **${result.claimEligibility.eligible ? 'yes' : 'no'}**.`);
+    for (const reason of result.claimEligibility.reasons ?? []) lines.push(`  - Blocker: ${reason}`);
+  } else {
+    lines.push('- Claim eligibility: **missing** (headline generation must fail when `--require-headline` is used).');
+  }
+  if (eligibilityFailures.length > 0) lines.push('- Headline gate: **blocked**. Use `node benchmark/generate-realworld-task-completion-section.mjs --require-headline` in release workflows to enforce this.');
   lines.push('- #1261 remains the DX/supporting axis; this section is the primary task-completion axis.');
   lines.push('');
 

--- a/benchmark/results/REALWORLD-TASK-COMPLETION-REPORT.md
+++ b/benchmark/results/REALWORLD-TASK-COMPLETION-REPORT.md
@@ -1,6 +1,6 @@
 # Complex Real-World Task Completion (#1305)
 
-Generated: 2026-05-15T23:53:20.745Z
+Generated: 2026-05-16T17:01:45.500Z
 Source: `benchmark/results/realworld-task-completion.json` (axis: `realworld-task-completion`).
 
 ## Claim scope
@@ -8,6 +8,11 @@ Source: `benchmark/results/realworld-task-completion.json` (axis: `realworld-tas
 - Measurement mode: `deterministic-fixture`
 - Claim scope: **scaffold-only; not a live competitive measurement**
 - This report is the scaffold/local-fixture baseline for the real-world task-completion axis. It is **not** a live competitive win claim.
+- Claim eligibility tier: **diagnostic-only**; eligible: **no**.
+  - Blocker: measurement mode scaffold is not headline-eligible; use live or recorded-real
+  - Blocker: sample count 5 is below aggregate threshold N >= 10
+  - Blocker: LLM model/settings/budgets are not pinned
+- Headline gate: **blocked**. Use `node benchmark/generate-realworld-task-completion-section.mjs --require-headline` in release workflows to enforce this.
 - #1261 remains the DX/supporting axis; this section is the primary task-completion axis.
 
 ## Metrics by library

--- a/benchmark/results/realworld-task-completion.json
+++ b/benchmark/results/realworld-task-completion.json
@@ -2,8 +2,8 @@
   "axis": "realworld-task-completion",
   "schemaVersion": "1.0.0",
   "environment": {
-    "capturedAt": "2026-05-15T23:53:20.624Z",
-    "gitSha": "83d85b07",
+    "capturedAt": "2026-05-16T17:01:41.662Z",
+    "gitSha": "26c4ce33",
     "gitDirty": true,
     "nodeVersion": "v20.19.6",
     "os": "darwin 25.3.0",
@@ -222,7 +222,17 @@
           "meanTokens": null,
           "costPerSuccessUsd": null
         }
-      ]
+      ],
+      "claimEligibility": {
+        "eligible": false,
+        "tier": "diagnostic-only",
+        "reasons": [
+          "measurement mode scaffold is not headline-eligible; use live or recorded-real",
+          "sample count 5 is below aggregate threshold N >= 10",
+          "LLM model/settings/budgets are not pinned"
+        ],
+        "requiredSamples": 10
+      }
     }
   ]
 }

--- a/tests/benchmark/run-realworld-task-completion.ts
+++ b/tests/benchmark/run-realworld-task-completion.ts
@@ -6,6 +6,7 @@ import { buildResultEnvelope, assertValidResultEnvelope } from './utils/result-e
 import { captureEnvironment } from './utils/environment';
 import { deterministicOpenChromeFixtureRuns, realWorldTaskSpecs } from './realworld-task-completion/fixtures';
 import { aggregateRealWorldMetrics, assertHonestMeasurement } from './realworld-task-completion/scoring';
+import { evaluateEpisodeClaimEligibility } from './episode-harness/claim-eligibility';
 
 const OUTPUT_PATH = path.join(process.cwd(), 'benchmark', 'results', 'realworld-task-completion.json');
 
@@ -22,6 +23,15 @@ export function buildRealWorldTaskCompletionResult() {
   const runs = deterministicOpenChromeFixtureRuns();
   assertHonestMeasurement(runs);
   const metrics = aggregateRealWorldMetrics(runs);
+  const claimEligibility = evaluateEpisodeClaimEligibility({
+    mode: 'scaffold',
+    scope: 'aggregate',
+    sampleCount: runs.length,
+    finalPostconditionEvaluated: true,
+    competitorVersionsPinned: true,
+    sameTaskContracts: true,
+    llmSettingsPinned: false,
+  });
   const envelope = buildResultEnvelope({
     axis: 'realworld-task-completion',
     environment: captureEnvironment(),
@@ -40,6 +50,7 @@ export function buildRealWorldTaskCompletionResult() {
         tasks: realWorldTaskSpecs,
         runs,
         metrics,
+        claimEligibility,
       },
     ],
   });


### PR DESCRIPTION
## Summary
- Adds a shared report-time claim eligibility gate for real-world benchmark outputs.
- Adds `claimEligibility` metadata to the current real-world task-completion envelope.
- Updates the real-world report to show diagnostic blockers and fail with `--require-headline` when rows are not live/recorded-real eligible.

## Verification
- `node benchmark/claim-eligibility.test.mjs`
- `npm run build`
- `npm run bench:realworld`
- `node benchmark/generate-realworld-task-completion-section.mjs`
- `! node benchmark/generate-realworld-task-completion-section.mjs --require-headline`

## Notes
This PR intentionally keeps the current fixture rows diagnostic-only. It makes accidental headline publication fail closed.
