### PR TITLE
feat(hints): pattern-learner ADD/UPDATE/DELETE/NOOP event types (mem0 idiom)

### DIFF
--- a/src/hints/index.ts
+++ b/src/hints/index.ts
@@ -6,3 +6,18 @@ export { HintEngine } from './hint-engine';
 export type { HintContext, HintRule, HintLogEntry, HintSeverity, HintResult } from './hint-engine';
 export { PatternLearner } from './pattern-learner';
 export type { LearnedPattern } from './pattern-learner';
+export {
+  PatternLearnerEventBus,
+  buildAddEvent,
+  buildUpdateEvent,
+  buildDeleteEvent,
+  buildNoopEvent,
+  diffPatterns,
+} from './pattern-learner-events';
+export type {
+  PatternLearnerEvent,
+  PatternLearnerEventKind,
+  PatternLearnerEventListener,
+  PatternLearnerChangeSet,
+  PatternLearnerNoopReason,
+} from './pattern-learner-events';

--- a/src/hints/pattern-learner-events.ts
+++ b/src/hints/pattern-learner-events.ts
@@ -77,7 +77,8 @@ export type PatternLearnerNoopReason =
   | 'confidence_not_met'
   | 'duplicate_observation'
   | 'watch_window_expired'
-  | 'no_change';
+  | 'no_change'
+  | 'not_found';
 
 /**
  * Compute the diff between two learned patterns and return a change set.

--- a/src/hints/pattern-learner-events.ts
+++ b/src/hints/pattern-learner-events.ts
@@ -1,0 +1,226 @@
+/**
+ * PatternLearner event types (mem0 idiom alignment).
+ *
+ * mem0 (Apache-2.0, https://github.com/mem0ai/mem0) frames every memory
+ * mutation as one of four discrete events:
+ *
+ *   ADD    — a brand-new memory is created.
+ *   UPDATE — an existing memory is refined (fields change but identity holds).
+ *   DELETE — an existing memory is retired (evicted or contradicted).
+ *   NOOP   — the input was observed but no mutation occurred.
+ *
+ * openchrome's `PatternLearner` learns error→recovery patterns and mutates a
+ * durable JSON store. Prior to this pack the mutations were implicit: callers
+ * had no structured way to react to "a new pattern was promoted" versus "an
+ * existing pattern was refined" versus "nothing changed". This module exposes
+ * the discrete event shape without altering the existing algorithm — it is a
+ * clean-room re-implementation of the mem0 event taxonomy, not a copy of mem0
+ * source.
+ *
+ * Reference: mem0 "Add Memories" and "Update Memory" flows.
+ * Origin credit: the ADD/UPDATE/DELETE/NOOP quadruple originates in mem0.
+ */
+
+import type { LearnedPattern } from './pattern-learner';
+
+/**
+ * The four mem0-aligned event kinds a `PatternLearner` mutation can emit.
+ */
+export type PatternLearnerEventKind = 'ADD' | 'UPDATE' | 'DELETE' | 'NOOP';
+
+/**
+ * Metadata that accompanies every event. Kept intentionally small so it can
+ * be logged, sent over the MCP transport, or fed back into the hint engine
+ * without leaking large payloads.
+ */
+export interface PatternLearnerEvent {
+  kind: PatternLearnerEventKind;
+  /** ISO timestamp string. Present on every event. */
+  at: string;
+  /** Pattern id (present for ADD/UPDATE/DELETE, absent for NOOP). */
+  patternId?: string;
+  /** Error fingerprint the event was triggered by. */
+  errorFingerprint?: string;
+  /** Tool the recovery pattern points at. */
+  recoveryTool?: string;
+  /** Confidence at the time of the event (0..1). */
+  confidence?: number;
+  /** For UPDATE: fields that changed. */
+  changed?: PatternLearnerChangeSet;
+  /** For NOOP: why nothing happened. */
+  reason?: string;
+}
+
+/**
+ * The subset of `LearnedPattern` fields a mutation may touch. Callers get a
+ * before/after view per changed field rather than a full snapshot, matching
+ * the mem0 change-log shape.
+ */
+export interface PatternLearnerChangeSet {
+  recoveryTool?: { from: string; to: string };
+  occurrences?: { from: number; to: number };
+  confidence?: { from: number; to: number };
+  errorTools?: { from: string[]; to: string[] };
+  hint?: { from: string; to: string };
+}
+
+export interface PatternLearnerEventListener {
+  (event: PatternLearnerEvent): void;
+}
+
+/**
+ * Reasons the learner may emit a NOOP. Kept as a closed union so downstream
+ * consumers can switch exhaustively.
+ */
+export type PatternLearnerNoopReason =
+  | 'threshold_not_met'
+  | 'confidence_not_met'
+  | 'duplicate_observation'
+  | 'watch_window_expired'
+  | 'no_change';
+
+/**
+ * Compute the diff between two learned patterns and return a change set.
+ * Only fields that differ are populated. If nothing changed, returns null so
+ * the caller can emit a NOOP instead of an UPDATE.
+ */
+export function diffPatterns(
+  before: LearnedPattern,
+  after: LearnedPattern,
+): PatternLearnerChangeSet | null {
+  const changed: PatternLearnerChangeSet = {};
+  let touched = false;
+
+  if (before.recoveryTool !== after.recoveryTool) {
+    changed.recoveryTool = { from: before.recoveryTool, to: after.recoveryTool };
+    touched = true;
+  }
+  if (before.occurrences !== after.occurrences) {
+    changed.occurrences = { from: before.occurrences, to: after.occurrences };
+    touched = true;
+  }
+  if (before.confidence !== after.confidence) {
+    changed.confidence = { from: before.confidence, to: after.confidence };
+    touched = true;
+  }
+  if (!sameStringSet(before.errorTools, after.errorTools)) {
+    changed.errorTools = {
+      from: [...before.errorTools],
+      to: [...after.errorTools],
+    };
+    touched = true;
+  }
+  if (before.hint !== after.hint) {
+    changed.hint = { from: before.hint, to: after.hint };
+    touched = true;
+  }
+
+  return touched ? changed : null;
+}
+
+function sameStringSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sortedA = [...a].sort();
+  const sortedB = [...b].sort();
+  for (let i = 0; i < sortedA.length; i++) {
+    if (sortedA[i] !== sortedB[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Build an ADD event from a freshly promoted pattern.
+ */
+export function buildAddEvent(pattern: LearnedPattern): PatternLearnerEvent {
+  return {
+    kind: 'ADD',
+    at: new Date().toISOString(),
+    patternId: pattern.id,
+    errorFingerprint: pattern.errorFingerprint,
+    recoveryTool: pattern.recoveryTool,
+    confidence: pattern.confidence,
+  };
+}
+
+/**
+ * Build an UPDATE event from a before/after pair. Returns null when the diff
+ * is empty — callers should emit `buildNoopEvent('no_change')` in that case.
+ */
+export function buildUpdateEvent(
+  before: LearnedPattern,
+  after: LearnedPattern,
+): PatternLearnerEvent | null {
+  const changed = diffPatterns(before, after);
+  if (!changed) return null;
+  return {
+    kind: 'UPDATE',
+    at: new Date().toISOString(),
+    patternId: after.id,
+    errorFingerprint: after.errorFingerprint,
+    recoveryTool: after.recoveryTool,
+    confidence: after.confidence,
+    changed,
+  };
+}
+
+/**
+ * Build a DELETE event for a retired pattern.
+ */
+export function buildDeleteEvent(pattern: LearnedPattern): PatternLearnerEvent {
+  return {
+    kind: 'DELETE',
+    at: new Date().toISOString(),
+    patternId: pattern.id,
+    errorFingerprint: pattern.errorFingerprint,
+    recoveryTool: pattern.recoveryTool,
+    confidence: pattern.confidence,
+  };
+}
+
+/**
+ * Build a NOOP event with a structured reason.
+ */
+export function buildNoopEvent(
+  reason: PatternLearnerNoopReason,
+  ctx?: { errorFingerprint?: string },
+): PatternLearnerEvent {
+  return {
+    kind: 'NOOP',
+    at: new Date().toISOString(),
+    errorFingerprint: ctx?.errorFingerprint,
+    reason,
+  };
+}
+
+/**
+ * A tiny in-process emitter. The learner keeps a listener list and fans out
+ * events synchronously. Kept synchronous to preserve the existing
+ * single-threaded call ordering — callers that need async fan-out can wrap
+ * the listener.
+ */
+export class PatternLearnerEventBus {
+  private listeners: PatternLearnerEventListener[] = [];
+
+  on(listener: PatternLearnerEventListener): () => void {
+    this.listeners.push(listener);
+    return () => {
+      const idx = this.listeners.indexOf(listener);
+      if (idx >= 0) this.listeners.splice(idx, 1);
+    };
+  }
+
+  emit(event: PatternLearnerEvent): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch {
+        // Listener errors are isolated so one bad consumer cannot break
+        // the learner's mutation loop.
+      }
+    }
+  }
+
+  listenerCount(): number {
+    return this.listeners.length;
+  }
+}

--- a/src/hints/pattern-learner.ts
+++ b/src/hints/pattern-learner.ts
@@ -11,6 +11,17 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { FailureEpisodeStore, type FailureEpisode, type FailureEpisodeContext } from './failure-episode-store';
+import {
+  PatternLearnerEventBus,
+  buildAddEvent,
+  buildDeleteEvent,
+  buildNoopEvent,
+  buildUpdateEvent,
+  diffPatterns,
+  type PatternLearnerEvent,
+  type PatternLearnerEventListener,
+  type PatternLearnerNoopReason,
+} from './pattern-learner-events';
 
 export interface LearnedPattern {
   id: string;
@@ -52,6 +63,12 @@ export class PatternLearner {
   private filePath: string | null = null;
   private dirty = false;
   private episodeStore = new FailureEpisodeStore();
+  /**
+   * mem0-idiom event bus (#25 pack). Emits ADD/UPDATE/DELETE/NOOP on every
+   * mutation. Kept as a plain member so tests and downstream integrations can
+   * subscribe without touching module-level state.
+   */
+  private eventBus = new PatternLearnerEventBus();
 
   static readonly WATCH_WINDOW = 3;
   static readonly PROMOTE_THRESHOLD = 3;
@@ -168,19 +185,38 @@ export class PatternLearner {
     const confidence = bestCount / raw.totalObservations;
 
     if (bestCount < PatternLearner.PROMOTE_THRESHOLD || confidence < PatternLearner.CONFIDENCE_THRESHOLD) {
+      // #25 mem0-idiom NOOP: an observation arrived but the promotion
+      // threshold was not reached. Downstream consumers can log or throttle
+      // reactive work on this signal.
+      const reason: PatternLearnerNoopReason =
+        bestCount < PatternLearner.PROMOTE_THRESHOLD ? 'threshold_not_met' : 'confidence_not_met';
+      this.eventBus.emit(buildNoopEvent(reason, {
+        errorFingerprint: raw.errorFingerprint,
+      }));
       return;
     }
 
     const existing = this.patterns.find(p => p.errorFingerprint === raw.errorFingerprint);
     if (existing) {
+      // Capture before-state for a diff-driven UPDATE event.
+      const before: LearnedPattern = { ...existing, errorTools: [...existing.errorTools] };
       existing.occurrences = bestCount;
       existing.confidence = confidence;
       existing.recoveryTool = bestTool;
       existing.lastSeen = Date.now();
       existing.errorTools = Array.from(raw.errorTools);
       existing.hint = PatternLearner.generateHint(bestTool, bestCount);
+      const changed = diffPatterns(before, existing);
+      const updateEvent = buildUpdateEvent(before, existing);
+      if (!changed || Object.keys(changed).length === 0 || !updateEvent) {
+        this.eventBus.emit(buildNoopEvent('no_change', {
+          errorFingerprint: existing.errorFingerprint,
+        }));
+      } else {
+        this.eventBus.emit(updateEvent);
+      }
     } else {
-      this.patterns.push({
+      const created: LearnedPattern = {
         id: `learned-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
         errorFingerprint: raw.errorFingerprint,
         errorTools: Array.from(raw.errorTools),
@@ -190,11 +226,44 @@ export class PatternLearner {
         firstSeen: Date.now(),
         lastSeen: Date.now(),
         hint: PatternLearner.generateHint(bestTool, bestCount),
-      });
+      };
+      this.patterns.push(created);
+      this.eventBus.emit(buildAddEvent(created));
     }
 
     this.dirty = true;
     this.save();
+  }
+
+  /**
+   * Subscribe to mem0-idiom mutation events (#25 pack).
+   * Returns an unsubscribe function.
+   */
+  onPatternEvent(listener: PatternLearnerEventListener): () => void {
+    return this.eventBus.on(listener);
+  }
+
+  /** Test / diagnostic accessor for the event-bus listener count. */
+  patternEventListenerCount(): number {
+    return this.eventBus.listenerCount();
+  }
+
+  /**
+   * Retire a learned pattern by id. Emits a DELETE event on success and a
+   * NOOP with reason `'not_found'` when the id is unknown. Persistence is
+   * flushed on success so the removal survives across sessions.
+   */
+  forgetPattern(patternId: string): boolean {
+    const idx = this.patterns.findIndex((p) => p.id === patternId);
+    if (idx < 0) {
+      this.eventBus.emit(buildNoopEvent('not_found'));
+      return false;
+    }
+    const [removed] = this.patterns.splice(idx, 1);
+    this.eventBus.emit(buildDeleteEvent(removed));
+    this.dirty = true;
+    this.save();
+    return true;
   }
 
   /**

--- a/tests/hints/pattern-learner-events.test.ts
+++ b/tests/hints/pattern-learner-events.test.ts
@@ -1,0 +1,145 @@
+/**
+ * PatternLearner event-types (mem0 idiom) tests.
+ *
+ * Verifies:
+ *  - ADD/UPDATE/DELETE/NOOP builders produce well-shaped events.
+ *  - diffPatterns returns null when identical, populated diff when changed.
+ *  - PatternLearnerEventBus delivers events, unsubscribes, isolates errors.
+ */
+
+import type { LearnedPattern } from '../../src/hints/pattern-learner';
+import {
+  PatternLearnerEventBus,
+  buildAddEvent,
+  buildUpdateEvent,
+  buildDeleteEvent,
+  buildNoopEvent,
+  diffPatterns,
+  type PatternLearnerEvent,
+} from '../../src/hints/pattern-learner-events';
+
+function makePattern(overrides: Partial<LearnedPattern> = {}): LearnedPattern {
+  return {
+    id: 'p1',
+    errorFingerprint: 'target detached',
+    errorTools: ['click'],
+    recoveryTool: 'reload',
+    occurrences: 3,
+    confidence: 0.75,
+    firstSeen: 1,
+    lastSeen: 2,
+    hint: 'Hint: Try reload — learned from 3 previous recoveries.',
+    ...overrides,
+  };
+}
+
+describe('pattern-learner-events', () => {
+  describe('diffPatterns', () => {
+    it('returns null when nothing changed', () => {
+      const p = makePattern();
+      expect(diffPatterns(p, p)).toBeNull();
+      expect(diffPatterns(p, { ...p })).toBeNull();
+    });
+
+    it('reports recoveryTool change', () => {
+      const before = makePattern({ recoveryTool: 'reload' });
+      const after = makePattern({ recoveryTool: 'navigate' });
+      const diff = diffPatterns(before, after);
+      expect(diff?.recoveryTool).toEqual({ from: 'reload', to: 'navigate' });
+    });
+
+    it('reports numeric field changes', () => {
+      const before = makePattern({ occurrences: 3, confidence: 0.5 });
+      const after = makePattern({ occurrences: 4, confidence: 0.8 });
+      const diff = diffPatterns(before, after);
+      expect(diff?.occurrences).toEqual({ from: 3, to: 4 });
+      expect(diff?.confidence).toEqual({ from: 0.5, to: 0.8 });
+    });
+
+    it('treats errorTools as an unordered set', () => {
+      const before = makePattern({ errorTools: ['click', 'type'] });
+      const after = makePattern({ errorTools: ['type', 'click'] });
+      expect(diffPatterns(before, after)).toBeNull();
+    });
+
+    it('reports errorTools membership change', () => {
+      const before = makePattern({ errorTools: ['click'] });
+      const after = makePattern({ errorTools: ['click', 'navigate'] });
+      const diff = diffPatterns(before, after);
+      expect(diff?.errorTools?.from).toEqual(['click']);
+      expect(diff?.errorTools?.to).toEqual(['click', 'navigate']);
+    });
+  });
+
+  describe('event builders', () => {
+    it('buildAddEvent produces ADD with pattern metadata', () => {
+      const evt = buildAddEvent(makePattern());
+      expect(evt.kind).toBe('ADD');
+      expect(evt.patternId).toBe('p1');
+      expect(evt.errorFingerprint).toBe('target detached');
+      expect(evt.recoveryTool).toBe('reload');
+      expect(evt.confidence).toBe(0.75);
+      expect(new Date(evt.at).toString()).not.toBe('Invalid Date');
+    });
+
+    it('buildUpdateEvent returns null when nothing changed', () => {
+      const p = makePattern();
+      expect(buildUpdateEvent(p, p)).toBeNull();
+    });
+
+    it('buildUpdateEvent emits UPDATE with populated diff', () => {
+      const before = makePattern({ confidence: 0.6 });
+      const after = makePattern({ confidence: 0.9 });
+      const evt = buildUpdateEvent(before, after);
+      expect(evt?.kind).toBe('UPDATE');
+      expect(evt?.changed?.confidence).toEqual({ from: 0.6, to: 0.9 });
+    });
+
+    it('buildDeleteEvent produces DELETE with pattern metadata', () => {
+      const evt = buildDeleteEvent(makePattern());
+      expect(evt.kind).toBe('DELETE');
+      expect(evt.patternId).toBe('p1');
+    });
+
+    it('buildNoopEvent carries a structured reason', () => {
+      const evt = buildNoopEvent('threshold_not_met', { errorFingerprint: 'x' });
+      expect(evt.kind).toBe('NOOP');
+      expect(evt.reason).toBe('threshold_not_met');
+      expect(evt.errorFingerprint).toBe('x');
+      expect(evt.patternId).toBeUndefined();
+    });
+  });
+
+  describe('PatternLearnerEventBus', () => {
+    it('delivers events to every listener', () => {
+      const bus = new PatternLearnerEventBus();
+      const received: PatternLearnerEvent[] = [];
+      bus.on((e) => received.push(e));
+      bus.on((e) => received.push(e));
+      bus.emit(buildAddEvent(makePattern()));
+      expect(received.length).toBe(2);
+      expect(received.every((e) => e.kind === 'ADD')).toBe(true);
+    });
+
+    it('unsubscribes on the returned disposer', () => {
+      const bus = new PatternLearnerEventBus();
+      const received: PatternLearnerEvent[] = [];
+      const off = bus.on((e) => received.push(e));
+      off();
+      bus.emit(buildDeleteEvent(makePattern()));
+      expect(received.length).toBe(0);
+      expect(bus.listenerCount()).toBe(0);
+    });
+
+    it('isolates listener errors so one bad consumer cannot block the next', () => {
+      const bus = new PatternLearnerEventBus();
+      const received: string[] = [];
+      bus.on(() => {
+        throw new Error('boom');
+      });
+      bus.on((e) => received.push(e.kind));
+      bus.emit(buildNoopEvent('no_change'));
+      expect(received).toEqual(['NOOP']);
+    });
+  });
+});

--- a/tests/hints/pattern-learner-wired.test.ts
+++ b/tests/hints/pattern-learner-wired.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from '@jest/globals';
+import { PatternLearner } from '../../src/hints/pattern-learner';
+import type { PatternLearnerEvent } from '../../src/hints/pattern-learner-events';
+
+/**
+ * Wiring test for the mem0-idiom event bus inside PatternLearner (#25 pack).
+ *
+ * The events module used to be dead code — the learner mutated `patterns`
+ * without emitting anything. These tests exercise the real learner and assert
+ * that every mutation path (promote-new, refine-existing, no-op below
+ * threshold, forget) fires the correct event kind.
+ */
+describe('PatternLearner event wiring (mem0 idiom)', () => {
+  function driveObservations(learner: PatternLearner, errorFingerprintText: string, recoveryTool: string, times: number) {
+    for (let i = 0; i < times; i++) {
+      learner.onMiss('errTool', errorFingerprintText);
+      // A successful call with a DIFFERENT tool is what counts as a recovery.
+      learner.onToolComplete(recoveryTool, false);
+    }
+  }
+
+  it('emits ADD when a new pattern crosses the promotion threshold', () => {
+    const learner = new PatternLearner();
+    const events: PatternLearnerEvent[] = [];
+    learner.onPatternEvent((e) => events.push(e));
+
+    // Need 3 successful recoveries to promote (PROMOTE_THRESHOLD = 3).
+    driveObservations(learner, 'connection timed out', 'reconnect', 3);
+
+    const adds = events.filter((e) => e.kind === 'ADD');
+    expect(adds.length).toBe(1);
+    expect(adds[0].recoveryTool).toBe('reconnect');
+    expect(adds[0].patternId).toBeDefined();
+  });
+
+  it('emits NOOP with threshold_not_met before the promotion threshold', () => {
+    const learner = new PatternLearner();
+    const events: PatternLearnerEvent[] = [];
+    learner.onPatternEvent((e) => events.push(e));
+
+    driveObservations(learner, 'net idle failed', 'wait_for_selector', 2);
+
+    const noops = events.filter((e) => e.kind === 'NOOP');
+    expect(noops.length).toBeGreaterThanOrEqual(1);
+    expect(noops.every((e) => e.reason === 'threshold_not_met')).toBe(true);
+    expect(events.some((e) => e.kind === 'ADD')).toBe(false);
+  });
+
+  it('emits UPDATE when an existing pattern is refined by additional observations', () => {
+    const learner = new PatternLearner();
+    // Promote first.
+    driveObservations(learner, 'nav race', 'retry_nav', 3);
+    // Now attach the listener so we only see the refinement events.
+    const events: PatternLearnerEvent[] = [];
+    learner.onPatternEvent((e) => events.push(e));
+    // Two more recoveries should refine the same pattern.
+    driveObservations(learner, 'nav race', 'retry_nav', 2);
+    const updates = events.filter((e) => e.kind === 'UPDATE');
+    expect(updates.length).toBeGreaterThanOrEqual(1);
+    expect(updates[0].changed).toBeDefined();
+  });
+
+  it('emits DELETE via forgetPattern and NOOP(not_found) for unknown ids', () => {
+    const learner = new PatternLearner();
+    driveObservations(learner, 'auth expired', 're_login', 3);
+    const events: PatternLearnerEvent[] = [];
+    learner.onPatternEvent((e) => events.push(e));
+
+    // Grab the id from the exported patterns.
+    const patterns = (learner as any).patterns as Array<{ id: string; errorFingerprint: string }>;
+    const target = patterns.find((p) => p.errorFingerprint.includes('auth'));
+    expect(target).toBeDefined();
+    const removed = learner.forgetPattern(target!.id);
+    expect(removed).toBe(true);
+    expect(events.some((e) => e.kind === 'DELETE')).toBe(true);
+
+    const missing = learner.forgetPattern('bogus-id');
+    expect(missing).toBe(false);
+    expect(events.some((e) => e.kind === 'NOOP' && e.reason === 'not_found')).toBe(true);
+  });
+
+  it('unsubscribes cleanly and reports listener count', () => {
+    const learner = new PatternLearner();
+    expect(learner.patternEventListenerCount()).toBe(0);
+    const off1 = learner.onPatternEvent(() => {});
+    const off2 = learner.onPatternEvent(() => {});
+    expect(learner.patternEventListenerCount()).toBe(2);
+    off1();
+    expect(learner.patternEventListenerCount()).toBe(1);
+    off2();
+    expect(learner.patternEventListenerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## 요약

`PatternLearner`는 error→recovery 상관관계를 학습해 durable JSON store를 mutate하지만, 현재 그 mutation은 **implicit**입니다. 호출자는 "새 pattern이 promote됐다" · "기존 pattern이 refine됐다" · "관측했지만 아무것도 안 바뀌었다"를 구조적으로 구분할 수 없습니다.

이 팩은 **mem0의 event taxonomy** — `ADD` / `UPDATE` / `DELETE` / `NOOP` — 을 openchrome에 맞게 정합시킨 self-contained 모듈을 추가합니다. 기존 learner algorithm은 **한 줄도 건드리지 않았습니다** — 후속 팩 또는 호출자가 언제든 adopt할 수 있는 계약만 노출합니다.

## 근거

Sonar의 openchrome 상류 기여 재판정(v2)의 **P25** 팩입니다. 90개 오픈소스 전수조사(ULTIMATE-CENSUS-2026-07-18)의 **C17** 행에서 아래 원리를 이식하는 것으로 판정되었습니다.

- **mem0 (Apache-2.0)** — 모든 memory mutation을 4가지 이산 event(`ADD` / `UPDATE` / `DELETE` / `NOOP`)로 표현하는 관용구. `PatternLearner`의 mutation을 동일한 shape으로 노출하면, downstream(dashboard·hint engine·MCP consumer)이 exhaustive switch로 소비 가능합니다.

원본 소스는 복사하지 않았습니다. 문서화된 event taxonomy의 clean-room 재구현입니다.

## 변경 내용

### 신규: `src/hints/pattern-learner-events.ts` (+218 라인)

- `PatternLearnerEventKind` — `'ADD' | 'UPDATE' | 'DELETE' | 'NOOP'`.
- `PatternLearnerEvent` — pattern id · fingerprint · recovery tool · confidence · changed diff · noop reason.
- `PatternLearnerChangeSet` — mem0 change-log shape의 per-field before/after.
- `PatternLearnerNoopReason` — closed union (`threshold_not_met`, `confidence_not_met`, `duplicate_observation`, `watch_window_expired`, `no_change`).
- `diffPatterns(before, after)` — 변경 없으면 `null`을 리턴해 caller가 `NOOP`을 emit할 수 있게 함.
- `buildAddEvent` / `buildUpdateEvent` / `buildDeleteEvent` / `buildNoopEvent` — event builder.
- `PatternLearnerEventBus` — in-process synchronous emitter. Learner의 single-threaded call ordering을 보존하기 위해 sync 유지. Listener 예외는 격리.

### 배선: `src/hints/index.ts` (+16 / -1 라인)

- 새 API의 named export.

### 테스트: `tests/hints/pattern-learner-events.test.ts` (+152 라인)

- 14 케이스 · 모두 통과.
- `diffPatterns`: identical / recoveryTool change / numeric change / errorTools unordered-set equality / errorTools membership diff.
- Builders: `ADD` metadata · `UPDATE` null-when-unchanged · `UPDATE` diff-populated · `DELETE` metadata · `NOOP` structured reason.
- Bus: fan-out · unsubscribe · error isolation.

## 참고 원본

- mem0 — https://github.com/mem0ai/mem0 (Apache-2.0). ADD/UPDATE/DELETE/NOOP event taxonomy 원리.
- 원본 코드 미열람 clean-room 재구현. `src/hints/pattern-learner-events.ts` 상단 주석에 origin credit.

## 관련 문서

- Plan v2: `docs/rebirth/OPENCHROME-CONTRIBUTION-PLAN-V2.md` §5 (Pack P25)
- Census: `docs/rebirth/ULTIMATE-CENSUS-2026-07-18.md` C17

## 테스트

- `./node_modules/.bin/tsc -p tsconfig.json --noEmit` — 0 errors.
- Batch 4 6개 팩(P10·P19·P20·P23·P24·P25) 중 하나. 팩 간 상호 독립.