### PR TITLE
Normalize diagnostics around real controller topology

### DIFF
--- a/src/cli/doctor/runtime-diagnostics.ts
+++ b/src/cli/doctor/runtime-diagnostics.ts
@@ -12,6 +12,7 @@ export type ActiveRuntimePath =
   | 'isolated-profile'
   | 'attach-mode'
   | 'unsafe-secondary-attach'
+  | 'stale-broker-metadata'
   | 'blocked-by-owner'
   | 'unknown';
 
@@ -32,6 +33,7 @@ export interface RuntimeDiagnostics {
     autoElectEnabled: boolean;
     unsafeSharedAttachEnabled: boolean;
     launchMode?: string;
+    ownerCommand?: string[];
   };
 }
 
@@ -70,11 +72,14 @@ export function classifyRuntimePath(params: {
     return 'unsafe-secondary-attach';
   }
   if (params.launchMode === 'attach') return 'attach-mode';
-  if (params.brokerPid && params.brokerPidAlive) {
-    if (params.autoElectEnabled) {
-      return params.ownerPid === params.brokerPid ? 'auto-elect-owner' : 'auto-elect-client';
+  if (params.brokerPid) {
+    if (params.brokerPidAlive === false) return 'stale-broker-metadata';
+    if (params.brokerPidAlive) {
+      if (params.autoElectEnabled) {
+        return params.ownerPid === params.brokerPid ? 'auto-elect-owner' : 'auto-elect-client';
+      }
+      return params.ownerPid === params.brokerPid ? 'broker-owner' : 'broker-client';
     }
-    return params.ownerPid === params.brokerPid ? 'broker-owner' : 'broker-client';
   }
   if (params.controllerRole === 'owner') return 'direct-owner';
   if (params.controllerRole === 'unknown' && params.ownerPid) return 'blocked-by-owner';
@@ -82,11 +87,18 @@ export function classifyRuntimePath(params: {
   return 'unknown';
 }
 
+function commandEnablesAutoElect(command?: string[]): boolean {
+  if (!command) return false;
+  if (command.includes('--no-auto-elect')) return false;
+  if (command.includes('--auto-elect')) return true;
+  return command.includes('serve') && command.includes('--auto-launch') && !command.includes('--server-mode');
+}
+
 export function collectDoctorDiagnostics(): DoctorDiagnostics {
   const topology = getCurrentControllerTopology();
   const broker = readBrokerMetadata(topology.port, topology.userDataDir);
   const brokerPidAlive = broker?.pid !== undefined ? isPidAlive(broker.pid) : undefined;
-  const autoElectEnabled = process.env.OPENCHROME_AUTO_ELECT === '1';
+  const autoElectEnabled = process.env.OPENCHROME_AUTO_ELECT === '1' || (process.env.OPENCHROME_AUTO_ELECT !== '0' && commandEnablesAutoElect(topology.ownerCommand));
   const unsafeSharedAttachEnabled = process.env.OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH === '1';
   const launchMode = process.env.OPENCHROME_LAUNCH_MODE;
 
@@ -116,6 +128,7 @@ export function collectDoctorDiagnostics(): DoctorDiagnostics {
         autoElectEnabled,
         unsafeSharedAttachEnabled,
         ...(launchMode ? { launchMode } : {}),
+        ...(topology.ownerCommand ? { ownerCommand: topology.ownerCommand } : {}),
       },
     },
   };

--- a/src/utils/duplicate-controller-diagnostics.ts
+++ b/src/utils/duplicate-controller-diagnostics.ts
@@ -12,7 +12,9 @@ export interface OpenChromeProcessInfo {
   port: number;
   userDataDir: string;
   source: 'global' | 'npx' | 'local' | 'unknown';
+  role: 'direct-controller' | 'broker-client';
 }
+
 
 export interface DuplicateControllerGroup {
   port: number;
@@ -81,6 +83,7 @@ export function inferOpenChromeProcess(pid: number, command: string, ppid?: numb
     port: Number.isFinite(port) ? port : DEFAULT_PORT,
     userDataDir: userDataDir === DEFAULT_PROFILE ? DEFAULT_PROFILE : normalizeControllerUserDataDir(userDataDir),
     source,
+    role: tokens.includes('--connect-broker') ? 'broker-client' : 'direct-controller',
   };
 }
 
@@ -106,10 +109,26 @@ export function scanOpenChromeProcesses(): OpenChromeProcessInfo[] {
   }
 }
 
+function controllerKey(proc: OpenChromeProcessInfo): string {
+  return `${proc.port}\u0000${proc.userDataDir}`;
+}
+
+function isWrapperProcess(proc: OpenChromeProcessInfo): boolean {
+  return /npm exec|npx|_npx|openchrome-mcp@/.test(proc.command);
+}
+
+export function normalizeControllerProcesses(processes: OpenChromeProcessInfo[]): OpenChromeProcessInfo[] {
+  return processes.filter((proc) => {
+    if (proc.role === 'broker-client') return false;
+    if (!isWrapperProcess(proc)) return true;
+    return !processes.some((child) => child.ppid === proc.pid && child.role === 'direct-controller' && controllerKey(child) === controllerKey(proc));
+  });
+}
+
 export function findDuplicateControllerGroups(processes: OpenChromeProcessInfo[]): DuplicateControllerGroup[] {
   const groups = new Map<string, OpenChromeProcessInfo[]>();
-  for (const proc of processes) {
-    const key = `${proc.port}\u0000${proc.userDataDir}`;
+  for (const proc of normalizeControllerProcesses(processes)) {
+    const key = controllerKey(proc);
     groups.set(key, [...(groups.get(key) ?? []), proc]);
   }
   return Array.from(groups.values())
@@ -206,6 +225,7 @@ export function getCurrentControllerTopology(options: { port?: number; userDataD
   userDataDir: string;
   lockPath: string;
   ownerPid?: number;
+  ownerCommand?: string[];
   remediation?: string;
 } {
   const port = options.port ?? parseInt(process.env.CHROME_PORT ?? String(DEFAULT_PORT), 10);
@@ -224,7 +244,7 @@ export function getCurrentControllerTopology(options: { port?: number; userDataD
     const raw = fs.readFileSync(lockPath, 'utf8');
     const parsed = JSON.parse(raw) as { pid?: number };
     if (typeof parsed.pid === 'number' && isPidAlive(parsed.pid)) {
-      return { role: parsed.pid === process.pid ? 'owner' : 'unknown', port, userDataDir, lockPath, ownerPid: parsed.pid };
+      return { role: parsed.pid === process.pid ? 'owner' : 'unknown', port, userDataDir, lockPath, ownerPid: parsed.pid, ownerCommand: Array.isArray((parsed as { command?: unknown }).command) ? (parsed as { command: string[] }).command : undefined };
     }
     return { role: 'unlocked', port, userDataDir, lockPath };
   } catch {

--- a/tests/cli/doctor/runtime-diagnostics.test.ts
+++ b/tests/cli/doctor/runtime-diagnostics.test.ts
@@ -1,7 +1,28 @@
 import * as os from 'os';
-import { classifyRuntimePath, displayPath } from '../../../src/cli/doctor/runtime-diagnostics';
+
+jest.mock('../../../src/utils/duplicate-controller-diagnostics', () => ({
+  getCurrentControllerTopology: jest.fn(),
+}));
+jest.mock('../../../src/broker/discovery', () => ({
+  readBrokerMetadata: jest.fn(),
+}));
+jest.mock('../../../src/utils/controller-lock', () => ({
+  isPidAlive: jest.fn(),
+}));
+
+const { getCurrentControllerTopology } = jest.requireMock('../../../src/utils/duplicate-controller-diagnostics') as { getCurrentControllerTopology: jest.Mock };
+const { readBrokerMetadata } = jest.requireMock('../../../src/broker/discovery') as { readBrokerMetadata: jest.Mock };
+const { isPidAlive } = jest.requireMock('../../../src/utils/controller-lock') as { isPidAlive: jest.Mock };
+import { classifyRuntimePath, collectDoctorDiagnostics, displayPath } from '../../../src/cli/doctor/runtime-diagnostics';
 
 describe('doctor runtime diagnostics', () => {
+  const oldAutoElect = process.env.OPENCHROME_AUTO_ELECT;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    if (oldAutoElect === undefined) delete process.env.OPENCHROME_AUTO_ELECT;
+    else process.env.OPENCHROME_AUTO_ELECT = oldAutoElect;
+  });
   test('classifies unsafe shared attach first', () => {
     expect(classifyRuntimePath({ controllerRole: 'unlocked', unsafeSharedAttachEnabled: true })).toBe('unsafe-secondary-attach');
   });
@@ -20,11 +41,50 @@ describe('doctor runtime diagnostics', () => {
     expect(classifyRuntimePath({ controllerRole: 'unknown', ownerPid: 10, brokerPid: 20, brokerPidAlive: true, autoElectEnabled: true })).toBe('auto-elect-client');
   });
 
+  test('classifies stale broker metadata', () => {
+    expect(classifyRuntimePath({ controllerRole: 'owner', ownerPid: 10, brokerPid: 99, brokerPidAlive: false })).toBe('stale-broker-metadata');
+  });
+
   test('classifies direct owner, blocked owner, isolated profile, and unknown', () => {
     expect(classifyRuntimePath({ controllerRole: 'owner', ownerPid: 10 })).toBe('direct-owner');
     expect(classifyRuntimePath({ controllerRole: 'unknown', ownerPid: 10 })).toBe('blocked-by-owner');
     expect(classifyRuntimePath({ controllerRole: 'unlocked', launchMode: 'isolated' })).toBe('isolated-profile');
     expect(classifyRuntimePath({ controllerRole: 'unlocked' })).toBe('unknown');
+  });
+
+  test('collects auto-elect topology from owner command metadata', () => {
+    delete process.env.OPENCHROME_AUTO_ELECT;
+    getCurrentControllerTopology.mockReturnValue({
+      role: 'owner',
+      port: 9222,
+      userDataDir: '/tmp/profile',
+      lockPath: '/tmp/lock.json',
+      ownerPid: 10,
+      ownerCommand: ['openchrome', 'serve', '--auto-launch'],
+    });
+    readBrokerMetadata.mockReturnValue({ pid: 10, endpoint: 'http://127.0.0.1:9422/mcp' });
+    isPidAlive.mockReturnValue(true);
+
+    const diagnostics = collectDoctorDiagnostics();
+
+    expect(diagnostics.runtime.runtime_topology).toBe('auto-elect-owner');
+    expect(diagnostics.runtime.facts.autoElectEnabled).toBe(true);
+  });
+
+  test('owner command --no-auto-elect overrides default auto-elect diagnostics', () => {
+    delete process.env.OPENCHROME_AUTO_ELECT;
+    getCurrentControllerTopology.mockReturnValue({
+      role: 'owner',
+      port: 9222,
+      userDataDir: '/tmp/profile',
+      lockPath: '/tmp/lock.json',
+      ownerPid: 10,
+      ownerCommand: ['openchrome', 'serve', '--auto-launch', '--no-auto-elect'],
+    });
+    readBrokerMetadata.mockReturnValue({ pid: 10, endpoint: 'http://127.0.0.1:9422/mcp' });
+    isPidAlive.mockReturnValue(true);
+
+    expect(collectDoctorDiagnostics().runtime.runtime_topology).toBe('broker-owner');
   });
 
   test('redacts home-relative paths for display facts', () => {

--- a/tests/duplicate-controller-diagnostics.test.ts
+++ b/tests/duplicate-controller-diagnostics.test.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   findDuplicateControllerGroups,
+  normalizeControllerProcesses,
   getCurrentControllerTopology,
   inferOpenChromeProcess,
   parsePsOutput,
@@ -40,17 +41,38 @@ describe('duplicate controller diagnostics', () => {
     expect(globalProc?.userDataDir).toBe(path.resolve('/tmp/shared'));
   });
 
-  test('groups duplicate processes by port and profile', () => {
+  test('groups only independent direct controllers by port and profile', () => {
     const processes = parsePsOutput([
       '100 1 openchrome serve --port 9222 --user-data-dir /tmp/shared',
       '101 1 npm exec openchrome-mcp@latest -- openchrome serve --port 9222 --user-data-dir /tmp/shared',
-      '102 1 openchrome serve --port 9223 --user-data-dir /tmp/shared',
+      '102 1 openchrome serve --connect-broker --port 9222 --user-data-dir /tmp/shared',
+      '103 1 openchrome serve --port 9223 --user-data-dir /tmp/shared',
     ].join('\n'));
 
     const groups = findDuplicateControllerGroups(processes);
 
     expect(groups).toHaveLength(1);
     expect(groups[0].processes.map((proc) => proc.pid)).toEqual([100, 101]);
+  });
+
+  test('collapses wrapper parent and child for the same direct controller', () => {
+    const processes = parsePsOutput([
+      '200 1 npm exec openchrome-mcp@latest -- openchrome serve --port 9222 --user-data-dir /tmp/shared',
+      '201 200 node /tmp/_npx/openchrome-mcp/dist/index.js serve --port 9222 --user-data-dir /tmp/shared',
+      '202 1 openchrome serve --connect-broker --port 9222 --user-data-dir /tmp/shared',
+    ].join('\n'));
+
+    expect(normalizeControllerProcesses(processes).map((proc) => proc.pid)).toEqual([201]);
+    expect(findDuplicateControllerGroups(processes)).toEqual([]);
+  });
+
+  test('does not collapse a non-wrapper direct parent and child', () => {
+    const processes = parsePsOutput([
+      '300 1 openchrome serve --port 9222 --user-data-dir /tmp/shared',
+      '301 300 node custom-direct-controller.js openchrome serve --port 9222 --user-data-dir /tmp/shared',
+    ].join('\n'));
+
+    expect(findDuplicateControllerGroups(processes)[0].processes.map((proc) => proc.pid)).toEqual([300, 301]);
   });
 
   test('detects stale Codex mcp.json and mixed registrations', () => {


### PR DESCRIPTION
## Linked issue

Part of #1504 — PR A: topology-aware diagnostics normalization.

## Implementation scope

- Collapses wrapper parent + node child process pairs for the same `(port, userDataDir)` direct controller.
- Excludes `--connect-broker` processes from direct duplicate-controller groups.
- Keeps independent direct controllers grouped/flagged as duplicates.
- Adds `stale-broker-metadata` runtime topology classification when broker metadata points to a dead PID.
- Adds focused unit tests for the above.

## Explicit non-goals

- No runtime election behavior changes.
- No process killing/reaping.
- No stale broker cleanup from diagnostics.
- No N>=3 real verification harness; reserved for #1504 PR B.

## Verification evidence

```bash
npm test -- --runTestsByPath tests/duplicate-controller-diagnostics.test.ts tests/cli/doctor/runtime-diagnostics.test.ts
# PASS: 13 tests

npm run build
# PASS

npm run lint:changed
# PASS

git diff --check
# PASS
```

## Risks / known gaps

- `ps` parsing remains defensive string parsing; tests use fixtures for the topology cases.
- Full N>=3 live verification remains in PR B.
