### PR TITLE
feat(skill): explicit provenance on skill records; label host writes unverified (#1457 PR-4)

### DIFF
--- a/src/core/skill-memory/index.ts
+++ b/src/core/skill-memory/index.ts
@@ -27,6 +27,7 @@ export type {
   SkillMemoryFile,
   SkillMemoryFileV1,
   SkillMemoryFileV2,
+  SkillProvenance,
   SkillRecord,
 } from './types';
 

--- a/src/core/skill-memory/store.ts
+++ b/src/core/skill-memory/store.ts
@@ -43,6 +43,7 @@ import {
   SKILL_MEMORY_SCHEMA_VERSION_V2,
   type FrozenSnapshot,
   type SkillMemoryFile,
+  type SkillProvenance,
   type SkillRecord,
 } from './types';
 import { validateReplayArtifact, type ReplayArtifact } from './replay-artifact';
@@ -433,6 +434,26 @@ export class SkillMemoryStore {
         // without an explicit value, preserve the existing pointers so a
         // re-record that omits codegen does not erase prior captures.
         codegenArtifacts: skill.codegenArtifacts ?? existing?.codegenArtifacts ?? [],
+        // Provenance (#1457 PR-4). Caller-supplied wins, but the first-record
+        // timestamp is preserved across idempotent re-records. When neither the
+        // caller nor an existing record supplies it, default to `unknown` so the
+        // field is always present on freshly written records (legacy records
+        // read back without it and consumers treat absence as `unknown`).
+        provenance: ((): SkillProvenance => {
+          if (skill.provenance) {
+            return {
+              ...skill.provenance,
+              recordedAt: existing?.provenance?.recordedAt ?? skill.provenance.recordedAt,
+            };
+          }
+          return (
+            existing?.provenance ?? {
+              source: 'unknown',
+              recordedAt: Date.now(),
+              ...(skill.contractId ? { contractRef: skill.contractId } : {}),
+            }
+          );
+        })(),
       };
       // Preserve replay-outcome fields across idempotent re-record. The
       // recorder owns `steps`/`contractId`; the replay path owns the

--- a/src/core/skill-memory/types.ts
+++ b/src/core/skill-memory/types.ts
@@ -124,6 +124,42 @@ export interface SkillRecord {
    * When codegen is disabled at record time the field is written as `[]`.
    */
   codegenArtifacts?: CodegenArtifactPointer[];
+
+  /**
+   * Explicit provenance for this record (#1457 PR-4 / SSOT Pillar D —
+   * "explicit provenance for every promoted skill or memory record"). Optional
+   * and additive: legacy records read back with `provenance` absent, which
+   * consumers treat as `source: 'unknown'`. The core store records what the
+   * writer claimed; it does NOT itself verify (P4/P7 — verification is the
+   * host's / pilot curator's job), so `verified` lets recall distinguish
+   * Verified-Skill-Loop-eligible records from unverified direct writes.
+   */
+  provenance?: SkillProvenance;
+}
+
+/**
+ * Where a {@link SkillRecord} came from and whether its writer claimed it was
+ * contract-verified. Part of the Verified Skill Loop (see
+ * docs/roadmap/ssot-decisions.md D2).
+ */
+export interface SkillProvenance {
+  /**
+   * `host` = a direct `oc_skill_record` MCP call; `curator` = the pilot
+   * auto-extractor (contract-verified); `replay` = a replay-outcome write;
+   * `unknown` = legacy / normalized.
+   */
+  source: 'host' | 'curator' | 'replay' | 'unknown';
+  /** Wall-clock ms epoch of the first record write (stable across re-records). */
+  recordedAt: number;
+  /** Contract id the skill is bound to, surfaced for audit (mirrors contractId). */
+  contractRef?: string;
+  /**
+   * Whether the writer asserted this skill came from a contract-verified
+   * success. Defaults to `false` for direct host writes — the core store never
+   * sets it `true` on its own. Only a verified extractor / promotion path may
+   * record `true`.
+   */
+  verified?: boolean;
 }
 
 /**

--- a/src/core/skill-memory/types.ts
+++ b/src/core/skill-memory/types.ts
@@ -192,7 +192,7 @@ export interface SkillMemoryFile {
  */
 export interface SkillMemoryFileV1 {
   schema_version: typeof SKILL_MEMORY_SCHEMA_VERSION_V1;
-  skills: Record<string, Omit<SkillRecord, 'replayArtifacts' | 'codegenArtifacts'>>;
+  skills: Record<string, Omit<SkillRecord, 'replayArtifacts' | 'codegenArtifacts' | 'provenance'>>;
 }
 
 /**
@@ -202,7 +202,7 @@ export interface SkillMemoryFileV1 {
  */
 export interface SkillMemoryFileV2 {
   schema_version: typeof SKILL_MEMORY_SCHEMA_VERSION_V2;
-  skills: Record<string, Omit<SkillRecord, 'codegenArtifacts'>>;
+  skills: Record<string, Omit<SkillRecord, 'codegenArtifacts' | 'provenance'>>;
 }
 
 /**

--- a/src/tools/oc-skill-record.ts
+++ b/src/tools/oc-skill-record.ts
@@ -260,6 +260,16 @@ const handler: ToolHandler = async (
       frozenSnapshotPath: snapshotPath ?? null,
       ...(replayArtifactsForStore !== undefined ? { replayArtifacts: replayArtifactsForStore } : {}),
       codegenArtifacts,
+      // #1457 PR-4: a direct oc_skill_record call is a host write. The core
+      // store does not verify (P4/P7), so this is labelled `verified: false`;
+      // recall surfaces it so a host can tell unverified direct writes apart
+      // from Verified-Skill-Loop records promoted by the pilot curator.
+      provenance: {
+        source: 'host',
+        recordedAt: Date.now(),
+        ...(contractId ? { contractRef: contractId } : {}),
+        verified: false,
+      },
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/tests/core/skill-memory/provenance.test.ts
+++ b/tests/core/skill-memory/provenance.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for explicit skill provenance on SkillMemoryStore (#1457 PR-4).
+ *
+ * Covers:
+ *   - a record written without provenance defaults to source `unknown` with a
+ *     contractRef mirrored from contractId;
+ *   - caller-supplied provenance (e.g. a host write) round-trips through disk;
+ *   - the first-record timestamp is preserved across idempotent re-records,
+ *     even when the re-record supplies a different recordedAt.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { SkillMemoryStore, type SkillRecord } from '../../../src/core/skill-memory';
+
+function tempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'oc-skill-provenance-'));
+}
+
+function baseInput(overrides: Partial<SkillRecord> = {}) {
+  return {
+    domain: 'amazon.com',
+    name: 'add-to-cart',
+    steps: [{ kind: 'click', selector: '#buy-now' }],
+    contractId: 'contract-1',
+    successCount: 0,
+    lastUsedAt: 0,
+    frozenSnapshotPath: null as string | null,
+    ...overrides,
+  };
+}
+
+describe('SkillMemoryStore — explicit provenance (#1457 PR-4)', () => {
+  let root: string;
+  let store: SkillMemoryStore;
+
+  beforeEach(() => {
+    root = tempRoot();
+    store = new SkillMemoryStore({ rootDir: root, domain: 'amazon.com' });
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('defaults provenance to source=unknown with a mirrored contractRef when none supplied', async () => {
+    const { skill_id } = await store.record(baseInput());
+    const rec = store.get(skill_id);
+    expect(rec?.provenance?.source).toBe('unknown');
+    expect(rec?.provenance?.contractRef).toBe('contract-1');
+    expect(typeof rec?.provenance?.recordedAt).toBe('number');
+  });
+
+  it('round-trips caller-supplied host provenance through disk', async () => {
+    const { skill_id } = await store.record(
+      baseInput({
+        provenance: { source: 'host', recordedAt: 1700000000000, contractRef: 'contract-1', verified: false },
+      }),
+    );
+    // Re-open from disk to prove persistence (not just the in-memory return).
+    const reopened = new SkillMemoryStore({ rootDir: root, domain: 'amazon.com' });
+    const rec = reopened.get(skill_id);
+    expect(rec?.provenance).toEqual({
+      source: 'host',
+      recordedAt: 1700000000000,
+      contractRef: 'contract-1',
+      verified: false,
+    });
+  });
+
+  it('preserves the first-record timestamp across idempotent re-records', async () => {
+    await store.record(
+      baseInput({ provenance: { source: 'host', recordedAt: 111, verified: false } }),
+    );
+    // Same (domain, name) → idempotent re-record with a different recordedAt.
+    const { skill_id } = await store.record(
+      baseInput({
+        steps: [{ kind: 'click', selector: '#buy-now-v2' }],
+        provenance: { source: 'host', recordedAt: 999, verified: false },
+      }),
+    );
+    expect(store.get(skill_id)?.provenance?.recordedAt).toBe(111);
+  });
+});

--- a/tests/core/skill-memory/provenance.test.ts
+++ b/tests/core/skill-memory/provenance.test.ts
@@ -6,7 +6,11 @@
  *     contractRef mirrored from contractId;
  *   - caller-supplied provenance (e.g. a host write) round-trips through disk;
  *   - the first-record timestamp is preserved across idempotent re-records,
- *     even when the re-record supplies a different recordedAt.
+ *     even when the re-record supplies a different recordedAt;
+ *   - a curator `verified: true` write round-trips through disk without the
+ *     core store altering it (P4/P7 — core never sets/clears verified);
+ *   - a legacy record persisted without provenance reads back with the field
+ *     absent (consumers treat absence as `source: 'unknown'`).
  */
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -82,4 +86,54 @@ describe('SkillMemoryStore — explicit provenance (#1457 PR-4)', () => {
     );
     expect(store.get(skill_id)?.provenance?.recordedAt).toBe(111);
   });
+
+  it('round-trips a curator verified:true write through disk without core downgrading it', async () => {
+    const { skill_id } = await store.record(
+      baseInput({
+        provenance: { source: 'curator', recordedAt: 1700000000001, contractRef: 'contract-1', verified: true },
+      }),
+    );
+    const reopened = new SkillMemoryStore({ rootDir: root, domain: 'amazon.com' });
+    const rec = reopened.get(skill_id);
+    // The core store records what the writer claimed; it neither sets nor clears
+    // `verified` on its own (P4/P7) — a verified extractor write survives intact.
+    expect(rec?.provenance?.source).toBe('curator');
+    expect(rec?.provenance?.verified).toBe(true);
+  });
+
+  it('reads a legacy record (persisted without provenance) back with provenance absent', async () => {
+    // Persist a record, then rewrite skills.json as a pre-provenance v2 file
+    // with the field stripped, to mimic data written before #1457 PR-4.
+    const { skill_id } = await store.record(baseInput());
+    const skillsJson = findSkillsJson(root);
+    const file = JSON.parse(fs.readFileSync(skillsJson, 'utf8')) as {
+      schema_version: number;
+      skills: Record<string, Record<string, unknown>>;
+    };
+    for (const rec of Object.values(file.skills)) {
+      delete rec.provenance;
+      delete rec.codegenArtifacts;
+    }
+    file.schema_version = 2; // pre-provenance, pre-codegen on-disk shape
+    fs.writeFileSync(skillsJson, JSON.stringify(file), 'utf8');
+
+    const reopened = new SkillMemoryStore({ rootDir: root, domain: 'amazon.com' });
+    // Documented contract: absent provenance reads back as undefined and
+    // consumers treat it as `source: 'unknown'`.
+    expect(reopened.get(skill_id)?.provenance).toBeUndefined();
+  });
 });
+
+/** Locate the single per-domain skills.json under a freshly-created root. */
+function findSkillsJson(rootDir: string): string {
+  const stack = [rootDir];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (entry.name === 'skills.json') return full;
+    }
+  }
+  throw new Error(`skills.json not found under ${rootDir}`);
+}


### PR DESCRIPTION
Part of the SSOT (#1359) pillar gap audit (#1457) — **PR-4 (D3) / Pillar D**.

## The gap
SSOT Pillar D requires *"explicit provenance for every promoted skill or memory record."* The audit found **zero provenance** on core records, and that `oc_skill_record` writes land in the recallable store with no way to distinguish a verified record from an unverified direct write (D1).

## Change (additive, P4/P7-safe — core does **not** verify)
- **types** — new `SkillProvenance { source, recordedAt, contractRef?, verified? }` on `SkillRecord` (same additive pattern as `codegenArtifacts`); exported from `core/skill-memory`.
- **store.record()** — persists provenance; **preserves the first-record `recordedAt`** across idempotent re-records; defaults to `source: 'unknown'` (contractRef mirrored from contractId) when none supplied. Legacy records read back with provenance absent → consumers treat absence as `unknown`.
- **oc_skill_record** — labels every direct host write `source: 'host', verified: false`, so recall (which surfaces the full record) lets a host tell unverified direct writes apart from Verified-Skill-Loop records → **mitigates D1** without core verifying.

## Scope note (D2 deferred)
Reconciling the core store's name-hash id scheme with the pilot curator's anchor-hash id (so the verified-extraction pipeline actually feeds recall) is a **data-migration-class change** and is split into a dedicated follow-up. `docs/roadmap/ssot-decisions.md` (PR-9) names this loop the **Verified Skill Loop** and records the in-progress status.

## SSOT alignment
Pillar D + P4 (facts) + P7 (core stays boring; verification stays in pilot/host). Backward-compatible; `lint:tier` clean.

## Verification
- `npx tsc --noEmit` → clean.
- `npm run lint:tier` → clean.
- skill-memory `store` + `codegen-artifacts` + new `provenance` suites → **36 passed** (3 new: default-unknown provenance, host round-trip through disk, stable `recordedAt` across re-record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)