### PR TITLE
feat(contracts): schema_diff-based promotion gate policy (B1-PR3)

### DIFF
--- a/src/core/contracts/promotion-gate.ts
+++ b/src/core/contracts/promotion-gate.ts
@@ -1,0 +1,122 @@
+/**
+ * Promotion gate — evaluate whether a SchemaDiff represents a contract
+ * success that's strong enough to promote a skill/selector record into
+ * verified memory (B1-PR3 of #1359).
+ *
+ * Per #1359 §P6 (verified memory only), the curator promotes records only
+ * from contract-verified successes. The schema-diff B1 thread emits
+ * structured facts (matched, missing, extra, typeMismatch, coverage); this
+ * module is the deterministic policy that turns those facts into a
+ * promote/skip decision.
+ *
+ * Pure function. No I/O. No Chrome dependency. Callers (curator,
+ * benchmark harness, host LLM) pass a {@link SchemaDiff} and an optional
+ * threshold record; the gate returns the decision plus a structured
+ * `reasons` array that downstream tracing/audit consumes.
+ *
+ * Defaults (chosen to be conservative for a default promotion bar):
+ *
+ *   - `minCoverage = 0.8` — require 80 % of required fields matched
+ *   - `maxTypeMismatch = 0` — any type mismatch blocks promotion
+ *   - `requireZeroMissing = false` — partial-match still promotes if
+ *     coverage clears the bar (callers can tighten this)
+ *
+ * Callers that need a different bar pass an `opts` record. The defaults
+ * never silently change once set; behaviour changes require a version
+ * bump in the policy module.
+ */
+
+import type { SchemaDiff } from './schema-diff';
+
+export interface PromotionGateOptions {
+  /** Minimum coverage (matched_required / required_total). Default 0.8. */
+  minCoverage?: number;
+  /** Max allowed type mismatches. Default 0. */
+  maxTypeMismatch?: number;
+  /**
+   * When true, any required field listed in `missing` blocks promotion
+   * regardless of coverage. Default false.
+   */
+  requireZeroMissing?: boolean;
+}
+
+export interface PromotionGateDecision {
+  eligible: boolean;
+  /**
+   * Structured reasons the gate evaluated. Always present — empty array
+   * means "no concerns observed". Lets callers attach the gate's
+   * verdict to audit trails without re-deriving the policy.
+   */
+  reasons: PromotionGateReason[];
+  /** The coverage value the gate compared against the bar. */
+  coverage: number;
+  /** The bar the gate compared against (after applying defaults). */
+  threshold: Required<PromotionGateOptions>;
+}
+
+export type PromotionGateReason =
+  | { kind: 'coverage_below_bar'; coverage: number; required: number }
+  | { kind: 'type_mismatch_present'; count: number; max: number; fields: string[] }
+  | { kind: 'missing_required_fields'; fields: string[] }
+  | { kind: 'pass' };
+
+const DEFAULTS: Required<PromotionGateOptions> = {
+  minCoverage: 0.8,
+  maxTypeMismatch: 0,
+  requireZeroMissing: false,
+};
+
+function resolveOptions(opts: PromotionGateOptions | undefined): Required<PromotionGateOptions> {
+  if (!opts) return DEFAULTS;
+  return {
+    minCoverage: typeof opts.minCoverage === 'number' && Number.isFinite(opts.minCoverage)
+      ? Math.max(0, Math.min(1, opts.minCoverage))
+      : DEFAULTS.minCoverage,
+    maxTypeMismatch: typeof opts.maxTypeMismatch === 'number' && Number.isFinite(opts.maxTypeMismatch)
+      ? Math.max(0, Math.floor(opts.maxTypeMismatch))
+      : DEFAULTS.maxTypeMismatch,
+    requireZeroMissing: opts.requireZeroMissing === true,
+  };
+}
+
+/**
+ * Evaluate whether a SchemaDiff clears the promotion bar.
+ *
+ * Idempotent and side-effect-free. Returns a structured decision —
+ * callers attach `reasons` to audit records and act on `eligible`.
+ */
+export function shouldPromoteFromSchemaDiff(
+  diff: SchemaDiff,
+  opts?: PromotionGateOptions,
+): PromotionGateDecision {
+  const threshold = resolveOptions(opts);
+  const reasons: PromotionGateReason[] = [];
+
+  if (diff.coverage < threshold.minCoverage) {
+    reasons.push({
+      kind: 'coverage_below_bar',
+      coverage: diff.coverage,
+      required: threshold.minCoverage,
+    });
+  }
+
+  if (diff.typeMismatch.length > threshold.maxTypeMismatch) {
+    reasons.push({
+      kind: 'type_mismatch_present',
+      count: diff.typeMismatch.length,
+      max: threshold.maxTypeMismatch,
+      fields: diff.typeMismatch.map(m => m.field),
+    });
+  }
+
+  if (threshold.requireZeroMissing && diff.missing.length > 0) {
+    reasons.push({ kind: 'missing_required_fields', fields: diff.missing });
+  }
+
+  if (reasons.length === 0) {
+    reasons.push({ kind: 'pass' });
+    return { eligible: true, reasons, coverage: diff.coverage, threshold };
+  }
+
+  return { eligible: false, reasons, coverage: diff.coverage, threshold };
+}

--- a/tests/core/contracts/promotion-gate.test.ts
+++ b/tests/core/contracts/promotion-gate.test.ts
@@ -1,0 +1,165 @@
+/// <reference types="jest" />
+
+/**
+ * Tests for the schema_diff-based promotion gate (B1-PR3 of #1359).
+ */
+
+import {
+  shouldPromoteFromSchemaDiff,
+} from '../../../src/core/contracts/promotion-gate';
+import type { SchemaDiff } from '../../../src/core/contracts/schema-diff';
+
+function diff(over: Partial<SchemaDiff> = {}): SchemaDiff {
+  return {
+    matched: [],
+    missing: [],
+    extra: [],
+    typeMismatch: [],
+    coverage: 1,
+    ...over,
+  };
+}
+
+describe('shouldPromoteFromSchemaDiff — defaults', () => {
+  test('full coverage and no mismatches → eligible with "pass" reason', () => {
+    const d = shouldPromoteFromSchemaDiff(diff({ coverage: 1 }));
+    expect(d.eligible).toBe(true);
+    expect(d.reasons).toEqual([{ kind: 'pass' }]);
+    expect(d.coverage).toBe(1);
+    expect(d.threshold.minCoverage).toBe(0.8);
+  });
+
+  test('coverage exactly at default bar (0.8) passes', () => {
+    const d = shouldPromoteFromSchemaDiff(diff({ coverage: 0.8 }));
+    expect(d.eligible).toBe(true);
+  });
+
+  test('coverage below default bar (0.79) blocks with coverage_below_bar', () => {
+    const d = shouldPromoteFromSchemaDiff(diff({ coverage: 0.79 }));
+    expect(d.eligible).toBe(false);
+    expect(d.reasons).toContainEqual({
+      kind: 'coverage_below_bar',
+      coverage: 0.79,
+      required: 0.8,
+    });
+  });
+
+  test('any type mismatch blocks under defaults', () => {
+    const d = shouldPromoteFromSchemaDiff(
+      diff({
+        coverage: 1,
+        typeMismatch: [{ field: 'statusCode', expected: 'number', got: 'string' }],
+      }),
+    );
+    expect(d.eligible).toBe(false);
+    expect(d.reasons).toContainEqual({
+      kind: 'type_mismatch_present',
+      count: 1,
+      max: 0,
+      fields: ['statusCode'],
+    });
+  });
+
+  test('default does not block on missing fields when coverage clears the bar', () => {
+    // Missing one optional field doesn't reduce coverage; but missing one
+    // required field does. Here we simulate "coverage stays at 0.9 with
+    // missing[]" — defaults allow it through.
+    const d = shouldPromoteFromSchemaDiff(diff({ coverage: 0.9, missing: ['preview'] }));
+    expect(d.eligible).toBe(true);
+  });
+});
+
+describe('shouldPromoteFromSchemaDiff — strict options', () => {
+  test('requireZeroMissing blocks when missing is non-empty', () => {
+    const d = shouldPromoteFromSchemaDiff(
+      diff({ coverage: 1, missing: ['description'] }),
+      { requireZeroMissing: true },
+    );
+    expect(d.eligible).toBe(false);
+    expect(d.reasons).toContainEqual({
+      kind: 'missing_required_fields',
+      fields: ['description'],
+    });
+  });
+
+  test('minCoverage = 1 requires perfect match', () => {
+    expect(
+      shouldPromoteFromSchemaDiff(diff({ coverage: 0.95 }), { minCoverage: 1 }).eligible,
+    ).toBe(false);
+    expect(
+      shouldPromoteFromSchemaDiff(diff({ coverage: 1 }), { minCoverage: 1 }).eligible,
+    ).toBe(true);
+  });
+
+  test('maxTypeMismatch = 2 allows up to 2 mismatches', () => {
+    const twoMismatches = diff({
+      coverage: 1,
+      typeMismatch: [
+        { field: 'a', expected: 'number', got: 'string' },
+        { field: 'b', expected: 'boolean', got: 'number' },
+      ],
+    });
+    expect(
+      shouldPromoteFromSchemaDiff(twoMismatches, { maxTypeMismatch: 2 }).eligible,
+    ).toBe(true);
+  });
+});
+
+describe('shouldPromoteFromSchemaDiff — option clamping', () => {
+  test('minCoverage clamps to [0, 1]', () => {
+    expect(shouldPromoteFromSchemaDiff(diff({ coverage: 0 }), { minCoverage: -5 }).threshold.minCoverage).toBe(0);
+    expect(shouldPromoteFromSchemaDiff(diff({ coverage: 1 }), { minCoverage: 5 }).threshold.minCoverage).toBe(1);
+  });
+
+  test('maxTypeMismatch clamps to >= 0 and floors', () => {
+    expect(
+      shouldPromoteFromSchemaDiff(diff(), { maxTypeMismatch: -3 }).threshold.maxTypeMismatch,
+    ).toBe(0);
+    expect(
+      shouldPromoteFromSchemaDiff(diff(), { maxTypeMismatch: 2.7 }).threshold.maxTypeMismatch,
+    ).toBe(2);
+  });
+
+  test('NaN / non-finite options fall back to defaults', () => {
+    const d = shouldPromoteFromSchemaDiff(diff(), {
+      minCoverage: Number.NaN,
+      maxTypeMismatch: Number.POSITIVE_INFINITY as unknown as number,
+    });
+    expect(d.threshold.minCoverage).toBe(0.8);
+    expect(d.threshold.maxTypeMismatch).toBe(0);
+  });
+});
+
+describe('shouldPromoteFromSchemaDiff — determinism', () => {
+  test('repeated evaluations on the same diff produce structurally identical output', () => {
+    const d1 = shouldPromoteFromSchemaDiff(
+      diff({ coverage: 0.75, missing: ['x', 'y'] }),
+    );
+    const d2 = shouldPromoteFromSchemaDiff(
+      diff({ coverage: 0.75, missing: ['x', 'y'] }),
+    );
+    expect(JSON.stringify(d1)).toBe(JSON.stringify(d2));
+  });
+});
+
+describe('shouldPromoteFromSchemaDiff — multiple reasons', () => {
+  test('blocking reasons accumulate (no short-circuit) — caller sees full diagnosis', () => {
+    const d = shouldPromoteFromSchemaDiff(
+      diff({
+        coverage: 0.5,
+        missing: ['statusCode'],
+        typeMismatch: [{ field: 'title', expected: 'string', got: 'number' }],
+      }),
+      { requireZeroMissing: true },
+    );
+    expect(d.eligible).toBe(false);
+    const kinds = d.reasons.map((r) => r.kind);
+    expect(kinds).toEqual(
+      expect.arrayContaining([
+        'coverage_below_bar',
+        'type_mismatch_present',
+        'missing_required_fields',
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Introduce `src/core/contracts/promotion-gate.ts` — a pure deterministic policy that turns a `SchemaDiff` (B1-PR1) into a promote-or-skip decision for verified-memory records.

Per #1359 §P6 (**verified memory only**): the curator must promote records only from contract-verified successes. This module is the authoritative threshold encoder; the schema-diff layer emits structured facts, and this layer turns those facts into a policy decision.

**Stacked on top of #1391 (B1-PR2 bundle schema-diff).** Base branch is `feat/b1-bundle-schema-diff`.

## API

```ts
shouldPromoteFromSchemaDiff(diff, opts?)
  → { eligible, reasons, coverage, threshold }
```

Defaults (conservative):
- `minCoverage: 0.8` — 80 % of required fields matched
- `maxTypeMismatch: 0` — any mismatch blocks
- `requireZeroMissing: false` — partial-match promotes if coverage clears the bar

## Properties

- **Pure / idempotent / deterministic** — same input → byte-identical output.
- **Blocking reasons accumulate** (no short-circuit) so the caller sees the full diagnosis in one pass.
- **Option clamping**: `minCoverage` to `[0, 1]`, `maxTypeMismatch` floored to `>= 0`, non-finite falls back to defaults.
- **Threshold echo**: the decision carries the bar that was applied, so audit trails record what policy ran.
- **Behaviour changes require a version bump** in the policy module — `DEFAULTS` is the SSOT.

## #1359 decision-rule check

| Rule | Answer |
|---|---|
| Pillar | C (contract-verifiable), D (verified memory promotion) |
| stdio/HTTP | both — pure function |
| LLM judgment in host | yes — host picks the threshold; default is conservative |
| Portable artifact | yes — JSON-serializable decision |

## Out of scope (follow-ups)

No curator integration in this PR. The follow-up wires this into `src/pilot/curator/promote.ts` and `src/pilot/curator/auto-extractor.ts` where contract-success records are written.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx jest tests/core/contracts/promotion-gate.test.ts tests/core/contracts/schema-diff.test.ts` — 29/29 passing
  - 13 cases for the gate: defaults (full match, 0.8 boundary, 0.79 block, type-mismatch block, missing-field tolerance), strict options (requireZeroMissing, minCoverage=1, maxTypeMismatch=2), option clamping (range and floor), NaN/Infinity fallback, determinism, multiple-reasons accumulation
  - 16 inherited schema-diff tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)