### PR TITLE
Close startup new-tab page for managed headed launches

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -433,6 +433,14 @@ export class CDPClient {
   }
 
   /**
+   * Return whether the connected Chrome is managed by OpenChrome or attached.
+   * Used by session cleanup to avoid closing user-owned tabs in attach mode.
+   */
+  getChromeLifecycleMode(): 'isolated' | 'attach' | undefined {
+    return getChromeLauncher(this.port).getInstance()?.launchMode;
+  }
+
+  /**
    * Get connection health metrics.
    */
   getConnectionMetrics(): {

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -992,6 +992,10 @@ export class SessionManager {
         .filter(t => t.type() === 'page')
         .map(t => getTargetId(t))
     );
+    const shouldPruneStartupBlankTargets =
+      Array.from(this.targetToWorker.keys()).length === 0 &&
+      existingTargetIds.size === 1 &&
+      cdpClient.getChromeLifecycleMode() === 'isolated';
 
     if (namedContext) {
       // Named-context path: bypass the pool (which serves the default
@@ -1056,28 +1060,39 @@ export class SessionManager {
 
     const targetId = getTargetId(page.target());
 
-    // Clean up orphan about:blank targets created by Chrome during navigation.
-    // Chrome's Site Isolation creates temporary renderer targets during cross-origin
-    // navigation (about:blank → real URL) that can persist as ghost tabs.
+    // Clean up blank targets that Chrome can leave visible around first navigation.
+    // - New, untracked about:blank targets can be Site Isolation renderer ghosts.
+    // - A freshly launched managed Chrome also creates an initial chrome://newtab/
+    //   page before OpenChrome creates the requested page. Prune that startup tab
+    //   only for isolated/managed Chrome so attach mode never closes user tabs.
     // Runs after a brief delay to catch async target creation by Chrome.
     const cleanupExistingIds = existingTargetIds;
     const cleanupTargetId = targetId;
     const cleanupBrowser = cdpClient.getBrowser();
+    const cleanupStartupBlankTargets = shouldPruneStartupBlankTargets;
     setTimeout(async () => {
       try {
-        const orphans = cleanupBrowser.targets().filter(t =>
-          t.type() === 'page' &&
-          t.url() === 'about:blank' &&
-          !cleanupExistingIds.has(getTargetId(t)) &&
-          getTargetId(t) !== cleanupTargetId &&
-          !this.targetToWorker.has(getTargetId(t))
-        );
+        const orphans = cleanupBrowser.targets().filter(t => {
+          if (t.type() !== 'page') return false;
+          const candidateTargetId = getTargetId(t);
+          if (candidateTargetId === cleanupTargetId) return false;
+          if (this.targetToWorker.has(candidateTargetId)) return false;
+
+          const candidateUrl = t.url();
+          const isBlankLike =
+            candidateUrl === 'about:blank' ||
+            candidateUrl === 'chrome://newtab/' ||
+            candidateUrl.startsWith('chrome://new-tab-page');
+          if (!isBlankLike) return false;
+
+          return cleanupStartupBlankTargets || !cleanupExistingIds.has(candidateTargetId);
+        });
         for (const t of orphans) {
           try {
             const orphanPage = await t.page();
             if (orphanPage && !orphanPage.isClosed()) {
               await orphanPage.close();
-              console.error(`[SessionManager] Closed orphan about:blank ghost tab: ${getTargetId(t)}`);
+              console.error(`[SessionManager] Closed orphan blank ghost tab: ${getTargetId(t)} (${t.url()})`);
             }
           } catch { /* target may already be destroyed */ }
         }

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -1079,13 +1079,14 @@ export class SessionManager {
           if (this.targetToWorker.has(candidateTargetId)) return false;
 
           const candidateUrl = t.url();
-          const isBlankLike =
-            candidateUrl === 'about:blank' ||
+          const isStartupNewTab =
             candidateUrl === 'chrome://newtab/' ||
             candidateUrl.startsWith('chrome://new-tab-page');
+          const isBlankLike = candidateUrl === 'about:blank' || isStartupNewTab;
           if (!isBlankLike) return false;
 
-          return cleanupStartupBlankTargets || !cleanupExistingIds.has(candidateTargetId);
+          if (isStartupNewTab) return cleanupStartupBlankTargets && cleanupExistingIds.has(candidateTargetId);
+          return !cleanupExistingIds.has(candidateTargetId);
         });
         for (const t of orphans) {
           try {

--- a/tests/src/session-manager-ttl.test.ts
+++ b/tests/src/session-manager-ttl.test.ts
@@ -189,6 +189,27 @@ describe('SessionManager TTL and Stats', () => {
       expect(closeStartupTab).toHaveBeenCalledTimes(1);
     });
 
+    test('does not close concurrently-created chrome://newtab pages when attached to user Chrome', async () => {
+      mockLifecycleMode = 'attach';
+      const closeUserTab = jest.fn().mockResolvedValue(undefined);
+      const userNewTab = makeTarget('user-newtab', 'chrome://newtab/', closeUserTab);
+      const createdTarget = makeTarget('mock-target-id-1', 'https://example.com/');
+
+      const targets = jest.fn()
+        .mockReturnValueOnce([])
+        .mockReturnValue([userNewTab, createdTarget]);
+      mockCdpClientInstance.getBrowser.mockReturnValue({
+        targets,
+        on: jest.fn(),
+        removeAllListeners: jest.fn(),
+      });
+
+      await sessionManager.createTarget('attach-concurrent-cleanup-session', 'https://example.com');
+      await jest.advanceTimersByTimeAsync(500);
+
+      expect(closeUserTab).not.toHaveBeenCalled();
+    });
+
     test('does not close pre-existing chrome://newtab pages when attached to user Chrome', async () => {
       mockLifecycleMode = 'attach';
       const closeUserTab = jest.fn().mockResolvedValue(undefined);

--- a/tests/src/session-manager-ttl.test.ts
+++ b/tests/src/session-manager-ttl.test.ts
@@ -16,6 +16,7 @@ const mockBrowserContext = {
 
 // Counter for unique target IDs
 let targetIdCounter = 0;
+let mockLifecycleMode: 'isolated' | 'attach' | undefined = 'isolated';
 
 // Mock CDP client instance
 const mockCdpClientInstance = {
@@ -33,6 +34,7 @@ const mockCdpClientInstance = {
   closePage: jest.fn().mockResolvedValue(undefined),
   getPageByTargetId: jest.fn().mockReturnValue(null),
   isConnected: jest.fn().mockReturnValue(true),
+  getChromeLifecycleMode: jest.fn(() => mockLifecycleMode),
   addConnectionListener: jest.fn(),
   addTargetDestroyedListener: jest.fn(),
   createBrowserContext: jest.fn().mockResolvedValue(mockBrowserContext),
@@ -107,6 +109,12 @@ describe('SessionManager TTL and Stats', () => {
     jest.clearAllMocks();
     jest.useFakeTimers();
     targetIdCounter = 0; // Reset counter
+    mockLifecycleMode = 'isolated';
+    mockCdpClientInstance.getBrowser.mockReturnValue({
+      targets: jest.fn().mockReturnValue([]),
+      on: jest.fn(),
+      removeAllListeners: jest.fn(),
+    });
 
     sessionManager = new SessionManager(undefined, {
       sessionTTL: 1000, // 1 second for testing
@@ -145,6 +153,61 @@ describe('SessionManager TTL and Stats', () => {
       sessionManager.updateConfig({ sessionTTL: 2000 });
 
       expect(sessionManager.getConfig().sessionTTL).toBe(2000);
+    });
+  });
+
+  describe('Blank startup tab cleanup', () => {
+    function makeTarget(targetId: string, url: string, close = jest.fn().mockResolvedValue(undefined)) {
+      return {
+        _targetId: targetId,
+        type: jest.fn().mockReturnValue('page'),
+        url: jest.fn().mockReturnValue(url),
+        page: jest.fn().mockResolvedValue({
+          isClosed: jest.fn().mockReturnValue(false),
+          close,
+        }),
+      };
+    }
+
+    test('closes the initial chrome://newtab page after creating the first managed target', async () => {
+      const closeStartupTab = jest.fn().mockResolvedValue(undefined);
+      const startupNewTab = makeTarget('startup-newtab', 'chrome://newtab/', closeStartupTab);
+      const createdTarget = makeTarget('mock-target-id-1', 'https://example.com/');
+
+      const targets = jest.fn()
+        .mockReturnValueOnce([startupNewTab])
+        .mockReturnValue([startupNewTab, createdTarget]);
+      mockCdpClientInstance.getBrowser.mockReturnValue({
+        targets,
+        on: jest.fn(),
+        removeAllListeners: jest.fn(),
+      });
+
+      await sessionManager.createTarget('startup-cleanup-session', 'https://example.com');
+      await jest.advanceTimersByTimeAsync(500);
+
+      expect(closeStartupTab).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not close pre-existing chrome://newtab pages when attached to user Chrome', async () => {
+      mockLifecycleMode = 'attach';
+      const closeUserTab = jest.fn().mockResolvedValue(undefined);
+      const userNewTab = makeTarget('user-newtab', 'chrome://newtab/', closeUserTab);
+      const createdTarget = makeTarget('mock-target-id-1', 'https://example.com/');
+
+      const targets = jest.fn()
+        .mockReturnValueOnce([userNewTab])
+        .mockReturnValue([userNewTab, createdTarget]);
+      mockCdpClientInstance.getBrowser.mockReturnValue({
+        targets,
+        on: jest.fn(),
+        removeAllListeners: jest.fn(),
+      });
+
+      await sessionManager.createTarget('attach-cleanup-session', 'https://example.com');
+      await jest.advanceTimersByTimeAsync(500);
+
+      expect(closeUserTab).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

- prune the initial `chrome://newtab/` page left by fresh managed headed Chrome launches after the first OpenChrome target is created
- keep the cleanup gated to isolated/managed Chrome so attach mode does not close user-owned tabs
- extend the session-manager regression coverage for managed-launch cleanup and attach-mode preservation

Closes #1325.

## Root cause

Chrome creates a default `chrome://newtab/` page when OpenChrome launches headed Chrome without an initial URL. OpenChrome then creates/navigates a separate controlled page. The previous orphan cleanup handled new untracked `about:blank` targets, but not the pre-existing startup `chrome://newtab/` target.

## Validation

- `npm run build`
- `npx jest tests/src/session-manager-ttl.test.ts --runInBand --silent`
- Live isolated OpenChrome reproduction after the fix:
  - command: `node dist/index.js serve --auto-launch --transport http --port 9333 --http 3133 --allow-unauthenticated-http --user-data-dir <tmp>` with `OPENCHROME_LAUNCH_MODE=isolated`, headed mode
  - `navigate` to `https://example.com`
  - `/json` result: `page_count=1`, `blank_page_count=0`
  - log evidence: `Closed orphan blank ghost tab: ... (chrome://newtab/)`
