### PR TITLE
docs(auto-connect): localhost-only guard, forbidden ports, attach recipe

### DIFF
--- a/docs/auto-connect.md
+++ b/docs/auto-connect.md
@@ -122,3 +122,81 @@ openchrome and is only valid in launch mode.
 `--auto-connect` always sets the lifecycle mode to `attach` (#661). openchrome
 will **not** kill the Chrome it attached to during shutdown — your existing
 window survives `oc_stop`, SIGTERM, and process-exit handlers.
+
+## Security: localhost-only guard
+
+`--auto-connect` only ever binds to `127.0.0.1`. Every code path that touches
+the discovered DevTools port normalises the host to loopback:
+
+- `AutoConnectResult.wsEndpoint` is always `ws://127.0.0.1:<port><target-path>`
+  — the second line of `DevToolsActivePort` is treated as a URL path, never a
+  host override.
+- The pre-return TCP probe (`probePort` in `src/chrome/auto-connect.ts`) dials
+  `127.0.0.1:<port>` and only returns a bound endpoint if loopback answers.
+- Downstream CDP fetches (`src/chrome/devtools-info.ts`) rebuild the WS URL
+  from the loopback host, so a hostile `DevToolsActivePort` file cannot rewrite
+  the target to a remote address.
+
+If you need to bridge the DevTools port to another host, do it in front of
+openchrome (SSH tunnel, `socat`, Cloudflare Tunnel) — do not point
+`--auto-connect` at a remote user-data dir. Remote attach is intentionally
+out of scope; see the same design note in `docs/security.md`.
+
+### Forbidden ports
+
+Chrome's remote debugging channel accepts any TCP port, but a few are unsafe
+regardless of loopback binding and openchrome refuses to keep them:
+
+| Range | Why |
+|---|---|
+| `0` | Chrome uses `0` to mean "pick a port". Only valid on the launch side; a written `DevToolsActivePort` value of `0` is a malformed file and is rejected as `devtools_active_port_malformed`. |
+| Anything below `1024` | Privileged ports; a stray `sudo`-launched Chrome could listen here, but openchrome refuses to attach because binding a debug protocol to a well-known port is almost certainly a misconfiguration. Pass `--allow-privileged-port` (future flag; tracked in P2) if you truly need it. |
+| Blocked-by-Chrome ports | Chrome itself refuses to serve DevTools on ports it blocks for outbound traffic (see `net::ERR_UNSAFE_PORT`). If Chrome wrote one of these into `DevToolsActivePort`, the file is corrupt and openchrome surfaces `port_not_bound`. |
+
+The port validator lives in `parseDevToolsActivePort` — it rejects non-digit
+port lines and any value outside `1..65535` so `parseInt`'s partial-number
+tolerance (`"9222junk" -> 9222`) cannot misroute the attach.
+
+## Attach recipe: switch a running Chrome into openchrome mid-session
+
+Sometimes you already have a Chrome window open with the state you care about
+(logged into GitHub, a partially-filled form, an SSO session) and you want an
+agent to drive it without losing that state. The steps below take you from a
+stock Chrome window to an openchrome-controlled session in about a minute.
+
+```bash
+# 1. Pick a user-data dir Chrome will actually write to. Reuse your daily
+#    profile if you accept the security tradeoff, or spin up a scratch dir.
+USER_DATA_DIR="${HOME}/.cache/openchrome-attach-demo"
+mkdir -p "$USER_DATA_DIR"
+
+# 2. Launch (or relaunch) Chrome with remote debugging on port 0. Port 0 lets
+#    Chrome pick a free port and write it to DevToolsActivePort.
+google-chrome \
+  --remote-debugging-port=0 \
+  --user-data-dir="$USER_DATA_DIR" \
+  https://example.com &
+
+# 3. Wait until Chrome writes the file (usually < 1 second on cold start).
+timeout 10 bash -c "until test -s \"$USER_DATA_DIR/DevToolsActivePort\"; do sleep 0.1; done"
+cat "$USER_DATA_DIR/DevToolsActivePort"
+# 53187
+# /devtools/browser/9b0e...
+
+# 4. Hand the dir to openchrome. It reads the file, probes 127.0.0.1:<port>,
+#    and attaches. No --port flag needed — the discovery lives in
+#    src/chrome/auto-connect.ts.
+openchrome serve --auto-connect="$USER_DATA_DIR"
+```
+
+Verify the attach worked by calling `mcp__openchrome__oc_get_connection_info`
+and confirming `mode` is `auto-connect` and `wsEndpoint` starts with
+`ws://127.0.0.1:` — that pair is your proof that openchrome bound to loopback
+on the port Chrome advertised.
+
+### Detach without killing Chrome
+
+`--auto-connect` implies `--launch-mode=attach`, so `oc_stop` and SIGTERM
+detach the CDP client and leave the Chrome window alive. To close the window
+too, quit Chrome yourself — openchrome will not do it for you when you owned
+the launch.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,5 +1,18 @@
 # Security policy notes
 
+## DevTools attach boundary (`--auto-connect`)
+
+`--auto-connect` binds only to `127.0.0.1`. The wsEndpoint returned by
+`discoverActiveDevToolsPort` is always `ws://127.0.0.1:<port><target-path>`
+regardless of what the `DevToolsActivePort` file's second line contains, and
+the pre-return probe dials loopback before the endpoint is handed back.
+
+Remote attach is intentionally out of scope. If you need to bridge the debug
+port across hosts, terminate the tunnel in front of openchrome (SSH tunnel,
+`socat`, Cloudflare Tunnel); do not point `--auto-connect` at a remote
+user-data dir. See `docs/auto-connect.md` for the full contract, including
+the forbidden-port list and the attach recipe.
+
 ## Page-origin boundary markers
 
 OpenChrome wraps page-origin text in `<oc:*>` blocks so host agents can


### PR DESCRIPTION
## 요약

`--auto-connect`의 localhost-only 계약과 attach 워크플로를 문서화합니다. 코드 동작은 그대로이며, 이미 구현되어 있는 불변을 계약으로 명시하고 attach 레시피를 추가합니다.

## 근거

이 PR은 Sonar의 openchrome 상류 기여 재판정(v2)의 **P1** 팩입니다. 90개 오픈소스 전수조사(별첨 census)에서 아래 두 프로젝트의 문서 관행을 openchrome에 정합화하는 것으로 판정되었습니다.

- **chrome-devtools-mcp (Apache-2.0)** — README에서 `--autoConnect`의 loopback 계약을 명시적으로 문서화합니다. openchrome도 같은 계약이지만 문서화되어 있지 않았습니다.
- **playwright-python (Apache-2.0)** — `connect_over_cdp`가 loopback bind인지 아닌지에 대한 문서화 관행.

## 변경 내용

- `docs/auto-connect.md`
  - **Security: localhost-only guard** 절 추가. `AutoConnectResult.wsEndpoint`가 항상 `ws://127.0.0.1:` 형식임을 계약으로 명시하고, `probePort()`(src/chrome/auto-connect.ts:170~)와 `src/chrome/devtools-info.ts`가 loopback host를 재조립한다는 사실을 근거로 제시합니다. 원격 attach는 앞단 SSH 터널·socat·Cloudflare Tunnel로 처리하도록 안내합니다.
  - **Forbidden ports** 절 추가. `parseDevToolsActivePort`의 숫자-only 검증(src/chrome/auto-connect.ts:200~)이 이미 `parseInt`의 부분숫자 관용(`"9222junk" -> 9222`)을 막고 있다는 점을 문서화합니다. 포트 0, privileged ports, ERR_UNSAFE_PORT의 처리 방식.
  - **Attach recipe** 절 추가. 스톡 Chrome 윈도우를 openchrome-controlled 세션으로 전환하는 복붙 가능한 스크립트. `oc_get_connection_info`로 loopback 검증까지 포함.
  - Detach-without-kill 노트 (`oc_stop` / SIGTERM은 attach된 Chrome을 죽이지 않음).

- `docs/security.md`
  - **DevTools attach boundary** 절 신설. auto-connect의 loopback 계약을 요약하고 auto-connect.md로 cross-link. 원격 attach가 out of scope인 이유를 명시.

## 참고 원본

- chrome-devtools-mcp — https://github.com/ChromeDevTools/chrome-devtools-mcp · Apache-2.0. README의 `--autoConnect` 문서화 관행.
- playwright-python — https://github.com/microsoft/playwright-python · Apache-2.0. `connect_over_cdp` 문서화 관행.
- 원본 코드를 복사한 부분은 없습니다. 두 프로젝트가 노출하는 문서 계약을 openchrome에 자연스러운 톤으로 옮긴 clean-room 문서 이식입니다.

## 테스트

문서 전용 변경입니다. 실행 가능한 테스트가 없으며, 관련 코드 경로(`src/chrome/auto-connect.ts`)의 기존 유닛 테스트(`tests/chrome/auto-connect.test.ts`)는 이 PR의 문서와 동일한 계약을 이미 검증하고 있습니다.

수동 확인:
- `mkdocs` 등 문서 렌더러가 없어서 raw markdown 프리뷰만 확인했습니다.
- Cross-link (`docs/security.md` → `docs/auto-connect.md`) 경로 유효성 확인.

## 관련

이 팩은 v2 계획의 **P1** 팩입니다. Sonar 프로젝트가 진행 중인 25개 팩 시리즈의 첫 배치(P1·P5·P6·P11·P13) 중 하나로 함께 제출됩니다.

- P2 (feat: non-localhost 거부 가드)는 이 문서 계약을 코드로 강제하는 후속 팩입니다.
- P5 (docs: CONTRIBUTING adapter-first) 별도 PR.