### PR TITLE
feat(diagnostics): expose doctor runtime topology facts

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -569,79 +569,15 @@ program
 
 program
   .command('doctor')
-  .description('Check installation status')
+  .description('Run holistic environment diagnostics (Node, Chrome, ports, disk, network)')
+  .option('--json', 'Emit DoctorReport as JSON to stdout')
+  .option('--check <id>', 'Run only this check (repeatable)', (_val: string, prev: string[]) => prev, [] as string[])
+  .option('--remote', 'Enable opt-in remote network probe (HEAD update.googleapis.com)')
+  .option('--no-color', 'Disable colored output (also respected via NO_COLOR env var)')
   .action(async () => {
-    console.log('Checking installation status...\n');
-
-    // Core checks (required for CDP mode)
-    const portCheck = await checkChromeDebugPort();
-    const coreChecks = {
-      'Node.js version (>=18)': checkNodeVersion(),
-      '.claude.json health': await checkClaudeConfigHealth(),
-      'Chrome debugging port': portCheck.available,
-    };
-
-    console.log('Core Requirements:');
-    for (const [name, passed] of Object.entries(coreChecks)) {
-      const status = passed ? '✅' : '❌';
-      console.log(`  ${status} ${name}`);
-    }
-
-    // Chrome binary detection
-    console.log('\nChrome Detection:');
-    const platform = os.platform();
-    const chromePaths: string[] = [];
-    if (platform === 'darwin') {
-      chromePaths.push('/Applications/Google Chrome.app/Contents/MacOS/Google Chrome');
-    } else if (platform === 'win32') {
-      const envProgramFiles = process.env['PROGRAMFILES'];
-      const envLocalAppData = process.env['LOCALAPPDATA'];
-      if (envProgramFiles) chromePaths.push(path.join(envProgramFiles, 'Google', 'Chrome', 'Application', 'chrome.exe'));
-      if (envLocalAppData) chromePaths.push(path.join(envLocalAppData, 'Google', 'Chrome', 'Application', 'chrome.exe'));
-    } else {
-      chromePaths.push('/usr/bin/google-chrome-stable', '/usr/bin/google-chrome', '/snap/bin/chromium');
-    }
-    if (process.env.CHROME_PATH) {
-      console.log(`  CHROME_PATH: ${process.env.CHROME_PATH} ${fs.existsSync(process.env.CHROME_PATH) ? '✅' : '❌ not found'}`);
-    } else {
-      let found = false;
-      for (const p of chromePaths) {
-        if (fs.existsSync(p)) {
-          console.log(`  ✅ Found: ${p}`);
-          found = true;
-          break;
-        }
-      }
-      if (!found) {
-        console.log('  ❌ Chrome not found in standard locations');
-        console.log('  Set CHROME_PATH environment variable to your Chrome binary');
-      }
-    }
-
-    printDoctorMCPTopologyGuidance();
-
-    const allPassed = Object.values(coreChecks).every(Boolean);
-    console.log();
-
-    if (allPassed) {
-      console.log('All checks passed! Ready to use with Claude Code.');
-      console.log('\nUsage:');
-      console.log('  1. Start Chrome with: chrome --remote-debugging-port=9222');
-      console.log('  2. Add to ~/.claude.json:');
-      console.log('     "mcpServers": { "openchrome": { "command": "openchrome", "args": ["serve"] } }');
-      console.log('  3. Restart Claude Code');
-    } else {
-      if (!coreChecks['Chrome debugging port']) {
-        console.log(`Chrome debugging port issue: ${portCheck.details || 'Unknown'}`);
-        if (portCheck.details?.includes('Nothing is listening')) {
-          console.log('Start Chrome with: chrome --remote-debugging-port=9222');
-          console.log('Or enable auto-launch: set autoLaunch=true in openchrome config');
-        }
-      }
-      if (!coreChecks['.claude.json health']) {
-        console.log('Run "openchrome recover" to fix .claude.json');
-      }
-    }
+    const serveEntry = path.join(__dirname, '..', 'index.js');
+    const child = spawn(process.execPath, [serveEntry, ...process.argv.slice(2)], { stdio: 'inherit' });
+    child.on('exit', (code) => process.exit(code ?? 0));
   });
 
 program

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -22,6 +22,7 @@ import { checkNetworkLocal } from './doctor/checks/network-local';
 import { checkNetworkRemote } from './doctor/checks/network-remote';
 import { checkOptionalDeps } from './doctor/checks/optional-deps';
 import { checkDuplicateControllers } from './doctor/checks/duplicate-controllers';
+import { collectDoctorDiagnostics, type DoctorDiagnostics } from './doctor/runtime-diagnostics';
 
 export type CheckStatus = 'ok' | 'warn' | 'fail' | 'skip';
 
@@ -41,6 +42,7 @@ export interface DoctorReport {
   nodeVersion: string;
   startedAt: string;
   results: CheckResult[];
+  diagnostics: DoctorDiagnostics;
   summary: { ok: number; warn: number; fail: number; skip: number };
   exitCode: 0 | 1 | 2;
 }
@@ -117,6 +119,7 @@ export async function runDoctor(options: {
   }
 
   const exitCode: 0 | 1 | 2 = summary.fail > 0 ? 2 : summary.warn > 0 ? 1 : 0;
+  const diagnostics = collectDoctorDiagnostics();
 
   return {
     openchromeVersion: getVersion(),
@@ -125,6 +128,7 @@ export async function runDoctor(options: {
     nodeVersion: process.versions.node,
     startedAt,
     results,
+    diagnostics,
     summary,
     exitCode,
   };

--- a/src/cli/doctor/runtime-diagnostics.ts
+++ b/src/cli/doctor/runtime-diagnostics.ts
@@ -1,0 +1,112 @@
+import * as os from 'os';
+import { readBrokerMetadata } from '../../broker/discovery';
+import { getCurrentControllerTopology } from '../../utils/duplicate-controller-diagnostics';
+import { isPidAlive } from '../../utils/controller-lock';
+
+export type ActiveRuntimePath =
+  | 'direct-owner'
+  | 'broker-owner'
+  | 'broker-client'
+  | 'auto-elect-owner'
+  | 'auto-elect-client'
+  | 'isolated-profile'
+  | 'attach-mode'
+  | 'unsafe-secondary-attach'
+  | 'blocked-by-owner'
+  | 'unknown';
+
+export interface RuntimeDiagnostics {
+  /** Derived controller/topology classification. */
+  runtime_topology: ActiveRuntimePath;
+  /** Compatibility alias for issue #1505 wording; prefer runtime_topology. */
+  active_runtime_path: ActiveRuntimePath;
+  facts: {
+    port: number;
+    userDataDir: string;
+    controllerRole: string;
+    lockPath: string;
+    ownerPid?: number;
+    brokerEndpoint?: string;
+    brokerPid?: number;
+    brokerPidAlive?: boolean;
+    autoElectEnabled: boolean;
+    unsafeSharedAttachEnabled: boolean;
+    launchMode?: string;
+  };
+}
+
+export interface DoctorDiagnostics {
+  runtime: RuntimeDiagnostics;
+}
+
+
+export function displayPath(filePath: string): string {
+  const home = os.homedir();
+  if (filePath === home) return '~';
+  if (filePath.startsWith(`${home}/`)) return `~/${filePath.slice(home.length + 1)}`;
+  return filePath;
+}
+
+export function classifyRuntimePath(params: {
+  controllerRole: string;
+  ownerPid?: number;
+  brokerPid?: number;
+  brokerPidAlive?: boolean;
+  autoElectEnabled?: boolean;
+  unsafeSharedAttachEnabled?: boolean;
+  launchMode?: string;
+}): ActiveRuntimePath {
+  if (params.unsafeSharedAttachEnabled || params.controllerRole === 'unsafe-secondary-attach') {
+    return 'unsafe-secondary-attach';
+  }
+  if (params.launchMode === 'attach') return 'attach-mode';
+  if (params.brokerPid && params.brokerPidAlive) {
+    if (params.autoElectEnabled) {
+      return params.ownerPid === params.brokerPid ? 'auto-elect-owner' : 'auto-elect-client';
+    }
+    return params.ownerPid === params.brokerPid ? 'broker-owner' : 'broker-client';
+  }
+  if (params.controllerRole === 'owner') return 'direct-owner';
+  if (params.controllerRole === 'unknown' && params.ownerPid) return 'blocked-by-owner';
+  if (params.launchMode === 'isolated') return 'isolated-profile';
+  return 'unknown';
+}
+
+export function collectDoctorDiagnostics(): DoctorDiagnostics {
+  const topology = getCurrentControllerTopology();
+  const broker = readBrokerMetadata(topology.port, topology.userDataDir);
+  const brokerPidAlive = broker?.pid !== undefined ? isPidAlive(broker.pid) : undefined;
+  const autoElectEnabled = process.env.OPENCHROME_AUTO_ELECT === '1';
+  const unsafeSharedAttachEnabled = process.env.OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH === '1';
+  const launchMode = process.env.OPENCHROME_LAUNCH_MODE;
+
+  const activeRuntimePath = classifyRuntimePath({
+    controllerRole: topology.role,
+    ownerPid: topology.ownerPid,
+    brokerPid: broker?.pid,
+    brokerPidAlive,
+    autoElectEnabled,
+    unsafeSharedAttachEnabled,
+    launchMode,
+  });
+
+  return {
+    runtime: {
+      runtime_topology: activeRuntimePath,
+      active_runtime_path: activeRuntimePath,
+      facts: {
+        port: topology.port,
+        userDataDir: displayPath(topology.userDataDir),
+        controllerRole: topology.role,
+        lockPath: displayPath(topology.lockPath),
+        ...(topology.ownerPid !== undefined ? { ownerPid: topology.ownerPid } : {}),
+        ...(broker?.endpoint ? { brokerEndpoint: broker.endpoint } : {}),
+        ...(broker?.pid !== undefined ? { brokerPid: broker.pid } : {}),
+        ...(brokerPidAlive !== undefined ? { brokerPidAlive } : {}),
+        autoElectEnabled,
+        unsafeSharedAttachEnabled,
+        ...(launchMode ? { launchMode } : {}),
+      },
+    },
+  };
+}

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import type { DoctorReport } from '../../src/cli/doctor';
 
 const DIST_INDEX = path.join(__dirname, '../../dist/index.js');
+const DIST_CLI_INDEX = path.join(__dirname, '../../dist/cli/index.js');
 
 // All check IDs that must appear in the report (network-remote is excluded by default)
 const REQUIRED_CHECK_IDS = [
@@ -26,8 +27,8 @@ const REQUIRED_CHECK_IDS = [
 ];
 
 // Run the doctor command using the compiled dist output
-function runDoctorJson(): { stdout: string; stderr: string; exitCode: number } {
-  const result = spawnSync(process.execPath, [DIST_INDEX, 'doctor', '--json'], {
+function runDoctorJson(entry = DIST_INDEX): { stdout: string; stderr: string; exitCode: number } {
+  const result = spawnSync(process.execPath, [entry, 'doctor', '--json'], {
     encoding: 'utf8',
     timeout: 30000,
     env: { ...process.env, NODE_ENV: 'test' },
@@ -82,6 +83,18 @@ describe('openchrome doctor --json', () => {
     }
   });
 
+  test('includes runtime diagnostics facts', () => {
+    const fs = require('fs');
+    if (!fs.existsSync(DIST_INDEX)) return;
+    expect(report.diagnostics).toBeDefined();
+    expect(report.diagnostics.runtime).toBeDefined();
+    expect(typeof report.diagnostics.runtime.runtime_topology).toBe('string');
+    expect(report.diagnostics.runtime.active_runtime_path).toBe(report.diagnostics.runtime.runtime_topology);
+    expect(typeof report.diagnostics.runtime.facts.port).toBe('number');
+    expect(typeof report.diagnostics.runtime.facts.userDataDir).toBe('string');
+    expect(typeof report.diagnostics.runtime.facts.lockPath).toBe('string');
+  });
+
   test('summary counts match results', () => {
     const fs = require('fs');
     if (!fs.existsSync(DIST_INDEX)) return;
@@ -110,6 +123,30 @@ describe('openchrome doctor --json', () => {
     const expectedExit = report.summary.fail > 0 ? 2 : report.summary.warn > 0 ? 1 : 0;
     expect(report.exitCode).toBe(expectedExit);
     expect(exitCode).toBe(expectedExit);
+  });
+
+
+  test('package bin wrapper delegates doctor --json to structured report', () => {
+    const fs = require('fs');
+    if (!fs.existsSync(DIST_CLI_INDEX)) return;
+    const result = runDoctorJson(DIST_CLI_INDEX);
+    const parsed = JSON.parse(result.stdout) as DoctorReport;
+    expect(parsed.diagnostics.runtime.active_runtime_path).toBeDefined();
+    expect(result.exitCode).toBe(parsed.exitCode);
+  });
+
+
+  test('package bin wrapper delegates plain doctor to canonical formatter', () => {
+    const fs = require('fs');
+    if (!fs.existsSync(DIST_CLI_INDEX)) return;
+    const result = spawnSync(process.execPath, [DIST_CLI_INDEX, 'doctor', '--check', 'node-version', '--no-color'], {
+      encoding: 'utf8',
+      timeout: 30000,
+      env: { ...process.env, NODE_ENV: 'test' },
+    });
+    expect(result.stdout).toContain('=== openchrome doctor ===');
+    expect(result.stdout).toContain('Node.js version');
+    expect(result.status).toBe(0);
   });
 
   test('network-remote check is absent by default', () => {

--- a/tests/cli/doctor/runtime-diagnostics.test.ts
+++ b/tests/cli/doctor/runtime-diagnostics.test.ts
@@ -1,0 +1,36 @@
+import * as os from 'os';
+import { classifyRuntimePath, displayPath } from '../../../src/cli/doctor/runtime-diagnostics';
+
+describe('doctor runtime diagnostics', () => {
+  test('classifies unsafe shared attach first', () => {
+    expect(classifyRuntimePath({ controllerRole: 'unlocked', unsafeSharedAttachEnabled: true })).toBe('unsafe-secondary-attach');
+  });
+
+  test('classifies attach launch mode', () => {
+    expect(classifyRuntimePath({ controllerRole: 'unlocked', launchMode: 'attach' })).toBe('attach-mode');
+  });
+
+  test('classifies broker owner and client', () => {
+    expect(classifyRuntimePath({ controllerRole: 'owner', ownerPid: 10, brokerPid: 10, brokerPidAlive: true })).toBe('broker-owner');
+    expect(classifyRuntimePath({ controllerRole: 'unknown', ownerPid: 10, brokerPid: 20, brokerPidAlive: true })).toBe('broker-client');
+  });
+
+  test('classifies auto-elect owner and client', () => {
+    expect(classifyRuntimePath({ controllerRole: 'owner', ownerPid: 10, brokerPid: 10, brokerPidAlive: true, autoElectEnabled: true })).toBe('auto-elect-owner');
+    expect(classifyRuntimePath({ controllerRole: 'unknown', ownerPid: 10, brokerPid: 20, brokerPidAlive: true, autoElectEnabled: true })).toBe('auto-elect-client');
+  });
+
+  test('classifies direct owner, blocked owner, isolated profile, and unknown', () => {
+    expect(classifyRuntimePath({ controllerRole: 'owner', ownerPid: 10 })).toBe('direct-owner');
+    expect(classifyRuntimePath({ controllerRole: 'unknown', ownerPid: 10 })).toBe('blocked-by-owner');
+    expect(classifyRuntimePath({ controllerRole: 'unlocked', launchMode: 'isolated' })).toBe('isolated-profile');
+    expect(classifyRuntimePath({ controllerRole: 'unlocked' })).toBe('unknown');
+  });
+
+  test('redacts home-relative paths for display facts', () => {
+    const home = os.homedir();
+    expect(displayPath(`${home}/.openchrome/profile`)).toBe('~/.openchrome/profile');
+    expect(displayPath(home)).toBe('~');
+    expect(displayPath('/var/tmp/openchrome-profile')).toBe('/var/tmp/openchrome-profile');
+  });
+});


### PR DESCRIPTION
## Summary
- add additive DoctorReport diagnostics for runtime topology/controller facts
- normalize home-relative paths in diagnostic facts before JSON/cache exposure
- delegate the package bin doctor command to the canonical doctor implementation
- cover runtime topology classification and bin wrapper doctor JSON/plain forwarding

Refs #1505 phase 1.

## SSOT #1359 alignment
- host-neutral MCP/browser harness facts only
- no domain-specific website/platform knowledge added
- no Chrome ownership/default topology behavior changed
- no automatic repair or hidden runtime action added

## Verification
- npm run lint:tier
- npm run build
- npm test -- --runInBand tests/cli/doctor/runtime-diagnostics.test.ts tests/cli/doctor.test.ts
- node dist/cli/index.js doctor --json
- node dist/cli/index.js doctor --check node-version --no-color
- git diff --check

## Review
- code-reviewer: REQUEST CHANGES addressed (blocked owner classification, path display redaction, bin wrapper test)
- architect: BLOCK addressed (tests fixed, doctor wrapper unified to canonical implementation, unknown options removed, runtime_topology added with active_runtime_path alias)