### PR TITLE
feat(skill): add fresh-lane skill promotion procedure

### DIFF
--- a/src/core/skill-memory/promote.ts
+++ b/src/core/skill-memory/promote.ts
@@ -1,0 +1,122 @@
+/**
+ * Fresh-lane skill promotion procedure (#1431 Part 3).
+ *
+ * Bridges Parts 1 (scratch-profile browser lanes) and 2 (promotion
+ * state on SkillMemoryStore) into a single host-callable routine.
+ *
+ * The procedure is deliberately dependency-injected: the production
+ * wiring will pass in a scratch-lane factory that produces a
+ * BrowserLane via `createBrowserLane({ profile: 'scratch' })` and a
+ * replay runner that drives `oc_skill_replay` against that lane. Tests
+ * pass deterministic fakes so the algorithm can be exercised without
+ * starting Chrome.
+ *
+ * Outcomes:
+ *   - replay PASS  → setPromotionState(skillId, 're_verified', now)
+ *                    and then setPromotionState(skillId, 'recallable', now)
+ *                    in the same call. The two-step rotation gives
+ *                    observers a transient `re_verified` checkpoint they
+ *                    can monitor without changing semantics.
+ *   - replay FAIL  → setPromotionState(skillId, 'quarantined', now, reason).
+ *
+ * SSOT (#1359) alignment: the procedure never calls a model. It only
+ * orchestrates the deterministic replay + contract check that already
+ * lives in oc_skill_replay (#856), in a clean profile guaranteed by
+ * Part 1 of this issue.
+ */
+import type { SkillMemoryStore } from './store';
+
+export interface PromoteSkillDeps {
+  /** Allocate a scratch lane and return an opaque handle. */
+  openScratchLane(): Promise<{ laneId: string; taskId: string }>;
+  /** Close the scratch lane (also rm-rfs its profile dir per #1431 Part 1). */
+  closeScratchLane(handle: { laneId: string; taskId: string }): Promise<void>;
+  /**
+   * Replay the recorded skill in the scratch lane and gate on its
+   * contract. PASS means both the steps and the contract held.
+   */
+  replayInLane(
+    handle: { laneId: string; taskId: string },
+    skillId: string,
+  ): Promise<{ outcome: 'PASS' | 'STEP_FAIL' | 'CONTRACT_FAIL' | 'PRECONDITION_FAIL'; reason?: string }>;
+  /** Wall-clock injection for deterministic tests. */
+  now(): number;
+  /** Optional logger; defaults to no-op. */
+  log?: (event: { stage: string; skillId: string; details?: unknown }) => void;
+}
+
+export type PromotionOutcome =
+  | { promoted: true; from: 'recorded' | 're_verified'; to: 'recallable' }
+  | { promoted: false; quarantined: true; reason: string }
+  | { promoted: false; quarantined: false; reason: string };
+
+export async function promoteSkill(
+  store: SkillMemoryStore,
+  skillId: string,
+  deps: PromoteSkillDeps,
+): Promise<PromotionOutcome> {
+  const log = deps.log ?? (() => {});
+  const existing = store.get(skillId);
+  if (!existing) {
+    return {
+      promoted: false,
+      quarantined: false,
+      reason: `unknown skill_id=${skillId}`,
+    };
+  }
+
+  // Idempotency: already promoted skills are a no-op success.
+  if (existing.promotionState === 'recallable') {
+    log({ stage: 'noop_already_recallable', skillId });
+    return { promoted: true, from: 're_verified', to: 'recallable' };
+  }
+
+  if (existing.promotionState === 'quarantined') {
+    return {
+      promoted: false,
+      quarantined: true,
+      reason: existing.promotionQuarantineReason ?? 'previously quarantined',
+    };
+  }
+
+  log({ stage: 'open_scratch_lane', skillId });
+  let lane: { laneId: string; taskId: string };
+  try {
+    lane = await deps.openScratchLane();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    log({ stage: 'open_scratch_lane_failed', skillId, details: reason });
+    // We do NOT quarantine here — infra failures are not the skill's
+    // fault. The host can retry later.
+    return { promoted: false, quarantined: false, reason: `lane_open_failed: ${reason}` };
+  }
+
+  let outcome: { outcome: string; reason?: string };
+  try {
+    log({ stage: 'replay_in_scratch_lane', skillId });
+    outcome = await deps.replayInLane(lane, skillId);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    log({ stage: 'replay_threw', skillId, details: reason });
+    await deps.closeScratchLane(lane).catch(() => {});
+    return { promoted: false, quarantined: false, reason: `replay_threw: ${reason}` };
+  }
+
+  // Always close the scratch lane.
+  await deps.closeScratchLane(lane).catch(() => {});
+
+  if (outcome.outcome !== 'PASS') {
+    const reason = `${outcome.outcome}: ${outcome.reason ?? 'no reason'}`;
+    log({ stage: 'quarantine', skillId, details: reason });
+    await store.setPromotionState(skillId, 'quarantined', deps.now(), reason);
+    return { promoted: false, quarantined: true, reason };
+  }
+
+  // PASS path: rotate through re_verified → recallable in the same call
+  // so observers always see the intermediate checkpoint at least once.
+  const ts = deps.now();
+  await store.setPromotionState(skillId, 're_verified', ts);
+  await store.setPromotionState(skillId, 'recallable', ts);
+  log({ stage: 'recallable', skillId });
+  return { promoted: true, from: 're_verified', to: 'recallable' };
+}

--- a/src/core/skill-memory/promote.ts
+++ b/src/core/skill-memory/promote.ts
@@ -46,9 +46,15 @@ export interface PromoteSkillDeps {
 }
 
 export type PromotionOutcome =
-  | { promoted: true; from: 'recorded' | 're_verified'; to: 'recallable' }
+  // `from` is the actual prior state the skill was in. Narrow the two
+  // failure variants with `r.quarantined === true`, NOT `'quarantined' in r`
+  // — both carry the field, so an `in` check is always true.
+  | { promoted: true; from: 'recorded' | 're_verified' | 'recallable'; to: 'recallable' }
   | { promoted: false; quarantined: true; reason: string }
   | { promoted: false; quarantined: false; reason: string };
+
+/** Quarantine reasons are capped to match the store's own on-disk limit. */
+const MAX_REASON_LEN = 512;
 
 export async function promoteSkill(
   store: SkillMemoryStore,
@@ -68,7 +74,7 @@ export async function promoteSkill(
   // Idempotency: already promoted skills are a no-op success.
   if (existing.promotionState === 'recallable') {
     log({ stage: 'noop_already_recallable', skillId });
-    return { promoted: true, from: 're_verified', to: 'recallable' };
+    return { promoted: true, from: 'recallable', to: 'recallable' };
   }
 
   if (existing.promotionState === 'quarantined') {
@@ -98,25 +104,48 @@ export async function promoteSkill(
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     log({ stage: 'replay_threw', skillId, details: reason });
-    await deps.closeScratchLane(lane).catch(() => {});
+    await closeLane(deps, lane, skillId, log);
     return { promoted: false, quarantined: false, reason: `replay_threw: ${reason}` };
   }
 
   // Always close the scratch lane.
-  await deps.closeScratchLane(lane).catch(() => {});
+  await closeLane(deps, lane, skillId, log);
 
   if (outcome.outcome !== 'PASS') {
-    const reason = `${outcome.outcome}: ${outcome.reason ?? 'no reason'}`;
+    const reason = capReason(`${outcome.outcome}: ${outcome.reason ?? 'no reason'}`);
     log({ stage: 'quarantine', skillId, details: reason });
     await store.setPromotionState(skillId, 'quarantined', deps.now(), reason);
     return { promoted: false, quarantined: true, reason };
   }
 
-  // PASS path: rotate through re_verified → recallable in the same call
-  // so observers always see the intermediate checkpoint at least once.
-  const ts = deps.now();
-  await store.setPromotionState(skillId, 're_verified', ts);
-  await store.setPromotionState(skillId, 'recallable', ts);
+  // PASS path: write the durable record straight to `recallable` in a single
+  // store write. The `re_verified` checkpoint is emitted as a log event for
+  // observers, not persisted — a two-write rotation could strand the skill at
+  // `re_verified` permanently if the process died between the writes.
+  const from = existing.promotionState ?? 'recorded';
+  log({ stage: 're_verified', skillId });
+  await store.setPromotionState(skillId, 'recallable', deps.now());
   log({ stage: 'recallable', skillId });
-  return { promoted: true, from: 're_verified', to: 'recallable' };
+  return { promoted: true, from, to: 'recallable' };
+}
+
+function capReason(reason: string): string {
+  return reason.length > MAX_REASON_LEN ? reason.slice(0, MAX_REASON_LEN) : reason;
+}
+
+async function closeLane(
+  deps: PromoteSkillDeps,
+  lane: { laneId: string; taskId: string },
+  skillId: string,
+  log: NonNullable<PromoteSkillDeps['log']>,
+): Promise<void> {
+  // A failed close must not change the promotion outcome, but a silent
+  // swallow hides scratch-profile/disk leaks. Surface it on the log stream.
+  await deps.closeScratchLane(lane).catch((err: unknown) => {
+    log({
+      stage: 'close_scratch_lane_failed',
+      skillId,
+      details: err instanceof Error ? err.message : String(err),
+    });
+  });
 }

--- a/src/core/skill-memory/promote.ts
+++ b/src/core/skill-memory/promote.ts
@@ -23,6 +23,16 @@
  * orchestrates the deterministic replay + contract check that already
  * lives in oc_skill_replay (#856), in a clean profile guaranteed by
  * Part 1 of this issue.
+ *
+ * Concurrency: this routine is NOT safe to run concurrently for the same
+ * `skillId`. It snapshots the skill's state, then awaits lane-open + replay
+ * (seconds), then writes the final state — `setPromotionState` performs no
+ * compare-and-swap, so a second in-flight promotion of the same skill could
+ * overwrite the first's terminal state (e.g. clobber a `quarantined` write
+ * with `recallable`). The host must serialize promotion per skill, which is
+ * the natural fit for the SSOT #1359 single-owner / per-target-queue model
+ * where one broker orchestrates promotion. Concurrent promotion of *different*
+ * skillIds is fine.
  */
 import type { SkillMemoryStore } from './store';
 
@@ -46,12 +56,16 @@ export interface PromoteSkillDeps {
 }
 
 export type PromotionOutcome =
-  // `from` is the actual prior state the skill was in. Narrow the two
-  // failure variants with `r.quarantined === true`, NOT `'quarantined' in r`
-  // — both carry the field, so an `in` check is always true.
+  // `from` is the actual prior state the skill was in.
   | { promoted: true; from: 'recorded' | 're_verified' | 'recallable'; to: 'recallable' }
-  | { promoted: false; quarantined: true; reason: string }
-  | { promoted: false; quarantined: false; reason: string };
+  // Single failure shape — `quarantined` is the discriminant, not a structural
+  // variant. true = the skill failed re-verification (STEP/CONTRACT/PRECONDITION
+  // fail) and is now quarantined; false = an infra fault (lane-open throw, replay
+  // throw, unknown skill_id) that left the skill's promotion state untouched.
+  // Narrow with `r.quarantined === true`, never `'quarantined' in r` (the field
+  // is always present). Kept as one member because two structurally identical
+  // union entries collapse to this anyway and only convey false precision.
+  | { promoted: false; quarantined: boolean; reason: string };
 
 /** Quarantine reasons are capped to match the store's own on-disk limit. */
 const MAX_REASON_LEN = 512;

--- a/tests/core/skill-memory/promote.test.ts
+++ b/tests/core/skill-memory/promote.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the fresh-lane skill promotion procedure (#1431 Part 3).
+ *
+ * The procedure is dependency-injected so we can drive every branch
+ * without launching Chrome. The fakes here implement the same contract
+ * the real wiring will: a scratch lane factory, a replay runner, and a
+ * clock.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  SkillMemoryStore,
+  type SkillRecord,
+} from '../../../src/core/skill-memory';
+import {
+  promoteSkill,
+  type PromoteSkillDeps,
+} from '../../../src/core/skill-memory/promote';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-promote-'));
+}
+
+function makeDeps(
+  override: Partial<PromoteSkillDeps> & {
+    outcome?: 'PASS' | 'STEP_FAIL' | 'CONTRACT_FAIL' | 'PRECONDITION_FAIL';
+    failOpen?: boolean;
+    throwOnReplay?: boolean;
+  } = {},
+): PromoteSkillDeps & { events: Array<{ stage: string; skillId: string }> } {
+  const events: Array<{ stage: string; skillId: string }> = [];
+  return {
+    events,
+    openScratchLane: async () => {
+      if (override.failOpen) throw new Error('lane allocation refused');
+      return { laneId: 'lane-1', taskId: 'task-1' };
+    },
+    closeScratchLane: async () => {
+      // no-op
+    },
+    replayInLane: async () => {
+      if (override.throwOnReplay) throw new Error('boom');
+      return { outcome: override.outcome ?? 'PASS' };
+    },
+    now: () => 1_000,
+    log: (e) => events.push({ stage: e.stage, skillId: e.skillId }),
+  };
+}
+
+describe('promoteSkill (#1431 Part 3)', () => {
+  let root: string;
+  let prevHome: string | undefined;
+  let store: SkillMemoryStore;
+
+  beforeEach(() => {
+    root = tempRoot();
+    prevHome = process.env.HOME;
+    process.env.HOME = root;
+    store = new SkillMemoryStore({ domain: 'amazon.com' });
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  async function recordSkill(name: string): Promise<string> {
+    const r = await store.record({
+      domain: 'amazon.com',
+      name,
+      steps: [{ kind: 'click' }],
+      contractId: 'contract-1',
+      successCount: 0,
+      lastUsedAt: 0,
+      frozenSnapshotPath: null,
+    } as Omit<SkillRecord, 'skillId'>);
+    return r.skill_id;
+  }
+
+  it('promotes recorded → recallable on a PASS replay', async () => {
+    const id = await recordSkill('a');
+    const deps = makeDeps({ outcome: 'PASS' });
+    const r = await promoteSkill(store, id, deps);
+    expect(r).toEqual({ promoted: true, from: 're_verified', to: 'recallable' });
+    expect(store.get(id)?.promotionState).toBe('recallable');
+    // Observers see the open + replay + recallable stages.
+    expect(deps.events.map((e) => e.stage)).toEqual([
+      'open_scratch_lane',
+      'replay_in_scratch_lane',
+      'recallable',
+    ]);
+  });
+
+  it('quarantines on a STEP_FAIL outcome', async () => {
+    const id = await recordSkill('a');
+    const r = await promoteSkill(store, id, makeDeps({ outcome: 'STEP_FAIL' }));
+    expect(r.promoted).toBe(false);
+    expect('quarantined' in r && r.quarantined).toBe(true);
+    expect(store.get(id)?.promotionState).toBe('quarantined');
+    expect(store.get(id)?.promotionQuarantineReason).toMatch(/STEP_FAIL/);
+  });
+
+  it('quarantines on a CONTRACT_FAIL outcome', async () => {
+    const id = await recordSkill('a');
+    const r = await promoteSkill(store, id, makeDeps({ outcome: 'CONTRACT_FAIL' }));
+    expect(r.promoted).toBe(false);
+    expect(store.get(id)?.promotionState).toBe('quarantined');
+  });
+
+  it('does NOT quarantine on lane-open failure (infra fault)', async () => {
+    const id = await recordSkill('a');
+    const r = await promoteSkill(store, id, makeDeps({ failOpen: true }));
+    expect(r.promoted).toBe(false);
+    expect('quarantined' in r && r.quarantined).toBe(false);
+    expect(store.get(id)?.promotionState).toBe('recorded');
+  });
+
+  it('does NOT quarantine when replay throws (treated as infra fault)', async () => {
+    const id = await recordSkill('a');
+    const r = await promoteSkill(store, id, makeDeps({ throwOnReplay: true }));
+    expect(r.promoted).toBe(false);
+    expect('quarantined' in r && r.quarantined).toBe(false);
+    expect(store.get(id)?.promotionState).toBe('recorded');
+  });
+
+  it('is a no-op success when the skill is already recallable', async () => {
+    const id = await recordSkill('a');
+    await store.setPromotionState(id, 'recallable', 100);
+    const deps = makeDeps({ outcome: 'STEP_FAIL' }); // would normally quarantine
+    const r = await promoteSkill(store, id, deps);
+    expect(r.promoted).toBe(true);
+    expect(deps.events.find((e) => e.stage === 'noop_already_recallable')).toBeDefined();
+    expect(store.get(id)?.promotionState).toBe('recallable');
+  });
+
+  it('refuses to re-promote a quarantined skill', async () => {
+    const id = await recordSkill('a');
+    await store.setPromotionState(id, 'quarantined', 100, 'previous run');
+    const r = await promoteSkill(store, id, makeDeps({ outcome: 'PASS' }));
+    expect(r.promoted).toBe(false);
+    if (!r.promoted && 'quarantined' in r) {
+      expect(r.quarantined).toBe(true);
+      expect(r.reason).toMatch(/previous run/);
+    }
+  });
+
+  it('returns a structured error for unknown skill_id', async () => {
+    const r = await promoteSkill(store, 'deadbeefdeadbeef', makeDeps());
+    expect(r.promoted).toBe(false);
+    if (!r.promoted && 'quarantined' in r) {
+      expect(r.quarantined).toBe(false);
+      expect(r.reason).toMatch(/unknown skill_id/);
+    }
+  });
+});

--- a/tests/core/skill-memory/promote.test.ts
+++ b/tests/core/skill-memory/promote.test.ts
@@ -51,19 +51,17 @@ function makeDeps(
 
 describe('promoteSkill (#1431 Part 3)', () => {
   let root: string;
-  let prevHome: string | undefined;
   let store: SkillMemoryStore;
 
   beforeEach(() => {
     root = tempRoot();
-    prevHome = process.env.HOME;
-    process.env.HOME = root;
-    store = new SkillMemoryStore({ domain: 'amazon.com' });
+    // Inject rootDir explicitly rather than mutating process.env.HOME:
+    // os.homedir() reads USERPROFILE (not HOME) on Windows, so the env
+    // trick would write to the real home there. The store accepts rootDir.
+    store = new SkillMemoryStore({ domain: 'amazon.com', rootDir: root });
   });
 
   afterEach(() => {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
     fs.rmSync(root, { recursive: true, force: true });
   });
 
@@ -84,12 +82,14 @@ describe('promoteSkill (#1431 Part 3)', () => {
     const id = await recordSkill('a');
     const deps = makeDeps({ outcome: 'PASS' });
     const r = await promoteSkill(store, id, deps);
-    expect(r).toEqual({ promoted: true, from: 're_verified', to: 'recallable' });
+    expect(r).toEqual({ promoted: true, from: 'recorded', to: 'recallable' });
     expect(store.get(id)?.promotionState).toBe('recallable');
-    // Observers see the open + replay + recallable stages.
+    // Observers see open + replay + the re_verified checkpoint (log-only,
+    // not persisted) + recallable.
     expect(deps.events.map((e) => e.stage)).toEqual([
       'open_scratch_lane',
       'replay_in_scratch_lane',
+      're_verified',
       'recallable',
     ]);
   });
@@ -98,7 +98,7 @@ describe('promoteSkill (#1431 Part 3)', () => {
     const id = await recordSkill('a');
     const r = await promoteSkill(store, id, makeDeps({ outcome: 'STEP_FAIL' }));
     expect(r.promoted).toBe(false);
-    expect('quarantined' in r && r.quarantined).toBe(true);
+    if (!r.promoted) expect(r.quarantined).toBe(true);
     expect(store.get(id)?.promotionState).toBe('quarantined');
     expect(store.get(id)?.promotionQuarantineReason).toMatch(/STEP_FAIL/);
   });
@@ -114,7 +114,7 @@ describe('promoteSkill (#1431 Part 3)', () => {
     const id = await recordSkill('a');
     const r = await promoteSkill(store, id, makeDeps({ failOpen: true }));
     expect(r.promoted).toBe(false);
-    expect('quarantined' in r && r.quarantined).toBe(false);
+    if (!r.promoted) expect(r.quarantined).toBe(false);
     expect(store.get(id)?.promotionState).toBe('recorded');
   });
 
@@ -122,7 +122,7 @@ describe('promoteSkill (#1431 Part 3)', () => {
     const id = await recordSkill('a');
     const r = await promoteSkill(store, id, makeDeps({ throwOnReplay: true }));
     expect(r.promoted).toBe(false);
-    expect('quarantined' in r && r.quarantined).toBe(false);
+    if (!r.promoted) expect(r.quarantined).toBe(false);
     expect(store.get(id)?.promotionState).toBe('recorded');
   });
 
@@ -141,7 +141,7 @@ describe('promoteSkill (#1431 Part 3)', () => {
     await store.setPromotionState(id, 'quarantined', 100, 'previous run');
     const r = await promoteSkill(store, id, makeDeps({ outcome: 'PASS' }));
     expect(r.promoted).toBe(false);
-    if (!r.promoted && 'quarantined' in r) {
+    if (!r.promoted) {
       expect(r.quarantined).toBe(true);
       expect(r.reason).toMatch(/previous run/);
     }
@@ -150,9 +150,31 @@ describe('promoteSkill (#1431 Part 3)', () => {
   it('returns a structured error for unknown skill_id', async () => {
     const r = await promoteSkill(store, 'deadbeefdeadbeef', makeDeps());
     expect(r.promoted).toBe(false);
-    if (!r.promoted && 'quarantined' in r) {
+    if (!r.promoted) {
       expect(r.quarantined).toBe(false);
       expect(r.reason).toMatch(/unknown skill_id/);
     }
+  });
+
+  it('caps an overlong quarantine reason in the returned outcome', async () => {
+    const id = await recordSkill('a');
+    const deps = makeDeps();
+    deps.replayInLane = async () => ({ outcome: 'CONTRACT_FAIL', reason: 'x'.repeat(900) });
+    const r = await promoteSkill(store, id, deps);
+    expect(r.promoted).toBe(false);
+    if (!r.promoted) expect(r.reason.length).toBeLessThanOrEqual(512);
+    expect(store.get(id)?.promotionQuarantineReason?.length).toBeLessThanOrEqual(512);
+  });
+
+  it('logs close_scratch_lane_failed without changing the outcome', async () => {
+    const id = await recordSkill('a');
+    const deps = makeDeps({ outcome: 'PASS' });
+    deps.closeScratchLane = async () => {
+      throw new Error('rm -rf failed');
+    };
+    const r = await promoteSkill(store, id, deps);
+    expect(r.promoted).toBe(true);
+    expect(store.get(id)?.promotionState).toBe('recallable');
+    expect(deps.events.find((e) => e.stage === 'close_scratch_lane_failed')).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
Stacked on #1447 (Part 2). Closes #1431 once stack lands.
- `promoteSkill(store, skillId, deps)`: rotates `recorded → recallable` on PASS, quarantines on STEP_FAIL/CONTRACT_FAIL/PRECONDITION_FAIL, infra-fault tolerant.
- Dependency-injected: tests cover every branch without launching Chrome. Production wiring binds `openScratchLane` to `createBrowserLane({ profile: 'scratch' })` (#1439) and `replayInLane` to `oc_skill_replay` (#856).

## SSOT (#1359) alignment
- No model calls. Pure orchestration of deterministic primitives.

## Test plan
- [x] `tests/core/skill-memory/promote.test.ts` — 8/8 pass (PASS path, two FAIL outcomes, lane-open infra fault, replay-throw infra fault, idempotent recallable, quarantined refusal, unknown id).

Part 3 of #1431. Depends on #1447 → #1439.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>