### PR TITLE
Prefer minimal MCP startup configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ and add the printed `[mcp_servers.openchrome]` block to `~/.codex/config.toml`.
   "mcpServers": {
     "openchrome": {
       "command": "openchrome",
-      "args": ["serve", "--auto-launch", "--auto-elect"]
+      "args": ["serve", "--auto-launch", "--auto-elect", "--minimal"]
     }
   }
 }

--- a/cli/mcp-client-config.ts
+++ b/cli/mcp-client-config.ts
@@ -16,6 +16,7 @@ export interface ServeArgOptions {
   autoElect?: boolean;
   broker?: boolean;
   connectBroker?: boolean;
+  minimal?: boolean;
 }
 
 export interface MCPServerConfig {
@@ -69,6 +70,7 @@ export function getServeArgs(options: ServeArgOptions = {}): string[] {
   }
 
   if (resolved.autoElect === true) serveArgs.push('--auto-elect');
+  if (resolved.minimal !== false) serveArgs.push('--minimal');
   if (resolved.autoElect === false) serveArgs.push('--no-auto-elect');
   if (resolved.broker) serveArgs.push('--broker');
   if (resolved.connectBroker) serveArgs.push('--connect-broker');

--- a/docs/mcp/topologies.md
+++ b/docs/mcp/topologies.md
@@ -4,7 +4,7 @@ OpenChrome currently supports one safe direct-controller rule:
 
 > Run at most one direct `openchrome serve --auto-launch` process for the same Chrome debug port and user-data directory.
 
-Multiple MCP clients can still run in parallel today. New `openchrome setup` / `openchrome config` output defaults to the auto-elect topology (`openchrome serve --auto-launch --auto-elect`): one process wins the Chrome/CDP owner lock and publishes broker metadata; surplus same-profile clients proxy through that broker. For explicit shared-profile deployments, run a single broker owner (`openchrome serve --broker --auto-launch`) and point the other clients at it with `--connect-broker`; otherwise give each client its own isolated port and user-data directory.
+Multiple MCP clients can still run in parallel today. New `openchrome setup` / `openchrome config` output defaults to the auto-elect topology (`openchrome serve --auto-launch --auto-elect --minimal`): one process wins the Chrome/CDP owner lock and publishes broker metadata; surplus same-profile clients proxy through that broker. For explicit shared-profile deployments, run a single broker owner (`openchrome serve --broker --auto-launch`) and point the other clients at it with `--connect-broker`; otherwise give each client its own isolated port and user-data directory.
 
 ## After upgrading OpenChrome
 
@@ -38,7 +38,7 @@ openchrome config --client opencode
 Generated configs use:
 
 ```bash
-openchrome serve --auto-launch --auto-elect
+openchrome serve --auto-launch --auto-elect --minimal
 ```
 
 For one `(port, userDataDir)`, exactly one process remains the direct Chrome/CDP owner. Surplus sessions attach as broker clients instead of becoming unsafe second direct controllers.

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -88,7 +88,7 @@ export interface CreateServerOptions {
   };
 
   pilot?: boolean;
-  tools?: { allTools?: boolean };
+  tools?: { allTools?: boolean; minimal?: boolean };
   security?: { blockedDomains?: string[]; auditLog?: boolean; sanitizeContent?: boolean };
   idleTimeoutMs?: number;
   parentPid?: number;
@@ -258,10 +258,15 @@ class OpenChromeServerImpl implements OpenChromeServer {
 
     // Tool tiers
     const envTier = parseInt(process.env.OPENCHROME_TOOL_TIER || '', 10);
+    if (opts.tools?.allTools && opts.tools?.minimal) {
+      throw new Error('[openchrome] --minimal and --all-tools are mutually exclusive');
+    }
     if (opts.tools?.allTools || envTier >= 3) {
       setMCPServerOptions({ initialToolTier: 3 as ToolTier });
     } else if (envTier === 2) {
       setMCPServerOptions({ initialToolTier: 2 as ToolTier });
+    } else if (opts.tools?.minimal) {
+      setMCPServerOptions({ initialToolTier: 1 as ToolTier });
     }
 
     // Transport

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,7 @@ program
   .option('--audit-log', 'Enable security audit logging (default: false)')
   .option('--no-sanitize-content', 'Disable content sanitization for prompt injection defense (default: enabled)')
   .option('--all-tools', 'Expose all tools from startup (bypass progressive disclosure)')
+  .option('--minimal', 'Expose only the minimal browser-essential startup tool surface. Advanced tools remain available through expand_tools.')
   .option('--server-mode', 'Server/headless mode: auto-launch headless Chrome, skip cookie bridge')
   .option('--http [port]', 'Use Streamable HTTP transport instead of stdio (default port: 3100)')
   .option('--http-host <host>', 'Bind address for HTTP transport (default: 127.0.0.1, use 0.0.0.0 for external access)')
@@ -134,7 +135,7 @@ program
   .option('--launch-mode <mode>', 'Chrome launch mode: auto | attach | isolated (#659). Also: OPENCHROME_LAUNCH_MODE env var.')
   .option('--secrets <path>', 'Load a dotenv-format secrets file (KEY=value per line). Tokens "${SECRET:NAME}" in tool arguments are substituted to the real value at MCP request deserialization; the same values are redacted from every LLM-visible artifact (responses, trace, skill records, journal). Default: no secrets loaded. P3: no OS keychain integration.')
   .option('--codegen <mode>', 'Opt-in replay artifact generation: off, puppeteer, playwright, or mcp-replay. Default: off (no response shape changes). Also: OPENCHROME_CODEGEN.')
-  .action(async (options: { port: string; autoLaunch?: boolean; allowUnsafeSharedAttach?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; windowSize?: string; windowPosition?: string; windowBounds?: string; startMaximized?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; broker?: boolean; connectBroker?: boolean; autoElect?: boolean; idleTimeout?: string; allowUnauthenticatedHttp?: boolean; pilot?: boolean; slim?: boolean; toolsOnly?: string; disableTools?: string; introspectToolsList?: boolean; autoConnect?: string | boolean; launchMode?: string; secrets?: string; codegen?: string }) => {
+  .action(async (options: { port: string; autoLaunch?: boolean; allowUnsafeSharedAttach?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; windowSize?: string; windowPosition?: string; windowBounds?: string; startMaximized?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; minimal?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; broker?: boolean; connectBroker?: boolean; autoElect?: boolean; idleTimeout?: string; allowUnauthenticatedHttp?: boolean; pilot?: boolean; slim?: boolean; toolsOnly?: string; disableTools?: string; introspectToolsList?: boolean; autoConnect?: string | boolean; launchMode?: string; secrets?: string; codegen?: string }) => {
     const { normalizeCodegenMode, setCodegenMode } = await import('./core/codegen');
     const codegenMode = normalizeCodegenMode(options.codegen ?? process.env.OPENCHROME_CODEGEN);
     setCodegenMode(codegenMode);
@@ -592,12 +593,19 @@ program
 
     // Tool tier configuration
     const envTier = parseInt(process.env.OPENCHROME_TOOL_TIER || '', 10);
+    if (options.allTools && options.minimal) {
+      console.error('[openchrome] Error: --minimal and --all-tools are mutually exclusive');
+      process.exit(2);
+    }
     if (options.allTools || envTier >= 3) {
       mcpOptions.initialToolTier = 3 as ToolTier;
       console.error('[openchrome] All tools exposed from startup');
     } else if (envTier === 2) {
       mcpOptions.initialToolTier = 2 as ToolTier;
       console.error('[openchrome] Tier 2 tools exposed from startup');
+    } else if (options.minimal) {
+      mcpOptions.initialToolTier = 1 as ToolTier;
+      console.error('[openchrome] Minimal startup tool surface enabled');
     }
 
     // Capability filter configuration (#829, #847)

--- a/tests/cli/mcp-client-config.test.ts
+++ b/tests/cli/mcp-client-config.test.ts
@@ -15,11 +15,11 @@ import {
 
 describe('cli/mcp-client-config', () => {
   test('getServeArgs enables auto-launch by default', () => {
-    expect(getServeArgs()).toEqual(['serve', '--auto-launch', '--auto-elect']);
+    expect(getServeArgs()).toEqual(['serve', '--auto-launch', '--auto-elect', '--minimal']);
   });
 
   test('getServeArgs includes dashboard when requested', () => {
-    expect(getServeArgs({ dashboard: true })).toEqual(['serve', '--auto-launch', '--auto-elect', '--dashboard']);
+    expect(getServeArgs({ dashboard: true })).toEqual(['serve', '--auto-launch', '--auto-elect', '--minimal', '--dashboard']);
   });
 
   test('getServeArgs preserves explicit port and profile topology', () => {
@@ -32,6 +32,7 @@ describe('cli/mcp-client-config', () => {
       'serve',
       '--auto-launch',
       '--auto-elect',
+      '--minimal',
       '--port',
       '9333',
       '--user-data-dir',
@@ -44,15 +45,15 @@ describe('cli/mcp-client-config', () => {
   });
 
   test('single-owner topology preset preserves the legacy direct owner explicitly', () => {
-    expect(getServeArgs({ topology: 'single-owner' })).toEqual(['serve', '--auto-launch', '--no-auto-elect']);
+    expect(getServeArgs({ topology: 'single-owner' })).toEqual(['serve', '--auto-launch', '--minimal', '--no-auto-elect']);
   });
 
   test('broker topology presets generate owner and client roles', () => {
     expect(getServeArgs({ topology: 'broker-owner', port: 9222, userDataDir: '/tmp/shared' })).toEqual([
-      'serve', '--auto-launch', '--broker', '--port', '9222', '--user-data-dir', '/tmp/shared',
+      'serve', '--auto-launch', '--minimal', '--broker', '--port', '9222', '--user-data-dir', '/tmp/shared',
     ]);
     expect(getServeArgs({ topology: 'broker-client', port: 9222, userDataDir: '/tmp/shared' })).toEqual([
-      'serve', '--connect-broker', '--port', '9222', '--user-data-dir', '/tmp/shared',
+      'serve', '--minimal', '--connect-broker', '--port', '9222', '--user-data-dir', '/tmp/shared',
     ]);
   });
 
@@ -60,6 +61,7 @@ describe('cli/mcp-client-config', () => {
     expect(getServeArgs({ topology: 'isolated' })).toEqual([
       'serve',
       '--auto-launch',
+      '--minimal',
       '--port',
       '9223',
       '--user-data-dir',
@@ -70,13 +72,18 @@ describe('cli/mcp-client-config', () => {
   });
 
   test('getServeArgs omits auto-launch when explicitly disabled', () => {
-    expect(getServeArgs({ autoLaunch: false })).toEqual(['serve']);
+    expect(getServeArgs({ autoLaunch: false })).toEqual(['serve', '--minimal']);
+  });
+
+
+  test('getServeArgs can opt out of generated minimal mode', () => {
+    expect(getServeArgs({ minimal: false })).toEqual(['serve', '--auto-launch', '--auto-elect']);
   });
 
   test('getCodexServerConfig uses the installed openchrome binary', () => {
     expect(getCodexServerConfig()).toEqual({
       command: 'openchrome',
-      args: ['serve', '--auto-launch', '--auto-elect'],
+      args: ['serve', '--auto-launch', '--auto-elect', '--minimal'],
     });
   });
 
@@ -92,6 +99,7 @@ describe('cli/mcp-client-config', () => {
       'serve',
       '--auto-launch',
       '--auto-elect',
+      '--minimal',
       '--dashboard',
     ]);
     expect(command).not.toContain('remove');
@@ -100,7 +108,7 @@ describe('cli/mcp-client-config', () => {
   test('getClaudeManualServerConfig uses the installed openchrome binary', () => {
     expect(getClaudeManualServerConfig()).toEqual({
       command: 'openchrome',
-      args: ['serve', '--auto-launch', '--auto-elect'],
+      args: ['serve', '--auto-launch', '--auto-elect', '--minimal'],
     });
   });
 
@@ -116,6 +124,7 @@ describe('cli/mcp-client-config', () => {
       'serve',
       '--auto-launch',
       '--auto-elect',
+      '--minimal',
       '--dashboard',
     ]);
   });
@@ -142,7 +151,7 @@ describe('cli/mcp-client-config', () => {
         },
         openchrome: {
           command: 'openchrome',
-          args: ['serve', '--auto-launch', '--auto-elect'],
+          args: ['serve', '--auto-launch', '--auto-elect', '--minimal'],
         },
       },
     });
@@ -153,7 +162,7 @@ describe('cli/mcp-client-config', () => {
       mcpServers: {
         openchrome: {
           command: 'openchrome',
-          args: ['serve', '--auto-launch', '--auto-elect'],
+          args: ['serve', '--auto-launch', '--auto-elect', '--minimal'],
         },
       },
     });
@@ -164,7 +173,7 @@ describe('cli/mcp-client-config', () => {
       [
         '[mcp_servers.openchrome]',
         'command = "openchrome"',
-        'args = ["serve", "--auto-launch", "--auto-elect"]',
+        'args = ["serve", "--auto-launch", "--auto-elect", "--minimal"]',
       ].join('\n')
     );
   });
@@ -173,7 +182,7 @@ describe('cli/mcp-client-config', () => {
     const options = { port: 9333, userDataDir: '/tmp/openchrome-codex' };
 
     expect(formatCodexMCPServerConfigSnippet('openchrome', getCodexServerConfig(options))).toContain(
-      'args = ["serve", "--auto-launch", "--auto-elect", "--port", "9333", "--user-data-dir", "/tmp/openchrome-codex"]'
+      'args = ["serve", "--auto-launch", "--auto-elect", "--minimal", "--port", "9333", "--user-data-dir", "/tmp/openchrome-codex"]'
     );
     expect(getClaudeSetupCommand('user', options)).toEqual([
       'mcp',
@@ -186,6 +195,7 @@ describe('cli/mcp-client-config', () => {
       'serve',
       '--auto-launch',
       '--auto-elect',
+      '--minimal',
       '--port',
       '9333',
       '--user-data-dir',
@@ -201,6 +211,7 @@ describe('cli/mcp-client-config', () => {
         'serve',
         '--auto-launch',
         '--auto-elect',
+        '--minimal',
         '--port',
         '9444',
         '--user-data-dir',

--- a/tests/mcp-progressive-disclosure.test.ts
+++ b/tests/mcp-progressive-disclosure.test.ts
@@ -92,6 +92,20 @@ describe('MCP progressive disclosure client detection', () => {
     expect(tools.length).toBeLessThan(118);
   });
 
+
+  test('explicit minimal mode keeps unknown clients on the small startup surface', async () => {
+    const mockSM = createMockSessionManager();
+    (getSessionManager as jest.Mock).mockReturnValue(mockSM);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const server = new MCPServer(mockSM as any, { initialToolTier: 1 });
+    registerAllTools(server);
+
+    const { tools } = await initializeAndList(server, 'unknown-editor');
+
+    expect(tools).toContain('expand_tools');
+    expect(tools.length).toBeLessThanOrEqual(16);
+  });
+
   test('unknown clients without list_changed support keep legacy all-tools behavior', async () => {
     const { init, tools } = await initializeAndList(makeServer(), 'unknown-editor');
 


### PR DESCRIPTION
## Summary
- Adds `openchrome serve --minimal` as an explicit low-token startup mode.
- Makes generated Codex, Claude, and OpenCode MCP configs include `--minimal` by default.
- Keeps `--all-tools` as the full-manifest escape hatch and rejects `--minimal --all-tools`.
- Updates README/topology docs and tests for the new generated config output.

## Linked issue
- Fixes part of #1524

## Verification
- `npm test -- --runTestsByPath tests/cli/mcp-client-config.test.ts tests/mcp-progressive-disclosure.test.ts --runInBand`
- `npm run build`
- `node dist/index.js serve --help` shows `--minimal`
- Explicit minimal tools/list measurement: 15 tools / 22,854 JSON chars / approximately 5,714 tokens
- `npm run lint:changed`
- `git diff --check`

## Non-goals
- Does not mutate existing user MCP host configs.
- Does not remove tools.
- Does not replace `--slim` or `--all-tools`.

## Risks / notes
- Newly generated configs start smaller; advanced tools remain available through `expand_tools` or by using `--all-tools`.
- Native subagent code-review lanes were unavailable in this runtime; merge readiness is gated by explicit local verification plus CI.
