### PR TITLE
feat(broker): auto-elect lock winner as broker owner

### DIFF
--- a/src/broker/auto-elect.ts
+++ b/src/broker/auto-elect.ts
@@ -1,0 +1,87 @@
+/**
+ * Auto-elect coordinated sharing (#1480; SSOT decision D3 Q1′).
+ *
+ * Pure, side-effect-free decision helpers for the default `serve --auto-launch`
+ * election path:
+ *
+ *   - the process that WINS the controller lock becomes the broker OWNER and
+ *     publishes broker discovery metadata (so surplus sessions can attach);
+ *   - a process that LOSES to a healthy owner becomes a coordinated CLIENT
+ *     (`--connect-broker` proxy) instead of failing fast.
+ *
+ * The behavior is gated behind an explicit opt-in (`--auto-elect` /
+ * `OPENCHROME_AUTO_ELECT=1`). With the flag unset, the default path is byte-for-
+ * byte unchanged (fail-fast single owner), so this module's wiring has zero blast
+ * radius until an operator opts in. See docs/roadmap/ssot-decisions.md (D3 Q1′)
+ * for the policy and the eventual default-flip plan.
+ *
+ * Keeping the decisions here (rather than inline in src/index.ts) makes the
+ * election rules unit-testable without booting a server or Chrome.
+ */
+
+/** Offset from the CDP port used for the elected owner's broker HTTP endpoint. */
+export const BROKER_HTTP_PORT_OFFSET = 200;
+
+/**
+ * Is auto-elect enabled for this process?
+ *
+ * True when the operator passed `--auto-elect` or set `OPENCHROME_AUTO_ELECT=1`.
+ */
+export function isAutoElectEnabled(
+  opts: { autoElect?: boolean },
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return Boolean(opts.autoElect) || env.OPENCHROME_AUTO_ELECT === '1';
+}
+
+/**
+ * Should the lock WINNER elect itself as the broker owner (publish a broker so
+ * losers can attach)?
+ *
+ * Only when auto-elect is on, this process owns Chrome lifecycle (`--auto-launch`),
+ * and the operator did not already pick an explicit role. Explicit `--broker` /
+ * `--connect-broker` always win over auto-elect — auto-elect never overrides a
+ * deliberate operator choice.
+ */
+export function shouldElectBrokerOwner(params: {
+  autoElect: boolean;
+  autoLaunch: boolean;
+  manualBroker: boolean;
+  connectBroker: boolean;
+}): boolean {
+  return (
+    params.autoElect &&
+    params.autoLaunch &&
+    !params.manualBroker &&
+    !params.connectBroker
+  );
+}
+
+/**
+ * Should a process that LOST the controller lock attach as a coordinated client
+ * rather than fail fast?
+ *
+ * Only when auto-elect is on AND a broker is actually discoverable for this
+ * `(port, userDataDir)` — i.e. the healthy owner is itself an auto-elect/broker
+ * owner. If the owner is a plain direct controller (no broker published), there
+ * is nothing to attach to and the caller must fall back to the normal
+ * duplicate-controller remediation.
+ */
+export function shouldClientAutoConnect(params: {
+  autoElect: boolean;
+  brokerPresent: boolean;
+}): boolean {
+  return params.autoElect && params.brokerPresent;
+}
+
+/**
+ * The default broker HTTP port for an auto-elected owner on a given CDP port.
+ *
+ * Deterministic (`cdpPort + 200`, e.g. 9222 → 9422) so it is predictable and
+ * clear of the headed-fallback offset (`+100`). Operators can still override via
+ * `--http`/`OPENCHROME_HTTP_PORT`; clients never rely on this value directly —
+ * they read the actual endpoint from the published broker metadata.
+ */
+export function defaultBrokerHttpPort(cdpPort: number): number {
+  return cdpPort + BROKER_HTTP_PORT_OFFSET;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -707,9 +707,13 @@ program
     // tenant trust still requires explicit auth per D3 Q6.
     const effectiveHttpHost = (options as Record<string, unknown>).httpHost as string || process.env.OPENCHROME_HTTP_HOST || '127.0.0.1';
     const brokerHostIsLoopback = effectiveHttpHost === '127.0.0.1' || effectiveHttpHost === 'localhost' || effectiveHttpHost === '::1';
-    const allowUnauthenticatedHttp = options.allowUnauthenticatedHttp
+    const explicitAllowUnauthenticatedHttp = options.allowUnauthenticatedHttp
+      || process.env.OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP === '1'
+      || process.env.OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP === 'true'
+      || process.env.OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP === 'yes';
+    const allowUnauthenticatedHttp = explicitAllowUnauthenticatedHttp
       || (electBrokerOwner && !authToken && brokerHostIsLoopback);
-    if (electBrokerOwner && !authToken && brokerHostIsLoopback && !options.allowUnauthenticatedHttp) {
+    if (electBrokerOwner && !authToken && brokerHostIsLoopback && !explicitAllowUnauthenticatedHttp) {
       console.error('[openchrome] auto-elect: broker HTTP leg is loopback-only and unauthenticated (no token configured).');
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import {
 } from './utils/controller-lock';
 import { fetchJsonVersion } from './chrome/devtools-info';
 import { getCurrentControllerTopology } from './utils/duplicate-controller-diagnostics';
+import { isAutoElectEnabled, shouldElectBrokerOwner, defaultBrokerHttpPort } from './broker/auto-elect';
 import {
   DEFAULT_PROCESS_WATCHDOG_INTERVAL_MS,
   DEFAULT_TAB_HEALTH_PROBE_INTERVAL_MS,
@@ -120,6 +121,7 @@ program
   .option('--transport <mode>', 'Transport mode: stdio, http, or both (default: stdio)')
   .option('--broker', 'Run as the shared-profile broker owner (HTTP daemon plus broker discovery metadata)')
   .option('--connect-broker', 'Proxy stdio MCP requests to the discovered broker instead of attaching to Chrome directly')
+  .option('--auto-elect', 'Coordinated sharing (#1480): the --auto-launch process that wins the controller lock becomes the broker owner and surplus sessions auto-attach as clients instead of failing fast. Also: OPENCHROME_AUTO_ELECT=1. Off by default.')
   .option('--idle-timeout <duration>', 'Self-exit (code 0) after idle window with zero sessions. Format: <number>(ms|s|m|h), e.g. 30m, 90s, 500ms. Bare numbers are rejected. Also: OPENCHROME_IDLE_TIMEOUT_MS env var (integer ms). Default: disabled.')
   .option('--pilot', 'Enable experimental pilot tier (see docs/roadmap/portability-harness-contract.md). Off by default; lazy-loads src/pilot/ modules when set. Also: OPENCHROME_PILOT=1 env var.')
   .option('--slim', 'Expose only core tools (alias for --tools-only core).')
@@ -130,7 +132,7 @@ program
   .option('--launch-mode <mode>', 'Chrome launch mode: auto | attach | isolated (#659). Also: OPENCHROME_LAUNCH_MODE env var.')
   .option('--secrets <path>', 'Load a dotenv-format secrets file (KEY=value per line). Tokens "${SECRET:NAME}" in tool arguments are substituted to the real value at MCP request deserialization; the same values are redacted from every LLM-visible artifact (responses, trace, skill records, journal). Default: no secrets loaded. P3: no OS keychain integration.')
   .option('--codegen <mode>', 'Opt-in replay artifact generation: off, puppeteer, playwright, or mcp-replay. Default: off (no response shape changes). Also: OPENCHROME_CODEGEN.')
-  .action(async (options: { port: string; autoLaunch?: boolean; allowUnsafeSharedAttach?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; windowSize?: string; windowPosition?: string; windowBounds?: string; startMaximized?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; broker?: boolean; connectBroker?: boolean; idleTimeout?: string; allowUnauthenticatedHttp?: boolean; pilot?: boolean; slim?: boolean; toolsOnly?: string; disableTools?: string; introspectToolsList?: boolean; autoConnect?: string | boolean; launchMode?: string; secrets?: string; codegen?: string }) => {
+  .action(async (options: { port: string; autoLaunch?: boolean; allowUnsafeSharedAttach?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; windowSize?: string; windowPosition?: string; windowBounds?: string; startMaximized?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; broker?: boolean; connectBroker?: boolean; autoElect?: boolean; idleTimeout?: string; allowUnauthenticatedHttp?: boolean; pilot?: boolean; slim?: boolean; toolsOnly?: string; disableTools?: string; introspectToolsList?: boolean; autoConnect?: string | boolean; launchMode?: string; secrets?: string; codegen?: string }) => {
     const { normalizeCodegenMode, setCodegenMode } = await import('./core/codegen');
     const codegenMode = normalizeCodegenMode(options.codegen ?? process.env.OPENCHROME_CODEGEN);
     setCodegenMode(codegenMode);
@@ -267,6 +269,19 @@ program
       process.exit(2);
     }
 
+    // #1480 auto-elect (D3 Q1′): the --auto-launch lock winner elects itself the
+    // broker owner so surplus sessions attach as coordinated clients instead of
+    // failing fast. Opt-in (off by default) — when disabled, every branch below
+    // is byte-for-byte the prior fail-fast behavior. Explicit --broker/
+    // --connect-broker always take precedence over auto-elect.
+    const autoElect = isAutoElectEnabled(options);
+    const electBrokerOwner = shouldElectBrokerOwner({
+      autoElect,
+      autoLaunch,
+      manualBroker: Boolean(options.broker),
+      connectBroker: Boolean(options.connectBroker),
+    });
+
     // Resolve transport mode before owner-lock acquisition so lock metadata
     // describes whether this process is a stdio, HTTP, or dual-transport owner.
     const validModes = ['stdio', 'http', 'both'];
@@ -278,7 +293,11 @@ program
     }
     const rawMode = options.broker
       ? 'http'
-      : options.transport ?? process.env.OPENCHROME_TRANSPORT ?? (options.http !== undefined && options.http !== false ? 'http' : 'stdio');
+      // An elected owner serves its own host over stdio AND exposes the broker
+      // over HTTP, so it needs dual transport.
+      : electBrokerOwner
+        ? 'both'
+        : options.transport ?? process.env.OPENCHROME_TRANSPORT ?? (options.http !== undefined && options.http !== false ? 'http' : 'stdio');
     if (!validModes.includes(rawMode)) {
       console.error(`[openchrome] Unknown transport mode "${rawMode}", falling back to stdio`);
     }
@@ -705,7 +724,13 @@ program
 
     if (transportMode === 'both') {
       // Dual mode: run both stdio and HTTP transports simultaneously
-      const httpPort = typeof options.http === 'string' ? parseInt(options.http, 10) : parseInt(process.env.OPENCHROME_HTTP_PORT || '', 10) || 3100;
+      // #1480: an auto-elected owner with no explicit --http uses a deterministic
+      // broker port (cdpPort + 200) instead of the shared 3100 default, so two
+      // owners on different profiles don't collide on one HTTP port.
+      const httpPort = typeof options.http === 'string'
+        ? parseInt(options.http, 10)
+        : parseInt(process.env.OPENCHROME_HTTP_PORT || '', 10)
+          || (electBrokerOwner ? defaultBrokerHttpPort(port) : 3100);
       const httpHost = (options as Record<string, unknown>).httpHost as string || process.env.OPENCHROME_HTTP_HOST || '127.0.0.1';
       const { HTTPTransport } = require('./transports/http');
       const httpTrans = new HTTPTransport(
@@ -729,13 +754,15 @@ program
 
       console.error(`[openchrome] Dual transport mode: stdio + HTTP on ${httpHost}:${httpPort}`);
       console.error('[openchrome] Infinite reconnection: enabled (daemon mode)');
-      if (options.broker) {
+      // Publish broker discovery for an explicit --broker owner OR an auto-elected
+      // owner (#1480), so surplus sessions can find and attach to this owner.
+      if (options.broker || electBrokerOwner) {
         const { publishBrokerMetadata, removeBrokerMetadata } = await import('./broker/discovery');
         const { setBrokerOwnerMode, recordBrokerStopped } = await import('./broker/lifecycle');
         setBrokerOwnerMode(true);
         const metadata = publishBrokerMetadata({ port, userDataDir: lockUserDataDir, httpHost, httpPort, authTokenEnv: brokerAuthTokenEnv });
         process.on('exit', () => { recordBrokerStopped(); removeBrokerMetadata(port, lockUserDataDir); });
-        console.error(`[openchrome] Broker metadata: ${metadata.endpoint}`);
+        console.error(`[openchrome] Broker metadata: ${metadata.endpoint}${electBrokerOwner ? ' (auto-elected)' : ''}`);
       }
     } else if (useHttp) {
       const httpPort = typeof options.http === 'string' ? parseInt(options.http, 10) : parseInt(process.env.OPENCHROME_HTTP_PORT || '', 10) || 3100;

--- a/src/index.ts
+++ b/src/index.ts
@@ -696,7 +696,22 @@ program
     if (authToken) {
       console.error('[openchrome] Bearer token authentication: enabled');
     }
-    const allowUnauthenticatedHttp = options.allowUnauthenticatedHttp;
+    // #1480 S2: an auto-elected owner exposes the broker over a loopback HTTP
+    // endpoint for same-user local sharing. There is no operator to supply a
+    // bearer token (this is zero-config), and a cross-process auto-generated
+    // token cannot be advertised via `authTokenEnv` (the client process would
+    // not inherit it). So, only when electing AND no token is configured AND the
+    // broker binds loopback, allow the unauthenticated loopback HTTP leg — the
+    // same posture as OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP=1. Non-loopback
+    // (--http-host 0.0.0.0) or any explicit token keeps auth mandatory; cross-
+    // tenant trust still requires explicit auth per D3 Q6.
+    const effectiveHttpHost = (options as Record<string, unknown>).httpHost as string || process.env.OPENCHROME_HTTP_HOST || '127.0.0.1';
+    const brokerHostIsLoopback = effectiveHttpHost === '127.0.0.1' || effectiveHttpHost === 'localhost' || effectiveHttpHost === '::1';
+    const allowUnauthenticatedHttp = options.allowUnauthenticatedHttp
+      || (electBrokerOwner && !authToken && brokerHostIsLoopback);
+    if (electBrokerOwner && !authToken && brokerHostIsLoopback && !options.allowUnauthenticatedHttp) {
+      console.error('[openchrome] auto-elect: broker HTTP leg is loopback-only and unauthenticated (no token configured).');
+    }
 
     // Multi-tenant API key store: when OPENCHROME_API_KEYS_PATH points at a
     // JSONL store file, load it and pass it to the HTTP transport so

--- a/tests/auto-elect.test.ts
+++ b/tests/auto-elect.test.ts
@@ -1,0 +1,84 @@
+/// <reference types="jest" />
+/**
+ * Unit tests for the auto-elect decision helpers (#1480, D3 Q1′).
+ *
+ * These lock the election rules that src/index.ts wires into the
+ * `serve --auto-launch` path, without booting a server or Chrome.
+ */
+
+import {
+  isAutoElectEnabled,
+  shouldElectBrokerOwner,
+  shouldClientAutoConnect,
+  defaultBrokerHttpPort,
+  BROKER_HTTP_PORT_OFFSET,
+} from '../src/broker/auto-elect';
+
+describe('isAutoElectEnabled', () => {
+  test('false by default (no flag, no env)', () => {
+    expect(isAutoElectEnabled({}, {})).toBe(false);
+  });
+
+  test('true when --auto-elect flag set', () => {
+    expect(isAutoElectEnabled({ autoElect: true }, {})).toBe(true);
+  });
+
+  test('true when OPENCHROME_AUTO_ELECT=1', () => {
+    expect(isAutoElectEnabled({}, { OPENCHROME_AUTO_ELECT: '1' })).toBe(true);
+  });
+
+  test('env values other than "1" do not enable', () => {
+    expect(isAutoElectEnabled({}, { OPENCHROME_AUTO_ELECT: 'true' })).toBe(false);
+    expect(isAutoElectEnabled({}, { OPENCHROME_AUTO_ELECT: '0' })).toBe(false);
+  });
+});
+
+describe('shouldElectBrokerOwner', () => {
+  const base = { autoElect: true, autoLaunch: true, manualBroker: false, connectBroker: false };
+
+  test('elects when auto-elect + auto-launch and no explicit role', () => {
+    expect(shouldElectBrokerOwner(base)).toBe(true);
+  });
+
+  test('does not elect when auto-elect is off', () => {
+    expect(shouldElectBrokerOwner({ ...base, autoElect: false })).toBe(false);
+  });
+
+  test('does not elect without --auto-launch (no Chrome ownership)', () => {
+    expect(shouldElectBrokerOwner({ ...base, autoLaunch: false })).toBe(false);
+  });
+
+  test('explicit --broker takes precedence over auto-elect', () => {
+    expect(shouldElectBrokerOwner({ ...base, manualBroker: true })).toBe(false);
+  });
+
+  test('explicit --connect-broker takes precedence over auto-elect', () => {
+    expect(shouldElectBrokerOwner({ ...base, connectBroker: true })).toBe(false);
+  });
+});
+
+describe('shouldClientAutoConnect', () => {
+  test('connects only when auto-elect is on and a broker is discoverable', () => {
+    expect(shouldClientAutoConnect({ autoElect: true, brokerPresent: true })).toBe(true);
+  });
+
+  test('does not connect when no broker is published (plain direct owner)', () => {
+    expect(shouldClientAutoConnect({ autoElect: true, brokerPresent: false })).toBe(false);
+  });
+
+  test('does not connect when auto-elect is off', () => {
+    expect(shouldClientAutoConnect({ autoElect: false, brokerPresent: true })).toBe(false);
+  });
+});
+
+describe('defaultBrokerHttpPort', () => {
+  test('is cdpPort + offset', () => {
+    expect(defaultBrokerHttpPort(9222)).toBe(9222 + BROKER_HTTP_PORT_OFFSET);
+    expect(defaultBrokerHttpPort(9222)).toBe(9422);
+  });
+
+  test('clears the headed-fallback offset (+100)', () => {
+    // The fallback uses +100 (9322); the broker must not collide with it.
+    expect(defaultBrokerHttpPort(9222)).not.toBe(9222 + 100);
+  });
+});


### PR DESCRIPTION
Supersedes #1484 after its stacked base PR was squash-merged and the base branch was deleted.

## Goal
Implement #1480 S2: let the `--auto-launch` lock winner automatically become the local broker owner.

## Final Implementation Scope
- Add broker auto-election helper logic.
- Wire auto-election into the MCP server startup path.
- Add regression coverage for owner election and loopback unauthenticated HTTP for the auto-elected owner.

## Success Criteria
- A lock winner can start/own the broker without manual broker setup.
- Losing/duplicate controller behavior remains outside this PR's scope.
- The diff remains limited to S2 auto-election owner behavior.

## Verification Method
- Local targeted test: `npx jest tests/auto-elect.test.ts --runInBand`.
- Source build: `npm run build:src`.
- GitHub CI must pass before merge.

## Guardrails
- No client-side loser attach logic here; that is S3.
- No broker-owner death re-election here; that is S4.
- No changes to DuplicateController remediation semantics beyond consuming the already-merged base.

## Explicit Non-Goals
- Multi-controller sharing after the owner is already running.
- Re-election after broker loss.
- Broad auth model changes outside loopback behavior needed for the elected owner.

## Implementation Approach
Keep auto-election isolated in `src/broker/auto-elect.ts` and perform minimal wiring in `src/index.ts`.

## PR Decomposition
This is S2 of the #1480 stack and should merge before S3 and S4.

## Over-Engineering Checklist
- No new dependency.
- No generalized broker lifecycle manager.
- Only the owner-election path is added.

## Drift-Prevention Checklist
- Rebased onto current `develop` after #1493 was squash-merged.
- Net diff checked against `origin/develop`.
- S3/S4 descendants must be rebased after this PR lands.

## Language Boundary
No user-facing language expansion beyond necessary diagnostics/wiring.

## Critical Risk Review
Main risks are accidentally widening unauthenticated HTTP and changing non-auto-launch behavior. Tests cover auto-election and keep the feature scoped to the intended path.

## Definition of Done
- Local targeted tests pass.
- Source build passes.
- GitHub CI green.
- Squash-merged into `develop` before S3/S4 are retargeted.
