### PR TITLE
fix(cli): align `update --client` with supported setup clients; fail fast otherwise (#1457 PR-8)

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -425,7 +425,7 @@ program
   .command('update')
   .description('Update the globally installed OpenChrome package')
   .option('--no-setup', 'skip MCP client reconfiguration after updating')
-  .option('--client <client>', 'MCP client to reconfigure after updating (claude, codex, vscode, cursor, windsurf)', 'claude')
+  .option('--client <client>', 'MCP client to reconfigure after updating (claude, codex, opencode)', 'claude')
   .option('--scope <scope>', 'Claude Code scope to use during setup (user or project)', 'user')
   .action((options) => {
     const code = runUpdateCommand({

--- a/cli/update-command.ts
+++ b/cli/update-command.ts
@@ -1,10 +1,16 @@
 import { spawnSync } from 'child_process';
+import { getSupportedMCPClients, isSupportedMCPClient } from './mcp-client-config';
 
 const UPDATE_COMMAND = ['npm', 'install', '-g', 'openchrome-mcp@latest'] as const;
 
 export interface UpdateCommandOptions {
   setup?: boolean;
-  client?: 'claude' | 'codex' | 'vscode' | 'cursor' | 'windsurf';
+  /**
+   * MCP client to reconfigure after updating. Validated at runtime against the
+   * automated-setup set (`getSupportedMCPClients()`); unsupported clients such as
+   * Cursor / VS Code / Windsurf are rejected with a pointer to the manual config.
+   */
+  client?: string;
   scope?: 'user' | 'project';
 }
 
@@ -43,6 +49,18 @@ function getSetupArgs(options: UpdateCommandOptions): string[] {
 
 export function runUpdateCommand(options: UpdateCommandOptions = {}): number {
   const setup = options.setup !== false;
+
+  // Fail fast on an unsupported --client before touching npm, so the advertised
+  // flag can never forward to `setup --client X` and exit(1) mid-update. Cursor /
+  // VS Code / Windsurf use a manual MCP config block (see README), not automated
+  // setup.
+  if (setup && options.client && !isSupportedMCPClient(options.client)) {
+    console.error(`Unsupported --client "${options.client}". Automated setup supports: ${getSupportedMCPClients().join(', ')}.`);
+    console.error('For Cursor / VS Code / Windsurf, copy the manual MCP config block from the README:');
+    console.error('  https://github.com/shaun0927/openchrome#quick-start');
+    console.error('Or run "openchrome update --no-setup" to update the package without reconfiguring a client.');
+    return 1;
+  }
 
   console.log(`Running: ${getUpdateCommandText()}`);
   const updateStatus = run(UPDATE_COMMAND[0], UPDATE_COMMAND.slice(1));

--- a/tests/cli/update-command.test.ts
+++ b/tests/cli/update-command.test.ts
@@ -60,6 +60,31 @@ describe('cli/update-command', () => {
     });
   });
 
+  test('can refresh OpenCode setup after updating', () => {
+    mockedSpawnSync.mockReturnValue({ status: 0 } as unknown as ReturnType<typeof spawnSync>);
+
+    // opencode was previously missing from the --client type even though `setup`
+    // supports it; this guards that regression.
+    expect(runUpdateCommand({ client: 'opencode' })).toBe(0);
+
+    expect(mockedSpawnSync).toHaveBeenNthCalledWith(2, 'openchrome', ['setup', '--client', 'opencode', '--scope', 'user'], {
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
+  });
+
+  test('rejects an unsupported --client before touching npm, pointing to manual config', () => {
+    // cursor/windsurf/vscode were advertised in --client help but rejected by the
+    // setup layer with exit(1) mid-update. Now we fail fast with guidance.
+    expect(runUpdateCommand({ client: 'cursor' })).toBe(1);
+
+    expect(mockedSpawnSync).not.toHaveBeenCalled();
+
+    const output = consoleErrorSpy.mock.calls.map((call: unknown[]) => call[0]).join('\n');
+    expect(output).toContain('Unsupported --client "cursor"');
+    expect(output).toContain('manual MCP config');
+  });
+
   test('prints actionable guidance when npm is unavailable', () => {
     const error = Object.assign(new Error('spawn npm ENOENT'), { code: 'ENOENT' });
     mockedSpawnSync.mockReturnValue({ error } as unknown as ReturnType<typeof spawnSync>);


### PR DESCRIPTION
Part of the SSOT (#1359) pillar gap audit (#1457) — **PR-8 / Pillar A**.

## The dead path
`openchrome update --client cursor|windsurf|vscode` advertised those clients in `--client` help and forwarded to `openchrome setup --client X` — but `setup` only supports `claude|codex|opencode`, so the advertised value hit `process.exit(1)` mid-update. The flag also **omitted `opencode`**, which `setup` does support.

## Changes
- **cli/index.ts** — fix `--client` help to the real set: `(claude, codex, opencode)`.
- **cli/update-command.ts** — validate `--client` against `getSupportedMCPClients()` **before touching npm**; reject unsupported clients with a pointer to the README manual MCP config block (Cursor / VS Code / Windsurf) and the `--no-setup` escape hatch. Option type widened to a runtime-validated string.

## SSOT alignment
Pillar A (setup support for the declared host classes). Honest advertising: the CLI no longer offers automated setup it then rejects; manual config remains documented for the other clients.

## Verification
- `npx tsc --noEmit` → clean.
- `tests/cli/update-command.test.ts` → 6 passed, incl. `--client opencode` (regression guard) and fail-fast on `--client cursor` (npm not invoked, manual-config guidance printed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)