### PR TITLE
chore(test): cap jest workers and per-worker memory to prevent local RAM spikes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,5 +31,14 @@ module.exports = {
   },
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
   testTimeout: 10000,
+  // Bound worker count and per-worker memory so a full local run cannot
+  // exhaust RAM. This suite is large (~600 suites) and ts-jest holds a TS
+  // program per worker; on many-core machines the default (cores - 1)
+  // workers spike to multiple GB. '50%' keeps parallelism reasonable, and
+  // workerIdleMemoryLimit restarts any worker that grows past the cap
+  // (also mitigates leaky test teardowns). CI runners are small-core, so
+  // these caps are effectively no-ops there.
+  maxWorkers: '50%',
+  workerIdleMemoryLimit: '512MB',
   verbose: true,
 };


### PR DESCRIPTION
## Why

`jest.config.js` set **no `maxWorkers` and no `workerIdleMemoryLimit`**. This suite is large (~600 suites / ~7,400 tests) and the `ts-jest` preset holds a full TS program per worker. On a many-core dev machine the default (`cores - 1`) workers each consume hundreds of MB, so a full `npm test` / `npx jest` run can spike to **multiple GB** — compounded by tests that leak handles/timers ("worker failed to exit gracefully") and so delay worker exit.

A local full-suite verification run locked up RAM; this adds durable guardrails so it can't recur.

## Change (`jest.config.js`)

- `maxWorkers: '50%'` — bound parallelism to half the cores.
- `workerIdleMemoryLimit: '512MB'` — Jest restarts any worker that grows past the cap (also mitigates the leaky-teardown buildup).

## Impact

- **Local:** bounded RAM; no behavior change to tests.
- **CI:** `jest.ci.config.js` inherits these via `...baseConfig`. GitHub runners are small-core (2–4), so `'50%'` ≈ the previous effective worker count — no meaningful slowdown; the memory limit only adds OOM safety.

Validated: config parses (`maxWorkers=50%`, `workerIdleMemoryLimit=512MB`) and a scoped run passes (`tests/core/task-ledger/early-stop.test.ts` 7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)