### PR TITLE
Track broker lifecycle for reconnect-safe shared stops

### DIFF
--- a/src/broker/lifecycle.ts
+++ b/src/broker/lifecycle.ts
@@ -1,0 +1,83 @@
+export type BrokerLifecycleMode = 'disabled' | 'owner';
+export type BrokerLifecycleState = 'idle' | 'running' | 'reconnecting' | 'stopping' | 'stopped';
+
+export interface BrokerLifecycleSnapshot {
+  mode: BrokerLifecycleMode;
+  state: BrokerLifecycleState;
+  startedAt: string | null;
+  updatedAt: string | null;
+  reconnectCount: number;
+  lastEvent: string | null;
+  ocStopDefaultKeepChrome: boolean;
+}
+
+const lifecycle: BrokerLifecycleSnapshot = {
+  mode: 'disabled',
+  state: 'idle',
+  startedAt: null,
+  updatedAt: null,
+  reconnectCount: 0,
+  lastEvent: null,
+  ocStopDefaultKeepChrome: false,
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function setBrokerOwnerMode(enabled: boolean): BrokerLifecycleSnapshot {
+  const now = nowIso();
+  lifecycle.mode = enabled ? 'owner' : 'disabled';
+  lifecycle.state = enabled ? 'running' : 'idle';
+  lifecycle.startedAt = enabled ? lifecycle.startedAt ?? now : null;
+  lifecycle.updatedAt = now;
+  lifecycle.lastEvent = enabled ? 'broker_owner_started' : 'broker_owner_disabled';
+  lifecycle.ocStopDefaultKeepChrome = enabled;
+  return getBrokerLifecycleSnapshot();
+}
+
+export function recordBrokerReconnect(event: 'reconnecting' | 'reconnected' | 'reconnect_failed'): BrokerLifecycleSnapshot {
+  lifecycle.updatedAt = nowIso();
+  lifecycle.lastEvent = event;
+  if (event === 'reconnecting') {
+    lifecycle.state = 'reconnecting';
+  } else if (event === 'reconnected') {
+    lifecycle.state = lifecycle.mode === 'owner' ? 'running' : 'idle';
+    lifecycle.reconnectCount += 1;
+  } else {
+    lifecycle.state = 'reconnecting';
+  }
+  return getBrokerLifecycleSnapshot();
+}
+
+export function recordBrokerStopping(): BrokerLifecycleSnapshot {
+  lifecycle.updatedAt = nowIso();
+  lifecycle.state = 'stopping';
+  lifecycle.lastEvent = 'broker_owner_stopping';
+  return getBrokerLifecycleSnapshot();
+}
+
+export function recordBrokerStopped(): BrokerLifecycleSnapshot {
+  lifecycle.updatedAt = nowIso();
+  lifecycle.state = 'stopped';
+  lifecycle.lastEvent = 'broker_owner_stopped';
+  return getBrokerLifecycleSnapshot();
+}
+
+export function shouldOcStopKeepChromeByDefault(): boolean {
+  return lifecycle.ocStopDefaultKeepChrome;
+}
+
+export function getBrokerLifecycleSnapshot(): BrokerLifecycleSnapshot {
+  return { ...lifecycle };
+}
+
+export function resetBrokerLifecycleForTest(): void {
+  lifecycle.mode = 'disabled';
+  lifecycle.state = 'idle';
+  lifecycle.startedAt = null;
+  lifecycle.updatedAt = null;
+  lifecycle.reconnectCount = 0;
+  lifecycle.lastEvent = null;
+  lifecycle.ocStopDefaultKeepChrome = false;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -698,8 +698,10 @@ program
       console.error('[openchrome] Infinite reconnection: enabled (daemon mode)');
       if (options.broker) {
         const { publishBrokerMetadata, removeBrokerMetadata } = await import('./broker/discovery');
+        const { setBrokerOwnerMode, recordBrokerStopped } = await import('./broker/lifecycle');
+        setBrokerOwnerMode(true);
         const metadata = publishBrokerMetadata({ port, userDataDir: lockUserDataDir, httpHost, httpPort, authTokenEnv: brokerAuthTokenEnv });
-        process.on('exit', () => removeBrokerMetadata(port, lockUserDataDir));
+        process.on('exit', () => { recordBrokerStopped(); removeBrokerMetadata(port, lockUserDataDir); });
         console.error(`[openchrome] Broker metadata: ${metadata.endpoint}`);
       }
     } else if (useHttp) {
@@ -712,8 +714,10 @@ program
       console.error('[openchrome] Infinite reconnection: enabled (daemon mode)');
       if (options.broker) {
         const { publishBrokerMetadata, removeBrokerMetadata } = await import('./broker/discovery');
+        const { setBrokerOwnerMode, recordBrokerStopped } = await import('./broker/lifecycle');
+        setBrokerOwnerMode(true);
         const metadata = publishBrokerMetadata({ port, userDataDir: lockUserDataDir, httpHost, httpPort, authTokenEnv: brokerAuthTokenEnv });
-        process.on('exit', () => removeBrokerMetadata(port, lockUserDataDir));
+        process.on('exit', () => { recordBrokerStopped(); removeBrokerMetadata(port, lockUserDataDir); });
         console.error(`[openchrome] Broker metadata: ${metadata.endpoint}`);
       }
     } else {

--- a/src/tools/connection-health.ts
+++ b/src/tools/connection-health.ts
@@ -8,6 +8,7 @@ import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getCDPClient } from '../cdp/client';
 import { getCurrentControllerTopology } from '../utils/duplicate-controller-diagnostics';
+import { getBrokerLifecycleSnapshot } from '../broker/lifecycle';
 
 const definition: MCPToolDefinition = {
   name: 'oc_connection_health',
@@ -50,6 +51,7 @@ const handler: ToolHandler = async (
               reconnectAttempt: metrics.reconnectAttempt,
               reconnectNextRetryInMs: metrics.reconnectNextRetryInMs,
               controllerTopology: getCurrentControllerTopology(),
+              brokerLifecycle: getBrokerLifecycleSnapshot(),
             },
             null,
             2

--- a/src/tools/shutdown.ts
+++ b/src/tools/shutdown.ts
@@ -16,6 +16,7 @@ import { getCDPConnectionPool } from '../cdp/connection-pool';
 import { getCDPClient } from '../cdp/client';
 import { getChromeLauncher } from '../chrome/launcher';
 import { shutdownHeadedFallback } from '../chrome/headed-fallback';
+import { shouldOcStopKeepChromeByDefault } from '../broker/lifecycle';
 
 const definition: MCPToolDefinition = {
   name: 'oc_stop',
@@ -25,7 +26,7 @@ const definition: MCPToolDefinition = {
     properties: {
       keepChrome: {
         type: 'boolean',
-        description: 'Keep Chrome running, just disconnect. Default: false',
+        description: 'Keep Chrome running, just disconnect. Default: false in standalone mode, true when running in broker owner mode so shared clients are not impacted.',
       },
       dryRun: {
         type: 'boolean',
@@ -42,7 +43,9 @@ const handler: ToolHandler = async (
   _sessionId: string,
   args: Record<string, unknown>
 ): Promise<MCPResult> => {
-  const keepChrome = (args.keepChrome as boolean) || false;
+  const keepChrome = typeof args.keepChrome === 'boolean'
+    ? (args.keepChrome as boolean)
+    : shouldOcStopKeepChromeByDefault();
   const dryRun = args.dryRun === true;
   const steps: string[] = [];
   const startTime = Date.now();

--- a/tests/broker-lifecycle.test.ts
+++ b/tests/broker-lifecycle.test.ts
@@ -1,0 +1,29 @@
+import {
+  getBrokerLifecycleSnapshot,
+  recordBrokerReconnect,
+  recordBrokerStopped,
+  recordBrokerStopping,
+  resetBrokerLifecycleForTest,
+  setBrokerOwnerMode,
+  shouldOcStopKeepChromeByDefault,
+} from '../src/broker/lifecycle';
+
+describe('broker lifecycle state', () => {
+  beforeEach(() => resetBrokerLifecycleForTest());
+
+  test('enables broker owner mode and makes oc_stop keep Chrome by default', () => {
+    const state = setBrokerOwnerMode(true);
+
+    expect(state).toMatchObject({ mode: 'owner', state: 'running', ocStopDefaultKeepChrome: true });
+    expect(shouldOcStopKeepChromeByDefault()).toBe(true);
+    expect(getBrokerLifecycleSnapshot().startedAt).toEqual(expect.any(String));
+  });
+
+  test('tracks reconnect and stop transitions for health diagnostics', () => {
+    setBrokerOwnerMode(true);
+    expect(recordBrokerReconnect('reconnecting')).toMatchObject({ state: 'reconnecting', lastEvent: 'reconnecting' });
+    expect(recordBrokerReconnect('reconnected')).toMatchObject({ state: 'running', reconnectCount: 1, lastEvent: 'reconnected' });
+    expect(recordBrokerStopping()).toMatchObject({ state: 'stopping', lastEvent: 'broker_owner_stopping' });
+    expect(recordBrokerStopped()).toMatchObject({ state: 'stopped', lastEvent: 'broker_owner_stopped' });
+  });
+});


### PR DESCRIPTION
## Summary\n- add process-local broker lifecycle state for owner/reconnect/stop diagnostics\n- expose broker lifecycle in oc_connection_health\n- make oc_stop default to keepChrome in broker owner mode unless explicitly overridden\n\n## Issues\n- Advances #1373\n- Aligns with #1359 by protecting the single shared Chrome owner from accidental proxy/client shutdown semantics\n\n## Validation\n- npm test -- tests/broker-lifecycle.test.ts --runInBand\n- npm run build\n- git diff --check\n\n## Notes\n- Live crash/reconnect validation still requires an operator Chrome environment; this PR locks the state model and safety default.