### PR TITLE
feat(harness): early-stop policy on the marginal-utility tracker

### DIFF
--- a/src/core/task-ledger/early-stop.ts
+++ b/src/core/task-ledger/early-stop.ts
@@ -1,0 +1,107 @@
+/**
+ * Early-stop policy for episode budgets (#1428 Part 2).
+ *
+ * Pure function. Reads a MarginalUtilitySummary (Part 1) and decides
+ * whether the host should stop work even before the hard step budget
+ * is exhausted. The policy targets Webwright's empirical observation
+ * that "the next 50 steps deliver only 3–4 additional accuracy points"
+ * — once Δp/Δstep stays below a small threshold for N consecutive
+ * steps, additional spend is unlikely to move the needle.
+ *
+ * Crucially this module ONLY recommends. It does not raise, does not
+ * mutate anything, and never decides on behalf of the host. The host
+ * remains the sole authority on when to stop (SSOT #1359, P3 host
+ * neutrality).
+ */
+
+import type { MarginalUtilitySummary } from './marginal-utility';
+
+/** Default plateau threshold: 0.02 of p_success change per step. */
+export const DEFAULT_PLATEAU_DELTA = 0.02;
+/** Default plateau length: 10 consecutive low-Δ steps. */
+export const DEFAULT_PLATEAU_STEPS = 10;
+/** Minimum p_success that must be reached before any stop recommendation. */
+export const DEFAULT_MIN_P_FOR_STOP = 0.7;
+
+export interface EarlyStopPolicy {
+  /** |delta| per step must remain below this to count as a plateau step. */
+  plateau_delta?: number;
+  /** Number of consecutive plateau steps required to recommend stop. */
+  plateau_steps?: number;
+  /** Only recommend stop when last_p meets this minimum. */
+  min_p_for_stop?: number;
+}
+
+export interface EarlyStopRecommendation {
+  /** True iff the policy recommends stopping now. */
+  should_stop: boolean;
+  /**
+   * One-line human-readable reason. Always populated, even when
+   * `should_stop` is false — used by the host to surface the policy's
+   * current verdict in journals / dashboards.
+   */
+  reason: string;
+  /** Snapshot of the policy that produced this recommendation. */
+  policy: Required<EarlyStopPolicy>;
+}
+
+function resolved(policy?: EarlyStopPolicy): Required<EarlyStopPolicy> {
+  return {
+    plateau_delta:
+      typeof policy?.plateau_delta === 'number' && policy.plateau_delta > 0
+        ? policy.plateau_delta
+        : DEFAULT_PLATEAU_DELTA,
+    plateau_steps:
+      typeof policy?.plateau_steps === 'number' && policy.plateau_steps > 0
+        ? Math.floor(policy.plateau_steps)
+        : DEFAULT_PLATEAU_STEPS,
+    min_p_for_stop:
+      typeof policy?.min_p_for_stop === 'number' &&
+      policy.min_p_for_stop >= 0 &&
+      policy.min_p_for_stop <= 1
+        ? policy.min_p_for_stop
+        : DEFAULT_MIN_P_FOR_STOP,
+  };
+}
+
+/**
+ * Decide whether to stop based on the latest marginal-utility summary.
+ *
+ * The rule is intentionally simple and observable:
+ *
+ *   should_stop = (last_p >= min_p_for_stop) AND
+ *                 (consecutive_low_delta >= plateau_steps)
+ *
+ * The first conjunct prevents the policy from recommending stop while
+ * the episode is still failing (low p_success + flat = stuck, not
+ * done). The second is the Webwright "additional steps deliver no
+ * marginal benefit" condition.
+ */
+export function recommendEarlyStop(
+  summary: MarginalUtilitySummary,
+  policy?: EarlyStopPolicy,
+): EarlyStopRecommendation {
+  const r = resolved(policy);
+
+  if (summary.last_p < r.min_p_for_stop) {
+    return {
+      should_stop: false,
+      reason: `last_p=${summary.last_p.toFixed(3)} below min_p_for_stop=${r.min_p_for_stop}`,
+      policy: r,
+    };
+  }
+
+  if (summary.consecutive_low_delta < r.plateau_steps) {
+    return {
+      should_stop: false,
+      reason: `consecutive_low_delta=${summary.consecutive_low_delta} below plateau_steps=${r.plateau_steps}`,
+      policy: r,
+    };
+  }
+
+  return {
+    should_stop: true,
+    reason: `plateau reached: last_p=${summary.last_p.toFixed(3)} consecutive_low_delta=${summary.consecutive_low_delta}`,
+    policy: r,
+  };
+}

--- a/src/core/task-ledger/early-stop.ts
+++ b/src/core/task-ledger/early-stop.ts
@@ -34,7 +34,10 @@ export interface EarlyStopPolicy {
    * them must accumulate.
    */
   plateau_steps?: number;
-  /** Only recommend stop when last_p meets this minimum. */
+  /**
+   * Only recommend stop when last_p meets this minimum. Pass `0` to
+   * disable the p_success gate entirely (plateau alone then suffices).
+   */
   min_p_for_stop?: number;
 }
 
@@ -84,6 +87,14 @@ export function recommendEarlyStop(
   policy?: EarlyStopPolicy,
 ): EarlyStopRecommendation {
   const r = resolved(policy);
+
+  if (!Number.isFinite(summary.last_p)) {
+    return {
+      should_stop: false,
+      reason: `last_p is not finite (${summary.last_p}); refusing to recommend stop`,
+      policy: r,
+    };
+  }
 
   if (summary.last_p < r.min_p_for_stop) {
     return {

--- a/src/core/task-ledger/early-stop.ts
+++ b/src/core/task-ledger/early-stop.ts
@@ -5,8 +5,13 @@
  * whether the host should stop work even before the hard step budget
  * is exhausted. The policy targets Webwright's empirical observation
  * that "the next 50 steps deliver only 3–4 additional accuracy points"
- * — once Δp/Δstep stays below a small threshold for N consecutive
- * steps, additional spend is unlikely to move the needle.
+ * — once p_success has plateaued for N consecutive steps, additional
+ * spend is unlikely to move the needle.
+ *
+ * The plateau is detected upstream by the marginal-utility tracker
+ * (`consecutive_low_delta`, gated by the tracker's own
+ * `LOW_DELTA_THRESHOLD`); this policy only thresholds that count, so it
+ * deliberately does not re-expose a per-step delta knob it cannot honor.
  *
  * Crucially this module ONLY recommends. It does not raise, does not
  * mutate anything, and never decides on behalf of the host. The host
@@ -16,17 +21,18 @@
 
 import type { MarginalUtilitySummary } from './marginal-utility';
 
-/** Default plateau threshold: 0.02 of p_success change per step. */
-export const DEFAULT_PLATEAU_DELTA = 0.02;
 /** Default plateau length: 10 consecutive low-Δ steps. */
 export const DEFAULT_PLATEAU_STEPS = 10;
 /** Minimum p_success that must be reached before any stop recommendation. */
 export const DEFAULT_MIN_P_FOR_STOP = 0.7;
 
 export interface EarlyStopPolicy {
-  /** |delta| per step must remain below this to count as a plateau step. */
-  plateau_delta?: number;
-  /** Number of consecutive plateau steps required to recommend stop. */
+  /**
+   * Number of consecutive plateau steps required to recommend stop.
+   * A "plateau step" is decided upstream by the marginal-utility
+   * tracker (`consecutive_low_delta`); this knob only sets how many of
+   * them must accumulate.
+   */
   plateau_steps?: number;
   /** Only recommend stop when last_p meets this minimum. */
   min_p_for_stop?: number;
@@ -47,10 +53,6 @@ export interface EarlyStopRecommendation {
 
 function resolved(policy?: EarlyStopPolicy): Required<EarlyStopPolicy> {
   return {
-    plateau_delta:
-      typeof policy?.plateau_delta === 'number' && policy.plateau_delta > 0
-        ? policy.plateau_delta
-        : DEFAULT_PLATEAU_DELTA,
     plateau_steps:
       typeof policy?.plateau_steps === 'number' && policy.plateau_steps > 0
         ? Math.floor(policy.plateau_steps)

--- a/tests/core/task-ledger/early-stop.test.ts
+++ b/tests/core/task-ledger/early-stop.test.ts
@@ -2,7 +2,6 @@
  * Tests for the early-stop policy (#1428 Part 2).
  */
 import {
-  DEFAULT_PLATEAU_DELTA,
   DEFAULT_PLATEAU_STEPS,
   DEFAULT_MIN_P_FOR_STOP,
   recommendEarlyStop,
@@ -54,11 +53,10 @@ describe('recommendEarlyStop', () => {
   it('falls back to defaults on invalid policy fields', () => {
     const r = recommendEarlyStop(
       summary({ last_p: 1, consecutive_low_delta: DEFAULT_PLATEAU_STEPS }),
-      { min_p_for_stop: -1, plateau_steps: 0, plateau_delta: -2 },
+      { min_p_for_stop: -1, plateau_steps: 0 },
     );
     expect(r.policy.min_p_for_stop).toBe(DEFAULT_MIN_P_FOR_STOP);
     expect(r.policy.plateau_steps).toBe(DEFAULT_PLATEAU_STEPS);
-    expect(r.policy.plateau_delta).toBe(DEFAULT_PLATEAU_DELTA);
   });
 
   it('is pure — same input yields the same output', () => {

--- a/tests/core/task-ledger/early-stop.test.ts
+++ b/tests/core/task-ledger/early-stop.test.ts
@@ -59,6 +59,16 @@ describe('recommendEarlyStop', () => {
     expect(r.policy.plateau_steps).toBe(DEFAULT_PLATEAU_STEPS);
   });
 
+  it('refuses to recommend stop on a non-finite last_p', () => {
+    for (const bad of [NaN, Infinity, -Infinity]) {
+      const r = recommendEarlyStop(
+        summary({ last_p: bad, consecutive_low_delta: 999 }),
+      );
+      expect(r.should_stop).toBe(false);
+      expect(r.reason).toMatch(/not finite/);
+    }
+  });
+
   it('is pure — same input yields the same output', () => {
     const input = summary({ last_p: 0.9, consecutive_low_delta: 11 });
     const a = recommendEarlyStop(input);

--- a/tests/core/task-ledger/early-stop.test.ts
+++ b/tests/core/task-ledger/early-stop.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for the early-stop policy (#1428 Part 2).
+ */
+import {
+  DEFAULT_PLATEAU_DELTA,
+  DEFAULT_PLATEAU_STEPS,
+  DEFAULT_MIN_P_FOR_STOP,
+  recommendEarlyStop,
+} from '../../../src/core/task-ledger/early-stop';
+import type { MarginalUtilitySummary } from '../../../src/core/task-ledger/marginal-utility';
+
+function summary(overrides: Partial<MarginalUtilitySummary>): MarginalUtilitySummary {
+  return {
+    last_p: 0.5,
+    mean_delta_per_step: 0,
+    consecutive_low_delta: 0,
+    ...overrides,
+  };
+}
+
+describe('recommendEarlyStop', () => {
+  it('does not recommend stop while last_p is below the minimum', () => {
+    const r = recommendEarlyStop(summary({ last_p: 0.4, consecutive_low_delta: 99 }));
+    expect(r.should_stop).toBe(false);
+    expect(r.reason).toMatch(/last_p=0.400 below/);
+  });
+
+  it('does not recommend stop while the plateau has not been reached', () => {
+    const r = recommendEarlyStop(
+      summary({ last_p: 0.9, consecutive_low_delta: DEFAULT_PLATEAU_STEPS - 1 }),
+    );
+    expect(r.should_stop).toBe(false);
+    expect(r.reason).toMatch(/consecutive_low_delta=/);
+  });
+
+  it('recommends stop when both conditions hold', () => {
+    const r = recommendEarlyStop(
+      summary({ last_p: 0.95, consecutive_low_delta: DEFAULT_PLATEAU_STEPS }),
+    );
+    expect(r.should_stop).toBe(true);
+    expect(r.reason).toMatch(/plateau reached/);
+  });
+
+  it('uses explicit policy values when provided', () => {
+    const r = recommendEarlyStop(
+      summary({ last_p: 0.6, consecutive_low_delta: 3 }),
+      { min_p_for_stop: 0.5, plateau_steps: 3 },
+    );
+    expect(r.should_stop).toBe(true);
+    expect(r.policy.min_p_for_stop).toBe(0.5);
+    expect(r.policy.plateau_steps).toBe(3);
+  });
+
+  it('falls back to defaults on invalid policy fields', () => {
+    const r = recommendEarlyStop(
+      summary({ last_p: 1, consecutive_low_delta: DEFAULT_PLATEAU_STEPS }),
+      { min_p_for_stop: -1, plateau_steps: 0, plateau_delta: -2 },
+    );
+    expect(r.policy.min_p_for_stop).toBe(DEFAULT_MIN_P_FOR_STOP);
+    expect(r.policy.plateau_steps).toBe(DEFAULT_PLATEAU_STEPS);
+    expect(r.policy.plateau_delta).toBe(DEFAULT_PLATEAU_DELTA);
+  });
+
+  it('is pure — same input yields the same output', () => {
+    const input = summary({ last_p: 0.9, consecutive_low_delta: 11 });
+    const a = recommendEarlyStop(input);
+    const b = recommendEarlyStop(input);
+    expect(a).toEqual(b);
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on #1437 (Part 1).
- New `recommendEarlyStop(summary, policy?)` pure function.
- Rule: `last_p >= min_p_for_stop AND consecutive_low_delta >= plateau_steps`.
- Defaults: `min_p_for_stop=0.7`, `plateau_steps=10`.
- Refuses to recommend on a non-finite `last_p`.
- Reason string always populated for journal/dashboard visibility.

## SSOT (#1359) alignment
- Pure additive change. No tool surface, no host decision-making moved into OpenChrome — the host stays the sole authority on stopping.

## Test plan
- [x] `tests/core/task-ledger/early-stop.test.ts` — 7/7 pass.

## Review-pass changes
- Dropped the non-functional `plateau_delta` knob: the plateau is decided upstream by the marginal-utility tracker (`consecutive_low_delta`, gated by the tracker's `LOW_DELTA_THRESHOLD`), so the policy could never honor a custom `plateau_delta`.
- Added a non-finite `last_p` guard (NaN/Infinity previously bypassed the min-p comparison).

Part 2 of #1428. Depends on #1437.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>