### PR TITLE
fix(reliability): health-aware controller lock — take over half-zombie owner instead of deadlocking (#1474)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import { setComponent, resetReadinessMachine } from './watchdog/readiness';
 import { wireChromeReadiness } from './watchdog/chrome-readiness';
 import {
   DuplicateControllerError,
-  acquireControllerLock,
+  acquireControllerLockWithHealthCheck,
   formatDuplicateControllerMessage,
   type ControllerLockHandle,
 } from './utils/controller-lock';
@@ -320,7 +320,11 @@ program
         );
       } else {
         try {
-          controllerLock = acquireControllerLock({
+          // #1474: health-aware acquisition. A half-zombie owner (MCP alive but
+          // its Chrome/CDP dead) would otherwise hold the lock forever and
+          // deadlock every other session. This probes the owner's CDP endpoint
+          // and takes over a stale lock, while never evicting a healthy owner.
+          controllerLock = await acquireControllerLockWithHealthCheck({
             port,
             userDataDir: lockUserDataDir,
             lifecycleMode: options.launchMode || 'auto',

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,8 +44,10 @@ import {
   DuplicateControllerError,
   acquireControllerLockWithHealthCheck,
   formatDuplicateControllerMessage,
+  startControllerHeartbeat,
   type ControllerLockHandle,
 } from './utils/controller-lock';
+import { fetchJsonVersion } from './chrome/devtools-info';
 import { getCurrentControllerTopology } from './utils/duplicate-controller-diagnostics';
 import {
   DEFAULT_PROCESS_WATCHDOG_INTERVAL_MS,
@@ -340,7 +342,17 @@ program
       }
     }
 
+    // #1474: while we own the lock, periodically refresh its heartbeat whenever
+    // our Chrome/CDP is reachable. This lets a contender distinguish a live
+    // owner that is briefly relaunching Chrome (heartbeat recent) from a true
+    // half-zombie (heartbeat stale beyond the grace), preventing split
+    // ownership during a legitimate relaunch.
+    const controllerHeartbeat = controllerLock
+      ? startControllerHeartbeat(controllerLock, async () => (await fetchJsonVersion(port)) !== null)
+      : null;
+
     process.on('exit', () => {
+      try { controllerHeartbeat?.stop(); } catch { /* best-effort */ }
       try { controllerLock?.release(); } catch { /* best-effort */ }
     });
 

--- a/src/utils/controller-lock.ts
+++ b/src/utils/controller-lock.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { getVersion } from '../version';
 import { fetchJsonVersion } from '../chrome/devtools-info';
+import { DEFAULT_CHROME_LAUNCH_TIMEOUT_MS } from '../config/defaults';
 
 export interface ControllerLockIdentity {
   port: number;
@@ -227,6 +228,22 @@ function envInt(name: string, fallback: number): number {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
 }
 
+/**
+ * Extra headroom added on top of the Chrome launch budget when deriving the
+ * default takeover grace, covering process spawn + waitForDebugPort jitter.
+ */
+const LOCK_TAKEOVER_GRACE_BUFFER_MS = 30_000;
+
+/**
+ * Resolve the Chrome launch budget the owner is allowed before its CDP
+ * endpoint must be listening — the same value the launcher uses
+ * (CHROME_LAUNCH_TIMEOUT_MS, else DEFAULT_CHROME_LAUNCH_TIMEOUT_MS).
+ */
+function resolveChromeLaunchBudgetMs(): number {
+  const raw = Number.parseInt(process.env.CHROME_LAUNCH_TIMEOUT_MS ?? '', 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_CHROME_LAUNCH_TIMEOUT_MS;
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -293,7 +310,13 @@ export async function acquireControllerLockWithHealthCheck(
   options: HealthAwareAcquireOptions = {},
 ): Promise<ControllerLockHandle> {
   const disabled = options.disabled ?? process.env.OPENCHROME_LOCK_HEALTH_TAKEOVER === '0';
-  const graceMs = options.graceMs ?? envInt('OPENCHROME_LOCK_TAKEOVER_GRACE_MS', 15_000);
+  // The lock is acquired BEFORE ensureChrome() launches Chrome, so a
+  // legitimately-launching owner has no CDP endpoint for up to the full launch
+  // budget (default 60s). The grace must exceed that budget, or a second
+  // --auto-launch started mid-launch would probe an empty port and evict the
+  // live owner — turning a slow-but-valid startup into split ownership (#1474).
+  const graceMs = options.graceMs
+    ?? envInt('OPENCHROME_LOCK_TAKEOVER_GRACE_MS', resolveChromeLaunchBudgetMs() + LOCK_TAKEOVER_GRACE_BUFFER_MS);
   const probeAttempts = options.probeAttempts ?? envInt('OPENCHROME_LOCK_PROBE_ATTEMPTS', 3);
   const probeIntervalMs = options.probeIntervalMs ?? envInt('OPENCHROME_LOCK_PROBE_INTERVAL_MS', 500);
   const maxTakeovers = options.maxTakeovers ?? 3;

--- a/src/utils/controller-lock.ts
+++ b/src/utils/controller-lock.ts
@@ -24,6 +24,14 @@ export interface ControllerLockMetadata {
   port: number;
   userDataDir: string;
   startedAt: string;
+  /**
+   * Last time the owner confirmed its Chrome/CDP was reachable and refreshed
+   * the lock. Distinguishes a live owner whose Chrome is briefly down (e.g.
+   * mid-relaunch after a crash) from a half-zombie whose Chrome is gone for
+   * good: a contender only takes over when this is stale beyond the grace.
+   * Falls back to `startedAt` for locks written before this field existed.
+   */
+  lastHeartbeatAt: string;
   lifecycleMode?: string;
   transportMode?: string;
   hostname: string;
@@ -98,6 +106,10 @@ function readMetadata(lockPath: string): ControllerLockMetadata | null {
       port,
       userDataDir,
       startedAt: typeof parsed.startedAt === 'string' ? parsed.startedAt : '',
+      lastHeartbeatAt:
+        typeof parsed.lastHeartbeatAt === 'string'
+          ? parsed.lastHeartbeatAt
+          : (typeof parsed.startedAt === 'string' ? parsed.startedAt : ''),
       ...(typeof parsed.lifecycleMode === 'string' ? { lifecycleMode: parsed.lifecycleMode } : {}),
       ...(typeof parsed.transportMode === 'string' ? { transportMode: parsed.transportMode } : {}),
       hostname: typeof parsed.hostname === 'string' ? parsed.hostname : '',
@@ -116,6 +128,7 @@ function buildMetadata(identity: ControllerLockIdentity): ControllerLockMetadata
     port: identity.port,
     userDataDir: normalizeControllerUserDataDir(identity.userDataDir),
     startedAt: new Date((identity.now ?? Date.now)()).toISOString(),
+    lastHeartbeatAt: new Date((identity.now ?? Date.now)()).toISOString(),
     ...(identity.lifecycleMode ? { lifecycleMode: identity.lifecycleMode } : {}),
     ...(identity.transportMode ? { transportMode: identity.transportMode } : {}),
     hostname: os.hostname(),
@@ -354,9 +367,14 @@ export async function acquireControllerLockWithHealthCheck(
       // its PID/CDP are not meaningfully probeable from here.
       if (owner.hostname && owner.hostname !== selfHostname) throw err;
 
-      // Owner may still be launching Chrome; its CDP endpoint is legitimately
-      // not listening yet during the grace window.
-      if (isWithinGracePeriod(owner.startedAt, now(), graceMs)) throw err;
+      // Owner liveness: a live owner refreshes `lastHeartbeatAt` whenever its
+      // Chrome/CDP is reachable. If that is recent (within grace), the owner is
+      // either still launching Chrome or mid-relaunch after a crash — its CDP
+      // is legitimately down for now, so do not evict. Only a heartbeat stale
+      // beyond the grace marks a true half-zombie. (Falls back to startedAt for
+      // pre-heartbeat locks.)
+      const ownerLivenessAt = owner.lastHeartbeatAt || owner.startedAt;
+      if (isWithinGracePeriod(ownerLivenessAt, now(), graceMs)) throw err;
 
       // Only a half-zombie (CDP unreachable across every attempt) is evictable.
       const healthy = await probeOwnerHealthy(owner.port, probeAttempts, probeIntervalMs, probe);
@@ -378,4 +396,63 @@ export async function acquireControllerLockWithHealthCheck(
 
   // Iteration ceiling hit under pathological churn — surface the duplicate error.
   return acquireControllerLock(identity, rootDir);
+}
+
+/**
+ * Refresh the owner's `lastHeartbeatAt` in the lock file. Best-effort and
+ * pid-guarded: if the lock has been taken over (pid changed) or removed, this
+ * is a no-op, so a stale owner can never resurrect a lock it no longer holds.
+ */
+export function recordControllerHeartbeat(
+  lockPath: string,
+  pid: number,
+  nowFn: () => number = Date.now,
+): void {
+  const current = readMetadata(lockPath);
+  if (!current || current.pid !== pid) return;
+  const updated: ControllerLockMetadata = { ...current, lastHeartbeatAt: new Date(nowFn()).toISOString() };
+  try {
+    fs.writeFileSync(lockPath, JSON.stringify(updated, null, 2) + '\n', { mode: 0o600 });
+  } catch {
+    /* best-effort */
+  }
+}
+
+export interface ControllerHeartbeatHandle {
+  stop(): void;
+}
+
+/**
+ * Periodically probe the owner's own Chrome/CDP and, when reachable, refresh
+ * the lock heartbeat so contenders can tell a live owner — even one briefly
+ * relaunching Chrome after a crash — from a half-zombie whose Chrome is gone
+ * for good. The timer is unref'd so it never keeps the process alive; disable
+ * with OPENCHROME_LOCK_HEARTBEAT=0.
+ */
+export function startControllerHeartbeat(
+  handle: Pick<ControllerLockHandle, 'path' | 'metadata'>,
+  probe: () => Promise<boolean>,
+  options: { intervalMs?: number; nowFn?: () => number } = {},
+): ControllerHeartbeatHandle {
+  if (process.env.OPENCHROME_LOCK_HEARTBEAT === '0') {
+    return { stop: () => undefined };
+  }
+  const intervalMs = Math.max(1000, options.intervalMs ?? envInt('OPENCHROME_LOCK_HEARTBEAT_INTERVAL_MS', 10_000));
+  const nowFn = options.nowFn ?? Date.now;
+  let inFlight = false;
+  const timer = setInterval(() => {
+    if (inFlight) return;
+    inFlight = true;
+    void (async () => {
+      try {
+        if (await probe()) recordControllerHeartbeat(handle.path, handle.metadata.pid, nowFn);
+      } catch {
+        // A failed/throwing probe simply means no refresh this tick.
+      } finally {
+        inFlight = false;
+      }
+    })();
+  }, intervalMs);
+  timer.unref?.();
+  return { stop: () => clearInterval(timer) };
 }

--- a/src/utils/controller-lock.ts
+++ b/src/utils/controller-lock.ts
@@ -408,13 +408,46 @@ export function recordControllerHeartbeat(
   pid: number,
   nowFn: () => number = Date.now,
 ): void {
-  const current = readMetadata(lockPath);
-  if (!current || current.pid !== pid) return;
-  const updated: ControllerLockMetadata = { ...current, lastHeartbeatAt: new Date(nowFn()).toISOString() };
+  let fd: number | null = null;
   try {
-    fs.writeFileSync(lockPath, JSON.stringify(updated, null, 2) + '\n', { mode: 0o600 });
+    // Open the currently-linked lock file and update that same inode. A simple
+    // readMetadata(path) -> writeFile(path) sequence can resurrect stale
+    // ownership if another process unlinks/recreates the lock between the read
+    // and write. With an already-open fd, a concurrent takeover that unlinks the
+    // old file makes our write target the unlinked old inode, never the new
+    // owner's path.
+    fd = fs.openSync(lockPath, 'r+');
+    const parsed = JSON.parse(fs.readFileSync(fd, 'utf8')) as Partial<ControllerLockMetadata>;
+    const currentPid = parsed.pid;
+    const port = parsed.port;
+    const userDataDir = parsed.userDataDir;
+    if (
+      currentPid !== pid ||
+      typeof port !== 'number' ||
+      !Number.isSafeInteger(port) ||
+      typeof userDataDir !== 'string'
+    ) return;
+    const updated: ControllerLockMetadata = {
+      pid,
+      command: Array.isArray(parsed.command) ? parsed.command.map(String) : [],
+      version: typeof parsed.version === 'string' ? parsed.version : 'unknown',
+      cwd: typeof parsed.cwd === 'string' ? parsed.cwd : '',
+      port,
+      userDataDir,
+      startedAt: typeof parsed.startedAt === 'string' ? parsed.startedAt : '',
+      lastHeartbeatAt: new Date(nowFn()).toISOString(),
+      ...(typeof parsed.lifecycleMode === 'string' ? { lifecycleMode: parsed.lifecycleMode } : {}),
+      ...(typeof parsed.transportMode === 'string' ? { transportMode: parsed.transportMode } : {}),
+      hostname: typeof parsed.hostname === 'string' ? parsed.hostname : '',
+    };
+    fs.ftruncateSync(fd, 0);
+    fs.writeSync(fd, JSON.stringify(updated, null, 2) + '\n', 0, 'utf8');
   } catch {
     /* best-effort */
+  } finally {
+    if (fd !== null) {
+      try { fs.closeSync(fd); } catch { /* best-effort */ }
+    }
   }
 }
 

--- a/src/utils/controller-lock.ts
+++ b/src/utils/controller-lock.ts
@@ -230,9 +230,12 @@ function envInt(name: string, fallback: number): number {
 
 /**
  * Extra headroom added on top of the Chrome launch budget when deriving the
- * default takeover grace, covering process spawn + waitForDebugPort jitter.
+ * default takeover grace. `startedAt` is stamped at lock-ACQUIRE time (MCP
+ * boot), which precedes the Chrome launch — so this buffer must also absorb a
+ * slow MCP boot (profile scan, cookie copy, disk latency) before Chrome even
+ * starts, on top of the launch budget itself.
  */
-const LOCK_TAKEOVER_GRACE_BUFFER_MS = 30_000;
+const LOCK_TAKEOVER_GRACE_BUFFER_MS = 60_000;
 
 /**
  * Resolve the Chrome launch budget the owner is allowed before its CDP
@@ -249,6 +252,9 @@ function delay(ms: number): Promise<void> {
 }
 
 function isWithinGracePeriod(startedAt: string, now: number, graceMs: number): boolean {
+  // A legacy lock written before `startedAt` existed has an empty string here:
+  // no timestamp means no grace can be computed, so proceed straight to the CDP
+  // probe (the probe — not the clock — then decides whether to evict).
   if (!startedAt) return false;
   const started = Date.parse(startedAt);
   if (!Number.isFinite(started)) return false;
@@ -315,18 +321,28 @@ export async function acquireControllerLockWithHealthCheck(
   // budget (default 60s). The grace must exceed that budget, or a second
   // --auto-launch started mid-launch would probe an empty port and evict the
   // live owner — turning a slow-but-valid startup into split ownership (#1474).
+  // NOTE: `OPENCHROME_LOCK_TAKEOVER_GRACE_MS=0` disables the grace window (a
+  // foot-gun). To turn off health-based takeover entirely, use the dedicated
+  // kill-switch `OPENCHROME_LOCK_HEALTH_TAKEOVER=0` instead.
   const graceMs = options.graceMs
     ?? envInt('OPENCHROME_LOCK_TAKEOVER_GRACE_MS', resolveChromeLaunchBudgetMs() + LOCK_TAKEOVER_GRACE_BUFFER_MS);
   const probeAttempts = options.probeAttempts ?? envInt('OPENCHROME_LOCK_PROBE_ATTEMPTS', 3);
   const probeIntervalMs = options.probeIntervalMs ?? envInt('OPENCHROME_LOCK_PROBE_INTERVAL_MS', 500);
-  const maxTakeovers = options.maxTakeovers ?? 3;
+  const maxTakeovers = options.maxTakeovers ?? envInt('OPENCHROME_LOCK_MAX_TAKEOVERS', 3);
   const now = options.now ?? Date.now;
   const probe = options.probe ?? (async (port: number) => (await fetchJsonVersion(port)) !== null);
   const userDataDir = normalizeControllerUserDataDir(identity.userDataDir);
   const lockPath = getControllerLockPath(identity.port, userDataDir, rootDir);
   const selfHostname = os.hostname();
 
-  for (let attempt = 0; attempt <= maxTakeovers; attempt++) {
+  // Bound total iterations independently of the takeover budget so pathological
+  // lock churn (a concurrent taker repeatedly rewriting the lock) can never
+  // livelock. Only *successful* takeovers count against maxTakeovers, so a
+  // contended re-evaluation no longer burns the budget prematurely.
+  const maxIterations = maxTakeovers + 8;
+  let takeovers = 0;
+
+  for (let iter = 0; iter < maxIterations; iter++) {
     try {
       return acquireControllerLock(identity, rootDir);
     } catch (err) {
@@ -346,15 +362,20 @@ export async function acquireControllerLockWithHealthCheck(
       const healthy = await probeOwnerHealthy(owner.port, probeAttempts, probeIntervalMs, probe);
       if (healthy) throw err;
 
-      if (!unlinkStaleLock(lockPath, owner.pid, owner.startedAt)) {
-        // The lock changed underneath us (a concurrent taker won) — re-evaluate.
-        continue;
+      // Out of takeover budget — surface the duplicate-owner error rather than
+      // evicting yet another owner.
+      if (takeovers >= maxTakeovers) throw err;
+
+      if (unlinkStaleLock(lockPath, owner.pid, owner.startedAt)) {
+        // A real takeover: count it, then re-attempt the O_EXCL create.
+        takeovers += 1;
       }
-      // Loop: re-attempt the O_EXCL create. A concurrent taker may still win,
-      // in which case the next iteration sees a (now healthy) owner and throws.
+      // else: the lock changed underneath us (a concurrent taker won). Re-
+      // evaluate WITHOUT spending takeover budget — the next iteration probes
+      // the new owner and throws if it is healthy.
     }
   }
 
-  // Takeover budget exhausted — surface the duplicate-owner error to the caller.
+  // Iteration ceiling hit under pathological churn — surface the duplicate error.
   return acquireControllerLock(identity, rootDir);
 }

--- a/src/utils/controller-lock.ts
+++ b/src/utils/controller-lock.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { getVersion } from '../version';
+import { fetchJsonVersion } from '../chrome/devtools-info';
 
 export interface ControllerLockIdentity {
   port: number;
@@ -192,4 +193,145 @@ export function formatDuplicateControllerMessage(error: DuplicateControllerError
     'For debugging only, set OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH=1 or pass',
     '--allow-unsafe-shared-attach to bypass this guard.',
   ].join('\n');
+}
+
+/**
+ * Tunables for health-aware controller-lock acquisition. Each has an env
+ * override so operators can adjust grace/probe behaviour without a rebuild;
+ * tests inject `probe`/`now` to stay hermetic.
+ */
+export interface HealthAwareAcquireOptions {
+  /**
+   * Do not evict an owner whose process started less than `graceMs` ago — its
+   * Chrome may still be booting and its CDP endpoint not yet listening.
+   */
+  graceMs?: number;
+  /** Total CDP probe attempts before declaring the owner a half-zombie. */
+  probeAttempts?: number;
+  /** Delay between probe attempts. */
+  probeIntervalMs?: number;
+  /** Maximum stale-lock takeovers before giving up and surfacing the error. */
+  maxTakeovers?: number;
+  /** Injectable reachability probe (tests). Resolves true when CDP responds. */
+  probe?: (port: number) => Promise<boolean>;
+  /** Injectable clock (tests). */
+  now?: () => number;
+  /** Disable health-based takeover entirely (env escape hatch). */
+  disabled?: boolean;
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isWithinGracePeriod(startedAt: string, now: number, graceMs: number): boolean {
+  if (!startedAt) return false;
+  const started = Date.parse(startedAt);
+  if (!Number.isFinite(started)) return false;
+  return now - started < graceMs;
+}
+
+async function probeOwnerHealthy(
+  port: number,
+  attempts: number,
+  intervalMs: number,
+  probe: (port: number) => Promise<boolean>,
+): Promise<boolean> {
+  const total = Math.max(1, attempts);
+  for (let i = 0; i < total; i++) {
+    if (await probe(port)) return true;
+    if (i < total - 1) await delay(intervalMs);
+  }
+  return false;
+}
+
+/**
+ * Remove the lock file only if it still describes the exact owner we just
+ * judged stale (same pid + startedAt). Combined with the O_EXCL re-acquire in
+ * the caller, this makes takeover safe under concurrency: a racing taker that
+ * already rewrote the lock fails the match and we re-evaluate instead of
+ * clobbering the new (possibly healthy) owner.
+ */
+function unlinkStaleLock(lockPath: string, pid: number, startedAt: string): boolean {
+  const current = readMetadata(lockPath);
+  if (!current) return true; // already gone or malformed — let acquire race decide
+  if (current.pid !== pid || current.startedAt !== startedAt) return false;
+  try {
+    fs.unlinkSync(lockPath);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return true;
+    throw err;
+  }
+}
+
+/**
+ * Health-aware wrapper around {@link acquireControllerLock}.
+ *
+ * The synchronous lock recovers only *dead-pid* stale locks. A "half-zombie"
+ * owner — MCP process alive but its managed Chrome/CDP gone — keeps PID
+ * liveness true and would otherwise hold the lock forever, deadlocking every
+ * other session (#1474). This wrapper additionally probes the owner's CDP
+ * endpoint and, when it is unreachable past a grace window, takes the lock
+ * over. A genuinely healthy owner is never evicted.
+ *
+ * Guardrails: a boot grace period (`startedAt`), multi-attempt probing to
+ * tolerate transient stalls, a hostname check so a shared lock directory across
+ * machines is never raced cross-host, an atomic compare-and-unlink takeover,
+ * and an env kill-switch (`OPENCHROME_LOCK_HEALTH_TAKEOVER=0`).
+ */
+export async function acquireControllerLockWithHealthCheck(
+  identity: ControllerLockIdentity,
+  rootDir?: string,
+  options: HealthAwareAcquireOptions = {},
+): Promise<ControllerLockHandle> {
+  const disabled = options.disabled ?? process.env.OPENCHROME_LOCK_HEALTH_TAKEOVER === '0';
+  const graceMs = options.graceMs ?? envInt('OPENCHROME_LOCK_TAKEOVER_GRACE_MS', 15_000);
+  const probeAttempts = options.probeAttempts ?? envInt('OPENCHROME_LOCK_PROBE_ATTEMPTS', 3);
+  const probeIntervalMs = options.probeIntervalMs ?? envInt('OPENCHROME_LOCK_PROBE_INTERVAL_MS', 500);
+  const maxTakeovers = options.maxTakeovers ?? 3;
+  const now = options.now ?? Date.now;
+  const probe = options.probe ?? (async (port: number) => (await fetchJsonVersion(port)) !== null);
+  const userDataDir = normalizeControllerUserDataDir(identity.userDataDir);
+  const lockPath = getControllerLockPath(identity.port, userDataDir, rootDir);
+  const selfHostname = os.hostname();
+
+  for (let attempt = 0; attempt <= maxTakeovers; attempt++) {
+    try {
+      return acquireControllerLock(identity, rootDir);
+    } catch (err) {
+      if (!(err instanceof DuplicateControllerError)) throw err;
+      if (disabled) throw err;
+      const owner = err.owner;
+
+      // Cross-host shared lock directory: never evict another machine's owner;
+      // its PID/CDP are not meaningfully probeable from here.
+      if (owner.hostname && owner.hostname !== selfHostname) throw err;
+
+      // Owner may still be launching Chrome; its CDP endpoint is legitimately
+      // not listening yet during the grace window.
+      if (isWithinGracePeriod(owner.startedAt, now(), graceMs)) throw err;
+
+      // Only a half-zombie (CDP unreachable across every attempt) is evictable.
+      const healthy = await probeOwnerHealthy(owner.port, probeAttempts, probeIntervalMs, probe);
+      if (healthy) throw err;
+
+      if (!unlinkStaleLock(lockPath, owner.pid, owner.startedAt)) {
+        // The lock changed underneath us (a concurrent taker won) — re-evaluate.
+        continue;
+      }
+      // Loop: re-attempt the O_EXCL create. A concurrent taker may still win,
+      // in which case the next iteration sees a (now healthy) owner and throws.
+    }
+  }
+
+  // Takeover budget exhausted — surface the duplicate-owner error to the caller.
+  return acquireControllerLock(identity, rootDir);
 }

--- a/tests/controller-lock.test.ts
+++ b/tests/controller-lock.test.ts
@@ -262,6 +262,17 @@ describe('controller lock', () => {
       handle.release();
     });
 
+    test('recordControllerHeartbeat ignores malformed lock content even when pid matches', () => {
+      const lockPath = writeOwnerLock({ pid: 111, port: undefined });
+      fs.writeFileSync(lockPath, JSON.stringify({ pid: 111, userDataDir: path.resolve(profile()) }) + '\n');
+
+      recordControllerHeartbeat(lockPath, 111, () => Date.parse('2026-01-01T00:02:00.000Z'));
+
+      const current = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+      expect(current.lastHeartbeatAt).toBeUndefined();
+      expect(current.port).toBeUndefined();
+    });
+
     test('startControllerHeartbeat refreshes the lock while the probe reports healthy', async () => {
       jest.useFakeTimers();
       try {

--- a/tests/controller-lock.test.ts
+++ b/tests/controller-lock.test.ts
@@ -8,7 +8,9 @@ import {
   controllerLockKey,
   formatDuplicateControllerMessage,
   getControllerLockPath,
+  recordControllerHeartbeat,
   releaseControllerLock,
+  startControllerHeartbeat,
 } from '../src/utils/controller-lock';
 
 describe('controller lock', () => {
@@ -209,6 +211,77 @@ describe('controller lock', () => {
         ),
       ).rejects.toBeInstanceOf(DuplicateControllerError);
       expect(probe).not.toHaveBeenCalled();
+    });
+
+    test('does NOT take over a long-lived owner that is mid-relaunch (recent heartbeat)', async () => {
+      // The owner started long ago (past the grace) but refreshed its heartbeat
+      // 1s ago — i.e. its Chrome was healthy a moment before this crash/relaunch
+      // window. Its CDP is momentarily unreachable, but it must NOT be evicted,
+      // or two controllers would own the same port/profile (the #1474 P1 gap).
+      writeOwnerLock({
+        startedAt: new Date(Date.now() - 30 * 60_000).toISOString(),
+        lastHeartbeatAt: new Date(Date.now() - 1_000).toISOString(),
+      });
+      const probe = jest.fn(async () => false);
+
+      await expect(
+        acquireControllerLockWithHealthCheck({ port: 9222, userDataDir: profile() }, tmpDir, opts({ probe })),
+      ).rejects.toBeInstanceOf(DuplicateControllerError);
+      expect(probe).not.toHaveBeenCalled(); // recent heartbeat short-circuits before probing
+    });
+
+    test('DOES take over when the heartbeat is stale beyond the grace (true half-zombie)', async () => {
+      writeOwnerLock({
+        startedAt: new Date(Date.now() - 30 * 60_000).toISOString(),
+        lastHeartbeatAt: new Date(Date.now() - 5 * 60_000).toISOString(), // stale > grace
+      });
+      const probe = jest.fn(async () => false);
+
+      const handle = await acquireControllerLockWithHealthCheck(
+        { port: 9222, userDataDir: profile() },
+        tmpDir,
+        opts({ probe }),
+      );
+      expect(handle.metadata.pid).toBe(process.pid);
+      handle.release();
+    });
+
+    test('recordControllerHeartbeat refreshes lastHeartbeatAt only for the owning pid', () => {
+      const handle = acquireControllerLock({ port: 9222, userDataDir: profile() }, tmpDir);
+      const before = handle.metadata.lastHeartbeatAt;
+
+      recordControllerHeartbeat(handle.path, handle.metadata.pid, () => Date.parse(before) + 60_000);
+      const afterOwn = JSON.parse(fs.readFileSync(handle.path, 'utf8'));
+      expect(afterOwn.lastHeartbeatAt).not.toBe(before);
+
+      // A different pid must not be able to refresh (or resurrect) the lock.
+      recordControllerHeartbeat(handle.path, handle.metadata.pid + 1, () => Date.parse(before) + 120_000);
+      const afterOther = JSON.parse(fs.readFileSync(handle.path, 'utf8'));
+      expect(afterOther.lastHeartbeatAt).toBe(afterOwn.lastHeartbeatAt);
+
+      handle.release();
+    });
+
+    test('startControllerHeartbeat refreshes the lock while the probe reports healthy', async () => {
+      jest.useFakeTimers();
+      try {
+        const handle = acquireControllerLock({ port: 9222, userDataDir: profile() }, tmpDir);
+        const before = JSON.parse(fs.readFileSync(handle.path, 'utf8')).lastHeartbeatAt;
+        let clock = Date.parse(before);
+
+        const hb = startControllerHeartbeat(handle, async () => true, {
+          intervalMs: 1000,
+          nowFn: () => (clock += 60_000),
+        });
+        await jest.advanceTimersByTimeAsync(1000); // fire one tick + flush probe/record
+        hb.stop();
+
+        const after = JSON.parse(fs.readFileSync(handle.path, 'utf8')).lastHeartbeatAt;
+        expect(after).not.toBe(before);
+        handle.release();
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     test('still recovers a plain dead-pid stale lock without probing', async () => {

--- a/tests/controller-lock.test.ts
+++ b/tests/controller-lock.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import {
   DuplicateControllerError,
   acquireControllerLock,
+  acquireControllerLockWithHealthCheck,
   controllerLockKey,
   formatDuplicateControllerMessage,
   getControllerLockPath,
@@ -100,5 +101,114 @@ describe('controller lock', () => {
     } finally {
       first.release();
     }
+  });
+
+  describe('health-aware acquisition (#1474)', () => {
+    const profile = () => path.join(tmpDir, 'profile');
+
+    // Writes a lock owned by a *live* pid (this process) so PID-liveness alone
+    // would keep it forever. Guardrail inputs (startedAt/hostname) are explicit.
+    function writeOwnerLock(overrides: Record<string, unknown> = {}): string {
+      const lockPath = getControllerLockPath(9222, profile(), tmpDir);
+      fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+      fs.writeFileSync(
+        lockPath,
+        JSON.stringify({
+          pid: process.pid,
+          port: 9222,
+          userDataDir: path.resolve(profile()),
+          startedAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+          hostname: os.hostname(),
+          ...overrides,
+        }) + '\n',
+      );
+      return lockPath;
+    }
+
+    const opts = (over: Record<string, unknown> = {}) => ({
+      graceMs: 15_000,
+      probeAttempts: 2,
+      probeIntervalMs: 0,
+      ...over,
+    });
+
+    test('takes over a half-zombie owner whose CDP is unreachable', async () => {
+      const lockPath = writeOwnerLock();
+      const probe = jest.fn(async () => false);
+
+      const handle = await acquireControllerLockWithHealthCheck(
+        { port: 9222, userDataDir: profile() },
+        tmpDir,
+        opts({ probe }),
+      );
+
+      expect(probe).toHaveBeenCalledWith(9222);
+      expect(handle.metadata.pid).toBe(process.pid);
+      expect(fs.existsSync(lockPath)).toBe(true);
+      handle.release();
+    });
+
+    test('never evicts a healthy owner (CDP reachable)', async () => {
+      const first = acquireControllerLock({ port: 9222, userDataDir: profile() }, tmpDir);
+      const probe = jest.fn(async () => true);
+
+      await expect(
+        acquireControllerLockWithHealthCheck({ port: 9222, userDataDir: profile() }, tmpDir, opts({ probe })),
+      ).rejects.toBeInstanceOf(DuplicateControllerError);
+
+      first.release();
+    });
+
+    test('does not take over within the boot grace period', async () => {
+      writeOwnerLock({ startedAt: new Date().toISOString() });
+      const probe = jest.fn(async () => false);
+
+      await expect(
+        acquireControllerLockWithHealthCheck({ port: 9222, userDataDir: profile() }, tmpDir, opts({ probe })),
+      ).rejects.toBeInstanceOf(DuplicateControllerError);
+      // Grace short-circuits before any probe runs.
+      expect(probe).not.toHaveBeenCalled();
+    });
+
+    test('never evicts an owner registered on a different host', async () => {
+      writeOwnerLock({ hostname: `${os.hostname()}-other` });
+      const probe = jest.fn(async () => false);
+
+      await expect(
+        acquireControllerLockWithHealthCheck({ port: 9222, userDataDir: profile() }, tmpDir, opts({ probe })),
+      ).rejects.toBeInstanceOf(DuplicateControllerError);
+      expect(probe).not.toHaveBeenCalled();
+    });
+
+    test('escape hatch (disabled) preserves legacy reject-on-live-owner', async () => {
+      writeOwnerLock();
+      const probe = jest.fn(async () => false);
+
+      await expect(
+        acquireControllerLockWithHealthCheck(
+          { port: 9222, userDataDir: profile() },
+          tmpDir,
+          opts({ probe, disabled: true }),
+        ),
+      ).rejects.toBeInstanceOf(DuplicateControllerError);
+      expect(probe).not.toHaveBeenCalled();
+    });
+
+    test('still recovers a plain dead-pid stale lock without probing', async () => {
+      const lockPath = getControllerLockPath(9222, profile(), tmpDir);
+      fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+      fs.writeFileSync(lockPath, JSON.stringify({ pid: 99999999, port: 9222, userDataDir: profile() }) + '\n');
+      const probe = jest.fn(async () => false);
+
+      const handle = await acquireControllerLockWithHealthCheck(
+        { port: 9222, userDataDir: profile() },
+        tmpDir,
+        opts({ probe }),
+      );
+
+      expect(handle.metadata.pid).toBe(process.pid);
+      expect(probe).not.toHaveBeenCalled();
+      handle.release();
+    });
   });
 });

--- a/tests/controller-lock.test.ts
+++ b/tests/controller-lock.test.ts
@@ -170,6 +170,23 @@ describe('controller lock', () => {
       expect(probe).not.toHaveBeenCalled();
     });
 
+    test('default grace derives from the Chrome launch budget — does not evict a still-launching owner', async () => {
+      // 45s old: past the previous 15s default, but well within the 60s Chrome
+      // launch budget during which CDP is legitimately not yet listening.
+      writeOwnerLock({ startedAt: new Date(Date.now() - 45_000).toISOString() });
+      const probe = jest.fn(async () => false);
+
+      await expect(
+        // No graceMs override → exercises the launch-budget-derived default.
+        acquireControllerLockWithHealthCheck(
+          { port: 9222, userDataDir: profile() },
+          tmpDir,
+          { probe, probeAttempts: 2, probeIntervalMs: 0 },
+        ),
+      ).rejects.toBeInstanceOf(DuplicateControllerError);
+      expect(probe).not.toHaveBeenCalled(); // grace short-circuits before probing
+    });
+
     test('never evicts an owner registered on a different host', async () => {
       writeOwnerLock({ hostname: `${os.hostname()}-other` });
       const probe = jest.fn(async () => false);


### PR DESCRIPTION
## Summary

PR **1 of 3** for #1474 (parallel-session controller-lock deadlock). **This PR alone closes the reported deadlock.**

The controller lock treated "owner PID alive" as "owner healthy". A **half-zombie** owner — MCP process alive but its managed Chrome/CDP dead — kept PID liveness true and held the lock forever, so every other parallel session hit `DuplicateController` and exited with a bare `-32000`, with no automatic recovery.

## What changed

`acquireControllerLockWithHealthCheck()` (`src/utils/controller-lock.ts`): on a live-owner collision it probes the owner's CDP endpoint (`/json/version`, reusing `fetchJsonVersion`) and, when unreachable past a grace window, **atomically takes the stale lock over**. A genuinely healthy owner is never evicted. `src/index.ts` now `await`s it in the `--auto-launch` path.

## Guardrails (so we don't turn the deadlock into split-brain / flapping)

- **Boot grace period** (`startedAt`) — an owner still launching Chrome is not evicted while its CDP endpoint is legitimately not yet listening.
- **Multi-attempt probing** — tolerates transient CDP stalls (GC/busy); evict only when *every* attempt fails.
- **Hostname guard** — a shared lock dir across machines is never raced cross-host.
- **Compare-and-unlink + O_EXCL re-acquire** — concurrent takers cannot clobber a freshly-elected healthy owner.
- **Env escape hatch** — `OPENCHROME_LOCK_HEALTH_TAKEOVER=0`, plus grace/attempt/interval overrides.

Default behaviour is unchanged for single-session use and for plain dead-pid stale recovery (SSOT #1359 P7 core-boring).

## Tests

`tests/controller-lock.test.ts` — half-zombie takeover, healthy-owner-never-evicted, grace-period, cross-host, disabled escape hatch, dead-pid recovery without probing. 13/13 pass; `tsc` src+cli + eslint clean.

## SSOT

Aligns with #1359 P3/P3a (deterministic lifecycle, single CDP owner, orphan prevention). Part of #1457 "primitives built, wiring/enforcement missing".

🤖 Generated with [Claude Code](https://claude.com/claude-code)