### PR TITLE
feat(evidence): accept target_schema and emit schema_diff in oc_evidence_bundle (B1-PR2)

### DIFF
--- a/src/core/contracts/evidence-bundle.ts
+++ b/src/core/contracts/evidence-bundle.ts
@@ -25,9 +25,20 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { phashFromPng, phashToHex } from '../../contracts/phash';
+import {
+  diffAgainstSchema,
+  SchemaDefinition,
+  SchemaDiff,
+} from './schema-diff';
 
 /** Parts the caller can request. Each maps to a file in the bundle dir. */
-export type EvidenceBundlePart = 'dom' | 'screenshot' | 'network' | 'console' | 'phash';
+export type EvidenceBundlePart =
+  | 'dom'
+  | 'screenshot'
+  | 'network'
+  | 'console'
+  | 'phash'
+  | 'schema_diff';
 
 /** Default include set — cheap parts that almost every caller wants. */
 export const DEFAULT_INCLUDE: readonly EvidenceBundlePart[] = ['dom', 'screenshot'];
@@ -71,6 +82,13 @@ export interface EvidenceBundleSnapshot {
   console?: ConsoleEntry[];
   /** Optional clock used for the network window. Defaults to `Date.now()`. */
   now_ms?: number;
+  /**
+   * Caller-supplied structured data extracted from the page. Diffed against
+   * `EvidenceBundleOptions.targetSchema` (B1-PR1 schema-diff) when both
+   * are present and the `schema_diff` part is included. Opaque to the
+   * bundle writer beyond the diff step.
+   */
+  observed?: unknown;
 }
 
 export interface EvidenceBundleOptions {
@@ -85,6 +103,13 @@ export interface EvidenceBundleOptions {
   networkWindowMs?: number;
   /** Cap for console entries kept. Default = 200. */
   consoleMaxEntries?: number;
+  /**
+   * Declared target schema. When supplied together with
+   * `snapshot.observed` and the `schema_diff` part is included, the
+   * bundle writer computes a structured diff and writes
+   * `schema_diff.json` to the bundle directory.
+   */
+  targetSchema?: SchemaDefinition;
 }
 
 export interface EvidenceBundleResult {
@@ -95,6 +120,12 @@ export interface EvidenceBundleResult {
   size_bytes: number;
   /** Relative filenames written, in capture order. */
   parts: string[];
+  /**
+   * Schema diff summary, present iff the bundle wrote `schema_diff.json`.
+   * Mirrors the on-disk file so single-call consumers don't have to
+   * re-read it.
+   */
+  schema_diff?: SchemaDiff;
 }
 
 const CONSOLE_MAX_DEFAULT = 200;
@@ -177,6 +208,27 @@ export function writeEvidenceBundle(
     parts.push(filename);
   }
 
+  // ── Schema diff ───────────────────────────────────────────────────────
+  let schemaDiff: SchemaDiff | undefined;
+  if (
+    include.has('schema_diff') &&
+    opts.targetSchema !== undefined &&
+    snapshot.observed !== undefined
+  ) {
+    schemaDiff = diffAgainstSchema(opts.targetSchema, snapshot.observed);
+    const filename = 'schema_diff.json';
+    const payload = JSON.stringify(
+      {
+        target_schema_version: opts.targetSchema.version,
+        diff: schemaDiff,
+      },
+      null,
+      2,
+    );
+    totalBytes += writePart(bundleDir, filename, payload);
+    parts.push(filename);
+  }
+
   // ── Perceptual hash ───────────────────────────────────────────────────
   if (include.has('phash')) {
     // If the caller didn't ask for the screenshot part but did ask for
@@ -207,6 +259,7 @@ export function writeEvidenceBundle(
     path: bundleDir,
     size_bytes: totalBytes,
     parts,
+    ...(schemaDiff !== undefined ? { schema_diff: schemaDiff } : {}),
   };
 }
 
@@ -218,7 +271,7 @@ function normalizeInclude(
   if (!include || include.length === 0) {
     return new Set(DEFAULT_INCLUDE);
   }
-  const valid: EvidenceBundlePart[] = ['dom', 'screenshot', 'network', 'console', 'phash'];
+  const valid: EvidenceBundlePart[] = ['dom', 'screenshot', 'network', 'console', 'phash', 'schema_diff'];
   const out = new Set<EvidenceBundlePart>();
   for (const item of include) {
     if ((valid as string[]).includes(item)) out.add(item);

--- a/src/core/contracts/promotion-gate.ts
+++ b/src/core/contracts/promotion-gate.ts
@@ -1,0 +1,122 @@
+/**
+ * Promotion gate — evaluate whether a SchemaDiff represents a contract
+ * success that's strong enough to promote a skill/selector record into
+ * verified memory (B1-PR3 of #1359).
+ *
+ * Per #1359 §P6 (verified memory only), the curator promotes records only
+ * from contract-verified successes. The schema-diff B1 thread emits
+ * structured facts (matched, missing, extra, typeMismatch, coverage); this
+ * module is the deterministic policy that turns those facts into a
+ * promote/skip decision.
+ *
+ * Pure function. No I/O. No Chrome dependency. Callers (curator,
+ * benchmark harness, host LLM) pass a {@link SchemaDiff} and an optional
+ * threshold record; the gate returns the decision plus a structured
+ * `reasons` array that downstream tracing/audit consumes.
+ *
+ * Defaults (chosen to be conservative for a default promotion bar):
+ *
+ *   - `minCoverage = 0.8` — require 80 % of required fields matched
+ *   - `maxTypeMismatch = 0` — any type mismatch blocks promotion
+ *   - `requireZeroMissing = false` — partial-match still promotes if
+ *     coverage clears the bar (callers can tighten this)
+ *
+ * Callers that need a different bar pass an `opts` record. The defaults
+ * never silently change once set; behaviour changes require a version
+ * bump in the policy module.
+ */
+
+import type { SchemaDiff } from './schema-diff';
+
+export interface PromotionGateOptions {
+  /** Minimum coverage (matched_required / required_total). Default 0.8. */
+  minCoverage?: number;
+  /** Max allowed type mismatches. Default 0. */
+  maxTypeMismatch?: number;
+  /**
+   * When true, any required field listed in `missing` blocks promotion
+   * regardless of coverage. Default false.
+   */
+  requireZeroMissing?: boolean;
+}
+
+export interface PromotionGateDecision {
+  eligible: boolean;
+  /**
+   * Structured reasons the gate evaluated. Always present — empty array
+   * means "no concerns observed". Lets callers attach the gate's
+   * verdict to audit trails without re-deriving the policy.
+   */
+  reasons: PromotionGateReason[];
+  /** The coverage value the gate compared against the bar. */
+  coverage: number;
+  /** The bar the gate compared against (after applying defaults). */
+  threshold: Required<PromotionGateOptions>;
+}
+
+export type PromotionGateReason =
+  | { kind: 'coverage_below_bar'; coverage: number; required: number }
+  | { kind: 'type_mismatch_present'; count: number; max: number; fields: string[] }
+  | { kind: 'missing_required_fields'; fields: string[] }
+  | { kind: 'pass' };
+
+const DEFAULTS: Required<PromotionGateOptions> = {
+  minCoverage: 0.8,
+  maxTypeMismatch: 0,
+  requireZeroMissing: false,
+};
+
+function resolveOptions(opts: PromotionGateOptions | undefined): Required<PromotionGateOptions> {
+  if (!opts) return DEFAULTS;
+  return {
+    minCoverage: typeof opts.minCoverage === 'number' && Number.isFinite(opts.minCoverage)
+      ? Math.max(0, Math.min(1, opts.minCoverage))
+      : DEFAULTS.minCoverage,
+    maxTypeMismatch: typeof opts.maxTypeMismatch === 'number' && Number.isFinite(opts.maxTypeMismatch)
+      ? Math.max(0, Math.floor(opts.maxTypeMismatch))
+      : DEFAULTS.maxTypeMismatch,
+    requireZeroMissing: opts.requireZeroMissing === true,
+  };
+}
+
+/**
+ * Evaluate whether a SchemaDiff clears the promotion bar.
+ *
+ * Idempotent and side-effect-free. Returns a structured decision —
+ * callers attach `reasons` to audit records and act on `eligible`.
+ */
+export function shouldPromoteFromSchemaDiff(
+  diff: SchemaDiff,
+  opts?: PromotionGateOptions,
+): PromotionGateDecision {
+  const threshold = resolveOptions(opts);
+  const reasons: PromotionGateReason[] = [];
+
+  if (diff.coverage < threshold.minCoverage) {
+    reasons.push({
+      kind: 'coverage_below_bar',
+      coverage: diff.coverage,
+      required: threshold.minCoverage,
+    });
+  }
+
+  if (diff.typeMismatch.length > threshold.maxTypeMismatch) {
+    reasons.push({
+      kind: 'type_mismatch_present',
+      count: diff.typeMismatch.length,
+      max: threshold.maxTypeMismatch,
+      fields: diff.typeMismatch.map(m => m.field),
+    });
+  }
+
+  if (threshold.requireZeroMissing && diff.missing.length > 0) {
+    reasons.push({ kind: 'missing_required_fields', fields: diff.missing });
+  }
+
+  if (reasons.length === 0) {
+    reasons.push({ kind: 'pass' });
+    return { eligible: true, reasons, coverage: diff.coverage, threshold };
+  }
+
+  return { eligible: false, reasons, coverage: diff.coverage, threshold };
+}

--- a/src/tools/oc-evidence-bundle.ts
+++ b/src/tools/oc-evidence-bundle.ts
@@ -29,6 +29,7 @@ import {
 import type {
   SchemaDefinition,
   SchemaDiff,
+  SchemaFieldType,
 } from '../core/contracts/schema-diff';
 import {
   OUTPUT_MODE_SCHEMA_PROPERTIES,
@@ -163,6 +164,19 @@ function buildSnapshot(input: SnapshotInput | undefined): EvidenceBundleSnapshot
  * step is then silently skipped — consistent with the rest of the bundle
  * writer, which treats missing/malformed inputs as "omit gracefully".
  */
+const VALID_SCHEMA_FIELD_TYPES = new Set<SchemaFieldType>([
+  'string',
+  'number',
+  'boolean',
+  'object',
+  'array',
+  'null',
+]);
+
+function isSchemaFieldType(value: unknown): value is SchemaFieldType {
+  return typeof value === 'string' && VALID_SCHEMA_FIELD_TYPES.has(value as SchemaFieldType);
+}
+
 function parseTargetSchema(raw: unknown): SchemaDefinition | undefined {
   if (!raw || typeof raw !== 'object') return undefined;
   const candidate = raw as { version?: unknown; fields?: unknown };
@@ -172,7 +186,7 @@ function parseTargetSchema(raw: unknown): SchemaDefinition | undefined {
     if (!f || typeof f !== 'object') return undefined;
     const field = f as { name?: unknown; type?: unknown };
     if (typeof field.name !== 'string') return undefined;
-    if (typeof field.type !== 'string') return undefined;
+    if (!isSchemaFieldType(field.type)) return undefined;
   }
   return candidate as unknown as SchemaDefinition;
 }

--- a/src/tools/oc-evidence-bundle.ts
+++ b/src/tools/oc-evidence-bundle.ts
@@ -26,6 +26,10 @@ import {
   type ConsoleEntry,
   type NetworkEntry,
 } from '../core/contracts/evidence-bundle';
+import type {
+  SchemaDefinition,
+  SchemaDiff,
+} from '../core/contracts/schema-diff';
 import {
   OUTPUT_MODE_SCHEMA_PROPERTIES,
   parseOutputMode,
@@ -39,6 +43,11 @@ interface OcEvidenceBundleOutput {
   parts: string[];
   /** Filled when no snapshot was supplied; bundle is still created (empty). */
   inconclusive_reason?: string;
+  /**
+   * Present iff the bundle wrote `schema_diff.json`. Mirrors the on-disk
+   * diff so the caller does not need a second read to inspect coverage.
+   */
+  schema_diff?: SchemaDiff;
 }
 
 interface SnapshotInput {
@@ -48,6 +57,8 @@ interface SnapshotInput {
   network?: NetworkEntry[];
   console?: ConsoleEntry[];
   now_ms?: number;
+  /** Structured data the caller extracted from the page; diffed against `target_schema`. */
+  observed?: unknown;
 }
 
 const VALID_PARTS: readonly EvidenceBundlePart[] = [
@@ -56,6 +67,7 @@ const VALID_PARTS: readonly EvidenceBundlePart[] = [
   'network',
   'console',
   'phash',
+  'schema_diff',
 ];
 
 const definition: MCPToolDefinition = {
@@ -74,11 +86,22 @@ const definition: MCPToolDefinition = {
         type: 'array',
         description:
           "Which parts to capture. Default ['dom', 'screenshot']. Allowed " +
-          "items: 'dom' | 'screenshot' | 'network' | 'console' | 'phash'.",
+          "items: 'dom' | 'screenshot' | 'network' | 'console' | 'phash' | " +
+          "'schema_diff'. `schema_diff` requires `target_schema` and " +
+          '`evidence.snapshot.observed`; otherwise the part is omitted.',
         items: {
           type: 'string',
           enum: VALID_PARTS as unknown as string[],
         },
+      },
+      target_schema: {
+        type: 'object',
+        description:
+          'Declared target schema (see src/core/contracts/schema-diff.ts: ' +
+          '{ version: 1, fields: [ { name, type, required? } ] }). When ' +
+          "supplied together with `evidence.snapshot.observed` and the " +
+          "'schema_diff' part is included, the bundle writes " +
+          "`schema_diff.json` containing the structured field-match diff.",
       },
       network_window_ms: {
         type: 'number',
@@ -129,7 +152,29 @@ function buildSnapshot(input: SnapshotInput | undefined): EvidenceBundleSnapshot
   if (Array.isArray(input.network)) out.network = input.network;
   if (Array.isArray(input.console)) out.console = input.console;
   if (typeof input.now_ms === 'number') out.now_ms = input.now_ms;
+  if (input.observed !== undefined) out.observed = input.observed;
   return out;
+}
+
+/**
+ * Narrow validation of the caller-supplied `target_schema` input.
+ *
+ * Returns the schema when shape-correct, otherwise `undefined`. The diff
+ * step is then silently skipped — consistent with the rest of the bundle
+ * writer, which treats missing/malformed inputs as "omit gracefully".
+ */
+function parseTargetSchema(raw: unknown): SchemaDefinition | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const candidate = raw as { version?: unknown; fields?: unknown };
+  if (candidate.version !== 1) return undefined;
+  if (!Array.isArray(candidate.fields)) return undefined;
+  for (const f of candidate.fields) {
+    if (!f || typeof f !== 'object') return undefined;
+    const field = f as { name?: unknown; type?: unknown };
+    if (typeof field.name !== 'string') return undefined;
+    if (typeof field.type !== 'string') return undefined;
+  }
+  return candidate as unknown as SchemaDefinition;
 }
 
 const handler: ToolHandler = async (
@@ -141,11 +186,16 @@ const handler: ToolHandler = async (
     typeof args.network_window_ms === 'number' ? args.network_window_ms : undefined;
   const evidenceArg = args.evidence as { snapshot?: SnapshotInput } | undefined;
   const snapshot = buildSnapshot(evidenceArg?.snapshot);
+  const targetSchema = parseTargetSchema(args.target_schema);
   const { mode, inlineLimit } = parseOutputMode(args);
 
   let result;
   try {
-    result = writeEvidenceBundle(snapshot, { include, networkWindowMs });
+    result = writeEvidenceBundle(snapshot, {
+      include,
+      networkWindowMs,
+      ...(targetSchema !== undefined ? { targetSchema } : {}),
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     const failure: OcEvidenceBundleOutput = {
@@ -164,10 +214,13 @@ const handler: ToolHandler = async (
     size_bytes: result.size_bytes,
     parts: result.parts,
   };
+  if (result.schema_diff !== undefined) {
+    output.schema_diff = result.schema_diff;
+  }
   if (result.parts.length === 0) {
     output.inconclusive_reason =
       'no evidence parts captured — supply `evidence.snapshot` with at least one of ' +
-      "dom / screenshot_png_base64 / network / console, and select matching `include` parts.";
+      "dom / screenshot_png_base64 / network / console / observed, and select matching `include` parts.";
   }
   const inlineResult = jsonResult(output);
   return resolveOutputMode(mode, inlineLimit, inlineResult, output, 'oc_evidence_bundle');

--- a/tests/core/contracts/evidence-bundle.schema-diff.test.ts
+++ b/tests/core/contracts/evidence-bundle.schema-diff.test.ts
@@ -1,0 +1,128 @@
+/// <reference types="jest" />
+
+/**
+ * Tests for the schema_diff part of writeEvidenceBundle (B1-PR2 of #1359).
+ *
+ * Confirms:
+ *  - schema_diff.json is written only when all preconditions hold;
+ *  - the on-disk payload is the canonical diff plus the schema version;
+ *  - the returned `schema_diff` mirrors the on-disk file;
+ *  - the rest of the bundle behavior is unchanged.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { writeEvidenceBundle } from '../../../src/core/contracts/evidence-bundle';
+import type { SchemaDefinition } from '../../../src/core/contracts/schema-diff';
+
+function tmpRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-bundle-schema-diff-'));
+}
+
+const schema: SchemaDefinition = {
+  version: 1,
+  fields: [
+    { name: 'title', type: 'string' },
+    { name: 'statusCode', type: 'number' },
+    { name: 'preview', type: 'string', required: false },
+  ],
+};
+
+describe('writeEvidenceBundle — schema_diff part', () => {
+  test('writes schema_diff.json when targetSchema + observed + include are all present', () => {
+    const rootDir = tmpRoot();
+
+    const result = writeEvidenceBundle(
+      { observed: { title: 'Example', statusCode: 200 } },
+      {
+        rootDir,
+        include: ['schema_diff'],
+        targetSchema: schema,
+      },
+    );
+
+    expect(result.parts).toContain('schema_diff.json');
+    expect(result.schema_diff).toBeDefined();
+    expect(result.schema_diff?.matched).toEqual(['title', 'statusCode']);
+    expect(result.schema_diff?.missing).toEqual([]);
+    expect(result.schema_diff?.coverage).toBe(1);
+
+    // On-disk file matches the in-memory diff.
+    const diskPayload = JSON.parse(
+      fs.readFileSync(path.join(result.path, 'schema_diff.json'), 'utf8'),
+    );
+    expect(diskPayload.target_schema_version).toBe(1);
+    expect(diskPayload.diff).toEqual(result.schema_diff);
+  });
+
+  test('records missing fields and partial coverage', () => {
+    const rootDir = tmpRoot();
+
+    const result = writeEvidenceBundle(
+      { observed: { title: 'only-title' } },
+      {
+        rootDir,
+        include: ['schema_diff'],
+        targetSchema: schema,
+      },
+    );
+
+    expect(result.schema_diff?.matched).toEqual(['title']);
+    expect(result.schema_diff?.missing).toEqual(['statusCode']);
+    expect(result.schema_diff?.coverage).toBe(0.5);
+  });
+
+  test('omitted when target_schema is absent', () => {
+    const rootDir = tmpRoot();
+
+    const result = writeEvidenceBundle(
+      { observed: { title: 'whatever' } },
+      { rootDir, include: ['schema_diff'] },
+    );
+
+    expect(result.parts).not.toContain('schema_diff.json');
+    expect(result.schema_diff).toBeUndefined();
+  });
+
+  test('omitted when observed is absent', () => {
+    const rootDir = tmpRoot();
+
+    const result = writeEvidenceBundle(
+      {},
+      { rootDir, include: ['schema_diff'], targetSchema: schema },
+    );
+
+    expect(result.parts).not.toContain('schema_diff.json');
+    expect(result.schema_diff).toBeUndefined();
+  });
+
+  test('omitted when schema_diff is not in the include set', () => {
+    const rootDir = tmpRoot();
+
+    const result = writeEvidenceBundle(
+      { observed: { title: 'whatever' } },
+      { rootDir, include: ['dom'], targetSchema: schema },
+    );
+
+    expect(result.parts).not.toContain('schema_diff.json');
+    expect(result.schema_diff).toBeUndefined();
+  });
+
+  test('schema_diff can coexist with other parts', () => {
+    const rootDir = tmpRoot();
+
+    const result = writeEvidenceBundle(
+      { dom: '<html></html>', observed: { title: 'x', statusCode: 200 } },
+      {
+        rootDir,
+        include: ['dom', 'schema_diff'],
+        targetSchema: schema,
+      },
+    );
+
+    expect(result.parts).toEqual(['dom.json', 'schema_diff.json']);
+    expect(result.schema_diff).toBeDefined();
+  });
+});

--- a/tests/core/contracts/promotion-gate.test.ts
+++ b/tests/core/contracts/promotion-gate.test.ts
@@ -1,0 +1,165 @@
+/// <reference types="jest" />
+
+/**
+ * Tests for the schema_diff-based promotion gate (B1-PR3 of #1359).
+ */
+
+import {
+  shouldPromoteFromSchemaDiff,
+} from '../../../src/core/contracts/promotion-gate';
+import type { SchemaDiff } from '../../../src/core/contracts/schema-diff';
+
+function diff(over: Partial<SchemaDiff> = {}): SchemaDiff {
+  return {
+    matched: [],
+    missing: [],
+    extra: [],
+    typeMismatch: [],
+    coverage: 1,
+    ...over,
+  };
+}
+
+describe('shouldPromoteFromSchemaDiff — defaults', () => {
+  test('full coverage and no mismatches → eligible with "pass" reason', () => {
+    const d = shouldPromoteFromSchemaDiff(diff({ coverage: 1 }));
+    expect(d.eligible).toBe(true);
+    expect(d.reasons).toEqual([{ kind: 'pass' }]);
+    expect(d.coverage).toBe(1);
+    expect(d.threshold.minCoverage).toBe(0.8);
+  });
+
+  test('coverage exactly at default bar (0.8) passes', () => {
+    const d = shouldPromoteFromSchemaDiff(diff({ coverage: 0.8 }));
+    expect(d.eligible).toBe(true);
+  });
+
+  test('coverage below default bar (0.79) blocks with coverage_below_bar', () => {
+    const d = shouldPromoteFromSchemaDiff(diff({ coverage: 0.79 }));
+    expect(d.eligible).toBe(false);
+    expect(d.reasons).toContainEqual({
+      kind: 'coverage_below_bar',
+      coverage: 0.79,
+      required: 0.8,
+    });
+  });
+
+  test('any type mismatch blocks under defaults', () => {
+    const d = shouldPromoteFromSchemaDiff(
+      diff({
+        coverage: 1,
+        typeMismatch: [{ field: 'statusCode', expected: 'number', got: 'string' }],
+      }),
+    );
+    expect(d.eligible).toBe(false);
+    expect(d.reasons).toContainEqual({
+      kind: 'type_mismatch_present',
+      count: 1,
+      max: 0,
+      fields: ['statusCode'],
+    });
+  });
+
+  test('default does not block on missing fields when coverage clears the bar', () => {
+    // Missing one optional field doesn't reduce coverage; but missing one
+    // required field does. Here we simulate "coverage stays at 0.9 with
+    // missing[]" — defaults allow it through.
+    const d = shouldPromoteFromSchemaDiff(diff({ coverage: 0.9, missing: ['preview'] }));
+    expect(d.eligible).toBe(true);
+  });
+});
+
+describe('shouldPromoteFromSchemaDiff — strict options', () => {
+  test('requireZeroMissing blocks when missing is non-empty', () => {
+    const d = shouldPromoteFromSchemaDiff(
+      diff({ coverage: 1, missing: ['description'] }),
+      { requireZeroMissing: true },
+    );
+    expect(d.eligible).toBe(false);
+    expect(d.reasons).toContainEqual({
+      kind: 'missing_required_fields',
+      fields: ['description'],
+    });
+  });
+
+  test('minCoverage = 1 requires perfect match', () => {
+    expect(
+      shouldPromoteFromSchemaDiff(diff({ coverage: 0.95 }), { minCoverage: 1 }).eligible,
+    ).toBe(false);
+    expect(
+      shouldPromoteFromSchemaDiff(diff({ coverage: 1 }), { minCoverage: 1 }).eligible,
+    ).toBe(true);
+  });
+
+  test('maxTypeMismatch = 2 allows up to 2 mismatches', () => {
+    const twoMismatches = diff({
+      coverage: 1,
+      typeMismatch: [
+        { field: 'a', expected: 'number', got: 'string' },
+        { field: 'b', expected: 'boolean', got: 'number' },
+      ],
+    });
+    expect(
+      shouldPromoteFromSchemaDiff(twoMismatches, { maxTypeMismatch: 2 }).eligible,
+    ).toBe(true);
+  });
+});
+
+describe('shouldPromoteFromSchemaDiff — option clamping', () => {
+  test('minCoverage clamps to [0, 1]', () => {
+    expect(shouldPromoteFromSchemaDiff(diff({ coverage: 0 }), { minCoverage: -5 }).threshold.minCoverage).toBe(0);
+    expect(shouldPromoteFromSchemaDiff(diff({ coverage: 1 }), { minCoverage: 5 }).threshold.minCoverage).toBe(1);
+  });
+
+  test('maxTypeMismatch clamps to >= 0 and floors', () => {
+    expect(
+      shouldPromoteFromSchemaDiff(diff(), { maxTypeMismatch: -3 }).threshold.maxTypeMismatch,
+    ).toBe(0);
+    expect(
+      shouldPromoteFromSchemaDiff(diff(), { maxTypeMismatch: 2.7 }).threshold.maxTypeMismatch,
+    ).toBe(2);
+  });
+
+  test('NaN / non-finite options fall back to defaults', () => {
+    const d = shouldPromoteFromSchemaDiff(diff(), {
+      minCoverage: Number.NaN,
+      maxTypeMismatch: Number.POSITIVE_INFINITY as unknown as number,
+    });
+    expect(d.threshold.minCoverage).toBe(0.8);
+    expect(d.threshold.maxTypeMismatch).toBe(0);
+  });
+});
+
+describe('shouldPromoteFromSchemaDiff — determinism', () => {
+  test('repeated evaluations on the same diff produce structurally identical output', () => {
+    const d1 = shouldPromoteFromSchemaDiff(
+      diff({ coverage: 0.75, missing: ['x', 'y'] }),
+    );
+    const d2 = shouldPromoteFromSchemaDiff(
+      diff({ coverage: 0.75, missing: ['x', 'y'] }),
+    );
+    expect(JSON.stringify(d1)).toBe(JSON.stringify(d2));
+  });
+});
+
+describe('shouldPromoteFromSchemaDiff — multiple reasons', () => {
+  test('blocking reasons accumulate (no short-circuit) — caller sees full diagnosis', () => {
+    const d = shouldPromoteFromSchemaDiff(
+      diff({
+        coverage: 0.5,
+        missing: ['statusCode'],
+        typeMismatch: [{ field: 'title', expected: 'string', got: 'number' }],
+      }),
+      { requireZeroMissing: true },
+    );
+    expect(d.eligible).toBe(false);
+    const kinds = d.reasons.map((r) => r.kind);
+    expect(kinds).toEqual(
+      expect.arrayContaining([
+        'coverage_below_bar',
+        'type_mismatch_present',
+        'missing_required_fields',
+      ]),
+    );
+  });
+});

--- a/tests/tools/oc-evidence-bundle.schema-diff.test.ts
+++ b/tests/tools/oc-evidence-bundle.schema-diff.test.ts
@@ -101,6 +101,19 @@ describe('oc_evidence_bundle — target_schema diff wiring', () => {
     expect(out.schema_diff).toBeUndefined();
   });
 
+  test('target_schema with an unknown field type is silently dropped', async () => {
+    const handler = setup();
+    const result = await handler('sess', {
+      include: ['schema_diff'],
+      target_schema: { version: 1, fields: [{ name: 'publishedAt', type: 'date' }] },
+      evidence: { snapshot: { observed: { publishedAt: '2026-05-27' } } },
+    });
+
+    const out = parseResult(result);
+    expect(out.parts).not.toEqual(expect.arrayContaining(['schema_diff.json']));
+    expect(out.schema_diff).toBeUndefined();
+  });
+
   test('absent observed yields no schema_diff even when target_schema is valid', async () => {
     const handler = setup();
     const result = await handler('sess', {

--- a/tests/tools/oc-evidence-bundle.schema-diff.test.ts
+++ b/tests/tools/oc-evidence-bundle.schema-diff.test.ts
@@ -1,0 +1,147 @@
+/// <reference types="jest" />
+
+/**
+ * MCP surface tests for the `target_schema` input on `oc_evidence_bundle`
+ * (B1-PR2 of #1359).
+ *
+ * Confirms:
+ *  - `args.target_schema` together with `evidence.snapshot.observed` and
+ *    `include: ['schema_diff']` produces a `schema_diff` field in the
+ *    parsed JSON output AND a `schema_diff.json` file on disk.
+ *  - Malformed `target_schema` is silently dropped (no schema_diff field,
+ *    no schema_diff.json file).
+ *  - Absent `observed` is silently dropped.
+ *  - The default include set behavior (no schema_diff request) is
+ *    unaffected — preserves backward compatibility.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { registerOcEvidenceBundleTool } from '../../src/tools/oc-evidence-bundle';
+import type {
+  MCPToolDefinition,
+  MCPResult,
+  ToolHandler,
+} from '../../src/types/mcp';
+
+interface RegisteredTool {
+  name: string;
+  handler: ToolHandler;
+  definition: MCPToolDefinition;
+}
+
+class MockServer {
+  public tools = new Map<string, RegisteredTool>();
+  registerTool(name: string, handler: ToolHandler, definition: MCPToolDefinition): void {
+    this.tools.set(name, { name, handler, definition });
+  }
+}
+
+function parseResult(result: MCPResult): Record<string, unknown> {
+  const text = result.content?.[0]?.text;
+  expect(typeof text).toBe('string');
+  return JSON.parse(text as string) as Record<string, unknown>;
+}
+
+function setup(): ToolHandler {
+  const server = new MockServer();
+  registerOcEvidenceBundleTool(
+    server as unknown as Parameters<typeof registerOcEvidenceBundleTool>[0],
+  );
+  const reg = server.tools.get('oc_evidence_bundle');
+  expect(reg).toBeDefined();
+  return reg!.handler;
+}
+
+const schema = {
+  version: 1,
+  fields: [
+    { name: 'title', type: 'string' },
+    { name: 'statusCode', type: 'number' },
+  ],
+};
+
+describe('oc_evidence_bundle — target_schema diff wiring', () => {
+  test('produces schema_diff in the JSON response and writes schema_diff.json', async () => {
+    const handler = setup();
+    const result = await handler('sess', {
+      include: ['schema_diff'],
+      target_schema: schema,
+      evidence: {
+        snapshot: { observed: { title: 'Example', statusCode: 200 } },
+      },
+    });
+
+    const out = parseResult(result);
+    expect(out.parts).toEqual(expect.arrayContaining(['schema_diff.json']));
+    expect(out.schema_diff).toBeDefined();
+    const diff = out.schema_diff as Record<string, unknown>;
+    expect(diff.matched).toEqual(['title', 'statusCode']);
+    expect(diff.coverage).toBe(1);
+
+    // schema_diff.json exists on disk and matches the response.
+    const bundlePath = out.path as string;
+    const onDisk = JSON.parse(
+      fs.readFileSync(path.join(bundlePath, 'schema_diff.json'), 'utf8'),
+    );
+    expect(onDisk.target_schema_version).toBe(1);
+    expect(onDisk.diff).toEqual(diff);
+  });
+
+  test('malformed target_schema is silently dropped — no schema_diff in output', async () => {
+    const handler = setup();
+    const result = await handler('sess', {
+      include: ['schema_diff'],
+      target_schema: { version: 'not-a-number', fields: [] },
+      evidence: { snapshot: { observed: { title: 'x' } } },
+    });
+
+    const out = parseResult(result);
+    expect(out.parts).not.toEqual(expect.arrayContaining(['schema_diff.json']));
+    expect(out.schema_diff).toBeUndefined();
+  });
+
+  test('absent observed yields no schema_diff even when target_schema is valid', async () => {
+    const handler = setup();
+    const result = await handler('sess', {
+      include: ['schema_diff'],
+      target_schema: schema,
+      evidence: { snapshot: {} },
+    });
+
+    const out = parseResult(result);
+    expect(out.parts).not.toEqual(expect.arrayContaining(['schema_diff.json']));
+    expect(out.schema_diff).toBeUndefined();
+  });
+
+  test('default behavior (no schema_diff request) is unchanged — no new fields', async () => {
+    const handler = setup();
+    const result = await handler('sess', {
+      evidence: {
+        snapshot: { dom: '<html></html>' },
+      },
+    });
+
+    const out = parseResult(result);
+    expect(out.parts).toEqual(['dom.json']);
+    expect(out.schema_diff).toBeUndefined();
+  });
+
+  test('schema_diff coexists with other parts in the same bundle', async () => {
+    const handler = setup();
+    const result = await handler('sess', {
+      include: ['dom', 'schema_diff'],
+      target_schema: schema,
+      evidence: {
+        snapshot: {
+          dom: '<html></html>',
+          observed: { title: 't', statusCode: 200 },
+        },
+      },
+    });
+
+    const out = parseResult(result);
+    expect(out.parts).toEqual(['dom.json', 'schema_diff.json']);
+    expect(out.schema_diff).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Wire the B1-PR1 schema-diff function (#1385) into `oc_evidence_bundle`. When the caller passes a `target_schema`, an `evidence.snapshot.observed` payload, and includes the `schema_diff` part, the bundle writer computes a deterministic field-match diff and writes `schema_diff.json` into the bundle directory.

**Stacked on top of #1385 (B1-PR1).** Base branch is `feat/b1-schema-diff`. Rebase to `develop` once #1385 lands.

## What lands

- `EvidenceBundlePart` gains `'schema_diff'`.
- `EvidenceBundleSnapshot` gains `observed: unknown` — caller-supplied structured data extracted from the page.
- `EvidenceBundleOptions` gains `targetSchema: SchemaDefinition`.
- `EvidenceBundleResult` gains optional `schema_diff: SchemaDiff` so single-call consumers don't re-read the file.
- `oc_evidence_bundle` MCP tool exposes:
  - `args.target_schema` (object)
  - `args.evidence.snapshot.observed` (any structured data)
  - `result.schema_diff` (object) when conditions hold
- Malformed `target_schema` (wrong version, missing fields, non-string name/type) is silently dropped — consistent with the rest of the bundle writer's "omit gracefully" policy.

## Why facts, not a score

Per #1359 §P4: the bundle emits a **structured fact** describing how well the host's extraction matched the declared schema. No threshold, no verdict, no opinion is encoded. `coverage` is provided as a convenience; callers that need a different metric compute it from `matched`/`missing`.

This is the load-bearing surface for:
- CI gating ("fail when coverage < 0.8")
- Agent recovery ("retry when typeMismatch is non-empty")
- Verified-memory promotion gates (#1358-style)
- External benchmarking (e.g. airena.lol scoring)

## #1359 decision-rule check

| Rule | Answer |
|---|---|
| Pillar | C (contract-verifiable browser work), D (verified memory promotion) |
| stdio/HTTP | both — pure tool input/output change |
| Unknown clients | works (no optional capability required) |
| LLM judgment in host | yes — diff only, no opinion |
| Portable artifact | yes — schema_diff.json on disk + JSON in response |
| Real Chrome state | none touched |

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx jest tests/core/contracts/evidence-bundle.test.ts tests/core/contracts/evidence-bundle.schema-diff.test.ts tests/tools/oc-evidence-bundle.schema-diff.test.ts tests/core/contracts/schema-diff.test.ts` — 47/47 passing
  - new bundle-writer tests: writes-when-conditions-hold, partial coverage, omitted when schema absent / observed absent / part not requested, coexistence with other parts
  - new MCP wiring tests: round-trips schema_diff through JSON response, malformed target_schema silently dropped, absent observed → no diff, default behavior unchanged, coexistence with other parts
  - existing 21 evidence-bundle tests still pass — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)