### PR TITLE
Add injected OpenAI tool-use loop

### DIFF
--- a/tests/benchmark/llm-provider/openai-loop.test.ts
+++ b/tests/benchmark/llm-provider/openai-loop.test.ts
@@ -12,7 +12,7 @@ describe('OpenAI tool-use loop', () => {
     const adapter: MCPAdapter = { name: 'mock', mode: 'test', kind: 'library', callTool: jest.fn(async () => ({ content: [{ type: 'text', text: 'page' }] })) };
     const result = await runOpenAiToolUseLoop({ client, adapter, model: 'gpt-test', instructions: 's', user: 'u', tools: [{ name: 'read_page', description: 'Read page', inputSchema: { type: 'object', properties: { tabId: { type: 'string' } } } }] });
     expect(adapter.callTool).toHaveBeenCalledWith('read_page', { tabId: 'a' });
-    expect(client.create).toHaveBeenNthCalledWith(1, expect.objectContaining({ tools: [expect.objectContaining({ type: 'function', name: 'read_page', parameters: expect.objectContaining({ type: 'object' }) })] }));
+    expect(client.create).toHaveBeenNthCalledWith(1, expect.objectContaining({ include: ['reasoning.encrypted_content'], tools: [expect.objectContaining({ type: 'function', name: 'read_page', parameters: expect.objectContaining({ type: 'object' }) })] }));
     expect(client.create).toHaveBeenNthCalledWith(2, expect.objectContaining({ previous_response_id: 'resp-1', input: [expect.objectContaining({ type: 'reasoning', id: 'rs_1' }), expect.objectContaining({ type: 'function_call', call_id: 'c1' }), expect.objectContaining({ type: 'function_call_output', call_id: 'c1' })] }));
     expect(result.finalText).toBe('done');
     expect(result.totalTokens).toBe(27);

--- a/tests/benchmark/llm-provider/openai-loop.test.ts
+++ b/tests/benchmark/llm-provider/openai-loop.test.ts
@@ -13,7 +13,7 @@ describe('OpenAI tool-use loop', () => {
     const result = await runOpenAiToolUseLoop({ client, adapter, model: 'gpt-test', instructions: 's', user: 'u', tools: [{ name: 'read_page', description: 'Read page', inputSchema: { type: 'object', properties: { tabId: { type: 'string' } } } }] });
     expect(adapter.callTool).toHaveBeenCalledWith('read_page', { tabId: 'a' });
     expect(client.create).toHaveBeenNthCalledWith(1, expect.objectContaining({ tools: [expect.objectContaining({ type: 'function', name: 'read_page', parameters: expect.objectContaining({ type: 'object' }) })] }));
-    expect(client.create).toHaveBeenNthCalledWith(2, expect.objectContaining({ previous_response_id: 'resp-1', input: [expect.objectContaining({ type: 'reasoning', id: 'rs_1' }), expect.objectContaining({ type: 'function_call_output', call_id: 'c1' })] }));
+    expect(client.create).toHaveBeenNthCalledWith(2, expect.objectContaining({ previous_response_id: 'resp-1', input: [expect.objectContaining({ type: 'reasoning', id: 'rs_1' }), expect.objectContaining({ type: 'function_call', call_id: 'c1' }), expect.objectContaining({ type: 'function_call_output', call_id: 'c1' })] }));
     expect(result.finalText).toBe('done');
     expect(result.totalTokens).toBe(27);
   });

--- a/tests/benchmark/llm-provider/openai-loop.test.ts
+++ b/tests/benchmark/llm-provider/openai-loop.test.ts
@@ -1,0 +1,22 @@
+/// <reference types="jest" />
+import type { MCPAdapter } from '../benchmark-runner';
+import { assertOpenAiLiveEnabled, runOpenAiToolUseLoop } from './openai-loop';
+
+describe('OpenAI tool-use loop', () => {
+  test('dispatches normalized function calls and returns final text', async () => {
+    const rawTurns = [
+      { model: 'gpt-test', usage: { input_tokens: 10, output_tokens: 5 }, output: [{ type: 'function_call', call_id: 'c1', name: 'read_page', arguments: '{"tabId":"a"}' }] },
+      { model: 'gpt-test', usage: { input_tokens: 8, output_tokens: 4 }, output: [{ type: 'message', content: [{ text: 'done' }] }] },
+    ];
+    const client = { create: jest.fn(async () => rawTurns.shift()) };
+    const adapter: MCPAdapter = { name: 'mock', mode: 'test', kind: 'library', callTool: jest.fn(async () => ({ content: [{ type: 'text', text: 'page' }] })) };
+    const result = await runOpenAiToolUseLoop({ client, adapter, model: 'gpt-test', instructions: 's', user: 'u', tools: [] });
+    expect(adapter.callTool).toHaveBeenCalledWith('read_page', { tabId: 'a' });
+    expect(result.finalText).toBe('done');
+    expect(result.totalTokens).toBe(27);
+  });
+  test('fails closed without explicit live env', () => {
+    expect(() => assertOpenAiLiveEnabled({} as NodeJS.ProcessEnv)).toThrow(/OPENAI_API_KEY/);
+    expect(() => assertOpenAiLiveEnabled({ OPENAI_API_KEY: 'x' } as NodeJS.ProcessEnv)).toThrow(/OPENCHROME_BENCH_REAL/);
+  });
+});

--- a/tests/benchmark/llm-provider/openai-loop.test.ts
+++ b/tests/benchmark/llm-provider/openai-loop.test.ts
@@ -5,7 +5,7 @@ import { assertOpenAiLiveEnabled, runOpenAiToolUseLoop } from './openai-loop';
 describe('OpenAI tool-use loop', () => {
   test('dispatches normalized function calls and returns final text', async () => {
     const rawTurns = [
-      { id: 'resp-1', model: 'gpt-test', usage: { input_tokens: 10, output_tokens: 5 }, output: [{ type: 'function_call', call_id: 'c1', name: 'read_page', arguments: '{"tabId":"a"}' }] },
+      { id: 'resp-1', model: 'gpt-test', usage: { input_tokens: 10, output_tokens: 5 }, output: [{ type: 'reasoning', id: 'rs_1', summary: [] }, { type: 'function_call', call_id: 'c1', name: 'read_page', arguments: '{"tabId":"a"}' }] },
       { id: 'resp-2', model: 'gpt-test', usage: { input_tokens: 8, output_tokens: 4 }, output: [{ type: 'message', content: [{ text: 'done' }] }] },
     ];
     const client = { create: jest.fn(async () => rawTurns.shift()) };
@@ -13,7 +13,7 @@ describe('OpenAI tool-use loop', () => {
     const result = await runOpenAiToolUseLoop({ client, adapter, model: 'gpt-test', instructions: 's', user: 'u', tools: [{ name: 'read_page', description: 'Read page', inputSchema: { type: 'object', properties: { tabId: { type: 'string' } } } }] });
     expect(adapter.callTool).toHaveBeenCalledWith('read_page', { tabId: 'a' });
     expect(client.create).toHaveBeenNthCalledWith(1, expect.objectContaining({ tools: [expect.objectContaining({ type: 'function', name: 'read_page', parameters: expect.objectContaining({ type: 'object' }) })] }));
-    expect(client.create).toHaveBeenNthCalledWith(2, expect.objectContaining({ previous_response_id: 'resp-1', input: [expect.objectContaining({ type: 'function_call_output', call_id: 'c1' })] }));
+    expect(client.create).toHaveBeenNthCalledWith(2, expect.objectContaining({ previous_response_id: 'resp-1', input: [expect.objectContaining({ type: 'reasoning', id: 'rs_1' }), expect.objectContaining({ type: 'function_call_output', call_id: 'c1' })] }));
     expect(result.finalText).toBe('done');
     expect(result.totalTokens).toBe(27);
   });

--- a/tests/benchmark/llm-provider/openai-loop.test.ts
+++ b/tests/benchmark/llm-provider/openai-loop.test.ts
@@ -13,7 +13,7 @@ describe('OpenAI tool-use loop', () => {
     const result = await runOpenAiToolUseLoop({ client, adapter, model: 'gpt-test', instructions: 's', user: 'u', tools: [{ name: 'read_page', description: 'Read page', inputSchema: { type: 'object', properties: { tabId: { type: 'string' } } } }] });
     expect(adapter.callTool).toHaveBeenCalledWith('read_page', { tabId: 'a' });
     expect(client.create).toHaveBeenNthCalledWith(1, expect.objectContaining({ include: ['reasoning.encrypted_content'], tools: [expect.objectContaining({ type: 'function', name: 'read_page', parameters: expect.objectContaining({ type: 'object' }) })] }));
-    expect(client.create).toHaveBeenNthCalledWith(2, expect.objectContaining({ previous_response_id: 'resp-1', input: [expect.objectContaining({ type: 'reasoning', id: 'rs_1' }), expect.objectContaining({ type: 'function_call', call_id: 'c1' }), expect.objectContaining({ type: 'function_call_output', call_id: 'c1' })] }));
+    expect(client.create).toHaveBeenNthCalledWith(2, expect.objectContaining({ input: [{ role: 'user', content: 'u' }, expect.objectContaining({ type: 'reasoning', id: 'rs_1' }), expect.objectContaining({ type: 'function_call', call_id: 'c1' }), expect.objectContaining({ type: 'function_call_output', call_id: 'c1' })] }));
     expect(result.finalText).toBe('done');
     expect(result.totalTokens).toBe(27);
   });

--- a/tests/benchmark/llm-provider/openai-loop.test.ts
+++ b/tests/benchmark/llm-provider/openai-loop.test.ts
@@ -10,8 +10,10 @@ describe('OpenAI tool-use loop', () => {
     ];
     const client = { create: jest.fn(async () => rawTurns.shift()) };
     const adapter: MCPAdapter = { name: 'mock', mode: 'test', kind: 'library', callTool: jest.fn(async () => ({ content: [{ type: 'text', text: 'page' }] })) };
-    const result = await runOpenAiToolUseLoop({ client, adapter, model: 'gpt-test', instructions: 's', user: 'u', tools: [] });
+    const result = await runOpenAiToolUseLoop({ client, adapter, model: 'gpt-test', instructions: 's', user: 'u', tools: [{ name: 'read_page', description: 'Read page', inputSchema: { type: 'object', properties: { tabId: { type: 'string' } } } }] });
     expect(adapter.callTool).toHaveBeenCalledWith('read_page', { tabId: 'a' });
+    expect(client.create).toHaveBeenNthCalledWith(1, expect.objectContaining({ tools: [expect.objectContaining({ type: 'function', name: 'read_page', parameters: expect.objectContaining({ type: 'object' }) })] }));
+    expect(client.create).toHaveBeenNthCalledWith(2, expect.objectContaining({ input: expect.arrayContaining([expect.objectContaining({ type: 'function_call', call_id: 'c1' }), expect.objectContaining({ type: 'function_call_output', call_id: 'c1' })]) }));
     expect(result.finalText).toBe('done');
     expect(result.totalTokens).toBe(27);
   });

--- a/tests/benchmark/llm-provider/openai-loop.test.ts
+++ b/tests/benchmark/llm-provider/openai-loop.test.ts
@@ -13,7 +13,7 @@ describe('OpenAI tool-use loop', () => {
     const result = await runOpenAiToolUseLoop({ client, adapter, model: 'gpt-test', instructions: 's', user: 'u', tools: [{ name: 'read_page', description: 'Read page', inputSchema: { type: 'object', properties: { tabId: { type: 'string' } } } }] });
     expect(adapter.callTool).toHaveBeenCalledWith('read_page', { tabId: 'a' });
     expect(client.create).toHaveBeenNthCalledWith(1, expect.objectContaining({ tools: [expect.objectContaining({ type: 'function', name: 'read_page', parameters: expect.objectContaining({ type: 'object' }) })] }));
-    expect(client.create).toHaveBeenNthCalledWith(2, expect.objectContaining({ previous_response_id: 'resp-1', input: expect.arrayContaining([expect.objectContaining({ type: 'function_call', call_id: 'c1' }), expect.objectContaining({ type: 'function_call_output', call_id: 'c1' })]) }));
+    expect(client.create).toHaveBeenNthCalledWith(2, expect.objectContaining({ previous_response_id: 'resp-1', input: [expect.objectContaining({ type: 'function_call_output', call_id: 'c1' })] }));
     expect(result.finalText).toBe('done');
     expect(result.totalTokens).toBe(27);
   });

--- a/tests/benchmark/llm-provider/openai-loop.test.ts
+++ b/tests/benchmark/llm-provider/openai-loop.test.ts
@@ -5,15 +5,15 @@ import { assertOpenAiLiveEnabled, runOpenAiToolUseLoop } from './openai-loop';
 describe('OpenAI tool-use loop', () => {
   test('dispatches normalized function calls and returns final text', async () => {
     const rawTurns = [
-      { model: 'gpt-test', usage: { input_tokens: 10, output_tokens: 5 }, output: [{ type: 'function_call', call_id: 'c1', name: 'read_page', arguments: '{"tabId":"a"}' }] },
-      { model: 'gpt-test', usage: { input_tokens: 8, output_tokens: 4 }, output: [{ type: 'message', content: [{ text: 'done' }] }] },
+      { id: 'resp-1', model: 'gpt-test', usage: { input_tokens: 10, output_tokens: 5 }, output: [{ type: 'function_call', call_id: 'c1', name: 'read_page', arguments: '{"tabId":"a"}' }] },
+      { id: 'resp-2', model: 'gpt-test', usage: { input_tokens: 8, output_tokens: 4 }, output: [{ type: 'message', content: [{ text: 'done' }] }] },
     ];
     const client = { create: jest.fn(async () => rawTurns.shift()) };
     const adapter: MCPAdapter = { name: 'mock', mode: 'test', kind: 'library', callTool: jest.fn(async () => ({ content: [{ type: 'text', text: 'page' }] })) };
     const result = await runOpenAiToolUseLoop({ client, adapter, model: 'gpt-test', instructions: 's', user: 'u', tools: [{ name: 'read_page', description: 'Read page', inputSchema: { type: 'object', properties: { tabId: { type: 'string' } } } }] });
     expect(adapter.callTool).toHaveBeenCalledWith('read_page', { tabId: 'a' });
     expect(client.create).toHaveBeenNthCalledWith(1, expect.objectContaining({ tools: [expect.objectContaining({ type: 'function', name: 'read_page', parameters: expect.objectContaining({ type: 'object' }) })] }));
-    expect(client.create).toHaveBeenNthCalledWith(2, expect.objectContaining({ input: expect.arrayContaining([expect.objectContaining({ type: 'function_call', call_id: 'c1' }), expect.objectContaining({ type: 'function_call_output', call_id: 'c1' })]) }));
+    expect(client.create).toHaveBeenNthCalledWith(2, expect.objectContaining({ previous_response_id: 'resp-1', input: expect.arrayContaining([expect.objectContaining({ type: 'function_call', call_id: 'c1' }), expect.objectContaining({ type: 'function_call_output', call_id: 'c1' })]) }));
     expect(result.finalText).toBe('done');
     expect(result.totalTokens).toBe(27);
   });

--- a/tests/benchmark/llm-provider/openai-loop.ts
+++ b/tests/benchmark/llm-provider/openai-loop.ts
@@ -38,7 +38,7 @@ export async function runOpenAiToolUseLoop(options: { client: OpenAiResponsesCli
   const tools = toResponsesTools(options.tools);
   let previousResponseId: string | undefined;
   for (let i = 0; i < maxTurns; i++) {
-    const request: Record<string, unknown> = { model: options.model, instructions: options.instructions, input: nextInput, tools };
+    const request: Record<string, unknown> = { model: options.model, instructions: options.instructions, input: nextInput, tools, include: ['reasoning.encrypted_content'] };
     if (previousResponseId) request.previous_response_id = previousResponseId;
     const raw = await options.client.create(request);
     const responseId = raw && typeof raw === 'object' ? (raw as { id?: unknown }).id : undefined;

--- a/tests/benchmark/llm-provider/openai-loop.ts
+++ b/tests/benchmark/llm-provider/openai-loop.ts
@@ -37,7 +37,10 @@ export async function runOpenAiToolUseLoop(options: { client: OpenAiResponsesCli
     const accounted = accountLlmBudget(turns.map((t) => ({ inputTokens: t.usage.inputTokens, outputTokens: t.usage.outputTokens, toolCalls: t.toolCalls.length })), budget, DEFAULT_PRICING);
     if (accounted.aborted) return { turns, toolResults, finalText: turn.text, aborted: accounted.aborted, totalTokens: accounted.totalTokens, usdSpent: accounted.usdSpent };
     if (turn.toolCalls.length === 0) return { turns, toolResults, finalText: turn.text, totalTokens: accounted.totalTokens, usdSpent: accounted.usdSpent };
-    const toolOutputs: Array<Record<string, unknown>> = [];
+    const preservedReasoning = raw && typeof raw === 'object' && Array.isArray((raw as { output?: unknown }).output)
+      ? ((raw as { output: unknown[] }).output.filter((item): item is Record<string, unknown> => !!item && typeof item === 'object' && (item as { type?: unknown }).type === 'reasoning') as Array<Record<string, unknown>>)
+      : [];
+    const toolOutputs: Array<Record<string, unknown>> = [...preservedReasoning];
     for (const call of turn.toolCalls) {
       const result = await options.adapter.callTool(call.name, call.arguments);
       toolResults.push(result);

--- a/tests/benchmark/llm-provider/openai-loop.ts
+++ b/tests/benchmark/llm-provider/openai-loop.ts
@@ -18,6 +18,13 @@ function toResponsesTools(tools: OpenAiBenchmarkTool[]): Array<Record<string, un
   }));
 }
 
+function reasoningOutputItems(raw: unknown): Array<Record<string, unknown>> {
+  if (!raw || typeof raw !== 'object') return [];
+  const output = (raw as { output?: unknown }).output;
+  if (!Array.isArray(output)) return [];
+  return output.filter((item): item is Record<string, unknown> => !!item && typeof item === 'object' && (item as { type?: unknown }).type === 'reasoning');
+}
+
 export async function runOpenAiToolUseLoop(options: { client: OpenAiResponsesClient; adapter: MCPAdapter; model: string; instructions: string; user: string; tools: OpenAiBenchmarkTool[]; maxTurns?: number; budget?: BudgetCaps; }): Promise<OpenAiLoopResult> {
   const budget = options.budget ?? WEBVOYAGER_BUDGET;
   const maxTurns = options.maxTurns ?? budget.max_tool_iterations;
@@ -37,10 +44,9 @@ export async function runOpenAiToolUseLoop(options: { client: OpenAiResponsesCli
     const accounted = accountLlmBudget(turns.map((t) => ({ inputTokens: t.usage.inputTokens, outputTokens: t.usage.outputTokens, toolCalls: t.toolCalls.length })), budget, DEFAULT_PRICING);
     if (accounted.aborted) return { turns, toolResults, finalText: turn.text, aborted: accounted.aborted, totalTokens: accounted.totalTokens, usdSpent: accounted.usdSpent };
     if (turn.toolCalls.length === 0) return { turns, toolResults, finalText: turn.text, totalTokens: accounted.totalTokens, usdSpent: accounted.usdSpent };
-    const preservedReasoning = raw && typeof raw === 'object' && Array.isArray((raw as { output?: unknown }).output)
-      ? ((raw as { output: unknown[] }).output.filter((item): item is Record<string, unknown> => !!item && typeof item === 'object' && (item as { type?: unknown }).type === 'reasoning') as Array<Record<string, unknown>>)
-      : [];
-    const toolOutputs: Array<Record<string, unknown>> = [...preservedReasoning];
+    const toolOutputs: Array<Record<string, unknown>> = [
+      ...reasoningOutputItems(raw),
+    ];
     for (const call of turn.toolCalls) {
       const result = await options.adapter.callTool(call.name, call.arguments);
       toolResults.push(result);

--- a/tests/benchmark/llm-provider/openai-loop.ts
+++ b/tests/benchmark/llm-provider/openai-loop.ts
@@ -36,27 +36,25 @@ export async function runOpenAiToolUseLoop(options: { client: OpenAiResponsesCli
   const toolResults: MCPToolResult[] = [];
   let nextInput: Array<Record<string, unknown>> = [{ role: 'user', content: options.user }];
   const tools = toResponsesTools(options.tools);
-  let previousResponseId: string | undefined;
   for (let i = 0; i < maxTurns; i++) {
     const request: Record<string, unknown> = { model: options.model, instructions: options.instructions, input: nextInput, tools, include: ['reasoning.encrypted_content'] };
-    if (previousResponseId) request.previous_response_id = previousResponseId;
     const raw = await options.client.create(request);
-    const responseId = raw && typeof raw === 'object' ? (raw as { id?: unknown }).id : undefined;
-    if (typeof responseId === 'string' && responseId.trim()) previousResponseId = responseId;
     const turn = normalizeOpenAiTurn(raw as Parameters<typeof normalizeOpenAiTurn>[0]);
     turns.push(turn);
     const accounted = accountLlmBudget(turns.map((t) => ({ inputTokens: t.usage.inputTokens, outputTokens: t.usage.outputTokens, toolCalls: t.toolCalls.length })), budget, DEFAULT_PRICING);
     if (accounted.aborted) return { turns, toolResults, finalText: turn.text, aborted: accounted.aborted, totalTokens: accounted.totalTokens, usdSpent: accounted.usdSpent };
     if (turn.toolCalls.length === 0) return { turns, toolResults, finalText: turn.text, totalTokens: accounted.totalTokens, usdSpent: accounted.usdSpent };
-    const toolOutputs: Array<Record<string, unknown>> = [
-      ...responseOutputContextItems(raw),
-    ];
+    const functionCallOutputs: Array<Record<string, unknown>> = [];
     for (const call of turn.toolCalls) {
       const result = await options.adapter.callTool(call.name, call.arguments);
       toolResults.push(result);
-      toolOutputs.push({ type: 'function_call_output', call_id: call.id, output: result.content?.map((c) => c.text ?? '').join('\n') ?? '' });
+      functionCallOutputs.push({ type: 'function_call_output', call_id: call.id, output: result.content?.map((c) => c.text ?? '').join('\n') ?? '' });
     }
-    nextInput = toolOutputs;
+    nextInput = [
+      ...nextInput,
+      ...responseOutputContextItems(raw),
+      ...functionCallOutputs,
+    ];
   }
   const accounted = accountLlmBudget(turns.map((t) => ({ inputTokens: t.usage.inputTokens, outputTokens: t.usage.outputTokens, toolCalls: t.toolCalls.length })), budget, DEFAULT_PRICING);
   return { turns, toolResults, finalText: turns.at(-1)?.text ?? '', aborted: 'MAX_ITERATIONS', totalTokens: accounted.totalTokens, usdSpent: accounted.usdSpent };

--- a/tests/benchmark/llm-provider/openai-loop.ts
+++ b/tests/benchmark/llm-provider/openai-loop.ts
@@ -31,8 +31,13 @@ export async function runOpenAiToolUseLoop(options: { client: OpenAiResponsesCli
   const toolResults: MCPToolResult[] = [];
   const input: Array<Record<string, unknown>> = [{ role: 'user', content: options.user }];
   const tools = toResponsesTools(options.tools);
+  let previousResponseId: string | undefined;
   for (let i = 0; i < maxTurns; i++) {
-    const raw = await options.client.create({ model: options.model, instructions: options.instructions, input, tools });
+    const request: Record<string, unknown> = { model: options.model, instructions: options.instructions, input, tools };
+    if (previousResponseId) request.previous_response_id = previousResponseId;
+    const raw = await options.client.create(request);
+    const responseId = raw && typeof raw === 'object' ? (raw as { id?: unknown }).id : undefined;
+    if (typeof responseId === 'string' && responseId.trim()) previousResponseId = responseId;
     const turn = normalizeOpenAiTurn(raw as Parameters<typeof normalizeOpenAiTurn>[0]);
     turns.push(turn);
     const accounted = accountLlmBudget(turns.map((t) => ({ inputTokens: t.usage.inputTokens, outputTokens: t.usage.outputTokens, toolCalls: t.toolCalls.length })), budget, DEFAULT_PRICING);

--- a/tests/benchmark/llm-provider/openai-loop.ts
+++ b/tests/benchmark/llm-provider/openai-loop.ts
@@ -1,0 +1,37 @@
+import type { MCPAdapter, MCPToolResult } from '../benchmark-runner';
+import { WEBVOYAGER_BUDGET, BudgetCaps } from '../webvoyager/llm/budget';
+import { accountLlmBudget } from '../webvoyager/llm/token-budget';
+import { normalizeOpenAiTurn } from './normalizers';
+import type { NormalizedLlmTurn } from './types';
+
+export interface OpenAiResponsesClient { create(input: Record<string, unknown>): Promise<unknown>; }
+export interface OpenAiLoopResult { turns: NormalizedLlmTurn[]; toolResults: MCPToolResult[]; finalText: string; aborted?: 'BUDGET_EXCEEDED' | 'MAX_ITERATIONS'; totalTokens: number; usdSpent: number; }
+const DEFAULT_PRICING = { input_usd_per_million: 2.5, output_usd_per_million: 10 };
+
+export async function runOpenAiToolUseLoop(options: { client: OpenAiResponsesClient; adapter: MCPAdapter; model: string; instructions: string; user: string; tools: Array<{ name: string; description: string; inputSchema: Record<string, unknown> }>; maxTurns?: number; budget?: BudgetCaps; }): Promise<OpenAiLoopResult> {
+  const budget = options.budget ?? WEBVOYAGER_BUDGET;
+  const maxTurns = options.maxTurns ?? budget.max_tool_iterations;
+  const turns: NormalizedLlmTurn[] = [];
+  const toolResults: MCPToolResult[] = [];
+  const input: Array<Record<string, unknown>> = [{ role: 'user', content: options.user }];
+  for (let i = 0; i < maxTurns; i++) {
+    const raw = await options.client.create({ model: options.model, instructions: options.instructions, input, tools: options.tools });
+    const turn = normalizeOpenAiTurn(raw as Parameters<typeof normalizeOpenAiTurn>[0]);
+    turns.push(turn);
+    const accounted = accountLlmBudget(turns.map((t) => ({ inputTokens: t.usage.inputTokens, outputTokens: t.usage.outputTokens, toolCalls: t.toolCalls.length })), budget, DEFAULT_PRICING);
+    if (accounted.aborted) return { turns, toolResults, finalText: turn.text, aborted: accounted.aborted, totalTokens: accounted.totalTokens, usdSpent: accounted.usdSpent };
+    if (turn.toolCalls.length === 0) return { turns, toolResults, finalText: turn.text, totalTokens: accounted.totalTokens, usdSpent: accounted.usdSpent };
+    for (const call of turn.toolCalls) {
+      const result = await options.adapter.callTool(call.name, call.arguments);
+      toolResults.push(result);
+      input.push({ type: 'function_call_output', call_id: call.id, output: result.content?.map((c) => c.text ?? '').join('\n') ?? '' });
+    }
+  }
+  const accounted = accountLlmBudget(turns.map((t) => ({ inputTokens: t.usage.inputTokens, outputTokens: t.usage.outputTokens, toolCalls: t.toolCalls.length })), budget, DEFAULT_PRICING);
+  return { turns, toolResults, finalText: turns.at(-1)?.text ?? '', aborted: 'MAX_ITERATIONS', totalTokens: accounted.totalTokens, usdSpent: accounted.usdSpent };
+}
+
+export function assertOpenAiLiveEnabled(env = process.env): void {
+  if (!env.OPENAI_API_KEY) throw new Error('OPENAI_API_KEY is required for live OpenAI benchmark loops');
+  if (env.OPENCHROME_BENCH_REAL !== '1') throw new Error('OPENCHROME_BENCH_REAL=1 is required for live OpenAI benchmark loops');
+}

--- a/tests/benchmark/llm-provider/openai-loop.ts
+++ b/tests/benchmark/llm-provider/openai-loop.ts
@@ -5,22 +5,40 @@ import { normalizeOpenAiTurn } from './normalizers';
 import type { NormalizedLlmTurn } from './types';
 
 export interface OpenAiResponsesClient { create(input: Record<string, unknown>): Promise<unknown>; }
+export interface OpenAiBenchmarkTool { name: string; description: string; inputSchema: Record<string, unknown>; }
 export interface OpenAiLoopResult { turns: NormalizedLlmTurn[]; toolResults: MCPToolResult[]; finalText: string; aborted?: 'BUDGET_EXCEEDED' | 'MAX_ITERATIONS'; totalTokens: number; usdSpent: number; }
 const DEFAULT_PRICING = { input_usd_per_million: 2.5, output_usd_per_million: 10 };
 
-export async function runOpenAiToolUseLoop(options: { client: OpenAiResponsesClient; adapter: MCPAdapter; model: string; instructions: string; user: string; tools: Array<{ name: string; description: string; inputSchema: Record<string, unknown> }>; maxTurns?: number; budget?: BudgetCaps; }): Promise<OpenAiLoopResult> {
+function toResponsesTools(tools: OpenAiBenchmarkTool[]): Array<Record<string, unknown>> {
+  return tools.map((tool) => ({
+    type: 'function',
+    name: tool.name,
+    description: tool.description,
+    parameters: tool.inputSchema,
+  }));
+}
+
+function toResponseInputItems(raw: unknown): Array<Record<string, unknown>> {
+  if (!raw || typeof raw !== 'object') return [];
+  const output = (raw as { output?: unknown }).output;
+  return Array.isArray(output) ? output.filter((item): item is Record<string, unknown> => !!item && typeof item === 'object') : [];
+}
+
+export async function runOpenAiToolUseLoop(options: { client: OpenAiResponsesClient; adapter: MCPAdapter; model: string; instructions: string; user: string; tools: OpenAiBenchmarkTool[]; maxTurns?: number; budget?: BudgetCaps; }): Promise<OpenAiLoopResult> {
   const budget = options.budget ?? WEBVOYAGER_BUDGET;
   const maxTurns = options.maxTurns ?? budget.max_tool_iterations;
   const turns: NormalizedLlmTurn[] = [];
   const toolResults: MCPToolResult[] = [];
   const input: Array<Record<string, unknown>> = [{ role: 'user', content: options.user }];
+  const tools = toResponsesTools(options.tools);
   for (let i = 0; i < maxTurns; i++) {
-    const raw = await options.client.create({ model: options.model, instructions: options.instructions, input, tools: options.tools });
+    const raw = await options.client.create({ model: options.model, instructions: options.instructions, input, tools });
     const turn = normalizeOpenAiTurn(raw as Parameters<typeof normalizeOpenAiTurn>[0]);
     turns.push(turn);
     const accounted = accountLlmBudget(turns.map((t) => ({ inputTokens: t.usage.inputTokens, outputTokens: t.usage.outputTokens, toolCalls: t.toolCalls.length })), budget, DEFAULT_PRICING);
     if (accounted.aborted) return { turns, toolResults, finalText: turn.text, aborted: accounted.aborted, totalTokens: accounted.totalTokens, usdSpent: accounted.usdSpent };
     if (turn.toolCalls.length === 0) return { turns, toolResults, finalText: turn.text, totalTokens: accounted.totalTokens, usdSpent: accounted.usdSpent };
+    input.push(...toResponseInputItems(raw));
     for (const call of turn.toolCalls) {
       const result = await options.adapter.callTool(call.name, call.arguments);
       toolResults.push(result);

--- a/tests/benchmark/llm-provider/openai-loop.ts
+++ b/tests/benchmark/llm-provider/openai-loop.ts
@@ -18,11 +18,15 @@ function toResponsesTools(tools: OpenAiBenchmarkTool[]): Array<Record<string, un
   }));
 }
 
-function reasoningOutputItems(raw: unknown): Array<Record<string, unknown>> {
+function responseOutputContextItems(raw: unknown): Array<Record<string, unknown>> {
   if (!raw || typeof raw !== 'object') return [];
   const output = (raw as { output?: unknown }).output;
   if (!Array.isArray(output)) return [];
-  return output.filter((item): item is Record<string, unknown> => !!item && typeof item === 'object' && (item as { type?: unknown }).type === 'reasoning');
+  return output.filter((item): item is Record<string, unknown> => {
+    if (!item || typeof item !== 'object') return false;
+    const type = (item as { type?: unknown }).type;
+    return type === 'reasoning' || type === 'function_call';
+  });
 }
 
 export async function runOpenAiToolUseLoop(options: { client: OpenAiResponsesClient; adapter: MCPAdapter; model: string; instructions: string; user: string; tools: OpenAiBenchmarkTool[]; maxTurns?: number; budget?: BudgetCaps; }): Promise<OpenAiLoopResult> {
@@ -45,7 +49,7 @@ export async function runOpenAiToolUseLoop(options: { client: OpenAiResponsesCli
     if (accounted.aborted) return { turns, toolResults, finalText: turn.text, aborted: accounted.aborted, totalTokens: accounted.totalTokens, usdSpent: accounted.usdSpent };
     if (turn.toolCalls.length === 0) return { turns, toolResults, finalText: turn.text, totalTokens: accounted.totalTokens, usdSpent: accounted.usdSpent };
     const toolOutputs: Array<Record<string, unknown>> = [
-      ...reasoningOutputItems(raw),
+      ...responseOutputContextItems(raw),
     ];
     for (const call of turn.toolCalls) {
       const result = await options.adapter.callTool(call.name, call.arguments);

--- a/tests/benchmark/llm-provider/openai-loop.ts
+++ b/tests/benchmark/llm-provider/openai-loop.ts
@@ -18,22 +18,16 @@ function toResponsesTools(tools: OpenAiBenchmarkTool[]): Array<Record<string, un
   }));
 }
 
-function toResponseInputItems(raw: unknown): Array<Record<string, unknown>> {
-  if (!raw || typeof raw !== 'object') return [];
-  const output = (raw as { output?: unknown }).output;
-  return Array.isArray(output) ? output.filter((item): item is Record<string, unknown> => !!item && typeof item === 'object') : [];
-}
-
 export async function runOpenAiToolUseLoop(options: { client: OpenAiResponsesClient; adapter: MCPAdapter; model: string; instructions: string; user: string; tools: OpenAiBenchmarkTool[]; maxTurns?: number; budget?: BudgetCaps; }): Promise<OpenAiLoopResult> {
   const budget = options.budget ?? WEBVOYAGER_BUDGET;
   const maxTurns = options.maxTurns ?? budget.max_tool_iterations;
   const turns: NormalizedLlmTurn[] = [];
   const toolResults: MCPToolResult[] = [];
-  const input: Array<Record<string, unknown>> = [{ role: 'user', content: options.user }];
+  let nextInput: Array<Record<string, unknown>> = [{ role: 'user', content: options.user }];
   const tools = toResponsesTools(options.tools);
   let previousResponseId: string | undefined;
   for (let i = 0; i < maxTurns; i++) {
-    const request: Record<string, unknown> = { model: options.model, instructions: options.instructions, input, tools };
+    const request: Record<string, unknown> = { model: options.model, instructions: options.instructions, input: nextInput, tools };
     if (previousResponseId) request.previous_response_id = previousResponseId;
     const raw = await options.client.create(request);
     const responseId = raw && typeof raw === 'object' ? (raw as { id?: unknown }).id : undefined;
@@ -43,12 +37,13 @@ export async function runOpenAiToolUseLoop(options: { client: OpenAiResponsesCli
     const accounted = accountLlmBudget(turns.map((t) => ({ inputTokens: t.usage.inputTokens, outputTokens: t.usage.outputTokens, toolCalls: t.toolCalls.length })), budget, DEFAULT_PRICING);
     if (accounted.aborted) return { turns, toolResults, finalText: turn.text, aborted: accounted.aborted, totalTokens: accounted.totalTokens, usdSpent: accounted.usdSpent };
     if (turn.toolCalls.length === 0) return { turns, toolResults, finalText: turn.text, totalTokens: accounted.totalTokens, usdSpent: accounted.usdSpent };
-    input.push(...toResponseInputItems(raw));
+    const toolOutputs: Array<Record<string, unknown>> = [];
     for (const call of turn.toolCalls) {
       const result = await options.adapter.callTool(call.name, call.arguments);
       toolResults.push(result);
-      input.push({ type: 'function_call_output', call_id: call.id, output: result.content?.map((c) => c.text ?? '').join('\n') ?? '' });
+      toolOutputs.push({ type: 'function_call_output', call_id: call.id, output: result.content?.map((c) => c.text ?? '').join('\n') ?? '' });
     }
+    nextInput = toolOutputs;
   }
   const accounted = accountLlmBudget(turns.map((t) => ({ inputTokens: t.usage.inputTokens, outputTokens: t.usage.outputTokens, toolCalls: t.toolCalls.length })), budget, DEFAULT_PRICING);
   return { turns, toolResults, finalText: turns.at(-1)?.text ?? '', aborted: 'MAX_ITERATIONS', totalTokens: accounted.totalTokens, usdSpent: accounted.usdSpent };


### PR DESCRIPTION
## Summary
- Adds OpenAI tool-use loop matching the Anthropic loop contract.
- Dispatches normalized function calls to benchmark adapters.
- Enforces token/USD budget accounting and fail-closed live env checks.

## Verification
- npm run build
- npx jest tests/benchmark/llm-provider/openai-loop.test.ts --runInBand

Roadmap: PR4 of 12.