### PR TITLE
feat(cli): warn when setup migration is required after updates

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -33,11 +33,13 @@ import {
   getCodexSetupCommand,
   getOpenCodeServerConfig,
   getTopologyWarning,
+  HOST_CONFIG_MIGRATION_NOTE,
   formatOpenCodeMCPServerConfigSnippet,
   getSupportedMCPClients,
   isSupportedMCPClient,
   upsertOpenCodeMCPServerConfig,
 } from './mcp-client-config';
+import { getHostConfigMigrationNotice, scanOpenChromeHostConfigs } from './mcp-config-diagnostics';
 import {
   addTotpSecret,
   generateTOTP,
@@ -185,6 +187,41 @@ program
     console.log('Simply remove the MCP server config from ~/.claude.json if you want to disable it.');
   });
 
+function printHostConfigMigrationNotice(label: string): void {
+  for (const line of getHostConfigMigrationNotice(label)) {
+    console.log(`ℹ️  ${line}`);
+  }
+}
+
+function printDoctorMCPTopologyGuidance(): void {
+  const diagnostics = scanOpenChromeHostConfigs();
+  console.log('\nMCP Host Topology:');
+
+  if (diagnostics.configs.length === 0) {
+    console.log('  ℹ️  No OpenChrome MCP host registrations detected in Claude Code, Codex CLI, or OpenCode config files.');
+    console.log(`  ℹ️  ${HOST_CONFIG_MIGRATION_NOTE}`);
+    return;
+  }
+
+  for (const config of diagnostics.configs) {
+    const mode = config.connectBroker ? 'broker client' : config.broker ? 'broker owner' : 'direct';
+    console.log(`  • ${config.label}: ${mode} port=${config.port} userDataDir=${config.userDataDir} (${config.path})`);
+  }
+
+  if (diagnostics.duplicateDirectGroups.length > 0) {
+    console.log('  ⚠️  Multiple host registrations use the same direct OpenChrome port/profile.');
+    for (const group of diagnostics.duplicateDirectGroups) {
+      const labels = group.configs.map((config) => config.label).join(', ');
+      console.log(`     - port=${group.port} userDataDir=${group.userDataDir}: ${labels}`);
+    }
+    console.log('     Use isolated per-client ports/profiles or the broker topology; do not rely on npm update alone.');
+  } else if (diagnostics.directConfigs.length > 0) {
+    console.log('  ℹ️  Direct OpenChrome registrations stay direct until setup or manual config changes migrate them.');
+  }
+
+  console.log(`  ℹ️  ${HOST_CONFIG_MIGRATION_NOTE}`);
+}
+
 program
   .command('setup')
   .description('Automatically configure MCP server for Claude Code, Codex CLI, or OpenCode')
@@ -295,7 +332,8 @@ program
 
         console.log(`\nScope: ${scope === 'user' ? 'Global (all projects)' : 'Project (this directory only)'}`);
         console.log('Updates: run "openchrome update"\n');
-        console.log('Next steps:');
+        printHostConfigMigrationNotice('Claude Code');
+        console.log('\nNext steps:');
         console.log('  1. Restart Claude Code');
         console.log('  2. Just say "oc" — that\'s it.\n');
         console.log('Examples:');
@@ -333,7 +371,8 @@ program
         console.log('\n✅ MCP server configured successfully!\n');
         console.log(`Config file: ${openCodeConfigPath}`);
         console.log('Auto-updates: enabled (via npx)\n');
-        console.log('Next steps:');
+        printHostConfigMigrationNotice('OpenCode');
+        console.log('\nNext steps:');
         console.log('  1. Restart OpenCode');
         console.log('  2. Verify the openchrome MCP server reconnects cleanly\n');
         console.log('Installed MCP snippet:');
@@ -362,7 +401,8 @@ program
       console.log('\n✅ MCP server configured successfully!\n');
       console.log('Config file: ~/.codex/config.toml');
       console.log('Updates: run "openchrome update"\n');
-      console.log('Next steps:');
+      printHostConfigMigrationNotice('Codex CLI');
+      console.log('\nNext steps:');
       console.log('  1. Restart Codex CLI');
       console.log('  2. Verify the openchrome MCP server reconnects cleanly\n');
       console.log('Installed MCP snippet:');
@@ -577,6 +617,8 @@ program
         console.log('  Set CHROME_PATH environment variable to your Chrome binary');
       }
     }
+
+    printDoctorMCPTopologyGuidance();
 
     const allPassed = Object.values(coreChecks).every(Boolean);
     console.log();

--- a/cli/mcp-client-config.ts
+++ b/cli/mcp-client-config.ts
@@ -3,6 +3,8 @@ export type SetupScope = 'user' | 'project';
 
 export type TopologyPreset = 'single-owner' | 'isolated' | 'ci-headless' | 'dev-profile';
 
+export const HOST_CONFIG_MIGRATION_NOTE = 'Package updates do not rewrite existing MCP host registrations; rerun setup or edit host config, then restart the host to activate topology changes.';
+
 export interface ServeArgOptions {
   autoLaunch?: boolean;
   dashboard?: boolean;
@@ -114,7 +116,7 @@ export function getTopologyWarning(options: ServeArgOptions = {}): string | null
   const resolved = resolveTopologyOptions(options);
   const usingDefaultPortProfile = resolved.port === undefined && !resolved.userDataDir;
   if (!usingDefaultPortProfile) return null;
-  return 'Topology note: this config uses the default single-owner Chrome port/profile. Do not install the same direct config in multiple MCP clients at once; choose --topology isolated or explicit --port + --user-data-dir until broker mode is available.';
+  return `Topology note: this config uses the default single-owner Chrome port/profile. Do not install the same direct config in multiple MCP clients at once; choose --topology isolated, explicit --port + --user-data-dir, or the broker topology for shared profiles. ${HOST_CONFIG_MIGRATION_NOTE}`;
 }
 
 export function getCodexServerConfig(options: ServeArgOptions = {}): MCPServerConfig {

--- a/cli/mcp-config-diagnostics.ts
+++ b/cli/mcp-config-diagnostics.ts
@@ -41,7 +41,7 @@ export function getHostConfigMigrationNotice(label = 'this MCP host'): string[] 
 
 export function classifyOpenChromeCommand(command: string, args: string[]): Omit<DetectedOpenChromeConfig, 'client' | 'label' | 'path'> | null {
   const commandParts = [command, ...args].filter(Boolean);
-  const openchromeIndex = commandParts.findIndex((part) => part === 'openchrome' || part.endsWith('/openchrome'));
+  const openchromeIndex = commandParts.findIndex(isOpenChromeExecutable);
   if (openchromeIndex === -1) return null;
 
   const serveArgs = commandParts.slice(openchromeIndex + 1);
@@ -96,7 +96,17 @@ export function scanOpenChromeHostConfigs(homeDir = os.homedir()): MCPConfigDiag
   ]);
 }
 
+function isOpenChromeExecutable(part: string): boolean {
+  const normalized = part.replace(/\\/g, '/');
+  const basename = normalized.split('/').pop() ?? normalized;
+  return basename === 'openchrome' || basename === 'openchrome.cmd' || basename === 'openchrome.exe';
+}
+
 function readFlagValue(args: string[], flag: string): string | undefined {
+  const equalsPrefix = `${flag}=`;
+  const equalsValue = args.find((arg) => arg.startsWith(equalsPrefix));
+  if (equalsValue) return equalsValue.slice(equalsPrefix.length) || undefined;
+
   const index = args.indexOf(flag);
   if (index === -1) return undefined;
   const value = args[index + 1];

--- a/cli/mcp-config-diagnostics.ts
+++ b/cli/mcp-config-diagnostics.ts
@@ -1,0 +1,210 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+export interface DetectedOpenChromeConfig {
+  client: 'claude' | 'codex' | 'opencode';
+  label: string;
+  path: string;
+  command: string;
+  args: string[];
+  port: string;
+  userDataDir: string;
+  direct: boolean;
+  broker: boolean;
+  connectBroker: boolean;
+}
+
+export interface DirectConfigGroup {
+  key: string;
+  port: string;
+  userDataDir: string;
+  configs: DetectedOpenChromeConfig[];
+}
+
+export interface MCPConfigDiagnostics {
+  configs: DetectedOpenChromeConfig[];
+  duplicateDirectGroups: DirectConfigGroup[];
+  directConfigs: DetectedOpenChromeConfig[];
+}
+
+const DEFAULT_PORT = '9222';
+const DEFAULT_USER_DATA_DIR = '<openchrome-default-profile>';
+
+export function getHostConfigMigrationNotice(label = 'this MCP host'): string[] {
+  return [
+    'Package updates do not rewrite existing MCP host registrations.',
+    `This setup refreshed ${label}'s OpenChrome command; restart the host session so it loads the new MCP namespace.`,
+    'If a release requires a new topology, rerun setup for each host or edit its MCP config manually.',
+  ];
+}
+
+export function classifyOpenChromeCommand(command: string, args: string[]): Omit<DetectedOpenChromeConfig, 'client' | 'label' | 'path'> | null {
+  const commandParts = [command, ...args].filter(Boolean);
+  const openchromeIndex = commandParts.findIndex((part) => part === 'openchrome' || part.endsWith('/openchrome'));
+  if (openchromeIndex === -1) return null;
+
+  const serveArgs = commandParts.slice(openchromeIndex + 1);
+  if (!serveArgs.includes('serve')) return null;
+
+  const broker = serveArgs.includes('--broker');
+  const connectBroker = serveArgs.includes('--connect-broker');
+  const direct = !broker && !connectBroker;
+
+  return {
+    command,
+    args,
+    port: readFlagValue(serveArgs, '--port') ?? readFlagValue(serveArgs, '-p') ?? DEFAULT_PORT,
+    userDataDir: readFlagValue(serveArgs, '--user-data-dir') ?? DEFAULT_USER_DATA_DIR,
+    direct,
+    broker,
+    connectBroker,
+  };
+}
+
+export function findDuplicateDirectGroups(configs: DetectedOpenChromeConfig[]): DirectConfigGroup[] {
+  const groups = new Map<string, DirectConfigGroup>();
+  for (const config of configs) {
+    if (!config.direct) continue;
+    const key = `${config.port}\0${config.userDataDir}`;
+    const existing = groups.get(key) ?? {
+      key,
+      port: config.port,
+      userDataDir: config.userDataDir,
+      configs: [],
+    };
+    existing.configs.push(config);
+    groups.set(key, existing);
+  }
+  return [...groups.values()].filter((group) => group.configs.length > 1);
+}
+
+export function analyzeOpenChromeConfigs(configs: DetectedOpenChromeConfig[]): MCPConfigDiagnostics {
+  return {
+    configs,
+    duplicateDirectGroups: findDuplicateDirectGroups(configs),
+    directConfigs: configs.filter((config) => config.direct),
+  };
+}
+
+export function scanOpenChromeHostConfigs(homeDir = os.homedir()): MCPConfigDiagnostics {
+  return analyzeOpenChromeConfigs([
+    ...scanJsonHostConfig('claude', 'Claude Code', path.join(homeDir, '.claude.json')),
+    ...scanCodexToml(path.join(homeDir, '.codex', 'config.toml')),
+    ...scanJsonHostConfig('codex', 'Codex CLI', path.join(homeDir, '.codex', 'mcp.json')),
+    ...scanJsonHostConfig('opencode', 'OpenCode', path.join(homeDir, '.config', 'opencode', 'opencode.json')),
+  ]);
+}
+
+function readFlagValue(args: string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  if (index === -1) return undefined;
+  const value = args[index + 1];
+  return value && !value.startsWith('-') ? value : undefined;
+}
+
+function scanJsonHostConfig(
+  client: DetectedOpenChromeConfig['client'],
+  label: string,
+  filePath: string
+): DetectedOpenChromeConfig[] {
+  if (!fs.existsSync(filePath)) return [];
+  try {
+    const document = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    return findOpenChromeEntriesInJson(document).map((entry) => ({
+      ...entry,
+      client,
+      label,
+      path: filePath,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+function findOpenChromeEntriesInJson(value: unknown): Array<Omit<DetectedOpenChromeConfig, 'client' | 'label' | 'path'>> {
+  const found: Array<Omit<DetectedOpenChromeConfig, 'client' | 'label' | 'path'>> = [];
+  visitJson(value, (key, candidate) => {
+    if (key !== 'openchrome' || !candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return;
+    const record = candidate as Record<string, unknown>;
+    const parsed = parseJsonOpenChromeEntry(record);
+    if (parsed) found.push(parsed);
+  });
+  return found;
+}
+
+function visitJson(value: unknown, visitor: (key: string, value: unknown) => void): void {
+  if (!value || typeof value !== 'object') return;
+  if (Array.isArray(value)) {
+    for (const item of value) visitJson(item, visitor);
+    return;
+  }
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    visitor(key, child);
+    visitJson(child, visitor);
+  }
+}
+
+function parseJsonOpenChromeEntry(record: Record<string, unknown>): Omit<DetectedOpenChromeConfig, 'client' | 'label' | 'path'> | null {
+  if (typeof record.command === 'string') {
+    const args = Array.isArray(record.args) ? record.args.filter((arg): arg is string => typeof arg === 'string') : [];
+    return classifyOpenChromeCommand(record.command, args);
+  }
+
+  if (Array.isArray(record.command) && record.command.every((part) => typeof part === 'string')) {
+    const [command, ...args] = record.command as string[];
+    return classifyOpenChromeCommand(command, args);
+  }
+
+  return null;
+}
+
+function scanCodexToml(filePath: string): DetectedOpenChromeConfig[] {
+  if (!fs.existsSync(filePath)) return [];
+  try {
+    const text = fs.readFileSync(filePath, 'utf8');
+    const block = findTomlTableBlock(text, 'mcp_servers.openchrome');
+    if (!block) return [];
+    const command = readTomlString(block, 'command');
+    const args = readTomlStringArray(block, 'args');
+    if (!command) return [];
+    const parsed = classifyOpenChromeCommand(command, args ?? []);
+    return parsed ? [{ ...parsed, client: 'codex', label: 'Codex CLI', path: filePath }] : [];
+  } catch {
+    return [];
+  }
+}
+
+function findTomlTableBlock(text: string, table: string): string | null {
+  const lines = text.split(/\r?\n/);
+  const start = lines.findIndex((line) => line.trim() === `[${table}]`);
+  if (start === -1) return null;
+  const block: string[] = [];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (/^\s*\[/.test(line)) break;
+    block.push(line);
+  }
+  return block.join('\n');
+}
+
+function readTomlString(block: string, key: string): string | undefined {
+  const match = block.match(new RegExp(`^\\s*${escapeRegex(key)}\\s*=\\s*("(?:\\\\.|[^"])*")`, 'm'));
+  if (!match) return undefined;
+  try { return JSON.parse(match[1]); } catch { return undefined; }
+}
+
+function readTomlStringArray(block: string, key: string): string[] | undefined {
+  const match = block.match(new RegExp(`^\\s*${escapeRegex(key)}\\s*=\\s*(\\[(?:.|\\n)*?\\])`, 'm'));
+  if (!match) return undefined;
+  try {
+    const parsed = JSON.parse(match[1]);
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/tests/cli/mcp-client-config.test.ts
+++ b/tests/cli/mcp-client-config.test.ts
@@ -8,6 +8,7 @@ import {
   getOpenCodeServerConfig,
   getServeArgs,
   getTopologyWarning,
+  HOST_CONFIG_MIGRATION_NOTE,
   isSupportedMCPClient,
   upsertMCPServerConfig,
 } from '../../cli/mcp-client-config';
@@ -192,6 +193,7 @@ describe('cli/mcp-client-config', () => {
 
   test('default topology warning is omitted once port/profile is explicit', () => {
     expect(getTopologyWarning()).toContain('default single-owner');
+    expect(getTopologyWarning()).toContain(HOST_CONFIG_MIGRATION_NOTE);
     expect(getTopologyWarning({ port: 9333, userDataDir: '/tmp/openchrome-codex' })).toBeNull();
   });
 

--- a/tests/cli/mcp-config-diagnostics.test.ts
+++ b/tests/cli/mcp-config-diagnostics.test.ts
@@ -1,0 +1,149 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  analyzeOpenChromeConfigs,
+  classifyOpenChromeCommand,
+  findDuplicateDirectGroups,
+  getHostConfigMigrationNotice,
+  scanOpenChromeHostConfigs,
+} from '../../cli/mcp-config-diagnostics';
+
+function makeTempHome(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-mcp-config-'));
+}
+
+describe('cli/mcp-config-diagnostics', () => {
+  test('migration notice explains update versus host config activation', () => {
+    const notice = getHostConfigMigrationNotice('Codex CLI').join('\n');
+
+    expect(notice).toContain('Package updates do not rewrite existing MCP host registrations');
+    expect(notice).toContain('Codex CLI');
+    expect(notice).toContain('restart the host session');
+  });
+
+  test('classifies direct, broker owner, and broker client commands', () => {
+    expect(classifyOpenChromeCommand('openchrome', ['serve', '--auto-launch'])).toMatchObject({
+      direct: true,
+      broker: false,
+      connectBroker: false,
+      port: '9222',
+      userDataDir: '<openchrome-default-profile>',
+    });
+
+    expect(classifyOpenChromeCommand('openchrome', ['serve', '--broker', '--port', '9333'])).toMatchObject({
+      direct: false,
+      broker: true,
+      connectBroker: false,
+      port: '9333',
+    });
+
+    expect(classifyOpenChromeCommand('openchrome', ['serve', '--connect-broker', '--user-data-dir', '/tmp/oc'])).toMatchObject({
+      direct: false,
+      broker: false,
+      connectBroker: true,
+      userDataDir: '/tmp/oc',
+    });
+  });
+
+  test('groups duplicate direct configs by port and user data dir', () => {
+    const duplicateGroups = findDuplicateDirectGroups([
+      {
+        client: 'claude',
+        label: 'Claude Code',
+        path: '/tmp/claude',
+        command: 'openchrome',
+        args: ['serve', '--auto-launch'],
+        port: '9222',
+        userDataDir: '<openchrome-default-profile>',
+        direct: true,
+        broker: false,
+        connectBroker: false,
+      },
+      {
+        client: 'codex',
+        label: 'Codex CLI',
+        path: '/tmp/codex',
+        command: 'openchrome',
+        args: ['serve', '--auto-launch'],
+        port: '9222',
+        userDataDir: '<openchrome-default-profile>',
+        direct: true,
+        broker: false,
+        connectBroker: false,
+      },
+      {
+        client: 'opencode',
+        label: 'OpenCode',
+        path: '/tmp/opencode',
+        command: 'openchrome',
+        args: ['serve', '--connect-broker'],
+        port: '9222',
+        userDataDir: '<openchrome-default-profile>',
+        direct: false,
+        broker: false,
+        connectBroker: true,
+      },
+    ]);
+
+    expect(duplicateGroups).toHaveLength(1);
+    expect(duplicateGroups[0].configs.map((config) => config.label)).toEqual(['Claude Code', 'Codex CLI']);
+  });
+
+  test('scans Claude JSON, Codex TOML, Codex MCP JSON, and OpenCode JSON configs', () => {
+    const home = makeTempHome();
+    fs.writeFileSync(path.join(home, '.claude.json'), JSON.stringify({
+      mcpServers: {
+        openchrome: { command: 'openchrome', args: ['serve', '--auto-launch'] },
+      },
+    }));
+    fs.mkdirSync(path.join(home, '.codex'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.codex', 'config.toml'), [
+      '[mcp_servers.openchrome]',
+      'command = "openchrome"',
+      'args = ["serve", "--auto-launch"]',
+    ].join('\n'));
+    fs.writeFileSync(path.join(home, '.codex', 'mcp.json'), JSON.stringify({
+      mcpServers: {
+        openchrome: { command: 'openchrome', args: ['serve', '--connect-broker'] },
+      },
+    }));
+    fs.mkdirSync(path.join(home, '.config', 'opencode'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.config', 'opencode', 'opencode.json'), JSON.stringify({
+      mcp: {
+        openchrome: { type: 'local', command: ['openchrome', 'serve', '--auto-launch', '--port', '9444'] },
+      },
+    }));
+
+    const diagnostics = scanOpenChromeHostConfigs(home);
+
+    expect(diagnostics.configs.map((config) => `${config.label}:${config.port}:${config.direct}`).sort()).toEqual([
+      'Claude Code:9222:true',
+      'Codex CLI:9222:false',
+      'Codex CLI:9222:true',
+      'OpenCode:9444:true',
+    ]);
+    expect(diagnostics.duplicateDirectGroups).toHaveLength(1);
+  });
+
+  test('analysis preserves direct config list without duplicate groups', () => {
+    const analyzed = analyzeOpenChromeConfigs([
+      {
+        client: 'claude',
+        label: 'Claude Code',
+        path: '/tmp/claude',
+        command: 'openchrome',
+        args: ['serve', '--auto-launch', '--port', '9223'],
+        port: '9223',
+        userDataDir: '<openchrome-default-profile>',
+        direct: true,
+        broker: false,
+        connectBroker: false,
+      },
+    ]);
+
+    expect(analyzed.directConfigs).toHaveLength(1);
+    expect(analyzed.duplicateDirectGroups).toHaveLength(0);
+  });
+});

--- a/tests/cli/mcp-config-diagnostics.test.ts
+++ b/tests/cli/mcp-config-diagnostics.test.ts
@@ -47,6 +47,25 @@ describe('cli/mcp-config-diagnostics', () => {
     });
   });
 
+
+  test('classifies equals-style flags and platform-specific openchrome executable names', () => {
+    expect(classifyOpenChromeCommand('/opt/bin/openchrome', ['serve', '--port=9333', '--user-data-dir=/tmp/oc'])).toMatchObject({
+      direct: true,
+      port: '9333',
+      userDataDir: '/tmp/oc',
+    });
+
+    expect(classifyOpenChromeCommand('C:\\Tools\\openchrome.cmd', ['serve', '-p', '9444'])).toMatchObject({
+      direct: true,
+      port: '9444',
+    });
+
+    expect(classifyOpenChromeCommand('C:\\Tools\\openchrome.exe', ['serve', '--broker'])).toMatchObject({
+      broker: true,
+      direct: false,
+    });
+  });
+
   test('groups duplicate direct configs by port and user data dir', () => {
     const duplicateGroups = findDuplicateDirectGroups([
       {


### PR DESCRIPTION
## Summary

Part of #1489. This is **PR B — setup/doctor inform path** from the issue decomposition.

This PR makes the update-vs-host-config boundary visible in CLI flows:

- `openchrome setup` now prints a host-specific notice that package updates do not rewrite existing MCP host registrations, and that the host session must be restarted after setup refreshes the command.
- `openchrome config` / topology warning copy now includes the same migration note for default direct topology output.
- `openchrome doctor` now scans common Claude Code, Codex CLI, and OpenCode config locations for OpenChrome registrations and reports:
  - direct vs broker-owner vs broker-client mode;
  - port and user-data-dir;
  - duplicate direct registrations that share one port/profile;
  - the same "npm update is not host config migration" guidance.

## Scope

- Adds CLI diagnostics and user-facing setup/doctor copy.
- Does **not** mutate user config automatically outside the already-explicit `setup` command.
- Does **not** add npm `postinstall` migration.
- Does **not** change OpenChrome runtime duplicate-controller behavior; that remains PR C and should be based on #1479 / #1480 surfaces.

## Verification

- `npm run build:cli`
- `jest tests/cli/mcp-client-config.test.ts tests/cli/mcp-config-diagnostics.test.ts --runInBand`
- `git diff --check`
- Doctor smoke with local configs showed duplicate direct Codex registrations and printed the migration notice.

## Guardrails

- Auto-elect wording remains out of setup/doctor behavior until the runtime stack lands and the final flag/default is decided.
- Broker/direct/isolated topologies remain distinct.
- No package-update side effects are introduced.

---

## Goal

Make update-vs-host-config migration requirements visible in setup/config/doctor CLI flows after package updates.

## Final Implementation Scope

- Print setup/config notices that package updates do not rewrite existing MCP host registrations.
- Add read-only doctor diagnostics for Claude Code, Codex CLI, and OpenCode OpenChrome registrations.
- Detect direct/broker-owner/broker-client mode plus port/profile duplicate direct registrations, including equals-style flags and Windows launchers.

## Success Criteria

- Users get explicit restart/rerun-setup guidance after setup/config output.
- Doctor reports duplicate direct configs sharing one port/profile without mutating files.
- Generated/manual topology guidance stays separate from runtime duplicate-controller remediation.

## Verification Method

- `npm run build:cli` passed after rebase.
- `npx jest tests/cli/mcp-client-config.test.ts tests/cli/mcp-config-diagnostics.test.ts --runInBand` passed: 23 tests.
- `git diff --check` passed.
- GitHub CI on rebased head must complete 9/9 success before final merge-ready verdict.

## Guardrails

- No npm `postinstall` config mutation.
- No automatic user-config edits outside explicit `setup` command.
- No auto-elect default wording until runtime/default policy is decided.

## Explicit Non-Goals

- No runtime duplicate-controller behavior change.
- No PR C auto-remediation implementation.
- No live mutation of Claude/Codex/OpenCode configs during doctor.

## Implementation Approach

Centralize migration notice text, add a read-only scanner/parser for common host config shapes, and surface concise diagnostics in doctor/setup/config outputs.

## PR Decomposition

PR B of #1489 setup/doctor inform path. It complements docs PR #1490 and remains separate from runtime remediation work based on #1479/#1480.

## Over-Engineering Checklist

- Regex/TOML/JSON scanning is intentionally narrow to OpenChrome entries.
- No full TOML parser dependency.
- No cross-host config rewrite engine.

## Drift-Prevention Checklist

- Scope is CLI information/diagnostics only.
- Any runtime broker/election behavior is drift.
- Any package-install side effect is drift.

## Language Boundary

User-facing CLI text is English. Korean README/docs wording belongs to docs PR #1490, not this CLI PR.

## Critical Risk Review

Critical risks are false negatives for real host commands and unsafe config mutation; tests cover common JSON/TOML forms, equals flags, and Windows executables, and scanner is read-only.

## Definition of Done

- CLI diagnostics implemented and tested.
- Branch includes current `develop` base.
- Targeted local verification and 9/9 GitHub CI pass.
