### PR TITLE
Add live real-world episode runner seam

### DIFF
--- a/tests/benchmark/realworld-task-completion/live-runner.test.ts
+++ b/tests/benchmark/realworld-task-completion/live-runner.test.ts
@@ -1,0 +1,16 @@
+/// <reference types="jest" />
+import { runLiveRealWorldEpisodes, assertLiveRealWorldEnabled } from './live-runner';
+
+describe('live real-world episode runner', () => {
+  test('runs library × task × repetition through injected executor', async () => {
+    const executor = { run: jest.fn(async () => ({ success: true, firstAttempt: true, recovered: null, wallTimeMs: 10, toolCalls: 1, retries: 0, noProgressLoops: 0, tokens: 5, usd: 0.001, failureCategory: 'none' as const, notes: 'dry-run final postcondition evaluated' })) };
+    const result = await runLiveRealWorldEpisodes({ provider: 'openai', library: 'openchrome', repetitions: 2, taskIds: ['rw-001-checkout-update-address'], mode: 'dry-run' }, executor);
+    expect(result.runs).toHaveLength(2);
+    expect(executor.run).toHaveBeenCalledTimes(2);
+    expect(result.claimEligibility.eligible).toBe(false);
+    expect(result.claimEligibility.reasons.join('\n')).toMatch(/dry-run/);
+  });
+  test('live mode fails closed without explicit env', () => {
+    expect(() => assertLiveRealWorldEnabled({} as NodeJS.ProcessEnv)).toThrow(/OPENCHROME_BENCH_REAL/);
+  });
+});

--- a/tests/benchmark/realworld-task-completion/live-runner.test.ts
+++ b/tests/benchmark/realworld-task-completion/live-runner.test.ts
@@ -10,6 +10,23 @@ describe('live real-world episode runner', () => {
     expect(result.claimEligibility.eligible).toBe(false);
     expect(result.claimEligibility.reasons.join('\n')).toMatch(/dry-run/);
   });
+  test('rejects unknown task ids instead of silently shrinking coverage', async () => {
+    const executor = { run: jest.fn() };
+
+    await expect(runLiveRealWorldEpisodes({ provider: 'openai', library: 'openchrome', repetitions: 1, taskIds: ['missing-task'], mode: 'dry-run' }, executor)).rejects.toThrow(/Unknown real-world taskIds: missing-task/);
+    expect(executor.run).not.toHaveBeenCalled();
+  });
+
+  test('non-dry runs require explicit pinning evidence for headline eligibility', async () => {
+    const executor = { run: jest.fn(async () => ({ success: true, firstAttempt: true, recovered: null, wallTimeMs: 10, toolCalls: 1, retries: 0, noProgressLoops: 0, tokens: 5, usd: 0.001, failureCategory: 'none' as const, notes: 'recorded postcondition' })) };
+
+    const result = await runLiveRealWorldEpisodes({ provider: 'openai', library: 'openchrome', repetitions: 10, taskIds: ['rw-001-checkout-update-address'], mode: 'recorded-real' }, executor);
+
+    expect(result.claimEligibility.eligible).toBe(false);
+    expect(result.claimEligibility.reasons.join('\n')).toMatch(/versions are not pinned/);
+    expect(result.claimEligibility.reasons.join('\n')).toMatch(/LLM model/);
+  });
+
   test('live mode fails closed without explicit env', () => {
     expect(() => assertLiveRealWorldEnabled({} as NodeJS.ProcessEnv)).toThrow(/OPENCHROME_BENCH_REAL/);
   });

--- a/tests/benchmark/realworld-task-completion/live-runner.test.ts
+++ b/tests/benchmark/realworld-task-completion/live-runner.test.ts
@@ -18,13 +18,33 @@ describe('live real-world episode runner', () => {
   });
 
   test('non-dry runs require explicit pinning evidence for headline eligibility', async () => {
-    const executor = { run: jest.fn(async () => ({ success: true, firstAttempt: true, recovered: null, wallTimeMs: 10, toolCalls: 1, retries: 0, noProgressLoops: 0, tokens: 5, usd: 0.001, failureCategory: 'none' as const, notes: 'recorded postcondition' })) };
-
+    const executor = { run: jest.fn(async () => ({ success: true, firstAttempt: true, recovered: null, wallTimeMs: 10, toolCalls: 1, retries: 0, noProgressLoops: 0, tokens: 5, usd: 0.001, failureCategory: 'none' as const, notes: 'recorded postcondition', finalPostconditionEvaluated: true })) };
+    const previous = process.env.OPENCHROME_BENCH_REAL;
+    process.env.OPENCHROME_BENCH_REAL = '1';
     const result = await runLiveRealWorldEpisodes({ provider: 'openai', library: 'openchrome', repetitions: 10, taskIds: ['rw-001-checkout-update-address'], mode: 'recorded-real' }, executor);
+    if (previous === undefined) delete process.env.OPENCHROME_BENCH_REAL;
+    else process.env.OPENCHROME_BENCH_REAL = previous;
 
     expect(result.claimEligibility.eligible).toBe(false);
     expect(result.claimEligibility.reasons.join('\n')).toMatch(/versions are not pinned/);
     expect(result.claimEligibility.reasons.join('\n')).toMatch(/LLM model/);
+  });
+
+  test('postcondition eligibility is derived from executor evidence', async () => {
+    const executor = { run: jest.fn(async () => ({ success: true, firstAttempt: true, recovered: null, wallTimeMs: 10, toolCalls: 1, retries: 0, noProgressLoops: 0, tokens: 5, usd: 0.001, failureCategory: 'none' as const, notes: 'recorded without postcondition evidence' })) };
+    const previous = process.env.OPENCHROME_BENCH_REAL;
+    process.env.OPENCHROME_BENCH_REAL = '1';
+    const result = await runLiveRealWorldEpisodes({ provider: 'openai', library: 'openchrome', repetitions: 10, taskIds: ['rw-001-checkout-update-address'], mode: 'recorded-real', competitorVersionsPinned: true, llmSettingsPinned: true }, executor);
+    if (previous === undefined) delete process.env.OPENCHROME_BENCH_REAL;
+    else process.env.OPENCHROME_BENCH_REAL = previous;
+
+    expect(result.claimEligibility.eligible).toBe(false);
+    expect(result.claimEligibility.reasons.join('\n')).toMatch(/postcondition/);
+  });
+
+  test('recorded-real mode fails closed without explicit env', async () => {
+    const executor = { run: jest.fn() };
+    await expect(runLiveRealWorldEpisodes({ provider: 'openai', library: 'openchrome', repetitions: 1, taskIds: ['rw-001-checkout-update-address'], mode: 'recorded-real' }, executor)).rejects.toThrow(/OPENCHROME_BENCH_REAL/);
   });
 
   test('live mode fails closed without explicit env', () => {

--- a/tests/benchmark/realworld-task-completion/live-runner.test.ts
+++ b/tests/benchmark/realworld-task-completion/live-runner.test.ts
@@ -10,6 +10,14 @@ describe('live real-world episode runner', () => {
     expect(result.claimEligibility.eligible).toBe(false);
     expect(result.claimEligibility.reasons.join('\n')).toMatch(/dry-run/);
   });
+  test('canonical run identity cannot be overridden by executor output', async () => {
+    const executor = { run: jest.fn(async () => ({ library: 'wrong', taskId: 'wrong', mode: 'wrong', success: true, firstAttempt: true, recovered: null, wallTimeMs: 10, toolCalls: 1, retries: 0, noProgressLoops: 0, tokens: 5, usd: 0.001, failureCategory: 'none' as const, notes: 'dry-run final postcondition evaluated' })) };
+
+    const result = await runLiveRealWorldEpisodes({ provider: 'openai', library: 'openchrome', repetitions: 1, taskIds: ['rw-001-checkout-update-address'], mode: 'dry-run' }, executor);
+
+    expect(result.runs[0]).toEqual(expect.objectContaining({ library: 'openchrome', taskId: 'rw-001-checkout-update-address', mode: 'deterministic-fixture' }));
+  });
+
   test('rejects empty task selections instead of returning zero-coverage results', async () => {
     const executor = { run: jest.fn() };
 

--- a/tests/benchmark/realworld-task-completion/live-runner.test.ts
+++ b/tests/benchmark/realworld-task-completion/live-runner.test.ts
@@ -10,6 +10,13 @@ describe('live real-world episode runner', () => {
     expect(result.claimEligibility.eligible).toBe(false);
     expect(result.claimEligibility.reasons.join('\n')).toMatch(/dry-run/);
   });
+  test('rejects empty task selections instead of returning zero-coverage results', async () => {
+    const executor = { run: jest.fn() };
+
+    await expect(runLiveRealWorldEpisodes({ provider: 'openai', library: 'openchrome', repetitions: 1, taskIds: [], mode: 'dry-run' }, executor)).rejects.toThrow(/At least one/);
+    expect(executor.run).not.toHaveBeenCalled();
+  });
+
   test('rejects unknown task ids instead of silently shrinking coverage', async () => {
     const executor = { run: jest.fn() };
 

--- a/tests/benchmark/realworld-task-completion/live-runner.ts
+++ b/tests/benchmark/realworld-task-completion/live-runner.ts
@@ -15,14 +15,15 @@ export interface LiveRealWorldRunOptions {
   competitorVersionsPinned?: boolean;
   llmSettingsPinned?: boolean;
 }
-export interface LiveTaskExecutor { run(input: { taskId: string; library: LiveLibraryName; provider: LiveProviderName; repetition: number }): Promise<Omit<RealWorldTaskRun, 'library' | 'taskId' | 'mode'>>; }
+export type LiveTaskExecutorRun = Omit<RealWorldTaskRun, 'library' | 'taskId' | 'mode'> & { finalPostconditionEvaluated?: boolean };
+export interface LiveTaskExecutor { run(input: { taskId: string; library: LiveLibraryName; provider: LiveProviderName; repetition: number }): Promise<LiveTaskExecutorRun>; }
 
 export function assertLiveRealWorldEnabled(env = process.env): void {
   if (env.OPENCHROME_BENCH_REAL !== '1') throw new Error('OPENCHROME_BENCH_REAL=1 is required for live real-world episodes');
 }
 
 export async function runLiveRealWorldEpisodes(options: LiveRealWorldRunOptions, executor: LiveTaskExecutor): Promise<{ runs: RealWorldTaskRun[]; claimEligibility: ReturnType<typeof evaluateEpisodeClaimEligibility> }> {
-  if (options.mode === 'live') assertLiveRealWorldEnabled();
+  if (options.mode !== 'dry-run') assertLiveRealWorldEnabled();
   if (!Number.isInteger(options.repetitions) || options.repetitions <= 0) throw new Error('repetitions must be a positive integer');
   const requestedTaskIds = new Set(options.taskIds ?? realWorldTaskSpecs.map((task) => task.id));
   const selected = realWorldTaskSpecs.filter((task) => requestedTaskIds.has(task.id));
@@ -30,17 +31,20 @@ export async function runLiveRealWorldEpisodes(options: LiveRealWorldRunOptions,
   const unknownTaskIds = [...requestedTaskIds].filter((id) => !selectedIds.has(id));
   if (unknownTaskIds.length > 0) throw new Error(`Unknown real-world taskIds: ${unknownTaskIds.join(', ')}`);
   const runs: RealWorldTaskRun[] = [];
+  const postconditionEvidence: boolean[] = [];
   for (const task of selected) {
     for (let repetition = 0; repetition < options.repetitions; repetition++) {
       const row = await executor.run({ taskId: task.id, library: options.library, provider: options.provider, repetition });
-      runs.push({ library: options.library, taskId: task.id, mode: options.mode === 'recorded-real' ? 'recorded-real' : options.mode === 'live' ? 'live-llm' : 'deterministic-fixture', ...row });
+      const { finalPostconditionEvaluated, ...runRow } = row;
+      postconditionEvidence.push(finalPostconditionEvaluated === true);
+      runs.push({ library: options.library, taskId: task.id, mode: options.mode === 'recorded-real' ? 'recorded-real' : options.mode === 'live' ? 'live-llm' : 'deterministic-fixture', ...runRow });
     }
   }
   const claimEligibility = evaluateEpisodeClaimEligibility({
     mode: options.mode === 'live' ? 'live' : options.mode === 'recorded-real' ? 'recorded-real' : 'dry-run',
     scope: 'aggregate',
     sampleCount: runs.length,
-    finalPostconditionEvaluated: true,
+    finalPostconditionEvaluated: runs.length > 0 && postconditionEvidence.every(Boolean),
     competitorVersionsPinned: options.competitorVersionsPinned === true,
     sameTaskContracts: true,
     llmSettingsPinned: options.llmSettingsPinned === true,

--- a/tests/benchmark/realworld-task-completion/live-runner.ts
+++ b/tests/benchmark/realworld-task-completion/live-runner.ts
@@ -30,6 +30,7 @@ export async function runLiveRealWorldEpisodes(options: LiveRealWorldRunOptions,
   const selectedIds = new Set(selected.map((task) => task.id));
   const unknownTaskIds = [...requestedTaskIds].filter((id) => !selectedIds.has(id));
   if (unknownTaskIds.length > 0) throw new Error(`Unknown real-world taskIds: ${unknownTaskIds.join(', ')}`);
+  if (selected.length === 0) throw new Error('At least one real-world task must be selected');
   const runs: RealWorldTaskRun[] = [];
   const postconditionEvidence: boolean[] = [];
   for (const task of selected) {

--- a/tests/benchmark/realworld-task-completion/live-runner.ts
+++ b/tests/benchmark/realworld-task-completion/live-runner.ts
@@ -6,7 +6,15 @@ export type LiveProviderName = 'anthropic' | 'openai';
 export type LiveLibraryName = 'openchrome' | 'playwright' | 'puppeteer' | 'playwright-mcp' | 'browser-use';
 export type LiveRunnerMode = 'dry-run' | 'live' | 'recorded-real';
 
-export interface LiveRealWorldRunOptions { provider: LiveProviderName; library: LiveLibraryName; repetitions: number; taskIds?: string[]; mode: LiveRunnerMode; }
+export interface LiveRealWorldRunOptions {
+  provider: LiveProviderName;
+  library: LiveLibraryName;
+  repetitions: number;
+  taskIds?: string[];
+  mode: LiveRunnerMode;
+  competitorVersionsPinned?: boolean;
+  llmSettingsPinned?: boolean;
+}
 export interface LiveTaskExecutor { run(input: { taskId: string; library: LiveLibraryName; provider: LiveProviderName; repetition: number }): Promise<Omit<RealWorldTaskRun, 'library' | 'taskId' | 'mode'>>; }
 
 export function assertLiveRealWorldEnabled(env = process.env): void {
@@ -16,7 +24,11 @@ export function assertLiveRealWorldEnabled(env = process.env): void {
 export async function runLiveRealWorldEpisodes(options: LiveRealWorldRunOptions, executor: LiveTaskExecutor): Promise<{ runs: RealWorldTaskRun[]; claimEligibility: ReturnType<typeof evaluateEpisodeClaimEligibility> }> {
   if (options.mode === 'live') assertLiveRealWorldEnabled();
   if (!Number.isInteger(options.repetitions) || options.repetitions <= 0) throw new Error('repetitions must be a positive integer');
-  const selected = realWorldTaskSpecs.filter((task) => !options.taskIds || options.taskIds.includes(task.id));
+  const requestedTaskIds = new Set(options.taskIds ?? realWorldTaskSpecs.map((task) => task.id));
+  const selected = realWorldTaskSpecs.filter((task) => requestedTaskIds.has(task.id));
+  const selectedIds = new Set(selected.map((task) => task.id));
+  const unknownTaskIds = [...requestedTaskIds].filter((id) => !selectedIds.has(id));
+  if (unknownTaskIds.length > 0) throw new Error(`Unknown real-world taskIds: ${unknownTaskIds.join(', ')}`);
   const runs: RealWorldTaskRun[] = [];
   for (const task of selected) {
     for (let repetition = 0; repetition < options.repetitions; repetition++) {
@@ -29,9 +41,9 @@ export async function runLiveRealWorldEpisodes(options: LiveRealWorldRunOptions,
     scope: 'aggregate',
     sampleCount: runs.length,
     finalPostconditionEvaluated: true,
-    competitorVersionsPinned: options.mode !== 'dry-run',
+    competitorVersionsPinned: options.competitorVersionsPinned === true,
     sameTaskContracts: true,
-    llmSettingsPinned: options.mode !== 'dry-run',
+    llmSettingsPinned: options.llmSettingsPinned === true,
   });
   return { runs, claimEligibility };
 }

--- a/tests/benchmark/realworld-task-completion/live-runner.ts
+++ b/tests/benchmark/realworld-task-completion/live-runner.ts
@@ -1,0 +1,37 @@
+import { evaluateEpisodeClaimEligibility } from '../episode-harness/claim-eligibility';
+import type { RealWorldTaskRun } from './types';
+import { realWorldTaskSpecs } from './fixtures';
+
+export type LiveProviderName = 'anthropic' | 'openai';
+export type LiveLibraryName = 'openchrome' | 'playwright' | 'puppeteer' | 'playwright-mcp' | 'browser-use';
+export type LiveRunnerMode = 'dry-run' | 'live' | 'recorded-real';
+
+export interface LiveRealWorldRunOptions { provider: LiveProviderName; library: LiveLibraryName; repetitions: number; taskIds?: string[]; mode: LiveRunnerMode; }
+export interface LiveTaskExecutor { run(input: { taskId: string; library: LiveLibraryName; provider: LiveProviderName; repetition: number }): Promise<Omit<RealWorldTaskRun, 'library' | 'taskId' | 'mode'>>; }
+
+export function assertLiveRealWorldEnabled(env = process.env): void {
+  if (env.OPENCHROME_BENCH_REAL !== '1') throw new Error('OPENCHROME_BENCH_REAL=1 is required for live real-world episodes');
+}
+
+export async function runLiveRealWorldEpisodes(options: LiveRealWorldRunOptions, executor: LiveTaskExecutor): Promise<{ runs: RealWorldTaskRun[]; claimEligibility: ReturnType<typeof evaluateEpisodeClaimEligibility> }> {
+  if (options.mode === 'live') assertLiveRealWorldEnabled();
+  if (!Number.isInteger(options.repetitions) || options.repetitions <= 0) throw new Error('repetitions must be a positive integer');
+  const selected = realWorldTaskSpecs.filter((task) => !options.taskIds || options.taskIds.includes(task.id));
+  const runs: RealWorldTaskRun[] = [];
+  for (const task of selected) {
+    for (let repetition = 0; repetition < options.repetitions; repetition++) {
+      const row = await executor.run({ taskId: task.id, library: options.library, provider: options.provider, repetition });
+      runs.push({ library: options.library, taskId: task.id, mode: options.mode === 'recorded-real' ? 'recorded-real' : options.mode === 'live' ? 'live-llm' : 'deterministic-fixture', ...row });
+    }
+  }
+  const claimEligibility = evaluateEpisodeClaimEligibility({
+    mode: options.mode === 'live' ? 'live' : options.mode === 'recorded-real' ? 'recorded-real' : 'dry-run',
+    scope: 'aggregate',
+    sampleCount: runs.length,
+    finalPostconditionEvaluated: true,
+    competitorVersionsPinned: options.mode !== 'dry-run',
+    sameTaskContracts: true,
+    llmSettingsPinned: options.mode !== 'dry-run',
+  });
+  return { runs, claimEligibility };
+}

--- a/tests/benchmark/realworld-task-completion/live-runner.ts
+++ b/tests/benchmark/realworld-task-completion/live-runner.ts
@@ -38,7 +38,7 @@ export async function runLiveRealWorldEpisodes(options: LiveRealWorldRunOptions,
       const row = await executor.run({ taskId: task.id, library: options.library, provider: options.provider, repetition });
       const { finalPostconditionEvaluated, ...runRow } = row;
       postconditionEvidence.push(finalPostconditionEvaluated === true);
-      runs.push({ library: options.library, taskId: task.id, mode: options.mode === 'recorded-real' ? 'recorded-real' : options.mode === 'live' ? 'live-llm' : 'deterministic-fixture', ...runRow });
+      runs.push({ ...runRow, library: options.library, taskId: task.id, mode: options.mode === 'recorded-real' ? 'recorded-real' : options.mode === 'live' ? 'live-llm' : 'deterministic-fixture' });
     }
   }
   const claimEligibility = evaluateEpisodeClaimEligibility({


### PR DESCRIPTION
## Summary
- Adds live/recorded-real/dry-run real-world episode runner seam.
- Supports provider/library/task/repetition matrix with injected executor tests.
- Emits claimEligibility so dry-run evidence remains diagnostic-only.

## Verification
- npm run build
- npx jest tests/benchmark/realworld-task-completion/live-runner.test.ts --runInBand

Roadmap: PR5 of 12. Stacked on PR4.