### PR TITLE
Ingest recorded live token payloads

### DIFF
--- a/tests/benchmark/extractors/live-only.ts
+++ b/tests/benchmark/extractors/live-only.ts
@@ -6,7 +6,7 @@
  * browser_snapshot, browser-use DOM serialization). Playwright content and
  * innerText run deterministically from frozen fixture HTML because those APIs
  * map directly to raw HTML/body text for this corpus. Today the
- * runner ships their `Extractor` entries as live-only scaffolds — they
+ * runner ships the remaining `Extractor` entries as live-only scaffolds — they
  * advertise `liveOnly: true` and the matrix runner emits a clean skip
  * annotation in `--skip-live` mode instead of fabricating numbers.
  *
@@ -14,9 +14,12 @@
  * `extract()` stub with the real library call without touching the matrix
  * runner. CI stays green via `--skip-live`; an operator with a Chrome on
  * :9222 runs `OPENCHROME_BENCH_LIVE=1 npm run bench:tokens` to exercise the
- * real cells.
+ * real cells. Operators can also provide recorded payload files through
+ * `OPENCHROME_BENCH_RECORDED_TOKENS_DIR` to measure captured live payloads
+ * without launching those runtimes during CI.
  */
 
+import { loadRecordedPayload } from './recorded-payload';
 import type { Extractor, ExtractorContext, ExtractorResult } from './types';
 
 function liveOnlyStub(library: string, mode: string): Extractor {
@@ -25,6 +28,8 @@ function liveOnlyStub(library: string, mode: string): Extractor {
     mode,
     liveOnly: true,
     extract(ctx: ExtractorContext): ExtractorResult | null {
+      const recorded = loadRecordedPayload(library, ctx);
+      if (recorded) return recorded;
       if (!ctx.liveAllowed) return null;
       // When the operator sets OPENCHROME_BENCH_LIVE=1, the runner expects a
       // real measurement — but the integration code lands in the next PR.

--- a/tests/benchmark/extractors/recorded-payload.test.ts
+++ b/tests/benchmark/extractors/recorded-payload.test.ts
@@ -1,0 +1,38 @@
+/// <reference types="jest" />
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { liveOnlyExtractors } from './live-only';
+import { recordedPayloadPath } from './recorded-payload';
+
+describe('recorded token payload ingestion', () => {
+  const oldEnv = process.env.OPENCHROME_BENCH_RECORDED_TOKENS_DIR;
+
+  afterEach(() => {
+    if (oldEnv === undefined) delete process.env.OPENCHROME_BENCH_RECORDED_TOKENS_DIR;
+    else process.env.OPENCHROME_BENCH_RECORDED_TOKENS_DIR = oldEnv;
+  });
+
+  test('lets live-only extractors use operator-recorded payloads without live runtime', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-recordings-'));
+    const extractor = liveOnlyExtractors[0];
+    process.env.OPENCHROME_BENCH_RECORDED_TOKENS_DIR = dir;
+    fs.writeFileSync(recordedPayloadPath(dir, extractor.library, 'fixture-a'), JSON.stringify({
+      payload: 'recorded payload',
+      extracted: { title: 'Recorded' },
+      evidence: { source: 'recorded-live', capturedAt: '2026-05-17T00:00:00.000Z', libraryVersion: '1.0.0' },
+    }));
+
+    const result = extractor.extract({
+      html: '<html></html>',
+      fixtureName: 'fixture-a',
+      archetype: 'test',
+      groundTruth: { fixture: 'fixture-a', fields: [{ key: 'title', expected: 'Recorded' }] },
+      liveAllowed: false,
+    });
+
+    expect(result).toEqual({ payload: 'recorded payload', extracted: { title: 'Recorded' } });
+  });
+});

--- a/tests/benchmark/extractors/recorded-payload.ts
+++ b/tests/benchmark/extractors/recorded-payload.ts
@@ -1,0 +1,39 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { ExtractorContext, ExtractorResult } from './types';
+
+export interface RecordedPayloadFile {
+  payload: string;
+  extracted: Record<string, string | null>;
+  evidence: {
+    source: 'recorded-live' | 'recorded-real';
+    capturedAt: string;
+    libraryVersion: string;
+  };
+}
+
+function safeName(value: string): string {
+  return value.replace(/[^a-z0-9_.-]+/gi, '_');
+}
+
+export function recordedPayloadPath(root: string, library: string, fixtureName: string): string {
+  return path.join(root, `${safeName(library)}__${safeName(fixtureName)}.json`);
+}
+
+export function loadRecordedPayload(library: string, ctx: ExtractorContext): ExtractorResult | null {
+  const root = process.env.OPENCHROME_BENCH_RECORDED_TOKENS_DIR;
+  if (!root || !ctx.fixtureName) return null;
+  const file = recordedPayloadPath(root, library, ctx.fixtureName);
+  if (!fs.existsSync(file)) return null;
+  const parsed = JSON.parse(fs.readFileSync(file, 'utf8')) as RecordedPayloadFile;
+  if (typeof parsed.payload !== 'string') throw new Error(`${file}: payload must be string`);
+  if (!parsed.extracted || typeof parsed.extracted !== 'object') throw new Error(`${file}: extracted must be object`);
+  if (!parsed.evidence || (parsed.evidence.source !== 'recorded-live' && parsed.evidence.source !== 'recorded-real')) {
+    throw new Error(`${file}: evidence.source must be recorded-live or recorded-real`);
+  }
+  if (typeof parsed.evidence.libraryVersion !== 'string' || parsed.evidence.libraryVersion.length === 0) {
+    throw new Error(`${file}: evidence.libraryVersion is required`);
+  }
+  return { payload: parsed.payload, extracted: parsed.extracted };
+}

--- a/tests/benchmark/extractors/types.ts
+++ b/tests/benchmark/extractors/types.ts
@@ -53,6 +53,10 @@ export type CellOutcome = SkippedCell | RunCell;
 export interface ExtractorContext {
   /** Full fixture HTML — every extractor's input. */
   html: string;
+  /** Stable fixture name, used by recorded live-payload ingestion. */
+  fixtureName?: string;
+  /** Fixture archetype, used by recorded live-payload ingestion/reporting. */
+  archetype?: string;
   /** Ground truth — extractors may use it to know which keys to populate. */
   groundTruth: GroundTruthSpec;
   /** Set when `OPENCHROME_BENCH_LIVE=1` — gate for live-only extractors. */

--- a/tests/benchmark/run-token-efficiency.ts
+++ b/tests/benchmark/run-token-efficiency.ts
@@ -142,6 +142,8 @@ export function scoreCell(
   for (let i = 0; i < options.samplesPerCell; i++) {
     result = extractor.extract({
       html: fixture.html,
+      fixtureName: fixture.name,
+      archetype: fixture.archetype,
       groundTruth: fixture.groundTruth,
       liveAllowed: options.liveAllowed,
     });


### PR DESCRIPTION
## Summary
- Adds fixture-aware context to token extractors.
- Adds recorded live/real payload ingestion for live-only token extractors via `OPENCHROME_BENCH_RECORDED_TOKENS_DIR`.
- Keeps default CI behavior unchanged: live-only cells still skip unless a recorded payload or live runtime is present.

## Verification
- `npm run build`
- `npx jest tests/benchmark/extractors/recorded-payload.test.ts tests/benchmark/run-token-efficiency.test.ts --runInBand`

## Notes
This is the safe non-synthetic path for operator-captured OpenChrome/Playwright accessibility/playwright-mcp/browser-use token payloads to enter the same scoring matrix.
