### PR TITLE
Make generated MCP configs choose safe topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Install and point your MCP client at it — one command:
 npm install -g openchrome-mcp
 
 openchrome setup                       # Claude Code
-openchrome setup --client codex        # Codex CLI
-npx openchrome-mcp setup --client opencode   # OpenCode
+openchrome setup --client codex        # Codex CLI (auto-elect topology)
+npx openchrome-mcp setup --client opencode   # OpenCode (auto-elect topology)
 ```
 
 Restart your MCP client. That's it — Chrome auto-launches on first tool call.
@@ -67,7 +67,7 @@ Restart your MCP client. That's it — Chrome auto-launches on first tool call.
 updates the OpenChrome binary, but it does not rewrite existing Claude Code,
 Codex CLI, OpenCode, or other MCP host registrations. If a release note asks you
 to move to a new topology (for example isolated profiles, broker mode, or a
-future auto-elect mode), rerun `openchrome setup --client <host> ...` or update
+legacy single-owner or manual broker topology), rerun `openchrome setup --client <host> ...` or update
 the host config manually, then restart that host session so the MCP namespace is
 loaded from the new config.
 
@@ -82,7 +82,7 @@ and add the printed `[mcp_servers.openchrome]` block to `~/.codex/config.toml`.
   "mcpServers": {
     "openchrome": {
       "command": "openchrome",
-      "args": ["serve", "--auto-launch"]
+      "args": ["serve", "--auto-launch", "--auto-elect"]
     }
   }
 }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -235,7 +235,7 @@ program
   .option('--user-data-dir <dir>', 'Chrome user data directory for generated serve args')
   .option('--profile-directory <name>', 'Chrome profile directory name for generated serve args')
   .option('--launch-mode <mode>', 'Chrome launch mode: auto, attach, or isolated')
-  .option('--topology <preset>', 'Topology preset: single-owner, isolated, ci-headless, or dev-profile')
+  .option('--topology <preset>', 'Topology preset: auto-elect (default), single-owner, broker-owner, broker-client, isolated, ci-headless, or dev-profile')
   .option('-s, --scope <scope>', 'Installation scope: "user" (global, default) or "project" (current project only)', 'user')
   .action(async (options: { client?: string; dashboard?: boolean; autoLaunch?: boolean; port?: string; userDataDir?: string; profileDirectory?: string; launchMode?: string; topology?: string; scope?: string }) => {
     const requestedClient = options.client || 'claude';
@@ -261,7 +261,7 @@ program
       userDataDir: options.userDataDir,
       profileDirectory: options.profileDirectory,
       launchMode: options.launchMode,
-      topology: options.topology as undefined | 'single-owner' | 'isolated' | 'ci-headless' | 'dev-profile',
+      topology: options.topology as undefined | 'auto-elect' | 'single-owner' | 'broker-owner' | 'broker-client' | 'isolated' | 'ci-headless' | 'dev-profile',
     };
     const topologyWarning = getTopologyWarning(serveArgOptions);
     if (topologyWarning) {
@@ -429,7 +429,7 @@ program
   .option('--user-data-dir <dir>', 'Chrome user data directory for generated serve args')
   .option('--profile-directory <name>', 'Chrome profile directory name for generated serve args')
   .option('--launch-mode <mode>', 'Chrome launch mode: auto, attach, or isolated')
-  .option('--topology <preset>', 'Topology preset: single-owner, isolated, ci-headless, or dev-profile')
+  .option('--topology <preset>', 'Topology preset: auto-elect (default), single-owner, broker-owner, broker-client, isolated, ci-headless, or dev-profile')
   .action((options: { client: string; dashboard?: boolean; autoLaunch?: boolean; port?: string; userDataDir?: string; profileDirectory?: string; launchMode?: string; topology?: string }) => {
     if (!isSupportedMCPClient(options.client)) {
       console.error(`❌ Invalid client. Use one of: ${getSupportedMCPClients().join(', ')}`);
@@ -443,7 +443,7 @@ program
       userDataDir: options.userDataDir,
       profileDirectory: options.profileDirectory,
       launchMode: options.launchMode,
-      topology: options.topology as undefined | 'single-owner' | 'isolated' | 'ci-headless' | 'dev-profile',
+      topology: options.topology as undefined | 'auto-elect' | 'single-owner' | 'broker-owner' | 'broker-client' | 'isolated' | 'ci-headless' | 'dev-profile',
     };
     const topologyWarning = getTopologyWarning(serveArgOptions);
     if (topologyWarning) {

--- a/cli/mcp-client-config.ts
+++ b/cli/mcp-client-config.ts
@@ -1,7 +1,7 @@
 export type SupportedMCPClient = 'claude' | 'codex' | 'opencode';
 export type SetupScope = 'user' | 'project';
 
-export type TopologyPreset = 'single-owner' | 'isolated' | 'ci-headless' | 'dev-profile';
+export type TopologyPreset = 'auto-elect' | 'single-owner' | 'broker-owner' | 'broker-client' | 'isolated' | 'ci-headless' | 'dev-profile';
 
 export const HOST_CONFIG_MIGRATION_NOTE = 'Package updates do not rewrite existing MCP host registrations; rerun setup or edit host config, then restart the host to activate topology changes.';
 
@@ -13,6 +13,9 @@ export interface ServeArgOptions {
   profileDirectory?: string;
   launchMode?: string;
   topology?: TopologyPreset;
+  autoElect?: boolean;
+  broker?: boolean;
+  connectBroker?: boolean;
 }
 
 export interface MCPServerConfig {
@@ -65,6 +68,11 @@ export function getServeArgs(options: ServeArgOptions = {}): string[] {
     serveArgs.push('--auto-launch');
   }
 
+  if (resolved.autoElect === true) serveArgs.push('--auto-elect');
+  if (resolved.autoElect === false) serveArgs.push('--no-auto-elect');
+  if (resolved.broker) serveArgs.push('--broker');
+  if (resolved.connectBroker) serveArgs.push('--connect-broker');
+
   if (resolved.port !== undefined) {
     serveArgs.push('--port', String(resolved.port));
   }
@@ -91,6 +99,23 @@ export function getServeArgs(options: ServeArgOptions = {}): string[] {
 export function resolveTopologyOptions(options: ServeArgOptions = {}): ServeArgOptions {
   const next: ServeArgOptions = { ...options };
   switch (options.topology) {
+    case 'broker-owner':
+      next.autoLaunch = true;
+      next.broker = true;
+      break;
+    case 'broker-client':
+      next.autoLaunch = false;
+      next.connectBroker = true;
+      break;
+    case 'single-owner':
+      next.autoLaunch ??= true;
+      next.autoElect ??= false;
+      break;
+    case 'auto-elect':
+    case undefined:
+      next.autoLaunch ??= true;
+      if (next.autoLaunch !== false) next.autoElect ??= true;
+      break;
     case 'isolated':
       next.port ??= 9223;
       next.userDataDir ??= '~/.openchrome/profiles/isolated';
@@ -105,18 +130,13 @@ export function resolveTopologyOptions(options: ServeArgOptions = {}): ServeArgO
       next.port ??= 9225;
       next.userDataDir ??= '~/.openchrome/profiles/dev';
       break;
-    case 'single-owner':
-    case undefined:
-      break;
   }
   return next;
 }
 
 export function getTopologyWarning(options: ServeArgOptions = {}): string | null {
-  const resolved = resolveTopologyOptions(options);
-  const usingDefaultPortProfile = resolved.port === undefined && !resolved.userDataDir;
-  if (!usingDefaultPortProfile) return null;
-  return `Topology note: this config uses the default single-owner Chrome port/profile. Do not install the same direct config in multiple MCP clients at once; choose --topology isolated, explicit --port + --user-data-dir, or the broker topology for shared profiles. ${HOST_CONFIG_MIGRATION_NOTE}`;
+  if (options.topology !== 'single-owner') return null;
+  return `Topology note: --topology single-owner generates the legacy direct-owner config. Do not install the same direct config in multiple MCP clients at once; prefer the default auto-elect topology, choose --topology isolated, explicit --port + --user-data-dir, or the broker topology for shared profiles. ${HOST_CONFIG_MIGRATION_NOTE}`;
 }
 
 export function getCodexServerConfig(options: ServeArgOptions = {}): MCPServerConfig {

--- a/docs/mcp/topologies.md
+++ b/docs/mcp/topologies.md
@@ -4,7 +4,7 @@ OpenChrome currently supports one safe direct-controller rule:
 
 > Run at most one direct `openchrome serve --auto-launch` process for the same Chrome debug port and user-data directory.
 
-Multiple MCP clients can still run in parallel today. When they need to share one Chrome user data directory, run a single broker owner (`openchrome serve --broker --auto-launch`) and point the other clients at it with `--connect-broker`; otherwise give each client its own isolated port and user-data directory.
+Multiple MCP clients can still run in parallel today. New `openchrome setup` / `openchrome config` output defaults to the auto-elect topology (`openchrome serve --auto-launch --auto-elect`): one process wins the Chrome/CDP owner lock and publishes broker metadata; surplus same-profile clients proxy through that broker. For explicit shared-profile deployments, run a single broker owner (`openchrome serve --broker --auto-launch`) and point the other clients at it with `--connect-broker`; otherwise give each client its own isolated port and user-data directory.
 
 ## After upgrading OpenChrome
 
@@ -23,25 +23,38 @@ or opaque `-32000` startup failures:
 3. restart the MCP host session. Active sessions usually load their MCP tool
    namespace at startup and will not hot-reload a changed config.
 
-Until an auto-elect topology is explicitly shipped and enabled by the release
-notes, use either isolated per-client profiles or the explicit broker owner /
-`--connect-broker` topology below. Maintainers can reuse the release-note wording
-in [`docs/releases/action-required-config-migration.md`](../releases/action-required-config-migration.md)
-when a release requires host config migration.
+For existing host configs, package update alone is not a migration. Rerun `openchrome setup --client <host>` or edit the host config manually, then restart the MCP host. Maintainers can reuse the release-note wording in [`docs/releases/action-required-config-migration.md`](../releases/action-required-config-migration.md) when a release requires host config migration.
 
-## Single-owner default
+## Auto-elect default
 
-Use this when one MCP client owns OpenChrome on the default Chrome port/profile.
+Use this for new Codex, OpenCode, or Claude Code configs unless you have a reason to pin an older topology.
 
 ```bash
 openchrome config --client codex
 openchrome config --client claude
+openchrome config --client opencode
 ```
 
 Generated configs use:
 
 ```bash
-openchrome serve --auto-launch
+openchrome serve --auto-launch --auto-elect
+```
+
+For one `(port, userDataDir)`, exactly one process remains the direct Chrome/CDP owner. Surplus sessions attach as broker clients instead of becoming unsafe second direct controllers.
+
+## Legacy single-owner explicit preset
+
+Use this only when exactly one MCP host/session will use the generated config:
+
+```bash
+openchrome config --client codex --topology single-owner
+```
+
+Generated configs use:
+
+```bash
+openchrome serve --auto-launch --no-auto-elect
 ```
 
 Do not install this same direct config in multiple clients at the same time.
@@ -79,7 +92,7 @@ openchrome config --client claude --topology dev-profile
 ## Shared-profile broker trust model
 
 Broker mode is the only supported way for more than one MCP client to share a
-single Chrome user data directory. The broker process is the sole CDP owner for
+single Chrome user data directory without auto-elect. The broker process is the sole CDP owner for
 that `(port, userDataDir)` pair; every other client must use `--connect-broker`
 so it forwards stdio JSON-RPC over the broker's HTTP endpoint instead of opening
 its own Chrome/CDP connection.
@@ -105,15 +118,16 @@ screenshot, DOM, or extracted page payloads across tenant boundaries.
 
 ```bash
 # Terminal 1: the single Chrome/CDP owner
+openchrome config --client codex --topology broker-owner --port 9222 \
+  --user-data-dir ~/.openchrome/shared-profile
 openchrome serve --broker --auto-launch --http 3100 --port 9222 \
   --user-data-dir ~/.openchrome/shared-profile
 
 # Terminal 2+: stdio MCP clients. When the broker has an auth token, share it
 # via OPENCHROME_AUTH_TOKEN (the proxy auto-discovers the broker's authTokenEnv
 # hint and uses that bearer for every forwarded JSON-RPC request).
-openchrome serve --connect-broker --port 9222 \
+openchrome config --client claude --topology broker-client --port 9222 \
   --user-data-dir ~/.openchrome/shared-profile
-
 openchrome serve --connect-broker --port 9222 \
   --user-data-dir ~/.openchrome/shared-profile
 ```

--- a/tests/cli/mcp-client-config.test.ts
+++ b/tests/cli/mcp-client-config.test.ts
@@ -15,11 +15,11 @@ import {
 
 describe('cli/mcp-client-config', () => {
   test('getServeArgs enables auto-launch by default', () => {
-    expect(getServeArgs()).toEqual(['serve', '--auto-launch']);
+    expect(getServeArgs()).toEqual(['serve', '--auto-launch', '--auto-elect']);
   });
 
   test('getServeArgs includes dashboard when requested', () => {
-    expect(getServeArgs({ dashboard: true })).toEqual(['serve', '--auto-launch', '--dashboard']);
+    expect(getServeArgs({ dashboard: true })).toEqual(['serve', '--auto-launch', '--auto-elect', '--dashboard']);
   });
 
   test('getServeArgs preserves explicit port and profile topology', () => {
@@ -31,6 +31,7 @@ describe('cli/mcp-client-config', () => {
     })).toEqual([
       'serve',
       '--auto-launch',
+      '--auto-elect',
       '--port',
       '9333',
       '--user-data-dir',
@@ -39,6 +40,19 @@ describe('cli/mcp-client-config', () => {
       'Default',
       '--launch-mode',
       'isolated',
+    ]);
+  });
+
+  test('single-owner topology preset preserves the legacy direct owner explicitly', () => {
+    expect(getServeArgs({ topology: 'single-owner' })).toEqual(['serve', '--auto-launch', '--no-auto-elect']);
+  });
+
+  test('broker topology presets generate owner and client roles', () => {
+    expect(getServeArgs({ topology: 'broker-owner', port: 9222, userDataDir: '/tmp/shared' })).toEqual([
+      'serve', '--auto-launch', '--broker', '--port', '9222', '--user-data-dir', '/tmp/shared',
+    ]);
+    expect(getServeArgs({ topology: 'broker-client', port: 9222, userDataDir: '/tmp/shared' })).toEqual([
+      'serve', '--connect-broker', '--port', '9222', '--user-data-dir', '/tmp/shared',
     ]);
   });
 
@@ -62,7 +76,7 @@ describe('cli/mcp-client-config', () => {
   test('getCodexServerConfig uses the installed openchrome binary', () => {
     expect(getCodexServerConfig()).toEqual({
       command: 'openchrome',
-      args: ['serve', '--auto-launch'],
+      args: ['serve', '--auto-launch', '--auto-elect'],
     });
   });
 
@@ -77,6 +91,7 @@ describe('cli/mcp-client-config', () => {
       'openchrome',
       'serve',
       '--auto-launch',
+      '--auto-elect',
       '--dashboard',
     ]);
     expect(command).not.toContain('remove');
@@ -85,7 +100,7 @@ describe('cli/mcp-client-config', () => {
   test('getClaudeManualServerConfig uses the installed openchrome binary', () => {
     expect(getClaudeManualServerConfig()).toEqual({
       command: 'openchrome',
-      args: ['serve', '--auto-launch'],
+      args: ['serve', '--auto-launch', '--auto-elect'],
     });
   });
 
@@ -100,6 +115,7 @@ describe('cli/mcp-client-config', () => {
       'openchrome',
       'serve',
       '--auto-launch',
+      '--auto-elect',
       '--dashboard',
     ]);
   });
@@ -126,7 +142,7 @@ describe('cli/mcp-client-config', () => {
         },
         openchrome: {
           command: 'openchrome',
-          args: ['serve', '--auto-launch'],
+          args: ['serve', '--auto-launch', '--auto-elect'],
         },
       },
     });
@@ -137,7 +153,7 @@ describe('cli/mcp-client-config', () => {
       mcpServers: {
         openchrome: {
           command: 'openchrome',
-          args: ['serve', '--auto-launch'],
+          args: ['serve', '--auto-launch', '--auto-elect'],
         },
       },
     });
@@ -148,7 +164,7 @@ describe('cli/mcp-client-config', () => {
       [
         '[mcp_servers.openchrome]',
         'command = "openchrome"',
-        'args = ["serve", "--auto-launch"]',
+        'args = ["serve", "--auto-launch", "--auto-elect"]',
       ].join('\n')
     );
   });
@@ -157,7 +173,7 @@ describe('cli/mcp-client-config', () => {
     const options = { port: 9333, userDataDir: '/tmp/openchrome-codex' };
 
     expect(formatCodexMCPServerConfigSnippet('openchrome', getCodexServerConfig(options))).toContain(
-      'args = ["serve", "--auto-launch", "--port", "9333", "--user-data-dir", "/tmp/openchrome-codex"]'
+      'args = ["serve", "--auto-launch", "--auto-elect", "--port", "9333", "--user-data-dir", "/tmp/openchrome-codex"]'
     );
     expect(getClaudeSetupCommand('user', options)).toEqual([
       'mcp',
@@ -169,6 +185,7 @@ describe('cli/mcp-client-config', () => {
       'openchrome',
       'serve',
       '--auto-launch',
+      '--auto-elect',
       '--port',
       '9333',
       '--user-data-dir',
@@ -183,6 +200,7 @@ describe('cli/mcp-client-config', () => {
         'openchrome',
         'serve',
         '--auto-launch',
+        '--auto-elect',
         '--port',
         '9444',
         '--user-data-dir',
@@ -191,10 +209,10 @@ describe('cli/mcp-client-config', () => {
     });
   });
 
-  test('default topology warning is omitted once port/profile is explicit', () => {
-    expect(getTopologyWarning()).toContain('default single-owner');
-    expect(getTopologyWarning()).toContain(HOST_CONFIG_MIGRATION_NOTE);
-    expect(getTopologyWarning({ port: 9333, userDataDir: '/tmp/openchrome-codex' })).toBeNull();
+  test('single-owner topology warning calls out legacy direct-owner risk', () => {
+    expect(getTopologyWarning()).toBeNull();
+    expect(getTopologyWarning({ topology: 'single-owner' })).toContain('legacy direct-owner');
+    expect(getTopologyWarning({ topology: 'single-owner' })).toContain(HOST_CONFIG_MIGRATION_NOTE);
   });
 
   test('generated configs do not use transient package runners', () => {


### PR DESCRIPTION
## Linked issue

Closes #1501.

## Implementation scope

- Adds setup/config topology presets:
  - `auto-elect` (default)
  - `single-owner` (legacy direct owner, explicit `--no-auto-elect`)
  - `broker-owner`
  - `broker-client`
  - retains `isolated`, `ci-headless`, `dev-profile`
- Makes generated MCP configs default to `serve --auto-launch --auto-elect`.
- Keeps `--topology single-owner` available for the old direct-owner command.
- Makes `broker-client` emit `serve --connect-broker ...` without `--auto-launch`.
- Updates topology docs/README migration language.

## Explicit non-goals

- No runtime election behavior changes.
- No stale broker cleanup.
- No process killing/reaping.
- No interactive migration wizard.
- No package-update host config rewrite.

## Verification evidence

```bash
npm run build
# PASS

npm test -- --runTestsByPath tests/cli/mcp-client-config.test.ts
# PASS: 19 tests

node dist/cli/index.js config --client codex
# args = ["serve", "--auto-launch", "--auto-elect"]

node dist/cli/index.js config --client opencode
# command includes "serve", "--auto-launch", "--auto-elect"

node dist/cli/index.js config --client claude
# claude mcp add ... serve --auto-launch --auto-elect

npm run lint:changed
# PASS: no changed src/**/*.ts files

git diff --check
# PASS
```

## Risks / known gaps

- Real host CLI setup writes were not run to avoid mutating user configs; config output covers the generated command shape.
