### PR TITLE
feat(benchmark): wire OM2W runner output into the headline gate

### DIFF
--- a/benchmark/COMPETITORS.md
+++ b/benchmark/COMPETITORS.md
@@ -35,6 +35,7 @@ they are not reproducible here. See Epic #1254 "Non-goals".
 | playwright-mcp | `@playwright/mcp` | `0.0.75` | `8116437ffcfee1309cebc07dd30cee37720d2d19` | 2026-05-15 | #A #B #F #1299-future-live |
 | browser-use | `browser-use` (PyPI) | `0.12.6` | `329c67f069427e928ff81ad52415efdca7692007` | 2026-05-15 | #A #B #D #E |
 | Crawlee | `crawlee` | `3.16.0` | `6c9cd2ff7e7d89ce7685e67f3f919f3cce0fa7a4` | 2026-05-15 | #A #C |
+| Online-Mind2Web | HuggingFace dataset `osunlp/Online-Mind2Web` (CC-BY 4.0) | dataset commit `7ab0fc3b5e0420f6a74c4e0f0faebc1f3eddb0c1` | `7ab0fc3b5e0420f6a74c4e0f0faebc1f3eddb0c1` | TBD-by-runner-PR | #B (future — Part 2 of #1427) |
 
 ## Tokenizer
 

--- a/benchmark/om2w-headline-gate.smoke.mjs
+++ b/benchmark/om2w-headline-gate.smoke.mjs
@@ -1,0 +1,64 @@
+/**
+ * End-to-end smoke: OM2W adapter output → headline gate (#1427 Part 3).
+ *
+ * The adapter `toHeadlineRow` lives in TypeScript and is unit-tested in
+ * tests/benchmark/datasets/online-mind2web/headline-eligibility.test.ts.
+ * ts-jest's CJS runtime cannot import this native-ESM gate, so this script
+ * closes the loop from the gate side: it feeds rows shaped exactly like
+ * `toHeadlineRow` emits through the real `partitionHeadlineResults` /
+ * `requireHeadlineReport` and asserts the gate accepts eligible rows and
+ * rejects ineligible ones.
+ *
+ * Run: node benchmark/om2w-headline-gate.smoke.mjs
+ */
+import assert from 'node:assert/strict';
+import { partitionHeadlineResults, requireHeadlineReport } from './headline-gate.mjs';
+
+// Shape produced by toHeadlineRow for an eligible OM2W run (step_budget=100,
+// pinned llm, non-empty evidence/reason).
+const eligibleRow = {
+  library: 'openchrome',
+  taskId: 'om2w-1',
+  measurementMode: 'live-llm',
+  finalPostconditionEvidence: 'judge marked task complete',
+  claimEligibility: { eligible: true, reasons: [], llm: 'gpt-5.4', step_budget: 100 },
+};
+
+// Shape produced by toHeadlineRow when ineligible (wrong budget / blank llm /
+// no evidence): measurementMode flips to diagnostic and reasons[] is populated.
+const diagnosticRow = {
+  library: 'openchrome',
+  taskId: 'om2w-2',
+  measurementMode: 'diagnostic',
+  finalPostconditionEvidence: 'judge marked task complete',
+  claimEligibility: {
+    eligible: false,
+    reasons: ['step_budget 50 != published reference 100'],
+    llm: 'gpt-5.4',
+    step_budget: 50,
+  },
+};
+
+// Eligible rows partition into the headline bucket.
+const onlyEligible = partitionHeadlineResults({ results: [eligibleRow] });
+assert.equal(onlyEligible.headline.length, 1, 'eligible row should be headline');
+assert.equal(onlyEligible.diagnostic.length, 0);
+
+// Diagnostic rows never reach the headline bucket.
+const mixed = partitionHeadlineResults({ results: [eligibleRow, diagnosticRow] });
+assert.equal(mixed.headline.length, 1);
+assert.equal(mixed.diagnostic.length, 1);
+assert.match(mixed.failures[0], /not headline-eligible/);
+
+// An all-eligible OM2W envelope is accepted by the fail-closed gate.
+assert.doesNotThrow(() =>
+  requireHeadlineReport({ results: [eligibleRow] }, 'OM2W live-llm report'),
+);
+
+// A diagnostic-only OM2W envelope is rejected.
+assert.throws(
+  () => requireHeadlineReport({ results: [diagnosticRow] }, 'OM2W diagnostic report'),
+  /contains no headline-eligible rows/,
+);
+
+console.log('om2w-headline-gate smoke: OK');

--- a/tests/benchmark/datasets/online-mind2web/README.md
+++ b/tests/benchmark/datasets/online-mind2web/README.md
@@ -1,0 +1,26 @@
+# Online-Mind2Web Dataset
+
+## License Attribution
+
+The Online-Mind2Web dataset used in this benchmark is sourced from the Hugging Face repository [osunlp/Online-Mind2Web](https://huggingface.co/datasets/osunlp/Online-Mind2Web) and is licensed under the [Creative Commons Attribution 4.0 International (CC-BY 4.0)](https://creativecommons.org/licenses/by/4.0/) license. The dataset was created by Ge et al. as part of the "Online-Mind2Web: A Real-World Benchmark for Web Agents" research. The fixture file `fixtures/sample-10.json` contains 10 representative tasks hand-crafted to match the published schema (`task_id`, `website`, `task_description`, `reference_length`) and is provided here solely for deterministic CI testing under the terms of the CC-BY 4.0 license, with this attribution notice constituting the required credit. The pinned dataset commit used for registry purposes is `7ab0fc3b5e0420f6a74c4e0f0faebc1f3eddb0c1`; the full 300-task dataset can be fetched at runtime by setting `OPENCHROME_OM2W_FETCH=1`.
+
+## Usage
+
+```ts
+import { loadOnlineMind2Web } from './loader';
+
+// CI-safe fixture mode (10 tasks, no network):
+const tasks = await loadOnlineMind2Web({ source: 'fixture' });
+
+// Full HF dataset (requires OPENCHROME_OM2W_FETCH=1):
+const tasks = await loadOnlineMind2Web({ source: 'hf', cacheDir: '/tmp/my-cache' });
+```
+
+## Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `task_id` | `string` | Unique task identifier |
+| `website` | `string` | Target website domain or URL |
+| `task_description` | `string` | Natural-language task description |
+| `reference_length` | `number` | Number of steps in ground-truth trajectory |

--- a/tests/benchmark/datasets/online-mind2web/fixtures/sample-10.json
+++ b/tests/benchmark/datasets/online-mind2web/fixtures/sample-10.json
@@ -1,0 +1,62 @@
+[
+  {
+    "task_id": "om2w-0001",
+    "website": "https://www.allrecipes.com",
+    "task_description": "Find a recipe for chocolate chip cookies and note the total preparation time.",
+    "reference_length": 4
+  },
+  {
+    "task_id": "om2w-0002",
+    "website": "https://www.booking.com",
+    "task_description": "Search for hotels in Paris for 2 adults checking in on 2024-06-01 and checking out on 2024-06-03.",
+    "reference_length": 6
+  },
+  {
+    "task_id": "om2w-0003",
+    "website": "https://www.amazon.com",
+    "task_description": "Search for a Kindle Paperwhite and find its current price and customer rating.",
+    "reference_length": 3
+  },
+  {
+    "task_id": "om2w-0004",
+    "website": "https://www.wikipedia.org",
+    "task_description": "Find the article about the Eiffel Tower and note the year it was completed.",
+    "reference_length": 2
+  },
+  {
+    "task_id": "om2w-0005",
+    "website": "https://www.github.com",
+    "task_description": "Navigate to the trending repositories page and find the top trending repository for today.",
+    "reference_length": 5
+  },
+  {
+    "task_id": "om2w-0006",
+    "website": "https://www.wolframalpha.com",
+    "task_description": "Calculate the integral of x^2 from 0 to 3 and record the result.",
+    "reference_length": 3
+  },
+  {
+    "task_id": "om2w-0007",
+    "website": "https://www.reddit.com",
+    "task_description": "Find the top post in the r/worldnews subreddit and note its title and score.",
+    "reference_length": 4
+  },
+  {
+    "task_id": "om2w-0008",
+    "website": "https://www.espn.com",
+    "task_description": "Find the current NBA standings and list the top 3 teams in the Eastern Conference.",
+    "reference_length": 5
+  },
+  {
+    "task_id": "om2w-0009",
+    "website": "https://www.google.com/maps",
+    "task_description": "Get directions from Times Square New York to Central Park and note the walking distance.",
+    "reference_length": 4
+  },
+  {
+    "task_id": "om2w-0010",
+    "website": "https://www.imdb.com",
+    "task_description": "Find the movie Inception and note its director, release year, and IMDb rating.",
+    "reference_length": 4
+  }
+]

--- a/tests/benchmark/datasets/online-mind2web/headline-eligibility.test.ts
+++ b/tests/benchmark/datasets/online-mind2web/headline-eligibility.test.ts
@@ -99,4 +99,41 @@ describe('OM2W headline-eligibility adapter (#1427 Part 3)', () => {
     });
     expect(row.notes).toMatch(/recorded final-postcondition/);
   });
+
+  it('rejects a row whose runner reason (postcondition evidence) is empty', () => {
+    const blank: RunnerResult = { ...passResult(), reason: '   ' };
+    const row = toHeadlineRow(blank, {
+      llm: 'gpt-5.4',
+      step_budget: OM2W_REFERENCE_STEP_BUDGET,
+    });
+    expect(row.claimEligibility.eligible).toBe(false);
+    expect(row.claimEligibility.reasons.join(' ')).toMatch(/no final-postcondition evidence/);
+    expect(row.measurementMode).toBe('diagnostic');
+  });
+
+  it('trims a whitespace-only llm out of claimEligibility.llm', () => {
+    const row = toHeadlineRow(passResult(), {
+      llm: '   ',
+      step_budget: OM2W_REFERENCE_STEP_BUDGET,
+    });
+    expect(row.claimEligibility.eligible).toBe(false);
+    expect(row.claimEligibility.llm).toBeUndefined();
+  });
+
+  it('eligible rows satisfy every invariant the headline gate reads', () => {
+    // Mirrors benchmark/headline-gate.mjs partitionHeadlineResults: an
+    // eligible row must resolve to a headline mode and carry non-empty
+    // string postcondition evidence. Locks the adapter output to the gate
+    // contract from the producer side (the .mjs gate cannot be imported
+    // from ts-jest's CJS runtime, so the end-to-end run lives in the
+    // sibling om2w-headline-gate.smoke.mjs).
+    const row = toHeadlineRow(passResult(), {
+      llm: 'gpt-5.4',
+      step_budget: OM2W_REFERENCE_STEP_BUDGET,
+    });
+    expect(row.claimEligibility.eligible).toBe(true);
+    expect(['live-llm', 'recorded-real']).toContain(row.measurementMode);
+    expect(typeof row.finalPostconditionEvidence).toBe('string');
+    expect(row.finalPostconditionEvidence.trim().length).toBeGreaterThan(0);
+  });
 });

--- a/tests/benchmark/datasets/online-mind2web/headline-eligibility.test.ts
+++ b/tests/benchmark/datasets/online-mind2web/headline-eligibility.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the OM2W → headline-gate adapter (#1427 Part 3).
+ *
+ * Validates the shape produced by `toHeadlineRow` against the
+ * documented `benchmark/headline-gate.mjs` contract:
+ *   - eligible rows carry `claimEligibility.eligible === true`,
+ *     `measurementMode === 'live-llm'`, and `finalPostconditionEvidence`;
+ *   - diagnostic rows carry an explanatory `claimEligibility.reasons[]`.
+ *
+ * The .mjs gate module itself is intentionally not invoked from this
+ * .ts test (ts-jest's CJS runtime can't resolve native ESM in this
+ * repo). A sibling smoke runbook can wire the produced envelopes
+ * through `partitionHeadlineResults` end-to-end.
+ */
+import {
+  toHeadlineRow,
+  toHeadlineEnvelope,
+  OM2W_REFERENCE_STEP_BUDGET,
+} from './headline-eligibility';
+import type { RunnerResult } from './runner';
+
+function passResult(taskId = 'om2w-1'): RunnerResult {
+  return {
+    task_id: taskId,
+    passed: true,
+    steps_used: 12,
+    reason: 'judge marked task complete',
+    judge_id: 'host-llm-judge',
+    evidence: [
+      {
+        step: 1,
+        tool: 'navigate',
+        args: { url: 'https://example.com' },
+        ok: true,
+        summary: 'navigate',
+      },
+    ],
+  };
+}
+
+describe('OM2W headline-eligibility adapter (#1427 Part 3)', () => {
+  it('marks a result eligible when step_budget matches and LLM is pinned', () => {
+    const row = toHeadlineRow(passResult(), {
+      llm: 'gpt-5.4',
+      step_budget: OM2W_REFERENCE_STEP_BUDGET,
+    });
+    expect(row.measurementMode).toBe('live-llm');
+    expect(row.claimEligibility.eligible).toBe(true);
+    expect(row.claimEligibility.reasons).toEqual([]);
+    expect(row.finalPostconditionEvidence.length).toBeGreaterThan(0);
+    expect(row.claimEligibility.llm).toBe('gpt-5.4');
+    expect(row.claimEligibility.step_budget).toBe(OM2W_REFERENCE_STEP_BUDGET);
+  });
+
+  it('rejects rows whose step_budget does not match the OM2W reference', () => {
+    const row = toHeadlineRow(passResult(), {
+      llm: 'gpt-5.4',
+      step_budget: 50,
+    });
+    expect(row.claimEligibility.eligible).toBe(false);
+    expect(row.claimEligibility.reasons.join(' ')).toMatch(/step_budget/);
+    expect(row.measurementMode).toBe('diagnostic');
+  });
+
+  it('rejects rows with no LLM id', () => {
+    const row = toHeadlineRow(passResult(), {
+      llm: '',
+      step_budget: OM2W_REFERENCE_STEP_BUDGET,
+    });
+    expect(row.claimEligibility.eligible).toBe(false);
+    expect(row.claimEligibility.reasons.join(' ')).toMatch(/llm id is required/);
+  });
+
+  it('rejects rows whose runner produced no evidence', () => {
+    const empty: RunnerResult = { ...passResult(), evidence: [] };
+    const row = toHeadlineRow(empty, {
+      llm: 'gpt-5.4',
+      step_budget: OM2W_REFERENCE_STEP_BUDGET,
+    });
+    expect(row.claimEligibility.eligible).toBe(false);
+    expect(row.claimEligibility.reasons.join(' ')).toMatch(/no evidence/);
+  });
+
+  it('accumulates rows into a single headline envelope', () => {
+    const rows = [
+      toHeadlineRow(passResult('a'), { llm: 'gpt-5.4', step_budget: OM2W_REFERENCE_STEP_BUDGET }),
+      toHeadlineRow(passResult('b'), { llm: 'gpt-5.4', step_budget: OM2W_REFERENCE_STEP_BUDGET }),
+    ];
+    const envelope = toHeadlineEnvelope(rows);
+    expect(envelope.results).toHaveLength(2);
+    expect(envelope.results.every((r) => r.claimEligibility.eligible)).toBe(true);
+  });
+
+  it('preserves diagnostic notes on rows that carry them', () => {
+    const row = toHeadlineRow(passResult(), {
+      llm: 'gpt-5.4',
+      step_budget: OM2W_REFERENCE_STEP_BUDGET,
+      note: 'recorded final-postcondition evidence: judge marked task complete',
+    });
+    expect(row.notes).toMatch(/recorded final-postcondition/);
+  });
+});

--- a/tests/benchmark/datasets/online-mind2web/headline-eligibility.ts
+++ b/tests/benchmark/datasets/online-mind2web/headline-eligibility.ts
@@ -47,18 +47,34 @@ export const OM2W_REFERENCE_STEP_BUDGET = 100;
 
 export function toHeadlineRow(result: RunnerResult, meta: OmTaskMeta): HeadlineRow {
   const reasons: string[] = [];
+  const llm = (meta.llm ?? '').trim();
   const budgetMatches = meta.step_budget === OM2W_REFERENCE_STEP_BUDGET;
   if (!budgetMatches) {
     reasons.push(
       `step_budget ${meta.step_budget} != published reference ${OM2W_REFERENCE_STEP_BUDGET}`,
     );
   }
-  if (!meta.llm || meta.llm.trim().length === 0) {
+  if (llm.length === 0) {
     reasons.push('llm id is required for OM2W headline eligibility');
   }
   if (result.evidence.length === 0) {
     reasons.push('runner produced no evidence');
   }
+  // The headline gate (benchmark/headline-gate.mjs) requires a non-empty
+  // finalPostconditionEvidence. RunnerResult.reason is typed string with no
+  // non-empty constraint, so guard here — otherwise a blank judge reason
+  // would mark the row eligible by our rules yet silently fail the upstream
+  // gate (eligible=true but partitioned to the diagnostic bucket).
+  if (result.reason.trim().length === 0) {
+    reasons.push('runner produced no final-postcondition evidence (reason is empty)');
+  }
+  // Trust boundary (SSOT P5): `meta.llm` is supplied by the caller, not
+  // derived from the run. The caller (the live-CI integration that drives
+  // the runner) is responsible for passing the model that actually backed
+  // `result.judge_id`. This adapter does not enforce a match — equal-LLM
+  // cross-checking belongs in the production wiring PR, where both the
+  // runner judge and the meta come from one pinned config. Recorded here so
+  // the assumption is explicit rather than silent.
   const eligible = reasons.length === 0;
 
   return {
@@ -69,7 +85,7 @@ export function toHeadlineRow(result: RunnerResult, meta: OmTaskMeta): HeadlineR
     claimEligibility: {
       eligible,
       reasons,
-      llm: meta.llm,
+      llm: llm.length > 0 ? llm : undefined,
       step_budget: meta.step_budget,
     },
     ...(meta.note ? { notes: meta.note } : {}),

--- a/tests/benchmark/datasets/online-mind2web/headline-eligibility.ts
+++ b/tests/benchmark/datasets/online-mind2web/headline-eligibility.ts
@@ -1,0 +1,83 @@
+/**
+ * Headline-gate adapter for OM2W runner results (#1427 Part 3).
+ *
+ * The benchmark suite already enforces a fail-closed headline gate in
+ * `benchmark/headline-gate.mjs`: only results with `claimEligibility`
+ * = true and a headline-eligible `mode` reach the published report.
+ * This module adapts a `RunnerResult` (#1427 Part 2) into the gate's
+ * input envelope and applies the OM2W-specific eligibility policy:
+ *
+ *   - Mode must be `live-llm` (real model, real browser, live web).
+ *   - Step budget must equal the published 100 for parity with the
+ *     OM2W leaderboard. Diagnostic budgets are partitioned as
+ *     diagnostic-only, not headline.
+ *   - Each row carries the LLM id under `claimEligibility.llm` so the
+ *     eventual cross-library comparison can pin equal-LLM cells.
+ */
+
+import type { RunnerResult } from './runner';
+
+export interface OmTaskMeta {
+  /** Pinned LLM identifier the runner was driven against. */
+  llm: string;
+  /** Step budget the runner was constrained to. */
+  step_budget: number;
+  /** Library name (always 'openchrome' here; competitor rows use their own). */
+  library?: string;
+  /** Diagnostic note included on dry-runs. */
+  note?: string;
+}
+
+/** Shape consumed by `partitionHeadlineResults`. */
+export interface HeadlineRow {
+  library: string;
+  taskId: string;
+  measurementMode: 'live-llm' | 'diagnostic';
+  finalPostconditionEvidence: string;
+  claimEligibility: {
+    eligible: boolean;
+    reasons: string[];
+    llm?: string;
+    step_budget?: number;
+  };
+  notes?: string;
+}
+
+export const OM2W_REFERENCE_STEP_BUDGET = 100;
+
+export function toHeadlineRow(result: RunnerResult, meta: OmTaskMeta): HeadlineRow {
+  const reasons: string[] = [];
+  const budgetMatches = meta.step_budget === OM2W_REFERENCE_STEP_BUDGET;
+  if (!budgetMatches) {
+    reasons.push(
+      `step_budget ${meta.step_budget} != published reference ${OM2W_REFERENCE_STEP_BUDGET}`,
+    );
+  }
+  if (!meta.llm || meta.llm.trim().length === 0) {
+    reasons.push('llm id is required for OM2W headline eligibility');
+  }
+  if (result.evidence.length === 0) {
+    reasons.push('runner produced no evidence');
+  }
+  const eligible = reasons.length === 0;
+
+  return {
+    library: meta.library ?? 'openchrome',
+    taskId: result.task_id,
+    measurementMode: eligible ? 'live-llm' : 'diagnostic',
+    finalPostconditionEvidence: result.reason,
+    claimEligibility: {
+      eligible,
+      reasons,
+      llm: meta.llm,
+      step_budget: meta.step_budget,
+    },
+    ...(meta.note ? { notes: meta.note } : {}),
+  };
+}
+
+export function toHeadlineEnvelope(
+  rows: HeadlineRow[],
+): { results: HeadlineRow[] } {
+  return { results: rows };
+}

--- a/tests/benchmark/datasets/online-mind2web/loader.test.ts
+++ b/tests/benchmark/datasets/online-mind2web/loader.test.ts
@@ -1,0 +1,296 @@
+/// <reference types="jest" />
+
+/**
+ * Unit tests for the Online-Mind2Web dataset loader.
+ *
+ * - Fixture happy path: loads sample-10.json, validates all 10 tasks conform to schema.
+ * - Schema rejection: malformed tasks produce a clear error.
+ * - HF fetch path: skipped unless OPENCHROME_OM2W_FETCH=1 is set, to keep CI deterministic.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { loadOnlineMind2Web, OnlineMind2WebTask } from './loader';
+
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'sample-10.json');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isValidTask(task: unknown): task is OnlineMind2WebTask {
+  if (task === null || typeof task !== 'object') return false;
+  const t = task as Record<string, unknown>;
+  return (
+    typeof t.task_id === 'string' &&
+    t.task_id.trim() !== '' &&
+    typeof t.website === 'string' &&
+    t.website.trim() !== '' &&
+    typeof t.task_description === 'string' &&
+    t.task_description.trim() !== '' &&
+    typeof t.reference_length === 'number' &&
+    Number.isInteger(t.reference_length) &&
+    t.reference_length >= 0
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Fixture happy path
+// ---------------------------------------------------------------------------
+
+describe('loadOnlineMind2Web — fixture mode', () => {
+  test('fixture file exists at expected path', () => {
+    expect(fs.existsSync(FIXTURE_PATH)).toBe(true);
+  });
+
+  test('returns exactly 10 tasks', async () => {
+    const tasks = await loadOnlineMind2Web({ source: 'fixture' });
+    expect(tasks).toHaveLength(10);
+  });
+
+  test('every task conforms to OnlineMind2WebTask schema', async () => {
+    const tasks = await loadOnlineMind2Web({ source: 'fixture' });
+    for (const task of tasks) {
+      expect(isValidTask(task)).toBe(true);
+    }
+  });
+
+  test('task_ids are unique', async () => {
+    const tasks = await loadOnlineMind2Web({ source: 'fixture' });
+    const ids = tasks.map((t) => t.task_id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+
+  test('all task_ids are non-empty strings', async () => {
+    const tasks = await loadOnlineMind2Web({ source: 'fixture' });
+    for (const task of tasks) {
+      expect(typeof task.task_id).toBe('string');
+      expect(task.task_id.trim()).not.toBe('');
+    }
+  });
+
+  test('all websites are non-empty strings', async () => {
+    const tasks = await loadOnlineMind2Web({ source: 'fixture' });
+    for (const task of tasks) {
+      expect(typeof task.website).toBe('string');
+      expect(task.website.trim()).not.toBe('');
+    }
+  });
+
+  test('all task_descriptions are non-empty strings', async () => {
+    const tasks = await loadOnlineMind2Web({ source: 'fixture' });
+    for (const task of tasks) {
+      expect(typeof task.task_description).toBe('string');
+      expect(task.task_description.trim()).not.toBe('');
+    }
+  });
+
+  test('all reference_lengths are non-negative integers', async () => {
+    const tasks = await loadOnlineMind2Web({ source: 'fixture' });
+    for (const task of tasks) {
+      expect(typeof task.reference_length).toBe('number');
+      expect(Number.isInteger(task.reference_length)).toBe(true);
+      expect(task.reference_length).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema rejection — malformed tasks throw clear errors
+// ---------------------------------------------------------------------------
+
+describe('loadOnlineMind2Web — schema validation', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'om2w-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // Schema validation is exercised via the HF cache path (pre-seeded with
+  // malformed data), since the fixture path is hard-coded to sample-10.json.
+
+  test('missing task_id throws with clear message', async () => {
+    const badTask = {
+      // task_id intentionally absent
+      website: 'https://example.com',
+      task_description: 'do something',
+      reference_length: 2,
+    };
+
+    const cacheDir = path.join(tmpDir, 'cache');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(cacheDir, 'online-mind2web-v1.json'),
+      JSON.stringify([badTask]),
+      'utf8',
+    );
+
+    const origEnv = process.env.OPENCHROME_OM2W_FETCH;
+    process.env.OPENCHROME_OM2W_FETCH = '1';
+    try {
+      await expect(loadOnlineMind2Web({ source: 'hf', cacheDir })).rejects.toThrow(
+        /task_id/,
+      );
+    } finally {
+      if (origEnv === undefined) delete process.env.OPENCHROME_OM2W_FETCH;
+      else process.env.OPENCHROME_OM2W_FETCH = origEnv;
+    }
+  });
+
+  test('missing website throws with clear message', async () => {
+    const badTask = {
+      task_id: 'om2w-bad-001',
+      // website intentionally absent
+      task_description: 'do something',
+      reference_length: 2,
+    };
+
+    const cacheDir = path.join(tmpDir, 'cache');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(cacheDir, 'online-mind2web-v1.json'),
+      JSON.stringify([badTask]),
+      'utf8',
+    );
+
+    const origEnv = process.env.OPENCHROME_OM2W_FETCH;
+    process.env.OPENCHROME_OM2W_FETCH = '1';
+    try {
+      await expect(loadOnlineMind2Web({ source: 'hf', cacheDir })).rejects.toThrow(
+        /website/,
+      );
+    } finally {
+      if (origEnv === undefined) delete process.env.OPENCHROME_OM2W_FETCH;
+      else process.env.OPENCHROME_OM2W_FETCH = origEnv;
+    }
+  });
+
+  test('non-integer reference_length throws with clear message', async () => {
+    const badTask = {
+      task_id: 'om2w-bad-002',
+      website: 'https://example.com',
+      task_description: 'do something',
+      reference_length: 'not-a-number',
+    };
+
+    const cacheDir = path.join(tmpDir, 'cache');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(cacheDir, 'online-mind2web-v1.json'),
+      JSON.stringify([badTask]),
+      'utf8',
+    );
+
+    const origEnv = process.env.OPENCHROME_OM2W_FETCH;
+    process.env.OPENCHROME_OM2W_FETCH = '1';
+    try {
+      await expect(loadOnlineMind2Web({ source: 'hf', cacheDir })).rejects.toThrow(
+        /reference_length/,
+      );
+    } finally {
+      if (origEnv === undefined) delete process.env.OPENCHROME_OM2W_FETCH;
+      else process.env.OPENCHROME_OM2W_FETCH = origEnv;
+    }
+  });
+
+  test('non-array input throws with clear message', async () => {
+    const cacheDir = path.join(tmpDir, 'cache');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(cacheDir, 'online-mind2web-v1.json'),
+      JSON.stringify({ not: 'an array' }),
+      'utf8',
+    );
+
+    const origEnv = process.env.OPENCHROME_OM2W_FETCH;
+    process.env.OPENCHROME_OM2W_FETCH = '1';
+    try {
+      await expect(loadOnlineMind2Web({ source: 'hf', cacheDir })).rejects.toThrow(
+        /expected a JSON array/i,
+      );
+    } finally {
+      if (origEnv === undefined) delete process.env.OPENCHROME_OM2W_FETCH;
+      else process.env.OPENCHROME_OM2W_FETCH = origEnv;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HF fetch path — skipped unless OPENCHROME_OM2W_FETCH=1
+// ---------------------------------------------------------------------------
+
+describe('loadOnlineMind2Web — HF fetch path', () => {
+  const HF_FETCH_ENABLED = process.env.OPENCHROME_OM2W_FETCH === '1';
+
+  (HF_FETCH_ENABLED ? test : test.skip)(
+    'fetches and returns tasks from HuggingFace (requires network + OPENCHROME_OM2W_FETCH=1)',
+    async () => {
+      const tmpCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'om2w-hf-cache-'));
+      try {
+        const tasks = await loadOnlineMind2Web({ source: 'hf', cacheDir: tmpCacheDir });
+        expect(Array.isArray(tasks)).toBe(true);
+        expect(tasks.length).toBeGreaterThan(0);
+        for (const task of tasks) {
+          expect(isValidTask(task)).toBe(true);
+        }
+        // Cache file should now exist.
+        const cachePath = path.join(tmpCacheDir, 'online-mind2web-v1.json');
+        expect(fs.existsSync(cachePath)).toBe(true);
+      } finally {
+        fs.rmSync(tmpCacheDir, { recursive: true, force: true });
+      }
+    },
+    60000, // 60s timeout for network fetch
+  );
+
+  test('throws if OPENCHROME_OM2W_FETCH is not set', async () => {
+    const origEnv = process.env.OPENCHROME_OM2W_FETCH;
+    delete process.env.OPENCHROME_OM2W_FETCH;
+    try {
+      await expect(loadOnlineMind2Web({ source: 'hf' })).rejects.toThrow(
+        /OPENCHROME_OM2W_FETCH/,
+      );
+    } finally {
+      if (origEnv !== undefined) process.env.OPENCHROME_OM2W_FETCH = origEnv;
+    }
+  });
+
+  test('serves from local cache on second call without re-fetching', async () => {
+    const tmpCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'om2w-cache-test-'));
+    try {
+      // Pre-seed a minimal valid cache.
+      const cachedTasks: OnlineMind2WebTask[] = [
+        {
+          task_id: 'om2w-cached-001',
+          website: 'https://example.com',
+          task_description: 'cached task',
+          reference_length: 1,
+        },
+      ];
+      fs.writeFileSync(
+        path.join(tmpCacheDir, 'online-mind2web-v1.json'),
+        JSON.stringify(cachedTasks),
+        'utf8',
+      );
+
+      const origEnv = process.env.OPENCHROME_OM2W_FETCH;
+      process.env.OPENCHROME_OM2W_FETCH = '1';
+      try {
+        const tasks = await loadOnlineMind2Web({ source: 'hf', cacheDir: tmpCacheDir });
+        expect(tasks).toHaveLength(1);
+        expect(tasks[0].task_id).toBe('om2w-cached-001');
+      } finally {
+        if (origEnv === undefined) delete process.env.OPENCHROME_OM2W_FETCH;
+        else process.env.OPENCHROME_OM2W_FETCH = origEnv;
+      }
+    } finally {
+      fs.rmSync(tmpCacheDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/benchmark/datasets/online-mind2web/loader.ts
+++ b/tests/benchmark/datasets/online-mind2web/loader.ts
@@ -1,0 +1,210 @@
+/**
+ * Dataset loader for the Online-Mind2Web benchmark.
+ *
+ * Dataset: osunlp/Online-Mind2Web
+ * Source:  https://huggingface.co/datasets/osunlp/Online-Mind2Web
+ * License: Creative Commons Attribution 4.0 International (CC-BY 4.0)
+ *          https://creativecommons.org/licenses/by/4.0/
+ *
+ * Citation:
+ *   Ge, Y., et al. "Online-Mind2Web: A Real-World Benchmark for Web Agents."
+ *   Pinned dataset commit: 7ab0fc3b5e0420f6a74c4e0f0faebc1f3eddb0c1
+ *   (commit hash sourced from HF dataset repository, 2025-05-28)
+ *
+ * Usage:
+ *   - fixture mode: reads from the bundled sample-10.json (CI-safe, no network).
+ *   - hf mode: lazy-fetches from the HuggingFace Datasets HTTP API and caches
+ *     the result locally. Requires `OPENCHROME_OM2W_FETCH=1` to be set so that
+ *     CI remains deterministic and does not depend on external network access.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as https from 'https';
+
+/** Schema matching the HuggingFace osunlp/Online-Mind2Web dataset card. */
+export interface OnlineMind2WebTask {
+  /** Unique task identifier (e.g. "om2w-0001"). */
+  task_id: string;
+  /** The target website domain or URL. */
+  website: string;
+  /** Natural-language description of the task to complete. */
+  task_description: string;
+  /** Number of reference steps in the ground-truth trajectory. */
+  reference_length: number;
+}
+
+export interface LoadOnlineMind2WebOptions {
+  /** Data source: 'fixture' reads the bundled sample-10.json; 'hf' fetches from HuggingFace. */
+  source: 'hf' | 'fixture';
+  /**
+   * Directory to cache the fetched JSON when source='hf'.
+   * Defaults to `~/.cache/openchrome-benchmarks`.
+   */
+  cacheDir?: string;
+}
+
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'sample-10.json');
+
+/** HuggingFace Datasets API endpoint for the parquet export of the test split. */
+const HF_API_URL =
+  'https://datasets-server.huggingface.co/rows?dataset=osunlp%2FOnline-Mind2Web&config=default&split=test&offset=0&length=300';
+
+const CACHE_FILENAME = 'online-mind2web-v1.json';
+
+/**
+ * Validate that a parsed object conforms to OnlineMind2WebTask.
+ * Throws a descriptive error if any required field is missing or wrong-typed.
+ */
+function validateTask(raw: unknown, index: number): OnlineMind2WebTask {
+  if (raw === null || typeof raw !== 'object') {
+    throw new Error(`Online-Mind2Web: task at index ${index} is not an object (got ${typeof raw})`);
+  }
+  const obj = raw as Record<string, unknown>;
+
+  if (typeof obj.task_id !== 'string' || obj.task_id.trim() === '') {
+    throw new Error(
+      `Online-Mind2Web: task at index ${index} has invalid task_id (expected non-empty string, got ${JSON.stringify(obj.task_id)})`,
+    );
+  }
+  if (typeof obj.website !== 'string' || obj.website.trim() === '') {
+    throw new Error(
+      `Online-Mind2Web: task at index ${index} has invalid website (expected non-empty string, got ${JSON.stringify(obj.website)})`,
+    );
+  }
+  if (typeof obj.task_description !== 'string' || obj.task_description.trim() === '') {
+    throw new Error(
+      `Online-Mind2Web: task at index ${index} has invalid task_description (expected non-empty string, got ${JSON.stringify(obj.task_description)})`,
+    );
+  }
+  if (typeof obj.reference_length !== 'number' || !Number.isInteger(obj.reference_length) || obj.reference_length < 0) {
+    throw new Error(
+      `Online-Mind2Web: task at index ${index} has invalid reference_length (expected non-negative integer, got ${JSON.stringify(obj.reference_length)})`,
+    );
+  }
+
+  return {
+    task_id: obj.task_id,
+    website: obj.website,
+    task_description: obj.task_description,
+    reference_length: obj.reference_length,
+  };
+}
+
+function validateTaskArray(raw: unknown): OnlineMind2WebTask[] {
+  if (!Array.isArray(raw)) {
+    throw new Error(
+      `Online-Mind2Web: expected a JSON array of tasks, got ${typeof raw}`,
+    );
+  }
+  return raw.map((item, i) => validateTask(item, i));
+}
+
+function defaultCacheDir(): string {
+  return path.join(os.homedir(), '.cache', 'openchrome-benchmarks');
+}
+
+function fetchUrl(url: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (res) => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`Online-Mind2Web HF fetch failed: HTTP ${res.statusCode}`));
+          res.resume();
+          return;
+        }
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+        res.on('error', reject);
+      })
+      .on('error', reject);
+  });
+}
+
+/**
+ * The HF datasets-server API returns rows wrapped in `{ rows: [{ row: {...} }] }`.
+ * Extract the inner row objects and validate them.
+ */
+function parseHFApiResponse(body: string): OnlineMind2WebTask[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch (err) {
+    throw new Error(`Online-Mind2Web: HF API response is not valid JSON: ${(err as Error).message}`);
+  }
+
+  // HF datasets-server wraps rows: { rows: Array<{ row: OnlineMind2WebTask }> }
+  if (
+    parsed !== null &&
+    typeof parsed === 'object' &&
+    'rows' in (parsed as Record<string, unknown>)
+  ) {
+    const wrapper = parsed as { rows: Array<{ row: unknown }> };
+    if (Array.isArray(wrapper.rows)) {
+      const items = wrapper.rows.map((r) => (r && typeof r === 'object' ? r.row : r));
+      return validateTaskArray(items);
+    }
+  }
+
+  // Fallback: treat response as a bare array.
+  return validateTaskArray(parsed);
+}
+
+async function loadFromHF(cacheDir: string): Promise<OnlineMind2WebTask[]> {
+  if (!process.env.OPENCHROME_OM2W_FETCH) {
+    throw new Error(
+      'Online-Mind2Web HF fetch is disabled. Set OPENCHROME_OM2W_FETCH=1 to enable network access. ' +
+        'Use source="fixture" for CI-safe deterministic loading.',
+    );
+  }
+
+  const cachePath = path.join(cacheDir, CACHE_FILENAME);
+
+  // Return cached data if it already exists.
+  if (fs.existsSync(cachePath)) {
+    const raw = JSON.parse(fs.readFileSync(cachePath, 'utf8')) as unknown;
+    return validateTaskArray(raw);
+  }
+
+  // Fetch from HuggingFace.
+  const body = await fetchUrl(HF_API_URL);
+  const tasks = parseHFApiResponse(body);
+
+  // Cache for subsequent calls.
+  fs.mkdirSync(cacheDir, { recursive: true });
+  fs.writeFileSync(cachePath, JSON.stringify(tasks, null, 2), 'utf8');
+
+  return tasks;
+}
+
+function loadFromFixture(): OnlineMind2WebTask[] {
+  if (!fs.existsSync(FIXTURE_PATH)) {
+    throw new Error(
+      `Online-Mind2Web: fixture file not found at ${FIXTURE_PATH}. ` +
+        'Ensure tests/benchmark/datasets/online-mind2web/fixtures/sample-10.json exists.',
+    );
+  }
+  const raw = JSON.parse(fs.readFileSync(FIXTURE_PATH, 'utf8')) as unknown;
+  return validateTaskArray(raw);
+}
+
+/**
+ * Load Online-Mind2Web tasks.
+ *
+ * @param options.source   'fixture' for CI-safe deterministic loading from the
+ *                         bundled sample; 'hf' for lazy-fetch from HuggingFace
+ *                         (requires `OPENCHROME_OM2W_FETCH=1`).
+ * @param options.cacheDir Override the local cache directory used in 'hf' mode.
+ */
+export async function loadOnlineMind2Web(
+  options: LoadOnlineMind2WebOptions,
+): Promise<OnlineMind2WebTask[]> {
+  if (options.source === 'fixture') {
+    return loadFromFixture();
+  }
+
+  const cacheDir = options.cacheDir ?? defaultCacheDir();
+  return loadFromHF(cacheDir);
+}

--- a/tests/benchmark/datasets/online-mind2web/runner.test.ts
+++ b/tests/benchmark/datasets/online-mind2web/runner.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for the OM2W runner shell (#1427 Part 2).
+ *
+ * Drives the runner with deterministic fakes — no real LLM, no real
+ * browser. Validates step budget, early-stop, judge wiring.
+ */
+import {
+  runOnlineMind2WebTask,
+  fakeSentinelJudge,
+  type RunnerStep,
+  type RunnerDeps,
+} from './runner';
+import type { OnlineMind2WebTask } from './loader';
+
+function fakeTask(): OnlineMind2WebTask {
+  return {
+    task_id: 'om2w-fake-1',
+    website: 'https://example.com',
+    task_description: 'find the login link',
+    reference_length: 3,
+  };
+}
+
+function fakeStep(i: number, summary: string, ok = true): RunnerStep {
+  return { step: i, tool: 'navigate', args: { url: '/x' }, ok, summary };
+}
+
+describe('runOnlineMind2WebTask', () => {
+  it('respects the 100-step default budget when no step ever fails or completes', async () => {
+    const deps: RunnerDeps = {
+      step: async (_t, i) => fakeStep(i, 'still searching'),
+      judge: fakeSentinelJudge(),
+    };
+    const r = await runOnlineMind2WebTask(fakeTask(), deps);
+    expect(r.steps_used).toBe(100);
+    expect(r.passed).toBe(false);
+    expect(r.reason).toBe('sentinel not reached');
+    expect(r.judge_id).toBe('fake-sentinel');
+  });
+
+  it('passes when the fake judge sentinel is reached', async () => {
+    const deps: RunnerDeps = {
+      step: async (_t, i) => fakeStep(i, i === 5 ? 'navigate ok OM2W_COMPLETE' : 'navigate'),
+      judge: fakeSentinelJudge(),
+    };
+    const r = await runOnlineMind2WebTask(fakeTask(), deps, { step_budget: 20 });
+    expect(r.passed).toBe(true);
+    expect(r.steps_used).toBe(20); // sentinel doesn't short-circuit; judge runs at end
+  });
+
+  it('stops early on the first hard step failure', async () => {
+    const deps: RunnerDeps = {
+      step: async (_t, i) => fakeStep(i, 'step ok', i !== 3),
+      judge: fakeSentinelJudge(),
+    };
+    const r = await runOnlineMind2WebTask(fakeTask(), deps, { step_budget: 50 });
+    expect(r.steps_used).toBe(3);
+    expect(r.passed).toBe(false);
+  });
+
+  it('honours an explicit step_budget', async () => {
+    const deps: RunnerDeps = {
+      step: async (_t, i) => fakeStep(i, 'navigate'),
+      judge: fakeSentinelJudge(),
+    };
+    const r = await runOnlineMind2WebTask(fakeTask(), deps, { step_budget: 7 });
+    expect(r.steps_used).toBe(7);
+  });
+
+  it('respects an external shouldStop signal', async () => {
+    const deps: RunnerDeps = {
+      step: async (_t, i) => fakeStep(i, 'navigate'),
+      shouldStop: (history) => history.length >= 4,
+      judge: fakeSentinelJudge(),
+    };
+    const r = await runOnlineMind2WebTask(fakeTask(), deps, { step_budget: 50 });
+    expect(r.steps_used).toBe(4);
+  });
+
+  it('forwards the judge_id through the result', async () => {
+    const deps: RunnerDeps = {
+      step: async (_t, i) => fakeStep(i, 'navigate'),
+      judge: async () => ({ passed: true, reason: 'custom', judge_id: 'gpt-5.4' }),
+    };
+    const r = await runOnlineMind2WebTask(fakeTask(), deps, { step_budget: 3 });
+    expect(r.judge_id).toBe('gpt-5.4');
+    expect(r.passed).toBe(true);
+    expect(r.reason).toBe('custom');
+  });
+});

--- a/tests/benchmark/datasets/online-mind2web/runner.ts
+++ b/tests/benchmark/datasets/online-mind2web/runner.ts
@@ -1,0 +1,110 @@
+/**
+ * Online-Mind2Web runner + LLM-as-Judge skeleton (#1427 Part 2).
+ *
+ * Drives a benchmark adapter (OpenChrome, Playwright-MCP, browser-use,
+ * …) through a single OM2W task within a 100-step budget, captures
+ * screenshot+action evidence, and forwards the evidence to a
+ * pluggable LLM-as-Judge. The judge is dependency-injected so this
+ * file can be unit-tested without a real LLM.
+ *
+ * Production wiring will:
+ *   1. instantiate the OpenChrome adapter from `tests/benchmark/adapters/`,
+ *   2. drive it through `task.task_description` with a model-backed plan,
+ *   3. pass the captured evidence to a Claude/GPT judge prompt.
+ *
+ * This Part 2 ships the contract surface and a deterministic fake
+ * judge so the runner shape can be reviewed without committing to a
+ * specific live model or prompt.
+ */
+
+import type { OnlineMind2WebTask } from './loader';
+
+/** Per-step capture the runner accumulates. */
+export interface RunnerStep {
+  step: number;
+  tool: string;
+  args: unknown;
+  ok: boolean;
+  screenshot_ref?: string;
+  summary: string;
+}
+
+/** Final verdict the judge produces. */
+export interface JudgeVerdict {
+  passed: boolean;
+  reason: string;
+  judge_id?: string;
+}
+
+/** Dependency a host wires in to drive the actual browsing. */
+export interface RunnerDeps {
+  /** Plan and execute one step. Returns the captured tool call. */
+  step(task: OnlineMind2WebTask, stepIndex: number, history: RunnerStep[]): Promise<RunnerStep>;
+  /** Optional early-stop hook (#1428 Part 2 will eventually wire this). */
+  shouldStop?(history: RunnerStep[]): boolean;
+  /** Decide whether the task is complete (model-backed in prod). */
+  judge(task: OnlineMind2WebTask, evidence: RunnerStep[]): Promise<JudgeVerdict>;
+}
+
+export interface RunnerOptions {
+  step_budget?: number;
+}
+
+export interface RunnerResult {
+  task_id: string;
+  passed: boolean;
+  steps_used: number;
+  reason: string;
+  judge_id?: string;
+  evidence: RunnerStep[];
+}
+
+const DEFAULT_STEP_BUDGET = 100;
+
+export async function runOnlineMind2WebTask(
+  task: OnlineMind2WebTask,
+  deps: RunnerDeps,
+  options: RunnerOptions = {},
+): Promise<RunnerResult> {
+  const budget =
+    typeof options.step_budget === 'number' && options.step_budget > 0
+      ? Math.floor(options.step_budget)
+      : DEFAULT_STEP_BUDGET;
+
+  const evidence: RunnerStep[] = [];
+  for (let i = 1; i <= budget; i++) {
+    if (deps.shouldStop?.(evidence)) break;
+    const step = await deps.step(task, i, evidence);
+    evidence.push(step);
+    if (!step.ok) {
+      // Stop on the first hard failure; the judge can still rule on
+      // the partial evidence.
+      break;
+    }
+  }
+
+  const verdict = await deps.judge(task, evidence);
+  return {
+    task_id: task.task_id,
+    passed: verdict.passed,
+    steps_used: evidence.length,
+    reason: verdict.reason,
+    ...(verdict.judge_id ? { judge_id: verdict.judge_id } : {}),
+    evidence,
+  };
+}
+
+/**
+ * Deterministic fake judge used in tests and CI smoke runs. Marks a
+ * task as passed iff the evidence contains at least one tool call
+ * whose summary contains the literal "OM2W_COMPLETE" sentinel. Easy
+ * to drive from a fake step function without invoking a model.
+ */
+export function fakeSentinelJudge(): RunnerDeps['judge'] {
+  return async (_task, evidence) => {
+    const hit = evidence.find((e) => e.summary.includes('OM2W_COMPLETE'));
+    return hit
+      ? { passed: true, reason: 'sentinel reached', judge_id: 'fake-sentinel' }
+      : { passed: false, reason: 'sentinel not reached', judge_id: 'fake-sentinel' };
+  };
+}


### PR DESCRIPTION
## Summary
Stacked on #1449 (Part 2). Closes #1427 once stack lands.
- `toHeadlineRow(runnerResult, meta)`: adapts an OM2W `RunnerResult` to the envelope shape consumed by `benchmark/headline-gate.mjs` (existing #1310/#1424 gate).
- Enforces OM2W-specific eligibility: step_budget MUST equal 100, llm id pinned, evidence non-empty.
- Ineligible rows partition as `measurementMode='diagnostic'`; eligible rows go to `measurementMode='live-llm'`.

## SSOT (#1359) alignment
- Adapter-only. Reuses the existing fail-closed headline gate; no policy bypass.

## Test plan
- [x] 6/6 unit tests pass.

Part 3 of #1427. Depends on #1449 → #1438.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>