### PR TITLE
Enable auto-elect serve integration with real smoke

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "bench:full:live": "ts-node tests/benchmark/run-full-benchmark.ts --mode live",
     "bench:full:recorded": "ts-node tests/benchmark/run-full-benchmark.ts --mode recorded",
     "bench:api-key-readiness": "ts-node tests/benchmark/benchmark-readiness.ts --api-key-only",
-    "lint:skill-tools": "node scripts/lint-skill-tool-refs.mjs skills/openchrome/SKILL.md"
+    "lint:skill-tools": "node scripts/lint-skill-tool-refs.mjs skills/openchrome/SKILL.md",
+    "verify:auto-elect-smoke": "node scripts/verify/auto-elect-two-client-smoke.mjs"
   },
   "keywords": [
     "openchrome",

--- a/scripts/verify/auto-elect-two-client-smoke.mjs
+++ b/scripts/verify/auto-elect-two-client-smoke.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync, readFileSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import net from 'node:net';
+
+const root = resolve(new URL('../..', import.meta.url).pathname);
+const entry = join(root, 'dist', 'index.js');
+const timeoutMs = Number(process.env.OPENCHROME_AUTO_ELECT_SMOKE_TIMEOUT_MS || 30000);
+
+function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+function allocPort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      server.close((err) => err ? reject(err) : resolve(addr.port));
+    });
+  });
+}
+
+function start(name, args, env) {
+  const child = spawn(process.execPath, [entry, 'serve', ...args], {
+    cwd: root,
+    env: { ...process.env, ...env },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  child.name = name;
+  child.stderrText = '';
+  child.stdoutText = '';
+  child.stderr.on('data', (b) => { child.stderrText += b.toString(); });
+  child.stdout.on('data', (b) => { child.stdoutText += b.toString(); });
+  return child;
+}
+
+async function waitFor(label, fn, ms = timeoutMs) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    const v = await fn();
+    if (v) return v;
+    await sleep(100);
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+function readOnlyMetadata(registryDir) {
+  const files = readdirSync(registryDir).filter((name) => name.endsWith('.json'));
+  if (files.length !== 1) return null;
+  return JSON.parse(readFileSync(join(registryDir, files[0]), 'utf8'));
+}
+
+function sendRpc(child, id, method, params = {}) {
+  child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+}
+
+function jsonLines(text) {
+  return text.split('\n').filter(Boolean).flatMap((line) => {
+    try { return [JSON.parse(line)]; } catch { return []; }
+  });
+}
+
+async function terminate(children) {
+  for (const child of children) {
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
+  }
+  await sleep(500);
+  for (const child of children) {
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+  }
+}
+
+async function main() {
+  const tmp = mkdtempSync(join(tmpdir(), 'openchrome-auto-elect-'));
+  const userDataDir = join(tmp, 'profile');
+  const registryDir = join(tmp, 'brokers');
+  const cdpPort = await allocPort();
+  const httpPort = await allocPort();
+  const env = {
+    OPENCHROME_BROKER_REGISTRY_DIR: registryDir,
+    OPENCHROME_PPID_WATCH: '0',
+    OPENCHROME_HEALTH_ENDPOINT: '0',
+  };
+  const baseArgs = ['--auto-launch', '--headless', '--port', String(cdpPort), '--user-data-dir', userDataDir, '--http', String(httpPort), '--http-host', '127.0.0.1'];
+  const children = [];
+
+  try {
+    const owner = start('owner', baseArgs, env);
+    children.push(owner);
+    await waitFor('auto-elected broker metadata', () => /Broker metadata: .*\(auto-elected\)/.test(owner.stderrText));
+
+    const metadata = await waitFor('live broker metadata file', async () => {
+      try {
+        const m = readOnlyMetadata(registryDir);
+        if (!m) return null;
+        const res = await fetch(new URL('/health', m.endpoint), { signal: AbortSignal.timeout(1000) });
+        return res.ok ? m : null;
+      } catch { return null; }
+    });
+    if (metadata.pid !== owner.pid) throw new Error(`metadata pid ${metadata.pid} != owner pid ${owner.pid}`);
+
+    const client = start('client', baseArgs, env);
+    children.push(client);
+    await waitFor('surplus client broker attach', () => /auto-elect: attaching as broker client/.test(client.stderrText));
+    sendRpc(client, 1, 'initialize');
+    await waitFor('proxied initialize response', () => jsonLines(client.stdoutText).some((m) => m.id === 1 && m.result?.serverInfo?.name === 'openchrome'));
+
+    const optedOut = start('optout', [...baseArgs, '--no-auto-elect'], env);
+    children.push(optedOut);
+    await waitFor('opt-out duplicate remediation', () => /Refusing to start a second direct controller/.test(optedOut.stderrText) || /Another OpenChrome controller/.test(optedOut.stderrText));
+    if (/auto-elect: attaching as broker client/.test(optedOut.stderrText)) throw new Error('--no-auto-elect unexpectedly attached as broker client');
+
+    console.log(JSON.stringify({ ok: true, cdpPort, httpPort, ownerPid: owner.pid, brokerPid: metadata.pid, clientAttached: true, optOutPreservedFailFast: true }, null, 2));
+  } finally {
+    await terminate(children);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(err.stack || err.message || String(err));
+  process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,12 +271,14 @@ program
       process.exit(2);
     }
 
-    // #1480 auto-elect (D3 Q1′): PR A defines the default decision helper and
-    // opt-out flags, but keeps the live serve path on the previously validated
-    // explicit opt-in until PR B adds the real two-client smoke. Intentionally
-    // omit autoLaunch from this call; PR B is the scoped runtime default flip.
+    // #1480 auto-elect (D3 Q1′): direct `serve --auto-launch` defaults to
+    // coordinated broker election; explicit broker/client roles and opt-outs
+    // still take precedence inside the decision helper.
     const autoElect = isAutoElectEnabled({
       autoElect: options.autoElect,
+      // Keep the default flip scoped to direct `serve --auto-launch`; server-mode
+      // can still opt in with --auto-elect / OPENCHROME_AUTO_ELECT=1.
+      autoLaunch: options.autoLaunch === true,
       broker: options.broker,
       connectBroker: options.connectBroker,
     });


### PR DESCRIPTION
## Linked issue

Part of #1500 — PR B: serve integration and real two-client auto-elect smoke.

## Implementation scope

- Flips live `serve --auto-launch` to pass `autoLaunch` context into `isAutoElectEnabled()`.
- Keeps explicit `--broker` / `--connect-broker`, `--no-auto-elect`, and `OPENCHROME_AUTO_ELECT=0` precedence from PR A.
- Adds `npm run verify:auto-elect-smoke`, a real process smoke that uses temp profile + temp broker registry and proves:
  - one direct owner publishes auto-elected broker metadata;
  - broker metadata pid matches the owner process;
  - surplus same-port/profile client attaches through broker proxy;
  - `--no-auto-elect` preserves duplicate-controller remediation.

## Explicit non-goals

- No setup/config topology presets (#1501).
- No topology-aware diagnostics normalization (#1504 PR A).
- No N>=3 final verification harness (#1504 PR B).
- No unsafe shared direct-CDP ownership.
- No user real Chrome profile in smoke; it uses a temp profile.

## Verification evidence

```bash
npm test -- --runTestsByPath tests/auto-elect.test.ts
# PASS: 19 tests

npm run build
# PASS

npm run lint:changed
# PASS

npm run verify:auto-elect-smoke
# PASS: ownerPid == brokerPid, clientAttached true, optOutPreservedFailFast true

git diff --check
# PASS
```

## Risks / known gaps

- Smoke requires a locally discoverable Chrome/Chromium binary, same as real `serve --auto-launch`.
- N>=3 certification remains intentionally reserved for #1504 PR B.
