### PR TITLE
feat(contracts): outcome contract template registry scaffold (A2-PR1)

### DIFF
--- a/src/contracts/templates/index.ts
+++ b/src/contracts/templates/index.ts
@@ -15,3 +15,6 @@ export {
 } from './types';
 export type { TemplateListing } from './registry';
 export { TemplateRegistry } from './registry';
+
+// ── public-web template catalog (A2-PR2..5 of #1359) ──────────────────────
+export { PAGE_META_TEMPLATE } from './public-web/page-meta';

--- a/src/contracts/templates/index.ts
+++ b/src/contracts/templates/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Public surface of the Outcome Contract Template subsystem (A2 thread).
+ *
+ * Concrete templates (page-meta, spa-hydrated, link-graph,
+ * authenticated-fields) ship in follow-up PRs and re-export here.
+ */
+
+export type {
+  OutcomeTemplate,
+  OutcomeTemplateSchema,
+} from './types';
+export {
+  DuplicateTemplateError,
+  InvalidTemplateError,
+} from './types';
+export type { TemplateListing } from './registry';
+export { TemplateRegistry } from './registry';

--- a/src/contracts/templates/public-web/page-meta.ts
+++ b/src/contracts/templates/public-web/page-meta.ts
@@ -1,0 +1,59 @@
+/**
+ * public-web.page-meta — outcome contract template (A2-PR2 of #1359).
+ *
+ * Declares the canonical schema for *page-level meta extraction* — the
+ * Tier-1 task family every web crawler needs and the smallest unit of
+ * comparison for external benchmarks. Use this template when the host
+ * agent wants oc_assert / oc_evidence_bundle to verify that an
+ * extraction produced `{title, url, description, statusCode}` plus
+ * Open Graph fields where present.
+ *
+ * Wire format is `schema-diff.v1` so the same JSON travels through:
+ *   - oc_evidence_bundle's target_schema input (B1-PR2)
+ *   - external benchmark scorers (airena, etc.)
+ *
+ * No detector / executor / heuristic is bundled — per #1359 §P4 the
+ * template is data only. The host extracts the page (read_page,
+ * extract_data, network response inspection) and presents the result
+ * to the bundle writer under this schema's identity.
+ */
+
+import type { OutcomeTemplate } from '../types';
+
+export const PAGE_META_TEMPLATE: OutcomeTemplate = {
+  id: 'public-web.page-meta',
+  version: 1,
+  description:
+    'Tier-1 page-level meta extraction: title, url, description, statusCode, ' +
+    'Open Graph fields. The minimum schema every public-web crawl task must ' +
+    'satisfy.',
+  tags: ['public-web', 'meta', 'static', 'tier-1'],
+  targetSchema: {
+    format: 'schema-diff.v1',
+    definition: {
+      version: 1,
+      fields: [
+        // ── Required ─────────────────────────────────────────────────
+        { name: 'title', type: 'string' },
+        { name: 'url', type: 'string' },
+        { name: 'statusCode', type: 'number' },
+
+        // ── Optional ─────────────────────────────────────────────────
+        // Description is conventionally required but missing on many
+        // real-world pages. Mark optional so absence does not lower
+        // coverage; the host can still detect omission via `missing`
+        // when they want a stricter contract by overriding the
+        // template inline.
+        { name: 'description', type: 'string', required: false },
+
+        // Open Graph (og:*) and Twitter Card fields — common
+        // enrichments. Always optional in v1.
+        { name: 'og.title', type: 'string', required: false },
+        { name: 'og.description', type: 'string', required: false },
+        { name: 'og.image', type: 'string', required: false },
+        { name: 'og.type', type: 'string', required: false },
+        { name: 'twitter.card', type: 'string', required: false },
+      ],
+    },
+  },
+};

--- a/src/contracts/templates/registry.ts
+++ b/src/contracts/templates/registry.ts
@@ -1,0 +1,150 @@
+/**
+ * Outcome Contract Template Registry — A2-PR1.
+ *
+ * In-memory, deterministic lookup table for {@link OutcomeTemplate}
+ * records. The registry is the single source of truth for which template
+ * IDs are known and which `version` is the default for unversioned
+ * lookups.
+ *
+ * Why a class instead of a global mutable object: tests need isolation
+ * and host-integration code may want per-tenant registries. The registry
+ * is small and explicit — instantiate one, register your templates,
+ * pass it where it's needed.
+ *
+ * Concrete public-web templates (page-meta, spa-hydrated, link-graph,
+ * authenticated-fields) ship in follow-up PRs A2-PR2..5.
+ */
+
+import {
+  DuplicateTemplateError,
+  InvalidTemplateError,
+  OutcomeTemplate,
+} from './types';
+
+/** Result of a successful `list()` call — a frozen view of the registry. */
+export interface TemplateListing {
+  /** Template id. */
+  id: string;
+  /** Available versions, sorted ascending. */
+  versions: number[];
+  /** Latest registered version. Identical to `Math.max(...versions)`. */
+  latest: number;
+  /** Description of the latest version. */
+  description: string;
+}
+
+const ID_PATTERN = /^[a-z0-9]+(?:[-.][a-z0-9]+)*$/;
+
+function validateTemplate(template: OutcomeTemplate): void {
+  if (typeof template.id !== 'string' || template.id.length === 0) {
+    throw new InvalidTemplateError('id must be a non-empty string');
+  }
+  if (!ID_PATTERN.test(template.id)) {
+    throw new InvalidTemplateError(
+      `id "${template.id}" must be dotted kebab-case (a-z0-9 separated by '-' or '.')`,
+    );
+  }
+  if (
+    typeof template.version !== 'number' ||
+    !Number.isInteger(template.version) ||
+    template.version < 1
+  ) {
+    throw new InvalidTemplateError('version must be a positive integer');
+  }
+  if (typeof template.description !== 'string' || template.description.length === 0) {
+    throw new InvalidTemplateError('description must be a non-empty string');
+  }
+}
+
+export class TemplateRegistry {
+  /** id → version → template. Inner map preserves insertion order. */
+  private readonly byId = new Map<string, Map<number, OutcomeTemplate>>();
+
+  /**
+   * Register a template. Rejects duplicate `(id, version)` pairs with
+   * {@link DuplicateTemplateError} and shape violations with
+   * {@link InvalidTemplateError}.
+   */
+  register(template: OutcomeTemplate): void {
+    validateTemplate(template);
+    let versions = this.byId.get(template.id);
+    if (!versions) {
+      versions = new Map();
+      this.byId.set(template.id, versions);
+    }
+    if (versions.has(template.version)) {
+      throw new DuplicateTemplateError(template.id, template.version);
+    }
+    versions.set(template.version, Object.freeze({ ...template }) as OutcomeTemplate);
+  }
+
+  /**
+   * Resolve a template. With no `version`, returns the highest registered
+   * version. Returns `undefined` if either the id is unknown or the
+   * specific version is unknown.
+   */
+  get(id: string, version?: number): OutcomeTemplate | undefined {
+    const versions = this.byId.get(id);
+    if (!versions) return undefined;
+    if (version === undefined) {
+      let best: OutcomeTemplate | undefined;
+      let bestVersion = -Infinity;
+      for (const [v, t] of versions) {
+        if (v > bestVersion) {
+          bestVersion = v;
+          best = t;
+        }
+      }
+      return best;
+    }
+    return versions.get(version);
+  }
+
+  /** Whether a template `(id, version?)` is registered. */
+  has(id: string, version?: number): boolean {
+    return this.get(id, version) !== undefined;
+  }
+
+  /**
+   * Remove one template. With no `version`, removes the id and every
+   * version registered under it. Returns the count removed.
+   */
+  unregister(id: string, version?: number): number {
+    const versions = this.byId.get(id);
+    if (!versions) return 0;
+    if (version === undefined) {
+      const count = versions.size;
+      this.byId.delete(id);
+      return count;
+    }
+    const removed = versions.delete(version);
+    if (versions.size === 0) this.byId.delete(id);
+    return removed ? 1 : 0;
+  }
+
+  /**
+   * Enumerate every registered id with its versions. Output is sorted by
+   * id for determinism (helpful in trace bundles and test snapshots).
+   */
+  list(): TemplateListing[] {
+    const ids = [...this.byId.keys()].sort();
+    return ids.map(id => {
+      const versions = [...this.byId.get(id)!.keys()].sort((a, b) => a - b);
+      const latest = versions[versions.length - 1];
+      const latestTemplate = this.byId.get(id)!.get(latest)!;
+      return {
+        id,
+        versions,
+        latest,
+        description: latestTemplate.description,
+      };
+    });
+  }
+
+  /** Total number of registered `(id, version)` pairs. */
+  size(): number {
+    let n = 0;
+    for (const versions of this.byId.values()) n += versions.size;
+    return n;
+  }
+}

--- a/src/contracts/templates/registry.ts
+++ b/src/contracts/templates/registry.ts
@@ -35,6 +35,28 @@ export interface TemplateListing {
 
 const ID_PATTERN = /^[a-z0-9]+(?:[-.][a-z0-9]+)*$/;
 
+/**
+ * Recursively freeze a plain object or array so that the registry's stored
+ * record is truly immutable. `Object.freeze` is shallow — it would leave
+ * nested `Assertion` trees (whose `children`/`operands` are arrays of further
+ * `Assertion` nodes) and `targetSchema.definition` (typed `unknown`) live
+ * and mutable, breaking the "frozen output" invariant for any template that
+ * carries either field.
+ *
+ * Only plain objects, arrays, and primitives appear inside templates (they
+ * must be JSON-serializable per P4), so this helper does not need to handle
+ * Maps, Sets, Dates, class instances, or cyclic references.
+ */
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object') return value;
+  if (Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const key of Object.keys(value as object)) {
+    deepFreeze((value as Record<string, unknown>)[key]);
+  }
+  return value;
+}
+
 function validateTemplate(template: OutcomeTemplate): void {
   if (typeof template.id !== 'string' || template.id.length === 0) {
     throw new InvalidTemplateError('id must be a non-empty string');
@@ -75,7 +97,12 @@ export class TemplateRegistry {
     if (versions.has(template.version)) {
       throw new DuplicateTemplateError(template.id, template.version);
     }
-    versions.set(template.version, Object.freeze({ ...template }) as OutcomeTemplate);
+    // Structured-clone so the registry owns its copy (callers cannot mutate
+    // arrays they handed in), then deep-freeze the clone so consumers cannot
+    // mutate either. Templates are JSON-serializable by contract, so
+    // structuredClone is safe and preserves nested Assertion / targetSchema
+    // structure without us hand-rolling a deep-copy walker.
+    versions.set(template.version, deepFreeze(structuredClone(template)));
   }
 
   /**

--- a/src/contracts/templates/types.ts
+++ b/src/contracts/templates/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Outcome Contract Template types — A2-PR1.
+ *
+ * A *template* is a portable, importable data definition that bundles a
+ * named target schema with an optional pre-built assertion tree. Templates
+ * are the canonical way to declare "what counts as success" for a recurring
+ * extraction task (page meta, SPA hydration, link graph, authenticated
+ * profile fields).
+ *
+ * This module ships the **type system and a registry only**. Concrete
+ * templates land in follow-up PRs (A2-PR2..5) and import this surface.
+ *
+ * Design rules (per #1359):
+ *
+ *  - **Data, not behavior** (P4 facts before decisions): a template is a
+ *    JSON-serializable record. No code is bundled. The runtime that consumes
+ *    a template (oc_assert, extract_data) supplies the behavior.
+ *  - **Host owns selection** (P2 harness, not agent): we never infer which
+ *    template applies from a free-text instruction. The host names the
+ *    template by `id` (and optional `version`).
+ *  - **Immutable contract identity**: a template's `(id, version)` pair is
+ *    its eternal name. Renaming requires bumping `version`. Old versions
+ *    must remain usable for replay and benchmarking reproducibility.
+ *  - **Portability**: every template must be expressible as plain JSON so
+ *    it can travel through MCP tool input, evidence bundles, and traces
+ *    without code-mobility tricks.
+ */
+
+import type { Assertion } from '../types';
+
+/**
+ * Target schema descriptor that a template advertises. Intentionally a
+ * loose `unknown` field on the data layer — downstream PRs (B1-PR2 and
+ * later) will narrow this to the deterministic schema-diff shape. Keeping
+ * it `unknown` in this PR avoids coupling A2-PR1 to schema-diff and lets
+ * each thread land independently.
+ */
+export interface OutcomeTemplateSchema {
+  /** Format identifier so the consumer knows which validator to invoke. */
+  format: string;
+  /** Format-specific definition. Opaque to the registry. */
+  definition: unknown;
+}
+
+/**
+ * The canonical template record. Plain data; no methods.
+ *
+ * Naming convention: `id` should be a dotted kebab-case namespace such as
+ * `public-web.page-meta` so a future ID collision across template families
+ * surfaces visually. The registry enforces uniqueness on `(id, version)`.
+ */
+export interface OutcomeTemplate {
+  /** Stable kebab-case identifier. Required. */
+  id: string;
+  /**
+   * Monotonic integer version. Required. Two templates may share an `id`
+   * if their versions differ; the registry stores them side by side.
+   */
+  version: number;
+  /** Human-readable summary. Required so traces stay legible. */
+  description: string;
+  /**
+   * Optional schema this template targets. Consumed by extract_data,
+   * oc_evidence_bundle's schema-diff hook, and benchmark harnesses.
+   */
+  targetSchema?: OutcomeTemplateSchema;
+  /**
+   * Optional pre-built assertion tree, evaluated by oc_assert and the
+   * contract runtime. Either or both of {targetSchema, assertions} may
+   * be present; a template with neither is legal but inert.
+   */
+  assertions?: Assertion;
+  /** Free-form tags for catalog search. Order is not significant. */
+  tags?: readonly string[];
+}
+
+/** Error thrown when the registry is asked to register a duplicate key. */
+export class DuplicateTemplateError extends Error {
+  constructor(public readonly id: string, public readonly version: number) {
+    super(`outcome template already registered: ${id}@${version}`);
+    this.name = 'DuplicateTemplateError';
+  }
+}
+
+/** Error thrown when validation rejects a template record. */
+export class InvalidTemplateError extends Error {
+  constructor(public readonly reason: string) {
+    super(`invalid outcome template: ${reason}`);
+    this.name = 'InvalidTemplateError';
+  }
+}

--- a/tests/contracts/templates/public-web/page-meta.test.ts
+++ b/tests/contracts/templates/public-web/page-meta.test.ts
@@ -1,0 +1,115 @@
+/// <reference types="jest" />
+
+/**
+ * Tests for public-web.page-meta template (A2-PR2 of #1359).
+ *
+ * The template is data-only; tests pin:
+ *   - identity (id, version, kebab-case, well-formed description)
+ *   - schema format and required/optional field discrimination
+ *   - registration round-trip through TemplateRegistry
+ *   - portability: JSON-serializable
+ */
+
+import {
+  PAGE_META_TEMPLATE,
+  TemplateRegistry,
+} from '../../../../src/contracts/templates';
+
+describe('PAGE_META_TEMPLATE — identity', () => {
+  test('id is "public-web.page-meta" and version is 1', () => {
+    expect(PAGE_META_TEMPLATE.id).toBe('public-web.page-meta');
+    expect(PAGE_META_TEMPLATE.version).toBe(1);
+  });
+
+  test('description is non-empty and starts with the task family', () => {
+    expect(PAGE_META_TEMPLATE.description.length).toBeGreaterThan(10);
+    expect(PAGE_META_TEMPLATE.description.toLowerCase()).toContain('page-level meta extraction');
+  });
+
+  test('tags include public-web and tier-1', () => {
+    expect(PAGE_META_TEMPLATE.tags).toEqual(
+      expect.arrayContaining(['public-web', 'meta', 'tier-1']),
+    );
+  });
+});
+
+describe('PAGE_META_TEMPLATE — schema shape', () => {
+  test('targetSchema.format is schema-diff.v1', () => {
+    expect(PAGE_META_TEMPLATE.targetSchema?.format).toBe('schema-diff.v1');
+  });
+
+  test('schema declares title/url/statusCode as required', () => {
+    const def = PAGE_META_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string; type: string; required?: boolean }>;
+    };
+    const required = def.fields
+      .filter((f) => f.required !== false)
+      .map((f) => f.name);
+
+    expect(required).toEqual(
+      expect.arrayContaining(['title', 'url', 'statusCode']),
+    );
+  });
+
+  test('description and og:* are optional', () => {
+    const def = PAGE_META_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string; type: string; required?: boolean }>;
+    };
+    const optional = def.fields
+      .filter((f) => f.required === false)
+      .map((f) => f.name);
+
+    expect(optional).toEqual(
+      expect.arrayContaining([
+        'description',
+        'og.title',
+        'og.description',
+        'og.image',
+        'og.type',
+        'twitter.card',
+      ]),
+    );
+  });
+
+  test('every field declares a primitive JS-type bucket', () => {
+    const def = PAGE_META_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string; type: string }>;
+    };
+    const allowed = new Set(['string', 'number', 'boolean', 'object', 'array', 'null']);
+    for (const f of def.fields) {
+      expect(allowed.has(f.type)).toBe(true);
+    }
+  });
+});
+
+describe('PAGE_META_TEMPLATE — portability', () => {
+  test('round-trips through JSON without loss', () => {
+    const copy = JSON.parse(JSON.stringify(PAGE_META_TEMPLATE));
+    expect(copy).toEqual(PAGE_META_TEMPLATE);
+  });
+});
+
+describe('PAGE_META_TEMPLATE — registry round-trip', () => {
+  test('registers and resolves through TemplateRegistry', () => {
+    const r = new TemplateRegistry();
+    r.register(PAGE_META_TEMPLATE);
+
+    expect(r.has('public-web.page-meta')).toBe(true);
+    expect(r.has('public-web.page-meta', 1)).toBe(true);
+    expect(r.get('public-web.page-meta')).toEqual(PAGE_META_TEMPLATE);
+  });
+
+  test('listing surfaces the public-web.page-meta entry with version 1 as latest', () => {
+    const r = new TemplateRegistry();
+    r.register(PAGE_META_TEMPLATE);
+
+    expect(r.list()).toEqual([
+      {
+        id: 'public-web.page-meta',
+        versions: [1],
+        latest: 1,
+        description: PAGE_META_TEMPLATE.description,
+      },
+    ]);
+  });
+});

--- a/tests/contracts/templates/registry.test.ts
+++ b/tests/contracts/templates/registry.test.ts
@@ -156,6 +156,58 @@ describe('TemplateRegistry', () => {
     expect(r.get(t.id)?.description).toBe('page-level meta extraction');
   });
 
+  test('nested assertions tree is deep-frozen and cannot be mutated via registry output', () => {
+    const r = new TemplateRegistry();
+    const t: OutcomeTemplate = {
+      id: 'public-web.deep-freeze',
+      version: 1,
+      description: 'deep freeze probe',
+      assertions: {
+        kind: 'and',
+        children: [{ kind: 'no_dialog' }],
+      } as unknown as OutcomeTemplate['assertions'],
+      targetSchema: { format: 'schema-diff.v1', definition: { fields: ['a'] } },
+      tags: ['public-web'],
+    };
+    r.register(t);
+
+    const got = r.get(t.id)!;
+    expect(Object.isFrozen(got)).toBe(true);
+    expect(Object.isFrozen(got.assertions)).toBe(true);
+    // The Assertion DSL nests via `children` / `operands`; both must be
+    // deep-frozen so callers cannot reach in and mutate the tree.
+    const assertions = got.assertions as { children: unknown[] };
+    expect(Object.isFrozen(assertions.children)).toBe(true);
+    expect(() => assertions.children.push({} as never)).toThrow();
+    expect(Object.isFrozen(got.targetSchema)).toBe(true);
+    expect(Object.isFrozen(got.targetSchema!.definition as object)).toBe(true);
+    expect(Object.isFrozen(got.tags)).toBe(true);
+    expect(() => (got.tags as string[]).push('mutated')).toThrow();
+  });
+
+  test('mutating the caller-side input after register() does not affect the stored template', () => {
+    const r = new TemplateRegistry();
+    const tags = ['a'];
+    const definition = { fields: ['initial'] };
+    const t: OutcomeTemplate = {
+      id: 'public-web.aliasing-probe',
+      version: 1,
+      description: 'aliasing probe',
+      targetSchema: { format: 'schema-diff.v1', definition },
+      tags,
+    };
+    r.register(t);
+
+    // Mutate the caller's references; the registry copy is a structured clone
+    // so neither change should be observable through get().
+    tags.push('b');
+    definition.fields.push('mutated');
+
+    const got = r.get(t.id)!;
+    expect(got.tags).toEqual(['a']);
+    expect((got.targetSchema!.definition as { fields: string[] }).fields).toEqual(['initial']);
+  });
+
   test('template targetSchema and assertions pass through unchanged', () => {
     const r = new TemplateRegistry();
     const t: OutcomeTemplate = {

--- a/tests/contracts/templates/registry.test.ts
+++ b/tests/contracts/templates/registry.test.ts
@@ -1,0 +1,172 @@
+/// <reference types="jest" />
+
+import {
+  DuplicateTemplateError,
+  InvalidTemplateError,
+  OutcomeTemplate,
+  TemplateRegistry,
+} from '../../../src/contracts/templates';
+
+function tpl(overrides: Partial<OutcomeTemplate> = {}): OutcomeTemplate {
+  return {
+    id: 'public-web.page-meta',
+    version: 1,
+    description: 'page-level meta extraction',
+    ...overrides,
+  };
+}
+
+describe('TemplateRegistry', () => {
+  test('empty registry: size, list, get, has are all consistent', () => {
+    const r = new TemplateRegistry();
+    expect(r.size()).toBe(0);
+    expect(r.list()).toEqual([]);
+    expect(r.get('anything')).toBeUndefined();
+    expect(r.has('anything')).toBe(false);
+  });
+
+  test('register exposes a single template via get/has', () => {
+    const r = new TemplateRegistry();
+    const t = tpl();
+    r.register(t);
+
+    expect(r.size()).toBe(1);
+    expect(r.get('public-web.page-meta')).toEqual(t);
+    expect(r.get('public-web.page-meta', 1)).toEqual(t);
+    expect(r.has('public-web.page-meta')).toBe(true);
+    expect(r.has('public-web.page-meta', 1)).toBe(true);
+    expect(r.has('public-web.page-meta', 2)).toBe(false);
+  });
+
+  test('multiple versions co-exist; unversioned get returns the highest', () => {
+    const r = new TemplateRegistry();
+    r.register(tpl({ version: 1, description: 'v1' }));
+    r.register(tpl({ version: 3, description: 'v3' }));
+    r.register(tpl({ version: 2, description: 'v2' }));
+
+    expect(r.size()).toBe(3);
+    expect(r.get('public-web.page-meta')?.version).toBe(3);
+    expect(r.get('public-web.page-meta', 1)?.description).toBe('v1');
+    expect(r.get('public-web.page-meta', 2)?.description).toBe('v2');
+    expect(r.get('public-web.page-meta', 3)?.description).toBe('v3');
+  });
+
+  test('duplicate (id, version) throws DuplicateTemplateError', () => {
+    const r = new TemplateRegistry();
+    r.register(tpl());
+    expect(() => r.register(tpl())).toThrow(DuplicateTemplateError);
+  });
+
+  test('rejects malformed ids', () => {
+    const r = new TemplateRegistry();
+    expect(() => r.register(tpl({ id: '' }))).toThrow(InvalidTemplateError);
+    expect(() => r.register(tpl({ id: 'NotKebabCase' }))).toThrow(InvalidTemplateError);
+    expect(() => r.register(tpl({ id: 'spaces not allowed' }))).toThrow(InvalidTemplateError);
+    expect(() => r.register(tpl({ id: '-leading-dash' }))).toThrow(InvalidTemplateError);
+    expect(() => r.register(tpl({ id: 'trailing-' }))).toThrow(InvalidTemplateError);
+  });
+
+  test('accepts dotted kebab-case ids', () => {
+    const r = new TemplateRegistry();
+    expect(() => r.register(tpl({ id: 'a' }))).not.toThrow();
+    expect(() => r.register(tpl({ id: 'a-b' }))).not.toThrow();
+    expect(() => r.register(tpl({ id: 'public-web.spa-hydrated' }))).not.toThrow();
+    expect(() => r.register(tpl({ id: 'ns.sub.leaf' }))).not.toThrow();
+  });
+
+  test('rejects malformed version values', () => {
+    const r = new TemplateRegistry();
+    expect(() => r.register(tpl({ version: 0 }))).toThrow(InvalidTemplateError);
+    expect(() => r.register(tpl({ version: -1 }))).toThrow(InvalidTemplateError);
+    expect(() => r.register(tpl({ version: 1.5 }))).toThrow(InvalidTemplateError);
+    expect(() => r.register(tpl({ version: Number.NaN }))).toThrow(InvalidTemplateError);
+    expect(() => r.register(tpl({ version: 'one' as unknown as number }))).toThrow(
+      InvalidTemplateError,
+    );
+  });
+
+  test('rejects empty descriptions', () => {
+    const r = new TemplateRegistry();
+    expect(() => r.register(tpl({ description: '' }))).toThrow(InvalidTemplateError);
+  });
+
+  test('list() returns ids sorted, with versions ascending and latest correct', () => {
+    const r = new TemplateRegistry();
+    r.register(tpl({ id: 'b.template', version: 2, description: 'b@2' }));
+    r.register(tpl({ id: 'a.template', version: 1, description: 'a@1' }));
+    r.register(tpl({ id: 'b.template', version: 1, description: 'b@1' }));
+    r.register(tpl({ id: 'a.template', version: 5, description: 'a@5' }));
+
+    expect(r.list()).toEqual([
+      { id: 'a.template', versions: [1, 5], latest: 5, description: 'a@5' },
+      { id: 'b.template', versions: [1, 2], latest: 2, description: 'b@2' },
+    ]);
+  });
+
+  test('unregister(id) removes every version under that id', () => {
+    const r = new TemplateRegistry();
+    r.register(tpl({ version: 1 }));
+    r.register(tpl({ version: 2 }));
+
+    expect(r.unregister('public-web.page-meta')).toBe(2);
+    expect(r.size()).toBe(0);
+    expect(r.has('public-web.page-meta')).toBe(false);
+  });
+
+  test('unregister(id, version) removes exactly one version and keeps others', () => {
+    const r = new TemplateRegistry();
+    r.register(tpl({ version: 1 }));
+    r.register(tpl({ version: 2 }));
+
+    expect(r.unregister('public-web.page-meta', 1)).toBe(1);
+    expect(r.size()).toBe(1);
+    expect(r.has('public-web.page-meta', 1)).toBe(false);
+    expect(r.has('public-web.page-meta', 2)).toBe(true);
+    expect(r.get('public-web.page-meta')?.version).toBe(2);
+  });
+
+  test('unregister returns 0 for unknown id or version', () => {
+    const r = new TemplateRegistry();
+    expect(r.unregister('does-not-exist')).toBe(0);
+    r.register(tpl({ version: 1 }));
+    expect(r.unregister('public-web.page-meta', 999)).toBe(0);
+    expect(r.size()).toBe(1);
+  });
+
+  test('removing the last version cleans the id slot from list()', () => {
+    const r = new TemplateRegistry();
+    r.register(tpl({ version: 1 }));
+    expect(r.list().length).toBe(1);
+    r.unregister('public-web.page-meta', 1);
+    expect(r.list()).toEqual([]);
+  });
+
+  test('registered template is frozen — mutating the input does not affect the registry view', () => {
+    const r = new TemplateRegistry();
+    const t = tpl({ tags: ['a', 'b'] });
+    r.register(t);
+
+    // The mutation below would fail in strict mode; we wrap to assert the
+    // registry's view is independent regardless of what callers do post-
+    // registration.
+    expect(() => {
+      const got = r.get(t.id)!;
+      (got as { description: string }).description = 'mutated';
+    }).toThrow();
+    expect(r.get(t.id)?.description).toBe('page-level meta extraction');
+  });
+
+  test('template targetSchema and assertions pass through unchanged', () => {
+    const r = new TemplateRegistry();
+    const t: OutcomeTemplate = {
+      id: 'public-web.page-meta',
+      version: 1,
+      description: 'meta',
+      targetSchema: { format: 'schema-diff.v1', definition: { fields: [] } },
+      assertions: { kind: 'no_dialog' },
+      tags: ['public-web', 'meta'],
+    };
+    r.register(t);
+    expect(r.get(t.id)).toEqual(t);
+  });
+});


### PR DESCRIPTION
## Summary

Introduce `src/contracts/templates/` — the type system and in-memory registry for the broader **A2** thread of #1359 (outcome contract template library for public-web extraction).

This PR ships **only** the scaffolding. No concrete templates land here; page-meta / spa-hydrated / link-graph / authenticated-fields ship in A2-PR2..5 and import this surface.

## What lands

```ts
interface OutcomeTemplate {
  id: string;             // kebab-case, dotted namespaces allowed
  version: number;        // positive integer; multiple versions coexist
  description: string;
  targetSchema?: { format: string; definition: unknown };
  assertions?: Assertion; // existing contract DSL
  tags?: readonly string[];
}

class TemplateRegistry {
  register(t: OutcomeTemplate): void;
  get(id, version?): OutcomeTemplate | undefined;
  has(id, version?): boolean;
  unregister(id, version?): number;
  list(): TemplateListing[];
  size(): number;
}
```

## Design rules (per #1359)

- **Data, not behavior (P4):** templates are JSON-serializable records; the runtime supplies the behavior.
- **Host owns selection (P2):** we never infer which template applies from a free-text instruction. The host names a template by `id` and optional `version`.
- **Immutable identity:** `(id, version)` is the eternal name; renaming requires bumping the version. Old versions remain usable for replay and benchmarking reproducibility.
- **Portable:** every template is plain JSON, transport-agnostic.

## #1359 decision-rule check

| Rule | Answer |
|---|---|
| Pillar | C (contract-verifiable browser work), E (benchmark anchoring) |
| stdio/HTTP | both — pure data layer |
| Optional capabilities | none |
| Pilot-off | unchanged |
| LLM judgment in host | yes — selection by name only |
| Portable artifact | yes — JSON records |
| Real Chrome state | none touched |
| Host-specific behavior | none |

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx jest tests/contracts/templates/registry.test.ts` — 15/15 passing
  - empty-state consistency, register, multi-version coexistence
  - duplicate `(id, version)` rejection
  - id validation (kebab-case + dotted namespaces), version validation, description validation
  - `list()` determinism (sorted ids, ascending versions, latest correct)
  - `unregister` variants, slot cleanup
  - registered output is frozen
  - `targetSchema`/`assertions`/`tags` round-trip

## What this does NOT do

- No concrete templates yet — those are A2-PR2..5.
- No `extract_data` / `oc_assert` wiring — those land after the concrete templates exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)