### PR TITLE
Fix javascript_tool Promise remote results

### DIFF
--- a/src/tools/javascript.ts
+++ b/src/tools/javascript.ts
@@ -102,16 +102,26 @@ export const JAVASCRIPT_HELPER_INJECTION = `(() => {
 export function wrapInIIFE(code: string): string {
   const trimmed = code.trim();
 
+  // Already-complete IIFEs should evaluate as written. Re-wrapping them can
+  // turn a sync result into an outer Promise and can also drop the inner return.
+  if (/^\(\s*(?:async\s*)?\(\s*\)\s*=>[\s\S]*\)\s*\(\s*\)\s*;?$/.test(trimmed)) {
+    return trimmed;
+  }
+
   // Single expression without semicolons, newlines, or return: evaluate as-is
   // so the expression value is returned naturally by Runtime.evaluate.
   if (!trimmed.includes('\n') && !trimmed.includes(';') && !/\breturn\b/.test(trimmed)) {
     return trimmed;
   }
 
-  // Multi-statement code or code with explicit return: wrap in async IIFE.
+  const iifeStart = /\bawait\b/.test(trimmed) ? '(async () => {' : '(() => {';
+
+  // Multi-statement code or code with explicit return: wrap in an IIFE.
   // This fixes two common LLM errors:
   //   1. SyntaxError: Illegal return statement  (return outside a function)
   //   2. SyntaxError: Identifier 'x' has already been declared  (let/const redeclaration)
+  // Use async only when the code actually awaits, so ordinary sync snippets do
+  // not produce a Promise remote object.
   //
   // If there is no explicit `return`, try to auto-return the last expression so
   // that `let x = 5;\nx` still returns 5 instead of undefined.
@@ -144,11 +154,11 @@ export function wrapInIIFE(code: string): string {
     if (isAutoReturnable) {
       const bodyLines = lines.slice(0, -1).join('\n');
       const body = bodyLines ? `${bodyLines}\nreturn ${lastLine}` : `return ${lastLine}`;
-      return `(async () => { ${body}\n})()`;
+      return `${iifeStart} ${body}\n})()`;
     }
   }
 
-  return `(async () => { ${code}\n})()`;
+  return `${iifeStart} ${code}\n})()`;
 }
 
 export function buildJavascriptExpression(code: string): string {
@@ -158,7 +168,8 @@ export function buildJavascriptExpression(code: string): string {
 export async function formatCDPResult(
   evalResult: CDPEvalResult['result'],
   cdpClient?: CDPSender,
-  page?: unknown
+  page?: unknown,
+  promiseDepth = 0
 ): Promise<string> {
   const { type, subtype, value, description, className, objectId } = evalResult;
 
@@ -179,13 +190,50 @@ export async function formatCDPResult(
   }
 
   if (type === 'object' && (subtype === 'promise' || className === 'Promise')) {
-    if (objectId) {
-      releaseObject(cdpClient, page, objectId);
+    if (objectId && cdpClient && page) {
+      let promiseReleased = false;
+      const releasePromise = () => {
+        if (!promiseReleased) {
+          promiseReleased = true;
+          releaseObject(cdpClient, page, objectId);
+        }
+      };
+
+      if (promiseDepth >= 3) {
+        releasePromise();
+        throw new Error('Runtime.awaitPromise exceeded nested Promise resolution limit');
+      }
+
+      try {
+        const awaited = await cdpClient.send<CDPEvalResult>(
+          page,
+          'Runtime.awaitPromise',
+          {
+            promiseObjectId: objectId,
+            returnByValue: false,
+          }
+        );
+        releasePromise();
+
+        if (awaited.exceptionDetails) {
+          const errorMsg =
+            awaited.exceptionDetails.exception?.description ||
+            awaited.exceptionDetails.text ||
+            'Unknown error';
+          throw new Error(`Runtime.awaitPromise rejected: ${errorMsg}`);
+        }
+
+        return formatCDPResult(awaited.result, cdpClient, page, promiseDepth + 1);
+      } catch (error) {
+        releasePromise();
+        throw new Error(`Runtime.awaitPromise failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
     }
+
+    if (objectId) releaseObject(cdpClient, page, objectId);
     return [
       description || 'Promise',
-      'Diagnostic: CDP returned a Promise remote object even though Runtime.evaluate used awaitPromise: true.',
-      'Return or await the promise directly so javascript_tool can show the resolved value.',
+      'Diagnostic: CDP returned a Promise remote object, but javascript_tool could not resolve it because CDP context was unavailable.',
     ].join('\n');
   }
 

--- a/tests/tools/javascript-iife.test.ts
+++ b/tests/tools/javascript-iife.test.ts
@@ -28,18 +28,18 @@ describe('wrapInIIFE', () => {
   test('bare return statement gets wrapped', () => {
     const code = "return 'hello'";
     const wrapped = wrapInIIFE(code);
-    expect(wrapped).toContain('(async () =>');
+    expect(wrapped).toContain('(() =>');
     expect(wrapped).toContain("return 'hello'");
   });
 
   test('top-level return remains valid inside generated IIFE', () => {
-    expect(wrapInIIFE('return document.title')).toBe('(async () => { return document.title\n})()');
+    expect(wrapInIIFE('return document.title')).toBe('(() => { return document.title\n})()');
   });
 
   test('multi-line code with explicit return gets wrapped', () => {
     const code = 'const x = 5;\nreturn x;';
     const wrapped = wrapInIIFE(code);
-    expect(wrapped).toContain('(async () =>');
+    expect(wrapped).toContain('(() =>');
     expect(wrapped).toContain('return x');
   });
 
@@ -55,21 +55,22 @@ describe('wrapInIIFE', () => {
   test('multi-line expression auto-returns last line', () => {
     const code = 'const x = 5;\nx';
     const wrapped = wrapInIIFE(code);
-    expect(wrapped).toContain('(async () =>');
+    expect(wrapped).toContain('(() =>');
     expect(wrapped).toContain('return x');
   });
 
   test('let declaration followed by identifier auto-returns identifier', () => {
     const code = "let result = 'test';\nresult";
     const wrapped = wrapInIIFE(code);
-    expect(wrapped).toContain('(async () =>');
+    expect(wrapped).toContain('(() =>');
     expect(wrapped).toContain('return result');
   });
 
   test('semicolon-separated single-line code gets wrapped', () => {
     const code = "const a = 1; a + 2";
     const wrapped = wrapInIIFE(code);
-    expect(wrapped).toContain('(async () =>');
+    expect(wrapped).toContain('(() =>');
+    expect(wrapped).not.toContain('(async () =>');
   });
 
   // --- last line is a declaration — wrapped but no spurious auto-return ---
@@ -77,7 +78,7 @@ describe('wrapInIIFE', () => {
   test('code ending with a declaration is wrapped without auto-return', () => {
     const code = 'let x = 5;\nconst y = x + 1';
     const wrapped = wrapInIIFE(code);
-    expect(wrapped).toContain('(async () =>');
+    expect(wrapped).toContain('(() =>');
     // No auto-return injected before a const line
     expect(wrapped).not.toMatch(/return const/);
   });
@@ -86,13 +87,19 @@ describe('wrapInIIFE', () => {
     const code = 'function f() { return 1; }\nf()';
     // last non-empty line is "f()" which IS auto-returnable
     const wrapped = wrapInIIFE(code);
-    expect(wrapped).toContain('(async () =>');
+    expect(wrapped).toContain('(() =>');
   });
 
   // --- IIFE structure correctness ---
 
-  test('IIFE uses async arrow function', () => {
+  test('IIFE uses sync arrow function unless await is present', () => {
     const wrapped = wrapInIIFE("return 42");
+    expect(wrapped).toMatch(/^\(\(\) => \{/);
+    expect(wrapped).not.toContain('(async () =>');
+  });
+
+  test('IIFE uses async arrow function when await is present', () => {
+    const wrapped = wrapInIIFE('const x = await Promise.resolve(42);\nreturn x');
     expect(wrapped).toMatch(/^\(async \(\) => \{/);
   });
 
@@ -105,5 +112,25 @@ describe('wrapInIIFE', () => {
     const code = "const x = 'world';\nreturn 'hello ' + x;";
     const wrapped = wrapInIIFE(code);
     expect(wrapped).toContain(code);
+  });
+
+  test('already-complete sync IIFE stays unwrapped for issue #1497', () => {
+    const code = `(() => {
+  const header = document.querySelector('header.z-30');
+  return {
+    headerBg: header ? window.getComputedStyle(header).backgroundColor : 'not found',
+  };
+})();`;
+
+    expect(wrapInIIFE(code)).toBe(code);
+  });
+
+  test('already-complete async IIFE stays unwrapped', () => {
+    const code = `(async () => {
+  const value = await Promise.resolve(42);
+  return value;
+})();`;
+
+    expect(wrapInIIFE(code)).toBe(code);
   });
 });

--- a/tests/tools/javascript.test.ts
+++ b/tests/tools/javascript.test.ts
@@ -534,8 +534,12 @@ describe('JavaScriptTool', () => {
   });
 
   describe('Result formatting diagnostics', () => {
-    test('returns an explicit Promise remote object diagnostic', async () => {
-      const mockSender = { send: jest.fn().mockResolvedValue({}) };
+    test('resolves Promise remote object before formatting result', async () => {
+      const mockSender = {
+        send: jest.fn()
+          .mockResolvedValueOnce({ result: { type: 'number', value: 42, description: '42' } })
+          .mockResolvedValue({}),
+      };
 
       const result = await formatCDPResult(
         {
@@ -549,10 +553,58 @@ describe('JavaScriptTool', () => {
         {}
       );
 
-      expect(result).toContain('Promise');
-      expect(result).toContain('Diagnostic: CDP returned a Promise remote object');
-      expect(result).toContain('awaitPromise: true');
+      expect(result).toBe('42');
+      expect(mockSender.send).toHaveBeenCalledWith({}, 'Runtime.awaitPromise', {
+        promiseObjectId: 'promise-1',
+        returnByValue: false,
+      });
       expect(mockSender.send).toHaveBeenCalledWith({}, 'Runtime.releaseObject', { objectId: 'promise-1' });
+    });
+
+    test('resolves Promise remote object to object output', async () => {
+      const mockSender = {
+        send: jest.fn()
+          .mockResolvedValueOnce({
+            result: { type: 'object', objectId: 'obj-1', description: 'Object', className: 'Object' },
+          })
+          .mockResolvedValueOnce({})
+          .mockResolvedValueOnce({ result: { value: '{\n  "ok": true\n}' } })
+          .mockResolvedValue({}),
+      };
+
+      const result = await formatCDPResult(
+        {
+          type: 'object',
+          subtype: 'promise',
+          className: 'Promise',
+          description: 'Promise',
+          objectId: 'promise-1',
+        },
+        mockSender,
+        {}
+      );
+
+      expect(result).toContain('"ok": true');
+      expect(mockSender.send).toHaveBeenCalledWith({}, 'Runtime.awaitPromise', {
+        promiseObjectId: 'promise-1',
+        returnByValue: false,
+      });
+    });
+
+    test('throws when Promise remote object cannot be resolved', async () => {
+      const mockSender = { send: jest.fn().mockRejectedValue(new Error('Protocol error')) };
+
+      await expect(formatCDPResult(
+        {
+          type: 'object',
+          subtype: 'promise',
+          className: 'Promise',
+          description: 'Promise',
+          objectId: 'promise-1',
+        },
+        mockSender,
+        {}
+      )).rejects.toThrow(/Runtime\.awaitPromise failed/);
     });
   });
 


### PR DESCRIPTION
## Problem

`javascript_tool` could return successful text containing `Promise` / `CDP returned a Promise remote object` when CDP surfaced a Promise remote object despite `Runtime.evaluate({ awaitPromise: true })`. MCP hosts such as opencode interpreted that as a failed JS attempt and wasted turns retrying alternative approaches.

## Fix

- Resolve Promise remote objects through CDP `Runtime.awaitPromise` before formatting the result.
- Keep Promise resolution bounded through the existing tool-call path; resolution failures now surface as tool errors instead of normal successful diagnostic text.
- Avoid wrapping already-complete sync/async IIFEs in another IIFE, preserving issue #1497-style snippets.
- Use sync IIFE wrapping unless the snippet actually needs `await`, avoiding unnecessary Promise remote objects for ordinary sync JavaScript.

## Tests

- `npm test -- tests/tools/javascript.test.ts tests/tools/javascript-iife.test.ts`
- `npm run build`
- `npm run lint`

## Compatibility / OpenChrome direction alignment

- Core/tool-server behavior only: no host-specific branching and no new dependencies.
- Preserves existing result formatting for primitives, objects, arrays, DOM nodes, NodeList/HTMLCollection/Map/Set, errors, timeouts, and top-level await coverage.
- Keeps the server returning normalized facts from CDP rather than pushing recovery decisions to MCP hosts.

Closes #1497
