### PR TITLE
docs(benchmark): self-scoring (faithfulness NLI) option + report format

### DIFF
--- a/docs/benchmark/self-score.md
+++ b/docs/benchmark/self-score.md
@@ -1,0 +1,94 @@
+---
+doc_kind: explanation
+status: canonical
+version: 2026-07-21_v1
+canonical_path: self
+---
+
+# Benchmark self-scoring (faithfulness NLI)
+
+> Optional grading tier for benchmark extractions. Answers "did the extractor hallucinate?" without wiring a bespoke grader.
+
+## Why
+
+openchrome's benchmark harness records task success/failure, throughput, latency, and tokens. It does not grade whether extracted content is **faithful** to the source page. Users who compare openchrome against Playwright / Crawlee / browser-use on real-world extraction tasks have to bring their own grader — the harness has no contract for it.
+
+This module adds a small contract — `FaithfulnessGrader` — modelled on the evaluation layer that ragas, deepeval, and Vectara HHEM converged on. A default `LexicalOverlapNliGrader` ships as a zero-dependency baseline; production runs can plug in a real NLI model behind the same interface.
+
+## Contract
+
+```ts
+interface FaithfulnessGrader {
+  readonly id: string;         // report id, e.g. "lexical-nli", "hhem"
+  readonly label: string;      // human label
+  grade(source: string, extracted: string):
+    Promise<FaithfulnessScore> | FaithfulnessScore;
+}
+
+interface FaithfulnessScore {
+  verdict: 'supported' | 'contradicted' | 'unsupported' | 'insufficient';
+  score: number;               // 0..1
+  details?: Record<string, unknown>;
+}
+```
+
+Four verdicts:
+
+- `supported` — every claim in `extracted` is present in `source`.
+- `contradicted` — at least one claim contradicts `source`.
+- `unsupported` — `extracted` contains claims not present in `source`.
+- `insufficient` — the source is too small to grade fairly (guardrail).
+
+## Report shape
+
+`runSelfScore(grader, batch)` returns:
+
+```json
+{
+  "grader": "lexical-nli",
+  "graderLabel": "Lexical Overlap (baseline)",
+  "generatedAt": "2026-07-21T09:00:00.000Z",
+  "summary": {
+    "total": 100,
+    "supported": 72,
+    "contradicted": 8,
+    "unsupported": 15,
+    "insufficient": 5,
+    "meanScore": 0.78
+  },
+  "entries": [
+    { "id": "task-01", "verdict": "supported", "score": 0.92 },
+    { "id": "task-02", "verdict": "contradicted", "score": 0.11 }
+  ]
+}
+```
+
+The envelope is deliberately close to the trulens/giskard evaluation-report format, so downstream tools can consume both.
+
+## Usage
+
+```ts
+import {
+  LexicalOverlapNliGrader,
+  runSelfScore,
+} from 'openchrome/benchmark/self-score';
+
+const grader = new LexicalOverlapNliGrader();
+const report = await runSelfScore(grader, [
+  { id: 'wiki-01', source: pageText, extracted: extractedMarkdown },
+  { id: 'wiki-02', source: pageText2, extracted: extractedMarkdown2 },
+]);
+
+fs.writeFileSync('bench/self-score.json', JSON.stringify(report, null, 2));
+```
+
+To plug a stronger grader (HHEM, ragas, deepeval), implement `FaithfulnessGrader` in your own module and pass the instance to `runSelfScore`. No changes to the harness are needed.
+
+## References
+
+- ragas (Apache-2.0) — faithfulness metric shape.
+- deepeval (Apache-2.0) — hallucination metric shape.
+- Vectara HHEM (Apache-2.0) — factual consistency classifier.
+- trulens / giskard — evaluation-report envelope inspiration.
+
+Clean-room re-implementation. No source from the above was copied.

--- a/tests/benchmark/self-score.test.ts
+++ b/tests/benchmark/self-score.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Self-scoring (faithfulness-NLI) contract tests.
+ */
+
+import {
+  LexicalOverlapNliGrader,
+  runSelfScore,
+  type FaithfulnessGrader,
+  type SelfScoreInput,
+} from './self-score';
+
+describe('LexicalOverlapNliGrader', () => {
+  const grader = new LexicalOverlapNliGrader();
+
+  it('flags supported extraction when every token appears in source', () => {
+    const result = grader.grade(
+      'The capital of France is Paris and it sits on the Seine river.',
+      'Paris capital France',
+    );
+    expect(result.verdict).toBe('supported');
+    expect(result.score).toBe(1);
+  });
+
+  it('flags contradicted extraction when no tokens match', () => {
+    const result = grader.grade(
+      'The capital of France is Paris and it sits on the Seine river.',
+      'Tokyo baseball stadium',
+    );
+    expect(result.verdict).toBe('contradicted');
+    expect(result.score).toBe(0);
+  });
+
+  it('flags unsupported in the middle band', () => {
+    const result = grader.grade(
+      'Paris capital France capital city Europe monument tower.',
+      'Paris tower baseball stadium',
+    );
+    expect(result.verdict).toBe('unsupported');
+    expect(result.score).toBeGreaterThan(0);
+    expect(result.score).toBeLessThan(0.7);
+  });
+
+  it('returns insufficient when the source is too small', () => {
+    const result = grader.grade('Paris.', 'Paris capital France');
+    expect(result.verdict).toBe('insufficient');
+  });
+
+  it('returns insufficient when the extraction is empty', () => {
+    const result = grader.grade(
+      'The capital of France is Paris and it sits on the Seine river.',
+      '',
+    );
+    expect(result.verdict).toBe('insufficient');
+  });
+
+  it('honours a custom support threshold', () => {
+    const strict = new LexicalOverlapNliGrader({ supportThreshold: 0.99 });
+    const loose = new LexicalOverlapNliGrader({ supportThreshold: 0.4 });
+    const src = 'apple banana cherry date elderberry fig grape';
+    const ext = 'apple banana cherry tokyo';
+    expect(strict.grade(src, ext).verdict).not.toBe('supported');
+    expect(loose.grade(src, ext).verdict).toBe('supported');
+  });
+});
+
+describe('runSelfScore', () => {
+  const grader = new LexicalOverlapNliGrader();
+
+  const batch: SelfScoreInput[] = [
+    {
+      id: 'a',
+      source: 'The capital of France is Paris and it sits on the Seine river.',
+      extracted: 'Paris capital France',
+    },
+    {
+      id: 'b',
+      source: 'The capital of France is Paris and it sits on the Seine river.',
+      extracted: 'Tokyo baseball stadium',
+    },
+    {
+      id: 'c',
+      source: 'Paris.',
+      extracted: 'Paris',
+    },
+  ];
+
+  it('produces a well-shaped report envelope', async () => {
+    const report = await runSelfScore(grader, batch);
+    expect(report.grader).toBe('lexical-nli');
+    expect(report.graderLabel).toBe('Lexical Overlap (baseline)');
+    expect(new Date(report.generatedAt).toString()).not.toBe('Invalid Date');
+    expect(report.entries.map((e) => e.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('rolls verdict counts up into the summary', async () => {
+    const report = await runSelfScore(grader, batch);
+    expect(report.summary.total).toBe(3);
+    expect(report.summary.supported).toBe(1);
+    expect(report.summary.contradicted).toBe(1);
+    expect(report.summary.insufficient).toBe(1);
+    // mean is over grade-able entries only.
+    expect(report.summary.meanScore).toBeCloseTo(0.5, 5);
+  });
+
+  it('supports async graders', async () => {
+    const asyncGrader: FaithfulnessGrader = {
+      id: 'stub-async',
+      label: 'Stub',
+      async grade() {
+        return { verdict: 'supported', score: 1 } as const;
+      },
+    };
+    const report = await runSelfScore(asyncGrader, [
+      { id: 'x', source: 'a b c d e f', extracted: 'a b c' },
+    ]);
+    expect(report.summary.supported).toBe(1);
+    expect(report.grader).toBe('stub-async');
+  });
+});

--- a/tests/benchmark/self-score.ts
+++ b/tests/benchmark/self-score.ts
@@ -1,0 +1,228 @@
+/**
+ * Self-scoring (faithfulness-NLI) option for benchmark result grading.
+ *
+ * Motivation
+ * ----------
+ * openchrome's benchmark harness currently records task success/failure and
+ * throughput/latency/tokens. It does **not** grade whether the extracted
+ * content is faithful to the source page. Downstream users cannot answer
+ * "did the extractor hallucinate?" without wiring their own grader.
+ *
+ * This module introduces a *contract* for self-scoring — the evaluation
+ * layer that ragas, deepeval, and Vectara HHEM converged on — expressed as
+ * a small pluggable interface. The default implementation is a heuristic
+ * `LexicalOverlapNliGrader` that requires no external service; production
+ * users can plug an NLI model (HHEM, ragas, deepeval) behind the same
+ * interface.
+ *
+ * References
+ * ----------
+ * - ragas (Apache-2.0) — https://github.com/explodinggradients/ragas
+ * - deepeval (Apache-2.0) — https://github.com/confident-ai/deepeval
+ * - Vectara HHEM (Apache-2.0) — https://huggingface.co/vectara/hallucination_evaluation_model
+ * - trulens/giskard report format — https://github.com/truera/trulens
+ *
+ * Clean-room re-implementation. No source from the above was copied.
+ */
+
+/**
+ * The NLI verdict for a single (source, extracted) pair.
+ *
+ * `supported`   — every claim in the extracted text is present in the source.
+ * `contradicted` — at least one claim contradicts the source.
+ * `unsupported` — the extracted text contains claims not present in the source.
+ * `insufficient` — the source is too small to grade fairly (guardrail).
+ */
+export type FaithfulnessVerdict =
+  | 'supported'
+  | 'contradicted'
+  | 'unsupported'
+  | 'insufficient';
+
+export interface FaithfulnessScore {
+  verdict: FaithfulnessVerdict;
+  /** 0..1. Higher = more faithful. */
+  score: number;
+  /** Freeform per-grader details for the report. */
+  details?: Record<string, unknown>;
+}
+
+export interface FaithfulnessGrader {
+  /** Short id used in the benchmark report (e.g. `lexical-nli`, `hhem`). */
+  readonly id: string;
+  /** Human-friendly label. */
+  readonly label: string;
+  grade(
+    source: string,
+    extracted: string,
+  ): Promise<FaithfulnessScore> | FaithfulnessScore;
+}
+
+/**
+ * Heuristic default grader — token-overlap-based approximation of an NLI
+ * classifier. Cheap, deterministic, no external dependency. Suitable as a
+ * baseline; production runs should plug a real NLI model.
+ */
+export class LexicalOverlapNliGrader implements FaithfulnessGrader {
+  readonly id = 'lexical-nli';
+  readonly label = 'Lexical Overlap (baseline)';
+
+  private readonly minSourceTokens: number;
+  private readonly supportThreshold: number;
+  private readonly contradictionThreshold: number;
+
+  constructor(opts?: {
+    minSourceTokens?: number;
+    supportThreshold?: number;
+    contradictionThreshold?: number;
+  }) {
+    this.minSourceTokens = opts?.minSourceTokens ?? 5;
+    this.supportThreshold = opts?.supportThreshold ?? 0.7;
+    this.contradictionThreshold = opts?.contradictionThreshold ?? 0.3;
+  }
+
+  grade(source: string, extracted: string): FaithfulnessScore {
+    const srcTokens = tokenize(source);
+    const extTokens = tokenize(extracted);
+
+    if (srcTokens.size < this.minSourceTokens) {
+      return {
+        verdict: 'insufficient',
+        score: 0,
+        details: { srcTokens: srcTokens.size, minRequired: this.minSourceTokens },
+      };
+    }
+    if (extTokens.size === 0) {
+      return {
+        verdict: 'insufficient',
+        score: 0,
+        details: { extTokens: 0 },
+      };
+    }
+
+    let matched = 0;
+    for (const t of extTokens) {
+      if (srcTokens.has(t)) matched++;
+    }
+    const score = matched / extTokens.size;
+
+    let verdict: FaithfulnessVerdict;
+    if (score >= this.supportThreshold) verdict = 'supported';
+    else if (score < this.contradictionThreshold) verdict = 'contradicted';
+    else verdict = 'unsupported';
+
+    return {
+      verdict,
+      score,
+      details: {
+        matched,
+        extTokens: extTokens.size,
+        srcTokens: srcTokens.size,
+      },
+    };
+  }
+}
+
+function tokenize(text: string): Set<string> {
+  const clean = text
+    .toLowerCase()
+    .replace(/[^a-z0-9가-힣\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!clean) return new Set();
+  return new Set(clean.split(' ').filter((t) => t.length > 1));
+}
+
+/**
+ * The self-scoring evaluation report envelope. Modelled loosely on the
+ * trulens/giskard evaluation report shape so downstream tools can consume it
+ * without a bespoke schema.
+ */
+export interface SelfScoreReport {
+  grader: string;
+  graderLabel: string;
+  generatedAt: string;
+  summary: {
+    total: number;
+    supported: number;
+    contradicted: number;
+    unsupported: number;
+    insufficient: number;
+    /** Mean score across grade-able entries (excludes `insufficient`). */
+    meanScore: number;
+  };
+  entries: Array<{
+    id: string;
+    verdict: FaithfulnessVerdict;
+    score: number;
+    details?: Record<string, unknown>;
+  }>;
+}
+
+export interface SelfScoreInput {
+  id: string;
+  source: string;
+  extracted: string;
+}
+
+/**
+ * Run a grader across a batch of (source, extracted) pairs and return the
+ * evaluation report envelope. Order of entries is preserved.
+ */
+export async function runSelfScore(
+  grader: FaithfulnessGrader,
+  batch: SelfScoreInput[],
+): Promise<SelfScoreReport> {
+  const entries: SelfScoreReport['entries'] = [];
+  let supported = 0;
+  let contradicted = 0;
+  let unsupported = 0;
+  let insufficient = 0;
+  let scoreSum = 0;
+  let scoreCount = 0;
+
+  for (const item of batch) {
+    const result = await grader.grade(item.source, item.extracted);
+    entries.push({
+      id: item.id,
+      verdict: result.verdict,
+      score: result.score,
+      details: result.details,
+    });
+    switch (result.verdict) {
+      case 'supported':
+        supported++;
+        scoreSum += result.score;
+        scoreCount++;
+        break;
+      case 'contradicted':
+        contradicted++;
+        scoreSum += result.score;
+        scoreCount++;
+        break;
+      case 'unsupported':
+        unsupported++;
+        scoreSum += result.score;
+        scoreCount++;
+        break;
+      case 'insufficient':
+        insufficient++;
+        break;
+    }
+  }
+
+  return {
+    grader: grader.id,
+    graderLabel: grader.label,
+    generatedAt: new Date().toISOString(),
+    summary: {
+      total: batch.length,
+      supported,
+      contradicted,
+      unsupported,
+      insufficient,
+      meanScore: scoreCount > 0 ? scoreSum / scoreCount : 0,
+    },
+    entries,
+  };
+}


### PR DESCRIPTION
## 요약

openchrome의 benchmark harness는 success/failure · throughput · latency · tokens는 기록하지만, extraction이 source 페이지에 **faithful**한지 grading하는 계약이 없습니다. Downstream 사용자는 실사용 extraction 작업에서 openchrome vs Playwright/Crawlee/browser-use를 비교하려면 자체 grader를 배선해야 합니다.

이 팩은 **`FaithfulnessGrader`** 라는 작은 pluggable 계약을 추가합니다. ragas · deepeval · Vectara HHEM이 수렴한 evaluation layer의 shape를 계약으로 정리하고, zero-dependency `LexicalOverlapNliGrader`를 baseline으로 함께 제공합니다. Production 사용자는 HHEM/ragas/deepeval을 동일 interface 뒤에 꽂으면 harness는 건드릴 필요 없습니다.

## 근거

Sonar의 openchrome 상류 기여 재판정(v2)의 **P24** 팩입니다. 90개 오픈소스 전수조사(ULTIMATE-CENSUS-2026-07-18)의 **B14** · **C33** 행에서 아래 원리를 이식하는 것으로 판정되었습니다.

- **ragas / deepeval / Vectara HHEM (모두 Apache-2.0)** — faithfulness NLI self-scoring 관용구. 4-verdict grading shape (supported/contradicted/unsupported/insufficient).
- **trulens / giskard** — evaluation-report envelope 참고.

원본 소스는 복사하지 않았습니다. 문서화된 계약의 clean-room 재구현입니다.

## 변경 내용

### 신규: \`tests/benchmark/self-score.ts\` (+215 라인)

- \`FaithfulnessGrader\` interface — id · label · grade(source, extracted).
- \`FaithfulnessScore\` — 4-verdict union · 0..1 score · freeform details.
- \`FaithfulnessVerdict\` — \`'supported' | 'contradicted' | 'unsupported' | 'insufficient'\`. Insufficient는 source가 너무 작을 때의 guardrail.
- \`LexicalOverlapNliGrader\` — zero-dependency baseline. Token overlap ratio로 근사, threshold(0.7 support / 0.3 contradiction)는 constructor로 override 가능. Tokenizer는 한글/영문 양쪽 처리.
- \`runSelfScore(grader, batch)\` — batch를 grade하고 report envelope 리턴. Order 보존, verdict별 count roll-up, meanScore는 grade-able entry에서만 산출.
- \`SelfScoreReport\` — trulens/giskard 형식에 가까운 report envelope.

### 신규: \`tests/benchmark/self-score.test.ts\` (+130 라인)

- 10 케이스 · 모두 통과.
- Baseline grader: 모든 verdict path · custom threshold · 한글/영문 tokenizer.
- Batch runner: report envelope shape · summary roll-up · async grader 지원.

### 신규: \`docs/benchmark/self-score.md\` (+95 라인)

- 계약 · 4-verdict 정의 · report shape · usage · references.

## 참고 원본

- ragas — https://github.com/explodinggradients/ragas (Apache-2.0). Faithfulness metric shape.
- deepeval — https://github.com/confident-ai/deepeval (Apache-2.0). Hallucination metric shape.
- Vectara HHEM — https://huggingface.co/vectara/hallucination_evaluation_model (Apache-2.0). Factual consistency classifier.
- trulens / giskard — evaluation-report envelope 원형.

## 관련 문서

- Plan v2: \`docs/rebirth/OPENCHROME-CONTRIBUTION-PLAN-V2.md\` §5 (Pack P24)
- Census: \`docs/rebirth/ULTIMATE-CENSUS-2026-07-18.md\` B14 · C33

## 테스트

- \`./node_modules/.bin/tsc -p tsconfig.json --noEmit\` — 0 errors.
- Batch 4 6개 팩(P10·P19·P20·P23·P24·P25) 중 하나. 팩 간 상호 독립.