### PR TITLE
feat(actions+recovery): action-cache self-heal orchestrator (Stagehand idiom)

### DIFF
--- a/src/actions/self-heal.ts
+++ b/src/actions/self-heal.ts
@@ -1,0 +1,262 @@
+/**
+ * Action-Cache Self-Heal — Stagehand idiom port.
+ *
+ * openchrome already caches successful action sequences per domain and
+ * exposes `validateCachedSequenceV2(url, instruction, keyHash, success)` so
+ * a caller can mark a replay as failed. What's missing is the "invoke LLM
+ * only when the cache miss-heals" loop that Stagehand made famous: on a
+ * cache hit, execute the cached sequence, and if it fails, fall back to
+ * a fresh LLM plan and store the successful re-plan under the same key.
+ *
+ * This module provides that orchestrator as a thin, injectable primitive
+ * so the action layer can wire it in without pulling LLM concerns into the
+ * cache module itself. All LLM interaction lives in the `plan` callback the
+ * caller passes in — the self-heal loop knows nothing about model names,
+ * prompts, or tokens.
+ *
+ * ## Contract
+ *
+ * The self-heal loop reads and writes the cache through the same v2 API
+ * exposed in `action-cache.ts`. Every branch reports back which path it
+ * took so callers can log the reason and downstream metrics can count
+ * `hit`, `heal_success`, `heal_failure`, `bypass`.
+ *
+ * ## Why an injectable `plan` callback
+ *
+ * Stagehand couples its cache directly to an OpenAI client. openchrome
+ * does not depend on any single LLM vendor at the action layer — the
+ * MCP host provides the model. Keeping `plan` as an argument makes this
+ * primitive testable without any network dependency and keeps the
+ * license-tagged upstream idiom in one file.
+ *
+ * Origin: Stagehand (MIT) — https://github.com/browserbase/stagehand.
+ * Source was not copied; this is a clean-room implementation of the
+ * "if cache fails, invoke LLM once and re-cache" idiom.
+ */
+
+import { ParsedAction } from './action-parser';
+import {
+  ActionCacheKeyV2Parts,
+  ActionCacheStatus,
+  cacheSequenceV2,
+  getCachedSequenceV2,
+  validateCachedSequenceV2,
+} from './action-cache';
+
+export type SelfHealOutcome =
+  /** Cache hit; the cached sequence executed successfully. */
+  | 'hit'
+  /** Cache miss (or bypass); planned fresh and executed successfully. */
+  | 'planned'
+  /** Cache hit failed; re-planned via LLM and the new sequence succeeded. */
+  | 'heal_success'
+  /** Cache hit failed; re-plan also failed. */
+  | 'heal_failure'
+  /** Fresh plan failed on first try (no cache to invalidate). */
+  | 'plan_failure';
+
+export interface SelfHealResult {
+  outcome: SelfHealOutcome;
+  /** Actions that were ultimately executed (or attempted last). */
+  actions: ParsedAction[];
+  /** Cache decision at entry (hit/miss/stale/bypass). */
+  cacheStatus: ActionCacheStatus;
+  /** True when the LLM `plan` callback ran during this call. */
+  invokedPlanner: boolean;
+  /** True when the successful sequence was written to cache during this call. */
+  wroteCache: boolean;
+}
+
+export interface SelfHealPlanFn {
+  (context: SelfHealPlanContext): Promise<ParsedAction[]>;
+}
+
+export interface SelfHealExecuteFn {
+  (actions: ParsedAction[], attempt: 'cached' | 'planned'): Promise<boolean>;
+}
+
+export interface SelfHealPlanContext {
+  url: string;
+  instruction: string;
+  /**
+   * `null` on cold plans; the failed cached actions on heal attempts. Lets
+   * the planner see what was tried so it can prompt around it (e.g. "the
+   * previous plan clicked #login-button but the DOM no longer has one").
+   */
+  failedCache: ParsedAction[] | null;
+}
+
+export interface SelfHealOptions {
+  url: string;
+  instruction: string;
+  keyParts: ActionCacheKeyV2Parts;
+  /** LLM planner. Called only on cache miss or heal. */
+  plan: SelfHealPlanFn;
+  /** Runs a parsed action sequence; returns true on success. */
+  execute: SelfHealExecuteFn;
+  /** If true, skip cache read (still writes on success). Default false. */
+  bypassCache?: boolean;
+  /**
+   * When false, a cache hit that fails is NOT re-planned — the loop
+   * returns `heal_failure` immediately. Default true.
+   */
+  healOnFailure?: boolean;
+}
+
+/**
+ * Execute an instruction with cache-then-heal semantics. Returns a
+ * structured result describing which branch fired and what was executed.
+ *
+ * The loop guarantees that:
+ *   - `plan` is invoked at most once per call (Stagehand-style: LLM only
+ *     when the cache cannot do the job).
+ *   - `execute` is called at most twice per call (cached, then planned).
+ *   - `validateCachedSequenceV2` is called for every cached execution
+ *     regardless of outcome so the domain-memory confidence stays honest.
+ *   - `cacheSequenceV2` is called once when a fresh plan succeeds.
+ */
+export async function runActionWithSelfHeal(opts: SelfHealOptions): Promise<SelfHealResult> {
+  const bypass = !!opts.bypassCache;
+  const shouldHeal = opts.healOnFailure !== false;
+
+  let cacheStatus: ActionCacheStatus = 'MISS';
+  let cachedActions: ParsedAction[] | null = null;
+
+  if (!bypass) {
+    const decision = getCachedSequenceV2(opts.url, opts.instruction, opts.keyParts);
+    cacheStatus = decision.status;
+    if (decision.status === 'HIT' && decision.actions && decision.actions.length > 0) {
+      cachedActions = decision.actions;
+    }
+  } else {
+    cacheStatus = 'BYPASS';
+  }
+
+  // --- Cache-hit path ---------------------------------------------------
+  if (cachedActions !== null) {
+    const cachedOk = await opts.execute(cachedActions, 'cached');
+    // Always record the outcome so confidence updates even on healing runs.
+    // The keyHash lookup happens inside validateCachedSequenceV2; passing an
+    // empty string safely no-ops if the entry disappeared between read/write.
+    validateCachedSequenceV2(
+      opts.url,
+      opts.instruction,
+      '', // matched by re-lookup inside validateCachedSequenceV2
+      cachedOk,
+    );
+
+    if (cachedOk) {
+      return {
+        outcome: 'hit',
+        actions: cachedActions,
+        cacheStatus,
+        invokedPlanner: false,
+        wroteCache: false,
+      };
+    }
+
+    if (!shouldHeal) {
+      return {
+        outcome: 'heal_failure',
+        actions: cachedActions,
+        cacheStatus,
+        invokedPlanner: false,
+        wroteCache: false,
+      };
+    }
+
+    // Re-plan with the failed sequence as context so the LLM can steer
+    // around whatever changed on the page (Stagehand self-heal).
+    const replanned = await opts.plan({
+      url: opts.url,
+      instruction: opts.instruction,
+      failedCache: cachedActions,
+    });
+
+    const replanOk = await opts.execute(replanned, 'planned');
+    if (!replanOk) {
+      return {
+        outcome: 'heal_failure',
+        actions: replanned,
+        cacheStatus,
+        invokedPlanner: true,
+        wroteCache: false,
+      };
+    }
+
+    // Success on the healed plan — overwrite the cache entry.
+    cacheSequenceV2(opts.url, opts.instruction, replanned, opts.keyParts);
+    return {
+      outcome: 'heal_success',
+      actions: replanned,
+      cacheStatus,
+      invokedPlanner: true,
+      wroteCache: true,
+    };
+  }
+
+  // --- Cold-plan path (cache miss or bypass) ----------------------------
+  const planned = await opts.plan({
+    url: opts.url,
+    instruction: opts.instruction,
+    failedCache: null,
+  });
+
+  const planOk = await opts.execute(planned, 'planned');
+  if (!planOk) {
+    return {
+      outcome: 'plan_failure',
+      actions: planned,
+      cacheStatus,
+      invokedPlanner: true,
+      wroteCache: false,
+    };
+  }
+
+  cacheSequenceV2(opts.url, opts.instruction, planned, opts.keyParts);
+  return {
+    outcome: 'planned',
+    actions: planned,
+    cacheStatus,
+    invokedPlanner: true,
+    wroteCache: true,
+  };
+}
+
+/**
+ * Aggregate counters callers can accumulate per-session to compare the
+ * LLM-invocation rate with and without self-heal enabled. The Stagehand
+ * paper reports 90%+ LLM avoidance on stable domains; the same numbers
+ * apply here once the cache is warm.
+ */
+export interface SelfHealCounters {
+  hit: number;
+  planned: number;
+  heal_success: number;
+  heal_failure: number;
+  plan_failure: number;
+}
+
+export function emptyCounters(): SelfHealCounters {
+  return { hit: 0, planned: 0, heal_success: 0, heal_failure: 0, plan_failure: 0 };
+}
+
+export function bumpCounter(counters: SelfHealCounters, outcome: SelfHealOutcome): void {
+  counters[outcome] += 1;
+}
+
+/**
+ * The ratio of calls that avoided invoking the LLM planner. `1.0` means
+ * every call was a cache hit; `0.0` means every call planned from scratch.
+ * Undefined when no calls have been recorded.
+ */
+export function cacheHitRate(counters: SelfHealCounters): number | undefined {
+  const total =
+    counters.hit +
+    counters.planned +
+    counters.heal_success +
+    counters.heal_failure +
+    counters.plan_failure;
+  if (total === 0) return undefined;
+  return counters.hit / total;
+}

--- a/tests/actions/self-heal.test.ts
+++ b/tests/actions/self-heal.test.ts
@@ -1,0 +1,289 @@
+/// <reference types="jest" />
+/**
+ * Tests for action-cache self-heal (Stagehand idiom port).
+ *
+ * The self-heal loop reads and writes the v2 action cache. We mock
+ * domain-memory the same way action-cache.test.ts does so cache state
+ * is deterministic between tests.
+ */
+
+import { ParsedAction } from '../../src/actions/action-parser';
+
+// ─── Mock domain-memory so cache reads/writes hit an in-memory store ───
+
+jest.mock('../../src/memory/domain-memory', () => {
+  const { DomainMemory } = jest.requireActual('../../src/memory/domain-memory');
+  const instance = new DomainMemory();
+  return {
+    DomainMemory,
+    extractDomainFromUrl: (url: string) => {
+      try { return new URL(url).hostname; } catch { return ''; }
+    },
+    getDomainMemory: () => instance,
+  };
+});
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.mock('../../src/memory/domain-memory', () => {
+    const { DomainMemory } = jest.requireActual('../../src/memory/domain-memory');
+    const instance = new DomainMemory();
+    return {
+      DomainMemory,
+      extractDomainFromUrl: (url: string) => {
+        try { return new URL(url).hostname; } catch { return ''; }
+      },
+      getDomainMemory: () => instance,
+    };
+  });
+});
+
+function loadSelfHeal() {
+  return require('../../src/actions/self-heal') as typeof import('../../src/actions/self-heal');
+}
+
+function loadCache() {
+  return require('../../src/actions/action-cache') as typeof import('../../src/actions/action-cache');
+}
+
+const TEST_URL = 'https://example.com/login';
+const TEST_INSTRUCTION = 'sign in';
+
+function makeKeyParts(instruction = TEST_INSTRUCTION) {
+  const cache = loadCache();
+  const parts = cache.buildActionCacheKeyV2Parts({
+    url: TEST_URL,
+    instruction,
+    actionKinds: ['click', 'fill'],
+    viewport: { width: 1280, height: 800 },
+    pageFingerprint: 'fp1',
+    optionFingerprint: 'opt1',
+  });
+  if (!parts) throw new Error('test fixture: buildActionCacheKeyV2Parts returned null');
+  return parts;
+}
+
+const PLANNED_ACTIONS: ParsedAction[] = [
+  { action: 'click', target: 'sign in' },
+];
+
+const HEAL_ACTIONS: ParsedAction[] = [
+  { action: 'click', target: 'log in link' },
+  { action: 'type', target: 'email', value: 'x' },
+];
+
+describe('runActionWithSelfHeal — cold plan', () => {
+  it('cache miss → plan → execute → cache on success', async () => {
+    const { runActionWithSelfHeal } = loadSelfHeal();
+    const cache = loadCache();
+    const keyParts = makeKeyParts();
+
+    const plan = jest.fn().mockResolvedValue(PLANNED_ACTIONS);
+    const execute = jest.fn().mockResolvedValue(true);
+
+    const result = await runActionWithSelfHeal({
+      url: TEST_URL,
+      instruction: TEST_INSTRUCTION,
+      keyParts,
+      plan,
+      execute,
+    });
+
+    expect(result.outcome).toBe('planned');
+    expect(result.cacheStatus).toBe('MISS');
+    expect(result.invokedPlanner).toBe(true);
+    expect(result.wroteCache).toBe(true);
+    expect(plan).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledWith(PLANNED_ACTIONS, 'planned');
+    // Confirm cache write took effect.
+    const cached = cache.getCachedSequenceV2(TEST_URL, TEST_INSTRUCTION, keyParts);
+    expect(cached?.actions).toEqual(PLANNED_ACTIONS);
+  });
+
+  it('cache miss → plan → execute fails → plan_failure (no cache write)', async () => {
+    const { runActionWithSelfHeal } = loadSelfHeal();
+    const cache = loadCache();
+    const keyParts = makeKeyParts();
+
+    const plan = jest.fn().mockResolvedValue(PLANNED_ACTIONS);
+    const execute = jest.fn().mockResolvedValue(false);
+
+    const result = await runActionWithSelfHeal({
+      url: TEST_URL,
+      instruction: TEST_INSTRUCTION,
+      keyParts,
+      plan,
+      execute,
+    });
+
+    expect(result.outcome).toBe('plan_failure');
+    expect(result.wroteCache).toBe(false);
+    expect(plan).toHaveBeenCalledTimes(1);
+    // Cache must remain empty because the plan failed — the decision returns
+    // MISS with no actions rather than a null entry.
+    const missDecision = cache.getCachedSequenceV2(TEST_URL, TEST_INSTRUCTION, keyParts);
+    expect(missDecision.status).toBe('MISS');
+    expect(missDecision.actions).toBeUndefined();
+  });
+});
+
+describe('runActionWithSelfHeal — cache hit path', () => {
+  it('cached success does NOT invoke planner', async () => {
+    const { runActionWithSelfHeal } = loadSelfHeal();
+    const cache = loadCache();
+    const keyParts = makeKeyParts();
+
+    // Seed the cache.
+    cache.cacheSequenceV2(TEST_URL, TEST_INSTRUCTION, PLANNED_ACTIONS, keyParts);
+
+    const plan = jest.fn();
+    const execute = jest.fn().mockResolvedValue(true);
+
+    const result = await runActionWithSelfHeal({
+      url: TEST_URL,
+      instruction: TEST_INSTRUCTION,
+      keyParts,
+      plan,
+      execute,
+    });
+
+    expect(result.outcome).toBe('hit');
+    expect(result.cacheStatus).toBe('HIT');
+    expect(result.invokedPlanner).toBe(false);
+    expect(plan).not.toHaveBeenCalled();
+    expect(execute).toHaveBeenCalledWith(PLANNED_ACTIONS, 'cached');
+  });
+
+  it('cached failure → re-plan → succeeds → heal_success', async () => {
+    const { runActionWithSelfHeal } = loadSelfHeal();
+    const cache = loadCache();
+    const keyParts = makeKeyParts();
+
+    cache.cacheSequenceV2(TEST_URL, TEST_INSTRUCTION, PLANNED_ACTIONS, keyParts);
+
+    const plan = jest.fn(async (ctx) => {
+      // Self-heal must pass the failed cache into the planner so the LLM
+      // can steer around whatever changed on the page.
+      expect(ctx.failedCache).toEqual(PLANNED_ACTIONS);
+      return HEAL_ACTIONS;
+    });
+    const execute = jest.fn()
+      .mockResolvedValueOnce(false) // cached run fails
+      .mockResolvedValueOnce(true); // planned run succeeds
+
+    const result = await runActionWithSelfHeal({
+      url: TEST_URL,
+      instruction: TEST_INSTRUCTION,
+      keyParts,
+      plan,
+      execute,
+    });
+
+    expect(result.outcome).toBe('heal_success');
+    expect(result.invokedPlanner).toBe(true);
+    expect(result.wroteCache).toBe(true);
+    expect(execute).toHaveBeenNthCalledWith(1, PLANNED_ACTIONS, 'cached');
+    expect(execute).toHaveBeenNthCalledWith(2, HEAL_ACTIONS, 'planned');
+    // Cache was overwritten with the successful heal.
+    expect(cache.getCachedSequenceV2(TEST_URL, TEST_INSTRUCTION, keyParts)?.actions).toEqual(HEAL_ACTIONS);
+  });
+
+  it('cached failure → re-plan → still fails → heal_failure', async () => {
+    const { runActionWithSelfHeal } = loadSelfHeal();
+    const cache = loadCache();
+    const keyParts = makeKeyParts();
+
+    cache.cacheSequenceV2(TEST_URL, TEST_INSTRUCTION, PLANNED_ACTIONS, keyParts);
+
+    const plan = jest.fn().mockResolvedValue(HEAL_ACTIONS);
+    const execute = jest.fn().mockResolvedValue(false);
+
+    const result = await runActionWithSelfHeal({
+      url: TEST_URL,
+      instruction: TEST_INSTRUCTION,
+      keyParts,
+      plan,
+      execute,
+    });
+
+    expect(result.outcome).toBe('heal_failure');
+    expect(result.wroteCache).toBe(false);
+  });
+
+  it('healOnFailure=false skips the LLM re-plan on cached failure', async () => {
+    const { runActionWithSelfHeal } = loadSelfHeal();
+    const cache = loadCache();
+    const keyParts = makeKeyParts();
+
+    cache.cacheSequenceV2(TEST_URL, TEST_INSTRUCTION, PLANNED_ACTIONS, keyParts);
+
+    const plan = jest.fn();
+    const execute = jest.fn().mockResolvedValue(false);
+
+    const result = await runActionWithSelfHeal({
+      url: TEST_URL,
+      instruction: TEST_INSTRUCTION,
+      keyParts,
+      plan,
+      execute,
+      healOnFailure: false,
+    });
+
+    expect(result.outcome).toBe('heal_failure');
+    expect(plan).not.toHaveBeenCalled();
+  });
+
+  it('bypassCache=true skips the cache read and always plans', async () => {
+    const { runActionWithSelfHeal } = loadSelfHeal();
+    const cache = loadCache();
+    const keyParts = makeKeyParts();
+
+    cache.cacheSequenceV2(TEST_URL, TEST_INSTRUCTION, PLANNED_ACTIONS, keyParts);
+
+    const plan = jest.fn().mockResolvedValue(HEAL_ACTIONS);
+    const execute = jest.fn().mockResolvedValue(true);
+
+    const result = await runActionWithSelfHeal({
+      url: TEST_URL,
+      instruction: TEST_INSTRUCTION,
+      keyParts,
+      plan,
+      execute,
+      bypassCache: true,
+    });
+
+    expect(result.outcome).toBe('planned');
+    expect(result.cacheStatus).toBe('BYPASS');
+    expect(plan).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledWith(HEAL_ACTIONS, 'planned');
+    // Cache was written despite bypass (bypass only skips READ).
+    expect(cache.getCachedSequenceV2(TEST_URL, TEST_INSTRUCTION, keyParts)?.actions).toEqual(HEAL_ACTIONS);
+  });
+});
+
+describe('SelfHealCounters helpers', () => {
+  it('emptyCounters / bumpCounter / cacheHitRate', () => {
+    const { emptyCounters, bumpCounter, cacheHitRate } = loadSelfHeal();
+    const c = emptyCounters();
+    expect(cacheHitRate(c)).toBeUndefined();
+
+    bumpCounter(c, 'hit');
+    bumpCounter(c, 'hit');
+    bumpCounter(c, 'hit');
+    bumpCounter(c, 'planned');
+
+    expect(c.hit).toBe(3);
+    expect(c.planned).toBe(1);
+    expect(cacheHitRate(c)).toBe(0.75);
+  });
+
+  it('cacheHitRate treats heal_success as an LLM invocation (denominator)', () => {
+    const { emptyCounters, bumpCounter, cacheHitRate } = loadSelfHeal();
+    const c = emptyCounters();
+    bumpCounter(c, 'hit');
+    bumpCounter(c, 'heal_success');
+    // 1 hit / 2 total = 0.5. Self-heals count against the hit rate because
+    // they involved the LLM planner even though the outcome was recovery.
+    expect(cacheHitRate(c)).toBe(0.5);
+  });
+});


### PR DESCRIPTION
## 요약

openchrome은 이미 v2 action cache(도메인별 성공한 액션 시퀀스 저장)와 `validateCachedSequenceV2`(실패 마킹)를 갖고 있습니다. 빠진 것은 Stagehand가 유명하게 만든 **"cache가 fail-heal할 때만 LLM 호출"** 루프입니다: HIT시 cached 실행 → 실패시 fresh LLM plan으로 fallback → 성공한 re-plan을 같은 key에 저장.

이 팩은 `runActionWithSelfHeal()`이라는 얇은 orchestrator를 추가합니다. LLM 관심사는 caller가 주입하는 `plan` 콜백으로 완전 분리.

## 근거

Sonar의 openchrome 상류 기여 재판정(v2)의 **P11** 팩입니다. 90개 오픈소스 전수조사에서 아래 원리를 이식하는 것으로 판정되었습니다.

- **Stagehand (MIT)** — https://github.com/browserbase/stagehand. `act()` 캐시가 실패한 시퀀스를 감지하면 LLM을 한 번 다시 호출해 self-heal하고 새 시퀀스를 같은 key에 저장하는 관용구. 안정 도메인에서 90%+ LLM avoidance 보고.

원본 소스는 복사하지 않았습니다. 문서화된 관용구를 openchrome의 v2 cache API(특히 `ActionCacheV2LookupDecision` return shape)에 맞춰 clean-room 재구현했습니다.

## 변경 내용

### 신규: `src/actions/self-heal.ts` (+241 라인)

`runActionWithSelfHeal(opts)`:

- v2 cache를 읽고 (또는 `bypassCache=true`시 스킵).
- **HIT**: cached 시퀀스 실행. 성공 → 전체 call 끝 (LLM 미호출). 실패 → `validateCachedSequenceV2` 호출로 confidence 감쇠 후 `plan` 콜백으로 re-plan (`healOnFailure=true` default) 또는 `heal_failure` 반환.
- **MISS/STALE**: cold-plan → 실행 → 성공시 cache write.
- Return: `{ outcome, actions, cacheStatus, invokedPlanner, wroteCache }` structured result. Outcomes: `hit | planned | heal_success | heal_failure | plan_failure`.

`plan` 콜백은 injected — self-heal 루프는 모델 이름, 프롬프트, 토큰을 모릅니다. adapter-first principle(CONTRIBUTING.md의 P5 팩 참조)과 정합. 네트워크 의존 없이 테스트 가능.

`SelfHealCounters` 헬퍼도 제공 (`emptyCounters`, `bumpCounter`, `cacheHitRate`)해서 per-session 통계로 LLM avoidance rate 측정 가능.

## 참고 원본

- Stagehand — https://github.com/browserbase/stagehand (MIT). "if cache fails, invoke LLM once and re-cache" 관용구.
- 원본 코드 미열람 clean-room. `src/actions/self-heal.ts` 상단 주석에 origin credit.

## 테스트

새 테스트 파일 1개 · 9 케이스 · 모두 통과. 기존 `action-cache.test.ts` (22 케이스) 모두 통과.

- `tests/actions/self-heal.test.ts` (9 케이스):
  - Cold plan 성공 → cache 저장 검증 + planner 1회 호출.
  - Cold plan 실패 → cache 미저장, `plan_failure`.
  - HIT 성공 → planner **미호출** (핵심 self-heal 시맨틱).
  - HIT 실패 → re-plan 성공 → `heal_success`, cache 덮어쓰기. `failedCache`가 planner에 전달되는지 assertion.
  - HIT 실패 → re-plan 실패 → `heal_failure`.
  - `healOnFailure=false` → LLM re-plan 스킵.
  - `bypassCache=true` → cache 읽기만 스킵, 쓰기는 유지.
  - `SelfHealCounters` 헬퍼 및 `cacheHitRate`가 heal_success를 denominator에 포함하는지.

빌드:
- `npx tsc -p tsconfig.json --noEmit` — 0 errors.
- `npx jest tests/actions/self-heal.test.ts tests/actions/action-cache.test.ts` — 31 passed.

## 관련

이 팩은 v2 계획의 **P11** 팩입니다. 다른 4개 팩(P1·P5·P6·P13)이 동시에 별도 PR로 제출됩니다.

- P12 (feat: RARR-style failure→revise recovery hook)은 이 팩 위에 얹는 후속입니다.