### PR TITLE
docs(skill): document LLM-free recall→precheck→replay fast path

### DIFF
--- a/docs/skills/llm-free-fast-path.md
+++ b/docs/skills/llm-free-fast-path.md
@@ -1,0 +1,67 @@
+# LLM-free skill fast path
+
+> Recall → contract precheck → deterministic replay, with no model call.
+> See issues #1430, #856 (oc_skill_replay), #1253 (replay codegen).
+
+When a host agent has previously recorded a skill under
+[`oc_skill_record`](../mcp/tool-annotations.md) with replay artifacts
+emitted by the `--codegen` pipeline (#1253), subsequent task runs can
+skip the LLM round entirely on contract match. The flow is:
+
+1. **Recall** — call `oc_skill_recall` scoped to the current domain (and
+   contract id, if known). The response includes each candidate skill's
+   `codegenArtifacts: { kind, path, created_at }[]` pointing at
+   replay-capable files written next to the skill store.
+2. **Contract precheck** — call `oc_assert` against the candidate
+   skill's `contractId`. If the contract holds against the current page
+   state, the recorded steps are still valid and the LLM is not needed
+   to rediscover them.
+3. **Deterministic replay** — call `oc_skill_replay` with the
+   `skill_id` from the recalled record. Replay is gated on
+   `OPENCHROME_SKILL_REPLAY=1` and the `--pilot` flag (#856). It walks
+   the recorded CDP steps, then re-evaluates the contract as the
+   PASS gate. No retries, no DOM heuristics, no LLM.
+
+If any step fails or the contract no longer holds, the host falls back
+to the normal LLM-driven flow. The failed replay marks the skill via
+`lastReplayFailedAt`, which `oc_skill_recall` re-uses to demote it on
+the next recall (#856 invariant #4).
+
+## Why the artifact pointers matter
+
+The `codegenArtifacts` payload lets a host that does **not** want to
+invoke `oc_skill_replay` (e.g. a Codex-side runtime that prefers a
+Playwright script) still pick up the same recorded steps. Each
+pointer carries:
+
+- `kind`: `puppeteer` | `playwright` | `mcp-replay`.
+- `path`: relative to the SkillMemoryStore root for portability across
+  machines (per the SSOT #1359 "portable local artifacts" principle).
+- `created_at`: wall-clock ms epoch.
+
+A host should treat `codegenArtifacts: []` as "no replay surface
+available, must use LLM".
+
+## Gating
+
+- The artifact pointers are persisted at `oc_skill_record` time only
+  when `OPENCHROME_CODEGEN` (or `--codegen`) is enabled. When codegen
+  is off, the field is written as `[]`.
+- `oc_skill_replay` itself is double-gated by `--pilot` and
+  `OPENCHROME_SKILL_REPLAY=1`. The recall response always surfaces the
+  pointers; whether a host actually replays is its own decision.
+
+## Operator checklist
+
+1. Recorded skills carry `codegenArtifacts` after a record run with
+   `OPENCHROME_CODEGEN=mcp-replay` (or `playwright` / `puppeteer`).
+2. `oc_skill_recall` returns the same array on the response.
+3. If the host opts into the fast path, an `oc_assert` precheck against
+   the recorded `contractId` should be cheap (deterministic, no LLM).
+4. On contract match, `oc_skill_replay` runs the recorded steps and
+   reports PASS / STEP_FAIL / CONTRACT_FAIL / PRECONDITION_FAIL.
+
+This loop is what enables the Webwright-style "Qwen-3.5-9B with 5+
+reusable tools" pattern referenced in issue #1430 — small models
+succeed when the harness can replay vetted, contract-bound recordings
+without re-reasoning from scratch.

--- a/tests/tools/oc-skill-recall-codegen.test.ts
+++ b/tests/tools/oc-skill-recall-codegen.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for #1430 Part 2 — oc_skill_recall surfaces codegenArtifacts.
+ *
+ * Today the recall response shape is `RankedSkillRecord extends SkillRecord`,
+ * so the field is forwarded automatically. These tests pin that behaviour:
+ * if a future refactor reshapes the recall payload, the LLM-free fast path
+ * documented in `docs/skills/llm-free-fast-path.md` would silently break.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { MCPServer } from '../../src/mcp-server';
+import { registerOcSkillRecallTool } from '../../src/tools/oc-skill-recall';
+import {
+  SkillMemoryStore,
+  type CodegenArtifactPointer,
+  type SkillRecord,
+} from '../../src/core/skill-memory';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-recall-codegen-'));
+}
+
+function getRegisteredTool(server: MCPServer, name: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const reg = (server as any).tools as Map<string, { handler: Function }> | undefined;
+  if (!reg) throw new Error('MCPServer has no `tools` map exposed');
+  const entry = reg.get(name);
+  if (!entry) throw new Error(`tool not registered: ${name}`);
+  return entry;
+}
+
+function parseResult(res: { content: Array<{ type: string; text?: string }> }) {
+  const block = res.content[0];
+  if (!block || block.type !== 'text' || typeof block.text !== 'string') {
+    throw new Error('expected text result block');
+  }
+  return JSON.parse(block.text);
+}
+
+describe('oc_skill_recall — codegen artifact surfacing (#1430 Part 2)', () => {
+  let root: string;
+  let prevRoot: string | undefined;
+  let server: MCPServer;
+
+  beforeAll(() => {
+    server = new MCPServer();
+    registerOcSkillRecallTool(server);
+  });
+
+  beforeEach(() => {
+    root = tempRoot();
+    // Steer the store's default rootDir resolution via HOME override —
+    // defaultSkillMemoryRootDir() = path.join(os.homedir(), '.openchrome',
+    // 'skill-memory'), and os.homedir() reads $HOME on POSIX. The recall
+    // handler constructs the store without rootDir, so both record and
+    // recall see the same path through this single override.
+    prevRoot = process.env.HOME;
+    process.env.HOME = root;
+  });
+
+  afterEach(() => {
+    if (prevRoot === undefined) delete process.env.HOME;
+    else process.env.HOME = prevRoot;
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('surfaces codegenArtifacts from the persisted record on recall', async () => {
+    const artifacts: CodegenArtifactPointer[] = [
+      { kind: 'playwright', path: 'sess-1/skill.spec.ts', created_at: 1700000000 },
+      { kind: 'mcp-replay', path: 'sess-1/skill.jsonl', created_at: 1700000001 },
+    ];
+    const store = new SkillMemoryStore({ domain: 'amazon.com' });
+    await store.record({
+      domain: 'amazon.com',
+      name: 'add-to-cart',
+      steps: [{ kind: 'click', selector: '#buy-now' }],
+      contractId: 'contract-1',
+      successCount: 0,
+      lastUsedAt: 0,
+      frozenSnapshotPath: null,
+      codegenArtifacts: artifacts,
+    } as Omit<SkillRecord, 'skillId'>);
+
+    const tool = getRegisteredTool(server, 'oc_skill_recall');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await (tool.handler as any)('test-session', { domain: 'amazon.com' });
+    const parsed = parseResult(res);
+    expect(parsed.skills).toHaveLength(1);
+    expect(parsed.skills[0].codegenArtifacts).toEqual(artifacts);
+  });
+
+  it('emits codegenArtifacts as an empty array when none were persisted', async () => {
+    const store = new SkillMemoryStore({ domain: 'amazon.com' });
+    await store.record({
+      domain: 'amazon.com',
+      name: 'add-to-cart',
+      steps: [],
+      contractId: 'contract-1',
+      successCount: 0,
+      lastUsedAt: 0,
+      frozenSnapshotPath: null,
+      codegenArtifacts: [],
+    } as Omit<SkillRecord, 'skillId'>);
+
+    const tool = getRegisteredTool(server, 'oc_skill_recall');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await (tool.handler as any)('test-session', { domain: 'amazon.com' });
+    const parsed = parseResult(res);
+    expect(parsed.skills).toHaveLength(1);
+    expect(parsed.skills[0].codegenArtifacts).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on top of #1440 (Part 1).

- Pin the existing recall payload behavior with regression tests: `oc_skill_recall` returns `codegenArtifacts` because `RankedSkillRecord extends SkillRecord`. If a future refactor reshapes the recall payload, this test fails before users find out.
- New `docs/skills/llm-free-fast-path.md` describing the host-side recall → contract precheck → `oc_skill_replay` flow that bypasses the LLM on contract match.

## SSOT (#1359) alignment
- Pure docs + tests. No runtime change.
- The recall response still respects #856 pilot gates for actual replay.

## Test plan
- [x] `tests/tools/oc-skill-recall-codegen.test.ts` — 2/2 pass.

Part 2 of #1430. Depends on #1440.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>