### PR TITLE
feat(broker): re-elect when broker owner dies

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -376,7 +376,9 @@ program
                   || process.env.OPENCHROME_AUTH_TOKEN
                   || (broker.authTokenEnv ? process.env[broker.authTokenEnv] : undefined);
                 console.error(`[openchrome] auto-elect: attaching as broker client -> ${broker.endpoint}`);
-                new BrokerProxyStdioBridge(broker, resolvedAuthToken).start();
+                // #1480 S4: re-elect if this owner later dies (host respawns →
+                // a survivor wins the lock and becomes the new owner; no SPOF).
+                new BrokerProxyStdioBridge(broker, { authToken: resolvedAuthToken, reElectOnBrokerLoss: true }).start();
                 return;
               }
               console.error('[openchrome] auto-elect: owner holds the lock but published no broker; falling back to duplicate-controller remediation.');

--- a/src/transports/broker-proxy.ts
+++ b/src/transports/broker-proxy.ts
@@ -1,6 +1,15 @@
 import * as readline from 'readline';
 import type { BrokerMetadata } from '../broker/discovery';
+import { readBrokerMetadata } from '../broker/discovery';
 import { MCPErrorCodes, MCPResponse } from '../types/mcp';
+
+/**
+ * Exit code a re-electing client uses when it detects its broker owner has died.
+ * The MCP host respawns the stdio server, which re-runs the controller-lock
+ * election (#1480 S2/S3) and — with the old owner gone — typically wins and
+ * becomes the new owner, removing the single-point-of-failure (#1480 S4).
+ */
+export const BROKER_REELECT_EXIT_CODE = 75;
 
 const MCP_SESSION_ID_HEADER = 'Mcp-Session-Id';
 export const BROKER_CLIENT_ID_HEADER = 'X-OpenChrome-Broker-Client-Id';
@@ -15,6 +24,17 @@ export interface BrokerProxyOptions {
   fetchImpl?: typeof fetch;
   /** Override stdout writer (tests). */
   write?: (chunk: string) => void;
+  /**
+   * #1480 S4: when the broker owner dies, re-elect instead of returning errors
+   * forever. Off by default (manual `--connect-broker` daemons keep the prior
+   * behavior); the auto-elect client path (S3) turns it on. When on, a confirmed
+   * broker loss calls `onBrokerLost`.
+   */
+  reElectOnBrokerLoss?: boolean;
+  /** Action on confirmed broker loss. Defaults to `process.exit(75)`. */
+  onBrokerLost?: () => void;
+  /** Override broker-metadata reader (tests). */
+  readBrokerMetadataImpl?: (port: number, userDataDir: string) => BrokerMetadata | null;
 }
 
 export class BrokerProxyStdioBridge {
@@ -24,6 +44,10 @@ export class BrokerProxyStdioBridge {
   private readonly clientId: string;
   private readonly tenantId?: string;
   private readonly writeOut: (chunk: string) => void;
+  private readonly reElectOnBrokerLoss: boolean;
+  private readonly onBrokerLost: () => void;
+  private readonly readBrokerMetadataImpl: (port: number, userDataDir: string) => BrokerMetadata | null;
+  private brokerLostHandled = false;
   private mcpSessionId?: string;
 
   constructor(broker: BrokerMetadata, authTokenOrOptions?: string | BrokerProxyOptions) {
@@ -36,6 +60,9 @@ export class BrokerProxyStdioBridge {
     this.tenantId = options.tenantId ?? process.env.OPENCHROME_TENANT_ID;
     this.fetchImpl = options.fetchImpl ?? fetch;
     this.writeOut = options.write ?? ((chunk) => { process.stdout.write(chunk); });
+    this.reElectOnBrokerLoss = options.reElectOnBrokerLoss ?? false;
+    this.onBrokerLost = options.onBrokerLost ?? (() => process.exit(BROKER_REELECT_EXIT_CODE));
+    this.readBrokerMetadataImpl = options.readBrokerMetadataImpl ?? readBrokerMetadata;
   }
 
   start(): void {
@@ -45,6 +72,33 @@ export class BrokerProxyStdioBridge {
       void this.forwardLine(line);
     });
     rl.on('close', () => process.exit(0));
+
+    // #1480 S4: idle clients should re-elect promptly when the owner dies, not
+    // only on the next request. Poll the broker discovery file periodically;
+    // unref so this timer never keeps the process alive on its own.
+    if (this.reElectOnBrokerLoss) {
+      const timer = setInterval(() => {
+        if (this.isBrokerGone()) this.handleBrokerLost();
+      }, 5000);
+      timer.unref?.();
+    }
+  }
+
+  /**
+   * Has the broker owner this client attached to gone away? True when the
+   * discovery file is absent or now describes a different owner (pid/endpoint),
+   * i.e. a clean owner exit or a replacement. Exposed for tests.
+   */
+  isBrokerGone(): boolean {
+    const latest = this.readBrokerMetadataImpl(this.broker.port, this.broker.userDataDir);
+    return !latest || latest.endpoint !== this.broker.endpoint || latest.pid !== this.broker.pid;
+  }
+
+  private handleBrokerLost(): void {
+    if (this.brokerLostHandled) return;
+    this.brokerLostHandled = true;
+    console.error('[openchrome] auto-elect: broker owner is gone; re-electing (host will respawn this session).');
+    this.onBrokerLost();
   }
 
   /** Exposed for tests. */
@@ -100,6 +154,14 @@ export class BrokerProxyStdioBridge {
         this.writeOut(payload.trimEnd() + '\n');
       }
     } catch (err) {
+      // #1480 S4: a forwarding failure can be a transient hiccup or the owner
+      // dying. Distinguish via the discovery file: if the broker is gone,
+      // re-elect instead of returning errors forever. Otherwise surface the
+      // transient error as before.
+      if (this.reElectOnBrokerLoss && this.isBrokerGone()) {
+        this.handleBrokerLost();
+        return;
+      }
       this.writeResponse({
         jsonrpc: '2.0',
         id: extractId(parsed),

--- a/src/transports/broker-proxy.ts
+++ b/src/transports/broker-proxy.ts
@@ -2,6 +2,7 @@ import * as readline from 'readline';
 import type { BrokerMetadata } from '../broker/discovery';
 import { readBrokerMetadata } from '../broker/discovery';
 import { MCPErrorCodes, MCPResponse } from '../types/mcp';
+import { isPidAlive } from '../utils/controller-lock';
 
 /**
  * Exit code a re-electing client uses when it detects its broker owner has died.
@@ -35,6 +36,8 @@ export interface BrokerProxyOptions {
   onBrokerLost?: () => void;
   /** Override broker-metadata reader (tests). */
   readBrokerMetadataImpl?: (port: number, userDataDir: string) => BrokerMetadata | null;
+  /** Override process liveness check (tests). */
+  isPidAliveImpl?: (pid: number) => boolean;
 }
 
 export class BrokerProxyStdioBridge {
@@ -47,6 +50,7 @@ export class BrokerProxyStdioBridge {
   private readonly reElectOnBrokerLoss: boolean;
   private readonly onBrokerLost: () => void;
   private readonly readBrokerMetadataImpl: (port: number, userDataDir: string) => BrokerMetadata | null;
+  private readonly isPidAliveImpl: (pid: number) => boolean;
   private brokerLostHandled = false;
   private mcpSessionId?: string;
 
@@ -63,6 +67,7 @@ export class BrokerProxyStdioBridge {
     this.reElectOnBrokerLoss = options.reElectOnBrokerLoss ?? false;
     this.onBrokerLost = options.onBrokerLost ?? (() => process.exit(BROKER_REELECT_EXIT_CODE));
     this.readBrokerMetadataImpl = options.readBrokerMetadataImpl ?? readBrokerMetadata;
+    this.isPidAliveImpl = options.isPidAliveImpl ?? isPidAlive;
   }
 
   start(): void {
@@ -91,7 +96,22 @@ export class BrokerProxyStdioBridge {
    */
   isBrokerGone(): boolean {
     const latest = this.readBrokerMetadataImpl(this.broker.port, this.broker.userDataDir);
+    return this.isDifferentBrokerOwner(latest);
+  }
+
+  private isDifferentBrokerOwner(latest: BrokerMetadata | null): boolean {
     return !latest || latest.endpoint !== this.broker.endpoint || latest.pid !== this.broker.pid;
+  }
+
+  private shouldReElectAfterForwardingFailure(): boolean {
+    const latest = this.readBrokerMetadataImpl(this.broker.port, this.broker.userDataDir);
+    if (this.isDifferentBrokerOwner(latest)) return true;
+
+    // The discovery file can be left behind by a hard crash/SIGKILL. In that
+    // case the metadata still names the original owner, but the forwarding
+    // request just failed and the owner PID is no longer alive, so this client
+    // should re-elect instead of returning transient errors forever.
+    return !this.isPidAliveImpl(this.broker.pid);
   }
 
   private handleBrokerLost(): void {
@@ -158,7 +178,7 @@ export class BrokerProxyStdioBridge {
       // dying. Distinguish via the discovery file: if the broker is gone,
       // re-elect instead of returning errors forever. Otherwise surface the
       // transient error as before.
-      if (this.reElectOnBrokerLoss && this.isBrokerGone()) {
+      if (this.reElectOnBrokerLoss && this.shouldReElectAfterForwardingFailure()) {
         this.handleBrokerLost();
         return;
       }

--- a/tests/broker-proxy.test.ts
+++ b/tests/broker-proxy.test.ts
@@ -185,4 +185,73 @@ describe('BrokerProxyStdioBridge multi-client broker forwarding', () => {
     const headers = (fetchImpl.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
     expect(headers['X-Tenant-Id']).toBe('tenant-alpha');
   });
+
+  describe('re-election on broker loss (#1480 S4)', () => {
+    const throwingFetch = (() => { throw new Error('connect ECONNREFUSED 127.0.0.1:3100'); }) as unknown as typeof fetch;
+
+    test('isBrokerGone() is false while the discovery file still names this owner', () => {
+      const bridge = new BrokerProxyStdioBridge(broker, {
+        readBrokerMetadataImpl: () => broker,
+      });
+      expect(bridge.isBrokerGone()).toBe(false);
+    });
+
+    test('isBrokerGone() is true when the discovery file is absent or names a new owner', () => {
+      expect(new BrokerProxyStdioBridge(broker, { readBrokerMetadataImpl: () => null }).isBrokerGone()).toBe(true);
+      expect(new BrokerProxyStdioBridge(broker, { readBrokerMetadataImpl: () => ({ ...broker, pid: 999 }) }).isBrokerGone()).toBe(true);
+      expect(new BrokerProxyStdioBridge(broker, { readBrokerMetadataImpl: () => ({ ...broker, endpoint: 'http://127.0.0.1:9999/mcp' }) }).isBrokerGone()).toBe(true);
+    });
+
+    test('forwarding failure with the broker GONE triggers re-election (no error spam)', async () => {
+      const output: string[] = [];
+      const onBrokerLost = jest.fn();
+      const bridge = new BrokerProxyStdioBridge(broker, {
+        fetchImpl: throwingFetch,
+        write: (chunk) => { output.push(chunk); },
+        reElectOnBrokerLoss: true,
+        onBrokerLost,
+        readBrokerMetadataImpl: () => null, // owner gone
+      });
+
+      await bridge.forwardLine('{"jsonrpc":"2.0","id":1,"method":"tools/list"}');
+
+      expect(onBrokerLost).toHaveBeenCalledTimes(1);
+      expect(output).toHaveLength(0); // re-elect instead of returning an error
+    });
+
+    test('forwarding failure with the broker still ALIVE returns a transient error, no re-election', async () => {
+      const output: string[] = [];
+      const onBrokerLost = jest.fn();
+      const bridge = new BrokerProxyStdioBridge(broker, {
+        fetchImpl: throwingFetch,
+        write: (chunk) => { output.push(chunk); },
+        reElectOnBrokerLoss: true,
+        onBrokerLost,
+        readBrokerMetadataImpl: () => broker, // owner still present
+      });
+
+      await bridge.forwardLine('{"jsonrpc":"2.0","id":1,"method":"tools/list"}');
+
+      expect(onBrokerLost).not.toHaveBeenCalled();
+      expect(output).toHaveLength(1);
+      expect(output[0]).toContain('Broker forwarding failed');
+    });
+
+    test('default (reElectOnBrokerLoss off) preserves the prior error-returning behavior', async () => {
+      const output: string[] = [];
+      const onBrokerLost = jest.fn();
+      const bridge = new BrokerProxyStdioBridge(broker, {
+        fetchImpl: throwingFetch,
+        write: (chunk) => { output.push(chunk); },
+        onBrokerLost,
+        readBrokerMetadataImpl: () => null,
+      });
+
+      await bridge.forwardLine('{"jsonrpc":"2.0","id":1,"method":"tools/list"}');
+
+      expect(onBrokerLost).not.toHaveBeenCalled();
+      expect(output).toHaveLength(1);
+      expect(output[0]).toContain('Broker forwarding failed');
+    });
+  });
 });

--- a/tests/broker-proxy.test.ts
+++ b/tests/broker-proxy.test.ts
@@ -228,6 +228,7 @@ describe('BrokerProxyStdioBridge multi-client broker forwarding', () => {
         reElectOnBrokerLoss: true,
         onBrokerLost,
         readBrokerMetadataImpl: () => broker, // owner still present
+        isPidAliveImpl: () => true,
       });
 
       await bridge.forwardLine('{"jsonrpc":"2.0","id":1,"method":"tools/list"}');
@@ -235,6 +236,27 @@ describe('BrokerProxyStdioBridge multi-client broker forwarding', () => {
       expect(onBrokerLost).not.toHaveBeenCalled();
       expect(output).toHaveLength(1);
       expect(output[0]).toContain('Broker forwarding failed');
+    });
+
+    test('forwarding failure with stale same-owner metadata but dead owner PID triggers re-election', async () => {
+      const staleBroker = { ...broker, pid: 999_999_999 };
+      const output: string[] = [];
+      const onBrokerLost = jest.fn();
+      const bridge = new BrokerProxyStdioBridge(staleBroker, {
+        fetchImpl: throwingFetch,
+        write: (chunk) => { output.push(chunk); },
+        reElectOnBrokerLoss: true,
+        onBrokerLost,
+        readBrokerMetadataImpl: () => staleBroker, // stale file still names the old owner
+        isPidAliveImpl: () => false,
+      });
+
+      expect(bridge.isBrokerGone()).toBe(false); // metadata alone looks unchanged
+
+      await bridge.forwardLine('{"jsonrpc":"2.0","id":1,"method":"tools/list"}');
+
+      expect(onBrokerLost).toHaveBeenCalledTimes(1);
+      expect(output).toHaveLength(0);
     });
 
     test('default (reElectOnBrokerLoss off) preserves the prior error-returning behavior', async () => {


### PR DESCRIPTION
Supersedes #1486 after S3 was squash-merged and its feature branch was deleted.

## Goal
Implement #1480 S4: remove the broker-owner single point of failure by re-electing when the current broker owner dies or becomes unreachable.

## Final Implementation Scope
- Add broker-loss re-election wiring to the proxy/client path.
- Detect forwarding failure against stale same-owner metadata when the advertised owner PID is dead.
- Add regression coverage for broker-owner death and stale metadata re-election.

## Success Criteria
- Auto-elect clients can recover when the broker owner dies.
- Stale metadata that still names the same owner does not suppress re-election when the owner PID is dead.
- Manual/default clients preserve previous forwarding error behavior unless re-election is enabled.
- Net diff remains limited to S4 re-election behavior.

## Verification Method
- Local targeted test: `npx jest tests/broker-proxy.test.ts --runInBand`.
- Source build: `npm run build:src`.
- GitHub CI must pass before merge.

## Guardrails
- Do not broaden re-election to non-auto-elect/manual clients.
- Do not hide real broker forwarding errors when the owner is still alive.
- Do not change S2 owner election or S3 loser attach semantics.
- Keep PID liveness handling as a minimal stale-metadata check, not a full process supervisor.

## Explicit Non-Goals
- Distributed consensus or multi-owner arbitration.
- Cross-machine broker failover.
- Persistent broker state migration.
- Reworking discovery metadata format beyond what S4 consumes.

## Implementation Approach
Keep re-election as a targeted broker-proxy recovery path: on forwarding failure, compare metadata/owner state and call the existing broker-lost callback only when the loss condition is proven, including the stale same-owner dead-PID case.

## PR Decomposition
This is S4 of #1480 and should merge after S2 (#1494) and S3 (#1495). It is the final PR in the auto-elect stack.

## Over-Engineering Checklist
- No new dependency.
- No new daemon/supervisor.
- No metadata schema migration.
- No broad broker lifecycle rewrite.

## Drift-Prevention Checklist
- Rebased onto current `develop` after #1495 squash-merge.
- Net diff checked against `origin/develop`.
- Includes the prior code-review fix for stale same-owner dead-PID metadata.

## Language Boundary
No new user-facing language beyond existing startup/recovery diagnostics.

## Critical Risk Review
The critical risk is false-positive re-election that masks ordinary forwarding errors. The implementation gates re-election on enabled re-election mode plus broker-loss evidence, and adds a stale same-owner dead-PID regression for the reviewer-identified gap.

## Definition of Done
- Local targeted tests pass.
- Source build passes.
- GitHub CI green.
- Squash-merged into `develop`.
- Final open-PR audit confirms no remaining processable PRs.
