### PR TITLE
Enable progressive tool disclosure for OpenCode

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -304,6 +304,7 @@ const PROGRESSIVE_DISCLOSURE_CLIENTS = new Set([
   'cline',
   'zed',
   'continue',
+  'opencode',
 ]);
 
 const RECONNECTION_GUIDANCE =
@@ -1320,8 +1321,11 @@ export class MCPServer {
 
     // Detect client identity for progressive disclosure decisions
     const clientInfo = params?.clientInfo as { name?: string; version?: string } | undefined;
+    const clientCapabilities = params?.capabilities as { tools?: { listChanged?: boolean }; notifications?: { tools?: { listChanged?: boolean } } } | undefined;
     const rawName = clientInfo?.name ?? '';
     const nameLower = rawName.toLowerCase();
+    const supportsToolListChanged = clientCapabilities?.tools?.listChanged === true
+      || clientCapabilities?.notifications?.tools?.listChanged === true;
 
     // Idempotency: only detect client on first initialize (reconnects preserve state)
     if (!this.clientDetected) {
@@ -1334,14 +1338,15 @@ export class MCPServer {
           nameLower.includes(known)
         );
 
-        if (!isKnownClient) {
+        if (!isKnownClient && !supportsToolListChanged) {
           // Unknown or absent client: expose all tools immediately (no progressive disclosure)
           this.exposedTier = 3;
           this.clientSupportsListChanged = false;
           console.error(`[openchrome] Client "${rawName || '(no clientInfo)'}" — progressive disclosure disabled, exposing all tools`);
         } else {
-          // Known client: keep progressive disclosure enabled
-          console.error(`[openchrome] Client "${rawName}" supports tool list changes — progressive disclosure enabled`);
+          // Known/capable client: keep progressive disclosure enabled.
+          const source = supportsToolListChanged && !isKnownClient ? 'capability' : 'known-client';
+          console.error(`[openchrome] Client "${rawName || '(no clientInfo)'}" supports tool list changes (${source}) — progressive disclosure enabled`);
         }
       }
     }

--- a/tests/mcp-progressive-disclosure.test.ts
+++ b/tests/mcp-progressive-disclosure.test.ts
@@ -1,0 +1,84 @@
+/// <reference types="jest" />
+
+import { createMockSessionManager } from './utils/mock-session';
+
+jest.mock('../src/cdp/client', () => ({
+  getCDPClient: jest.fn(() => ({
+    forceReconnect: jest.fn().mockResolvedValue(undefined),
+    isConnected: jest.fn().mockReturnValue(false),
+  })),
+}));
+
+jest.mock('../src/session-manager', () => ({
+  getSessionManager: jest.fn(),
+}));
+
+import { getSessionManager } from '../src/session-manager';
+import { MCPServer } from '../src/mcp-server';
+import { registerAllTools } from '../src/tools';
+
+interface TestResponse {
+  result?: {
+    capabilities?: { tools?: { listChanged?: boolean } };
+    tools?: Array<{ name: string }>;
+  };
+}
+
+function makeServer(): MCPServer {
+  const mockSM = createMockSessionManager();
+  (getSessionManager as jest.Mock).mockReturnValue(mockSM);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const server = new MCPServer(mockSM as any);
+  registerAllTools(server);
+  return server;
+}
+
+async function initializeAndList(server: MCPServer, clientName: string, capabilities: Record<string, unknown> = {}): Promise<{ init: TestResponse; tools: string[] }> {
+  const init = await server.handleRequest({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities,
+      clientInfo: { name: clientName, version: '0.0.0' },
+    },
+  }) as TestResponse;
+
+  const listed = await server.handleRequest({
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/list',
+    params: {},
+  }) as TestResponse;
+
+  return { init, tools: (listed.result?.tools ?? []).map(t => t.name) };
+}
+
+describe('MCP progressive disclosure client detection', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  test('OpenCode gets progressive disclosure instead of all tools', async () => {
+    const { init, tools } = await initializeAndList(makeServer(), 'opencode');
+
+    expect(init.result?.capabilities?.tools?.listChanged).toBe(true);
+    expect(tools).toContain('expand_tools');
+    expect(tools.length).toBeLessThan(118);
+  });
+
+  test('capability-aware unknown clients get progressive disclosure', async () => {
+    const { init, tools } = await initializeAndList(makeServer(), 'unknown-editor', { tools: { listChanged: true } });
+
+    expect(init.result?.capabilities?.tools?.listChanged).toBe(true);
+    expect(tools).toContain('expand_tools');
+    expect(tools.length).toBeLessThan(118);
+  });
+
+  test('unknown clients without list_changed support keep legacy all-tools behavior', async () => {
+    const { init, tools } = await initializeAndList(makeServer(), 'unknown-editor');
+
+    expect(init.result?.capabilities?.tools?.listChanged).toBe(false);
+    expect(tools).not.toContain('expand_tools');
+    expect(tools.length).toBeGreaterThanOrEqual(118);
+  });
+});


### PR DESCRIPTION
Closes part of #1524.\n\n## Scope\n- Treat OpenCode as a progressive-disclosure client.\n- Also enable progressive disclosure for clients that explicitly advertise tool-list-change support.\n- Preserve legacy all-tools behavior for unknown clients without that support.\n\n## Verification\n- npm test -- --runTestsByPath tests/mcp-progressive-disclosure.test.ts\n- npm run build\n- npm run lint:changed\n- git diff --check\n\n## Non-goals\n- Does not retier the default tool surface.\n- Does not add --minimal.\n- Does not change tool schemas or remove tools.