### PR TITLE
feat(harness): wire marginal-utility tracker into task ledger

### DIFF
--- a/src/core/task-ledger/budget.ts
+++ b/src/core/task-ledger/budget.ts
@@ -8,6 +8,12 @@ import type {
   TaskPhase,
   TaskRecentEvent,
 } from './types';
+import {
+  initialMarginalUtilityState,
+  recordStep,
+  type MarginalUtilityState,
+  type StepSignals,
+} from './marginal-utility';
 
 const DEFAULT_MAX_CONSECUTIVE_SAME_TOOL = 5;
 const DEFAULT_MAX_OBSERVATION_STREAK = 6;
@@ -80,6 +86,9 @@ export function initialCounters(): TaskCounters {
   };
 }
 
+/** Hard cap on cost_curve entries to bound TaskMeta growth. */
+const COST_CURVE_MAX_ENTRIES = 500;
+
 export function applyToolCallToTask(meta: TaskMeta, call: RecordedToolCall): TaskMeta {
   const policy = normalizeTaskPolicy(meta.policy);
   const current = meta.counters ?? initialCounters();
@@ -117,6 +126,35 @@ export function applyToolCallToTask(meta: TaskMeta, call: RecordedToolCall): Tas
   };
   const recent_events = [...(meta.recent_events ?? []), recentEvent].slice(-RECENT_EVENT_LIMIT);
 
+  // Marginal-utility tracker (#1428 Parts 1+2 wire-up). Each tool call
+  // becomes one tracker step. Signals are derived from the recorded
+  // call: oc_assert pass/fail counts come straight from the assertion
+  // tool's ok bit, checkpointAdvanced from oc_checkpoint, toolOk from
+  // the call itself. We never read the assert verdict body — the
+  // budget ledger does not see tool result payloads.
+  const muSignals: StepSignals = {
+    ts: call.ts,
+    toolOk: call.ok,
+    assertPasses: call.tool === 'oc_assert' && call.ok ? 1 : 0,
+    assertFails: call.tool === 'oc_assert' && !call.ok ? 1 : 0,
+    assertInconclusives: 0,
+    checkpointAdvanced: call.tool === 'oc_checkpoint' && call.ok,
+  };
+  const prevMuState: MarginalUtilityState =
+    meta._mu_state !== undefined
+      ? {
+          totalSteps: meta._mu_state.totalSteps,
+          window: meta._mu_state.window.map((w) => ({ ...w })),
+          lastP: meta._mu_state.lastP,
+        }
+      : initialMarginalUtilityState();
+  const nextMuState = recordStep(prevMuState, muSignals);
+  const latestStep = nextMuState.window[nextMuState.window.length - 1];
+  const cost_curve = [
+    ...(meta.cost_curve ?? []),
+    { step: latestStep.step, p: latestStep.p, delta: latestStep.delta },
+  ].slice(-COST_CURVE_MAX_ENTRIES);
+
   return {
     ...meta,
     phase: normalizeTaskPhase(meta.phase),
@@ -128,6 +166,8 @@ export function applyToolCallToTask(meta: TaskMeta, call: RecordedToolCall): Tas
     recent_events,
     last_tool_name: call.tool,
     last_activity_at: call.ts,
+    cost_curve,
+    _mu_state: nextMuState,
   };
 }
 

--- a/tests/core/task-ledger/marginal-utility-wireup.test.ts
+++ b/tests/core/task-ledger/marginal-utility-wireup.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for marginal-utility tracker wire-up into applyToolCallToTask
+ * (#1428 wire-up follow-up).
+ *
+ * These tests pin the contract that every tool call appends a
+ * cost_curve entry and that oc_assert / oc_checkpoint signals move
+ * p_success deterministically.
+ */
+import { applyToolCallToTask, initialCounters } from '../../../src/core/task-ledger';
+import type { TaskMeta, RecordedToolCall } from '../../../src/core/task-ledger';
+
+function makeMeta(overrides: Partial<TaskMeta> = {}): TaskMeta {
+  return {
+    task_id: 'a'.repeat(16),
+    kind: 'browser',
+    status: 'in_progress',
+    pid: 1,
+    created_at: 0,
+    args_summary: {},
+    counters: initialCounters(),
+    ...overrides,
+  } as TaskMeta;
+}
+
+function call(overrides: Partial<RecordedToolCall> = {}): RecordedToolCall {
+  return {
+    ts: 1_700_000_000,
+    tool: 'read_page',
+    sessionId: 's',
+    args: {},
+    durationMs: 10,
+    ok: true,
+    ...overrides,
+  };
+}
+
+describe('applyToolCallToTask — marginal-utility wire-up (#1428)', () => {
+  it('appends one cost_curve entry per tool call', () => {
+    let meta = makeMeta();
+    expect(meta.cost_curve ?? []).toEqual([]);
+    meta = applyToolCallToTask(meta, call({ ts: 1 }));
+    expect(meta.cost_curve).toHaveLength(1);
+    expect(meta.cost_curve![0].step).toBe(1);
+    meta = applyToolCallToTask(meta, call({ ts: 2 }));
+    expect(meta.cost_curve).toHaveLength(2);
+    expect(meta.cost_curve![1].step).toBe(2);
+  });
+
+  it('persists _mu_state between calls', () => {
+    let meta = makeMeta();
+    meta = applyToolCallToTask(meta, call({ ts: 1 }));
+    expect(meta._mu_state).toBeDefined();
+    expect(meta._mu_state!.totalSteps).toBe(1);
+    meta = applyToolCallToTask(meta, call({ ts: 2 }));
+    expect(meta._mu_state!.totalSteps).toBe(2);
+  });
+
+  it('counts an oc_assert success as a positive assert signal', () => {
+    let meta = makeMeta();
+    // Two read_page calls to establish a baseline.
+    meta = applyToolCallToTask(meta, call({ ts: 1 }));
+    meta = applyToolCallToTask(meta, call({ ts: 2 }));
+    const baseP = meta._mu_state!.lastP;
+    meta = applyToolCallToTask(meta, call({ ts: 3, tool: 'oc_assert', ok: true }));
+    // oc_assert pass = strict 1.0 contribution → p_success increases.
+    expect(meta._mu_state!.lastP).toBeGreaterThan(baseP);
+  });
+
+  it('counts an oc_assert failure as a negative assert signal', () => {
+    let meta = makeMeta();
+    meta = applyToolCallToTask(meta, call({ ts: 1, tool: 'oc_assert', ok: true }));
+    const peak = meta._mu_state!.lastP;
+    meta = applyToolCallToTask(meta, call({ ts: 2, tool: 'oc_assert', ok: false }));
+    expect(meta._mu_state!.lastP).toBeLessThan(peak);
+    expect(meta.cost_curve![1].delta).toBeLessThan(0);
+  });
+
+  it('treats oc_checkpoint success as a checkpoint advance', () => {
+    let meta = makeMeta();
+    meta = applyToolCallToTask(meta, call({ ts: 1, tool: 'navigate' }));
+    const baseP = meta._mu_state!.lastP;
+    meta = applyToolCallToTask(meta, call({ ts: 2, tool: 'oc_checkpoint', ok: true }));
+    expect(meta._mu_state!.lastP).toBeGreaterThan(baseP);
+  });
+
+  it('caps cost_curve at COST_CURVE_MAX_ENTRIES (500) to bound TaskMeta growth', () => {
+    let meta = makeMeta();
+    for (let i = 0; i < 600; i++) {
+      meta = applyToolCallToTask(meta, call({ ts: i }));
+    }
+    expect(meta.cost_curve!.length).toBe(500);
+    // Newest survive, oldest evicted.
+    expect(meta.cost_curve![meta.cost_curve!.length - 1].step).toBe(600);
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on #1446. Completes the wire-up promised in the original #1428-A brief that was deferred from PR #1437.
- `applyToolCallToTask` now calls `recordStep()` on every tool call.
- `TaskMeta.cost_curve` is appended on each step (capped at 500 entries).
- `TaskMeta._mu_state` persists the sliding window across calls.
- Signals: tool ok, oc_assert pass/fail (from call.ok), oc_checkpoint advance.

## Why this is a fix not a feature
PR #1437 added the tracker module and the cost_curve field but no caller invoked it. Every downstream consumer (#1446 early-stop policy, future cost-curve report) was dead code without this. Calling out as a fix to the original Part 1 commitment.

## SSOT (#1359) alignment
- Pure server-side derivation. No host coupling, no model.
- Bounded growth: cost_curve cap = 500 entries.

## Test plan
- [x] `tests/core/task-ledger/marginal-utility-wireup.test.ts` — 6/6 pass.
- [x] `tests/core/task-ledger/budget.test.ts` — 11/11 still pass (no regression).

Stacked on #1446 → #1437.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>