### PR TITLE
fix(chrome): reap orphaned headed-fallback Chrome via ownership marker (I2 of #1480)

### DIFF
--- a/src/chrome/headed-fallback.ts
+++ b/src/chrome/headed-fallback.ts
@@ -21,6 +21,7 @@ import { detectBlockingPage, BlockingInfo } from '../utils/page-diagnostics';
 import { safeTitle } from '../utils/safe-title';
 import { getTargetId } from '../utils/puppeteer-helpers';
 import { spawnProcessGuardian } from '../utils/process-guardian';
+import { writeMarker, removeMarker } from './ownership-marker';
 
 /** Default port offset from main Chrome port for the headed fallback */
 const HEADED_PORT_OFFSET = 100;
@@ -85,6 +86,12 @@ class HeadedFallbackManager {
   private port: number;
   private alivePages: Map<string, Page> = new Map();
   private profileDirectory?: string;
+  // #1480 G2: track the fallback Chrome's identity so the orphan reaper can
+  // reclaim it. The reaper's marker scan is port-independent, so a marker is the
+  // only thing that lets it reap a fallback Chrome living at basePort+100 — well
+  // outside the default basePort..basePort+4 reap window.
+  private chromePid?: number;
+  private markerUserDataDir?: string;
   private readonly cleanup = (): void => { this.shutdown(); };
   constructor(basePort: number = 9222) {
     this.port = basePort + HEADED_PORT_OFFSET;
@@ -182,6 +189,17 @@ class HeadedFallbackManager {
       spawnProcessGuardian(process.pid, this.chromeProcess.pid, {
         label: 'headed-fallback',
       });
+      // #1480 G2: mark the fallback Chrome as openchrome-managed so that if this
+      // owner dies hard (SIGKILL) before the guardian/cleanup fires, the next
+      // openchrome start's orphan-reap sweep classifies it 'kill' (ppid dead)
+      // and reclaims it instead of leaking a headed Chrome on port basePort+100.
+      this.chromePid = this.chromeProcess.pid;
+      this.markerUserDataDir = userDataDir;
+      try {
+        writeMarker({ chromePid: this.chromeProcess.pid, userDataDir });
+      } catch (err) {
+        console.error('[HeadedFallback] ownership marker write failed:', err);
+      }
     }
 
     // Wait for Chrome to be ready
@@ -322,6 +340,13 @@ class HeadedFallbackManager {
     if (this.chromeProcess && this.chromeProcess.exitCode === null) {
       try { this.chromeProcess.kill(); } catch { /* ignore */ }
       this.chromeProcess = null;
+    }
+    // #1480 G2: drop the ownership marker on clean shutdown so the reaper does
+    // not later chase an already-terminated PID.
+    if (this.chromePid !== undefined) {
+      try { removeMarker({ chromePid: this.chromePid, userDataDir: this.markerUserDataDir }); } catch { /* ignore */ }
+      this.chromePid = undefined;
+      this.markerUserDataDir = undefined;
     }
   }
 }

--- a/tests/headed/headed-fallback-manager.test.ts
+++ b/tests/headed/headed-fallback-manager.test.ts
@@ -53,6 +53,8 @@ const mockSpawn = jest.fn().mockReturnValue({
   kill: jest.fn(),
   pid: 12345,
 });
+const mockWriteMarker = jest.fn().mockReturnValue('marker-uuid');
+const mockRemoveMarker = jest.fn();
 
 // Mock fetch for waitForDebugPort
 const mockFetch = jest.fn();
@@ -90,6 +92,11 @@ jest.mock('../../src/utils/puppeteer-helpers', () => ({
 
 jest.mock('../../src/utils/process-guardian', () => ({
   spawnProcessGuardian: jest.fn(),
+}));
+
+jest.mock('../../src/chrome/ownership-marker', () => ({
+  writeMarker: (...args: any[]) => mockWriteMarker(...args),
+  removeMarker: (...args: any[]) => mockRemoveMarker(...args),
 }));
 
 import { getHeadedFallback, shutdownHeadedFallback } from '../../src/chrome/headed-fallback';
@@ -247,6 +254,37 @@ describe('HeadedFallbackManager', () => {
     test('safe to call when no Chrome was launched', () => {
       const manager = getHeadedFallback(9222);
       expect(() => manager.shutdown()).not.toThrow();
+    });
+  });
+
+  describe('ownership marker (#1480 G2)', () => {
+    test('writes a managed marker for the fallback Chrome on launch', async () => {
+      const manager = getHeadedFallback(9222);
+      await manager.navigate('https://example.com');
+
+      expect(mockWriteMarker).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chromePid: 12345,
+          userDataDir: expect.stringContaining('openchrome-headed-fallback-9322'),
+        }),
+      );
+    });
+
+    test('removes the marker on shutdown', async () => {
+      const manager = getHeadedFallback(9222);
+      await manager.navigate('https://example.com');
+
+      manager.shutdown();
+
+      expect(mockRemoveMarker).toHaveBeenCalledWith(
+        expect.objectContaining({ chromePid: 12345 }),
+      );
+    });
+
+    test('does not attempt marker removal when no Chrome was launched', () => {
+      const manager = getHeadedFallback(9222);
+      manager.shutdown();
+      expect(mockRemoveMarker).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## I2 of the #1480 PR program — orphan-Chrome leak (G2)

The Tier-3 **headed fallback** (#459) launches Chrome on `basePort + 100`
(e.g. `9322`) by spawning it directly, **without an ownership marker**. The orphan
reaper (`oc_reap_orphans` / start-up sweep) reclaims a Chrome only if either:
- its port is in the default window `basePort..basePort+4` (9322 is **not**), or
- it carries an openchrome ownership marker (the fallback writes **none**).

So when an owner dies **hard** (SIGKILL by the watchdog, before the in-process
guardian/cleanup fires), the fallback Chrome is invisible to both paths and
**leaks** — exactly the `9322` orphan observed in the field report behind #1480.

### Change
`src/chrome/headed-fallback.ts`:
- after spawning the fallback Chrome, `writeMarker({ chromePid, userDataDir })`
  (marker `ppid` = this MCP process, `launchMode: 'isolated'`);
- `removeMarker(...)` on clean shutdown.

Now the next openchrome start's **port-independent** marker scan classifies an
orphaned fallback as `kill` (alive PID + dead ppid + identity match) and reclaims
it. Reuses the existing `writeMarker`/`removeMarker` primitives — no reaper config
change, no new port to scan.

### Verification
- `npm run build:src` ✓ · eslint ✓
- `tests/headed/*` — **61 → 64** tests pass (added 3 marker assertions:
  written-on-launch, removed-on-shutdown, no-op when nothing launched).

### Note
The `9666` headless orphan also seen in the field is **not** produced by current
`src/` (no literal/codepath builds it on `develop`); it is a stale artifact of an
older build and out of scope here. This PR fixes the live `headed-fallback`
codepath. Part of #1480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
