### PR TITLE
Pin competitor smoke provenance before live runs

### DIFF
--- a/benchmark/COMPETITORS.md
+++ b/benchmark/COMPETITORS.md
@@ -23,15 +23,15 @@ they are not reproducible here. See Epic #1254 "Non-goals".
 
 ## Competitor registry
 
-> Versions below are **placeholders** — each is pinned to an exact version +
-> commit + measurement date by the sub-issue that first benchmarks against it
-> (#1256–#1261). Until a row is pinned by a real run, treat it as TBD.
+> Versions below are the benchmark registry pins used by diagnostic/smoke
+> runners. A row still needs live or recorded-real result evidence before it can
+> become a headline comparison.
 
 | Library | npm package | Pinned version | Commit | Measured at | Used by axes |
 |---|---|---|---|---|---|
-| OpenChrome | `openchrome-mcp` (this repo) | _repo HEAD_ | _per-run git SHA_ | _per run_ | all, #1299 |
-| Playwright | `playwright` | TBD | — | TBD | #A #C #D #E |
-| Puppeteer | `puppeteer` | TBD | — | TBD | #C #D #E #F |
+| OpenChrome | `openchrome-mcp` (this repo) | `1.12.4` | _per-run git SHA_ | _per run_ | all, #1299 |
+| Playwright | `playwright` | `1.60.0` | — | 2026-05-18 smoke runtime | #A #C #D #E |
+| Puppeteer | `puppeteer-core` / `rebrowser-puppeteer-core` | `23.10.3` | — | 2026-05-18 smoke runtime | #C #D #E #F |
 | playwright-mcp | `@playwright/mcp` | `0.0.75` | `8116437ffcfee1309cebc07dd30cee37720d2d19` | 2026-05-15 | #A #B #F #1299-future-live |
 | browser-use | `browser-use` (PyPI) | `0.12.6` | `329c67f069427e928ff81ad52415efdca7692007` | 2026-05-15 | #A #B #D #E |
 | Crawlee | `crawlee` | `3.16.0` | `6c9cd2ff7e7d89ce7685e67f3f919f3cce0fa7a4` | 2026-05-15 | #A #C |

--- a/benchmark/results/BENCHMARK-READINESS.md
+++ b/benchmark/results/BENCHMARK-READINESS.md
@@ -1,6 +1,6 @@
 # Open benchmark issue readiness audit
 
-Generated: 2026-05-17T15:56:16.091Z
+Generated: 2026-05-17T16:01:48.600Z
 
 ## Verdict
 
@@ -17,7 +17,7 @@ Generated: 2026-05-17T15:56:16.091Z
 | Not measurable yet | 5 |
 | API-key-only ready | 0 |
 | Blocked by non-key work | 15 |
-| Stale OpenChrome result artifacts | 10 |
+| Stale OpenChrome result artifacts | 9 |
 
 ## Issue matrix
 
@@ -268,7 +268,6 @@ These committed result artifacts contain OpenChrome version pins older than the 
 | Artifact | Expected OpenChrome version | Found OpenChrome versions |
 | --- | --- | --- |
 | `benchmark/results/auth-usability.json` | `1.12.4` | `1.12.2` |
-| `benchmark/results/competitor-smoke.json` | `1.12.4` | `1.12.2` |
 | `benchmark/results/dx.json` | `1.12.4` | `1.12.2` |
 | `benchmark/results/episode-token-cost.json` | `1.12.4` | `1.12.2` |
 | `benchmark/results/longrun-stability.json` | `1.12.4` | `1.11.0` |

--- a/benchmark/results/benchmark-readiness.json
+++ b/benchmark/results/benchmark-readiness.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-17T15:56:16.091Z",
+  "generatedAt": "2026-05-17T16:01:48.600Z",
   "summary": {
     "totalOpenBenchmarkIssues": 15,
     "ready": 0,
@@ -12,20 +12,13 @@
     "apiKeyOnlyReady": 0,
     "nonKeyBlocked": 15,
     "apiKeyOnlyCanMeasureEveryOpenBenchmarkIssue": false,
-    "staleResultArtifactCount": 10
+    "staleResultArtifactCount": 9
   },
   "artifactFreshness": {
     "currentOpenChromeVersion": "1.12.4",
     "staleArtifacts": [
       {
         "file": "benchmark/results/auth-usability.json",
-        "expectedOpenChromeVersion": "1.12.4",
-        "foundVersions": [
-          "1.12.2"
-        ]
-      },
-      {
-        "file": "benchmark/results/competitor-smoke.json",
         "expectedOpenChromeVersion": "1.12.4",
         "foundVersions": [
           "1.12.2"

--- a/benchmark/results/competitor-smoke.json
+++ b/benchmark/results/competitor-smoke.json
@@ -2,8 +2,8 @@
   "axis": "foundation",
   "schemaVersion": "1.0.0",
   "environment": {
-    "capturedAt": "2026-05-16T16:53:35.104Z",
-    "gitSha": "e21609c4",
+    "capturedAt": "2026-05-17T16:01:19.485Z",
+    "gitSha": "43e6bb9d",
     "gitDirty": true,
     "nodeVersion": "v20.19.6",
     "os": "darwin 25.3.0",
@@ -17,27 +17,27 @@
   "competitors": [
     {
       "name": "OpenChrome",
-      "version": "1.12.2"
+      "version": "1.12.4"
     },
     {
       "name": "Playwright",
-      "version": "operator-pinned-runtime"
+      "version": "1.60.0"
     },
     {
       "name": "Puppeteer",
-      "version": "operator-pinned-runtime"
+      "version": "23.10.3"
     },
     {
       "name": "Crawlee",
-      "version": "operator-pinned-runtime"
+      "version": "3.16.0"
     },
     {
       "name": "playwright-mcp",
-      "version": "operator-pinned-runtime"
+      "version": "0.0.75"
     },
     {
       "name": "browser-use",
-      "version": "operator-pinned-runtime"
+      "version": "0.12.6"
     }
   ],
   "tokenizer": "cl100k_base",
@@ -45,11 +45,15 @@
     {
       "library": "OpenChrome",
       "mode": "dom-stub",
-      "status": "passed",
       "taskContract": "tabs_create/read_page/tabs_close",
       "liveRequired": false,
+      "version": "1.12.4",
+      "versionSource": "package-json",
       "versionPinned": true,
+      "dependencyAvailable": true,
       "sameTaskContract": true,
+      "status": "passed",
+      "skipCategory": "none",
       "durationMs": 0,
       "payloadChars": 13,
       "skipReason": "",
@@ -58,11 +62,15 @@
     {
       "library": "Playwright",
       "mode": "raw-html-cdp",
-      "status": "skipped",
       "taskContract": "tabs_create/read_page/tabs_close",
       "liveRequired": true,
+      "version": "1.60.0",
+      "versionSource": "node-resolution",
       "versionPinned": true,
+      "dependencyAvailable": true,
       "sameTaskContract": true,
+      "status": "skipped",
+      "skipCategory": "not_requested",
       "durationMs": 0,
       "payloadChars": 0,
       "skipReason": "live competitor omitted; pass --include-live with required runtime/credentials",
@@ -71,11 +79,15 @@
     {
       "library": "Puppeteer",
       "mode": "raw-html-cdp",
-      "status": "skipped",
       "taskContract": "tabs_create/read_page/tabs_close",
       "liveRequired": true,
+      "version": "23.10.3",
+      "versionSource": "node-resolution",
       "versionPinned": true,
+      "dependencyAvailable": true,
       "sameTaskContract": true,
+      "status": "skipped",
+      "skipCategory": "not_requested",
       "durationMs": 0,
       "payloadChars": 0,
       "skipReason": "live competitor omitted; pass --include-live with required runtime/credentials",
@@ -84,12 +96,16 @@
     {
       "library": "Crawlee",
       "mode": "cheerio-text",
-      "status": "passed",
       "taskContract": "tabs_create/read_page/tabs_close",
       "liveRequired": false,
+      "version": "3.16.0",
+      "versionSource": "node-resolution",
       "versionPinned": true,
+      "dependencyAvailable": true,
       "sameTaskContract": true,
-      "durationMs": 38,
+      "status": "passed",
+      "skipCategory": "none",
+      "durationMs": 53,
       "payloadChars": 3154,
       "skipReason": "",
       "failure": ""
@@ -97,11 +113,15 @@
     {
       "library": "playwright-mcp",
       "mode": "native-mcp",
-      "status": "skipped",
       "taskContract": "tabs_create/read_page/tabs_close",
       "liveRequired": true,
+      "version": "0.0.75",
+      "versionSource": "node-resolution",
       "versionPinned": true,
+      "dependencyAvailable": true,
       "sameTaskContract": true,
+      "status": "skipped",
+      "skipCategory": "not_requested",
       "durationMs": 0,
       "payloadChars": 0,
       "skipReason": "live competitor omitted; pass --include-live with required runtime/credentials",
@@ -110,11 +130,15 @@
     {
       "library": "browser-use",
       "mode": "python-bridge",
-      "status": "skipped",
       "taskContract": "tabs_create/read_page/tabs_close",
       "liveRequired": true,
+      "version": "0.12.6",
+      "versionSource": "benchmark-registry",
       "versionPinned": true,
+      "dependencyAvailable": false,
       "sameTaskContract": true,
+      "status": "skipped",
+      "skipCategory": "not_requested",
       "durationMs": 0,
       "payloadChars": 0,
       "skipReason": "live competitor omitted; pass --include-live with required runtime/credentials",

--- a/tests/benchmark/run-competitor-smoke.test.ts
+++ b/tests/benchmark/run-competitor-smoke.test.ts
@@ -15,7 +15,12 @@ describe('competitor smoke matrix', () => {
     expect(rows.map((row) => row.library).sort()).toEqual(['Crawlee', 'OpenChrome', 'Playwright', 'Puppeteer', 'browser-use', 'playwright-mcp'].sort());
     expect(rows.find((row) => row.library === 'OpenChrome')?.status).toBe('passed');
     expect(rows.find((row) => row.library === 'Crawlee')?.status).toBe('passed');
-    expect(rows.find((row) => row.library === 'Playwright')?.status).toBe('skipped');
+    const playwright = rows.find((row) => row.library === 'Playwright');
+    expect(playwright?.status).toBe('skipped');
+    expect(playwright?.skipCategory).toBe('not_requested');
+    expect(playwright?.version).toMatch(/^[0-9]+\.[0-9]+\.[0-9]+/);
+    expect(playwright?.versionPinned).toBe(true);
+    expect(rows.find((row) => row.library === 'OpenChrome')?.version).toBe('1.12.4');
     expect(rows.every((row) => row.sameTaskContract)).toBe(true);
   }, 30000);
 });

--- a/tests/benchmark/run-competitor-smoke.ts
+++ b/tests/benchmark/run-competitor-smoke.ts
@@ -10,6 +10,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { spawnSync } from 'child_process';
 
 import { MCPAdapter } from './benchmark-runner';
 import { buildResultEnvelope, assertValidResultEnvelope } from './utils/result-envelope';
@@ -29,6 +30,8 @@ const OUTPUT_PATH = path.join(process.cwd(), 'benchmark', 'results', 'competitor
 
 export type SmokeLibrary = 'openchrome' | 'playwright' | 'puppeteer' | 'crawlee' | 'playwright-mcp' | 'browser-use' | 'all';
 export type SmokeStatus = 'passed' | 'failed' | 'skipped';
+export type SmokeSkipCategory = 'none' | 'not_requested' | 'dependency_missing' | 'runtime_missing' | 'not_wired';
+export type SmokeVersionSource = 'package-json' | 'node-resolution' | 'python-importlib' | 'benchmark-registry' | 'unknown';
 
 export interface CompetitorSmokeOptions {
   includeLive: boolean;
@@ -42,7 +45,11 @@ export interface CompetitorSmokeRow {
   status: SmokeStatus;
   taskContract: 'tabs_create/read_page/tabs_close';
   liveRequired: boolean;
+  version: string;
+  versionSource: SmokeVersionSource;
   versionPinned: boolean;
+  dependencyAvailable: boolean;
+  skipCategory: SmokeSkipCategory;
   sameTaskContract: boolean;
   durationMs: number;
   payloadChars: number;
@@ -54,10 +61,26 @@ interface AdapterSpec {
   library: string;
   mode: string;
   liveRequired: boolean;
+  packageName?: string;
   adapterFactory: () => MCPAdapter;
 }
 
+interface VersionInfo {
+  version: string;
+  source: SmokeVersionSource;
+  dependencyAvailable: boolean;
+}
+
 const LIBRARIES: readonly Exclude<SmokeLibrary, 'all'>[] = ['openchrome', 'playwright', 'puppeteer', 'crawlee', 'playwright-mcp', 'browser-use'];
+
+const REGISTRY_PINNED_VERSIONS: Readonly<Record<string, string>> = {
+  OpenChrome: readRepoVersion(),
+  Playwright: '1.49.0',
+  Puppeteer: '23.10.3',
+  Crawlee: '3.16.0',
+  'playwright-mcp': '0.0.75',
+  'browser-use': '0.12.6',
+};
 
 function flagValue(argv: string[], name: string): string | undefined {
   const idx = argv.indexOf(name);
@@ -96,10 +119,10 @@ function specs(options: CompetitorSmokeOptions): AdapterSpec[] {
     openchrome: options.includeLive
       ? { library: 'OpenChrome', mode: 'dom-live', liveRequired: true, adapterFactory: () => new OpenChromeRealAdapter({ mode: 'dom' }) }
       : { library: 'OpenChrome', mode: 'dom-stub', liveRequired: false, adapterFactory: () => new OpenChromeStubAdapter({ mode: 'dom' }) },
-    playwright: { library: 'Playwright', mode: 'raw-html-cdp', liveRequired: true, adapterFactory: () => new PlaywrightAdapter() },
-    puppeteer: { library: 'Puppeteer', mode: 'raw-html-cdp', liveRequired: true, adapterFactory: () => new PuppeteerAdapter() },
-    crawlee: { library: 'Crawlee', mode: 'cheerio-text', liveRequired: false, adapterFactory: () => new CrawleeAdapter() },
-    'playwright-mcp': { library: 'playwright-mcp', mode: 'native-mcp', liveRequired: true, adapterFactory: () => new PlaywrightMcpAdapter({ serverPath: process.env.PLAYWRIGHT_MCP_SERVER_PATH, cdpEndpoint: process.env.OPENCHROME_BENCH_CDP_ENDPOINT }) },
+    playwright: { library: 'Playwright', mode: 'raw-html-cdp', liveRequired: true, packageName: 'playwright', adapterFactory: () => new PlaywrightAdapter() },
+    puppeteer: { library: 'Puppeteer', mode: 'raw-html-cdp', liveRequired: true, packageName: 'puppeteer-core', adapterFactory: () => new PuppeteerAdapter() },
+    crawlee: { library: 'Crawlee', mode: 'cheerio-text', liveRequired: false, packageName: 'crawlee', adapterFactory: () => new CrawleeAdapter() },
+    'playwright-mcp': { library: 'playwright-mcp', mode: 'native-mcp', liveRequired: true, packageName: '@playwright/mcp', adapterFactory: () => new PlaywrightMcpAdapter({ serverPath: process.env.PLAYWRIGHT_MCP_SERVER_PATH, cdpEndpoint: process.env.OPENCHROME_BENCH_CDP_ENDPOINT }) },
     'browser-use': { library: 'browser-use', mode: 'python-bridge', liveRequired: true, adapterFactory: () => new BrowserUseAdapter({ bridgeScriptPath: process.env.BROWSER_USE_BRIDGE_SCRIPT, python: process.env.BROWSER_USE_PYTHON }) },
   };
   return requested.map((library) => all[library]);
@@ -119,6 +142,61 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: str
   }
 }
 
+
+function packageVersion(packageName: string): VersionInfo {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const packageJsonPath = require.resolve(`${packageName}/package.json`, { paths: [process.cwd()] });
+    const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as { version?: unknown };
+    if (typeof pkg.version === 'string' && pkg.version.trim().length > 0) {
+      return { version: pkg.version.trim(), source: 'node-resolution', dependencyAvailable: true };
+    }
+  } catch {
+    // Fall through to registry pin / unavailable status.
+  }
+  return {
+    version: REGISTRY_PINNED_VERSIONS[packageNameToLibrary(packageName)] ?? 'unknown',
+    source: 'benchmark-registry',
+    dependencyAvailable: false,
+  };
+}
+
+function packageNameToLibrary(packageName: string): string {
+  if (packageName === 'playwright') return 'Playwright';
+  if (packageName === 'puppeteer-core') return 'Puppeteer';
+  if (packageName === 'crawlee') return 'Crawlee';
+  if (packageName === '@playwright/mcp') return 'playwright-mcp';
+  return packageName;
+}
+
+function browserUseVersion(python = process.env.BROWSER_USE_PYTHON ?? (process.platform === 'win32' ? 'python' : 'python3')): VersionInfo {
+  const result = spawnSync(python, ['-c', "import importlib.metadata; print(importlib.metadata.version('browser-use'))"], {
+    encoding: 'utf8',
+    timeout: 3000,
+  });
+  if (result.status === 0 && result.stdout.trim().length > 0) {
+    return { version: result.stdout.trim(), source: 'python-importlib', dependencyAvailable: true };
+  }
+  return {
+    version: REGISTRY_PINNED_VERSIONS['browser-use'],
+    source: 'benchmark-registry',
+    dependencyAvailable: false,
+  };
+}
+
+function versionInfoFor(spec: AdapterSpec): VersionInfo {
+  if (spec.library === 'OpenChrome') {
+    return { version: readRepoVersion(), source: 'package-json', dependencyAvailable: true };
+  }
+  if (spec.library === 'browser-use') return browserUseVersion();
+  if (spec.packageName) return packageVersion(spec.packageName);
+  return { version: REGISTRY_PINNED_VERSIONS[spec.library] ?? 'unknown', source: 'benchmark-registry', dependencyAvailable: false };
+}
+
+function isPinnedVersion(version: string): boolean {
+  return version.length > 0 && !/^(unknown|TBD|operator-pinned-runtime)$/i.test(version);
+}
+
 function parseTabId(text: string | undefined): string {
   if (!text) throw new Error('tabs_create returned no text payload');
   const parsed = JSON.parse(text);
@@ -127,18 +205,39 @@ function parseTabId(text: string | undefined): string {
 }
 
 async function runOne(spec: AdapterSpec, url: string, options: CompetitorSmokeOptions): Promise<CompetitorSmokeRow> {
+  const versionInfo = versionInfoFor(spec);
+  const base = {
+    library: spec.library,
+    mode: spec.mode,
+    taskContract: 'tabs_create/read_page/tabs_close' as const,
+    liveRequired: spec.liveRequired,
+    version: versionInfo.version,
+    versionSource: versionInfo.source,
+    versionPinned: isPinnedVersion(versionInfo.version),
+    dependencyAvailable: versionInfo.dependencyAvailable,
+    sameTaskContract: true,
+  };
+
   if (spec.liveRequired && !options.includeLive) {
     return {
-      library: spec.library,
-      mode: spec.mode,
+      ...base,
       status: 'skipped',
-      taskContract: 'tabs_create/read_page/tabs_close',
-      liveRequired: true,
-      versionPinned: true,
-      sameTaskContract: true,
+      skipCategory: 'not_requested',
       durationMs: 0,
       payloadChars: 0,
       skipReason: 'live competitor omitted; pass --include-live with required runtime/credentials',
+      failure: '',
+    };
+  }
+
+  if (!versionInfo.dependencyAvailable) {
+    return {
+      ...base,
+      status: 'skipped',
+      skipCategory: 'dependency_missing',
+      durationMs: 0,
+      payloadChars: 0,
+      skipReason: `${spec.library} dependency is not installed or not resolvable in this benchmark runtime`,
       failure: '',
     };
   }
@@ -155,13 +254,9 @@ async function runOne(spec: AdapterSpec, url: string, options: CompetitorSmokeOp
     await withTimeout(adapter.callTool('tabs_close', { tabId }), options.timeoutMs, `${spec.library} tabs_close`);
     const payload = read.content?.map((entry) => entry.text ?? '').join('\n') ?? '';
     return {
-      library: spec.library,
-      mode: spec.mode,
+      ...base,
       status: 'passed',
-      taskContract: 'tabs_create/read_page/tabs_close',
-      liveRequired: spec.liveRequired,
-      versionPinned: true,
-      sameTaskContract: true,
+      skipCategory: 'none',
       durationMs: Date.now() - started,
       payloadChars: payload.length,
       skipReason: '',
@@ -169,13 +264,9 @@ async function runOne(spec: AdapterSpec, url: string, options: CompetitorSmokeOp
     };
   } catch (err) {
     return {
-      library: spec.library,
-      mode: spec.mode,
+      ...base,
       status: 'failed',
-      taskContract: 'tabs_create/read_page/tabs_close',
-      liveRequired: spec.liveRequired,
-      versionPinned: true,
-      sameTaskContract: true,
+      skipCategory: 'none',
       durationMs: Date.now() - started,
       payloadChars: 0,
       skipReason: '',
@@ -210,11 +301,13 @@ export async function runCompetitorSmokeMatrix(options: CompetitorSmokeOptions):
 function formatReport(rows: readonly CompetitorSmokeRow[]): string {
   return [
     'Competitor smoke matrix (#1255) — same tabs_create/read_page/tabs_close contract',
-    'library          mode             status    payload  note',
+    'library          mode             status    version          skip-category       payload  note',
     ...rows.map((row) => [
       row.library.padEnd(16),
       row.mode.padEnd(16),
       row.status.padEnd(8),
+      row.version.padEnd(16),
+      row.skipCategory.padEnd(19),
       String(row.payloadChars).padStart(7),
       row.skipReason || row.failure,
     ].join(' ')),
@@ -224,7 +317,7 @@ function formatReport(rows: readonly CompetitorSmokeRow[]): string {
 export async function main(argv = process.argv.slice(2)): Promise<void> {
   const options = parseSmokeArgs(argv);
   const rows = await runCompetitorSmokeMatrix(options);
-  const competitors = Array.from(new Set(rows.map((row) => row.library))).map((name) => ({ name, version: name === 'OpenChrome' ? readRepoVersion() : 'operator-pinned-runtime' }));
+  const competitors = rows.map((row) => ({ name: row.library, version: row.version }));
   const envelope = buildResultEnvelope({
     axis: 'foundation',
     environment: captureEnvironment(),


### PR DESCRIPTION
## Summary

- strengthens `bench:competitor-smoke` to capture concrete competitor versions and version sources
- records dependency availability plus explicit skip categories (`not_requested`, `dependency_missing`, etc.) per row
- updates `benchmark/COMPETITORS.md` from placeholder pins to the current smoke/runtime registry pins
- refreshes `competitor-smoke.json` and readiness artifacts; stale artifact count drops because the smoke artifact now pins OpenChrome `1.12.4`

## Stack

- Base: #1338 (`benchmark/pr1-contract-hardening`)
- This is PR2 of the validated benchmark plan.

## Scope boundaries

In scope:
- competitor smoke/version provenance
- dependency detection and visible diagnostic skips
- smoke result artifact refresh

Out of scope:
- full `--include-live` Chrome/CDP execution
- native browser-use/playwright-mcp LLM loops
- headline comparisons
- OpenChrome product/core changes

## Verification

- [x] `npm run bench:competitor-smoke`
- [x] `npm test -- --runTestsByPath tests/benchmark/run-competitor-smoke.test.ts tests/benchmark/adapters/browser-use-adapter.test.ts tests/benchmark/adapters/playwright-mcp-adapter.test.ts tests/benchmark/benchmark-readiness.test.ts --runInBand`
- [x] `npm run bench:readiness`
- [x] `npm run build`
- [x] `git diff --check`
