### PR TITLE
fix(cli): expose broker flags in serve --help + forward unknowns (I1 of #1480)

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -465,6 +465,23 @@ program
   .option('--dashboard', 'Enable terminal dashboard for real-time monitoring')
   .option('--persist-storage', 'Enable browser state persistence (cookies + localStorage)')
   .option('--storage-dir <path>', 'Directory for storage state files (default: .openchrome/storage-state/)')
+  // Shared-profile / parallel-session topology (#1359 broker, #1480). These are
+  // implemented in dist/index.js and reach it via the argv passthrough below;
+  // they are declared here so `openchrome serve --help` documents them instead of
+  // hiding the only sanctioned multi-session path (see docs/roadmap/ssot-decisions.md D3).
+  .option('--broker', 'Run as the shared-profile broker owner (HTTP daemon plus broker discovery metadata). Requires --auto-launch.')
+  .option('--connect-broker', 'Proxy stdio MCP requests to the discovered broker for this (port, profile) instead of attaching to Chrome directly')
+  .option('--allow-unsafe-shared-attach', 'Debug escape hatch: allow a second direct controller for the same Chrome port/profile (races on target cleanup/reconnect — not for normal use)')
+  // Mirror the remaining src/index.ts serve flags that operators commonly need
+  // documented; the passthrough already forwards them.
+  .option('--transport <mode>', 'Transport mode: stdio, http, or both')
+  .option('--auth-token <token>', 'Bearer token for HTTP transport')
+  .option('--auto-connect [userDataDir]', 'Attach to a Chrome you started yourself by reading <userDataDir>/DevToolsActivePort (#849). Implies --launch-mode=attach.')
+  .option('--launch-mode <mode>', 'Chrome launch mode: auto | attach | isolated (#659)')
+  // Never let the bin wrapper reject a flag that the real serve implementation in
+  // dist/index.js understands: forward unknowns instead of erroring, so this
+  // wrapper can never again silently diverge from the full option surface (#1480 G1).
+  .allowUnknownOption()
   .action(async () => {
     // Non-blocking update check (fires in background)
     checkForUpdates(version).catch(() => {});


### PR DESCRIPTION
## I1 of the #1480 PR program — discoverability (G1)

`openchrome serve --help` (the bin wrapper, `cli/index.ts`) hid the only
sanctioned multi-session flags. The wrapper re-declares a **subset** of serve
options for its help text, then spawn-forwards raw `argv` to the full
implementation in `dist/index.js`. That subset omitted `--broker`,
`--connect-broker`, and `--allow-unsafe-shared-attach` — so the documented broker
topology (docs/mcp/topologies.md, decision D3) was invisible at the surface most
operators read, and commander could also reject those flags before forwarding.

### Change
- Declare `--broker` / `--connect-broker` / `--allow-unsafe-shared-attach` (plus
  commonly-documented `--transport` / `--auth-token` / `--auto-connect` /
  `--launch-mode`) on the bin `serve` command so they render in `--help`.
- Add `.allowUnknownOption()` so the wrapper **forwards** any flag it doesn't
  declare instead of erroring — it can never again silently diverge from the
  `dist/index.js` option surface.

No runtime behavior change to the forwarded server (argv passthrough is unchanged).

### Verification
- `npm run build:cli` ✓
- `node dist/cli/index.js serve --help` now lists the broker flags ✓
- `serve --connect-broker …` parses without an unknown-option error ✓

Part of #1480. Independent of the auto-elect core (S2–S4) and the #1474 stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
