### PR TITLE
fix(vision): retain DOM identity in perception snapshots

### DIFF
--- a/docs/vision/perception-snapshot.md
+++ b/docs/vision/perception-snapshot.md
@@ -4,6 +4,8 @@
 
 The snapshot contract is exported from `src/vision/perception-types.ts` and is intentionally provider-neutral: DOM annotation, future OmniParser-compatible HTTP providers, and tests can all describe visible elements with stable snapshot-local IDs, labels, viewport-relative CSS pixel boxes, normalized ratios, provenance, and bounded warnings.
 
+OpenChrome-emitted snapshots include `captureMode`. `viewport` uses live viewport coordinates and may be executed after the checks below. `tiled` aggregates document-space coordinates and is rejected by `interact mode="perception"`; recapture the target viewport first. Older provider snapshots may omit this additive field and retain viewport semantics.
+
 ## Execute a caller-selected target
 
 The MCP host can select one exact snapshot-local element ID and pass the original viewport snapshot to `interact`:

--- a/src/tools/vision-find.ts
+++ b/src/tools/vision-find.ts
@@ -138,7 +138,7 @@ const handler: ToolHandler = async (
     const modeArg = args.mode;
     const mode: 'viewport' | 'tiled' = modeArg === 'tiled' ? 'tiled' : 'viewport';
 
-    const provider = new DomAnnotatorPerceptionProvider(page);
+    const provider = new DomAnnotatorPerceptionProvider(page, sessionManager.getCDPClient());
     const { result, snapshot } = await provider.captureAnnotated(tabId, page.url(), {
       showGrid,
       showBoundingBoxes,

--- a/src/utils/element-discovery.ts
+++ b/src/utils/element-discovery.ts
@@ -533,12 +533,12 @@ export async function resolveBackendNodeIds(
   page: Page,
   cdpClient: CDPClient,
   tagProperty: string,
-  results: Array<{ backendDOMNodeId: number }>,
+  results: Array<{ backendDOMNodeId?: number }>,
 ): Promise<void> {
   if (results.length === 0) return;
 
   // Skip if all elements already have valid backendDOMNodeIds (e.g., from CDP path)
-  if (results.every(r => r.backendDOMNodeId > 0)) return;
+  if (results.every(r => (r.backendDOMNodeId ?? 0) > 0)) return;
 
   // Step 1: Single Runtime.evaluate to collect tagged elements in index order
   // Uses deep walk to find elements inside open shadow roots
@@ -576,7 +576,7 @@ export async function resolveBackendNodeIds(
   for (const prop of properties) {
     const index = parseInt(prop.name, 10);
     if (isNaN(index) || index >= results.length || !prop.value?.objectId) continue;
-    if (results[index].backendDOMNodeId > 0) continue; // already resolved
+    if ((results[index].backendDOMNodeId ?? 0) > 0) continue; // already resolved
 
     describePromises.push(
       cdpClient

--- a/src/vision/perception-provider.ts
+++ b/src/vision/perception-provider.ts
@@ -110,6 +110,7 @@ export function buildPerceptionSnapshotFromAnnotatedResult(
   return {
     version: 1,
     provider,
+    captureMode: result.tiling ? 'tiled' : 'viewport',
     tabId: args.tabId,
     url: args.url,
     capturedAt: args.capturedAt ?? Date.now(),
@@ -171,6 +172,9 @@ export function validatePerceptionSnapshot(
   const row = snapshot as Record<string, unknown>;
   if (row.version !== 1) addError('version must be 1');
   if (typeof row.provider !== 'string' || row.provider.length === 0) addError('provider is required');
+  if (row.captureMode !== undefined && row.captureMode !== 'viewport' && row.captureMode !== 'tiled') {
+    addError('captureMode must be "viewport" or "tiled" when present');
+  }
   if (typeof row.tabId !== 'string' || row.tabId.length === 0) addError('tabId is required');
   if (typeof row.url !== 'string') addError('url must be a string');
   if (typeof row.capturedAt !== 'number' || !Number.isFinite(row.capturedAt)) addError('capturedAt must be a finite number');

--- a/src/vision/perception-target.ts
+++ b/src/vision/perception-target.ts
@@ -11,6 +11,7 @@ const UNSAFE_VISUAL_LABEL = /\b(delete|deletion|remove|destroy|confirm|pay|payme
 
 export type PerceptionTargetFailureReason =
   | 'malformed_snapshot'
+  | 'unsupported_capture_mode'
   | 'tab_mismatch'
   | 'url_mismatch'
   | 'element_not_found'
@@ -67,6 +68,13 @@ export function resolvePerceptionTarget(input: ResolvePerceptionTargetInput): Re
   }
 
   const snapshot = input.snapshot as PerceptionSnapshot;
+  if (snapshot.captureMode === 'tiled') {
+    return failure(
+      'INVALID_PERCEPTION_TARGET',
+      'unsupported_capture_mode',
+      'Tiled perception snapshots use document-space coordinates and are not executable. Recapture the target viewport.',
+    );
+  }
   if (typeof input.elementId !== 'string' || input.elementId.length === 0) {
     return failure('INVALID_PERCEPTION_TARGET', 'element_not_found', 'perception.elementId must be a non-empty string.');
   }

--- a/src/vision/providers/dom-annotator-provider.ts
+++ b/src/vision/providers/dom-annotator-provider.ts
@@ -1,4 +1,5 @@
 import type { Page } from 'puppeteer-core';
+import type { CDPClient } from '../../cdp/client';
 import type { AnnotatedScreenshotResult, AnnotationOptions, PerceptionSnapshot } from '../types';
 import { analyzeScreenshot } from '../screenshot-analyzer';
 import { buildPerceptionSnapshotFromAnnotatedResult, type PerceptionProviderOptions } from '../perception-provider';
@@ -11,7 +12,10 @@ export interface DomAnnotatorCaptureResult {
 export class DomAnnotatorPerceptionProvider {
   readonly name = 'dom-annotator';
 
-  constructor(private readonly page: Page) {}
+  constructor(
+    private readonly page: Page,
+    private readonly cdpClient?: CDPClient,
+  ) {}
 
   async capture(
     tabId: string,
@@ -26,7 +30,7 @@ export class DomAnnotatorPerceptionProvider {
     url: string,
     options?: PerceptionProviderOptions & AnnotationOptions
   ): Promise<DomAnnotatorCaptureResult> {
-    const result = await analyzeScreenshot(this.page, options);
+    const result = await analyzeScreenshot(this.page, options, this.cdpClient);
     const snapshot = buildPerceptionSnapshotFromAnnotatedResult(result, {
       provider: this.name,
       tabId,

--- a/src/vision/screenshot-analyzer.ts
+++ b/src/vision/screenshot-analyzer.ts
@@ -16,6 +16,7 @@
  */
 
 import type { Frame, Page } from 'puppeteer-core';
+import type { CDPClient } from '../cdp/client';
 import {
   DEFAULT_SCREENSHOT_QUALITY,
   DEFAULT_DOM_SETTLE_DELAY_MS,
@@ -31,6 +32,7 @@ import type {
 } from './types';
 import { bufferToBase64WithPayloadGuard, resolveViewportDimensions, validateCaptureArea } from '../utils/screenshot-guards';
 import { detectImageMimeType } from '../utils/image-mime';
+import { cleanupTags, resolveBackendNodeIds } from '../utils/element-discovery';
 
 /** Raw element collected from the page */
 export interface RawElement {
@@ -65,6 +67,13 @@ const DEFAULT_OPTIONS: Required<Omit<AnnotationOptions, 'occlusionFilter' | 'ifr
 
 /** Overlay element ID — must not collide with page content */
 const OVERLAY_ID = '__oc_vision_overlay__';
+const VISION_ELEMENT_TAG = '__ocVisionIdx';
+let visionElementTagCounter = 0;
+
+function nextVisionElementTag(): string {
+  visionElementTagCounter = (visionElementTagCounter + 1) % Number.MAX_SAFE_INTEGER;
+  return `${VISION_ELEMENT_TAG}_${process.pid}_${visionElementTagCounter}`;
+}
 
 /** Hard caps for tiled mode (per spec). */
 const TILED_MAX_TILES = 20;
@@ -82,8 +91,8 @@ const IFRAME_MAX_COUNT = 20;
  * Returns rects in the frame's local viewport coordinates. The caller is responsible for
  * translating to top-frame document coordinates when collected from an iframe.
  */
-function collectInPage(filterInteractive: boolean, occlusionFilter: boolean): {
-  elements: Array<{ role: string; name: string; x: number; y: number; width: number; height: number }>;
+function collectInPage(filterInteractive: boolean, occlusionFilter: boolean, tagProperty?: string): {
+  elements: Array<{ role: string; name: string; x: number; y: number; width: number; height: number; backendDOMNodeId?: number }>;
   occludedDropped: number;
 } {
   const INTERACTIVE_SELECTORS = [
@@ -108,6 +117,7 @@ function collectInPage(filterInteractive: boolean, occlusionFilter: boolean): {
     y: number;
     width: number;
     height: number;
+    backendDOMNodeId?: number;
   }> = [];
 
   const seen = new Set<Element>();
@@ -183,6 +193,10 @@ function collectInPage(filterInteractive: boolean, occlusionFilter: boolean): {
           }
         }
 
+        const index = results.length;
+        if (tagProperty) {
+          (el as unknown as Record<string, number>)[tagProperty] = index;
+        }
         results.push({
           role: resolveRole(el),
           name: resolveName(el),
@@ -190,6 +204,7 @@ function collectInPage(filterInteractive: boolean, occlusionFilter: boolean): {
           y: Math.round(rect.y),
           width: Math.round(rect.width),
           height: Math.round(rect.height),
+          ...(tagProperty ? { backendDOMNodeId: 0 } : {}),
         });
 
         if (results.length >= 500) break;
@@ -234,24 +249,59 @@ export async function collectInteractiveElements(
   const wantsCount = occlusionFilter !== undefined;
   const flag = occlusionFilter === true;
 
-  const raw = await page.evaluate(collectInPage, interactiveOnly, flag);
-  // Tolerate legacy mocks that return a bare array.
-  const elements = Array.isArray(raw)
-    ? (raw as Array<{ role: string; name: string; x: number; y: number; width: number; height: number }>)
-    : raw.elements;
-  const occludedDropped = Array.isArray(raw) ? 0 : raw.occludedDropped;
-
-  const sorted = elements.slice().sort((a, b) => {
-    const rowA = Math.floor(a.y / 50);
-    const rowB = Math.floor(b.y / 50);
-    if (rowA !== rowB) return rowA - rowB;
-    return a.x - b.x;
-  });
+  const { elements: sorted, occludedDropped } = await collectInteractiveElementsInternal(
+    page,
+    interactiveOnly,
+    flag,
+  );
 
   if (wantsCount) {
     return { elements: sorted, occludedDropped };
   }
   return sorted;
+}
+
+async function collectInteractiveElementsInternal(
+  page: Page,
+  interactiveOnly: boolean,
+  occlusionFilter: boolean,
+  cdpClient?: CDPClient,
+): Promise<{ elements: RawElement[]; occludedDropped: number }> {
+  const tagProperty = cdpClient ? nextVisionElementTag() : undefined;
+  let raw: Awaited<ReturnType<typeof collectInPage>> | RawElement[];
+  try {
+    raw = await page.evaluate(collectInPage, interactiveOnly, occlusionFilter, tagProperty);
+    const elements = Array.isArray(raw)
+      ? raw
+      : raw.elements;
+
+    if (cdpClient && elements.length > 0) {
+      try {
+        await resolveBackendNodeIds(page, cdpClient, tagProperty!, elements);
+      } catch {
+        // Identity enrichment is best-effort. Unresolved elements remain visual-only.
+      }
+      for (const element of elements) {
+        if (!Number.isInteger(element.backendDOMNodeId) || (element.backendDOMNodeId ?? 0) <= 0) {
+          delete element.backendDOMNodeId;
+        }
+      }
+    }
+
+    const occludedDropped = Array.isArray(raw) ? 0 : raw.occludedDropped;
+    const sorted = elements.slice().sort((a, b) => {
+      const rowA = Math.floor(a.y / 50);
+      const rowB = Math.floor(b.y / 50);
+      if (rowA !== rowB) return rowA - rowB;
+      return a.x - b.x;
+    });
+
+    return { elements: sorted, occludedDropped };
+  } finally {
+    if (tagProperty) {
+      await cleanupTags(page, tagProperty);
+    }
+  }
 }
 
 /**
@@ -840,7 +890,8 @@ async function analyzeTiledScreenshot(
  */
 export async function analyzeScreenshot(
   page: Page,
-  options?: AnnotationOptions
+  options?: AnnotationOptions,
+  cdpClient?: CDPClient,
 ): Promise<AnnotatedScreenshotResult> {
   const startTime = Date.now();
   const opts = { ...DEFAULT_OPTIONS, ...options } as typeof DEFAULT_OPTIONS;
@@ -886,7 +937,16 @@ export async function analyzeScreenshot(
   // (which return a bare array from page.evaluate) keep working.
   let elements: RawElement[];
   let occludedDropped = 0;
-  if (opts.occlusionFilter) {
+  if (cdpClient) {
+    const result = await collectInteractiveElementsInternal(
+      page,
+      opts.interactiveOnly,
+      opts.occlusionFilter,
+      cdpClient,
+    );
+    elements = result.elements;
+    occludedDropped = result.occludedDropped;
+  } else if (opts.occlusionFilter) {
     const result = await collectInteractiveElements(page, opts.interactiveOnly, true);
     elements = result.elements;
     occludedDropped = result.occludedDropped;

--- a/src/vision/types.ts
+++ b/src/vision/types.ts
@@ -115,6 +115,8 @@ export interface PerceptionElement {
 export interface PerceptionSnapshot {
   version: 1;
   provider: string;
+  /** Coordinate space of this capture. Tiled snapshots are document-space and non-executable. */
+  captureMode?: VisionAnalysisMode;
   tabId: string;
   url: string;
   capturedAt: number;

--- a/tests/tools/interact.perception.test.ts
+++ b/tests/tools/interact.perception.test.ts
@@ -213,6 +213,7 @@ describe('interact tool - perception mode', () => {
   });
 
   test.each([
+    ['tiled capture', perceptionSnapshot({ captureMode: 'tiled' }), 'unsupported_capture_mode'],
     ['wrong tab', perceptionSnapshot({ tabId: 'tab-2' }), 'tab_mismatch'],
     ['wrong URL', perceptionSnapshot({ url: 'https://example.test/other' }), 'url_mismatch'],
     ['stale capture', visualSnapshot(), 'snapshot_stale'],

--- a/tests/vision/perception-snapshot.test.ts
+++ b/tests/vision/perception-snapshot.test.ts
@@ -47,6 +47,7 @@ describe('perception snapshot helpers', () => {
     expect(snapshot).toMatchObject({
       version: 1,
       provider: 'dom-annotator',
+      captureMode: 'viewport',
       tabId: 'tab-1',
       url: 'https://example.test',
       capturedAt: 123,
@@ -116,6 +117,23 @@ describe('perception snapshot helpers', () => {
     const parsed = JSON.parse(formatPerceptionSnapshotAsText(snapshot));
     expect(parsed).toEqual(snapshot);
   });
+
+  test('marks tiled annotated results as document-space captures', () => {
+    const result = annotated({});
+    result.tiling = {
+      tileCount: 1,
+      tileHeight: 500,
+      tiles: [{ tileTop: 0, imageBase64: 'tile', mimeType: 'image/webp' }],
+      truncated: false,
+    };
+
+    const snapshot = buildPerceptionSnapshotFromAnnotatedResult(result, {
+      tabId: 'tab',
+      url: 'https://example.test',
+    });
+
+    expect(snapshot.captureMode).toBe('tiled');
+  });
 });
 
 
@@ -179,6 +197,21 @@ describe('perception snapshot schema validation', () => {
 
     expect(result.ok).toBe(false);
     expect(result.errors.join('\n')).toContain('elements[0].type');
+  });
+
+  test('rejects unknown capture modes', () => {
+    const snapshot = {
+      ...buildPerceptionSnapshotFromAnnotatedResult(annotated({}), {
+        tabId: 'tab',
+        url: 'https://example.test',
+      }),
+      captureMode: 'document',
+    };
+
+    const result = validatePerceptionSnapshot(snapshot);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.join('\n')).toContain('captureMode');
   });
 
   test('limits validation diagnostics for hostile provider output', () => {

--- a/tests/vision/perception-target.test.ts
+++ b/tests/vision/perception-target.test.ts
@@ -82,6 +82,16 @@ describe('resolvePerceptionTarget', () => {
     });
   });
 
+  test('rejects tiled document-space snapshots before browser input', () => {
+    const result = resolve(snapshot({ captureMode: 'tiled' }));
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'INVALID_PERCEPTION_TARGET',
+      reason: 'unsupported_capture_mode',
+    });
+  });
+
   test.each([
     ['tab mismatch', snapshot({ tabId: 'tab-2' }), 'tab_mismatch'],
     ['URL mismatch', snapshot({ url: 'https://example.test/other' }), 'url_mismatch'],

--- a/tests/vision/screenshot-analyzer.test.ts
+++ b/tests/vision/screenshot-analyzer.test.ts
@@ -61,13 +61,10 @@ describe('collectInteractiveElements', () => {
   it('passes interactiveOnly flag to page.evaluate', async () => {
     const page = createMockPage([]);
     await collectInteractiveElements(page as any, true);
-    // Updated for #932 P1 iframe-offset fix: the in-page collector now also
-    // receives a third arg (a translation-mode flag) so the assertion accepts
-    // any trailing argument.
-    expect(page.evaluate).toHaveBeenCalledWith(expect.any(Function), true, expect.anything());
+    expect(page.evaluate).toHaveBeenCalledWith(expect.any(Function), true, false, undefined);
 
     await collectInteractiveElements(page as any, false);
-    expect(page.evaluate).toHaveBeenCalledWith(expect.any(Function), false, expect.anything());
+    expect(page.evaluate).toHaveBeenCalledWith(expect.any(Function), false, false, undefined);
   });
 
   it('handles empty page', async () => {
@@ -157,6 +154,44 @@ describe('formatElementMapAsText', () => {
 // ─── analyzeScreenshot ───
 
 describe('analyzeScreenshot', () => {
+  it('enriches viewport elements with live backend DOM identity when CDP is available', async () => {
+    const page = createMockPage([
+      { role: 'button', name: 'Click Me', x: 50, y: 60, width: 100, height: 35 },
+    ]);
+    const cdpClient = {
+      send: jest.fn()
+        .mockResolvedValueOnce({ result: { objectId: 'vision-batch' } })
+        .mockResolvedValueOnce({ result: [
+          { name: '0', value: { objectId: 'vision-element-0' } },
+        ] })
+        .mockResolvedValueOnce({ node: { backendNodeId: 4242 } }),
+    };
+
+    const result = await analyzeScreenshot(page as any, {}, cdpClient as any);
+
+    expect(result.elementMap[1].backendDOMNodeId).toBe(4242);
+    expect(cdpClient.send).toHaveBeenCalledWith(page, 'DOM.describeNode', {
+      objectId: 'vision-element-0',
+    });
+  });
+
+  it('keeps viewport elements visual-only when backend identity enrichment fails', async () => {
+    const page = createMockPage([
+      { role: 'button', name: 'Click Me', x: 50, y: 60, width: 100, height: 35 },
+    ]);
+    const cdpClient = {
+      send: jest.fn().mockRejectedValue(new Error('CDP unavailable')),
+    };
+
+    const result = await analyzeScreenshot(page as any, {}, cdpClient as any);
+
+    expect(result.elementMap[1].backendDOMNodeId).toBeUndefined();
+    expect(page.evaluate).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.stringMatching(/^__ocVisionIdx_\d+_\d+$/),
+    );
+  });
+
   it('returns complete result with screenshot, map, and metadata', async () => {
     const mockElements = [
       { role: 'button', name: 'Click Me', x: 50, y: 60, width: 100, height: 35 },

--- a/tests/vision/vision-find.test.ts
+++ b/tests/vision/vision-find.test.ts
@@ -72,7 +72,10 @@ describe('VisionFindTool', () => {
   const getVisionFindHandler = async (mockSessionManager: Record<string, jest.Mock>) => {
     jest.resetModules();
     jest.doMock('../../src/session-manager', () => ({
-      getSessionManager: jest.fn(() => mockSessionManager),
+      getSessionManager: jest.fn(() => ({
+        getCDPClient: jest.fn(() => undefined),
+        ...mockSessionManager,
+      })),
     }));
 
     const { registerVisionFindTool } = await import('../../src/tools/vision-find');
@@ -117,6 +120,39 @@ describe('VisionFindTool', () => {
     expect(result.content[1].type).toBe('image');
     expect(result.content[1].data).toBeTruthy();
     expect(result.content[1].mimeType).toMatch(/^image\//);
+  });
+
+  it('emits a viewport snapshot with live backend DOM identity when CDP resolves it', async () => {
+    const page = createMockPage([
+      { role: 'button', name: 'Submit', x: 100, y: 200, width: 80, height: 30 },
+    ]);
+    const cdpClient = {
+      send: jest.fn()
+        .mockResolvedValueOnce({ result: { objectId: 'vision-batch' } })
+        .mockResolvedValueOnce({ result: [
+          { name: '0', value: { objectId: 'vision-element-0' } },
+        ] })
+        .mockResolvedValueOnce({ node: { backendNodeId: 5150 } }),
+    };
+    const mockSessionManager = {
+      getPage: jest.fn().mockResolvedValue(page),
+      getAvailableTargets: jest.fn().mockResolvedValue([]),
+      getCDPClient: jest.fn().mockReturnValue(cdpClient),
+    };
+
+    const handler = await getVisionFindHandler(mockSessionManager);
+    const context = { startTime: Date.now(), deadlineMs: 60000 };
+    const result = await handler('session-1', {
+      tabId: 'tab-1',
+      mode: 'viewport',
+      format: 'snapshot',
+      includeImage: false,
+    }, context) as any;
+    const snapshot = JSON.parse(result.content[0].text);
+
+    expect(snapshot.captureMode).toBe('viewport');
+    expect(snapshot.elements[0].backendDOMNodeId).toBe(5150);
+    expect(mockSessionManager.getCDPClient).toHaveBeenCalledTimes(1);
   });
 
   it('writes opt-in visual trajectory artifacts without inline images', async () => {


### PR DESCRIPTION
## Summary

- preserve live `backendDOMNodeId` provenance in viewport `vision_find format="snapshot"` output by reusing OpenChrome's existing batched CDP resolver
- keep identity enrichment best-effort: unresolved elements remain valid visual-only targets instead of failing capture
- add additive `captureMode` provenance and reject tiled/document-space snapshots before `interact mode="perception"` dispatch
- use per-call unique temporary DOM tags and remove them in `finally`

## Root cause

PR #1576 added a DOM-backed perception execution path, but post-merge real-Chrome verification showed the default `dom-annotator` provider never populated `backendDOMNodeId`. `screenshot-analyzer` serialized role/name/box descriptors inside `page.evaluate()` and did not invoke the existing tag-based `resolveBackendNodeIds` utility, so the new CDP re-resolution branch was unreachable from normal `vision_find` output.

The same audit found that docs called tiled snapshots non-executable, but the snapshot contract did not identify their coordinate space, so the runtime could not enforce that rule.

## Direction fit

This completes the narrow Midscene-derived principle already accepted in #1557: bind location evidence to durable browser identity before one bounded mutation.

It preserves OpenChrome's core boundary:

- the MCP host still selects the exact element ID
- OpenChrome performs deterministic capture, validation, identity re-resolution, and input only
- no planner, model call, candidate ranking, retry loop, provider dependency, or snapshot persistence is added
- existing providers may omit additive `captureMode` and retain viewport-compatible behavior
- CDP identity failure degrades to the existing visual-only safety path

## Implementation

- `src/vision/screenshot-analyzer.ts`
  - tags top-frame viewport elements with a per-call unique property
  - reuses `resolveBackendNodeIds` before reading-order sort
  - removes invalid sentinel IDs and cleans tags in `finally`
  - leaves tiled and iframe elements outside identity enrichment in this patch
- `src/vision/providers/dom-annotator-provider.ts` / `src/tools/vision-find.ts`
  - wire the current `SessionManager` CDP client into viewport capture
- `src/vision/{types,perception-provider,perception-target}.ts`
  - emit and validate `captureMode?: "viewport" | "tiled"`
  - reject tiled snapshots with structured `unsupported_capture_mode` before browser input
- tests and docs cover live identity, graceful degradation, compatibility, and the executable coordinate-space boundary

## Safety and compatibility

- legacy `ref` and `coordinate` modes are unchanged
- snapshots without `captureMode` remain valid
- unresolved/partial CDP identity results omit `backendDOMNodeId`; no invalid `0` sentinel reaches the snapshot
- temporary element tags are unique per capture and removed on success/failure
- tiled snapshots now fail closed before `page.mouse.*`
- no new dependency or MCP tool is added

## Verification

- `npm test -- --runInBand tests/vision tests/tools/interact.perception.test.ts tests/tools/find.test.ts` — 142 passed
- focused identity/contract suite — 63 passed
- focused handler/contract suite after review — 47 passed
- `npm run build`
- `npm run lint:changed`
- `npm run lint:tier`
- `npm run lint:tool-schemas` — 0 new violations
- `npm run docs:capability-map:check`
- `git diff --check`

### Real Chrome smoke

Google Chrome `150.0.7871.187`, isolated temporary profile and port, deterministic local fixture:

- viewport snapshot declared `captureMode: "viewport"`
- normal button carried positive `backendDOMNodeId` and executed with `resolution: "backend-node"`
- the same fresh target with its backend ID removed executed with `resolution: "snapshot-bbox"`
- tiled snapshot failed with `unsupported_capture_mode` and did not increment the page click counter
- after navigation to a same-position replacement button, the old snapshot failed with `url_mismatch` and the replacement click counter remained `0`

The full local Jest suite was not run; required GitHub CI remains the merge gate.

Closes #1581
