### PR TITLE
docs(skill): make OpenChrome skill the agent-facing routing SSOT

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "bench:runtime-preflight": "ts-node tests/benchmark/runtime-preflight.ts",
     "bench:full:live": "ts-node tests/benchmark/run-full-benchmark.ts --mode live",
     "bench:full:recorded": "ts-node tests/benchmark/run-full-benchmark.ts --mode recorded",
-    "bench:api-key-readiness": "ts-node tests/benchmark/benchmark-readiness.ts --api-key-only"
+    "bench:api-key-readiness": "ts-node tests/benchmark/benchmark-readiness.ts --api-key-only",
+    "lint:skill-tools": "node scripts/lint-skill-tool-refs.mjs skills/openchrome/SKILL.md"
   },
   "keywords": [
     "openchrome",
@@ -140,6 +141,11 @@
     "assets",
     "config",
     "README.md",
-    "LICENSE"
+    "docs/agent/capability-map.md",
+    "LICENSE",
+    "skills",
+    "commands",
+    ".codex-plugin",
+    ".claude-plugin"
   ]
 }

--- a/scripts/lint-skill-tool-refs.mjs
+++ b/scripts/lint-skill-tool-refs.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const skillPath = process.argv[2] ?? 'skills/openchrome/SKILL.md';
+const toolIndexPath = 'src/tools/index.ts';
+
+function fail(message) {
+  console.error(`[lint-skill-tool-refs] ${message}`);
+  process.exitCode = 1;
+}
+
+function read(file) {
+  return fs.readFileSync(file, 'utf8');
+}
+
+const skill = read(skillPath);
+const toolIndex = read(toolIndexPath);
+
+const knownTools = new Set();
+for (const match of toolIndex.matchAll(/^\s*([a-z][a-z0-9_]*):\s*'[^']+',/gm)) {
+  knownTools.add(match[1]);
+}
+
+const routingStart = skill.indexOf('## First tool by intent');
+if (routingStart === -1) {
+  fail(`${skillPath} is missing "## First tool by intent"`);
+  process.exit();
+}
+const nextSection = skill.indexOf('\n## ', routingStart + 1);
+const routingSection = skill.slice(routingStart, nextSection === -1 ? undefined : nextSection);
+
+const allowedCommands = new Set(['openchrome doctor', 'openchrome check']);
+const referenced = new Set();
+for (const line of routingSection.split('\n')) {
+  if (!line.startsWith('|') || line.includes('---')) continue;
+  for (const match of line.matchAll(/`([^`]+)`/g)) {
+    const raw = match[1].trim();
+    if (!raw || allowedCommands.has(raw)) continue;
+    const tool = raw.split(/\s+/)[0];
+    if (tool.startsWith('--')) continue;
+    referenced.add(tool);
+  }
+}
+
+if (referenced.size === 0) {
+  fail('No tool references found in routing card');
+}
+
+for (const tool of referenced) {
+  if (!knownTools.has(tool)) {
+    fail(`Unknown OpenChrome tool referenced in routing card: ${tool}`);
+  }
+}
+
+if (!process.exitCode) {
+  console.log(`Checked ${referenced.size} OpenChrome tool references in ${path.relative(process.cwd(), skillPath)}.`);
+}

--- a/skills/openchrome/SKILL.md
+++ b/skills/openchrome/SKILL.md
@@ -43,6 +43,33 @@ openchrome setup --client codex   # Codex CLI
 
 Restart your MCP client. Chrome auto-launches on the first tool call.
 
+## First tool by intent
+
+Use this as the short routing card. The full catalogue remains in
+[`docs/agent/capability-map.md`](../../docs/agent/capability-map.md).
+
+| Intent | Start with | Fallback | Verify with |
+|---|---|---|---|
+| Open a URL | `navigate` | `tabs_create` | `read_page` |
+| Read page facts | `read_page mode=dom` | `inspect` / `query_dom` | `oc_assert` |
+| Find action targets | `oc_observe` | `find` / `oc_query` | `inspect` |
+| Click or type | `interact` | `computer` | `oc_assert` |
+| Verify success | `oc_assert` | `validate_page` | `oc_evidence_bundle` |
+| Capture evidence | `oc_evidence_bundle` | `page_screenshot` | `oc_diff` |
+| Debug a broken page | `validate_page` | `console_capture` | `oc_evidence_bundle` |
+| Crawl or run background work | `crawl_start` | `crawl_status` / `crawl_cancel` | `oc_assert` |
+| Repair runtime setup | `openchrome doctor` | `oc_doctor_report` | `openchrome check` |
+
+Default loop: `navigate` → `read_page` / `oc_observe` → `interact` →
+`oc_assert` → `oc_evidence_bundle` if the result is uncertain.
+
+Use something else when:
+
+- You need a deterministic browser script without an MCP host agent: use
+  Playwright or Puppeteer.
+- The user explicitly asks for a platform API or CLI: use that external tool.
+- The next step is irreversible: get the host/user confirmation gate first.
+
 ## Key tools
 
 | Tool | Purpose |


### PR DESCRIPTION
## Summary
- expand the shared OpenChrome skill with a compact first-tool-by-intent routing card
- add a minimal lint gate for routing-card tool references against the tool registry
- include shared plugin/skill assets and the linked capability map in the npm package

Closes #1506.

## SSOT #1359 alignment
- host-neutral MCP guidance only; no runtime behavior added
- no domain-specific website/platform knowledge added
- no Codex/Claude-only behavior added; both manifests continue to share skills/openchrome/SKILL.md

## Verification
- node --check scripts/lint-skill-tool-refs.mjs
- npm run lint:skill-tools
- npm run docs:capability-map:check
- npm run build
- npm pack --dry-run --json
- git diff --check

## Review
- code-reviewer: APPROVE, no findings
- architect: WATCH addressed by packaging docs/agent/capability-map.md and tightening lint to one source/table scope