### PR TITLE
Release startup owners that cannot reach Chrome

### DIFF
--- a/docs/roadmap/ssot-decisions.md
+++ b/docs/roadmap/ssot-decisions.md
@@ -116,6 +116,12 @@ default flip:
   surviving client re-elects
   ([#1478](https://github.com/shaun0927/openchrome/pull/1478) self-release + lock
   takeover), removing the single-point-of-failure.
+- An owner that becomes a **half-zombie during startup** (controller lock acquired,
+  but Chrome/CDP never becomes reachable) self-releases the lock and exits with
+  the owner self-release code after a confirming CDP probe. Probe errors,
+  debug-port timeouts, or a reachable CDP endpoint keep ownership, so
+  slow-but-valid Chrome startup is not evicted merely because launch returned an
+  error.
 
 This is **not** a return to silent multi-controller sharing: there is still exactly
 **one** direct CDP owner per `(port, userDataDir)`; the change is that surplus

--- a/src/chrome/launcher-debug-port.ts
+++ b/src/chrome/launcher-debug-port.ts
@@ -51,28 +51,46 @@ export async function waitForDebugPort(port: number, timeout = 30000, chromeProc
   const deadline = Date.now() + timeout;
   let attempts = 0;
   let backoff = DEBUG_PORT_INITIAL_BACKOFF_MS;
+  let onProcessError: ((err: Error) => void) | undefined;
+  const canObserveProcessError = typeof chromeProcess?.once === 'function';
+  const processError = canObserveProcessError
+    ? new Promise<never>((_, reject) => {
+        onProcessError = (err: Error) => reject(err);
+        chromeProcess.once('error', onProcessError);
+      })
+    : null;
 
-  while (Date.now() <= deadline) {
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) throw new DebugPortTimeoutError(port, timeout, attempts);
-    if (chromeProcess && (chromeProcess.exitCode !== null || chromeProcess.signalCode !== null)) {
-      throw new Error(
-        `Chrome exited with code ${chromeProcess.exitCode} signal ${chromeProcess.signalCode} before debug port ${port} became available. ` +
-        `Likely cause: --user-data-dir is locked by another Chrome instance.`
-      );
+  try {
+    while (Date.now() <= deadline) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) throw new DebugPortTimeoutError(port, timeout, attempts);
+      if (chromeProcess && (chromeProcess.exitCode !== null || chromeProcess.signalCode !== null)) {
+        throw new Error(
+          `Chrome exited with code ${chromeProcess.exitCode} signal ${chromeProcess.signalCode} before debug port ${port} became available. ` +
+          `Likely cause: --user-data-dir is locked by another Chrome instance.`
+        );
+      }
+      attempts += 1;
+      const wsEndpoint = await (processError
+        ? Promise.race([checkDebugPort(port, Math.min(remaining, DEBUG_PORT_MAX_HTTP_TIMEOUT_MS)), processError])
+        : checkDebugPort(port, Math.min(remaining, DEBUG_PORT_MAX_HTTP_TIMEOUT_MS)));
+      if (wsEndpoint) return wsEndpoint;
+      if (attempts % DEBUG_PORT_PROGRESS_LOG_INTERVAL === 0) {
+        const elapsed = timeout - remaining;
+        console.error(`[Launcher] Debug port ${port} not ready yet ` + `(attempt ${attempts}, elapsed ${elapsed}ms, remaining ${Math.max(0, deadline - Date.now())}ms)`);
+      }
+      const remainingAfterProbe = deadline - Date.now();
+      if (remainingAfterProbe <= 0) throw new DebugPortTimeoutError(port, timeout, attempts);
+      const sleepFor = Math.min(backoff, DEBUG_PORT_MAX_BACKOFF_MS, Math.max(0, remainingAfterProbe - 1));
+      if (sleepFor > 0) {
+        await (processError
+          ? Promise.race([new Promise((r) => setTimeout(r, sleepFor)), processError])
+          : new Promise((r) => setTimeout(r, sleepFor)));
+      }
+      backoff = Math.min(backoff * DEBUG_PORT_BACKOFF_FACTOR, DEBUG_PORT_MAX_BACKOFF_MS);
     }
-    attempts += 1;
-    const wsEndpoint = await checkDebugPort(port, Math.min(remaining, DEBUG_PORT_MAX_HTTP_TIMEOUT_MS));
-    if (wsEndpoint) return wsEndpoint;
-    if (attempts % DEBUG_PORT_PROGRESS_LOG_INTERVAL === 0) {
-      const elapsed = timeout - remaining;
-      console.error(`[Launcher] Debug port ${port} not ready yet ` + `(attempt ${attempts}, elapsed ${elapsed}ms, remaining ${Math.max(0, deadline - Date.now())}ms)`);
-    }
-    const remainingAfterProbe = deadline - Date.now();
-    if (remainingAfterProbe <= 0) throw new DebugPortTimeoutError(port, timeout, attempts);
-    const sleepFor = Math.min(backoff, DEBUG_PORT_MAX_BACKOFF_MS, Math.max(0, remainingAfterProbe - 1));
-    if (sleepFor > 0) await new Promise((r) => setTimeout(r, sleepFor));
-    backoff = Math.min(backoff * DEBUG_PORT_BACKOFF_FACTOR, DEBUG_PORT_MAX_BACKOFF_MS);
+    throw new DebugPortTimeoutError(port, timeout, attempts);
+  } finally {
+    if (canObserveProcessError && onProcessError) chromeProcess.off('error', onProcessError);
   }
-  throw new DebugPortTimeoutError(port, timeout, attempts);
 }

--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -537,10 +537,20 @@ export class ChromeLauncher {
       console.error('[ChromeLauncher] CI/Docker detected: sandbox disabled');
     }
 
+    const launchTimeout = parseInt(process.env.CHROME_LAUNCH_TIMEOUT_MS || String(DEFAULT_CHROME_LAUNCH_TIMEOUT_MS), 10);
+    let spawnFailedError: Error | null = null;
     const chromeProcess = spawn(chromePath, args, {
       detached: true,
       stdio: ['ignore', 'ignore', 'pipe'],
       // shell: false is safe on all platforms; avoids cmd.exe injection risks on Windows
+    });
+
+    chromeProcess.once('error', (err) => {
+      if (this.pendingProcess === chromeProcess) this.pendingProcess = null;
+      spawnFailedError = new Error(
+        `[ChromeLauncher] Failed to spawn Chrome at ${chromePath}: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
     });
 
     // Capture stderr for diagnostics (Chrome writes "DevTools listening on ws://..." and errors here)
@@ -641,8 +651,6 @@ export class ChromeLauncher {
     // Track as pending for retry reuse (issue #171)
     this.pendingProcess = chromeProcess;
 
-    const launchTimeout = parseInt(process.env.CHROME_LAUNCH_TIMEOUT_MS || String(DEFAULT_CHROME_LAUNCH_TIMEOUT_MS), 10);
-
     // Wait for debug port — pass chromeProcess for fast-fail on premature exit.
     // On timeout, pendingProcess is intentionally kept set so the next call can
     // reuse the still-starting Chrome instead of spawning a duplicate (issue #171).
@@ -650,6 +658,10 @@ export class ChromeLauncher {
     try {
       wsEndpoint = await waitForDebugPort(port, launchTimeout, chromeProcess);
     } catch (err) {
+      if (spawnFailedError) {
+        if (this.pendingProcess === chromeProcess) this.pendingProcess = null;
+        throw spawnFailedError;
+      }
       const stderr = stderrChunks.join('').trim();
       const diagnostics = [
         `Chrome debug port ${port} not available after ${launchTimeout}ms`,

--- a/src/chrome/owner-self-release.ts
+++ b/src/chrome/owner-self-release.ts
@@ -22,6 +22,7 @@
  */
 
 import type { EventEmitter } from 'events';
+import { DebugPortTimeoutError } from './launcher-debug-port';
 
 /**
  * Non-zero exit code meaning "owner gave up Chrome; respawn me". Distinct from
@@ -106,6 +107,28 @@ export async function releaseOwnerIfChromeUnreachable(
   }
   deps.exit(OWNER_SELF_RELEASE_EXIT_CODE);
   return 'released';
+}
+
+export async function releaseOwnerAfterStartupFailure(
+  err: unknown,
+  deps: OwnerSelfReleaseDeps,
+): Promise<OwnerReleaseAttemptResult> {
+  const log = deps.log ?? ((m: string) => console.error(m));
+  log(`[SelfHealing] Startup Chrome launch failed after controller lock acquisition: ${err instanceof Error ? err.message : String(err)}`);
+
+  // A debug-port timeout is intentionally not terminal in ChromeLauncher: the
+  // spawned process may still be starting and is kept as pending for reuse.
+  // Treat it as inconclusive here so a slow-but-valid Chrome is not evicted by
+  // a single immediate post-timeout probe. Watchdog relaunch failures and
+  // health-aware takeover still cover genuinely dead owners after their grace.
+  if (err instanceof DebugPortTimeoutError) {
+    log('[SelfHealing] Startup Chrome launch timed out; keeping ownership while watchdog/health checks continue.');
+    return 'inconclusive';
+  }
+
+  return releaseOwnerIfChromeUnreachable(deps, {
+    trigger: 'startup Chrome launch failure and a confirming CDP probe',
+  });
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import { getIdleState } from './utils/idle-state';
 import { getVersion } from './version';
 import { bootstrapPilot, logActiveFlags } from './harness/flags';
 import { ChromeProcessWatchdog } from './chrome/process-watchdog';
-import { wireOwnerSelfRelease } from './chrome/owner-self-release';
+import { releaseOwnerAfterStartupFailure, wireOwnerSelfRelease } from './chrome/owner-self-release';
 import { TabHealthMonitor } from './cdp/tab-health-monitor';
 import { EventLoopMonitor, setGlobalEventLoopMonitor } from './watchdog/event-loop-monitor';
 import { HealthEndpoint, HealthData } from './watchdog/health-endpoint';
@@ -51,6 +51,7 @@ import {
 import { fetchJsonVersion } from './chrome/devtools-info';
 import { getCurrentControllerTopology } from './utils/duplicate-controller-diagnostics';
 import { isAutoElectEnabled, shouldElectBrokerOwner, shouldClientAutoConnect, defaultBrokerHttpPort } from './broker/auto-elect';
+import { removeBrokerMetadata } from './broker/discovery';
 import {
   DEFAULT_PROCESS_WATCHDOG_INTERVAL_MS,
   DEFAULT_TAB_HEALTH_PROBE_INTERVAL_MS,
@@ -893,9 +894,25 @@ program
 
     // ─── Self-Healing Module Wiring (#354) ──────────────────────────────────
 
-    const launcher = getChromeLauncher();
+    const launcher = getChromeLauncher(port);
     const cdpClient = getCDPClient();
     const sessionManager = getSessionManager();
+
+    if (controllerLock && autoLaunch) {
+      launcher.ensureChrome({ autoLaunch: true, port, userDataDir }).catch((err: unknown) => {
+        releaseOwnerAfterStartupFailure(err, {
+          releaseLock: () => {
+            if (options.broker || electBrokerOwner) removeBrokerMetadata(port, lockUserDataDir);
+            controllerLock?.release();
+            controllerLock = null;
+          },
+          exit: (code) => process.exit(code),
+          probeChromeReachable: async () => (await fetchJsonVersion(port)) !== null,
+        }).catch((releaseErr: unknown) => {
+          console.error('[SelfHealing] Startup owner self-release failed:', releaseErr);
+        });
+      });
+    }
 
     // Readiness: wire chrome component via CDPClient connection events, then
     // proactively connect so daemon /ready probes can become ready before the

--- a/tests/chrome/launcher-launch.test.ts
+++ b/tests/chrome/launcher-launch.test.ts
@@ -72,6 +72,7 @@ const mockSpawn = child_process.spawn as jest.MockedFunction<typeof child_proces
 
 interface MockProcess extends EventEmitter {
   exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
   pid: number;
   unref: jest.MockedFunction<() => void>;
   kill: jest.MockedFunction<(signal?: string) => boolean>;
@@ -80,6 +81,7 @@ interface MockProcess extends EventEmitter {
 function createMockProcess(opts: { exitCode?: number | null } = {}): MockProcess {
   const proc = new EventEmitter() as MockProcess;
   proc.exitCode = opts.exitCode ?? null;
+  proc.signalCode = null;
   proc.pid = 12345;
   proc.unref = jest.fn();
   proc.kill = jest.fn().mockReturnValue(true);
@@ -195,6 +197,23 @@ describe('ChromeLauncher launch timeout fix (issue #171)', () => {
 
       // pendingProcess should still be set (for reuse on next call)
       expect((launcher as any).pendingProcess).toBe(proc);
+    }, 15000);
+
+    it('should reject and clear pendingProcess when Chrome spawn emits an error', async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as any);
+
+      const launcher = new ChromeLauncher(19993);
+      const launch = launcher.ensureChrome({ autoLaunch: true });
+      for (let i = 0; i < 80 && proc.listenerCount('error') === 0; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      expect(mockSpawn).toHaveBeenCalled();
+      expect(proc.listenerCount('error')).toBeGreaterThan(0);
+      proc.emit('error', new Error('spawn ENOENT'));
+
+      await expect(launch).rejects.toThrow(/Failed to spawn Chrome.*spawn ENOENT/);
+      expect((launcher as any).pendingProcess).toBeNull();
     }, 15000);
 
     it('should clear pendingProcess on successful launch', async () => {

--- a/tests/owner-self-release.test.ts
+++ b/tests/owner-self-release.test.ts
@@ -2,9 +2,11 @@ import { EventEmitter } from 'events';
 import {
   DEFAULT_RELEASE_FAILURE_THRESHOLD,
   OWNER_SELF_RELEASE_EXIT_CODE,
+  releaseOwnerAfterStartupFailure,
   releaseOwnerIfChromeUnreachable,
   wireOwnerSelfRelease,
 } from '../src/chrome/owner-self-release';
+import { DebugPortTimeoutError } from '../src/chrome/launcher-debug-port';
 
 const flush = () => new Promise((resolve) => setImmediate(resolve));
 
@@ -233,6 +235,74 @@ describe('owner self-release (#1474)', () => {
 
     expect(result).toBe('inconclusive');
     expect(onInconclusive).toHaveBeenCalledTimes(1);
+    expect(releaseLock).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  test('startup failure helper logs the startup failure and uses the same release gate', async () => {
+    const releaseLock = jest.fn();
+    const exit = jest.fn();
+    const log = jest.fn();
+
+    const result = await releaseOwnerAfterStartupFailure(new Error('launch timeout'), {
+      releaseLock,
+      exit,
+      log,
+      probeChromeReachable: jest.fn(async () => false),
+    });
+
+    expect(result).toBe('released');
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Startup Chrome launch failed'));
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(OWNER_SELF_RELEASE_EXIT_CODE);
+  });
+
+  test('startup failure helper keeps ownership when CDP is reachable', async () => {
+    const releaseLock = jest.fn();
+    const exit = jest.fn();
+
+    const result = await releaseOwnerAfterStartupFailure(new Error('launch timeout'), {
+      releaseLock,
+      exit,
+      log: jest.fn(),
+      probeChromeReachable: jest.fn(async () => true),
+    });
+
+    expect(result).toBe('reachable');
+    expect(releaseLock).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  test('startup failure helper treats probe errors as inconclusive', async () => {
+    const releaseLock = jest.fn();
+    const exit = jest.fn();
+
+    const result = await releaseOwnerAfterStartupFailure(new Error('launch timeout'), {
+      releaseLock,
+      exit,
+      log: jest.fn(),
+      probeChromeReachable: jest.fn(async () => { throw new Error('probe failed'); }),
+    });
+
+    expect(result).toBe('inconclusive');
+    expect(releaseLock).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  test('startup failure helper treats debug-port timeout as inconclusive without probing', async () => {
+    const releaseLock = jest.fn();
+    const exit = jest.fn();
+    const probeChromeReachable = jest.fn(async () => false);
+
+    const result = await releaseOwnerAfterStartupFailure(new DebugPortTimeoutError(9222, 1000, 3), {
+      releaseLock,
+      exit,
+      log: jest.fn(),
+      probeChromeReachable,
+    });
+
+    expect(result).toBe('inconclusive');
+    expect(probeChromeReachable).not.toHaveBeenCalled();
     expect(releaseLock).not.toHaveBeenCalled();
     expect(exit).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Linked issue

Part of #1503 — PR B: wire startup half-zombie self-release after controller lock acquisition.

## Implementation scope

- Wires startup `ensureChrome()` failure for lock-owning auto-launch servers into the shared owner self-release primitive.
- Keeps release gated by failure class + fresh CDP reachability:
  - definite spawn/connect failure + unreachable CDP -> release controller lock and exit 70;
  - reachable CDP -> keep ownership;
  - probe error -> inconclusive, keep ownership;
  - `DebugPortTimeoutError` -> inconclusive, keep ownership to protect slow startup.
- Removes own broker metadata best-effort when the self-releasing owner had published broker metadata.
- Makes `waitForDebugPort()` observe `ChildProcess#error` directly so spawn ENOENT rejects `ensureChrome()` without leaving a long-lived debug-port wait timer.
- Documents startup half-zombie self-release in the SSOT D3 topology notes.

## Explicit non-goals

- No auto-elect default change.
- No setup/config topology changes.
- No unsafe shared direct-CDP ownership.
- No target lease TTL or broad process killing.
- No successful real Chrome startup behavior change beyond sharing the same launcher wait path.

## Verification evidence

Local:

```bash
npm test -- --runTestsByPath tests/owner-self-release.test.ts tests/chrome/launcher-launch.test.ts tests/chrome/launcher-debug-port-deadline.test.ts
# PASS: 36 tests

npm run build
# PASS

npm run lint:changed
# PASS
```

Real post-lock startup failure smoke:

- temp profile under `/tmp/openchrome-half-zombie.*`
- temp controller lock dir under `/tmp/openchrome-locks.*`
- `CHROME_BINARY=/does/not/exist`
- `CHROME_LAUNCH_TIMEOUT_MS=1000`
- stdin held open via FIFO so stdio transport does not exit early

Observed:

```text
EXIT=70
LOCK_FILES=0
[SelfHealing] Startup Chrome launch failed after controller lock acquisition: ... ENOENT
[SelfHealing] Chrome unreachable after startup Chrome launch failure and a confirming CDP probe; releasing controller lock and exiting (code 70) ...
```

## Review follow-up

Architect WATCH on timeout false-release risk was addressed before merge readiness:

- `DebugPortTimeoutError` now returns `inconclusive` without probing/releasing.
- Added unit coverage that timeout does not call the CDP probe, release lock, or exit.
- Docs now state debug-port timeouts keep ownership.

## Risks / known gaps

- Successful real Chrome startup path was not live-smoked in this PR branch; existing launcher/connect tests plus unchanged reachable-probe and timeout-inconclusive guards cover the non-release path.
- `waitForDebugPort()` observes child-process `error` events only when the supplied process is EventEmitter-compatible; partial test doubles without `.once()` retain previous timeout/exited-process behavior.
