### PR TITLE
feat(benchmark): Online-Mind2Web runner shell with DI judge

### DIFF
--- a/tests/benchmark/datasets/online-mind2web/runner.test.ts
+++ b/tests/benchmark/datasets/online-mind2web/runner.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for the OM2W runner shell (#1427 Part 2).
+ *
+ * Drives the runner with deterministic fakes — no real LLM, no real
+ * browser. Validates step budget, early-stop, judge wiring.
+ */
+import {
+  runOnlineMind2WebTask,
+  fakeSentinelJudge,
+  type RunnerStep,
+  type RunnerDeps,
+} from './runner';
+import type { OnlineMind2WebTask } from './loader';
+
+function fakeTask(): OnlineMind2WebTask {
+  return {
+    task_id: 'om2w-fake-1',
+    website: 'https://example.com',
+    task_description: 'find the login link',
+    reference_length: 3,
+  };
+}
+
+function fakeStep(i: number, summary: string, ok = true): RunnerStep {
+  return { step: i, tool: 'navigate', args: { url: '/x' }, ok, summary };
+}
+
+describe('runOnlineMind2WebTask', () => {
+  it('respects the 100-step default budget when no step ever fails or completes', async () => {
+    const deps: RunnerDeps = {
+      step: async (_t, i) => fakeStep(i, 'still searching'),
+      judge: fakeSentinelJudge(),
+    };
+    const r = await runOnlineMind2WebTask(fakeTask(), deps);
+    expect(r.steps_used).toBe(100);
+    expect(r.passed).toBe(false);
+    expect(r.reason).toBe('sentinel not reached');
+    expect(r.judge_id).toBe('fake-sentinel');
+  });
+
+  it('passes when the fake judge sentinel is reached', async () => {
+    const deps: RunnerDeps = {
+      step: async (_t, i) => fakeStep(i, i === 5 ? 'navigate ok OM2W_COMPLETE' : 'navigate'),
+      judge: fakeSentinelJudge(),
+    };
+    const r = await runOnlineMind2WebTask(fakeTask(), deps, { step_budget: 20 });
+    expect(r.passed).toBe(true);
+    expect(r.steps_used).toBe(20); // sentinel doesn't short-circuit; judge runs at end
+  });
+
+  it('stops early on the first hard step failure', async () => {
+    const deps: RunnerDeps = {
+      step: async (_t, i) => fakeStep(i, 'step ok', i !== 3),
+      judge: fakeSentinelJudge(),
+    };
+    const r = await runOnlineMind2WebTask(fakeTask(), deps, { step_budget: 50 });
+    expect(r.steps_used).toBe(3);
+    expect(r.passed).toBe(false);
+  });
+
+  it('honours an explicit step_budget', async () => {
+    const deps: RunnerDeps = {
+      step: async (_t, i) => fakeStep(i, 'navigate'),
+      judge: fakeSentinelJudge(),
+    };
+    const r = await runOnlineMind2WebTask(fakeTask(), deps, { step_budget: 7 });
+    expect(r.steps_used).toBe(7);
+  });
+
+  it('respects an external shouldStop signal', async () => {
+    const deps: RunnerDeps = {
+      step: async (_t, i) => fakeStep(i, 'navigate'),
+      shouldStop: (history) => history.length >= 4,
+      judge: fakeSentinelJudge(),
+    };
+    const r = await runOnlineMind2WebTask(fakeTask(), deps, { step_budget: 50 });
+    expect(r.steps_used).toBe(4);
+  });
+
+  it('forwards the judge_id through the result', async () => {
+    const deps: RunnerDeps = {
+      step: async (_t, i) => fakeStep(i, 'navigate'),
+      judge: async () => ({ passed: true, reason: 'custom', judge_id: 'gpt-5.4' }),
+    };
+    const r = await runOnlineMind2WebTask(fakeTask(), deps, { step_budget: 3 });
+    expect(r.judge_id).toBe('gpt-5.4');
+    expect(r.passed).toBe(true);
+    expect(r.reason).toBe('custom');
+  });
+});

--- a/tests/benchmark/datasets/online-mind2web/runner.ts
+++ b/tests/benchmark/datasets/online-mind2web/runner.ts
@@ -1,0 +1,110 @@
+/**
+ * Online-Mind2Web runner + LLM-as-Judge skeleton (#1427 Part 2).
+ *
+ * Drives a benchmark adapter (OpenChrome, Playwright-MCP, browser-use,
+ * …) through a single OM2W task within a 100-step budget, captures
+ * screenshot+action evidence, and forwards the evidence to a
+ * pluggable LLM-as-Judge. The judge is dependency-injected so this
+ * file can be unit-tested without a real LLM.
+ *
+ * Production wiring will:
+ *   1. instantiate the OpenChrome adapter from `tests/benchmark/adapters/`,
+ *   2. drive it through `task.task_description` with a model-backed plan,
+ *   3. pass the captured evidence to a Claude/GPT judge prompt.
+ *
+ * This Part 2 ships the contract surface and a deterministic fake
+ * judge so the runner shape can be reviewed without committing to a
+ * specific live model or prompt.
+ */
+
+import type { OnlineMind2WebTask } from './loader';
+
+/** Per-step capture the runner accumulates. */
+export interface RunnerStep {
+  step: number;
+  tool: string;
+  args: unknown;
+  ok: boolean;
+  screenshot_ref?: string;
+  summary: string;
+}
+
+/** Final verdict the judge produces. */
+export interface JudgeVerdict {
+  passed: boolean;
+  reason: string;
+  judge_id?: string;
+}
+
+/** Dependency a host wires in to drive the actual browsing. */
+export interface RunnerDeps {
+  /** Plan and execute one step. Returns the captured tool call. */
+  step(task: OnlineMind2WebTask, stepIndex: number, history: RunnerStep[]): Promise<RunnerStep>;
+  /** Optional early-stop hook (#1428 Part 2 will eventually wire this). */
+  shouldStop?(history: RunnerStep[]): boolean;
+  /** Decide whether the task is complete (model-backed in prod). */
+  judge(task: OnlineMind2WebTask, evidence: RunnerStep[]): Promise<JudgeVerdict>;
+}
+
+export interface RunnerOptions {
+  step_budget?: number;
+}
+
+export interface RunnerResult {
+  task_id: string;
+  passed: boolean;
+  steps_used: number;
+  reason: string;
+  judge_id?: string;
+  evidence: RunnerStep[];
+}
+
+const DEFAULT_STEP_BUDGET = 100;
+
+export async function runOnlineMind2WebTask(
+  task: OnlineMind2WebTask,
+  deps: RunnerDeps,
+  options: RunnerOptions = {},
+): Promise<RunnerResult> {
+  const budget =
+    typeof options.step_budget === 'number' && options.step_budget > 0
+      ? Math.floor(options.step_budget)
+      : DEFAULT_STEP_BUDGET;
+
+  const evidence: RunnerStep[] = [];
+  for (let i = 1; i <= budget; i++) {
+    if (deps.shouldStop?.(evidence)) break;
+    const step = await deps.step(task, i, evidence);
+    evidence.push(step);
+    if (!step.ok) {
+      // Stop on the first hard failure; the judge can still rule on
+      // the partial evidence.
+      break;
+    }
+  }
+
+  const verdict = await deps.judge(task, evidence);
+  return {
+    task_id: task.task_id,
+    passed: verdict.passed,
+    steps_used: evidence.length,
+    reason: verdict.reason,
+    ...(verdict.judge_id ? { judge_id: verdict.judge_id } : {}),
+    evidence,
+  };
+}
+
+/**
+ * Deterministic fake judge used in tests and CI smoke runs. Marks a
+ * task as passed iff the evidence contains at least one tool call
+ * whose summary contains the literal "OM2W_COMPLETE" sentinel. Easy
+ * to drive from a fake step function without invoking a model.
+ */
+export function fakeSentinelJudge(): RunnerDeps['judge'] {
+  return async (_task, evidence) => {
+    const hit = evidence.find((e) => e.summary.includes('OM2W_COMPLETE'));
+    return hit
+      ? { passed: true, reason: 'sentinel reached', judge_id: 'fake-sentinel' }
+      : { passed: false, reason: 'sentinel not reached', judge_id: 'fake-sentinel' };
+  };
+}


### PR DESCRIPTION
## Summary
Stacked on #1438 (Part 1).
- `runOnlineMind2WebTask(task, deps, opts)`: drives a single OM2W task through a step budget (default 100 — matches the published OM2W reference), captures evidence per step, forwards it to a pluggable LLM-as-Judge.
- Dependency-injected so the runner shape is reviewable without committing to a specific model. Production wiring will bind step() to the OpenChrome adapter and judge() to a pinned LLM prompt.
- Deterministic fake judge (`fakeSentinelJudge`) for CI smoke runs.

## SSOT (#1359) alignment
- No model calls in the runner itself — judge is host-provided.
- Pure additive change to the benchmark tree.

## Test plan
- [x] `tests/benchmark/datasets/online-mind2web/runner.test.ts` — 6/6 pass (default budget, sentinel pass, hard-fail stop, explicit budget, external shouldStop, judge_id forwarding).

Part 2 of #1427. Depends on #1438. Part 3 (headline-gate integration) follows.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>