### PR TITLE
Keep benchmark readiness current for v1.12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to OpenChrome are documented here. For full release notes se
 
 ---
 
+## v1.12.5 — host-neutral harness release gates (2026-05-25)
+
+Focused release-prep patch after the host-neutral MCP browser harness SSOT.
+This release integrates startup-tab reuse, pilot memory foundations, and
+benchmark release-gate hardening while keeping full competitive benchmark
+headline claims gated behind live or recorded-real evidence.
+
+See [`docs/releases/v1.12.5.md`](docs/releases/v1.12.5.md) for the full
+release notes.
+
 ## v1.12.4 — API-key-only benchmark readiness gate (2026-05-17)
 
 Focused benchmark release-safety patch. This release adds an explicit

--- a/benchmark/results/BENCHMARK-READINESS.md
+++ b/benchmark/results/BENCHMARK-READINESS.md
@@ -1,6 +1,6 @@
 # Open benchmark issue readiness audit
 
-Generated: 2026-05-17T16:32:47.118Z
+Generated: 2026-05-25T12:53:47.652Z
 
 ## Verdict
 
@@ -17,7 +17,7 @@ Generated: 2026-05-17T16:32:47.118Z
 | Not measurable yet | 0 |
 | API-key-only ready | 0 |
 | Blocked by non-key work | 15 |
-| Stale OpenChrome result artifacts | 2 |
+| Stale OpenChrome result artifacts | 10 |
 
 ## Issue matrix
 
@@ -262,13 +262,21 @@ Generated: 2026-05-17T16:32:47.118Z
 
 ## Result artifact freshness
 
-Current OpenChrome package version: `1.12.4`.
+Current OpenChrome package version: `1.12.5`.
 These committed result artifacts contain OpenChrome version pins older than the current package version. They remain diagnostic until regenerated or explicitly superseded:
 
 | Artifact | Expected OpenChrome version | Found OpenChrome versions |
 | --- | --- | --- |
-| `benchmark/results/longrun-stability.json` | `1.12.4` | `1.11.0` |
-| `benchmark/results/runtime-preflight.json` | `1.12.4` | `1.12.2` |
+| `benchmark/results/auth-usability.json` | `1.12.5` | `1.12.4` |
+| `benchmark/results/competitor-smoke.json` | `1.12.5` | `1.12.4` |
+| `benchmark/results/dx.json` | `1.12.5` | `1.12.4` |
+| `benchmark/results/episode-token-cost.json` | `1.12.5` | `1.12.4` |
+| `benchmark/results/longrun-stability.json` | `1.12.5` | `1.11.0` |
+| `benchmark/results/realworld-task-completion.json` | `1.12.5` | `1.12.4` |
+| `benchmark/results/reliability.json` | `1.12.5` | `1.12.4` |
+| `benchmark/results/runtime-preflight.json` | `1.12.5` | `1.12.2` |
+| `benchmark/results/speed-throughput.json` | `1.12.5` | `1.12.4` |
+| `benchmark/results/token-efficiency.json` | `1.12.5` | `1.12.4` |
 
 ## Additional PR scopes to reach API-key-only readiness
 
@@ -523,3 +531,4 @@ These are the remaining non-key PRs needed before supplying API keys should be e
   - npm run bench:readiness -- --strict
   - npm run bench:api-key-readiness
   - npm run build
+

--- a/benchmark/results/benchmark-readiness.json
+++ b/benchmark/results/benchmark-readiness.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-17T16:32:47.118Z",
+  "generatedAt": "2026-05-25T12:53:47.652Z",
   "summary": {
     "totalOpenBenchmarkIssues": 15,
     "ready": 0,
@@ -12,23 +12,79 @@
     "apiKeyOnlyReady": 0,
     "nonKeyBlocked": 15,
     "apiKeyOnlyCanMeasureEveryOpenBenchmarkIssue": false,
-    "staleResultArtifactCount": 2
+    "staleResultArtifactCount": 10
   },
   "artifactFreshness": {
-    "currentOpenChromeVersion": "1.12.4",
+    "currentOpenChromeVersion": "1.12.5",
     "staleArtifacts": [
       {
+        "file": "benchmark/results/auth-usability.json",
+        "expectedOpenChromeVersion": "1.12.5",
+        "foundVersions": [
+          "1.12.4"
+        ]
+      },
+      {
+        "file": "benchmark/results/competitor-smoke.json",
+        "expectedOpenChromeVersion": "1.12.5",
+        "foundVersions": [
+          "1.12.4"
+        ]
+      },
+      {
+        "file": "benchmark/results/dx.json",
+        "expectedOpenChromeVersion": "1.12.5",
+        "foundVersions": [
+          "1.12.4"
+        ]
+      },
+      {
+        "file": "benchmark/results/episode-token-cost.json",
+        "expectedOpenChromeVersion": "1.12.5",
+        "foundVersions": [
+          "1.12.4"
+        ]
+      },
+      {
         "file": "benchmark/results/longrun-stability.json",
-        "expectedOpenChromeVersion": "1.12.4",
+        "expectedOpenChromeVersion": "1.12.5",
         "foundVersions": [
           "1.11.0"
         ]
       },
       {
+        "file": "benchmark/results/realworld-task-completion.json",
+        "expectedOpenChromeVersion": "1.12.5",
+        "foundVersions": [
+          "1.12.4"
+        ]
+      },
+      {
+        "file": "benchmark/results/reliability.json",
+        "expectedOpenChromeVersion": "1.12.5",
+        "foundVersions": [
+          "1.12.4"
+        ]
+      },
+      {
         "file": "benchmark/results/runtime-preflight.json",
-        "expectedOpenChromeVersion": "1.12.4",
+        "expectedOpenChromeVersion": "1.12.5",
         "foundVersions": [
           "1.12.2"
+        ]
+      },
+      {
+        "file": "benchmark/results/speed-throughput.json",
+        "expectedOpenChromeVersion": "1.12.5",
+        "foundVersions": [
+          "1.12.4"
+        ]
+      },
+      {
+        "file": "benchmark/results/token-efficiency.json",
+        "expectedOpenChromeVersion": "1.12.5",
+        "foundVersions": [
+          "1.12.4"
         ]
       }
     ]

--- a/tests/benchmark/benchmark-readiness.test.ts
+++ b/tests/benchmark/benchmark-readiness.test.ts
@@ -41,7 +41,7 @@ describe('benchmark readiness audit', () => {
     expect(report.summary.nonKeyBlocked).toBe(15);
     expect(report.summary.apiKeyOnlyCanMeasureEveryOpenBenchmarkIssue).toBe(false);
     expect(report.summary.staleResultArtifactCount).toBeGreaterThan(0);
-    expect(report.artifactFreshness.currentOpenChromeVersion).toBe('1.12.4');
+    expect(report.artifactFreshness.currentOpenChromeVersion).toBe(require('../../package.json').version);
   });
 
   it('keeps the closed #1305 real-world task runner out of the open-issue audit', () => {

--- a/tests/benchmark/run-competitor-smoke.test.ts
+++ b/tests/benchmark/run-competitor-smoke.test.ts
@@ -1,6 +1,7 @@
 /// <reference types="jest" />
 
 import type { MCPAdapter, MCPToolResult } from './benchmark-runner';
+import packageJson from '../../package.json';
 import {
   AdapterSpec,
   parseSmokeArgs,
@@ -52,7 +53,7 @@ describe('competitor smoke matrix', () => {
     expect(playwright?.skipCategory).toBe('not_requested');
     expect(playwright?.version).toMatch(/^[0-9]+\.[0-9]+\.[0-9]+/);
     expect(playwright?.versionPinned).toBe(true);
-    expect(rows.find((row) => row.library === 'OpenChrome')?.version).toBe('1.12.4');
+    expect(rows.find((row) => row.library === 'OpenChrome')?.version).toBe(packageJson.version);
     expect(rows.every((row) => row.sameTaskContract)).toBe(true);
   }, 30000);
 

--- a/tests/cdp/client-contracts.test.ts
+++ b/tests/cdp/client-contracts.test.ts
@@ -9,6 +9,7 @@ jest.mock('../../src/chrome/launcher', () => ({
   getChromeLauncher: jest.fn().mockReturnValue({
     ensureChrome: jest.fn(),
     invalidateInstance: jest.fn(),
+    getInstance: jest.fn(() => ({ launchMode: 'attach' })),
   }),
 }));
 


### PR DESCRIPTION
## Why\n\nThe v1.12.5 release bumped package metadata, but the benchmark readiness test still asserted v1.12.4. That made the readiness audit fail for the current release and obscured the real benchmark blockers.\n\n## Scope\n\n- Make the readiness version assertion package-driven instead of hardcoded.\n- Regenerate benchmark readiness artifacts for v1.12.5.\n- Add the v1.12.5 changelog pointer.\n\n## Verification\n\n- npm run bench:readiness\n- npm test -- --runInBand tests/benchmark/benchmark-readiness.test.ts\n- npm run build\n\n## Notes\n\nThis PR does not claim headline benchmark readiness. The regenerated audit still reports all open benchmark issues as partial/diagnostic-only.