### PR TITLE
Account LLM token and dollar budgets

### DIFF
--- a/tests/benchmark/webvoyager/llm/claude-adapter.ts
+++ b/tests/benchmark/webvoyager/llm/claude-adapter.ts
@@ -27,6 +27,7 @@
 import type { EvalContext } from '../../../../src/contracts/eval-context';
 import type { BudgetCaps } from './budget';
 import type { WebVoyagerTask } from '../types';
+import { accountLlmBudget, LlmUsageSample } from './token-budget';
 
 export interface ClaudeAdapterPricing {
   input_usd_per_million: number;
@@ -43,6 +44,9 @@ export interface ClaudeAdapterResult {
   tool_calls: number;
   response_bytes: number;
   usd_spent: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  total_tokens?: number;
   /** Reason the task aborted before producing a final state, if any. */
   aborted?: 'BUDGET_EXCEEDED' | 'MAX_ITERATIONS' | 'API_ERROR';
 }
@@ -56,6 +60,18 @@ export interface ClaudeAdapterResult {
  * loop and (b) v1 CI gating uses mock-mode only. The scaffold demonstrates
  * the budget plumbing and surfaces the integration seam for the recorder.
  */
+export function summarizeClaudeUsage(samples: readonly LlmUsageSample[], budget: BudgetCaps, pricing: ClaudeAdapterPricing = DEFAULT_PRICING): Pick<ClaudeAdapterResult, 'tool_calls' | 'usd_spent' | 'input_tokens' | 'output_tokens' | 'total_tokens' | 'aborted'> {
+  const accounted = accountLlmBudget(samples, budget, pricing);
+  return {
+    tool_calls: accounted.toolCalls,
+    usd_spent: accounted.usdSpent,
+    input_tokens: accounted.inputTokens,
+    output_tokens: accounted.outputTokens,
+    total_tokens: accounted.totalTokens,
+    ...(accounted.aborted && { aborted: accounted.aborted }),
+  };
+}
+
 export async function runClaudeTask(
   _task: WebVoyagerTask,
   _budget: BudgetCaps,

--- a/tests/benchmark/webvoyager/llm/token-budget.test.ts
+++ b/tests/benchmark/webvoyager/llm/token-budget.test.ts
@@ -1,0 +1,36 @@
+/// <reference types="jest" />
+
+import { WEBVOYAGER_BUDGET } from './budget';
+import { accountLlmBudget, estimateUsd } from './token-budget';
+
+const pricing = { input_usd_per_million: 3, output_usd_per_million: 15 };
+
+describe('LLM token/USD budget accounting', () => {
+  test('estimates USD from input and output tokens', () => {
+    expect(estimateUsd(1_000_000, 1_000_000, pricing)).toBe(18);
+  });
+
+  test('aggregates usage samples without aborting under budget', () => {
+    const result = accountLlmBudget([
+      { inputTokens: 1000, outputTokens: 200, toolCalls: 2 },
+      { inputTokens: 500, outputTokens: 100, toolCalls: 1 },
+    ], WEBVOYAGER_BUDGET, pricing);
+    expect(result.totalTokens).toBe(1800);
+    expect(result.toolCalls).toBe(3);
+    expect(result.aborted).toBeUndefined();
+  });
+
+  test('aborts when the USD ceiling is exceeded', () => {
+    const result = accountLlmBudget([
+      { inputTokens: 500_000, outputTokens: 500_000, toolCalls: 1 },
+    ], { ...WEBVOYAGER_BUDGET, max_usd_per_task: 0.01 }, pricing);
+    expect(result.aborted).toBe('BUDGET_EXCEEDED');
+  });
+
+  test('aborts when max tool iterations are exceeded', () => {
+    const result = accountLlmBudget([
+      { inputTokens: 10, outputTokens: 10, toolCalls: 51 },
+    ], WEBVOYAGER_BUDGET, pricing);
+    expect(result.aborted).toBe('MAX_ITERATIONS');
+  });
+});

--- a/tests/benchmark/webvoyager/llm/token-budget.ts
+++ b/tests/benchmark/webvoyager/llm/token-budget.ts
@@ -1,0 +1,45 @@
+import type { BudgetCaps } from './budget';
+import type { ClaudeAdapterPricing } from './claude-adapter';
+
+export interface LlmUsageSample {
+  inputTokens: number;
+  outputTokens: number;
+  toolCalls: number;
+}
+
+export interface LlmBudgetAccountingResult {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  toolCalls: number;
+  usdSpent: number;
+  aborted?: 'BUDGET_EXCEEDED' | 'MAX_ITERATIONS';
+}
+
+export function estimateUsd(inputTokens: number, outputTokens: number, pricing: ClaudeAdapterPricing): number {
+  return (inputTokens / 1_000_000) * pricing.input_usd_per_million +
+    (outputTokens / 1_000_000) * pricing.output_usd_per_million;
+}
+
+export function accountLlmBudget(samples: readonly LlmUsageSample[], caps: BudgetCaps, pricing: ClaudeAdapterPricing): LlmBudgetAccountingResult {
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let toolCalls = 0;
+  for (const sample of samples) {
+    if (!Number.isFinite(sample.inputTokens) || sample.inputTokens < 0) throw new Error('inputTokens must be non-negative');
+    if (!Number.isFinite(sample.outputTokens) || sample.outputTokens < 0) throw new Error('outputTokens must be non-negative');
+    if (!Number.isFinite(sample.toolCalls) || sample.toolCalls < 0) throw new Error('toolCalls must be non-negative');
+    inputTokens += sample.inputTokens;
+    outputTokens += sample.outputTokens;
+    toolCalls += sample.toolCalls;
+    const usdSpent = estimateUsd(inputTokens, outputTokens, pricing);
+    if (toolCalls > caps.max_tool_iterations) {
+      return { inputTokens, outputTokens, totalTokens: inputTokens + outputTokens, toolCalls, usdSpent, aborted: 'MAX_ITERATIONS' };
+    }
+    if (usdSpent > caps.max_usd_per_task) {
+      return { inputTokens, outputTokens, totalTokens: inputTokens + outputTokens, toolCalls, usdSpent, aborted: 'BUDGET_EXCEEDED' };
+    }
+  }
+  const usdSpent = estimateUsd(inputTokens, outputTokens, pricing);
+  return { inputTokens, outputTokens, totalTokens: inputTokens + outputTokens, toolCalls, usdSpent };
+}


### PR DESCRIPTION
## Summary
- Adds deterministic LLM token/USD budget accounting for WebVoyager/episode loops.
- Tracks input/output/total tokens, tool calls, USD spent, and budget abort reasons.
- Exposes `summarizeClaudeUsage` so the live Claude adapter can use the same tested accounting path once SDK tool-use is wired.

## Verification
- `npm run build`
- `npx jest tests/benchmark/webvoyager/llm/token-budget.test.ts --runInBand`

## Notes
This does not call the live Anthropic API. It removes the credential dependency from budget enforcement tests and keeps the future live loop fail-closed.
