### PR TITLE
Codify benchmark API-key-only readiness blockers

### DIFF
--- a/benchmark/results/BENCHMARK-READINESS.md
+++ b/benchmark/results/BENCHMARK-READINESS.md
@@ -1,6 +1,6 @@
 # Open benchmark issue readiness audit
 
-Generated: 2026-05-16T03:34:40.041Z
+Generated: 2026-05-17T10:04:50.876Z
 
 ## Verdict
 
@@ -8,34 +8,35 @@ Generated: 2026-05-16T03:34:40.041Z
 
 | Metric | Count |
 | --- | ---: |
-| Open benchmark issues audited | 16 |
+| Open benchmark issues audited | 15 |
 | Ready | 0 |
-| Partial | 11 |
+| Partial | 10 |
 | Not ready | 5 |
 | Headline-measurement-ready | 0 |
-| Diagnostic/smoke only | 11 |
+| Diagnostic/smoke only | 10 |
 | Not measurable yet | 5 |
+| API-key-only ready | 0 |
+| Blocked by non-key work | 15 |
 
 ## Issue matrix
 
-| Issue | Status | Measurement readiness | Primary blocker |
-| --- | --- | --- | --- |
-| [#1254](https://github.com/shaun0927/openchrome/issues/1254) Epic: Competitive Benchmark Suite — OpenChrome vs 2026 best-in-class open-source | not_ready | not_measurable | Multiple child axes remain partial or scaffolded; unified report still marks several sections pending. |
-| [#1255](https://github.com/shaun0927/openchrome/issues/1255) Benchmark #0: Harness Foundation — competitor adapters, exact tokenizer, env metadata | partial | diagnostic_or_smoke_only | The suite is not yet proven with every live competitor adapter passing the same smoke task and pinned versions. |
-| [#1256](https://github.com/shaun0927/openchrome/issues/1256) Benchmark #A: Token Efficiency — payload tokens vs information retention | partial | diagnostic_or_smoke_only | OpenChrome read_page/ax, Playwright a11y, playwright-mcp, and browser-use extractors still require live/recorded-real wiring before headline token-efficiency claims. |
-| [#1257](https://github.com/shaun0927/openchrome/issues/1257) Benchmark #B: Agent Task Success — WebVoyager at equal LLM and equal budget | partial | diagnostic_or_smoke_only | Live Claude/WebVoyager and competitor-native loops remain unwired, so current rows are controlled mock evidence only. |
-| [#1258](https://github.com/shaun0927/openchrome/issues/1258) Benchmark #C: Speed & Throughput — effective (success-weighted) throughput | partial | diagnostic_or_smoke_only | Playwright/Puppeteer throughput cells require a live Chrome/CDP endpoint; session-reuse delta is still missing; headline competitor matrix needs operator-run live evidence. |
-| [#1259](https://github.com/shaun0927/openchrome/issues/1259) Benchmark #D: Reliability & Fault-Recovery — recovery rate, flaky rate, leak/zombie | partial | diagnostic_or_smoke_only | Live fault-injection proxy/CDP cells, Chrome RSS/zombie sampling, and task-completion stress matrix remain unwired. |
-| [#1260](https://github.com/shaun0927/openchrome/issues/1260) Benchmark #E: Auth & Real-World Usability — logged-in success + setup cost | partial | diagnostic_or_smoke_only | Wall-clock setup time and logged-in smoke success are null/pending in the current runner. |
-| [#1261](https://github.com/shaun0927/openchrome/issues/1261) Benchmark #F: Developer Experience — LOC/task, tool-schema quality, error actionability | partial | diagnostic_or_smoke_only | Schema completeness and error actionability are emitted as null pending MCP introspection/failure induction. |
-| [#1299](https://github.com/shaun0927/openchrome/issues/1299) Benchmark: Episode-level token cost to completion | partial | diagnostic_or_smoke_only | Rows are controlled mock/local evidence; live LLM token/USD accounting and competitor-native task cost are not wired. |
-| [#1300](https://github.com/shaun0927/openchrome/issues/1300) Benchmark #B follow-up: controlled realistic Agent Task Success workflow suite | partial | diagnostic_or_smoke_only | The suite is still a controlled foundation and does not yet cover live/recorded-real competitor rows across the full taxonomy. |
-| [#1301](https://github.com/shaun0927/openchrome/issues/1301) Benchmark #B follow-up: real LLM repetitions and full-task metrics gate | not_ready | not_measurable | Real Anthropic Messages loop throws intentionally; `--repetitions` is not expanded into repeated samples; full-task token/USD accounting is missing. |
-| [#1302](https://github.com/shaun0927/openchrome/issues/1302) Benchmark #B follow-up: native/passive competitor adapter matrix | not_ready | not_measurable | playwright-mcp and browser-use native loops are marked `nativeLoopWired: false`. |
-| [#1303](https://github.com/shaun0927/openchrome/issues/1303) Benchmark #D follow-up: inject reliability faults inside real-world tasks | not_ready | not_measurable | Faults are not injected inside real-world task episodes and recovery is not judged by final task postconditions. |
-| [#1304](https://github.com/shaun0927/openchrome/issues/1304) Benchmark #D follow-up: real-world task completion as primary reliability signal | not_ready | not_measurable | No library × task × repetition matrix uses real-world task completion as the primary reliability metric. |
-| [#1305](https://github.com/shaun0927/openchrome/issues/1305) Benchmark #G: Complex Real-World Task Completion | partial | diagnostic_or_smoke_only | Current rows are deterministic scaffold/local-fixture evidence, not live competitive task-completion measurements. |
-| [#1310](https://github.com/shaun0927/openchrome/issues/1310) Benchmark: enforce headline eligibility for real-world episode claims | partial | diagnostic_or_smoke_only | Eligibility is not yet enforced across every real-world/live report path and cannot promote any row without live or recorded-real evidence. |
+| Issue | Status | Measurement readiness | API-key-only readiness | Primary non-key blocker |
+| --- | --- | --- | --- | --- |
+| [#1254](https://github.com/shaun0927/openchrome/issues/1254) Epic: Competitive Benchmark Suite — OpenChrome vs 2026 best-in-class open-source | not_ready | not_measurable | non_key_blockers | Multiple child axes remain partial or scaffolded; unified report still marks several sections pending. |
+| [#1255](https://github.com/shaun0927/openchrome/issues/1255) Benchmark #0: Harness Foundation — competitor adapters, exact tokenizer, env metadata | partial | diagnostic_or_smoke_only | non_key_blockers | The suite is not yet proven with every live competitor adapter passing the same smoke task and pinned versions. |
+| [#1256](https://github.com/shaun0927/openchrome/issues/1256) Benchmark #A: Token Efficiency — payload tokens vs information retention | partial | diagnostic_or_smoke_only | non_key_blockers | OpenChrome read_page/ax, Playwright a11y, playwright-mcp, and browser-use extractors still require live/recorded-real wiring before headline token-efficiency claims. |
+| [#1257](https://github.com/shaun0927/openchrome/issues/1257) Benchmark #B: Agent Task Success — WebVoyager at equal LLM and equal budget | partial | diagnostic_or_smoke_only | non_key_blockers | Live Claude/WebVoyager and competitor-native loops remain unwired, so current rows are controlled mock evidence only. |
+| [#1258](https://github.com/shaun0927/openchrome/issues/1258) Benchmark #C: Speed & Throughput — effective (success-weighted) throughput | partial | diagnostic_or_smoke_only | non_key_blockers | Playwright/Puppeteer throughput cells require a live Chrome/CDP endpoint; session-reuse delta is still missing; headline competitor matrix needs operator-run live evidence. |
+| [#1259](https://github.com/shaun0927/openchrome/issues/1259) Benchmark #D: Reliability & Fault-Recovery — recovery rate, flaky rate, leak/zombie | partial | diagnostic_or_smoke_only | non_key_blockers | Live fault-injection proxy/CDP cells, Chrome RSS/zombie sampling, and task-completion stress matrix remain unwired. |
+| [#1260](https://github.com/shaun0927/openchrome/issues/1260) Benchmark #E: Auth & Real-World Usability — logged-in success + setup cost | partial | diagnostic_or_smoke_only | non_key_blockers | Wall-clock setup time and logged-in smoke success are null/pending in the current runner. |
+| [#1261](https://github.com/shaun0927/openchrome/issues/1261) Benchmark #F: Developer Experience — LOC/task, tool-schema quality, error actionability | partial | diagnostic_or_smoke_only | non_key_blockers | Schema completeness and error actionability are emitted as null pending MCP introspection/failure induction. |
+| [#1299](https://github.com/shaun0927/openchrome/issues/1299) Benchmark: Episode-level token cost to completion | partial | diagnostic_or_smoke_only | non_key_blockers | Rows are controlled mock/local evidence; live LLM token/USD accounting and competitor-native task cost are not wired. |
+| [#1300](https://github.com/shaun0927/openchrome/issues/1300) Benchmark #B follow-up: controlled realistic Agent Task Success workflow suite | partial | diagnostic_or_smoke_only | non_key_blockers | The suite is still a controlled foundation and does not yet cover live/recorded-real competitor rows across the full taxonomy. |
+| [#1301](https://github.com/shaun0927/openchrome/issues/1301) Benchmark #B follow-up: real LLM repetitions and full-task metrics gate | not_ready | not_measurable | non_key_blockers | Real Anthropic Messages loop throws intentionally; `--repetitions` is not expanded into repeated samples; full-task token/USD accounting is missing. |
+| [#1302](https://github.com/shaun0927/openchrome/issues/1302) Benchmark #B follow-up: native/passive competitor adapter matrix | not_ready | not_measurable | non_key_blockers | playwright-mcp and browser-use native loops are marked `nativeLoopWired: false`. |
+| [#1303](https://github.com/shaun0927/openchrome/issues/1303) Benchmark #D follow-up: inject reliability faults inside real-world tasks | not_ready | not_measurable | non_key_blockers | Faults are not injected inside real-world task episodes and recovery is not judged by final task postconditions. |
+| [#1304](https://github.com/shaun0927/openchrome/issues/1304) Benchmark #D follow-up: real-world task completion as primary reliability signal | not_ready | not_measurable | non_key_blockers | No library × task × repetition matrix uses real-world task completion as the primary reliability metric. |
+| [#1310](https://github.com/shaun0927/openchrome/issues/1310) Benchmark: enforce headline eligibility for real-world episode claims | partial | diagnostic_or_smoke_only | non_key_blockers | Eligibility is not yet enforced across every real-world/live report path and cannot promote any row without live or recorded-real evidence. |
 
 ## Details
 
@@ -46,6 +47,9 @@ Generated: 2026-05-16T03:34:40.041Z
 - Evidence:
   - Some axis runners and result envelopes exist under tests/benchmark/ and benchmark/results/.
 - Blockers:
+  - Multiple child axes remain partial or scaffolded; unified report still marks several sections pending.
+- API-key-only readiness: `non_key_blockers`
+- Non-key blockers:
   - Multiple child axes remain partial or scaffolded; unified report still marks several sections pending.
 - Next actions:
   - Close only after #1255-#1261 plus real-world follow-ups have headline-eligible measured rows.
@@ -58,6 +62,9 @@ Generated: 2026-05-16T03:34:40.041Z
   - Adapter files, exact tokenizer helpers, environment capture, and result schema exist.
 - Blockers:
   - The suite is not yet proven with every live competitor adapter passing the same smoke task and pinned versions.
+- API-key-only readiness: `non_key_blockers`
+- Non-key blockers:
+  - The suite is not yet proven with every live competitor adapter passing the same smoke task and pinned versions.
 - Next actions:
   - Run a shared live smoke matrix for OpenChrome, Playwright, Puppeteer, playwright-mcp, browser-use, and Crawlee; commit version pins.
 
@@ -68,6 +75,9 @@ Generated: 2026-05-16T03:34:40.041Z
 - Evidence:
   - `npm run bench:tokens` emits deterministic-static, crawlee-cheerio, playwright-content, and playwright-innerText rows with explicit skips for remaining live-only cells.
 - Blockers:
+  - OpenChrome read_page/ax, Playwright a11y, playwright-mcp, and browser-use extractors still require live/recorded-real wiring before headline token-efficiency claims.
+- API-key-only readiness: `non_key_blockers`
+- Non-key blockers:
   - OpenChrome read_page/ax, Playwright a11y, playwright-mcp, and browser-use extractors still require live/recorded-real wiring before headline token-efficiency claims.
 - Next actions:
   - Wire remaining live extractor calls and version pins before publishing competitive token-efficiency claims.
@@ -80,6 +90,10 @@ Generated: 2026-05-16T03:34:40.041Z
   - Controlled agent-success harness, mock workflow repetitions, task taxonomy, first-tool accuracy, and no-progress metrics exist.
 - Blockers:
   - Live Claude/WebVoyager and competitor-native loops remain unwired, so current rows are controlled mock evidence only.
+- API-key-only readiness: `non_key_blockers`
+- Required secrets after non-key blockers clear: `ANTHROPIC_API_KEY or OPENAI_API_KEY`
+- Non-key blockers:
+  - Live Claude/WebVoyager and competitor-native loops remain unwired, so current rows are controlled mock evidence only.
 - Next actions:
   - Implement live/recorded-real adapter rows with pinned LLM settings and competitor versions before headline claims.
 
@@ -90,6 +104,9 @@ Generated: 2026-05-16T03:34:40.041Z
 - Evidence:
   - Latency and throughput runners exist; CI throughput uses deterministic OpenChrome stub; throughput can run Crawlee without Chrome and Playwright/Puppeteer/OpenChrome live through the shared adapter gate.
 - Blockers:
+  - Playwright/Puppeteer throughput cells require a live Chrome/CDP endpoint; session-reuse delta is still missing; headline competitor matrix needs operator-run live evidence.
+- API-key-only readiness: `non_key_blockers`
+- Non-key blockers:
   - Playwright/Puppeteer throughput cells require a live Chrome/CDP endpoint; session-reuse delta is still missing; headline competitor matrix needs operator-run live evidence.
 - Next actions:
   - Run live Chrome throughput cells for OpenChrome/Playwright/Puppeteer and add session-reuse mode.
@@ -102,6 +119,9 @@ Generated: 2026-05-16T03:34:40.041Z
   - Mock reliability matrix, Node-only long-run sampler, and real-world reliability methodology guardrails exist.
 - Blockers:
   - Live fault-injection proxy/CDP cells, Chrome RSS/zombie sampling, and task-completion stress matrix remain unwired.
+- API-key-only readiness: `non_key_blockers`
+- Non-key blockers:
+  - Live fault-injection proxy/CDP cells, Chrome RSS/zombie sampling, and task-completion stress matrix remain unwired.
 - Next actions:
   - Implement library-agnostic live fault injection inside real-world task episodes plus process sampling.
 
@@ -112,6 +132,10 @@ Generated: 2026-05-16T03:34:40.041Z
 - Evidence:
   - Local auth fixture, setup scripts, LOC count, and profile-attach metadata exist.
 - Blockers:
+  - Wall-clock setup time and logged-in smoke success are null/pending in the current runner.
+- API-key-only readiness: `non_key_blockers`
+- Required secrets after non-key blockers clear: `operator-owned live-site credentials for optional live tier`
+- Non-key blockers:
   - Wall-clock setup time and logged-in smoke success are null/pending in the current runner.
 - Next actions:
   - Wire live local login-wall smoke for each library and keep third-party live tier best-effort only.
@@ -124,6 +148,9 @@ Generated: 2026-05-16T03:34:40.041Z
   - LOC matrix runner and DX scripts exist.
 - Blockers:
   - Schema completeness and error actionability are emitted as null pending MCP introspection/failure induction.
+- API-key-only readiness: `non_key_blockers`
+- Non-key blockers:
+  - Schema completeness and error actionability are emitted as null pending MCP introspection/failure induction.
 - Next actions:
   - Add tools/list introspection for MCP competitors and fixed induced-failure scoring.
 
@@ -134,6 +161,10 @@ Generated: 2026-05-16T03:34:40.041Z
 - Evidence:
   - `bench:episode:tokens` exists and reports deterministic mock episode token breakdowns through `tokenUsage`.
 - Blockers:
+  - Rows are controlled mock/local evidence; live LLM token/USD accounting and competitor-native task cost are not wired.
+- API-key-only readiness: `non_key_blockers`
+- Required secrets after non-key blockers clear: `ANTHROPIC_API_KEY or OPENAI_API_KEY`
+- Non-key blockers:
   - Rows are controlled mock/local evidence; live LLM token/USD accounting and competitor-native task cost are not wired.
 - Next actions:
   - Add live/recorded-real token accounting with pinned LLM settings, budgets, and competitor versions.
@@ -146,6 +177,9 @@ Generated: 2026-05-16T03:34:40.041Z
   - Controlled mock workflow matrix includes categorized fixtures, repeated samples, first-tool accuracy, and no-progress metrics.
 - Blockers:
   - The suite is still a controlled foundation and does not yet cover live/recorded-real competitor rows across the full taxonomy.
+- API-key-only readiness: `non_key_blockers`
+- Non-key blockers:
+  - The suite is still a controlled foundation and does not yet cover live/recorded-real competitor rows across the full taxonomy.
 - Next actions:
   - Expand taxonomy coverage and wire live/recorded-real adapter rows before headline use.
 
@@ -156,6 +190,10 @@ Generated: 2026-05-16T03:34:40.041Z
 - Evidence:
   - Budget constants and repetition CLI parsing exist.
 - Blockers:
+  - Real Anthropic Messages loop throws intentionally; `--repetitions` is not expanded into repeated samples; full-task token/USD accounting is missing.
+- API-key-only readiness: `non_key_blockers`
+- Required secrets after non-key blockers clear: `ANTHROPIC_API_KEY or OPENAI_API_KEY`
+- Non-key blockers:
   - Real Anthropic Messages loop throws intentionally; `--repetitions` is not expanded into repeated samples; full-task token/USD accounting is missing.
 - Next actions:
   - Implement Messages tool-use loop, repetition matrix, budget aborts, and sample-count gates.
@@ -168,6 +206,10 @@ Generated: 2026-05-16T03:34:40.041Z
   - Library routing identities and dry-run projection exist.
 - Blockers:
   - playwright-mcp and browser-use native loops are marked `nativeLoopWired: false`.
+- API-key-only readiness: `non_key_blockers`
+- Required secrets after non-key blockers clear: `ANTHROPIC_API_KEY or OPENAI_API_KEY`
+- Non-key blockers:
+  - playwright-mcp and browser-use native loops are marked `nativeLoopWired: false`.
 - Next actions:
   - Wire native mode for playwright-mcp and browser-use and keep passive mode as secondary.
 
@@ -178,6 +220,10 @@ Generated: 2026-05-16T03:34:40.041Z
 - Evidence:
   - Reliability fault type taxonomy exists.
 - Blockers:
+  - Faults are not injected inside real-world task episodes and recovery is not judged by final task postconditions.
+- API-key-only readiness: `non_key_blockers`
+- Required secrets after non-key blockers clear: `ANTHROPIC_API_KEY or OPENAI_API_KEY`
+- Non-key blockers:
   - Faults are not injected inside real-world task episodes and recovery is not judged by final task postconditions.
 - Next actions:
   - Add stress-mode episode runner with deterministic fault checkpoints.
@@ -190,19 +236,12 @@ Generated: 2026-05-16T03:34:40.041Z
   - Current code separates episode harness and reliability mock matrix.
 - Blockers:
   - No library × task × repetition matrix uses real-world task completion as the primary reliability metric.
+- API-key-only readiness: `non_key_blockers`
+- Required secrets after non-key blockers clear: `ANTHROPIC_API_KEY or OPENAI_API_KEY`
+- Non-key blockers:
+  - No library × task × repetition matrix uses real-world task completion as the primary reliability metric.
 - Next actions:
   - Unify reliability reporting around task-completion episodes and demote isolated cells to stress diagnostics.
-
-### [#1305](https://github.com/shaun0927/openchrome/issues/1305) Benchmark #G: Complex Real-World Task Completion
-
-- Status: `partial`
-- Measurement readiness: `diagnostic_or_smoke_only`
-- Evidence:
-  - `bench:realworld`, deterministic real-world fixtures, scoring, result envelope, report generator, and docs exist.
-- Blockers:
-  - Current rows are deterministic scaffold/local-fixture evidence, not live competitive task-completion measurements.
-- Next actions:
-  - Add live/recorded-real OpenChrome and competitor rows with pinned versions and claim eligibility before headline claims.
 
 ### [#1310](https://github.com/shaun0927/openchrome/issues/1310) Benchmark: enforce headline eligibility for real-world episode claims
 
@@ -212,6 +251,69 @@ Generated: 2026-05-16T03:34:40.041Z
   - Episode harness reports include `claimEligibility`, and the unified report documents primary evidence policy.
 - Blockers:
   - Eligibility is not yet enforced across every real-world/live report path and cannot promote any row without live or recorded-real evidence.
+- API-key-only readiness: `non_key_blockers`
+- Required secrets after non-key blockers clear: `ANTHROPIC_API_KEY or OPENAI_API_KEY`
+- Non-key blockers:
+  - Eligibility is not yet enforced across every real-world/live report path and cannot promote any row without live or recorded-real evidence.
 - Next actions:
   - Extend claim eligibility checks to every live/recorded-real runner and fail report generation on missing eligibility metadata.
+
+
+## Additional PR scopes to reach API-key-only readiness
+
+These are the remaining non-key PRs needed before supplying API keys should be enough to run the full comparison.
+
+### PR-A: Wire real LLM episode loops and repetition accounting
+
+- Issues: #1257, #1299, #1301
+- Objective: Connect the Anthropic/OpenAI tool-use loop seams to the WebVoyager and episode-token runners, expand task × library × mode × repetition cells, and persist full token/USD/budget-abort metrics.
+- Acceptance criteria:
+  - `--repetitions 10` writes ten samples per selected task/library/mode cell.
+  - Live runs refuse to start without pinned provider/model/temperature/budget metadata.
+  - Token, USD, tool-call, wall-time, and budget-abort fields are present in every live/recorded-real row.
+
+### PR-B: Enable native/passive competitor matrix execution
+
+- Issues: #1255, #1257, #1302
+- Objective: Promote playwright-mcp and browser-use from native-loop scaffolds to runnable competitors and keep passive browser-use rows secondary/non-headline.
+- Acceptance criteria:
+  - `bench:webvoyager:real --library playwright-mcp --mode native` and `--library browser-use --mode native` run or emit explicit dependency-only setup errors.
+  - Cross-library JSON separates native headline rows from passive secondary rows.
+  - Competitor versions are pinned in result envelopes before comparison rows are publishable.
+
+### PR-C: Wire live token-efficiency extractors and recorded payload ingestion
+
+- Issues: #1256
+- Objective: Replace token live-only stubs for OpenChrome read_page/AX, Playwright accessibility, playwright-mcp snapshot, and browser-use DOM serialization with real or recorded-live extractors.
+- Acceptance criteria:
+  - `OPENCHROME_BENCH_LIVE=1 npm run bench:tokens` measures all live extractor cells instead of throwing scaffold errors.
+  - Recorded payloads include source/version/timestamp evidence and are validated before inclusion.
+  - Reports distinguish live/recorded-real rows from deterministic diagnostic rows.
+
+### PR-D: Make real-world completion and fault stress headline-eligible
+
+- Issues: #1300, #1303, #1304, #1310, #1259
+- Objective: Unify live/recorded-real real-world task completion with deterministic fault checkpoints, final postcondition recovery judging, and per-row claimEligibility.
+- Acceptance criteria:
+  - `bench:realworld` can run live/recorded-real OpenChrome and competitor rows with N>=10 aggregate samples.
+  - Fault-injected rows set `fault_injected=true` and count recovered only when the final task postcondition passes.
+  - `benchmark/generate-realworld-task-completion-section.mjs --require-headline` passes only with eligible live/recorded-real rows.
+
+### PR-E: Finish speed/auth/DX live measurement gaps
+
+- Issues: #1258, #1260, #1261
+- Objective: Close remaining non-LLM measurement gaps: live throughput/session-reuse evidence, auth fixture wall-clock/pass evidence, MCP schema introspection, and induced error-actionability scoring.
+- Acceptance criteria:
+  - Throughput reports include live OpenChrome/Playwright/Puppeteer/Crawlee rows plus reuse-vs-cold deltas.
+  - Auth reports include local login-wall pass/fail and setup minutes for every library.
+  - DX reports include schema completeness and error actionability scores with null-free measured rows for MCP competitors.
+
+### PR-F: Add full live benchmark orchestration and release gate
+
+- Issues: #1254, #1255, #1310
+- Objective: Provide one preflighted command that, after API keys and local runtime credentials are present, runs every axis, validates result envelopes, and blocks headline report publication on any diagnostic-only row.
+- Acceptance criteria:
+  - `npm run bench:full:live -- --preflight` reports only missing secrets/runtime services before execution.
+  - The full command runs axes in dependency order and writes a unified report with no mock/scaffold headline rows.
+  - `npm run bench:readiness -- --api-key-only` passes only when non-key blockers are gone.
 

--- a/benchmark/results/benchmark-readiness.json
+++ b/benchmark/results/benchmark-readiness.json
@@ -1,14 +1,17 @@
 {
-  "generatedAt": "2026-05-16T03:34:40.041Z",
+  "generatedAt": "2026-05-17T10:04:50.876Z",
   "summary": {
-    "totalOpenBenchmarkIssues": 16,
+    "totalOpenBenchmarkIssues": 15,
     "ready": 0,
-    "partial": 11,
+    "partial": 10,
     "notReady": 5,
     "headlineReady": 0,
-    "diagnosticOrSmokeOnly": 11,
+    "diagnosticOrSmokeOnly": 10,
     "notMeasurable": 5,
-    "canMeasureEveryOpenBenchmarkIssue": false
+    "canMeasureEveryOpenBenchmarkIssue": false,
+    "apiKeyOnlyReady": 0,
+    "nonKeyBlocked": 15,
+    "apiKeyOnlyCanMeasureEveryOpenBenchmarkIssue": false
   },
   "issues": [
     {
@@ -25,6 +28,11 @@
       ],
       "nextActions": [
         "Close only after #1255-#1261 plus real-world follow-ups have headline-eligible measured rows."
+      ],
+      "apiKeyOnlyReadiness": "non_key_blockers",
+      "requiredSecrets": [],
+      "nonKeyBlockers": [
+        "Multiple child axes remain partial or scaffolded; unified report still marks several sections pending."
       ]
     },
     {
@@ -41,6 +49,11 @@
       ],
       "nextActions": [
         "Run a shared live smoke matrix for OpenChrome, Playwright, Puppeteer, playwright-mcp, browser-use, and Crawlee; commit version pins."
+      ],
+      "apiKeyOnlyReadiness": "non_key_blockers",
+      "requiredSecrets": [],
+      "nonKeyBlockers": [
+        "The suite is not yet proven with every live competitor adapter passing the same smoke task and pinned versions."
       ]
     },
     {
@@ -57,6 +70,11 @@
       ],
       "nextActions": [
         "Wire remaining live extractor calls and version pins before publishing competitive token-efficiency claims."
+      ],
+      "apiKeyOnlyReadiness": "non_key_blockers",
+      "requiredSecrets": [],
+      "nonKeyBlockers": [
+        "OpenChrome read_page/ax, Playwright a11y, playwright-mcp, and browser-use extractors still require live/recorded-real wiring before headline token-efficiency claims."
       ]
     },
     {
@@ -73,6 +91,13 @@
       ],
       "nextActions": [
         "Implement live/recorded-real adapter rows with pinned LLM settings and competitor versions before headline claims."
+      ],
+      "apiKeyOnlyReadiness": "non_key_blockers",
+      "requiredSecrets": [
+        "ANTHROPIC_API_KEY or OPENAI_API_KEY"
+      ],
+      "nonKeyBlockers": [
+        "Live Claude/WebVoyager and competitor-native loops remain unwired, so current rows are controlled mock evidence only."
       ]
     },
     {
@@ -89,6 +114,11 @@
       ],
       "nextActions": [
         "Run live Chrome throughput cells for OpenChrome/Playwright/Puppeteer and add session-reuse mode."
+      ],
+      "apiKeyOnlyReadiness": "non_key_blockers",
+      "requiredSecrets": [],
+      "nonKeyBlockers": [
+        "Playwright/Puppeteer throughput cells require a live Chrome/CDP endpoint; session-reuse delta is still missing; headline competitor matrix needs operator-run live evidence."
       ]
     },
     {
@@ -105,6 +135,11 @@
       ],
       "nextActions": [
         "Implement library-agnostic live fault injection inside real-world task episodes plus process sampling."
+      ],
+      "apiKeyOnlyReadiness": "non_key_blockers",
+      "requiredSecrets": [],
+      "nonKeyBlockers": [
+        "Live fault-injection proxy/CDP cells, Chrome RSS/zombie sampling, and task-completion stress matrix remain unwired."
       ]
     },
     {
@@ -121,6 +156,13 @@
       ],
       "nextActions": [
         "Wire live local login-wall smoke for each library and keep third-party live tier best-effort only."
+      ],
+      "apiKeyOnlyReadiness": "non_key_blockers",
+      "requiredSecrets": [
+        "operator-owned live-site credentials for optional live tier"
+      ],
+      "nonKeyBlockers": [
+        "Wall-clock setup time and logged-in smoke success are null/pending in the current runner."
       ]
     },
     {
@@ -137,6 +179,11 @@
       ],
       "nextActions": [
         "Add tools/list introspection for MCP competitors and fixed induced-failure scoring."
+      ],
+      "apiKeyOnlyReadiness": "non_key_blockers",
+      "requiredSecrets": [],
+      "nonKeyBlockers": [
+        "Schema completeness and error actionability are emitted as null pending MCP introspection/failure induction."
       ]
     },
     {
@@ -153,6 +200,13 @@
       ],
       "nextActions": [
         "Add live/recorded-real token accounting with pinned LLM settings, budgets, and competitor versions."
+      ],
+      "apiKeyOnlyReadiness": "non_key_blockers",
+      "requiredSecrets": [
+        "ANTHROPIC_API_KEY or OPENAI_API_KEY"
+      ],
+      "nonKeyBlockers": [
+        "Rows are controlled mock/local evidence; live LLM token/USD accounting and competitor-native task cost are not wired."
       ]
     },
     {
@@ -169,6 +223,11 @@
       ],
       "nextActions": [
         "Expand taxonomy coverage and wire live/recorded-real adapter rows before headline use."
+      ],
+      "apiKeyOnlyReadiness": "non_key_blockers",
+      "requiredSecrets": [],
+      "nonKeyBlockers": [
+        "The suite is still a controlled foundation and does not yet cover live/recorded-real competitor rows across the full taxonomy."
       ]
     },
     {
@@ -185,6 +244,13 @@
       ],
       "nextActions": [
         "Implement Messages tool-use loop, repetition matrix, budget aborts, and sample-count gates."
+      ],
+      "apiKeyOnlyReadiness": "non_key_blockers",
+      "requiredSecrets": [
+        "ANTHROPIC_API_KEY or OPENAI_API_KEY"
+      ],
+      "nonKeyBlockers": [
+        "Real Anthropic Messages loop throws intentionally; `--repetitions` is not expanded into repeated samples; full-task token/USD accounting is missing."
       ]
     },
     {
@@ -201,6 +267,13 @@
       ],
       "nextActions": [
         "Wire native mode for playwright-mcp and browser-use and keep passive mode as secondary."
+      ],
+      "apiKeyOnlyReadiness": "non_key_blockers",
+      "requiredSecrets": [
+        "ANTHROPIC_API_KEY or OPENAI_API_KEY"
+      ],
+      "nonKeyBlockers": [
+        "playwright-mcp and browser-use native loops are marked `nativeLoopWired: false`."
       ]
     },
     {
@@ -217,6 +290,13 @@
       ],
       "nextActions": [
         "Add stress-mode episode runner with deterministic fault checkpoints."
+      ],
+      "apiKeyOnlyReadiness": "non_key_blockers",
+      "requiredSecrets": [
+        "ANTHROPIC_API_KEY or OPENAI_API_KEY"
+      ],
+      "nonKeyBlockers": [
+        "Faults are not injected inside real-world task episodes and recovery is not judged by final task postconditions."
       ]
     },
     {
@@ -233,22 +313,13 @@
       ],
       "nextActions": [
         "Unify reliability reporting around task-completion episodes and demote isolated cells to stress diagnostics."
-      ]
-    },
-    {
-      "issue": 1305,
-      "title": "Benchmark #G: Complex Real-World Task Completion",
-      "url": "https://github.com/shaun0927/openchrome/issues/1305",
-      "status": "partial",
-      "measurementReadiness": "diagnostic_or_smoke_only",
-      "evidence": [
-        "`bench:realworld`, deterministic real-world fixtures, scoring, result envelope, report generator, and docs exist."
       ],
-      "blockers": [
-        "Current rows are deterministic scaffold/local-fixture evidence, not live competitive task-completion measurements."
+      "apiKeyOnlyReadiness": "non_key_blockers",
+      "requiredSecrets": [
+        "ANTHROPIC_API_KEY or OPENAI_API_KEY"
       ],
-      "nextActions": [
-        "Add live/recorded-real OpenChrome and competitor rows with pinned versions and claim eligibility before headline claims."
+      "nonKeyBlockers": [
+        "No library × task × repetition matrix uses real-world task completion as the primary reliability metric."
       ]
     },
     {
@@ -265,6 +336,105 @@
       ],
       "nextActions": [
         "Extend claim eligibility checks to every live/recorded-real runner and fail report generation on missing eligibility metadata."
+      ],
+      "apiKeyOnlyReadiness": "non_key_blockers",
+      "requiredSecrets": [
+        "ANTHROPIC_API_KEY or OPENAI_API_KEY"
+      ],
+      "nonKeyBlockers": [
+        "Eligibility is not yet enforced across every real-world/live report path and cannot promote any row without live or recorded-real evidence."
+      ]
+    }
+  ],
+  "additionalPrScopes": [
+    {
+      "id": "PR-A",
+      "title": "Wire real LLM episode loops and repetition accounting",
+      "issues": [
+        1257,
+        1299,
+        1301
+      ],
+      "objective": "Connect the Anthropic/OpenAI tool-use loop seams to the WebVoyager and episode-token runners, expand task × library × mode × repetition cells, and persist full token/USD/budget-abort metrics.",
+      "acceptanceCriteria": [
+        "`--repetitions 10` writes ten samples per selected task/library/mode cell.",
+        "Live runs refuse to start without pinned provider/model/temperature/budget metadata.",
+        "Token, USD, tool-call, wall-time, and budget-abort fields are present in every live/recorded-real row."
+      ]
+    },
+    {
+      "id": "PR-B",
+      "title": "Enable native/passive competitor matrix execution",
+      "issues": [
+        1255,
+        1257,
+        1302
+      ],
+      "objective": "Promote playwright-mcp and browser-use from native-loop scaffolds to runnable competitors and keep passive browser-use rows secondary/non-headline.",
+      "acceptanceCriteria": [
+        "`bench:webvoyager:real --library playwright-mcp --mode native` and `--library browser-use --mode native` run or emit explicit dependency-only setup errors.",
+        "Cross-library JSON separates native headline rows from passive secondary rows.",
+        "Competitor versions are pinned in result envelopes before comparison rows are publishable."
+      ]
+    },
+    {
+      "id": "PR-C",
+      "title": "Wire live token-efficiency extractors and recorded payload ingestion",
+      "issues": [
+        1256
+      ],
+      "objective": "Replace token live-only stubs for OpenChrome read_page/AX, Playwright accessibility, playwright-mcp snapshot, and browser-use DOM serialization with real or recorded-live extractors.",
+      "acceptanceCriteria": [
+        "`OPENCHROME_BENCH_LIVE=1 npm run bench:tokens` measures all live extractor cells instead of throwing scaffold errors.",
+        "Recorded payloads include source/version/timestamp evidence and are validated before inclusion.",
+        "Reports distinguish live/recorded-real rows from deterministic diagnostic rows."
+      ]
+    },
+    {
+      "id": "PR-D",
+      "title": "Make real-world completion and fault stress headline-eligible",
+      "issues": [
+        1300,
+        1303,
+        1304,
+        1310,
+        1259
+      ],
+      "objective": "Unify live/recorded-real real-world task completion with deterministic fault checkpoints, final postcondition recovery judging, and per-row claimEligibility.",
+      "acceptanceCriteria": [
+        "`bench:realworld` can run live/recorded-real OpenChrome and competitor rows with N>=10 aggregate samples.",
+        "Fault-injected rows set `fault_injected=true` and count recovered only when the final task postcondition passes.",
+        "`benchmark/generate-realworld-task-completion-section.mjs --require-headline` passes only with eligible live/recorded-real rows."
+      ]
+    },
+    {
+      "id": "PR-E",
+      "title": "Finish speed/auth/DX live measurement gaps",
+      "issues": [
+        1258,
+        1260,
+        1261
+      ],
+      "objective": "Close remaining non-LLM measurement gaps: live throughput/session-reuse evidence, auth fixture wall-clock/pass evidence, MCP schema introspection, and induced error-actionability scoring.",
+      "acceptanceCriteria": [
+        "Throughput reports include live OpenChrome/Playwright/Puppeteer/Crawlee rows plus reuse-vs-cold deltas.",
+        "Auth reports include local login-wall pass/fail and setup minutes for every library.",
+        "DX reports include schema completeness and error actionability scores with null-free measured rows for MCP competitors."
+      ]
+    },
+    {
+      "id": "PR-F",
+      "title": "Add full live benchmark orchestration and release gate",
+      "issues": [
+        1254,
+        1255,
+        1310
+      ],
+      "objective": "Provide one preflighted command that, after API keys and local runtime credentials are present, runs every axis, validates result envelopes, and blocks headline report publication on any diagnostic-only row.",
+      "acceptanceCriteria": [
+        "`npm run bench:full:live -- --preflight` reports only missing secrets/runtime services before execution.",
+        "The full command runs axes in dependency order and writes a unified report with no mock/scaffold headline rows.",
+        "`npm run bench:readiness -- --api-key-only` passes only when non-key blockers are gone."
       ]
     }
   ]

--- a/docs/benchmarks/api-key-ready-measurement-plan.md
+++ b/docs/benchmarks/api-key-ready-measurement-plan.md
@@ -1,0 +1,115 @@
+# Benchmark API-key-only readiness plan
+
+Generated from the benchmark readiness review after the May 17, 2026 benchmark PR train (#1328-#1336).
+
+## Target state
+
+The benchmark suite is **API-key-only ready** when a maintainer can provide the required LLM/API credentials and then run the full OpenChrome-vs-competitor comparison without any additional code changes, scaffold replacement, version-pin work, or manual result massaging.
+
+That target still requires local runtime prerequisites such as Chrome/CDP availability and any competitor package installations already declared by the repository. Those are operational prerequisites, not missing benchmark implementation.
+
+## Current verdict
+
+The repository is **not API-key-only ready** yet.
+
+Recent PRs added useful seams and fail-closed report gates:
+
+- OpenAI/Anthropic tool-use loop helpers
+- live real-world runner seam
+- playwright-mcp and browser-use native helper surfaces
+- live token extractor seam
+- live throughput executor seam
+- episode fault injection hooks
+- recorded corpus validation
+- real-world headline gate enforcement
+
+However, every currently open benchmark issue still has at least one non-key blocker. Supplying `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or other credentials today would not by itself produce a complete, headline-eligible comparison.
+
+## Non-key blockers found
+
+| Area                 | Open issues         | Non-key blocker                                                                                                                                                                              |
+| -------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Harness foundation   | #1255, #1254        | Shared live competitor smoke matrix and complete pinned competitor registry are not proven for every competitor.                                                                             |
+| Token efficiency     | #1256               | OpenChrome read_page/AX, Playwright accessibility, playwright-mcp snapshot, and browser-use DOM extractors remain live-only/scaffold or recorded-payload-only paths.                         |
+| Agent task success   | #1257, #1301, #1302 | WebVoyager repetitions are parsed but not expanded into repeated samples; the legacy Claude adapter still throws; playwright-mcp and browser-use remain `nativeLoopWired: false` in routing. |
+| Speed/throughput     | #1258               | Live Chrome-backed competitor rows are possible through a seam but not yet backed by committed operator-run evidence and session reuse-vs-cold deltas.                                       |
+| Reliability          | #1259, #1303, #1304 | Live reliability rows are `live_unwired_skip`; fault hooks are not integrated into real-world task episodes; task completion is not yet the primary reliability matrix.                      |
+| Auth usability       | #1260               | Local login-wall fixture exists, but wall-clock setup time and logged-in success rows are still pending/null.                                                                                |
+| Developer experience | #1261               | LOC rows exist, but schema completeness and induced error-actionability scoring are not populated for MCP competitors.                                                                       |
+| Episode token cost   | #1299               | Deterministic/mock token breakdown exists, but live LLM/competitor-native token and USD accounting are not wired.                                                                            |
+| Headline gating      | #1310               | The report gate correctly rejects mock/scaffold rows, but there are no eligible live or recorded-real rows to promote.                                                                       |
+
+## Additional PR ladder
+
+The readiness audit encodes the following PR scopes in `tests/benchmark/benchmark-readiness.ts` so release gates and reports can stay aligned with the implementation plan.
+
+### PR-A — Wire real LLM episode loops and repetition accounting
+
+Covers #1257, #1299, #1301.
+
+Acceptance:
+
+- `--repetitions 10` writes ten samples per selected task/library/mode cell.
+- Live runs refuse to start without pinned provider/model/temperature/budget metadata.
+- Token, USD, tool-call, wall-time, and budget-abort fields are present in every live/recorded-real row.
+
+### PR-B — Enable native/passive competitor matrix execution
+
+Covers #1255, #1257, #1302.
+
+Acceptance:
+
+- `bench:webvoyager:real --library playwright-mcp --mode native` and `--library browser-use --mode native` run or emit explicit dependency-only setup errors.
+- Cross-library JSON separates native headline rows from passive secondary rows.
+- Competitor versions are pinned in result envelopes before comparison rows are publishable.
+
+### PR-C — Wire live token-efficiency extractors and recorded payload ingestion
+
+Covers #1256.
+
+Acceptance:
+
+- `OPENCHROME_BENCH_LIVE=1 npm run bench:tokens` measures all live extractor cells instead of throwing scaffold errors.
+- Recorded payloads include source/version/timestamp evidence and are validated before inclusion.
+- Reports distinguish live/recorded-real rows from deterministic diagnostic rows.
+
+### PR-D — Make real-world completion and fault stress headline-eligible
+
+Covers #1259, #1300, #1303, #1304, #1310.
+
+Acceptance:
+
+- `bench:realworld` can run live/recorded-real OpenChrome and competitor rows with N>=10 aggregate samples.
+- Fault-injected rows set `fault_injected=true` and count recovered only when the final task postcondition passes.
+- `benchmark/generate-realworld-task-completion-section.mjs --require-headline` passes only with eligible live/recorded-real rows.
+
+### PR-E — Finish speed/auth/DX live measurement gaps
+
+Covers #1258, #1260, #1261.
+
+Acceptance:
+
+- Throughput reports include live OpenChrome/Playwright/Puppeteer/Crawlee rows plus reuse-vs-cold deltas.
+- Auth reports include local login-wall pass/fail and setup minutes for every library.
+- DX reports include schema completeness and error actionability scores with null-free measured rows for MCP competitors.
+
+### PR-F — Add full live benchmark orchestration and release gate
+
+Covers #1254, #1255, #1310.
+
+Acceptance:
+
+- `npm run bench:full:live -- --preflight` reports only missing secrets/runtime services before execution.
+- The full command runs axes in dependency order and writes a unified report with no mock/scaffold headline rows.
+- `npm run bench:readiness -- --api-key-only` passes only when non-key blockers are gone.
+
+## Scope of this PR
+
+This PR does not pretend to close all live benchmark implementation gaps. Its scope is the release-safety and planning layer needed before those implementation PRs land:
+
+1. Make the readiness audit distinguish ordinary headline readiness from **API-key-only readiness**.
+2. Remove closed #1305 from the open benchmark issue audit and keep #1310 as the open real-world headline gate.
+3. Encode the additional PR ladder above as repo-native data emitted in JSON and Markdown reports.
+4. Add `bench:api-key-readiness` / `--api-key-only` as a fail-closed gate for future release workflows.
+
+This prevents a future API-key-provided run from being mistaken as ready while non-key implementation gaps remain.

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "bench:agent-success:mock": "ts-node tests/benchmark/episode-harness/cli.ts --adapter mock",
     "bench:readiness": "ts-node tests/benchmark/benchmark-readiness.ts",
     "bench:competitor-smoke": "ts-node tests/benchmark/run-competitor-smoke.ts",
-    "bench:runtime-preflight": "ts-node tests/benchmark/runtime-preflight.ts"
+    "bench:runtime-preflight": "ts-node tests/benchmark/runtime-preflight.ts",
+    "bench:api-key-readiness": "ts-node tests/benchmark/benchmark-readiness.ts --api-key-only"
   },
   "keywords": [
     "openchrome",

--- a/tests/benchmark/benchmark-readiness.test.ts
+++ b/tests/benchmark/benchmark-readiness.test.ts
@@ -1,4 +1,9 @@
-import { buildBenchmarkReadinessReport, OPEN_BENCHMARK_ISSUES, renderBenchmarkReadinessMarkdown } from './benchmark-readiness';
+import {
+  ADDITIONAL_BENCHMARK_PR_SCOPES,
+  buildBenchmarkReadinessReport,
+  OPEN_BENCHMARK_ISSUES,
+  renderBenchmarkReadinessMarkdown,
+} from './benchmark-readiness';
 
 describe('benchmark readiness audit', () => {
   it('covers every currently open benchmark issue tracked by the audit', () => {
@@ -18,37 +23,54 @@ describe('benchmark readiness audit', () => {
       1302,
       1303,
       1304,
-      1305,
       1310,
     ]);
   });
 
-  it('states that the open benchmark suite is not fully measurable yet', () => {
-    const report = buildBenchmarkReadinessReport(new Date('2026-05-16T00:00:00.000Z'));
-    expect(report.summary.totalOpenBenchmarkIssues).toBe(16);
+  it('states that the open benchmark suite is not fully measurable or api-key-only ready yet', () => {
+    const report = buildBenchmarkReadinessReport(new Date('2026-05-17T00:00:00.000Z'));
+    expect(report.summary.totalOpenBenchmarkIssues).toBe(15);
     expect(report.summary.ready).toBe(0);
-    expect(report.summary.partial).toBe(11);
+    expect(report.summary.partial).toBe(10);
     expect(report.summary.notReady).toBe(5);
     expect(report.summary.headlineReady).toBe(0);
-    expect(report.summary.diagnosticOrSmokeOnly).toBe(11);
+    expect(report.summary.diagnosticOrSmokeOnly).toBe(10);
     expect(report.summary.notMeasurable).toBe(5);
     expect(report.summary.canMeasureEveryOpenBenchmarkIssue).toBe(false);
+    expect(report.summary.apiKeyOnlyReady).toBe(0);
+    expect(report.summary.nonKeyBlocked).toBe(15);
+    expect(report.summary.apiKeyOnlyCanMeasureEveryOpenBenchmarkIssue).toBe(false);
   });
 
-  it('calls out the real-world task completion runner as scaffold-only', () => {
-    const report = buildBenchmarkReadinessReport(new Date('2026-05-16T00:00:00.000Z'));
-    const realworld = report.issues.find((issue) => issue.issue === 1305);
-    expect(realworld?.status).toBe('partial');
-    expect(realworld?.measurementReadiness).toBe('diagnostic_or_smoke_only');
-    expect(realworld?.evidence.join('\n')).toMatch(/bench:realworld/);
-    expect(realworld?.blockers.join('\n')).toMatch(/deterministic scaffold/);
+  it('keeps the closed #1305 real-world task runner out of the open-issue audit', () => {
+    const report = buildBenchmarkReadinessReport(new Date('2026-05-17T00:00:00.000Z'));
+    expect(report.issues.find((issue) => issue.issue === 1305)).toBeUndefined();
+    const headlineGate = report.issues.find((issue) => issue.issue === 1310);
+    expect(headlineGate?.status).toBe('partial');
+    expect(headlineGate?.measurementReadiness).toBe('diagnostic_or_smoke_only');
+    expect(headlineGate?.nonKeyBlockers?.join('\n')).toMatch(/live or recorded-real evidence/);
   });
 
-  it('renders a human-readable not-ready verdict', () => {
-    const report = buildBenchmarkReadinessReport(new Date('2026-05-16T00:00:00.000Z'));
+  it('records the additional PR ladder needed before API keys are the only remaining gate', () => {
+    expect(ADDITIONAL_BENCHMARK_PR_SCOPES.map((scope) => scope.id)).toEqual([
+      'PR-A',
+      'PR-B',
+      'PR-C',
+      'PR-D',
+      'PR-E',
+      'PR-F',
+    ]);
+    const coveredIssues = new Set(ADDITIONAL_BENCHMARK_PR_SCOPES.flatMap((scope) => scope.issues));
+    for (const issue of OPEN_BENCHMARK_ISSUES) expect(coveredIssues.has(issue.issue)).toBe(true);
+  });
+
+  it('renders a human-readable not-ready verdict and API-key-only PR scopes', () => {
+    const report = buildBenchmarkReadinessReport(new Date('2026-05-17T00:00:00.000Z'));
     const markdown = renderBenchmarkReadinessMarkdown(report);
     expect(markdown).toContain('**NOT READY:**');
-    expect(markdown).toContain('Issue matrix');
-    expect(markdown).toContain('#1305');
+    expect(markdown).toContain('API-key-only readiness');
+    expect(markdown).toContain('Additional PR scopes to reach API-key-only readiness');
+    expect(markdown).toContain('PR-A: Wire real LLM episode loops');
+    expect(markdown).not.toContain('#1305');
   });
 });

--- a/tests/benchmark/benchmark-readiness.ts
+++ b/tests/benchmark/benchmark-readiness.ts
@@ -14,6 +14,7 @@ import * as path from 'path';
 
 export type ReadinessStatus = 'ready' | 'partial' | 'not_ready';
 export type MeasurementReadiness = 'headline_ready' | 'diagnostic_or_smoke_only' | 'not_measurable';
+export type ApiKeyOnlyReadiness = 'api_key_only_ready' | 'non_key_blockers';
 
 export interface BenchmarkIssueReadiness {
   issue: number;
@@ -21,9 +22,27 @@ export interface BenchmarkIssueReadiness {
   url: string;
   status: ReadinessStatus;
   measurementReadiness: MeasurementReadiness;
+  /**
+   * Whether this issue would become publishable if the operator supplied only
+   * required API keys/secrets. `non_key_blockers` means code, data, runner,
+   * version-pin, or live-runtime wiring still has to land first.
+   */
+  apiKeyOnlyReadiness?: ApiKeyOnlyReadiness;
+  /** Secrets needed after non-key blockers are gone. Empty means local/recorded-only. */
+  requiredSecrets?: string[];
   evidence: string[];
   blockers: string[];
+  /** Blockers that are not solved by adding API keys. */
+  nonKeyBlockers?: string[];
   nextActions: string[];
+}
+
+export interface AdditionalBenchmarkPrScope {
+  id: string;
+  title: string;
+  issues: number[];
+  objective: string;
+  acceptanceCriteria: string[];
 }
 
 export interface BenchmarkReadinessReport {
@@ -37,8 +56,12 @@ export interface BenchmarkReadinessReport {
     diagnosticOrSmokeOnly: number;
     notMeasurable: number;
     canMeasureEveryOpenBenchmarkIssue: boolean;
+    apiKeyOnlyReady: number;
+    nonKeyBlocked: number;
+    apiKeyOnlyCanMeasureEveryOpenBenchmarkIssue: boolean;
   };
   issues: BenchmarkIssueReadiness[];
+  additionalPrScopes: AdditionalBenchmarkPrScope[];
 }
 
 export const OPEN_BENCHMARK_ISSUES: readonly BenchmarkIssueReadiness[] = [
@@ -183,16 +206,6 @@ export const OPEN_BENCHMARK_ISSUES: readonly BenchmarkIssueReadiness[] = [
     nextActions: ['Unify reliability reporting around task-completion episodes and demote isolated cells to stress diagnostics.'],
   },
   {
-    issue: 1305,
-    title: 'Benchmark #G: Complex Real-World Task Completion',
-    url: 'https://github.com/shaun0927/openchrome/issues/1305',
-    status: 'partial',
-    measurementReadiness: 'diagnostic_or_smoke_only',
-    evidence: ['`bench:realworld`, deterministic real-world fixtures, scoring, result envelope, report generator, and docs exist.'],
-    blockers: ['Current rows are deterministic scaffold/local-fixture evidence, not live competitive task-completion measurements.'],
-    nextActions: ['Add live/recorded-real OpenChrome and competitor rows with pinned versions and claim eligibility before headline claims.'],
-  },
-  {
     issue: 1310,
     title: 'Benchmark: enforce headline eligibility for real-world episode claims',
     url: 'https://github.com/shaun0927/openchrome/issues/1310',
@@ -204,14 +217,106 @@ export const OPEN_BENCHMARK_ISSUES: readonly BenchmarkIssueReadiness[] = [
   },
 ];
 
+
+export const ADDITIONAL_BENCHMARK_PR_SCOPES: readonly AdditionalBenchmarkPrScope[] = [
+  {
+    id: 'PR-A',
+    title: 'Wire real LLM episode loops and repetition accounting',
+    issues: [1257, 1299, 1301],
+    objective: 'Connect the Anthropic/OpenAI tool-use loop seams to the WebVoyager and episode-token runners, expand task × library × mode × repetition cells, and persist full token/USD/budget-abort metrics.',
+    acceptanceCriteria: [
+      '`--repetitions 10` writes ten samples per selected task/library/mode cell.',
+      'Live runs refuse to start without pinned provider/model/temperature/budget metadata.',
+      'Token, USD, tool-call, wall-time, and budget-abort fields are present in every live/recorded-real row.',
+    ],
+  },
+  {
+    id: 'PR-B',
+    title: 'Enable native/passive competitor matrix execution',
+    issues: [1255, 1257, 1302],
+    objective: 'Promote playwright-mcp and browser-use from native-loop scaffolds to runnable competitors and keep passive browser-use rows secondary/non-headline.',
+    acceptanceCriteria: [
+      '`bench:webvoyager:real --library playwright-mcp --mode native` and `--library browser-use --mode native` run or emit explicit dependency-only setup errors.',
+      'Cross-library JSON separates native headline rows from passive secondary rows.',
+      'Competitor versions are pinned in result envelopes before comparison rows are publishable.',
+    ],
+  },
+  {
+    id: 'PR-C',
+    title: 'Wire live token-efficiency extractors and recorded payload ingestion',
+    issues: [1256],
+    objective: 'Replace token live-only stubs for OpenChrome read_page/AX, Playwright accessibility, playwright-mcp snapshot, and browser-use DOM serialization with real or recorded-live extractors.',
+    acceptanceCriteria: [
+      '`OPENCHROME_BENCH_LIVE=1 npm run bench:tokens` measures all live extractor cells instead of throwing scaffold errors.',
+      'Recorded payloads include source/version/timestamp evidence and are validated before inclusion.',
+      'Reports distinguish live/recorded-real rows from deterministic diagnostic rows.',
+    ],
+  },
+  {
+    id: 'PR-D',
+    title: 'Make real-world completion and fault stress headline-eligible',
+    issues: [1300, 1303, 1304, 1310, 1259],
+    objective: 'Unify live/recorded-real real-world task completion with deterministic fault checkpoints, final postcondition recovery judging, and per-row claimEligibility.',
+    acceptanceCriteria: [
+      '`bench:realworld` can run live/recorded-real OpenChrome and competitor rows with N>=10 aggregate samples.',
+      'Fault-injected rows set `fault_injected=true` and count recovered only when the final task postcondition passes.',
+      '`benchmark/generate-realworld-task-completion-section.mjs --require-headline` passes only with eligible live/recorded-real rows.',
+    ],
+  },
+  {
+    id: 'PR-E',
+    title: 'Finish speed/auth/DX live measurement gaps',
+    issues: [1258, 1260, 1261],
+    objective: 'Close remaining non-LLM measurement gaps: live throughput/session-reuse evidence, auth fixture wall-clock/pass evidence, MCP schema introspection, and induced error-actionability scoring.',
+    acceptanceCriteria: [
+      'Throughput reports include live OpenChrome/Playwright/Puppeteer/Crawlee rows plus reuse-vs-cold deltas.',
+      'Auth reports include local login-wall pass/fail and setup minutes for every library.',
+      'DX reports include schema completeness and error actionability scores with null-free measured rows for MCP competitors.',
+    ],
+  },
+  {
+    id: 'PR-F',
+    title: 'Add full live benchmark orchestration and release gate',
+    issues: [1254, 1255, 1310],
+    objective: 'Provide one preflighted command that, after API keys and local runtime credentials are present, runs every axis, validates result envelopes, and blocks headline report publication on any diagnostic-only row.',
+    acceptanceCriteria: [
+      '`npm run bench:full:live -- --preflight` reports only missing secrets/runtime services before execution.',
+      'The full command runs axes in dependency order and writes a unified report with no mock/scaffold headline rows.',
+      '`npm run bench:readiness -- --api-key-only` passes only when non-key blockers are gone.',
+    ],
+  },
+];
+
+
+function defaultRequiredSecretsForIssue(issue: number): string[] {
+  if ([1257, 1299, 1301, 1302, 1303, 1304, 1310].includes(issue)) {
+    return ['ANTHROPIC_API_KEY or OPENAI_API_KEY'];
+  }
+  if (issue === 1260) return ['operator-owned live-site credentials for optional live tier'];
+  return [];
+}
+
+function normalizeIssue(issue: BenchmarkIssueReadiness): Required<BenchmarkIssueReadiness> {
+  const nonKeyBlockers = issue.nonKeyBlockers ?? issue.blockers;
+  const apiKeyOnlyReadiness = issue.apiKeyOnlyReadiness ?? (issue.measurementReadiness === 'headline_ready' && nonKeyBlockers.length === 0 ? 'api_key_only_ready' : 'non_key_blockers');
+  return {
+    ...issue,
+    apiKeyOnlyReadiness,
+    requiredSecrets: issue.requiredSecrets ?? defaultRequiredSecretsForIssue(issue.issue),
+    nonKeyBlockers,
+  };
+}
+
 export function buildBenchmarkReadinessReport(now = new Date()): BenchmarkReadinessReport {
-  const issues = [...OPEN_BENCHMARK_ISSUES];
+  const issues = OPEN_BENCHMARK_ISSUES.map(normalizeIssue);
   const ready = issues.filter((issue) => issue.status === 'ready').length;
   const partial = issues.filter((issue) => issue.status === 'partial').length;
   const notReady = issues.filter((issue) => issue.status === 'not_ready').length;
   const headlineReady = issues.filter((issue) => issue.measurementReadiness === 'headline_ready').length;
   const diagnosticOrSmokeOnly = issues.filter((issue) => issue.measurementReadiness === 'diagnostic_or_smoke_only').length;
   const notMeasurable = issues.filter((issue) => issue.measurementReadiness === 'not_measurable').length;
+  const apiKeyOnlyReady = issues.filter((issue) => issue.apiKeyOnlyReadiness === 'api_key_only_ready').length;
+  const nonKeyBlocked = issues.filter((issue) => issue.apiKeyOnlyReadiness === 'non_key_blockers').length;
   return {
     generatedAt: now.toISOString(),
     summary: {
@@ -223,8 +328,12 @@ export function buildBenchmarkReadinessReport(now = new Date()): BenchmarkReadin
       diagnosticOrSmokeOnly,
       notMeasurable,
       canMeasureEveryOpenBenchmarkIssue: issues.every((issue) => issue.measurementReadiness === 'headline_ready'),
+      apiKeyOnlyReady,
+      nonKeyBlocked,
+      apiKeyOnlyCanMeasureEveryOpenBenchmarkIssue: issues.every((issue) => issue.apiKeyOnlyReadiness === 'api_key_only_ready'),
     },
     issues,
+    additionalPrScopes: [...ADDITIONAL_BENCHMARK_PR_SCOPES],
   };
 }
 
@@ -249,16 +358,18 @@ export function renderBenchmarkReadinessMarkdown(report: BenchmarkReadinessRepor
     `| Headline-measurement-ready | ${report.summary.headlineReady} |`,
     `| Diagnostic/smoke only | ${report.summary.diagnosticOrSmokeOnly} |`,
     `| Not measurable yet | ${report.summary.notMeasurable} |`,
+    `| API-key-only ready | ${report.summary.apiKeyOnlyReady} |`,
+    `| Blocked by non-key work | ${report.summary.nonKeyBlocked} |`,
     '',
     '## Issue matrix',
     '',
-    '| Issue | Status | Measurement readiness | Primary blocker |',
-    '| --- | --- | --- | --- |',
+    '| Issue | Status | Measurement readiness | API-key-only readiness | Primary non-key blocker |',
+    '| --- | --- | --- | --- | --- |',
   ];
 
   for (const issue of report.issues) {
     lines.push(
-      `| [#${issue.issue}](${issue.url}) ${issue.title} | ${issue.status} | ${issue.measurementReadiness} | ${issue.blockers[0] ?? 'none'} |`,
+      `| [#${issue.issue}](${issue.url}) ${issue.title} | ${issue.status} | ${issue.measurementReadiness} | ${issue.apiKeyOnlyReadiness} | ${issue.nonKeyBlockers?.[0] ?? issue.blockers[0] ?? 'none'} |`,
     );
   }
 
@@ -272,8 +383,27 @@ export function renderBenchmarkReadinessMarkdown(report: BenchmarkReadinessRepor
     for (const item of issue.evidence) lines.push(`  - ${item}`);
     lines.push('- Blockers:');
     for (const item of issue.blockers) lines.push(`  - ${item}`);
+    lines.push('- API-key-only readiness: `' + issue.apiKeyOnlyReadiness + '`');
+    if ((issue.requiredSecrets ?? []).length > 0) {
+      lines.push('- Required secrets after non-key blockers clear: `' + (issue.requiredSecrets ?? []).join('`, `') + '`');
+    }
+    lines.push('- Non-key blockers:');
+    for (const item of issue.nonKeyBlockers ?? issue.blockers) lines.push(`  - ${item}`);
     lines.push('- Next actions:');
     for (const item of issue.nextActions) lines.push(`  - ${item}`);
+    lines.push('');
+  }
+
+  lines.push('', '## Additional PR scopes to reach API-key-only readiness', '');
+  lines.push('These are the remaining non-key PRs needed before supplying API keys should be enough to run the full comparison.');
+  lines.push('');
+  for (const scope of report.additionalPrScopes) {
+    lines.push(`### ${scope.id}: ${scope.title}`);
+    lines.push('');
+    lines.push(`- Issues: ${scope.issues.map((issue) => `#${issue}`).join(', ')}`);
+    lines.push(`- Objective: ${scope.objective}`);
+    lines.push('- Acceptance criteria:');
+    for (const criterion of scope.acceptanceCriteria) lines.push(`  - ${criterion}`);
     lines.push('');
   }
 
@@ -290,9 +420,13 @@ export function writeBenchmarkReadinessArtifacts(outDir = path.join(process.cwd(
 
 export function main(argv = process.argv.slice(2)): void {
   const strict = argv.includes('--strict');
+  const apiKeyOnly = argv.includes('--api-key-only');
   const report = writeBenchmarkReadinessArtifacts();
   console.error(renderBenchmarkReadinessMarkdown(report));
   if (strict && !report.summary.canMeasureEveryOpenBenchmarkIssue) {
+    process.exitCode = 1;
+  }
+  if (apiKeyOnly && !report.summary.apiKeyOnlyCanMeasureEveryOpenBenchmarkIssue) {
     process.exitCode = 1;
   }
 }


### PR DESCRIPTION
## Summary

This PR codifies the benchmark measurement gap review after the recent benchmark PR train (#1328-#1336). It does **not** claim the suite is API-key-only ready yet; it adds a fail-closed readiness layer so future API-key-provided runs cannot be mistaken for publishable/headline comparisons while non-key implementation blockers remain.

Changes:

- add API-key-only readiness fields to the benchmark readiness JSON/Markdown artifacts
- remove closed #1305 from the currently-open benchmark issue audit and keep #1310 as the open real-world headline gate
- encode the additional PR ladder needed before API keys are the only remaining gate:
  - PR-A: real LLM episode loops + repetition accounting
  - PR-B: native/passive competitor matrix execution
  - PR-C: live token-efficiency extractors
  - PR-D: real-world completion + fault stress eligibility
  - PR-E: speed/auth/DX live measurement gaps
  - PR-F: full live benchmark orchestration + release gate
- add `npm run bench:api-key-readiness`, which exits non-zero while non-key blockers remain
- document the detailed gap analysis in `docs/benchmarks/api-key-ready-measurement-plan.md`

## Why

Supplying API keys today is still insufficient for a full benchmark comparison because several runners are scaffold/live-unwired or diagnostic-only. This PR makes that explicit in repo-native artifacts and gives follow-up PRs concrete acceptance criteria.

## Verification

- [x] `npm test -- --runTestsByPath tests/benchmark/benchmark-readiness.test.ts --runInBand`
- [x] `npm run build`
- [x] `npm run bench:readiness`
- [x] `npm run bench:api-key-readiness` exits `1` as expected while non-key blockers remain

## Notes

`bench:api-key-readiness` should only pass after the implementation PR ladder clears all non-key blockers; until then it is intentionally fail-closed.
