### PR TITLE
feat(interact): report opener-correlated tabs without changing focus

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -37,6 +37,7 @@ import { getIdleState } from '../utils/idle-state';
 import { assertDomainAllowed, isInternalBrowserUrl } from '../security/domain-guard';
 import { applyRegisteredPreloads } from './preload-injector';
 import { TargetPageIndex } from './target-page-index';
+import { safeTitle } from '../utils/safe-title';
 
 // Cookie type shared across methods
 type CookieEntry = {
@@ -819,20 +820,30 @@ export class CDPClient {
       // Inbound CDP event — reset idle window (issue #649 Part A).
       getIdleState().notifyActive();
       if (target.type() !== 'page') return;
+      const targetId = getTargetId(target);
+      const { getSessionManager } = await import('../session-manager');
+      const sessionManager = getSessionManager();
+      const trackedPopup = targetId ? sessionManager.hasTargetCreationRecord(targetId) : false;
       const url = target.url();
       if (!isInternalBrowserUrl(url)) {
         try {
           assertDomainAllowed(url);
         } catch (err) {
-          const targetId = getTargetId(target);
           if (targetId) {
+            if (trackedPopup) sessionManager.markPopupTargetBlocked(targetId);
             await this.closePage(targetId).catch(() => {});
           }
           console.error(`[CDPClient] Blocked changed target by domain policy (URL: ${url}): ${err instanceof Error ? err.message : String(err)}`);
           return;
         }
       }
-      const targetId = getTargetId(target);
+      if (trackedPopup && !isInternalBrowserUrl(url)) {
+        sessionManager.markPopupTargetReady(targetId, { url });
+        const page = await target.page().catch(() => null);
+        if (page) {
+          sessionManager.markPopupTargetReady(targetId, { title: await safeTitle(page) });
+        }
+      }
       if (this.targetIdIndex.has(targetId)) {
         console.error(`[CDPClient] Target changed: ${targetId}`);
       }
@@ -853,61 +864,94 @@ export class CDPClient {
       // Only track 'page' type targets (skip service_worker, browser, etc.)
       if (target.type() !== 'page') return;
 
+      const targetId = getTargetId(target);
+      if (!targetId) return;
+
       const url = target.url();
-      // New Chrome pages are commonly born as about:blank before createPage()
-      // or popup scripts navigate them. Do not close these provisional targets;
-      // targetchanged enforces the allowlist once they reach a real URL.
-      if (isInternalBrowserUrl(url)) return;
-      try {
-        assertDomainAllowed(url);
-      } catch (err) {
-        const targetId = getTargetId(target);
-        if (targetId) {
+      const provisional = url === '' || url === 'about:blank';
+      if (isInternalBrowserUrl(url) && !provisional) return;
+
+      if (!provisional) {
+        try {
+          assertDomainAllowed(url);
+        } catch (err) {
+          const blockedOpener = target.opener();
+          const blockedOpenerTargetId = blockedOpener ? getTargetId(blockedOpener) : '';
+          if (blockedOpenerTargetId) {
+            const { getSessionManager } = await import('../session-manager');
+            const sessionManager = getSessionManager();
+            if (sessionManager.getTargetOwner(blockedOpenerTargetId)) {
+              await sessionManager.registerPopupTarget(targetId, blockedOpenerTargetId, { state: 'blocked' });
+            }
+          }
           await this.closePage(targetId).catch(() => {});
+          console.error(`[CDPClient] Blocked popup target by domain policy (URL: ${url}): ${err instanceof Error ? err.message : String(err)}`);
+          return;
         }
-        console.error(`[CDPClient] Blocked popup target by domain policy (URL: ${url}): ${err instanceof Error ? err.message : String(err)}`);
-        return;
       }
-      // Filter out Chrome internal pages and blank pages
-      // Check if this target was opened by a tracked page (popup/window.open)
+
       const opener = target.opener();
       if (!opener) return; // Not a popup - skip to avoid ghost tabs
-
-      // Get the opener's target ID to check if it's managed
       const openerTargetId = getTargetId(opener);
       if (!openerTargetId) return;
 
       // Check if opener is managed by SessionManager (dynamic import to avoid circular dep)
       const { getSessionManager } = await import('../session-manager');
       const sessionManager = getSessionManager();
-      const ownerInfo = sessionManager.getTargetOwner(openerTargetId);
-      if (!ownerInfo) return; // Opener not tracked, skip
+      if (!sessionManager.getTargetOwner(openerTargetId)) return;
 
-      // This is a popup from a managed page - track it
-      const targetId = getTargetId(target);
-      if (!targetId) return;
-
-      // Register in the same worker as opener and inherit the opener's
-      // named-context mapping (#848 Codex P1) so popups count toward the
-      // same context's tab total instead of slipping into the default.
-      await sessionManager.registerExternalTarget(targetId, ownerInfo.sessionId, ownerInfo.workerId, {
-        inheritContextFromTargetId: openerTargetId,
+      // Register in the same worker as opener and inherit its named context.
+      // Managed blank targets remain provisional until targetchanged observes
+      // an allowed non-internal URL.
+      const registered = await sessionManager.registerPopupTarget(targetId, openerTargetId, {
+        state: provisional ? 'provisional' : 'ready',
+        ...(!provisional && { url }),
       });
+      if (!registered) {
+        await this.closePage(targetId).catch(() => {});
+        return;
+      }
 
       // target.page() can race with target close — keep the inner try/catch
       // as a localized best-effort, but any *other* failure in this handler
       // now surfaces via safeAsyncListener → openchrome_listener_errors_total.
+      let popupPage: Page | null = null;
       try {
-        const page = await target.page();
-        if (page) {
-          this.targetIdIndex.set(targetId, page);
-          this.touchTargetActivity(targetId);
-          this.configurePageDefenses(page);
-          await applyRegisteredPreloads(page);
-          console.error(`[CDPClient] Indexed popup target ${targetId} (URL: ${url})`);
+        popupPage = await target.page();
+        if (!popupPage) {
+          sessionManager.onTargetClosed(targetId);
+          return;
         }
+
+        const page = popupPage;
+        this.targetIdIndex.set(targetId, page);
+        this.touchTargetActivity(targetId);
+        this.configurePageDefenses(page);
+        await applyRegisteredPreloads(page);
+
+        const currentUrl = page.url();
+        if (!isInternalBrowserUrl(currentUrl)) {
+          try {
+            assertDomainAllowed(currentUrl);
+            sessionManager.markPopupTargetReady(targetId, { url: currentUrl });
+            sessionManager.markPopupTargetReady(targetId, { title: await safeTitle(page) });
+          } catch (err) {
+            sessionManager.markPopupTargetBlocked(targetId);
+            await this.closePage(targetId).catch(() => {});
+            console.error(`[CDPClient] Blocked popup target after registration (URL: ${currentUrl}): ${err instanceof Error ? err.message : String(err)}`);
+            return;
+          }
+        }
+        console.error(`[CDPClient] Indexed popup target ${targetId} (URL: ${currentUrl})`);
       } catch {
-        // Target may have already closed — expected race, not an error.
+        // A close race keeps ready-then-closed evidence. A live-page
+        // initialization failure is fail-closed and must not confirm success.
+        if (popupPage && !popupPage.isClosed()) {
+          sessionManager.markPopupTargetBlocked(targetId);
+        }
+        await this.closePage(targetId).catch(() => {});
+        this.targetIdIndex.delete(targetId);
+        sessionManager.evictTarget(targetId, 'listener_error');
       }
     }, (_err, args) => {
       const target = args[0];
@@ -915,7 +959,10 @@ export class CDPClient {
       if (!targetId) return;
       import('../session-manager')
         .then(({ getSessionManager }) => {
-          getSessionManager().evictTarget(targetId, 'listener_error');
+          const sessionManager = getSessionManager();
+          sessionManager.markPopupTargetBlocked(targetId);
+          sessionManager.evictTarget(targetId, 'listener_error');
+          return this.closePage(targetId).catch(() => {});
         })
         .catch(() => {
           // best-effort cleanup only

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -9,6 +9,11 @@ import { Session, SessionInfo, SessionCreateOptions, SessionEvent, Worker, Worke
 import { TargetOwnershipRegistry } from './session/target-registry';
 import { TargetLeaseConflictError, TargetLeaseRegistry, type TargetLeaseRecord } from './session/target-lease-registry';
 import { TargetQueueManager } from './session/target-command-queue';
+import {
+  TargetCreationLedger,
+  type OpenedTabFact,
+  type TargetCreationQueryResult,
+} from './session/target-creation-ledger';
 import { CDPClient, getCDPClient, CDPClientFactory, getCDPClientFactory } from './cdp/client';
 import { CDPConnectionPool, getCDPConnectionPool, PoolStats } from './cdp/connection-pool';
 import { ChromePool, getChromePool } from './chrome/pool';
@@ -104,6 +109,17 @@ export interface SessionManagerStats {
   connectionPool?: PoolStats;
 }
 
+export interface ExternalTargetRegistrationOptions {
+  inheritContextFromTargetId?: string;
+  openerTargetId?: string;
+}
+
+export interface PopupTargetRegistrationOptions {
+  state: 'provisional' | 'ready' | 'blocked';
+  url?: string;
+  title?: string;
+}
+
 const DEFAULT_CONFIG: Required<Omit<SessionManagerConfig, 'tenantManager' | 'strictTenantIsolation'>> = {
   sessionTTL: 30 * 60 * 1000,      // 30 minutes
   cleanupInterval: 60 * 1000,       // 1 minute
@@ -140,6 +156,8 @@ export class SessionManager {
   private cdpFactory: CDPClientFactory;
   private queueManager: RequestQueueManager;
   private targetQueueManager = new TargetQueueManager();
+  private targetCreationLedger = new TargetCreationLedger();
+  private targetLifecycleClients = new WeakSet<CDPClient>();
   private eventListeners: ((event: SessionEvent) => void)[] = [];
   private browserRouter: BrowserRouter | null = null;
   /**
@@ -159,7 +177,9 @@ export class SessionManager {
   private storageStateManagers = new Map<string, StorageStateManager>();
   private storageStateConfig: StorageStateConfig | null = null;
   private pendingCreations = new Map<string, Promise<Session>>();
-  private externalTargetRegistrationLocks = new Map<string, Promise<void>>();
+  private externalTargetRegistrationLocks = new Map<string, Promise<boolean>>();
+  private deletingSessions = new Set<string>();
+  private deletingWorkers = new Set<string>();
 
   // Stealth mode tracking — targets opened via createTargetStealth
   private stealthTargets = new Set<string>();
@@ -197,10 +217,7 @@ export class SessionManager {
       this.startAutoCleanup();
     }
 
-    // Register target destroyed listener
-    this.cdpClient.addTargetDestroyedListener((targetId) => {
-      this.onTargetClosed(targetId);
-    });
+    this.bindTargetLifecycle(this.cdpClient);
 
     // Validate stale targets after reconnection
     this.cdpClient.addConnectionListener((event) => {
@@ -250,6 +267,14 @@ export class SessionManager {
     try { return new URL(url).origin; } catch { return undefined; }
   }
 
+  private bindTargetLifecycle(client: CDPClient): void {
+    if (this.targetLifecycleClients.has(client)) return;
+    this.targetLifecycleClients.add(client);
+    client.addTargetDestroyedListener((targetId) => {
+      this.onTargetClosed(targetId);
+    });
+  }
+
   /**
    * Get the CDPClient for a specific worker (may be on a different Chrome instance)
    */
@@ -257,8 +282,12 @@ export class SessionManager {
     const worker = this.getWorker(sessionId, workerId);
     if (worker?.port) {
       const client = this.cdpFactory.get(worker.port);
-      if (client) return client;
+      if (client) {
+        this.bindTargetLifecycle(client);
+        return client;
+      }
     }
+    this.bindTargetLifecycle(this.cdpClient);
     return this.cdpClient;
   }
 
@@ -310,6 +339,32 @@ export class SessionManager {
 
   getTargetQueueStats(): ReturnType<TargetQueueManager['getStats']> {
     return this.targetQueueManager.getStats();
+  }
+
+  getTargetCreationCursor(): number {
+    return this.targetCreationLedger.getCursor();
+  }
+
+  hasTargetCreationRecord(targetId: string): boolean {
+    return this.targetCreationLedger.has(targetId);
+  }
+
+  markPopupTargetReady(targetId: string, metadata: { url?: string; title?: string }): boolean {
+    return this.targetCreationLedger.markReady(targetId, metadata);
+  }
+
+  markPopupTargetBlocked(targetId: string): boolean {
+    return this.targetCreationLedger.markBlocked(targetId);
+  }
+
+  getOpenedTabsAfter(input: {
+    afterSequence: number;
+    sessionId: string;
+    workerId: string;
+    openerTargetId: string;
+    limit?: number;
+  }): TargetCreationQueryResult & { tabs: OpenedTabFact[] } {
+    return this.targetCreationLedger.query(input);
   }
 
   getTargetDiagnostics(tenantId: TenantId = DEFAULT_TENANT_ID): { leases: Array<Record<string, unknown>>; queues: Array<Record<string, unknown>> } {
@@ -640,6 +695,7 @@ export class SessionManager {
     if (!session) {
       return;
     }
+    this.deletingSessions.add(sessionId);
 
     // Save storage state before cleanup (save first, then stop watchdog).
     // #848: flush ONE representative tab per named context so per-context
@@ -680,10 +736,12 @@ export class SessionManager {
 
     // Clean up ref IDs
     getRefIdManager().clearSessionRefs(sessionId);
+    this.targetCreationLedger.clearSession(sessionId);
 
     // Remove session
     this.sessions.delete(sessionId);
     this.targetLeases.releaseSession(sessionId);
+    this.deletingSessions.delete(sessionId);
     this.emitEvent({ type: 'session:deleted', sessionId, timestamp: Date.now() });
     this.emitLifecycle({ kind: 'session:destroy', sessionId, reason, ts: Date.now() });
 
@@ -820,6 +878,7 @@ export class SessionManager {
         const workerCdpClient = this.cdpFactory.getOrCreate(workerPort, {
           autoLaunch: getGlobalConfig().autoLaunch,
         });
+        this.bindTargetLifecycle(workerCdpClient);
         if (!workerCdpClient.isConnected()) {
           await workerCdpClient.connect();
         }
@@ -836,6 +895,7 @@ export class SessionManager {
         const workerCdpClient = this.cdpFactory.getOrCreate(workerPort, {
           autoLaunch: false,
         });
+        this.bindTargetLifecycle(workerCdpClient);
         if (!workerCdpClient.isConnected()) {
           await workerCdpClient.connect();
         }
@@ -856,6 +916,7 @@ export class SessionManager {
           const workerCdpClient = this.cdpFactory.getOrCreate(workerPort, {
             autoLaunch: getGlobalConfig().autoLaunch,
           });
+          this.bindTargetLifecycle(workerCdpClient);
           if (!workerCdpClient.isConnected()) {
             await workerCdpClient.connect();
           }
@@ -1000,6 +1061,8 @@ export class SessionManager {
   private async deleteWorkerInternal(session: Session, workerId: string): Promise<void> {
     const worker = session.workers.get(workerId);
     if (!worker) return;
+    const deletionKey = `${session.id}:${workerId}`;
+    this.deletingWorkers.add(deletionKey);
 
     // Determine which CDPClient to use for this worker
     const workerCdpClient = worker.port
@@ -1055,7 +1118,9 @@ export class SessionManager {
       getRefIdManager().clearTargetRefs(session.id, targetId);
     }
 
+    this.targetCreationLedger.clearWorker(session.id, workerId);
     session.workers.delete(workerId);
+    this.deletingWorkers.delete(deletionKey);
     console.error(`[SessionManager] Deleted worker ${workerId} from session ${session.id}`);
   }
 
@@ -1614,11 +1679,66 @@ export class SessionManager {
    */
   async registerHeadedPage(targetId: string, sessionId: string, workerId: string, page: Page): Promise<void> {
     // Register target ownership (no parent — headed pages are top-level navigations).
-    await this.registerExternalTarget(targetId, sessionId, workerId);
+    const registered = await this.registerExternalTarget(targetId, sessionId, workerId);
+    if (!registered) return;
 
     // Inject the page into the main CDPClient's index so getPageByTargetId()
     // returns it and the stale-target guards in getCDPSession()/send() pass.
     this.cdpClient.indexExternalPage(targetId, page);
+  }
+
+  /**
+   * Register a page target opened by an already-managed opener.
+   *
+   * The opener owner and creation sequence are captured synchronously before
+   * the worker-level registration lock is awaited. Registration later
+   * revalidates the opener so a close/delete race cannot transfer the child to
+   * an unrelated owner.
+   */
+  async registerPopupTarget(
+    targetId: string,
+    openerTargetId: string,
+    options: PopupTargetRegistrationOptions,
+  ): Promise<boolean> {
+    const ownerInfo = this.targetToWorker.get(openerTargetId);
+    if (!ownerInfo) return false;
+    if (
+      this.deletingSessions.has(ownerInfo.sessionId) ||
+      this.deletingWorkers.has(`${ownerInfo.sessionId}:${ownerInfo.workerId}`)
+    ) return false;
+
+    this.targetCreationLedger.register({
+      targetId,
+      sessionId: ownerInfo.sessionId,
+      workerId: ownerInfo.workerId,
+      openerTargetId,
+      state: options.state,
+      url: options.url,
+      title: options.title,
+      ownershipCommitted: false,
+    });
+
+    if (options.state === 'blocked') return false;
+
+    const registered = await this.registerExternalTarget(
+      targetId,
+      ownerInfo.sessionId,
+      ownerInfo.workerId,
+      {
+        inheritContextFromTargetId: openerTargetId,
+        openerTargetId,
+      },
+    );
+    if (!registered) {
+      this.targetCreationLedger.markBlocked(targetId);
+      return false;
+    }
+
+    if (!this.targetCreationLedger.markOwnershipCommitted(targetId)) {
+      this.onTargetClosed(targetId);
+      return false;
+    }
+    return true;
   }
 
   /**
@@ -1635,17 +1755,17 @@ export class SessionManager {
     targetId: string,
     sessionId: string,
     workerId: string,
-    opts?: { inheritContextFromTargetId?: string },
-  ): Promise<void> {
+    opts?: ExternalTargetRegistrationOptions,
+  ): Promise<boolean> {
     const lockKey = `${sessionId}:${workerId}`;
-    const previous = this.externalTargetRegistrationLocks.get(lockKey) ?? Promise.resolve();
-    const next = previous.catch(() => undefined).then(() =>
+    const previous = this.externalTargetRegistrationLocks.get(lockKey) ?? Promise.resolve(false);
+    const next = previous.catch(() => false).then(() =>
       this.registerExternalTargetLocked(targetId, sessionId, workerId, opts),
     );
 
     this.externalTargetRegistrationLocks.set(lockKey, next);
     try {
-      await next;
+      return await next;
     } finally {
       if (this.externalTargetRegistrationLocks.get(lockKey) === next) {
         this.externalTargetRegistrationLocks.delete(lockKey);
@@ -1657,16 +1777,35 @@ export class SessionManager {
     targetId: string,
     sessionId: string,
     workerId: string,
-    opts?: { inheritContextFromTargetId?: string },
-  ): Promise<void> {
+    opts?: ExternalTargetRegistrationOptions,
+  ): Promise<boolean> {
+    if (this.deletingSessions.has(sessionId) || this.deletingWorkers.has(`${sessionId}:${workerId}`)) {
+      return false;
+    }
+    if (opts?.openerTargetId && !this.targetCreationLedger.canCommitOwnership(targetId)) {
+      return false;
+    }
     // Don't overwrite existing entries
-    if (this.targetToWorker.has(targetId)) return;
+    const existingOwner = this.targetToWorker.get(targetId);
+    if (existingOwner) {
+      return existingOwner.sessionId === sessionId && existingOwner.workerId === workerId;
+    }
 
     const session = this.sessions.get(sessionId);
-    if (!session) return;
+    if (!session) return false;
 
     const worker = session.workers.get(workerId);
-    if (!worker) return;
+    if (!worker) return false;
+
+    if (opts?.openerTargetId) {
+      const openerOwner = this.targetToWorker.get(opts.openerTargetId);
+      if (openerOwner?.sessionId !== sessionId || openerOwner.workerId !== workerId) return false;
+      if (!this.targetCreationLedger.canCommitOwnership(targetId)) return false;
+    }
+
+    const inheritedContext = opts?.inheritContextFromTargetId
+      ? this.targetToContext.get(opts.inheritContextFromTargetId)
+      : undefined;
 
     // Enforce per-worker tab limit for externally-created targets too
     // (popups, headed fallback pages, and other out-of-band registrations).
@@ -1675,11 +1814,24 @@ export class SessionManager {
     // wrapper serializes this block per worker so concurrent popups cannot all
     // close the same oldest target and then overfill the worker.
     if (worker.targets.size >= this.config.maxTargetsPerWorker) {
-      const oldestTargetId = worker.targets.values().next().value;
+      const oldestTargetId = Array.from(worker.targets).find((candidate) => candidate !== opts?.openerTargetId);
       if (oldestTargetId) {
         console.error(`[SessionManager] Worker ${worker.id} reached tab limit (${this.config.maxTargetsPerWorker}), closing oldest external tab ${oldestTargetId}`);
         await this.closeTarget(sessionId, oldestTargetId);
+      } else {
+        return false;
       }
+    }
+
+    if (
+      this.deletingSessions.has(sessionId) ||
+      this.deletingWorkers.has(`${sessionId}:${workerId}`) ||
+      this.sessions.get(sessionId) !== session ||
+      session.workers.get(workerId) !== worker
+    ) return false;
+    if (opts?.openerTargetId) {
+      const openerOwner = this.targetToWorker.get(opts.openerTargetId);
+      if (openerOwner?.sessionId !== sessionId || openerOwner.workerId !== workerId) return false;
     }
 
     worker.targets.add(targetId);
@@ -1690,12 +1842,9 @@ export class SessionManager {
     // #848 Codex P1: inherit named-context mapping from the opener so popup
     // tab accounting matches the parent. Skip when the parent lives in the
     // default BrowserContext (no entry in `targetToContext`).
-    if (opts?.inheritContextFromTargetId) {
-      const parent = this.targetToContext.get(opts.inheritContextFromTargetId);
-      if (parent) {
-        this.targetToContext.set(targetId, { browser: parent.browser, name: parent.name });
-        this.namedContextRegistry.incrementTabCount(parent.browser, parent.name);
-      }
+    if (inheritedContext) {
+      this.targetToContext.set(targetId, { browser: inheritedContext.browser, name: inheritedContext.name });
+      this.namedContextRegistry.incrementTabCount(inheritedContext.browser, inheritedContext.name);
     }
 
     this.emitEvent({
@@ -1709,6 +1858,7 @@ export class SessionManager {
 
     this.touchSession(sessionId);
     console.error(`[SessionManager] Registered external target ${targetId} in worker ${workerId} of session ${sessionId}`);
+    return true;
   }
 
   /**
@@ -1725,6 +1875,7 @@ export class SessionManager {
     }
 
     try {
+      this.targetCreationLedger.markClosed(targetId);
       // Close the page via CDP (use worker's CDPClient if on pool)
       const cdpClient = this.getCDPClientForWorker(sessionId, ownerInfo.workerId);
 
@@ -1812,6 +1963,30 @@ export class SessionManager {
   }
 
   /**
+   * Serialize an arbitrary mutation/observation window for one managed target.
+   * Different target IDs retain independent queues and continue in parallel.
+   */
+  async runTargetExclusive<T>(
+    sessionId: string,
+    targetId: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    if (!this.validateTargetOwnership(sessionId, targetId)) {
+      throw new Error(this.buildStaleTargetError(sessionId, targetId));
+    }
+
+    this.touchSession(sessionId);
+    this.targetLeases.touch(targetId);
+
+    return this.targetQueueManager.enqueue(targetId, async () => {
+      if (!this.validateTargetOwnership(sessionId, targetId)) {
+        throw new Error(this.buildStaleTargetError(sessionId, targetId));
+      }
+      return fn();
+    });
+  }
+
+  /**
    * Execute a CDP command through the session's queue
    */
   async executeCDP<T = unknown>(
@@ -1820,21 +1995,11 @@ export class SessionManager {
     method: string,
     params?: Record<string, unknown>
   ): Promise<T> {
-    if (!this.validateTargetOwnership(sessionId, targetId)) {
-      throw new Error(this.buildStaleTargetError(sessionId, targetId));
-    }
-
-    this.touchSession(sessionId);
-    // Slide the target lease forward on activity so an actively used tab is never
-    // reclaimed by the idle-TTL sweep (#1359 backlog item 7).
-    this.targetLeases.touch(targetId);
-
-    const ownerInfo = this.targetToWorker.get(targetId);
-    const cdpClient = ownerInfo
-      ? this.getCDPClientForWorker(sessionId, ownerInfo.workerId)
-      : this.cdpClient;
-
-    return this.targetQueueManager.enqueue(targetId, async () => {
+    return this.runTargetExclusive(sessionId, targetId, async () => {
+      const ownerInfo = this.targetToWorker.get(targetId);
+      const cdpClient = ownerInfo
+        ? this.getCDPClientForWorker(sessionId, ownerInfo.workerId)
+        : this.cdpClient;
       const page = await cdpClient.getPageByTargetId(targetId);
       if (!page) {
         throw new Error(`Page not found for target ${targetId}`);
@@ -1848,9 +2013,10 @@ export class SessionManager {
    */
   onTargetClosed(targetId: string): void {
     flushRecorderBuffer(targetId);
+    this.targetCreationLedger.markClosed(targetId);
     const ownerInfo = this.targetToWorker.get(targetId);
+    const session = ownerInfo ? this.sessions.get(ownerInfo.sessionId) : undefined;
     if (ownerInfo) {
-      const session = this.sessions.get(ownerInfo.sessionId);
       if (session) {
         const worker = session.workers.get(ownerInfo.workerId);
         if (worker) {
@@ -1859,23 +2025,6 @@ export class SessionManager {
 
         // Clean up ref IDs before removing from targetToWorker mapping
         getRefIdManager().clearTargetRefs(ownerInfo.sessionId, targetId);
-
-        this.targetToWorker.delete(targetId);
-        this.targetLeases.release(targetId, ownerInfo.sessionId);
-        this.targetQueueManager.cancelTarget(targetId);
-        this.stealthTargets.delete(targetId);
-        this.lastRoutingByTarget.delete(targetId);
-
-        // #848: drop the named-context association and let the registry
-        // GC the BrowserContext when the last tab closes AND no
-        // oc_session_resume token still pins it.
-        const ctxEntry = this.targetToContext.get(targetId);
-        if (ctxEntry) {
-          this.targetToContext.delete(targetId);
-          this.namedContextRegistry.decrementTabCount(ctxEntry.browser, ctxEntry.name).catch((err) => {
-            console.error(`[SessionManager] decrementTabCount(${ctxEntry.name}) failed:`, err);
-          });
-        }
 
         this.emitEvent({
           type: 'session:target-removed',
@@ -1886,6 +2035,22 @@ export class SessionManager {
         });
         this.emitLifecycle({ kind: 'target:close', sessionId: ownerInfo.sessionId, workerId: ownerInfo.workerId, targetId, ts: Date.now() });
       }
+    }
+
+    this.targetToWorker.delete(targetId);
+    this.targetLeases.release(targetId, ownerInfo?.sessionId);
+    this.targetQueueManager.cancelTarget(targetId);
+    this.stealthTargets.delete(targetId);
+    this.lastRoutingByTarget.delete(targetId);
+
+    // #848: drop the named-context association and let the registry GC the
+    // BrowserContext when the last tab closes and no resume token pins it.
+    const ctxEntry = this.targetToContext.get(targetId);
+    if (ctxEntry) {
+      this.targetToContext.delete(targetId);
+      this.namedContextRegistry.decrementTabCount(ctxEntry.browser, ctxEntry.name).catch((err) => {
+        console.error(`[SessionManager] decrementTabCount(${ctxEntry.name}) failed:`, err);
+      });
     }
   }
 
@@ -2083,6 +2248,7 @@ export class SessionManager {
         // Update targetToWorker mapping
         this.targetToWorker.delete(targetId);
         this.targetToWorker.set(newTargetId, ownerInfo);
+        this.targetCreationLedger.remapTargetId(targetId, newTargetId);
         // #1359 backlog item 3: reconcileAliveTargetIds above already dropped
         // the old targetId from the lease registry. Acquire a fresh lease
         // for the re-mapped targetId so diagnostics and cleanup observe the
@@ -2116,6 +2282,7 @@ export class SessionManager {
       this.onTargetClosed(targetId);
       removed++;
     }
+    this.targetCreationLedger.reconcileAliveTargetIds(aliveTargetIds);
 
     // Rebuild the CDP client's targetIdIndex from surviving targets.
     // The index was cleared during disconnect (handleDisconnect / forceReconnect)

--- a/src/session/target-creation-ledger.ts
+++ b/src/session/target-creation-ledger.ts
@@ -1,0 +1,315 @@
+export type TargetCreationState = 'provisional' | 'ready' | 'blocked' | 'closed';
+
+export interface TargetCreationRegistration {
+  targetId: string;
+  sessionId: string;
+  workerId: string;
+  openerTargetId: string;
+  state: Exclude<TargetCreationState, 'closed'>;
+  url?: string;
+  title?: string;
+  createdAt?: number;
+  ownershipCommitted?: boolean;
+}
+
+export interface TargetCreationRecord {
+  sequence: number;
+  targetId: string;
+  sessionId: string;
+  workerId: string;
+  openerTargetId: string;
+  currentOpenerTargetId: string;
+  state: TargetCreationState;
+  url: string;
+  title: string;
+  createdAt: number;
+  ownershipCommittedAt?: number;
+  readyAt?: number;
+  blockedAt?: number;
+  closedAt?: number;
+}
+
+export interface OpenedTabFact {
+  tabId: string;
+  workerId: string;
+  url: string;
+  title: string;
+  status: 'ready' | 'closed';
+}
+
+export interface TargetCreationQuery {
+  afterSequence: number;
+  sessionId: string;
+  workerId: string;
+  openerTargetId: string;
+  limit?: number;
+}
+
+export interface TargetCreationQueryResult {
+  total: number;
+  truncated: boolean;
+  pendingCount: number;
+  tabs: OpenedTabFact[];
+}
+
+const DEFAULT_MAX_RECORDS = 2048;
+const MAX_URL_LENGTH = 2048;
+const MAX_TITLE_LENGTH = 200;
+const MAX_ID_LENGTH = 128;
+
+function sanitizeText(value: string | undefined, maxLength: number): string {
+  if (!value) return '';
+  return value
+    .replace(/[\u0000-\u001f\u007f-\u009f]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, maxLength);
+}
+
+export function sanitizeTargetUrl(value: string | undefined): string {
+  const cleaned = sanitizeText(value, MAX_URL_LENGTH * 2);
+  if (!cleaned) return '';
+  try {
+    const parsed = new URL(cleaned);
+    parsed.username = '';
+    parsed.password = '';
+    parsed.hash = '';
+    return parsed.toString().slice(0, MAX_URL_LENGTH);
+  } catch {
+    return cleaned.split('#', 1)[0].slice(0, MAX_URL_LENGTH);
+  }
+}
+
+export function sanitizeTargetTitle(value: string | undefined): string {
+  return sanitizeText(value, MAX_TITLE_LENGTH);
+}
+
+export class TargetCreationLedger {
+  private readonly records = new Map<number, TargetCreationRecord>();
+  private readonly targetToSequence = new Map<string, number>();
+  private sequence = 0;
+
+  constructor(private readonly maxRecords = DEFAULT_MAX_RECORDS) {
+    if (!Number.isInteger(maxRecords) || maxRecords < 1) {
+      throw new Error('TargetCreationLedger maxRecords must be a positive integer');
+    }
+  }
+
+  getCursor(): number {
+    return this.sequence;
+  }
+
+  get size(): number {
+    return this.records.size;
+  }
+
+  has(targetId: string): boolean {
+    return this.targetToSequence.has(targetId);
+  }
+
+  get(targetId: string): TargetCreationRecord | undefined {
+    const sequence = this.targetToSequence.get(targetId);
+    const record = sequence === undefined ? undefined : this.records.get(sequence);
+    return record ? { ...record } : undefined;
+  }
+
+  register(input: TargetCreationRegistration): TargetCreationRecord {
+    const existing = this.get(input.targetId);
+    if (existing) {
+      if (input.state === 'ready') {
+        this.markReady(input.targetId, { url: input.url, title: input.title }, input.createdAt);
+      } else if (input.state === 'blocked') {
+        this.markBlocked(input.targetId, input.createdAt);
+      }
+      return this.get(input.targetId)!;
+    }
+
+    const createdAt = input.createdAt ?? Date.now();
+    const sequence = ++this.sequence;
+    const record: TargetCreationRecord = {
+      sequence,
+      targetId: input.targetId,
+      sessionId: input.sessionId,
+      workerId: input.workerId,
+      openerTargetId: input.openerTargetId,
+      currentOpenerTargetId: input.openerTargetId,
+      state: input.state,
+      url: input.state === 'ready' ? sanitizeTargetUrl(input.url) : '',
+      title: input.state === 'ready' ? sanitizeTargetTitle(input.title) : '',
+      createdAt,
+      ...(input.ownershipCommitted !== false && { ownershipCommittedAt: createdAt }),
+      ...(input.state === 'ready' && { readyAt: createdAt }),
+      ...(input.state === 'blocked' && { blockedAt: createdAt }),
+    };
+
+    this.records.set(sequence, record);
+    this.targetToSequence.set(input.targetId, sequence);
+    this.prune();
+    return { ...record };
+  }
+
+  markReady(
+    targetId: string,
+    metadata: { url?: string; title?: string },
+    at = Date.now(),
+  ): boolean {
+    const record = this.getMutable(targetId);
+    if (!record || record.blockedAt !== undefined) return false;
+    if (record.state === 'closed' && record.readyAt === undefined) return false;
+
+    if (record.state !== 'closed') record.state = 'ready';
+    record.readyAt ??= at;
+    if (metadata.url !== undefined) record.url = sanitizeTargetUrl(metadata.url);
+    if (metadata.title !== undefined) record.title = sanitizeTargetTitle(metadata.title);
+    return true;
+  }
+
+  markOwnershipCommitted(targetId: string, at = Date.now()): boolean {
+    const record = this.getMutable(targetId);
+    if (!record || record.state === 'blocked' || record.state === 'closed') return false;
+    record.ownershipCommittedAt ??= at;
+    return true;
+  }
+
+  canCommitOwnership(targetId: string): boolean {
+    const record = this.getMutable(targetId);
+    return !!record && record.state !== 'blocked' && record.state !== 'closed';
+  }
+
+  markBlocked(targetId: string, at = Date.now()): boolean {
+    const record = this.getMutable(targetId);
+    if (!record) return false;
+    record.state = 'blocked';
+    record.blockedAt ??= at;
+    record.url = '';
+    record.title = '';
+    return true;
+  }
+
+  markClosed(targetId: string, at = Date.now()): boolean {
+    const record = this.getMutable(targetId);
+    if (!record) return false;
+    if (record.state !== 'blocked') record.state = 'closed';
+    record.closedAt ??= at;
+    return true;
+  }
+
+  remapTargetId(oldTargetId: string, newTargetId: string): boolean {
+    if (oldTargetId === newTargetId) return this.has(oldTargetId);
+    const sequence = this.targetToSequence.get(oldTargetId);
+    if (sequence !== undefined) {
+      const conflictingSequence = this.targetToSequence.get(newTargetId);
+      if (conflictingSequence !== undefined && conflictingSequence !== sequence) return false;
+      const record = this.records.get(sequence);
+      if (record) {
+        this.targetToSequence.delete(oldTargetId);
+        record.targetId = newTargetId;
+        this.targetToSequence.set(newTargetId, sequence);
+      }
+    }
+
+    let remapped = sequence !== undefined;
+    for (const record of this.records.values()) {
+      if (record.currentOpenerTargetId === oldTargetId) {
+        record.currentOpenerTargetId = newTargetId;
+        remapped = true;
+      }
+    }
+    return remapped;
+  }
+
+  reconcileAliveTargetIds(aliveTargetIds: Set<string>, at = Date.now()): void {
+    for (const record of this.records.values()) {
+      if (
+        (record.state === 'provisional' || record.state === 'ready') &&
+        !aliveTargetIds.has(record.targetId)
+      ) {
+        this.markClosed(record.targetId, at);
+      }
+    }
+  }
+
+  clearSession(sessionId: string): void {
+    this.removeWhere((record) => record.sessionId === sessionId);
+  }
+
+  clearWorker(sessionId: string, workerId: string): void {
+    this.removeWhere((record) => record.sessionId === sessionId && record.workerId === workerId);
+  }
+
+  query(input: TargetCreationQuery): TargetCreationQueryResult {
+    const limit = Math.max(0, Math.min(input.limit ?? 5, 5));
+    const eligible: TargetCreationRecord[] = [];
+    let pendingCount = 0;
+
+    for (const record of this.records.values()) {
+      if (record.sequence <= input.afterSequence) continue;
+      if (record.sessionId !== input.sessionId || record.workerId !== input.workerId) continue;
+      if (record.currentOpenerTargetId !== input.openerTargetId) continue;
+
+      if (
+        record.blockedAt === undefined &&
+        record.state !== 'closed' &&
+        (record.state === 'provisional' || record.ownershipCommittedAt === undefined)
+      ) {
+        pendingCount++;
+      }
+      if (
+        record.readyAt === undefined ||
+        record.ownershipCommittedAt === undefined ||
+        record.blockedAt !== undefined
+      ) continue;
+      eligible.push(record);
+    }
+
+    const tabs = eligible.slice(0, limit).map((record): OpenedTabFact => ({
+      tabId: sanitizeText(record.targetId, MAX_ID_LENGTH),
+      workerId: sanitizeText(record.workerId, MAX_ID_LENGTH),
+      url: record.url,
+      title: record.title,
+      status: record.state === 'closed' ? 'closed' : 'ready',
+    }));
+
+    return {
+      total: eligible.length,
+      truncated: eligible.length > tabs.length,
+      pendingCount,
+      tabs,
+    };
+  }
+
+  private getMutable(targetId: string): TargetCreationRecord | undefined {
+    const sequence = this.targetToSequence.get(targetId);
+    return sequence === undefined ? undefined : this.records.get(sequence);
+  }
+
+  private prune(): void {
+    while (this.records.size > this.maxRecords) {
+      let sequenceToDelete: number | undefined;
+      for (const [sequence, record] of this.records) {
+        if (record.state === 'blocked' || record.state === 'closed') {
+          sequenceToDelete = sequence;
+          break;
+        }
+      }
+      sequenceToDelete ??= this.records.keys().next().value;
+      if (sequenceToDelete === undefined) return;
+      this.removeSequence(sequenceToDelete);
+    }
+  }
+
+  private removeWhere(predicate: (record: TargetCreationRecord) => boolean): void {
+    for (const [sequence, record] of Array.from(this.records.entries())) {
+      if (predicate(record)) this.removeSequence(sequence);
+    }
+  }
+
+  private removeSequence(sequence: number): void {
+    const record = this.records.get(sequence);
+    if (!record) return;
+    this.records.delete(sequence);
+    if (this.targetToSequence.get(record.targetId) === sequence) {
+      this.targetToSequence.delete(record.targetId);
+    }
+  }
+}

--- a/src/tools/interact.ts
+++ b/src/tools/interact.ts
@@ -41,6 +41,7 @@ import {
   type PerceptionTargetFailureReason,
   type ResolvedPerceptionTarget,
 } from '../vision/perception-target';
+import type { OpenedTabFact } from '../session/target-creation-ledger';
 
 
 async function resolveInteractVault(value: unknown): Promise<{ value: unknown; token?: string; plaintext?: string; error?: MCPResult }> {
@@ -192,6 +193,82 @@ function perceptionProvenance(
       snapshotAgeMs: target.snapshotAgeMs,
       coordinates: point,
     },
+  };
+}
+
+interface OpenedTabCursor {
+  afterSequence: number;
+  workerId: string;
+}
+
+interface OpenedTabsObservation {
+  openedTabCount: number;
+  openedTabsTruncated: boolean;
+  openedTabs: OpenedTabFact[];
+}
+
+async function collectOpenedTabs(
+  sessionManager: ReturnType<typeof getSessionManager>,
+  cursor: OpenedTabCursor | undefined,
+  sessionId: string,
+  openerTargetId: string,
+  waitAfter: number,
+): Promise<OpenedTabsObservation | null> {
+  if (!cursor || typeof sessionManager.getOpenedTabsAfter !== 'function') return null;
+
+  const query = () => sessionManager.getOpenedTabsAfter({
+    afterSequence: cursor.afterSequence,
+    sessionId,
+    workerId: cursor.workerId,
+    openerTargetId,
+    limit: 5,
+  });
+
+  let observed = query();
+  if (observed.total === 0 && observed.pendingCount === 0) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    observed = query();
+  }
+
+  const deadline = Date.now() + Math.min(Math.max(waitAfter, 250), 1000);
+  while (observed.pendingCount > 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    observed = query();
+  }
+
+  if (observed.total === 0) return null;
+  return {
+    openedTabCount: observed.total,
+    openedTabsTruncated: observed.truncated,
+    openedTabs: observed.tabs,
+  };
+}
+
+function attachOpenedTabs(result: MCPResult, observation: OpenedTabsObservation | null): MCPResult {
+  if (!observation) return result;
+
+  const details = observation.openedTabs.map((tab) => {
+    const title = tab.title ? ` title=${JSON.stringify(tab.title.slice(0, 80))}` : '';
+    return `tabId=${tab.tabId} status=${tab.status} url=${JSON.stringify(tab.url.slice(0, 160))}${title}`;
+  });
+  const suffix = observation.openedTabsTruncated ? ' | details truncated' : '';
+  const line = `[Opened tabs] ${details.join(' | ')}${suffix}`;
+
+  const content = [...(result.content ?? [])];
+  const textIndex = content.findIndex((item) => item.type === 'text');
+  if (textIndex >= 0) {
+    const item = content[textIndex];
+    content[textIndex] = { ...item, text: `${item.text ?? ''}\n${line}` };
+  } else {
+    content.push({ type: 'text', text: line });
+  }
+
+  return {
+    ...result,
+    content,
+    openedTabCount: observation.openedTabCount,
+    openedTabsTruncated: observation.openedTabsTruncated,
+    openedTabs: observation.openedTabs,
   };
 }
 
@@ -411,6 +488,15 @@ const coreHandler: ToolHandler = async (
 
   const sessionManager = getSessionManager();
   const refIdManager = getRefIdManager();
+  const observeOpenedTabs = action === 'click' || action === 'double_click';
+  const beginOpenedTabObservation = (): OpenedTabCursor | undefined => {
+    if (!observeOpenedTabs || typeof sessionManager.getTargetCreationCursor !== 'function') return undefined;
+    const workerId = sessionManager.getTargetWorkerId(tabId);
+    if (!workerId) return undefined;
+    return { afterSequence: sessionManager.getTargetCreationCursor(), workerId };
+  };
+  const finishOpenedTabObservation = (cursor: OpenedTabCursor | undefined) =>
+    collectOpenedTabs(sessionManager, cursor, sessionId, tabId, waitAfter);
 
   const runLocatorFallbackForPage = async (page: any, trigger: LocatorFallbackTrigger): Promise<MCPResult | null> => {
     if (!locatorFallbackEnabled || !query) return null;
@@ -437,22 +523,39 @@ const coreHandler: ToolHandler = async (
     const x = Math.round(candidate.rect.x);
     const y = Math.round(candidate.rect.y);
     const isStealthFallback = sessionManager.isStealthTarget(tabId);
+    let fallbackOpenedTabCursor: OpenedTabCursor | undefined;
     const { result: fallbackDomResult, verify: fallbackVerifyReport } = await runVerify(
       page,
       verifyMode,
       async () =>
         withDomDelta(page, async () => {
           if (isStealthFallback) await humanMouseMove(page, x, y);
-          if (action === 'double_click') await page.mouse.click(x, y, { clickCount: 2 });
+          if (action === 'double_click') {
+            fallbackOpenedTabCursor = beginOpenedTabObservation();
+            await page.mouse.click(x, y, { clickCount: 2 });
+          }
           else if (action === 'hover') { if (!isStealthFallback) await page.mouse.move(x, y); }
-          else await page.mouse.click(x, y);
+          else if (action === 'type') {
+            await page.mouse.click(x, y);
+            const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+            await page.keyboard.down(modifier);
+            await page.keyboard.press('KeyA');
+            await page.keyboard.up(modifier);
+            await page.keyboard.press('Backspace');
+            await page.keyboard.type(String(typeValue));
+          }
+          else {
+            fallbackOpenedTabCursor = beginOpenedTabObservation();
+            await page.mouse.click(x, y);
+          }
         }, { settleMs: Math.max(150, waitAfter) }),
     );
+    const openedTabs = await finishOpenedTabObservation(fallbackOpenedTabCursor);
     invalidateAXCache(getTargetId(page.target()));
-    const verb = action === 'double_click' ? 'Double-clicked' : action === 'hover' ? 'Hovered' : 'Clicked';
+    const verb = action === 'double_click' ? 'Double-clicked' : action === 'hover' ? 'Hovered' : action === 'type' ? 'Typed into' : 'Clicked';
     const lines = [`${verb} locator fallback candidate "${candidate.label ?? candidate.selector}" [provider=${candidate.provider} confidence=${candidate.confidence}]`];
     if (fallbackDomResult.delta) lines.push('', '[DOM Delta]', fallbackDomResult.delta);
-    return attachVerifyReport({
+    return attachOpenedTabs(attachVerifyReport({
       content: [{ type: 'text', text: lines.join('\n') }],
       locatorFallback: {
         trigger,
@@ -460,7 +563,7 @@ const coreHandler: ToolHandler = async (
         accepted: true,
         selected: { selector: candidate.selector, confidence: candidate.confidence, reason: candidate.reason, provider: candidate.provider },
       },
-    } as MCPResult, fallbackVerifyReport);
+    } as MCPResult, fallbackVerifyReport), openedTabs);
   };
 
   if (!tabId) {
@@ -604,16 +707,24 @@ const coreHandler: ToolHandler = async (
       if (target.resolution === 'snapshot-bbox') point = target.point;
 
       const isStealth = sessionManager.isStealthTarget(tabId);
+      let perceptionOpenedTabCursor: OpenedTabCursor | undefined;
       const { result: perceptionDomResult, verify: perceptionVerifyReport } = await runVerify(
         page,
         verifyMode,
         async () => withDomDelta(page, async () => {
           if (isStealth) await humanMouseMove(page, point.x, point.y);
-          if (action === 'double_click') await page.mouse.click(point.x, point.y, { clickCount: 2 });
+          if (action === 'double_click') {
+            perceptionOpenedTabCursor = beginOpenedTabObservation();
+            await page.mouse.click(point.x, point.y, { clickCount: 2 });
+          }
           else if (action === 'hover') { if (!isStealth) await page.mouse.move(point.x, point.y); }
-          else await page.mouse.click(point.x, point.y);
+          else {
+            perceptionOpenedTabCursor = beginOpenedTabObservation();
+            await page.mouse.click(point.x, point.y);
+          }
         }, { settleMs: Math.max(150, waitAfter) }),
       );
+      const openedTabs = await finishOpenedTabObservation(perceptionOpenedTabCursor);
 
       if (captureArtifact && action === 'click' && backendNodeId !== undefined) {
         await captureBackendNodeReplayStep({
@@ -655,10 +766,13 @@ const coreHandler: ToolHandler = async (
         } catch { /* screenshot failed, non-fatal */ }
       }
 
-      return attachVerifyReport({
-        content: resultContent,
-        structuredContent: provenance,
-      }, perceptionVerifyReport);
+      return attachOpenedTabs(
+        attachVerifyReport({
+          content: resultContent,
+          structuredContent: provenance,
+        }, perceptionVerifyReport),
+        openedTabs,
+      );
     } catch (error) {
       return {
         content: [{ type: 'text', text: `Interact error: ${error instanceof Error ? error.message : String(error)}` }],
@@ -728,8 +842,10 @@ const coreHandler: ToolHandler = async (
       const [x1, y1,, , x2,, , y2] = boxModel.model.content;
       const cx = Math.round((x1 + x2) / 2);
       const cy = Math.round((y1 + y2) / 2);
+      let refOpenedTabCursor: OpenedTabCursor | undefined;
 
       if (action === 'double_click') {
+        refOpenedTabCursor = beginOpenedTabObservation();
         await page.mouse.click(cx, cy, { clickCount: 2 });
       } else if (action === 'hover') {
         await page.mouse.move(cx, cy);
@@ -742,6 +858,7 @@ const coreHandler: ToolHandler = async (
         await page.keyboard.press('Backspace');
         await page.keyboard.type(String(typeValue));
       } else {
+        refOpenedTabCursor = beginOpenedTabObservation();
         await page.mouse.click(cx, cy);
       }
 
@@ -756,11 +873,12 @@ const coreHandler: ToolHandler = async (
 
       const actionVerb = action === 'double_click' ? 'Double-clicked' : action === 'hover' ? 'Hovered' : action === 'type' ? 'Typed into' : 'Clicked';
       const lines = [`${actionVerb} [${refArg}] [via ref]`];
+      const openedTabs = await finishOpenedTabObservation(refOpenedTabCursor);
 
-      return {
+      return attachOpenedTabs({
         content: [{ type: 'text', text: maskInteractVault(lines.join('\n'), vaultValue) }],
         via: 'ref',
-      } as MCPResult;
+      } as MCPResult, openedTabs);
     } catch (err) {
       return {
         content: [{ type: 'text', text: `Interact error: ${err instanceof Error ? err.message : String(err)}` }],
@@ -829,19 +947,45 @@ const coreHandler: ToolHandler = async (
 
       const cdpClient = sessionManager.getCDPClient();
       const isStealth = sessionManager.isStealthTarget(tabId);
+      let coordinateOpenedTabCursor: OpenedTabCursor | undefined;
+      const coordinateClick = (clickCount: number) => dispatchCoordinateClick(cdpClient, page, {
+        x: cx,
+        y: cy,
+        button: (coordinateArg.button as 'left' | 'right' | 'middle') ?? 'left',
+        clickCount,
+        modifiers: (coordinateArg.modifiers as Array<'alt' | 'ctrl' | 'meta' | 'shift'>) ?? [],
+      });
 
       const { delta } = await withDomDelta(page, async () => {
         if (isStealth) await humanMouseMove(page, cx, cy);
-        await dispatchCoordinateClick(cdpClient, page, {
-          x: cx,
-          y: cy,
-          button: (coordinateArg.button as 'left' | 'right' | 'middle') ?? 'left',
-          clickCount: (coordinateArg.clickCount as number) ?? 1,
-          modifiers: (coordinateArg.modifiers as Array<'alt' | 'ctrl' | 'meta' | 'shift'>) ?? [],
-        });
+        if (action === 'double_click') {
+          coordinateOpenedTabCursor = beginOpenedTabObservation();
+          await coordinateClick((coordinateArg.clickCount as number) ?? 2);
+        } else if (action === 'hover') {
+          if (!isStealth) await page.mouse.move(cx, cy);
+        } else if (action === 'type') {
+          await dispatchCoordinateClick(cdpClient, page, {
+            x: cx,
+            y: cy,
+            button: 'left',
+            clickCount: 1,
+            modifiers: [],
+          });
+          const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+          await page.keyboard.down(modifier);
+          await page.keyboard.press('KeyA');
+          await page.keyboard.up(modifier);
+          await page.keyboard.press('Backspace');
+          await page.keyboard.type(String(typeValue));
+        } else {
+          coordinateOpenedTabCursor = beginOpenedTabObservation();
+          await coordinateClick((coordinateArg.clickCount as number) ?? 1);
+        }
       }, { settleMs: Math.max(150, waitAfter) });
+      const openedTabs = await finishOpenedTabObservation(coordinateOpenedTabCursor);
 
-      const lines: string[] = [`Clicked coordinate (${cx}, ${cy}) via CDP`];
+      const coordinateVerb = action === 'double_click' ? 'Double-clicked' : action === 'hover' ? 'Hovered' : action === 'type' ? 'Typed into' : 'Clicked';
+      const lines: string[] = [`${coordinateVerb} coordinate (${cx}, ${cy}) via CDP`];
       if (delta) lines.push('', '[DOM Delta]', delta);
 
       const resultContent: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }> = [
@@ -860,7 +1004,7 @@ const coreHandler: ToolHandler = async (
         } catch { /* screenshot failed, non-fatal */ }
       }
 
-      return { content: resultContent };
+      return attachOpenedTabs({ content: resultContent }, openedTabs);
     } catch (error) {
       return {
         content: [{ type: 'text', text: `Interact error: ${error instanceof Error ? error.message : String(error)}` }],
@@ -960,6 +1104,7 @@ const coreHandler: ToolHandler = async (
         // Perform action with DOM delta — wrapped in runVerify so the per-action
         // verify report (AX-hash + pHash) is captured around the actual click.
         const isStealth = sessionManager.isStealthTarget(tabId);
+        let axOpenedTabCursor: OpenedTabCursor | undefined;
         const { verify: axVerifyReport, result: axActionResult } = await runVerify(
           page,
           verifyMode,
@@ -967,7 +1112,10 @@ const coreHandler: ToolHandler = async (
             withDomDelta(page, async () => {
               // Stealth: use Bézier curve mouse path to avoid bot detection
               if (isStealth) await humanMouseMove(page, axX, axY);
-              if (action === 'double_click') await page.mouse.click(axX, axY, { clickCount: 2 });
+              if (action === 'double_click') {
+                axOpenedTabCursor = beginOpenedTabObservation();
+                await page.mouse.click(axX, axY, { clickCount: 2 });
+              }
               else if (action === 'hover') { if (!isStealth) await page.mouse.move(axX, axY); }
               else if (action === 'type') {
                 await page.mouse.click(axX, axY);
@@ -978,7 +1126,10 @@ const coreHandler: ToolHandler = async (
                 await page.keyboard.press('Backspace');
                 await page.keyboard.type(String(typeValue));
               }
-              else await page.mouse.click(axX, axY);
+              else {
+                axOpenedTabCursor = beginOpenedTabObservation();
+                await page.mouse.click(axX, axY);
+              }
             }, { settleMs: Math.max(150, waitAfter) }),
         );
         const axDelta = axActionResult.delta;
@@ -1005,8 +1156,12 @@ const coreHandler: ToolHandler = async (
         await cleanupTags(page, DISCOVERY_TAG).catch(() => {});
 
         // Classify outcome and build response
+        const openedTabs = await finishOpenedTabObservation(axOpenedTabCursor);
         const axVerb = action === 'double_click' ? 'Double-clicked' : action === 'hover' ? 'Hovered' : action === 'type' ? 'Typed into' : 'Clicked';
-        const axOutcome = classifyOutcome(axDelta, ax.role);
+        const classifiedAxOutcome = classifyOutcome(axDelta, ax.role);
+        const axOutcome = openedTabs && classifiedAxOutcome === 'SILENT_CLICK'
+          ? 'SUCCESS'
+          : classifiedAxOutcome;
         const axLine = formatOutcomeLine(axOutcome, axVerb, `${ax.role} "${ax.name}"`, `[${axRef}]`, `[${MATCH_LEVEL_LABELS[ax.matchLevel]} via AX tree]`);
 
         // Gather state summary (same as CSS path)
@@ -1046,7 +1201,10 @@ const coreHandler: ToolHandler = async (
           } catch { /* screenshot failed, non-fatal */ }
         }
 
-        return attachVerifyReport({ content: resultContent }, axVerifyReport);
+        return attachOpenedTabs(
+          attachVerifyReport({ content: resultContent }, axVerifyReport),
+          openedTabs,
+        );
       }
     } catch (axError) {
       throwIfAborted(context);
@@ -1177,6 +1335,7 @@ const coreHandler: ToolHandler = async (
     // Perform the action with DOM delta capture, wrapped in runVerify so the
     // structured verify report (AX-hash + pHash) covers the actual click.
     const isStealthCSS = sessionManager.isStealthTarget(tabId);
+    let cssOpenedTabCursor: OpenedTabCursor | undefined;
     const { result: cssDomResult, verify: cssVerifyReport } = await runVerify(
       page,
       verifyMode,
@@ -1187,6 +1346,7 @@ const coreHandler: ToolHandler = async (
             // Stealth: use Bézier curve mouse path to avoid bot detection
             if (isStealthCSS) await humanMouseMove(page, finalX, finalY);
             if (action === 'double_click') {
+              cssOpenedTabCursor = beginOpenedTabObservation();
               await page.mouse.click(finalX, finalY, { clickCount: 2 });
             } else if (action === 'hover') {
               if (!isStealthCSS) await page.mouse.move(finalX, finalY);
@@ -1199,6 +1359,7 @@ const coreHandler: ToolHandler = async (
               await page.keyboard.press('Backspace');
               await page.keyboard.type(String(typeValue));
             } else {
+              cssOpenedTabCursor = beginOpenedTabObservation();
               await page.mouse.click(finalX, finalY);
             }
           },
@@ -1237,12 +1398,16 @@ const coreHandler: ToolHandler = async (
     invalidateAXCache(getTargetId(page.target()));
 
     // Build compact action label with confidence score
+    const openedTabs = await finishOpenedTabObservation(cssOpenedTabCursor);
     const actionVerb = action === 'double_click' ? 'Double-clicked' : action === 'hover' ? 'Hovered' : action === 'type' ? 'Typed into' : 'Clicked';
     const textSample = bestMatch.textContent?.slice(0, 50) || bestMatch.name.slice(0, 50);
     const textPart = textSample ? ` "${textSample}"` : '';
     const refPart = refId ? ` [${refId}]` : '';
     const confidencePart = bestMatch.score < 50 ? ` [via CSS, LOW CONFIDENCE]` : ` [via CSS]`;
-    const cssOutcome = classifyOutcome(delta, bestMatch.role);
+    const classifiedCssOutcome = classifyOutcome(delta, bestMatch.role);
+    const cssOutcome = openedTabs && classifiedCssOutcome === 'SILENT_CLICK'
+      ? 'SUCCESS'
+      : classifiedCssOutcome;
     const interactedLine = formatOutcomeLine(cssOutcome, actionVerb, `${bestMatch.tagName}${textPart}`, refPart, confidencePart);
 
     // Gather state summary via page.evaluate
@@ -1398,7 +1563,10 @@ const coreHandler: ToolHandler = async (
       responseContent.push(screenshotContent);
     }
 
-    return attachVerifyReport({ content: responseContent }, cssVerifyReport);
+    return attachOpenedTabs(
+      attachVerifyReport({ content: responseContent }, cssVerifyReport),
+      openedTabs,
+    );
   } catch (error) {
     return {
       content: [
@@ -1414,22 +1582,46 @@ const coreHandler: ToolHandler = async (
 
 
 const handler: ToolHandler = async (sessionId, args, context): Promise<MCPResult> => {
-  const result = await coreHandler(sessionId, args, context);
-  const returnAfterState = parseReturnAfterState(args.returnAfterState);
-  if (returnAfterState === 'none' || result.isError) return result;
+  let tabId: string | undefined;
+  try {
+    tabId = applyLaneTarget(args).tabId as string | undefined;
+  } catch {
+    // coreHandler preserves the existing lane-validation error contract.
+  }
 
-  const tabId = args.tabId as string | undefined;
-  if (!tabId) return result;
+  const execute = async (): Promise<MCPResult> => {
+    const result = await coreHandler(sessionId, args, context);
+    const returnAfterState = parseReturnAfterState(args.returnAfterState);
+    if (returnAfterState === 'none' || result.isError || !tabId) return result;
+
+    try {
+      const page = await getSessionManager().getPage(sessionId, tabId, undefined, 'interact');
+      if (page) {
+        await appendReturnAfterState(result, page, sessionId, tabId, returnAfterState, context);
+      }
+    } catch {
+      // Snapshot chaining is best-effort; never mask the successful action result.
+    }
+    return result;
+  };
+
+  const sessionManager = getSessionManager();
+  if (
+    !tabId ||
+    typeof sessionManager.runTargetExclusive !== 'function' ||
+    !sessionManager.validateTargetOwnership(sessionId, tabId)
+  ) {
+    return execute();
+  }
 
   try {
-    const page = await getSessionManager().getPage(sessionId, tabId, undefined, 'interact');
-    if (page) {
-      await appendReturnAfterState(result, page, sessionId, tabId, returnAfterState, context);
-    }
-  } catch {
-    // Snapshot chaining is best-effort; never mask the successful action result.
+    return await sessionManager.runTargetExclusive(sessionId, tabId, execute);
+  } catch (error) {
+    return {
+      content: [{ type: 'text', text: `Interact error: ${error instanceof Error ? error.message : String(error)}` }],
+      isError: true,
+    };
   }
-  return result;
 };
 
 export function registerInteractTool(server: MCPServer): void {

--- a/tests/cdp/listener-error.test.ts
+++ b/tests/cdp/listener-error.test.ts
@@ -2,6 +2,8 @@
 
 const browserHandlers: Record<string, Function> = {};
 const mockConnect = jest.fn();
+const mockAssertDomainAllowed = jest.fn();
+const mockApplyRegisteredPreloads = jest.fn();
 
 jest.mock('puppeteer-core', () => ({
   __esModule: true,
@@ -21,9 +23,24 @@ jest.mock('../../src/config/global', () => ({
   getGlobalConfig: jest.fn().mockReturnValue({ port: 9222, autoLaunch: false }),
 }));
 
+jest.mock('../../src/security/domain-guard', () => ({
+  assertDomainAllowed: (url: string) => mockAssertDomainAllowed(url),
+  isInternalBrowserUrl: (url: string) =>
+    url === 'about:blank' || url.startsWith('about:') || url.startsWith('chrome:') ||
+    url.startsWith('chrome-extension:') || url.startsWith('devtools:'),
+}));
+
+jest.mock('../../src/cdp/preload-injector', () => ({
+  applyRegisteredPreloads: (...args: unknown[]) => mockApplyRegisteredPreloads(...args),
+}));
+
 const sessionManagerMock = {
   getTargetOwner: jest.fn().mockReturnValue({ sessionId: 's1', workerId: 'default' }),
-  registerExternalTarget: jest.fn(() => { throw new Error('listener boom'); }),
+  registerPopupTarget: jest.fn().mockResolvedValue(true),
+  hasTargetCreationRecord: jest.fn().mockReturnValue(false),
+  markPopupTargetReady: jest.fn(),
+  markPopupTargetBlocked: jest.fn(),
+  onTargetClosed: jest.fn(),
   evictTarget: jest.fn(),
 };
 
@@ -47,6 +64,10 @@ describe('CDPClient listener error integration', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    mockAssertDomainAllowed.mockImplementation(() => undefined);
+    mockApplyRegisteredPreloads.mockResolvedValue(undefined);
+    sessionManagerMock.getTargetOwner.mockReturnValue({ sessionId: 's1', workerId: 'default' });
+    sessionManagerMock.registerPopupTarget.mockResolvedValue(true);
     jest.spyOn(console, 'error').mockImplementation(() => {});
     for (const key of Object.keys(browserHandlers)) delete browserHandlers[key];
 
@@ -73,6 +94,7 @@ describe('CDPClient listener error integration', () => {
   });
 
   test('evicts a popup target when the targetcreated listener fails after ownership lookup', async () => {
+    sessionManagerMock.registerPopupTarget.mockRejectedValueOnce(new Error('listener boom'));
     const before = counterValueFor('targetcreated');
     const opener = { _targetId: 'opener-1' };
     const target = {
@@ -87,6 +109,164 @@ describe('CDPClient listener error integration', () => {
     await new Promise((r) => setTimeout(r, 5));
 
     expect(counterValueFor('targetcreated')).toBe(before + 1);
+    expect(sessionManagerMock.markPopupTargetBlocked).toHaveBeenCalledWith('popup-1');
     expect(sessionManagerMock.evictTarget).toHaveBeenCalledWith('popup-1', 'listener_error');
+  });
+
+  test('registers managed about:blank popups provisionally', async () => {
+    const target = {
+      _targetId: 'popup-blank',
+      type: jest.fn().mockReturnValue('page'),
+      url: jest.fn().mockReturnValue('about:blank'),
+      opener: jest.fn().mockReturnValue({ _targetId: 'opener-1' }),
+      page: jest.fn().mockResolvedValue(null),
+    };
+
+    browserHandlers.targetcreated(target);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(sessionManagerMock.registerPopupTarget).toHaveBeenCalledWith(
+      'popup-blank',
+      'opener-1',
+      { state: 'provisional' },
+    );
+  });
+
+  test('leaves popups from unmanaged openers untouched', async () => {
+    sessionManagerMock.getTargetOwner.mockReturnValueOnce(undefined);
+    const closeSpy = jest.spyOn(client, 'closePage').mockResolvedValue(undefined);
+    const target = {
+      _targetId: 'popup-unmanaged',
+      type: jest.fn().mockReturnValue('page'),
+      url: jest.fn().mockReturnValue('https://example.com/unmanaged'),
+      opener: jest.fn().mockReturnValue({ _targetId: 'unmanaged-opener' }),
+      page: jest.fn().mockResolvedValue(null),
+    };
+
+    browserHandlers.targetcreated(target);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(sessionManagerMock.registerPopupTarget).not.toHaveBeenCalled();
+    expect(closeSpy).not.toHaveBeenCalled();
+  });
+
+  test('enforces policy for blocked initial URLs before opener ownership filtering', async () => {
+    sessionManagerMock.getTargetOwner.mockReturnValueOnce(undefined);
+    mockAssertDomainAllowed.mockImplementationOnce(() => { throw new Error('blocked'); });
+    const closeSpy = jest.spyOn(client, 'closePage').mockResolvedValue(undefined);
+    const target = {
+      _targetId: 'blocked-unmanaged',
+      type: jest.fn().mockReturnValue('page'),
+      url: jest.fn().mockReturnValue('https://blocked.example/'),
+      opener: jest.fn().mockReturnValue({ _targetId: 'unmanaged-opener' }),
+    };
+
+    browserHandlers.targetcreated(target);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(closeSpy).toHaveBeenCalledWith('blocked-unmanaged');
+    expect(sessionManagerMock.registerPopupTarget).not.toHaveBeenCalled();
+  });
+
+  test('promotes tracked popups after allowed navigation', async () => {
+    sessionManagerMock.hasTargetCreationRecord.mockReturnValueOnce(true);
+    const target = {
+      _targetId: 'popup-ready',
+      type: jest.fn().mockReturnValue('page'),
+      url: jest.fn().mockReturnValue('https://example.com/next'),
+      page: jest.fn().mockResolvedValue({ title: jest.fn().mockResolvedValue('Next page') }),
+    };
+
+    browserHandlers.targetchanged(target);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(sessionManagerMock.markPopupTargetReady).toHaveBeenNthCalledWith(1, 'popup-ready', {
+      url: 'https://example.com/next',
+    });
+    expect(sessionManagerMock.markPopupTargetReady).toHaveBeenNthCalledWith(2, 'popup-ready', {
+      title: 'Next page',
+    });
+  });
+
+  test('records an allowed URL before waiting for optional title metadata', async () => {
+    sessionManagerMock.hasTargetCreationRecord.mockReturnValueOnce(true);
+    let releasePage!: (page: { title: jest.Mock }) => void;
+    const pagePromise = new Promise<{ title: jest.Mock }>((resolve) => { releasePage = resolve; });
+    const target = {
+      _targetId: 'popup-fast-close',
+      type: jest.fn().mockReturnValue('page'),
+      url: jest.fn().mockReturnValue('https://example.com/fast'),
+      page: jest.fn().mockReturnValue(pagePromise),
+    };
+
+    browserHandlers.targetchanged(target);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(sessionManagerMock.markPopupTargetReady).toHaveBeenCalledWith('popup-fast-close', {
+      url: 'https://example.com/fast',
+    });
+
+    releasePage({ title: jest.fn().mockResolvedValue('Fast') });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(sessionManagerMock.markPopupTargetReady).toHaveBeenCalledWith('popup-fast-close', { title: 'Fast' });
+  });
+
+  test('cleans ownership when a registered popup has no live page', async () => {
+    const target = {
+      _targetId: 'popup-gone',
+      type: jest.fn().mockReturnValue('page'),
+      url: jest.fn().mockReturnValue('about:blank'),
+      opener: jest.fn().mockReturnValue({ _targetId: 'opener-1' }),
+      page: jest.fn().mockResolvedValue(null),
+    };
+
+    browserHandlers.targetcreated(target);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(sessionManagerMock.onTargetClosed).toHaveBeenCalledWith('popup-gone');
+  });
+
+  test('closes, de-indexes, and evicts a popup when initialization fails', async () => {
+    mockApplyRegisteredPreloads.mockRejectedValueOnce(new Error('preload failed'));
+    jest.spyOn(client as any, 'configurePageDefenses').mockImplementation(() => {});
+    const closeSpy = jest.spyOn(client, 'closePage').mockResolvedValue(undefined);
+    const page = {
+      url: jest.fn().mockReturnValue('https://example.com/popup'),
+      title: jest.fn().mockResolvedValue('Popup'),
+      isClosed: jest.fn().mockReturnValue(false),
+    };
+    const target = {
+      _targetId: 'popup-init-failed',
+      type: jest.fn().mockReturnValue('page'),
+      url: jest.fn().mockReturnValue('https://example.com/popup'),
+      opener: jest.fn().mockReturnValue({ _targetId: 'opener-1' }),
+      page: jest.fn().mockResolvedValue(page),
+    };
+
+    browserHandlers.targetcreated(target);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(sessionManagerMock.markPopupTargetBlocked).toHaveBeenCalledWith('popup-init-failed');
+    expect(closeSpy).toHaveBeenCalledWith('popup-init-failed');
+    expect(sessionManagerMock.evictTarget).toHaveBeenCalledWith('popup-init-failed', 'listener_error');
+    expect((client as any).targetIdIndex.has('popup-init-failed')).toBe(false);
+  });
+
+  test('marks a tracked popup blocked before closing it', async () => {
+    sessionManagerMock.hasTargetCreationRecord.mockReturnValueOnce(true);
+    mockAssertDomainAllowed.mockImplementationOnce(() => { throw new Error('blocked'); });
+    const closeSpy = jest.spyOn(client, 'closePage').mockResolvedValue(undefined);
+    const target = {
+      _targetId: 'popup-blocked',
+      type: jest.fn().mockReturnValue('page'),
+      url: jest.fn().mockReturnValue('https://blocked.example/'),
+    };
+
+    browserHandlers.targetchanged(target);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(sessionManagerMock.markPopupTargetBlocked).toHaveBeenCalledWith('popup-blocked');
+    expect(closeSpy).toHaveBeenCalledWith('popup-blocked');
+    expect(sessionManagerMock.markPopupTargetBlocked.mock.invocationCallOrder[0])
+      .toBeLessThan(closeSpy.mock.invocationCallOrder[0]);
   });
 });

--- a/tests/integration/popup-interact-live.test.ts
+++ b/tests/integration/popup-interact-live.test.ts
@@ -1,0 +1,214 @@
+jest.unmock('puppeteer-core');
+jest.unmock('../../src/chrome/launcher');
+
+import fs from 'node:fs';
+import http from 'node:http';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import puppeteer, { type Browser, type Page } from 'puppeteer-core';
+
+import {
+  _resetCDPClientFactoryForTesting,
+  _resetCDPClientForTesting,
+  getCDPClient,
+} from '../../src/cdp/client';
+import { getCDPConnectionPool } from '../../src/cdp/connection-pool';
+import { getGlobalConfig, setGlobalConfig, type GlobalConfig } from '../../src/config/global';
+import { _resetSessionManagerForTesting, getSessionManager, type SessionManager } from '../../src/session-manager';
+import { registerInteractTool } from '../../src/tools/interact';
+
+const REAL_CHROME = process.env.OPENCHROME_REAL_CHROME === '1';
+
+function findChromeExecutable(): string | null {
+  if (process.env.OPENCHROME_TEST_CHROME) return process.env.OPENCHROME_TEST_CHROME;
+  const candidates = [
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    '/usr/bin/google-chrome',
+    '/usr/bin/chromium-browser',
+    '/usr/bin/chromium',
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate)) ?? null;
+}
+
+async function reservePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('Could not reserve a TCP port'));
+        return;
+      }
+      server.close((error) => error ? reject(error) : resolve(address.port));
+    });
+  });
+}
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('Fixture server did not expose a TCP port'));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+async function buttonCenter(page: Page, selector: string): Promise<{ x: number; y: number }> {
+  return page.$eval(selector, (element) => {
+    const rect = element.getBoundingClientRect();
+    return { x: Math.round(rect.left + rect.width / 2), y: Math.round(rect.top + rect.height / 2) };
+  });
+}
+
+(REAL_CHROME ? describe : describe.skip)('interact popup ledger - real headed Chrome', () => {
+  let browser: Browser;
+  let fixtureServer: http.Server;
+  let fixturePort: number;
+  let userDataDir: string;
+  let manager: SessionManager;
+  let page: Page;
+  let tabId: string;
+  let interact: (sessionId: string, args: Record<string, unknown>) => Promise<any>;
+  let previousConfig: GlobalConfig | undefined;
+  const sessionId = 'popup-live';
+
+  beforeAll(async () => {
+    const executablePath = findChromeExecutable();
+    if (!executablePath) throw new Error('No Chrome executable found');
+
+    fixtureServer = http.createServer((request, response) => {
+      const url = request.url ?? '/';
+      response.setHeader('Content-Type', 'text/html; charset=utf-8');
+      if (url === '/') {
+        response.end(`<!doctype html>
+          <title>Popup fixture</title>
+          <button id="direct" onclick="window.open('/direct', '_blank')">Direct child</button>
+          <button id="delayed" onclick="const w = window.open('about:blank', '_blank'); setTimeout(() => { if (w) w.location = '/delayed'; }, 100)">Delayed child</button>
+          <button id="blocked" onclick="window.open('http://localhost:${fixturePort}/blocked', '_blank')">Blocked child</button>`);
+        return;
+      }
+      if (url === '/direct') {
+        response.end('<!doctype html><title>Direct child</title><h1>Direct child</h1>');
+        return;
+      }
+      if (url === '/delayed') {
+        response.end('<!doctype html><title>Delayed child</title><h1>Delayed child</h1>');
+        return;
+      }
+      response.end('<!doctype html><title>Blocked child</title><h1>Blocked child</h1>');
+    });
+    fixturePort = await listen(fixtureServer);
+
+    const chromePort = await reservePort();
+    userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-popup-live-'));
+    browser = await puppeteer.launch({
+      executablePath,
+      headless: false,
+      userDataDir,
+      args: [
+        `--remote-debugging-port=${chromePort}`,
+        '--no-first-run',
+        '--no-default-browser-check',
+        '--disable-background-networking',
+      ],
+    });
+
+    previousConfig = { ...getGlobalConfig(), security: getGlobalConfig().security ? { ...getGlobalConfig().security } : undefined };
+    setGlobalConfig({
+      port: chromePort,
+      autoLaunch: false,
+      security: { blocked_domains: ['localhost'] },
+    });
+    process.env.OC_PERSIST_STORAGE = '0';
+    _resetSessionManagerForTesting();
+    _resetCDPClientForTesting();
+    _resetCDPClientFactoryForTesting();
+
+    manager = getSessionManager();
+    manager.stopAutoCleanup();
+    await manager.ensureConnected();
+    const created = await manager.createTarget(sessionId, `http://127.0.0.1:${fixturePort}/`);
+    tabId = created.targetId;
+    page = created.page;
+
+    let registered: typeof interact | undefined;
+    registerInteractTool({
+      registerTool: (_name: string, handler: typeof interact) => { registered = handler; },
+    } as never);
+    if (!registered) throw new Error('interact handler was not registered');
+    interact = registered;
+  }, 180_000);
+
+  afterAll(async () => {
+    await manager?.cleanupAllSessions().catch(() => {});
+    manager?.stopAutoCleanup();
+    await getCDPConnectionPool().shutdown().catch(() => {});
+    await getCDPClient().disconnect().catch(() => {});
+    await browser?.close().catch(() => {});
+    if (fixtureServer) await closeServer(fixtureServer);
+    if (userDataDir) fs.rmSync(userDataDir, { recursive: true, force: true });
+    if (previousConfig) setGlobalConfig(previousConfig);
+    delete process.env.OC_PERSIST_STORAGE;
+    _resetSessionManagerForTesting();
+    _resetCDPClientForTesting();
+    _resetCDPClientFactoryForTesting();
+  }, 180_000);
+
+  test('reports direct and delayed children, omits blocked children, and keeps using the source tab', async () => {
+    const directCoordinate = await buttonCenter(page, '#direct');
+    const direct = await interact(sessionId, {
+      tabId,
+      mode: 'coordinate',
+      coordinate: directCoordinate,
+      waitAfter: 500,
+    });
+    expect(direct.openedTabCount).toBe(1);
+    expect(direct.openedTabs[0]).toMatchObject({
+      workerId: 'default',
+      url: `http://127.0.0.1:${fixturePort}/direct`,
+      status: 'ready',
+    });
+
+    const delayedCoordinate = await buttonCenter(page, '#delayed');
+    const delayed = await interact(sessionId, {
+      tabId,
+      mode: 'coordinate',
+      coordinate: delayedCoordinate,
+      waitAfter: 700,
+    });
+    expect(delayed.openedTabCount).toBe(1);
+    expect(delayed.openedTabs[0].url).toBe(`http://127.0.0.1:${fixturePort}/delayed`);
+
+    const blockedCoordinate = await buttonCenter(page, '#blocked');
+    const blocked = await interact(sessionId, {
+      tabId,
+      mode: 'coordinate',
+      coordinate: blockedCoordinate,
+      waitAfter: 500,
+    });
+    expect(blocked).not.toHaveProperty('openedTabCount');
+    expect(blocked).not.toHaveProperty('openedTabs');
+
+    expect(page.url()).toBe(`http://127.0.0.1:${fixturePort}/`);
+    expect(manager.getTargetOwner(tabId)).toEqual({ sessionId, workerId: 'default' });
+  }, 180_000);
+});
+
+describe('interact popup ledger - live test compile smoke', () => {
+  test('fixture gate is explicit', () => {
+    expect(typeof REAL_CHROME).toBe('boolean');
+  });
+});

--- a/tests/session-manager-target-creation.test.ts
+++ b/tests/session-manager-target-creation.test.ts
@@ -1,0 +1,206 @@
+const targetDestroyedListeners: Array<(targetId: string) => void> = [];
+
+const mockCdpClientInstance = {
+  connect: jest.fn().mockResolvedValue(undefined),
+  isConnected: jest.fn().mockReturnValue(true),
+  addConnectionListener: jest.fn(),
+  addTargetDestroyedListener: jest.fn((listener: (targetId: string) => void) => {
+    targetDestroyedListeners.push(listener);
+  }),
+  createBrowserContext: jest.fn(),
+  closeBrowserContext: jest.fn().mockResolvedValue(undefined),
+  getBrowser: jest.fn().mockReturnValue({ targets: jest.fn().mockReturnValue([]) }),
+  getPageByTargetId: jest.fn().mockResolvedValue(null),
+  closePage: jest.fn().mockResolvedValue(undefined),
+  send: jest.fn(),
+};
+
+jest.mock('../src/cdp/client', () => ({
+  CDPClient: jest.fn().mockImplementation(() => mockCdpClientInstance),
+  getCDPClient: jest.fn().mockReturnValue(mockCdpClientInstance),
+  getCDPClientFactory: jest.fn().mockReturnValue({
+    get: jest.fn().mockReturnValue(mockCdpClientInstance),
+    getOrCreate: jest.fn().mockReturnValue(mockCdpClientInstance),
+    getAll: jest.fn().mockReturnValue([mockCdpClientInstance]),
+    disconnectAll: jest.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+jest.mock('../src/cdp/connection-pool', () => ({
+  CDPConnectionPool: jest.fn(),
+  getCDPConnectionPool: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../src/utils/request-queue', () => ({
+  RequestQueueManager: jest.fn().mockImplementation(() => ({
+    enqueue: jest.fn((_: string, fn: () => Promise<unknown>) => fn()),
+    deleteQueue: jest.fn(),
+  })),
+}));
+
+jest.mock('../src/utils/ref-id-manager', () => ({
+  getRefIdManager: jest.fn(() => ({
+    clearSessionRefs: jest.fn(),
+    clearTargetRefs: jest.fn(),
+  })),
+}));
+
+import { SessionManager } from '../src/session-manager';
+
+function createManager(maxTargetsPerWorker = 5): SessionManager {
+  return new SessionManager(undefined, {
+    autoCleanup: false,
+    useConnectionPool: false,
+    useDefaultContext: true,
+    maxTargetsPerWorker,
+  });
+}
+
+describe('SessionManager target creation ledger', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    targetDestroyedListeners.length = 0;
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('promotes a provisional popup and retains it as closed evidence', async () => {
+    const manager = createManager();
+    await manager.createSession({ id: 's1' });
+    await manager.registerExternalTarget('parent', 's1', 'default');
+    const cursor = manager.getTargetCreationCursor();
+
+    await expect(manager.registerPopupTarget('child', 'parent', { state: 'provisional' })).resolves.toBe(true);
+    expect(manager.getOpenedTabsAfter({ afterSequence: cursor, sessionId: 's1', workerId: 'default', openerTargetId: 'parent' })).toMatchObject({
+      total: 0,
+      pendingCount: 1,
+    });
+
+    manager.markPopupTargetReady('child', { url: 'https://example.com/next#secret', title: 'Next\nPage' });
+    manager.onTargetClosed('child');
+
+    expect(manager.getOpenedTabsAfter({ afterSequence: cursor, sessionId: 's1', workerId: 'default', openerTargetId: 'parent' }).tabs).toEqual([{
+      tabId: 'child',
+      workerId: 'default',
+      url: 'https://example.com/next',
+      title: 'Next Page',
+      status: 'closed',
+    }]);
+  });
+
+  test('blocked children never become success evidence', async () => {
+    const manager = createManager();
+    await manager.createSession({ id: 's1' });
+    await manager.registerExternalTarget('parent', 's1', 'default');
+    const cursor = manager.getTargetCreationCursor();
+
+    await expect(manager.registerPopupTarget('blocked', 'parent', { state: 'blocked' })).resolves.toBe(false);
+    manager.onTargetClosed('blocked');
+
+    expect(manager.getOpenedTabsAfter({ afterSequence: cursor, sessionId: 's1', workerId: 'default', openerTargetId: 'parent' }).total).toBe(0);
+  });
+
+  test('keeps a ready child pending until worker ownership commits', async () => {
+    const manager = createManager();
+    await manager.createSession({ id: 's1' });
+    await manager.registerExternalTarget('parent', 's1', 'default');
+    const cursor = manager.getTargetCreationCursor();
+    const originalRegister = manager.registerExternalTarget.bind(manager);
+    let release!: () => void;
+    jest.spyOn(manager, 'registerExternalTarget').mockImplementation(async (...args) => {
+      await new Promise<void>((resolve) => { release = resolve; });
+      return originalRegister(...args);
+    });
+
+    const registration = manager.registerPopupTarget('child', 'parent', {
+      state: 'ready',
+      url: 'https://example.com/child',
+    });
+    expect(manager.getOpenedTabsAfter({ afterSequence: cursor, sessionId: 's1', workerId: 'default', openerTargetId: 'parent' })).toMatchObject({
+      total: 0,
+      pendingCount: 1,
+    });
+
+    release();
+    await expect(registration).resolves.toBe(true);
+    expect(manager.getOpenedTabsAfter({ afterSequence: cursor, sessionId: 's1', workerId: 'default', openerTargetId: 'parent' }).total).toBe(1);
+  });
+
+  test('cleans ownership when a popup closes before registration commits', async () => {
+    const manager = createManager(2);
+    await manager.createSession({ id: 's1' });
+    await manager.registerExternalTarget('parent', 's1', 'default');
+    await manager.registerExternalTarget('oldest-other', 's1', 'default');
+    const closeTargetSpy = jest.spyOn(manager, 'closeTarget');
+    const originalRegister = manager.registerExternalTarget.bind(manager);
+    jest.spyOn(manager, 'registerExternalTarget').mockImplementationOnce(async (...args) => {
+      manager.onTargetClosed('child');
+      return originalRegister(...args);
+    });
+
+    await expect(manager.registerPopupTarget('child', 'parent', {
+      state: 'ready',
+      url: 'https://example.com/child',
+    })).resolves.toBe(false);
+
+    expect(manager.getTargetOwner('child')).toBeUndefined();
+    expect(manager.getSessionInfo('s1')?.targetCount).toBe(2);
+    expect(manager.getTargetOwner('oldest-other')).toEqual({ sessionId: 's1', workerId: 'default' });
+    expect(closeTargetSpy).not.toHaveBeenCalled();
+  });
+
+  test('rejects late popup registration while the owning session is deleting', async () => {
+    const manager = createManager();
+    await manager.createSession({ id: 's1' });
+    await manager.registerExternalTarget('parent', 's1', 'default');
+    let releaseClose!: () => void;
+    mockCdpClientInstance.closePage.mockImplementationOnce(() => new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    }));
+
+    const deletion = manager.deleteSession('s1');
+    await Promise.resolve();
+    await expect(manager.registerPopupTarget('late-child', 'parent', { state: 'provisional' })).resolves.toBe(false);
+
+    releaseClose();
+    await deletion;
+    expect(manager.getTargetOwner('late-child')).toBeUndefined();
+  });
+
+  test('does not evict the opener when the worker has no other target slot', async () => {
+    const manager = createManager(1);
+    await manager.createSession({ id: 's1' });
+    await manager.registerExternalTarget('parent', 's1', 'default');
+
+    await expect(manager.registerPopupTarget('child', 'parent', { state: 'provisional' })).resolves.toBe(false);
+    expect(manager.getTargetOwner('parent')).toEqual({ sessionId: 's1', workerId: 'default' });
+    expect(manager.getTargetOwner('child')).toBeUndefined();
+  });
+
+  test('serializes complete windows for one target and preserves cross-target parallelism', async () => {
+    const manager = createManager();
+    await manager.createSession({ id: 's1' });
+    await manager.registerExternalTarget('tab-1', 's1', 'default');
+    await manager.registerExternalTarget('tab-2', 's1', 'default');
+    const events: string[] = [];
+
+    const first = manager.runTargetExclusive('s1', 'tab-1', async () => {
+      events.push('first:start');
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      events.push('first:end');
+    });
+    const second = manager.runTargetExclusive('s1', 'tab-1', async () => {
+      events.push('second:start');
+    });
+    const parallel = manager.runTargetExclusive('s1', 'tab-2', async () => {
+      events.push('parallel:start');
+    });
+
+    await Promise.all([first, second, parallel]);
+    expect(events.indexOf('parallel:start')).toBeLessThan(events.indexOf('first:end'));
+    expect(events.indexOf('second:start')).toBeGreaterThan(events.indexOf('first:end'));
+  });
+});

--- a/tests/target-creation-ledger.test.ts
+++ b/tests/target-creation-ledger.test.ts
@@ -1,0 +1,137 @@
+import {
+  TargetCreationLedger,
+  sanitizeTargetTitle,
+  sanitizeTargetUrl,
+} from '../src/session/target-creation-ledger';
+
+describe('TargetCreationLedger', () => {
+  test('reports only ready children created after the cursor in deterministic order', () => {
+    const ledger = new TargetCreationLedger();
+    ledger.register({
+      targetId: 'before', sessionId: 's1', workerId: 'w1', openerTargetId: 'parent',
+      state: 'ready', url: 'https://example.com/before', createdAt: 1,
+    });
+    const cursor = ledger.getCursor();
+    ledger.register({
+      targetId: 'first', sessionId: 's1', workerId: 'w1', openerTargetId: 'parent',
+      state: 'provisional', createdAt: 2,
+    });
+    ledger.register({
+      targetId: 'second', sessionId: 's1', workerId: 'w1', openerTargetId: 'parent',
+      state: 'ready', url: 'https://example.com/second', title: 'Second', createdAt: 3,
+    });
+    ledger.markReady('first', { url: 'https://example.com/first', title: 'First' }, 4);
+
+    const result = ledger.query({
+      afterSequence: cursor,
+      sessionId: 's1',
+      workerId: 'w1',
+      openerTargetId: 'parent',
+      limit: 5,
+    });
+
+    expect(result.total).toBe(2);
+    expect(result.pendingCount).toBe(0);
+    expect(result.tabs.map((tab) => tab.tabId)).toEqual(['first', 'second']);
+  });
+
+  test('keeps ready-then-closed facts but excludes provisional-closed and blocked targets', () => {
+    const ledger = new TargetCreationLedger();
+    const cursor = ledger.getCursor();
+
+    ledger.register({ targetId: 'ready', sessionId: 's1', workerId: 'w1', openerTargetId: 'parent', state: 'ready', url: 'https://example.com' });
+    ledger.markClosed('ready');
+    ledger.register({ targetId: 'blank', sessionId: 's1', workerId: 'w1', openerTargetId: 'parent', state: 'provisional' });
+    ledger.markClosed('blank');
+    ledger.register({ targetId: 'blocked', sessionId: 's1', workerId: 'w1', openerTargetId: 'parent', state: 'ready', url: 'https://allowed.example' });
+    ledger.markBlocked('blocked');
+
+    const result = ledger.query({ afterSequence: cursor, sessionId: 's1', workerId: 'w1', openerTargetId: 'parent' });
+    expect(result.tabs).toEqual([{
+      tabId: 'ready', workerId: 'w1', url: 'https://example.com/', title: '', status: 'closed',
+    }]);
+  });
+
+  test('does not expose ready metadata until ownership registration commits', () => {
+    const ledger = new TargetCreationLedger();
+    const cursor = ledger.getCursor();
+    ledger.register({
+      targetId: 'child',
+      sessionId: 's1',
+      workerId: 'w1',
+      openerTargetId: 'parent',
+      state: 'ready',
+      url: 'https://example.com/child',
+      ownershipCommitted: false,
+    });
+
+    expect(ledger.query({ afterSequence: cursor, sessionId: 's1', workerId: 'w1', openerTargetId: 'parent' })).toMatchObject({
+      total: 0,
+      pendingCount: 1,
+    });
+
+    expect(ledger.markOwnershipCommitted('child')).toBe(true);
+    expect(ledger.query({ afterSequence: cursor, sessionId: 's1', workerId: 'w1', openerTargetId: 'parent' }).total).toBe(1);
+  });
+
+  test('filters exact session, worker, and opener and caps details at five', () => {
+    const ledger = new TargetCreationLedger();
+    const cursor = ledger.getCursor();
+    for (let i = 0; i < 7; i++) {
+      ledger.register({
+        targetId: `child-${i}`,
+        sessionId: 's1',
+        workerId: 'w1',
+        openerTargetId: 'parent',
+        state: 'ready',
+        url: `https://example.com/${i}`,
+      });
+    }
+    ledger.register({ targetId: 'other-worker', sessionId: 's1', workerId: 'w2', openerTargetId: 'parent', state: 'ready', url: 'https://example.com/w2' });
+    ledger.register({ targetId: 'other-session', sessionId: 's2', workerId: 'w1', openerTargetId: 'parent', state: 'ready', url: 'https://example.com/s2' });
+    ledger.register({ targetId: 'other-opener', sessionId: 's1', workerId: 'w1', openerTargetId: 'other', state: 'ready', url: 'https://example.com/other' });
+
+    const result = ledger.query({ afterSequence: cursor, sessionId: 's1', workerId: 'w1', openerTargetId: 'parent', limit: 5 });
+    expect(result.total).toBe(7);
+    expect(result.truncated).toBe(true);
+    expect(result.tabs.map((tab) => tab.tabId)).toEqual(['child-0', 'child-1', 'child-2', 'child-3', 'child-4']);
+  });
+
+  test('sanitizes credentials, fragments, control characters, and output length', () => {
+    expect(sanitizeTargetUrl('https://user:secret@example.com/path?q=1#token')).toBe('https://example.com/path?q=1');
+    expect(sanitizeTargetTitle('  Hello\n\u0000World  ')).toBe('Hello World');
+    expect(sanitizeTargetTitle('x'.repeat(500))).toHaveLength(200);
+  });
+
+  test('remaps child IDs and opener aliases without changing creation provenance', () => {
+    const ledger = new TargetCreationLedger();
+    const cursor = ledger.getCursor();
+    ledger.register({
+      targetId: 'child-old', sessionId: 's1', workerId: 'w1', openerTargetId: 'parent-old',
+      state: 'ready', url: 'https://example.com',
+    });
+
+    expect(ledger.remapTargetId('parent-old', 'parent-new')).toBe(true);
+    expect(ledger.remapTargetId('child-old', 'child-new')).toBe(true);
+    expect(ledger.get('child-new')).toMatchObject({
+      openerTargetId: 'parent-old',
+      currentOpenerTargetId: 'parent-new',
+    });
+    expect(ledger.query({ afterSequence: cursor, sessionId: 's1', workerId: 'w1', openerTargetId: 'parent-new' }).tabs[0].tabId).toBe('child-new');
+  });
+
+  test('clears session/worker state and remains bounded', () => {
+    const ledger = new TargetCreationLedger(3);
+    ledger.register({ targetId: 'a', sessionId: 's1', workerId: 'w1', openerTargetId: 'p', state: 'blocked' });
+    ledger.register({ targetId: 'b', sessionId: 's1', workerId: 'w1', openerTargetId: 'p', state: 'provisional' });
+    ledger.markClosed('b');
+    ledger.register({ targetId: 'c', sessionId: 's1', workerId: 'w2', openerTargetId: 'p', state: 'ready', url: 'https://example.com/c' });
+    ledger.register({ targetId: 'd', sessionId: 's2', workerId: 'w1', openerTargetId: 'p', state: 'ready', url: 'https://example.com/d' });
+    expect(ledger.size).toBe(3);
+
+    ledger.clearWorker('s1', 'w2');
+    expect(ledger.get('c')).toBeUndefined();
+    ledger.clearSession('s2');
+    expect(ledger.get('d')).toBeUndefined();
+  });
+});

--- a/tests/tools/interact-opened-tabs.test.ts
+++ b/tests/tools/interact-opened-tabs.test.ts
@@ -1,0 +1,211 @@
+import { createMockSessionManager } from '../utils/mock-session';
+
+const mockResolveElementsByAXTree = jest.fn();
+const mockDiscoverElements = jest.fn();
+const mockResolveLocatorFallback = jest.fn();
+
+jest.mock('../../src/session-manager', () => ({ getSessionManager: jest.fn() }));
+jest.mock('../../src/utils/ref-id-manager', () => ({
+  getRefIdManager: jest.fn(() => ({
+    generateRef: jest.fn().mockReturnValue('ref_1'),
+    getBackendDOMNodeId: jest.fn(),
+    isRefStale: jest.fn().mockReturnValue(false),
+    resolveToBackendNodeId: jest.fn(),
+  })),
+}));
+jest.mock('../../src/utils/ax-element-resolver', () => ({
+  resolveElementsByAXTree: (...args: unknown[]) => mockResolveElementsByAXTree(...args),
+  invalidateAXCache: jest.fn(),
+  MATCH_LEVEL_LABELS: { 1: 'exact match' },
+}));
+jest.mock('../../src/utils/dom-delta', () => ({
+  withDomDelta: jest.fn().mockImplementation(async (_page: unknown, fn: () => Promise<void>) => {
+    await fn();
+    return { delta: '' };
+  }),
+}));
+jest.mock('../../src/utils/element-discovery', () => ({
+  discoverElements: (...args: unknown[]) => mockDiscoverElements(...args),
+  cleanupTags: jest.fn().mockResolvedValue(undefined),
+  getTaggedElementRect: jest.fn().mockResolvedValue(null),
+  DISCOVERY_TAG: 'data-oc-discovery',
+}));
+jest.mock('../../src/stealth/human-behavior', () => ({
+  humanMouseMove: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../src/utils/with-timeout', () => ({
+  withTimeout: jest.fn().mockImplementation(async (promise: Promise<unknown>) => promise),
+}));
+jest.mock('../../src/core/perception/verify', () => ({
+  coerceVerifyMode: jest.fn().mockReturnValue('none'),
+  runVerify: jest.fn().mockImplementation(async (_page: unknown, _mode: unknown, fn: () => Promise<unknown>) => ({
+    result: await fn(),
+    verify: undefined,
+  })),
+  VERIFY_FIELD_SCHEMA: { type: 'string' },
+}));
+jest.mock('../../src/core/perception/locator-fallback', () => ({
+  getLocatorFallbackProvider: jest.fn().mockReturnValue({ name: 'test-provider' }),
+  isLocatorFallbackEnabled: (value: unknown) => Boolean(value && typeof value === 'object' && (value as { enabled?: boolean }).enabled),
+  locatorFallbackThreshold: jest.fn().mockReturnValue(0.7),
+  resolveLocatorFallback: (...args: unknown[]) => mockResolveLocatorFallback(...args),
+}));
+jest.mock('../../src/harness/flags', () => ({ isPilotEnabled: jest.fn().mockReturnValue(false) }));
+jest.mock('../../src/tools/_shared/replay-recorder', () => ({
+  captureBackendNodeReplayStep: jest.fn().mockResolvedValue(undefined),
+  shouldCaptureReplayArtifact: jest.fn().mockReturnValue(false),
+}));
+jest.mock('../../src/core/browser-lanes', () => ({
+  applyLaneTarget: (args: Record<string, unknown>) => args,
+  recordLaneToolCall: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { getSessionManager } from '../../src/session-manager';
+import { registerInteractTool } from '../../src/tools/interact';
+
+type Handler = (sessionId: string, args: Record<string, unknown>) => Promise<any>;
+
+function getHandler(): Handler {
+  let handler: Handler | undefined;
+  registerInteractTool({
+    registerTool: (_name: string, registered: Handler) => { handler = registered; },
+  } as never);
+  if (!handler) throw new Error('interact handler not registered');
+  return handler;
+}
+
+describe('interact opened-tab observation across resolver paths', () => {
+  let manager: ReturnType<typeof createMockSessionManager>;
+  let sessionId: string;
+  let tabId: string;
+  let page: any;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    sessionId = 's1';
+    manager = createMockSessionManager();
+    ({ targetId: tabId, page } = await manager.createTarget(sessionId, 'https://example.com'));
+    (manager as any).isStealthTarget = jest.fn().mockReturnValue(false);
+    (getSessionManager as jest.Mock).mockReturnValue(manager);
+    (manager.getTargetCreationCursor as jest.Mock).mockReturnValue(20);
+    (manager.getOpenedTabsAfter as jest.Mock).mockReturnValue({
+      total: 1,
+      truncated: false,
+      pendingCount: 0,
+      tabs: [{
+        tabId: 'popup-1',
+        workerId: 'default',
+        url: 'https://example.com/next',
+        title: 'Next',
+        status: 'ready',
+      }],
+    });
+    page.evaluate.mockResolvedValue({
+      url: 'https://example.com',
+      title: 'Example',
+      activeInfo: 'none',
+      scrollX: 0,
+      scrollY: 0,
+      panels: [],
+      headings: [],
+    });
+    manager.mockCDPClient.send.mockImplementation(async (_page: unknown, method: string) => {
+      if (method === 'DOM.getBoxModel') {
+        return { model: { content: [10, 20, 110, 20, 110, 60, 10, 60] } };
+      }
+      return {};
+    });
+    mockResolveElementsByAXTree.mockResolvedValue([]);
+    mockDiscoverElements.mockResolvedValue([]);
+    mockResolveLocatorFallback.mockResolvedValue({ provider: 'test-provider', accepted: null, rejected: [] });
+  });
+
+  test('AX click upgrades an empty DOM delta from SILENT_CLICK to confirmed success', async () => {
+    mockResolveElementsByAXTree.mockResolvedValueOnce([{
+      backendDOMNodeId: 101,
+      role: 'button',
+      name: 'Open',
+      matchLevel: 1,
+      rect: { x: 50, y: 40, width: 100, height: 40 },
+    }]);
+
+    const result = await getHandler()(sessionId, { tabId, query: 'Open', action: 'click' });
+
+    expect(result.openedTabCount).toBe(1);
+    expect(result.content[0].text).toContain('✓ Clicked button "Open"');
+    expect(result.content[0].text).not.toContain('no DOM change detected');
+  });
+
+  test('CSS fallback click uses the same opened-tab contract', async () => {
+    mockDiscoverElements.mockResolvedValueOnce([{
+      backendDOMNodeId: 202,
+      role: 'button',
+      name: 'Open report',
+      tagName: 'button',
+      textContent: 'Open report',
+      rect: { x: 50, y: 40, width: 100, height: 40 },
+    }]);
+
+    const result = await getHandler()(sessionId, { tabId, query: 'Open report', action: 'click' });
+
+    expect(result.openedTabs[0].tabId).toBe('popup-1');
+    expect(result.content[0].text).toContain('✓ Clicked button "Open report"');
+    expect(result.content[0].text).toContain('[Opened tabs]');
+  });
+
+  test('locator fallback click uses the same opened-tab contract', async () => {
+    mockResolveLocatorFallback.mockResolvedValueOnce({
+      provider: 'test-provider',
+      accepted: {
+        selector: '#open',
+        label: 'Open report',
+        provider: 'test-provider',
+        confidence: 0.95,
+        reason: 'semantic match',
+        rect: { x: 50, y: 40, width: 100, height: 40 },
+      },
+      rejected: [],
+    });
+
+    const result = await getHandler()(sessionId, {
+      tabId,
+      query: 'Open report',
+      action: 'click',
+      locatorFallback: { enabled: true },
+    });
+
+    expect(result.openedTabCount).toBe(1);
+    expect(result.locatorFallback.accepted).toBe(true);
+    expect(result.content[0].text).toContain('[Opened tabs]');
+  });
+
+  test('locator fallback type enters text without opened-tab confirmation', async () => {
+    mockResolveLocatorFallback.mockResolvedValueOnce({
+      provider: 'test-provider',
+      accepted: {
+        selector: '#name',
+        label: 'Name',
+        provider: 'test-provider',
+        confidence: 0.95,
+        reason: 'semantic match',
+        rect: { x: 50, y: 40, width: 100, height: 40 },
+      },
+      rejected: [],
+    });
+
+    const result = await getHandler()(sessionId, {
+      tabId,
+      query: 'Name',
+      action: 'type',
+      value: 'Ada',
+      locatorFallback: { enabled: true },
+    });
+
+    expect(page.mouse.click).toHaveBeenCalledWith(50, 40);
+    expect(page.keyboard.type).toHaveBeenCalledWith('Ada');
+    expect(manager.getTargetCreationCursor).not.toHaveBeenCalled();
+    expect(manager.getOpenedTabsAfter).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain('Typed into locator fallback candidate');
+    expect(result).not.toHaveProperty('openedTabCount');
+  });
+});

--- a/tests/tools/interact.coordinate.test.ts
+++ b/tests/tools/interact.coordinate.test.ts
@@ -281,4 +281,140 @@ describe('interact tool — coordinate mode', () => {
     expect(result.isError).toBeFalsy();
     expect(result.content[0].text).toMatch(/Clicked coordinate \(100, 200\)/);
   });
+
+  test('coordinate click reports opener-correlated tabs without changing the no-tab contract', async () => {
+    (mockSessionManager.getTargetWorkerId as jest.Mock).mockReturnValue('default');
+    (mockSessionManager.getTargetCreationCursor as jest.Mock).mockReturnValue(10);
+    (mockSessionManager.getOpenedTabsAfter as jest.Mock).mockReturnValue({
+      total: 1,
+      truncated: false,
+      pendingCount: 0,
+      tabs: [{
+        tabId: 'popup-1',
+        workerId: 'default',
+        url: 'https://example.com/next',
+        title: 'Next',
+        status: 'ready',
+      }],
+    });
+
+    const result = await callInteract({
+      tabId: 'tab-1',
+      mode: 'coordinate',
+      coordinate: { x: 100, y: 200 },
+    }) as any;
+
+    expect(result.openedTabCount).toBe(1);
+    expect(result.openedTabsTruncated).toBe(false);
+    expect(result.openedTabs[0]).toMatchObject({ tabId: 'popup-1', status: 'ready' });
+    expect(result.content[0].text).toContain('[Opened tabs]');
+  });
+
+  test('coordinate no-child response has no optional opened-tab fields', async () => {
+    (mockSessionManager.getTargetWorkerId as jest.Mock).mockReturnValue('default');
+    (mockSessionManager.getOpenedTabsAfter as jest.Mock).mockReturnValue({
+      total: 0,
+      truncated: false,
+      pendingCount: 0,
+      tabs: [],
+    });
+
+    const result = await callInteract({
+      tabId: 'tab-1',
+      mode: 'coordinate',
+      coordinate: { x: 100, y: 200 },
+    }) as any;
+
+    expect(result.content[0].text).toBe('Clicked coordinate (100, 200) via CDP');
+    expect(result).not.toHaveProperty('openedTabCount');
+    expect(result).not.toHaveProperty('openedTabs');
+  });
+
+  test('hover moves without clicking, querying, or reporting opened tabs', async () => {
+    (mockSessionManager.getTargetWorkerId as jest.Mock).mockReturnValue('default');
+
+    const result = await callInteract({
+      tabId: 'tab-1',
+      mode: 'coordinate',
+      action: 'hover',
+      coordinate: { x: 100, y: 200 },
+    }) as any;
+    const coordinateInput = await import('../../src/cdp/input');
+
+    expect(mockPage.mouse.move).toHaveBeenCalledWith(100, 200);
+    expect(coordinateInput.dispatchCoordinateClick).not.toHaveBeenCalled();
+    expect(mockSessionManager.getTargetCreationCursor).not.toHaveBeenCalled();
+    expect(result.content[0].text).toBe('Hovered coordinate (100, 200) via CDP');
+    expect(result).not.toHaveProperty('openedTabCount');
+  });
+
+  test('type focuses the coordinate and enters text without opened-tab confirmation', async () => {
+    (mockSessionManager.getTargetWorkerId as jest.Mock).mockReturnValue('default');
+
+    const result = await callInteract({
+      tabId: 'tab-1',
+      mode: 'coordinate',
+      action: 'type',
+      value: 'hello',
+      coordinate: { x: 100, y: 200 },
+    }) as any;
+    const coordinateInput = await import('../../src/cdp/input');
+
+    expect(coordinateInput.dispatchCoordinateClick).toHaveBeenCalledWith(
+      expect.anything(),
+      mockPage,
+      { x: 100, y: 200, button: 'left', clickCount: 1, modifiers: [] },
+    );
+    expect(mockPage.keyboard.type).toHaveBeenCalledWith('hello');
+    expect(mockSessionManager.getTargetCreationCursor).not.toHaveBeenCalled();
+    expect(result.content[0].text).toBe('Typed into coordinate (100, 200) via CDP');
+    expect(result).not.toHaveProperty('openedTabCount');
+  });
+
+  test('double_click dispatches two clicks and observes opener-correlated tabs', async () => {
+    (mockSessionManager.getTargetWorkerId as jest.Mock).mockReturnValue('default');
+    (mockSessionManager.getTargetCreationCursor as jest.Mock).mockReturnValue(10);
+    (mockSessionManager.getOpenedTabsAfter as jest.Mock).mockReturnValue({
+      total: 1,
+      truncated: false,
+      pendingCount: 0,
+      tabs: [{
+        tabId: 'popup-1',
+        workerId: 'default',
+        url: 'https://example.com/next',
+        title: 'Next',
+        status: 'ready',
+      }],
+    });
+
+    const result = await callInteract({
+      tabId: 'tab-1',
+      mode: 'coordinate',
+      action: 'double_click',
+      coordinate: { x: 100, y: 200 },
+    }) as any;
+    const coordinateInput = await import('../../src/cdp/input');
+
+    expect(coordinateInput.dispatchCoordinateClick).toHaveBeenCalledWith(
+      expect.anything(),
+      mockPage,
+      { x: 100, y: 200, button: 'left', clickCount: 2, modifiers: [] },
+    );
+    expect(result.content[0].text).toContain('Double-clicked coordinate (100, 200) via CDP');
+    expect(result.openedTabCount).toBe(1);
+  });
+
+  test('queue-close races preserve the structured Interact error contract', async () => {
+    (mockSessionManager.validateTargetOwnership as jest.Mock).mockReturnValue(true);
+    (mockSessionManager.runTargetExclusive as jest.Mock).mockRejectedValueOnce(new Error('target closed while queued'));
+
+    const result = await callInteract({
+      tabId: 'tab-1',
+      mode: 'coordinate',
+      coordinate: { x: 100, y: 200 },
+    }) as any;
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe('Interact error: target closed while queued');
+  });
 });

--- a/tests/tools/interact.perception.test.ts
+++ b/tests/tools/interact.perception.test.ts
@@ -97,6 +97,7 @@ describe('interact tool - perception mode', () => {
   let handler: (sessionId: string, args: Record<string, unknown>) => Promise<MCPResult>;
   let page: ReturnType<typeof createMockPage>;
   let cdpSend: jest.Mock;
+  let sessionManager: Record<string, jest.Mock>;
   let nowSpy: jest.SpyInstance<number, []>;
 
   beforeAll(async () => {
@@ -122,12 +123,21 @@ describe('interact tool - perception mode', () => {
       }
       return {};
     });
-    (getSessionManager as jest.Mock).mockReturnValue({
+    sessionManager = {
       getPage: jest.fn().mockResolvedValue(page),
       getAvailableTargets: jest.fn().mockResolvedValue([]),
       getCDPClient: jest.fn().mockReturnValue({ send: cdpSend }),
       isStealthTarget: jest.fn().mockReturnValue(false),
-    });
+      getTargetWorkerId: jest.fn().mockReturnValue('default'),
+      getTargetCreationCursor: jest.fn().mockReturnValue(20),
+      getOpenedTabsAfter: jest.fn().mockReturnValue({
+        total: 0,
+        truncated: false,
+        pendingCount: 0,
+        tabs: [],
+      }),
+    };
+    (getSessionManager as jest.Mock).mockReturnValue(sessionManager);
   });
 
   afterEach(() => {
@@ -210,6 +220,79 @@ describe('interact tool - perception mode', () => {
       expect(page.mouse.move).toHaveBeenCalledWith(240, 320);
     }
     expect(result.structuredContent).toMatchObject({ action });
+  });
+
+  test('reports opener-correlated tabs created by a perception click', async () => {
+    sessionManager.getOpenedTabsAfter.mockReturnValue({
+      total: 1,
+      truncated: false,
+      pendingCount: 0,
+      tabs: [{
+        tabId: 'popup-1',
+        workerId: 'default',
+        url: 'https://example.test/report',
+        title: 'Report',
+        status: 'ready',
+      }],
+    });
+
+    const result = await callPerception();
+
+    expect(sessionManager.getTargetCreationCursor).toHaveBeenCalledTimes(1);
+    expect(sessionManager.getOpenedTabsAfter).toHaveBeenCalledWith({
+      afterSequence: 20,
+      sessionId: 'session-1',
+      workerId: 'default',
+      openerTargetId: 'tab-1',
+      limit: 5,
+    });
+    expect(result).toMatchObject({
+      openedTabCount: 1,
+      openedTabsTruncated: false,
+      openedTabs: [{ tabId: 'popup-1', status: 'ready' }],
+    });
+    expect(result.content?.[0].text).toContain('[Opened tabs]');
+    expect(result.structuredContent).toMatchObject({ mode: 'perception', action: 'click' });
+  });
+
+  test('reports opener-correlated tabs created by a perception double-click', async () => {
+    sessionManager.getOpenedTabsAfter.mockReturnValue({
+      total: 1,
+      truncated: false,
+      pendingCount: 0,
+      tabs: [{
+        tabId: 'popup-2',
+        workerId: 'default',
+        url: 'https://example.test/details',
+        title: 'Details',
+        status: 'ready',
+      }],
+    });
+
+    const result = await callPerception({ action: 'double_click' });
+
+    expect(page.mouse.click).toHaveBeenCalledWith(240, 320, { clickCount: 2 });
+    expect(sessionManager.getOpenedTabsAfter).toHaveBeenCalledWith({
+      afterSequence: 20,
+      sessionId: 'session-1',
+      workerId: 'default',
+      openerTargetId: 'tab-1',
+      limit: 5,
+    });
+    expect(result).toMatchObject({
+      openedTabCount: 1,
+      openedTabs: [{ tabId: 'popup-2', status: 'ready' }],
+    });
+    expect(result.structuredContent).toMatchObject({ mode: 'perception', action: 'double_click' });
+  });
+
+  test('does not observe opened tabs for a perception hover', async () => {
+    const result = await callPerception({ action: 'hover' });
+
+    expect(sessionManager.getTargetCreationCursor).not.toHaveBeenCalled();
+    expect(sessionManager.getOpenedTabsAfter).not.toHaveBeenCalled();
+    expect(result).not.toHaveProperty('openedTabCount');
+    expect(result).not.toHaveProperty('openedTabs');
   });
 
   test.each([

--- a/tests/tools/snapshot-refs.test.ts
+++ b/tests/tools/snapshot-refs.test.ts
@@ -218,6 +218,36 @@ describe('Snapshot Refs (#831)', () => {
       expect(resolveElementsByAXTree).not.toHaveBeenCalled();
     });
 
+    test('fresh ref click reports opener-correlated tabs', async () => {
+      const handler = await getInteractHandler();
+      const refId = mockRefIdManager.generateRef(testSessionId, testTargetId, 4242, 'button', 'Open report');
+      mockSessionManager.mockCDPClient.send
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ model: { content: [10, 20, 110, 20, 110, 60, 10, 60] } });
+      (mockSessionManager.getTargetCreationCursor as jest.Mock).mockReturnValue(12);
+      (mockSessionManager.getOpenedTabsAfter as jest.Mock).mockReturnValue({
+        total: 1,
+        truncated: false,
+        pendingCount: 0,
+        tabs: [{
+          tabId: 'popup-ref',
+          workerId: 'default',
+          url: 'https://example.com/report',
+          title: 'Report',
+          status: 'ready',
+        }],
+      });
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        ref: refId,
+        action: 'click',
+      }) as { openedTabCount?: number; content: Array<{ text: string }> };
+
+      expect(result.openedTabCount).toBe(1);
+      expect(result.content[0].text).toContain('tabId=popup-ref');
+    });
+
     test('stale ref (TTL expired) → STALE_REF error', async () => {
       const handler = await getInteractHandler();
 

--- a/tests/utils/mock-session.ts
+++ b/tests/utils/mock-session.ts
@@ -6,6 +6,7 @@
 
 import { Page } from 'puppeteer-core';
 import { createMockPage, createMockCDPClient } from './mock-cdp';
+import { TargetCreationLedger } from '../../src/session/target-creation-ledger';
 
 export interface MockWorker {
   id: string;
@@ -45,6 +46,7 @@ export function createMockSessionManager(options: MockSessionManagerOptions = {}
   const targetToWorker: Map<string, { sessionId: string; workerId: string }> = new Map();
   const pages: Map<string, Page> = new Map();
   const mockCDPClient = createMockCDPClient();
+  const targetCreationLedger = new TargetCreationLedger();
 
   // Initialize with provided sessions
   if (options.initialSessions) {
@@ -114,6 +116,7 @@ export function createMockSessionManager(options: MockSessionManagerOptions = {}
             targetToWorker.delete(targetId);
           }
         }
+        targetCreationLedger.clearSession(sessionId);
         sessions.delete(sessionId);
       }
     }),
@@ -186,6 +189,7 @@ export function createMockSessionManager(options: MockSessionManagerOptions = {}
           pages.delete(targetId);
           targetToWorker.delete(targetId);
         }
+        targetCreationLedger.clearWorker(sessionId, workerId);
         session.workers.delete(workerId);
       }
     }),
@@ -200,14 +204,55 @@ export function createMockSessionManager(options: MockSessionManagerOptions = {}
 
     registerExternalTarget: jest.fn().mockImplementation((targetId: string, sessionId: string, workerId: string) => {
       const session = sessions.get(sessionId);
-      if (!session) return;
+      if (!session) return false;
       const worker = session.workers.get(workerId);
-      if (!worker) return;
-      if (targetToWorker.has(targetId)) return;
+      if (!worker) return false;
+      if (targetToWorker.has(targetId)) return true;
       worker.targets.add(targetId);
       worker.lastActivityAt = Date.now();
       targetToWorker.set(targetId, { sessionId, workerId });
+      return true;
     }),
+
+    registerPopupTarget: jest.fn().mockImplementation(async (
+      targetId: string,
+      openerTargetId: string,
+      options: { state: 'provisional' | 'ready' | 'blocked'; url?: string; title?: string },
+    ) => {
+      const owner = targetToWorker.get(openerTargetId);
+      if (!owner) return false;
+      targetCreationLedger.register({
+        targetId,
+        sessionId: owner.sessionId,
+        workerId: owner.workerId,
+        openerTargetId,
+        state: options.state,
+        url: options.url,
+        title: options.title,
+        ownershipCommitted: false,
+      });
+      if (options.state === 'blocked') return false;
+      const registered = await manager.registerExternalTarget(targetId, owner.sessionId, owner.workerId);
+      if (!registered) {
+        targetCreationLedger.markBlocked(targetId);
+        return false;
+      }
+      return targetCreationLedger.markOwnershipCommitted(targetId);
+    }),
+
+    getTargetCreationCursor: jest.fn().mockImplementation(() => targetCreationLedger.getCursor()),
+    hasTargetCreationRecord: jest.fn().mockImplementation((targetId: string) => targetCreationLedger.has(targetId)),
+    markPopupTargetReady: jest.fn().mockImplementation((targetId: string, metadata: { url?: string; title?: string }) =>
+      targetCreationLedger.markReady(targetId, metadata)),
+    markPopupTargetBlocked: jest.fn().mockImplementation((targetId: string) => targetCreationLedger.markBlocked(targetId)),
+    getOpenedTabsAfter: jest.fn().mockImplementation((input: {
+      afterSequence: number;
+      sessionId: string;
+      workerId: string;
+      openerTargetId: string;
+      limit?: number;
+    }) => targetCreationLedger.query(input)),
+    runTargetExclusive: jest.fn().mockImplementation(async (_sessionId: string, _targetId: string, fn: () => Promise<unknown>) => fn()),
 
     registerHeadedPage: jest.fn().mockImplementation((targetId: string, sessionId: string, workerId: string, page: Page) => {
       manager.registerExternalTarget(targetId, sessionId, workerId);
@@ -295,6 +340,7 @@ export function createMockSessionManager(options: MockSessionManagerOptions = {}
         }
         targetToWorker.delete(targetId);
         pages.delete(targetId);
+        targetCreationLedger.markClosed(targetId);
       }
     }),
 
@@ -358,6 +404,7 @@ export function createMockSessionManager(options: MockSessionManagerOptions = {}
 
     _getPages: () => pages,
     _getSessions: () => sessions,
+    _getTargetCreationLedger: () => targetCreationLedger,
   };
 
   return manager;


### PR DESCRIPTION
## Summary

- add a bounded target-creation ledger with monotonic cursors, exact session/worker/opener filtering, ownership commit gating, lifecycle reconciliation, and sanitized metadata
- register managed `about:blank` popups provisionally, promote only allowed URLs, and fail closed on blocked URLs, deletion races, or popup initialization failures
- serialize the complete `interact` mutation/observation/post-state window per source target while preserving cross-target parallelism
- return optional `openedTabCount`, `openedTabsTruncated`, and `openedTabs` facts plus one bounded `[Opened tabs]` text line
- treat an otherwise `SILENT_CLICK` AX/CSS result as confirmed when an eligible opener-correlated child is observed
- cover the latest `mode: "perception"` click and double-click paths while keeping hover/type outside opened-tab confirmation
- preserve requested coordinate and locator-fallback action semantics so hover does not click and type still enters text

## Directional fit

This adopts Browser Use's useful immediate new-tab awareness without importing its agent loop or focus policy. The implementation deliberately rejects whole-tab before/after diffs and automatic tab switching because both conflict with OpenChrome's explicit-tab, host-neutral harness direction.

OpenChrome reports the browser side effect. The host still decides whether to continue on the source tab, act on the returned `tabId`, close it, or explicitly activate it through a separate surface.

## Guardrails

- no whole-session tab diff
- no automatic focus, activation, or switching
- no cross-session or cross-worker disclosure
- no success evidence from provisional, blocked, unowned, or failed-initialization targets
- no opened-tab success semantics for hover or type
- no new dependency
- no changes to `act`, `computer`, download handling, or explicit activation
- no optional result fields when no child opens

## Validation

- `npm run build`
- `npm run lint:changed`
- `npm run lint:tier`
- `npm run lint:tool-schemas`
- 9 focused Jest suites: 93 passed
- perception integration suite after the final assertion: 23 passed
- real headed Google Chrome fixture: 2 passed, covering direct popup, delayed `about:blank` navigation, blocked popup, and continued source-tab ownership
- independent post-rebase adversarial review: final `APPROVE`
- GitHub CI: macOS, Windows, Node 18, Node 22, E2E smoke, and all three Node 20 full-test shards passed
- Node 20 shard 2 initially hit an unrelated `health-endpoint-gating` child-shutdown timeout; the isolated test passed 7/7 locally and the failed job passed unchanged on rerun
- `git diff --check`

## Known validation boundary

`npx tsc -p tsconfig.test.json --noEmit` remains blocked only by pre-existing unrelated errors:

- `extension/src/tools/navigate.ts`: missing `chrome.tabs.TabChangeInfo`
- `tests/benchmark/webvoyager/llm/claude-adapter.ts`: missing `WebVoyagerLibrary`

Source and CLI builds pass.

Closes #1559
