### PR TITLE
feat(interact): execute perception targets with provenance guards

### DIFF
--- a/docs/perception/ralph-visual-grounding.md
+++ b/docs/perception/ralph-visual-grounding.md
@@ -32,6 +32,24 @@ When the visual fallback succeeds, the normal Ralph response includes:
 
 ## Current boundary
 
-This is the engine-level fallback hook. Tool-level callers can wire a
-`PerceptionSnapshot` from `vision_find` or an optional provider in follow-up
-integration without changing the deterministic safety gates.
+Ralph retains the engine-level fallback hook and deterministic candidate score.
+For a caller that has already selected an exact element, `interact
+mode="perception"` provides the direct tool-level path:
+
+```text
+vision_find format="snapshot"
+  -> host selects one snapshot element ID
+  -> interact mode="perception"
+  -> OpenChrome validates provenance and dispatches one action
+```
+
+These paths have different ownership boundaries:
+
+- Ralph visual grounding deterministically matches a requested label against
+  snapshot candidates as a late fallback.
+- `interact mode="perception"` never selects or ranks candidates. It consumes
+  the exact snapshot-local ID chosen by the MCP host.
+
+Both paths keep DOM/AX/CDP authority first when durable browser identity is
+available, reject unsafe visual-only targets, and add no server-side model or
+provider dependency.

--- a/docs/vision/perception-snapshot.md
+++ b/docs/vision/perception-snapshot.md
@@ -4,6 +4,31 @@
 
 The snapshot contract is exported from `src/vision/perception-types.ts` and is intentionally provider-neutral: DOM annotation, future OmniParser-compatible HTTP providers, and tests can all describe visible elements with stable snapshot-local IDs, labels, viewport-relative CSS pixel boxes, normalized ratios, provenance, and bounded warnings.
 
+## Execute a caller-selected target
+
+The MCP host can select one exact snapshot-local element ID and pass the original viewport snapshot to `interact`:
+
+```json
+{
+  "tabId": "target-123",
+  "mode": "perception",
+  "action": "click",
+  "perception": {
+    "snapshot": { "version": 1, "provider": "dom-annotator", "...": "PerceptionSnapshot" },
+    "elementId": "v7"
+  }
+}
+```
+
+OpenChrome does not rank the snapshot or choose the element. It validates the caller's selection, binds it to the live tab and exact URL, and allows only `click`, `double_click`, or `hover`.
+
+Use `vision_find` with its default `mode: "viewport"` for this flow. Tiled snapshots use document-space aggregation and are intentionally not executable through perception mode; capture the target viewport again before interacting.
+
+- DOM-backed elements may be up to 60 seconds old. Their `backendDOMNodeId` is scrolled into view, checked for clickability, and resolved to a fresh CDP box before input.
+- Visual-only elements may be up to 15 seconds old and require an unchanged viewport. Unsafe labels involving deletion, payment, transfer, credentials, MFA, OTP, or secrets fail closed.
+- The response contains only bounded provenance: provider, element ID, source, resolution path, snapshot age, and final coordinates. It does not echo the snapshot or screenshot bytes.
+- Existing `verify`, DOM-delta, stealth movement, `returnAfterState`, and DOM-backed replay capture remain available.
+
 ## Validation expectations
 
 Provider output should pass `validatePerceptionSnapshot` before it is trusted by downstream grounding code. Validation diagnostics are bounded with `maxErrors` so malformed or hostile providers cannot flood MCP responses or model context. A failed validation should be surfaced as an actionable warning or an `isError` tool response instead of an uncaught MCP-server exception.
@@ -17,4 +42,4 @@ Provider output should pass `validatePerceptionSnapshot` before it is trusted by
 
 ## Non-goals
 
-This layer does not add OmniParser, Python, Torch, model weights, persistent screenshot storage, or automatic clicking from visual elements. External perception providers should remain optional and adapt to this contract.
+This layer does not add OmniParser, Python, Torch, model weights, persistent screenshot storage, server-side candidate selection, or an autonomous visual planning loop. External perception providers remain optional and adapt to this contract.

--- a/src/tools/interact.ts
+++ b/src/tools/interact.ts
@@ -36,6 +36,11 @@ import { isPilotEnabled } from '../harness/flags';
 import { captureBackendNodeReplayStep, shouldCaptureReplayArtifact } from './_shared/replay-recorder';
 import { applyLaneTarget, recordLaneToolCall } from '../core/browser-lanes';
 import { appendReturnAfterState, parseReturnAfterState, RETURN_AFTER_STATE_SCHEMA } from './_shared/return-after-state';
+import {
+  resolvePerceptionTarget,
+  type PerceptionTargetFailureReason,
+  type ResolvedPerceptionTarget,
+} from '../vision/perception-target';
 
 
 async function resolveInteractVault(value: unknown): Promise<{ value: unknown; token?: string; plaintext?: string; error?: MCPResult }> {
@@ -67,6 +72,129 @@ function attachVerifyReport(result: MCPResult, report: VerifyReport | undefined)
   return { ...result, verify: report };
 }
 
+type PerceptionExecutionFailureReason =
+  | PerceptionTargetFailureReason
+  | 'backend_node_unavailable'
+  | 'backend_node_not_clickable'
+  | 'invalid_live_bbox'
+  | 'viewport_unavailable';
+
+function boundedPerceptionText(value: unknown, maxLength = 120): string {
+  const text = typeof value === 'string' ? value : String(value ?? '');
+  return text.length <= maxLength ? text : `${text.slice(0, maxLength - 1)}…`;
+}
+
+function boundedPerceptionDetails(
+  reason: PerceptionExecutionFailureReason,
+  details?: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (!details) return undefined;
+  if (reason === 'malformed_snapshot' && Array.isArray(details.errors)) {
+    return {
+      errors: details.errors.slice(0, 10).map((error) => boundedPerceptionText(error, 200)),
+      truncated: details.truncated === true,
+    };
+  }
+  if (reason === 'snapshot_stale') {
+    return {
+      snapshotAgeMs: details.snapshotAgeMs,
+      maxAgeMs: details.maxAgeMs,
+    };
+  }
+  if (reason === 'viewport_mismatch') {
+    return {
+      snapshotViewport: details.snapshotViewport,
+      liveViewport: details.liveViewport,
+    };
+  }
+  return undefined;
+}
+
+function perceptionFailure(
+  code: 'INVALID_PERCEPTION_TARGET' | 'STALE_PERCEPTION_TARGET',
+  reason: PerceptionExecutionFailureReason,
+  message: string,
+  details?: Record<string, unknown>,
+): MCPResult {
+  const boundedDetails = boundedPerceptionDetails(reason, details);
+  const error = {
+    code,
+    reason,
+    message: boundedPerceptionText(message, 240),
+    ...(boundedDetails ? { details: boundedDetails } : {}),
+  };
+  return {
+    content: [{ type: 'text', text: `${code}: ${error.message} [reason=${reason}]` }],
+    isError: true,
+    error,
+    structuredContent: { mode: 'perception', error },
+  };
+}
+
+function perceptionSchemaFailure(code: 'INVALID_SCHEMA' | 'UNSUPPORTED_PERCEPTION_ACTION', message: string): MCPResult {
+  const error = { code, message: boundedPerceptionText(message, 240) };
+  return {
+    content: [{ type: 'text', text: `${code}: ${error.message}` }],
+    isError: true,
+    error,
+    structuredContent: { mode: 'perception', error },
+  };
+}
+
+async function getLiveViewport(page: any): Promise<{ width: number; height: number } | null> {
+  const viewport = page.viewport?.();
+  if (viewport && Number.isFinite(viewport.width) && viewport.width > 0 && Number.isFinite(viewport.height) && viewport.height > 0) {
+    return { width: viewport.width, height: viewport.height };
+  }
+  const evaluated = await page.evaluate(() => ({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  })).catch(() => null);
+  if (!evaluated || !Number.isFinite(evaluated.width) || evaluated.width <= 0 || !Number.isFinite(evaluated.height) || evaluated.height <= 0) {
+    return null;
+  }
+  return evaluated;
+}
+
+function resolveLiveBoxCenter(
+  content: unknown,
+  viewport: { width: number; height: number },
+): { x: number; y: number } | null {
+  if (!Array.isArray(content) || content.length < 8) return null;
+  const quad = content.slice(0, 8);
+  if (!quad.every((value) => typeof value === 'number' && Number.isFinite(value))) return null;
+  const xs = [quad[0], quad[2], quad[4], quad[6]] as number[];
+  const ys = [quad[1], quad[3], quad[5], quad[7]] as number[];
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minY = Math.min(...ys);
+  const maxY = Math.max(...ys);
+  if (maxX <= minX || maxY <= minY) return null;
+  const x = Math.round((minX + maxX) / 2);
+  const y = Math.round((minY + maxY) / 2);
+  if (x < 0 || y < 0 || x >= viewport.width || y >= viewport.height) return null;
+  return { x, y };
+}
+
+function perceptionProvenance(
+  target: ResolvedPerceptionTarget,
+  action: string,
+  point: { x: number; y: number },
+): Record<string, unknown> {
+  return {
+    mode: 'perception',
+    action,
+    perception: {
+      provider: boundedPerceptionText(target.snapshot.provider),
+      elementId: boundedPerceptionText(target.element.id),
+      source: boundedPerceptionText(target.element.source),
+      resolution: target.resolution,
+      snapshotAgeMs: target.snapshotAgeMs,
+      coordinates: point,
+    },
+  };
+}
+
 const definition: MCPToolDefinition = {
   name: 'interact',
   description: 'Find element by natural language; click/hover/double_click it; wait for DOM settle; return state.\n\nWhen to use: One described element action, with coordinate fallback for Shadow DOM/canvas/iframes.\nWhen NOT to use: Use act for multi-step flows; computer for general coordinate clicks.',
@@ -86,9 +214,9 @@ const definition: MCPToolDefinition = {
       },
       mode: {
         type: 'string',
-        enum: ['ref', 'coordinate'],
+        enum: ['ref', 'coordinate', 'perception'],
         default: 'ref',
-        description: 'Dispatch mode. "ref" (default) resolves the element by query; "coordinate" sends a CDP mouse event directly to pixel coordinates.',
+        description: 'Dispatch mode. "ref" resolves by query, "coordinate" sends a pixel event, and "perception" executes one caller-selected snapshot element after provenance validation.',
       },
       coordinate: {
         type: 'object',
@@ -104,6 +232,23 @@ const definition: MCPToolDefinition = {
           },
         },
         required: ['x', 'y'],
+      },
+      perception: {
+        type: 'object',
+        description: 'Caller-selected visual target for perception mode. The snapshot is validated and never echoed in the response.',
+        properties: {
+          snapshot: {
+            type: 'object',
+            description: 'Provider-neutral viewport-mode PerceptionSnapshot returned by vision_find format="snapshot".',
+          },
+          elementId: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 160,
+            description: 'Exact snapshot-local element ID selected by the caller.',
+          },
+        },
+        required: ['snapshot', 'elementId'],
       },
       action: {
         type: 'string',
@@ -242,12 +387,13 @@ const coreHandler: ToolHandler = async (
   const mode = (args.mode as string) || 'ref';
   const query = args.query as string;
   const coordinateArg = args.coordinate as Record<string, unknown> | undefined;
+  const perceptionArg = args.perception as Record<string, unknown> | undefined;
   const action = (args.action as string) || 'click';
   const rawValue = args.value;
-  const vaultValue = await resolveInteractVault(rawValue);
+  const vaultValue = mode === 'perception' ? { value: rawValue } : await resolveInteractVault(rawValue);
   if (vaultValue.error) return vaultValue.error;
   const typeValue = vaultValue.value;
-  if (action === 'type' && typeValue === undefined) {
+  if (mode !== 'perception' && action === 'type' && typeValue === undefined) {
     return { content: [{ type: 'text', text: 'Error: value is required when action is type' }], isError: true };
   }
   const waitAfter = Math.min(Math.max((args.waitAfter as number) || 500, 0), 10000);
@@ -335,6 +481,187 @@ const coreHandler: ToolHandler = async (
     if (intent.length > 120) {
       return {
         content: [{ type: 'text', text: 'INVALID_INTENT: intent must be at most 120 characters.' }],
+        isError: true,
+      };
+    }
+  }
+
+  // ─── Mode: perception ───
+  if (mode === 'perception') {
+    if (args.query !== undefined || args.coordinate !== undefined || args.ref !== undefined) {
+      return perceptionSchemaFailure(
+        'INVALID_SCHEMA',
+        '"query", "coordinate", and "ref" must not be provided when mode is "perception".',
+      );
+    }
+    if (!['click', 'double_click', 'hover'].includes(action)) {
+      return perceptionSchemaFailure(
+        'UNSUPPORTED_PERCEPTION_ACTION',
+        'Perception mode only supports click, double_click, and hover.',
+      );
+    }
+    if (!perceptionArg || typeof perceptionArg !== 'object' || Array.isArray(perceptionArg)) {
+      return perceptionSchemaFailure(
+        'INVALID_SCHEMA',
+        '"perception" with snapshot and elementId is required when mode is "perception".',
+      );
+    }
+
+    try {
+      const page = await sessionManager.getPage(sessionId, tabId, undefined, 'interact');
+      await recordLaneToolCall(args, !!page, tabId);
+      if (!page) {
+        return {
+          content: [{ type: 'text', text: `Error: Tab ${tabId} not found or no longer available.` }],
+          isError: true,
+        };
+      }
+
+      const liveViewport = await getLiveViewport(page);
+      if (!liveViewport) {
+        return perceptionFailure(
+          'STALE_PERCEPTION_TARGET',
+          'viewport_unavailable',
+          'Live viewport is unavailable, so perception provenance cannot be validated.',
+        );
+      }
+
+      const initialResolution = resolvePerceptionTarget({
+        snapshot: perceptionArg.snapshot,
+        elementId: perceptionArg.elementId,
+        tabId,
+        url: page.url(),
+        viewport: liveViewport,
+      });
+      if (!initialResolution.ok) {
+        return perceptionFailure(
+          initialResolution.code,
+          initialResolution.reason,
+          initialResolution.message,
+          initialResolution.details,
+        );
+      }
+
+      let target = initialResolution.target;
+      let point = target.point;
+      const cdpClient = sessionManager.getCDPClient();
+      const backendNodeId = target.element.backendDOMNodeId;
+      if (target.resolution === 'backend-node' && backendNodeId !== undefined) {
+        try {
+          await cdpClient.send(page, 'DOM.scrollIntoViewIfNeeded', { backendNodeId });
+          if (!(await validateBackendNodeClickability(page, backendNodeId, cdpClient))) {
+            return perceptionFailure(
+              'STALE_PERCEPTION_TARGET',
+              'backend_node_not_clickable',
+              'The DOM-backed perception target is no longer visible and clickable.',
+            );
+          }
+          const boxModel = await cdpClient.send(page, 'DOM.getBoxModel', { backendNodeId }) as
+            { model?: { content?: unknown } };
+          const livePoint = resolveLiveBoxCenter(boxModel.model?.content, liveViewport);
+          if (!livePoint) {
+            return perceptionFailure(
+              'STALE_PERCEPTION_TARGET',
+              'invalid_live_bbox',
+              'The DOM-backed perception target no longer has a credible live box.',
+            );
+          }
+          point = livePoint;
+        } catch {
+          return perceptionFailure(
+            'STALE_PERCEPTION_TARGET',
+            'backend_node_unavailable',
+            'The DOM-backed perception target could not be re-resolved through CDP.',
+          );
+        }
+      }
+
+      // Re-check URL, freshness, and visual-only viewport immediately before mutation.
+      const finalViewport = await getLiveViewport(page);
+      if (!finalViewport) {
+        return perceptionFailure(
+          'STALE_PERCEPTION_TARGET',
+          'viewport_unavailable',
+          'Live viewport is unavailable immediately before perception dispatch.',
+        );
+      }
+      const finalResolution = resolvePerceptionTarget({
+        snapshot: perceptionArg.snapshot,
+        elementId: perceptionArg.elementId,
+        tabId,
+        url: page.url(),
+        viewport: finalViewport,
+      });
+      if (!finalResolution.ok) {
+        return perceptionFailure(
+          finalResolution.code,
+          finalResolution.reason,
+          finalResolution.message,
+          finalResolution.details,
+        );
+      }
+      target = finalResolution.target;
+      if (target.resolution === 'snapshot-bbox') point = target.point;
+
+      const isStealth = sessionManager.isStealthTarget(tabId);
+      const { result: perceptionDomResult, verify: perceptionVerifyReport } = await runVerify(
+        page,
+        verifyMode,
+        async () => withDomDelta(page, async () => {
+          if (isStealth) await humanMouseMove(page, point.x, point.y);
+          if (action === 'double_click') await page.mouse.click(point.x, point.y, { clickCount: 2 });
+          else if (action === 'hover') { if (!isStealth) await page.mouse.move(point.x, point.y); }
+          else await page.mouse.click(point.x, point.y);
+        }, { settleMs: Math.max(150, waitAfter) }),
+      );
+
+      if (captureArtifact && action === 'click' && backendNodeId !== undefined) {
+        await captureBackendNodeReplayStep({
+          cdpClient,
+          page,
+          backendNodeId,
+          kind: 'click',
+        });
+      }
+      invalidateAXCache(getTargetId(page.target()));
+
+      const actionVerb = action === 'double_click' ? 'Double-clicked' : action === 'hover' ? 'Hovered' : 'Clicked';
+      const provenance = perceptionProvenance(target, action, point);
+      const targetInfo = provenance.perception as Record<string, unknown>;
+      const lines = [
+        `${actionVerb} perception target [${targetInfo.elementId}] ` +
+        `[provider=${targetInfo.provider} source=${targetInfo.source} resolution=${targetInfo.resolution} ` +
+        `age=${targetInfo.snapshotAgeMs}ms at=${point.x},${point.y}]`,
+      ];
+      if ((returnFormat === 'dom_delta' || returnFormat === 'both') && perceptionDomResult.delta) {
+        lines.push('', '[DOM Delta]', perceptionDomResult.delta);
+      }
+      if (returnFormat === 'state_summary' || returnFormat === 'both') {
+        lines.push('', `[State Summary] url: ${boundedPerceptionText(page.url(), 300)}`);
+      }
+
+      const resultContent: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }> = [
+        { type: 'text', text: lines.join('\n') },
+      ];
+      if (verifyMode === 'screenshot' || verifyMode === 'both') {
+        try {
+          const screenshotBuf = await withTimeout(
+            page.screenshot({ type: 'webp', quality: 60, encoding: 'base64' }),
+            DEFAULT_SCREENSHOT_TIMEOUT_MS,
+            'verify-screenshot',
+            context,
+          ) as string;
+          resultContent.push(makeImageContent(screenshotBuf, 'image/webp'));
+        } catch { /* screenshot failed, non-fatal */ }
+      }
+
+      return attachVerifyReport({
+        content: resultContent,
+        structuredContent: provenance,
+      }, perceptionVerifyReport);
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Interact error: ${error instanceof Error ? error.message : String(error)}` }],
         isError: true,
       };
     }
@@ -444,6 +771,12 @@ const coreHandler: ToolHandler = async (
 
   // ─── Mode: coordinate ───
   if (mode === 'coordinate') {
+    if (perceptionArg) {
+      return {
+        content: [{ type: 'text', text: 'INVALID_SCHEMA: "perception" must not be provided when mode is "coordinate".' }],
+        isError: true,
+      };
+    }
     if (query) {
       return {
         content: [{ type: 'text', text: 'INVALID_SCHEMA: "query" must not be provided when mode is "coordinate". Use "coordinate" block instead.' }],
@@ -539,7 +872,13 @@ const coreHandler: ToolHandler = async (
   // ─── Mode: ref (default) ───
   if (mode !== 'ref') {
     return {
-      content: [{ type: 'text', text: 'INVALID_SCHEMA: mode must be "ref" or "coordinate".' }],
+      content: [{ type: 'text', text: 'INVALID_SCHEMA: mode must be "ref", "coordinate", or "perception".' }],
+      isError: true,
+    };
+  }
+  if (perceptionArg) {
+    return {
+      content: [{ type: 'text', text: 'INVALID_SCHEMA: "perception" must not be provided when mode is "ref".' }],
       isError: true,
     };
   }

--- a/src/vision/perception-target.ts
+++ b/src/vision/perception-target.ts
@@ -1,0 +1,178 @@
+import { validatePerceptionSnapshot } from './perception-provider';
+import type { PerceptionElement, PerceptionSnapshot } from './types';
+
+export const DOM_PERCEPTION_MAX_AGE_MS = 60_000;
+export const VISUAL_PERCEPTION_MAX_AGE_MS = 15_000;
+const MAX_FUTURE_CLOCK_SKEW_MS = 5_000;
+const MAX_PERCEPTION_ELEMENTS = 500;
+const MIN_VISUAL_TARGET_SIZE_PX = 4;
+
+const UNSAFE_VISUAL_LABEL = /\b(delete|deletion|remove|destroy|confirm|pay|payments?|purchases?|checkout|transfers?|passwords?|mfa|otp|credentials?|secrets?)\b/i;
+
+export type PerceptionTargetFailureReason =
+  | 'malformed_snapshot'
+  | 'tab_mismatch'
+  | 'url_mismatch'
+  | 'element_not_found'
+  | 'duplicate_element_id'
+  | 'element_not_interactive'
+  | 'invalid_backend_node_id'
+  | 'invalid_bbox'
+  | 'snapshot_from_future'
+  | 'snapshot_stale'
+  | 'viewport_mismatch'
+  | 'unsafe_visual_label';
+
+export interface ResolvedPerceptionTarget {
+  snapshot: PerceptionSnapshot;
+  element: PerceptionElement;
+  resolution: 'backend-node' | 'snapshot-bbox';
+  snapshotAgeMs: number;
+  point: { x: number; y: number };
+}
+
+export type ResolvePerceptionTargetResult =
+  | { ok: true; target: ResolvedPerceptionTarget }
+  | {
+      ok: false;
+      code: 'INVALID_PERCEPTION_TARGET' | 'STALE_PERCEPTION_TARGET';
+      reason: PerceptionTargetFailureReason;
+      message: string;
+      details?: Record<string, unknown>;
+    };
+
+export interface ResolvePerceptionTargetInput {
+  snapshot: unknown;
+  elementId: unknown;
+  tabId: string;
+  url: string;
+  viewport: { width: number; height: number };
+  now?: number;
+}
+
+export function isUnsafeVisualTargetLabel(value: string): boolean {
+  return UNSAFE_VISUAL_LABEL.test(value);
+}
+
+export function resolvePerceptionTarget(input: ResolvePerceptionTargetInput): ResolvePerceptionTargetResult {
+  const validation = validatePerceptionSnapshot(input.snapshot, {
+    maxErrors: 10,
+    maxElements: MAX_PERCEPTION_ELEMENTS,
+  });
+  if (!validation.ok) {
+    return failure('INVALID_PERCEPTION_TARGET', 'malformed_snapshot', 'Perception snapshot validation failed.', {
+      errors: validation.errors,
+      truncated: validation.truncated,
+    });
+  }
+
+  const snapshot = input.snapshot as PerceptionSnapshot;
+  if (typeof input.elementId !== 'string' || input.elementId.length === 0) {
+    return failure('INVALID_PERCEPTION_TARGET', 'element_not_found', 'perception.elementId must be a non-empty string.');
+  }
+  if (snapshot.tabId !== input.tabId) {
+    return failure('INVALID_PERCEPTION_TARGET', 'tab_mismatch', 'Perception snapshot belongs to a different tab.', {
+      snapshotTabId: snapshot.tabId,
+      liveTabId: input.tabId,
+    });
+  }
+  if (snapshot.url !== input.url) {
+    return failure('STALE_PERCEPTION_TARGET', 'url_mismatch', 'Perception snapshot URL does not match the live page.', {
+      snapshotUrl: snapshot.url,
+      liveUrl: input.url,
+    });
+  }
+
+  const matches = snapshot.elements.filter((element) => element.id === input.elementId);
+  if (matches.length === 0) {
+    return failure('INVALID_PERCEPTION_TARGET', 'element_not_found', `Perception element "${input.elementId}" was not found.`);
+  }
+  if (matches.length > 1) {
+    return failure('INVALID_PERCEPTION_TARGET', 'duplicate_element_id', `Perception element id "${input.elementId}" is not unique.`);
+  }
+
+  const element = matches[0];
+  if (element.interactive !== true) {
+    return failure('INVALID_PERCEPTION_TARGET', 'element_not_interactive', 'Selected perception element is not explicitly interactive.');
+  }
+
+  const backendNodeId = element.backendDOMNodeId;
+  if (backendNodeId !== undefined && (!Number.isInteger(backendNodeId) || backendNodeId <= 0)) {
+    return failure('INVALID_PERCEPTION_TARGET', 'invalid_backend_node_id', 'backendDOMNodeId must be a positive integer when present.');
+  }
+
+  if (!isCredibleBox(element, snapshot.viewport, backendNodeId === undefined)) {
+    return failure('INVALID_PERCEPTION_TARGET', 'invalid_bbox', 'Selected perception element has an invalid or out-of-bounds box.');
+  }
+
+  const now = input.now ?? Date.now();
+  const snapshotAgeMs = now - snapshot.capturedAt;
+  if (snapshotAgeMs < -MAX_FUTURE_CLOCK_SKEW_MS) {
+    return failure('INVALID_PERCEPTION_TARGET', 'snapshot_from_future', 'Perception snapshot capture time is too far in the future.', {
+      snapshotAgeMs,
+    });
+  }
+
+  const visualOnly = backendNodeId === undefined;
+  const maxAgeMs = visualOnly ? VISUAL_PERCEPTION_MAX_AGE_MS : DOM_PERCEPTION_MAX_AGE_MS;
+  if (snapshotAgeMs > maxAgeMs) {
+    return failure('STALE_PERCEPTION_TARGET', 'snapshot_stale', `Perception snapshot is older than ${maxAgeMs}ms.`, {
+      snapshotAgeMs,
+      maxAgeMs,
+    });
+  }
+
+  if (visualOnly && !sameViewport(snapshot.viewport, input.viewport)) {
+    return failure('STALE_PERCEPTION_TARGET', 'viewport_mismatch', 'Visual-only perception target requires an unchanged viewport.', {
+      snapshotViewport: snapshot.viewport,
+      liveViewport: input.viewport,
+    });
+  }
+
+  if (visualOnly && isUnsafeVisualTargetLabel(`${element.label} ${element.role || ''}`)) {
+    return failure('INVALID_PERCEPTION_TARGET', 'unsafe_visual_label', 'Unsafe visual-only target requires DOM-backed identity or user intervention.');
+  }
+
+  return {
+    ok: true,
+    target: {
+      snapshot,
+      element,
+      resolution: visualOnly ? 'snapshot-bbox' : 'backend-node',
+      snapshotAgeMs: Math.max(0, snapshotAgeMs),
+      point: {
+        x: Math.round(element.bbox.x + element.bbox.width / 2),
+        y: Math.round(element.bbox.y + element.bbox.height / 2),
+      },
+    },
+  };
+}
+
+function failure(
+  code: 'INVALID_PERCEPTION_TARGET' | 'STALE_PERCEPTION_TARGET',
+  reason: PerceptionTargetFailureReason,
+  message: string,
+  details?: Record<string, unknown>,
+): ResolvePerceptionTargetResult {
+  return { ok: false, code, reason, message, ...(details ? { details } : {}) };
+}
+
+function sameViewport(a: { width: number; height: number }, b: { width: number; height: number }): boolean {
+  return a.width === b.width && a.height === b.height;
+}
+
+function isCredibleBox(
+  element: PerceptionElement,
+  viewport: { width: number; height: number },
+  visualOnly: boolean,
+): boolean {
+  const { x, y, width, height } = element.bbox;
+  const minSize = visualOnly ? MIN_VISUAL_TARGET_SIZE_PX : 1;
+  if (![x, y, width, height].every(Number.isFinite)) return false;
+  if (x < 0 || y < 0 || width < minSize || height < minSize) return false;
+  if (x + width > viewport.width || y + height > viewport.height) return false;
+
+  const ratio = element.bboxRatio;
+  if (ratio.x + ratio.width > 1 || ratio.y + ratio.height > 1) return false;
+  return true;
+}

--- a/tests/tools/interact.perception.test.ts
+++ b/tests/tools/interact.perception.test.ts
@@ -1,0 +1,342 @@
+/// <reference types="jest" />
+
+import type { MCPResult, MCPToolDefinition } from '../../src/types/mcp';
+import type { PerceptionElement, PerceptionSnapshot } from '../../src/vision/types';
+import { VISUAL_PERCEPTION_MAX_AGE_MS } from '../../src/vision/perception-target';
+import { createMockPage } from '../utils/mock-cdp';
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(),
+}));
+
+jest.mock('../../src/utils/ref-id-manager', () => ({
+  getRefIdManager: jest.fn(() => ({
+    generateRef: jest.fn().mockReturnValue('ref_1'),
+    isRefStale: jest.fn().mockReturnValue(false),
+    resolveToBackendNodeId: jest.fn(),
+  })),
+}));
+
+jest.mock('../../src/core/browser-lanes', () => ({
+  applyLaneTarget: jest.fn((args: Record<string, unknown>) => args),
+  recordLaneToolCall: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../src/utils/dom-delta', () => ({
+  withDomDelta: jest.fn().mockImplementation(async (_page: unknown, action: () => Promise<void>) => {
+    await action();
+    return { delta: 'button state changed' };
+  }),
+}));
+
+jest.mock('../../src/core/perception/verify', () => {
+  const actual = jest.requireActual('../../src/core/perception/verify');
+  return {
+    ...actual,
+    runVerify: jest.fn().mockImplementation(async (_page: unknown, mode: string, action: () => Promise<unknown>) => ({
+      result: await action(),
+      verify: mode === 'none' ? undefined : { mode, total_bytes: 0 },
+    })),
+  };
+});
+
+jest.mock('../../src/stealth/human-behavior', () => ({
+  humanMouseMove: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../src/tools/_shared/replay-recorder', () => ({
+  captureBackendNodeReplayStep: jest.fn().mockResolvedValue(undefined),
+  shouldCaptureReplayArtifact: jest.fn((value: unknown) => value === true),
+}));
+
+import { getSessionManager } from '../../src/session-manager';
+import { runVerify } from '../../src/core/perception/verify';
+import { captureBackendNodeReplayStep } from '../../src/tools/_shared/replay-recorder';
+
+const NOW = 1_800_000_000_000;
+const VIEWPORT = { width: 1280, height: 720 };
+
+function perceptionElement(overrides: Partial<PerceptionElement> = {}): PerceptionElement {
+  return {
+    id: 'v1',
+    type: 'control',
+    label: 'Continue',
+    role: 'button',
+    interactive: true,
+    bbox: { x: 100, y: 200, width: 80, height: 40 },
+    bboxRatio: { x: 100 / 1280, y: 200 / 720, width: 80 / 1280, height: 40 / 720 },
+    source: 'mock',
+    backendDOMNodeId: 42,
+    ...overrides,
+  };
+}
+
+function perceptionSnapshot(overrides: Partial<PerceptionSnapshot> = {}): PerceptionSnapshot {
+  return {
+    version: 1,
+    provider: 'mock-provider',
+    tabId: 'tab-1',
+    url: 'https://example.test/app',
+    capturedAt: NOW - 100,
+    viewport: VIEWPORT,
+    elements: [perceptionElement()],
+    warnings: ['snapshot-only-warning'],
+    latencyMs: 12,
+    ...overrides,
+  };
+}
+
+function visualSnapshot(overrides: Partial<PerceptionElement> = {}): PerceptionSnapshot {
+  return perceptionSnapshot({
+    elements: [perceptionElement({ backendDOMNodeId: undefined, ...overrides })],
+  });
+}
+
+describe('interact tool - perception mode', () => {
+  let definition: MCPToolDefinition;
+  let handler: (sessionId: string, args: Record<string, unknown>) => Promise<MCPResult>;
+  let page: ReturnType<typeof createMockPage>;
+  let cdpSend: jest.Mock;
+  let nowSpy: jest.SpyInstance<number, []>;
+
+  beforeAll(async () => {
+    const { registerInteractTool } = await import('../../src/tools/interact');
+    registerInteractTool({
+      registerTool: (_name: string, registeredHandler: typeof handler, registeredDefinition: MCPToolDefinition) => {
+        handler = registeredHandler;
+        definition = registeredDefinition;
+      },
+    } as unknown as Parameters<typeof registerInteractTool>[0]);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    nowSpy = jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    page = createMockPage({ url: 'https://example.test/app', title: 'Fixture' });
+    cdpSend = jest.fn().mockImplementation(async (_page: unknown, method: string) => {
+      if (method === 'DOM.scrollIntoViewIfNeeded') return {};
+      if (method === 'DOM.resolveNode') return { object: { objectId: 'object-42' } };
+      if (method === 'Runtime.callFunctionOn') return { result: { value: { clickable: true } } };
+      if (method === 'DOM.getBoxModel') {
+        return { model: { content: [200, 300, 280, 300, 280, 340, 200, 340] } };
+      }
+      return {};
+    });
+    (getSessionManager as jest.Mock).mockReturnValue({
+      getPage: jest.fn().mockResolvedValue(page),
+      getAvailableTargets: jest.fn().mockResolvedValue([]),
+      getCDPClient: jest.fn().mockReturnValue({ send: cdpSend }),
+      isStealthTarget: jest.fn().mockReturnValue(false),
+    });
+  });
+
+  afterEach(() => {
+    nowSpy.mockRestore();
+  });
+
+  function callPerception(overrides: Record<string, unknown> = {}): Promise<MCPResult> {
+    return handler('session-1', {
+      tabId: 'tab-1',
+      mode: 'perception',
+      action: 'click',
+      perception: { snapshot: perceptionSnapshot(), elementId: 'v1' },
+      ...overrides,
+    });
+  }
+
+  function expectNoInput(): void {
+    expect(page.mouse.click).not.toHaveBeenCalled();
+    expect(page.mouse.move).not.toHaveBeenCalled();
+  }
+
+  test('exposes an additive perception schema without removing existing modes', () => {
+    const properties = definition.inputSchema.properties as Record<string, any>;
+
+    expect(properties.mode.enum).toEqual(['ref', 'coordinate', 'perception']);
+    expect(properties.perception.required).toEqual(['snapshot', 'elementId']);
+    expect(properties.perception.properties.elementId).toMatchObject({ type: 'string', minLength: 1 });
+  });
+
+  test('re-resolves a DOM-backed target and returns bounded provenance', async () => {
+    const result = await callPerception({ verify: 'ax-diff', capture_artifact: true });
+
+    expect(result.isError).toBeFalsy();
+    expect(cdpSend).toHaveBeenCalledWith(page, 'DOM.scrollIntoViewIfNeeded', { backendNodeId: 42 });
+    expect(cdpSend).toHaveBeenCalledWith(page, 'DOM.getBoxModel', { backendNodeId: 42 });
+    expect(page.mouse.click).toHaveBeenCalledWith(240, 320);
+    expect(runVerify).toHaveBeenCalledWith(page, 'ax-diff', expect.any(Function));
+    expect(captureBackendNodeReplayStep).toHaveBeenCalledWith(expect.objectContaining({
+      page,
+      backendNodeId: 42,
+      kind: 'click',
+    }));
+    expect(result.structuredContent).toEqual({
+      mode: 'perception',
+      action: 'click',
+      perception: {
+        provider: 'mock-provider',
+        elementId: 'v1',
+        source: 'mock',
+        resolution: 'backend-node',
+        snapshotAgeMs: 100,
+        coordinates: { x: 240, y: 320 },
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain('snapshot-only-warning');
+    expect(result.verify).toMatchObject({ mode: 'ax-diff' });
+  });
+
+  test('uses the validated snapshot box for a visual-only target', async () => {
+    const result = await callPerception({
+      perception: { snapshot: visualSnapshot(), elementId: 'v1' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(page.mouse.click).toHaveBeenCalledWith(140, 220);
+    expect(cdpSend).not.toHaveBeenCalled();
+    expect(captureBackendNodeReplayStep).not.toHaveBeenCalled();
+    expect(result.structuredContent).toMatchObject({
+      perception: { resolution: 'snapshot-bbox', coordinates: { x: 140, y: 220 } },
+    });
+  });
+
+  test.each(['double_click', 'hover'])('dispatches the supported %s action', async (action) => {
+    const result = await callPerception({ action });
+
+    expect(result.isError).toBeFalsy();
+    if (action === 'double_click') {
+      expect(page.mouse.click).toHaveBeenCalledWith(240, 320, { clickCount: 2 });
+    } else {
+      expect(page.mouse.move).toHaveBeenCalledWith(240, 320);
+    }
+    expect(result.structuredContent).toMatchObject({ action });
+  });
+
+  test.each([
+    ['wrong tab', perceptionSnapshot({ tabId: 'tab-2' }), 'tab_mismatch'],
+    ['wrong URL', perceptionSnapshot({ url: 'https://example.test/other' }), 'url_mismatch'],
+    ['stale capture', visualSnapshot(), 'snapshot_stale'],
+    ['unsafe label', visualSnapshot({ label: 'Payment credentials' }), 'unsafe_visual_label'],
+  ])('rejects %s before dispatching browser input', async (_name, snapshot, reason) => {
+    if (reason === 'snapshot_stale') snapshot.capturedAt = NOW - VISUAL_PERCEPTION_MAX_AGE_MS - 1;
+
+    const result = await callPerception({ perception: { snapshot, elementId: 'v1' } });
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: { error: { reason } },
+    });
+    expectNoInput();
+  });
+
+  test('fails closed when the live viewport cannot be read', async () => {
+    page.viewport.mockReturnValue(null);
+    page.evaluate.mockRejectedValue(new Error('viewport unavailable'));
+
+    const result = await callPerception();
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: { error: { reason: 'viewport_unavailable' } },
+    });
+    expectNoInput();
+  });
+
+  test('rejects visual-only viewport drift before browser input', async () => {
+    page.viewport.mockReturnValue({ width: 800, height: 600 });
+
+    const result = await callPerception({
+      perception: { snapshot: visualSnapshot(), elementId: 'v1' },
+    });
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: { error: { reason: 'viewport_mismatch' } },
+    });
+    expectNoInput();
+  });
+
+  test.each([
+    ['query', { query: 'Continue' }],
+    ['coordinate', { coordinate: { x: 10, y: 20 } }],
+    ['ref', { ref: 'ref_1' }],
+  ])('rejects the mutually exclusive %s field before browser input', async (_name, extra) => {
+    const result = await callPerception(extra);
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0].text).toContain('INVALID_SCHEMA');
+    expectNoInput();
+  });
+
+  test('rejects type actions even when a value is supplied', async () => {
+    const result = await callPerception({ action: 'type', value: 'do not type' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0].text).toContain('UNSUPPORTED_PERCEPTION_ACTION');
+    expect(page.keyboard.type).not.toHaveBeenCalled();
+    expectNoInput();
+  });
+
+  test('fails closed when a DOM-backed target is no longer clickable', async () => {
+    cdpSend.mockImplementation(async (_page: unknown, method: string) => {
+      if (method === 'DOM.scrollIntoViewIfNeeded') return {};
+      if (method === 'DOM.resolveNode') return { object: { objectId: 'object-42' } };
+      if (method === 'Runtime.callFunctionOn') return { result: { value: { clickable: false } } };
+      return {};
+    });
+
+    const result = await callPerception();
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: { error: { reason: 'backend_node_not_clickable' } },
+    });
+    expectNoInput();
+  });
+
+  test('fails closed when CDP cannot re-resolve the backend node', async () => {
+    cdpSend.mockRejectedValue(new Error('stale backend node'));
+
+    const result = await callPerception();
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: { error: { reason: 'backend_node_unavailable' } },
+    });
+    expectNoInput();
+  });
+
+  test('fails closed when the live CDP box is degenerate', async () => {
+    cdpSend.mockImplementation(async (_page: unknown, method: string) => {
+      if (method === 'DOM.scrollIntoViewIfNeeded') return {};
+      if (method === 'DOM.resolveNode') return { object: { objectId: 'object-42' } };
+      if (method === 'Runtime.callFunctionOn') return { result: { value: { clickable: true } } };
+      if (method === 'DOM.getBoxModel') {
+        return { model: { content: [20, 20, 20, 20, 20, 20, 20, 20] } };
+      }
+      return {};
+    });
+
+    const result = await callPerception();
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: { error: { reason: 'invalid_live_bbox' } },
+    });
+    expectNoInput();
+  });
+
+  test('bounds malformed snapshot diagnostics and never dispatches input', async () => {
+    const result = await callPerception({
+      perception: { snapshot: { version: 1, elements: Array.from({ length: 1000 }, () => ({})) }, elementId: 'v1' },
+    });
+
+    const errors = (result.structuredContent?.error as { details?: { errors?: string[] } }).details?.errors;
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: 'INVALID_PERCEPTION_TARGET', reason: 'malformed_snapshot' } },
+    });
+    expect(errors?.length).toBeLessThanOrEqual(10);
+    expectNoInput();
+  });
+});

--- a/tests/vision/perception-target.test.ts
+++ b/tests/vision/perception-target.test.ts
@@ -1,0 +1,142 @@
+/// <reference types="jest" />
+
+import {
+  DOM_PERCEPTION_MAX_AGE_MS,
+  VISUAL_PERCEPTION_MAX_AGE_MS,
+  resolvePerceptionTarget,
+} from '../../src/vision/perception-target';
+import type { PerceptionSnapshot } from '../../src/vision/types';
+
+const NOW = 10_000_000;
+const VIEWPORT = { width: 1280, height: 720 };
+
+function snapshot(overrides: Partial<PerceptionSnapshot> = {}): PerceptionSnapshot {
+  return {
+    version: 1,
+    provider: 'mock',
+    tabId: 'tab-1',
+    url: 'https://example.test/app',
+    capturedAt: NOW - 100,
+    viewport: VIEWPORT,
+    elements: [{
+      id: 'v1',
+      type: 'control',
+      label: 'Continue',
+      role: 'button',
+      interactive: true,
+      bbox: { x: 100, y: 200, width: 80, height: 40 },
+      bboxRatio: { x: 100 / 1280, y: 200 / 720, width: 80 / 1280, height: 40 / 720 },
+      source: 'mock',
+      backendDOMNodeId: 42,
+    }],
+    warnings: [],
+    latencyMs: 10,
+    ...overrides,
+  };
+}
+
+function resolve(candidate: unknown, elementId: unknown = 'v1') {
+  return resolvePerceptionTarget({
+    snapshot: candidate,
+    elementId,
+    tabId: 'tab-1',
+    url: 'https://example.test/app',
+    viewport: VIEWPORT,
+    now: NOW,
+  });
+}
+
+describe('resolvePerceptionTarget', () => {
+  test('accepts a DOM-backed target and marks it for live backend-node resolution', () => {
+    const result = resolve(snapshot());
+
+    expect(result).toMatchObject({
+      ok: true,
+      target: {
+        resolution: 'backend-node',
+        snapshotAgeMs: 100,
+        point: { x: 140, y: 220 },
+        element: { id: 'v1', backendDOMNodeId: 42 },
+      },
+    });
+  });
+
+  test('accepts a fresh visual-only target when viewport and provenance still match', () => {
+    const candidate = snapshot({
+      elements: [{
+        id: 'v2',
+        type: 'control',
+        label: 'Open map marker',
+        interactive: true,
+        bbox: { x: 20, y: 40, width: 30, height: 20 },
+        bboxRatio: { x: 20 / 1280, y: 40 / 720, width: 30 / 1280, height: 20 / 720 },
+        source: 'mock',
+      }],
+    });
+
+    const result = resolve(candidate, 'v2');
+
+    expect(result).toMatchObject({
+      ok: true,
+      target: { resolution: 'snapshot-bbox', point: { x: 35, y: 50 } },
+    });
+  });
+
+  test.each([
+    ['tab mismatch', snapshot({ tabId: 'tab-2' }), 'tab_mismatch'],
+    ['URL mismatch', snapshot({ url: 'https://example.test/other' }), 'url_mismatch'],
+    ['missing element', snapshot(), 'element_not_found', 'missing'],
+    ['non-interactive element', snapshot({ elements: [{ ...snapshot().elements[0], interactive: false }] }), 'element_not_interactive'],
+    ['invalid backend id', snapshot({ elements: [{ ...snapshot().elements[0], backendDOMNodeId: -1 }] }), 'invalid_backend_node_id'],
+    ['out-of-bounds box', snapshot({ elements: [{ ...snapshot().elements[0], bbox: { x: 1260, y: 10, width: 40, height: 20 } }] }), 'invalid_bbox'],
+  ])('rejects %s before browser input', (_name, candidate, reason, elementId = 'v1') => {
+    const result = resolve(candidate, elementId);
+
+    expect(result).toMatchObject({ ok: false, reason });
+  });
+
+  test('rejects duplicate element IDs', () => {
+    const element = snapshot().elements[0];
+    const result = resolve(snapshot({ elements: [element, { ...element }] }));
+
+    expect(result).toMatchObject({ ok: false, reason: 'duplicate_element_id' });
+  });
+
+  test('rejects stale DOM-backed and visual-only targets using separate bounds', () => {
+    const staleDom = resolve(snapshot({ capturedAt: NOW - DOM_PERCEPTION_MAX_AGE_MS - 1 }));
+    const visualElement = { ...snapshot().elements[0] };
+    delete visualElement.backendDOMNodeId;
+    const staleVisual = resolve(snapshot({
+      capturedAt: NOW - VISUAL_PERCEPTION_MAX_AGE_MS - 1,
+      elements: [visualElement],
+    }));
+
+    expect(staleDom).toMatchObject({ ok: false, code: 'STALE_PERCEPTION_TARGET', reason: 'snapshot_stale' });
+    expect(staleVisual).toMatchObject({ ok: false, code: 'STALE_PERCEPTION_TARGET', reason: 'snapshot_stale' });
+  });
+
+  test('rejects visual-only viewport drift and unsafe labels', () => {
+    const visualElement = { ...snapshot().elements[0], label: 'Pay now' };
+    delete visualElement.backendDOMNodeId;
+    const unsafe = resolve(snapshot({ elements: [visualElement] }));
+    const drifted = resolvePerceptionTarget({
+      snapshot: snapshot({ elements: [{ ...visualElement, label: 'Open menu' }] }),
+      elementId: 'v1',
+      tabId: 'tab-1',
+      url: 'https://example.test/app',
+      viewport: { width: 800, height: 600 },
+      now: NOW,
+    });
+
+    expect(unsafe).toMatchObject({ ok: false, reason: 'unsafe_visual_label' });
+    expect(drifted).toMatchObject({ ok: false, code: 'STALE_PERCEPTION_TARGET', reason: 'viewport_mismatch' });
+  });
+
+  test('bounds malformed provider diagnostics', () => {
+    const result = resolve({ version: 1, elements: Array.from({ length: 1000 }, () => ({})) });
+
+    expect(result).toMatchObject({ ok: false, reason: 'malformed_snapshot' });
+    if (result.ok) throw new Error('expected failure');
+    expect((result.details?.errors as string[]).length).toBeLessThanOrEqual(10);
+  });
+});


### PR DESCRIPTION
## Summary

- add opt-in `interact mode="perception"` for one exact element selected by the MCP host from a `PerceptionSnapshot`
- validate bounded snapshot shape, tab, URL, freshness, interactivity, geometry, and visual-only safety before any browser input
- re-resolve DOM-backed targets through current CDP clickability and box data; keep visual-only targets short-lived and exact-viewport
- return compact provider/element/source/resolution/age/coordinate provenance without echoing the snapshot
- document the `vision_find mode="viewport"` -> host selection -> `interact` flow and its boundary from Ralph visual matching

## Direction fit

This absorbs the narrow Midscene pattern that fits OpenChrome: separate location evidence from a bounded action and recover durable web identity before mutation. The caller still chooses the target. OpenChrome performs deterministic validation and real-Chrome execution only.

The change does not add a planner, model call, candidate ranking, automatic retry, cross-device abstraction, snapshot persistence, or `type` support. Tiled/document-space snapshots are intentionally not executable; callers recapture the target viewport first. No Midscene source or dependency is copied.

## Safety and compatibility

- existing `ref` and `coordinate` modes remain the default/legacy paths
- malformed, wrong-tab, wrong-URL, stale, duplicate, non-interactive, unsafe, drifted, or unresolvable targets fail before `page.mouse.*`
- DOM-backed targets use a fresh `backendDOMNodeId` box after `scrollIntoViewIfNeeded` and clickability validation
- visual-only targets use a 15-second age cap, exact viewport match, minimum geometry, and destructive/credential label guard
- existing verify, DOM-delta, stealth movement, `returnAfterState`, AX invalidation, and DOM-backed replay capture stay available

## Verification

- `npm test -- --runInBand tests/vision/perception-target.test.ts tests/tools/interact.perception.test.ts tests/tools/interact.coordinate.test.ts tests/tools/interact.verify.test.ts tests/headed/headed-tool-interop.test.ts` (63 passed)
- post-rebase focused suites: perception 19 passed, helper 12 passed, coordinate 9 passed, verify 8 passed
- `npm run build`
- `npm run lint:changed`
- `npm run lint:tier`
- `npm run lint:tool-schemas` (0 new violations)
- `npm run docs:capability-map:check`
- `git diff --check`
- independent read-only code review: APPROVE
- independent architecture/product-direction review: CLEAR

The full Jest suite was also attempted, but existing long-lived timers/open handles kept the run active beyond 20 minutes; it was stopped after many unrelated suites passed. Required CI remains the merge gate.

Closes #1557