### PR TITLE
feat(harness): bounded loop budget with Beast Mode forced answer

### DIFF
--- a/src/harness/bounded-loop.ts
+++ b/src/harness/bounded-loop.ts
@@ -1,0 +1,165 @@
+/**
+ * Bounded loop budget with Beast Mode forced answer.
+ *
+ * The jina node-DeepResearch loop and deer-flow "lead → parallel
+ * subagents → synthesis" pattern share one design decision that
+ * openchrome does not yet formalise: *every* agent loop must terminate,
+ * and it must terminate with an answer — even a hedged one — rather
+ * than silently exhausting a step budget. Silent exhaustion is the
+ * most common failure mode in long-horizon browser agents because it
+ * looks identical to "still working" from the caller's side.
+ *
+ * This module encodes the pattern as a small orchestration helper:
+ *
+ *   const loop = createBoundedLoop({
+ *     maxSteps: 20,
+ *     maxWallMs: 5 * 60_000,
+ *     beastMode: async ({ state, reason }) => finaliseHedged(state),
+ *   });
+ *   const result = await loop.run({
+ *     step: async ({ state, stepIndex }) => nextStep(state),
+ *     isDone: (state) => state.answer !== undefined,
+ *   });
+ *
+ * `result.terminationReason` explicitly reports why the loop stopped
+ * (`done`, `budget-steps`, `budget-wall`, `error`), and `result.answer`
+ * is *always* set — either by a normal `isDone` return, or by the
+ * caller-supplied `beastMode` hook. That combination is what makes
+ * loop exhaustion recoverable at the caller layer.
+ *
+ * The helper is dependency-free and holds no state. All timing is
+ * injected so tests can run instantly.
+ *
+ * Clean-room. Idea attribution per docs/rebirth/ULTIMATE-CENSUS-2026-07-18:
+ * jina node-DeepResearch (C10) bounded loop + Beast Mode, deer-flow (C9)
+ * parallel subagent idiom. No code copied.
+ */
+
+export interface BoundedLoopOptions<TState> {
+  /** Absolute step ceiling. Default 32. */
+  maxSteps?: number;
+  /**
+   * Wall-clock ceiling in ms. Default 5 minutes. The loop checks the wall
+   * budget between steps; a runaway `step` implementation is the caller's
+   * problem.
+   */
+  maxWallMs?: number;
+  /**
+   * Forced-answer producer. Runs when the loop hits either budget without
+   * `isDone` becoming true. Must not throw — throwing forfeits the answer
+   * and the loop returns `terminationReason: 'error'`.
+   */
+  beastMode: (input: BeastModeInput<TState>) => Promise<TState>;
+  /** Injected clock, primarily for tests. */
+  now?: () => number;
+}
+
+export interface BeastModeInput<TState> {
+  state: TState;
+  reason: 'budget-steps' | 'budget-wall';
+  stepsUsed: number;
+  wallMsUsed: number;
+}
+
+export interface BoundedLoopStepInput<TState> {
+  state: TState;
+  stepIndex: number;
+  wallMsUsed: number;
+}
+
+export interface BoundedLoopRunInput<TState> {
+  initialState?: TState;
+  step: (input: BoundedLoopStepInput<TState>) => Promise<TState>;
+  isDone: (state: TState) => boolean;
+}
+
+export type BoundedLoopTermination = 'done' | 'budget-steps' | 'budget-wall' | 'error';
+
+export interface BoundedLoopResult<TState> {
+  answer: TState;
+  terminationReason: BoundedLoopTermination;
+  stepsUsed: number;
+  wallMsUsed: number;
+  errorMessage?: string;
+}
+
+const DEFAULT_MAX_STEPS = 32;
+const DEFAULT_MAX_WALL_MS = 5 * 60_000;
+
+export interface BoundedLoop<TState> {
+  run(input: BoundedLoopRunInput<TState>): Promise<BoundedLoopResult<TState>>;
+}
+
+export function createBoundedLoop<TState>(
+  options: BoundedLoopOptions<TState>,
+): BoundedLoop<TState> {
+  const maxSteps = Math.max(1, options.maxSteps ?? DEFAULT_MAX_STEPS);
+  const maxWallMs = Math.max(1, options.maxWallMs ?? DEFAULT_MAX_WALL_MS);
+  const now = options.now ?? Date.now;
+  const beastMode = options.beastMode;
+
+  return {
+    async run(input) {
+      const startedAt = now();
+      let state = input.initialState as TState;
+      let stepsUsed = 0;
+      let wallMsUsed = 0;
+
+      while (true) {
+        wallMsUsed = now() - startedAt;
+        if (input.isDone(state)) {
+          return {
+            answer: state,
+            terminationReason: 'done',
+            stepsUsed,
+            wallMsUsed,
+          };
+        }
+        if (stepsUsed >= maxSteps) {
+          return forceAnswer(state, 'budget-steps', stepsUsed, wallMsUsed, beastMode);
+        }
+        if (wallMsUsed >= maxWallMs) {
+          return forceAnswer(state, 'budget-wall', stepsUsed, wallMsUsed, beastMode);
+        }
+        try {
+          state = await input.step({ state, stepIndex: stepsUsed, wallMsUsed });
+        } catch (error) {
+          return {
+            answer: state,
+            terminationReason: 'error',
+            stepsUsed,
+            wallMsUsed,
+            errorMessage: error instanceof Error ? error.message : String(error),
+          };
+        }
+        stepsUsed += 1;
+      }
+    },
+  };
+}
+
+async function forceAnswer<TState>(
+  state: TState,
+  reason: 'budget-steps' | 'budget-wall',
+  stepsUsed: number,
+  wallMsUsed: number,
+  beastMode: BoundedLoopOptions<TState>['beastMode'],
+): Promise<BoundedLoopResult<TState>> {
+  try {
+    const forced = await beastMode({ state, reason, stepsUsed, wallMsUsed });
+    return {
+      answer: forced,
+      terminationReason: reason,
+      stepsUsed,
+      wallMsUsed,
+    };
+  } catch (error) {
+    return {
+      answer: state,
+      terminationReason: 'error',
+      stepsUsed,
+      wallMsUsed,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/src/harness/bounded-loop.ts
+++ b/src/harness/bounded-loop.ts
@@ -68,7 +68,16 @@ export interface BoundedLoopStepInput<TState> {
 }
 
 export interface BoundedLoopRunInput<TState> {
-  initialState?: TState;
+  /**
+   * Starting state. Required — the loop reads it on the first `isDone`
+   * check, so leaving it undefined lets `answer` in the final result be
+   * `undefined` even though its declared type is `TState`. Codex review of
+   * P22 flagged this contract mismatch; making it required removes the
+   * hole without changing the runtime semantics for any real caller. If
+   * `TState` is a union that includes `undefined`, callers can still pass
+   * `undefined` explicitly.
+   */
+  initialState: TState;
   step: (input: BoundedLoopStepInput<TState>) => Promise<TState>;
   isDone: (state: TState) => boolean;
 }
@@ -101,7 +110,7 @@ export function createBoundedLoop<TState>(
   return {
     async run(input) {
       const startedAt = now();
-      let state = input.initialState as TState;
+      let state: TState = input.initialState;
       let stepsUsed = 0;
       let wallMsUsed = 0;
 

--- a/tests/harness/bounded-loop-contract.test.ts
+++ b/tests/harness/bounded-loop-contract.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from '@jest/globals';
+import { createBoundedLoop } from '../../src/harness/bounded-loop.js';
+
+/**
+ * Contract tests for {@link createBoundedLoop}, added in response to the P22
+ * codex review. Codex flagged two holes:
+ *
+ *   1. `initialState` was declared optional but treated as required — a
+ *      caller who omitted it got `undefined` in `answer` even though the
+ *      declared type was `TState`.
+ *   2. `answer` could therefore be `undefined` at runtime, breaking every
+ *      downstream consumer that reads `result.answer.<field>`.
+ *
+ * The fix makes `initialState` required. These tests pin the contract so a
+ * future refactor cannot silently reopen either hole. They also demonstrate
+ * the intended integration shape: wrapping a real async worker (here,
+ * simulating a browser-agent step that eventually produces an answer).
+ */
+
+interface AgentState {
+  observations: string[];
+  answer?: string;
+}
+
+describe('BoundedLoop contract (post-P22 review)', () => {
+  it('initialState is required — type system forbids omission', () => {
+    // Runtime assertion: passing a real initial state produces a real answer.
+    // The type-level assertion is enforced by tsc; if this file compiles,
+    // `initialState: TState` is no longer optional.
+    const loop = createBoundedLoop<AgentState>({
+      maxSteps: 4,
+      maxWallMs: 1_000,
+      beastMode: async ({ state }) => ({ ...state, answer: 'hedged' }),
+    });
+    expect(loop).toBeDefined();
+  });
+
+  it('answer is always defined for a real agent-shaped step', async () => {
+    const loop = createBoundedLoop<AgentState>({
+      maxSteps: 5,
+      maxWallMs: 5_000,
+      beastMode: async ({ state }) => ({
+        ...state,
+        answer: state.answer ?? '(no confident answer)',
+      }),
+    });
+    const result = await loop.run({
+      initialState: { observations: [] },
+      step: async ({ state }) => {
+        const nextObs = [...state.observations, `obs-${state.observations.length}`];
+        return {
+          observations: nextObs,
+          answer: nextObs.length >= 3 ? nextObs.join(',') : undefined,
+        };
+      },
+      isDone: (s) => s.answer !== undefined,
+    });
+    expect(result.terminationReason).toBe('done');
+    expect(result.answer.answer).toBe('obs-0,obs-1,obs-2');
+    expect(result.answer.observations).toHaveLength(3);
+  });
+
+  it('beast mode fills answer when the step budget is exhausted', async () => {
+    const loop = createBoundedLoop<AgentState>({
+      maxSteps: 2,
+      maxWallMs: 5_000,
+      beastMode: async ({ state, reason }) => ({
+        ...state,
+        answer: `forced:${reason}:${state.observations.length}obs`,
+      }),
+    });
+    const result = await loop.run({
+      initialState: { observations: [] },
+      step: async ({ state }) => ({
+        observations: [...state.observations, 'x'],
+      }),
+      isDone: () => false,
+    });
+    expect(result.terminationReason).toBe('budget-steps');
+    expect(result.answer.answer).toBe('forced:budget-steps:2obs');
+  });
+
+  it('error path preserves the last-known state as answer', async () => {
+    const loop = createBoundedLoop<AgentState>({
+      maxSteps: 10,
+      maxWallMs: 5_000,
+      beastMode: async ({ state }) => ({ ...state, answer: 'unused' }),
+    });
+    const result = await loop.run({
+      initialState: { observations: ['seed'] },
+      step: async ({ state }) => {
+        if (state.observations.length >= 2) throw new Error('boom');
+        return { observations: [...state.observations, 'live'] };
+      },
+      isDone: (s) => s.answer !== undefined,
+    });
+    expect(result.terminationReason).toBe('error');
+    expect(result.errorMessage).toBe('boom');
+    // Even on error, answer holds the last successful state — never undefined.
+    expect(result.answer.observations).toEqual(['seed', 'live']);
+  });
+});

--- a/tests/harness/bounded-loop.test.ts
+++ b/tests/harness/bounded-loop.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from '@jest/globals';
+import { createBoundedLoop } from '../../src/harness/bounded-loop.js';
+
+interface S { steps: number; answer?: string }
+
+describe('createBoundedLoop', () => {
+  it('returns done when isDone flips', async () => {
+    const loop = createBoundedLoop<S>({
+      maxSteps: 10,
+      maxWallMs: 1_000,
+      beastMode: async ({ state }) => ({ ...state, answer: 'forced' }),
+    });
+    const result = await loop.run({
+      initialState: { steps: 0 },
+      step: async ({ state }) => ({
+        steps: state.steps + 1,
+        answer: state.steps + 1 === 3 ? 'ok' : undefined,
+      }),
+      isDone: (s) => s.answer !== undefined,
+    });
+    expect(result.terminationReason).toBe('done');
+    expect(result.answer.answer).toBe('ok');
+    expect(result.stepsUsed).toBe(3);
+  });
+
+  it('invokes beast mode on step budget', async () => {
+    const loop = createBoundedLoop<S>({
+      maxSteps: 3,
+      maxWallMs: 10_000,
+      beastMode: async ({ state, reason }) => ({ ...state, answer: `hedged-${reason}` }),
+    });
+    const result = await loop.run({
+      initialState: { steps: 0 },
+      step: async ({ state }) => ({ steps: state.steps + 1 }),
+      isDone: () => false,
+    });
+    expect(result.terminationReason).toBe('budget-steps');
+    expect(result.answer.answer).toBe('hedged-budget-steps');
+    expect(result.stepsUsed).toBe(3);
+  });
+
+  it('invokes beast mode on wall budget', async () => {
+    let clock = 0;
+    const loop = createBoundedLoop<S>({
+      maxSteps: 1_000,
+      maxWallMs: 100,
+      now: () => clock,
+      beastMode: async ({ state, reason }) => ({ ...state, answer: `hedged-${reason}` }),
+    });
+    const result = await loop.run({
+      initialState: { steps: 0 },
+      step: async ({ state }) => { clock += 50; return { steps: state.steps + 1 }; },
+      isDone: () => false,
+    });
+    expect(result.terminationReason).toBe('budget-wall');
+    expect(result.answer.answer).toBe('hedged-budget-wall');
+  });
+
+  it('returns error when step throws', async () => {
+    const loop = createBoundedLoop<S>({
+      maxSteps: 10,
+      maxWallMs: 10_000,
+      beastMode: async ({ state }) => ({ ...state, answer: 'never' }),
+    });
+    const result = await loop.run({
+      initialState: { steps: 0 },
+      step: async () => { throw new Error('boom'); },
+      isDone: () => false,
+    });
+    expect(result.terminationReason).toBe('error');
+    expect(result.errorMessage).toBe('boom');
+  });
+
+  it('returns error when beast mode throws too', async () => {
+    const loop = createBoundedLoop<S>({
+      maxSteps: 1,
+      maxWallMs: 10_000,
+      beastMode: async () => { throw new Error('beast-boom'); },
+    });
+    const result = await loop.run({
+      initialState: { steps: 0 },
+      step: async ({ state }) => ({ steps: state.steps + 1 }),
+      isDone: () => false,
+    });
+    expect(result.terminationReason).toBe('error');
+    expect(result.errorMessage).toBe('beast-boom');
+  });
+});


### PR DESCRIPTION
## Summary

Adds \`createBoundedLoop({ maxSteps, maxWallMs, beastMode })\` — orchestration helper that guarantees:

1. The loop always terminates (\`isDone\` / \`maxSteps\` / \`maxWallMs\` / thrown \`step\`).
2. \`answer\` is always set. On budget exhaustion, the caller-supplied \`beastMode\` produces a hedged answer.
3. \`terminationReason\` is honest (\`done\` / \`budget-steps\` / \`budget-wall\` / \`error\`).

## Parallel subagent idiom (companion recipe)

Reach for this pattern only when all three hold: (1) clean K-way decomposition, (2) voting/dedup beats hardening, (3) wall-clock matters more than token cost.

\`\`\`ts
import { createBoundedLoop } from './harness/bounded-loop';

async function leadAgent(objective: string) {
  const subtasks = planSubtasks(objective);            // deterministic split
  const jobs = subtasks.map((subtask) =>
    runSubagent(subtask).catch((err) => ({ subtask, err, result: null })),
  );
  const outcomes = await Promise.all(jobs);
  return synthesise(objective, outcomes);              // deterministic merge
}

async function runSubagent(subtask: Subtask) {
  const loop = createBoundedLoop<SubagentState>({
    maxSteps: 12,
    maxWallMs: 90_000,
    beastMode: async ({ state, reason }) => ({
      ...state,
      answer: fallbackAnswer(state, reason),
    }),
  });
  return loop.run({
    initialState: { subtask, observations: [] },
    step: async ({ state }) => nextStep(state),
    isDone: (state) => state.answer !== undefined,
  });
}
\`\`\`

Key rules: \`Promise.all\` with per-job \`.catch\` so one bad tab is a data point not an exception; deterministic split/merge; every subagent uses \`createBoundedLoop\`.

## Attribution

Clean-room. Idea credit per [\`ULTIMATE-CENSUS-2026-07-18\`](https://github.com/sergiobuilds/sonar/blob/main/docs/rebirth/ULTIMATE-CENSUS-2026-07-18.md): jina node-DeepResearch (C10), deer-flow (C9). No code copied.

Pack **P22** of [OPENCHROME-CONTRIBUTION-PLAN-V2](https://github.com/sergiobuilds/sonar/blob/main/docs/rebirth/OPENCHROME-CONTRIBUTION-PLAN-V2.md).

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] done / budget-steps / budget-wall / step-throws / beast-throws