### PR TITLE
Add benchmark Chrome launcher and 12-PR plan

### DIFF
--- a/docs/benchmarks/publishable-benchmark-12pr-plan.md
+++ b/docs/benchmarks/publishable-benchmark-12pr-plan.md
@@ -1,0 +1,69 @@
+# Publishable benchmark implementation plan: 12 PRs
+
+This plan turns OpenChrome's diagnostic benchmark harness into a publishable live/recorded-real competitive benchmark system. Each PR must preserve the diagnostic/headline boundary and fail closed when credentials or runtimes are missing.
+
+## PR1 — Chrome launcher + runtime preflight expansion
+Acceptance criteria:
+- Provide a benchmark-owned Chrome launch helper with explicit profile dir, remote-debugging port, readiness probe, and cleanup.
+- Runtime preflight can either check an existing CDP endpoint or launch a managed Chrome when requested.
+- CI tests use injected process/probe seams; no real Chrome dependency.
+
+## PR2 — LLM provider abstraction
+Acceptance criteria:
+- Define vendor-neutral provider, turn result, tool call, and usage interfaces.
+- Normalize Anthropic/OpenAI token usage and stop reasons.
+- Keep API keys out of logs and result artifacts.
+
+## PR3 — Anthropic tool-use loop
+Acceptance criteria:
+- Implement Messages API tool-use loop behind `ANTHROPIC_API_KEY` and explicit live flag.
+- Dispatch normalized tool calls to benchmark adapters.
+- Enforce max tokens, max iterations, USD caps, and record artifacts.
+
+## PR4 — OpenAI tool-use loop
+Acceptance criteria:
+- Implement OpenAI Responses/Chat tool loop behind `OPENAI_API_KEY` and explicit live flag.
+- Use the same provider abstraction and budget accounting as Anthropic.
+- Preserve deterministic injected tests.
+
+## PR5 — Live real-world episode runner
+Acceptance criteria:
+- Run `library × task × repetition` real-world episodes through a chosen provider and browser adapter.
+- Evaluate final postconditions, classify failure, and write live/recorded-real artifacts.
+- Never promote rows without claim eligibility.
+
+## PR6 — playwright-mcp native loop
+Acceptance criteria:
+- Drive `@playwright/mcp` native tools, not just passive translated calls.
+- Capture tool list, tool trace, task result, and explicit unsupported/failure reasons.
+
+## PR7 — browser-use native loop
+Acceptance criteria:
+- Extend Python bridge to run task-level browser-use agent instructions.
+- Return final answer, trace, failure category, timeout, and postcondition evidence.
+
+## PR8 — Live token extractor wiring
+Acceptance criteria:
+- Wire OpenChrome read_page/AX, Playwright accessibility, playwright-mcp snapshot, and browser-use DOM payloads.
+- Keep recorded payload fallback distinct from live payloads.
+
+## PR9 — Live throughput executor
+Acceptance criteria:
+- Use managed/existing Chrome CDP to run OpenChrome, Playwright, Puppeteer live throughput rows.
+- Record cold/reuse session mode, concurrency, retries, and failure classification.
+
+## PR10 — Fault injection inside episodes
+Acceptance criteria:
+- Add fault plan schema and episode hooks for selector drift, network stall, target closed, delayed DOM, and CDP disconnect.
+- Reliability primary metric derives from final task postcondition after fault injection.
+
+## PR11 — Recording corpus schema/validator
+Acceptance criteria:
+- Validate manifest, run files, version pins, LLM settings, redaction status, and final postcondition evidence.
+- Provide CLI to validate corpus before report generation.
+
+## PR12 — Headline report enforcement
+Acceptance criteria:
+- All live/recorded-real report paths require claimEligibility metadata.
+- `--require-headline` fails if sample thresholds, version pins, LLM pins, or postcondition evidence are missing.
+- Unified report separates diagnostic and headline evidence.

--- a/tests/benchmark/runtime/chrome-launcher.test.ts
+++ b/tests/benchmark/runtime/chrome-launcher.test.ts
@@ -1,0 +1,27 @@
+/// <reference types="jest" />
+
+import { EventEmitter } from 'events';
+import { launchManagedChrome, resolveChromePath } from './chrome-launcher';
+
+describe('benchmark Chrome launcher', () => {
+  test('resolves explicit chrome path from env', () => {
+    expect(resolveChromePath({ OPENCHROME_BENCH_CHROME_PATH: '/tmp/chrome' } as NodeJS.ProcessEnv, 'linux')).toBe('/tmp/chrome');
+  });
+
+  test('launches with benchmark-safe flags and waits for probe', async () => {
+    const calls: { cmd: string; args: string[] }[] = [];
+    const fakeProc = Object.assign(new EventEmitter(), { pid: 123, killed: false, kill() { this.killed = true; return true; } });
+    const managed = await launchManagedChrome({
+      chromePath: '/bin/chrome',
+      port: 9333,
+      userDataDir: '/tmp/profile',
+      probe: async () => true,
+      spawnImpl: ((cmd: string, args: string[]) => { calls.push({ cmd, args }); return fakeProc; }) as never,
+    });
+    expect(managed.endpoint).toBe('http://127.0.0.1:9333');
+    expect(calls[0].args).toContain('--remote-debugging-port=9333');
+    expect(calls[0].args).toContain('--user-data-dir=/tmp/profile');
+    await managed.close();
+    expect(fakeProc.killed).toBe(true);
+  });
+});

--- a/tests/benchmark/runtime/chrome-launcher.ts
+++ b/tests/benchmark/runtime/chrome-launcher.ts
@@ -1,0 +1,77 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ChildProcess, spawn } from 'child_process';
+
+export interface ChromeLaunchOptions {
+  chromePath?: string;
+  port: number;
+  userDataDir?: string;
+  extraArgs?: string[];
+  spawnImpl?: typeof spawn;
+  probe?: (endpoint: string) => Promise<boolean>;
+  readinessTimeoutMs?: number;
+  pollIntervalMs?: number;
+}
+
+export interface ManagedChrome {
+  endpoint: string;
+  userDataDir: string;
+  pid?: number;
+  close(): Promise<void>;
+}
+
+export function resolveChromePath(env = process.env, platform = process.platform): string | null {
+  if (env.OPENCHROME_BENCH_CHROME_PATH) return env.OPENCHROME_BENCH_CHROME_PATH;
+  if (platform === 'darwin') {
+    const p = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+    return fs.existsSync(p) ? p : null;
+  }
+  if (platform === 'win32') return env.ProgramFiles ? path.join(env.ProgramFiles, 'Google', 'Chrome', 'Application', 'chrome.exe') : null;
+  return 'google-chrome';
+}
+
+export async function launchManagedChrome(options: ChromeLaunchOptions): Promise<ManagedChrome> {
+  const chromePath = options.chromePath ?? resolveChromePath();
+  if (!chromePath) throw new Error('Chrome path not found; set OPENCHROME_BENCH_CHROME_PATH');
+  const userDataDir = options.userDataDir ?? fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-bench-profile-'));
+  const endpoint = `http://127.0.0.1:${options.port}`;
+  const args = [
+    `--remote-debugging-port=${options.port}`,
+    `--user-data-dir=${userDataDir}`,
+    '--no-first-run',
+    '--disable-background-networking',
+    '--disable-default-apps',
+    ...(options.extraArgs ?? []),
+  ];
+  const spawnImpl = options.spawnImpl ?? spawn;
+  const proc = spawnImpl(chromePath, args, { stdio: 'ignore', detached: false }) as ChildProcess;
+  const probe = options.probe ?? defaultCdpProbe;
+  await waitForProbe(endpoint, probe, options.readinessTimeoutMs ?? 5000, options.pollIntervalMs ?? 100);
+  return {
+    endpoint,
+    userDataDir,
+    pid: proc.pid,
+    async close() {
+      if (!proc.killed) proc.kill();
+    },
+  };
+}
+
+async function waitForProbe(endpoint: string, probe: (endpoint: string) => Promise<boolean>, timeoutMs: number, pollMs: number): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (await probe(endpoint)) return;
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  throw new Error(`Chrome CDP endpoint did not become ready: ${endpoint}`);
+}
+
+async function defaultCdpProbe(endpoint: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${endpoint}/json/version`);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Documents the 12-PR publishable benchmark implementation plan with acceptance criteria.
- Adds a managed Chrome launcher helper for benchmark-owned CDP runtimes.
- Covers launch flags and cleanup with injected-process tests.

## Verification
- `npm run build`
- `npx jest tests/benchmark/runtime/chrome-launcher.test.ts --runInBand`

## Notes
This is PR1 of the 12-PR roadmap. It does not run live Chrome in CI; it provides the tested launcher seam for later live executors.
