### PR TITLE
feat(benchmark): Online-Mind2Web dataset loader and schema fixtures

### DIFF
--- a/benchmark/COMPETITORS.md
+++ b/benchmark/COMPETITORS.md
@@ -35,6 +35,7 @@ they are not reproducible here. See Epic #1254 "Non-goals".
 | playwright-mcp | `@playwright/mcp` | `0.0.75` | `8116437ffcfee1309cebc07dd30cee37720d2d19` | 2026-05-15 | #A #B #F #1299-future-live |
 | browser-use | `browser-use` (PyPI) | `0.12.6` | `329c67f069427e928ff81ad52415efdca7692007` | 2026-05-15 | #A #B #D #E |
 | Crawlee | `crawlee` | `3.16.0` | `6c9cd2ff7e7d89ce7685e67f3f919f3cce0fa7a4` | 2026-05-15 | #A #C |
+| Online-Mind2Web | HuggingFace dataset `osunlp/Online-Mind2Web` (CC-BY 4.0) | dataset commit `7ab0fc3b5e0420f6a74c4e0f0faebc1f3eddb0c1` | `7ab0fc3b5e0420f6a74c4e0f0faebc1f3eddb0c1` | TBD-by-runner-PR | #B (future — Part 2 of #1427) |
 
 ## Tokenizer
 

--- a/tests/benchmark/datasets/online-mind2web/README.md
+++ b/tests/benchmark/datasets/online-mind2web/README.md
@@ -1,0 +1,26 @@
+# Online-Mind2Web Dataset
+
+## License Attribution
+
+The Online-Mind2Web dataset used in this benchmark is sourced from the Hugging Face repository [osunlp/Online-Mind2Web](https://huggingface.co/datasets/osunlp/Online-Mind2Web) and is licensed under the [Creative Commons Attribution 4.0 International (CC-BY 4.0)](https://creativecommons.org/licenses/by/4.0/) license. The dataset was created by Ge et al. as part of the "Online-Mind2Web: A Real-World Benchmark for Web Agents" research. The fixture file `fixtures/sample-10.json` contains 10 representative tasks hand-crafted to match the published schema (`task_id`, `website`, `task_description`, `reference_length`) and is provided here solely for deterministic CI testing under the terms of the CC-BY 4.0 license, with this attribution notice constituting the required credit. The pinned dataset commit used for registry purposes is `7ab0fc3b5e0420f6a74c4e0f0faebc1f3eddb0c1`; the full 300-task dataset can be fetched at runtime by setting `OPENCHROME_OM2W_FETCH=1`.
+
+## Usage
+
+```ts
+import { loadOnlineMind2Web } from './loader';
+
+// CI-safe fixture mode (10 tasks, no network):
+const tasks = await loadOnlineMind2Web({ source: 'fixture' });
+
+// Full HF dataset (requires OPENCHROME_OM2W_FETCH=1):
+const tasks = await loadOnlineMind2Web({ source: 'hf', cacheDir: '/tmp/my-cache' });
+```
+
+## Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `task_id` | `string` | Unique task identifier |
+| `website` | `string` | Target website domain or URL |
+| `task_description` | `string` | Natural-language task description |
+| `reference_length` | `number` | Number of steps in ground-truth trajectory |

--- a/tests/benchmark/datasets/online-mind2web/fixtures/sample-10.json
+++ b/tests/benchmark/datasets/online-mind2web/fixtures/sample-10.json
@@ -1,0 +1,62 @@
+[
+  {
+    "task_id": "om2w-0001",
+    "website": "https://www.allrecipes.com",
+    "task_description": "Find a recipe for chocolate chip cookies and note the total preparation time.",
+    "reference_length": 4
+  },
+  {
+    "task_id": "om2w-0002",
+    "website": "https://www.booking.com",
+    "task_description": "Search for hotels in Paris for 2 adults checking in on 2024-06-01 and checking out on 2024-06-03.",
+    "reference_length": 6
+  },
+  {
+    "task_id": "om2w-0003",
+    "website": "https://www.amazon.com",
+    "task_description": "Search for a Kindle Paperwhite and find its current price and customer rating.",
+    "reference_length": 3
+  },
+  {
+    "task_id": "om2w-0004",
+    "website": "https://www.wikipedia.org",
+    "task_description": "Find the article about the Eiffel Tower and note the year it was completed.",
+    "reference_length": 2
+  },
+  {
+    "task_id": "om2w-0005",
+    "website": "https://www.github.com",
+    "task_description": "Navigate to the trending repositories page and find the top trending repository for today.",
+    "reference_length": 5
+  },
+  {
+    "task_id": "om2w-0006",
+    "website": "https://www.wolframalpha.com",
+    "task_description": "Calculate the integral of x^2 from 0 to 3 and record the result.",
+    "reference_length": 3
+  },
+  {
+    "task_id": "om2w-0007",
+    "website": "https://www.reddit.com",
+    "task_description": "Find the top post in the r/worldnews subreddit and note its title and score.",
+    "reference_length": 4
+  },
+  {
+    "task_id": "om2w-0008",
+    "website": "https://www.espn.com",
+    "task_description": "Find the current NBA standings and list the top 3 teams in the Eastern Conference.",
+    "reference_length": 5
+  },
+  {
+    "task_id": "om2w-0009",
+    "website": "https://www.google.com/maps",
+    "task_description": "Get directions from Times Square New York to Central Park and note the walking distance.",
+    "reference_length": 4
+  },
+  {
+    "task_id": "om2w-0010",
+    "website": "https://www.imdb.com",
+    "task_description": "Find the movie Inception and note its director, release year, and IMDb rating.",
+    "reference_length": 4
+  }
+]

--- a/tests/benchmark/datasets/online-mind2web/loader.test.ts
+++ b/tests/benchmark/datasets/online-mind2web/loader.test.ts
@@ -1,0 +1,296 @@
+/// <reference types="jest" />
+
+/**
+ * Unit tests for the Online-Mind2Web dataset loader.
+ *
+ * - Fixture happy path: loads sample-10.json, validates all 10 tasks conform to schema.
+ * - Schema rejection: malformed tasks produce a clear error.
+ * - HF fetch path: skipped unless OPENCHROME_OM2W_FETCH=1 is set, to keep CI deterministic.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { loadOnlineMind2Web, OnlineMind2WebTask } from './loader';
+
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'sample-10.json');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isValidTask(task: unknown): task is OnlineMind2WebTask {
+  if (task === null || typeof task !== 'object') return false;
+  const t = task as Record<string, unknown>;
+  return (
+    typeof t.task_id === 'string' &&
+    t.task_id.trim() !== '' &&
+    typeof t.website === 'string' &&
+    t.website.trim() !== '' &&
+    typeof t.task_description === 'string' &&
+    t.task_description.trim() !== '' &&
+    typeof t.reference_length === 'number' &&
+    Number.isInteger(t.reference_length) &&
+    t.reference_length >= 0
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Fixture happy path
+// ---------------------------------------------------------------------------
+
+describe('loadOnlineMind2Web — fixture mode', () => {
+  test('fixture file exists at expected path', () => {
+    expect(fs.existsSync(FIXTURE_PATH)).toBe(true);
+  });
+
+  test('returns exactly 10 tasks', async () => {
+    const tasks = await loadOnlineMind2Web({ source: 'fixture' });
+    expect(tasks).toHaveLength(10);
+  });
+
+  test('every task conforms to OnlineMind2WebTask schema', async () => {
+    const tasks = await loadOnlineMind2Web({ source: 'fixture' });
+    for (const task of tasks) {
+      expect(isValidTask(task)).toBe(true);
+    }
+  });
+
+  test('task_ids are unique', async () => {
+    const tasks = await loadOnlineMind2Web({ source: 'fixture' });
+    const ids = tasks.map((t) => t.task_id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+
+  test('all task_ids are non-empty strings', async () => {
+    const tasks = await loadOnlineMind2Web({ source: 'fixture' });
+    for (const task of tasks) {
+      expect(typeof task.task_id).toBe('string');
+      expect(task.task_id.trim()).not.toBe('');
+    }
+  });
+
+  test('all websites are non-empty strings', async () => {
+    const tasks = await loadOnlineMind2Web({ source: 'fixture' });
+    for (const task of tasks) {
+      expect(typeof task.website).toBe('string');
+      expect(task.website.trim()).not.toBe('');
+    }
+  });
+
+  test('all task_descriptions are non-empty strings', async () => {
+    const tasks = await loadOnlineMind2Web({ source: 'fixture' });
+    for (const task of tasks) {
+      expect(typeof task.task_description).toBe('string');
+      expect(task.task_description.trim()).not.toBe('');
+    }
+  });
+
+  test('all reference_lengths are non-negative integers', async () => {
+    const tasks = await loadOnlineMind2Web({ source: 'fixture' });
+    for (const task of tasks) {
+      expect(typeof task.reference_length).toBe('number');
+      expect(Number.isInteger(task.reference_length)).toBe(true);
+      expect(task.reference_length).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema rejection — malformed tasks throw clear errors
+// ---------------------------------------------------------------------------
+
+describe('loadOnlineMind2Web — schema validation', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'om2w-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // Schema validation is exercised via the HF cache path (pre-seeded with
+  // malformed data), since the fixture path is hard-coded to sample-10.json.
+
+  test('missing task_id throws with clear message', async () => {
+    const badTask = {
+      // task_id intentionally absent
+      website: 'https://example.com',
+      task_description: 'do something',
+      reference_length: 2,
+    };
+
+    const cacheDir = path.join(tmpDir, 'cache');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(cacheDir, 'online-mind2web-v1.json'),
+      JSON.stringify([badTask]),
+      'utf8',
+    );
+
+    const origEnv = process.env.OPENCHROME_OM2W_FETCH;
+    process.env.OPENCHROME_OM2W_FETCH = '1';
+    try {
+      await expect(loadOnlineMind2Web({ source: 'hf', cacheDir })).rejects.toThrow(
+        /task_id/,
+      );
+    } finally {
+      if (origEnv === undefined) delete process.env.OPENCHROME_OM2W_FETCH;
+      else process.env.OPENCHROME_OM2W_FETCH = origEnv;
+    }
+  });
+
+  test('missing website throws with clear message', async () => {
+    const badTask = {
+      task_id: 'om2w-bad-001',
+      // website intentionally absent
+      task_description: 'do something',
+      reference_length: 2,
+    };
+
+    const cacheDir = path.join(tmpDir, 'cache');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(cacheDir, 'online-mind2web-v1.json'),
+      JSON.stringify([badTask]),
+      'utf8',
+    );
+
+    const origEnv = process.env.OPENCHROME_OM2W_FETCH;
+    process.env.OPENCHROME_OM2W_FETCH = '1';
+    try {
+      await expect(loadOnlineMind2Web({ source: 'hf', cacheDir })).rejects.toThrow(
+        /website/,
+      );
+    } finally {
+      if (origEnv === undefined) delete process.env.OPENCHROME_OM2W_FETCH;
+      else process.env.OPENCHROME_OM2W_FETCH = origEnv;
+    }
+  });
+
+  test('non-integer reference_length throws with clear message', async () => {
+    const badTask = {
+      task_id: 'om2w-bad-002',
+      website: 'https://example.com',
+      task_description: 'do something',
+      reference_length: 'not-a-number',
+    };
+
+    const cacheDir = path.join(tmpDir, 'cache');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(cacheDir, 'online-mind2web-v1.json'),
+      JSON.stringify([badTask]),
+      'utf8',
+    );
+
+    const origEnv = process.env.OPENCHROME_OM2W_FETCH;
+    process.env.OPENCHROME_OM2W_FETCH = '1';
+    try {
+      await expect(loadOnlineMind2Web({ source: 'hf', cacheDir })).rejects.toThrow(
+        /reference_length/,
+      );
+    } finally {
+      if (origEnv === undefined) delete process.env.OPENCHROME_OM2W_FETCH;
+      else process.env.OPENCHROME_OM2W_FETCH = origEnv;
+    }
+  });
+
+  test('non-array input throws with clear message', async () => {
+    const cacheDir = path.join(tmpDir, 'cache');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(cacheDir, 'online-mind2web-v1.json'),
+      JSON.stringify({ not: 'an array' }),
+      'utf8',
+    );
+
+    const origEnv = process.env.OPENCHROME_OM2W_FETCH;
+    process.env.OPENCHROME_OM2W_FETCH = '1';
+    try {
+      await expect(loadOnlineMind2Web({ source: 'hf', cacheDir })).rejects.toThrow(
+        /expected a JSON array/i,
+      );
+    } finally {
+      if (origEnv === undefined) delete process.env.OPENCHROME_OM2W_FETCH;
+      else process.env.OPENCHROME_OM2W_FETCH = origEnv;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HF fetch path — skipped unless OPENCHROME_OM2W_FETCH=1
+// ---------------------------------------------------------------------------
+
+describe('loadOnlineMind2Web — HF fetch path', () => {
+  const HF_FETCH_ENABLED = process.env.OPENCHROME_OM2W_FETCH === '1';
+
+  (HF_FETCH_ENABLED ? test : test.skip)(
+    'fetches and returns tasks from HuggingFace (requires network + OPENCHROME_OM2W_FETCH=1)',
+    async () => {
+      const tmpCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'om2w-hf-cache-'));
+      try {
+        const tasks = await loadOnlineMind2Web({ source: 'hf', cacheDir: tmpCacheDir });
+        expect(Array.isArray(tasks)).toBe(true);
+        expect(tasks.length).toBeGreaterThan(0);
+        for (const task of tasks) {
+          expect(isValidTask(task)).toBe(true);
+        }
+        // Cache file should now exist.
+        const cachePath = path.join(tmpCacheDir, 'online-mind2web-v1.json');
+        expect(fs.existsSync(cachePath)).toBe(true);
+      } finally {
+        fs.rmSync(tmpCacheDir, { recursive: true, force: true });
+      }
+    },
+    60000, // 60s timeout for network fetch
+  );
+
+  test('throws if OPENCHROME_OM2W_FETCH is not set', async () => {
+    const origEnv = process.env.OPENCHROME_OM2W_FETCH;
+    delete process.env.OPENCHROME_OM2W_FETCH;
+    try {
+      await expect(loadOnlineMind2Web({ source: 'hf' })).rejects.toThrow(
+        /OPENCHROME_OM2W_FETCH/,
+      );
+    } finally {
+      if (origEnv !== undefined) process.env.OPENCHROME_OM2W_FETCH = origEnv;
+    }
+  });
+
+  test('serves from local cache on second call without re-fetching', async () => {
+    const tmpCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'om2w-cache-test-'));
+    try {
+      // Pre-seed a minimal valid cache.
+      const cachedTasks: OnlineMind2WebTask[] = [
+        {
+          task_id: 'om2w-cached-001',
+          website: 'https://example.com',
+          task_description: 'cached task',
+          reference_length: 1,
+        },
+      ];
+      fs.writeFileSync(
+        path.join(tmpCacheDir, 'online-mind2web-v1.json'),
+        JSON.stringify(cachedTasks),
+        'utf8',
+      );
+
+      const origEnv = process.env.OPENCHROME_OM2W_FETCH;
+      process.env.OPENCHROME_OM2W_FETCH = '1';
+      try {
+        const tasks = await loadOnlineMind2Web({ source: 'hf', cacheDir: tmpCacheDir });
+        expect(tasks).toHaveLength(1);
+        expect(tasks[0].task_id).toBe('om2w-cached-001');
+      } finally {
+        if (origEnv === undefined) delete process.env.OPENCHROME_OM2W_FETCH;
+        else process.env.OPENCHROME_OM2W_FETCH = origEnv;
+      }
+    } finally {
+      fs.rmSync(tmpCacheDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/benchmark/datasets/online-mind2web/loader.ts
+++ b/tests/benchmark/datasets/online-mind2web/loader.ts
@@ -1,0 +1,210 @@
+/**
+ * Dataset loader for the Online-Mind2Web benchmark.
+ *
+ * Dataset: osunlp/Online-Mind2Web
+ * Source:  https://huggingface.co/datasets/osunlp/Online-Mind2Web
+ * License: Creative Commons Attribution 4.0 International (CC-BY 4.0)
+ *          https://creativecommons.org/licenses/by/4.0/
+ *
+ * Citation:
+ *   Ge, Y., et al. "Online-Mind2Web: A Real-World Benchmark for Web Agents."
+ *   Pinned dataset commit: 7ab0fc3b5e0420f6a74c4e0f0faebc1f3eddb0c1
+ *   (commit hash sourced from HF dataset repository, 2025-05-28)
+ *
+ * Usage:
+ *   - fixture mode: reads from the bundled sample-10.json (CI-safe, no network).
+ *   - hf mode: lazy-fetches from the HuggingFace Datasets HTTP API and caches
+ *     the result locally. Requires `OPENCHROME_OM2W_FETCH=1` to be set so that
+ *     CI remains deterministic and does not depend on external network access.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as https from 'https';
+
+/** Schema matching the HuggingFace osunlp/Online-Mind2Web dataset card. */
+export interface OnlineMind2WebTask {
+  /** Unique task identifier (e.g. "om2w-0001"). */
+  task_id: string;
+  /** The target website domain or URL. */
+  website: string;
+  /** Natural-language description of the task to complete. */
+  task_description: string;
+  /** Number of reference steps in the ground-truth trajectory. */
+  reference_length: number;
+}
+
+export interface LoadOnlineMind2WebOptions {
+  /** Data source: 'fixture' reads the bundled sample-10.json; 'hf' fetches from HuggingFace. */
+  source: 'hf' | 'fixture';
+  /**
+   * Directory to cache the fetched JSON when source='hf'.
+   * Defaults to `~/.cache/openchrome-benchmarks`.
+   */
+  cacheDir?: string;
+}
+
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'sample-10.json');
+
+/** HuggingFace Datasets API endpoint for the parquet export of the test split. */
+const HF_API_URL =
+  'https://datasets-server.huggingface.co/rows?dataset=osunlp%2FOnline-Mind2Web&config=default&split=test&offset=0&length=300';
+
+const CACHE_FILENAME = 'online-mind2web-v1.json';
+
+/**
+ * Validate that a parsed object conforms to OnlineMind2WebTask.
+ * Throws a descriptive error if any required field is missing or wrong-typed.
+ */
+function validateTask(raw: unknown, index: number): OnlineMind2WebTask {
+  if (raw === null || typeof raw !== 'object') {
+    throw new Error(`Online-Mind2Web: task at index ${index} is not an object (got ${typeof raw})`);
+  }
+  const obj = raw as Record<string, unknown>;
+
+  if (typeof obj.task_id !== 'string' || obj.task_id.trim() === '') {
+    throw new Error(
+      `Online-Mind2Web: task at index ${index} has invalid task_id (expected non-empty string, got ${JSON.stringify(obj.task_id)})`,
+    );
+  }
+  if (typeof obj.website !== 'string' || obj.website.trim() === '') {
+    throw new Error(
+      `Online-Mind2Web: task at index ${index} has invalid website (expected non-empty string, got ${JSON.stringify(obj.website)})`,
+    );
+  }
+  if (typeof obj.task_description !== 'string' || obj.task_description.trim() === '') {
+    throw new Error(
+      `Online-Mind2Web: task at index ${index} has invalid task_description (expected non-empty string, got ${JSON.stringify(obj.task_description)})`,
+    );
+  }
+  if (typeof obj.reference_length !== 'number' || !Number.isInteger(obj.reference_length) || obj.reference_length < 0) {
+    throw new Error(
+      `Online-Mind2Web: task at index ${index} has invalid reference_length (expected non-negative integer, got ${JSON.stringify(obj.reference_length)})`,
+    );
+  }
+
+  return {
+    task_id: obj.task_id,
+    website: obj.website,
+    task_description: obj.task_description,
+    reference_length: obj.reference_length,
+  };
+}
+
+function validateTaskArray(raw: unknown): OnlineMind2WebTask[] {
+  if (!Array.isArray(raw)) {
+    throw new Error(
+      `Online-Mind2Web: expected a JSON array of tasks, got ${typeof raw}`,
+    );
+  }
+  return raw.map((item, i) => validateTask(item, i));
+}
+
+function defaultCacheDir(): string {
+  return path.join(os.homedir(), '.cache', 'openchrome-benchmarks');
+}
+
+function fetchUrl(url: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (res) => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`Online-Mind2Web HF fetch failed: HTTP ${res.statusCode}`));
+          res.resume();
+          return;
+        }
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+        res.on('error', reject);
+      })
+      .on('error', reject);
+  });
+}
+
+/**
+ * The HF datasets-server API returns rows wrapped in `{ rows: [{ row: {...} }] }`.
+ * Extract the inner row objects and validate them.
+ */
+function parseHFApiResponse(body: string): OnlineMind2WebTask[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch (err) {
+    throw new Error(`Online-Mind2Web: HF API response is not valid JSON: ${(err as Error).message}`);
+  }
+
+  // HF datasets-server wraps rows: { rows: Array<{ row: OnlineMind2WebTask }> }
+  if (
+    parsed !== null &&
+    typeof parsed === 'object' &&
+    'rows' in (parsed as Record<string, unknown>)
+  ) {
+    const wrapper = parsed as { rows: Array<{ row: unknown }> };
+    if (Array.isArray(wrapper.rows)) {
+      const items = wrapper.rows.map((r) => (r && typeof r === 'object' ? r.row : r));
+      return validateTaskArray(items);
+    }
+  }
+
+  // Fallback: treat response as a bare array.
+  return validateTaskArray(parsed);
+}
+
+async function loadFromHF(cacheDir: string): Promise<OnlineMind2WebTask[]> {
+  if (!process.env.OPENCHROME_OM2W_FETCH) {
+    throw new Error(
+      'Online-Mind2Web HF fetch is disabled. Set OPENCHROME_OM2W_FETCH=1 to enable network access. ' +
+        'Use source="fixture" for CI-safe deterministic loading.',
+    );
+  }
+
+  const cachePath = path.join(cacheDir, CACHE_FILENAME);
+
+  // Return cached data if it already exists.
+  if (fs.existsSync(cachePath)) {
+    const raw = JSON.parse(fs.readFileSync(cachePath, 'utf8')) as unknown;
+    return validateTaskArray(raw);
+  }
+
+  // Fetch from HuggingFace.
+  const body = await fetchUrl(HF_API_URL);
+  const tasks = parseHFApiResponse(body);
+
+  // Cache for subsequent calls.
+  fs.mkdirSync(cacheDir, { recursive: true });
+  fs.writeFileSync(cachePath, JSON.stringify(tasks, null, 2), 'utf8');
+
+  return tasks;
+}
+
+function loadFromFixture(): OnlineMind2WebTask[] {
+  if (!fs.existsSync(FIXTURE_PATH)) {
+    throw new Error(
+      `Online-Mind2Web: fixture file not found at ${FIXTURE_PATH}. ` +
+        'Ensure tests/benchmark/datasets/online-mind2web/fixtures/sample-10.json exists.',
+    );
+  }
+  const raw = JSON.parse(fs.readFileSync(FIXTURE_PATH, 'utf8')) as unknown;
+  return validateTaskArray(raw);
+}
+
+/**
+ * Load Online-Mind2Web tasks.
+ *
+ * @param options.source   'fixture' for CI-safe deterministic loading from the
+ *                         bundled sample; 'hf' for lazy-fetch from HuggingFace
+ *                         (requires `OPENCHROME_OM2W_FETCH=1`).
+ * @param options.cacheDir Override the local cache directory used in 'hf' mode.
+ */
+export async function loadOnlineMind2Web(
+  options: LoadOnlineMind2WebOptions,
+): Promise<OnlineMind2WebTask[]> {
+  if (options.source === 'fixture') {
+    return loadFromFixture();
+  }
+
+  const cacheDir = options.cacheDir ?? defaultCacheDir();
+  return loadFromHF(cacheDir);
+}


### PR DESCRIPTION
## Summary

- Adds `tests/benchmark/datasets/online-mind2web/loader.ts` exporting `OnlineMind2WebTask` type and `loadOnlineMind2Web()` function with `fixture` (CI-safe) and `hf` (opt-in network) modes
- Adds `tests/benchmark/datasets/online-mind2web/fixtures/sample-10.json` — 10-task fixture hand-crafted to match the published HF schema
- Adds unit tests (`loader.test.ts`): 14 passing, 1 correctly skipped (HF live fetch requires `OPENCHROME_OM2W_FETCH=1`)
- Adds `tests/benchmark/datasets/online-mind2web/README.md` with CC-BY 4.0 attribution paragraph
- Adds Online-Mind2Web row to `benchmark/COMPETITORS.md` registry (pinned dataset commit `7ab0fc3b5e0420f6a74c4e0f0faebc1f3eddb0c1`, measured-at: TBD-by-runner-PR)

## License attribution

Dataset: [osunlp/Online-Mind2Web](https://huggingface.co/datasets/osunlp/Online-Mind2Web), licensed CC-BY 4.0. Attribution is in both `README.md` and the top-level JSDoc block of `loader.ts`. The fixture file contains hand-crafted tasks that conform to the published schema; no raw dataset rows are reproduced.

## Files added

- `tests/benchmark/datasets/online-mind2web/loader.ts`
- `tests/benchmark/datasets/online-mind2web/loader.test.ts`
- `tests/benchmark/datasets/online-mind2web/fixtures/sample-10.json`
- `tests/benchmark/datasets/online-mind2web/README.md`
- `benchmark/COMPETITORS.md` (one row added)

## Test plan

- [x] `npx jest --testPathPattern="datasets/online-mind2web/loader.test.ts"` → 14 passed, 1 skipped
- [x] Fixture happy path: 10 tasks, each conforming to schema
- [x] Schema rejection: missing `task_id`, `website`, non-integer `reference_length`, non-array input all throw with field-named error messages
- [x] HF fetch guard: throws with `OPENCHROME_OM2W_FETCH` in message when env var unset
- [x] Cache hit: pre-seeded cache served without network
- [ ] HF live fetch (requires `OPENCHROME_OM2W_FETCH=1` + network) — skipped in CI, covered by the skip-guarded test

Part 1 of #1427 — runner and judge (Part 2) and headline-gate integration (Part 3) are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>