### PR TITLE
Enforce headline report eligibility for benchmark claims

### DIFF
--- a/benchmark/generate-benchmark-report.mjs
+++ b/benchmark/generate-benchmark-report.mjs
@@ -82,6 +82,10 @@ function enforceHeadlineInputs(argv = process.argv.slice(2)) {
   if (!existsSync(REALWORLD_ENVELOPE_PATH)) {
     throw new Error('Missing benchmark/results/realworld-task-completion.json for --require-headline');
   }
+  const realworldSection = readSection('REALWORLD-TASK-COMPLETION-REPORT.md');
+  if (!realworldSection || /Headline gate:\s*\*\*blocked\*\*/i.test(realworldSection)) {
+    throw new Error('REALWORLD-TASK-COMPLETION-REPORT.md is missing or still marks the headline gate as blocked');
+  }
   const envelope = JSON.parse(readFileSync(REALWORLD_ENVELOPE_PATH, 'utf8'));
   requireHeadlineReport(envelope, 'unified benchmark report real-world section');
 }

--- a/benchmark/generate-benchmark-report.mjs
+++ b/benchmark/generate-benchmark-report.mjs
@@ -24,6 +24,7 @@
  */
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { requireHeadlineReport } from './headline-gate.mjs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -32,6 +33,7 @@ const __dirname = path.dirname(__filename);
 const REPO_ROOT = path.resolve(__dirname, '..');
 const RESULTS_DIR = path.join(REPO_ROOT, 'benchmark', 'results');
 const OUTPUT_PATH = path.join(RESULTS_DIR, 'BENCHMARK-REPORT.md');
+const REALWORLD_ENVELOPE_PATH = path.join(RESULTS_DIR, 'realworld-task-completion.json');
 
 const SECTIONS = [
   { id: '#G', axis: 'Complex Real-World Task Completion', issue: '#1305', file: 'REALWORLD-TASK-COMPLETION-REPORT.md', role: 'primary' },
@@ -75,7 +77,17 @@ function buildSection(section) {
   return lines.join('\n');
 }
 
-function main() {
+function enforceHeadlineInputs(argv = process.argv.slice(2)) {
+  if (!argv.includes('--require-headline')) return;
+  if (!existsSync(REALWORLD_ENVELOPE_PATH)) {
+    throw new Error('Missing benchmark/results/realworld-task-completion.json for --require-headline');
+  }
+  const envelope = JSON.parse(readFileSync(REALWORLD_ENVELOPE_PATH, 'utf8'));
+  requireHeadlineReport(envelope, 'unified benchmark report real-world section');
+}
+
+function main(argv = process.argv.slice(2)) {
+  enforceHeadlineInputs(argv);
   const lines = [];
   lines.push('# OpenChrome Competitive Benchmark Report');
   lines.push('');

--- a/benchmark/generate-realworld-task-completion-section.mjs
+++ b/benchmark/generate-realworld-task-completion-section.mjs
@@ -2,7 +2,8 @@
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { findClaimEligibilityFailures, requireHeadlineEligibility } from './claim-eligibility.mjs';
+import { findClaimEligibilityFailures } from './claim-eligibility.mjs';
+import { requireHeadlineReport } from './headline-gate.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -33,7 +34,7 @@ function main(argv = process.argv.slice(2)) {
   }
 
   if (requireHeadline) {
-    requireHeadlineEligibility(envelope, 'realworld-task-completion');
+    requireHeadlineReport(envelope, 'realworld-task-completion');
   }
   const eligibilityFailures = findClaimEligibilityFailures(envelope);
 

--- a/benchmark/headline-gate.mjs
+++ b/benchmark/headline-gate.mjs
@@ -22,9 +22,15 @@ function getTaskId(result) {
   return result?.taskId ?? result?.task ?? result?.scenario?.taskId ?? 'unknown';
 }
 
+function rowHasPostconditionEvidence(row) {
+  const evidence = row?.finalPostconditionEvidence ?? row?.postconditionEvidence ?? row?.evidence?.finalPostcondition;
+  return (typeof evidence === 'string' && evidence.trim().length > 0) || row?.finalPostconditionEvaluated === true;
+}
+
 function hasPostconditionEvidence(result) {
-  const evidence = result?.finalPostconditionEvidence ?? result?.postconditionEvidence ?? result?.evidence?.finalPostcondition;
-  return (typeof evidence === 'string' && evidence.trim().length > 0) || result?.finalPostconditionEvaluated === true;
+  if (rowHasPostconditionEvidence(result)) return true;
+  if (Array.isArray(result?.runs) && result.runs.length > 0) return result.runs.every(rowHasPostconditionEvidence);
+  return false;
 }
 
 function classifyResult(result, index) {

--- a/benchmark/headline-gate.mjs
+++ b/benchmark/headline-gate.mjs
@@ -24,7 +24,8 @@ function getTaskId(result) {
 
 function rowHasPostconditionEvidence(row) {
   const evidence = row?.finalPostconditionEvidence ?? row?.postconditionEvidence ?? row?.evidence?.finalPostcondition;
-  return (typeof evidence === 'string' && evidence.trim().length > 0) || row?.finalPostconditionEvaluated === true;
+  const recordedNoteEvidence = typeof row?.notes === 'string' && /^recorded final-postcondition evidence:\s*\S/i.test(row.notes);
+  return (typeof evidence === 'string' && evidence.trim().length > 0) || row?.finalPostconditionEvaluated === true || recordedNoteEvidence;
 }
 
 function hasPostconditionEvidence(result) {

--- a/benchmark/headline-gate.mjs
+++ b/benchmark/headline-gate.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Final report-time headline gate.
+ *
+ * Diagnostic benchmark rows are useful for local development, but published
+ * competitor comparisons must be backed by claimEligibility metadata and by
+ * live or recorded-real execution evidence. This module partitions mixed report
+ * envelopes and provides a fail-closed assertion for headline report generation.
+ */
+
+const HEADLINE_MODES = new Set(['live', 'recorded-real']);
+
+function getMode(result) {
+  return result?.mode ?? result?.metadata?.mode ?? result?.scenario?.mode ?? 'unknown';
+}
+
+function getLibrary(result) {
+  return result?.library ?? result?.system ?? result?.competitor ?? result?.name ?? 'unknown';
+}
+
+function getTaskId(result) {
+  return result?.taskId ?? result?.task ?? result?.scenario?.taskId ?? 'unknown';
+}
+
+function hasPostconditionEvidence(result) {
+  const evidence = result?.finalPostconditionEvidence ?? result?.postconditionEvidence ?? result?.evidence?.finalPostcondition;
+  return typeof evidence === 'string' && evidence.trim().length > 0;
+}
+
+function classifyResult(result, index) {
+  const eligibility = result?.claimEligibility;
+  const mode = getMode(result);
+  const id = `results[${index}] ${getLibrary(result)}/${getTaskId(result)}`;
+  const reasons = [];
+
+  if (!eligibility) reasons.push('missing claimEligibility');
+  else if (eligibility.eligible !== true) {
+    const explicit = Array.isArray(eligibility.reasons) && eligibility.reasons.length > 0
+      ? eligibility.reasons.join('; ')
+      : 'claimEligibility.eligible is not true';
+    reasons.push(explicit);
+  }
+
+  if (!HEADLINE_MODES.has(mode)) reasons.push(`mode ${mode} is not headline-eligible`);
+  if (!hasPostconditionEvidence(result)) reasons.push('missing final postcondition evidence');
+
+  if (reasons.length > 0) {
+    return { bucket: 'diagnostic', id, reasons, result };
+  }
+  return { bucket: 'headline', id, reasons: [], result };
+}
+
+export function partitionHeadlineResults(envelope) {
+  const results = Array.isArray(envelope?.results) ? envelope.results : [];
+  const headline = [];
+  const diagnostic = [];
+  const failures = [];
+
+  results.forEach((result, index) => {
+    const classified = classifyResult(result, index);
+    if (classified.bucket === 'headline') headline.push(result);
+    else {
+      diagnostic.push(result);
+      failures.push(`${classified.id}: ${classified.reasons.join('; ')}`);
+    }
+  });
+
+  return { headline, diagnostic, failures, total: results.length };
+}
+
+export function requireHeadlineReport(envelope, label = 'benchmark report') {
+  const partition = partitionHeadlineResults(envelope);
+  if (partition.headline.length === 0) {
+    throw new Error(`${label} contains no headline-eligible rows`);
+  }
+  if (partition.failures.length > 0) {
+    throw new Error(`${label} contains diagnostic rows that cannot be published as headline claims:\n- ${partition.failures.join('\n- ')}`);
+  }
+  return partition;
+}

--- a/benchmark/headline-gate.mjs
+++ b/benchmark/headline-gate.mjs
@@ -28,9 +28,10 @@ function rowHasPostconditionEvidence(row) {
 }
 
 function hasPostconditionEvidence(result) {
-  if (rowHasPostconditionEvidence(result)) return true;
-  if (Array.isArray(result?.runs) && result.runs.length > 0) return result.runs.every(rowHasPostconditionEvidence);
-  return false;
+  if (Array.isArray(result?.runs) && result.runs.length > 0) {
+    return result.runs.every(rowHasPostconditionEvidence);
+  }
+  return rowHasPostconditionEvidence(result);
 }
 
 function classifyResult(result, index) {

--- a/benchmark/headline-gate.mjs
+++ b/benchmark/headline-gate.mjs
@@ -8,7 +8,7 @@
  * envelopes and provides a fail-closed assertion for headline report generation.
  */
 
-const HEADLINE_MODES = new Set(['live', 'recorded-real']);
+const HEADLINE_MODES = new Set(['live', 'live-llm', 'recorded-real']);
 
 function getMode(result) {
   return result?.mode ?? result?.measurementMode ?? result?.metadata?.mode ?? result?.scenario?.mode ?? 'unknown';

--- a/benchmark/headline-gate.mjs
+++ b/benchmark/headline-gate.mjs
@@ -11,7 +11,7 @@
 const HEADLINE_MODES = new Set(['live', 'recorded-real']);
 
 function getMode(result) {
-  return result?.mode ?? result?.metadata?.mode ?? result?.scenario?.mode ?? 'unknown';
+  return result?.mode ?? result?.measurementMode ?? result?.metadata?.mode ?? result?.scenario?.mode ?? 'unknown';
 }
 
 function getLibrary(result) {
@@ -24,7 +24,7 @@ function getTaskId(result) {
 
 function hasPostconditionEvidence(result) {
   const evidence = result?.finalPostconditionEvidence ?? result?.postconditionEvidence ?? result?.evidence?.finalPostcondition;
-  return typeof evidence === 'string' && evidence.trim().length > 0;
+  return (typeof evidence === 'string' && evidence.trim().length > 0) || result?.finalPostconditionEvaluated === true;
 }
 
 function classifyResult(result, index) {

--- a/benchmark/headline-gate.test.mjs
+++ b/benchmark/headline-gate.test.mjs
@@ -31,6 +31,7 @@ assert.match(mixed.failures[0], /dry-run mode/);
 assert.match(mixed.failures[0], /not headline-eligible/);
 
 assert.doesNotThrow(() => requireHeadlineReport({ results: [headlineRow] }, 'recorded-real report'));
+assert.doesNotThrow(() => requireHeadlineReport({ results: [{ ...headlineRow, measurementMode: 'live-llm' }] }, 'live-llm report'));
 assert.doesNotThrow(() => requireHeadlineReport({ results: [{ ...headlineRow, finalPostconditionEvidence: undefined, finalPostconditionEvaluated: true }] }, 'evaluated aggregate report'));
 assert.doesNotThrow(() => requireHeadlineReport({ results: [{ ...headlineRow, finalPostconditionEvidence: undefined, runs: [{ finalPostconditionEvidence: 'postcondition checked' }] }] }, 'aggregate with run evidence report'));
 assert.doesNotThrow(() => requireHeadlineReport({ results: [{ ...headlineRow, finalPostconditionEvidence: undefined, runs: [{ notes: 'recorded final-postcondition evidence: postcondition checked' }] }] }, 'aggregate with recorded note evidence report'));

--- a/benchmark/headline-gate.test.mjs
+++ b/benchmark/headline-gate.test.mjs
@@ -4,7 +4,7 @@ import { partitionHeadlineResults, requireHeadlineReport } from './headline-gate
 const headlineRow = {
   library: 'openchrome',
   taskId: 'checkout-product',
-  mode: 'recorded-real',
+  measurementMode: 'recorded-real',
   finalPostconditionEvidence: 'cart contains expected product',
   claimEligibility: { eligible: true, reasons: [] },
 };
@@ -31,6 +31,7 @@ assert.match(mixed.failures[0], /dry-run mode/);
 assert.match(mixed.failures[0], /not headline-eligible/);
 
 assert.doesNotThrow(() => requireHeadlineReport({ results: [headlineRow] }, 'recorded-real report'));
+assert.doesNotThrow(() => requireHeadlineReport({ results: [{ ...headlineRow, finalPostconditionEvidence: undefined, finalPostconditionEvaluated: true }] }, 'evaluated aggregate report'));
 assert.throws(() => requireHeadlineReport({ results: [diagnosticRow] }, 'diagnostic-only report'), /contains no headline-eligible rows/);
 assert.throws(() => requireHeadlineReport({ results: [headlineRow, diagnosticRow] }, 'mixed report'), /diagnostic rows/);
 assert.throws(

--- a/benchmark/headline-gate.test.mjs
+++ b/benchmark/headline-gate.test.mjs
@@ -33,6 +33,7 @@ assert.match(mixed.failures[0], /not headline-eligible/);
 assert.doesNotThrow(() => requireHeadlineReport({ results: [headlineRow] }, 'recorded-real report'));
 assert.doesNotThrow(() => requireHeadlineReport({ results: [{ ...headlineRow, finalPostconditionEvidence: undefined, finalPostconditionEvaluated: true }] }, 'evaluated aggregate report'));
 assert.doesNotThrow(() => requireHeadlineReport({ results: [{ ...headlineRow, finalPostconditionEvidence: undefined, runs: [{ finalPostconditionEvidence: 'postcondition checked' }] }] }, 'aggregate with run evidence report'));
+assert.doesNotThrow(() => requireHeadlineReport({ results: [{ ...headlineRow, finalPostconditionEvidence: undefined, runs: [{ notes: 'recorded final-postcondition evidence: postcondition checked' }] }] }, 'aggregate with recorded note evidence report'));
 assert.throws(() => requireHeadlineReport({ results: [diagnosticRow] }, 'diagnostic-only report'), /contains no headline-eligible rows/);
 assert.throws(() => requireHeadlineReport({ results: [headlineRow, diagnosticRow] }, 'mixed report'), /diagnostic rows/);
 assert.throws(

--- a/benchmark/headline-gate.test.mjs
+++ b/benchmark/headline-gate.test.mjs
@@ -36,6 +36,10 @@ assert.doesNotThrow(() => requireHeadlineReport({ results: [{ ...headlineRow, fi
 assert.throws(() => requireHeadlineReport({ results: [diagnosticRow] }, 'diagnostic-only report'), /contains no headline-eligible rows/);
 assert.throws(() => requireHeadlineReport({ results: [headlineRow, diagnosticRow] }, 'mixed report'), /diagnostic rows/);
 assert.throws(
+  () => requireHeadlineReport({ results: [{ ...headlineRow, finalPostconditionEvidence: 'aggregate summary', runs: [{ finalPostconditionEvidence: 'ok' }, { notes: 'missing structured evidence' }] }] }, 'partial aggregate report'),
+  /contains no headline-eligible rows/,
+);
+assert.throws(
   () => requireHeadlineReport({ results: [{ ...headlineRow, finalPostconditionEvidence: '' }] }, 'missing evidence'),
   /contains no headline-eligible rows/,
 );

--- a/benchmark/headline-gate.test.mjs
+++ b/benchmark/headline-gate.test.mjs
@@ -32,6 +32,7 @@ assert.match(mixed.failures[0], /not headline-eligible/);
 
 assert.doesNotThrow(() => requireHeadlineReport({ results: [headlineRow] }, 'recorded-real report'));
 assert.doesNotThrow(() => requireHeadlineReport({ results: [{ ...headlineRow, finalPostconditionEvidence: undefined, finalPostconditionEvaluated: true }] }, 'evaluated aggregate report'));
+assert.doesNotThrow(() => requireHeadlineReport({ results: [{ ...headlineRow, finalPostconditionEvidence: undefined, runs: [{ finalPostconditionEvidence: 'postcondition checked' }] }] }, 'aggregate with run evidence report'));
 assert.throws(() => requireHeadlineReport({ results: [diagnosticRow] }, 'diagnostic-only report'), /contains no headline-eligible rows/);
 assert.throws(() => requireHeadlineReport({ results: [headlineRow, diagnosticRow] }, 'mixed report'), /diagnostic rows/);
 assert.throws(

--- a/benchmark/headline-gate.test.mjs
+++ b/benchmark/headline-gate.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { partitionHeadlineResults, requireHeadlineReport } from './headline-gate.mjs';
+
+const headlineRow = {
+  library: 'openchrome',
+  taskId: 'checkout-product',
+  mode: 'recorded-real',
+  finalPostconditionEvidence: 'cart contains expected product',
+  claimEligibility: { eligible: true, reasons: [] },
+};
+
+const diagnosticRow = {
+  library: 'browser-use',
+  taskId: 'checkout-product',
+  mode: 'dry-run',
+  finalPostconditionEvidence: 'mock postcondition',
+  claimEligibility: { eligible: false, reasons: ['dry-run mode'] },
+};
+
+assert.deepEqual(partitionHeadlineResults({ results: [headlineRow] }), {
+  headline: [headlineRow],
+  diagnostic: [],
+  failures: [],
+  total: 1,
+});
+
+const mixed = partitionHeadlineResults({ results: [headlineRow, diagnosticRow] });
+assert.equal(mixed.headline.length, 1);
+assert.equal(mixed.diagnostic.length, 1);
+assert.match(mixed.failures[0], /dry-run mode/);
+assert.match(mixed.failures[0], /not headline-eligible/);
+
+assert.doesNotThrow(() => requireHeadlineReport({ results: [headlineRow] }, 'recorded-real report'));
+assert.throws(() => requireHeadlineReport({ results: [diagnosticRow] }, 'diagnostic-only report'), /contains no headline-eligible rows/);
+assert.throws(() => requireHeadlineReport({ results: [headlineRow, diagnosticRow] }, 'mixed report'), /diagnostic rows/);
+assert.throws(
+  () => requireHeadlineReport({ results: [{ ...headlineRow, finalPostconditionEvidence: '' }] }, 'missing evidence'),
+  /contains no headline-eligible rows/,
+);

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "docs:capability-map:check": "ts-node scripts/gen-capability-map.ts --check",
     "bench:episode:tokens": "ts-node tests/benchmark/run-episode-token-cost.ts",
     "bench:realworld": "ts-node tests/benchmark/run-realworld-task-completion.ts && node benchmark/generate-realworld-task-completion-section.mjs",
+    "bench:realworld:headline": "ts-node tests/benchmark/run-realworld-task-completion.ts --recording-dir=benchmark/recordings/realworld && node benchmark/generate-realworld-task-completion-section.mjs --require-headline",
     "bench:agent-success": "ts-node tests/benchmark/episode-harness/cli.ts",
     "bench:agent-success:mock": "ts-node tests/benchmark/episode-harness/cli.ts --adapter mock",
     "bench:readiness": "ts-node tests/benchmark/benchmark-readiness.ts",

--- a/tests/benchmark/realworld-task-completion/recordings.test.ts
+++ b/tests/benchmark/realworld-task-completion/recordings.test.ts
@@ -47,6 +47,9 @@ describe('real-world recorded evidence ingestion', () => {
     const result = envelope.results[0];
     expect(result.measurementMode).toBe('recorded-real');
     expect(result.claimEligibility.eligible).toBe(true);
+    expect(result.finalPostconditionEvaluated).toBe(true);
+    expect(result.finalPostconditionEvidence).toContain('postcondition ok 0');
+    expect(result.runs.every((run: { finalPostconditionEvidence?: string; finalPostconditionEvaluated?: boolean }) => run.finalPostconditionEvaluated === true && typeof run.finalPostconditionEvidence === 'string')).toBe(true);
     expect(result.metrics.map((row: { library: string }) => row.library).sort()).toEqual(['openchrome', 'playwright']);
   });
 });

--- a/tests/benchmark/realworld-task-completion/recordings.ts
+++ b/tests/benchmark/realworld-task-completion/recordings.ts
@@ -107,6 +107,8 @@ export function recordedSamplesToRuns(samples: readonly RecordedRealWorldSample[
     tokens: sample.tokens,
     usd: sample.usd,
     failureCategory: sample.failureCategory,
+    finalPostconditionEvidence: sample.finalPostconditionEvidence,
+    finalPostconditionEvaluated: true,
     notes: `recorded final-postcondition evidence: ${sample.finalPostconditionEvidence}${sample.notes ? `; ${sample.notes}` : ''}`,
   }));
 }

--- a/tests/benchmark/realworld-task-completion/types.ts
+++ b/tests/benchmark/realworld-task-completion/types.ts
@@ -39,6 +39,8 @@ export interface RealWorldTaskRun {
   usd: number | null;
   failureCategory: FailureCategory;
   notes: string;
+  finalPostconditionEvidence?: string;
+  finalPostconditionEvaluated?: boolean;
 }
 
 export interface RealWorldLibraryMetrics {

--- a/tests/benchmark/run-realworld-task-completion.ts
+++ b/tests/benchmark/run-realworld-task-completion.ts
@@ -34,6 +34,10 @@ export function buildRealWorldTaskCompletionResult(argv: string[] = []) {
   const runs = recordingDir ? recordedSamplesToRuns(recordedSamples) : deterministicOpenChromeFixtureRuns();
   assertHonestMeasurement(runs);
   const metrics = aggregateRealWorldMetrics(runs);
+  const finalPostconditionEvidence = runs
+    .map((run) => run.finalPostconditionEvidence)
+    .filter((evidence): evidence is string => typeof evidence === 'string' && evidence.trim().length > 0)
+    .join('; ');
   const claimEligibility = evaluateEpisodeClaimEligibility({
     mode: recordingDir ? 'recorded-real' : 'scaffold',
     scope: 'aggregate',
@@ -61,6 +65,8 @@ export function buildRealWorldTaskCompletionResult(argv: string[] = []) {
         tasks: realWorldTaskSpecs,
         runs,
         metrics,
+        finalPostconditionEvidence,
+        finalPostconditionEvaluated: runs.length > 0 && runs.every((run) => run.finalPostconditionEvaluated === true || (typeof run.finalPostconditionEvidence === 'string' && run.finalPostconditionEvidence.trim().length > 0)),
         claimEligibility,
       },
     ],


### PR DESCRIPTION
## Summary\n- add a final headline report gate that separates headline-eligible rows from diagnostics\n- require live/recorded-real mode, explicit claimEligibility approval, and final postcondition evidence\n- fail closed when mixed or diagnostic-only envelopes are about to be published as headline claims\n\n## Tests\n- npm run build\n- node benchmark/headline-gate.test.mjs\n\nStacked on #1335.