### PR TITLE
Harden opt-in codegen replay artifacts

### DIFF
--- a/src/core/codegen/aggregator.ts
+++ b/src/core/codegen/aggregator.ts
@@ -132,6 +132,8 @@ export function listCodegenFiles(root = defaultCodegenRoot()): string[] {
 export function replayCommandFor(file: string, format: Exclude<CodegenMode, 'off'>): string {
   const qFile = JSON.stringify(file);
   if (format === 'mcp-replay') return `openchrome replay --from ${qFile}`;
-  if (format === 'puppeteer') return `npx ts-node ${qFile}`;
+  // puppeteer and playwright artifacts are both standalone TypeScript scripts
+  // that run via ts-node (playwright uses `import { chromium } from 'playwright'`,
+  // not `playwright/test`, so `npx playwright test` is not the right invocation).
   return `npx ts-node ${qFile}`;
 }

--- a/src/core/codegen/aggregator.ts
+++ b/src/core/codegen/aggregator.ts
@@ -86,12 +86,24 @@ function buildPlaywrightSnippet(tool: string, args: Record<string, unknown>): st
   }
 }
 
+function tsFooter(format: 'puppeteer' | 'playwright'): string {
+  const closeContext = format === 'playwright' ? '  await context.close();\n' : '';
+  return `${closeContext}  await browser.close();\n}\n\nmain().catch((error) => {\n  console.error(error);\n  process.exitCode = 1;\n});\n`;
+}
+
+function stripTsFooter(source: string): string {
+  const marker = '\n  await browser.close();\n}\n\nmain().catch';
+  const index = source.indexOf(marker);
+  if (index === -1) return source;
+  return source.slice(0, index) + '\n';
+}
+
 function ensureTsHeader(file: string, format: 'puppeteer' | 'playwright'): void {
   if (fs.existsSync(file)) return;
   const header = format === 'puppeteer'
     ? "import puppeteer from 'puppeteer-core';\n\nasync function main() {\n  const browser = await puppeteer.launch({ headless: true });\n  const page = await browser.newPage();\n"
     : "import { chromium } from 'playwright';\n\nasync function main() {\n  const browser = await chromium.launch();\n  const context = await browser.newContext();\n  const page = await context.newPage();\n";
-  fs.writeFileSync(file, header, 'utf8');
+  fs.writeFileSync(file, header + tsFooter(format), 'utf8');
 }
 
 export function recordCodegenStep(sessionId: string, tool: string, rawArgs: Record<string, unknown>): ReplayEnvelope | undefined {
@@ -105,7 +117,8 @@ export function recordCodegenStep(sessionId: string, tool: string, rawArgs: Reco
     const file = codegenPath(sessionId, mode, root);
     ensureTsHeader(file, mode);
     const snippet = mode === 'puppeteer' ? envelope.puppeteer_snippet : envelope.playwright_snippet;
-    fs.appendFileSync(file, `  ${snippet ?? `// ${tool} ${json(rawArgs)}`}\n`, 'utf8');
+    const body = stripTsFooter(fs.readFileSync(file, 'utf8'));
+    fs.writeFileSync(file, `${body}  ${snippet ?? `// ${tool} ${json(rawArgs)}`}\n${tsFooter(mode)}`, 'utf8');
   }
   return envelope;
 }
@@ -114,4 +127,11 @@ export function listCodegenFiles(root = defaultCodegenRoot()): string[] {
   try {
     return fs.readdirSync(root).map((f) => path.join(root, f)).filter((f) => fs.statSync(f).isFile()).sort();
   } catch { return []; }
+}
+
+export function replayCommandFor(file: string, format: Exclude<CodegenMode, 'off'>): string {
+  const qFile = JSON.stringify(file);
+  if (format === 'mcp-replay') return `openchrome replay --from ${qFile}`;
+  if (format === 'puppeteer') return `npx ts-node ${qFile}`;
+  return `npx ts-node ${qFile}`;
 }

--- a/src/tools/oc-skill-export.ts
+++ b/src/tools/oc-skill-export.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { MCPServer } from '../mcp-server';
 import { MCPResult, MCPToolDefinition, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
-import { codegenPath, defaultCodegenRoot, listCodegenFiles, type CodegenMode } from '../core/codegen';
+import { codegenPath, defaultCodegenRoot, listCodegenFiles, replayCommandFor, type CodegenMode } from '../core/codegen';
 
 const definition: MCPToolDefinition = {
   name: 'oc_skill_export',
@@ -36,7 +36,7 @@ const handler: ToolHandler = async (sessionId, args): Promise<MCPResult> => {
   }
   try {
     const stat = await import('node:fs').then((fs) => fs.statSync(file));
-    const payload = { path: file, byte_count: stat.size, format };
+    const payload = { path: file, byte_count: stat.size, format, replay_command: replayCommandFor(file, format) };
     return { content: [{ type: 'text', text: JSON.stringify(payload) }], structuredContent: payload };
   } catch {
     return { isError: true, content: [{ type: 'text', text: `oc_skill_export: no ${format} codegen artifact found for session ${sid}` }] };

--- a/tests/core/codegen.test.ts
+++ b/tests/core/codegen.test.ts
@@ -1,8 +1,9 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import ts from 'typescript';
 
-import { codegenPath, getCodegenMode, normalizeCodegenMode, recordCodegenStep, setCodegenMode } from '../../src/core/codegen';
+import { codegenPath, getCodegenMode, normalizeCodegenMode, recordCodegenStep, replayCommandFor, setCodegenMode } from '../../src/core/codegen';
 
 describe('codegen aggregator (#836)', () => {
   let dir: string;
@@ -45,8 +46,29 @@ describe('codegen aggregator (#836)', () => {
     const replay = recordCodegenStep('s1', 'navigate', { url: 'http://localhost/form' });
     expect(replay?.puppeteer_snippet).toContain('page.goto');
     expect(fs.readFileSync(codegenPath('s1', 'mcp-replay'), 'utf8')).toContain('navigate');
-    const ts = fs.readFileSync(codegenPath('s1', 'puppeteer'), 'utf8');
-    expect(ts).toContain("import puppeteer");
-    expect(ts).toContain('page.goto');
+    const source = fs.readFileSync(codegenPath('s1', 'puppeteer'), 'utf8');
+    expect(source).toContain("import puppeteer");
+    expect(source).toContain('page.goto');
+    expect(source).toContain('main().catch');
+    const output = ts.transpileModule(source, { compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 } });
+    expect(output.diagnostics ?? []).toEqual([]);
+  });
+
+  test('playwright mode keeps the generated TypeScript syntactically complete after multiple steps', () => {
+    setCodegenMode('playwright');
+    recordCodegenStep('s1', 'navigate', { url: 'http://localhost/a' });
+    recordCodegenStep('s1', 'wait_for', { timeoutMs: 25 });
+
+    const file = codegenPath('s1', 'playwright');
+    const source = fs.readFileSync(file, 'utf8');
+    expect(source.match(/main\(\)\.catch/g)).toHaveLength(1);
+    expect(source).toContain('await context.close();');
+    const output = ts.transpileModule(source, { compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 } });
+    expect(output.diagnostics ?? []).toEqual([]);
+  });
+
+  test('replayCommandFor returns an operator command for each artifact format', () => {
+    expect(replayCommandFor('/tmp/s1.mcp-replay.jsonl', 'mcp-replay')).toContain('openchrome replay');
+    expect(replayCommandFor('/tmp/s1.puppeteer.ts', 'puppeteer')).toContain('ts-node');
   });
 });

--- a/tests/core/codegen.test.ts
+++ b/tests/core/codegen.test.ts
@@ -70,5 +70,6 @@ describe('codegen aggregator (#836)', () => {
   test('replayCommandFor returns an operator command for each artifact format', () => {
     expect(replayCommandFor('/tmp/s1.mcp-replay.jsonl', 'mcp-replay')).toContain('openchrome replay');
     expect(replayCommandFor('/tmp/s1.puppeteer.ts', 'puppeteer')).toContain('ts-node');
+    expect(replayCommandFor('/tmp/s1.playwright.ts', 'playwright')).toContain('ts-node');
   });
 });


### PR DESCRIPTION
## Summary\n- keep generated Puppeteer/Playwright TypeScript files syntactically complete after every recorded step\n- add replay_command to oc_skill_export structured output\n- add syntax checks for generated TypeScript and replay command coverage\n\n## Issues\n- Advances #836\n- Aligns with #1359 by preserving default-off behavior while improving opt-in reproducibility\n\n## Validation\n- npm test -- tests/core/codegen.test.ts --runInBand\n- npm run build\n- git diff --check