### PR TITLE
feat(hints): domain trust scoring + gap-driven next-action hints

### DIFF
--- a/src/hints/domain-trust.ts
+++ b/src/hints/domain-trust.ts
@@ -1,0 +1,171 @@
+/**
+ * Domain trust — reputation scoring for extraction / result sources.
+ *
+ * Why this exists
+ * ---------------
+ * openchrome's HintEngine turns tool results into next-action hints,
+ * but it treats every source URL the same. In practice a `wikipedia.org`
+ * result is not the same evidence weight as a `some-random-blog.tk`
+ * result. HKUDS/AI-Researcher's Resource Filter idiom scores each
+ * source by category (curated ref, government, org, primary source,
+ * SNS, aggregator, unknown) and lets downstream steps weight
+ * accordingly.
+ *
+ * openchrome uses this in two places:
+ *
+ *  1. `hint-engine.ts` result-guidance — when a tool returns URLs, the
+ *     hint layer can annotate "this looks like a primary source"
+ *     versus "this looks like aggregator soup".
+ *  2. `pattern-learner.ts` — the score becomes a feature in the
+ *     failure-episode learner so a pattern that reliably crashes on
+ *     low-trust sources gets a domain-scoped hint rather than a
+ *     global one.
+ *
+ * Design
+ * ------
+ * - Pure module. No dependency on any tool result shape — the caller
+ *   passes a URL and gets back `{ score, category, rationale }`.
+ * - Score is 0..1. The lookup is deterministic: classifier rules run
+ *   in a fixed order, first match wins.
+ * - Extension point `registerDomainTrustRule()` for callers who want
+ *   to layer site-specific trust on top of the defaults (e.g. an
+ *   internal wiki that should score 0.9). Registrations do not
+ *   mutate the defaults — they are consulted first.
+ *
+ * Origin credit
+ * -------------
+ * Idiom from HKUDS/AI-Researcher's Resource Filter (unlicensed).
+ * Clean-room implementation; no upstream code copied.
+ */
+
+export type TrustCategory =
+  | 'primary-reference'
+  | 'academic'
+  | 'government'
+  | 'organisation'
+  | 'news-established'
+  | 'aggregator'
+  | 'user-generated'
+  | 'unknown';
+
+export interface TrustResult {
+  score: number;
+  category: TrustCategory;
+  rationale: string;
+}
+
+export interface DomainTrustRule {
+  /** Runs against the lowercased hostname. */
+  match: (hostname: string) => boolean;
+  category: TrustCategory;
+  score: number;
+  rationale: string;
+}
+
+const DEFAULT_RULES: DomainTrustRule[] = [
+  {
+    match: (h) => h === 'wikipedia.org' || h.endsWith('.wikipedia.org'),
+    category: 'primary-reference',
+    score: 0.85,
+    rationale: 'wikipedia — curated reference',
+  },
+  {
+    match: (h) => h.endsWith('.arxiv.org') || h === 'arxiv.org' || h === 'pubmed.ncbi.nlm.nih.gov',
+    category: 'academic',
+    score: 0.9,
+    rationale: 'academic archive',
+  },
+  {
+    match: (h) => h.endsWith('.edu') || h.endsWith('.ac.kr') || h.endsWith('.ac.uk') || h.endsWith('.ac.jp'),
+    category: 'academic',
+    score: 0.85,
+    rationale: 'academic institution TLD',
+  },
+  {
+    match: (h) => h.endsWith('.gov') || h.endsWith('.go.kr') || h.endsWith('.gov.uk') || h.endsWith('.gc.ca'),
+    category: 'government',
+    score: 0.9,
+    rationale: 'government TLD',
+  },
+  {
+    match: (h) => h.endsWith('.mil'),
+    category: 'government',
+    score: 0.9,
+    rationale: 'military TLD',
+  },
+  {
+    match: (h) => h.endsWith('.or.kr') || h.endsWith('.org'),
+    category: 'organisation',
+    score: 0.6,
+    rationale: 'organisation TLD',
+  },
+  {
+    match: (h) => /(?:^|\.)(?:nytimes|bbc|reuters|ft|economist|apnews|npr|wsj|washingtonpost|guardian)\.(?:com|co\.uk|org)$/.test(h),
+    category: 'news-established',
+    score: 0.7,
+    rationale: 'established news',
+  },
+  {
+    match: (h) => /(?:^|\.)(?:medium|substack|hackernoon|dev\.to)\.com$/.test(h) || h.endsWith('.blogspot.com') || h.endsWith('.wordpress.com') || h.endsWith('.tistory.com'),
+    category: 'aggregator',
+    score: 0.35,
+    rationale: 'blog aggregator',
+  },
+  {
+    match: (h) => /(?:^|\.)(?:reddit|twitter|x|facebook|instagram|tiktok|youtube|linkedin|threads)\.com$/.test(h),
+    category: 'user-generated',
+    score: 0.25,
+    rationale: 'user-generated content',
+  },
+];
+
+const _customRules: DomainTrustRule[] = [];
+
+/** Add a caller-defined rule, consulted before the defaults. */
+export function registerDomainTrustRule(rule: DomainTrustRule): void {
+  if (typeof rule.match !== 'function' || typeof rule.score !== 'number') {
+    throw new TypeError('registerDomainTrustRule: match and score are required');
+  }
+  if (rule.score < 0 || rule.score > 1) {
+    throw new RangeError('registerDomainTrustRule: score must be in [0, 1]');
+  }
+  _customRules.push(rule);
+}
+
+/** Test-only reset. */
+export function resetDomainTrustRulesForTests(): void {
+  _customRules.length = 0;
+}
+
+/**
+ * Score a URL for source trust. Malformed URLs return an unknown
+ * category with score 0.
+ */
+export function scoreDomain(url: string): TrustResult {
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return { score: 0, category: 'unknown', rationale: 'malformed url' };
+  }
+  if (host.startsWith('www.')) host = host.slice(4);
+  for (const rule of _customRules) {
+    if (rule.match(host)) {
+      return { score: rule.score, category: rule.category, rationale: rule.rationale };
+    }
+  }
+  for (const rule of DEFAULT_RULES) {
+    if (rule.match(host)) {
+      return { score: rule.score, category: rule.category, rationale: rule.rationale };
+    }
+  }
+  return { score: 0.4, category: 'unknown', rationale: 'no matching rule' };
+}
+
+/** Rank a list of URLs by trust score, ties broken by input order. */
+export function rankByTrust(urls: readonly string[]): { url: string; trust: TrustResult }[] {
+  return urls
+    .map((url, i) => ({ url, trust: scoreDomain(url), _i: i }))
+    .sort((a, b) => (b.trust.score - a.trust.score) || (a._i - b._i))
+    .map(({ url, trust }) => ({ url, trust }));
+}

--- a/src/hints/gap-driven.ts
+++ b/src/hints/gap-driven.ts
@@ -1,0 +1,153 @@
+/**
+ * Gap-driven next-action hints.
+ *
+ * Why this exists
+ * ---------------
+ * openchrome's HintEngine already fires proactive hints on tool
+ * results, but the rules are all pattern-forward — "when tool X
+ * returns shape Y, suggest Z". Two upstream projects landed a
+ * complementary pattern that runs pattern-backward:
+ *
+ *  - **qx-labs** — Knowledge-Gap Analyzer computes the delta between
+ *    "what the plan needs to answer" and "what the accumulated
+ *    results actually cover", then routes the next tool selection
+ *    against the gap.
+ *  - **Search-o1** — Reason-in-Documents: when a document arrives, ask
+ *    "what did this add? what did it *not* add?" and use the
+ *    negative side to drive the next action.
+ *
+ * Both idioms collapse into the same primitive: a `gapAnalyse()` that
+ * takes the plan requirements plus the covered evidence and returns
+ * the uncovered subset, ranked by importance. openchrome's
+ * hint-engine can then call the primitive after each tool result to
+ * decide what to suggest next.
+ *
+ * Design
+ * ------
+ * - Pure module. Takes plan `requirements` (labelled goals) and
+ *   `evidence` (labelled facts already gathered) and returns the
+ *   `gaps` — requirement labels not yet covered by evidence, in
+ *   descending importance order.
+ * - Coverage is decided by a case-insensitive, whitespace-tolerant
+ *   overlap between a requirement's `keywords` and any evidence
+ *   entry's `keywords`. A requirement is covered when any evidence
+ *   entry hits the coverage threshold (default: 1 keyword match).
+ * - `nextActionHint(gaps, options)` composes a human-facing hint
+ *   from the top gap, respecting a small budget on characters and
+ *   optional per-gap templates.
+ *
+ * Origin credit
+ * -------------
+ * Shared idiom from qx-labs (Apache-2.0, Knowledge-Gap Analyzer) and
+ * Search-o1 (MIT, Reason-in-Documents). Clean-room implementation;
+ * no upstream code copied.
+ */
+
+export interface Requirement {
+  label: string;
+  keywords: readonly string[];
+  /** 0..1 importance weight. Default 0.5 when omitted. */
+  weight?: number;
+}
+
+export interface EvidenceItem {
+  /** Source id — url, tool call id, document title, etc. */
+  source: string;
+  keywords: readonly string[];
+}
+
+export interface GapAnalysisOptions {
+  /** Minimum keyword overlap for coverage. Default 1. */
+  minOverlap?: number;
+}
+
+export interface GapReport {
+  label: string;
+  weight: number;
+  keywords: readonly string[];
+  /** How many evidence items partially matched but fell below minOverlap. */
+  partialHits: number;
+}
+
+export interface GapAnalysisResult {
+  covered: string[];
+  gaps: GapReport[];
+}
+
+function normaliseKeyword(k: string): string {
+  return k.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Compute the coverage delta between plan requirements and gathered
+ * evidence. Requirements the evidence hits above threshold move to
+ * `covered`; the rest surface as `gaps` sorted by weight desc.
+ */
+export function gapAnalyse(
+  requirements: readonly Requirement[],
+  evidence: readonly EvidenceItem[],
+  options: GapAnalysisOptions = {},
+): GapAnalysisResult {
+  const minOverlap = options.minOverlap ?? 1;
+  if (minOverlap < 1) {
+    throw new RangeError('gapAnalyse: minOverlap must be >= 1');
+  }
+  const covered: string[] = [];
+  const gaps: GapReport[] = [];
+  for (const req of requirements) {
+    const reqKeywords = new Set(req.keywords.map(normaliseKeyword).filter(Boolean));
+    if (reqKeywords.size === 0) continue;
+    let bestOverlap = 0;
+    let partialHits = 0;
+    for (const item of evidence) {
+      const itemKeywords = new Set(item.keywords.map(normaliseKeyword).filter(Boolean));
+      let overlap = 0;
+      for (const k of reqKeywords) if (itemKeywords.has(k)) overlap += 1;
+      if (overlap >= minOverlap) {
+        bestOverlap = Math.max(bestOverlap, overlap);
+      } else if (overlap > 0) {
+        partialHits += 1;
+      }
+    }
+    if (bestOverlap >= minOverlap) {
+      covered.push(req.label);
+    } else {
+      gaps.push({
+        label: req.label,
+        weight: req.weight ?? 0.5,
+        keywords: [...reqKeywords],
+        partialHits,
+      });
+    }
+  }
+  gaps.sort((a, b) => b.weight - a.weight);
+  return { covered, gaps };
+}
+
+export interface NextActionHintOptions {
+  /** Max character length of the returned hint. Default 240. */
+  maxChars?: number;
+  /**
+   * Per-label template. Keys are requirement labels; values are the
+   * templated action for that gap. Falls back to the default template
+   * when no per-label entry is present.
+   */
+  templates?: Readonly<Record<string, string>>;
+}
+
+/**
+ * Compose the caller-facing hint for the top uncovered gap. Returns
+ * null when there are no gaps.
+ */
+export function nextActionHint(
+  result: GapAnalysisResult,
+  options: NextActionHintOptions = {},
+): string | null {
+  if (result.gaps.length === 0) return null;
+  const top = result.gaps[0];
+  const maxChars = options.maxChars ?? 240;
+  const template = options.templates?.[top.label]
+    ?? `next: cover "${top.label}" — try queries with ${top.keywords.slice(0, 3).map((k) => `"${k}"`).join(', ')}`;
+  if (template.length <= maxChars) return template;
+  return template.slice(0, Math.max(0, maxChars - 1)) + '…';
+}

--- a/tests/hints/domain-trust.test.ts
+++ b/tests/hints/domain-trust.test.ts
@@ -1,0 +1,97 @@
+import {
+  rankByTrust,
+  registerDomainTrustRule,
+  resetDomainTrustRulesForTests,
+  scoreDomain,
+} from '../../src/hints/domain-trust';
+
+describe('domain trust (P21)', () => {
+  beforeEach(() => resetDomainTrustRulesForTests());
+
+  describe('scoreDomain — default rules', () => {
+    test.each([
+      ['https://en.wikipedia.org/wiki/X', 'primary-reference'],
+      ['https://arxiv.org/abs/1234.5678', 'academic'],
+      ['https://mit.edu/', 'academic'],
+      ['https://kaist.ac.kr/', 'academic'],
+      ['https://ox.ac.uk/', 'academic'],
+      ['https://cdc.gov/', 'government'],
+      ['https://mohw.go.kr/', 'government'],
+      ['https://army.mil/', 'government'],
+      ['https://mozilla.org/', 'organisation'],
+      ['https://nytimes.com/a', 'news-established'],
+      ['https://www.bbc.co.uk/', 'news-established'],
+      ['https://medium.com/@x/y', 'aggregator'],
+      ['https://foo.tistory.com/1', 'aggregator'],
+      ['https://reddit.com/r/x', 'user-generated'],
+      ['https://twitter.com/x', 'user-generated'],
+    ])('%s → %s', (url, expected) => {
+      expect(scoreDomain(url).category).toBe(expected);
+    });
+
+    test('www prefix is stripped', () => {
+      const a = scoreDomain('https://wikipedia.org/x');
+      const b = scoreDomain('https://www.wikipedia.org/x');
+      expect(a.category).toBe(b.category);
+      expect(a.score).toBe(b.score);
+    });
+
+    test('unknown domain returns 0.4 neutral', () => {
+      const r = scoreDomain('https://example.com/');
+      expect(r.category).toBe('unknown');
+      expect(r.score).toBe(0.4);
+    });
+
+    test('malformed url returns 0 unknown', () => {
+      const r = scoreDomain('not a url');
+      expect(r.category).toBe('unknown');
+      expect(r.score).toBe(0);
+    });
+  });
+
+  describe('registerDomainTrustRule', () => {
+    test('custom rules run before defaults', () => {
+      registerDomainTrustRule({
+        match: (h) => h === 'internal-wiki.corp',
+        category: 'primary-reference',
+        score: 0.95,
+        rationale: 'internal wiki',
+      });
+      const r = scoreDomain('https://internal-wiki.corp/page');
+      expect(r.score).toBe(0.95);
+      expect(r.rationale).toBe('internal wiki');
+    });
+
+    test('validates score bounds', () => {
+      expect(() =>
+        registerDomainTrustRule({ match: () => true, category: 'unknown', score: 1.5, rationale: 'x' }),
+      ).toThrow(RangeError);
+      expect(() =>
+        registerDomainTrustRule({ match: () => true, category: 'unknown', score: -0.1, rationale: 'x' }),
+      ).toThrow(RangeError);
+    });
+
+    test('validates required fields', () => {
+      expect(() =>
+        registerDomainTrustRule({ match: 'not-a-fn', score: 0.5 } as any),
+      ).toThrow(TypeError);
+    });
+  });
+
+  describe('rankByTrust', () => {
+    test('sorts by score desc, ties by input order', () => {
+      const ranked = rankByTrust([
+        'https://reddit.com/x',
+        'https://mit.edu/',
+        'https://arxiv.org/x',
+        'https://example.com/',
+      ]);
+      expect(ranked.map((r) => r.url)).toEqual([
+        'https://arxiv.org/x',
+        'https://mit.edu/',
+        'https://example.com/',
+        'https://reddit.com/x',
+      ]);
+    });
+  });
+});

--- a/tests/hints/gap-driven.test.ts
+++ b/tests/hints/gap-driven.test.ts
@@ -1,0 +1,96 @@
+import { gapAnalyse, nextActionHint, type Requirement, type EvidenceItem } from '../../src/hints/gap-driven';
+
+describe('gap-driven hints (P21)', () => {
+  const reqs: Requirement[] = [
+    { label: 'company revenue 2025', keywords: ['revenue', '2025'], weight: 0.9 },
+    { label: 'company headcount', keywords: ['headcount', 'employees'], weight: 0.6 },
+    { label: 'founding date', keywords: ['founded', 'founding'], weight: 0.3 },
+  ];
+
+  describe('gapAnalyse', () => {
+    test('empty evidence → everything is a gap sorted by weight', () => {
+      const r = gapAnalyse(reqs, []);
+      expect(r.covered).toEqual([]);
+      expect(r.gaps.map((g) => g.label)).toEqual([
+        'company revenue 2025',
+        'company headcount',
+        'founding date',
+      ]);
+    });
+
+    test('single keyword overlap satisfies default minOverlap=1', () => {
+      const evidence: EvidenceItem[] = [
+        { source: 'a', keywords: ['revenue', '2025', 'growth'] },
+      ];
+      const r = gapAnalyse(reqs, evidence);
+      expect(r.covered).toContain('company revenue 2025');
+      expect(r.gaps.map((g) => g.label)).not.toContain('company revenue 2025');
+    });
+
+    test('minOverlap=2 requires two keyword hits', () => {
+      const evidence: EvidenceItem[] = [
+        { source: 'a', keywords: ['revenue'] }, // 1 hit only
+      ];
+      const r = gapAnalyse(reqs, evidence, { minOverlap: 2 });
+      expect(r.gaps.map((g) => g.label)).toContain('company revenue 2025');
+      const g = r.gaps.find((x) => x.label === 'company revenue 2025')!;
+      expect(g.partialHits).toBe(1);
+    });
+
+    test('case and whitespace tolerant', () => {
+      const evidence: EvidenceItem[] = [
+        { source: 'a', keywords: ['  REVENUE  ', '2025'] },
+      ];
+      const r = gapAnalyse(reqs, evidence);
+      expect(r.covered).toContain('company revenue 2025');
+    });
+
+    test('gaps sorted by weight desc', () => {
+      const evidence: EvidenceItem[] = [
+        { source: 'a', keywords: ['revenue', '2025'] }, // covers highest-weight
+      ];
+      const r = gapAnalyse(reqs, evidence);
+      expect(r.gaps[0].label).toBe('company headcount'); // 0.6 > 0.3
+    });
+
+    test('requirement with no keywords is skipped', () => {
+      const r = gapAnalyse([{ label: 'x', keywords: [] }], []);
+      expect(r.covered).toEqual([]);
+      expect(r.gaps).toEqual([]);
+    });
+
+    test('rejects minOverlap < 1', () => {
+      expect(() => gapAnalyse(reqs, [], { minOverlap: 0 })).toThrow(RangeError);
+    });
+  });
+
+  describe('nextActionHint', () => {
+    test('null when there are no gaps', () => {
+      expect(nextActionHint({ covered: ['x'], gaps: [] })).toBeNull();
+    });
+
+    test('default template includes top gap label and up to 3 keywords', () => {
+      const gaps = [{ label: 'company revenue 2025', weight: 0.9, keywords: ['revenue', '2025', 'growth', 'q4'], partialHits: 0 }];
+      const hint = nextActionHint({ covered: [], gaps })!;
+      expect(hint).toContain('company revenue 2025');
+      expect(hint).toContain('"revenue"');
+      expect(hint).toContain('"2025"');
+      expect(hint).toContain('"growth"');
+      expect(hint).not.toContain('"q4"');
+    });
+
+    test('per-label template wins', () => {
+      const gaps = [{ label: 'x', weight: 0.9, keywords: ['a'], partialHits: 0 }];
+      const hint = nextActionHint({ covered: [], gaps }, { templates: { x: 'go fetch x' } });
+      expect(hint).toBe('go fetch x');
+    });
+
+    test('maxChars truncates with ellipsis', () => {
+      const gaps = [{ label: 'x', weight: 0.9, keywords: ['a'], partialHits: 0 }];
+      const long = 'a'.repeat(500);
+      const hint = nextActionHint({ covered: [], gaps }, { templates: { x: long }, maxChars: 50 })!;
+      expect(hint.length).toBe(50);
+      expect(hint.endsWith('…')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## 요약

openchrome의 HintEngine은 이미 tool result에 proactive hint를 발사하지만, 두 gap이 품질을 떨어뜨립니다:

1. 모든 source URL을 똑같이 취급 · `wikipedia.org` result와 `some-random-blog.tk` result의 증거 가중치는 다른데 hint 계층은 그걸 말할 어휘가 없음.
2. Rule이 pattern-forward만 · "tool X가 shape Y를 반환하면 Z 제안". Pattern-backward primitive("플랜이 요구한 것 중 축적된 result가 아직 안 커버한 게 뭐냐? 다음 액션을 거기로 몰아라")가 없음.

이 팩은 두 primitive를 pure module로 배치해서 hint 계층과 pattern-learner가 schema 변경 없이 호출할 수 있게 합니다.

## 근거

Sonar의 openchrome 상류 기여 재판정(v2)의 **P21** 팩입니다. 원본:

- **HKUDS/AI-Researcher** (unlicensed) · Resource Filter의 source-reputation scoring 관용구.
- **qx-labs** (Apache-2.0) · Knowledge-Gap Analyzer가 대표하는 pattern-backward routing.
- **Search-o1** (MIT) · Reason-in-Documents의 "이 문서가 뭘 안 채웠나" 관점.

원본 코드는 복사하지 않았습니다. 세 프로젝트의 관용구·contract만 참조한 clean-room 구현입니다.

## 변경 내용

### 신규 · `src/hints/domain-trust.ts` (+171 라인)

- URL → `{ score, category, rationale }` classifier. 고정 rule 순서 first-match-wins, 결정적. Score 0..1.
- Categories · `primary-reference`(wikipedia), `academic`(arxiv, .edu, .ac.\*), `government`(.gov, .go.kr, .mil), `organisation`(.org, .or.kr), `news-established`(nytimes, bbc, reuters, ft, economist, apnews, npr, wsj, washingtonpost, guardian), `aggregator`(medium, substack, hackernoon, dev.to, blogspot, wordpress, tistory), `user-generated`(reddit, twitter, x, facebook, instagram, tiktok, youtube, linkedin, threads), `unknown`.
- `registerDomainTrustRule()` · caller가 internal wiki를 0.95로 pin해도 defaults를 안 건드림 — custom rules가 defaults 앞에서 실행.
- `rankByTrust()` · URL 리스트 정렬, tie는 input order.

### 신규 · `src/hints/gap-driven.ts` (+153 라인)

- `gapAnalyse(requirements, evidence)` · `{ covered, gaps sorted by weight desc }`. Requirement가 커버됐다고 판정되는 조건 · evidence item 중 하나라도 keyword overlap threshold(default 1) 이상. Keyword 비교는 whitespace-tolerant, case-insensitive. Empty-keyword requirement는 skip.
- `nextActionHint(result, options)` · top uncovered gap을 caller-facing 문자열로. Per-label template이 default template 이김. `maxChars` 초과 시 ellipsis truncate.

두 module 모두 pure · ActivityTracker·CDP·puppeteer·기존 HintEngine surface 무의존. Intent · `hint-engine.ts`와 `pattern-learner.ts`가 필요할 때 import — 이 팩은 downstream 팀이 자기 페이스로 채택하도록 wiring을 강제하지 않음.

## 테스트

- `tests/hints/domain-trust.test.ts` · 15 케이스.
- `tests/hints/gap-driven.test.ts` · 18 케이스.

빌드:
- `node_modules/.bin/tsc -p tsconfig.json --noEmit` · 0 errors.
- `node_modules/.bin/jest tests/hints/domain-trust.test.ts tests/hints/gap-driven.test.ts` · 33 passed.

## 참고

- v2 계획서 · `docs/rebirth/OPENCHROME-CONTRIBUTION-PLAN-V2.md` §5 P21
- 90개 전수 근거 · `docs/rebirth/ULTIMATE-CENSUS-2026-07-18.md`
- 원본 코드 미열람 clean-room 구현. 각 파일 상단 주석에 origin credit.

## 관련

이 팩은 v2 계획의 **P21** 팩입니다. Batch 2의 6개 팩(P2·P3·P14·P15·P17·P18)이 동시에 별도 PR로 제출됩니다.