### PR TITLE
Prove shared broker multi-client forwarding

### DIFF
--- a/src/observability/request-id.ts
+++ b/src/observability/request-id.ts
@@ -83,6 +83,8 @@ export interface RequestContext {
   keyId?: string;
   /** HTTP MCP session id when the transport provides one. */
   mcpSessionId?: string;
+  /** Broker stdio-proxy identity when this request arrived via --connect-broker. */
+  brokerClientId?: string;
 }
 
 const requestStore = new AsyncLocalStorage<RequestContext>();

--- a/src/transports/broker-proxy.ts
+++ b/src/transports/broker-proxy.ts
@@ -3,9 +3,14 @@ import type { BrokerMetadata } from '../broker/discovery';
 import { MCPErrorCodes, MCPResponse } from '../types/mcp';
 
 const MCP_SESSION_ID_HEADER = 'Mcp-Session-Id';
+export const BROKER_CLIENT_ID_HEADER = 'X-OpenChrome-Broker-Client-Id';
 
 export interface BrokerProxyOptions {
   authToken?: string;
+  /** Stable client identity propagated to the broker for diagnostics/audit. */
+  clientId?: string;
+  /** Optional tenant id forwarded to the broker HTTP transport. */
+  tenantId?: string;
   /** Override fetch implementation (tests). */
   fetchImpl?: typeof fetch;
   /** Override stdout writer (tests). */
@@ -16,6 +21,8 @@ export class BrokerProxyStdioBridge {
   private readonly broker: BrokerMetadata;
   private readonly authToken?: string;
   private readonly fetchImpl: typeof fetch;
+  private readonly clientId: string;
+  private readonly tenantId?: string;
   private readonly writeOut: (chunk: string) => void;
   private mcpSessionId?: string;
 
@@ -25,6 +32,8 @@ export class BrokerProxyStdioBridge {
       ? { authToken: authTokenOrOptions }
       : authTokenOrOptions ?? {};
     this.authToken = options.authToken;
+    this.clientId = options.clientId ?? process.env.OPENCHROME_BROKER_CLIENT_ID ?? `stdio-proxy-${process.pid}`;
+    this.tenantId = options.tenantId ?? process.env.OPENCHROME_TENANT_ID;
     this.fetchImpl = options.fetchImpl ?? fetch;
     this.writeOut = options.write ?? ((chunk) => { process.stdout.write(chunk); });
   }
@@ -55,7 +64,9 @@ export class BrokerProxyStdioBridge {
         // response framing. The proxy unwraps SSE below so stdio clients keep
         // receiving plain JSON-RPC lines.
         Accept: 'application/json, text/event-stream',
+        [BROKER_CLIENT_ID_HEADER]: this.clientId,
       };
+      if (this.tenantId) headers['X-Tenant-Id'] = this.tenantId;
       if (this.authToken) headers.Authorization = `Bearer ${this.authToken}`;
       if (this.mcpSessionId) headers[MCP_SESSION_ID_HEADER] = this.mcpSessionId;
 

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -15,6 +15,7 @@ import * as crypto from 'node:crypto';
 import { MCPResponse, MCPErrorCodes } from '../types/mcp';
 import { ClientDisconnectError } from '../errors/abort';
 import { MCPTransport, TransportMessageContext } from './index';
+import { BROKER_CLIENT_ID_HEADER } from './broker-proxy';
 import type { SessionManager } from '../session-manager';
 import {
   REQUEST_ID_HEADER,
@@ -721,6 +722,7 @@ export class HTTPTransport implements MCPTransport {
       const requestId = (req as http.IncomingMessage & { requestId?: string }).requestId
         || resolveRequestId(req.headers[REQUEST_ID_HEADER_LOWER]);
       const principal = requestPrincipals.get(req);
+      const brokerClientId = normalizeBrokerClientId(req.headers[BROKER_CLIENT_ID_HEADER.toLowerCase()]);
 
       // Handle JSON-RPC batch (array of requests)
       if (Array.isArray(parsed)) {
@@ -732,8 +734,9 @@ export class HTTPTransport implements MCPTransport {
               : tenantId,
             keyId: principal?.mode === 'api-key' ? principal.keyId : undefined,
             mcpSessionId: sessionId,
+            brokerClientId,
           },
-          () => this.processBatch(parsed, sessionId, tenantId, signal, principal),
+          () => this.processBatch(parsed, sessionId, tenantId, signal, principal, brokerClientId),
         );
         // Filter out null results (notifications don't produce responses)
         const responses = results.filter((r): r is MCPResponse => r !== null);
@@ -786,8 +789,9 @@ export class HTTPTransport implements MCPTransport {
               : tenantId,
             keyId: principal?.mode === 'api-key' ? principal.keyId : undefined,
             mcpSessionId: sessionId,
+            brokerClientId,
           },
-          () => this.messageHandler!(msg, signal, { mcpSessionId: sessionId, tenantId }),
+          () => this.messageHandler!(msg, signal, { mcpSessionId: sessionId, tenantId, brokerClientId }),
         );
 
         if (sessionId) {
@@ -921,6 +925,7 @@ export class HTTPTransport implements MCPTransport {
     tenantId: TenantId,
     signal?: AbortSignal,
     principal?: Principal,
+    brokerClientId?: string,
   ): Promise<(MCPResponse | null)[]> {
     const handler = this.messageHandler!;
 
@@ -977,7 +982,7 @@ export class HTTPTransport implements MCPTransport {
           (record as Record<PropertyKey, unknown>)[PRINCIPAL_SYM] = principal;
         }
 
-        return await handler(record, signal, { mcpSessionId: sessionId, tenantId });
+        return await handler(record, signal, { mcpSessionId: sessionId, tenantId, brokerClientId });
       } catch (error) {
         const id = record !== null
           ? ((record.id as string | number | undefined) ?? 0)
@@ -1005,4 +1010,12 @@ export class HTTPTransport implements MCPTransport {
   ): Promise<R[]> {
     return mapBatchWithConcurrency(items, concurrency, fn);
   }
+}
+
+function normalizeBrokerClientId(value: string | string[] | undefined): string | undefined {
+  const raw = Array.isArray(value) ? value[0] : value;
+  if (!raw) return undefined;
+  const normalized = raw.trim();
+  if (!normalized) return undefined;
+  return normalized.slice(0, 128);
 }

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -9,6 +9,8 @@ import type { ApiKeyStore } from '../auth/api-key-store';
 export interface TransportMessageContext {
   mcpSessionId?: string;
   tenantId?: string;
+  /** Broker stdio-proxy identity propagated through HTTP for audit/diagnostics. */
+  brokerClientId?: string;
 }
 
 /**

--- a/tests/broker-proxy.test.ts
+++ b/tests/broker-proxy.test.ts
@@ -138,3 +138,51 @@ describe('BrokerProxyStdioBridge', () => {
     expect(parsed.error.message).toContain('500');
   });
 });
+
+describe('BrokerProxyStdioBridge multi-client broker forwarding', () => {
+  test('keeps independent Mcp-Session-Id values per stdio proxy while targeting one broker endpoint', async () => {
+    const fetchImpl = jest.fn<Promise<Response>, [string, RequestInit]>()
+      .mockResolvedValueOnce(createMockResponse({ body: '{"jsonrpc":"2.0","id":1,"result":{}}', headers: { 'Mcp-Session-Id': 'session-a' } }))
+      .mockResolvedValueOnce(createMockResponse({ body: '{"jsonrpc":"2.0","id":1,"result":{}}', headers: { 'Mcp-Session-Id': 'session-b' } }))
+      .mockResolvedValueOnce(createMockResponse({ body: '{"jsonrpc":"2.0","id":2,"result":{}}' }))
+      .mockResolvedValueOnce(createMockResponse({ body: '{"jsonrpc":"2.0","id":2,"result":{}}' }));
+
+    const clientA = new BrokerProxyStdioBridge(broker, {
+      clientId: 'codex-a',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      write: () => undefined,
+    });
+    const clientB = new BrokerProxyStdioBridge(broker, {
+      clientId: 'claude-b',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      write: () => undefined,
+    });
+
+    await clientA.forwardLine('{"jsonrpc":"2.0","id":1,"method":"initialize"}');
+    await clientB.forwardLine('{"jsonrpc":"2.0","id":1,"method":"initialize"}');
+    await clientA.forwardLine('{"jsonrpc":"2.0","id":2,"method":"tools/list"}');
+    await clientB.forwardLine('{"jsonrpc":"2.0","id":2,"method":"tools/list"}');
+
+    expect(fetchImpl.mock.calls.map(([url]) => url)).toEqual(Array(4).fill(broker.endpoint));
+    const headers = fetchImpl.mock.calls.map(([, init]) => init.headers as Record<string, string>);
+    expect(headers[0]['X-OpenChrome-Broker-Client-Id']).toBe('codex-a');
+    expect(headers[1]['X-OpenChrome-Broker-Client-Id']).toBe('claude-b');
+    expect(headers[2]['Mcp-Session-Id']).toBe('session-a');
+    expect(headers[3]['Mcp-Session-Id']).toBe('session-b');
+  });
+
+  test('propagates tenant id to the broker HTTP transport when configured', async () => {
+    const fetchImpl = jest.fn<Promise<Response>, [string, RequestInit]>(async () => createMockResponse({ body: '{"jsonrpc":"2.0","id":1,"result":{}}' }));
+    const bridge = new BrokerProxyStdioBridge(broker, {
+      clientId: 'client-with-tenant',
+      tenantId: 'tenant-alpha',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      write: () => undefined,
+    });
+
+    await bridge.forwardLine('{"jsonrpc":"2.0","id":1,"method":"initialize"}');
+
+    const headers = (fetchImpl.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+    expect(headers['X-Tenant-Id']).toBe('tenant-alpha');
+  });
+});


### PR DESCRIPTION
## Summary\n- propagate a stable broker proxy client id and optional tenant id over the HTTP broker transport\n- keep independent Mcp-Session-Id state per stdio proxy while all proxy clients target the same broker endpoint\n- carry broker client identity through HTTP transport context for downstream diagnostics/audit work\n\n## Issues\n- Advances #1370\n- Aligns with #1359 single-owner shared-profile broker direction\n\n## Validation\n- npm test -- tests/broker-proxy.test.ts --runInBand\n- npm run build\n- git diff --check\n\n## Notes\n- Live two-process Chrome broker smoke remains operator-environment dependent; this PR locks the transport contract with deterministic tests.