### PR TITLE
feat(contracts): machine-stable failure_category on oc_assert fail (#1457 PR-5)

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -231,6 +231,18 @@ followed by `JSON.parse` is lossless for every assertion kind in this
 document. If you need to wire trace events to a replay UI, attach
 `trace_ref` from the runtime — the DSL itself never invents trace IDs.
 
+### `failure_category` on a `fail` verdict
+
+When `oc_assert` returns `verdict: "fail"`, the output also carries a
+machine-stable `failure_category` (one of the shared `FAILURE_CATEGORIES`,
+e.g. `POSTCONDITION_FAILED`, `ELEMENT_NOT_FOUND`, `NAVIGATION_TIMEOUT`) plus a
+short `failure_reason`. A clean expected/actual mismatch is
+`POSTCONDITION_FAILED`; if an evaluator surfaced an error string (e.g. a
+detached node), that error is classified instead. This lets a host agent branch
+recovery (retry vs re-auth vs solve-captcha) on a stable code rather than
+re-parsing raw diffs. Classification is purely deterministic — OpenChrome never
+calls a model to decide it.
+
 ## Worked example — `amazon.checkout`
 
 ```jsonc

--- a/src/tools/oc-assert.ts
+++ b/src/tools/oc-assert.ts
@@ -29,6 +29,8 @@ import { evaluate } from '../contracts/evaluate';
 import { validateAssertion } from '../contracts/validator';
 import { getActiveActionRecorder } from '../recording/action-recorder';
 import type { EvalContext, NetworkLogEntry } from '../contracts/eval-context';
+import { primaryFailureCategory } from '../failure/classifier';
+import type { FailureCategory } from '../failure/categories';
 import type {
   Assertion,
   EvaluationResult,
@@ -48,6 +50,13 @@ interface FailedAssertion {
 interface OcAssertOutput {
   verdict: Verdict;
   failed_assertions?: FailedAssertion[];
+  /**
+   * Machine-stable failure category on a `fail` verdict, so a host agent can
+   * branch recovery (retry vs re-auth vs solve-captcha) instead of re-parsing
+   * raw expected/actual diffs (#1457 PR-5 / SSOT P4 — facts the host can act on).
+   */
+  failure_category?: FailureCategory;
+  failure_reason?: string;
   evidence_handle?: string;
   evidence?: Evidence;
   validation_errors?: Array<{ path: string; message: string }>;
@@ -400,6 +409,9 @@ const handler: ToolHandler = async (
 
   if (verdict === 'fail') {
     output.failed_assertions = collectFailedAssertions(validation.value, result.evidence, '$');
+    const classified = deriveFailureCategory(result.evidence, output.failed_assertions);
+    output.failure_category = classified.category;
+    output.failure_reason = classified.reason;
   } else if (verdict === 'inconclusive') {
     output.inconclusive_reason =
       typeof result.evidence.details.error === 'string'
@@ -422,6 +434,39 @@ const handler: ToolHandler = async (
 
   return jsonResult(output);
 };
+
+/**
+ * Map an oc_assert failure to a structured, host-actionable failure category
+ * (#1457 PR-5 / SSOT P4). A clean expected/actual mismatch is POSTCONDITION_FAILED;
+ * when an evaluator surfaced an error string (e.g. a detached node or a navigation
+ * timeout caught by the evaluator) we classify that instead, so a host can branch
+ * recovery rather than re-reading raw diffs. Purely deterministic — no LLM.
+ */
+function deriveFailureCategory(
+  evidence: Evidence,
+  failed: FailedAssertion[],
+): { category: FailureCategory; reason: string } {
+  const errorTexts: string[] = [];
+  const collectError = (details: unknown): void => {
+    if (details && typeof details === 'object' && !Array.isArray(details)) {
+      const err = (details as Record<string, unknown>).error;
+      if (typeof err === 'string' && err.length > 0) errorTexts.push(err);
+    }
+  };
+  collectError(evidence.details);
+  for (const fa of failed) collectError(fa.actual);
+
+  for (const text of errorTexts) {
+    const classified = primaryFailureCategory({ message: text, fallbackToUnknown: false });
+    if (classified && classified.category !== 'UNKNOWN') {
+      return { category: classified.category, reason: classified.reason };
+    }
+  }
+  return {
+    category: 'POSTCONDITION_FAILED',
+    reason: 'the contract postcondition did not hold (expected/actual mismatch)',
+  };
+}
 
 function makeEvidenceHandle(): string {
   // Placeholder for #792 oc_evidence_bundle. The handle is currently not

--- a/src/tools/oc-assert.ts
+++ b/src/tools/oc-assert.ts
@@ -442,7 +442,7 @@ const handler: ToolHandler = async (
  * timeout caught by the evaluator) we classify that instead, so a host can branch
  * recovery rather than re-reading raw diffs. Purely deterministic — no LLM.
  */
-function deriveFailureCategory(
+export function deriveFailureCategory(
   evidence: Evidence,
   failed: FailedAssertion[],
 ): { category: FailureCategory; reason: string } {
@@ -453,12 +453,17 @@ function deriveFailureCategory(
       if (typeof err === 'string' && err.length > 0) errorTexts.push(err);
     }
   };
+  // A top-level evidence error routes to `inconclusive` (see isInconclusive), so
+  // on a `fail` verdict the reachable error source is usually a logical child
+  // leaf surfaced in `fa.actual`; we still scan both for completeness.
   collectError(evidence.details);
   for (const fa of failed) collectError(fa.actual);
 
   for (const text of errorTexts) {
+    // With `fallbackToUnknown: false`, primaryFailureCategory returns undefined
+    // (never UNKNOWN) when no rule matches, so a falsy result means "fall back".
     const classified = primaryFailureCategory({ message: text, fallbackToUnknown: false });
-    if (classified && classified.category !== 'UNKNOWN') {
+    if (classified) {
       return { category: classified.category, reason: classified.reason };
     }
   }

--- a/tests/core/contracts/oc-assert.test.ts
+++ b/tests/core/contracts/oc-assert.test.ts
@@ -13,8 +13,9 @@
  * (oc_evidence_bundle). It is asserted only by shape — not consumed.
  */
 
-import { registerOcAssertTool } from '../../../src/tools/oc-assert';
+import { registerOcAssertTool, deriveFailureCategory } from '../../../src/tools/oc-assert';
 import type { MCPToolDefinition, MCPResult, ToolHandler } from '../../../src/types/mcp';
+import type { Evidence } from '../../../src/contracts/types';
 
 interface RegisteredTool {
   name: string;
@@ -258,5 +259,52 @@ describe('oc_assert — per-evaluator coverage', () => {
     // The failing leaf is the dom_text child at index 1.
     expect(failed[0].name).toContain('dom_text');
     expect(failed[0].name).toContain('children.1');
+  });
+});
+
+describe('deriveFailureCategory — host-actionable taxonomy', () => {
+  const failEvidence = (details: Record<string, unknown> = {}): Evidence => ({
+    passed: false,
+    assertion_kind: 'and',
+    details,
+  });
+
+  test('clean expected/actual mismatch (no evaluator error) → POSTCONDITION_FAILED', () => {
+    const out = deriveFailureCategory(failEvidence(), [
+      { name: '$[url]', expected: { pattern: '^x$' }, actual: 'https://example.com' },
+    ]);
+    expect(out.category).toBe('POSTCONDITION_FAILED');
+    expect(out.reason).toMatch(/postcondition/i);
+  });
+
+  test('classifies an evaluator error surfaced on a failed child leaf (ELEMENT_NOT_FOUND)', () => {
+    // A logical (and/or) failure can crack open to a child leaf whose `actual`
+    // carries an evaluator error string — that error is classified, not the diff.
+    const out = deriveFailureCategory(failEvidence(), [
+      { name: '$.children.0[dom_text]', expected: {}, actual: { error: 'element not found: .add-to-cart' } },
+    ]);
+    expect(out.category).toBe('ELEMENT_NOT_FOUND');
+    expect(out.reason.length).toBeGreaterThan(0);
+  });
+
+  test('classifies a navigation-timeout error string', () => {
+    const out = deriveFailureCategory(failEvidence({ error: 'navigation timeout exceeded' }), []);
+    expect(out.category).toBe('NAVIGATION_TIMEOUT');
+  });
+
+  test('unclassifiable error text falls back to POSTCONDITION_FAILED (never UNKNOWN)', () => {
+    const out = deriveFailureCategory(failEvidence(), [
+      { name: '$[dom_text]', expected: {}, actual: { error: 'totally opaque failure xyzzy' } },
+    ]);
+    expect(out.category).toBe('POSTCONDITION_FAILED');
+  });
+
+  test('ignores non-object / non-string actual values without throwing', () => {
+    const out = deriveFailureCategory(failEvidence(), [
+      { name: '$[url]', expected: {}, actual: null },
+      { name: '$[count]', expected: {}, actual: 3 },
+      { name: '$[list]', expected: {}, actual: ['element not found'] },
+    ]);
+    expect(out.category).toBe('POSTCONDITION_FAILED');
   });
 });

--- a/tests/core/contracts/oc-assert.test.ts
+++ b/tests/core/contracts/oc-assert.test.ts
@@ -87,6 +87,35 @@ describe('oc_assert — verdicts', () => {
     expect(failed[0].actual).toBe('https://example.com');
   });
 
+  test('fail: surfaces a machine-stable failure_category (POSTCONDITION_FAILED for a clean mismatch)', async () => {
+    const { handler } = setup();
+    const out = await invoke(handler, {
+      contract: { kind: 'url', pattern: '^https://other\\.com' },
+      evidence: { snapshot: { url: 'https://example.com' } },
+    });
+    expect(out.verdict).toBe('fail');
+    // A clean expected/actual mismatch (no evaluator error) classifies as a
+    // postcondition failure so the host can branch recovery on a stable code.
+    expect(out.failure_category).toBe('POSTCONDITION_FAILED');
+    expect(typeof out.failure_reason).toBe('string');
+  });
+
+  test('pass / inconclusive verdicts carry no failure_category', async () => {
+    const { handler } = setup();
+    const pass = await invoke(handler, {
+      contract: { kind: 'url', pattern: '^https://example\\.com/?$' },
+      evidence: { snapshot: { url: 'https://example.com' } },
+    });
+    expect(pass.verdict).toBe('pass');
+    expect(pass.failure_category).toBeUndefined();
+
+    const inconclusive = await invoke(handler, {
+      contract: { kind: 'url', pattern: '^x$' },
+    });
+    expect(inconclusive.verdict).toBe('inconclusive');
+    expect(inconclusive.failure_category).toBeUndefined();
+  });
+
   test('inconclusive: missing evidence.snapshot', async () => {
     const { handler } = setup();
     const out = await invoke(handler, {


### PR DESCRIPTION
Part of the SSOT (#1359) pillar gap audit (#1457) — **PR-5 (C5) / Pillar C / P4**.

## The gap
On a `fail` verdict, `oc_assert` returned only per-leaf expected/actual diffs. The full deterministic failure taxonomy (`src/failure/`) existed but was consumed **only** by the pilot recovery runtime — so a host using core `oc_assert` got no machine-stable code to branch recovery on.

## Change
- `oc_assert` output now carries **`failure_category`** (a `FAILURE_CATEGORIES` value — `POSTCONDITION_FAILED`, `ELEMENT_NOT_FOUND`, `NAVIGATION_TIMEOUT`, …) and **`failure_reason`** on `fail`.
- A clean expected/actual mismatch → `POSTCONDITION_FAILED`; if an evaluator surfaced an error string (detached node, timeout) that error is classified via `primaryFailureCategory`.
- `docs/contracts.md` documents it under *Evidence shape*.

## SSOT alignment
P4 — facts the host can act on, **no LLM**. `src/tools` (core) → `src/failure` (core) keeps the tier boundary intact (`lint:tier` clean).

## Scope note
The audit's **C6 perf/console assertion kinds** are intentionally **split into a follow-up**: they extend the `EvalContext` contract (new console/perf seams) and the snapshot adapter, which is a materially larger change deserving its own PR.

## Verification
- `npx tsc --noEmit` → clean.
- `npm run lint:tier` → no core→pilot violation.
- `tests/core/contracts/oc-assert.test.ts` → 17 passed, incl. 2 new (POSTCONDITION_FAILED on clean mismatch; no category on pass/inconclusive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)