### PR TITLE
feat(auth): KMS/keychain vault adapters + email-OTP reader

### DIFF
--- a/src/auth/adapters/vault-adapter.ts
+++ b/src/auth/adapters/vault-adapter.ts
@@ -1,0 +1,238 @@
+/**
+ * Vault-backed credential adapter — KMS / OS-keychain plumbing.
+ *
+ * Why this exists
+ * ---------------
+ * openchrome today has three credential providers: `local` (AES-256-GCM
+ * on disk, key derived from a machine-id), `1password` and `bitwarden`
+ * (CLI shell-out). For enterprise deployments the answer is often
+ * neither: credentials live in a **KMS**-encrypted blob or in an OS
+ * **keychain** (macOS Keychain, Windows Credential Vault, Linux
+ * libsecret).
+ *
+ * notte's `Vault` idiom — swap the "how do we decrypt" primitive
+ * without touching the "how do we look up creds by domain" surface —
+ * is exactly the shape we need.
+ *
+ * Design
+ * ------
+ * Two concrete vault flavours ship, both implementing the existing
+ * `CredentialProvider` interface so they slot into
+ * `getCredentialProvider()` without a schema change:
+ *
+ *  1. `KeychainVaultAdapter` — reads secrets from the OS keychain via
+ *     a caller-supplied `keychain` object. The runtime dependency
+ *     (typically `keytar`) is **not** required by openchrome-mcp; the
+ *     adapter accepts any object matching the minimal `KeychainLike`
+ *     interface. Callers that want it construct the adapter with
+ *     `new KeychainVaultAdapter({ keychain: require('keytar') })` at
+ *     their entrypoint.
+ *
+ *  2. `KmsVaultAdapter` — reads an encrypted blob from disk and hands
+ *     the ciphertext to a caller-supplied `decrypt(ciphertext) → plaintext`
+ *     function. The decrypt function is where a caller wires AWS KMS,
+ *     GCP KMS, Vault Transit, etc. openchrome-mcp has no dependency on
+ *     any of them — just the byte-slice contract.
+ *
+ * Both adapters expose the same `getCredentials(domain)` /
+ * `listDomains()` surface as `LocalAdapter`, so tools that iterate
+ * `provider.listDomains()` keep working.
+ *
+ * Credential blob shape (KMS): after decrypt, JSON:
+ *
+ *   { "example.com": { "username": "…", "password": "…", "totpSecret": "…" },
+ *     "app.io":      { "username": "…", "password": "…" } }
+ *
+ * Keychain layout: each domain is a `service="openchrome:<domain>"`
+ * account entry whose password is the same JSON credential value.
+ *
+ * Origin credit
+ * -------------
+ * The "decouple the KMS from the lookup" idiom is from notte's
+ * `Vault` class (SSPL). Clean-room implementation; no upstream code
+ * copied.
+ */
+
+import type { CredentialProvider, Credentials } from '../credential-provider';
+
+// --- KeychainVaultAdapter ---------------------------------------------------
+
+export interface KeychainLike {
+  /** Get one credential blob string. Returns null when the entry is missing. */
+  getPassword(service: string, account: string): Promise<string | null>;
+  /** Enumerate all credentials under a service prefix. */
+  findCredentials(service: string): Promise<{ account: string; password: string }[]>;
+}
+
+export interface KeychainVaultOptions {
+  keychain: KeychainLike;
+  /** Service prefix used for all entries. Default `openchrome`. */
+  servicePrefix?: string;
+  /** Account name under which the credential blob is stored. Default `credentials`. */
+  account?: string;
+}
+
+const DEFAULT_SERVICE_PREFIX = 'openchrome';
+const DEFAULT_ACCOUNT = 'credentials';
+
+export class KeychainVaultAdapter implements CredentialProvider {
+  readonly name = 'keychain-vault';
+  private readonly keychain: KeychainLike;
+  private readonly servicePrefix: string;
+  private readonly account: string;
+
+  constructor(opts: KeychainVaultOptions) {
+    if (!opts || !opts.keychain) {
+      throw new TypeError('KeychainVaultAdapter: opts.keychain is required');
+    }
+    this.keychain = opts.keychain;
+    this.servicePrefix = opts.servicePrefix ?? DEFAULT_SERVICE_PREFIX;
+    this.account = opts.account ?? DEFAULT_ACCOUNT;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    // Probe by trying to enumerate. The keychain layer decides whether
+    // to prompt the user; we just want a non-throwing outcome.
+    try {
+      await this.keychain.findCredentials(this.servicePrefix);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getCredentials(domain: string): Promise<Credentials | null> {
+    const service = `${this.servicePrefix}:${domain}`;
+    const raw = await this.keychain.getPassword(service, this.account);
+    if (raw === null) return null;
+    return parseCredentialBlob(raw);
+  }
+
+  async listDomains(): Promise<string[]> {
+    const entries = await this.keychain.findCredentials(this.servicePrefix);
+    const out: string[] = [];
+    for (const entry of entries) {
+      // entry.account is the account name; we store domain in the service.
+      // findCredentials returns entries for the whole prefix, so filter.
+      // (keytar returns service string as-is; the caller reconstructs.)
+      // Convention: entries stored under service `${prefix}:${domain}`
+      // will be returned with account === this.account.
+      if (entry.account === this.account) {
+        // No way to recover domain from findCredentials — the caller
+        // must have used `openchrome:<domain>` as service. Since keytar
+        // does not expose the service on find, we require callers to
+        // maintain a domain index sibling entry named `__index__` if
+        // they need enumeration. Absence returns [].
+      }
+    }
+    // Try the index entry — a JSON array of known domains.
+    const idxRaw = await this.keychain.getPassword(this.servicePrefix, '__index__');
+    if (!idxRaw) return out;
+    try {
+      const parsed = JSON.parse(idxRaw);
+      return Array.isArray(parsed) ? parsed.filter((s) => typeof s === 'string') : out;
+    } catch {
+      return out;
+    }
+  }
+}
+
+// --- KmsVaultAdapter --------------------------------------------------------
+
+/** Encrypted blob loader — reads bytes from wherever the caller stores them. */
+export type CiphertextLoader = () => Promise<Buffer | Uint8Array>;
+
+/** Ciphertext → plaintext primitive. Wire AWS KMS / GCP KMS / Vault Transit here. */
+export type DecryptFn = (ciphertext: Buffer) => Promise<Buffer | Uint8Array | string>;
+
+export interface KmsVaultOptions {
+  load: CiphertextLoader;
+  decrypt: DecryptFn;
+  /**
+   * When true, cache the decrypted plaintext in-memory for the process
+   * lifetime. Default: true (avoids repeated KMS calls per tool call).
+   */
+  cache?: boolean;
+}
+
+export class KmsVaultAdapter implements CredentialProvider {
+  readonly name = 'kms-vault';
+  private readonly load: CiphertextLoader;
+  private readonly decrypt: DecryptFn;
+  private readonly cache: boolean;
+  private _cached: Record<string, Credentials> | null = null;
+
+  constructor(opts: KmsVaultOptions) {
+    if (!opts || typeof opts.load !== 'function' || typeof opts.decrypt !== 'function') {
+      throw new TypeError('KmsVaultAdapter: opts.load and opts.decrypt are required functions');
+    }
+    this.load = opts.load;
+    this.decrypt = opts.decrypt;
+    this.cache = opts.cache !== false;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      await this.getAll();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getCredentials(domain: string): Promise<Credentials | null> {
+    const all = await this.getAll();
+    return all[domain] ?? null;
+  }
+
+  async listDomains(): Promise<string[]> {
+    const all = await this.getAll();
+    return Object.keys(all).sort();
+  }
+
+  /** Test-only cache reset. */
+  _resetCache(): void {
+    this._cached = null;
+  }
+
+  private async getAll(): Promise<Record<string, Credentials>> {
+    if (this.cache && this._cached) return this._cached;
+    const ciphertext = await this.load();
+    const buf = Buffer.isBuffer(ciphertext) ? ciphertext : Buffer.from(ciphertext);
+    const plain = await this.decrypt(buf);
+    const text = typeof plain === 'string' ? plain : Buffer.from(plain as Uint8Array).toString('utf8');
+    const parsed = JSON.parse(text);
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('KmsVaultAdapter: decrypted blob must be a JSON object');
+    }
+    const out: Record<string, Credentials> = {};
+    for (const [domain, entry] of Object.entries(parsed)) {
+      const norm = coerceCredentials(entry);
+      if (norm) out[domain] = norm;
+    }
+    if (this.cache) this._cached = out;
+    return out;
+  }
+}
+
+// --- Shared helpers ---------------------------------------------------------
+
+export function parseCredentialBlob(raw: string): Credentials | null {
+  try {
+    const parsed = JSON.parse(raw);
+    return coerceCredentials(parsed);
+  } catch {
+    return null;
+  }
+}
+
+export function coerceCredentials(v: unknown): Credentials | null {
+  if (!v || typeof v !== 'object') return null;
+  const o = v as Record<string, unknown>;
+  const username = typeof o.username === 'string' ? o.username : null;
+  const password = typeof o.password === 'string' ? o.password : null;
+  if (username === null || password === null) return null;
+  const out: Credentials = { username, password };
+  if (typeof o.totpSecret === 'string') out.totpSecret = o.totpSecret;
+  return out;
+}

--- a/src/auth/email-otp-reader.ts
+++ b/src/auth/email-otp-reader.ts
@@ -1,0 +1,176 @@
+/**
+ * Email OTP reader — extract one-time codes from message bodies.
+ *
+ * Why this exists
+ * ---------------
+ * Many logins that openchrome drives (banks, government portals, SaaS
+ * providers) push the second factor to email rather than to a TOTP
+ * app or a phone. Today an operator has to hand-shuttle the code from
+ * a mail client into the browser session, breaking the automation
+ * loop. Agent360dk's idiom — open a Gmail tab, fetch the newest
+ * matching message, pull the six-digit code — collapses that back
+ * into automation.
+ *
+ * Scope
+ * -----
+ * This module is deliberately **transport-agnostic**. Callers supply
+ * the message text (or subject) — from the Gmail tab openchrome
+ * already drives, from IMAP, from a Graph API fetch, from a webhook.
+ * The core is a parser plus a small strategy layer for common
+ * template patterns.
+ *
+ * Design
+ * ------
+ * - `extractOtp(text, opts)` returns the strongest matching code,
+ *   preferring:
+ *     1. explicit code-marker patterns ("Your code is 123456", "OTP:
+ *        123456", "verification code 123456") over
+ *     2. isolated 6-digit runs in a short subject line over
+ *     3. any 4-8 digit run in the body that is not adjacent to
+ *        currency, dates, phone numbers, or reference numbers.
+ * - Locale-tolerant markers cover English, Korean ("인증 번호",
+ *   "확인 코드"), and generic OTP labels. Extendable via
+ *   `opts.extraMarkers`.
+ * - Time-window filter — reject codes whose surrounding text hints at
+ *   expiry already passed. Optional; default off.
+ * - Batch API `pickNewestOtp(messages)` for the common Gmail case
+ *   (fetch last N inbox items, take the first with a valid code).
+ *
+ * Origin credit
+ * -------------
+ * Idiom from Agent360dk's Gmail OTP flow (MIT). Clean-room parser;
+ * no upstream code copied.
+ */
+
+export interface OtpExtractionOptions {
+  /**
+   * Expected code length range. Default: [4, 8]. Codes outside this
+   * range are ignored.
+   */
+  lengthRange?: [number, number];
+  /** Additional marker patterns to try before the generic scan. */
+  extraMarkers?: readonly RegExp[];
+  /**
+   * When true, only accept codes flanked by whitespace / punctuation
+   * (not embedded in longer digit strings). Default: true.
+   */
+  standaloneOnly?: boolean;
+}
+
+export interface OtpMatch {
+  code: string;
+  /** Which parsing tier produced the match. */
+  tier: 'marker' | 'subject' | 'body';
+  /** Confidence 0..1. Marker matches are 1.0; body scans decay by count. */
+  confidence: number;
+}
+
+const DEFAULT_MARKERS: RegExp[] = [
+  // English
+  /(?:your\s+(?:code|otp|verification\s+code|security\s+code)\s+(?:is\s+)?)(\d{4,8})/i,
+  /(?:code\s*[:\-]?\s*)(\d{4,8})/i,
+  /(?:otp\s*[:\-]?\s*)(\d{4,8})/i,
+  /(?:verification\s+code\s*[:\-]?\s*)(\d{4,8})/i,
+  // Korean
+  /(?:인증\s*번호\s*(?:는|:|\-)?\s*)(\d{4,8})/,
+  /(?:확인\s*코드\s*(?:는|:|\-)?\s*)(\d{4,8})/,
+  /(?:일회용\s*비밀번호\s*(?:는|:|\-)?\s*)(\d{4,8})/,
+];
+
+const REJECT_NEIGHBOURS = /[$₩¥€£]|\d{4}-\d{2}-\d{2}|\d{3,4}[-\s]\d{3,4}[-\s]\d{4}/;
+
+/**
+ * Extract the strongest OTP candidate from a text blob. Returns null
+ * when no candidate meets the length/format constraints.
+ */
+export function extractOtp(text: string, opts: OtpExtractionOptions = {}): OtpMatch | null {
+  if (typeof text !== 'string' || text.length === 0) return null;
+  const [minLen, maxLen] = opts.lengthRange ?? [4, 8];
+  if (minLen < 3 || maxLen > 12 || minLen > maxLen) {
+    throw new RangeError(`extractOtp: invalid lengthRange [${minLen}, ${maxLen}]`);
+  }
+
+  // Tier 1 — explicit markers
+  const markers = [...DEFAULT_MARKERS, ...(opts.extraMarkers ?? [])];
+  for (const re of markers) {
+    const m = re.exec(text);
+    if (m && m[1]) {
+      const code = m[1];
+      if (code.length >= minLen && code.length <= maxLen) {
+        return { code, tier: 'marker', confidence: 1.0 };
+      }
+    }
+  }
+
+  // Tier 2 — subject line (heuristic: first non-empty line, ≤80 chars)
+  const firstLine = text.split(/\r?\n/, 1)[0] ?? '';
+  if (firstLine.length > 0 && firstLine.length <= 80) {
+    const subj = extractStandaloneDigits(firstLine, minLen, maxLen);
+    if (subj) return { code: subj, tier: 'subject', confidence: 0.7 };
+  }
+
+  // Tier 3 — body scan
+  const bodyCodes = collectStandaloneDigits(text, minLen, maxLen, opts.standaloneOnly !== false);
+  if (bodyCodes.length === 0) return null;
+  // Confidence decays with candidate count: 1 candidate ≈ 0.6, more → lower.
+  const confidence = Math.max(0.2, 0.6 - 0.1 * (bodyCodes.length - 1));
+  return { code: bodyCodes[0], tier: 'body', confidence };
+}
+
+/**
+ * Batch API — iterate messages in order and return the first with a
+ * valid extraction result. Each element is `{ text, receivedAt? }`;
+ * the runner sorts by `receivedAt` desc if provided.
+ */
+export interface EmailMessage {
+  text: string;
+  receivedAt?: Date | number;
+}
+
+export function pickNewestOtp(
+  messages: readonly EmailMessage[],
+  opts: OtpExtractionOptions = {},
+): { message: EmailMessage; match: OtpMatch } | null {
+  const sorted = [...messages].sort((a, b) => {
+    const ta = a.receivedAt ? +new Date(a.receivedAt) : 0;
+    const tb = b.receivedAt ? +new Date(b.receivedAt) : 0;
+    return tb - ta;
+  });
+  for (const msg of sorted) {
+    const match = extractOtp(msg.text, opts);
+    if (match) return { message: msg, match };
+  }
+  return null;
+}
+
+// --- helpers ---------------------------------------------------------------
+
+function extractStandaloneDigits(line: string, minLen: number, maxLen: number): string | null {
+  const re = new RegExp(`(?<![\\d])(\\d{${minLen},${maxLen}})(?![\\d])`);
+  const m = re.exec(line);
+  return m ? m[1] : null;
+}
+
+function collectStandaloneDigits(
+  text: string,
+  minLen: number,
+  maxLen: number,
+  standaloneOnly: boolean,
+): string[] {
+  const re = standaloneOnly
+    ? new RegExp(`(?<![\\d])(\\d{${minLen},${maxLen}})(?![\\d])`, 'g')
+    : new RegExp(`(\\d{${minLen},${maxLen}})`, 'g');
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const code = m[1];
+    if (out.includes(code)) continue;
+    // Reject when surrounded by currency, dates, phone-number-like patterns.
+    // Window is wide enough to catch a full 3-4-4 phone pattern that straddles
+    // the match position (e.g. `010 1234 5678` where `1234` is the match).
+    const window = text.slice(Math.max(0, m.index - 16), Math.min(text.length, m.index + code.length + 16));
+    if (REJECT_NEIGHBOURS.test(window)) continue;
+    out.push(code);
+  }
+  return out;
+}

--- a/tests/auth/email-otp-reader.test.ts
+++ b/tests/auth/email-otp-reader.test.ts
@@ -1,0 +1,123 @@
+import { extractOtp, pickNewestOtp } from '../../src/auth/email-otp-reader';
+
+describe('email OTP reader (P17)', () => {
+  describe('extractOtp — tier 1 marker patterns', () => {
+    test.each([
+      ['Your code is 123456.', '123456'],
+      ['Your verification code is 928374 - expires in 5m', '928374'],
+      ['OTP: 4321', '4321'],
+      ['code - 987654', '987654'],
+      ['Verification Code: 12345', '12345'],
+    ])('EN marker: %s → %s', (text, expected) => {
+      const m = extractOtp(text);
+      expect(m?.code).toBe(expected);
+      expect(m?.tier).toBe('marker');
+      expect(m?.confidence).toBe(1.0);
+    });
+
+    test.each([
+      ['인증 번호는 246810 입니다', '246810'],
+      ['확인 코드: 135790', '135790'],
+      ['일회용 비밀번호 - 555444', '555444'],
+    ])('KR marker: %s → %s', (text, expected) => {
+      const m = extractOtp(text);
+      expect(m?.code).toBe(expected);
+      expect(m?.tier).toBe('marker');
+    });
+  });
+
+  describe('extractOtp — tier 2 subject line', () => {
+    test('short subject with isolated code', () => {
+      const m = extractOtp('321654\n\nThe rest of the email body goes on and mentions the year 2026 several times.');
+      expect(m?.code).toBe('321654');
+      expect(m?.tier).toBe('subject');
+    });
+    test('long first line disqualifies subject tier', () => {
+      const text = 'This is a very long subject line that is definitely more than eighty characters long and 111222 sits in it';
+      const m = extractOtp(text);
+      expect(m?.tier).not.toBe('subject');
+    });
+  });
+
+  describe('extractOtp — tier 3 body scan', () => {
+    test('finds isolated code in body', () => {
+      const text = 'Hello,\nPlease use 314159 to sign in.\nRegards.';
+      const m = extractOtp(text);
+      expect(m?.code).toBe('314159');
+    });
+    test('rejects codes adjacent to currency', () => {
+      const text = 'Body\nInvoice total: $998877.\nSee attached PDF for details.';
+      const m = extractOtp(text);
+      expect(m?.code).not.toBe('998877');
+    });
+    test('rejects codes adjacent to date-like patterns', () => {
+      const text = 'Body\nMeeting on 2026-05-28 at HQ.\n';
+      const m = extractOtp(text);
+      // Bare "2026" is 4 digits but surrounded by date pattern — rejected.
+      expect(m).toBeNull();
+    });
+    test('rejects phone-number-like triples', () => {
+      const text = 'Body\nCall us at 010 1234 5678 anytime.';
+      const m = extractOtp(text);
+      expect(m).toBeNull();
+    });
+  });
+
+  describe('extractOtp — options', () => {
+    test('respects lengthRange', () => {
+      const text = 'Something 12 34567890 something';
+      const m = extractOtp(text, { lengthRange: [6, 6] });
+      // 12 too short, 34567890 too long, nothing matches marker/subject.
+      expect(m).toBeNull();
+    });
+    test('extraMarkers picks vendor-specific pattern', () => {
+      const text = 'Nifty security phrase 909090 stamp';
+      const m = extractOtp(text, { extraMarkers: [/(?:phrase\s+)(\d{4,8})/] });
+      expect(m?.code).toBe('909090');
+      expect(m?.tier).toBe('marker');
+    });
+    test('standaloneOnly:false accepts embedded digits', () => {
+      const text = 'ref_id 9998887 ends here';
+      const strict = extractOtp(text);
+      const loose = extractOtp(text, { standaloneOnly: false });
+      expect(strict?.code).toBe('9998887');
+      expect(loose?.code).toBe('9998887');
+    });
+    test('invalid lengthRange throws', () => {
+      expect(() => extractOtp('x', { lengthRange: [2, 6] })).toThrow(RangeError);
+      expect(() => extractOtp('x', { lengthRange: [6, 20] })).toThrow(RangeError);
+      expect(() => extractOtp('x', { lengthRange: [8, 4] })).toThrow(RangeError);
+    });
+    test('empty text → null', () => {
+      expect(extractOtp('')).toBeNull();
+    });
+  });
+
+  describe('pickNewestOtp', () => {
+    test('picks the newest message with a valid code', () => {
+      const messages = [
+        { text: 'old code is 111111', receivedAt: new Date('2024-01-01') },
+        { text: 'Your code is 222222', receivedAt: new Date('2026-06-01') },
+        { text: 'unrelated', receivedAt: new Date('2026-07-01') },
+      ];
+      const r = pickNewestOtp(messages);
+      // Sorted newest first — but newest has no code, so falls to 2026-06-01.
+      expect(r?.match.code).toBe('222222');
+    });
+    test('returns null when no message has a code', () => {
+      const messages = [
+        { text: 'hi', receivedAt: 1 },
+        { text: 'bye', receivedAt: 2 },
+      ];
+      expect(pickNewestOtp(messages)).toBeNull();
+    });
+    test('missing receivedAt is treated as oldest', () => {
+      const messages = [
+        { text: 'no timestamp with code 313131' },
+        { text: 'Your code is 424242', receivedAt: new Date('2026-06-01') },
+      ];
+      const r = pickNewestOtp(messages);
+      expect(r?.match.code).toBe('424242');
+    });
+  });
+});

--- a/tests/auth/vault-adapter.test.ts
+++ b/tests/auth/vault-adapter.test.ts
@@ -1,0 +1,165 @@
+import {
+  coerceCredentials,
+  KeychainVaultAdapter,
+  KmsVaultAdapter,
+  parseCredentialBlob,
+  type CiphertextLoader,
+  type DecryptFn,
+  type KeychainLike,
+} from '../../src/auth/adapters/vault-adapter';
+
+describe('vault credential adapters (P17)', () => {
+  describe('parseCredentialBlob / coerceCredentials', () => {
+    test('valid blob returns credentials', () => {
+      expect(parseCredentialBlob('{"username":"u","password":"p"}')).toEqual({ username: 'u', password: 'p' });
+    });
+    test('includes optional totpSecret', () => {
+      expect(parseCredentialBlob('{"username":"u","password":"p","totpSecret":"JBSWY3DPEHPK3PXP"}')).toEqual({
+        username: 'u',
+        password: 'p',
+        totpSecret: 'JBSWY3DPEHPK3PXP',
+      });
+    });
+    test('missing username → null', () => {
+      expect(parseCredentialBlob('{"password":"p"}')).toBeNull();
+    });
+    test('malformed JSON → null', () => {
+      expect(parseCredentialBlob('not-json')).toBeNull();
+    });
+    test('coerceCredentials rejects non-object', () => {
+      expect(coerceCredentials(null)).toBeNull();
+      expect(coerceCredentials(42)).toBeNull();
+      expect(coerceCredentials([])).toEqual(null);
+    });
+  });
+
+  describe('KeychainVaultAdapter', () => {
+    function makeKeychain(entries: Record<string, string>, indexDomains?: string[]): KeychainLike {
+      return {
+        async getPassword(service, account) {
+          if (service === 'openchrome' && account === '__index__') {
+            return indexDomains ? JSON.stringify(indexDomains) : null;
+          }
+          return entries[`${service}|${account}`] ?? null;
+        },
+        async findCredentials(service) {
+          return Object.keys(entries)
+            .filter((k) => k.startsWith(`${service}|`) || k.startsWith(`${service}:`))
+            .map((k) => {
+              const [, account] = k.split('|');
+              return { account, password: entries[k] };
+            });
+        },
+      };
+    }
+
+    test('constructor rejects missing keychain', () => {
+      expect(() => new KeychainVaultAdapter({} as any)).toThrow(TypeError);
+    });
+
+    test('getCredentials returns parsed blob', async () => {
+      const kc = makeKeychain({
+        'openchrome:example.com|credentials': '{"username":"alice","password":"pw"}',
+      });
+      const v = new KeychainVaultAdapter({ keychain: kc });
+      const c = await v.getCredentials('example.com');
+      expect(c).toEqual({ username: 'alice', password: 'pw' });
+    });
+
+    test('getCredentials returns null when missing', async () => {
+      const kc = makeKeychain({});
+      const v = new KeychainVaultAdapter({ keychain: kc });
+      expect(await v.getCredentials('missing.com')).toBeNull();
+    });
+
+    test('listDomains reads __index__ entry', async () => {
+      const kc = makeKeychain({}, ['a.com', 'b.com']);
+      const v = new KeychainVaultAdapter({ keychain: kc });
+      expect(await v.listDomains()).toEqual(['a.com', 'b.com']);
+    });
+
+    test('listDomains without index returns []', async () => {
+      const kc = makeKeychain({});
+      const v = new KeychainVaultAdapter({ keychain: kc });
+      expect(await v.listDomains()).toEqual([]);
+    });
+
+    test('isAvailable false when keychain throws', async () => {
+      const kc: KeychainLike = {
+        async getPassword() { return null; },
+        async findCredentials() { throw new Error('locked'); },
+      };
+      const v = new KeychainVaultAdapter({ keychain: kc });
+      expect(await v.isAvailable()).toBe(false);
+    });
+
+    test('custom servicePrefix + account', async () => {
+      const kc = makeKeychain({
+        'myapp:x.com|prod': '{"username":"u","password":"p"}',
+      });
+      const v = new KeychainVaultAdapter({ keychain: kc, servicePrefix: 'myapp', account: 'prod' });
+      expect(await v.getCredentials('x.com')).toEqual({ username: 'u', password: 'p' });
+    });
+  });
+
+  describe('KmsVaultAdapter', () => {
+    const blob = JSON.stringify({
+      'a.com': { username: 'ua', password: 'pa' },
+      'b.com': { username: 'ub', password: 'pb', totpSecret: 'ABCDEF' },
+    });
+
+    const load: CiphertextLoader = async () => Buffer.from(blob);
+    const decrypt: DecryptFn = async (buf) => buf.toString('utf8');
+
+    test('constructor validates load and decrypt', () => {
+      expect(() => new KmsVaultAdapter({} as any)).toThrow(TypeError);
+      expect(() => new KmsVaultAdapter({ load } as any)).toThrow(TypeError);
+    });
+
+    test('getCredentials looks up by domain', async () => {
+      const v = new KmsVaultAdapter({ load, decrypt });
+      expect(await v.getCredentials('a.com')).toEqual({ username: 'ua', password: 'pa' });
+      expect(await v.getCredentials('b.com')).toEqual({ username: 'ub', password: 'pb', totpSecret: 'ABCDEF' });
+      expect(await v.getCredentials('nope.com')).toBeNull();
+    });
+
+    test('listDomains returns sorted keys', async () => {
+      const v = new KmsVaultAdapter({ load, decrypt });
+      expect(await v.listDomains()).toEqual(['a.com', 'b.com']);
+    });
+
+    test('cache: second call does not invoke load again', async () => {
+      const loadFn = jest.fn(load);
+      const v = new KmsVaultAdapter({ load: loadFn, decrypt });
+      await v.getCredentials('a.com');
+      await v.getCredentials('b.com');
+      expect(loadFn).toHaveBeenCalledTimes(1);
+    });
+
+    test('cache: false reloads every call', async () => {
+      const loadFn = jest.fn(load);
+      const v = new KmsVaultAdapter({ load: loadFn, decrypt, cache: false });
+      await v.getCredentials('a.com');
+      await v.getCredentials('b.com');
+      expect(loadFn).toHaveBeenCalledTimes(2);
+    });
+
+    test('rejects non-object blob', async () => {
+      const badLoad: CiphertextLoader = async () => Buffer.from('[]');
+      const v = new KmsVaultAdapter({ load: badLoad, decrypt });
+      await expect(v.getCredentials('x')).rejects.toThrow(/JSON object/);
+    });
+
+    test('isAvailable false when decrypt throws', async () => {
+      const failDecrypt: DecryptFn = async () => { throw new Error('no key'); };
+      const v = new KmsVaultAdapter({ load, decrypt: failDecrypt });
+      expect(await v.isAvailable()).toBe(false);
+    });
+
+    test('accepts string plaintext from decrypt', async () => {
+      const decryptStr: DecryptFn = async (buf) => buf.toString('utf8');
+      const v = new KmsVaultAdapter({ load, decrypt: decryptStr });
+      expect(await v.getCredentials('a.com')).toEqual({ username: 'ua', password: 'pa' });
+    });
+  });
+});


### PR DESCRIPTION
## 요약

엔터프라이즈에서 openchrome을 붙일 때 기존 provider가 커버 못 하는 두 갈래가 반복적으로 필요합니다:

1. Secret material을 on-disk AES-GCM이나 1Password/Bitwarden CLI 대신 **KMS-암호화 blob** 또는 **OS keychain**(macOS Keychain, Windows Credential Vault, Linux libsecret)에서 읽기.
2. Email second factor 로그인을 **사람이 mail client에서 6자리를 손으로 옮기지 않고** 완결 — 에이전트가 이미 조종 중인 Gmail 탭에서 코드를 뽑아 오기.

이 팩은 두 갈래를 다 추가하되, 기존 `CredentialProvider` surface를 건드리지 않아 `provider.listDomains()`를 순회하는 도구들이 그대로 돕니다.

## 근거

Sonar의 openchrome 상류 기여 재판정(v2)의 **P17** 팩입니다. 원본:

- **notte** (SSPL) · `Vault` 관용구. "KMS decrypt 원시체"와 "domain별 lookup"을 분리해 두 층을 독립적으로 교체 가능.
- **Agent360dk** (MIT) · 이미 열어둔 Gmail 탭에서 OTP를 파싱해 로그인 자동화 루프를 닫는 관용구.

원본 코드는 복사하지 않았습니다. 두 프로젝트의 shape·contract만 참조한 clean-room 구현입니다.

## 변경 내용

### 신규 · `src/auth/adapters/vault-adapter.ts` (+238 라인)

- **`KeychainVaultAdapter`** · `KeychainLike` 객체(전형적으로 caller가 entrypoint에서 `require('keytar')`한 결과)를 받음. openchrome-mcp 자체는 `keytar`에 의존 안 함 — `{ getPassword, findCredentials }` 최소 인터페이스만 요구.
  - 저장 layout · service=`openchrome:<domain>`, account=`credentials`, 값=JSON blob.
  - 열거 · 자매 `__index__` 엔트리(known domain의 JSON 배열)를 읽음.
  - 커스텀 `servicePrefix`·`account` 지원 · 같은 keychain을 다른 도구와 공유하는 caller 대비.

- **`KmsVaultAdapter`** · `{ load, decrypt, cache? }`. `load`는 caller가 어디에 저장했든 암호문 바이트를 반환(localfs·S3·secretsmanager). `decrypt`는 caller가 AWS KMS / GCP KMS / Vault Transit / 하드웨어 키를 배선하는 지점 — openchrome-mcp는 그중 어느 것에도 의존 안 함.
  - Plaintext는 domain-keyed JSON object. In-memory cache 기본 on; `cache: false`면 매 호출 재decrypt(KMS 키 로테이션 즉시 반영).

- 공용 `parseCredentialBlob()` / `coerceCredentials()` · 반쯤 채워진 blob이 브라우저 flow로 새어들어가지 않도록 parse 시점에 거부.

### 신규 · `src/auth/email-otp-reader.ts` (+176 라인)

Transport-agnostic 파서 — caller가 message text(Gmail 탭·IMAP·Graph API 뭐든)를 넘기면 `{ code, tier, confidence }` 반환. 3-tier 파싱:

1. **Explicit marker patterns** · EN("Your code is ###", "OTP: ###", "verification code ###") + KR("인증 번호", "확인 코드", "일회용 비밀번호"). `extraMarkers`로 벤더별 확장 가능.
2. **Subject line** · 첫 non-empty line ≤80자, 목표 길이의 isolated digit run.
3. **Body scan** · 4-8자 digit run, 기본 standalone(더 긴 digit string에 임베드 X), 통화($/₩/¥/€/£)·ISO 날짜(2026-05-28)·전화번호형 triple(010 1234 5678) 인접 rejection 윈도.

`pickNewestOtp()` · `receivedAt` desc 정렬 후 첫 매치 반환 — 흔한 Gmail 케이스.

## 테스트

- `tests/auth/vault-adapter.test.ts` · 20 케이스.
- `tests/auth/email-otp-reader.test.ts` · 22 케이스.

빌드:
- `node_modules/.bin/tsc -p tsconfig.json --noEmit` · 0 errors.
- `node_modules/.bin/jest tests/auth/vault-adapter.test.ts tests/auth/email-otp-reader.test.ts` · 42 passed.

## 참고

- v2 계획서 · `docs/rebirth/OPENCHROME-CONTRIBUTION-PLAN-V2.md` §5 P17
- 90개 전수 근거 · `docs/rebirth/ULTIMATE-CENSUS-2026-07-18.md`
- 원본 코드 미열람 clean-room 구현. 각 파일 상단 주석에 origin credit.

## 관련

이 팩은 v2 계획의 **P17** 팩입니다. Batch 2의 6개 팩(P2·P3·P14·P15·P18·P21)이 동시에 별도 PR로 제출됩니다.