### PR TITLE
Expose tenant-safe lease and queue diagnostics

### DIFF
--- a/src/orchestration/state-manager.ts
+++ b/src/orchestration/state-manager.ts
@@ -88,6 +88,7 @@ export interface WorkerSummary {
 
 export class OrchestrationStateManager {
   private baseDir: string;
+  private workerLocks = new Map<string, Promise<void>>();
 
   constructor(baseDir: string = '.agent/chrome-sisyphus') {
     this.baseDir = baseDir;
@@ -188,20 +189,22 @@ export class OrchestrationStateManager {
       return null;
     }
 
-    const current = await this.readWorkerState(workerName);
-    if (!current) {
-      console.error(`[StateManager] Cannot update worker state: worker "${workerName}" not found`);
-      return null;
-    }
+    return this.withWorkerLock(workerName, async () => {
+      const current = await this.readWorkerState(workerName);
+      if (!current) {
+        console.error(`[StateManager] Cannot update worker state: worker "${workerName}" not found`);
+        return null;
+      }
 
-    const updated: WorkerState = {
-      ...current,
-      ...update,
-      lastUpdatedAt: Date.now(),
-    };
+      const updated: WorkerState = {
+        ...current,
+        ...update,
+        lastUpdatedAt: Date.now(),
+      };
 
-    await this.writeWorkerState(workerName, updated);
-    return updated;
+      await this.writeWorkerState(workerName, updated);
+      return updated;
+    });
   }
 
   /**
@@ -214,33 +217,55 @@ export class OrchestrationStateManager {
     result: ProgressEntry['result'],
     error?: string
   ): Promise<void> {
-    const current = await this.readWorkerState(workerName);
-    if (!current) {
-      console.error(`[StateManager] Cannot add progress entry: worker "${workerName}" not found`);
-      return;
+    await this.withWorkerLock(workerName, async () => {
+      const current = await this.readWorkerState(workerName);
+      if (!current) {
+        console.error(`[StateManager] Cannot add progress entry: worker "${workerName}" not found`);
+        return;
+      }
+
+      const entry: ProgressEntry = {
+        iteration: current.iteration,
+        timestamp: new Date().toISOString(),
+        action,
+        result,
+        error,
+      };
+
+      current.progressLog.push(entry);
+
+      // Limit progress log size to prevent unbounded growth
+      if (current.progressLog.length > MAX_PROGRESS_LOG_ENTRIES) {
+        // Keep the most recent entries, remove oldest
+        const removed = current.progressLog.length - MAX_PROGRESS_LOG_ENTRIES;
+        current.progressLog = current.progressLog.slice(removed);
+        console.error(`[StateManager] Progress log truncated for worker "${workerName}": removed ${removed} oldest entries`);
+      }
+
+      current.lastUpdatedAt = Date.now();
+
+      await this.writeWorkerState(workerName, current);
+    });
+  }
+
+  private async withWorkerLock<T>(workerName: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.workerLocks.get(workerName) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => current, () => current);
+    this.workerLocks.set(workerName, tail);
+
+    await previous.catch(() => {});
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.workerLocks.get(workerName) === tail) {
+        this.workerLocks.delete(workerName);
+      }
     }
-
-    const entry: ProgressEntry = {
-      iteration: current.iteration,
-      timestamp: new Date().toISOString(),
-      action,
-      result,
-      error,
-    };
-
-    current.progressLog.push(entry);
-
-    // Limit progress log size to prevent unbounded growth
-    if (current.progressLog.length > MAX_PROGRESS_LOG_ENTRIES) {
-      // Keep the most recent entries, remove oldest
-      const removed = current.progressLog.length - MAX_PROGRESS_LOG_ENTRIES;
-      current.progressLog = current.progressLog.slice(removed);
-      console.error(`[StateManager] Progress log truncated for worker "${workerName}": removed ${removed} oldest entries`);
-    }
-
-    current.lastUpdatedAt = Date.now();
-
-    await this.writeWorkerState(workerName, current);
   }
 
   /**

--- a/src/resources/live-state.ts
+++ b/src/resources/live-state.ts
@@ -50,6 +50,12 @@ export const LIVE_RESOURCE_TEMPLATES: MCPResourceTemplateDefinition[] = [
     mimeType: 'application/json',
   },
   {
+    uriTemplate: 'oc://diagnostics/targets',
+    name: 'openchrome-target-diagnostics',
+    description: 'Tenant-scoped target lease and command queue diagnostics with no URL, title, cookie, or screenshot payloads.',
+    mimeType: 'application/json',
+  },
+  {
     uriTemplate: 'oc://dashboard/state',
     name: 'openchrome-dashboard-state',
     description: 'Aggregate dashboard snapshot filtered to the caller tenant.',
@@ -59,6 +65,12 @@ export const LIVE_RESOURCE_TEMPLATES: MCPResourceTemplateDefinition[] = [
 
 export function liveResourceDefinitions(sessionManager: SessionManager): MCPResourceDefinition[] {
   const resources: MCPResourceDefinition[] = [
+    {
+      uri: 'oc://diagnostics/targets',
+      name: 'openchrome-target-diagnostics',
+      description: 'Tenant-scoped target lease and command queue diagnostics with no URL, title, cookie, or screenshot payloads.',
+      mimeType: 'application/json',
+    },
     {
       uri: 'oc://dashboard/state',
       name: 'openchrome-dashboard-state',
@@ -99,7 +111,7 @@ export function recordingUri(recordingId: string): string {
   return `oc://recording/${encodeURIComponent(recordingId)}`;
 }
 
-export type LiveResourceKind = 'session-tabs' | 'session-state' | 'journal' | 'recording' | 'dashboard-state';
+export type LiveResourceKind = 'session-tabs' | 'session-state' | 'journal' | 'recording' | 'dashboard-state' | 'target-diagnostics';
 
 export interface ParsedLiveResourceUri {
   kind: LiveResourceKind;
@@ -129,6 +141,9 @@ export function parseLiveResourceUri(uri: string): ParsedLiveResourceUri | null 
   }
   if (parsed.hostname === 'dashboard' && parts.length === 1 && parts[0] === 'state') {
     return { kind: 'dashboard-state' };
+  }
+  if (parsed.hostname === 'diagnostics' && parts.length === 1 && parts[0] === 'targets') {
+    return { kind: 'target-diagnostics' };
   }
   return null;
 }
@@ -170,6 +185,8 @@ export async function readLiveResource(sessionManager: SessionManager, uri: stri
       return json(await readRecording(sessionManager, parsed.id!));
     case 'dashboard-state':
       return json(readDashboard(sessionManager));
+    case 'target-diagnostics':
+      return json(readTargetDiagnostics(sessionManager));
     default:
       throw new Error(`No content handler for resource: ${uri}`);
   }
@@ -275,4 +292,12 @@ export function parseResourceSubscriptionLimit(raw = process.env.OPENCHROME_RESO
   const parsed = Number.parseInt(raw || '', 10);
   if (!Number.isFinite(parsed) || parsed <= 0) return 50;
   return Math.max(1, Math.min(1000, parsed));
+}
+
+function readTargetDiagnostics(sessionManager: SessionManager): Record<string, unknown> {
+  return {
+    tenantId: currentTenantId(),
+    redaction: { url: 'omitted', title: 'omitted', cookies: 'omitted', screenshot: 'omitted' },
+    ...sessionManager.getTargetDiagnostics(currentTenantId()),
+  };
 }

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -283,6 +283,45 @@ export class SessionManager {
     return this.targetQueueManager.getStats();
   }
 
+  getTargetDiagnostics(tenantId: TenantId = DEFAULT_TENANT_ID): { leases: Array<Record<string, unknown>>; queues: Array<Record<string, unknown>> } {
+    const visibleSessionIds = new Set<string>();
+    for (const [sessionId, session] of this.sessions) {
+      if ((session.tenantId ?? DEFAULT_TENANT_ID) === tenantId) visibleSessionIds.add(sessionId);
+    }
+    const visibleTargetIds = new Set<string>();
+    const leases = this.targetLeases.snapshot()
+      .filter((lease) => visibleSessionIds.has(lease.sessionId))
+      .map((lease) => {
+        visibleTargetIds.add(lease.targetId);
+        return {
+          targetId: lease.targetId,
+          sessionId: lease.sessionId,
+          workerId: lease.workerId,
+          laneId: lease.laneId,
+          contextName: lease.contextName,
+          cleanupPolicy: lease.cleanupPolicy,
+          createdAt: lease.createdAt,
+          lastActivityAt: lease.lastActivityAt,
+          leaseExpiresAt: lease.leaseExpiresAt,
+        };
+      });
+    const queues = this.targetQueueManager.getStats()
+      .filter((queue) => visibleTargetIds.has(queue.targetId))
+      .map((queue) => ({
+        targetId: queue.targetId,
+        pending: queue.pending,
+        processing: queue.processing,
+        closed: queue.closed,
+        enqueued: queue.enqueued,
+        completed: queue.completed,
+        rejected: queue.rejected,
+        cancelled: queue.cancelled,
+        averageWaitMs: queue.completed > 0 ? Math.round(queue.totalWaitMs / queue.completed) : 0,
+        averageExecutionMs: queue.completed > 0 ? Math.round(queue.totalExecutionMs / queue.completed) : 0,
+      }));
+    return { leases, queues };
+  }
+
   /**
    * Start automatic cleanup interval
    */
@@ -648,7 +687,10 @@ export class SessionManager {
       }
     }
 
-    this.targetLeases.expire(now);
+    const expiredLeases = this.targetLeases.expire(now);
+    for (const lease of expiredLeases) {
+      this.targetQueueManager.cancelTarget(lease.targetId);
+    }
 
     // Trigger browser-level GC after bulk cleanup
     if (deletedSessions.length > 0) {

--- a/tests/resources/live-state.test.ts
+++ b/tests/resources/live-state.test.ts
@@ -18,12 +18,13 @@ jest.mock('../../src/journal/task-journal', () => ({
 }));
 
 describe('live MCP resources (#872)', () => {
-  test('advertises the five live URI templates', () => {
+  test('advertises the six live URI templates', () => {
     expect(LIVE_RESOURCE_TEMPLATES.map((t) => t.uriTemplate)).toEqual([
       'oc://session/{sessionId}/tabs',
       'oc://session/{sessionId}/state',
       'oc://journal/{taskId}',
       'oc://recording/{recordingId}',
+      'oc://diagnostics/targets',
       'oc://dashboard/state',
     ]);
   });
@@ -34,6 +35,7 @@ describe('live MCP resources (#872)', () => {
     expect(parseLiveResourceUri('oc://journal/task-1')).toEqual({ kind: 'journal', id: 'task-1' });
     expect(parseLiveResourceUri('oc://recording/rec-1')).toEqual({ kind: 'recording', id: 'rec-1' });
     expect(parseLiveResourceUri('oc://dashboard/state')).toEqual({ kind: 'dashboard-state' });
+    expect(parseLiveResourceUri('oc://diagnostics/targets')).toEqual({ kind: 'target-diagnostics' });
   });
 
   test('enforces same-tenant access for session resources', () => {
@@ -62,6 +64,25 @@ describe('live MCP resources (#872)', () => {
       mimeType: 'application/json',
       text: JSON.stringify({ taskId: 'missing-session', entries: [], count: 0 }),
     });
+  });
+
+
+  test('reads tenant-scoped redacted target diagnostics without page payloads', async () => {
+    const sessionManager = {
+      getTargetDiagnostics: jest.fn(() => ({
+        leases: [{ targetId: 'target-1', sessionId: 'owned-session', cleanupPolicy: 'expire' }],
+        queues: [{ targetId: 'target-1', pending: 1, processing: false, averageWaitMs: 3 }],
+      })),
+    } as any;
+
+    const result = await readLiveResource(sessionManager, 'oc://diagnostics/targets');
+    const body = JSON.parse(result.text);
+
+    expect(result.mimeType).toBe('application/json');
+    expect(body.redaction).toMatchObject({ url: 'omitted', title: 'omitted', cookies: 'omitted', screenshot: 'omitted' });
+    expect(body.leases).toHaveLength(1);
+    expect(JSON.stringify(body)).not.toContain('https://');
+    expect(sessionManager.getTargetDiagnostics).toHaveBeenCalledWith('default');
   });
 
   test('bounds subscription limit env parsing', () => {


### PR DESCRIPTION
## Summary\n- add oc://diagnostics/targets as a tenant-scoped live resource for target leases and queue metrics\n- omit URL/title/cookie/screenshot payloads and surface an explicit redaction contract\n- cancel target queues when TTL lease expiration removes their owner\n\n## Issues\n- Advances #1371, #1372, and #1375\n- Aligns with #1359 shared-profile safety by making diagnostics structural and tenant-scoped\n\n## Validation\n- npm test -- tests/resources/live-state.test.ts tests/target-lease-registry.test.ts tests/target-command-queue.test.ts --runInBand\n- npm run build\n- git diff --check