### PR TITLE
feat(chrome): --launch-on-first-use lazy gate (Chrome spawns on first tool call)

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -37,6 +37,7 @@ import { getIdleState } from '../utils/idle-state';
 import { assertDomainAllowed, isInternalBrowserUrl } from '../security/domain-guard';
 import { applyRegisteredPreloads } from './preload-injector';
 import { TargetPageIndex } from './target-page-index';
+import { resolveEffectiveAutoLaunch } from '../chrome/launch-gate';
 
 // Cookie type shared across methods
 type CookieEntry = {
@@ -68,6 +69,14 @@ export interface CDPClientOptions {
   heartbeatIntervalMs?: number;
   /** If true, auto-launch Chrome when not running (default: false) */
   autoLaunch?: boolean;
+  /**
+   * When true, treat `autoLaunch` as `false` for `ensureChrome()` calls that
+   * happen **before** the process-wide launch gate is armed (typically by
+   * MCP tool dispatch). This defers Chrome spawn from server-boot time to
+   * first-tool-call time. Default: false. Also honours env
+   * `OPENCHROME_LAUNCH_ON_FIRST_USE=1`.
+   */
+  launchOnFirstUse?: boolean;
 }
 
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
@@ -111,6 +120,7 @@ export class CDPClient {
   private consecutiveHeartbeatSuccesses = 0;
   private checkConnectionInFlight = false;
   private autoLaunch: boolean;
+  private launchOnFirstUse: boolean;
   private cookieSourceCache: Map<string, { targetId: string; timestamp: number }> = new Map();
   private cookieDataCache: Map<string, { cookies: CookieEntry[]; timestamp: number }> = new Map();
   private targetIdIndex = new TargetPageIndex();
@@ -169,6 +179,10 @@ export class CDPClient {
     this.heartbeatIntervalMs = options.heartbeatIntervalMs ?? parseEnvInt('OPENCHROME_HEARTBEAT_INTERVAL_MS', DEFAULT_HEARTBEAT_INTERVAL_MS);
     // Use explicit option if provided, otherwise use global config
     this.autoLaunch = options.autoLaunch !== undefined ? options.autoLaunch : globalConfig.autoLaunch;
+    // Launch-gate opt-in — when true, defer physical Chrome spawn from
+    // startup-time `ensureChrome()` to first-tool-call time. See
+    // src/chrome/launch-gate.ts.
+    this.launchOnFirstUse = options.launchOnFirstUse === true;
   }
 
   /**
@@ -710,8 +724,13 @@ export class CDPClient {
         budget!.requireRemaining(DEFAULT_SESSION_INIT_MIN_ATTEMPT_MS, 'connectInternal.attempt-gate');
       }
 
-      // Re-fetch instance on each attempt — Chrome may have regenerated its UUID
-      const instance = await launcher.ensureChrome({ autoLaunch });
+      // Re-fetch instance on each attempt — Chrome may have regenerated its UUID.
+      // Route autoLaunch through the launch-gate translator so `--launch-on-first-use`
+      // callers see `false` until MCP has armed the gate on first tool call.
+      const effectiveAutoLaunch = resolveEffectiveAutoLaunch(autoLaunch, {
+        launchOnFirstUse: this.launchOnFirstUse,
+      });
+      const instance = await launcher.ensureChrome({ autoLaunch: effectiveAutoLaunch });
       if (!this.isCurrentConnectionGeneration(generation)) {
         return false;
       }

--- a/src/chrome/launch-gate.ts
+++ b/src/chrome/launch-gate.ts
@@ -1,0 +1,157 @@
+/**
+ * Launch Gate — deferred `autoLaunch` for `--launch-on-first-use`.
+ *
+ * Why this exists
+ * ---------------
+ * openchrome today has two extremes for Chrome lifecycle:
+ *
+ *   1. `autoLaunch=false` (default) · the server refuses to spawn Chrome
+ *      even when a tool call needs it. The operator has to manually start
+ *      Chrome with `--remote-debugging-port` before any request works.
+ *   2. `autoLaunch=true` · Chrome is spawned aggressively — including at
+ *      **server startup** (readiness probes, health endpoints, and any
+ *      early `ensureChrome()` call), before any client tool call has
+ *      arrived. This defeats a common ops pattern: run `openchrome serve`
+ *      under a systemd unit or `pnpm dev` sidecar and let it sit idle
+ *      until a real request appears.
+ *
+ * The gate is a middle position: `autoLaunch=true` **semantically**, but
+ * physically Chrome only spawns after the *first tool call* has arrived.
+ * Startup-time `ensureChrome()` calls that predate the first tool see
+ * `autoLaunch=false` and fail loudly (or, in the readiness path, skip).
+ * The moment MCP dispatches the first tool, the gate is armed and the
+ * next `ensureChrome()` proceeds with the launch.
+ *
+ * Design
+ * ------
+ * - Module-level singleton with `arm()` / `disarm()` / `isArmed()` /
+ *   `resetForTests()`. One process, one gate.
+ * - `resolveEffectiveAutoLaunch(cfgAutoLaunch, opts)` — the sanctioned
+ *   translator. Callers pass their configured `autoLaunch` and, when the
+ *   caller opted into the gate, this returns `false` until the gate is
+ *   armed and `cfgAutoLaunch` afterwards.
+ * - `onFirstUse(fn)` — optional subscriber for observability (metrics,
+ *   startup timing). Fires exactly once, on the first successful `arm()`.
+ *
+ * Wiring notes
+ * ------------
+ * The gate is intentionally decoupled from the CLI. A caller opts in per
+ * `CDPClient` via `CDPClientOptions.launchOnFirstUse`, or globally via
+ * `OPENCHROME_LAUNCH_ON_FIRST_USE=1`. The MCP tool-dispatch layer arms
+ * the gate before invoking any tool; the health/readiness path does not.
+ *
+ * Origin credit
+ * -------------
+ * The "lazy launch on first tool" idiom is the same pattern many MCP
+ * servers use to avoid warming heavyweight processes for idle registries
+ * (see e.g. chrome-devtools-mcp's attach-on-demand recipe). This module
+ * is a clean-room implementation.
+ */
+
+export interface LaunchGateOptions {
+  /** When true, the caller opts into the deferred-launch behaviour. */
+  launchOnFirstUse?: boolean;
+}
+
+let _armed = false;
+let _armedAt = 0;
+const _listeners: Array<() => void> = [];
+
+/**
+ * Arm the gate. Subsequent `resolveEffectiveAutoLaunch()` calls that
+ * were previously being coerced to `false` will now return the caller's
+ * configured `autoLaunch`. Fires the first-use listeners exactly once.
+ *
+ * Idempotent: repeated calls after the first are no-ops.
+ */
+export function arm(): void {
+  if (_armed) return;
+  _armed = true;
+  _armedAt = Date.now();
+  const snapshot = _listeners.slice();
+  _listeners.length = 0;
+  for (const fn of snapshot) {
+    try {
+      fn();
+    } catch (err) {
+      // Listener errors must not corrupt the gate state.
+      console.error('[LaunchGate] first-use listener threw:', err);
+    }
+  }
+}
+
+/**
+ * Disarm the gate. Intended for shutdown paths that want to prevent
+ * further launches (e.g. graceful stop). New `ensureChrome()` calls
+ * after this point behave as `autoLaunch=false` under the gate again.
+ */
+export function disarm(): void {
+  _armed = false;
+  _armedAt = 0;
+}
+
+/** Read the gate state. */
+export function isArmed(): boolean {
+  return _armed;
+}
+
+/** Timestamp of the arming event (0 if disarmed). */
+export function armedAt(): number {
+  return _armedAt;
+}
+
+/**
+ * Subscribe to the first-use event. If the gate is already armed the
+ * listener fires synchronously. Otherwise it fires exactly once on the
+ * next `arm()` call.
+ */
+export function onFirstUse(fn: () => void): void {
+  if (_armed) {
+    try {
+      fn();
+    } catch (err) {
+      console.error('[LaunchGate] first-use listener threw:', err);
+    }
+    return;
+  }
+  _listeners.push(fn);
+}
+
+/**
+ * Read the env opt-in. Kept as a function so tests can stub the env per
+ * call. Truthy values: `1`, `true`, `yes`, `on` (case-insensitive).
+ */
+export function envLaunchOnFirstUse(): boolean {
+  const raw = process.env.OPENCHROME_LAUNCH_ON_FIRST_USE;
+  if (!raw) return false;
+  const v = raw.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on';
+}
+
+/**
+ * Sanctioned translator. Callers should never gate on `isArmed()`
+ * directly — they should route their `autoLaunch` choice through this
+ * function so the opt-in check and env override live in one place.
+ *
+ * Behaviour matrix (opt-in on):
+ *   gate armed   → returns `cfgAutoLaunch` (pass-through)
+ *   gate disarmed → returns `false` (defer launch)
+ *
+ * Behaviour matrix (opt-in off):
+ *   any state → returns `cfgAutoLaunch` (pass-through)
+ */
+export function resolveEffectiveAutoLaunch(
+  cfgAutoLaunch: boolean,
+  opts: LaunchGateOptions = {},
+): boolean {
+  const optedIn = opts.launchOnFirstUse === true || envLaunchOnFirstUse();
+  if (!optedIn) return cfgAutoLaunch;
+  return _armed ? cfgAutoLaunch : false;
+}
+
+/** Test-only reset. */
+export function resetLaunchGateForTests(): void {
+  _armed = false;
+  _armedAt = 0;
+  _listeners.length = 0;
+}

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -205,6 +205,11 @@ class OpenChromeServerImpl implements OpenChromeServer {
 
     console.error(`[openchrome] Chrome debugging port: ${port}`);
     console.error(`[openchrome] Auto-launch Chrome: ${autoLaunch}`);
+    // Launch-gate mode is opt-in via env (or the per-client option). When on,
+    // physical Chrome spawn is deferred until the first MCP tool call.
+    if (process.env.OPENCHROME_LAUNCH_ON_FIRST_USE) {
+      console.error('[openchrome] Launch-on-first-use: ON (Chrome will spawn on first tool call)');
+    }
 
     // Headless resolution
     let headless: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,11 +135,21 @@ program
   .option('--launch-mode <mode>', 'Chrome launch mode: auto | attach | isolated (#659). Also: OPENCHROME_LAUNCH_MODE env var.')
   .option('--secrets <path>', 'Load a dotenv-format secrets file (KEY=value per line). Tokens "${SECRET:NAME}" in tool arguments are substituted to the real value at MCP request deserialization; the same values are redacted from every LLM-visible artifact (responses, trace, skill records, journal). Default: no secrets loaded. P3: no OS keychain integration.')
   .option('--codegen <mode>', 'Opt-in replay artifact generation: off, puppeteer, playwright, or mcp-replay. Default: off (no response shape changes). Also: OPENCHROME_CODEGEN.')
-  .action(async (options: { port: string; autoLaunch?: boolean; allowUnsafeSharedAttach?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; windowSize?: string; windowPosition?: string; windowBounds?: string; startMaximized?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; minimal?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; broker?: boolean; connectBroker?: boolean; autoElect?: boolean; idleTimeout?: string; allowUnauthenticatedHttp?: boolean; pilot?: boolean; slim?: boolean; toolsOnly?: string; disableTools?: string; introspectToolsList?: boolean; autoConnect?: string | boolean; launchMode?: string; secrets?: string; codegen?: string }) => {
+  .option('--launch-on-first-use', 'Defer Chrome spawn until the first tool call — combined with --auto-launch, Chrome is not started at server boot but only when a caller actually needs a browser. Also: OPENCHROME_LAUNCH_ON_FIRST_USE=1. (#P3 pack)')
+  .action(async (options: { port: string; autoLaunch?: boolean; allowUnsafeSharedAttach?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; windowSize?: string; windowPosition?: string; windowBounds?: string; startMaximized?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; minimal?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; broker?: boolean; connectBroker?: boolean; autoElect?: boolean; idleTimeout?: string; allowUnauthenticatedHttp?: boolean; pilot?: boolean; slim?: boolean; toolsOnly?: string; disableTools?: string; introspectToolsList?: boolean; autoConnect?: string | boolean; launchMode?: string; secrets?: string; codegen?: string; launchOnFirstUse?: boolean }) => {
     const { normalizeCodegenMode, setCodegenMode } = await import('./core/codegen');
     const codegenMode = normalizeCodegenMode(options.codegen ?? process.env.OPENCHROME_CODEGEN);
     setCodegenMode(codegenMode);
     process.env.OPENCHROME_CODEGEN = codegenMode;
+
+    // #P3 pack wiring: expose --launch-on-first-use as the CLI-facing alias
+    // for the pre-existing OPENCHROME_LAUNCH_ON_FIRST_USE env flag. Setting
+    // the env var here means downstream consumers (src/core/server.ts,
+    // src/cdp/client.ts, launch-gate.ts) pick up the opt-in without any
+    // additional plumbing.
+    if (options.launchOnFirstUse) {
+      process.env.OPENCHROME_LAUNCH_ON_FIRST_USE = '1';
+    }
 
     // --introspect-tools-list: print tools/list JSON and exit, NO Chrome/CDP/transport startup.
     if (options.introspectToolsList) {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -36,6 +36,7 @@ import { formatError } from './utils/format-error';
 import { getCDPConnectionPool } from './cdp/connection-pool';
 import { getCDPClient, ConnectionEvent } from './cdp/client';
 import { getChromeLauncher } from './chrome/launcher';
+import { arm as launchGateArm } from './chrome/launch-gate';
 import { getChromePool } from './chrome/pool';
 import { ToolManifest, ToolEntry, ToolCategory } from './types/tool-manifest';
 import { DEFAULT_TOOL_EXECUTION_TIMEOUT_MS, DEFAULT_SESSION_INIT_TIMEOUT_MS, DEFAULT_SESSION_INIT_TIMEOUT_AUTO_LAUNCH_MS, DEFAULT_RECONNECT_TIMEOUT_MS, DEFAULT_OPERATION_GATE_TIMEOUT_MS, DEFAULT_HEARTBEAT_IDLE_TIMEOUT_MS, DEFAULT_RATE_LIMIT_RPM } from './config/defaults';
@@ -1617,6 +1618,12 @@ export class MCPServer {
     if (!toolName) {
       throw new Error('Missing tool name');
     }
+
+    // Arm the launch-gate on first tool call. Idempotent — subsequent calls
+    // are no-ops. Callers that opted into `launchOnFirstUse` (per client, or
+    // via OPENCHROME_LAUNCH_ON_FIRST_USE=1) block Chrome spawn until this
+    // point; every other call site is unaffected.
+    launchGateArm();
 
     // Session-tenant binding (api-key mode only): reject if the session was
     // already claimed by a different tenant. First api-key caller to COMPLETE

--- a/tests/chrome/launch-gate-cli-wired.test.ts
+++ b/tests/chrome/launch-gate-cli-wired.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from '@jest/globals';
+import {
+  envLaunchOnFirstUse,
+  resolveEffectiveAutoLaunch,
+  resetLaunchGateForTests,
+  arm,
+} from '../../src/chrome/launch-gate';
+
+/**
+ * Wiring test for the P3 pack CLI surface. Codex flagged that the promised
+ * `--launch-on-first-use` CLI flag was absent — only the env var
+ * OPENCHROME_LAUNCH_ON_FIRST_USE existed. This test pins the wiring the
+ * CLI uses: when `--launch-on-first-use` is present, the CLI sets
+ * OPENCHROME_LAUNCH_ON_FIRST_USE=1 so downstream consumers
+ * (src/core/server.ts, src/cdp/client.ts, launch-gate.ts::envLaunchOnFirstUse)
+ * pick up the opt-in unchanged.
+ */
+describe('P3 CLI wiring — --launch-on-first-use maps to OPENCHROME_LAUNCH_ON_FIRST_USE=1', () => {
+  const ORIGINAL = process.env.OPENCHROME_LAUNCH_ON_FIRST_USE;
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.OPENCHROME_LAUNCH_ON_FIRST_USE;
+    else process.env.OPENCHROME_LAUNCH_ON_FIRST_USE = ORIGINAL;
+    resetLaunchGateForTests();
+  });
+
+  it('default (no flag, no env): envLaunchOnFirstUse() is false and autoLaunch passes through', () => {
+    delete process.env.OPENCHROME_LAUNCH_ON_FIRST_USE;
+    expect(envLaunchOnFirstUse()).toBe(false);
+    // opt-in off → autoLaunch true stays true regardless of arm state.
+    expect(resolveEffectiveAutoLaunch(true)).toBe(true);
+  });
+
+  it('after the CLI sets OPENCHROME_LAUNCH_ON_FIRST_USE=1, envLaunchOnFirstUse() flips to true', () => {
+    // Simulate what the --launch-on-first-use CLI branch does (src/index.ts).
+    process.env.OPENCHROME_LAUNCH_ON_FIRST_USE = '1';
+    expect(envLaunchOnFirstUse()).toBe(true);
+  });
+
+  it('opt-in on: autoLaunch is deferred until the gate is armed', () => {
+    process.env.OPENCHROME_LAUNCH_ON_FIRST_USE = '1';
+    // Not armed yet — autoLaunch is deferred (returns false).
+    expect(resolveEffectiveAutoLaunch(true)).toBe(false);
+    // First tool call arms the gate — now the caller's autoLaunch takes effect.
+    arm();
+    expect(resolveEffectiveAutoLaunch(true)).toBe(true);
+  });
+
+  it.each(['1', 'true', 'yes', 'on', 'TRUE'])('accepts %s as on', (v) => {
+    process.env.OPENCHROME_LAUNCH_ON_FIRST_USE = v;
+    expect(envLaunchOnFirstUse()).toBe(true);
+  });
+
+  it.each(['0', 'false', 'off', ''])('rejects %s as off', (v) => {
+    process.env.OPENCHROME_LAUNCH_ON_FIRST_USE = v;
+    expect(envLaunchOnFirstUse()).toBe(false);
+  });
+});

--- a/tests/chrome/launch-gate.test.ts
+++ b/tests/chrome/launch-gate.test.ts
@@ -1,0 +1,131 @@
+import {
+  arm,
+  armedAt,
+  disarm,
+  envLaunchOnFirstUse,
+  isArmed,
+  onFirstUse,
+  resetLaunchGateForTests,
+  resolveEffectiveAutoLaunch,
+} from '../../src/chrome/launch-gate';
+
+describe('launch gate (P3)', () => {
+  const savedEnv = process.env.OPENCHROME_LAUNCH_ON_FIRST_USE;
+  beforeEach(() => {
+    delete process.env.OPENCHROME_LAUNCH_ON_FIRST_USE;
+    resetLaunchGateForTests();
+  });
+  afterAll(() => {
+    if (savedEnv === undefined) delete process.env.OPENCHROME_LAUNCH_ON_FIRST_USE;
+    else process.env.OPENCHROME_LAUNCH_ON_FIRST_USE = savedEnv;
+  });
+
+  describe('arm / disarm / isArmed', () => {
+    test('starts disarmed', () => {
+      expect(isArmed()).toBe(false);
+      expect(armedAt()).toBe(0);
+    });
+    test('arm() flips state and stamps time', () => {
+      const before = Date.now();
+      arm();
+      expect(isArmed()).toBe(true);
+      expect(armedAt()).toBeGreaterThanOrEqual(before);
+    });
+    test('arm() is idempotent (second call preserves original timestamp)', () => {
+      arm();
+      const first = armedAt();
+      arm();
+      expect(armedAt()).toBe(first);
+    });
+    test('disarm() reverts state', () => {
+      arm();
+      disarm();
+      expect(isArmed()).toBe(false);
+      expect(armedAt()).toBe(0);
+    });
+  });
+
+  describe('resolveEffectiveAutoLaunch', () => {
+    test('opt-in off + gate off → pass-through true', () => {
+      expect(resolveEffectiveAutoLaunch(true)).toBe(true);
+    });
+    test('opt-in off + gate off → pass-through false', () => {
+      expect(resolveEffectiveAutoLaunch(false)).toBe(false);
+    });
+    test('opt-in on + gate disarmed → coerce to false even when cfg=true', () => {
+      expect(resolveEffectiveAutoLaunch(true, { launchOnFirstUse: true })).toBe(false);
+    });
+    test('opt-in on + gate armed → pass-through cfg', () => {
+      arm();
+      expect(resolveEffectiveAutoLaunch(true, { launchOnFirstUse: true })).toBe(true);
+      expect(resolveEffectiveAutoLaunch(false, { launchOnFirstUse: true })).toBe(false);
+    });
+    test('env OPENCHROME_LAUNCH_ON_FIRST_USE=1 opts in without option', () => {
+      process.env.OPENCHROME_LAUNCH_ON_FIRST_USE = '1';
+      expect(resolveEffectiveAutoLaunch(true)).toBe(false);
+      arm();
+      expect(resolveEffectiveAutoLaunch(true)).toBe(true);
+    });
+    test('env falsy does not opt in', () => {
+      process.env.OPENCHROME_LAUNCH_ON_FIRST_USE = 'no';
+      expect(resolveEffectiveAutoLaunch(true)).toBe(true);
+    });
+  });
+
+  describe('onFirstUse', () => {
+    test('listener fires exactly once on arm()', () => {
+      const fn = jest.fn();
+      onFirstUse(fn);
+      expect(fn).not.toHaveBeenCalled();
+      arm();
+      expect(fn).toHaveBeenCalledTimes(1);
+      arm(); // idempotent
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+    test('listener fires synchronously if gate already armed', () => {
+      arm();
+      const fn = jest.fn();
+      onFirstUse(fn);
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+    test('listener error does not corrupt subsequent listeners or state', () => {
+      const err = jest.fn(() => { throw new Error('boom'); });
+      const ok = jest.fn();
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      onFirstUse(err);
+      onFirstUse(ok);
+      arm();
+      expect(err).toHaveBeenCalled();
+      expect(ok).toHaveBeenCalled();
+      expect(isArmed()).toBe(true);
+      errSpy.mockRestore();
+    });
+    test('listeners are cleared after firing (no re-fire on disarm→arm)', () => {
+      const fn = jest.fn();
+      onFirstUse(fn);
+      arm();
+      disarm();
+      arm();
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('envLaunchOnFirstUse', () => {
+    test.each([
+      ['1', true],
+      ['true', true],
+      ['TRUE', true],
+      ['yes', true],
+      ['on', true],
+      ['0', false],
+      ['false', false],
+      ['', false],
+    ])('env=%s → %s', (v, expected) => {
+      process.env.OPENCHROME_LAUNCH_ON_FIRST_USE = v;
+      expect(envLaunchOnFirstUse()).toBe(expected);
+    });
+    test('unset env → false', () => {
+      expect(envLaunchOnFirstUse()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## 요약

openchrome의 Chrome lifecycle은 두 극단입니다:

1. `autoLaunch=false`(default) · tool call이 Chrome을 필요로 해도 서버가 spawn을 거부. 오퍼레이터가 수동으로 Chrome을 먼저 띄워야 함.
2. `autoLaunch=true` · 서버 boot 시점에 readiness probe·health endpoint·초기 `ensureChrome()` 호출로 Chrome이 **선제 spawn**. `openchrome serve`를 systemd unit이나 dev sidecar로 idle하게 돌리다가 실제 요청이 왔을 때만 Chrome을 띄우고 싶은 흔한 ops 패턴을 무력화.

이 팩은 중간 자리를 만듭니다 · `autoLaunch=true`인데 **첫 tool call**이 도착한 순간에만 물리적으로 Chrome을 spawn.

## 근거

Sonar의 openchrome 상류 기여 재판정(v2)의 **P3** 팩입니다. 원본:

- chrome-devtools-mcp의 attach-on-demand 레시피가 대표하는 "lazy launch on first tool" 관용구. 많은 MCP 서버가 idle registry를 위해 heavyweight process warm-up을 피하는 데 씁니다.

원본 코드는 복사하지 않았습니다. 문서화된 관용구의 clean-room 구현입니다.

## 변경 내용

### 신규 · `src/chrome/launch-gate.ts` (+157 라인)

- `arm() / disarm() / isArmed() / armedAt()` · 프로세스 전역 단일 게이트 primitive.
- `onFirstUse(fn)` · 첫 arm() 순간을 딱 한 번 관측할 subscriber. 이미 armed면 sync 발사. 리스너 예외는 로깅되지만 게이트 상태는 오염 안 됨.
- `resolveEffectiveAutoLaunch(cfgAutoLaunch, opts)` · sanctioned translator. Opt-in on + gate disarmed → false 반환 / opt-in on + gate armed → cfg pass-through / opt-in off → 언제나 pass-through.
- Env override · `OPENCHROME_LAUNCH_ON_FIRST_USE=1|true|yes|on`. CLI 진입점을 감쌀 수 없는 MCP shim 환경 대비.

### 배선 · `src/cdp/client.ts` (+13 라인)

- `CDPClientOptions.launchOnFirstUse?: boolean` 추가 (default false).
- `connectInternal()` 매 attempt마다 `resolveEffectiveAutoLaunch()`를 거쳐 `ensureChrome({ autoLaunch: effective })` 호출. 다른 call site는 영향 없음(opt-in default false).

### 배선 · `src/mcp-server.ts` (+7 라인)

- `handleToolsCall()`가 첫 side-effect로 `launchGateArm()` 호출. Idempotent — 이후 호출은 no-op. Session-binding 이전에 배치해서, tool dispatcher까지 도달한 어떤 call로도 게이트가 arm되도록.

### 배선 · `src/core/server.ts` (+5 라인)

- Boot 시점에 launch-gate 모드를 로깅해 오퍼레이터가 deferred로 도는 걸 인지하도록.

## 테스트

- `tests/chrome/launch-gate.test.ts` · 23 케이스, 모두 통과:
  - `arm`/`disarm`/`isArmed`/`armedAt` · idempotence 포함.
  - `resolveEffectiveAutoLaunch` 전 매트릭스 · opt-in on/off × gate armed/disarmed × cfg true/false.
  - `onFirstUse` fire-once · 이미 armed면 sync 발사, 리스너 예외 격리, disarm→arm 재발사 안 됨.
  - `envLaunchOnFirstUse` · 1/true/TRUE/yes/on/0/false/빈/unset.

빌드:
- `node_modules/.bin/tsc -p tsconfig.json --noEmit` · 0 errors.
- `node_modules/.bin/jest tests/chrome/launch-gate.test.ts` · 23 passed.

## 참고

- v2 계획서 · `docs/rebirth/OPENCHROME-CONTRIBUTION-PLAN-V2.md` §5 P3
- 90개 전수 근거 · `docs/rebirth/ULTIMATE-CENSUS-2026-07-18.md`
- 원본 코드 미열람 clean-room 구현. `src/chrome/launch-gate.ts` 상단 주석에 origin credit.

## 관련

이 팩은 v2 계획의 **P3** 팩입니다. Batch 2의 6개 팩(P2·P14·P15·P17·P18·P21)이 동시에 별도 PR로 제출됩니다.