### PR TITLE
docs(tools): document path_taken exemption for crawl_status (A3-PR2e)

### DIFF
--- a/src/tools/_shared/path-meta.ts
+++ b/src/tools/_shared/path-meta.ts
@@ -22,9 +22,12 @@
  * Known exemptions (tools that do NOT surface `meta.path_taken`):
  *
  *   - `crawl_start`: host-driven async tool that does not route through
- *     BrowserRouter. The router-decision facts for each crawled page are
- *     surfaced on `crawl_status` (per page) and on tool calls that consume
- *     the resulting pages.
+ *     BrowserRouter. The router-decision facts for each crawled page
+ *     belong inside the worker's per-page records and on tool calls that
+ *     consume the resulting pages.
+ *   - `crawl_status`: reads job state from the persisted job-store; it
+ *     does not route any tab through BrowserRouter. Per-page facts are
+ *     captured inside the worker, not surfaced on the status reader.
  */
 
 import type { SessionManager } from '../../session-manager';

--- a/src/tools/crawl-status.ts
+++ b/src/tools/crawl-status.ts
@@ -160,6 +160,13 @@ const handler: ToolHandler = async (
   for (const [k, v] of Object.entries(response)) {
     if (v !== undefined) cleaned[k] = v;
   }
+  // A3-PR2e note: `crawl_status` reads job state from the persisted
+  // job-store; it does not route any tab through BrowserRouter. The
+  // router-decision facts for each crawled page belong inside the
+  // worker's per-page records (a future PR) rather than on the
+  // status reader's response envelope. We deliberately omit
+  // `meta.path_taken` so the field does not give a misleading "n/a"
+  // signal that would force the host to special-case the value.
   return {
     content: [{ type: 'text', text: JSON.stringify(cleaned) }],
     ...cleaned,


### PR DESCRIPTION
## Summary

`crawl_status` reads job state from the persisted job-store; it does not route any tab through `BrowserRouter`. The router-decision facts for each crawled page belong inside the worker's per-page records rather than on the status reader's response envelope.

Make the boundary explicit:

1. Inline comment at the `crawl_status` response construction site explaining why `meta.path_taken` is deliberately omitted.
2. "Known exemptions" section in the `path-meta` helper docstring grows to include `crawl_status` alongside `crawl_start`.

No functional change.

**Stacked on top of #1400 (A3-PR2d crawl_start exemption).** Base branch is `feat/a3-crawl-start-path-meta`.

## #1359 decision-rule check

| Rule | Answer |
|---|---|
| Pillar | C (facts) — documents an honest fact-emission boundary |
| Backward compatibility | strictly additive (comments only) |

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean (no runtime change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)