### PR TITLE
Add live token extractor wiring seam

### DIFF
--- a/tests/benchmark/extractors/live-token-wiring.test.ts
+++ b/tests/benchmark/extractors/live-token-wiring.test.ts
@@ -27,6 +27,14 @@ describe('live token extractor wiring', () => {
     expect(result.extracted.title).toBeNull();
   });
 
+  test('extracts OpenChrome serialized DOM snapshot field text', async () => {
+    const adapter: MCPAdapter = { name: 'mock', mode: 'live', kind: 'library', callTool: jest.fn(async (tool: string) => tool === 'tabs_create' ? { content: [{ type: 'text', text: '{\"tabId\":\"t\"}' }] } : { content: [{ type: 'text', text: '<main data-field=\"title\"/>Hello\n<p/>Hello elsewhere' }] }) };
+
+    const result = await extractLiveMcpPayload({ library: 'openchrome', mode: 'dom', adapterFactory: () => adapter }, 'http://x', ctx);
+
+    expect(result.extracted.title).toBe('Hello');
+  });
+
   test('extracts structured JSON fields when a live adapter returns JSON', async () => {
     const adapter: MCPAdapter = { name: 'mock', mode: 'live', kind: 'library', callTool: jest.fn(async (tool: string) => tool === 'tabs_create' ? { content: [{ type: 'text', text: '{\"tabId\":\"t\"}' }] } : { content: [{ type: 'text', text: '{\"title\":\"Hello\"}' }] }) };
 

--- a/tests/benchmark/extractors/live-token-wiring.test.ts
+++ b/tests/benchmark/extractors/live-token-wiring.test.ts
@@ -1,0 +1,19 @@
+/// <reference types="jest" />
+import type { MCPAdapter } from '../benchmark-runner';
+import { createLiveMcpExtractor, extractLiveMcpPayload } from './live-token-wiring';
+
+describe('live token extractor wiring', () => {
+  const ctx = { html: '<html></html>', fixtureName: 'f', archetype: 'a', liveAllowed: true, groundTruth: { fixture: 'f', fields: [{ key: 'title', expected: 'Hello' }] } };
+  test('sync extractor remains live-gated', () => {
+    const extractor = createLiveMcpExtractor({ library: 'openchrome-readpage-dom', mode: 'dom', adapterFactory: jest.fn() });
+    expect(extractor.extract({ ...ctx, liveAllowed: false })).toBeNull();
+    expect(() => extractor.extract(ctx)).toThrow(/async live extraction/);
+  });
+  test('async live extraction drives adapter create/read/close', async () => {
+    const adapter: MCPAdapter = { name: 'mock', mode: 'live', kind: 'library', setup: jest.fn(), teardown: jest.fn(), callTool: jest.fn(async (tool: string) => tool === 'tabs_create' ? { content: [{ type: 'text', text: '{"tabId":"t"}' }] } : { content: [{ type: 'text', text: 'Hello payload' }] }) };
+    const result = await extractLiveMcpPayload({ library: 'openchrome', mode: 'dom', adapterFactory: () => adapter }, 'http://x', ctx);
+    expect(result.payload).toContain('Hello');
+    expect(result.extracted.title).toBe('Hello');
+    expect(adapter.callTool).toHaveBeenCalledWith('read_page', { tabId: 't' });
+  });
+});

--- a/tests/benchmark/extractors/live-token-wiring.test.ts
+++ b/tests/benchmark/extractors/live-token-wiring.test.ts
@@ -15,5 +15,25 @@ describe('live token extractor wiring', () => {
     expect(result.payload).toContain('Hello');
     expect(result.extracted.title).toBe('Hello');
     expect(adapter.callTool).toHaveBeenCalledWith('read_page', { tabId: 't', mode: 'dom' });
+    expect(adapter.callTool).toHaveBeenCalledWith('tabs_close', { tabId: 't' });
+  });
+
+  test('closes created tabs when read_page fails', async () => {
+    const adapter: MCPAdapter = {
+      name: 'mock',
+      mode: 'live',
+      kind: 'library',
+      teardown: jest.fn(),
+      callTool: jest.fn(async (tool: string) => {
+        if (tool === 'tabs_create') return { content: [{ type: 'text', text: '{\"tabId\":\"t\"}' }] };
+        if (tool === 'read_page') return { isError: true, content: [{ type: 'text', text: 'read failed' }] };
+        return { content: [{ type: 'text', text: 'closed' }] };
+      }),
+    };
+
+    await expect(extractLiveMcpPayload({ library: 'openchrome', mode: 'ax', adapterFactory: () => adapter }, 'http://x', ctx)).rejects.toThrow(/read failed/);
+
+    expect(adapter.callTool).toHaveBeenCalledWith('tabs_close', { tabId: 't' });
+    expect(adapter.teardown).toHaveBeenCalled();
   });
 });

--- a/tests/benchmark/extractors/live-token-wiring.test.ts
+++ b/tests/benchmark/extractors/live-token-wiring.test.ts
@@ -14,6 +14,6 @@ describe('live token extractor wiring', () => {
     const result = await extractLiveMcpPayload({ library: 'openchrome', mode: 'dom', adapterFactory: () => adapter }, 'http://x', ctx);
     expect(result.payload).toContain('Hello');
     expect(result.extracted.title).toBe('Hello');
-    expect(adapter.callTool).toHaveBeenCalledWith('read_page', { tabId: 't' });
+    expect(adapter.callTool).toHaveBeenCalledWith('read_page', { tabId: 't', mode: 'dom' });
   });
 });

--- a/tests/benchmark/extractors/live-token-wiring.test.ts
+++ b/tests/benchmark/extractors/live-token-wiring.test.ts
@@ -10,12 +10,29 @@ describe('live token extractor wiring', () => {
     expect(() => extractor.extract(ctx)).toThrow(/async live extraction/);
   });
   test('async live extraction drives adapter create/read/close', async () => {
-    const adapter: MCPAdapter = { name: 'mock', mode: 'live', kind: 'library', setup: jest.fn(), teardown: jest.fn(), callTool: jest.fn(async (tool: string) => tool === 'tabs_create' ? { content: [{ type: 'text', text: '{"tabId":"t"}' }] } : { content: [{ type: 'text', text: 'Hello payload' }] }) };
+    const adapter: MCPAdapter = { name: 'mock', mode: 'live', kind: 'library', setup: jest.fn(), teardown: jest.fn(), callTool: jest.fn(async (tool: string) => tool === 'tabs_create' ? { content: [{ type: 'text', text: '{"tabId":"t"}' }] } : { content: [{ type: 'text', text: '<main><h1 data-field="title">Hello</h1><p>Hello elsewhere</p></main>' }] }) };
     const result = await extractLiveMcpPayload({ library: 'openchrome', mode: 'dom', adapterFactory: () => adapter }, 'http://x', ctx);
     expect(result.payload).toContain('Hello');
     expect(result.extracted.title).toBe('Hello');
     expect(adapter.callTool).toHaveBeenCalledWith('read_page', { tabId: 't', mode: 'dom' });
     expect(adapter.callTool).toHaveBeenCalledWith('tabs_close', { tabId: 't' });
+  });
+
+  test('does not treat raw substring matches as structured extraction', async () => {
+    const adapter: MCPAdapter = { name: 'mock', mode: 'live', kind: 'library', callTool: jest.fn(async (tool: string) => tool === 'tabs_create' ? { content: [{ type: 'text', text: '{\"tabId\":\"t\"}' }] } : { content: [{ type: 'text', text: 'Hello appears in an unstructured blob' }] }) };
+
+    const result = await extractLiveMcpPayload({ library: 'openchrome', mode: 'ax', adapterFactory: () => adapter }, 'http://x', ctx);
+
+    expect(result.payload).toContain('Hello');
+    expect(result.extracted.title).toBeNull();
+  });
+
+  test('extracts structured JSON fields when a live adapter returns JSON', async () => {
+    const adapter: MCPAdapter = { name: 'mock', mode: 'live', kind: 'library', callTool: jest.fn(async (tool: string) => tool === 'tabs_create' ? { content: [{ type: 'text', text: '{\"tabId\":\"t\"}' }] } : { content: [{ type: 'text', text: '{\"title\":\"Hello\"}' }] }) };
+
+    const result = await extractLiveMcpPayload({ library: 'openchrome', mode: 'dom', adapterFactory: () => adapter }, 'http://x', ctx);
+
+    expect(result.extracted.title).toBe('Hello');
   });
 
   test('closes created tabs when read_page fails', async () => {

--- a/tests/benchmark/extractors/live-token-wiring.ts
+++ b/tests/benchmark/extractors/live-token-wiring.ts
@@ -24,17 +24,19 @@ export function createLiveMcpExtractor(options: LiveExtractorFactoryOptions): Ex
 
 export async function extractLiveMcpPayload(options: LiveExtractorFactoryOptions, url: string, ctx: ExtractorContext): Promise<ExtractorResult> {
   const adapter = options.adapterFactory();
+  let tabId: unknown;
   try {
     await adapter.setup?.();
     const create = await adapter.callTool('tabs_create', { url });
     if (create.isError) throw new Error(create.content?.[0]?.text ?? 'tabs_create failed');
-    const tabId = JSON.parse(create.content?.[0]?.text ?? '{}').tabId;
+    tabId = JSON.parse(create.content?.[0]?.text ?? '{}').tabId;
     const read = await adapter.callTool('read_page', { tabId, mode: options.mode });
     if (read.isError) throw new Error(read.content?.[0]?.text ?? 'read_page failed');
     const payload = read.content?.map((c) => c.text ?? '').join('\n') ?? '';
-    await adapter.callTool('tabs_close', { tabId }).catch(() => undefined);
     return { payload, extracted: fieldExtractionFromPayload(payload, ctx) };
   } finally {
+    if (tabId !== undefined) await adapter.callTool('tabs_close', { tabId }).catch(() => undefined);
     await adapter.teardown?.();
   }
 }
+

--- a/tests/benchmark/extractors/live-token-wiring.ts
+++ b/tests/benchmark/extractors/live-token-wiring.ts
@@ -29,7 +29,7 @@ export async function extractLiveMcpPayload(options: LiveExtractorFactoryOptions
     const create = await adapter.callTool('tabs_create', { url });
     if (create.isError) throw new Error(create.content?.[0]?.text ?? 'tabs_create failed');
     const tabId = JSON.parse(create.content?.[0]?.text ?? '{}').tabId;
-    const read = await adapter.callTool('read_page', { tabId });
+    const read = await adapter.callTool('read_page', { tabId, mode: options.mode });
     if (read.isError) throw new Error(read.content?.[0]?.text ?? 'read_page failed');
     const payload = read.content?.map((c) => c.text ?? '').join('\n') ?? '';
     await adapter.callTool('tabs_close', { tabId }).catch(() => undefined);

--- a/tests/benchmark/extractors/live-token-wiring.ts
+++ b/tests/benchmark/extractors/live-token-wiring.ts
@@ -1,5 +1,3 @@
-import * as cheerio from 'cheerio';
-
 import type { Extractor, ExtractorContext, ExtractorResult } from './types';
 import type { MCPAdapter } from '../benchmark-runner';
 
@@ -10,7 +8,7 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function serializedSnapshotFieldText(payload: string, fieldKey: string): string | null {
+function fieldTextFromMarkupOrSnapshot(payload: string, fieldKey: string): string | null {
   const escapedKey = escapeRegExp(fieldKey);
   const snapshotLine = new RegExp(String.raw`<[^>]*\bdata-field=(?:"${escapedKey}"|'${escapedKey}')[^>]*\/?>\s*([^<\n]*)`, 'i');
   const match = payload.match(snapshotLine);
@@ -22,7 +20,7 @@ function serializedSnapshotFields(payload: string, ctx: ExtractorContext): Recor
   const extracted: Record<string, string | null> = Object.fromEntries(ctx.groundTruth.fields.map((field) => [field.key, null]));
   let found = false;
   for (const field of ctx.groundTruth.fields) {
-    const value = serializedSnapshotFieldText(payload, field.key);
+    const value = fieldTextFromMarkupOrSnapshot(payload, field.key);
     if (value !== null) found = true;
     extracted[field.key] = value;
   }
@@ -46,15 +44,7 @@ function fieldExtractionFromPayload(payload: string, ctx: ExtractorContext): Rec
   }
   const snapshotExtracted = serializedSnapshotFields(payload, ctx);
   if (snapshotExtracted) return snapshotExtracted;
-  if (/<[a-z][\s\S]*>/i.test(payload)) {
-    const $ = cheerio.load(payload);
-    for (const field of ctx.groundTruth.fields) {
-      const node = $(`[data-field="${field.key}"]`).first();
-      const htmlText = node.length > 0 ? node.text().trim() : '';
-      extracted[field.key] = htmlText || null;
-    }
-  }
-  return extracted;
+  return snapshotExtracted ?? extracted;
 }
 
 export function createLiveMcpExtractor(options: LiveExtractorFactoryOptions): Extractor {

--- a/tests/benchmark/extractors/live-token-wiring.ts
+++ b/tests/benchmark/extractors/live-token-wiring.ts
@@ -1,0 +1,40 @@
+import type { Extractor, ExtractorContext, ExtractorResult } from './types';
+import type { MCPAdapter } from '../benchmark-runner';
+
+export type LivePayloadSource = 'live' | 'recorded-live';
+export interface LiveExtractorFactoryOptions { adapterFactory: () => MCPAdapter; library: string; mode: string; source?: LivePayloadSource; }
+
+function fieldExtractionFromPayload(payload: string, ctx: ExtractorContext): Record<string, string | null> {
+  const extracted: Record<string, string | null> = {};
+  for (const field of ctx.groundTruth.fields) extracted[field.key] = payload.includes(field.expected) ? field.expected : null;
+  return extracted;
+}
+
+export function createLiveMcpExtractor(options: LiveExtractorFactoryOptions): Extractor {
+  return {
+    library: options.library,
+    mode: options.mode,
+    liveOnly: true,
+    extract(ctx: ExtractorContext): ExtractorResult | null {
+      if (!ctx.liveAllowed) return null;
+      throw new Error(`${options.library}/${options.mode} requires async live extraction; use extractLiveMcpPayload`);
+    },
+  };
+}
+
+export async function extractLiveMcpPayload(options: LiveExtractorFactoryOptions, url: string, ctx: ExtractorContext): Promise<ExtractorResult> {
+  const adapter = options.adapterFactory();
+  try {
+    await adapter.setup?.();
+    const create = await adapter.callTool('tabs_create', { url });
+    if (create.isError) throw new Error(create.content?.[0]?.text ?? 'tabs_create failed');
+    const tabId = JSON.parse(create.content?.[0]?.text ?? '{}').tabId;
+    const read = await adapter.callTool('read_page', { tabId });
+    if (read.isError) throw new Error(read.content?.[0]?.text ?? 'read_page failed');
+    const payload = read.content?.map((c) => c.text ?? '').join('\n') ?? '';
+    await adapter.callTool('tabs_close', { tabId }).catch(() => undefined);
+    return { payload, extracted: fieldExtractionFromPayload(payload, ctx) };
+  } finally {
+    await adapter.teardown?.();
+  }
+}

--- a/tests/benchmark/extractors/live-token-wiring.ts
+++ b/tests/benchmark/extractors/live-token-wiring.ts
@@ -1,3 +1,5 @@
+import * as cheerio from 'cheerio';
+
 import type { Extractor, ExtractorContext, ExtractorResult } from './types';
 import type { MCPAdapter } from '../benchmark-runner';
 
@@ -5,8 +7,27 @@ export type LivePayloadSource = 'live' | 'recorded-live';
 export interface LiveExtractorFactoryOptions { adapterFactory: () => MCPAdapter; library: string; mode: string; source?: LivePayloadSource; }
 
 function fieldExtractionFromPayload(payload: string, ctx: ExtractorContext): Record<string, string | null> {
-  const extracted: Record<string, string | null> = {};
-  for (const field of ctx.groundTruth.fields) extracted[field.key] = payload.includes(field.expected) ? field.expected : null;
+  const extracted: Record<string, string | null> = Object.fromEntries(ctx.groundTruth.fields.map((field) => [field.key, null]));
+  const trimmed = payload.trim();
+  if (trimmed.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+      for (const field of ctx.groundTruth.fields) {
+        const value = parsed[field.key];
+        extracted[field.key] = typeof value === 'string' ? value : null;
+      }
+      return extracted;
+    } catch {
+      // Fall through to HTML parsing. Malformed JSON is not structured evidence.
+    }
+  }
+  if (/<[a-z][\s\S]*>/i.test(payload)) {
+    const $ = cheerio.load(payload);
+    for (const field of ctx.groundTruth.fields) {
+      const node = $(`[data-field="${field.key}"]`).first();
+      extracted[field.key] = node.length > 0 ? node.text() : null;
+    }
+  }
   return extracted;
 }
 

--- a/tests/benchmark/extractors/live-token-wiring.ts
+++ b/tests/benchmark/extractors/live-token-wiring.ts
@@ -18,6 +18,17 @@ function serializedSnapshotFieldText(payload: string, fieldKey: string): string 
   return value ? value : null;
 }
 
+function serializedSnapshotFields(payload: string, ctx: ExtractorContext): Record<string, string | null> | null {
+  const extracted: Record<string, string | null> = Object.fromEntries(ctx.groundTruth.fields.map((field) => [field.key, null]));
+  let found = false;
+  for (const field of ctx.groundTruth.fields) {
+    const value = serializedSnapshotFieldText(payload, field.key);
+    if (value !== null) found = true;
+    extracted[field.key] = value;
+  }
+  return found ? extracted : null;
+}
+
 function fieldExtractionFromPayload(payload: string, ctx: ExtractorContext): Record<string, string | null> {
   const extracted: Record<string, string | null> = Object.fromEntries(ctx.groundTruth.fields.map((field) => [field.key, null]));
   const trimmed = payload.trim();
@@ -33,13 +44,14 @@ function fieldExtractionFromPayload(payload: string, ctx: ExtractorContext): Rec
       // Fall through to HTML parsing. Malformed JSON is not structured evidence.
     }
   }
+  const snapshotExtracted = serializedSnapshotFields(payload, ctx);
+  if (snapshotExtracted) return snapshotExtracted;
   if (/<[a-z][\s\S]*>/i.test(payload)) {
     const $ = cheerio.load(payload);
     for (const field of ctx.groundTruth.fields) {
       const node = $(`[data-field="${field.key}"]`).first();
-      const snapshotText = serializedSnapshotFieldText(payload, field.key);
       const htmlText = node.length > 0 ? node.text().trim() : '';
-      extracted[field.key] = snapshotText || htmlText || null;
+      extracted[field.key] = htmlText || null;
     }
   }
   return extracted;

--- a/tests/benchmark/extractors/live-token-wiring.ts
+++ b/tests/benchmark/extractors/live-token-wiring.ts
@@ -6,6 +6,18 @@ import type { MCPAdapter } from '../benchmark-runner';
 export type LivePayloadSource = 'live' | 'recorded-live';
 export interface LiveExtractorFactoryOptions { adapterFactory: () => MCPAdapter; library: string; mode: string; source?: LivePayloadSource; }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function serializedSnapshotFieldText(payload: string, fieldKey: string): string | null {
+  const escapedKey = escapeRegExp(fieldKey);
+  const snapshotLine = new RegExp(String.raw`<[^>]*\bdata-field=(?:"${escapedKey}"|'${escapedKey}')[^>]*\/?>\s*([^<\n]*)`, 'i');
+  const match = payload.match(snapshotLine);
+  const value = match?.[1]?.trim();
+  return value ? value : null;
+}
+
 function fieldExtractionFromPayload(payload: string, ctx: ExtractorContext): Record<string, string | null> {
   const extracted: Record<string, string | null> = Object.fromEntries(ctx.groundTruth.fields.map((field) => [field.key, null]));
   const trimmed = payload.trim();
@@ -25,7 +37,9 @@ function fieldExtractionFromPayload(payload: string, ctx: ExtractorContext): Rec
     const $ = cheerio.load(payload);
     for (const field of ctx.groundTruth.fields) {
       const node = $(`[data-field="${field.key}"]`).first();
-      extracted[field.key] = node.length > 0 ? node.text() : null;
+      const snapshotText = serializedSnapshotFieldText(payload, field.key);
+      const htmlText = node.length > 0 ? node.text().trim() : '';
+      extracted[field.key] = snapshotText || htmlText || null;
     }
   }
   return extracted;


### PR DESCRIPTION
## Summary
- Adds async live MCP payload extraction helper for token-efficiency rows.
- Keeps synchronous extractor registry live-gated/fail-closed.
- Covers adapter create/read/close payload scoring with injected tests.

## Verification
- npm run build
- npx jest tests/benchmark/extractors/live-token-wiring.test.ts --runInBand

Roadmap: PR8 of 12. Stacked on PR7.