### PR TITLE
feat(contracts): public-web.page-meta outcome contract template (A2-PR2)

### DIFF
--- a/src/contracts/templates/index.ts
+++ b/src/contracts/templates/index.ts
@@ -15,3 +15,6 @@ export {
 } from './types';
 export type { TemplateListing } from './registry';
 export { TemplateRegistry } from './registry';
+
+// ── public-web template catalog (A2-PR2..5 of #1359) ──────────────────────
+export { PAGE_META_TEMPLATE } from './public-web/page-meta';

--- a/src/contracts/templates/public-web/page-meta.ts
+++ b/src/contracts/templates/public-web/page-meta.ts
@@ -1,0 +1,59 @@
+/**
+ * public-web.page-meta — outcome contract template (A2-PR2 of #1359).
+ *
+ * Declares the canonical schema for *page-level meta extraction* — the
+ * Tier-1 task family every web crawler needs and the smallest unit of
+ * comparison for external benchmarks. Use this template when the host
+ * agent wants oc_assert / oc_evidence_bundle to verify that an
+ * extraction produced `{title, url, description, statusCode}` plus
+ * Open Graph fields where present.
+ *
+ * Wire format is `schema-diff.v1` so the same JSON travels through:
+ *   - oc_evidence_bundle's target_schema input (B1-PR2)
+ *   - external benchmark scorers (airena, etc.)
+ *
+ * No detector / executor / heuristic is bundled — per #1359 §P4 the
+ * template is data only. The host extracts the page (read_page,
+ * extract_data, network response inspection) and presents the result
+ * to the bundle writer under this schema's identity.
+ */
+
+import type { OutcomeTemplate } from '../types';
+
+export const PAGE_META_TEMPLATE: OutcomeTemplate = {
+  id: 'public-web.page-meta',
+  version: 1,
+  description:
+    'Tier-1 page-level meta extraction: title, url, description, statusCode, ' +
+    'Open Graph fields. The minimum schema every public-web crawl task must ' +
+    'satisfy.',
+  tags: ['public-web', 'meta', 'static', 'tier-1'],
+  targetSchema: {
+    format: 'schema-diff.v1',
+    definition: {
+      version: 1,
+      fields: [
+        // ── Required ─────────────────────────────────────────────────
+        { name: 'title', type: 'string' },
+        { name: 'url', type: 'string' },
+        { name: 'statusCode', type: 'number' },
+
+        // ── Optional ─────────────────────────────────────────────────
+        // Description is conventionally required but missing on many
+        // real-world pages. Mark optional so absence does not lower
+        // coverage; the host can still detect omission via `missing`
+        // when they want a stricter contract by overriding the
+        // template inline.
+        { name: 'description', type: 'string', required: false },
+
+        // Open Graph (og:*) and Twitter Card fields — common
+        // enrichments. Always optional in v1.
+        { name: 'og.title', type: 'string', required: false },
+        { name: 'og.description', type: 'string', required: false },
+        { name: 'og.image', type: 'string', required: false },
+        { name: 'og.type', type: 'string', required: false },
+        { name: 'twitter.card', type: 'string', required: false },
+      ],
+    },
+  },
+};

--- a/tests/contracts/templates/public-web/page-meta.test.ts
+++ b/tests/contracts/templates/public-web/page-meta.test.ts
@@ -1,0 +1,115 @@
+/// <reference types="jest" />
+
+/**
+ * Tests for public-web.page-meta template (A2-PR2 of #1359).
+ *
+ * The template is data-only; tests pin:
+ *   - identity (id, version, kebab-case, well-formed description)
+ *   - schema format and required/optional field discrimination
+ *   - registration round-trip through TemplateRegistry
+ *   - portability: JSON-serializable
+ */
+
+import {
+  PAGE_META_TEMPLATE,
+  TemplateRegistry,
+} from '../../../../src/contracts/templates';
+
+describe('PAGE_META_TEMPLATE — identity', () => {
+  test('id is "public-web.page-meta" and version is 1', () => {
+    expect(PAGE_META_TEMPLATE.id).toBe('public-web.page-meta');
+    expect(PAGE_META_TEMPLATE.version).toBe(1);
+  });
+
+  test('description is non-empty and starts with the task family', () => {
+    expect(PAGE_META_TEMPLATE.description.length).toBeGreaterThan(10);
+    expect(PAGE_META_TEMPLATE.description.toLowerCase()).toContain('page-level meta extraction');
+  });
+
+  test('tags include public-web and tier-1', () => {
+    expect(PAGE_META_TEMPLATE.tags).toEqual(
+      expect.arrayContaining(['public-web', 'meta', 'tier-1']),
+    );
+  });
+});
+
+describe('PAGE_META_TEMPLATE — schema shape', () => {
+  test('targetSchema.format is schema-diff.v1', () => {
+    expect(PAGE_META_TEMPLATE.targetSchema?.format).toBe('schema-diff.v1');
+  });
+
+  test('schema declares title/url/statusCode as required', () => {
+    const def = PAGE_META_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string; type: string; required?: boolean }>;
+    };
+    const required = def.fields
+      .filter((f) => f.required !== false)
+      .map((f) => f.name);
+
+    expect(required).toEqual(
+      expect.arrayContaining(['title', 'url', 'statusCode']),
+    );
+  });
+
+  test('description and og:* are optional', () => {
+    const def = PAGE_META_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string; type: string; required?: boolean }>;
+    };
+    const optional = def.fields
+      .filter((f) => f.required === false)
+      .map((f) => f.name);
+
+    expect(optional).toEqual(
+      expect.arrayContaining([
+        'description',
+        'og.title',
+        'og.description',
+        'og.image',
+        'og.type',
+        'twitter.card',
+      ]),
+    );
+  });
+
+  test('every field declares a primitive JS-type bucket', () => {
+    const def = PAGE_META_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string; type: string }>;
+    };
+    const allowed = new Set(['string', 'number', 'boolean', 'object', 'array', 'null']);
+    for (const f of def.fields) {
+      expect(allowed.has(f.type)).toBe(true);
+    }
+  });
+});
+
+describe('PAGE_META_TEMPLATE — portability', () => {
+  test('round-trips through JSON without loss', () => {
+    const copy = JSON.parse(JSON.stringify(PAGE_META_TEMPLATE));
+    expect(copy).toEqual(PAGE_META_TEMPLATE);
+  });
+});
+
+describe('PAGE_META_TEMPLATE — registry round-trip', () => {
+  test('registers and resolves through TemplateRegistry', () => {
+    const r = new TemplateRegistry();
+    r.register(PAGE_META_TEMPLATE);
+
+    expect(r.has('public-web.page-meta')).toBe(true);
+    expect(r.has('public-web.page-meta', 1)).toBe(true);
+    expect(r.get('public-web.page-meta')).toEqual(PAGE_META_TEMPLATE);
+  });
+
+  test('listing surfaces the public-web.page-meta entry with version 1 as latest', () => {
+    const r = new TemplateRegistry();
+    r.register(PAGE_META_TEMPLATE);
+
+    expect(r.list()).toEqual([
+      {
+        id: 'public-web.page-meta',
+        versions: [1],
+        latest: 1,
+        description: PAGE_META_TEMPLATE.description,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Concrete Tier-1 template that declares the canonical schema for **page-level meta extraction**: `{ title, url, statusCode }` required, plus `{ description, og.*, twitter.card }` optional. Wire format is `schema-diff.v1` so the same JSON travels through `oc_evidence_bundle.target_schema` (B1-PR2 / #1391) and external benchmark scorers.

**Stacked on top of #1388 (A2-PR1 registry scaffold).** Base branch is `feat/a2-template-registry`.

## Template shape

```ts
{
  id: 'public-web.page-meta',
  version: 1,
  description: 'Tier-1 page-level meta extraction: ...',
  tags: ['public-web', 'meta', 'static', 'tier-1'],
  targetSchema: {
    format: 'schema-diff.v1',
    definition: {
      version: 1,
      fields: [
        { name: 'title', type: 'string' },
        { name: 'url', type: 'string' },
        { name: 'statusCode', type: 'number' },
        { name: 'description', type: 'string', required: false },
        { name: 'og.title', type: 'string', required: false },
        { name: 'og.description', type: 'string', required: false },
        { name: 'og.image', type: 'string', required: false },
        { name: 'og.type', type: 'string', required: false },
        { name: 'twitter.card', type: 'string', required: false },
      ],
    },
  },
}
```

## Why `description` is optional

Real-world pages frequently omit a meta description. Treating it as required would lower coverage for every legitimate page that doesn't ship one. Hosts needing a stricter contract can clone the template inline and flip `required`.

## #1359 decision-rule check

| Rule | Answer |
|---|---|
| Pillar | C (contract-verifiable browser work), E (benchmark anchoring) |
| stdio/HTTP | both — pure JSON data |
| Optional capabilities | none |
| LLM judgment in host | yes — host extracts, template only describes the shape |
| Portable artifact | yes — JSON round-trip tested |
| Real Chrome state | none touched |
| Host-specific behavior | none |

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx jest tests/contracts/templates/` — 25/25 passing
  - 15 registry tests still pass (no regression)
  - 10 new page-meta tests: identity, schema shape (required/optional discrimination, JS-type bucket validity), JSON portability, registry round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)