### PR TITLE
test(ci): remove avoidable Jest wait tails

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -10,14 +10,48 @@ concurrency:
 
 jobs:
   build-and-test:
-    name: build-and-test (${{ matrix.os }}, ${{ matrix.node-version }})
+    name: build-and-test (${{ matrix.os }}, ${{ matrix.node-version }}, shard=${{ matrix.test-shard }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [18, 20, 22]
+        include:
+          # Main-branch full matrix keeps OS/Node smoke coverage, while the
+          # expensive Ubuntu/Node 20 Jest suite runs as three parallel shards.
+          - os: ubuntu-latest
+            node-version: 18
+            test-shard: ''
+          - os: ubuntu-latest
+            node-version: 20
+            test-shard: '1'
+          - os: ubuntu-latest
+            node-version: 20
+            test-shard: '2'
+          - os: ubuntu-latest
+            node-version: 20
+            test-shard: '3'
+          - os: ubuntu-latest
+            node-version: 22
+            test-shard: ''
+          - os: macos-latest
+            node-version: 18
+            test-shard: ''
+          - os: macos-latest
+            node-version: 20
+            test-shard: ''
+          - os: macos-latest
+            node-version: 22
+            test-shard: ''
+          - os: windows-latest
+            node-version: 18
+            test-shard: ''
+          - os: windows-latest
+            node-version: 20
+            test-shard: ''
+          - os: windows-latest
+            node-version: 22
+            test-shard: ''
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -49,14 +83,14 @@ jobs:
       - name: Check capability map is in sync
         run: npm run docs:capability-map:check
 
-      - name: Run full tests
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 20
-        run: npx jest --config jest.ci.config.js
+      - name: Run full tests shard ${{ matrix.test-shard }}/3
+        if: matrix.test-shard != ''
+        run: npx jest --config jest.ci.config.js --shard=${{ matrix.test-shard }}/3
         env:
           CI: true
 
       - name: Run smoke tests
-        if: matrix.os != 'ubuntu-latest' || matrix.node-version != 20
+        if: matrix.test-shard == ''
         run: npx jest --config jest.ci.config.js --runTestsByPath tests/cli/doctor/runtime-diagnostics.test.ts tests/scripts/gen-capability-map.test.ts
         env:
           CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    name: build-and-test (${{ matrix.os }}, ${{ matrix.node-version }})
+    name: build-and-test (${{ matrix.os }}, ${{ matrix.node-version }}, shard=${{ matrix.test-shard }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:
@@ -18,18 +18,30 @@ jobs:
       matrix:
         include:
           # Fast PR gate: full Node compatibility on Linux plus one smoke lane
-          # per non-Linux OS. This keeps PRs from waiting on three macOS hosted
-          # runners while preserving cross-platform signal before merge.
+          # per non-Linux OS. The full Ubuntu/Node 20 Jest suite is sharded so
+          # CI wall-clock is bounded by the slowest shard instead of one long
+          # serial test job.
           - os: ubuntu-latest
             node-version: 18
+            test-shard: ''
           - os: ubuntu-latest
             node-version: 20
+            test-shard: '1'
+          - os: ubuntu-latest
+            node-version: 20
+            test-shard: '2'
+          - os: ubuntu-latest
+            node-version: 20
+            test-shard: '3'
           - os: ubuntu-latest
             node-version: 22
+            test-shard: ''
           - os: windows-latest
             node-version: 20
+            test-shard: ''
           - os: macos-latest
             node-version: 20
+            test-shard: ''
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -61,14 +73,14 @@ jobs:
       - name: Check capability map is in sync
         run: npm run docs:capability-map:check
 
-      - name: Run full tests
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 20
-        run: npx jest --config jest.ci.config.js
+      - name: Run full tests shard ${{ matrix.test-shard }}/3
+        if: matrix.test-shard != ''
+        run: npx jest --config jest.ci.config.js --shard=${{ matrix.test-shard }}/3
         env:
           CI: true
 
       - name: Run smoke tests
-        if: matrix.os != 'ubuntu-latest' || matrix.node-version != 20
+        if: matrix.test-shard == ''
         run: npx jest --config jest.ci.config.js --runTestsByPath tests/cli/doctor/runtime-diagnostics.test.ts tests/scripts/gen-capability-map.test.ts
         env:
           CI: true

--- a/jest.ci.config.js
+++ b/jest.ci.config.js
@@ -18,6 +18,11 @@ module.exports = {
     'tests/hints/hint-engine\\.test\\.ts',
     'tests/cli/update-check\\.test\\.ts',
   ],
+  // CI logs are expensive for this suite: many passing tests intentionally
+  // exercise diagnostic paths that write large console.error/console.log streams.
+  // Keep failure assertions visible while suppressing passing-test chatter.
+  verbose: false,
+  silent: true,
   // Disable coverage thresholds in CI (subset of tests)
   coverageThreshold: undefined,
 };

--- a/src/auth/twofa-handler.ts
+++ b/src/auth/twofa-handler.ts
@@ -36,7 +36,7 @@ async function waitForPageChange(
   timeoutMs: number,
 ): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
-  const pollIntervalMs = 500;
+  const pollIntervalMs = Math.min(500, Math.max(1, Math.floor(timeoutMs / 2) || 1));
 
   while (Date.now() < deadline) {
     try {
@@ -130,7 +130,7 @@ export async function handleTwoFA(
               );
 
               // Wait briefly and check if page changed
-              const changed = await waitForPageChange(page, originalUrl, 3000);
+              const changed = await waitForPageChange(page, originalUrl, Math.min(timeoutMs, 3000));
               if (changed) {
                 filled = true;
                 break;

--- a/src/chrome/headed-fallback.ts
+++ b/src/chrome/headed-fallback.ts
@@ -33,6 +33,14 @@ function runGlobalCleanup(): void {
   activeCleanup?.();
 }
 
+
+function headedFallbackSettleMs(): number {
+  const raw = process.env.OPENCHROME_HEADED_FALLBACK_SETTLE_MS;
+  if (raw === undefined) return 2000;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : 2000;
+}
+
 function installGlobalCleanupHandlers(): void {
   if (cleanupHandlersInstalled) return;
   process.on('exit', runGlobalCleanup);
@@ -245,8 +253,9 @@ class HeadedFallbackManager {
         timeout: 30000,
       });
 
-      // Wait a moment for any JS to execute
-      await new Promise(resolve => setTimeout(resolve, 2000));
+      // Wait a moment for any JS to execute.
+      const settleMs = headedFallbackSettleMs();
+      if (settleMs > 0) await new Promise(resolve => setTimeout(resolve, settleMs));
 
       const [title, elementCount, blocking] = await Promise.all([
         safeTitle(page as unknown as Page),
@@ -290,8 +299,9 @@ class HeadedFallbackManager {
         timeout: 30000,
       });
 
-      // Wait a moment for any JS to execute
-      await new Promise(resolve => setTimeout(resolve, 2000));
+      // Wait a moment for any JS to execute.
+      const settleMs = headedFallbackSettleMs();
+      if (settleMs > 0) await new Promise(resolve => setTimeout(resolve, settleMs));
 
       const [title, elementCount, blocking] = await Promise.all([
         safeTitle(page as unknown as Page),

--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -1093,11 +1093,12 @@ export class ChromeLauncher {
 
     // Poll until Chrome exits
     const startTime = Date.now();
+    const pollIntervalMs = Math.min(500, Math.max(1, timeout));
     while (Date.now() - startTime < timeout) {
       if (!this.isChromeRunning()) {
         return true;
       }
-      await new Promise((r) => setTimeout(r, 500));
+      await new Promise((r) => setTimeout(r, pollIntervalMs));
     }
 
     console.error(`[ChromeLauncher] Chrome did not exit within ${timeout}ms`);
@@ -1116,11 +1117,12 @@ export class ChromeLauncher {
 
     // Poll until profile lock is released
     const startTime = Date.now();
+    const pollIntervalMs = Math.min(500, Math.max(1, unlockTimeout));
     while (Date.now() - startTime < unlockTimeout) {
       if (!this.isProfileLocked(profileDir)) {
         return true;
       }
-      await new Promise((r) => setTimeout(r, 500));
+      await new Promise((r) => setTimeout(r, pollIntervalMs));
     }
 
     console.error(`[ChromeLauncher] Profile lock not released within ${unlockTimeout}ms`);

--- a/src/hints/hint-engine.ts
+++ b/src/hints/hint-engine.ts
@@ -116,6 +116,24 @@ export class HintEngine {
   private flushTimer: NodeJS.Timeout | null = null;
   private recoveryFeedback: RecoveryFeedbackWriter | null = null;
   private static readonly FLUSH_INTERVAL = 200; // ms
+  private static readonly instances = new Set<HintEngine>();
+  private static exitFlushRegistered = false;
+
+  private static registerExitFlush(engine: HintEngine): void {
+    HintEngine.instances.add(engine);
+    if (HintEngine.exitFlushRegistered) return;
+
+    // One process-level listener is enough for every engine instance. Tests and
+    // capability-filter setup may instantiate many MCPServer/HintEngine objects
+    // in a single process; registering per instance trips MaxListenersExceeded
+    // warnings and slows CI with noisy stderr output.
+    process.on('exit', () => {
+      for (const instance of HintEngine.instances) {
+        instance.flushBuffer();
+      }
+    });
+    HintEngine.exitFlushRegistered = true;
+  }
 
   constructor(activityTracker: ActivityTracker, progressTracker?: ProgressTracker, repeatedCallDetector?: RepeatedCallDetector) {
     this.activityTracker = activityTracker;
@@ -140,10 +158,8 @@ export class HintEngine {
       ...successHintRules,           // priority 400-403
     ].sort((a, b) => a.priority - b.priority);
 
-    // Flush remaining buffer on process exit
-    process.on('exit', () => {
-      this.flushBuffer();
-    });
+    // Flush remaining buffer on process exit.
+    HintEngine.registerExitFlush(this);
   }
 
   /**
@@ -590,6 +606,7 @@ export class HintEngine {
    * Flush pending writes and close the log stream. Call on shutdown.
    */
   destroy(): void {
+    HintEngine.instances.delete(this);
     this.flushBuffer();
     if (this.logStream) {
       this.logStream.end();

--- a/src/utils/static-fetch.ts
+++ b/src/utils/static-fetch.ts
@@ -183,9 +183,9 @@ export async function staticFetch(
         const n = Number(declaredLen);
         if (Number.isFinite(n) && n > maxBytes) {
           try {
-            await response.arrayBuffer();
+            await response.body?.cancel();
           } catch {
-            // ignore drain errors
+            // ignore cancel errors
           }
           throw new StaticFetchError(
             `response too large: ${n} > ${maxBytes}`,

--- a/tests/auth/twofa-handler.test.ts
+++ b/tests/auth/twofa-handler.test.ts
@@ -99,7 +99,7 @@ describe('handleTwoFA', () => {
       const options: TwoFAHandlerOptions = {
         domain: 'github.com',
         credentialProvider,
-        timeoutMs: 5000,
+        timeoutMs: 10,
       };
 
       const result = await handleTwoFA(page, detection, options);
@@ -124,7 +124,7 @@ describe('handleTwoFA', () => {
         domain: 'github.com',
         credentialProvider,
         maxRetries: 3,
-        timeoutMs: 1000,
+        timeoutMs: 1,
       };
 
       const result = await handleTwoFA(page, detection, options);
@@ -147,7 +147,7 @@ describe('handleTwoFA', () => {
         domain: 'github.com',
         credentialProvider,
         maxRetries: 2,
-        timeoutMs: 500,
+        timeoutMs: 1,
       };
 
       await handleTwoFA(page, detection, options);
@@ -202,7 +202,7 @@ describe('handleTwoFA', () => {
       const page = makePage({
         urlSequence: ['https://example.com/2fa'],
       });
-      const options: TwoFAHandlerOptions = { domain: 'example.com', timeoutMs: 600 };
+      const options: TwoFAHandlerOptions = { domain: 'example.com', timeoutMs: 1 };
 
       const result = await handleTwoFA(page, detection, options);
 
@@ -228,7 +228,7 @@ describe('handleTwoFA', () => {
         type: jest.fn().mockResolvedValue(undefined),
         keyboard: { press: jest.fn().mockResolvedValue(undefined) },
       };
-      const options: TwoFAHandlerOptions = { domain: 'example.com', timeoutMs: 5000 };
+      const options: TwoFAHandlerOptions = { domain: 'example.com', timeoutMs: 10 };
 
       const result = await handleTwoFA(page, detection, options);
 

--- a/tests/benchmark/run-token-efficiency.test.ts
+++ b/tests/benchmark/run-token-efficiency.test.ts
@@ -5,7 +5,7 @@ import {
   TOKEN_EFFICIENCY_CORPUS,
   deterministicExtract,
 } from './fixtures/token-efficiency/corpus';
-import { scoreFixture, runTokenEfficiencyBenchmark } from './run-token-efficiency';
+import { scoreFixture, runTokenEfficiencyMatrix } from './run-token-efficiency';
 import { validateResultEnvelope, buildResultEnvelope } from './utils/result-envelope';
 import { captureEnvironment } from './utils/environment';
 
@@ -63,9 +63,14 @@ describe('scoreFixture', () => {
   });
 });
 
-describe('runTokenEfficiencyBenchmark', () => {
+describe('runTokenEfficiencyMatrix', () => {
+  let rows: ReturnType<typeof runTokenEfficiencyMatrix>;
+
+  beforeAll(() => {
+    rows = runTokenEfficiencyMatrix({ liveAllowed: false, samplesPerCell: 1 });
+  });
+
   test('produces one row per (library, fixture) cell of the matrix', () => {
-    const rows = runTokenEfficiencyBenchmark();
     const libraries = new Set(rows.map((r) => r.library));
     // Every fixture must appear once per library — the matrix shape.
     expect(rows).toHaveLength(TOKEN_EFFICIENCY_CORPUS.length * libraries.size);
@@ -83,7 +88,7 @@ describe('runTokenEfficiencyBenchmark', () => {
       axis: 'token-efficiency',
       environment: captureEnvironment(),
       competitors: [{ name: 'OpenChrome', version: '1.12.0' }],
-      results: runTokenEfficiencyBenchmark(),
+      results: rows,
     });
     expect(validateResultEnvelope(envelope)).toEqual([]);
   });

--- a/tests/benchmark/utils/tokenizer.ts
+++ b/tests/benchmark/utils/tokenizer.ts
@@ -22,6 +22,7 @@ import { getEncoding, type Tiktoken } from 'js-tiktoken';
 export const TOKENIZER_ENCODING = 'cl100k_base' as const;
 
 let encoder: Tiktoken | null = null;
+const tokenCountCache = new Map<string, number>();
 
 function getEncoder(): Tiktoken {
   if (encoder === null) {
@@ -38,7 +39,13 @@ export function countTokens(text: string | null | undefined): number {
   if (typeof text !== 'string' || text.length === 0) {
     return 0;
   }
-  return getEncoder().encode(text).length;
+  const cached = tokenCountCache.get(text);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const tokens = getEncoder().encode(text).length;
+  tokenCountCache.set(text, tokens);
+  return tokens;
 }
 
 /**

--- a/tests/capability-filter.test.ts
+++ b/tests/capability-filter.test.ts
@@ -118,38 +118,35 @@ describe('capability-filter: default surface (P2 compliance)', () => {
 // ---------------------------------------------------------------------------
 
 describe('capability-filter: --tools-only=core', () => {
-  let server: MCPServer;
+  let names: string[];
 
-  beforeEach(() => {
+  beforeAll(async () => {
     const filter: Set<ToolCapability> = new Set(['core']);
-    server = makeServer({ capabilityFilter: filter });
+    const server = makeServer({ capabilityFilter: filter });
     registerAllTools(server);
+    names = await getToolNames(server);
   });
 
-  afterEach(() => {
+  afterAll(() => {
     jest.clearAllMocks();
   });
 
-  test('no workflow_* tools exposed', async () => {
-    const names = await getToolNames(server);
+  test('no workflow_* tools exposed', () => {
     const workflow = names.filter(n => n.startsWith('workflow_'));
     expect(workflow).toEqual([]);
   });
 
-  test('no oc_recording_* tools exposed', async () => {
-    const names = await getToolNames(server);
+  test('no oc_recording_* tools exposed', () => {
     const recording = names.filter(n => n.startsWith('oc_recording_'));
     expect(recording).toEqual([]);
   });
 
-  test('no crawl* tools exposed', async () => {
-    const names = await getToolNames(server);
+  test('no crawl* tools exposed', () => {
     const crawl = names.filter(n => n.startsWith('crawl') || n === 'batch_execute' || n === 'batch_paginate' || n === 'worker_update' || n === 'worker_complete');
     expect(crawl).toEqual([]);
   });
 
-  test('core tools are still present', async () => {
-    const names = await getToolNames(server);
+  test('core tools are still present', () => {
     expect(names).toContain('navigate');
     expect(names).toContain('read_page');
     expect(names).toContain('interact');
@@ -185,7 +182,7 @@ describe('capability-filter: --disable-tools=workflow,recording', () => {
   let defaultNames: string[];
   let filteredNames: string[];
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     // Default (no filter)
     const defaultServer = makeServer();
     registerAllTools(defaultServer);
@@ -200,7 +197,7 @@ describe('capability-filter: --disable-tools=workflow,recording', () => {
     filteredNames = await getToolNames(filteredServer);
   });
 
-  afterEach(() => {
+  afterAll(() => {
     jest.clearAllMocks();
   });
 
@@ -342,7 +339,10 @@ describe('lint:tools-capabilities', () => {
     let exitCode = 0;
     let output = '';
     try {
-      output = execFileSync(process.execPath, [lintScript], { encoding: 'utf8' });
+      output = execFileSync(process.execPath, [lintScript], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
     } catch (err: unknown) {
       exitCode = (err as { status?: number }).status ?? 1;
       output = (err as { stdout?: string; stderr?: string }).stdout ?? '';

--- a/tests/chrome/launcher-launch.test.ts
+++ b/tests/chrome/launcher-launch.test.ts
@@ -173,6 +173,7 @@ describe('ChromeLauncher launch timeout fix (issue #171)', () => {
     } else {
       process.env.CHROME_LAUNCH_TIMEOUT_MS = savedEnv;
     }
+    delete process.env.OPENCHROME_LAUNCH_MODE;
     mockSpawn.mockReset();
   });
 
@@ -184,7 +185,8 @@ describe('ChromeLauncher launch timeout fix (issue #171)', () => {
     });
 
     it('should track spawned process as pendingProcess on launch timeout', async () => {
-      process.env.CHROME_LAUNCH_TIMEOUT_MS = '1000';
+      process.env.CHROME_LAUNCH_TIMEOUT_MS = '1';
+      process.env.OPENCHROME_LAUNCH_MODE = 'isolated';
 
       const proc = createMockProcess();
       mockSpawn.mockReturnValue(proc as any);
@@ -247,7 +249,7 @@ describe('ChromeLauncher launch timeout fix (issue #171)', () => {
         (launcher as any).pendingProcess = proc;
 
         // Second call: should detect pending process and reuse it (port is already open)
-        process.env.CHROME_LAUNCH_TIMEOUT_MS = '5000';
+        process.env.CHROME_LAUNCH_TIMEOUT_MS = '50';
         const instance = await launcher.ensureChrome({ autoLaunch: true });
 
         // spawn should NOT have been called (reused pending process)
@@ -271,7 +273,7 @@ describe('ChromeLauncher launch timeout fix (issue #171)', () => {
         // Simulate: previous pending process already exited
         (launcher as any).pendingProcess = createMockProcess({ exitCode: 1 });
 
-        process.env.CHROME_LAUNCH_TIMEOUT_MS = '5000';
+        process.env.CHROME_LAUNCH_TIMEOUT_MS = '50';
         const instance = await launcher.ensureChrome({ autoLaunch: true });
 
         expect(instance.wsEndpoint).toContain('ws://');
@@ -286,7 +288,8 @@ describe('ChromeLauncher launch timeout fix (issue #171)', () => {
 
   describe('configurable timeout', () => {
     it('should use CHROME_LAUNCH_TIMEOUT_MS env var', async () => {
-      process.env.CHROME_LAUNCH_TIMEOUT_MS = '1500';
+      process.env.CHROME_LAUNCH_TIMEOUT_MS = '1';
+      process.env.OPENCHROME_LAUNCH_MODE = 'isolated';
 
       const proc = createMockProcess();
       mockSpawn.mockReturnValue(proc as any);
@@ -299,14 +302,12 @@ describe('ChromeLauncher launch timeout fix (issue #171)', () => {
       ).rejects.toThrow(/not available after/);
 
       const elapsed = Date.now() - start;
-      // Should have waited ~1.5s for the launch timeout (plus ~5s initial port check)
-      // Total should be ~6.5s, definitely less than old 35s (5s check + 30s launch)
-      expect(elapsed).toBeLessThan(12000);
-      expect(elapsed).toBeGreaterThan(1000);
+      expect(elapsed).toBeLessThan(2000);
     }, 20000);
 
     it('should default to 60000ms when env var not set', async () => {
       delete process.env.CHROME_LAUNCH_TIMEOUT_MS;
+      process.env.OPENCHROME_LAUNCH_MODE = 'isolated';
 
       // We can't actually wait 60s in a test. Instead, verify the code path
       // by checking that the error message contains the timeout value.

--- a/tests/chrome/launcher-restart.test.ts
+++ b/tests/chrome/launcher-restart.test.ts
@@ -70,16 +70,20 @@ const mockExecFileSync = execFileSync as jest.MockedFunction<typeof execFileSync
 describe('ChromeLauncher graceful restart', () => {
   let launcher: ChromeLauncher;
   let consoleErrorSpy: jest.SpyInstance;
+  const savedLaunchMode = process.env.OPENCHROME_LAUNCH_MODE;
 
   beforeEach(() => {
     launcher = new ChromeLauncher(9222);
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     mockExecSync.mockReset();
     mockExecFileSync.mockReset();
+    process.env.OPENCHROME_LAUNCH_MODE = 'isolated';
   });
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
+    if (savedLaunchMode === undefined) delete process.env.OPENCHROME_LAUNCH_MODE;
+    else process.env.OPENCHROME_LAUNCH_MODE = savedLaunchMode;
   });
 
   describe('isChromeRunning()', () => {
@@ -153,7 +157,7 @@ describe('ChromeLauncher graceful restart', () => {
       // pgrep always succeeds → Chrome never exits
       mockExecFileSync.mockReturnValue(Buffer.from('12345'));
 
-      const result = await (launcher as any).quitRunningChrome(1000);
+      const result = await (launcher as any).quitRunningChrome(1);
       expect(result).toBe(false);
     });
 
@@ -214,7 +218,7 @@ describe('ChromeLauncher graceful restart', () => {
       // pgrep always succeeds → Chrome never quits
       mockExecFileSync.mockReturnValue(Buffer.from('12345'));
 
-      const result = await (launcher as any).quitAndUnlockProfile(tmpDir, 1000, 1000);
+      const result = await (launcher as any).quitAndUnlockProfile(tmpDir, 1, 1);
       expect(result).toBe(false);
 
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -243,7 +247,7 @@ describe('ChromeLauncher graceful restart', () => {
         return Buffer.from('');
       });
 
-      const result = await (launcher as any).quitAndUnlockProfile(tmpDir, 5000, 1000);
+      const result = await (launcher as any).quitAndUnlockProfile(tmpDir, 5000, 1);
       expect(result).toBe(false);
 
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/core/lifecycle/event-bus.test.ts
+++ b/tests/core/lifecycle/event-bus.test.ts
@@ -43,8 +43,10 @@ function makeSessionEvent(): LifecycleEvent {
 
 describe('LifecycleEventBus', () => {
   let metrics: MetricsCollector;
+  let stderrWriteSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    stderrWriteSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
     resetLifecycleBusForTests();
     metrics = new MetricsCollector();
     metrics.registerCounter(
@@ -56,6 +58,7 @@ describe('LifecycleEventBus', () => {
   });
 
   afterEach(() => {
+    stderrWriteSpy.mockRestore();
     delete process.env.OPENCHROME_LIFECYCLE_BUS;
     delete process.env.OPENCHROME_DEV_HOOKS;
     delete process.env.OPENCHROME_LIFECYCLE_INJECT_THROW;

--- a/tests/core/utils/static-fetch.test.ts
+++ b/tests/core/utils/static-fetch.test.ts
@@ -235,7 +235,7 @@ describe('staticFetch', () => {
           '</p></body></html>',
       },
       '/slow.html': {
-        delayMs: 1000,
+        delayMs: 50,
         status: 200,
         contentType: 'text/html',
         body: '<html><body>too late</body></html>',
@@ -314,14 +314,14 @@ describe('staticFetch', () => {
 
   test('aborts when timeoutMs elapses before response', async () => {
     await expect(
-      staticFetch(`${server.origin}/slow.html`, { timeoutMs: 100 }),
+      staticFetch(`${server.origin}/slow.html`, { timeoutMs: 1 }),
     ).rejects.toThrow();
   });
 
   test('honors external AbortSignal', async () => {
     const ac = new AbortController();
     const p = staticFetch(`${server.origin}/slow.html`, { signal: ac.signal });
-    setTimeout(() => ac.abort(new Error('client gone')), 50);
+    setTimeout(() => ac.abort(new Error('client gone')), 1);
     await expect(p).rejects.toThrow();
   });
 

--- a/tests/headed/headed-fallback-manager.test.ts
+++ b/tests/headed/headed-fallback-manager.test.ts
@@ -102,7 +102,10 @@ jest.mock('../../src/chrome/ownership-marker', () => ({
 import { getHeadedFallback, shutdownHeadedFallback } from '../../src/chrome/headed-fallback';
 
 describe('HeadedFallbackManager', () => {
+  const savedSettleMs = process.env.OPENCHROME_HEADED_FALLBACK_SETTLE_MS;
+
   beforeEach(() => {
+    process.env.OPENCHROME_HEADED_FALLBACK_SETTLE_MS = '0';
     jest.clearAllMocks();
     // Reset singleton
     shutdownHeadedFallback();
@@ -118,6 +121,8 @@ describe('HeadedFallbackManager', () => {
 
   afterEach(() => {
     shutdownHeadedFallback();
+    if (savedSettleMs === undefined) delete process.env.OPENCHROME_HEADED_FALLBACK_SETTLE_MS;
+    else process.env.OPENCHROME_HEADED_FALLBACK_SETTLE_MS = savedSettleMs;
   });
 
   describe('isAvailable()', () => {

--- a/tests/integration/lifecycle-parity.test.ts
+++ b/tests/integration/lifecycle-parity.test.ts
@@ -51,8 +51,10 @@ function mkEvent(kind: LifecycleEventKind, extra: Record<string, unknown> = {}):
 
 describe('lifecycle-parity', () => {
   let metrics: MetricsCollector;
+  let stderrWriteSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    stderrWriteSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
     resetLifecycleBusForTests();
     metrics = new MetricsCollector();
     metrics.registerCounter(LIFECYCLE_LISTENER_ERROR_METRIC, 'test');
@@ -60,6 +62,7 @@ describe('lifecycle-parity', () => {
   });
 
   afterEach(() => {
+    stderrWriteSpy.mockRestore();
     delete process.env.OPENCHROME_LIFECYCLE_BUS;
     resetLifecycleBusForTests();
   });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -5,6 +5,13 @@
 
 /// <reference types="jest" />
 
+// Some tests intentionally reset Jest's module registry and re-import modules
+// that depend on proper-lockfile/signal-exit. In one worker process that can
+// install many process-level signal listeners and produce MaxListeners warnings
+// even when behavior is correct. Raise the process listener cap for tests so CI
+// output stays actionable and fast.
+process.setMaxListeners(Math.max(process.getMaxListeners(), 100));
+
 // ============================================================================
 // GLOBAL SAFETY NET: Prevent real Chrome connections during tests
 // These mocks are overridden by individual test files that provide their own.


### PR DESCRIPTION
## Summary
- shard the expensive Ubuntu/Node 20 full Jest lane into 3 parallel shards in PR and main CI workflows
- suppress expected CI Jest console noise and MaxListeners warnings from test-only module reload patterns
- remove artificial wait tails from headed fallback, launcher timeout/restart, 2FA, static-fetch, and token-efficiency tests while preserving production defaults
- reduce repeated capability-filter setup and expected lifecycle stderr noise in tests

## CI speed impact
- headed fallback targeted suite: previously ~24s class of real sleeps; now ~3s targeted
- 2FA targeted suite: previously ~16s class of waits; now ~2s targeted
- launcher restart timeout paths: previously seconds per false-timeout case; now millisecond timeout path
- token-efficiency unit test now uses 1 sample/cell and cached tokenizer counts; benchmark script defaults unchanged
- full Jest lane is now coverage-preserving but wall-clock sharded across 3 Ubuntu/Node 20 jobs

## Verification
- `npm run build`
- `npm run lint:tier`
- `npm run lint`
- `npm run lint:tool-schemas`
- `npm run docs:capability-map:check`
- `npx jest --config jest.ci.config.js --runTestsByPath tests/chrome/launcher-launch.test.ts tests/auth/twofa-handler.test.ts tests/core/utils/static-fetch.test.ts tests/headed/headed-fallback-manager.test.ts tests/benchmark/run-token-efficiency.test.ts tests/capability-filter.test.ts tests/core/lifecycle/event-bus.test.ts tests/integration/lifecycle-parity.test.ts --runInBand`
- `npx jest --config jest.config.js --runTestsByPath tests/chrome/launcher-restart.test.ts --runInBand`
- `TMPDIR=$PWD/.tmp-jest npx jest --config jest.ci.config.js` → 611 passed / 3 skipped, 7289 tests total, 227.724s Jest time
- `npx jest --config jest.ci.config.js --shard=1/3 --listTests`, `2/3`, `3/3` → 205 / 205 / 204 test files
- `ruby -e "require 'yaml'; ..."` parsed both CI workflow files

## Guardrails
- no test suites removed from CI coverage
- no production default timeout changed; test-only env/config lowers waits
- no Chrome ownership/default topology behavior changed
- no domain-specific website/platform knowledge added
