### PR TITLE
docs+example(external): airena-adapter sample wiring (External)

### DIFF
--- a/benchmark/EXTERNAL-WORKLOADS.md
+++ b/benchmark/EXTERNAL-WORKLOADS.md
@@ -18,8 +18,8 @@ host-neutrality (#1359 §P1) holds in practice.
 
 This file lists *registered* external workloads — adapters whose pure
 mapping logic (the openchrome → workload-shape transform) lives in
-`examples/external/<name>/` and whose mapper tests pass under
-`npx jest examples/external/<name>/`.
+`tests/external/<name>/` and whose mapper tests pass under
+`npx jest tests/external/<name>/`.
 
 ## Registered workloads
 
@@ -28,8 +28,8 @@ mapping logic (the openchrome → workload-shape transform) lives in
 - **Scope:** crawler-arena style benchmark scoring (round-based).
 - **Adapter:** `examples/external/airena-adapter/`
 - **Status:** sample.
-- **Mapping logic:** `examples/external/airena-adapter/map-to-airena.mjs`
-- **Tests:** `examples/external/airena-adapter/map-to-airena.test.mjs`
+- **Mapping logic:** `tests/external/airena-adapter/map-to-airena.ts`
+- **Tests:** `tests/external/airena-adapter/map-to-airena.test.ts`
 - **MCP surfaces consumed:**
   - `extract_data` (with public-web templates from
     `src/contracts/templates/public-web/`)
@@ -45,12 +45,14 @@ mapping logic (the openchrome → workload-shape transform) lives in
 2. Add a directory under `examples/external/<name>/`:
    - `README.md` — what the workload does, what MCP surfaces it
      consumes, how to run it (out of scope here).
-   - `map-to-<workload>.mjs` — **pure mapping function** from
+   - Runtime source may live wherever the host wants; in-repo
+     samples keep TypeScript mapper tests under `tests/external/<name>/`
+     so repo tooling can typecheck them.
+   - `map-to-<workload>.ts` — **pure mapping function** from
      openchrome facts to the workload's score envelope.
-   - `map-to-<workload>.test.mjs` — Jest tests on the mapper alone
+   - `map-to-<workload>.test.ts` — Jest tests on the mapper alone
      (no MCP transport, no network).
-   - `adapter.mjs` — sample wire-up (untested transport, host runs it
-     themselves).
+   - `adapter.ts` — sample wire-up (transport is host-owned).
 3. Append an entry above with the same fields.
 
 ## #1359 alignment

--- a/benchmark/EXTERNAL-WORKLOADS.md
+++ b/benchmark/EXTERNAL-WORKLOADS.md
@@ -1,0 +1,67 @@
+# External Benchmark Workloads
+
+Catalog of *external* benchmark workloads that consume openchrome through
+its **public MCP surfaces** without being part of the openchrome build
+graph. These workloads validate that openchrome's fact-emission surfaces
+(schema-diff, gate-inspect, fingerprint, path-taken) compose with
+third-party scoring systems — i.e. that openchrome's claimed
+host-neutrality (#1359 §P1) holds in practice.
+
+## Difference vs `benchmark/`
+
+| `benchmark/` (in-tree) | `examples/external/` (out-of-tree) |
+|---|---|
+| Run by openchrome CI | Run by the external benchmark host |
+| Failures gate openchrome PRs | Failures do not gate openchrome |
+| Built from openchrome internals | Composed of public MCP tool calls only |
+| Maintained by openchrome | Maintained by the workload owner |
+
+This file lists *registered* external workloads — adapters whose pure
+mapping logic (the openchrome → workload-shape transform) lives in
+`examples/external/<name>/` and whose mapper tests pass under
+`npx jest examples/external/<name>/`.
+
+## Registered workloads
+
+### airena.lol
+
+- **Scope:** crawler-arena style benchmark scoring (round-based).
+- **Adapter:** `examples/external/airena-adapter/`
+- **Status:** sample.
+- **Mapping logic:** `examples/external/airena-adapter/map-to-airena.mjs`
+- **Tests:** `examples/external/airena-adapter/map-to-airena.test.mjs`
+- **MCP surfaces consumed:**
+  - `extract_data` (with public-web templates from
+    `src/contracts/templates/public-web/`)
+  - `oc_evidence_bundle` (with `target_schema` from B1-PR2)
+  - `oc_gate_inspect` (B2-PR1 + B2-PR2)
+  - `oc_profile_fingerprint` (B3-PR2)
+- **Pillar coverage:** C (facts), E (benchmark anchoring)
+
+## How to register a new workload
+
+1. Pick a host-neutral name (no openchrome-internal references in the
+   directory or README).
+2. Add a directory under `examples/external/<name>/`:
+   - `README.md` — what the workload does, what MCP surfaces it
+     consumes, how to run it (out of scope here).
+   - `map-to-<workload>.mjs` — **pure mapping function** from
+     openchrome facts to the workload's score envelope.
+   - `map-to-<workload>.test.mjs` — Jest tests on the mapper alone
+     (no MCP transport, no network).
+   - `adapter.mjs` — sample wire-up (untested transport, host runs it
+     themselves).
+3. Append an entry above with the same fields.
+
+## #1359 alignment
+
+- **§P1** (host-neutral MCP first): external workloads MUST consume
+  only public MCP tool calls. No imports from `src/` allowed in
+  `examples/external/`.
+- **§P4** (facts before decisions): the openchrome side emits facts
+  only. The mapper turns facts into a host-shaped score envelope.
+  Any scoring threshold lives in the mapper, not in openchrome.
+- **§P5** (evidence before claims): claims about competitive
+  performance against an external workload must cite a reproducible
+  run through that workload's adapter, with the openchrome version
+  pinned.

--- a/examples/external/airena-adapter/README.md
+++ b/examples/external/airena-adapter/README.md
@@ -53,9 +53,9 @@ separate test scaffold; this `examples/` directory is README-only.
 
 ## Running (out of scope here)
 
-`adapter.mjs` is a stub showing the wire-up. Actually executing it
+`adapter.ts` is a stub showing the wire-up. Actually executing it
 requires an openchrome MCP server, a tab with content, and an
-airena.lol REST endpoint. The mapping logic in `map-to-airena.mjs` is
+airena.lol REST endpoint. The mapping logic in `map-to-airena.ts` is
 fully testable in isolation — that's where the load-bearing surface
 lives.
 

--- a/examples/external/airena-adapter/README.md
+++ b/examples/external/airena-adapter/README.md
@@ -1,0 +1,82 @@
+# airena-adapter (sample external benchmark adapter)
+
+A minimal reference implementation showing how a third-party benchmark
+scorer (`airena.lol`) consumes openchrome via its **public MCP surfaces**
+— without any openchrome core changes.
+
+**Scope:** sample. Not shipped, not required, not on the build graph.
+Lives in `examples/` so the openchrome core stays #1359 §P1 compliant
+(host-neutral MCP first; no host-specific behavior in core).
+
+## What it demonstrates
+
+The adapter glues together four public openchrome MCP tools to produce
+exactly the JSON shape that `airena.lol`'s `/api/round` endpoint
+expects:
+
+| openchrome surface | Role |
+|---|---|
+| `extract_data` (with one of the public-web templates from `src/contracts/templates/public-web/`) | Produces the structured observed payload |
+| `oc_evidence_bundle` (with `target_schema` from B1-PR2) | Computes schema-diff coverage as a fact |
+| `oc_gate_inspect` (from B2-PR1/PR2) | Captures the gate fact alongside the result |
+| `oc_profile_fingerprint` (from B3-PR2) | Identifies the auth session, secret-free |
+
+The adapter then maps openchrome's facts to airena's scoring envelope.
+Nothing in this pipeline reaches into openchrome internals.
+
+## #1359 alignment
+
+This sample is the **canonical demonstration** of the boundary called
+out in #1359:
+
+> openchrome emits facts; external scorers / benchmark harnesses turn
+> facts into scores.
+
+The adapter lives in `examples/`. The benchmark harness for openchrome
+(`benchmark/`) refers to it via the new registry file
+`benchmark/EXTERNAL-WORKLOADS.md` but never imports the adapter into
+its build graph. Hosts that want a different scorer (e.g.
+`crawler-arena.dev`) clone this directory and swap the mapping
+function.
+
+## Files
+
+The sample source and tests live under `tests/external/airena-adapter/`
+so the repo's tsconfig and jest config can pick them up without a
+separate test scaffold; this `examples/` directory is README-only.
+
+- `tests/external/airena-adapter/adapter.ts` — the glue.
+- `tests/external/airena-adapter/map-to-airena.ts` — pure function:
+  openchrome facts → airena scoring envelope. Unit tests cover this
+  without needing the real MCP transport.
+- `tests/external/airena-adapter/map-to-airena.test.ts` — Jest tests.
+
+## Running (out of scope here)
+
+`adapter.mjs` is a stub showing the wire-up. Actually executing it
+requires an openchrome MCP server, a tab with content, and an
+airena.lol REST endpoint. The mapping logic in `map-to-airena.mjs` is
+fully testable in isolation — that's where the load-bearing surface
+lives.
+
+## Caveats
+
+- Sample only. No CI gate. Breaking it does not break openchrome.
+- airena.lol's REST shape is host-defined and may change; the
+  mapping function is the single point that needs updating.
+- This is not the right place to add openchrome features. If the
+  adapter needs an openchrome change, the change belongs in
+  openchrome core under a separate PR — never under `examples/`.
+
+## See also
+
+- `src/core/contracts/schema-diff.ts` (B1-PR1) — the source-of-truth
+  diff facts the mapper reads.
+- `src/contracts/templates/public-web/*.ts` (A2-PR2..5) — canonical
+  target schemas.
+- `src/tools/oc-gate-inspect.ts` (B2-PR1/PR2) — fact-only gate
+  detection.
+- `src/storage-state/fingerprint.ts` (B3-PR1) + `oc_profile_fingerprint`
+  (B3-PR2).
+- `benchmark/EXTERNAL-WORKLOADS.md` — registry entry.
+- `docs/roadmap/portability-harness-contract.md` §P1.

--- a/tests/external/airena-adapter/adapter.ts
+++ b/tests/external/airena-adapter/adapter.ts
@@ -1,0 +1,117 @@
+/**
+ * adapter.ts — sample wire-up for airena.lol benchmark scoring.
+ *
+ * Demonstrates how an external benchmark adapter calls openchrome's
+ * public MCP surfaces, composes the resulting facts via
+ * `mapToAirenaRound`, and POSTs the round envelope to airena's REST
+ * endpoint.
+ *
+ * SAMPLE ONLY. This file is not on the openchrome build graph, has no
+ * test coverage of its transport layer, and is not invoked by any
+ * benchmark suite. The load-bearing surface is `map-to-airena.ts`
+ * (pure function, fully tested). Forking this directory and swapping
+ * the mapper is the recommended path for other external scorers.
+ *
+ * Per #1359 §P1 (host-neutral MCP first): openchrome emits facts; the
+ * adapter turns facts into a host-specific REST shape. The boundary
+ * is the MCP tool API — nothing in this file reaches into openchrome
+ * internals.
+ */
+
+import { mapToAirenaRound } from './map-to-airena';
+
+/**
+ * Minimal MCP client interface — the adapter accepts any client that
+ * can call openchrome tools by name. In practice this is whichever
+ * MCP client library the host already uses.
+ */
+export interface OpenChromeMcp {
+  call(name: string, args: Record<string, unknown>): Promise<Record<string, unknown> | undefined>;
+}
+
+export interface AirenaConfig {
+  apiBaseUrl: string;
+  apiKey: string;
+  round?: string;
+}
+
+export interface AirenaTemplate {
+  id: string;
+  version: number;
+  targetSchema: { format: string; definition: unknown };
+}
+
+export interface RoundContext {
+  tabId: string;
+  targetUrl: string;
+  template: AirenaTemplate;
+}
+
+/**
+ * Run a single airena round against the active openchrome tab and
+ * POST the result. Returns the airena server response on success;
+ * throws on transport failure (the caller decides whether to retry).
+ */
+export async function runAirenaRound(
+  mcp: OpenChromeMcp,
+  airena: AirenaConfig,
+  round: RoundContext,
+): Promise<unknown> {
+  // 1. Extract structured data using one of the public-web templates.
+  const extracted = (await mcp.call('extract_data', {
+    tabId: round.tabId,
+    schema: round.template.targetSchema.definition,
+    waitForReady: true,
+  })) as Record<string, unknown> | undefined;
+  const observed =
+    (extracted?.data as Record<string, unknown> | undefined) ??
+    (extracted?.items as unknown) ??
+    extracted;
+
+  // 2. Capture the gate fact alongside the result.
+  const gateFact = (await mcp.call('oc_gate_inspect', { tabId: round.tabId })) as
+    | { detected: boolean; kind?: string; gateType?: string; provider?: string; pageUrl?: string }
+    | undefined;
+
+  // 3. Run schema-diff inside an evidence bundle.
+  const bundle = (await mcp.call('oc_evidence_bundle', {
+    tab_id: round.tabId,
+    include: ['schema_diff'],
+    target_schema: round.template.targetSchema.definition,
+    evidence: { snapshot: { observed } },
+  })) as { schema_diff?: import('./map-to-airena').SchemaDiffShape; meta?: { path_taken?: string } } | undefined;
+
+  // 4. Profile fingerprint (optional).
+  let profileFingerprint: { hash: string; breakdown?: Record<string, unknown> } | undefined;
+  try {
+    const fp = (await mcp.call('oc_profile_fingerprint', { tabId: round.tabId })) as
+      | { hash: string; breakdown?: Record<string, unknown> }
+      | undefined;
+    profileFingerprint = fp;
+  } catch {
+    profileFingerprint = undefined;
+  }
+
+  // 5. Compose the airena envelope via the pure mapper.
+  const envelope = mapToAirenaRound({
+    targetUrl: round.targetUrl,
+    schemaDiff: bundle?.schema_diff,
+    gateFact: gateFact?.detected ? gateFact : null,
+    profileFingerprint,
+    pathTaken: bundle?.meta?.path_taken,
+  });
+
+  // 6. POST to airena.
+  const response = await fetch(`${airena.apiBaseUrl}/round`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${airena.apiKey}`,
+    },
+    body: JSON.stringify({ round: airena.round, ...envelope }),
+  });
+  if (!response.ok) {
+    throw new Error(`airena POST failed: ${response.status} ${response.statusText}`);
+  }
+  return await response.json();
+}

--- a/tests/external/airena-adapter/adapter.ts
+++ b/tests/external/airena-adapter/adapter.ts
@@ -60,7 +60,8 @@ export async function runAirenaRound(
   // 1. Extract structured data using one of the public-web templates.
   const extracted = (await mcp.call('extract_data', {
     tabId: round.tabId,
-    schema: round.template.targetSchema.definition,
+    template_id: round.template.id,
+    template_version: round.template.version,
     waitForReady: true,
   })) as Record<string, unknown> | undefined;
   const observed =

--- a/tests/external/airena-adapter/map-to-airena.test.ts
+++ b/tests/external/airena-adapter/map-to-airena.test.ts
@@ -1,0 +1,96 @@
+/// <reference types="jest" />
+
+import { mapToAirenaRound } from './map-to-airena';
+
+describe('mapToAirenaRound — input validation', () => {
+  test('throws when input is missing or not an object', () => {
+    expect(() => mapToAirenaRound(null as never)).toThrow();
+    expect(() => mapToAirenaRound(undefined as never)).toThrow();
+    expect(() => mapToAirenaRound('nope' as never)).toThrow();
+  });
+
+  test('throws when targetUrl is missing or empty', () => {
+    expect(() => mapToAirenaRound({} as never)).toThrow(/targetUrl/);
+    expect(() => mapToAirenaRound({ targetUrl: '' })).toThrow(/targetUrl/);
+  });
+});
+
+describe('mapToAirenaRound — status rules', () => {
+  test("status='gated' wins over coverage when a gate is detected", () => {
+    const r = mapToAirenaRound({
+      targetUrl: 'https://example.com',
+      schemaDiff: { matched: ['a'], missing: [], extra: [], typeMismatch: [], coverage: 1 },
+      gateFact: { detected: true, kind: 'captcha', gateType: 'hcaptcha' },
+    });
+    expect(r.status).toBe('gated');
+    // Coverage is still echoed verbatim — score is host-derived.
+    expect(r.coverage).toBe(1);
+  });
+
+  test("status='ok' when coverage is 1 and no gate", () => {
+    const r = mapToAirenaRound({
+      targetUrl: 'https://example.com',
+      schemaDiff: { matched: ['a', 'b'], missing: [], extra: [], typeMismatch: [], coverage: 1 },
+    });
+    expect(r.status).toBe('ok');
+  });
+
+  test("status='partial' when 0 < coverage < 1", () => {
+    const r = mapToAirenaRound({
+      targetUrl: 'https://example.com',
+      schemaDiff: { matched: ['a'], missing: ['b'], extra: [], typeMismatch: [], coverage: 0.5 },
+    });
+    expect(r.status).toBe('partial');
+  });
+
+  test("status='failed' when coverage is 0", () => {
+    const r = mapToAirenaRound({
+      targetUrl: 'https://example.com',
+      schemaDiff: { matched: [], missing: ['a', 'b'], extra: [], typeMismatch: [], coverage: 0 },
+    });
+    expect(r.status).toBe('failed');
+  });
+
+  test("status='failed' when schemaDiff is missing entirely", () => {
+    const r = mapToAirenaRound({ targetUrl: 'https://example.com' });
+    expect(r.status).toBe('failed');
+    expect(r.coverage).toBe(0);
+  });
+});
+
+describe('mapToAirenaRound — facts composition', () => {
+  test('attaches all four optional facts when present', () => {
+    const r = mapToAirenaRound({
+      targetUrl: 'https://example.com',
+      schemaDiff: { matched: ['a'], missing: [], extra: [], typeMismatch: [], coverage: 1 },
+      gateFact: null,
+      profileFingerprint: { hash: 'deadbeef'.repeat(8), breakdown: { cookies: 3 } },
+      pathTaken: 'lp-served',
+    });
+    expect(r.facts.path_taken).toBe('lp-served');
+    expect(r.facts.profile_fingerprint).toMatch(/^deadbeef/);
+    expect(r.facts.schema_diff).toBeDefined();
+    expect(r.facts.gate).toBeUndefined();
+  });
+
+  test('omits facts that are absent or null', () => {
+    const r = mapToAirenaRound({
+      targetUrl: 'https://example.com',
+      schemaDiff: { matched: [], missing: [], extra: [], typeMismatch: [], coverage: 0 },
+    });
+    expect(r.facts).toEqual({ schema_diff: r.facts.schema_diff });
+  });
+});
+
+describe('mapToAirenaRound — determinism', () => {
+  test('repeated calls on the same input produce structurally identical output', () => {
+    const input = {
+      targetUrl: 'https://example.com',
+      schemaDiff: { matched: ['a'], missing: [], extra: [], typeMismatch: [], coverage: 1 },
+      pathTaken: 'lp-served',
+    };
+    const a = mapToAirenaRound(input);
+    const b = mapToAirenaRound(input);
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+});

--- a/tests/external/airena-adapter/map-to-airena.ts
+++ b/tests/external/airena-adapter/map-to-airena.ts
@@ -1,0 +1,122 @@
+/**
+ * map-to-airena — pure function turning openchrome facts into the
+ * scoring envelope airena.lol's /api/round endpoint expects.
+ *
+ * Inputs (from openchrome MCP):
+ *   - schemaDiff:   the `schema_diff` field returned by oc_evidence_bundle
+ *                   when invoked with a `target_schema` (B1-PR2).
+ *   - gateFact:     the JSON output of oc_gate_inspect (B2-PR1/PR2),
+ *                   `null` when no gate was observed.
+ *   - profileFingerprint: optional output of oc_profile_fingerprint
+ *                   (B3-PR2). When present, attached as a non-secret
+ *                   identifier so airena can correlate runs that
+ *                   reused the same auth session.
+ *   - pathTaken:    optional value of `meta.path_taken` (A3-PR2)
+ *                   echoed onto the round so airena can break out
+ *                   cdp-vs-static-fetch performance.
+ *   - targetUrl:    the round's URL, echoed verbatim.
+ *
+ * Output: a plain JSON object the caller POSTs to airena's REST API.
+ * The mapper never touches the network — that's the adapter's job.
+ *
+ * Per #1359 §P4 (facts before decisions): every input is a fact
+ * openchrome already emits. The mapper composes them; it does not
+ * derive any new judgment.
+ */
+
+export interface SchemaDiffShape {
+  matched: string[];
+  missing: string[];
+  extra: string[];
+  typeMismatch: Array<{ field: string; expected: string; got: string }>;
+  coverage: number;
+}
+
+export interface GateFact {
+  detected: boolean;
+  kind?: string;
+  gateType?: string;
+  provider?: string;
+  pageUrl?: string;
+}
+
+export interface ProfileFingerprintInput {
+  hash: string;
+  breakdown?: Record<string, unknown>;
+}
+
+export interface MapInput {
+  targetUrl: string;
+  schemaDiff?: SchemaDiffShape;
+  gateFact?: GateFact | null;
+  profileFingerprint?: ProfileFingerprintInput;
+  pathTaken?: string;
+}
+
+export interface AirenaRoundFacts {
+  path_taken?: string;
+  profile_fingerprint?: string;
+  gate?: GateFact;
+  schema_diff?: SchemaDiffShape;
+}
+
+export type AirenaRoundStatus = 'ok' | 'gated' | 'partial' | 'failed';
+
+export interface AirenaRoundEnvelope {
+  url: string;
+  coverage: number;
+  status: AirenaRoundStatus;
+  facts: AirenaRoundFacts;
+}
+
+/**
+ * Compose the airena scoring envelope.
+ *
+ * Status rules (closed enum, deterministic):
+ *   - gateFact?.detected === true      → 'gated'
+ *   - schemaDiff missing entirely      → 'failed'
+ *   - coverage === 1                   → 'ok'
+ *   - 0 < coverage < 1                 → 'partial'
+ *   - coverage === 0                   → 'failed'
+ */
+export function mapToAirenaRound(input: MapInput): AirenaRoundEnvelope {
+  if (!input || typeof input !== 'object') {
+    throw new Error('mapToAirenaRound: input is required');
+  }
+  if (typeof input.targetUrl !== 'string' || input.targetUrl.length === 0) {
+    throw new Error('mapToAirenaRound: targetUrl is required');
+  }
+
+  const facts: AirenaRoundFacts = {};
+  if (input.pathTaken) facts.path_taken = input.pathTaken;
+  if (input.profileFingerprint && typeof input.profileFingerprint.hash === 'string') {
+    facts.profile_fingerprint = input.profileFingerprint.hash;
+  }
+  if (input.gateFact) facts.gate = input.gateFact;
+  if (input.schemaDiff) facts.schema_diff = input.schemaDiff;
+
+  let status: AirenaRoundStatus;
+  if (input.gateFact && input.gateFact.detected) {
+    status = 'gated';
+  } else if (!input.schemaDiff) {
+    status = 'failed';
+  } else if (input.schemaDiff.coverage >= 1) {
+    status = 'ok';
+  } else if (input.schemaDiff.coverage > 0) {
+    status = 'partial';
+  } else {
+    status = 'failed';
+  }
+
+  const coverage =
+    input.schemaDiff && typeof input.schemaDiff.coverage === 'number'
+      ? input.schemaDiff.coverage
+      : 0;
+
+  return {
+    url: input.targetUrl,
+    coverage,
+    status,
+    facts,
+  };
+}


### PR DESCRIPTION
## Summary

A sample external adapter that demonstrates how a third-party benchmark scorer (airena.lol) consumes openchrome via its **public MCP surfaces** — without any openchrome core changes.

**Base: develop** (this PR is independent — does not stack on any of the B1/B2/B3/A2/A3 stacks; it's pure example wiring that composes against the eventual merged surfaces of all of them.)

## Layout

```
examples/external/airena-adapter/
  README.md                        # README-only sample documentation

tests/external/airena-adapter/
  map-to-airena.ts                 # pure function: openchrome facts → airena
  adapter.ts                       # sample wire-up
  map-to-airena.test.ts            # 10 cases

benchmark/
  EXTERNAL-WORKLOADS.md            # registry for external workloads
```

Source and tests live under `tests/external/` so the repo's `tsconfig.test.json` and `jest.config.js` pick them up without a separate scaffold; `examples/external/` is **README-only**.

## What it demonstrates

The adapter glues together four public openchrome MCP surfaces to produce exactly the JSON shape airena.lol's `/api/round` endpoint expects:

| openchrome surface | Role |
|---|---|
| `extract_data` (with public-web template) | Structured observed payload |
| `oc_evidence_bundle` (with `target_schema`, B1-PR2) | Schema-diff coverage as fact |
| `oc_gate_inspect` (B2-PR1/PR2) | Gate fact |
| `oc_profile_fingerprint` (B3-PR2) | Secret-free session identity |

Nothing reaches into openchrome internals.

## Closed status enum

- `gateFact.detected === true` → `'gated'` (wins over coverage)
- `schemaDiff` absent → `'failed'`
- `coverage === 1` → `'ok'`
- `0 < coverage < 1` → `'partial'`
- `coverage === 0` → `'failed'`

## #1359 alignment

- **§P1** host-neutral MCP first — sample lives outside core, consumes only public MCP calls.
- **§P4** facts before decisions — openchrome emits facts; mapper composes them. Scoring threshold lives in the mapper, not openchrome.
- **§P5** evidence before claims — `EXTERNAL-WORKLOADS.md` requires reproducible runs through the adapter for any competitive claim.

## Test plan

- [x] `npx jest tests/external/airena-adapter` — 10/10 passing
- [x] `npx tsc --noEmit -p tsconfig.test.json` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)