### PR TITLE
feat(recovery): RARR-style post-hoc revise hook

### DIFF
--- a/src/recovery/revise.ts
+++ b/src/recovery/revise.ts
@@ -1,0 +1,163 @@
+/**
+ * RARR-style post-hoc revise hook.
+ *
+ * Classic recovery in openchrome is "detect failure → propose retry
+ * candidate". That is the *prevention* mode: try to avoid the wrong answer.
+ * RARR (Retrofit Attribution using Research and Revision, Gao et al.) makes
+ * the opposite bet — assume the initial answer will land, then use a
+ * cheaper revise pass to patch specific claims that fail post-hoc
+ * verification.
+ *
+ * In an openchrome context this maps to a common pattern: an extraction
+ * strategy returns a plausible-looking payload, but downstream schema
+ * validation, tests, or a human review flag a specific field as wrong.
+ * Instead of throwing away the whole result and re-running the extractor,
+ * we invoke a `revise` hook that only rewrites the flagged fields.
+ *
+ * Contract
+ * --------
+ *   const revise = createReviseHook({
+ *     revisers: {
+ *       'schema-violation': async ({ payload, findings }) => ({ ... }),
+ *       'stale-value':      async ({ payload, findings }) => ({ ... }),
+ *     },
+ *   });
+ *   const outcome = await revise({
+ *     payload: originalResult,
+ *     findings: [{ kind: 'schema-violation', locus: 'invoice.total', ... }],
+ *   });
+ *   if (outcome.status === 'revised') use(outcome.payload);
+ *
+ * The hook itself owns *only* the dispatch policy. Concrete revisers are
+ * caller-supplied — they are the ones that know how to patch a given
+ * failure class. This keeps this module dependency-free and testable in
+ * isolation.
+ *
+ * Clean-room. Idea attribution per docs/rebirth/ULTIMATE-CENSUS-2026-07-18:
+ * RARR (B13). No code copied.
+ */
+
+export interface ReviseFinding {
+  kind: string;
+  locus: string;
+  detail?: string;
+}
+
+export interface ReviseRequest<TPayload> {
+  payload: TPayload;
+  findings: readonly ReviseFinding[];
+  /** Optional session id for logging / cache keying. */
+  sessionId?: string;
+}
+
+export interface ReviseAppliedPatch {
+  kind: string;
+  locus: string;
+  status: 'applied' | 'skipped' | 'failed';
+  reason?: string;
+}
+
+export type ReviseResult<TPayload> =
+  | { status: 'no-findings'; payload: TPayload; patches: readonly ReviseAppliedPatch[] }
+  | { status: 'revised'; payload: TPayload; patches: readonly ReviseAppliedPatch[] }
+  | {
+      status: 'unrecoverable';
+      payload: TPayload;
+      patches: readonly ReviseAppliedPatch[];
+      reason: string;
+    };
+
+export interface ReviserContext<TPayload> {
+  payload: TPayload;
+  finding: ReviseFinding;
+  allFindings: readonly ReviseFinding[];
+  sessionId?: string;
+}
+
+export type Reviser<TPayload> = (
+  ctx: ReviserContext<TPayload>,
+) => Promise<TPayload | null>;
+
+export interface ReviseHookOptions<TPayload> {
+  revisers: Readonly<Record<string, Reviser<TPayload>>>;
+  /**
+   * Maximum number of findings to attempt per call. Guards against a runaway
+   * finding stream from a broken classifier. Default 16.
+   */
+  maxFindings?: number;
+  /**
+   * If true, a reviser that returns `null` marks the finding as `skipped`
+   * (default). If false, `null` marks it as `failed`, which can escalate to
+   * `unrecoverable`.
+   */
+  nullMeansSkip?: boolean;
+}
+
+export interface ReviseHook<TPayload> {
+  (request: ReviseRequest<TPayload>): Promise<ReviseResult<TPayload>>;
+}
+
+/**
+ * Build a revise hook. Pure factory — the returned hook holds no state.
+ */
+export function createReviseHook<TPayload>(
+  options: ReviseHookOptions<TPayload>,
+): ReviseHook<TPayload> {
+  const maxFindings = Math.max(1, options.maxFindings ?? 16);
+  const nullMeansSkip = options.nullMeansSkip ?? true;
+  return async (request) => {
+    if (request.findings.length === 0) {
+      return { status: 'no-findings', payload: request.payload, patches: [] };
+    }
+    const applied: ReviseAppliedPatch[] = [];
+    let current = request.payload;
+    const cappedFindings = request.findings.slice(0, maxFindings);
+    let anyApplied = false;
+    let anyFailed = false;
+    for (const finding of cappedFindings) {
+      const reviser = options.revisers[finding.kind];
+      if (!reviser) {
+        applied.push({ kind: finding.kind, locus: finding.locus, status: 'skipped', reason: 'no-reviser' });
+        continue;
+      }
+      try {
+        const next = await reviser({
+          payload: current,
+          finding,
+          allFindings: cappedFindings,
+          sessionId: request.sessionId,
+        });
+        if (next === null || next === undefined) {
+          applied.push({
+            kind: finding.kind,
+            locus: finding.locus,
+            status: nullMeansSkip ? 'skipped' : 'failed',
+            reason: nullMeansSkip ? 'reviser-null' : 'reviser-returned-null',
+          });
+          if (!nullMeansSkip) anyFailed = true;
+          continue;
+        }
+        current = next;
+        applied.push({ kind: finding.kind, locus: finding.locus, status: 'applied' });
+        anyApplied = true;
+      } catch (error) {
+        applied.push({
+          kind: finding.kind,
+          locus: finding.locus,
+          status: 'failed',
+          reason: error instanceof Error ? error.message : String(error),
+        });
+        anyFailed = true;
+      }
+    }
+    if (!anyApplied && anyFailed) {
+      return {
+        status: 'unrecoverable',
+        payload: current,
+        patches: applied,
+        reason: 'all-revisers-failed',
+      };
+    }
+    return { status: 'revised', payload: current, patches: applied };
+  };
+}

--- a/tests/recovery/revise.test.ts
+++ b/tests/recovery/revise.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from '@jest/globals';
+import { createReviseHook } from '../../src/recovery/revise.js';
+
+interface Invoice { total: number; currency: string; }
+
+describe('createReviseHook', () => {
+  it('returns no-findings when nothing to fix', async () => {
+    const hook = createReviseHook<Invoice>({ revisers: {} });
+    const result = await hook({ payload: { total: 10, currency: 'USD' }, findings: [] });
+    expect(result.status).toBe('no-findings');
+  });
+
+  it('applies matched revisers and reports patches', async () => {
+    const hook = createReviseHook<Invoice>({
+      revisers: {
+        'stale-value': async ({ payload }) => ({ ...payload, total: 42 }),
+      },
+    });
+    const result = await hook({
+      payload: { total: 10, currency: 'USD' },
+      findings: [{ kind: 'stale-value', locus: 'invoice.total' }],
+    });
+    expect(result.status).toBe('revised');
+    if (result.status === 'revised') {
+      expect(result.payload.total).toBe(42);
+      expect(result.patches[0]!.status).toBe('applied');
+    }
+  });
+
+  it('skips findings with no matching reviser', async () => {
+    const hook = createReviseHook<Invoice>({ revisers: {} });
+    const result = await hook({
+      payload: { total: 10, currency: 'USD' },
+      findings: [{ kind: 'schema-violation', locus: 'invoice.total' }],
+    });
+    expect(result.status).toBe('revised'); // skipped-only still counts as processed
+    expect(result.patches[0]!.status).toBe('skipped');
+  });
+
+  it('surfaces unrecoverable when all revisers throw', async () => {
+    const hook = createReviseHook<Invoice>({
+      revisers: {
+        boom: async () => { throw new Error('nope'); },
+      },
+    });
+    const result = await hook({
+      payload: { total: 10, currency: 'USD' },
+      findings: [{ kind: 'boom', locus: 'x' }],
+    });
+    expect(result.status).toBe('unrecoverable');
+    if (result.status === 'unrecoverable') {
+      expect(result.patches[0]!.status).toBe('failed');
+    }
+  });
+
+  it('honours maxFindings cap', async () => {
+    let calls = 0;
+    const hook = createReviseHook<Invoice>({
+      revisers: {
+        touch: async ({ payload }) => { calls++; return payload; },
+      },
+      maxFindings: 2,
+    });
+    await hook({
+      payload: { total: 0, currency: 'USD' },
+      findings: [
+        { kind: 'touch', locus: 'a' },
+        { kind: 'touch', locus: 'b' },
+        { kind: 'touch', locus: 'c' },
+      ],
+    });
+    expect(calls).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds \`createReviseHook({ revisers })\` — a dispatch policy that accepts an already-produced payload plus a list of findings and delegates to caller-supplied revisers keyed by finding kind.

## Design

- Complements the existing prevention-mode recovery (avoid the wrong answer) with a cheaper cure-mode (patch specific claims).
- Unmatched findings → \`skipped\`; thrown revisers → \`failed\`; all-fail → \`unrecoverable\`.
- Dependency-free, holds no state.

## Attribution

Clean-room. Idea credit per [\`ULTIMATE-CENSUS-2026-07-18\`](https://github.com/sergiobuilds/sonar/blob/main/docs/rebirth/ULTIMATE-CENSUS-2026-07-18.md): RARR (B13). No code copied.

Pack **P12** of [OPENCHROME-CONTRIBUTION-PLAN-V2](https://github.com/sergiobuilds/sonar/blob/main/docs/rebirth/OPENCHROME-CONTRIBUTION-PLAN-V2.md). Builds naturally on pack P11 (action-cache self-heal, PR #1533).

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] no-findings / matched / unmatched / thrown / cap