### PR TITLE
feat(contracts): public-web.spa-hydrated outcome contract template (A2-PR3)

### DIFF
--- a/src/contracts/templates/index.ts
+++ b/src/contracts/templates/index.ts
@@ -18,3 +18,4 @@ export { TemplateRegistry } from './registry';
 
 // ── public-web template catalog (A2-PR2..5 of #1359) ──────────────────────
 export { PAGE_META_TEMPLATE } from './public-web/page-meta';
+export { SPA_HYDRATED_TEMPLATE } from './public-web/spa-hydrated';

--- a/src/contracts/templates/public-web/spa-hydrated.ts
+++ b/src/contracts/templates/public-web/spa-hydrated.ts
@@ -1,0 +1,87 @@
+/**
+ * public-web.spa-hydrated — outcome contract template (A2-PR3 of #1359).
+ *
+ * Declares the canonical schema for *post-hydration SPA extraction* —
+ * the Tier-1 task family that proves a real-Chrome harness is worth the
+ * cost over a static fetch. Use this template when the host agent runs
+ * a single-page app (React/Vue/Next/Angular) through full hydration and
+ * extracts the post-rendered content.
+ *
+ * The schema captures what every SPA observer cares about regardless of
+ * framework:
+ *
+ *   - The post-hydration page identity (title, url, route).
+ *   - A characterization of mainContent so callers can diff hydration
+ *     coverage across runs (length, has headings, structured data
+ *     presence).
+ *   - Readiness signals so the host can confirm hydration completed
+ *     before the snapshot was taken.
+ *
+ * Wire format is schema-diff.v1, identical to public-web.page-meta —
+ * downstream consumers (oc_evidence_bundle, external scorers) treat
+ * the two templates interchangeably at the diff level.
+ *
+ * Per #1359 §P4 the template is data only. The host extracts the
+ * post-hydration page (read_page after wait_for stable, query_dom,
+ * extract_data) and presents the result to the bundle writer under
+ * this schema's identity.
+ */
+
+import type { OutcomeTemplate } from '../types';
+
+export const SPA_HYDRATED_TEMPLATE: OutcomeTemplate = {
+  id: 'public-web.spa-hydrated',
+  version: 1,
+  description:
+    'Tier-1 single-page-app extraction: title, url, route, post-hydration ' +
+    'mainContent characterization, readiness signals, and any structured-data ' +
+    'blocks emitted by the framework after hydration.',
+  tags: ['public-web', 'spa', 'dynamic', 'tier-1'],
+  targetSchema: {
+    format: 'schema-diff.v1',
+    definition: {
+      version: 1,
+      fields: [
+        // ── Page identity ─────────────────────────────────────────────
+        { name: 'title', type: 'string' },
+        { name: 'url', type: 'string' },
+
+        // SPA route (the client-side router's current path). May equal
+        // window.location.pathname or may be a hash route. Required
+        // because the whole point of SPA hydration is to surface this.
+        { name: 'route', type: 'string' },
+
+        // ── Main content characterization ─────────────────────────────
+        // Don't ship the raw mainContent text in the schema — it varies
+        // wildly across runs and would tank coverage on every retry.
+        // Instead capture deterministic features the host can diff.
+        { name: 'mainContent.length', type: 'number' },
+        { name: 'mainContent.hasHeadings', type: 'boolean' },
+
+        // ── Readiness signals ─────────────────────────────────────────
+        // Required: prove hydration actually completed when the snapshot
+        // was taken. domStable=false should be treated as
+        // "extraction may be partial."
+        { name: 'readiness.domStable', type: 'boolean' },
+        { name: 'readiness.framework', type: 'string' },
+
+        // ── Optional enrichments ──────────────────────────────────────
+        // Description (when the framework wires meta tags into the SSR
+        // payload — many SPAs ship blank descriptions).
+        { name: 'description', type: 'string', required: false },
+
+        // Structured data blocks (JSON-LD, microdata). Optional because
+        // not every SPA emits them.
+        { name: 'structuredData', type: 'array', required: false },
+        { name: 'structuredData.count', type: 'number', required: false },
+
+        // Open Graph / Twitter Card mirrors of page-meta for sites that
+        // hydrate them client-side.
+        { name: 'og.title', type: 'string', required: false },
+        { name: 'og.description', type: 'string', required: false },
+        { name: 'og.image', type: 'string', required: false },
+        { name: 'twitter.card', type: 'string', required: false },
+      ],
+    },
+  },
+};

--- a/tests/contracts/templates/public-web/spa-hydrated.test.ts
+++ b/tests/contracts/templates/public-web/spa-hydrated.test.ts
@@ -1,0 +1,129 @@
+/// <reference types="jest" />
+
+/**
+ * Tests for public-web.spa-hydrated template (A2-PR3 of #1359).
+ */
+
+import {
+  SPA_HYDRATED_TEMPLATE,
+  TemplateRegistry,
+} from '../../../../src/contracts/templates';
+
+describe('SPA_HYDRATED_TEMPLATE — identity', () => {
+  test('id is "public-web.spa-hydrated" and version is 1', () => {
+    expect(SPA_HYDRATED_TEMPLATE.id).toBe('public-web.spa-hydrated');
+    expect(SPA_HYDRATED_TEMPLATE.version).toBe(1);
+  });
+
+  test('description mentions single-page-app extraction and hydration', () => {
+    expect(SPA_HYDRATED_TEMPLATE.description.toLowerCase()).toContain('single-page');
+    expect(SPA_HYDRATED_TEMPLATE.description.toLowerCase()).toContain('hydration');
+  });
+
+  test('tags include public-web, spa, dynamic, tier-1', () => {
+    expect(SPA_HYDRATED_TEMPLATE.tags).toEqual(
+      expect.arrayContaining(['public-web', 'spa', 'dynamic', 'tier-1']),
+    );
+  });
+});
+
+describe('SPA_HYDRATED_TEMPLATE — schema shape', () => {
+  test('targetSchema.format is schema-diff.v1', () => {
+    expect(SPA_HYDRATED_TEMPLATE.targetSchema?.format).toBe('schema-diff.v1');
+  });
+
+  test('required fields include identity + mainContent characterization + readiness', () => {
+    const def = SPA_HYDRATED_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string; type: string; required?: boolean }>;
+    };
+    const required = def.fields
+      .filter((f) => f.required !== false)
+      .map((f) => f.name);
+
+    expect(required).toEqual(
+      expect.arrayContaining([
+        'title',
+        'url',
+        'route',
+        'mainContent.length',
+        'mainContent.hasHeadings',
+        'readiness.domStable',
+        'readiness.framework',
+      ]),
+    );
+  });
+
+  test('description / structuredData / og.* are optional', () => {
+    const def = SPA_HYDRATED_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string; type: string; required?: boolean }>;
+    };
+    const optional = def.fields
+      .filter((f) => f.required === false)
+      .map((f) => f.name);
+
+    expect(optional).toEqual(
+      expect.arrayContaining([
+        'description',
+        'structuredData',
+        'structuredData.count',
+        'og.title',
+        'og.description',
+        'og.image',
+        'twitter.card',
+      ]),
+    );
+  });
+
+  test('mainContent NEVER appears as raw text in the schema (only characterizations)', () => {
+    // Per the design note: ship features the host can diff, not raw
+    // content that changes every run.
+    const def = SPA_HYDRATED_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string }>;
+    };
+    const names = def.fields.map((f) => f.name);
+    expect(names).not.toContain('mainContent');
+    expect(names).not.toContain('mainContent.text');
+    expect(names).not.toContain('mainContent.html');
+  });
+
+  test('every field declares a primitive JS-type bucket', () => {
+    const def = SPA_HYDRATED_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ type: string }>;
+    };
+    const allowed = new Set(['string', 'number', 'boolean', 'object', 'array', 'null']);
+    for (const f of def.fields) {
+      expect(allowed.has(f.type)).toBe(true);
+    }
+  });
+
+  test('readiness.domStable is the explicit hydration-completed signal', () => {
+    const def = SPA_HYDRATED_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string; type: string; required?: boolean }>;
+    };
+    const field = def.fields.find((f) => f.name === 'readiness.domStable');
+    expect(field).toBeDefined();
+    expect(field?.type).toBe('boolean');
+    expect(field?.required).not.toBe(false);
+  });
+});
+
+describe('SPA_HYDRATED_TEMPLATE — portability and registry', () => {
+  test('round-trips through JSON without loss', () => {
+    const copy = JSON.parse(JSON.stringify(SPA_HYDRATED_TEMPLATE));
+    expect(copy).toEqual(SPA_HYDRATED_TEMPLATE);
+  });
+
+  test('coexists with public-web.page-meta in the registry without id collision', async () => {
+    const { PAGE_META_TEMPLATE } = await import(
+      '../../../../src/contracts/templates'
+    );
+    const r = new TemplateRegistry();
+    r.register(PAGE_META_TEMPLATE);
+    r.register(SPA_HYDRATED_TEMPLATE);
+
+    expect(r.size()).toBe(2);
+    expect(r.has('public-web.page-meta')).toBe(true);
+    expect(r.has('public-web.spa-hydrated')).toBe(true);
+    expect(r.get('public-web.spa-hydrated')?.version).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Concrete Tier-1 template for post-hydration SPA extraction — the task family that proves a real-Chrome harness is worth the cost over a static fetch.

**Stacked on top of #1394 (A2-PR2 page-meta).** Base branch is `feat/a2-template-page-meta`.

## Schema

**Required:**
- `title`, `url`, `route` (string)
- `mainContent.length` (number), `mainContent.hasHeadings` (boolean)
- `readiness.domStable` (boolean), `readiness.framework` (string)

**Optional:**
- `description` (string)
- `structuredData` (array), `structuredData.count` (number)
- `og.title`, `og.description`, `og.image`, `twitter.card`

## Design note — characterizations, not raw text

The schema captures *characterizations* of `mainContent` (length, hasHeadings) rather than raw text. Raw mainContent varies wildly across runs and would tank coverage on every retry. Hosts that need text-level diff use `oc_diff` or pHash; the schema-diff layer sticks to deterministic features.

This is codified by an explicit negative test in `spa-hydrated.test.ts`:
```ts
expect(names).not.toContain('mainContent');
expect(names).not.toContain('mainContent.text');
expect(names).not.toContain('mainContent.html');
```

## #1359 decision-rule check

| Rule | Answer |
|---|---|
| Pillar | C, E |
| stdio/HTTP | both — pure JSON data |
| LLM judgment in host | yes |
| Portable artifact | yes — JSON round-trip tested |
| Real Chrome state | none touched |

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx jest tests/contracts/templates/` — 36/36 passing
  - 25 inherited (registry + page-meta) still pass
  - 11 new spa-hydrated tests: identity, required/optional discrimination, **mainContent-is-not-raw-text negative assertion**, readiness.domStable boolean, JS-type bucket validity, JSON portability, registry coexistence with page-meta

🤖 Generated with [Claude Code](https://claude.com/claude-code)