### PR TITLE
Add high-signal views to retained browser captures

### DIFF
--- a/docs/mcp/pagination.md
+++ b/docs/mcp/pagination.md
@@ -49,25 +49,22 @@ Cursors are base64url-encoded JSON of the form
 
 ## Stale cursor handling
 
-A cursor referring to a stale view (the underlying set changed between
-calls) MUST be reported as a JSON-RPC error, not a `MCPResult.isError`:
+A cursor referring to a stale view (the underlying set changed between calls)
+is reported as a structured tool error:
 
 ```json
 {
-  "jsonrpc": "2.0",
-  "id": <id>,
-  "error": {
-    "code": -32003,
-    "message": "stale_cursor",
-    "data": { "code": "stale_cursor", "retry": "restart_from_no_cursor" }
+  "isError": true,
+  "structuredContent": {
+    "error": { "code": "stale_cursor", "retry": "restart_from_no_cursor" }
   }
 }
 ```
 
 Rationale: stale-cursor errors are mechanical — clients should auto-retry
-from the start, not surface a tool error to the orchestrating LLM. Using
-the JSON-RPC channel makes the error machine-readable and keeps the
-LLM-visible response free of recoverable failures.
+from the start rather than silently resetting to offset zero. The structured
+error keeps the retry instruction machine-readable; transport-level promotion
+to a JSON-RPC error may be added later without changing cursor encoding.
 
 ## Helper API
 
@@ -85,8 +82,11 @@ const { items, hasMore, nextCursor, total, staleCursor } = paginate(allMatches, 
 });
 
 if (staleCursor) {
-  // Return JSON-RPC -32003 — see "Stale cursor handling" above.
-  throw new StaleCursorError();
+  return {
+    isError: true,
+    content: [{ type: 'text', text: JSON.stringify({ error: { code: 'stale_cursor', retry: 'restart_from_no_cursor' } }) }],
+    structuredContent: { error: { code: 'stale_cursor', retry: 'restart_from_no_cursor' } },
+  };
 }
 
 return {
@@ -101,8 +101,8 @@ return {
 | -------------- | -------------- | ----------------- | ------ |
 | `paginate` helper | `items` | caller supplied | ✅ shipped |
 | `query_dom` | `elements` / `results` | 50 | ✅ multiple CSS/XPath results accept `cursor` and return `nextCursor` / `hasMore` / `totalCount` |
-| `console_capture` `get` | `entries` / `logs` | 200 when cursoring; no-cursor output remains legacy-compatible | ✅ cursor support in PR #1234 |
-| `network_capture_lite/full` `getLogs` | `requests` / `entries` | 100 | ✅ cursor support in PR #1235 |
+| `console_capture` `get` | `entries` / `logs` | 200 for filtered views and legacy cursor calls | ✅ cursor support plus opt-in high-signal views |
+| `network_capture_lite/full` `getLogs` | `requests` / `entries` | 100 | ✅ cursor support plus opt-in failure view |
 | `read_page` markdown | `text` | 5,000 chars after the legacy first chunk | ✅ markdown cursor support in this PR |
 | `crawl` | `pages` | 25 pages | ✅ cursor support in this PR |
 
@@ -127,12 +127,37 @@ paged console entries in `structuredContent.entries`; the text payload uses the
 legacy `logs` field and includes `hasMore` / `nextCursor` only for cursor calls.
 Calls without `cursor` preserve the v1.11 text response baseline.
 
+For an opt-in high-signal read, set `view: "problems"` (`error`, `warning`,
+`warn`, and `assert`) or `view: "errors"` (`error` and `assert`). The tool
+classifies the complete retained snapshot, applies the existing consecutive-log
+deduplication, reverses the result to newest-first order, and only then applies
+`limit` and cursor pagination. Filtered calls always return `hasMore`, optional
+`nextCursor`, and the selected `view` in both response channels. Their default
+page size is 200, and `limit: 0` returns every match.
+
+Filtered console cursors are scoped to the selected view and ordering version.
+Reusing a cursor under another view returns `stale_cursor`, even when the two
+views happen to contain the same entries. Omitted `view` and `view: "all"`
+continue through the exact legacy response path.
+
 ### `network_capture_lite/full`
 
 For `action: "getLogs"`, pass a previous `nextCursor` as `cursor`. Cursoring
 returns paged requests in `structuredContent.requests`; the text payload keeps
 the legacy `entries` field and includes `hasMore` / `nextCursor` only for cursor
 calls. `limit: 0` still means "all retained entries" for compatibility.
+
+Set `view: "failures"` to retrieve only HTTP responses with `status >= 400`
+and non-canceled request failures. The view excludes normal canceled requests,
+unfinished requests, and response-body `fetch_failed` markers because those are
+not request failures by themselves. Filtering runs across the complete retained
+newest-first set before the 100-entry default page or caller-supplied `limit` is
+applied. `limit: 0` returns all matches.
+
+Filtered network calls always expose `hasMore`, optional `nextCursor`,
+`matchedEntries`, and the selected `view`. Their cursors are scoped to the
+failure view and ordering version. Omitted `view` and `view: "all"` preserve the
+legacy response path and cursor hashes.
 
 ### `read_page` markdown
 

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -21,6 +21,7 @@ model composes them into prose.
 | [competitive-feature-matrix.md](competitive-feature-matrix.md) | Build a structured feature-matrix table across several vendor pages. | `navigate`, `extract_data`, `read_page` |
 | [semantic-login-flow.md](semantic-login-flow.md) | Resolve semantic query refs, drive plan actions, and verify with an Outcome Contract. | `oc_query`, `fill_form`, `interact`, `oc_assert`, `oc_evidence_bundle`, `execute_plan` |
 | [safe-plan-contract.md](safe-plan-contract.md) | Run reusable compiled browser workflows with v2 allow-list validation and bounded execution evidence. | `execute_plan` |
+| [high-signal-browser-diagnostics.md](high-signal-browser-diagnostics.md) | Retrieve deterministic console problems and network failures without discarding the full capture. | `console_capture`, `network_capture_lite`, `network_capture_full` |
 
 ## How recipes are structured
 

--- a/docs/recipes/high-signal-browser-diagnostics.md
+++ b/docs/recipes/high-signal-browser-diagnostics.md
@@ -1,0 +1,101 @@
+# High-signal browser diagnostics
+
+## Goal
+
+Capture broad browser evidence during a workflow, then retrieve a small,
+deterministic problem set for host-side diagnosis. The filtered reads preserve
+the underlying console and network buffers, so the host can fall back to the
+full evidence when a high-signal record needs more context.
+
+## Inputs
+
+- The target `tabId`.
+- Whether response bodies are needed (`network_capture_full`) or metadata is
+  sufficient (`network_capture_lite`).
+- The browser action or workflow to observe.
+
+## Plan
+
+1. Start console capture without a capture-time type filter:
+
+   ```json
+   { "tabId": "<tabId>", "action": "start" }
+   ```
+
+2. Start one network recorder. Prefer lite mode unless response bodies are
+   required:
+
+   ```json
+   { "tabId": "<tabId>", "action": "start" }
+   ```
+
+3. Run the browser action or workflow under test.
+
+4. Retrieve console problems. Use `errors` when warnings are intentionally out
+   of scope:
+
+   ```json
+   {
+     "tabId": "<tabId>",
+     "action": "get",
+     "view": "problems",
+     "limit": 200
+   }
+   ```
+
+   The result is newest-first and reports the full retained count, classified
+   count, post-dedup matched count, current page count, and cursor metadata.
+
+5. Retrieve network failures from the same retained recording:
+
+   ```json
+   {
+     "tabId": "<tabId>",
+     "action": "getLogs",
+     "view": "failures",
+     "limit": 100
+   }
+   ```
+
+   The result includes HTTP 4xx/5xx responses and non-canceled request
+   failures. It excludes normal canceled navigation requests, unfinished
+   requests, and body-fetch omissions.
+
+6. While `hasMore` is true, repeat the same call with the returned
+   `nextCursor`. Keep the same `view`: cursors are intentionally scoped to the
+   selected view and ordering contract.
+
+7. When a filtered record needs surrounding context, make an omitted-view or
+   `view: "all"` call against the still-retained capture. Filtering does not
+   mutate or discard raw records.
+
+8. Stop both captures after evidence collection. For full network capture,
+   set `keepBodies` only when the retained files are still needed.
+
+## Synthesis
+
+The host LLM correlates console timestamps, locations, request URLs, statuses,
+and failure text. OpenChrome reports closed-set browser facts only; it does not
+decide root cause, choose remediation, or run a server-owned recovery loop.
+
+Start with the newest matched records, group records that share a navigation or
+action window, and request the full view only for the context needed to test a
+hypothesis. Treat a clean filtered result as "no matching retained facts", not
+as proof that the page is correct.
+
+## Verification
+
+Against a deterministic local fixture:
+
+1. Emit console `log`, `warning`, `assert`, and uncaught exception records.
+2. Generate HTTP 200, 399, 400, 404, and 500 responses, one canceled request,
+   and one non-canceled request failure.
+3. Confirm `problems` returns warning/assert/error facts and `errors` returns
+   assert/error facts, both newest-first.
+4. Confirm `failures` returns 400/404/500 and the non-canceled failure, but not
+   200/399/canceled/unfinished/body-fetch-only records.
+5. Traverse more than one page and verify there are no gaps or duplicates.
+6. Reuse a cursor under another view and confirm the tool reports
+   `stale_cursor`.
+7. Retrieve `view: "all"` and confirm the original broad evidence remains
+   available.

--- a/src/tools/console-capture.ts
+++ b/src/tools/console-capture.ts
@@ -110,6 +110,20 @@ interface DedupedLogEntry {
   truncatedFrom?: number;
 }
 
+export type ConsoleCaptureView = 'all' | 'problems' | 'errors';
+
+const FILTERED_CONSOLE_DEFAULT_PAGE_SIZE = 200;
+const FILTERED_CONSOLE_ORDERING_VERSION = 'newest-first-v1';
+
+export function matchesConsoleCaptureView(
+  log: Pick<ConsoleLogEntry, 'type'>,
+  view: Exclude<ConsoleCaptureView, 'all'>,
+): boolean {
+  const type = log.type.toLowerCase();
+  if (view === 'errors') return type === 'error' || type === 'assert';
+  return type === 'error' || type === 'warning' || type === 'warn' || type === 'assert';
+}
+
 /**
  * Collapse consecutive identical log messages into single entries with a count.
  * Error and warning types are NEVER deduplicated — always shown individually.
@@ -208,6 +222,11 @@ const definition: MCPToolDefinition = {
         type: 'string',
         description: 'Opaque pagination cursor returned as nextCursor from a prior console_capture get call.',
       },
+      view: {
+        type: 'string',
+        enum: ['all', 'problems', 'errors'],
+        description: 'Get only: all preserves legacy output; problems keeps warning/error/assert; errors keeps error/assert.',
+      },
       maxLogs: {
         type: 'number',
         description: 'Max logs to store. Default: 1000',
@@ -271,6 +290,7 @@ const handler: ToolHandler = async (
   const filter = args.filter as string[] | undefined;
   const limit = args.limit as number | undefined;
   const cursor = typeof args.cursor === 'string' ? args.cursor : undefined;
+  const view = resolveConsoleCaptureView(args.view);
   // maxLogs is a backward-compatible alias for maxLines. Defense-in-depth:
   // reject zero / non-positive / non-integer values BEFORE forwarding to
   // createConsoleRingBuffer so a malformed `start` request returns a clear
@@ -312,6 +332,15 @@ const handler: ToolHandler = async (
       content: [{ type: 'text', text: 'Error: action is required' }],
       isError: true,
     };
+  }
+
+  if (view === null) {
+    return invalidViewResult(args.view);
+  }
+
+  if (action === 'get' && view !== 'all') {
+    const invalidLimit = validateFilteredLimit(limit);
+    if (invalidLimit) return invalidLimit;
   }
 
   try {
@@ -525,6 +554,64 @@ const handler: ToolHandler = async (
           };
         }
 
+        if (view !== 'all') {
+          const pageSize = resolveFilteredConsolePageSize(limit, state.logs.stats().retained);
+          if (typeof pageSize !== 'number') return pageSize;
+
+          const retainedLogs = state.logs.drain();
+          const classifiedLogs = retainedLogs.filter((log) => matchesConsoleCaptureView(log, view));
+          const pageableLogs = deduplicateLogs(classifiedLogs).reverse();
+          const pagination = buildConsoleCapturePagination(pageableLogs, {
+            cursor,
+            pageSize,
+            view,
+          });
+          if (pagination.staleCursor) return staleCursorResult();
+          if (pagination.invalidCursor) return invalidCursorResult(pagination.invalidCursor);
+
+          const returnedLogs = pagination.logs.map((log) => ({
+            ...log,
+            text: boundaryMarkers ? wrapBoundaryMarker('console', { origin: log.location?.url || page.url() }, log.text) : log.text,
+            args: boundaryMarkers && log.args ? log.args.map((arg) => wrapBoundaryMarker('console', { origin: log.location?.url || page.url() }, arg)) : log.args,
+          }));
+          const bufStats = state.logs.stats();
+          const byType: Record<string, number> = {};
+          for (const log of retainedLogs) {
+            byType[log.type] = (byType[log.type] || 0) + 1;
+          }
+          const stats = {
+            total: bufStats.retained,
+            returned: returnedLogs.length,
+            beforeDedup: classifiedLogs.length,
+            matched: pageableLogs.length,
+            byType,
+          };
+          const payload = {
+            action: 'get',
+            status: 'running',
+            view,
+            logs: returnedLogs,
+            stats,
+            durationMs: Date.now() - state.startedAt,
+            bufferStats: bufStats,
+            hasMore: pagination.hasMore,
+            ...(pagination.nextCursor ? { nextCursor: pagination.nextCursor } : {}),
+          };
+
+          return {
+            content: [{ type: 'text', text: JSON.stringify(payload) }],
+            structuredContent: {
+              action: 'get',
+              status: 'running',
+              view,
+              entries: returnedLogs,
+              hasMore: pagination.hasMore,
+              ...(pagination.nextCursor ? { nextCursor: pagination.nextCursor } : {}),
+              total: pageableLogs.length,
+            },
+          };
+        }
+
         const logs: ConsoleLogEntry[] = (limit && limit > 0)
           ? state.logs.tail(limit)
           : state.logs.drain();
@@ -646,7 +733,7 @@ const handler: ToolHandler = async (
 
 export function buildConsoleCapturePagination(
   logs: DedupedLogEntry[],
-  opts: { cursor?: string; pageSize: number },
+  opts: { cursor?: string; pageSize: number; view?: ConsoleCaptureView },
 ): {
   logs: DedupedLogEntry[];
   hasMore: boolean;
@@ -659,7 +746,7 @@ export function buildConsoleCapturePagination(
     const page = paginate(logs, {
       cursor: opts.cursor,
       pageSize: opts.pageSize,
-      contentHash: hashConsoleEntries(logs),
+      contentHash: hashConsoleEntries(logs, opts.view),
     });
     if (page.staleCursor) return { logs: [], hasMore: false, total: page.total, staleCursor: true };
     return {
@@ -673,8 +760,13 @@ export function buildConsoleCapturePagination(
   }
 }
 
-function hashConsoleEntries(logs: DedupedLogEntry[]): string {
+function hashConsoleEntries(logs: DedupedLogEntry[], view?: ConsoleCaptureView): string {
   const hash = crypto.createHash('sha256');
+  if (view && view !== 'all') {
+    hash
+      .update(`console:${view}:${FILTERED_CONSOLE_ORDERING_VERSION}`)
+      .update('\0');
+  }
   for (const log of logs) {
     hash
       .update(log.type)
@@ -689,6 +781,45 @@ function hashConsoleEntries(logs: DedupedLogEntry[]): string {
       .update('\0');
   }
   return hash.digest('hex');
+}
+
+function resolveConsoleCaptureView(value: unknown): ConsoleCaptureView | null {
+  if (value === undefined || value === 'all') return 'all';
+  if (value === 'problems' || value === 'errors') return value;
+  return null;
+}
+
+function resolveFilteredConsolePageSize(limit: number | undefined, total: number): number | MCPResult {
+  if (limit === undefined) return FILTERED_CONSOLE_DEFAULT_PAGE_SIZE;
+  const invalidLimit = validateFilteredLimit(limit);
+  if (invalidLimit) return invalidLimit;
+  if (limit === 0) return Math.max(1, total);
+  return limit;
+}
+
+function validateFilteredLimit(limit: number | undefined): MCPResult | null {
+  if (limit === undefined || (Number.isFinite(limit) && Number.isInteger(limit) && limit >= 0)) {
+    return null;
+  }
+  return invalidLimitResult(limit);
+}
+
+function invalidLimitResult(limit: unknown): MCPResult {
+  const message = `limit must be a finite non-negative integer for filtered views; received ${String(limit)}`;
+  return {
+    isError: true,
+    content: [{ type: 'text', text: JSON.stringify({ error: { code: 'invalid_limit', message } }) }],
+    structuredContent: { error: { code: 'invalid_limit', message } },
+  };
+}
+
+function invalidViewResult(view: unknown): MCPResult {
+  const message = `view must be one of all, problems, or errors when supplied; received ${String(view)}`;
+  return {
+    isError: true,
+    content: [{ type: 'text', text: JSON.stringify({ error: { code: 'invalid_view', message } }) }],
+    structuredContent: { error: { code: 'invalid_view', message } },
+  };
 }
 
 function invalidCursorResult(error: unknown): MCPResult {

--- a/src/tools/network-capture-shared.ts
+++ b/src/tools/network-capture-shared.ts
@@ -18,6 +18,20 @@ import { MCPResult, ToolHandler } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
 import { paginate } from '../utils/paginate';
 
+export type NetworkCaptureView = 'all' | 'failures';
+
+const FILTERED_NETWORK_DEFAULT_PAGE_SIZE = 100;
+const FILTERED_NETWORK_ORDERING_VERSION = 'newest-first-v1';
+
+export function matchesNetworkCaptureView(
+  entry: NetworkCaptureEntry,
+  view: Exclude<NetworkCaptureView, 'all'>,
+): boolean {
+  if (view !== 'failures') return true;
+  if (typeof entry.status === 'number' && entry.status >= 400) return true;
+  return entry.failed !== undefined && entry.failed.canceled !== true;
+}
+
 export const NETWORK_CAPTURE_INPUT_SCHEMA = {
   type: 'object' as const,
   properties: {
@@ -52,6 +66,11 @@ export const NETWORK_CAPTURE_INPUT_SCHEMA = {
     cursor: {
       type: 'string',
       description: 'Opaque pagination cursor returned as nextCursor from a prior getLogs call.',
+    },
+    view: {
+      type: 'string',
+      enum: ['all', 'failures'],
+      description: 'getLogs only: all preserves legacy output; failures keeps HTTP 4xx/5xx and non-canceled request failures.',
     },
   },
   required: ['tabId', 'action'],
@@ -99,11 +118,17 @@ export function createNetworkCaptureHandler(captureMode: CaptureMode): ToolHandl
     const keepBodies = args.keepBodies as boolean | undefined;
     const limit = args.limit as number | undefined;
     const cursor = typeof args.cursor === 'string' ? args.cursor : undefined;
+    const view = resolveNetworkCaptureView(args.view);
 
     setupCleanupListener();
 
     if (!tabId) return jsonResult({ success: false, error: 'tabId is required' }, true);
     if (!action) return jsonResult({ success: false, error: 'action is required' }, true);
+    if (view === null) return invalidViewResult(args.view);
+    if (action === 'getLogs' && view === 'failures') {
+      const invalidLimit = validateFilteredLimit(limit);
+      if (invalidLimit) return invalidLimit;
+    }
 
     const sessionManager = getSessionManager();
 
@@ -176,6 +201,39 @@ export function createNetworkCaptureHandler(captureMode: CaptureMode): ToolHandl
             });
           }
           const allEntries = recorder.getLogs(0);
+
+          if (view === 'failures') {
+            const pageSize = resolveFilteredNetworkPageSize(limit, allEntries.length);
+            if (typeof pageSize !== 'number') return pageSize;
+
+            const matchedEntries = allEntries.filter((entry) => matchesNetworkCaptureView(entry, view));
+            const page = paginateNetworkCaptureEntries(matchedEntries, { cursor, pageSize, view });
+            if (page.staleCursor) return staleCursorResult();
+            if (page.invalidCursor) return invalidCursorResult(page.invalidCursor);
+            const entries = page.entries;
+            return jsonResult({
+              success: true,
+              action: 'getLogs',
+              mode: captureMode,
+              view,
+              entries,
+              totalEntries: recorder.getEntryCount(),
+              matchedEntries: matchedEntries.length,
+              returned: entries.length,
+              hasMore: page.hasMore,
+              ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
+            }, false, {
+              success: true,
+              action: 'getLogs',
+              mode: captureMode,
+              view,
+              requests: entries,
+              total: matchedEntries.length,
+              hasMore: page.hasMore,
+              ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
+            });
+          }
+
           const pageSize = resolveNetworkCapturePageSize(limit, allEntries.length);
           const page = paginateNetworkCaptureEntries(allEntries, { cursor, pageSize });
           if (page.staleCursor) return staleCursorResult();
@@ -241,7 +299,7 @@ export function createNetworkCaptureHandler(captureMode: CaptureMode): ToolHandl
 
 export function paginateNetworkCaptureEntries(
   entries: NetworkCaptureEntry[],
-  opts: { cursor?: string; pageSize: number },
+  opts: { cursor?: string; pageSize: number; view?: NetworkCaptureView },
 ): {
   entries: NetworkCaptureEntry[];
   hasMore: boolean;
@@ -254,7 +312,7 @@ export function paginateNetworkCaptureEntries(
     const page = paginate(entries, {
       cursor: opts.cursor,
       pageSize: opts.pageSize,
-      contentHash: hashNetworkCaptureEntries(entries),
+      contentHash: hashNetworkCaptureEntries(entries, opts.view),
     });
     if (page.staleCursor) return { entries: [], hasMore: false, total: page.total, staleCursor: true };
     return {
@@ -273,8 +331,13 @@ function resolveNetworkCapturePageSize(limit: number | undefined, total: number)
   return Math.max(1, Math.floor(limit ?? 100));
 }
 
-function hashNetworkCaptureEntries(entries: NetworkCaptureEntry[]): string {
+function hashNetworkCaptureEntries(entries: NetworkCaptureEntry[], view?: NetworkCaptureView): string {
   const hash = crypto.createHash('sha256');
+  if (view && view !== 'all') {
+    hash
+      .update(`network:${view}:${FILTERED_NETWORK_ORDERING_VERSION}`)
+      .update('\0');
+  }
   for (const entry of entries) {
     hash
       .update(entry.requestId)
@@ -293,6 +356,41 @@ function hashNetworkCaptureEntries(entries: NetworkCaptureEntry[]): string {
       .update('\0');
   }
   return hash.digest('hex');
+}
+
+function resolveFilteredNetworkPageSize(limit: number | undefined, total: number): number | MCPResult {
+  if (limit === undefined) return FILTERED_NETWORK_DEFAULT_PAGE_SIZE;
+  const invalidLimit = validateFilteredLimit(limit);
+  if (invalidLimit) return invalidLimit;
+  if (limit === 0) return Math.max(1, total);
+  return limit;
+}
+
+function validateFilteredLimit(limit: number | undefined): MCPResult | null {
+  if (limit === undefined || (Number.isFinite(limit) && Number.isInteger(limit) && limit >= 0)) {
+    return null;
+  }
+  return invalidLimitResult(limit);
+}
+
+function invalidLimitResult(limit: unknown): MCPResult {
+  const message = `limit must be a finite non-negative integer for filtered views; received ${String(limit)}`;
+  return jsonResult({ error: { code: 'invalid_limit', message } }, true, {
+    error: { code: 'invalid_limit', message },
+  });
+}
+
+function resolveNetworkCaptureView(value: unknown): NetworkCaptureView | null {
+  if (value === undefined || value === 'all') return 'all';
+  if (value === 'failures') return 'failures';
+  return null;
+}
+
+function invalidViewResult(view: unknown): MCPResult {
+  const message = `view must be all or failures when supplied; received ${String(view)}`;
+  return jsonResult({ error: { code: 'invalid_view', message } }, true, {
+    error: { code: 'invalid_view', message },
+  });
 }
 
 function invalidCursorResult(error: unknown): MCPResult {

--- a/src/utils/paginate.ts
+++ b/src/utils/paginate.ts
@@ -15,9 +15,9 @@
  *
  * Cursor encoding: base64url JSON `{ v: 1, offset: number, hash?: string }`.
  * Including an optional content hash lets the server detect cursor reuse on
- * stale data and reject explicitly — a stale cursor returns a JSON-RPC
- * `-32003` error rather than a silent reset (clients should auto-retry from
- * the start instead of surfacing a tool error to the LLM).
+ * stale data and reject explicitly. Adopting tools currently return a
+ * structured `stale_cursor` tool error so clients can auto-retry from the
+ * start rather than silently resetting the offset.
  *
  * The helper is intentionally `T[]`-only at this layer — cursor semantics
  * for char-offset paginated outputs (e.g. `read_page` text) live in the
@@ -35,9 +35,9 @@ export interface PaginateOpts {
   /**
    * Optional content hash of the underlying input set. When supplied, the
    * helper compares it to the cursor's recorded hash; a mismatch surfaces as
-   * `staleCursor: true` so the dispatcher can convert it to a JSON-RPC
-   * `-32003` error. Skip the hash for unstable / streamed datasets — the
-   * cursor becomes a pure offset reference.
+   * `staleCursor: true` so the caller can return a structured stale-cursor
+   * error. Skip the hash for unstable / streamed datasets — the cursor becomes
+   * a pure offset reference.
    */
   contentHash?: string;
 }
@@ -58,8 +58,8 @@ export interface PaginateResult<T> {
   total: number;
   /**
    * Set when the incoming cursor referenced a different content hash than the
-   * current input set. The dispatcher should reject the call with JSON-RPC
-   * code `-32003` (data: `{ code: 'stale_cursor', retry: 'restart_from_no_cursor' }`).
+   * current input set. The caller should reject the call with
+   * `{ code: 'stale_cursor', retry: 'restart_from_no_cursor' }`.
    */
   staleCursor?: true;
 }
@@ -86,8 +86,8 @@ export function encodeCursor(state: { offset: number; hash?: string }): string {
 /**
  * Decode a previously-emitted cursor. Throws `Error('invalid_cursor')` on
  * any structural problem (bad base64, bad JSON, missing/wrong version,
- * non-integer offset). The caller should map that error to JSON-RPC
- * `-32602` (Invalid params).
+ * non-integer offset). The caller should map that error to a structured
+ * invalid-cursor response.
  */
 export function decodeCursor(cursor: string): CursorState {
   let decoded: unknown;

--- a/tests/tools/capture-high-signal-views.test.ts
+++ b/tests/tools/capture-high-signal-views.test.ts
@@ -1,0 +1,602 @@
+/// <reference types="jest" />
+
+import type { Page } from 'puppeteer-core';
+
+jest.mock('../../src/session-manager', () => ({ getSessionManager: jest.fn() }));
+
+import { createConsoleRingBuffer } from '../../src/core/console-buffer/ring-buffer';
+import {
+  _resetActiveRecordersForTests,
+  NetworkCaptureRecorder,
+  setActiveRecorder,
+} from '../../src/core/network-capture/recorder';
+import type { CaptureMode, NetworkCaptureEntry } from '../../src/core/network-capture/types';
+import { getSessionManager } from '../../src/session-manager';
+import {
+  captureStates,
+  registerConsoleCaptureTool,
+} from '../../src/tools/console-capture';
+import {
+  createNetworkCaptureHandler,
+  NETWORK_CAPTURE_INPUT_SCHEMA,
+} from '../../src/tools/network-capture-shared';
+import type { MCPServer } from '../../src/mcp-server';
+import type { MCPResult, MCPToolDefinition, ToolHandler } from '../../src/types/mcp';
+import { createMockPage } from '../utils/mock-cdp';
+import { createMockSessionManager } from '../utils/mock-session';
+
+const SESSION_ID = 'session-high-signal';
+const TAB_ID = 'tab-high-signal';
+const NOW = 1_800_000_000_000;
+
+interface TestConsoleLogEntry {
+  type: string;
+  text: string;
+  timestamp: number;
+  location?: { url?: string; lineNumber?: number; columnNumber?: number };
+  args?: string[];
+  truncatedFrom?: number;
+}
+
+function captureConsoleRegistration(): { handler: ToolHandler; definition: MCPToolDefinition } {
+  let handler: ToolHandler | undefined;
+  let definition: MCPToolDefinition | undefined;
+  const server = {
+    registerTool: (_name: string, registeredHandler: ToolHandler, registeredDefinition: MCPToolDefinition) => {
+      handler = registeredHandler;
+      definition = registeredDefinition;
+    },
+  } as unknown as MCPServer;
+
+  registerConsoleCaptureTool(server);
+  if (!handler || !definition) throw new Error('console_capture did not register');
+  return { handler, definition };
+}
+
+function parseText(result: MCPResult): Record<string, any> {
+  if (!result.content || result.content.length === 0) {
+    throw new Error('expected text content');
+  }
+  const item = result.content[0] as { type: 'text'; text: string };
+  return JSON.parse(item.text) as Record<string, any>;
+}
+
+function consoleLog(index: number, type = 'log', text = `${type}-${index}`): TestConsoleLogEntry {
+  return {
+    type,
+    text,
+    timestamp: 1_700_000_000_000 + index,
+    args: [text],
+    location: { url: 'https://example.test/app.js', lineNumber: index },
+  };
+}
+
+function seedConsole(logs: TestConsoleLogEntry[]): void {
+  const buffer = createConsoleRingBuffer<TestConsoleLogEntry>(
+    { maxLines: 1000, maxBytes: 4 * 1024 * 1024 },
+    (size) => ({ type: 'log', text: '[truncated]', timestamp: NOW, truncatedFrom: size }),
+  );
+  for (const log of logs) buffer.push(log, JSON.stringify(log).length);
+
+  captureStates.set(TAB_ID, {
+    logs: buffer,
+    cdpSession: { detach: jest.fn(), off: jest.fn(), send: jest.fn() },
+    consoleHandler: jest.fn(),
+    exceptionHandler: jest.fn(),
+    startedAt: NOW - 1000,
+    maxLogs: 1000,
+    maxBytes: 4 * 1024 * 1024,
+  } as any);
+}
+
+function networkEntry(
+  index: number,
+  overrides: Partial<NetworkCaptureEntry> = {},
+): NetworkCaptureEntry {
+  return {
+    requestId: `req-${index}`,
+    loaderId: 'loader-1',
+    url: `https://example.test/request/${index}`,
+    method: 'GET',
+    resourceType: 'xhr',
+    status: 200,
+    statusText: 'OK',
+    requestHeaders: {},
+    responseHeaders: {},
+    timing: {
+      startedAt: 1_700_000_000_000 + index,
+      finishedAt: 1_700_000_000_100 + index,
+    },
+    body: { mode: 'omitted', reason: 'lite_mode' },
+    ...overrides,
+  };
+}
+
+function seedNetwork(page: Page, entries: NetworkCaptureEntry[], mode: CaptureMode): void {
+  const recorder = new NetworkCaptureRecorder(page, SESSION_ID, mode);
+  (recorder as unknown as { entries: NetworkCaptureEntry[] }).entries = entries;
+  setActiveRecorder(TAB_ID, recorder);
+}
+
+const consoleRegistration = captureConsoleRegistration();
+
+describe('capture high-signal view schemas', () => {
+  test('exposes opt-in view enums without changing omitted-call defaults', () => {
+    const consoleView = consoleRegistration.definition.inputSchema.properties?.view as Record<string, unknown>;
+    const networkView = NETWORK_CAPTURE_INPUT_SCHEMA.properties.view as Record<string, unknown>;
+
+    expect(consoleView.enum).toEqual(['all', 'problems', 'errors']);
+    expect(consoleView).not.toHaveProperty('default');
+    expect(networkView.enum).toEqual(['all', 'failures']);
+    expect(networkView).not.toHaveProperty('default');
+  });
+});
+
+describe('capture high-signal handler behavior', () => {
+  let page: Page;
+  let sessionManager: ReturnType<typeof createMockSessionManager>;
+
+  beforeEach(async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    captureStates.clear();
+    _resetActiveRecordersForTests();
+
+    sessionManager = createMockSessionManager();
+    await sessionManager.createSession({ id: SESSION_ID });
+    page = createMockPage({ url: 'https://example.test/', targetId: TAB_ID });
+    sessionManager._addPage(SESSION_ID, TAB_ID, page);
+    (getSessionManager as jest.Mock).mockReturnValue(sessionManager);
+  });
+
+  afterEach(() => {
+    captureStates.clear();
+    _resetActiveRecordersForTests();
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  test('console omitted view and explicit all are exactly equivalent', async () => {
+    seedConsole([
+      consoleLog(1, 'log'),
+      consoleLog(2, 'error'),
+      consoleLog(3, 'warning'),
+    ]);
+
+    const omitted = await consoleRegistration.handler(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'get',
+      boundaryMarkers: false,
+    });
+    const explicitAll = await consoleRegistration.handler(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'get',
+      view: 'all',
+      boundaryMarkers: false,
+    });
+
+    expect(explicitAll).toEqual(omitted);
+    expect(parseText(explicitAll)).not.toHaveProperty('view');
+  });
+
+  test.each<CaptureMode>(['lite', 'full'])(
+    'network %s omitted view and explicit all are exactly equivalent',
+    async (mode) => {
+      seedNetwork(page, [networkEntry(1), networkEntry(2, { status: 500 })], mode);
+      const handler = createNetworkCaptureHandler(mode);
+
+      const omitted = await handler(SESSION_ID, { tabId: TAB_ID, action: 'getLogs' });
+      const explicitAll = await handler(SESSION_ID, {
+        tabId: TAB_ID,
+        action: 'getLogs',
+        view: 'all',
+      });
+
+      expect(explicitAll).toEqual(omitted);
+      expect(parseText(explicitAll)).not.toHaveProperty('view');
+    },
+  );
+
+  test('invalid views fail closed instead of widening to all retained records', async () => {
+    seedConsole([consoleLog(1, 'error')]);
+    const consoleResult = await consoleRegistration.handler(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'get',
+      view: 'problem',
+      boundaryMarkers: false,
+    });
+    expect(consoleResult.isError).toBe(true);
+    expect(parseText(consoleResult).error.code).toBe('invalid_view');
+
+    seedNetwork(page, [networkEntry(1, { status: 500 })], 'lite');
+    const networkResult = await createNetworkCaptureHandler('lite')(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'getLogs',
+      view: 'failure',
+    });
+    expect(networkResult.isError).toBe(true);
+    expect(parseText(networkResult).error.code).toBe('invalid_view');
+  });
+
+  test('console problems and errors use closed-set classification with explicit accounting', async () => {
+    seedConsole([
+      consoleLog(1, 'error'),
+      consoleLog(2, 'log'),
+      consoleLog(3, 'warning'),
+      consoleLog(4, 'warn'),
+      consoleLog(5, 'assert', 'repeated assertion'),
+      consoleLog(6, 'assert', 'repeated assertion'),
+      consoleLog(7, 'assert', 'repeated assertion'),
+      consoleLog(8, 'info'),
+    ]);
+
+    const problems = await consoleRegistration.handler(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'get',
+      view: 'problems',
+      limit: 0,
+      boundaryMarkers: false,
+    });
+    const errors = await consoleRegistration.handler(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'get',
+      view: 'errors',
+      limit: 0,
+      boundaryMarkers: false,
+    });
+
+    const problemsText = parseText(problems);
+    expect(problemsText.logs.map((log: any) => log.type)).toEqual([
+      'assert',
+      'warn',
+      'warning',
+      'error',
+    ]);
+    expect(problemsText.stats).toEqual({
+      total: 8,
+      returned: 4,
+      beforeDedup: 6,
+      matched: 4,
+      byType: { error: 1, log: 1, warning: 1, warn: 1, assert: 3, info: 1 },
+    });
+    expect(problemsText.logs[0]).toMatchObject({ type: 'assert', count: 3 });
+    expect(problems.structuredContent).toMatchObject({
+      view: 'problems',
+      total: 4,
+      hasMore: false,
+    });
+
+    const errorsText = parseText(errors);
+    expect(errorsText.logs.map((log: any) => log.type)).toEqual(['assert', 'error']);
+    expect(errorsText.stats.beforeDedup).toBe(4);
+    expect(errorsText.stats.matched).toBe(2);
+  });
+
+  test('console capture normalizes Runtime.exceptionThrown into the errors view', async () => {
+    const cdpSession = await (page as any).createCDPSession();
+    const handlers = new Map<string, (event: any) => void>();
+    (cdpSession.on as jest.Mock).mockImplementation((event: string, listener: (payload: any) => void) => {
+      handlers.set(event, listener);
+    });
+
+    const started = await consoleRegistration.handler(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'start',
+    });
+    expect(parseText(started).status).toBe('started');
+
+    handlers.get('Runtime.exceptionThrown')?.({
+      timestamp: NOW,
+      exceptionDetails: {
+        text: 'Uncaught',
+        exception: { description: 'Error: fixture exploded' },
+        stackTrace: {
+          callFrames: [{
+            url: 'https://example.test/app.js',
+            lineNumber: 42,
+            columnNumber: 7,
+          }],
+        },
+      },
+    });
+
+    const result = await consoleRegistration.handler(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'get',
+      view: 'errors',
+      limit: 0,
+      boundaryMarkers: false,
+    });
+    expect(parseText(result).logs).toEqual([
+      expect.objectContaining({
+        type: 'error',
+        text: 'Error: fixture exploded',
+        count: 1,
+        location: {
+          url: 'https://example.test/app.js',
+          lineNumber: 42,
+          columnNumber: 7,
+        },
+      }),
+    ]);
+  });
+
+  test('console filters the complete retained snapshot before applying limit', async () => {
+    seedConsole([
+      consoleLog(1, 'error', 'old failure'),
+      ...Array.from({ length: 8 }, (_, i) => consoleLog(i + 2, 'log', `recent noise ${i}`)),
+    ]);
+
+    const result = await consoleRegistration.handler(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'get',
+      view: 'errors',
+      limit: 1,
+      boundaryMarkers: false,
+    });
+
+    expect(parseText(result).logs.map((log: any) => log.text)).toEqual(['old failure']);
+  });
+
+  test('console filtered pages are newest-first with no gaps or duplicates', async () => {
+    seedConsole(Array.from({ length: 5 }, (_, i) => consoleLog(i + 1, 'error')));
+
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    let pageNumber = 0;
+    do {
+      const result = await consoleRegistration.handler(SESSION_ID, {
+        tabId: TAB_ID,
+        action: 'get',
+        view: 'errors',
+        limit: 2,
+        ...(cursor ? { cursor } : {}),
+        boundaryMarkers: false,
+      });
+      const text = parseText(result);
+      seen.push(...text.logs.map((log: any) => log.text));
+      expect(result.structuredContent).toMatchObject({
+        view: 'errors',
+        hasMore: text.hasMore,
+        total: 5,
+      });
+      expect((result.structuredContent as any).nextCursor).toBe(text.nextCursor);
+      cursor = text.nextCursor;
+      pageNumber++;
+    } while (cursor);
+
+    expect(pageNumber).toBe(3);
+    expect(seen).toEqual(['error-5', 'error-4', 'error-3', 'error-2', 'error-1']);
+    expect(new Set(seen).size).toBe(5);
+  });
+
+  test('console filtered defaults page at 200 and binds cursors to the selected view', async () => {
+    seedConsole(Array.from({ length: 201 }, (_, i) => consoleLog(i + 1, 'error')));
+
+    const first = await consoleRegistration.handler(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'get',
+      view: 'problems',
+      boundaryMarkers: false,
+    });
+    const firstText = parseText(first);
+    expect(firstText.logs).toHaveLength(200);
+    expect(firstText.hasMore).toBe(true);
+    expect(firstText.nextCursor).toEqual(expect.any(String));
+
+    const crossView = await consoleRegistration.handler(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'get',
+      view: 'errors',
+      cursor: firstText.nextCursor,
+      boundaryMarkers: false,
+    });
+    expect(crossView.isError).toBe(true);
+    expect(parseText(crossView).error.code).toBe('stale_cursor');
+  });
+
+  test('console filtered limit validates finite non-negative integers and zero returns all matches', async () => {
+    seedConsole(Array.from({ length: 3 }, (_, i) => consoleLog(i + 1, 'error')));
+
+    for (const limit of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const result = await consoleRegistration.handler(SESSION_ID, {
+        tabId: TAB_ID,
+        action: 'get',
+        view: 'errors',
+        limit,
+        boundaryMarkers: false,
+      });
+      expect(result.isError).toBe(true);
+      expect(parseText(result).error.code).toBe('invalid_limit');
+    }
+
+    const all = await consoleRegistration.handler(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'get',
+      view: 'errors',
+      limit: 0,
+      boundaryMarkers: false,
+    });
+    expect(parseText(all).logs).toHaveLength(3);
+  });
+
+  test('filtered limit validation precedes inactive capture and network mode checks', async () => {
+    const inactiveConsole = await consoleRegistration.handler(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'get',
+      view: 'errors',
+      limit: -1,
+      boundaryMarkers: false,
+    });
+    expect(inactiveConsole.isError).toBe(true);
+    expect(parseText(inactiveConsole).error.code).toBe('invalid_limit');
+
+    const inactiveNetwork = await createNetworkCaptureHandler('lite')(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'getLogs',
+      view: 'failures',
+      limit: -1,
+    });
+    expect(inactiveNetwork.isError).toBe(true);
+    expect(parseText(inactiveNetwork).error.code).toBe('invalid_limit');
+
+    seedNetwork(page, [networkEntry(1, { status: 500 })], 'full');
+    const mismatchedNetwork = await createNetworkCaptureHandler('lite')(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'getLogs',
+      view: 'failures',
+      limit: -1,
+    });
+    expect(mismatchedNetwork.isError).toBe(true);
+    expect(parseText(mismatchedNetwork).error.code).toBe('invalid_limit');
+  });
+
+  test.each<CaptureMode>(['lite', 'full'])(
+    'network %s failures classify protocol facts without treating cancellation or body fetch as request failure',
+    async (mode) => {
+      seedNetwork(page, [
+        networkEntry(1, { status: 200 }),
+        networkEntry(2, { status: 399 }),
+        networkEntry(3, { status: 400 }),
+        networkEntry(4, { status: 404 }),
+        networkEntry(5, { status: 500 }),
+        networkEntry(6, { status: undefined, failed: { errorText: 'net::ERR_ABORTED', canceled: true } }),
+        networkEntry(7, { status: undefined, failed: { errorText: 'net::ERR_FAILED', canceled: false } }),
+        networkEntry(8, { status: undefined, timing: { startedAt: 1_700_000_000_008 } }),
+        networkEntry(9, { status: 200, body: { mode: 'omitted', reason: 'fetch_failed' } }),
+      ], mode);
+
+      const result = await createNetworkCaptureHandler(mode)(SESSION_ID, {
+        tabId: TAB_ID,
+        action: 'getLogs',
+        view: 'failures',
+        limit: 0,
+      });
+      const text = parseText(result);
+
+      expect(text.entries.map((entry: NetworkCaptureEntry) => entry.requestId)).toEqual([
+        'req-7',
+        'req-5',
+        'req-4',
+        'req-3',
+      ]);
+      expect(text).toMatchObject({
+        view: 'failures',
+        totalEntries: 9,
+        matchedEntries: 4,
+        returned: 4,
+        hasMore: false,
+      });
+      expect(result.structuredContent).toMatchObject({
+        view: 'failures',
+        total: 4,
+        hasMore: false,
+      });
+    },
+  );
+
+  test('network filters the complete retained snapshot before applying limit', async () => {
+    seedNetwork(page, [
+      networkEntry(1, { status: 500 }),
+      ...Array.from({ length: 8 }, (_, i) => networkEntry(i + 2, { status: 200 })),
+    ], 'lite');
+
+    const result = await createNetworkCaptureHandler('lite')(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'getLogs',
+      view: 'failures',
+      limit: 1,
+    });
+
+    expect(parseText(result).entries.map((entry: NetworkCaptureEntry) => entry.requestId)).toEqual(['req-1']);
+  });
+
+  test('network filtered pages are newest-first with no gaps or duplicates', async () => {
+    seedNetwork(
+      page,
+      Array.from({ length: 5 }, (_, i) => networkEntry(i + 1, { status: 500 })),
+      'lite',
+    );
+    const handler = createNetworkCaptureHandler('lite');
+
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    do {
+      const result = await handler(SESSION_ID, {
+        tabId: TAB_ID,
+        action: 'getLogs',
+        view: 'failures',
+        limit: 2,
+        ...(cursor ? { cursor } : {}),
+      });
+      const text = parseText(result);
+      seen.push(...text.entries.map((entry: NetworkCaptureEntry) => entry.requestId));
+      expect(result.structuredContent).toMatchObject({
+        view: 'failures',
+        hasMore: text.hasMore,
+        total: 5,
+      });
+      expect((result.structuredContent as any).nextCursor).toBe(text.nextCursor);
+      cursor = text.nextCursor;
+    } while (cursor);
+
+    expect(seen).toEqual(['req-5', 'req-4', 'req-3', 'req-2', 'req-1']);
+    expect(new Set(seen).size).toBe(5);
+  });
+
+  test('network filtered defaults page at 100 and rejects its cursor under the all view', async () => {
+    seedNetwork(
+      page,
+      Array.from({ length: 101 }, (_, i) => networkEntry(i + 1, { status: 500 })),
+      'lite',
+    );
+    const handler = createNetworkCaptureHandler('lite');
+
+    const first = await handler(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'getLogs',
+      view: 'failures',
+    });
+    const firstText = parseText(first);
+    expect(firstText.entries).toHaveLength(100);
+    expect(firstText.hasMore).toBe(true);
+    expect(firstText.nextCursor).toEqual(expect.any(String));
+
+    const crossView = await handler(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'getLogs',
+      view: 'all',
+      limit: 100,
+      cursor: firstText.nextCursor,
+    });
+    expect(crossView.isError).toBe(true);
+    expect(parseText(crossView).error.code).toBe('stale_cursor');
+  });
+
+  test('network filtered limit validates finite non-negative integers and zero returns all matches', async () => {
+    seedNetwork(
+      page,
+      Array.from({ length: 3 }, (_, i) => networkEntry(i + 1, { status: 500 })),
+      'lite',
+    );
+    const handler = createNetworkCaptureHandler('lite');
+
+    for (const limit of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const result = await handler(SESSION_ID, {
+        tabId: TAB_ID,
+        action: 'getLogs',
+        view: 'failures',
+        limit,
+      });
+      expect(result.isError).toBe(true);
+      expect(parseText(result).error.code).toBe('invalid_limit');
+    }
+
+    const all = await handler(SESSION_ID, {
+      tabId: TAB_ID,
+      action: 'getLogs',
+      view: 'failures',
+      limit: 0,
+    });
+    expect(parseText(all).entries).toHaveLength(3);
+  });
+});

--- a/tests/tools/console-capture-regression.test.ts
+++ b/tests/tools/console-capture-regression.test.ts
@@ -212,4 +212,19 @@ describe('console_capture cursor pagination (#881)', () => {
     expect(stale.staleCursor).toBe(true);
     expect(stale.logs).toEqual([]);
   });
+
+  test('binds filtered console cursors to the selected view', async () => {
+    const { buildConsoleCapturePagination } = await import('../../src/tools/console-capture');
+    const logs = deduplicateLogs(buildFrozenLogs());
+    const first = buildConsoleCapturePagination(logs, { pageSize: 50, view: 'problems' });
+
+    const crossView = buildConsoleCapturePagination(logs, {
+      pageSize: 50,
+      cursor: first.nextCursor,
+      view: 'errors',
+    });
+
+    expect(crossView.staleCursor).toBe(true);
+    expect(crossView.logs).toEqual([]);
+  });
 });

--- a/tests/tools/network-capture-pagination.test.ts
+++ b/tests/tools/network-capture-pagination.test.ts
@@ -55,4 +55,18 @@ describe('network_capture cursor pagination (#881)', () => {
     expect(result.invalidCursor).toBeDefined();
     expect(result.entries).toEqual([]);
   });
+
+  test('binds filtered network cursors to the selected view', () => {
+    const entries = Array.from({ length: 25 }, (_, i) => entry(i));
+    const first = paginateNetworkCaptureEntries(entries, { pageSize: 10, view: 'failures' });
+
+    const crossView = paginateNetworkCaptureEntries(entries, {
+      pageSize: 10,
+      cursor: first.nextCursor,
+      view: 'all',
+    });
+
+    expect(crossView.staleCursor).toBe(true);
+    expect(crossView.entries).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Why

`browserbase/stagehand#2373` demonstrates a useful deterministic pattern: retain the raw browser event stream, then provide an opt-in no-LLM view containing only console problems and network failures. That reduces host token use and diagnostic tool calls without discarding evidence.

OpenChrome should absorb that retrieval pattern, not Stagehand's hosted Browserbase assumptions, server-owned `agent()` loop, external model dependency, or multi-step agent cache replay. OpenChrome already owns the better-fitting primitives: local real-Chrome capture buffers, MCP pagination, evidence bundles, journals, host-mediated sampling, and guarded action-cache behavior.

## Direction fit

This advances SSOT #1359 while preserving OpenChrome's identity:

- Host-neutral MCP: the capability lives on the existing console and network tools.
- Harness, not agent: OpenChrome classifies browser facts; the host decides root cause and remediation.
- Real Chrome evidence: filtered reads never mutate or replace the retained raw capture.
- Facts before decisions: classification uses console type, HTTP status, and request-failure facts only.
- Zero-impact default: omitted `view` and explicit `view: "all"` use the legacy response paths and hashes.
- No tool or dependency growth.

## What changed

- `console_capture get`
  - adds `view: "all" | "problems" | "errors"`
  - filters the complete retained snapshot before deduplication and pagination
  - returns filtered results newest-first
  - reports retained, classified, matched, and returned counts
- `network_capture_lite/full getLogs`
  - adds `view: "all" | "failures"`
  - includes HTTP 4xx/5xx and non-canceled request failures
  - excludes normal canceled requests, unfinished requests, and body-fetch-only omissions
- Filtered views
  - use deterministic default page sizes of 200 console records and 100 network records
  - treat `limit: 0` as all matches
  - reject invalid views and limits without widening results
  - bind cursors to the selected view and ordering version
- Documentation
  - updates the pagination contract
  - adds a high-signal browser diagnostics recipe

## Compatibility

- Omitted `view` and `view: "all"` are covered by exact-equivalence handler tests.
- Existing legacy cursor hashes remain unchanged.
- Capture-start filters, retention limits, buffer contents, and stop behavior are unchanged.

## Review

An independent review first found three gaps: invalid views could widen to `all`, stale-cursor documentation did not match the shipped tool-error channel, and exception/dedup boundaries needed stronger tests. Those were fixed.

A final review then found filtered `limit` validation occurred after inactive-capture and network mode checks. Validation was moved ahead of those branches and regression coverage was added. The final re-review verdict was **APPROVE** with no code findings.

## Validation

Post-fix and post-rebase validation on `develop`:

- `npm test -- --runInBand --testTimeout=30000 tests/tools/capture-high-signal-views.test.ts tests/tools/console-capture-regression.test.ts tests/tools/network-capture-pagination.test.ts` (28/28 passed)
- `npm run build`
- `npm run lint`
- `npm run lint:tier` (0 dependency violations)
- `npm run lint:tool-schemas` (0 new violations)
- `npm run docs:capability-map:check`
- `git diff --check`

A full pre-final-fix suite run completed 621 passing suites, 3 skipped suites, and one unrelated `tests/auth/twofa-handler.test.ts` timing failure. That test passed 12/12 immediately in isolation. The final validation-order-only fix is covered by the 28 focused post-rebase tests above.

Live Chrome fixture verification remains a follow-up validation gap; the implementation tests exercise the real tool handlers, CDP exception normalization, retained-buffer ordering, classification boundaries, pagination, counts, and stale cursors.

Closes #1566
