### PR TITLE
fix(recording): isolate active recorders by MCP session

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -58,7 +58,11 @@ import { isTimeoutError } from './errors/timeout';
 import { OpenChromeConnectionError } from './errors/connection';
 import { getTaskJournal } from './journal/task-journal';
 import { getDashboardState } from './desktop/dashboard-state';
-import { getActionRecorder } from './recording/action-recorder';
+import {
+  beginSessionRecorderDeletion,
+  completeSessionRecorderDeletion,
+  getActiveActionRecording,
+} from './recording/action-recorder';
 import { extractTaskId, getTaskStore, recordTaskToolCall } from './core/task-ledger';
 import {
   substituteSecrets,
@@ -598,9 +602,12 @@ export class MCPServer {
     // sessionManager uses, unlike the transport's Mcp-Session-Id.
     if (typeof this.sessionManager.addEventListener === 'function') {
       this.sessionManager.addEventListener((event) => {
-        if (event.type === 'session:deleted') {
+        if (event.type === 'session:deleting') {
+          beginSessionRecorderDeletion(event.sessionId);
+        } else if (event.type === 'session:deleted') {
           this.sessionTenants.delete(event.sessionId);
           getTaskDriftLedger().cleanupSession(event.sessionId);
+          completeSessionRecorderDeletion(event.sessionId);
         } else if ((event.type === 'session:target-closed' || event.type === 'session:target-removed') && event.sessionId && event.targetId) {
           getTaskDriftLedger().cleanupTab(event.sessionId, event.targetId);
         }
@@ -2131,6 +2138,9 @@ export class MCPServer {
     const callId = this.activityTracker!.startCall(toolName, sessionId || 'default', telemetryToolArgs, requestId);
     getDashboardState().recordToolStart(sessionId || 'default', toolName, telemetryToolArgs, callId);
     const toolStartTime = Date.now();
+    const recordingAtDispatch = SKIP_RECORDING_TOOLS.has(toolName)
+      ? undefined
+      : getActiveActionRecording(sessionId);
 
     const runHarnessId = isRunHarnessEnabled() ? extractRunId(toolArgs) : undefined;
     if (runHarnessId && !toolName.startsWith('oc_run_')) {
@@ -2449,12 +2459,13 @@ export class MCPServer {
 
       // Record to session recording (best-effort, skip recording tools themselves)
       try {
-        const recorder = getActionRecorder();
-        if (recorder.isRecording && !SKIP_RECORDING_TOOLS.has(toolName)) {
+        if (recordingAtDispatch) {
+          const { recorder, recordingId } = recordingAtDispatch;
           const tabId = toolArgs['tabId'] as string | undefined;
           const summary = (result as Record<string, unknown>)?._summary as string | undefined;
-          recorder.recordAction(toolName, telemetryToolArgs, Date.now() - toolStartTime, true, { tabId, summary }).then(() => {
-            if (recorder.activeRecordingId) this.emitResourceUpdated(recordingUri(recorder.activeRecordingId));
+          const actionSucceeded = result.isError !== true;
+          recorder.recordActionForRecording(recordingId, toolName, telemetryToolArgs, Date.now() - toolStartTime, actionSucceeded, { tabId, summary }).then(() => {
+            if (recorder.activeRecordingId === recordingId) this.emitResourceUpdated(recordingUri(recordingId));
           }).catch(() => {});
         }
       } catch {
@@ -2686,12 +2697,12 @@ export class MCPServer {
 
       // Record to session recording (best-effort, skip recording tools themselves)
       try {
-        const recorder = getActionRecorder();
-        if (recorder.isRecording && !SKIP_RECORDING_TOOLS.has(toolName)) {
+        if (recordingAtDispatch) {
+          const { recorder, recordingId } = recordingAtDispatch;
           const tabId = toolArgs['tabId'] as string | undefined;
           const errMsg = message;
-          recorder.recordAction(toolName, telemetryToolArgs, Date.now() - toolStartTime, false, { tabId, error: errMsg }).then(() => {
-            if (recorder.activeRecordingId) this.emitResourceUpdated(recordingUri(recorder.activeRecordingId));
+          recorder.recordActionForRecording(recordingId, toolName, telemetryToolArgs, Date.now() - toolStartTime, false, { tabId, error: errMsg }).then(() => {
+            if (recorder.activeRecordingId === recordingId) this.emitResourceUpdated(recordingUri(recordingId));
           }).catch(() => {});
         }
       } catch {

--- a/src/recording/action-recorder.ts
+++ b/src/recording/action-recorder.ts
@@ -87,13 +87,11 @@ export class ActionRecorder {
   private _activeMetadata: RecordingMetadata | null = null;
   private _seq = 0;
   /**
-   * Promise-chain mutex serializing every write to this recorder. Without this,
-   * two concurrent recordAction() calls each read _seq before either has
-   * incremented it, producing duplicate seq values (observed in concurrent
-   * tests). appendContractResult() rides the same chain so contract rows can
-   * never interleave with an in-flight recordAction().
+   * Promise-chain mutex serializing lifecycle transitions and writes. Keeping
+   * start(), stop(), and append operations on one queue prevents late writes
+   * from slipping past finalization or into a restarted recording.
    */
-  private _writeChain: Promise<void> = Promise.resolve();
+  private _mutationChain: Promise<void> = Promise.resolve();
   private _trajectoryBundle: TrajectoryBundleWriter | null = null;
   private _lastTrajectoryReport: TrajectoryReport | null = null;
 
@@ -102,11 +100,11 @@ export class ActionRecorder {
     this.config = { ...DEFAULT_RECORDING_CONFIG, ...configOverrides };
   }
 
-  /** Queue `op` behind any in-flight writes. Errors are isolated per-task. */
-  private enqueueWrite<T>(op: () => Promise<T>): Promise<T> {
-    const next = this._writeChain.then(op, op);
-    // Keep the chain alive even if op rejects, so later writes still serialize.
-    this._writeChain = next.then(
+  /** Queue `op` behind any in-flight mutation. Errors are isolated per-task. */
+  private enqueueMutation<T>(op: () => Promise<T>): Promise<T> {
+    const next = this._mutationChain.then(op, op);
+    // Keep the chain alive even if op rejects, so later mutations still serialize.
+    this._mutationChain = next.then(
       () => undefined,
       () => undefined,
     );
@@ -144,47 +142,49 @@ export class ActionRecorder {
    * Throws if a recording is already active.
    */
   async start(sessionId: string, opts?: StartRecordingOptions): Promise<RecordingMetadata> {
-    if (this._isRecording) {
-      throw new Error('A recording is already active. Call stop() first.');
-    }
-
-    const id = generateRecordingId();
-    const metadata: RecordingMetadata = {
-      version: 1,
-      id,
-      sessionId,
-      startedAt: new Date().toISOString(),
-      actionCount: 0,
-      profile: opts?.profile,
-      label: opts?.label,
-    };
-
-    await this.store.init();
-    await this.store.createRecording(metadata);
-
-    this._trajectoryBundle = null;
-    this._lastTrajectoryReport = null;
-    if (opts?.trajectoryBundle === true) {
-      try {
-        this._trajectoryBundle = await TrajectoryBundleWriter.create({
-          sessionId,
-          recordingId: id,
-          rootDir: opts.trajectoryRootDir,
-        });
-        metadata.trajectoryBundle = this._trajectoryBundle.snapshot;
-        await this.store.writeMetadata(metadata);
-      } catch (err) {
-        console.error('[ActionRecorder] Trajectory bundle disabled:', err instanceof Error ? err.message : err);
-        metadata.trajectoryBundle = { enabled: false };
+    return this.enqueueMutation(async () => {
+      if (this._isRecording) {
+        throw new Error('A recording is already active. Call stop() first.');
       }
-    }
 
-    this._activeMetadata = metadata;
-    this._activeRecordingId = id;
-    this._isRecording = true;
-    this._seq = 0;
+      const id = generateRecordingId();
+      const metadata: RecordingMetadata = {
+        version: 1,
+        id,
+        sessionId,
+        startedAt: new Date().toISOString(),
+        actionCount: 0,
+        profile: opts?.profile,
+        label: opts?.label,
+      };
 
-    return { ...metadata };
+      await this.store.init();
+      await this.store.createRecording(metadata);
+
+      this._trajectoryBundle = null;
+      this._lastTrajectoryReport = null;
+      if (opts?.trajectoryBundle === true) {
+        try {
+          this._trajectoryBundle = await TrajectoryBundleWriter.create({
+            sessionId,
+            recordingId: id,
+            rootDir: opts.trajectoryRootDir,
+          });
+          metadata.trajectoryBundle = this._trajectoryBundle.snapshot;
+          await this.store.writeMetadata(metadata);
+        } catch (err) {
+          console.error('[ActionRecorder] Trajectory bundle disabled:', err instanceof Error ? err.message : err);
+          metadata.trajectoryBundle = { enabled: false };
+        }
+      }
+
+      this._activeMetadata = metadata;
+      this._activeRecordingId = id;
+      this._isRecording = true;
+      this._seq = 0;
+
+      return { ...metadata };
+    });
   }
 
   /**
@@ -192,39 +192,35 @@ export class ActionRecorder {
    * Throws if no recording is active.
    */
   async stop(): Promise<RecordingMetadata> {
-    if (!this._isRecording || !this._activeMetadata || !this._activeRecordingId) {
-      throw new Error('No active recording. Call start() first.');
-    }
+    return this.enqueueMutation(async () => {
+      if (!this._isRecording || !this._activeMetadata || !this._activeRecordingId) {
+        throw new Error('No active recording. Call start() first.');
+      }
 
-    // Drain any in-flight writes BEFORE flipping `_isRecording = false`.
-    // Otherwise recordAction()/appendContractResult() tasks still sitting on
-    // the queue would see `_isRecording === false` when their turn comes and
-    // silently no-op, losing recorded actions on a busy stop() (Codex P1).
-    await this._writeChain;
+      // The shared mutation queue guarantees all previously accepted writes
+      // have completed before final metadata is captured.
+      const metadata: RecordingMetadata = {
+        ...this._activeMetadata,
+        stoppedAt: new Date().toISOString(),
+      };
 
-    // After the chain has drained, take a final snapshot — actionCount may
-    // have grown while we were waiting.
-    const metadata: RecordingMetadata = {
-      ...this._activeMetadata,
-      stoppedAt: new Date().toISOString(),
-    };
+      if (this._trajectoryBundle) {
+        const report = await this._trajectoryBundle.finalize();
+        this._lastTrajectoryReport = report;
+        metadata.trajectoryBundle = { ...this._trajectoryBundle.snapshot, report: report as unknown as Record<string, unknown> };
+      }
 
-    if (this._trajectoryBundle) {
-      const report = await this._trajectoryBundle.finalize();
-      this._lastTrajectoryReport = report;
-      metadata.trajectoryBundle = { ...this._trajectoryBundle.snapshot, report: report as unknown as Record<string, unknown> };
-    }
+      await this.store.writeMetadata(metadata);
 
-    await this.store.writeMetadata(metadata);
+      // Reset state
+      this._isRecording = false;
+      this._activeMetadata = null;
+      this._activeRecordingId = null;
+      this._trajectoryBundle = null;
+      this._seq = 0;
 
-    // Reset state
-    this._isRecording = false;
-    this._activeMetadata = null;
-    this._activeRecordingId = null;
-    this._trajectoryBundle = null;
-    this._seq = 0;
-
-    return metadata;
+      return metadata;
+    });
   }
 
   /**
@@ -240,13 +236,26 @@ export class ActionRecorder {
     if (!this._isRecording || !this._activeRecordingId || !this._activeMetadata) {
       return;
     }
+    return this.recordActionForRecording(this._activeRecordingId, tool, args, durationMs, ok, opts);
+  }
 
-    const id = this._activeRecordingId;
+  /** Record an action only if `recordingId` is still the active generation. */
+  async recordActionForRecording(
+    recordingId: string,
+    tool: string,
+    args: Record<string, unknown>,
+    durationMs: number,
+    ok: boolean,
+    opts?: RecordActionOptions,
+  ): Promise<void> {
+    if (!this._isRecording || this._activeRecordingId !== recordingId || !this._activeMetadata) {
+      return;
+    }
+
     const sanitizedArgs = this.sanitizeArgs(args);
 
-    // Serialize every write so concurrent callers can't share the same _seq.
-    return this.enqueueWrite(async () => {
-      if (!this._isRecording || this._activeRecordingId !== id || !this._activeMetadata) {
+    return this.enqueueMutation(async () => {
+      if (!this._isRecording || this._activeRecordingId !== recordingId || !this._activeMetadata) {
         return;
       }
       try {
@@ -268,7 +277,7 @@ export class ActionRecorder {
           ...applyConsoleBounds(opts?.console),
         };
 
-        await this.store.appendAction(id, action);
+        await this.store.appendAction(recordingId, action);
         if (this._trajectoryBundle) {
           await this._trajectoryBundle.appendToolCall({
             tool,
@@ -306,20 +315,29 @@ export class ActionRecorder {
     if (!this._isRecording || !this._activeRecordingId) {
       return;
     }
-    const recordingIdAtCall = this._activeRecordingId;
+    return this.appendContractResultForRecording(this._activeRecordingId, entry);
+  }
+
+  /** Append a contract result only if `recordingId` is still active. */
+  async appendContractResultForRecording(
+    recordingId: string,
+    entry: ContractResultEntry,
+  ): Promise<void> {
+    if (!this._isRecording || this._activeRecordingId !== recordingId) {
+      return;
+    }
 
     // Serialize so we read _seq AFTER any in-flight recordAction() completes —
     // otherwise the contract row could reference an action index that doesn't
     // exist yet on disk, or, worse, point at the wrong action when the in-flight
     // write resolves first.
-    return this.enqueueWrite(async () => {
-      if (!this._isRecording || this._activeRecordingId !== recordingIdAtCall || this._seq === 0) {
+    return this.enqueueMutation(async () => {
+      if (!this._isRecording || this._activeRecordingId !== recordingId || this._seq === 0) {
         return;
       }
-      const id = this._activeRecordingId;
       const actionIndex = this._seq;
       try {
-        await this.store.appendContractResultRow(id, actionIndex, entry);
+        await this.store.appendContractResultRow(recordingId, actionIndex, entry);
         if (this._trajectoryBundle) {
           await this._trajectoryBundle.appendContract(entry);
         }
@@ -335,9 +353,18 @@ export class ActionRecorder {
    * No-op when recording or trajectory capture is disabled.
    */
   async appendCheckpoint(checkpoint: Record<string, unknown>): Promise<void> {
-    if (!this._isRecording || !this._trajectoryBundle) return;
-    return this.enqueueWrite(async () => {
-      if (!this._isRecording || !this._trajectoryBundle) return;
+    if (!this._isRecording || !this._activeRecordingId || !this._trajectoryBundle) return;
+    return this.appendCheckpointForRecording(this._activeRecordingId, checkpoint);
+  }
+
+  /** Append a checkpoint only if `recordingId` is still active. */
+  async appendCheckpointForRecording(
+    recordingId: string,
+    checkpoint: Record<string, unknown>,
+  ): Promise<void> {
+    if (!this._isRecording || this._activeRecordingId !== recordingId || !this._trajectoryBundle) return;
+    return this.enqueueMutation(async () => {
+      if (!this._isRecording || this._activeRecordingId !== recordingId || !this._trajectoryBundle) return;
       await this._trajectoryBundle.appendCheckpoint(checkpoint);
     });
   }
@@ -488,37 +515,75 @@ function applyConsoleBounds(
 }
 
 // ---------------------------------------------------------------------------
-// Singleton registry: sessionId → ActionRecorder
-// Per-session recorders allow oc_assert to look up the active recorder for
-// a given MCP session without coupling to the global singleton.
+// Session recorder registry: sessionId → ActionRecorder
 // ---------------------------------------------------------------------------
 
-/** Map of sessionId → ActionRecorder instances (populated on start()) */
+/** Map of sessionId → stable ActionRecorder instances. */
 const sessionRecorderRegistry = new Map<string, ActionRecorder>();
+/** In-flight deletion count per session; recorder recreation stays blocked until zero. */
+const deletingSessionRecorderCounts = new Map<string, number>();
 
-/** Singleton instance (global recorder used by the recording MCP tool) */
-let instance: ActionRecorder | null = null;
+/** Immutable handle captured when a tool call begins. */
+export interface ActiveActionRecording {
+  recorder: ActionRecorder;
+  recordingId: string;
+}
 
-export function getActionRecorder(): ActionRecorder {
-  if (!instance) {
-    instance = new ActionRecorder();
+/** Get or create the recorder owned by one logical tool session. */
+export function getOrCreateActionRecorder(sessionId: string): ActionRecorder {
+  if ((deletingSessionRecorderCounts.get(sessionId) ?? 0) > 0) {
+    throw new Error('Session recording is unavailable while the session is being deleted.');
   }
-  return instance;
+  let recorder = sessionRecorderRegistry.get(sessionId);
+  if (!recorder) {
+    recorder = new ActionRecorder();
+    sessionRecorderRegistry.set(sessionId, recorder);
+  }
+  return recorder;
 }
 
 /**
- * Register an ActionRecorder for a given sessionId so that oc_assert can
- * retrieve it. Called by the recording tool on start.
+ * Register an ActionRecorder for a given sessionId so recorder-aware tools can
+ * retrieve it. Primarily used by tests and explicit recorder integrations.
  */
 export function registerSessionRecorder(sessionId: string, recorder: ActionRecorder): void {
+  if ((deletingSessionRecorderCounts.get(sessionId) ?? 0) > 0) {
+    throw new Error('Cannot register a recorder while the session is being deleted.');
+  }
   sessionRecorderRegistry.set(sessionId, recorder);
 }
 
+/** Whether `recorder` is still the registered owner for `sessionId`. */
+export function isSessionRecorderRegistered(sessionId: string, recorder: ActionRecorder): boolean {
+  return sessionRecorderRegistry.get(sessionId) === recorder;
+}
+
 /**
- * Unregister an ActionRecorder for a given sessionId. Called on stop.
+ * Unregister an ActionRecorder for a deleted session.
  */
 export function unregisterSessionRecorder(sessionId: string): void {
   sessionRecorderRegistry.delete(sessionId);
+  deletingSessionRecorderCounts.delete(sessionId);
+}
+
+/** Evict recorder ownership and block recreation while deletion is in progress. */
+export function beginSessionRecorderDeletion(sessionId: string): void {
+  sessionRecorderRegistry.delete(sessionId);
+  deletingSessionRecorderCounts.set(
+    sessionId,
+    (deletingSessionRecorderCounts.get(sessionId) ?? 0) + 1,
+  );
+}
+
+/** Finish deletion and permit a future session with the same ID to record. */
+export function completeSessionRecorderDeletion(sessionId: string): void {
+  sessionRecorderRegistry.delete(sessionId);
+  const remaining = (deletingSessionRecorderCounts.get(sessionId) ?? 0) - 1;
+  if (remaining > 0) {
+    deletingSessionRecorderCounts.set(sessionId, remaining);
+  } else {
+    deletingSessionRecorderCounts.delete(sessionId);
+  }
 }
 
 /**
@@ -531,10 +596,13 @@ export function getActiveActionRecorder(sessionId: string): ActionRecorder | und
   if (recorder && recorder.isRecording) {
     return recorder;
   }
-  // Also check the global singleton in case it was started without explicit registration
-  const global = getActionRecorder();
-  if (global.isRecording && global.activeMetadata?.sessionId === sessionId) {
-    return global;
-  }
   return undefined;
+}
+
+/** Capture the active recorder and recording generation for dispatch fencing. */
+export function getActiveActionRecording(sessionId: string): ActiveActionRecording | undefined {
+  const recorder = getActiveActionRecorder(sessionId);
+  const recordingId = recorder?.activeRecordingId;
+  if (!recorder || !recordingId) return undefined;
+  return { recorder, recordingId };
 }

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -641,6 +641,10 @@ export class SessionManager {
       return;
     }
 
+    // Notify session-owned sidecars before asynchronous cleanup begins so
+    // they can stop admitting new work during the deletion window.
+    this.emitEvent({ type: 'session:deleting', sessionId, timestamp: Date.now() });
+
     // Save storage state before cleanup (save first, then stop watchdog).
     // #848: flush ONE representative tab per named context so per-context
     // cookies / localStorage are partitioned in their own snapshot files.

--- a/src/tools/checkpoint.ts
+++ b/src/tools/checkpoint.ts
@@ -13,7 +13,7 @@ import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { writeFileAtomicSafe, readFileSafe } from '../utils/atomic-file';
 import { getSessionManager } from '../session-manager';
 import { safeTitle } from '../utils/safe-title';
-import { getActiveActionRecorder } from '../recording/action-recorder';
+import { getActiveActionRecording } from '../recording/action-recorder';
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -318,6 +318,9 @@ const handler: ToolHandler = async (
   args: Record<string, unknown>,
 ): Promise<MCPResult> => {
   const action = args.action as string;
+  const recordingAtDispatch = action === 'save'
+    ? getActiveActionRecording(sessionId)
+    : undefined;
 
   if (action === 'save') {
     if (args.completedSteps !== undefined && !isStringArray(args.completedSteps)) {
@@ -360,7 +363,13 @@ const handler: ToolHandler = async (
     await writeCheckpointTimeline(checkpoint);
 
     try {
-      await getActiveActionRecorder(sessionId)?.appendCheckpoint(checkpoint as unknown as Record<string, unknown>);
+      if (recordingAtDispatch) {
+        const { recorder, recordingId } = recordingAtDispatch;
+        await recorder.appendCheckpointForRecording(
+          recordingId,
+          checkpoint as unknown as Record<string, unknown>,
+        );
+      }
     } catch {
       // Best-effort trajectory linkage must never fail checkpoint save.
     }

--- a/src/tools/oc-assert.ts
+++ b/src/tools/oc-assert.ts
@@ -27,7 +27,7 @@ import { runImageQaSampling } from './image-qa';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { evaluate } from '../contracts/evaluate';
 import { validateAssertion } from '../contracts/validator';
-import { getActiveActionRecorder } from '../recording/action-recorder';
+import { getActiveActionRecording } from '../recording/action-recorder';
 import type { EvalContext, NetworkLogEntry } from '../contracts/eval-context';
 import { primaryFailureCategory } from '../failure/classifier';
 import type { FailureCategory } from '../failure/categories';
@@ -333,6 +333,7 @@ const handler: ToolHandler = async (
   args: Record<string, unknown>,
   context?: ToolContext,
 ): Promise<MCPResult> => {
+  const recordingAtDispatch = getActiveActionRecording(sessionId);
   const contractInline = args.contract;
   const contractId = args.contract_id as string | undefined;
 
@@ -421,9 +422,9 @@ const handler: ToolHandler = async (
 
   // Wire into active recording: append verdict to most-recent action's contractResults.
   // No-op if no recording is active for this session or if no action has been recorded yet.
-  const recorder = getActiveActionRecorder(sessionId);
-  if (recorder) {
-    recorder.appendContractResult({
+  if (recordingAtDispatch) {
+    const { recorder, recordingId } = recordingAtDispatch;
+    recorder.appendContractResultForRecording(recordingId, {
       assertion: contractInline,
       verdict,
       details: result.evidence.details as Record<string, unknown> | undefined,

--- a/src/tools/recording.ts
+++ b/src/tools/recording.ts
@@ -8,7 +8,11 @@ import * as path from 'path';
 import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
-import { getActionRecorder, registerSessionRecorder, unregisterSessionRecorder } from '../recording/action-recorder';
+import {
+  getActiveActionRecorder,
+  getOrCreateActionRecorder,
+  isSessionRecorderRegistered,
+} from '../recording/action-recorder';
 import { getRecordingStore } from '../recording/recording-store';
 import { RecordingAction, RecordingMetadata } from '../recording/types';
 import { currentRequestContext } from '../observability/request-id';
@@ -52,23 +56,30 @@ const startHandler: ToolHandler = async (
   sessionId: string,
   args: Record<string, unknown>,
 ): Promise<MCPResult> => {
-  const recorder = getActionRecorder();
-
-  if (recorder.isRecording) {
-    return {
-      content: [{ type: 'text', text: `Error: A recording is already active (ID: ${recorder.activeRecordingId}). Call oc_recording_stop first.` }],
-      isError: true,
-    };
-  }
-
   try {
+    const recorder = getOrCreateActionRecorder(sessionId);
+
+    if (recorder.isRecording) {
+      return {
+        content: [{ type: 'text', text: `Error: A recording is already active (ID: ${recorder.activeRecordingId}). Call oc_recording_stop first.` }],
+        isError: true,
+      };
+    }
+
     const startOptions = {
       label: args.label as string | undefined,
       profile: args.profile as string | undefined,
       ...(args.trajectoryBundle === true ? { trajectoryBundle: true } : {}),
     };
     const metadata = await recorder.start(sessionId, startOptions);
-    registerSessionRecorder(sessionId, recorder);
+    if (!isSessionRecorderRegistered(sessionId, recorder)) {
+      try {
+        await recorder.stop();
+      } catch {
+        // Best-effort finalization after the owning session was deleted.
+      }
+      throw new Error('The session ended while recording was starting.');
+    }
 
     const lines = [
       'Recording started.',
@@ -109,12 +120,12 @@ const stopDefinition: MCPToolDefinition = {
 };
 
 const stopHandler: ToolHandler = async (
-  _sessionId: string,
+  sessionId: string,
   _args: Record<string, unknown>,
 ): Promise<MCPResult> => {
-  const recorder = getActionRecorder();
+  const recorder = getActiveActionRecorder(sessionId);
 
-  if (!recorder.isRecording) {
+  if (!recorder) {
     return {
       content: [{ type: 'text', text: 'Error: No active recording. Call oc_recording_start first.' }],
       isError: true,
@@ -144,8 +155,6 @@ const stopHandler: ToolHandler = async (
       const report = metadata.trajectoryBundle.report as Record<string, unknown> | undefined;
       if (report) lines.push(`  Events:   ${String(report.total_events ?? 'unknown')}`);
     }
-    unregisterSessionRecorder(metadata.sessionId);
-
     return { content: [{ type: 'text', text: lines.join('\n') }] };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -167,15 +176,15 @@ const statusDefinition: MCPToolDefinition = {
 };
 
 const statusHandler: ToolHandler = async (
-  _sessionId: string,
+  sessionId: string,
   _args: Record<string, unknown>,
 ): Promise<MCPResult> => {
-  const recorder = getActionRecorder();
-  const metadata = recorder.activeMetadata;
-  const trajectory = recorder.activeTrajectoryBundle || metadata?.trajectoryBundle;
+  const recorder = getActiveActionRecorder(sessionId);
+  const metadata = recorder?.activeMetadata;
+  const trajectory = recorder?.activeTrajectoryBundle || metadata?.trajectoryBundle;
   const payload = {
-    active: recorder.isRecording,
-    recordingId: recorder.activeRecordingId,
+    active: recorder?.isRecording ?? false,
+    recordingId: recorder?.activeRecordingId ?? null,
     sessionId: metadata?.sessionId,
     actionCount: metadata?.actionCount ?? 0,
     trajectoryBundle: trajectory ?? { enabled: false },

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -85,7 +85,7 @@ export interface SessionCreateOptions {
 }
 
 export interface SessionEvent {
-  type: 'session:created' | 'session:deleted' | 'session:target-added' | 'session:target-removed' | 'session:target-closed' | 'worker:created' | 'worker:deleted';
+  type: 'session:created' | 'session:deleting' | 'session:deleted' | 'session:target-added' | 'session:target-removed' | 'session:target-closed' | 'worker:created' | 'worker:deleted';
   sessionId: string;
   targetId?: string;
   workerId?: string;

--- a/tests/mcp-server-recording-isolation.test.ts
+++ b/tests/mcp-server-recording-isolation.test.ts
@@ -1,0 +1,221 @@
+/// <reference types="jest" />
+
+interface FakeRecorder {
+  activeRecordingId: string;
+  recordActionForRecording: jest.Mock;
+}
+
+const mockRecorders = new Map<string, FakeRecorder>();
+const mockGetActiveActionRecording = jest.fn((sessionId: string) => {
+  const recorder = mockRecorders.get(sessionId);
+  return recorder ? { recorder, recordingId: recorder.activeRecordingId } : undefined;
+});
+const mockBeginSessionRecorderDeletion = jest.fn((sessionId: string) => {
+  mockRecorders.delete(sessionId);
+});
+const mockCompleteSessionRecorderDeletion = jest.fn((sessionId: string) => {
+  mockRecorders.delete(sessionId);
+});
+
+jest.mock('../src/recording/action-recorder', () => ({
+  beginSessionRecorderDeletion: mockBeginSessionRecorderDeletion,
+  completeSessionRecorderDeletion: mockCompleteSessionRecorderDeletion,
+  getActiveActionRecording: mockGetActiveActionRecording,
+}));
+
+import { MCPServer } from '../src/mcp-server';
+import type { MCPRequest, MCPResult, MCPToolDefinition } from '../src/types/mcp';
+
+const TOOL_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: false,
+  openWorldHint: false,
+};
+
+function toolDefinition(name: string): MCPToolDefinition {
+  return {
+    name,
+    description: `${name} test tool`,
+    inputSchema: { type: 'object', properties: {} },
+    annotations: TOOL_ANNOTATIONS,
+  };
+}
+
+function callTool(server: MCPServer, name: string, sessionId: string): Promise<unknown> {
+  const request: MCPRequest = {
+    jsonrpc: '2.0',
+    id: `${name}-${sessionId}`,
+    method: 'tools/call',
+    params: { name, arguments: {}, sessionId },
+  };
+  return server.handleRequest(request);
+}
+
+async function flushRecordingWrites(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+describe('MCPServer session-scoped recording hooks', () => {
+  let listeners: Array<(event: Record<string, unknown>) => void>;
+  let server: MCPServer;
+
+  beforeEach(() => {
+    listeners = [];
+    mockRecorders.clear();
+    mockGetActiveActionRecording.mockClear();
+    mockBeginSessionRecorderDeletion.mockClear();
+    mockCompleteSessionRecorderDeletion.mockClear();
+
+    server = new MCPServer({
+      getOrCreateSession: jest.fn().mockResolvedValue({ id: 'session' }),
+      addEventListener: jest.fn((listener) => listeners.push(listener)),
+      getAllSessionInfos: jest.fn().mockReturnValue([]),
+      sessionCount: 0,
+    } as any);
+  });
+
+  it('routes successful and returned-error results only to the matching session recorder', async () => {
+    const recordA = jest.fn().mockResolvedValue(undefined);
+    const recordB = jest.fn().mockResolvedValue(undefined);
+    mockRecorders.set('session-a', { activeRecordingId: 'rec-a', recordActionForRecording: recordA });
+    mockRecorders.set('session-b', { activeRecordingId: 'rec-b', recordActionForRecording: recordB });
+
+    server.registerTool(
+      'record_ok',
+      jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] }),
+      toolDefinition('record_ok'),
+    );
+    server.registerTool(
+      'record_soft_error',
+      jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'failed' }], isError: true }),
+      toolDefinition('record_soft_error'),
+    );
+
+    await callTool(server, 'record_ok', 'session-a');
+    await callTool(server, 'record_ok', 'session-b');
+    await callTool(server, 'record_soft_error', 'session-a');
+    await flushRecordingWrites();
+
+    expect(recordA).toHaveBeenCalledTimes(2);
+    expect(recordA.mock.calls[0][0]).toBe('rec-a');
+    expect(recordA.mock.calls[0][1]).toBe('record_ok');
+    expect(recordA.mock.calls[0][4]).toBe(true);
+    expect(recordA.mock.calls[1][0]).toBe('rec-a');
+    expect(recordA.mock.calls[1][1]).toBe('record_soft_error');
+    expect(recordA.mock.calls[1][4]).toBe(false);
+    expect(recordB).toHaveBeenCalledTimes(1);
+    expect(recordB.mock.calls[0][0]).toBe('rec-b');
+    expect(recordB.mock.calls[0][1]).toBe('record_ok');
+  });
+
+  it('routes thrown failures to the matching recorder only', async () => {
+    const recordB = jest.fn().mockResolvedValue(undefined);
+    mockRecorders.set('session-b', { activeRecordingId: 'rec-b', recordActionForRecording: recordB });
+
+    server.registerTool(
+      'record_throw',
+      jest.fn().mockRejectedValue(new Error('boom')),
+      toolDefinition('record_throw'),
+    );
+
+    await callTool(server, 'record_throw', 'session-b');
+    await flushRecordingWrites();
+
+    expect(recordB).toHaveBeenCalledTimes(1);
+    expect(recordB.mock.calls[0][0]).toBe('rec-b');
+    expect(recordB.mock.calls[0][1]).toBe('record_throw');
+    expect(recordB.mock.calls[0][4]).toBe(false);
+  });
+
+  it('does not append an inactive session call to another active session recorder', async () => {
+    const recordA = jest.fn().mockResolvedValue(undefined);
+    mockRecorders.set('session-a', { activeRecordingId: 'rec-a', recordActionForRecording: recordA });
+
+    server.registerTool(
+      'record_inactive',
+      jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] }),
+      toolDefinition('record_inactive'),
+    );
+
+    await callTool(server, 'record_inactive', 'session-b');
+    await flushRecordingWrites();
+
+    expect(recordA).not.toHaveBeenCalled();
+  });
+
+  it('does not record the recording tools themselves', async () => {
+    const recordA = jest.fn().mockResolvedValue(undefined);
+    mockRecorders.set('session-a', { activeRecordingId: 'rec-a', recordActionForRecording: recordA });
+    server.registerTool(
+      'oc_recording_status',
+      jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'status' }] }),
+      toolDefinition('oc_recording_status'),
+    );
+
+    await callTool(server, 'oc_recording_status', 'session-a');
+    await flushRecordingWrites();
+
+    expect(recordA).not.toHaveBeenCalled();
+    expect(mockGetActiveActionRecording).not.toHaveBeenCalled();
+  });
+
+  it('keeps an in-flight call fenced to the recording active at dispatch', async () => {
+    let markHandlerStarted!: () => void;
+    let releaseHandler!: () => void;
+    const handlerStarted = new Promise<void>((resolve) => { markHandlerStarted = resolve; });
+    const handlerGate = new Promise<void>((resolve) => { releaseHandler = resolve; });
+    const recordOld = jest.fn().mockResolvedValue(undefined);
+    const recordReplacement = jest.fn().mockResolvedValue(undefined);
+    mockRecorders.set('session-a', { activeRecordingId: 'rec-old', recordActionForRecording: recordOld });
+    server.registerTool(
+      'record_slow',
+      jest.fn(async (): Promise<MCPResult> => {
+        markHandlerStarted();
+        await handlerGate;
+        return { content: [{ type: 'text', text: 'ok' }] };
+      }),
+      toolDefinition('record_slow'),
+    );
+
+    const inFlight = callTool(server, 'record_slow', 'session-a');
+    await handlerStarted;
+    for (const listener of listeners) {
+      listener({ type: 'session:deleting', sessionId: 'session-a', timestamp: Date.now() });
+      listener({ type: 'session:deleted', sessionId: 'session-a', timestamp: Date.now() });
+    }
+    mockRecorders.set('session-a', {
+      activeRecordingId: 'rec-replacement',
+      recordActionForRecording: recordReplacement,
+    });
+    releaseHandler();
+
+    await inFlight;
+    await flushRecordingWrites();
+
+    expect(recordOld).toHaveBeenCalledTimes(1);
+    expect(recordOld.mock.calls[0][0]).toBe('rec-old');
+    expect(recordReplacement).not.toHaveBeenCalled();
+  });
+
+  it('blocks recorder ownership during deletion and evicts only that session', () => {
+    mockRecorders.set('session-a', { activeRecordingId: 'rec-a', recordActionForRecording: jest.fn() });
+    mockRecorders.set('session-b', { activeRecordingId: 'rec-b', recordActionForRecording: jest.fn() });
+
+    for (const listener of listeners) {
+      listener({ type: 'session:deleting', sessionId: 'session-a', timestamp: Date.now() });
+    }
+
+    expect(mockBeginSessionRecorderDeletion).toHaveBeenCalledWith('session-a');
+    expect(mockRecorders.has('session-a')).toBe(false);
+    expect(mockRecorders.has('session-b')).toBe(true);
+
+    for (const listener of listeners) {
+      listener({ type: 'session:deleted', sessionId: 'session-a', timestamp: Date.now() });
+    }
+
+    expect(mockCompleteSessionRecorderDeletion).toHaveBeenCalledWith('session-a');
+    expect(mockRecorders.has('session-a')).toBe(false);
+    expect(mockRecorders.has('session-b')).toBe(true);
+  });
+});

--- a/tests/mcp-server-recording-store-isolation.test.ts
+++ b/tests/mcp-server-recording-store-isolation.test.ts
@@ -1,0 +1,128 @@
+/// <reference types="jest" />
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { MCPServer } from '../src/mcp-server';
+import {
+  ActionRecorder,
+  registerSessionRecorder,
+  unregisterSessionRecorder,
+} from '../src/recording/action-recorder';
+import { RecordingStore } from '../src/recording/recording-store';
+import type { MCPRequest, MCPToolDefinition } from '../src/types/mcp';
+
+const TOOL_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: false,
+  openWorldHint: false,
+};
+
+function toolDefinition(name: string): MCPToolDefinition {
+  return {
+    name,
+    description: `${name} integration test tool`,
+    inputSchema: { type: 'object', properties: {} },
+    annotations: TOOL_ANNOTATIONS,
+  };
+}
+
+function callTool(server: MCPServer, name: string, sessionId: string): Promise<unknown> {
+  const request: MCPRequest = {
+    jsonrpc: '2.0',
+    id: `${name}-${sessionId}`,
+    method: 'tools/call',
+    params: { name, arguments: {}, sessionId },
+  };
+  return server.handleRequest(request);
+}
+
+async function waitForActionCount(
+  store: RecordingStore,
+  recordingId: string,
+  expected: number,
+): Promise<void> {
+  const deadline = Date.now() + 2000;
+  while (Date.now() < deadline) {
+    if (store.readActions(recordingId).length === expected) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for ${expected} action(s) in ${recordingId}`);
+}
+
+describe('MCPServer real recording-store session isolation', () => {
+  let dirA: string;
+  let dirB: string;
+  let storeA: RecordingStore;
+  let storeB: RecordingStore;
+  let recorderA: ActionRecorder;
+  let recorderB: ActionRecorder;
+  let recordingA: string;
+  let recordingB: string;
+  let server: MCPServer;
+
+  beforeEach(async () => {
+    dirA = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-mcp-recording-a-'));
+    dirB = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-mcp-recording-b-'));
+    storeA = new RecordingStore(dirA);
+    storeB = new RecordingStore(dirB);
+    recorderA = new ActionRecorder(storeA, { captureScreenshots: false });
+    recorderB = new ActionRecorder(storeB, { captureScreenshots: false });
+    recordingA = (await recorderA.start('session-a')).id;
+    recordingB = (await recorderB.start('session-b')).id;
+    registerSessionRecorder('session-a', recorderA);
+    registerSessionRecorder('session-b', recorderB);
+
+    server = new MCPServer({
+      getOrCreateSession: jest.fn().mockResolvedValue({ id: 'session' }),
+      addEventListener: jest.fn(),
+      getAllSessionInfos: jest.fn().mockReturnValue([]),
+      sessionCount: 0,
+    } as any);
+  });
+
+  afterEach(async () => {
+    if (recorderA.isRecording) await recorderA.stop();
+    if (recorderB.isRecording) await recorderB.stop();
+    unregisterSessionRecorder('session-a');
+    unregisterSessionRecorder('session-b');
+    fs.rmSync(dirA, { recursive: true, force: true });
+    fs.rmSync(dirB, { recursive: true, force: true });
+  });
+
+  it('writes each result only to the recording active for that tool session', async () => {
+    server.registerTool(
+      'record_ok',
+      jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] }),
+      toolDefinition('record_ok'),
+    );
+    server.registerTool(
+      'record_soft_error',
+      jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'failed' }], isError: true }),
+      toolDefinition('record_soft_error'),
+    );
+
+    await Promise.all([
+      callTool(server, 'record_ok', 'session-a'),
+      callTool(server, 'record_soft_error', 'session-b'),
+    ]);
+    await Promise.all([
+      waitForActionCount(storeA, recordingA, 1),
+      waitForActionCount(storeB, recordingB, 1),
+    ]);
+
+    expect(storeA.readActions(recordingA)).toEqual([
+      expect.objectContaining({ tool: 'record_ok', ok: true }),
+    ]);
+    expect(storeB.readActions(recordingB)).toEqual([
+      expect.objectContaining({ tool: 'record_soft_error', ok: false }),
+    ]);
+
+    await callTool(server, 'record_ok', 'session-c');
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+
+    expect(storeA.readActions(recordingA)).toHaveLength(1);
+    expect(storeB.readActions(recordingB)).toHaveLength(1);
+  });
+});

--- a/tests/recording/action-recorder-session-lifecycle.test.ts
+++ b/tests/recording/action-recorder-session-lifecycle.test.ts
@@ -1,0 +1,136 @@
+/// <reference types="jest" />
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  ActionRecorder,
+  beginSessionRecorderDeletion,
+  completeSessionRecorderDeletion,
+  getOrCreateActionRecorder,
+  unregisterSessionRecorder,
+} from '../../src/recording/action-recorder';
+import { RecordingStore } from '../../src/recording/recording-store';
+
+describe('session-scoped ActionRecorder lifecycle', () => {
+  afterEach(() => {
+    completeSessionRecorderDeletion('session-a');
+    completeSessionRecorderDeletion('session-b');
+    unregisterSessionRecorder('session-a');
+    unregisterSessionRecorder('session-b');
+  });
+
+  it('returns one stable recorder per session and distinct recorders across sessions', () => {
+    const firstA = getOrCreateActionRecorder('session-a');
+    const secondA = getOrCreateActionRecorder('session-a');
+    const firstB = getOrCreateActionRecorder('session-b');
+
+    expect(secondA).toBe(firstA);
+    expect(firstB).not.toBe(firstA);
+  });
+
+  it('creates a fresh recorder after the session registry entry is evicted', () => {
+    const first = getOrCreateActionRecorder('session-a');
+    unregisterSessionRecorder('session-a');
+
+    expect(getOrCreateActionRecorder('session-a')).not.toBe(first);
+  });
+
+  it('blocks recorder recreation during deletion and permits session ID reuse afterward', () => {
+    const first = getOrCreateActionRecorder('session-a');
+    beginSessionRecorderDeletion('session-a');
+    beginSessionRecorderDeletion('session-a');
+
+    expect(() => getOrCreateActionRecorder('session-a')).toThrow('being deleted');
+
+    completeSessionRecorderDeletion('session-a');
+    expect(() => getOrCreateActionRecorder('session-a')).toThrow('being deleted');
+
+    completeSessionRecorderDeletion('session-a');
+    expect(getOrCreateActionRecorder('session-a')).not.toBe(first);
+  });
+
+  it('serializes concurrent starts so exactly one recording becomes active', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-recorder-lifecycle-'));
+    const store = new RecordingStore(dir);
+    const recorder = new ActionRecorder(store, { captureScreenshots: false });
+
+    try {
+      const outcomes = await Promise.allSettled([
+        recorder.start('session-a'),
+        recorder.start('session-a'),
+      ]);
+
+      expect(outcomes.filter((outcome) => outcome.status === 'fulfilled')).toHaveLength(1);
+      expect(outcomes.filter((outcome) => outcome.status === 'rejected')).toHaveLength(1);
+      expect(await store.listRecordings()).toHaveLength(1);
+      expect(recorder.isRecording).toBe(true);
+    } finally {
+      if (recorder.isRecording) await recorder.stop();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('finalizes before writes admitted after stop and keeps metadata consistent', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-recorder-stop-order-'));
+    const store = new RecordingStore(dir);
+    const recorder = new ActionRecorder(store, { captureScreenshots: false });
+    const originalAppendAction = store.appendAction.bind(store);
+    let markAppendStarted!: () => void;
+    let releaseAppend!: () => void;
+    const appendStarted = new Promise<void>((resolve) => { markAppendStarted = resolve; });
+    const appendGate = new Promise<void>((resolve) => { releaseAppend = resolve; });
+
+    jest.spyOn(store, 'appendAction').mockImplementation(async (recordingId, action) => {
+      if (action.tool === 'first') {
+        markAppendStarted();
+        await appendGate;
+      }
+      await originalAppendAction(recordingId, action);
+    });
+
+    try {
+      await recorder.start('session-a');
+      const recordingId = recorder.activeRecordingId!;
+      const firstWrite = recorder.recordAction('first', {}, 10, true);
+      await appendStarted;
+
+      const stopping = recorder.stop();
+      await Promise.resolve();
+      const lateWrite = recorder.recordAction('late', {}, 10, true);
+      releaseAppend();
+
+      const [, metadata] = await Promise.all([firstWrite, stopping, lateWrite]);
+      const persisted = await store.readMetadata(recordingId);
+
+      expect(store.readActions(recordingId).map((action) => action.tool)).toEqual(['first']);
+      expect(metadata.actionCount).toBe(1);
+      expect(persisted?.actionCount).toBe(1);
+      expect(recorder.isRecording).toBe(false);
+    } finally {
+      releaseAppend();
+      if (recorder.isRecording) await recorder.stop();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a stale recording generation after stop and restart', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-recorder-generation-'));
+    const store = new RecordingStore(dir);
+    const recorder = new ActionRecorder(store, { captureScreenshots: false });
+
+    try {
+      const first = await recorder.start('session-a');
+      await recorder.stop();
+      const second = await recorder.start('session-a');
+
+      await recorder.recordActionForRecording(first.id, 'stale', {}, 10, true);
+
+      expect(store.readActions(second.id)).toHaveLength(0);
+      expect(recorder.activeMetadata?.actionCount).toBe(0);
+    } finally {
+      if (recorder.isRecording) await recorder.stop();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/recording/action-recorder-trajectory.test.ts
+++ b/tests/recording/action-recorder-trajectory.test.ts
@@ -67,4 +67,20 @@ describe('ActionRecorder trajectory bundle', () => {
     expect(fs.readFileSync(path.join(bundle.dir, 'contracts', '000002.json'), 'utf8')).not.toContain('super-secret-fixture-password');
     expect(fs.readFileSync(path.join(bundle.dir, 'checkpoints', '000003.json'), 'utf8')).not.toContain('super-secret-fixture-password');
   });
+
+  it('rejects stale contract and checkpoint linkage after a recording restart', async () => {
+    const first = await recorder.start('sess-traj', { trajectoryBundle: true, trajectoryRootDir: trajectoryRoot });
+    await recorder.stop();
+
+    await recorder.start('sess-traj', { trajectoryBundle: true, trajectoryRootDir: trajectoryRoot });
+    const currentBundle = recorder.activeTrajectoryBundle!;
+    await recorder.recordAction('navigate', { url: 'https://example.com' }, 10, true);
+    await recorder.appendContractResultForRecording(first.id, { assertion: {}, verdict: 'pass' });
+    await recorder.appendCheckpointForRecording(first.id, { taskDescription: 'stale' });
+    await recorder.stop();
+
+    expect(jsonl(path.join(currentBundle.dir, 'events.jsonl')).map((event) => event.event)).toEqual([
+      'tool_call_end',
+    ]);
+  });
 });

--- a/tests/src/session-manager-ttl.test.ts
+++ b/tests/src/session-manager-ttl.test.ts
@@ -371,6 +371,21 @@ describe('SessionManager TTL and Stats', () => {
       expect(session.lastActivityAt).toBeGreaterThan(initialTime);
     });
   });
+
+  describe('session deletion events', () => {
+    test('emits session:deleting before asynchronous cleanup and session:deleted', async () => {
+      await sessionManager.createSession({ id: 'delete-events' });
+      const listener = jest.fn();
+      sessionManager.addEventListener(listener);
+
+      await sessionManager.deleteSession('delete-events');
+
+      expect(listener.mock.calls.map(([event]) => event.type)).toEqual([
+        'session:deleting',
+        'session:deleted',
+      ]);
+    });
+  });
 });
 
 describe('SessionManager with Connection Pool', () => {

--- a/tests/tools/checkpoint-timeline.test.ts
+++ b/tests/tools/checkpoint-timeline.test.ts
@@ -4,6 +4,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
+const mockGetActiveActionRecording = jest.fn(() => undefined as unknown);
+
 jest.mock('../../src/session-manager', () => ({
   getSessionManager: jest.fn(() => ({
     getAllSessionInfos: jest.fn(() => []),
@@ -13,7 +15,10 @@ jest.mock('../../src/session-manager', () => ({
 }));
 
 jest.mock('../../src/recording/action-recorder', () => ({
-  getActiveActionRecorder: jest.fn(() => undefined),
+  beginSessionRecorderDeletion: jest.fn(),
+  completeSessionRecorderDeletion: jest.fn(),
+  getActiveActionRecording: mockGetActiveActionRecording,
+  unregisterSessionRecorder: jest.fn(),
 }));
 
 type Handler = (sessionId: string, args: Record<string, unknown>) => Promise<{ content?: Array<{ type: string; text?: string }>; isError?: boolean }>;
@@ -42,6 +47,7 @@ describe('oc_checkpoint timeline (#1025)', () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-checkpoint-timeline-'));
     process.env.OPENCHROME_CHECKPOINT_DIR = tmpDir;
     process.env.OPENCHROME_CHECKPOINT_TIMELINE_MAX = '10';
+    mockGetActiveActionRecording.mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -81,6 +87,26 @@ describe('oc_checkpoint timeline (#1025)', () => {
     ]);
     expect(listed.checkpoints[0].label).toBe('second');
     expect(listed.checkpoints[0].pendingSteps).toBe(0);
+  });
+
+  test('save links the checkpoint through the captured recording generation', async () => {
+    const appendCheckpointForRecording = jest.fn().mockResolvedValue(undefined);
+    mockGetActiveActionRecording.mockReturnValue({
+      recorder: { appendCheckpointForRecording },
+      recordingId: 'rec-captured',
+    });
+    const handler = await loadHandler();
+
+    const saved = readJson(await handler('sess-1', {
+      action: 'save',
+      taskDescription: 'task',
+    }));
+
+    expect(saved.status).toBe('saved');
+    expect(appendCheckpointForRecording).toHaveBeenCalledWith(
+      'rec-captured',
+      expect.objectContaining({ sessionId: 'sess-1', checkpointId: saved.checkpointId }),
+    );
   });
 
   test('load supports latest compatibility and specific checkpoint id', async () => {

--- a/tests/tools/oc-assert-recording-generation.test.ts
+++ b/tests/tools/oc-assert-recording-generation.test.ts
@@ -1,0 +1,79 @@
+/// <reference types="jest" />
+
+const mockEvaluate = jest.fn();
+const mockGetActiveActionRecording = jest.fn();
+
+jest.mock('../../src/contracts/evaluate', () => ({
+  evaluate: mockEvaluate,
+}));
+
+jest.mock('../../src/recording/action-recorder', () => ({
+  getActiveActionRecording: mockGetActiveActionRecording,
+}));
+
+import { registerOcAssertTool } from '../../src/tools/oc-assert';
+import type { MCPResult, ToolHandler } from '../../src/types/mcp';
+
+function loadHandler(): ToolHandler {
+  let handler: ToolHandler | undefined;
+  registerOcAssertTool({
+    registerTool: (_name: string, registered: ToolHandler) => {
+      handler = registered;
+    },
+  } as any);
+  if (!handler) throw new Error('oc_assert handler not registered');
+  return handler;
+}
+
+describe('oc_assert recording generation fence', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('appends the verdict only through the recording captured at handler dispatch', async () => {
+    let markEvaluationStarted!: () => void;
+    let releaseEvaluation!: () => void;
+    const evaluationStarted = new Promise<void>((resolve) => { markEvaluationStarted = resolve; });
+    const evaluationGate = new Promise<void>((resolve) => { releaseEvaluation = resolve; });
+    const appendOld = jest.fn().mockResolvedValue(undefined);
+    const appendReplacement = jest.fn().mockResolvedValue(undefined);
+    mockGetActiveActionRecording.mockReturnValue({
+      recorder: { appendContractResultForRecording: appendOld },
+      recordingId: 'rec-old',
+    });
+    mockEvaluate.mockImplementation(async () => {
+      markEvaluationStarted();
+      await evaluationGate;
+      return {
+        passed: true,
+        evidence: {
+          passed: true,
+          assertion_kind: 'url',
+          details: { url: 'https://example.com' },
+        },
+      };
+    });
+    const handler = loadHandler();
+
+    const pending = handler('session-a', {
+      contract: { kind: 'url', pattern: 'example\\.com' },
+      evidence: { snapshot: { url: 'https://example.com' } },
+    });
+    await evaluationStarted;
+    mockGetActiveActionRecording.mockReturnValue({
+      recorder: { appendContractResultForRecording: appendReplacement },
+      recordingId: 'rec-replacement',
+    });
+    releaseEvaluation();
+
+    const result = await pending as MCPResult;
+
+    expect(result.isError).not.toBe(true);
+    expect(mockGetActiveActionRecording).toHaveBeenCalledTimes(1);
+    expect(appendOld).toHaveBeenCalledWith(
+      'rec-old',
+      expect.objectContaining({ verdict: 'pass' }),
+    );
+    expect(appendReplacement).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tools/recording-session-isolation.test.ts
+++ b/tests/tools/recording-session-isolation.test.ts
@@ -1,0 +1,202 @@
+/// <reference types="jest" />
+
+interface FakeRecorder {
+  isRecording: boolean;
+  activeRecordingId: string | null;
+  activeMetadata: Record<string, unknown> | null;
+  activeTrajectoryBundle: null;
+  start: jest.Mock;
+  stop: jest.Mock;
+}
+
+let mockRecordingSequence = 0;
+const mockRecorders = new Map<string, FakeRecorder>();
+
+function mockCreateRecorder(): FakeRecorder {
+  const recorder: FakeRecorder = {
+    isRecording: false,
+    activeRecordingId: null,
+    activeMetadata: null,
+    activeTrajectoryBundle: null,
+    start: jest.fn(),
+    stop: jest.fn(),
+  };
+
+  recorder.start.mockImplementation(async (sessionId: string, options?: Record<string, unknown>) => {
+    if (recorder.isRecording) throw new Error('A recording is already active. Call stop() first.');
+    const id = `rec-20260728-120000-${String(++mockRecordingSequence).padStart(4, '0')}`;
+    const metadata = {
+      version: 1,
+      id,
+      sessionId,
+      startedAt: '2026-07-28T12:00:00.000Z',
+      actionCount: 0,
+      label: options?.label,
+      profile: options?.profile,
+    };
+    recorder.isRecording = true;
+    recorder.activeRecordingId = id;
+    recorder.activeMetadata = metadata;
+    return metadata;
+  });
+
+  recorder.stop.mockImplementation(async () => {
+    if (!recorder.isRecording || !recorder.activeMetadata) {
+      throw new Error('No active recording. Call start() first.');
+    }
+    const metadata = {
+      ...recorder.activeMetadata,
+      stoppedAt: '2026-07-28T12:01:00.000Z',
+    };
+    recorder.isRecording = false;
+    recorder.activeRecordingId = null;
+    recorder.activeMetadata = null;
+    return metadata;
+  });
+
+  return recorder;
+}
+
+const mockGlobalRecorder = mockCreateRecorder();
+const mockGetOrCreateActionRecorder = jest.fn((sessionId: string) => {
+  let recorder = mockRecorders.get(sessionId);
+  if (!recorder) {
+    recorder = mockCreateRecorder();
+    mockRecorders.set(sessionId, recorder);
+  }
+  return recorder;
+});
+const mockGetActiveActionRecorder = jest.fn((sessionId: string) => {
+  const recorder = mockRecorders.get(sessionId);
+  return recorder?.isRecording ? recorder : undefined;
+});
+
+jest.mock('../../src/recording/action-recorder', () => ({
+  beginSessionRecorderDeletion: jest.fn(),
+  completeSessionRecorderDeletion: jest.fn(),
+  getActionRecorder: jest.fn(() => mockGlobalRecorder),
+  getOrCreateActionRecorder: mockGetOrCreateActionRecorder,
+  getActiveActionRecorder: mockGetActiveActionRecorder,
+  getActiveActionRecording: jest.fn(() => undefined),
+  isSessionRecorderRegistered: jest.fn((sessionId: string, recorder: FakeRecorder) => (
+    mockRecorders.get(sessionId) === recorder
+  )),
+  registerSessionRecorder: jest.fn((sessionId: string, recorder: FakeRecorder) => {
+    mockRecorders.set(sessionId, recorder);
+  }),
+  unregisterSessionRecorder: jest.fn((sessionId: string) => {
+    mockRecorders.delete(sessionId);
+  }),
+}));
+
+jest.mock('../../src/session-manager', () => ({
+  getSessionManager: jest.fn(() => ({
+    getAllSessionInfos: jest.fn().mockReturnValue([]),
+    getOrCreateSession: jest.fn().mockResolvedValue({}),
+    cleanupAllSessions: jest.fn().mockResolvedValue(undefined),
+    deleteSession: jest.fn().mockResolvedValue(undefined),
+    addEventListener: jest.fn(),
+  })),
+}));
+
+jest.mock('../../src/chrome/launcher', () => ({
+  getChromeLauncher: jest.fn(() => ({
+    isConnected: jest.fn().mockReturnValue(false),
+    getProfileState: jest.fn().mockReturnValue({ type: 'temp', extensionsAvailable: false }),
+  })),
+}));
+
+import { MCPServer } from '../../src/mcp-server';
+import { registerRecordingTools } from '../../src/tools/recording';
+
+function payload(result: { structuredContent?: Record<string, unknown> }): Record<string, unknown> {
+  return result.structuredContent ?? {};
+}
+
+describe('recording tool session isolation', () => {
+  let server: MCPServer;
+
+  beforeEach(() => {
+    mockRecordingSequence = 0;
+    mockRecorders.clear();
+    mockGlobalRecorder.isRecording = false;
+    mockGlobalRecorder.activeRecordingId = null;
+    mockGlobalRecorder.activeMetadata = null;
+    jest.clearAllMocks();
+
+    server = new MCPServer();
+    registerRecordingTools(server);
+  });
+
+  it('starts, reports, and stops recordings independently across sessions', async () => {
+    const start = server.getToolHandler('oc_recording_start')!;
+    const status = server.getToolHandler('oc_recording_status')!;
+    const stop = server.getToolHandler('oc_recording_stop')!;
+
+    const [startedA, startedB] = await Promise.all([
+      start('session-a', { label: 'A' }),
+      start('session-b', { label: 'B' }),
+    ]);
+    expect(startedA.isError).not.toBe(true);
+    expect(startedB.isError).not.toBe(true);
+
+    const statusA = payload(await status('session-a', {}));
+    const statusB = payload(await status('session-b', {}));
+    expect(statusA.active).toBe(true);
+    expect(statusB.active).toBe(true);
+    expect(statusA.recordingId).not.toBe(statusB.recordingId);
+
+    const firstAId = statusA.recordingId;
+    expect((await stop('session-a', {})).isError).not.toBe(true);
+    expect(payload(await status('session-a', {})).active).toBe(false);
+    expect(payload(await status('session-b', {})).active).toBe(true);
+
+    expect((await start('session-a', { label: 'A2' })).isError).not.toBe(true);
+    expect(payload(await status('session-a', {})).recordingId).not.toBe(firstAId);
+  });
+
+  it('does not expose or stop another session recording from an inactive session', async () => {
+    const start = server.getToolHandler('oc_recording_start')!;
+    const status = server.getToolHandler('oc_recording_status')!;
+    const stop = server.getToolHandler('oc_recording_stop')!;
+
+    await start('session-b', {});
+
+    const inactiveA = payload(await status('session-a', {}));
+    expect(inactiveA.active).toBe(false);
+    expect(inactiveA.recordingId).toBeNull();
+    expect(inactiveA.sessionId).toBeUndefined();
+
+    expect((await stop('session-a', {})).isError).toBe(true);
+    expect(payload(await status('session-b', {})).active).toBe(true);
+    expect(mockGetOrCreateActionRecorder).toHaveBeenCalledTimes(1);
+    expect(mockGetOrCreateActionRecorder).toHaveBeenCalledWith('session-b');
+  });
+
+  it('finalizes a start that loses session ownership before it completes', async () => {
+    let markStartPending!: () => void;
+    let releaseStart!: () => void;
+    const startPending = new Promise<void>((resolve) => { markStartPending = resolve; });
+    const startGate = new Promise<void>((resolve) => { releaseStart = resolve; });
+    const recorder = mockCreateRecorder();
+    const originalStart = recorder.start.getMockImplementation()!;
+    recorder.start.mockImplementationOnce(async (sessionId: string, options?: Record<string, unknown>) => {
+      markStartPending();
+      await startGate;
+      return originalStart(sessionId, options);
+    });
+    mockRecorders.set('session-a', recorder);
+    const start = server.getToolHandler('oc_recording_start')!;
+
+    const pendingResult = start('session-a', {});
+    await startPending;
+    mockRecorders.delete('session-a');
+    releaseStart();
+
+    const result = await pendingResult;
+
+    expect(result.isError).toBe(true);
+    expect(recorder.stop).toHaveBeenCalledTimes(1);
+    expect(recorder.isRecording).toBe(false);
+  });
+});

--- a/tests/tools/recording.test.ts
+++ b/tests/tools/recording.test.ts
@@ -16,16 +16,23 @@ let mockIsRecording = false;
 let mockActiveRecordingId: string | null = null;
 let mockActiveMetadata: Record<string, unknown> | null = null;
 let mockActiveTrajectoryBundle: Record<string, unknown> | null = null;
+const mockRecorder = {
+  get isRecording() { return mockIsRecording; },
+  get activeRecordingId() { return mockActiveRecordingId; },
+  get activeMetadata() { return mockActiveMetadata; },
+  get activeTrajectoryBundle() { return mockActiveTrajectoryBundle; },
+  start: mockStart,
+  stop: mockStop,
+};
+const mockGetOrCreateActionRecorder = jest.fn(() => mockRecorder);
 
 jest.mock('../../src/recording/action-recorder', () => ({
-  getActionRecorder: jest.fn(() => ({
-    get isRecording() { return mockIsRecording; },
-    get activeRecordingId() { return mockActiveRecordingId; },
-    get activeMetadata() { return mockActiveMetadata; },
-    get activeTrajectoryBundle() { return mockActiveTrajectoryBundle; },
-    start: mockStart,
-    stop: mockStop,
-  })),
+  beginSessionRecorderDeletion: jest.fn(),
+  completeSessionRecorderDeletion: jest.fn(),
+  getOrCreateActionRecorder: mockGetOrCreateActionRecorder,
+  getActiveActionRecorder: jest.fn(() => mockIsRecording ? mockRecorder : undefined),
+  getActiveActionRecording: jest.fn(() => undefined),
+  isSessionRecorderRegistered: jest.fn(() => true),
   registerSessionRecorder: jest.fn(),
   unregisterSessionRecorder: jest.fn(),
 }));
@@ -185,6 +192,17 @@ describe('recording tools', () => {
 
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('disk full');
+    });
+
+    test('returns error while recorder ownership is blocked by session deletion', async () => {
+      mockGetOrCreateActionRecorder.mockImplementationOnce(() => {
+        throw new Error('Session recording is unavailable while the session is being deleted.');
+      });
+
+      const result = await handler('default', {});
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('being deleted');
     });
 
     test('includes label and profile in output when provided', async () => {


### PR DESCRIPTION
## Summary

- replace the process-global recording singleton with one stable recorder per logical tool session;
- serialize recorder lifecycle and append operations through one mutation queue;
- capture the active recording generation when MCP dispatch, `oc_assert`, and checkpoint save begin;
- reject stale action, contract, and checkpoint writes after stop/restart or session-ID reuse;
- mark `session:deleting` before asynchronous cleanup, reference-count recorder deletion tombstones, and permit reuse only after all matching `session:deleted` events complete;
- preserve existing recording IDs, metadata, JSONL, trajectory, list/export, retention, and recording-tool exclusion behavior.

## Why

OpenChrome's browser sessions, tabs, queues, leases, and journals are session-owned, but active recording was process-global. That let one session inspect or stop another session's recording and allowed stale asynchronous work to contaminate replacement evidence streams.

BrowserOS/BrowserClaw provided the architectural signal that audit and replay sidecars need explicit identity ownership and ordered teardown. Its implementation is AGPL-3.0-or-later, so this PR is a clean-room OpenChrome implementation using only existing OpenChrome types, lifecycle events, storage formats, and tests. No BrowserOS source, tests, prompts, or comments were copied.

## Design

- The resolved `ToolHandler` session ID owns recorder lifecycle.
- The recording ID captured when asynchronous work begins is the generation fence.
- `ActionRecorder` uses one mutation chain for start, stop, actions, contracts, and checkpoints, so finalization cannot be overtaken by a late append.
- `session:deleting` immediately evicts recorder ownership and blocks recreation; reference counting covers overlapping deletes; `session:deleted` releases the block for safe future session-ID reuse.
- Returned `MCPResult.isError === true` results are recorded with `ok: false`.

## Verification

- `npm run build`
- `npm run lint`
- `npm run lint:changed`
- `npm run lint:tier`
- `npm run lint:tool-schemas` (0 new schema violations)
- 88 focused tests covering concurrent lifecycle, real A/B `RecordingStore` JSONL isolation, successful/soft/thrown errors, stale dispatch, `oc_assert`, checkpoint, trajectory generation fences, deletion windows, overlapping deletion tombstones, and session-ID reuse
- `git diff --check`
- final independent read-only review: no blockers

The full 631-suite local run was interrupted when the pre-fix review found race conditions; the GitHub Actions matrix is the full-suite gate for this PR.

## Non-goals

- persisted recording list/export tenancy or authorization;
- deletion-time durable recorder finalization and audit flush barriers;
- automatic recording, replay UI/video, or format changes;
- BrowserOS browser distribution, tab groups, cockpit, or built-in agent features.

Fixes #1562