### PR TITLE
Surface unsafe multi-controller topologies

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -32,6 +32,7 @@ import {
   getCodexServerConfig,
   getCodexSetupCommand,
   getOpenCodeServerConfig,
+  getTopologyWarning,
   formatOpenCodeMCPServerConfigSnippet,
   getSupportedMCPClients,
   isSupportedMCPClient,
@@ -190,8 +191,13 @@ program
   .option('--client <client>', 'Client to configure: "claude" (default), "codex", or "opencode"', 'claude')
   .option('--dashboard', 'Enable terminal dashboard')
   .option('--auto-launch', 'Auto-launch Chrome if not running (default: true)')
+  .option('--port <port>', 'Chrome remote debugging port for generated serve args')
+  .option('--user-data-dir <dir>', 'Chrome user data directory for generated serve args')
+  .option('--profile-directory <name>', 'Chrome profile directory name for generated serve args')
+  .option('--launch-mode <mode>', 'Chrome launch mode: auto, attach, or isolated')
+  .option('--topology <preset>', 'Topology preset: single-owner, isolated, ci-headless, or dev-profile')
   .option('-s, --scope <scope>', 'Installation scope: "user" (global, default) or "project" (current project only)', 'user')
-  .action(async (options: { client?: string; dashboard?: boolean; autoLaunch?: boolean; scope?: string }) => {
+  .action(async (options: { client?: string; dashboard?: boolean; autoLaunch?: boolean; port?: string; userDataDir?: string; profileDirectory?: string; launchMode?: string; topology?: string; scope?: string }) => {
     const requestedClient = options.client || 'claude';
     if (!isSupportedMCPClient(requestedClient)) {
       console.error(`❌ Invalid client. Use one of: ${getSupportedMCPClients().join(', ')}`);
@@ -208,7 +214,20 @@ program
       process.exit(1);
     }
 
-    const serveArgOptions = { autoLaunch: options.autoLaunch, dashboard: options.dashboard };
+    const serveArgOptions = {
+      autoLaunch: options.autoLaunch,
+      dashboard: options.dashboard,
+      port: options.port,
+      userDataDir: options.userDataDir,
+      profileDirectory: options.profileDirectory,
+      launchMode: options.launchMode,
+      topology: options.topology as undefined | 'single-owner' | 'isolated' | 'ci-headless' | 'dev-profile',
+    };
+    const topologyWarning = getTopologyWarning(serveArgOptions);
+    if (topologyWarning) {
+      console.warn(`⚠️  ${topologyWarning}`);
+      console.warn('   See docs/mcp/topologies.md for safe parallel setup examples.');
+    }
 
     if (client === 'claude') {
       const claudeCmd = getClaudeCliCommand();
@@ -363,13 +382,31 @@ program
   .requiredOption('--client <client>', 'Client to generate config for: "claude", "codex", or "opencode"')
   .option('--dashboard', 'Enable terminal dashboard')
   .option('--auto-launch', 'Auto-launch Chrome if not running (default: true)')
-  .action((options: { client: string; dashboard?: boolean; autoLaunch?: boolean }) => {
+  .option('--port <port>', 'Chrome remote debugging port for generated serve args')
+  .option('--user-data-dir <dir>', 'Chrome user data directory for generated serve args')
+  .option('--profile-directory <name>', 'Chrome profile directory name for generated serve args')
+  .option('--launch-mode <mode>', 'Chrome launch mode: auto, attach, or isolated')
+  .option('--topology <preset>', 'Topology preset: single-owner, isolated, ci-headless, or dev-profile')
+  .action((options: { client: string; dashboard?: boolean; autoLaunch?: boolean; port?: string; userDataDir?: string; profileDirectory?: string; launchMode?: string; topology?: string }) => {
     if (!isSupportedMCPClient(options.client)) {
       console.error(`❌ Invalid client. Use one of: ${getSupportedMCPClients().join(', ')}`);
       process.exit(1);
     }
 
-    const serveArgOptions = { autoLaunch: options.autoLaunch, dashboard: options.dashboard };
+    const serveArgOptions = {
+      autoLaunch: options.autoLaunch,
+      dashboard: options.dashboard,
+      port: options.port,
+      userDataDir: options.userDataDir,
+      profileDirectory: options.profileDirectory,
+      launchMode: options.launchMode,
+      topology: options.topology as undefined | 'single-owner' | 'isolated' | 'ci-headless' | 'dev-profile',
+    };
+    const topologyWarning = getTopologyWarning(serveArgOptions);
+    if (topologyWarning) {
+      console.error(`⚠️  ${topologyWarning}`);
+      console.error('   See docs/mcp/topologies.md for safe parallel setup examples.');
+    }
 
     if (options.client === 'claude') {
       console.log(['claude', ...getClaudeSetupCommand('user', serveArgOptions)].join(' '));

--- a/cli/mcp-client-config.ts
+++ b/cli/mcp-client-config.ts
@@ -1,9 +1,16 @@
 export type SupportedMCPClient = 'claude' | 'codex' | 'opencode';
 export type SetupScope = 'user' | 'project';
 
+export type TopologyPreset = 'single-owner' | 'isolated' | 'ci-headless' | 'dev-profile';
+
 export interface ServeArgOptions {
   autoLaunch?: boolean;
   dashboard?: boolean;
+  port?: string | number;
+  userDataDir?: string;
+  profileDirectory?: string;
+  launchMode?: string;
+  topology?: TopologyPreset;
 }
 
 export interface MCPServerConfig {
@@ -49,17 +56,65 @@ export function getClientLabel(client: SupportedMCPClient): string {
 }
 
 export function getServeArgs(options: ServeArgOptions = {}): string[] {
+  const resolved = resolveTopologyOptions(options);
   const serveArgs = ['serve'];
 
-  if (options.autoLaunch !== false) {
+  if (resolved.autoLaunch !== false) {
     serveArgs.push('--auto-launch');
   }
 
-  if (options.dashboard) {
+  if (resolved.port !== undefined) {
+    serveArgs.push('--port', String(resolved.port));
+  }
+
+  if (resolved.userDataDir) {
+    serveArgs.push('--user-data-dir', resolved.userDataDir);
+  }
+
+  if (resolved.profileDirectory) {
+    serveArgs.push('--profile-directory', resolved.profileDirectory);
+  }
+
+  if (resolved.launchMode) {
+    serveArgs.push('--launch-mode', resolved.launchMode);
+  }
+
+  if (resolved.dashboard) {
     serveArgs.push('--dashboard');
   }
 
   return serveArgs;
+}
+
+export function resolveTopologyOptions(options: ServeArgOptions = {}): ServeArgOptions {
+  const next: ServeArgOptions = { ...options };
+  switch (options.topology) {
+    case 'isolated':
+      next.port ??= 9223;
+      next.userDataDir ??= '~/.openchrome/profiles/isolated';
+      next.launchMode ??= 'isolated';
+      break;
+    case 'ci-headless':
+      next.port ??= 9224;
+      next.userDataDir ??= '~/.openchrome/profiles/ci';
+      next.launchMode ??= 'isolated';
+      break;
+    case 'dev-profile':
+      next.port ??= 9225;
+      next.userDataDir ??= '~/.openchrome/profiles/dev';
+      break;
+    case 'single-owner':
+    case undefined:
+      break;
+  }
+  return next;
+}
+
+export function getTopologyWarning(options: ServeArgOptions = {}): string | null {
+  const resolved = resolveTopologyOptions(options);
+  const usingDefaultPortProfile = resolved.port === undefined && !resolved.userDataDir;
+  if (!usingDefaultPortProfile) return null;
+  return 'Topology note: this config uses the default single-owner Chrome port/profile. Do not install the same direct config in multiple MCP clients at once; choose --topology isolated or explicit --port + --user-data-dir until broker mode is available.';
 }
 
 export function getCodexServerConfig(options: ServeArgOptions = {}): MCPServerConfig {
@@ -92,7 +147,7 @@ export function getClaudeManualServerConfig(options: ServeArgOptions = {}): MCPS
 export function getOpenCodeServerConfig(options: ServeArgOptions = {}): OpenCodeLocalMCPServerConfig {
   return {
     type: 'local',
-    command: ['npx', '--prefer-online', '-y', 'openchrome-mcp@latest', ...getServeArgs(options)],
+    command: ['openchrome', ...getServeArgs(options)],
   };
 }
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,6 +46,10 @@ are optional.
 For manual Codex CLI setup, run `openchrome config --client codex` and add
 the printed `[mcp_servers.openchrome]` block to `~/.codex/config.toml`.
 
+Running multiple MCP clients? Read
+[`docs/mcp/safe-parallelism.md`](./mcp/safe-parallelism.md) before installing
+the same default direct config in more than one client.
+
 ## 2. Confirm core tier is live
 
 Open a fresh chat in your MCP client and ask it to navigate somewhere:

--- a/docs/mcp/safe-parallelism.md
+++ b/docs/mcp/safe-parallelism.md
@@ -4,19 +4,23 @@ OpenChrome can drive many browser tasks in parallel, but the topology matters.
 
 ## Choose one topology
 
-### 1. Broker owner with many clients
+### 1. Broker owner with many clients (early)
 
-Use one OpenChrome broker owner for a shared Chrome profile, then point MCP clients at that owner.
+Use one OpenChrome broker owner for a shared Chrome profile, then point MCP clients at that owner. The `--broker` flag publishes broker metadata that proxy clients discover by matching on `--port` and `--user-data-dir`; the `--http` port is what proxies actually connect through, so the owner must keep running while clients are attached.
+
+Step 1 — start the broker owner once (keeps running):
 
 ```bash
-# Terminal 1: owns Chrome/CDP and publishes broker metadata
 openchrome serve --broker --auto-launch --http 3100 --port 9222 --user-data-dir ~/.openchrome/profiles/shared
+```
 
-# MCP client config: stdio proxy, no direct Chrome attach
+Step 2 — register each MCP client as a stdio proxy with the same `--port` + `--user-data-dir`:
+
+```bash
 openchrome serve --connect-broker --port 9222 --user-data-dir ~/.openchrome/profiles/shared
 ```
 
-This is the long-term shared-profile design: one direct CDP owner, many MCP clients. The broker owns browser lifecycle, leases, reconnect state, and per-target queues.
+This is the long-term shared-profile design: one direct CDP owner, many MCP clients. The broker owns browser lifecycle, leases, reconnect state, and per-target queues. Broker mode is implemented but still early — read the trust policy in [`docs/security/shared-profile-trust.md`](../security/shared-profile-trust.md) before sharing a profile across clients.
 
 ### 2. Independent direct MCP processes with isolated profiles
 
@@ -68,13 +72,13 @@ openchrome setup --client codex --port 9224 --user-data-dir ~/.openchrome/profil
 
 ### Claude + Codex with shared broker
 
-Run one broker owner:
+Step 1 — run one broker owner (keep this process running while clients are attached):
 
 ```bash
 openchrome serve --broker --auto-launch --http 3100 --port 9222 --user-data-dir ~/.openchrome/profiles/shared
 ```
 
-Configure both clients to use the stdio broker proxy command:
+Step 2 — register both Claude and Codex with the stdio broker proxy command, using the same `--port` and `--user-data-dir` as the owner so they discover the same broker metadata:
 
 ```bash
 openchrome serve --connect-broker --port 9222 --user-data-dir ~/.openchrome/profiles/shared

--- a/docs/mcp/safe-parallelism.md
+++ b/docs/mcp/safe-parallelism.md
@@ -1,0 +1,101 @@
+# Safe OpenChrome parallelism
+
+OpenChrome can drive many browser tasks in parallel, but the topology matters.
+
+## Choose one topology
+
+### 1. Broker owner with many clients
+
+Use one OpenChrome broker owner for a shared Chrome profile, then point MCP clients at that owner.
+
+```bash
+# Terminal 1: owns Chrome/CDP and publishes broker metadata
+openchrome serve --broker --auto-launch --http 3100 --port 9222 --user-data-dir ~/.openchrome/profiles/shared
+
+# MCP client config: stdio proxy, no direct Chrome attach
+openchrome serve --connect-broker --port 9222 --user-data-dir ~/.openchrome/profiles/shared
+```
+
+This is the long-term shared-profile design: one direct CDP owner, many MCP clients. The broker owns browser lifecycle, leases, reconnect state, and per-target queues.
+
+### 2. Independent direct MCP processes with isolated profiles
+
+Use this today when you want several MCP clients without sharing a browser profile.
+
+```bash
+openchrome setup --client claude --port 9223 --user-data-dir ~/.openchrome/profiles/claude
+openchrome setup --client codex --port 9224 --user-data-dir ~/.openchrome/profiles/codex
+openchrome setup --client opencode --port 9225 --user-data-dir ~/.openchrome/profiles/opencode
+```
+
+Each process owns a different Chrome instance/profile, so direct CDP control does not conflict.
+
+### 3. Unsafe: many direct MCP processes, one Chrome/profile
+
+Avoid this:
+
+```text
+Claude -> openchrome serve --auto-launch --port 9222 --user-data-dir ~/.openchrome/profile
+Codex  -> openchrome serve --auto-launch --port 9222 --user-data-dir ~/.openchrome/profile
+```
+
+Multiple direct controllers can race on target lifecycle, reconnect, cleanup, and tab ownership. Symptoms include missing MCP tools, `Target closed`, `CDPSession closed`, stale tabs, or unexpected Chrome shutdown.
+
+## Client recipes
+
+### Claude only
+
+```bash
+openchrome setup --client claude
+```
+
+Safe for one client. If another client will also run direct mode, add explicit `--port` and `--user-data-dir`.
+
+### Codex only
+
+```bash
+openchrome setup --client codex
+```
+
+Remove stale `~/.codex/mcp.json` entries if you migrated to `~/.codex/config.toml`.
+
+### Claude + Codex with isolated profiles
+
+```bash
+openchrome setup --client claude --port 9223 --user-data-dir ~/.openchrome/profiles/claude
+openchrome setup --client codex --port 9224 --user-data-dir ~/.openchrome/profiles/codex
+```
+
+### Claude + Codex with shared broker
+
+Run one broker owner:
+
+```bash
+openchrome serve --broker --auto-launch --http 3100 --port 9222 --user-data-dir ~/.openchrome/profiles/shared
+```
+
+Configure both clients to use the stdio broker proxy command:
+
+```bash
+openchrome serve --connect-broker --port 9222 --user-data-dir ~/.openchrome/profiles/shared
+```
+
+### OMX / Codex development
+
+When developing OpenChrome itself while another assistant also uses OpenChrome, prefer isolated dev profiles:
+
+```bash
+openchrome setup --client codex --port 9322 --user-data-dir ~/.openchrome/profiles/openchrome-dev
+```
+
+### CI/headless
+
+Use a disposable profile and a non-default port:
+
+```bash
+openchrome config --client codex --topology ci-headless
+```
+
+## Memory tradeoffs
+
+A shared broker profile can reduce duplicate browser-process overhead, but each active tab can still create renderer, worker, GPU, and cache pressure. Shared Chrome is not a guarantee of flat memory usage. Use fewer active tabs, close unused leases, and prefer isolated CI profiles for reproducibility.

--- a/docs/mcp/topologies.md
+++ b/docs/mcp/topologies.md
@@ -1,0 +1,58 @@
+# OpenChrome MCP topologies
+
+OpenChrome currently supports one safe direct-controller rule:
+
+> Run at most one direct `openchrome serve --auto-launch` process for the same Chrome debug port and user-data directory.
+
+Multiple MCP clients can still run in parallel today, but each direct OpenChrome process should use an explicit isolated Chrome topology until broker mode is available.
+
+## Single-owner default
+
+Use this when one MCP client owns OpenChrome on the default Chrome port/profile.
+
+```bash
+openchrome config --client codex
+openchrome config --client claude
+```
+
+Generated configs use:
+
+```bash
+openchrome serve --auto-launch
+```
+
+Do not install this same direct config in multiple clients at the same time.
+
+## Isolated per-client profiles
+
+Use a different port and user-data directory for each client:
+
+```bash
+openchrome setup --client codex --port 9223 --user-data-dir ~/.openchrome/profiles/codex
+openchrome setup --client claude --port 9224 --user-data-dir ~/.openchrome/profiles/claude
+openchrome setup --client opencode --port 9225 --user-data-dir ~/.openchrome/profiles/opencode
+```
+
+Or use the built-in isolated preset as a starting point:
+
+```bash
+openchrome config --client codex --topology isolated
+```
+
+## CI/headless and development presets
+
+For reproducible automation, prefer an isolated throwaway profile:
+
+```bash
+openchrome config --client codex --topology ci-headless
+```
+
+For local development, use a named development profile:
+
+```bash
+openchrome config --client claude --topology dev-profile
+```
+
+## Future broker topology
+
+The planned broker topology will allow many MCP clients to share one direct Chrome owner. Until that exists, direct shared-profile multi-client setups should be treated as unsafe because independent processes can race over CDP target lifecycle, reconnect, and cleanup.

--- a/docs/mcp/topologies.md
+++ b/docs/mcp/topologies.md
@@ -56,3 +56,8 @@ openchrome config --client claude --topology dev-profile
 ## Future broker topology
 
 The planned broker topology will allow many MCP clients to share one direct Chrome owner. Until that exists, direct shared-profile multi-client setups should be treated as unsafe because independent processes can race over CDP target lifecycle, reconnect, and cleanup.
+
+## See also
+
+- [Safe OpenChrome parallelism](./safe-parallelism.md)
+- [Parallelism troubleshooting](./troubleshooting-parallelism.md)

--- a/docs/mcp/topologies.md
+++ b/docs/mcp/topologies.md
@@ -4,7 +4,7 @@ OpenChrome currently supports one safe direct-controller rule:
 
 > Run at most one direct `openchrome serve --auto-launch` process for the same Chrome debug port and user-data directory.
 
-Multiple MCP clients can still run in parallel today, but each direct OpenChrome process should use an explicit isolated Chrome topology until broker mode is available.
+Multiple MCP clients can still run in parallel today, either through isolated direct topologies or through the shared broker (early — see [Safe OpenChrome parallelism](./safe-parallelism.md) for full recipes and tradeoffs).
 
 ## Single-owner default
 
@@ -53,9 +53,9 @@ For local development, use a named development profile:
 openchrome config --client claude --topology dev-profile
 ```
 
-## Future broker topology
+## Shared broker topology (early)
 
-The planned broker topology will allow many MCP clients to share one direct Chrome owner. Until that exists, direct shared-profile multi-client setups should be treated as unsafe because independent processes can race over CDP target lifecycle, reconnect, and cleanup.
+The broker topology lets many MCP clients share one direct Chrome owner. It is implemented (`openchrome serve --broker` plus `openchrome serve --connect-broker`) but still early — exercise it with care. Direct shared-profile multi-client setups without the broker remain unsafe because independent processes race over CDP target lifecycle, reconnect, and cleanup. See [Safe OpenChrome parallelism](./safe-parallelism.md) for the full broker recipe.
 
 ## See also
 

--- a/docs/mcp/troubleshooting-parallelism.md
+++ b/docs/mcp/troubleshooting-parallelism.md
@@ -2,11 +2,7 @@
 
 ## MCP disconnected or tools disappeared
 
-1. Run diagnostics:
-
-   ```bash
-   openchrome doctor --check duplicate-controllers
-   ```
+1. From an MCP client, call `oc_doctor_report` and `oc_connection_health` — these expose the duplicate-controller signal and broker lifecycle directly through the MCP contract.
 
 2. Check running OpenChrome processes:
 
@@ -29,10 +25,8 @@ Likely causes:
 
 Safe next steps:
 
-```bash
-openchrome doctor --json
-openchrome check --port 9222
-```
+- Call `oc_doctor_report` (MCP) for a structured diagnostic snapshot, or `oc_connection_health` for the live controller topology and broker lifecycle state.
+- Run `openchrome check --port 9222` to confirm Chrome is still reachable on that port (this is a bare Chrome ping, not a parallelism diagnostic).
 
 Then restart only the affected MCP client or switch it to `--connect-broker` / isolated profile mode.
 
@@ -51,9 +45,17 @@ Codex now uses `~/.codex/config.toml`. If `~/.codex/mcp.json` still contains Ope
 
 ## Broker health checks
 
-Use `oc_connection_health` and the optional `/health` endpoint to inspect:
+Use the `oc_connection_health` MCP tool, or the optional `/health` HTTP endpoint when `--http` is enabled, to inspect controller topology and broker lifecycle. Both surfaces include sibling fields shaped like:
 
-- `controllerTopology.role`
-- `brokerLifecycle.mode`
-- `brokerLifecycle.reconnectState`
-- `brokerLifecycle.activeLeases`
+```json
+{
+  "controllerTopology": { "role": "owner" },
+  "brokerLifecycle": {
+    "mode": "broker-owner",
+    "reconnectState": "idle",
+    "activeLeases": 0
+  }
+}
+```
+
+`mode` is one of `direct`, `broker-owner`, or `broker-client`; `reconnectState` is one of `idle`, `reconnecting`, or `failed`.

--- a/docs/mcp/troubleshooting-parallelism.md
+++ b/docs/mcp/troubleshooting-parallelism.md
@@ -1,0 +1,59 @@
+# Troubleshooting OpenChrome parallelism
+
+## MCP disconnected or tools disappeared
+
+1. Run diagnostics:
+
+   ```bash
+   openchrome doctor --check duplicate-controllers
+   ```
+
+2. Check running OpenChrome processes:
+
+   ```bash
+   ps aux | grep openchrome-mcp
+   ```
+
+3. If several processes target the same port/profile, either stop the extra client cleanly or move clients to explicit isolated ports/profiles.
+
+Avoid broad `pkill` commands unless you have confirmed the processes are disposable.
+
+## `Target closed` or `CDPSession closed`
+
+Likely causes:
+
+- another direct controller closed or detached the tab;
+- Chrome restarted while a client still held stale target IDs;
+- memory-pressure cleanup closed an unleased tab;
+- stale client config launched a second OpenChrome copy.
+
+Safe next steps:
+
+```bash
+openchrome doctor --json
+openchrome check --port 9222
+```
+
+Then restart only the affected MCP client or switch it to `--connect-broker` / isolated profile mode.
+
+## Multiple `openchrome-mcp` installs
+
+Mixed global and `npm exec openchrome-mcp@latest` registrations can launch different binaries against the same Chrome. Prefer generated configs from:
+
+```bash
+openchrome setup --client codex
+openchrome setup --client claude
+```
+
+## Stale Codex `mcp.json`
+
+Codex now uses `~/.codex/config.toml`. If `~/.codex/mcp.json` still contains OpenChrome, remove or archive that stale entry after confirming `config.toml` has the intended server.
+
+## Broker health checks
+
+Use `oc_connection_health` and the optional `/health` endpoint to inspect:
+
+- `controllerTopology.role`
+- `brokerLifecycle.mode`
+- `brokerLifecycle.reconnectState`
+- `brokerLifecycle.activeLeases`

--- a/docs/security/shared-profile-trust.md
+++ b/docs/security/shared-profile-trust.md
@@ -1,0 +1,52 @@
+# Shared-profile trust model
+
+Shared-profile broker mode is a **same-trust-zone** feature. It is intended for local workflows where the connected MCP clients are operated by the same user or team and are allowed to share the same Chrome cookies, authenticated sessions, storage, and visible page state.
+
+It is not a hosted browser-cloud isolation boundary.
+
+## Trust boundary
+
+Use shared-profile broker mode only when all connected clients are trusted to access the same browser profile.
+
+Use separate ports/profiles when clients are unrelated, untrusted, externally exposed, or belong to different tenants:
+
+```bash
+openchrome setup --client claude --port 9223 --user-data-dir ~/.openchrome/profiles/claude
+openchrome setup --client codex --port 9224 --user-data-dir ~/.openchrome/profiles/codex
+```
+
+## Identity model
+
+Policy decisions use host-neutral identifiers:
+
+- `clientId`: MCP/HTTP client identity when known.
+- `sessionId`: OpenChrome session identity.
+- `workerId` / `laneId`: task subdivision identity.
+- `targetId`: Chrome target/tab identity.
+- target leases: the broker-side ownership record tying targets to the identifiers above.
+
+No policy may privilege Claude, Codex, OpenCode, or an unknown MCP host. The same rules apply to every client.
+
+## Diagnostics and redaction
+
+Broker diagnostics should not expose sensitive cross-tenant details by default. Lease diagnostics may show ownership metadata, but URLs, titles, cookies, storage, screenshots, and page text must be omitted or redacted unless policy explicitly allows cross-tenant diagnostics.
+
+Environment flags:
+
+- `OPENCHROME_SHARED_PROFILE_UNTRUSTED=1`: declare that clients are not in one trust zone; shared-profile broker startup should be rejected and isolated profiles should be used.
+- `OPENCHROME_SHARED_PROFILE_CROSS_TENANT_DIAGNOSTICS=1`: allow cross-tenant lease diagnostics for trusted local debugging.
+
+## HTTP daemon default
+
+A shared-profile HTTP broker must bind to loopback by default and use existing HTTP auth controls before exposure beyond localhost. Do not expose a shared profile broker on a public network.
+
+## Required separate-profile cases
+
+Use separate profiles/ports for:
+
+- different users;
+- CI jobs from different trust domains;
+- untrusted agents;
+- public or remote HTTP clients;
+- workflows that must not share cookies/history/storage;
+- compliance or audit boundaries.

--- a/docs/security/shared-profile-trust.md
+++ b/docs/security/shared-profile-trust.md
@@ -33,7 +33,7 @@ Broker diagnostics should not expose sensitive cross-tenant details by default. 
 
 Environment flags:
 
-- `OPENCHROME_SHARED_PROFILE_UNTRUSTED=1`: declare that clients are not in one trust zone; shared-profile broker startup should be rejected and isolated profiles should be used.
+- `OPENCHROME_SHARED_PROFILE_UNTRUSTED=1`: declare that clients are not in one trust zone. Any shared-profile entry point — `openchrome serve --broker` and `openchrome serve --allow-unsafe-shared-attach` (or `OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH=1`) — is rejected; isolated profiles must be used instead.
 - `OPENCHROME_SHARED_PROFILE_CROSS_TENANT_DIAGNOSTICS=1`: allow cross-tenant lease diagnostics for trusted local debugging.
 
 ## HTTP daemon default

--- a/src/broker/discovery.ts
+++ b/src/broker/discovery.ts
@@ -1,0 +1,79 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { getVersion } from '../version';
+import { controllerLockKey, normalizeControllerUserDataDir } from '../utils/controller-lock';
+
+export interface BrokerIdentity {
+  port: number;
+  userDataDir: string;
+  httpHost: string;
+  httpPort: number;
+  pid?: number;
+  startedAt?: string;
+  version?: string;
+  authTokenEnv?: string;
+}
+
+export interface BrokerMetadata {
+  schemaVersion: 1;
+  pid: number;
+  version: string;
+  startedAt: string;
+  port: number;
+  userDataDir: string;
+  endpoint: string;
+  authTokenEnv?: string;
+}
+
+export function getBrokerRegistryDir(rootDir = process.env.OPENCHROME_BROKER_REGISTRY_DIR): string {
+  return rootDir || path.join(os.homedir(), '.openchrome', 'brokers');
+}
+
+export function getBrokerMetadataPath(port: number, userDataDir: string, rootDir?: string): string {
+  return path.join(getBrokerRegistryDir(rootDir), `${controllerLockKey(port, userDataDir)}.json`);
+}
+
+function normalizeHost(host: string): string {
+  return host === '0.0.0.0' ? '127.0.0.1' : host;
+}
+
+export function buildBrokerMetadata(identity: BrokerIdentity): BrokerMetadata {
+  const userDataDir = normalizeControllerUserDataDir(identity.userDataDir);
+  return {
+    schemaVersion: 1,
+    pid: identity.pid ?? process.pid,
+    version: identity.version ?? getVersion(),
+    startedAt: identity.startedAt ?? new Date().toISOString(),
+    port: identity.port,
+    userDataDir,
+    endpoint: `http://${normalizeHost(identity.httpHost)}:${identity.httpPort}/mcp`,
+    ...(identity.authTokenEnv ? { authTokenEnv: identity.authTokenEnv } : {}),
+  };
+}
+
+export function publishBrokerMetadata(identity: BrokerIdentity, rootDir?: string): BrokerMetadata {
+  const metadata = buildBrokerMetadata(identity);
+  const filePath = getBrokerMetadataPath(identity.port, metadata.userDataDir, rootDir);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(metadata, null, 2) + '\n', { mode: 0o600 });
+  return metadata;
+}
+
+export function readBrokerMetadata(port: number, userDataDir: string, rootDir?: string): BrokerMetadata | null {
+  const filePath = getBrokerMetadataPath(port, userDataDir, rootDir);
+  try {
+    const metadata = JSON.parse(fs.readFileSync(filePath, 'utf8')) as BrokerMetadata;
+    if (metadata.schemaVersion !== 1 || typeof metadata.endpoint !== 'string' || typeof metadata.pid !== 'number') return null;
+    return metadata;
+  } catch {
+    return null;
+  }
+}
+
+export function removeBrokerMetadata(port: number, userDataDir: string, pid = process.pid, rootDir?: string): void {
+  const filePath = getBrokerMetadataPath(port, userDataDir, rootDir);
+  const existing = readBrokerMetadata(port, userDataDir, rootDir);
+  if (existing && existing.pid !== pid) return;
+  try { fs.unlinkSync(filePath); } catch { /* best effort */ }
+}

--- a/src/broker/lifecycle.ts
+++ b/src/broker/lifecycle.ts
@@ -1,0 +1,56 @@
+export type BrokerLifecycleMode = 'direct' | 'broker-owner' | 'broker-client';
+export type BrokerReconnectState = 'idle' | 'reconnecting' | 'failed';
+
+export interface BrokerLifecycleState {
+  mode: BrokerLifecycleMode;
+  reconnectState: BrokerReconnectState;
+  activeLeases: number;
+  lastReconnectAt?: number;
+  lastDisconnectAt?: number;
+  lastError?: string;
+}
+
+const state: BrokerLifecycleState = {
+  mode: 'direct',
+  reconnectState: 'idle',
+  activeLeases: 0,
+};
+
+export function setBrokerLifecycleMode(mode: BrokerLifecycleMode): void {
+  state.mode = mode;
+}
+
+export function markBrokerReconnectStart(now = Date.now()): void {
+  state.reconnectState = 'reconnecting';
+  state.lastDisconnectAt = now;
+  delete state.lastError;
+}
+
+export function markBrokerReconnectSuccess(now = Date.now()): void {
+  state.reconnectState = 'idle';
+  state.lastReconnectAt = now;
+  delete state.lastError;
+}
+
+export function markBrokerReconnectFailed(error: string, now = Date.now()): void {
+  state.reconnectState = 'failed';
+  state.lastDisconnectAt = now;
+  state.lastError = error;
+}
+
+export function setBrokerActiveLeases(count: number): void {
+  state.activeLeases = Math.max(0, count);
+}
+
+export function getBrokerLifecycleState(): BrokerLifecycleState {
+  return { ...state };
+}
+
+export function resetBrokerLifecycleState(): void {
+  state.mode = 'direct';
+  state.reconnectState = 'idle';
+  state.activeLeases = 0;
+  delete state.lastReconnectAt;
+  delete state.lastDisconnectAt;
+  delete state.lastError;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -21,6 +21,7 @@ import { checkMacosPerms } from './doctor/checks/macos-perms';
 import { checkNetworkLocal } from './doctor/checks/network-local';
 import { checkNetworkRemote } from './doctor/checks/network-remote';
 import { checkOptionalDeps } from './doctor/checks/optional-deps';
+import { checkDuplicateControllers } from './doctor/checks/duplicate-controllers';
 
 export type CheckStatus = 'ok' | 'warn' | 'fail' | 'skip';
 
@@ -56,6 +57,7 @@ const ALL_CHECKS: Array<{ id: string; fn: CheckFn }> = [
   { id: 'pid-lock', fn: checkPidLock },
   { id: 'orphan-chrome', fn: checkOrphanChrome },
   { id: 'profile-lock', fn: checkProfileLock },
+  { id: 'duplicate-controllers', fn: checkDuplicateControllers },
   { id: 'disk-space', fn: checkDiskSpace },
   { id: 'macos-perms', fn: checkMacosPerms },
   { id: 'network-local', fn: checkNetworkLocal },

--- a/src/cli/doctor/checks/duplicate-controllers.ts
+++ b/src/cli/doctor/checks/duplicate-controllers.ts
@@ -1,0 +1,32 @@
+/**
+ * Check: duplicate-controllers
+ * Surfaces unsafe multi-controller OpenChrome topologies before they cause CDP disconnects.
+ */
+
+import type { CheckFn } from '../../doctor';
+import { summarizeDuplicateControllerDiagnostics } from '../../../utils/duplicate-controller-diagnostics';
+
+export const checkDuplicateControllers: CheckFn = async () => {
+  const diagnostics = summarizeDuplicateControllerDiagnostics();
+  if (diagnostics.warnings.length === 0) {
+    return {
+      id: 'duplicate-controllers',
+      title: 'Duplicate OpenChrome controllers',
+      status: 'ok',
+      detail: `${diagnostics.processes.length} OpenChrome MCP process(es), no duplicate port/profile groups detected`,
+    };
+  }
+
+  const duplicateDetail = diagnostics.duplicateGroups.map((group) => (
+    `port ${group.port}, profile ${group.userDataDir}: pid(s) ${group.processes.map((proc) => proc.pid).join(', ')}`
+  ));
+  const detailParts = [...diagnostics.warnings, ...duplicateDetail];
+
+  return {
+    id: 'duplicate-controllers',
+    title: 'Duplicate OpenChrome controllers',
+    status: 'warn',
+    detail: detailParts.join('; '),
+    remediation: diagnostics.remediation.join(' '),
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,8 @@ program
   .option('--auth-token <token>', 'Bearer token for HTTP transport authentication (also: OPENCHROME_AUTH_TOKEN env var)')
   .option('--allow-unauthenticated-http', 'Explicitly allow unauthenticated loopback-only HTTP development mode (also: OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP=1)')
   .option('--transport <mode>', 'Transport mode: stdio, http, or both (default: stdio)')
+  .option('--broker', 'Run as the shared-profile broker owner (HTTP daemon plus broker discovery metadata)')
+  .option('--connect-broker', 'Proxy stdio MCP requests to the discovered broker instead of attaching to Chrome directly')
   .option('--idle-timeout <duration>', 'Self-exit (code 0) after idle window with zero sessions. Format: <number>(ms|s|m|h), e.g. 30m, 90s, 500ms. Bare numbers are rejected. Also: OPENCHROME_IDLE_TIMEOUT_MS env var (integer ms). Default: disabled.')
   .option('--pilot', 'Enable experimental pilot tier (see docs/roadmap/portability-harness-contract.md). Off by default; lazy-loads src/pilot/ modules when set. Also: OPENCHROME_PILOT=1 env var.')
   .option('--slim', 'Expose only core tools (alias for --tools-only core).')
@@ -125,7 +127,7 @@ program
   .option('--launch-mode <mode>', 'Chrome launch mode: auto | attach | isolated (#659). Also: OPENCHROME_LAUNCH_MODE env var.')
   .option('--secrets <path>', 'Load a dotenv-format secrets file (KEY=value per line). Tokens "${SECRET:NAME}" in tool arguments are substituted to the real value at MCP request deserialization; the same values are redacted from every LLM-visible artifact (responses, trace, skill records, journal). Default: no secrets loaded. P3: no OS keychain integration.')
   .option('--codegen <mode>', 'Opt-in replay artifact generation: off, puppeteer, playwright, or mcp-replay. Default: off (no response shape changes). Also: OPENCHROME_CODEGEN.')
-  .action(async (options: { port: string; autoLaunch?: boolean; allowUnsafeSharedAttach?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; windowSize?: string; windowPosition?: string; windowBounds?: string; startMaximized?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; idleTimeout?: string; allowUnauthenticatedHttp?: boolean; pilot?: boolean; slim?: boolean; toolsOnly?: string; disableTools?: string; introspectToolsList?: boolean; autoConnect?: string | boolean; launchMode?: string; secrets?: string; codegen?: string }) => {
+  .action(async (options: { port: string; autoLaunch?: boolean; allowUnsafeSharedAttach?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; windowSize?: string; windowPosition?: string; windowBounds?: string; startMaximized?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; broker?: boolean; connectBroker?: boolean; idleTimeout?: string; allowUnauthenticatedHttp?: boolean; pilot?: boolean; slim?: boolean; toolsOnly?: string; disableTools?: string; introspectToolsList?: boolean; autoConnect?: string | boolean; launchMode?: string; secrets?: string; codegen?: string }) => {
     const { normalizeCodegenMode, setCodegenMode } = await import('./core/codegen');
     const codegenMode = normalizeCodegenMode(options.codegen ?? process.env.OPENCHROME_CODEGEN);
     setCodegenMode(codegenMode);
@@ -256,17 +258,32 @@ program
     // Resolve transport mode before owner-lock acquisition so lock metadata
     // describes whether this process is a stdio, HTTP, or dual-transport owner.
     const validModes = ['stdio', 'http', 'both'];
-    const rawMode = options.transport ?? process.env.OPENCHROME_TRANSPORT ?? (options.http !== undefined && options.http !== false ? 'http' : 'stdio');
+    const rawMode = options.broker
+      ? 'http'
+      : options.transport ?? process.env.OPENCHROME_TRANSPORT ?? (options.http !== undefined && options.http !== false ? 'http' : 'stdio');
     if (!validModes.includes(rawMode)) {
       console.error(`[openchrome] Unknown transport mode "${rawMode}", falling back to stdio`);
     }
     const transportMode = validModes.includes(rawMode) ? rawMode : 'stdio';
     const useHttp = transportMode === 'http' || transportMode === 'both';
+    const lockUserDataDir = resolveControllerLockUserDataDir(userDataDir, useHeadlessShell);
+
+    if (options.connectBroker) {
+      const { readBrokerMetadata } = await import('./broker/discovery');
+      const { BrokerProxyStdioBridge } = await import('./transports/broker-proxy');
+      const broker = readBrokerMetadata(port, lockUserDataDir);
+      if (!broker) {
+        console.error(`[openchrome] No broker metadata found for port ${port} and profile ${lockUserDataDir}. Start one with: openchrome serve --broker --auto-launch --port ${port} --user-data-dir ${lockUserDataDir}`);
+        process.exit(2);
+      }
+      console.error(`[openchrome] Proxying stdio MCP requests to broker ${broker.endpoint}`);
+      new BrokerProxyStdioBridge(broker, options.authToken || process.env.OPENCHROME_AUTH_TOKEN || undefined).start();
+      return;
+    }
 
     let controllerLock: ControllerLockHandle | null = null;
     const unsafeSharedAttach = options.allowUnsafeSharedAttach || process.env.OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH === '1';
     if (autoLaunch) {
-      const lockUserDataDir = resolveControllerLockUserDataDir(userDataDir, useHeadlessShell);
       if (unsafeSharedAttach) {
         console.error(
           '[openchrome] Warning: unsafe shared attach guard bypassed. Multiple direct OpenChrome controllers for the same Chrome/profile can disconnect or close each other\'s targets.',
@@ -641,6 +658,12 @@ program
 
       console.error(`[openchrome] Dual transport mode: stdio + HTTP on ${httpHost}:${httpPort}`);
       console.error('[openchrome] Infinite reconnection: enabled (daemon mode)');
+      if (options.broker) {
+        const { publishBrokerMetadata, removeBrokerMetadata } = await import('./broker/discovery');
+        const metadata = publishBrokerMetadata({ port, userDataDir: lockUserDataDir, httpHost, httpPort, authTokenEnv: authToken ? 'OPENCHROME_AUTH_TOKEN' : undefined });
+        process.on('exit', () => removeBrokerMetadata(port, lockUserDataDir));
+        console.error(`[openchrome] Broker metadata: ${metadata.endpoint}`);
+      }
     } else if (useHttp) {
       const httpPort = typeof options.http === 'string' ? parseInt(options.http, 10) : parseInt(process.env.OPENCHROME_HTTP_PORT || '', 10) || 3100;
       const httpHost = (options as Record<string, unknown>).httpHost as string || process.env.OPENCHROME_HTTP_HOST || '127.0.0.1';
@@ -649,6 +672,12 @@ program
       server.start(transport);
       console.error(`[openchrome] HTTP transport enabled on ${httpHost}:${httpPort}`);
       console.error('[openchrome] Infinite reconnection: enabled (daemon mode)');
+      if (options.broker) {
+        const { publishBrokerMetadata, removeBrokerMetadata } = await import('./broker/discovery');
+        const metadata = publishBrokerMetadata({ port, userDataDir: lockUserDataDir, httpHost, httpPort, authTokenEnv: authToken ? 'OPENCHROME_AUTH_TOKEN' : undefined });
+        process.on('exit', () => removeBrokerMetadata(port, lockUserDataDir));
+        console.error(`[openchrome] Broker metadata: ${metadata.endpoint}`);
+      }
     } else {
       server.start();
       console.error('[openchrome] STDIO transport enabled');

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,7 +267,10 @@ program
     // Resolve transport mode before owner-lock acquisition so lock metadata
     // describes whether this process is a stdio, HTTP, or dual-transport owner.
     const validModes = ['stdio', 'http', 'both'];
-    if (options.broker && options.transport && options.transport !== 'http' && options.transport !== 'both') {
+    if (options.broker && options.transport && options.transport !== 'http') {
+      // `both` is also coerced because the broker proxy speaks HTTP only;
+      // advertising a `both` daemon as the broker endpoint would silently
+      // drop the stdio leg without telling the operator.
       console.error(`[openchrome] Warning: --broker forces HTTP transport; ignoring --transport ${options.transport}.`);
     }
     const rawMode = options.broker
@@ -628,8 +631,16 @@ program
     if (process.platform === 'win32') {
       process.on('SIGHUP', () => shutdown('SIGHUP'));
     }
-    // Resolve auth token: CLI flag takes precedence over env var
-    const authToken = options.authToken || process.env.OPENCHROME_AUTH_TOKEN || undefined;
+    // Resolve auth token: CLI flag takes precedence over env var.
+    // Track which source supplied the token so the broker metadata can only
+    // advertise `authTokenEnv` when the value actually lives in that env var
+    // — otherwise a `--connect-broker` client would read the wrong (or no)
+    // token from OPENCHROME_AUTH_TOKEN and silently send unauthenticated.
+    const envAuthToken = process.env.OPENCHROME_AUTH_TOKEN || undefined;
+    const authToken = options.authToken || envAuthToken;
+    const brokerAuthTokenEnv = authToken && !options.authToken && envAuthToken === authToken
+      ? 'OPENCHROME_AUTH_TOKEN'
+      : undefined;
     if (authToken) {
       console.error('[openchrome] Bearer token authentication: enabled');
     }
@@ -687,7 +698,7 @@ program
       console.error('[openchrome] Infinite reconnection: enabled (daemon mode)');
       if (options.broker) {
         const { publishBrokerMetadata, removeBrokerMetadata } = await import('./broker/discovery');
-        const metadata = publishBrokerMetadata({ port, userDataDir: lockUserDataDir, httpHost, httpPort, authTokenEnv: authToken ? 'OPENCHROME_AUTH_TOKEN' : undefined });
+        const metadata = publishBrokerMetadata({ port, userDataDir: lockUserDataDir, httpHost, httpPort, authTokenEnv: brokerAuthTokenEnv });
         process.on('exit', () => removeBrokerMetadata(port, lockUserDataDir));
         console.error(`[openchrome] Broker metadata: ${metadata.endpoint}`);
       }
@@ -701,7 +712,7 @@ program
       console.error('[openchrome] Infinite reconnection: enabled (daemon mode)');
       if (options.broker) {
         const { publishBrokerMetadata, removeBrokerMetadata } = await import('./broker/discovery');
-        const metadata = publishBrokerMetadata({ port, userDataDir: lockUserDataDir, httpHost, httpPort, authTokenEnv: authToken ? 'OPENCHROME_AUTH_TOKEN' : undefined });
+        const metadata = publishBrokerMetadata({ port, userDataDir: lockUserDataDir, httpHost, httpPort, authTokenEnv: brokerAuthTokenEnv });
         process.on('exit', () => removeBrokerMetadata(port, lockUserDataDir));
         console.error(`[openchrome] Broker metadata: ${metadata.endpoint}`);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import {
   formatDuplicateControllerMessage,
   type ControllerLockHandle,
 } from './utils/controller-lock';
+import { getCurrentControllerTopology } from './utils/duplicate-controller-diagnostics';
 import {
   DEFAULT_PROCESS_WATCHDOG_INTERVAL_MS,
   DEFAULT_TAB_HEALTH_PROBE_INTERVAL_MS,
@@ -913,6 +914,7 @@ program
         sessions: { active: sessionManager?.sessionCount ?? 0 },
         tenants: { activeContexts: sessionManager?.tenantContextCount ?? 0 },
         listeners: getListenerErrorStats(),
+        controllerTopology: getCurrentControllerTopology({ port, userDataDir: resolveControllerLockUserDataDir(userDataDir, useHeadlessShell) }),
       };
       return data;
     }, healthPort, healthBind) : null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -255,9 +255,21 @@ program
     const useHeadlessShell = options.headlessShell || false;
     const restartChrome = options.restartChrome || false;
 
+    // #1359 broker foundation: --broker and --connect-broker are mutually
+    // exclusive because one publishes broker ownership while the other forwards
+    // stdio JSON-RPC to an existing broker. Combining them produces undefined
+    // behavior (proxy + owner in one process).
+    if (options.broker && options.connectBroker) {
+      console.error('[openchrome] Error: --broker and --connect-broker cannot be combined. Pick one role per process.');
+      process.exit(2);
+    }
+
     // Resolve transport mode before owner-lock acquisition so lock metadata
     // describes whether this process is a stdio, HTTP, or dual-transport owner.
     const validModes = ['stdio', 'http', 'both'];
+    if (options.broker && options.transport && options.transport !== 'http' && options.transport !== 'both') {
+      console.error(`[openchrome] Warning: --broker forces HTTP transport; ignoring --transport ${options.transport}.`);
+    }
     const rawMode = options.broker
       ? 'http'
       : options.transport ?? process.env.OPENCHROME_TRANSPORT ?? (options.http !== undefined && options.http !== false ? 'http' : 'stdio');
@@ -267,6 +279,14 @@ program
     const transportMode = validModes.includes(rawMode) ? rawMode : 'stdio';
     const useHttp = transportMode === 'http' || transportMode === 'both';
     const lockUserDataDir = resolveControllerLockUserDataDir(userDataDir, useHeadlessShell);
+
+    // #1359 P3a: the broker is the single CDP owner for a (port, userDataDir).
+    // Refuse to publish broker metadata when this process did not take Chrome
+    // ownership via the controller lock (i.e., when --auto-launch is off).
+    if (options.broker && !autoLaunch) {
+      console.error('[openchrome] Error: --broker requires --auto-launch so this process owns Chrome lifecycle and the controller lock for the shared profile.');
+      process.exit(2);
+    }
 
     if (options.connectBroker) {
       const { readBrokerMetadata } = await import('./broker/discovery');

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,8 +296,15 @@ program
         console.error(`[openchrome] No broker metadata found for port ${port} and profile ${lockUserDataDir}. Start one with: openchrome serve --broker --auto-launch --port ${port} --user-data-dir ${lockUserDataDir}`);
         process.exit(2);
       }
+      // #1359 P3a follow-up: the broker advertises which env var holds its
+      // bearer token via `authTokenEnv`. Honour that hint so a client that
+      // only knows the broker file (not the original launch invocation) can
+      // still authenticate without the operator restating --auth-token.
+      const resolvedAuthToken = options.authToken
+        || process.env.OPENCHROME_AUTH_TOKEN
+        || (broker.authTokenEnv ? process.env[broker.authTokenEnv] : undefined);
       console.error(`[openchrome] Proxying stdio MCP requests to broker ${broker.endpoint}`);
-      new BrokerProxyStdioBridge(broker, options.authToken || process.env.OPENCHROME_AUTH_TOKEN || undefined).start();
+      new BrokerProxyStdioBridge(broker, resolvedAuthToken).start();
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ import {
 } from './utils/controller-lock';
 import { getCurrentControllerTopology } from './utils/duplicate-controller-diagnostics';
 import { setBrokerLifecycleMode, getBrokerLifecycleState } from './broker/lifecycle';
+import { assertSharedProfileAllowed } from './security/shared-profile-policy';
 import {
   DEFAULT_PROCESS_WATCHDOG_INTERVAL_MS,
   DEFAULT_TAB_HEALTH_PROBE_INTERVAL_MS,
@@ -283,6 +284,12 @@ program
       return;
     }
     if (options.broker) {
+      try {
+        assertSharedProfileAllowed();
+      } catch (err) {
+        console.error(`[openchrome] ${(err as Error).message}`);
+        process.exit(2);
+      }
       setBrokerLifecycleMode('broker-owner');
       process.env.OPENCHROME_BROKER_OWNER = '1';
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -298,6 +298,12 @@ program
     const unsafeSharedAttach = options.allowUnsafeSharedAttach || process.env.OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH === '1';
     if (autoLaunch) {
       if (unsafeSharedAttach) {
+        try {
+          assertSharedProfileAllowed();
+        } catch (err) {
+          console.error(`[openchrome] ${(err as Error).message}`);
+          process.exit(2);
+        }
         console.error(
           '[openchrome] Warning: unsafe shared attach guard bypassed. Multiple direct OpenChrome controllers for the same Chrome/profile can disconnect or close each other\'s targets.',
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import {
   type ControllerLockHandle,
 } from './utils/controller-lock';
 import { getCurrentControllerTopology } from './utils/duplicate-controller-diagnostics';
+import { setBrokerLifecycleMode, getBrokerLifecycleState } from './broker/lifecycle';
 import {
   DEFAULT_PROCESS_WATCHDOG_INTERVAL_MS,
   DEFAULT_TAB_HEALTH_PROBE_INTERVAL_MS,
@@ -277,8 +278,13 @@ program
         process.exit(2);
       }
       console.error(`[openchrome] Proxying stdio MCP requests to broker ${broker.endpoint}`);
+      setBrokerLifecycleMode('broker-client');
       new BrokerProxyStdioBridge(broker, options.authToken || process.env.OPENCHROME_AUTH_TOKEN || undefined).start();
       return;
+    }
+    if (options.broker) {
+      setBrokerLifecycleMode('broker-owner');
+      process.env.OPENCHROME_BROKER_OWNER = '1';
     }
 
     let controllerLock: ControllerLockHandle | null = null;
@@ -944,6 +950,7 @@ program
         tenants: { activeContexts: sessionManager?.tenantContextCount ?? 0 },
         listeners: getListenerErrorStats(),
         controllerTopology: getCurrentControllerTopology({ port, userDataDir: resolveControllerLockUserDataDir(userDataDir, useHeadlessShell) }),
+        brokerLifecycle: getBrokerLifecycleState(),
       };
       return data;
     }, healthPort, healthBind) : null;

--- a/src/security/shared-profile-policy.ts
+++ b/src/security/shared-profile-policy.ts
@@ -1,0 +1,73 @@
+import type { TargetLeaseRecord } from '../session/target-lease-registry';
+
+export type SharedProfileTrustMode = 'same-trust-zone' | 'isolated-required';
+
+export interface SharedProfilePolicy {
+  trustMode: SharedProfileTrustMode;
+  allowCrossTenantDiagnostics: boolean;
+  redactUrls: boolean;
+  redactTitles: boolean;
+}
+
+export interface RedactedLeaseDiagnostic {
+  targetId: string;
+  sessionId: string;
+  clientId?: string;
+  workerId?: string;
+  laneId?: string;
+  contextName?: string;
+  createdAt: number;
+  lastActivityAt: number;
+  leaseExpiresAt?: number;
+  cleanupPolicy: string;
+  redacted: boolean;
+}
+
+export function getSharedProfilePolicy(env: NodeJS.ProcessEnv = process.env): SharedProfilePolicy {
+  const allowCrossTenantDiagnostics = env.OPENCHROME_SHARED_PROFILE_CROSS_TENANT_DIAGNOSTICS === '1';
+  const trustMode: SharedProfileTrustMode = env.OPENCHROME_SHARED_PROFILE_UNTRUSTED === '1' ? 'isolated-required' : 'same-trust-zone';
+  return {
+    trustMode,
+    allowCrossTenantDiagnostics,
+    redactUrls: true,
+    redactTitles: true,
+  };
+}
+
+export function assertSharedProfileAllowed(policy = getSharedProfilePolicy()): void {
+  if (policy.trustMode === 'isolated-required') {
+    throw new Error('Shared-profile broker mode is same-trust-zone only. Use separate --port and --user-data-dir for untrusted or unrelated clients.');
+  }
+}
+
+export function canAccessLeaseDiagnostic(
+  lease: TargetLeaseRecord,
+  requester: { sessionId?: string; clientId?: string },
+  policy = getSharedProfilePolicy(),
+): boolean {
+  if (policy.allowCrossTenantDiagnostics) return true;
+  if (requester.sessionId && requester.sessionId === lease.sessionId) return true;
+  if (requester.clientId && lease.clientId && requester.clientId === lease.clientId) return true;
+  return false;
+}
+
+export function redactLeaseDiagnostic(
+  lease: TargetLeaseRecord,
+  requester: { sessionId?: string; clientId?: string },
+  policy = getSharedProfilePolicy(),
+): RedactedLeaseDiagnostic | null {
+  if (!canAccessLeaseDiagnostic(lease, requester, policy)) return null;
+  return {
+    targetId: lease.targetId,
+    sessionId: lease.sessionId,
+    ...(lease.clientId ? { clientId: lease.clientId } : {}),
+    ...(lease.workerId ? { workerId: lease.workerId } : {}),
+    ...(lease.laneId ? { laneId: lease.laneId } : {}),
+    ...(lease.contextName ? { contextName: lease.contextName } : {}),
+    createdAt: lease.createdAt,
+    lastActivityAt: lease.lastActivityAt,
+    ...(lease.leaseExpiresAt ? { leaseExpiresAt: lease.leaseExpiresAt } : {}),
+    cleanupPolicy: lease.cleanupPolicy,
+    redacted: policy.redactUrls || policy.redactTitles,
+  };
+}

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import { Page, Target, BrowserContext, Browser } from 'puppeteer-core';
 import { Session, SessionInfo, SessionCreateOptions, SessionEvent, Worker, WorkerInfo, WorkerCreateOptions } from './types/session';
 import { TargetOwnershipRegistry } from './session/target-registry';
+import { TargetLeaseRegistry, type TargetLeaseRecord } from './session/target-lease-registry';
 import { CDPClient, getCDPClient, CDPClientFactory, getCDPClientFactory } from './cdp/client';
 import { CDPConnectionPool, getCDPConnectionPool, PoolStats } from './cdp/connection-pool';
 import { ChromePool, getChromePool } from './chrome/pool';
@@ -111,6 +112,7 @@ const DEFAULT_CONFIG: Required<Omit<SessionManagerConfig, 'tenantManager' | 'str
 export class SessionManager {
   private sessions: Map<string, Session> = new Map();
   private targetToWorker = new TargetOwnershipRegistry();
+  private targetLeases = new TargetLeaseRegistry();
   /**
    * Maps targetId → `{browser, name}` for the owning named context (#848).
    * Targets opened in the default Chrome context are not present here;
@@ -228,6 +230,28 @@ export class SessionManager {
       if (client) return client;
     }
     return this.cdpClient;
+  }
+
+  private acquireTargetLease(
+    targetId: string,
+    sessionId: string,
+    workerId: string,
+    contextName?: string,
+    parentTargetId?: string,
+  ): void {
+    if (parentTargetId && this.targetLeases.inherit(targetId, parentTargetId, { sessionId, workerId, contextName })) {
+      return;
+    }
+    this.targetLeases.acquire({ targetId, sessionId, workerId, contextName });
+  }
+
+  getTargetLease(targetId: string): TargetLeaseRecord | undefined {
+    const lease = this.targetLeases.get(targetId);
+    return lease ? { ...lease } : undefined;
+  }
+
+  getTargetLeaseSnapshot(): TargetLeaseRecord[] {
+    return this.targetLeases.snapshot();
   }
 
   /**
@@ -562,6 +586,7 @@ export class SessionManager {
 
     // Remove session
     this.sessions.delete(sessionId);
+    this.targetLeases.releaseSession(sessionId);
     this.emitEvent({ type: 'session:deleted', sessionId, timestamp: Date.now() });
     this.emitLifecycle({ kind: 'session:destroy', sessionId, reason, ts: Date.now() });
 
@@ -593,6 +618,8 @@ export class SessionManager {
         this.totalSessionsCleaned++;
       }
     }
+
+    this.targetLeases.expire(now);
 
     // Trigger browser-level GC after bulk cleanup
     if (deletedSessions.length > 0) {
@@ -1117,6 +1144,7 @@ export class SessionManager {
       resolvedContextName = isolatedContext;
       resolvedIsolated = true;
     }
+    this.acquireTargetLease(targetId, sessionId, worker.id, resolvedContextName);
 
     this.emitEvent({
       type: 'session:target-added',
@@ -1198,6 +1226,7 @@ export class SessionManager {
     worker.targets.add(targetId);
     worker.lastActivityAt = Date.now();
     this.targetToWorker.set(targetId, { sessionId, workerId: worker.id });
+    this.acquireTargetLease(targetId, sessionId, worker.id);
 
     // Track as stealth target for human-behavior integration in tools
     this.stealthTargets.add(targetId);
@@ -1235,6 +1264,7 @@ export class SessionManager {
     worker.targets.add(targetId);
     worker.lastActivityAt = Date.now();
     this.targetToWorker.set(targetId, { sessionId, workerId });
+    this.acquireTargetLease(targetId, sessionId, workerId);
 
     this.emitEvent({
       type: 'session:target-added',
@@ -1513,6 +1543,7 @@ export class SessionManager {
     worker.targets.add(targetId);
     worker.lastActivityAt = Date.now();
     this.targetToWorker.set(targetId, { sessionId, workerId });
+    this.acquireTargetLease(targetId, sessionId, workerId, undefined, opts?.inheritContextFromTargetId);
 
     // #848 Codex P1: inherit named-context mapping from the opener so popup
     // tab accounting matches the parent. Skip when the parent lives in the
@@ -1587,6 +1618,7 @@ export class SessionManager {
 
       // Remove from mapping
       this.targetToWorker.delete(targetId);
+      this.targetLeases.release(targetId, sessionId);
 
       // #848: drop named-context association on graceful close.
       const ctxEntry = this.targetToContext.get(targetId);
@@ -1684,6 +1716,7 @@ export class SessionManager {
         getRefIdManager().clearTargetRefs(ownerInfo.sessionId, targetId);
 
         this.targetToWorker.delete(targetId);
+        this.targetLeases.release(targetId, ownerInfo.sessionId);
         this.stealthTargets.delete(targetId);
 
         // #848: drop the named-context association and let the registry
@@ -1853,6 +1886,7 @@ export class SessionManager {
 
     const aliveTargets = browser.targets().filter(t => t.type() === 'page');
     const aliveTargetIds = new Set(aliveTargets.map(t => getTargetId(t)));
+    this.targetLeases.reconcileAliveTargetIds(aliveTargetIds);
 
     // Build a map of untracked live targets by URL for re-mapping
     const untrackedByUrl = new Map<string, Target>();

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -907,6 +907,11 @@ export class SessionManager {
         // Page might already be closed
       }
       this.targetToWorker.delete(targetId);
+      // #1359 backlog item 3: closePage triggers targetdestroyed → onTargetClosed
+      // asynchronously, but targetToWorker.delete above runs first, so by the
+      // time the event handler fires it cannot resolve the owner. Release the
+      // lease here so the registry stays consistent with the legacy map.
+      this.targetLeases.release(targetId, session.id);
     }
 
     // Close the browser context (only if it's an isolated context, not the default)
@@ -1390,6 +1395,13 @@ export class SessionManager {
       // Re-register the target
       worker.targets.add(targetId);
       this.targetToWorker.set(targetId, { sessionId, workerId: resolvedWorkerId });
+      // #1359 backlog item 3: keep the lease registry in sync with the
+      // recovered ownership so reconcile/expire/diagnostics observe the same
+      // session/worker the legacy targetToWorker map records. Recovery
+      // intentionally transfers ownership, so drop any stale lease the
+      // previous owner left behind before acquiring fresh.
+      this.targetLeases.release(targetId);
+      this.acquireTargetLease(targetId, sessionId, resolvedWorkerId);
       console.error(`[SessionManager] Recovered untracked target ${targetId.slice(0, 8)} (${pageUrl.slice(0, 50)}) into session ${sessionId} worker ${resolvedWorkerId}`);
 
       return page;
@@ -1932,6 +1944,11 @@ export class SessionManager {
         // Update targetToWorker mapping
         this.targetToWorker.delete(targetId);
         this.targetToWorker.set(newTargetId, ownerInfo);
+        // #1359 backlog item 3: reconcileAliveTargetIds above already dropped
+        // the old targetId from the lease registry. Acquire a fresh lease
+        // for the re-mapped targetId so diagnostics and cleanup observe the
+        // same ownership the legacy map records.
+        this.acquireTargetLease(newTargetId, ownerInfo.sessionId, ownerInfo.workerId);
 
         // Update worker's target set
         const session = this.sessions.get(ownerInfo.sessionId);

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -189,7 +189,12 @@ export class SessionManager {
         console.error('[SessionManager] Reconnect failed, clearing stale target mappings');
         for (const targetId of Array.from(this.targetToWorker.keys())) {
           this.onTargetClosed(targetId);
-          // Safety: force-delete in case session is already gone and onTargetClosed skipped it
+          // Safety: force-delete in case session is already gone and
+          // onTargetClosed skipped it. The lease release mirrors the
+          // targetToWorker.delete below so the lease registry never
+          // outlives the legacy ownership map — leases without a TTL
+          // would otherwise survive indefinitely after Chrome disappears.
+          this.targetLeases.release(targetId);
           this.targetToWorker.delete(targetId);
         }
       }

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import { Page, Target, BrowserContext, Browser } from 'puppeteer-core';
 import { Session, SessionInfo, SessionCreateOptions, SessionEvent, Worker, WorkerInfo, WorkerCreateOptions } from './types/session';
 import { TargetOwnershipRegistry } from './session/target-registry';
-import { TargetLeaseRegistry, type TargetLeaseRecord } from './session/target-lease-registry';
+import { TargetLeaseConflictError, TargetLeaseRegistry, type TargetLeaseRecord } from './session/target-lease-registry';
 import { CDPClient, getCDPClient, CDPClientFactory, getCDPClientFactory } from './cdp/client';
 import { CDPConnectionPool, getCDPConnectionPool, PoolStats } from './cdp/connection-pool';
 import { ChromePool, getChromePool } from './chrome/pool';
@@ -242,7 +242,25 @@ export class SessionManager {
     if (parentTargetId && this.targetLeases.inherit(targetId, parentTargetId, { sessionId, workerId, contextName })) {
       return;
     }
-    this.targetLeases.acquire({ targetId, sessionId, workerId, contextName });
+    try {
+      this.targetLeases.acquire({ targetId, sessionId, workerId, contextName });
+    } catch (err) {
+      // #1359 backlog item 3: a conflicting lease means a stale or rogue
+      // owner still holds the registry entry — log loudly so operators see
+      // the duplicate-controller signal, then transfer ownership to the
+      // caller. This keeps the legacy targetToWorker map (which has already
+      // recorded the new owner) consistent with the registry and prevents
+      // the conflict from killing the caller's tool invocation.
+      if (err instanceof TargetLeaseConflictError) {
+        console.error(
+          `[SessionManager] Target ${targetId.slice(0, 8)} lease conflict: previous owner session=${err.existing.sessionId} worker=${err.existing.workerId ?? 'unknown'}; transferring to session=${sessionId} worker=${workerId}`,
+        );
+        this.targetLeases.release(targetId);
+        this.targetLeases.acquire({ targetId, sessionId, workerId, contextName });
+        return;
+      }
+      throw err;
+    }
   }
 
   getTargetLease(targetId: string): TargetLeaseRecord | undefined {

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -8,6 +8,7 @@ import { Page, Target, BrowserContext, Browser } from 'puppeteer-core';
 import { Session, SessionInfo, SessionCreateOptions, SessionEvent, Worker, WorkerInfo, WorkerCreateOptions } from './types/session';
 import { TargetOwnershipRegistry } from './session/target-registry';
 import { TargetLeaseConflictError, TargetLeaseRegistry, type TargetLeaseRecord } from './session/target-lease-registry';
+import { TargetQueueManager } from './session/target-command-queue';
 import { CDPClient, getCDPClient, CDPClientFactory, getCDPClientFactory } from './cdp/client';
 import { CDPConnectionPool, getCDPConnectionPool, PoolStats } from './cdp/connection-pool';
 import { ChromePool, getChromePool } from './chrome/pool';
@@ -129,6 +130,7 @@ export class SessionManager {
   private chromePool: ChromePool | null = null;
   private cdpFactory: CDPClientFactory;
   private queueManager: RequestQueueManager;
+  private targetQueueManager = new TargetQueueManager();
   private eventListeners: ((event: SessionEvent) => void)[] = [];
   private browserRouter: BrowserRouter | null = null;
   private storageStateManagers = new Map<string, StorageStateManager>();
@@ -275,6 +277,10 @@ export class SessionManager {
 
   getTargetLeaseSnapshot(): TargetLeaseRecord[] {
     return this.targetLeases.snapshot();
+  }
+
+  getTargetQueueStats(): ReturnType<TargetQueueManager['getStats']> {
+    return this.targetQueueManager.getStats();
   }
 
   /**
@@ -1654,6 +1660,7 @@ export class SessionManager {
       // Remove from mapping
       this.targetToWorker.delete(targetId);
       this.targetLeases.release(targetId, sessionId);
+      this.targetQueueManager.cancelTarget(targetId);
 
       // #848: drop named-context association on graceful close.
       const ctxEntry = this.targetToContext.get(targetId);
@@ -1723,8 +1730,7 @@ export class SessionManager {
       ? this.getCDPClientForWorker(sessionId, ownerInfo.workerId)
       : this.cdpClient;
 
-    const workerQueueKey = ownerInfo ? `${sessionId}:${ownerInfo.workerId}` : sessionId;
-    return this.queueManager.enqueue(workerQueueKey, async () => {
+    return this.targetQueueManager.enqueue(targetId, async () => {
       const page = await cdpClient.getPageByTargetId(targetId);
       if (!page) {
         throw new Error(`Page not found for target ${targetId}`);
@@ -1752,6 +1758,7 @@ export class SessionManager {
 
         this.targetToWorker.delete(targetId);
         this.targetLeases.release(targetId, ownerInfo.sessionId);
+        this.targetQueueManager.cancelTarget(targetId);
         this.stealthTargets.delete(targetId);
 
         // #848: drop the named-context association and let the registry

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -1929,6 +1929,10 @@ export class SessionManager {
     const aliveTargets = browser.targets().filter(t => t.type() === 'page');
     const aliveTargetIds = new Set(aliveTargets.map(t => getTargetId(t)));
     this.targetLeases.reconcileAliveTargetIds(aliveTargetIds);
+    // #1359 backlog item 4: drop per-target queues whose targetId no longer
+    // exists post-reconnect so closed/expired targets stop holding queue
+    // state and metrics in memory.
+    this.targetQueueManager.reconcileAliveTargetIds(aliveTargetIds);
 
     // Build a map of untracked live targets by URL for re-mapping
     const untrackedByUrl = new Map<string, Target>();

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -253,6 +253,7 @@ export class SessionManager {
     parentTargetId?: string,
   ): void {
     if (parentTargetId && this.targetLeases.inherit(targetId, parentTargetId, { sessionId, workerId, contextName })) {
+      setBrokerActiveLeases(this.targetLeases.snapshot().length);
       return;
     }
     this.targetLeases.acquire({ targetId, sessionId, workerId, contextName });

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -8,6 +8,7 @@ import { Page, Target, BrowserContext, Browser } from 'puppeteer-core';
 import { Session, SessionInfo, SessionCreateOptions, SessionEvent, Worker, WorkerInfo, WorkerCreateOptions } from './types/session';
 import { TargetOwnershipRegistry } from './session/target-registry';
 import { TargetLeaseRegistry, type TargetLeaseRecord } from './session/target-lease-registry';
+import { TargetQueueManager } from './session/target-command-queue';
 import { CDPClient, getCDPClient, CDPClientFactory, getCDPClientFactory } from './cdp/client';
 import { CDPConnectionPool, getCDPConnectionPool, PoolStats } from './cdp/connection-pool';
 import { ChromePool, getChromePool } from './chrome/pool';
@@ -129,6 +130,7 @@ export class SessionManager {
   private chromePool: ChromePool | null = null;
   private cdpFactory: CDPClientFactory;
   private queueManager: RequestQueueManager;
+  private targetQueueManager = new TargetQueueManager();
   private eventListeners: ((event: SessionEvent) => void)[] = [];
   private browserRouter: BrowserRouter | null = null;
   private storageStateManagers = new Map<string, StorageStateManager>();
@@ -252,6 +254,10 @@ export class SessionManager {
 
   getTargetLeaseSnapshot(): TargetLeaseRecord[] {
     return this.targetLeases.snapshot();
+  }
+
+  getTargetQueueStats(): ReturnType<TargetQueueManager['getStats']> {
+    return this.targetQueueManager.getStats();
   }
 
   /**
@@ -1619,6 +1625,7 @@ export class SessionManager {
       // Remove from mapping
       this.targetToWorker.delete(targetId);
       this.targetLeases.release(targetId, sessionId);
+      this.targetQueueManager.cancelTarget(targetId);
 
       // #848: drop named-context association on graceful close.
       const ctxEntry = this.targetToContext.get(targetId);
@@ -1688,8 +1695,7 @@ export class SessionManager {
       ? this.getCDPClientForWorker(sessionId, ownerInfo.workerId)
       : this.cdpClient;
 
-    const workerQueueKey = ownerInfo ? `${sessionId}:${ownerInfo.workerId}` : sessionId;
-    return this.queueManager.enqueue(workerQueueKey, async () => {
+    return this.targetQueueManager.enqueue(targetId, async () => {
       const page = await cdpClient.getPageByTargetId(targetId);
       if (!page) {
         throw new Error(`Page not found for target ${targetId}`);
@@ -1717,6 +1723,7 @@ export class SessionManager {
 
         this.targetToWorker.delete(targetId);
         this.targetLeases.release(targetId, ownerInfo.sessionId);
+        this.targetQueueManager.cancelTarget(targetId);
         this.stealthTargets.delete(targetId);
 
         // #848: drop the named-context association and let the registry

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -9,6 +9,12 @@ import { Session, SessionInfo, SessionCreateOptions, SessionEvent, Worker, Worke
 import { TargetOwnershipRegistry } from './session/target-registry';
 import { TargetLeaseRegistry, type TargetLeaseRecord } from './session/target-lease-registry';
 import { TargetQueueManager } from './session/target-command-queue';
+import {
+  markBrokerReconnectFailed,
+  markBrokerReconnectStart,
+  markBrokerReconnectSuccess,
+  setBrokerActiveLeases,
+} from './broker/lifecycle';
 import { CDPClient, getCDPClient, CDPClientFactory, getCDPClientFactory } from './cdp/client';
 import { CDPConnectionPool, getCDPConnectionPool, PoolStats } from './cdp/connection-pool';
 import { ChromePool, getChromePool } from './chrome/pool';
@@ -182,11 +188,16 @@ export class SessionManager {
     // Validate stale targets after reconnection
     this.cdpClient.addConnectionListener((event) => {
       if (event.type === 'reconnected') {
+        markBrokerReconnectSuccess();
         this.validateTargetsAfterReconnect().catch((err) => {
           console.error('[SessionManager] Post-reconnect target validation failed:', err);
         });
       }
+      if (event.type === 'disconnected' || event.type === 'reconnecting') {
+        markBrokerReconnectStart();
+      }
       if (event.type === 'reconnect_failed') {
+        markBrokerReconnectFailed('CDP reconnect failed');
         // Chrome is gone — purge all stale target mappings
         console.error('[SessionManager] Reconnect failed, clearing stale target mappings');
         for (const targetId of Array.from(this.targetToWorker.keys())) {
@@ -245,6 +256,7 @@ export class SessionManager {
       return;
     }
     this.targetLeases.acquire({ targetId, sessionId, workerId, contextName });
+    setBrokerActiveLeases(this.targetLeases.snapshot().length);
   }
 
   getTargetLease(targetId: string): TargetLeaseRecord | undefined {
@@ -593,6 +605,7 @@ export class SessionManager {
     // Remove session
     this.sessions.delete(sessionId);
     this.targetLeases.releaseSession(sessionId);
+    setBrokerActiveLeases(this.targetLeases.snapshot().length);
     this.emitEvent({ type: 'session:deleted', sessionId, timestamp: Date.now() });
     this.emitLifecycle({ kind: 'session:destroy', sessionId, reason, ts: Date.now() });
 
@@ -1625,6 +1638,7 @@ export class SessionManager {
       // Remove from mapping
       this.targetToWorker.delete(targetId);
       this.targetLeases.release(targetId, sessionId);
+      setBrokerActiveLeases(this.targetLeases.snapshot().length);
       this.targetQueueManager.cancelTarget(targetId);
 
       // #848: drop named-context association on graceful close.
@@ -1723,6 +1737,7 @@ export class SessionManager {
 
         this.targetToWorker.delete(targetId);
         this.targetLeases.release(targetId, ownerInfo.sessionId);
+        setBrokerActiveLeases(this.targetLeases.snapshot().length);
         this.targetQueueManager.cancelTarget(targetId);
         this.stealthTargets.delete(targetId);
 

--- a/src/session/target-command-queue.ts
+++ b/src/session/target-command-queue.ts
@@ -108,6 +108,22 @@ export class TargetQueueManager {
     }
   }
 
+  /**
+   * Cancel queues for any targetId not in the alive set. Mirrors the lease
+   * registry reconcile path so a Chrome reconnect that loses targetIds does
+   * not leave per-target queues orphaned in memory.
+   */
+  reconcileAliveTargetIds(aliveTargetIds: Set<string>): string[] {
+    const cancelled: string[] = [];
+    for (const targetId of Array.from(this.queues.keys())) {
+      if (!aliveTargetIds.has(targetId)) {
+        this.cancelTarget(targetId);
+        cancelled.push(targetId);
+      }
+    }
+    return cancelled;
+  }
+
   getStats(): Array<ReturnType<TargetCommandQueue['snapshot']>> {
     return Array.from(this.queues.values()).map((queue) => queue.snapshot());
   }

--- a/src/session/target-command-queue.ts
+++ b/src/session/target-command-queue.ts
@@ -1,0 +1,114 @@
+export interface TargetQueueMetrics {
+  enqueued: number;
+  completed: number;
+  rejected: number;
+  cancelled: number;
+  totalWaitMs: number;
+  totalExecutionMs: number;
+}
+
+interface QueueItem<T> {
+  enqueuedAt: number;
+  fn: () => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+}
+
+export class TargetQueueCancelledError extends Error {
+  constructor(targetId: string) {
+    super(`Target queue cancelled for closed or expired target ${targetId}`);
+    this.name = 'TargetQueueCancelledError';
+  }
+}
+
+export class TargetCommandQueue {
+  private readonly targetId: string;
+  private readonly queue: QueueItem<unknown>[] = [];
+  private processing: Promise<void> | null = null;
+  private closed = false;
+  private readonly metrics: TargetQueueMetrics = {
+    enqueued: 0,
+    completed: 0,
+    rejected: 0,
+    cancelled: 0,
+    totalWaitMs: 0,
+    totalExecutionMs: 0,
+  };
+
+  constructor(targetId: string) {
+    this.targetId = targetId;
+  }
+
+  enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.closed) return Promise.reject(new TargetQueueCancelledError(this.targetId));
+    this.metrics.enqueued++;
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push({ enqueuedAt: Date.now(), fn, resolve: resolve as (value: unknown) => void, reject });
+      this.start();
+    });
+  }
+
+  cancel(): void {
+    this.closed = true;
+    const error = new TargetQueueCancelledError(this.targetId);
+    while (this.queue.length > 0) {
+      this.queue.shift()!.reject(error);
+      this.metrics.cancelled++;
+    }
+  }
+
+  snapshot(): TargetQueueMetrics & { targetId: string; pending: number; processing: boolean; closed: boolean } {
+    return { targetId: this.targetId, pending: this.queue.length, processing: this.processing !== null, closed: this.closed, ...this.metrics };
+  }
+
+  private start(): void {
+    if (!this.processing) this.processing = this.drain();
+  }
+
+  private async drain(): Promise<void> {
+    try {
+      while (this.queue.length > 0 && !this.closed) {
+        const item = this.queue.shift()!;
+        const startedAt = Date.now();
+        this.metrics.totalWaitMs += Math.max(0, startedAt - item.enqueuedAt);
+        try {
+          const value = await item.fn();
+          this.metrics.completed++;
+          this.metrics.totalExecutionMs += Math.max(0, Date.now() - startedAt);
+          item.resolve(value);
+        } catch (err) {
+          this.metrics.rejected++;
+          item.reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      }
+    } finally {
+      this.processing = null;
+      if (this.queue.length > 0 && !this.closed) this.start();
+    }
+  }
+}
+
+export class TargetQueueManager {
+  private readonly queues = new Map<string, TargetCommandQueue>();
+
+  enqueue<T>(targetId: string, fn: () => Promise<T>): Promise<T> {
+    let queue = this.queues.get(targetId);
+    if (!queue) {
+      queue = new TargetCommandQueue(targetId);
+      this.queues.set(targetId, queue);
+    }
+    return queue.enqueue(fn);
+  }
+
+  cancelTarget(targetId: string): void {
+    const queue = this.queues.get(targetId);
+    if (queue) {
+      queue.cancel();
+      this.queues.delete(targetId);
+    }
+  }
+
+  getStats(): Array<ReturnType<TargetCommandQueue['snapshot']>> {
+    return Array.from(this.queues.values()).map((queue) => queue.snapshot());
+  }
+}

--- a/src/session/target-command-queue.ts
+++ b/src/session/target-command-queue.ts
@@ -48,6 +48,16 @@ export class TargetCommandQueue {
     });
   }
 
+  /**
+   * Cancel queued commands and mark the queue closed.
+   *
+   * In-flight work is intentionally NOT aborted: once `drain` has popped an
+   * item and awaits its `fn()`, that promise runs to completion so callers
+   * who already issued a CDP command see its result (or its native error)
+   * rather than a phantom cancellation. Only items still pending in the
+   * queue at cancellation time are rejected with `TargetQueueCancelledError`.
+   * After `cancel()`, future `enqueue` calls reject immediately.
+   */
   cancel(): void {
     this.closed = true;
     const error = new TargetQueueCancelledError(this.targetId);
@@ -100,24 +110,35 @@ export class TargetQueueManager {
     return queue.enqueue(fn);
   }
 
+  /**
+   * Cancel a target's queue but keep the closed instance in the map. Any
+   * caller that races a concurrent target-close (e.g. reads `targetToWorker`
+   * before `onTargetClosed` clears it, then calls `enqueue` after) will hit
+   * the already-closed instance and receive `TargetQueueCancelledError`
+   * instead of silently resurrecting a fresh queue on a dead target. The
+   * tombstone is removed by `reconcileAliveTargetIds` when Chrome confirms
+   * the targetId is truly gone.
+   */
   cancelTarget(targetId: string): void {
     const queue = this.queues.get(targetId);
     if (queue) {
       queue.cancel();
-      this.queues.delete(targetId);
     }
   }
 
   /**
-   * Cancel queues for any targetId not in the alive set. Mirrors the lease
-   * registry reconcile path so a Chrome reconnect that loses targetIds does
-   * not leave per-target queues orphaned in memory.
+   * Cancel queues for any targetId not in the alive set and remove their
+   * tombstones from the map. Mirrors the lease registry reconcile path so a
+   * Chrome reconnect that loses targetIds does not leave per-target queues
+   * (or their post-cancel tombstones) orphaned in memory.
    */
   reconcileAliveTargetIds(aliveTargetIds: Set<string>): string[] {
     const cancelled: string[] = [];
     for (const targetId of Array.from(this.queues.keys())) {
       if (!aliveTargetIds.has(targetId)) {
-        this.cancelTarget(targetId);
+        const queue = this.queues.get(targetId);
+        if (queue) queue.cancel();
+        this.queues.delete(targetId);
         cancelled.push(targetId);
       }
     }

--- a/src/session/target-lease-registry.ts
+++ b/src/session/target-lease-registry.ts
@@ -1,0 +1,129 @@
+export type TargetCleanupPolicy = 'close-on-session-end' | 'preserve' | 'expire';
+
+export interface TargetLeaseRecord {
+  targetId: string;
+  sessionId: string;
+  clientId?: string;
+  workerId?: string;
+  laneId?: string;
+  contextName?: string;
+  createdAt: number;
+  lastActivityAt: number;
+  leaseExpiresAt?: number;
+  cleanupPolicy: TargetCleanupPolicy;
+}
+
+export interface AcquireTargetLeaseInput {
+  targetId: string;
+  sessionId: string;
+  clientId?: string;
+  workerId?: string;
+  laneId?: string;
+  contextName?: string;
+  now?: number;
+  ttlMs?: number;
+  cleanupPolicy?: TargetCleanupPolicy;
+}
+
+export class TargetLeaseConflictError extends Error {
+  readonly existing: TargetLeaseRecord;
+
+  constructor(existing: TargetLeaseRecord) {
+    super(`Target ${existing.targetId} is already leased by session ${existing.sessionId}`);
+    this.name = 'TargetLeaseConflictError';
+    this.existing = existing;
+  }
+}
+
+export class TargetLeaseRegistry {
+  private readonly leases = new Map<string, TargetLeaseRecord>();
+
+  acquire(input: AcquireTargetLeaseInput): TargetLeaseRecord {
+    const now = input.now ?? Date.now();
+    const existing = this.leases.get(input.targetId);
+    if (existing && existing.sessionId !== input.sessionId) throw new TargetLeaseConflictError(existing);
+    const record: TargetLeaseRecord = {
+      targetId: input.targetId,
+      sessionId: input.sessionId,
+      ...(input.clientId ? { clientId: input.clientId } : {}),
+      ...(input.workerId ? { workerId: input.workerId } : {}),
+      ...(input.laneId ? { laneId: input.laneId } : {}),
+      ...(input.contextName ? { contextName: input.contextName } : {}),
+      createdAt: existing?.createdAt ?? now,
+      lastActivityAt: now,
+      ...(input.ttlMs ? { leaseExpiresAt: now + input.ttlMs } : existing?.leaseExpiresAt ? { leaseExpiresAt: existing.leaseExpiresAt } : {}),
+      cleanupPolicy: input.cleanupPolicy ?? existing?.cleanupPolicy ?? 'close-on-session-end',
+    };
+    this.leases.set(input.targetId, record);
+    return record;
+  }
+
+  inherit(targetId: string, parentTargetId: string, overrides: Partial<AcquireTargetLeaseInput> = {}): TargetLeaseRecord | null {
+    const parent = this.leases.get(parentTargetId);
+    if (!parent) return null;
+    return this.acquire({
+      targetId,
+      sessionId: overrides.sessionId ?? parent.sessionId,
+      clientId: overrides.clientId ?? parent.clientId,
+      workerId: overrides.workerId ?? parent.workerId,
+      laneId: overrides.laneId ?? parent.laneId,
+      contextName: overrides.contextName ?? parent.contextName,
+      now: overrides.now,
+      cleanupPolicy: overrides.cleanupPolicy ?? parent.cleanupPolicy,
+      ...(overrides.ttlMs ? { ttlMs: overrides.ttlMs } : {}),
+    });
+  }
+
+  touch(targetId: string, now = Date.now()): void {
+    const lease = this.leases.get(targetId);
+    if (lease) lease.lastActivityAt = now;
+  }
+
+  get(targetId: string): TargetLeaseRecord | undefined {
+    return this.leases.get(targetId);
+  }
+
+  release(targetId: string, sessionId?: string): boolean {
+    const lease = this.leases.get(targetId);
+    if (!lease) return false;
+    if (sessionId && lease.sessionId !== sessionId) return false;
+    return this.leases.delete(targetId);
+  }
+
+  releaseSession(sessionId: string): string[] {
+    const released: string[] = [];
+    for (const [targetId, lease] of this.leases) {
+      if (lease.sessionId === sessionId) {
+        this.leases.delete(targetId);
+        released.push(targetId);
+      }
+    }
+    return released;
+  }
+
+  expire(now = Date.now()): TargetLeaseRecord[] {
+    const expired: TargetLeaseRecord[] = [];
+    for (const [targetId, lease] of this.leases) {
+      if (lease.leaseExpiresAt !== undefined && lease.leaseExpiresAt <= now) {
+        this.leases.delete(targetId);
+        expired.push(lease);
+      }
+    }
+    return expired;
+  }
+
+  reconcileAliveTargetIds(aliveTargetIds: Set<string>): TargetLeaseRecord[] {
+    const removed: TargetLeaseRecord[] = [];
+    for (const [targetId, lease] of this.leases) {
+      if (!aliveTargetIds.has(targetId)) {
+        this.leases.delete(targetId);
+        removed.push(lease);
+      }
+    }
+    return removed;
+  }
+
+  snapshot(): TargetLeaseRecord[] {
+    return Array.from(this.leases.values()).map((lease) => ({ ...lease }));
+  }
+}

--- a/src/tools/connection-health.ts
+++ b/src/tools/connection-health.ts
@@ -7,6 +7,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getCDPClient } from '../cdp/client';
+import { getCurrentControllerTopology } from '../utils/duplicate-controller-diagnostics';
 
 const definition: MCPToolDefinition = {
   name: 'oc_connection_health',
@@ -48,6 +49,7 @@ const handler: ToolHandler = async (
               reconnecting: metrics.reconnecting,
               reconnectAttempt: metrics.reconnectAttempt,
               reconnectNextRetryInMs: metrics.reconnectNextRetryInMs,
+              controllerTopology: getCurrentControllerTopology(),
             },
             null,
             2

--- a/src/tools/connection-health.ts
+++ b/src/tools/connection-health.ts
@@ -8,6 +8,7 @@ import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getCDPClient } from '../cdp/client';
 import { getCurrentControllerTopology } from '../utils/duplicate-controller-diagnostics';
+import { getBrokerLifecycleState } from '../broker/lifecycle';
 
 const definition: MCPToolDefinition = {
   name: 'oc_connection_health',
@@ -50,6 +51,7 @@ const handler: ToolHandler = async (
               reconnectAttempt: metrics.reconnectAttempt,
               reconnectNextRetryInMs: metrics.reconnectNextRetryInMs,
               controllerTopology: getCurrentControllerTopology(),
+              brokerLifecycle: getBrokerLifecycleState(),
             },
             null,
             2

--- a/src/tools/shutdown.ts
+++ b/src/tools/shutdown.ts
@@ -32,6 +32,11 @@ const definition: MCPToolDefinition = {
         default: false,
         description: 'Preview sessions/tabs and managed Chrome resources that oc_stop would shut down without mutating runtime state.',
       },
+      force: {
+        type: 'boolean',
+        default: false,
+        description: 'Broker safety override: allow stopping a broker owner even when active target leases remain.',
+      },
     },
     required: [],
   },
@@ -44,6 +49,7 @@ const handler: ToolHandler = async (
 ): Promise<MCPResult> => {
   const keepChrome = (args.keepChrome as boolean) || false;
   const dryRun = args.dryRun === true;
+  const force = args.force === true;
   const steps: string[] = [];
   const startTime = Date.now();
 
@@ -69,6 +75,7 @@ const handler: ToolHandler = async (
           connectionPool: true,
           cdpClient: true,
           chromeProcess: !keepChrome,
+          activeLeases: typeof sessionManager.getTargetLeaseSnapshot === 'function' ? sessionManager.getTargetLeaseSnapshot().length : 0,
         },
       };
       return {
@@ -95,6 +102,17 @@ const handler: ToolHandler = async (
     // the remaining steps (pool shutdown, CDP disconnect, Chrome kill) from running.
     try {
       const sessionManager = getSessionManager();
+      const activeLeases = typeof sessionManager.getTargetLeaseSnapshot === 'function' ? sessionManager.getTargetLeaseSnapshot().length : 0;
+      if (activeLeases > 0 && !force && process.env.OPENCHROME_BROKER_OWNER === '1') {
+        return {
+          content: [{
+            type: 'text',
+            text: `Refusing to stop broker owner while ${activeLeases} active target lease(s) remain. Pass force:true to override or close/release those sessions first.`,
+          }],
+          structuredContent: { activeLeases, forceRequired: true },
+          isError: true,
+        };
+      }
       const sessionCount = await sessionManager.cleanupAllSessions();
       steps.push(`Cleaned up ${sessionCount} session(s)`);
     } catch (e) {

--- a/src/transports/broker-proxy.ts
+++ b/src/transports/broker-proxy.ts
@@ -2,13 +2,31 @@ import * as readline from 'readline';
 import type { BrokerMetadata } from '../broker/discovery';
 import { MCPErrorCodes, MCPResponse } from '../types/mcp';
 
+const MCP_SESSION_ID_HEADER = 'Mcp-Session-Id';
+
+export interface BrokerProxyOptions {
+  authToken?: string;
+  /** Override fetch implementation (tests). */
+  fetchImpl?: typeof fetch;
+  /** Override stdout writer (tests). */
+  write?: (chunk: string) => void;
+}
+
 export class BrokerProxyStdioBridge {
   private readonly broker: BrokerMetadata;
   private readonly authToken?: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly writeOut: (chunk: string) => void;
+  private mcpSessionId?: string;
 
-  constructor(broker: BrokerMetadata, authToken?: string) {
+  constructor(broker: BrokerMetadata, authTokenOrOptions?: string | BrokerProxyOptions) {
     this.broker = broker;
-    this.authToken = authToken;
+    const options: BrokerProxyOptions = typeof authTokenOrOptions === 'string'
+      ? { authToken: authTokenOrOptions }
+      : authTokenOrOptions ?? {};
+    this.authToken = options.authToken;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.writeOut = options.write ?? ((chunk) => { process.stdout.write(chunk); });
   }
 
   start(): void {
@@ -20,31 +38,91 @@ export class BrokerProxyStdioBridge {
     rl.on('close', () => process.exit(0));
   }
 
-  private async forwardLine(line: string): Promise<void> {
+  /** Exposed for tests. */
+  async forwardLine(line: string): Promise<void> {
     let parsed: Record<string, unknown>;
     try {
       parsed = JSON.parse(line) as Record<string, unknown>;
     } catch (err) {
-      this.write({ jsonrpc: '2.0', id: 0, error: { code: MCPErrorCodes.PARSE_ERROR, message: err instanceof Error ? err.message : 'Parse error' } });
+      this.writeResponse({ jsonrpc: '2.0', id: 0, error: { code: MCPErrorCodes.PARSE_ERROR, message: err instanceof Error ? err.message : 'Parse error' } });
       return;
     }
 
     try {
-      const headers: Record<string, string> = { 'Content-Type': 'application/json', Accept: 'application/json' };
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        // Streamable HTTP advertises both JSON and SSE; the server picks the
+        // response framing. The proxy unwraps SSE below so stdio clients keep
+        // receiving plain JSON-RPC lines.
+        Accept: 'application/json, text/event-stream',
+      };
       if (this.authToken) headers.Authorization = `Bearer ${this.authToken}`;
-      const response = await fetch(this.broker.endpoint, { method: 'POST', headers, body: JSON.stringify(parsed) });
-      const text = await response.text();
+      if (this.mcpSessionId) headers[MCP_SESSION_ID_HEADER] = this.mcpSessionId;
+
+      const response = await this.fetchImpl(this.broker.endpoint, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(parsed),
+      });
+
+      const sessionHeader = readHeader(response.headers, MCP_SESSION_ID_HEADER);
+      if (sessionHeader) this.mcpSessionId = sessionHeader;
+
       if (!response.ok) {
-        this.write({ jsonrpc: '2.0', id: parsed.id as string | number | null ?? 0, error: { code: MCPErrorCodes.INTERNAL_ERROR, message: `Broker HTTP ${response.status}: ${text}` } });
+        const text = await response.text();
+        this.writeResponse({
+          jsonrpc: '2.0',
+          id: extractId(parsed),
+          error: { code: MCPErrorCodes.INTERNAL_ERROR, message: `Broker HTTP ${response.status}: ${text}` },
+        });
         return;
       }
-      process.stdout.write(text.trimEnd() + '\n');
+
+      // 202 Accepted: notification consumed by the server, no JSON-RPC reply.
+      if (response.status === 202) return;
+
+      const rawBody = await response.text();
+      if (!rawBody) return;
+
+      const payload = unwrapBody(rawBody, response.headers);
+      if (!payload) return;
+      this.writeOut(payload.trimEnd() + '\n');
     } catch (err) {
-      this.write({ jsonrpc: '2.0', id: parsed.id as string | number | null ?? 0, error: { code: MCPErrorCodes.INTERNAL_ERROR, message: `Broker forwarding failed: ${err instanceof Error ? err.message : String(err)}` } });
+      this.writeResponse({
+        jsonrpc: '2.0',
+        id: extractId(parsed),
+        error: { code: MCPErrorCodes.INTERNAL_ERROR, message: `Broker forwarding failed: ${err instanceof Error ? err.message : String(err)}` },
+      });
     }
   }
 
-  private write(response: MCPResponse): void {
-    process.stdout.write(JSON.stringify(response) + '\n');
+  private writeResponse(response: MCPResponse): void {
+    this.writeOut(JSON.stringify(response) + '\n');
   }
+}
+
+function readHeader(headers: Headers | Record<string, string> | undefined, name: string): string | undefined {
+  if (!headers) return undefined;
+  if (typeof (headers as Headers).get === 'function') return (headers as Headers).get(name) ?? undefined;
+  const map = headers as Record<string, string>;
+  return map[name] ?? map[name.toLowerCase()];
+}
+
+function extractId(parsed: Record<string, unknown>): string | number | null {
+  const id = parsed.id;
+  return (typeof id === 'string' || typeof id === 'number' || id === null) ? id : 0;
+}
+
+function unwrapBody(rawBody: string, headers: Headers | Record<string, string> | undefined): string | null {
+  const contentType = readHeader(headers, 'Content-Type') ?? readHeader(headers, 'content-type') ?? '';
+  if (!contentType.includes('text/event-stream')) return rawBody;
+
+  // Streamable HTTP single-response framing: one `event:` line followed by
+  // one or more `data:` lines. Concatenate `data:` payloads and drop the rest.
+  const dataLines: string[] = [];
+  for (const line of rawBody.split(/\r?\n/)) {
+    if (line.startsWith('data:')) dataLines.push(line.slice(5).replace(/^\s/, ''));
+  }
+  if (dataLines.length === 0) return null;
+  return dataLines.join('');
 }

--- a/src/transports/broker-proxy.ts
+++ b/src/transports/broker-proxy.ts
@@ -1,0 +1,50 @@
+import * as readline from 'readline';
+import type { BrokerMetadata } from '../broker/discovery';
+import { MCPErrorCodes, MCPResponse } from '../types/mcp';
+
+export class BrokerProxyStdioBridge {
+  private readonly broker: BrokerMetadata;
+  private readonly authToken?: string;
+
+  constructor(broker: BrokerMetadata, authToken?: string) {
+    this.broker = broker;
+    this.authToken = authToken;
+  }
+
+  start(): void {
+    const rl = readline.createInterface({ input: process.stdin, terminal: false });
+    rl.on('line', (line) => {
+      if (!line.trim()) return;
+      void this.forwardLine(line);
+    });
+    rl.on('close', () => process.exit(0));
+  }
+
+  private async forwardLine(line: string): Promise<void> {
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(line) as Record<string, unknown>;
+    } catch (err) {
+      this.write({ jsonrpc: '2.0', id: 0, error: { code: MCPErrorCodes.PARSE_ERROR, message: err instanceof Error ? err.message : 'Parse error' } });
+      return;
+    }
+
+    try {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json', Accept: 'application/json' };
+      if (this.authToken) headers.Authorization = `Bearer ${this.authToken}`;
+      const response = await fetch(this.broker.endpoint, { method: 'POST', headers, body: JSON.stringify(parsed) });
+      const text = await response.text();
+      if (!response.ok) {
+        this.write({ jsonrpc: '2.0', id: parsed.id as string | number | null ?? 0, error: { code: MCPErrorCodes.INTERNAL_ERROR, message: `Broker HTTP ${response.status}: ${text}` } });
+        return;
+      }
+      process.stdout.write(text.trimEnd() + '\n');
+    } catch (err) {
+      this.write({ jsonrpc: '2.0', id: parsed.id as string | number | null ?? 0, error: { code: MCPErrorCodes.INTERNAL_ERROR, message: `Broker forwarding failed: ${err instanceof Error ? err.message : String(err)}` } });
+    }
+  }
+
+  private write(response: MCPResponse): void {
+    process.stdout.write(JSON.stringify(response) + '\n');
+  }
+}

--- a/src/transports/broker-proxy.ts
+++ b/src/transports/broker-proxy.ts
@@ -84,9 +84,10 @@ export class BrokerProxyStdioBridge {
       const rawBody = await response.text();
       if (!rawBody) return;
 
-      const payload = unwrapBody(rawBody, response.headers);
-      if (!payload) return;
-      this.writeOut(payload.trimEnd() + '\n');
+      const payloads = unwrapBody(rawBody, response.headers);
+      for (const payload of payloads) {
+        this.writeOut(payload.trimEnd() + '\n');
+      }
     } catch (err) {
       this.writeResponse({
         jsonrpc: '2.0',
@@ -113,16 +114,17 @@ function extractId(parsed: Record<string, unknown>): string | number | null {
   return (typeof id === 'string' || typeof id === 'number' || id === null) ? id : 0;
 }
 
-function unwrapBody(rawBody: string, headers: Headers | Record<string, string> | undefined): string | null {
+function unwrapBody(rawBody: string, headers: Headers | Record<string, string> | undefined): string[] {
   const contentType = readHeader(headers, 'Content-Type') ?? readHeader(headers, 'content-type') ?? '';
-  if (!contentType.includes('text/event-stream')) return rawBody;
+  if (!contentType.includes('text/event-stream')) return rawBody ? [rawBody] : [];
 
-  // Streamable HTTP single-response framing: one `event:` line followed by
-  // one or more `data:` lines. Concatenate `data:` payloads and drop the rest.
+  // Streamable HTTP framing: one or more `event:`/`data:` pairs separated by
+  // blank lines. Each `data:` payload is a complete JSON-RPC response, so
+  // emit them as separate lines instead of concatenating (which would
+  // produce invalid JSON for batched responses).
   const dataLines: string[] = [];
   for (const line of rawBody.split(/\r?\n/)) {
     if (line.startsWith('data:')) dataLines.push(line.slice(5).replace(/^\s/, ''));
   }
-  if (dataLines.length === 0) return null;
-  return dataLines.join('');
+  return dataLines;
 }

--- a/src/utils/duplicate-controller-diagnostics.ts
+++ b/src/utils/duplicate-controller-diagnostics.ts
@@ -1,0 +1,233 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { ProfileManager } from '../chrome/profile-manager';
+import { getControllerLockPath, isPidAlive, normalizeControllerUserDataDir } from './controller-lock';
+
+export interface OpenChromeProcessInfo {
+  pid: number;
+  ppid?: number;
+  command: string;
+  port: number;
+  userDataDir: string;
+  source: 'global' | 'npx' | 'local' | 'unknown';
+}
+
+export interface DuplicateControllerGroup {
+  port: number;
+  userDataDir: string;
+  processes: OpenChromeProcessInfo[];
+}
+
+export interface McpConfigRegistration {
+  client: 'codex' | 'claude' | 'opencode' | 'unknown';
+  path: string;
+  exists: boolean;
+  stale?: boolean;
+  registrationCount: number;
+  commands: string[];
+  risk: 'none' | 'openchrome' | 'mixed-installation' | 'stale-config';
+}
+
+export interface DuplicateControllerDiagnostics {
+  processes: OpenChromeProcessInfo[];
+  duplicateGroups: DuplicateControllerGroup[];
+  configs: McpConfigRegistration[];
+  mixedInstallations: boolean;
+  warnings: string[];
+  remediation: string[];
+}
+
+const DEFAULT_PORT = 9222;
+const DEFAULT_PROFILE = '<default-profile>';
+
+function tokenize(command: string): string[] {
+  return command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g)?.map((part) => part.replace(/^['"]|['"]$/g, '')) ?? [];
+}
+
+function optionValue(tokens: string[], longName: string, shortName?: string): string | undefined {
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (token === longName || (shortName && token === shortName)) return tokens[i + 1];
+    if (token.startsWith(`${longName}=`)) return token.slice(longName.length + 1);
+  }
+  return undefined;
+}
+
+function envValue(command: string, name: string): string | undefined {
+  const match = command.match(new RegExp(`(?:^|\\s)${name}=([^\\s]+)`));
+  return match?.[1];
+}
+
+export function inferOpenChromeProcess(pid: number, command: string, ppid?: number): OpenChromeProcessInfo | null {
+  if (!/(openchrome|openchrome-mcp)/.test(command)) return null;
+  if (!/(serve|dist\/index\.js|openchrome-mcp)/.test(command)) return null;
+  if (/grep /.test(command)) return null;
+
+  const tokens = tokenize(command);
+  const rawPort = optionValue(tokens, '--port', '-p') ?? envValue(command, 'CHROME_PORT') ?? String(DEFAULT_PORT);
+  const port = parseInt(rawPort, 10);
+  const userDataDir = optionValue(tokens, '--user-data-dir') ?? envValue(command, 'CHROME_USER_DATA_DIR') ?? envValue(command, 'OPENCHROME_USER_DATA_DIR') ?? DEFAULT_PROFILE;
+  let source: OpenChromeProcessInfo['source'] = 'unknown';
+  if (command.includes('npm exec') || command.includes('npx') || command.includes('/_npx/') || command.includes('openchrome-mcp@')) source = 'npx';
+  else if (command.includes('/node_modules/openchrome-mcp/') || /(^|\s)openchrome(\s|$)/.test(command)) source = 'global';
+  else if (command.includes('dist/index.js')) source = 'local';
+
+  return {
+    pid,
+    ...(ppid !== undefined ? { ppid } : {}),
+    command,
+    port: Number.isFinite(port) ? port : DEFAULT_PORT,
+    userDataDir: userDataDir === DEFAULT_PROFILE ? DEFAULT_PROFILE : normalizeControllerUserDataDir(userDataDir),
+    source,
+  };
+}
+
+export function parsePsOutput(output: string): OpenChromeProcessInfo[] {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const match = line.match(/^(\d+)\s+(?:(\d+)\s+)?(.+)$/);
+      if (!match) return null;
+      return inferOpenChromeProcess(parseInt(match[1], 10), match[3], match[2] ? parseInt(match[2], 10) : undefined);
+    })
+    .filter((entry): entry is OpenChromeProcessInfo => entry !== null);
+}
+
+export function scanOpenChromeProcesses(): OpenChromeProcessInfo[] {
+  try {
+    const output = execFileSync('ps', ['-axo', 'pid=,ppid=,command='], { encoding: 'utf8', timeout: 3000 });
+    return parsePsOutput(output).filter((proc) => proc.pid !== process.pid);
+  } catch {
+    return [];
+  }
+}
+
+export function findDuplicateControllerGroups(processes: OpenChromeProcessInfo[]): DuplicateControllerGroup[] {
+  const groups = new Map<string, OpenChromeProcessInfo[]>();
+  for (const proc of processes) {
+    const key = `${proc.port}\u0000${proc.userDataDir}`;
+    groups.set(key, [...(groups.get(key) ?? []), proc]);
+  }
+  return Array.from(groups.values())
+    .filter((items) => items.length > 1)
+    .map((items) => ({ port: items[0].port, userDataDir: items[0].userDataDir, processes: items }));
+}
+
+function defaultConfigPaths(home = os.homedir()): Array<{ client: McpConfigRegistration['client']; path: string; stale?: boolean }> {
+  return [
+    { client: 'codex', path: path.join(home, '.codex', 'config.toml') },
+    { client: 'codex', path: path.join(home, '.codex', 'mcp.json'), stale: true },
+    { client: 'claude', path: path.join(home, '.claude.json') },
+    { client: 'claude', path: path.join(home, '.claude', 'mcp.json') },
+    { client: 'opencode', path: path.join(home, '.config', 'opencode', 'opencode.json') },
+    { client: 'opencode', path: path.join(home, '.opencode.json') },
+  ];
+}
+
+function extractOpenChromeCommands(content: string): string[] {
+  const lines = content.split('\n').filter((line) => /openchrome|openchrome-mcp/.test(line));
+  if (lines.length > 0) return lines.map((line) => line.trim()).filter(Boolean);
+  return /openchrome|openchrome-mcp/.test(content) ? ['<json registration containing openchrome>'] : [];
+}
+
+export function scanMcpConfigRegistrations(pathsToScan?: Array<{ client: McpConfigRegistration['client']; path: string; stale?: boolean }>): McpConfigRegistration[] {
+  const envPaths = process.env.OPENCHROME_MCP_CONFIG_PATHS?.split(path.delimiter).filter(Boolean);
+  const candidates: Array<{ client: McpConfigRegistration['client']; path: string; stale?: boolean }> =
+    pathsToScan ?? (envPaths ? envPaths.map((p) => ({ client: 'unknown' as const, path: p })) : defaultConfigPaths());
+
+  return candidates.map((candidate) => {
+    let content = '';
+    let exists = false;
+    try {
+      content = fs.readFileSync(candidate.path, 'utf8');
+      exists = true;
+    } catch {
+      // absent or unreadable config files are treated as no registration.
+    }
+    const commands = exists ? extractOpenChromeCommands(content) : [];
+    const hasNpx = commands.some((cmd) => /npm exec|npx|openchrome-mcp@|_npx/.test(cmd));
+    const hasGlobal = commands.some((cmd) => /openchrome(\s|[\"']|$)|node_modules\/openchrome-mcp/.test(cmd));
+    const risk: McpConfigRegistration['risk'] = commands.length === 0
+      ? 'none'
+      : candidate.stale
+        ? 'stale-config'
+        : hasNpx && hasGlobal
+          ? 'mixed-installation'
+          : 'openchrome';
+    return {
+      client: candidate.client,
+      path: candidate.path,
+      exists,
+      ...(candidate.stale ? { stale: true } : {}),
+      registrationCount: commands.length,
+      commands,
+      risk,
+    };
+  });
+}
+
+export function summarizeDuplicateControllerDiagnostics(options: {
+  processes?: OpenChromeProcessInfo[];
+  configs?: McpConfigRegistration[];
+} = {}): DuplicateControllerDiagnostics {
+  const processes = options.processes ?? scanOpenChromeProcesses();
+  const duplicateGroups = findDuplicateControllerGroups(processes);
+  const configs = options.configs ?? scanMcpConfigRegistrations();
+  const processSources = new Set(processes.map((proc) => proc.source).filter((source) => source !== 'unknown'));
+  const configMixed = configs.some((config) => config.risk === 'mixed-installation')
+    || configs.filter((config) => config.registrationCount > 0).some((config) => config.commands.some((cmd) => /npm exec|npx|openchrome-mcp@|_npx/.test(cmd)))
+      && configs.filter((config) => config.registrationCount > 0).some((config) => config.commands.some((cmd) => /openchrome(\s|[\"']|$)|node_modules\/openchrome-mcp/.test(cmd)));
+  const mixedInstallations = processSources.has('npx') && (processSources.has('global') || processSources.has('local')) || configMixed;
+  const staleConfigs = configs.filter((config) => config.stale && config.registrationCount > 0);
+
+  const warnings: string[] = [];
+  if (duplicateGroups.length > 0) {
+    warnings.push(`${duplicateGroups.length} duplicate OpenChrome controller group(s) detected`);
+  }
+  if (mixedInstallations) warnings.push('mixed OpenChrome registrations detected (for example global openchrome plus npm/npx openchrome-mcp@latest)');
+  if (staleConfigs.length > 0) warnings.push(`stale MCP config registration(s) detected: ${staleConfigs.map((config) => config.path).join(', ')}`);
+
+  const remediation = [
+    'Keep exactly one direct OpenChrome controller per Chrome port/profile until broker mode is available.',
+    'Prefer assigning different --port and --user-data-dir values to independent MCP clients, or route clients through the future broker topology.',
+    'Remove stale MCP registrations such as ~/.codex/mcp.json after migrating to the active client config.',
+  ];
+
+  return { processes, duplicateGroups, configs, mixedInstallations, warnings, remediation };
+}
+
+export function getCurrentControllerTopology(options: { port?: number; userDataDir?: string } = {}): {
+  role: 'owner' | 'unsafe-secondary-attach' | 'unlocked' | 'unknown';
+  port: number;
+  userDataDir: string;
+  lockPath: string;
+  ownerPid?: number;
+  remediation?: string;
+} {
+  const port = options.port ?? parseInt(process.env.CHROME_PORT ?? String(DEFAULT_PORT), 10);
+  const userDataDir = normalizeControllerUserDataDir(options.userDataDir ?? process.env.CHROME_USER_DATA_DIR ?? process.env.OPENCHROME_USER_DATA_DIR ?? ProfileManager.PERSISTENT_PROFILE_DIR);
+  const lockPath = getControllerLockPath(port, userDataDir);
+  if (process.env.OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH === '1') {
+    return {
+      role: 'unsafe-secondary-attach',
+      port,
+      userDataDir,
+      lockPath,
+      remediation: 'Disable OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH and use one owner per port/profile, isolated profiles, or broker mode.',
+    };
+  }
+  try {
+    const raw = fs.readFileSync(lockPath, 'utf8');
+    const parsed = JSON.parse(raw) as { pid?: number };
+    if (typeof parsed.pid === 'number' && isPidAlive(parsed.pid)) {
+      return { role: parsed.pid === process.pid ? 'owner' : 'unknown', port, userDataDir, lockPath, ownerPid: parsed.pid };
+    }
+    return { role: 'unlocked', port, userDataDir, lockPath };
+  } catch {
+    return { role: 'unlocked', port, userDataDir, lockPath };
+  }
+}

--- a/src/watchdog/health-endpoint.ts
+++ b/src/watchdog/health-endpoint.ts
@@ -51,6 +51,14 @@ export interface HealthData {
     errorCount1m: number;
     errorCount1h: number;
   };
+  controllerTopology?: {
+    role: 'owner' | 'unsafe-secondary-attach' | 'unlocked' | 'unknown';
+    port: number;
+    userDataDir: string;
+    lockPath: string;
+    ownerPid?: number;
+    remediation?: string;
+  };
 }
 
 export type HealthDataProvider = () => HealthData;

--- a/src/watchdog/health-endpoint.ts
+++ b/src/watchdog/health-endpoint.ts
@@ -59,6 +59,14 @@ export interface HealthData {
     ownerPid?: number;
     remediation?: string;
   };
+  brokerLifecycle?: {
+    mode: 'direct' | 'broker-owner' | 'broker-client';
+    reconnectState: 'idle' | 'reconnecting' | 'failed';
+    activeLeases: number;
+    lastReconnectAt?: number;
+    lastDisconnectAt?: number;
+    lastError?: string;
+  };
 }
 
 export type HealthDataProvider = () => HealthData;

--- a/tests/broker-discovery.test.ts
+++ b/tests/broker-discovery.test.ts
@@ -1,0 +1,64 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  buildBrokerMetadata,
+  getBrokerMetadataPath,
+  publishBrokerMetadata,
+  readBrokerMetadata,
+  removeBrokerMetadata,
+} from '../src/broker/discovery';
+
+describe('broker discovery metadata', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-broker-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('builds a loopback broker endpoint and normalized profile identity', () => {
+    const metadata = buildBrokerMetadata({
+      port: 9222,
+      userDataDir: './profile',
+      httpHost: '0.0.0.0',
+      httpPort: 3100,
+      pid: 123,
+      startedAt: '2026-01-01T00:00:00.000Z',
+      version: 'test',
+    });
+
+    expect(metadata).toMatchObject({
+      schemaVersion: 1,
+      pid: 123,
+      version: 'test',
+      port: 9222,
+      endpoint: 'http://127.0.0.1:3100/mcp',
+    });
+    expect(path.isAbsolute(metadata.userDataDir)).toBe(true);
+  });
+
+  test('publishes, reads, and removes broker metadata by port/profile', () => {
+    const profile = path.join(tmpDir, 'profile');
+    const metadata = publishBrokerMetadata({ port: 9222, userDataDir: profile, httpHost: '127.0.0.1', httpPort: 3101 }, tmpDir);
+    const filePath = getBrokerMetadataPath(9222, profile, tmpDir);
+
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(readBrokerMetadata(9222, profile, tmpDir)).toEqual(metadata);
+
+    removeBrokerMetadata(9222, profile, process.pid, tmpDir);
+    expect(fs.existsSync(filePath)).toBe(false);
+  });
+
+  test('does not remove another broker owner metadata', () => {
+    const profile = path.join(tmpDir, 'profile');
+    publishBrokerMetadata({ port: 9222, userDataDir: profile, httpHost: '127.0.0.1', httpPort: 3101, pid: 999999 }, tmpDir);
+
+    removeBrokerMetadata(9222, profile, process.pid, tmpDir);
+
+    expect(readBrokerMetadata(9222, profile, tmpDir)?.pid).toBe(999999);
+  });
+});

--- a/tests/broker-lifecycle.test.ts
+++ b/tests/broker-lifecycle.test.ts
@@ -1,0 +1,26 @@
+import {
+  getBrokerLifecycleState,
+  markBrokerReconnectFailed,
+  markBrokerReconnectStart,
+  markBrokerReconnectSuccess,
+  resetBrokerLifecycleState,
+  setBrokerActiveLeases,
+  setBrokerLifecycleMode,
+} from '../src/broker/lifecycle';
+
+describe('broker lifecycle state', () => {
+  afterEach(() => resetBrokerLifecycleState());
+
+  test('tracks broker mode, reconnect state, and active leases', () => {
+    setBrokerLifecycleMode('broker-owner');
+    setBrokerActiveLeases(2);
+    markBrokerReconnectStart(10);
+    expect(getBrokerLifecycleState()).toMatchObject({ mode: 'broker-owner', reconnectState: 'reconnecting', activeLeases: 2, lastDisconnectAt: 10 });
+
+    markBrokerReconnectSuccess(20);
+    expect(getBrokerLifecycleState()).toMatchObject({ reconnectState: 'idle', lastReconnectAt: 20 });
+
+    markBrokerReconnectFailed('boom', 30);
+    expect(getBrokerLifecycleState()).toMatchObject({ reconnectState: 'failed', lastError: 'boom', lastDisconnectAt: 30 });
+  });
+});

--- a/tests/broker-proxy.test.ts
+++ b/tests/broker-proxy.test.ts
@@ -1,0 +1,39 @@
+import { BrokerProxyStdioBridge } from '../src/transports/broker-proxy';
+
+describe('BrokerProxyStdioBridge', () => {
+  const originalFetch = global.fetch;
+  const originalStdoutWrite = process.stdout.write;
+  let output: string[];
+
+  beforeEach(() => {
+    output = [];
+    process.stdout.write = jest.fn((chunk: string | Uint8Array) => {
+      output.push(String(chunk));
+      return true;
+    }) as any;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.stdout.write = originalStdoutWrite;
+    jest.restoreAllMocks();
+  });
+
+  test('forwards one JSON-RPC line to broker HTTP endpoint', async () => {
+    global.fetch = jest.fn(async () => ({ ok: true, text: async () => '{"jsonrpc":"2.0","id":1,"result":{}}' })) as any;
+    const bridge = new BrokerProxyStdioBridge({ schemaVersion: 1, pid: 1, version: 'test', startedAt: 'now', port: 9222, userDataDir: '/tmp/profile', endpoint: 'http://127.0.0.1:3100/mcp' });
+
+    await (bridge as any).forwardLine('{"jsonrpc":"2.0","id":1,"method":"ping"}');
+
+    expect(global.fetch).toHaveBeenCalledWith('http://127.0.0.1:3100/mcp', expect.objectContaining({ method: 'POST' }));
+    expect(output.join('')).toContain('"id":1');
+  });
+
+  test('returns JSON-RPC parse errors locally', async () => {
+    const bridge = new BrokerProxyStdioBridge({ schemaVersion: 1, pid: 1, version: 'test', startedAt: 'now', port: 9222, userDataDir: '/tmp/profile', endpoint: 'http://127.0.0.1:3100/mcp' });
+
+    await (bridge as any).forwardLine('not json');
+
+    expect(output.join('')).toContain('"code":-32700');
+  });
+});

--- a/tests/broker-proxy.test.ts
+++ b/tests/broker-proxy.test.ts
@@ -1,39 +1,120 @@
 import { BrokerProxyStdioBridge } from '../src/transports/broker-proxy';
+import type { BrokerMetadata } from '../src/broker/discovery';
+
+const broker: BrokerMetadata = {
+  schemaVersion: 1,
+  pid: 1,
+  version: 'test',
+  startedAt: 'now',
+  port: 9222,
+  userDataDir: '/tmp/profile',
+  endpoint: 'http://127.0.0.1:3100/mcp',
+};
+
+function createMockResponse(opts: { status?: number; body?: string; headers?: Record<string, string> }): Response {
+  const status = opts.status ?? 200;
+  const headers = new Headers(opts.headers ?? {});
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers,
+    text: async () => opts.body ?? '',
+  } as unknown as Response;
+}
 
 describe('BrokerProxyStdioBridge', () => {
-  const originalFetch = global.fetch;
-  const originalStdoutWrite = process.stdout.write;
-  let output: string[];
+  test('forwards a JSON-RPC line to the broker HTTP endpoint with streamable Accept', async () => {
+    const fetchImpl = jest.fn<Promise<Response>, [string, RequestInit]>(async () => createMockResponse({ body: '{"jsonrpc":"2.0","id":1,"result":{}}' }));
+    const output: string[] = [];
+    const bridge = new BrokerProxyStdioBridge(broker, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      write: (chunk) => { output.push(chunk); },
+    });
 
-  beforeEach(() => {
-    output = [];
-    process.stdout.write = jest.fn((chunk: string | Uint8Array) => {
-      output.push(String(chunk));
-      return true;
-    }) as any;
-  });
+    await bridge.forwardLine('{"jsonrpc":"2.0","id":1,"method":"ping"}');
 
-  afterEach(() => {
-    global.fetch = originalFetch;
-    process.stdout.write = originalStdoutWrite;
-    jest.restoreAllMocks();
-  });
-
-  test('forwards one JSON-RPC line to broker HTTP endpoint', async () => {
-    global.fetch = jest.fn(async () => ({ ok: true, text: async () => '{"jsonrpc":"2.0","id":1,"result":{}}' })) as any;
-    const bridge = new BrokerProxyStdioBridge({ schemaVersion: 1, pid: 1, version: 'test', startedAt: 'now', port: 9222, userDataDir: '/tmp/profile', endpoint: 'http://127.0.0.1:3100/mcp' });
-
-    await (bridge as any).forwardLine('{"jsonrpc":"2.0","id":1,"method":"ping"}');
-
-    expect(global.fetch).toHaveBeenCalledWith('http://127.0.0.1:3100/mcp', expect.objectContaining({ method: 'POST' }));
+    expect(fetchImpl).toHaveBeenCalledWith('http://127.0.0.1:3100/mcp', expect.objectContaining({ method: 'POST' }));
+    const sentInit = fetchImpl.mock.calls[0][1] as RequestInit;
+    expect((sentInit.headers as Record<string, string>).Accept).toContain('text/event-stream');
     expect(output.join('')).toContain('"id":1');
   });
 
   test('returns JSON-RPC parse errors locally', async () => {
-    const bridge = new BrokerProxyStdioBridge({ schemaVersion: 1, pid: 1, version: 'test', startedAt: 'now', port: 9222, userDataDir: '/tmp/profile', endpoint: 'http://127.0.0.1:3100/mcp' });
+    const fetchImpl = jest.fn();
+    const output: string[] = [];
+    const bridge = new BrokerProxyStdioBridge(broker, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      write: (chunk) => { output.push(chunk); },
+    });
 
-    await (bridge as any).forwardLine('not json');
+    await bridge.forwardLine('not json');
 
+    expect(fetchImpl).not.toHaveBeenCalled();
     expect(output.join('')).toContain('"code":-32700');
+  });
+
+  test('preserves Mcp-Session-Id across requests after initialize', async () => {
+    const fetchImpl = jest.fn<Promise<Response>, [string, RequestInit]>()
+      .mockResolvedValueOnce(createMockResponse({
+        body: '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05"}}',
+        headers: { 'Mcp-Session-Id': 'abc-123' },
+      }))
+      .mockResolvedValueOnce(createMockResponse({ body: '{"jsonrpc":"2.0","id":2,"result":{}}' }));
+    const bridge = new BrokerProxyStdioBridge(broker, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      write: () => undefined,
+    });
+
+    await bridge.forwardLine('{"jsonrpc":"2.0","id":1,"method":"initialize"}');
+    await bridge.forwardLine('{"jsonrpc":"2.0","id":2,"method":"tools/list"}');
+
+    const secondHeaders = (fetchImpl.mock.calls[1][1] as RequestInit).headers as Record<string, string>;
+    expect(secondHeaders['Mcp-Session-Id']).toBe('abc-123');
+  });
+
+  test('writes no body for 202 Accepted notifications', async () => {
+    const fetchImpl = jest.fn(async () => createMockResponse({ status: 202 }));
+    const output: string[] = [];
+    const bridge = new BrokerProxyStdioBridge(broker, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      write: (chunk) => { output.push(chunk); },
+    });
+
+    await bridge.forwardLine('{"jsonrpc":"2.0","method":"notifications/initialized"}');
+
+    expect(output).toEqual([]);
+  });
+
+  test('unwraps Streamable HTTP SSE responses into JSON-RPC lines', async () => {
+    const sseBody = 'event: message\ndata: {"jsonrpc":"2.0","id":3,"result":{"ok":true}}\n\n';
+    const fetchImpl = jest.fn(async () => createMockResponse({
+      body: sseBody,
+      headers: { 'Content-Type': 'text/event-stream' },
+    }));
+    const output: string[] = [];
+    const bridge = new BrokerProxyStdioBridge(broker, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      write: (chunk) => { output.push(chunk); },
+    });
+
+    await bridge.forwardLine('{"jsonrpc":"2.0","id":3,"method":"tools/list"}');
+
+    expect(output.join('')).toContain('"id":3');
+    expect(output.join('')).not.toContain('data:');
+  });
+
+  test('emits a JSON-RPC error response when the broker returns an HTTP error', async () => {
+    const fetchImpl = jest.fn(async () => createMockResponse({ status: 500, body: 'oops' }));
+    const output: string[] = [];
+    const bridge = new BrokerProxyStdioBridge(broker, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      write: (chunk) => { output.push(chunk); },
+    });
+
+    await bridge.forwardLine('{"jsonrpc":"2.0","id":7,"method":"tools/list"}');
+
+    const parsed = JSON.parse(output.join('').trim());
+    expect(parsed).toMatchObject({ id: 7, error: expect.objectContaining({ code: expect.any(Number) }) });
+    expect(parsed.error.message).toContain('500');
   });
 });

--- a/tests/broker-proxy.test.ts
+++ b/tests/broker-proxy.test.ts
@@ -103,6 +103,26 @@ describe('BrokerProxyStdioBridge', () => {
     expect(output.join('')).not.toContain('data:');
   });
 
+  test('emits one stdout line per data frame in a batched SSE response', async () => {
+    const sseBody = 'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{}}\n\nevent: message\ndata: {"jsonrpc":"2.0","id":2,"result":{}}\n\n';
+    const fetchImpl = jest.fn(async () => createMockResponse({
+      body: sseBody,
+      headers: { 'Content-Type': 'text/event-stream' },
+    }));
+    const output: string[] = [];
+    const bridge = new BrokerProxyStdioBridge(broker, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      write: (chunk) => { output.push(chunk); },
+    });
+
+    await bridge.forwardLine('{"jsonrpc":"2.0","id":1,"method":"tools/list"}');
+
+    // Each data frame is its own JSON-RPC line — concatenating them would
+    // produce invalid JSON for downstream stdio clients.
+    expect(output.filter((line) => line.includes('"id":1')).length).toBeGreaterThan(0);
+    expect(output.filter((line) => line.includes('"id":2')).length).toBeGreaterThan(0);
+  });
+
   test('emits a JSON-RPC error response when the broker returns an HTTP error', async () => {
     const fetchImpl = jest.fn(async () => createMockResponse({ status: 500, body: 'oops' }));
     const output: string[] = [];

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -18,6 +18,7 @@ const REQUIRED_CHECK_IDS = [
   'pid-lock',
   'orphan-chrome',
   'profile-lock',
+  'duplicate-controllers',
   'disk-space',
   'macos-perms',
   'network-local',

--- a/tests/cli/mcp-client-config.test.ts
+++ b/tests/cli/mcp-client-config.test.ts
@@ -5,7 +5,9 @@ import {
   getClaudeSetupCommand,
   getCodexServerConfig,
   getCodexSetupCommand,
+  getOpenCodeServerConfig,
   getServeArgs,
+  getTopologyWarning,
   isSupportedMCPClient,
   upsertMCPServerConfig,
 } from '../../cli/mcp-client-config';
@@ -17,6 +19,39 @@ describe('cli/mcp-client-config', () => {
 
   test('getServeArgs includes dashboard when requested', () => {
     expect(getServeArgs({ dashboard: true })).toEqual(['serve', '--auto-launch', '--dashboard']);
+  });
+
+  test('getServeArgs preserves explicit port and profile topology', () => {
+    expect(getServeArgs({
+      port: 9333,
+      userDataDir: '/tmp/openchrome-codex',
+      profileDirectory: 'Default',
+      launchMode: 'isolated',
+    })).toEqual([
+      'serve',
+      '--auto-launch',
+      '--port',
+      '9333',
+      '--user-data-dir',
+      '/tmp/openchrome-codex',
+      '--profile-directory',
+      'Default',
+      '--launch-mode',
+      'isolated',
+    ]);
+  });
+
+  test('isolated topology preset chooses a non-default port and profile', () => {
+    expect(getServeArgs({ topology: 'isolated' })).toEqual([
+      'serve',
+      '--auto-launch',
+      '--port',
+      '9223',
+      '--user-data-dir',
+      '~/.openchrome/profiles/isolated',
+      '--launch-mode',
+      'isolated',
+    ]);
   });
 
   test('getServeArgs omits auto-launch when explicitly disabled', () => {
@@ -117,11 +152,55 @@ describe('cli/mcp-client-config', () => {
     );
   });
 
+  test('Codex and Claude generated configs preserve explicit port and user-data-dir', () => {
+    const options = { port: 9333, userDataDir: '/tmp/openchrome-codex' };
+
+    expect(formatCodexMCPServerConfigSnippet('openchrome', getCodexServerConfig(options))).toContain(
+      'args = ["serve", "--auto-launch", "--port", "9333", "--user-data-dir", "/tmp/openchrome-codex"]'
+    );
+    expect(getClaudeSetupCommand('user', options)).toEqual([
+      'mcp',
+      'add',
+      'openchrome',
+      '-s',
+      'user',
+      '--',
+      'openchrome',
+      'serve',
+      '--auto-launch',
+      '--port',
+      '9333',
+      '--user-data-dir',
+      '/tmp/openchrome-codex',
+    ]);
+  });
+
+  test('OpenCode generated config uses installed openchrome and preserves topology args', () => {
+    expect(getOpenCodeServerConfig({ port: 9444, userDataDir: '/tmp/openchrome-opencode' })).toEqual({
+      type: 'local',
+      command: [
+        'openchrome',
+        'serve',
+        '--auto-launch',
+        '--port',
+        '9444',
+        '--user-data-dir',
+        '/tmp/openchrome-opencode',
+      ],
+    });
+  });
+
+  test('default topology warning is omitted once port/profile is explicit', () => {
+    expect(getTopologyWarning()).toContain('default single-owner');
+    expect(getTopologyWarning({ port: 9333, userDataDir: '/tmp/openchrome-codex' })).toBeNull();
+  });
+
   test('generated configs do not use transient package runners', () => {
     const serialized = [
       JSON.stringify(getCodexServerConfig()),
       JSON.stringify(getClaudeManualServerConfig()),
       formatCodexMCPServerConfigSnippet('openchrome', getCodexServerConfig()),
+      JSON.stringify(getOpenCodeServerConfig()),
       getClaudeSetupCommand('user').join(' '),
       getCodexSetupCommand().join(' '),
     ].join('\n');

--- a/tests/duplicate-controller-diagnostics.test.ts
+++ b/tests/duplicate-controller-diagnostics.test.ts
@@ -1,0 +1,93 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  findDuplicateControllerGroups,
+  getCurrentControllerTopology,
+  inferOpenChromeProcess,
+  parsePsOutput,
+  scanMcpConfigRegistrations,
+  summarizeDuplicateControllerDiagnostics,
+} from '../src/utils/duplicate-controller-diagnostics';
+import { acquireControllerLock } from '../src/utils/controller-lock';
+
+describe('duplicate controller diagnostics', () => {
+  let tmpDir: string;
+  const oldLockDir = process.env.OPENCHROME_CONTROLLER_LOCK_DIR;
+  const oldUnsafe = process.env.OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-diagnostics-test-'));
+    process.env.OPENCHROME_CONTROLLER_LOCK_DIR = tmpDir;
+    delete process.env.OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (oldLockDir === undefined) delete process.env.OPENCHROME_CONTROLLER_LOCK_DIR;
+    else process.env.OPENCHROME_CONTROLLER_LOCK_DIR = oldLockDir;
+    if (oldUnsafe === undefined) delete process.env.OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH;
+    else process.env.OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH = oldUnsafe;
+  });
+
+  test('infers global and npx OpenChrome process topology', () => {
+    const globalProc = inferOpenChromeProcess(100, 'openchrome serve --auto-launch --port 9222 --user-data-dir /tmp/shared');
+    const npxProc = inferOpenChromeProcess(101, 'npm exec openchrome-mcp@latest -- openchrome serve -p 9222 --user-data-dir /tmp/shared');
+
+    expect(globalProc?.source).toBe('global');
+    expect(npxProc?.source).toBe('npx');
+    expect(globalProc?.port).toBe(9222);
+    expect(globalProc?.userDataDir).toBe(path.resolve('/tmp/shared'));
+  });
+
+  test('groups duplicate processes by port and profile', () => {
+    const processes = parsePsOutput([
+      '100 1 openchrome serve --port 9222 --user-data-dir /tmp/shared',
+      '101 1 npm exec openchrome-mcp@latest -- openchrome serve --port 9222 --user-data-dir /tmp/shared',
+      '102 1 openchrome serve --port 9223 --user-data-dir /tmp/shared',
+    ].join('\n'));
+
+    const groups = findDuplicateControllerGroups(processes);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].processes.map((proc) => proc.pid)).toEqual([100, 101]);
+  });
+
+  test('detects stale Codex mcp.json and mixed registrations', () => {
+    const codexToml = path.join(tmpDir, 'config.toml');
+    const staleMcp = path.join(tmpDir, 'mcp.json');
+    fs.writeFileSync(codexToml, '[mcp_servers.openchrome]\ncommand = "openchrome"\nargs = ["serve"]\n');
+    fs.writeFileSync(staleMcp, JSON.stringify({ mcpServers: { openchrome: { command: 'npm', args: ['exec', 'openchrome-mcp@latest'] } } }));
+
+    const configs = scanMcpConfigRegistrations([
+      { client: 'codex', path: codexToml },
+      { client: 'codex', path: staleMcp, stale: true },
+    ]);
+
+    expect(configs[0].risk).toBe('openchrome');
+    expect(configs[1].risk).toBe('stale-config');
+    const summary = summarizeDuplicateControllerDiagnostics({ processes: [], configs });
+    expect(summary.mixedInstallations).toBe(true);
+    expect(summary.warnings.join(' ')).toContain('stale MCP config');
+  });
+
+  test('reports current owner lock topology', () => {
+    const profile = path.join(tmpDir, 'profile');
+    const handle = acquireControllerLock({ port: 9333, userDataDir: profile }, tmpDir);
+
+    const topology = getCurrentControllerTopology({ port: 9333, userDataDir: profile });
+
+    expect(topology.role).toBe('owner');
+    expect(topology.ownerPid).toBe(process.pid);
+    handle.release();
+  });
+
+  test('reports explicit unsafe secondary attach topology', () => {
+    process.env.OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH = '1';
+
+    const topology = getCurrentControllerTopology({ port: 9334, userDataDir: path.join(tmpDir, 'profile') });
+
+    expect(topology.role).toBe('unsafe-secondary-attach');
+    expect(topology.remediation).toContain('Disable OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH');
+  });
+});

--- a/tests/shared-profile-policy.test.ts
+++ b/tests/shared-profile-policy.test.ts
@@ -1,0 +1,46 @@
+import {
+  assertSharedProfileAllowed,
+  canAccessLeaseDiagnostic,
+  getSharedProfilePolicy,
+  redactLeaseDiagnostic,
+} from '../src/security/shared-profile-policy';
+import type { TargetLeaseRecord } from '../src/session/target-lease-registry';
+
+const lease: TargetLeaseRecord = {
+  targetId: 't1',
+  sessionId: 's1',
+  clientId: 'c1',
+  workerId: 'w1',
+  createdAt: 1,
+  lastActivityAt: 2,
+  cleanupPolicy: 'close-on-session-end',
+};
+
+describe('shared profile policy', () => {
+  test('defaults to same-trust-zone with redacted diagnostics', () => {
+    const policy = getSharedProfilePolicy({});
+    expect(policy).toMatchObject({ trustMode: 'same-trust-zone', redactUrls: true, redactTitles: true });
+    expect(() => assertSharedProfileAllowed(policy)).not.toThrow();
+  });
+
+  test('rejects shared profile when untrusted mode is declared', () => {
+    const policy = getSharedProfilePolicy({ OPENCHROME_SHARED_PROFILE_UNTRUSTED: '1' });
+    expect(policy.trustMode).toBe('isolated-required');
+    expect(() => assertSharedProfileAllowed(policy)).toThrow('same-trust-zone only');
+  });
+
+  test('limits lease diagnostics to same session/client unless explicitly allowed', () => {
+    expect(canAccessLeaseDiagnostic(lease, { sessionId: 's1' }, getSharedProfilePolicy({}))).toBe(true);
+    expect(canAccessLeaseDiagnostic(lease, { clientId: 'c1' }, getSharedProfilePolicy({}))).toBe(true);
+    expect(canAccessLeaseDiagnostic(lease, { sessionId: 'other' }, getSharedProfilePolicy({}))).toBe(false);
+    expect(canAccessLeaseDiagnostic(lease, { sessionId: 'other' }, getSharedProfilePolicy({ OPENCHROME_SHARED_PROFILE_CROSS_TENANT_DIAGNOSTICS: '1' }))).toBe(true);
+  });
+
+  test('redacted lease diagnostics omit URL/title-shaped sensitive fields', () => {
+    const diagnostic = redactLeaseDiagnostic(lease, { sessionId: 's1' }, getSharedProfilePolicy({}));
+    expect(diagnostic).toEqual(expect.objectContaining({ targetId: 't1', sessionId: 's1', redacted: true }));
+    expect(diagnostic).not.toHaveProperty('url');
+    expect(diagnostic).not.toHaveProperty('title');
+    expect(redactLeaseDiagnostic(lease, { sessionId: 'other' }, getSharedProfilePolicy({}))).toBeNull();
+  });
+});

--- a/tests/target-command-queue.test.ts
+++ b/tests/target-command-queue.test.ts
@@ -1,0 +1,54 @@
+import { TargetQueueCancelledError, TargetQueueManager } from '../src/session/target-command-queue';
+
+describe('TargetQueueManager', () => {
+  test('serializes commands for the same target', async () => {
+    const queue = new TargetQueueManager();
+    const events: string[] = [];
+
+    const first = queue.enqueue('tab-1', async () => {
+      events.push('first:start');
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      events.push('first:end');
+      return 1;
+    });
+    const second = queue.enqueue('tab-1', async () => {
+      events.push('second:start');
+      return 2;
+    });
+
+    await expect(Promise.all([first, second])).resolves.toEqual([1, 2]);
+    expect(events).toEqual(['first:start', 'first:end', 'second:start']);
+  });
+
+  test('allows commands for different targets to run concurrently', async () => {
+    const queue = new TargetQueueManager();
+    const events: string[] = [];
+
+    await Promise.all([
+      queue.enqueue('tab-1', async () => {
+        events.push('tab-1:start');
+        await new Promise((resolve) => setTimeout(resolve, 15));
+        events.push('tab-1:end');
+      }),
+      queue.enqueue('tab-2', async () => {
+        events.push('tab-2:start');
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        events.push('tab-2:end');
+      }),
+    ]);
+
+    expect(events.indexOf('tab-2:start')).toBeLessThan(events.indexOf('tab-1:end'));
+  });
+
+  test('cancels queued commands for a closed target', async () => {
+    const queue = new TargetQueueManager();
+    let release!: () => void;
+    const first = queue.enqueue('tab-1', async () => new Promise<void>((resolve) => { release = resolve; }));
+    const second = queue.enqueue('tab-1', async () => undefined);
+
+    queue.cancelTarget('tab-1');
+    release();
+    await first;
+    await expect(second).rejects.toBeInstanceOf(TargetQueueCancelledError);
+  });
+});

--- a/tests/target-command-queue.test.ts
+++ b/tests/target-command-queue.test.ts
@@ -52,6 +52,31 @@ describe('TargetQueueManager', () => {
     await expect(second).rejects.toBeInstanceOf(TargetQueueCancelledError);
   });
 
+  test('rejects new enqueue after a target queue has been cancelled', async () => {
+    const queue = new TargetQueueManager();
+    const first = queue.enqueue('tab-1', async () => 1);
+    await first;
+
+    queue.cancelTarget('tab-1');
+
+    // The cancelled queue is kept in the map as a tombstone so a racing
+    // caller cannot silently spin up a fresh queue against a dead target.
+    await expect(queue.enqueue('tab-1', async () => 2)).rejects.toBeInstanceOf(TargetQueueCancelledError);
+  });
+
+  test('in-flight work survives cancel() while pending work is rejected', async () => {
+    const queue = new TargetQueueManager();
+    let release!: () => void;
+    const inflight = queue.enqueue('tab-1', () => new Promise<string>((resolve) => { release = () => resolve('done'); }));
+    const pending = queue.enqueue('tab-1', async () => 'never');
+
+    queue.cancelTarget('tab-1');
+    release();
+
+    await expect(inflight).resolves.toBe('done');
+    await expect(pending).rejects.toBeInstanceOf(TargetQueueCancelledError);
+  });
+
   test('reconcile drops queues whose targetId is no longer alive', async () => {
     const queue = new TargetQueueManager();
     const aliveDone = queue.enqueue('alive', async () => 1);

--- a/tests/target-command-queue.test.ts
+++ b/tests/target-command-queue.test.ts
@@ -51,4 +51,17 @@ describe('TargetQueueManager', () => {
     await first;
     await expect(second).rejects.toBeInstanceOf(TargetQueueCancelledError);
   });
+
+  test('reconcile drops queues whose targetId is no longer alive', async () => {
+    const queue = new TargetQueueManager();
+    const aliveDone = queue.enqueue('alive', async () => 1);
+    const orphanWork = queue.enqueue('orphan', async () => undefined);
+    await aliveDone;
+
+    const cancelled = queue.reconcileAliveTargetIds(new Set(['alive']));
+
+    expect(cancelled).toEqual(['orphan']);
+    await expect(orphanWork).resolves.toBeUndefined();
+    expect(queue.getStats().map((s) => s.targetId)).toEqual(['alive']);
+  });
 });

--- a/tests/target-lease-registry.test.ts
+++ b/tests/target-lease-registry.test.ts
@@ -1,0 +1,38 @@
+import { TargetLeaseConflictError, TargetLeaseRegistry } from '../src/session/target-lease-registry';
+
+describe('TargetLeaseRegistry', () => {
+  test('acquires and snapshots leases with ownership metadata', () => {
+    const registry = new TargetLeaseRegistry();
+    const lease = registry.acquire({ targetId: 't1', sessionId: 's1', clientId: 'c1', workerId: 'w1', laneId: 'l1', contextName: 'ctx', now: 10, ttlMs: 1000 });
+
+    expect(lease).toMatchObject({ targetId: 't1', sessionId: 's1', clientId: 'c1', workerId: 'w1', laneId: 'l1', contextName: 'ctx', createdAt: 10, lastActivityAt: 10, leaseExpiresAt: 1010 });
+    expect(registry.snapshot()).toHaveLength(1);
+  });
+
+  test('rejects another session acquiring an active lease', () => {
+    const registry = new TargetLeaseRegistry();
+    registry.acquire({ targetId: 't1', sessionId: 's1' });
+
+    expect(() => registry.acquire({ targetId: 't1', sessionId: 's2' })).toThrow(TargetLeaseConflictError);
+  });
+
+  test('inherits popup ownership from parent target', () => {
+    const registry = new TargetLeaseRegistry();
+    registry.acquire({ targetId: 'parent', sessionId: 's1', workerId: 'w1', contextName: 'ctx' });
+
+    const popup = registry.inherit('popup', 'parent');
+
+    expect(popup).toMatchObject({ targetId: 'popup', sessionId: 's1', workerId: 'w1', contextName: 'ctx' });
+  });
+
+  test('expires and reconciles orphan leases', () => {
+    const registry = new TargetLeaseRegistry();
+    registry.acquire({ targetId: 'expired', sessionId: 's1', now: 0, ttlMs: 10 });
+    registry.acquire({ targetId: 'alive', sessionId: 's1' });
+    registry.acquire({ targetId: 'gone', sessionId: 's2' });
+
+    expect(registry.expire(11).map((lease) => lease.targetId)).toEqual(['expired']);
+    expect(registry.reconcileAliveTargetIds(new Set(['alive'])).map((lease) => lease.targetId)).toEqual(['gone']);
+    expect(registry.snapshot().map((lease) => lease.targetId)).toEqual(['alive']);
+  });
+});

--- a/tests/target-lease-registry.test.ts
+++ b/tests/target-lease-registry.test.ts
@@ -25,6 +25,16 @@ describe('TargetLeaseRegistry', () => {
     expect(popup).toMatchObject({ targetId: 'popup', sessionId: 's1', workerId: 'w1', contextName: 'ctx' });
   });
 
+  test('release with no sessionId drops a lease so recovery can transfer ownership', () => {
+    const registry = new TargetLeaseRegistry();
+    registry.acquire({ targetId: 't1', sessionId: 's1' });
+
+    expect(registry.release('t1')).toBe(true);
+    // The recovery path (SessionManager.tryRecoverTarget) re-acquires under
+    // the new owner once the stale lease has been released.
+    expect(registry.acquire({ targetId: 't1', sessionId: 's2' })).toMatchObject({ sessionId: 's2' });
+  });
+
   test('expires and reconciles orphan leases', () => {
     const registry = new TargetLeaseRegistry();
     registry.acquire({ targetId: 'expired', sessionId: 's1', now: 0, ttlMs: 10 });

--- a/tests/target-lease-registry.test.ts
+++ b/tests/target-lease-registry.test.ts
@@ -23,6 +23,7 @@ describe('TargetLeaseRegistry', () => {
     const popup = registry.inherit('popup', 'parent');
 
     expect(popup).toMatchObject({ targetId: 'popup', sessionId: 's1', workerId: 'w1', contextName: 'ctx' });
+    expect(registry.snapshot()).toHaveLength(2);
   });
 
   test('expires and reconciles orphan leases', () => {

--- a/tests/tools/connection-health.test.ts
+++ b/tests/tools/connection-health.test.ts
@@ -19,6 +19,16 @@ jest.mock('../../src/session-manager', () => ({
   getSessionManager: jest.fn(),
 }));
 
+jest.mock('../../src/utils/duplicate-controller-diagnostics', () => ({
+  getCurrentControllerTopology: jest.fn(() => ({
+    role: 'owner',
+    port: 9222,
+    userDataDir: '/tmp/profile',
+    lockPath: '/tmp/lock.json',
+    ownerPid: process.pid,
+  })),
+}));
+
 import { getSessionManager } from '../../src/session-manager';
 import { MCPServer } from '../../src/mcp-server';
 import { registerConnectionHealthTool } from '../../src/tools/connection-health';
@@ -70,6 +80,7 @@ describe('oc_connection_health tool', () => {
     expect(data.msSinceLastVerified).toBe(1500);
     expect(data.consecutiveSuccesses).toBe(5);
     expect(data.lastVerifiedAt).not.toBeNull();
+    expect(data.controllerTopology.role).toBe('owner');
     // Should be an ISO string
     expect(typeof data.lastVerifiedAt).toBe('string');
     expect(() => new Date(data.lastVerifiedAt)).not.toThrow();

--- a/tests/tools/shutdown.test.ts
+++ b/tests/tools/shutdown.test.ts
@@ -2,13 +2,14 @@
 
 const cleanupAllSessions = jest.fn();
 const getAllSessionInfos = jest.fn();
+const getTargetLeaseSnapshot = jest.fn();
 const poolShutdown = jest.fn();
 const cdpDisconnect = jest.fn();
 const launcherClose = jest.fn();
 const shutdownHeadedFallback = jest.fn();
 
 jest.mock('../../src/session-manager', () => ({
-  getSessionManager: () => ({ cleanupAllSessions, getAllSessionInfos }),
+  getSessionManager: () => ({ cleanupAllSessions, getAllSessionInfos, getTargetLeaseSnapshot }),
 }));
 
 jest.mock('../../src/cdp/connection-pool', () => ({
@@ -48,6 +49,7 @@ describe('oc_stop dryRun (#878)', () => {
     poolShutdown.mockResolvedValue(undefined);
     cdpDisconnect.mockResolvedValue(undefined);
     launcherClose.mockResolvedValue(undefined);
+    getTargetLeaseSnapshot.mockReturnValue([]);
     getAllSessionInfos.mockReturnValue([
       { id: 's1', name: 'Session 1', targetCount: 2, workerCount: 1, workers: [], createdAt: 1, lastActivityAt: 2 },
       { id: 's2', name: 'Session 2', targetCount: 1, workerCount: 1, workers: [], createdAt: 3, lastActivityAt: 4 },
@@ -78,6 +80,7 @@ describe('oc_stop dryRun (#878)', () => {
           connectionPool: true,
           cdpClient: true,
           chromeProcess: false,
+          activeLeases: 0,
         },
       },
       guidance: 'Pass dryRun:false (or omit) to execute.',
@@ -88,5 +91,64 @@ describe('oc_stop dryRun (#878)', () => {
     expect(poolShutdown).not.toHaveBeenCalled();
     expect(cdpDisconnect).not.toHaveBeenCalled();
     expect(launcherClose).not.toHaveBeenCalled();
+  });
+});
+
+describe('oc_stop broker safety (#1373)', () => {
+  let handler: (sessionId: string, args: Record<string, unknown>) => Promise<any>;
+  const previousBrokerOwner = process.env.OPENCHROME_BROKER_OWNER;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cleanupAllSessions.mockResolvedValue(0);
+    poolShutdown.mockResolvedValue(undefined);
+    cdpDisconnect.mockResolvedValue(undefined);
+    launcherClose.mockResolvedValue(undefined);
+    getAllSessionInfos.mockReturnValue([]);
+    const server = new MCPServer(undefined, { initialToolTier: 3 });
+    registerShutdownTool(server);
+    handler = server.getToolHandler('oc_stop')!;
+  });
+
+  afterEach(() => {
+    if (previousBrokerOwner === undefined) {
+      delete process.env.OPENCHROME_BROKER_OWNER;
+    } else {
+      process.env.OPENCHROME_BROKER_OWNER = previousBrokerOwner;
+    }
+  });
+
+  test('broker owner with active leases refuses shutdown without force', async () => {
+    process.env.OPENCHROME_BROKER_OWNER = '1';
+    getTargetLeaseSnapshot.mockReturnValue([{ targetId: 't1' }, { targetId: 't2' }]);
+
+    const result = await handler('default', {});
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toEqual({ activeLeases: 2, forceRequired: true });
+    expect(cleanupAllSessions).not.toHaveBeenCalled();
+    expect(poolShutdown).not.toHaveBeenCalled();
+    expect(cdpDisconnect).not.toHaveBeenCalled();
+    expect(launcherClose).not.toHaveBeenCalled();
+  });
+
+  test('broker owner with active leases proceeds when force is set', async () => {
+    process.env.OPENCHROME_BROKER_OWNER = '1';
+    getTargetLeaseSnapshot.mockReturnValue([{ targetId: 't1' }]);
+
+    const result = await handler('default', { force: true });
+
+    expect(result.isError).toBeFalsy();
+    expect(cleanupAllSessions).toHaveBeenCalledTimes(1);
+  });
+
+  test('non-broker process is not gated by active leases', async () => {
+    delete process.env.OPENCHROME_BROKER_OWNER;
+    getTargetLeaseSnapshot.mockReturnValue([{ targetId: 't1' }]);
+
+    const result = await handler('default', {});
+
+    expect(result.isError).toBeFalsy();
+    expect(cleanupAllSessions).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- add a duplicate-controller diagnostic scanner for running OpenChrome MCP processes
- scan common MCP client config locations and flag stale Codex `mcp.json` / mixed global+npx registrations
- expose controller topology in `oc_connection_health` and the optional health endpoint
- add an `openchrome doctor` check with safe remediation text

## Stack
- Stacked on #1376 because this diagnostics PR reuses the controller lock/topology primitive from #1367.

## Tests
- `npm test -- tests/duplicate-controller-diagnostics.test.ts tests/tools/connection-health.test.ts --runInBand`
- `npm test -- tests/cli/doctor.test.ts --runInBand`
- `npm run build`

Closes #1368
