### PR TITLE
Add recorded corpus validator for benchmark publication

### DIFF
--- a/tests/benchmark/recordings/schema.ts
+++ b/tests/benchmark/recordings/schema.ts
@@ -1,0 +1,54 @@
+export type RecordedLibrary = 'openchrome' | 'playwright-mcp' | 'browser-use' | (string & {});
+
+export type RecordedProvider = 'anthropic' | 'openai';
+
+export interface RecordingCompetitorVersion {
+  version: string;
+  source: 'package-lock' | 'pip-freeze' | 'git-sha' | 'manual';
+}
+
+export interface RecordingManifest {
+  schemaVersion: 'recording-corpus/v1';
+  corpusId: string;
+  capturedAt: string;
+  operator: string;
+  environment: {
+    os: string;
+    chromeVersion: string;
+    nodeVersion?: string;
+    pythonVersion?: string;
+  };
+  llm: {
+    provider: RecordedProvider;
+    model: string;
+    temperature: number;
+    maxSteps: number;
+  };
+  competitors: Record<string, RecordingCompetitorVersion>;
+  redaction: {
+    secretsRemoved: boolean;
+    reviewedBy: string;
+  };
+}
+
+export interface RecordingRun {
+  taskId: string;
+  library: RecordedLibrary;
+  mode: 'recorded-real';
+  success: boolean;
+  finalPostconditionEvidence: string;
+  tokens: number;
+  usd: number;
+  wallTimeMs: number;
+  toolCalls: number;
+  failureCategory: string | null;
+  artifactRefs: string[];
+}
+
+export interface RecordingCorpusValidation {
+  valid: boolean;
+  errors: string[];
+  sampleCount: number;
+  libraries: string[];
+  taskIds: string[];
+}

--- a/tests/benchmark/recordings/validator.test.ts
+++ b/tests/benchmark/recordings/validator.test.ts
@@ -55,6 +55,15 @@ describe('recording corpus validator', () => {
     expect(result.errors).toContain('recording corpus contains secret-like text');
   });
 
+  it('does not reject benign prose that mentions secret-like words without credential values', () => {
+    const benign = run();
+    benign.finalPostconditionEvidence = 'secret menu item was visible to the secretary user';
+
+    const result = validateRecordingCorpus(manifest(), [benign]);
+
+    expect(result.valid).toBe(true);
+  });
+
   it('does not reject benign task ids that contain sk- substrings', () => {
     const benign = run();
     benign.taskId = 'risk-9-task-1';

--- a/tests/benchmark/recordings/validator.test.ts
+++ b/tests/benchmark/recordings/validator.test.ts
@@ -74,6 +74,25 @@ describe('recording corpus validator', () => {
     expect(result.errors).toContain('recording corpus contains secret-like text');
   });
 
+  it('does not reject benign prose about bearer authentication', () => {
+    const benign = run();
+    benign.finalPostconditionEvidence = 'bearer authentication was requested before checkout';
+
+    const result = validateRecordingCorpus(manifest(), [benign]);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects credential-shaped bearer tokens before corpus publication', () => {
+    const leaked = run();
+    leaked.finalPostconditionEvidence = 'authorization: bearer abcdefghijklmnopqrstuvwxyz.abcdefghijklmno';
+
+    const result = validateRecordingCorpus(manifest(), [leaked]);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('recording corpus contains secret-like text');
+  });
+
   it('does not reject benign task ids that contain sk- substrings', () => {
     const benign = run();
     benign.taskId = 'risk-9-task-1';

--- a/tests/benchmark/recordings/validator.test.ts
+++ b/tests/benchmark/recordings/validator.test.ts
@@ -64,6 +64,16 @@ describe('recording corpus validator', () => {
     expect(result.valid).toBe(true);
   });
 
+  it('rejects generic sk-prefixed API keys before corpus publication', () => {
+    const result = validateRecordingCorpus(
+      { ...manifest(), operator: 'sk-abcdefghijklmnopqrstuvwxyz012345' },
+      [run()],
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('recording corpus contains secret-like text');
+  });
+
   it('does not reject benign task ids that contain sk- substrings', () => {
     const benign = run();
     benign.taskId = 'risk-9-task-1';

--- a/tests/benchmark/recordings/validator.test.ts
+++ b/tests/benchmark/recordings/validator.test.ts
@@ -80,6 +80,26 @@ describe('recording corpus validator', () => {
     expect(result.errors).toContain('runs[0] must be an object');
   });
 
+  it('reports malformed manifest strings without throwing', () => {
+    const malformed = { ...manifest(), corpusId: 123, redaction: { secretsRemoved: 'yes', reviewedBy: 456 } } as unknown as RecordingManifest;
+
+    const result = validateRecordingCorpus(malformed, [run()]);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('manifest.corpusId is required');
+    expect(result.errors).toContain('manifest.redaction.secretsRemoved must be true');
+    expect(result.errors).toContain('manifest.redaction.reviewedBy is required');
+  });
+
+  it('restricts competitor version provenance values', () => {
+    const malformed = { ...manifest(), competitors: { openchrome: { version: 'abc123', source: 'blog' } } } as unknown as RecordingManifest;
+
+    const result = validateRecordingCorpus(malformed, [run()]);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('manifest.competitors.openchrome.source must be package-lock, pip-freeze, git-sha, or manual');
+  });
+
   it('reports non-string competitor versions without throwing', () => {
     const malformed = { ...manifest(), competitors: { openchrome: { version: 123, source: 'manual' } } } as unknown as RecordingManifest;
 

--- a/tests/benchmark/recordings/validator.test.ts
+++ b/tests/benchmark/recordings/validator.test.ts
@@ -80,6 +80,15 @@ describe('recording corpus validator', () => {
     expect(result.errors).toContain('runs[0] must be an object');
   });
 
+  it('reports non-string competitor versions without throwing', () => {
+    const malformed = { ...manifest(), competitors: { openchrome: { version: 123, source: 'manual' } } } as unknown as RecordingManifest;
+
+    const result = validateRecordingCorpus(malformed, [run()]);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('manifest.competitors.openchrome.version is required for recorded run');
+  });
+
   it('requires every recorded library to have a pinned competitor version', () => {
     const incomplete = manifest();
     delete incomplete.competitors.openchrome;

--- a/tests/benchmark/recordings/validator.test.ts
+++ b/tests/benchmark/recordings/validator.test.ts
@@ -47,12 +47,37 @@ describe('recording corpus validator', () => {
 
   it('rejects secret-like payloads before corpus publication', () => {
     const result = validateRecordingCorpus(
-      { ...manifest(), operator: 'sk-proj-not-a-real-key' },
+      { ...manifest(), operator: 'sk-proj-abcdefghijklmnopqrstuvwxyz' },
       [run()],
     );
 
     expect(result.valid).toBe(false);
     expect(result.errors).toContain('recording corpus contains secret-like text');
+  });
+
+  it('does not reject benign task ids that contain sk- substrings', () => {
+    const benign = run();
+    benign.taskId = 'risk-9-task-1';
+
+    const result = validateRecordingCorpus(manifest(), [benign]);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('reports malformed competitor entries without throwing', () => {
+    const malformed = { ...manifest(), competitors: { openchrome: null } } as unknown as RecordingManifest;
+
+    const result = validateRecordingCorpus(malformed, [run()]);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('manifest.competitors.openchrome must be an object');
+  });
+
+  it('reports malformed run entries without throwing', () => {
+    const result = validateRecordingCorpus(manifest(), [null] as unknown as RecordingRun[]);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('runs[0] must be an object');
   });
 
   it('requires every recorded library to have a pinned competitor version', () => {

--- a/tests/benchmark/recordings/validator.test.ts
+++ b/tests/benchmark/recordings/validator.test.ts
@@ -1,0 +1,67 @@
+import { validateRecordingCorpus } from './validator';
+import type { RecordingManifest, RecordingRun } from './schema';
+
+const manifest = (): RecordingManifest => ({
+  schemaVersion: 'recording-corpus/v1',
+  corpusId: 'local-smoke-2026-05-17',
+  capturedAt: '2026-05-17T00:00:00.000Z',
+  operator: 'ci',
+  environment: { os: 'darwin', chromeVersion: '124.0.0.0', nodeVersion: 'v20.0.0' },
+  llm: { provider: 'openai', model: 'gpt-test', temperature: 0, maxSteps: 8 },
+  competitors: {
+    openchrome: { version: 'abc123', source: 'git-sha' },
+    'playwright-mcp': { version: '1.0.0', source: 'package-lock' },
+  },
+  redaction: { secretsRemoved: true, reviewedBy: 'ci' },
+});
+
+const run = (): RecordingRun => ({
+  taskId: 'checkout-product',
+  library: 'openchrome',
+  mode: 'recorded-real',
+  success: true,
+  finalPostconditionEvidence: 'cart contains the requested product',
+  tokens: 123,
+  usd: 0.0042,
+  wallTimeMs: 1500,
+  toolCalls: 5,
+  failureCategory: null,
+  artifactRefs: ['artifacts/session.jsonl'],
+});
+
+describe('recording corpus validator', () => {
+  it('accepts a complete redacted recorded-real corpus', () => {
+    const result = validateRecordingCorpus(manifest(), [run(), { ...run(), library: 'playwright-mcp' }]);
+
+    expect(result.valid).toBe(true);
+    expect(result.sampleCount).toBe(2);
+    expect(result.libraries).toEqual(['openchrome', 'playwright-mcp']);
+  });
+
+  it('rejects runs without final postcondition evidence', () => {
+    const result = validateRecordingCorpus(manifest(), [{ ...run(), finalPostconditionEvidence: '' }]);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('runs[0].finalPostconditionEvidence is required');
+  });
+
+  it('rejects secret-like payloads before corpus publication', () => {
+    const result = validateRecordingCorpus(
+      { ...manifest(), operator: 'sk-proj-not-a-real-key' },
+      [run()],
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('recording corpus contains secret-like text');
+  });
+
+  it('requires every recorded library to have a pinned competitor version', () => {
+    const incomplete = manifest();
+    delete incomplete.competitors.openchrome;
+
+    const result = validateRecordingCorpus(incomplete, [run()]);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('manifest.competitors.openchrome.version is required for recorded run');
+  });
+});

--- a/tests/benchmark/recordings/validator.ts
+++ b/tests/benchmark/recordings/validator.ts
@@ -1,6 +1,6 @@
 import type { RecordingCorpusValidation, RecordingManifest, RecordingRun } from './schema';
 
-const SECRET_PATTERN = /(sk-ant-|sk-proj-|sk-[A-Za-z0-9]|AKIA[0-9A-Z]{16}|api[_-]?key|secret|bearer\s+[A-Za-z0-9._-]+)/i;
+const SECRET_PATTERN = /(sk-ant-[A-Za-z0-9_-]{10,}|sk-proj-[A-Za-z0-9_-]{10,}|AKIA[0-9A-Z]{16}|api[_-]?key|secret|bearer\s+[A-Za-z0-9._-]{10,})/i;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -51,29 +51,38 @@ export function validateRecordingCorpus(
   const competitors = manifest.competitors ?? {};
   for (const [library, version] of Object.entries(competitors)) {
     if (!library.trim()) errors.push('manifest.competitors contains an empty library key');
-    if (!version.version?.trim()) errors.push(`manifest.competitors.${library}.version is required`);
-    if (!version.source?.trim()) errors.push(`manifest.competitors.${library}.source is required`);
+    if (!isPlainObject(version)) {
+      errors.push(`manifest.competitors.${library} must be an object`);
+      continue;
+    }
+    if (typeof version.version !== 'string' || !version.version.trim()) errors.push(`manifest.competitors.${library}.version is required`);
+    if (typeof version.source !== 'string' || !version.source.trim()) errors.push(`manifest.competitors.${library}.source is required`);
   }
 
   if (!Array.isArray(runs) || runs.length === 0) errors.push('runs must contain at least one recorded episode');
 
   const libraries = new Set<string>();
   const taskIds = new Set<string>();
-  for (const [index, run] of (Array.isArray(runs) ? runs : []).entries()) {
+  for (const [index, maybeRun] of (Array.isArray(runs) ? runs : []).entries()) {
     const prefix = `runs[${index}]`;
-    if (!run.taskId?.trim()) errors.push(`${prefix}.taskId is required`);
-    if (!run.library?.trim()) errors.push(`${prefix}.library is required`);
+    if (!isPlainObject(maybeRun)) {
+      errors.push(`${prefix} must be an object`);
+      continue;
+    }
+    const run = maybeRun as unknown as Partial<RecordingRun>;
+    if (typeof run.taskId !== 'string' || !run.taskId.trim()) errors.push(`${prefix}.taskId is required`);
+    if (typeof run.library !== 'string' || !run.library.trim()) errors.push(`${prefix}.library is required`);
     if (run.mode !== 'recorded-real') errors.push(`${prefix}.mode must be recorded-real`);
     if (typeof run.success !== 'boolean') errors.push(`${prefix}.success must be boolean`);
-    if (!run.finalPostconditionEvidence?.trim()) errors.push(`${prefix}.finalPostconditionEvidence is required`);
+    if (typeof run.finalPostconditionEvidence !== 'string' || !run.finalPostconditionEvidence.trim()) errors.push(`${prefix}.finalPostconditionEvidence is required`);
     if (!isFiniteNonNegative(run.tokens)) errors.push(`${prefix}.tokens must be non-negative`);
     if (!isFiniteNonNegative(run.usd)) errors.push(`${prefix}.usd must be non-negative`);
     if (!isFiniteNonNegative(run.wallTimeMs)) errors.push(`${prefix}.wallTimeMs must be non-negative`);
-    if (!Number.isInteger(run.toolCalls) || run.toolCalls < 0) errors.push(`${prefix}.toolCalls must be a non-negative integer`);
+    if (typeof run.toolCalls !== 'number' || !Number.isInteger(run.toolCalls) || run.toolCalls < 0) errors.push(`${prefix}.toolCalls must be a non-negative integer`);
     if (!Array.isArray(run.artifactRefs) || run.artifactRefs.length === 0) errors.push(`${prefix}.artifactRefs must not be empty`);
 
-    if (run.library?.trim()) libraries.add(run.library);
-    if (run.taskId?.trim()) taskIds.add(run.taskId);
+    if (typeof run.library === 'string' && run.library.trim()) libraries.add(run.library);
+    if (typeof run.taskId === 'string' && run.taskId.trim()) taskIds.add(run.taskId);
   }
 
   for (const library of libraries) {

--- a/tests/benchmark/recordings/validator.ts
+++ b/tests/benchmark/recordings/validator.ts
@@ -1,6 +1,6 @@
 import type { RecordingCorpusValidation, RecordingManifest, RecordingRun } from './schema';
 
-const SECRET_PATTERN = /(sk-ant-[A-Za-z0-9_-]{10,}|sk-proj-[A-Za-z0-9_-]{10,}|AKIA[0-9A-Z]{16}|(?:api[_-]?key|secret)\s*[:=]\s*[A-Za-z0-9._-]{10,}|bearer\s+[A-Za-z0-9._-]{10,})/i;
+const SECRET_PATTERN = /(sk-[A-Za-z0-9_-]{20,}|AKIA[0-9A-Z]{16}|(?:api[_-]?key|secret)\s*[:=]\s*[A-Za-z0-9._-]{10,}|bearer\s+[A-Za-z0-9._-]{10,})/i;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/tests/benchmark/recordings/validator.ts
+++ b/tests/benchmark/recordings/validator.ts
@@ -1,6 +1,6 @@
 import type { RecordingCorpusValidation, RecordingManifest, RecordingRun } from './schema';
 
-const SECRET_PATTERN = /(sk-ant-[A-Za-z0-9_-]{10,}|sk-proj-[A-Za-z0-9_-]{10,}|AKIA[0-9A-Z]{16}|api[_-]?key|secret|bearer\s+[A-Za-z0-9._-]{10,})/i;
+const SECRET_PATTERN = /(sk-ant-[A-Za-z0-9_-]{10,}|sk-proj-[A-Za-z0-9_-]{10,}|AKIA[0-9A-Z]{16}|(?:api[_-]?key|secret)\s*[:=]\s*[A-Za-z0-9._-]{10,}|bearer\s+[A-Za-z0-9._-]{10,})/i;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/tests/benchmark/recordings/validator.ts
+++ b/tests/benchmark/recordings/validator.ts
@@ -86,7 +86,10 @@ export function validateRecordingCorpus(
   }
 
   for (const library of libraries) {
-    if (!competitors[library]?.version?.trim()) errors.push(`manifest.competitors.${library}.version is required for recorded run`);
+    const competitor = competitors[library];
+    if (!isPlainObject(competitor) || typeof competitor.version !== 'string' || !competitor.version.trim()) {
+      errors.push(`manifest.competitors.${library}.version is required for recorded run`);
+    }
   }
 
   if (hasSecretLikeText(manifest) || hasSecretLikeText(runs)) {

--- a/tests/benchmark/recordings/validator.ts
+++ b/tests/benchmark/recordings/validator.ts
@@ -1,0 +1,94 @@
+import type { RecordingCorpusValidation, RecordingManifest, RecordingRun } from './schema';
+
+const SECRET_PATTERN = /(sk-ant-|sk-proj-|sk-[A-Za-z0-9]|AKIA[0-9A-Z]{16}|api[_-]?key|secret|bearer\s+[A-Za-z0-9._-]+)/i;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasSecretLikeText(value: unknown): boolean {
+  if (typeof value === 'string') return SECRET_PATTERN.test(value);
+  if (Array.isArray(value)) return value.some(hasSecretLikeText);
+  if (isPlainObject(value)) return Object.values(value).some(hasSecretLikeText);
+  return false;
+}
+
+function isIsoDate(value: unknown): boolean {
+  return typeof value === 'string' && !Number.isNaN(Date.parse(value));
+}
+
+function isFiniteNonNegative(value: unknown): boolean {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+export function validateRecordingCorpus(
+  manifest: RecordingManifest,
+  runs: RecordingRun[],
+): RecordingCorpusValidation {
+  const errors: string[] = [];
+
+  if (!isPlainObject(manifest)) {
+    return { valid: false, errors: ['manifest must be an object'], sampleCount: 0, libraries: [], taskIds: [] };
+  }
+
+  if (manifest.schemaVersion !== 'recording-corpus/v1') errors.push('manifest.schemaVersion must be recording-corpus/v1');
+  if (!manifest.corpusId?.trim()) errors.push('manifest.corpusId is required');
+  if (!isIsoDate(manifest.capturedAt)) errors.push('manifest.capturedAt must be an ISO-like date');
+  if (!manifest.operator?.trim()) errors.push('manifest.operator is required');
+  if (!manifest.environment?.os?.trim()) errors.push('manifest.environment.os is required');
+  if (!manifest.environment?.chromeVersion?.trim()) errors.push('manifest.environment.chromeVersion is required');
+  if (manifest.llm?.provider !== 'anthropic' && manifest.llm?.provider !== 'openai') {
+    errors.push('manifest.llm.provider must be anthropic or openai');
+  }
+  if (!manifest.llm?.model?.trim()) errors.push('manifest.llm.model is required');
+  if (!isFiniteNonNegative(manifest.llm?.temperature)) errors.push('manifest.llm.temperature must be non-negative');
+  if (!Number.isInteger(manifest.llm?.maxSteps) || manifest.llm.maxSteps <= 0) {
+    errors.push('manifest.llm.maxSteps must be a positive integer');
+  }
+  if (!manifest.redaction?.secretsRemoved) errors.push('manifest.redaction.secretsRemoved must be true');
+  if (!manifest.redaction?.reviewedBy?.trim()) errors.push('manifest.redaction.reviewedBy is required');
+
+  const competitors = manifest.competitors ?? {};
+  for (const [library, version] of Object.entries(competitors)) {
+    if (!library.trim()) errors.push('manifest.competitors contains an empty library key');
+    if (!version.version?.trim()) errors.push(`manifest.competitors.${library}.version is required`);
+    if (!version.source?.trim()) errors.push(`manifest.competitors.${library}.source is required`);
+  }
+
+  if (!Array.isArray(runs) || runs.length === 0) errors.push('runs must contain at least one recorded episode');
+
+  const libraries = new Set<string>();
+  const taskIds = new Set<string>();
+  for (const [index, run] of (Array.isArray(runs) ? runs : []).entries()) {
+    const prefix = `runs[${index}]`;
+    if (!run.taskId?.trim()) errors.push(`${prefix}.taskId is required`);
+    if (!run.library?.trim()) errors.push(`${prefix}.library is required`);
+    if (run.mode !== 'recorded-real') errors.push(`${prefix}.mode must be recorded-real`);
+    if (typeof run.success !== 'boolean') errors.push(`${prefix}.success must be boolean`);
+    if (!run.finalPostconditionEvidence?.trim()) errors.push(`${prefix}.finalPostconditionEvidence is required`);
+    if (!isFiniteNonNegative(run.tokens)) errors.push(`${prefix}.tokens must be non-negative`);
+    if (!isFiniteNonNegative(run.usd)) errors.push(`${prefix}.usd must be non-negative`);
+    if (!isFiniteNonNegative(run.wallTimeMs)) errors.push(`${prefix}.wallTimeMs must be non-negative`);
+    if (!Number.isInteger(run.toolCalls) || run.toolCalls < 0) errors.push(`${prefix}.toolCalls must be a non-negative integer`);
+    if (!Array.isArray(run.artifactRefs) || run.artifactRefs.length === 0) errors.push(`${prefix}.artifactRefs must not be empty`);
+
+    if (run.library?.trim()) libraries.add(run.library);
+    if (run.taskId?.trim()) taskIds.add(run.taskId);
+  }
+
+  for (const library of libraries) {
+    if (!competitors[library]?.version?.trim()) errors.push(`manifest.competitors.${library}.version is required for recorded run`);
+  }
+
+  if (hasSecretLikeText(manifest) || hasSecretLikeText(runs)) {
+    errors.push('recording corpus contains secret-like text');
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    sampleCount: Array.isArray(runs) ? runs.length : 0,
+    libraries: [...libraries].sort(),
+    taskIds: [...taskIds].sort(),
+  };
+}

--- a/tests/benchmark/recordings/validator.ts
+++ b/tests/benchmark/recordings/validator.ts
@@ -1,6 +1,6 @@
 import type { RecordingCorpusValidation, RecordingManifest, RecordingRun } from './schema';
 
-const SECRET_PATTERN = /(sk-[A-Za-z0-9_-]{20,}|AKIA[0-9A-Z]{16}|(?:api[_-]?key|secret)\s*[:=]\s*[A-Za-z0-9._-]{10,}|bearer\s+[A-Za-z0-9._-]{10,})/i;
+const SECRET_PATTERN = /(sk-[A-Za-z0-9_-]{20,}|AKIA[0-9A-Z]{16}|(?:api[_-]?key|secret)\s*[:=]\s*[A-Za-z0-9._-]{10,}|bearer\s+[A-Za-z0-9._-]{20,}\.[A-Za-z0-9._-]{10,}(?:\.[A-Za-z0-9._-]{10,})?)/i;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/tests/benchmark/recordings/validator.ts
+++ b/tests/benchmark/recordings/validator.ts
@@ -32,21 +32,21 @@ export function validateRecordingCorpus(
   }
 
   if (manifest.schemaVersion !== 'recording-corpus/v1') errors.push('manifest.schemaVersion must be recording-corpus/v1');
-  if (!manifest.corpusId?.trim()) errors.push('manifest.corpusId is required');
+  if (typeof manifest.corpusId !== 'string' || !manifest.corpusId.trim()) errors.push('manifest.corpusId is required');
   if (!isIsoDate(manifest.capturedAt)) errors.push('manifest.capturedAt must be an ISO-like date');
-  if (!manifest.operator?.trim()) errors.push('manifest.operator is required');
-  if (!manifest.environment?.os?.trim()) errors.push('manifest.environment.os is required');
-  if (!manifest.environment?.chromeVersion?.trim()) errors.push('manifest.environment.chromeVersion is required');
+  if (typeof manifest.operator !== 'string' || !manifest.operator.trim()) errors.push('manifest.operator is required');
+  if (typeof manifest.environment?.os !== 'string' || !manifest.environment.os.trim()) errors.push('manifest.environment.os is required');
+  if (typeof manifest.environment?.chromeVersion !== 'string' || !manifest.environment.chromeVersion.trim()) errors.push('manifest.environment.chromeVersion is required');
   if (manifest.llm?.provider !== 'anthropic' && manifest.llm?.provider !== 'openai') {
     errors.push('manifest.llm.provider must be anthropic or openai');
   }
-  if (!manifest.llm?.model?.trim()) errors.push('manifest.llm.model is required');
+  if (typeof manifest.llm?.model !== 'string' || !manifest.llm.model.trim()) errors.push('manifest.llm.model is required');
   if (!isFiniteNonNegative(manifest.llm?.temperature)) errors.push('manifest.llm.temperature must be non-negative');
   if (!Number.isInteger(manifest.llm?.maxSteps) || manifest.llm.maxSteps <= 0) {
     errors.push('manifest.llm.maxSteps must be a positive integer');
   }
-  if (!manifest.redaction?.secretsRemoved) errors.push('manifest.redaction.secretsRemoved must be true');
-  if (!manifest.redaction?.reviewedBy?.trim()) errors.push('manifest.redaction.reviewedBy is required');
+  if (manifest.redaction?.secretsRemoved !== true) errors.push('manifest.redaction.secretsRemoved must be true');
+  if (typeof manifest.redaction?.reviewedBy !== 'string' || !manifest.redaction.reviewedBy.trim()) errors.push('manifest.redaction.reviewedBy is required');
 
   const competitors = manifest.competitors ?? {};
   for (const [library, version] of Object.entries(competitors)) {
@@ -56,7 +56,7 @@ export function validateRecordingCorpus(
       continue;
     }
     if (typeof version.version !== 'string' || !version.version.trim()) errors.push(`manifest.competitors.${library}.version is required`);
-    if (typeof version.source !== 'string' || !version.source.trim()) errors.push(`manifest.competitors.${library}.source is required`);
+    if (version.source !== 'package-lock' && version.source !== 'pip-freeze' && version.source !== 'git-sha' && version.source !== 'manual') errors.push(`manifest.competitors.${library}.source must be package-lock, pip-freeze, git-sha, or manual`);
   }
 
   if (!Array.isArray(runs) || runs.length === 0) errors.push('runs must contain at least one recorded episode');


### PR DESCRIPTION
## Summary\n- define the recorded-real corpus manifest/run schema used before benchmark publication\n- validate redaction metadata, pinned competitor versions, postcondition evidence, and numeric metrics\n- reject secret-like payloads before a corpus is eligible for sharing or headline reports\n\n## Tests\n- npm run build\n- npx jest tests/benchmark/recordings/validator.test.ts --runInBand\n\nStacked on #1334.