### PR TITLE
feat(cdp): non-localhost refuse gate + --allow-remote opt-in

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -37,6 +37,7 @@ import { getIdleState } from '../utils/idle-state';
 import { assertDomainAllowed, isInternalBrowserUrl } from '../security/domain-guard';
 import { applyRegisteredPreloads } from './preload-injector';
 import { TargetPageIndex } from './target-page-index';
+import { assertHostAllowed, RemoteHostRefusedError } from './host-guard';
 
 // Cookie type shared across methods
 type CookieEntry = {
@@ -68,6 +69,12 @@ export interface CDPClientOptions {
   heartbeatIntervalMs?: number;
   /** If true, auto-launch Chrome when not running (default: false) */
   autoLaunch?: boolean;
+  /**
+   * If true, permit `browserWSEndpoint` values that resolve to non-loopback
+   * hostnames. Default: false (host guard refuses). Also honours env
+   * `OPENCHROME_ALLOW_REMOTE_CDP=1`.
+   */
+  allowRemote?: boolean;
 }
 
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
@@ -111,6 +118,7 @@ export class CDPClient {
   private consecutiveHeartbeatSuccesses = 0;
   private checkConnectionInFlight = false;
   private autoLaunch: boolean;
+  private allowRemote: boolean;
   private cookieSourceCache: Map<string, { targetId: string; timestamp: number }> = new Map();
   private cookieDataCache: Map<string, { cookies: CookieEntry[]; timestamp: number }> = new Map();
   private targetIdIndex = new TargetPageIndex();
@@ -169,6 +177,9 @@ export class CDPClient {
     this.heartbeatIntervalMs = options.heartbeatIntervalMs ?? parseEnvInt('OPENCHROME_HEARTBEAT_INTERVAL_MS', DEFAULT_HEARTBEAT_INTERVAL_MS);
     // Use explicit option if provided, otherwise use global config
     this.autoLaunch = options.autoLaunch !== undefined ? options.autoLaunch : globalConfig.autoLaunch;
+    // Host-guard opt-in — default refuse non-loopback. Env override applied in
+    // assertHostAllowed() so a runtime env change is picked up per-attempt.
+    this.allowRemote = options.allowRemote === true;
   }
 
   /**
@@ -714,6 +725,20 @@ export class CDPClient {
       const instance = await launcher.ensureChrome({ autoLaunch });
       if (!this.isCurrentConnectionGeneration(generation)) {
         return false;
+      }
+
+      // Host guard — refuse non-loopback `browserWSEndpoint` unless the caller
+      // opted in. This runs on every attempt so a stale endpoint that flips
+      // hostname mid-retry (e.g. via env change) is re-evaluated.
+      try {
+        assertHostAllowed(instance.wsEndpoint, { allowRemote: this.allowRemote });
+      } catch (guardErr) {
+        if (guardErr instanceof RemoteHostRefusedError) {
+          // Do not retry — a non-loopback endpoint is a policy decision, not a
+          // transient failure. Surface immediately as the connect() error.
+          throw guardErr;
+        }
+        throw guardErr;
       }
 
       const wsTimeoutMs = budgetDriven

--- a/src/cdp/host-guard.ts
+++ b/src/cdp/host-guard.ts
@@ -1,0 +1,183 @@
+/**
+ * CDP Host Guard — non-localhost refuse gate for `browserWSEndpoint` / DevTools HTTP.
+ *
+ * Why this exists
+ * ---------------
+ * openchrome's `CDPClient` accepts any `browserWSEndpoint` and forwards it to
+ * `puppeteer.connect()`. A misconfigured launcher, hostile CLI flag, or a
+ * malicious MCP client can point the endpoint at a **remote** host and turn
+ * the local operator's session into a proxy for someone else's Chrome —
+ * cookies, storage state, and CDP command surface are all handed over.
+ *
+ * The Chrome team is explicit that `--remote-debugging-port` binds only to
+ * localhost by design, and remote debugging is considered a security bug when
+ * the socket leaks off-box. openchrome should refuse to connect to a
+ * non-loopback endpoint by default, and require an explicit `--allow-remote`
+ * opt-in for the (rare) supervised remote-debugging bridge case.
+ *
+ * Design
+ * ------
+ *   1. `parseEndpoint(url)` — normalises ws/wss/http/https URL to `{ hostname,
+ *      port, protocol }`. Rejects malformed input up front.
+ *   2. `isLoopbackHost(hostname)` — decides "loopback" using a fixed allowlist
+ *      (`localhost`, `127.0.0.1`, `[::1]`, `::1`) plus RFC1122 127/8. Any
+ *      other host — including link-local, private LAN (10/8, 172.16/12,
+ *      192.168/16), Tailscale (100.64/10), and public IPs — is non-loopback.
+ *   3. `assertHostAllowed(url, opts)` — throws `RemoteHostRefusedError` if the
+ *      endpoint is non-loopback and `opts.allowRemote !== true`. When allow
+ *      is set, emits a one-shot `console.error` audit line so operators can
+ *      see they are running in the opt-in mode.
+ *   4. `RemoteHostRefusedError` — typed error with `{ hostname, protocol,
+ *      code: 'remote_host_refused' }` so MCP callers can surface a structured
+ *      error rather than a raw `puppeteer.connect()` failure.
+ *
+ * Environment override
+ * --------------------
+ * `OPENCHROME_ALLOW_REMOTE_CDP=1` grants the opt-in without a CLI flag, for
+ * environments where the CLI entry point is out of the caller's control (e.g.
+ * a wrapped MCP shim). The opt-in is still surfaced in the audit line.
+ *
+ * Origin credit
+ * -------------
+ * The "loopback-only unless opted in" idiom is the same guard the Chrome
+ * DevTools team documents for `--remote-debugging-port`. This module is a
+ * clean-room implementation; no upstream Chrome/DevTools code is copied.
+ */
+
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
+
+export interface HostGuardOptions {
+  /** When true, non-loopback endpoints are allowed (audit line still emitted). */
+  allowRemote?: boolean;
+  /** Optional logger override — defaults to `console.error`. */
+  logger?: (msg: string) => void;
+}
+
+export interface ParsedEndpoint {
+  hostname: string;
+  port: string;
+  protocol: string;
+  href: string;
+}
+
+export class RemoteHostRefusedError extends Error {
+  readonly code = 'remote_host_refused' as const;
+  readonly hostname: string;
+  readonly protocol: string;
+  readonly endpoint: string;
+
+  constructor(endpoint: ParsedEndpoint) {
+    super(
+      `CDP host guard refused non-localhost endpoint ` +
+        `${endpoint.protocol}//${endpoint.hostname}:${endpoint.port}. ` +
+        `Pass --allow-remote (or set OPENCHROME_ALLOW_REMOTE_CDP=1) to opt in.`,
+    );
+    this.name = 'RemoteHostRefusedError';
+    this.hostname = endpoint.hostname;
+    this.protocol = endpoint.protocol;
+    this.endpoint = endpoint.href;
+  }
+}
+
+/**
+ * Parse a CDP endpoint URL into structured parts. Throws on malformed input.
+ *
+ * Accepts ws/wss/http/https. Bracketed IPv6 (`[::1]`) is unwrapped so the
+ * loopback check sees the raw form.
+ */
+export function parseEndpoint(url: string): ParsedEndpoint {
+  if (typeof url !== 'string' || url.length === 0) {
+    throw new TypeError('parseEndpoint: url must be a non-empty string');
+  }
+  const parsed = new URL(url);
+  let hostname = parsed.hostname;
+  // WHATWG URL keeps IPv6 hostnames bare (no brackets) — normalise just in case
+  // a caller passes a pre-bracketed form via manual string manipulation.
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    hostname = hostname.slice(1, -1);
+  }
+  return {
+    hostname,
+    port: parsed.port,
+    protocol: parsed.protocol,
+    href: parsed.href,
+  };
+}
+
+/**
+ * Return true iff hostname is loopback (localhost, 127/8, ::1).
+ *
+ * Private LAN, link-local, Tailscale, and public IPs all return false.
+ */
+export function isLoopbackHost(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  if (LOOPBACK_HOSTS.has(h)) return true;
+  // 127.0.0.0/8 — the full IPv4 loopback range, not just 127.0.0.1.
+  if (/^127(?:\.\d{1,3}){3}$/.test(h)) {
+    return h.split('.').every((octet) => {
+      const n = Number(octet);
+      return Number.isInteger(n) && n >= 0 && n <= 255;
+    });
+  }
+  return false;
+}
+
+/**
+ * Read the environment opt-in flag. Kept as a module-level function so
+ * tests can stub `process.env` before each call.
+ */
+export function envAllowRemote(): boolean {
+  const raw = process.env.OPENCHROME_ALLOW_REMOTE_CDP;
+  if (!raw) return false;
+  const v = raw.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on';
+}
+
+let auditEmitted = false;
+
+/** Reset the one-shot audit latch — test-only. */
+export function resetHostGuardAuditLatch(): void {
+  auditEmitted = false;
+}
+
+/**
+ * Refuse the connection unless the endpoint is loopback or the caller opted in.
+ *
+ * When the caller opts in (either via `opts.allowRemote` or the env flag),
+ * emit a single audit line so operators know they are running unlocked.
+ */
+export function assertHostAllowed(url: string, opts: HostGuardOptions = {}): ParsedEndpoint {
+  const endpoint = parseEndpoint(url);
+  if (isLoopbackHost(endpoint.hostname)) return endpoint;
+
+  const allow = opts.allowRemote === true || envAllowRemote();
+  if (!allow) {
+    throw new RemoteHostRefusedError(endpoint);
+  }
+
+  if (!auditEmitted) {
+    auditEmitted = true;
+    const log = opts.logger ?? ((msg: string) => console.error(msg));
+    log(
+      `[CDPClient] --allow-remote is ACTIVE. Connecting to non-loopback CDP endpoint ` +
+        `${endpoint.protocol}//${endpoint.hostname}:${endpoint.port}. ` +
+        `Cookies and storage state on the remote Chrome will be exposed to this client.`,
+    );
+  }
+  return endpoint;
+}
+
+/**
+ * Convenience predicate — true when the endpoint would be refused under
+ * default policy (no allowRemote, no env opt-in). Useful for pre-flight
+ * checks that want to surface the reason without throwing.
+ */
+export function wouldRefuse(url: string): boolean {
+  try {
+    const endpoint = parseEndpoint(url);
+    return !isLoopbackHost(endpoint.hostname);
+  } catch {
+    // Malformed URLs are refused at parse time by assertHostAllowed.
+    return true;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,11 +135,21 @@ program
   .option('--launch-mode <mode>', 'Chrome launch mode: auto | attach | isolated (#659). Also: OPENCHROME_LAUNCH_MODE env var.')
   .option('--secrets <path>', 'Load a dotenv-format secrets file (KEY=value per line). Tokens "${SECRET:NAME}" in tool arguments are substituted to the real value at MCP request deserialization; the same values are redacted from every LLM-visible artifact (responses, trace, skill records, journal). Default: no secrets loaded. P3: no OS keychain integration.')
   .option('--codegen <mode>', 'Opt-in replay artifact generation: off, puppeteer, playwright, or mcp-replay. Default: off (no response shape changes). Also: OPENCHROME_CODEGEN.')
-  .action(async (options: { port: string; autoLaunch?: boolean; allowUnsafeSharedAttach?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; windowSize?: string; windowPosition?: string; windowBounds?: string; startMaximized?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; minimal?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; broker?: boolean; connectBroker?: boolean; autoElect?: boolean; idleTimeout?: string; allowUnauthenticatedHttp?: boolean; pilot?: boolean; slim?: boolean; toolsOnly?: string; disableTools?: string; introspectToolsList?: boolean; autoConnect?: string | boolean; launchMode?: string; secrets?: string; codegen?: string }) => {
+  .option('--allow-remote', 'Allow attaching to a non-loopback CDP endpoint. Off by default — the CDP host guard refuses non-127.0.0.1/::1 endpoints unless this flag or OPENCHROME_ALLOW_REMOTE_CDP=1 is set. (#P2 pack)')
+  .action(async (options: { port: string; autoLaunch?: boolean; allowUnsafeSharedAttach?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; windowSize?: string; windowPosition?: string; windowBounds?: string; startMaximized?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; minimal?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; broker?: boolean; connectBroker?: boolean; autoElect?: boolean; idleTimeout?: string; allowUnauthenticatedHttp?: boolean; pilot?: boolean; slim?: boolean; toolsOnly?: string; disableTools?: string; introspectToolsList?: boolean; autoConnect?: string | boolean; launchMode?: string; secrets?: string; codegen?: string; allowRemote?: boolean }) => {
     const { normalizeCodegenMode, setCodegenMode } = await import('./core/codegen');
     const codegenMode = normalizeCodegenMode(options.codegen ?? process.env.OPENCHROME_CODEGEN);
     setCodegenMode(codegenMode);
     process.env.OPENCHROME_CODEGEN = codegenMode;
+
+    // #P2 pack wiring: expose --allow-remote as the CLI-facing alias for the
+    // pre-existing OPENCHROME_ALLOW_REMOTE_CDP env flag consumed by
+    // src/cdp/host-guard.ts::envAllowRemote(). Setting the env var here
+    // means the singleton CDPClient (constructed later via getCDPClient())
+    // sees the opt-in without any additional plumbing.
+    if (options.allowRemote) {
+      process.env.OPENCHROME_ALLOW_REMOTE_CDP = '1';
+    }
 
     // --introspect-tools-list: print tools/list JSON and exit, NO Chrome/CDP/transport startup.
     if (options.introspectToolsList) {

--- a/tests/cdp/host-guard-cli-wired.test.ts
+++ b/tests/cdp/host-guard-cli-wired.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from '@jest/globals';
+import { assertHostAllowed, envAllowRemote } from '../../src/cdp/host-guard';
+
+/**
+ * Wiring test for the P2 pack CLI surface. Codex flagged that the promised
+ * `--allow-remote` flag was absent — only the env var
+ * OPENCHROME_ALLOW_REMOTE_CDP existed. This test pins the wiring the CLI
+ * uses: when `--allow-remote` is present, the CLI sets
+ * OPENCHROME_ALLOW_REMOTE_CDP=1 so downstream host-guard consumers pick it
+ * up unchanged.
+ *
+ * We assert the env-var contract itself (envAllowRemote + assertHostAllowed),
+ * not commander parsing — the CLI mapping is one line in src/index.ts and
+ * belongs to an integration test surface; the wiring guarantee is that the
+ * env var, once set, actually flips the host-guard decision.
+ */
+describe('P2 CLI wiring — --allow-remote maps to OPENCHROME_ALLOW_REMOTE_CDP=1', () => {
+  const ORIGINAL = process.env.OPENCHROME_ALLOW_REMOTE_CDP;
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.OPENCHROME_ALLOW_REMOTE_CDP;
+    else process.env.OPENCHROME_ALLOW_REMOTE_CDP = ORIGINAL;
+  });
+
+  it('a non-loopback endpoint is refused by default (no flag, no env)', () => {
+    delete process.env.OPENCHROME_ALLOW_REMOTE_CDP;
+    expect(envAllowRemote()).toBe(false);
+    expect(() =>
+      assertHostAllowed('ws://10.0.0.5:9222/devtools/browser/abc'),
+    ).toThrow(/refused non-localhost/i);
+  });
+
+  it('after the CLI sets OPENCHROME_ALLOW_REMOTE_CDP=1, the same endpoint is accepted', () => {
+    // Simulate what the --allow-remote CLI branch does (src/index.ts).
+    process.env.OPENCHROME_ALLOW_REMOTE_CDP = '1';
+    expect(envAllowRemote()).toBe(true);
+    expect(() =>
+      assertHostAllowed('ws://10.0.0.5:9222/devtools/browser/abc'),
+    ).not.toThrow();
+  });
+
+  it('opts.allowRemote=true remains an equivalent programmatic path', () => {
+    delete process.env.OPENCHROME_ALLOW_REMOTE_CDP;
+    expect(() =>
+      assertHostAllowed('ws://10.0.0.5:9222/devtools/browser/abc', {
+        allowRemote: true,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/tests/cdp/host-guard.test.ts
+++ b/tests/cdp/host-guard.test.ts
@@ -1,0 +1,148 @@
+import {
+  assertHostAllowed,
+  envAllowRemote,
+  isLoopbackHost,
+  parseEndpoint,
+  RemoteHostRefusedError,
+  resetHostGuardAuditLatch,
+  wouldRefuse,
+} from '../../src/cdp/host-guard';
+
+describe('CDP host guard (P2)', () => {
+  const savedEnv = process.env.OPENCHROME_ALLOW_REMOTE_CDP;
+  beforeEach(() => {
+    delete process.env.OPENCHROME_ALLOW_REMOTE_CDP;
+    resetHostGuardAuditLatch();
+  });
+  afterAll(() => {
+    if (savedEnv === undefined) delete process.env.OPENCHROME_ALLOW_REMOTE_CDP;
+    else process.env.OPENCHROME_ALLOW_REMOTE_CDP = savedEnv;
+  });
+
+  describe('parseEndpoint', () => {
+    test('parses ws://127.0.0.1:9222', () => {
+      const p = parseEndpoint('ws://127.0.0.1:9222/devtools/browser/abc');
+      expect(p.hostname).toBe('127.0.0.1');
+      expect(p.port).toBe('9222');
+      expect(p.protocol).toBe('ws:');
+    });
+    test('unwraps bracketed IPv6', () => {
+      const p = parseEndpoint('ws://[::1]:9222/devtools/browser/abc');
+      expect(p.hostname).toBe('::1');
+    });
+    test('rejects empty string', () => {
+      expect(() => parseEndpoint('')).toThrow(TypeError);
+    });
+    test('rejects malformed URL', () => {
+      expect(() => parseEndpoint('not-a-url')).toThrow();
+    });
+  });
+
+  describe('isLoopbackHost', () => {
+    test.each([
+      ['localhost', true],
+      ['LocalHost', true],
+      ['127.0.0.1', true],
+      ['127.0.0.2', true],
+      ['127.255.255.254', true],
+      ['::1', true],
+      ['0.0.0.0', false],
+      ['10.0.0.1', false],
+      ['192.168.1.1', false],
+      ['100.105.164.20', false], // Tailscale range
+      ['8.8.8.8', false],
+      ['example.com', false],
+      ['128.0.0.1', false],
+    ])('%s → %s', (host, expected) => {
+      expect(isLoopbackHost(host)).toBe(expected);
+    });
+  });
+
+  describe('assertHostAllowed', () => {
+    test('loopback passes without opt-in', () => {
+      expect(() => assertHostAllowed('ws://127.0.0.1:9222/devtools/browser/x')).not.toThrow();
+      expect(() => assertHostAllowed('ws://localhost:9222/x')).not.toThrow();
+      expect(() => assertHostAllowed('ws://[::1]:9222/x')).not.toThrow();
+    });
+
+    test('non-loopback throws RemoteHostRefusedError by default', () => {
+      let caught: unknown;
+      try {
+        assertHostAllowed('ws://100.64.0.5:9222/devtools/browser/x');
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(RemoteHostRefusedError);
+      const err = caught as RemoteHostRefusedError;
+      expect(err.code).toBe('remote_host_refused');
+      expect(err.hostname).toBe('100.64.0.5');
+      expect(err.protocol).toBe('ws:');
+      expect(err.message).toContain('--allow-remote');
+    });
+
+    test('opts.allowRemote=true bypasses refuse', () => {
+      const logs: string[] = [];
+      expect(() =>
+        assertHostAllowed('ws://10.0.0.5:9222/devtools/browser/x', {
+          allowRemote: true,
+          logger: (m) => logs.push(m),
+        }),
+      ).not.toThrow();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toContain('--allow-remote is ACTIVE');
+      expect(logs[0]).toContain('10.0.0.5');
+    });
+
+    test('audit line is emitted only once across calls', () => {
+      const logs: string[] = [];
+      assertHostAllowed('ws://10.0.0.5:9222/x', { allowRemote: true, logger: (m) => logs.push(m) });
+      assertHostAllowed('ws://10.0.0.6:9222/x', { allowRemote: true, logger: (m) => logs.push(m) });
+      expect(logs).toHaveLength(1);
+    });
+
+    test('env OPENCHROME_ALLOW_REMOTE_CDP=1 bypasses refuse', () => {
+      process.env.OPENCHROME_ALLOW_REMOTE_CDP = '1';
+      const logs: string[] = [];
+      expect(() =>
+        assertHostAllowed('ws://192.168.1.10:9222/x', { logger: (m) => logs.push(m) }),
+      ).not.toThrow();
+      expect(logs[0]).toContain('192.168.1.10');
+    });
+
+    test('env values that are not truthy do NOT bypass', () => {
+      process.env.OPENCHROME_ALLOW_REMOTE_CDP = 'no';
+      expect(() => assertHostAllowed('ws://192.168.1.10:9222/x')).toThrow(RemoteHostRefusedError);
+    });
+  });
+
+  describe('envAllowRemote', () => {
+    test.each([
+      ['1', true],
+      ['true', true],
+      ['TRUE', true],
+      ['yes', true],
+      ['on', true],
+      ['0', false],
+      ['false', false],
+      ['', false],
+    ])('env=%s → %s', (v, expected) => {
+      process.env.OPENCHROME_ALLOW_REMOTE_CDP = v;
+      expect(envAllowRemote()).toBe(expected);
+    });
+    test('unset env → false', () => {
+      expect(envAllowRemote()).toBe(false);
+    });
+  });
+
+  describe('wouldRefuse', () => {
+    test('loopback → false', () => {
+      expect(wouldRefuse('ws://127.0.0.1:9222/x')).toBe(false);
+    });
+    test('remote → true', () => {
+      expect(wouldRefuse('ws://10.0.0.5:9222/x')).toBe(true);
+    });
+    test('malformed → true (fail-closed)', () => {
+      expect(wouldRefuse('garbage')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## 요약

`CDPClient`가 `browserWSEndpoint`를 무조건 `puppeteer.connect()`에 넘기고 있어서, 잘못 구성된 launcher·적대적 CLI 플래그·endpoint 값을 조작한 MCP client 하나면 로컬 오퍼레이터의 세션이 **원격 Chrome을 향한 프록시**로 바뀝니다. 쿠키·스토리지 상태·CDP 명령 전체가 새어 나갑니다.

Chrome은 `--remote-debugging-port`를 loopback-only로 설계·문서화하고 있습니다. openchrome도 non-loopback endpoint를 **기본 거부**하고, 감독된 원격 디버깅 브릿지 케이스에만 **명시적 opt-in**을 요구해야 합니다.

## 근거

Sonar의 openchrome 상류 기여 재판정(v2)의 **P2** 팩입니다. 원본:

- Chromium — `--remote-debugging-port`는 loopback 바인딩이 설계된 기본값이며, 원격 노출은 보안 결함으로 분류됩니다. 이 팩은 그 정책을 client 계층에서 강제합니다.

원본 코드는 복사하지 않았습니다. 문서화된 정책의 clean-room 구현입니다.

## 변경 내용

### 신규 · `src/cdp/host-guard.ts` (+183 라인)

- `parseEndpoint(url)` · ws/wss/http/https URL을 `{ hostname, port, protocol, href }`로 정규화. 잘못된 입력은 앞에서 거부.
- `isLoopbackHost(hostname)` · 고정 allowlist(`localhost`, `127.0.0.1`, `::1`) + 127/8 전 범위. 사설 LAN·link-local·Tailscale(100.64/10)·public IP는 모두 non-loopback.
- `assertHostAllowed(url, opts)` · non-loopback인데 `opts.allowRemote !== true`고 env도 안 켜져 있으면 `RemoteHostRefusedError` 발생. opt-in 시 1회성 audit 라인을 `console.error`로 남겨 오퍼레이터가 unlocked 모드를 인지하도록.
- `RemoteHostRefusedError` · `{ code: 'remote_host_refused', hostname, protocol, endpoint }` typed error. MCP caller가 raw connect 실패 대신 구조화된 오류를 노출 가능.
- Env override · `OPENCHROME_ALLOW_REMOTE_CDP=1|true|yes|on`. CLI 진입점을 감쌀 수 없는 MCP shim 환경 대비.

### 배선 · `src/cdp/client.ts` (+25 라인)

- `CDPClientOptions`에 `allowRemote?: boolean` 추가 (default false).
- `connectInternal()` 재시도 루프의 매 attempt마다 `assertHostAllowed(instance.wsEndpoint, ...)` 호출. Endpoint가 mid-retry에 바뀌어도 재평가.
- `RemoteHostRefusedError`는 policy decision이므로 재시도 소모 없이 즉시 throw.

## 테스트

- `tests/cdp/host-guard.test.ts` · 35 케이스, 모두 통과:
  - `parseEndpoint` · v4·v6·bracketed IPv6·malformed.
  - `isLoopbackHost` · 대소문자·127/8 전 범위·0.0.0.0·10/8·192.168/16·100.64/10 Tailscale·public IP·도메인.
  - `assertHostAllowed` · loopback pass·refuse default·`allowRemote:true` bypass·audit 1회성·env bypass·env falsy는 bypass 안 함.
  - `envAllowRemote` · 1/true/TRUE/yes/on/0/false/빈 문자열/unset.
  - `wouldRefuse` · loopback·remote·malformed(fail-closed).

빌드:
- `node_modules/.bin/tsc -p tsconfig.json --noEmit` · 0 errors.
- `node_modules/.bin/jest tests/cdp/host-guard.test.ts` · 35 passed.

## 참고

- v2 계획서 · `docs/rebirth/OPENCHROME-CONTRIBUTION-PLAN-V2.md` §5 P2
- 90개 전수 근거 · `docs/rebirth/ULTIMATE-CENSUS-2026-07-18.md`
- 원본 코드 미열람 clean-room 구현. `src/cdp/host-guard.ts` 상단 주석에 origin credit.

## 관련

이 팩은 v2 계획의 **P2** 팩입니다. Batch 2의 6개 팩(P3·P14·P15·P17·P18·P21)이 동시에 별도 PR로 제출됩니다.