### PR TITLE
feat(contracts): public-web.link-graph outcome contract template (A2-PR4)

### DIFF
--- a/src/contracts/templates/index.ts
+++ b/src/contracts/templates/index.ts
@@ -19,3 +19,4 @@ export { TemplateRegistry } from './registry';
 // ── public-web template catalog (A2-PR2..5 of #1359) ──────────────────────
 export { PAGE_META_TEMPLATE } from './public-web/page-meta';
 export { SPA_HYDRATED_TEMPLATE } from './public-web/spa-hydrated';
+export { LINK_GRAPH_TEMPLATE } from './public-web/link-graph';

--- a/src/contracts/templates/public-web/link-graph.ts
+++ b/src/contracts/templates/public-web/link-graph.ts
@@ -1,0 +1,69 @@
+/**
+ * public-web.link-graph — outcome contract template (A2-PR4 of #1359).
+ *
+ * Declares the canonical schema for *site-crawl link-graph extraction* —
+ * the Tier-1 task family that proves a crawl tool ranges over a site and
+ * preserves the relationship between pages.
+ *
+ * The schema captures graph identity (root, nodeCount, edgeCount,
+ * maxDepth) and policy (sameOrigin) so two runs can be diffed for
+ * coverage without shipping the raw node/edge arrays in the schema-diff
+ * layer. The raw `nodes` and `edges` arrays are also declared so the
+ * host can verify their presence and type, but the schema does not
+ * impose a content-level shape — host-supplied schemas (or oc_diff)
+ * handle that.
+ *
+ * Wire format is schema-diff.v1.
+ *
+ * Per #1359 §P4 the template is data only. The host runs the crawl
+ * (crawl_start / crawl_status / find / extract_data) and presents the
+ * shaped graph to the bundle writer under this schema's identity.
+ */
+
+import type { OutcomeTemplate } from '../types';
+
+export const LINK_GRAPH_TEMPLATE: OutcomeTemplate = {
+  id: 'public-web.link-graph',
+  version: 1,
+  description:
+    'Tier-1 site-crawl link-graph extraction: root, nodes (url+title), ' +
+    'edges (from→to), maxDepth, sameOrigin policy. The minimum shape every ' +
+    'crawl task surfaces so two runs can be diffed for coverage without ' +
+    'shipping the raw node/edge arrays in the schema-diff layer.',
+  tags: ['public-web', 'crawl', 'graph', 'tier-1'],
+  targetSchema: {
+    format: 'schema-diff.v1',
+    definition: {
+      version: 1,
+      fields: [
+        // ── Identity / policy ─────────────────────────────────────────
+        { name: 'root', type: 'string' },
+        { name: 'sameOrigin', type: 'boolean' },
+
+        // ── Graph cardinality (load-bearing for coverage diff) ────────
+        { name: 'nodeCount', type: 'number' },
+        { name: 'edgeCount', type: 'number' },
+        { name: 'maxDepth', type: 'number' },
+
+        // ── Raw payload presence (host validates content via oc_diff) ─
+        // The host extracts these arrays. We declare them as array
+        // buckets so schema-diff confirms shape; content-level
+        // verification belongs in a stricter contract supplied by the
+        // host or in oc_diff.
+        { name: 'nodes', type: 'array' },
+        { name: 'edges', type: 'array' },
+
+        // ── Optional enrichments ──────────────────────────────────────
+        // Wall-clock duration the crawl took. Optional because some
+        // host execution paths (replay, mock) don't measure it.
+        { name: 'durationMs', type: 'number', required: false },
+
+        // Robots / disallow signals encountered. Optional.
+        { name: 'robotsBlocked.count', type: 'number', required: false },
+
+        // Worker / queue diagnostics that some crawlers emit.
+        { name: 'frontierSize.final', type: 'number', required: false },
+      ],
+    },
+  },
+};

--- a/tests/contracts/templates/public-web/link-graph.test.ts
+++ b/tests/contracts/templates/public-web/link-graph.test.ts
@@ -1,0 +1,120 @@
+/// <reference types="jest" />
+
+/**
+ * Tests for public-web.link-graph template (A2-PR4 of #1359).
+ */
+
+import {
+  LINK_GRAPH_TEMPLATE,
+  PAGE_META_TEMPLATE,
+  SPA_HYDRATED_TEMPLATE,
+  TemplateRegistry,
+} from '../../../../src/contracts/templates';
+
+describe('LINK_GRAPH_TEMPLATE — identity', () => {
+  test('id is "public-web.link-graph" and version is 1', () => {
+    expect(LINK_GRAPH_TEMPLATE.id).toBe('public-web.link-graph');
+    expect(LINK_GRAPH_TEMPLATE.version).toBe(1);
+  });
+
+  test('description mentions site-crawl link-graph extraction', () => {
+    expect(LINK_GRAPH_TEMPLATE.description.toLowerCase()).toContain('site-crawl');
+    expect(LINK_GRAPH_TEMPLATE.description.toLowerCase()).toContain('link-graph');
+  });
+
+  test('tags include crawl + graph + tier-1', () => {
+    expect(LINK_GRAPH_TEMPLATE.tags).toEqual(
+      expect.arrayContaining(['public-web', 'crawl', 'graph', 'tier-1']),
+    );
+  });
+});
+
+describe('LINK_GRAPH_TEMPLATE — schema shape', () => {
+  test('targetSchema.format is schema-diff.v1', () => {
+    expect(LINK_GRAPH_TEMPLATE.targetSchema?.format).toBe('schema-diff.v1');
+  });
+
+  test('required fields cover identity, policy, cardinality, raw payloads', () => {
+    const def = LINK_GRAPH_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string; type: string; required?: boolean }>;
+    };
+    const required = def.fields
+      .filter((f) => f.required !== false)
+      .map((f) => f.name);
+
+    expect(required).toEqual(
+      expect.arrayContaining([
+        'root',
+        'sameOrigin',
+        'nodeCount',
+        'edgeCount',
+        'maxDepth',
+        'nodes',
+        'edges',
+      ]),
+    );
+  });
+
+  test('durationMs and diagnostic fields are optional', () => {
+    const def = LINK_GRAPH_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string; required?: boolean }>;
+    };
+    const optional = def.fields
+      .filter((f) => f.required === false)
+      .map((f) => f.name);
+
+    expect(optional).toEqual(
+      expect.arrayContaining([
+        'durationMs',
+        'robotsBlocked.count',
+        'frontierSize.final',
+      ]),
+    );
+  });
+
+  test('nodes and edges are array-typed at the schema-diff level', () => {
+    const def = LINK_GRAPH_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string; type: string }>;
+    };
+    expect(def.fields.find((f) => f.name === 'nodes')?.type).toBe('array');
+    expect(def.fields.find((f) => f.name === 'edges')?.type).toBe('array');
+  });
+
+  test('sameOrigin is a boolean policy field', () => {
+    const def = LINK_GRAPH_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string; type: string }>;
+    };
+    expect(def.fields.find((f) => f.name === 'sameOrigin')?.type).toBe('boolean');
+  });
+
+  test('every field declares a primitive JS-type bucket', () => {
+    const def = LINK_GRAPH_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ type: string }>;
+    };
+    const allowed = new Set(['string', 'number', 'boolean', 'object', 'array', 'null']);
+    for (const f of def.fields) {
+      expect(allowed.has(f.type)).toBe(true);
+    }
+  });
+});
+
+describe('LINK_GRAPH_TEMPLATE — portability and registry', () => {
+  test('round-trips through JSON without loss', () => {
+    const copy = JSON.parse(JSON.stringify(LINK_GRAPH_TEMPLATE));
+    expect(copy).toEqual(LINK_GRAPH_TEMPLATE);
+  });
+
+  test('coexists with page-meta and spa-hydrated in the registry', () => {
+    const r = new TemplateRegistry();
+    r.register(PAGE_META_TEMPLATE);
+    r.register(SPA_HYDRATED_TEMPLATE);
+    r.register(LINK_GRAPH_TEMPLATE);
+
+    expect(r.size()).toBe(3);
+    expect(r.list().map((e) => e.id)).toEqual([
+      'public-web.link-graph',
+      'public-web.page-meta',
+      'public-web.spa-hydrated',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Concrete Tier-1 template for site-crawl link-graph extraction.

**Stacked on top of #1395 (A2-PR3 spa-hydrated).** Base branch is `feat/a2-template-spa-hydrated`.

## Schema

**Required (7):** `root`, `sameOrigin`, `nodeCount`, `edgeCount`, `maxDepth`, `nodes`, `edges`
**Optional (3):** `durationMs`, `robotsBlocked.count`, `frontierSize.final`

## Design note — coverage features vs raw payloads

The schema discriminates between:

- **Coverage features** (`nodeCount`, `edgeCount`, `maxDepth`) — numeric cardinality that two runs can diff cleanly.
- **Raw payloads** (`nodes`, `edges`) — array-typed; the schema-diff layer confirms presence and bucket only. Content-level diff is the host's job via a stricter contract or `oc_diff`.

## #1359 decision-rule check

| Rule | Answer |
|---|---|
| Pillar | C, E |
| stdio/HTTP | both |
| LLM judgment in host | yes |
| Portable artifact | yes |

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx jest tests/contracts/templates/` — 47/47 passing
  - 36 inherited (registry + page-meta + spa-hydrated) still pass
  - 11 new link-graph tests: identity, required/optional discrimination (7 vs 3), nodes/edges array-typed, sameOrigin boolean, JS-type bucket validity, JSON portability, sorted-list registry coexistence with page-meta and spa-hydrated

🤖 Generated with [Claude Code](https://claude.com/claude-code)