### PR TITLE
Promote OpenChrome parallel-session stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Install and point your MCP client at it — one command:
 npm install -g openchrome-mcp
 
 openchrome setup                       # Claude Code
-openchrome setup --client codex        # Codex CLI
-npx openchrome-mcp setup --client opencode   # OpenCode
+openchrome setup --client codex        # Codex CLI (auto-elect topology)
+npx openchrome-mcp setup --client opencode   # OpenCode (auto-elect topology)
 ```
 
 Restart your MCP client. That's it — Chrome auto-launches on first tool call.
@@ -67,7 +67,7 @@ Restart your MCP client. That's it — Chrome auto-launches on first tool call.
 updates the OpenChrome binary, but it does not rewrite existing Claude Code,
 Codex CLI, OpenCode, or other MCP host registrations. If a release note asks you
 to move to a new topology (for example isolated profiles, broker mode, or a
-future auto-elect mode), rerun `openchrome setup --client <host> ...` or update
+legacy single-owner or manual broker topology), rerun `openchrome setup --client <host> ...` or update
 the host config manually, then restart that host session so the MCP namespace is
 loaded from the new config.
 
@@ -82,7 +82,7 @@ and add the printed `[mcp_servers.openchrome]` block to `~/.codex/config.toml`.
   "mcpServers": {
     "openchrome": {
       "command": "openchrome",
-      "args": ["serve", "--auto-launch"]
+      "args": ["serve", "--auto-launch", "--auto-elect"]
     }
   }
 }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -235,7 +235,7 @@ program
   .option('--user-data-dir <dir>', 'Chrome user data directory for generated serve args')
   .option('--profile-directory <name>', 'Chrome profile directory name for generated serve args')
   .option('--launch-mode <mode>', 'Chrome launch mode: auto, attach, or isolated')
-  .option('--topology <preset>', 'Topology preset: single-owner, isolated, ci-headless, or dev-profile')
+  .option('--topology <preset>', 'Topology preset: auto-elect (default), single-owner, broker-owner, broker-client, isolated, ci-headless, or dev-profile')
   .option('-s, --scope <scope>', 'Installation scope: "user" (global, default) or "project" (current project only)', 'user')
   .action(async (options: { client?: string; dashboard?: boolean; autoLaunch?: boolean; port?: string; userDataDir?: string; profileDirectory?: string; launchMode?: string; topology?: string; scope?: string }) => {
     const requestedClient = options.client || 'claude';
@@ -261,7 +261,7 @@ program
       userDataDir: options.userDataDir,
       profileDirectory: options.profileDirectory,
       launchMode: options.launchMode,
-      topology: options.topology as undefined | 'single-owner' | 'isolated' | 'ci-headless' | 'dev-profile',
+      topology: options.topology as undefined | 'auto-elect' | 'single-owner' | 'broker-owner' | 'broker-client' | 'isolated' | 'ci-headless' | 'dev-profile',
     };
     const topologyWarning = getTopologyWarning(serveArgOptions);
     if (topologyWarning) {
@@ -429,7 +429,7 @@ program
   .option('--user-data-dir <dir>', 'Chrome user data directory for generated serve args')
   .option('--profile-directory <name>', 'Chrome profile directory name for generated serve args')
   .option('--launch-mode <mode>', 'Chrome launch mode: auto, attach, or isolated')
-  .option('--topology <preset>', 'Topology preset: single-owner, isolated, ci-headless, or dev-profile')
+  .option('--topology <preset>', 'Topology preset: auto-elect (default), single-owner, broker-owner, broker-client, isolated, ci-headless, or dev-profile')
   .action((options: { client: string; dashboard?: boolean; autoLaunch?: boolean; port?: string; userDataDir?: string; profileDirectory?: string; launchMode?: string; topology?: string }) => {
     if (!isSupportedMCPClient(options.client)) {
       console.error(`❌ Invalid client. Use one of: ${getSupportedMCPClients().join(', ')}`);
@@ -443,7 +443,7 @@ program
       userDataDir: options.userDataDir,
       profileDirectory: options.profileDirectory,
       launchMode: options.launchMode,
-      topology: options.topology as undefined | 'single-owner' | 'isolated' | 'ci-headless' | 'dev-profile',
+      topology: options.topology as undefined | 'auto-elect' | 'single-owner' | 'broker-owner' | 'broker-client' | 'isolated' | 'ci-headless' | 'dev-profile',
     };
     const topologyWarning = getTopologyWarning(serveArgOptions);
     if (topologyWarning) {

--- a/cli/mcp-client-config.ts
+++ b/cli/mcp-client-config.ts
@@ -1,7 +1,7 @@
 export type SupportedMCPClient = 'claude' | 'codex' | 'opencode';
 export type SetupScope = 'user' | 'project';
 
-export type TopologyPreset = 'single-owner' | 'isolated' | 'ci-headless' | 'dev-profile';
+export type TopologyPreset = 'auto-elect' | 'single-owner' | 'broker-owner' | 'broker-client' | 'isolated' | 'ci-headless' | 'dev-profile';
 
 export const HOST_CONFIG_MIGRATION_NOTE = 'Package updates do not rewrite existing MCP host registrations; rerun setup or edit host config, then restart the host to activate topology changes.';
 
@@ -13,6 +13,9 @@ export interface ServeArgOptions {
   profileDirectory?: string;
   launchMode?: string;
   topology?: TopologyPreset;
+  autoElect?: boolean;
+  broker?: boolean;
+  connectBroker?: boolean;
 }
 
 export interface MCPServerConfig {
@@ -65,6 +68,11 @@ export function getServeArgs(options: ServeArgOptions = {}): string[] {
     serveArgs.push('--auto-launch');
   }
 
+  if (resolved.autoElect === true) serveArgs.push('--auto-elect');
+  if (resolved.autoElect === false) serveArgs.push('--no-auto-elect');
+  if (resolved.broker) serveArgs.push('--broker');
+  if (resolved.connectBroker) serveArgs.push('--connect-broker');
+
   if (resolved.port !== undefined) {
     serveArgs.push('--port', String(resolved.port));
   }
@@ -91,6 +99,23 @@ export function getServeArgs(options: ServeArgOptions = {}): string[] {
 export function resolveTopologyOptions(options: ServeArgOptions = {}): ServeArgOptions {
   const next: ServeArgOptions = { ...options };
   switch (options.topology) {
+    case 'broker-owner':
+      next.autoLaunch = true;
+      next.broker = true;
+      break;
+    case 'broker-client':
+      next.autoLaunch = false;
+      next.connectBroker = true;
+      break;
+    case 'single-owner':
+      next.autoLaunch ??= true;
+      next.autoElect ??= false;
+      break;
+    case 'auto-elect':
+    case undefined:
+      next.autoLaunch ??= true;
+      if (next.autoLaunch !== false) next.autoElect ??= true;
+      break;
     case 'isolated':
       next.port ??= 9223;
       next.userDataDir ??= '~/.openchrome/profiles/isolated';
@@ -105,18 +130,13 @@ export function resolveTopologyOptions(options: ServeArgOptions = {}): ServeArgO
       next.port ??= 9225;
       next.userDataDir ??= '~/.openchrome/profiles/dev';
       break;
-    case 'single-owner':
-    case undefined:
-      break;
   }
   return next;
 }
 
 export function getTopologyWarning(options: ServeArgOptions = {}): string | null {
-  const resolved = resolveTopologyOptions(options);
-  const usingDefaultPortProfile = resolved.port === undefined && !resolved.userDataDir;
-  if (!usingDefaultPortProfile) return null;
-  return `Topology note: this config uses the default single-owner Chrome port/profile. Do not install the same direct config in multiple MCP clients at once; choose --topology isolated, explicit --port + --user-data-dir, or the broker topology for shared profiles. ${HOST_CONFIG_MIGRATION_NOTE}`;
+  if (options.topology !== 'single-owner') return null;
+  return `Topology note: --topology single-owner generates the legacy direct-owner config. Do not install the same direct config in multiple MCP clients at once; prefer the default auto-elect topology, choose --topology isolated, explicit --port + --user-data-dir, or the broker topology for shared profiles. ${HOST_CONFIG_MIGRATION_NOTE}`;
 }
 
 export function getCodexServerConfig(options: ServeArgOptions = {}): MCPServerConfig {

--- a/docs/mcp/topologies.md
+++ b/docs/mcp/topologies.md
@@ -4,7 +4,7 @@ OpenChrome currently supports one safe direct-controller rule:
 
 > Run at most one direct `openchrome serve --auto-launch` process for the same Chrome debug port and user-data directory.
 
-Multiple MCP clients can still run in parallel today. When they need to share one Chrome user data directory, run a single broker owner (`openchrome serve --broker --auto-launch`) and point the other clients at it with `--connect-broker`; otherwise give each client its own isolated port and user-data directory.
+Multiple MCP clients can still run in parallel today. New `openchrome setup` / `openchrome config` output defaults to the auto-elect topology (`openchrome serve --auto-launch --auto-elect`): one process wins the Chrome/CDP owner lock and publishes broker metadata; surplus same-profile clients proxy through that broker. For explicit shared-profile deployments, run a single broker owner (`openchrome serve --broker --auto-launch`) and point the other clients at it with `--connect-broker`; otherwise give each client its own isolated port and user-data directory.
 
 ## After upgrading OpenChrome
 
@@ -23,25 +23,38 @@ or opaque `-32000` startup failures:
 3. restart the MCP host session. Active sessions usually load their MCP tool
    namespace at startup and will not hot-reload a changed config.
 
-Until an auto-elect topology is explicitly shipped and enabled by the release
-notes, use either isolated per-client profiles or the explicit broker owner /
-`--connect-broker` topology below. Maintainers can reuse the release-note wording
-in [`docs/releases/action-required-config-migration.md`](../releases/action-required-config-migration.md)
-when a release requires host config migration.
+For existing host configs, package update alone is not a migration. Rerun `openchrome setup --client <host>` or edit the host config manually, then restart the MCP host. Maintainers can reuse the release-note wording in [`docs/releases/action-required-config-migration.md`](../releases/action-required-config-migration.md) when a release requires host config migration.
 
-## Single-owner default
+## Auto-elect default
 
-Use this when one MCP client owns OpenChrome on the default Chrome port/profile.
+Use this for new Codex, OpenCode, or Claude Code configs unless you have a reason to pin an older topology.
 
 ```bash
 openchrome config --client codex
 openchrome config --client claude
+openchrome config --client opencode
 ```
 
 Generated configs use:
 
 ```bash
-openchrome serve --auto-launch
+openchrome serve --auto-launch --auto-elect
+```
+
+For one `(port, userDataDir)`, exactly one process remains the direct Chrome/CDP owner. Surplus sessions attach as broker clients instead of becoming unsafe second direct controllers.
+
+## Legacy single-owner explicit preset
+
+Use this only when exactly one MCP host/session will use the generated config:
+
+```bash
+openchrome config --client codex --topology single-owner
+```
+
+Generated configs use:
+
+```bash
+openchrome serve --auto-launch --no-auto-elect
 ```
 
 Do not install this same direct config in multiple clients at the same time.
@@ -79,7 +92,7 @@ openchrome config --client claude --topology dev-profile
 ## Shared-profile broker trust model
 
 Broker mode is the only supported way for more than one MCP client to share a
-single Chrome user data directory. The broker process is the sole CDP owner for
+single Chrome user data directory without auto-elect. The broker process is the sole CDP owner for
 that `(port, userDataDir)` pair; every other client must use `--connect-broker`
 so it forwards stdio JSON-RPC over the broker's HTTP endpoint instead of opening
 its own Chrome/CDP connection.
@@ -105,15 +118,16 @@ screenshot, DOM, or extracted page payloads across tenant boundaries.
 
 ```bash
 # Terminal 1: the single Chrome/CDP owner
+openchrome config --client codex --topology broker-owner --port 9222 \
+  --user-data-dir ~/.openchrome/shared-profile
 openchrome serve --broker --auto-launch --http 3100 --port 9222 \
   --user-data-dir ~/.openchrome/shared-profile
 
 # Terminal 2+: stdio MCP clients. When the broker has an auth token, share it
 # via OPENCHROME_AUTH_TOKEN (the proxy auto-discovers the broker's authTokenEnv
 # hint and uses that bearer for every forwarded JSON-RPC request).
-openchrome serve --connect-broker --port 9222 \
+openchrome config --client claude --topology broker-client --port 9222 \
   --user-data-dir ~/.openchrome/shared-profile
-
 openchrome serve --connect-broker --port 9222 \
   --user-data-dir ~/.openchrome/shared-profile
 ```

--- a/docs/mcp/topologies.md
+++ b/docs/mcp/topologies.md
@@ -154,3 +154,14 @@ multi-client shared-profile behavior.
 | A client lost connection but Chrome stayed open | Expected proxy disconnect behavior | Reconnect the stdio proxy; do not start a second direct owner. |
 | Cross-tenant resource denial | The MCP session is bound to a different tenant | Use the matching tenant credentials or an isolated profile. |
 | Memory pressure from too many tabs | Shared profile accumulates all clients' tabs | Close unused sessions/tabs or split clients across isolated profiles. |
+
+## Verification
+
+Maintainers can verify the local auto-elect topology without touching user MCP configs or the real Chrome profile:
+
+```bash
+npm run build
+npm run verify:parallel-auto-elect
+```
+
+The script uses a temp Chrome user-data-dir and temp broker registry, starts at least three stdio MCP clients against one `(port, userDataDir)`, and asserts one direct owner plus broker/proxy clients that complete `initialize` and `tools/list`.

--- a/docs/roadmap/ssot-decisions.md
+++ b/docs/roadmap/ssot-decisions.md
@@ -79,11 +79,11 @@ made sharing a deliberate act.
 
 #### Amendment — auto-elect coordinated sharing path (Q1′, 2026-06-08)
 
-**Superseded target for the `serve --auto-launch` path: OpenChrome should converge
-on coordinated auto-elect sharing instead of fail-fast surplus sessions.** The
-initial implementation is intentionally guarded by `--auto-elect` /
-`OPENCHROME_AUTO_ELECT=1`; flipping that path to the default remains a separate
-release decision after S2–S4 validation. Recorded after the parallel-session
+**Default for the direct `serve --auto-launch` path: OpenChrome uses coordinated
+auto-elect sharing instead of fail-fast surplus sessions.** Operators can still
+force the legacy direct-owner behavior with `--no-auto-elect` /
+`OPENCHROME_AUTO_ELECT=0`, or choose explicit broker roles with `--broker` /
+`--connect-broker`. Recorded after the parallel-session
 regression report ([#1474](https://github.com/shaun0927/openchrome/issues/1474))
 and root-cause tracking ([#1480](https://github.com/shaun0927/openchrome/issues/1480)).
 
@@ -98,9 +98,9 @@ names the safe end-state explicitly:
 > "Multiple sessions may share a Chrome/profile, but they must do so through **one
 > coordinated owner/broker**, not through multiple independent controllers."
 
-Auto-elect *is* that end-state. The #1480 implementation first wires it as an
-explicit opt-in (`--auto-elect`) so the behavior can be validated before any
-default flip:
+Auto-elect *is* that end-state. The #1480 rollout first wired it as an explicit
+opt-in (`--auto-elect`), then flipped the direct `serve --auto-launch` path after
+real two-client and N-client verification:
 
 - The `--auto-launch` process that **wins** the controller lock becomes the broker
   **owner** (it alone runs Chrome lifecycle, the watchdog, and CDP cleanup) and
@@ -138,14 +138,12 @@ hidden host-specific behavior** — election is host-neutral, decided purely by 
 outcome (owner / client / takeover / refusal) is surfaced over portable MCP
 surfaces, not host-coded.
 
-> **Status:** decided as the target topology; implementation in flight under #1480.
-> The controller lock, broker discovery, and stdio proxy primitives are already on
-> `develop`; the S2 owner auto-publish → S3 client auto-connect → S4 re-election
-> wiring is stacked on the #1474 reliability fixes (#1477 → #1478 → #1479). Until
-> an explicit default-flip PR lands, plain `serve --auto-launch` remains fail-fast
-> and coordinated sharing requires `--auto-elect` (or manual `--broker` /
-> `--connect-broker`). Treat this section as the normative target and rollout plan,
-> not as a claim that the default has already flipped.
+> **Status:** shipped as the default topology for direct `serve --auto-launch`.
+> The controller lock, broker discovery, stdio proxy, owner self-release,
+> default-flip, setup/config, diagnostics, and local N-client verification gates
+> have landed. `--auto-elect` remains an explicit force-enable flag,
+> `--no-auto-elect` preserves the old direct-owner fail-fast behavior, and manual
+> `--broker` / `--connect-broker` remains the explicit daemon topology.
 
 ### Local discovery mechanism (Q2)
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "bench:full:live": "ts-node tests/benchmark/run-full-benchmark.ts --mode live",
     "bench:full:recorded": "ts-node tests/benchmark/run-full-benchmark.ts --mode recorded",
     "bench:api-key-readiness": "ts-node tests/benchmark/benchmark-readiness.ts --api-key-only",
-    "lint:skill-tools": "node scripts/lint-skill-tool-refs.mjs skills/openchrome/SKILL.md"
+    "lint:skill-tools": "node scripts/lint-skill-tool-refs.mjs skills/openchrome/SKILL.md",
+    "verify:auto-elect-smoke": "node scripts/verify/auto-elect-two-client-smoke.mjs"
   },
   "keywords": [
     "openchrome",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "bench:full:recorded": "ts-node tests/benchmark/run-full-benchmark.ts --mode recorded",
     "bench:api-key-readiness": "ts-node tests/benchmark/benchmark-readiness.ts --api-key-only",
     "lint:skill-tools": "node scripts/lint-skill-tool-refs.mjs skills/openchrome/SKILL.md",
-    "verify:auto-elect-smoke": "node scripts/verify/auto-elect-two-client-smoke.mjs"
+    "verify:auto-elect-smoke": "node scripts/verify/auto-elect-two-client-smoke.mjs",
+    "verify:parallel-auto-elect": "node scripts/verify/parallel-auto-elect.mjs --clients=3"
   },
   "keywords": [
     "openchrome",

--- a/scripts/verify/auto-elect-two-client-smoke.mjs
+++ b/scripts/verify/auto-elect-two-client-smoke.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync, readFileSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import net from 'node:net';
+
+const root = resolve(new URL('../..', import.meta.url).pathname);
+const entry = join(root, 'dist', 'index.js');
+const timeoutMs = Number(process.env.OPENCHROME_AUTO_ELECT_SMOKE_TIMEOUT_MS || 30000);
+
+function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+function allocPort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      server.close((err) => err ? reject(err) : resolve(addr.port));
+    });
+  });
+}
+
+function start(name, args, env) {
+  const child = spawn(process.execPath, [entry, 'serve', ...args], {
+    cwd: root,
+    env: { ...process.env, ...env },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  child.name = name;
+  child.stderrText = '';
+  child.stdoutText = '';
+  child.stderr.on('data', (b) => { child.stderrText += b.toString(); });
+  child.stdout.on('data', (b) => { child.stdoutText += b.toString(); });
+  return child;
+}
+
+async function waitFor(label, fn, ms = timeoutMs) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    const v = await fn();
+    if (v) return v;
+    await sleep(100);
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+function readOnlyMetadata(registryDir) {
+  const files = readdirSync(registryDir).filter((name) => name.endsWith('.json'));
+  if (files.length !== 1) return null;
+  return JSON.parse(readFileSync(join(registryDir, files[0]), 'utf8'));
+}
+
+function sendRpc(child, id, method, params = {}) {
+  child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+}
+
+function jsonLines(text) {
+  return text.split('\n').filter(Boolean).flatMap((line) => {
+    try { return [JSON.parse(line)]; } catch { return []; }
+  });
+}
+
+async function terminate(children) {
+  for (const child of children) {
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
+  }
+  await sleep(500);
+  for (const child of children) {
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+  }
+}
+
+async function main() {
+  const tmp = mkdtempSync(join(tmpdir(), 'openchrome-auto-elect-'));
+  const userDataDir = join(tmp, 'profile');
+  const registryDir = join(tmp, 'brokers');
+  const cdpPort = await allocPort();
+  const httpPort = await allocPort();
+  const env = {
+    OPENCHROME_BROKER_REGISTRY_DIR: registryDir,
+    OPENCHROME_PPID_WATCH: '0',
+    OPENCHROME_HEALTH_ENDPOINT: '0',
+  };
+  const baseArgs = ['--auto-launch', '--headless', '--port', String(cdpPort), '--user-data-dir', userDataDir, '--http', String(httpPort), '--http-host', '127.0.0.1'];
+  const children = [];
+
+  try {
+    const owner = start('owner', baseArgs, env);
+    children.push(owner);
+    await waitFor('auto-elected broker metadata', () => /Broker metadata: .*\(auto-elected\)/.test(owner.stderrText));
+
+    const metadata = await waitFor('live broker metadata file', async () => {
+      try {
+        const m = readOnlyMetadata(registryDir);
+        if (!m) return null;
+        const res = await fetch(new URL('/health', m.endpoint), { signal: AbortSignal.timeout(1000) });
+        return res.ok ? m : null;
+      } catch { return null; }
+    });
+    if (metadata.pid !== owner.pid) throw new Error(`metadata pid ${metadata.pid} != owner pid ${owner.pid}`);
+
+    const client = start('client', baseArgs, env);
+    children.push(client);
+    await waitFor('surplus client broker attach', () => /auto-elect: attaching as broker client/.test(client.stderrText));
+    sendRpc(client, 1, 'initialize');
+    await waitFor('proxied initialize response', () => jsonLines(client.stdoutText).some((m) => m.id === 1 && m.result?.serverInfo?.name === 'openchrome'));
+
+    const optedOut = start('optout', [...baseArgs, '--no-auto-elect'], env);
+    children.push(optedOut);
+    await waitFor('opt-out duplicate remediation', () => /Refusing to start a second direct controller/.test(optedOut.stderrText) || /Another OpenChrome controller/.test(optedOut.stderrText));
+    if (/auto-elect: attaching as broker client/.test(optedOut.stderrText)) throw new Error('--no-auto-elect unexpectedly attached as broker client');
+
+    console.log(JSON.stringify({ ok: true, cdpPort, httpPort, ownerPid: owner.pid, brokerPid: metadata.pid, clientAttached: true, optOutPreservedFailFast: true }, null, 2));
+  } finally {
+    await terminate(children);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(err.stack || err.message || String(err));
+  process.exit(1);
+});

--- a/scripts/verify/parallel-auto-elect.mjs
+++ b/scripts/verify/parallel-auto-elect.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync, readFileSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import net from 'node:net';
+
+const root = resolve(new URL('../..', import.meta.url).pathname);
+const entry = join(root, 'dist', 'index.js');
+const timeoutMs = Number(process.env.OPENCHROME_AUTO_ELECT_SMOKE_TIMEOUT_MS || 30000);
+function parseClientCount(argv) {
+  const eq = argv.find((arg) => arg.startsWith('--clients='));
+  const spaced = argv[argv.indexOf('--clients') + 1];
+  return Math.max(3, Number(eq?.split('=')[1] || spaced || process.env.OPENCHROME_PARALLEL_CLIENTS || 3));
+}
+const clientCount = parseClientCount(process.argv.slice(2));
+
+function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+function allocPort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      server.close((err) => err ? reject(err) : resolve(addr.port));
+    });
+  });
+}
+
+function start(name, args, env) {
+  const child = spawn(process.execPath, [entry, 'serve', ...args], {
+    cwd: root,
+    env: { ...process.env, ...env },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  child.name = name;
+  child.stderrText = '';
+  child.stdoutText = '';
+  child.stderr.on('data', (b) => { child.stderrText += b.toString(); });
+  child.stdout.on('data', (b) => { child.stdoutText += b.toString(); });
+  return child;
+}
+
+async function waitFor(label, fn, ms = timeoutMs) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    const v = await fn();
+    if (v) return v;
+    await sleep(100);
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+function readOnlyMetadata(registryDir) {
+  const files = readdirSync(registryDir).filter((name) => name.endsWith('.json'));
+  if (files.length !== 1) return null;
+  return JSON.parse(readFileSync(join(registryDir, files[0]), 'utf8'));
+}
+
+function sendRpc(child, id, method, params = {}) {
+  child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+}
+
+function jsonLines(text) {
+  return text.split('\n').filter(Boolean).flatMap((line) => {
+    try { return [JSON.parse(line)]; } catch { return []; }
+  });
+}
+
+function hasValidToolList(message) {
+  const tools = message?.result?.tools;
+  if (!Array.isArray(tools) || tools.length < 5) return false;
+  const names = tools.map((tool) => typeof tool?.name === 'string' ? tool.name : '').filter(Boolean);
+  return names.length === tools.length && new Set(names).size === names.length;
+}
+
+async function verifyMcpClient(child, idBase) {
+  sendRpc(child, idBase, 'initialize');
+  const initialized = Boolean(await waitFor(`${child.name} initialize response`, () => jsonLines(child.stdoutText).some((m) => m.id === idBase && m.result?.serverInfo?.name === 'openchrome')));
+  sendRpc(child, idBase + 100, 'tools/list');
+  const listedTools = Boolean(await waitFor(`${child.name} tools/list response`, () => jsonLines(child.stdoutText).some((m) => m.id === idBase + 100 && hasValidToolList(m))));
+  return { initialized, listedTools };
+}
+
+async function terminate(children) {
+  for (const child of children) {
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
+  }
+  await sleep(500);
+  for (const child of children) {
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+  }
+}
+
+async function main() {
+  const tmp = mkdtempSync(join(tmpdir(), 'openchrome-auto-elect-'));
+  const userDataDir = join(tmp, 'profile');
+  const registryDir = join(tmp, 'brokers');
+  const cdpPort = await allocPort();
+  const httpPort = await allocPort();
+  const env = {
+    OPENCHROME_BROKER_REGISTRY_DIR: registryDir,
+    OPENCHROME_PPID_WATCH: '0',
+    OPENCHROME_HEALTH_ENDPOINT: '0',
+  };
+  const baseArgs = ['--auto-launch', '--headless', '--port', String(cdpPort), '--user-data-dir', userDataDir, '--http', String(httpPort), '--http-host', '127.0.0.1'];
+  const children = [];
+
+  try {
+    const owner = start('owner', baseArgs, env);
+    children.push(owner);
+    await waitFor('auto-elected broker metadata', () => /Broker metadata: .*\(auto-elected\)/.test(owner.stderrText));
+
+    const metadata = await waitFor('live broker metadata file', async () => {
+      try {
+        const m = readOnlyMetadata(registryDir);
+        if (!m) return null;
+        const res = await fetch(new URL('/health', m.endpoint), { signal: AbortSignal.timeout(1000) });
+        return res.ok ? m : null;
+      } catch { return null; }
+    });
+    if (metadata.pid !== owner.pid) throw new Error(`metadata pid ${metadata.pid} != owner pid ${owner.pid}`);
+
+    const clients = [owner];
+    for (let i = 1; i < clientCount; i++) {
+      const client = start(`client-${i}`, baseArgs, env);
+      children.push(client);
+      clients.push(client);
+    }
+    const mcpChecks = [];
+    for (const [index, client] of clients.entries()) {
+      if (client !== owner) await waitFor(`${client.name} broker attach`, () => /auto-elect: attaching as broker client/.test(client.stderrText));
+      mcpChecks.push(await verifyMcpClient(client, index + 1));
+    }
+
+    const optedOut = start('optout', [...baseArgs, '--no-auto-elect'], env);
+    children.push(optedOut);
+    await waitFor('opt-out duplicate remediation', () => /Refusing to start a second direct controller/.test(optedOut.stderrText) || /Another OpenChrome controller/.test(optedOut.stderrText));
+    if (/auto-elect: attaching as broker client/.test(optedOut.stderrText)) throw new Error('--no-auto-elect unexpectedly attached as broker client');
+
+    const allClientsInitialized = mcpChecks.every((check) => check.initialized);
+    const allClientsListedTools = mcpChecks.every((check) => check.listedTools);
+    console.log(JSON.stringify({ ok: true, clients: clientCount, cdpPort, httpPort, directOwners: 1, ownerPid: owner.pid, brokerPid: metadata.pid, brokerClients: clients.length - 1, allClientsInitialized, allClientsListedTools, optOutPreservedFailFast: true }, null, 2));
+  } finally {
+    await terminate(children);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(err.stack || err.message || String(err));
+  process.exit(1);
+});

--- a/src/broker/auto-elect.ts
+++ b/src/broker/auto-elect.ts
@@ -9,29 +9,43 @@
  *   - a process that LOSES to a healthy owner becomes a coordinated CLIENT
  *     (`--connect-broker` proxy) instead of failing fast.
  *
- * The behavior is gated behind an explicit opt-in (`--auto-elect` /
- * `OPENCHROME_AUTO_ELECT=1`). With the flag unset, the default path is byte-for-
- * byte unchanged (fail-fast single owner), so this module's wiring has zero blast
- * radius until an operator opts in. See docs/roadmap/ssot-decisions.md (D3 Q1′)
- * for the policy and the eventual default-flip plan.
- *
- * Keeping the decisions here (rather than inline in src/index.ts) makes the
- * election rules unit-testable without booting a server or Chrome.
+ * The default applies only to the direct `serve --auto-launch` path. Operators
+ * can still opt out (`--no-auto-elect` / `OPENCHROME_AUTO_ELECT=0`) or choose an
+ * explicit role (`--broker` / `--connect-broker`), and the unsafe shared attach
+ * escape hatch remains separate. Keeping the decisions here (rather than inline
+ * in src/index.ts) makes the election rules unit-testable without booting a
+ * server or Chrome.
  */
 
 /** Offset from the CDP port used for the elected owner's broker HTTP endpoint. */
 export const BROKER_HTTP_PORT_OFFSET = 200;
 
+export interface AutoElectDecisionContext {
+  /** Commander value for --auto-elect / --no-auto-elect. false is explicit opt-out. */
+  autoElect?: boolean;
+  /** This process owns Chrome lifecycle and participates in controller-lock election. */
+  autoLaunch?: boolean;
+  /** Explicit broker owner role. Explicit roles take precedence over auto-elect. */
+  broker?: boolean;
+  /** Explicit broker client role. Explicit roles take precedence over auto-elect. */
+  connectBroker?: boolean;
+}
+
 /**
- * Is auto-elect enabled for this process?
+ * Is coordinated auto-elect enabled for this process?
  *
- * True when the operator passed `--auto-elect` or set `OPENCHROME_AUTO_ELECT=1`.
+ * Default true only for the direct `serve --auto-launch` path. Explicit opt-outs
+ * win (`--no-auto-elect`, `OPENCHROME_AUTO_ELECT=0`), and explicit broker/client
+ * roles are not auto-election decisions.
  */
 export function isAutoElectEnabled(
-  opts: { autoElect?: boolean },
+  opts: AutoElectDecisionContext,
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  return Boolean(opts.autoElect) || env.OPENCHROME_AUTO_ELECT === '1';
+  if (env.OPENCHROME_AUTO_ELECT === '0' || opts.autoElect === false) return false;
+  if (opts.broker || opts.connectBroker) return false;
+  if (opts.autoElect === true || env.OPENCHROME_AUTO_ELECT === '1') return true;
+  return opts.autoLaunch === true;
 }
 
 /**

--- a/src/cli/doctor/runtime-diagnostics.ts
+++ b/src/cli/doctor/runtime-diagnostics.ts
@@ -12,6 +12,7 @@ export type ActiveRuntimePath =
   | 'isolated-profile'
   | 'attach-mode'
   | 'unsafe-secondary-attach'
+  | 'stale-broker-metadata'
   | 'blocked-by-owner'
   | 'unknown';
 
@@ -32,6 +33,7 @@ export interface RuntimeDiagnostics {
     autoElectEnabled: boolean;
     unsafeSharedAttachEnabled: boolean;
     launchMode?: string;
+    ownerCommand?: string[];
   };
 }
 
@@ -70,11 +72,14 @@ export function classifyRuntimePath(params: {
     return 'unsafe-secondary-attach';
   }
   if (params.launchMode === 'attach') return 'attach-mode';
-  if (params.brokerPid && params.brokerPidAlive) {
-    if (params.autoElectEnabled) {
-      return params.ownerPid === params.brokerPid ? 'auto-elect-owner' : 'auto-elect-client';
+  if (params.brokerPid) {
+    if (params.brokerPidAlive === false) return 'stale-broker-metadata';
+    if (params.brokerPidAlive) {
+      if (params.autoElectEnabled) {
+        return params.ownerPid === params.brokerPid ? 'auto-elect-owner' : 'auto-elect-client';
+      }
+      return params.ownerPid === params.brokerPid ? 'broker-owner' : 'broker-client';
     }
-    return params.ownerPid === params.brokerPid ? 'broker-owner' : 'broker-client';
   }
   if (params.controllerRole === 'owner') return 'direct-owner';
   if (params.controllerRole === 'unknown' && params.ownerPid) return 'blocked-by-owner';
@@ -82,11 +87,18 @@ export function classifyRuntimePath(params: {
   return 'unknown';
 }
 
+function commandEnablesAutoElect(command?: string[]): boolean {
+  if (!command) return false;
+  if (command.includes('--no-auto-elect')) return false;
+  if (command.includes('--auto-elect')) return true;
+  return command.includes('serve') && command.includes('--auto-launch') && !command.includes('--server-mode');
+}
+
 export function collectDoctorDiagnostics(): DoctorDiagnostics {
   const topology = getCurrentControllerTopology();
   const broker = readBrokerMetadata(topology.port, topology.userDataDir);
   const brokerPidAlive = broker?.pid !== undefined ? isPidAlive(broker.pid) : undefined;
-  const autoElectEnabled = process.env.OPENCHROME_AUTO_ELECT === '1';
+  const autoElectEnabled = process.env.OPENCHROME_AUTO_ELECT === '1' || (process.env.OPENCHROME_AUTO_ELECT !== '0' && commandEnablesAutoElect(topology.ownerCommand));
   const unsafeSharedAttachEnabled = process.env.OPENCHROME_ALLOW_UNSAFE_SHARED_ATTACH === '1';
   const launchMode = process.env.OPENCHROME_LAUNCH_MODE;
 
@@ -116,6 +128,7 @@ export function collectDoctorDiagnostics(): DoctorDiagnostics {
         autoElectEnabled,
         unsafeSharedAttachEnabled,
         ...(launchMode ? { launchMode } : {}),
+        ...(topology.ownerCommand ? { ownerCommand: topology.ownerCommand } : {}),
       },
     },
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,8 @@ program
   .option('--transport <mode>', 'Transport mode: stdio, http, or both (default: stdio)')
   .option('--broker', 'Run as the shared-profile broker owner (HTTP daemon plus broker discovery metadata)')
   .option('--connect-broker', 'Proxy stdio MCP requests to the discovered broker instead of attaching to Chrome directly')
-  .option('--auto-elect', 'Coordinated sharing (#1480): the --auto-launch process that wins the controller lock becomes the broker owner and surplus sessions auto-attach as clients instead of failing fast. Also: OPENCHROME_AUTO_ELECT=1. Off by default.')
+  .option('--auto-elect', 'Coordinated sharing (#1480): force-enable auto-election for compatible serve paths (also: OPENCHROME_AUTO_ELECT=1).')
+  .option('--no-auto-elect', 'Disable coordinated auto-election and preserve fail-fast duplicate-controller behavior (also: OPENCHROME_AUTO_ELECT=0).')
   .option('--idle-timeout <duration>', 'Self-exit (code 0) after idle window with zero sessions. Format: <number>(ms|s|m|h), e.g. 30m, 90s, 500ms. Bare numbers are rejected. Also: OPENCHROME_IDLE_TIMEOUT_MS env var (integer ms). Default: disabled.')
   .option('--pilot', 'Enable experimental pilot tier (see docs/roadmap/portability-harness-contract.md). Off by default; lazy-loads src/pilot/ modules when set. Also: OPENCHROME_PILOT=1 env var.')
   .option('--slim', 'Expose only core tools (alias for --tools-only core).')
@@ -270,12 +271,15 @@ program
       process.exit(2);
     }
 
-    // #1480 auto-elect (D3 Q1′): the --auto-launch lock winner elects itself the
-    // broker owner so surplus sessions attach as coordinated clients instead of
-    // failing fast. Opt-in (off by default) — when disabled, every branch below
-    // is byte-for-byte the prior fail-fast behavior. Explicit --broker/
-    // --connect-broker always take precedence over auto-elect.
-    const autoElect = isAutoElectEnabled(options);
+    // #1480 auto-elect (D3 Q1′): PR A defines the default decision helper and
+    // opt-out flags, but keeps the live serve path on the previously validated
+    // explicit opt-in until PR B adds the real two-client smoke. Intentionally
+    // omit autoLaunch from this call; PR B is the scoped runtime default flip.
+    const autoElect = isAutoElectEnabled({
+      autoElect: options.autoElect,
+      broker: options.broker,
+      connectBroker: options.connectBroker,
+    });
     const electBrokerOwner = shouldElectBrokerOwner({
       autoElect,
       autoLaunch,

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,12 +271,14 @@ program
       process.exit(2);
     }
 
-    // #1480 auto-elect (D3 Q1′): PR A defines the default decision helper and
-    // opt-out flags, but keeps the live serve path on the previously validated
-    // explicit opt-in until PR B adds the real two-client smoke. Intentionally
-    // omit autoLaunch from this call; PR B is the scoped runtime default flip.
+    // #1480 auto-elect (D3 Q1′): direct `serve --auto-launch` defaults to
+    // coordinated broker election; explicit broker/client roles and opt-outs
+    // still take precedence inside the decision helper.
     const autoElect = isAutoElectEnabled({
       autoElect: options.autoElect,
+      // Keep the default flip scoped to direct `serve --auto-launch`; server-mode
+      // can still opt in with --auto-elect / OPENCHROME_AUTO_ELECT=1.
+      autoLaunch: options.autoLaunch === true,
       broker: options.broker,
       connectBroker: options.connectBroker,
     });

--- a/src/utils/duplicate-controller-diagnostics.ts
+++ b/src/utils/duplicate-controller-diagnostics.ts
@@ -12,7 +12,9 @@ export interface OpenChromeProcessInfo {
   port: number;
   userDataDir: string;
   source: 'global' | 'npx' | 'local' | 'unknown';
+  role: 'direct-controller' | 'broker-client';
 }
+
 
 export interface DuplicateControllerGroup {
   port: number;
@@ -81,6 +83,7 @@ export function inferOpenChromeProcess(pid: number, command: string, ppid?: numb
     port: Number.isFinite(port) ? port : DEFAULT_PORT,
     userDataDir: userDataDir === DEFAULT_PROFILE ? DEFAULT_PROFILE : normalizeControllerUserDataDir(userDataDir),
     source,
+    role: tokens.includes('--connect-broker') ? 'broker-client' : 'direct-controller',
   };
 }
 
@@ -106,10 +109,26 @@ export function scanOpenChromeProcesses(): OpenChromeProcessInfo[] {
   }
 }
 
+function controllerKey(proc: OpenChromeProcessInfo): string {
+  return `${proc.port}\u0000${proc.userDataDir}`;
+}
+
+function isWrapperProcess(proc: OpenChromeProcessInfo): boolean {
+  return /npm exec|npx|_npx|openchrome-mcp@/.test(proc.command);
+}
+
+export function normalizeControllerProcesses(processes: OpenChromeProcessInfo[]): OpenChromeProcessInfo[] {
+  return processes.filter((proc) => {
+    if (proc.role === 'broker-client') return false;
+    if (!isWrapperProcess(proc)) return true;
+    return !processes.some((child) => child.ppid === proc.pid && child.role === 'direct-controller' && controllerKey(child) === controllerKey(proc));
+  });
+}
+
 export function findDuplicateControllerGroups(processes: OpenChromeProcessInfo[]): DuplicateControllerGroup[] {
   const groups = new Map<string, OpenChromeProcessInfo[]>();
-  for (const proc of processes) {
-    const key = `${proc.port}\u0000${proc.userDataDir}`;
+  for (const proc of normalizeControllerProcesses(processes)) {
+    const key = controllerKey(proc);
     groups.set(key, [...(groups.get(key) ?? []), proc]);
   }
   return Array.from(groups.values())
@@ -206,6 +225,7 @@ export function getCurrentControllerTopology(options: { port?: number; userDataD
   userDataDir: string;
   lockPath: string;
   ownerPid?: number;
+  ownerCommand?: string[];
   remediation?: string;
 } {
   const port = options.port ?? parseInt(process.env.CHROME_PORT ?? String(DEFAULT_PORT), 10);
@@ -224,7 +244,7 @@ export function getCurrentControllerTopology(options: { port?: number; userDataD
     const raw = fs.readFileSync(lockPath, 'utf8');
     const parsed = JSON.parse(raw) as { pid?: number };
     if (typeof parsed.pid === 'number' && isPidAlive(parsed.pid)) {
-      return { role: parsed.pid === process.pid ? 'owner' : 'unknown', port, userDataDir, lockPath, ownerPid: parsed.pid };
+      return { role: parsed.pid === process.pid ? 'owner' : 'unknown', port, userDataDir, lockPath, ownerPid: parsed.pid, ownerCommand: Array.isArray((parsed as { command?: unknown }).command) ? (parsed as { command: string[] }).command : undefined };
     }
     return { role: 'unlocked', port, userDataDir, lockPath };
   } catch {

--- a/tests/auto-elect.test.ts
+++ b/tests/auto-elect.test.ts
@@ -15,21 +15,46 @@ import {
 } from '../src/broker/auto-elect';
 
 describe('isAutoElectEnabled', () => {
-  test('false by default (no flag, no env)', () => {
-    expect(isAutoElectEnabled({}, {})).toBe(false);
+  test('true by default for direct serve --auto-launch path', () => {
+    expect(isAutoElectEnabled({ autoLaunch: true }, {})).toBe(true);
   });
 
-  test('true when --auto-elect flag set', () => {
+  test('false by default when process is not an auto-launch controller', () => {
+    expect(isAutoElectEnabled({}, {})).toBe(false);
+    expect(isAutoElectEnabled({ autoLaunch: false }, {})).toBe(false);
+  });
+
+  test('caller can defer the runtime default by omitting autoLaunch context', () => {
+    expect(isAutoElectEnabled({ autoElect: undefined, broker: false, connectBroker: false }, {})).toBe(false);
+  });
+
+  test('explicit --auto-elect still enables compatible paths', () => {
     expect(isAutoElectEnabled({ autoElect: true }, {})).toBe(true);
   });
 
-  test('true when OPENCHROME_AUTO_ELECT=1', () => {
+  test('--no-auto-elect hard-disables the default', () => {
+    expect(isAutoElectEnabled({ autoLaunch: true, autoElect: false }, {})).toBe(false);
+  });
+
+  test('OPENCHROME_AUTO_ELECT=0 hard-disables the default', () => {
+    expect(isAutoElectEnabled({ autoLaunch: true }, { OPENCHROME_AUTO_ELECT: '0' })).toBe(false);
+    expect(isAutoElectEnabled({ autoLaunch: true, autoElect: true }, { OPENCHROME_AUTO_ELECT: '0' })).toBe(false);
+  });
+
+  test('OPENCHROME_AUTO_ELECT=1 explicitly enables compatible paths', () => {
     expect(isAutoElectEnabled({}, { OPENCHROME_AUTO_ELECT: '1' })).toBe(true);
   });
 
-  test('env values other than "1" do not enable', () => {
-    expect(isAutoElectEnabled({}, { OPENCHROME_AUTO_ELECT: 'true' })).toBe(false);
-    expect(isAutoElectEnabled({}, { OPENCHROME_AUTO_ELECT: '0' })).toBe(false);
+  test('env values other than "0" do not accidentally disable the default', () => {
+    expect(isAutoElectEnabled({ autoLaunch: true }, { OPENCHROME_AUTO_ELECT: 'true' })).toBe(true);
+    expect(isAutoElectEnabled({ autoLaunch: true }, { OPENCHROME_AUTO_ELECT: '' })).toBe(true);
+  });
+
+  test('explicit broker roles take precedence over auto-elect', () => {
+    expect(isAutoElectEnabled({ autoLaunch: true, broker: true }, {})).toBe(false);
+    expect(isAutoElectEnabled({ autoLaunch: true, connectBroker: true }, {})).toBe(false);
+    expect(isAutoElectEnabled({ autoElect: true, broker: true }, {})).toBe(false);
+    expect(isAutoElectEnabled({ autoElect: true, connectBroker: true }, {})).toBe(false);
   });
 });
 

--- a/tests/cli/doctor/runtime-diagnostics.test.ts
+++ b/tests/cli/doctor/runtime-diagnostics.test.ts
@@ -1,7 +1,28 @@
 import * as os from 'os';
-import { classifyRuntimePath, displayPath } from '../../../src/cli/doctor/runtime-diagnostics';
+
+jest.mock('../../../src/utils/duplicate-controller-diagnostics', () => ({
+  getCurrentControllerTopology: jest.fn(),
+}));
+jest.mock('../../../src/broker/discovery', () => ({
+  readBrokerMetadata: jest.fn(),
+}));
+jest.mock('../../../src/utils/controller-lock', () => ({
+  isPidAlive: jest.fn(),
+}));
+
+const { getCurrentControllerTopology } = jest.requireMock('../../../src/utils/duplicate-controller-diagnostics') as { getCurrentControllerTopology: jest.Mock };
+const { readBrokerMetadata } = jest.requireMock('../../../src/broker/discovery') as { readBrokerMetadata: jest.Mock };
+const { isPidAlive } = jest.requireMock('../../../src/utils/controller-lock') as { isPidAlive: jest.Mock };
+import { classifyRuntimePath, collectDoctorDiagnostics, displayPath } from '../../../src/cli/doctor/runtime-diagnostics';
 
 describe('doctor runtime diagnostics', () => {
+  const oldAutoElect = process.env.OPENCHROME_AUTO_ELECT;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    if (oldAutoElect === undefined) delete process.env.OPENCHROME_AUTO_ELECT;
+    else process.env.OPENCHROME_AUTO_ELECT = oldAutoElect;
+  });
   test('classifies unsafe shared attach first', () => {
     expect(classifyRuntimePath({ controllerRole: 'unlocked', unsafeSharedAttachEnabled: true })).toBe('unsafe-secondary-attach');
   });
@@ -20,11 +41,50 @@ describe('doctor runtime diagnostics', () => {
     expect(classifyRuntimePath({ controllerRole: 'unknown', ownerPid: 10, brokerPid: 20, brokerPidAlive: true, autoElectEnabled: true })).toBe('auto-elect-client');
   });
 
+  test('classifies stale broker metadata', () => {
+    expect(classifyRuntimePath({ controllerRole: 'owner', ownerPid: 10, brokerPid: 99, brokerPidAlive: false })).toBe('stale-broker-metadata');
+  });
+
   test('classifies direct owner, blocked owner, isolated profile, and unknown', () => {
     expect(classifyRuntimePath({ controllerRole: 'owner', ownerPid: 10 })).toBe('direct-owner');
     expect(classifyRuntimePath({ controllerRole: 'unknown', ownerPid: 10 })).toBe('blocked-by-owner');
     expect(classifyRuntimePath({ controllerRole: 'unlocked', launchMode: 'isolated' })).toBe('isolated-profile');
     expect(classifyRuntimePath({ controllerRole: 'unlocked' })).toBe('unknown');
+  });
+
+  test('collects auto-elect topology from owner command metadata', () => {
+    delete process.env.OPENCHROME_AUTO_ELECT;
+    getCurrentControllerTopology.mockReturnValue({
+      role: 'owner',
+      port: 9222,
+      userDataDir: '/tmp/profile',
+      lockPath: '/tmp/lock.json',
+      ownerPid: 10,
+      ownerCommand: ['openchrome', 'serve', '--auto-launch'],
+    });
+    readBrokerMetadata.mockReturnValue({ pid: 10, endpoint: 'http://127.0.0.1:9422/mcp' });
+    isPidAlive.mockReturnValue(true);
+
+    const diagnostics = collectDoctorDiagnostics();
+
+    expect(diagnostics.runtime.runtime_topology).toBe('auto-elect-owner');
+    expect(diagnostics.runtime.facts.autoElectEnabled).toBe(true);
+  });
+
+  test('owner command --no-auto-elect overrides default auto-elect diagnostics', () => {
+    delete process.env.OPENCHROME_AUTO_ELECT;
+    getCurrentControllerTopology.mockReturnValue({
+      role: 'owner',
+      port: 9222,
+      userDataDir: '/tmp/profile',
+      lockPath: '/tmp/lock.json',
+      ownerPid: 10,
+      ownerCommand: ['openchrome', 'serve', '--auto-launch', '--no-auto-elect'],
+    });
+    readBrokerMetadata.mockReturnValue({ pid: 10, endpoint: 'http://127.0.0.1:9422/mcp' });
+    isPidAlive.mockReturnValue(true);
+
+    expect(collectDoctorDiagnostics().runtime.runtime_topology).toBe('broker-owner');
   });
 
   test('redacts home-relative paths for display facts', () => {

--- a/tests/cli/mcp-client-config.test.ts
+++ b/tests/cli/mcp-client-config.test.ts
@@ -15,11 +15,11 @@ import {
 
 describe('cli/mcp-client-config', () => {
   test('getServeArgs enables auto-launch by default', () => {
-    expect(getServeArgs()).toEqual(['serve', '--auto-launch']);
+    expect(getServeArgs()).toEqual(['serve', '--auto-launch', '--auto-elect']);
   });
 
   test('getServeArgs includes dashboard when requested', () => {
-    expect(getServeArgs({ dashboard: true })).toEqual(['serve', '--auto-launch', '--dashboard']);
+    expect(getServeArgs({ dashboard: true })).toEqual(['serve', '--auto-launch', '--auto-elect', '--dashboard']);
   });
 
   test('getServeArgs preserves explicit port and profile topology', () => {
@@ -31,6 +31,7 @@ describe('cli/mcp-client-config', () => {
     })).toEqual([
       'serve',
       '--auto-launch',
+      '--auto-elect',
       '--port',
       '9333',
       '--user-data-dir',
@@ -39,6 +40,19 @@ describe('cli/mcp-client-config', () => {
       'Default',
       '--launch-mode',
       'isolated',
+    ]);
+  });
+
+  test('single-owner topology preset preserves the legacy direct owner explicitly', () => {
+    expect(getServeArgs({ topology: 'single-owner' })).toEqual(['serve', '--auto-launch', '--no-auto-elect']);
+  });
+
+  test('broker topology presets generate owner and client roles', () => {
+    expect(getServeArgs({ topology: 'broker-owner', port: 9222, userDataDir: '/tmp/shared' })).toEqual([
+      'serve', '--auto-launch', '--broker', '--port', '9222', '--user-data-dir', '/tmp/shared',
+    ]);
+    expect(getServeArgs({ topology: 'broker-client', port: 9222, userDataDir: '/tmp/shared' })).toEqual([
+      'serve', '--connect-broker', '--port', '9222', '--user-data-dir', '/tmp/shared',
     ]);
   });
 
@@ -62,7 +76,7 @@ describe('cli/mcp-client-config', () => {
   test('getCodexServerConfig uses the installed openchrome binary', () => {
     expect(getCodexServerConfig()).toEqual({
       command: 'openchrome',
-      args: ['serve', '--auto-launch'],
+      args: ['serve', '--auto-launch', '--auto-elect'],
     });
   });
 
@@ -77,6 +91,7 @@ describe('cli/mcp-client-config', () => {
       'openchrome',
       'serve',
       '--auto-launch',
+      '--auto-elect',
       '--dashboard',
     ]);
     expect(command).not.toContain('remove');
@@ -85,7 +100,7 @@ describe('cli/mcp-client-config', () => {
   test('getClaudeManualServerConfig uses the installed openchrome binary', () => {
     expect(getClaudeManualServerConfig()).toEqual({
       command: 'openchrome',
-      args: ['serve', '--auto-launch'],
+      args: ['serve', '--auto-launch', '--auto-elect'],
     });
   });
 
@@ -100,6 +115,7 @@ describe('cli/mcp-client-config', () => {
       'openchrome',
       'serve',
       '--auto-launch',
+      '--auto-elect',
       '--dashboard',
     ]);
   });
@@ -126,7 +142,7 @@ describe('cli/mcp-client-config', () => {
         },
         openchrome: {
           command: 'openchrome',
-          args: ['serve', '--auto-launch'],
+          args: ['serve', '--auto-launch', '--auto-elect'],
         },
       },
     });
@@ -137,7 +153,7 @@ describe('cli/mcp-client-config', () => {
       mcpServers: {
         openchrome: {
           command: 'openchrome',
-          args: ['serve', '--auto-launch'],
+          args: ['serve', '--auto-launch', '--auto-elect'],
         },
       },
     });
@@ -148,7 +164,7 @@ describe('cli/mcp-client-config', () => {
       [
         '[mcp_servers.openchrome]',
         'command = "openchrome"',
-        'args = ["serve", "--auto-launch"]',
+        'args = ["serve", "--auto-launch", "--auto-elect"]',
       ].join('\n')
     );
   });
@@ -157,7 +173,7 @@ describe('cli/mcp-client-config', () => {
     const options = { port: 9333, userDataDir: '/tmp/openchrome-codex' };
 
     expect(formatCodexMCPServerConfigSnippet('openchrome', getCodexServerConfig(options))).toContain(
-      'args = ["serve", "--auto-launch", "--port", "9333", "--user-data-dir", "/tmp/openchrome-codex"]'
+      'args = ["serve", "--auto-launch", "--auto-elect", "--port", "9333", "--user-data-dir", "/tmp/openchrome-codex"]'
     );
     expect(getClaudeSetupCommand('user', options)).toEqual([
       'mcp',
@@ -169,6 +185,7 @@ describe('cli/mcp-client-config', () => {
       'openchrome',
       'serve',
       '--auto-launch',
+      '--auto-elect',
       '--port',
       '9333',
       '--user-data-dir',
@@ -183,6 +200,7 @@ describe('cli/mcp-client-config', () => {
         'openchrome',
         'serve',
         '--auto-launch',
+        '--auto-elect',
         '--port',
         '9444',
         '--user-data-dir',
@@ -191,10 +209,10 @@ describe('cli/mcp-client-config', () => {
     });
   });
 
-  test('default topology warning is omitted once port/profile is explicit', () => {
-    expect(getTopologyWarning()).toContain('default single-owner');
-    expect(getTopologyWarning()).toContain(HOST_CONFIG_MIGRATION_NOTE);
-    expect(getTopologyWarning({ port: 9333, userDataDir: '/tmp/openchrome-codex' })).toBeNull();
+  test('single-owner topology warning calls out legacy direct-owner risk', () => {
+    expect(getTopologyWarning()).toBeNull();
+    expect(getTopologyWarning({ topology: 'single-owner' })).toContain('legacy direct-owner');
+    expect(getTopologyWarning({ topology: 'single-owner' })).toContain(HOST_CONFIG_MIGRATION_NOTE);
   });
 
   test('generated configs do not use transient package runners', () => {

--- a/tests/duplicate-controller-diagnostics.test.ts
+++ b/tests/duplicate-controller-diagnostics.test.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   findDuplicateControllerGroups,
+  normalizeControllerProcesses,
   getCurrentControllerTopology,
   inferOpenChromeProcess,
   parsePsOutput,
@@ -40,17 +41,38 @@ describe('duplicate controller diagnostics', () => {
     expect(globalProc?.userDataDir).toBe(path.resolve('/tmp/shared'));
   });
 
-  test('groups duplicate processes by port and profile', () => {
+  test('groups only independent direct controllers by port and profile', () => {
     const processes = parsePsOutput([
       '100 1 openchrome serve --port 9222 --user-data-dir /tmp/shared',
       '101 1 npm exec openchrome-mcp@latest -- openchrome serve --port 9222 --user-data-dir /tmp/shared',
-      '102 1 openchrome serve --port 9223 --user-data-dir /tmp/shared',
+      '102 1 openchrome serve --connect-broker --port 9222 --user-data-dir /tmp/shared',
+      '103 1 openchrome serve --port 9223 --user-data-dir /tmp/shared',
     ].join('\n'));
 
     const groups = findDuplicateControllerGroups(processes);
 
     expect(groups).toHaveLength(1);
     expect(groups[0].processes.map((proc) => proc.pid)).toEqual([100, 101]);
+  });
+
+  test('collapses wrapper parent and child for the same direct controller', () => {
+    const processes = parsePsOutput([
+      '200 1 npm exec openchrome-mcp@latest -- openchrome serve --port 9222 --user-data-dir /tmp/shared',
+      '201 200 node /tmp/_npx/openchrome-mcp/dist/index.js serve --port 9222 --user-data-dir /tmp/shared',
+      '202 1 openchrome serve --connect-broker --port 9222 --user-data-dir /tmp/shared',
+    ].join('\n'));
+
+    expect(normalizeControllerProcesses(processes).map((proc) => proc.pid)).toEqual([201]);
+    expect(findDuplicateControllerGroups(processes)).toEqual([]);
+  });
+
+  test('does not collapse a non-wrapper direct parent and child', () => {
+    const processes = parsePsOutput([
+      '300 1 openchrome serve --port 9222 --user-data-dir /tmp/shared',
+      '301 300 node custom-direct-controller.js openchrome serve --port 9222 --user-data-dir /tmp/shared',
+    ].join('\n'));
+
+    expect(findDuplicateControllerGroups(processes)[0].processes.map((proc) => proc.pid)).toEqual([300, 301]);
   });
 
   test('detects stale Codex mcp.json and mixed registrations', () => {


### PR DESCRIPTION
Promotes the merged OpenChrome parallel-session stability plan from develop to main.

Scope:
- Auto-elect direct serve clients into one owner + broker clients.
- Broker liveness/stale cleanup, half-zombie owner release, setup topology presets, diagnostics normalization, and real parallel verification harness.

Verification already run on origin/develop:
- npm run build
- npm test -- --runInBand
- npm run verify:auto-elect-smoke
- npm run verify:parallel-auto-elect
- node dist/cli/index.js check --help
- node dist/cli/index.js doctor --help

Non-goals:
- No unsafe multi-controller sharing.
- No user real Chrome profile or MCP config mutation in harnesses.