### PR TITLE
Make auto-elect default decision explicit

### DIFF
--- a/src/broker/auto-elect.ts
+++ b/src/broker/auto-elect.ts
@@ -9,29 +9,43 @@
  *   - a process that LOSES to a healthy owner becomes a coordinated CLIENT
  *     (`--connect-broker` proxy) instead of failing fast.
  *
- * The behavior is gated behind an explicit opt-in (`--auto-elect` /
- * `OPENCHROME_AUTO_ELECT=1`). With the flag unset, the default path is byte-for-
- * byte unchanged (fail-fast single owner), so this module's wiring has zero blast
- * radius until an operator opts in. See docs/roadmap/ssot-decisions.md (D3 Q1′)
- * for the policy and the eventual default-flip plan.
- *
- * Keeping the decisions here (rather than inline in src/index.ts) makes the
- * election rules unit-testable without booting a server or Chrome.
+ * The default applies only to the direct `serve --auto-launch` path. Operators
+ * can still opt out (`--no-auto-elect` / `OPENCHROME_AUTO_ELECT=0`) or choose an
+ * explicit role (`--broker` / `--connect-broker`), and the unsafe shared attach
+ * escape hatch remains separate. Keeping the decisions here (rather than inline
+ * in src/index.ts) makes the election rules unit-testable without booting a
+ * server or Chrome.
  */
 
 /** Offset from the CDP port used for the elected owner's broker HTTP endpoint. */
 export const BROKER_HTTP_PORT_OFFSET = 200;
 
+export interface AutoElectDecisionContext {
+  /** Commander value for --auto-elect / --no-auto-elect. false is explicit opt-out. */
+  autoElect?: boolean;
+  /** This process owns Chrome lifecycle and participates in controller-lock election. */
+  autoLaunch?: boolean;
+  /** Explicit broker owner role. Explicit roles take precedence over auto-elect. */
+  broker?: boolean;
+  /** Explicit broker client role. Explicit roles take precedence over auto-elect. */
+  connectBroker?: boolean;
+}
+
 /**
- * Is auto-elect enabled for this process?
+ * Is coordinated auto-elect enabled for this process?
  *
- * True when the operator passed `--auto-elect` or set `OPENCHROME_AUTO_ELECT=1`.
+ * Default true only for the direct `serve --auto-launch` path. Explicit opt-outs
+ * win (`--no-auto-elect`, `OPENCHROME_AUTO_ELECT=0`), and explicit broker/client
+ * roles are not auto-election decisions.
  */
 export function isAutoElectEnabled(
-  opts: { autoElect?: boolean },
+  opts: AutoElectDecisionContext,
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  return Boolean(opts.autoElect) || env.OPENCHROME_AUTO_ELECT === '1';
+  if (env.OPENCHROME_AUTO_ELECT === '0' || opts.autoElect === false) return false;
+  if (opts.broker || opts.connectBroker) return false;
+  if (opts.autoElect === true || env.OPENCHROME_AUTO_ELECT === '1') return true;
+  return opts.autoLaunch === true;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,8 @@ program
   .option('--transport <mode>', 'Transport mode: stdio, http, or both (default: stdio)')
   .option('--broker', 'Run as the shared-profile broker owner (HTTP daemon plus broker discovery metadata)')
   .option('--connect-broker', 'Proxy stdio MCP requests to the discovered broker instead of attaching to Chrome directly')
-  .option('--auto-elect', 'Coordinated sharing (#1480): the --auto-launch process that wins the controller lock becomes the broker owner and surplus sessions auto-attach as clients instead of failing fast. Also: OPENCHROME_AUTO_ELECT=1. Off by default.')
+  .option('--auto-elect', 'Coordinated sharing (#1480): force-enable auto-election for compatible serve paths (also: OPENCHROME_AUTO_ELECT=1).')
+  .option('--no-auto-elect', 'Disable coordinated auto-election and preserve fail-fast duplicate-controller behavior (also: OPENCHROME_AUTO_ELECT=0).')
   .option('--idle-timeout <duration>', 'Self-exit (code 0) after idle window with zero sessions. Format: <number>(ms|s|m|h), e.g. 30m, 90s, 500ms. Bare numbers are rejected. Also: OPENCHROME_IDLE_TIMEOUT_MS env var (integer ms). Default: disabled.')
   .option('--pilot', 'Enable experimental pilot tier (see docs/roadmap/portability-harness-contract.md). Off by default; lazy-loads src/pilot/ modules when set. Also: OPENCHROME_PILOT=1 env var.')
   .option('--slim', 'Expose only core tools (alias for --tools-only core).')
@@ -270,12 +271,15 @@ program
       process.exit(2);
     }
 
-    // #1480 auto-elect (D3 Q1′): the --auto-launch lock winner elects itself the
-    // broker owner so surplus sessions attach as coordinated clients instead of
-    // failing fast. Opt-in (off by default) — when disabled, every branch below
-    // is byte-for-byte the prior fail-fast behavior. Explicit --broker/
-    // --connect-broker always take precedence over auto-elect.
-    const autoElect = isAutoElectEnabled(options);
+    // #1480 auto-elect (D3 Q1′): PR A defines the default decision helper and
+    // opt-out flags, but keeps the live serve path on the previously validated
+    // explicit opt-in until PR B adds the real two-client smoke. Intentionally
+    // omit autoLaunch from this call; PR B is the scoped runtime default flip.
+    const autoElect = isAutoElectEnabled({
+      autoElect: options.autoElect,
+      broker: options.broker,
+      connectBroker: options.connectBroker,
+    });
     const electBrokerOwner = shouldElectBrokerOwner({
       autoElect,
       autoLaunch,

--- a/tests/auto-elect.test.ts
+++ b/tests/auto-elect.test.ts
@@ -15,21 +15,46 @@ import {
 } from '../src/broker/auto-elect';
 
 describe('isAutoElectEnabled', () => {
-  test('false by default (no flag, no env)', () => {
-    expect(isAutoElectEnabled({}, {})).toBe(false);
+  test('true by default for direct serve --auto-launch path', () => {
+    expect(isAutoElectEnabled({ autoLaunch: true }, {})).toBe(true);
   });
 
-  test('true when --auto-elect flag set', () => {
+  test('false by default when process is not an auto-launch controller', () => {
+    expect(isAutoElectEnabled({}, {})).toBe(false);
+    expect(isAutoElectEnabled({ autoLaunch: false }, {})).toBe(false);
+  });
+
+  test('caller can defer the runtime default by omitting autoLaunch context', () => {
+    expect(isAutoElectEnabled({ autoElect: undefined, broker: false, connectBroker: false }, {})).toBe(false);
+  });
+
+  test('explicit --auto-elect still enables compatible paths', () => {
     expect(isAutoElectEnabled({ autoElect: true }, {})).toBe(true);
   });
 
-  test('true when OPENCHROME_AUTO_ELECT=1', () => {
+  test('--no-auto-elect hard-disables the default', () => {
+    expect(isAutoElectEnabled({ autoLaunch: true, autoElect: false }, {})).toBe(false);
+  });
+
+  test('OPENCHROME_AUTO_ELECT=0 hard-disables the default', () => {
+    expect(isAutoElectEnabled({ autoLaunch: true }, { OPENCHROME_AUTO_ELECT: '0' })).toBe(false);
+    expect(isAutoElectEnabled({ autoLaunch: true, autoElect: true }, { OPENCHROME_AUTO_ELECT: '0' })).toBe(false);
+  });
+
+  test('OPENCHROME_AUTO_ELECT=1 explicitly enables compatible paths', () => {
     expect(isAutoElectEnabled({}, { OPENCHROME_AUTO_ELECT: '1' })).toBe(true);
   });
 
-  test('env values other than "1" do not enable', () => {
-    expect(isAutoElectEnabled({}, { OPENCHROME_AUTO_ELECT: 'true' })).toBe(false);
-    expect(isAutoElectEnabled({}, { OPENCHROME_AUTO_ELECT: '0' })).toBe(false);
+  test('env values other than "0" do not accidentally disable the default', () => {
+    expect(isAutoElectEnabled({ autoLaunch: true }, { OPENCHROME_AUTO_ELECT: 'true' })).toBe(true);
+    expect(isAutoElectEnabled({ autoLaunch: true }, { OPENCHROME_AUTO_ELECT: '' })).toBe(true);
+  });
+
+  test('explicit broker roles take precedence over auto-elect', () => {
+    expect(isAutoElectEnabled({ autoLaunch: true, broker: true }, {})).toBe(false);
+    expect(isAutoElectEnabled({ autoLaunch: true, connectBroker: true }, {})).toBe(false);
+    expect(isAutoElectEnabled({ autoElect: true, broker: true }, {})).toBe(false);
+    expect(isAutoElectEnabled({ autoElect: true, connectBroker: true }, {})).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Linked issue

Part of #1500 — PR A: auto-elect default decision helper, `--no-auto-elect`, env opt-out.

## Implementation scope

- Makes `isAutoElectEnabled()` context-aware:
  - default true for direct `serve --auto-launch` election path when the caller supplies auto-launch context;
  - false when the caller omits/defer auto-launch context;
  - false for non-auto-launch paths;
  - false for explicit `--broker` / `--connect-broker` roles;
  - false for `--no-auto-elect` or `OPENCHROME_AUTO_ELECT=0`;
  - explicit `--auto-elect` / `OPENCHROME_AUTO_ELECT=1` remain supported.
- Adds Commander `--no-auto-elect` option.
- Updates unit tests for decision semantics.
- Keeps live `serve` runtime on the previously validated explicit opt-in path by intentionally omitting `autoLaunch` context in `src/index.ts`; PR B owns the runtime default flip plus real two-client smoke.

## Explicit non-goals

- No two-process integration/smoke in this PR; reserved for #1500 PR B.
- No live `serve --auto-launch` default behavior flip in this PR; reserved for #1500 PR B.
- No setup/config default changes.
- No stale broker cleanup.
- No unsafe shared direct-CDP ownership.
- No SSOT docs update claiming default is fully shipped until PR B verifies real two-client behavior.

## Verification evidence

```bash
npm test -- --runTestsByPath tests/auto-elect.test.ts
# PASS: 19 tests

npm run build
# PASS

npm run lint:changed
# PASS

node dist/index.js serve --help | grep -A2 -B2 "auto-elect"
# shows --auto-elect and --no-auto-elect

git diff --check
# PASS
```

## Risks / known gaps

- Helper semantics now define the future default, but live `serve` deliberately defers passing `autoLaunch` context until PR B.
- PR B must still provide the real two-process auto-elect smoke before claiming the parallel-session default is fully verified.
