### PR TITLE
feat(stealth): joint-distribution fingerprint sampler + Bezier pointer path

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -32,7 +32,13 @@ import { Budget, isLegacyBudgetMode } from '../utils/budget';
 import { withTimeout } from '../utils/with-timeout';
 import { getMetricsCollector } from '../metrics/collector';
 import { OpenChromeConnectionError } from '../errors/connection';
-import { getStealthFingerprintDefenseScript, getStealthStackSanitizationScript } from '../stealth/fingerprint-defense';
+import {
+  getFingerprintSampleOverrideScript,
+  getStealthFingerprintDefenseScript,
+  getStealthStackSanitizationScript,
+  isFingerprintSamplerEnabled,
+} from '../stealth/fingerprint-defense';
+import { sampleFingerprint } from '../stealth/fingerprint-sampler';
 import { getIdleState } from '../utils/idle-state';
 import { assertDomainAllowed, isInternalBrowserUrl } from '../security/domain-guard';
 import { applyRegisteredPreloads } from './preload-injector';
@@ -1842,6 +1848,20 @@ export class CDPClient {
     await applyRegisteredPreloads(page);
 
     // Stealth-only fingerprint defenses (WebGL, Canvas, Audio, hardware, screen, webdriver)
+    // #P8 wiring: opt-in joint-distribution fingerprint override. Injected
+    // BEFORE the base defense script so the base's "default to 8" guards
+    // do not clobber the sampled hardwareConcurrency / deviceMemory values.
+    if (isFingerprintSamplerEnabled()) {
+      try {
+        // Seed by targetId so the same tab keeps a stable fingerprint across
+        // navigations, matching real-user behaviour.
+        const sample = sampleFingerprint(targetId);
+        const overrideScript = getFingerprintSampleOverrideScript(sample);
+        await page.evaluateOnNewDocument(overrideScript).catch(() => {});
+      } catch (err) {
+        console.error(`[CDPClient] fingerprint sampler injection failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
     const fpScript = getStealthFingerprintDefenseScript();
     const stackScript = getStealthStackSanitizationScript();
     await page.evaluateOnNewDocument(fpScript).catch(() => {});

--- a/src/stealth/fingerprint-defense.ts
+++ b/src/stealth/fingerprint-defense.ts
@@ -256,3 +256,107 @@ export function getStealthStackSanitizationScript(): string {
     }
   })();`;
 }
+
+// ---------------------------------------------------------------------------
+// Joint-distribution fingerprint injection (#P8 pack wiring)
+//
+// The base `getStealthFingerprintDefenseScript()` above only patches
+// invariants (WebGL renderer, canvas noise, hardware minimums). It does not
+// vary the *identity* fields (UA, timezone, screen, hardware totals) across
+// sessions, which is exactly the "small static table" signal that the
+// browserforge/fingerprint-suite idiom is designed to remove.
+//
+// The sampler in `fingerprint-sampler.ts` produces a coherent
+// {UA, platform, language, timezone, screen, cpu, memory} tuple. This helper
+// turns that tuple into a companion evaluateOnNewDocument script that
+// overrides the corresponding navigator/screen fields. Register it *before*
+// the base defense script so the base's "if unset, default to 8" guards do
+// not clobber the sampled hardwareConcurrency value.
+// ---------------------------------------------------------------------------
+
+import type { FingerprintSample } from './fingerprint-sampler';
+
+/**
+ * Return a JS source string that overrides UA / language / timezone /
+ * screen / hardware fields with values from `sample`. Safe to inject via
+ * `page.evaluateOnNewDocument()` because every property definer is wrapped
+ * in try/catch — a hostile page cannot break the override host by
+ * pre-defining a non-configurable getter.
+ */
+export function getFingerprintSampleOverrideScript(sample: FingerprintSample): string {
+  // Only stringify values we control; never interpolate raw page-supplied data.
+  const encoded = JSON.stringify(sample);
+  return `(function(){
+    'use strict';
+    try {
+      var s = ${encoded};
+      try {
+        Object.defineProperty(Navigator.prototype, 'userAgent', {
+          get: function() { return s.userAgent; }, configurable: true,
+        });
+      } catch(e) {}
+      try {
+        Object.defineProperty(Navigator.prototype, 'platform', {
+          get: function() { return s.platform; }, configurable: true,
+        });
+      } catch(e) {}
+      try {
+        Object.defineProperty(Navigator.prototype, 'language', {
+          get: function() { return s.language; }, configurable: true,
+        });
+      } catch(e) {}
+      try {
+        Object.defineProperty(Navigator.prototype, 'languages', {
+          get: function() { return Object.freeze(s.languages.slice()); }, configurable: true,
+        });
+      } catch(e) {}
+      try {
+        Object.defineProperty(Navigator.prototype, 'hardwareConcurrency', {
+          get: function() { return s.hardwareConcurrency; }, configurable: true,
+        });
+      } catch(e) {}
+      try {
+        Object.defineProperty(Navigator.prototype, 'deviceMemory', {
+          get: function() { return s.deviceMemoryGB; }, configurable: true,
+        });
+      } catch(e) {}
+      try {
+        Object.defineProperty(Screen.prototype, 'width', {
+          get: function() { return s.screen.width; }, configurable: true,
+        });
+        Object.defineProperty(Screen.prototype, 'height', {
+          get: function() { return s.screen.height; }, configurable: true,
+        });
+      } catch(e) {}
+      try {
+        Object.defineProperty(window, 'devicePixelRatio', {
+          get: function() { return s.screen.devicePixelRatio; }, configurable: true,
+        });
+      } catch(e) {}
+      // Timezone spoof — the Intl fallback fools most fingerprinting probes.
+      try {
+        var _DTF = Intl.DateTimeFormat;
+        Intl.DateTimeFormat = function(locale, opts) {
+          var patched = opts ? Object.assign({}, opts) : {};
+          if (!patched.timeZone) patched.timeZone = s.timezone;
+          return new _DTF(locale, patched);
+        };
+        Intl.DateTimeFormat.prototype = _DTF.prototype;
+        var _resolved = _DTF.prototype.resolvedOptions;
+        _DTF.prototype.resolvedOptions = function() {
+          var out = _resolved.call(this);
+          out.timeZone = s.timezone;
+          return out;
+        };
+      } catch(e) {}
+    } catch(e) {}
+  })();`;
+}
+
+/** Env-flag check for the sampler wiring. Off by default. */
+export function isFingerprintSamplerEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.OPENCHROME_FINGERPRINT_SAMPLER;
+  if (raw === undefined) return false;
+  const lowered = raw.toLowerCase();
+  return lowered === '1' || lowered === 'true' || lowered === 'yes' || lowered === 'on';
+}

--- a/src/stealth/fingerprint-sampler.ts
+++ b/src/stealth/fingerprint-sampler.ts
@@ -1,0 +1,290 @@
+/**
+ * Real-distribution fingerprint sampler.
+ *
+ * The current `src/stealth/fingerprint-defense.ts` picks values from a small
+ * static table, which is trivially profileable — every session ends up with
+ * the same few UA / screen / timezone tuples. Anti-bot vendors already
+ * fingerprint that exact table.
+ *
+ * The fix, popularised by browserforge/fingerprint-suite, is to sample from
+ * a joint distribution that reflects the real user population: locale is
+ * correlated with timezone, timezone with screen ratio, device pixel ratio
+ * with UA platform, and so on. Independent uniform sampling of each field
+ * produces impossible combinations (e.g. `ko-KR` + `America/New_York` +
+ * `en-US` accept-language) that themselves become a signal.
+ *
+ * This module encodes a small joint distribution over the fields openchrome
+ * currently exposes, plus a deterministic sampler keyed by a caller-supplied
+ * `seed` so the same session always yields the same fingerprint. That
+ * property matters because a legitimate user's fingerprint is stable across
+ * navigations within a session.
+ *
+ * Clean-room implementation. Idea attribution (see census entry A20):
+ * browserforge/fingerprint-suite. Also incorporates the Bezier idea from
+ * pydoll (A8) via {@link bezierPointerPath}, kept in this module because
+ * fingerprint and motion are two sides of the same "look human" coin.
+ */
+
+export interface FingerprintSample {
+  userAgent: string;
+  platform: 'Win32' | 'MacIntel' | 'Linux x86_64';
+  language: string;
+  languages: readonly string[];
+  timezone: string;
+  screen: { width: number; height: number; devicePixelRatio: number };
+  hardwareConcurrency: number;
+  deviceMemoryGB: number;
+}
+
+interface JointRow {
+  weight: number;
+  sample: FingerprintSample;
+}
+
+/**
+ * The joint table is intentionally small. Each row is a plausible
+ * co-occurrence — locale, timezone, screen and UA all agree.
+ *
+ * Weights are ordinal proxies for population share; they do not need to sum
+ * to 1 because the sampler normalises.
+ */
+const JOINT_TABLE: readonly JointRow[] = [
+  {
+    weight: 22,
+    sample: {
+      userAgent:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
+      platform: 'Win32',
+      language: 'en-US',
+      languages: ['en-US', 'en'],
+      timezone: 'America/New_York',
+      screen: { width: 1920, height: 1080, devicePixelRatio: 1 },
+      hardwareConcurrency: 8,
+      deviceMemoryGB: 16,
+    },
+  },
+  {
+    weight: 14,
+    sample: {
+      userAgent:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
+      platform: 'Win32',
+      language: 'en-GB',
+      languages: ['en-GB', 'en'],
+      timezone: 'Europe/London',
+      screen: { width: 1536, height: 864, devicePixelRatio: 1.25 },
+      hardwareConcurrency: 8,
+      deviceMemoryGB: 8,
+    },
+  },
+  {
+    weight: 12,
+    sample: {
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
+      platform: 'MacIntel',
+      language: 'en-US',
+      languages: ['en-US', 'en'],
+      timezone: 'America/Los_Angeles',
+      screen: { width: 1728, height: 1117, devicePixelRatio: 2 },
+      hardwareConcurrency: 10,
+      deviceMemoryGB: 16,
+    },
+  },
+  {
+    weight: 8,
+    sample: {
+      userAgent:
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
+      platform: 'Linux x86_64',
+      language: 'en-US',
+      languages: ['en-US', 'en'],
+      timezone: 'UTC',
+      screen: { width: 1920, height: 1080, devicePixelRatio: 1 },
+      hardwareConcurrency: 12,
+      deviceMemoryGB: 32,
+    },
+  },
+  {
+    weight: 9,
+    sample: {
+      userAgent:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
+      platform: 'Win32',
+      language: 'de-DE',
+      languages: ['de-DE', 'de', 'en'],
+      timezone: 'Europe/Berlin',
+      screen: { width: 1920, height: 1080, devicePixelRatio: 1 },
+      hardwareConcurrency: 8,
+      deviceMemoryGB: 16,
+    },
+  },
+  {
+    weight: 7,
+    sample: {
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
+      platform: 'MacIntel',
+      language: 'fr-FR',
+      languages: ['fr-FR', 'fr', 'en'],
+      timezone: 'Europe/Paris',
+      screen: { width: 1440, height: 900, devicePixelRatio: 2 },
+      hardwareConcurrency: 8,
+      deviceMemoryGB: 16,
+    },
+  },
+  {
+    weight: 6,
+    sample: {
+      userAgent:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
+      platform: 'Win32',
+      language: 'ja-JP',
+      languages: ['ja-JP', 'ja', 'en'],
+      timezone: 'Asia/Tokyo',
+      screen: { width: 1920, height: 1080, devicePixelRatio: 1 },
+      hardwareConcurrency: 8,
+      deviceMemoryGB: 16,
+    },
+  },
+  {
+    weight: 5,
+    sample: {
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
+      platform: 'MacIntel',
+      language: 'ko-KR',
+      languages: ['ko-KR', 'ko', 'en'],
+      timezone: 'Asia/Seoul',
+      screen: { width: 1512, height: 982, devicePixelRatio: 2 },
+      hardwareConcurrency: 10,
+      deviceMemoryGB: 16,
+    },
+  },
+  {
+    weight: 4,
+    sample: {
+      userAgent:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
+      platform: 'Win32',
+      language: 'pt-BR',
+      languages: ['pt-BR', 'pt', 'en'],
+      timezone: 'America/Sao_Paulo',
+      screen: { width: 1366, height: 768, devicePixelRatio: 1 },
+      hardwareConcurrency: 4,
+      deviceMemoryGB: 8,
+    },
+  },
+];
+
+/**
+ * Sample a fingerprint from the joint distribution.
+ *
+ * Deterministic if a `seed` is provided — same seed always yields the same
+ * sample. Callers should pick a seed once per session (e.g. from the
+ * session id) and reuse it, so within-session navigation looks stable.
+ */
+export function sampleFingerprint(seed?: string): FingerprintSample {
+  const totalWeight = JOINT_TABLE.reduce((sum, row) => sum + row.weight, 0);
+  const pick = seed !== undefined ? hash32(seed) / 2 ** 32 : Math.random();
+  let cursor = pick * totalWeight;
+  for (const row of JOINT_TABLE) {
+    cursor -= row.weight;
+    if (cursor <= 0) return row.sample;
+  }
+  return JOINT_TABLE[JOINT_TABLE.length - 1]!.sample;
+}
+
+/**
+ * Small stable hash — Fowler-Noll-Vo 32. Written from the spec, not copied.
+ * Enough entropy for weighted sampling; not cryptographic.
+ */
+export function hash32(input: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  // Squash to unsigned 32-bit.
+  return hash >>> 0;
+}
+
+// -----------------------------------------------------------------------
+// Bezier pointer path — extends src/stealth/human-behavior.ts idiom to
+// arbitrary control points so a caller can synthesise a curved cursor path
+// between two page coordinates.
+// -----------------------------------------------------------------------
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface BezierPathOptions {
+  /** Number of intermediate points to emit (excludes endpoints). */
+  steps?: number;
+  /** Jitter magnitude for the control points. Higher = curvier. */
+  curveMagnitude?: number;
+  /** Deterministic seed. */
+  seed?: string;
+}
+
+/**
+ * Produce a cubic Bezier path from `from` to `to` with two randomised
+ * control points. The path is naturally arced and non-monotone, which is
+ * what human motion looks like — a straight-line + easing curve, which is
+ * what most bots produce, is trivially detectable.
+ */
+export function bezierPointerPath(
+  from: Point,
+  to: Point,
+  options: BezierPathOptions = {},
+): Point[] {
+  const steps = Math.max(2, options.steps ?? 24);
+  const magnitude = options.curveMagnitude ?? 0.35;
+  const rng = seededRng(options.seed);
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  // Control points offset perpendicular to the travel vector.
+  const perpX = -dy;
+  const perpY = dx;
+  const c1: Point = {
+    x: from.x + dx / 3 + perpX * magnitude * (rng() - 0.5),
+    y: from.y + dy / 3 + perpY * magnitude * (rng() - 0.5),
+  };
+  const c2: Point = {
+    x: from.x + (2 * dx) / 3 + perpX * magnitude * (rng() - 0.5),
+    y: from.y + (2 * dy) / 3 + perpY * magnitude * (rng() - 0.5),
+  };
+  const out: Point[] = [];
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps;
+    out.push(cubicBezier(from, c1, c2, to, t));
+  }
+  return out;
+}
+
+function cubicBezier(p0: Point, p1: Point, p2: Point, p3: Point, t: number): Point {
+  const u = 1 - t;
+  const tt = t * t;
+  const uu = u * u;
+  const uuu = uu * u;
+  const ttt = tt * t;
+  return {
+    x: uuu * p0.x + 3 * uu * t * p1.x + 3 * u * tt * p2.x + ttt * p3.x,
+    y: uuu * p0.y + 3 * uu * t * p1.y + 3 * u * tt * p2.y + ttt * p3.y,
+  };
+}
+
+function seededRng(seed?: string): () => number {
+  if (seed === undefined) return Math.random;
+  let state = hash32(seed) || 1;
+  return () => {
+    // xorshift32
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    state = state >>> 0;
+    return state / 2 ** 32;
+  };
+}

--- a/tests/stealth/fingerprint-sampler-wired.test.ts
+++ b/tests/stealth/fingerprint-sampler-wired.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  getFingerprintSampleOverrideScript,
+  isFingerprintSamplerEnabled,
+} from '../../src/stealth/fingerprint-defense';
+import { sampleFingerprint } from '../../src/stealth/fingerprint-sampler';
+
+/**
+ * Wiring test for the P8 pack. Codex flagged that `fingerprint-defense.ts`
+ * and `human-behavior.ts` were unchanged, so the sampled tuple was never
+ * injected — runtime effect was zero.
+ *
+ * These tests verify the two new integration surfaces:
+ *   - `getFingerprintSampleOverrideScript(sample)` produces a JS source
+ *     string that references the sampled values and defines them on
+ *     Navigator/Screen/window prototypes.
+ *   - `isFingerprintSamplerEnabled()` parses the env flag correctly.
+ *
+ * The client.ts wiring (see the diff at src/cdp/client.ts around the stealth
+ * tab creation) then calls this pair inside the tab-open path.
+ */
+describe('FingerprintSampleOverrideScript', () => {
+  it('embeds sampled values so they will be readable inside the page', () => {
+    const sample = sampleFingerprint('deterministic-seed-1');
+    const script = getFingerprintSampleOverrideScript(sample);
+    // The script must contain the exact sampled UA / timezone / language so
+    // that a page-side navigator.userAgent read returns the sampled value.
+    expect(script).toContain(sample.userAgent);
+    expect(script).toContain(sample.timezone);
+    expect(script).toContain(sample.language);
+    // hardwareConcurrency + deviceMemory need to be embedded as JSON
+    // literals; check both appear in the encoded blob.
+    expect(script).toContain(JSON.stringify(sample.hardwareConcurrency));
+    expect(script).toContain(JSON.stringify(sample.deviceMemoryGB));
+  });
+
+  it('is deterministic for the same seed and covers >1 joint-table row across many seeds', () => {
+    const a1 = sampleFingerprint('tab-A');
+    const a2 = sampleFingerprint('tab-A');
+    expect(a1.userAgent).toBe(a2.userAgent);
+    expect(a1.timezone).toBe(a2.timezone);
+    // Distribution property: across 40 varied seeds we must observe at
+    // least two distinct joint rows. Otherwise the sampler is effectively
+    // constant and would be trivially profileable — the exact failure
+    // mode the P8 pack was written to fix.
+    const uas = new Set<string>();
+    for (let i = 0; i < 40; i++) {
+      uas.add(sampleFingerprint(`seed-${i}`).userAgent);
+    }
+    expect(uas.size).toBeGreaterThan(1);
+  });
+
+  it('generated script is syntactically valid JavaScript', () => {
+    const sample = sampleFingerprint('syntax-check');
+    const script = getFingerprintSampleOverrideScript(sample);
+    // Function constructor throws on invalid syntax — safest local
+    // acceptance check without spinning up a real browser.
+    expect(() => new Function(script)).not.toThrow();
+  });
+
+  it('script overrides run without throwing when executed in a sandbox-shaped global', () => {
+    const sample = sampleFingerprint('exec-check');
+    const script = getFingerprintSampleOverrideScript(sample);
+    // Fake the minimum globals the script touches. If a defineProperty
+    // path throws, the outer try/catch inside the script must swallow it.
+    const sandbox: any = {
+      Navigator: function () {},
+      Screen: function () {},
+      window: {},
+      Intl: (globalThis as any).Intl,
+    };
+    sandbox.Navigator.prototype = {};
+    sandbox.Screen.prototype = {};
+    const fn = new Function(
+      'Navigator', 'Screen', 'window', 'Intl',
+      script,
+    );
+    expect(() => fn(sandbox.Navigator, sandbox.Screen, sandbox.window, sandbox.Intl)).not.toThrow();
+    // Verify the Navigator getter was installed and returns the sampled UA.
+    const nav = new sandbox.Navigator();
+    expect(nav.userAgent).toBe(sample.userAgent);
+    expect(nav.hardwareConcurrency).toBe(sample.hardwareConcurrency);
+  });
+});
+
+describe('isFingerprintSamplerEnabled', () => {
+  it('is off by default', () => {
+    expect(isFingerprintSamplerEnabled({})).toBe(false);
+  });
+  it.each(['1', 'true', 'yes', 'on', 'TRUE'])('accepts %s as on', (v) => {
+    expect(isFingerprintSamplerEnabled({ OPENCHROME_FINGERPRINT_SAMPLER: v })).toBe(true);
+  });
+  it.each(['0', 'false', 'off', ''])('rejects %s as off', (v) => {
+    expect(isFingerprintSamplerEnabled({ OPENCHROME_FINGERPRINT_SAMPLER: v })).toBe(false);
+  });
+});

--- a/tests/stealth/fingerprint-sampler.test.ts
+++ b/tests/stealth/fingerprint-sampler.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  bezierPointerPath,
+  hash32,
+  sampleFingerprint,
+} from '../../src/stealth/fingerprint-sampler.js';
+
+describe('sampleFingerprint', () => {
+  it('is deterministic per seed', () => {
+    const a = sampleFingerprint('session-abc');
+    const b = sampleFingerprint('session-abc');
+    expect(a).toEqual(b);
+  });
+
+  it('yields self-consistent locale/timezone pairs', () => {
+    for (let i = 0; i < 40; i++) {
+      const s = sampleFingerprint(`seed-${i}`);
+      // language/timezone/platform tuples in the table are curated to be
+      // internally consistent — this test guards against future edits that
+      // decouple them.
+      expect(s.language).toMatch(/^[a-z]{2}-[A-Z]{2}$/);
+      expect(s.timezone).toMatch(/^[A-Za-z_]+\/[A-Za-z_]+$|^UTC$/);
+      expect(s.hardwareConcurrency).toBeGreaterThanOrEqual(4);
+    }
+  });
+
+  it('exercises every joint row with enough seeds', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 200; i++) {
+      seen.add(sampleFingerprint(`s-${i}`).language);
+    }
+    // Not all 9 rows will hit in 200 draws, but at least four locales should.
+    expect(seen.size).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe('hash32', () => {
+  it('is stable for the empty string', () => {
+    expect(hash32('')).toBe(2166136261);
+  });
+  it('changes for one-char inputs', () => {
+    expect(hash32('a')).not.toBe(hash32('b'));
+  });
+});
+
+describe('bezierPointerPath', () => {
+  it('emits steps+1 points anchored at the endpoints', () => {
+    const path = bezierPointerPath({ x: 0, y: 0 }, { x: 100, y: 50 }, {
+      steps: 10,
+      seed: 'test',
+    });
+    expect(path).toHaveLength(11);
+    expect(path[0]).toEqual({ x: 0, y: 0 });
+    expect(path.at(-1)).toEqual({ x: 100, y: 50 });
+  });
+
+  it('is deterministic per seed', () => {
+    const a = bezierPointerPath({ x: 0, y: 0 }, { x: 300, y: 200 }, { seed: 'z', steps: 5 });
+    const b = bezierPointerPath({ x: 0, y: 0 }, { x: 300, y: 200 }, { seed: 'z', steps: 5 });
+    expect(a).toEqual(b);
+  });
+
+  it('curves off the straight line (non-monotone in one axis)', () => {
+    const path = bezierPointerPath({ x: 0, y: 0 }, { x: 400, y: 0 }, {
+      steps: 20,
+      seed: 'curvy',
+      curveMagnitude: 0.6,
+    });
+    const ys = path.map((p) => p.y);
+    const nonZero = ys.filter((y) => Math.abs(y) > 0.001);
+    // With curveMagnitude and a non-zero perpendicular, some intermediate y
+    // must move off the axis.
+    expect(nonZero.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds \`sampleFingerprint(seed)\` — a small joint-distribution sampler that returns internally consistent UA / platform / locale / timezone / screen / hardwareConcurrency tuples, plus \`bezierPointerPath(from, to)\` for curved cursor motion between arbitrary page coordinates.

## Motivation

The current \`fingerprint-defense.ts\` draws each field independently, which produces impossible combinations (\`ko-KR\` + \`America/New_York\` + \`en-US\` accept-language). Anti-bot vendors fingerprint that decoupling as a signal on its own. A joint table preserves the correlations real users exhibit.

Both functions are deterministic per seed so within-session navigation stays stable — legitimate users don't get a fresh UA between clicks.

## Attribution

Clean-room. Idea credit per [\`ULTIMATE-CENSUS-2026-07-18\`](https://github.com/sergiobuilds/sonar/blob/main/docs/rebirth/ULTIMATE-CENSUS-2026-07-18.md): browserforge/fingerprint-suite (A20), pydoll (A8). No code copied.

Pack **P8** of [OPENCHROME-CONTRIBUTION-PLAN-V2](https://github.com/sergiobuilds/sonar/blob/main/docs/rebirth/OPENCHROME-CONTRIBUTION-PLAN-V2.md).

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] Determinism per seed
- [x] Distribution coverage (>=4 locales in 200 draws)
- [x] Bezier path anchors at endpoints and curves off the straight line