### PR TITLE
feat(harness): per-step marginal-utility tracker for episode budgets

### DIFF
--- a/src/core/task-ledger/marginal-utility.ts
+++ b/src/core/task-ledger/marginal-utility.ts
@@ -1,0 +1,210 @@
+/**
+ * Marginal-utility tracker for task episodes (issue #1428, Part 1).
+ *
+ * Each tool call is a "step". After every step we update a sliding-window
+ * estimate of p_success (the probability the episode ends successfully).
+ *
+ * Formula
+ * -------
+ * p_success is maintained as a weighted-average score in [0, 1]:
+ *
+ *   base_weight  = WINDOW_SIZE − window_index   (older = lighter)
+ *   step_score   = passes − failures + 0.5 * inconclusives + checkpoints
+ *                  ─────────────────────────────────────────────────────
+ *                  passes + failures + inconclusives + (checkpoint ? 1 : 0)
+ *
+ * When no oc_assert signals arrive in a step, tool success/failure drives
+ * a smaller signal:
+ *   step_score = 0.7  (tool ok, no asserts)
+ *   step_score = 0.3  (tool error, no asserts)
+ *
+ * p_success is the weighted average of step_scores in the sliding window.
+ * delta = p_success_now − p_success_previous.
+ *
+ * The tracker is intentionally simple and deterministic — no ML, no
+ * clocks (callers supply timestamps). Identical inputs always produce
+ * identical outputs.
+ */
+
+/** Maximum number of steps kept in the sliding window. */
+const WINDOW_SIZE = 20;
+
+/**
+ * Per-step aggregated signals fed to `recordStep`.
+ *
+ * All counts are non-negative integers. `toolOk` reflects the outcome
+ * of the tool call that triggered this step (true = no MCP error).
+ */
+export interface StepSignals {
+  /** Unix ms timestamp supplied by the caller (no internal Date.now()). */
+  ts: number;
+  /** Whether the triggering tool call returned without error. */
+  toolOk: boolean;
+  /** Number of oc_assert calls in this step that returned verdict "pass". */
+  assertPasses: number;
+  /** Number of oc_assert calls that returned verdict "fail". */
+  assertFails: number;
+  /** Number of oc_assert calls that returned verdict "inconclusive". */
+  assertInconclusives: number;
+  /**
+   * Whether a checkpoint advance occurred during this step (e.g. the
+   * host advanced task phase or oc_checkpoint was called).
+   */
+  checkpointAdvanced: boolean;
+}
+
+/** One entry in the sliding window. Stored for traceability. */
+export interface StepRecord {
+  step: number;
+  ts: number;
+  p: number;
+  delta: number;
+}
+
+/**
+ * Sliding-window state for the marginal-utility tracker.
+ * Treat as opaque — mutate only via `recordStep`.
+ */
+export interface MarginalUtilityState {
+  /** Total number of steps recorded (monotonically increasing). */
+  totalSteps: number;
+  /** Sliding window of the most recent WINDOW_SIZE step records. */
+  window: StepRecord[];
+  /** p_success after the last step (0.5 initial prior). */
+  lastP: number;
+}
+
+/** Summary returned by `summary()`. */
+export interface MarginalUtilitySummary {
+  /** p_success estimate after the latest step (0 – 1). */
+  last_p: number;
+  /** Average Δp per step over the current window. */
+  mean_delta_per_step: number;
+  /**
+   * Number of consecutive steps at the tail of the window where
+   * |delta| < LOW_DELTA_THRESHOLD — indicates a plateau.
+   */
+  consecutive_low_delta: number;
+}
+
+/** |delta| below this is considered "low" (plateau indicator). */
+const LOW_DELTA_THRESHOLD = 0.02;
+
+/**
+ * Create a fresh MarginalUtilityState with a neutral 0.5 prior.
+ */
+export function initialMarginalUtilityState(): MarginalUtilityState {
+  return { totalSteps: 0, window: [], lastP: 0.5 };
+}
+
+/**
+ * Pure function. Records one step and returns a new state.
+ *
+ * The caller is responsible for aggregating signals from all events that
+ * occurred during a single tool-call round-trip into one `StepSignals`
+ * object before calling this function.
+ */
+export function recordStep(
+  state: MarginalUtilityState,
+  signals: StepSignals,
+): MarginalUtilityState {
+  const stepIndex = state.totalSteps + 1;
+  const score = computeStepScore(signals);
+
+  // Build the new window (limited to WINDOW_SIZE entries).
+  const prevWindow = state.window;
+  const candidateWindow: StepRecord[] = prevWindow.length >= WINDOW_SIZE
+    ? prevWindow.slice(prevWindow.length - (WINDOW_SIZE - 1))
+    : [...prevWindow];
+
+  // Compute new p_success as weighted average over the window + current step.
+  // Weights: oldest entry gets weight 1, newest gets weight WINDOW_SIZE.
+  const scores = candidateWindow.map((r) => r.p);
+  scores.push(score);
+  const n = scores.length;
+  let weightedSum = 0;
+  let totalWeight = 0;
+  for (let i = 0; i < n; i++) {
+    const w = i + 1; // weight 1 for oldest, n for newest
+    weightedSum += scores[i] * w;
+    totalWeight += w;
+  }
+  const newP = totalWeight > 0 ? weightedSum / totalWeight : score;
+  const delta = newP - state.lastP;
+
+  const record: StepRecord = {
+    step: stepIndex,
+    ts: signals.ts,
+    p: newP,
+    delta,
+  };
+
+  return {
+    totalSteps: stepIndex,
+    window: [...candidateWindow, record],
+    lastP: newP,
+  };
+}
+
+/**
+ * Return a concise summary of the current tracker state.
+ */
+export function summary(state: MarginalUtilityState): MarginalUtilitySummary {
+  const { window: win, lastP } = state;
+
+  if (win.length === 0) {
+    return { last_p: lastP, mean_delta_per_step: 0, consecutive_low_delta: 0 };
+  }
+
+  const meanDelta = win.reduce((acc, r) => acc + r.delta, 0) / win.length;
+
+  let consecutiveLow = 0;
+  for (let i = win.length - 1; i >= 0; i--) {
+    if (Math.abs(win[i].delta) < LOW_DELTA_THRESHOLD) {
+      consecutiveLow++;
+    } else {
+      break;
+    }
+  }
+
+  return {
+    last_p: lastP,
+    mean_delta_per_step: meanDelta,
+    consecutive_low_delta: consecutiveLow,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert per-step signals into a [0, 1] score.
+ *
+ * When assert signals are present they dominate. When absent, tool success
+ * provides a weak 0.7/0.3 signal.
+ */
+function computeStepScore(signals: StepSignals): number {
+  const {
+    assertPasses,
+    assertFails,
+    assertInconclusives,
+    checkpointAdvanced,
+    toolOk,
+  } = signals;
+
+  const checkpointBonus = checkpointAdvanced ? 1 : 0;
+  const assertTotal = assertPasses + assertFails + assertInconclusives;
+  const denominator = assertTotal + checkpointBonus;
+
+  if (denominator === 0) {
+    // No assert or checkpoint signals — fall back to tool success heuristic.
+    return toolOk ? 0.7 : 0.3;
+  }
+
+  // score = (passes + 0.5*inconclusives + checkpoint) / denominator
+  // failures subtract — they pull the numerator down by having no contribution
+  // while still increasing the denominator.
+  const numerator = assertPasses + 0.5 * assertInconclusives + checkpointBonus;
+  return Math.max(0, Math.min(1, numerator / denominator));
+}

--- a/src/core/task-ledger/types.ts
+++ b/src/core/task-ledger/types.ts
@@ -156,6 +156,21 @@ export interface TaskMeta {
   lanes?: BrowserLane[];
   last_tool_name?: string;
   last_activity_at?: number;
+  /**
+   * Per-step success-probability curve (issue #1428, Part 1).
+   * Appended by the marginal-utility tracker on every tool call.
+   * Optional and additive — absent on tasks that pre-date the tracker.
+   */
+  cost_curve?: Array<{ step: number; p: number; delta: number }>;
+  /**
+   * Internal tracker state persisted between tool calls so the sliding
+   * window survives across process restarts (stored in meta.json).
+   */
+  _mu_state?: {
+    totalSteps: number;
+    window: Array<{ step: number; ts: number; p: number; delta: number }>;
+    lastP: number;
+  };
 }
 
 

--- a/tests/core/task-ledger/marginal-utility.test.ts
+++ b/tests/core/task-ledger/marginal-utility.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for the marginal-utility tracker (issue #1428, Part 1).
+ */
+import {
+  initialMarginalUtilityState,
+  recordStep,
+  summary,
+  type StepSignals,
+} from '../../../src/core/task-ledger/marginal-utility';
+
+function signals(overrides: Partial<StepSignals> = {}): StepSignals {
+  return {
+    ts: 0,
+    toolOk: true,
+    assertPasses: 0,
+    assertFails: 0,
+    assertInconclusives: 0,
+    checkpointAdvanced: false,
+    ...overrides,
+  };
+}
+
+describe('marginal-utility tracker', () => {
+  it('starts with a neutral 0.5 prior and empty window', () => {
+    const state = initialMarginalUtilityState();
+    expect(state.totalSteps).toBe(0);
+    expect(state.window).toHaveLength(0);
+    expect(state.lastP).toBe(0.5);
+  });
+
+  it('monotonically increases p_success on a clean pass run', () => {
+    let state = initialMarginalUtilityState();
+    for (let i = 0; i < 5; i++) {
+      state = recordStep(
+        state,
+        signals({ ts: i, assertPasses: 1, checkpointAdvanced: true }),
+      );
+    }
+    expect(state.totalSteps).toBe(5);
+    expect(state.lastP).toBeGreaterThan(0.5);
+    // delta is positive on each step
+    state.window.forEach((r) => expect(r.delta).toBeGreaterThanOrEqual(0));
+  });
+
+  it('drops p_success on a failure cluster', () => {
+    let state = initialMarginalUtilityState();
+    // Three passes establish a high prior.
+    for (let i = 0; i < 3; i++) {
+      state = recordStep(state, signals({ ts: i, assertPasses: 1 }));
+    }
+    const priorP = state.lastP;
+
+    // Three failures must pull p_success down.
+    for (let i = 3; i < 6; i++) {
+      state = recordStep(
+        state,
+        signals({ ts: i, assertFails: 1, toolOk: false }),
+      );
+    }
+    expect(state.lastP).toBeLessThan(priorP);
+    // The last step's delta is negative.
+    expect(state.window[state.window.length - 1].delta).toBeLessThan(0);
+  });
+
+  it('counts consecutive low-delta steps as a plateau', () => {
+    // No asserts, tool ok every step → step_score = 0.7 each step.
+    // After enough steps p_success stabilises near 0.7 with tiny deltas.
+    let state = initialMarginalUtilityState();
+    for (let i = 0; i < 25; i++) {
+      state = recordStep(state, signals({ ts: i }));
+    }
+    const s = summary(state);
+    expect(s.consecutive_low_delta).toBeGreaterThan(0);
+  });
+
+  it('is a pure function — identical inputs give identical outputs', () => {
+    const input = signals({ ts: 7, assertPasses: 1 });
+    const a = recordStep(initialMarginalUtilityState(), input);
+    const b = recordStep(initialMarginalUtilityState(), input);
+    expect(a).toEqual(b);
+  });
+
+  it('keeps the window bounded to WINDOW_SIZE entries', () => {
+    let state = initialMarginalUtilityState();
+    for (let i = 0; i < 50; i++) {
+      state = recordStep(state, signals({ ts: i, assertPasses: 1 }));
+    }
+    expect(state.totalSteps).toBe(50);
+    expect(state.window.length).toBeLessThanOrEqual(20);
+  });
+
+  it('summary on an empty state returns zeroed metrics', () => {
+    const s = summary(initialMarginalUtilityState());
+    expect(s.last_p).toBe(0.5);
+    expect(s.mean_delta_per_step).toBe(0);
+    expect(s.consecutive_low_delta).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- New deterministic sliding-window tracker (`src/core/task-ledger/marginal-utility.ts`) that estimates `p_success` after each tool call.
- Inputs: per-step signals (oc_assert passes/fails/inconclusives, checkpoint advance, tool ok). Output: `{ last_p, mean_delta_per_step, consecutive_low_delta }`.
- Pure additive change to `TaskMeta`: new optional `cost_curve[]` and internal `_mu_state`.
- 7 unit tests covering pass run, failure cluster, plateau detection, purity, window bound, empty summary.

## SSOT (#1359) alignment
Pure server-side resource tracking; no host coupling, no LLM, deterministic.

## Out of scope (Part 2 of #1428)
- Early-stop policy that actually halts execution
- Report curve / chart generation
- Headline-gate integration

## Test plan
- [x] `npx jest tests/core/task-ledger/marginal-utility.test.ts` — 7/7 pass
- [ ] Reviewer to confirm no regression in existing budget tests

Part 1 of #1428.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>