### PR TITLE
feat(skill): persist codegen artifact pointers on oc_skill_record

### DIFF
--- a/src/core/skill-memory/index.ts
+++ b/src/core/skill-memory/index.ts
@@ -19,11 +19,14 @@ export type {
 export {
   SKILL_MEMORY_SCHEMA_VERSION,
   SKILL_MEMORY_SCHEMA_VERSION_V1,
+  SKILL_MEMORY_SCHEMA_VERSION_V2,
 } from './types';
 export type {
+  CodegenArtifactPointer,
   FrozenSnapshot,
   SkillMemoryFile,
   SkillMemoryFileV1,
+  SkillMemoryFileV2,
   SkillRecord,
 } from './types';
 

--- a/src/core/skill-memory/store.ts
+++ b/src/core/skill-memory/store.ts
@@ -40,6 +40,7 @@ import { acquireLock, writeFileAtomicSafe } from '../../utils/atomic-file';
 import {
   SKILL_MEMORY_SCHEMA_VERSION,
   SKILL_MEMORY_SCHEMA_VERSION_V1,
+  SKILL_MEMORY_SCHEMA_VERSION_V2,
   type FrozenSnapshot,
   type SkillMemoryFile,
   type SkillRecord,
@@ -150,23 +151,31 @@ function assertSafeSnapshotId(snapshotId: string): void {
 
 /**
  * Normalise a record read from disk so its `replayArtifacts` field is
- * always defined and parallel-indexed with `steps`. Defensive against:
- *   - v1 records (no field on disk),
- *   - partial v2 writes (field present but wrong length),
- *   - non-array `steps` (we leave the field undefined; callers handle).
+ * always defined and parallel-indexed with `steps`, and its
+ * `codegenArtifacts` field is always a (possibly-empty) array. Defensive
+ * against:
+ *   - v1 records (neither field on disk),
+ *   - v2 records (`replayArtifacts` present, `codegenArtifacts` absent),
+ *   - partial v3 writes (field present but wrong length for replayArtifacts),
+ *   - non-array `steps` (we leave replayArtifacts undefined; callers handle).
  */
 function normaliseRecordForRead(rec: SkillRecord): SkillRecord {
-  if (!Array.isArray(rec.steps)) return { ...rec };
-  const stepCount = rec.steps.length;
-  const existing = rec.replayArtifacts;
-  if (Array.isArray(existing) && existing.length === stepCount) return rec;
+  // Always ensure codegenArtifacts is an array (migration from v1/v2).
+  const normalised: SkillRecord = Array.isArray(rec.codegenArtifacts)
+    ? { ...rec }
+    : { ...rec, codegenArtifacts: [] };
+
+  if (!Array.isArray(normalised.steps)) return normalised;
+  const stepCount = normalised.steps.length;
+  const existing = normalised.replayArtifacts;
+  if (Array.isArray(existing) && existing.length === stepCount) return normalised;
   const padded: Array<ReplayArtifact | null> = new Array(stepCount).fill(null);
   if (Array.isArray(existing)) {
     for (let i = 0; i < Math.min(existing.length, stepCount); i++) {
       padded[i] = existing[i] ?? null;
     }
   }
-  return { ...rec, replayArtifacts: padded };
+  return { ...normalised, replayArtifacts: padded };
 }
 
 /**
@@ -290,6 +299,19 @@ export class SkillMemoryStore {
       }
       return { schema_version: SKILL_MEMORY_SCHEMA_VERSION, skills: normalised };
     }
+    if (obj.schema_version === SKILL_MEMORY_SCHEMA_VERSION_V2) {
+      if (!obj.skills || typeof obj.skills !== 'object') {
+        return { schema_version: SKILL_MEMORY_SCHEMA_VERSION, skills: {} };
+      }
+      const v2Skills = obj.skills as Record<string, SkillRecord>;
+      const upgraded: Record<string, SkillRecord> = {};
+      for (const [id, rec] of Object.entries(v2Skills)) {
+        upgraded[id] = normaliseRecordForRead(rec);
+      }
+      // Note: we return v3 in memory but do NOT rewrite the file here.
+      // The next record() acquires the lock and writes v3 explicitly.
+      return { schema_version: SKILL_MEMORY_SCHEMA_VERSION, skills: upgraded };
+    }
     if (obj.schema_version === SKILL_MEMORY_SCHEMA_VERSION_V1) {
       if (!obj.skills || typeof obj.skills !== 'object') {
         return { schema_version: SKILL_MEMORY_SCHEMA_VERSION, skills: {} };
@@ -299,8 +321,8 @@ export class SkillMemoryStore {
       for (const [id, rec] of Object.entries(v1Skills)) {
         upgraded[id] = normaliseRecordForRead(rec);
       }
-      // Note: we return v2 in memory but do NOT rewrite the file here.
-      // The next record() acquires the lock and writes v2 explicitly.
+      // Note: we return v3 in memory but do NOT rewrite the file here.
+      // The next record() acquires the lock and writes v3 explicitly.
       return { schema_version: SKILL_MEMORY_SCHEMA_VERSION, skills: upgraded };
     }
     console.error(
@@ -404,6 +426,10 @@ export class SkillMemoryStore {
         // keeps the previously-recorded value.
         frozenSnapshotPath: skill.frozenSnapshotPath ?? existing?.frozenSnapshotPath ?? null,
         ...(replayArtifacts !== undefined ? { replayArtifacts } : {}),
+        // codegen_artifacts (#1430): caller supplies the array; on re-record
+        // without an explicit value, preserve the existing pointers so a
+        // re-record that omits codegen does not erase prior captures.
+        codegenArtifacts: skill.codegenArtifacts ?? existing?.codegenArtifacts ?? [],
       };
       // Preserve replay-outcome fields across idempotent re-record. The
       // recorder owns `steps`/`contractId`; the replay path owns the

--- a/src/core/skill-memory/types.ts
+++ b/src/core/skill-memory/types.ts
@@ -8,11 +8,13 @@
  *
  * with the structure:
  *
- *   { schema_version: 2, skills: { [skill_id]: SkillRecord } }
+ *   { schema_version: 3, skills: { [skill_id]: SkillRecord } }
  *
- * `schema_version` is mandatory. The store reads both v1 and v2 records
- * (v1 records are upgraded in memory with `replay_artifact = null` per
- * step; the file is rewritten as v2 on the next idempotent re-record).
+ * `schema_version` is mandatory. The store reads v1, v2, and v3 records:
+ *   - v1 records are upgraded in memory with `replay_artifact = null` per
+ *     step and `codegen_artifacts = []`; the file is rewritten as v3 on
+ *     the next idempotent re-record.
+ *   - v2 records are upgraded in memory with `codegen_artifacts = []`.
  *
  * The recall *ranking* logic (relevance score, recency weighting,
  * LLM-facing payload sizing) is pilot-tier work and intentionally lives
@@ -22,15 +24,17 @@
 import type { ReplayArtifact } from './replay-artifact';
 
 /**
- * v2 = v1 + optional `replay_artifact` per step (#875). Reads are
- * back-compatible: v1 files load and surface `replay_artifact: null`
- * for every step. Writes always produce v2 so freshly-recorded skills
- * carry the latest schema even when no artifact is attached.
+ * v3 = v2 + optional `codegen_artifacts` at the skill level (#1430).
+ * Reads are back-compatible: v1/v2 files load cleanly; the missing field
+ * normalises to `[]` in memory. Writes always produce v3.
  */
-export const SKILL_MEMORY_SCHEMA_VERSION = 2;
+export const SKILL_MEMORY_SCHEMA_VERSION = 3;
 
-/** Pre-#875 schema version. Still readable; promoted to v2 on next write. */
+/** Pre-#875 schema version. Still readable; promoted to v3 on next write. */
 export const SKILL_MEMORY_SCHEMA_VERSION_V1 = 1;
+
+/** Pre-#1430 schema version. Still readable; promoted to v3 on next write. */
+export const SKILL_MEMORY_SCHEMA_VERSION_V2 = 2;
 
 /**
  * A single stored skill.
@@ -91,9 +95,36 @@ export interface SkillRecord {
    */
   lastReplayError?: string;
 
+  /**
+   * Codegen artifact pointers persisted at record time (#1430). Each entry
+   * points to a file written by the opt-in codegen pipeline
+   * (`OPENCHROME_CODEGEN` / `--codegen`). Paths are stored relative to the
+   * skill store rootDir so the record is portable across machines (per SSOT
+   * #1359 "portable local artifacts").
+   *
+   * When omitted on read (v1/v2 records), the store normalises to `[]`.
+   * When codegen is disabled at record time the field is written as `[]`.
+   */
+  codegenArtifacts?: CodegenArtifactPointer[];
 }
 
-/** On-disk shape for `<rootDir>/<encodedDomain>/skills.json` (v2). */
+/**
+ * A pointer to one codegen output file produced by the `--codegen` pipeline.
+ * Stored relative to the skill store rootDir for portability (#1359).
+ */
+export interface CodegenArtifactPointer {
+  /** Codegen output format. Matches the `CodegenMode` values (never 'off'). */
+  kind: 'puppeteer' | 'playwright' | 'mcp-replay';
+  /**
+   * Path to the artifact file, relative to the SkillMemoryStore rootDir.
+   * Use `path.join(rootDir, pointer.path)` to resolve to an absolute path.
+   */
+  path: string;
+  /** Wall-clock ms epoch when the artifact file was created. */
+  created_at: number;
+}
+
+/** On-disk shape for `<rootDir>/<encodedDomain>/skills.json` (v3). */
 export interface SkillMemoryFile {
   schema_version: typeof SKILL_MEMORY_SCHEMA_VERSION;
   skills: Record<string, SkillRecord>;
@@ -101,12 +132,23 @@ export interface SkillMemoryFile {
 
 /**
  * v1 file shape — read-only. Persisted before #875; the store accepts it
- * on read, normalises every record to v2 by setting `replayArtifacts` to
- * an array of nulls, and the next `record()` write promotes the file.
+ * on read, normalises every record to v3 by setting `replayArtifacts` to
+ * an array of nulls and `codegenArtifacts` to `[]`, and the next
+ * `record()` write promotes the file.
  */
 export interface SkillMemoryFileV1 {
   schema_version: typeof SKILL_MEMORY_SCHEMA_VERSION_V1;
-  skills: Record<string, Omit<SkillRecord, 'replayArtifacts'>>;
+  skills: Record<string, Omit<SkillRecord, 'replayArtifacts' | 'codegenArtifacts'>>;
+}
+
+/**
+ * v2 file shape — read-only. Persisted before #1430; the store accepts it
+ * on read, normalises every record to v3 by setting `codegenArtifacts` to
+ * `[]`, and the next `record()` write promotes the file.
+ */
+export interface SkillMemoryFileV2 {
+  schema_version: typeof SKILL_MEMORY_SCHEMA_VERSION_V2;
+  skills: Record<string, Omit<SkillRecord, 'codegenArtifacts'>>;
 }
 
 /**

--- a/src/tools/oc-skill-record.ts
+++ b/src/tools/oc-skill-record.ts
@@ -12,18 +12,35 @@
  *
  * No LLM ranking is performed here — this is a pure write surface. Recall
  * with optional filtering lives in oc_skill_recall (#785).
+ *
+ * Codegen artifact pointers (#1430): when `OPENCHROME_CODEGEN` is set to a
+ * non-off value, existing codegen output files for the current session are
+ * detected and their paths (relative to the skill store rootDir) are persisted
+ * in `codegen_artifacts` on the stored record. When codegen is off (the
+ * default), `codegen_artifacts` is written as `[]` so existing records always
+ * have the field present after a re-record.
  */
+
+import * as path from 'node:path';
 
 import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import {
+  defaultSkillMemoryRootDir,
   flushRecorderBuffer,
   REPLAY_ARTIFACT_SCHEMA_VERSION,
   SkillMemoryStore,
+  type CodegenArtifactPointer,
   type ReplayArtifact,
   type ReplayArtifactStep,
 } from '../core/skill-memory';
+import {
+  codegenPath,
+  getCodegenMode,
+  isCodegenEnabled,
+  type CodegenMode,
+} from '../core/codegen';
 import { redactSecrets } from '../core/secrets';
 import { isDynamicSkillsEnabled, isSkillReplayEnabled } from '../harness/flags';
 import { getSessionManager } from '../session-manager';
@@ -199,6 +216,38 @@ const handler: ToolHandler = async (
     : undefined;
   const replayArtifactsForStore = replayArtifacts && replayArtifacts.length > 0 ? replayArtifacts : undefined;
 
+  // codegen_artifacts (#1430): collect pointers to any codegen output files
+  // written for this session by the opt-in `--codegen` / OPENCHROME_CODEGEN
+  // pipeline. Paths are stored relative to the skill store rootDir for
+  // portability across machines (per SSOT #1359 "portable local artifacts").
+  // When codegen is off (the default), we write an empty array so the field
+  // is always present in v3 records after a record/re-record.
+  const codegenArtifacts: CodegenArtifactPointer[] = [];
+  if (isCodegenEnabled()) {
+    const storeRoot = defaultSkillMemoryRootDir();
+    const codegenMode = getCodegenMode();
+    const formats: Array<Exclude<CodegenMode, 'off'>> = ['mcp-replay'];
+    if (codegenMode === 'puppeteer') formats.push('puppeteer');
+    if (codegenMode === 'playwright') formats.push('playwright');
+    const { statSync, existsSync } = await import('node:fs');
+    for (const fmt of formats) {
+      const artifactPath = codegenPath(sessionId, fmt);
+      if (existsSync(artifactPath)) {
+        let created_at: number;
+        try {
+          created_at = statSync(artifactPath).birthtimeMs || statSync(artifactPath).mtimeMs;
+        } catch {
+          created_at = Date.now();
+        }
+        codegenArtifacts.push({
+          kind: fmt,
+          path: path.relative(storeRoot, artifactPath),
+          created_at,
+        });
+      }
+    }
+  }
+
   let recordResult: { skill_id: string; stored_at: number };
   try {
     recordResult = await store.record({
@@ -210,6 +259,7 @@ const handler: ToolHandler = async (
       lastUsedAt: 0,
       frozenSnapshotPath: snapshotPath ?? null,
       ...(replayArtifactsForStore !== undefined ? { replayArtifacts: replayArtifactsForStore } : {}),
+      codegenArtifacts,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/tests/core/skill-memory/codegen-artifacts.test.ts
+++ b/tests/core/skill-memory/codegen-artifacts.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for the codegen artifact pointers on SkillMemoryStore (#1430 Part 1).
+ *
+ * Covers:
+ *   - v3 records round-trip with codegenArtifacts populated;
+ *   - v1 and v2 on-disk records load cleanly and normalise codegenArtifacts
+ *     to `[]` in memory (back-compatibility migration);
+ *   - records with no pointers preserve an empty array so writes always
+ *     produce v3.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  SKILL_MEMORY_SCHEMA_VERSION,
+  SkillMemoryStore,
+  type CodegenArtifactPointer,
+  type SkillRecord,
+} from '../../../src/core/skill-memory';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-skill-codegen-'));
+}
+
+function baseInput(overrides: Partial<SkillRecord> = {}) {
+  return {
+    domain: 'amazon.com',
+    name: 'add-to-cart',
+    steps: [{ kind: 'click', selector: '#buy-now' }],
+    contractId: 'contract-1',
+    successCount: 0,
+    lastUsedAt: 0,
+    frozenSnapshotPath: null as string | null,
+    ...overrides,
+  };
+}
+
+describe('SkillMemoryStore — codegen artifact pointers (#1430)', () => {
+  let root: string;
+  let store: SkillMemoryStore;
+
+  beforeEach(() => {
+    root = tempRoot();
+    store = new SkillMemoryStore({ rootDir: root, domain: 'amazon.com' });
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('persists codegenArtifacts on record and reloads them from disk', async () => {
+    const artifacts: CodegenArtifactPointer[] = [
+      { kind: 'playwright', path: 'sess-1/skill.spec.ts', created_at: 1700000000 },
+      { kind: 'mcp-replay', path: 'sess-1/skill.jsonl', created_at: 1700000001 },
+    ];
+
+    const recorded = await store.record({
+      ...baseInput(),
+      codegenArtifacts: artifacts,
+    });
+    expect(recorded.skill_id).toMatch(/^[a-f0-9]{16}$/);
+
+    // Reload from disk via a fresh instance to confirm round-trip.
+    const reloaded = new SkillMemoryStore({ rootDir: root, domain: 'amazon.com' });
+    const fetched = reloaded.get(recorded.skill_id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.codegenArtifacts).toEqual(artifacts);
+  });
+
+  it('writes a v3 schema_version on disk', async () => {
+    await store.record(baseInput());
+    // Find the skills.json file produced by the store (encoded domain).
+    const dirs = fs.readdirSync(root);
+    expect(dirs.length).toBeGreaterThan(0);
+    const file = path.join(root, dirs[0], 'skills.json');
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(parsed.schema_version).toBe(SKILL_MEMORY_SCHEMA_VERSION);
+    expect(parsed.schema_version).toBe(3);
+  });
+
+  it('reads v1 on-disk records and normalises codegenArtifacts to []', async () => {
+    // Write a v1 record first by going through the store at a clean root.
+    // We seed by writing a synthetic v1 JSON to the exact path the store
+    // will read. To discover the encoded-domain dir name, do a no-op write
+    // first then overwrite with v1 content.
+    await store.record(baseInput({ name: 'seed-to-discover-path' }));
+    const dirs = fs.readdirSync(root);
+    const dir = path.join(root, dirs[0]);
+    const skillId = 'a'.repeat(16);
+    const v1 = {
+      schema_version: 1,
+      skills: {
+        [skillId]: {
+          skillId,
+          domain: 'amazon.com',
+          name: 'legacy-skill',
+          steps: [{ kind: 'click' }],
+          contractId: 'contract-1',
+          successCount: 0,
+          lastUsedAt: 0,
+          frozenSnapshotPath: null,
+        },
+      },
+    };
+    fs.writeFileSync(path.join(dir, 'skills.json'), JSON.stringify(v1));
+
+    const loaded = new SkillMemoryStore({ rootDir: root, domain: 'amazon.com' });
+    const fetched = loaded.get(skillId);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.codegenArtifacts).toEqual([]);
+  });
+
+  it('reads v2 on-disk records and normalises codegenArtifacts to []', async () => {
+    await store.record(baseInput({ name: 'seed-to-discover-path' }));
+    const dirs = fs.readdirSync(root);
+    const dir = path.join(root, dirs[0]);
+    const skillId = 'b'.repeat(16);
+    const v2 = {
+      schema_version: 2,
+      skills: {
+        [skillId]: {
+          skillId,
+          domain: 'amazon.com',
+          name: 'v2-skill',
+          steps: [{ kind: 'click', replay_artifact: null }],
+          contractId: 'contract-1',
+          successCount: 0,
+          lastUsedAt: 0,
+          frozenSnapshotPath: null,
+        },
+      },
+    };
+    fs.writeFileSync(path.join(dir, 'skills.json'), JSON.stringify(v2));
+
+    const loaded = new SkillMemoryStore({ rootDir: root, domain: 'amazon.com' });
+    const fetched = loaded.get(skillId);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.codegenArtifacts).toEqual([]);
+  });
+
+  it('preserves an empty codegenArtifacts array on records with no pointers', async () => {
+    const recorded = await store.record({ ...baseInput(), codegenArtifacts: [] });
+    const reloaded = new SkillMemoryStore({ rootDir: root, domain: 'amazon.com' });
+    const fetched = reloaded.get(recorded.skill_id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.codegenArtifacts).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Bumps SkillMemoryStore schema v2 → v3 with an optional `codegenArtifacts: { kind, path, created_at }[]` on `SkillRecord`.
- `oc_skill_record` snapshots #1253 codegen output (mcp-replay/playwright/puppeteer) into the record when `OPENCHROME_CODEGEN` is on. Paths are stored relative to the store rootDir for portability (SSOT #1359).
- v1/v2 on-disk records load cleanly and normalise the new field to `[]` in memory.

## Out of scope (Part 2 of #1430)
- `oc_skill_recall` does **not** yet surface the new field.
- Host-side LLM-free fast-path docs land in Part 2.

## Test plan
- [x] `tests/core/skill-memory/codegen-artifacts.test.ts` — 5/5 pass (v3 round-trip, v1/v2 migration, empty-array preservation).
- [ ] Reviewer to confirm existing skill-memory tests still pass.

Part 1 of #1430.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>