### PR TITLE
Validate live broker metadata before proxy attach

### DIFF
--- a/src/broker/discovery.ts
+++ b/src/broker/discovery.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { getVersion } from '../version';
-import { controllerLockKey, normalizeControllerUserDataDir } from '../utils/controller-lock';
+import { controllerLockKey, isPidAlive, normalizeControllerUserDataDir } from '../utils/controller-lock';
 
 export interface BrokerIdentity {
   port: number;
@@ -69,6 +69,61 @@ export function readBrokerMetadata(port: number, userDataDir: string, rootDir?: 
   } catch {
     return null;
   }
+}
+
+export interface LiveBrokerMetadataOptions {
+  rootDir?: string;
+  fetchImpl?: typeof fetch;
+  isPidAliveImpl?: (pid: number) => boolean;
+}
+
+type BrokerEndpointState = 'live' | 'not-broker' | 'unreachable';
+
+function brokerHealthEndpoint(metadata: BrokerMetadata): string {
+  const url = new URL(metadata.endpoint);
+  url.pathname = '/health';
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}
+
+async function brokerEndpointState(metadata: BrokerMetadata, fetchImpl: typeof fetch): Promise<BrokerEndpointState> {
+  try {
+    const response = await fetchImpl(brokerHealthEndpoint(metadata), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(1000),
+    });
+    if (response.status !== 200) return 'not-broker';
+
+    const body = await response.json().catch(() => null) as { status?: unknown; transport?: unknown } | null;
+    return body?.status === 'ok' && body.transport === 'http' ? 'live' : 'not-broker';
+  } catch {
+    return 'unreachable';
+  }
+}
+
+export async function resolveLiveBrokerMetadata(
+  port: number,
+  userDataDir: string,
+  options: LiveBrokerMetadataOptions = {},
+): Promise<BrokerMetadata | null> {
+  const metadata = readBrokerMetadata(port, userDataDir, options.rootDir);
+  if (!metadata) return null;
+
+  const pidAlive = (options.isPidAliveImpl ?? isPidAlive)(metadata.pid);
+  if (!pidAlive) {
+    removeBrokerMetadata(port, userDataDir, metadata.pid, options.rootDir);
+    return null;
+  }
+
+  const endpointState = await brokerEndpointState(metadata, options.fetchImpl ?? fetch);
+  if (endpointState === 'live') return metadata;
+
+  if (endpointState === 'not-broker') {
+    removeBrokerMetadata(port, userDataDir, metadata.pid, options.rootDir);
+  }
+  return null;
 }
 
 export function removeBrokerMetadata(port: number, userDataDir: string, pid = process.pid, rootDir?: string): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -314,9 +314,9 @@ program
     }
 
     if (options.connectBroker) {
-      const { readBrokerMetadata } = await import('./broker/discovery');
+      const { resolveLiveBrokerMetadata } = await import('./broker/discovery');
       const { BrokerProxyStdioBridge } = await import('./transports/broker-proxy');
-      const broker = readBrokerMetadata(port, lockUserDataDir);
+      const broker = await resolveLiveBrokerMetadata(port, lockUserDataDir);
       if (!broker) {
         console.error(`[openchrome] No broker metadata found for port ${port} and profile ${lockUserDataDir}. Start one with: openchrome serve --broker --auto-launch --port ${port} --user-data-dir ${lockUserDataDir}`);
         process.exit(2);
@@ -364,12 +364,12 @@ program
             // coordinated --connect-broker client; the previously-rejected surplus
             // session now works.
             if (autoElect) {
-              const { readBrokerMetadata } = await import('./broker/discovery');
+              const { resolveLiveBrokerMetadata } = await import('./broker/discovery');
               const { BrokerProxyStdioBridge } = await import('./transports/broker-proxy');
-              let broker = readBrokerMetadata(port, lockUserDataDir);
+              let broker = await resolveLiveBrokerMetadata(port, lockUserDataDir);
               for (let i = 0; i < 10 && !broker; i++) {
                 await new Promise((r) => setTimeout(r, 300));
-                broker = readBrokerMetadata(port, lockUserDataDir);
+                broker = await resolveLiveBrokerMetadata(port, lockUserDataDir);
               }
               if (broker && shouldClientAutoConnect({ autoElect, brokerPresent: true })) {
                 const resolvedAuthToken = options.authToken

--- a/tests/broker-discovery.test.ts
+++ b/tests/broker-discovery.test.ts
@@ -7,6 +7,7 @@ import {
   publishBrokerMetadata,
   readBrokerMetadata,
   removeBrokerMetadata,
+  resolveLiveBrokerMetadata,
 } from '../src/broker/discovery';
 
 describe('broker discovery metadata', () => {
@@ -60,5 +61,74 @@ describe('broker discovery metadata', () => {
     removeBrokerMetadata(9222, profile, process.pid, tmpDir);
 
     expect(readBrokerMetadata(9222, profile, tmpDir)?.pid).toBe(999999);
+  });
+
+  test('live resolver removes metadata for a dead owner pid', async () => {
+    const profile = path.join(tmpDir, 'profile');
+    publishBrokerMetadata({ port: 9222, userDataDir: profile, httpHost: '127.0.0.1', httpPort: 3101, pid: 999999 }, tmpDir);
+
+    const resolved = await resolveLiveBrokerMetadata(9222, profile, {
+      rootDir: tmpDir,
+      isPidAliveImpl: () => false,
+      fetchImpl: jest.fn() as unknown as typeof fetch,
+    });
+
+    expect(resolved).toBeNull();
+    expect(readBrokerMetadata(9222, profile, tmpDir)).toBeNull();
+  });
+
+  test('live resolver preserves live-pid metadata when the endpoint has a transient failure', async () => {
+    const profile = path.join(tmpDir, 'profile');
+    const metadata = publishBrokerMetadata({ port: 9222, userDataDir: profile, httpHost: '127.0.0.1', httpPort: 3101, pid: 123 }, tmpDir);
+
+    const resolved = await resolveLiveBrokerMetadata(9222, profile, {
+      rootDir: tmpDir,
+      isPidAliveImpl: () => true,
+      fetchImpl: jest.fn(async () => { throw new Error('ECONNREFUSED'); }) as unknown as typeof fetch,
+    });
+
+    expect(resolved).toBeNull();
+    expect(readBrokerMetadata(9222, profile, tmpDir)).toEqual(metadata);
+  });
+
+  test('live resolver removes metadata when the endpoint is a non-broker HTTP service', async () => {
+    const profile = path.join(tmpDir, 'profile');
+    publishBrokerMetadata({ port: 9222, userDataDir: profile, httpHost: '127.0.0.1', httpPort: 3101, pid: 123 }, tmpDir);
+
+    const resolved = await resolveLiveBrokerMetadata(9222, profile, {
+      rootDir: tmpDir,
+      isPidAliveImpl: () => true,
+      fetchImpl: jest.fn(async () => ({
+        status: 404,
+        json: async () => ({ error: 'not found' }),
+      } as Response)) as unknown as typeof fetch,
+    });
+
+    expect(resolved).toBeNull();
+    expect(readBrokerMetadata(9222, profile, tmpDir)).toBeNull();
+  });
+
+  test('live resolver requires OpenChrome health response and preserves auth token env hints', async () => {
+    const profile = path.join(tmpDir, 'profile');
+    const metadata = publishBrokerMetadata({
+      port: 9222,
+      userDataDir: profile,
+      httpHost: '127.0.0.1',
+      httpPort: 3101,
+      pid: 123,
+      authTokenEnv: 'OPENCHROME_AUTH_TOKEN',
+    }, tmpDir);
+
+    const resolved = await resolveLiveBrokerMetadata(9222, profile, {
+      rootDir: tmpDir,
+      isPidAliveImpl: () => true,
+      fetchImpl: jest.fn(async () => ({
+        status: 200,
+        json: async () => ({ status: 'ok', transport: 'http' }),
+      } as Response)) as unknown as typeof fetch,
+    });
+
+    expect(resolved).toEqual(metadata);
+    expect(resolved?.authTokenEnv).toBe('OPENCHROME_AUTH_TOKEN');
   });
 });


### PR DESCRIPTION
Closes #1502.

## Implementation scope
- Adds `resolveLiveBrokerMetadata()` as the live-validation attach gate for broker discovery records.
- Validates owner PID before broker client/proxy attach.
- Probes the broker's OpenChrome `/health` endpoint before treating metadata as live.
- Removes metadata immediately for dead owner PIDs and for endpoints that respond as non-OpenChrome HTTP services.
- Preserves metadata on live-PID endpoint transients so one startup/load hiccup cannot strand a valid broker owner.
- Wires manual `--connect-broker` and auto-elect loser polling to use live metadata resolution.

## Verification
- `npm test -- --runTestsByPath tests/broker-discovery.test.ts`
- `npm run build`
- Dist smoke: dead-pid stale broker metadata resolves `null` and is removed.
- Dist smoke: live-pid transient endpoint failure resolves `null` but preserves metadata for later retry.

## Code review
- Architecture review: CLEAR for D3 topology alignment.
- Code review found two blockers (transient deletion and accepting any HTTP response); both fixed with tests.

## Explicit non-goals
- No default auto-elect behavior changes.
- No setup/config mutation.
- No new dependencies.
- No unsafe shared direct CDP ownership.
- No full parallel-session harness; reserved for #1504.

## Risks / known gaps
- Real multi-client broker smoke is deferred to #1500/#1504 per PR decomposition.
