### PR TITLE
feat(tools): oc_gate_inspect — fact-only gate detection (B2-PR1)

### DIFF
--- a/src/core/contracts/evidence-bundle.ts
+++ b/src/core/contracts/evidence-bundle.ts
@@ -27,7 +27,24 @@ import * as path from 'node:path';
 import { phashFromPng, phashToHex } from '../../contracts/phash';
 
 /** Parts the caller can request. Each maps to a file in the bundle dir. */
-export type EvidenceBundlePart = 'dom' | 'screenshot' | 'network' | 'console' | 'phash';
+export type EvidenceBundlePart = 'dom' | 'screenshot' | 'network' | 'console' | 'phash' | 'gate';
+
+/**
+ * Gate fact surfaced into the bundle (B2-PR4). Mirrors the closed
+ * vocabulary of `oc_gate_inspect`'s output without depending on the tool
+ * module — the bundle writer is intentionally I/O-only.
+ */
+export interface GateFact {
+  detected: boolean;
+  kind?: string;
+  gateType?: string;
+  siteKey?: string;
+  siteKeySource?: string;
+  invisible?: boolean;
+  provider?: string;
+  selector?: string;
+  pageUrl?: string;
+}
 
 /** Default include set — cheap parts that almost every caller wants. */
 export const DEFAULT_INCLUDE: readonly EvidenceBundlePart[] = ['dom', 'screenshot'];
@@ -71,6 +88,12 @@ export interface EvidenceBundleSnapshot {
   console?: ConsoleEntry[];
   /** Optional clock used for the network window. Defaults to `Date.now()`. */
   now_ms?: number;
+  /**
+   * Caller-supplied gate fact (B2-PR4). Sourced from `oc_gate_inspect`
+   * or constructed by the host. Written to `gate.json` when the
+   * `gate` part is included.
+   */
+  gate?: GateFact;
 }
 
 export interface EvidenceBundleOptions {
@@ -177,6 +200,14 @@ export function writeEvidenceBundle(
     parts.push(filename);
   }
 
+  // ── Gate fact ─────────────────────────────────────────────────────────
+  if (include.has('gate') && snapshot.gate !== undefined) {
+    const filename = 'gate.json';
+    const payload = JSON.stringify(snapshot.gate, null, 2);
+    totalBytes += writePart(bundleDir, filename, payload);
+    parts.push(filename);
+  }
+
   // ── Perceptual hash ───────────────────────────────────────────────────
   if (include.has('phash')) {
     // If the caller didn't ask for the screenshot part but did ask for
@@ -218,7 +249,7 @@ function normalizeInclude(
   if (!include || include.length === 0) {
     return new Set(DEFAULT_INCLUDE);
   }
-  const valid: EvidenceBundlePart[] = ['dom', 'screenshot', 'network', 'console', 'phash'];
+  const valid: EvidenceBundlePart[] = ['dom', 'screenshot', 'network', 'console', 'phash', 'gate'];
   const out = new Set<EvidenceBundlePart>();
   for (const item of include) {
     if ((valid as string[]).includes(item)) out.add(item);

--- a/src/gates/detect-other-gates.ts
+++ b/src/gates/detect-other-gates.ts
@@ -1,0 +1,247 @@
+/**
+ * Non-CAPTCHA gate detection (B2-PR2 of #1359).
+ *
+ * Pure DOM/URL heuristics that surface common access gates the host agent
+ * should reason about before proceeding:
+ *
+ *   - SSO redirect: the page has navigated to an identity provider login.
+ *   - Paywall: a subscription/metered overlay is blocking the content.
+ *   - Two-factor: an OTP / verification-code input is the foreground form.
+ *
+ * Each detector is **read-only** and **fact-only** (#1359 P4). It returns
+ * either the structured signal it observed or `null`. None of these
+ * detectors makes a network call, evaluates host-controlled credentials,
+ * or attempts to bypass the gate. The MCP tool `oc_gate_inspect` composes
+ * these detectors after the CAPTCHA detector so the host can decide what
+ * to do with the result.
+ *
+ * Known gaps recorded as comments below:
+ *   - HTTP Basic auth: not reliably DOM-detectable (the browser shows a
+ *     native dialog). Use HTTP response status + WWW-Authenticate header
+ *     parsing at the network layer instead — out of scope for this PR.
+ */
+
+import type { Page } from 'puppeteer-core';
+
+export type NonCaptchaGateKind = 'sso' | 'paywall' | '2fa';
+
+export type SsoProvider =
+  | 'microsoft'
+  | 'google'
+  | 'okta'
+  | 'auth0'
+  | 'github'
+  | 'apple'
+  | 'generic';
+
+export interface SsoSignal {
+  kind: 'sso';
+  gateType: 'sso_redirect';
+  provider: SsoProvider;
+  pageUrl: string;
+}
+
+export interface PaywallSignal {
+  kind: 'paywall';
+  gateType: 'paywall';
+  /** CSS-style selector that triggered the match. */
+  selector: string;
+  pageUrl: string;
+}
+
+export interface TwoFactorSignal {
+  kind: '2fa';
+  gateType: 'two_factor';
+  /** CSS-style selector for the OTP input that triggered the match. */
+  selector: string;
+  pageUrl: string;
+}
+
+export type NonCaptchaGateSignal = SsoSignal | PaywallSignal | TwoFactorSignal;
+
+// ─── SSO ──────────────────────────────────────────────────────────────────
+
+/** Known identity-provider host patterns. Order is not significant. */
+const SSO_PROVIDERS: Array<{ provider: SsoProvider; hostPattern: RegExp }> = [
+  { provider: 'microsoft', hostPattern: /(?:login\.microsoftonline\.com|login\.live\.com)/i },
+  { provider: 'google', hostPattern: /accounts\.google\.com/i },
+  { provider: 'okta', hostPattern: /\.okta\.com$/i },
+  { provider: 'auth0', hostPattern: /\.auth0\.com$/i },
+  { provider: 'github', hostPattern: /github\.com\/login/i },
+  { provider: 'apple', hostPattern: /appleid\.apple\.com/i },
+];
+
+/**
+ * Generic SSO URL hints — any of these path/query fragments are a strong
+ * signal even when the host is not in the provider table.
+ */
+const SSO_PATH_HINTS = [
+  '/sso',
+  '/saml',
+  '/oauth',
+  '/oauth2',
+  '/openid',
+  '/openid-connect',
+  '/authorize',
+  '/auth/realms', // Keycloak
+];
+
+export function detectSsoSignalFromUrl(rawUrl: string): SsoSignal | null {
+  if (!rawUrl || typeof rawUrl !== 'string') return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  // 1. Known provider host match — strongest signal.
+  for (const { provider, hostPattern } of SSO_PROVIDERS) {
+    if (hostPattern.test(parsed.host) || hostPattern.test(parsed.href)) {
+      return { kind: 'sso', gateType: 'sso_redirect', provider, pageUrl: rawUrl };
+    }
+  }
+
+  // 2. Generic SSO path hint — provider unknown, but the URL still says
+  //    the user is mid-auth.
+  const lowerPath = parsed.pathname.toLowerCase();
+  for (const hint of SSO_PATH_HINTS) {
+    if (lowerPath.startsWith(hint) || lowerPath.includes(hint)) {
+      return { kind: 'sso', gateType: 'sso_redirect', provider: 'generic', pageUrl: rawUrl };
+    }
+  }
+
+  return null;
+}
+
+export async function detectSso(page: Page): Promise<SsoSignal | null> {
+  let url: string;
+  try {
+    url = page.url();
+  } catch {
+    return null;
+  }
+  return detectSsoSignalFromUrl(url);
+}
+
+// ─── Paywall ──────────────────────────────────────────────────────────────
+
+/**
+ * Paywall selector list. Each entry is a CSS selector that publishers use
+ * to gate content. Worst-case false positives only deliver a "paywall
+ * detected" fact to the host — the host still has to decide what to do,
+ * which is the right place for that judgment.
+ */
+const PAYWALL_SELECTORS = [
+  '.paywall',
+  '#paywall',
+  '.subscription-overlay',
+  '.subscription-wall',
+  '.metered-wall',
+  '.tp-modal',                  // Piano / Tinypass
+  '.tp-backdrop',
+  '.zephr-paywall',             // Zephr
+  '[data-paywall]',
+  '[data-subscription-required]',
+];
+
+function paywallProbe(selectors: string[]): { selector: string } | null {
+  for (const sel of selectors) {
+    const node = document.querySelector(sel) as HTMLElement | null;
+    if (!node) continue;
+    // Quick "is this actually visible-ish?" check. We bail on display:none
+    // / hidden attribute / zero box to avoid matching dead markup left in
+    // the page template by the publisher's CMS.
+    const style = (node.ownerDocument && node.ownerDocument.defaultView)
+      ? node.ownerDocument.defaultView.getComputedStyle(node)
+      : null;
+    const hidden = node.hidden
+      || (style && (style.display === 'none' || style.visibility === 'hidden'))
+      || (node.offsetWidth === 0 && node.offsetHeight === 0);
+    if (!hidden) return { selector: sel };
+  }
+  return null;
+}
+
+export async function detectPaywall(page: Page): Promise<PaywallSignal | null> {
+  let url: string;
+  try {
+    url = page.url();
+  } catch {
+    url = 'unknown';
+  }
+  try {
+    const match = await page.evaluate(paywallProbe, PAYWALL_SELECTORS);
+    if (!match) return null;
+    return { kind: 'paywall', gateType: 'paywall', selector: match.selector, pageUrl: url };
+  } catch {
+    return null;
+  }
+}
+
+// ─── Two-factor ───────────────────────────────────────────────────────────
+
+/**
+ * OTP / verification-code input selectors. The `autocomplete="one-time-code"`
+ * attribute is the strongest signal (it's defined by the HTML spec for
+ * exactly this purpose). The remaining selectors catch the long tail of
+ * naming conventions across login flows.
+ */
+const TWOFA_SELECTORS = [
+  'input[autocomplete="one-time-code"]',
+  'input[name="otp"]',
+  'input[name="otp_code"]',
+  'input[name="one_time_code"]',
+  'input[name="verification_code"]',
+  'input[name="totp"]',
+  'input[name="2fa_code"]',
+  'input[id="otp"]',
+  'input[id="verification-code"]',
+  'input[inputmode="numeric"][maxlength="6"]',
+];
+
+function twoFactorProbe(selectors: string[]): { selector: string } | null {
+  for (const sel of selectors) {
+    const node = document.querySelector(sel) as HTMLInputElement | null;
+    if (node) return { selector: sel };
+  }
+  return null;
+}
+
+export async function detectTwoFactor(page: Page): Promise<TwoFactorSignal | null> {
+  let url: string;
+  try {
+    url = page.url();
+  } catch {
+    url = 'unknown';
+  }
+  try {
+    const match = await page.evaluate(twoFactorProbe, TWOFA_SELECTORS);
+    if (!match) return null;
+    return { kind: '2fa', gateType: 'two_factor', selector: match.selector, pageUrl: url };
+  } catch {
+    return null;
+  }
+}
+
+// ─── Composer ─────────────────────────────────────────────────────────────
+
+/**
+ * Run the non-CAPTCHA detectors in priority order and return the first
+ * positive signal. Used by `oc_gate_inspect` after CAPTCHA detection. The
+ * order — SSO → paywall → 2FA — reflects how the host would typically
+ * reason about a gate: an SSO redirect means "you're no longer on the
+ * target site"; a paywall means "you're on the site but blocked"; a 2FA
+ * prompt means "you're authenticating right now."
+ */
+export async function detectNonCaptchaGate(
+  page: Page,
+): Promise<NonCaptchaGateSignal | null> {
+  const sso = await detectSso(page);
+  if (sso) return sso;
+  const paywall = await detectPaywall(page);
+  if (paywall) return paywall;
+  const twoFactor = await detectTwoFactor(page);
+  if (twoFactor) return twoFactor;
+  return null;
+}

--- a/src/tools/__tests__/__snapshots__/tools-list.v1.11.snap.json
+++ b/src/tools/__tests__/__snapshots__/tools-list.v1.11.snap.json
@@ -124,6 +124,9 @@
       "name": "oc_evidence_bundle"
     },
     {
+      "name": "oc_gate_inspect"
+    },
+    {
       "name": "oc_get_connection_info"
     },
     {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -116,6 +116,9 @@ import { registerTotpGenerateTool } from './totp-generate';
 // Outcome Contracts (#784) — single-call assertion verifier
 import { registerOcAssertTool } from './oc-assert';
 
+// Gate detection (B2-PR1 of #1359) — fact-only CAPTCHA/auth gate detection
+import { registerOcGateInspectTool } from './oc-gate-inspect';
+
 // Outcome Contracts (#792) — evidence bundle capture
 import { registerOcEvidenceBundleTool } from './oc-evidence-bundle';
 import { registerOcDiffTool } from './oc-diff';
@@ -230,6 +233,7 @@ export const TOOL_CAPABILITY_MAP: Record<string, ToolCapability> = {
   oc_diff: 'core',
   oc_doctor_report: 'core',
   oc_evidence_bundle: 'core',
+  oc_gate_inspect: 'core',
   oc_get_connection_info: 'core',
   oc_journal: 'core',
   oc_observe: 'core',
@@ -495,6 +499,9 @@ export function registerAllTools(server: MCPServer): void {
 
   // Outcome Contracts (#784) — single-call assertion verifier
   registerOcAssertTool(proxy);
+
+  // Gate detection (B2-PR1 of #1359) — fact-only CAPTCHA/auth gate detection
+  registerOcGateInspectTool(proxy);
 
   // Action schema normalizer (#1062) — no browser side effects.
   registerOcNormalizeActionTool(server);

--- a/src/tools/oc-evidence-bundle.ts
+++ b/src/tools/oc-evidence-bundle.ts
@@ -48,6 +48,8 @@ interface SnapshotInput {
   network?: NetworkEntry[];
   console?: ConsoleEntry[];
   now_ms?: number;
+  /** Caller-supplied gate fact (typically the oc_gate_inspect output). */
+  gate?: Record<string, unknown>;
 }
 
 const VALID_PARTS: readonly EvidenceBundlePart[] = [
@@ -56,6 +58,7 @@ const VALID_PARTS: readonly EvidenceBundlePart[] = [
   'network',
   'console',
   'phash',
+  'gate',
 ];
 
 const definition: MCPToolDefinition = {
@@ -74,7 +77,7 @@ const definition: MCPToolDefinition = {
         type: 'array',
         description:
           "Which parts to capture. Default ['dom', 'screenshot']. Allowed " +
-          "items: 'dom' | 'screenshot' | 'network' | 'console' | 'phash'.",
+          "items: 'dom' | 'screenshot' | 'network' | 'console' | 'phash' | 'gate'.",
         items: {
           type: 'string',
           enum: VALID_PARTS as unknown as string[],
@@ -90,7 +93,7 @@ const definition: MCPToolDefinition = {
         type: 'object',
         description:
           'Caller-supplied snapshot. Provide the subset of fields the requested ' +
-          'parts need: `dom`, `screenshot_png_base64`, `network`, `console`, `now_ms`. ' +
+          'parts need: `dom`, `screenshot_png_base64`, `network`, `console`, `now_ms`, `gate`. ' +
           'Missing fields cause the corresponding part to be omitted gracefully.',
         properties: {
           snapshot: {
@@ -98,7 +101,7 @@ const definition: MCPToolDefinition = {
             description:
               'Snapshot fields. `dom` (string|object), `screenshot_png_base64` (base64 PNG), ' +
               '`network` (NetworkEntry[]), `console` (ConsoleEntry[]), `now_ms` (epoch ms ' +
-              'used for the network window cutoff).',
+              'used for the network window cutoff), `gate` (oc_gate_inspect-compatible fact).',
           },
         },
       },
@@ -129,6 +132,13 @@ function buildSnapshot(input: SnapshotInput | undefined): EvidenceBundleSnapshot
   if (Array.isArray(input.network)) out.network = input.network;
   if (Array.isArray(input.console)) out.console = input.console;
   if (typeof input.now_ms === 'number') out.now_ms = input.now_ms;
+  if (input.gate && typeof input.gate === 'object') {
+    // Shallow-copy through with `unknown` shape; the bundle writer is
+    // schema-neutral and persists the JSON verbatim. The MCP tool surface
+    // intentionally avoids re-importing oc_gate_inspect types so the
+    // bundle module stays I/O-only.
+    out.gate = input.gate as unknown as EvidenceBundleSnapshot['gate'];
+  }
   return out;
 }
 

--- a/src/tools/oc-gate-inspect.ts
+++ b/src/tools/oc-gate-inspect.ts
@@ -1,25 +1,29 @@
 /**
- * oc_gate_inspect — fact-only gate detection (B2-PR1 of #1359).
+ * oc_gate_inspect — fact-only gate detection.
  *
- * Inspect the current tab for a *gate* — today, one of the CAPTCHA flavors
- * understood by `src/captcha/detect.ts`. Returns a structured fact record
- * describing what is present on the page; it **never** invokes any solver,
+ * Inspect the current tab for a *gate* and return a structured fact record
+ * describing what is present on the page. It **never** invokes any solver,
  * makes any third-party HTTP call, or asserts anything beyond what the DOM
  * directly observes.
  *
- * This is the host-side counterpart of #1359 Pillar C (facts before
- * decisions). The host agent reads the fact and decides:
+ * Gate families detected (B2-PR1 + B2-PR2 of #1359):
  *
- *   - retry / back off,
- *   - ask the user to solve it interactively,
- *   - hand off to an external solver under the host's own credentials,
- *   - or give up and report the gate to the caller.
+ *   - `captcha`  — reCAPTCHA v2/v3, hCaptcha, Cloudflare Turnstile, AWS WAF.
+ *   - `sso`      — redirect to a known identity provider OR a generic SSO
+ *                  path (`/sso`, `/saml`, `/oauth`, `/openid`, `/authorize`).
+ *   - `paywall`  — visible subscription/metered-content overlay.
+ *   - `2fa`      — OTP / one-time-code input is foreground.
  *
- * Future PRs in the B2 thread extend the gate vocabulary (SSO redirect,
- * basic-auth, 2FA prompt, paywall). The tool name and output shape are
- * designed to absorb those additions without a breaking change — new
- * `gateType` values are simply added to the union, and `kind` discriminates
- * whether the gate is a captcha (sitekey present) or a different family.
+ * Detection order is captcha → SSO → paywall → 2FA. The first positive
+ * signal wins. Multiple gates can be present in practice, but the host
+ * almost always reasons about them in that order anyway.
+ *
+ * Known gap: HTTP Basic auth is not detected here — it is a native browser
+ * dialog with no DOM hook. Network-layer detection (401 status +
+ * `WWW-Authenticate: Basic` header) is out of scope for this PR.
+ *
+ * Host-agent counterpart of #1359 Pillar C (facts before decisions). The
+ * host reads the fact and decides what to do next.
  */
 
 import { MCPServer } from '../mcp-server';
@@ -27,32 +31,47 @@ import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { detectCaptcha } from '../captcha/detect';
+import {
+  detectNonCaptchaGate,
+  type NonCaptchaGateKind,
+  type SsoProvider,
+} from '../gates/detect-other-gates';
 import type { CaptchaType } from '../types/captcha';
 
 /**
- * High-level family of gate. Today only `captcha` is detected; the schema is
- * stable for the SSO/basic-auth/paywall extensions that land in B2-PR2.
+ * High-level family of gate. Closed union; adding a value is a non-breaking
+ * change. Removing or renaming requires a tool version bump.
  */
-export type GateKind = 'captcha';
+export type GateKind = 'captcha' | NonCaptchaGateKind;
 
 /**
- * Closed gate-type vocabulary. Adding a value here is a non-breaking change;
- * removing or renaming requires a tool version bump.
+ * Closed gate-type vocabulary. Adding a value is non-breaking.
  */
-export type GateType = CaptchaType;
+export type GateType = CaptchaType | 'sso_redirect' | 'paywall' | 'two_factor';
 
 export interface OcGateInspectOutput {
   detected: boolean;
   /** The gate family. Absent iff `detected === false`. */
   kind?: GateKind;
-  /** Specific gate type (captcha flavor today). Absent iff `detected === false`. */
+  /** Specific gate type. Absent iff `detected === false`. */
   gateType?: GateType;
+
+  // ── captcha-only ──────────────────────────────────────────────────────
   /** Captcha site key. Only present when a site key was extractable. */
   siteKey?: string;
   /** Provenance of the site key: which signal the detector read. */
   siteKeySource?: 'attribute' | 'script' | 'iframe';
-  /** Whether the gate is invisible/background (captcha v3, invisible v2). */
+  /** Whether the captcha is invisible/background (v3, invisible v2). */
   invisible?: boolean;
+
+  // ── sso-only ──────────────────────────────────────────────────────────
+  /** Identity provider name. Only present when kind === 'sso'. */
+  provider?: SsoProvider;
+
+  // ── paywall / 2fa ─────────────────────────────────────────────────────
+  /** CSS selector that triggered the paywall or 2fa match. */
+  selector?: string;
+
   /** The page URL observed at detection time. Always present. */
   pageUrl: string;
 }
@@ -60,10 +79,10 @@ export interface OcGateInspectOutput {
 const definition: MCPToolDefinition = {
   name: 'oc_gate_inspect',
   description:
-    'Detect whether the current tab is gated (CAPTCHA today; SSO/basic-auth/' +
-    'paywall in follow-up PRs). Returns facts only — never invokes any ' +
-    'solver, never makes a third-party HTTP call. The host agent decides ' +
-    'what to do next.',
+    'Detect whether the current tab is gated (CAPTCHA, SSO redirect, ' +
+    'paywall, 2FA prompt). Returns facts only — never invokes any solver, ' +
+    'never makes a third-party HTTP call, never bypasses the gate. The ' +
+    'host agent decides what to do next.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -133,23 +152,44 @@ const handler: ToolHandler = async (
     pageUrl = 'unknown';
   }
 
-  const detection = await detectCaptcha(page);
-  if (!detection) {
-    return toResult({ detected: false, pageUrl });
+  // 1. CAPTCHA takes priority — it overlays the page even if the
+  //    user is mid-SSO or behind a paywall, and the host typically
+  //    needs to deal with it first.
+  const captcha = await detectCaptcha(page);
+  if (captcha) {
+    const out: OcGateInspectOutput = {
+      detected: true,
+      kind: 'captcha',
+      gateType: captcha.captchaType,
+      invisible: captcha.invisible,
+      pageUrl: captcha.pageUrl || pageUrl,
+    };
+    if (captcha.siteKey) {
+      out.siteKey = captcha.siteKey.key;
+      out.siteKeySource = captcha.siteKey.source;
+    }
+    return toResult(out);
   }
 
-  const out: OcGateInspectOutput = {
-    detected: true,
-    kind: 'captcha',
-    gateType: detection.captchaType,
-    invisible: detection.invisible,
-    pageUrl: detection.pageUrl || pageUrl,
-  };
-  if (detection.siteKey) {
-    out.siteKey = detection.siteKey.key;
-    out.siteKeySource = detection.siteKey.source;
+  // 2. Non-CAPTCHA gates in priority order (sso → paywall → 2fa).
+  const other = await detectNonCaptchaGate(page);
+  if (other) {
+    const base: OcGateInspectOutput = {
+      detected: true,
+      kind: other.kind,
+      gateType: other.gateType,
+      pageUrl: other.pageUrl || pageUrl,
+    };
+    if (other.kind === 'sso') {
+      base.provider = other.provider;
+    } else {
+      base.selector = other.selector;
+    }
+    return toResult(base);
   }
-  return toResult(out);
+
+  // 3. No gate observed.
+  return toResult({ detected: false, pageUrl });
 };
 
 export function registerOcGateInspectTool(server: MCPServer): void {

--- a/src/tools/oc-gate-inspect.ts
+++ b/src/tools/oc-gate-inspect.ts
@@ -1,0 +1,140 @@
+/**
+ * oc_gate_inspect — fact-only gate detection (B2-PR1 of #1359).
+ *
+ * Inspect the current tab for a *gate* — today, one of the CAPTCHA flavors
+ * understood by `src/captcha/detect.ts`. Returns a structured fact record
+ * describing what is present on the page; it **never** invokes any solver,
+ * makes any third-party HTTP call, or asserts anything beyond what the DOM
+ * directly observes.
+ *
+ * This is the host-side counterpart of #1359 Pillar C (facts before
+ * decisions). The host agent reads the fact and decides:
+ *
+ *   - retry / back off,
+ *   - ask the user to solve it interactively,
+ *   - hand off to an external solver under the host's own credentials,
+ *   - or give up and report the gate to the caller.
+ *
+ * Future PRs in the B2 thread extend the gate vocabulary (SSO redirect,
+ * basic-auth, 2FA prompt, paywall). The tool name and output shape are
+ * designed to absorb those additions without a breaking change — new
+ * `gateType` values are simply added to the union, and `kind` discriminates
+ * whether the gate is a captcha (sitekey present) or a different family.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
+import { getSessionManager } from '../session-manager';
+import { detectCaptcha } from '../captcha/detect';
+import type { CaptchaType } from '../types/captcha';
+
+/**
+ * High-level family of gate. Today only `captcha` is detected; the schema is
+ * stable for the SSO/basic-auth/paywall extensions that land in B2-PR2.
+ */
+export type GateKind = 'captcha';
+
+/**
+ * Closed gate-type vocabulary. Adding a value here is a non-breaking change;
+ * removing or renaming requires a tool version bump.
+ */
+export type GateType = CaptchaType;
+
+export interface OcGateInspectOutput {
+  detected: boolean;
+  /** The gate family. Absent iff `detected === false`. */
+  kind?: GateKind;
+  /** Specific gate type (captcha flavor today). Absent iff `detected === false`. */
+  gateType?: GateType;
+  /** Captcha site key. Only present when a site key was extractable. */
+  siteKey?: string;
+  /** Provenance of the site key: which signal the detector read. */
+  siteKeySource?: 'attribute' | 'script' | 'iframe';
+  /** Whether the gate is invisible/background (captcha v3, invisible v2). */
+  invisible?: boolean;
+  /** The page URL observed at detection time. Always present. */
+  pageUrl: string;
+}
+
+const definition: MCPToolDefinition = {
+  name: 'oc_gate_inspect',
+  description:
+    'Detect whether the current tab is gated (CAPTCHA today; SSO/basic-auth/' +
+    'paywall in follow-up PRs). Returns facts only — never invokes any ' +
+    'solver, never makes a third-party HTTP call. The host agent decides ' +
+    'what to do next.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      tabId: {
+        type: 'string',
+        description: 'Tab ID to inspect. Required.',
+      },
+    },
+    required: ['tabId'],
+  },
+  annotations: TOOL_ANNOTATIONS.oc_gate_inspect,
+};
+
+function toResult(output: OcGateInspectOutput): MCPResult {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(output),
+      },
+    ],
+  };
+}
+
+const handler: ToolHandler = async (
+  sessionId: string,
+  args: Record<string, unknown>,
+): Promise<MCPResult> => {
+  const tabId = typeof args.tabId === 'string' ? args.tabId : '';
+  if (!tabId) {
+    return {
+      content: [{ type: 'text', text: 'Error: tabId is required' }],
+      isError: true,
+    };
+  }
+
+  const sessionManager = getSessionManager();
+  const page = await sessionManager.getPage(sessionId, tabId, undefined, 'oc_gate_inspect');
+  if (!page) {
+    return {
+      content: [{ type: 'text', text: `Error: Tab ${tabId} not found` }],
+      isError: true,
+    };
+  }
+
+  let pageUrl = 'unknown';
+  try {
+    pageUrl = page.url();
+  } catch {
+    pageUrl = 'unknown';
+  }
+
+  const detection = await detectCaptcha(page);
+  if (!detection) {
+    return toResult({ detected: false, pageUrl });
+  }
+
+  const out: OcGateInspectOutput = {
+    detected: true,
+    kind: 'captcha',
+    gateType: detection.captchaType,
+    invisible: detection.invisible,
+    pageUrl: detection.pageUrl || pageUrl,
+  };
+  if (detection.siteKey) {
+    out.siteKey = detection.siteKey.key;
+    out.siteKeySource = detection.siteKey.source;
+  }
+  return toResult(out);
+};
+
+export function registerOcGateInspectTool(server: MCPServer): void {
+  server.registerTool('oc_gate_inspect', handler, definition);
+}

--- a/src/tools/oc-gate-inspect.ts
+++ b/src/tools/oc-gate-inspect.ts
@@ -69,7 +69,7 @@ const definition: MCPToolDefinition = {
     properties: {
       tabId: {
         type: 'string',
-        description: 'Tab ID to inspect. Required.',
+        description: 'REQUIRED Tab ID to inspect.',
       },
     },
     required: ['tabId'],

--- a/src/tools/oc-gate-inspect.ts
+++ b/src/tools/oc-gate-inspect.ts
@@ -101,7 +101,24 @@ const handler: ToolHandler = async (
   }
 
   const sessionManager = getSessionManager();
-  const page = await sessionManager.getPage(sessionId, tabId, undefined, 'oc_gate_inspect');
+  let page;
+  try {
+    // getPage may throw on ownership mismatch or stale targets in addition
+    // to returning null when the tab is not found at all. Surface either
+    // failure mode as a structured isError result rather than letting it
+    // escape as an unhandled rejection.
+    page = await sessionManager.getPage(sessionId, tabId, undefined, 'oc_gate_inspect');
+  } catch (err) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Error: ${err instanceof Error ? err.message : String(err)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
   if (!page) {
     return {
       content: [{ type: 'text', text: `Error: Tab ${tabId} not found` }],

--- a/src/types/tool-annotations.ts
+++ b/src/types/tool-annotations.ts
@@ -83,6 +83,7 @@ export const TOOL_ANNOTATIONS = {
   oc_skill_export: READ_ONLY,
   vision_find: READ_ONLY,
   oc_assert: READ_ONLY,
+  oc_gate_inspect: READ_ONLY,
   oc_recording_list: READ_ONLY,
   oc_recording_status: READ_ONLY,
   workflow_status: READ_ONLY,

--- a/tests/core/contracts/evidence-bundle.test.ts
+++ b/tests/core/contracts/evidence-bundle.test.ts
@@ -144,6 +144,30 @@ describe('writeEvidenceBundle — individual include flags', () => {
     expect(payload.entries[49].text).toBe('line-249');
   });
 
+  test("include=['gate']: writes caller-supplied gate fact to gate.json", () => {
+    const rootDir = mkRoot();
+    const gate = {
+      detected: true,
+      kind: 'captcha',
+      gateType: 'turnstile',
+      siteKey: 'site-key-1',
+      siteKeySource: 'data-sitekey',
+      invisible: false,
+      provider: 'cloudflare',
+      selector: '#challenge',
+      pageUrl: 'https://example.test/login',
+    };
+    const result = writeEvidenceBundle({ gate }, { rootDir, include: ['gate'] });
+    expect(result.parts).toEqual(['gate.json']);
+    expect(readJson(path.join(result.path, 'gate.json'))).toEqual(gate);
+  });
+
+  test("include=['gate'] without a gate fact omits the part gracefully", () => {
+    const rootDir = mkRoot();
+    const result = writeEvidenceBundle({}, { rootDir, include: ['gate'] });
+    expect(result.parts).toEqual([]);
+  });
+
   test("include=['phash']: writes a 16-char lowercase hex digest", () => {
     const rootDir = mkRoot();
     const png = encodeRgbaPng(32, 32, gradientRgba(32, 32));

--- a/tests/gates/detect-other-gates.test.ts
+++ b/tests/gates/detect-other-gates.test.ts
@@ -1,0 +1,166 @@
+/// <reference types="jest" />
+
+/**
+ * Unit tests for src/gates/detect-other-gates.ts (B2-PR2 of #1359).
+ *
+ * Each detector is fact-only: no network, no judgment. The tests pin the
+ * heuristics that the broader oc_gate_inspect composer depends on.
+ */
+
+import {
+  detectSsoSignalFromUrl,
+  detectSso,
+  detectPaywall,
+  detectTwoFactor,
+  detectNonCaptchaGate,
+} from '../../src/gates/detect-other-gates';
+
+function makePage(url: string, evalImpl: (fn: any, ...args: any[]) => any): any {
+  return {
+    url: () => url,
+    evaluate: jest.fn(async (fn: any, ...args: any[]) => evalImpl(fn, ...args)),
+  };
+}
+
+describe('detectSsoSignalFromUrl', () => {
+  test('returns null for empty / invalid URLs', () => {
+    expect(detectSsoSignalFromUrl('')).toBeNull();
+    expect(detectSsoSignalFromUrl('not a url')).toBeNull();
+    expect(detectSsoSignalFromUrl(null as unknown as string)).toBeNull();
+  });
+
+  test('matches Microsoft, Google, Okta, Auth0, GitHub, Apple', () => {
+    expect(detectSsoSignalFromUrl('https://login.microsoftonline.com/common/oauth2/authorize')?.provider).toBe('microsoft');
+    expect(detectSsoSignalFromUrl('https://accounts.google.com/o/oauth2/v2/auth')?.provider).toBe('google');
+    expect(detectSsoSignalFromUrl('https://acme.okta.com/sso/saml')?.provider).toBe('okta');
+    expect(detectSsoSignalFromUrl('https://acme.auth0.com/authorize')?.provider).toBe('auth0');
+    expect(detectSsoSignalFromUrl('https://github.com/login/oauth/authorize')?.provider).toBe('github');
+    expect(detectSsoSignalFromUrl('https://appleid.apple.com/auth/authorize')?.provider).toBe('apple');
+  });
+
+  test('generic SSO path hints surface as provider="generic"', () => {
+    expect(detectSsoSignalFromUrl('https://corp.example.com/sso/login')?.provider).toBe('generic');
+    expect(detectSsoSignalFromUrl('https://example.com/oauth2/authorize?client_id=x')?.provider).toBe('generic');
+    expect(detectSsoSignalFromUrl('https://example.com/auth/realms/test/login-actions')?.provider).toBe('generic');
+  });
+
+  test('non-SSO URLs return null', () => {
+    expect(detectSsoSignalFromUrl('https://example.com/')).toBeNull();
+    expect(detectSsoSignalFromUrl('https://example.com/articles/123')).toBeNull();
+  });
+
+  test('returned signal carries kind, gateType, pageUrl', () => {
+    const s = detectSsoSignalFromUrl('https://accounts.google.com/o/oauth2/v2/auth');
+    expect(s?.kind).toBe('sso');
+    expect(s?.gateType).toBe('sso_redirect');
+    expect(s?.pageUrl).toBe('https://accounts.google.com/o/oauth2/v2/auth');
+  });
+});
+
+describe('detectSso (page)', () => {
+  test('reads page.url() and runs the URL heuristic', async () => {
+    const page = makePage('https://accounts.google.com/signin', () => null);
+    const out = await detectSso(page);
+    expect(out?.provider).toBe('google');
+  });
+
+  test('returns null when the page URL throws', async () => {
+    const page = { url: () => { throw new Error('detached'); } };
+    expect(await detectSso(page as any)).toBeNull();
+  });
+});
+
+describe('detectPaywall', () => {
+  test('returns signal when probe matches a selector', async () => {
+    const page = makePage('https://news.example.com/article', () => ({ selector: '.paywall' }));
+    const out = await detectPaywall(page);
+    expect(out).toEqual({
+      kind: 'paywall',
+      gateType: 'paywall',
+      selector: '.paywall',
+      pageUrl: 'https://news.example.com/article',
+    });
+  });
+
+  test('returns null when probe finds nothing', async () => {
+    const page = makePage('https://news.example.com/article', () => null);
+    expect(await detectPaywall(page)).toBeNull();
+  });
+
+  test('returns null and does not throw if evaluate throws', async () => {
+    const page = {
+      url: () => 'https://example.com',
+      evaluate: jest.fn(async () => { throw new Error('boom'); }),
+    };
+    expect(await detectPaywall(page as any)).toBeNull();
+  });
+});
+
+describe('detectTwoFactor', () => {
+  test('returns signal when probe finds an OTP input', async () => {
+    const page = makePage('https://example.com/login/verify', () => ({
+      selector: 'input[autocomplete="one-time-code"]',
+    }));
+    const out = await detectTwoFactor(page);
+    expect(out).toEqual({
+      kind: '2fa',
+      gateType: 'two_factor',
+      selector: 'input[autocomplete="one-time-code"]',
+      pageUrl: 'https://example.com/login/verify',
+    });
+  });
+
+  test('returns null when probe finds nothing', async () => {
+    const page = makePage('https://example.com/', () => null);
+    expect(await detectTwoFactor(page)).toBeNull();
+  });
+});
+
+describe('detectNonCaptchaGate — priority composer', () => {
+  test('SSO wins over paywall / 2fa', async () => {
+    const page = {
+      url: () => 'https://accounts.google.com/signin',
+      evaluate: jest.fn(),
+    };
+    const out = await detectNonCaptchaGate(page as any);
+    expect(out?.kind).toBe('sso');
+    expect(page.evaluate).not.toHaveBeenCalled();
+  });
+
+  test('paywall wins over 2fa when there is no SSO', async () => {
+    let call = 0;
+    const page = {
+      url: () => 'https://news.example.com/article',
+      evaluate: jest.fn(async () => {
+        call += 1;
+        if (call === 1) return { selector: '.paywall' };
+        return null;
+      }),
+    };
+    const out = await detectNonCaptchaGate(page as any);
+    expect(out?.kind).toBe('paywall');
+  });
+
+  test('2fa is the last fallback', async () => {
+    let call = 0;
+    const page = {
+      url: () => 'https://example.com/verify',
+      evaluate: jest.fn(async () => {
+        call += 1;
+        // 1st: paywall probe → null. 2nd: 2fa probe → match.
+        if (call === 1) return null;
+        return { selector: 'input[name="otp"]' };
+      }),
+    };
+    const out = await detectNonCaptchaGate(page as any);
+    expect(out?.kind).toBe('2fa');
+  });
+
+  test('returns null when nothing matches', async () => {
+    const page = {
+      url: () => 'https://example.com/',
+      evaluate: jest.fn(async () => null),
+    };
+    expect(await detectNonCaptchaGate(page as any)).toBeNull();
+  });
+});

--- a/tests/tools/oc-gate-inspect.test.ts
+++ b/tests/tools/oc-gate-inspect.test.ts
@@ -1,0 +1,246 @@
+/// <reference types="jest" />
+
+/**
+ * Unit tests for the oc_gate_inspect MCP tool (B2-PR1 of #1359).
+ *
+ * Covers:
+ *  - registration shape (name, annotations, required input)
+ *  - facts-only output when no gate is present
+ *  - facts-only output when a captcha gate IS present (each captcha type)
+ *  - tabId validation and missing-page error path
+ *  - P7 invariant: no CAPTCHA solver provider module is loaded
+ */
+
+import type { MCPToolDefinition, MCPResult, ToolHandler } from '../../src/types/mcp';
+
+const PROVIDER_MODULE_KEYS = [
+  '/captcha/providers/twocaptcha',
+  '/captcha/providers/anticaptcha',
+  '/captcha/providers/capsolver',
+];
+
+function providerModulesInRequireCache(): string[] {
+  return Object.keys(require.cache).filter(k =>
+    PROVIDER_MODULE_KEYS.some(suffix => k.includes(suffix)),
+  );
+}
+
+// ─── Test harness ──────────────────────────────────────────────────────────
+
+interface RegisteredTool {
+  name: string;
+  handler: ToolHandler;
+  definition: MCPToolDefinition;
+}
+
+class MockServer {
+  public tools = new Map<string, RegisteredTool>();
+  registerTool(name: string, handler: ToolHandler, definition: MCPToolDefinition): void {
+    this.tools.set(name, { name, handler, definition });
+  }
+}
+
+function parseResult(result: MCPResult): Record<string, unknown> {
+  const text = result.content?.[0]?.text;
+  expect(typeof text).toBe('string');
+  return JSON.parse(text as string) as Record<string, unknown>;
+}
+
+// ─── Module mocks ──────────────────────────────────────────────────────────
+
+const mockGetPage = jest.fn();
+const mockDetectCaptcha = jest.fn();
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: () => ({ getPage: mockGetPage }),
+}));
+
+jest.mock('../../src/captcha/detect', () => ({
+  detectCaptcha: (...args: unknown[]) => mockDetectCaptcha(...args),
+}));
+
+function loadHandler(): {
+  handler: ToolHandler;
+  definition: MCPToolDefinition;
+} {
+  jest.isolateModules(() => {
+    /* nothing — required to ensure the mocks above are in scope when the tool is loaded */
+  });
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { registerOcGateInspectTool } = require('../../src/tools/oc-gate-inspect');
+  const server = new MockServer();
+  registerOcGateInspectTool(server as unknown as Parameters<typeof registerOcGateInspectTool>[0]);
+  const registered = server.tools.get('oc_gate_inspect');
+  if (!registered) throw new Error('tool was not registered');
+  return { handler: registered.handler, definition: registered.definition };
+}
+
+function makeFakePage(url: string) {
+  return { url: () => url };
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('oc_gate_inspect — registration', () => {
+  beforeEach(() => {
+    mockGetPage.mockReset();
+    mockDetectCaptcha.mockReset();
+  });
+
+  test('registers a tool named oc_gate_inspect with tabId required and read-only annotations', () => {
+    const { definition } = loadHandler();
+    expect(definition.name).toBe('oc_gate_inspect');
+    expect(definition.inputSchema.type).toBe('object');
+    expect(definition.inputSchema.required).toEqual(['tabId']);
+    // READ_ONLY: not destructive, not open-world, idempotent or readOnlyHint true.
+    expect(definition.annotations?.readOnlyHint).toBe(true);
+    expect(definition.annotations?.destructiveHint).toBe(false);
+    expect(definition.annotations?.openWorldHint).toBe(false);
+  });
+});
+
+describe('oc_gate_inspect — facts-only output', () => {
+  beforeEach(() => {
+    mockGetPage.mockReset();
+    mockDetectCaptcha.mockReset();
+  });
+
+  test('no gate present → {detected: false, pageUrl}', async () => {
+    const { handler } = loadHandler();
+    mockGetPage.mockResolvedValue(makeFakePage('https://example.com/'));
+    mockDetectCaptcha.mockResolvedValue(null);
+
+    const result = await handler('sess-1', { tabId: 'tab-1' });
+    const out = parseResult(result);
+
+    expect(out).toEqual({ detected: false, pageUrl: 'https://example.com/' });
+  });
+
+  test('captcha present → kind + gateType + invisible + siteKey + source', async () => {
+    const { handler } = loadHandler();
+    mockGetPage.mockResolvedValue(makeFakePage('https://example.com/'));
+    mockDetectCaptcha.mockResolvedValue({
+      detected: true,
+      captchaType: 'recaptcha_v2',
+      siteKey: { key: 'site-key-abc', source: 'attribute' },
+      invisible: false,
+      pageUrl: 'https://example.com/',
+    });
+
+    const result = await handler('sess-1', { tabId: 'tab-1' });
+    const out = parseResult(result);
+
+    expect(out).toEqual({
+      detected: true,
+      kind: 'captcha',
+      gateType: 'recaptcha_v2',
+      siteKey: 'site-key-abc',
+      siteKeySource: 'attribute',
+      invisible: false,
+      pageUrl: 'https://example.com/',
+    });
+  });
+
+  test('captcha v3 (invisible, no site key) is reported without siteKey fields', async () => {
+    const { handler } = loadHandler();
+    mockGetPage.mockResolvedValue(makeFakePage('https://example.com/'));
+    mockDetectCaptcha.mockResolvedValue({
+      detected: true,
+      captchaType: 'recaptcha_v3',
+      invisible: true,
+      pageUrl: 'https://example.com/',
+    });
+
+    const result = await handler('sess-1', { tabId: 'tab-1' });
+    const out = parseResult(result);
+
+    expect(out.detected).toBe(true);
+    expect(out.kind).toBe('captcha');
+    expect(out.gateType).toBe('recaptcha_v3');
+    expect(out.invisible).toBe(true);
+    expect('siteKey' in out).toBe(false);
+    expect('siteKeySource' in out).toBe(false);
+  });
+
+  test('aws_waf with no extractable site key is still reported', async () => {
+    const { handler } = loadHandler();
+    mockGetPage.mockResolvedValue(makeFakePage('https://example.com/'));
+    mockDetectCaptcha.mockResolvedValue({
+      detected: true,
+      captchaType: 'aws_waf',
+      invisible: false,
+      pageUrl: 'https://example.com/',
+    });
+
+    const result = await handler('sess-1', { tabId: 'tab-1' });
+    const out = parseResult(result);
+
+    expect(out.detected).toBe(true);
+    expect(out.gateType).toBe('aws_waf');
+    expect('siteKey' in out).toBe(false);
+  });
+});
+
+describe('oc_gate_inspect — input validation', () => {
+  beforeEach(() => {
+    mockGetPage.mockReset();
+    mockDetectCaptcha.mockReset();
+  });
+
+  test('missing tabId returns an error result and never calls getPage', async () => {
+    const { handler } = loadHandler();
+
+    const result = await handler('sess-1', {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text).toMatch(/tabId is required/i);
+    expect(mockGetPage).not.toHaveBeenCalled();
+    expect(mockDetectCaptcha).not.toHaveBeenCalled();
+  });
+
+  test('tabId of wrong type returns an error', async () => {
+    const { handler } = loadHandler();
+
+    const result = await handler('sess-1', { tabId: 123 as unknown as string });
+
+    expect(result.isError).toBe(true);
+    expect(mockDetectCaptcha).not.toHaveBeenCalled();
+  });
+
+  test('page-not-found returns an error result', async () => {
+    const { handler } = loadHandler();
+    mockGetPage.mockResolvedValue(null);
+
+    const result = await handler('sess-1', { tabId: 'tab-missing' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text).toMatch(/not found/i);
+    expect(mockDetectCaptcha).not.toHaveBeenCalled();
+  });
+});
+
+describe('oc_gate_inspect — P7 invariant', () => {
+  beforeEach(() => {
+    mockGetPage.mockReset();
+    mockDetectCaptcha.mockReset();
+  });
+
+  test('inspecting a captcha-gated page does NOT load any solver provider module', async () => {
+    const before = providerModulesInRequireCache();
+
+    const { handler } = loadHandler();
+    mockGetPage.mockResolvedValue(makeFakePage('https://example.com/'));
+    mockDetectCaptcha.mockResolvedValue({
+      detected: true,
+      captchaType: 'hcaptcha',
+      siteKey: { key: 'k', source: 'attribute' },
+      invisible: false,
+      pageUrl: 'https://example.com/',
+    });
+
+    await handler('sess-1', { tabId: 'tab-1' });
+
+    const after = providerModulesInRequireCache();
+    expect(after).toEqual(before);
+  });
+});

--- a/tests/tools/oc-gate-inspect.test.ts
+++ b/tests/tools/oc-gate-inspect.test.ts
@@ -50,6 +50,7 @@ function parseResult(result: MCPResult): Record<string, unknown> {
 
 const mockGetPage = jest.fn();
 const mockDetectCaptcha = jest.fn();
+const mockDetectNonCaptchaGate = jest.fn();
 
 jest.mock('../../src/session-manager', () => ({
   getSessionManager: () => ({ getPage: mockGetPage }),
@@ -57,6 +58,10 @@ jest.mock('../../src/session-manager', () => ({
 
 jest.mock('../../src/captcha/detect', () => ({
   detectCaptcha: (...args: unknown[]) => mockDetectCaptcha(...args),
+}));
+
+jest.mock('../../src/gates/detect-other-gates', () => ({
+  detectNonCaptchaGate: (...args: unknown[]) => mockDetectNonCaptchaGate(...args),
 }));
 
 function loadHandler(): {
@@ -85,6 +90,8 @@ describe('oc_gate_inspect — registration', () => {
   beforeEach(() => {
     mockGetPage.mockReset();
     mockDetectCaptcha.mockReset();
+    mockDetectNonCaptchaGate.mockReset();
+    mockDetectNonCaptchaGate.mockResolvedValue(null);
   });
 
   test('registers a tool named oc_gate_inspect with tabId required and read-only annotations', () => {
@@ -103,6 +110,8 @@ describe('oc_gate_inspect — facts-only output', () => {
   beforeEach(() => {
     mockGetPage.mockReset();
     mockDetectCaptcha.mockReset();
+    mockDetectNonCaptchaGate.mockReset();
+    mockDetectNonCaptchaGate.mockResolvedValue(null);
   });
 
   test('no gate present → {detected: false, pageUrl}', async () => {
@@ -185,6 +194,8 @@ describe('oc_gate_inspect — input validation', () => {
   beforeEach(() => {
     mockGetPage.mockReset();
     mockDetectCaptcha.mockReset();
+    mockDetectNonCaptchaGate.mockReset();
+    mockDetectNonCaptchaGate.mockResolvedValue(null);
   });
 
   test('missing tabId returns an error result and never calls getPage', async () => {
@@ -223,6 +234,8 @@ describe('oc_gate_inspect — P7 invariant', () => {
   beforeEach(() => {
     mockGetPage.mockReset();
     mockDetectCaptcha.mockReset();
+    mockDetectNonCaptchaGate.mockReset();
+    mockDetectNonCaptchaGate.mockResolvedValue(null);
   });
 
   test('requiring the tool module does NOT statically load any solver provider', async () => {
@@ -288,5 +301,122 @@ describe('oc_gate_inspect — error propagation', () => {
     expect(out.detected).toBe(true);
     expect(out.kind).toBe('captcha');
     expect('gateType' in out).toBe(false);
+  });
+});
+
+// ─── B2-PR2: non-CAPTCHA gates ────────────────────────────────────────────
+
+describe('oc_gate_inspect — non-CAPTCHA gates', () => {
+  beforeEach(() => {
+    mockGetPage.mockReset();
+    mockDetectCaptcha.mockReset();
+    mockDetectNonCaptchaGate.mockReset();
+    mockDetectCaptcha.mockResolvedValue(null);
+  });
+
+  test('SSO redirect → kind=sso, gateType=sso_redirect, provider exposed', async () => {
+    const { handler } = loadHandler();
+    mockGetPage.mockResolvedValue(makeFakePage('https://accounts.google.com/signin'));
+    mockDetectNonCaptchaGate.mockResolvedValue({
+      kind: 'sso',
+      gateType: 'sso_redirect',
+      provider: 'google',
+      pageUrl: 'https://accounts.google.com/signin',
+    });
+
+    const result = await handler('sess-1', { tabId: 'tab-1' });
+    const out = parseResult(result);
+
+    expect(out).toEqual({
+      detected: true,
+      kind: 'sso',
+      gateType: 'sso_redirect',
+      provider: 'google',
+      pageUrl: 'https://accounts.google.com/signin',
+    });
+    expect('siteKey' in out).toBe(false);
+    expect('selector' in out).toBe(false);
+  });
+
+  test('paywall → kind=paywall, selector exposed', async () => {
+    const { handler } = loadHandler();
+    mockGetPage.mockResolvedValue(makeFakePage('https://news.example.com/article'));
+    mockDetectNonCaptchaGate.mockResolvedValue({
+      kind: 'paywall',
+      gateType: 'paywall',
+      selector: '.paywall',
+      pageUrl: 'https://news.example.com/article',
+    });
+
+    const result = await handler('sess-1', { tabId: 'tab-1' });
+    const out = parseResult(result);
+
+    expect(out).toEqual({
+      detected: true,
+      kind: 'paywall',
+      gateType: 'paywall',
+      selector: '.paywall',
+      pageUrl: 'https://news.example.com/article',
+    });
+    expect('provider' in out).toBe(false);
+  });
+
+  test('2fa → kind=2fa, selector exposed', async () => {
+    const { handler } = loadHandler();
+    mockGetPage.mockResolvedValue(makeFakePage('https://example.com/verify'));
+    mockDetectNonCaptchaGate.mockResolvedValue({
+      kind: '2fa',
+      gateType: 'two_factor',
+      selector: 'input[autocomplete="one-time-code"]',
+      pageUrl: 'https://example.com/verify',
+    });
+
+    const result = await handler('sess-1', { tabId: 'tab-1' });
+    const out = parseResult(result);
+
+    expect(out).toEqual({
+      detected: true,
+      kind: '2fa',
+      gateType: 'two_factor',
+      selector: 'input[autocomplete="one-time-code"]',
+      pageUrl: 'https://example.com/verify',
+    });
+  });
+
+  test('CAPTCHA takes priority over non-CAPTCHA gates when both signal', async () => {
+    const { handler } = loadHandler();
+    mockGetPage.mockResolvedValue(makeFakePage('https://example.com/'));
+    mockDetectCaptcha.mockResolvedValue({
+      detected: true,
+      captchaType: 'turnstile',
+      invisible: false,
+      pageUrl: 'https://example.com/',
+    });
+    // Non-CAPTCHA mock would also resolve to a signal, but should not be
+    // consulted once CAPTCHA is positive.
+    mockDetectNonCaptchaGate.mockResolvedValue({
+      kind: 'paywall',
+      gateType: 'paywall',
+      selector: '.paywall',
+      pageUrl: 'https://example.com/',
+    });
+
+    const result = await handler('sess-1', { tabId: 'tab-1' });
+    const out = parseResult(result);
+
+    expect(out.kind).toBe('captcha');
+    expect(out.gateType).toBe('turnstile');
+    expect(mockDetectNonCaptchaGate).not.toHaveBeenCalled();
+  });
+
+  test('nothing detected → {detected:false, pageUrl}', async () => {
+    const { handler } = loadHandler();
+    mockGetPage.mockResolvedValue(makeFakePage('https://example.com/'));
+    mockDetectNonCaptchaGate.mockResolvedValue(null);
+
+    const result = await handler('sess-1', { tabId: 'tab-1' });
+    const out = parseResult(result);
+
+    expect(out).toEqual({ detected: false, pageUrl: 'https://example.com/' });
   });
 });

--- a/tests/tools/oc-gate-inspect.test.ts
+++ b/tests/tools/oc-gate-inspect.test.ts
@@ -225,10 +225,21 @@ describe('oc_gate_inspect — P7 invariant', () => {
     mockDetectCaptcha.mockReset();
   });
 
-  test('inspecting a captcha-gated page does NOT load any solver provider module', async () => {
+  test('requiring the tool module does NOT statically load any solver provider', async () => {
+    // Snapshot the cache BEFORE loadHandler() so a hypothetical top-level
+    // `import ... from '../captcha/providers/foo'` in oc-gate-inspect.ts
+    // would land in `require.cache` between `before` and `afterLoad` and
+    // fail this assertion. Sampling only around handler() (as in the
+    // call-time assertion below) would let static imports escape.
     const before = providerModulesInRequireCache();
+    loadHandler();
+    const afterLoad = providerModulesInRequireCache();
+    expect(afterLoad).toEqual(before);
+  });
 
+  test('inspecting a captcha-gated page does NOT load any solver provider module at call time', async () => {
     const { handler } = loadHandler();
+    const beforeCall = providerModulesInRequireCache();
     mockGetPage.mockResolvedValue(makeFakePage('https://example.com/'));
     mockDetectCaptcha.mockResolvedValue({
       detected: true,
@@ -240,7 +251,42 @@ describe('oc_gate_inspect — P7 invariant', () => {
 
     await handler('sess-1', { tabId: 'tab-1' });
 
-    const after = providerModulesInRequireCache();
-    expect(after).toEqual(before);
+    const afterCall = providerModulesInRequireCache();
+    expect(afterCall).toEqual(beforeCall);
+  });
+});
+
+describe('oc_gate_inspect — error propagation', () => {
+  beforeEach(() => {
+    mockGetPage.mockReset();
+    mockDetectCaptcha.mockReset();
+  });
+
+  test('getPage throwing (ownership/stale-target) is surfaced as isError, not unhandled', async () => {
+    const { handler } = loadHandler();
+    mockGetPage.mockRejectedValue(new Error('Tab tab-1 belongs to a different session'));
+
+    const result = await handler('sess-1', { tabId: 'tab-1' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text).toMatch(/different session/);
+    expect(mockDetectCaptcha).not.toHaveBeenCalled();
+  });
+
+  test('detection without captchaType is reported as detected with kind=captcha but no gateType', async () => {
+    const { handler } = loadHandler();
+    mockGetPage.mockResolvedValue(makeFakePage('https://example.com/'));
+    mockDetectCaptcha.mockResolvedValue({
+      detected: true,
+      captchaType: undefined as unknown as 'unknown',
+      invisible: false,
+      pageUrl: 'https://example.com/',
+    });
+
+    const result = await handler('sess-1', { tabId: 'tab-1' });
+    const out = JSON.parse(result.content?.[0]?.text as string) as Record<string, unknown>;
+    expect(out.detected).toBe(true);
+    expect(out.kind).toBe('captcha');
+    expect('gateType' in out).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Expose `src/captcha/detect.ts` as a standalone Tier-1 MCP tool `oc_gate_inspect`. The tool returns a structured **fact** record describing whether the current tab is gated. It **never** invokes any solver, **never** makes a third-party HTTP call.

This is the host-side counterpart of #1359 Pillar C (facts before decisions). The host agent reads the fact and decides what to do (retry, ask the user, hand off to an external solver under host credentials, give up). OpenChrome itself stays out of the decision — preserving P2 (harness, not agent) and P7 (no third-party credentials at boot).

## Output shape (closed, additive)

```ts
{
  detected: boolean,
  kind?: 'captcha',                                  // future: 'sso' | 'basic-auth' | 'paywall'
  gateType?: 'recaptcha_v2' | 'recaptcha_v3' | 'hcaptcha' | 'turnstile' | 'aws_waf' | 'unknown',
  siteKey?: string,
  siteKeySource?: 'attribute' | 'script' | 'iframe',
  invisible?: boolean,
  pageUrl: string,
}
```

`kind` and `gateType` are open enough to absorb the SSO/basic-auth/paywall additions in **B2-PR2** without a breaking change.

## Wiring

- New `READ_ONLY` entry in `TOOL_ANNOTATIONS`.
- Registered in `registerAllTools()` with capability `'core'`.
- v1.11 tools-list snapshot extended to include the new tool name (the snapshot is the canonical baseline; the test `'tools/list matches v1.11.0 baseline snapshot'` still passes).

## #1359 decision-rule check

| Rule | Answer |
|---|---|
| Pillar | C (facts before decisions) |
| stdio/HTTP | both — read-only tool surface |
| Unknown clients | works (no optional capability) |
| Third-party credentials at boot | none — solver providers never load on this path |
| LLM judgment in host | yes — facts only |
| Real Chrome state | read-only (page.url + detector evaluate) |
| Portable artifact | yes — JSON shape |
| Host-specific behavior | none |

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx jest tests/tools/oc-gate-inspect.test.ts tests/capability-filter.test.ts tests/unit/tool-annotations.test.ts` — 33/33 passing, including:
  - registration shape, READ_ONLY flags
  - facts-only output: no gate; hcaptcha-with-sitekey; recaptcha v3 (invisible, no key); aws_waf (no key)
  - input validation: missing tabId, wrong type, page-not-found
  - P7 invariant: handling a captcha-gated page does NOT load any solver provider module into the require cache
  - existing snapshot baseline test still passes with the new entry

## What this does NOT do

- Does not detect SSO redirect / basic-auth / 2FA / paywall — those land in **B2-PR2**.
- Does not extend `gateType` union beyond CAPTCHA flavors yet.
- Does not feed gate facts into evidence bundles — that's **B2-PR4** (depends on A3-PR3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)