### PR TITLE
ci: keep PR checks from saturating macOS runners

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -1,11 +1,11 @@
-name: CI
+name: CI Full Matrix
 
 on:
-  pull_request:
+  push:
     branches: [main, develop]
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
+  group: ci-full-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -16,20 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # Fast PR gate: full Node compatibility on Linux plus one smoke lane
-          # per non-Linux OS. This keeps PRs from waiting on three macOS hosted
-          # runners while preserving cross-platform signal before merge.
-          - os: ubuntu-latest
-            node-version: 18
-          - os: ubuntu-latest
-            node-version: 20
-          - os: ubuntu-latest
-            node-version: 22
-          - os: windows-latest
-            node-version: 20
-          - os: macos-latest
-            node-version: 20
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [18, 20, 22]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary

Cancels the current macOS long-tail failure mode by changing CI topology instead of rerunning the same saturated matrix:

- adds workflow-level `concurrency` so superseded PR/branch runs cancel automatically;
- splits pull-request CI from protected-branch push CI into separate workflows so PRs do not get skipped placeholder jobs;
- keeps PRs to five signal lanes: Ubuntu Node 18/20/22 plus Windows Node 20 and macOS Node 20;
- keeps the full 3 OS × 3 Node matrix on `main`/`develop` pushes after merge;
- adds a 45-minute job timeout so genuinely stuck jobs do not run unbounded.

## Goal

Stop open PRs from being blocked for an hour or more by hosted macOS runner queue long-tail while preserving meaningful pre-merge and post-merge CI coverage.

## Final Implementation Scope

- `.github/workflows/ci.yml` for pull-request fast CI.
- `.github/workflows/ci-full.yml` for full push CI on `main`/`develop`.
- Pull-request CI becomes a bounded five-lane fast gate.
- Push CI to `main`/`develop` remains the full 9-lane compatibility matrix.
- Superseded CI runs are cancelled per workflow/branch or workflow/PR head branch.
- Each CI job has a 45-minute timeout.

## Success Criteria

- A PR push no longer requests three macOS runners; it requests exactly one macOS PR smoke lane.
- Linux still covers Node 18, 20, and 22 before merge.
- Windows and macOS still provide pre-merge OS smoke coverage on Node 20.
- Full Windows/macOS × Node 18/20/22 coverage still runs after merge to `main`/`develop`.
- Pushing a replacement commit to the same PR cancels the superseded run automatically.

## Verification Method

- `actionlint .github/workflows/ci.yml` passed.
- YAML parse smoke passed.
- `git diff --check` passed.
- GitHub branch-protection required-status API returned unprotected for both `main` and `develop`, so removing four PR check names will not strand required checks.
- Live PR CI should show five pull-request jobs for this PR and no skipped push-only placeholder job.

## Guardrails

- Do not remove macOS PR coverage entirely.
- Do not remove Windows PR coverage entirely.
- Do not remove full post-merge matrix coverage for protected branch pushes.
- Do not reintroduce all three macOS Node versions on every pull request.

## Explicit Non-Goals

- No changes to source, tests, build scripts, or package dependencies.
- No attempt to change GitHub-hosted runner capacity.
- No branch-protection policy changes.
- No scheduled/nightly CI design in this PR.

## Implementation Approach

Use separate workflows: `CI` handles pull requests with the reduced matrix, and `CI Full Matrix` handles pushes with the full existing matrix. This avoids skipped placeholder jobs on PRs while keeping check display names consistent for the lanes that remain, adding timeout bounds, and adding concurrency cancellation.

## PR Decomposition

This is an operational CI fix PR created after #1491 exposed repeated macOS runner long-tail. It is independent from the feature/documentation stacks and should merge before rerunning long-tail-blocked PR checks where possible.

## Over-Engineering Checklist

- No reusable workflow extraction for a one-file CI topology change.
- No new actions or third-party dependencies.
- No dynamic script-generated matrix.
- No removal of post-merge full compatibility coverage.

## Drift-Prevention Checklist

- Scope is only `.github/workflows/ci.yml` and `.github/workflows/ci-full.yml`.
- If a diff touches product code, tests, docs, or release artifacts, it is drift.
- If PR CI again includes macOS Node 18/20/22 simultaneously, it regresses the root fix.
- If post-merge full matrix disappears, it overcorrects the root fix.

## Language Boundary

Workflow comments and PR text are English. No product/user-facing CLI or documentation language changes are included.

## Critical Risk Review

The main risk is reduced pre-merge OS/version coverage. The mitigation is to keep Linux Node-version coverage before merge, keep one smoke lane for each non-Linux OS before merge, and preserve the full matrix after merge. Branch protection is currently unprotected for `main` and `develop`, so the check-name reduction does not conflict with required-status settings.

## Definition of Done

- Current long-tail CI runs are cancelled.
- This PR opens with the required objective sections.
- Live PR CI for this branch uses the reduced PR matrix.
- `actionlint`, YAML parse, and diff check remain clean.
- After merge, future PRs no longer request three macOS runners per push.
