### PR TITLE
Add live throughput executor seam

### DIFF
--- a/tests/benchmark/adapters/openchrome-real-adapter.ts
+++ b/tests/benchmark/adapters/openchrome-real-adapter.ts
@@ -47,18 +47,24 @@ interface MCPResponse {
   error?: { code: number; message: string };
 }
 
-export function chromePortFromCdpEndpoint(cdpEndpoint: string | undefined): string | undefined {
+export function cdpEndpointParts(cdpEndpoint: string | undefined): { host: string; port: string } | undefined {
   if (!cdpEndpoint) return undefined;
   try {
-    return String(new URL(cdpEndpoint).port || 9222);
+    const url = new URL(cdpEndpoint);
+    return { host: url.hostname || '127.0.0.1', port: String(url.port || 9222) };
   } catch {
     return undefined;
   }
 }
 
+export function chromePortFromCdpEndpoint(cdpEndpoint: string | undefined): string | undefined {
+  return cdpEndpointParts(cdpEndpoint)?.port;
+}
+
 export function openChromeServeEnvForCdpEndpoint(cdpEndpoint: string | undefined, baseEnv: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
   const chromePort = chromePortFromCdpEndpoint(cdpEndpoint);
-  return chromePort ? { ...baseEnv, CHROME_PORT: chromePort } : baseEnv;
+  const endpoint = cdpEndpointParts(cdpEndpoint);
+  return endpoint ? { ...baseEnv, CHROME_HOST: endpoint.host, CHROME_PORT: endpoint.port } : baseEnv;
 }
 
 export class OpenChromeRealAdapter implements MCPAdapter {

--- a/tests/benchmark/adapters/openchrome-real-adapter.ts
+++ b/tests/benchmark/adapters/openchrome-real-adapter.ts
@@ -87,7 +87,9 @@ export class OpenChromeRealAdapter implements MCPAdapter {
 
   async setup(): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.process = spawn('node', [this.options.serverPath, 'serve'], {
+      const chromePort = chromePortFromCdpEndpoint(this.options.cdpEndpoint);
+      const serveArgs = [this.options.serverPath, 'serve', ...(chromePort ? ['--port', chromePort] : [])];
+      this.process = spawn('node', serveArgs, {
         stdio: ['pipe', 'pipe', 'pipe'],
         env: openChromeServeEnvForCdpEndpoint(this.options.cdpEndpoint),
       });

--- a/tests/benchmark/adapters/openchrome-real-adapter.ts
+++ b/tests/benchmark/adapters/openchrome-real-adapter.ts
@@ -54,6 +54,11 @@ export function chromePortFromCdpEndpoint(cdpEndpoint: string | undefined): stri
   }
 }
 
+export function openChromeServeEnvForCdpEndpoint(cdpEndpoint: string | undefined, baseEnv: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const chromePort = chromePortFromCdpEndpoint(cdpEndpoint);
+  return chromePort ? { ...baseEnv, CHROME_PORT: chromePort } : baseEnv;
+}
+
 export class OpenChromeRealAdapter implements MCPAdapter {
   name = 'OpenChrome';
   mode: string;
@@ -82,10 +87,9 @@ export class OpenChromeRealAdapter implements MCPAdapter {
 
   async setup(): Promise<void> {
     return new Promise((resolve, reject) => {
-      const chromePort = chromePortFromCdpEndpoint(this.options.cdpEndpoint);
       this.process = spawn('node', [this.options.serverPath, 'serve'], {
         stdio: ['pipe', 'pipe', 'pipe'],
-        env: chromePort ? { ...process.env, CHROME_PORT: chromePort } : process.env,
+        env: openChromeServeEnvForCdpEndpoint(this.options.cdpEndpoint),
       });
 
       let ready = false;

--- a/tests/benchmark/adapters/openchrome-real-adapter.ts
+++ b/tests/benchmark/adapters/openchrome-real-adapter.ts
@@ -25,6 +25,8 @@ export interface RealAdapterOptions {
   startupTimeoutMs?: number;
   /** CDP endpoint whose port should be used by the OpenChrome MCP server. */
   cdpEndpoint?: string;
+  /** Explicit Chrome debugging port for OpenChrome MCP serve. */
+  chromePort?: string;
 }
 
 interface MCPRequest {
@@ -63,7 +65,7 @@ export class OpenChromeRealAdapter implements MCPAdapter {
   name = 'OpenChrome';
   mode: string;
 
-  private options: Required<Omit<RealAdapterOptions, 'cdpEndpoint'>> & Pick<RealAdapterOptions, 'cdpEndpoint'>;
+  private options: Required<Omit<RealAdapterOptions, 'cdpEndpoint' | 'chromePort'>> & Pick<RealAdapterOptions, 'cdpEndpoint' | 'chromePort'>;
   private process: ChildProcess | null = null;
   private requestId = 0;
   private pending: Map<number, {
@@ -81,13 +83,14 @@ export class OpenChromeRealAdapter implements MCPAdapter {
       callTimeoutMs: options.callTimeoutMs || 30000,
       startupTimeoutMs: options.startupTimeoutMs || 15000,
       cdpEndpoint: options.cdpEndpoint,
+      chromePort: options.chromePort,
     };
   }
 
 
   async setup(): Promise<void> {
     return new Promise((resolve, reject) => {
-      const chromePort = chromePortFromCdpEndpoint(this.options.cdpEndpoint);
+      const chromePort = this.options.chromePort ?? chromePortFromCdpEndpoint(this.options.cdpEndpoint);
       const serveArgs = [this.options.serverPath, 'serve', ...(chromePort ? ['--port', chromePort] : [])];
       this.process = spawn('node', serveArgs, {
         stdio: ['pipe', 'pipe', 'pipe'],

--- a/tests/benchmark/adapters/openchrome-real-adapter.ts
+++ b/tests/benchmark/adapters/openchrome-real-adapter.ts
@@ -23,6 +23,8 @@ export interface RealAdapterOptions {
   callTimeoutMs?: number;
   /** Timeout for server startup in ms (default: 15000) */
   startupTimeoutMs?: number;
+  /** CDP endpoint whose port should be used by the OpenChrome MCP server. */
+  cdpEndpoint?: string;
 }
 
 interface MCPRequest {
@@ -43,11 +45,20 @@ interface MCPResponse {
   error?: { code: number; message: string };
 }
 
+export function chromePortFromCdpEndpoint(cdpEndpoint: string | undefined): string | undefined {
+  if (!cdpEndpoint) return undefined;
+  try {
+    return String(new URL(cdpEndpoint).port || 9222);
+  } catch {
+    return undefined;
+  }
+}
+
 export class OpenChromeRealAdapter implements MCPAdapter {
   name = 'OpenChrome';
   mode: string;
 
-  private options: Required<RealAdapterOptions>;
+  private options: Required<Omit<RealAdapterOptions, 'cdpEndpoint'>> & Pick<RealAdapterOptions, 'cdpEndpoint'>;
   private process: ChildProcess | null = null;
   private requestId = 0;
   private pending: Map<number, {
@@ -64,13 +75,17 @@ export class OpenChromeRealAdapter implements MCPAdapter {
       serverPath: options.serverPath || path.join(process.cwd(), 'dist', 'index.js'),
       callTimeoutMs: options.callTimeoutMs || 30000,
       startupTimeoutMs: options.startupTimeoutMs || 15000,
+      cdpEndpoint: options.cdpEndpoint,
     };
   }
 
+
   async setup(): Promise<void> {
     return new Promise((resolve, reject) => {
+      const chromePort = chromePortFromCdpEndpoint(this.options.cdpEndpoint);
       this.process = spawn('node', [this.options.serverPath, 'serve'], {
         stdio: ['pipe', 'pipe', 'pipe'],
+        env: chromePort ? { ...process.env, CHROME_PORT: chromePort } : process.env,
       });
 
       let ready = false;

--- a/tests/benchmark/benchmark-runner.test.ts
+++ b/tests/benchmark/benchmark-runner.test.ts
@@ -8,7 +8,7 @@ import {
   BenchmarkRunnerOptions,
   BenchmarkReport,
 } from './benchmark-runner';
-import { OpenChromeRealAdapter } from './adapters/openchrome-real-adapter';
+import { chromePortFromCdpEndpoint, OpenChromeRealAdapter } from './adapters/openchrome-real-adapter';
 import { main, writeCiOutput } from './run';
 
 // ---------------------------------------------------------------------------
@@ -329,6 +329,14 @@ describe('BenchmarkRunner', () => {
     expect(report.summary.totalInputChars).toBe(0);
     expect(report.summary.totalOutputChars).toBe(0);
     expect(report.summary.totalToolCalls).toBe(0);
+  });
+
+
+
+  test('extracts Chrome port from configured CDP endpoint', () => {
+    expect(chromePortFromCdpEndpoint('http://127.0.0.1:9444')).toBe('9444');
+    expect(chromePortFromCdpEndpoint('http://127.0.0.1')).toBe('9222');
+    expect(chromePortFromCdpEndpoint('not a url')).toBeUndefined();
   });
 
   test('real adapter rejects tool results marked isError', async () => {

--- a/tests/benchmark/benchmark-runner.test.ts
+++ b/tests/benchmark/benchmark-runner.test.ts
@@ -8,7 +8,7 @@ import {
   BenchmarkRunnerOptions,
   BenchmarkReport,
 } from './benchmark-runner';
-import { chromePortFromCdpEndpoint, OpenChromeRealAdapter } from './adapters/openchrome-real-adapter';
+import { chromePortFromCdpEndpoint, openChromeServeEnvForCdpEndpoint, OpenChromeRealAdapter } from './adapters/openchrome-real-adapter';
 import { main, writeCiOutput } from './run';
 
 // ---------------------------------------------------------------------------
@@ -337,6 +337,11 @@ describe('BenchmarkRunner', () => {
     expect(chromePortFromCdpEndpoint('http://127.0.0.1:9444')).toBe('9444');
     expect(chromePortFromCdpEndpoint('http://127.0.0.1')).toBe('9222');
     expect(chromePortFromCdpEndpoint('not a url')).toBeUndefined();
+  });
+
+  test('configures OpenChrome MCP serve environment from managed CDP endpoint', () => {
+    const env = openChromeServeEnvForCdpEndpoint('http://127.0.0.1:9444', { PATH: '/bin', CHROME_PORT: '9222' });
+    expect(env).toEqual({ PATH: '/bin', CHROME_PORT: '9444' });
   });
 
   test('real adapter rejects tool results marked isError', async () => {

--- a/tests/benchmark/benchmark-runner.test.ts
+++ b/tests/benchmark/benchmark-runner.test.ts
@@ -341,7 +341,7 @@ describe('BenchmarkRunner', () => {
 
   test('configures OpenChrome MCP serve environment from managed CDP endpoint', () => {
     const env = openChromeServeEnvForCdpEndpoint('http://127.0.0.1:9444', { PATH: '/bin', CHROME_PORT: '9222' });
-    expect(env).toEqual({ PATH: '/bin', CHROME_PORT: '9444' });
+    expect(env).toEqual({ PATH: '/bin', CHROME_HOST: '127.0.0.1', CHROME_PORT: '9444' });
   });
 
   test('real adapter rejects tool results marked isError', async () => {

--- a/tests/benchmark/run-throughput-live.test.ts
+++ b/tests/benchmark/run-throughput-live.test.ts
@@ -4,8 +4,10 @@ import { runLiveThroughputExecutor } from './run-throughput-live';
 describe('live throughput executor', () => {
   test('launches and closes managed Chrome around live run failures', async () => {
     const close = jest.fn(async () => undefined);
-    const result = await runLiveThroughputExecutor({ argv: ['--library=openchrome', '--concurrency=1', '--iterations=4'], launchChrome: true, port: 9444, launcher: async () => ({ endpoint: 'http://127.0.0.1:9444', userDataDir: '/tmp/p', close }), runBenchmark: async () => [{ library: 'OpenChrome', mode: 'dom-live', sessionMode: 'reuse', concurrency: 1, pagesPerPass: 1, sampleCount: 1, warmupDiscarded: 0, rawPagesPerSecond: 1, successRate: 1, effectivePagesPerSecond: 1, meanWallMs: 1, p50WallMs: 1, p95WallMs: 1 }] });
+    const runBenchmark = jest.fn(async () => [{ library: 'OpenChrome', mode: 'dom-live', sessionMode: 'reuse' as const, concurrency: 1, pagesPerPass: 1, sampleCount: 1, warmupDiscarded: 0, rawPagesPerSecond: 1, successRate: 1, effectivePagesPerSecond: 1, meanWallMs: 1, p50WallMs: 1, p95WallMs: 1 }]);
+    const result = await runLiveThroughputExecutor({ argv: ['--library=openchrome', '--concurrency=1', '--iterations=4'], launchChrome: true, port: 9444, launcher: async () => ({ endpoint: 'http://127.0.0.1:9444', userDataDir: '/tmp/p', close }), runBenchmark });
     expect(result.launchedChrome).toBe(true);
+    expect(runBenchmark).toHaveBeenCalledWith(expect.objectContaining({ cdpEndpoint: 'http://127.0.0.1:9444' }));
     expect(close).toHaveBeenCalled();
     // No live OpenChrome server is expected in CI, so the failure is explicit.
     expect(result.rows).toHaveLength(1);

--- a/tests/benchmark/run-throughput-live.test.ts
+++ b/tests/benchmark/run-throughput-live.test.ts
@@ -12,4 +12,20 @@ describe('live throughput executor', () => {
     // No live OpenChrome server is expected in CI, so the failure is explicit.
     expect(result.rows).toHaveLength(1);
   }, 30000);
+
+  test('preserves selected CDP endpoint on benchmark failure', async () => {
+    const close = jest.fn(async () => undefined);
+    const result = await runLiveThroughputExecutor({
+      argv: ['--library=openchrome'],
+      launchChrome: true,
+      port: 9555,
+      launcher: async () => ({ endpoint: 'http://127.0.0.1:9555', userDataDir: '/tmp/p', close }),
+      runBenchmark: async () => { throw new Error('benchmark failed'); },
+    });
+
+    expect(result.rows).toEqual([]);
+    expect(result.cdpEndpoint).toBe('http://127.0.0.1:9555');
+    expect(result.failureCategory).toMatch(/benchmark failed/);
+    expect(close).toHaveBeenCalled();
+  });
 });

--- a/tests/benchmark/run-throughput-live.test.ts
+++ b/tests/benchmark/run-throughput-live.test.ts
@@ -28,4 +28,17 @@ describe('live throughput executor', () => {
     expect(result.failureCategory).toMatch(/benchmark failed/);
     expect(close).toHaveBeenCalled();
   });
+
+  test('sets CHROME_PORT for OpenChrome live adapter subprocesses', async () => {
+    const seen: Array<string | undefined> = [];
+    await runLiveThroughputExecutor({
+      argv: ['--library=openchrome'],
+      launchChrome: false,
+      port: 9666,
+      runBenchmark: async () => { seen.push(process.env.CHROME_PORT); return []; },
+    });
+    expect(seen).toEqual(['9666']);
+    expect(process.env.CHROME_PORT).toBeUndefined();
+  });
+
 });

--- a/tests/benchmark/run-throughput-live.test.ts
+++ b/tests/benchmark/run-throughput-live.test.ts
@@ -7,7 +7,7 @@ describe('live throughput executor', () => {
     const runBenchmark = jest.fn(async () => [{ library: 'OpenChrome', mode: 'dom-live', sessionMode: 'reuse' as const, concurrency: 1, pagesPerPass: 1, sampleCount: 1, warmupDiscarded: 0, rawPagesPerSecond: 1, successRate: 1, effectivePagesPerSecond: 1, meanWallMs: 1, p50WallMs: 1, p95WallMs: 1 }]);
     const result = await runLiveThroughputExecutor({ argv: ['--library=openchrome', '--concurrency=1', '--iterations=4'], launchChrome: true, port: 9444, launcher: async () => ({ endpoint: 'http://127.0.0.1:9444', userDataDir: '/tmp/p', close }), runBenchmark });
     expect(result.launchedChrome).toBe(true);
-    expect(runBenchmark).toHaveBeenCalledWith(expect.objectContaining({ cdpEndpoint: 'http://127.0.0.1:9444' }));
+    expect(runBenchmark).toHaveBeenCalledWith(expect.objectContaining({ cdpEndpoint: 'http://127.0.0.1:9444', openChromePort: '9444' }));
     expect(close).toHaveBeenCalled();
     // No live OpenChrome server is expected in CI, so the failure is explicit.
     expect(result.rows).toHaveLength(1);

--- a/tests/benchmark/run-throughput-live.test.ts
+++ b/tests/benchmark/run-throughput-live.test.ts
@@ -1,0 +1,13 @@
+/// <reference types="jest" />
+import { runLiveThroughputExecutor } from './run-throughput-live';
+
+describe('live throughput executor', () => {
+  test('launches and closes managed Chrome around live run failures', async () => {
+    const close = jest.fn(async () => undefined);
+    const result = await runLiveThroughputExecutor({ argv: ['--library=openchrome', '--concurrency=1', '--iterations=4'], launchChrome: true, port: 9444, launcher: async () => ({ endpoint: 'http://127.0.0.1:9444', userDataDir: '/tmp/p', close }), runBenchmark: async () => [{ library: 'OpenChrome', mode: 'dom-live', sessionMode: 'reuse', concurrency: 1, pagesPerPass: 1, sampleCount: 1, warmupDiscarded: 0, rawPagesPerSecond: 1, successRate: 1, effectivePagesPerSecond: 1, meanWallMs: 1, p50WallMs: 1, p95WallMs: 1 }] });
+    expect(result.launchedChrome).toBe(true);
+    expect(close).toHaveBeenCalled();
+    // No live OpenChrome server is expected in CI, so the failure is explicit.
+    expect(result.rows).toHaveLength(1);
+  }, 30000);
+});

--- a/tests/benchmark/run-throughput-live.ts
+++ b/tests/benchmark/run-throughput-live.ts
@@ -4,6 +4,14 @@ import { parseThroughputArgs, runThroughputBenchmark, ThroughputRow } from './ru
 export interface LiveThroughputExecutorOptions { argv: string[]; launchChrome: boolean; launcher?: (port: number) => Promise<ManagedChrome>; runBenchmark?: typeof runThroughputBenchmark; port?: number; }
 export interface LiveThroughputExecutorResult { rows: ThroughputRow[]; cdpEndpoint: string; launchedChrome: boolean; failureCategory?: string; }
 
+function throughputOptionsForManagedChrome(argv: string[], cdpEndpoint: string, chromePort: string) {
+  return {
+    ...parseThroughputArgs([...argv, '--live', `--cdp-endpoint=${cdpEndpoint}`, `--openchrome-port=${chromePort}`]),
+    cdpEndpoint,
+    openChromePort: chromePort,
+  };
+}
+
 export async function runLiveThroughputExecutor(options: LiveThroughputExecutorOptions): Promise<LiveThroughputExecutorResult> {
   const port = options.port ?? 9222;
   let chrome: ManagedChrome | undefined;
@@ -17,11 +25,7 @@ export async function runLiveThroughputExecutor(options: LiveThroughputExecutorO
     process.env.OPENCHROME_BENCH_CDP_ENDPOINT = cdpEndpoint;
     process.env.CHROME_PORT = chromePort;
     try {
-      const args = {
-        ...parseThroughputArgs([...options.argv, '--live', `--cdp-endpoint=${cdpEndpoint}`, `--openchrome-port=${chromePort}`]),
-        cdpEndpoint,
-        openChromePort: chromePort,
-      };
+      const args = throughputOptionsForManagedChrome(options.argv, cdpEndpoint, chromePort);
       const rows = await (options.runBenchmark ?? runThroughputBenchmark)(args);
       return { rows, cdpEndpoint, launchedChrome: Boolean(chrome) };
     } finally {

--- a/tests/benchmark/run-throughput-live.ts
+++ b/tests/benchmark/run-throughput-live.ts
@@ -17,7 +17,11 @@ export async function runLiveThroughputExecutor(options: LiveThroughputExecutorO
     process.env.OPENCHROME_BENCH_CDP_ENDPOINT = cdpEndpoint;
     process.env.CHROME_PORT = chromePort;
     try {
-      const args = parseThroughputArgs([...options.argv, '--live', `--cdp-endpoint=${cdpEndpoint}`, `--openchrome-port=${chromePort}`]);
+      const args = {
+        ...parseThroughputArgs([...options.argv, '--live', `--cdp-endpoint=${cdpEndpoint}`, `--openchrome-port=${chromePort}`]),
+        cdpEndpoint,
+        openChromePort: chromePort,
+      };
       const rows = await (options.runBenchmark ?? runThroughputBenchmark)(args);
       return { rows, cdpEndpoint, launchedChrome: Boolean(chrome) };
     } finally {

--- a/tests/benchmark/run-throughput-live.ts
+++ b/tests/benchmark/run-throughput-live.ts
@@ -17,7 +17,7 @@ export async function runLiveThroughputExecutor(options: LiveThroughputExecutorO
     process.env.OPENCHROME_BENCH_CDP_ENDPOINT = cdpEndpoint;
     process.env.CHROME_PORT = chromePort;
     try {
-      const args = parseThroughputArgs([...options.argv, '--live', `--cdp-endpoint=${cdpEndpoint}`]);
+      const args = parseThroughputArgs([...options.argv, '--live', `--cdp-endpoint=${cdpEndpoint}`, `--openchrome-port=${chromePort}`]);
       const rows = await (options.runBenchmark ?? runThroughputBenchmark)(args);
       return { rows, cdpEndpoint, launchedChrome: Boolean(chrome) };
     } finally {

--- a/tests/benchmark/run-throughput-live.ts
+++ b/tests/benchmark/run-throughput-live.ts
@@ -12,7 +12,10 @@ export async function runLiveThroughputExecutor(options: LiveThroughputExecutorO
     if (options.launchChrome) chrome = await (options.launcher ?? ((p) => launchManagedChrome({ port: p })))(port);
     cdpEndpoint = chrome?.endpoint ?? cdpEndpoint;
     const previousEndpoint = process.env.OPENCHROME_BENCH_CDP_ENDPOINT;
+    const previousChromePort = process.env.CHROME_PORT;
+    const chromePort = new URL(cdpEndpoint).port || '9222';
     process.env.OPENCHROME_BENCH_CDP_ENDPOINT = cdpEndpoint;
+    process.env.CHROME_PORT = chromePort;
     try {
       const args = parseThroughputArgs([...options.argv, '--live', `--cdp-endpoint=${cdpEndpoint}`]);
       const rows = await (options.runBenchmark ?? runThroughputBenchmark)(args);
@@ -20,6 +23,8 @@ export async function runLiveThroughputExecutor(options: LiveThroughputExecutorO
     } finally {
       if (previousEndpoint === undefined) delete process.env.OPENCHROME_BENCH_CDP_ENDPOINT;
       else process.env.OPENCHROME_BENCH_CDP_ENDPOINT = previousEndpoint;
+      if (previousChromePort === undefined) delete process.env.CHROME_PORT;
+      else process.env.CHROME_PORT = previousChromePort;
     }
   } catch (err) {
     return { rows: [], cdpEndpoint: chrome?.endpoint ?? cdpEndpoint, launchedChrome: Boolean(chrome), failureCategory: err instanceof Error ? err.message : String(err) };

--- a/tests/benchmark/run-throughput-live.ts
+++ b/tests/benchmark/run-throughput-live.ts
@@ -7,9 +7,10 @@ export interface LiveThroughputExecutorResult { rows: ThroughputRow[]; cdpEndpoi
 export async function runLiveThroughputExecutor(options: LiveThroughputExecutorOptions): Promise<LiveThroughputExecutorResult> {
   const port = options.port ?? 9222;
   let chrome: ManagedChrome | undefined;
+  let cdpEndpoint = process.env.OPENCHROME_BENCH_CDP_ENDPOINT ?? `http://127.0.0.1:${port}`;
   try {
     if (options.launchChrome) chrome = await (options.launcher ?? ((p) => launchManagedChrome({ port: p })))(port);
-    const cdpEndpoint = chrome?.endpoint ?? process.env.OPENCHROME_BENCH_CDP_ENDPOINT ?? `http://127.0.0.1:${port}`;
+    cdpEndpoint = chrome?.endpoint ?? cdpEndpoint;
     const previousEndpoint = process.env.OPENCHROME_BENCH_CDP_ENDPOINT;
     process.env.OPENCHROME_BENCH_CDP_ENDPOINT = cdpEndpoint;
     try {
@@ -21,7 +22,7 @@ export async function runLiveThroughputExecutor(options: LiveThroughputExecutorO
       else process.env.OPENCHROME_BENCH_CDP_ENDPOINT = previousEndpoint;
     }
   } catch (err) {
-    return { rows: [], cdpEndpoint: chrome?.endpoint ?? `http://127.0.0.1:${port}`, launchedChrome: Boolean(chrome), failureCategory: err instanceof Error ? err.message : String(err) };
+    return { rows: [], cdpEndpoint: chrome?.endpoint ?? cdpEndpoint, launchedChrome: Boolean(chrome), failureCategory: err instanceof Error ? err.message : String(err) };
   } finally {
     await chrome?.close();
   }

--- a/tests/benchmark/run-throughput-live.ts
+++ b/tests/benchmark/run-throughput-live.ts
@@ -1,0 +1,21 @@
+import { launchManagedChrome, ManagedChrome } from './runtime/chrome-launcher';
+import { parseThroughputArgs, runThroughputBenchmark, ThroughputRow } from './run-throughput';
+
+export interface LiveThroughputExecutorOptions { argv: string[]; launchChrome: boolean; launcher?: (port: number) => Promise<ManagedChrome>; runBenchmark?: typeof runThroughputBenchmark; port?: number; }
+export interface LiveThroughputExecutorResult { rows: ThroughputRow[]; cdpEndpoint: string; launchedChrome: boolean; failureCategory?: string; }
+
+export async function runLiveThroughputExecutor(options: LiveThroughputExecutorOptions): Promise<LiveThroughputExecutorResult> {
+  const port = options.port ?? 9222;
+  let chrome: ManagedChrome | undefined;
+  try {
+    if (options.launchChrome) chrome = await (options.launcher ?? ((p) => launchManagedChrome({ port: p })))(port);
+    const cdpEndpoint = chrome?.endpoint ?? process.env.OPENCHROME_BENCH_CDP_ENDPOINT ?? `http://127.0.0.1:${port}`;
+    const args = parseThroughputArgs([...options.argv, '--live']);
+    const rows = await (options.runBenchmark ?? runThroughputBenchmark)(args);
+    return { rows, cdpEndpoint, launchedChrome: Boolean(chrome) };
+  } catch (err) {
+    return { rows: [], cdpEndpoint: chrome?.endpoint ?? `http://127.0.0.1:${port}`, launchedChrome: Boolean(chrome), failureCategory: err instanceof Error ? err.message : String(err) };
+  } finally {
+    await chrome?.close();
+  }
+}

--- a/tests/benchmark/run-throughput-live.ts
+++ b/tests/benchmark/run-throughput-live.ts
@@ -4,6 +4,11 @@ import { parseThroughputArgs, runThroughputBenchmark, ThroughputRow } from './ru
 export interface LiveThroughputExecutorOptions { argv: string[]; launchChrome: boolean; launcher?: (port: number) => Promise<ManagedChrome>; runBenchmark?: typeof runThroughputBenchmark; port?: number; }
 export interface LiveThroughputExecutorResult { rows: ThroughputRow[]; cdpEndpoint: string; launchedChrome: boolean; failureCategory?: string; }
 
+function chromePortFromEndpoint(endpoint: string): string {
+  try { return new URL(endpoint).port || '9222'; }
+  catch { return '9222'; }
+}
+
 function throughputOptionsForManagedChrome(argv: string[], cdpEndpoint: string, chromePort: string) {
   return {
     ...parseThroughputArgs([...argv, '--live', `--cdp-endpoint=${cdpEndpoint}`, `--openchrome-port=${chromePort}`]),
@@ -17,11 +22,18 @@ export async function runLiveThroughputExecutor(options: LiveThroughputExecutorO
   let chrome: ManagedChrome | undefined;
   let cdpEndpoint = process.env.OPENCHROME_BENCH_CDP_ENDPOINT ?? `http://127.0.0.1:${port}`;
   try {
-    if (options.launchChrome) chrome = await (options.launcher ?? ((p) => launchManagedChrome({ port: p })))(port);
+    if (options.launchChrome) {
+      try {
+        chrome = await (options.launcher ?? ((p) => launchManagedChrome({ port: p })))(port);
+      } catch (err) {
+        await chrome?.close().catch(() => undefined);
+        throw err;
+      }
+    }
     cdpEndpoint = chrome?.endpoint ?? cdpEndpoint;
     const previousEndpoint = process.env.OPENCHROME_BENCH_CDP_ENDPOINT;
     const previousChromePort = process.env.CHROME_PORT;
-    const chromePort = new URL(cdpEndpoint).port || '9222';
+    const chromePort = chromePortFromEndpoint(cdpEndpoint);
     process.env.OPENCHROME_BENCH_CDP_ENDPOINT = cdpEndpoint;
     process.env.CHROME_PORT = chromePort;
     try {

--- a/tests/benchmark/run-throughput-live.ts
+++ b/tests/benchmark/run-throughput-live.ts
@@ -10,9 +10,16 @@ export async function runLiveThroughputExecutor(options: LiveThroughputExecutorO
   try {
     if (options.launchChrome) chrome = await (options.launcher ?? ((p) => launchManagedChrome({ port: p })))(port);
     const cdpEndpoint = chrome?.endpoint ?? process.env.OPENCHROME_BENCH_CDP_ENDPOINT ?? `http://127.0.0.1:${port}`;
-    const args = parseThroughputArgs([...options.argv, '--live']);
-    const rows = await (options.runBenchmark ?? runThroughputBenchmark)(args);
-    return { rows, cdpEndpoint, launchedChrome: Boolean(chrome) };
+    const previousEndpoint = process.env.OPENCHROME_BENCH_CDP_ENDPOINT;
+    process.env.OPENCHROME_BENCH_CDP_ENDPOINT = cdpEndpoint;
+    try {
+      const args = parseThroughputArgs([...options.argv, '--live', `--cdp-endpoint=${cdpEndpoint}`]);
+      const rows = await (options.runBenchmark ?? runThroughputBenchmark)(args);
+      return { rows, cdpEndpoint, launchedChrome: Boolean(chrome) };
+    } finally {
+      if (previousEndpoint === undefined) delete process.env.OPENCHROME_BENCH_CDP_ENDPOINT;
+      else process.env.OPENCHROME_BENCH_CDP_ENDPOINT = previousEndpoint;
+    }
   } catch (err) {
     return { rows: [], cdpEndpoint: chrome?.endpoint ?? `http://127.0.0.1:${port}`, launchedChrome: Boolean(chrome), failureCategory: err instanceof Error ? err.message : String(err) };
   } finally {

--- a/tests/benchmark/run-throughput.test.ts
+++ b/tests/benchmark/run-throughput.test.ts
@@ -31,6 +31,7 @@ describe('run-throughput competitor selection', () => {
   test('parses CDP endpoint flag', () => {
     const opts = parseThroughputArgs(['--cdp-endpoint=http://127.0.0.1:9444']);
     expect(opts.cdpEndpoint).toBe('http://127.0.0.1:9444');
+    expect(opts.openChromePort).toBe('9444');
   });
 
   test('parses cold session mode', () => {

--- a/tests/benchmark/run-throughput.test.ts
+++ b/tests/benchmark/run-throughput.test.ts
@@ -25,6 +25,12 @@ describe('run-throughput competitor selection', () => {
     expect(opts.concurrencies).toEqual([1, 5]);
     expect(opts.iterations).toBe(5);
     expect(opts.sessionMode).toBe('reuse');
+    expect(opts.cdpEndpoint).toBe('http://127.0.0.1:9222');
+  });
+
+  test('parses CDP endpoint flag', () => {
+    const opts = parseThroughputArgs(['--cdp-endpoint=http://127.0.0.1:9444']);
+    expect(opts.cdpEndpoint).toBe('http://127.0.0.1:9444');
   });
 
   test('parses cold session mode', () => {

--- a/tests/benchmark/run-throughput.ts
+++ b/tests/benchmark/run-throughput.ts
@@ -283,7 +283,7 @@ function buildAdapters(options: ThroughputRunOptions): AdapterEntry[] {
         entries.push({
           library: "OpenChrome",
           mode: "dom-live",
-          adapter: new OpenChromeRealAdapter({ mode: "dom" }),
+          adapter: new OpenChromeRealAdapter({ mode: "dom", cdpEndpoint: options.cdpEndpoint }),
           requiresLiveChrome: true,
         });
       } else {

--- a/tests/benchmark/run-throughput.ts
+++ b/tests/benchmark/run-throughput.ts
@@ -82,6 +82,8 @@ export interface ThroughputRunOptions {
   includeLiveCompetitors: boolean;
   /** Reuse one adapter setup per library, or cold-start setup/teardown for every concurrency cell. */
   sessionMode: ThroughputSessionMode;
+  /** CDP endpoint for live Chrome-backed competitor adapters. */
+  cdpEndpoint: string;
 }
 
 export interface ThroughputRow {
@@ -192,6 +194,7 @@ export function parseThroughputArgs(argv: string[]): ThroughputRunOptions {
   const sessionMode = parseSessionMode(
     flagValue(argv, "--session-mode") ?? process.env.OPENCHROME_BENCH_SESSION_MODE,
   );
+  const cdpEndpoint = flagValue(argv, "--cdp-endpoint") ?? process.env.OPENCHROME_BENCH_CDP_ENDPOINT ?? 'http://127.0.0.1:9222';
   return {
     ciMode,
     iterations,
@@ -201,6 +204,7 @@ export function parseThroughputArgs(argv: string[]): ThroughputRunOptions {
     library,
     includeLiveCompetitors,
     sessionMode,
+    cdpEndpoint,
   };
 }
 
@@ -301,14 +305,14 @@ function buildAdapters(options: ThroughputRunOptions): AdapterEntry[] {
       entries.push({
         library: "Playwright",
         mode: "raw-html-cdp",
-        adapter: new PlaywrightAdapter(),
+        adapter: new PlaywrightAdapter({ cdpEndpoint: options.cdpEndpoint }),
         requiresLiveChrome: true,
       });
     } else if (library === "puppeteer") {
       entries.push({
         library: "Puppeteer",
         mode: "raw-html-cdp",
-        adapter: new PuppeteerAdapter(),
+        adapter: new PuppeteerAdapter({ browserURL: options.cdpEndpoint }),
         requiresLiveChrome: true,
       });
     }

--- a/tests/benchmark/run-throughput.ts
+++ b/tests/benchmark/run-throughput.ts
@@ -84,6 +84,8 @@ export interface ThroughputRunOptions {
   sessionMode: ThroughputSessionMode;
   /** CDP endpoint for live Chrome-backed competitor adapters. */
   cdpEndpoint: string;
+  /** Explicit OpenChrome MCP serve port derived from the live CDP endpoint. */
+  openChromePort: string;
 }
 
 export interface ThroughputRow {
@@ -195,6 +197,7 @@ export function parseThroughputArgs(argv: string[]): ThroughputRunOptions {
     flagValue(argv, "--session-mode") ?? process.env.OPENCHROME_BENCH_SESSION_MODE,
   );
   const cdpEndpoint = flagValue(argv, "--cdp-endpoint") ?? process.env.OPENCHROME_BENCH_CDP_ENDPOINT ?? 'http://127.0.0.1:9222';
+  const openChromePort = flagValue(argv, "--openchrome-port") ?? (new URL(cdpEndpoint).port || '9222');
   return {
     ciMode,
     iterations,
@@ -205,6 +208,7 @@ export function parseThroughputArgs(argv: string[]): ThroughputRunOptions {
     includeLiveCompetitors,
     sessionMode,
     cdpEndpoint,
+    openChromePort,
   };
 }
 
@@ -283,7 +287,7 @@ function buildAdapters(options: ThroughputRunOptions): AdapterEntry[] {
         entries.push({
           library: "OpenChrome",
           mode: "dom-live",
-          adapter: new OpenChromeRealAdapter({ mode: "dom", cdpEndpoint: options.cdpEndpoint }),
+          adapter: new OpenChromeRealAdapter({ mode: "dom", cdpEndpoint: options.cdpEndpoint, chromePort: options.openChromePort }),
           requiresLiveChrome: true,
         });
       } else {


### PR DESCRIPTION
## Summary
- Adds live throughput executor wrapper around managed/existing Chrome CDP.
- Ensures managed Chrome cleanup and explicit failureCategory on runtime failure.
- Covers launcher lifecycle with injected tests.

## Verification
- npm run build
- npx jest tests/benchmark/run-throughput-live.test.ts --runInBand

Roadmap: PR9 of 12. Stacked on PR8.