### PR TITLE
feat(storage-state): deterministic, secret-free profile fingerprint (B3-PR1)

### DIFF
--- a/docs/storage-state/fingerprint-spec.md
+++ b/docs/storage-state/fingerprint-spec.md
@@ -1,0 +1,152 @@
+# Profile Fingerprint Spec — v1
+
+A *profile fingerprint* is a deterministic, secret-free hash over a captured
+storage-state envelope. It lets two parties verify *"is this the same
+authenticated session?"* without either party seeing the cookie or storage
+values.
+
+This document freezes the canonical form for **v1**. Any change to the
+canonical form requires bumping `version` to a new integer. v1 fingerprints
+remain recognizable forever.
+
+## Inputs
+
+The fingerprint is computed from an `EnvelopeCapture`
+(`src/storage-state/storage-state-manager.ts`):
+
+```ts
+interface EnvelopeCapture {
+  origin: string;
+  cookies: Cookie[];
+  localStorage: Record<string, string>;
+  sessionStorage: Record<string, string>;
+  // userAgent and viewport are not part of v1's hash domain
+}
+```
+
+`userAgent` and `viewport` are **excluded** from v1: they describe the *probe*,
+not the session. If a future version needs them, it must be v2.
+
+## Hash domain — what enters the hash
+
+Only **shape**, never **contents**:
+
+### Cookies
+
+For each cookie, the hash sees:
+
+| Field         | Source                                     |
+| ------------- | ------------------------------------------ |
+| `name`        | as-is                                      |
+| `domain`      | as-is                                      |
+| `path`        | as-is                                      |
+| `httpOnly`    | coerced to boolean                         |
+| `secure`      | coerced to boolean                         |
+| `sameSite`    | as-is string, or `""` when missing         |
+| `valueLength` | `cookie.value.length` (the value itself is never used) |
+| `expiryBucket`| `Math.floor(expires / 3600) * 3600` in seconds; `-1` for session cookies and any non-finite or non-positive expiry |
+
+Cookies are **sorted** by `(domain, name, path)` before serialization.
+
+### Local / session storage
+
+For each entry, the hash sees:
+
+| Field         | Source                          |
+| ------------- | ------------------------------- |
+| `key`         | as-is                           |
+| `valueLength` | `value.length` (value excluded) |
+
+Entries are sorted by `key`. `localStorage` and `sessionStorage` are hashed in
+separate, named sections — moving a key between them changes the fingerprint.
+
+### Origin
+
+`capture.origin` enters the hash directly. Origins are not secrets.
+Non-string origins are normalized to `""`.
+
+## Canonical JSON
+
+The canonical representation is a `JSON.stringify` call **with no whitespace
+argument** on a fixed-key-order object:
+
+```json
+{
+  "version": 1,
+  "origin": "<origin>",
+  "cookies":         [ { "name", "domain", "path", "httpOnly", "secure", "sameSite", "valueLength", "expiryBucket" }, ... ],
+  "localStorage":    [ { "key", "valueLength" }, ... ],
+  "sessionStorage":  [ { "key", "valueLength" }, ... ]
+}
+```
+
+Every nested object has a fixed key order. Every array is pre-sorted as
+described above. The result is byte-identical across V8 versions and operating
+systems.
+
+## Hash function
+
+```text
+hash = lowercase-hex( SHA-256( canonical-json-utf8-bytes ) )
+```
+
+## Output shape
+
+```ts
+interface ProfileFingerprint {
+  version: 1;
+  algorithm: 'sha256';
+  hash: string;          // 64-char lowercase hex
+  breakdown: {
+    cookies: number;
+    localStorageKeys: number;
+    sessionStorageKeys: number;
+    origin: string;
+  };
+}
+```
+
+`breakdown` is a non-secret diagnostic aid. It is *not* signed and *not* the
+authoritative identity — `hash` is.
+
+## Invariants (codified by `tests/storage-state/fingerprint.test.ts`)
+
+1. **Determinism** — repeated calls on the same capture produce the same hash.
+2. **Value secrecy** — changing only a cookie or storage *value* (with the
+   same length) never changes the hash.
+3. **Length sensitivity** — changing a cookie or storage value's *length* does
+   change the hash. (Length leaks roughly the same information that a
+   `Content-Length` header would; this is acceptable for a session-identity
+   check and required to detect substantively different sessions.)
+4. **Order independence** — declaring cookies or storage keys in a different
+   order yields the same hash.
+5. **Bucket stability** — cookies whose `expires` falls in the same hour
+   bucket fingerprint identically. Crossing a bucket boundary changes the
+   hash. Session cookies (`expires <= 0` or non-finite) collapse to a single
+   stable bucket.
+6. **Separation** — `localStorage` and `sessionStorage` are distinct sections.
+7. **Forward compatibility** — `version: 1` is the spec frozen in this file.
+   Any change requires bumping the version.
+
+## Threat model & non-goals
+
+This fingerprint is **not** a cryptographic identifier of the session. It is a
+fast, deterministic shape hash. It is acceptable for:
+
+- comparing two captures to ask "is this the same logged-in session?"
+- recording a non-secret identifier of a profile snapshot in a trace
+- gating which snapshot to restore for a given lane
+
+It is **not** acceptable for:
+
+- authentication
+- tamper detection (use a signed envelope for that — covered in B3-PR3)
+- replacing the storage values themselves (the hash is not invertible, but
+  short fields with low-entropy lengths can still be guessed under enough
+  brute force)
+
+## See also
+
+- `src/storage-state/fingerprint.ts` — implementation
+- `tests/storage-state/fingerprint.test.ts` — invariant tests
+- #1359 §Pillar B (profile/auth reuse), §Pillar D (portable memory)

--- a/src/storage-state/fingerprint.ts
+++ b/src/storage-state/fingerprint.ts
@@ -1,0 +1,207 @@
+/**
+ * Profile fingerprint — deterministic, secret-free hash of a captured
+ * storage-state envelope (issue: B3-PR1 of #1359 host-neutral harness).
+ *
+ * A fingerprint lets two parties verify "is this the same logged-in session?"
+ * *without* either side seeing the cookie or storage values. Inputs that
+ * enter the hash are limited to **shape, not contents**:
+ *
+ *   - For each cookie: `name`, `domain`, `path`, `httpOnly`, `secure`,
+ *     `sameSite`, the **length** of the value (never the value), and a
+ *     **bucketed** expiry (rounded down to the hour, in seconds).
+ *   - For each storage entry: `key` and the **length** of the value.
+ *   - `origin` (origins are not secrets).
+ *
+ * The cookie/storage values themselves are *never* fed into the hash. A
+ * negative test in `fingerprint.test.ts` codifies this property: changing
+ * only the values must not change the fingerprint.
+ *
+ * Canonical JSON serialization is used so the same inputs produce the same
+ * hash across machines:
+ *
+ *   - Object keys are sorted (the JSON object spec is unordered; we pick a
+ *     stable order).
+ *   - Cookie / storage entries are pre-sorted before serialization.
+ *   - `JSON.stringify` is called with no whitespace argument.
+ *
+ * The output is wrapped in a versioned envelope so that any future change
+ * to the canonical form gets a new `version` and old fingerprints remain
+ * recognizable.
+ *
+ * Pure function. Zero I/O. Zero Chrome dependency.
+ *
+ * @see docs/storage-state/fingerprint-spec.md
+ * @see #1359 Pillar B (profile/auth reuse), Pillar D (portable memory)
+ */
+
+import { createHash } from 'node:crypto';
+import type { EnvelopeCapture } from './storage-state-manager';
+
+/** Bucket size (seconds) for the cookie expiry input. */
+const EXPIRY_BUCKET_SECONDS = 3600;
+
+/** Format version of the canonical fingerprint. */
+export const FINGERPRINT_VERSION = 1 as const;
+
+/** Hash algorithm name. */
+export const FINGERPRINT_ALGORITHM = 'sha256' as const;
+
+export interface FingerprintBreakdown {
+  /** Number of cookies summarized. */
+  cookies: number;
+  /** Number of localStorage keys summarized. */
+  localStorageKeys: number;
+  /** Number of sessionStorage keys summarized. */
+  sessionStorageKeys: number;
+  /** The origin string used in the hash. */
+  origin: string;
+}
+
+export interface ProfileFingerprint {
+  version: typeof FINGERPRINT_VERSION;
+  algorithm: typeof FINGERPRINT_ALGORITHM;
+  /** Lowercase hex digest of the canonical-JSON summary. */
+  hash: string;
+  /** Non-secret summary counts. Useful for diagnostics and trace bundles. */
+  breakdown: FingerprintBreakdown;
+}
+
+interface CookieSummary {
+  readonly name: string;
+  readonly domain: string;
+  readonly path: string;
+  readonly httpOnly: boolean;
+  readonly secure: boolean;
+  readonly sameSite: string;
+  readonly valueLength: number;
+  /**
+   * Cookie expiry, bucketed to the hour. `-1` is used for session cookies
+   * (no expiry). Bucketing keeps the fingerprint stable across small
+   * timing differences in capture.
+   */
+  readonly expiryBucket: number;
+}
+
+interface StorageSummary {
+  readonly key: string;
+  readonly valueLength: number;
+}
+
+interface CanonicalSummary {
+  readonly version: typeof FINGERPRINT_VERSION;
+  readonly origin: string;
+  readonly cookies: readonly CookieSummary[];
+  readonly localStorage: readonly StorageSummary[];
+  readonly sessionStorage: readonly StorageSummary[];
+}
+
+function bucketExpiry(expires: number | undefined): number {
+  if (expires === undefined || expires === null) return -1;
+  // Cookies' `expires` is a Unix epoch in seconds. Treat <= 0 as session.
+  if (!Number.isFinite(expires) || expires <= 0) return -1;
+  return Math.floor(expires / EXPIRY_BUCKET_SECONDS) * EXPIRY_BUCKET_SECONDS;
+}
+
+function summarizeCookies(
+  cookies: EnvelopeCapture['cookies'] | undefined,
+): CookieSummary[] {
+  if (!cookies) return [];
+  const out: CookieSummary[] = [];
+  for (const c of cookies) {
+    const value = typeof c.value === 'string' ? c.value : '';
+    out.push({
+      name: c.name,
+      domain: c.domain,
+      path: c.path,
+      httpOnly: Boolean(c.httpOnly),
+      secure: Boolean(c.secure),
+      sameSite: typeof c.sameSite === 'string' ? c.sameSite : '',
+      valueLength: value.length,
+      expiryBucket: bucketExpiry(c.expires),
+    });
+  }
+  // Sort lexicographically by (domain, name, path) for determinism.
+  out.sort((a, b) => {
+    if (a.domain !== b.domain) return a.domain < b.domain ? -1 : 1;
+    if (a.name !== b.name) return a.name < b.name ? -1 : 1;
+    if (a.path !== b.path) return a.path < b.path ? -1 : 1;
+    return 0;
+  });
+  return out;
+}
+
+function summarizeStorage(
+  store: Record<string, string> | undefined,
+): StorageSummary[] {
+  if (!store) return [];
+  const keys = Object.keys(store).sort();
+  return keys.map(k => ({ key: k, valueLength: (store[k] ?? '').length }));
+}
+
+/**
+ * Canonical JSON encoder for the summary. We do NOT use a generic
+ * canonicalizer because our shape is closed; emitting keys in a fixed
+ * order is sufficient and avoids a dependency.
+ */
+function encodeCanonical(summary: CanonicalSummary): string {
+  // Build the object with a fixed key order, then JSON.stringify. Because
+  // the summary type is closed and every nested array element has a fixed
+  // key order too, this produces a byte-identical string for identical
+  // inputs across V8 versions.
+  const cookieObjects = summary.cookies.map(c => ({
+    name: c.name,
+    domain: c.domain,
+    path: c.path,
+    httpOnly: c.httpOnly,
+    secure: c.secure,
+    sameSite: c.sameSite,
+    valueLength: c.valueLength,
+    expiryBucket: c.expiryBucket,
+  }));
+  const localObjects = summary.localStorage.map(s => ({ key: s.key, valueLength: s.valueLength }));
+  const sessionObjects = summary.sessionStorage.map(s => ({ key: s.key, valueLength: s.valueLength }));
+
+  return JSON.stringify({
+    version: summary.version,
+    origin: summary.origin,
+    cookies: cookieObjects,
+    localStorage: localObjects,
+    sessionStorage: sessionObjects,
+  });
+}
+
+/**
+ * Compute the fingerprint of a storage-state envelope.
+ *
+ * Idempotent and side-effect-free. Returns the structured fingerprint —
+ * the hex `hash` field is what callers compare; the `breakdown` is a
+ * non-secret diagnostic aid (e.g. "we hashed 12 cookies and 3 localStorage
+ * keys for `https://example.com`").
+ */
+export function fingerprintEnvelope(capture: EnvelopeCapture): ProfileFingerprint {
+  const cookies = summarizeCookies(capture.cookies);
+  const localStorageEntries = summarizeStorage(capture.localStorage);
+  const sessionStorageEntries = summarizeStorage(capture.sessionStorage);
+  const summary: CanonicalSummary = {
+    version: FINGERPRINT_VERSION,
+    origin: typeof capture.origin === 'string' ? capture.origin : '',
+    cookies,
+    localStorage: localStorageEntries,
+    sessionStorage: sessionStorageEntries,
+  };
+
+  const canonical = encodeCanonical(summary);
+  const hash = createHash(FINGERPRINT_ALGORITHM).update(canonical, 'utf8').digest('hex');
+
+  return {
+    version: FINGERPRINT_VERSION,
+    algorithm: FINGERPRINT_ALGORITHM,
+    hash,
+    breakdown: {
+      cookies: cookies.length,
+      localStorageKeys: localStorageEntries.length,
+      sessionStorageKeys: sessionStorageEntries.length,
+      origin: summary.origin,
+    },
+  };
+}

--- a/tests/storage-state/fingerprint.test.ts
+++ b/tests/storage-state/fingerprint.test.ts
@@ -1,0 +1,236 @@
+/// <reference types="jest" />
+
+import {
+  fingerprintEnvelope,
+  FINGERPRINT_ALGORITHM,
+  FINGERPRINT_VERSION,
+} from '../../src/storage-state/fingerprint';
+import type { EnvelopeCapture } from '../../src/storage-state/storage-state-manager';
+
+const emptyCapture: EnvelopeCapture = {
+  origin: 'https://example.com',
+  cookies: [],
+  localStorage: {},
+  sessionStorage: {},
+};
+
+function makeCookie(overrides: Partial<EnvelopeCapture['cookies'][number]> = {}) {
+  return {
+    name: 'sid',
+    value: 'secret-value',
+    domain: '.example.com',
+    path: '/',
+    expires: 1_900_000_000,
+    size: 4,
+    httpOnly: true,
+    secure: true,
+    session: false,
+    sameSite: 'Lax',
+    ...overrides,
+  };
+}
+
+describe('fingerprintEnvelope', () => {
+  test('envelope structure carries version, algorithm, hash and breakdown', () => {
+    const fp = fingerprintEnvelope(emptyCapture);
+    expect(fp.version).toBe(FINGERPRINT_VERSION);
+    expect(fp.algorithm).toBe(FINGERPRINT_ALGORITHM);
+    expect(typeof fp.hash).toBe('string');
+    expect(fp.hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(fp.breakdown).toEqual({
+      cookies: 0,
+      localStorageKeys: 0,
+      sessionStorageKeys: 0,
+      origin: 'https://example.com',
+    });
+  });
+
+  test('determinism: repeated calls on the same capture produce the same hash', () => {
+    const cap: EnvelopeCapture = {
+      origin: 'https://example.com',
+      cookies: [makeCookie()],
+      localStorage: { a: '1', b: 'long-value' },
+      sessionStorage: { z: 'zz' },
+    };
+    const a = fingerprintEnvelope(cap);
+    const b = fingerprintEnvelope(cap);
+    expect(a.hash).toBe(b.hash);
+  });
+
+  test('cookie VALUE never enters the hash (secret-free invariant)', () => {
+    const base: EnvelopeCapture = {
+      origin: 'https://example.com',
+      cookies: [makeCookie({ value: 'A' })],
+      localStorage: {},
+      sessionStorage: {},
+    };
+    const alt: EnvelopeCapture = {
+      origin: 'https://example.com',
+      // Same length, different value
+      cookies: [makeCookie({ value: 'B' })],
+      localStorage: {},
+      sessionStorage: {},
+    };
+    expect(fingerprintEnvelope(base).hash).toBe(fingerprintEnvelope(alt).hash);
+  });
+
+  test('changing cookie VALUE LENGTH changes the hash', () => {
+    const base: EnvelopeCapture = {
+      origin: 'https://example.com',
+      cookies: [makeCookie({ value: 'short' })],
+      localStorage: {},
+      sessionStorage: {},
+    };
+    const longer: EnvelopeCapture = {
+      origin: 'https://example.com',
+      cookies: [makeCookie({ value: 'much-much-longer' })],
+      localStorage: {},
+      sessionStorage: {},
+    };
+    expect(fingerprintEnvelope(base).hash).not.toBe(fingerprintEnvelope(longer).hash);
+  });
+
+  test('changing cookie name or domain changes the hash', () => {
+    const a: EnvelopeCapture = {
+      ...emptyCapture,
+      cookies: [makeCookie({ name: 'sid' })],
+    };
+    const renamed: EnvelopeCapture = {
+      ...emptyCapture,
+      cookies: [makeCookie({ name: 'sid2' })],
+    };
+    const cross: EnvelopeCapture = {
+      ...emptyCapture,
+      cookies: [makeCookie({ domain: '.other.com' })],
+    };
+    const hashA = fingerprintEnvelope(a).hash;
+    expect(hashA).not.toBe(fingerprintEnvelope(renamed).hash);
+    expect(hashA).not.toBe(fingerprintEnvelope(cross).hash);
+  });
+
+  test('cookie order independence: same set in different declaration order yields same hash', () => {
+    const a: EnvelopeCapture = {
+      ...emptyCapture,
+      cookies: [
+        makeCookie({ name: 'a' }),
+        makeCookie({ name: 'b' }),
+      ],
+    };
+    const b: EnvelopeCapture = {
+      ...emptyCapture,
+      cookies: [
+        makeCookie({ name: 'b' }),
+        makeCookie({ name: 'a' }),
+      ],
+    };
+    expect(fingerprintEnvelope(a).hash).toBe(fingerprintEnvelope(b).hash);
+  });
+
+  test('storage VALUE never enters the hash, but KEY and LENGTH do', () => {
+    const v1: EnvelopeCapture = {
+      ...emptyCapture,
+      localStorage: { token: 'AAAA' },
+    };
+    const v2_sameLen: EnvelopeCapture = {
+      ...emptyCapture,
+      localStorage: { token: 'BBBB' },
+    };
+    const v3_diffLen: EnvelopeCapture = {
+      ...emptyCapture,
+      localStorage: { token: 'BBBBB' },
+    };
+    const v4_diffKey: EnvelopeCapture = {
+      ...emptyCapture,
+      localStorage: { other: 'AAAA' },
+    };
+    expect(fingerprintEnvelope(v1).hash).toBe(fingerprintEnvelope(v2_sameLen).hash);
+    expect(fingerprintEnvelope(v1).hash).not.toBe(fingerprintEnvelope(v3_diffLen).hash);
+    expect(fingerprintEnvelope(v1).hash).not.toBe(fingerprintEnvelope(v4_diffKey).hash);
+  });
+
+  test('sessionStorage is hashed separately from localStorage', () => {
+    const local: EnvelopeCapture = {
+      ...emptyCapture,
+      localStorage: { k: 'v' },
+    };
+    const session: EnvelopeCapture = {
+      ...emptyCapture,
+      sessionStorage: { k: 'v' },
+    };
+    expect(fingerprintEnvelope(local).hash).not.toBe(fingerprintEnvelope(session).hash);
+  });
+
+  test('changing origin changes the hash', () => {
+    const a = fingerprintEnvelope({ ...emptyCapture, origin: 'https://example.com' });
+    const b = fingerprintEnvelope({ ...emptyCapture, origin: 'https://other.com' });
+    expect(a.hash).not.toBe(b.hash);
+  });
+
+  test('cookie expiry within the same hour bucket does NOT change the hash', () => {
+    const baseExpiry = 1_900_000_000; // a known Unix second
+    const sameBucket = baseExpiry + 60; // 60s later, still same hour
+    const a: EnvelopeCapture = {
+      ...emptyCapture,
+      cookies: [makeCookie({ expires: baseExpiry })],
+    };
+    const b: EnvelopeCapture = {
+      ...emptyCapture,
+      cookies: [makeCookie({ expires: sameBucket })],
+    };
+    expect(fingerprintEnvelope(a).hash).toBe(fingerprintEnvelope(b).hash);
+  });
+
+  test('cookie expiry across a different hour bucket DOES change the hash', () => {
+    const baseExpiry = 1_900_000_000;
+    const differentBucket = baseExpiry + 3700; // > 1h later
+    const a: EnvelopeCapture = {
+      ...emptyCapture,
+      cookies: [makeCookie({ expires: baseExpiry })],
+    };
+    const b: EnvelopeCapture = {
+      ...emptyCapture,
+      cookies: [makeCookie({ expires: differentBucket })],
+    };
+    expect(fingerprintEnvelope(a).hash).not.toBe(fingerprintEnvelope(b).hash);
+  });
+
+  test('session cookies (no expiry) collapse to the same bucket regardless of value', () => {
+    const a: EnvelopeCapture = {
+      ...emptyCapture,
+      cookies: [makeCookie({ expires: -1, session: true })],
+    };
+    const b: EnvelopeCapture = {
+      ...emptyCapture,
+      cookies: [makeCookie({ expires: 0, session: true })],
+    };
+    expect(fingerprintEnvelope(a).hash).toBe(fingerprintEnvelope(b).hash);
+  });
+
+  test('breakdown counts match the input sizes', () => {
+    const cap: EnvelopeCapture = {
+      origin: 'https://example.com',
+      cookies: [makeCookie({ name: 'a' }), makeCookie({ name: 'b' })],
+      localStorage: { x: '1', y: '2', z: '3' },
+      sessionStorage: { s: 'v' },
+    };
+    const fp = fingerprintEnvelope(cap);
+    expect(fp.breakdown).toEqual({
+      cookies: 2,
+      localStorageKeys: 3,
+      sessionStorageKeys: 1,
+      origin: 'https://example.com',
+    });
+  });
+
+  test('non-string origin is normalized to empty string in breakdown', () => {
+    // Type-check escape hatch: callers may hand us a malformed capture.
+    const fp = fingerprintEnvelope({
+      origin: undefined as unknown as string,
+      cookies: [],
+      localStorage: {},
+      sessionStorage: {},
+    });
+    expect(fp.breakdown.origin).toBe('');
+    expect(fp.hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});


### PR DESCRIPTION
## Summary

Introduce `src/storage-state/fingerprint.ts` — a pure function that maps an `EnvelopeCapture` (cookies + localStorage + sessionStorage + origin) to a stable hex digest plus a non-secret breakdown.

The hash domain is **shape, not contents**: cookie / storage *values* never enter the hash. Only key names, domains, paths, value *lengths*, flag booleans, and hour-bucketed expiry. This lets two parties verify *"is this the same logged-in session?"* without either party seeing the secrets.

Foundation for the broader **B3** thread of #1359 (profile snapshot export/import/fingerprint surfaces). No MCP tool wiring in this PR — downstream PRs consume the fingerprint.

## Spec — frozen as v1

Full canonical form in `docs/storage-state/fingerprint-spec.md`. Key choices:

- Canonical JSON with fixed key order; cookies sorted by `(domain, name, path)`; storage entries sorted by `key`.
- `localStorage` and `sessionStorage` hashed in distinct sections.
- Cookie `expires` bucketed to the hour. Session cookies (`expires <= 0` or non-finite) collapse to `-1`.
- SHA-256 over canonical UTF-8 bytes, lowercase hex digest.
- Any change to the canonical form requires bumping `version` to a new integer. v1 fingerprints stay recognizable forever.

## #1359 decision-rule check

| Rule | Answer |
|---|---|
| Pillar | B (profile/auth reuse), D (portable memory) |
| stdio/HTTP | both — pure function, no transport coupling |
| Unknown clients | works (no MCP surface in this PR) |
| Optional capabilities | none |
| Pilot-off | unchanged |
| Third-party credentials at boot | none |
| LLM judgment in host | yes — fingerprint is a label, not a verdict |
| Portable artifact | yes — versioned hex digest + breakdown |
| Real Chrome state | none touched |
| Security posture | values are NOT in the hash domain; length leakage acknowledged in spec |

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx jest tests/storage-state/fingerprint.test.ts` — 14/14 passing
  - determinism, value secrecy, length sensitivity
  - cookie name / domain / order sensitivity
  - localStorage vs sessionStorage separation
  - origin sensitivity, expiry bucketing, session-cookie collapse
  - breakdown correctness, malformed-origin tolerance

## What this does NOT do

- No MCP tool surface — `oc_profile_fingerprint` lands in B3-PR2.
- No portable signed envelope — that's B3-PR3.
- No `oc_context_export/import` envelope format — that's B3-PR4.
- No trust boundary / multi-tenant policy — that's B3-PR5, gated on #1375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)