### PR TITLE
Ingest recorded real-world task evidence

### DIFF
--- a/tests/benchmark/realworld-task-completion/recordings.test.ts
+++ b/tests/benchmark/realworld-task-completion/recordings.test.ts
@@ -1,0 +1,52 @@
+/// <reference types="jest" />
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { buildRealWorldTaskCompletionResult } from '../run-realworld-task-completion';
+import { loadRecordedSamples, recordedSamplesToRuns } from './recordings';
+
+function sample(library: string, i: number) {
+  return {
+    library,
+    mode: 'recorded-real',
+    taskId: 'rw-001-checkout-update-address',
+    success: true,
+    firstAttempt: true,
+    recovered: null,
+    wallTimeMs: 1000 + i,
+    toolCalls: 6,
+    retries: 0,
+    noProgressLoops: 0,
+    tokens: 100 + i,
+    usd: 0.001,
+    failureCategory: 'none',
+    finalPostconditionEvidence: `postcondition ok ${i}`,
+    competitorVersion: library === 'openchrome' ? '1.12.2' : 'fixture-1.0.0',
+    llmModel: 'claude-sonnet-fixed',
+  };
+}
+
+describe('real-world recorded evidence ingestion', () => {
+  test('loads recorded samples and converts them to task runs', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rw-recordings-'));
+    fs.writeFileSync(path.join(dir, 'samples.json'), JSON.stringify([sample('openchrome', 0), sample('playwright', 1)]));
+    const samples = loadRecordedSamples(dir);
+    const runs = recordedSamplesToRuns(samples);
+    expect(samples).toHaveLength(2);
+    expect(runs.map((run) => run.mode)).toEqual(['recorded-real', 'recorded-real']);
+    expect(runs[0].notes).toMatch(/final-postcondition evidence/);
+  });
+
+  test('builds a headline-eligible aggregate when recorded evidence meets gates', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rw-recordings-'));
+    const rows = Array.from({ length: 10 }, (_, i) => sample(i % 2 === 0 ? 'openchrome' : 'playwright', i));
+    fs.writeFileSync(path.join(dir, 'samples.json'), JSON.stringify(rows));
+    const envelope = buildRealWorldTaskCompletionResult([`--recording-dir=${dir}`]);
+    const result = envelope.results[0];
+    expect(result.measurementMode).toBe('recorded-real');
+    expect(result.claimEligibility.eligible).toBe(true);
+    expect(result.metrics.map((row: { library: string }) => row.library).sort()).toEqual(['openchrome', 'playwright']);
+  });
+});

--- a/tests/benchmark/realworld-task-completion/recordings.ts
+++ b/tests/benchmark/realworld-task-completion/recordings.ts
@@ -1,0 +1,122 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { FailureCategory, RealWorldTaskRun } from './types';
+import { realWorldTaskSpecs } from './fixtures';
+
+export interface RecordedRealWorldSample {
+  library: string;
+  mode: 'recorded-real' | 'live-llm';
+  taskId: string;
+  success: boolean;
+  firstAttempt: boolean;
+  recovered: boolean | null;
+  wallTimeMs: number;
+  toolCalls: number;
+  retries: number;
+  noProgressLoops: number;
+  tokens: number | null;
+  usd: number | null;
+  failureCategory: FailureCategory;
+  finalPostconditionEvidence: string;
+  competitorVersion: string;
+  llmModel: string;
+  notes?: string;
+}
+
+const TASK_IDS = new Set(realWorldTaskSpecs.map((task) => task.id));
+
+function assertString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) throw new Error(`${label} must be a non-empty string`);
+  return value;
+}
+
+function assertNumber(value: unknown, label: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) throw new Error(`${label} must be a non-negative number`);
+  return value;
+}
+
+function assertBoolean(value: unknown, label: string): boolean {
+  if (typeof value !== 'boolean') throw new Error(`${label} must be boolean`);
+  return value;
+}
+
+function assertNullableBoolean(value: unknown, label: string): boolean | null {
+  if (value === null) return null;
+  return assertBoolean(value, label);
+}
+
+function assertNullableNumber(value: unknown, label: string): number | null {
+  if (value === null) return null;
+  return assertNumber(value, label);
+}
+
+export function parseRecordedSample(raw: unknown, source = '<memory>'): RecordedRealWorldSample {
+  if (!raw || typeof raw !== 'object') throw new Error(`${source}: sample must be an object`);
+  const obj = raw as Record<string, unknown>;
+  const taskId = assertString(obj.taskId, `${source}: taskId`);
+  if (!TASK_IDS.has(taskId)) throw new Error(`${source}: unknown taskId ${taskId}`);
+  const mode = obj.mode === 'recorded-real' || obj.mode === 'live-llm' ? obj.mode : undefined;
+  if (!mode) throw new Error(`${source}: mode must be recorded-real or live-llm`);
+  const evidence = assertString(obj.finalPostconditionEvidence, `${source}: finalPostconditionEvidence`);
+  return {
+    library: assertString(obj.library, `${source}: library`),
+    mode,
+    taskId,
+    success: assertBoolean(obj.success, `${source}: success`),
+    firstAttempt: assertBoolean(obj.firstAttempt, `${source}: firstAttempt`),
+    recovered: assertNullableBoolean(obj.recovered, `${source}: recovered`),
+    wallTimeMs: assertNumber(obj.wallTimeMs, `${source}: wallTimeMs`),
+    toolCalls: assertNumber(obj.toolCalls, `${source}: toolCalls`),
+    retries: assertNumber(obj.retries, `${source}: retries`),
+    noProgressLoops: assertNumber(obj.noProgressLoops, `${source}: noProgressLoops`),
+    tokens: assertNullableNumber(obj.tokens, `${source}: tokens`),
+    usd: assertNullableNumber(obj.usd, `${source}: usd`),
+    failureCategory: assertString(obj.failureCategory, `${source}: failureCategory`) as FailureCategory,
+    finalPostconditionEvidence: evidence,
+    competitorVersion: assertString(obj.competitorVersion, `${source}: competitorVersion`),
+    llmModel: assertString(obj.llmModel, `${source}: llmModel`),
+    notes: typeof obj.notes === 'string' ? obj.notes : '',
+  };
+}
+
+export function loadRecordedSamples(recordingDir: string): RecordedRealWorldSample[] {
+  const files = fs.readdirSync(recordingDir).filter((file) => file.endsWith('.json')).sort();
+  const samples: RecordedRealWorldSample[] = [];
+  for (const file of files) {
+    const full = path.join(recordingDir, file);
+    const parsed = JSON.parse(fs.readFileSync(full, 'utf8'));
+    const entries = Array.isArray(parsed) ? parsed : [parsed];
+    for (let i = 0; i < entries.length; i++) samples.push(parseRecordedSample(entries[i], `${file}[${i}]`));
+  }
+  return samples;
+}
+
+export function recordedSamplesToRuns(samples: readonly RecordedRealWorldSample[]): RealWorldTaskRun[] {
+  return samples.map((sample) => ({
+    library: sample.library,
+    taskId: sample.taskId,
+    mode: sample.mode,
+    success: sample.success,
+    firstAttempt: sample.firstAttempt,
+    recovered: sample.recovered,
+    wallTimeMs: sample.wallTimeMs,
+    toolCalls: sample.toolCalls,
+    retries: sample.retries,
+    noProgressLoops: sample.noProgressLoops,
+    tokens: sample.tokens,
+    usd: sample.usd,
+    failureCategory: sample.failureCategory,
+    notes: `recorded final-postcondition evidence: ${sample.finalPostconditionEvidence}${sample.notes ? `; ${sample.notes}` : ''}`,
+  }));
+}
+
+export function competitorPinsFromRecordings(samples: readonly RecordedRealWorldSample[]): Array<{ name: string; version: string; measuredAt?: string }> {
+  const byLibrary = new Map<string, string>();
+  for (const sample of samples) {
+    const existing = byLibrary.get(sample.library);
+    if (existing && existing !== sample.competitorVersion) throw new Error(`multiple versions recorded for ${sample.library}: ${existing}, ${sample.competitorVersion}`);
+    byLibrary.set(sample.library, sample.competitorVersion);
+  }
+  return Array.from(byLibrary.entries()).sort(([a], [b]) => a.localeCompare(b)).map(([name, version]) => ({ name, version }));
+}

--- a/tests/benchmark/realworld-task-completion/types.ts
+++ b/tests/benchmark/realworld-task-completion/types.ts
@@ -1,6 +1,6 @@
 export type RealWorldTaskTier = 'local-fixture' | 'stable-public-reference' | 'recovery' | 'long-horizon';
 
-export type MeasurementMode = 'deterministic-fixture' | 'live-llm';
+export type MeasurementMode = 'deterministic-fixture' | 'recorded-real' | 'live-llm';
 
 export type FailureCategory =
   | 'planning'

--- a/tests/benchmark/run-realworld-task-completion.ts
+++ b/tests/benchmark/run-realworld-task-completion.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import { buildResultEnvelope, assertValidResultEnvelope } from './utils/result-envelope';
 import { captureEnvironment } from './utils/environment';
 import { deterministicOpenChromeFixtureRuns, realWorldTaskSpecs } from './realworld-task-completion/fixtures';
+import { competitorPinsFromRecordings, loadRecordedSamples, recordedSamplesToRuns } from './realworld-task-completion/recordings';
 import { aggregateRealWorldMetrics, assertHonestMeasurement } from './realworld-task-completion/scoring';
 import { evaluateEpisodeClaimEligibility } from './episode-harness/claim-eligibility';
 
@@ -19,23 +20,33 @@ function readRepoVersion(): string {
   }
 }
 
-export function buildRealWorldTaskCompletionResult() {
-  const runs = deterministicOpenChromeFixtureRuns();
+function flagValue(argv: string[], name: string): string | undefined {
+  const idx = argv.indexOf(name);
+  if (idx !== -1) return argv[idx + 1];
+  const prefix = `${name}=`;
+  const match = argv.find((arg) => arg.startsWith(prefix));
+  return match ? match.slice(prefix.length) : undefined;
+}
+
+export function buildRealWorldTaskCompletionResult(argv: string[] = []) {
+  const recordingDir = flagValue(argv, '--recording-dir');
+  const recordedSamples = recordingDir ? loadRecordedSamples(recordingDir) : [];
+  const runs = recordingDir ? recordedSamplesToRuns(recordedSamples) : deterministicOpenChromeFixtureRuns();
   assertHonestMeasurement(runs);
   const metrics = aggregateRealWorldMetrics(runs);
   const claimEligibility = evaluateEpisodeClaimEligibility({
-    mode: 'scaffold',
+    mode: recordingDir ? 'recorded-real' : 'scaffold',
     scope: 'aggregate',
     sampleCount: runs.length,
     finalPostconditionEvaluated: true,
-    competitorVersionsPinned: true,
+    competitorVersionsPinned: recordingDir ? recordedSamples.every((sample) => sample.competitorVersion.length > 0) : true,
     sameTaskContracts: true,
-    llmSettingsPinned: false,
+    llmSettingsPinned: recordingDir ? recordedSamples.every((sample) => sample.llmModel.length > 0) : false,
   });
   const envelope = buildResultEnvelope({
     axis: 'realworld-task-completion',
     environment: captureEnvironment(),
-    competitors: [
+    competitors: recordingDir ? competitorPinsFromRecordings(recordedSamples) : [
       {
         name: 'openchrome',
         version: readRepoVersion(),
@@ -45,8 +56,8 @@ export function buildRealWorldTaskCompletionResult() {
       {
         suite: 'complex-real-world-task-completion',
         issue: '#1305',
-        measurementMode: 'deterministic-fixture',
-        claimScope: 'scaffold-only; not a live competitive measurement',
+        measurementMode: recordingDir ? 'recorded-real' : 'deterministic-fixture',
+        claimScope: recordingDir ? 'recorded-real aggregate; eligible only if sample/version/LLM gates pass' : 'scaffold-only; not a live competitive measurement',
         tasks: realWorldTaskSpecs,
         runs,
         metrics,
@@ -59,7 +70,7 @@ export function buildRealWorldTaskCompletionResult() {
 }
 
 export function main(): void {
-  const envelope = buildRealWorldTaskCompletionResult();
+  const envelope = buildRealWorldTaskCompletionResult(process.argv.slice(2));
   fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
   fs.writeFileSync(OUTPUT_PATH, JSON.stringify(envelope, null, 2) + '\n');
 


### PR DESCRIPTION
## Summary
- Adds a recorded-real ingestion path for real-world task-completion evidence files.
- Validates task IDs, final postcondition evidence, competitor versions, and LLM model pins before converting samples to benchmark rows.
- Allows `run-realworld-task-completion` to produce headline-eligible aggregate envelopes when recorded evidence satisfies sample/version/LLM gates.

## Verification
- `npm run build`
- `npx jest tests/benchmark/realworld-task-completion/recordings.test.ts tests/benchmark/episode-harness/claim-eligibility.test.ts --runInBand`

## Notes
This PR does not fabricate recorded evidence. It provides the ingestion/validation/report path for operator-captured recordings.
