### PR TITLE
feat(cli): preserve stable IDs in playbook results

### DIFF
--- a/cli/playbook/parse.ts
+++ b/cli/playbook/parse.ts
@@ -3,7 +3,8 @@
  *
  * Validates:
  *   { name?: string, vars?: Record<string,string>, steps: Step[] }
- * Each step must have exactly one verb key from SUPPORTED_VERBS.
+ * Each step may have one stable `id` plus exactly one verb key from
+ * SUPPORTED_VERBS.
  */
 
 import * as fs from 'fs';
@@ -24,7 +25,11 @@ export const SUPPORTED_VERBS = [
 
 export type Verb = (typeof SUPPORTED_VERBS)[number];
 
+const STEP_METADATA_KEYS = new Set(['id']);
+const STEP_ID_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
+
 export interface Step {
+  id?: string;
   verb: Verb;
   args: Record<string, unknown>;
 }
@@ -55,7 +60,9 @@ function parseRawStep(raw: unknown, index: number): Step {
   }
   const keys = Object.keys(raw);
   const verbKeys = keys.filter((k) => SUPPORTED_VERBS.includes(k as Verb));
-  const unknownKeys = keys.filter((k) => !SUPPORTED_VERBS.includes(k as Verb));
+  const unknownKeys = keys.filter(
+    (k) => !SUPPORTED_VERBS.includes(k as Verb) && !STEP_METADATA_KEYS.has(k),
+  );
 
   if (verbKeys.length === 0) {
     if (unknownKeys.length > 0) {
@@ -72,16 +79,28 @@ function parseRawStep(raw: unknown, index: number): Step {
     );
   }
 
-  // P2 codex fix: strict validation — reject extra non-verb keys even when a
-  // valid verb is present. Without this, typos or misplaced fields at the step
-  // top level (e.g. `args:` alongside `navigate:`) would be silently dropped,
-  // making playbooks harder to debug. A step is exactly { <verb>: <args> }.
+  // Strict validation: reject extra keys even when a valid verb is present.
+  // `id` is the only reserved metadata key; all step parameters still belong
+  // inside the verb's value.
   if (unknownKeys.length > 0) {
     throw new ParseError(
       `Step ${index}: unexpected key "${unknownKeys[0]}" alongside verb "${verbKeys[0]}". ` +
-        `Each step must contain exactly one verb key; put step parameters inside the verb's value. ` +
+        `Each step may contain only an optional "id" plus exactly one verb key; ` +
+        `put step parameters inside the verb's value. ` +
         `Supported verbs: ${SUPPORTED_VERBS.join(', ')}`,
     );
+  }
+
+  const id = raw['id'];
+  if (id !== undefined) {
+    if (typeof id !== 'string') {
+      throw new ParseError(`Step ${index}: id must be a string`);
+    }
+    if (!STEP_ID_PATTERN.test(id)) {
+      throw new ParseError(
+        `Step ${index}: invalid id "${id}". IDs must match ${STEP_ID_PATTERN.source}`,
+      );
+    }
   }
 
   const verb = verbKeys[0] as Verb;
@@ -92,7 +111,11 @@ function parseRawStep(raw: unknown, index: number): Step {
     throw new ParseError(`Step ${index}: args for verb "${verb}" must be an object or null`);
   }
 
-  return { verb, args: (isRecord(args) ? args : {}) as Record<string, unknown> };
+  return {
+    ...(id !== undefined ? { id } : {}),
+    verb,
+    args: (isRecord(args) ? args : {}) as Record<string, unknown>,
+  };
 }
 
 function validateRawPlaybook(raw: unknown): Playbook {
@@ -120,6 +143,17 @@ function validateRawPlaybook(raw: unknown): Playbook {
   }
 
   const steps: Step[] = (raw['steps'] as unknown[]).map((s, i) => parseRawStep(s, i));
+  const stepIds = new Map<string, number>();
+  steps.forEach((step, index) => {
+    if (step.id === undefined) return;
+    const existingIndex = stepIds.get(step.id);
+    if (existingIndex !== undefined) {
+      throw new ParseError(
+        `Step ${index}: duplicate id "${step.id}" (already used by step ${existingIndex})`,
+      );
+    }
+    stepIds.set(step.id, index);
+  });
 
   return {
     name: raw['name'] as string | undefined,

--- a/cli/playbook/report.ts
+++ b/cli/playbook/report.ts
@@ -25,7 +25,8 @@ function formatPlain(result: RunResult): string {
   for (const step of result.steps) {
     const icon = STATUS_ICON[step.status] ?? step.status.toUpperCase();
     const dur = step.status === 'skipped' ? '-' : `${step.durationMs}ms`;
-    lines.push(`  [${icon}] step ${step.index}: ${step.verb} (${dur})`);
+    const id = step.id === undefined ? '' : ` [${step.id}]`;
+    lines.push(`  [${icon}] step ${step.index}${id}: ${step.verb} (${dur})`);
     if (step.error) {
       lines.push(`         ${step.error}`);
     }
@@ -40,14 +41,25 @@ function formatPlain(result: RunResult): string {
 function formatMarkdown(result: RunResult): string {
   const name = result.name ?? '(unnamed playbook)';
   const lines: string[] = [];
+  const includesIds = result.steps.some((step) => step.id !== undefined);
   lines.push(`# Playbook: ${name}`);
   lines.push('');
-  lines.push('| # | Verb | Tool | Status | Duration |');
-  lines.push('|---|------|------|--------|----------|');
+  if (includesIds) {
+    lines.push('| # | ID | Verb | Tool | Status | Duration |');
+    lines.push('|---|----|------|------|--------|----------|');
+  } else {
+    lines.push('| # | Verb | Tool | Status | Duration |');
+    lines.push('|---|------|------|--------|----------|');
+  }
 
   for (const step of result.steps) {
     const dur = step.status === 'skipped' ? '-' : `${step.durationMs}ms`;
-    lines.push(`| ${step.index} | \`${step.verb}\` | \`${step.tool || '-'}\` | ${step.status.toUpperCase()} | ${dur} |`);
+    if (includesIds) {
+      const id = step.id === undefined ? '-' : `\`${step.id}\``;
+      lines.push(`| ${step.index} | ${id} | \`${step.verb}\` | \`${step.tool || '-'}\` | ${step.status.toUpperCase()} | ${dur} |`);
+    } else {
+      lines.push(`| ${step.index} | \`${step.verb}\` | \`${step.tool || '-'}\` | ${step.status.toUpperCase()} | ${dur} |`);
+    }
   }
 
   lines.push('');

--- a/cli/playbook/run.ts
+++ b/cli/playbook/run.ts
@@ -14,6 +14,7 @@ export type StepStatus = 'ok' | 'failed' | 'skipped';
 
 export interface StepResult {
   index: number;
+  id?: string;
   verb: string;
   tool: string;
   args: Record<string, unknown>;
@@ -76,6 +77,11 @@ function extractTabId(result: unknown): string | undefined {
   return typeof tabId === 'string' && tabId.length > 0 ? tabId : undefined;
 }
 
+function formatStepContext(index: number, step: Step): string {
+  const id = step.id === undefined ? '' : ` [${step.id}]`;
+  return `Step ${index}${id} (${step.verb})`;
+}
+
 export async function runPlaybook(playbook: Playbook, options: RunOptions): Promise<RunResult> {
   const client = options.client ?? new StdioMcpClient();
 
@@ -98,6 +104,7 @@ export async function runPlaybook(playbook: Playbook, options: RunOptions): Prom
       if (failed) {
         stepResults.push({
           index: i,
+          ...(step.id !== undefined ? { id: step.id } : {}),
           verb: step.verb,
           tool: '',
           args: {},
@@ -125,9 +132,9 @@ export async function runPlaybook(playbook: Playbook, options: RunOptions): Prom
         if (!callResult.success) {
           status = 'failed';
           failed = true;
-          error = `Step ${i} (${step.verb}): tool call returned failure`;
+          error = `${formatStepContext(i, step)}: tool call returned failure`;
           if (callResult.verdict) {
-            error = `Step ${i} (${step.verb}): assert verdict="${callResult.verdict}"`;
+            error = `${formatStepContext(i, step)}: assert verdict="${callResult.verdict}"`;
           }
         }
         currentTabId = extractTabId(callResult.result) ?? currentTabId;
@@ -144,11 +151,12 @@ export async function runPlaybook(playbook: Playbook, options: RunOptions): Prom
         }
         status = 'failed';
         failed = true;
-        error = `Step ${i} (${step.verb}): ${err instanceof Error ? err.message : String(err)}`;
+        error = `${formatStepContext(i, step)}: ${err instanceof Error ? err.message : String(err)}`;
       }
 
       stepResults.push({
         index: i,
+        ...(step.id !== undefined ? { id: step.id } : {}),
         verb: step.verb,
         tool: expanded.tool,
         args: expanded.callArgs,

--- a/docs/cli/playbook.md
+++ b/docs/cli/playbook.md
@@ -28,7 +28,8 @@ name: <string>           # optional — appears in reports
 vars:                    # optional — key/value defaults; CLI --vars override these
   KEY: value
 steps:
-  - <verb>:              # exactly one verb per step
+  - id: <string>         # optional stable author-supplied step label
+    <verb>:              # exactly one verb per step
       <arg>: <value>     # verb-specific args (see table below)
 ```
 
@@ -36,7 +37,8 @@ steps:
 
 ```yaml
 steps:
-  - navigate:
+  - id: open_home
+    navigate:
       url: https://example.com
 ```
 
@@ -48,9 +50,11 @@ vars:
   url: https://example.com
   heading: Example
 steps:
-  - navigate:
+  - id: open_home
+    navigate:
       url: ${url}
-  - assert:
+  - id: verify_heading
+    assert:
       kind: dom_text
       selector: h1
       pattern: ${heading}
@@ -70,6 +74,26 @@ steps:
   - act:
       action: "scroll down"
 ```
+
+## Stable step IDs
+
+Each step may include an optional author-supplied `id` alongside exactly one
+verb. IDs make reports and failure diagnostics stable when earlier steps are
+inserted or reordered.
+
+Rules:
+
+- IDs must match `^[a-z][a-z0-9_-]{0,63}$`.
+- IDs must be unique within one playbook.
+- IDs use lowercase ASCII and are compared exactly.
+- IDs are metadata and are never forwarded to MCP tool arguments.
+- Numeric `index` remains 0-based and is always present in run results.
+- A missing ID remains absent; OpenChrome does not synthesize IDs from indexes.
+- IDs do not create graph edges, jumps, dependencies, or control flow.
+
+Legacy playbooks without IDs continue to parse and run unchanged. Plain and
+Markdown reports also preserve their previous layout when no step has an ID;
+the Markdown `ID` column appears only when at least one result carries an ID.
 
 ---
 
@@ -178,15 +202,17 @@ The playbook executes **sequentially**. When a step fails:
 2. All subsequent steps are marked `skipped` — their MCP tools are **not** called.
 3. The runner disconnects and exits with code `1`.
 
-Example output (`--json`) after step 1 fails in a 3-step playbook:
+Abbreviated output (`--json`) after step 1 fails in a 3-step playbook. The
+complete schema also includes `tool`, `args`, and optional `result` fields as
+documented below:
 
 ```json
 {
   "name": "fail-fast fixture",
   "steps": [
     { "index": 0, "verb": "navigate", "status": "ok",      "durationMs": 45 },
-    { "index": 1, "verb": "assert",   "status": "failed",  "durationMs": 12, "error": "Step 1 (assert): assert verdict=\"fail\"" },
-    { "index": 2, "verb": "interact", "status": "skipped", "durationMs": 0  }
+    { "index": 1, "id": "verify_heading", "verb": "assert", "status": "failed", "durationMs": 12, "error": "Step 1 [verify_heading] (assert): assert verdict=\"fail\"" },
+    { "index": 2, "verb": "interact", "status": "skipped", "durationMs": 0 }
   ],
   "summary": { "ok": false, "total": 3, "passed": 1, "failed": 1, "skipped": 1 }
 }
@@ -227,6 +253,7 @@ Options:
   name: string | undefined,
   steps: Array<{
     index:      number,           // 0-based
+    id?:        string,           // optional stable author-supplied label
     verb:       string,           // playbook verb (e.g. "navigate")
     tool:       string,           // MCP tool name (e.g. "oc_assert")
     args:       object,           // args sent to the MCP tool
@@ -256,8 +283,8 @@ The same parser accepts `.json` files using the identical top-level shape:
   "name": "example.com sanity (JSON)",
   "vars": { "url": "https://example.com" },
   "steps": [
-    { "navigate": { "url": "${url}" } },
-    { "assert": { "kind": "dom_text", "selector": "h1", "pattern": "Example" } }
+    { "id": "open_home", "navigate": { "url": "${url}" } },
+    { "id": "verify_heading", "assert": { "kind": "dom_text", "selector": "h1", "pattern": "Example" } }
   ]
 }
 ```

--- a/tests/cli/playbook/parse.test.ts
+++ b/tests/cli/playbook/parse.test.ts
@@ -39,6 +39,58 @@ describe('parsePlaybookContent — YAML', () => {
     expect(pb.steps).toHaveLength(1);
   });
 
+  test('accepts optional stable step ids in YAML', () => {
+    const pb = loadPlaybook(path.join(FIXTURES, 'step-ids.yaml'));
+
+    expect(pb.steps).toEqual([
+      { id: 'open_home', verb: 'navigate', args: { url: 'https://example.com' } },
+      { id: 'verify_home', verb: 'assert', args: { kind: 'url', pattern: 'example\\.com' } },
+    ]);
+  });
+
+  test('accepts optional stable step ids in JSON', () => {
+    const pb = loadPlaybook(path.join(FIXTURES, 'step-ids.json'));
+
+    expect(pb.steps.map((step) => step.id)).toEqual(['open_home', 'verify_home']);
+  });
+
+  test('accepts an id at the 64-character boundary', () => {
+    const id = `a${'b'.repeat(63)}`;
+    const yaml = `steps:\n  - id: ${id}\n    navigate:\n      url: https://example.com\n`;
+
+    expect(parsePlaybookContent(yaml, 'test.yaml').steps[0].id).toBe(id);
+  });
+
+  test.each([
+    ['uppercase', 'Open_home'],
+    ['leading digit', '1_open_home'],
+    ['Unicode', '열기'],
+    ['empty', ''],
+    ['too long', `a${'b'.repeat(64)}`],
+  ])('rejects %s step id', (_label, id) => {
+    const yaml = `steps:\n  - id: ${JSON.stringify(id)}\n    navigate:\n      url: https://example.com\n`;
+
+    expect(() => parsePlaybookContent(yaml, 'test.yaml')).toThrow(/invalid id/i);
+  });
+
+  test('rejects non-string step id', () => {
+    const yaml = `steps:\n  - id: 42\n    navigate:\n      url: https://example.com\n`;
+
+    expect(() => parsePlaybookContent(yaml, 'test.yaml')).toThrow(/id.*string/i);
+  });
+
+  test('rejects duplicate step ids before execution', () => {
+    const yaml = `steps:\n  - id: open_home\n    navigate:\n      url: https://example.com\n  - id: open_home\n    read_page:\n      mode: ax\n`;
+
+    expect(() => parsePlaybookContent(yaml, 'test.yaml')).toThrow(/duplicate id "open_home".*step 0/i);
+  });
+
+  test('rejects unknown metadata alongside id and verb', () => {
+    const yaml = `steps:\n  - id: open_home\n    description: Open the fixture\n    navigate:\n      url: https://example.com\n`;
+
+    expect(() => parsePlaybookContent(yaml, 'test.yaml')).toThrow(/unexpected key "description"/i);
+  });
+
   test('rejects unknown verb', () => {
     const yaml = `steps:\n  - unknown_verb:\n      foo: bar\n`;
     expect(() => parsePlaybookContent(yaml, 'test.yaml')).toThrow(ParseError);

--- a/tests/cli/playbook/report.test.ts
+++ b/tests/cli/playbook/report.test.ts
@@ -1,0 +1,97 @@
+/// <reference types="jest" />
+
+import { formatMarkdown, formatPlain, writeReport } from '../../../cli/playbook/report';
+import type { RunResult } from '../../../cli/playbook/run';
+
+const result: RunResult = {
+  name: 'stable ids',
+  steps: [
+    {
+      index: 0,
+      id: 'open_home',
+      verb: 'navigate',
+      tool: 'navigate',
+      args: { url: 'https://example.com' },
+      status: 'ok',
+      durationMs: 12,
+    },
+    {
+      index: 1,
+      verb: 'assert',
+      tool: 'oc_assert',
+      args: { contract: { kind: 'url', pattern: 'missing' } },
+      status: 'failed',
+      durationMs: 3,
+      error: 'Step 1 (assert): assert verdict="fail"',
+    },
+  ],
+  summary: {
+    ok: false,
+    total: 2,
+    passed: 1,
+    failed: 1,
+    skipped: 0,
+  },
+};
+
+describe('playbook report formatting', () => {
+  test('plain output includes authored ids and preserves legacy index rendering when absent', () => {
+    expect(formatPlain(result)).toBe([
+      'Playbook: stable ids',
+      '',
+      '  [PASS] step 0 [open_home]: navigate (12ms)',
+      '  [FAIL] step 1: assert (3ms)',
+      '         Step 1 (assert): assert verdict="fail"',
+      '',
+      'Summary: FAIL — 1/2 passed, 1 failed, 0 skipped',
+    ].join('\n'));
+  });
+
+  test('Markdown output adds a stable ID column and uses a dash when absent', () => {
+    expect(formatMarkdown(result)).toBe([
+      '# Playbook: stable ids',
+      '',
+      '| # | ID | Verb | Tool | Status | Duration |',
+      '|---|----|------|------|--------|----------|',
+      '| 0 | `open_home` | `navigate` | `navigate` | OK | 12ms |',
+      '| 1 | - | `assert` | `oc_assert` | FAILED | 3ms |',
+      '',
+      '**Result:** FAIL — 1/2 passed, 1 failed, 0 skipped',
+    ].join('\n'));
+  });
+
+  test('Markdown output preserves the legacy table when no step has an id', () => {
+    const legacyResult: RunResult = {
+      ...result,
+      steps: result.steps.map(({ id: _id, ...step }) => step),
+    };
+
+    expect(formatMarkdown(legacyResult)).toBe([
+      '# Playbook: stable ids',
+      '',
+      '| # | Verb | Tool | Status | Duration |',
+      '|---|------|------|--------|----------|',
+      '| 0 | `navigate` | `navigate` | OK | 12ms |',
+      '| 1 | `assert` | `oc_assert` | FAILED | 3ms |',
+      '',
+      '**Result:** FAIL — 1/2 passed, 1 failed, 0 skipped',
+    ].join('\n'));
+  });
+
+  test('JSON output serializes identified rows and omits absent ids', () => {
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      writeReport(result, { json: true });
+
+      expect(log).toHaveBeenCalledTimes(1);
+      const output = log.mock.calls[0][0] as string;
+      expect(JSON.parse(output)).toEqual(result);
+      expect(output).toContain('"id": "open_home"');
+      expect(output).not.toContain('"id": null');
+      expect(Object.prototype.hasOwnProperty.call(JSON.parse(output).steps[1], 'id')).toBe(false);
+    } finally {
+      log.mockRestore();
+    }
+  });
+});

--- a/tests/cli/playbook/run.test.ts
+++ b/tests/cli/playbook/run.test.ts
@@ -79,6 +79,15 @@ const failFastPlaybook: Playbook = {
   ],
 };
 
+const identifiedPlaybook: Playbook = {
+  name: 'identified steps',
+  steps: [
+    { id: 'open_home', verb: 'navigate', args: { url: 'https://example.com' } },
+    { id: 'verify_home', verb: 'assert', args: { kind: 'url', pattern: 'example\\.com' } },
+    { id: 'read_home', verb: 'read_page', args: { mode: 'ax' } },
+  ],
+};
+
 // ---------------------------------------------------------------------------
 // Test 1: Call ordering
 // ---------------------------------------------------------------------------
@@ -144,6 +153,19 @@ describe('runPlaybook — call ordering', () => {
       args: { fields: { name: 'OpenChrome' }, tabId: 'tab-123' },
     });
   });
+
+  test('preserves step ids without forwarding them to MCP tool arguments', async () => {
+    const { client, calls } = makeMockClient();
+
+    const result = await runPlaybook(identifiedPlaybook, { reuse: false, varMap: {}, client });
+
+    expect(result.steps.map((step) => step.id)).toEqual(['open_home', 'verify_home', 'read_home']);
+    expect(calls).toEqual([
+      { tool: 'navigate', args: { url: 'https://example.com' } },
+      { tool: 'oc_assert', args: { contract: { kind: 'url', pattern: 'example\\.com' } } },
+      { tool: 'read_page', args: { mode: 'ax' } },
+    ]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -203,6 +225,24 @@ describe('runPlaybook — fail-fast semantics', () => {
     expect(result.summary.passed).toBe(1);
     expect(result.summary.failed).toBe(1);
     expect(result.summary.skipped).toBe(1);
+  });
+
+  test('preserves ids on failed and skipped results and includes the failed id in diagnostics', async () => {
+    const { client } = makeMockClient({
+      results: {
+        navigate: { success: true, result: null },
+        oc_assert: { success: false, result: null, verdict: 'fail' },
+      },
+    });
+
+    const result = await runPlaybook(identifiedPlaybook, { reuse: false, varMap: {}, client });
+
+    expect(result.steps[1]).toMatchObject({
+      id: 'verify_home',
+      status: 'failed',
+      error: 'Step 1 [verify_home] (assert): assert verdict="fail"',
+    });
+    expect(result.steps[2]).toMatchObject({ id: 'read_home', status: 'skipped' });
   });
 });
 
@@ -288,6 +328,8 @@ describe('runPlaybook — JSON output shape', () => {
       expect(['ok', 'failed', 'skipped']).toContain(step.status);
       expect(typeof step.durationMs).toBe('number');
     }
+
+    expect(result.steps.every((step) => step.id === undefined)).toBe(true);
 
     // Summary shape
     const { summary } = result;
@@ -409,5 +451,26 @@ describe('runPlaybook — transport error escalation', () => {
     expect(result.steps[1].status).toBe('failed');
     expect(result.steps[1].error).toContain('network timeout');
     expect(result.steps[2].status).toBe('skipped');
+  });
+
+  test('callTool() rejection includes an authored step id in the diagnostic', async () => {
+    const client: RunOptions['client'] = {
+      async connect() {},
+      async callTool() {
+        throw new Error('network timeout');
+      },
+      async disconnect() {},
+    };
+
+    const result = await runPlaybook({
+      name: 'identified failure',
+      steps: [{ id: 'open_home', verb: 'navigate', args: { url: 'https://example.com' } }],
+    }, { reuse: false, varMap: {}, client });
+
+    expect(result.steps[0]).toMatchObject({
+      id: 'open_home',
+      status: 'failed',
+      error: 'Step 0 [open_home] (navigate): network timeout',
+    });
   });
 });

--- a/tests/fixtures/playbook/step-ids.json
+++ b/tests/fixtures/playbook/step-ids.json
@@ -1,0 +1,18 @@
+{
+  "name": "stable step ids (JSON)",
+  "steps": [
+    {
+      "id": "open_home",
+      "navigate": {
+        "url": "https://example.com"
+      }
+    },
+    {
+      "id": "verify_home",
+      "assert": {
+        "kind": "url",
+        "pattern": "example\\.com"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/playbook/step-ids.yaml
+++ b/tests/fixtures/playbook/step-ids.yaml
@@ -1,0 +1,9 @@
+name: stable step ids
+steps:
+  - id: open_home
+    navigate:
+      url: https://example.com
+  - id: verify_home
+    assert:
+      kind: url
+      pattern: "example\\.com"


### PR DESCRIPTION
## Why

Playbook results currently identify steps only by positional index. Inserting or reordering an earlier step changes every later identity, which makes failures, reports, and issue evidence harder to correlate across revisions.

Automa demonstrates the value of durable authored node identity and execution-log correlation. This PR absorbs only that narrow lesson. It keeps `oc playbook` as a deterministic thin client where one step expands to one existing MCP tool call.

## What changed

- allow optional author-supplied step IDs matching `^[a-z][a-z0-9_-]{0,63}$`
- reject duplicate IDs and all unknown sibling metadata before execution
- preserve IDs on successful, failed, and skipped `StepResult` rows
- include IDs in step-level failure diagnostics while retaining the numeric index and verb
- keep IDs out of MCP tool arguments
- expose optional IDs in JSON and plain reports
- add a Markdown ID column only when at least one result has an ID; legacy no-ID reports retain their existing layout
- document the grammar, compatibility contract, and non-control-flow semantics
- add YAML/JSON fixtures and exact parser, runner, and reporter tests

## Direction guardrails

- no graph nodes, edges, jumps, dependencies, branching, loops, or parallel execution
- no retry, fallback, continue-on-error, or workflow-restart policy
- no visual editor, recorder, scheduler, trigger daemon, or marketplace
- no playbook `schemaVersion` without a real incompatible migration
- no dependency additions and no Automa code or schema copied

The ID is observation metadata only. Numeric 0-based indexes remain present, and legacy playbooks without IDs preserve their call order, MCP arguments, and report layout.

## Verification

- `npm test -- --runInBand tests/cli/playbook` — 81/81 passed
- `npm run build` — passed
- `npm run lint:tier` — 0 dependency violations
- scoped `git diff --check` — passed
- independent read-only re-review — approved with no remaining findings

Closes #1560
