### PR TITLE
fix(auto-connect): honor DevToolsActivePort endpoint on HTTP 404

### DIFF
--- a/docs/auto-connect.md
+++ b/docs/auto-connect.md
@@ -42,6 +42,39 @@ The discovered port and the resolved user-data dir are exposed via
 }
 ```
 
+### Endpoint validation and Chrome restarts
+
+OpenChrome re-reads `DevToolsActivePort` from the exact `userDataDir` selected
+by `--auto-connect` whenever the launcher needs to attach or refresh its cached
+endpoint. The selected profile's file remains the browser identity source of
+truth:
+
+- when `GET /json/version` returns a matching browser WebSocket endpoint,
+  OpenChrome uses the freshly read file endpoint;
+- when `/json/version` returns HTTP 404, OpenChrome uses the freshly read file
+  endpoint directly, which supports default-profile configurations where Chrome
+  disables HTTP discovery;
+- when `/json/version` names a different browser path on the same port,
+  OpenChrome refuses the attach instead of crossing profile boundaries;
+- 403, 500, malformed successful responses, network failures, and timeouts do
+  not enter the 404 compatibility path.
+
+Legacy one-line `DevToolsActivePort` files do not contain a browser path. They
+remain supported only when `/json/version` succeeds with a valid loopback
+WebSocket endpoint on the selected port; that HTTP endpoint supplies the path.
+HTTP 404 cannot recover a one-line file because there is no file-backed browser
+identity to validate.
+
+If Chrome restarts on the same port and writes a new browser UUID, OpenChrome
+refreshes the cached endpoint. If Chrome chooses a different port, restart the
+OpenChrome server so its transport and session routing cannot silently drift to
+another port.
+
+This behavior applies only to explicit `--auto-connect`. Generic attach,
+auto-launch, broker ownership, and managed Chrome lifecycle behavior are
+unchanged. `/json/list`-based inspector metadata may remain unavailable when
+Chrome disables the `/json/*` HTTP surface.
+
 ## Environment variable
 
 `OPENCHROME_AUTO_CONNECT=<userDataDir>` mirrors the CLI flag. An empty value

--- a/src/chrome/auto-connect-state.ts
+++ b/src/chrome/auto-connect-state.ts
@@ -34,6 +34,19 @@ export function setAutoConnectState(result: AutoConnectResult): AutoConnectState
   return current;
 }
 
+/** Refresh endpoint metadata without changing when the attach mode began. */
+export function refreshAutoConnectState(result: AutoConnectResult): AutoConnectState {
+  current = {
+    mode: 'auto-connect',
+    userDataDir: result.userDataDir,
+    port: result.port,
+    wsEndpoint: result.wsEndpoint,
+    browserTargetPath: result.browserTargetPath,
+    attachedAt: current?.attachedAt ?? Date.now(),
+  };
+  return current;
+}
+
 export function getAutoConnectState(): AutoConnectState | null {
   return current;
 }

--- a/src/chrome/auto-connect.ts
+++ b/src/chrome/auto-connect.ts
@@ -23,6 +23,8 @@ import * as fs from 'fs';
 import * as net from 'net';
 import * as os from 'os';
 import * as path from 'path';
+import { URL } from 'url';
+import { probeDebugPort, type DebugPortProbeResult } from './launcher-debug-port';
 
 export type ChromeChannel = 'stable' | 'beta' | 'dev' | 'canary';
 
@@ -40,10 +42,10 @@ export interface AutoConnectOptions {
 }
 
 export interface AutoConnectResult {
-  /** ws://127.0.0.1:<port><browser-target-path>. */
+  /** Validated browser WebSocket endpoint for the selected profile. */
   wsEndpoint: string;
   port: number;
-  /** The browser-target path Chrome wrote on line 2 of the file. */
+  /** Browser-target path from the file, or HTTP discovery for legacy one-line files. */
   browserTargetPath: string;
   /** Resolved user-data dir (after channel / default fallback). */
   userDataDir: string;
@@ -56,7 +58,10 @@ export class AutoConnectError extends Error {
     | 'devtools_active_port_malformed'
     | 'port_not_bound'
     | 'stale_active_port_file'
-    | 'invalid_user_data_dir';
+    | 'invalid_user_data_dir'
+    | 'port_changed'
+    | 'endpoint_mismatch'
+    | 'debug_endpoint_unavailable';
 
   constructor(
     message: string,
@@ -66,7 +71,10 @@ export class AutoConnectError extends Error {
       | 'devtools_active_port_malformed'
       | 'port_not_bound'
       | 'stale_active_port_file'
-      | 'invalid_user_data_dir',
+      | 'invalid_user_data_dir'
+      | 'port_changed'
+      | 'endpoint_mismatch'
+      | 'debug_endpoint_unavailable',
   ) {
     super(message);
     this.name = 'AutoConnectError';
@@ -199,8 +207,9 @@ interface ParsedActivePort {
 
 function parseDevToolsActivePort(raw: string): ParsedActivePort {
   // Chrome writes two lines: <port>\n<browser-target-path>. Tolerate trailing
-  // whitespace and an optional trailing newline. Browser-target-path may be
-  // empty (older Chrome), in which case we default to '/'.
+  // whitespace and an optional trailing newline. Older Chrome may omit the
+  // browser path; '/' is a legacy sentinel that requires successful HTTP
+  // discovery later and is never eligible for the 404 compatibility path.
   const lines = raw.split(/\r?\n/);
   const portLine = (lines[0] ?? '').trim();
   // Require the port line to be digits only so `parseInt`'s partial-number
@@ -335,6 +344,147 @@ export async function discoverActiveDevToolsPort(
   };
 }
 
+export interface RefreshAutoConnectOptions {
+  /** Port selected during CLI startup. A changed auto-assigned port requires restart. */
+  expectedPort: number;
+  /** Bounded wait for Chrome to rewrite DevToolsActivePort during restart. */
+  fileTimeoutMs?: number;
+  /** Bounded /json/version probe timeout. */
+  probeTimeoutMs?: number;
+}
+
+interface BrowserEndpointIdentity {
+  port: number;
+  browserTargetPath: string;
+  key: string;
+}
+
+function browserEndpointIdentity(endpoint: string): BrowserEndpointIdentity | null {
+  try {
+    const parsed = new URL(endpoint);
+    if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') return null;
+    if (parsed.username || parsed.password) return null;
+
+    const host = parsed.hostname.toLowerCase();
+    if (!['127.0.0.1', 'localhost', '::1', '[::1]'].includes(host)) return null;
+
+    const port = parsed.port
+      ? Number.parseInt(parsed.port, 10)
+      : parsed.protocol === 'wss:'
+        ? 443
+        : 80;
+    const browserPathPrefix = '/devtools/browser/';
+    if (
+      !Number.isInteger(port)
+      || port <= 0
+      || port > 65535
+      || !parsed.pathname.startsWith(browserPathPrefix)
+      || parsed.pathname.length <= browserPathPrefix.length
+    ) return null;
+
+    return {
+      port,
+      browserTargetPath: parsed.pathname,
+      key: `${port}${parsed.pathname}`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function debugProbeDetail(probe: DebugPortProbeResult): string {
+  if (probe.kind === 'ok') return 'a valid browser endpoint';
+  if (probe.kind === 'http-error') return `HTTP ${probe.statusCode}`;
+  if (probe.kind === 'network-error') {
+    return `network error${probe.code ? ` ${probe.code}` : ''}`;
+  }
+  return probe.kind;
+}
+
+/**
+ * Refresh the exact profile selected by `--auto-connect` and validate that the
+ * HTTP discovery endpoint, when available, identifies the same browser.
+ *
+ * Chrome configurations that intentionally return 404 for `/json/version`
+ * may use the freshly re-read DevToolsActivePort endpoint. Every other failure
+ * is rejected so a same-port process cannot silently replace the chosen
+ * profile.
+ */
+export async function refreshAutoConnectEndpoint(
+  current: Pick<AutoConnectResult, 'userDataDir' | 'port'>,
+  opts: RefreshAutoConnectOptions,
+): Promise<AutoConnectResult> {
+  const refreshed = await discoverActiveDevToolsPort({
+    userDataDir: current.userDataDir,
+    timeoutMs: opts.fileTimeoutMs ?? 1000,
+  });
+
+  if (refreshed.port !== opts.expectedPort) {
+    throw new AutoConnectError(
+      `DevToolsActivePort for ${refreshed.userDataDir} changed from port ${opts.expectedPort} ` +
+        `to ${refreshed.port}. Restart OpenChrome so transport and session routing use the new port.`,
+      'port_changed',
+    );
+  }
+
+  const fileIdentity = browserEndpointIdentity(refreshed.wsEndpoint);
+  if (!fileIdentity && refreshed.browserTargetPath !== '/') {
+    throw new AutoConnectError(
+      `DevToolsActivePort for ${refreshed.userDataDir} contains an invalid browser WebSocket path.`,
+      'devtools_active_port_malformed',
+    );
+  }
+
+  const probe = await probeDebugPort(refreshed.port, opts.probeTimeoutMs);
+  if (!fileIdentity) {
+    if (probe.kind !== 'ok') {
+      throw new AutoConnectError(
+        `DevToolsActivePort for ${refreshed.userDataDir} does not include a browser WebSocket path, ` +
+          `and /json/version returned ${debugProbeDetail(probe)}. Legacy one-line files require ` +
+          `a successful same-port browser endpoint and cannot use the HTTP 404 fallback.`,
+        'debug_endpoint_unavailable',
+      );
+    }
+
+    const httpIdentity = browserEndpointIdentity(probe.wsEndpoint);
+    if (!httpIdentity || httpIdentity.port !== opts.expectedPort) {
+      throw new AutoConnectError(
+        `/json/version on port ${refreshed.port} did not return a valid loopback browser endpoint ` +
+          `on the expected port. Refusing legacy one-line DevToolsActivePort attach.`,
+        'endpoint_mismatch',
+      );
+    }
+
+    return {
+      ...refreshed,
+      wsEndpoint: probe.wsEndpoint,
+      browserTargetPath: httpIdentity.browserTargetPath,
+    };
+  }
+
+  if (probe.kind === 'ok') {
+    const httpIdentity = browserEndpointIdentity(probe.wsEndpoint);
+    if (!httpIdentity || httpIdentity.key !== fileIdentity.key) {
+      throw new AutoConnectError(
+        `/json/version on port ${refreshed.port} points at a different browser than ` +
+          `${path.join(refreshed.userDataDir, 'DevToolsActivePort')}. Refusing cross-profile attach.`,
+        'endpoint_mismatch',
+      );
+    }
+    return refreshed;
+  }
+
+  if (probe.kind === 'http-error' && probe.statusCode === 404) {
+    return refreshed;
+  }
+
+  throw new AutoConnectError(
+    `Unable to validate the auto-connect Chrome on port ${refreshed.port}: /json/version returned ${debugProbeDetail(probe)}. ` +
+      `Only an exact matching endpoint or HTTP 404 with the current DevToolsActivePort path is accepted.`,
+    'debug_endpoint_unavailable',
+  );
+}
+
 /**
  * Internal helper: pure fns exported for unit tests.
  * Keep parsing deterministic and side-effect free.
@@ -345,4 +495,5 @@ export const __testing = {
   probePort,
   canonicalize,
   pathsEqual,
+  browserEndpointIdentity,
 };

--- a/src/chrome/launcher-debug-port.ts
+++ b/src/chrome/launcher-debug-port.ts
@@ -25,25 +25,58 @@ const DEBUG_PORT_MAX_BACKOFF_MS = 2000;
 const DEBUG_PORT_BACKOFF_FACTOR = 1.5;
 const DEBUG_PORT_PROGRESS_LOG_INTERVAL = 10;
 
-export async function checkDebugPort(port: number, timeoutMs: number = DEBUG_PORT_MAX_HTTP_TIMEOUT_MS): Promise<string | null> {
+export type DebugPortProbeResult =
+  | { kind: 'ok'; statusCode: number; wsEndpoint: string }
+  | { kind: 'http-error'; statusCode: number }
+  | { kind: 'invalid-response'; statusCode: number }
+  | { kind: 'network-error'; code?: string }
+  | { kind: 'timeout' };
+
+export async function probeDebugPort(
+  port: number,
+  timeoutMs: number = DEBUG_PORT_MAX_HTTP_TIMEOUT_MS,
+): Promise<DebugPortProbeResult> {
   const clampedTimeout = Math.min(Math.max(1, timeoutMs), DEBUG_PORT_MAX_HTTP_TIMEOUT_MS);
   return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: DebugPortProbeResult) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
     const req = http.request({ hostname: '127.0.0.1', port, path: '/json/version', method: 'GET', timeout: clampedTimeout }, (res) => {
       let data = '';
       res.on('data', (chunk) => (data += chunk));
       res.on('end', () => {
+        const statusCode = res.statusCode ?? 0;
+        if (statusCode < 200 || statusCode >= 300) {
+          finish({ kind: 'http-error', statusCode });
+          return;
+        }
         try {
           const json = JSON.parse(data);
-          resolve(json.webSocketDebuggerUrl || null);
+          if (typeof json.webSocketDebuggerUrl === 'string' && json.webSocketDebuggerUrl) {
+            finish({ kind: 'ok', statusCode, wsEndpoint: json.webSocketDebuggerUrl });
+            return;
+          }
         } catch {
-          resolve(null);
+          // Fall through to the invalid-response result.
         }
+        finish({ kind: 'invalid-response', statusCode });
       });
     });
-    req.on('error', () => resolve(null));
-    req.on('timeout', () => { req.destroy(); resolve(null); });
+    req.on('error', (err: NodeJS.ErrnoException) => finish({ kind: 'network-error', code: err.code }));
+    req.on('timeout', () => {
+      finish({ kind: 'timeout' });
+      req.destroy();
+    });
     req.end();
   });
+}
+
+export async function checkDebugPort(port: number, timeoutMs: number = DEBUG_PORT_MAX_HTTP_TIMEOUT_MS): Promise<string | null> {
+  const result = await probeDebugPort(port, timeoutMs);
+  return result.kind === 'ok' ? result.wsEndpoint : null;
 }
 
 export async function waitForDebugPort(port: number, timeout = 30000, chromeProcess?: ChildProcess): Promise<string> {

--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -21,6 +21,8 @@ import { registerManagedChrome, unregisterManagedChrome } from '../utils/sync-sh
 import { classifyExit, ExitClassification, quiesceMs } from './exit-classifier';
 import { getLifecycleBus } from '../core/lifecycle';
 import type { ChromeExitReason } from '../core/lifecycle';
+import { refreshAutoConnectEndpoint } from './auto-connect';
+import { getAutoConnectState, refreshAutoConnectState } from './auto-connect-state';
 import {
   resolveLaunchMode,
   AttachConsentRequiredError,
@@ -103,6 +105,15 @@ export interface ProfileState {
   profileDirectory?: string;     // Chrome profile directory name (e.g., "Profile 1", "Default")
 }
 
+async function refreshKnownAutoConnectWsEndpoint(port: number): Promise<string | null> {
+  const state = getAutoConnectState();
+  if (!state || state.port !== port) return null;
+
+  const refreshed = await refreshAutoConnectEndpoint(state, { expectedPort: port });
+  refreshAutoConnectState(refreshed);
+  return refreshed.wsEndpoint;
+}
+
 export class ChromeLauncher {
   private instance: ChromeInstance | null = null;
   private pendingProcess: ChildProcess | null = null;
@@ -146,6 +157,21 @@ export class ChromeLauncher {
 
     // Check if already connected and instance is still valid
     if (this.instance) {
+      if (this.instance.launchMode === 'attach' && getAutoConnectState()?.port === port) {
+        try {
+          const currentWs = await refreshKnownAutoConnectWsEndpoint(port);
+          if (currentWs) {
+            if (currentWs !== this.instance.wsEndpoint) {
+              console.error('[ChromeLauncher] Auto-connect browser endpoint changed; refreshing cached instance.');
+              this.instance = { ...this.instance, wsEndpoint: currentWs };
+            }
+            return this.instance;
+          }
+        } catch (err) {
+          this.instance = null;
+          throw err;
+        }
+      }
       // Verify the cached instance is still valid by checking the debug port
       const currentWs = await checkDebugPort(port);
       if (currentWs && currentWs === this.instance.wsEndpoint) {
@@ -206,10 +232,15 @@ export class ChromeLauncher {
       }
       console.error('[ChromeLauncher] Launch mode: isolated — skipping debug-port attach.');
     } else {
-      // Check if Chrome is already running with debug port.
-      // Use a brief retry window (5s) instead of a single-shot check, because Chrome
-      // may still be binding the debug port during startup (1-5s window).
-      existingWs = await waitForDebugPort(port, 5000).catch(() => null);
+      const autoConnectState = launchMode === 'attach' ? getAutoConnectState() : null;
+      if (autoConnectState?.port === port) {
+        existingWs = await refreshKnownAutoConnectWsEndpoint(port);
+      } else {
+        // Check if Chrome is already running with debug port.
+        // Use a brief retry window (5s) instead of a single-shot check, because Chrome
+        // may still be binding the debug port during startup (1-5s window).
+        existingWs = await waitForDebugPort(port, 5000).catch(() => null);
+      }
     }
 
     // 'attach' mode: must attach. If no debug port responded, surface a

--- a/tests/chrome/auto-connect.test.ts
+++ b/tests/chrome/auto-connect.test.ts
@@ -12,11 +12,13 @@
  */
 
 import * as fs from 'fs';
+import * as http from 'http';
 import * as net from 'net';
 import * as os from 'os';
 import * as path from 'path';
 import {
   discoverActiveDevToolsPort,
+  refreshAutoConnectEndpoint,
   AutoConnectError,
   __testing,
 } from '../../src/chrome/auto-connect';
@@ -53,6 +55,35 @@ function bindLocalListener(): Promise<{ port: number; close: () => void }> {
       resolve({
         port: addr.port,
         close: () => { try { server.close(); } catch { /* ignore */ } },
+      });
+    });
+    server.on('error', reject);
+  });
+}
+
+function bindDebugServer(
+  handler: (port: number, req: http.IncomingMessage, res: http.ServerResponse) => void,
+): Promise<{ port: number; close: () => Promise<void> }> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        res.statusCode = 500;
+        res.end();
+        return;
+      }
+      handler(address.port, req, res);
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('failed to acquire HTTP port'));
+        return;
+      }
+      resolve({
+        port: address.port,
+        close: () => new Promise<void>((done) => server.close(() => done())),
       });
     });
     server.on('error', reject);
@@ -172,7 +203,7 @@ describe('discoverActiveDevToolsPort (#849)', () => {
     }
   });
 
-  it('parser tolerates missing browser-target line and trailing newlines', () => {
+  it('parser preserves the legacy missing browser-target line as a root sentinel', () => {
     const a = __testing.parseDevToolsActivePort('12345\n');
     expect(a.port).toBe(12345);
     expect(a.browserTargetPath).toBe('/');
@@ -321,6 +352,264 @@ describe('discoverActiveDevToolsPort (#849)', () => {
     const d = __testing.defaultUserDataDir('stable');
     expect(typeof d).toBe('string');
     expect((d as string).length).toBeGreaterThan(0);
+  });
+});
+
+describe('refreshAutoConnectEndpoint (#1558)', () => {
+  it('uses the current profile endpoint when /json/version returns 404', async () => {
+    const dir = makeTempDir();
+    const server = await bindDebugServer((_port, _req, res) => {
+      res.statusCode = 404;
+      res.end('not found');
+    });
+    try {
+      writeActivePortFile(dir, server.port, '/devtools/browser/from-file');
+      const result = await refreshAutoConnectEndpoint(
+        { userDataDir: dir, port: server.port },
+        { expectedPort: server.port, fileTimeoutMs: 50, probeTimeoutMs: 500 },
+      );
+      expect(result.wsEndpoint).toBe(
+        `ws://127.0.0.1:${server.port}/devtools/browser/from-file`,
+      );
+    } finally {
+      await server.close();
+      rm(dir);
+    }
+  });
+
+  it('accepts a matching /json/version endpoint and keeps the file path authoritative', async () => {
+    const dir = makeTempDir();
+    const server = await bindDebugServer((port, req, res) => {
+      if (req.url === '/json/version') {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({
+          webSocketDebuggerUrl: `ws://localhost:${port}/devtools/browser/matching`,
+        }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end();
+    });
+    try {
+      writeActivePortFile(dir, server.port, '/devtools/browser/matching');
+      const result = await refreshAutoConnectEndpoint(
+        { userDataDir: dir, port: server.port },
+        { expectedPort: server.port, fileTimeoutMs: 50, probeTimeoutMs: 500 },
+      );
+      expect(result.wsEndpoint).toBe(
+        `ws://127.0.0.1:${server.port}/devtools/browser/matching`,
+      );
+    } finally {
+      await server.close();
+      rm(dir);
+    }
+  });
+
+  it('preserves legacy one-line files when /json/version supplies a valid browser endpoint', async () => {
+    const dir = makeTempDir();
+    const server = await bindDebugServer((port, req, res) => {
+      if (req.url === '/json/version') {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({
+          webSocketDebuggerUrl: `ws://localhost:${port}/devtools/browser/from-http`,
+        }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end();
+    });
+    try {
+      fs.writeFileSync(path.join(dir, 'DevToolsActivePort'), `${server.port}\n`);
+      const result = await refreshAutoConnectEndpoint(
+        { userDataDir: dir, port: server.port },
+        { expectedPort: server.port, fileTimeoutMs: 50, probeTimeoutMs: 500 },
+      );
+      expect(result).toMatchObject({
+        wsEndpoint: `ws://localhost:${server.port}/devtools/browser/from-http`,
+        browserTargetPath: '/devtools/browser/from-http',
+      });
+    } finally {
+      await server.close();
+      rm(dir);
+    }
+  });
+
+  it('does not use the HTTP 404 fallback for a legacy one-line file', async () => {
+    const dir = makeTempDir();
+    const server = await bindDebugServer((_port, _req, res) => {
+      res.statusCode = 404;
+      res.end('not found');
+    });
+    try {
+      fs.writeFileSync(path.join(dir, 'DevToolsActivePort'), `${server.port}\n`);
+      await expect(
+        refreshAutoConnectEndpoint(
+          { userDataDir: dir, port: server.port },
+          { expectedPort: server.port, fileTimeoutMs: 50, probeTimeoutMs: 500 },
+        ),
+      ).rejects.toMatchObject({
+        name: 'AutoConnectError',
+        errorCode: 'debug_endpoint_unavailable',
+      });
+    } finally {
+      await server.close();
+      rm(dir);
+    }
+  });
+
+  it.each([
+    ['wrong port', (port: number) => `ws://127.0.0.1:${port + 1}/devtools/browser/http`],
+    ['non-loopback host', (port: number) => `ws://example.com:${port}/devtools/browser/http`],
+    ['credentials', (port: number) => `ws://user:pass@127.0.0.1:${port}/devtools/browser/http`],
+    ['non-browser path', (port: number) => `ws://127.0.0.1:${port}/devtools/page/http`],
+  ])('rejects a legacy one-line file with a %s HTTP endpoint', async (_label, endpointForPort) => {
+    const dir = makeTempDir();
+    const server = await bindDebugServer((port, _req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ webSocketDebuggerUrl: endpointForPort(port) }));
+    });
+    try {
+      fs.writeFileSync(path.join(dir, 'DevToolsActivePort'), `${server.port}\n`);
+      await expect(
+        refreshAutoConnectEndpoint(
+          { userDataDir: dir, port: server.port },
+          { expectedPort: server.port, fileTimeoutMs: 50, probeTimeoutMs: 500 },
+        ),
+      ).rejects.toMatchObject({
+        name: 'AutoConnectError',
+        errorCode: 'endpoint_mismatch',
+      });
+    } finally {
+      await server.close();
+      rm(dir);
+    }
+  });
+
+  it('fails closed when /json/version points at another browser on the same port', async () => {
+    const dir = makeTempDir();
+    const server = await bindDebugServer((port, _req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({
+        webSocketDebuggerUrl: `ws://127.0.0.1:${port}/devtools/browser/other-profile`,
+      }));
+    });
+    try {
+      writeActivePortFile(dir, server.port, '/devtools/browser/selected-profile');
+      await expect(
+        refreshAutoConnectEndpoint(
+          { userDataDir: dir, port: server.port },
+          { expectedPort: server.port, fileTimeoutMs: 50, probeTimeoutMs: 500 },
+        ),
+      ).rejects.toMatchObject({
+        name: 'AutoConnectError',
+        errorCode: 'endpoint_mismatch',
+      });
+    } finally {
+      await server.close();
+      rm(dir);
+    }
+  });
+
+  it.each([
+    ['HTTP 403', 403, 'blocked'],
+    ['HTTP 500', 500, 'failed'],
+    ['malformed 200', 200, '{"Browser":"Chrome"}'],
+  ])('does not fall back on %s', async (_label, statusCode, body) => {
+    const dir = makeTempDir();
+    const server = await bindDebugServer((_port, _req, res) => {
+      res.statusCode = statusCode as number;
+      res.end(body as string);
+    });
+    try {
+      writeActivePortFile(dir, server.port, '/devtools/browser/from-file');
+      await expect(
+        refreshAutoConnectEndpoint(
+          { userDataDir: dir, port: server.port },
+          { expectedPort: server.port, fileTimeoutMs: 50, probeTimeoutMs: 500 },
+        ),
+      ).rejects.toMatchObject({
+        name: 'AutoConnectError',
+        errorCode: 'debug_endpoint_unavailable',
+      });
+    } finally {
+      await server.close();
+      rm(dir);
+    }
+  });
+
+  it('does not fall back when /json/version times out', async () => {
+    const dir = makeTempDir();
+    const server = await bindDebugServer((_port, _req, res) => {
+      setTimeout(() => {
+        if (!res.writableEnded) res.end('late');
+      }, 200);
+    });
+    try {
+      writeActivePortFile(dir, server.port, '/devtools/browser/from-file');
+      await expect(
+        refreshAutoConnectEndpoint(
+          { userDataDir: dir, port: server.port },
+          { expectedPort: server.port, fileTimeoutMs: 50, probeTimeoutMs: 25 },
+        ),
+      ).rejects.toMatchObject({
+        name: 'AutoConnectError',
+        errorCode: 'debug_endpoint_unavailable',
+      });
+    } finally {
+      await server.close();
+      rm(dir);
+    }
+  });
+
+  it('refreshes a changed browser UUID on the same port', async () => {
+    const dir = makeTempDir();
+    const server = await bindDebugServer((_port, _req, res) => {
+      res.statusCode = 404;
+      res.end('not found');
+    });
+    try {
+      writeActivePortFile(dir, server.port, '/devtools/browser/uuid-one');
+      const first = await refreshAutoConnectEndpoint(
+        { userDataDir: dir, port: server.port },
+        { expectedPort: server.port, fileTimeoutMs: 50, probeTimeoutMs: 500 },
+      );
+
+      writeActivePortFile(dir, server.port, '/devtools/browser/uuid-two');
+      const second = await refreshAutoConnectEndpoint(first, {
+        expectedPort: server.port,
+        fileTimeoutMs: 50,
+        probeTimeoutMs: 500,
+      });
+
+      expect(first.browserTargetPath).toBe('/devtools/browser/uuid-one');
+      expect(second.browserTargetPath).toBe('/devtools/browser/uuid-two');
+    } finally {
+      await server.close();
+      rm(dir);
+    }
+  });
+
+  it('requires a server restart when DevToolsActivePort changes ports', async () => {
+    const dir = makeTempDir();
+    const server = await bindDebugServer((_port, _req, res) => {
+      res.statusCode = 404;
+      res.end('not found');
+    });
+    try {
+      writeActivePortFile(dir, server.port, '/devtools/browser/new-port');
+      await expect(
+        refreshAutoConnectEndpoint(
+          { userDataDir: dir, port: server.port - 1 },
+          { expectedPort: server.port - 1, fileTimeoutMs: 50, probeTimeoutMs: 500 },
+        ),
+      ).rejects.toMatchObject({
+        name: 'AutoConnectError',
+        errorCode: 'port_changed',
+      });
+    } finally {
+      await server.close();
+      rm(dir);
+    }
   });
 });
 

--- a/tests/chrome/launcher-auto-connect-fallback.test.ts
+++ b/tests/chrome/launcher-auto-connect-fallback.test.ts
@@ -1,0 +1,134 @@
+jest.unmock('../../src/chrome/launcher');
+
+import * as childProcess from 'child_process';
+import * as fs from 'fs';
+import * as http from 'http';
+import type { AddressInfo } from 'net';
+import * as os from 'os';
+import * as path from 'path';
+
+import { ChromeLauncher } from '../../src/chrome/launcher';
+import {
+  __resetAutoConnectStateForTests,
+  getAutoConnectState,
+  setAutoConnectState,
+} from '../../src/chrome/auto-connect-state';
+
+jest.mock('child_process', () => {
+  const actual = jest.requireActual('child_process');
+  return {
+    ...actual,
+    spawn: jest.fn(),
+  };
+});
+
+jest.mock('../../src/config/global', () => ({
+  getGlobalConfig: () => ({ chromeLaunchMode: 'attach' }),
+}));
+
+const mockSpawn = childProcess.spawn as jest.MockedFunction<typeof childProcess.spawn>;
+
+describe('ChromeLauncher auto-connect endpoint refresh (#1558)', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    __resetAutoConnectStateForTests();
+    mockSpawn.mockReset();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('attaches on HTTP 404 and refreshes a changed same-port browser UUID', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-launcher-auto-connect-'));
+    let versionRequests = 0;
+    const server = http.createServer((req, res) => {
+      if (req.url === '/json/version') versionRequests += 1;
+      res.statusCode = 404;
+      res.end('not found');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as AddressInfo).port;
+    const activePortPath = path.join(dir, 'DevToolsActivePort');
+    fs.writeFileSync(activePortPath, `${port}\n/devtools/browser/uuid-one\n`);
+
+    const initial = setAutoConnectState({
+      port,
+      wsEndpoint: `ws://127.0.0.1:${port}/devtools/browser/uuid-one`,
+      browserTargetPath: '/devtools/browser/uuid-one',
+      userDataDir: dir,
+    });
+
+    const launcher = new ChromeLauncher(port);
+    try {
+      const first = await launcher.ensureChrome({
+        autoLaunch: false,
+        launchMode: 'attach',
+      });
+      expect(first.wsEndpoint).toBe(
+        `ws://127.0.0.1:${port}/devtools/browser/uuid-one`,
+      );
+      expect(first.launchMode).toBe('attach');
+
+      fs.writeFileSync(activePortPath, `${port}\n/devtools/browser/uuid-two\n`);
+      const second = await launcher.ensureChrome({
+        autoLaunch: false,
+        launchMode: 'attach',
+      });
+
+      expect(second.wsEndpoint).toBe(
+        `ws://127.0.0.1:${port}/devtools/browser/uuid-two`,
+      );
+      expect(getAutoConnectState()).toMatchObject({
+        wsEndpoint: `ws://127.0.0.1:${port}/devtools/browser/uuid-two`,
+        browserTargetPath: '/devtools/browser/uuid-two',
+        attachedAt: initial.attachedAt,
+      });
+      expect(versionRequests).toBe(2);
+      expect(mockSpawn).not.toHaveBeenCalled();
+    } finally {
+      await launcher.close();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it('does not accept the cached endpoint when the selected profile file disappears', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-launcher-auto-connect-stale-'));
+    const server = http.createServer((_req, res) => {
+      res.statusCode = 404;
+      res.end('not found');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as AddressInfo).port;
+    const activePortPath = path.join(dir, 'DevToolsActivePort');
+    fs.writeFileSync(activePortPath, `${port}\n/devtools/browser/uuid-one\n`);
+
+    setAutoConnectState({
+      port,
+      wsEndpoint: `ws://127.0.0.1:${port}/devtools/browser/uuid-one`,
+      browserTargetPath: '/devtools/browser/uuid-one',
+      userDataDir: dir,
+    });
+
+    const launcher = new ChromeLauncher(port);
+    try {
+      await launcher.ensureChrome({ autoLaunch: false, launchMode: 'attach' });
+      fs.unlinkSync(activePortPath);
+
+      await expect(
+        launcher.ensureChrome({ autoLaunch: false, launchMode: 'attach' }),
+      ).rejects.toMatchObject({
+        name: 'AutoConnectError',
+        errorCode: 'devtools_active_port_missing',
+      });
+      expect(mockSpawn).not.toHaveBeenCalled();
+    } finally {
+      await launcher.close();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
+});

--- a/tests/chrome/launcher-debug-port-deadline.test.ts
+++ b/tests/chrome/launcher-debug-port-deadline.test.ts
@@ -21,6 +21,7 @@ import type { AddressInfo } from 'net';
 import { ChildProcess } from 'child_process';
 
 import { waitForDebugPort, DebugPortTimeoutError } from '../../src/chrome/launcher';
+import { checkDebugPort, probeDebugPort } from '../../src/chrome/launcher-debug-port';
 
 jest.mock('../../src/config/global', () => ({
   getGlobalConfig: () => ({}),
@@ -100,6 +101,62 @@ describe('waitForDebugPort monotonic deadline', () => {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
   }, 10_000);
+
+  it('distinguishes HTTP 404 from other debug-port failures', async () => {
+    const server = http.createServer((_req, res) => {
+      res.statusCode = 404;
+      res.end('not found');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as AddressInfo).port;
+
+    try {
+      await expect(probeDebugPort(port, 500)).resolves.toEqual({
+        kind: 'http-error',
+        statusCode: 404,
+      });
+      await expect(checkDebugPort(port, 500)).resolves.toBeNull();
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it.each([403, 500])('reports HTTP %s without treating it as a valid endpoint', async (statusCode) => {
+    const server = http.createServer((_req, res) => {
+      res.statusCode = statusCode;
+      res.end('blocked');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as AddressInfo).port;
+
+    try {
+      await expect(probeDebugPort(port, 500)).resolves.toEqual({
+        kind: 'http-error',
+        statusCode,
+      });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('reports malformed successful responses separately', async () => {
+    const server = http.createServer((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end('{"Browser":"Chrome"}');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as AddressInfo).port;
+
+    try {
+      await expect(probeDebugPort(port, 500)).resolves.toEqual({
+        kind: 'invalid-response',
+        statusCode: 200,
+      });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
 
   it('succeeds with sub-100ms timeout when port is already serving', async () => {
     // Regression: the previous implementation floored the HTTP probe timeout


### PR DESCRIPTION
## Summary

Fix explicit `--auto-connect` attach when Chrome keeps the current browser WebSocket path in `DevToolsActivePort` but returns HTTP 404 for `GET /json/version`.

The launcher now re-reads the exact selected profile before initial attach and cached-instance reuse, distinguishes HTTP discovery failure classes, and refreshes same-port browser UUID changes without widening generic attach behavior.

Closes #1558.

## Design

- Add a status-aware debug-port probe while preserving the existing `checkDebugPort(): string | null` API.
- Re-read `DevToolsActivePort` from the exact `userDataDir` selected by `--auto-connect`.
- Treat a valid two-line file browser path as the profile identity source of truth.
- Accept a successful `/json/version` response only when it is loopback, same-port, credential-free, and names the same browser path.
- Use the freshly read file endpoint only for HTTP 404.
- Preserve legacy one-line files only when successful HTTP discovery supplies a valid loopback same-port browser endpoint; one-line files cannot use the 404 path.
- Refresh the cached endpoint when Chrome restarts on the same port with a new UUID.
- Require an OpenChrome restart when the selected profile changes ports.
- Preserve the original `attachedAt` timestamp across endpoint refreshes.

## OpenChrome boundary

`browser-use/browser-harness#292` provided evidence for the Chrome 404 compatibility case. This implementation is independent and stays inside OpenChrome's existing TypeScript MCP/launcher architecture.

It does not add arbitrary helper execution, a raw CDP escape hatch, a second daemon, vendor cloud/telemetry coupling, or a mutable global tab. Generic attach, auto-launch, broker election, controller locks, target leases, and process ownership are unchanged. `ChromeLauncher.close()` continues to leave externally started Chrome alive.

## Failure boundaries

The compatibility path fails closed for:

- HTTP 403 and 500;
- malformed successful responses;
- network failures and timeouts;
- non-loopback, wrong-port, credentialed, or non-browser WebSocket endpoints;
- successful HTTP discovery naming a different browser than the selected profile file;
- HTTP 404 when a legacy one-line file contains no browser identity;
- `DevToolsActivePort` changing to another port.

## Verification

- Full Jest: **623 suites passed**, **7,560 tests passed**, **97 skipped**, 0 failed.
- Focused post-rebase Jest: **48/48 passed** across auto-connect, debug-port, and launcher integration suites.
- Isolated deadline regression: **12/12 passed** after confirming two concurrent-load timeouts were environmental.
- `npm run build`
- `npm run lint:changed`
- `npm run lint:tier`: 567 modules / 1,356 dependencies, zero violations after rebase.
- `git diff --check origin/main`
- Independent adversarial review: **APPROVE**, no correctness or security blockers.
- Live Chrome 150 smoke with a temporary profile:
  - `DevToolsActivePort` discovery and launcher endpoint matched;
  - Puppeteer connected through the launcher endpoint;
  - lifecycle mode was `attach`;
  - `ChromeLauncher.close()` left the external Chrome process alive.

## Live-test caveat

The installed default Chrome profile had no active `DevToolsActivePort`, while the temporary profile returned HTTP 200 from `/json/version`. The real default-profile 404 branch is therefore fixture-tested rather than reproduced against the user's active default profile; modifying that profile solely for validation was intentionally avoided.
