### PR TITLE
Normalize LLM provider turns for benchmark loops

### DIFF
--- a/tests/benchmark/llm-provider/normalizers.test.ts
+++ b/tests/benchmark/llm-provider/normalizers.test.ts
@@ -1,0 +1,34 @@
+/// <reference types="jest" />
+
+import { normalizeAnthropicTurn, normalizeOpenAiTurn } from './normalizers';
+import { sanitizeProviderConfig } from './types';
+
+describe('LLM provider normalization', () => {
+  test('normalizes Anthropic tool use and token usage', () => {
+    const turn = normalizeAnthropicTurn({
+      model: 'claude-test',
+      stop_reason: 'tool_use',
+      usage: { input_tokens: 10, output_tokens: 5 },
+      content: [{ type: 'tool_use', id: 't1', name: 'read_page', input: { tabId: '1' } }],
+    });
+    expect(turn.provider).toBe('anthropic');
+    expect(turn.stopReason).toBe('tool_use');
+    expect(turn.usage.totalTokens).toBe(15);
+    expect(turn.toolCalls[0].name).toBe('read_page');
+  });
+
+  test('normalizes OpenAI function calls and usage aliases', () => {
+    const turn = normalizeOpenAiTurn({
+      model: 'gpt-test',
+      usage: { prompt_tokens: 7, completion_tokens: 3 },
+      output: [{ type: 'function_call', call_id: 'c1', name: 'tabs_create', arguments: '{"url":"http://x"}' }],
+    });
+    expect(turn.provider).toBe('openai');
+    expect(turn.usage.totalTokens).toBe(10);
+    expect(turn.toolCalls[0].arguments.url).toBe('http://x');
+  });
+
+  test('redacts API keys in provider config artifacts', () => {
+    expect(sanitizeProviderConfig({ model: 'm', apiKey: 'secret', token: 'abc' })).toEqual({ model: 'm', apiKey: '[redacted]', token: '[redacted]' });
+  });
+});

--- a/tests/benchmark/llm-provider/normalizers.ts
+++ b/tests/benchmark/llm-provider/normalizers.ts
@@ -1,0 +1,52 @@
+import type { LlmProviderName, NormalizedLlmTurn, NormalizedToolCall } from './types';
+
+function usage(inputTokens = 0, outputTokens = 0) {
+  return { inputTokens, outputTokens, totalTokens: inputTokens + outputTokens };
+}
+
+export function normalizeAnthropicTurn(raw: {
+  model: string;
+  stop_reason?: string;
+  usage?: { input_tokens?: number; output_tokens?: number };
+  content?: Array<{ type: string; text?: string; id?: string; name?: string; input?: Record<string, unknown> }>;
+}): NormalizedLlmTurn {
+  const toolCalls: NormalizedToolCall[] = [];
+  const text: string[] = [];
+  for (const part of raw.content ?? []) {
+    if (part.type === 'text' && part.text) text.push(part.text);
+    if (part.type === 'tool_use' && part.id && part.name) toolCalls.push({ id: part.id, name: part.name, arguments: part.input ?? {} });
+  }
+  return {
+    provider: 'anthropic',
+    model: raw.model,
+    stopReason: toolCalls.length > 0 ? 'tool_use' : raw.stop_reason === 'max_tokens' ? 'max_tokens' : 'final',
+    text: text.join('\n'),
+    toolCalls,
+    usage: usage(raw.usage?.input_tokens, raw.usage?.output_tokens),
+  };
+}
+
+export function normalizeOpenAiTurn(raw: {
+  model: string;
+  output?: Array<{ type: string; content?: Array<{ text?: string }>; call_id?: string; name?: string; arguments?: string }>;
+  usage?: { input_tokens?: number; output_tokens?: number; prompt_tokens?: number; completion_tokens?: number };
+}): NormalizedLlmTurn {
+  const toolCalls: NormalizedToolCall[] = [];
+  const text: string[] = [];
+  for (const item of raw.output ?? []) {
+    if (item.type === 'message') for (const c of item.content ?? []) if (c.text) text.push(c.text);
+    if (item.type === 'function_call' && item.call_id && item.name) {
+      toolCalls.push({ id: item.call_id, name: item.name, arguments: item.arguments ? JSON.parse(item.arguments) : {} });
+    }
+  }
+  const input = raw.usage?.input_tokens ?? raw.usage?.prompt_tokens ?? 0;
+  const output = raw.usage?.output_tokens ?? raw.usage?.completion_tokens ?? 0;
+  return {
+    provider: 'openai' as LlmProviderName,
+    model: raw.model,
+    stopReason: toolCalls.length > 0 ? 'tool_use' : 'final',
+    text: text.join('\n'),
+    toolCalls,
+    usage: usage(input, output),
+  };
+}

--- a/tests/benchmark/llm-provider/types.ts
+++ b/tests/benchmark/llm-provider/types.ts
@@ -1,0 +1,41 @@
+export type LlmProviderName = 'anthropic' | 'openai';
+export type LlmStopReason = 'tool_use' | 'final' | 'max_tokens' | 'error';
+
+export interface NormalizedToolCall {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface NormalizedLlmUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+export interface NormalizedLlmTurn {
+  provider: LlmProviderName;
+  model: string;
+  stopReason: LlmStopReason;
+  text: string;
+  toolCalls: NormalizedToolCall[];
+  usage: NormalizedLlmUsage;
+}
+
+export interface LlmToolLoopProvider {
+  provider: LlmProviderName;
+  model: string;
+  runTurn(input: {
+    system: string;
+    messages: Array<{ role: 'user' | 'assistant' | 'tool'; content: string }>;
+    tools: Array<{ name: string; description: string; inputSchema: Record<string, unknown> }>;
+  }): Promise<NormalizedLlmTurn>;
+}
+
+export function sanitizeProviderConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const redacted: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config)) {
+    redacted[key] = /api[_-]?key|token|secret/i.test(key) ? '[redacted]' : value;
+  }
+  return redacted;
+}


### PR DESCRIPTION
## Summary
- Adds vendor-neutral LLM provider/tool-call/usage types.
- Adds Anthropic and OpenAI response normalizers.
- Adds credential redaction for provider config artifacts.

## Verification
- `npm run build`
- `npx jest tests/benchmark/llm-provider/normalizers.test.ts --runInBand`

## Roadmap
PR2 of the 12-PR benchmark implementation plan.
