### PR TITLE
Wire WebVoyager live loops through benchmark adapters

### DIFF
--- a/docs/benchmarks/webvoyager.md
+++ b/docs/benchmarks/webvoyager.md
@@ -80,6 +80,18 @@ records the sample index in each row. Live/recorded-real reports must also pin:
 Rows without live or recorded-real evidence remain diagnostic, even when they
 use the same report schema.
 
+## Live loop status
+
+The live provider path now dispatches Claude/OpenAI tool-use turns through the
+selected benchmark library adapter (`openchrome`, `playwright-mcp`, or
+`browser-use`) instead of stopping at a scaffold. The path is still fail-closed
+and opt-in: preflight plus `OPENCHROME_BENCH_REAL=1` and provider credentials are
+required before any paid call.
+
+Current live rows should remain diagnostic until enough recorded-real samples,
+competitor version pins, and final-state evidence satisfy the headline gates in
+`docs/benchmarks/benchmark-direction.md`.
+
 ## Transcript determinism contract
 
 Frozen transcripts are JSONL files containing zero or more `tool_call` entries

--- a/tests/benchmark/webvoyager/llm/claude-adapter.ts
+++ b/tests/benchmark/webvoyager/llm/claude-adapter.ts
@@ -28,6 +28,7 @@ import type { EvalContext } from '../../../../src/contracts/eval-context';
 import type { BudgetCaps } from './budget';
 import type { WebVoyagerTask } from '../types';
 import { accountLlmBudget, LlmUsageSample } from './token-budget';
+import { runLiveWebVoyagerTask } from './live-task-runner';
 
 export interface ClaudeAdapterPricing {
   input_usd_per_million: number;
@@ -76,6 +77,7 @@ export async function runClaudeTask(
   _task: WebVoyagerTask,
   _budget: BudgetCaps,
   _pricing: ClaudeAdapterPricing = DEFAULT_PRICING,
+  options: { library?: WebVoyagerLibrary; model?: string } = {},
 ): Promise<ClaudeAdapterResult> {
   if (!process.env.ANTHROPIC_API_KEY) {
     throw new Error('ANTHROPIC_API_KEY is not set; refusing to run real adapter');
@@ -84,28 +86,23 @@ export async function runClaudeTask(
     throw new Error('OPENCHROME_BENCH_REAL=1 is required to run the real adapter');
   }
 
-  // Dynamic import so the SDK isn't a hard dep at module-load time.
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  let Anthropic: unknown;
+  void _pricing;
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    Anthropic = require('@anthropic-ai/sdk');
+    return await runLiveWebVoyagerTask({
+      provider: 'claude',
+      library: options.library ?? 'openchrome',
+      task: _task,
+      budget: _budget,
+      model: options.model ?? process.env.OPENCHROME_BENCH_MODEL ?? 'claude-sonnet-4-5',
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    throw new Error(
-      `@anthropic-ai/sdk is not installed. Install it as a dev dep before ` +
-        `running the real adapter: npm i -D @anthropic-ai/sdk. Original error: ${message}`,
-    );
+    if (message.includes('@anthropic-ai/sdk')) {
+      throw new Error(
+        `@anthropic-ai/sdk is not installed. Install it as a dev dep before ` +
+          `running the real adapter: npm i -D @anthropic-ai/sdk. Original error: ${message}`,
+      );
+    }
+    throw err;
   }
-
-  // Suppress unused-variable lint until the loop is wired up.
-  void Anthropic;
-  void _pricing;
-
-  throw new Error(
-    'claude-adapter: real-API tool-use loop is a v1 follow-up. The scaffold ' +
-      'exists so the harness API surface is stable; record transcripts via ' +
-      'the standalone recorder and use --adapter mock for CI. See ' +
-      'docs/benchmarks/webvoyager.md for the recording workflow.',
-  );
 }

--- a/tests/benchmark/webvoyager/llm/live-task-runner.test.ts
+++ b/tests/benchmark/webvoyager/llm/live-task-runner.test.ts
@@ -1,0 +1,50 @@
+import type { MCPAdapter } from '../../benchmark-runner';
+import { CapturingBenchmarkAdapter, runLiveWebVoyagerTask } from './live-task-runner';
+import { WEBVOYAGER_BUDGET } from './budget';
+import type { WebVoyagerTask } from '../types';
+
+const task: WebVoyagerTask = {
+  name: 'sample',
+  instruction: 'Visit https://example.com and report the title.',
+  contract: { postconditions: { kind: 'dom_text', selector: 'body', contains: 'Example Domain' } },
+  timeout_ms: 1000,
+};
+
+function adapter(): MCPAdapter {
+  return {
+    name: 'test-adapter',
+    mode: 'test',
+    kind: 'mcp',
+    setup: jest.fn(async () => undefined),
+    teardown: jest.fn(async () => undefined),
+    callTool: jest.fn(async (name: string) => {
+      if (name === 'tabs_create') return { content: [{ type: 'text', text: JSON.stringify({ tabId: 'tab-1' }) }] };
+      if (name === 'read_page') return { content: [{ type: 'text', text: 'Example Domain' }] };
+      return { content: [{ type: 'text', text: 'ok' }] };
+    }),
+  };
+}
+
+describe('live WebVoyager task runner', () => {
+  it('captures tab and page payload for contract evaluation', async () => {
+    const wrapped = new CapturingBenchmarkAdapter(adapter());
+    await wrapped.callTool('tabs_create', { url: 'https://example.com' });
+    await wrapped.callTool('read_page', { tabId: 'tab-1' });
+    const ctx = wrapped.evalContext('final');
+    await expect(ctx.url()).resolves.toBe('https://example.com');
+    await expect(ctx.domText('body')).resolves.toContain('Example Domain');
+  });
+
+  it('runs an injected Anthropic client through the benchmark adapter', async () => {
+    const rawTurns = [
+      { model: 'claude-test', usage: { input_tokens: 10, output_tokens: 5 }, content: [{ type: 'tool_use', id: 't1', name: 'tabs_create', input: { url: 'https://example.com' } }] },
+      { model: 'claude-test', usage: { input_tokens: 8, output_tokens: 4 }, content: [{ type: 'tool_use', id: 't2', name: 'read_page', input: { tabId: 'tab-1' } }] },
+      { model: 'claude-test', usage: { input_tokens: 6, output_tokens: 3 }, content: [{ type: 'text', text: 'done' }] },
+    ];
+    const client = { create: jest.fn(async () => rawTurns.shift()) };
+    const result = await runLiveWebVoyagerTask({ provider: 'claude', library: 'openchrome', task, budget: WEBVOYAGER_BUDGET, model: 'claude-test', anthropicClient: client, adapter: adapter() });
+    expect(result.tool_calls).toBe(2);
+    expect(result.total_tokens).toBe(36);
+    await expect(result.context.domText('body')).resolves.toContain('Example Domain');
+  });
+});

--- a/tests/benchmark/webvoyager/llm/live-task-runner.ts
+++ b/tests/benchmark/webvoyager/llm/live-task-runner.ts
@@ -1,0 +1,206 @@
+import type { EvalContext } from '../../../../src/contracts/eval-context';
+import type { MCPAdapter, MCPToolResult } from '../../benchmark-runner';
+import { BrowserUseAdapter, OpenChromeRealAdapter, PlaywrightMcpAdapter } from '../../adapters';
+import { runAnthropicToolUseLoop, type AnthropicMessagesClient } from '../../llm-provider/anthropic-loop';
+import { runOpenAiToolUseLoop, type OpenAiResponsesClient } from '../../llm-provider/openai-loop';
+import type { BudgetCaps } from './budget';
+import type { WebVoyagerTask } from '../types';
+import type { WebVoyagerLibrary } from './library-routing';
+
+export type LiveProviderAdapter = 'claude' | 'openai';
+
+export interface LiveTaskRunnerResult {
+  context: EvalContext;
+  tool_calls: number;
+  response_bytes: number;
+  usd_spent: number;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  aborted?: 'BUDGET_EXCEEDED' | 'MAX_ITERATIONS' | 'API_ERROR';
+}
+
+export interface LiveTaskRunnerOptions {
+  provider: LiveProviderAdapter;
+  library: WebVoyagerLibrary;
+  task: WebVoyagerTask;
+  budget: BudgetCaps;
+  model: string;
+  anthropicClient?: AnthropicMessagesClient;
+  openAiClient?: OpenAiResponsesClient;
+  adapter?: MCPAdapter;
+}
+
+export const WEBVOYAGER_TOOLS = [
+  {
+    name: 'tabs_create',
+    description: 'Open a new browser tab at the requested URL and return a tabId.',
+    inputSchema: {
+      type: 'object',
+      properties: { url: { type: 'string' } },
+      required: ['url'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'read_page',
+    description: 'Read the current browser page payload for a tabId.',
+    inputSchema: {
+      type: 'object',
+      properties: { tabId: { type: 'string' } },
+      required: ['tabId'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'tabs_close',
+    description: 'Close a browser tab by tabId.',
+    inputSchema: {
+      type: 'object',
+      properties: { tabId: { type: 'string' } },
+      required: ['tabId'],
+      additionalProperties: false,
+    },
+  },
+] as const;
+
+function textFromResult(result: MCPToolResult): string {
+  return (result.content || []).map((part) => part.text ?? part.data ?? '').filter(Boolean).join('\n');
+}
+
+function parseTabId(result: MCPToolResult): string | null {
+  try {
+    const parsed = JSON.parse(textFromResult(result));
+    return typeof parsed.tabId === 'string' && parsed.tabId.length > 0 ? parsed.tabId : null;
+  } catch {
+    return null;
+  }
+}
+
+export class CapturingBenchmarkAdapter implements MCPAdapter {
+  readonly name: string;
+  readonly mode: string;
+  readonly kind?: MCPAdapter['kind'];
+  readonly version?: string;
+  private lastTabId: string | null = null;
+  private lastUrl = '';
+  private lastPayload = '';
+  private networkLog: Array<{ url: string; status: number; ts: number }> = [];
+
+  constructor(private readonly inner: MCPAdapter) {
+    this.name = inner.name;
+    this.mode = inner.mode;
+    this.kind = inner.kind;
+    this.version = inner.version;
+  }
+
+  async setup(): Promise<void> { await this.inner.setup?.(); }
+  async teardown(): Promise<void> { await this.inner.teardown?.(); }
+
+  async callTool(toolName: string, args: Record<string, unknown>): Promise<MCPToolResult> {
+    const result = await this.inner.callTool(toolName, args);
+    if (toolName === 'tabs_create') {
+      const tabId = parseTabId(result);
+      if (tabId) this.lastTabId = tabId;
+      if (typeof args.url === 'string') {
+        this.lastUrl = args.url;
+        this.networkLog.push({ url: args.url, status: result.isError ? 0 : 200, ts: Date.now() });
+      }
+    }
+    if (toolName === 'read_page') this.lastPayload = textFromResult(result);
+    return result;
+  }
+
+  async ensureFinalPayload(): Promise<void> {
+    if (!this.lastTabId || this.lastPayload.trim().length > 0) return;
+    try {
+      const result = await this.callTool('read_page', { tabId: this.lastTabId });
+      this.lastPayload = textFromResult(result);
+    } catch {
+      // Contract evaluation will fail honestly if the final payload cannot be read.
+    }
+  }
+
+  evalContext(finalText: string): EvalContext {
+    const payload = () => [this.lastPayload, finalText].filter((s) => s && s.trim().length > 0).join('\n');
+    return {
+      url: async () => this.lastUrl,
+      domText: async () => payload() || null,
+      domCount: async () => 0,
+      networkSince: async () => this.networkLog,
+      screenshotPng: async () => null,
+      hasOpenDialog: async () => false,
+    };
+  }
+}
+
+export function createLibraryAdapter(library: WebVoyagerLibrary): MCPAdapter {
+  const cdpEndpoint = process.env.OPENCHROME_BENCH_CDP_ENDPOINT;
+  if (library === 'openchrome') return new OpenChromeRealAdapter({ mode: 'dom', cdpEndpoint });
+  if (library === 'playwright-mcp') return new PlaywrightMcpAdapter({ cdpEndpoint, serverPath: process.env.PLAYWRIGHT_MCP_SERVER_PATH });
+  return new BrowserUseAdapter({ bridgeScriptPath: process.env.BROWSER_USE_BRIDGE_SCRIPT, python: process.env.BROWSER_USE_PYTHON });
+}
+
+function systemPrompt(library: WebVoyagerLibrary): string {
+  return [
+    'You are running a browser benchmark task. Use only the provided browser tools.',
+    'Open the target page, read the page, and stop once the requested information is available.',
+    'Do not invent browser state; the deterministic contract evaluator will check the final page state.',
+    `Library under test: ${library}.`,
+  ].join('\n');
+}
+
+export async function runLiveWebVoyagerTask(options: LiveTaskRunnerOptions): Promise<LiveTaskRunnerResult> {
+  const adapter = new CapturingBenchmarkAdapter(options.adapter ?? createLibraryAdapter(options.library));
+  await adapter.setup?.();
+  try {
+    const tools = WEBVOYAGER_TOOLS.map((tool) => ({ name: tool.name, description: tool.description, inputSchema: tool.inputSchema as Record<string, unknown> }));
+    const common = { adapter, model: options.model, user: options.task.instruction, tools, budget: options.budget };
+    const loop = options.provider === 'claude'
+      ? await runAnthropicToolUseLoop({ ...common, client: options.anthropicClient ?? createAnthropicClient(), system: systemPrompt(options.library) })
+      : await runOpenAiToolUseLoop({ ...common, client: options.openAiClient ?? createOpenAiClient(), instructions: systemPrompt(options.library) });
+    await adapter.ensureFinalPayload();
+    const inputTokens = loop.turns.reduce((sum, turn) => sum + turn.usage.inputTokens, 0);
+    const outputTokens = loop.turns.reduce((sum, turn) => sum + turn.usage.outputTokens, 0);
+    const responseBytes = loop.toolResults.reduce((sum, result) => sum + Buffer.byteLength(textFromResult(result)), 0) + Buffer.byteLength(loop.finalText);
+    return {
+      context: adapter.evalContext(loop.finalText),
+      tool_calls: loop.toolResults.length,
+      response_bytes: responseBytes,
+      usd_spent: loop.usdSpent,
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      total_tokens: loop.totalTokens,
+      ...(loop.aborted && { aborted: loop.aborted }),
+    };
+  } catch (err) {
+    if (err instanceof Error && /budget|iteration/i.test(err.message)) throw err;
+    throw err;
+  } finally {
+    await adapter.teardown?.();
+  }
+}
+
+function createAnthropicClient(): AnthropicMessagesClient {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mod = require('@anthropic-ai/sdk');
+  const Anthropic = mod.default ?? mod;
+  const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  return { create: (input) => client.messages.create(input) };
+}
+
+function createOpenAiClient(): OpenAiResponsesClient {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('openai');
+    const OpenAI = mod.default ?? mod;
+    const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    return { create: (input) => client.responses.create(input) };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `openai package is not installed. Install it as a dev dep before ` +
+        `running the real adapter: npm i -D openai. Original error: ${message}`,
+    );
+  }
+}

--- a/tests/benchmark/webvoyager/llm/openai-adapter.ts
+++ b/tests/benchmark/webvoyager/llm/openai-adapter.ts
@@ -1,6 +1,8 @@
 import type { EvalContext } from '../../../../src/contracts/eval-context';
 import type { BudgetCaps } from './budget';
 import type { WebVoyagerTask } from '../types';
+import { runLiveWebVoyagerTask } from './live-task-runner';
+import type { WebVoyagerLibrary } from './library-routing';
 
 export interface OpenAiAdapterResult {
   context: EvalContext;
@@ -16,6 +18,7 @@ export interface OpenAiAdapterResult {
 export async function runOpenAiTask(
   _task: WebVoyagerTask,
   _budget: BudgetCaps,
+  options: { library?: WebVoyagerLibrary; model?: string } = {},
 ): Promise<OpenAiAdapterResult> {
   if (!process.env.OPENAI_API_KEY) {
     throw new Error('OPENAI_API_KEY is not set; refusing to run real adapter');
@@ -24,9 +27,11 @@ export async function runOpenAiTask(
     throw new Error('OPENCHROME_BENCH_REAL=1 is required to run the real adapter');
   }
 
-  throw new Error(
-    'openai-adapter: real-API tool-use loop seam is present but not enabled in CI. ' +
-      'Use --adapter mock for deterministic runs, or provide OPENCHROME_BENCH_REAL=1 ' +
-      'and implement the recorded-real adapter path before publishing headline rows.',
-  );
+  return await runLiveWebVoyagerTask({
+    provider: 'openai',
+    library: options.library ?? 'openchrome',
+    task: _task,
+    budget: _budget,
+    model: options.model ?? process.env.OPENCHROME_BENCH_MODEL ?? 'gpt-5.5',
+  });
 }

--- a/tests/benchmark/webvoyager/runner.ts
+++ b/tests/benchmark/webvoyager/runner.ts
@@ -265,6 +265,7 @@ async function runTask(
   task: WebVoyagerTask,
   adapter: AdapterName,
   repetition: number,
+  options: Pick<CliOptions, 'library' | 'model'>,
 ): Promise<TaskRunReport> {
   const started = Date.now();
 
@@ -318,8 +319,8 @@ async function runTask(
     }
 
     const run = adapter === 'claude'
-      ? await withTimeout((await import('./llm/claude-adapter')).runClaudeTask(task, WEBVOYAGER_BUDGET), task.timeout_ms, task.name)
-      : await withTimeout((await import('./llm/openai-adapter')).runOpenAiTask(task, WEBVOYAGER_BUDGET), task.timeout_ms, task.name);
+      ? await withTimeout((await import('./llm/claude-adapter')).runClaudeTask(task, WEBVOYAGER_BUDGET, undefined, { library: options.library, model: options.model }), task.timeout_ms, task.name)
+      : await withTimeout((await import('./llm/openai-adapter')).runOpenAiTask(task, WEBVOYAGER_BUDGET, { library: options.library, model: options.model }), task.timeout_ms, task.name);
     const check = await evaluateContract(task.contract.postconditions, run.context);
     return {
       name: task.name,
@@ -450,7 +451,7 @@ export async function main(argv: string[] = process.argv): Promise<number> {
   const taskReports: TaskRunReport[] = [];
   for (const t of tasks) {
     for (let repetition = 1; repetition <= opts.repetitions; repetition++) {
-      const r = await runTask(t, opts.adapter, repetition);
+      const r = await runTask(t, opts.adapter, repetition, { library: opts.library, model: providerMetadata?.model });
       taskReports.push(r);
       console.error(
         `[webvoyager] ${r.name}#${r.repetition}: ${r.result}` +


### PR DESCRIPTION
## Why\n\nThe WebVoyager real adapters accepted provider keys but still stopped at throwing scaffolds, so supplying API keys could not produce even diagnostic live rows.\n\n## Scope\n\n- Add a live WebVoyager task runner that dispatches Claude/OpenAI tool-use turns through the selected benchmark library adapter.\n- Capture tab/page payload evidence into the contract-eval seam.\n- Let runner-selected library/model flow into provider adapters.\n- Keep the path opt-in and diagnostic until recorded-real/headline gates are satisfied.\n\n## Verification\n\n- npm test -- --runInBand tests/benchmark/webvoyager/llm/live-task-runner.test.ts tests/benchmark/webvoyager/runner.test.ts\n- npm run build\n\n## Not tested\n\n- Real paid provider calls.\n- Full live browser competitor matrix.