### PR TITLE
feat(skill): add promotion state to the skill memory store

### DIFF
--- a/src/core/skill-memory/store.ts
+++ b/src/core/skill-memory/store.ts
@@ -423,6 +423,17 @@ export class SkillMemoryStore {
       if (existing?.lastReplayError !== undefined) {
         next.lastReplayError = existing.lastReplayError;
       }
+      // Preserve promotion-lifecycle fields across idempotent re-record
+      // (#1431 Part 2). The recorder owns `steps`/`contractId`; the
+      // promotion procedure (Part 3) owns the state machine. Mixing them
+      // would silently demote a `recallable` skill back to invisible.
+      if (existing?.promotionState !== undefined) {
+        next.promotionState = existing.promotionState;
+        next.promotionStateAt = existing.promotionStateAt;
+        if (existing.promotionQuarantineReason !== undefined) {
+          next.promotionQuarantineReason = existing.promotionQuarantineReason;
+        }
+      }
       file.skills[skillId] = next;
       await this.writeFile(file);
       return { skill_id: skillId, stored_at: Date.now() };
@@ -602,12 +613,17 @@ export class SkillMemoryStore {
         ...existing,
         promotionState: nextState,
         promotionStateAt: at,
-        ...(nextState === 'quarantined' && quarantineReason
-          ? { promotionQuarantineReason: quarantineReason.slice(0, 512) }
-          : nextState === 'quarantined'
-            ? {}
-            : { promotionQuarantineReason: undefined }),
       };
+      if (nextState === 'quarantined') {
+        if (quarantineReason) {
+          next.promotionQuarantineReason = quarantineReason.slice(0, 512);
+        }
+      } else {
+        // Explicit delete keeps the in-memory object consistent with the
+        // on-disk JSON; relying on `JSON.stringify` to drop an `undefined`
+        // value would survive a future serializer change.
+        delete next.promotionQuarantineReason;
+      }
       file.skills[skillId] = next;
       await this.writeFile(file);
     } finally {

--- a/src/core/skill-memory/store.ts
+++ b/src/core/skill-memory/store.ts
@@ -156,17 +156,22 @@ function assertSafeSnapshotId(snapshotId: string): void {
  *   - non-array `steps` (we leave the field undefined; callers handle).
  */
 function normaliseRecordForRead(rec: SkillRecord): SkillRecord {
-  if (!Array.isArray(rec.steps)) return { ...rec };
-  const stepCount = rec.steps.length;
-  const existing = rec.replayArtifacts;
-  if (Array.isArray(existing) && existing.length === stepCount) return rec;
+  // Default promotion state for legacy records (#1431 Part 2).
+  const withPromotion: SkillRecord =
+    rec.promotionState === undefined
+      ? { ...rec, promotionState: 'recorded' }
+      : rec;
+  if (!Array.isArray(withPromotion.steps)) return { ...withPromotion };
+  const stepCount = withPromotion.steps.length;
+  const existing = withPromotion.replayArtifacts;
+  if (Array.isArray(existing) && existing.length === stepCount) return withPromotion;
   const padded: Array<ReplayArtifact | null> = new Array(stepCount).fill(null);
   if (Array.isArray(existing)) {
     for (let i = 0; i < Math.min(existing.length, stepCount); i++) {
       padded[i] = existing[i] ?? null;
     }
   }
-  return { ...rec, replayArtifacts: padded };
+  return { ...withPromotion, replayArtifacts: padded };
 }
 
 /**
@@ -552,6 +557,56 @@ export class SkillMemoryStore {
         ...existing,
         lastUsedAt: ts,
         successCount: success ? existing.successCount + 1 : existing.successCount,
+      };
+      file.skills[skillId] = next;
+      await this.writeFile(file);
+    } finally {
+      await release();
+    }
+  }
+
+  /**
+   * Move a skill through the promotion lifecycle (#1431 Part 2).
+   *
+   *   recorded → re_verified → recallable
+   *   * → quarantined (terminal)
+   *
+   * The store enforces only the structural transitions; the host (or
+   * the Part 3 promotion procedure) decides when each transition is
+   * earned. Caller supplies `at` so the function stays deterministic
+   * under test.
+   */
+  async setPromotionState(
+    skillId: string,
+    nextState: 'recorded' | 're_verified' | 'recallable' | 'quarantined',
+    at: number,
+    quarantineReason?: string,
+  ): Promise<void> {
+    if (typeof skillId !== 'string' || skillId.length === 0) {
+      throw new Error('SkillMemoryStore.setPromotionState: skillId is required');
+    }
+    if (!Number.isFinite(at)) {
+      throw new Error('SkillMemoryStore.setPromotionState: at must be a finite number');
+    }
+    this.ensureDomainDir();
+    const release = await acquireLock(this.lockFile());
+    try {
+      const file = this.readFileSync();
+      const existing = file.skills[skillId];
+      if (!existing) {
+        throw new Error(
+          `SkillMemoryStore.setPromotionState: unknown skill_id=${skillId}`,
+        );
+      }
+      const next: SkillRecord = {
+        ...existing,
+        promotionState: nextState,
+        promotionStateAt: at,
+        ...(nextState === 'quarantined' && quarantineReason
+          ? { promotionQuarantineReason: quarantineReason.slice(0, 512) }
+          : nextState === 'quarantined'
+            ? {}
+            : { promotionQuarantineReason: undefined }),
       };
       file.skills[skillId] = next;
       await this.writeFile(file);

--- a/src/core/skill-memory/types.ts
+++ b/src/core/skill-memory/types.ts
@@ -91,6 +91,23 @@ export interface SkillRecord {
    */
   lastReplayError?: string;
 
+  /**
+   * Promotion state (#1431 Part 2). Skills move
+   *   `recorded` → `re_verified` → `recallable`
+   * and `quarantined` is a terminal exclusion state. `oc_skill_recall`
+   * filters to `re_verified` + `recallable` by default; pass
+   * `include_unpromoted: true` to see `recorded` ones, and
+   * `include_quarantined: true` to see quarantined ones.
+   *
+   * Records persisted before #1431 normalise to `recorded` on read so
+   * recall keeps its v1.x semantics unchanged unless promotion is
+   * actively in use.
+   */
+  promotionState?: 'recorded' | 're_verified' | 'recallable' | 'quarantined';
+  /** Wall-clock ms epoch of the last promotion-state transition. */
+  promotionStateAt?: number;
+  /** Truncated reason string when promotionState === 'quarantined'. */
+  promotionQuarantineReason?: string;
 }
 
 /** On-disk shape for `<rootDir>/<encodedDomain>/skills.json` (v2). */

--- a/src/tools/oc-skill-recall.ts
+++ b/src/tools/oc-skill-recall.ts
@@ -93,7 +93,11 @@ const definition: MCPToolDefinition = {
         description:
           'When true, also surface skills in promotionState=quarantined. ' +
           'Default false. Diagnostic use only — quarantined skills failed ' +
-          'a fresh-lane re-verification and should not be replayed.',
+          'a fresh-lane re-verification and should not be replayed. ' +
+          'This flag is independent of the recorded-vs-promoted filter: on a ' +
+          'domain with no promoted skills, recall is in v1.x auto-fallback ' +
+          '(recorded skills surface), so passing only include_quarantined ' +
+          'yields recorded + quarantined skills.',
       },
     },
     required: ['domain'],

--- a/src/tools/oc-skill-recall.ts
+++ b/src/tools/oc-skill-recall.ts
@@ -71,6 +71,20 @@ const definition: MCPToolDefinition = {
           `Maximum number of skills to return. Default ${DEFAULT_LIMIT}. ` +
           'Pass 0 to return an empty list. Values below 0 are treated as 0.',
       },
+      include_unpromoted: {
+        type: 'boolean',
+        description:
+          'When true, also surface skills still in promotionState=recorded. ' +
+          'Default false — recall returns only re_verified + recallable so ' +
+          'the LLM-free fast path never picks an unverified skill (#1431).',
+      },
+      include_quarantined: {
+        type: 'boolean',
+        description:
+          'When true, also surface skills in promotionState=quarantined. ' +
+          'Default false. Diagnostic use only — quarantined skills failed ' +
+          'a fresh-lane re-verification and should not be replayed.',
+      },
     },
     required: ['domain'],
   },
@@ -132,6 +146,18 @@ const handler: ToolHandler = async (
     };
     return jsonResult(output);
   }
+
+  // Promotion-state filter (#1431 Part 2). Default keeps the LLM-free
+  // fast path safe: only `re_verified` and `recallable` skills surface.
+  // Legacy records (no promotionState) normalise to `recorded` on read.
+  const includeUnpromoted = args.include_unpromoted === true;
+  const includeQuarantined = args.include_quarantined === true;
+  skills = skills.filter((s) => {
+    const state = s.promotionState ?? 'recorded';
+    if (state === 'quarantined') return includeQuarantined;
+    if (state === 'recorded') return includeUnpromoted;
+    return true;
+  });
 
   const ordered = rankedRecall
     ? rankSkillsForTask(skills, { task, contractId })

--- a/src/tools/oc-skill-recall.ts
+++ b/src/tools/oc-skill-recall.ts
@@ -24,6 +24,14 @@ export interface RankedSkillRecord extends SkillRecord {
 
 interface OcSkillRecallOutput {
   skills: RankedSkillRecord[];
+  /**
+   * True when the domain has at least one `re_verified` or `recallable` skill
+   * and the default filter applied (legacy `recorded` records were hidden).
+   * False when no promoted skills exist yet — recall falls back to v1.x
+   * semantics and surfaces all non-quarantined records so legacy callers and
+   * pre-promotion stores keep working unchanged.
+   */
+  promotion_filter_active?: boolean;
   error?: string;
 }
 
@@ -75,8 +83,10 @@ const definition: MCPToolDefinition = {
         type: 'boolean',
         description:
           'When true, also surface skills still in promotionState=recorded. ' +
-          'Default false — recall returns only re_verified + recallable so ' +
-          'the LLM-free fast path never picks an unverified skill (#1431).',
+          'Default false — once a domain has any re_verified/recallable skill ' +
+          'recall hides unpromoted ones so the LLM-free fast path stays safe. ' +
+          'Domains with no promoted skills auto-fallback to v1.x semantics ' +
+          '(all non-quarantined surface) (#1431).',
       },
       include_quarantined: {
         type: 'boolean',
@@ -147,15 +157,26 @@ const handler: ToolHandler = async (
     return jsonResult(output);
   }
 
-  // Promotion-state filter (#1431 Part 2). Default keeps the LLM-free
-  // fast path safe: only `re_verified` and `recallable` skills surface.
-  // Legacy records (no promotionState) normalise to `recorded` on read.
+  // Promotion-state filter (#1431 Part 2). Quarantined records are hidden
+  // unless `include_quarantined` is set. The `recorded` vs promoted filter
+  // auto-falls-back to v1.x semantics when no promoted skill exists in the
+  // domain — without this, every v1.x deployment that upgrades silently
+  // loses all recall results because legacy records normalise to `recorded`
+  // on read. Once at least one skill is promoted to `re_verified` or
+  // `recallable`, the filter activates and hides `recorded` ones unless
+  // `include_unpromoted` is set.
   const includeUnpromoted = args.include_unpromoted === true;
   const includeQuarantined = args.include_quarantined === true;
+  const hasPromoted = skills.some((s) => {
+    const state = s.promotionState ?? 'recorded';
+    return state === 're_verified' || state === 'recallable';
+  });
+  const promotionFilterActive = hasPromoted && !includeUnpromoted;
   skills = skills.filter((s) => {
     const state = s.promotionState ?? 'recorded';
     if (state === 'quarantined') return includeQuarantined;
-    if (state === 'recorded') return includeUnpromoted;
+    if (state === 'recorded') return !promotionFilterActive;
+    // re_verified or recallable: always surface.
     return true;
   });
 
@@ -164,7 +185,7 @@ const handler: ToolHandler = async (
     : applyRecallRanking(skills);
 
   const capped = limit === 0 ? [] : ordered.slice(0, limit);
-  return jsonResult({ skills: capped });
+  return jsonResult({ skills: capped, promotion_filter_active: promotionFilterActive });
 };
 
 export function applyRecallRanking(skills: SkillRecord[]): SkillRecord[] {

--- a/src/tools/oc-skill-recall.ts
+++ b/src/tools/oc-skill-recall.ts
@@ -82,22 +82,20 @@ const definition: MCPToolDefinition = {
       include_unpromoted: {
         type: 'boolean',
         description:
-          'When true, also surface skills still in promotionState=recorded. ' +
-          'Default false — once a domain has any re_verified/recallable skill ' +
-          'recall hides unpromoted ones so the LLM-free fast path stays safe. ' +
-          'Domains with no promoted skills auto-fallback to v1.x semantics ' +
-          '(all non-quarantined surface) (#1431).',
+          'When true, also surface promotionState=recorded skills. Default ' +
+          'false: once a domain has any re_verified/recallable skill, recall ' +
+          'hides recorded ones to keep the LLM-free fast path safe. Domains ' +
+          'with no promoted skill auto-fallback to v1.x (all non-quarantined ' +
+          'surface). (#1431)',
       },
       include_quarantined: {
         type: 'boolean',
         description:
-          'When true, also surface skills in promotionState=quarantined. ' +
-          'Default false. Diagnostic use only — quarantined skills failed ' +
-          'a fresh-lane re-verification and should not be replayed. ' +
-          'This flag is independent of the recorded-vs-promoted filter: on a ' +
-          'domain with no promoted skills, recall is in v1.x auto-fallback ' +
-          '(recorded skills surface), so passing only include_quarantined ' +
-          'yields recorded + quarantined skills.',
+          'When true, also surface promotionState=quarantined skills. Default ' +
+          'false; diagnostic only — they failed re-verification and should not ' +
+          'be replayed. Independent of the recorded/promoted filter, so on an ' +
+          'unpromoted domain (v1.x auto-fallback) it yields recorded + ' +
+          'quarantined. (#1431)',
       },
     },
     required: ['domain'],

--- a/tests/core/skill-memory/promotion-state.test.ts
+++ b/tests/core/skill-memory/promotion-state.test.ts
@@ -17,6 +17,15 @@ import {
   type SkillRecord,
 } from '../../../src/core/skill-memory';
 
+// Redirect os.homedir() to a per-test temp root. The recall tool builds its
+// own SkillMemoryStore from the default root, so a constructor rootDir on the
+// test store alone is not enough; mocking homedir covers both stores and is
+// portable (HOME on POSIX, USERPROFILE on Windows would otherwise diverge).
+jest.mock('node:os', () => {
+  const actual = jest.requireActual('node:os');
+  return { ...actual, homedir: jest.fn(() => actual.homedir()) };
+});
+
 function tempRoot(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-skill-promotion-'));
 }
@@ -40,7 +49,6 @@ function parseResult(res: { content: Array<{ type: string; text?: string }> }) {
 
 describe('skill promotion state (#1431 Part 2)', () => {
   let root: string;
-  let prevHome: string | undefined;
   let store: SkillMemoryStore;
   let server: MCPServer;
 
@@ -51,14 +59,11 @@ describe('skill promotion state (#1431 Part 2)', () => {
 
   beforeEach(() => {
     root = tempRoot();
-    prevHome = process.env.HOME;
-    process.env.HOME = root;
+    (os.homedir as jest.Mock).mockReturnValue(root);
     store = new SkillMemoryStore({ domain: 'amazon.com' });
   });
 
   afterEach(() => {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
     fs.rmSync(root, { recursive: true, force: true });
   });
 
@@ -158,5 +163,50 @@ describe('skill promotion state (#1431 Part 2)', () => {
       }),
     );
     expect(r2.skills.length).toBe(2);
+  });
+
+  it('clears promotionQuarantineReason when transitioning out of quarantine', async () => {
+    const skillId = await record('a');
+    await store.setPromotionState(skillId, 'quarantined', 1000, 'bad replay');
+    expect(store.get(skillId)?.promotionQuarantineReason).toBeDefined();
+    await store.setPromotionState(skillId, 're_verified', 2000);
+    const fetched = store.get(skillId);
+    expect(fetched?.promotionState).toBe('re_verified');
+    expect(fetched?.promotionQuarantineReason).toBeUndefined();
+  });
+
+  it('preserves promotionState across idempotent re-record', async () => {
+    const skillId = await record('a');
+    await store.setPromotionState(skillId, 'recallable', 1000);
+    await record('a'); // same domain + name → re-record
+    const fetched = store.get(skillId);
+    expect(fetched?.promotionState).toBe('recallable');
+    expect(fetched?.promotionStateAt).toBe(1000);
+  });
+
+  it('auto-fallback: surfaces unpromoted records when no skill in domain is promoted', async () => {
+    // Domain has only legacy / unpromoted records → recall keeps v1.x
+    // semantics so existing deployments do not silently lose skills.
+    await record('legacy-a');
+    await record('legacy-b');
+    const tool = getRegisteredTool(server, 'oc_skill_recall');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await (tool.handler as any)('test-session', { domain: 'amazon.com' });
+    const parsed = parseResult(res);
+    expect(parsed.skills.length).toBe(2);
+    expect(parsed.promotion_filter_active).toBe(false);
+  });
+
+  it('promotion_filter_active reports true once any skill is promoted', async () => {
+    await record('legacy');
+    const promoted = await record('shiny');
+    await store.setPromotionState(promoted, 'recallable', 1);
+    const tool = getRegisteredTool(server, 'oc_skill_recall');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await (tool.handler as any)('test-session', { domain: 'amazon.com' });
+    const parsed = parseResult(res);
+    expect(parsed.promotion_filter_active).toBe(true);
+    expect(parsed.skills).toHaveLength(1);
+    expect(parsed.skills[0].promotionState).toBe('recallable');
   });
 });

--- a/tests/core/skill-memory/promotion-state.test.ts
+++ b/tests/core/skill-memory/promotion-state.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the skill promotion state field on SkillMemoryStore
+ * (#1431 Part 2). Covers:
+ *   - records loaded from disk normalise to promotionState='recorded';
+ *   - setPromotionState rotates state and updates timestamp;
+ *   - quarantine carries a truncated reason;
+ *   - oc_skill_recall filters by promotion state with safe defaults.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { MCPServer } from '../../../src/mcp-server';
+import { registerOcSkillRecallTool } from '../../../src/tools/oc-skill-recall';
+import {
+  SkillMemoryStore,
+  type SkillRecord,
+} from '../../../src/core/skill-memory';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-skill-promotion-'));
+}
+
+function getRegisteredTool(server: MCPServer, name: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const reg = (server as any).tools as Map<string, { handler: Function }> | undefined;
+  if (!reg) throw new Error('MCPServer has no tools map');
+  const entry = reg.get(name);
+  if (!entry) throw new Error(`tool not registered: ${name}`);
+  return entry;
+}
+
+function parseResult(res: { content: Array<{ type: string; text?: string }> }) {
+  const block = res.content[0];
+  if (!block || block.type !== 'text' || typeof block.text !== 'string') {
+    throw new Error('expected text result block');
+  }
+  return JSON.parse(block.text);
+}
+
+describe('skill promotion state (#1431 Part 2)', () => {
+  let root: string;
+  let prevHome: string | undefined;
+  let store: SkillMemoryStore;
+  let server: MCPServer;
+
+  beforeAll(() => {
+    server = new MCPServer();
+    registerOcSkillRecallTool(server);
+  });
+
+  beforeEach(() => {
+    root = tempRoot();
+    prevHome = process.env.HOME;
+    process.env.HOME = root;
+    store = new SkillMemoryStore({ domain: 'amazon.com' });
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  async function record(name: string): Promise<string> {
+    const r = await store.record({
+      domain: 'amazon.com',
+      name,
+      steps: [],
+      contractId: 'contract-1',
+      successCount: 0,
+      lastUsedAt: 0,
+      frozenSnapshotPath: null,
+    } as Omit<SkillRecord, 'skillId'>);
+    return r.skill_id;
+  }
+
+  it('defaults newly-loaded records to promotionState=recorded', async () => {
+    const skillId = await record('a');
+    const fetched = store.get(skillId);
+    expect(fetched?.promotionState).toBe('recorded');
+  });
+
+  it('rotates promotionState through re_verified -> recallable', async () => {
+    const skillId = await record('a');
+    await store.setPromotionState(skillId, 're_verified', 1000);
+    expect(store.get(skillId)?.promotionState).toBe('re_verified');
+    expect(store.get(skillId)?.promotionStateAt).toBe(1000);
+
+    await store.setPromotionState(skillId, 'recallable', 2000);
+    expect(store.get(skillId)?.promotionState).toBe('recallable');
+    expect(store.get(skillId)?.promotionStateAt).toBe(2000);
+  });
+
+  it('quarantine carries a truncated reason', async () => {
+    const skillId = await record('a');
+    const reason = 'x'.repeat(800);
+    await store.setPromotionState(skillId, 'quarantined', 3000, reason);
+    const fetched = store.get(skillId);
+    expect(fetched?.promotionState).toBe('quarantined');
+    expect(fetched?.promotionQuarantineReason?.length).toBeLessThanOrEqual(512);
+  });
+
+  it('throws on unknown skill_id', async () => {
+    await expect(
+      store.setPromotionState('deadbeefdeadbeef', 'recallable', 1),
+    ).rejects.toThrow(/unknown skill_id/);
+  });
+
+  it('oc_skill_recall hides recorded skills by default', async () => {
+    await record('a'); // stays recorded
+    const promoted = await record('b');
+    await store.setPromotionState(promoted, 'recallable', 1000);
+
+    const tool = getRegisteredTool(server, 'oc_skill_recall');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await (tool.handler as any)('test-session', { domain: 'amazon.com' });
+    const parsed = parseResult(res);
+    expect(parsed.skills).toHaveLength(1);
+    expect(parsed.skills[0].promotionState).toBe('recallable');
+  });
+
+  it('oc_skill_recall surfaces recorded skills when include_unpromoted=true', async () => {
+    const skillId = await record('isolated-name-for-this-test');
+    const tool = getRegisteredTool(server, 'oc_skill_recall');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await (tool.handler as any)('test-session', {
+      domain: 'amazon.com',
+      include_unpromoted: true,
+    });
+    const parsed = parseResult(res);
+    // Locate by skill_id rather than by total count — other tests in
+    // this file may leak state if a parallel jest worker shares HOME.
+    const found = parsed.skills.find(
+      (s: { skillId: string }) => s.skillId === skillId,
+    );
+    expect(found).toBeDefined();
+    expect(found.promotionState).toBe('recorded');
+  });
+
+  it('oc_skill_recall hides quarantined skills unless include_quarantined=true', async () => {
+    const a = await record('a');
+    const b = await record('b');
+    await store.setPromotionState(a, 'recallable', 1);
+    await store.setPromotionState(b, 'quarantined', 2, 'contract failed');
+    const tool = getRegisteredTool(server, 'oc_skill_recall');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const r1 = parseResult(await (tool.handler as any)('test-session', { domain: 'amazon.com' }));
+    expect(r1.skills).toHaveLength(1);
+    expect(r1.skills[0].promotionState).toBe('recallable');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const r2 = parseResult(
+      await (tool.handler as any)('test-session', {
+        domain: 'amazon.com',
+        include_quarantined: true,
+      }),
+    );
+    expect(r2.skills.length).toBe(2);
+  });
+});

--- a/tests/core/skill-memory/promotion-state.test.ts
+++ b/tests/core/skill-memory/promotion-state.test.ts
@@ -209,4 +209,26 @@ describe('skill promotion state (#1431 Part 2)', () => {
     expect(parsed.skills).toHaveLength(1);
     expect(parsed.skills[0].promotionState).toBe('recallable');
   });
+
+  it('include_quarantined on an unpromoted domain surfaces recorded + quarantined (auto-fallback)', async () => {
+    // No skill is promoted, so recall is in v1.x auto-fallback and recorded
+    // skills surface. include_quarantined is an independent diagnostic flag, so
+    // passing it alone yields recorded + quarantined together — and the filter
+    // stays inactive because nothing is promoted.
+    const a = await record('recorded-one');
+    const q = await record('quarantined-one');
+    await store.setPromotionState(q, 'quarantined', 1, 'contract failed');
+    const tool = getRegisteredTool(server, 'oc_skill_recall');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await (tool.handler as any)('test-session', {
+      domain: 'amazon.com',
+      include_quarantined: true,
+    });
+    const parsed = parseResult(res);
+    expect(parsed.promotion_filter_active).toBe(false);
+    const states = parsed.skills
+      .map((s: { skillId: string; promotionState?: string }) => s.skillId)
+      .sort();
+    expect(states).toEqual([a, q].sort());
+  });
 });


### PR DESCRIPTION
## Summary
Stacked on #1439 (Part 1).
- New `promotionState` field on `SkillRecord`: `recorded → re_verified → recallable`, plus terminal `quarantined`.
- `SkillMemoryStore.setPromotionState(skillId, state, at, reason?)` rotates the field. Caller supplies `at` for deterministic tests.
- `oc_skill_recall` filters by promotion state with safe defaults; new flags `include_unpromoted` and `include_quarantined` for opt-in.
- Legacy records normalise to `recorded` on read — recall semantics for v1.x data unchanged unless promotion is actively used.

## SSOT (#1359) alignment
- Pure store + recall change. No host coupling.

## Test plan
- [x] `tests/core/skill-memory/promotion-state.test.ts` — 7/7 pass (defaults, rotation, quarantine truncation, unknown-id throw, three recall filter modes).

Part 2 of #1431. Depends on #1439. Part 3 (fresh-lane re-verification procedure) follows.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>