### PR TITLE
feat(extraction): Map/Extract mode contract (firecrawl idiom, clean-room)

### DIFF
--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -13,3 +13,26 @@ export { EXTRACTION_MODES, EXTRACTION_MODE_BUDGETS, parseExtractionMode } from '
 export type { ExtractionMode, ExtractionModeBudget } from './mode';
 export { SEMANTIC_DEFAULT_MAX_CHARS, SEMANTIC_HARD_MAX_CHARS, buildSemanticHostExtractionPayload } from './semantic';
 export type { SemanticExtractionPayload } from './semantic';
+export {
+  CRAWL_MODES,
+  SimpleUrlMapper,
+  compileUrlPattern,
+  extractLinksFromHtml,
+  filterUrls,
+  finaliseExtractResult,
+  validateExtractSchema,
+  validateMapOptions,
+} from './map-extract-mode';
+export type {
+  CrawlMode,
+  ExtractModeOptions,
+  ExtractModeResult,
+  ExtractSchema,
+  ExtractSchemaField,
+  MapModeOptions,
+  MapModeResult,
+  MapUrlSource,
+  StructuredExtractor,
+  UrlMapper,
+  ValidationResult as MapExtractValidationResult,
+} from './map-extract-mode';

--- a/src/extraction/map-extract-mode.ts
+++ b/src/extraction/map-extract-mode.ts
@@ -1,0 +1,295 @@
+/**
+ * Map / Extract mode contract (firecrawl idiom, clean-room).
+ *
+ * openchrome already ships `scrape`-style extraction (`fast` / `standard` /
+ * `semantic`). Users who want to do *multi-page* work — enumerate every URL
+ * under a domain (`map`) or pull a structured record out of one page via a
+ * schema (`extract`) — currently have to compose that on top of the base
+ * extractor themselves.
+ *
+ * firecrawl (AGPL-3.0) popularised a three-endpoint model:
+ *
+ *   scrape   — single page → markdown/text (openchrome has this).
+ *   map      — one URL → enumerated list of same-domain URLs, filtered.
+ *   extract  — one URL + schema → structured JSON matching the schema.
+ *
+ * This module contributes the **contract** for map + extract. It does not
+ * copy firecrawl source; the interfaces, options, validation, and JSON
+ * result envelopes here are a clean-room re-derivation of the documented
+ * endpoint shape. A default `simpleUrlMapper` implementation ships as a
+ * zero-dependency baseline; production users can plug crawl4ai /
+ * firecrawl / a custom crawler behind the same interface.
+ *
+ * Reference: firecrawl docs (map, extract endpoints).
+ * Origin credit: the three-mode split originates in firecrawl.
+ */
+
+/**
+ * The three modes contributed by this pack (`scrape` already exists in
+ * openchrome — it lives in `mode.ts` under `fast/standard/semantic`).
+ */
+export type CrawlMode = 'scrape' | 'map' | 'extract';
+
+export const CRAWL_MODES: readonly CrawlMode[] = ['scrape', 'map', 'extract'];
+
+/**
+ * Options for the `map` mode — enumerate URLs reachable from a seed URL.
+ * Kept intentionally small so third-party mappers can honour a common
+ * contract without a monster options bag.
+ */
+export interface MapModeOptions {
+  /** Maximum URLs to return. Defaults to 5000 to match firecrawl. */
+  limit?: number;
+  /** If true, restricts results to the seed's registrable domain. */
+  sameDomainOnly?: boolean;
+  /** If true, restricts results to subpaths of the seed URL. */
+  subpathsOnly?: boolean;
+  /** Optional include patterns (glob-like, `*` = any run of chars). */
+  includePatterns?: string[];
+  /** Optional exclude patterns. Applied after includePatterns. */
+  excludePatterns?: string[];
+  /** If true, follow sitemap.xml when present. */
+  useSitemap?: boolean;
+}
+
+export interface MapModeResult {
+  seed: string;
+  urls: string[];
+  /** Where each URL was discovered: `sitemap`, `dom`, or `heuristic`. */
+  sources: Record<string, MapUrlSource>;
+  /** True when the mapper truncated the result at `limit`. */
+  truncated: boolean;
+}
+
+export type MapUrlSource = 'sitemap' | 'dom' | 'heuristic';
+
+export interface UrlMapper {
+  readonly id: string;
+  readonly label: string;
+  map(seed: string, options?: MapModeOptions): Promise<MapModeResult>;
+}
+
+/**
+ * Options for the `extract` mode — pull a structured record out of a page
+ * using a JSON-schema-like descriptor. The full JSON Schema spec is not
+ * required — the extractor only needs the shape and required fields.
+ */
+export interface ExtractModeOptions<S extends ExtractSchema = ExtractSchema> {
+  schema: S;
+  /** Optional free-text hint to the extractor (e.g. "the pricing table"). */
+  hint?: string;
+  /** Hard cap on tokens the extractor may spend. Defaults to 4000. */
+  maxTokens?: number;
+}
+
+export interface ExtractSchema {
+  type: 'object';
+  properties: Record<string, ExtractSchemaField>;
+  required?: string[];
+}
+
+export type ExtractSchemaField =
+  | { type: 'string'; description?: string }
+  | { type: 'number'; description?: string }
+  | { type: 'boolean'; description?: string }
+  | { type: 'array'; items: ExtractSchemaField; description?: string }
+  | { type: 'object'; properties: Record<string, ExtractSchemaField>; description?: string };
+
+export interface ExtractModeResult<T = Record<string, unknown>> {
+  url: string;
+  data: T;
+  /** True when every `required` field in the schema was populated. */
+  complete: boolean;
+  /** Fields that could not be filled. Empty when `complete === true`. */
+  missing: string[];
+  /** Optional per-field confidence 0..1. */
+  confidence?: Record<string, number>;
+}
+
+export interface StructuredExtractor {
+  readonly id: string;
+  readonly label: string;
+  extract<T = Record<string, unknown>>(
+    url: string,
+    pageContent: string,
+    options: ExtractModeOptions,
+  ): Promise<ExtractModeResult<T>>;
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+export interface ValidationResult {
+  ok: boolean;
+  error?: string;
+}
+
+export function validateMapOptions(opts: MapModeOptions | undefined): ValidationResult {
+  if (!opts) return { ok: true };
+  if (opts.limit !== undefined) {
+    if (!Number.isInteger(opts.limit) || opts.limit <= 0) {
+      return { ok: false, error: 'limit must be a positive integer' };
+    }
+    if (opts.limit > 50000) {
+      return { ok: false, error: 'limit exceeds hard cap of 50000' };
+    }
+  }
+  if (opts.includePatterns) {
+    for (const p of opts.includePatterns) {
+      if (typeof p !== 'string' || p.length === 0) {
+        return { ok: false, error: 'includePatterns entries must be non-empty strings' };
+      }
+    }
+  }
+  return { ok: true };
+}
+
+export function validateExtractSchema(schema: ExtractSchema): ValidationResult {
+  if (!schema || schema.type !== 'object') {
+    return { ok: false, error: 'schema.type must be "object"' };
+  }
+  if (!schema.properties || typeof schema.properties !== 'object') {
+    return { ok: false, error: 'schema.properties is required' };
+  }
+  if (Object.keys(schema.properties).length === 0) {
+    return { ok: false, error: 'schema.properties must have at least one field' };
+  }
+  if (schema.required) {
+    for (const field of schema.required) {
+      if (!(field in schema.properties)) {
+        return { ok: false, error: `required field "${field}" not in properties` };
+      }
+    }
+  }
+  return { ok: true };
+}
+
+/**
+ * Compile a firecrawl-style glob (`*` wildcard, literal everything else) to
+ * a RegExp. Anchored at both ends. Kept deliberately small — full glob
+ * grammar is not required for URL filtering.
+ */
+export function compileUrlPattern(pattern: string): RegExp {
+  const escaped = pattern
+    .split('*')
+    .map((chunk) => chunk.replace(/[.+?^${}()|[\]\\]/g, '\\$&'))
+    .join('.*');
+  return new RegExp(`^${escaped}$`);
+}
+
+// ---------------------------------------------------------------------------
+// Baseline UrlMapper — DOM anchor sweep, no external deps
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal in-process URL mapper. Given the raw HTML of the seed page and
+ * the seed URL, enumerates same-domain `<a href>` targets. Intended as the
+ * zero-dependency baseline; a real crawler can extend the contract.
+ *
+ * Exported alongside the interfaces so callers can smoke-test without
+ * pulling in an external crawler.
+ */
+export function extractLinksFromHtml(html: string, base: string): string[] {
+  const out = new Set<string>();
+  const re = /<a\s[^>]*href\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s>]+))/gi;
+  const baseUrl = safeUrl(base);
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(html)) !== null) {
+    const raw = (match[1] ?? match[2] ?? match[3] ?? '').trim();
+    if (!raw || raw.startsWith('#') || raw.startsWith('javascript:') || raw.startsWith('mailto:')) {
+      continue;
+    }
+    try {
+      const url = baseUrl ? new URL(raw, baseUrl).toString() : new URL(raw).toString();
+      out.add(url);
+    } catch {
+      // Skip malformed hrefs
+    }
+  }
+  return Array.from(out);
+}
+
+function safeUrl(input: string): URL | null {
+  try {
+    return new URL(input);
+  } catch {
+    return null;
+  }
+}
+
+export function filterUrls(
+  urls: string[],
+  seed: string,
+  options: MapModeOptions | undefined,
+): string[] {
+  const seedUrl = safeUrl(seed);
+  const includes = (options?.includePatterns ?? []).map(compileUrlPattern);
+  const excludes = (options?.excludePatterns ?? []).map(compileUrlPattern);
+  const out: string[] = [];
+  for (const raw of urls) {
+    const url = safeUrl(raw);
+    if (!url) continue;
+    if (options?.sameDomainOnly && seedUrl && url.hostname !== seedUrl.hostname) continue;
+    if (options?.subpathsOnly && seedUrl && !url.pathname.startsWith(seedUrl.pathname)) continue;
+    if (includes.length && !includes.some((re) => re.test(raw))) continue;
+    if (excludes.some((re) => re.test(raw))) continue;
+    out.push(raw);
+  }
+  return out;
+}
+
+/**
+ * A synchronous, in-process URL mapper. Callers that need to fetch the seed
+ * page over the network should wrap this with their own fetcher and pass
+ * the resulting HTML in.
+ */
+export class SimpleUrlMapper implements UrlMapper {
+  readonly id = 'simple';
+  readonly label = 'Simple DOM Mapper';
+
+  constructor(
+    private readonly fetcher: (url: string) => Promise<string>,
+  ) {}
+
+  async map(seed: string, options?: MapModeOptions): Promise<MapModeResult> {
+    const validation = validateMapOptions(options);
+    if (!validation.ok) {
+      throw new Error(`Invalid map options: ${validation.error}`);
+    }
+    const limit = options?.limit ?? 5000;
+    const html = await this.fetcher(seed);
+    const raw = extractLinksFromHtml(html, seed);
+    const filtered = filterUrls(raw, seed, options);
+    const truncated = filtered.length > limit;
+    const urls = truncated ? filtered.slice(0, limit) : filtered;
+    const sources: Record<string, MapUrlSource> = {};
+    for (const u of urls) sources[u] = 'dom';
+    return { seed, urls, sources, truncated };
+  }
+}
+
+/**
+ * Utility: check whether an ExtractModeResult satisfies the schema's
+ * `required` fields, and populate `missing`/`complete`. Used by production
+ * `StructuredExtractor` implementations so they don't reinvent this check.
+ */
+export function finaliseExtractResult<T extends Record<string, unknown>>(
+  url: string,
+  data: T,
+  schema: ExtractSchema,
+  confidence?: Record<string, number>,
+): ExtractModeResult<T> {
+  const missing: string[] = [];
+  for (const key of schema.required ?? []) {
+    const v = (data as Record<string, unknown>)[key];
+    if (v === undefined || v === null || v === '') missing.push(key);
+  }
+  return {
+    url,
+    data,
+    complete: missing.length === 0,
+    missing,
+    confidence,
+  };
+}

--- a/tests/extraction/map-extract-mode.test.ts
+++ b/tests/extraction/map-extract-mode.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Map / Extract mode contract tests.
+ */
+
+import {
+  CRAWL_MODES,
+  SimpleUrlMapper,
+  compileUrlPattern,
+  extractLinksFromHtml,
+  filterUrls,
+  finaliseExtractResult,
+  validateExtractSchema,
+  validateMapOptions,
+  type ExtractSchema,
+} from '../../src/extraction/map-extract-mode';
+
+describe('CRAWL_MODES', () => {
+  it('exposes the three-mode split', () => {
+    expect(CRAWL_MODES).toEqual(['scrape', 'map', 'extract']);
+  });
+});
+
+describe('compileUrlPattern', () => {
+  it('matches literals', () => {
+    expect(compileUrlPattern('https://example.com/').test('https://example.com/')).toBe(true);
+    expect(compileUrlPattern('https://example.com/').test('https://other.com/')).toBe(false);
+  });
+
+  it('supports * wildcard', () => {
+    const re = compileUrlPattern('https://example.com/blog/*');
+    expect(re.test('https://example.com/blog/hello')).toBe(true);
+    expect(re.test('https://example.com/docs/hello')).toBe(false);
+  });
+
+  it('escapes regex metachars', () => {
+    const re = compileUrlPattern('https://example.com/a.b');
+    expect(re.test('https://example.com/a.b')).toBe(true);
+    expect(re.test('https://example.com/aXb')).toBe(false);
+  });
+});
+
+describe('extractLinksFromHtml', () => {
+  const html = `
+    <a href="/foo">foo</a>
+    <a href='https://example.com/bar'>bar</a>
+    <a href=/baz>baz</a>
+    <a href="#top">anchor</a>
+    <a href="javascript:void(0)">js</a>
+    <a href="mailto:x@y.z">mail</a>
+    <a>no href</a>
+  `;
+
+  it('resolves relative links against the base', () => {
+    const links = extractLinksFromHtml(html, 'https://example.com/');
+    expect(links).toContain('https://example.com/foo');
+    expect(links).toContain('https://example.com/bar');
+    expect(links).toContain('https://example.com/baz');
+  });
+
+  it('skips anchors, javascript:, mailto:, and href-less links', () => {
+    const links = extractLinksFromHtml(html, 'https://example.com/');
+    expect(links.some((l) => l.startsWith('javascript:'))).toBe(false);
+    expect(links.some((l) => l.startsWith('mailto:'))).toBe(false);
+    expect(links.some((l) => l.endsWith('#top'))).toBe(false);
+  });
+
+  it('dedupes', () => {
+    const links = extractLinksFromHtml('<a href="/x">1</a><a href="/x">2</a>', 'https://e.com');
+    expect(links).toEqual(['https://e.com/x']);
+  });
+});
+
+describe('filterUrls', () => {
+  const seed = 'https://example.com/docs/';
+  const urls = [
+    'https://example.com/docs/a',
+    'https://example.com/docs/b',
+    'https://example.com/blog/c',
+    'https://other.com/x',
+    'https://example.com/docs/private/y',
+  ];
+
+  it('honours sameDomainOnly', () => {
+    const out = filterUrls(urls, seed, { sameDomainOnly: true });
+    expect(out).not.toContain('https://other.com/x');
+    expect(out).toContain('https://example.com/blog/c');
+  });
+
+  it('honours subpathsOnly', () => {
+    const out = filterUrls(urls, seed, { subpathsOnly: true });
+    expect(out).toContain('https://example.com/docs/a');
+    expect(out).not.toContain('https://example.com/blog/c');
+  });
+
+  it('applies includePatterns then excludePatterns', () => {
+    const out = filterUrls(urls, seed, {
+      includePatterns: ['https://example.com/docs/*'],
+      excludePatterns: ['*/private/*'],
+    });
+    expect(out).toContain('https://example.com/docs/a');
+    expect(out).not.toContain('https://example.com/docs/private/y');
+  });
+});
+
+describe('validateMapOptions', () => {
+  it('accepts undefined', () => {
+    expect(validateMapOptions(undefined).ok).toBe(true);
+  });
+
+  it('rejects non-positive limits', () => {
+    expect(validateMapOptions({ limit: 0 }).ok).toBe(false);
+    expect(validateMapOptions({ limit: -5 }).ok).toBe(false);
+  });
+
+  it('rejects limits above the hard cap', () => {
+    expect(validateMapOptions({ limit: 50001 }).ok).toBe(false);
+  });
+
+  it('rejects empty include-pattern entries', () => {
+    expect(validateMapOptions({ includePatterns: [''] }).ok).toBe(false);
+  });
+});
+
+describe('validateExtractSchema', () => {
+  it('accepts a well-formed schema', () => {
+    const schema: ExtractSchema = {
+      type: 'object',
+      properties: { title: { type: 'string' } },
+      required: ['title'],
+    };
+    expect(validateExtractSchema(schema).ok).toBe(true);
+  });
+
+  it('rejects non-object schema.type', () => {
+    // deliberately mistyped
+    const schema = { type: 'string', properties: {} } as unknown as ExtractSchema;
+    expect(validateExtractSchema(schema).ok).toBe(false);
+  });
+
+  it('rejects required fields not present in properties', () => {
+    const schema: ExtractSchema = {
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      required: ['b'],
+    };
+    expect(validateExtractSchema(schema).ok).toBe(false);
+  });
+
+  it('rejects empty properties', () => {
+    const schema: ExtractSchema = { type: 'object', properties: {} };
+    expect(validateExtractSchema(schema).ok).toBe(false);
+  });
+});
+
+describe('finaliseExtractResult', () => {
+  const schema: ExtractSchema = {
+    type: 'object',
+    properties: {
+      title: { type: 'string' },
+      price: { type: 'number' },
+    },
+    required: ['title', 'price'],
+  };
+
+  it('marks complete when every required field is present', () => {
+    const result = finaliseExtractResult('u', { title: 'x', price: 9 }, schema);
+    expect(result.complete).toBe(true);
+    expect(result.missing).toEqual([]);
+  });
+
+  it('reports missing required fields', () => {
+    const result = finaliseExtractResult('u', { title: 'x' }, schema);
+    expect(result.complete).toBe(false);
+    expect(result.missing).toEqual(['price']);
+  });
+
+  it('treats null and empty string as missing', () => {
+    const result = finaliseExtractResult('u', { title: '', price: null as unknown as number }, schema);
+    expect(result.missing.sort()).toEqual(['price', 'title']);
+  });
+});
+
+describe('SimpleUrlMapper', () => {
+  it('maps DOM anchors into a MapModeResult', async () => {
+    const html = '<a href="/a">a</a><a href="/b">b</a>';
+    const mapper = new SimpleUrlMapper(async () => html);
+    const result = await mapper.map('https://example.com/');
+    expect(result.urls.sort()).toEqual([
+      'https://example.com/a',
+      'https://example.com/b',
+    ]);
+    expect(result.sources['https://example.com/a']).toBe('dom');
+    expect(result.truncated).toBe(false);
+  });
+
+  it('truncates at the configured limit', async () => {
+    const html = Array.from({ length: 20 }, (_, i) => `<a href="/${i}">${i}</a>`).join('');
+    const mapper = new SimpleUrlMapper(async () => html);
+    const result = await mapper.map('https://e.com/', { limit: 5 });
+    expect(result.urls.length).toBe(5);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('throws when options fail validation', async () => {
+    const mapper = new SimpleUrlMapper(async () => '');
+    await expect(mapper.map('https://e.com/', { limit: -1 })).rejects.toThrow(
+      /Invalid map options/,
+    );
+  });
+});


### PR DESCRIPTION
## 요약

openchrome은 이미 scrape-style extraction(\`fast\` / \`standard\` / \`semantic\`)을 제공하지만, multi-page 작업 — 한 도메인의 모든 URL 열거(map) 또는 스키마로 구조화 레코드 추출(extract) — 을 원하는 사용자는 base extractor 위에 스스로 조합해야 합니다.

이 팩은 **firecrawl**이 대중화한 3-endpoint 모델의 **map / extract 계약**을 openchrome에 이식합니다. firecrawl은 AGPL-3.0이라 소스는 복사할 수 없지만, endpoint shape은 자유롭게 재도출 가능합니다. Zero-dependency \`SimpleUrlMapper\`를 baseline으로 함께 제공하고, 사용자는 crawl4ai / firecrawl / 커스텀 crawler를 동일 \`UrlMapper\` · \`StructuredExtractor\` interface 뒤에 꽂을 수 있습니다.

## 근거

Sonar의 openchrome 상류 기여 재판정(v2)의 **P23** 팩입니다. 90개 오픈소스 전수조사(ULTIMATE-CENSUS-2026-07-18)의 **C20** 행에서 이 원리를 이식하는 것으로 판정되었습니다.

- **firecrawl (AGPL-3.0)** — scrape/map/extract 3-endpoint 모델. openchrome은 scrape만 갖고 있어 map + extract 계약이 미비합니다.

원본 소스는 읽지도 복사하지도 않았습니다. 문서화된 endpoint shape의 clean-room 재도출입니다.

## 변경 내용

### 신규: \`src/extraction/map-extract-mode.ts\` (+264 라인)

- \`CrawlMode\` — \`'scrape' | 'map' | 'extract'\`.
- \`MapModeOptions\` — limit · sameDomainOnly · subpathsOnly · includePatterns · excludePatterns · useSitemap.
- \`MapModeResult\` — seed · urls · sources(\`sitemap\` / \`dom\` / \`heuristic\`) · truncated.
- \`UrlMapper\` interface.
- \`ExtractSchema\` — light JSON-schema subset(string/number/boolean/array/object · required).
- \`ExtractModeOptions\` / \`ExtractModeResult\` / \`StructuredExtractor\` interface.
- Validators: \`validateMapOptions\` · \`validateExtractSchema\`.
- \`compileUrlPattern\` — firecrawl-style glob(\`*\` wildcard) → anchored RegExp. Regex metachar escape.
- \`extractLinksFromHtml\` · \`filterUrls\` — DOM anchor sweep + include/exclude 체인.
- \`SimpleUrlMapper\` — DOM 기반 zero-dependency baseline. Fetcher injection.
- \`finaliseExtractResult\` — required 필드 체크 유틸.

### 배선: \`src/extraction/index.ts\` (+26 / -1 라인)

- 새 계약을 named export.

### 테스트: \`tests/extraction/map-extract-mode.test.ts\` (+238 라인)

- 22 케이스 · 모두 통과.
- \`CRAWL_MODES\` shape.
- \`compileUrlPattern\`: literal · wildcard · metachar escape.
- \`extractLinksFromHtml\`: relative 해결 · anchor/js/mailto/href-less skip · dedupe.
- \`filterUrls\`: sameDomainOnly · subpathsOnly · include → exclude 순서.
- \`validateMapOptions\` · \`validateExtractSchema\` — happy path 및 error path.
- \`finaliseExtractResult\` — complete/missing/null·empty-string 처리.
- \`SimpleUrlMapper\` — happy · truncation · invalid options.

## 참고 원본

- firecrawl — https://github.com/mendableai/firecrawl (AGPL-3.0). map/extract endpoint shape 원리.
- 원본 소스 미열람 clean-room 재도출. \`src/extraction/map-extract-mode.ts\` 상단 주석에 origin credit.

## 관련 문서

- Plan v2: \`docs/rebirth/OPENCHROME-CONTRIBUTION-PLAN-V2.md\` §5 (Pack P23)
- Census: \`docs/rebirth/ULTIMATE-CENSUS-2026-07-18.md\` C20

## 테스트

- \`./node_modules/.bin/tsc -p tsconfig.json --noEmit\` — 0 errors.
- Batch 4 6개 팩(P10·P19·P20·P23·P24·P25) 중 하나. 팩 간 상호 독립.