### PR TITLE
feat(session): fleet lease with background/foreground lane isolation

### DIFF
--- a/docs/orchestration/fleet-non-focus.md
+++ b/docs/orchestration/fleet-non-focus.md
@@ -1,0 +1,79 @@
+---
+doc_kind: project-material
+status: working
+version: 2026-07-21_v1
+canonical_path: /home/elite/projects/tools/references/openchrome-fork-b2/docs/orchestration/fleet-non-focus.md
+---
+
+# Fleet lease · non-focus (background) driving
+
+`FleetLease` (src/session/fleet-lease.ts) lets a worker be marked
+`background: true`. The intent is that CDP commands the driver
+issues against that worker must not raise the tab or the browser
+window to focus — every desktop OS treats focus activation as an
+event, and stealth vendors fingerprint it.
+
+## Command allowlist (safe for background)
+
+- Target lifecycle · `Target.attachToTarget`, `Target.detachFromTarget`,
+  `Target.createTarget` (only with `background: true` param on Chromium
+  builds that support it).
+- Page state · `Page.reload`, `Page.navigate` (does not steal focus
+  when target is background), `Page.setLifecycleEventsEnabled`.
+- DOM / Runtime evaluation · `Runtime.evaluate`, `DOM.querySelector`,
+  `DOM.getBoxModel`, `Accessibility.getFullAXTree`.
+- Network · `Network.enable`, `Network.setCacheDisabled`,
+  `Network.getCookies`.
+- Storage · `Storage.setCookies`, `IndexedDB.*`, `CacheStorage.*`.
+- Screenshotting `Page.captureScreenshot` with `fromSurface: true`
+  reads the compositor surface without a focus change.
+
+## Command denylist (raise focus)
+
+- `Page.bringToFront` — the whole point of background mode is to
+  avoid this call. Refuse it in the background driver's dispatcher.
+- `Input.dispatchMouseEvent` at coordinates covered by another
+  window — on many OSes this activates the tab. Prefer
+  `Runtime.evaluate` synth-clicks via `element.click()` for
+  background tabs.
+- `Input.dispatchKeyEvent` on macOS — depending on the target's
+  frame chain, key events may raise the window. Use
+  `Runtime.evaluate` to dispatch key events synthesised in-page.
+- `Emulation.setFocusEmulationEnabled(false)` toggled at runtime
+  can force focus recovery paths in web content — leave it on the
+  default the tab was created with.
+
+## Acquiring a background lease
+
+```ts
+import { FleetLease } from 'openchrome-mcp/dist/session/fleet-lease';
+
+const pool = new FleetLease();
+pool.register('worker-fg-1');
+pool.register('worker-bg-1', { background: true, label: 'crawler' });
+pool.register('worker-bg-2', { background: true, label: 'crawler' });
+
+// Foreground driver — will only see worker-fg-1
+const fg = pool.acquire({ sessionId: 'user-1', ttlMs: 60_000 });
+
+// Background driver — will only see worker-bg-1 or worker-bg-2
+const bg = pool.acquire({
+  sessionId: 'crawler-1', ttlMs: 60_000, preferBackground: true,
+});
+```
+
+The lease primitive enforces the flag by never handing a background
+worker to a caller that did not set `preferBackground: true`, and
+vice versa. Callers cannot cross the lane by accident.
+
+## Sweep cadence
+
+Leases carry an expiry (`expiresAt`) so a crashed driver does not
+starve the pool. Callers arm a periodic timer that calls
+`pool.sweep()` — a good default is `ttlMs / 4`. Sweep and acquire
+are race-free because the pool serialises on the JS single thread.
+
+## Origin credit
+
+Idiom from trycua's Fleet Lease primitive (MIT). Clean-room
+implementation in `src/session/fleet-lease.ts`.

--- a/src/session/fleet-lease.ts
+++ b/src/session/fleet-lease.ts
@@ -1,0 +1,227 @@
+/**
+ * Fleet lease — worker-scoped rotating browser pool with lease TTL.
+ *
+ * Why this exists
+ * ---------------
+ * openchrome's `TargetLeaseRegistry` (src/session/target-lease-registry.ts)
+ * tracks lease ownership at the **target** level — one CDP target ↔ one
+ * session. That's the right primitive for a single-user, single-Chrome
+ * layout, but for two other patterns it leaves gaps:
+ *
+ *  1. A **fleet** of Chrome workers — an operator running several
+ *     independent tabs or profiles in parallel, each with its own
+ *     lifecycle. The registry needs to answer "which worker owns which
+ *     lease right now, and which worker is next in line?"
+ *  2. A **background non-focus** worker — a lease that lives on a tab
+ *     the user is not looking at. openchrome must be able to acquire,
+ *     drive, and release the lease **without** raising the tab to
+ *     focus (which every desktop OS treats as an activation event and
+ *     stealth vendors then fingerprint).
+ *
+ * trycua's Fleet Lease primitive answers both: an in-memory pool of
+ * `workerId → { available|leased, until, activatedBy }` entries with
+ * `acquire()` / `renew()` / `release()` returning a `LeaseHandle`
+ * carrying the id and expiry.
+ *
+ * Design
+ * ------
+ * - `FleetLease` is a pure in-process orchestrator. It does not spawn
+ *   or touch Chrome — that's the launcher's job. Callers wire it into
+ *   whatever spawn/attach layer they use.
+ * - Registration: `register(workerId, meta?)` adds an entry to the
+ *   pool. Registering the same id twice replaces the meta but keeps
+ *   the lease state.
+ * - Acquire: `acquire({ sessionId, ttlMs, avoid?, preferBackground? })`
+ *   picks the first eligible worker (available, not in avoid[], and
+ *   optionally marked backgroundable). Returns a `LeaseHandle` or
+ *   null when the pool is exhausted.
+ * - Renew: `renew(handle, ttlMs)` slides expiry forward. Rejects
+ *   handles whose lease has already been reclaimed by expiry.
+ * - Release: `release(handle)` returns the worker to the pool.
+ * - Sweep: `sweep(nowMs?)` reclaims expired leases. Callers arm a
+ *   timer that calls this periodically; the pool is race-free
+ *   because sweep-then-acquire is serialised in JS's single thread.
+ *
+ * Non-focus idiom
+ * ---------------
+ * `LeaseMeta.background = true` marks a worker whose CDP session may
+ * only be driven with commands that do **not** raise the tab to
+ * focus. Currently the flag is a hint the caller passes through to
+ * its own driver layer — see `docs/orchestration/fleet-non-focus.md`
+ * for the recommended CDP command list (Page.reload, Target.attachToTarget,
+ * DOM/Runtime evaluation) and the ones to avoid (`Page.bringToFront`,
+ * `Input.dispatchMouseEvent` at coordinates covered by another
+ * window). The lease primitive enforces the flag by refusing to
+ * hand out background workers to callers that did not opt in via
+ * `preferBackground` — a foreground driver cannot accidentally take
+ * a background lease.
+ *
+ * Origin credit
+ * -------------
+ * Idiom from trycua's Fleet Lease primitive (MIT). Clean-room
+ * implementation; no upstream code copied.
+ */
+
+export type LeaseState = 'available' | 'leased';
+
+export interface LeaseMeta {
+  /**
+   * When true, this worker is expected to be driven without raising
+   * the tab to focus. Foreground callers get skipped over this
+   * worker unless they explicitly set `preferBackground: false` (in
+   * which case they still get skipped — the flag is worker-side).
+   */
+  background?: boolean;
+  /** Free-form label; useful for logs and dashboards. */
+  label?: string;
+}
+
+export interface LeaseHandle {
+  readonly workerId: string;
+  readonly sessionId: string;
+  readonly expiresAt: number;
+  readonly issuedAt: number;
+  /** Opaque token that identifies this lease instance. Renewals check it. */
+  readonly token: string;
+}
+
+export interface AcquireOptions {
+  sessionId: string;
+  ttlMs: number;
+  /** Skip these workers even if available. */
+  avoid?: readonly string[];
+  /**
+   * When true, only pick workers whose `LeaseMeta.background === true`.
+   * When false or undefined, only pick workers whose background flag is
+   * false/undefined. This is the opt-in that keeps a foreground driver
+   * from grabbing a background lease.
+   */
+  preferBackground?: boolean;
+}
+
+interface WorkerEntry {
+  workerId: string;
+  meta: LeaseMeta;
+  state: LeaseState;
+  handle: LeaseHandle | null;
+}
+
+let _tokenCounter = 0;
+function mintToken(): string {
+  _tokenCounter += 1;
+  return `lh-${Date.now().toString(36)}-${_tokenCounter.toString(36)}`;
+}
+
+export class FleetLease {
+  private readonly workers = new Map<string, WorkerEntry>();
+
+  register(workerId: string, meta: LeaseMeta = {}): void {
+    if (typeof workerId !== 'string' || workerId.length === 0) {
+      throw new TypeError('FleetLease.register: workerId must be a non-empty string');
+    }
+    const existing = this.workers.get(workerId);
+    if (existing) {
+      existing.meta = { ...existing.meta, ...meta };
+      return;
+    }
+    this.workers.set(workerId, {
+      workerId,
+      meta: { ...meta },
+      state: 'available',
+      handle: null,
+    });
+  }
+
+  unregister(workerId: string): void {
+    this.workers.delete(workerId);
+  }
+
+  /** All registered worker ids, in insertion order. */
+  ids(): string[] {
+    return [...this.workers.keys()];
+  }
+
+  /** Snapshot of pool state — for dashboards. */
+  snapshot(): { workerId: string; state: LeaseState; meta: LeaseMeta; expiresAt: number | null }[] {
+    return [...this.workers.values()].map((w) => ({
+      workerId: w.workerId,
+      state: w.state,
+      meta: { ...w.meta },
+      expiresAt: w.handle ? w.handle.expiresAt : null,
+    }));
+  }
+
+  acquire(opts: AcquireOptions, nowMs: number = Date.now()): LeaseHandle | null {
+    if (!opts || typeof opts.sessionId !== 'string' || opts.sessionId.length === 0) {
+      throw new TypeError('FleetLease.acquire: opts.sessionId required');
+    }
+    if (typeof opts.ttlMs !== 'number' || opts.ttlMs <= 0) {
+      throw new RangeError('FleetLease.acquire: opts.ttlMs must be > 0');
+    }
+    // Reclaim expired leases first so the acquire is race-free with sweep.
+    this.reclaimExpired(nowMs);
+    const avoid = new Set(opts.avoid ?? []);
+    const wantBackground = opts.preferBackground === true;
+    for (const entry of this.workers.values()) {
+      if (entry.state !== 'available') continue;
+      if (avoid.has(entry.workerId)) continue;
+      const isBackground = entry.meta.background === true;
+      if (wantBackground !== isBackground) continue;
+      const handle: LeaseHandle = {
+        workerId: entry.workerId,
+        sessionId: opts.sessionId,
+        issuedAt: nowMs,
+        expiresAt: nowMs + opts.ttlMs,
+        token: mintToken(),
+      };
+      entry.state = 'leased';
+      entry.handle = handle;
+      return handle;
+    }
+    return null;
+  }
+
+  renew(handle: LeaseHandle, ttlMs: number, nowMs: number = Date.now()): LeaseHandle | null {
+    if (typeof ttlMs !== 'number' || ttlMs <= 0) {
+      throw new RangeError('FleetLease.renew: ttlMs must be > 0');
+    }
+    const entry = this.workers.get(handle.workerId);
+    if (!entry || entry.state !== 'leased' || !entry.handle) return null;
+    if (entry.handle.token !== handle.token) return null;
+    const renewed: LeaseHandle = {
+      ...entry.handle,
+      expiresAt: nowMs + ttlMs,
+    };
+    entry.handle = renewed;
+    return renewed;
+  }
+
+  release(handle: LeaseHandle): boolean {
+    const entry = this.workers.get(handle.workerId);
+    if (!entry || !entry.handle) return false;
+    if (entry.handle.token !== handle.token) return false;
+    entry.state = 'available';
+    entry.handle = null;
+    return true;
+  }
+
+  /**
+   * Reclaim any lease whose expiry has passed. Returns the number
+   * reclaimed. Callers arm a timer to run this periodically.
+   */
+  sweep(nowMs: number = Date.now()): number {
+    return this.reclaimExpired(nowMs);
+  }
+
+  private reclaimExpired(nowMs: number): number {
+    let n = 0;
+    for (const entry of this.workers.values()) {
+      if (entry.state === 'leased' && entry.handle && entry.handle.expiresAt <= nowMs) {
+        entry.state = 'available';
+        entry.handle = null;
+        n += 1;
+      }
+    }
+    return n;
+  }
+}

--- a/tests/session/fleet-lease.test.ts
+++ b/tests/session/fleet-lease.test.ts
@@ -1,0 +1,173 @@
+import { FleetLease, LeaseHandle } from '../../src/session/fleet-lease';
+
+describe('FleetLease (P18)', () => {
+  let pool: FleetLease;
+  beforeEach(() => {
+    pool = new FleetLease();
+  });
+
+  describe('register / unregister', () => {
+    test('register adds a worker to the pool', () => {
+      pool.register('w1');
+      expect(pool.ids()).toEqual(['w1']);
+    });
+    test('duplicate register merges meta, keeps state', () => {
+      pool.register('w1', { label: 'a' });
+      const h = pool.acquire({ sessionId: 's1', ttlMs: 1000 })!;
+      pool.register('w1', { label: 'b' });
+      const snap = pool.snapshot().find((s) => s.workerId === 'w1')!;
+      expect(snap.meta.label).toBe('b');
+      expect(snap.state).toBe('leased');
+      pool.release(h);
+    });
+    test('unregister removes the worker', () => {
+      pool.register('w1');
+      pool.unregister('w1');
+      expect(pool.ids()).toEqual([]);
+    });
+    test('rejects empty workerId', () => {
+      expect(() => pool.register('')).toThrow(TypeError);
+    });
+  });
+
+  describe('acquire', () => {
+    test('returns null for empty pool', () => {
+      expect(pool.acquire({ sessionId: 's', ttlMs: 100 })).toBeNull();
+    });
+    test('picks first available and marks it leased', () => {
+      pool.register('w1');
+      pool.register('w2');
+      const h = pool.acquire({ sessionId: 's', ttlMs: 100, }, 1000)!;
+      expect(h.workerId).toBe('w1');
+      expect(h.expiresAt).toBe(1100);
+      expect(h.sessionId).toBe('s');
+      expect(pool.snapshot().find((s) => s.workerId === 'w1')?.state).toBe('leased');
+    });
+    test('skips leased workers', () => {
+      pool.register('w1');
+      pool.register('w2');
+      pool.acquire({ sessionId: 's1', ttlMs: 1000 });
+      const h2 = pool.acquire({ sessionId: 's2', ttlMs: 1000 })!;
+      expect(h2.workerId).toBe('w2');
+    });
+    test('respects avoid list', () => {
+      pool.register('w1');
+      pool.register('w2');
+      const h = pool.acquire({ sessionId: 's', ttlMs: 1000, avoid: ['w1'] })!;
+      expect(h.workerId).toBe('w2');
+    });
+    test('foreground driver never gets a background worker', () => {
+      pool.register('bg', { background: true });
+      expect(pool.acquire({ sessionId: 's', ttlMs: 100 })).toBeNull();
+    });
+    test('background driver never gets a foreground worker', () => {
+      pool.register('fg');
+      expect(pool.acquire({ sessionId: 's', ttlMs: 100, preferBackground: true })).toBeNull();
+    });
+    test('mixed pool routes to correct lane', () => {
+      pool.register('fg1');
+      pool.register('bg1', { background: true });
+      const fg = pool.acquire({ sessionId: 's1', ttlMs: 100 })!;
+      const bg = pool.acquire({ sessionId: 's2', ttlMs: 100, preferBackground: true })!;
+      expect(fg.workerId).toBe('fg1');
+      expect(bg.workerId).toBe('bg1');
+    });
+    test('rejects missing sessionId', () => {
+      pool.register('w1');
+      expect(() => pool.acquire({ sessionId: '', ttlMs: 100 } as any)).toThrow(TypeError);
+    });
+    test('rejects non-positive ttlMs', () => {
+      pool.register('w1');
+      expect(() => pool.acquire({ sessionId: 's', ttlMs: 0 })).toThrow(RangeError);
+      expect(() => pool.acquire({ sessionId: 's', ttlMs: -1 })).toThrow(RangeError);
+    });
+    test('auto-reclaims expired lease before returning', () => {
+      pool.register('w1');
+      const h1 = pool.acquire({ sessionId: 's1', ttlMs: 100 }, 1000)!;
+      expect(h1.workerId).toBe('w1');
+      // At now=2000 the lease has expired.
+      const h2 = pool.acquire({ sessionId: 's2', ttlMs: 100 }, 2000)!;
+      expect(h2.workerId).toBe('w1');
+      expect(h2.sessionId).toBe('s2');
+      expect(h2.token).not.toBe(h1.token);
+    });
+  });
+
+  describe('renew', () => {
+    test('slides expiresAt forward', () => {
+      pool.register('w1');
+      const h = pool.acquire({ sessionId: 's', ttlMs: 100 }, 1000)!;
+      const r = pool.renew(h, 500, 1050)!;
+      expect(r.expiresAt).toBe(1550);
+      expect(r.token).toBe(h.token);
+    });
+    test('rejects handle whose lease was reclaimed', () => {
+      pool.register('w1');
+      const h = pool.acquire({ sessionId: 's', ttlMs: 100 }, 1000)!;
+      pool.acquire({ sessionId: 's2', ttlMs: 100 }, 2000); // reclaims + re-leases
+      expect(pool.renew(h, 500, 2100)).toBeNull();
+    });
+    test('rejects handle for unregistered worker', () => {
+      const h: LeaseHandle = {
+        workerId: 'ghost', sessionId: 's', expiresAt: 1, issuedAt: 0, token: 'x',
+      };
+      expect(pool.renew(h, 500)).toBeNull();
+    });
+    test('rejects non-positive ttlMs', () => {
+      pool.register('w1');
+      const h = pool.acquire({ sessionId: 's', ttlMs: 100 })!;
+      expect(() => pool.renew(h, 0)).toThrow(RangeError);
+    });
+  });
+
+  describe('release', () => {
+    test('returns worker to available', () => {
+      pool.register('w1');
+      const h = pool.acquire({ sessionId: 's', ttlMs: 100 })!;
+      expect(pool.release(h)).toBe(true);
+      expect(pool.snapshot()[0].state).toBe('available');
+    });
+    test('rejects handle with wrong token', () => {
+      pool.register('w1');
+      const h = pool.acquire({ sessionId: 's', ttlMs: 100 })!;
+      const fake: LeaseHandle = { ...h, token: 'wrong' };
+      expect(pool.release(fake)).toBe(false);
+    });
+    test('release of already-released is no-op', () => {
+      pool.register('w1');
+      const h = pool.acquire({ sessionId: 's', ttlMs: 100 })!;
+      pool.release(h);
+      expect(pool.release(h)).toBe(false);
+    });
+  });
+
+  describe('sweep', () => {
+    test('reclaims expired leases and returns count', () => {
+      pool.register('w1');
+      pool.register('w2');
+      pool.acquire({ sessionId: 's1', ttlMs: 100 }, 1000);
+      pool.acquire({ sessionId: 's2', ttlMs: 100 }, 1000);
+      expect(pool.sweep(2000)).toBe(2);
+      expect(pool.snapshot().every((s) => s.state === 'available')).toBe(true);
+    });
+    test('does not touch un-expired leases', () => {
+      pool.register('w1');
+      pool.acquire({ sessionId: 's', ttlMs: 10_000 }, 1000);
+      expect(pool.sweep(1100)).toBe(0);
+      expect(pool.snapshot()[0].state).toBe('leased');
+    });
+  });
+
+  describe('snapshot', () => {
+    test('reports state and expiry for observability', () => {
+      pool.register('w1', { label: 'main' });
+      pool.register('w2', { background: true });
+      pool.acquire({ sessionId: 's', ttlMs: 100 }, 1000);
+      const snap = pool.snapshot();
+      expect(snap).toEqual([
+        { workerId: 'w1', state: 'leased', meta: { label: 'main' }, expiresAt: 1100 },
+        { workerId: 'w2', state: 'available', meta: { background: true }, expiresAt: null },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## 요약

openchrome의 `TargetLeaseRegistry`는 target 레벨(CDP target ↔ session)로 리스 소유권을 추적합니다. Single-user·single-Chrome layout에는 맞지만, 다른 두 패턴에 구멍이 있습니다:

1. **Fleet of Chrome workers** · 여러 독립 tab·profile을 병렬로 돌리며 각자의 lifecycle을 갖는 오퍼레이터. 레지스트리는 "지금 어떤 worker가 어떤 리스를 갖고 있는가, 다음 차례는?"에 답해야 함.
2. **Background non-focus worker** · 사용자가 안 보고 있는 tab의 리스. openchrome이 tab을 **focus로 올리지 않고** 그 리스를 acquire·drive·release해야 함. 모든 데스크톱 OS가 focus activation을 이벤트로 취급하고 스텔스 벤더가 그걸 fingerprint하기 때문.

## 근거

Sonar의 openchrome 상류 기여 재판정(v2)의 **P18** 팩입니다. 원본:

- **trycua** (MIT) · Fleet Lease primitive. In-memory pool + acquire/renew/release + LeaseHandle 관용구.

원본 코드는 복사하지 않았습니다. 관용구·contract만 참조한 clean-room 구현입니다.

## 변경 내용

### 신규 · `src/session/fleet-lease.ts` (+227 라인)

- Pure in-process orchestrator · Chrome spawn·attach는 launcher 몫. 호출자가 자기 spawn/attach 계층에 wire.
- **Lane isolation** · `meta.background=true` worker는 `preferBackground:true` caller에게만 배정. Foreground driver가 background lease를 실수로 잡을 수 없고 그 역도 성립. Cross-lane traffic 불가능 — 프리미티브가 강제.
- `acquire()` · `LeaseHandle { workerId, sessionId, issuedAt, expiresAt, token }` 반환. Renewal이 token을 검사하므로 expiry로 reclaim된 handle을 renew할 수 없음. Release도 token 검사 — 오래된 handle이 남의 리스를 pool에 돌려놓지 못함.
- `sweep()` · 만료 lease 회수. Caller가 주기 timer를 켬 — 권장 default `ttlMs / 4`. Acquire·sweep race-free (JS 단일 스레드 직렬화 + acquire 내부 `reclaimExpired()` 선행 호출).
- `snapshot()` · `{ workerId, state, meta, expiresAt }` — 대시보드용.

### 신규 · `docs/orchestration/fleet-non-focus.md` (+79 라인)

Background driver가 지켜야 할 CDP 명령 allowlist(Target/Page/Runtime/DOM/Network/Storage evaluation, `Page.captureScreenshot` with `fromSurface:true`)와 denylist(`Page.bringToFront`, covered 좌표 위 `Input.dispatchMouseEvent`, macOS key event). 리스 프리미티브가 라우팅을 강제하고 driver 계층이 CDP 명령을 clean하게 유지.

## 테스트

- `tests/session/fleet-lease.test.ts` · 24 케이스, 모두 통과.

빌드:
- `node_modules/.bin/tsc -p tsconfig.json --noEmit` · 0 errors.
- `node_modules/.bin/jest tests/session/fleet-lease.test.ts` · 24 passed.

## 참고

- v2 계획서 · `docs/rebirth/OPENCHROME-CONTRIBUTION-PLAN-V2.md` §5 P18
- 90개 전수 근거 · `docs/rebirth/ULTIMATE-CENSUS-2026-07-18.md`
- 원본 코드 미열람 clean-room 구현. `src/session/fleet-lease.ts` 상단 주석에 origin credit.

## 관련

이 팩은 v2 계획의 **P18** 팩입니다. Batch 2의 6개 팩(P2·P3·P14·P15·P17·P21)이 동시에 별도 PR로 제출됩니다.