### PR TITLE
Add bounded intent search to progressive tool disclosure

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -422,12 +422,68 @@ export interface MCPServerOptions {
 }
 
 const STDIO_TOOL_EXPOSURE_SESSION = 'stdio';
+const DEFAULT_TOOL_SEARCH_LIMIT = 5;
+const MAX_TOOL_SEARCH_LIMIT = 8;
+const MAX_SELECTED_TOOL_COUNT = 12;
+const MAX_SELECTED_SCHEMA_BYTES = 16_000;
 
 interface ToolExposureState {
   exposedTier: ToolTier;
   selectedToolNames: Set<string>;
+  selectedSchemaBytes: number;
   clientSupportsListChanged: boolean;
   clientDetected: boolean;
+}
+
+function normalizeToolSearchText(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function toolSchemaSearchText(schema: unknown): string {
+  if (!schema || typeof schema !== 'object') return '';
+  const parts: string[] = [];
+  const visit = (value: unknown, propertyName?: string): void => {
+    if (!value || typeof value !== 'object') return;
+    const record = value as Record<string, unknown>;
+    if (propertyName) parts.push(propertyName);
+    if (typeof record.type === 'string') parts.push(record.type);
+    if (typeof record.description === 'string') parts.push(record.description);
+    if (Array.isArray(record.enum)) parts.push(...record.enum.map(String));
+    if (record.properties && typeof record.properties === 'object') {
+      for (const [name, child] of Object.entries(record.properties as Record<string, unknown>)) {
+        visit(child, name);
+      }
+    }
+  };
+  visit(schema);
+  return parts.join(' ');
+}
+
+function scoreToolSearch(query: string, definition: MCPToolDefinition): number {
+  const phrase = normalizeToolSearchText(query);
+  const tokens = Array.from(new Set(phrase.split(' ').filter(Boolean)));
+  if (tokens.length === 0) return 0;
+  const name = normalizeToolSearchText(definition.name);
+  const description = normalizeToolSearchText(definition.description);
+  const capability = normalizeToolSearchText(definition.capability ?? 'core');
+  const parameters = normalizeToolSearchText(toolSchemaSearchText(definition.inputSchema));
+  let score = 0;
+  if (name.includes(phrase)) score += 14;
+  if (description.includes(phrase)) score += 8;
+  if (capability.includes(phrase)) score += 6;
+  if (parameters.includes(phrase)) score += 5;
+  for (const token of tokens) {
+    if (name.split(' ').includes(token)) score += 9;
+    else if (name.includes(token)) score += 6;
+    if (description.includes(token)) score += 3;
+    if (capability.includes(token)) score += 2;
+    if (parameters.includes(token)) score += 2;
+  }
+  return score;
 }
 
 
@@ -676,6 +732,7 @@ export class MCPServer {
       state = {
         exposedTier: this.options.initialToolTier ?? 1,
         selectedToolNames: new Set(),
+        selectedSchemaBytes: 0,
         clientSupportsListChanged: true,
         clientDetected: false,
       };
@@ -1462,7 +1519,7 @@ export class MCPServer {
       if (hiddenCount > 0) {
         tools.push({
           name: 'expand_tools',
-          description: `Show ${hiddenCount} additional specialist tools (network, emulation, PDF, orchestration, etc). Call with tier=2 for specialist tools, tier=3 for all tools including orchestration.`,
+          description: `Discover or show ${hiddenCount} additional specialist tools. Use query to expose only intent-matched tools, tier=2 for all specialist tools, or tier=3 for everything including orchestration.`,
           inputSchema: {
             type: 'object',
             properties: {
@@ -1471,8 +1528,17 @@ export class MCPServer {
                 enum: Array.from({ length: 3 - exposureState.exposedTier }, (_, i) => String(exposureState.exposedTier + 1 + i)),
                 description: 'Tool tier to expand to. 2=specialist, 3=all including orchestration',
               },
+              query: {
+                type: 'string',
+                description: 'Intent or capability to find, such as PDF export, network capture, or workflow status',
+              },
+              limit: {
+                type: 'integer',
+                minimum: 1,
+                maximum: MAX_TOOL_SEARCH_LIMIT,
+                description: `Maximum matching schemas to expose. Defaults to ${DEFAULT_TOOL_SEARCH_LIMIT}.`,
+              },
             },
-            required: ['tier'],
           },
           annotations: TOOL_ANNOTATIONS.expand_tools,
         });
@@ -1767,6 +1833,78 @@ export class MCPServer {
             isError: true,
           };
         }
+      }
+
+      if (toolArgs.query !== undefined) {
+        if (toolArgs.tier !== undefined) {
+          return {
+            content: [{ type: 'text', text: 'Error: provide either query or tier, not both.' }],
+            isError: true,
+          };
+        }
+        const query = typeof toolArgs.query === 'string' ? toolArgs.query.trim() : '';
+        if (query.length === 0 || query.length > 256) {
+          return {
+            content: [{ type: 'text', text: 'Error: query must be a non-empty string of at most 256 characters.' }],
+            isError: true,
+          };
+        }
+        const requestedLimit = typeof toolArgs.limit === 'number'
+          ? toolArgs.limit
+          : Number(toolArgs.limit ?? DEFAULT_TOOL_SEARCH_LIMIT);
+        const limit = Math.max(
+          1,
+          Math.min(MAX_TOOL_SEARCH_LIMIT, Number.isFinite(requestedLimit) ? Math.floor(requestedLimit) : DEFAULT_TOOL_SEARCH_LIMIT),
+        );
+        const ranked = Array.from(this.tools.values())
+          .filter((registry) => {
+            const definition = registry.definition;
+            return getToolTier(definition.name) > exposureState.exposedTier
+              && !exposureState.selectedToolNames.has(definition.name)
+              && this.isCapabilityAllowed(definition.capability)
+              && (!principal || isAllowed(definition.name, principal.scopes));
+          })
+          .map((registry) => ({
+            definition: registry.definition,
+            score: scoreToolSearch(query, registry.definition),
+          }))
+          .filter((candidate) => candidate.score > 0)
+          .sort((a, b) => {
+            if (b.score !== a.score) return b.score - a.score;
+            return a.definition.name < b.definition.name ? -1 : a.definition.name > b.definition.name ? 1 : 0;
+          });
+
+        const selected: MCPToolDefinition[] = [];
+        for (const candidate of ranked) {
+          if (selected.length >= limit || exposureState.selectedToolNames.size >= MAX_SELECTED_TOOL_COUNT) break;
+          const schemaBytes = Buffer.byteLength(JSON.stringify(candidate.definition), 'utf8');
+          if (exposureState.selectedSchemaBytes + schemaBytes > MAX_SELECTED_SCHEMA_BYTES) continue;
+          exposureState.selectedToolNames.add(candidate.definition.name);
+          exposureState.selectedSchemaBytes += schemaBytes;
+          selected.push(candidate.definition);
+        }
+        if (selected.length > 0 && exposureState.clientSupportsListChanged) {
+          this.sendToolListChanged(this.currentToolExposureSessionId());
+        }
+        const searchResult = {
+          query,
+          matchedCount: ranked.length,
+          exposedCount: selected.length,
+          omittedCount: ranked.length - selected.length,
+          selectedToolCount: exposureState.selectedToolNames.size,
+          selectedSchemaBytes: exposureState.selectedSchemaBytes,
+          limits: {
+            resultCount: MAX_TOOL_SEARCH_LIMIT,
+            selectedToolCount: MAX_SELECTED_TOOL_COUNT,
+            selectedSchemaBytes: MAX_SELECTED_SCHEMA_BYTES,
+          },
+          tools: selected,
+        };
+        const expandResult: MCPResult = {
+          content: [{ type: 'text', text: JSON.stringify(searchResult) }],
+        };
+        this.recordToolOutputObservability(toolName, expandResult);
+        return expandResult;
       }
 
       const oldTier = exposureState.exposedTier;

--- a/tests/mcp/expand-tools-schema.test.ts
+++ b/tests/mcp/expand-tools-schema.test.ts
@@ -28,6 +28,22 @@ jest.mock('../../src/config/global', () => ({
 // ─── Imports ─────────────────────────────────────────────────────────────────
 
 import { MCPServer } from '../../src/mcp-server';
+import type { MCPToolDefinition } from '../../src/types/mcp';
+
+const annotations = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+};
+
+function registerSearchTool(server: MCPServer, definition: Omit<MCPToolDefinition, 'annotations'>): void {
+  server.registerTool(definition.name, jest.fn(), { ...definition, annotations });
+}
+
+function parseTextResult(result: any): any {
+  return JSON.parse(result.content?.[0]?.text ?? '{}');
+}
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
@@ -82,6 +98,25 @@ describe('expand_tools schema (Gemini compatibility)', () => {
     }
   });
 
+  test('schema advertises optional intent query and bounded limit', async () => {
+    registerSearchTool(server, {
+      name: 'page_pdf',
+      description: 'Export the current page as PDF',
+      inputSchema: { type: 'object', properties: {} },
+    });
+    // @ts-expect-error - accessing private method for testing
+    const result = await server.handleToolsList();
+    const expandTool = (result as any).tools?.find((t: any) => t.name === 'expand_tools');
+
+    expect(expandTool.inputSchema.properties.query.type).toBe('string');
+    expect(expandTool.inputSchema.properties.limit).toMatchObject({
+      type: 'integer',
+      minimum: 1,
+      maximum: 8,
+    });
+    expect(expandTool.inputSchema.required).toBeUndefined();
+  });
+
   test('expand_tools handler accepts string tier values', async () => {
     // @ts-expect-error - accessing private method for testing
     const result = await server.handleToolsCall({ name: 'expand_tools', arguments: { tier: '2' } });
@@ -128,5 +163,73 @@ describe('expand_tools schema (Gemini compatibility)', () => {
     const text = (result as any).content?.[0]?.text;
     expect(text).toContain('Tool tier expanded');
     expect(text).not.toContain('Newly available tools:');
+  });
+
+  test('query mode exposes only matching hidden tools', async () => {
+    registerSearchTool(server, {
+      name: 'page_pdf',
+      description: 'Export the current page as a PDF document',
+      inputSchema: { type: 'object', properties: {} },
+    });
+    registerSearchTool(server, {
+      name: 'drag_drop',
+      description: 'Drag one element onto another element',
+      inputSchema: { type: 'object', properties: {} },
+    });
+
+    // @ts-expect-error - accessing private method for testing
+    const result = await server.handleToolsCall({ name: 'expand_tools', arguments: { query: 'export pdf' } });
+    const search = parseTextResult(result);
+    // @ts-expect-error - accessing private method for testing
+    const listed = await server.handleToolsList();
+    const names = (listed as any).tools.map((tool: any) => tool.name);
+
+    expect(search.tools.map((tool: any) => tool.name)).toEqual(['page_pdf']);
+    expect(names).toContain('page_pdf');
+    expect(names).not.toContain('drag_drop');
+  });
+
+  test('query ranking is deterministic across registration order', async () => {
+    const makeRankedServer = (names: string[]): MCPServer => {
+      const ranked = new MCPServer();
+      for (const name of names) {
+        registerSearchTool(ranked, {
+          name,
+          description: 'Deterministic pdf export helper',
+          inputSchema: { type: 'object', properties: {} },
+        });
+      }
+      return ranked;
+    };
+
+    const first = makeRankedServer(['zeta_pdf', 'alpha_pdf']);
+    const second = makeRankedServer(['alpha_pdf', 'zeta_pdf']);
+    // @ts-expect-error - accessing private method for testing
+    const firstResult = parseTextResult(await first.handleToolsCall({ name: 'expand_tools', arguments: { query: 'pdf' } }));
+    // @ts-expect-error - accessing private method for testing
+    const secondResult = parseTextResult(await second.handleToolsCall({ name: 'expand_tools', arguments: { query: 'pdf' } }));
+
+    expect(firstResult.tools.map((tool: any) => tool.name)).toEqual(['alpha_pdf', 'zeta_pdf']);
+    expect(secondResult.tools.map((tool: any) => tool.name)).toEqual(['alpha_pdf', 'zeta_pdf']);
+  });
+
+  test('query mode enforces result-count and cumulative schema-byte budgets', async () => {
+    for (let i = 0; i < 20; i++) {
+      registerSearchTool(server, {
+        name: `bounded_tool_${String(i).padStart(2, '0')}`,
+        description: `Bounded specialist ${'x'.repeat(4000)}`,
+        inputSchema: { type: 'object', properties: {} },
+      });
+    }
+
+    // @ts-expect-error - accessing private method for testing
+    const result = parseTextResult(await server.handleToolsCall({
+      name: 'expand_tools',
+      arguments: { query: 'bounded specialist', limit: 99 },
+    }));
+
+    expect(result.tools.length).toBeLessThanOrEqual(8);
+    expect(result.selectedSchemaBytes).toBeLessThanOrEqual(16000);
+    expect(result.omittedCount).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

Complete #1567 by extending the existing synthetic `expand_tools` tool with deterministic query mode.

- Search hidden registered tools by name, description, capability, and parameter metadata.
- Expose only matching schemas to the originating MCP session.
- Preserve the existing `tier=2|3` branch and direct-call compatibility.
- Filter candidates through capability and principal-scope policy.
- Bound each query to 8 results, each session to 12 selected tools, and cumulative selected schemas to 16,000 UTF-8 bytes.
- Return full selected definitions as a deterministic fallback while sending a targeted list-change notification when supported.

## Direction fit

This adopts the compact-catalog/tool-search advantage observed in BuilderIO/agent-native without importing its app framework, autonomous runtime, LLM loop, dependencies, or source code. OpenChrome remains a host-neutral MCP browser harness: the server ranks registry facts deterministically; the host decides what capability to use.

## Compatibility

- Calls with only `tier` keep the previous response text and effects.
- Unknown clients without list-change support keep the legacy full catalog.
- `--minimal`, `--all-tools`, annotations, capability filters, and direct hidden-tool calls remain available.
- `expand_tools` remains mutating/write-scoped.

## Validation

- `npm run build`
- `npx jest tests/mcp/expand-tools-schema.test.ts tests/mcp-progressive-disclosure.test.ts tests/capability-filter.test.ts --runInBand`
- `npm run lint:changed`
- `npm run lint:tier`
- `npm run lint:tool-schemas`

The targeted suites passed 33/33 tests after the session-isolation prerequisite in #1573.

## Risk

Moderate. The search path is intentionally pure and bounded; tests cover schema compatibility, selective visibility, deterministic ordering independent of registration order, count limits, byte limits, progressive startup regression, and capability filtering.

Closes #1567.