### PR TITLE
fix(reliability): make swallowed-error retry fire + guard it with reconcile/timeout (L1)

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -2150,11 +2150,21 @@ export class MCPServer {
       // isError results, bypassing the thrown-error retry at the catch block above.
       if (result.isError && result.content?.[0]?.type === 'text') {
         const errorText = (result.content[0] as { text: string }).text;
-        if (isConnectionError({ message: errorText })) {
+        // Pass the string directly: isConnectionError() runs the value through
+        // formatError(), which only extracts `.message` from Error instances and
+        // otherwise calls String(value). A plain `{ message: errorText }` object
+        // therefore stringifies to "[object Object]" and matches no pattern — which
+        // had silently made this whole swallowed-error retry path dead code. (L1)
+        if (isConnectionError(errorText)) {
           console.error(`[MCPServer] Detected swallowed connection error in "${toolName}" result, attempting reconnect + retry`);
           try {
             const cdpClientRetry = getCDPClient();
             await cdpClientRetry.forceReconnect();
+            // Wait for session state reconciliation before retrying — mirrors the
+            // thrown-error retry path above. If reconciliation fails this throws and
+            // the catch below keeps the original error result, since stale target
+            // state would otherwise cause wrong-target errors. (SSOT decision D4 / L1)
+            await this.sessionManager.reconcileAfterReconnect();
             // Retry the tool call once
             const swallowedRetryContext: ToolContext = {
               startTime: Date.now(),
@@ -2165,7 +2175,20 @@ export class MCPServer {
               requestClient: this.requestFromClient.bind(this),
               reportProgress,
             };
-            result = await Promise.resolve(tool.handler(sessionId, substitutedArgs, swallowedRetryContext));
+            // Race the retry against the tool-execution timeout, exactly like the
+            // initial dispatch and the thrown-error retry. A bare `await` here can
+            // hang the stdio path indefinitely (no outer request timeout exists in
+            // stdio mode), violating the never-hang contract. (SSOT decision D5 / L1)
+            let swallowedRetryTid: ReturnType<typeof setTimeout>;
+            result = await Promise.race([
+              Promise.resolve(tool.handler(sessionId, substitutedArgs, swallowedRetryContext)).finally(() => clearTimeout(swallowedRetryTid)),
+              new Promise<never>((_, reject) => {
+                swallowedRetryTid = setTimeout(
+                  () => reject(new Error(`Tool '${toolName}' timed out after ${DEFAULT_TOOL_EXECUTION_TIMEOUT_MS}ms (swallowed-error retry)`)),
+                  DEFAULT_TOOL_EXECUTION_TIMEOUT_MS,
+                );
+              }),
+            ]);
             console.error(`[MCPServer] Retry after swallowed connection error succeeded for "${toolName}"`);
           } catch (retryError) {
             console.error(`[MCPServer] Retry after swallowed connection error failed for "${toolName}":`, retryError);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -2159,7 +2159,21 @@ export class MCPServer {
           console.error(`[MCPServer] Detected swallowed connection error in "${toolName}" result, attempting reconnect + retry`);
           try {
             const cdpClientRetry = getCDPClient();
-            await cdpClientRetry.forceReconnect();
+            // Race the reconnect against DEFAULT_RECONNECT_TIMEOUT_MS, exactly like the
+            // thrown-error retry path above. A bare `await forceReconnect()` would
+            // re-open the same hang window the handler race below closes: if Chrome is
+            // dead and the reconnect never resolves, the stdio path would hang here
+            // before the retry is even dispatched. (SSOT decision D5 / L1)
+            let swallowedReconnectTid: ReturnType<typeof setTimeout>;
+            await Promise.race([
+              cdpClientRetry.forceReconnect().finally(() => clearTimeout(swallowedReconnectTid)),
+              new Promise<never>((_, reject) => {
+                swallowedReconnectTid = setTimeout(
+                  () => reject(new Error(`Reconnect timed out after ${DEFAULT_RECONNECT_TIMEOUT_MS}ms (swallowed-error path)`)),
+                  DEFAULT_RECONNECT_TIMEOUT_MS,
+                );
+              }),
+            ]);
             // Wait for session state reconciliation before retrying — mirrors the
             // thrown-error retry path above. If reconciliation fails this throws and
             // the catch below keeps the original error result, since stale target

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -21,6 +21,7 @@ jest.mock('../src/session-manager', () => ({
 import { getSessionManager } from '../src/session-manager';
 import { MCPServer } from '../src/mcp-server';
 import { MCPRequest, MCPErrorCodes, MCPToolDefinition } from '../src/types/mcp';
+import { DEFAULT_TOOL_EXECUTION_TIMEOUT_MS } from '../src/config/defaults';
 
 // Helper type for response with result
 interface MCPResultResponse {
@@ -685,6 +686,88 @@ describe('MCPServer', () => {
         expect(handler).toHaveBeenCalledTimes(2);
         mockForceReconnect.mockClear();
       }
+    });
+
+    // L1 (issue #1469 / SSOT D4 & D5): the swallowed-connection-error retry path —
+    // where a tool RETURNS an isError result instead of throwing — must apply the
+    // same guards as the thrown-error path: a reconcile gate and a timeout race.
+    describe('swallowed connection error retry (L1)', () => {
+      const swallowedErr = 'WebSocket is not open: readyState 3 (CLOSED)';
+      const makeTool = (name: string, handler: jest.Mock) => {
+        const definition: MCPToolDefinition = {
+          name,
+          description: 'swallowed-error tool',
+          inputSchema: { type: 'object' as const, properties: {}, required: [] },
+          annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+        };
+        server.registerTool(name, handler, definition);
+        return { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name, arguments: {} } } as MCPRequest;
+      };
+
+      test('retries and succeeds when handler returns (not throws) a connection error', async () => {
+        let callCount = 0;
+        const handler = jest.fn().mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) {
+            return { content: [{ type: 'text', text: swallowedErr }], isError: true };
+          }
+          return { content: [{ type: 'text', text: 'Recovered' }] };
+        });
+        const request = makeTool('swallowed_ok', handler);
+
+        const response = (await server.handleRequest(request)) as MCPResultResponse;
+
+        expect(handler).toHaveBeenCalledTimes(2);
+        expect(mockForceReconnect).toHaveBeenCalledTimes(1);
+        expect(mockSessionManager.reconcileAfterReconnect).toHaveBeenCalledTimes(1);
+        expect(response.result!.content![0].text).toBe('Recovered');
+      });
+
+      test('aborts the retry and keeps the original error when reconcile fails', async () => {
+        (mockSessionManager.reconcileAfterReconnect as jest.Mock).mockRejectedValueOnce(
+          new Error('reconcile failed'),
+        );
+        const handler = jest.fn().mockReturnValue({
+          content: [{ type: 'text', text: swallowedErr }],
+          isError: true,
+        });
+        const request = makeTool('swallowed_reconcile_fail', handler);
+
+        const response = (await server.handleRequest(request)) as MCPResultResponse;
+
+        // Reconcile threw → no second handler invocation, original error kept.
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(mockForceReconnect).toHaveBeenCalledTimes(1);
+        expect(response.result!.isError).toBe(true);
+        expect(response.result!.content![0].text).toContain('WebSocket is not open');
+      });
+
+      test('does not hang: the retry is bounded by the tool-execution timeout', async () => {
+        jest.useFakeTimers();
+        try {
+          let callCount = 0;
+          const handler = jest.fn().mockImplementation(() => {
+            callCount++;
+            if (callCount === 1) {
+              return { content: [{ type: 'text', text: swallowedErr }], isError: true };
+            }
+            // Retry handler never resolves — only the timeout race can end the call.
+            return new Promise(() => { /* never resolves */ });
+          });
+          const request = makeTool('swallowed_hang', handler);
+
+          const responsePromise = server.handleRequest(request) as Promise<MCPResultResponse>;
+          await jest.advanceTimersByTimeAsync(DEFAULT_TOOL_EXECUTION_TIMEOUT_MS + 50);
+          const response = await responsePromise;
+
+          expect(handler).toHaveBeenCalledTimes(2);
+          // Retry timed out → catch keeps the original swallowed error result.
+          expect(response.result!.isError).toBe(true);
+          expect(response.result!.content![0].text).toContain('WebSocket is not open');
+        } finally {
+          jest.useRealTimers();
+        }
+      });
     });
   });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -21,7 +21,7 @@ jest.mock('../src/session-manager', () => ({
 import { getSessionManager } from '../src/session-manager';
 import { MCPServer } from '../src/mcp-server';
 import { MCPRequest, MCPErrorCodes, MCPToolDefinition } from '../src/types/mcp';
-import { DEFAULT_TOOL_EXECUTION_TIMEOUT_MS } from '../src/config/defaults';
+import { DEFAULT_TOOL_EXECUTION_TIMEOUT_MS, DEFAULT_RECONNECT_TIMEOUT_MS } from '../src/config/defaults';
 
 // Helper type for response with result
 interface MCPResultResponse {
@@ -762,6 +762,31 @@ describe('MCPServer', () => {
 
           expect(handler).toHaveBeenCalledTimes(2);
           // Retry timed out → catch keeps the original swallowed error result.
+          expect(response.result!.isError).toBe(true);
+          expect(response.result!.content![0].text).toContain('WebSocket is not open');
+        } finally {
+          jest.useRealTimers();
+        }
+      });
+
+      test('does not hang when the reconnect itself stalls', async () => {
+        jest.useFakeTimers();
+        try {
+          // forceReconnect never resolves — the reconnect timeout race must end the call.
+          mockForceReconnect.mockReturnValueOnce(new Promise(() => { /* never resolves */ }));
+          const handler = jest.fn().mockReturnValue({
+            content: [{ type: 'text', text: swallowedErr }],
+            isError: true,
+          });
+          const request = makeTool('swallowed_reconnect_hang', handler);
+
+          const responsePromise = server.handleRequest(request) as Promise<MCPResultResponse>;
+          await jest.advanceTimersByTimeAsync(DEFAULT_RECONNECT_TIMEOUT_MS + 50);
+          const response = await responsePromise;
+
+          // Reconnect timed out before the retry was dispatched → handler called once,
+          // original error result preserved (never-hang honored at the reconnect step).
+          expect(handler).toHaveBeenCalledTimes(1);
           expect(response.result!.isError).toBe(true);
           expect(response.result!.content![0].text).toContain('WebSocket is not open');
         } finally {


### PR DESCRIPTION
Fixes **L1** from the post-ship reliability audit. Closes #1469. Implements SSOT decisions **D4/D5** (recorded in #1468).

## The bug(s)

The swallowed-connection-error retry path in `MCPServer` — the branch that handles a tool which **returns** an `isError` result instead of throwing — had two defects:

1. **It was dead code.** The gate was `isConnectionError({ message: errorText })`. `isConnectionError()` runs its argument through `formatError()`, which only pulls `.message` off `Error` instances and otherwise does `String(value)`. A plain `{ message }` object stringifies to `"[object Object]"`, matching no connection pattern — so the retry **never fired**. Fixed by passing the `errorText` string directly.

2. **Missing guards vs. the thrown-error path.** Once activated, the retry must mirror the protections the thrown-error path (~L2092) already has:
   - a **`reconcileAfterReconnect()` gate** — abort the retry and keep the original error if reconciliation fails (stale target state would otherwise cause wrong-target errors);
   - a **`Promise.race` timeout** around the retried handler. A bare `await` could hang the **stdio** path indefinitely (no outer request timeout in stdio mode), violating the never-hang contract. (HTTP mode was incidentally masked by `HTTP_REQUEST_TIMEOUT_MS`.)

## Fix

`src/mcp-server.ts`: pass the string to `isConnectionError`, add the reconcile gate and the timeout race so both retry paths apply identical guards.

## Tests

`tests/mcp-server.test.ts` — 3 new regressions under **"swallowed connection error retry (L1)"**:
- retry fires and succeeds (path active, reconcile invoked);
- reconcile failure aborts the retry and keeps the original error;
- does-not-hang: retry bounded by the tool-execution timeout (fake timers).

`npm run build` clean; `tests/mcp-server.test.ts` green (35/35).

## Scope / safety

This activates a previously-dead retry path. Per **D4** it is connection-error-only, now reconcile-gated and timeout-bounded, so it is at-least-once and never-hang-safe. No happy-path or non-connection-error behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)