### PR TITLE
feat(observability): surface DuplicateController remediation over MCP

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -342,6 +342,11 @@ program
             // Instead complete `initialize` and surface the remediation through
             // MCP. A human running this in a terminal (TTY) keeps the old
             // exit(2) so the command does not hang waiting on stdin.
+            //
+            // Scope: stdio only. `--transport both`/`http` daemons keep the
+            // hard exit(2) — the responder speaks stdio, and surfacing this over
+            // the HTTP leg would need a separate HTTP error path (out of scope;
+            // such daemons typically use --connect-broker, not --auto-launch).
             if (transportMode === 'stdio' && !process.stdin.isTTY) {
               const { DuplicateControllerErrorServer } = await import('./transports/duplicate-controller-error-server');
               new DuplicateControllerErrorServer(err).start();

--- a/src/index.ts
+++ b/src/index.ts
@@ -335,7 +335,18 @@ program
           });
         } catch (err) {
           if (err instanceof DuplicateControllerError) {
+            // Always emit the full diagnostic to stderr (CLI/operator path).
             console.error(formatDuplicateControllerMessage(err));
+            // #1474: when launched by an MCP host over stdio, exiting before the
+            // handshake makes the host discard stderr and show only `-32000`.
+            // Instead complete `initialize` and surface the remediation through
+            // MCP. A human running this in a terminal (TTY) keeps the old
+            // exit(2) so the command does not hang waiting on stdin.
+            if (transportMode === 'stdio' && !process.stdin.isTTY) {
+              const { DuplicateControllerErrorServer } = await import('./transports/duplicate-controller-error-server');
+              new DuplicateControllerErrorServer(err).start();
+              return;
+            }
             process.exit(2);
           }
           throw err;

--- a/src/transports/duplicate-controller-error-server.ts
+++ b/src/transports/duplicate-controller-error-server.ts
@@ -1,0 +1,184 @@
+/**
+ * Degraded stdio MCP responder for the duplicate-controller case (#1474).
+ *
+ * When `--auto-launch` refuses to start because another session already owns
+ * Chrome for this (port, userDataDir), the old behaviour was
+ * `console.error(remediation); process.exit(2)` — but the process exited
+ * *before* the MCP handshake, so the host discarded stderr and the user saw
+ * only a bare `-32000`. The rich, actionable diagnostic never reached them.
+ *
+ * Instead of exiting, this minimal responder completes the `initialize`
+ * handshake (so the host accepts the connection) and then surfaces the
+ * remediation through portable MCP surfaces:
+ *   - a `notifications/message` (logging) emitted right after initialize;
+ *   - a single diagnostic tool whose name/description state the conflict;
+ *   - a structured JSON-RPC error (with `data`) on every other request.
+ *
+ * It owns no Chrome and holds no controller lock — it is a read-only
+ * explainer that lets the host render "another session owns Chrome; here is
+ * how to fix it" rather than `-32000`. SSOT #1359 P1: portable MCP, robust
+ * errors a host LLM can act on.
+ */
+
+import * as readline from 'readline';
+import { getVersion } from '../version';
+import { MCPErrorCodes, type MCPResponse } from '../types/mcp';
+import type { DuplicateControllerError } from '../utils/controller-lock';
+
+/** Server-defined JSON-RPC error code surfaced for the conflict. */
+export const DUPLICATE_CONTROLLER_ERROR_CODE = -32000;
+
+const DIAGNOSTIC_TOOL_NAME = 'openchrome_owner_conflict';
+
+export interface DuplicateControllerErrorServerOptions {
+  /** Override stdout writer (tests). */
+  write?: (chunk: string) => void;
+  /** Override the protocol version echoed in initialize (tests/compat). */
+  protocolVersion?: string;
+}
+
+type JsonRpcMessage = {
+  jsonrpc?: unknown;
+  id?: number | string | null;
+  method?: unknown;
+  params?: unknown;
+};
+
+export class DuplicateControllerErrorServer {
+  private readonly error: DuplicateControllerError;
+  private readonly writeOut: (chunk: string) => void;
+  private readonly protocolVersion: string;
+
+  constructor(error: DuplicateControllerError, options: DuplicateControllerErrorServerOptions = {}) {
+    this.error = error;
+    this.writeOut = options.write ?? ((chunk) => { process.stdout.write(chunk); });
+    this.protocolVersion = options.protocolVersion ?? '2024-11-05';
+  }
+
+  start(): void {
+    const rl = readline.createInterface({ input: process.stdin, terminal: false });
+    rl.on('line', (line) => {
+      for (const out of this.handleLine(line)) this.writeOut(out);
+    });
+    rl.on('close', () => process.exit(0));
+  }
+
+  /** Structured remediation payload reused for both the error and the tool. */
+  remediationData(): Record<string, unknown> {
+    const owner = this.error.owner;
+    return {
+      reason: 'duplicate_controller',
+      port: owner.port,
+      userDataDir: owner.userDataDir,
+      ownerPid: owner.pid,
+      ownerVersion: owner.version,
+      ownerCommand: owner.command,
+      lockPath: this.error.lockPath,
+      remediations: [
+        'Stop the existing OpenChrome MCP owner, then reconnect this session.',
+        'Or run one shared broker — `openchrome serve --broker --auto-launch ' +
+          `--port ${owner.port} --user-data-dir ${owner.userDataDir}` +
+          '` — and point every session at it with `serve --connect-broker`.',
+        'Or give this session a distinct --port and --user-data-dir.',
+      ],
+    };
+  }
+
+  private summaryMessage(): string {
+    const owner = this.error.owner;
+    return (
+      `OpenChrome is unavailable: another session (pid ${owner.pid}) already owns ` +
+      `Chrome on port ${owner.port} for profile ${owner.userDataDir}. ` +
+      'Use --connect-broker to share it, or a distinct --port/--user-data-dir.'
+    );
+  }
+
+  /** Pure line handler — returns serialized JSON-RPC frames to write. */
+  handleLine(line: string): string[] {
+    if (!line.trim()) return [];
+    let message: JsonRpcMessage;
+    try {
+      message = JSON.parse(line) as JsonRpcMessage;
+    } catch (err) {
+      return [serialize({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: MCPErrorCodes.PARSE_ERROR, message: err instanceof Error ? err.message : 'Parse error' },
+      })];
+    }
+    return this.handle(message).map(serialize);
+  }
+
+  private handle(message: JsonRpcMessage): Array<MCPResponse | Record<string, unknown>> {
+    const method = typeof message.method === 'string' ? message.method : '';
+    const hasId = message.id !== undefined && message.id !== null;
+    const id = (message.id ?? null) as number | string | null;
+
+    // Notifications (no id) get no reply — JSON-RPC §4.1.
+    if (!hasId) return [];
+
+    if (method === 'initialize') {
+      return [
+        {
+          jsonrpc: '2.0',
+          id,
+          result: {
+            protocolVersion: this.protocolVersion,
+            capabilities: { tools: { listChanged: false }, logging: {} },
+            serverInfo: { name: 'openchrome', version: getVersion() },
+          },
+        },
+        // Push the remediation as a logging notification so hosts that surface
+        // server logs show it immediately, before any tool call.
+        {
+          jsonrpc: '2.0',
+          method: 'notifications/message',
+          params: { level: 'error', logger: 'openchrome', data: this.summaryMessage() },
+        },
+      ];
+    }
+
+    if (method === 'tools/list') {
+      return [{
+        jsonrpc: '2.0',
+        id,
+        result: {
+          tools: [{
+            name: DIAGNOSTIC_TOOL_NAME,
+            description: this.summaryMessage(),
+            inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+          }],
+        },
+      }];
+    }
+
+    if (method === 'tools/call') {
+      // Return the remediation as a tool error (isError content), the standard
+      // shape a host renders for a failed tool.
+      return [{
+        jsonrpc: '2.0',
+        id,
+        result: {
+          isError: true,
+          content: [{ type: 'text', text: this.summaryMessage() }],
+          structuredContent: this.remediationData(),
+        },
+      }];
+    }
+
+    // Any other request: structured JSON-RPC error carrying the remediation.
+    return [{
+      jsonrpc: '2.0',
+      id,
+      error: {
+        code: DUPLICATE_CONTROLLER_ERROR_CODE,
+        message: this.summaryMessage(),
+        data: this.remediationData(),
+      },
+    }];
+  }
+}
+
+function serialize(frame: MCPResponse | Record<string, unknown>): string {
+  return JSON.stringify(frame) + '\n';
+}

--- a/src/transports/duplicate-controller-error-server.ts
+++ b/src/transports/duplicate-controller-error-server.ts
@@ -37,6 +37,18 @@ export interface DuplicateControllerErrorServerOptions {
   protocolVersion?: string;
   /** Override process exit (tests). */
   exit?: (code: number) => void;
+  /**
+   * If no `initialize` arrives within this window, exit(2) instead of hanging.
+   * Guards a non-MCP stdin that stays open but never speaks (e.g.
+   * `tail -f /dev/null | serve`). 0 disables. Default 10s.
+   */
+  initTimeoutMs?: number;
+}
+
+function parseEnvInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === '') return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
 }
 
 type JsonRpcMessage = {
@@ -51,6 +63,7 @@ export class DuplicateControllerErrorServer {
   private readonly writeOut: (chunk: string) => void;
   private readonly protocolVersion: string;
   private readonly exit: (code: number) => void;
+  private readonly initTimeoutMs: number;
   /** Whether a real MCP client completed `initialize` before stdin closed. */
   private sawInitialize = false;
 
@@ -59,14 +72,36 @@ export class DuplicateControllerErrorServer {
     this.writeOut = options.write ?? ((chunk) => { process.stdout.write(chunk); });
     this.protocolVersion = options.protocolVersion ?? '2024-11-05';
     this.exit = options.exit ?? ((code) => process.exit(code));
+    this.initTimeoutMs = options.initTimeoutMs
+      ?? parseEnvInt(process.env.OPENCHROME_DUPLICATE_RESPONDER_INIT_TIMEOUT_MS, 10_000);
   }
 
-  start(): void {
-    const rl = readline.createInterface({ input: process.stdin, terminal: false });
+  start(input: NodeJS.ReadableStream = process.stdin): void {
+    const rl = readline.createInterface({ input, terminal: false });
+
+    // A non-MCP stdin that stays open but never sends `initialize` (e.g.
+    // `tail -f /dev/null | serve`) would otherwise hang forever and never
+    // report the duplicate-controller refusal. Bound the wait: if no handshake
+    // arrives in time, exit(2). Unref'd so a real MCP client is unaffected.
+    let initTimer: NodeJS.Timeout | null = null;
+    if (this.initTimeoutMs > 0) {
+      initTimer = setTimeout(() => {
+        if (!this.sawInitialize) this.exit(2);
+      }, this.initTimeoutMs);
+      initTimer.unref?.();
+    }
+    const clearInitTimer = () => {
+      if (initTimer) { clearTimeout(initTimer); initTimer = null; }
+    };
+
     rl.on('line', (line) => {
       for (const out of this.handleLine(line)) this.writeOut(out);
+      if (this.sawInitialize) clearInitTimer();
     });
-    rl.on('close', () => this.exit(this.closeExitCode()));
+    rl.on('close', () => {
+      clearInitTimer();
+      this.exit(this.closeExitCode());
+    });
   }
 
   /**
@@ -140,7 +175,7 @@ export class DuplicateControllerErrorServer {
       const responses: Array<MCPResponse | Record<string, unknown>> = [];
       const serverNotifications: string[] = [];
       for (const item of parsed) {
-        for (const frame of this.handle(item as JsonRpcMessage)) {
+        for (const frame of this.handle(item)) {
           if ('id' in frame) responses.push(frame);
           else serverNotifications.push(serialize(frame)); // server notification → own line
         }
@@ -150,10 +185,22 @@ export class DuplicateControllerErrorServer {
       return out.concat(serverNotifications);
     }
 
-    return this.handle(parsed as JsonRpcMessage).map(serialize);
+    return this.handle(parsed).map(serialize);
   }
 
-  private handle(message: JsonRpcMessage): Array<MCPResponse | Record<string, unknown>> {
+  private handle(raw: unknown): Array<MCPResponse | Record<string, unknown>> {
+    // Valid JSON that is not a JSON-RPC object (null, number, string, boolean,
+    // or a nested array inside a batch) must yield an Invalid Request error —
+    // not a TypeError from `'id' in raw`, which would crash the process and
+    // drop the connection the responder exists to preserve.
+    if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+      return [{
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: MCPErrorCodes.INVALID_REQUEST, message: 'Invalid Request: expected a JSON-RPC object' },
+      }];
+    }
+    const message = raw as JsonRpcMessage;
     const method = typeof message.method === 'string' ? message.method : '';
     // JSON-RPC §4.1: a notification is a request WITHOUT an `id` member. An
     // explicit `id: null` is an unusual-but-valid request, so key off member

--- a/src/transports/duplicate-controller-error-server.ts
+++ b/src/transports/duplicate-controller-error-server.ts
@@ -35,6 +35,8 @@ export interface DuplicateControllerErrorServerOptions {
   write?: (chunk: string) => void;
   /** Override the protocol version echoed in initialize (tests/compat). */
   protocolVersion?: string;
+  /** Override process exit (tests). */
+  exit?: (code: number) => void;
 }
 
 type JsonRpcMessage = {
@@ -48,11 +50,15 @@ export class DuplicateControllerErrorServer {
   private readonly error: DuplicateControllerError;
   private readonly writeOut: (chunk: string) => void;
   private readonly protocolVersion: string;
+  private readonly exit: (code: number) => void;
+  /** Whether a real MCP client completed `initialize` before stdin closed. */
+  private sawInitialize = false;
 
   constructor(error: DuplicateControllerError, options: DuplicateControllerErrorServerOptions = {}) {
     this.error = error;
     this.writeOut = options.write ?? ((chunk) => { process.stdout.write(chunk); });
     this.protocolVersion = options.protocolVersion ?? '2024-11-05';
+    this.exit = options.exit ?? ((code) => process.exit(code));
   }
 
   start(): void {
@@ -60,7 +66,19 @@ export class DuplicateControllerErrorServer {
     rl.on('line', (line) => {
       for (const out of this.handleLine(line)) this.writeOut(out);
     });
-    rl.on('close', () => process.exit(0));
+    rl.on('close', () => this.exit(this.closeExitCode()));
+  }
+
+  /**
+   * Exit code to use when stdin closes. If a real MCP client handshook
+   * (`initialize` seen), the remediation was delivered and a clean disconnect
+   * is success (0). But a non-interactive launch with stdin already EOF — e.g.
+   * `serve --auto-launch </dev/null` from CI/systemd — closes without any
+   * handshake; that is still a refusal-to-start and MUST report failure (2),
+   * not a silent success (Codex P2, #1474).
+   */
+  closeExitCode(): number {
+    return this.sawInitialize ? 0 : 2;
   }
 
   /** Structured remediation payload reused for both the error and the tool. */
@@ -118,6 +136,7 @@ export class DuplicateControllerErrorServer {
     if (!hasId) return [];
 
     if (method === 'initialize') {
+      this.sawInitialize = true;
       return [
         {
           jsonrpc: '2.0',

--- a/src/transports/duplicate-controller-error-server.ts
+++ b/src/transports/duplicate-controller-error-server.ts
@@ -114,9 +114,9 @@ export class DuplicateControllerErrorServer {
   /** Pure line handler — returns serialized JSON-RPC frames to write. */
   handleLine(line: string): string[] {
     if (!line.trim()) return [];
-    let message: JsonRpcMessage;
+    let parsed: unknown;
     try {
-      message = JSON.parse(line) as JsonRpcMessage;
+      parsed = JSON.parse(line);
     } catch (err) {
       return [serialize({
         jsonrpc: '2.0',
@@ -124,15 +124,44 @@ export class DuplicateControllerErrorServer {
         error: { code: MCPErrorCodes.PARSE_ERROR, message: err instanceof Error ? err.message : 'Parse error' },
       })];
     }
-    return this.handle(message).map(serialize);
+
+    // JSON-RPC §6 batch: respond with an array of the per-request responses;
+    // request members that are notifications produce no response member. We
+    // also surface any server-originated notification (the logging frame from
+    // initialize) as its own line outside the batch array.
+    if (Array.isArray(parsed)) {
+      if (parsed.length === 0) {
+        return [serialize({
+          jsonrpc: '2.0',
+          id: null,
+          error: { code: MCPErrorCodes.INVALID_REQUEST, message: 'Invalid empty batch' },
+        })];
+      }
+      const responses: Array<MCPResponse | Record<string, unknown>> = [];
+      const serverNotifications: string[] = [];
+      for (const item of parsed) {
+        for (const frame of this.handle(item as JsonRpcMessage)) {
+          if ('id' in frame) responses.push(frame);
+          else serverNotifications.push(serialize(frame)); // server notification → own line
+        }
+      }
+      const out: string[] = [];
+      if (responses.length > 0) out.push(JSON.stringify(responses) + '\n');
+      return out.concat(serverNotifications);
+    }
+
+    return this.handle(parsed as JsonRpcMessage).map(serialize);
   }
 
   private handle(message: JsonRpcMessage): Array<MCPResponse | Record<string, unknown>> {
     const method = typeof message.method === 'string' ? message.method : '';
-    const hasId = message.id !== undefined && message.id !== null;
+    // JSON-RPC §4.1: a notification is a request WITHOUT an `id` member. An
+    // explicit `id: null` is an unusual-but-valid request, so key off member
+    // presence rather than null-ness (a null-check would drop the reply).
+    const hasId = 'id' in message;
     const id = (message.id ?? null) as number | string | null;
 
-    // Notifications (no id) get no reply — JSON-RPC §4.1.
+    // Notifications (no id member) get no reply — JSON-RPC §4.1.
     if (!hasId) return [];
 
     if (method === 'initialize') {
@@ -152,9 +181,23 @@ export class DuplicateControllerErrorServer {
         {
           jsonrpc: '2.0',
           method: 'notifications/message',
-          params: { level: 'error', logger: 'openchrome', data: this.summaryMessage() },
+          // MCP logging `data` is a structured, JSON-serializable value (the
+          // real server uses an object too), not a bare string.
+          params: {
+            level: 'error',
+            logger: 'openchrome',
+            data: { message: this.summaryMessage(), remediation: this.remediationData() },
+          },
         },
       ];
+    }
+
+    // MCP/JSON-RPC keepalive: a host that pings during or after initialize must
+    // get `{ result: {} }`. Returning the generic error here would make many
+    // hosts treat the connection as failed and disconnect before the user ever
+    // sees the remediation.
+    if (method === 'ping') {
+      return [{ jsonrpc: '2.0', id, result: {} }];
     }
 
     if (method === 'tools/list') {

--- a/tests/duplicate-controller-error-server.test.ts
+++ b/tests/duplicate-controller-error-server.test.ts
@@ -80,4 +80,16 @@ describe('DuplicateControllerErrorServer (#1474)', () => {
   test('blank lines are ignored', () => {
     expect(makeServer().handleLine('   ')).toEqual([]);
   });
+
+  test('exits with failure (2) when stdin closes without an MCP handshake', () => {
+    // e.g. `serve --auto-launch </dev/null` from CI/systemd: non-TTY, immediate
+    // EOF, no initialize. Must report refusal-to-start, not silent success.
+    expect(makeServer().closeExitCode()).toBe(2);
+  });
+
+  test('exits cleanly (0) after a real MCP client handshook and disconnected', () => {
+    const server = makeServer();
+    server.handleLine(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }));
+    expect(server.closeExitCode()).toBe(0);
+  });
 });

--- a/tests/duplicate-controller-error-server.test.ts
+++ b/tests/duplicate-controller-error-server.test.ts
@@ -1,3 +1,4 @@
+import { PassThrough } from 'stream';
 import {
   DUPLICATE_CONTROLLER_ERROR_CODE,
   DuplicateControllerErrorServer,
@@ -13,6 +14,7 @@ function makeServer(): DuplicateControllerErrorServer {
     port: 9222,
     userDataDir: '/home/u/.openchrome/profile',
     startedAt: '2026-06-05T00:00:00.000Z',
+    lastHeartbeatAt: '2026-06-05T00:00:00.000Z',
     hostname: 'host',
   };
   return new DuplicateControllerErrorServer(
@@ -75,6 +77,46 @@ describe('DuplicateControllerErrorServer (#1474)', () => {
   test('an empty batch is rejected as an invalid request', () => {
     const frames = parseFrames(makeServer(), '[]');
     expect(frames[0].error.code).toBe(-32600);
+  });
+
+  test('non-object JSON does not crash — returns Invalid Request', () => {
+    // valid JSON that is not a JSON-RPC object would make `'id' in message`
+    // throw a TypeError (process crash) without the guard.
+    for (const line of ['null', '5', '"hello"', 'true']) {
+      const frames = parseFrames(makeServer(), line);
+      expect(frames[0].error.code).toBe(-32600);
+      expect(frames[0].id).toBeNull();
+    }
+  });
+
+  test('a batch member that is a non-object yields an Invalid Request response', () => {
+    const out = makeServer().handleLine(JSON.stringify([1, { jsonrpc: '2.0', id: 2, method: 'ping' }]));
+    const batch = JSON.parse(out[0]);
+    expect(Array.isArray(batch)).toBe(true);
+    expect(batch.some((r: any) => r.error?.code === -32600)).toBe(true); // the bare `1`
+    expect(batch.some((r: any) => r.id === 2 && r.result)).toBe(true); // the ping
+  });
+
+  test('init-timeout exits(2) when an open non-MCP stdin never sends initialize', () => {
+    jest.useFakeTimers();
+    const input = new PassThrough(); // open, never emits a line, never closes
+    try {
+      const exit = jest.fn();
+      const owner: ControllerLockMetadata = {
+        pid: 1, command: [], version: 'x', cwd: '', port: 9222,
+        userDataDir: '/p', startedAt: 't', lastHeartbeatAt: 't', hostname: 'h',
+      };
+      const server = new DuplicateControllerErrorServer(
+        new DuplicateControllerError('/l', owner),
+        { exit, initTimeoutMs: 5_000 },
+      );
+      server.start(input);
+      jest.advanceTimersByTime(5_000);
+      expect(exit).toHaveBeenCalledWith(2);
+    } finally {
+      input.end();
+      jest.useRealTimers();
+    }
   });
 
   test('lists a single diagnostic tool that names the conflict', () => {

--- a/tests/duplicate-controller-error-server.test.ts
+++ b/tests/duplicate-controller-error-server.test.ts
@@ -38,8 +38,43 @@ describe('DuplicateControllerErrorServer (#1474)', () => {
     const note = frames.find((f) => f.method === 'notifications/message');
     expect(note).toBeDefined();
     expect(note.params.level).toBe('error');
-    expect(String(note.params.data)).toContain('another session');
+    // data is a structured object (spec), not a bare string.
+    expect(note.params.data.message).toContain('another session');
+    expect(note.params.data.remediation.reason).toBe('duplicate_controller');
     expect(note.id).toBeUndefined(); // notification has no id
+  });
+
+  test('responds to ping with an empty result (keepalive must not error)', () => {
+    const frames = parseFrames(makeServer(), JSON.stringify({ jsonrpc: '2.0', id: 7, method: 'ping' }));
+    expect(frames[0].id).toBe(7);
+    expect(frames[0].result).toEqual({});
+    expect(frames[0].error).toBeUndefined();
+  });
+
+  test('handles a JSON-RPC batch: array of responses + the server notification', () => {
+    const out = makeServer().handleLine(JSON.stringify([
+      { jsonrpc: '2.0', id: 1, method: 'initialize' },
+      { jsonrpc: '2.0', id: 2, method: 'ping' },
+      { jsonrpc: '2.0', method: 'notifications/initialized' }, // notification → no response member
+    ]));
+    const parsed = out.map((f) => JSON.parse(f));
+    const batch = parsed.find((f) => Array.isArray(f)) as any[] | undefined;
+    expect(batch).toBeDefined();
+    expect((batch as any[]).map((r: any) => r.id).sort()).toEqual([1, 2]); // only the two requests
+    // the server-originated logging notification is emitted as its own frame
+    expect(parsed.some((f) => !Array.isArray(f) && f.method === 'notifications/message')).toBe(true);
+  });
+
+  test('an explicit id:null request still gets a reply (not treated as a notification)', () => {
+    const frames = parseFrames(makeServer(), JSON.stringify({ jsonrpc: '2.0', id: null, method: 'resources/list' }));
+    expect(frames).toHaveLength(1);
+    expect(frames[0].id).toBeNull();
+    expect(frames[0].error.code).toBe(DUPLICATE_CONTROLLER_ERROR_CODE);
+  });
+
+  test('an empty batch is rejected as an invalid request', () => {
+    const frames = parseFrames(makeServer(), '[]');
+    expect(frames[0].error.code).toBe(-32600);
   });
 
   test('lists a single diagnostic tool that names the conflict', () => {

--- a/tests/duplicate-controller-error-server.test.ts
+++ b/tests/duplicate-controller-error-server.test.ts
@@ -1,0 +1,83 @@
+import {
+  DUPLICATE_CONTROLLER_ERROR_CODE,
+  DuplicateControllerErrorServer,
+} from '../src/transports/duplicate-controller-error-server';
+import { DuplicateControllerError, type ControllerLockMetadata } from '../src/utils/controller-lock';
+
+function makeServer(): DuplicateControllerErrorServer {
+  const owner: ControllerLockMetadata = {
+    pid: 95061,
+    command: ['node', 'dist/index.js', 'serve', '--auto-launch'],
+    version: '1.12.7',
+    cwd: '/home/u/repo',
+    port: 9222,
+    userDataDir: '/home/u/.openchrome/profile',
+    startedAt: '2026-06-05T00:00:00.000Z',
+    hostname: 'host',
+  };
+  return new DuplicateControllerErrorServer(
+    new DuplicateControllerError('/home/u/.openchrome/locks/port-9222.json', owner),
+  );
+}
+
+function parseFrames(server: DuplicateControllerErrorServer, line: string): any[] {
+  return server.handleLine(line).map((f) => JSON.parse(f));
+}
+
+describe('DuplicateControllerErrorServer (#1474)', () => {
+  test('completes the initialize handshake instead of failing it', () => {
+    const frames = parseFrames(makeServer(), JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }));
+    const init = frames.find((f) => f.id === 1);
+    expect(init.result.serverInfo.name).toBe('openchrome');
+    expect(init.result.protocolVersion).toBe('2024-11-05');
+    expect(init.error).toBeUndefined();
+  });
+
+  test('pushes a logging notification carrying the remediation after initialize', () => {
+    const frames = parseFrames(makeServer(), JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }));
+    const note = frames.find((f) => f.method === 'notifications/message');
+    expect(note).toBeDefined();
+    expect(note.params.level).toBe('error');
+    expect(String(note.params.data)).toContain('another session');
+    expect(note.id).toBeUndefined(); // notification has no id
+  });
+
+  test('lists a single diagnostic tool that names the conflict', () => {
+    const frames = parseFrames(makeServer(), JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }));
+    expect(frames[0].result.tools).toHaveLength(1);
+    expect(frames[0].result.tools[0].name).toBe('openchrome_owner_conflict');
+    expect(frames[0].result.tools[0].description).toContain('port 9222');
+  });
+
+  test('tools/call returns the remediation as a tool error with structured content', () => {
+    const frames = parseFrames(makeServer(), JSON.stringify({
+      jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'openchrome_owner_conflict' },
+    }));
+    expect(frames[0].result.isError).toBe(true);
+    expect(frames[0].result.content[0].text).toContain('another session');
+    expect(frames[0].result.structuredContent.reason).toBe('duplicate_controller');
+    expect(frames[0].result.structuredContent.remediations.join(' ')).toContain('--connect-broker');
+  });
+
+  test('other requests get a structured JSON-RPC error (not a bare code)', () => {
+    const frames = parseFrames(makeServer(), JSON.stringify({ jsonrpc: '2.0', id: 4, method: 'resources/list' }));
+    expect(frames[0].error.code).toBe(DUPLICATE_CONTROLLER_ERROR_CODE);
+    expect(frames[0].error.message).toContain('OpenChrome is unavailable');
+    expect(frames[0].error.data.ownerPid).toBe(95061);
+    expect(frames[0].error.data.lockPath).toContain('port-9222');
+  });
+
+  test('notifications (no id) get no reply', () => {
+    expect(makeServer().handleLine(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }))).toEqual([]);
+  });
+
+  test('malformed JSON yields a parse error with null id', () => {
+    const frames = parseFrames(makeServer(), '{not json');
+    expect(frames[0].id).toBeNull();
+    expect(frames[0].error.code).toBe(-32700);
+  });
+
+  test('blank lines are ignored', () => {
+    expect(makeServer().handleLine('   ')).toEqual([]);
+  });
+});


### PR DESCRIPTION
Supersedes #1479 after its stacked base branch was squash-merged and deleted.

## Goal
Return a structured MCP DuplicateController remediation response instead of surfacing only a bare `-32000` transport error.

## Final Implementation Scope
- Add the degraded duplicate-controller responder transport.
- Wire duplicate-controller remediation into the MCP entrypoint.
- Cover MCP and non-MCP stdin behavior, malformed input handling, and failure-exit preservation.

## Success Criteria
- MCP clients receive actionable duplicate-controller remediation metadata.
- Non-MCP/stdin error behavior remains failure-preserving.
- The branch diff is limited to observability/remediation transport code and tests.

## Verification Method
- Local targeted test: `npx jest tests/duplicate-controller-error-server.test.ts --runInBand`.
- Source build: `npm run build:src`.
- GitHub CI must pass before merge.

## Guardrails
- No controller-lock ownership semantics are changed here.
- No auto-election behavior is introduced here.
- No broad transport rewrite or protocol expansion beyond the duplicate-controller degraded responder.

## Explicit Non-Goals
- Broker auto-election.
- Owner self-release logic.
- Cross-process lock takeover policy changes.

## Implementation Approach
Keep the remediation path isolated in a dedicated duplicate-controller error server and call it only from the duplicate-controller failure path.

## PR Decomposition
This is the observability/remediation layer after #1478 and before the #1480 auto-election stack.

## Over-Engineering Checklist
- No new dependency.
- No new long-lived abstraction outside the degraded responder boundary.
- Tests cover behavior instead of implementation internals where possible.

## Drift-Prevention Checklist
- Rebased onto current `develop` after #1478 was squash-merged.
- Net diff checked against `origin/develop`.
- Descendant PRs must be retargeted only after this PR lands.

## Language Boundary
User-facing remediation copy is English and limited to MCP duplicate-controller remediation.

## Critical Risk Review
Main risk is breaking MCP protocol correctness on the degraded path; covered by protocol-focused tests and source build.

## Definition of Done
- Local targeted tests pass.
- Source build passes.
- GitHub CI green.
- Squash-merged into `develop` before S2/S3/S4 descendants are retargeted.
