### PR TITLE
feat(broker): auto-elect loser attaches to owner broker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ import {
 } from './utils/controller-lock';
 import { fetchJsonVersion } from './chrome/devtools-info';
 import { getCurrentControllerTopology } from './utils/duplicate-controller-diagnostics';
-import { isAutoElectEnabled, shouldElectBrokerOwner, defaultBrokerHttpPort } from './broker/auto-elect';
+import { isAutoElectEnabled, shouldElectBrokerOwner, shouldClientAutoConnect, defaultBrokerHttpPort } from './broker/auto-elect';
 import {
   DEFAULT_PROCESS_WATCHDOG_INTERVAL_MS,
   DEFAULT_TAB_HEALTH_PROBE_INTERVAL_MS,
@@ -356,17 +356,42 @@ program
           if (err instanceof DuplicateControllerError) {
             // Always emit the full diagnostic to stderr (CLI/operator path).
             console.error(formatDuplicateControllerMessage(err));
+
+            // #1480 S3: auto-elect loser attaches to the healthy owner's broker
+            // instead of failing fast. The owner may have only just won the lock
+            // (this collision is the race), so poll briefly for its broker
+            // discovery metadata before giving up. If a broker is found, become a
+            // coordinated --connect-broker client; the previously-rejected surplus
+            // session now works.
+            if (autoElect) {
+              const { readBrokerMetadata } = await import('./broker/discovery');
+              const { BrokerProxyStdioBridge } = await import('./transports/broker-proxy');
+              let broker = readBrokerMetadata(port, lockUserDataDir);
+              for (let i = 0; i < 10 && !broker; i++) {
+                await new Promise((r) => setTimeout(r, 300));
+                broker = readBrokerMetadata(port, lockUserDataDir);
+              }
+              if (broker && shouldClientAutoConnect({ autoElect, brokerPresent: true })) {
+                const resolvedAuthToken = options.authToken
+                  || process.env.OPENCHROME_AUTH_TOKEN
+                  || (broker.authTokenEnv ? process.env[broker.authTokenEnv] : undefined);
+                console.error(`[openchrome] auto-elect: attaching as broker client -> ${broker.endpoint}`);
+                new BrokerProxyStdioBridge(broker, resolvedAuthToken).start();
+                return;
+              }
+              console.error('[openchrome] auto-elect: owner holds the lock but published no broker; falling back to duplicate-controller remediation.');
+            }
+
             // #1474: when launched by an MCP host over stdio, exiting before the
             // handshake makes the host discard stderr and show only `-32000`.
             // Instead complete `initialize` and surface the remediation through
             // MCP. A human running this in a terminal (TTY) keeps the old
             // exit(2) so the command does not hang waiting on stdin.
             //
-            // Scope: stdio only. `--transport both`/`http` daemons keep the
-            // hard exit(2) — the responder speaks stdio, and surfacing this over
-            // the HTTP leg would need a separate HTTP error path (out of scope;
-            // such daemons typically use --connect-broker, not --auto-launch).
-            if (transportMode === 'stdio' && !process.stdin.isTTY) {
+            // An auto-elect loser that found no broker is also a stdio host
+            // session (the elected owner serves stdio to its own host); surface
+            // the MCP error to it too rather than a bare exit(2).
+            if ((transportMode === 'stdio' || autoElect) && !process.stdin.isTTY) {
               const { DuplicateControllerErrorServer } = await import('./transports/duplicate-controller-error-server');
               new DuplicateControllerErrorServer(err).start();
               return;


### PR DESCRIPTION
Supersedes #1485 after S2 was squash-merged and its feature branch was deleted.

## Goal
Implement #1480 S3: when auto-elect is enabled, surplus/lost-lock controllers should attach to the elected owner's broker instead of failing as duplicate controllers.

## Final Implementation Scope
- Extend startup flow so auto-elect losers discover and connect to the elected owner broker.
- Keep the change in the MCP server entrypoint wiring only.
- Preserve the already-merged S2 owner election behavior as the base.

## Success Criteria
- Auto-elect loser path uses broker discovery/connection instead of surfacing a duplicate-controller failure.
- Explicit `--broker`, `--connect-broker`, and non-auto-elect paths retain their existing precedence.
- Net diff remains limited to S3 client auto-connect wiring.

## Verification Method
- Local targeted tests: `npx jest tests/auto-elect.test.ts --runInBand`.
- Source build: `npm run build:src`.
- GitHub CI must pass before merge.

## Guardrails
- No S4 re-election behavior in this PR.
- No broker owner death handling here.
- No broad broker lifecycle rewrite.
- No auth-policy changes beyond consuming the S2 base.

## Explicit Non-Goals
- Re-election after broker-owner crash.
- Stale broker metadata cleanup.
- Changing manual broker/client semantics.

## Implementation Approach
Reuse the broker discovery decision points and keep S3 as a thin startup-flow extension after S2 owner election.

## PR Decomposition
This is S3 of the #1480 stack. It should merge after S2 (#1494) and before S4 (#1486 replacement/retarget).

## Over-Engineering Checklist
- No new dependency.
- No new broker manager abstraction.
- No protocol expansion.
- One-file net diff after rebase.

## Drift-Prevention Checklist
- Rebased onto current `develop` after #1494 squash-merge.
- Net diff checked against `origin/develop`.
- S4 must be rebased after this PR lands.

## Language Boundary
No new user-facing copy beyond existing startup diagnostics/remediation behavior.

## Critical Risk Review
Main risk is precedence drift: explicit broker/client flags must still beat auto-elect. S2 targeted tests cover the core election predicates; this PR keeps the change localized to startup wiring.

## Definition of Done
- Local targeted test passes.
- Source build passes.
- GitHub CI green.
- Squash-merged into `develop` before S4 is retargeted.
