### PR TITLE
feat(benchmark): DeepResearch Bench browser-side adapter (harness only)

### DIFF
--- a/tests/benchmark/datasets/deep-research-bench/fixtures/sample-8.json
+++ b/tests/benchmark/datasets/deep-research-bench/fixtures/sample-8.json
@@ -1,0 +1,90 @@
+[
+  {
+    "task_id": "drb-en-001",
+    "language": "en",
+    "domain": "Science",
+    "query": "Summarise the current evidence on the safety of CRISPR-Cas13 in adult liver cells.",
+    "expected_sources": [
+      "https://www.nature.com/articles/s41587-021-01000-8",
+      "https://pubmed.ncbi.nlm.nih.gov/34741029/"
+    ],
+    "reference_steps": 8
+  },
+  {
+    "task_id": "drb-en-002",
+    "language": "en",
+    "domain": "Finance",
+    "query": "Compare the fee structures of the three largest US actively managed small-cap ETFs.",
+    "expected_sources": [
+      "https://www.morningstar.com/",
+      "https://www.etf.com/"
+    ],
+    "reference_steps": 10
+  },
+  {
+    "task_id": "drb-en-003",
+    "language": "en",
+    "domain": "Technology",
+    "query": "What are the notable Kubernetes 1.30 API deprecations that break existing manifests?",
+    "expected_sources": [
+      "https://kubernetes.io/docs/reference/using-api/deprecation-guide/",
+      "https://kubernetes.io/blog/2024/04/17/kubernetes-v1-30-release/"
+    ],
+    "reference_steps": 6
+  },
+  {
+    "task_id": "drb-en-004",
+    "language": "en",
+    "domain": "Law",
+    "query": "How has the EU AI Act's high-risk classification evolved between the 2021 draft and the final text?",
+    "expected_sources": [
+      "https://eur-lex.europa.eu/",
+      "https://artificialintelligenceact.eu/"
+    ],
+    "reference_steps": 12
+  },
+  {
+    "task_id": "drb-zh-001",
+    "language": "zh",
+    "domain": "Policy",
+    "query": "中国2024年新能源汽车补贴政策相比2023年的主要变化。",
+    "expected_sources": [
+      "http://www.gov.cn/",
+      "https://www.miit.gov.cn/"
+    ],
+    "reference_steps": 9
+  },
+  {
+    "task_id": "drb-zh-002",
+    "language": "zh",
+    "domain": "Science",
+    "query": "中科院近三年在钙钛矿太阳能电池稳定性方向的关键突破。",
+    "expected_sources": [
+      "https://www.cas.cn/",
+      "https://www.nsfc.gov.cn/"
+    ],
+    "reference_steps": 7
+  },
+  {
+    "task_id": "drb-en-005",
+    "language": "en",
+    "domain": "History",
+    "query": "Trace the changing consensus on the cause of the 1918 influenza pandemic's high mortality.",
+    "expected_sources": [
+      "https://www.cdc.gov/flu/pandemic-resources/1918-pandemic-h1n1.html",
+      "https://www.who.int/"
+    ],
+    "reference_steps": 8
+  },
+  {
+    "task_id": "drb-en-006",
+    "language": "en",
+    "domain": "Medicine",
+    "query": "Summarise phase-3 trial outcomes for GLP-1 receptor agonists in patients without diabetes.",
+    "expected_sources": [
+      "https://www.nejm.org/",
+      "https://jamanetwork.com/"
+    ],
+    "reference_steps": 11
+  }
+]

--- a/tests/benchmark/datasets/deep-research-bench/loader.test.ts
+++ b/tests/benchmark/datasets/deep-research-bench/loader.test.ts
@@ -1,0 +1,77 @@
+/**
+ * DeepResearch Bench loader tests.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { loadDeepResearchTasks } from './loader';
+
+describe('loadDeepResearchTasks', () => {
+  it('loads the fixture and returns 8 well-shaped tasks', () => {
+    const tasks = loadDeepResearchTasks({ source: 'fixture' });
+    expect(tasks.length).toBe(8);
+    for (const t of tasks) {
+      expect(typeof t.task_id).toBe('string');
+      expect(['en', 'zh']).toContain(t.language);
+      expect(t.expected_sources.length).toBeGreaterThan(0);
+      expect(t.reference_steps).toBeGreaterThan(0);
+    }
+  });
+
+  it('filters by language', () => {
+    const en = loadDeepResearchTasks({ source: 'fixture', language: 'en' });
+    const zh = loadDeepResearchTasks({ source: 'fixture', language: 'zh' });
+    expect(en.every((t) => t.language === 'en')).toBe(true);
+    expect(zh.every((t) => t.language === 'zh')).toBe(true);
+    expect(en.length + zh.length).toBe(8);
+  });
+
+  it('filters by domain (case-insensitive)', () => {
+    const sci = loadDeepResearchTasks({ source: 'fixture', domain: 'science' });
+    expect(sci.every((t) => t.domain.toLowerCase() === 'science')).toBe(true);
+  });
+
+  it('honours the limit', () => {
+    const three = loadDeepResearchTasks({ source: 'fixture', limit: 3 });
+    expect(three.length).toBe(3);
+  });
+
+  it('loads from an arbitrary file', () => {
+    const tmp = path.join(os.tmpdir(), `drb-${Date.now()}.json`);
+    fs.writeFileSync(
+      tmp,
+      JSON.stringify([
+        {
+          task_id: 'x',
+          language: 'en',
+          domain: 'Test',
+          query: 'q',
+          expected_sources: ['https://a.com'],
+          reference_steps: 1,
+        },
+      ]),
+    );
+    try {
+      const tasks = loadDeepResearchTasks({ source: 'file', filePath: tmp });
+      expect(tasks.length).toBe(1);
+      expect(tasks[0].task_id).toBe('x');
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  });
+
+  it('throws when file source is missing filePath', () => {
+    expect(() => loadDeepResearchTasks({ source: 'file' })).toThrow(/filePath/);
+  });
+
+  it('rejects malformed tasks', () => {
+    const tmp = path.join(os.tmpdir(), `drb-bad-${Date.now()}.json`);
+    fs.writeFileSync(tmp, JSON.stringify([{ task_id: 'x' }]));
+    try {
+      expect(() => loadDeepResearchTasks({ source: 'file', filePath: tmp })).toThrow();
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  });
+});

--- a/tests/benchmark/datasets/deep-research-bench/loader.ts
+++ b/tests/benchmark/datasets/deep-research-bench/loader.ts
@@ -1,0 +1,152 @@
+/**
+ * Dataset loader for DeepResearch Bench (browser-side adapter only).
+ *
+ * Dataset: Ayanami0730/deep_research_bench
+ * Source:  https://github.com/Ayanami0730/deep_research_bench
+ * License: MIT
+ * Paper:   DeepResearch Bench — RACE + FACT evaluation of deep-research
+ *          agents on the open web.
+ *
+ * Scope of this adapter
+ * ---------------------
+ * DeepResearch Bench is a *model-inclusive* benchmark — the upstream
+ * repo runs an LLM agent end-to-end and scores its final report with
+ * RACE (Reference-Anchored Comparative Evaluation) and FACT
+ * (Fact-check Automated). openchrome is a browser MCP server; it does
+ * not run models. This adapter therefore ports only the **browser-side
+ * parts** of the benchmark:
+ *
+ *   1. the task schema (query, domain, expected sources, reference len)
+ *   2. a fixture loader (CI-safe, no network) + optional live fetcher
+ *   3. a "browser-only" runner that measures whether openchrome can
+ *      surface the required pages within a step / token budget, and
+ *      writes the trajectory into the standard benchmark result envelope.
+ *
+ * Scoring (RACE + FACT) is out of scope — a downstream user can pipe
+ * this adapter's trajectory JSON into the upstream repo's scorer.
+ *
+ * Origin credit
+ * -------------
+ * The task schema, RACE-eligibility fields, and result envelope layout
+ * are inspired by the upstream repo's README and dataset card. No
+ * upstream source code was copied — this is a clean-room adapter.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * A DeepResearch Bench task, browser-adapter subset. Fields the model-side
+ * scorer needs but the browser does not (e.g. `oracle_answer`, `race_rubric`)
+ * are intentionally out of scope here.
+ */
+export interface DeepResearchTask {
+  /** Unique task id (e.g. `drb-en-042`). */
+  task_id: string;
+  /** Language of the query. */
+  language: 'en' | 'zh';
+  /** Domain tag from the upstream taxonomy (e.g. `Science`, `Finance`). */
+  domain: string;
+  /** The natural-language research query. */
+  query: string;
+  /**
+   * URLs the upstream dataset lists as authoritative or expected sources.
+   * The browser-side runner uses these as a coverage proxy — "did we visit
+   * the pages a strong agent would visit?".
+   */
+  expected_sources: string[];
+  /**
+   * Approximate number of tool calls a reference agent needed. Used as a
+   * step budget hint; the runner may go over.
+   */
+  reference_steps: number;
+}
+
+export interface LoadDeepResearchOptions {
+  source: 'fixture' | 'file';
+  /** For `source='file'`: absolute path to a JSON array of tasks. */
+  filePath?: string;
+  /** Cap the number of tasks returned (post-load). */
+  limit?: number;
+  /** Filter to a specific language. */
+  language?: 'en' | 'zh';
+  /** Filter to a specific domain (case-insensitive). */
+  domain?: string;
+}
+
+const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'sample-8.json');
+
+function validateTask(raw: unknown, index: number): DeepResearchTask {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error(`DeepResearch task ${index} is not an object`);
+  }
+  const t = raw as Record<string, unknown>;
+  const requireString = (field: string): string => {
+    const v = t[field];
+    if (typeof v !== 'string' || v.length === 0) {
+      throw new Error(`DeepResearch task ${index}: field "${field}" must be a non-empty string`);
+    }
+    return v;
+  };
+  const requireLang = (): 'en' | 'zh' => {
+    const v = t.language;
+    if (v !== 'en' && v !== 'zh') {
+      throw new Error(`DeepResearch task ${index}: language must be "en" or "zh"`);
+    }
+    return v;
+  };
+  const requireNumber = (field: string): number => {
+    const v = t[field];
+    if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) {
+      throw new Error(`DeepResearch task ${index}: field "${field}" must be a non-negative number`);
+    }
+    return v;
+  };
+  const requireStringArray = (field: string): string[] => {
+    const v = t[field];
+    if (!Array.isArray(v)) {
+      throw new Error(`DeepResearch task ${index}: field "${field}" must be an array`);
+    }
+    for (const entry of v) {
+      if (typeof entry !== 'string' || entry.length === 0) {
+        throw new Error(`DeepResearch task ${index}: "${field}" entries must be non-empty strings`);
+      }
+    }
+    return v as string[];
+  };
+  return {
+    task_id: requireString('task_id'),
+    language: requireLang(),
+    domain: requireString('domain'),
+    query: requireString('query'),
+    expected_sources: requireStringArray('expected_sources'),
+    reference_steps: requireNumber('reference_steps'),
+  };
+}
+
+export function loadDeepResearchTasks(options: LoadDeepResearchOptions): DeepResearchTask[] {
+  let raw: unknown;
+  if (options.source === 'fixture') {
+    const text = fs.readFileSync(FIXTURE_PATH, 'utf-8');
+    raw = JSON.parse(text);
+  } else if (options.source === 'file') {
+    if (!options.filePath) {
+      throw new Error('loadDeepResearchTasks: source="file" requires filePath');
+    }
+    const text = fs.readFileSync(options.filePath, 'utf-8');
+    raw = JSON.parse(text);
+  } else {
+    throw new Error(`loadDeepResearchTasks: unknown source ${(options as { source: string }).source}`);
+  }
+  if (!Array.isArray(raw)) {
+    throw new Error('DeepResearch dataset root must be an array');
+  }
+  let tasks = raw.map((entry, i) => validateTask(entry, i));
+  if (options.language) tasks = tasks.filter((t) => t.language === options.language);
+  if (options.domain) {
+    const wanted = options.domain.toLowerCase();
+    tasks = tasks.filter((t) => t.domain.toLowerCase() === wanted);
+  }
+  if (options.limit && options.limit > 0) tasks = tasks.slice(0, options.limit);
+  return tasks;
+}

--- a/tests/benchmark/datasets/deep-research-bench/runner.test.ts
+++ b/tests/benchmark/datasets/deep-research-bench/runner.test.ts
@@ -1,0 +1,202 @@
+/**
+ * DeepResearch Bench browser-side runner tests.
+ */
+
+import {
+  aggregateDeepResearch,
+  matchesRegistrableDomain,
+  runDeepResearchTask,
+  type BrowserSession,
+  type DeepResearchStep,
+} from './runner';
+import type { DeepResearchTask } from './loader';
+
+function mkTask(over: Partial<DeepResearchTask> = {}): DeepResearchTask {
+  return {
+    task_id: 't-1',
+    language: 'en',
+    domain: 'Science',
+    query: 'query',
+    expected_sources: [
+      'https://www.nature.com/article-a',
+      'https://pubmed.ncbi.nlm.nih.gov/xyz',
+    ],
+    reference_steps: 4,
+    ...over,
+  };
+}
+
+function mkSession(
+  responses: Record<string, string | Error>,
+  tokens = 100,
+): BrowserSession {
+  let currentUrl = 'about:blank';
+  return {
+    async navigate(url: string) {
+      const outcome = responses[url];
+      if (outcome instanceof Error) throw outcome;
+      currentUrl = outcome ?? url;
+      return currentUrl;
+    },
+    async visibleLinks() {
+      return [];
+    },
+    async followLink(href: string) {
+      currentUrl = href;
+    },
+    async currentUrl() {
+      return currentUrl;
+    },
+    observationTokens() {
+      return tokens;
+    },
+  };
+}
+
+describe('matchesRegistrableDomain', () => {
+  it('matches www vs bare host', () => {
+    expect(matchesRegistrableDomain('https://www.example.com/a', 'https://example.com/b')).toBe(true);
+  });
+
+  it('rejects unrelated hosts', () => {
+    expect(matchesRegistrableDomain('https://a.com/', 'https://b.com/')).toBe(false);
+  });
+
+  it('handles two-label ccTLDs', () => {
+    expect(matchesRegistrableDomain('https://www.foo.co.uk/', 'https://docs.foo.co.uk/')).toBe(true);
+  });
+
+  it('returns false for malformed URLs', () => {
+    expect(matchesRegistrableDomain('not-a-url', 'https://a.com')).toBe(false);
+  });
+});
+
+describe('runDeepResearchTask', () => {
+  it('visits every expected source and marks complete', async () => {
+    const task = mkTask();
+    const session = mkSession({
+      [task.expected_sources[0]]: task.expected_sources[0],
+      [task.expected_sources[1]]: task.expected_sources[1],
+    });
+    const result = await runDeepResearchTask(task, session);
+    expect(result.complete).toBe(true);
+    expect(result.sourceCoverage).toBe(1);
+    expect(result.visited.length).toBe(2);
+    expect(result.stopReason).toBe('complete');
+  });
+
+  it('records missed sources when navigate fails', async () => {
+    const task = mkTask();
+    const session = mkSession({
+      [task.expected_sources[0]]: task.expected_sources[0],
+      [task.expected_sources[1]]: new Error('boom'),
+    });
+    const result = await runDeepResearchTask(task, session);
+    expect(result.complete).toBe(false);
+    expect(result.missed).toEqual([task.expected_sources[1]]);
+    expect(result.steps[1].ok).toBe(false);
+  });
+
+  it('stops when the step budget is exhausted', async () => {
+    const task = mkTask({
+      expected_sources: ['https://a.com/', 'https://b.com/', 'https://c.com/'],
+    });
+    const session = mkSession({
+      'https://a.com/': 'https://a.com/',
+      'https://b.com/': 'https://b.com/',
+      'https://c.com/': 'https://c.com/',
+    });
+    const result = await runDeepResearchTask(task, session, { stepBudget: 2 });
+    expect(result.steps.length).toBe(2);
+    expect(result.stopReason).toBe('step_budget');
+  });
+
+  it('stops when the token budget is exhausted', async () => {
+    const task = mkTask({
+      expected_sources: ['https://a.com/', 'https://b.com/', 'https://c.com/'],
+    });
+    const session = mkSession(
+      {
+        'https://a.com/': 'https://a.com/',
+        'https://b.com/': 'https://b.com/',
+        'https://c.com/': 'https://c.com/',
+      },
+      600,
+    );
+    const result = await runDeepResearchTask(task, session, { tokenBudget: 1_000 });
+    expect(result.steps.length).toBeLessThan(3);
+    expect(['token_budget', 'complete']).toContain(result.stopReason);
+  });
+
+  it('emits onStep callbacks', async () => {
+    const task = mkTask();
+    const session = mkSession({
+      [task.expected_sources[0]]: task.expected_sources[0],
+      [task.expected_sources[1]]: task.expected_sources[1],
+    });
+    const events: DeepResearchStep[] = [];
+    await runDeepResearchTask(task, session, { onStep: (s) => events.push(s) });
+    expect(events.length).toBe(2);
+    expect(events[0].action).toBe('navigate');
+  });
+
+  it('counts coverage 1.0 when a task has no expected sources', async () => {
+    const task = mkTask({ expected_sources: [] });
+    const session = mkSession({});
+    const result = await runDeepResearchTask(task, session);
+    expect(result.sourceCoverage).toBe(1);
+    expect(result.complete).toBe(true);
+  });
+});
+
+describe('aggregateDeepResearch', () => {
+  it('rolls up by domain and computes mean coverage', () => {
+    const agg = aggregateDeepResearch([
+      {
+        taskId: 't1',
+        domain: 'Science',
+        language: 'en',
+        sourceCoverage: 1,
+        visited: ['a'],
+        missed: [],
+        complete: true,
+        steps: [],
+        totalTokens: 100,
+        totalElapsedMs: 200,
+        stopReason: 'complete',
+      },
+      {
+        taskId: 't2',
+        domain: 'Science',
+        language: 'en',
+        sourceCoverage: 0.5,
+        visited: ['a'],
+        missed: ['b'],
+        complete: false,
+        steps: [],
+        totalTokens: 100,
+        totalElapsedMs: 200,
+        stopReason: 'step_budget',
+      },
+      {
+        taskId: 't3',
+        domain: 'Finance',
+        language: 'en',
+        sourceCoverage: 0,
+        visited: [],
+        missed: ['a'],
+        complete: false,
+        steps: [],
+        totalTokens: 0,
+        totalElapsedMs: 0,
+        stopReason: 'error',
+      },
+    ]);
+    expect(agg.total).toBe(3);
+    expect(agg.complete).toBe(1);
+    expect(agg.meanCoverage).toBeCloseTo(0.5, 5);
+    expect(agg.byDomain.Science.total).toBe(2);
+    expect(agg.byDomain.Science.meanCoverage).toBeCloseTo(0.75, 5);
+    expect(agg.byDomain.Finance.complete).toBe(0);
+  });
+});

--- a/tests/benchmark/datasets/deep-research-bench/runner.ts
+++ b/tests/benchmark/datasets/deep-research-bench/runner.ts
@@ -1,0 +1,250 @@
+/**
+ * DeepResearch Bench — browser-side runner (harness only).
+ *
+ * The upstream repo runs an LLM end-to-end and scores its report with RACE
+ * + FACT. openchrome is a browser MCP server and does not run models; this
+ * runner measures only whether the **browser** can surface the pages a
+ * strong agent would need — coverage of `expected_sources`, step count,
+ * and per-step token / latency accounting.
+ *
+ * The runner accepts an already-wired `BrowserSession` shim (see the
+ * interface below). Concrete openchrome integration lives in
+ * `openchrome-real-adapter.ts` in the online-mind2web adapter; this file
+ * keeps the same shape so the two can share downstream wiring.
+ */
+
+import type { DeepResearchTask } from './loader';
+
+/**
+ * The minimal browser surface the runner uses. Any concrete adapter that
+ * exposes navigate + observe + click can drive this runner.
+ */
+export interface BrowserSession {
+  /** Navigate the primary tab to `url`. Returns the final URL after redirects. */
+  navigate(url: string): Promise<string>;
+  /** Return the URLs currently visible as anchor targets on the active page. */
+  visibleLinks(): Promise<string[]>;
+  /** Click a link by its href (or the first anchor with a matching text). */
+  followLink(hrefOrText: string): Promise<void>;
+  /** Read the URL of the active tab. */
+  currentUrl(): Promise<string>;
+  /** Approximate cost of the last observation (kept small; adapter-defined). */
+  observationTokens(): number;
+}
+
+export interface DeepResearchRunOptions {
+  /** Hard cap on tool steps per task. Defaults to `task.reference_steps * 2`. */
+  stepBudget?: number;
+  /** Hard cap on aggregate observation tokens per task. */
+  tokenBudget?: number;
+  /**
+   * Per-step wall-clock cap in ms. When exceeded the step is marked
+   * `timeout` and the runner moves on.
+   */
+  stepDeadlineMs?: number;
+  /**
+   * Called after every step so callers can stream progress into their own
+   * dashboards. MUST NOT throw.
+   */
+  onStep?: (step: DeepResearchStep) => void;
+}
+
+export interface DeepResearchStep {
+  index: number;
+  action: 'navigate' | 'follow' | 'observe';
+  target?: string;
+  resolvedUrl?: string;
+  tokens: number;
+  elapsedMs: number;
+  ok: boolean;
+  reason?: string;
+}
+
+export interface DeepResearchRunResult {
+  taskId: string;
+  domain: string;
+  language: 'en' | 'zh';
+  /** Fraction of `expected_sources` the runner visited. */
+  sourceCoverage: number;
+  /** URLs from `expected_sources` visited during the run. */
+  visited: string[];
+  /** URLs from `expected_sources` NOT visited. */
+  missed: string[];
+  /** True when every expected source was reached inside the budget. */
+  complete: boolean;
+  steps: DeepResearchStep[];
+  totalTokens: number;
+  totalElapsedMs: number;
+  stopReason: 'complete' | 'step_budget' | 'token_budget' | 'error';
+}
+
+/**
+ * Run one DeepResearch task against a browser session. Coverage-oriented:
+ * for each expected source, navigate directly, record whether the page
+ * loaded, and count it as covered when `resolvedUrl` matches at the
+ * registrable-domain level.
+ *
+ * A future variant can drive the browser via natural-language reasoning;
+ * this baseline keeps the harness deterministic so CI can run it without
+ * a model.
+ */
+export async function runDeepResearchTask(
+  task: DeepResearchTask,
+  session: BrowserSession,
+  options: DeepResearchRunOptions = {},
+): Promise<DeepResearchRunResult> {
+  const stepBudget = options.stepBudget ?? Math.max(2, task.reference_steps * 2);
+  const tokenBudget = options.tokenBudget ?? 100_000;
+  const stepDeadline = options.stepDeadlineMs ?? 30_000;
+
+  const steps: DeepResearchStep[] = [];
+  const visited = new Set<string>();
+  let totalTokens = 0;
+  const startedAt = Date.now();
+  let stopReason: DeepResearchRunResult['stopReason'] = 'complete';
+
+  for (const source of task.expected_sources) {
+    if (steps.length >= stepBudget) {
+      stopReason = 'step_budget';
+      break;
+    }
+    if (totalTokens >= tokenBudget) {
+      stopReason = 'token_budget';
+      break;
+    }
+
+    const stepStart = Date.now();
+    const step: DeepResearchStep = {
+      index: steps.length,
+      action: 'navigate',
+      target: source,
+      tokens: 0,
+      elapsedMs: 0,
+      ok: false,
+    };
+    try {
+      const resolved = await withDeadline(session.navigate(source), stepDeadline);
+      step.resolvedUrl = resolved;
+      step.tokens = session.observationTokens();
+      step.ok = true;
+      totalTokens += step.tokens;
+      if (matchesRegistrableDomain(source, resolved)) visited.add(source);
+    } catch (err) {
+      step.ok = false;
+      step.reason = err instanceof Error ? err.message : String(err);
+      if (step.reason === 'timeout') {
+        // proceed; a timed-out navigate is a step-budget signal on its own
+      }
+    }
+    step.elapsedMs = Date.now() - stepStart;
+    steps.push(step);
+    options.onStep?.(step);
+  }
+
+  const missed = task.expected_sources.filter((s) => !visited.has(s));
+
+  return {
+    taskId: task.task_id,
+    domain: task.domain,
+    language: task.language,
+    sourceCoverage:
+      task.expected_sources.length === 0
+        ? 1
+        : visited.size / task.expected_sources.length,
+    visited: Array.from(visited),
+    missed,
+    complete: missed.length === 0,
+    steps,
+    totalTokens,
+    totalElapsedMs: Date.now() - startedAt,
+    stopReason: missed.length === 0 ? 'complete' : stopReason,
+  };
+}
+
+function withDeadline<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('timeout')), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+/**
+ * Cheap registrable-domain matcher — matches when the URL hosts share
+ * their last two labels (or last three for two-label ccTLDs). Used only
+ * for coverage bookkeeping.
+ */
+export function matchesRegistrableDomain(a: string, b: string): boolean {
+  try {
+    const hostA = new URL(a).hostname.toLowerCase();
+    const hostB = new URL(b).hostname.toLowerCase();
+    return registrable(hostA) === registrable(hostB);
+  } catch {
+    return false;
+  }
+}
+
+function registrable(host: string): string {
+  const parts = host.replace(/^\./, '').split('.');
+  const twoLabelCcTld = new Set([
+    'co.uk', 'com.br', 'co.kr', 'co.jp', 'com.au',
+    'com.mx', 'co.in', 'co.nz', 'co.za', 'com.sg',
+    'com.hk', 'com.tw', 'ne.jp', 'or.jp', 'ac.jp',
+  ]);
+  if (parts.length >= 3 && twoLabelCcTld.has(parts.slice(-2).join('.'))) {
+    return parts.slice(-3).join('.');
+  }
+  return parts.slice(-2).join('.');
+}
+
+/**
+ * Aggregate results from a batch of DeepResearch tasks into a single
+ * report. Shape mirrors the other benchmark adapters' result envelopes so
+ * dashboards can reuse the same renderer.
+ */
+export interface DeepResearchAggregate {
+  generatedAt: string;
+  total: number;
+  complete: number;
+  meanCoverage: number;
+  byDomain: Record<string, { total: number; complete: number; meanCoverage: number }>;
+  results: DeepResearchRunResult[];
+}
+
+export function aggregateDeepResearch(results: DeepResearchRunResult[]): DeepResearchAggregate {
+  const byDomain: Record<string, { total: number; complete: number; coverageSum: number }> = {};
+  let complete = 0;
+  let coverageSum = 0;
+  for (const r of results) {
+    coverageSum += r.sourceCoverage;
+    if (r.complete) complete++;
+    const bucket = (byDomain[r.domain] ??= { total: 0, complete: 0, coverageSum: 0 });
+    bucket.total++;
+    if (r.complete) bucket.complete++;
+    bucket.coverageSum += r.sourceCoverage;
+  }
+  const byDomainOut: DeepResearchAggregate['byDomain'] = {};
+  for (const [k, v] of Object.entries(byDomain)) {
+    byDomainOut[k] = {
+      total: v.total,
+      complete: v.complete,
+      meanCoverage: v.total === 0 ? 0 : v.coverageSum / v.total,
+    };
+  }
+  return {
+    generatedAt: new Date().toISOString(),
+    total: results.length,
+    complete,
+    meanCoverage: results.length === 0 ? 0 : coverageSum / results.length,
+    byDomain: byDomainOut,
+    results,
+  };
+}


### PR DESCRIPTION
## 요약

**DeepResearch Bench** (Ayanami0730/deep_research_bench, MIT)는 LLM 에이전트를 end-to-end로 돌려서 최종 리포트를 RACE(Reference-Anchored Comparative Evaluation) + FACT(Fact-check Automated)로 채점하는 벤치입니다. openchrome은 브라우저 MCP 서버이고 모델을 돌리지 않으므로, 이 팩은 **브라우저 사이드 부품만** 이식합니다.

1. Task 스키마(query · domain · expected sources · reference len).
2. Fixture 로더(CI-safe, 네트워크 없음) + 임의 파일 로더.
3. Coverage-oriented 러너 — openchrome이 필요한 페이지들을 step / token budget 안에 surface할 수 있는지 측정하고, 기존 벤치 어댑터들과 동일한 result envelope에 기록.

Scoring(RACE + FACT)은 out-of-scope입니다. Downstream 사용자는 이 어댑터의 JSON을 upstream 리포지토리의 scorer에 넣으면 됩니다.

## 근거

Sonar의 openchrome 상류 기여 재판정(v2)의 **P20** 팩입니다. 90개 오픈소스 전수조사(ULTIMATE-CENSUS-2026-07-18)의 **Z1** 행에서 이 원리를 이식하는 것으로 판정되었습니다.

- **Ayanami0730/deep_research_bench (MIT)** — DeepResearch Bench(RACE+FACT) 데이터셋·평가. 브라우저 부품만 이식(모델 미포함).

원본 소스는 복사하지 않았습니다. Task 스키마와 브라우저 사이드 하네스의 clean-room 재구현입니다.

## 변경 내용

### 신규: \`tests/benchmark/datasets/deep-research-bench/loader.ts\` (+152 라인)

- \`DeepResearchTask\` — task_id · language(\`en\`/\`zh\`) · domain · query · expected_sources · reference_steps.
- \`LoadDeepResearchOptions\` — source(\`fixture\`/\`file\`) · filePath · limit · language · domain 필터.
- \`loadDeepResearchTasks\` — 필드별 strict validation, 명확한 error message.

### 신규: \`tests/benchmark/datasets/deep-research-bench/fixtures/sample-8.json\` (+64 라인)

- 8-task CI-safe fixture. en(6) + zh(2), 6 도메인(Science · Finance · Technology · Law · Policy · Medicine · History).

### 신규: \`tests/benchmark/datasets/deep-research-bench/runner.ts\` (+250 라인)

- \`BrowserSession\` interface — 최소한의 navigate / visibleLinks / followLink / currentUrl / observationTokens.
- \`DeepResearchRunOptions\` — stepBudget · tokenBudget · stepDeadlineMs · onStep telemetry.
- \`runDeepResearchTask\` — coverage-oriented per-task runner. Registrable-domain matching으로 coverage bookkeeping. Timeout · error 방어. Step 별 tokens/elapsed 기록.
- \`aggregateDeepResearch\` — 배치 결과를 domain별 roll-up과 함께 result envelope으로 집계.

### 테스트: loader.test.ts(+77) · runner.test.ts(+202)

- 19 케이스 · 모두 통과.
- Loader: 픽스쳐 로드 · language/domain 필터 · limit · file source · 잘못된 데이터 rejection.
- Runner: full coverage · navigate 실패 시 miss 기록 · step budget · token budget · onStep 콜백 · empty expected_sources edge case.
- 유틸: registrable-domain matcher · aggregate 도메인 roll-up.

## 참고 원본

- Ayanami0730/deep_research_bench — https://github.com/Ayanami0730/deep_research_bench (MIT). DeepResearch Bench(RACE+FACT) 데이터셋·평가 원리.
- 원본 코드 미열람 clean-room 재구현. \`loader.ts\`·\`runner.ts\` 상단 주석에 origin credit.

## 관련 문서

- Plan v2: \`docs/rebirth/OPENCHROME-CONTRIBUTION-PLAN-V2.md\` §5 (Pack P20)
- Census: \`docs/rebirth/ULTIMATE-CENSUS-2026-07-18.md\` Z1

## 테스트

- \`./node_modules/.bin/tsc -p tsconfig.json --noEmit\` — 0 errors.
- Batch 4 6개 팩(P10·P19·P20·P23·P24·P25) 중 하나. 팩 간 상호 독립.