### PR TITLE
feat(benchmark): Online-Mind2Web live-run production wiring (#1427 Part 2 / #1428)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "benchmark:ci": "ts-node tests/benchmark/run.ts --ci",
     "bench:webvoyager:mock": "ts-node tests/benchmark/webvoyager/runner.ts --adapter mock",
     "bench:webvoyager:real": "ts-node tests/benchmark/webvoyager/runner.ts --adapter claude",
+    "bench:om2w:mock": "ts-node tests/benchmark/datasets/online-mind2web/cli.ts --adapter mock",
+    "bench:om2w": "ts-node tests/benchmark/datasets/online-mind2web/cli.ts --adapter claude",
     "bench:latency": "ts-node tests/benchmark/run-latency.ts",
     "bench:tokens": "ts-node tests/benchmark/run-token-efficiency.ts",
     "bench:throughput": "ts-node tests/benchmark/run-throughput.ts --library all --include-live-competitors=false --session-mode both",

--- a/tests/benchmark/datasets/online-mind2web/cli.ts
+++ b/tests/benchmark/datasets/online-mind2web/cli.ts
@@ -1,0 +1,336 @@
+/**
+ * Online-Mind2Web live-run CLI (#1427 Part 2).
+ *
+ * Mirrors the WebVoyager runner CLI shape:
+ *   - parse `--adapter mock|claude`, `--model`, `--limit`, `--step-budget`
+ *   - load the dataset (`fixture` default; `hf` when OPENCHROME_OM2W_FETCH=1)
+ *   - mock: deterministic fake client + fake adapter (NO network, NO API key)
+ *   - claude: assertAnthropicLiveEnabled, then real Anthropic SDK client +
+ *     OpenChromeRealAdapter
+ *   - run each task via runOnlineMind2WebTask, aggregate pass-rate, and write
+ *     a JSON + Markdown report under ./results.
+ *
+ * Run via:
+ *   npm run bench:om2w:mock   # default, deterministic, CI-safe
+ *   npm run bench:om2w        # requires ANTHROPIC_API_KEY + OPENCHROME_BENCH_REAL=1
+ *
+ * Logging goes to stderr (console.error) — stdout is reserved for MCP JSON-RPC.
+ */
+
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+
+import type { MCPAdapter, MCPToolResult } from '../../benchmark-runner';
+import type { AnthropicMessagesClient } from '../../llm-provider/anthropic-loop';
+import { assertAnthropicLiveEnabled } from '../../llm-provider/anthropic-loop';
+import { loadOnlineMind2Web, type OnlineMind2WebTask } from './loader';
+import { runOnlineMind2WebTask, type RunnerResult } from './runner';
+import { createLiveOnlineMind2WebDeps, DEFAULT_OM2W_MODEL } from './live-deps';
+
+const RESULTS_DIR = path.join(__dirname, 'results');
+
+type AdapterName = 'mock' | 'claude';
+
+interface CliOptions {
+  adapter: AdapterName;
+  model: string;
+  limit?: number;
+  stepBudget?: number;
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+  const opts: CliOptions = { adapter: 'mock', model: DEFAULT_OM2W_MODEL };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--adapter') {
+      opts.adapter = requireAdapter(argv[++i]);
+    } else if (a.startsWith('--adapter=')) {
+      opts.adapter = requireAdapter(a.slice('--adapter='.length));
+    } else if (a === '--model') {
+      opts.model = argv[++i];
+    } else if (a.startsWith('--model=')) {
+      opts.model = a.slice('--model='.length);
+    } else if (a === '--limit') {
+      opts.limit = requirePositiveInt(argv[++i], '--limit');
+    } else if (a.startsWith('--limit=')) {
+      opts.limit = requirePositiveInt(a.slice('--limit='.length), '--limit');
+    } else if (a === '--step-budget') {
+      opts.stepBudget = requirePositiveInt(argv[++i], '--step-budget');
+    } else if (a.startsWith('--step-budget=')) {
+      opts.stepBudget = requirePositiveInt(a.slice('--step-budget='.length), '--step-budget');
+    }
+  }
+
+  const envAdapter = process.env.OPENCHROME_BENCH_ADAPTER;
+  if (envAdapter === 'mock' || envAdapter === 'claude') {
+    opts.adapter = envAdapter;
+  }
+  return opts;
+}
+
+function requireAdapter(v: string | undefined): AdapterName {
+  if (v !== 'mock' && v !== 'claude') {
+    throw new Error(`unknown --adapter: ${v}. Choose one of mock, claude`);
+  }
+  return v;
+}
+
+function requirePositiveInt(raw: string | undefined, flag: string): number {
+  const n = Number.parseInt(raw ?? '', 10);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(`${flag} must be a positive integer; got ${raw}`);
+  }
+  return n;
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic mock client + adapter (NO network, NO API key, NO browser).
+// ---------------------------------------------------------------------------
+
+/**
+ * A deterministic fake Anthropic client. For the step loop it returns a
+ * single navigate tool call on the first message, then a terminal text turn.
+ * For the judge call (a `system` mentioning "evaluator") it returns a strict
+ * JSON verdict that always passes. State is keyed off the system prompt so
+ * step and judge calls are distinguishable without network access.
+ */
+export function createMockAnthropicClient(): AnthropicMessagesClient {
+  const stepCallCounts = new Map<string, number>();
+  return {
+    create: async (input: Record<string, unknown>) => {
+      const system = typeof input.system === 'string' ? input.system : '';
+      const isJudge = system.includes('evaluator');
+      if (isJudge) {
+        return {
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 10, output_tokens: 10 },
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ passed: true, reason: 'mock judge: deterministic pass' }),
+            },
+          ],
+        };
+      }
+
+      // Step loop: emit one tool call, then finish on the follow-up turn.
+      const key = JSON.stringify(input.messages ?? []);
+      const seen = stepCallCounts.get(key) ?? 0;
+      stepCallCounts.set(key, seen + 1);
+      const hasToolResult = Array.isArray(input.messages)
+        && (input.messages as Array<{ content?: unknown }>).some(
+          (m) => Array.isArray(m.content)
+            && (m.content as Array<{ type?: string }>).some((c) => c.type === 'tool_result'),
+        );
+      if (hasToolResult) {
+        return {
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 5, output_tokens: 5 },
+          content: [{ type: 'text', text: 'OM2W_COMPLETE: navigated to target page.' }],
+        };
+      }
+      return {
+        stop_reason: 'tool_use',
+        usage: { input_tokens: 8, output_tokens: 8 },
+        content: [
+          { type: 'text', text: 'Navigating to the target site.' },
+          {
+            type: 'tool_use',
+            id: `mock-tool-${seen}`,
+            name: 'navigate',
+            input: { url: 'https://example.com' },
+          },
+        ],
+      };
+    },
+  };
+}
+
+/** A deterministic fake MCP adapter that succeeds on every tool call. */
+export function createMockAdapter(): MCPAdapter {
+  return {
+    name: 'mock-om2w',
+    mode: 'dom',
+    kind: 'mcp',
+    async callTool(toolName: string, args: Record<string, unknown>): Promise<MCPToolResult> {
+      return {
+        content: [{ type: 'text', text: `mock ${toolName} ok ${JSON.stringify(args)}` }],
+        isError: false,
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Report shapes.
+// ---------------------------------------------------------------------------
+
+interface TaskReport {
+  task_id: string;
+  passed: boolean;
+  steps_used: number;
+  reason: string;
+  judge_id?: string;
+}
+
+interface Om2wReport {
+  adapter: AdapterName;
+  model: string;
+  source: 'fixture' | 'hf';
+  total_tasks: number;
+  pass_count: number;
+  fail_count: number;
+  pass_rate: number;
+  step_budget: number | null;
+  timestamp: string;
+  tasks: TaskReport[];
+}
+
+function toTaskReport(r: RunnerResult): TaskReport {
+  return {
+    task_id: r.task_id,
+    passed: r.passed,
+    steps_used: r.steps_used,
+    reason: r.reason,
+    ...(r.judge_id ? { judge_id: r.judge_id } : {}),
+  };
+}
+
+function renderMarkdown(report: Om2wReport): string {
+  const lines: string[] = [];
+  lines.push('# Online-Mind2Web live-run report');
+  lines.push('');
+  lines.push(`- adapter: \`${report.adapter}\``);
+  lines.push(`- model: \`${report.model}\``);
+  lines.push(`- source: \`${report.source}\``);
+  lines.push(`- step_budget: \`${report.step_budget ?? 'default'}\``);
+  lines.push(`- timestamp: ${report.timestamp}`);
+  lines.push('');
+  lines.push(`**pass-rate: ${report.pass_count}/${report.total_tasks} (${(report.pass_rate * 100).toFixed(1)}%)**`);
+  lines.push('');
+  lines.push('| task_id | passed | steps | reason |');
+  lines.push('| --- | --- | --- | --- |');
+  for (const t of report.tasks) {
+    const reason = t.reason.replace(/\|/g, '\\|').slice(0, 120);
+    lines.push(`| ${t.task_id} | ${t.passed ? 'yes' : 'no'} | ${t.steps_used} | ${reason} |`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function buildDeps(opts: CliOptions) {
+  if (opts.adapter === 'mock') {
+    return createLiveOnlineMind2WebDeps({
+      client: createMockAnthropicClient(),
+      adapter: createMockAdapter(),
+      model: opts.model,
+      maxTurnsPerStep: 4,
+      now: () => 0,
+    });
+  }
+
+  // Live Claude path — gated, requires API key + OPENCHROME_BENCH_REAL=1.
+  assertAnthropicLiveEnabled();
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const sdk = require('@anthropic-ai/sdk');
+  const Anthropic = sdk.default ?? sdk;
+  const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  const client: AnthropicMessagesClient = {
+    create: (input) => anthropic.messages.create(input),
+  };
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { OpenChromeRealAdapter } = require('../../adapters');
+  const adapter: MCPAdapter = new OpenChromeRealAdapter({
+    mode: 'dom',
+    cdpEndpoint: process.env.OPENCHROME_BENCH_CDP_ENDPOINT,
+  });
+  return createLiveOnlineMind2WebDeps({ client, adapter, model: opts.model });
+}
+
+export async function main(argv: string[] = process.argv): Promise<number> {
+  const opts = parseArgs(argv);
+  const source: 'fixture' | 'hf' = process.env.OPENCHROME_OM2W_FETCH ? 'hf' : 'fixture';
+
+  let tasks: OnlineMind2WebTask[];
+  try {
+    tasks = await loadOnlineMind2Web({ source });
+  } catch (err) {
+    console.error(`[om2w] failed to load dataset (source=${source}): ${(err as Error).message}`);
+    return 1;
+  }
+  if (typeof opts.limit === 'number') {
+    tasks = tasks.slice(0, opts.limit);
+  }
+  if (tasks.length === 0) {
+    console.error('[om2w] no tasks selected');
+    return 1;
+  }
+
+  console.error(`[om2w] adapter=${opts.adapter} model=${opts.model} source=${source} tasks=${tasks.length}`);
+
+  let deps;
+  try {
+    deps = buildDeps(opts);
+  } catch (err) {
+    console.error(`[om2w] failed to build deps: ${(err as Error).message}`);
+    return 1;
+  }
+
+  const runnerOptions = typeof opts.stepBudget === 'number' ? { step_budget: opts.stepBudget } : {};
+  const taskReports: TaskReport[] = [];
+  for (const task of tasks) {
+    try {
+      const result = await runOnlineMind2WebTask(task, deps, runnerOptions);
+      taskReports.push(toTaskReport(result));
+      console.error(
+        `[om2w] ${result.task_id}: ${result.passed ? 'passed' : 'failed'} ` +
+          `(${result.steps_used} steps) — ${result.reason}`,
+      );
+    } catch (err) {
+      taskReports.push({
+        task_id: task.task_id,
+        passed: false,
+        steps_used: 0,
+        reason: `runner error: ${(err as Error).message}`,
+      });
+      console.error(`[om2w] ${task.task_id}: error — ${(err as Error).message}`);
+    }
+  }
+
+  const passCount = taskReports.filter((t) => t.passed).length;
+  const failCount = taskReports.length - passCount;
+  const report: Om2wReport = {
+    adapter: opts.adapter,
+    model: opts.model,
+    source,
+    total_tasks: taskReports.length,
+    pass_count: passCount,
+    fail_count: failCount,
+    pass_rate: taskReports.length > 0 ? passCount / taskReports.length : 0,
+    step_budget: opts.stepBudget ?? null,
+    timestamp: new Date().toISOString(),
+    tasks: taskReports,
+  };
+
+  await fs.mkdir(RESULTS_DIR, { recursive: true });
+  const jsonPath = path.join(RESULTS_DIR, `${opts.adapter}-latest.json`);
+  const mdPath = path.join(RESULTS_DIR, `${opts.adapter}-latest.md`);
+  await fs.writeFile(jsonPath, JSON.stringify(report, null, 2) + '\n', 'utf8');
+  await fs.writeFile(mdPath, renderMarkdown(report), 'utf8');
+
+  console.error(
+    `[om2w] OK: ${passCount} passed / ${failCount} failed / ${taskReports.length} total ` +
+      `(pass-rate=${(report.pass_rate * 100).toFixed(1)}%) -> ${jsonPath}`,
+  );
+  return 0;
+}
+
+if (require.main === module) {
+  main().then(
+    (code) => process.exit(code),
+    (err) => {
+      console.error('[om2w] fatal:', err);
+      process.exit(2);
+    },
+  );
+}

--- a/tests/benchmark/datasets/online-mind2web/cli.ts
+++ b/tests/benchmark/datasets/online-mind2web/cli.ts
@@ -24,7 +24,7 @@ import type { MCPAdapter, MCPToolResult } from '../../benchmark-runner';
 import type { AnthropicMessagesClient } from '../../llm-provider/anthropic-loop';
 import { assertAnthropicLiveEnabled } from '../../llm-provider/anthropic-loop';
 import { loadOnlineMind2Web, type OnlineMind2WebTask } from './loader';
-import { runOnlineMind2WebTask, type RunnerResult } from './runner';
+import { runOnlineMind2WebTask, type RunnerDeps, type RunnerResult } from './runner';
 import { createLiveOnlineMind2WebDeps, DEFAULT_OM2W_MODEL } from './live-deps';
 
 const RESULTS_DIR = path.join(__dirname, 'results');
@@ -218,15 +218,23 @@ function renderMarkdown(report: Om2wReport): string {
   return lines.join('\n');
 }
 
-function buildDeps(opts: CliOptions) {
+/**
+ * Build the runner deps plus the underlying adapter. The adapter is returned
+ * alongside the deps so the caller can drive its setup()/teardown() lifecycle
+ * once around the whole run — the live OpenChromeRealAdapter only spawns its
+ * MCP subprocess in setup() and would otherwise throw on the first tool call.
+ */
+function buildDeps(opts: CliOptions): { deps: RunnerDeps; adapter: MCPAdapter } {
   if (opts.adapter === 'mock') {
-    return createLiveOnlineMind2WebDeps({
+    const adapter = createMockAdapter();
+    const deps = createLiveOnlineMind2WebDeps({
       client: createMockAnthropicClient(),
-      adapter: createMockAdapter(),
+      adapter,
       model: opts.model,
       maxTurnsPerStep: 4,
       now: () => 0,
     });
+    return { deps, adapter };
   }
 
   // Live Claude path — gated, requires API key + OPENCHROME_BENCH_REAL=1.
@@ -244,12 +252,13 @@ function buildDeps(opts: CliOptions) {
     mode: 'dom',
     cdpEndpoint: process.env.OPENCHROME_BENCH_CDP_ENDPOINT,
   });
-  return createLiveOnlineMind2WebDeps({ client, adapter, model: opts.model });
+  const deps = createLiveOnlineMind2WebDeps({ client, adapter, model: opts.model });
+  return { deps, adapter };
 }
 
 export async function main(argv: string[] = process.argv): Promise<number> {
   const opts = parseArgs(argv);
-  const source: 'fixture' | 'hf' = process.env.OPENCHROME_OM2W_FETCH ? 'hf' : 'fixture';
+  const source: 'fixture' | 'hf' = process.env.OPENCHROME_OM2W_FETCH === '1' ? 'hf' : 'fixture';
 
   let tasks: OnlineMind2WebTask[];
   try {
@@ -268,32 +277,51 @@ export async function main(argv: string[] = process.argv): Promise<number> {
 
   console.error(`[om2w] adapter=${opts.adapter} model=${opts.model} source=${source} tasks=${tasks.length}`);
 
-  let deps;
+  let deps: RunnerDeps;
+  let adapter: MCPAdapter;
   try {
-    deps = buildDeps(opts);
+    ({ deps, adapter } = buildDeps(opts));
   } catch (err) {
     console.error(`[om2w] failed to build deps: ${(err as Error).message}`);
     return 1;
   }
 
+  // The adapter owns a real MCP subprocess on the live path; set it up once
+  // before the run and tear it down afterwards even if a task throws. The mock
+  // adapter has no setup/teardown, so this is a no-op there.
+  try {
+    await adapter.setup?.();
+  } catch (err) {
+    console.error(`[om2w] adapter setup failed: ${(err as Error).message}`);
+    return 1;
+  }
+
   const runnerOptions = typeof opts.stepBudget === 'number' ? { step_budget: opts.stepBudget } : {};
   const taskReports: TaskReport[] = [];
-  for (const task of tasks) {
+  try {
+    for (const task of tasks) {
+      try {
+        const result = await runOnlineMind2WebTask(task, deps, runnerOptions);
+        taskReports.push(toTaskReport(result));
+        console.error(
+          `[om2w] ${result.task_id}: ${result.passed ? 'passed' : 'failed'} ` +
+            `(${result.steps_used} steps) — ${result.reason}`,
+        );
+      } catch (err) {
+        taskReports.push({
+          task_id: task.task_id,
+          passed: false,
+          steps_used: 0,
+          reason: `runner error: ${(err as Error).message}`,
+        });
+        console.error(`[om2w] ${task.task_id}: error — ${(err as Error).message}`);
+      }
+    }
+  } finally {
     try {
-      const result = await runOnlineMind2WebTask(task, deps, runnerOptions);
-      taskReports.push(toTaskReport(result));
-      console.error(
-        `[om2w] ${result.task_id}: ${result.passed ? 'passed' : 'failed'} ` +
-          `(${result.steps_used} steps) — ${result.reason}`,
-      );
+      await adapter.teardown?.();
     } catch (err) {
-      taskReports.push({
-        task_id: task.task_id,
-        passed: false,
-        steps_used: 0,
-        reason: `runner error: ${(err as Error).message}`,
-      });
-      console.error(`[om2w] ${task.task_id}: error — ${(err as Error).message}`);
+      console.error(`[om2w] adapter teardown failed: ${(err as Error).message}`);
     }
   }
 

--- a/tests/benchmark/datasets/online-mind2web/live-deps.test.ts
+++ b/tests/benchmark/datasets/online-mind2web/live-deps.test.ts
@@ -14,6 +14,7 @@ import {
   createLiveOnlineMind2WebDeps,
   parseJudgeReply,
   CapturingOM2WAdapter,
+  DEFAULT_OM2W_MAX_TURNS_PER_STEP,
 } from './live-deps';
 import type { OnlineMind2WebTask } from './loader';
 import type { RunnerStep } from './runner';
@@ -160,6 +161,71 @@ describe('createLiveOnlineMind2WebDeps.step', () => {
     const step = await deps.step(fakeTask(), 1, []);
     expect(step.ok).toBe(false);
     expect(step.summary).toContain('step aborted: MAX_ITERATIONS');
+  });
+
+  it('bounds a step to the OM2W per-step turn default when none is injected', async () => {
+    // A model that always emits another tool call would, without an explicit
+    // cap, fall back to WEBVOYAGER_BUDGET.max_tool_iterations (50) per step. The
+    // OM2W deps inject DEFAULT_OM2W_MAX_TURNS_PER_STEP instead, so the inner loop
+    // makes exactly that many tool calls before aborting MAX_ITERATIONS.
+    const adapter = fakeAdapter();
+    const neverStopsClient: AnthropicMessagesClient = {
+      create: async () => ({
+        stop_reason: 'tool_use',
+        usage: { input_tokens: 1, output_tokens: 1 },
+        content: [
+          { type: 'text', text: 'again' },
+          { type: 'tool_use', id: 't1', name: 'navigate', input: { url: 'https://example.com' } },
+        ],
+      }),
+    };
+    const deps = createLiveOnlineMind2WebDeps({
+      client: neverStopsClient,
+      adapter,
+      now: () => 0,
+    });
+    const step = await deps.step(fakeTask(), 1, []);
+    expect(step.ok).toBe(false);
+    expect(step.summary).toContain('step aborted: MAX_ITERATIONS');
+    expect(adapter.calls).toHaveLength(DEFAULT_OM2W_MAX_TURNS_PER_STEP);
+  });
+
+  it('surfaces a USD budget abort as a failed step', async () => {
+    // The other abort path: a single turn whose reported token usage blows the
+    // per-task USD ceiling (WEBVOYAGER_BUDGET.max_usd_per_task = 0.5; pricing is
+    // $15/M output, so 1M output tokens ≈ $15). accountLlmBudget aborts with
+    // BUDGET_EXCEEDED before the loop ever inspects the tool calls. The step
+    // must be recorded as failed so the runner stops and the abort reason is
+    // visible to the judge — same contract as MAX_ITERATIONS, different trigger.
+    const overBudgetClient: AnthropicMessagesClient = {
+      create: async (input: Record<string, unknown>) => {
+        const system = typeof input.system === 'string' ? input.system : '';
+        if (system.includes('evaluator')) {
+          return {
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 1, output_tokens: 1 },
+            content: [{ type: 'text', text: '{"passed":false,"reason":"aborted"}' }],
+          };
+        }
+        return {
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 1, output_tokens: 1_000_000 },
+          content: [
+            { type: 'text', text: 'expensive turn' },
+            { type: 'tool_use', id: 't1', name: 'navigate', input: { url: 'https://example.com' } },
+          ],
+        };
+      },
+    };
+    const deps = createLiveOnlineMind2WebDeps({
+      client: overBudgetClient,
+      adapter: fakeAdapter(),
+      maxTurnsPerStep: 4,
+      now: () => 0,
+    });
+    const step = await deps.step(fakeTask(), 1, []);
+    expect(step.ok).toBe(false);
+    expect(step.summary).toContain('step aborted: BUDGET_EXCEEDED');
   });
 });
 

--- a/tests/benchmark/datasets/online-mind2web/live-deps.test.ts
+++ b/tests/benchmark/datasets/online-mind2web/live-deps.test.ts
@@ -125,6 +125,42 @@ describe('createLiveOnlineMind2WebDeps.step', () => {
     expect(step.ok).toBe(true);
     expect(step.summary).toBe('I cannot proceed.');
   });
+
+  it('surfaces a budget/iteration abort as a failed step', async () => {
+    // A model that never stops emitting tool calls exhausts maxTurns, so the
+    // tool-use loop returns aborted:'MAX_ITERATIONS'. The step must be recorded
+    // as a failure (not a clean success) so the runner stops and the abort
+    // reason reaches the judge's evidence.
+    const neverStopsClient: AnthropicMessagesClient = {
+      create: async (input: Record<string, unknown>) => {
+        const system = typeof input.system === 'string' ? input.system : '';
+        if (system.includes('evaluator')) {
+          return {
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 1, output_tokens: 1 },
+            content: [{ type: 'text', text: '{"passed":false,"reason":"aborted"}' }],
+          };
+        }
+        return {
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 1, output_tokens: 1 },
+          content: [
+            { type: 'text', text: 'still working' },
+            { type: 'tool_use', id: 't1', name: 'navigate', input: { url: 'https://example.com' } },
+          ],
+        };
+      },
+    };
+    const deps = createLiveOnlineMind2WebDeps({
+      client: neverStopsClient,
+      adapter: fakeAdapter(),
+      maxTurnsPerStep: 2,
+      now: () => 0,
+    });
+    const step = await deps.step(fakeTask(), 1, []);
+    expect(step.ok).toBe(false);
+    expect(step.summary).toContain('step aborted: MAX_ITERATIONS');
+  });
 });
 
 describe('createLiveOnlineMind2WebDeps.judge', () => {

--- a/tests/benchmark/datasets/online-mind2web/live-deps.test.ts
+++ b/tests/benchmark/datasets/online-mind2web/live-deps.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Unit tests for the OM2W live-run production deps (#1427 Part 2).
+ *
+ * Everything is driven with FAKES — a fake AnthropicMessagesClient and a fake
+ * MCPAdapter. No API key, no network, no browser. Asserts:
+ *   - step() captures the model's tool call into a RunnerStep
+ *   - judge() parses well-formed JSON and falls back safely on malformed JSON
+ *   - shouldStop() eventually fires via the marginal-utility / early-stop wiring
+ */
+
+import type { MCPAdapter, MCPToolResult } from '../../benchmark-runner';
+import type { AnthropicMessagesClient } from '../../llm-provider/anthropic-loop';
+import {
+  createLiveOnlineMind2WebDeps,
+  parseJudgeReply,
+  CapturingOM2WAdapter,
+} from './live-deps';
+import type { OnlineMind2WebTask } from './loader';
+import type { RunnerStep } from './runner';
+
+function fakeTask(): OnlineMind2WebTask {
+  return {
+    task_id: 'om2w-fake-1',
+    website: 'https://example.com',
+    task_description: 'find the login link',
+    reference_length: 3,
+  };
+}
+
+function okResult(text: string): MCPToolResult {
+  return { content: [{ type: 'text', text }], isError: false };
+}
+
+/** Fake adapter that records calls and always succeeds. */
+function fakeAdapter(): MCPAdapter & { calls: Array<{ tool: string; args: Record<string, unknown> }> } {
+  const calls: Array<{ tool: string; args: Record<string, unknown> }> = [];
+  return {
+    name: 'fake',
+    mode: 'dom',
+    kind: 'mcp',
+    calls,
+    async callTool(tool, args) {
+      calls.push({ tool, args });
+      return okResult(`${tool} done`);
+    },
+  };
+}
+
+/**
+ * Fake client: emits one navigate tool call, then a terminal text turn once
+ * a tool_result has been threaded back. Distinguishes judge calls by system.
+ */
+function fakeStepAndJudgeClient(judgeText: string): AnthropicMessagesClient {
+  return {
+    create: async (input: Record<string, unknown>) => {
+      const system = typeof input.system === 'string' ? input.system : '';
+      if (system.includes('evaluator')) {
+        return {
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 1 },
+          content: [{ type: 'text', text: judgeText }],
+        };
+      }
+      const hasToolResult = Array.isArray(input.messages)
+        && (input.messages as Array<{ content?: unknown }>).some(
+          (m) => Array.isArray(m.content)
+            && (m.content as Array<{ type?: string }>).some((c) => c.type === 'tool_result'),
+        );
+      if (hasToolResult) {
+        return {
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 1 },
+          content: [{ type: 'text', text: 'done navigating' }],
+        };
+      }
+      return {
+        stop_reason: 'tool_use',
+        usage: { input_tokens: 1, output_tokens: 1 },
+        content: [
+          { type: 'text', text: 'navigating' },
+          { type: 'tool_use', id: 't1', name: 'navigate', input: { url: 'https://example.com' } },
+        ],
+      };
+    },
+  };
+}
+
+describe('createLiveOnlineMind2WebDeps.step', () => {
+  it('captures the model tool call into a RunnerStep', async () => {
+    const adapter = fakeAdapter();
+    const deps = createLiveOnlineMind2WebDeps({
+      client: fakeStepAndJudgeClient('{"passed":true,"reason":"ok"}'),
+      adapter,
+      maxTurnsPerStep: 4,
+      now: () => 0,
+    });
+
+    const step = await deps.step(fakeTask(), 1, []);
+
+    expect(step.step).toBe(1);
+    expect(step.tool).toBe('navigate');
+    expect(step.args).toEqual({ url: 'https://example.com' });
+    expect(step.ok).toBe(true);
+    expect(step.summary).toContain('navigate done');
+    // The adapter actually executed the model's tool call.
+    expect(adapter.calls).toEqual([{ tool: 'navigate', args: { url: 'https://example.com' } }]);
+  });
+
+  it('records a no-op step when the model emits no tool call', async () => {
+    const noToolClient: AnthropicMessagesClient = {
+      create: async () => ({
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 1, output_tokens: 1 },
+        content: [{ type: 'text', text: 'I cannot proceed.' }],
+      }),
+    };
+    const deps = createLiveOnlineMind2WebDeps({
+      client: noToolClient,
+      adapter: fakeAdapter(),
+      maxTurnsPerStep: 2,
+      now: () => 0,
+    });
+    const step = await deps.step(fakeTask(), 2, []);
+    expect(step.tool).toBe('none');
+    expect(step.ok).toBe(true);
+    expect(step.summary).toBe('I cannot proceed.');
+  });
+});
+
+describe('createLiveOnlineMind2WebDeps.judge', () => {
+  it('parses a well-formed JSON verdict (happy path)', async () => {
+    const deps = createLiveOnlineMind2WebDeps({
+      client: fakeStepAndJudgeClient('{"passed":true,"reason":"task complete"}'),
+      adapter: fakeAdapter(),
+      now: () => 0,
+    });
+    const verdict = await deps.judge(fakeTask(), []);
+    expect(verdict.passed).toBe(true);
+    expect(verdict.reason).toBe('task complete');
+    expect(verdict.judge_id).toBe('claude-llm-judge');
+  });
+
+  it('parses a JSON verdict embedded in prose / code fences', async () => {
+    const wrapped = 'Here is my verdict:\n```json\n{"passed": false, "reason": "no evidence"}\n```\nThanks.';
+    const deps = createLiveOnlineMind2WebDeps({
+      client: fakeStepAndJudgeClient(wrapped),
+      adapter: fakeAdapter(),
+      now: () => 0,
+    });
+    const verdict = await deps.judge(fakeTask(), []);
+    expect(verdict.passed).toBe(false);
+    expect(verdict.reason).toBe('no evidence');
+  });
+
+  it('falls back to passed:false on malformed JSON', async () => {
+    const deps = createLiveOnlineMind2WebDeps({
+      client: fakeStepAndJudgeClient('not json at all'),
+      adapter: fakeAdapter(),
+      now: () => 0,
+    });
+    const verdict = await deps.judge(fakeTask(), []);
+    expect(verdict.passed).toBe(false);
+    expect(verdict.reason).toContain('not JSON');
+    expect(verdict.judge_id).toBe('claude-llm-judge');
+  });
+
+  it('falls back to passed:false when the judge invocation throws', async () => {
+    const throwingClient: AnthropicMessagesClient = {
+      create: async () => {
+        throw new Error('network down');
+      },
+    };
+    const deps = createLiveOnlineMind2WebDeps({
+      client: throwingClient,
+      adapter: fakeAdapter(),
+      now: () => 0,
+    });
+    const verdict = await deps.judge(fakeTask(), []);
+    expect(verdict.passed).toBe(false);
+    expect(verdict.reason).toContain('judge invocation failed');
+  });
+});
+
+describe('parseJudgeReply', () => {
+  it('rejects an object missing the boolean passed field', () => {
+    const v = parseJudgeReply('{"reason":"hmm"}');
+    expect(v.passed).toBe(false);
+    expect(v.reason).toContain('missing boolean');
+  });
+
+  it('handles empty input', () => {
+    const v = parseJudgeReply('');
+    expect(v.passed).toBe(false);
+    expect(v.reason).toContain('empty');
+  });
+
+  it('defaults the reason when omitted but passed is present', () => {
+    const v = parseJudgeReply('{"passed": true}');
+    expect(v.passed).toBe(true);
+    expect(v.reason).toBe('no reason provided');
+  });
+});
+
+describe('createLiveOnlineMind2WebDeps.shouldStop', () => {
+  function okStep(i: number): RunnerStep {
+    return { step: i, tool: 'read_page', args: {}, ok: true, summary: 'ok' };
+  }
+
+  it('does not stop on an empty history', () => {
+    const deps = createLiveOnlineMind2WebDeps({
+      client: fakeStepAndJudgeClient('{"passed":true,"reason":"ok"}'),
+      adapter: fakeAdapter(),
+      now: () => 0,
+    });
+    expect(deps.shouldStop?.([])).toBe(false);
+  });
+
+  it('does not stop early before the plateau accumulates', () => {
+    const deps = createLiveOnlineMind2WebDeps({
+      client: fakeStepAndJudgeClient('{"passed":true,"reason":"ok"}'),
+      adapter: fakeAdapter(),
+      now: () => 0,
+    });
+    const history = Array.from({ length: 3 }, (_v, i) => okStep(i + 1));
+    expect(deps.shouldStop?.(history)).toBe(false);
+  });
+
+  it('recommends stop once p_success plateaus over a long all-ok history', () => {
+    const deps = createLiveOnlineMind2WebDeps({
+      client: fakeStepAndJudgeClient('{"passed":true,"reason":"ok"}'),
+      adapter: fakeAdapter(),
+      now: () => 0,
+    });
+    // All-ok steps drive step_score=0.7; p_success converges to 0.7 and the
+    // deltas fall below the tracker's low-delta threshold, accumulating a
+    // plateau that satisfies the default early-stop policy.
+    const history = Array.from({ length: 40 }, (_v, i) => okStep(i + 1));
+    expect(deps.shouldStop?.(history)).toBe(true);
+  });
+});
+
+describe('CapturingOM2WAdapter', () => {
+  it('mirrors inner adapter identity and resets capture between steps', async () => {
+    const inner = fakeAdapter();
+    const wrapper = new CapturingOM2WAdapter(inner);
+    expect(wrapper.name).toBe('fake');
+    expect(wrapper.mode).toBe('dom');
+
+    await wrapper.callTool('navigate', { url: 'https://a.test' });
+    expect(wrapper.capturedCalls()).toHaveLength(1);
+    wrapper.resetStepCapture();
+    expect(wrapper.capturedCalls()).toHaveLength(0);
+  });
+});

--- a/tests/benchmark/datasets/online-mind2web/live-deps.test.ts
+++ b/tests/benchmark/datasets/online-mind2web/live-deps.test.ts
@@ -199,6 +199,19 @@ describe('parseJudgeReply', () => {
     expect(v.passed).toBe(true);
     expect(v.reason).toBe('no reason provided');
   });
+
+  it('extracts the verdict object even when prose contains stray braces', () => {
+    const reply = 'Consider the criteria {accuracy, recall} first.\n{"passed": true, "reason": "login link clicked"}';
+    const v = parseJudgeReply(reply);
+    expect(v.passed).toBe(true);
+    expect(v.reason).toBe('login link clicked');
+  });
+
+  it('does not mis-slice when a brace appears inside a string value', () => {
+    const v = parseJudgeReply('{"passed": false, "reason": "saw text like {x} on page"}');
+    expect(v.passed).toBe(false);
+    expect(v.reason).toBe('saw text like {x} on page');
+  });
 });
 
 describe('createLiveOnlineMind2WebDeps.shouldStop', () => {

--- a/tests/benchmark/datasets/online-mind2web/live-deps.ts
+++ b/tests/benchmark/datasets/online-mind2web/live-deps.ts
@@ -248,31 +248,88 @@ export function parseJudgeReply(text: string): JudgeVerdict {
     return fallback('judge returned empty response');
   }
 
-  // Extract the first balanced JSON object substring.
-  const start = text.indexOf('{');
-  const end = text.lastIndexOf('}');
-  if (start === -1 || end === -1 || end <= start) {
+  // Scan for balanced JSON object substrings (string-aware, so a brace inside
+  // a string or surrounding prose does not corrupt the slice). The first
+  // candidate that decodes to an object carrying a boolean `passed` wins; this
+  // tolerates code-fenced or prose-embedded verdicts without a greedy
+  // first-`{`..last-`}` slice that breaks on stray braces in the prose.
+  const candidates = extractJsonObjectCandidates(text);
+  if (candidates.length === 0) {
     return fallback(`judge response is not JSON: ${text.slice(0, 200)}`);
   }
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(text.slice(start, end + 1));
-  } catch (err) {
-    return fallback(`judge response JSON parse failed: ${(err as Error).message}`);
+  let lastObject: Record<string, unknown> | null = null;
+  let lastParseError: string | null = null;
+  for (const candidate of candidates) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(candidate);
+    } catch (err) {
+      lastParseError = (err as Error).message;
+      continue;
+    }
+    if (parsed === null || typeof parsed !== 'object') {
+      continue;
+    }
+    const obj = parsed as Record<string, unknown>;
+    if (typeof obj.passed === 'boolean') {
+      const reason = typeof obj.reason === 'string' && obj.reason.trim() !== ''
+        ? obj.reason
+        : 'no reason provided';
+      return { passed: obj.passed, reason, judge_id: LIVE_JUDGE_ID };
+    }
+    if (lastObject === null) {
+      lastObject = obj;
+    }
   }
 
-  if (parsed === null || typeof parsed !== 'object') {
-    return fallback('judge response did not decode to an object');
+  if (lastObject !== null) {
+    return fallback(`judge response missing boolean "passed": ${JSON.stringify(lastObject).slice(0, 200)}`);
   }
-  const obj = parsed as Record<string, unknown>;
-  if (typeof obj.passed !== 'boolean') {
-    return fallback(`judge response missing boolean "passed": ${JSON.stringify(obj).slice(0, 200)}`);
+  if (lastParseError !== null) {
+    return fallback(`judge response JSON parse failed: ${lastParseError}`);
   }
-  const reason = typeof obj.reason === 'string' && obj.reason.trim() !== ''
-    ? obj.reason
-    : 'no reason provided';
-  return { passed: obj.passed, reason, judge_id: LIVE_JUDGE_ID };
+  return fallback('judge response did not decode to an object');
+}
+
+/**
+ * Extract every balanced `{...}` substring from `text`, in start-index order,
+ * ignoring braces that appear inside JSON string literals. Used to locate a
+ * judge verdict object that may be wrapped in prose or code fences.
+ */
+function extractJsonObjectCandidates(text: string): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== '{') continue;
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let j = i; j < text.length; j++) {
+      const ch = text[j];
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (ch === '\\') {
+          escaped = true;
+        } else if (ch === '"') {
+          inString = false;
+        }
+        continue;
+      }
+      if (ch === '"') {
+        inString = true;
+      } else if (ch === '{') {
+        depth++;
+      } else if (ch === '}') {
+        depth--;
+        if (depth === 0) {
+          out.push(text.slice(i, j + 1));
+          break;
+        }
+      }
+    }
+  }
+  return out;
 }
 
 const JUDGE_SYSTEM_PROMPT = [

--- a/tests/benchmark/datasets/online-mind2web/live-deps.ts
+++ b/tests/benchmark/datasets/online-mind2web/live-deps.ts
@@ -106,6 +106,16 @@ export const OM2W_TOOLS = [
 /** Default model used when none is injected. */
 export const DEFAULT_OM2W_MODEL = 'claude-3-5-sonnet-latest';
 
+/**
+ * Default model<->tool turns allowed per single OM2W step. A step is meant to
+ * be ONE concrete action (optionally read the page, then act), so this is kept
+ * small on purpose. Without it the inner tool-use loop would fall back to
+ * WEBVOYAGER_BUDGET.max_tool_iterations (50) — a whole-task budget that, on
+ * OM2W's per-step runner (up to step_budget=100 steps), would permit ~100x50
+ * model turns per task. Callers may override via CreateLiveDepsOptions.
+ */
+export const DEFAULT_OM2W_MAX_TURNS_PER_STEP = 8;
+
 /** Default judge id surfaced on live verdicts. */
 const LIVE_JUDGE_ID = 'claude-llm-judge';
 
@@ -212,6 +222,12 @@ function summariseStep(
   finalText: string,
 ): RunnerStep {
   if (calls.length === 0) {
+    // A no-op turn (the model talked but called no tool) is recorded as ok:true
+    // by design: it is a benign "nothing happened this step", not a hard failure
+    // — the model often emits a terminal "done"/completion sentence here, and the
+    // judge rules on the accumulated evidence. It is NOT a runaway risk: the
+    // marginal-utility tracker feeds shouldStop(), which plateaus and stops the
+    // runner well before the step budget is exhausted on a stuck model.
     return {
       step: stepIndex,
       tool: 'none',
@@ -373,6 +389,7 @@ function textFromAnthropicRaw(raw: unknown): string {
 export function createLiveOnlineMind2WebDeps(options: CreateLiveDepsOptions): RunnerDeps {
   const model = options.model ?? DEFAULT_OM2W_MODEL;
   const now = options.now ?? Date.now;
+  const maxTurnsPerStep = options.maxTurnsPerStep ?? DEFAULT_OM2W_MAX_TURNS_PER_STEP;
   const adapter = new CapturingOM2WAdapter(options.adapter);
   const tools = OM2W_TOOLS.map((tool) => ({
     name: tool.name,
@@ -408,7 +425,7 @@ export function createLiveOnlineMind2WebDeps(options: CreateLiveDepsOptions): Ru
       system: STEP_SYSTEM_PROMPT,
       user: stepUserPrompt(task, stepIndex, history),
       tools,
-      ...(typeof options.maxTurnsPerStep === 'number' ? { maxTurns: options.maxTurnsPerStep } : {}),
+      maxTurns: maxTurnsPerStep,
     });
     const result = summariseStep(stepIndex, adapter.capturedCalls(), loop.finalText);
     // A budget/iteration abort means the agent ran out of turns or token/USD

--- a/tests/benchmark/datasets/online-mind2web/live-deps.ts
+++ b/tests/benchmark/datasets/online-mind2web/live-deps.ts
@@ -1,0 +1,385 @@
+/**
+ * Online-Mind2Web live-run production dependencies (#1427 Part 2 + #1428 wiring).
+ *
+ * Builds a production `RunnerDeps` (see ./runner) that:
+ *   1. step()      — drives ONE OM2W step by running the Anthropic tool-use
+ *                    loop (`runAnthropicToolUseLoop`) against an injected
+ *                    `MCPAdapter`, using an OM2W tool set modelled on the
+ *                    WebVoyager tool definitions. Evidence is captured through
+ *                    a `CapturingOM2WAdapter` wrapper.
+ *   2. judge()     — a REAL Claude LLM-as-Judge: sends task_description +
+ *                    accumulated evidence to the injected `AnthropicMessagesClient`
+ *                    and parses a strict JSON `{passed, reason}` verdict,
+ *                    falling back to `{passed:false}` on any parse failure.
+ *   3. shouldStop() — feeds the step history into the marginal-utility tracker
+ *                    and asks `recommendEarlyStop(...)` (#1428).
+ *
+ * Everything that touches the network or a browser is dependency-injected
+ * (`client`, `model`, `adapter`), so this module is fully unit-testable with
+ * fakes and runs in CI without an API key or a browser.
+ */
+
+import type { MCPAdapter, MCPToolResult } from '../../benchmark-runner';
+import { runAnthropicToolUseLoop, type AnthropicMessagesClient } from '../../llm-provider/anthropic-loop';
+import {
+  initialMarginalUtilityState,
+  recordStep,
+  summary as marginalUtilitySummary,
+  type MarginalUtilityState,
+} from '../../../../src/core/task-ledger/marginal-utility';
+import {
+  recommendEarlyStop,
+  type EarlyStopPolicy,
+} from '../../../../src/core/task-ledger/early-stop';
+import type { OnlineMind2WebTask } from './loader';
+import type { JudgeVerdict, RunnerDeps, RunnerStep } from './runner';
+
+/**
+ * OM2W browser tool set. Modelled on WEBVOYAGER_TOOLS' definition style — a
+ * flat list of MCP tools the model may call to drive a single step. The
+ * adapter is responsible for actually executing these against the live
+ * browser; here we only describe their shape for the model.
+ */
+export const OM2W_TOOLS = [
+  {
+    name: 'navigate',
+    description: 'Navigate the active browser tab to the requested URL.',
+    inputSchema: {
+      type: 'object',
+      properties: { url: { type: 'string' } },
+      required: ['url'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'tabs_create',
+    description: 'Open a new browser tab at the requested URL and return a tabId.',
+    inputSchema: {
+      type: 'object',
+      properties: { url: { type: 'string' } },
+      required: ['url'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'read_page',
+    description: 'Read the current browser page payload (text + interactive elements).',
+    inputSchema: {
+      type: 'object',
+      properties: { tabId: { type: 'string' } },
+      required: [],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'act',
+    description: 'Perform a high-level natural-language action on the page (e.g. "click the search button").',
+    inputSchema: {
+      type: 'object',
+      properties: { instruction: { type: 'string' } },
+      required: ['instruction'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'click',
+    description: 'Click an element identified by a selector or accessible label.',
+    inputSchema: {
+      type: 'object',
+      properties: { target: { type: 'string' } },
+      required: ['target'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'type',
+    description: 'Type text into an input element identified by a selector or accessible label.',
+    inputSchema: {
+      type: 'object',
+      properties: { target: { type: 'string' }, text: { type: 'string' } },
+      required: ['target', 'text'],
+      additionalProperties: false,
+    },
+  },
+] as const;
+
+/** Default model used when none is injected. */
+export const DEFAULT_OM2W_MODEL = 'claude-3-5-sonnet-latest';
+
+/** Default judge id surfaced on live verdicts. */
+const LIVE_JUDGE_ID = 'claude-llm-judge';
+
+function textFromResult(result: MCPToolResult): string {
+  return (result.content || [])
+    .map((part) => part.text ?? part.data ?? '')
+    .filter(Boolean)
+    .join('\n');
+}
+
+/**
+ * Wraps an inner `MCPAdapter`, recording the most recent tool calls so a
+ * single OM2W step can be summarised into a `RunnerStep`. Mirrors the
+ * WebVoyager `CapturingBenchmarkAdapter` capture pattern.
+ */
+export class CapturingOM2WAdapter implements MCPAdapter {
+  readonly name: string;
+  readonly mode: string;
+  readonly kind?: MCPAdapter['kind'];
+  readonly version?: string;
+
+  /** The tool calls made during the most recent step() invocation. */
+  private calls: Array<{ tool: string; args: Record<string, unknown>; ok: boolean; text: string }> = [];
+
+  constructor(private readonly inner: MCPAdapter) {
+    this.name = inner.name;
+    this.mode = inner.mode;
+    this.kind = inner.kind;
+    this.version = inner.version;
+  }
+
+  async setup(): Promise<void> {
+    await this.inner.setup?.();
+  }
+
+  async teardown(): Promise<void> {
+    await this.inner.teardown?.();
+  }
+
+  async callTool(toolName: string, args: Record<string, unknown>): Promise<MCPToolResult> {
+    const result = await this.inner.callTool(toolName, args);
+    this.calls.push({
+      tool: toolName,
+      args,
+      ok: !result.isError,
+      text: textFromResult(result),
+    });
+    return result;
+  }
+
+  /** Reset the per-step capture buffer. Call before each step. */
+  resetStepCapture(): void {
+    this.calls = [];
+  }
+
+  /** Snapshot of the tool calls captured since the last reset. */
+  capturedCalls(): ReadonlyArray<{ tool: string; args: Record<string, unknown>; ok: boolean; text: string }> {
+    return this.calls;
+  }
+}
+
+export interface CreateLiveDepsOptions {
+  /** Injectable Anthropic client (real SDK in prod, fake in tests). */
+  client: AnthropicMessagesClient;
+  /** Injectable MCP adapter (OpenChromeRealAdapter in prod, fake in tests). */
+  adapter: MCPAdapter;
+  /** Model id; defaults to {@link DEFAULT_OM2W_MODEL}. */
+  model?: string;
+  /** Max model<->tool iterations per single OM2W step. */
+  maxTurnsPerStep?: number;
+  /** Early-stop policy overrides forwarded to recommendEarlyStop. */
+  earlyStopPolicy?: EarlyStopPolicy;
+  /** Clock injection for deterministic marginal-utility timestamps. */
+  now?: () => number;
+}
+
+const STEP_SYSTEM_PROMPT = [
+  'You are an autonomous web agent running the Online-Mind2Web benchmark.',
+  'Use only the provided browser tools to make progress on the task.',
+  'On each turn take the single next concrete action that advances the task,',
+  'then stop and report what you did. Do not invent browser state.',
+].join('\n');
+
+function stepUserPrompt(task: OnlineMind2WebTask, stepIndex: number, history: RunnerStep[]): string {
+  const historyLines = history.length
+    ? history.map((h) => `  step ${h.step}: ${h.tool} -> ${h.ok ? 'ok' : 'error'} (${h.summary})`).join('\n')
+    : '  (none yet)';
+  return [
+    `Task: ${task.task_description}`,
+    `Target website: ${task.website}`,
+    `This is step ${stepIndex}. Prior steps:`,
+    historyLines,
+    'Take the next action now using a browser tool.',
+  ].join('\n');
+}
+
+/**
+ * Summarise the captured tool calls of one step into a single RunnerStep.
+ * If the model emitted no tool call this step is recorded as a no-op.
+ */
+function summariseStep(
+  stepIndex: number,
+  calls: ReadonlyArray<{ tool: string; args: Record<string, unknown>; ok: boolean; text: string }>,
+  finalText: string,
+): RunnerStep {
+  if (calls.length === 0) {
+    return {
+      step: stepIndex,
+      tool: 'none',
+      args: {},
+      ok: true,
+      summary: finalText.trim() || 'model produced no tool call',
+    };
+  }
+  // The last tool call drives the step's headline outcome.
+  const last = calls[calls.length - 1];
+  const summaryParts = [finalText.trim(), last.text.trim()].filter(Boolean);
+  return {
+    step: stepIndex,
+    tool: last.tool,
+    args: last.args,
+    ok: calls.every((c) => c.ok),
+    summary: summaryParts.join(' | ') || `${last.tool} executed`,
+  };
+}
+
+/**
+ * Parse the judge's reply into a JudgeVerdict. Accepts a bare JSON object or
+ * a JSON object embedded in surrounding prose / code fences. Any failure to
+ * extract a well-formed `{passed, reason}` falls back to passed:false.
+ */
+export function parseJudgeReply(text: string): JudgeVerdict {
+  const fallback = (reason: string): JudgeVerdict => ({
+    passed: false,
+    reason,
+    judge_id: LIVE_JUDGE_ID,
+  });
+
+  if (!text || text.trim() === '') {
+    return fallback('judge returned empty response');
+  }
+
+  // Extract the first balanced JSON object substring.
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start === -1 || end === -1 || end <= start) {
+    return fallback(`judge response is not JSON: ${text.slice(0, 200)}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text.slice(start, end + 1));
+  } catch (err) {
+    return fallback(`judge response JSON parse failed: ${(err as Error).message}`);
+  }
+
+  if (parsed === null || typeof parsed !== 'object') {
+    return fallback('judge response did not decode to an object');
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj.passed !== 'boolean') {
+    return fallback(`judge response missing boolean "passed": ${JSON.stringify(obj).slice(0, 200)}`);
+  }
+  const reason = typeof obj.reason === 'string' && obj.reason.trim() !== ''
+    ? obj.reason
+    : 'no reason provided';
+  return { passed: obj.passed, reason, judge_id: LIVE_JUDGE_ID };
+}
+
+const JUDGE_SYSTEM_PROMPT = [
+  'You are a strict evaluator for the Online-Mind2Web web-agent benchmark.',
+  "Given a task and the agent's step-by-step evidence, decide whether the task was completed.",
+  'Be conservative: only mark passed=true when the evidence clearly demonstrates success.',
+  'Respond with a single JSON object and nothing else: {"passed": boolean, "reason": string}.',
+].join('\n');
+
+function judgeUserPrompt(task: OnlineMind2WebTask, evidence: RunnerStep[]): string {
+  const evidenceLines = evidence.length
+    ? evidence
+        .map((e) => `  step ${e.step}: ${e.tool}(${JSON.stringify(e.args)}) -> ${e.ok ? 'ok' : 'error'}: ${e.summary}`)
+        .join('\n')
+    : '  (no steps recorded)';
+  return [
+    `Task: ${task.task_description}`,
+    `Target website: ${task.website}`,
+    'Agent evidence:',
+    evidenceLines,
+    'Did the agent complete the task? Reply with the JSON object only.',
+  ].join('\n');
+}
+
+/** Extract the assistant text from a raw Anthropic Messages response. */
+function textFromAnthropicRaw(raw: unknown): string {
+  if (raw === null || typeof raw !== 'object') return '';
+  const content = (raw as { content?: Array<{ type?: string; text?: string }> }).content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter((p) => p && p.type === 'text' && typeof p.text === 'string')
+    .map((p) => p.text as string)
+    .join('\n');
+}
+
+/**
+ * Build a production `RunnerDeps` from injected primitives. The returned deps
+ * are stateful only through the wrapped capturing adapter and a
+ * marginal-utility tracker rebuilt from history on each shouldStop() call.
+ */
+export function createLiveOnlineMind2WebDeps(options: CreateLiveDepsOptions): RunnerDeps {
+  const model = options.model ?? DEFAULT_OM2W_MODEL;
+  const now = options.now ?? Date.now;
+  const adapter = new CapturingOM2WAdapter(options.adapter);
+  const tools = OM2W_TOOLS.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema as Record<string, unknown>,
+  }));
+
+  // The marginal-utility tracker is rebuilt from history on each shouldStop()
+  // call so the deps object stays free of cross-task leakage.
+  const rebuildTracker = (history: RunnerStep[]): MarginalUtilityState => {
+    let state = initialMarginalUtilityState();
+    let ts = now();
+    for (const s of history) {
+      ts += 1;
+      state = recordStep(state, {
+        ts,
+        toolOk: s.ok,
+        assertPasses: 0,
+        assertFails: 0,
+        assertInconclusives: 0,
+        checkpointAdvanced: false,
+      });
+    }
+    return state;
+  };
+
+  const step: RunnerDeps['step'] = async (task, stepIndex, history) => {
+    adapter.resetStepCapture();
+    const loop = await runAnthropicToolUseLoop({
+      client: options.client,
+      adapter,
+      model,
+      system: STEP_SYSTEM_PROMPT,
+      user: stepUserPrompt(task, stepIndex, history),
+      tools,
+      ...(typeof options.maxTurnsPerStep === 'number' ? { maxTurns: options.maxTurnsPerStep } : {}),
+    });
+    return summariseStep(stepIndex, adapter.capturedCalls(), loop.finalText);
+  };
+
+  const judge: RunnerDeps['judge'] = async (task, evidence) => {
+    let raw: unknown;
+    try {
+      raw = await options.client.create({
+        model,
+        system: JUDGE_SYSTEM_PROMPT,
+        messages: [{ role: 'user', content: judgeUserPrompt(task, evidence) }],
+      });
+    } catch (err) {
+      return {
+        passed: false,
+        reason: `judge invocation failed: ${(err as Error).message}`,
+        judge_id: LIVE_JUDGE_ID,
+      };
+    }
+    return parseJudgeReply(textFromAnthropicRaw(raw));
+  };
+
+  const shouldStop: NonNullable<RunnerDeps['shouldStop']> = (history) => {
+    if (history.length === 0) return false;
+    const state = rebuildTracker(history);
+    const rec = recommendEarlyStop(marginalUtilitySummary(state), options.earlyStopPolicy);
+    return rec.should_stop;
+  };
+
+  return { step, judge, shouldStop };
+}

--- a/tests/benchmark/datasets/online-mind2web/live-deps.ts
+++ b/tests/benchmark/datasets/online-mind2web/live-deps.ts
@@ -410,7 +410,21 @@ export function createLiveOnlineMind2WebDeps(options: CreateLiveDepsOptions): Ru
       tools,
       ...(typeof options.maxTurnsPerStep === 'number' ? { maxTurns: options.maxTurnsPerStep } : {}),
     });
-    return summariseStep(stepIndex, adapter.capturedCalls(), loop.finalText);
+    const result = summariseStep(stepIndex, adapter.capturedCalls(), loop.finalText);
+    // A budget/iteration abort means the agent ran out of turns or token/USD
+    // budget before completing this step. Surface it as a failed step (mirrors
+    // the WebVoyager live runner, which records run.aborted) so the runner
+    // stops and the abort reason reaches the judge's evidence — otherwise a
+    // truncated step would be scored as a clean success and silently skew the
+    // benchmark pass-rate.
+    if (loop.aborted) {
+      return {
+        ...result,
+        ok: false,
+        summary: `${result.summary} | step aborted: ${loop.aborted}`,
+      };
+    }
+    return result;
   };
 
   const judge: RunnerDeps['judge'] = async (task, evidence) => {

--- a/tests/benchmark/datasets/online-mind2web/results/.gitignore
+++ b/tests/benchmark/datasets/online-mind2web/results/.gitignore
@@ -1,0 +1,3 @@
+# Generated OM2W live-run reports — not checked in.
+*
+!.gitignore


### PR DESCRIPTION
## Summary

Wires the **production live-run path** onto the previously-merged Online-Mind2Web (OM2W) skeleton. The merged `runOnlineMind2WebTask(task, deps, options)` contract (loader + runner + headline gate) shipped with only a deterministic *fake* judge and unimplemented `RunnerDeps`; this PR adds the real deps + a CLI so OM2W can actually be scored "webright-style", mirroring the existing WebVoyager live runner.

Implements **#1427 Part 2** (production adapter + model planner + real LLM-as-Judge) and the **#1428** early-stop wiring into the runner loop.

## What's added
- `tests/benchmark/datasets/online-mind2web/live-deps.ts` — `createLiveOnlineMind2WebDeps(...)` returns a production `RunnerDeps`:
  - `step()` drives one OM2W step via `runAnthropicToolUseLoop` over an OM2W tool set (navigate / tabs_create / read_page / act / click / type), capturing evidence through a `CapturingOM2WAdapter` wrapper.
  - `judge()` is a real Claude **LLM-as-Judge** with robust JSON extraction (`parseJudgeReply`) — handles bare/code-fenced/prose-embedded JSON and falls back to `{passed:false}` on malformed/empty/throwing replies.
  - `shouldStop()` rebuilds the marginal-utility tracker from step history and calls `recommendEarlyStop(...)` (`src/core/task-ledger/early-stop.ts`).
- `tests/benchmark/datasets/online-mind2web/cli.ts` — WebVoyager-style CLI: `--adapter mock|claude`, `--model`, `--limit`, `--step-budget`, `OPENCHROME_BENCH_ADAPTER` env override. Loads `fixture` by default / `hf` (300 tasks) when `OPENCHROME_OM2W_FETCH=1`. `mock` runs deterministically with no network/key/browser; `claude` gates via `assertAnthropicLiveEnabled()` then uses the real Anthropic SDK + `OpenChromeRealAdapter`. Emits JSON + MD report.
- `tests/benchmark/datasets/online-mind2web/live-deps.test.ts` — 13 unit tests with fake client + fake adapter (step capture, judge happy/embedded/malformed/throwing, early-stop plateau).
- `package.json` — `bench:om2w:mock` and `bench:om2w` scripts (no new dependencies; lockfile unchanged).

## Contract safety
The exported `RunnerDeps` / `RunnerResult` contract in `runner.ts` is **unchanged** — this only adds a production implementation of it. Broker/lease/CDP core untouched.

## Verification
- `npm run build` → exit 0, clean.
- `npx jest tests/benchmark/datasets/online-mind2web` → **42 passed, 1 skipped** (skip = HF network test, gated by design), 4 suites.
- Mock CLI E2E (no key): `cli.ts --adapter mock --limit 3 --step-budget 5` → `3 passed / 0 failed (pass-rate=100.0%)`, report written.
- Claude path with no key → fails fast with `ANTHROPIC_API_KEY is required...` (correctly gated).

## Out of scope
The actual *scored headline run* (real Chrome + real API key) is not executed here — this PR makes `bench:om2w:mock` run deterministically end-to-end and leaves `bench:om2w` ready for a keyed run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)