### PR TITLE
fix(cdp): reuse startup NTP tab on first createPage to prevent extra blank tab

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -1150,7 +1150,7 @@ export class CDPClient {
   private getChromeLifecycleMode(): 'isolated' | 'attach' {
     const launcher = getChromeLauncher(this.port) as { getInstance?: () => { launchMode?: string } | null };
     const instance = typeof launcher.getInstance === 'function' ? launcher.getInstance() : null;
-    return instance?.launchMode === 'attach' ? 'attach' : 'isolated';
+    return instance?.launchMode === 'isolated' ? 'isolated' : 'attach';
   }
 
   /**

--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -1143,6 +1143,17 @@ export class CDPClient {
   static readonly DEFAULT_VIEWPORT = DEFAULT_VIEWPORT;
 
   /**
+   * Lifecycle ownership of the underlying Chrome process. 'isolated' means
+   * OpenChrome spawned this Chrome (and therefore owns/produced the startup
+   * NTP); 'attach' means we connected to a user-started Chrome.
+   */
+  private getChromeLifecycleMode(): 'isolated' | 'attach' {
+    const launcher = getChromeLauncher(this.port) as { getInstance?: () => { launchMode?: string } | null };
+    const instance = typeof launcher.getInstance === 'function' ? launcher.getInstance() : null;
+    return instance?.launchMode === 'attach' ? 'attach' : 'isolated';
+  }
+
+  /**
    * Create a new isolated browser context for session isolation
    * Each context has its own cookies, localStorage, sessionStorage
    */
@@ -1592,39 +1603,76 @@ export class CDPClient {
         }),
       ]) as Page;
     } else {
-      // Create page in Chrome's default context
-      let newPageTid2: ReturnType<typeof setTimeout>;
-      page = await Promise.race([
-        browser.newPage().finally(() => clearTimeout(newPageTid2)),
-        new Promise<never>((_, reject) => {
-          newPageTid2 = setTimeout(() => reject(new Error(`newPage() timed out after ${DEFAULT_NEW_PAGE_TIMEOUT_MS}ms`)), DEFAULT_NEW_PAGE_TIMEOUT_MS);
-        }),
-      ]) as Page;
-
-      // Copy cookies from an authenticated page (skip for pool pre-warming to avoid
-      // CDP session conflicts and unnecessary overhead on about:blank pages).
-      // The global skipCookieBridge flag serves as a manual override escape hatch.
-      // Overall timeout prevents cascading hangs from unresponsive source tabs.
-      if (!skipCookieBridge && !getGlobalConfig().skipCookieBridge) {
-        const cookieScan = await this.findAuthenticatedPageTarget(targetDomain);
-        if (cookieScan.status === 'partial' && !cookieScan.targetId) {
-          console.error(
-            `[CDPClient] Cookie bridge proceeding without copied cookies: ${cookieScan.warning ?? 'cookie scan incomplete'}`,
-          );
+      // First-call NTP reuse: when this CDPClient hasn't created any managed
+      // pages yet AND Chrome was OpenChrome-spawned AND there's exactly one
+      // untracked page-type target whose URL looks like the startup New Tab
+      // Page, navigate THAT tab instead of opening a second one. Avoids the
+      // "extra blank tab" race that the post-hoc prune in _createTargetImpl
+      // tries (imperfectly) to clean up.
+      let reused: Page | null = null;
+      if (this.targetIdIndex.size === 0 && this.getChromeLifecycleMode() === 'isolated') {
+        const candidates = browser.targets().filter(t => {
+          if (t.type() !== 'page') return false;
+          const tid = getTargetId(t);
+          return !!tid && !this.targetIdIndex.has(tid);
+        });
+        if (candidates.length === 1) {
+          const candidateUrl = candidates[0].url();
+          const isStartupBlank =
+            candidateUrl === '' ||
+            candidateUrl === 'about:blank' ||
+            candidateUrl === 'chrome://newtab/' ||
+            candidateUrl.startsWith('chrome://new-tab-page');
+          if (isStartupBlank) {
+            try {
+              reused = await candidates[0].page();
+            } catch {
+              reused = null;
+            }
+          }
         }
-        if (cookieScan.targetId) {
-          let cookieCopyTid: ReturnType<typeof setTimeout> | undefined;
-          await Promise.race([
-            this.copyCookiesViaCDP(cookieScan.targetId, page),
-            new Promise<void>((resolve) => {
-              cookieCopyTid = setTimeout(() => {
-                console.error(`[CDPClient] Cookie copy timed out after ${DEFAULT_COOKIE_COPY_TIMEOUT_MS}ms, proceeding without cookies`);
-                resolve();
-              }, DEFAULT_COOKIE_COPY_TIMEOUT_MS);
-            }),
-          ]).finally(() => {
-            if (cookieCopyTid) clearTimeout(cookieCopyTid);
-          });
+      }
+
+      if (reused) {
+        page = reused;
+        console.error(`[CDPClient] Reused startup NTP target ${getTargetId(reused.target())} for first createPage (URL: ${reused.url()})`);
+        // Skip cookie bridge on reuse: this is the very first managed page on
+        // this Chrome, so there are no authenticated source tabs to copy from.
+      } else {
+        // Create page in Chrome's default context
+        let newPageTid2: ReturnType<typeof setTimeout>;
+        page = await Promise.race([
+          browser.newPage().finally(() => clearTimeout(newPageTid2)),
+          new Promise<never>((_, reject) => {
+            newPageTid2 = setTimeout(() => reject(new Error(`newPage() timed out after ${DEFAULT_NEW_PAGE_TIMEOUT_MS}ms`)), DEFAULT_NEW_PAGE_TIMEOUT_MS);
+          }),
+        ]) as Page;
+
+        // Copy cookies from an authenticated page (skip for pool pre-warming to avoid
+        // CDP session conflicts and unnecessary overhead on about:blank pages).
+        // The global skipCookieBridge flag serves as a manual override escape hatch.
+        // Overall timeout prevents cascading hangs from unresponsive source tabs.
+        if (!skipCookieBridge && !getGlobalConfig().skipCookieBridge) {
+          const cookieScan = await this.findAuthenticatedPageTarget(targetDomain);
+          if (cookieScan.status === 'partial' && !cookieScan.targetId) {
+            console.error(
+              `[CDPClient] Cookie bridge proceeding without copied cookies: ${cookieScan.warning ?? 'cookie scan incomplete'}`,
+            );
+          }
+          if (cookieScan.targetId) {
+            let cookieCopyTid: ReturnType<typeof setTimeout> | undefined;
+            await Promise.race([
+              this.copyCookiesViaCDP(cookieScan.targetId, page),
+              new Promise<void>((resolve) => {
+                cookieCopyTid = setTimeout(() => {
+                  console.error(`[CDPClient] Cookie copy timed out after ${DEFAULT_COOKIE_COPY_TIMEOUT_MS}ms, proceeding without cookies`);
+                  resolve();
+                }, DEFAULT_COOKIE_COPY_TIMEOUT_MS);
+              }),
+            ]).finally(() => {
+              if (cookieCopyTid) clearTimeout(cookieCopyTid);
+            });
+          }
         }
       }
     }

--- a/tests/cdp/create-page-startup-reuse.test.ts
+++ b/tests/cdp/create-page-startup-reuse.test.ts
@@ -1,0 +1,240 @@
+/// <reference types="jest" />
+
+// Tests for the first-call NTP reuse path in CDPClient.createPage().
+// See issue #1346: managed Chrome auto-opens a startup New Tab Page.
+// On the very first createPage() per CDPClient, we navigate that
+// existing tab instead of opening a second one.
+
+jest.mock('puppeteer-core', () => ({
+  __esModule: true,
+  default: { connect: jest.fn() },
+}));
+
+const launcherInstance: { launchMode: 'isolated' | 'attach' } = { launchMode: 'isolated' };
+jest.mock('../../src/chrome/launcher', () => ({
+  getChromeLauncher: jest.fn().mockReturnValue({
+    ensureChrome: jest.fn(),
+    invalidateInstance: jest.fn(),
+    getInstance: jest.fn(() => launcherInstance),
+  }),
+}));
+
+jest.mock('../../src/config/global', () => ({
+  getGlobalConfig: jest.fn().mockReturnValue({ port: 9222, autoLaunch: false, skipCookieBridge: true }),
+}));
+
+const smartGoto = jest.fn();
+jest.mock('../../src/utils/smart-goto', () => ({
+  smartGoto: (...args: unknown[]) => smartGoto(...args),
+}));
+
+jest.mock('../../src/utils/ref-id-manager', () => ({
+  getRefIdManager: jest.fn(() => ({
+    clearTargetRefsAllSessions: jest.fn(),
+  })),
+}));
+
+import { CDPClient } from '../../src/cdp/client';
+
+type MockPage = {
+  target: jest.Mock;
+  isClosed: jest.Mock<boolean, []>;
+  url: jest.Mock<string, []>;
+  on: jest.Mock;
+  once: jest.Mock;
+  evaluateOnNewDocument: jest.Mock<Promise<void>, [unknown]>;
+  setViewport: jest.Mock<Promise<void>, [unknown]>;
+  createCDPSession: jest.Mock;
+  close: jest.Mock<Promise<void>, []>;
+  mainFrame: jest.Mock;
+};
+
+function makeTarget(targetId: string, page?: MockPage, type = 'page', url = '') {
+  return {
+    _targetId: targetId,
+    type: jest.fn(() => type),
+    url: jest.fn(() => url),
+    page: jest.fn(async () => page ?? null),
+    createCDPSession: jest.fn(async () => ({ send: jest.fn(async () => ({})), detach: jest.fn(async () => undefined) })),
+  };
+}
+
+function makePage(targetId: string, url = 'about:blank'): MockPage {
+  const session = { send: jest.fn(async () => ({})), detach: jest.fn(async () => undefined) };
+  const page = {} as MockPage;
+  const target = makeTarget(targetId, undefined, 'page', url);
+  Object.assign(page, {
+    target: jest.fn(() => target),
+    isClosed: jest.fn(() => false),
+    url: jest.fn(() => url),
+    on: jest.fn(),
+    once: jest.fn(),
+    evaluateOnNewDocument: jest.fn(async () => undefined),
+    setViewport: jest.fn(async () => undefined),
+    createCDPSession: jest.fn(async () => session),
+    close: jest.fn(async () => undefined),
+    mainFrame: jest.fn(() => ({})),
+  });
+  // Wire target.page() to return this page (so reuse path can resolve it).
+  (target.page as jest.Mock).mockImplementation(async () => page);
+  return page;
+}
+
+function makeBrowser(targets: ReturnType<typeof makeTarget>[] = []) {
+  return {
+    isConnected: jest.fn(() => true),
+    pages: jest.fn(async () => []),
+    targets: jest.fn(() => targets),
+    newPage: jest.fn(async () => makePage('newly-created-target', 'about:blank')),
+    target: jest.fn(() => makeTarget('browser-target')),
+    on: jest.fn(),
+    removeAllListeners: jest.fn(),
+    disconnect: jest.fn(async () => undefined),
+  };
+}
+
+function connectedClient(browser: ReturnType<typeof makeBrowser>) {
+  const client = new CDPClient({ port: 9222 });
+  (client as unknown as { browser: unknown }).browser = browser;
+  (client as unknown as { connectionState: string }).connectionState = 'connected';
+  return client;
+}
+
+describe('CDPClient.createPage first-call NTP reuse (#1346)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    launcherInstance.launchMode = 'isolated';
+    smartGoto.mockReset();
+    smartGoto.mockResolvedValue(undefined);
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('reuses the startup NTP target when URL is chrome://newtab/', async () => {
+    const ntpPage = makePage('ntp-target', 'chrome://newtab/');
+    const ntpTarget = ntpPage.target() as ReturnType<typeof makeTarget>;
+    const browser = makeBrowser([ntpTarget]);
+    const client = connectedClient(browser);
+
+    const page = await client.createPage('https://example.test/');
+
+    expect(browser.newPage).not.toHaveBeenCalled();
+    expect(page).toBe(ntpPage);
+    expect(smartGoto).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses the startup target when URL is about:blank', async () => {
+    const ntpPage = makePage('ntp-target', 'about:blank');
+    const ntpTarget = ntpPage.target() as ReturnType<typeof makeTarget>;
+    const browser = makeBrowser([ntpTarget]);
+    const client = connectedClient(browser);
+
+    const page = await client.createPage('https://example.test/');
+
+    expect(browser.newPage).not.toHaveBeenCalled();
+    expect(page).toBe(ntpPage);
+  });
+
+  it('reuses the startup target when URL starts with chrome://new-tab-page', async () => {
+    const ntpPage = makePage('ntp-target', 'chrome://new-tab-page/anything');
+    const ntpTarget = ntpPage.target() as ReturnType<typeof makeTarget>;
+    const browser = makeBrowser([ntpTarget]);
+    const client = connectedClient(browser);
+
+    const page = await client.createPage('https://example.test/');
+
+    expect(browser.newPage).not.toHaveBeenCalled();
+    expect(page).toBe(ntpPage);
+  });
+
+  it('does NOT reuse when targetIdIndex already has entries (second createPage)', async () => {
+    const ntpPage = makePage('ntp-target', 'chrome://newtab/');
+    const ntpTarget = ntpPage.target() as ReturnType<typeof makeTarget>;
+    const browser = makeBrowser([ntpTarget]);
+    const client = connectedClient(browser);
+
+    // Simulate that a page already exists in the index (second-call scenario).
+    const existingPage = makePage('existing-target', 'https://existing.test/');
+    (client as unknown as { targetIdIndex: Map<string, unknown> }).targetIdIndex.set(
+      'existing-target',
+      existingPage,
+    );
+
+    const created = makePage('fresh-target', 'about:blank');
+    browser.newPage.mockResolvedValueOnce(created);
+
+    const page = await client.createPage('https://example.test/');
+
+    expect(browser.newPage).toHaveBeenCalledTimes(1);
+    expect(page).toBe(created);
+  });
+
+  it('does NOT reuse when Chrome lifecycle mode is "attach"', async () => {
+    launcherInstance.launchMode = 'attach';
+    const ntpPage = makePage('ntp-target', 'chrome://newtab/');
+    const ntpTarget = ntpPage.target() as ReturnType<typeof makeTarget>;
+    const browser = makeBrowser([ntpTarget]);
+    const client = connectedClient(browser);
+
+    const created = makePage('fresh-target', 'about:blank');
+    browser.newPage.mockResolvedValueOnce(created);
+
+    const page = await client.createPage('https://example.test/');
+
+    expect(browser.newPage).toHaveBeenCalledTimes(1);
+    expect(page).toBe(created);
+  });
+
+  it('does NOT reuse when there are multiple untracked page candidates', async () => {
+    const ntpPage = makePage('ntp-target', 'chrome://newtab/');
+    const otherPage = makePage('other-target', 'about:blank');
+    const browser = makeBrowser([
+      ntpPage.target() as ReturnType<typeof makeTarget>,
+      otherPage.target() as ReturnType<typeof makeTarget>,
+    ]);
+    const client = connectedClient(browser);
+
+    const created = makePage('fresh-target', 'about:blank');
+    browser.newPage.mockResolvedValueOnce(created);
+
+    const page = await client.createPage('https://example.test/');
+
+    expect(browser.newPage).toHaveBeenCalledTimes(1);
+    expect(page).toBe(created);
+  });
+
+  it('does NOT reuse when the candidate URL is a real site (not blank-like)', async () => {
+    const realPage = makePage('real-target', 'https://example.com');
+    const browser = makeBrowser([realPage.target() as ReturnType<typeof makeTarget>]);
+    const client = connectedClient(browser);
+
+    const created = makePage('fresh-target', 'about:blank');
+    browser.newPage.mockResolvedValueOnce(created);
+
+    const page = await client.createPage('https://example.test/');
+
+    expect(browser.newPage).toHaveBeenCalledTimes(1);
+    expect(page).toBe(created);
+  });
+
+  it('does NOT enter reuse branch when context argument is non-null', async () => {
+    const ntpPage = makePage('ntp-target', 'chrome://newtab/');
+    const ntpTarget = ntpPage.target() as ReturnType<typeof makeTarget>;
+    const browser = makeBrowser([ntpTarget]);
+    const client = connectedClient(browser);
+
+    const contextPage = makePage('context-target', 'about:blank');
+    const context = {
+      newPage: jest.fn(async () => contextPage),
+    };
+
+    const page = await client.createPage('https://example.test/', context as never);
+
+    expect(context.newPage).toHaveBeenCalledTimes(1);
+    expect(browser.newPage).not.toHaveBeenCalled();
+    expect(page).toBe(contextPage);
+  });
+});

--- a/tests/cdp/create-page-startup-reuse.test.ts
+++ b/tests/cdp/create-page-startup-reuse.test.ts
@@ -220,6 +220,24 @@ describe('CDPClient.createPage first-call NTP reuse (#1346)', () => {
     expect(page).toBe(created);
   });
 
+  it('falls back to browser.newPage() when target.page() rejects', async () => {
+    // Single untracked NTP target, but target.page() throws (e.g. target closed during race).
+    const ntpTarget = makeTarget('ntp-target', undefined, 'page', 'chrome://newtab/');
+    (ntpTarget.page as jest.Mock).mockRejectedValueOnce(new Error('target closed'));
+    const browser = makeBrowser([ntpTarget]);
+    const client = connectedClient(browser);
+
+    const ntpPage = makePage('newly-created-target', 'about:blank');
+    browser.newPage.mockResolvedValueOnce(ntpPage);
+
+    const result = await client.createPage(undefined, null, true);
+
+    // newPage was called as fallback
+    expect(browser.newPage).toHaveBeenCalledTimes(1);
+    // Returned page is the fresh one, not the NTP target's page
+    expect(result).not.toBe(await ntpTarget.page().catch(() => null));
+  });
+
   it('does NOT enter reuse branch when context argument is non-null', async () => {
     const ntpPage = makePage('ntp-target', 'chrome://newtab/');
     const ntpTarget = ntpPage.target() as ReturnType<typeof makeTarget>;


### PR DESCRIPTION
## Summary
- Managed Chrome auto-opens a New Tab Page (`chrome://newtab/` / `chrome://new-tab-page/...`) on launch. `CDPClient.createPage()` then unconditionally called `browser.newPage()` in the default-context branch, producing "NTP + requested URL" = two visible tabs after every `tabs_create` (and the first `navigate`/`crawl`/`crawl_sitemap`/`batch_paginate`/`validate_page`).
- The post-hoc 500 ms prune in `_createTargetImpl` tried to clean up the leftover but races on `about:blank ↔ chrome://newtab/` URL transitions and the `existingTargetIds.size === 1` guard, leaving a ghost blank tab or a brief flicker.
- This patch fixes the bug at its source: when this `CDPClient` has not created any managed pages yet, Chrome was OpenChrome-spawned (`lifecycle === 'isolated'`), and exactly one untracked page-type target exists whose URL is NTP-like, navigate THAT tab instead of opening a second one.

## Why this is the right scope
Single surgical change in `src/cdp/client.ts` (default-context branch of `createPage()` only). Four-gate guard ensures zero behavior change for every other path:

| Gate | Protects |
|---|---|
| `context == null` | Named contexts (#848) take `context.newPage()` — never reused |
| `getChromeLifecycleMode() === 'isolated'` | Attach mode (user-owned Chrome) — never reuses user tabs |
| `targetIdIndex.size === 0` | Only the very first `createPage()` per CDPClient — multi-Chrome (profileDirectory) safe |
| Exactly one untracked page candidate with URL ∈ {NTP, about:blank, ''} | `--restore-last-session`, popups, and other multi-tab startups auto-fallback |

If the gates do not hold, the existing `browser.newPage()` + cookie-bridge path runs **byte-identically** as before.

The reviewer also asked for a tighter defensive default in the lifecycle helper: when the launcher cache is mid-invalidation and `getInstance()` returns null, we now default to `'attach'` (safer) so reuse cannot misfire in attach mode under a reconnect race.

## Out of scope (separate PRs)
- `createTargetStealth` startup-NTP reuse — separate CDP path with its own anti-bot ordering constraints
- `_createTargetImpl` prune simplification — keeps the Site Isolation orphan-blank cleanup responsibility intact
- Passing initial URL to Chrome launcher — unnecessary now
- Pool prewarm redesign (`minPoolSize` defaults to 0 so user-visible behavior is unchanged)

## Test plan
- [x] First `createPage` (managed isolated, default context, single NTP target): reuses NTP — `browser.newPage()` is not called, returned page is the NTP
- [x] First `createPage` with URL `about:blank` candidate: reuses NTP
- [x] First `createPage` with URL `chrome://new-tab-page/anything` candidate: reuses NTP
- [x] Second `createPage` (`targetIdIndex` non-empty): no reuse, `browser.newPage()` called
- [x] Attach mode (`launchMode === 'attach'`): no reuse
- [x] Multiple untracked page candidates (user has extra tabs): no reuse
- [x] Candidate URL is `https://example.com` (not blank-like): no reuse
- [x] `context` argument is non-null (named context path): reuse branch not entered, `context.newPage()` called
- [x] `target.page()` rejects mid-race (closed target): cleanly falls back to `browser.newPage()`
- [x] `npm run build` clean
- [x] `npm test` full suite green (only pre-existing unrelated worker-teardown warnings, exit 0)

## Verification
```
npm install && npm run build && npm test    # all pass
npx jest tests/cdp/ --runInBand              # 110/110 pass, 18 suites
```

Fixes #1346