### PR TITLE
Record throughput cold versus reused session mode

### DIFF
--- a/benchmark/results/speed-throughput.json
+++ b/benchmark/results/speed-throughput.json
@@ -2,8 +2,8 @@
   "axis": "speed-throughput",
   "schemaVersion": "1.0.0",
   "environment": {
-    "capturedAt": "2026-05-16T03:34:35.182Z",
-    "gitSha": "217fe98d",
+    "capturedAt": "2026-05-16T17:41:01.275Z",
+    "gitSha": "88ea93eb",
     "gitDirty": true,
     "nodeVersion": "v20.19.6",
     "os": "darwin 25.3.0",
@@ -29,6 +29,7 @@
     {
       "library": "OpenChrome",
       "mode": "dom-stub",
+      "sessionMode": "cold",
       "concurrency": 1,
       "pagesPerPass": 50,
       "sampleCount": 1,
@@ -43,16 +44,17 @@
     {
       "library": "Crawlee",
       "mode": "cheerio-text",
+      "sessionMode": "cold",
       "concurrency": 1,
       "pagesPerPass": 50,
       "sampleCount": 1,
       "warmupDiscarded": 3,
-      "rawPagesPerSecond": 135.13513513513513,
+      "rawPagesPerSecond": 2631.5789473684213,
       "successRate": 1,
-      "effectivePagesPerSecond": 135.13513513513513,
-      "meanWallMs": 370,
-      "p50WallMs": 370,
-      "p95WallMs": 370
+      "effectivePagesPerSecond": 2631.5789473684213,
+      "meanWallMs": 19,
+      "p50WallMs": 19,
+      "p95WallMs": 19
     }
   ]
 }

--- a/tests/benchmark/run-throughput.test.ts
+++ b/tests/benchmark/run-throughput.test.ts
@@ -24,6 +24,12 @@ describe('run-throughput competitor selection', () => {
     expect(opts.includeLiveCompetitors).toBe(false);
     expect(opts.concurrencies).toEqual([1, 5]);
     expect(opts.iterations).toBe(5);
+    expect(opts.sessionMode).toBe('reuse');
+  });
+
+  test('parses cold session mode', () => {
+    const opts = parseThroughputArgs(['--session-mode=cold']);
+    expect(opts.sessionMode).toBe('cold');
   });
 
   test('can run the no-Chrome Crawlee competitor cell against local fixtures', async () => {
@@ -36,6 +42,7 @@ describe('run-throughput competitor selection', () => {
     );
     expect(rows).toHaveLength(1);
     expect(rows[0].library).toBe('Crawlee');
+    expect(rows[0].sessionMode).toBe('reuse');
     expect(rows[0].sampleCount).toBe(1);
     expect(rows[0].pagesPerPass).toBeGreaterThan(0);
   }, 30000);
@@ -52,3 +59,17 @@ describe('run-throughput competitor selection', () => {
     expect(rows.map((row) => row.library).sort()).toEqual(['Crawlee', 'OpenChrome']);
   }, 30000);
 });
+
+
+test('cold session mode records cold-start rows for each concurrency cell', async () => {
+  const rows = await runThroughputBenchmark(
+    parseThroughputArgs([
+      '--library=crawlee',
+      '--session-mode=cold',
+      '--concurrency=1,2',
+      '--iterations=4',
+    ]),
+  );
+  expect(rows).toHaveLength(2);
+  expect(rows.every((row) => row.sessionMode === 'cold')).toBe(true);
+}, 30000);

--- a/tests/benchmark/run-throughput.ts
+++ b/tests/benchmark/run-throughput.ts
@@ -63,6 +63,8 @@ export type ThroughputLibrary =
   | "crawlee"
   | "all";
 
+export type ThroughputSessionMode = 'reuse' | 'cold';
+
 export interface ThroughputRunOptions {
   /** When true, use the deterministic stub adapter for OpenChrome unless live is set. */
   ciMode: boolean;
@@ -78,11 +80,14 @@ export interface ThroughputRunOptions {
   library: ThroughputLibrary;
   /** Include Chrome/CDP competitors when `library=all` and live mode is disabled. */
   includeLiveCompetitors: boolean;
+  /** Reuse one adapter setup per library, or cold-start setup/teardown for every concurrency cell. */
+  sessionMode: ThroughputSessionMode;
 }
 
 export interface ThroughputRow {
   library: string;
   mode: string;
+  sessionMode: ThroughputSessionMode;
   concurrency: number;
   pagesPerPass: number;
   sampleCount: number;
@@ -120,6 +125,12 @@ function flagValue(argv: string[], name: string): string | undefined {
   const prefix = `${name}=`;
   const match = argv.find((arg) => arg.startsWith(prefix));
   return match ? match.slice(prefix.length) : undefined;
+}
+
+function parseSessionMode(value: string | undefined): ThroughputSessionMode {
+  if (value === undefined) return 'reuse';
+  if (value === 'reuse' || value === 'cold') return value;
+  throw new Error(`--session-mode must be reuse or cold; got: ${value}`);
 }
 
 function parseBooleanFlag(
@@ -178,6 +189,9 @@ export function parseThroughputArgs(argv: string[]): ThroughputRunOptions {
       process.env.OPENCHROME_BENCH_INCLUDE_LIVE_COMPETITORS,
     liveFlag,
   );
+  const sessionMode = parseSessionMode(
+    flagValue(argv, "--session-mode") ?? process.env.OPENCHROME_BENCH_SESSION_MODE,
+  );
   return {
     ciMode,
     iterations,
@@ -186,17 +200,20 @@ export function parseThroughputArgs(argv: string[]): ThroughputRunOptions {
     live: liveFlag,
     library,
     includeLiveCompetitors,
+    sessionMode,
   };
 }
 
 function toRow(
   library: string,
   mode: string,
+  sessionMode: ThroughputSessionMode,
   summary: ThroughputSummary,
 ): ThroughputRow {
   return {
     library,
     mode,
+    sessionMode,
     concurrency: summary.concurrency,
     pagesPerPass: summary.pagesPerPass,
     sampleCount: summary.sampleCount,
@@ -317,19 +334,36 @@ export async function runThroughputBenchmark(
   const rows: ThroughputRow[] = [];
   try {
     for (const entry of entries) {
-      try {
-        if (entry.adapter.setup) await entry.adapter.setup();
-        for (const concurrency of options.concurrencies) {
-          const summary = await measureThroughput(entry.adapter, {
-            urls,
-            concurrency,
-            iterations: options.iterations,
-            warmupDiscard: options.warmupDiscard,
-          });
-          rows.push(toRow(entry.library, entry.mode, summary));
+      if (options.sessionMode === 'reuse') {
+        try {
+          if (entry.adapter.setup) await entry.adapter.setup();
+          for (const concurrency of options.concurrencies) {
+            const summary = await measureThroughput(entry.adapter, {
+              urls,
+              concurrency,
+              iterations: options.iterations,
+              warmupDiscard: options.warmupDiscard,
+            });
+            rows.push(toRow(entry.library, entry.mode, options.sessionMode, summary));
+          }
+        } finally {
+          if (entry.adapter.teardown) await entry.adapter.teardown();
         }
-      } finally {
-        if (entry.adapter.teardown) await entry.adapter.teardown();
+      } else {
+        for (const concurrency of options.concurrencies) {
+          try {
+            if (entry.adapter.setup) await entry.adapter.setup();
+            const summary = await measureThroughput(entry.adapter, {
+              urls,
+              concurrency,
+              iterations: options.iterations,
+              warmupDiscard: options.warmupDiscard,
+            });
+            rows.push(toRow(entry.library, entry.mode, options.sessionMode, summary));
+          } finally {
+            if (entry.adapter.teardown) await entry.adapter.teardown();
+          }
+        }
       }
     }
   } finally {
@@ -341,13 +375,14 @@ export async function runThroughputBenchmark(
 function formatReport(rows: ThroughputRow[]): string {
   const lines = [
     "Throughput benchmark (#1258) — raw + success + effective (labeled secondary)",
-    "library      mode       conc   raw pg/s   success   effective   p50(ms)   p95(ms)   samples",
+    "library      mode       session conc   raw pg/s   success   effective   p50(ms)   p95(ms)   samples",
   ];
   for (const r of rows) {
     lines.push(
       [
         r.library.padEnd(12),
         r.mode.padEnd(10),
+        r.sessionMode.padEnd(7),
         String(r.concurrency).padStart(4),
         r.rawPagesPerSecond.toFixed(1).padStart(10),
         (r.successRate * 100).toFixed(1).padStart(7) + "%",


### PR DESCRIPTION
## Summary
- Adds `--session-mode=reuse|cold` to throughput runs.
- Persists `sessionMode` on every throughput result row.
- Adds tests for parsing and cold-session execution across multiple concurrency cells.

## Verification
- `npm run build`
- `npx jest tests/benchmark/run-throughput.test.ts --runInBand`
- `npm run bench:throughput -- --library=all --include-live-competitors=false --session-mode=cold --concurrency=1 --iterations=4`

## Notes
Live/CDP rows remain behind the live gate. This PR makes session lifecycle explicit so live operators can compute reuse deltas without mixing row semantics.
