### PR TITLE
feat(cdp+recovery): tunable exponential-backoff + tab health self-heal

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -68,6 +68,23 @@ export interface CDPClientOptions {
   heartbeatIntervalMs?: number;
   /** If true, auto-launch Chrome when not running (default: false) */
   autoLaunch?: boolean;
+  /**
+   * Upper bound (ms) on the exponential backoff delay between reconnect
+   * attempts. When omitted, defaults to 30_000 ms for bounded reconnection
+   * (`maxReconnectAttempts` finite) and 60_000 ms for infinite reconnection.
+   *
+   * Inspired by real-browser-mcp (MIT), which exposes the cap so long-running
+   * headed sessions can lengthen the ceiling without recompiling. See
+   * `OPENCHROME_RECONNECT_BACKOFF_CAP_MS` for the env-var equivalent.
+   */
+  reconnectBackoffCapMs?: number;
+  /**
+   * Jitter ratio (0.0-1.0) applied on top of the exponential delay. `0`
+   * disables jitter (fully deterministic backoff — useful for tests). Default
+   * `0.5` matches the historical implementation (`random(0..baseDelay/2)`).
+   * Env override: `OPENCHROME_RECONNECT_JITTER_RATIO`.
+   */
+  reconnectJitterRatio?: number;
 }
 
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
@@ -77,6 +94,17 @@ export interface ConnectionEvent {
   timestamp: number;
   attempt?: number;
   error?: string;
+  /**
+   * When emitted for a `reconnecting` event, the estimated wall-clock time
+   * (ms since epoch) at which the *next* reconnect attempt will run after
+   * this one fails. Observers can use it to render a countdown UI or gate
+   * user-facing "still trying" messages without polling `estimatedRetryMs()`.
+   *
+   * Omitted for terminal events (`connected`, `reconnected`, `reconnect_failed`).
+   */
+  nextRetryAt?: number;
+  /** For `reconnecting` events, the backoff delay (ms) that produced `nextRetryAt`. */
+  backoffMs?: number;
 }
 
 
@@ -95,12 +123,56 @@ function parseEnvInt(name: string, fallback: number): number {
   return parsed;
 }
 
+/**
+ * Parse a float in [0, 1] from an env var. Falls back on parse error or
+ * out-of-range value. Used by the reconnect jitter ratio knob.
+ */
+function parseEnvRatio(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    console.error(`[CDPClient] Invalid value for ${name}="${raw}" (must be 0..1), using default ${fallback}`);
+    return fallback;
+  }
+  return parsed;
+}
+
+/**
+ * Compute the exponential backoff delay for a given reconnect attempt.
+ *
+ * Contract:
+ *   - Attempt 1 uses `base * 2^0 = base` (no penalty on the first retry).
+ *   - The exponent is clamped to 6 so `Number` never overflows even in
+ *     infinite-reconnect mode (2^6 = 64× base).
+ *   - Jitter is `random(0..base*jitterRatio)`. Passing `jitterRatio=0`
+ *     yields a deterministic sequence, which lets tests assert exact ms.
+ *   - The final value is clamped to `cap`.
+ *
+ * Exported for unit tests; not part of the public API.
+ */
+export function computeReconnectBackoffMs(
+  attempt: number,
+  base: number,
+  cap: number,
+  jitterRatio: number,
+  random: () => number = Math.random,
+): number {
+  const safeAttempt = Math.max(1, Math.floor(attempt));
+  const exponent = Math.min(safeAttempt - 1, 6);
+  const jitter = jitterRatio > 0 ? Math.floor(random() * base * jitterRatio) : 0;
+  const raw = base * Math.pow(2, exponent) + jitter;
+  return Math.min(raw, cap);
+}
+
 export class CDPClient {
   private browser: Browser | null = null;
   private sessions: Map<string, CDPSession> = new Map();
   private port: number;
   private maxReconnectAttempts: number;
   private reconnectDelayMs: number;
+  private reconnectBackoffCapMs: number | null;
+  private reconnectJitterRatio: number;
   private heartbeatIntervalMs: number;
   private heartbeatTimer: NodeJS.Timeout | null = null;
   private connectionState: ConnectionState = 'disconnected';
@@ -166,6 +238,18 @@ export class CDPClient {
     this.port = options.port || globalConfig.port;
     this.maxReconnectAttempts = options.maxReconnectAttempts ?? parseEnvInt('OPENCHROME_MAX_RECONNECT_ATTEMPTS', DEFAULT_MAX_RECONNECT_ATTEMPTS);
     this.reconnectDelayMs = options.reconnectDelayMs ?? parseEnvInt('OPENCHROME_RECONNECT_DELAY_MS', DEFAULT_RECONNECT_DELAY_MS);
+    // Backoff cap: explicit option > env var > sentinel (null = "use mode default").
+    // The mode-default (bounded=30s, infinite=60s) is resolved in the reconnect
+    // loop so a caller can flip maxReconnectAttempts at runtime without stale caps.
+    if (options.reconnectBackoffCapMs !== undefined) {
+      this.reconnectBackoffCapMs = options.reconnectBackoffCapMs;
+    } else if (process.env['OPENCHROME_RECONNECT_BACKOFF_CAP_MS'] !== undefined) {
+      this.reconnectBackoffCapMs = parseEnvInt('OPENCHROME_RECONNECT_BACKOFF_CAP_MS', 30_000);
+    } else {
+      this.reconnectBackoffCapMs = null;
+    }
+    this.reconnectJitterRatio = options.reconnectJitterRatio
+      ?? parseEnvRatio('OPENCHROME_RECONNECT_JITTER_RATIO', 0.5);
     this.heartbeatIntervalMs = options.heartbeatIntervalMs ?? parseEnvInt('OPENCHROME_HEARTBEAT_INTERVAL_MS', DEFAULT_HEARTBEAT_INTERVAL_MS);
     // Use explicit option if provided, otherwise use global config
     this.autoLaunch = options.autoLaunch !== undefined ? options.autoLaunch : globalConfig.autoLaunch;
@@ -639,15 +723,28 @@ export class CDPClient {
         console.error(`[CDPClient] Reconnect attempt ${this.reconnectAttempts} failed:`, error);
 
         if (this.maxReconnectAttempts === Infinity || this.reconnectAttempts < this.maxReconnectAttempts) {
-          // Exponential backoff with jitter: baseDelay * 2^(attempt-1) + random(0..baseDelay/2)
-          // Exponent capped at 6 to prevent Number overflow on high attempt counts (infinite mode)
-          const backoffCap = this.maxReconnectAttempts === Infinity ? 60000 : 30000;
-          const backoffDelay = Math.min(
-            this.reconnectDelayMs * Math.pow(2, Math.min(this.reconnectAttempts - 1, 6)) + Math.floor(Math.random() * this.reconnectDelayMs / 2),
-            backoffCap,
+          // Exponential backoff with jitter — factored into computeReconnectBackoffMs
+          // so tests can pin the formula and callers can override cap/jitter via
+          // CDPClientOptions (see #real-browser-mcp idiom).
+          const modeDefaultCap = this.maxReconnectAttempts === Infinity ? 60_000 : 30_000;
+          const cap = this.reconnectBackoffCapMs ?? modeDefaultCap;
+          const backoffDelay = computeReconnectBackoffMs(
+            this.reconnectAttempts,
+            this.reconnectDelayMs,
+            cap,
+            this.reconnectJitterRatio,
           );
           this.reconnectNextRetryAt = Date.now() + backoffDelay;
-          console.error(`[CDPClient] Waiting ${backoffDelay}ms before next attempt (exponential backoff)...`);
+          // Advertise the next-attempt ETA before we sleep so observers can render
+          // a countdown without polling estimatedRetryMs().
+          this.emitConnectionEvent({
+            type: 'reconnecting',
+            timestamp: Date.now(),
+            attempt: this.reconnectAttempts + 1,
+            nextRetryAt: this.reconnectNextRetryAt,
+            backoffMs: backoffDelay,
+          });
+          console.error(`[CDPClient] Waiting ${backoffDelay}ms before next attempt (exponential backoff, cap=${cap}ms, jitter=${this.reconnectJitterRatio})...`);
           await new Promise(resolve => setTimeout(resolve, backoffDelay));
           if (this.disconnectRequested) {
             return;

--- a/src/cdp/tab-health-monitor.ts
+++ b/src/cdp/tab-health-monitor.ts
@@ -45,6 +45,19 @@ export interface TabHealthMonitorOptions {
   evictionThreshold?: number;
   /** Idle-state source. Defaults to the process-global singleton. */
   idleState?: IdleState;
+  /**
+   * Consecutive failures before attempting an in-place `page.reload()`
+   * self-heal, sitting between `unhealthyThreshold` and `evictionThreshold`.
+   * Set to 0 to disable self-heal entirely (revert to the historical
+   * unhealthy → evict progression). Default: `unhealthyThreshold + 1`
+   * (i.e. one attempt to reload before we start counting toward eviction).
+   *
+   * Inspired by real-browser-mcp (MIT) which retries the failing surface
+   * once before tearing it down, and by the Stagehand self-heal loop.
+   */
+  selfHealThreshold?: number;
+  /** Timeout for the self-heal `page.reload()` call (ms). Default: 10000 (10s). */
+  selfHealTimeoutMs?: number;
 }
 
 interface TabMonitorState {
@@ -61,7 +74,11 @@ export class TabHealthMonitor extends EventEmitter {
   private readonly probeTimeoutMs: number;
   private readonly unhealthyThreshold: number;
   private readonly evictionThreshold: number;
+  private readonly selfHealThreshold: number;
+  private readonly selfHealTimeoutMs: number;
   private readonly idleState: IdleState;
+  /** Per-tab flag: have we already tried a self-heal reload this failure streak. */
+  private readonly selfHealAttempted: Map<string, boolean> = new Map();
 
   /**
    * Per-tab timestamp (ms) when retainedBytes first exceeded the pressure
@@ -78,6 +95,14 @@ export class TabHealthMonitor extends EventEmitter {
     this.probeTimeoutMs = opts?.probeTimeoutMs ?? 5000;
     this.unhealthyThreshold = opts?.unhealthyThreshold ?? 3;
     this.evictionThreshold = opts?.evictionThreshold ?? 5;
+    // selfHealThreshold sits strictly between unhealthy and eviction: at
+    // exactly this failure count we attempt one page.reload() before further
+    // failures push the tab into eviction. Set to 0 to disable.
+    const requestedSelfHeal = opts?.selfHealThreshold ?? (this.unhealthyThreshold + 1);
+    this.selfHealThreshold = requestedSelfHeal > 0
+      ? Math.min(Math.max(requestedSelfHeal, this.unhealthyThreshold + 1), this.evictionThreshold - 1)
+      : 0;
+    this.selfHealTimeoutMs = opts?.selfHealTimeoutMs ?? 10_000;
     this.idleState = opts?.idleState ?? getIdleState();
   }
 
@@ -115,6 +140,7 @@ export class TabHealthMonitor extends EventEmitter {
     this.health.delete(targetId);
     this.pressureOnsetAt.delete(targetId);
     this.pressureFired.delete(targetId);
+    this.selfHealAttempted.delete(targetId);
   }
 
   /**
@@ -174,6 +200,9 @@ export class TabHealthMonitor extends EventEmitter {
       info.status = 'healthy';
       info.consecutiveFailures = 0;
       info.lastHealthyAt = now;
+      // Recovering to healthy resets the self-heal budget so a future streak
+      // can attempt reload again.
+      this.selfHealAttempted.delete(targetId);
       this.emit('tab-healthy', { targetId });
       this.checkBufferPressure(targetId, now);
     } catch (error) {
@@ -186,6 +215,20 @@ export class TabHealthMonitor extends EventEmitter {
         // to prevent zombie renderer processes in Chrome.
         this.emit('tab-evict', { targetId, consecutiveFailures: info.consecutiveFailures });
         this.unmonitorTab(targetId); // stop monitoring evicted tab
+      } else if (
+        this.selfHealThreshold > 0
+        && info.consecutiveFailures >= this.selfHealThreshold
+        && !this.selfHealAttempted.get(targetId)
+      ) {
+        // Between unhealthy and eviction we get one shot at recovering the tab
+        // in-place via page.reload() (real-browser-mcp idiom). The attempt is
+        // async but non-blocking for the probe loop — we mark the tab so we
+        // do not retry on every subsequent probe, and let the next probe
+        // observe whether the reload made the renderer responsive again.
+        this.selfHealAttempted.set(targetId, true);
+        console.error(`[TabHealthMonitor] Tab ${targetId} attempting self-heal reload (strike ${info.consecutiveFailures}/${this.evictionThreshold})`);
+        this.emit('tab-self-heal', { targetId, failures: info.consecutiveFailures });
+        void this.attemptSelfHeal(targetId, page);
       } else if (info.consecutiveFailures >= this.unhealthyThreshold) {
         info.status = 'unhealthy';
         console.error(`[TabHealthMonitor] Tab ${targetId} marked unhealthy (${info.consecutiveFailures} failures)`);
@@ -194,6 +237,31 @@ export class TabHealthMonitor extends EventEmitter {
         console.error(`[TabHealthMonitor] Tab ${targetId} probe failed (strike ${info.consecutiveFailures}/${this.unhealthyThreshold}):`,
           error instanceof Error ? error.message : String(error));
       }
+    }
+  }
+
+  /**
+   * Attempt one in-place recovery of a failing tab via `page.reload()`.
+   * Errors are swallowed intentionally — the next probe will observe whether
+   * the renderer became responsive again. If reload throws, the failure count
+   * simply keeps climbing toward the eviction threshold.
+   */
+  private async attemptSelfHeal(targetId: string, page: Page): Promise<void> {
+    let tid: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        page.reload({ timeout: this.selfHealTimeoutMs }).finally(() => { if (tid) clearTimeout(tid); }),
+        new Promise<never>((_, reject) => {
+          tid = setTimeout(
+            () => reject(new Error(`self-heal reload timeout after ${this.selfHealTimeoutMs}ms`)),
+            this.selfHealTimeoutMs,
+          );
+        }),
+      ]);
+      console.error(`[TabHealthMonitor] Tab ${targetId} self-heal reload completed; waiting for next probe to confirm health.`);
+    } catch (err) {
+      console.error(`[TabHealthMonitor] Tab ${targetId} self-heal reload failed:`,
+        err instanceof Error ? err.message : String(err));
     }
   }
 

--- a/tests/cdp/reconnect-backoff.test.ts
+++ b/tests/cdp/reconnect-backoff.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for the exponential-backoff formula that drives CDP
+ * reconnection. Pins the formula so future refactors do not silently
+ * change reconnect timing behaviour.
+ */
+
+import { computeReconnectBackoffMs } from '../../src/cdp/client';
+
+describe('computeReconnectBackoffMs', () => {
+  // Deterministic RNG: always returns 0 → jitter = 0.
+  const zeroRandom = () => 0;
+  // Deterministic RNG: returns 0.5 → half of the jitter window.
+  const halfRandom = () => 0.5;
+
+  it('attempt 1 is the base delay with zero jitter', () => {
+    expect(computeReconnectBackoffMs(1, 1000, 30_000, 0, zeroRandom)).toBe(1000);
+  });
+
+  it('doubles the delay per attempt (jitter=0)', () => {
+    expect(computeReconnectBackoffMs(1, 1000, 30_000, 0, zeroRandom)).toBe(1000);
+    expect(computeReconnectBackoffMs(2, 1000, 30_000, 0, zeroRandom)).toBe(2000);
+    expect(computeReconnectBackoffMs(3, 1000, 30_000, 0, zeroRandom)).toBe(4000);
+    expect(computeReconnectBackoffMs(4, 1000, 30_000, 0, zeroRandom)).toBe(8000);
+    expect(computeReconnectBackoffMs(5, 1000, 30_000, 0, zeroRandom)).toBe(16000);
+  });
+
+  it('caps at the provided ceiling', () => {
+    // 1000 * 2^6 = 64000, capped at 30_000
+    expect(computeReconnectBackoffMs(7, 1000, 30_000, 0, zeroRandom)).toBe(30_000);
+    // Also caps for the infinite-mode default of 60_000
+    expect(computeReconnectBackoffMs(7, 1000, 60_000, 0, zeroRandom)).toBe(60_000);
+  });
+
+  it('caps the exponent at 6 so infinite reconnect stays bounded', () => {
+    // With no cap and jitter=0, attempt 100 should still yield 1000 * 2^6.
+    const noCap = Number.MAX_SAFE_INTEGER;
+    expect(computeReconnectBackoffMs(100, 1000, noCap, 0, zeroRandom)).toBe(64_000);
+    expect(computeReconnectBackoffMs(1000, 1000, noCap, 0, zeroRandom)).toBe(64_000);
+  });
+
+  it('jitter adds up to (base * jitterRatio) with random()=0.5', () => {
+    // base=1000, jitterRatio=0.5, random=0.5 → jitter = floor(0.5*1000*0.5) = 250
+    expect(computeReconnectBackoffMs(1, 1000, 30_000, 0.5, halfRandom)).toBe(1250);
+    expect(computeReconnectBackoffMs(2, 1000, 30_000, 0.5, halfRandom)).toBe(2250);
+  });
+
+  it('jitter=0 yields fully deterministic timing (test-friendly)', () => {
+    for (const attempt of [1, 2, 3, 4, 5, 6, 7, 8]) {
+      const a = computeReconnectBackoffMs(attempt, 500, 30_000, 0, zeroRandom);
+      const b = computeReconnectBackoffMs(attempt, 500, 30_000, 0, zeroRandom);
+      expect(a).toBe(b);
+    }
+  });
+
+  it('handles attempt < 1 defensively (clamps to 1)', () => {
+    expect(computeReconnectBackoffMs(0, 1000, 30_000, 0, zeroRandom)).toBe(1000);
+    expect(computeReconnectBackoffMs(-5, 1000, 30_000, 0, zeroRandom)).toBe(1000);
+  });
+});

--- a/tests/cdp/tab-health-monitor.test.ts
+++ b/tests/cdp/tab-health-monitor.test.ts
@@ -191,6 +191,75 @@ describe('TabHealthMonitor', () => {
     monitor.stopAll();
   });
 
+  test('attempts one self-heal reload between unhealthy and eviction', async () => {
+    const reload = jest.fn().mockResolvedValue(undefined);
+    const evaluate = jest.fn().mockRejectedValue(new Error('renderer crashed'));
+    const page = { evaluate, reload } as unknown as Page;
+
+    monitor = new TabHealthMonitor({
+      probeIntervalMs: 30,
+      probeTimeoutMs: 10,
+      unhealthyThreshold: 2,
+      selfHealThreshold: 3,
+      evictionThreshold: 5,
+      selfHealTimeoutMs: 200,
+    });
+
+    const selfHealHandler = jest.fn();
+    const evictHandler = jest.fn();
+    monitor.on('tab-self-heal', selfHealHandler);
+    monitor.on('tab-evict', evictHandler);
+
+    monitor.monitorTab('tab1', page);
+
+    // Wait for self-heal to fire (at strike 3), then eviction (at strike 5).
+    await waitFor(() => selfHealHandler.mock.calls.length > 0);
+    expect(selfHealHandler).toHaveBeenCalledTimes(1);
+    // reload should have been called by attemptSelfHeal.
+    await waitFor(() => reload.mock.calls.length > 0);
+
+    // Even as failures continue, self-heal must not re-fire (one shot per streak).
+    await waitFor(() => evictHandler.mock.calls.length > 0);
+    expect(selfHealHandler).toHaveBeenCalledTimes(1);
+    expect(evictHandler).toHaveBeenCalledTimes(1);
+
+    monitor.stopAll();
+  });
+
+  test('self-heal budget resets after a successful probe', async () => {
+    // Fail 3 times → self-heal fires → next probe succeeds → tab healthy.
+    // If failures resume, self-heal must fire again (new streak).
+    let calls = 0;
+    const reload = jest.fn().mockResolvedValue(undefined);
+    const evaluate = jest.fn().mockImplementation(async () => {
+      calls++;
+      // Fail 3, succeed 1, then fail forever.
+      if (calls <= 3) throw new Error('crashed');
+      if (calls === 4) return 1;
+      throw new Error('crashed again');
+    });
+    const page = { evaluate, reload } as unknown as Page;
+
+    monitor = new TabHealthMonitor({
+      probeIntervalMs: 20,
+      probeTimeoutMs: 10,
+      unhealthyThreshold: 2,
+      selfHealThreshold: 3,
+      evictionThreshold: 6,
+      selfHealTimeoutMs: 200,
+    });
+
+    const selfHealHandler = jest.fn();
+    monitor.on('tab-self-heal', selfHealHandler);
+
+    monitor.monitorTab('tab1', page);
+    // First streak → self-heal, then recovery, then second streak → self-heal again.
+    await waitFor(() => selfHealHandler.mock.calls.length >= 2, { timeoutMs: 5000 });
+    expect(selfHealHandler.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+    monitor.stopAll();
+  });
+
   test('probe timeout detects hanging renderer', async () => {
     monitor = new TabHealthMonitor({
       probeIntervalMs: 30,


### PR DESCRIPTION
## 요약

두 개의 관련된 상신 층 개선을 하나의 팩으로 묶었습니다.

1. **CDPClient** 재연결 지수백오프의 cap과 jitter를 튜너블 옵션으로 노출하고, 재시도 사이 sleep에 앞서 `nextRetryAt`/`backoffMs` 필드를 담은 `reconnecting` 이벤트를 발행합니다.
2. **TabHealthMonitor**의 unhealthy와 eviction 사이에 `page.reload()` self-heal 단계를 추가합니다. 일시적 renderer 스톨은 tab을 tear-down하기 전에 한 번 회복 시도를 갖습니다.

## 근거

Sonar의 openchrome 상류 기여 재판정(v2)의 **P13** 팩입니다. 90개 오픈소스 전수조사에서 아래 원리를 이식하는 것으로 판정되었습니다.

- **real-browser-mcp (MIT)** — long-running headed session에서 지수백오프의 cap을 튜너블하게 노출하고, 재시도 사이 발행하는 이벤트에 다음 시도 ETA를 포함해 UI가 poll 없이 카운트다운을 렌더링할 수 있게 하는 관용구.
- **real-browser-mcp (MIT)** + **Stagehand self-heal (MIT)** — 실패한 리소스(tab, action) 자체를 tear-down 전에 한 번 재시도하는 원리. 이 팩은 그 원리를 tab health monitor에 적용합니다.

원본 소스는 복사하지 않았습니다. 두 원리 모두 clean-room 재구현입니다.

## 변경 내용

### `src/cdp/client.ts` (+141 라인)

- `CDPClientOptions`에 `reconnectBackoffCapMs`, `reconnectJitterRatio` 필드 추가. 각각 `OPENCHROME_RECONNECT_BACKOFF_CAP_MS`, `OPENCHROME_RECONNECT_JITTER_RATIO` 환경변수와 매핑.
- 기존 인라인 backoff 계산을 exported `computeReconnectBackoffMs(attempt, base, cap, jitterRatio, random)`로 factor out. 지수 clamp를 6으로 유지해 `Number` overflow 방지. `jitterRatio=0`은 fully deterministic (테스트 친화).
- `ConnectionEvent`에 optional `nextRetryAt` (ms since epoch)과 `backoffMs` 추가. `reconnecting` 이벤트 발행 시점을 sleep 이전으로 옮겨 observers가 poll 없이 카운트다운을 렌더링할 수 있음.
- 기존 consumers는 `event.type` branch만 보면 되므로 breaking change 없음.

### `src/cdp/tab-health-monitor.ts` (+68 라인)

- `TabHealthMonitorOptions`에 `selfHealThreshold`, `selfHealTimeoutMs` 추가. 기본값 = `unhealthyThreshold + 1`, 10초. `selfHealThreshold=0`으로 비활성화 가능.
- selfHealThreshold를 `[unhealthyThreshold+1, evictionThreshold-1]` 범위로 clamp해서 두 임계 지점을 skip할 수 없음.
- 실패 스트릭이 selfHealThreshold에 도달하면 `page.reload()`를 한 번 dispatch. dispatch는 async·non-blocking이므로 probe 루프 timing은 유지. 다음 probe가 renderer 반응성 회복 여부를 판정.
- 성공 probe는 `selfHealAttempted` 플래그를 clear해서 미래의 스트릭이 새 self-heal 예산을 갖도록 함.
- 새 이벤트: `tab-self-heal { targetId, failures }`. `tab-unhealthy` / `tab-evict` 시맨틱은 그대로.

## 참고 원본

- real-browser-mcp — https://github.com/imprvhub/mcp-real-browser (MIT). 튜너블 backoff cap과 재시도 ETA 이벤트 관용구.
- Stagehand — https://github.com/browserbase/stagehand (MIT). 실패한 리소스 자체를 한 번 self-heal하는 원리.
- 두 원본 모두 코드 미열람 clean-room. 각 파일 상단·인라인 주석에 origin credit 있음.

## 테스트

새 테스트 파일 2개 · 총 9개 케이스 추가. 기존 테스트 18개 모두 통과.

- `tests/cdp/reconnect-backoff.test.ts` (7 케이스) — `computeReconnectBackoffMs` 공식 pin. base delay, 지수 배수, cap clamp, 지수 exponent cap=6, jitter=0.5, jitter=0 determinism, 방어적 attempt<1.
- `tests/cdp/tab-health-monitor.test.ts` (2 신규 케이스) — self-heal이 unhealthy와 eviction 사이에 정확히 1회 발화, 성공 probe 후 self-heal 예산이 리셋되어 새 스트릭에서 다시 발화. 기존 9개 케이스 모두 통과.

빌드:
- `npx tsc -p tsconfig.json --noEmit` — 0 errors.
- `npx jest tests/cdp/tab-health-monitor.test.ts tests/cdp/reconnect-backoff.test.ts` — 18 passed.

## 관련

이 팩은 v2 계획의 **P13** 팩입니다. 다른 4개 팩(P1·P5·P6·P11)이 동시에 별도 PR로 제출됩니다.