### PR TITLE
Sync released MCP disclosure changes into develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ and add the printed `[mcp_servers.openchrome]` block to `~/.codex/config.toml`.
   "mcpServers": {
     "openchrome": {
       "command": "openchrome",
-      "args": ["serve", "--auto-launch", "--auto-elect"]
+      "args": ["serve", "--auto-launch", "--auto-elect", "--minimal"]
     }
   }
 }

--- a/cli/mcp-client-config.ts
+++ b/cli/mcp-client-config.ts
@@ -16,6 +16,7 @@ export interface ServeArgOptions {
   autoElect?: boolean;
   broker?: boolean;
   connectBroker?: boolean;
+  minimal?: boolean;
 }
 
 export interface MCPServerConfig {
@@ -69,6 +70,7 @@ export function getServeArgs(options: ServeArgOptions = {}): string[] {
   }
 
   if (resolved.autoElect === true) serveArgs.push('--auto-elect');
+  if (resolved.minimal !== false) serveArgs.push('--minimal');
   if (resolved.autoElect === false) serveArgs.push('--no-auto-elect');
   if (resolved.broker) serveArgs.push('--broker');
   if (resolved.connectBroker) serveArgs.push('--connect-broker');

--- a/docs/mcp/topologies.md
+++ b/docs/mcp/topologies.md
@@ -4,7 +4,7 @@ OpenChrome currently supports one safe direct-controller rule:
 
 > Run at most one direct `openchrome serve --auto-launch` process for the same Chrome debug port and user-data directory.
 
-Multiple MCP clients can still run in parallel today. New `openchrome setup` / `openchrome config` output defaults to the auto-elect topology (`openchrome serve --auto-launch --auto-elect`): one process wins the Chrome/CDP owner lock and publishes broker metadata; surplus same-profile clients proxy through that broker. For explicit shared-profile deployments, run a single broker owner (`openchrome serve --broker --auto-launch`) and point the other clients at it with `--connect-broker`; otherwise give each client its own isolated port and user-data directory.
+Multiple MCP clients can still run in parallel today. New `openchrome setup` / `openchrome config` output defaults to the auto-elect topology (`openchrome serve --auto-launch --auto-elect --minimal`): one process wins the Chrome/CDP owner lock and publishes broker metadata; surplus same-profile clients proxy through that broker. For explicit shared-profile deployments, run a single broker owner (`openchrome serve --broker --auto-launch`) and point the other clients at it with `--connect-broker`; otherwise give each client its own isolated port and user-data directory.
 
 ## After upgrading OpenChrome
 
@@ -38,7 +38,7 @@ openchrome config --client opencode
 Generated configs use:
 
 ```bash
-openchrome serve --auto-launch --auto-elect
+openchrome serve --auto-launch --auto-elect --minimal
 ```
 
 For one `(port, userDataDir)`, exactly one process remains the direct Chrome/CDP owner. Surplus sessions attach as broker clients instead of becoming unsafe second direct controllers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openchrome-mcp",
-  "version": "1.12.8",
+  "version": "1.12.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openchrome-mcp",
-      "version": "1.12.8",
+      "version": "1.12.9",
       "license": "MIT",
       "dependencies": {
         "argon2": "^0.43.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openchrome-mcp",
-  "version": "1.12.8",
+  "version": "1.12.9",
   "description": "Open-source browser automation MCP server. Control your real Chrome from any AI agent.",
   "main": "dist/index.js",
   "exports": {

--- a/src/config/tool-tiers.ts
+++ b/src/config/tool-tiers.ts
@@ -2,7 +2,7 @@
  * Tool Tier Configuration
  *
  * Controls which tools are exposed by default vs on-demand.
- * Tier 1: Always exposed (core tools for every session)
+ * Tier 1: Always exposed (small browser essentials for every session)
  * Tier 2: Exposed on demand (specialist/niche tools)
  * Tier 3: Orchestration only (workflow lifecycle tools)
  */
@@ -11,98 +11,132 @@ export type ToolTier = 1 | 2 | 3;
 
 /** Map of tool name → tier assignment */
 export const TOOL_TIERS: Record<string, ToolTier> = {
-  // Tier 1: Core (always exposed)
+  // Tier 1: Browser essentials (always exposed)
   navigate: 1,
-  page_reload: 1,
   computer: 1,
-  interact: 1,
-  find: 1,
-  form_input: 1,
-  fill_form: 1,
   read_page: 1,
-  oc_observe: 1,              // src/tools/oc-observe.ts — compact observable action map (#866)
-  element_pick: 1,             // src/tools/element-pick.ts — in-page picker facts (#899)
-  inspect: 1,
+  find: 1,
   query_dom: 1,
-  oc_query: 1, // src/tools/oc-query.ts — semantic refs for interaction workflows (#1045)
-  javascript_tool: 1,
+  interact: 1,
+  form_input: 1,
   tabs_context: 1,
   tabs_create: 1,
   tabs_close: 1,
-  cookies: 1,
-  storage: 1,
   wait_for: 1,
-  memory: 1,
-  lightweight_scroll: 1,
-  console_capture: 1,         // src/tools/console-capture.ts — surfaces page errors during validation (#token-efficiency)
+  page_screenshot: 1,
+  oc_connection_health: 1,
   oc_stop: 1,
-  oc_profile_status: 1,
-  oc_session_snapshot: 1,
-  oc_session_resume: 1,
-  oc_journal: 1,
-  oc_get_connection_info: 1,
-  oc_copy_to_clipboard: 1,
-  oc_open_host_settings: 1,
-  act: 1,                     // src/tools/act.ts — composite NL action API (#578)
-  validate_page: 1,           // src/tools/validate-page.ts — composite page-health check (#token-efficiency)
-  oc_reap_orphans: 1,         // src/tools/reap-orphans.ts — manual lifecycle recovery sweep
-  oc_assert: 1,               // src/tools/oc-assert.ts — Outcome Contracts single-call verifier (#784)
-  oc_evidence_bundle: 1,      // src/tools/oc-evidence-bundle.ts — Outcome Contracts evidence bundle capture (#792)
-  oc_skill_record: 1,         // src/tools/oc-skill-record.ts — skill memory write surface (#785)
-  oc_skill_recall: 1,         // src/tools/oc-skill-recall.ts — skill memory read surface (#785)
-  oc_output_fetch: 1,         // src/tools/oc-output-fetch.ts — 2-stage fetch for large-output tools (#887)
 
   // Tier 2: Specialist (on demand)
-  extract_data: 2,              // src/tools/extract-data.ts — structured extraction (#571)
-  oc_totp_generate: 2,
-  drag_drop: 2,
+  javascript_tool: 2,
   network: 2,
-  request_intercept: 2,
-  http_auth: 2,
+  page_reload: 2,
+  cookies: 2,
+  page_content: 2,
+  storage: 2,
   user_agent: 2,
   geolocation: 2,
   emulate_device: 2,
   page_pdf: 2,
-  page_screenshot: 2,
-  page_content: 2,
+  console_capture: 2,
   performance_metrics: 2,
+  request_intercept: 2,
+  network_capture_lite: 2,
+  network_capture_full: 2,
   file_upload: 2,
+  http_auth: 2,
+  drag_drop: 2,
+  fill_form: 2,
   batch_execute: 2,
+  lightweight_scroll: 2,
   batch_paginate: 2,
-  crawl: 2,
-  crawl_sitemap: 2,
+  inspect: 2,
   vision_find: 2,
-  oc_context_export: 2,
-  oc_context_import: 2,
-
-  // Session recording tools (#572) — opt-in, not needed for every session
+  memory: 2,
+  oc_query: 2,
+  oc_reap_orphans: 2,
+  oc_profile_status: 2,
+  list_profiles: 2,
+  oc_session_snapshot: 2,
+  oc_session_resume: 2,
+  oc_journal: 2,
+  oc_reflect: 2,
+  oc_policy: 2,
+  oc_checkpoint: 2,
+  oc_get_connection_info: 2,
+  oc_copy_to_clipboard: 2,
+  oc_open_host_settings: 2,
   oc_recording_start: 2,
   oc_recording_stop: 2,
   oc_recording_status: 2,
   oc_recording_list: 2,
   oc_recording_export: 2,
-
-  // Internal/diagnostic tools (exposed at Tier 1 but explicitly declared)
-  // Names must match the 'name' field in each tool's definition
-  oc_connection_health: 1,  // src/tools/connection-health.ts
-  oc_policy: 1,             // src/tools/oc-policy.ts
-  oc_checkpoint: 1,         // src/tools/checkpoint.ts
-  list_profiles: 1,         // src/tools/list-profiles.ts
-  oc_devtools_url: 1,       // src/tools/oc-devtools-url.ts (#860) — gated by env
+  crawl: 2,
+  crawl_sitemap: 2,
+  crawl_start: 2,
+  crawl_status: 2,
+  crawl_cancel: 2,
+  act: 2,
+  validate_page: 2,
+  extract_data: 2,
+  oc_totp_generate: 2,
+  oc_assert: 2,
+  oc_journal_compact: 2,
+  image_qa: 2,
+  oc_gate_inspect: 2,
+  oc_normalize_action: 2,
+  oc_progress_status: 2,
+  oc_vitals: 2,
+  oc_output_fetch: 2,
+  oc_evidence_bundle: 2,
+  oc_diff: 2,
+  oc_skill_record: 2,
+  oc_skill_recall: 2,
+  oc_skill_export: 2,
+  oc_doctor_report: 2,
+  oc_performance_insights: 2,
+  oc_performance_analyze: 2,
+  oc_observe: 2,
+  element_pick: 2,
+  oc_devtools_url: 2,
+  oc_context_export: 2,
+  oc_context_import: 2,
 
   // Tier 3: Orchestration only
+  worker: 3,
   workflow_init: 3,
   workflow_status: 3,
   workflow_collect: 3,
   workflow_collect_partial: 3,
   workflow_cleanup: 3,
-  worker: 3,
   worker_update: 3,
   worker_complete: 3,
   execute_plan: 3,
+  oc_task_start: 3,
+  oc_task_list: 3,
+  oc_task_get: 3,
+  oc_task_cancel: 3,
+  oc_task_wait: 3,
+  oc_task_update: 3,
+  oc_task_finish: 3,
+  oc_lane_create: 3,
+  oc_lane_list: 3,
+  oc_lane_get: 3,
+  oc_lane_close: 3,
+  oc_run_start: 3,
+  oc_run_status: 3,
+  oc_run_events: 3,
+  oc_run_finish: 3,
+  oc_task_run_start: 3,
+  oc_task_run_update: 3,
+  oc_task_run_checkpoint: 3,
+  oc_task_run_needs_help: 3,
+  oc_task_run_complete: 3,
+  oc_task_run_get: 3,
+  oc_task_run_list: 3,
 };
 
-/** Get the tier for a tool (defaults to 1 if not configured) */
+/** Get the tier for a tool (defaults to on-demand so new tools do not bloat startup). */
 export function getToolTier(toolName: string): ToolTier {
-  return TOOL_TIERS[toolName] ?? 1;
+  return TOOL_TIERS[toolName] ?? 2;
 }

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -88,7 +88,7 @@ export interface CreateServerOptions {
   };
 
   pilot?: boolean;
-  tools?: { allTools?: boolean };
+  tools?: { allTools?: boolean; minimal?: boolean };
   security?: { blockedDomains?: string[]; auditLog?: boolean; sanitizeContent?: boolean };
   idleTimeoutMs?: number;
   parentPid?: number;
@@ -258,10 +258,15 @@ class OpenChromeServerImpl implements OpenChromeServer {
 
     // Tool tiers
     const envTier = parseInt(process.env.OPENCHROME_TOOL_TIER || '', 10);
+    if (opts.tools?.allTools && opts.tools?.minimal) {
+      throw new Error('[openchrome] --minimal and --all-tools are mutually exclusive');
+    }
     if (opts.tools?.allTools || envTier >= 3) {
       setMCPServerOptions({ initialToolTier: 3 as ToolTier });
     } else if (envTier === 2) {
       setMCPServerOptions({ initialToolTier: 2 as ToolTier });
+    } else if (opts.tools?.minimal) {
+      setMCPServerOptions({ initialToolTier: 1 as ToolTier });
     }
 
     // Transport

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,7 @@ program
   .option('--audit-log', 'Enable security audit logging (default: false)')
   .option('--no-sanitize-content', 'Disable content sanitization for prompt injection defense (default: enabled)')
   .option('--all-tools', 'Expose all tools from startup (bypass progressive disclosure)')
+  .option('--minimal', 'Expose only the minimal browser-essential startup tool surface. Advanced tools remain available through expand_tools.')
   .option('--server-mode', 'Server/headless mode: auto-launch headless Chrome, skip cookie bridge')
   .option('--http [port]', 'Use Streamable HTTP transport instead of stdio (default port: 3100)')
   .option('--http-host <host>', 'Bind address for HTTP transport (default: 127.0.0.1, use 0.0.0.0 for external access)')
@@ -134,7 +135,7 @@ program
   .option('--launch-mode <mode>', 'Chrome launch mode: auto | attach | isolated (#659). Also: OPENCHROME_LAUNCH_MODE env var.')
   .option('--secrets <path>', 'Load a dotenv-format secrets file (KEY=value per line). Tokens "${SECRET:NAME}" in tool arguments are substituted to the real value at MCP request deserialization; the same values are redacted from every LLM-visible artifact (responses, trace, skill records, journal). Default: no secrets loaded. P3: no OS keychain integration.')
   .option('--codegen <mode>', 'Opt-in replay artifact generation: off, puppeteer, playwright, or mcp-replay. Default: off (no response shape changes). Also: OPENCHROME_CODEGEN.')
-  .action(async (options: { port: string; autoLaunch?: boolean; allowUnsafeSharedAttach?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; windowSize?: string; windowPosition?: string; windowBounds?: string; startMaximized?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; broker?: boolean; connectBroker?: boolean; autoElect?: boolean; idleTimeout?: string; allowUnauthenticatedHttp?: boolean; pilot?: boolean; slim?: boolean; toolsOnly?: string; disableTools?: string; introspectToolsList?: boolean; autoConnect?: string | boolean; launchMode?: string; secrets?: string; codegen?: string }) => {
+  .action(async (options: { port: string; autoLaunch?: boolean; allowUnsafeSharedAttach?: boolean; userDataDir?: string; profileDirectory?: string; chromeBinary?: string; headlessShell?: boolean; headless?: boolean; visible?: boolean; windowSize?: string; windowPosition?: string; windowBounds?: string; startMaximized?: boolean; restartChrome?: boolean; hybrid?: boolean; lpPort?: string; blockedDomains?: string; auditLog?: boolean; sanitizeContent?: boolean; allTools?: boolean; minimal?: boolean; serverMode?: boolean; http?: string | boolean; authToken?: string; transport?: string; broker?: boolean; connectBroker?: boolean; autoElect?: boolean; idleTimeout?: string; allowUnauthenticatedHttp?: boolean; pilot?: boolean; slim?: boolean; toolsOnly?: string; disableTools?: string; introspectToolsList?: boolean; autoConnect?: string | boolean; launchMode?: string; secrets?: string; codegen?: string }) => {
     const { normalizeCodegenMode, setCodegenMode } = await import('./core/codegen');
     const codegenMode = normalizeCodegenMode(options.codegen ?? process.env.OPENCHROME_CODEGEN);
     setCodegenMode(codegenMode);
@@ -592,12 +593,19 @@ program
 
     // Tool tier configuration
     const envTier = parseInt(process.env.OPENCHROME_TOOL_TIER || '', 10);
+    if (options.allTools && options.minimal) {
+      console.error('[openchrome] Error: --minimal and --all-tools are mutually exclusive');
+      process.exit(2);
+    }
     if (options.allTools || envTier >= 3) {
       mcpOptions.initialToolTier = 3 as ToolTier;
       console.error('[openchrome] All tools exposed from startup');
     } else if (envTier === 2) {
       mcpOptions.initialToolTier = 2 as ToolTier;
       console.error('[openchrome] Tier 2 tools exposed from startup');
+    } else if (options.minimal) {
+      mcpOptions.initialToolTier = 1 as ToolTier;
+      console.error('[openchrome] Minimal startup tool surface enabled');
     }
 
     // Capability filter configuration (#829, #847)

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -304,6 +304,7 @@ const PROGRESSIVE_DISCLOSURE_CLIENTS = new Set([
   'cline',
   'zed',
   'continue',
+  'opencode',
 ]);
 
 const RECONNECTION_GUIDANCE =
@@ -1320,8 +1321,11 @@ export class MCPServer {
 
     // Detect client identity for progressive disclosure decisions
     const clientInfo = params?.clientInfo as { name?: string; version?: string } | undefined;
+    const clientCapabilities = params?.capabilities as { tools?: { listChanged?: boolean }; notifications?: { tools?: { listChanged?: boolean } } } | undefined;
     const rawName = clientInfo?.name ?? '';
     const nameLower = rawName.toLowerCase();
+    const supportsToolListChanged = clientCapabilities?.tools?.listChanged === true
+      || clientCapabilities?.notifications?.tools?.listChanged === true;
 
     // Idempotency: only detect client on first initialize (reconnects preserve state)
     if (!this.clientDetected) {
@@ -1334,14 +1338,15 @@ export class MCPServer {
           nameLower.includes(known)
         );
 
-        if (!isKnownClient) {
+        if (!isKnownClient && !supportsToolListChanged) {
           // Unknown or absent client: expose all tools immediately (no progressive disclosure)
           this.exposedTier = 3;
           this.clientSupportsListChanged = false;
           console.error(`[openchrome] Client "${rawName || '(no clientInfo)'}" — progressive disclosure disabled, exposing all tools`);
         } else {
-          // Known client: keep progressive disclosure enabled
-          console.error(`[openchrome] Client "${rawName}" supports tool list changes — progressive disclosure enabled`);
+          // Known/capable client: keep progressive disclosure enabled.
+          const source = supportsToolListChanged && !isKnownClient ? 'capability' : 'known-client';
+          console.error(`[openchrome] Client "${rawName || '(no clientInfo)'}" supports tool list changes (${source}) — progressive disclosure enabled`);
         }
       }
     }

--- a/tests/cli/mcp-client-config.test.ts
+++ b/tests/cli/mcp-client-config.test.ts
@@ -15,11 +15,11 @@ import {
 
 describe('cli/mcp-client-config', () => {
   test('getServeArgs enables auto-launch by default', () => {
-    expect(getServeArgs()).toEqual(['serve', '--auto-launch', '--auto-elect']);
+    expect(getServeArgs()).toEqual(['serve', '--auto-launch', '--auto-elect', '--minimal']);
   });
 
   test('getServeArgs includes dashboard when requested', () => {
-    expect(getServeArgs({ dashboard: true })).toEqual(['serve', '--auto-launch', '--auto-elect', '--dashboard']);
+    expect(getServeArgs({ dashboard: true })).toEqual(['serve', '--auto-launch', '--auto-elect', '--minimal', '--dashboard']);
   });
 
   test('getServeArgs preserves explicit port and profile topology', () => {
@@ -32,6 +32,7 @@ describe('cli/mcp-client-config', () => {
       'serve',
       '--auto-launch',
       '--auto-elect',
+      '--minimal',
       '--port',
       '9333',
       '--user-data-dir',
@@ -44,15 +45,15 @@ describe('cli/mcp-client-config', () => {
   });
 
   test('single-owner topology preset preserves the legacy direct owner explicitly', () => {
-    expect(getServeArgs({ topology: 'single-owner' })).toEqual(['serve', '--auto-launch', '--no-auto-elect']);
+    expect(getServeArgs({ topology: 'single-owner' })).toEqual(['serve', '--auto-launch', '--minimal', '--no-auto-elect']);
   });
 
   test('broker topology presets generate owner and client roles', () => {
     expect(getServeArgs({ topology: 'broker-owner', port: 9222, userDataDir: '/tmp/shared' })).toEqual([
-      'serve', '--auto-launch', '--broker', '--port', '9222', '--user-data-dir', '/tmp/shared',
+      'serve', '--auto-launch', '--minimal', '--broker', '--port', '9222', '--user-data-dir', '/tmp/shared',
     ]);
     expect(getServeArgs({ topology: 'broker-client', port: 9222, userDataDir: '/tmp/shared' })).toEqual([
-      'serve', '--connect-broker', '--port', '9222', '--user-data-dir', '/tmp/shared',
+      'serve', '--minimal', '--connect-broker', '--port', '9222', '--user-data-dir', '/tmp/shared',
     ]);
   });
 
@@ -60,6 +61,7 @@ describe('cli/mcp-client-config', () => {
     expect(getServeArgs({ topology: 'isolated' })).toEqual([
       'serve',
       '--auto-launch',
+      '--minimal',
       '--port',
       '9223',
       '--user-data-dir',
@@ -70,13 +72,18 @@ describe('cli/mcp-client-config', () => {
   });
 
   test('getServeArgs omits auto-launch when explicitly disabled', () => {
-    expect(getServeArgs({ autoLaunch: false })).toEqual(['serve']);
+    expect(getServeArgs({ autoLaunch: false })).toEqual(['serve', '--minimal']);
+  });
+
+
+  test('getServeArgs can opt out of generated minimal mode', () => {
+    expect(getServeArgs({ minimal: false })).toEqual(['serve', '--auto-launch', '--auto-elect']);
   });
 
   test('getCodexServerConfig uses the installed openchrome binary', () => {
     expect(getCodexServerConfig()).toEqual({
       command: 'openchrome',
-      args: ['serve', '--auto-launch', '--auto-elect'],
+      args: ['serve', '--auto-launch', '--auto-elect', '--minimal'],
     });
   });
 
@@ -92,6 +99,7 @@ describe('cli/mcp-client-config', () => {
       'serve',
       '--auto-launch',
       '--auto-elect',
+      '--minimal',
       '--dashboard',
     ]);
     expect(command).not.toContain('remove');
@@ -100,7 +108,7 @@ describe('cli/mcp-client-config', () => {
   test('getClaudeManualServerConfig uses the installed openchrome binary', () => {
     expect(getClaudeManualServerConfig()).toEqual({
       command: 'openchrome',
-      args: ['serve', '--auto-launch', '--auto-elect'],
+      args: ['serve', '--auto-launch', '--auto-elect', '--minimal'],
     });
   });
 
@@ -116,6 +124,7 @@ describe('cli/mcp-client-config', () => {
       'serve',
       '--auto-launch',
       '--auto-elect',
+      '--minimal',
       '--dashboard',
     ]);
   });
@@ -142,7 +151,7 @@ describe('cli/mcp-client-config', () => {
         },
         openchrome: {
           command: 'openchrome',
-          args: ['serve', '--auto-launch', '--auto-elect'],
+          args: ['serve', '--auto-launch', '--auto-elect', '--minimal'],
         },
       },
     });
@@ -153,7 +162,7 @@ describe('cli/mcp-client-config', () => {
       mcpServers: {
         openchrome: {
           command: 'openchrome',
-          args: ['serve', '--auto-launch', '--auto-elect'],
+          args: ['serve', '--auto-launch', '--auto-elect', '--minimal'],
         },
       },
     });
@@ -164,7 +173,7 @@ describe('cli/mcp-client-config', () => {
       [
         '[mcp_servers.openchrome]',
         'command = "openchrome"',
-        'args = ["serve", "--auto-launch", "--auto-elect"]',
+        'args = ["serve", "--auto-launch", "--auto-elect", "--minimal"]',
       ].join('\n')
     );
   });
@@ -173,7 +182,7 @@ describe('cli/mcp-client-config', () => {
     const options = { port: 9333, userDataDir: '/tmp/openchrome-codex' };
 
     expect(formatCodexMCPServerConfigSnippet('openchrome', getCodexServerConfig(options))).toContain(
-      'args = ["serve", "--auto-launch", "--auto-elect", "--port", "9333", "--user-data-dir", "/tmp/openchrome-codex"]'
+      'args = ["serve", "--auto-launch", "--auto-elect", "--minimal", "--port", "9333", "--user-data-dir", "/tmp/openchrome-codex"]'
     );
     expect(getClaudeSetupCommand('user', options)).toEqual([
       'mcp',
@@ -186,6 +195,7 @@ describe('cli/mcp-client-config', () => {
       'serve',
       '--auto-launch',
       '--auto-elect',
+      '--minimal',
       '--port',
       '9333',
       '--user-data-dir',
@@ -201,6 +211,7 @@ describe('cli/mcp-client-config', () => {
         'serve',
         '--auto-launch',
         '--auto-elect',
+        '--minimal',
         '--port',
         '9444',
         '--user-data-dir',

--- a/tests/cross-env/cursor-verification.test.ts
+++ b/tests/cross-env/cursor-verification.test.ts
@@ -157,7 +157,8 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
       expect(toolNames).toContain('expand_tools');
 
       const nonExpandTools = tier1Tools.filter((t: any) => t.name !== 'expand_tools');
-      expect(nonExpandTools.length).toBeGreaterThanOrEqual(46);
+      expect(nonExpandTools.length).toBeGreaterThanOrEqual(14);
+      expect(nonExpandTools.length).toBeLessThanOrEqual(15);
       expect(new Set(toolNames).size).toBe(toolNames.length);
     });
 
@@ -171,25 +172,20 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
     test('Tier 1 contains expected core tools', () => {
       const names = tier1Tools.map((t: any) => t.name);
       const expectedCore = [
-        'navigate', 'page_reload', 'computer', 'interact', 'find',
-        'form_input', 'fill_form', 'read_page', 'oc_observe', 'inspect', 'query_dom',
-        'javascript_tool', 'tabs_context', 'tabs_create', 'tabs_close',
-        'cookies', 'storage', 'wait_for', 'memory', 'lightweight_scroll',
-        'oc_stop', 'oc_profile_status', 'oc_session_snapshot', 'oc_session_resume',
-        'oc_journal',
-        'oc_get_connection_info', 'oc_copy_to_clipboard', 'oc_open_host_settings',
-        'act',
+        'navigate', 'computer', 'interact', 'find', 'form_input',
+        'read_page', 'query_dom', 'tabs_context', 'tabs_create', 'tabs_close',
+        'wait_for', 'page_screenshot', 'oc_connection_health', 'oc_stop',
       ];
       for (const tool of expectedCore) {
         expect(names).toContain(tool);
       }
     });
 
-    test('Tier 1 also contains diagnostic tools (oc_connection_health, oc_checkpoint, list_profiles)', () => {
+    test('Tier 1 omits specialist diagnostics until expansion', () => {
       const names = tier1Tools.map((t: any) => t.name);
       expect(names).toContain('oc_connection_health');
-      expect(names).toContain('oc_checkpoint');
-      expect(names).toContain('list_profiles');
+      expect(names).not.toContain('oc_checkpoint');
+      expect(names).not.toContain('list_profiles');
     });
 
     test('expand_tools(tier=2) → Tier 2 tools appear + notification sent', async () => {
@@ -210,9 +206,11 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
       const expectedTier2 = [
         'extract_data', 'drag_drop', 'network',
         'request_intercept', 'http_auth', 'user_agent', 'geolocation',
-        'emulate_device', 'page_pdf', 'page_screenshot', 'page_content',
+        'emulate_device', 'page_pdf', 'page_content',
         'console_capture', 'performance_metrics', 'file_upload',
-        'batch_execute', 'batch_paginate',
+        'batch_execute', 'batch_paginate', 'javascript_tool', 'page_reload',
+        'cookies', 'storage', 'fill_form', 'inspect', 'memory', 'oc_query',
+        'oc_checkpoint', 'list_profiles',
         'oc_recording_start', 'oc_recording_stop', 'oc_recording_status', 'oc_recording_list', 'oc_recording_export',
       ];
       for (const tool of expectedTier2) {

--- a/tests/mcp-progressive-disclosure.test.ts
+++ b/tests/mcp-progressive-disclosure.test.ts
@@ -33,7 +33,7 @@ function makeServer(): MCPServer {
   return server;
 }
 
-async function initializeAndList(server: MCPServer, clientName: string, capabilities: Record<string, unknown> = {}): Promise<{ init: TestResponse; tools: string[] }> {
+async function initializeAndList(server: MCPServer, clientName: string, capabilities: Record<string, unknown> = {}): Promise<{ init: TestResponse; toolDefs: Array<{ name: string }>; tools: string[] }> {
   const init = await server.handleRequest({
     jsonrpc: '2.0',
     id: 1,
@@ -52,18 +52,36 @@ async function initializeAndList(server: MCPServer, clientName: string, capabili
     params: {},
   }) as TestResponse;
 
-  return { init, tools: (listed.result?.tools ?? []).map(t => t.name) };
+  const toolDefs = listed.result?.tools ?? [];
+  return { init, toolDefs, tools: toolDefs.map(t => t.name) };
 }
 
 describe('MCP progressive disclosure client detection', () => {
   afterEach(() => jest.clearAllMocks());
 
-  test('OpenCode gets progressive disclosure instead of all tools', async () => {
-    const { init, tools } = await initializeAndList(makeServer(), 'opencode');
+  test('OpenCode gets a small progressive startup surface', async () => {
+    const { init, toolDefs, tools } = await initializeAndList(makeServer(), 'opencode');
 
     expect(init.result?.capabilities?.tools?.listChanged).toBe(true);
     expect(tools).toContain('expand_tools');
-    expect(tools.length).toBeLessThan(118);
+    expect(tools.length).toBeLessThanOrEqual(16);
+    expect(JSON.stringify(toolDefs).length).toBeLessThanOrEqual(40000);
+    expect(tools).toEqual(expect.arrayContaining([
+      'navigate',
+      'computer',
+      'read_page',
+      'find',
+      'query_dom',
+      'interact',
+      'form_input',
+      'tabs_context',
+      'tabs_create',
+      'tabs_close',
+      'wait_for',
+      'page_screenshot',
+      'oc_connection_health',
+      'oc_stop',
+    ]));
   });
 
   test('capability-aware unknown clients get progressive disclosure', async () => {

--- a/tests/mcp-progressive-disclosure.test.ts
+++ b/tests/mcp-progressive-disclosure.test.ts
@@ -92,6 +92,20 @@ describe('MCP progressive disclosure client detection', () => {
     expect(tools.length).toBeLessThan(118);
   });
 
+
+  test('explicit minimal mode keeps unknown clients on the small startup surface', async () => {
+    const mockSM = createMockSessionManager();
+    (getSessionManager as jest.Mock).mockReturnValue(mockSM);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const server = new MCPServer(mockSM as any, { initialToolTier: 1 });
+    registerAllTools(server);
+
+    const { tools } = await initializeAndList(server, 'unknown-editor');
+
+    expect(tools).toContain('expand_tools');
+    expect(tools.length).toBeLessThanOrEqual(16);
+  });
+
   test('unknown clients without list_changed support keep legacy all-tools behavior', async () => {
     const { init, tools } = await initializeAndList(makeServer(), 'unknown-editor');
 

--- a/tests/mcp-progressive-disclosure.test.ts
+++ b/tests/mcp-progressive-disclosure.test.ts
@@ -1,0 +1,84 @@
+/// <reference types="jest" />
+
+import { createMockSessionManager } from './utils/mock-session';
+
+jest.mock('../src/cdp/client', () => ({
+  getCDPClient: jest.fn(() => ({
+    forceReconnect: jest.fn().mockResolvedValue(undefined),
+    isConnected: jest.fn().mockReturnValue(false),
+  })),
+}));
+
+jest.mock('../src/session-manager', () => ({
+  getSessionManager: jest.fn(),
+}));
+
+import { getSessionManager } from '../src/session-manager';
+import { MCPServer } from '../src/mcp-server';
+import { registerAllTools } from '../src/tools';
+
+interface TestResponse {
+  result?: {
+    capabilities?: { tools?: { listChanged?: boolean } };
+    tools?: Array<{ name: string }>;
+  };
+}
+
+function makeServer(): MCPServer {
+  const mockSM = createMockSessionManager();
+  (getSessionManager as jest.Mock).mockReturnValue(mockSM);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const server = new MCPServer(mockSM as any);
+  registerAllTools(server);
+  return server;
+}
+
+async function initializeAndList(server: MCPServer, clientName: string, capabilities: Record<string, unknown> = {}): Promise<{ init: TestResponse; tools: string[] }> {
+  const init = await server.handleRequest({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities,
+      clientInfo: { name: clientName, version: '0.0.0' },
+    },
+  }) as TestResponse;
+
+  const listed = await server.handleRequest({
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/list',
+    params: {},
+  }) as TestResponse;
+
+  return { init, tools: (listed.result?.tools ?? []).map(t => t.name) };
+}
+
+describe('MCP progressive disclosure client detection', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  test('OpenCode gets progressive disclosure instead of all tools', async () => {
+    const { init, tools } = await initializeAndList(makeServer(), 'opencode');
+
+    expect(init.result?.capabilities?.tools?.listChanged).toBe(true);
+    expect(tools).toContain('expand_tools');
+    expect(tools.length).toBeLessThan(118);
+  });
+
+  test('capability-aware unknown clients get progressive disclosure', async () => {
+    const { init, tools } = await initializeAndList(makeServer(), 'unknown-editor', { tools: { listChanged: true } });
+
+    expect(init.result?.capabilities?.tools?.listChanged).toBe(true);
+    expect(tools).toContain('expand_tools');
+    expect(tools.length).toBeLessThan(118);
+  });
+
+  test('unknown clients without list_changed support keep legacy all-tools behavior', async () => {
+    const { init, tools } = await initializeAndList(makeServer(), 'unknown-editor');
+
+    expect(init.result?.capabilities?.tools?.listChanged).toBe(false);
+    expect(tools).not.toContain('expand_tools');
+    expect(tools.length).toBeGreaterThanOrEqual(118);
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -165,7 +165,8 @@ describe('MCPServer', () => {
       expect(server.getToolNames()).toContain('test_tool');
     });
 
-    test('returns registered tools via tools/list', async () => {
+    test('returns registered tools via tools/list when full exposure is requested', async () => {
+      server = new MCPServer(mockSessionManager as any, { initialToolTier: 3 });
       const handler = jest.fn();
       const definition: MCPToolDefinition = {
         name: 'my_tool',


### PR DESCRIPTION
## Summary

Bring `develop` back in sync with the five commits already released on `main`, including the progressive-disclosure and minimal-startup work from #1525, #1526, and #1527.

## Rationale

Feature pull requests target `develop`. Leaving these released commits only on `main` would make the next feature branch regress the current tool-surface behavior or carry unrelated reconciliation work.

## Validation

- This branch is a strict fast-forward from `origin/develop` to `origin/main`.
- No new code or merge commit is introduced.
- The tip is the released `main` commit `a0bd63a7`, whose full CI matrix passed when #1527 landed.

## Risk

Narrow. This only restores branch ancestry so future feature PRs start from the released product state.