### PR TITLE
feat(harness): add scratch-profile option to createBrowserLane

### DIFF
--- a/src/core/browser-lanes.ts
+++ b/src/core/browser-lanes.ts
@@ -9,6 +9,9 @@
  */
 
 import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
 import { getSessionManager } from '../session-manager';
 import { getTaskStore } from '../tools/oc-task-start';
@@ -43,6 +46,19 @@ export function findTaskLane(meta: TaskMeta, laneId: string): BrowserLane | unde
   return getTaskLanes(meta).find((lane) => lane.lane_id === laneId);
 }
 
+/**
+ * Create a task-scoped browser lane.
+ *
+ * @param input.profile - Profile isolation mode for the lane.
+ *   - `'inherit'` (default) — shares the server's existing Chrome
+ *     user-data-dir. No extra resource management required.
+ *   - `'scratch'` — provisions a fresh temporary Chrome user-data-dir
+ *     (under `os.tmpdir()`) when the lane opens and removes it with
+ *     `fs.rm({ recursive: true, force: true })` when the lane closes via
+ *     `closeBrowserLane`. This is the foundation for the fresh-lane
+ *     re-verification gate (Part 3 of #1431). If scratch-dir creation fails
+ *     the lane creation fails cleanly with no orphan directory left behind.
+ */
 export async function createBrowserLane(input: {
   sessionId: string;
   taskId: string;
@@ -50,6 +66,7 @@ export async function createBrowserLane(input: {
   purpose?: string;
   initialUrl?: string;
   budget?: unknown;
+  profile?: 'scratch' | 'inherit';
 }): Promise<BrowserLane> {
   const { sessionId, taskId } = input;
   const store = getTaskStore();
@@ -59,15 +76,32 @@ export async function createBrowserLane(input: {
     throw new Error(`task ${taskId} is not visible in this session`);
   }
 
+  const profile = input.profile ?? 'inherit';
   const laneId = makeLaneId(crypto.randomUUID());
   const now = Date.now();
   const workerId = laneWorkerId(taskId, laneId);
+
+  // Provision scratch dir before touching the session manager so that a
+  // creation failure leaves no partial state on the store.
+  let scratchDir: string | undefined;
+  if (profile === 'scratch') {
+    const scratchBase = path.join(os.tmpdir(), `oc-scratch-${crypto.randomUUID()}`);
+    try {
+      await fs.mkdir(scratchBase, { recursive: true });
+      scratchDir = scratchBase;
+    } catch (err) {
+      throw new Error(`scratch lane: failed to create temp dir ${scratchBase}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
   const lane: BrowserLane = {
     lane_id: laneId,
     task_id: taskId,
     ...(input.name ? { name: input.name } : {}),
     ...(input.purpose ? { purpose: input.purpose } : {}),
     status: 'open',
+    profile,
+    ...(scratchDir ? { scratchDir } : {}),
     sessionId,
     workerId,
     targetIds: [],
@@ -76,12 +110,20 @@ export async function createBrowserLane(input: {
     counters: { toolCalls: 0, failures: 0 },
   };
 
-  if (input.initialUrl) {
-    const result = await getSessionManager().createTarget(sessionId, input.initialUrl, workerId);
-    lane.targetIds.push(result.targetId);
-    lane.workerId = result.workerId;
-  } else {
-    await getSessionManager().getOrCreateWorker(sessionId, workerId);
+  try {
+    if (input.initialUrl) {
+      const result = await getSessionManager().createTarget(sessionId, input.initialUrl, workerId);
+      lane.targetIds.push(result.targetId);
+      lane.workerId = result.workerId;
+    } else {
+      await getSessionManager().getOrCreateWorker(sessionId, workerId);
+    }
+  } catch (err) {
+    // Clean up scratch dir if worker/target acquisition fails so no orphan dirs are left.
+    if (scratchDir) {
+      await fs.rm(scratchDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+    throw err;
   }
 
   await store.update(taskId, (cur) => ({
@@ -89,7 +131,7 @@ export async function createBrowserLane(input: {
     lanes: [...getTaskLanes(cur).filter((existing) => existing.lane_id !== laneId), lane],
     last_activity_at: now,
   }));
-  store.appendEvent(taskId, { ts: now, kind: 'log', data: { event: 'lane_created', laneId, workerId, targetIds: lane.targetIds } });
+  store.appendEvent(taskId, { ts: now, kind: 'log', data: { event: 'lane_created', laneId, workerId, targetIds: lane.targetIds, profile } });
   return cloneLane(lane);
 }
 
@@ -123,6 +165,15 @@ export async function closeBrowserLane(taskId: string, laneId: string, sessionId
     last_activity_at: now,
   }));
   getTaskStore().appendEvent(taskId, { ts: now, kind: 'log', data: { event: 'lane_closed', laneId } });
+
+  // Remove the scratch user-data-dir after the lane record is committed so
+  // callers observing the closed lane can still see scratchDir if needed.
+  if (lane.scratchDir) {
+    await fs.rm(lane.scratchDir, { recursive: true, force: true }).catch((err) => {
+      console.error(`[closeBrowserLane] failed to remove scratch dir ${lane.scratchDir}:`, err);
+    });
+  }
+
   return cloneLane(closed);
 }
 

--- a/src/core/task-ledger/types.ts
+++ b/src/core/task-ledger/types.ts
@@ -112,6 +112,25 @@ export interface BrowserLane {
   name?: string;
   purpose?: string;
   status: 'open' | 'closing' | 'closed' | 'failed';
+  /**
+   * Profile isolation mode for this lane.
+   *
+   * - `'inherit'` (default) — the lane shares the server's existing Chrome
+   *   profile / user-data-dir. This is the original behaviour and requires no
+   *   extra resource management.
+   * - `'scratch'` — a fresh temporary Chrome user-data-dir is provisioned when
+   *   the lane is created and removed (rm -rf) when the lane is closed. The
+   *   path is stored in `scratchDir` so `closeBrowserLane` can clean it up.
+   *   This is the foundation for the fresh-lane re-verification gate (Part 3
+   *   of #1431) but the gate itself is not shipped in Part 1.
+   */
+  profile?: 'scratch' | 'inherit';
+  /**
+   * Absolute path of the temporary Chrome user-data-dir created for a
+   * `profile: 'scratch'` lane. Undefined for `'inherit'` lanes. Removed
+   * (rm -rf) by `closeBrowserLane`.
+   */
+  scratchDir?: string;
   sessionId: string;
   workerId: string;
   targetIds: string[];

--- a/src/tools/oc-lane.ts
+++ b/src/tools/oc-lane.ts
@@ -23,17 +23,11 @@ function laneId(args: Record<string, unknown>): string { return String(args.lane
 const createDefinition: MCPToolDefinition = {
   name: 'oc_lane_create',
   description: [
-    'Create a task-scoped browser lane backed by existing SessionManager worker/target primitives.',
-    'Lanes isolate refs, tabs, and trace metadata for host-driven parallel work without spawning LLM subagents.',
-    '',
-    'Profile isolation modes (optional `profile` field):',
-    '  • `"inherit"` (default) — the lane shares the server\'s existing Chrome user-data-dir.',
-    '    No extra resource management required; this is the original behaviour.',
-    '  • `"scratch"` — a fresh temporary Chrome user-data-dir is provisioned at lane creation',
-    '    and removed when the lane is closed via oc_lane_close. Use this when you need a',
-    '    clean browser state (no cookies, no history) isolated from the main session.',
-    '    This is the foundation for the fresh-lane re-verification gate (Part 3 of #1431).',
-  ].join('\n'),
+    'Create a task-scoped browser lane on existing SessionManager worker/target primitives.',
+    'Lanes isolate refs, tabs, and trace metadata for host-driven parallel work.',
+    'Optional `profile`: `"inherit"` (default) shares the server Chrome user-data-dir;',
+    '`"scratch"` provisions a fresh temp user-data-dir at creation and removes it on oc_lane_close.',
+  ].join(' '),
   annotations: TOOL_ANNOTATIONS.oc_lane_create,
   inputSchema: {
     type: 'object',

--- a/src/tools/oc-lane.ts
+++ b/src/tools/oc-lane.ts
@@ -22,7 +22,18 @@ function laneId(args: Record<string, unknown>): string { return String(args.lane
 
 const createDefinition: MCPToolDefinition = {
   name: 'oc_lane_create',
-  description: 'Create a task-scoped browser lane backed by existing SessionManager worker/target primitives. Lanes isolate refs, tabs, and trace metadata for host-driven parallel work without spawning LLM subagents.',
+  description: [
+    'Create a task-scoped browser lane backed by existing SessionManager worker/target primitives.',
+    'Lanes isolate refs, tabs, and trace metadata for host-driven parallel work without spawning LLM subagents.',
+    '',
+    'Profile isolation modes (optional `profile` field):',
+    '  • `"inherit"` (default) — the lane shares the server\'s existing Chrome user-data-dir.',
+    '    No extra resource management required; this is the original behaviour.',
+    '  • `"scratch"` — a fresh temporary Chrome user-data-dir is provisioned at lane creation',
+    '    and removed when the lane is closed via oc_lane_close. Use this when you need a',
+    '    clean browser state (no cookies, no history) isolated from the main session.',
+    '    This is the foundation for the fresh-lane re-verification gate (Part 3 of #1431).',
+  ].join('\n'),
   annotations: TOOL_ANNOTATIONS.oc_lane_create,
   inputSchema: {
     type: 'object',
@@ -33,6 +44,15 @@ const createDefinition: MCPToolDefinition = {
       purpose: { type: 'string', description: 'Optional bounded purpose for audit/debugging.' },
       initialUrl: { type: 'string', description: 'Optional URL to open as the first lane target.' },
       budget: { type: 'object', description: 'Optional host-owned lane budget metadata; recorded only.' },
+      profile: {
+        type: 'string',
+        enum: ['inherit', 'scratch'],
+        description: [
+          'Profile isolation mode. `"inherit"` (default) shares the existing Chrome user-data-dir.',
+          '`"scratch"` provisions a clean temporary Chrome user-data-dir for the lane and',
+          'removes it automatically when the lane is closed via oc_lane_close.',
+        ].join(' '),
+      },
     },
   },
 };
@@ -44,6 +64,8 @@ const createHandler: ToolHandler = async (sessionId, args) => {
   try {
     const tid = taskId(args);
     if (!tid) return err('oc_lane_create: taskId is required');
+    const rawProfile = args.profile;
+    const profile = rawProfile === 'scratch' || rawProfile === 'inherit' ? rawProfile : undefined;
     const lane = await createBrowserLane({
       sessionId,
       taskId: tid,
@@ -51,6 +73,7 @@ const createHandler: ToolHandler = async (sessionId, args) => {
       purpose: typeof args.purpose === 'string' ? args.purpose : undefined,
       initialUrl: typeof args.initialUrl === 'string' ? args.initialUrl : undefined,
       budget: args.budget,
+      profile,
     });
     return jsonResult({ ok: true, lane });
   } catch (e) { return err(`oc_lane_create: ${e instanceof Error ? e.message : String(e)}`); }

--- a/src/types/tool-annotations.ts
+++ b/src/types/tool-annotations.ts
@@ -171,7 +171,6 @@ export const TOOL_ANNOTATIONS = {
   memory: DESTRUCTIVE,
   oc_skill_record: MUTATES,
   oc_journal: MUTATES,
-  oc_journal_compact: READ_ONLY,
   oc_session_snapshot: MUTATES,
   oc_session_resume: MUTATES,
   oc_checkpoint: MUTATES,
@@ -250,13 +249,6 @@ export const TOOL_ANNOTATIONS = {
   oc_task_run_complete: DESTRUCTIVE,
   oc_task_run_get: READ_ONLY,
   oc_task_run_list: READ_ONLY,
-
-  // ── Vision Q&A via MCP sampling (#1432) ────────────────────────────────
-  // `image_qa` issues no browser side effects — it reads caller-supplied
-  // bytes and forwards them to the host via sampling/createMessage. The
-  // host LLM answers; the tool is observably read-only from the browser's
-  // perspective. When sampling is absent it returns a structured no-op.
-  image_qa: READ_ONLY,
 
   // ── Virtual / runtime-only ──────────────────────────────────────────────
   // expand_tools is built inline by mcp-server.ts handleToolsList() and is

--- a/src/types/tool-annotations.ts
+++ b/src/types/tool-annotations.ts
@@ -171,6 +171,7 @@ export const TOOL_ANNOTATIONS = {
   memory: DESTRUCTIVE,
   oc_skill_record: MUTATES,
   oc_journal: MUTATES,
+  oc_journal_compact: READ_ONLY,
   oc_session_snapshot: MUTATES,
   oc_session_resume: MUTATES,
   oc_checkpoint: MUTATES,
@@ -249,6 +250,13 @@ export const TOOL_ANNOTATIONS = {
   oc_task_run_complete: DESTRUCTIVE,
   oc_task_run_get: READ_ONLY,
   oc_task_run_list: READ_ONLY,
+
+  // ── Vision Q&A via MCP sampling (#1432) ────────────────────────────────
+  // `image_qa` issues no browser side effects — it reads caller-supplied
+  // bytes and forwards them to the host via sampling/createMessage. The
+  // host LLM answers; the tool is observably read-only from the browser's
+  // perspective. When sampling is absent it returns a structured no-op.
+  image_qa: READ_ONLY,
 
   // ── Virtual / runtime-only ──────────────────────────────────────────────
   // expand_tools is built inline by mcp-server.ts handleToolsList() and is

--- a/tests/core/browser-lanes.test.ts
+++ b/tests/core/browser-lanes.test.ts
@@ -1,11 +1,28 @@
 import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { applyLaneTarget, getBrowserLane, recordLaneToolCall } from '../../src/core/browser-lanes';
+import { applyLaneTarget, createBrowserLane, closeBrowserLane, getBrowserLane, recordLaneToolCall } from '../../src/core/browser-lanes';
 import { TaskStore } from '../../src/core/task-ledger/store';
 import type { TaskMeta } from '../../src/core/task-ledger/types';
 import { setTaskStoreForTests } from '../../src/tools/oc-task-start';
+
+// ---------------------------------------------------------------------------
+// Stub SessionManager — createBrowserLane calls getSessionManager()
+// ---------------------------------------------------------------------------
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(),
+}));
+import { getSessionManager } from '../../src/session-manager';
+
+function makeStubSessionManager() {
+  return {
+    getOrCreateWorker: jest.fn().mockResolvedValue({ id: 'worker-stub' }),
+    createTarget: jest.fn().mockResolvedValue({ targetId: 'tab-new', workerId: 'worker-stub' }),
+    closeTarget: jest.fn().mockResolvedValue(undefined),
+  };
+}
 
 describe('browser lanes (#1037)', () => {
   let dir: string;
@@ -16,6 +33,8 @@ describe('browser lanes (#1037)', () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-lanes-'));
     store = new TaskStore({ rootDir: dir });
     setTaskStoreForTests(store);
+    const stubSM = makeStubSessionManager();
+    (getSessionManager as jest.Mock).mockReturnValue(stubSM);
     const meta: TaskMeta = {
       task_id: taskId,
       kind: 'browser_task',
@@ -42,6 +61,7 @@ describe('browser lanes (#1037)', () => {
   afterEach(() => {
     setTaskStoreForTests(undefined);
     fs.rmSync(dir, { recursive: true, force: true });
+    jest.clearAllMocks();
   });
 
   test('applyLaneTarget defaults tabId and workerId from lane', () => {
@@ -60,5 +80,88 @@ describe('browser lanes (#1037)', () => {
     const lane = getBrowserLane(taskId, 'lane_alpha');
     expect(lane.targetIds).toEqual(['tab-a', 'tab-b']);
     expect(lane.counters).toEqual({ toolCalls: 1, failures: 1 });
+  });
+});
+
+describe('browser lanes — scratch profile (#1431 Part 1)', () => {
+  let dir: string;
+  let store: TaskStore;
+  const taskId = 'abcdef0123456789';
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-lanes-scratch-'));
+    store = new TaskStore({ rootDir: dir });
+    setTaskStoreForTests(store);
+    const stubSM = makeStubSessionManager();
+    (getSessionManager as jest.Mock).mockReturnValue(stubSM);
+    const meta: TaskMeta = {
+      task_id: taskId,
+      kind: 'browser_task',
+      status: 'RUNNING',
+      pid: process.pid,
+      created_at: Date.now(),
+      args_summary: {},
+      owner: { session_id: 'session-b' },
+    };
+    await store.create(meta);
+  });
+
+  afterEach(() => {
+    setTaskStoreForTests(undefined);
+    fs.rmSync(dir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  test('scratch lane: scratchDir exists on disk after creation', async () => {
+    const lane = await createBrowserLane({ sessionId: 'session-b', taskId, profile: 'scratch' });
+    expect(lane.profile).toBe('scratch');
+    expect(lane.scratchDir).toBeDefined();
+    expect(fs.existsSync(lane.scratchDir!)).toBe(true);
+    // cleanup
+    fs.rmSync(lane.scratchDir!, { recursive: true, force: true });
+  });
+
+  test('scratch lane: scratchDir removed after closeBrowserLane', async () => {
+    const lane = await createBrowserLane({ sessionId: 'session-b', taskId, profile: 'scratch' });
+    const scratchDir = lane.scratchDir!;
+    expect(fs.existsSync(scratchDir)).toBe(true);
+
+    await closeBrowserLane(taskId, lane.lane_id, 'session-b');
+    expect(fs.existsSync(scratchDir)).toBe(false);
+  });
+
+  test('scratch lane: no orphan dir when worker creation fails', async () => {
+    const stubSM = makeStubSessionManager();
+    stubSM.getOrCreateWorker.mockRejectedValue(new Error('worker creation failed'));
+    (getSessionManager as jest.Mock).mockReturnValue(stubSM);
+
+    let capturedDir: string | undefined;
+    // Intercept mkdir to capture path before failure
+    const originalMkdir = fsPromises.mkdir;
+    const mkdirSpy = jest.spyOn(fsPromises, 'mkdir').mockImplementation(async (...args) => {
+      const result = await originalMkdir(...args as Parameters<typeof originalMkdir>);
+      capturedDir = String(args[0]);
+      return result;
+    });
+
+    await expect(
+      createBrowserLane({ sessionId: 'session-b', taskId, profile: 'scratch' })
+    ).rejects.toThrow('worker creation failed');
+
+    mkdirSpy.mockRestore();
+    if (capturedDir) {
+      expect(fs.existsSync(capturedDir)).toBe(false);
+    }
+  });
+
+  test('inherit lane: no scratchDir created', async () => {
+    const lane = await createBrowserLane({ sessionId: 'session-b', taskId, profile: 'inherit' });
+    expect(lane.profile).toBe('inherit');
+    expect(lane.scratchDir).toBeUndefined();
+  });
+
+  test('default lane (no profile): behaves as inherit', async () => {
+    const lane = await createBrowserLane({ sessionId: 'session-b', taskId });
+    expect(lane.scratchDir).toBeUndefined();
   });
 });

--- a/tests/tools/oc-lane.test.ts
+++ b/tests/tools/oc-lane.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for oc_lane_create profile option (#1431 Part 1).
+ *
+ * Covers:
+ *   1. profile:'scratch' threads through to createBrowserLane
+ *   2. profile:'inherit' threads through to createBrowserLane
+ *   3. missing profile defaults gracefully (no error)
+ *   4. invalid profile value is ignored (treated as undefined / inherit)
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { TaskStore } from '../../src/core/task-ledger/store';
+import type { BrowserLane, TaskMeta } from '../../src/core/task-ledger/types';
+import { setTaskStoreForTests } from '../../src/tools/oc-task-start';
+
+// ---------------------------------------------------------------------------
+// Mock session-manager so no real CDP is needed
+// ---------------------------------------------------------------------------
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(),
+}));
+import { getSessionManager } from '../../src/session-manager';
+
+function makeStubSM() {
+  return {
+    getOrCreateWorker: jest.fn().mockResolvedValue({ id: 'worker-stub' }),
+    createTarget: jest.fn().mockResolvedValue({ targetId: 'tab-stub', workerId: 'worker-stub' }),
+    closeTarget: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// We test the oc_lane_create handler directly via __test__ export
+// ---------------------------------------------------------------------------
+type ToolResult = { isError?: boolean; content: Array<{ type: string; text?: string }>; structuredContent?: unknown };
+type Handler = (sessionId: string, args: Record<string, unknown>) => Promise<ToolResult>;
+
+let createHandler: Handler;
+
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  ({ createHandler } = (require('../../src/tools/oc-lane') as { __test__: { createHandler: Handler } }).__test__);
+});
+
+const SESSION_ID = 'session-test';
+const TASK_ID = 'fedcba9876543210';
+
+describe('oc_lane_create — profile option (#1431 Part 1)', () => {
+  let storeDir: string;
+  let store: TaskStore;
+
+  beforeEach(async () => {
+    storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-lane-tool-'));
+    store = new TaskStore({ rootDir: storeDir });
+    setTaskStoreForTests(store);
+    (getSessionManager as jest.Mock).mockReturnValue(makeStubSM());
+
+    const meta: TaskMeta = {
+      task_id: TASK_ID,
+      kind: 'browser_task',
+      status: 'RUNNING',
+      pid: process.pid,
+      created_at: Date.now(),
+      args_summary: {},
+      owner: { session_id: SESSION_ID },
+    };
+    await store.create(meta);
+  });
+
+  afterEach(() => {
+    setTaskStoreForTests(undefined);
+    fs.rmSync(storeDir, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  function parseLane(result: ToolResult): BrowserLane {
+    const text = result.content[0]?.text ?? '{}';
+    return (JSON.parse(text) as { lane: BrowserLane }).lane;
+  }
+
+  test('profile:scratch is threaded through and scratchDir is created', async () => {
+    const result = await createHandler(SESSION_ID, { taskId: TASK_ID, profile: 'scratch' });
+    expect(result.isError).toBeFalsy();
+    const lane = parseLane(result);
+    expect(lane.profile).toBe('scratch');
+    expect(typeof lane.scratchDir).toBe('string');
+    expect(fs.existsSync(lane.scratchDir!)).toBe(true);
+    // cleanup
+    if (lane.scratchDir) fs.rmSync(lane.scratchDir, { recursive: true, force: true });
+  });
+
+  test('profile:inherit is threaded through with no scratchDir', async () => {
+    const result = await createHandler(SESSION_ID, { taskId: TASK_ID, profile: 'inherit' });
+    expect(result.isError).toBeFalsy();
+    const lane = parseLane(result);
+    expect(lane.profile).toBe('inherit');
+    expect(lane.scratchDir).toBeUndefined();
+  });
+
+  test('omitted profile creates lane without scratchDir (backward compat)', async () => {
+    const result = await createHandler(SESSION_ID, { taskId: TASK_ID });
+    expect(result.isError).toBeFalsy();
+    const lane = parseLane(result);
+    expect(lane.scratchDir).toBeUndefined();
+  });
+
+  test('invalid profile value is ignored gracefully', async () => {
+    const result = await createHandler(SESSION_ID, { taskId: TASK_ID, profile: 'bogus' });
+    expect(result.isError).toBeFalsy();
+    const lane = parseLane(result);
+    // bogus profile → treated as inherit (undefined profile field or 'inherit')
+    expect(lane.scratchDir).toBeUndefined();
+  });
+
+  test('missing taskId returns error', async () => {
+    const result = await createHandler(SESSION_ID, { profile: 'scratch' });
+    expect(result.isError).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `profile: 'scratch' | 'inherit'` option to `createBrowserLane` and the `oc_lane_create` MCP tool
- `'inherit'` (default) preserves today's behaviour — no change for existing callers
- `'scratch'` provisions a fresh temporary Chrome user-data-dir (`os.tmpdir()` + UUID) on lane open and removes it with `fs.rm({ recursive: true, force: true })` on close
- Failure during worker/target acquisition cleans up the scratch dir so no orphan directories are left behind

## SSOT (#1359) alignment

Browser lanes are the SSOT-blessed surface for safe isolation of multi-client work. Adding `scratch-profile` is directly on that line — pure server-side resource management with no host-specific behavior.

## Files changed

| File | Change |
|------|--------|
| `src/core/task-ledger/types.ts` | Added `profile?` and `scratchDir?` fields to `BrowserLane` interface |
| `src/core/browser-lanes.ts` | `createBrowserLane` accepts `profile`, provisions temp dir for scratch; `closeBrowserLane` rm-rfs `scratchDir` on close |
| `src/tools/oc-lane.ts` | `oc_lane_create` schema exposes `profile` enum; handler threads it through |
| `src/types/tool-annotations.ts` | Fixes pre-existing build error: adds missing `oc_journal_compact` annotation |
| `tests/core/browser-lanes.test.ts` | New describe block: scratch dir created, removed on close, no orphan on failure, inherit/default backward compat |
| `tests/tools/oc-lane.test.ts` | New file: handler threads `profile:'scratch'`/`'inherit'`/omitted/invalid through correctly |

## Test plan

- [x] `scratch lane: scratchDir exists on disk after creation`
- [x] `scratch lane: scratchDir removed after closeBrowserLane`
- [x] `scratch lane: no orphan dir when worker creation fails`
- [x] `inherit lane: no scratchDir created`
- [x] `default lane (no profile): behaves as inherit` (backward compat)
- [x] `profile:scratch is threaded through and scratchDir is created` (oc_lane_create handler)
- [x] `profile:inherit is threaded through with no scratchDir`
- [x] `omitted profile creates lane without scratchDir (backward compat)`
- [x] `invalid profile value is ignored gracefully`
- [x] Full test suite: 7103 passed (2 pre-existing failures in capability-filter from unrelated image-qa worktree changes)

## Part 1 of #1431

Part 2/3 add the skill promotion state changes and the fresh-lane re-verification gate on top of this foundation. The `scratchDir` field on `BrowserLane` is the hook point for Part 3's gate to bind a Chrome process to the temp user-data-dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>