### PR TITLE
refactor(stealth): Runtime.enable audit + refuse-by-default policy

### DIFF
--- a/src/stealth/index.ts
+++ b/src/stealth/index.ts
@@ -20,10 +20,10 @@ export {
 
 export {
   ensureRuntimeEnabled,
-  installRuntimeHookHiding,
-  isStealthArtefactEvent,
-  payloadMatchesArtefact,
+  disableRuntime,
+  getGuardStats,
   RuntimeEnableRefusedError,
   type EnsureRuntimeEnabledOptions,
   type StealthEnableMode,
+  type GuardStats,
 } from './runtime-enable-guard';

--- a/src/stealth/index.ts
+++ b/src/stealth/index.ts
@@ -17,3 +17,13 @@ export {
   getStealthFingerprintDefenseScript,
   getStealthStackSanitizationScript,
 } from './fingerprint-defense';
+
+export {
+  ensureRuntimeEnabled,
+  installRuntimeHookHiding,
+  isStealthArtefactEvent,
+  payloadMatchesArtefact,
+  RuntimeEnableRefusedError,
+  type EnsureRuntimeEnabledOptions,
+  type StealthEnableMode,
+} from './runtime-enable-guard';

--- a/src/stealth/runtime-enable-guard.ts
+++ b/src/stealth/runtime-enable-guard.ts
@@ -1,44 +1,53 @@
 /**
- * Runtime.enable Leak Guard — patchright idiom, clean-room port.
+ * Runtime.enable audit + minimal-window policy for stealth targets.
  *
- * Why this exists
- * ---------------
- * Sending `Runtime.enable` on a CDP session creates observable side effects
- * in the target renderer: it materialises an execution context object,
- * starts firing `Runtime.executionContextCreated` events, and — most
- * importantly for stealth — makes `console.debug` calls arrive as
- * `Runtime.consoleAPICalled` events which enterprise anti-bot vendors
- * (Radware, Akamai Bot Manager, PerimeterX, DataDome) probe for.
+ * Honest scope
+ * ------------
+ * Sending `Runtime.enable` on a CDP session has renderer-observable side
+ * effects: it materialises an execution context, starts firing
+ * `Runtime.executionContextCreated` events, and — most importantly for
+ * stealth — makes `console.debug` serialisation walk target objects, which
+ * enterprise anti-bot vendors (Radware, Akamai Bot Manager, PerimeterX,
+ * DataDome) probe for.
  *
- * The classic detection sequence is:
- *   1. Page ships a poisoned `Object.getOwnPropertyDescriptor` proxy that
- *      logs to `console.debug` when accessed on `navigator`.
- *   2. If `Runtime.enable` is already active, the CDP client's serialisation
- *      of the log payload (which walks the target object) triggers the
- *      proxy synchronously and the vendor's script sees the trace.
- *   3. Absent `Runtime.enable`, the same access is invisible.
+ * **This module does NOT prevent that leak.** Both `console_capture` and
+ * `validate_page` fundamentally require the Runtime domain to be enabled
+ * to do their job (capture console events, catch exceptions). Client-side
+ * event filtering after the fact is theatre — by the time we filter, the
+ * renderer has already fired the events the vendor script sees.
  *
- * patchright's fix (Apache-2.0): defer `Runtime.enable` until the caller
- * proves it actually needs live console/exception events, and never enable
- * it implicitly during page bootstrap. openchrome already avoids the
- * implicit path (rebrowser-puppeteer-core skips `Runtime.enable`) but has
- * no gate on the explicit path — `console_capture` and `validate_page`
- * both call `Runtime.enable` unconditionally, defeating stealth mode.
+ * What this module DOES provide:
  *
- * This module adds a two-part gate:
- *   1. `ensureRuntimeEnabled(session, opts)` — the only sanctioned way to
- *      enable Runtime on a CDP session. In non-stealth mode it's a passthrough;
- *      in stealth mode it either refuses (default) or enables with the
- *      leak-hiding preload applied first.
- *   2. `installRuntimeHookHiding(session)` — patches
- *      `Runtime.consoleAPICalled` payloads so common CDP-artefact fingerprints
- *      (`__pptr__`, `pptr:evaluateHandle`, injected wrappers) are filtered
- *      out of the events the caller sees, matching patchright's stack
- *      sanitisation but at the CDP boundary rather than in-page.
+ *   1. **Single choke point.** `ensureRuntimeEnabled` is the only sanctioned
+ *      way to send `Runtime.enable` on a stealth-flagged target. Direct
+ *      `session.send('Runtime.enable')` calls in stealth-touching tools are
+ *      an audit finding.
  *
- * All origin credit goes to the patchright project (Apache-2.0). Their
- * source was not copied; this is a clean-room implementation of the
- * documented idiom.
+ *   2. **Refuse-by-default in stealth.** An operator must consciously pass
+ *      `stealthMode: 'allow'` to accept the leak. The refusal error names
+ *      the caller so leaks are traceable.
+ *
+ *   3. **Minimal-window contract.** Every `ensureRuntimeEnabled` must be
+ *      paired with `disableRuntime(session)` when the caller no longer
+ *      needs live events. Callers are audited on this: `getGuardStats()`
+ *      exposes counters test/monitoring code uses to prove enable calls are
+ *      matched by disables. See `tests/stealth/runtime-enable-guard.integration.test.ts`.
+ *
+ * What was removed vs. earlier drafts
+ * -----------------------------------
+ * A `'shield'` mode that installed a client-side `Runtime.consoleAPICalled`
+ * filter used to live here. It was removed because it did not defend
+ * against the renderer-side leak it claimed to defend against — it only
+ * filtered payloads that had already reached the CDP client. Keeping it
+ * around encouraged operators to opt into stealth-mode Runtime.enable
+ * believing they were shielded, which is worse than refusing outright.
+ *
+ * Origin credit: the `Runtime.enable` deferral idiom is from patchright
+ * (Apache-2.0). This module is a narrower, honest port — patchright's
+ * upstream can defer/batch because Playwright abstracts enable per-frame;
+ * openchrome's tool surface exposes `console_capture` as a persistent
+ * capture, so the same deferral is not architecturally available. The
+ * honest posture is: audit + refuse-by-default + minimal window.
  */
 
 import type { CDPSession } from 'puppeteer-core';
@@ -46,25 +55,27 @@ import type { CDPSession } from 'puppeteer-core';
 export type StealthEnableMode =
   /** Refuse Runtime.enable in stealth mode; caller must opt in explicitly. */
   | 'refuse'
-  /** Enable Runtime.enable but install the CDP-hook hiding filter first. */
-  | 'shield'
-  /** Enable Runtime.enable with no shielding — leaks are the caller's choice. */
+  /** Enable Runtime.enable and accept the renderer-side leak. */
   | 'allow';
 
 export interface EnsureRuntimeEnabledOptions {
-  /**
-   * Whether the target is a stealth session (opened via
-   * SessionManager.isStealthTarget or otherwise flagged). Controls whether
-   * `stealthMode` gates apply.
-   */
+  /** Is the target flagged stealth (SessionManager.isStealthTarget)? */
   isStealthTarget: boolean;
   /** How to behave in stealth mode. Ignored when `isStealthTarget=false`. */
   stealthMode?: StealthEnableMode;
-  /**
-   * Human-readable caller name for the "refused" error message. Helps
-   * operators pinpoint which tool tried to enable Runtime.
-   */
+  /** Caller name for audit + error diagnostics. */
   callerId?: string;
+}
+
+export interface GuardStats {
+  /** Total ensureRuntimeEnabled calls that resulted in Runtime.enable being sent. */
+  enableCalls: number;
+  /** Total disableRuntime calls that resulted in Runtime.disable being sent. */
+  disableCalls: number;
+  /** Total ensureRuntimeEnabled calls refused (throws RuntimeEnableRefusedError). */
+  refusals: number;
+  /** Per-caller enable counts, keyed by callerId. */
+  byCaller: Record<string, { enables: number; disables: number; refusals: number }>;
 }
 
 export class RuntimeEnableRefusedError extends Error {
@@ -72,109 +83,92 @@ export class RuntimeEnableRefusedError extends Error {
   constructor(callerId: string) {
     super(
       `[stealth] Refused to send Runtime.enable on a stealth target ` +
-        `(caller="${callerId}"). Runtime.enable exposes execution-context ` +
-        `and consoleAPICalled events that enterprise anti-bot vendors probe ` +
-        `for. If you accept the leak trade-off, pass stealthMode="shield" ` +
-        `or "allow" to ensureRuntimeEnabled().`,
+        `(caller="${callerId}"). Runtime.enable has renderer-observable ` +
+        `side effects that enterprise anti-bot vendors probe for; this ` +
+        `module does not shield them. To accept the leak, pass ` +
+        `stealthMode="allow" to ensureRuntimeEnabled().`,
     );
     this.name = 'RuntimeEnableRefusedError';
   }
 }
 
+const stats: GuardStats = {
+  enableCalls: 0,
+  disableCalls: 0,
+  refusals: 0,
+  byCaller: {},
+};
+
+function bumpCaller(callerId: string, key: 'enables' | 'disables' | 'refusals'): void {
+  const slot = stats.byCaller[callerId] ?? { enables: 0, disables: 0, refusals: 0 };
+  slot[key] += 1;
+  stats.byCaller[callerId] = slot;
+}
+
 /**
- * The only sanctioned way to send `Runtime.enable`. Non-stealth targets are
- * always enabled (unchanged behaviour). Stealth targets:
- *   - `refuse` (default): throws RuntimeEnableRefusedError.
- *   - `shield`: installs hook-hiding filter, then enables.
- *   - `allow`: enables without shielding.
+ * The only sanctioned way to send `Runtime.enable`.
  *
- * Idempotent: safe to call multiple times on the same session. The second
- * call to `Runtime.enable` is a no-op inside Chrome.
+ * Non-stealth targets: passthrough (unchanged behaviour).
+ * Stealth targets:
+ *   - `refuse` (default): throws RuntimeEnableRefusedError. No enable is sent.
+ *   - `allow`: sends Runtime.enable and accepts the renderer-side leak.
+ *
+ * Idempotent per Chrome semantics — a second `Runtime.enable` is a no-op
+ * inside the browser, but each call is still counted for audit purposes so
+ * callers who enable-in-a-loop are visible.
  */
 export async function ensureRuntimeEnabled(
   session: CDPSession,
   opts: EnsureRuntimeEnabledOptions,
 ): Promise<void> {
+  const callerId = opts.callerId ?? 'unknown';
   const mode: StealthEnableMode = opts.isStealthTarget ? (opts.stealthMode ?? 'refuse') : 'allow';
 
   if (mode === 'refuse') {
-    throw new RuntimeEnableRefusedError(opts.callerId ?? 'unknown');
-  }
-
-  if (mode === 'shield') {
-    await installRuntimeHookHiding(session);
+    stats.refusals += 1;
+    bumpCaller(callerId, 'refusals');
+    throw new RuntimeEnableRefusedError(callerId);
   }
 
   await session.send('Runtime.enable');
+  stats.enableCalls += 1;
+  bumpCaller(callerId, 'enables');
 }
 
 /**
- * Install a CDP-side filter that suppresses `Runtime.consoleAPICalled`
- * events whose payloads reveal CDP/Puppeteer artefacts. Runs before
- * `Runtime.enable` so no leaky event is delivered even for the initial
- * context.
- *
- * Filter is best-effort — if the CDP session cannot subscribe (session
- * closing, target already gone), the function throws so the caller can
- * decide whether to proceed without the shield.
+ * The paired disable. Callers MUST call this once they no longer need live
+ * Runtime events, minimising the enable-window. Best-effort — a detached
+ * or crashed session yields no error.
  */
-export async function installRuntimeHookHiding(session: CDPSession): Promise<void> {
-  // The vendor detection payloads we filter out. Kept in sync with the
-  // in-page stack sanitiser (`getStealthStackSanitizationScript`) so the
-  // two layers block the same fingerprint set from different sides.
-  const CDP_ARTIFACT_PATTERNS = [
-    '__pptr__',
-    '__puppeteer',
-    'pptr:evaluate',
-    'pptr:evaluateHandle',
-    'evaluateOnNewDocument',
-    'DevTools',
-    'debugger eval',
-  ];
-
-  session.on('Runtime.consoleAPICalled', (event: unknown) => {
-    const shouldSuppress = payloadMatchesArtefact(event, CDP_ARTIFACT_PATTERNS);
-    if (shouldSuppress) {
-      // We cannot un-emit an event that the CDP session already dispatched
-      // to other listeners registered before ours, but we can tag it so
-      // downstream openchrome listeners (console-capture, validate-page)
-      // skip artefact payloads. Downstream code should check
-      // `Object.getPrototypeOf(event) === CDP_ARTEFACT_MARKER` to filter.
-      Object.defineProperty(event as object, '__oc_stealth_artefact__', {
-        value: true,
-        enumerable: false,
-      });
-    }
-  });
-}
-
-/**
- * Returns true if the payload's serialised representation contains any of
- * the CDP-artefact patterns. Kept small and synchronous so the filter runs
- * inline in the event handler. Exported for tests and cross-module reuse.
- */
-export function payloadMatchesArtefact(payload: unknown, patterns: string[]): boolean {
-  let serialised: string;
+export async function disableRuntime(
+  session: CDPSession,
+  opts: { callerId?: string } = {},
+): Promise<void> {
+  const callerId = opts.callerId ?? 'unknown';
   try {
-    serialised = JSON.stringify(payload);
+    await session.send('Runtime.disable');
   } catch {
-    return false;
+    // Session may be gone — swallow so callers can chain in cleanup paths.
+    return;
   }
-  for (const pattern of patterns) {
-    if (serialised.indexOf(pattern) !== -1) return true;
-  }
-  return false;
+  stats.disableCalls += 1;
+  bumpCaller(callerId, 'disables');
 }
 
-/**
- * Downstream consumers use this predicate to skip events tagged by the
- * shield. Keeps the tag name in one place.
- */
-export function isStealthArtefactEvent(event: unknown): boolean {
-  return !!(event && typeof event === 'object' && (event as Record<string, unknown>)['__oc_stealth_artefact__']);
+/** Snapshot audit counters. Read-only from the caller's perspective. */
+export function getGuardStats(): GuardStats {
+  return {
+    enableCalls: stats.enableCalls,
+    disableCalls: stats.disableCalls,
+    refusals: stats.refusals,
+    byCaller: JSON.parse(JSON.stringify(stats.byCaller)),
+  };
 }
 
-/** For unit tests — reset any module-level state. Currently a no-op. */
-export const __testing = {
-  payloadMatchesArtefact,
-};
+/** For tests — reset audit counters. */
+export function __resetGuardStatsForTest(): void {
+  stats.enableCalls = 0;
+  stats.disableCalls = 0;
+  stats.refusals = 0;
+  stats.byCaller = {};
+}

--- a/src/stealth/runtime-enable-guard.ts
+++ b/src/stealth/runtime-enable-guard.ts
@@ -1,0 +1,180 @@
+/**
+ * Runtime.enable Leak Guard — patchright idiom, clean-room port.
+ *
+ * Why this exists
+ * ---------------
+ * Sending `Runtime.enable` on a CDP session creates observable side effects
+ * in the target renderer: it materialises an execution context object,
+ * starts firing `Runtime.executionContextCreated` events, and — most
+ * importantly for stealth — makes `console.debug` calls arrive as
+ * `Runtime.consoleAPICalled` events which enterprise anti-bot vendors
+ * (Radware, Akamai Bot Manager, PerimeterX, DataDome) probe for.
+ *
+ * The classic detection sequence is:
+ *   1. Page ships a poisoned `Object.getOwnPropertyDescriptor` proxy that
+ *      logs to `console.debug` when accessed on `navigator`.
+ *   2. If `Runtime.enable` is already active, the CDP client's serialisation
+ *      of the log payload (which walks the target object) triggers the
+ *      proxy synchronously and the vendor's script sees the trace.
+ *   3. Absent `Runtime.enable`, the same access is invisible.
+ *
+ * patchright's fix (Apache-2.0): defer `Runtime.enable` until the caller
+ * proves it actually needs live console/exception events, and never enable
+ * it implicitly during page bootstrap. openchrome already avoids the
+ * implicit path (rebrowser-puppeteer-core skips `Runtime.enable`) but has
+ * no gate on the explicit path — `console_capture` and `validate_page`
+ * both call `Runtime.enable` unconditionally, defeating stealth mode.
+ *
+ * This module adds a two-part gate:
+ *   1. `ensureRuntimeEnabled(session, opts)` — the only sanctioned way to
+ *      enable Runtime on a CDP session. In non-stealth mode it's a passthrough;
+ *      in stealth mode it either refuses (default) or enables with the
+ *      leak-hiding preload applied first.
+ *   2. `installRuntimeHookHiding(session)` — patches
+ *      `Runtime.consoleAPICalled` payloads so common CDP-artefact fingerprints
+ *      (`__pptr__`, `pptr:evaluateHandle`, injected wrappers) are filtered
+ *      out of the events the caller sees, matching patchright's stack
+ *      sanitisation but at the CDP boundary rather than in-page.
+ *
+ * All origin credit goes to the patchright project (Apache-2.0). Their
+ * source was not copied; this is a clean-room implementation of the
+ * documented idiom.
+ */
+
+import type { CDPSession } from 'puppeteer-core';
+
+export type StealthEnableMode =
+  /** Refuse Runtime.enable in stealth mode; caller must opt in explicitly. */
+  | 'refuse'
+  /** Enable Runtime.enable but install the CDP-hook hiding filter first. */
+  | 'shield'
+  /** Enable Runtime.enable with no shielding — leaks are the caller's choice. */
+  | 'allow';
+
+export interface EnsureRuntimeEnabledOptions {
+  /**
+   * Whether the target is a stealth session (opened via
+   * SessionManager.isStealthTarget or otherwise flagged). Controls whether
+   * `stealthMode` gates apply.
+   */
+  isStealthTarget: boolean;
+  /** How to behave in stealth mode. Ignored when `isStealthTarget=false`. */
+  stealthMode?: StealthEnableMode;
+  /**
+   * Human-readable caller name for the "refused" error message. Helps
+   * operators pinpoint which tool tried to enable Runtime.
+   */
+  callerId?: string;
+}
+
+export class RuntimeEnableRefusedError extends Error {
+  readonly code = 'runtime_enable_refused';
+  constructor(callerId: string) {
+    super(
+      `[stealth] Refused to send Runtime.enable on a stealth target ` +
+        `(caller="${callerId}"). Runtime.enable exposes execution-context ` +
+        `and consoleAPICalled events that enterprise anti-bot vendors probe ` +
+        `for. If you accept the leak trade-off, pass stealthMode="shield" ` +
+        `or "allow" to ensureRuntimeEnabled().`,
+    );
+    this.name = 'RuntimeEnableRefusedError';
+  }
+}
+
+/**
+ * The only sanctioned way to send `Runtime.enable`. Non-stealth targets are
+ * always enabled (unchanged behaviour). Stealth targets:
+ *   - `refuse` (default): throws RuntimeEnableRefusedError.
+ *   - `shield`: installs hook-hiding filter, then enables.
+ *   - `allow`: enables without shielding.
+ *
+ * Idempotent: safe to call multiple times on the same session. The second
+ * call to `Runtime.enable` is a no-op inside Chrome.
+ */
+export async function ensureRuntimeEnabled(
+  session: CDPSession,
+  opts: EnsureRuntimeEnabledOptions,
+): Promise<void> {
+  const mode: StealthEnableMode = opts.isStealthTarget ? (opts.stealthMode ?? 'refuse') : 'allow';
+
+  if (mode === 'refuse') {
+    throw new RuntimeEnableRefusedError(opts.callerId ?? 'unknown');
+  }
+
+  if (mode === 'shield') {
+    await installRuntimeHookHiding(session);
+  }
+
+  await session.send('Runtime.enable');
+}
+
+/**
+ * Install a CDP-side filter that suppresses `Runtime.consoleAPICalled`
+ * events whose payloads reveal CDP/Puppeteer artefacts. Runs before
+ * `Runtime.enable` so no leaky event is delivered even for the initial
+ * context.
+ *
+ * Filter is best-effort — if the CDP session cannot subscribe (session
+ * closing, target already gone), the function throws so the caller can
+ * decide whether to proceed without the shield.
+ */
+export async function installRuntimeHookHiding(session: CDPSession): Promise<void> {
+  // The vendor detection payloads we filter out. Kept in sync with the
+  // in-page stack sanitiser (`getStealthStackSanitizationScript`) so the
+  // two layers block the same fingerprint set from different sides.
+  const CDP_ARTIFACT_PATTERNS = [
+    '__pptr__',
+    '__puppeteer',
+    'pptr:evaluate',
+    'pptr:evaluateHandle',
+    'evaluateOnNewDocument',
+    'DevTools',
+    'debugger eval',
+  ];
+
+  session.on('Runtime.consoleAPICalled', (event: unknown) => {
+    const shouldSuppress = payloadMatchesArtefact(event, CDP_ARTIFACT_PATTERNS);
+    if (shouldSuppress) {
+      // We cannot un-emit an event that the CDP session already dispatched
+      // to other listeners registered before ours, but we can tag it so
+      // downstream openchrome listeners (console-capture, validate-page)
+      // skip artefact payloads. Downstream code should check
+      // `Object.getPrototypeOf(event) === CDP_ARTEFACT_MARKER` to filter.
+      Object.defineProperty(event as object, '__oc_stealth_artefact__', {
+        value: true,
+        enumerable: false,
+      });
+    }
+  });
+}
+
+/**
+ * Returns true if the payload's serialised representation contains any of
+ * the CDP-artefact patterns. Kept small and synchronous so the filter runs
+ * inline in the event handler. Exported for tests and cross-module reuse.
+ */
+export function payloadMatchesArtefact(payload: unknown, patterns: string[]): boolean {
+  let serialised: string;
+  try {
+    serialised = JSON.stringify(payload);
+  } catch {
+    return false;
+  }
+  for (const pattern of patterns) {
+    if (serialised.indexOf(pattern) !== -1) return true;
+  }
+  return false;
+}
+
+/**
+ * Downstream consumers use this predicate to skip events tagged by the
+ * shield. Keeps the tag name in one place.
+ */
+export function isStealthArtefactEvent(event: unknown): boolean {
+  return !!(event && typeof event === 'object' && (event as Record<string, unknown>)['__oc_stealth_artefact__']);
+}
+
+/** For unit tests — reset any module-level state. Currently a no-op. */
+export const __testing = {
+  payloadMatchesArtefact,
+};

--- a/src/tools/console-capture.ts
+++ b/src/tools/console-capture.ts
@@ -17,6 +17,11 @@ import { createConsoleRingBuffer, DEFAULT_MAX_LINES, DEFAULT_MAX_BYTES } from '.
 import type { ConsoleRingBuffer, ConsoleRingBufferStats } from '../core/console-buffer/types';
 import { paginate } from '../utils/paginate';
 import { areBoundaryMarkersEnabled, wrapBoundaryMarker } from '../core/perception/boundary-markers';
+import {
+  ensureRuntimeEnabled,
+  isStealthArtefactEvent,
+  RuntimeEnableRefusedError,
+} from '../stealth/runtime-enable-guard';
 
 /**
  * Validate caller-supplied cap values. Used to reject `maxLogs`/`maxBytes`
@@ -345,8 +350,45 @@ const handler: ToolHandler = async (
         // so we receive consoleAPICalled and exceptionThrown events.
         // rebrowser-puppeteer-core skips Runtime.enable by default,
         // so Puppeteer's page.on('console') never fires.
+        //
+        // Stealth targets (opened via session-manager stealth navigation)
+        // route through ensureRuntimeEnabled so operators must consciously
+        // accept the leak trade-off. Non-stealth targets are unaffected —
+        // ensureRuntimeEnabled is a passthrough. See P6 in the
+        // openchrome contribution plan for the patchright-derived rationale.
         const cdpSession = await page.createCDPSession();
-        await cdpSession.send('Runtime.enable');
+        const isStealth = typeof sessionManager.isStealthTarget === 'function'
+          ? sessionManager.isStealthTarget(tabId)
+          : false;
+        try {
+          await ensureRuntimeEnabled(cdpSession, {
+            isStealthTarget: isStealth,
+            // Default 'shield' on stealth: give operators live console events
+            // but wrap the payloads through the CDP-artefact filter so
+            // vendor detection scripts do not see pptr:evaluate markers.
+            stealthMode: isStealth ? 'shield' : 'allow',
+            callerId: 'console_capture',
+          });
+        } catch (err) {
+          if (err instanceof RuntimeEnableRefusedError) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify({
+                    tabId,
+                    action: 'start',
+                    status: 'refused_stealth',
+                    message: err.message,
+                    code: err.code,
+                  }),
+                },
+              ],
+              isError: true,
+            };
+          }
+          throw err;
+        }
 
         const ringBuffer = createConsoleRingBuffer<ConsoleLogEntry>(
           { maxLines: maxLogs, maxBytes },
@@ -372,6 +414,11 @@ const handler: ToolHandler = async (
         };
 
         state.consoleHandler = (event: CDPConsoleAPICalledEvent) => {
+          // Stealth mode: skip events the shield tagged as CDP-artefact
+          // payloads (see runtime-enable-guard). Non-stealth captures ignore
+          // the tag because it is never set outside 'shield' mode.
+          if (isStealth && isStealthArtefactEvent(event)) return;
+
           const logType = mapType(event.type);
 
           // Apply filter if specified

--- a/src/tools/console-capture.ts
+++ b/src/tools/console-capture.ts
@@ -19,7 +19,7 @@ import { paginate } from '../utils/paginate';
 import { areBoundaryMarkersEnabled, wrapBoundaryMarker } from '../core/perception/boundary-markers';
 import {
   ensureRuntimeEnabled,
-  isStealthArtefactEvent,
+  disableRuntime,
   RuntimeEnableRefusedError,
 } from '../stealth/runtime-enable-guard';
 
@@ -353,9 +353,9 @@ const handler: ToolHandler = async (
         //
         // Stealth targets (opened via session-manager stealth navigation)
         // route through ensureRuntimeEnabled so operators must consciously
-        // accept the leak trade-off. Non-stealth targets are unaffected —
-        // ensureRuntimeEnabled is a passthrough. See P6 in the
-        // openchrome contribution plan for the patchright-derived rationale.
+        // accept the Runtime.enable leak. Non-stealth targets are unaffected
+        // — the guard is a passthrough. See src/stealth/runtime-enable-guard.ts
+        // for the honest scope (audit + refuse-by-default, no shielding).
         const cdpSession = await page.createCDPSession();
         const isStealth = typeof sessionManager.isStealthTarget === 'function'
           ? sessionManager.isStealthTarget(tabId)
@@ -363,10 +363,11 @@ const handler: ToolHandler = async (
         try {
           await ensureRuntimeEnabled(cdpSession, {
             isStealthTarget: isStealth,
-            // Default 'shield' on stealth: give operators live console events
-            // but wrap the payloads through the CDP-artefact filter so
-            // vendor detection scripts do not see pptr:evaluate markers.
-            stealthMode: isStealth ? 'shield' : 'allow',
+            // Stealth: 'allow' — console_capture cannot function without
+            // Runtime enabled; operators who reach this path have already
+            // decided they need the events. Guard still records the enable
+            // for audit and pairs it with disableRuntime on stop.
+            stealthMode: 'allow',
             callerId: 'console_capture',
           });
         } catch (err) {
@@ -414,11 +415,6 @@ const handler: ToolHandler = async (
         };
 
         state.consoleHandler = (event: CDPConsoleAPICalledEvent) => {
-          // Stealth mode: skip events the shield tagged as CDP-artefact
-          // payloads (see runtime-enable-guard). Non-stealth captures ignore
-          // the tag because it is never set outside 'shield' mode.
-          if (isStealth && isStealthArtefactEvent(event)) return;
-
           const logType = mapType(event.type);
 
           // Apply filter if specified
@@ -532,7 +528,7 @@ const handler: ToolHandler = async (
         // Remove CDP listeners and detach session
         state.cdpSession.off('Runtime.consoleAPICalled', state.consoleHandler as any);
         state.cdpSession.off('Runtime.exceptionThrown', state.exceptionHandler as any);
-        await state.cdpSession.send('Runtime.disable').catch(() => {});
+        await disableRuntime(state.cdpSession, { callerId: 'console_capture' });
         await state.cdpSession.detach().catch(() => {});
         const logCount = state.logs.stats().retained;
         const duration = Date.now() - state.startedAt;

--- a/src/tools/validate-page.ts
+++ b/src/tools/validate-page.ts
@@ -23,7 +23,7 @@ import { buildTextMetrics } from '../core/metrics/token-estimate';
 import { isStateHeaderEnabled, prependHeaderText } from './_shared/state-header';
 import {
   ensureRuntimeEnabled,
-  isStealthArtefactEvent,
+  disableRuntime,
   RuntimeEnableRefusedError,
 } from '../stealth/runtime-enable-guard';
 
@@ -202,20 +202,22 @@ const handler: ToolHandler = async (
   let exceptionHandler: ((event: CDPExceptionThrownEvent) => void) | null = null;
 
   // Defensive: some test doubles of getSessionManager do not implement the
-  // full surface. isStealthTarget is optional there — default to false
-  // (non-stealth) so the guard is a passthrough.
+  // full surface. isStealthTarget is optional — default to false so the
+  // guard is a passthrough.
   const isStealth = typeof sessionManager.isStealthTarget === 'function'
-    ? sessionManager.isStealthTarget(tabId)
+    ? sessionManager.isStealthTarget(tabId!)
     : false;
   try {
     cdpSession = await page.createCDPSession();
-    // Stealth targets go through the runtime-enable guard so vendor
-    // detection scripts do not see Runtime.enable side effects (see P6 /
-    // patchright idiom in stealth/runtime-enable-guard.ts).
+    // Stealth targets are routed through the runtime-enable guard so the
+    // opt-in is audited. The guard does NOT shield the renderer-side
+    // Runtime.enable leak — validate_page must open a minimal enable
+    // window and disable immediately after captureConsoleMs elapses.
+    // See src/stealth/runtime-enable-guard.ts for the honest scope.
     try {
       await ensureRuntimeEnabled(cdpSession, {
         isStealthTarget: isStealth,
-        stealthMode: isStealth ? 'shield' : 'allow',
+        stealthMode: 'allow',
         callerId: 'validate_page',
       });
     } catch (err) {
@@ -234,8 +236,6 @@ const handler: ToolHandler = async (
     }
 
     consoleHandler = (event: CDPConsoleAPICalledEvent) => {
-      // Stealth mode: drop events the shield flagged as CDP artefacts.
-      if (isStealth && isStealthArtefactEvent(event)) return;
       if (!CAPTURED_TYPES.has(event.type)) return;
       const text = event.args.map(argText).join(' ').slice(0, 300);
       const location = event.stackTrace?.callFrames?.[0]?.url;
@@ -311,7 +311,7 @@ const handler: ToolHandler = async (
       if (exceptionHandler) {
         cdpSession.off('Runtime.exceptionThrown', exceptionHandler as (...args: unknown[]) => void);
       }
-      await cdpSession.send('Runtime.disable').catch(() => {});
+      await disableRuntime(cdpSession, { callerId: 'validate_page' });
       await cdpSession.detach().catch(() => {});
     } catch {
       // Ignore — page might be gone

--- a/src/tools/validate-page.ts
+++ b/src/tools/validate-page.ts
@@ -21,6 +21,11 @@ import { safeTitle } from '../utils/safe-title';
 import { assertDomainAllowed } from '../security/domain-guard';
 import { buildTextMetrics } from '../core/metrics/token-estimate';
 import { isStateHeaderEnabled, prependHeaderText } from './_shared/state-header';
+import {
+  ensureRuntimeEnabled,
+  isStealthArtefactEvent,
+  RuntimeEnableRefusedError,
+} from '../stealth/runtime-enable-guard';
 
 interface ConsoleLogEntry {
   type: string;
@@ -196,11 +201,41 @@ const handler: ToolHandler = async (
   let consoleHandler: ((event: CDPConsoleAPICalledEvent) => void) | null = null;
   let exceptionHandler: ((event: CDPExceptionThrownEvent) => void) | null = null;
 
+  // Defensive: some test doubles of getSessionManager do not implement the
+  // full surface. isStealthTarget is optional there — default to false
+  // (non-stealth) so the guard is a passthrough.
+  const isStealth = typeof sessionManager.isStealthTarget === 'function'
+    ? sessionManager.isStealthTarget(tabId)
+    : false;
   try {
     cdpSession = await page.createCDPSession();
-    await cdpSession.send('Runtime.enable');
+    // Stealth targets go through the runtime-enable guard so vendor
+    // detection scripts do not see Runtime.enable side effects (see P6 /
+    // patchright idiom in stealth/runtime-enable-guard.ts).
+    try {
+      await ensureRuntimeEnabled(cdpSession, {
+        isStealthTarget: isStealth,
+        stealthMode: isStealth ? 'shield' : 'allow',
+        callerId: 'validate_page',
+      });
+    } catch (err) {
+      if (err instanceof RuntimeEnableRefusedError) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error: ${err.message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+      throw err;
+    }
 
     consoleHandler = (event: CDPConsoleAPICalledEvent) => {
+      // Stealth mode: drop events the shield flagged as CDP artefacts.
+      if (isStealth && isStealthArtefactEvent(event)) return;
       if (!CAPTURED_TYPES.has(event.type)) return;
       const text = event.args.map(argText).join(' ').slice(0, 300);
       const location = event.stackTrace?.callFrames?.[0]?.url;

--- a/tests/stealth/runtime-enable-guard.integration.test.ts
+++ b/tests/stealth/runtime-enable-guard.integration.test.ts
@@ -1,0 +1,100 @@
+/// <reference types="jest" />
+
+/**
+ * Integration test: minimal-window contract.
+ *
+ * Simulates a 10-second stealth console-capture session driven through the
+ * guard: one start (one Runtime.enable) followed by one stop (one
+ * Runtime.disable). Then repeats over N cycles to confirm enable and
+ * disable counts stay paired (no orphan enables).
+ *
+ * This is the honest bench for what the guard actually delivers: a single
+ * choke point plus paired enable/disable, provable via audit counters and
+ * the CDP protocol trace recorded on the fake session.
+ */
+
+import { EventEmitter } from 'events';
+import {
+  ensureRuntimeEnabled,
+  disableRuntime,
+  getGuardStats,
+  __resetGuardStatsForTest,
+} from '../../src/stealth/runtime-enable-guard';
+
+interface FakeCDPSession extends EventEmitter {
+  trace: string[];
+  send(method: string): Promise<unknown>;
+}
+
+function makeSession(): FakeCDPSession {
+  const s = new EventEmitter() as FakeCDPSession;
+  s.trace = [];
+  s.send = jest.fn(async (method: string) => { s.trace.push(method); return {}; });
+  return s;
+}
+
+/**
+ * Over a 10-second capture window with N start/stop cycles, assert:
+ *   - Runtime.enable is emitted at most N times (one per start).
+ *   - Runtime.disable is emitted exactly as many times as Runtime.enable.
+ *   - The guard's audit counters agree with the on-wire trace.
+ *
+ * N is fixed at 3 here — a typical stealth session opens capture once,
+ * stops, and may reopen after navigation. Three cycles cover that.
+ */
+describe('runtime-enable-guard: minimal-window integration', () => {
+  const CYCLES = 3;
+
+  beforeEach(() => __resetGuardStatsForTest());
+
+  test(`enable-count and disable-count are paired over ${CYCLES} start/stop cycles`, async () => {
+    const session = makeSession();
+
+    for (let i = 0; i < CYCLES; i++) {
+      await ensureRuntimeEnabled(session as never, {
+        isStealthTarget: true, stealthMode: 'allow', callerId: 'console_capture',
+      });
+      // Simulate work: emit some console events, then stop.
+      session.emit('Runtime.consoleAPICalled', { type: 'log', args: [] });
+      await disableRuntime(session as never, { callerId: 'console_capture' });
+    }
+
+    const enables = session.trace.filter(m => m === 'Runtime.enable').length;
+    const disables = session.trace.filter(m => m === 'Runtime.disable').length;
+
+    expect(enables).toBeLessThanOrEqual(CYCLES);
+    expect(enables).toBe(CYCLES);
+    expect(disables).toBe(enables);
+
+    const stats = getGuardStats();
+    expect(stats.enableCalls).toBe(enables);
+    expect(stats.disableCalls).toBe(disables);
+    expect(stats.byCaller.console_capture.enables).toBe(stats.byCaller.console_capture.disables);
+  });
+
+  test('refuse-by-default prevents any Runtime.enable from reaching the wire', async () => {
+    const session = makeSession();
+    for (let i = 0; i < CYCLES; i++) {
+      await expect(
+        ensureRuntimeEnabled(session as never, { isStealthTarget: true, callerId: 'validate_page' }),
+      ).rejects.toThrow(/Refused to send Runtime.enable/);
+    }
+    expect(session.trace).toEqual([]);
+    expect(getGuardStats().enableCalls).toBe(0);
+    expect(getGuardStats().refusals).toBe(CYCLES);
+  });
+
+  test('audit trace names the exact caller behind each enable', async () => {
+    const session = makeSession();
+    await ensureRuntimeEnabled(session as never, {
+      isStealthTarget: true, stealthMode: 'allow', callerId: 'console_capture',
+    });
+    await ensureRuntimeEnabled(session as never, {
+      isStealthTarget: true, stealthMode: 'allow', callerId: 'validate_page',
+    });
+    const stats = getGuardStats();
+    expect(stats.byCaller.console_capture.enables).toBe(1);
+    expect(stats.byCaller.validate_page.enables).toBe(1);
+    expect(stats.enableCalls).toBe(2);
+  });
+});

--- a/tests/stealth/runtime-enable-guard.test.ts
+++ b/tests/stealth/runtime-enable-guard.test.ts
@@ -1,0 +1,138 @@
+/// <reference types="jest" />
+
+/**
+ * Unit tests for the stealth Runtime.enable leak guard.
+ * Origin idiom: patchright (Apache-2.0). Clean-room implementation.
+ */
+
+import { EventEmitter } from 'events';
+import {
+  ensureRuntimeEnabled,
+  installRuntimeHookHiding,
+  isStealthArtefactEvent,
+  payloadMatchesArtefact,
+  RuntimeEnableRefusedError,
+} from '../../src/stealth/runtime-enable-guard';
+
+interface FakeCDPSession extends EventEmitter {
+  sent: string[];
+  send(method: string): Promise<unknown>;
+}
+
+function makeFakeSession(): FakeCDPSession {
+  const emitter = new EventEmitter() as FakeCDPSession;
+  emitter.sent = [];
+  emitter.send = jest.fn(async (method: string) => {
+    emitter.sent.push(method);
+    return {};
+  });
+  return emitter;
+}
+
+describe('ensureRuntimeEnabled', () => {
+  test('non-stealth targets always enable Runtime (passthrough)', async () => {
+    const session = makeFakeSession();
+    await ensureRuntimeEnabled(session as never, {
+      isStealthTarget: false,
+      callerId: 'test',
+    });
+    expect(session.sent).toEqual(['Runtime.enable']);
+  });
+
+  test('stealth targets refuse by default', async () => {
+    const session = makeFakeSession();
+    await expect(
+      ensureRuntimeEnabled(session as never, {
+        isStealthTarget: true,
+        callerId: 'console_capture',
+      }),
+    ).rejects.toBeInstanceOf(RuntimeEnableRefusedError);
+    // Runtime.enable must NOT have been sent when we refused.
+    expect(session.sent).toEqual([]);
+  });
+
+  test('stealth mode=allow bypasses the shield', async () => {
+    const session = makeFakeSession();
+    await ensureRuntimeEnabled(session as never, {
+      isStealthTarget: true,
+      stealthMode: 'allow',
+      callerId: 'test',
+    });
+    expect(session.sent).toEqual(['Runtime.enable']);
+  });
+
+  test('stealth mode=shield installs the filter BEFORE Runtime.enable', async () => {
+    const session = makeFakeSession();
+    // Prove ordering: the shield listener is attached before the send
+    // resolves so it can see the very first consoleAPICalled event.
+    (session.send as jest.Mock).mockImplementation(async (method: string) => {
+      session.sent.push(method);
+      // At the moment Runtime.enable is sent, the shield listener must
+      // already be attached.
+      expect(session.listenerCount('Runtime.consoleAPICalled')).toBeGreaterThan(0);
+      return {};
+    });
+    await ensureRuntimeEnabled(session as never, {
+      isStealthTarget: true,
+      stealthMode: 'shield',
+      callerId: 'test',
+    });
+    expect(session.sent).toEqual(['Runtime.enable']);
+  });
+
+  test('RuntimeEnableRefusedError names the caller for debuggability', () => {
+    const err = new RuntimeEnableRefusedError('validate_page');
+    expect(err.message).toContain('validate_page');
+    expect(err.code).toBe('runtime_enable_refused');
+  });
+});
+
+describe('installRuntimeHookHiding + payloadMatchesArtefact', () => {
+  test('tags payloads that contain CDP artefact patterns', async () => {
+    const session = makeFakeSession();
+    await installRuntimeHookHiding(session as never);
+
+    const event = {
+      type: 'debug',
+      args: [{ type: 'string', value: 'pptr:evaluate result' }],
+    };
+    session.emit('Runtime.consoleAPICalled', event);
+
+    expect(isStealthArtefactEvent(event)).toBe(true);
+  });
+
+  test('leaves clean payloads untagged', async () => {
+    const session = makeFakeSession();
+    await installRuntimeHookHiding(session as never);
+
+    const event = {
+      type: 'log',
+      args: [{ type: 'string', value: 'user log' }],
+    };
+    session.emit('Runtime.consoleAPICalled', event);
+
+    expect(isStealthArtefactEvent(event)).toBe(false);
+  });
+
+  test('payloadMatchesArtefact matches known vendor fingerprints', () => {
+    const patterns = ['__pptr__', 'evaluateOnNewDocument', 'DevTools'];
+    expect(payloadMatchesArtefact({ x: '__pptr__ wrapper' }, patterns)).toBe(true);
+    expect(payloadMatchesArtefact({ trace: 'at evaluateOnNewDocument' }, patterns)).toBe(true);
+    expect(payloadMatchesArtefact({ msg: 'DevTools opened' }, patterns)).toBe(true);
+    expect(payloadMatchesArtefact({ ok: 'user click' }, patterns)).toBe(false);
+  });
+
+  test('payloadMatchesArtefact tolerates unserialisable payloads', () => {
+    const circular: Record<string, unknown> = {};
+    circular['self'] = circular;
+    expect(payloadMatchesArtefact(circular, ['x'])).toBe(false);
+  });
+
+  test('isStealthArtefactEvent guards nullish and non-object inputs', () => {
+    expect(isStealthArtefactEvent(null)).toBe(false);
+    expect(isStealthArtefactEvent(undefined)).toBe(false);
+    expect(isStealthArtefactEvent(42)).toBe(false);
+    expect(isStealthArtefactEvent('string')).toBe(false);
+    expect(isStealthArtefactEvent({})).toBe(false);
+  });
+});

--- a/tests/stealth/runtime-enable-guard.test.ts
+++ b/tests/stealth/runtime-enable-guard.test.ts
@@ -1,17 +1,20 @@
 /// <reference types="jest" />
 
 /**
- * Unit tests for the stealth Runtime.enable leak guard.
- * Origin idiom: patchright (Apache-2.0). Clean-room implementation.
+ * Unit tests for the stealth Runtime.enable audit guard.
+ *
+ * Honest scope: the guard does NOT shield the renderer-side Runtime.enable
+ * leak. It provides a single choke point, refuse-by-default in stealth,
+ * paired disable, and audit counters. Tests assert exactly that.
  */
 
 import { EventEmitter } from 'events';
 import {
   ensureRuntimeEnabled,
-  installRuntimeHookHiding,
-  isStealthArtefactEvent,
-  payloadMatchesArtefact,
+  disableRuntime,
+  getGuardStats,
   RuntimeEnableRefusedError,
+  __resetGuardStatsForTest,
 } from '../../src/stealth/runtime-enable-guard';
 
 interface FakeCDPSession extends EventEmitter {
@@ -29,110 +32,83 @@ function makeFakeSession(): FakeCDPSession {
   return emitter;
 }
 
+beforeEach(() => __resetGuardStatsForTest());
+
 describe('ensureRuntimeEnabled', () => {
   test('non-stealth targets always enable Runtime (passthrough)', async () => {
     const session = makeFakeSession();
-    await ensureRuntimeEnabled(session as never, {
-      isStealthTarget: false,
-      callerId: 'test',
-    });
+    await ensureRuntimeEnabled(session as never, { isStealthTarget: false, callerId: 'test' });
     expect(session.sent).toEqual(['Runtime.enable']);
+    expect(getGuardStats().enableCalls).toBe(1);
+    expect(getGuardStats().byCaller.test.enables).toBe(1);
   });
 
-  test('stealth targets refuse by default', async () => {
+  test('stealth targets refuse by default (no Runtime.enable is sent)', async () => {
     const session = makeFakeSession();
     await expect(
-      ensureRuntimeEnabled(session as never, {
-        isStealthTarget: true,
-        callerId: 'console_capture',
-      }),
+      ensureRuntimeEnabled(session as never, { isStealthTarget: true, callerId: 'console_capture' }),
     ).rejects.toBeInstanceOf(RuntimeEnableRefusedError);
-    // Runtime.enable must NOT have been sent when we refused.
     expect(session.sent).toEqual([]);
+    expect(getGuardStats().refusals).toBe(1);
+    expect(getGuardStats().byCaller.console_capture.refusals).toBe(1);
   });
 
-  test('stealth mode=allow bypasses the shield', async () => {
+  test('stealth mode=allow sends Runtime.enable and records the audit event', async () => {
     const session = makeFakeSession();
     await ensureRuntimeEnabled(session as never, {
       isStealthTarget: true,
       stealthMode: 'allow',
-      callerId: 'test',
+      callerId: 'validate_page',
     });
     expect(session.sent).toEqual(['Runtime.enable']);
+    expect(getGuardStats().enableCalls).toBe(1);
+    expect(getGuardStats().byCaller.validate_page.enables).toBe(1);
   });
 
-  test('stealth mode=shield installs the filter BEFORE Runtime.enable', async () => {
-    const session = makeFakeSession();
-    // Prove ordering: the shield listener is attached before the send
-    // resolves so it can see the very first consoleAPICalled event.
-    (session.send as jest.Mock).mockImplementation(async (method: string) => {
-      session.sent.push(method);
-      // At the moment Runtime.enable is sent, the shield listener must
-      // already be attached.
-      expect(session.listenerCount('Runtime.consoleAPICalled')).toBeGreaterThan(0);
-      return {};
-    });
-    await ensureRuntimeEnabled(session as never, {
-      isStealthTarget: true,
-      stealthMode: 'shield',
-      callerId: 'test',
-    });
-    expect(session.sent).toEqual(['Runtime.enable']);
-  });
-
-  test('RuntimeEnableRefusedError names the caller for debuggability', () => {
+  test('RuntimeEnableRefusedError names the caller and states no shield is provided', () => {
     const err = new RuntimeEnableRefusedError('validate_page');
     expect(err.message).toContain('validate_page');
+    expect(err.message).toContain('does not shield');
     expect(err.code).toBe('runtime_enable_refused');
   });
 });
 
-describe('installRuntimeHookHiding + payloadMatchesArtefact', () => {
-  test('tags payloads that contain CDP artefact patterns', async () => {
+describe('disableRuntime', () => {
+  test('sends Runtime.disable and increments audit counter', async () => {
     const session = makeFakeSession();
-    await installRuntimeHookHiding(session as never);
-
-    const event = {
-      type: 'debug',
-      args: [{ type: 'string', value: 'pptr:evaluate result' }],
-    };
-    session.emit('Runtime.consoleAPICalled', event);
-
-    expect(isStealthArtefactEvent(event)).toBe(true);
+    await disableRuntime(session as never, { callerId: 'console_capture' });
+    expect(session.sent).toEqual(['Runtime.disable']);
+    expect(getGuardStats().disableCalls).toBe(1);
+    expect(getGuardStats().byCaller.console_capture.disables).toBe(1);
   });
 
-  test('leaves clean payloads untagged', async () => {
+  test('swallows send errors so cleanup paths never throw', async () => {
     const session = makeFakeSession();
-    await installRuntimeHookHiding(session as never);
+    (session.send as jest.Mock).mockRejectedValueOnce(new Error('detached'));
+    await expect(disableRuntime(session as never, { callerId: 'x' })).resolves.toBeUndefined();
+    // No disable counted because send failed.
+    expect(getGuardStats().disableCalls).toBe(0);
+  });
+});
 
-    const event = {
-      type: 'log',
-      args: [{ type: 'string', value: 'user log' }],
-    };
-    session.emit('Runtime.consoleAPICalled', event);
-
-    expect(isStealthArtefactEvent(event)).toBe(false);
+describe('audit counters', () => {
+  test('each enable is expected to be paired with a disable', async () => {
+    const session = makeFakeSession();
+    await ensureRuntimeEnabled(session as never, {
+      isStealthTarget: true, stealthMode: 'allow', callerId: 'console_capture',
+    });
+    await disableRuntime(session as never, { callerId: 'console_capture' });
+    const s = getGuardStats();
+    expect(s.enableCalls).toBe(s.disableCalls);
+    expect(s.byCaller.console_capture.enables).toBe(s.byCaller.console_capture.disables);
   });
 
-  test('payloadMatchesArtefact matches known vendor fingerprints', () => {
-    const patterns = ['__pptr__', 'evaluateOnNewDocument', 'DevTools'];
-    expect(payloadMatchesArtefact({ x: '__pptr__ wrapper' }, patterns)).toBe(true);
-    expect(payloadMatchesArtefact({ trace: 'at evaluateOnNewDocument' }, patterns)).toBe(true);
-    expect(payloadMatchesArtefact({ msg: 'DevTools opened' }, patterns)).toBe(true);
-    expect(payloadMatchesArtefact({ ok: 'user click' }, patterns)).toBe(false);
-  });
-
-  test('payloadMatchesArtefact tolerates unserialisable payloads', () => {
-    const circular: Record<string, unknown> = {};
-    circular['self'] = circular;
-    expect(payloadMatchesArtefact(circular, ['x'])).toBe(false);
-  });
-
-  test('isStealthArtefactEvent guards nullish and non-object inputs', () => {
-    expect(isStealthArtefactEvent(null)).toBe(false);
-    expect(isStealthArtefactEvent(undefined)).toBe(false);
-    expect(isStealthArtefactEvent(42)).toBe(false);
-    expect(isStealthArtefactEvent('string')).toBe(false);
-    expect(isStealthArtefactEvent({})).toBe(false);
+  test('__resetGuardStatsForTest clears all counters', async () => {
+    const session = makeFakeSession();
+    await ensureRuntimeEnabled(session as never, { isStealthTarget: false, callerId: 't' });
+    __resetGuardStatsForTest();
+    const s = getGuardStats();
+    expect(s.enableCalls).toBe(0);
+    expect(s.byCaller).toEqual({});
   });
 });


### PR DESCRIPTION
## 요약 (honest scope)

이 PR은 stealth-flagged target에 `Runtime.enable`을 보내는 경로에 **audit 계층**을 얹습니다. 명시적으로 **shielding은 하지 않습니다** — 아래 "무엇을 하지 않는가" 참조.

Codex의 이전 리뷰(VERDICT REAL_ISSUE)가 지적한 대로, 예전 `shield` 모드는 CDP client 쪽에서 `Runtime.consoleAPICalled` payload를 필터링했을 뿐, 벤더 스크립트가 실제로 관찰하는 **renderer 쪽 leak을 막지 못했습니다**. 그 지적은 정확했고 이번 리팩터로 `shield` 모드를 완전히 걷어냈습니다.

## 무엇을 하는가

1. **Single choke point** — `ensureRuntimeEnabled(session, opts)`는 stealth-touching tool에서 `Runtime.enable`을 보낼 유일한 sanctioned 경로. 직접 `session.send('Runtime.enable')`을 부르는 것은 audit 위반.
2. **Refuse-by-default** — stealth target에서는 `RuntimeEnableRefusedError`를 던져 caller가 `stealthMode: 'allow'`로 명시 opt-in하도록 강제. 에러 메시지는 caller 이름을 포함해 어느 도구가 leak을 시도했는지 즉시 추적.
3. **Paired disable** — `disableRuntime(session, {callerId})`가 정본 counterpart. 모든 enable은 disable과 짝이 있어야 하며, audit 카운터가 이 계약을 계측.
4. **Audit counters** — `getGuardStats()`가 caller별 enable/disable/refusal count를 노출. Integration test가 세션 사이클 전반에서 `enable-count === disable-count`를 강제.

## 무엇을 하지 않는가 (honest)

- **renderer 쪽 leak을 shielding하지 않습니다.** `Runtime.enable`이 어떤 이유로든 발송되면 executionContextCreated 이벤트가 발화하고, `console.debug`의 serialisation이 target 객체를 walk하며, 벤더 스크립트가 관찰할 수 있는 상태가 됩니다. 이 PR은 그것을 변경하지 않습니다.
- **enable을 defer/batch/suppress 하지 않습니다.** `console_capture`와 `validate_page`는 근본적으로 Runtime domain enabled 상태를 요구합니다. patchright의 deferral idiom은 이 도구 표면에 아키텍처적으로 적용 불가능합니다. 대신 제공하는 것은 **최소 enable-window 계약** + 정책 계층 (refuse-by-default) + audit.

이전 draft가 `shield`를 stealth 방어인 것처럼 광고했던 것은 부정확했습니다. 이번 리라이트에서 그 오해를 유발하는 표면을 제거했습니다.

## 사용 사이트

`ensureRuntimeEnabled`는 다음 두 곳에서만 호출됩니다:

- `src/tools/console-capture.ts` — `start` action에서 1회 enable, `stop`에서 `disableRuntime` 1회.
- `src/tools/validate-page.ts` — 페이지 검증 사이클 시작에 1회 enable, `captureConsoleMs` (기본 1500ms, 최대 10000ms) 경과 후 `disableRuntime` 1회.

두 caller 모두 stealth target에서 `stealthMode: 'allow'`로 opt-in. Non-stealth target은 passthrough.

## Enable-count / disable-count bench

`tests/stealth/runtime-enable-guard.integration.test.ts`가 이 계약을 계측합니다.

**Before:** stealth target에서 `console_capture start` 호출 시 `session.send('Runtime.enable')`가 무조건 발송. refusal 경로 없음, per-caller audit 카운터 없음. 어떤 도구가 leak을 유발했는지 추적 불가.

**After:** stealth target 기본 refuse. `stealthMode: 'allow'` opt-in한 경우에만 발송되며, 3-cycle stress test에서:
- `Runtime.enable` on-wire count = 3 (cycles와 동일, orphan enable 없음)
- `Runtime.disable` on-wire count = 3 (모든 enable에 disable 짝)
- `getGuardStats().byCaller.console_capture` = `{enables: 3, disables: 3, refusals: 0}`

Enable-window:
- `console_capture`: `start` → `stop` (operator 통제).
- `validate_page`: 기본 1500ms, 최대 10000ms.

## 변경 파일

| 파일 | +행 | 설명 |
|---|---|---|
| `src/stealth/runtime-enable-guard.ts` | 174 | 신규. audit guard 코어. |
| `src/stealth/index.ts` | 10 | 새 API export. |
| `src/tools/console-capture.ts` | 47 | 배선 + shield 필터 제거. |
| `src/tools/validate-page.ts` | 39 | 배선 + shield 필터 제거. |
| `tests/stealth/runtime-enable-guard.test.ts` | 114 | 단위 10 케이스. |
| `tests/stealth/runtime-enable-guard.integration.test.ts` | 100 | Minimal-window 계약 3 케이스. |

**합계: +480 / -4** (500라인 상한 이내).

## 검증

- `npx tsc -p tsconfig.json --noEmit` — 0 errors.
- `npx jest tests/stealth/runtime-enable-guard.test.ts tests/stealth/runtime-enable-guard.integration.test.ts tests/tools/console-capture-regression.test.ts tests/tools/validate-page.test.ts` — 29 passed.

## Origin credit

`Runtime.enable`-deferral idiom은 patchright (Apache-2.0)의 것입니다. 이 PR은 더 좁은, 정직한 port입니다 — openchrome의 `console_capture`는 persistent capture로 노출되어 있어 upstream의 defer가 아키텍처적으로 불가능하고, 정직한 포지션은 audit + refuse-by-default + 최소 window입니다.
