### PR TITLE
fix(extract_data): add items to alreadyCollected array schema (#1473)

### DIFF
--- a/src/tools/extract-data.ts
+++ b/src/tools/extract-data.ts
@@ -78,6 +78,7 @@ const definition: MCPToolDefinition = {
       },
       alreadyCollected: {
         type: 'array',
+        items: { type: 'string' },
         description: 'Semantic mode only: values already collected by the host, used for simple chunk dedupe hints.',
       },
       selector: {


### PR DESCRIPTION
## Problem

`extract_data`'s `alreadyCollected` input parameter declared `type: 'array'` with no `items`. JSON Schema permits this (it means "any items"), but the MCP tool-parameter validator used by strict clients such as **VS Code** is stricter and rejects the whole tool:

> Failed to validate tool `mcp_openchrome_extract_data`: Error: tool parameters array type must have items.

Result: `extract_data` is **unloadable** in those clients. Reported in #1473.

## Fix

Add `items: { type: 'string' }` to `alreadyCollected`. The host passes back previously-collected values that the semantic extractor consumes via `String(item)` (`src/extraction/semantic.ts`), so `string` is the honest element type.

## Scope

- One file, one field. **inputSchema only.**
- This is PR 1 of 2. PR 2 fixes the remaining latent `outputSchema` arrays (oc_normalize_action, oc_progress_status) and adds a recursive `array ⇒ items` lint guardrail (Rule 7) to `lint-tool-schemas.mjs` so this class cannot recur.

## Verification

- `npm run build` ✅
- `node dist/index.js serve --introspect-tools-list | node scripts/lint-tool-schemas.mjs -` → `OK — 0 new` ✅
- Confirmed emitted schema now carries `items`.

Fixes #1473.

🤖 Generated with [Claude Code](https://claude.com/claude-code)