### PR TITLE
feat(captcha+auth): Cloudflare challenge cookie retrieval + cf_clearance scheme

### DIFF
--- a/src/captcha/cf-clearance.ts
+++ b/src/captcha/cf-clearance.ts
@@ -1,0 +1,310 @@
+/**
+ * Cloudflare challenge cookie retrieval (`cf_clearance` scheme).
+ *
+ * Motivation
+ * ----------
+ * openchrome's `src/captcha/` already handles Turnstile / reCAPTCHA solve
+ * flows, and `src/gates/` detects Cloudflare bot-check interstitials (see
+ * PR #1517). What is missing is the *cookie-retrieval* half: once the
+ * challenge has been passed — either by a solver, a real user, or a
+ * FlareSolverr-style headless pass — the site issues a `cf_clearance`
+ * cookie that must be captured, persisted, and replayed on subsequent
+ * requests to the same registrable domain.
+ *
+ * This module contributes the contract:
+ *
+ *   - a typed `ChallengeCookie` shape covering `cf_clearance`,
+ *     `__cf_bm`, `_cfuvid`, `cf_chl_*` and unknown-but-cf-prefixed cookies.
+ *   - a `ChallengeCookieStore` with the small operations openchrome needs
+ *     (put, get, list, evict-expired, prune-by-domain).
+ *   - `extractChallengeCookies(rawCookies, url)` — filter arbitrary
+ *     browser-cookie jars down to the challenge-cookie subset.
+ *   - `deriveRegistrableDomain(hostname)` — public-suffix-ish grouping
+ *     helper so `docs.foo.co.uk` and `www.foo.co.uk` share one bucket.
+ *
+ * References
+ * ----------
+ * - FlareSolverr (MIT) — https://github.com/FlareSolverr/FlareSolverr —
+ *   showed the cf_clearance retrieval flow (solve challenge, harvest cookie,
+ *   replay).
+ * - SeleniumBase (MIT) — https://github.com/seleniumbase/SeleniumBase —
+ *   documents the cookie scheme and challenge families.
+ *
+ * Clean-room re-implementation. No FlareSolverr / SeleniumBase source was
+ * copied.
+ */
+
+/**
+ * The subset of cookies openchrome treats as "challenge-issued". Everything
+ * else stays in the regular browser cookie jar untouched.
+ *
+ *   cf_clearance   — the persistent clearance cookie. Highest-value; TTL is
+ *                    site-configured (typically 30 min to hours).
+ *   __cf_bm        — bot-management short-lived cookie (~30 min).
+ *   _cfuvid        — unique visitor id used by rate-limiting rules.
+ *   cf_chl_*       — challenge-transient cookies (drop after solve).
+ *   other-cf       — any other `cf_`- / `__cf`-prefixed cookie, preserved
+ *                    conservatively.
+ */
+export type ChallengeCookieKind =
+  | 'cf_clearance'
+  | '__cf_bm'
+  | '_cfuvid'
+  | 'cf_chl'
+  | 'other-cf';
+
+export interface ChallengeCookie {
+  kind: ChallengeCookieKind;
+  name: string;
+  value: string;
+  /** Registrable domain the cookie applies to (see deriveRegistrableDomain). */
+  domain: string;
+  /** UNIX epoch seconds. `undefined` = session cookie. */
+  expiresAt?: number;
+  /** True if the cookie was set with the Secure flag. */
+  secure: boolean;
+  /** True if the cookie was set with HttpOnly. */
+  httpOnly: boolean;
+  /** ISO timestamp when openchrome captured the cookie. */
+  capturedAt: string;
+}
+
+/**
+ * A raw cookie as delivered by CDP / Playwright / puppeteer-core. Only the
+ * fields this module needs are typed — everything else is ignored.
+ */
+export interface RawCookie {
+  name: string;
+  value: string;
+  domain: string;
+  expires?: number;
+  secure?: boolean;
+  httpOnly?: boolean;
+}
+
+/**
+ * Classify a cookie name. Returns `null` when the cookie is not
+ * challenge-related.
+ */
+export function classifyCookieName(name: string): ChallengeCookieKind | null {
+  if (name === 'cf_clearance') return 'cf_clearance';
+  if (name === '__cf_bm') return '__cf_bm';
+  if (name === '_cfuvid') return '_cfuvid';
+  if (name.startsWith('cf_chl_')) return 'cf_chl';
+  if (name.startsWith('cf_') || name.startsWith('__cf')) return 'other-cf';
+  return null;
+}
+
+/**
+ * Derive a registrable-domain-ish key from a hostname. This is deliberately
+ * lightweight — a full Public Suffix List match would be preferable, but
+ * would bloat the runtime. The heuristic covers the common cases:
+ *
+ *   - two-label ccTLDs (`co.uk`, `com.br`, `co.kr`, `co.jp`, `com.au`, …)
+ *     collapse to `<sld>.<cctld>`.
+ *   - everything else collapses to `<sld>.<tld>`.
+ *   - IP addresses and single-label hosts pass through unchanged.
+ *
+ * If openchrome later adopts a PSL library, callers can swap this out — the
+ * `ChallengeCookieStore` never looks at the domain string beyond equality.
+ */
+export function deriveRegistrableDomain(hostname: string): string {
+  const clean = hostname.replace(/^\./, '').toLowerCase();
+  if (isIpLiteral(clean) || !clean.includes('.')) return clean;
+
+  const parts = clean.split('.');
+  const twoLabelCcTld = new Set([
+    'co.uk', 'com.br', 'co.kr', 'co.jp', 'com.au',
+    'com.mx', 'co.in', 'co.nz', 'co.za', 'com.sg',
+    'com.hk', 'com.tw', 'ne.jp', 'or.jp', 'ac.jp',
+    'co.il', 'com.tr', 'com.ar', 'org.uk', 'ac.uk',
+  ]);
+
+  if (parts.length >= 3) {
+    const lastTwo = parts.slice(-2).join('.');
+    if (twoLabelCcTld.has(lastTwo)) return parts.slice(-3).join('.');
+  }
+  return parts.slice(-2).join('.');
+}
+
+function isIpLiteral(host: string): boolean {
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(host)) return true;
+  if (host.startsWith('[') && host.endsWith(']')) return true;
+  return false;
+}
+
+/**
+ * Turn a raw cookie into a `ChallengeCookie`, or return `null` if the
+ * cookie does not belong to the challenge namespace.
+ */
+export function toChallengeCookie(raw: RawCookie): ChallengeCookie | null {
+  const kind = classifyCookieName(raw.name);
+  if (!kind) return null;
+  return {
+    kind,
+    name: raw.name,
+    value: raw.value,
+    domain: deriveRegistrableDomain(raw.domain),
+    expiresAt: raw.expires && raw.expires > 0 ? Math.floor(raw.expires) : undefined,
+    secure: raw.secure === true,
+    httpOnly: raw.httpOnly === true,
+    capturedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Given a raw cookie jar and the URL the cookies were observed on, return
+ * the challenge-cookie subset with registrable-domain keys. Cookies whose
+ * host does not resolve to the URL's registrable domain are still included
+ * (Cloudflare frequently sets cookies on a parent domain).
+ */
+export function extractChallengeCookies(rawCookies: RawCookie[], _url: string): ChallengeCookie[] {
+  const out: ChallengeCookie[] = [];
+  for (const raw of rawCookies) {
+    const cookie = toChallengeCookie(raw);
+    if (cookie) out.push(cookie);
+  }
+  return out;
+}
+
+/**
+ * Options for a `ChallengeCookieStore` implementation.
+ */
+export interface ChallengeCookieStoreOptions {
+  /** Clock override for tests. */
+  now?: () => number;
+  /** If provided, the store persists to disk under this path. */
+  persistPath?: string;
+}
+
+export interface ChallengeCookieStoreSnapshot {
+  version: 1;
+  updatedAt: string;
+  cookies: ChallengeCookie[];
+}
+
+/**
+ * In-memory `ChallengeCookieStore`. Keyed by (domain, name). New writes
+ * overwrite prior values; expired cookies are pruned on read.
+ */
+export class ChallengeCookieStore {
+  private cookies: Map<string, ChallengeCookie> = new Map();
+  private readonly now: () => number;
+
+  constructor(private readonly options: ChallengeCookieStoreOptions = {}) {
+    this.now = options.now ?? (() => Math.floor(Date.now() / 1000));
+  }
+
+  private key(domain: string, name: string): string {
+    return `${domain}::${name}`;
+  }
+
+  put(cookie: ChallengeCookie): void {
+    this.cookies.set(this.key(cookie.domain, cookie.name), cookie);
+  }
+
+  putMany(cookies: ChallengeCookie[]): number {
+    let n = 0;
+    for (const c of cookies) {
+      this.put(c);
+      n++;
+    }
+    return n;
+  }
+
+  get(domain: string, name: string): ChallengeCookie | undefined {
+    const cookie = this.cookies.get(this.key(domain, name));
+    if (!cookie) return undefined;
+    if (this.isExpired(cookie)) {
+      this.cookies.delete(this.key(domain, name));
+      return undefined;
+    }
+    return cookie;
+  }
+
+  /** Get every non-expired cookie for a registrable domain. */
+  listForDomain(domain: string): ChallengeCookie[] {
+    const out: ChallengeCookie[] = [];
+    const expired: string[] = [];
+    for (const [key, cookie] of this.cookies) {
+      if (cookie.domain !== domain) continue;
+      if (this.isExpired(cookie)) {
+        expired.push(key);
+        continue;
+      }
+      out.push(cookie);
+    }
+    for (const key of expired) this.cookies.delete(key);
+    return out;
+  }
+
+  /** Return every non-expired cookie in the store. */
+  listAll(): ChallengeCookie[] {
+    const out: ChallengeCookie[] = [];
+    const expired: string[] = [];
+    for (const [key, cookie] of this.cookies) {
+      if (this.isExpired(cookie)) {
+        expired.push(key);
+        continue;
+      }
+      out.push(cookie);
+    }
+    for (const key of expired) this.cookies.delete(key);
+    return out;
+  }
+
+  /** Drop every cookie for a registrable domain. */
+  pruneDomain(domain: string): number {
+    let n = 0;
+    for (const [key, cookie] of this.cookies) {
+      if (cookie.domain === domain) {
+        this.cookies.delete(key);
+        n++;
+      }
+    }
+    return n;
+  }
+
+  /** Drop every expired cookie. Returns the number pruned. */
+  evictExpired(): number {
+    let n = 0;
+    for (const [key, cookie] of this.cookies) {
+      if (this.isExpired(cookie)) {
+        this.cookies.delete(key);
+        n++;
+      }
+    }
+    return n;
+  }
+
+  size(): number {
+    return this.cookies.size;
+  }
+
+  isExpired(cookie: ChallengeCookie): boolean {
+    if (cookie.expiresAt === undefined) return false;
+    return cookie.expiresAt <= this.now();
+  }
+
+  snapshot(): ChallengeCookieStoreSnapshot {
+    return {
+      version: 1,
+      updatedAt: new Date().toISOString(),
+      cookies: this.listAll(),
+    };
+  }
+
+  /** Hydrate from a previously produced snapshot. Expired cookies are dropped. */
+  restore(snapshot: ChallengeCookieStoreSnapshot): number {
+    if (snapshot.version !== 1) {
+      throw new Error(`unsupported ChallengeCookieStore snapshot version: ${snapshot.version}`);
+    }
+    let n = 0;
+    for (const cookie of snapshot.cookies) {
+      if (this.isExpired(cookie)) continue;
+      this.put(cookie);
+      n++;
+    }
+    return n;
+  }
+}

--- a/src/captcha/index.ts
+++ b/src/captcha/index.ts
@@ -11,3 +11,17 @@ export { handleCaptcha, checkDomainCaptchaHistory } from './handler';
 export type { CaptchaHandleResult } from './handler';
 export { injectSolution } from './inject-solution';
 export type { CaptchaType, CaptchaDetectionResult, CaptchaSiteKey } from '../types/captcha';
+export {
+  ChallengeCookieStore,
+  classifyCookieName,
+  deriveRegistrableDomain,
+  extractChallengeCookies,
+  toChallengeCookie,
+} from './cf-clearance';
+export type {
+  ChallengeCookie,
+  ChallengeCookieKind,
+  ChallengeCookieStoreOptions,
+  ChallengeCookieStoreSnapshot,
+  RawCookie,
+} from './cf-clearance';

--- a/tests/captcha/cf-clearance.test.ts
+++ b/tests/captcha/cf-clearance.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Cloudflare challenge cookie (cf_clearance) scheme tests.
+ */
+
+import {
+  ChallengeCookieStore,
+  classifyCookieName,
+  deriveRegistrableDomain,
+  extractChallengeCookies,
+  toChallengeCookie,
+  type ChallengeCookie,
+  type RawCookie,
+} from '../../src/captcha/cf-clearance';
+
+function mkCookie(over: Partial<ChallengeCookie> = {}): ChallengeCookie {
+  return {
+    kind: 'cf_clearance',
+    name: 'cf_clearance',
+    value: 'tokenXYZ',
+    domain: 'example.com',
+    secure: true,
+    httpOnly: true,
+    capturedAt: new Date().toISOString(),
+    ...over,
+  };
+}
+
+describe('classifyCookieName', () => {
+  it('recognises the four named cookies', () => {
+    expect(classifyCookieName('cf_clearance')).toBe('cf_clearance');
+    expect(classifyCookieName('__cf_bm')).toBe('__cf_bm');
+    expect(classifyCookieName('_cfuvid')).toBe('_cfuvid');
+    expect(classifyCookieName('cf_chl_2_abc')).toBe('cf_chl');
+  });
+
+  it('bucket-classifies unknown cf_ / __cf cookies as other-cf', () => {
+    expect(classifyCookieName('cf_something')).toBe('other-cf');
+    expect(classifyCookieName('__cf_extra')).toBe('other-cf');
+  });
+
+  it('returns null for non-challenge cookies', () => {
+    expect(classifyCookieName('sessionid')).toBeNull();
+    expect(classifyCookieName('user_id')).toBeNull();
+  });
+});
+
+describe('deriveRegistrableDomain', () => {
+  it('collapses www / subdomains to eTLD+1', () => {
+    expect(deriveRegistrableDomain('www.example.com')).toBe('example.com');
+    expect(deriveRegistrableDomain('docs.foo.com')).toBe('foo.com');
+    expect(deriveRegistrableDomain('.example.com')).toBe('example.com');
+  });
+
+  it('handles two-label ccTLDs', () => {
+    expect(deriveRegistrableDomain('www.foo.co.uk')).toBe('foo.co.uk');
+    expect(deriveRegistrableDomain('shop.example.com.br')).toBe('example.com.br');
+    expect(deriveRegistrableDomain('portal.jd.co.kr')).toBe('jd.co.kr');
+  });
+
+  it('passes IP literals and single-label hosts through', () => {
+    expect(deriveRegistrableDomain('192.168.0.1')).toBe('192.168.0.1');
+    expect(deriveRegistrableDomain('localhost')).toBe('localhost');
+    expect(deriveRegistrableDomain('[::1]')).toBe('[::1]');
+  });
+
+  it('is case-insensitive', () => {
+    expect(deriveRegistrableDomain('WWW.EXAMPLE.COM')).toBe('example.com');
+  });
+});
+
+describe('toChallengeCookie / extractChallengeCookies', () => {
+  const raws: RawCookie[] = [
+    {
+      name: 'cf_clearance',
+      value: 't1',
+      domain: 'www.example.com',
+      expires: Math.floor(Date.now() / 1000) + 3600,
+      secure: true,
+      httpOnly: true,
+    },
+    {
+      name: 'sessionid',
+      value: 'abc',
+      domain: 'www.example.com',
+    },
+    {
+      name: '__cf_bm',
+      value: 't2',
+      domain: '.example.com',
+      expires: Math.floor(Date.now() / 1000) + 1800,
+    },
+  ];
+
+  it('drops non-challenge cookies', () => {
+    const out = extractChallengeCookies(raws, 'https://www.example.com');
+    expect(out.map((c) => c.name).sort()).toEqual(['__cf_bm', 'cf_clearance']);
+  });
+
+  it('collapses domain to registrable form', () => {
+    const out = extractChallengeCookies(raws, 'https://www.example.com');
+    for (const c of out) expect(c.domain).toBe('example.com');
+  });
+
+  it('records secure/httpOnly and capture timestamp', () => {
+    const cookie = toChallengeCookie(raws[0])!;
+    expect(cookie.secure).toBe(true);
+    expect(cookie.httpOnly).toBe(true);
+    expect(new Date(cookie.capturedAt).toString()).not.toBe('Invalid Date');
+  });
+
+  it('treats a missing/zero expires as a session cookie', () => {
+    const c = toChallengeCookie({ name: 'cf_clearance', value: 'x', domain: 'e.com' });
+    expect(c?.expiresAt).toBeUndefined();
+  });
+});
+
+describe('ChallengeCookieStore', () => {
+  let now = 1_700_000_000;
+  const clock = () => now;
+
+  beforeEach(() => {
+    now = 1_700_000_000;
+  });
+
+  it('put and get round-trip', () => {
+    const store = new ChallengeCookieStore({ now: clock });
+    store.put(mkCookie({ expiresAt: now + 60 }));
+    const got = store.get('example.com', 'cf_clearance');
+    expect(got?.value).toBe('tokenXYZ');
+  });
+
+  it('overwrites on repeat put', () => {
+    const store = new ChallengeCookieStore({ now: clock });
+    store.put(mkCookie({ value: 'v1' }));
+    store.put(mkCookie({ value: 'v2' }));
+    expect(store.get('example.com', 'cf_clearance')?.value).toBe('v2');
+    expect(store.size()).toBe(1);
+  });
+
+  it('prunes expired cookies on get', () => {
+    const store = new ChallengeCookieStore({ now: clock });
+    store.put(mkCookie({ expiresAt: now - 1 }));
+    expect(store.get('example.com', 'cf_clearance')).toBeUndefined();
+    expect(store.size()).toBe(0);
+  });
+
+  it('treats session cookies (no expiresAt) as always live', () => {
+    const store = new ChallengeCookieStore({ now: clock });
+    store.put(mkCookie({ expiresAt: undefined }));
+    now += 999_999;
+    expect(store.get('example.com', 'cf_clearance')?.value).toBe('tokenXYZ');
+  });
+
+  it('listForDomain filters by registrable domain', () => {
+    const store = new ChallengeCookieStore({ now: clock });
+    store.put(mkCookie({ domain: 'example.com', name: 'cf_clearance' }));
+    store.put(mkCookie({ domain: 'other.com', name: 'cf_clearance' }));
+    expect(store.listForDomain('example.com').length).toBe(1);
+    expect(store.listForDomain('other.com').length).toBe(1);
+  });
+
+  it('pruneDomain drops every cookie for a domain', () => {
+    const store = new ChallengeCookieStore({ now: clock });
+    store.put(mkCookie({ name: 'cf_clearance' }));
+    store.put(mkCookie({ name: '__cf_bm', kind: '__cf_bm' }));
+    const n = store.pruneDomain('example.com');
+    expect(n).toBe(2);
+    expect(store.size()).toBe(0);
+  });
+
+  it('evictExpired removes only past-due cookies', () => {
+    const store = new ChallengeCookieStore({ now: clock });
+    store.put(mkCookie({ expiresAt: now - 1, name: 'cf_clearance' }));
+    store.put(mkCookie({ expiresAt: now + 60, name: '__cf_bm', kind: '__cf_bm' }));
+    expect(store.evictExpired()).toBe(1);
+    expect(store.size()).toBe(1);
+  });
+
+  it('snapshot + restore round-trips live cookies and drops expired ones', () => {
+    const src = new ChallengeCookieStore({ now: clock });
+    src.put(mkCookie({ expiresAt: now + 60, name: 'cf_clearance', value: 'live' }));
+    src.put(mkCookie({ expiresAt: now - 60, name: '__cf_bm', kind: '__cf_bm', value: 'stale' }));
+    const snap = src.snapshot();
+    expect(snap.cookies.length).toBe(1);
+
+    const dst = new ChallengeCookieStore({ now: clock });
+    const restored = dst.restore(snap);
+    expect(restored).toBe(1);
+    expect(dst.get('example.com', 'cf_clearance')?.value).toBe('live');
+  });
+
+  it('rejects unknown snapshot versions', () => {
+    const store = new ChallengeCookieStore({ now: clock });
+    // deliberate cast — we're testing the guard
+    const bad = { version: 2, updatedAt: '', cookies: [] } as unknown as ReturnType<
+      ChallengeCookieStore['snapshot']
+    >;
+    expect(() => store.restore(bad)).toThrow(/unsupported/);
+  });
+});


### PR DESCRIPTION
## Status: DRAFT — scope-limited, not ready for merge

### Honest scope assessment

This PR contributes only the **classification + in-memory store** half of `cf_clearance` handling. It does NOT perform the end-to-end retrieval flow that a merged Cloudflare-challenge feature would require:

- Does not navigate to a Cloudflare-challenged URL
- Does not detect challenge-solve completion
- Does not call `Network.getAllCookies` to harvest the issued cookie
- Does not persist to `persistPath` (the option is declared but unused)
- Does not replay via `Network.setCookies` on subsequent sessions
- Not wired into any CDP session lifecycle

### Why this stays draft

Adversarial review (codex) correctly flagged the contribution as a config/store layer masquerading as a retrieval feature. A real implementation needs to integrate with the repo's existing `src/storage-state/storage-state-manager.ts` (which already owns `Network.getAllCookies` / `Network.setCookies` at `src/storage-state/storage-state-manager.ts:108,244` and `src/cdp/client.ts:1139,1517`), plus hook into the challenge-detection path in `src/gates/`. That is a redesign, not a patch — the current module would duplicate storage-state-manager's responsibilities.

### What is here (524 lines)

- `src/captcha/cf-clearance.ts` (310) — `ChallengeCookie` type, `classifyCookieName`, `deriveRegistrableDomain` (heuristic PSL), `ChallengeCookieStore` (put/get/list/evictExpired/snapshot/restore)
- `src/captcha/index.ts` (14) — re-export barrel
- `tests/captcha/cf-clearance.test.ts` (200) — unit coverage of classification, domain derivation, store semantics

Tests pass, `tsc --noEmit` clean. **No integration test, no benchmark.** No 5-site pass rate — the module cannot pass or fail a live challenge because it never touches the network.

### Recommendation

Either (a) close this PR and open a redesigned one that extends `storage-state-manager` with challenge-cookie awareness plus gate-triggered capture, or (b) merge as a scoped "types + store" contribution with a companion follow-up PR doing the actual CDP wiring. Marking draft so reviewers can decide.
