### PR TITLE
Add client-mediated sampling fallback to act

### DIFF
--- a/src/tools/act.ts
+++ b/src/tools/act.ts
@@ -163,12 +163,20 @@ async function maybeRefineActionsWithSampling(
         },
       }],
       maxTokens: 400,
-    }, { timeoutMs: 5000, signal: context.signal });
+    }, { timeoutMs: 8000, signal: context.signal });
     const sampled = parseSampledActions(response);
     if (!sampled) return { actions, decision: { used: false, supported: true, fallbackReason: 'invalid_sampling_response' } };
     return { actions: sampled, decision: { used: true, supported: true } };
   } catch (err) {
-    return { actions, decision: { used: false, supported: true, fallbackReason: err instanceof Error ? err.message : String(err) } };
+    // Map known transport/cancel signatures to closed-set reasons so we don't
+    // leak raw transport text to clients in `_meta.sampling.fallbackReason`.
+    const message = err instanceof Error ? err.message : String(err);
+    const fallbackReason = /timeout/i.test(message)
+      ? 'timeout'
+      : /abort|cancel/i.test(message)
+        ? 'cancelled'
+        : 'transport_error';
+    return { actions, decision: { used: false, supported: true, fallbackReason } };
   }
 }
 

--- a/src/tools/act.ts
+++ b/src/tools/act.ts
@@ -100,6 +100,71 @@ const definition: MCPToolDefinition = {
   annotations: TOOL_ANNOTATIONS.act,
 };
 
+
+interface SamplingDecision {
+  used: boolean;
+  supported: boolean;
+  fallbackReason?: string;
+}
+
+const VALID_ACTIONS = new Set(['click', 'type', 'select', 'hover', 'scroll', 'wait', 'navigate', 'check', 'uncheck']);
+
+function parseSampledActions(value: unknown): ParsedAction[] | null {
+  const text = typeof value === 'string'
+    ? value
+    : typeof (value as { content?: Array<{ type?: string; text?: string }> })?.content?.[0]?.text === 'string'
+      ? (value as { content: Array<{ text: string }> }).content[0].text
+      : undefined;
+  if (!text) return null;
+  let parsed: unknown;
+  try { parsed = JSON.parse(text); } catch { return null; }
+  const actions = (parsed as { actions?: unknown }).actions;
+  if (!Array.isArray(actions) || actions.length === 0) return null;
+  const normalized: ParsedAction[] = [];
+  for (const action of actions) {
+    if (!action || typeof action !== 'object') return null;
+    const record = action as Record<string, unknown>;
+    if (typeof record.action !== 'string' || !VALID_ACTIONS.has(record.action)) return null;
+    normalized.push({
+      action: record.action as ParsedAction['action'],
+      ...(typeof record.target === 'string' ? { target: record.target } : {}),
+      ...(typeof record.value === 'string' ? { value: record.value } : {}),
+      ...(typeof record.url === 'string' ? { value: record.url } : {}),
+    });
+  }
+  return normalized;
+}
+
+async function maybeRefineActionsWithSampling(
+  instruction: string,
+  actions: ParsedAction[],
+  context?: ToolContext,
+): Promise<{ actions: ParsedAction[]; decision: SamplingDecision }> {
+  if (!context?.clientCapabilities?.sampling || !context.requestClient) {
+    return { actions, decision: { used: false, supported: false, fallbackReason: 'sampling_unavailable' } };
+  }
+  if (actions.length < 2) {
+    return { actions, decision: { used: false, supported: true, fallbackReason: 'single_action' } };
+  }
+  try {
+    const response = await context.requestClient<unknown>('sampling/createMessage', {
+      messages: [{
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `Choose the safest deterministic OpenChrome act action sequence for: ${instruction}\nReturn strict JSON only: {'actions':[{'action':'click|type|select|hover|scroll|wait|navigate|check|uncheck','target':'optional','value':'optional'}]}`,
+        },
+      }],
+      maxTokens: 400,
+    }, { timeoutMs: 5000, signal: context.signal });
+    const sampled = parseSampledActions(response);
+    if (!sampled) return { actions, decision: { used: false, supported: true, fallbackReason: 'invalid_sampling_response' } };
+    return { actions: sampled, decision: { used: true, supported: true } };
+  } catch (err) {
+    return { actions, decision: { used: false, supported: true, fallbackReason: err instanceof Error ? err.message : String(err) } };
+  }
+}
+
 // ─── Element resolution helper ───
 
 async function collectWorkflowPageSignature(page: any): Promise<WorkflowPageSignature | null> {
@@ -669,6 +734,10 @@ Suggestion: ${suggestion}`,
     }
   }
 
+  const samplingResult = await maybeRefineActionsWithSampling(instruction, actions, context);
+  actions = samplingResult.actions;
+  const samplingDecision = samplingResult.decision;
+
   const cdpClient = sessionManager.getCDPClient();
   const isStealth = sessionManager.isStealthTarget(tabId);
   const stepResults: StepResult[] = [];
@@ -840,6 +909,11 @@ Suggestion: ${suggestion}`,
     lines.push('', `[Warning] ${parseWarning}`);
   }
 
+  if (samplingDecision) {
+    const reason = samplingDecision.fallbackReason ? ` fallback=${samplingDecision.fallbackReason}` : '';
+    lines.push('', `[Sampling] supported=${samplingDecision.supported} used=${samplingDecision.used}${reason}`);
+  }
+
   if (workflowDebug && workflowDecision) {
     lines.push('', formatWorkflowDebug(workflowDecision));
   }
@@ -848,7 +922,8 @@ Suggestion: ${suggestion}`,
     content: [{ type: 'text', text: lines.join('\n') }],
     isError: !success,
   };
-  return actVerifyReport ? { ...baseResult, verify: actVerifyReport } : baseResult;
+  const withMeta = samplingDecision ? { ...baseResult, _meta: { sampling: samplingDecision } } : baseResult;
+  return actVerifyReport ? { ...withMeta, verify: actVerifyReport } : withMeta;
 };
 
 // ─── Registration ───
@@ -876,3 +951,4 @@ const handler: ToolHandler = async (sessionId, args, context): Promise<MCPResult
 export function registerActTool(server: MCPServer): void {
   server.registerTool('act', handler, definition);
 }
+export const __test__ = { maybeRefineActionsWithSampling, parseSampledActions };

--- a/src/tools/act.ts
+++ b/src/tools/act.ts
@@ -125,11 +125,18 @@ function parseSampledActions(value: unknown): ParsedAction[] | null {
     if (!action || typeof action !== 'object') return null;
     const record = action as Record<string, unknown>;
     if (typeof record.action !== 'string' || !VALID_ACTIONS.has(record.action)) return null;
+    // `url` is accepted as a synonym for `value` (e.g. navigate actions) but
+    // must not silently shadow an explicit `value` the sampler also emitted.
+    const valueField = typeof record.value === 'string'
+      ? record.value
+      : typeof record.url === 'string'
+        ? record.url
+        : undefined;
     normalized.push({
       action: record.action as ParsedAction['action'],
       ...(typeof record.target === 'string' ? { target: record.target } : {}),
-      ...(typeof record.value === 'string' ? { value: record.value } : {}),
-      ...(typeof record.url === 'string' ? { value: record.url } : {}),
+      ...(valueField !== undefined ? { value: valueField } : {}),
+      ...(typeof record.condition === 'string' ? { condition: record.condition } : {}),
     });
   }
   return normalized;
@@ -152,7 +159,7 @@ async function maybeRefineActionsWithSampling(
         role: 'user',
         content: {
           type: 'text',
-          text: `Choose the safest deterministic OpenChrome act action sequence for: ${instruction}\nReturn strict JSON only: {'actions':[{'action':'click|type|select|hover|scroll|wait|navigate|check|uncheck','target':'optional','value':'optional'}]}`,
+          text: `Choose the safest deterministic OpenChrome act action sequence for: ${instruction}\nReturn strict JSON only: {"actions":[{"action":"click|type|select|hover|scroll|wait|navigate|check|uncheck","target":"optional","value":"optional","condition":"optional"}]}`,
         },
       }],
       maxTokens: 400,
@@ -734,7 +741,12 @@ Suggestion: ${suggestion}`,
     }
   }
 
-  const samplingResult = await maybeRefineActionsWithSampling(instruction, actions, context);
+  // Cached/templated sequences are already known-good; subjecting them to a
+  // sampling round-trip would only add tokens and risk regressions per P4/P7.
+  const allowSampling = source === 'parsed';
+  const samplingResult = allowSampling
+    ? await maybeRefineActionsWithSampling(instruction, actions, context)
+    : { actions, decision: { used: false, supported: false, fallbackReason: `skipped_${source}` } as SamplingDecision };
   actions = samplingResult.actions;
   const samplingDecision = samplingResult.decision;
 
@@ -909,9 +921,12 @@ Suggestion: ${suggestion}`,
     lines.push('', `[Warning] ${parseWarning}`);
   }
 
-  if (samplingDecision) {
+  // Only surface the [Sampling] line and `_meta.sampling` when the connected
+  // client actually advertised sampling; otherwise this would pollute every
+  // act result for clients that never opted into sampling.
+  if (samplingDecision.supported) {
     const reason = samplingDecision.fallbackReason ? ` fallback=${samplingDecision.fallbackReason}` : '';
-    lines.push('', `[Sampling] supported=${samplingDecision.supported} used=${samplingDecision.used}${reason}`);
+    lines.push('', `[Sampling] used=${samplingDecision.used}${reason}`);
   }
 
   if (workflowDebug && workflowDecision) {
@@ -922,7 +937,7 @@ Suggestion: ${suggestion}`,
     content: [{ type: 'text', text: lines.join('\n') }],
     isError: !success,
   };
-  const withMeta = samplingDecision ? { ...baseResult, _meta: { sampling: samplingDecision } } : baseResult;
+  const withMeta = samplingDecision.supported ? { ...baseResult, _meta: { sampling: samplingDecision } } : baseResult;
   return actVerifyReport ? { ...withMeta, verify: actVerifyReport } : withMeta;
 };
 

--- a/tests/tools/act-sampling.test.ts
+++ b/tests/tools/act-sampling.test.ts
@@ -37,4 +37,43 @@ describe('act client-mediated sampling (#876)', () => {
     expect(result.actions).toBe(parsedActions);
     expect(result.decision).toMatchObject({ used: false, fallbackReason: 'invalid_sampling_response' });
   });
+
+  test('falls back deterministically when sampling throws (timeout or transport error)', async () => {
+    const requestClient = jest.fn(async () => { throw new Error('s2c_timeout:sampling/createMessage'); });
+    const result = await __test__.maybeRefineActionsWithSampling('continue', parsedActions, {
+      clientCapabilities: { sampling: {} },
+      requestClient,
+    } as any);
+
+    expect(result.actions).toBe(parsedActions);
+    expect(result.decision).toMatchObject({
+      supported: true,
+      used: false,
+      fallbackReason: 's2c_timeout:sampling/createMessage',
+    });
+  });
+
+  test('treats url as a fallback for value but does not let url shadow value', () => {
+    const parsed = __test__.parseSampledActions({
+      content: [{ type: 'text', text: JSON.stringify({ actions: [
+        { action: 'navigate', value: 'https://wins.test', url: 'https://loses.test' },
+        { action: 'navigate', url: 'https://only-url.test' },
+      ] }) }],
+    });
+
+    expect(parsed).toEqual([
+      { action: 'navigate', value: 'https://wins.test' },
+      { action: 'navigate', value: 'https://only-url.test' },
+    ]);
+  });
+
+  test('preserves wait condition from sampled actions', () => {
+    const parsed = __test__.parseSampledActions({
+      content: [{ type: 'text', text: JSON.stringify({ actions: [
+        { action: 'wait', target: 'Submit', condition: 'appear' },
+      ] }) }],
+    });
+
+    expect(parsed).toEqual([{ action: 'wait', target: 'Submit', condition: 'appear' }]);
+  });
 });

--- a/tests/tools/act-sampling.test.ts
+++ b/tests/tools/act-sampling.test.ts
@@ -22,7 +22,7 @@ describe('act client-mediated sampling (#876)', () => {
       requestClient,
     } as any);
 
-    expect(requestClient).toHaveBeenCalledWith('sampling/createMessage', expect.any(Object), expect.objectContaining({ timeoutMs: 5000 }));
+    expect(requestClient).toHaveBeenCalledWith('sampling/createMessage', expect.any(Object), expect.objectContaining({ timeoutMs: 8000 }));
     expect(result.actions).toEqual([{ action: 'click', target: 'Continue' }]);
     expect(result.decision).toMatchObject({ supported: true, used: true });
   });
@@ -38,7 +38,7 @@ describe('act client-mediated sampling (#876)', () => {
     expect(result.decision).toMatchObject({ used: false, fallbackReason: 'invalid_sampling_response' });
   });
 
-  test('falls back deterministically when sampling throws (timeout or transport error)', async () => {
+  test('maps sampling timeout errors to the closed-set "timeout" fallback reason', async () => {
     const requestClient = jest.fn(async () => { throw new Error('s2c_timeout:sampling/createMessage'); });
     const result = await __test__.maybeRefineActionsWithSampling('continue', parsedActions, {
       clientCapabilities: { sampling: {} },
@@ -46,11 +46,29 @@ describe('act client-mediated sampling (#876)', () => {
     } as any);
 
     expect(result.actions).toBe(parsedActions);
-    expect(result.decision).toMatchObject({
-      supported: true,
-      used: false,
-      fallbackReason: 's2c_timeout:sampling/createMessage',
-    });
+    expect(result.decision).toMatchObject({ supported: true, used: false, fallbackReason: 'timeout' });
+  });
+
+  test('maps host-side cancellation to the closed-set "cancelled" fallback reason', async () => {
+    const requestClient = jest.fn(async () => { throw new Error('AbortError: cancelled by host'); });
+    const result = await __test__.maybeRefineActionsWithSampling('continue', parsedActions, {
+      clientCapabilities: { sampling: {} },
+      requestClient,
+    } as any);
+
+    expect(result.actions).toBe(parsedActions);
+    expect(result.decision).toMatchObject({ used: false, fallbackReason: 'cancelled' });
+  });
+
+  test('falls back to the closed-set "transport_error" reason on opaque transport failures', async () => {
+    const requestClient = jest.fn(async () => { throw new Error('connection reset'); });
+    const result = await __test__.maybeRefineActionsWithSampling('continue', parsedActions, {
+      clientCapabilities: { sampling: {} },
+      requestClient,
+    } as any);
+
+    expect(result.actions).toBe(parsedActions);
+    expect(result.decision).toMatchObject({ used: false, fallbackReason: 'transport_error' });
   });
 
   test('treats url as a fallback for value but does not let url shadow value', () => {

--- a/tests/tools/act-sampling.test.ts
+++ b/tests/tools/act-sampling.test.ts
@@ -1,0 +1,40 @@
+import { __test__ } from '../../src/tools/act';
+
+describe('act client-mediated sampling (#876)', () => {
+  const parsedActions = [
+    { action: 'click' as const, target: 'Sign in' },
+    { action: 'type' as const, target: 'Email', value: 'a@example.test' },
+  ];
+
+  test('falls back deterministically when sampling is unavailable', async () => {
+    const result = await __test__.maybeRefineActionsWithSampling('sign in', parsedActions, {} as any);
+    expect(result.actions).toBe(parsedActions);
+    expect(result.decision).toMatchObject({ supported: false, used: false, fallbackReason: 'sampling_unavailable' });
+  });
+
+  test('accepts strict JSON sampled actions from the MCP client', async () => {
+    const requestClient = jest.fn(async () => ({
+      content: [{ type: 'text', text: JSON.stringify({ actions: [{ action: 'click', target: 'Continue' }] }) }],
+    }));
+
+    const result = await __test__.maybeRefineActionsWithSampling('continue', parsedActions, {
+      clientCapabilities: { sampling: {} },
+      requestClient,
+    } as any);
+
+    expect(requestClient).toHaveBeenCalledWith('sampling/createMessage', expect.any(Object), expect.objectContaining({ timeoutMs: 5000 }));
+    expect(result.actions).toEqual([{ action: 'click', target: 'Continue' }]);
+    expect(result.decision).toMatchObject({ supported: true, used: true });
+  });
+
+  test('rejects malformed sampling output and keeps parsed actions', async () => {
+    const requestClient = jest.fn(async () => ({ content: [{ type: 'text', text: '{not-json' }] }));
+    const result = await __test__.maybeRefineActionsWithSampling('continue', parsedActions, {
+      clientCapabilities: { sampling: {} },
+      requestClient,
+    } as any);
+
+    expect(result.actions).toBe(parsedActions);
+    expect(result.decision).toMatchObject({ used: false, fallbackReason: 'invalid_sampling_response' });
+  });
+});


### PR DESCRIPTION
## Summary\n- add MCP client-mediated sampling refinement for multi-step act sequences when the client advertises sampling\n- strictly parse sampled JSON actions and fall back to deterministic parsed actions on timeout/error/malformed output\n- surface sampling metadata without adding server-side LLM calls\n\n## Issues\n- Advances #876\n- Aligns with #1359 by keeping sampling client-mediated and deterministic by default\n\n## Validation\n- npm test -- tests/tools/act-sampling.test.ts --runInBand\n- npm run build\n- git diff --check