### PR TITLE
fix(mcp): normalize image MIME from screenshot bytes

### DIFF
--- a/src/tools/batch-paginate.ts
+++ b/src/tools/batch-paginate.ts
@@ -15,6 +15,7 @@ import { getScreenshotScheduler } from '../cdp/screenshot-scheduler';
 import { DEFAULT_SCREENSHOT_QUALITY, DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS, DEFAULT_SCREENSHOT_TIMEOUT_MS, MAX_OUTPUT_CHARS } from '../config/defaults';
 import { withDomDelta } from '../utils/dom-delta';
 import { withTimeout } from '../utils/with-timeout';
+import { normalizeImageMimeType, makeImageContent, type SupportedImageMimeType } from '../utils/image-mime';
 
 const definition: MCPToolDefinition = {
   name: 'batch_paginate',
@@ -78,7 +79,7 @@ interface PageResult {
   pageNumber: number;
   text?: string;
   screenshot?: string; // base64
-  screenshotMimeType?: 'image/webp' | 'image/png';
+  screenshotMimeType?: SupportedImageMimeType;
   dom?: string;
   error?: string;
 }
@@ -205,7 +206,7 @@ const handler: ToolHandler = async (
           ]);
           if (screenshotData !== null) {
             result.screenshot = screenshotData;
-            result.screenshotMimeType = 'image/webp';
+            result.screenshotMimeType = normalizeImageMimeType(screenshotData, 'image/webp');
           } else {
             throw new Error('Screenshot timed out');
           }
@@ -225,7 +226,7 @@ const handler: ToolHandler = async (
               }),
             ]);
             result.screenshot = screenshotData as string;
-            result.screenshotMimeType = 'image/png';
+            result.screenshotMimeType = normalizeImageMimeType(result.screenshot, 'image/png');
           }
         }
       }
@@ -497,11 +498,7 @@ const handler: ToolHandler = async (
     if ((captureMode === 'screenshot' || captureMode === 'both') && !tooManyScreenshots) {
       for (const p of pages) {
         if (p.screenshot) {
-          content.push({
-            type: 'image',
-            data: p.screenshot,
-            mimeType: p.screenshotMimeType ?? 'image/webp',
-          });
+          content.push(makeImageContent(p.screenshot, p.screenshotMimeType ?? 'image/webp'));
         }
       }
     }

--- a/src/tools/computer.ts
+++ b/src/tools/computer.ts
@@ -13,6 +13,7 @@ import { DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS } from '../config/defaults';
 import { withDomDelta } from '../utils/dom-delta';
 import { generateVisualSummary } from '../utils/visual-summary';
 import { AdaptiveScreenshot } from '../utils/adaptive-screenshot';
+import { makeImageContent } from '../utils/image-mime';
 import { withTimeout } from '../utils/with-timeout';
 import { retryWithFallback } from '../utils/retry-with-fallback';
 import { detectPagination, type PaginationInfo } from '../utils/pagination-detector';
@@ -303,7 +304,7 @@ const innerHandler: ToolHandler = async (
           }
 
           const content: MCPContent[] = [
-            { type: 'image', data: screenshot.data, mimeType: screenshot.mimeType },
+            makeImageContent(screenshot.data, screenshot.mimeType as 'image/webp' | 'image/png' | 'image/jpeg'),
           ];
 
           const paginationGuidance = await getPaginationGuidance(page, tabId);

--- a/src/tools/find.ts
+++ b/src/tools/find.ts
@@ -16,6 +16,7 @@ import { analyzeScreenshot, formatElementMapAsText } from '../vision/screenshot-
 import { getVisionMode, trackVisionUsage } from '../vision/config';
 import { detectVisionHints, formatVisionHints } from '../vision/auto-detect';
 import { formatAffordancePrefix } from '../utils/element-affordance';
+import { makeImageContent, type SupportedImageMimeType } from '../utils/image-mime';
 
 const definition: MCPToolDefinition = {
   name: 'find',
@@ -255,11 +256,7 @@ const handler: ToolHandler = async (
                   type: 'text',
                   text: `DOM found nothing for "${query}" — vision fallback found ${visionResult.elementCount} elements:\n\n${textMap}`,
                 },
-                {
-                  type: 'image',
-                  data: visionResult.screenshot,
-                  mimeType: visionResult.mimeType,
-                },
+                makeImageContent(visionResult.screenshot, visionResult.mimeType as SupportedImageMimeType),
               ],
             };
           }

--- a/src/tools/image-qa.ts
+++ b/src/tools/image-qa.ts
@@ -21,6 +21,7 @@ import * as fs from 'node:fs';
 import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolContext, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
+import { coerceSupportedImageMimeType, makeImageContent } from '../utils/image-mime';
 
 interface ImageQaScreenshot {
   /** Opaque in-memory reference produced by a sibling tool. */
@@ -189,7 +190,7 @@ const handler: ToolHandler = async (
           {
             role: 'user',
             content: [
-              { type: 'image', data: decoded.base64, mimeType: decoded.mime },
+              makeImageContent(decoded.base64, coerceSupportedImageMimeType(decoded.mime)),
               { type: 'text', text: question },
             ],
           },
@@ -268,7 +269,7 @@ export async function runImageQaSampling(
           {
             role: 'user',
             content: [
-              { type: 'image', data: params.base64, mimeType: params.mime ?? 'image/png' },
+              makeImageContent(params.base64, coerceSupportedImageMimeType(params.mime)),
               { type: 'text', text: params.question },
             ],
           },

--- a/src/tools/interact.ts
+++ b/src/tools/interact.ts
@@ -14,6 +14,7 @@ import { DEFAULT_DOM_SETTLE_DELAY_MS, DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS, DEFAUL
 import { FoundElement, normalizeQuery, scoreElement, tokenizeQuery } from '../utils/element-finder';
 import { discoverElements, getTaggedElementRect, cleanupTags, DISCOVERY_TAG } from '../utils/element-discovery';
 import { withTimeout } from '../utils/with-timeout';
+import { makeImageContent } from '../utils/image-mime';
 import { resolveElementsByAXTree, invalidateAXCache, MATCH_LEVEL_LABELS } from '../utils/ax-element-resolver';
 import { getTargetId } from '../utils/puppeteer-helpers';
 import { classifyOutcome, formatOutcomeLine } from '../utils/ralph/outcome-classifier';
@@ -522,7 +523,7 @@ const coreHandler: ToolHandler = async (
             'verify-screenshot',
             context
           ) as string;
-          resultContent.push({ type: 'image' as const, data: screenshotBuf, mimeType: 'image/webp' });
+          resultContent.push(makeImageContent(screenshotBuf, 'image/webp'));
         } catch { /* screenshot failed, non-fatal */ }
       }
 
@@ -702,7 +703,7 @@ const coreHandler: ToolHandler = async (
               'verify-screenshot',
               context
             ) as string;
-            resultContent.push({ type: 'image' as const, data: screenshotBuf, mimeType: 'image/webp' });
+            resultContent.push(makeImageContent(screenshotBuf, 'image/webp'));
           } catch { /* screenshot failed, non-fatal */ }
         }
 
@@ -1021,7 +1022,7 @@ const coreHandler: ToolHandler = async (
                 quality: 60,
                 optimizeForSpeed: true,
               });
-              return { data: data as string, mimeType: 'image/webp' };
+              return makeImageContent(data as string, 'image/webp');
             } finally {
               await cdpSession.detach().catch(() => {});
             }
@@ -1030,7 +1031,7 @@ const coreHandler: ToolHandler = async (
         ]);
 
         if (screenshotResult) {
-          screenshotContent = { type: 'image' as const, ...screenshotResult };
+          screenshotContent = screenshotResult;
         } else {
           throw new Error('CDP screenshot timed out');
         }
@@ -1044,7 +1045,7 @@ const coreHandler: ToolHandler = async (
               fallbackTimer = setTimeout(() => reject(new Error('Fallback screenshot timed out')), DEFAULT_SCREENSHOT_TIMEOUT_MS);
             }),
           ]);
-          screenshotContent = { type: 'image' as const, data: screenshot as unknown as string, mimeType: 'image/png' };
+          screenshotContent = makeImageContent(screenshot as unknown as string, 'image/png');
         } catch {
           // Screenshot failure is non-fatal
         }

--- a/src/tools/page-screenshot.ts
+++ b/src/tools/page-screenshot.ts
@@ -15,6 +15,7 @@ import {
   validateCaptureArea,
 } from '../utils/screenshot-guards';
 import { withTimeout } from '../utils/with-timeout';
+import { makeImageContent, type SupportedImageMimeType } from '../utils/image-mime';
 
 const FULL_PAGE_DIMENSION_TIMEOUT_MS = 5000;
 
@@ -216,15 +217,9 @@ const handler: ToolHandler = async (
         return makeError(`Error: ${encoded.error}`);
       }
 
-      const mimeType = format === 'jpeg' ? 'image/jpeg' : format === 'webp' ? 'image/webp' : 'image/png';
+      const mimeType: SupportedImageMimeType = format === 'jpeg' ? 'image/jpeg' : format === 'webp' ? 'image/webp' : 'image/png';
       return {
-        content: [
-          {
-            type: 'image',
-            data: encoded.data,
-            mimeType,
-          },
-        ],
+        content: [makeImageContent(encoded.data, mimeType)],
       };
     }
   } catch (error) {

--- a/src/tools/vision-find.ts
+++ b/src/tools/vision-find.ts
@@ -17,6 +17,7 @@ import { formatPerceptionSnapshotAsText } from '../vision/perception-provider';
 import { DomAnnotatorPerceptionProvider } from '../vision/providers/dom-annotator-provider';
 import { trackVisionUsage } from '../vision/config';
 import { recordVisualTrajectory } from '../observability/visual-trajectory';
+import { makeImageContent, type SupportedImageMimeType } from '../utils/image-mime';
 
 const definition: MCPToolDefinition = {
   name: 'vision_find',
@@ -178,8 +179,8 @@ Tiled mode: ${tiles.length} tile screenshot(s) attached below in document-Y orde
         : '';
     const imageBlocks =
       tiles.length > 0
-        ? tiles.map((t) => ({ type: 'image' as const, data: t.imageBase64, mimeType: t.mimeType }))
-        : [{ type: 'image' as const, data: result.screenshot, mimeType: result.mimeType }];
+        ? tiles.map((t) => makeImageContent(t.imageBase64, t.mimeType as SupportedImageMimeType))
+        : [makeImageContent(result.screenshot, result.mimeType as SupportedImageMimeType)];
 
     const content: MCPResult['content'] = [];
     if (format === 'legacy' || format === 'both') {

--- a/src/utils/image-mime.ts
+++ b/src/utils/image-mime.ts
@@ -1,0 +1,64 @@
+/**
+ * Small image MIME helpers for MCP image content.
+ *
+ * The MCP image block's `mimeType` must describe the actual base64 bytes, not
+ * merely the requested screenshot encoder. Keep this dependency-free and based
+ * on strict file signatures so screenshot tools remain host-neutral.
+ */
+
+export type SupportedImageMimeType = 'image/png' | 'image/jpeg' | 'image/webp';
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+export function detectImageMimeType(buffer: Buffer): SupportedImageMimeType | undefined {
+  if (buffer.length >= PNG_MAGIC.length && PNG_MAGIC.every((byte, index) => buffer[index] === byte)) {
+    return 'image/png';
+  }
+
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return 'image/jpeg';
+  }
+
+  if (
+    buffer.length >= 12 &&
+    buffer.toString('ascii', 0, 4) === 'RIFF' &&
+    buffer.toString('ascii', 8, 12) === 'WEBP'
+  ) {
+    return 'image/webp';
+  }
+
+  return undefined;
+}
+
+export function detectImageMimeTypeFromBase64(base64: string): SupportedImageMimeType | undefined {
+  try {
+    return detectImageMimeType(Buffer.from(base64, 'base64'));
+  } catch {
+    return undefined;
+  }
+}
+
+export function coerceSupportedImageMimeType(
+  value: string | undefined,
+  fallback: SupportedImageMimeType = 'image/png'
+): SupportedImageMimeType {
+  return value === 'image/png' || value === 'image/jpeg' || value === 'image/webp' ? value : fallback;
+}
+
+export function normalizeImageMimeType(
+  base64: string,
+  declaredMimeType: SupportedImageMimeType
+): SupportedImageMimeType {
+  return detectImageMimeTypeFromBase64(base64) ?? declaredMimeType;
+}
+
+export function makeImageContent(
+  base64: string,
+  declaredMimeType: SupportedImageMimeType
+): { type: 'image'; data: string; mimeType: SupportedImageMimeType } {
+  return {
+    type: 'image',
+    data: base64,
+    mimeType: normalizeImageMimeType(base64, declaredMimeType),
+  };
+}

--- a/src/vision/screenshot-analyzer.ts
+++ b/src/vision/screenshot-analyzer.ts
@@ -30,6 +30,7 @@ import type {
   VisionTilingInfo,
 } from './types';
 import { bufferToBase64WithPayloadGuard, resolveViewportDimensions, validateCaptureArea } from '../utils/screenshot-guards';
+import { detectImageMimeType } from '../utils/image-mime';
 
 /** Raw element collected from the page */
 export interface RawElement {
@@ -609,7 +610,7 @@ async function captureAnnotatedScreenshot(
     if ('error' in encoded) {
       throw new Error(encoded.error);
     }
-    const mimeType = options.format === 'webp' ? 'image/webp' : 'image/png';
+    const mimeType = detectImageMimeType(screenshotBuffer) ?? (options.format === 'webp' ? 'image/webp' : 'image/png');
 
     return {
       screenshot: encoded.data,

--- a/tests/tools/computer.test.ts
+++ b/tests/tools/computer.test.ts
@@ -7,6 +7,9 @@ import { createMockSessionManager, createMockRefIdManager } from '../utils/mock-
 import { keyNormalizationMap } from '../utils/test-helpers';
 import { DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS, MAX_INLINE_IMAGE_PAYLOAD_BYTES } from '../../src/config/defaults';
 
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+const PNG_BASE64 = PNG_BYTES.toString('base64');
+
 // Mock the session manager and ref-id-manager modules
 jest.mock('../../src/session-manager', () => ({
   getSessionManager: jest.fn(),
@@ -534,6 +537,24 @@ describe('ComputerTool', () => {
         format: 'webp',
         optimizeForSpeed: true,
       }));
+    });
+
+    test('normalizes MIME when a WebP-requested CDP screenshot returns PNG bytes', async () => {
+      const handler = await getComputerHandler();
+      const page = (await mockSessionManager.getPage(testSessionId, testTargetId))!;
+      const cdpSession = await (page as any).createCDPSession();
+      (cdpSession.send as jest.Mock).mockResolvedValueOnce({ data: PNG_BASE64 });
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        action: 'screenshot',
+      }) as { content: Array<{ type: string; data?: string; mimeType?: string }> };
+
+      expect(result.content[0]).toMatchObject({
+        type: 'image',
+        data: PNG_BASE64,
+        mimeType: 'image/png',
+      });
     });
 
     test('returns image/png and omits quality when screenshotFormat="png"', async () => {

--- a/tests/tools/interact.coordinate.test.ts
+++ b/tests/tools/interact.coordinate.test.ts
@@ -13,6 +13,9 @@
 import { createMockSessionManager } from '../utils/mock-session';
 import { createMockPage } from '../utils/mock-cdp';
 
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+const PNG_BASE64 = PNG_BYTES.toString('base64');
+
 // Session manager mock
 jest.mock('../../src/session-manager', () => ({
   getSessionManager: jest.fn(),
@@ -251,6 +254,23 @@ describe('interact tool — coordinate mode', () => {
   });
 
   // ── Happy path ─────────────────────────────────────────────────────────────
+
+  test('verify screenshot normalizes MIME when WebP request returns PNG bytes', async () => {
+    mockPage.screenshot.mockResolvedValueOnce(PNG_BASE64 as never);
+
+    const result = await callInteract({
+      tabId: 'tab-1',
+      mode: 'coordinate',
+      coordinate: { x: 100, y: 200 },
+      verify: true,
+    }) as { content: Array<{ type: string; data?: string; mimeType?: string }> };
+
+    expect(result.content[1]).toEqual({
+      type: 'image',
+      data: PNG_BASE64,
+      mimeType: 'image/png',
+    });
+  });
 
   test('valid coordinate click dispatches via cdpClient and returns success', async () => {
     const result = await callInteract({

--- a/tests/tools/page-screenshot-guards.test.ts
+++ b/tests/tools/page-screenshot-guards.test.ts
@@ -7,6 +7,8 @@ import {
   getBase64EncodedByteLengthForRawBytes,
 } from '../../src/utils/screenshot-guards';
 
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+
 jest.mock('../../src/session-manager', () => ({
   getSessionManager: jest.fn(),
 }));
@@ -89,6 +91,24 @@ describe('page_screenshot payload guards', () => {
     expect(result.content[0]).toEqual({
       type: 'image',
       data: Buffer.from('small image').toString('base64'),
+      mimeType: 'image/png',
+    });
+  });
+
+  it('normalizes MIME when a WebP-requested screenshot returns PNG bytes', async () => {
+    const handler = await getPageScreenshotHandler(mockSessionManager);
+    const page = (await mockSessionManager.getPage(sessionId, tabId))!;
+    (page.screenshot as jest.Mock).mockResolvedValue(PNG_BYTES);
+
+    const result = await handler(sessionId, { tabId, format: 'webp' }) as {
+      content: Array<{ type: string; data?: string; mimeType?: string }>;
+      isError?: boolean;
+    };
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0]).toEqual({
+      type: 'image',
+      data: PNG_BYTES.toString('base64'),
       mimeType: 'image/png',
     });
   });

--- a/tests/utils/image-mime.test.ts
+++ b/tests/utils/image-mime.test.ts
@@ -1,0 +1,56 @@
+/// <reference types="jest" />
+
+import {
+  detectImageMimeType,
+  detectImageMimeTypeFromBase64,
+  coerceSupportedImageMimeType,
+  makeImageContent,
+  normalizeImageMimeType,
+} from '../../src/utils/image-mime';
+
+const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+const jpegBytes = Buffer.from([0xff, 0xd8, 0xff, 0xdb, 0x00]);
+const webpBytes = Buffer.concat([
+  Buffer.from('RIFF', 'ascii'),
+  Buffer.from([0x00, 0x00, 0x00, 0x00]),
+  Buffer.from('WEBP', 'ascii'),
+]);
+
+describe('image MIME helpers', () => {
+  it('detects PNG, JPEG, and WebP from strict magic bytes', () => {
+    expect(detectImageMimeType(pngBytes)).toBe('image/png');
+    expect(detectImageMimeType(jpegBytes)).toBe('image/jpeg');
+    expect(detectImageMimeType(webpBytes)).toBe('image/webp');
+  });
+
+  it('returns undefined for unknown bytes', () => {
+    expect(detectImageMimeType(Buffer.from('not-an-image'))).toBeUndefined();
+  });
+
+  it('coerces arbitrary MIME input to the supported MCP image set', () => {
+    expect(coerceSupportedImageMimeType('image/webp')).toBe('image/webp');
+    expect(coerceSupportedImageMimeType('application/octet-stream')).toBe('image/png');
+    expect(coerceSupportedImageMimeType(undefined, 'image/webp')).toBe('image/webp');
+  });
+
+  it('normalizes declared MIME from actual base64 bytes', () => {
+    const pngBase64 = pngBytes.toString('base64');
+    expect(detectImageMimeTypeFromBase64(pngBase64)).toBe('image/png');
+    expect(normalizeImageMimeType(pngBase64, 'image/webp')).toBe('image/png');
+  });
+
+  it('builds self-consistent MCP image content while preserving fallback MIME for unknown bytes', () => {
+    expect(makeImageContent(pngBytes.toString('base64'), 'image/webp')).toEqual({
+      type: 'image',
+      data: pngBytes.toString('base64'),
+      mimeType: 'image/png',
+    });
+
+    const unknown = Buffer.from('base64-screenshot-data').toString('base64');
+    expect(makeImageContent(unknown, 'image/webp')).toEqual({
+      type: 'image',
+      data: unknown,
+      mimeType: 'image/webp',
+    });
+  });
+});

--- a/tests/vision/screenshot-analyzer.test.ts
+++ b/tests/vision/screenshot-analyzer.test.ts
@@ -13,6 +13,8 @@ import {
 import type { VisionElementMap } from '../../src/vision/types';
 import { MAX_INLINE_IMAGE_PAYLOAD_BYTES } from '../../src/config/defaults';
 
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+
 // ─── Mock Page Factory ───
 
 function createMockPage(
@@ -189,6 +191,14 @@ describe('analyzeScreenshot', () => {
     const result = await analyzeScreenshot(page as any);
     expect(result.mimeType).toBe('image/webp');
     expect(result.elementCount).toBe(0);
+  });
+
+  it('normalizes MIME when a WebP-requested annotated screenshot returns PNG bytes', async () => {
+    const page = createMockPage([]);
+    page.screenshot.mockResolvedValueOnce(PNG_BYTES);
+    const result = await analyzeScreenshot(page as any, { format: 'webp' });
+    expect(result.screenshot).toBe(PNG_BYTES.toString('base64'));
+    expect(result.mimeType).toBe('image/png');
   });
 
   it('respects png format option', async () => {


### PR DESCRIPTION
## Summary

Fixes #1487 by making MCP image content blocks self-consistent: `mimeType` is now normalized from the actual image bytes before returning screenshot/image payloads to MCP clients.

This preserves existing screenshot format policy. WebP remains WebP when the returned bytes are WebP; PNG bytes are reported as `image/png` even if the requested capture format was WebP.

## SSOT alignment

Per #1359, OpenChrome should remain a host-neutral, standards-first MCP browser harness. This PR fixes the MCP result contract at the boundary instead of adding Claude/Anthropic-specific behavior or globally forcing PNG output.

## Changes

- Add `src/utils/image-mime.ts` for strict PNG/JPEG/WebP magic-byte detection and MCP image content construction.
- Apply the helper to image-producing paths:
  - `computer(action: "screenshot")`
  - `page_screenshot`
  - `interact` verification screenshots
  - `vision_find` and `find` vision fallback output
  - annotated screenshot analyzer output
  - `batch_paginate` screenshot output
  - `image_qa` sampling image forwarding
- Add regression coverage for requested-WebP / actual-PNG mismatch.

## Verification

- `npx jest tests/utils/image-mime.test.ts tests/tools/page-screenshot-guards.test.ts tests/vision/screenshot-analyzer.test.ts tests/tools/interact.coordinate.test.ts --runInBand`
- `npx jest tests/tools/computer.test.ts --runInBand`
- `npm run build:src`
- `git diff --check`

## Non-goals

- No global PNG-only behavior.
- No WebP removal.
- No image transcoding/re-encoding.
- No provider-specific branches.
- No MCP schema change.
