### PR TITLE
feat(contracts): public-web.authenticated-fields outcome contract template (A2-PR5)

### DIFF
--- a/src/contracts/templates/index.ts
+++ b/src/contracts/templates/index.ts
@@ -20,3 +20,4 @@ export { TemplateRegistry } from './registry';
 export { PAGE_META_TEMPLATE } from './public-web/page-meta';
 export { SPA_HYDRATED_TEMPLATE } from './public-web/spa-hydrated';
 export { LINK_GRAPH_TEMPLATE } from './public-web/link-graph';
+export { AUTHENTICATED_FIELDS_TEMPLATE } from './public-web/authenticated-fields';

--- a/src/contracts/templates/public-web/authenticated-fields.ts
+++ b/src/contracts/templates/public-web/authenticated-fields.ts
@@ -1,0 +1,88 @@
+/**
+ * public-web.authenticated-fields — outcome contract template
+ * (A2-PR5 of #1359).
+ *
+ * Declares the canonical schema for *post-authentication profile-field
+ * extraction* — the hard-track task family that exercises real-Chrome
+ * profile/auth reuse (#1359 §Pillar B).
+ *
+ * The schema separates three concerns:
+ *
+ *   - **Gate fact** — the host's pre-extraction read from
+ *     oc_gate_inspect (or a hand-constructed fact when the host knows
+ *     the gate by other means). The schema mirrors the closed
+ *     `kind`/`gateType` vocabulary so the diff can verify the host
+ *     reasoned about the gate before extracting.
+ *   - **Auth posture** — whether authentication was achieved and how
+ *     (cached-cookies vs interactive vs host-injected). The host
+ *     decides what counts as success; the schema only confirms the
+ *     posture was observed.
+ *   - **Profile fields** — the canonical post-login shape every
+ *     gated workflow surfaces: { userId, displayName, email,
+ *     emailVerified, plan? }. Hosts that need additional fields
+ *     clone the template inline and add them.
+ *
+ * The template **does not** bundle credentials, solver keys, or any
+ * heuristic for how to authenticate. Per #1359 §P7 the host owns the
+ * decision of how to clear the gate; the template only verifies the
+ * post-clear state is well-formed.
+ *
+ * Wire format is schema-diff.v1.
+ */
+
+import type { OutcomeTemplate } from '../types';
+
+export const AUTHENTICATED_FIELDS_TEMPLATE: OutcomeTemplate = {
+  id: 'public-web.authenticated-fields',
+  version: 1,
+  description:
+    'Tier-2 post-authentication profile-field extraction: gate-cleared ' +
+    'posture, gate fact reference, and canonical profile fields ' +
+    '(userId / displayName / email). The host owns gate-clearing; the ' +
+    'schema verifies the post-clear state is well-formed.',
+  tags: ['public-web', 'auth', 'profile', 'tier-2'],
+  targetSchema: {
+    format: 'schema-diff.v1',
+    definition: {
+      version: 1,
+      fields: [
+        // ── Auth posture ──────────────────────────────────────────────
+        // Required: the host MUST tell us whether authentication was
+        // achieved before claiming the rest of the fields are
+        // post-login state. `false` means the rest of the snapshot is
+        // pre-login.
+        { name: 'authenticated', type: 'boolean' },
+
+        // How the host believes authentication was reached.
+        // 'cached-cookies' | 'interactive' | 'host-injected' | 'unknown'
+        { name: 'authMethod', type: 'string' },
+
+        // ── Gate fact reference ───────────────────────────────────────
+        // The host's pre-extraction read of oc_gate_inspect (or an
+        // equivalent hand-constructed fact). Required so the diff can
+        // confirm the host reasoned about the gate.
+        { name: 'gate.detected', type: 'boolean' },
+
+        // The closed `kind` vocabulary from oc_gate_inspect (B2-PR1/PR2).
+        // 'captcha' | 'sso' | 'paywall' | '2fa'. Absent when
+        // gate.detected === false (treat with `required: false`).
+        { name: 'gate.kind', type: 'string', required: false },
+        { name: 'gate.gateType', type: 'string', required: false },
+
+        // ── Profile fields (post-login canonical shape) ───────────────
+        { name: 'profile.userId', type: 'string' },
+        { name: 'profile.displayName', type: 'string' },
+        { name: 'profile.email', type: 'string' },
+
+        // Optional but commonly available
+        { name: 'profile.emailVerified', type: 'boolean', required: false },
+        { name: 'profile.plan', type: 'string', required: false },
+        { name: 'profile.avatarUrl', type: 'string', required: false },
+        { name: 'profile.locale', type: 'string', required: false },
+
+        // ── Page identity (so the bundle can correlate with page-meta) ─
+        { name: 'url', type: 'string' },
+      ],
+    },
+  },
+};

--- a/tests/contracts/templates/public-web/authenticated-fields.test.ts
+++ b/tests/contracts/templates/public-web/authenticated-fields.test.ts
@@ -1,0 +1,143 @@
+/// <reference types="jest" />
+
+/**
+ * Tests for public-web.authenticated-fields template (A2-PR5 of #1359).
+ */
+
+import {
+  AUTHENTICATED_FIELDS_TEMPLATE,
+  PAGE_META_TEMPLATE,
+  SPA_HYDRATED_TEMPLATE,
+  LINK_GRAPH_TEMPLATE,
+  TemplateRegistry,
+} from '../../../../src/contracts/templates';
+
+describe('AUTHENTICATED_FIELDS_TEMPLATE — identity', () => {
+  test('id is "public-web.authenticated-fields" and version is 1', () => {
+    expect(AUTHENTICATED_FIELDS_TEMPLATE.id).toBe('public-web.authenticated-fields');
+    expect(AUTHENTICATED_FIELDS_TEMPLATE.version).toBe(1);
+  });
+
+  test('description mentions post-authentication and profile-field extraction', () => {
+    expect(AUTHENTICATED_FIELDS_TEMPLATE.description.toLowerCase()).toContain('post-authentication');
+    expect(AUTHENTICATED_FIELDS_TEMPLATE.description.toLowerCase()).toContain('profile-field');
+  });
+
+  test('tags include auth + profile + tier-2', () => {
+    expect(AUTHENTICATED_FIELDS_TEMPLATE.tags).toEqual(
+      expect.arrayContaining(['public-web', 'auth', 'profile', 'tier-2']),
+    );
+  });
+});
+
+describe('AUTHENTICATED_FIELDS_TEMPLATE — schema shape', () => {
+  test('targetSchema.format is schema-diff.v1', () => {
+    expect(AUTHENTICATED_FIELDS_TEMPLATE.targetSchema?.format).toBe('schema-diff.v1');
+  });
+
+  test('required fields cover auth posture, gate fact, core profile, url', () => {
+    const def = AUTHENTICATED_FIELDS_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string; type: string; required?: boolean }>;
+    };
+    const required = def.fields
+      .filter((f) => f.required !== false)
+      .map((f) => f.name);
+
+    expect(required).toEqual(
+      expect.arrayContaining([
+        'authenticated',
+        'authMethod',
+        'gate.detected',
+        'profile.userId',
+        'profile.displayName',
+        'profile.email',
+        'url',
+      ]),
+    );
+  });
+
+  test('gate.kind / gate.gateType are optional (absent when no gate)', () => {
+    const def = AUTHENTICATED_FIELDS_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string; required?: boolean }>;
+    };
+    const optional = def.fields
+      .filter((f) => f.required === false)
+      .map((f) => f.name);
+
+    expect(optional).toEqual(
+      expect.arrayContaining(['gate.kind', 'gate.gateType']),
+    );
+  });
+
+  test('profile enrichments (emailVerified, plan, avatarUrl, locale) are optional', () => {
+    const def = AUTHENTICATED_FIELDS_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string; required?: boolean }>;
+    };
+    const optional = def.fields
+      .filter((f) => f.required === false)
+      .map((f) => f.name);
+
+    expect(optional).toEqual(
+      expect.arrayContaining([
+        'profile.emailVerified',
+        'profile.plan',
+        'profile.avatarUrl',
+        'profile.locale',
+      ]),
+    );
+  });
+
+  test('authenticated is a boolean discriminator', () => {
+    const def = AUTHENTICATED_FIELDS_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string; type: string }>;
+    };
+    const field = def.fields.find((f) => f.name === 'authenticated');
+    expect(field?.type).toBe('boolean');
+  });
+
+  test('schema NEVER bundles credentials, tokens, or solver keys', () => {
+    const def = AUTHENTICATED_FIELDS_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ name: string }>;
+    };
+    const banned = ['password', 'token', 'apiKey', 'api_key', 'secret', 'credential'];
+    for (const f of def.fields) {
+      const lower = f.name.toLowerCase();
+      for (const b of banned) {
+        expect(lower).not.toContain(b);
+      }
+    }
+  });
+
+  test('every field declares a primitive JS-type bucket', () => {
+    const def = AUTHENTICATED_FIELDS_TEMPLATE.targetSchema?.definition as {
+      fields: Array<{ type: string }>;
+    };
+    const allowed = new Set(['string', 'number', 'boolean', 'object', 'array', 'null']);
+    for (const f of def.fields) {
+      expect(allowed.has(f.type)).toBe(true);
+    }
+  });
+});
+
+describe('AUTHENTICATED_FIELDS_TEMPLATE — portability and registry', () => {
+  test('round-trips through JSON without loss', () => {
+    const copy = JSON.parse(JSON.stringify(AUTHENTICATED_FIELDS_TEMPLATE));
+    expect(copy).toEqual(AUTHENTICATED_FIELDS_TEMPLATE);
+  });
+
+  test('coexists with all other public-web templates in the registry', () => {
+    const r = new TemplateRegistry();
+    r.register(PAGE_META_TEMPLATE);
+    r.register(SPA_HYDRATED_TEMPLATE);
+    r.register(LINK_GRAPH_TEMPLATE);
+    r.register(AUTHENTICATED_FIELDS_TEMPLATE);
+
+    expect(r.size()).toBe(4);
+    expect(r.list().map((e) => e.id)).toEqual([
+      'public-web.authenticated-fields',
+      'public-web.link-graph',
+      'public-web.page-meta',
+      'public-web.spa-hydrated',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Concrete Tier-2 template for **post-authentication profile-field extraction** — the hard-track task family that exercises real-Chrome profile/auth reuse (#1359 §Pillar B).

**Stacked on top of #1396 (A2-PR4 link-graph).** Base branch is `feat/a2-template-link-graph`. Final template in the A2-PR2..5 stack.

## Schema — three concerns

1. **Auth posture** — `authenticated` (boolean), `authMethod` (string).
2. **Gate fact reference** — `gate.detected` plus optional `gate.kind` / `gate.gateType` from `oc_gate_inspect` (B2-PR1 / B2-PR2).
3. **Profile fields** — `userId` / `displayName` / `email` required; `plan` / `emailVerified` / `avatarUrl` / `locale` optional.
4. **Page identity** — `url`, so the bundle can correlate with `public-web.page-meta`.

**Required (7):** `authenticated`, `authMethod`, `gate.detected`, `profile.userId`, `profile.displayName`, `profile.email`, `url`
**Optional (6):** `gate.kind`, `gate.gateType`, `profile.emailVerified`, `profile.plan`, `profile.avatarUrl`, `profile.locale`

## P7 negative test

Per #1359 §P7 the template bundles **NO** credentials, tokens, or solver keys. This is codified by a negative test that walks every field name for banned substrings (`password`, `token`, `apiKey`, `secret`, `credential`). The host owns gate-clearing; the schema only verifies the post-clear state is well-formed.

## #1359 decision-rule check

| Rule | Answer |
|---|---|
| Pillar | B (profile/auth reuse), C (contract-verifiable), E (benchmark) |
| Third-party credentials at boot | none — schema bundles no credentials, negative test enforces |
| stdio/HTTP | both |
| LLM judgment in host | yes — host owns gate-clearing |
| Portable artifact | yes |

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx jest tests/contracts/templates/` — 59/59 passing across all 5 suites
  - 47 inherited (registry + page-meta + spa-hydrated + link-graph) still pass
  - 12 new authenticated-fields tests: identity, required/optional discrimination (7 vs 6), `authenticated` boolean discriminator, **P7 credential-name negative assertion**, JS-type bucket validity, JSON portability, sorted-list registry coexistence with the other 3 templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)