### PR TITLE
Document safe OpenChrome parallelism

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,6 +46,10 @@ are optional.
 For manual Codex CLI setup, run `openchrome config --client codex` and add
 the printed `[mcp_servers.openchrome]` block to `~/.codex/config.toml`.
 
+Running multiple MCP clients? Read
+[`docs/mcp/safe-parallelism.md`](./mcp/safe-parallelism.md) before installing
+the same default direct config in more than one client.
+
 ## 2. Confirm core tier is live
 
 Open a fresh chat in your MCP client and ask it to navigate somewhere:

--- a/docs/mcp/safe-parallelism.md
+++ b/docs/mcp/safe-parallelism.md
@@ -4,19 +4,23 @@ OpenChrome can drive many browser tasks in parallel, but the topology matters.
 
 ## Choose one topology
 
-### 1. Broker owner with many clients
+### 1. Broker owner with many clients (early)
 
-Use one OpenChrome broker owner for a shared Chrome profile, then point MCP clients at that owner.
+Use one OpenChrome broker owner for a shared Chrome profile, then point MCP clients at that owner. The `--broker` flag publishes broker metadata that proxy clients discover by matching on `--port` and `--user-data-dir`; the `--http` port is what proxies actually connect through, so the owner must keep running while clients are attached.
+
+Step 1 — start the broker owner once (keeps running):
 
 ```bash
-# Terminal 1: owns Chrome/CDP and publishes broker metadata
 openchrome serve --broker --auto-launch --http 3100 --port 9222 --user-data-dir ~/.openchrome/profiles/shared
+```
 
-# MCP client config: stdio proxy, no direct Chrome attach
+Step 2 — register each MCP client as a stdio proxy with the same `--port` + `--user-data-dir`:
+
+```bash
 openchrome serve --connect-broker --port 9222 --user-data-dir ~/.openchrome/profiles/shared
 ```
 
-This is the long-term shared-profile design: one direct CDP owner, many MCP clients. The broker owns browser lifecycle, leases, reconnect state, and per-target queues.
+This is the long-term shared-profile design: one direct CDP owner, many MCP clients. The broker owns browser lifecycle, leases, reconnect state, and per-target queues. Broker mode is implemented but still early — read the trust policy in [`docs/security/shared-profile-trust.md`](../security/shared-profile-trust.md) before sharing a profile across clients.
 
 ### 2. Independent direct MCP processes with isolated profiles
 
@@ -68,13 +72,13 @@ openchrome setup --client codex --port 9224 --user-data-dir ~/.openchrome/profil
 
 ### Claude + Codex with shared broker
 
-Run one broker owner:
+Step 1 — run one broker owner (keep this process running while clients are attached):
 
 ```bash
 openchrome serve --broker --auto-launch --http 3100 --port 9222 --user-data-dir ~/.openchrome/profiles/shared
 ```
 
-Configure both clients to use the stdio broker proxy command:
+Step 2 — register both Claude and Codex with the stdio broker proxy command, using the same `--port` and `--user-data-dir` as the owner so they discover the same broker metadata:
 
 ```bash
 openchrome serve --connect-broker --port 9222 --user-data-dir ~/.openchrome/profiles/shared

--- a/docs/mcp/safe-parallelism.md
+++ b/docs/mcp/safe-parallelism.md
@@ -1,0 +1,101 @@
+# Safe OpenChrome parallelism
+
+OpenChrome can drive many browser tasks in parallel, but the topology matters.
+
+## Choose one topology
+
+### 1. Broker owner with many clients
+
+Use one OpenChrome broker owner for a shared Chrome profile, then point MCP clients at that owner.
+
+```bash
+# Terminal 1: owns Chrome/CDP and publishes broker metadata
+openchrome serve --broker --auto-launch --http 3100 --port 9222 --user-data-dir ~/.openchrome/profiles/shared
+
+# MCP client config: stdio proxy, no direct Chrome attach
+openchrome serve --connect-broker --port 9222 --user-data-dir ~/.openchrome/profiles/shared
+```
+
+This is the long-term shared-profile design: one direct CDP owner, many MCP clients. The broker owns browser lifecycle, leases, reconnect state, and per-target queues.
+
+### 2. Independent direct MCP processes with isolated profiles
+
+Use this today when you want several MCP clients without sharing a browser profile.
+
+```bash
+openchrome setup --client claude --port 9223 --user-data-dir ~/.openchrome/profiles/claude
+openchrome setup --client codex --port 9224 --user-data-dir ~/.openchrome/profiles/codex
+openchrome setup --client opencode --port 9225 --user-data-dir ~/.openchrome/profiles/opencode
+```
+
+Each process owns a different Chrome instance/profile, so direct CDP control does not conflict.
+
+### 3. Unsafe: many direct MCP processes, one Chrome/profile
+
+Avoid this:
+
+```text
+Claude -> openchrome serve --auto-launch --port 9222 --user-data-dir ~/.openchrome/profile
+Codex  -> openchrome serve --auto-launch --port 9222 --user-data-dir ~/.openchrome/profile
+```
+
+Multiple direct controllers can race on target lifecycle, reconnect, cleanup, and tab ownership. Symptoms include missing MCP tools, `Target closed`, `CDPSession closed`, stale tabs, or unexpected Chrome shutdown.
+
+## Client recipes
+
+### Claude only
+
+```bash
+openchrome setup --client claude
+```
+
+Safe for one client. If another client will also run direct mode, add explicit `--port` and `--user-data-dir`.
+
+### Codex only
+
+```bash
+openchrome setup --client codex
+```
+
+Remove stale `~/.codex/mcp.json` entries if you migrated to `~/.codex/config.toml`.
+
+### Claude + Codex with isolated profiles
+
+```bash
+openchrome setup --client claude --port 9223 --user-data-dir ~/.openchrome/profiles/claude
+openchrome setup --client codex --port 9224 --user-data-dir ~/.openchrome/profiles/codex
+```
+
+### Claude + Codex with shared broker
+
+Run one broker owner:
+
+```bash
+openchrome serve --broker --auto-launch --http 3100 --port 9222 --user-data-dir ~/.openchrome/profiles/shared
+```
+
+Configure both clients to use the stdio broker proxy command:
+
+```bash
+openchrome serve --connect-broker --port 9222 --user-data-dir ~/.openchrome/profiles/shared
+```
+
+### OMX / Codex development
+
+When developing OpenChrome itself while another assistant also uses OpenChrome, prefer isolated dev profiles:
+
+```bash
+openchrome setup --client codex --port 9322 --user-data-dir ~/.openchrome/profiles/openchrome-dev
+```
+
+### CI/headless
+
+Use a disposable profile and a non-default port:
+
+```bash
+openchrome config --client codex --topology ci-headless
+```
+
+## Memory tradeoffs
+
+A shared broker profile can reduce duplicate browser-process overhead, but each active tab can still create renderer, worker, GPU, and cache pressure. Shared Chrome is not a guarantee of flat memory usage. Use fewer active tabs, close unused leases, and prefer isolated CI profiles for reproducibility.

--- a/docs/mcp/topologies.md
+++ b/docs/mcp/topologies.md
@@ -56,3 +56,8 @@ openchrome config --client claude --topology dev-profile
 ## Future broker topology
 
 The planned broker topology will allow many MCP clients to share one direct Chrome owner. Until that exists, direct shared-profile multi-client setups should be treated as unsafe because independent processes can race over CDP target lifecycle, reconnect, and cleanup.
+
+## See also
+
+- [Safe OpenChrome parallelism](./safe-parallelism.md)
+- [Parallelism troubleshooting](./troubleshooting-parallelism.md)

--- a/docs/mcp/topologies.md
+++ b/docs/mcp/topologies.md
@@ -4,7 +4,7 @@ OpenChrome currently supports one safe direct-controller rule:
 
 > Run at most one direct `openchrome serve --auto-launch` process for the same Chrome debug port and user-data directory.
 
-Multiple MCP clients can still run in parallel today, but each direct OpenChrome process should use an explicit isolated Chrome topology until broker mode is available.
+Multiple MCP clients can still run in parallel today, either through isolated direct topologies or through the shared broker (early — see [Safe OpenChrome parallelism](./safe-parallelism.md) for full recipes and tradeoffs).
 
 ## Single-owner default
 
@@ -53,9 +53,9 @@ For local development, use a named development profile:
 openchrome config --client claude --topology dev-profile
 ```
 
-## Future broker topology
+## Shared broker topology (early)
 
-The planned broker topology will allow many MCP clients to share one direct Chrome owner. Until that exists, direct shared-profile multi-client setups should be treated as unsafe because independent processes can race over CDP target lifecycle, reconnect, and cleanup.
+The broker topology lets many MCP clients share one direct Chrome owner. It is implemented (`openchrome serve --broker` plus `openchrome serve --connect-broker`) but still early — exercise it with care. Direct shared-profile multi-client setups without the broker remain unsafe because independent processes race over CDP target lifecycle, reconnect, and cleanup. See [Safe OpenChrome parallelism](./safe-parallelism.md) for the full broker recipe.
 
 ## See also
 

--- a/docs/mcp/troubleshooting-parallelism.md
+++ b/docs/mcp/troubleshooting-parallelism.md
@@ -2,11 +2,7 @@
 
 ## MCP disconnected or tools disappeared
 
-1. Run diagnostics:
-
-   ```bash
-   openchrome doctor --check duplicate-controllers
-   ```
+1. From an MCP client, call `oc_doctor_report` and `oc_connection_health` — these expose the duplicate-controller signal and broker lifecycle directly through the MCP contract.
 
 2. Check running OpenChrome processes:
 
@@ -29,10 +25,8 @@ Likely causes:
 
 Safe next steps:
 
-```bash
-openchrome doctor --json
-openchrome check --port 9222
-```
+- Call `oc_doctor_report` (MCP) for a structured diagnostic snapshot, or `oc_connection_health` for the live controller topology and broker lifecycle state.
+- Run `openchrome check --port 9222` to confirm Chrome is still reachable on that port (this is a bare Chrome ping, not a parallelism diagnostic).
 
 Then restart only the affected MCP client or switch it to `--connect-broker` / isolated profile mode.
 
@@ -51,9 +45,17 @@ Codex now uses `~/.codex/config.toml`. If `~/.codex/mcp.json` still contains Ope
 
 ## Broker health checks
 
-Use `oc_connection_health` and the optional `/health` endpoint to inspect:
+Use the `oc_connection_health` MCP tool, or the optional `/health` HTTP endpoint when `--http` is enabled, to inspect controller topology and broker lifecycle. Both surfaces include sibling fields shaped like:
 
-- `controllerTopology.role`
-- `brokerLifecycle.mode`
-- `brokerLifecycle.reconnectState`
-- `brokerLifecycle.activeLeases`
+```json
+{
+  "controllerTopology": { "role": "owner" },
+  "brokerLifecycle": {
+    "mode": "broker-owner",
+    "reconnectState": "idle",
+    "activeLeases": 0
+  }
+}
+```
+
+`mode` is one of `direct`, `broker-owner`, or `broker-client`; `reconnectState` is one of `idle`, `reconnecting`, or `failed`.

--- a/docs/mcp/troubleshooting-parallelism.md
+++ b/docs/mcp/troubleshooting-parallelism.md
@@ -1,0 +1,59 @@
+# Troubleshooting OpenChrome parallelism
+
+## MCP disconnected or tools disappeared
+
+1. Run diagnostics:
+
+   ```bash
+   openchrome doctor --check duplicate-controllers
+   ```
+
+2. Check running OpenChrome processes:
+
+   ```bash
+   ps aux | grep openchrome-mcp
+   ```
+
+3. If several processes target the same port/profile, either stop the extra client cleanly or move clients to explicit isolated ports/profiles.
+
+Avoid broad `pkill` commands unless you have confirmed the processes are disposable.
+
+## `Target closed` or `CDPSession closed`
+
+Likely causes:
+
+- another direct controller closed or detached the tab;
+- Chrome restarted while a client still held stale target IDs;
+- memory-pressure cleanup closed an unleased tab;
+- stale client config launched a second OpenChrome copy.
+
+Safe next steps:
+
+```bash
+openchrome doctor --json
+openchrome check --port 9222
+```
+
+Then restart only the affected MCP client or switch it to `--connect-broker` / isolated profile mode.
+
+## Multiple `openchrome-mcp` installs
+
+Mixed global and `npm exec openchrome-mcp@latest` registrations can launch different binaries against the same Chrome. Prefer generated configs from:
+
+```bash
+openchrome setup --client codex
+openchrome setup --client claude
+```
+
+## Stale Codex `mcp.json`
+
+Codex now uses `~/.codex/config.toml`. If `~/.codex/mcp.json` still contains OpenChrome, remove or archive that stale entry after confirming `config.toml` has the intended server.
+
+## Broker health checks
+
+Use `oc_connection_health` and the optional `/health` endpoint to inspect:
+
+- `controllerTopology.role`
+- `brokerLifecycle.mode`
+- `brokerLifecycle.reconnectState`
+- `brokerLifecycle.activeLeases`

--- a/docs/security/shared-profile-trust.md
+++ b/docs/security/shared-profile-trust.md
@@ -1,0 +1,52 @@
+# Shared-profile trust model
+
+Shared-profile broker mode is a **same-trust-zone** feature. It is intended for local workflows where the connected MCP clients are operated by the same user or team and are allowed to share the same Chrome cookies, authenticated sessions, storage, and visible page state.
+
+It is not a hosted browser-cloud isolation boundary.
+
+## Trust boundary
+
+Use shared-profile broker mode only when all connected clients are trusted to access the same browser profile.
+
+Use separate ports/profiles when clients are unrelated, untrusted, externally exposed, or belong to different tenants:
+
+```bash
+openchrome setup --client claude --port 9223 --user-data-dir ~/.openchrome/profiles/claude
+openchrome setup --client codex --port 9224 --user-data-dir ~/.openchrome/profiles/codex
+```
+
+## Identity model
+
+Policy decisions use host-neutral identifiers:
+
+- `clientId`: MCP/HTTP client identity when known.
+- `sessionId`: OpenChrome session identity.
+- `workerId` / `laneId`: task subdivision identity.
+- `targetId`: Chrome target/tab identity.
+- target leases: the broker-side ownership record tying targets to the identifiers above.
+
+No policy may privilege Claude, Codex, OpenCode, or an unknown MCP host. The same rules apply to every client.
+
+## Diagnostics and redaction
+
+Broker diagnostics should not expose sensitive cross-tenant details by default. Lease diagnostics may show ownership metadata, but URLs, titles, cookies, storage, screenshots, and page text must be omitted or redacted unless policy explicitly allows cross-tenant diagnostics.
+
+Environment flags:
+
+- `OPENCHROME_SHARED_PROFILE_UNTRUSTED=1`: declare that clients are not in one trust zone; shared-profile broker startup should be rejected and isolated profiles should be used.
+- `OPENCHROME_SHARED_PROFILE_CROSS_TENANT_DIAGNOSTICS=1`: allow cross-tenant lease diagnostics for trusted local debugging.
+
+## HTTP daemon default
+
+A shared-profile HTTP broker must bind to loopback by default and use existing HTTP auth controls before exposure beyond localhost. Do not expose a shared profile broker on a public network.
+
+## Required separate-profile cases
+
+Use separate profiles/ports for:
+
+- different users;
+- CI jobs from different trust domains;
+- untrusted agents;
+- public or remote HTTP clients;
+- workflows that must not share cookies/history/storage;
+- compliance or audit boundaries.

--- a/docs/security/shared-profile-trust.md
+++ b/docs/security/shared-profile-trust.md
@@ -33,7 +33,7 @@ Broker diagnostics should not expose sensitive cross-tenant details by default. 
 
 Environment flags:
 
-- `OPENCHROME_SHARED_PROFILE_UNTRUSTED=1`: declare that clients are not in one trust zone; shared-profile broker startup should be rejected and isolated profiles should be used.
+- `OPENCHROME_SHARED_PROFILE_UNTRUSTED=1`: declare that clients are not in one trust zone. Any shared-profile entry point — `openchrome serve --broker` and `openchrome serve --allow-unsafe-shared-attach` (or `OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH=1`) — is rejected; isolated profiles must be used instead.
 - `OPENCHROME_SHARED_PROFILE_CROSS_TENANT_DIAGNOSTICS=1`: allow cross-tenant lease diagnostics for trusted local debugging.
 
 ## HTTP daemon default

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ import {
 } from './utils/controller-lock';
 import { getCurrentControllerTopology } from './utils/duplicate-controller-diagnostics';
 import { setBrokerLifecycleMode, getBrokerLifecycleState } from './broker/lifecycle';
+import { assertSharedProfileAllowed } from './security/shared-profile-policy';
 import {
   DEFAULT_PROCESS_WATCHDOG_INTERVAL_MS,
   DEFAULT_TAB_HEALTH_PROBE_INTERVAL_MS,
@@ -283,6 +284,12 @@ program
       return;
     }
     if (options.broker) {
+      try {
+        assertSharedProfileAllowed();
+      } catch (err) {
+        console.error(`[openchrome] ${(err as Error).message}`);
+        process.exit(2);
+      }
       setBrokerLifecycleMode('broker-owner');
       process.env.OPENCHROME_BROKER_OWNER = '1';
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -298,6 +298,12 @@ program
     const unsafeSharedAttach = options.allowUnsafeSharedAttach || process.env.OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH === '1';
     if (autoLaunch) {
       if (unsafeSharedAttach) {
+        try {
+          assertSharedProfileAllowed();
+        } catch (err) {
+          console.error(`[openchrome] ${(err as Error).message}`);
+          process.exit(2);
+        }
         console.error(
           '[openchrome] Warning: unsafe shared attach guard bypassed. Multiple direct OpenChrome controllers for the same Chrome/profile can disconnect or close each other\'s targets.',
         );

--- a/src/security/shared-profile-policy.ts
+++ b/src/security/shared-profile-policy.ts
@@ -1,0 +1,73 @@
+import type { TargetLeaseRecord } from '../session/target-lease-registry';
+
+export type SharedProfileTrustMode = 'same-trust-zone' | 'isolated-required';
+
+export interface SharedProfilePolicy {
+  trustMode: SharedProfileTrustMode;
+  allowCrossTenantDiagnostics: boolean;
+  redactUrls: boolean;
+  redactTitles: boolean;
+}
+
+export interface RedactedLeaseDiagnostic {
+  targetId: string;
+  sessionId: string;
+  clientId?: string;
+  workerId?: string;
+  laneId?: string;
+  contextName?: string;
+  createdAt: number;
+  lastActivityAt: number;
+  leaseExpiresAt?: number;
+  cleanupPolicy: string;
+  redacted: boolean;
+}
+
+export function getSharedProfilePolicy(env: NodeJS.ProcessEnv = process.env): SharedProfilePolicy {
+  const allowCrossTenantDiagnostics = env.OPENCHROME_SHARED_PROFILE_CROSS_TENANT_DIAGNOSTICS === '1';
+  const trustMode: SharedProfileTrustMode = env.OPENCHROME_SHARED_PROFILE_UNTRUSTED === '1' ? 'isolated-required' : 'same-trust-zone';
+  return {
+    trustMode,
+    allowCrossTenantDiagnostics,
+    redactUrls: true,
+    redactTitles: true,
+  };
+}
+
+export function assertSharedProfileAllowed(policy = getSharedProfilePolicy()): void {
+  if (policy.trustMode === 'isolated-required') {
+    throw new Error('Shared-profile broker mode is same-trust-zone only. Use separate --port and --user-data-dir for untrusted or unrelated clients.');
+  }
+}
+
+export function canAccessLeaseDiagnostic(
+  lease: TargetLeaseRecord,
+  requester: { sessionId?: string; clientId?: string },
+  policy = getSharedProfilePolicy(),
+): boolean {
+  if (policy.allowCrossTenantDiagnostics) return true;
+  if (requester.sessionId && requester.sessionId === lease.sessionId) return true;
+  if (requester.clientId && lease.clientId && requester.clientId === lease.clientId) return true;
+  return false;
+}
+
+export function redactLeaseDiagnostic(
+  lease: TargetLeaseRecord,
+  requester: { sessionId?: string; clientId?: string },
+  policy = getSharedProfilePolicy(),
+): RedactedLeaseDiagnostic | null {
+  if (!canAccessLeaseDiagnostic(lease, requester, policy)) return null;
+  return {
+    targetId: lease.targetId,
+    sessionId: lease.sessionId,
+    ...(lease.clientId ? { clientId: lease.clientId } : {}),
+    ...(lease.workerId ? { workerId: lease.workerId } : {}),
+    ...(lease.laneId ? { laneId: lease.laneId } : {}),
+    ...(lease.contextName ? { contextName: lease.contextName } : {}),
+    createdAt: lease.createdAt,
+    lastActivityAt: lease.lastActivityAt,
+    ...(lease.leaseExpiresAt ? { leaseExpiresAt: lease.leaseExpiresAt } : {}),
+    cleanupPolicy: lease.cleanupPolicy,
+    redacted: policy.redactUrls || policy.redactTitles,
+  };
+}

--- a/tests/shared-profile-policy.test.ts
+++ b/tests/shared-profile-policy.test.ts
@@ -1,0 +1,46 @@
+import {
+  assertSharedProfileAllowed,
+  canAccessLeaseDiagnostic,
+  getSharedProfilePolicy,
+  redactLeaseDiagnostic,
+} from '../src/security/shared-profile-policy';
+import type { TargetLeaseRecord } from '../src/session/target-lease-registry';
+
+const lease: TargetLeaseRecord = {
+  targetId: 't1',
+  sessionId: 's1',
+  clientId: 'c1',
+  workerId: 'w1',
+  createdAt: 1,
+  lastActivityAt: 2,
+  cleanupPolicy: 'close-on-session-end',
+};
+
+describe('shared profile policy', () => {
+  test('defaults to same-trust-zone with redacted diagnostics', () => {
+    const policy = getSharedProfilePolicy({});
+    expect(policy).toMatchObject({ trustMode: 'same-trust-zone', redactUrls: true, redactTitles: true });
+    expect(() => assertSharedProfileAllowed(policy)).not.toThrow();
+  });
+
+  test('rejects shared profile when untrusted mode is declared', () => {
+    const policy = getSharedProfilePolicy({ OPENCHROME_SHARED_PROFILE_UNTRUSTED: '1' });
+    expect(policy.trustMode).toBe('isolated-required');
+    expect(() => assertSharedProfileAllowed(policy)).toThrow('same-trust-zone only');
+  });
+
+  test('limits lease diagnostics to same session/client unless explicitly allowed', () => {
+    expect(canAccessLeaseDiagnostic(lease, { sessionId: 's1' }, getSharedProfilePolicy({}))).toBe(true);
+    expect(canAccessLeaseDiagnostic(lease, { clientId: 'c1' }, getSharedProfilePolicy({}))).toBe(true);
+    expect(canAccessLeaseDiagnostic(lease, { sessionId: 'other' }, getSharedProfilePolicy({}))).toBe(false);
+    expect(canAccessLeaseDiagnostic(lease, { sessionId: 'other' }, getSharedProfilePolicy({ OPENCHROME_SHARED_PROFILE_CROSS_TENANT_DIAGNOSTICS: '1' }))).toBe(true);
+  });
+
+  test('redacted lease diagnostics omit URL/title-shaped sensitive fields', () => {
+    const diagnostic = redactLeaseDiagnostic(lease, { sessionId: 's1' }, getSharedProfilePolicy({}));
+    expect(diagnostic).toEqual(expect.objectContaining({ targetId: 't1', sessionId: 's1', redacted: true }));
+    expect(diagnostic).not.toHaveProperty('url');
+    expect(diagnostic).not.toHaveProperty('title');
+    expect(redactLeaseDiagnostic(lease, { sessionId: 'other' }, getSharedProfilePolicy({}))).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add safe parallelism topology guidance for broker, isolated direct, and unsafe shared-direct setups
- add Claude/Codex/OpenCode/OMX/CI recipes
- add troubleshooting for MCP disconnects, missing tools, target/session closed errors, multiple processes, and stale Codex `mcp.json`
- link the guidance from getting started and the topology page

## Stack
- Stacked on #1382 as the documentation layer for the #1359 architecture.

## Tests
- `git diff --check`

Closes #1374
