### PR TITLE
feat(tools): add image_qa primitive via MCP sampling

### DIFF
--- a/docs/mcp/tool-annotations.md
+++ b/docs/mcp/tool-annotations.md
@@ -54,6 +54,7 @@ Categories below are documentation-only — the runtime source is
 | `oc_skill_recall`          | Read skill memory                                    |
 | `vision_find`              | Read-only image-based discovery                      |
 | `oc_assert`                | Single-call contract verifier (read-only)            |
+| `image_qa`                | Vision Q&A over caller-supplied screenshot via MCP sampling |
 | `oc_recording_list`        | List existing recordings                             |
 | `workflow_status`          | Workflow read                                        |
 | `workflow_collect`         | Collect previously-completed results                 |

--- a/src/tools/__tests__/__snapshots__/tools-list.v1.11.snap.json
+++ b/src/tools/__tests__/__snapshots__/tools-list.v1.11.snap.json
@@ -64,6 +64,9 @@
       "name": "http_auth"
     },
     {
+      "name": "image_qa"
+    },
+    {
       "name": "inspect"
     },
     {

--- a/src/tools/image-qa.ts
+++ b/src/tools/image-qa.ts
@@ -72,7 +72,7 @@ const definition: MCPToolDefinition = {
       screenshot: {
         type: 'object',
         description:
-          'Exactly one of `ref`, `path`, or `base64` must be supplied. ' +
+          'REQUIRED Exactly one of `ref`, `path`, or `base64` must be supplied. ' +
           'Optional `mime_type` defaults to `image/png`.',
         properties: {
           ref: {
@@ -95,7 +95,7 @@ const definition: MCPToolDefinition = {
       },
       question: {
         type: 'string',
-        description: 'Vision Q&A prompt for the host LLM.',
+        description: 'REQUIRED Vision Q&A prompt for the host LLM.',
       },
       max_tokens: {
         type: 'number',

--- a/src/tools/image-qa.ts
+++ b/src/tools/image-qa.ts
@@ -1,0 +1,222 @@
+/**
+ * image_qa — vision Q&A over a caller-supplied screenshot via MCP sampling
+ * (issue #1432, Part 1).
+ *
+ * SSOT (#1359) alignment:
+ *   - Host-neutral, MCP-first: the host LLM does the QA via
+ *     `sampling/createMessage`. OpenChrome never owns its own API key.
+ *   - Deterministic fallback when the client does not advertise the
+ *     `sampling` capability: returns
+ *     `{ status: 'unsupported_by_host', reason }`.
+ *   - No auto-capture. The caller MUST pass an existing screenshot
+ *     reference (file path, base64 blob, or in-memory ref). The tool only
+ *     reads bytes that some other tool already produced.
+ *
+ * Out of scope (Part 2 of #1432):
+ *   - Wiring `oc_assert` to cite an `image_qa` clause as evidence.
+ */
+
+import * as fs from 'node:fs';
+
+import { MCPServer } from '../mcp-server';
+import { MCPToolDefinition, MCPResult, ToolContext, ToolHandler } from '../types/mcp';
+import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
+
+interface ImageQaScreenshot {
+  /** Opaque in-memory reference produced by a sibling tool. */
+  ref?: string;
+  /** Absolute path to a PNG/JPEG file. */
+  path?: string;
+  /** Base64-encoded screenshot bytes. */
+  base64?: string;
+  /** Optional explicit mime type. Defaults to `image/png`. */
+  mime_type?: string;
+}
+
+interface ImageQaInput {
+  screenshot?: ImageQaScreenshot;
+  question?: string;
+  max_tokens?: number;
+}
+
+type ImageQaOutput =
+  | {
+      status: 'ok';
+      answer: string;
+      model?: string;
+      usage?: Record<string, unknown>;
+    }
+  | {
+      status: 'unsupported_by_host';
+      reason: string;
+    }
+  | {
+      status: 'error';
+      reason: string;
+    };
+
+const definition: MCPToolDefinition = {
+  name: 'image_qa',
+  description:
+    'Ask the connected host LLM a question about a caller-supplied ' +
+    'screenshot. Forwards via MCP `sampling/createMessage` when the client ' +
+    'advertises the `sampling` capability. Returns ' +
+    '`{ status: "unsupported_by_host", reason }` when the capability is ' +
+    'absent — OpenChrome never uses its own API keys. The caller MUST ' +
+    'supply one of `screenshot.ref`, `screenshot.path`, or ' +
+    '`screenshot.base64`. No auto-capture.',
+  annotations: TOOL_ANNOTATIONS.image_qa,
+  inputSchema: {
+    type: 'object',
+    properties: {
+      screenshot: {
+        type: 'object',
+        description:
+          'Exactly one of `ref`, `path`, or `base64` must be supplied. ' +
+          'Optional `mime_type` defaults to `image/png`.',
+        properties: {
+          ref: {
+            type: 'string',
+            description: 'Opaque reference from a sibling tool.',
+          },
+          path: {
+            type: 'string',
+            description: 'Absolute path to a PNG/JPEG screenshot file.',
+          },
+          base64: {
+            type: 'string',
+            description: 'Base64-encoded screenshot bytes.',
+          },
+          mime_type: {
+            type: 'string',
+            description: 'MIME type. Defaults to image/png.',
+          },
+        },
+      },
+      question: {
+        type: 'string',
+        description: 'Vision Q&A prompt for the host LLM.',
+      },
+      max_tokens: {
+        type: 'number',
+        description: 'Optional sampling cap. Defaults to 512.',
+      },
+    },
+    required: ['screenshot', 'question'],
+  },
+};
+
+function jsonResult(payload: ImageQaOutput): MCPResult {
+  return { content: [{ type: 'text', text: JSON.stringify(payload) }] };
+}
+
+function readBase64(screenshot: ImageQaScreenshot): { base64: string; mime: string } | { error: string } {
+  const mime = screenshot.mime_type ?? 'image/png';
+  // Exactly-one validation: count provided sources.
+  const provided = [
+    screenshot.ref ?? null,
+    screenshot.path ?? null,
+    screenshot.base64 ?? null,
+  ].filter((v) => v != null && v !== '').length;
+  if (provided !== 1) {
+    return { error: 'screenshot must contain exactly one of `ref`, `path`, or `base64`' };
+  }
+  if (screenshot.base64) {
+    return { base64: screenshot.base64, mime };
+  }
+  if (screenshot.path) {
+    try {
+      const bytes = fs.readFileSync(screenshot.path);
+      return { base64: bytes.toString('base64'), mime };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { error: `cannot read screenshot.path: ${message}` };
+    }
+  }
+  // ref-based screenshots: the contract is opaque — the host that produced
+  // the ref is responsible for resolving it. For Part 1 we surface a clear
+  // unsupported result rather than guessing.
+  return { error: 'screenshot.ref resolution is not supported yet — pass `path` or `base64`' };
+}
+
+const handler: ToolHandler = async (
+  _sessionId: string,
+  args: Record<string, unknown>,
+  context?: ToolContext,
+): Promise<MCPResult> => {
+  const input = args as ImageQaInput;
+  const screenshot = input.screenshot;
+  const question = input.question;
+  const maxTokens = typeof input.max_tokens === 'number' ? Math.max(1, Math.floor(input.max_tokens)) : 512;
+
+  if (!screenshot || typeof screenshot !== 'object') {
+    return jsonResult({ status: 'error', reason: 'missing required field: screenshot' });
+  }
+  if (typeof question !== 'string' || question.trim().length === 0) {
+    return jsonResult({ status: 'error', reason: 'missing required field: question' });
+  }
+
+  const decoded = readBase64(screenshot);
+  if ('error' in decoded) {
+    return jsonResult({ status: 'error', reason: decoded.error });
+  }
+
+  const samplingCap = context?.clientCapabilities?.sampling;
+  if (!samplingCap) {
+    return jsonResult({
+      status: 'unsupported_by_host',
+      reason: 'sampling capability not advertised by client',
+    });
+  }
+  if (!context?.requestClient) {
+    return jsonResult({
+      status: 'unsupported_by_host',
+      reason: 'requestClient bridge not available on this transport',
+    });
+  }
+
+  type SamplingResponse = {
+    content?: { type?: string; text?: string };
+    model?: string;
+    usage?: Record<string, unknown>;
+  };
+
+  try {
+    const response = await context.requestClient<SamplingResponse>(
+      'sampling/createMessage',
+      {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'image', data: decoded.base64, mimeType: decoded.mime },
+              { type: 'text', text: question },
+            ],
+          },
+        ],
+        maxTokens,
+        // The host decides which model to use; we do not impose one.
+      },
+      { timeoutMs: 30_000 },
+    );
+
+    const answer =
+      typeof response?.content?.text === 'string'
+        ? response.content.text
+        : '';
+
+    return jsonResult({
+      status: 'ok',
+      answer,
+      ...(response?.model ? { model: response.model } : {}),
+      ...(response?.usage ? { usage: response.usage } : {}),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return jsonResult({ status: 'error', reason: `sampling request failed: ${message}` });
+  }
+};
+
+export function registerImageQaTool(server: MCPServer): void {
+  server.registerTool('image_qa', handler, definition);
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -115,6 +115,7 @@ import { registerTotpGenerateTool } from './totp-generate';
 
 // Outcome Contracts (#784) — single-call assertion verifier
 import { registerOcAssertTool } from './oc-assert';
+import { registerImageQaTool } from './image-qa';
 
 // Gate detection (B2-PR1 of #1359) — fact-only CAPTCHA/auth gate detection
 import { registerOcGateInspectTool } from './oc-gate-inspect';
@@ -499,6 +500,7 @@ export function registerAllTools(server: MCPServer): void {
 
   // Outcome Contracts (#784) — single-call assertion verifier
   registerOcAssertTool(proxy);
+  registerImageQaTool(proxy);
 
   // Gate detection (B2-PR1 of #1359) — fact-only CAPTCHA/auth gate detection
   registerOcGateInspectTool(proxy);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -236,6 +236,7 @@ export const TOOL_CAPABILITY_MAP: Record<string, ToolCapability> = {
   oc_evidence_bundle: 'core',
   oc_gate_inspect: 'core',
   oc_get_connection_info: 'core',
+  image_qa: 'core',
   oc_journal: 'core',
   oc_observe: 'core',
   element_pick: 'core',

--- a/src/types/tool-annotations.ts
+++ b/src/types/tool-annotations.ts
@@ -83,6 +83,7 @@ export const TOOL_ANNOTATIONS = {
   oc_skill_export: READ_ONLY,
   vision_find: READ_ONLY,
   oc_assert: READ_ONLY,
+  image_qa: READ_ONLY,
   oc_gate_inspect: READ_ONLY,
   oc_recording_list: READ_ONLY,
   oc_recording_status: READ_ONLY,

--- a/tests/tools/image-qa.test.ts
+++ b/tests/tools/image-qa.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for the image_qa MCP tool (#1432 Part 1).
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { MCPServer } from '../../src/mcp-server';
+import { registerImageQaTool } from '../../src/tools/image-qa';
+import type { ToolContext } from '../../src/types/mcp';
+
+function getRegisteredTool(server: MCPServer, name: string) {
+  // MCPServer keeps a registry; reach in via the internal map for tests.
+  // The repo's other tool tests use the public registerTool surface and
+  // then invoke the registered handler through the registry getter when
+  // exposed. Fall back to capturing the handler during registration if no
+  // public getter exists.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const reg = (server as any).tools as Map<string, { handler: Function; definition: unknown }> | undefined;
+  if (!reg) throw new Error('MCPServer has no `tools` map exposed for test introspection');
+  const entry = reg.get(name);
+  if (!entry) throw new Error(`tool not registered: ${name}`);
+  return entry;
+}
+
+function parseResult(res: { content: Array<{ type: string; text?: string }> }) {
+  const block = res.content[0];
+  if (!block || block.type !== 'text' || typeof block.text !== 'string') {
+    throw new Error('expected text result block');
+  }
+  return JSON.parse(block.text);
+}
+
+describe('image_qa MCP tool (#1432)', () => {
+  let server: MCPServer;
+  let tmpDir: string;
+
+  beforeAll(() => {
+    server = new MCPServer();
+    registerImageQaTool(server);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'image-qa-test-'));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function callImageQa(args: Record<string, unknown>, ctx?: Partial<ToolContext>) {
+    const tool = getRegisteredTool(server, 'image_qa');
+    const fullCtx: ToolContext = {
+      startTime: Date.now(),
+      deadlineMs: 60_000,
+      ...(ctx ?? {}),
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (tool.handler as any)('test-session', args, fullCtx);
+  }
+
+  it('returns unsupported_by_host when the client lacks sampling capability', async () => {
+    const res = await callImageQa({
+      screenshot: { base64: 'AAAA' },
+      question: 'what is on the page?',
+    });
+    const parsed = parseResult(res);
+    expect(parsed.status).toBe('unsupported_by_host');
+  });
+
+  it('rejects when neither base64, path, nor ref is provided', async () => {
+    const res = await callImageQa({
+      screenshot: {},
+      question: 'q',
+    });
+    const parsed = parseResult(res);
+    expect(parsed.status).toBe('error');
+    expect(parsed.reason).toMatch(/exactly one of/);
+  });
+
+  it('rejects when both base64 and path are provided', async () => {
+    const res = await callImageQa({
+      screenshot: { base64: 'AAAA', path: '/tmp/x.png' },
+      question: 'q',
+    });
+    const parsed = parseResult(res);
+    expect(parsed.status).toBe('error');
+    expect(parsed.reason).toMatch(/exactly one of/);
+  });
+
+  it('rejects when question is missing', async () => {
+    const res = await callImageQa({
+      screenshot: { base64: 'AAAA' },
+    });
+    const parsed = parseResult(res);
+    expect(parsed.status).toBe('error');
+    expect(parsed.reason).toMatch(/question/);
+  });
+
+  it('forwards to sampling/createMessage when the client advertises sampling', async () => {
+    const calls: Array<{ method: string; params?: Record<string, unknown> }> = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fakeRequestClient = async (method: string, params?: Record<string, unknown>): Promise<any> => {
+      calls.push({ method, params });
+      return { content: { type: 'text', text: 'the page shows a login form' }, model: 'host-vision-1' };
+    };
+    const res = await callImageQa(
+      { screenshot: { base64: 'BBBB', mime_type: 'image/jpeg' }, question: 'what is on the page?' },
+      { clientCapabilities: { sampling: {} }, requestClient: fakeRequestClient },
+    );
+    const parsed = parseResult(res);
+    expect(parsed.status).toBe('ok');
+    expect(parsed.answer).toBe('the page shows a login form');
+    expect(parsed.model).toBe('host-vision-1');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('sampling/createMessage');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const messages = (calls[0].params as any).messages;
+    expect(messages[0].content[0].type).toBe('image');
+    expect(messages[0].content[0].data).toBe('BBBB');
+    expect(messages[0].content[0].mimeType).toBe('image/jpeg');
+  });
+
+  it('reads bytes from screenshot.path when sampling is available', async () => {
+    const file = path.join(tmpDir, 'shot.png');
+    fs.writeFileSync(file, Buffer.from([0xde, 0xad, 0xbe, 0xef]));
+    let receivedBase64: string | undefined;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fakeRequestClient = async (_method: string, params?: Record<string, unknown>): Promise<any> => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const messages = (params as any).messages;
+      receivedBase64 = messages[0].content[0].data as string;
+      return { content: { type: 'text', text: 'ok' } };
+    };
+    const res = await callImageQa(
+      { screenshot: { path: file }, question: 'q' },
+      { clientCapabilities: { sampling: {} }, requestClient: fakeRequestClient },
+    );
+    const parsed = parseResult(res);
+    expect(parsed.status).toBe('ok');
+    expect(receivedBase64).toBe(Buffer.from([0xde, 0xad, 0xbe, 0xef]).toString('base64'));
+  });
+});


### PR DESCRIPTION
## Summary
- New `image_qa` MCP tool: vision Q&A over a caller-supplied screenshot.
- Forwards to host via `sampling/createMessage` when client advertises the `sampling` capability.
- Returns deterministic `{ status: "unsupported_by_host", reason }` when sampling is absent.
- Strict no-auto-capture: caller must pass `path` or `base64`.

## SSOT (#1359) alignment
- No server-side LLM. No OpenChrome API key. Host owns the model.
- Pure read-only annotation.

## Files
- `src/tools/image-qa.ts` (new)
- `src/tools/index.ts` (register)
- `src/types/tool-annotations.ts` (READ_ONLY entry)
- `docs/mcp/tool-annotations.md` (markdown mirror)
- `tests/tools/image-qa.test.ts` — 6 tests covering sampling-present, sampling-absent, invalid input variants, and `path` byte read.

## Out of scope (Part 2 of #1432)
- `oc_assert` schema extension to cite `image_qa` clauses.

## Test plan
- [x] `tests/tools/image-qa.test.ts` — 6/6 pass.
- [x] `tests/unit/tool-annotations.test.ts` — 9/9 pass (markdown mirror sync).

Part 1 of #1432.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>