### PR TITLE
fix(benchmark): share operator CDP and reject empty-payload smoke rows (#1255)

### DIFF
--- a/tests/benchmark/run-competitor-smoke.test.ts
+++ b/tests/benchmark/run-competitor-smoke.test.ts
@@ -1,6 +1,38 @@
 /// <reference types="jest" />
 
-import { parseSmokeArgs, runCompetitorSmokeMatrix } from './run-competitor-smoke';
+import type { MCPAdapter, MCPToolResult } from './benchmark-runner';
+import {
+  AdapterSpec,
+  parseSmokeArgs,
+  runCompetitorSmokeMatrix,
+  runOne,
+} from './run-competitor-smoke';
+
+function fakeAdapter(read: MCPToolResult): MCPAdapter {
+  return {
+    name: 'fake',
+    mode: 'fake',
+    async callTool(tool: string): Promise<MCPToolResult> {
+      if (tool === 'tabs_create') return { content: [{ type: 'text', text: JSON.stringify({ tabId: 'tab-1' }) }] };
+      if (tool === 'read_page') return read;
+      if (tool === 'tabs_close') return { content: [{ type: 'text', text: 'ok' }] };
+      throw new Error(`unexpected tool ${tool}`);
+    },
+  };
+}
+
+function specOf(adapter: MCPAdapter): AdapterSpec {
+  // 'OpenChrome' as the library label is what `versionInfoFor` uses to short-
+  // circuit to `dependencyAvailable: true` (it reads the repo's own
+  // package.json), so the dependency-skip branch in runOne never trips and we
+  // can assert payload-sanity behaviour directly.
+  return {
+    library: 'OpenChrome',
+    mode: 'fake',
+    liveRequired: false,
+    adapterFactory: () => adapter,
+  };
+}
 
 describe('competitor smoke matrix', () => {
   test('parses defaults as CI-safe all-library matrix', () => {
@@ -23,4 +55,20 @@ describe('competitor smoke matrix', () => {
     expect(rows.find((row) => row.library === 'OpenChrome')?.version).toBe('1.12.4');
     expect(rows.every((row) => row.sameTaskContract)).toBe(true);
   }, 30000);
+
+  test('demotes a three-calls-succeeded row to failed when read_page returns empty payload', async () => {
+    const spec = specOf(fakeAdapter({ content: [{ type: 'text', text: '' }] }));
+    const row = await runOne(spec, 'http://example.local/', { includeLive: false, library: 'all', timeoutMs: 5000 });
+    expect(row.status).toBe('failed');
+    expect(row.payloadChars).toBe(0);
+    expect(row.failure).toMatch(/empty_payload/);
+  });
+
+  test('keeps a row passed when read_page returns non-empty payload', async () => {
+    const spec = specOf(fakeAdapter({ content: [{ type: 'text', text: '<html><body>hi</body></html>' }] }));
+    const row = await runOne(spec, 'http://example.local/', { includeLive: false, library: 'all', timeoutMs: 5000 });
+    expect(row.status).toBe('passed');
+    expect(row.payloadChars).toBeGreaterThan(0);
+    expect(row.failure).toBe('');
+  });
 });

--- a/tests/benchmark/run-competitor-smoke.ts
+++ b/tests/benchmark/run-competitor-smoke.ts
@@ -57,7 +57,7 @@ export interface CompetitorSmokeRow {
   failure: string;
 }
 
-interface AdapterSpec {
+export interface AdapterSpec {
   library: string;
   mode: string;
   liveRequired: boolean;
@@ -115,14 +115,21 @@ export function parseSmokeArgs(argv: string[]): CompetitorSmokeOptions {
 
 function specs(options: CompetitorSmokeOptions): AdapterSpec[] {
   const requested = options.library === 'all' ? LIBRARIES : [options.library];
+  // Every CDP-based adapter in the 6-way smoke attaches to the *operator's*
+  // Chrome via OPENCHROME_BENCH_CDP_ENDPOINT instead of each library
+  // launching/looking up its own default. Co-locating them on one Chrome
+  // (a) keeps the matrix comparable — same browser, same profile, same page —
+  // and (b) avoids the failure mode where two adapters race to launch their
+  // own Chromium against an identical default user-data-dir.
+  const cdpEndpoint = process.env.OPENCHROME_BENCH_CDP_ENDPOINT;
   const all: Record<Exclude<SmokeLibrary, 'all'>, AdapterSpec> = {
     openchrome: options.includeLive
-      ? { library: 'OpenChrome', mode: 'dom-live', liveRequired: true, adapterFactory: () => new OpenChromeRealAdapter({ mode: 'dom' }) }
+      ? { library: 'OpenChrome', mode: 'dom-live', liveRequired: true, adapterFactory: () => new OpenChromeRealAdapter({ mode: 'dom', cdpEndpoint }) }
       : { library: 'OpenChrome', mode: 'dom-stub', liveRequired: false, adapterFactory: () => new OpenChromeStubAdapter({ mode: 'dom' }) },
-    playwright: { library: 'Playwright', mode: 'raw-html-cdp', liveRequired: true, packageName: 'playwright', adapterFactory: () => new PlaywrightAdapter() },
-    puppeteer: { library: 'Puppeteer', mode: 'raw-html-cdp', liveRequired: true, packageName: 'puppeteer-core', adapterFactory: () => new PuppeteerAdapter() },
+    playwright: { library: 'Playwright', mode: 'raw-html-cdp', liveRequired: true, packageName: 'playwright', adapterFactory: () => new PlaywrightAdapter({ cdpEndpoint }) },
+    puppeteer: { library: 'Puppeteer', mode: 'raw-html-cdp', liveRequired: true, packageName: 'puppeteer-core', adapterFactory: () => new PuppeteerAdapter({ browserURL: cdpEndpoint }) },
     crawlee: { library: 'Crawlee', mode: 'cheerio-text', liveRequired: false, packageName: 'crawlee', adapterFactory: () => new CrawleeAdapter() },
-    'playwright-mcp': { library: 'playwright-mcp', mode: 'native-mcp', liveRequired: true, packageName: '@playwright/mcp', adapterFactory: () => new PlaywrightMcpAdapter({ serverPath: process.env.PLAYWRIGHT_MCP_SERVER_PATH, cdpEndpoint: process.env.OPENCHROME_BENCH_CDP_ENDPOINT }) },
+    'playwright-mcp': { library: 'playwright-mcp', mode: 'native-mcp', liveRequired: true, packageName: '@playwright/mcp', adapterFactory: () => new PlaywrightMcpAdapter({ serverPath: process.env.PLAYWRIGHT_MCP_SERVER_PATH, cdpEndpoint }) },
     'browser-use': { library: 'browser-use', mode: 'python-bridge', liveRequired: true, adapterFactory: () => new BrowserUseAdapter({ bridgeScriptPath: process.env.BROWSER_USE_BRIDGE_SCRIPT, python: process.env.BROWSER_USE_PYTHON }) },
   };
   return requested.map((library) => all[library]);
@@ -204,7 +211,7 @@ function parseTabId(text: string | undefined): string {
   return parsed.tabId;
 }
 
-async function runOne(spec: AdapterSpec, url: string, options: CompetitorSmokeOptions): Promise<CompetitorSmokeRow> {
+export async function runOne(spec: AdapterSpec, url: string, options: CompetitorSmokeOptions): Promise<CompetitorSmokeRow> {
   const versionInfo = versionInfoFor(spec);
   const base = {
     library: spec.library,
@@ -253,6 +260,23 @@ async function runOne(spec: AdapterSpec, url: string, options: CompetitorSmokeOp
     if (read.isError) throw new Error(read.content?.[0]?.text ?? 'read_page failed');
     await withTimeout(adapter.callTool('tabs_close', { tabId }), options.timeoutMs, `${spec.library} tabs_close`);
     const payload = read.content?.map((entry) => entry.text ?? '').join('\n') ?? '';
+    // Sanity gate: an adapter that returns the all-three-calls-succeeded shape
+    // but ships an empty payload is not actually evidence that the library can
+    // observe a page — it just means none of the three calls *threw*. The
+    // smoke's whole purpose is to prove the read step produced something for
+    // downstream axes to measure, so a zero-length payload is demoted to a
+    // failure (`empty_payload`) rather than recorded as a green row.
+    if (payload.length === 0) {
+      return {
+        ...base,
+        status: 'failed',
+        skipCategory: 'none',
+        durationMs: Date.now() - started,
+        payloadChars: 0,
+        skipReason: '',
+        failure: 'empty_payload: read_page returned no text content',
+      };
+    }
     return {
       ...base,
       status: 'passed',


### PR DESCRIPTION
## Summary

Two sanity hardenings to the #1255 competitor smoke matrix so the
"6/6 passed" gate cannot be satisfied trivially:

1. **Shared operator CDP.** Pipe \`OPENCHROME_BENCH_CDP_ENDPOINT\`
   through every CDP-attaching adapter (Playwright, Puppeteer,
   OpenChrome live). Previously only playwright-mcp respected the env
   var; Playwright/Puppeteer used their own hard-coded
   \`127.0.0.1:9222\` default. When an operator runs Chrome on a
   different port the adapters silently aimed at a different browser
   than playwright-mcp, breaking the "same browser, same page" axiom
   the smoke is supposed to guarantee (Epic #1254 methodology #5).
2. **Empty-payload demotion.** A row whose \`tabs_create / read_page /
   tabs_close\` all returned without throwing but whose \`read_page\`
   payload was zero-length previously counted as \`status: passed,
   payloadChars: 0\` — falsely satisfying the readiness gate. Such rows
   are now demoted to \`status: failed, failure: "empty_payload: ..."\`,
   so a green smoke row is also evidence that \`read_page\` produced
   text content downstream axes can measure.

\`runOne\` and \`AdapterSpec\` are exported so the demotion path can be
unit-tested against a fake adapter; new tests cover both demotion and
the non-empty pass-through.

## Stack

Targets \`chore/release-sync-main-to-develop\` while #1255 smoke infra
lands on develop (see stack root PR). Will re-target develop once that
merges.

## Test plan

- [ ] \`npm test -- tests/benchmark/run-competitor-smoke.test.ts\` —
      all four tests pass (parser default, default matrix, empty
      payload demotion, non-empty passes).
- [ ] No existing test depends on the previous "passed despite empty
      payload" behaviour.

Refs #1254, #1255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)