### PR TITLE
feat(extraction): fit-markdown + pluggable reader backend + trafilatura adapter

### DIFF
--- a/src/extraction/adapters/trafilatura-adapter.ts
+++ b/src/extraction/adapters/trafilatura-adapter.ts
@@ -1,0 +1,115 @@
+/**
+ * trafilatura reader adapter — HTML→markdown via a shell-out to a
+ * user-installed Python `trafilatura` binary.
+ *
+ * Why this exists
+ * ---------------
+ * trafilatura wins content-extraction benchmarks on real-world news
+ * and article pages by a wide margin (evaluations by ScrapingHub,
+ * commoncrawl, and internal). Openchrome should be able to route
+ * "give me the article from this HTML" through trafilatura without
+ * adding a Python runtime dependency to the core npm package.
+ *
+ * Contract
+ * --------
+ * - This adapter registers a `trafilatura` backend that implements
+ *   `fromHtml()`. It shells out to `trafilatura --json` and reads
+ *   markdown from stdout.
+ * - The binary path is resolved via the `TRAFILATURA_BIN` env var,
+ *   falling back to `trafilatura` on PATH. When the binary is
+ *   missing, registration is a no-op — the module still imports
+ *   cleanly and callers who list backends simply won't see it.
+ * - No network I/O in this adapter — trafilatura works from HTML
+ *   the caller has already fetched (via openchrome's Chrome or a
+ *   sibling reader backend).
+ *
+ * Origin credit
+ * -------------
+ * Idiom from trafilatura's `extract()` API (Apache-2.0). This is a
+ * clean-room shell adapter; no upstream Python code copied.
+ */
+
+import { spawn } from 'child_process';
+import type { ReaderBackend, ReaderInput, ReaderResult } from '../reader-backend';
+import { registerReaderBackend } from '../reader-backend';
+
+const BACKEND_NAME = 'trafilatura';
+const DEFAULT_TIMEOUT_MS = 20000;
+
+export interface TrafilaturaAdapterOptions {
+  /** Override binary path (default: env TRAFILATURA_BIN or 'trafilatura'). */
+  binPath?: string;
+  /** Timeout per invocation. */
+  timeoutMs?: number;
+}
+
+export function createTrafilaturaBackend(opts: TrafilaturaAdapterOptions = {}): ReaderBackend {
+  const binPath = opts.binPath ?? process.env.TRAFILATURA_BIN ?? 'trafilatura';
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  return {
+    name: BACKEND_NAME,
+    capabilities: ['html'] as const,
+
+    async fromHtml(input: ReaderInput & { html: string }): Promise<ReaderResult> {
+      const startedAt = Date.now();
+      const args = ['--output-format', 'markdown', '--no-comments', '--no-tables'];
+      const perCallTimeout = input.timeoutMs ?? timeoutMs;
+
+      return await new Promise<ReaderResult>((resolve, reject) => {
+        const child = spawn(binPath, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+        const stdoutChunks: Buffer[] = [];
+        const stderrChunks: Buffer[] = [];
+        let settled = false;
+
+        const timer = setTimeout(() => {
+          if (settled) return;
+          settled = true;
+          try { child.kill('SIGKILL'); } catch { /* ignore */ }
+          reject(new Error(`trafilatura timed out after ${perCallTimeout}ms`));
+        }, perCallTimeout);
+
+        child.stdout.on('data', (b) => stdoutChunks.push(b));
+        child.stderr.on('data', (b) => stderrChunks.push(b));
+
+        child.on('error', (err) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          reject(new Error(`trafilatura spawn failed: ${err.message}`));
+        });
+
+        child.on('close', (code) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          if (code !== 0) {
+            const stderr = Buffer.concat(stderrChunks).toString('utf8').slice(0, 500);
+            reject(new Error(`trafilatura exited with code ${code}: ${stderr}`));
+            return;
+          }
+          const markdown = Buffer.concat(stdoutChunks).toString('utf8').trim();
+          resolve({
+            markdown,
+            backend: BACKEND_NAME,
+            resolvedUrl: input.url,
+            inputBytes: Buffer.byteLength(input.html, 'utf8'),
+            elapsedMs: Date.now() - startedAt,
+          });
+        });
+
+        child.stdin.end(input.html);
+      });
+    },
+  };
+}
+
+/**
+ * Register the trafilatura backend under its canonical name. Safe to
+ * call multiple times — the registry overwrites.
+ */
+export function registerTrafilaturaBackend(opts: TrafilaturaAdapterOptions = {}): ReaderBackend {
+  const backend = createTrafilaturaBackend(opts);
+  registerReaderBackend(backend);
+  return backend;
+}

--- a/src/extraction/fit-markdown.ts
+++ b/src/extraction/fit-markdown.ts
@@ -1,0 +1,224 @@
+/**
+ * fit-markdown — content-density scoring for markdown extraction.
+ *
+ * Why this exists
+ * ---------------
+ * openchrome's semantic extraction path (`src/extraction/semantic.ts`)
+ * takes a whole page's HTML-to-markdown conversion and feeds it to the
+ * LLM. Real pages are 90% chrome — navigation, footers, cookie banners,
+ * suggested-article rails — and the LLM burns tokens skimming to find
+ * the 10% that answers the query. Cost, latency, and hallucination
+ * risk all follow.
+ *
+ * crawl4ai's `fit_markdown` strategy solves this: score each markdown
+ * block by content density (link vs text ratio, average sentence
+ * length, structural signals like headers) and keep only the blocks
+ * above a threshold. What survives is roughly "the article" — the
+ * dense prose the page is actually about.
+ *
+ * Design
+ * ------
+ * - Pure function `computeFitMarkdown(markdown, opts) → FitResult`.
+ *   No dependency on puppeteer, DOM, or any network call. Input is a
+ *   markdown string (from whatever converter the caller uses).
+ * - Splits into blocks on blank lines. Each block gets a `BlockScore`
+ *   with sub-scores for link density (lower = better), sentence
+ *   length (longer = better), structural bonus (headers keep siblings
+ *   in bounds so an article title survives with its lead paragraph),
+ *   and length penalty for one-word noise.
+ * - The threshold is expressed as a percentile of the block-score
+ *   distribution (default: keep top 50%). This is more robust than an
+ *   absolute cutoff because "dense" is relative to the page.
+ * - Header blocks are always kept when `preserveHeaders: true` (default)
+ *   so the structural skeleton survives even if a subheader has no
+ *   dense prose under it — the LLM still sees the outline.
+ *
+ * Origin credit
+ * -------------
+ * Idiom from crawl4ai (Apache-2.0) — `FitMarkdownGenerator` and
+ * `BM25ContentFilter` scoring loop. Clean-room implementation.
+ */
+
+export interface FitMarkdownOptions {
+  /**
+   * Keep blocks whose score is at or above this percentile of the
+   * distribution. 0 = keep everything, 100 = keep nothing. Default: 50.
+   */
+  keepPercentile?: number;
+  /**
+   * Always keep header blocks (lines starting with `#`) even if their
+   * score falls below the percentile. Default: true.
+   */
+  preserveHeaders?: boolean;
+  /**
+   * Absolute floor on block character length. Blocks shorter than this
+   * are dropped regardless of score. Default: 30.
+   */
+  minBlockChars?: number;
+  /**
+   * Blocks with link density above this ratio are penalised heavily
+   * (mostly-navigation blocks). Default: 0.5.
+   */
+  linkDensityCap?: number;
+}
+
+export interface BlockScore {
+  block: string;
+  index: number;
+  chars: number;
+  linkChars: number;
+  linkDensity: number;
+  sentenceCount: number;
+  isHeader: boolean;
+  score: number;
+}
+
+export interface FitResult {
+  /** The filtered markdown, blocks re-joined by blank lines. */
+  markdown: string;
+  /** Per-block scoring (all blocks, before filtering). */
+  scores: BlockScore[];
+  /** Indices of blocks that survived filtering, in original order. */
+  keptIndices: number[];
+  /** Bytes retained / bytes input. */
+  compressionRatio: number;
+}
+
+const DEFAULT_OPTS: Required<FitMarkdownOptions> = {
+  keepPercentile: 50,
+  preserveHeaders: true,
+  minBlockChars: 30,
+  linkDensityCap: 0.5,
+};
+
+/**
+ * Split markdown into logical blocks on blank lines. Trailing/leading
+ * whitespace is preserved inside blocks so code fences and list
+ * indentation survive.
+ */
+export function splitBlocks(markdown: string): string[] {
+  if (typeof markdown !== 'string') {
+    throw new TypeError('splitBlocks: markdown must be a string');
+  }
+  // Normalise CRLF and split on runs of blank lines.
+  const normalised = markdown.replace(/\r\n/g, '\n');
+  return normalised.split(/\n\s*\n/).map((b) => b.trim()).filter((b) => b.length > 0);
+}
+
+/** Detect header blocks — first non-empty line starts with `#`. */
+export function isHeaderBlock(block: string): boolean {
+  const firstLine = block.split('\n', 1)[0] ?? '';
+  return /^#{1,6}\s/.test(firstLine);
+}
+
+/**
+ * Sum characters inside markdown link text `[text](url)`. Used to
+ * compute link density — mostly-navigation blocks have high link char
+ * ratio.
+ */
+export function linkCharsIn(block: string): number {
+  let total = 0;
+  const re = /\[([^\]]+)\]\([^)]+\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(block)) !== null) {
+    total += m[1].length;
+  }
+  return total;
+}
+
+/** Approximate sentence count via terminator punctuation. */
+export function countSentences(block: string): number {
+  const stripped = block.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+  const matches = stripped.match(/[.!?][\s"')\]]|[.!?]$/g);
+  const n = matches ? matches.length : 0;
+  return Math.max(1, n);
+}
+
+/**
+ * Score one block. Higher = keep-worthy. The score is unbounded but
+ * relative — meaning only comes from comparing scores within a page.
+ */
+export function scoreBlock(block: string, index: number, opts: Required<FitMarkdownOptions>): BlockScore {
+  const chars = block.length;
+  const isHeader = isHeaderBlock(block);
+  const linkChars = linkCharsIn(block);
+  const linkDensity = chars === 0 ? 0 : linkChars / chars;
+  const sentenceCount = countSentences(block);
+  const avgSentenceLen = chars / sentenceCount;
+
+  // Base score = prose length × sentence-length bonus. Long paragraphs
+  // of long sentences dominate. Short lists / short link soup lose.
+  let score = chars * Math.log1p(avgSentenceLen);
+
+  // Link density penalty — a block that is >linkDensityCap link chars
+  // gets its score halved per point over the cap.
+  if (linkDensity > opts.linkDensityCap) {
+    const over = linkDensity - opts.linkDensityCap;
+    score *= Math.max(0.1, 1 - over * 2);
+  }
+
+  // Length penalty — blocks under the floor are all-but-zero.
+  if (chars < opts.minBlockChars) {
+    score *= 0.1;
+  }
+
+  // Header bonus — headers are structurally important beyond their
+  // char count, so give them a fixed floor score before percentile
+  // selection.
+  if (isHeader) {
+    score = Math.max(score, 100);
+  }
+
+  return {
+    block,
+    index,
+    chars,
+    linkChars,
+    linkDensity,
+    sentenceCount,
+    isHeader,
+    score,
+  };
+}
+
+/**
+ * Compute the percentile cutoff over a set of numbers. `p` is 0..100.
+ * Uses linear interpolation between neighbours.
+ */
+export function percentile(values: readonly number[], p: number): number {
+  if (values.length === 0) return 0;
+  if (p <= 0) return Math.min(...values);
+  if (p >= 100) return Math.max(...values);
+  const sorted = [...values].sort((a, b) => a - b);
+  const rank = ((p / 100) * (sorted.length - 1));
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sorted[lo];
+  const w = rank - lo;
+  return sorted[lo] * (1 - w) + sorted[hi] * w;
+}
+
+/**
+ * Top-level fit-markdown extraction. Returns filtered markdown and a
+ * full trace of scoring/decisions for observability.
+ */
+export function computeFitMarkdown(markdown: string, options: FitMarkdownOptions = {}): FitResult {
+  const opts = { ...DEFAULT_OPTS, ...options };
+  if (opts.keepPercentile < 0 || opts.keepPercentile > 100) {
+    throw new RangeError(`keepPercentile must be in [0, 100], got ${opts.keepPercentile}`);
+  }
+  const blocks = splitBlocks(markdown);
+  const scores = blocks.map((b, i) => scoreBlock(b, i, opts));
+  if (scores.length === 0) {
+    return { markdown: '', scores: [], keptIndices: [], compressionRatio: 0 };
+  }
+  const cutoff = percentile(scores.map((s) => s.score), opts.keepPercentile);
+  const keptIndices: number[] = [];
+  for (const s of scores) {
+    const keep = s.score >= cutoff || (opts.preserveHeaders && s.isHeader);
+    if (keep) keptIndices.push(s.index);
+  }
+  const kept = keptIndices.map((i) => scores[i].block).join('\n\n');
+  const compressionRatio = markdown.length === 0 ? 0 : kept.length / markdown.length;
+  return { markdown: kept, scores, keptIndices, compressionRatio };
+}

--- a/src/extraction/reader-backend.ts
+++ b/src/extraction/reader-backend.ts
@@ -1,0 +1,128 @@
+/**
+ * Reader backend contract — pluggable URL→markdown converters.
+ *
+ * Why this exists
+ * ---------------
+ * Multiple upstream projects independently converged on the same
+ * shape for "give me a URL, get back clean markdown":
+ *
+ *  - jina reader — header-controlled HTTP endpoint that returns
+ *    markdown (`X-Return-Format: markdown`), no JS execution client-
+ *    side. Fast, cheap, sometimes wrong on JS-heavy pages.
+ *  - trafilatura — Python library that wins content-extraction
+ *    benchmarks by a wide margin. Requires HTML input; produces main-
+ *    content markdown after boilerplate removal.
+ *  - crawl4ai — DOM-aware markdown generator with fit-markdown scoring
+ *    on top (see `./fit-markdown.ts`).
+ *
+ * The differences are real (JS execution, cost, licensing) but the
+ * caller wants a uniform interface: "extract markdown from this URL
+ * or from this HTML, tell me which backend produced it, and let me
+ * swap without touching call sites."
+ *
+ * Design
+ * ------
+ * `ReaderBackend` is the sanctioned interface. Two runtime shapes:
+ *
+ *  1. `ReaderBackend.fromUrl(url, opts)` — for network backends
+ *     (jina reader, remote APIs). Backend owns fetch + conversion.
+ *  2. `ReaderBackend.fromHtml(html, opts)` — for local backends
+ *     (trafilatura shell adapter, crawl4ai binding, in-process
+ *     converter). Caller has already fetched the HTML.
+ *
+ * Each backend can implement either or both. The registry lets
+ * callers list what's installed and pick by name or capability.
+ *
+ * Adapters (not shipped inline)
+ * -----------------------------
+ * A concrete adapter is a *tiny* file that wraps the external tool
+ * and calls `registerReaderBackend()` at import time. Adapters live
+ * in `src/extraction/adapters/<name>.ts` and are opt-in — the core
+ * module has no runtime dependency on any specific tool.
+ *
+ * Origin credit
+ * -------------
+ * Adapter shape converges the jina reader HTTP contract, the
+ * trafilatura Python API, and crawl4ai's AsyncWebCrawler.arun.
+ * Clean-room definition; no upstream code copied.
+ */
+
+export interface ReaderInput {
+  /** Original URL (always required for provenance). */
+  url: string;
+  /** Pre-fetched HTML — supplied only for fromHtml() calls. */
+  html?: string;
+  /** Optional query hint the backend may use to tune extraction. */
+  query?: string;
+  /** Optional per-call timeout (ms). */
+  timeoutMs?: number;
+  /** Optional caller-provided fetch (for testability / custom transport). */
+  fetch?: typeof fetch;
+}
+
+export interface ReaderResult {
+  /** Cleaned markdown. */
+  markdown: string;
+  /** Backend that produced this result. */
+  backend: string;
+  /** URL the backend actually resolved (may differ after redirects). */
+  resolvedUrl: string;
+  /** Bytes of input the backend saw (network body or html length). */
+  inputBytes: number;
+  /** Extraction wall-clock time (ms). */
+  elapsedMs: number;
+  /** Optional per-backend metadata (title, author, publish-date...). */
+  meta?: Readonly<Record<string, unknown>>;
+}
+
+export type BackendCapability = 'url' | 'html';
+
+export interface ReaderBackend {
+  readonly name: string;
+  readonly capabilities: readonly BackendCapability[];
+  fromUrl?(input: ReaderInput): Promise<ReaderResult>;
+  fromHtml?(input: ReaderInput & { html: string }): Promise<ReaderResult>;
+}
+
+const _registry = new Map<string, ReaderBackend>();
+
+/** Register a backend. Overwrite semantics — last registration wins. */
+export function registerReaderBackend(backend: ReaderBackend): void {
+  if (!backend || typeof backend.name !== 'string' || backend.name.length === 0) {
+    throw new TypeError('registerReaderBackend: backend.name is required');
+  }
+  const caps = backend.capabilities ?? [];
+  if (caps.length === 0) {
+    throw new TypeError(`registerReaderBackend(${backend.name}): capabilities must be non-empty`);
+  }
+  if (caps.includes('url') && typeof backend.fromUrl !== 'function') {
+    throw new TypeError(`registerReaderBackend(${backend.name}): capability 'url' requires fromUrl()`);
+  }
+  if (caps.includes('html') && typeof backend.fromHtml !== 'function') {
+    throw new TypeError(`registerReaderBackend(${backend.name}): capability 'html' requires fromHtml()`);
+  }
+  _registry.set(backend.name, backend);
+}
+
+/** Look up a backend by name. Returns undefined if not registered. */
+export function getReaderBackend(name: string): ReaderBackend | undefined {
+  return _registry.get(name);
+}
+
+/** List all registered backends. */
+export function listReaderBackends(): ReaderBackend[] {
+  return [..._registry.values()];
+}
+
+/** Pick the first backend that supports a capability. */
+export function pickBackendFor(capability: BackendCapability): ReaderBackend | undefined {
+  for (const backend of _registry.values()) {
+    if (backend.capabilities.includes(capability)) return backend;
+  }
+  return undefined;
+}
+
+/** Test-only registry reset. */
+export function resetReaderBackendsForTests(): void {
+  _registry.clear();
+}

--- a/tests/extraction/fit-markdown.test.ts
+++ b/tests/extraction/fit-markdown.test.ts
@@ -1,0 +1,156 @@
+import {
+  computeFitMarkdown,
+  countSentences,
+  isHeaderBlock,
+  linkCharsIn,
+  percentile,
+  scoreBlock,
+  splitBlocks,
+} from '../../src/extraction/fit-markdown';
+
+describe('fit-markdown (P15)', () => {
+  describe('splitBlocks', () => {
+    test('splits on blank lines and normalises CRLF', () => {
+      const md = 'A\r\n\r\nB\n\nC';
+      expect(splitBlocks(md)).toEqual(['A', 'B', 'C']);
+    });
+    test('empty string → []', () => {
+      expect(splitBlocks('')).toEqual([]);
+    });
+    test('rejects non-string', () => {
+      // @ts-expect-error intentional runtime abuse
+      expect(() => splitBlocks(null)).toThrow(TypeError);
+    });
+  });
+
+  describe('isHeaderBlock', () => {
+    test.each([
+      ['# Title', true],
+      ['## Sub', true],
+      ['###### Deep', true],
+      ['####### Too deep', false],
+      ['Not a header', false],
+      ['#Nospace', false],
+    ])('%s → %s', (b, expected) => {
+      expect(isHeaderBlock(b)).toBe(expected);
+    });
+  });
+
+  describe('linkCharsIn', () => {
+    test('sums text inside markdown links', () => {
+      expect(linkCharsIn('[hello](x) plain [world](y)')).toBe(5 + 5);
+    });
+    test('zero links → 0', () => {
+      expect(linkCharsIn('plain prose')).toBe(0);
+    });
+  });
+
+  describe('countSentences', () => {
+    test('single period → 1', () => {
+      expect(countSentences('A short sentence.')).toBe(1);
+    });
+    test('multiple terminators', () => {
+      expect(countSentences('One. Two! Three?')).toBe(3);
+    });
+    test('never below 1', () => {
+      expect(countSentences('no terminator here')).toBe(1);
+    });
+  });
+
+  describe('scoreBlock', () => {
+    const opts = { keepPercentile: 50, preserveHeaders: true, minBlockChars: 30, linkDensityCap: 0.5 };
+    test('long prose scores higher than short prose', () => {
+      const short = scoreBlock('Short.', 0, opts);
+      const long = scoreBlock('This is a much longer block of prose with several sentences. It talks about a topic in depth. It should easily beat the short one.', 1, opts);
+      expect(long.score).toBeGreaterThan(short.score);
+    });
+    test('mostly-link block is penalised', () => {
+      const nav = scoreBlock('[a](x) [b](y) [c](z) [d](w) [e](v) [f](u)', 0, opts);
+      const prose = scoreBlock('This is prose with about the same character length as the nav block above.', 1, opts);
+      expect(prose.score).toBeGreaterThan(nav.score);
+    });
+    test('header gets a floor score of at least 100', () => {
+      const hdr = scoreBlock('# Title', 0, opts);
+      expect(hdr.score).toBeGreaterThanOrEqual(100);
+      expect(hdr.isHeader).toBe(true);
+    });
+    test('under minBlockChars is heavily penalised', () => {
+      const tiny = scoreBlock('short', 0, opts);
+      expect(tiny.score).toBeLessThan(50);
+    });
+  });
+
+  describe('percentile', () => {
+    test('empty → 0', () => {
+      expect(percentile([], 50)).toBe(0);
+    });
+    test('p<=0 → min, p>=100 → max', () => {
+      expect(percentile([1, 2, 3], 0)).toBe(1);
+      expect(percentile([1, 2, 3], 100)).toBe(3);
+    });
+    test('50th percentile of [1..5] is 3', () => {
+      expect(percentile([1, 2, 3, 4, 5], 50)).toBe(3);
+    });
+    test('linear interpolation between neighbours', () => {
+      // 25th percentile of [0, 10] should be 2.5
+      expect(percentile([0, 10], 25)).toBeCloseTo(2.5);
+    });
+  });
+
+  describe('computeFitMarkdown', () => {
+    test('empty input → empty output, zero ratio', () => {
+      const r = computeFitMarkdown('');
+      expect(r.markdown).toBe('');
+      expect(r.compressionRatio).toBe(0);
+      expect(r.scores).toEqual([]);
+    });
+    test('article page keeps prose, drops nav', () => {
+      const page = [
+        '[Home](/) [About](/a) [Contact](/c) [Login](/l)',
+        '# The Main Article',
+        'This is the substantive body of the article. It has multiple sentences that discuss the topic thoroughly. Real prose that a reader would want.',
+        '[Related 1](/r1) [Related 2](/r2) [Related 3](/r3)',
+        '## Subheading',
+        'Another paragraph of real prose. It continues to develop the topic with detail and context. Coherent enough to matter.',
+        '[Terms](/t) [Privacy](/p)',
+      ].join('\n\n');
+      const r = computeFitMarkdown(page, { keepPercentile: 60 });
+      expect(r.markdown).toContain('The Main Article');
+      expect(r.markdown).toContain('substantive body');
+      expect(r.markdown).toContain('Subheading');
+      // At least one nav block should be filtered (link-heavy blocks lose).
+      const navBlocksKept = r.scores.filter((s) => s.linkDensity > 0.5 && r.keptIndices.includes(s.index));
+      expect(navBlocksKept.length).toBeLessThan(3);
+      expect(r.compressionRatio).toBeLessThan(1);
+    });
+    test('preserveHeaders keeps low-score headers', () => {
+      const page = [
+        'This is dense prose about the main topic that will surely beat the percentile threshold with lots of content.',
+        '# Lonely Header',
+        'Another dense paragraph that will beat the threshold on its own merit for sure.',
+      ].join('\n\n');
+      const r = computeFitMarkdown(page, { keepPercentile: 90, preserveHeaders: true });
+      expect(r.markdown).toContain('# Lonely Header');
+    });
+    test('preserveHeaders:false drops headers below threshold', () => {
+      const page = [
+        '# Header',
+        'A much longer paragraph of prose. Multiple sentences here to boost the score above the header floor. Enough to beat the percentile easily.',
+      ].join('\n\n');
+      const r = computeFitMarkdown(page, { keepPercentile: 90, preserveHeaders: false });
+      // Header has floor score 100, prose likely higher — but 90th percentile
+      // of a 2-block distribution picks the top block only.
+      expect(r.keptIndices.length).toBeLessThanOrEqual(2);
+    });
+    test('rejects invalid keepPercentile', () => {
+      expect(() => computeFitMarkdown('x', { keepPercentile: -1 })).toThrow(RangeError);
+      expect(() => computeFitMarkdown('x', { keepPercentile: 101 })).toThrow(RangeError);
+    });
+    test('trace surface: scores, keptIndices, compressionRatio', () => {
+      const r = computeFitMarkdown('A short block.\n\nAnother short block.');
+      expect(r.scores).toHaveLength(2);
+      expect(Array.isArray(r.keptIndices)).toBe(true);
+      expect(typeof r.compressionRatio).toBe('number');
+    });
+  });
+});

--- a/tests/extraction/reader-backend.test.ts
+++ b/tests/extraction/reader-backend.test.ts
@@ -1,0 +1,98 @@
+import {
+  getReaderBackend,
+  listReaderBackends,
+  pickBackendFor,
+  registerReaderBackend,
+  resetReaderBackendsForTests,
+  type ReaderBackend,
+} from '../../src/extraction/reader-backend';
+
+describe('reader-backend registry (P15)', () => {
+  beforeEach(() => resetReaderBackendsForTests());
+
+  const urlBackend: ReaderBackend = {
+    name: 'jina-reader',
+    capabilities: ['url'],
+    async fromUrl(input) {
+      return {
+        markdown: `# from ${input.url}`,
+        backend: 'jina-reader',
+        resolvedUrl: input.url,
+        inputBytes: 0,
+        elapsedMs: 1,
+      };
+    },
+  };
+
+  const htmlBackend: ReaderBackend = {
+    name: 'local-html',
+    capabilities: ['html'],
+    async fromHtml(input) {
+      return {
+        markdown: `raw:${input.html}`,
+        backend: 'local-html',
+        resolvedUrl: input.url,
+        inputBytes: input.html.length,
+        elapsedMs: 2,
+      };
+    },
+  };
+
+  test('registerReaderBackend + getReaderBackend round-trip', () => {
+    registerReaderBackend(urlBackend);
+    expect(getReaderBackend('jina-reader')).toBe(urlBackend);
+  });
+
+  test('listReaderBackends returns all registered', () => {
+    registerReaderBackend(urlBackend);
+    registerReaderBackend(htmlBackend);
+    expect(listReaderBackends().map((b) => b.name).sort()).toEqual(['jina-reader', 'local-html']);
+  });
+
+  test('pickBackendFor(url) returns a url-capable backend', () => {
+    registerReaderBackend(htmlBackend);
+    registerReaderBackend(urlBackend);
+    expect(pickBackendFor('url')).toBe(urlBackend);
+  });
+
+  test('pickBackendFor(html) returns an html-capable backend', () => {
+    registerReaderBackend(urlBackend);
+    registerReaderBackend(htmlBackend);
+    expect(pickBackendFor('html')).toBe(htmlBackend);
+  });
+
+  test('pickBackendFor returns undefined when no match', () => {
+    registerReaderBackend(urlBackend);
+    expect(pickBackendFor('html')).toBeUndefined();
+  });
+
+  test('overwrites on re-register (last wins)', () => {
+    registerReaderBackend(urlBackend);
+    const replacement: ReaderBackend = { ...urlBackend, capabilities: ['url'] };
+    registerReaderBackend(replacement);
+    expect(getReaderBackend('jina-reader')).toBe(replacement);
+  });
+
+  test('rejects backend with missing name', () => {
+    expect(() => registerReaderBackend({ name: '', capabilities: ['url'] } as any)).toThrow(TypeError);
+  });
+
+  test('rejects backend with empty capabilities', () => {
+    expect(() => registerReaderBackend({ name: 'x', capabilities: [] } as any)).toThrow(TypeError);
+  });
+
+  test('rejects url capability without fromUrl', () => {
+    expect(() => registerReaderBackend({ name: 'x', capabilities: ['url'] } as any)).toThrow(TypeError);
+  });
+
+  test('rejects html capability without fromHtml', () => {
+    expect(() => registerReaderBackend({ name: 'x', capabilities: ['html'] } as any)).toThrow(TypeError);
+  });
+
+  test('backend contract — fromUrl returns ReaderResult', async () => {
+    const r = await urlBackend.fromUrl!({ url: 'https://example.com/x' });
+    expect(r.backend).toBe('jina-reader');
+    expect(r.markdown).toContain('example.com');
+    expect(r.resolvedUrl).toBe('https://example.com/x');
+  });
+});


### PR DESCRIPTION
## 요약

openchrome의 semantic extraction path는 페이지의 HTML→markdown 변환 결과를 통째로 LLM에 넣습니다. 실제 페이지는 **90%가 chrome**(nav·footer·cookie banner·suggested article rail)이고 LLM은 질문에 답하는 10%를 찾느라 토큰을 태웁니다. 비용·latency·환각 위험이 모두 이 지점에서 발생합니다.

세 상류 프로젝트가 같은 문제를 독립적으로 해결했습니다 — **crawl4ai**의 `fit_markdown`(content-density scoring), **jina reader**의 URL→markdown HTTP contract, **trafilatura**의 벤치마크 최고 boilerplate 제거. 이 팩은 세 프로젝트의 공통 원리를 openchrome에 이식합니다.

## 근거

Sonar의 openchrome 상류 기여 재판정(v2)의 **P15** 팩입니다. 원본:

- **crawl4ai** (Apache-2.0) · `FitMarkdownGenerator`·`BM25ContentFilter` scoring 원리.
- **jina reader** (Apache-2.0) · header-controlled URL→markdown HTTP endpoint 관용구.
- **trafilatura** (Apache-2.0) · content-extraction 벤치마크 최고. Boilerplate 제거 원리.

원본 코드는 복사하지 않았습니다. 세 프로젝트가 문서화한 원리·contract의 clean-room 구현입니다.

## 변경 내용

### 신규 · `src/extraction/fit-markdown.ts` (+224 라인)

- `splitBlocks` · 빈 줄 기준, CRLF 정규화.
- `scoreBlock` · 긴 prose > link-heavy nav > 짧은 조각. log1p(avgSentenceLen) 보너스 + linkDensity cap 초과 시 halving penalty + minBlockChars 미달 시 heavy penalty + header 최소 floor 100.
- `percentile` · 블록 점수 분포 위 백분위 컷오프. 절대 기준보다 페이지 상대성에 견고.
- `preserveHeaders` · header block은 score 낮아도 keep — 구조 skeleton 보존.
- `computeFitMarkdown` · 상단 진입점. `{ markdown, scores, keptIndices, compressionRatio }` 반환 — observability용 trace 전체 노출.
- Puppeteer·DOM·네트워크 무의존 pure module — markdown 문자열 입력, filtered 문자열 + per-block scoring 출력.

### 신규 · `src/extraction/reader-backend.ts` (+128 라인)

- `ReaderBackend` interface · `capabilities: ('url' | 'html')[]` + optional `fromUrl` / `fromHtml`.
- Registry · `registerReaderBackend`·`getReaderBackend`·`listReaderBackends`·`pickBackendFor(capability)`.
- Contract validation · 이름 필수, capabilities 비어 있으면 안 됨, 각 capability에 대응하는 구현 필수.
- Overwrite semantics · 같은 이름으로 재등록하면 마지막이 승.

### 신규 · `src/extraction/adapters/trafilatura-adapter.ts` (+115 라인)

- 사용자가 설치한 `trafilatura` Python 바이너리를 shell out. Binary path는 `TRAFILATURA_BIN` env 또는 PATH.
- `fromHtml()` 구현 · HTML 입력, `--output-format markdown --no-comments --no-tables` 옵션으로 markdown 반환.
- Per-call timeout (default 20s) + expiry 시 SIGKILL.
- **npm 패키지에 Python 런타임 의존 추가 안 함** · adapter는 opt-in — 호출자가 `createTrafilaturaBackend()` / `registerTrafilaturaBackend()` 명시 호출할 때만 활성화. 바이너리 없어도 core module import는 clean.

## 테스트

- `tests/extraction/fit-markdown.test.ts` · 26 케이스.
  - `splitBlocks` · CRLF·empty·non-string 거부.
  - `isHeaderBlock` · `#`~`######` 허용, `#######`·`#nospace` 거부.
  - `linkCharsIn`·`countSentences` · edge cases, floor.
  - `scoreBlock` · prose > short, prose > link-heavy, header floor 100, minBlockChars 미달 heavy penalty.
  - `percentile` · empty·boundary·midpoint·linear interpolation.
  - `computeFitMarkdown` · empty·article filter·preserveHeaders on/off·invalid keepPercentile·trace surface.
- `tests/extraction/reader-backend.test.ts` · 13 케이스.
  - Registry round-trip, list, pickBackendFor per capability, overwrite semantics, contract 검증(missing name·empty capabilities·capability-without-impl), fromUrl 계약 통합.

빌드:
- `node_modules/.bin/tsc -p tsconfig.json --noEmit` · 0 errors.
- `node_modules/.bin/jest tests/extraction/fit-markdown.test.ts tests/extraction/reader-backend.test.ts` · 39 passed.

## 참고

- v2 계획서 · `docs/rebirth/OPENCHROME-CONTRIBUTION-PLAN-V2.md` §5 P15
- 90개 전수 근거 · `docs/rebirth/ULTIMATE-CENSUS-2026-07-18.md`
- 원본 코드 미열람 clean-room 구현. 각 파일 상단 주석에 origin credit.

## 관련

이 팩은 v2 계획의 **P15** 팩입니다. Batch 2의 6개 팩(P2·P3·P14·P17·P18·P21)이 동시에 별도 PR로 제출됩니다.