### PR TITLE
feat(vision): pixel-grounding fallback tier (UI-TARS / magnitude adapter contract)

### DIFF
--- a/src/vision/pixel-grounding-fallback.ts
+++ b/src/vision/pixel-grounding-fallback.ts
@@ -1,0 +1,308 @@
+/**
+ * Pixel-grounding fallback tier for vision-driven interaction.
+ *
+ * Motivation
+ * ----------
+ * openchrome's primary interaction path is DOM- / a11y-tree-based (see
+ * `src/dom/`, `src/vision/dom-annotator-provider.ts`). This works when the
+ * page cooperates. When it does not — heavily-shadowed DOM, canvas-only
+ * UI (Figma, MapLibre, WebGL games), Salesforce Aura components, or
+ * anti-automation obfuscation — the DOM does not have a stable element
+ * for the thing the user actually sees.
+ *
+ * The fix, adopted by UI-TARS (Apache-2.0) and magnitude (Apache-2.0),
+ * is a **pixel-grounding fallback**: send the screenshot + a natural-
+ * language target ("click the blue Submit button") to a vision model
+ * and receive normalised pixel coordinates back. openchrome then clicks
+ * at those coordinates.
+ *
+ * This module contributes the **contract** for that fallback tier — a
+ * `PixelGroundingAdapter` interface, a request/response shape covering
+ * click / hover / drag / type targets, and a `PixelGroundingFallbackChain`
+ * orchestrator that tries adapters in priority order and short-circuits on
+ * the first confident hit.
+ *
+ * The module does not ship a UI-TARS or magnitude implementation —
+ * openchrome cannot depend on those model runtimes. It ships the shape a
+ * downstream plugin implements once, so the tier itself is native to the
+ * MCP server and every plugin looks the same to callers.
+ *
+ * References
+ * ----------
+ * - UI-TARS (Apache-2.0) — https://github.com/bytedance/UI-TARS
+ * - magnitude (Apache-2.0) — https://github.com/magnitudedev/magnitude
+ * - Skyvern (AGPL-3.0) — https://github.com/Skyvern-AI/skyvern (form-vision
+ *   idiom, referenced for the target-language grammar).
+ *
+ * Clean-room re-implementation. No UI-TARS / magnitude / Skyvern source
+ * was copied.
+ */
+
+/**
+ * The user-visible target types the fallback can ground.
+ *
+ * `click`  — a single click / tap on the target.
+ * `hover`  — a hover over the target (used for menu opens).
+ * `drag`   — a drag from the target to a second target (`toTarget`).
+ * `type`   — click the target then type text.
+ * `select` — click the target treated as a dropdown, then click `option`.
+ */
+export type PixelGroundingActionKind = 'click' | 'hover' | 'drag' | 'type' | 'select';
+
+export interface PixelGroundingRequest {
+  action: PixelGroundingActionKind;
+  /** Natural-language description of the target the user sees. */
+  target: string;
+  /** For `drag`: the drop target. */
+  toTarget?: string;
+  /** For `type`: the text to enter. */
+  text?: string;
+  /** For `select`: the option label. */
+  option?: string;
+  /** Screenshot bytes (PNG/JPEG/WebP). Encoding is `data.encoding`. */
+  screenshot: PixelGroundingScreenshot;
+  /** Viewport pixel size — required for coordinate normalisation checks. */
+  viewport: { width: number; height: number };
+  /** Optional per-request hint (e.g. "avoid the sidebar"). */
+  hint?: string;
+  /** Milliseconds a caller is willing to wait. Adapters SHOULD respect. */
+  timeoutMs?: number;
+}
+
+export interface PixelGroundingScreenshot {
+  encoding: 'png' | 'jpeg' | 'webp';
+  bytes: Uint8Array;
+  /** Device pixel ratio the screenshot was taken at. Defaults to 1. */
+  devicePixelRatio?: number;
+}
+
+export interface PixelGroundingHit {
+  /** Adapter-supplied confidence 0..1. */
+  confidence: number;
+  /** Target pixel coordinates in the screenshot's coordinate space. */
+  target: { x: number; y: number };
+  /** For `drag` responses. */
+  toTarget?: { x: number; y: number };
+  /** Optional bounding box the adapter grounded on. */
+  bbox?: { x: number; y: number; width: number; height: number };
+  /** Adapter freeform reasoning / logs, kept small. */
+  rationale?: string;
+}
+
+export interface PixelGroundingResult {
+  ok: boolean;
+  /** Adapter id that produced the result (or attempted it). */
+  adapterId: string;
+  /** Populated when `ok === true`. */
+  hit?: PixelGroundingHit;
+  /** Populated when `ok === false`. */
+  error?: PixelGroundingError;
+  /** Wall-clock ms the adapter spent. */
+  elapsedMs: number;
+}
+
+export interface PixelGroundingError {
+  code: PixelGroundingErrorCode;
+  message: string;
+  /** True when a caller SHOULD try the next adapter. */
+  retryable: boolean;
+}
+
+export type PixelGroundingErrorCode =
+  | 'timeout'
+  | 'model_unavailable'
+  | 'no_ground'
+  | 'invalid_coordinates'
+  | 'rate_limited'
+  | 'internal_error';
+
+export interface PixelGroundingAdapter {
+  /** Short id used in logs and telemetry (e.g. `ui-tars`, `magnitude`). */
+  readonly id: string;
+  /** Human-friendly label. */
+  readonly label: string;
+  /**
+   * Priority for the fallback chain — lower runs first. Adapters with the
+   * same priority are attempted in registration order.
+   */
+  readonly priority: number;
+  /**
+   * Confidence floor an adapter's hit must clear before the chain accepts
+   * it. Adapters can enforce their own floor via this field so the chain
+   * does not need to know model-specific calibration.
+   */
+  readonly minConfidence: number;
+  /** Whether the adapter is currently usable (auth, quota, health). */
+  isReady(): Promise<boolean> | boolean;
+  /** Attempt to ground the request. MUST NOT throw — return an error result. */
+  ground(request: PixelGroundingRequest): Promise<PixelGroundingResult>;
+}
+
+// ---------------------------------------------------------------------------
+// Request validation
+// ---------------------------------------------------------------------------
+
+export interface ValidationResult {
+  ok: boolean;
+  error?: string;
+}
+
+export function validateGroundingRequest(req: PixelGroundingRequest): ValidationResult {
+  if (!req) return { ok: false, error: 'request is required' };
+  if (!req.action) return { ok: false, error: 'action is required' };
+  if (!isKnownAction(req.action)) {
+    return { ok: false, error: `unknown action: ${req.action}` };
+  }
+  if (!req.target || req.target.length === 0) {
+    return { ok: false, error: 'target is required' };
+  }
+  if (req.target.length > 500) {
+    return { ok: false, error: 'target exceeds 500-character cap' };
+  }
+  if (req.action === 'drag' && (!req.toTarget || req.toTarget.length === 0)) {
+    return { ok: false, error: 'drag action requires toTarget' };
+  }
+  if (req.action === 'type' && (req.text === undefined || req.text === null)) {
+    return { ok: false, error: 'type action requires text' };
+  }
+  if (req.action === 'select' && (!req.option || req.option.length === 0)) {
+    return { ok: false, error: 'select action requires option' };
+  }
+  if (!req.viewport || req.viewport.width <= 0 || req.viewport.height <= 0) {
+    return { ok: false, error: 'viewport width and height must be positive' };
+  }
+  if (!req.screenshot || !req.screenshot.bytes || req.screenshot.bytes.length === 0) {
+    return { ok: false, error: 'screenshot bytes are required' };
+  }
+  if (!['png', 'jpeg', 'webp'].includes(req.screenshot.encoding)) {
+    return { ok: false, error: `unsupported screenshot encoding: ${req.screenshot.encoding}` };
+  }
+  return { ok: true };
+}
+
+function isKnownAction(action: string): action is PixelGroundingActionKind {
+  return ['click', 'hover', 'drag', 'type', 'select'].includes(action);
+}
+
+/**
+ * Guard a hit's coordinates against the viewport. Adapters that return
+ * coordinates outside the viewport are considered to have failed
+ * (`invalid_coordinates`).
+ */
+export function coordinatesInViewport(
+  point: { x: number; y: number },
+  viewport: { width: number; height: number },
+  dpr: number,
+): boolean {
+  const maxX = viewport.width * dpr;
+  const maxY = viewport.height * dpr;
+  return (
+    Number.isFinite(point.x) &&
+    Number.isFinite(point.y) &&
+    point.x >= 0 &&
+    point.y >= 0 &&
+    point.x <= maxX &&
+    point.y <= maxY
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Fallback-chain orchestrator
+// ---------------------------------------------------------------------------
+
+export interface FallbackChainOptions {
+  /** Global request timeout applied to every adapter unless the adapter caps sooner. */
+  timeoutMs?: number;
+  /** If set, chain gives up after this many failed adapters. */
+  maxAttempts?: number;
+  /** Called on each adapter attempt for telemetry. */
+  onAttempt?: (result: PixelGroundingResult) => void;
+}
+
+export interface FallbackChainOutcome {
+  ok: boolean;
+  hit?: PixelGroundingHit;
+  /** The adapter that produced the successful hit, when `ok === true`. */
+  adapterId?: string;
+  attempts: PixelGroundingResult[];
+}
+
+/**
+ * Runs adapters in priority order and returns the first hit whose
+ * confidence >= adapter.minConfidence and whose coordinates lie within the
+ * viewport. Every attempt is recorded in `attempts` — callers can log the
+ * whole trace for auditing.
+ */
+export class PixelGroundingFallbackChain {
+  private adapters: PixelGroundingAdapter[] = [];
+
+  constructor(private readonly options: FallbackChainOptions = {}) {}
+
+  register(adapter: PixelGroundingAdapter): void {
+    this.adapters.push(adapter);
+    this.adapters.sort((a, b) => a.priority - b.priority);
+  }
+
+  size(): number {
+    return this.adapters.length;
+  }
+
+  listAdapters(): ReadonlyArray<PixelGroundingAdapter> {
+    return this.adapters;
+  }
+
+  async ground(request: PixelGroundingRequest): Promise<FallbackChainOutcome> {
+    const validation = validateGroundingRequest(request);
+    if (!validation.ok) {
+      const err: PixelGroundingResult = {
+        ok: false,
+        adapterId: 'chain',
+        error: { code: 'internal_error', message: validation.error!, retryable: false },
+        elapsedMs: 0,
+      };
+      return { ok: false, attempts: [err] };
+    }
+
+    const attempts: PixelGroundingResult[] = [];
+    const maxAttempts = this.options.maxAttempts ?? this.adapters.length;
+    const dpr = request.screenshot.devicePixelRatio ?? 1;
+
+    for (const adapter of this.adapters) {
+      if (attempts.length >= maxAttempts) break;
+      const ready = await Promise.resolve(adapter.isReady());
+      if (!ready) {
+        const skip: PixelGroundingResult = {
+          ok: false,
+          adapterId: adapter.id,
+          error: { code: 'model_unavailable', message: 'adapter not ready', retryable: true },
+          elapsedMs: 0,
+        };
+        attempts.push(skip);
+        this.options.onAttempt?.(skip);
+        continue;
+      }
+
+      const per = this.options.timeoutMs
+        ? { ...request, timeoutMs: Math.min(this.options.timeoutMs, request.timeoutMs ?? this.options.timeoutMs) }
+        : request;
+      const result = await adapter.ground(per);
+      attempts.push(result);
+      this.options.onAttempt?.(result);
+
+      if (!result.ok || !result.hit) continue;
+      if (result.hit.confidence < adapter.minConfidence) continue;
+      if (!coordinatesInViewport(result.hit.target, request.viewport, dpr)) continue;
+      if (
+        request.action === 'drag' &&
+        result.hit.toTarget &&
+        !coordinatesInViewport(result.hit.toTarget, request.viewport, dpr)
+      ) {
+        continue;
+      }
+
+      return { ok: true, hit: result.hit, adapterId: adapter.id, attempts };
+    }
+
+    return { ok: false, attempts };
+  }
+}

--- a/tests/vision/pixel-grounding-fallback.test.ts
+++ b/tests/vision/pixel-grounding-fallback.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Pixel-grounding fallback tier contract tests.
+ */
+
+import {
+  PixelGroundingFallbackChain,
+  coordinatesInViewport,
+  validateGroundingRequest,
+  type PixelGroundingAdapter,
+  type PixelGroundingRequest,
+  type PixelGroundingResult,
+} from '../../src/vision/pixel-grounding-fallback';
+
+function mkRequest(over: Partial<PixelGroundingRequest> = {}): PixelGroundingRequest {
+  return {
+    action: 'click',
+    target: 'the blue Submit button',
+    viewport: { width: 1280, height: 800 },
+    screenshot: {
+      encoding: 'png',
+      bytes: new Uint8Array([137, 80, 78, 71]),
+      devicePixelRatio: 1,
+    },
+    ...over,
+  };
+}
+
+function mkAdapter(over: Partial<PixelGroundingAdapter> & Pick<PixelGroundingAdapter, 'id'>): PixelGroundingAdapter {
+  return {
+    label: over.id,
+    priority: 100,
+    minConfidence: 0.5,
+    isReady: () => true,
+    ground: async () => ({
+      ok: true,
+      adapterId: over.id,
+      hit: { confidence: 0.9, target: { x: 100, y: 100 } },
+      elapsedMs: 5,
+    }),
+    ...over,
+  } as PixelGroundingAdapter;
+}
+
+describe('validateGroundingRequest', () => {
+  it('accepts a well-formed click request', () => {
+    expect(validateGroundingRequest(mkRequest()).ok).toBe(true);
+  });
+
+  it('rejects an empty target', () => {
+    const r = validateGroundingRequest(mkRequest({ target: '' }));
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/target/);
+  });
+
+  it('rejects unknown actions', () => {
+    // deliberate mistype
+    const req = mkRequest({ action: 'jump' as unknown as PixelGroundingRequest['action'] });
+    expect(validateGroundingRequest(req).ok).toBe(false);
+  });
+
+  it('requires toTarget for drag', () => {
+    const r = validateGroundingRequest(mkRequest({ action: 'drag' }));
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/toTarget/);
+  });
+
+  it('requires text for type', () => {
+    const r = validateGroundingRequest(mkRequest({ action: 'type' }));
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/text/);
+  });
+
+  it('requires option for select', () => {
+    const r = validateGroundingRequest(mkRequest({ action: 'select' }));
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/option/);
+  });
+
+  it('rejects non-positive viewport', () => {
+    const r = validateGroundingRequest(mkRequest({ viewport: { width: 0, height: 100 } }));
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/viewport/);
+  });
+
+  it('rejects missing screenshot bytes', () => {
+    const r = validateGroundingRequest(
+      mkRequest({
+        screenshot: { encoding: 'png', bytes: new Uint8Array(0) },
+      }),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/screenshot/);
+  });
+});
+
+describe('coordinatesInViewport', () => {
+  const vp = { width: 1000, height: 800 };
+  it('accepts in-viewport points at dpr=1', () => {
+    expect(coordinatesInViewport({ x: 500, y: 400 }, vp, 1)).toBe(true);
+  });
+
+  it('rejects negative coords', () => {
+    expect(coordinatesInViewport({ x: -1, y: 10 }, vp, 1)).toBe(false);
+  });
+
+  it('scales bounds by device pixel ratio', () => {
+    // With dpr=2, coords may be up to 2000×1600 in screenshot space.
+    expect(coordinatesInViewport({ x: 1500, y: 1200 }, vp, 2)).toBe(true);
+    expect(coordinatesInViewport({ x: 2001, y: 100 }, vp, 2)).toBe(false);
+  });
+
+  it('rejects non-finite values', () => {
+    expect(coordinatesInViewport({ x: NaN, y: 0 }, vp, 1)).toBe(false);
+    expect(coordinatesInViewport({ x: 0, y: Infinity }, vp, 1)).toBe(false);
+  });
+});
+
+describe('PixelGroundingFallbackChain', () => {
+  it('returns the first confident hit and stops there', async () => {
+    const chain = new PixelGroundingFallbackChain();
+    let secondCalled = false;
+    chain.register(mkAdapter({ id: 'first', priority: 10 }));
+    chain.register(
+      mkAdapter({
+        id: 'second',
+        priority: 20,
+        ground: async () => {
+          secondCalled = true;
+          return {
+            ok: true,
+            adapterId: 'second',
+            hit: { confidence: 0.99, target: { x: 200, y: 200 } },
+            elapsedMs: 1,
+          };
+        },
+      }),
+    );
+    const out = await chain.ground(mkRequest());
+    expect(out.ok).toBe(true);
+    expect(out.adapterId).toBe('first');
+    expect(secondCalled).toBe(false);
+  });
+
+  it('skips adapters that report not-ready and falls through', async () => {
+    const chain = new PixelGroundingFallbackChain();
+    chain.register(
+      mkAdapter({
+        id: 'a',
+        priority: 10,
+        isReady: () => false,
+      }),
+    );
+    chain.register(mkAdapter({ id: 'b', priority: 20 }));
+    const out = await chain.ground(mkRequest());
+    expect(out.ok).toBe(true);
+    expect(out.adapterId).toBe('b');
+    expect(out.attempts.length).toBe(2);
+    expect(out.attempts[0].error?.code).toBe('model_unavailable');
+  });
+
+  it('rejects hits below minConfidence and tries the next adapter', async () => {
+    const chain = new PixelGroundingFallbackChain();
+    chain.register(
+      mkAdapter({
+        id: 'weak',
+        priority: 10,
+        minConfidence: 0.9,
+        ground: async () => ({
+          ok: true,
+          adapterId: 'weak',
+          hit: { confidence: 0.5, target: { x: 50, y: 50 } },
+          elapsedMs: 1,
+        }),
+      }),
+    );
+    chain.register(mkAdapter({ id: 'strong', priority: 20 }));
+    const out = await chain.ground(mkRequest());
+    expect(out.ok).toBe(true);
+    expect(out.adapterId).toBe('strong');
+  });
+
+  it('rejects hits whose coordinates leave the viewport', async () => {
+    const chain = new PixelGroundingFallbackChain();
+    chain.register(
+      mkAdapter({
+        id: 'ooo',
+        priority: 10,
+        ground: async () => ({
+          ok: true,
+          adapterId: 'ooo',
+          hit: { confidence: 0.99, target: { x: 999_999, y: 999_999 } },
+          elapsedMs: 1,
+        }),
+      }),
+    );
+    const out = await chain.ground(mkRequest());
+    expect(out.ok).toBe(false);
+    expect(out.attempts.length).toBe(1);
+  });
+
+  it('validates the request before any adapter runs', async () => {
+    const chain = new PixelGroundingFallbackChain();
+    let called = false;
+    chain.register(
+      mkAdapter({
+        id: 'never',
+        priority: 10,
+        ground: async () => {
+          called = true;
+          return {
+            ok: true,
+            adapterId: 'never',
+            hit: { confidence: 1, target: { x: 0, y: 0 } },
+            elapsedMs: 0,
+          };
+        },
+      }),
+    );
+    const out = await chain.ground(mkRequest({ target: '' }));
+    expect(out.ok).toBe(false);
+    expect(called).toBe(false);
+    expect(out.attempts[0].adapterId).toBe('chain');
+  });
+
+  it('emits onAttempt for every attempt', async () => {
+    const events: string[] = [];
+    const chain = new PixelGroundingFallbackChain({
+      onAttempt: (r: PixelGroundingResult) => events.push(r.adapterId),
+    });
+    chain.register(mkAdapter({ id: 'a' }));
+    chain.register(mkAdapter({ id: 'b' }));
+    await chain.ground(mkRequest());
+    expect(events).toContain('a');
+  });
+
+  it('respects maxAttempts', async () => {
+    const chain = new PixelGroundingFallbackChain({ maxAttempts: 1 });
+    chain.register(
+      mkAdapter({
+        id: 'weak',
+        priority: 10,
+        minConfidence: 0.99,
+        ground: async () => ({
+          ok: true,
+          adapterId: 'weak',
+          hit: { confidence: 0.1, target: { x: 1, y: 1 } },
+          elapsedMs: 1,
+        }),
+      }),
+    );
+    chain.register(mkAdapter({ id: 'strong', priority: 20 }));
+    const out = await chain.ground(mkRequest());
+    expect(out.ok).toBe(false);
+    expect(out.attempts.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## 요약

openchrome의 primary interaction path는 DOM- / a11y-tree 기반(\`src/dom/\`, \`src/vision/dom-annotator-provider.ts\`)입니다. 페이지가 협조하면 잘 동작하지만, DOM이 심하게 shadowed 되어 있거나 canvas-only UI(Figma, MapLibre, WebGL games)·Salesforce Aura·anti-automation obfuscation일 때는 **사용자가 실제로 보는 것에 대응하는 안정 element가 DOM에 없습니다**.

UI-TARS(Apache-2.0)와 magnitude(Apache-2.0)가 같은 관용구로 수렴했습니다 — **pixel-grounding fallback**. Screenshot + natural-language target("click the blue Submit button")을 vision 모델에 보내 정규화 픽셀 좌표를 받고, openchrome이 그 좌표에 클릭합니다.

이 팩은 그 tier의 **계약**을 이식합니다. 모델 런타임은 함께 배포하지 않습니다(openchrome이 그것들에 의존할 수 없음). 대신 downstream 플러그인이 한 번 구현하면 tier 자체는 MCP 서버 native가 되고, 모든 플러그인이 caller에게 동일한 모습을 갖도록 shape를 노출합니다.

## 근거

Sonar의 openchrome 상류 기여 재판정(v2)의 **P19** 팩입니다. 90개 오픈소스 전수조사(ULTIMATE-CENSUS-2026-07-18)의 **A43** · **A44** · **A14** 행에서 아래 원리를 이식하는 것으로 판정되었습니다.

- **UI-TARS (Apache-2.0)** — 픽셀 그라운딩 모델. \`src/vision/\` 폴백 tier의 어댑터.
- **magnitude (Apache-2.0)** — 픽셀 그라운딩 프레임워크. 동일 어댑터 계약.
- **Skyvern (AGPL-3.0)** — form-vision 관용구. Target-language grammar 참고(코드 미열람).

원본 소스는 복사하지 않았습니다. 문서화된 관용구의 clean-room 재구현입니다.

## 변경 내용

### 신규: \`src/vision/pixel-grounding-fallback.ts\` (+280 라인)

**Request/Response 타입:**
- \`PixelGroundingActionKind\` — \`'click' | 'hover' | 'drag' | 'type' | 'select'\`.
- \`PixelGroundingRequest\` — target · optional toTarget / text / option · screenshot bytes · viewport · hint · timeoutMs.
- \`PixelGroundingScreenshot\` — png/jpeg/webp · devicePixelRatio.
- \`PixelGroundingHit\` — confidence · target coords · optional toTarget · bbox · rationale.
- \`PixelGroundingResult\` / \`PixelGroundingError\` — 6-code union(\`timeout\`, \`model_unavailable\`, \`no_ground\`, \`invalid_coordinates\`, \`rate_limited\`, \`internal_error\`).

**Adapter interface:**
- \`PixelGroundingAdapter\` — id · label · priority · minConfidence · isReady() · ground(request). ground는 throw 금지 — error result 리턴.

**Orchestrator:**
- \`PixelGroundingFallbackChain\` — priority-ordered chain. Not-ready 어댑터 skip. minConfidence 미달 hit 거부. Viewport(DPR 스케일 포함)를 벗어난 좌표 거부. \`onAttempt\` telemetry. \`maxAttempts\` 존중. Request validation을 어댑터 실행 전에 수행.

**Helpers:**
- \`validateGroundingRequest\` · \`coordinatesInViewport\`.

### 테스트: \`tests/vision/pixel-grounding-fallback.test.ts\` (+220 라인)

- 20 케이스 · 모두 통과.
- Request validation: 모든 action branch(click/hover/drag/type/select) · target 길이 · viewport · screenshot bytes · encoding.
- Viewport bound: dpr=1 / dpr=2 · 음수·NaN·Infinity guard.
- Chain: first-confident stop · not-ready skip · minConfidence 재시도 · viewport-out 거부 · validation 실패 시 어댑터 미실행 · telemetry · maxAttempts.

## 참고 원본

- UI-TARS — https://github.com/bytedance/UI-TARS (Apache-2.0). 픽셀 그라운딩 모델 원리.
- magnitude — https://github.com/magnitudedev/magnitude (Apache-2.0). 픽셀 그라운딩 프레임워크 원리.
- Skyvern — https://github.com/Skyvern-AI/skyvern (AGPL-3.0). Target-language grammar 참고. 소스 미열람.
- 원본 코드 미열람 clean-room 재구현. \`src/vision/pixel-grounding-fallback.ts\` 상단 주석에 origin credit.

## 관련 문서

- Plan v2: \`docs/rebirth/OPENCHROME-CONTRIBUTION-PLAN-V2.md\` §5 (Pack P19)
- Census: \`docs/rebirth/ULTIMATE-CENSUS-2026-07-18.md\` A43 · A44 · A14

## 테스트

- \`./node_modules/.bin/tsc -p tsconfig.json --noEmit\` — 0 errors.
- Batch 4 6개 팩(P10·P19·P20·P23·P24·P25) 중 하나. 팩 간 상호 독립.