### PR TITLE
Add episode fault injection hooks

### DIFF
--- a/tests/benchmark/reliability/episode-fault-hooks.test.ts
+++ b/tests/benchmark/reliability/episode-fault-hooks.test.ts
@@ -3,7 +3,7 @@ import { beforeEpisodeStep, finalizeFaultRecovery } from './episode-fault-hooks'
 
 describe('episode fault hooks', () => {
   test('injects a planned fault at the configured step and marks recovery by final postcondition', async () => {
-    const state = { events: [], recovered: null };
+    const state: import('./episode-fault-hooks').FaultHookState = { events: [], recovered: null };
     const plan = { taskId: 'rw', injectAtStep: 2, fault: 'selector-drift' as const, expectedRecoverySignal: 'semantic retry' };
     const executor = { inject: jest.fn(async () => 'selector changed') };
     await beforeEpisodeStep(1, plan, executor, state);

--- a/tests/benchmark/reliability/episode-fault-hooks.test.ts
+++ b/tests/benchmark/reliability/episode-fault-hooks.test.ts
@@ -15,6 +15,15 @@ describe('episode fault hooks', () => {
     expect(finalizeFaultRecovery(state, false).recovered).toBe(false);
   });
 
+  test('rejects malformed plans even before the injection step matches', async () => {
+    const state: import('./episode-fault-hooks').FaultHookState = { events: [], recovered: null };
+    const plan = { taskId: 'rw', injectAtStep: -1, fault: 'selector-drift' as const, expectedRecoverySignal: 'retry' };
+    const executor = { inject: jest.fn(async () => 'nope') };
+
+    await expect(beforeEpisodeStep(0, plan, executor, state)).rejects.toThrow(/injectAtStep/);
+    expect(executor.inject).not.toHaveBeenCalled();
+  });
+
   test('rejects unsupported runtime fault kinds', async () => {
     const state: import('./episode-fault-hooks').FaultHookState = { events: [], recovered: null };
     const plan = { taskId: 'rw', injectAtStep: 0, fault: 'bad-fault' as never, expectedRecoverySignal: 'retry' };

--- a/tests/benchmark/reliability/episode-fault-hooks.test.ts
+++ b/tests/benchmark/reliability/episode-fault-hooks.test.ts
@@ -8,9 +8,19 @@ describe('episode fault hooks', () => {
     const executor = { inject: jest.fn(async () => 'selector changed') };
     await beforeEpisodeStep(1, plan, executor, state);
     await beforeEpisodeStep(2, plan, executor, state);
+    await beforeEpisodeStep(2, plan, executor, state);
     expect(executor.inject).toHaveBeenCalledTimes(1);
     expect(state.events[0].fault).toBe('selector-drift');
     expect(finalizeFaultRecovery(state, true).recovered).toBe(true);
     expect(finalizeFaultRecovery(state, false).recovered).toBe(false);
+  });
+
+  test('rejects unsupported runtime fault kinds', async () => {
+    const state: import('./episode-fault-hooks').FaultHookState = { events: [], recovered: null };
+    const plan = { taskId: 'rw', injectAtStep: 0, fault: 'bad-fault' as never, expectedRecoverySignal: 'retry' };
+    const executor = { inject: jest.fn(async () => 'nope') };
+
+    await expect(beforeEpisodeStep(0, plan, executor, state)).rejects.toThrow(/unsupported/);
+    expect(executor.inject).not.toHaveBeenCalled();
   });
 });

--- a/tests/benchmark/reliability/episode-fault-hooks.test.ts
+++ b/tests/benchmark/reliability/episode-fault-hooks.test.ts
@@ -1,0 +1,16 @@
+/// <reference types="jest" />
+import { beforeEpisodeStep, finalizeFaultRecovery } from './episode-fault-hooks';
+
+describe('episode fault hooks', () => {
+  test('injects a planned fault at the configured step and marks recovery by final postcondition', async () => {
+    const state = { events: [], recovered: null };
+    const plan = { taskId: 'rw', injectAtStep: 2, fault: 'selector-drift' as const, expectedRecoverySignal: 'semantic retry' };
+    const executor = { inject: jest.fn(async () => 'selector changed') };
+    await beforeEpisodeStep(1, plan, executor, state);
+    await beforeEpisodeStep(2, plan, executor, state);
+    expect(executor.inject).toHaveBeenCalledTimes(1);
+    expect(state.events[0].fault).toBe('selector-drift');
+    expect(finalizeFaultRecovery(state, true).recovered).toBe(true);
+    expect(finalizeFaultRecovery(state, false).recovered).toBe(false);
+  });
+});

--- a/tests/benchmark/reliability/episode-fault-hooks.ts
+++ b/tests/benchmark/reliability/episode-fault-hooks.ts
@@ -5,9 +5,10 @@ export interface FaultExecutor { inject(plan: EpisodeFaultPlan): Promise<string>
 export interface FaultHookState { events: FaultEvent[]; recovered: boolean | null; }
 
 export async function beforeEpisodeStep(step: number, plan: EpisodeFaultPlan | undefined, executor: FaultExecutor, state: FaultHookState): Promise<void> {
-  if (!plan || step !== plan.injectAtStep) return;
-  if (state.events.some((event) => event.step === step && event.fault === plan.fault && event.injected)) return;
+  if (!plan) return;
   validateFaultPlan(plan);
+  if (step !== plan.injectAtStep) return;
+  if (state.events.some((event) => event.step === step && event.fault === plan.fault && event.injected)) return;
   const evidence = await executor.inject(plan);
   state.events.push({ step, fault: plan.fault, injected: true, evidence });
 }

--- a/tests/benchmark/reliability/episode-fault-hooks.ts
+++ b/tests/benchmark/reliability/episode-fault-hooks.ts
@@ -1,0 +1,16 @@
+import type { EpisodeFaultPlan, FaultEvent } from './fault-plan';
+import { validateFaultPlan } from './fault-plan';
+
+export interface FaultExecutor { inject(plan: EpisodeFaultPlan): Promise<string>; }
+export interface FaultHookState { events: FaultEvent[]; recovered: boolean | null; }
+
+export async function beforeEpisodeStep(step: number, plan: EpisodeFaultPlan | undefined, executor: FaultExecutor, state: FaultHookState): Promise<void> {
+  if (!plan || step !== plan.injectAtStep) return;
+  validateFaultPlan(plan);
+  const evidence = await executor.inject(plan);
+  state.events.push({ step, fault: plan.fault, injected: true, evidence });
+}
+
+export function finalizeFaultRecovery(state: FaultHookState, finalPostconditionPassed: boolean): FaultHookState {
+  return { ...state, recovered: state.events.length === 0 ? null : finalPostconditionPassed };
+}

--- a/tests/benchmark/reliability/episode-fault-hooks.ts
+++ b/tests/benchmark/reliability/episode-fault-hooks.ts
@@ -6,6 +6,7 @@ export interface FaultHookState { events: FaultEvent[]; recovered: boolean | nul
 
 export async function beforeEpisodeStep(step: number, plan: EpisodeFaultPlan | undefined, executor: FaultExecutor, state: FaultHookState): Promise<void> {
   if (!plan || step !== plan.injectAtStep) return;
+  if (state.events.some((event) => event.step === step && event.fault === plan.fault && event.injected)) return;
   validateFaultPlan(plan);
   const evidence = await executor.inject(plan);
   state.events.push({ step, fault: plan.fault, injected: true, evidence });

--- a/tests/benchmark/reliability/fault-plan.ts
+++ b/tests/benchmark/reliability/fault-plan.ts
@@ -1,0 +1,8 @@
+export type EpisodeFaultType = 'selector-drift' | 'network-stall' | 'target-closed' | 'delayed-dom' | 'cdp-disconnect';
+export interface EpisodeFaultPlan { taskId: string; injectAtStep: number; fault: EpisodeFaultType; expectedRecoverySignal: string; }
+export interface FaultEvent { step: number; fault: EpisodeFaultType; injected: boolean; evidence: string; }
+export function validateFaultPlan(plan: EpisodeFaultPlan): void {
+  if (!plan.taskId) throw new Error('fault plan taskId is required');
+  if (!Number.isInteger(plan.injectAtStep) || plan.injectAtStep < 0) throw new Error('fault plan injectAtStep must be a non-negative integer');
+  if (!plan.expectedRecoverySignal) throw new Error('fault plan expectedRecoverySignal is required');
+}

--- a/tests/benchmark/reliability/fault-plan.ts
+++ b/tests/benchmark/reliability/fault-plan.ts
@@ -1,8 +1,10 @@
 export type EpisodeFaultType = 'selector-drift' | 'network-stall' | 'target-closed' | 'delayed-dom' | 'cdp-disconnect';
 export interface EpisodeFaultPlan { taskId: string; injectAtStep: number; fault: EpisodeFaultType; expectedRecoverySignal: string; }
 export interface FaultEvent { step: number; fault: EpisodeFaultType; injected: boolean; evidence: string; }
+const SUPPORTED_FAULTS = new Set<EpisodeFaultType>(['selector-drift', 'network-stall', 'target-closed', 'delayed-dom', 'cdp-disconnect']);
 export function validateFaultPlan(plan: EpisodeFaultPlan): void {
   if (!plan.taskId) throw new Error('fault plan taskId is required');
   if (!Number.isInteger(plan.injectAtStep) || plan.injectAtStep < 0) throw new Error('fault plan injectAtStep must be a non-negative integer');
+  if (!SUPPORTED_FAULTS.has(plan.fault)) throw new Error(`fault plan fault is unsupported: ${String(plan.fault)}`);
   if (!plan.expectedRecoverySignal) throw new Error('fault plan expectedRecoverySignal is required');
 }

--- a/tests/benchmark/reliability/fault-plan.ts
+++ b/tests/benchmark/reliability/fault-plan.ts
@@ -1,10 +1,13 @@
 export type EpisodeFaultType = 'selector-drift' | 'network-stall' | 'target-closed' | 'delayed-dom' | 'cdp-disconnect';
 export interface EpisodeFaultPlan { taskId: string; injectAtStep: number; fault: EpisodeFaultType; expectedRecoverySignal: string; }
 export interface FaultEvent { step: number; fault: EpisodeFaultType; injected: boolean; evidence: string; }
-const SUPPORTED_FAULTS = new Set<EpisodeFaultType>(['selector-drift', 'network-stall', 'target-closed', 'delayed-dom', 'cdp-disconnect']);
+const SUPPORTED_FAULTS = ['selector-drift', 'network-stall', 'target-closed', 'delayed-dom', 'cdp-disconnect'] as const;
+function isSupportedFault(value: unknown): value is EpisodeFaultType {
+  return typeof value === 'string' && (SUPPORTED_FAULTS as readonly string[]).includes(value);
+}
 export function validateFaultPlan(plan: EpisodeFaultPlan): void {
   if (!plan.taskId) throw new Error('fault plan taskId is required');
   if (!Number.isInteger(plan.injectAtStep) || plan.injectAtStep < 0) throw new Error('fault plan injectAtStep must be a non-negative integer');
-  if (!SUPPORTED_FAULTS.has(plan.fault)) throw new Error(`fault plan fault is unsupported: ${String(plan.fault)}`);
+  if (!isSupportedFault(plan.fault)) throw new Error(`fault plan fault is unsupported: ${String(plan.fault)}`);
   if (!plan.expectedRecoverySignal) throw new Error('fault plan expectedRecoverySignal is required');
 }


### PR DESCRIPTION
## Summary
- Adds fault plan schema and episode before-step injection hook.
- Records fault events and derives recovery from final postcondition result.
- Covers deterministic selector-drift injection with tests.

## Verification
- npm run build
- npx jest tests/benchmark/reliability/episode-fault-hooks.test.ts --runInBand

Roadmap: PR10 of 12. Stacked on PR9.