### PR TITLE
feat(tools): oc_context_export/import accept portable signed envelope (B3-PR4)

### DIFF
--- a/src/storage-state/index.ts
+++ b/src/storage-state/index.ts
@@ -9,3 +9,23 @@ export {
   captureContextEnvelopeData,
   applyContextEnvelopeData,
 } from './storage-state-manager';
+
+export {
+  fingerprintEnvelope,
+  FINGERPRINT_VERSION,
+  FINGERPRINT_ALGORITHM,
+  type ProfileFingerprint,
+  type FingerprintBreakdown,
+} from './fingerprint';
+
+export {
+  sealEnvelope,
+  verifyEnvelope,
+  ENVELOPE_VERSION,
+  ENVELOPE_HMAC_ALGORITHM,
+  type PortableSnapshotEnvelope,
+  type VerifyResult,
+  type VerifyFailureReason,
+  type SealOptions,
+  type VerifyOptions,
+} from './envelope';

--- a/src/tools/oc-context.ts
+++ b/src/tools/oc-context.ts
@@ -456,6 +456,13 @@ const importDefinition: MCPToolDefinition = {
           '`signed_envelope`. Host-supplied; openchrome never stores ' +
           'or generates this key.',
       },
+      requireHmac: {
+        type: 'boolean',
+        description:
+          'When true, signed_envelope import requires a valid HMAC and ' +
+          'fails before applying state if the envelope is unsigned or no ' +
+          'hmacKey is provided. Default false.',
+      },
     },
     required: ['tabId'],
   },
@@ -476,7 +483,11 @@ const importHandler: ToolHandler = async (
     const hmacKey = typeof args.hmacKey === 'string' && args.hmacKey.length > 0
       ? args.hmacKey
       : undefined;
-    const verified = verifyEnvelope(args.signed_envelope, hmacKey ? { hmacKey } : {});
+    const verifyOptions = {
+      ...(hmacKey ? { hmacKey } : {}),
+      ...(args.requireHmac === true ? { requireHmac: true } : {}),
+    };
+    const verified = verifyEnvelope(args.signed_envelope, verifyOptions);
     if (!verified.ok) {
       const response: ImportResponse = {
         ok: false,

--- a/src/tools/oc-context.ts
+++ b/src/tools/oc-context.ts
@@ -30,7 +30,10 @@ import { assertDomainAllowed } from '../security/domain-guard';
 import {
   captureContextEnvelopeData,
   applyContextEnvelopeData,
+  sealEnvelope,
+  verifyEnvelope,
   type EnvelopeCapture,
+  type PortableSnapshotEnvelope,
 } from '../storage-state';
 import type { StorageState } from '../storage-state/storage-state-manager';
 
@@ -303,6 +306,22 @@ const exportDefinition: MCPToolDefinition = {
         type: 'boolean',
         description: 'Capture navigator.userAgent. Default: false.',
       },
+      signedEnvelope: {
+        type: 'boolean',
+        description:
+          'When true, additionally include a `signed_envelope` field in ' +
+          'the response: a portable v1 envelope (B3-PR3 of #1359) sealed ' +
+          'over the same capture, fingerprinted, and optionally HMAC-' +
+          'signed. Strictly additive — the existing `ContextEnvelope` ' +
+          'output is unchanged. Default: false.',
+      },
+      hmacKey: {
+        type: 'string',
+        description:
+          'Optional HMAC signing key (UTF-8). Only used when ' +
+          '`signedEnvelope=true`. Host-supplied; openchrome never ' +
+          'stores or generates this key.',
+      },
     },
     required: ['tabId'],
   },
@@ -363,9 +382,23 @@ const exportHandler: ToolHandler = async (
       httpAuth: undefined,
     });
 
+    // B3-PR4 of #1359: opt-in portable signed envelope. Additive only —
+    // the existing `envelope` response shape is unchanged.
+    let signed_envelope: PortableSnapshotEnvelope | undefined;
+    if (args.signedEnvelope === true) {
+      const hmacKey = typeof args.hmacKey === 'string' && args.hmacKey.length > 0
+        ? args.hmacKey
+        : undefined;
+      signed_envelope = sealEnvelope(capture, hmacKey ? { hmacKey } : {});
+    }
+
+    const responsePayload: Record<string, unknown> = { envelope };
+    if (signed_envelope) responsePayload.signed_envelope = signed_envelope;
+
     return {
-      content: [{ type: 'text', text: JSON.stringify({ envelope }) }],
+      content: [{ type: 'text', text: JSON.stringify(responsePayload) }],
       envelope,
+      ...(signed_envelope ? { signed_envelope } : {}),
     };
   } catch (error) {
     return errorResult(
@@ -405,8 +438,26 @@ const importDefinition: MCPToolDefinition = {
           'When true, reject the import if the active tab origin does not match ' +
           '`envelope.origin`. Default: false (caller is responsible for navigating).',
       },
+      signed_envelope: {
+        type: 'object',
+        description:
+          'B3-PR4: alternative input. A portable v1 envelope (B3-PR3) ' +
+          'produced by `oc_context_export` with `signedEnvelope=true`. ' +
+          'When supplied, the import verifies the portable envelope ' +
+          'first (fingerprint + optional HMAC via `hmacKey`); on success ' +
+          'the verified payload is materialized into the same flow as ' +
+          'the legacy `envelope` input. When both are supplied, ' +
+          '`signed_envelope` wins.',
+      },
+      hmacKey: {
+        type: 'string',
+        description:
+          'Optional HMAC key (UTF-8). Only used when verifying a ' +
+          '`signed_envelope`. Host-supplied; openchrome never stores ' +
+          'or generates this key.',
+      },
     },
-    required: ['tabId', 'envelope'],
+    required: ['tabId'],
   },
 };
 
@@ -415,8 +466,41 @@ const importHandler: ToolHandler = async (
   args: Record<string, unknown>,
 ): Promise<MCPResult> => {
   const tabId = args.tabId as string | undefined;
-  const envelope = args.envelope as ContextEnvelope | undefined;
+  let envelope = args.envelope as ContextEnvelope | undefined;
   const strictOrigin = args.strictOrigin === true;
+
+  // B3-PR4 of #1359: opt-in portable-envelope input. When supplied, verify
+  // first and materialize a ContextEnvelope from the verified payload.
+  // Wins over the legacy `envelope` arg when both are present.
+  if (args.signed_envelope && typeof args.signed_envelope === 'object') {
+    const hmacKey = typeof args.hmacKey === 'string' && args.hmacKey.length > 0
+      ? args.hmacKey
+      : undefined;
+    const verified = verifyEnvelope(args.signed_envelope, hmacKey ? { hmacKey } : {});
+    if (!verified.ok) {
+      const response: ImportResponse = {
+        ok: false,
+        appliedCookies: 0,
+        appliedStorageKeys: 0,
+        integrityError: `signed_envelope verification failed: ${verified.reason}`,
+      };
+      return {
+        content: [{ type: 'text', text: JSON.stringify(response) }],
+        ...response,
+      };
+    }
+    // Materialize a ContextEnvelope from the verified payload so the
+    // existing apply path stays the SSOT.
+    const capture: EnvelopeCapture = verified.envelope.payload;
+    envelope = buildEnvelope({
+      capture,
+      origin: capture.origin || '',
+      includeStorage: true,
+      includeHttpAuth: false,
+      captureUA: !!capture.userAgent,
+      httpAuth: undefined,
+    });
+  }
 
   if (!tabId) return errorResult('Error: tabId is required');
   if (!envelope || typeof envelope !== 'object') {

--- a/tests/tools/oc-context-replace.test.ts
+++ b/tests/tools/oc-context-replace.test.ts
@@ -32,6 +32,7 @@ import {
   applyContextEnvelopeData,
   type EnvelopeCapture,
 } from '../../src/storage-state/storage-state-manager';
+import { sealEnvelope } from '../../src/storage-state/envelope';
 import { setGlobalConfig } from '../../src/config/global';
 import * as sessionManagerModule from '../../src/session-manager';
 import type { Page } from 'puppeteer-core';
@@ -520,6 +521,70 @@ describe('applyContextEnvelopeData strict-replace', () => {
       jest.restoreAllMocks();
     }
   });
+
+  test('signed_envelope import with requireHmac rejects unsigned payload before applying state', async () => {
+    const signedEnvelope = sealEnvelope({
+      origin: 'https://httpbin.org',
+      cookies: [{
+        name: 'sid',
+        value: 'secret',
+        domain: 'httpbin.org',
+        path: '/',
+        expires: 1_900_000_000,
+        size: 6,
+        httpOnly: true,
+        secure: true,
+        session: false,
+      }],
+      localStorage: { fresh: 'value' },
+      sessionStorage: {},
+    }, { now: 1000 });
+
+    const dest = makeHarness({
+      origin: 'https://httpbin.org',
+      cookies: [{
+        name: 'stale',
+        value: 'keep',
+        domain: 'httpbin.org',
+        path: '/',
+        expires: 1_900_000_000,
+        size: 4,
+        httpOnly: false,
+        secure: true,
+        session: false,
+      }],
+      localStorage: { stale: 'keep' },
+      sessionStorage: {},
+    });
+
+    jest.spyOn(sessionManagerModule, 'getSessionManager').mockReturnValue({
+      getPage: async () => dest.page,
+      getCDPClient: () => dest.cdpClient,
+    } as unknown as ReturnType<typeof sessionManagerModule.getSessionManager>);
+
+    const handlers: Record<string, (sessionId: string, args: Record<string, unknown>) => Promise<unknown>> = {};
+    registerOcContextTools({
+      registerTool: (name: string, handler: (sessionId: string, args: Record<string, unknown>) => Promise<unknown>) => {
+        handlers[name] = handler;
+      },
+    } as never);
+
+    try {
+      const result = await handlers.oc_context_import('session', {
+        tabId: 'tab',
+        signed_envelope: signedEnvelope,
+        requireHmac: true,
+      }) as { ok: boolean; integrityError?: string };
+
+      expect(result.ok).toBe(false);
+      expect(result.integrityError).toContain('signed_envelope verification failed');
+      expect(dest.state.cookies.map((c) => c.name)).toEqual(['stale']);
+      expect(dest.state.localStorage).toEqual({ stale: 'keep' });
+    } finally {
+      jest.restoreAllMocks();
+    }
+  });
+
 });
 
 describe('oc_context_import security policy', () => {


### PR DESCRIPTION
## Summary

Wire the B3-PR3 portable envelope into both halves of the `oc_context_*` surface. Strictly additive: the existing `ContextEnvelope` output and `envelope` input are unchanged.

**Stacked on top of #1407 (B3-PR3 portable envelope).** Base branch is `feat/b3-portable-envelope`.

## Export — opt-in `signedEnvelope`

New args:
- `signedEnvelope: boolean` (default false)
- `hmacKey: string` (optional, only used when `signedEnvelope=true`)

When `signedEnvelope=true`, the response gains a `signed_envelope` field carrying the B3-PR3 `PortableSnapshotEnvelope` sealed over the same capture, fingerprinted, and optionally HMAC-signed.

## Import — `signed_envelope` accepted as an alternative

When supplied, the import:
1. **Verifies the portable envelope first** (fingerprint + optional HMAC via `hmacKey`). On failure returns `{ ok: false, integrityError: 'signed_envelope verification failed: <reason>' }` **without applying any state**.
2. Materializes a `ContextEnvelope` from the verified payload via `buildEnvelope()` so the existing strict-replace apply path stays the SSOT.

`signed_envelope` wins when both are supplied. `tabId` remains the only `required` field on import (envelope-or-signed-envelope is now the implicit constraint, surfaced as an error result rather than at the schema level so we can give a precise message).

## #1359 decision-rule check

| Rule | Answer |
|---|---|
| Pillar | B (profile/auth reuse), D (portable memory) |
| Third-party credentials at boot | none — HMAC key host-supplied, optional |
| stdio/HTTP | both — pure JSON I/O |
| Backward compatibility | strictly additive — existing `envelope`/`signedEnvelope=false` paths untouched |
| LLM judgment in host | yes — host picks signed vs unsigned |
| Portable artifact | yes — versioned JSON, fingerprint-verifiable, optionally HMAC-signed |

## Public surface

`src/storage-state/index.ts` re-exports fingerprint and envelope symbols so downstream consumers don't deep-import.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx jest tests/storage-state` — 54/54 across 4 suites
  - 18 envelope tests (seal/verify/failure-modes)
  - 14 fingerprint tests
  - 22 inherited (storage-state-manager etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)