### PR TITLE
feat(contracts): inject imageQaSample hook into oc_assert runtime

### DIFF
--- a/src/contracts/evaluators/image-qa.ts
+++ b/src/contracts/evaluators/image-qa.ts
@@ -10,6 +10,7 @@
  */
 import type { EvalContext } from '../eval-context';
 import type { EvaluationResult, ImageQaAssertion } from '../types';
+import { compileSafeRegex } from '../safe-regex';
 
 export async function evaluateImageQa(
   assertion: ImageQaAssertion,
@@ -22,6 +23,10 @@ export async function evaluateImageQa(
         passed: false,
         assertion_kind: 'image_qa',
         details: {
+          // `error` flips oc_assert verdict translation to inconclusive
+          // (not fail) — runtime wiring problems are not contract
+          // failures, they prevent evaluation entirely.
+          error: 'host_runtime_did_not_wire_imageQaSample',
           reason: 'host_runtime_did_not_wire_imageQaSample',
           question: assertion.question,
         },
@@ -37,6 +42,7 @@ export async function evaluateImageQa(
         passed: false,
         assertion_kind: 'image_qa',
         details: {
+          error: 'no_screenshot_available',
           reason: 'no_screenshot_available',
           question: assertion.question,
         },
@@ -56,6 +62,7 @@ export async function evaluateImageQa(
         passed: false,
         assertion_kind: 'image_qa',
         details: {
+          error: 'unsupported_by_host',
           reason: 'unsupported_by_host',
           host_reason: reply.reason,
           question: assertion.question,
@@ -64,9 +71,13 @@ export async function evaluateImageQa(
     };
   }
 
+  // Defense-in-depth: the DSL validator already ReDoS-guards
+  // expected_pattern at parse time, but the answer string is host-LLM
+  // output and the assertion may also be constructed programmatically,
+  // so re-guard here before running it against untrusted text.
   let regex: RegExp;
   try {
-    regex = new RegExp(assertion.expected_pattern);
+    regex = compileSafeRegex(assertion.expected_pattern);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return {
@@ -75,6 +86,7 @@ export async function evaluateImageQa(
         passed: false,
         assertion_kind: 'image_qa',
         details: {
+          error: 'invalid_expected_pattern',
           reason: 'invalid_expected_pattern',
           message,
           expected_pattern: assertion.expected_pattern,

--- a/src/tools/image-qa.ts
+++ b/src/tools/image-qa.ts
@@ -220,3 +220,79 @@ const handler: ToolHandler = async (
 export function registerImageQaTool(server: MCPServer): void {
   server.registerTool('image_qa', handler, definition);
 }
+
+/**
+ * Internal helper exposed for runtime wiring (e.g. the oc_assert
+ * contract evaluator's `imageQaSample` hook, #1432 Part 2 runtime
+ * follow-up). Takes a pre-decoded base64 screenshot, forwards to the
+ * host via MCP sampling when available, and returns a structured
+ * `{ status: 'ok', answer }` or `{ status: 'unsupported_by_host', reason }`.
+ *
+ * Does NOT register a tool — call it directly from another tool's
+ * handler, threading through the caller's ToolContext so the host
+ * capability lookup and requestClient bridge are honoured.
+ */
+export async function runImageQaSampling(
+  ctx: ToolContext | undefined,
+  params: { question: string; base64: string; mime?: string; maxTokens?: number },
+): Promise<
+  | { status: 'ok'; answer: string; model?: string; usage?: Record<string, unknown> }
+  | { status: 'unsupported_by_host'; reason: string }
+  | { status: 'error'; reason: string }
+> {
+  const samplingCap = ctx?.clientCapabilities?.sampling;
+  if (!samplingCap) {
+    return {
+      status: 'unsupported_by_host',
+      reason: 'sampling capability not advertised by client',
+    };
+  }
+  if (!ctx?.requestClient) {
+    return {
+      status: 'unsupported_by_host',
+      reason: 'requestClient bridge not available on this transport',
+    };
+  }
+
+  type SamplingResponse = {
+    content?: { type?: string; text?: string };
+    model?: string;
+    usage?: Record<string, unknown>;
+  };
+
+  try {
+    const response = await ctx.requestClient<SamplingResponse>(
+      'sampling/createMessage',
+      {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'image', data: params.base64, mimeType: params.mime ?? 'image/png' },
+              { type: 'text', text: params.question },
+            ],
+          },
+        ],
+        maxTokens: params.maxTokens ?? 512,
+      },
+      { timeoutMs: 30_000 },
+    );
+    // A non-text content block (e.g. the host echoes back an image) has
+    // no answer to match. Treat it as a transport-level error so the
+    // caller degrades to inconclusive rather than matching the regex
+    // against an empty string (which a permissive pattern would pass).
+    if (response?.content?.type !== 'text' || typeof response.content.text !== 'string') {
+      return { status: 'error', reason: 'sampling response was not a text content block' };
+    }
+    const answer = response.content.text;
+    return {
+      status: 'ok',
+      answer,
+      ...(response?.model ? { model: response.model } : {}),
+      ...(response?.usage ? { usage: response.usage } : {}),
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { status: 'error', reason: `sampling request failed: ${message}` };
+  }
+}

--- a/src/tools/oc-assert.ts
+++ b/src/tools/oc-assert.ts
@@ -22,7 +22,8 @@
  */
 
 import { MCPServer } from '../mcp-server';
-import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import { MCPToolDefinition, MCPResult, ToolContext, ToolHandler } from '../types/mcp';
+import { runImageQaSampling } from './image-qa';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { evaluate } from '../contracts/evaluate';
 import { validateAssertion } from '../contracts/validator';
@@ -114,7 +115,10 @@ const definition: MCPToolDefinition = {
   annotations: TOOL_ANNOTATIONS.oc_assert,
 };
 
-function buildEvalContext(snapshot: SnapshotInput | undefined): EvalContext {
+function buildEvalContext(
+  snapshot: SnapshotInput | undefined,
+  toolContext?: ToolContext,
+): EvalContext {
   const domTextMap =
     snapshot && typeof snapshot.dom_text === 'object' && snapshot.dom_text !== null
       ? (snapshot.dom_text as Record<string, string | null>)
@@ -159,6 +163,38 @@ function buildEvalContext(snapshot: SnapshotInput | undefined): EvalContext {
     async hasOpenDialog() {
       return snapshot?.has_open_dialog ?? false;
     },
+    // image_qa contract evaluator hook (#1432 Part 2 runtime wire-up).
+    // Forwards to the host LLM via MCP sampling when the connected
+    // client advertises the capability. When ToolContext is absent
+    // (older callers) or sampling is not available, the hook is
+    // omitted and the evaluator falls back to inconclusive.
+    ...(toolContext
+      ? {
+          imageQaSample: async ({
+            question,
+            screenshot,
+          }: {
+            question: string;
+            screenshot: Buffer;
+          }) => {
+            const reply = await runImageQaSampling(toolContext, {
+              question,
+              base64: screenshot.toString('base64'),
+              mime: 'image/png',
+            });
+            if (reply.status === 'ok') {
+              return { status: 'ok' as const, answer: reply.answer };
+            }
+            if (reply.status === 'unsupported_by_host') {
+              return { status: 'unsupported_by_host' as const, reason: reply.reason };
+            }
+            // status === 'error' — surface as unsupported_by_host so
+            // the evaluator returns inconclusive with the original
+            // error reason preserved for diagnostics.
+            return { status: 'unsupported_by_host' as const, reason: reply.reason };
+          },
+        }
+      : {}),
   };
 }
 
@@ -286,6 +322,7 @@ function isInconclusive(evidence: Evidence): boolean {
 const handler: ToolHandler = async (
   sessionId: string,
   args: Record<string, unknown>,
+  context?: ToolContext,
 ): Promise<MCPResult> => {
   const contractInline = args.contract;
   const contractId = args.contract_id as string | undefined;
@@ -333,7 +370,7 @@ const handler: ToolHandler = async (
     return jsonResult(output);
   }
 
-  const ctx = buildEvalContext(snapshot);
+  const ctx = buildEvalContext(snapshot, context);
   let result: EvaluationResult;
   try {
     result = await evaluate(validation.value, ctx);

--- a/tests/contracts/oc-assert-image-qa-runtime.test.ts
+++ b/tests/contracts/oc-assert-image-qa-runtime.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Runtime wire-up test for oc_assert + image_qa (#1432 Part 2 follow-up).
+ *
+ * Exercises the full path: an oc_assert call with an `image_qa`
+ * contract clause must thread through the runtime's `imageQaSample`
+ * hook to the host's MCP sampling capability, evaluate the regex
+ * match, and return a verdict.
+ */
+import { MCPServer } from '../../src/mcp-server';
+import { registerOcAssertTool } from '../../src/tools/oc-assert';
+import type { ToolContext } from '../../src/types/mcp';
+
+function getRegisteredTool(server: MCPServer, name: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const reg = (server as any).tools as Map<string, { handler: Function }> | undefined;
+  if (!reg) throw new Error('MCPServer has no tools map');
+  const entry = reg.get(name);
+  if (!entry) throw new Error(`tool not registered: ${name}`);
+  return entry;
+}
+
+function parseResult(res: { content: Array<{ type: string; text?: string }> }) {
+  const block = res.content[0];
+  if (!block || block.type !== 'text' || typeof block.text !== 'string') {
+    throw new Error('expected text result block');
+  }
+  return JSON.parse(block.text);
+}
+
+describe('oc_assert + image_qa runtime hook (#1432 Part 2 wire-up)', () => {
+  let server: MCPServer;
+
+  beforeAll(() => {
+    server = new MCPServer();
+    registerOcAssertTool(server);
+  });
+
+  function callAssert(args: Record<string, unknown>, ctx?: Partial<ToolContext>) {
+    const tool = getRegisteredTool(server, 'oc_assert');
+    const fullCtx: ToolContext = {
+      startTime: Date.now(),
+      deadlineMs: 60_000,
+      ...(ctx ?? {}),
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (tool.handler as any)('test-session', args, fullCtx);
+  }
+
+  const pngBase64 = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64');
+
+  it('passes when the host answer matches the expected_pattern', async () => {
+    const fakeRequestClient = async (
+      method: string,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      _params?: Record<string, unknown>,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ): Promise<any> => {
+      expect(method).toBe('sampling/createMessage');
+      return { content: { type: 'text', text: 'yes, dark mode is on' } };
+    };
+    const res = await callAssert(
+      {
+        contract: { kind: 'image_qa', question: 'dark mode?', expected_pattern: '^yes' },
+        evidence: { snapshot: { screenshot_png_base64: pngBase64 } },
+      },
+      { clientCapabilities: { sampling: {} }, requestClient: fakeRequestClient },
+    );
+    const parsed = parseResult(res);
+    expect(parsed.verdict).toBe('pass');
+  });
+
+  it('fails when the host answer does not match the expected_pattern', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fakeRequestClient = async (): Promise<any> => ({
+      content: { type: 'text', text: 'no, light mode is on' },
+    });
+    const res = await callAssert(
+      {
+        contract: { kind: 'image_qa', question: 'dark mode?', expected_pattern: '^yes' },
+        evidence: { snapshot: { screenshot_png_base64: pngBase64 } },
+      },
+      { clientCapabilities: { sampling: {} }, requestClient: fakeRequestClient },
+    );
+    const parsed = parseResult(res);
+    expect(parsed.verdict).toBe('fail');
+  });
+
+  it('returns inconclusive when the client has no sampling capability', async () => {
+    const res = await callAssert(
+      {
+        contract: { kind: 'image_qa', question: 'dark mode?', expected_pattern: '.' },
+        evidence: { snapshot: { screenshot_png_base64: pngBase64 } },
+      },
+      // No clientCapabilities, no requestClient.
+    );
+    const parsed = parseResult(res);
+    expect(parsed.verdict).toBe('inconclusive');
+  });
+
+  it('returns inconclusive when no screenshot is supplied', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fakeRequestClient = async (): Promise<any> => ({
+      content: { type: 'text', text: 'whatever' },
+    });
+    const res = await callAssert(
+      {
+        contract: { kind: 'image_qa', question: 'q', expected_pattern: '.' },
+        evidence: { snapshot: { url: 'https://example.com/' } },
+      },
+      { clientCapabilities: { sampling: {} }, requestClient: fakeRequestClient },
+    );
+    const parsed = parseResult(res);
+    expect(parsed.verdict).toBe('inconclusive');
+  });
+
+  it('returns inconclusive (not a vacuous pass) when the host returns a non-text content block', async () => {
+    // A permissive pattern like '.' would match an empty answer, so a
+    // non-text sampling response must degrade to inconclusive rather
+    // than silently matching against ''.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fakeRequestClient = async (): Promise<any> => ({
+      content: { type: 'image', data: 'AAAA' },
+    });
+    const res = await callAssert(
+      {
+        contract: { kind: 'image_qa', question: 'q', expected_pattern: '.' },
+        evidence: { snapshot: { screenshot_png_base64: pngBase64 } },
+      },
+      { clientCapabilities: { sampling: {} }, requestClient: fakeRequestClient },
+    );
+    const parsed = parseResult(res);
+    expect(parsed.verdict).toBe('inconclusive');
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on #1445. Completes the runtime wire-up promised in the original #1432-B brief that was deferred from that PR.

- `image_qa.ts` exports a reusable `runImageQaSampling(ctx, params)` that does the sampling forwarding.
- `oc_assert.buildEvalContext` now accepts the calling `ToolContext` and injects an `imageQaSample` closure delegating to `runImageQaSampling`.
- `oc_assert` handler signature accepts the optional context parameter.
- `image_qa` evaluator stamps `details.error` on infra-fault paths so `isInconclusive` translates them to `verdict='inconclusive'` (not `fail`). Runtime wiring problems are not contract failures.

## Why this is a fix not a feature
Without this, the image_qa DSL clause was dead code in production: every contract returned `inconclusive` with reason `host_runtime_did_not_wire_imageQaSample`. PR #1445 implicitly required this wire-up to keep its commitment.

## SSOT (#1359) alignment
- No server-side LLM. The closure only forwards via `sampling/createMessage`, falls back to `unsupported_by_host`.

## Test plan
- [x] `tests/contracts/oc-assert-image-qa-runtime.test.ts` — 4/4 pass (pass on match, fail on mismatch, inconclusive without sampling cap, inconclusive without screenshot).
- [x] `tests/contracts/image-qa.test.ts` — 9/9 still pass.
- [x] `tests/tools/image-qa.test.ts` — 6/6 still pass.

Stacked on #1445 → #1441.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>