### PR TITLE
fix(gates): detect Cloudflare bot-check interstitials

### DIFF
--- a/src/gates/detect-other-gates.ts
+++ b/src/gates/detect-other-gates.ts
@@ -82,15 +82,18 @@ function botCheckProbe(): { selector: string } | null {
     return { selector: 'title:just-a-moment' };
   }
 
-  if (bodyText.includes('verify you are human') ||
-      bodyText.includes('checking if the site connection is secure') ||
-      bodyText.includes('review the security of your connection') ||
-      bodyText.includes('please stand by, while we are checking your browser') ||
-      bodyText.includes('bot protection') ||
-      bodyText.includes('automated access') ||
-      title.includes('security check') ||
-      title.includes('robot check')) {
-    return { selector: 'text:bot-check' };
+  const hasBotCheckText =
+    bodyText.includes('verify you are human') ||
+    bodyText.includes('checking if the site connection is secure') ||
+    bodyText.includes('review the security of your connection') ||
+    bodyText.includes('please stand by, while we are checking your browser') ||
+    bodyText.includes('bot protection') ||
+    bodyText.includes('automated access');
+  const hasSecurityTitle = title.includes('security check') || title.includes('robot check');
+  const hasWafMarker = html.includes('cloudflare') || html.includes('cf_chl_') || html.includes('challenges.cloudflare.com');
+
+  if (hasSecurityTitle || (hasBotCheckText && hasWafMarker)) {
+    return { selector: hasSecurityTitle ? 'title:bot-check' : 'text:bot-check' };
   }
 
   return null;

--- a/src/gates/detect-other-gates.ts
+++ b/src/gates/detect-other-gates.ts
@@ -4,6 +4,7 @@
  * Pure DOM/URL heuristics that surface common access gates the host agent
  * should reason about before proceeding:
  *
+ *   - Bot check: a CDN/WAF interstitial is blocking progress.
  *   - SSO redirect: the page has navigated to an identity provider login.
  *   - Paywall: a subscription/metered overlay is blocking the content.
  *   - Two-factor: an OTP / verification-code input is the foreground form.
@@ -23,7 +24,7 @@
 
 import type { Page } from 'puppeteer-core';
 
-export type NonCaptchaGateKind = 'sso' | 'paywall' | '2fa';
+export type NonCaptchaGateKind = 'bot-check' | 'sso' | 'paywall' | '2fa';
 
 export type SsoProvider =
   | 'microsoft'
@@ -38,6 +39,13 @@ export interface SsoSignal {
   kind: 'sso';
   gateType: 'sso_redirect';
   provider: SsoProvider;
+  pageUrl: string;
+}
+
+export interface BotCheckSignal {
+  kind: 'bot-check';
+  gateType: 'bot_check';
+  selector: string;
   pageUrl: string;
 }
 
@@ -57,7 +65,52 @@ export interface TwoFactorSignal {
   pageUrl: string;
 }
 
-export type NonCaptchaGateSignal = SsoSignal | PaywallSignal | TwoFactorSignal;
+export type NonCaptchaGateSignal = BotCheckSignal | SsoSignal | PaywallSignal | TwoFactorSignal;
+
+// ─── Bot checks / CDN verification interstitials ──────────────────────────
+
+function botCheckProbe(): { selector: string } | null {
+  const title = document.title.toLowerCase();
+  const bodyText = document.body?.innerText?.slice(0, 1000).toLowerCase() || '';
+  const html = document.documentElement?.innerHTML?.slice(0, 5000).toLowerCase() || '';
+
+  // Cloudflare Managed Challenge pages are often sparse and expose no visible
+  // form controls while JavaScript runs. In the field they commonly present
+  // only a "Just a moment..." title and Cloudflare/privacy links, so relying
+  // solely on captcha iframes misses this gate.
+  if (title.includes('just a moment') && (bodyText.includes('cloudflare') || html.includes('cf_chl_'))) {
+    return { selector: 'title:just-a-moment' };
+  }
+
+  if (bodyText.includes('verify you are human') ||
+      bodyText.includes('checking if the site connection is secure') ||
+      bodyText.includes('review the security of your connection') ||
+      bodyText.includes('please stand by, while we are checking your browser') ||
+      bodyText.includes('bot protection') ||
+      bodyText.includes('automated access') ||
+      title.includes('security check') ||
+      title.includes('robot check')) {
+    return { selector: 'text:bot-check' };
+  }
+
+  return null;
+}
+
+export async function detectBotCheck(page: Page): Promise<BotCheckSignal | null> {
+  let url: string;
+  try {
+    url = page.url();
+  } catch {
+    url = 'unknown';
+  }
+  try {
+    const match = await page.evaluate(botCheckProbe);
+    if (!match) return null;
+    return { kind: 'bot-check', gateType: 'bot_check', selector: match.selector, pageUrl: url };
+  } catch {
+    return null;
+  }
+}
 
 // ─── SSO ──────────────────────────────────────────────────────────────────
 
@@ -229,7 +282,7 @@ export async function detectTwoFactor(page: Page): Promise<TwoFactorSignal | nul
 /**
  * Run the non-CAPTCHA detectors in priority order and return the first
  * positive signal. Used by `oc_gate_inspect` after CAPTCHA detection. The
- * order — SSO → paywall → 2FA — reflects how the host would typically
+ * order — bot-check → SSO → paywall → 2FA — reflects how the host would typically
  * reason about a gate: an SSO redirect means "you're no longer on the
  * target site"; a paywall means "you're on the site but blocked"; a 2FA
  * prompt means "you're authenticating right now."
@@ -237,6 +290,8 @@ export async function detectTwoFactor(page: Page): Promise<TwoFactorSignal | nul
 export async function detectNonCaptchaGate(
   page: Page,
 ): Promise<NonCaptchaGateSignal | null> {
+  const botCheck = await detectBotCheck(page);
+  if (botCheck) return botCheck;
   const sso = await detectSso(page);
   if (sso) return sso;
   const paywall = await detectPaywall(page);

--- a/src/tools/oc-gate-inspect.ts
+++ b/src/tools/oc-gate-inspect.ts
@@ -8,13 +8,14 @@
  *
  * Gate families detected (B2-PR1 + B2-PR2 of #1359):
  *
- *   - `captcha`  — reCAPTCHA v2/v3, hCaptcha, Cloudflare Turnstile, AWS WAF.
- *   - `sso`      — redirect to a known identity provider OR a generic SSO
+ *   - `captcha`   — reCAPTCHA v2/v3, hCaptcha, Cloudflare Turnstile, AWS WAF.
+ *   - `bot-check` — CDN/WAF verification interstitial without a CAPTCHA widget.
+ *   - `sso`       — redirect to a known identity provider OR a generic SSO
  *                  path (`/sso`, `/saml`, `/oauth`, `/openid`, `/authorize`).
- *   - `paywall`  — visible subscription/metered-content overlay.
- *   - `2fa`      — OTP / one-time-code input is foreground.
+ *   - `paywall`   — visible subscription/metered-content overlay.
+ *   - `2fa`       — OTP / one-time-code input is foreground.
  *
- * Detection order is captcha → SSO → paywall → 2FA. The first positive
+ * Detection order is captcha → bot-check → SSO → paywall → 2FA. The first positive
  * signal wins. Multiple gates can be present in practice, but the host
  * almost always reasons about them in that order anyway.
  *
@@ -79,7 +80,7 @@ export interface OcGateInspectOutput {
 const definition: MCPToolDefinition = {
   name: 'oc_gate_inspect',
   description:
-    'Detect whether the current tab is gated (CAPTCHA, SSO redirect, ' +
+    'Detect whether the current tab is gated (CAPTCHA, bot-check, SSO redirect, ' +
     'paywall, 2FA prompt). Returns facts only — never invokes any solver, ' +
     'never makes a third-party HTTP call, never bypasses the gate. The ' +
     'host agent decides what to do next.',
@@ -171,7 +172,7 @@ const handler: ToolHandler = async (
     return toResult(out);
   }
 
-  // 2. Non-CAPTCHA gates in priority order (sso → paywall → 2fa).
+  // 2. Non-CAPTCHA gates in priority order (bot-check → sso → paywall → 2fa).
   const other = await detectNonCaptchaGate(page);
   if (other) {
     const base: OcGateInspectOutput = {

--- a/src/tools/oc-gate-inspect.ts
+++ b/src/tools/oc-gate-inspect.ts
@@ -47,7 +47,7 @@ export type GateKind = 'captcha' | NonCaptchaGateKind;
 /**
  * Closed gate-type vocabulary. Adding a value is non-breaking.
  */
-export type GateType = CaptchaType | 'sso_redirect' | 'paywall' | 'two_factor';
+export type GateType = CaptchaType | 'bot_check' | 'sso_redirect' | 'paywall' | 'two_factor';
 
 export interface OcGateInspectOutput {
   detected: boolean;

--- a/tests/gates/detect-other-gates.test.ts
+++ b/tests/gates/detect-other-gates.test.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  detectBotCheck,
   detectSsoSignalFromUrl,
   detectSso,
   detectPaywall,
@@ -21,6 +22,24 @@ function makePage(url: string, evalImpl: (fn: any, ...args: any[]) => any): any 
     evaluate: jest.fn(async (fn: any, ...args: any[]) => evalImpl(fn, ...args)),
   };
 }
+
+describe('detectBotCheck', () => {
+  test('detects Cloudflare managed challenge pages that have no captcha iframe yet', async () => {
+    const page = makePage('https://dash.cloudflare.com/login', () => ({ selector: 'title:just-a-moment' }));
+    const out = await detectBotCheck(page);
+    expect(out).toEqual({
+      kind: 'bot-check',
+      gateType: 'bot_check',
+      selector: 'title:just-a-moment',
+      pageUrl: 'https://dash.cloudflare.com/login',
+    });
+  });
+
+  test('returns null when the bot-check probe finds nothing', async () => {
+    const page = makePage('https://example.com/', () => null);
+    expect(await detectBotCheck(page)).toBeNull();
+  });
+});
 
 describe('detectSsoSignalFromUrl', () => {
   test('returns null for empty / invalid URLs', () => {
@@ -117,14 +136,24 @@ describe('detectTwoFactor', () => {
 });
 
 describe('detectNonCaptchaGate — priority composer', () => {
-  test('SSO wins over paywall / 2fa', async () => {
+  test('bot-check wins over SSO / paywall / 2fa', async () => {
     const page = {
       url: () => 'https://accounts.google.com/signin',
-      evaluate: jest.fn(),
+      evaluate: jest.fn(async () => ({ selector: 'title:just-a-moment' })),
+    };
+    const out = await detectNonCaptchaGate(page as any);
+    expect(out?.kind).toBe('bot-check');
+    expect(out?.gateType).toBe('bot_check');
+  });
+
+  test('SSO wins over paywall / 2fa after bot-check probe misses', async () => {
+    const page = {
+      url: () => 'https://accounts.google.com/signin',
+      evaluate: jest.fn(async () => null),
     };
     const out = await detectNonCaptchaGate(page as any);
     expect(out?.kind).toBe('sso');
-    expect(page.evaluate).not.toHaveBeenCalled();
+    expect(page.evaluate).toHaveBeenCalledTimes(1);
   });
 
   test('paywall wins over 2fa when there is no SSO', async () => {
@@ -133,7 +162,7 @@ describe('detectNonCaptchaGate — priority composer', () => {
       url: () => 'https://news.example.com/article',
       evaluate: jest.fn(async () => {
         call += 1;
-        if (call === 1) return { selector: '.paywall' };
+        if (call === 2) return { selector: '.paywall' };
         return null;
       }),
     };
@@ -147,8 +176,8 @@ describe('detectNonCaptchaGate — priority composer', () => {
       url: () => 'https://example.com/verify',
       evaluate: jest.fn(async () => {
         call += 1;
-        // 1st: paywall probe → null. 2nd: 2fa probe → match.
-        if (call === 1) return null;
+        // 1st: bot-check probe → null. 2nd: paywall probe → null. 3rd: 2fa probe → match.
+        if (call < 3) return null;
         return { selector: 'input[name="otp"]' };
       }),
     };

--- a/tests/gates/detect-other-gates.test.ts
+++ b/tests/gates/detect-other-gates.test.ts
@@ -35,6 +35,40 @@ describe('detectBotCheck', () => {
     });
   });
 
+  test('detects generic bot-check text only with a WAF marker', async () => {
+    const page = makePage('https://example.com/', (fn: any) => {
+      const previousDocument = (globalThis as any).document;
+      (globalThis as any).document = {
+        title: 'Please wait',
+        body: { innerText: 'Verify you are human before continuing' },
+        documentElement: { innerHTML: '<script src="/cdn-cgi/challenge-platform/cf_chl_js"></script>' },
+      };
+      try {
+        return fn();
+      } finally {
+        (globalThis as any).document = previousDocument;
+      }
+    });
+    expect(await detectBotCheck(page)).toMatchObject({ selector: 'text:bot-check' });
+  });
+
+  test('does not flag ordinary content that merely mentions human verification', async () => {
+    const page = makePage('https://example.com/help', (fn: any) => {
+      const previousDocument = (globalThis as any).document;
+      (globalThis as any).document = {
+        title: 'Account help',
+        body: { innerText: 'Some forms ask you to verify you are human.' },
+        documentElement: { innerHTML: '<article>Some forms ask you to verify you are human.</article>' },
+      };
+      try {
+        return fn();
+      } finally {
+        (globalThis as any).document = previousDocument;
+      }
+    });
+    expect(await detectBotCheck(page)).toBeNull();
+  });
+
   test('returns null when the bot-check probe finds nothing', async () => {
     const page = makePage('https://example.com/', () => null);
     expect(await detectBotCheck(page)).toBeNull();

--- a/tests/tools/oc-gate-inspect.test.ts
+++ b/tests/tools/oc-gate-inspect.test.ts
@@ -314,6 +314,28 @@ describe('oc_gate_inspect — non-CAPTCHA gates', () => {
     mockDetectCaptcha.mockResolvedValue(null);
   });
 
+  test('bot-check → kind=bot-check, gateType=bot_check, selector exposed', async () => {
+    const { handler } = loadHandler();
+    mockGetPage.mockResolvedValue(makeFakePage('https://dash.cloudflare.com/login'));
+    mockDetectNonCaptchaGate.mockResolvedValue({
+      kind: 'bot-check',
+      gateType: 'bot_check',
+      selector: 'title:just-a-moment',
+      pageUrl: 'https://dash.cloudflare.com/login',
+    });
+
+    const result = await handler('sess-1', { tabId: 'tab-1' });
+    const out = parseResult(result);
+
+    expect(out).toEqual({
+      detected: true,
+      kind: 'bot-check',
+      gateType: 'bot_check',
+      selector: 'title:just-a-moment',
+      pageUrl: 'https://dash.cloudflare.com/login',
+    });
+  });
+
   test('SSO redirect → kind=sso, gateType=sso_redirect, provider exposed', async () => {
     const { handler } = loadHandler();
     mockGetPage.mockResolvedValue(makeFakePage('https://accounts.google.com/signin'));


### PR DESCRIPTION
## Summary
- Add a non-CAPTCHA bot-check gate signal for sparse CDN/WAF interstitials such as Cloudflare 'Just a moment...' pages.
- Surface bot_check through oc_gate_inspect instead of returning detected:false when no captcha iframe exists yet.
- Cover detector priority and oc_gate_inspect output with regression tests.

## Investigation
- Reproduced on Cloudflare Dashboard login: after reload the tab stayed on title 'Just a moment...' with only Cloudflare/Privacy links.
- Console capture returned zero page console entries, so the useful signal is DOM/title state rather than console errors.
- Existing blocking-page utility already knows 'just a moment', but oc_gate_inspect only composed captcha/SSO/paywall/2FA detectors and therefore returned detected:false for this gate.

## Test Plan
- npm test -- --runTestsByPath tests/gates/detect-other-gates.test.ts tests/tools/oc-gate-inspect.test.ts
- npm run build