### PR TITLE
Reuse startup NTP for first default-context page

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -1709,7 +1709,11 @@ export class CDPClient {
         await smartGoto(page, url, { timeout: DEFAULT_NAVIGATION_TIMEOUT_MS });
         assertDomainAllowed(page.url());
       } catch (err) {
-        // Close the page to prevent about:blank ghost tabs on navigation failure
+        // Close the page to prevent about:blank ghost tabs on navigation failure.
+        // When `page` came from findReusableStartupPage the closed tab is the
+        // startup NTP — that's intentional: reuse is gated to isolated-mode
+        // (OpenChrome owns Chrome), so the user does not see a stuck about:blank
+        // from a failed first navigation.
         const targetId = getTargetId(page.target());
         this.targetIdIndex.delete(targetId);
         await page.close().catch(() => {});

--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -1638,14 +1638,21 @@ export class CDPClient {
         }),
       ]) as Page;
     } else {
-      // Create page in Chrome's default context
-      let newPageTid2: ReturnType<typeof setTimeout>;
-      page = await Promise.race([
-        browser.newPage().finally(() => clearTimeout(newPageTid2)),
-        new Promise<never>((_, reject) => {
-          newPageTid2 = setTimeout(() => reject(new Error(`newPage() timed out after ${DEFAULT_NEW_PAGE_TIMEOUT_MS}ms`)), DEFAULT_NEW_PAGE_TIMEOUT_MS);
-        }),
-      ]) as Page;
+      const startupPage = await this.findReusableStartupPage(browser);
+      if (startupPage) {
+        page = startupPage;
+        skipCookieBridge = true;
+        console.error(`[CDPClient] Reused startup tab ${getTargetId(page.target())} for first default-context page`);
+      } else {
+        // Create page in Chrome's default context
+        let newPageTid2: ReturnType<typeof setTimeout>;
+        page = await Promise.race([
+          browser.newPage().finally(() => clearTimeout(newPageTid2)),
+          new Promise<never>((_, reject) => {
+            newPageTid2 = setTimeout(() => reject(new Error(`newPage() timed out after ${DEFAULT_NEW_PAGE_TIMEOUT_MS}ms`)), DEFAULT_NEW_PAGE_TIMEOUT_MS);
+          }),
+        ]) as Page;
+      }
 
       // Copy cookies from an authenticated page (skip for pool pre-warming to avoid
       // CDP session conflicts and unnecessary overhead on about:blank pages).
@@ -1711,6 +1718,27 @@ export class CDPClient {
     }
 
     return page;
+  }
+
+
+  private async findReusableStartupPage(browser: Browser): Promise<Page | null> {
+    if (this.targetIdIndex.size !== 0 || this.getChromeLifecycleMode() !== 'isolated') return null;
+    const candidates = browser.targets().filter((target) => {
+      if (target.type() !== 'page') return false;
+      const targetId = getTargetId(target);
+      if (!targetId || this.targetIdIndex.has(targetId)) return false;
+      const targetUrl = target.url();
+      return targetUrl === ''
+        || targetUrl === 'about:blank'
+        || targetUrl === 'chrome://newtab/'
+        || targetUrl.startsWith('chrome://new-tab-page');
+    });
+    if (candidates.length !== 1) return null;
+    try {
+      return await candidates[0].page();
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/tests/cdp/client-contracts.test.ts
+++ b/tests/cdp/client-contracts.test.ts
@@ -5,11 +5,13 @@ jest.mock('puppeteer-core', () => ({
   default: { connect: jest.fn() },
 }));
 
+const mockLauncher = {
+  ensureChrome: jest.fn(),
+  invalidateInstance: jest.fn(),
+  getInstance: jest.fn(() => ({ launchMode: 'isolated' })),
+};
 jest.mock('../../src/chrome/launcher', () => ({
-  getChromeLauncher: jest.fn().mockReturnValue({
-    ensureChrome: jest.fn(),
-    invalidateInstance: jest.fn(),
-  }),
+  getChromeLauncher: jest.fn(() => mockLauncher),
 }));
 
 jest.mock('../../src/config/global', () => ({
@@ -42,10 +44,11 @@ type MockPage = {
   mainFrame: jest.Mock;
 };
 
-function makeTarget(targetId: string, page?: MockPage, type = 'page') {
+function makeTarget(targetId: string, page?: MockPage, type = 'page', url = 'about:blank') {
   return {
     _targetId: targetId,
     type: jest.fn(() => type),
+    url: jest.fn(() => url),
     page: jest.fn(async () => page ?? null),
     createCDPSession: jest.fn(async () => ({ send: jest.fn(async () => ({})), detach: jest.fn(async () => undefined) })),
   };
@@ -92,6 +95,7 @@ function connectedClient(browser: ReturnType<typeof makeBrowser>) {
 describe('CDPClient target/page contracts (#687 Wave 4 prereq)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockLauncher.getInstance.mockReturnValue({ launchMode: 'isolated' });
     smartGoto.mockReset();
     smartGoto.mockResolvedValue(undefined);
     jest.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -150,4 +154,37 @@ describe('CDPClient target/page contracts (#687 Wave 4 prereq)', () => {
     expect(page.close).toHaveBeenCalled();
     expect(await client.getPageByTargetId('new-target')).toBeNull();
   });
+
+  it('createPage reuses the single startup NTP target on first default-context page', async () => {
+    const startupPage = makePage('startup-target', 'chrome://newtab/');
+    const startupTarget = makeTarget('startup-target', startupPage, 'page', 'chrome://newtab/');
+    const browser = makeBrowser([], [startupTarget]);
+    const client = connectedClient(browser);
+
+    const page = await client.createPage('https://example.test/', null, false);
+
+    expect(page).toBe(startupPage);
+    expect(browser.newPage).not.toHaveBeenCalled();
+    expect(startupTarget.page).toHaveBeenCalledTimes(1);
+    expect(startupPage.setViewport).toHaveBeenCalled();
+    expect(smartGoto).toHaveBeenCalledWith(startupPage, 'https://example.test/', expect.any(Object));
+    expect(await client.getPageByTargetId('startup-target')).toBe(startupPage);
+  });
+
+  it('createPage does not reuse startup candidates outside safe first-call guards', async () => {
+    const startupPage = makePage('startup-target', 'chrome://newtab/');
+    const startupTarget = makeTarget('startup-target', startupPage, 'page', 'chrome://newtab/');
+    const browser = makeBrowser([], [startupTarget]);
+    const newPage = makePage('new-target');
+    browser.newPage.mockResolvedValue(newPage);
+    const client = connectedClient(browser);
+    mockLauncher.getInstance.mockReturnValue({ launchMode: 'attach' });
+
+    const page = await client.createPage(undefined, null, true);
+
+    expect(page).toBe(newPage);
+    expect(browser.newPage).toHaveBeenCalledTimes(1);
+    expect(startupTarget.page).not.toHaveBeenCalled();
+  });
+
 });

--- a/tests/cdp/client-contracts.test.ts
+++ b/tests/cdp/client-contracts.test.ts
@@ -187,4 +187,27 @@ describe('CDPClient target/page contracts (#687 Wave 4 prereq)', () => {
     expect(startupTarget.page).not.toHaveBeenCalled();
   });
 
+  // Second-call guard: once targetIdIndex is non-empty the startup target must
+  // never be reused, even if Chrome still happens to list an NTP-shaped tab.
+  // Protects the bug where a second createPage call would race and consume an
+  // unrelated about:blank-ish target that another component opened.
+  it('createPage does not reuse startup candidates after the first default-context page is created', async () => {
+    const startupPage = makePage('startup-target', 'chrome://newtab/');
+    const startupTarget = makeTarget('startup-target', startupPage, 'page', 'chrome://newtab/');
+    const secondPage = makePage('second-target');
+    const browser = makeBrowser([], [startupTarget]);
+    browser.newPage.mockResolvedValue(secondPage);
+    const client = connectedClient(browser);
+
+    const first = await client.createPage('https://first.test/', null, true);
+    expect(first).toBe(startupPage);
+    expect(browser.newPage).not.toHaveBeenCalled();
+
+    const second = await client.createPage('https://second.test/', null, true);
+
+    expect(second).toBe(secondPage);
+    expect(browser.newPage).toHaveBeenCalledTimes(1);
+    expect(startupTarget.page).toHaveBeenCalledTimes(1);
+  });
+
 });


### PR DESCRIPTION
## Summary\n- reuse the single startup blank/NTP target on the first default-context createPage call\n- keep guardrails for attached Chrome, non-first calls, isolated contexts, and multiple candidates\n- add CDP client contract tests for reuse and non-reuse paths\n\n## Issues\n- Fixes #1346\n- Aligns with #1359 browser-visible stability/polish without changing shared-profile ownership semantics\n\n## Validation\n- npm test -- tests/cdp/client-contracts.test.ts --runInBand\n- npm run build\n- git diff --check