### PR TITLE
Share owner self-release confirmation logic

### DIFF
--- a/src/chrome/owner-self-release.ts
+++ b/src/chrome/owner-self-release.ts
@@ -49,6 +49,65 @@ export interface OwnerSelfReleaseDeps {
   log?: (message: string) => void;
 }
 
+export type OwnerReleaseAttemptResult = 'released' | 'reachable' | 'aborted' | 'inconclusive';
+
+export interface OwnerReleaseAttemptOptions {
+  /** Human-readable trigger used in release logs. */
+  trigger: string;
+  /**
+   * Optional race guard checked after the async CDP probe resolves. Return true
+   * when another recovery signal made the probe result stale.
+   */
+  abortIfRecovered?: () => boolean;
+  /** Called when the probe errors and release is skipped. */
+  onInconclusive?: () => void;
+  /** Called when Chrome is reachable or a recovery race aborts release. */
+  onKept?: () => void;
+}
+
+export async function releaseOwnerIfChromeUnreachable(
+  deps: OwnerSelfReleaseDeps,
+  options: OwnerReleaseAttemptOptions,
+): Promise<OwnerReleaseAttemptResult> {
+  const log = deps.log ?? ((m: string) => console.error(m));
+  let reachable: boolean;
+  try {
+    reachable = await deps.probeChromeReachable();
+  } catch (err) {
+    log(
+      `[SelfHealing] Chrome reachability probe errored during self-release; ` +
+        `staying up: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    options.onInconclusive?.();
+    return 'inconclusive';
+  }
+
+  if (options.abortIfRecovered?.()) {
+    options.onKept?.();
+    return 'aborted';
+  }
+
+  if (reachable) {
+    options.onKept?.();
+    return 'reachable';
+  }
+
+  log(
+    `[SelfHealing] Chrome unreachable after ${options.trigger}; releasing controller lock and ` +
+      `exiting (code ${OWNER_SELF_RELEASE_EXIT_CODE}) so another session can take over (#1474).`,
+  );
+  try {
+    deps.releaseLock();
+  } catch (err) {
+    log(
+      `[SelfHealing] Controller lock release failed during self-release: ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  deps.exit(OWNER_SELF_RELEASE_EXIT_CODE);
+  return 'released';
+}
+
 /**
  * Subscribe to the watchdog's relaunch-lifecycle events and, when Chrome is
  * confirmed irrecoverable, release the controller lock and exit.
@@ -62,7 +121,6 @@ export interface OwnerSelfReleaseDeps {
  * crash cannot flap the lock.
  */
 export function wireOwnerSelfRelease(watchdog: EventEmitter, deps: OwnerSelfReleaseDeps): void {
-  const log = deps.log ?? ((m: string) => console.error(m));
   const threshold = Math.max(1, deps.failureThreshold ?? DEFAULT_RELEASE_FAILURE_THRESHOLD);
   let consecutiveFailures = 0;
   let releasing = false;
@@ -85,53 +143,19 @@ export function wireOwnerSelfRelease(watchdog: EventEmitter, deps: OwnerSelfRele
     releasing = true;
     recoveredDuringProbe = false;
     void (async () => {
-      let reachable: boolean;
-      try {
-        reachable = await deps.probeChromeReachable();
-      } catch (err) {
-        // Inconclusive probe — do not tear down on uncertainty. Step the
-        // counter back one so at least one more failure is required before we
-        // re-probe, avoiding a tight no-back-off retry when the probe keeps
-        // timing out.
-        log(
-          `[SelfHealing] Chrome reachability probe errored during self-release; ` +
-            `staying up: ${err instanceof Error ? err.message : String(err)}`,
-        );
-        consecutiveFailures = Math.max(0, threshold - 1);
-        releasing = false;
-        return;
-      }
-
-      // A successful relaunch landed while we were probing — abort: a stale
-      // `false` here would tear down the freshly recovered browser.
-      if (recoveredDuringProbe) {
-        recoveredDuringProbe = false;
-        consecutiveFailures = 0;
-        releasing = false;
-        return;
-      }
-
-      if (reachable) {
-        // Chrome is actually serving despite the relaunch error — keep running.
-        consecutiveFailures = 0;
-        releasing = false;
-        return;
-      }
-
-      log(
-        `[SelfHealing] Chrome unrecoverable after ${consecutiveFailures} consecutive ` +
-          `relaunch failures and a confirming CDP probe; releasing controller lock and ` +
-          `exiting (code ${OWNER_SELF_RELEASE_EXIT_CODE}) so another session can take over (#1474).`,
-      );
-      try {
-        deps.releaseLock();
-      } catch (err) {
-        log(
-          `[SelfHealing] Controller lock release failed during self-release: ` +
-            `${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-      deps.exit(OWNER_SELF_RELEASE_EXIT_CODE);
+      await releaseOwnerIfChromeUnreachable(deps, {
+        trigger: `${consecutiveFailures} consecutive relaunch failures and a confirming CDP probe`,
+        abortIfRecovered: () => recoveredDuringProbe,
+        onInconclusive: () => {
+          consecutiveFailures = Math.max(0, threshold - 1);
+          releasing = false;
+        },
+        onKept: () => {
+          recoveredDuringProbe = false;
+          consecutiveFailures = 0;
+          releasing = false;
+        },
+      });
     })();
   });
 }

--- a/tests/owner-self-release.test.ts
+++ b/tests/owner-self-release.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 import {
   DEFAULT_RELEASE_FAILURE_THRESHOLD,
   OWNER_SELF_RELEASE_EXIT_CODE,
+  releaseOwnerIfChromeUnreachable,
   wireOwnerSelfRelease,
 } from '../src/chrome/owner-self-release';
 
@@ -168,5 +169,71 @@ describe('owner self-release (#1474)', () => {
 
     expect(exit).toHaveBeenCalledWith(OWNER_SELF_RELEASE_EXIT_CODE);
     expect(log).toHaveBeenCalledWith(expect.stringContaining('release failed'));
+  });
+
+  test('primitive releases only after a confirming unreachable probe', async () => {
+    const releaseLock = jest.fn();
+    const exit = jest.fn();
+    const result = await releaseOwnerIfChromeUnreachable({
+      releaseLock,
+      exit,
+      log: jest.fn(),
+      probeChromeReachable: jest.fn(async () => false),
+    }, { trigger: 'startup connect failure' });
+
+    expect(result).toBe('released');
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(OWNER_SELF_RELEASE_EXIT_CODE);
+  });
+
+  test('primitive keeps ownership when Chrome is reachable', async () => {
+    const releaseLock = jest.fn();
+    const exit = jest.fn();
+    const onKept = jest.fn();
+    const result = await releaseOwnerIfChromeUnreachable({
+      releaseLock,
+      exit,
+      log: jest.fn(),
+      probeChromeReachable: jest.fn(async () => true),
+    }, { trigger: 'startup connect failure', onKept });
+
+    expect(result).toBe('reachable');
+    expect(onKept).toHaveBeenCalledTimes(1);
+    expect(releaseLock).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  test('primitive aborts release when a recovery race makes the probe stale', async () => {
+    const releaseLock = jest.fn();
+    const exit = jest.fn();
+    const onKept = jest.fn();
+    const result = await releaseOwnerIfChromeUnreachable({
+      releaseLock,
+      exit,
+      log: jest.fn(),
+      probeChromeReachable: jest.fn(async () => false),
+    }, { trigger: 'startup connect failure', abortIfRecovered: () => true, onKept });
+
+    expect(result).toBe('aborted');
+    expect(onKept).toHaveBeenCalledTimes(1);
+    expect(releaseLock).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  test('primitive treats probe errors as inconclusive and keeps ownership', async () => {
+    const releaseLock = jest.fn();
+    const exit = jest.fn();
+    const onInconclusive = jest.fn();
+    const result = await releaseOwnerIfChromeUnreachable({
+      releaseLock,
+      exit,
+      log: jest.fn(),
+      probeChromeReachable: jest.fn(async () => { throw new Error('probe failed'); }),
+    }, { trigger: 'startup connect failure', onInconclusive });
+
+    expect(result).toBe('inconclusive');
+    expect(onInconclusive).toHaveBeenCalledTimes(1);
+    expect(releaseLock).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Part of #1503 (PR A).

## Implementation scope
- Extracts the existing owner self-release CDP reachability confirmation into `releaseOwnerIfChromeUnreachable()`.
- Keeps `wireOwnerSelfRelease()` behavior on the same safety gates:
  - inconclusive probe keeps owner alive,
  - recovered-during-probe aborts release,
  - reachable Chrome keeps owner alive,
  - unreachable Chrome releases lock and exits with `OWNER_SELF_RELEASE_EXIT_CODE`.
- Adds targeted primitive tests.

## Verification
- `npm test -- --runTestsByPath tests/owner-self-release.test.ts`
- `npm run build`
- Self-review: diff is behavior-preserving refactor plus tests; no new controller ownership mode, no config mutation, no unsafe shared attach.

## Explicit non-goals
- No startup half-zombie wiring in this PR; reserved for #1503 PR B.
- No broker/election behavior changes.
- No CLI/setup/docs changes.
- No new dependencies.

## Risks / known gaps
- This only introduces the reusable primitive; it does not call it from startup launch failure yet.
