### PR TITLE
feat(broker): auto-elect loser attaches to owner's broker (S3 of #1480)

### DIFF
--- a/src/broker/auto-elect.ts
+++ b/src/broker/auto-elect.ts
@@ -1,0 +1,87 @@
+/**
+ * Auto-elect coordinated sharing (#1480; SSOT decision D3 Q1′).
+ *
+ * Pure, side-effect-free decision helpers for the default `serve --auto-launch`
+ * election path:
+ *
+ *   - the process that WINS the controller lock becomes the broker OWNER and
+ *     publishes broker discovery metadata (so surplus sessions can attach);
+ *   - a process that LOSES to a healthy owner becomes a coordinated CLIENT
+ *     (`--connect-broker` proxy) instead of failing fast.
+ *
+ * The behavior is gated behind an explicit opt-in (`--auto-elect` /
+ * `OPENCHROME_AUTO_ELECT=1`). With the flag unset, the default path is byte-for-
+ * byte unchanged (fail-fast single owner), so this module's wiring has zero blast
+ * radius until an operator opts in. See docs/roadmap/ssot-decisions.md (D3 Q1′)
+ * for the policy and the eventual default-flip plan.
+ *
+ * Keeping the decisions here (rather than inline in src/index.ts) makes the
+ * election rules unit-testable without booting a server or Chrome.
+ */
+
+/** Offset from the CDP port used for the elected owner's broker HTTP endpoint. */
+export const BROKER_HTTP_PORT_OFFSET = 200;
+
+/**
+ * Is auto-elect enabled for this process?
+ *
+ * True when the operator passed `--auto-elect` or set `OPENCHROME_AUTO_ELECT=1`.
+ */
+export function isAutoElectEnabled(
+  opts: { autoElect?: boolean },
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return Boolean(opts.autoElect) || env.OPENCHROME_AUTO_ELECT === '1';
+}
+
+/**
+ * Should the lock WINNER elect itself as the broker owner (publish a broker so
+ * losers can attach)?
+ *
+ * Only when auto-elect is on, this process owns Chrome lifecycle (`--auto-launch`),
+ * and the operator did not already pick an explicit role. Explicit `--broker` /
+ * `--connect-broker` always win over auto-elect — auto-elect never overrides a
+ * deliberate operator choice.
+ */
+export function shouldElectBrokerOwner(params: {
+  autoElect: boolean;
+  autoLaunch: boolean;
+  manualBroker: boolean;
+  connectBroker: boolean;
+}): boolean {
+  return (
+    params.autoElect &&
+    params.autoLaunch &&
+    !params.manualBroker &&
+    !params.connectBroker
+  );
+}
+
+/**
+ * Should a process that LOST the controller lock attach as a coordinated client
+ * rather than fail fast?
+ *
+ * Only when auto-elect is on AND a broker is actually discoverable for this
+ * `(port, userDataDir)` — i.e. the healthy owner is itself an auto-elect/broker
+ * owner. If the owner is a plain direct controller (no broker published), there
+ * is nothing to attach to and the caller must fall back to the normal
+ * duplicate-controller remediation.
+ */
+export function shouldClientAutoConnect(params: {
+  autoElect: boolean;
+  brokerPresent: boolean;
+}): boolean {
+  return params.autoElect && params.brokerPresent;
+}
+
+/**
+ * The default broker HTTP port for an auto-elected owner on a given CDP port.
+ *
+ * Deterministic (`cdpPort + 200`, e.g. 9222 → 9422) so it is predictable and
+ * clear of the headed-fallback offset (`+100`). Operators can still override via
+ * `--http`/`OPENCHROME_HTTP_PORT`; clients never rely on this value directly —
+ * they read the actual endpoint from the published broker metadata.
+ */
+export function defaultBrokerHttpPort(cdpPort: number): number {
+  return cdpPort + BROKER_HTTP_PORT_OFFSET;
+}

--- a/src/chrome/owner-self-release.ts
+++ b/src/chrome/owner-self-release.ts
@@ -1,0 +1,62 @@
+/**
+ * Owner self-release (#1474).
+ *
+ * When the Chrome process watchdog exhausts its relaunch budget, the owner has
+ * become a half-zombie: its MCP process is alive but it can no longer bring
+ * Chrome back. Holding the controller lock in that state deadlocks every other
+ * parallel session, which is the exact outage reported in #1474.
+ *
+ * This wiring surrenders the controller lock and exits non-zero so the MCP host
+ * respawns a fresh owner and the health-aware acquirer (another session, or our
+ * own respawn) can take over. It is the proactive complement to the reactive
+ * health-aware takeover added to acquireControllerLockWithHealthCheck(): the
+ * dying owner releases instead of waiting to be evicted.
+ */
+
+import type { EventEmitter } from 'events';
+
+/**
+ * Non-zero exit code meaning "owner gave up Chrome; respawn me". Distinct from
+ * the config-error exit(2) so logs/hosts can tell the two apart.
+ */
+export const OWNER_SELF_RELEASE_EXIT_CODE = 70;
+
+export interface OwnerSelfReleaseDeps {
+  /** Release the controller lock held by this owner (best-effort, idempotent). */
+  releaseLock: () => void;
+  /** Terminate the process so the MCP host respawns a fresh owner. */
+  exit: (code: number) => void;
+  /** Logger. Defaults to console.error (stdout carries MCP JSON-RPC). */
+  log?: (message: string) => void;
+}
+
+/**
+ * Subscribe to the watchdog's terminal `watchdog-exhausted` event and, when it
+ * fires, release the controller lock and exit.
+ *
+ * Only `watchdog-exhausted` triggers release. `chrome-died` is the normal
+ * recoverable case (the watchdog relaunches) and a single `relaunch-failed` is
+ * transient (the watchdog retries); surrendering ownership on either would flap
+ * the lock on every Chrome crash. We only let go once the watchdog itself has
+ * given up and stopped.
+ */
+export function wireOwnerSelfRelease(watchdog: EventEmitter, deps: OwnerSelfReleaseDeps): void {
+  const log = deps.log ?? ((m: string) => console.error(m));
+  watchdog.on('watchdog-exhausted', (event?: { count?: number }) => {
+    const cycles = event?.count ?? '?';
+    log(
+      `[SelfHealing] Chrome unrecoverable after ${cycles} relaunch cycles; ` +
+        `releasing controller lock and exiting (code ${OWNER_SELF_RELEASE_EXIT_CODE}) ` +
+        `so another session can take over (#1474).`,
+    );
+    try {
+      deps.releaseLock();
+    } catch (err) {
+      log(
+        `[SelfHealing] Controller lock release failed during self-release: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    deps.exit(OWNER_SELF_RELEASE_EXIT_CODE);
+  });
+}

--- a/src/chrome/owner-self-release.ts
+++ b/src/chrome/owner-self-release.ts
@@ -1,16 +1,24 @@
 /**
  * Owner self-release (#1474).
  *
- * When the Chrome process watchdog exhausts its relaunch budget, the owner has
- * become a half-zombie: its MCP process is alive but it can no longer bring
- * Chrome back. Holding the controller lock in that state deadlocks every other
- * parallel session, which is the exact outage reported in #1474.
+ * When the managed Chrome dies and cannot be brought back, the owner becomes a
+ * half-zombie: its MCP process is alive but it can no longer provide a working
+ * Chrome, yet it keeps holding the controller lock — deadlocking every other
+ * parallel session, the exact outage reported in #1474.
  *
  * This wiring surrenders the controller lock and exits non-zero so the MCP host
  * respawns a fresh owner and the health-aware acquirer (another session, or our
  * own respawn) can take over. It is the proactive complement to the reactive
- * health-aware takeover added to acquireControllerLockWithHealthCheck(): the
- * dying owner releases instead of waiting to be evicted.
+ * takeover in acquireControllerLockWithHealthCheck(): the dying owner releases
+ * instead of waiting to be evicted.
+ *
+ * Trigger correctness: we do NOT key off `watchdog-exhausted`, which the
+ * ChromeProcessWatchdog emits after N *successful* relaunches (Chrome is up at
+ * that point) — exiting there would tear down a freshly-recovered browser and
+ * drop active work. Instead we count consecutive `relaunch-failed` events
+ * (reset by any `chrome-relaunched`) and, only once the failures cross a
+ * threshold, confirm with a live CDP probe. The process exits only when Chrome
+ * is genuinely unreachable, never while it is serving requests.
  */
 
 import type { EventEmitter } from 'events';
@@ -21,42 +29,89 @@ import type { EventEmitter } from 'events';
  */
 export const OWNER_SELF_RELEASE_EXIT_CODE = 70;
 
+/** Default consecutive relaunch failures before we confirm-and-release. */
+export const DEFAULT_RELEASE_FAILURE_THRESHOLD = 2;
+
 export interface OwnerSelfReleaseDeps {
   /** Release the controller lock held by this owner (best-effort, idempotent). */
   releaseLock: () => void;
   /** Terminate the process so the MCP host respawns a fresh owner. */
   exit: (code: number) => void;
+  /**
+   * Confirm whether this owner's Chrome/CDP is actually reachable right now.
+   * The hard safety gate: a true result aborts self-release so a recovered or
+   * still-serving Chrome is never torn down.
+   */
+  probeChromeReachable: () => Promise<boolean>;
+  /** Consecutive relaunch failures before confirming. Default 2. */
+  failureThreshold?: number;
   /** Logger. Defaults to console.error (stdout carries MCP JSON-RPC). */
   log?: (message: string) => void;
 }
 
 /**
- * Subscribe to the watchdog's terminal `watchdog-exhausted` event and, when it
- * fires, release the controller lock and exit.
+ * Subscribe to the watchdog's relaunch-lifecycle events and, when Chrome is
+ * confirmed irrecoverable, release the controller lock and exit.
  *
- * Only `watchdog-exhausted` triggers release. `chrome-died` is the normal
- * recoverable case (the watchdog relaunches) and a single `relaunch-failed` is
- * transient (the watchdog retries); surrendering ownership on either would flap
- * the lock on every Chrome crash. We only let go once the watchdog itself has
- * given up and stopped.
+ * - `chrome-relaunched` → recovery succeeded; reset the failure counter.
+ * - `relaunch-failed`   → a recovery attempt threw; count it. Once the count
+ *   reaches the threshold, probe CDP. Release + exit only if unreachable.
+ *
+ * `chrome-died` (normal, the watchdog will relaunch) and a single
+ * `relaunch-failed` (transient) never surrender ownership, so a momentary
+ * crash cannot flap the lock.
  */
 export function wireOwnerSelfRelease(watchdog: EventEmitter, deps: OwnerSelfReleaseDeps): void {
   const log = deps.log ?? ((m: string) => console.error(m));
-  watchdog.on('watchdog-exhausted', (event?: { count?: number }) => {
-    const cycles = event?.count ?? '?';
-    log(
-      `[SelfHealing] Chrome unrecoverable after ${cycles} relaunch cycles; ` +
-        `releasing controller lock and exiting (code ${OWNER_SELF_RELEASE_EXIT_CODE}) ` +
-        `so another session can take over (#1474).`,
-    );
-    try {
-      deps.releaseLock();
-    } catch (err) {
+  const threshold = Math.max(1, deps.failureThreshold ?? DEFAULT_RELEASE_FAILURE_THRESHOLD);
+  let consecutiveFailures = 0;
+  let releasing = false;
+
+  watchdog.on('chrome-relaunched', () => {
+    consecutiveFailures = 0;
+  });
+
+  watchdog.on('relaunch-failed', () => {
+    if (releasing) return;
+    consecutiveFailures += 1;
+    if (consecutiveFailures < threshold) return;
+
+    releasing = true;
+    void (async () => {
+      let reachable: boolean;
+      try {
+        reachable = await deps.probeChromeReachable();
+      } catch (err) {
+        // Inconclusive probe — do not tear down on uncertainty.
+        log(
+          `[SelfHealing] Chrome reachability probe errored during self-release; ` +
+            `staying up: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        releasing = false;
+        return;
+      }
+
+      if (reachable) {
+        // Chrome is actually serving despite the relaunch error — keep running.
+        consecutiveFailures = 0;
+        releasing = false;
+        return;
+      }
+
       log(
-        `[SelfHealing] Controller lock release failed during self-release: ` +
-          `${err instanceof Error ? err.message : String(err)}`,
+        `[SelfHealing] Chrome unrecoverable after ${consecutiveFailures} consecutive ` +
+          `relaunch failures and a confirming CDP probe; releasing controller lock and ` +
+          `exiting (code ${OWNER_SELF_RELEASE_EXIT_CODE}) so another session can take over (#1474).`,
       );
-    }
-    deps.exit(OWNER_SELF_RELEASE_EXIT_CODE);
+      try {
+        deps.releaseLock();
+      } catch (err) {
+        log(
+          `[SelfHealing] Controller lock release failed during self-release: ` +
+            `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      deps.exit(OWNER_SELF_RELEASE_EXIT_CODE);
+    })();
   });
 }

--- a/src/chrome/owner-self-release.ts
+++ b/src/chrome/owner-self-release.ts
@@ -66,9 +66,15 @@ export function wireOwnerSelfRelease(watchdog: EventEmitter, deps: OwnerSelfRele
   const threshold = Math.max(1, deps.failureThreshold ?? DEFAULT_RELEASE_FAILURE_THRESHOLD);
   let consecutiveFailures = 0;
   let releasing = false;
+  let recoveredDuringProbe = false;
 
   watchdog.on('chrome-relaunched', () => {
     consecutiveFailures = 0;
+    // A relaunch that lands while a self-release probe is in flight must abort
+    // that decision: the new Chrome may not have bound its debug port yet, so a
+    // `false` probe result would be stale and could tear down a recovered
+    // browser. Record it; the in-flight probe checks this flag after awaiting.
+    if (releasing) recoveredDuringProbe = true;
   });
 
   watchdog.on('relaunch-failed', () => {
@@ -77,16 +83,30 @@ export function wireOwnerSelfRelease(watchdog: EventEmitter, deps: OwnerSelfRele
     if (consecutiveFailures < threshold) return;
 
     releasing = true;
+    recoveredDuringProbe = false;
     void (async () => {
       let reachable: boolean;
       try {
         reachable = await deps.probeChromeReachable();
       } catch (err) {
-        // Inconclusive probe — do not tear down on uncertainty.
+        // Inconclusive probe — do not tear down on uncertainty. Step the
+        // counter back one so at least one more failure is required before we
+        // re-probe, avoiding a tight no-back-off retry when the probe keeps
+        // timing out.
         log(
           `[SelfHealing] Chrome reachability probe errored during self-release; ` +
             `staying up: ${err instanceof Error ? err.message : String(err)}`,
         );
+        consecutiveFailures = Math.max(0, threshold - 1);
+        releasing = false;
+        return;
+      }
+
+      // A successful relaunch landed while we were probing — abort: a stale
+      // `false` here would tear down the freshly recovered browser.
+      if (recoveredDuringProbe) {
+        recoveredDuringProbe = false;
+        consecutiveFailures = 0;
         releasing = false;
         return;
       }

--- a/src/chrome/process-watchdog.ts
+++ b/src/chrome/process-watchdog.ts
@@ -155,6 +155,14 @@ export class ChromeProcessWatchdog extends EventEmitter {
     if (shouldRateLimitRelaunch(this.launcher.recentCrashesMs)) {
       console.error('[ProcessWatchdog] Chrome crashing repeatedly; pausing relaunches. Run oc_stop and inspect logs.');
       this.cooldownUntil = Date.now() + 60_000;
+      // #1474: a rate-limited crash loop is an irrecoverable state — Chrome is
+      // down and we are deliberately not relaunching. Emit `relaunch-failed` so
+      // owner self-release can observe it; otherwise this branch is silent and a
+      // half-zombie would hold the controller lock forever.
+      this.emit('relaunch-failed', {
+        error: new Error('relaunch-rate-limited'),
+        timestamp: Date.now(),
+      });
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ import {
 } from './utils/controller-lock';
 import { fetchJsonVersion } from './chrome/devtools-info';
 import { getCurrentControllerTopology } from './utils/duplicate-controller-diagnostics';
-import { isAutoElectEnabled, shouldElectBrokerOwner, defaultBrokerHttpPort } from './broker/auto-elect';
+import { isAutoElectEnabled, shouldElectBrokerOwner, shouldClientAutoConnect, defaultBrokerHttpPort } from './broker/auto-elect';
 import {
   DEFAULT_PROCESS_WATCHDOG_INTERVAL_MS,
   DEFAULT_TAB_HEALTH_PROBE_INTERVAL_MS,
@@ -356,17 +356,42 @@ program
           if (err instanceof DuplicateControllerError) {
             // Always emit the full diagnostic to stderr (CLI/operator path).
             console.error(formatDuplicateControllerMessage(err));
+
+            // #1480 S3: auto-elect loser attaches to the healthy owner's broker
+            // instead of failing fast. The owner may have only just won the lock
+            // (this collision is the race), so poll briefly for its broker
+            // discovery metadata before giving up. If a broker is found, become a
+            // coordinated --connect-broker client; the previously-rejected surplus
+            // session now works.
+            if (autoElect) {
+              const { readBrokerMetadata } = await import('./broker/discovery');
+              const { BrokerProxyStdioBridge } = await import('./transports/broker-proxy');
+              let broker = readBrokerMetadata(port, lockUserDataDir);
+              for (let i = 0; i < 10 && !broker; i++) {
+                await new Promise((r) => setTimeout(r, 300));
+                broker = readBrokerMetadata(port, lockUserDataDir);
+              }
+              if (broker && shouldClientAutoConnect({ autoElect, brokerPresent: true })) {
+                const resolvedAuthToken = options.authToken
+                  || process.env.OPENCHROME_AUTH_TOKEN
+                  || (broker.authTokenEnv ? process.env[broker.authTokenEnv] : undefined);
+                console.error(`[openchrome] auto-elect: attaching as broker client -> ${broker.endpoint}`);
+                new BrokerProxyStdioBridge(broker, resolvedAuthToken).start();
+                return;
+              }
+              console.error('[openchrome] auto-elect: owner holds the lock but published no broker; falling back to duplicate-controller remediation.');
+            }
+
             // #1474: when launched by an MCP host over stdio, exiting before the
             // handshake makes the host discard stderr and show only `-32000`.
             // Instead complete `initialize` and surface the remediation through
             // MCP. A human running this in a terminal (TTY) keeps the old
             // exit(2) so the command does not hang waiting on stdin.
             //
-            // Scope: stdio only. `--transport both`/`http` daemons keep the
-            // hard exit(2) — the responder speaks stdio, and surfacing this over
-            // the HTTP leg would need a separate HTTP error path (out of scope;
-            // such daemons typically use --connect-broker, not --auto-launch).
-            if (transportMode === 'stdio' && !process.stdin.isTTY) {
+            // An auto-elect loser that found no broker is also a stdio host
+            // session (the elected owner serves stdio to its own host); surface
+            // the MCP error to it too rather than a bare exit(2).
+            if ((transportMode === 'stdio' || autoElect) && !process.stdin.isTTY) {
               const { DuplicateControllerErrorServer } = await import('./transports/duplicate-controller-error-server');
               new DuplicateControllerErrorServer(err).start();
               return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -342,6 +342,11 @@ program
             // Instead complete `initialize` and surface the remediation through
             // MCP. A human running this in a terminal (TTY) keeps the old
             // exit(2) so the command does not hang waiting on stdin.
+            //
+            // Scope: stdio only. `--transport both`/`http` daemons keep the
+            // hard exit(2) — the responder speaks stdio, and surfacing this over
+            // the HTTP leg would need a separate HTTP error path (out of scope;
+            // such daemons typically use --connect-broker, not --auto-launch).
             if (transportMode === 'stdio' && !process.stdin.isTTY) {
               const { DuplicateControllerErrorServer } = await import('./transports/duplicate-controller-error-server');
               new DuplicateControllerErrorServer(err).start();

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,6 @@ import { getVersion } from './version';
 import { bootstrapPilot, logActiveFlags } from './harness/flags';
 import { ChromeProcessWatchdog } from './chrome/process-watchdog';
 import { wireOwnerSelfRelease } from './chrome/owner-self-release';
-import { fetchJsonVersion } from './chrome/devtools-info';
 import { TabHealthMonitor } from './cdp/tab-health-monitor';
 import { EventLoopMonitor, setGlobalEventLoopMonitor } from './watchdog/event-loop-monitor';
 import { HealthEndpoint, HealthData } from './watchdog/health-endpoint';
@@ -874,12 +873,15 @@ program
     processWatchdog.on('chrome-died', () => {
       setComponent('chrome', 'failing');
     });
-    // #1474: owner self-release. If the watchdog exhausts its relaunch budget,
-    // Chrome is unrecoverable and this owner would otherwise hold the controller
-    // lock forever as a half-zombie, deadlocking every other session. Surrender
-    // the lock and exit so the host respawns and another session can take over.
+    // #1474: owner self-release. When relaunches keep failing and a CDP probe
+    // confirms Chrome is unreachable, this owner is a half-zombie that would
+    // otherwise hold the controller lock forever, deadlocking every other
+    // session. Surrender the lock and exit so the host respawns and another
+    // session can take over.
     wireOwnerSelfRelease(processWatchdog, {
-      releaseLock: () => controllerLock?.release(),
+      // Null the handle after release so the process.on('exit') hook above does
+      // not redundantly re-release during the exit(70) that follows.
+      releaseLock: () => { controllerLock?.release(); controllerLock = null; },
       exit: (code) => process.exit(code),
       // Hard safety gate: only release if Chrome's CDP is genuinely unreachable,
       // so a recovered or still-serving Chrome is never torn down.

--- a/src/index.ts
+++ b/src/index.ts
@@ -335,7 +335,18 @@ program
           });
         } catch (err) {
           if (err instanceof DuplicateControllerError) {
+            // Always emit the full diagnostic to stderr (CLI/operator path).
             console.error(formatDuplicateControllerMessage(err));
+            // #1474: when launched by an MCP host over stdio, exiting before the
+            // handshake makes the host discard stderr and show only `-32000`.
+            // Instead complete `initialize` and surface the remediation through
+            // MCP. A human running this in a terminal (TTY) keeps the old
+            // exit(2) so the command does not hang waiting on stdin.
+            if (transportMode === 'stdio' && !process.stdin.isTTY) {
+              const { DuplicateControllerErrorServer } = await import('./transports/duplicate-controller-error-server');
+              new DuplicateControllerErrorServer(err).start();
+              return;
+            }
             process.exit(2);
           }
           throw err;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { getVersion } from './version';
 import { bootstrapPilot, logActiveFlags } from './harness/flags';
 import { ChromeProcessWatchdog } from './chrome/process-watchdog';
 import { wireOwnerSelfRelease } from './chrome/owner-self-release';
+import { fetchJsonVersion } from './chrome/devtools-info';
 import { TabHealthMonitor } from './cdp/tab-health-monitor';
 import { EventLoopMonitor, setGlobalEventLoopMonitor } from './watchdog/event-loop-monitor';
 import { HealthEndpoint, HealthData } from './watchdog/health-endpoint';
@@ -880,6 +881,9 @@ program
     wireOwnerSelfRelease(processWatchdog, {
       releaseLock: () => controllerLock?.release(),
       exit: (code) => process.exit(code),
+      // Hard safety gate: only release if Chrome's CDP is genuinely unreachable,
+      // so a recovered or still-serving Chrome is never torn down.
+      probeChromeReachable: async () => (await fetchJsonVersion(port)) !== null,
     });
     processWatchdog.start();
     // Readiness: watchdogs component is ok once the first tick has been scheduled

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import {
 } from './utils/controller-lock';
 import { fetchJsonVersion } from './chrome/devtools-info';
 import { getCurrentControllerTopology } from './utils/duplicate-controller-diagnostics';
+import { isAutoElectEnabled, shouldElectBrokerOwner, defaultBrokerHttpPort } from './broker/auto-elect';
 import {
   DEFAULT_PROCESS_WATCHDOG_INTERVAL_MS,
   DEFAULT_TAB_HEALTH_PROBE_INTERVAL_MS,
@@ -120,6 +121,7 @@ program
   .option('--transport <mode>', 'Transport mode: stdio, http, or both (default: stdio)')
   .option('--broker', 'Run as the shared-profile broker owner (HTTP daemon plus broker discovery metadata)')
   .option('--connect-broker', 'Proxy stdio MCP requests to the discovered broker instead of attaching to Chrome directly')
+  .option('--auto-elect', 'Coordinated sharing (#1480): the --auto-launch process that wins the controller lock becomes the broker owner and surplus sessions auto-attach as clients instead of failing fast. Also: OPENCHROME_AUTO_ELECT=1. Off by default.')
   .option('--idle-timeout <duration>', 'Self-exit (code 0) after idle window with zero sessions. Format: <number>(ms|s|m|h), e.g. 30m, 90s, 500ms. Bare numbers are rejected. Also: OPENCHROME_IDLE_TIMEOUT_MS env var (integer ms). Default: disabled.')
   .option('--pilot', 'Enable experimental pilot tier (see docs/roadmap/portability-harness-contract.md). Off by default; lazy-loads src/pilot/ modules when set. Also: OPENCHROME_PILOT=1 env var.')
   .option('--slim', 'Expose only core tools (alias for --tools-only core).')
@@ -130,7 +132,7 @@ program
   .option('--launch-mode <mode>', 'Chrome launch mode: auto | attach | isolated (#659). Also: OPENCHROME_LAUNCH_MODE env var.')
   .option('--secrets <path>', 'Load a dotenv-format secrets file (KEY=value per line). Tokens "${SECRET:NAME}" in tool arguments are substituted to the real value at MCP request deserialization; the same values are redacted from every LLM-visible artifact (responses, trace, skill records, journal). Default: no secrets loaded. P3: no OS keychain integration.')
   .option('--codegen <mode>', 'Opt-in replay artifact generation: off, puppeteer, playwright, or mcp-replay. Default: off (no response shape changes). Also: OPENCHROME_CODEGEN.')
-  .action(async (options: { port: string; autoLaunch?: boolean; allowUnsafeSharedAttach?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; windowSize?: string; windowPosition?: string; windowBounds?: string; startMaximized?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; broker?: boolean; connectBroker?: boolean; idleTimeout?: string; allowUnauthenticatedHttp?: boolean; pilot?: boolean; slim?: boolean; toolsOnly?: string; disableTools?: string; introspectToolsList?: boolean; autoConnect?: string | boolean; launchMode?: string; secrets?: string; codegen?: string }) => {
+  .action(async (options: { port: string; autoLaunch?: boolean; allowUnsafeSharedAttach?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; windowSize?: string; windowPosition?: string; windowBounds?: string; startMaximized?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; broker?: boolean; connectBroker?: boolean; autoElect?: boolean; idleTimeout?: string; allowUnauthenticatedHttp?: boolean; pilot?: boolean; slim?: boolean; toolsOnly?: string; disableTools?: string; introspectToolsList?: boolean; autoConnect?: string | boolean; launchMode?: string; secrets?: string; codegen?: string }) => {
     const { normalizeCodegenMode, setCodegenMode } = await import('./core/codegen');
     const codegenMode = normalizeCodegenMode(options.codegen ?? process.env.OPENCHROME_CODEGEN);
     setCodegenMode(codegenMode);
@@ -267,6 +269,19 @@ program
       process.exit(2);
     }
 
+    // #1480 auto-elect (D3 Q1′): the --auto-launch lock winner elects itself the
+    // broker owner so surplus sessions attach as coordinated clients instead of
+    // failing fast. Opt-in (off by default) — when disabled, every branch below
+    // is byte-for-byte the prior fail-fast behavior. Explicit --broker/
+    // --connect-broker always take precedence over auto-elect.
+    const autoElect = isAutoElectEnabled(options);
+    const electBrokerOwner = shouldElectBrokerOwner({
+      autoElect,
+      autoLaunch,
+      manualBroker: Boolean(options.broker),
+      connectBroker: Boolean(options.connectBroker),
+    });
+
     // Resolve transport mode before owner-lock acquisition so lock metadata
     // describes whether this process is a stdio, HTTP, or dual-transport owner.
     const validModes = ['stdio', 'http', 'both'];
@@ -278,7 +293,11 @@ program
     }
     const rawMode = options.broker
       ? 'http'
-      : options.transport ?? process.env.OPENCHROME_TRANSPORT ?? (options.http !== undefined && options.http !== false ? 'http' : 'stdio');
+      // An elected owner serves its own host over stdio AND exposes the broker
+      // over HTTP, so it needs dual transport.
+      : electBrokerOwner
+        ? 'both'
+        : options.transport ?? process.env.OPENCHROME_TRANSPORT ?? (options.http !== undefined && options.http !== false ? 'http' : 'stdio');
     if (!validModes.includes(rawMode)) {
       console.error(`[openchrome] Unknown transport mode "${rawMode}", falling back to stdio`);
     }
@@ -705,7 +724,13 @@ program
 
     if (transportMode === 'both') {
       // Dual mode: run both stdio and HTTP transports simultaneously
-      const httpPort = typeof options.http === 'string' ? parseInt(options.http, 10) : parseInt(process.env.OPENCHROME_HTTP_PORT || '', 10) || 3100;
+      // #1480: an auto-elected owner with no explicit --http uses a deterministic
+      // broker port (cdpPort + 200) instead of the shared 3100 default, so two
+      // owners on different profiles don't collide on one HTTP port.
+      const httpPort = typeof options.http === 'string'
+        ? parseInt(options.http, 10)
+        : parseInt(process.env.OPENCHROME_HTTP_PORT || '', 10)
+          || (electBrokerOwner ? defaultBrokerHttpPort(port) : 3100);
       const httpHost = (options as Record<string, unknown>).httpHost as string || process.env.OPENCHROME_HTTP_HOST || '127.0.0.1';
       const { HTTPTransport } = require('./transports/http');
       const httpTrans = new HTTPTransport(
@@ -729,13 +754,15 @@ program
 
       console.error(`[openchrome] Dual transport mode: stdio + HTTP on ${httpHost}:${httpPort}`);
       console.error('[openchrome] Infinite reconnection: enabled (daemon mode)');
-      if (options.broker) {
+      // Publish broker discovery for an explicit --broker owner OR an auto-elected
+      // owner (#1480), so surplus sessions can find and attach to this owner.
+      if (options.broker || electBrokerOwner) {
         const { publishBrokerMetadata, removeBrokerMetadata } = await import('./broker/discovery');
         const { setBrokerOwnerMode, recordBrokerStopped } = await import('./broker/lifecycle');
         setBrokerOwnerMode(true);
         const metadata = publishBrokerMetadata({ port, userDataDir: lockUserDataDir, httpHost, httpPort, authTokenEnv: brokerAuthTokenEnv });
         process.on('exit', () => { recordBrokerStopped(); removeBrokerMetadata(port, lockUserDataDir); });
-        console.error(`[openchrome] Broker metadata: ${metadata.endpoint}`);
+        console.error(`[openchrome] Broker metadata: ${metadata.endpoint}${electBrokerOwner ? ' (auto-elected)' : ''}`);
       }
     } else if (useHttp) {
       const httpPort = typeof options.http === 'string' ? parseInt(options.http, 10) : parseInt(process.env.OPENCHROME_HTTP_PORT || '', 10) || 3100;

--- a/src/index.ts
+++ b/src/index.ts
@@ -696,7 +696,22 @@ program
     if (authToken) {
       console.error('[openchrome] Bearer token authentication: enabled');
     }
-    const allowUnauthenticatedHttp = options.allowUnauthenticatedHttp;
+    // #1480 S2: an auto-elected owner exposes the broker over a loopback HTTP
+    // endpoint for same-user local sharing. There is no operator to supply a
+    // bearer token (this is zero-config), and a cross-process auto-generated
+    // token cannot be advertised via `authTokenEnv` (the client process would
+    // not inherit it). So, only when electing AND no token is configured AND the
+    // broker binds loopback, allow the unauthenticated loopback HTTP leg — the
+    // same posture as OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP=1. Non-loopback
+    // (--http-host 0.0.0.0) or any explicit token keeps auth mandatory; cross-
+    // tenant trust still requires explicit auth per D3 Q6.
+    const effectiveHttpHost = (options as Record<string, unknown>).httpHost as string || process.env.OPENCHROME_HTTP_HOST || '127.0.0.1';
+    const brokerHostIsLoopback = effectiveHttpHost === '127.0.0.1' || effectiveHttpHost === 'localhost' || effectiveHttpHost === '::1';
+    const allowUnauthenticatedHttp = options.allowUnauthenticatedHttp
+      || (electBrokerOwner && !authToken && brokerHostIsLoopback);
+    if (electBrokerOwner && !authToken && brokerHostIsLoopback && !options.allowUnauthenticatedHttp) {
+      console.error('[openchrome] auto-elect: broker HTTP leg is loopback-only and unauthenticated (no token configured).');
+    }
 
     // Multi-tenant API key store: when OPENCHROME_API_KEYS_PATH points at a
     // JSONL store file, load it and pass it to the HTTP transport so

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { getIdleState } from './utils/idle-state';
 import { getVersion } from './version';
 import { bootstrapPilot, logActiveFlags } from './harness/flags';
 import { ChromeProcessWatchdog } from './chrome/process-watchdog';
+import { wireOwnerSelfRelease } from './chrome/owner-self-release';
 import { TabHealthMonitor } from './cdp/tab-health-monitor';
 import { EventLoopMonitor, setGlobalEventLoopMonitor } from './watchdog/event-loop-monitor';
 import { HealthEndpoint, HealthData } from './watchdog/health-endpoint';
@@ -871,6 +872,14 @@ program
     // Readiness: flip chrome to failing when watchdog detects Chrome died
     processWatchdog.on('chrome-died', () => {
       setComponent('chrome', 'failing');
+    });
+    // #1474: owner self-release. If the watchdog exhausts its relaunch budget,
+    // Chrome is unrecoverable and this owner would otherwise hold the controller
+    // lock forever as a half-zombie, deadlocking every other session. Surrender
+    // the lock and exit so the host respawns and another session can take over.
+    wireOwnerSelfRelease(processWatchdog, {
+      releaseLock: () => controllerLock?.release(),
+      exit: (code) => process.exit(code),
     });
     processWatchdog.start();
     // Readiness: watchdogs component is ok once the first tick has been scheduled

--- a/src/transports/duplicate-controller-error-server.ts
+++ b/src/transports/duplicate-controller-error-server.ts
@@ -1,0 +1,184 @@
+/**
+ * Degraded stdio MCP responder for the duplicate-controller case (#1474).
+ *
+ * When `--auto-launch` refuses to start because another session already owns
+ * Chrome for this (port, userDataDir), the old behaviour was
+ * `console.error(remediation); process.exit(2)` — but the process exited
+ * *before* the MCP handshake, so the host discarded stderr and the user saw
+ * only a bare `-32000`. The rich, actionable diagnostic never reached them.
+ *
+ * Instead of exiting, this minimal responder completes the `initialize`
+ * handshake (so the host accepts the connection) and then surfaces the
+ * remediation through portable MCP surfaces:
+ *   - a `notifications/message` (logging) emitted right after initialize;
+ *   - a single diagnostic tool whose name/description state the conflict;
+ *   - a structured JSON-RPC error (with `data`) on every other request.
+ *
+ * It owns no Chrome and holds no controller lock — it is a read-only
+ * explainer that lets the host render "another session owns Chrome; here is
+ * how to fix it" rather than `-32000`. SSOT #1359 P1: portable MCP, robust
+ * errors a host LLM can act on.
+ */
+
+import * as readline from 'readline';
+import { getVersion } from '../version';
+import { MCPErrorCodes, type MCPResponse } from '../types/mcp';
+import type { DuplicateControllerError } from '../utils/controller-lock';
+
+/** Server-defined JSON-RPC error code surfaced for the conflict. */
+export const DUPLICATE_CONTROLLER_ERROR_CODE = -32000;
+
+const DIAGNOSTIC_TOOL_NAME = 'openchrome_owner_conflict';
+
+export interface DuplicateControllerErrorServerOptions {
+  /** Override stdout writer (tests). */
+  write?: (chunk: string) => void;
+  /** Override the protocol version echoed in initialize (tests/compat). */
+  protocolVersion?: string;
+}
+
+type JsonRpcMessage = {
+  jsonrpc?: unknown;
+  id?: number | string | null;
+  method?: unknown;
+  params?: unknown;
+};
+
+export class DuplicateControllerErrorServer {
+  private readonly error: DuplicateControllerError;
+  private readonly writeOut: (chunk: string) => void;
+  private readonly protocolVersion: string;
+
+  constructor(error: DuplicateControllerError, options: DuplicateControllerErrorServerOptions = {}) {
+    this.error = error;
+    this.writeOut = options.write ?? ((chunk) => { process.stdout.write(chunk); });
+    this.protocolVersion = options.protocolVersion ?? '2024-11-05';
+  }
+
+  start(): void {
+    const rl = readline.createInterface({ input: process.stdin, terminal: false });
+    rl.on('line', (line) => {
+      for (const out of this.handleLine(line)) this.writeOut(out);
+    });
+    rl.on('close', () => process.exit(0));
+  }
+
+  /** Structured remediation payload reused for both the error and the tool. */
+  remediationData(): Record<string, unknown> {
+    const owner = this.error.owner;
+    return {
+      reason: 'duplicate_controller',
+      port: owner.port,
+      userDataDir: owner.userDataDir,
+      ownerPid: owner.pid,
+      ownerVersion: owner.version,
+      ownerCommand: owner.command,
+      lockPath: this.error.lockPath,
+      remediations: [
+        'Stop the existing OpenChrome MCP owner, then reconnect this session.',
+        'Or run one shared broker — `openchrome serve --broker --auto-launch ' +
+          `--port ${owner.port} --user-data-dir ${owner.userDataDir}` +
+          '` — and point every session at it with `serve --connect-broker`.',
+        'Or give this session a distinct --port and --user-data-dir.',
+      ],
+    };
+  }
+
+  private summaryMessage(): string {
+    const owner = this.error.owner;
+    return (
+      `OpenChrome is unavailable: another session (pid ${owner.pid}) already owns ` +
+      `Chrome on port ${owner.port} for profile ${owner.userDataDir}. ` +
+      'Use --connect-broker to share it, or a distinct --port/--user-data-dir.'
+    );
+  }
+
+  /** Pure line handler — returns serialized JSON-RPC frames to write. */
+  handleLine(line: string): string[] {
+    if (!line.trim()) return [];
+    let message: JsonRpcMessage;
+    try {
+      message = JSON.parse(line) as JsonRpcMessage;
+    } catch (err) {
+      return [serialize({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: MCPErrorCodes.PARSE_ERROR, message: err instanceof Error ? err.message : 'Parse error' },
+      })];
+    }
+    return this.handle(message).map(serialize);
+  }
+
+  private handle(message: JsonRpcMessage): Array<MCPResponse | Record<string, unknown>> {
+    const method = typeof message.method === 'string' ? message.method : '';
+    const hasId = message.id !== undefined && message.id !== null;
+    const id = (message.id ?? null) as number | string | null;
+
+    // Notifications (no id) get no reply — JSON-RPC §4.1.
+    if (!hasId) return [];
+
+    if (method === 'initialize') {
+      return [
+        {
+          jsonrpc: '2.0',
+          id,
+          result: {
+            protocolVersion: this.protocolVersion,
+            capabilities: { tools: { listChanged: false }, logging: {} },
+            serverInfo: { name: 'openchrome', version: getVersion() },
+          },
+        },
+        // Push the remediation as a logging notification so hosts that surface
+        // server logs show it immediately, before any tool call.
+        {
+          jsonrpc: '2.0',
+          method: 'notifications/message',
+          params: { level: 'error', logger: 'openchrome', data: this.summaryMessage() },
+        },
+      ];
+    }
+
+    if (method === 'tools/list') {
+      return [{
+        jsonrpc: '2.0',
+        id,
+        result: {
+          tools: [{
+            name: DIAGNOSTIC_TOOL_NAME,
+            description: this.summaryMessage(),
+            inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+          }],
+        },
+      }];
+    }
+
+    if (method === 'tools/call') {
+      // Return the remediation as a tool error (isError content), the standard
+      // shape a host renders for a failed tool.
+      return [{
+        jsonrpc: '2.0',
+        id,
+        result: {
+          isError: true,
+          content: [{ type: 'text', text: this.summaryMessage() }],
+          structuredContent: this.remediationData(),
+        },
+      }];
+    }
+
+    // Any other request: structured JSON-RPC error carrying the remediation.
+    return [{
+      jsonrpc: '2.0',
+      id,
+      error: {
+        code: DUPLICATE_CONTROLLER_ERROR_CODE,
+        message: this.summaryMessage(),
+        data: this.remediationData(),
+      },
+    }];
+  }
+}
+
+function serialize(frame: MCPResponse | Record<string, unknown>): string {
+  return JSON.stringify(frame) + '\n';
+}

--- a/src/transports/duplicate-controller-error-server.ts
+++ b/src/transports/duplicate-controller-error-server.ts
@@ -37,6 +37,18 @@ export interface DuplicateControllerErrorServerOptions {
   protocolVersion?: string;
   /** Override process exit (tests). */
   exit?: (code: number) => void;
+  /**
+   * If no `initialize` arrives within this window, exit(2) instead of hanging.
+   * Guards a non-MCP stdin that stays open but never speaks (e.g.
+   * `tail -f /dev/null | serve`). 0 disables. Default 10s.
+   */
+  initTimeoutMs?: number;
+}
+
+function parseEnvInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === '') return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
 }
 
 type JsonRpcMessage = {
@@ -51,6 +63,7 @@ export class DuplicateControllerErrorServer {
   private readonly writeOut: (chunk: string) => void;
   private readonly protocolVersion: string;
   private readonly exit: (code: number) => void;
+  private readonly initTimeoutMs: number;
   /** Whether a real MCP client completed `initialize` before stdin closed. */
   private sawInitialize = false;
 
@@ -59,14 +72,36 @@ export class DuplicateControllerErrorServer {
     this.writeOut = options.write ?? ((chunk) => { process.stdout.write(chunk); });
     this.protocolVersion = options.protocolVersion ?? '2024-11-05';
     this.exit = options.exit ?? ((code) => process.exit(code));
+    this.initTimeoutMs = options.initTimeoutMs
+      ?? parseEnvInt(process.env.OPENCHROME_DUPLICATE_RESPONDER_INIT_TIMEOUT_MS, 10_000);
   }
 
-  start(): void {
-    const rl = readline.createInterface({ input: process.stdin, terminal: false });
+  start(input: NodeJS.ReadableStream = process.stdin): void {
+    const rl = readline.createInterface({ input, terminal: false });
+
+    // A non-MCP stdin that stays open but never sends `initialize` (e.g.
+    // `tail -f /dev/null | serve`) would otherwise hang forever and never
+    // report the duplicate-controller refusal. Bound the wait: if no handshake
+    // arrives in time, exit(2). Unref'd so a real MCP client is unaffected.
+    let initTimer: NodeJS.Timeout | null = null;
+    if (this.initTimeoutMs > 0) {
+      initTimer = setTimeout(() => {
+        if (!this.sawInitialize) this.exit(2);
+      }, this.initTimeoutMs);
+      initTimer.unref?.();
+    }
+    const clearInitTimer = () => {
+      if (initTimer) { clearTimeout(initTimer); initTimer = null; }
+    };
+
     rl.on('line', (line) => {
       for (const out of this.handleLine(line)) this.writeOut(out);
+      if (this.sawInitialize) clearInitTimer();
     });
-    rl.on('close', () => this.exit(this.closeExitCode()));
+    rl.on('close', () => {
+      clearInitTimer();
+      this.exit(this.closeExitCode());
+    });
   }
 
   /**
@@ -140,7 +175,7 @@ export class DuplicateControllerErrorServer {
       const responses: Array<MCPResponse | Record<string, unknown>> = [];
       const serverNotifications: string[] = [];
       for (const item of parsed) {
-        for (const frame of this.handle(item as JsonRpcMessage)) {
+        for (const frame of this.handle(item)) {
           if ('id' in frame) responses.push(frame);
           else serverNotifications.push(serialize(frame)); // server notification → own line
         }
@@ -150,10 +185,22 @@ export class DuplicateControllerErrorServer {
       return out.concat(serverNotifications);
     }
 
-    return this.handle(parsed as JsonRpcMessage).map(serialize);
+    return this.handle(parsed).map(serialize);
   }
 
-  private handle(message: JsonRpcMessage): Array<MCPResponse | Record<string, unknown>> {
+  private handle(raw: unknown): Array<MCPResponse | Record<string, unknown>> {
+    // Valid JSON that is not a JSON-RPC object (null, number, string, boolean,
+    // or a nested array inside a batch) must yield an Invalid Request error —
+    // not a TypeError from `'id' in raw`, which would crash the process and
+    // drop the connection the responder exists to preserve.
+    if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+      return [{
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: MCPErrorCodes.INVALID_REQUEST, message: 'Invalid Request: expected a JSON-RPC object' },
+      }];
+    }
+    const message = raw as JsonRpcMessage;
     const method = typeof message.method === 'string' ? message.method : '';
     // JSON-RPC §4.1: a notification is a request WITHOUT an `id` member. An
     // explicit `id: null` is an unusual-but-valid request, so key off member

--- a/src/transports/duplicate-controller-error-server.ts
+++ b/src/transports/duplicate-controller-error-server.ts
@@ -35,6 +35,8 @@ export interface DuplicateControllerErrorServerOptions {
   write?: (chunk: string) => void;
   /** Override the protocol version echoed in initialize (tests/compat). */
   protocolVersion?: string;
+  /** Override process exit (tests). */
+  exit?: (code: number) => void;
 }
 
 type JsonRpcMessage = {
@@ -48,11 +50,15 @@ export class DuplicateControllerErrorServer {
   private readonly error: DuplicateControllerError;
   private readonly writeOut: (chunk: string) => void;
   private readonly protocolVersion: string;
+  private readonly exit: (code: number) => void;
+  /** Whether a real MCP client completed `initialize` before stdin closed. */
+  private sawInitialize = false;
 
   constructor(error: DuplicateControllerError, options: DuplicateControllerErrorServerOptions = {}) {
     this.error = error;
     this.writeOut = options.write ?? ((chunk) => { process.stdout.write(chunk); });
     this.protocolVersion = options.protocolVersion ?? '2024-11-05';
+    this.exit = options.exit ?? ((code) => process.exit(code));
   }
 
   start(): void {
@@ -60,7 +66,19 @@ export class DuplicateControllerErrorServer {
     rl.on('line', (line) => {
       for (const out of this.handleLine(line)) this.writeOut(out);
     });
-    rl.on('close', () => process.exit(0));
+    rl.on('close', () => this.exit(this.closeExitCode()));
+  }
+
+  /**
+   * Exit code to use when stdin closes. If a real MCP client handshook
+   * (`initialize` seen), the remediation was delivered and a clean disconnect
+   * is success (0). But a non-interactive launch with stdin already EOF — e.g.
+   * `serve --auto-launch </dev/null` from CI/systemd — closes without any
+   * handshake; that is still a refusal-to-start and MUST report failure (2),
+   * not a silent success (Codex P2, #1474).
+   */
+  closeExitCode(): number {
+    return this.sawInitialize ? 0 : 2;
   }
 
   /** Structured remediation payload reused for both the error and the tool. */
@@ -118,6 +136,7 @@ export class DuplicateControllerErrorServer {
     if (!hasId) return [];
 
     if (method === 'initialize') {
+      this.sawInitialize = true;
       return [
         {
           jsonrpc: '2.0',

--- a/src/transports/duplicate-controller-error-server.ts
+++ b/src/transports/duplicate-controller-error-server.ts
@@ -114,9 +114,9 @@ export class DuplicateControllerErrorServer {
   /** Pure line handler — returns serialized JSON-RPC frames to write. */
   handleLine(line: string): string[] {
     if (!line.trim()) return [];
-    let message: JsonRpcMessage;
+    let parsed: unknown;
     try {
-      message = JSON.parse(line) as JsonRpcMessage;
+      parsed = JSON.parse(line);
     } catch (err) {
       return [serialize({
         jsonrpc: '2.0',
@@ -124,15 +124,44 @@ export class DuplicateControllerErrorServer {
         error: { code: MCPErrorCodes.PARSE_ERROR, message: err instanceof Error ? err.message : 'Parse error' },
       })];
     }
-    return this.handle(message).map(serialize);
+
+    // JSON-RPC §6 batch: respond with an array of the per-request responses;
+    // request members that are notifications produce no response member. We
+    // also surface any server-originated notification (the logging frame from
+    // initialize) as its own line outside the batch array.
+    if (Array.isArray(parsed)) {
+      if (parsed.length === 0) {
+        return [serialize({
+          jsonrpc: '2.0',
+          id: null,
+          error: { code: MCPErrorCodes.INVALID_REQUEST, message: 'Invalid empty batch' },
+        })];
+      }
+      const responses: Array<MCPResponse | Record<string, unknown>> = [];
+      const serverNotifications: string[] = [];
+      for (const item of parsed) {
+        for (const frame of this.handle(item as JsonRpcMessage)) {
+          if ('id' in frame) responses.push(frame);
+          else serverNotifications.push(serialize(frame)); // server notification → own line
+        }
+      }
+      const out: string[] = [];
+      if (responses.length > 0) out.push(JSON.stringify(responses) + '\n');
+      return out.concat(serverNotifications);
+    }
+
+    return this.handle(parsed as JsonRpcMessage).map(serialize);
   }
 
   private handle(message: JsonRpcMessage): Array<MCPResponse | Record<string, unknown>> {
     const method = typeof message.method === 'string' ? message.method : '';
-    const hasId = message.id !== undefined && message.id !== null;
+    // JSON-RPC §4.1: a notification is a request WITHOUT an `id` member. An
+    // explicit `id: null` is an unusual-but-valid request, so key off member
+    // presence rather than null-ness (a null-check would drop the reply).
+    const hasId = 'id' in message;
     const id = (message.id ?? null) as number | string | null;
 
-    // Notifications (no id) get no reply — JSON-RPC §4.1.
+    // Notifications (no id member) get no reply — JSON-RPC §4.1.
     if (!hasId) return [];
 
     if (method === 'initialize') {
@@ -152,9 +181,23 @@ export class DuplicateControllerErrorServer {
         {
           jsonrpc: '2.0',
           method: 'notifications/message',
-          params: { level: 'error', logger: 'openchrome', data: this.summaryMessage() },
+          // MCP logging `data` is a structured, JSON-serializable value (the
+          // real server uses an object too), not a bare string.
+          params: {
+            level: 'error',
+            logger: 'openchrome',
+            data: { message: this.summaryMessage(), remediation: this.remediationData() },
+          },
         },
       ];
+    }
+
+    // MCP/JSON-RPC keepalive: a host that pings during or after initialize must
+    // get `{ result: {} }`. Returning the generic error here would make many
+    // hosts treat the connection as failed and disconnect before the user ever
+    // sees the remediation.
+    if (method === 'ping') {
+      return [{ jsonrpc: '2.0', id, result: {} }];
     }
 
     if (method === 'tools/list') {

--- a/tests/auto-elect.test.ts
+++ b/tests/auto-elect.test.ts
@@ -1,0 +1,84 @@
+/// <reference types="jest" />
+/**
+ * Unit tests for the auto-elect decision helpers (#1480, D3 Q1′).
+ *
+ * These lock the election rules that src/index.ts wires into the
+ * `serve --auto-launch` path, without booting a server or Chrome.
+ */
+
+import {
+  isAutoElectEnabled,
+  shouldElectBrokerOwner,
+  shouldClientAutoConnect,
+  defaultBrokerHttpPort,
+  BROKER_HTTP_PORT_OFFSET,
+} from '../src/broker/auto-elect';
+
+describe('isAutoElectEnabled', () => {
+  test('false by default (no flag, no env)', () => {
+    expect(isAutoElectEnabled({}, {})).toBe(false);
+  });
+
+  test('true when --auto-elect flag set', () => {
+    expect(isAutoElectEnabled({ autoElect: true }, {})).toBe(true);
+  });
+
+  test('true when OPENCHROME_AUTO_ELECT=1', () => {
+    expect(isAutoElectEnabled({}, { OPENCHROME_AUTO_ELECT: '1' })).toBe(true);
+  });
+
+  test('env values other than "1" do not enable', () => {
+    expect(isAutoElectEnabled({}, { OPENCHROME_AUTO_ELECT: 'true' })).toBe(false);
+    expect(isAutoElectEnabled({}, { OPENCHROME_AUTO_ELECT: '0' })).toBe(false);
+  });
+});
+
+describe('shouldElectBrokerOwner', () => {
+  const base = { autoElect: true, autoLaunch: true, manualBroker: false, connectBroker: false };
+
+  test('elects when auto-elect + auto-launch and no explicit role', () => {
+    expect(shouldElectBrokerOwner(base)).toBe(true);
+  });
+
+  test('does not elect when auto-elect is off', () => {
+    expect(shouldElectBrokerOwner({ ...base, autoElect: false })).toBe(false);
+  });
+
+  test('does not elect without --auto-launch (no Chrome ownership)', () => {
+    expect(shouldElectBrokerOwner({ ...base, autoLaunch: false })).toBe(false);
+  });
+
+  test('explicit --broker takes precedence over auto-elect', () => {
+    expect(shouldElectBrokerOwner({ ...base, manualBroker: true })).toBe(false);
+  });
+
+  test('explicit --connect-broker takes precedence over auto-elect', () => {
+    expect(shouldElectBrokerOwner({ ...base, connectBroker: true })).toBe(false);
+  });
+});
+
+describe('shouldClientAutoConnect', () => {
+  test('connects only when auto-elect is on and a broker is discoverable', () => {
+    expect(shouldClientAutoConnect({ autoElect: true, brokerPresent: true })).toBe(true);
+  });
+
+  test('does not connect when no broker is published (plain direct owner)', () => {
+    expect(shouldClientAutoConnect({ autoElect: true, brokerPresent: false })).toBe(false);
+  });
+
+  test('does not connect when auto-elect is off', () => {
+    expect(shouldClientAutoConnect({ autoElect: false, brokerPresent: true })).toBe(false);
+  });
+});
+
+describe('defaultBrokerHttpPort', () => {
+  test('is cdpPort + offset', () => {
+    expect(defaultBrokerHttpPort(9222)).toBe(9222 + BROKER_HTTP_PORT_OFFSET);
+    expect(defaultBrokerHttpPort(9222)).toBe(9422);
+  });
+
+  test('clears the headed-fallback offset (+100)', () => {
+    // The fallback uses +100 (9322); the broker must not collide with it.
+    expect(defaultBrokerHttpPort(9222)).not.toBe(9222 + 100);
+  });
+});

--- a/tests/chrome/process-watchdog-660.test.ts
+++ b/tests/chrome/process-watchdog-660.test.ts
@@ -88,9 +88,14 @@ describe('ChromeProcessWatchdog #660 quiesce', () => {
     });
 
     watchdog = new ChromeProcessWatchdog(launcher, { intervalMs: 100 });
+    const relaunchFailed = jest.fn();
+    watchdog.on('relaunch-failed', relaunchFailed);
     watchdog.start();
     await tickOnce(100);
 
     expect(ensureChrome).not.toHaveBeenCalled();
+    // #1474: the rate-limit branch must emit relaunch-failed so owner
+    // self-release can observe this otherwise-silent irrecoverable state.
+    expect(relaunchFailed).toHaveBeenCalled();
   });
 });

--- a/tests/duplicate-controller-error-server.test.ts
+++ b/tests/duplicate-controller-error-server.test.ts
@@ -80,4 +80,16 @@ describe('DuplicateControllerErrorServer (#1474)', () => {
   test('blank lines are ignored', () => {
     expect(makeServer().handleLine('   ')).toEqual([]);
   });
+
+  test('exits with failure (2) when stdin closes without an MCP handshake', () => {
+    // e.g. `serve --auto-launch </dev/null` from CI/systemd: non-TTY, immediate
+    // EOF, no initialize. Must report refusal-to-start, not silent success.
+    expect(makeServer().closeExitCode()).toBe(2);
+  });
+
+  test('exits cleanly (0) after a real MCP client handshook and disconnected', () => {
+    const server = makeServer();
+    server.handleLine(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }));
+    expect(server.closeExitCode()).toBe(0);
+  });
 });

--- a/tests/duplicate-controller-error-server.test.ts
+++ b/tests/duplicate-controller-error-server.test.ts
@@ -1,3 +1,4 @@
+import { PassThrough } from 'stream';
 import {
   DUPLICATE_CONTROLLER_ERROR_CODE,
   DuplicateControllerErrorServer,
@@ -13,6 +14,7 @@ function makeServer(): DuplicateControllerErrorServer {
     port: 9222,
     userDataDir: '/home/u/.openchrome/profile',
     startedAt: '2026-06-05T00:00:00.000Z',
+    lastHeartbeatAt: '2026-06-05T00:00:00.000Z',
     hostname: 'host',
   };
   return new DuplicateControllerErrorServer(
@@ -75,6 +77,46 @@ describe('DuplicateControllerErrorServer (#1474)', () => {
   test('an empty batch is rejected as an invalid request', () => {
     const frames = parseFrames(makeServer(), '[]');
     expect(frames[0].error.code).toBe(-32600);
+  });
+
+  test('non-object JSON does not crash — returns Invalid Request', () => {
+    // valid JSON that is not a JSON-RPC object would make `'id' in message`
+    // throw a TypeError (process crash) without the guard.
+    for (const line of ['null', '5', '"hello"', 'true']) {
+      const frames = parseFrames(makeServer(), line);
+      expect(frames[0].error.code).toBe(-32600);
+      expect(frames[0].id).toBeNull();
+    }
+  });
+
+  test('a batch member that is a non-object yields an Invalid Request response', () => {
+    const out = makeServer().handleLine(JSON.stringify([1, { jsonrpc: '2.0', id: 2, method: 'ping' }]));
+    const batch = JSON.parse(out[0]);
+    expect(Array.isArray(batch)).toBe(true);
+    expect(batch.some((r: any) => r.error?.code === -32600)).toBe(true); // the bare `1`
+    expect(batch.some((r: any) => r.id === 2 && r.result)).toBe(true); // the ping
+  });
+
+  test('init-timeout exits(2) when an open non-MCP stdin never sends initialize', () => {
+    jest.useFakeTimers();
+    const input = new PassThrough(); // open, never emits a line, never closes
+    try {
+      const exit = jest.fn();
+      const owner: ControllerLockMetadata = {
+        pid: 1, command: [], version: 'x', cwd: '', port: 9222,
+        userDataDir: '/p', startedAt: 't', lastHeartbeatAt: 't', hostname: 'h',
+      };
+      const server = new DuplicateControllerErrorServer(
+        new DuplicateControllerError('/l', owner),
+        { exit, initTimeoutMs: 5_000 },
+      );
+      server.start(input);
+      jest.advanceTimersByTime(5_000);
+      expect(exit).toHaveBeenCalledWith(2);
+    } finally {
+      input.end();
+      jest.useRealTimers();
+    }
   });
 
   test('lists a single diagnostic tool that names the conflict', () => {

--- a/tests/duplicate-controller-error-server.test.ts
+++ b/tests/duplicate-controller-error-server.test.ts
@@ -38,8 +38,43 @@ describe('DuplicateControllerErrorServer (#1474)', () => {
     const note = frames.find((f) => f.method === 'notifications/message');
     expect(note).toBeDefined();
     expect(note.params.level).toBe('error');
-    expect(String(note.params.data)).toContain('another session');
+    // data is a structured object (spec), not a bare string.
+    expect(note.params.data.message).toContain('another session');
+    expect(note.params.data.remediation.reason).toBe('duplicate_controller');
     expect(note.id).toBeUndefined(); // notification has no id
+  });
+
+  test('responds to ping with an empty result (keepalive must not error)', () => {
+    const frames = parseFrames(makeServer(), JSON.stringify({ jsonrpc: '2.0', id: 7, method: 'ping' }));
+    expect(frames[0].id).toBe(7);
+    expect(frames[0].result).toEqual({});
+    expect(frames[0].error).toBeUndefined();
+  });
+
+  test('handles a JSON-RPC batch: array of responses + the server notification', () => {
+    const out = makeServer().handleLine(JSON.stringify([
+      { jsonrpc: '2.0', id: 1, method: 'initialize' },
+      { jsonrpc: '2.0', id: 2, method: 'ping' },
+      { jsonrpc: '2.0', method: 'notifications/initialized' }, // notification → no response member
+    ]));
+    const parsed = out.map((f) => JSON.parse(f));
+    const batch = parsed.find((f) => Array.isArray(f)) as any[] | undefined;
+    expect(batch).toBeDefined();
+    expect((batch as any[]).map((r: any) => r.id).sort()).toEqual([1, 2]); // only the two requests
+    // the server-originated logging notification is emitted as its own frame
+    expect(parsed.some((f) => !Array.isArray(f) && f.method === 'notifications/message')).toBe(true);
+  });
+
+  test('an explicit id:null request still gets a reply (not treated as a notification)', () => {
+    const frames = parseFrames(makeServer(), JSON.stringify({ jsonrpc: '2.0', id: null, method: 'resources/list' }));
+    expect(frames).toHaveLength(1);
+    expect(frames[0].id).toBeNull();
+    expect(frames[0].error.code).toBe(DUPLICATE_CONTROLLER_ERROR_CODE);
+  });
+
+  test('an empty batch is rejected as an invalid request', () => {
+    const frames = parseFrames(makeServer(), '[]');
+    expect(frames[0].error.code).toBe(-32600);
   });
 
   test('lists a single diagnostic tool that names the conflict', () => {

--- a/tests/duplicate-controller-error-server.test.ts
+++ b/tests/duplicate-controller-error-server.test.ts
@@ -1,0 +1,83 @@
+import {
+  DUPLICATE_CONTROLLER_ERROR_CODE,
+  DuplicateControllerErrorServer,
+} from '../src/transports/duplicate-controller-error-server';
+import { DuplicateControllerError, type ControllerLockMetadata } from '../src/utils/controller-lock';
+
+function makeServer(): DuplicateControllerErrorServer {
+  const owner: ControllerLockMetadata = {
+    pid: 95061,
+    command: ['node', 'dist/index.js', 'serve', '--auto-launch'],
+    version: '1.12.7',
+    cwd: '/home/u/repo',
+    port: 9222,
+    userDataDir: '/home/u/.openchrome/profile',
+    startedAt: '2026-06-05T00:00:00.000Z',
+    hostname: 'host',
+  };
+  return new DuplicateControllerErrorServer(
+    new DuplicateControllerError('/home/u/.openchrome/locks/port-9222.json', owner),
+  );
+}
+
+function parseFrames(server: DuplicateControllerErrorServer, line: string): any[] {
+  return server.handleLine(line).map((f) => JSON.parse(f));
+}
+
+describe('DuplicateControllerErrorServer (#1474)', () => {
+  test('completes the initialize handshake instead of failing it', () => {
+    const frames = parseFrames(makeServer(), JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }));
+    const init = frames.find((f) => f.id === 1);
+    expect(init.result.serverInfo.name).toBe('openchrome');
+    expect(init.result.protocolVersion).toBe('2024-11-05');
+    expect(init.error).toBeUndefined();
+  });
+
+  test('pushes a logging notification carrying the remediation after initialize', () => {
+    const frames = parseFrames(makeServer(), JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }));
+    const note = frames.find((f) => f.method === 'notifications/message');
+    expect(note).toBeDefined();
+    expect(note.params.level).toBe('error');
+    expect(String(note.params.data)).toContain('another session');
+    expect(note.id).toBeUndefined(); // notification has no id
+  });
+
+  test('lists a single diagnostic tool that names the conflict', () => {
+    const frames = parseFrames(makeServer(), JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }));
+    expect(frames[0].result.tools).toHaveLength(1);
+    expect(frames[0].result.tools[0].name).toBe('openchrome_owner_conflict');
+    expect(frames[0].result.tools[0].description).toContain('port 9222');
+  });
+
+  test('tools/call returns the remediation as a tool error with structured content', () => {
+    const frames = parseFrames(makeServer(), JSON.stringify({
+      jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'openchrome_owner_conflict' },
+    }));
+    expect(frames[0].result.isError).toBe(true);
+    expect(frames[0].result.content[0].text).toContain('another session');
+    expect(frames[0].result.structuredContent.reason).toBe('duplicate_controller');
+    expect(frames[0].result.structuredContent.remediations.join(' ')).toContain('--connect-broker');
+  });
+
+  test('other requests get a structured JSON-RPC error (not a bare code)', () => {
+    const frames = parseFrames(makeServer(), JSON.stringify({ jsonrpc: '2.0', id: 4, method: 'resources/list' }));
+    expect(frames[0].error.code).toBe(DUPLICATE_CONTROLLER_ERROR_CODE);
+    expect(frames[0].error.message).toContain('OpenChrome is unavailable');
+    expect(frames[0].error.data.ownerPid).toBe(95061);
+    expect(frames[0].error.data.lockPath).toContain('port-9222');
+  });
+
+  test('notifications (no id) get no reply', () => {
+    expect(makeServer().handleLine(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }))).toEqual([]);
+  });
+
+  test('malformed JSON yields a parse error with null id', () => {
+    const frames = parseFrames(makeServer(), '{not json');
+    expect(frames[0].id).toBeNull();
+    expect(frames[0].error.code).toBe(-32700);
+  });
+
+  test('blank lines are ignored', () => {
+    expect(makeServer().handleLine('   ')).toEqual([]);
+  });
+});

--- a/tests/owner-self-release.test.ts
+++ b/tests/owner-self-release.test.ts
@@ -1,54 +1,129 @@
 import { EventEmitter } from 'events';
 import {
+  DEFAULT_RELEASE_FAILURE_THRESHOLD,
   OWNER_SELF_RELEASE_EXIT_CODE,
   wireOwnerSelfRelease,
 } from '../src/chrome/owner-self-release';
 
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
 describe('owner self-release (#1474)', () => {
-  function setup(over: { releaseLock?: () => void } = {}) {
+  function setup(over: {
+    releaseLock?: () => void;
+    probeChromeReachable?: () => Promise<boolean>;
+    failureThreshold?: number;
+  } = {}) {
     const watchdog = new EventEmitter();
     const releaseLock = over.releaseLock ?? jest.fn();
     const exit = jest.fn();
     const log = jest.fn();
-    wireOwnerSelfRelease(watchdog, { releaseLock, exit, log });
-    return { watchdog, releaseLock, exit, log };
+    const probeChromeReachable = over.probeChromeReachable ?? jest.fn(async () => false);
+    wireOwnerSelfRelease(watchdog, {
+      releaseLock,
+      exit,
+      log,
+      probeChromeReachable,
+      failureThreshold: over.failureThreshold,
+    });
+    return { watchdog, releaseLock, exit, log, probeChromeReachable };
   }
 
-  test('releases the lock and exits non-zero when the watchdog is exhausted', () => {
-    const { watchdog, releaseLock, exit } = setup();
+  test('releases + exits after threshold consecutive failures with CDP unreachable', async () => {
+    const { watchdog, releaseLock, exit, probeChromeReachable } = setup();
 
-    watchdog.emit('watchdog-exhausted', { count: 10, timestamp: 0 });
+    for (let i = 0; i < DEFAULT_RELEASE_FAILURE_THRESHOLD; i++) {
+      watchdog.emit('relaunch-failed', { error: new Error('boom'), timestamp: 0 });
+    }
+    await flush();
 
+    expect(probeChromeReachable).toHaveBeenCalled();
     expect(releaseLock).toHaveBeenCalledTimes(1);
     expect(exit).toHaveBeenCalledWith(OWNER_SELF_RELEASE_EXIT_CODE);
     expect(OWNER_SELF_RELEASE_EXIT_CODE).not.toBe(0);
   });
 
-  test('does NOT surrender ownership on a recoverable chrome-died', () => {
+  test('does NOT tear down a Chrome that is actually reachable (Codex P2)', async () => {
+    const { watchdog, releaseLock, exit } = setup({ probeChromeReachable: jest.fn(async () => true) });
+
+    for (let i = 0; i < DEFAULT_RELEASE_FAILURE_THRESHOLD; i++) {
+      watchdog.emit('relaunch-failed', { error: new Error('boom'), timestamp: 0 });
+    }
+    await flush();
+
+    expect(releaseLock).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  test('watchdog-exhausted (emitted after a SUCCESSFUL relaunch) never self-releases', async () => {
+    const { watchdog, releaseLock, exit, probeChromeReachable } = setup();
+
+    watchdog.emit('watchdog-exhausted', { count: 10, timestamp: 0 });
+    await flush();
+
+    expect(probeChromeReachable).not.toHaveBeenCalled();
+    expect(releaseLock).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  test('a single transient relaunch-failed does not act (below threshold)', async () => {
+    const { watchdog, releaseLock, exit, probeChromeReachable } = setup({ failureThreshold: 2 });
+
+    watchdog.emit('relaunch-failed', { error: new Error('boom'), timestamp: 0 });
+    await flush();
+
+    expect(probeChromeReachable).not.toHaveBeenCalled();
+    expect(releaseLock).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  test('a successful relaunch between failures resets the counter', async () => {
+    const { watchdog, releaseLock, exit } = setup({ failureThreshold: 2 });
+
+    watchdog.emit('relaunch-failed', { error: new Error('boom'), timestamp: 0 });
+    watchdog.emit('chrome-relaunched', { pid: 1, timestamp: 0 }); // recovery → reset
+    watchdog.emit('relaunch-failed', { error: new Error('boom'), timestamp: 0 });
+    await flush();
+
+    expect(releaseLock).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  test('does NOT surrender ownership on a recoverable chrome-died', async () => {
     const { watchdog, releaseLock, exit } = setup();
 
     watchdog.emit('chrome-died', { pid: 123, timestamp: 0 });
+    await flush();
 
     expect(releaseLock).not.toHaveBeenCalled();
     expect(exit).not.toHaveBeenCalled();
   });
 
-  test('does NOT surrender ownership on a single transient relaunch-failed', () => {
-    const { watchdog, releaseLock, exit } = setup();
+  test('stays up when the reachability probe itself errors (inconclusive)', async () => {
+    const probeChromeReachable = jest.fn(async () => {
+      throw new Error('probe exploded');
+    });
+    const { watchdog, releaseLock, exit, log } = setup({ probeChromeReachable });
 
-    watchdog.emit('relaunch-failed', { error: new Error('boom'), timestamp: 0 });
+    for (let i = 0; i < DEFAULT_RELEASE_FAILURE_THRESHOLD; i++) {
+      watchdog.emit('relaunch-failed', { error: new Error('boom'), timestamp: 0 });
+    }
+    await flush();
 
     expect(releaseLock).not.toHaveBeenCalled();
     expect(exit).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('probe errored'));
   });
 
-  test('still exits even if lock release throws (best-effort)', () => {
+  test('still exits even if lock release throws (best-effort)', async () => {
     const releaseLock = jest.fn(() => {
       throw new Error('unlink failed');
     });
     const { watchdog, exit, log } = setup({ releaseLock });
 
-    watchdog.emit('watchdog-exhausted', { count: 10, timestamp: 0 });
+    for (let i = 0; i < DEFAULT_RELEASE_FAILURE_THRESHOLD; i++) {
+      watchdog.emit('relaunch-failed', { error: new Error('boom'), timestamp: 0 });
+    }
+    await flush();
 
     expect(exit).toHaveBeenCalledWith(OWNER_SELF_RELEASE_EXIT_CODE);
     expect(log).toHaveBeenCalledWith(expect.stringContaining('release failed'));

--- a/tests/owner-self-release.test.ts
+++ b/tests/owner-self-release.test.ts
@@ -1,0 +1,56 @@
+import { EventEmitter } from 'events';
+import {
+  OWNER_SELF_RELEASE_EXIT_CODE,
+  wireOwnerSelfRelease,
+} from '../src/chrome/owner-self-release';
+
+describe('owner self-release (#1474)', () => {
+  function setup(over: { releaseLock?: () => void } = {}) {
+    const watchdog = new EventEmitter();
+    const releaseLock = over.releaseLock ?? jest.fn();
+    const exit = jest.fn();
+    const log = jest.fn();
+    wireOwnerSelfRelease(watchdog, { releaseLock, exit, log });
+    return { watchdog, releaseLock, exit, log };
+  }
+
+  test('releases the lock and exits non-zero when the watchdog is exhausted', () => {
+    const { watchdog, releaseLock, exit } = setup();
+
+    watchdog.emit('watchdog-exhausted', { count: 10, timestamp: 0 });
+
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(OWNER_SELF_RELEASE_EXIT_CODE);
+    expect(OWNER_SELF_RELEASE_EXIT_CODE).not.toBe(0);
+  });
+
+  test('does NOT surrender ownership on a recoverable chrome-died', () => {
+    const { watchdog, releaseLock, exit } = setup();
+
+    watchdog.emit('chrome-died', { pid: 123, timestamp: 0 });
+
+    expect(releaseLock).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  test('does NOT surrender ownership on a single transient relaunch-failed', () => {
+    const { watchdog, releaseLock, exit } = setup();
+
+    watchdog.emit('relaunch-failed', { error: new Error('boom'), timestamp: 0 });
+
+    expect(releaseLock).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  test('still exits even if lock release throws (best-effort)', () => {
+    const releaseLock = jest.fn(() => {
+      throw new Error('unlink failed');
+    });
+    const { watchdog, exit, log } = setup({ releaseLock });
+
+    watchdog.emit('watchdog-exhausted', { count: 10, timestamp: 0 });
+
+    expect(exit).toHaveBeenCalledWith(OWNER_SELF_RELEASE_EXIT_CODE);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('release failed'));
+  });
+});

--- a/tests/owner-self-release.test.ts
+++ b/tests/owner-self-release.test.ts
@@ -88,6 +88,47 @@ describe('owner self-release (#1474)', () => {
     expect(exit).not.toHaveBeenCalled();
   });
 
+  test('aborts self-release if Chrome recovers while the probe is in flight', async () => {
+    let resolveProbe!: (v: boolean) => void;
+    const probeChromeReachable = jest.fn(
+      () => new Promise<boolean>((resolve) => { resolveProbe = resolve; }),
+    );
+    const { watchdog, releaseLock, exit } = setup({ probeChromeReachable });
+
+    for (let i = 0; i < DEFAULT_RELEASE_FAILURE_THRESHOLD; i++) {
+      watchdog.emit('relaunch-failed', { error: new Error('boom'), timestamp: 0 });
+    }
+    // Probe is in flight. Chrome recovers, then the probe resolves a STALE false
+    // (the new Chrome has not bound its debug port yet). Must NOT tear it down.
+    watchdog.emit('chrome-relaunched', { pid: 1, timestamp: 0 });
+    resolveProbe(false);
+    await flush();
+
+    expect(releaseLock).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  test('after an inconclusive probe, one more failure re-probes and can release', async () => {
+    let calls = 0;
+    const probeChromeReachable = jest.fn(async () => {
+      calls += 1;
+      if (calls === 1) throw new Error('probe exploded'); // inconclusive
+      return false; // second probe: confirmed unreachable
+    });
+    const { watchdog, releaseLock, exit } = setup({ probeChromeReachable, failureThreshold: 2 });
+
+    watchdog.emit('relaunch-failed', { error: new Error('boom'), timestamp: 0 });
+    watchdog.emit('relaunch-failed', { error: new Error('boom'), timestamp: 0 }); // reaches threshold → inconclusive
+    await flush();
+    expect(releaseLock).not.toHaveBeenCalled();
+
+    watchdog.emit('relaunch-failed', { error: new Error('boom'), timestamp: 0 }); // steps back to threshold → re-probes
+    await flush();
+    expect(probeChromeReachable).toHaveBeenCalledTimes(2);
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(OWNER_SELF_RELEASE_EXIT_CODE);
+  });
+
   test('does NOT surrender ownership on a recoverable chrome-died', async () => {
     const { watchdog, releaseLock, exit } = setup();
 


### PR DESCRIPTION
## S3 of the #1480 PR program — client auto-elect (restores parallel sessions)

**Stacked on S2 #1484** (base `feat/1480-s2-owner-auto-elect`). Together S2+S3
restore stable parallel sessions: surplus sessions become coordinated clients of
one auto-elected owner — the #1359/#1367 "one coordinated owner/broker" end-state.

### Change
In the controller-lock collision handler (`src/index.ts`): when a
`--auto-elect --auto-launch` process **loses** the lock to a **healthy** owner, it
no longer fails fast. It polls briefly for the owner's broker discovery metadata
(the owner may have only just won the lock — that race *is* the collision) and,
when found, attaches as a `--connect-broker` client via `BrokerProxyStdioBridge`.

Fallbacks preserved:
- owner published **no** broker (old/plain direct controller) → fall back to the
  #1479 MCP-visible duplicate-controller remediation, not a bare `exit(2)`;
- `--auto-elect` unset → byte-for-byte the prior behavior.

Decision via `shouldClientAutoConnect` (unit-tested).

### End-to-end validation (real two-process smoke)
```
# owner
$ node dist/index.js serve --auto-launch --auto-elect --port 9531 --user-data-dir /tmp/p
[openchrome] Dual transport mode: stdio + HTTP on 127.0.0.1:9731
[openchrome] Broker metadata: http://127.0.0.1:9731/mcp (auto-elected)   # 9731 LISTEN ✓

# second session, same port+profile, while owner is alive
$ node dist/index.js serve --auto-launch --auto-elect --port 9531 --user-data-dir /tmp/p
[openchrome] Refusing to start a second direct controller for Chrome port 9531 ...
[openchrome] auto-elect: attaching as broker client -> http://127.0.0.1:9731/mcp   # ✅ attached
```
The second session — which on `develop` dies with `-32000` — now attaches as a
coordinated client. (This smoke also caught the S2 loopback-auth bug, now fixed in
#1484.)

### Verification
- `npm run build:src` ✓ · eslint ✓
- `auto-elect` / `duplicate-controller-error-server` / `controller-lock` /
  `broker-proxy` suites — **58** pass.
- two-process smoke above ✓ (cleaned up).

### Remaining
S4 (#1480) hardens re-election when the broker owner dies (removes the SPOF).
Default-flip of `--auto-elect` stays a separate, deliberate decision (D3 Q1′).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Goal

Implement the loser/client side of opt-in auto-elect so parallel sessions attach to the elected owner instead of failing fast.

## Final Implementation Scope

- In controller-lock collision handling, auto-elect losers poll for healthy owner broker metadata.
- Attach losers via `BrokerProxyStdioBridge` when metadata exists.
- Preserve #1479 duplicate-controller remediation when no broker metadata is published.

## Success Criteria

- Requires `--auto-elect --auto-launch`; default direct collisions remain prior behavior.
- Healthy elected-owner collision becomes broker client attach.
- Plain direct-owner collisions still produce actionable duplicate-controller remediation.

## Verification Method

- `auto-elect`, `duplicate-controller-error-server`, `controller-lock`, and `broker-proxy` suites passed.
- `npm run build:src` and lint passed.
- Real two-process smoke showed second session attaching to owner broker.
- Stack PR is CLEAN and base ancestry holds.

## Guardrails

- Do not attach to stale/unhealthy owner metadata.
- Do not bypass #1479 remediation fallback.
- Do not implement owner-death re-election here; that is #1486.

## Explicit Non-Goals

- No owner-side publish changes beyond inherited #1484.
- No default auto-elect flip.
- No long-lived retry daemon outside startup collision path.

## Implementation Approach

Extend the collision path with a short discovery wait for the just-elected owner, then bridge stdio to the owner broker when found.

## PR Decomposition

S3 of #1480 auto-elect stack, stacked on S2 #1484. S4 #1486 handles owner loss after attachment.

## Over-Engineering Checklist

- No new broker protocol.
- No broad lock manager rewrite.
- No permanent polling loop for startup attach.

## Drift-Prevention Checklist

- Scope is loser attach at startup collision only.
- Owner publication and re-election are separate PRs.
- Default direct mode must remain unchanged.

## Language Boundary

User-visible logs remain English and must clearly say opt-in auto-elect attachment.

## Critical Risk Review

Critical risks are attaching to wrong/stale owner or regressing duplicate-controller diagnostics; discovery health and fallback tests/smoke cover this.

## Definition of Done

- Auto-elect loser attaches in smoke.
- Fallback remediation preserved.
- Targeted suites/build/lint pass and PR is CLEAN.
