### PR TITLE
docs(reliability): reconcile stale roadmap with shipped reality; record D4/D5

### DIFF
--- a/docs/roadmap/issue-reliability-guarantee.md
+++ b/docs/roadmap/issue-reliability-guarantee.md
@@ -315,13 +315,15 @@ found to be already implemented (e.g. memory-pressure aggressive cleanup in
 `src/session-manager.ts` + E2E-21) or explicitly out of scope (SLO burn-rate alerting → operator).
 What survived rigorous re-verification:
 
-- **L1 — Retry-path inconsistency (bug).** The thrown-connection-error retry path
-  (`src/mcp-server.ts` ~2092) wraps its retry in a timeout race *and* gates it on
-  `reconcileAfterReconnect()`. The swallowed-connection-error retry path (~2148) does **neither**:
-  the retry is a bare `await tool.handler(...)` with no timeout race (can hang the stdio path,
-  violating the never-hang contract — HTTP mode is masked by the 30s request timeout) and no
-  reconcile guard. Fix is consistency, not new behavior: mirror the throw-path guards. Tracked
-  for a dedicated PR. Decision context: **D4** in `ssot-decisions.md`.
+- **L1 — Retry-path inconsistency + dead gate (bug). [Fixed: PR #1471, issue #1469]** The
+  thrown-connection-error retry path (`src/mcp-server.ts` ~2092) wraps its retry in a timeout race
+  *and* gates it on `reconcileAfterReconnect()`. The swallowed-connection-error retry path (~2148)
+  did **neither** — and was in fact **dead code**: it gated on `isConnectionError({ message: errorText })`,
+  but `isConnectionError` stringifies non-`Error` values via `formatError`→`String(value)`, so the
+  plain object became `"[object Object]"` and matched no pattern, so the retry never fired. The fix
+  passes the string directly, then mirrors the throw-path guards (reconcile gate + timeout race; a
+  bare `await` could otherwise hang the stdio path, violating the never-hang contract). Decision
+  context: **D4** in `ssot-decisions.md`.
 
 - **L2 — Timeout/abort does not cancel the underlying CDP call.** On tool timeout or client
   abort, `src/utils/with-timeout.ts` returns immediately and leaves the in-flight CDP command

--- a/docs/roadmap/issue-reliability-guarantee.md
+++ b/docs/roadmap/issue-reliability-guarantee.md
@@ -21,20 +21,29 @@ daemons:
 3. **Operational visibility** — operators can observe health metrics and set capacity limits
 
 OpenChrome already has a strong 4-layer self-healing architecture (CDP connection resilience,
-session state persistence, Chrome process supervision, application watchdog). The layers are
-solid individually. What is missing is the glue that makes them work together as a coherent
-production-grade daemon:
+session state persistence, Chrome process supervision, application watchdog). The original gap
+was the glue that makes those layers work together as a coherent production-grade daemon.
 
-- The server is still bound to its host process via stdio (no HTTP transport)
-- Reconnection attempts are capped at 5 (fine for interactive use, fatal for overnight runs)
-- There are no rate limits (a runaway agent can saturate the event loop)
-- The event-loop watchdog is disabled by default in production builds
-- Domain memory uses synchronous I/O that blocks the event loop under load
-- There are no Prometheus metrics (operators are flying blind)
-- There are no deployment artifacts (no systemd unit, no Docker Compose, no PM2 config)
-- Disk usage is unbounded (journals and snapshots accumulate forever)
+> **Status (reconciled 2026-06-02):** every item below has shipped. This section is kept as a
+> historical record of the original motivation; see `issue-reliability-tracking.md` for the
+> per-phase merge status and the "Known limitations" section at the end of this document for
+> what remains.
 
-This initiative closes all of those gaps in a single tracked effort.
+Originally-missing glue, now **delivered**:
+
+- ~~The server is still bound to its host process via stdio (no HTTP transport)~~ → Streamable
+  HTTP transport (`src/transports/http.ts`, PR #392)
+- ~~Reconnection attempts are capped at 5 (fatal for overnight runs)~~ → infinite reconnection in
+  HTTP mode (`DEFAULT_MAX_RECONNECT_ATTEMPTS_HTTP = Infinity`, PR #395)
+- ~~There are no rate limits~~ → per-session/tenant token bucket (`src/utils/rate-limiter.ts`, PR #397)
+- ~~The event-loop watchdog is disabled by default~~ → `DEFAULT_EVENT_LOOP_FATAL_MS = 30000` (PR #398)
+- ~~Domain memory uses synchronous I/O~~ → `fs/promises` async path (`src/memory/domain-memory.ts`, PR #398)
+- ~~There are no Prometheus metrics~~ → `/metrics` endpoint + collector (`src/metrics/collector.ts`, PR #399)
+- ~~There are no deployment artifacts~~ → `deploy/{systemd,docker,pm2}` (PR #400)
+- ~~Disk usage is unbounded~~ → disk monitor with auto-prune (`src/watchdog/disk-monitor.ts`, PR #402)
+
+The 1st-generation "never hangs" initiative is therefore **shipped**. Residual hardening work
+(retry-path consistency, timeout cancellation semantics) is tracked under "Known limitations".
 
 ---
 
@@ -294,6 +303,38 @@ The following are explicitly out of scope for this initiative:
 
 - **Authentication and authorization.** The HTTP transport added in Phase 1 will be
   localhost-only by default. Full auth is a separate security initiative.
+
+---
+
+## Known Limitations (post-ship, 2026-06-02)
+
+The 1st-generation initiative is shipped. A reliability audit surfaced the following residual
+items. They are **in-scope hardening** (per the Responsibility Boundary table in
+`issue-reliability-tracking.md`), not new direction. Most candidate "gaps" from the audit were
+found to be already implemented (e.g. memory-pressure aggressive cleanup in
+`src/session-manager.ts` + E2E-21) or explicitly out of scope (SLO burn-rate alerting → operator).
+What survived rigorous re-verification:
+
+- **L1 — Retry-path inconsistency (bug).** The thrown-connection-error retry path
+  (`src/mcp-server.ts` ~2092) wraps its retry in a timeout race *and* gates it on
+  `reconcileAfterReconnect()`. The swallowed-connection-error retry path (~2148) does **neither**:
+  the retry is a bare `await tool.handler(...)` with no timeout race (can hang the stdio path,
+  violating the never-hang contract — HTTP mode is masked by the 30s request timeout) and no
+  reconcile guard. Fix is consistency, not new behavior: mirror the throw-path guards. Tracked
+  for a dedicated PR. Decision context: **D4** in `ssot-decisions.md`.
+
+- **L2 — Timeout/abort does not cancel the underlying CDP call.** On tool timeout or client
+  abort, `src/utils/with-timeout.ts` returns immediately and leaves the in-flight CDP command
+  running (an "orphaned background call", acknowledged in that file's own doc comment). This is a
+  *deliberate* trade-off in favour of never-hang, with an accepted residual "ghost effect" risk
+  (the operation may complete after the error was returned). Promoted from a buried code comment
+  to a normative decision: **D5** in `ssot-decisions.md`. Per-tool best-effort cancellation is a
+  future improvement, not a contract.
+
+Explicitly **not** added here as direction (verified already-done or out of scope): memory-pressure
+eviction (done), circuit breaker on the Chrome path (optional latency optimization, not a contract
+gap — reconnection-wait already partial-fast-fails), SLO/error-budget alerting (operator's job per
+Non-Goals).
 
 ---
 

--- a/docs/roadmap/issue-reliability-tracking.md
+++ b/docs/roadmap/issue-reliability-tracking.md
@@ -2,6 +2,15 @@
 
 > **Philosophy:** Every tool call MUST return a result — success or error — within the timeout. OpenChrome never hangs.
 
+> **Reconciliation note (2026-06-02):** All 7 implementation phases below have **shipped** to
+> `develop`/`main` (PRs #392, #395, #397, #398, #399, #400, #402 — all verified MERGED). The
+> per-phase `Status` lines and the §7 E2E table have been updated to reflect shipped reality.
+> The manual verification checklists in §3–§6 are left unchecked: they are process artifacts to
+> be exercised at release time, not facts to assert here. Residual hardening items surfaced by a
+> post-ship audit live in the "Known Limitations" section of `issue-reliability-guarantee.md`
+> (L1 retry-path consistency, L2 timeout cancellation) with decision context in
+> `ssot-decisions.md` (D4, D5).
+
 ---
 
 ## 1. Overview & Philosophy
@@ -50,7 +59,7 @@ This initiative spans 7 phases, each shipped as an independent PR against `devel
 - `--auto-launch` — launch Chrome automatically on startup
 - `--server-mode` — suppress interactive prompts
 
-**Status:** - [ ] Merged
+**Status:** - [x] Merged (verified on `main`, 2026-06-02)
 
 ---
 
@@ -83,7 +92,7 @@ This initiative spans 7 phases, each shipped as an independent PR against `devel
 - `OPENCHROME_RECONNECT_BASE_DELAY_MS` — initial backoff delay (default: `1000`)
 - `OPENCHROME_RECONNECT_MAX_DELAY_MS` — maximum backoff ceiling (default: `30000`)
 
-**Status:** - [ ] Merged
+**Status:** - [x] Merged (verified on `main`, 2026-06-02)
 
 ---
 
@@ -108,7 +117,7 @@ This initiative spans 7 phases, each shipped as an independent PR against `devel
 - `OPENCHROME_RATE_LIMIT_BURST` — burst allowance above sustained rate (default: `20`)
 - Set to `0` to disable rate limiting entirely
 
-**Status:** - [ ] Merged
+**Status:** - [x] Merged (verified on `main`, 2026-06-02)
 
 ---
 
@@ -132,7 +141,7 @@ This initiative spans 7 phases, each shipped as an independent PR against `devel
 - `OPENCHROME_ASYNC_IO` — `true`/`false`, enables async file operations (default: `true`)
 - `OPENCHROME_EVENT_LOOP_FATAL_MS` — event loop stall threshold in ms before process exit (default: `30000`); set to `0` to disable
 
-**Status:** - [ ] Merged
+**Status:** - [x] Merged (verified on `main`, 2026-06-02)
 
 ---
 
@@ -156,7 +165,7 @@ This initiative spans 7 phases, each shipped as an independent PR against `devel
 - `OPENCHROME_METRICS_PORT` — port for `/health` and `/metrics` endpoints (default: `9090`)
 - Metrics endpoint is always enabled when running in HTTP mode; no flag to disable
 
-**Status:** - [ ] Merged
+**Status:** - [x] Merged (verified on `main`, 2026-06-02)
 
 ---
 
@@ -186,7 +195,7 @@ This initiative spans 7 phases, each shipped as an independent PR against `devel
 - All configuration via environment variables; see `deploy/systemd/openchrome.env` for full template
 - Docker volume: `/home/openchrome/.openchrome` for session state persistence
 
-**Status:** - [ ] Merged
+**Status:** - [x] Merged (verified on `main`, 2026-06-02)
 
 ---
 
@@ -213,7 +222,7 @@ This initiative spans 7 phases, each shipped as an independent PR against `devel
 - `OPENCHROME_DISK_TARGET_MB` — target disk usage after pruning (default: `400`)
 - `OPENCHROME_DISK_CHECK_INTERVAL_MS` — how often to check disk usage (default: `60000`)
 
-**Status:** - [ ] Merged
+**Status:** - [x] Merged (verified on `main`, 2026-06-02)
 
 ---
 
@@ -378,21 +387,28 @@ These scenarios test the reliability guarantee under real conditions. All must p
 
 ## 7. E2E Certification Tests (Follow-Up)
 
-Automated versions of the real-world tests above. Implementation tracked separately.
+Automated versions of the real-world tests above, under `tests/e2e/scenarios/`. Status below
+reconciled against the actual test files on 2026-06-02. ✅ = the test file self-declares its
+`E2E-NN` ID (confirmed). 🟡 = a scenario file by that name exists but does not carry an explicit
+`E2E-NN` tag, so the mapping is by filename and should be confirmed before relying on it.
 
-| Test ID | Scenario | Automated? |
-|---------|----------|------------|
-| E2E-11 | WebSocket disconnect recovery | ❌ To implement |
-| E2E-12 | Infinite reconnection (5 min Chrome down) | ❌ To implement |
-| E2E-13 | HTTP transport independence (client disconnect) | ❌ To implement |
-| E2E-14 | Multi-client HTTP concurrency | ❌ To implement |
-| E2E-15 | Parallel tool call burst | ❌ To implement |
-| E2E-16 | Rate limiter under flood | ❌ To implement |
-| E2E-17 | Prometheus metrics accuracy | ❌ To implement |
-| E2E-18 | Disk space auto-cleanup | ❌ To implement |
-| E2E-19 | Event loop fatal recovery | ❌ To implement |
-| E2E-20 | 72-hour endurance | ❌ To implement |
-| E2E-21 | System pressure degradation | ❌ To implement |
+| Test ID | Scenario | Automated? | File |
+|---------|----------|------------|------|
+| E2E-11 | WebSocket disconnect recovery | 🟡 Likely | `server-restart.e2e.ts` / `kill-recovery.e2e.ts` |
+| E2E-12 | Infinite reconnection (5 min Chrome down) | 🟡 Likely | `kill-recovery.e2e.ts` |
+| E2E-13 | HTTP transport independence (client disconnect) | ✅ Implemented | `http-independence.e2e.ts` |
+| E2E-14 | Multi-client HTTP concurrency | ✅ Implemented | `http-multi-client.e2e.ts` |
+| E2E-15 | Parallel tool call burst | ✅ Implemented | `parallel-burst.e2e.ts` |
+| E2E-16 | Rate limiter under flood | ✅ Implemented | `rate-limiter.e2e.ts` |
+| E2E-17 | Prometheus metrics accuracy | ✅ Implemented | `prometheus-metrics.e2e.ts` |
+| E2E-18 | Disk space auto-cleanup | ✅ Implemented | `disk-cleanup.e2e.ts` |
+| E2E-19 | Event loop fatal recovery | 🟡 Likely | `event-loop-block.e2e.ts` |
+| E2E-20 | 72-hour endurance | 🟡 Likely | `endurance-24h.e2e.ts` / `marathon.e2e.ts` (note: 24h file, not 72h) |
+| E2E-21 | System pressure degradation | 🟡 Likely | `memory-pressure.e2e.ts` |
+
+A certification harness also exists at `tests/harness/certification/run-certification.ts`. The
+🟡 rows need an explicit `E2E-NN` tag added to their test file (or the table corrected) to close
+the mapping — a small follow-up.
 
 See [E2E Certification Criteria](docs/roadmap/e2e-certification-criteria.md) for full test specifications.
 

--- a/docs/roadmap/ssot-decisions.md
+++ b/docs/roadmap/ssot-decisions.md
@@ -112,6 +112,52 @@ profiles.
 
 ---
 
+## D4. Auto-retry semantics (reliability scope)
+
+Recorded as part of the post-ship reliability audit (2026-06-02). Promotes an
+implicit behavior in `src/mcp-server.ts` to a normative decision so it is not
+"fixed" in the wrong direction by future contributors.
+
+**Decision.** OpenChrome's built-in auto-retry of a tool call is **connection-error
+only** and is **at-least-once**, not at-most-once:
+
+1. A retry is attempted only when the failure is classified as a connection error
+   (`isConnectionError`). Non-connection failures are surfaced as-is, never retried.
+2. The thrown-error retry path is gated on a successful
+   `sessionManager.reconcileAfterReconnect()`; if reconciliation fails the retry is
+   aborted and the **original** error is returned (stale target state must not drive
+   a retry).
+3. Because a connection can drop *after* a side effect was dispatched to Chrome but
+   *before* its acknowledgement, a side-effectful tool (e.g. a form submit) may
+   execute twice across the drop+retry. This at-least-once window is **accepted**:
+   **at-most-once / idempotency for arbitrary actions is the orchestrator's
+   responsibility** (see the Responsibility Boundary and Non-Goals in
+   `issue-reliability-tracking.md`). OpenChrome offers only an opt-in
+   `idempotencyKey` for callers that need dedup.
+4. Both retry paths (thrown error and swallowed-error-in-result) **must** apply the
+   same guards: a timeout race around the retried handler and the reconcile gate.
+   The swallowed-error path currently omits both — this is a tracked **bug** (the
+   "Known Limitations / L1" item in `issue-reliability-guarantee.md`), not a
+   sanctioned divergence.
+
+## D5. Timeout / abort cancellation semantics
+
+Recorded 2026-06-02. Promotes the doc comment in `src/utils/with-timeout.ts` to a
+normative decision.
+
+**Decision.** On a tool-execution timeout or a client `AbortSignal`, OpenChrome
+**returns immediately and does not guarantee cancellation of the in-flight CDP
+command.** The underlying operation may continue to completion in the background
+(an "orphaned background call"), so a side effect may land *after* a timeout/abort
+error was already returned ("ghost effect"). This residual risk is **consciously
+accepted** in favour of the never-hang contract — bounding caller latency takes
+priority over guaranteeing downstream cancellation. Per-tool best-effort
+cancellation (propagating the signal into specific CDP/Puppeteer calls and
+reconciling page state afterward) is a **future improvement, not part of the
+contract**.
+
+---
+
 ## Still open
 
 - The C6 perf/console **assertion kinds** (audit #1457) are deferred to a

--- a/docs/roadmap/ssot-decisions.md
+++ b/docs/roadmap/ssot-decisions.md
@@ -136,9 +136,14 @@ only** and is **at-least-once**, not at-most-once:
    `idempotencyKey` for callers that need dedup.
 4. Both retry paths (thrown error and swallowed-error-in-result) **must** apply the
    same guards: a timeout race around the retried handler and the reconcile gate.
-   The swallowed-error path currently omits both — this is a tracked **bug** (the
-   "Known Limitations / L1" item in `issue-reliability-guarantee.md`), not a
-   sanctioned divergence.
+   The swallowed-error path historically omitted both, **and was in fact dead code**:
+   it gated on `isConnectionError({ message: errorText })`, but `isConnectionError`
+   stringifies non-`Error` values via `formatError` → `String(value)`, so the plain
+   object became `"[object Object]"` and matched no pattern, meaning the retry never
+   fired. Fixed in PR #1471 (issue #1469 / "Known Limitations / L1" in
+   `issue-reliability-guarantee.md`): pass the string directly, then apply the same
+   reconcile gate and timeout race as the thrown-error path. This is the normative
+   shape; any future divergence is a bug.
 
 ## D5. Timeout / abort cancellation semantics
 


### PR DESCRIPTION
## Summary

A post-ship reliability audit found the `docs/roadmap/` reliability docs were **stale**: all 7 implementation phases were marked unmerged though their PRs (#392/#395/#397/#398/#399/#400/#402) are all merged, and the "what is missing" motivation list still enumerated already-shipped capability. This PR reconciles the docs with shipped reality and promotes two implicit decisions to normative SSOT entries.

## Changes

- **`issue-reliability-tracking.md`** — flip 7 phase statuses to `[x] Merged (verified on main)`; reconcile the §7 E2E table to actual test files (`E2E-13..18` confirmed by explicit ID tag; `11/12/19/20/21` marked 🟡 filename-only, pending a tag — see PR-C follow-up); add a reconciliation note. Manual checklists §3–6 left **unchecked on purpose** — they are release-time process artifacts, not facts to assert.
- **`issue-reliability-guarantee.md`** — rewrite the "what is missing" list to past-tense **Delivered** with PR/file references; add a **Known Limitations** section (L1 retry-path consistency bug, L2 timeout cancellation trade-off).
- **`ssot-decisions.md`** — record **D4** (auto-retry = connection-error-only, at-least-once; at-most-once is the orchestrator's job) and **D5** (timeout/abort does not cancel the in-flight CDP call — orphaned background call accepted for never-hang). These previously lived only in code comments.

## Verification

- Documentation only; no behavior change. `main == develop` and the three docs were identical on both branches, so this applies cleanly.
- All 7 referenced PRs verified MERGED via `gh pr view`.

## Follow-ups (separate PRs)

- **PR-B** — fix L1: apply the timeout race + `reconcileAfterReconnect()` guard to the swallowed-error retry path in `src/mcp-server.ts` (per D4).
- **PR-C** — tag `E2E-11/12/19/20/21` in their test files and close the §7 table mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)