### PR TITLE
Define shared-profile trust policy

### DIFF
--- a/docs/security/shared-profile-trust.md
+++ b/docs/security/shared-profile-trust.md
@@ -1,0 +1,52 @@
+# Shared-profile trust model
+
+Shared-profile broker mode is a **same-trust-zone** feature. It is intended for local workflows where the connected MCP clients are operated by the same user or team and are allowed to share the same Chrome cookies, authenticated sessions, storage, and visible page state.
+
+It is not a hosted browser-cloud isolation boundary.
+
+## Trust boundary
+
+Use shared-profile broker mode only when all connected clients are trusted to access the same browser profile.
+
+Use separate ports/profiles when clients are unrelated, untrusted, externally exposed, or belong to different tenants:
+
+```bash
+openchrome setup --client claude --port 9223 --user-data-dir ~/.openchrome/profiles/claude
+openchrome setup --client codex --port 9224 --user-data-dir ~/.openchrome/profiles/codex
+```
+
+## Identity model
+
+Policy decisions use host-neutral identifiers:
+
+- `clientId`: MCP/HTTP client identity when known.
+- `sessionId`: OpenChrome session identity.
+- `workerId` / `laneId`: task subdivision identity.
+- `targetId`: Chrome target/tab identity.
+- target leases: the broker-side ownership record tying targets to the identifiers above.
+
+No policy may privilege Claude, Codex, OpenCode, or an unknown MCP host. The same rules apply to every client.
+
+## Diagnostics and redaction
+
+Broker diagnostics should not expose sensitive cross-tenant details by default. Lease diagnostics may show ownership metadata, but URLs, titles, cookies, storage, screenshots, and page text must be omitted or redacted unless policy explicitly allows cross-tenant diagnostics.
+
+Environment flags:
+
+- `OPENCHROME_SHARED_PROFILE_UNTRUSTED=1`: declare that clients are not in one trust zone; shared-profile broker startup should be rejected and isolated profiles should be used.
+- `OPENCHROME_SHARED_PROFILE_CROSS_TENANT_DIAGNOSTICS=1`: allow cross-tenant lease diagnostics for trusted local debugging.
+
+## HTTP daemon default
+
+A shared-profile HTTP broker must bind to loopback by default and use existing HTTP auth controls before exposure beyond localhost. Do not expose a shared profile broker on a public network.
+
+## Required separate-profile cases
+
+Use separate profiles/ports for:
+
+- different users;
+- CI jobs from different trust domains;
+- untrusted agents;
+- public or remote HTTP clients;
+- workflows that must not share cookies/history/storage;
+- compliance or audit boundaries.

--- a/docs/security/shared-profile-trust.md
+++ b/docs/security/shared-profile-trust.md
@@ -33,7 +33,7 @@ Broker diagnostics should not expose sensitive cross-tenant details by default. 
 
 Environment flags:
 
-- `OPENCHROME_SHARED_PROFILE_UNTRUSTED=1`: declare that clients are not in one trust zone; shared-profile broker startup should be rejected and isolated profiles should be used.
+- `OPENCHROME_SHARED_PROFILE_UNTRUSTED=1`: declare that clients are not in one trust zone. Any shared-profile entry point — `openchrome serve --broker` and `openchrome serve --allow-unsafe-shared-attach` (or `OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH=1`) — is rejected; isolated profiles must be used instead.
 - `OPENCHROME_SHARED_PROFILE_CROSS_TENANT_DIAGNOSTICS=1`: allow cross-tenant lease diagnostics for trusted local debugging.
 
 ## HTTP daemon default

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ import {
 } from './utils/controller-lock';
 import { getCurrentControllerTopology } from './utils/duplicate-controller-diagnostics';
 import { setBrokerLifecycleMode, getBrokerLifecycleState } from './broker/lifecycle';
+import { assertSharedProfileAllowed } from './security/shared-profile-policy';
 import {
   DEFAULT_PROCESS_WATCHDOG_INTERVAL_MS,
   DEFAULT_TAB_HEALTH_PROBE_INTERVAL_MS,
@@ -283,6 +284,12 @@ program
       return;
     }
     if (options.broker) {
+      try {
+        assertSharedProfileAllowed();
+      } catch (err) {
+        console.error(`[openchrome] ${(err as Error).message}`);
+        process.exit(2);
+      }
       setBrokerLifecycleMode('broker-owner');
       process.env.OPENCHROME_BROKER_OWNER = '1';
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -298,6 +298,12 @@ program
     const unsafeSharedAttach = options.allowUnsafeSharedAttach || process.env.OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH === '1';
     if (autoLaunch) {
       if (unsafeSharedAttach) {
+        try {
+          assertSharedProfileAllowed();
+        } catch (err) {
+          console.error(`[openchrome] ${(err as Error).message}`);
+          process.exit(2);
+        }
         console.error(
           '[openchrome] Warning: unsafe shared attach guard bypassed. Multiple direct OpenChrome controllers for the same Chrome/profile can disconnect or close each other\'s targets.',
         );

--- a/src/security/shared-profile-policy.ts
+++ b/src/security/shared-profile-policy.ts
@@ -1,0 +1,73 @@
+import type { TargetLeaseRecord } from '../session/target-lease-registry';
+
+export type SharedProfileTrustMode = 'same-trust-zone' | 'isolated-required';
+
+export interface SharedProfilePolicy {
+  trustMode: SharedProfileTrustMode;
+  allowCrossTenantDiagnostics: boolean;
+  redactUrls: boolean;
+  redactTitles: boolean;
+}
+
+export interface RedactedLeaseDiagnostic {
+  targetId: string;
+  sessionId: string;
+  clientId?: string;
+  workerId?: string;
+  laneId?: string;
+  contextName?: string;
+  createdAt: number;
+  lastActivityAt: number;
+  leaseExpiresAt?: number;
+  cleanupPolicy: string;
+  redacted: boolean;
+}
+
+export function getSharedProfilePolicy(env: NodeJS.ProcessEnv = process.env): SharedProfilePolicy {
+  const allowCrossTenantDiagnostics = env.OPENCHROME_SHARED_PROFILE_CROSS_TENANT_DIAGNOSTICS === '1';
+  const trustMode: SharedProfileTrustMode = env.OPENCHROME_SHARED_PROFILE_UNTRUSTED === '1' ? 'isolated-required' : 'same-trust-zone';
+  return {
+    trustMode,
+    allowCrossTenantDiagnostics,
+    redactUrls: true,
+    redactTitles: true,
+  };
+}
+
+export function assertSharedProfileAllowed(policy = getSharedProfilePolicy()): void {
+  if (policy.trustMode === 'isolated-required') {
+    throw new Error('Shared-profile broker mode is same-trust-zone only. Use separate --port and --user-data-dir for untrusted or unrelated clients.');
+  }
+}
+
+export function canAccessLeaseDiagnostic(
+  lease: TargetLeaseRecord,
+  requester: { sessionId?: string; clientId?: string },
+  policy = getSharedProfilePolicy(),
+): boolean {
+  if (policy.allowCrossTenantDiagnostics) return true;
+  if (requester.sessionId && requester.sessionId === lease.sessionId) return true;
+  if (requester.clientId && lease.clientId && requester.clientId === lease.clientId) return true;
+  return false;
+}
+
+export function redactLeaseDiagnostic(
+  lease: TargetLeaseRecord,
+  requester: { sessionId?: string; clientId?: string },
+  policy = getSharedProfilePolicy(),
+): RedactedLeaseDiagnostic | null {
+  if (!canAccessLeaseDiagnostic(lease, requester, policy)) return null;
+  return {
+    targetId: lease.targetId,
+    sessionId: lease.sessionId,
+    ...(lease.clientId ? { clientId: lease.clientId } : {}),
+    ...(lease.workerId ? { workerId: lease.workerId } : {}),
+    ...(lease.laneId ? { laneId: lease.laneId } : {}),
+    ...(lease.contextName ? { contextName: lease.contextName } : {}),
+    createdAt: lease.createdAt,
+    lastActivityAt: lease.lastActivityAt,
+    ...(lease.leaseExpiresAt ? { leaseExpiresAt: lease.leaseExpiresAt } : {}),
+    cleanupPolicy: lease.cleanupPolicy,
+    redacted: policy.redactUrls || policy.redactTitles,
+  };
+}

--- a/tests/shared-profile-policy.test.ts
+++ b/tests/shared-profile-policy.test.ts
@@ -1,0 +1,46 @@
+import {
+  assertSharedProfileAllowed,
+  canAccessLeaseDiagnostic,
+  getSharedProfilePolicy,
+  redactLeaseDiagnostic,
+} from '../src/security/shared-profile-policy';
+import type { TargetLeaseRecord } from '../src/session/target-lease-registry';
+
+const lease: TargetLeaseRecord = {
+  targetId: 't1',
+  sessionId: 's1',
+  clientId: 'c1',
+  workerId: 'w1',
+  createdAt: 1,
+  lastActivityAt: 2,
+  cleanupPolicy: 'close-on-session-end',
+};
+
+describe('shared profile policy', () => {
+  test('defaults to same-trust-zone with redacted diagnostics', () => {
+    const policy = getSharedProfilePolicy({});
+    expect(policy).toMatchObject({ trustMode: 'same-trust-zone', redactUrls: true, redactTitles: true });
+    expect(() => assertSharedProfileAllowed(policy)).not.toThrow();
+  });
+
+  test('rejects shared profile when untrusted mode is declared', () => {
+    const policy = getSharedProfilePolicy({ OPENCHROME_SHARED_PROFILE_UNTRUSTED: '1' });
+    expect(policy.trustMode).toBe('isolated-required');
+    expect(() => assertSharedProfileAllowed(policy)).toThrow('same-trust-zone only');
+  });
+
+  test('limits lease diagnostics to same session/client unless explicitly allowed', () => {
+    expect(canAccessLeaseDiagnostic(lease, { sessionId: 's1' }, getSharedProfilePolicy({}))).toBe(true);
+    expect(canAccessLeaseDiagnostic(lease, { clientId: 'c1' }, getSharedProfilePolicy({}))).toBe(true);
+    expect(canAccessLeaseDiagnostic(lease, { sessionId: 'other' }, getSharedProfilePolicy({}))).toBe(false);
+    expect(canAccessLeaseDiagnostic(lease, { sessionId: 'other' }, getSharedProfilePolicy({ OPENCHROME_SHARED_PROFILE_CROSS_TENANT_DIAGNOSTICS: '1' }))).toBe(true);
+  });
+
+  test('redacted lease diagnostics omit URL/title-shaped sensitive fields', () => {
+    const diagnostic = redactLeaseDiagnostic(lease, { sessionId: 's1' }, getSharedProfilePolicy({}));
+    expect(diagnostic).toEqual(expect.objectContaining({ targetId: 't1', sessionId: 's1', redacted: true }));
+    expect(diagnostic).not.toHaveProperty('url');
+    expect(diagnostic).not.toHaveProperty('title');
+    expect(redactLeaseDiagnostic(lease, { sessionId: 'other' }, getSharedProfilePolicy({}))).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- define shared-profile broker mode as same-trust-zone only
- reject every shared-profile entry point (`--broker` and `--allow-unsafe-shared-attach`) when `OPENCHROME_SHARED_PROFILE_UNTRUSTED=1` declares unrelated/untrusted clients
- add redacted lease diagnostic policy helpers (foundation only — wiring these helpers into `oc_connection_health`, the `/health` endpoint, and other diagnostic surfaces is deferred to a follow-on PR)
- document host-neutral trust boundaries and when isolated profiles/ports are required

## Stack
- Stacked on #1383 as the trust-policy layer for shared-profile broker work.

## Tests
- `npm test -- tests/shared-profile-policy.test.ts --runInBand`
- `npm run build`

Closes #1375