### PR TITLE
Add playwright-mcp native task loop

### DIFF
--- a/tests/benchmark/native/playwright-mcp-native.test.ts
+++ b/tests/benchmark/native/playwright-mcp-native.test.ts
@@ -34,6 +34,15 @@ describe('playwright-mcp native loop', () => {
     expect(result.status).toBe('passed');
   });
 
+  test('snapshots one-shot iterators before required tool membership checks', async () => {
+    const discovered = ['browser_navigate', 'browser_snapshot'].values();
+    const transport = { listTools: jest.fn(async () => discovered), callTool: jest.fn(async (name: string) => ({ content: [{ type: 'text', text: `${name} ok` }] })) };
+
+    const result = await runPlaywrightMcpNativeTask(transport, { id: 't1', startUrl: 'http://x', goal: 'read', successText: 'browser_snapshot ok' });
+
+    expect(result.status).toBe('passed');
+  });
+
   test('reports unsupported when required tools are absent', async () => {
     const result = await runPlaywrightMcpNativeTask({ listTools: async () => ['browser_navigate'], callTool: jest.fn() }, { id: 't1', startUrl: 'http://x', goal: 'read' });
     expect(result.status).toBe('unsupported');

--- a/tests/benchmark/native/playwright-mcp-native.test.ts
+++ b/tests/benchmark/native/playwright-mcp-native.test.ts
@@ -26,6 +26,14 @@ describe('playwright-mcp native loop', () => {
     expect(result.trace[0]).toEqual(expect.objectContaining({ tool: 'transport', ok: false, error: 'mcp down' }));
   });
 
+  test('accepts Set-valued tool discovery from stdio MCP clients', async () => {
+    const transport = { listTools: jest.fn(async () => new Set(['browser_navigate', 'browser_snapshot'])), callTool: jest.fn(async (name: string) => ({ content: [{ type: 'text', text: `${name} ok` }] })) };
+
+    const result = await runPlaywrightMcpNativeTask(transport, { id: 't1', startUrl: 'http://x', goal: 'read', successText: 'browser_snapshot ok' });
+
+    expect(result.status).toBe('passed');
+  });
+
   test('reports unsupported when required tools are absent', async () => {
     const result = await runPlaywrightMcpNativeTask({ listTools: async () => ['browser_navigate'], callTool: jest.fn() }, { id: 't1', startUrl: 'http://x', goal: 'read' });
     expect(result.status).toBe('unsupported');

--- a/tests/benchmark/native/playwright-mcp-native.test.ts
+++ b/tests/benchmark/native/playwright-mcp-native.test.ts
@@ -4,11 +4,20 @@ import { runPlaywrightMcpNativeTask } from './playwright-mcp-native';
 describe('playwright-mcp native loop', () => {
   test('runs native navigate and snapshot sequence', async () => {
     const transport = { listTools: jest.fn(async () => ['browser_navigate', 'browser_snapshot']), callTool: jest.fn(async (name: string) => ({ content: [{ type: 'text', text: `${name} ok` }] })) };
-    const result = await runPlaywrightMcpNativeTask(transport, { id: 't1', startUrl: 'http://x', goal: 'read' });
+    const result = await runPlaywrightMcpNativeTask(transport, { id: 't1', startUrl: 'http://x', goal: 'read', successText: 'browser_snapshot ok' });
     expect(result.status).toBe('passed');
     expect(transport.callTool).toHaveBeenNthCalledWith(1, 'browser_navigate', { url: 'http://x' });
     expect(transport.callTool).toHaveBeenNthCalledWith(2, 'browser_snapshot', {});
   });
+  test('fails the task when the snapshot does not satisfy the goal evidence', async () => {
+    const transport = { listTools: jest.fn(async () => ['browser_navigate', 'browser_snapshot']), callTool: jest.fn(async () => ({ content: [{ type: 'text', text: 'wrong page' }] })) };
+
+    const result = await runPlaywrightMcpNativeTask(transport, { id: 't1', startUrl: 'http://x', goal: 'checkout complete' });
+
+    expect(result.status).toBe('failed');
+    expect(result.failureCategory).toBe('postcondition');
+  });
+
   test('classifies discovery failures as infrastructure failures', async () => {
     const result = await runPlaywrightMcpNativeTask({ listTools: async () => { throw new Error('mcp down'); }, callTool: jest.fn() }, { id: 't1', startUrl: 'http://x', goal: 'read' });
 

--- a/tests/benchmark/native/playwright-mcp-native.test.ts
+++ b/tests/benchmark/native/playwright-mcp-native.test.ts
@@ -1,0 +1,17 @@
+/// <reference types="jest" />
+import { runPlaywrightMcpNativeTask } from './playwright-mcp-native';
+
+describe('playwright-mcp native loop', () => {
+  test('runs native navigate and snapshot sequence', async () => {
+    const transport = { listTools: jest.fn(async () => ['browser_navigate', 'browser_snapshot']), callTool: jest.fn(async (name: string) => ({ content: [{ type: 'text', text: `${name} ok` }] })) };
+    const result = await runPlaywrightMcpNativeTask(transport, { id: 't1', startUrl: 'http://x', goal: 'read' });
+    expect(result.status).toBe('passed');
+    expect(transport.callTool).toHaveBeenNthCalledWith(1, 'browser_navigate', { url: 'http://x' });
+    expect(transport.callTool).toHaveBeenNthCalledWith(2, 'browser_snapshot', {});
+  });
+  test('reports unsupported when required tools are absent', async () => {
+    const result = await runPlaywrightMcpNativeTask({ listTools: async () => ['browser_navigate'], callTool: jest.fn() }, { id: 't1', startUrl: 'http://x', goal: 'read' });
+    expect(result.status).toBe('unsupported');
+    expect(result.failureCategory).toMatch(/browser_snapshot/);
+  });
+});

--- a/tests/benchmark/native/playwright-mcp-native.test.ts
+++ b/tests/benchmark/native/playwright-mcp-native.test.ts
@@ -9,6 +9,14 @@ describe('playwright-mcp native loop', () => {
     expect(transport.callTool).toHaveBeenNthCalledWith(1, 'browser_navigate', { url: 'http://x' });
     expect(transport.callTool).toHaveBeenNthCalledWith(2, 'browser_snapshot', {});
   });
+  test('classifies discovery failures as infrastructure failures', async () => {
+    const result = await runPlaywrightMcpNativeTask({ listTools: async () => { throw new Error('mcp down'); }, callTool: jest.fn() }, { id: 't1', startUrl: 'http://x', goal: 'read' });
+
+    expect(result.status).toBe('failed');
+    expect(result.failureCategory).toBe('infrastructure');
+    expect(result.trace[0]).toEqual(expect.objectContaining({ tool: 'transport', ok: false, error: 'mcp down' }));
+  });
+
   test('reports unsupported when required tools are absent', async () => {
     const result = await runPlaywrightMcpNativeTask({ listTools: async () => ['browser_navigate'], callTool: jest.fn() }, { id: 't1', startUrl: 'http://x', goal: 'read' });
     expect(result.status).toBe('unsupported');

--- a/tests/benchmark/native/playwright-mcp-native.ts
+++ b/tests/benchmark/native/playwright-mcp-native.ts
@@ -4,9 +4,14 @@ export interface NativeToolEvent { tool: string; ok: boolean; text?: string; err
 export interface NativeEpisodeResult { library: 'playwright-mcp'; mode: 'native'; taskId: string; status: 'passed' | 'failed' | 'unsupported' | 'timeout'; trace: NativeToolEvent[]; finalText: string; failureCategory?: string; }
 export interface PlaywrightMcpNativeTransport { listTools(): Promise<string[]>; callTool(name: string, args: Record<string, unknown>): Promise<MCPToolResult>; }
 
+function goalSatisfied(text: string, task: { goal: string; successText?: string; successCriteria?: string[] }): boolean {
+  const criteria = task.successCriteria?.length ? task.successCriteria : [task.successText ?? task.goal];
+  return criteria.every((criterion) => text.toLocaleLowerCase().includes(criterion.toLocaleLowerCase()));
+}
+
 const REQUIRED = ['browser_navigate', 'browser_snapshot'];
 
-export async function runPlaywrightMcpNativeTask(transport: PlaywrightMcpNativeTransport, task: { id: string; startUrl: string; goal: string }): Promise<NativeEpisodeResult> {
+export async function runPlaywrightMcpNativeTask(transport: PlaywrightMcpNativeTransport, task: { id: string; startUrl: string; goal: string; successText?: string; successCriteria?: string[] }): Promise<NativeEpisodeResult> {
   const trace: NativeToolEvent[] = [];
   try {
     const tools = await transport.listTools();
@@ -18,7 +23,9 @@ export async function runPlaywrightMcpNativeTask(transport: PlaywrightMcpNativeT
     const snapshot = await transport.callTool('browser_snapshot', {});
     const text = snapshot.content?.map((c) => c.text ?? '').join('\n') ?? '';
     trace.push({ tool: 'browser_snapshot', ok: !snapshot.isError, text });
-    return { library: 'playwright-mcp', mode: 'native', taskId: task.id, status: snapshot.isError ? 'failed' : 'passed', trace, finalText: text, ...(snapshot.isError && { failureCategory: 'snapshot' }) };
+    if (snapshot.isError) return { library: 'playwright-mcp', mode: 'native', taskId: task.id, status: 'failed', trace, finalText: text, failureCategory: 'snapshot' };
+    if (!goalSatisfied(text, task)) return { library: 'playwright-mcp', mode: 'native', taskId: task.id, status: 'failed', trace, finalText: text, failureCategory: 'postcondition' };
+    return { library: 'playwright-mcp', mode: 'native', taskId: task.id, status: 'passed', trace, finalText: text };
   } catch (err) {
     trace.push({ tool: 'transport', ok: false, error: err instanceof Error ? err.message : String(err) });
     return { library: 'playwright-mcp', mode: 'native', taskId: task.id, status: 'failed', trace, finalText: '', failureCategory: 'infrastructure' };

--- a/tests/benchmark/native/playwright-mcp-native.ts
+++ b/tests/benchmark/native/playwright-mcp-native.ts
@@ -1,0 +1,26 @@
+import type { MCPToolResult } from '../benchmark-runner';
+
+export interface NativeToolEvent { tool: string; ok: boolean; text?: string; error?: string; }
+export interface NativeEpisodeResult { library: 'playwright-mcp'; mode: 'native'; taskId: string; status: 'passed' | 'failed' | 'unsupported' | 'timeout'; trace: NativeToolEvent[]; finalText: string; failureCategory?: string; }
+export interface PlaywrightMcpNativeTransport { listTools(): Promise<string[]>; callTool(name: string, args: Record<string, unknown>): Promise<MCPToolResult>; }
+
+const REQUIRED = ['browser_navigate', 'browser_snapshot'];
+
+export async function runPlaywrightMcpNativeTask(transport: PlaywrightMcpNativeTransport, task: { id: string; startUrl: string; goal: string }): Promise<NativeEpisodeResult> {
+  const tools = await transport.listTools();
+  const missing = REQUIRED.filter((tool) => !tools.includes(tool));
+  if (missing.length > 0) return { library: 'playwright-mcp', mode: 'native', taskId: task.id, status: 'unsupported', trace: [], finalText: '', failureCategory: `missing tools: ${missing.join(', ')}` };
+  const trace: NativeToolEvent[] = [];
+  try {
+    const nav = await transport.callTool('browser_navigate', { url: task.startUrl });
+    trace.push({ tool: 'browser_navigate', ok: !nav.isError, text: nav.content?.[0]?.text });
+    if (nav.isError) return { library: 'playwright-mcp', mode: 'native', taskId: task.id, status: 'failed', trace, finalText: '', failureCategory: 'navigation' };
+    const snapshot = await transport.callTool('browser_snapshot', {});
+    const text = snapshot.content?.map((c) => c.text ?? '').join('\n') ?? '';
+    trace.push({ tool: 'browser_snapshot', ok: !snapshot.isError, text });
+    return { library: 'playwright-mcp', mode: 'native', taskId: task.id, status: snapshot.isError ? 'failed' : 'passed', trace, finalText: text, ...(snapshot.isError && { failureCategory: 'snapshot' }) };
+  } catch (err) {
+    trace.push({ tool: 'transport', ok: false, error: err instanceof Error ? err.message : String(err) });
+    return { library: 'playwright-mcp', mode: 'native', taskId: task.id, status: 'failed', trace, finalText: '', failureCategory: 'infrastructure' };
+  }
+}

--- a/tests/benchmark/native/playwright-mcp-native.ts
+++ b/tests/benchmark/native/playwright-mcp-native.ts
@@ -7,11 +7,11 @@ export interface PlaywrightMcpNativeTransport { listTools(): Promise<string[]>; 
 const REQUIRED = ['browser_navigate', 'browser_snapshot'];
 
 export async function runPlaywrightMcpNativeTask(transport: PlaywrightMcpNativeTransport, task: { id: string; startUrl: string; goal: string }): Promise<NativeEpisodeResult> {
-  const tools = await transport.listTools();
-  const missing = REQUIRED.filter((tool) => !tools.includes(tool));
-  if (missing.length > 0) return { library: 'playwright-mcp', mode: 'native', taskId: task.id, status: 'unsupported', trace: [], finalText: '', failureCategory: `missing tools: ${missing.join(', ')}` };
   const trace: NativeToolEvent[] = [];
   try {
+    const tools = await transport.listTools();
+    const missing = REQUIRED.filter((tool) => !tools.includes(tool));
+    if (missing.length > 0) return { library: 'playwright-mcp', mode: 'native', taskId: task.id, status: 'unsupported', trace, finalText: '', failureCategory: `missing tools: ${missing.join(', ')}` };
     const nav = await transport.callTool('browser_navigate', { url: task.startUrl });
     trace.push({ tool: 'browser_navigate', ok: !nav.isError, text: nav.content?.[0]?.text });
     if (nav.isError) return { library: 'playwright-mcp', mode: 'native', taskId: task.id, status: 'failed', trace, finalText: '', failureCategory: 'navigation' };

--- a/tests/benchmark/native/playwright-mcp-native.ts
+++ b/tests/benchmark/native/playwright-mcp-native.ts
@@ -2,7 +2,7 @@ import type { MCPToolResult } from '../benchmark-runner';
 
 export interface NativeToolEvent { tool: string; ok: boolean; text?: string; error?: string; }
 export interface NativeEpisodeResult { library: 'playwright-mcp'; mode: 'native'; taskId: string; status: 'passed' | 'failed' | 'unsupported' | 'timeout'; trace: NativeToolEvent[]; finalText: string; failureCategory?: string; }
-export interface PlaywrightMcpNativeTransport { listTools(): Promise<string[]>; callTool(name: string, args: Record<string, unknown>): Promise<MCPToolResult>; }
+export interface PlaywrightMcpNativeTransport { listTools(): Promise<Iterable<string>>; callTool(name: string, args: Record<string, unknown>): Promise<MCPToolResult>; }
 
 function goalSatisfied(text: string, task: { goal: string; successText?: string; successCriteria?: string[] }): boolean {
   const criteria = task.successCriteria?.length ? task.successCriteria : [task.successText ?? task.goal];
@@ -11,11 +11,16 @@ function goalSatisfied(text: string, task: { goal: string; successText?: string;
 
 const REQUIRED = ['browser_navigate', 'browser_snapshot'];
 
+function hasTool(tools: Iterable<string>, tool: string): boolean {
+  if (tools instanceof Set) return tools.has(tool);
+  return Array.from(tools).includes(tool);
+}
+
 export async function runPlaywrightMcpNativeTask(transport: PlaywrightMcpNativeTransport, task: { id: string; startUrl: string; goal: string; successText?: string; successCriteria?: string[] }): Promise<NativeEpisodeResult> {
   const trace: NativeToolEvent[] = [];
   try {
     const tools = await transport.listTools();
-    const missing = REQUIRED.filter((tool) => !tools.includes(tool));
+    const missing = REQUIRED.filter((tool) => !hasTool(tools, tool));
     if (missing.length > 0) return { library: 'playwright-mcp', mode: 'native', taskId: task.id, status: 'unsupported', trace, finalText: '', failureCategory: `missing tools: ${missing.join(', ')}` };
     const nav = await transport.callTool('browser_navigate', { url: task.startUrl });
     trace.push({ tool: 'browser_navigate', ok: !nav.isError, text: nav.content?.[0]?.text });

--- a/tests/benchmark/native/playwright-mcp-native.ts
+++ b/tests/benchmark/native/playwright-mcp-native.ts
@@ -11,16 +11,15 @@ function goalSatisfied(text: string, task: { goal: string; successText?: string;
 
 const REQUIRED = ['browser_navigate', 'browser_snapshot'];
 
-function hasTool(tools: Iterable<string>, tool: string): boolean {
-  if (tools instanceof Set) return tools.has(tool);
-  return Array.from(tools).includes(tool);
+function discoveredToolSet(tools: Iterable<string>): Set<string> {
+  return tools instanceof Set ? tools : new Set(Array.from(tools));
 }
 
 export async function runPlaywrightMcpNativeTask(transport: PlaywrightMcpNativeTransport, task: { id: string; startUrl: string; goal: string; successText?: string; successCriteria?: string[] }): Promise<NativeEpisodeResult> {
   const trace: NativeToolEvent[] = [];
   try {
-    const tools = await transport.listTools();
-    const missing = REQUIRED.filter((tool) => !hasTool(tools, tool));
+    const tools = discoveredToolSet(await transport.listTools());
+    const missing = REQUIRED.filter((tool) => !tools.has(tool));
     if (missing.length > 0) return { library: 'playwright-mcp', mode: 'native', taskId: task.id, status: 'unsupported', trace, finalText: '', failureCategory: `missing tools: ${missing.join(', ')}` };
     const nav = await transport.callTool('browser_navigate', { url: task.startUrl });
     trace.push({ tool: 'browser_navigate', ok: !nav.isError, text: nav.content?.[0]?.text });


### PR DESCRIPTION
## Summary
- Adds native playwright-mcp task loop over browser_navigate/browser_snapshot.
- Captures trace and unsupported missing-tool status.
- Uses injected transport tests; no live subprocess needed in CI.

## Verification
- npm run build
- npx jest tests/benchmark/native/playwright-mcp-native.test.ts --runInBand

Roadmap: PR6 of 12. Stacked on PR5.