### PR TITLE
fix(benchmark): align Playwright smoke registry pin with COMPETITORS.md (#1255)

### DIFF
--- a/tests/benchmark/run-competitor-smoke.ts
+++ b/tests/benchmark/run-competitor-smoke.ts
@@ -75,7 +75,7 @@ const LIBRARIES: readonly Exclude<SmokeLibrary, 'all'>[] = ['openchrome', 'playw
 
 const REGISTRY_PINNED_VERSIONS: Readonly<Record<string, string>> = {
   OpenChrome: readRepoVersion(),
-  Playwright: '1.49.0',
+  Playwright: '1.60.0',
   Puppeteer: '23.10.3',
   Crawlee: '3.16.0',
   'playwright-mcp': '0.0.75',


### PR DESCRIPTION
## Summary

- \`REGISTRY_PINNED_VERSIONS\` in \`tests/benchmark/run-competitor-smoke.ts\`
  still recorded Playwright as \`1.49.0\`. \`benchmark/COMPETITORS.md\` and
  the installed dependency have been at \`1.60.0\` since the 2026-05-18
  smoke runtime refresh.
- The fallback path in \`packageVersion()\` returns the registry pin when
  node resolution fails (e.g. CI without \`node_modules\`), so two runs of
  the same smoke matrix could disagree on the "pinned" Playwright
  version. This PR aligns the registry to \`1.60.0\`.

## Stack

Targets \`chore/release-sync-main-to-develop\` while #1255 smoke infra
lands on develop (see the stack root PR). Will re-target develop once
that merges.

## Test plan

- [ ] Existing \`tests/benchmark/run-competitor-smoke.test.ts\` still
      passes (the test asserts a semver-shape regex, not the exact
      version).
- [ ] \`benchmark/COMPETITORS.md\` Playwright row and the smoke
      registry pin now agree at \`1.60.0\`.

Refs #1254, #1255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)