### PR TITLE
Record browser lane target restoration state

### DIFF
--- a/src/core/browser-lanes.ts
+++ b/src/core/browser-lanes.ts
@@ -46,10 +46,14 @@ function laneWithStatuses(lane: BrowserLane, liveTargetIds?: Set<string>): Brows
     status: liveTargetIds && !liveTargetIds.has(targetId) ? 'target_missing' as const : 'open' as const,
   }));
   const missing = statuses.some((target) => target.status === 'target_missing');
+  // A reconciled lane with zero targets is treated as recoverable failure too:
+  // hosts need to see "lane has no live targets" rather than a silent open status.
+  const emptyAfterReconcile = liveTargetIds !== undefined && statuses.length === 0;
+  const degraded = missing || emptyAfterReconcile;
   return {
     ...lane,
-    ...(statuses.length ? { targetStatuses: statuses } : {}),
-    ...(missing ? { status: 'failed' as const, recovery: 'target_missing' as const } : {}),
+    targetStatuses: statuses,
+    ...(degraded ? { status: 'failed' as const, recovery: 'target_missing' as const } : {}),
   };
 }
 
@@ -145,14 +149,21 @@ export async function closeBrowserLane(taskId: string, laneId: string, sessionId
 }
 
 
+/**
+ * Reconcile persisted lane target ids against the live CDP target set.
+ * Intended to be called by the task-restore / session-resume path after a
+ * host restart (#1037) so hosts can see which lanes lost their targets and
+ * recover them explicitly instead of silently dropping the isolation facts.
+ */
 export async function reconcileBrowserLaneTargets(taskId: string, liveTargetIds: Set<string>): Promise<BrowserLane[]> {
   const store = getTaskStore();
-  const meta = store.readMetaSync(taskId);
-  if (!meta) throw new Error(`unknown task ${taskId}`);
   const now = Date.now();
-  const lanes = getTaskLanes(meta).map((lane) => laneWithStatuses(lane, liveTargetIds));
-  await store.update(taskId, (cur) => ({ ...cur, lanes, last_activity_at: now }));
-  return lanes.map(cloneLane);
+  let reconciled: BrowserLane[] = [];
+  await store.update(taskId, (cur) => {
+    reconciled = getTaskLanes(cur).map((lane) => laneWithStatuses(lane, liveTargetIds));
+    return { ...cur, lanes: reconciled, last_activity_at: now };
+  });
+  return reconciled.map(cloneLane);
 }
 
 export function resolveLaneForTool(args: Record<string, unknown>): { taskId?: string; laneId?: string } {

--- a/src/core/browser-lanes.ts
+++ b/src/core/browser-lanes.ts
@@ -32,7 +32,25 @@ export function laneWorkerId(taskId: string, laneId: string): string {
 }
 
 function cloneLane(lane: BrowserLane): BrowserLane {
-  return { ...lane, targetIds: [...lane.targetIds], counters: { ...lane.counters } };
+  return {
+    ...lane,
+    targetIds: [...lane.targetIds],
+    ...(lane.targetStatuses ? { targetStatuses: lane.targetStatuses.map((target) => ({ ...target })) } : {}),
+    counters: { ...lane.counters },
+  };
+}
+
+function laneWithStatuses(lane: BrowserLane, liveTargetIds?: Set<string>): BrowserLane {
+  const statuses = lane.targetIds.map((targetId) => ({
+    targetId,
+    status: liveTargetIds && !liveTargetIds.has(targetId) ? 'target_missing' as const : 'open' as const,
+  }));
+  const missing = statuses.some((target) => target.status === 'target_missing');
+  return {
+    ...lane,
+    ...(statuses.length ? { targetStatuses: statuses } : {}),
+    ...(missing ? { status: 'failed' as const, recovery: 'target_missing' as const } : {}),
+  };
 }
 
 export function getTaskLanes(meta: TaskMeta): BrowserLane[] {
@@ -124,6 +142,17 @@ export async function closeBrowserLane(taskId: string, laneId: string, sessionId
   }));
   getTaskStore().appendEvent(taskId, { ts: now, kind: 'log', data: { event: 'lane_closed', laneId } });
   return cloneLane(closed);
+}
+
+
+export async function reconcileBrowserLaneTargets(taskId: string, liveTargetIds: Set<string>): Promise<BrowserLane[]> {
+  const store = getTaskStore();
+  const meta = store.readMetaSync(taskId);
+  if (!meta) throw new Error(`unknown task ${taskId}`);
+  const now = Date.now();
+  const lanes = getTaskLanes(meta).map((lane) => laneWithStatuses(lane, liveTargetIds));
+  await store.update(taskId, (cur) => ({ ...cur, lanes, last_activity_at: now }));
+  return lanes.map(cloneLane);
 }
 
 export function resolveLaneForTool(args: Record<string, unknown>): { taskId?: string; laneId?: string } {

--- a/src/core/task-ledger/types.ts
+++ b/src/core/task-ledger/types.ts
@@ -115,6 +115,7 @@ export interface BrowserLane {
   sessionId: string;
   workerId: string;
   targetIds: string[];
+  targetStatuses?: Array<{ targetId: string; status: 'open' | 'target_missing' }>;
   created_at: number;
   last_activity_at: number;
   counters: { toolCalls: number; failures: number };

--- a/src/tools/session-resume.ts
+++ b/src/tools/session-resume.ts
@@ -14,6 +14,8 @@ import { getSessionManager } from '../session-manager';
 import { CHECKPOINT_DIR, CHECKPOINT_FILE } from './checkpoint';
 import { TaskRunStore } from '../core/task-run';
 import type { TaskRunCheckpoint, TaskRunEvent, TaskRunMeta } from '../core/task-run';
+import { reconcileBrowserLaneTargets } from '../core/browser-lanes';
+import type { BrowserLane } from '../core/task-ledger/types';
 
 // ─── Shared Types (same as session-snapshot.ts) ────────────────────────────
 
@@ -98,6 +100,7 @@ export interface ResumeGuideContext {
   recentJournal?: RecentJournalEntry[];
   evidenceBundles?: Array<{ id?: string; path: string }>;
   taskRun?: TaskRunResumeContext | null;
+  lanes?: BrowserLane[];
 }
 
 // ─── Tab Status Analysis ───────────────────────────────────────────────────
@@ -493,6 +496,22 @@ export function generateResumeGuide(snapshot: SessionSnapshot, tabAnalysis: TabA
     lines.push(`  Next host action class: ${task.nextHostAction}`);
   }
 
+  if (context.lanes && context.lanes.length > 0) {
+    lines.push('');
+    lines.push('Browser lanes:');
+    for (const lane of context.lanes) {
+      const missingCount = (lane.targetStatuses ?? []).filter((t) => t.status === 'target_missing').length;
+      const summary = lane.recovery === 'target_missing'
+        ? `${lane.status} recovery=target_missing missing=${missingCount}/${lane.targetIds.length}`
+        : `${lane.status}`;
+      const label = lane.name ? `${lane.lane_id} "${lane.name}"` : lane.lane_id;
+      lines.push(`  - ${label}: ${summary}`);
+    }
+    if (context.lanes.some((lane) => lane.recovery === 'target_missing')) {
+      lines.push('  Recovery: failed lanes need a fresh tab via oc_lane_create (or recreate the lane) before they can be reused.');
+    }
+  }
+
   if (context.evidenceBundles && context.evidenceBundles.length > 0) {
     lines.push('');
     lines.push('Evidence bundles:');
@@ -515,6 +534,50 @@ export function generateResumeGuide(snapshot: SessionSnapshot, tabAnalysis: TabA
   lines.push('Recommended next safe action: verify the live tab state with read_page or tabs_context before mutating the page.');
 
   return lines.join('\n');
+}
+
+// ─── Live target ID collection (for browser-lane reconciliation, #1037) ────
+
+export function collectLiveTargetIds(tabAnalysis: TabAnalysis[]): Set<string> {
+  const live = new Set<string>();
+  // Trust the tab analysis we already ran: LIVE/REMAPPED carry a verified
+  // currentTargetId, which is enough to keep lanes "open" after restart.
+  for (const tab of tabAnalysis) {
+    if (tab.currentTargetId && (tab.status === 'LIVE' || tab.status === 'REMAPPED')) {
+      live.add(tab.currentTargetId);
+    }
+  }
+  // Fall back to enumerating session-manager targets so lanes whose targets
+  // were not part of this snapshot still resolve as alive when present.
+  try {
+    const sessionManager = getSessionManager();
+    for (const sessionInfo of sessionManager.getAllSessionInfos()) {
+      for (const workerInfo of sessionInfo.workers) {
+        for (const id of sessionManager.getWorkerTargetIds(sessionInfo.id, workerInfo.id)) {
+          live.add(id);
+        }
+      }
+    }
+  } catch {
+    // SessionManager unavailable (e.g. Chrome disconnected) — fall back to
+    // snapshot-derived ids only; lanes whose targets are not in the snapshot
+    // will be reconciled as target_missing, which is the correct fact.
+  }
+  return live;
+}
+
+export async function reconcileLanesForResume(
+  taskId: string | undefined,
+  tabAnalysis: TabAnalysis[],
+): Promise<BrowserLane[] | undefined> {
+  if (!taskId) return undefined;
+  try {
+    return await reconcileBrowserLaneTargets(taskId, collectLiveTargetIds(tabAnalysis));
+  } catch {
+    // Task ledger unavailable or task has no lanes — silently skip; the rest
+    // of the resume guide remains useful.
+    return undefined;
+  }
 }
 
 // ─── Handler ───────────────────────────────────────────────────────────────
@@ -553,6 +616,7 @@ const handler: ToolHandler = async (
     checkpoint: loadCheckpoint(),
     recentJournal: loadRecentJournalEntries(),
     taskRun: await loadTaskRunResumeContext(taskId),
+    lanes: await reconcileLanesForResume(taskId, tabAnalysis),
   });
 
   return {

--- a/tests/core/browser-lanes.test.ts
+++ b/tests/core/browser-lanes.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { applyLaneTarget, getBrowserLane, recordLaneToolCall } from '../../src/core/browser-lanes';
+import { applyLaneTarget, getBrowserLane, reconcileBrowserLaneTargets, recordLaneToolCall } from '../../src/core/browser-lanes';
 import { TaskStore } from '../../src/core/task-ledger/store';
 import type { TaskMeta } from '../../src/core/task-ledger/types';
 import { setTaskStoreForTests } from '../../src/tools/oc-task-start';
@@ -53,6 +53,18 @@ describe('browser lanes (#1037)', () => {
 
   test('applyLaneTarget rejects cross-lane tabId', () => {
     expect(() => applyLaneTarget({ taskId, laneId: 'lane_alpha', tabId: 'tab-b' })).toThrow(/does not belong/);
+  });
+
+
+  test('reconcileBrowserLaneTargets marks missing restored targets as recoverable failures', async () => {
+    const lanes = await reconcileBrowserLaneTargets(taskId, new Set<string>());
+
+    expect(lanes[0]).toMatchObject({
+      status: 'failed',
+      recovery: 'target_missing',
+      targetStatuses: [{ targetId: 'tab-a', status: 'target_missing' }],
+    });
+    expect(getBrowserLane(taskId, 'lane_alpha')).toMatchObject({ status: 'failed', recovery: 'target_missing' });
   });
 
   test('recordLaneToolCall increments lane counters and appends new target', async () => {

--- a/tests/core/browser-lanes.test.ts
+++ b/tests/core/browser-lanes.test.ts
@@ -67,6 +67,31 @@ describe('browser lanes (#1037)', () => {
     expect(getBrowserLane(taskId, 'lane_alpha')).toMatchObject({ status: 'failed', recovery: 'target_missing' });
   });
 
+  test('reconcileBrowserLaneTargets keeps lane open when every restored target is live', async () => {
+    const lanes = await reconcileBrowserLaneTargets(taskId, new Set(['tab-a']));
+
+    expect(lanes[0]).toMatchObject({
+      status: 'open',
+      targetStatuses: [{ targetId: 'tab-a', status: 'open' }],
+    });
+    expect(lanes[0].recovery).toBeUndefined();
+  });
+
+  test('reconcileBrowserLaneTargets reports per-target status when some targets are missing', async () => {
+    await recordLaneToolCall({ taskId, laneId: 'lane_alpha' }, true, 'tab-b');
+
+    const lanes = await reconcileBrowserLaneTargets(taskId, new Set(['tab-a']));
+
+    expect(lanes[0]).toMatchObject({
+      status: 'failed',
+      recovery: 'target_missing',
+      targetStatuses: [
+        { targetId: 'tab-a', status: 'open' },
+        { targetId: 'tab-b', status: 'target_missing' },
+      ],
+    });
+  });
+
   test('recordLaneToolCall increments lane counters and appends new target', async () => {
     await recordLaneToolCall({ taskId, laneId: 'lane_alpha' }, false, 'tab-b');
     const lane = getBrowserLane(taskId, 'lane_alpha');

--- a/tests/tools/session-resume.test.ts
+++ b/tests/tools/session-resume.test.ts
@@ -21,6 +21,7 @@ import {
   generateResumeGuide,
   SNAPSHOT_DIR,
   registerSessionResumeTool,
+  collectLiveTargetIds,
 } from '../../src/tools/session-resume';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
@@ -734,5 +735,76 @@ describe('generateResumeGuide supplemental artifacts', () => {
     expect(guide).toContain('Evidence bundles:');
     expect(guide).toContain('bundle-1: /tmp/openchrome/bundle-1');
     expect(guide).toContain('Recommended next safe action');
+  });
+
+  test('surfaces browser lane recovery status when reconcile reports target_missing', () => {
+    const snap = makeSnapshot();
+    const guide = generateResumeGuide(snap as any, [], {
+      lanes: [{
+        lane_id: 'lane_alpha',
+        task_id: 'task-1',
+        name: 'login',
+        status: 'failed',
+        sessionId: 'sess-1',
+        workerId: 'task:task-1:lane:lane_alpha',
+        targetIds: ['tab-a', 'tab-b'],
+        targetStatuses: [
+          { targetId: 'tab-a', status: 'open' },
+          { targetId: 'tab-b', status: 'target_missing' },
+        ],
+        recovery: 'target_missing',
+        created_at: Date.now() - 1000,
+        last_activity_at: Date.now(),
+        counters: { toolCalls: 3, failures: 1 },
+      } as any],
+    });
+
+    expect(guide).toContain('Browser lanes:');
+    expect(guide).toContain('lane_alpha "login"');
+    expect(guide).toContain('recovery=target_missing missing=1/2');
+    expect(guide).toContain('Recovery: failed lanes need a fresh tab');
+  });
+
+  test('omits browser lane section when no lanes reconciled', () => {
+    const snap = makeSnapshot();
+    const guide = generateResumeGuide(snap as any, []);
+    expect(guide).not.toContain('Browser lanes:');
+  });
+});
+
+// ─── collectLiveTargetIds (lane reconciliation wiring, #1037) ─────────────
+
+describe('collectLiveTargetIds', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns LIVE and REMAPPED target ids from tab analysis', () => {
+    (getSessionManager as jest.Mock).mockReturnValue(makeMockSessionManager());
+
+    const ids = collectLiveTargetIds([
+      { saved: makeTab() as any, status: 'LIVE', currentTargetId: 'tab-live' },
+      { saved: makeTab() as any, status: 'REMAPPED', currentTargetId: 'tab-remap' },
+      { saved: makeTab() as any, status: 'CLOSED' },
+    ]);
+
+    expect(ids.has('tab-live')).toBe(true);
+    expect(ids.has('tab-remap')).toBe(true);
+    expect(ids.size).toBe(2);
+  });
+
+  test('also picks up SessionManager-known targets not present in the snapshot', () => {
+    (getSessionManager as jest.Mock).mockReturnValue(makeMockSessionManager({
+      getAllSessionInfos: jest.fn().mockReturnValue([{ id: 'sess-1', workers: [{ id: 'w1' }] }]),
+      getWorkerTargetIds: jest.fn().mockReturnValue(['extra-tab']),
+    }));
+
+    const ids = collectLiveTargetIds([]);
+    expect(ids.has('extra-tab')).toBe(true);
+  });
+
+  test('does not throw when SessionManager is unavailable', () => {
+    (getSessionManager as jest.Mock).mockImplementation(() => { throw new Error('disconnected'); });
+    expect(() => collectLiveTargetIds([])).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary\n- add per-target lane status metadata for open vs target_missing\n- add reconciliation helper to mark restored lanes with missing targets as recoverable failures\n- cover restart-style missing-target behavior in lane tests\n\n## Issues\n- Advances #1037\n- Aligns with #1359 by keeping browser lanes host-directed and deterministic\n\n## Validation\n- npm test -- tests/core/browser-lanes.test.ts --runInBand\n- npm run build\n- git diff --check