### PR TITLE
Add benchmark-only live API key input flags

### DIFF
--- a/docs/benchmarks/webvoyager.md
+++ b/docs/benchmarks/webvoyager.md
@@ -10,9 +10,17 @@ an LLM**. Eliminates the self-vs-LLM-eval gap by construction.
 # Deterministic replay over frozen transcripts (CI default).
 npm run bench:webvoyager:mock
 
-# Real Claude API run (opt-in; spends money).
-ANTHROPIC_API_KEY=sk-... OPENCHROME_BENCH_REAL=1 \
-  npm run bench:webvoyager:real -- --task task-01-example-com-title
+# Real Claude API run (opt-in; spends money). Prefer file/stdin/env-ref
+# benchmark-only secret input flags over exporting long-lived shell env.
+OPENCHROME_BENCH_REAL=1 \
+  npm run bench:webvoyager:real -- \
+  --anthropic-api-key-file ~/.config/openchrome/anthropic-benchmark.key \
+  --task task-01-example-com-title
+
+# Equivalent one-shot stdin form; the key is copied into ANTHROPIC_API_KEY only
+# for this Node process.
+printf '%s' "$ANTHROPIC_API_KEY" | OPENCHROME_BENCH_REAL=1 \
+  npm run bench:webvoyager:real -- --api-key-stdin=anthropic --preflight
 
 # Fail-closed live preflight; exits non-zero if env/model prerequisites are missing
 # and does not make an API call.
@@ -39,8 +47,23 @@ for a headline Agent Task Success claim. Stateful controlled workflows live in
 | Adapter | Env | Notes |
 | --- | --- | --- |
 | `mock` | (default) | Replays JSONL transcripts under `transcripts/`. Deterministic, no network, no API key. CI uses this. |
-| `claude` | `OPENCHROME_BENCH_ADAPTER=claude`, `ANTHROPIC_API_KEY`, `OPENCHROME_BENCH_REAL=1` | Anthropic Messages API seam. Requires `@anthropic-ai/sdk` installed locally (`npm i -D @anthropic-ai/sdk`) before live execution. Preflight reports missing prerequisites before any API call. |
-| `openai` | `OPENAI_API_KEY`, `OPENCHROME_BENCH_REAL=1` | OpenAI tool-use seam using the same metadata, budget, and preflight contract. It is opt-in only and is not run by CI. |
+| `claude` | `OPENCHROME_BENCH_ADAPTER=claude`, `ANTHROPIC_API_KEY` or `--anthropic-api-key-file` / `--api-key-stdin=anthropic`, `OPENCHROME_BENCH_REAL=1` | Anthropic Messages API seam. Requires `@anthropic-ai/sdk` installed locally (`npm i -D @anthropic-ai/sdk`) before live execution. Preflight reports missing prerequisites before any API call. |
+| `openai` | `OPENAI_API_KEY` or `--openai-api-key-file` / `--api-key-stdin=openai`, `OPENCHROME_BENCH_REAL=1` | OpenAI tool-use seam using the same metadata, budget, and preflight contract. It is opt-in only and is not run by CI. |
+
+## Benchmark-only API key input
+
+Live benchmark commands accept process-local secret input flags before provider
+preflight runs:
+
+- `--anthropic-api-key-file <path>` / `--openai-api-key-file <path>`
+- `--api-key-stdin=anthropic` / `--api-key-stdin=openai`
+- `--api-key-env <ENV_NAME> --api-key-env-provider <anthropic|openai>`
+- `--anthropic-api-key <value>` / `--openai-api-key <value>` for controlled CI only
+
+The flags are benchmark-only conveniences under `tests/benchmark`; they do not
+write a credential store. Inline key values are redacted from benchmark argv
+diagnostics, but file/stdin/env-ref forms are preferred because inline flags can
+remain in shell history.
 
 ## Repetitions and live-run metadata
 

--- a/tests/benchmark/run-full-benchmark.ts
+++ b/tests/benchmark/run-full-benchmark.ts
@@ -13,6 +13,7 @@ import * as path from 'path';
 import { spawnSync } from 'child_process';
 
 import { runRuntimePreflight, parseRuntimePreflightArgs } from './runtime-preflight';
+import { applyBenchmarkLiveSecretInputs } from './utils/live-secret-input';
 import { projectCost, WEBVOYAGER_LIBRARIES } from './webvoyager/llm/library-routing';
 
 const OUTPUT_PATH = path.join(process.cwd(), 'benchmark', 'results', 'full-benchmark-preflight.json');
@@ -59,6 +60,7 @@ export async function buildFullBenchmarkPreflight(argv: string[] = []): Promise<
   costEstimate: ReturnType<typeof projectCost>;
   orderedAxes: string[];
 }> {
+  applyBenchmarkLiveSecretInputs(argv);
   const options = parseFullBenchmarkArgs(argv);
   const runtimeRows = await runRuntimePreflight(parseRuntimePreflightArgs(argv));
   const missing = runtimeRows.filter((row) => row.status !== 'ready').map((row) => `${row.runtime}: ${row.evidence}`);

--- a/tests/benchmark/runtime-preflight.ts
+++ b/tests/benchmark/runtime-preflight.ts
@@ -13,6 +13,7 @@ import * as path from 'path';
 import { spawnSync } from 'child_process';
 
 import { buildResultEnvelope, assertValidResultEnvelope } from './utils/result-envelope';
+import { applyBenchmarkLiveSecretInputs } from './utils/live-secret-input';
 import { captureEnvironment } from './utils/environment';
 
 const OUTPUT_PATH = path.join(process.cwd(), 'benchmark', 'results', 'runtime-preflight.json');
@@ -200,6 +201,7 @@ function format(rows: readonly RuntimeProbeRow[]): string {
 }
 
 export async function main(argv = process.argv.slice(2)): Promise<void> {
+  applyBenchmarkLiveSecretInputs(argv);
   const options = parseRuntimePreflightArgs(argv);
   const rows = await runRuntimePreflight(options);
   const envelope = buildResultEnvelope({

--- a/tests/benchmark/utils/live-secret-input.test.ts
+++ b/tests/benchmark/utils/live-secret-input.test.ts
@@ -1,0 +1,35 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { applyBenchmarkLiveSecretInputs, redactLiveSecretArgs } from './live-secret-input';
+
+describe('benchmark live secret input flags', () => {
+  it('maps file-based provider keys into process-local env vars', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-secret-'));
+    const keyPath = path.join(dir, 'key.txt');
+    fs.writeFileSync(keyPath, 'sk-test-file\n');
+    const env: NodeJS.ProcessEnv = {};
+
+    const result = applyBenchmarkLiveSecretInputs(['--openai-api-key-file', keyPath], env);
+
+    expect(env.OPENAI_API_KEY).toBe('sk-test-file');
+    expect(result.applied).toEqual([{ provider: 'openai', source: 'file', envName: 'OPENAI_API_KEY' }]);
+  });
+
+  it('maps an arbitrary env reference to the requested provider', () => {
+    const env: NodeJS.ProcessEnv = { BENCH_KEY: 'sk-env-ref' };
+    applyBenchmarkLiveSecretInputs(['--api-key-env', 'BENCH_KEY', '--api-key-env-provider', 'anthropic'], env);
+    expect(env.ANTHROPIC_API_KEY).toBe('sk-env-ref');
+  });
+
+  it('redacts inline key values for diagnostics', () => {
+    expect(redactLiveSecretArgs(['--openai-api-key', 'sk-secret', '--x', '--anthropic-api-key=sk-other'])).toEqual([
+      '--openai-api-key', '<redacted>', '--x', '--anthropic-api-key=<redacted>',
+    ]);
+  });
+
+  it('rejects empty and whitespace-bearing keys', () => {
+    expect(() => applyBenchmarkLiveSecretInputs(['--anthropic-api-key', '  '], {})).toThrow(/empty/);
+    expect(() => applyBenchmarkLiveSecretInputs(['--openai-api-key', 'sk test'], {})).toThrow(/whitespace/);
+  });
+});

--- a/tests/benchmark/utils/live-secret-input.ts
+++ b/tests/benchmark/utils/live-secret-input.ts
@@ -1,0 +1,99 @@
+import * as fs from 'fs';
+
+export type LiveSecretProvider = 'anthropic' | 'openai';
+
+export interface LiveSecretInputResult {
+  applied: Array<{ provider: LiveSecretProvider; source: 'inline' | 'file' | 'stdin' | 'env-ref'; envName: 'ANTHROPIC_API_KEY' | 'OPENAI_API_KEY' }>;
+}
+
+const PROVIDER_ENV: Record<LiveSecretProvider, 'ANTHROPIC_API_KEY' | 'OPENAI_API_KEY'> = {
+  anthropic: 'ANTHROPIC_API_KEY',
+  openai: 'OPENAI_API_KEY',
+};
+
+function flagValue(argv: string[], name: string): string | undefined {
+  const idx = argv.indexOf(name);
+  if (idx !== -1) return argv[idx + 1];
+  const prefix = `${name}=`;
+  const found = argv.find((arg) => arg.startsWith(prefix));
+  return found ? found.slice(prefix.length) : undefined;
+}
+
+function hasFlag(argv: string[], name: string): boolean {
+  return argv.includes(name) || argv.some((arg) => arg.startsWith(`${name}=`));
+}
+
+function providerFromValue(raw: string | undefined, fallback: LiveSecretProvider): LiveSecretProvider {
+  const value = raw ?? fallback;
+  if (value === 'anthropic' || value === 'openai') return value;
+  throw new Error(`benchmark API key provider must be anthropic or openai; got ${value}`);
+}
+
+function cleanSecret(raw: string, source: string): string {
+  const value = raw.trim();
+  if (!value) throw new Error(`benchmark API key from ${source} was empty`);
+  if (/\s/.test(value)) throw new Error(`benchmark API key from ${source} contains whitespace`);
+  return value;
+}
+
+function apply(env: NodeJS.ProcessEnv, provider: LiveSecretProvider, value: string, source: LiveSecretInputResult['applied'][number]['source'], applied: LiveSecretInputResult['applied']): void {
+  const envName = PROVIDER_ENV[provider];
+  env[envName] = cleanSecret(value, source);
+  applied.push({ provider, source, envName });
+}
+
+/**
+ * Applies benchmark-only secret input flags to an env object.
+ *
+ * This intentionally lives under tests/benchmark: it is a convenience for local
+ * benchmark runs, not a product credential store. Values are copied into the
+ * conventional provider env var for the lifetime of the Node process only.
+ */
+export function applyBenchmarkLiveSecretInputs(argv: string[], env: NodeJS.ProcessEnv = process.env): LiveSecretInputResult {
+  const applied: LiveSecretInputResult['applied'] = [];
+
+  const anthropicInline = flagValue(argv, '--anthropic-api-key');
+  if (anthropicInline) apply(env, 'anthropic', anthropicInline, 'inline', applied);
+  const openAiInline = flagValue(argv, '--openai-api-key');
+  if (openAiInline) apply(env, 'openai', openAiInline, 'inline', applied);
+
+  const anthropicFile = flagValue(argv, '--anthropic-api-key-file');
+  if (anthropicFile) apply(env, 'anthropic', fs.readFileSync(anthropicFile, 'utf8'), 'file', applied);
+  const openAiFile = flagValue(argv, '--openai-api-key-file');
+  if (openAiFile) apply(env, 'openai', fs.readFileSync(openAiFile, 'utf8'), 'file', applied);
+
+  const envRefProvider = flagValue(argv, '--api-key-env-provider');
+  const envRefName = flagValue(argv, '--api-key-env');
+  if (envRefName) {
+    const provider = providerFromValue(envRefProvider, 'anthropic');
+    const value = env[envRefName];
+    if (!value) throw new Error(`--api-key-env ${envRefName} did not resolve to a non-empty environment variable`);
+    apply(env, provider, value, 'env-ref', applied);
+  }
+
+  if (hasFlag(argv, '--api-key-stdin')) {
+    const provider = providerFromValue(flagValue(argv, '--api-key-stdin'), 'anthropic');
+    apply(env, provider, fs.readFileSync(0, 'utf8'), 'stdin', applied);
+  }
+
+  return { applied };
+}
+
+export function redactLiveSecretArgs(argv: string[]): string[] {
+  const flagsWithValue = new Set(['--anthropic-api-key', '--openai-api-key']);
+  const redacted: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (flagsWithValue.has(arg)) {
+      redacted.push(arg, '<redacted>');
+      i++;
+      continue;
+    }
+    if (arg.startsWith('--anthropic-api-key=') || arg.startsWith('--openai-api-key=')) {
+      redacted.push(`${arg.split('=')[0]}=<redacted>`);
+      continue;
+    }
+    redacted.push(arg);
+  }
+  return redacted;
+}

--- a/tests/benchmark/webvoyager/runner.ts
+++ b/tests/benchmark/webvoyager/runner.ts
@@ -21,6 +21,7 @@ import type { EvalContext } from '../../../src/contracts/eval-context';
 import { runMockTask } from './llm/mock-adapter';
 import { renderMarkdown } from './report';
 import { WEBVOYAGER_BUDGET } from './llm/budget';
+import { applyBenchmarkLiveSecretInputs, redactLiveSecretArgs } from '../utils/live-secret-input';
 import { buildProviderRunMetadata, preflightProviderRun, providerForAdapter } from './llm/provider';
 import {
   WEBVOYAGER_LIBRARIES,
@@ -369,6 +370,11 @@ function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
 }
 
 export async function main(argv: string[] = process.argv): Promise<number> {
+  const secretInputs = applyBenchmarkLiveSecretInputs(argv.slice(2));
+  if (secretInputs.applied.length > 0) {
+    console.error(`[webvoyager] applied benchmark-only API key input: ${secretInputs.applied.map((s) => `${s.provider}:${s.source}->${s.envName}`).join(', ')}`);
+    console.error(`[webvoyager] argv: ${redactLiveSecretArgs(argv.slice(2)).join(' ')}`);
+  }
   const opts = parseArgs(argv);
   const allTasks = await loadTasks();
   const tasks = opts.taskFilter ? allTasks.filter((t) => t.name === opts.taskFilter) : allTasks;


### PR DESCRIPTION
## Why

Operators should be able to run live benchmark preflight/measurement with a one-shot benchmark secret input instead of exporting long-lived shell environment variables.

## Scope

- Add benchmark-only API key input helpers for file, stdin, env-ref, and controlled inline forms.
- Apply those inputs before WebVoyager and full/runtime preflight provider checks.
- Redact inline key values from benchmark argv diagnostics.
- Document the preferred file/stdin forms.

## Out of scope

- No credential persistence.
- No automatic paid API calls.
- No headline readiness claim.

## Verification

- npm test -- --runInBand tests/benchmark/utils/live-secret-input.test.ts tests/benchmark/webvoyager/llm/provider.test.ts tests/benchmark/run-full-benchmark.test.ts tests/benchmark/run-competitor-smoke.test.ts tests/cdp/client-contracts.test.ts
- npm run build
