### PR TITLE
docs(contributing): adapter-first principle + adapter contract

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,6 +242,96 @@ The hint engine (`src/hints/`) currently has 21 static rules. Areas to improve:
 - **Tutorials**: Step-by-step guides (e.g., "Automate your CI dashboard")
 - **Troubleshooting guide**: Common issues and solutions per platform
 
+## Contribution Principles
+
+### Adapter first, fork last
+
+Before you patch `src/` core files to wire in a new backend (a new stealth
+engine, a new extraction library, a new vision model, a new captcha solver),
+try to land the integration as an **adapter** behind an existing extension
+point. Adapters keep the core surface small, isolate third-party licence and
+release cadence risk, and let the core CI stay green when the vendor changes
+its API.
+
+Fork the core (edit files under `src/actions/`, `src/cdp/`, `src/chrome/`
+etc.) only when the adapter surface genuinely cannot express what you need.
+When in doubt, open an issue describing the extension point you wish existed
+before writing the fork.
+
+#### Existing extension points
+
+| Extension point | Where | Add a new backend by |
+|---|---|---|
+| Stealth injection scripts | `src/stealth/fingerprint-defense.ts`, `human-behavior.ts` | Adding a named script generator that returns a self-contained closure and wiring it into the stealth registry. |
+| Captcha providers | `src/captcha/providers/` | Implementing the provider interface (detect + solve) and registering it in `solver-registry.ts`. |
+| Extraction strategies | `src/extraction/strategies.ts` | Adding a strategy that consumes the shared `ExtractionRequest` and returns a `ExtractionResult`. |
+| Vision grounding | `src/vision/` | Implementing the grounding tier interface and adding a fallback rung in the tier chain. |
+| Auth backends | `src/auth/credential-store.ts` | Implementing the credential store interface (get/set/list) against a new backend (OS keychain, KMS, HashiCorp Vault). |
+| Recovery hooks | `src/recovery/` | Adding a `RecoveryTrajectoryLedger` consumer that reads outcomes and emits corrective actions. |
+| Hint rules | `src/hints/rules/` | Following the existing rule shape (match + response) and registering the rule. |
+| MCP tools | `src/tools/` + `src/tools/index.ts` | Implementing the tool contract and registering it in the tool index. |
+
+#### Adapter contract
+
+Every adapter should:
+
+1. **Declare its scope** — one exported interface that names what the adapter
+   does. Do not re-export third-party types; wrap them so vendor breakage does
+   not become a `src/` breakage.
+2. **Be self-contained** — no imports from other adapter directories. Two
+   adapters must never call each other; they meet only at the interface the
+   core defines.
+3. **Fail closed** — throw a typed error (e.g. `ExtractionError`,
+   `StealthUnavailableError`) rather than a generic `Error`. The core routes
+   typed errors into the failure classifier (`src/failure/classifier.ts`).
+4. **Ship its own tests** — under `tests/<domain>/<adapter-name>/`. If the
+   adapter cannot be tested without hitting the network or spawning Chrome,
+   add a mock/fake sibling that satisfies the interface for integration tests.
+5. **License-tag the origin** — if the adapter mirrors an idiom from an
+   upstream open-source project, note the project name, licence, and source
+   file at the top of the adapter module (see
+   `src/chrome/auto-connect.ts` for the pattern openchrome uses today).
+
+#### Example: adding a new extraction backend
+
+Suppose you want to add [trafilatura](https://github.com/adbar/trafilatura)
+(Apache-2.0) as a body-text extractor. The adapter path avoids touching
+`src/extraction/mode.ts` or `src/extraction/plan.ts`:
+
+```ts
+// src/extraction/strategies/trafilatura.ts
+import type { ExtractionRequest, ExtractionResult, ExtractionStrategy } from '../types';
+
+/**
+ * trafilatura-backed extractor. Origin: adbar/trafilatura (Apache-2.0).
+ * Runs the trafilatura CLI out-of-process so the vendor lifecycle stays
+ * isolated from the Node.js core.
+ */
+export const trafilaturaStrategy: ExtractionStrategy = {
+  name: 'trafilatura',
+  async extract(req: ExtractionRequest): Promise<ExtractionResult> {
+    // ... call trafilatura, wrap result, throw ExtractionError on failure.
+  },
+};
+```
+
+Then register the strategy in `src/extraction/strategies/index.ts` — one
+line. No core file changes, no cross-adapter coupling, and if trafilatura
+disappears tomorrow the strategy file is the only thing that needs replacing.
+
+#### When forking core is the right call
+
+Some changes cannot ship as adapters and legitimately need core patches:
+
+- Fixing a bug in the CDP client, launcher, or session manager.
+- Adding a new MCP protocol capability or resource.
+- Adding a new lifecycle mode (attach / launch / auto) or launch guard.
+- Refactoring a shared type or contract.
+
+For those, open an issue that names the invariant you are changing before you
+send the PR. Core changes go through a stricter review because they affect
+every adapter downstream.
+
 ### Good First Issues
 
 If you're new to the project, these are good starting points:


### PR DESCRIPTION
## 요약

새 백엔드(스텔스 엔진, 추출 라이브러리, vision 모델, captcha solver)를 통합할 때 core `src/` 파일을 fork하기 전에 어댑터로 landing하는 원칙을 CONTRIBUTING.md에 명문화합니다. 이미 존재하는 8개 extension point를 매핑하고, 5-clause 어댑터 계약을 정의합니다.

## 근거

Sonar의 openchrome 상류 기여 재판정(v2)의 **P5** 팩입니다. 90개 오픈소스 전수조사 결과, openchrome이 앞으로 흡수할 가능성이 높은 다수의 upstream 프로젝트(nodriver AGPL, camoufox MPL, Skyvern AGPL, patchright Apache, Stagehand MIT 등)의 라이선스·릴리스 케이던스가 다양합니다. 어댑터 경계를 원칙으로 못박아야 core `src/`가 라이선스적으로 깨끗한 MIT 상태를 유지할 수 있습니다.

이 원칙은 openchrome이 이미 `src/chrome/auto-connect.ts`에서 사용한 origin-attribution 패턴("Inspired by chrome-devtools-mcp (Apache-2.0); openchrome's implementation is independent")을 일반 규칙으로 확장한 것입니다.

## 변경 내용

`CONTRIBUTING.md`에 **Contribution Principles** 절 신설:

1. **Adapter first, fork last** — 원칙 선언과 근거.
2. **Existing extension points** 표 — src/에 이미 있는 8개 경계를 매핑:
   - Stealth (`src/stealth/`)
   - Captcha providers (`src/captcha/providers/`)
   - Extraction strategies (`src/extraction/strategies.ts`)
   - Vision grounding (`src/vision/`)
   - Auth backends (`src/auth/credential-store.ts`)
   - Recovery hooks (`src/recovery/`)
   - Hint rules (`src/hints/rules/`)
   - MCP tools (`src/tools/`)
3. **Adapter contract** — 5개 조항: scope 선언·self-contain·typed error로 fail closed·자체 테스트 동봉·origin license-tag.
4. **Worked example** — trafilatura(Apache-2.0)를 extraction backend로 추가할 때 core 파일(mode.ts, plan.ts)을 건드리지 않는 어댑터 경로를 보여주는 실제 코드 스니펫.
5. **When forking core is the right call** — core patch가 정당한 4가지 경우와 pre-PR issue 요구사항.

기존 CONTRIBUTING.md 내용은 그대로 두었으며, "Good First Issues" 절 앞에 새 절을 삽입했습니다.

## 참고 원본

이 팩은 특정 upstream 프로젝트의 코드를 이식하는 것이 아니라, 90개 census를 통해 관찰된 openchrome의 라이선스·통합 리스크를 어댑터 원칙으로 격리하는 문서입니다. 근거가 되는 upstream 프로젝트 예시:

- nodriver (AGPL) — copyleft라 어댑터 경계 필수.
- camoufox (MPL) — MPL은 파일 단위이므로 어댑터 파일만 격리.
- Skyvern (AGPL) — SaaS 조항까지 감안하면 별프로세스 어댑터 유일 안전.
- patchright (Apache) — permissive이지만 vendor cadence가 달라 어댑터가 안정.

## 테스트

문서 전용 변경입니다. 실행 가능한 테스트는 없으며, 문서가 참조하는 파일 경로가 모두 실제로 존재함을 확인했습니다.

수동 확인:
- 8개 extension-point 표에 나오는 모든 경로가 현재 트리에 존재함을 `ls` 로 확인.
- Worked example의 trafilatura strategy 코드는 `src/extraction/strategies.ts`의 export 스타일과 형식적으로 정합.

## 관련

이 팩은 v2 계획의 **P5** 팩입니다. 다른 4개 팩(P1·P6·P11·P13)이 동시에 별도 PR로 제출됩니다.