### PR TITLE
feat(tools): oc_profile_fingerprint MCP tool (B3-PR2)

### DIFF
--- a/src/tools/__tests__/__snapshots__/tools-list.v1.11.snap.json
+++ b/src/tools/__tests__/__snapshots__/tools-list.v1.11.snap.json
@@ -151,6 +151,9 @@
       "name": "oc_policy"
     },
     {
+      "name": "oc_profile_fingerprint"
+    },
+    {
       "name": "oc_profile_status"
     },
     {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -116,6 +116,9 @@ import { registerTotpGenerateTool } from './totp-generate';
 // Outcome Contracts (#784) — single-call assertion verifier
 import { registerOcAssertTool } from './oc-assert';
 
+// Profile fingerprint (B3-PR2 of #1359) — secret-free profile shape hash
+import { registerOcProfileFingerprintTool } from './oc-profile-fingerprint';
+
 // Outcome Contracts (#792) — evidence bundle capture
 import { registerOcEvidenceBundleTool } from './oc-evidence-bundle';
 import { registerOcDiffTool } from './oc-diff';
@@ -220,6 +223,7 @@ export const TOOL_CAPABILITY_MAP: Record<string, ToolCapability> = {
   network_capture_full: 'core',
   network_capture_lite: 'core',
   oc_assert: 'core',
+  oc_profile_fingerprint: 'core',
   oc_checkpoint: 'core',
   oc_context_export: 'core',
   oc_context_import: 'core',
@@ -495,6 +499,9 @@ export function registerAllTools(server: MCPServer): void {
 
   // Outcome Contracts (#784) — single-call assertion verifier
   registerOcAssertTool(proxy);
+
+  // Profile fingerprint (B3-PR2 of #1359) — secret-free profile shape hash
+  registerOcProfileFingerprintTool(proxy);
 
   // Action schema normalizer (#1062) — no browser side effects.
   registerOcNormalizeActionTool(server);

--- a/src/tools/oc-profile-fingerprint.ts
+++ b/src/tools/oc-profile-fingerprint.ts
@@ -1,0 +1,139 @@
+/**
+ * oc_profile_fingerprint — secret-free profile fingerprint MCP tool
+ * (B3-PR2 of #1359).
+ *
+ * Captures the current tab's storage state (cookies + localStorage +
+ * sessionStorage + origin) via the same CDP walker that
+ * `oc_context_export` uses, runs it through the deterministic
+ * fingerprint pipeline (B3-PR1), and returns a hex digest plus a
+ * non-secret breakdown.
+ *
+ * The fingerprint is a SHAPE hash — values never enter the hash. Two
+ * sessions with identical storage layouts but different secrets
+ * fingerprint identically; this is the intended property and the
+ * negative tests on `fingerprintEnvelope` enforce it.
+ *
+ * Per #1359 §Pillar B (profile/auth reuse) + §Pillar D (portable
+ * memory): the host uses this tool to ask "is this the same logged-in
+ * session?" *without* needing access to the secrets themselves.
+ *
+ * Read-only annotation: capture is observation only — no cookies or
+ * storage entries are written or deleted.
+ */
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
+import { getSessionManager } from '../session-manager';
+import {
+  captureContextEnvelopeData,
+  type CDPClientLike,
+} from '../storage-state/storage-state-manager';
+import {
+  fingerprintEnvelope,
+  FINGERPRINT_ALGORITHM,
+  FINGERPRINT_VERSION,
+  type ProfileFingerprint,
+} from '../storage-state/fingerprint';
+
+interface OcProfileFingerprintOutput {
+  /** Lowercase hex digest. 64 chars for sha256. */
+  hash: string;
+  algorithm: typeof FINGERPRINT_ALGORITHM;
+  version: typeof FINGERPRINT_VERSION;
+  /**
+   * Non-secret diagnostic counts. Lets the host verify the capture
+   * shape (e.g. "12 cookies, 3 localStorage keys for https://example.com")
+   * without exposing values.
+   */
+  breakdown: ProfileFingerprint['breakdown'];
+}
+
+const definition: MCPToolDefinition = {
+  name: 'oc_profile_fingerprint',
+  description:
+    'Compute a deterministic, secret-free fingerprint of the current ' +
+    'tab\'s storage state (cookies + localStorage + sessionStorage + ' +
+    'origin). Returns { hash, version, algorithm, breakdown }. Values ' +
+    'never enter the hash — two sessions with identical layouts but ' +
+    'different secrets fingerprint identically. Read-only. Useful for ' +
+    'comparing two captures to ask "is this the same logged-in ' +
+    'session?" without seeing the secrets.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      tabId: {
+        type: 'string',
+        description: 'Tab ID to fingerprint. Required.',
+      },
+      includeSessionStorage: {
+        type: 'boolean',
+        description:
+          'Capture window.sessionStorage for the active origin in the ' +
+          'fingerprint. Default false (sessionStorage is ephemeral per ' +
+          'tab so excluding it makes fingerprints more comparable ' +
+          'across reattach).',
+      },
+    },
+    required: ['tabId'],
+  },
+  annotations: TOOL_ANNOTATIONS.oc_profile_fingerprint,
+};
+
+function errorResult(message: string): MCPResult {
+  return {
+    content: [{ type: 'text', text: `Error: ${message}` }],
+    isError: true,
+  };
+}
+
+const handler: ToolHandler = async (
+  sessionId: string,
+  args: Record<string, unknown>,
+): Promise<MCPResult> => {
+  const tabId = typeof args.tabId === 'string' ? args.tabId : '';
+  if (!tabId) return errorResult('tabId is required');
+
+  const includeSessionStorage = args.includeSessionStorage === true;
+
+  const sessionManager = getSessionManager();
+  const page = await sessionManager.getPage(sessionId, tabId, undefined, 'oc_profile_fingerprint');
+  if (!page) return errorResult(`Tab ${tabId} not found`);
+
+  // Use the same CDP walker that powers oc_context_export so the
+  // fingerprint reflects the same envelope shape downstream tools
+  // would see when round-tripping the storage state.
+  const cdpClient = sessionManager.getCDPClient();
+  const cdpClientLike: CDPClientLike = {
+    send: <T,>(p: import('puppeteer-core').Page, method: string, params?: Record<string, unknown>): Promise<T> =>
+      cdpClient.send<T>(p, method, params),
+  };
+
+  let envelope;
+  try {
+    envelope = await captureContextEnvelopeData(page, cdpClientLike, {
+      includeCookies: true,
+      includeLocalStorage: true,
+      includeSessionStorage,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return errorResult(`failed to capture envelope: ${message}`);
+  }
+
+  const fp = fingerprintEnvelope(envelope);
+  const out: OcProfileFingerprintOutput = {
+    hash: fp.hash,
+    algorithm: fp.algorithm,
+    version: fp.version,
+    breakdown: fp.breakdown,
+  };
+
+  return {
+    content: [{ type: 'text', text: JSON.stringify(out) }],
+  };
+};
+
+export function registerOcProfileFingerprintTool(server: MCPServer): void {
+  server.registerTool('oc_profile_fingerprint', handler, definition);
+}

--- a/src/types/tool-annotations.ts
+++ b/src/types/tool-annotations.ts
@@ -83,6 +83,7 @@ export const TOOL_ANNOTATIONS = {
   oc_skill_export: READ_ONLY,
   vision_find: READ_ONLY,
   oc_assert: READ_ONLY,
+  oc_profile_fingerprint: READ_ONLY,
   oc_recording_list: READ_ONLY,
   oc_recording_status: READ_ONLY,
   workflow_status: READ_ONLY,


### PR DESCRIPTION
## Summary

Expose `fingerprintEnvelope` (B3-PR1, #1387) as a **Tier-1 read-only MCP tool**. Captures the current tab's storage state (cookies + localStorage + sessionStorage + origin) via the same CDP walker `oc_context_export` uses, runs it through the deterministic fingerprint pipeline, and returns:

```ts
{ hash, version, algorithm, breakdown }
```

The hash is a **shape hash** — values never enter it. Two sessions with identical layouts but different secrets fingerprint identically; the negative tests on `fingerprintEnvelope` enforce that invariant.

**Stacked on top of #1387 (B3-PR1).** Base branch is `feat/b3-fingerprint`.

## Why

Per #1359 §Pillar B (profile/auth reuse) + §Pillar D (portable memory): the host uses this tool to ask *"is this the same logged-in session?"* without needing access to the secrets themselves.

## Wiring

- new `READ_ONLY` entry in `TOOL_ANNOTATIONS`;
- registered in `registerAllTools()` with capability `'core'`;
- v1.11 tools-list snapshot extended to include the new tool name.

## Defaults

`includeSessionStorage: false` so the fingerprint stays comparable across reattach (sessionStorage is ephemeral per tab). Callers that need to bind to a single live tab pass `true`.

## #1359 decision-rule check

| Rule | Answer |
|---|---|
| Pillar | B (profile/auth reuse), D (portable memory) |
| stdio/HTTP | both — read-only tool surface |
| Third-party credentials at boot | none |
| LLM judgment in host | yes — hash is a label, host decides |
| Real Chrome state | read-only (captures cookies/storage; never writes) |
| Portable artifact | yes — JSON `{hash, version, algorithm, breakdown}` |

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx jest tests/storage-state/fingerprint.test.ts tests/capability-filter.test.ts` — 14 + snapshot tests passing (no regression on the pure function or the tools-list baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)