### PR TITLE
fix(cli): configure Codex MCP through config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ npx openchrome-mcp setup --client opencode   # OpenCode
 
 Restart your MCP client. That's it — Chrome auto-launches on first tool call.
 
+For manual Codex CLI configuration, run `openchrome config --client codex`
+and add the printed `[mcp_servers.openchrome]` block to `~/.codex/config.toml`.
+
 <details>
 <summary>Manual MCP config (Cursor / VS Code / Windsurf / others)</summary>
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -24,17 +24,18 @@ import { execFileSync, spawn } from 'child_process';
 import { checkForUpdates } from './update-check';
 import { runUpdateCommand } from './update-command';
 import {
+  formatCodexMCPServerConfigSnippet,
   formatMCPServerConfigSnippet,
   getClientLabel,
   getClaudeManualServerConfig,
   getClaudeSetupCommand,
   getCodexServerConfig,
+  getCodexSetupCommand,
   getOpenCodeServerConfig,
   formatOpenCodeMCPServerConfigSnippet,
   getSupportedMCPClients,
   isSupportedMCPClient,
   upsertOpenCodeMCPServerConfig,
-  upsertMCPServerConfig,
 } from './mcp-client-config';
 import {
   addTotpSecret,
@@ -330,34 +331,34 @@ program
     }
 
     if (scope !== 'user') {
-      console.warn('⚠️  Scope is not used for Codex CLI; writing to ~/.codex/mcp.json.');
+      console.warn('⚠️  Scope is not used for Codex CLI; configuring the user-level Codex MCP registry.');
+    }
+
+    const codexSetupArgs = getCodexSetupCommand(serveArgOptions);
+    console.log('Running: codex mcp add openchrome...');
+
+    try {
+      execFileSync('codex', ['mcp', 'remove', 'openchrome'], { stdio: 'ignore' });
+    } catch {
+      // Ignore if the server is not configured yet.
     }
 
     try {
-      const codexConfigPath = path.join(os.homedir(), '.codex', 'mcp.json');
-      fs.mkdirSync(path.dirname(codexConfigPath), { recursive: true });
-
-      let config: Record<string, unknown> = {};
-      if (fs.existsSync(codexConfigPath)) {
-        config = JSON.parse(fs.readFileSync(codexConfigPath, 'utf8'));
-      }
-
-      const updatedConfig = upsertMCPServerConfig(config, 'openchrome', getCodexServerConfig(serveArgOptions));
-      fs.writeFileSync(codexConfigPath, JSON.stringify(updatedConfig, null, 2) + '\n');
+      execFileSync('codex', codexSetupArgs, { stdio: 'inherit' });
 
       console.log('\n✅ MCP server configured successfully!\n');
-      console.log(`Config file: ${codexConfigPath}`);
+      console.log('Config file: ~/.codex/config.toml');
       console.log('Updates: run "openchrome update"\n');
       console.log('Next steps:');
       console.log('  1. Restart Codex CLI');
       console.log('  2. Verify the openchrome MCP server reconnects cleanly\n');
       console.log('Installed MCP snippet:');
-      console.log(formatMCPServerConfigSnippet('openchrome', getCodexServerConfig(serveArgOptions)));
+      console.log(formatCodexMCPServerConfigSnippet('openchrome', getCodexServerConfig(serveArgOptions)));
     } catch (error) {
       console.error('\n❌ Failed to configure MCP server for Codex CLI.');
       console.error(`   ${error instanceof Error ? error.message : String(error)}`);
-      console.error('   You can manually add this to ~/.codex/mcp.json:');
-      console.error(formatMCPServerConfigSnippet('openchrome', getCodexServerConfig(serveArgOptions)));
+      console.error('   You can manually add this to ~/.codex/config.toml:');
+      console.error(formatCodexMCPServerConfigSnippet('openchrome', getCodexServerConfig(serveArgOptions)));
       process.exit(1);
     }
   });
@@ -386,7 +387,7 @@ program
       return;
     }
 
-    console.log(formatMCPServerConfigSnippet('openchrome', getCodexServerConfig(serveArgOptions)));
+    console.log(formatCodexMCPServerConfigSnippet('openchrome', getCodexServerConfig(serveArgOptions)));
   });
 
 program

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -338,12 +338,6 @@ program
     console.log('Running: codex mcp add openchrome...');
 
     try {
-      execFileSync('codex', ['mcp', 'remove', 'openchrome'], { stdio: 'ignore' });
-    } catch {
-      // Ignore if the server is not configured yet.
-    }
-
-    try {
       execFileSync('codex', codexSetupArgs, { stdio: 'inherit' });
 
       console.log('\n✅ MCP server configured successfully!\n');

--- a/cli/mcp-client-config.ts
+++ b/cli/mcp-client-config.ts
@@ -79,7 +79,6 @@ export function formatCodexMCPServerConfigSnippet(serverName: string, serverConf
     `[mcp_servers.${serverName}]`,
     `command = ${JSON.stringify(serverConfig.command)}`,
     `args = [${quotedArgs}]`,
-    'type = "stdio"',
   ].join('\n');
 }
 

--- a/cli/mcp-client-config.ts
+++ b/cli/mcp-client-config.ts
@@ -69,6 +69,20 @@ export function getCodexServerConfig(options: ServeArgOptions = {}): MCPServerCo
   };
 }
 
+export function getCodexSetupCommand(options: ServeArgOptions = {}): string[] {
+  return ['mcp', 'add', 'openchrome', '--', 'openchrome', ...getServeArgs(options)];
+}
+
+export function formatCodexMCPServerConfigSnippet(serverName: string, serverConfig: MCPServerConfig): string {
+  const quotedArgs = serverConfig.args.map((arg) => JSON.stringify(arg)).join(', ');
+  return [
+    `[mcp_servers.${serverName}]`,
+    `command = ${JSON.stringify(serverConfig.command)}`,
+    `args = [${quotedArgs}]`,
+    'type = "stdio"',
+  ].join('\n');
+}
+
 export function getClaudeManualServerConfig(options: ServeArgOptions = {}): MCPServerConfig {
   return {
     command: 'openchrome',

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,6 +43,9 @@ openchrome setup --client opencode   # OpenCode
 Restart your MCP client. That's it for the core install — the next sections
 are optional.
 
+For manual Codex CLI setup, run `openchrome config --client codex` and add
+the printed `[mcp_servers.openchrome]` block to `~/.codex/config.toml`.
+
 ## 2. Confirm core tier is live
 
 Open a fresh chat in your MCP client and ask it to navigate somewhere:

--- a/tests/cli/mcp-client-config.test.ts
+++ b/tests/cli/mcp-client-config.test.ts
@@ -30,8 +30,10 @@ describe('cli/mcp-client-config', () => {
     });
   });
 
-  test('getCodexSetupCommand uses the Codex MCP registry command', () => {
-    expect(getCodexSetupCommand({ dashboard: true })).toEqual([
+  test('getCodexSetupCommand uses the Codex MCP registry add command without a destructive remove step', () => {
+    const command = getCodexSetupCommand({ dashboard: true });
+
+    expect(command).toEqual([
       'mcp',
       'add',
       'openchrome',
@@ -41,6 +43,7 @@ describe('cli/mcp-client-config', () => {
       '--auto-launch',
       '--dashboard',
     ]);
+    expect(command).not.toContain('remove');
   });
 
   test('getClaudeManualServerConfig uses the installed openchrome binary', () => {
@@ -110,7 +113,6 @@ describe('cli/mcp-client-config', () => {
         '[mcp_servers.openchrome]',
         'command = "openchrome"',
         'args = ["serve", "--auto-launch"]',
-        'type = "stdio"',
       ].join('\n')
     );
   });

--- a/tests/cli/mcp-client-config.test.ts
+++ b/tests/cli/mcp-client-config.test.ts
@@ -1,8 +1,10 @@
 import {
+  formatCodexMCPServerConfigSnippet,
   formatMCPServerConfigSnippet,
   getClaudeManualServerConfig,
   getClaudeSetupCommand,
   getCodexServerConfig,
+  getCodexSetupCommand,
   getServeArgs,
   isSupportedMCPClient,
   upsertMCPServerConfig,
@@ -26,6 +28,19 @@ describe('cli/mcp-client-config', () => {
       command: 'openchrome',
       args: ['serve', '--auto-launch'],
     });
+  });
+
+  test('getCodexSetupCommand uses the Codex MCP registry command', () => {
+    expect(getCodexSetupCommand({ dashboard: true })).toEqual([
+      'mcp',
+      'add',
+      'openchrome',
+      '--',
+      'openchrome',
+      'serve',
+      '--auto-launch',
+      '--dashboard',
+    ]);
   });
 
   test('getClaudeManualServerConfig uses the installed openchrome binary', () => {
@@ -89,12 +104,24 @@ describe('cli/mcp-client-config', () => {
     });
   });
 
+  test('formatCodexMCPServerConfigSnippet serializes Codex config.toml format', () => {
+    expect(formatCodexMCPServerConfigSnippet('openchrome', getCodexServerConfig())).toBe(
+      [
+        '[mcp_servers.openchrome]',
+        'command = "openchrome"',
+        'args = ["serve", "--auto-launch"]',
+        'type = "stdio"',
+      ].join('\n')
+    );
+  });
+
   test('generated configs do not use transient package runners', () => {
     const serialized = [
       JSON.stringify(getCodexServerConfig()),
       JSON.stringify(getClaudeManualServerConfig()),
-      formatMCPServerConfigSnippet('openchrome', getCodexServerConfig()),
+      formatCodexMCPServerConfigSnippet('openchrome', getCodexServerConfig()),
       getClaudeSetupCommand('user').join(' '),
+      getCodexSetupCommand().join(' '),
     ].join('\n');
 
     expect(serialized).not.toContain('npx');


### PR DESCRIPTION
## Summary

- Configure Codex through `codex mcp add` instead of writing `~/.codex/mcp.json`
- Print manual Codex config as a `[mcp_servers.openchrome]` TOML block
- Document the Codex `~/.codex/config.toml` manual setup path

Fixes #1365

## Tests

- `npm run build:cli`
- `npm test -- tests/cli/mcp-client-config.test.ts --runInBand`
- `npm test -- tests/cli --runInBand`
- `npm test -- --runInBand`

Note: the full Jest run printed a pass summary for 563 suites / 6967 tests, then required manual termination because existing open handles kept the process alive after completion.
