### PR TITLE
feat(evidence): add 'gate' part — gate fact in evidence bundle (B2-PR4)

### DIFF
--- a/src/core/contracts/evidence-bundle.ts
+++ b/src/core/contracts/evidence-bundle.ts
@@ -27,7 +27,24 @@ import * as path from 'node:path';
 import { phashFromPng, phashToHex } from '../../contracts/phash';
 
 /** Parts the caller can request. Each maps to a file in the bundle dir. */
-export type EvidenceBundlePart = 'dom' | 'screenshot' | 'network' | 'console' | 'phash';
+export type EvidenceBundlePart = 'dom' | 'screenshot' | 'network' | 'console' | 'phash' | 'gate';
+
+/**
+ * Gate fact surfaced into the bundle (B2-PR4). Mirrors the closed
+ * vocabulary of `oc_gate_inspect`'s output without depending on the tool
+ * module — the bundle writer is intentionally I/O-only.
+ */
+export interface GateFact {
+  detected: boolean;
+  kind?: string;
+  gateType?: string;
+  siteKey?: string;
+  siteKeySource?: string;
+  invisible?: boolean;
+  provider?: string;
+  selector?: string;
+  pageUrl?: string;
+}
 
 /** Default include set — cheap parts that almost every caller wants. */
 export const DEFAULT_INCLUDE: readonly EvidenceBundlePart[] = ['dom', 'screenshot'];
@@ -71,6 +88,12 @@ export interface EvidenceBundleSnapshot {
   console?: ConsoleEntry[];
   /** Optional clock used for the network window. Defaults to `Date.now()`. */
   now_ms?: number;
+  /**
+   * Caller-supplied gate fact (B2-PR4). Sourced from `oc_gate_inspect`
+   * or constructed by the host. Written to `gate.json` when the
+   * `gate` part is included.
+   */
+  gate?: GateFact;
 }
 
 export interface EvidenceBundleOptions {
@@ -177,6 +200,14 @@ export function writeEvidenceBundle(
     parts.push(filename);
   }
 
+  // ── Gate fact ─────────────────────────────────────────────────────────
+  if (include.has('gate') && snapshot.gate !== undefined) {
+    const filename = 'gate.json';
+    const payload = JSON.stringify(snapshot.gate, null, 2);
+    totalBytes += writePart(bundleDir, filename, payload);
+    parts.push(filename);
+  }
+
   // ── Perceptual hash ───────────────────────────────────────────────────
   if (include.has('phash')) {
     // If the caller didn't ask for the screenshot part but did ask for
@@ -218,7 +249,7 @@ function normalizeInclude(
   if (!include || include.length === 0) {
     return new Set(DEFAULT_INCLUDE);
   }
-  const valid: EvidenceBundlePart[] = ['dom', 'screenshot', 'network', 'console', 'phash'];
+  const valid: EvidenceBundlePart[] = ['dom', 'screenshot', 'network', 'console', 'phash', 'gate'];
   const out = new Set<EvidenceBundlePart>();
   for (const item of include) {
     if ((valid as string[]).includes(item)) out.add(item);

--- a/src/tools/oc-evidence-bundle.ts
+++ b/src/tools/oc-evidence-bundle.ts
@@ -48,6 +48,8 @@ interface SnapshotInput {
   network?: NetworkEntry[];
   console?: ConsoleEntry[];
   now_ms?: number;
+  /** Caller-supplied gate fact (typically the oc_gate_inspect output). */
+  gate?: Record<string, unknown>;
 }
 
 const VALID_PARTS: readonly EvidenceBundlePart[] = [
@@ -56,6 +58,7 @@ const VALID_PARTS: readonly EvidenceBundlePart[] = [
   'network',
   'console',
   'phash',
+  'gate',
 ];
 
 const definition: MCPToolDefinition = {
@@ -129,6 +132,13 @@ function buildSnapshot(input: SnapshotInput | undefined): EvidenceBundleSnapshot
   if (Array.isArray(input.network)) out.network = input.network;
   if (Array.isArray(input.console)) out.console = input.console;
   if (typeof input.now_ms === 'number') out.now_ms = input.now_ms;
+  if (input.gate && typeof input.gate === 'object') {
+    // Shallow-copy through with `unknown` shape; the bundle writer is
+    // schema-neutral and persists the JSON verbatim. The MCP tool surface
+    // intentionally avoids re-importing oc_gate_inspect types so the
+    // bundle module stays I/O-only.
+    out.gate = input.gate as unknown as EvidenceBundleSnapshot['gate'];
+  }
   return out;
 }
 

--- a/src/tools/oc-evidence-bundle.ts
+++ b/src/tools/oc-evidence-bundle.ts
@@ -77,7 +77,7 @@ const definition: MCPToolDefinition = {
         type: 'array',
         description:
           "Which parts to capture. Default ['dom', 'screenshot']. Allowed " +
-          "items: 'dom' | 'screenshot' | 'network' | 'console' | 'phash'.",
+          "items: 'dom' | 'screenshot' | 'network' | 'console' | 'phash' | 'gate'.",
         items: {
           type: 'string',
           enum: VALID_PARTS as unknown as string[],
@@ -93,7 +93,7 @@ const definition: MCPToolDefinition = {
         type: 'object',
         description:
           'Caller-supplied snapshot. Provide the subset of fields the requested ' +
-          'parts need: `dom`, `screenshot_png_base64`, `network`, `console`, `now_ms`. ' +
+          'parts need: `dom`, `screenshot_png_base64`, `network`, `console`, `now_ms`, `gate`. ' +
           'Missing fields cause the corresponding part to be omitted gracefully.',
         properties: {
           snapshot: {
@@ -101,7 +101,7 @@ const definition: MCPToolDefinition = {
             description:
               'Snapshot fields. `dom` (string|object), `screenshot_png_base64` (base64 PNG), ' +
               '`network` (NetworkEntry[]), `console` (ConsoleEntry[]), `now_ms` (epoch ms ' +
-              'used for the network window cutoff).',
+              'used for the network window cutoff), `gate` (oc_gate_inspect-compatible fact).',
           },
         },
       },

--- a/tests/core/contracts/evidence-bundle.test.ts
+++ b/tests/core/contracts/evidence-bundle.test.ts
@@ -144,6 +144,30 @@ describe('writeEvidenceBundle — individual include flags', () => {
     expect(payload.entries[49].text).toBe('line-249');
   });
 
+  test("include=['gate']: writes caller-supplied gate fact to gate.json", () => {
+    const rootDir = mkRoot();
+    const gate = {
+      detected: true,
+      kind: 'captcha',
+      gateType: 'turnstile',
+      siteKey: 'site-key-1',
+      siteKeySource: 'data-sitekey',
+      invisible: false,
+      provider: 'cloudflare',
+      selector: '#challenge',
+      pageUrl: 'https://example.test/login',
+    };
+    const result = writeEvidenceBundle({ gate }, { rootDir, include: ['gate'] });
+    expect(result.parts).toEqual(['gate.json']);
+    expect(readJson(path.join(result.path, 'gate.json'))).toEqual(gate);
+  });
+
+  test("include=['gate'] without a gate fact omits the part gracefully", () => {
+    const rootDir = mkRoot();
+    const result = writeEvidenceBundle({}, { rootDir, include: ['gate'] });
+    expect(result.parts).toEqual([]);
+  });
+
   test("include=['phash']: writes a 16-char lowercase hex digest", () => {
     const rootDir = mkRoot();
     const png = encodeRgbaPng(32, 32, gradientRgba(32, 32));


### PR DESCRIPTION
## Summary

Extend the evidence bundle vocabulary with a `'gate'` part that persists the host's pre-extraction gate-detection fact (`oc_gate_inspect` output or equivalent) to `gate.json` inside the bundle directory.

**Stacked on top of #1392 (B2-PR2 extended gate detection).** Base branch is `feat/b2-gate-extend`.

## Changes

- New `EvidenceBundlePart` `'gate'` + `GateFact` interface mirroring the closed `oc_gate_inspect` vocabulary (`detected`, `kind`, `gateType`, `siteKey`, `siteKeySource`, `invisible`, `provider`, `selector`, `pageUrl`).
- `EvidenceBundleSnapshot` gains optional `gate` field.
- `writeEvidenceBundle` writes `gate.json` when both `'gate'` is in the include set **AND** `snapshot.gate` is supplied.
- `oc_evidence_bundle` MCP tool snapshot input accepts `gate` as opaque `Record<string, unknown>` so the bundle module stays I/O-only (no import of tool-side types).
- `VALID_PARTS` list extended in both source files.

Strictly additive. Default include set is unchanged (`['dom', 'screenshot']`) so existing callers see no behavior change.

## Why this matters

Per #1359 §Pillar C (facts before decisions): every evidence bundle the host captures now records the **gate it observed before extraction**, alongside DOM / screenshot / network / console. The host agent's decision of *how to clear the gate* is unaffected — this PR only records the fact.

## #1359 decision-rule check

| Rule | Answer |
|---|---|
| Pillar | C (facts before decisions) |
| stdio/HTTP | both |
| Backward compatibility | strictly additive — default include unchanged |
| LLM judgment in host | yes — gate fact is a label, host decides |
| Portable artifact | yes — `gate.json` on disk |

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx jest tests/core/contracts/evidence-bundle.test.ts` — 20/20 passing (no regression on the other bundle parts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)