### PR TITLE
feat(diagnostics): add prescriptive doctor remediation

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -578,6 +578,7 @@ program
     }
     program.help();
   });
+
 program
   .command('launch')
   .description('Start Claude Code with isolated config (prevents corruption)')

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -32,6 +32,14 @@ export interface CheckResult {
   status: CheckStatus;
   detail?: string;
   remediation?: string;
+  /** Short factual cause, safe for machine readers. */
+  reason?: string;
+  /** Primary next action. Mirrors remediation when no better structured action exists. */
+  next_action?: string;
+  /** Safe alternatives that do not change OpenChrome policy by themselves. */
+  safe_alternatives?: string[];
+  docs?: string[];
+  facts?: Record<string, unknown>;
   durationMs: number;
 }
 
@@ -50,6 +58,83 @@ export interface DoctorReport {
 export type CheckFn = () => Promise<Omit<CheckResult, 'durationMs'>>;
 
 const CHECK_TIMEOUT_MS = 5000;
+
+
+function prescriptiveDefaults(result: Omit<CheckResult, 'durationMs'>): Partial<CheckResult> {
+  if (result.status === 'ok' || result.status === 'skip') {
+    return {};
+  }
+
+  const nextAction = result.remediation;
+  const base: Partial<CheckResult> = {
+    ...(result.detail ? { reason: result.detail } : {}),
+    ...(nextAction ? { next_action: nextAction } : {}),
+  };
+
+  switch (result.id) {
+    case 'chrome-binary':
+      return {
+        ...base,
+        docs: ['https://www.google.com/chrome/'],
+        safe_alternatives: [
+          'Install Google Chrome and rerun openchrome doctor.',
+          'Set CHROME_PATH to an existing Chrome or chrome-headless-shell binary.',
+        ],
+      };
+    case 'chrome-port':
+      return {
+        ...base,
+        safe_alternatives: [
+          'Free the configured CDP port, then rerun openchrome doctor.',
+          'Use a different --port or CHROME_PORT value for this OpenChrome instance.',
+          'If another OpenChrome owner should be shared, connect through the broker path instead of creating a second direct controller.',
+        ],
+        docs: ['docs/mcp/topologies.md'],
+      };
+    case 'duplicate-controllers':
+      return {
+        ...base,
+        safe_alternatives: [
+          'Use --broker/--connect-broker or --auto-elect for coordinated sharing when enabled.',
+          'Do not use --allow-unsafe-shared-attach unless debugging a known race; it is intentionally not selected by default.',
+          'Assign independent clients separate --port and --user-data-dir values.',
+        ],
+        docs: ['docs/mcp/topologies.md', 'docs/roadmap/ssot-decisions.md'],
+      };
+    case 'pid-lock':
+      return {
+        ...base,
+        safe_alternatives: [
+          'Run openchrome reap to clean stale OpenChrome-managed state.',
+          'Remove only the stale PID file named in the detail if the process is no longer alive.',
+        ],
+      };
+    case 'profile-lock':
+      return {
+        ...base,
+        safe_alternatives: [
+          'Close Chrome windows using this profile before reusing it.',
+          'Use --user-data-dir to point OpenChrome at a separate profile.',
+        ],
+        docs: ['docs/mcp/topologies.md'],
+      };
+    default:
+      return base;
+  }
+}
+
+export function withPrescriptiveFields(result: Omit<CheckResult, 'durationMs'>): Omit<CheckResult, 'durationMs'> {
+  const defaults = prescriptiveDefaults(result);
+  return {
+    ...result,
+    ...defaults,
+    reason: result.reason ?? defaults.reason,
+    next_action: result.next_action ?? defaults.next_action,
+    safe_alternatives: result.safe_alternatives ?? defaults.safe_alternatives,
+    docs: result.docs ?? defaults.docs,
+    facts: result.facts ?? defaults.facts,
+  };
+}
 
 const ALL_CHECKS: Array<{ id: string; fn: CheckFn }> = [
   { id: 'node-version', fn: checkNodeVersion },
@@ -89,7 +174,7 @@ async function runCheckWithTimeout(id: string, fn: CheckFn): Promise<CheckResult
       detail: msg === 'timed out' ? 'timed out' : `Error: ${msg}`,
     };
   }
-  return { ...partial, durationMs: Date.now() - start };
+  return { ...withPrescriptiveFields(partial), durationMs: Date.now() - start };
 }
 
 export async function runDoctor(options: {
@@ -161,8 +246,19 @@ export function formatReport(report: DoctorReport, noColor: boolean): string {
     const statusStr = statusColor(r.status, noColor);
     const detail = r.detail ? `  ${r.detail}` : '';
     lines.push(`[${statusStr}] ${r.title}${detail}`);
-    if (r.remediation && r.status !== 'ok' && r.status !== 'skip') {
-      lines.push(`         Fix: ${r.remediation}`);
+    if (r.status !== 'ok' && r.status !== 'skip') {
+      if (r.remediation && (!r.next_action || r.next_action === r.remediation)) {
+        lines.push(`         Fix: ${r.remediation}`);
+      } else if (r.next_action) {
+        lines.push(`         Next: ${r.next_action}`);
+      } else if (r.remediation) {
+        lines.push(`         Fix: ${r.remediation}`);
+      }
+    }
+    if (r.safe_alternatives && r.safe_alternatives.length > 0 && r.status !== 'ok' && r.status !== 'skip') {
+      for (const alternative of r.safe_alternatives.slice(0, 2)) {
+        lines.push(`         Also: ${alternative}`);
+      }
     }
   }
 

--- a/src/cli/doctor/checks/chrome-binary.ts
+++ b/src/cli/doctor/checks/chrome-binary.ts
@@ -77,6 +77,24 @@ function findChromeHeadlessShell(): string | null {
   return null;
 }
 
+
+function displayPath(filePath: string): string {
+  const homes = [os.homedir()];
+  try {
+    homes.push(os.userInfo().homedir);
+  } catch {
+    // Best-effort redaction only.
+  }
+
+  const normalizedHomes = Array.from(new Set(homes.filter(Boolean)))
+    .sort((a, b) => b.length - a.length);
+  for (const home of normalizedHomes) {
+    if (filePath === home) return '~';
+    if (filePath.startsWith(`${home}${path.sep}`)) return `~/${filePath.slice(home.length + 1)}`;
+  }
+  return filePath;
+}
+
 function probeChromeVersion(chromePath: string): { major: number; raw: string } | null {
   try {
     const outputRaw = execFileSync(chromePath, ['--version'], {
@@ -102,17 +120,20 @@ export const checkChromeBinary: CheckFn = async () => {
       status: 'fail',
       detail: 'Chrome executable not found on this system',
       remediation: 'Install Google Chrome, or set CHROME_PATH env var to the binary path',
+      facts: { chromeFound: false },
     };
   }
 
   const version = probeChromeVersion(candidatePath);
+  const chromePath = displayPath(candidatePath);
   if (!version) {
     return {
       id: 'chrome-binary',
       title: 'Chrome binary',
       status: 'fail',
-      detail: `Found at ${candidatePath} but could not determine version`,
-      remediation: `Ensure Chrome is executable: chmod +x "${candidatePath}"`,
+      detail: `Found at ${chromePath} but could not determine version`,
+      remediation: `Ensure Chrome is executable: chmod +x "${chromePath}"`,
+      facts: { chromeFound: true, chromePath },
     };
   }
 
@@ -121,8 +142,9 @@ export const checkChromeBinary: CheckFn = async () => {
       id: 'chrome-binary',
       title: 'Chrome binary',
       status: 'fail',
-      detail: `${version.raw} at ${candidatePath} (minimum major: ${MIN_CHROME_MAJOR})`,
+      detail: `${version.raw} at ${chromePath} (minimum major: ${MIN_CHROME_MAJOR})`,
       remediation: 'Upgrade Chrome to a recent stable release — https://www.google.com/chrome',
+      facts: { chromeFound: true, chromePath, chromeMajor: version.major, minChromeMajor: MIN_CHROME_MAJOR },
     };
   }
 
@@ -130,6 +152,7 @@ export const checkChromeBinary: CheckFn = async () => {
     id: 'chrome-binary',
     title: 'Chrome binary',
     status: 'ok',
-    detail: `${version.raw} at ${candidatePath}`,
+    detail: `${version.raw} at ${chromePath}`,
+    facts: { chromeFound: true, chromePath, chromeMajor: version.major },
   };
 };

--- a/src/cli/doctor/checks/chrome-port.ts
+++ b/src/cli/doctor/checks/chrome-port.ts
@@ -62,6 +62,7 @@ export const checkChromePort: CheckFn = async () => {
       title: `CDP port ${port}`,
       status: 'ok',
       detail: `Port ${port} is free`,
+      facts: { port, cdpReachable: false, portFree: true },
     };
   }
 
@@ -73,6 +74,7 @@ export const checkChromePort: CheckFn = async () => {
       title: `CDP port ${port}`,
       status: 'ok',
       detail: `CDP endpoint active: ${cdp.browser}`,
+      facts: { port, cdpReachable: true, portFree: false, browser: cdp.browser },
     };
   }
 
@@ -85,5 +87,6 @@ export const checkChromePort: CheckFn = async () => {
     status: 'warn',
     detail: `Port ${port} is in use${pidInfo} but no CDP endpoint found`,
     remediation: `Free port ${port} or set CHROME_PORT to a different port`,
+    facts: { port, cdpReachable: false, portFree: false, ...(pid ? { pid } : {}) },
   };
 };

--- a/src/cli/doctor/checks/duplicate-controllers.ts
+++ b/src/cli/doctor/checks/duplicate-controllers.ts
@@ -3,12 +3,34 @@
  * Surfaces unsafe multi-controller OpenChrome topologies before they cause CDP disconnects.
  */
 
+import * as os from 'os';
+import * as path from 'path';
 import type { CheckFn } from '../../doctor';
-import { summarizeDuplicateControllerDiagnostics } from '../../../utils/duplicate-controller-diagnostics';
+import { getCurrentControllerTopology, summarizeDuplicateControllerDiagnostics } from '../../../utils/duplicate-controller-diagnostics';
+
+function displayPath(filePath: string): string {
+  const homes = [os.homedir()];
+  try {
+    homes.push(os.userInfo().homedir);
+  } catch {
+    // Best-effort redaction only.
+  }
+
+  const normalizedHomes = Array.from(new Set(homes.filter(Boolean)))
+    .sort((a, b) => b.length - a.length);
+  for (const home of normalizedHomes) {
+    if (filePath === home) return '~';
+    if (filePath.startsWith(`${home}${path.sep}`)) return `~/${filePath.slice(home.length + 1)}`;
+  }
+  return filePath;
+}
 
 export const checkDuplicateControllers: CheckFn = async () => {
   const diagnostics = summarizeDuplicateControllerDiagnostics();
-  if (diagnostics.warnings.length === 0) {
+  const topology = getCurrentControllerTopology();
+  const blockedByOwner = topology.role === 'unknown' && topology.ownerPid !== undefined;
+
+  if (diagnostics.warnings.length === 0 && !blockedByOwner) {
     return {
       id: 'duplicate-controllers',
       title: 'Duplicate OpenChrome controllers',
@@ -18,9 +40,12 @@ export const checkDuplicateControllers: CheckFn = async () => {
   }
 
   const duplicateDetail = diagnostics.duplicateGroups.map((group) => (
-    `port ${group.port}, profile ${group.userDataDir}: pid(s) ${group.processes.map((proc) => proc.pid).join(', ')}`
+    `port ${group.port}, profile ${displayPath(group.userDataDir)}: pid(s) ${group.processes.map((proc) => proc.pid).join(', ')}`
   ));
-  const detailParts = [...diagnostics.warnings, ...duplicateDetail];
+  const ownershipDetail = blockedByOwner
+    ? [`configured port ${topology.port}, profile ${displayPath(topology.userDataDir)} is already owned by OpenChrome PID ${topology.ownerPid}`]
+    : [];
+  const detailParts = [...diagnostics.warnings, ...duplicateDetail, ...ownershipDetail];
 
   return {
     id: 'duplicate-controllers',
@@ -28,5 +53,14 @@ export const checkDuplicateControllers: CheckFn = async () => {
     status: 'warn',
     detail: detailParts.join('; '),
     remediation: diagnostics.remediation.join(' '),
+    facts: {
+      ...(blockedByOwner ? {
+        runtime_topology: 'blocked-by-owner',
+        port: topology.port,
+        userDataDir: displayPath(topology.userDataDir),
+        lockPath: displayPath(topology.lockPath),
+        ownerPid: topology.ownerPid,
+      } : {}),
+    },
   };
 };

--- a/src/cli/doctor/runtime-diagnostics.ts
+++ b/src/cli/doctor/runtime-diagnostics.ts
@@ -41,9 +41,19 @@ export interface DoctorDiagnostics {
 
 
 export function displayPath(filePath: string): string {
-  const home = os.homedir();
-  if (filePath === home) return '~';
-  if (filePath.startsWith(`${home}/`)) return `~/${filePath.slice(home.length + 1)}`;
+  const homes = [os.homedir()];
+  try {
+    homes.push(os.userInfo().homedir);
+  } catch {
+    // Best-effort redaction only.
+  }
+
+  const normalizedHomes = Array.from(new Set(homes.filter(Boolean)))
+    .sort((a, b) => b.length - a.length);
+  for (const home of normalizedHomes) {
+    if (filePath === home) return '~';
+    if (filePath.startsWith(`${home}/`)) return `~/${filePath.slice(home.length + 1)}`;
+  }
   return filePath;
 }
 

--- a/src/utils/duplicate-controller-diagnostics.ts
+++ b/src/utils/duplicate-controller-diagnostics.ts
@@ -192,8 +192,8 @@ export function summarizeDuplicateControllerDiagnostics(options: {
   if (staleConfigs.length > 0) warnings.push(`stale MCP config registration(s) detected: ${staleConfigs.map((config) => config.path).join(', ')}`);
 
   const remediation = [
-    'Keep exactly one direct OpenChrome controller per Chrome port/profile until broker mode is available.',
-    'Prefer assigning different --port and --user-data-dir values to independent MCP clients, or route clients through the future broker topology.',
+    'Keep exactly one direct OpenChrome owner per Chrome port/profile.',
+    'For coordinated sharing, route clients through --broker/--connect-broker or --auto-elect when that topology is explicitly enabled.',
     'Remove stale MCP registrations such as ~/.codex/mcp.json after migrating to the active client config.',
   ];
 

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -105,6 +105,20 @@ describe('openchrome doctor --json', () => {
     expect(report.summary).toEqual(computed);
   });
 
+
+  test('degraded checks expose structured remediation fields when present', () => {
+    const fs = require('fs');
+    if (!fs.existsSync(DIST_INDEX)) return;
+    for (const result of report.results) {
+      if (result.status === 'warn' || result.status === 'fail') {
+        expect(result.reason ?? result.detail).toBeDefined();
+        if (result.remediation) {
+          expect(result.next_action).toBe(result.remediation);
+        }
+      }
+    }
+  });
+
   test('each result has required fields', () => {
     const fs = require('fs');
     if (!fs.existsSync(DIST_INDEX)) return;
@@ -146,6 +160,19 @@ describe('openchrome doctor --json', () => {
     });
     expect(result.stdout).toContain('=== openchrome doctor ===');
     expect(result.stdout).toContain('Node.js version');
+    expect(result.status).toBe(0);
+  });
+
+
+  test('package bin wrapper delegates check to canonical implementation', () => {
+    const fs = require('fs');
+    if (!fs.existsSync(DIST_CLI_INDEX)) return;
+    const result = spawnSync(process.execPath, [DIST_CLI_INDEX, 'check', '--help'], {
+      encoding: 'utf8',
+      timeout: 30000,
+      env: { ...process.env, NODE_ENV: 'test' },
+    });
+    expect(result.stdout).toContain('Check Chrome connection status');
     expect(result.status).toBe(0);
   });
 

--- a/tests/cli/doctor/checks/duplicate-controllers.test.ts
+++ b/tests/cli/doctor/checks/duplicate-controllers.test.ts
@@ -1,0 +1,62 @@
+import { checkDuplicateControllers } from '../../../../src/cli/doctor/checks/duplicate-controllers';
+import { withPrescriptiveFields } from '../../../../src/cli/doctor';
+import {
+  getCurrentControllerTopology,
+  summarizeDuplicateControllerDiagnostics,
+} from '../../../../src/utils/duplicate-controller-diagnostics';
+
+jest.mock('../../../../src/utils/duplicate-controller-diagnostics', () => ({
+  getCurrentControllerTopology: jest.fn(),
+  summarizeDuplicateControllerDiagnostics: jest.fn(),
+}));
+
+const mockSummarize = summarizeDuplicateControllerDiagnostics as jest.MockedFunction<typeof summarizeDuplicateControllerDiagnostics>;
+const mockTopology = getCurrentControllerTopology as jest.MockedFunction<typeof getCurrentControllerTopology>;
+
+describe('duplicate controller doctor check', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockSummarize.mockReturnValue({
+      processes: [],
+      duplicateGroups: [],
+      configs: [],
+      mixedInstallations: false,
+      warnings: [],
+      remediation: [
+        'Keep exactly one direct OpenChrome owner per Chrome port/profile.',
+        'For coordinated sharing, route clients through --broker/--connect-broker or --auto-elect when that topology is explicitly enabled.',
+      ],
+    });
+    mockTopology.mockReturnValue({
+      role: 'unlocked',
+      port: 9222,
+      userDataDir: '/tmp/openchrome-profile',
+      lockPath: '/tmp/openchrome-lock.json',
+    });
+  });
+
+  test('warns with facts when configured port/profile is owned by another OpenChrome process', async () => {
+    mockTopology.mockReturnValue({
+      role: 'unknown',
+      port: 47777,
+      userDataDir: '/tmp/openchrome-live-profile',
+      lockPath: '/tmp/openchrome-live-profile.lock',
+      ownerPid: 12345,
+    });
+
+    const result = withPrescriptiveFields(await checkDuplicateControllers());
+
+    expect(result.status).toBe('warn');
+    expect(result.detail).toContain('already owned by OpenChrome PID 12345');
+    expect(result.reason).toContain('already owned');
+    expect(result.next_action).toContain('one direct OpenChrome owner');
+    expect(result.safe_alternatives?.slice(0, 2).join('\n')).toContain('--allow-unsafe-shared-attach');
+    expect(result.facts).toEqual(expect.objectContaining({
+      runtime_topology: 'blocked-by-owner',
+      port: 47777,
+      userDataDir: '/tmp/openchrome-live-profile',
+      lockPath: '/tmp/openchrome-live-profile.lock',
+      ownerPid: 12345,
+    }));
+  });
+});

--- a/tests/cli/doctor/prescriptive-fields.test.ts
+++ b/tests/cli/doctor/prescriptive-fields.test.ts
@@ -1,0 +1,112 @@
+import { formatReport, withPrescriptiveFields, type DoctorReport } from '../../../src/cli/doctor';
+
+describe('doctor prescriptive fields', () => {
+  test('mirrors remediation into reason and next_action for degraded checks', () => {
+    const result = withPrescriptiveFields({
+      id: 'chrome-port',
+      title: 'CDP port 9222',
+      status: 'warn',
+      detail: 'Port 9222 is in use but no CDP endpoint found',
+      remediation: 'Free port 9222 or set CHROME_PORT to a different port',
+    });
+
+    expect(result.reason).toContain('Port 9222 is in use');
+    expect(result.next_action).toContain('Free port 9222');
+    expect(result.safe_alternatives).toEqual(expect.arrayContaining([
+      expect.stringContaining('different --port'),
+    ]));
+    expect(result.docs).toContain('docs/mcp/topologies.md');
+  });
+
+  test('preserves existing explicit structured fields', () => {
+    const result = withPrescriptiveFields({
+      id: 'chrome-port',
+      title: 'CDP port 9222',
+      status: 'warn',
+      detail: 'detail',
+      remediation: 'legacy remediation',
+      reason: 'custom reason',
+      next_action: 'custom action',
+      safe_alternatives: ['custom alternative'],
+      docs: ['custom.md'],
+      facts: { port: 9222 },
+    });
+
+    expect(result.reason).toBe('custom reason');
+    expect(result.next_action).toBe('custom action');
+    expect(result.safe_alternatives).toEqual(['custom alternative']);
+    expect(result.docs).toEqual(['custom.md']);
+    expect(result.facts).toEqual({ port: 9222 });
+  });
+
+
+  test('does not attach remediation advice to ok checks', () => {
+    const result = withPrescriptiveFields({
+      id: 'chrome-binary',
+      title: 'Chrome binary',
+      status: 'ok',
+      detail: 'Chrome found',
+      facts: { chromeFound: true },
+    });
+
+    expect(result.reason).toBeUndefined();
+    expect(result.next_action).toBeUndefined();
+    expect(result.safe_alternatives).toBeUndefined();
+    expect(result.docs).toBeUndefined();
+    expect(result.facts).toEqual({ chromeFound: true });
+  });
+
+
+  test('human formatter keeps legacy Fix label when next_action mirrors remediation', () => {
+    const report: DoctorReport = {
+      openchromeVersion: '0.0.0-test',
+      platform: process.platform,
+      arch: process.arch,
+      nodeVersion: process.versions.node,
+      startedAt: new Date(0).toISOString(),
+      diagnostics: {
+        runtime: {
+          runtime_topology: 'unknown',
+          active_runtime_path: 'unknown',
+          facts: {
+            port: 9222,
+            userDataDir: '~/.openchrome/profile',
+            controllerRole: 'unlocked',
+            lockPath: '~/.openchrome/locks/test.lock',
+            autoElectEnabled: false,
+            unsafeSharedAttachEnabled: false,
+          },
+        },
+      },
+      results: [{
+        id: 'chrome-port',
+        title: 'CDP port 9222',
+        status: 'warn',
+        detail: 'busy',
+        remediation: 'Free port 9222',
+        next_action: 'Free port 9222',
+        durationMs: 1,
+      }],
+      summary: { ok: 0, warn: 1, fail: 0, skip: 0 },
+      exitCode: 1,
+    };
+
+    const formatted = formatReport(report, true);
+    expect(formatted).toContain('Fix: Free port 9222');
+    expect(formatted).not.toContain('Next: Free port 9222');
+  });
+
+  test('duplicate-controller advice keeps unsafe shared attach as a non-default debug escape', () => {
+    const result = withPrescriptiveFields({
+      id: 'duplicate-controllers',
+      title: 'Duplicate OpenChrome controllers',
+      status: 'warn',
+      detail: 'duplicate controller group detected',
+      remediation: 'Use one direct controller per port/profile',
+    });
+
+    expect(result.safe_alternatives?.join('\n')).toContain('--allow-unsafe-shared-attach');
+    expect(result.safe_alternatives?.join('\n')).toContain('not selected by default');
+    expect(result.safe_alternatives?.slice(0, 2).join('\n')).toContain('--allow-unsafe-shared-attach');
+  });
+});

--- a/tests/tools/oc-doctor-report.test.ts
+++ b/tests/tools/oc-doctor-report.test.ts
@@ -23,6 +23,13 @@ const SAMPLE_REPORT = {
   results: [
     { id: 'node-version', title: 'Node.js version', status: 'ok', durationMs: 1 },
   ],
+  diagnostics: {
+    runtime: {
+      runtime_topology: 'unknown',
+      active_runtime_path: 'unknown',
+      facts: { port: 9222, userDataDir: '~/.openchrome/profile', controllerRole: 'unlocked', lockPath: '~/.openchrome/locks/example.json', autoElectEnabled: false, unsafeSharedAttachEnabled: false },
+    },
+  },
   summary: { ok: 1, warn: 0, fail: 0, skip: 0 },
   exitCode: 0,
 };
@@ -100,6 +107,7 @@ describe('oc_doctor_report tool', () => {
     expect(parsed.report).toBeDefined();
     expect(parsed.report.openchromeVersion).toBe('1.11.0');
     expect(parsed.report.results).toHaveLength(1);
+    expect(parsed.report.diagnostics.runtime.runtime_topology).toBe('unknown');
     expect(parsed.cachedAt).toBeDefined();
     expect(typeof parsed.cachedAt).toBe('number');
   });


### PR DESCRIPTION
## Summary

Closes #1505.

Implements phase 2 prescriptive doctor remediation on top of the merged phase 1 runtime topology facts:

- Adds additive structured doctor fields: `reason`, `next_action`, `safe_alternatives`, `docs`, and `facts`.
- Keeps human doctor output backward-compatible by preserving the existing `Fix:` label when `next_action` mirrors `remediation`.
- Adds prescriptive remediation for common degraded cases: missing Chrome binary, CDP port issues, PID/profile locks, duplicate/blocked controller ownership.
- Reports same port/profile already owned by another OpenChrome process as a degraded `duplicate-controllers` check with `facts.runtime_topology=blocked-by-owner` and `next_action`.
- Keeps `oc_doctor_report` cache-only and confirms it returns the cached structured report.
- Adds `dist/cli/index.js check` wrapper delegation to the canonical CLI so the documented verification command works.

## SSOT / Guardrails

- Preserves #1359: OpenChrome remains a host-neutral MCP browser harness.
- No domain-specific website/platform knowledge added.
- No server-side LLM calls, autonomous planning, scraping framework behavior, or host-specific Codex/Claude-only behavior added.
- No Chrome ownership, broker, auto-elect, unsafe attach, or default topology behavior changed.
- Doctor suggests only; it does not automatically repair.

## Verification

Local:

```text
npm run build
npm test -- --runInBand tests/cli/doctor/prescriptive-fields.test.ts tests/cli/doctor/checks/duplicate-controllers.test.ts tests/cli/doctor/runtime-diagnostics.test.ts tests/cli/doctor.test.ts tests/tools/oc-doctor-report.test.ts
npm run lint:tier
npm run docs:capability-map:check
```

Full Jest before the final wrapper-only addition:

```text
Test Suites: 3 skipped, 620 passed, 620 of 623 total
Tests:       97 skipped, 7492 passed, 7589 total
Snapshots:   2 passed, 2 total
```

Command smoke:

```text
node dist/cli/index.js doctor --json
# JSON parsed successfully; local exit=1 because this machine currently has doctor warnings.

node dist/cli/index.js doctor --no-color
# Human output includes Fix:/Also: remediation.

node dist/cli/index.js check
# Command delegates correctly; local exit=1 because no Chrome is connected on default port 9222.

git diff --check
# pass
```

Live temp-profile verification (no normal Chrome profile/process killed or touched):

```text
tmp_root= /tmp/openchrome-live-1505-ZnNP1K
runtime_topology= blocked-by-owner
duplicate_status= warn
duplicate_next_action= Keep exactly one direct OpenChrome owner per Chrome port/profile. For coordinated sharing, route clients through --broker/--connect-broker or --auto-elect when that topology is explicitly enabled. Remove stale MCP registrations such as ~/.codex/mcp.json after migrating to the active client config.
duplicate_facts= {'runtime_topology': 'blocked-by-owner', 'port': 49163, 'userDataDir': '/tmp/openchrome-live-1505-ZnNP1K/profile', 'lockPath': '~/.openchrome/locks/port-49163-tmp_openchrome-live-1505-ZnNP1K_profile.json', 'ownerPid': 7509}
```

Human doctor excerpt from the same temp run:

```text
[ warn ] Duplicate OpenChrome controllers ... configured port 49163, profile /tmp/openchrome-live-1505-ZnNP1K/profile is already owned by OpenChrome PID 7509
         Fix: Keep exactly one direct OpenChrome owner per Chrome port/profile. For coordinated sharing, route clients through --broker/--connect-broker or --auto-elect when that topology is explicitly enabled. Remove stale MCP registrations such as ~/.codex/mcp.json after migrating to the active client config.
         Also: Use --broker/--connect-broker or --auto-elect for coordinated sharing when enabled.
         Also: Do not use --allow-unsafe-shared-attach unless debugging a known race; it is intentionally not selected by default.
```

`oc_doctor_report` cached structured report verification:

```text
oc_doctor_report= {'success': True, 'runtime_topology': 'blocked-by-owner', 'duplicate_next_action': 'Keep exactly one direct OpenChrome owner per Chrome port/profile. For coordinated sharing, route clients through --broker/--connect-broker or --auto-elect when that topology is explicitly enabled. Remove stale MCP registrations such as ~/.codex/mcp.json after migrating to the active client config.'}
```

## Review Notes

Earlier independent code-reviewer/architect reviews found issues around OK-state remediation, path redaction, text-output compatibility, and unsafe-attach visibility. This PR fixes those findings:

- OK/skip checks do not receive prescriptive remediation defaults.
- Home-relative display paths redact both `os.homedir()` and `os.userInfo().homedir`.
- Existing `Fix:` output is preserved when structured `next_action` mirrors `remediation`.
- Unsafe shared attach warning appears in the default human output for duplicate-controller warnings.
