### PR TITLE
test(e2e): repair residual nightly contracts

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -115,6 +115,7 @@ export class CDPClient {
   private cookieSourceCache: Map<string, { targetId: string; timestamp: number }> = new Map();
   private cookieDataCache: Map<string, { cookies: CookieEntry[]; timestamp: number }> = new Map();
   private targetIdIndex = new TargetPageIndex();
+  private startupPageReuseAttempted = new WeakSet<Browser>();
   private targetActivityAt: Map<string, number> = new Map();
   private inFlightCookieScans: Map<string, Promise<CookieScanResult>> = new Map();
   private lastCookieScanResult: CookieScanResult | null = null;
@@ -1774,7 +1775,10 @@ export class CDPClient {
 
 
   private async findReusableStartupPage(browser: Browser): Promise<Page | null> {
-    if (this.targetIdIndex.size !== 0 || this.getChromeLifecycleMode() !== 'isolated') return null;
+    if (this.getChromeLifecycleMode() !== 'isolated' || this.startupPageReuseAttempted.has(browser)) return null;
+    this.startupPageReuseAttempted.add(browser);
+    if (this.targetIdIndex.size !== 0) return null;
+
     const candidates = browser.targets().filter((target) => {
       if (target.type() !== 'page') return false;
       const targetId = getTargetId(target);
@@ -1786,11 +1790,22 @@ export class CDPClient {
         || targetUrl.startsWith('chrome://new-tab-page');
     });
     if (candidates.length !== 1) return null;
+    const targetId = getTargetId(candidates[0]);
+    if (!targetId) return null;
+
+    let page: Page | null;
     try {
-      return await candidates[0].page();
+      page = await candidates[0].page();
     } catch {
       return null;
     }
+
+    if (this.browser !== browser || !browser.isConnected()) {
+      throw new Error('Chrome connection changed while resolving the startup page');
+    }
+    if (!page || page.isClosed()) return null;
+    if (!browser.targets().some((target) => getTargetId(target) === targetId)) return null;
+    return page;
   }
 
   /**

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1896,7 +1896,7 @@ export class MCPServer {
           const timeout = setTimeout(() => {
             cdpClient.removeConnectionListener(listener);
             resolve('timeout');
-          }, DEFAULT_SESSION_INIT_TIMEOUT_MS);
+          }, DEFAULT_RECONNECT_TIMEOUT_MS);
 
           const listener = (event: ConnectionEvent) => {
             if (event.type === 'reconnected' || event.type === 'connected') {

--- a/tests/cdp/client-contracts.test.ts
+++ b/tests/cdp/client-contracts.test.ts
@@ -171,6 +171,116 @@ describe('CDPClient target/page contracts (#687 Wave 4 prereq)', () => {
     expect(await client.getPageByTargetId('startup-target')).toBe(startupPage);
   });
 
+  it('createPage attempts startup reuse only once during concurrent page hydration', async () => {
+    const startupPage = makePage('startup-target', 'chrome://newtab/');
+    const startupTarget = makeTarget('startup-target', startupPage, 'page', 'chrome://newtab/');
+    let resolveStartupPage!: (page: MockPage | null) => void;
+    const startupPageReady = new Promise<MockPage | null>((resolve) => {
+      resolveStartupPage = resolve;
+    });
+    startupTarget.page.mockImplementation(() => startupPageReady);
+
+    const freshPage = makePage('fresh-target');
+    const browser = makeBrowser([], [startupTarget]);
+    browser.newPage.mockResolvedValue(freshPage);
+    const client = connectedClient(browser);
+
+    const firstPagePromise = client.createPage('https://first.test/', null, true);
+    await Promise.resolve();
+    const secondPagePromise = client.createPage('https://second.test/', null, true);
+    resolveStartupPage(startupPage);
+
+    await expect(firstPagePromise).resolves.toBe(startupPage);
+    await expect(secondPagePromise).resolves.toBe(freshPage);
+    expect(startupTarget.page).toHaveBeenCalledTimes(1);
+    expect(browser.newPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('createPage does not reuse a later blank page while three page creations overlap', async () => {
+    const startupPage = makePage('startup-target', 'chrome://newtab/');
+    const startupTarget = makeTarget('startup-target', startupPage, 'page', 'chrome://newtab/');
+    let resolveStartupPage!: (page: MockPage | null) => void;
+    const startupPageReady = new Promise<MockPage | null>((resolve) => {
+      resolveStartupPage = resolve;
+    });
+    startupTarget.page.mockImplementation(() => startupPageReady);
+
+    const secondPage = makePage('second-target');
+    const secondTarget = makeTarget('second-target', secondPage, 'page', 'about:blank');
+    let resolveSecondPage!: (page: MockPage) => void;
+    const secondPageReady = new Promise<MockPage>((resolve) => {
+      resolveSecondPage = resolve;
+    });
+    const thirdPage = makePage('third-target');
+    const visibleTargets = [startupTarget];
+    const browser = makeBrowser([], visibleTargets);
+    browser.newPage
+      .mockImplementationOnce(() => {
+        visibleTargets.push(secondTarget);
+        return secondPageReady;
+      })
+      .mockResolvedValueOnce(thirdPage);
+    const client = connectedClient(browser);
+
+    const firstPagePromise = client.createPage('https://first.test/', null, true);
+    await Promise.resolve();
+    const secondPagePromise = client.createPage('https://second.test/', null, true);
+    await Promise.resolve();
+    const thirdPagePromise = client.createPage('https://third.test/', null, true);
+    resolveStartupPage(startupPage);
+    resolveSecondPage(secondPage);
+
+    await expect(firstPagePromise).resolves.toBe(startupPage);
+    await expect(secondPagePromise).resolves.toBe(secondPage);
+    await expect(thirdPagePromise).resolves.toBe(thirdPage);
+    expect(startupTarget.page).toHaveBeenCalledTimes(1);
+    expect(secondTarget.page).not.toHaveBeenCalled();
+    expect(browser.newPage).toHaveBeenCalledTimes(2);
+  });
+
+  it('createPage rejects startup hydration that resolves after disconnect', async () => {
+    const startupPage = makePage('startup-target', 'chrome://newtab/');
+    const startupTarget = makeTarget('startup-target', startupPage, 'page', 'chrome://newtab/');
+    let resolveStartupPage!: (page: MockPage | null) => void;
+    const startupPageReady = new Promise<MockPage | null>((resolve) => {
+      resolveStartupPage = resolve;
+    });
+    startupTarget.page.mockImplementation(() => startupPageReady);
+    const browser = makeBrowser([], [startupTarget]);
+    const client = connectedClient(browser);
+
+    const pagePromise = client.createPage('https://stale.test/', null, true);
+    await Promise.resolve();
+    await client.disconnect();
+    resolveStartupPage(startupPage);
+
+    await expect(pagePromise).rejects.toThrow('Chrome connection changed while resolving the startup page');
+    expect(browser.newPage).not.toHaveBeenCalled();
+    expect(
+      (client as unknown as { targetIdIndex: { has(targetId: string): boolean } })
+        .targetIdIndex.has('startup-target'),
+    ).toBe(false);
+  });
+
+  it('createPage can reuse one startup page for each browser connection', async () => {
+    const firstStartupPage = makePage('first-startup', 'chrome://newtab/');
+    const firstStartupTarget = makeTarget('first-startup', firstStartupPage, 'page', 'chrome://newtab/');
+    const firstBrowser = makeBrowser([], [firstStartupTarget]);
+    const client = connectedClient(firstBrowser);
+
+    await expect(client.createPage('https://first.test/', null, true)).resolves.toBe(firstStartupPage);
+
+    const secondStartupPage = makePage('second-startup', 'chrome://newtab/');
+    const secondStartupTarget = makeTarget('second-startup', secondStartupPage, 'page', 'chrome://newtab/');
+    const secondBrowser = makeBrowser([], [secondStartupTarget]);
+    (client as unknown as { browser: unknown }).browser = secondBrowser;
+    (client as unknown as { targetIdIndex: { clear(): void } }).targetIdIndex.clear();
+
+    await expect(client.createPage('https://second.test/', null, true)).resolves.toBe(secondStartupPage);
+    expect(firstStartupTarget.page).toHaveBeenCalledTimes(1);
+    expect(secondStartupTarget.page).toHaveBeenCalledTimes(1);
+  });
+
   it('createPage does not reuse startup candidates outside safe first-call guards', async () => {
     const startupPage = makePage('startup-target', 'chrome://newtab/');
     const startupTarget = makeTarget('startup-target', startupPage, 'page', 'chrome://newtab/');

--- a/tests/e2e/harness/chrome-controller.test.ts
+++ b/tests/e2e/harness/chrome-controller.test.ts
@@ -1,0 +1,49 @@
+/// <reference types="jest" />
+
+jest.mock('child_process', () => ({ execSync: jest.fn() }));
+jest.mock('os', () => ({ platform: jest.fn() }));
+
+import { execSync } from 'child_process';
+import * as os from 'os';
+import { ChromeController } from './chrome-controller';
+
+const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
+const mockPlatform = os.platform as jest.MockedFunction<typeof os.platform>;
+
+describe('ChromeController PID discovery', () => {
+  beforeEach(() => {
+    mockExecSync.mockReset();
+    mockPlatform.mockReset();
+  });
+
+  test.each(['darwin', 'linux'] as const)(
+    'selects only the TCP listener on %s',
+    async (platform) => {
+      mockPlatform.mockReturnValue(platform);
+      mockExecSync.mockReturnValue('3043\n' as never);
+
+      const controller = new ChromeController();
+      await expect(controller.discoverPid(9222)).resolves.toBe(3043);
+      expect(mockExecSync).toHaveBeenCalledWith(
+        expect.stringContaining('-sTCP:LISTEN'),
+        { encoding: 'utf-8' },
+      );
+    },
+  );
+
+  test('parses the listening PID on Windows', async () => {
+    mockPlatform.mockReturnValue('win32');
+    mockExecSync.mockReturnValue('TCP 127.0.0.1:9222 0.0.0.0:0 LISTENING 4120' as never);
+
+    const controller = new ChromeController();
+    await expect(controller.discoverPid(9222)).resolves.toBe(4120);
+  });
+
+  test('rejects when no listener owns the debug port', async () => {
+    mockPlatform.mockReturnValue('linux');
+    mockExecSync.mockReturnValue('' as never);
+
+    const controller = new ChromeController();
+    await expect(controller.discoverPid(9222)).rejects.toThrow('No process found on port 9222');
+  });
+});

--- a/tests/e2e/harness/chrome-controller.ts
+++ b/tests/e2e/harness/chrome-controller.ts
@@ -22,14 +22,20 @@ export class ChromeController {
     try {
       let output: string;
       if (platform === 'darwin') {
-        output = execSync(`lsof -i :${debugPort} -t 2>/dev/null`, { encoding: 'utf-8' }).trim();
+        output = execSync(
+          `lsof -nP -iTCP:${debugPort} -sTCP:LISTEN -t 2>/dev/null`,
+          { encoding: 'utf-8' },
+        ).trim();
       } else if (platform === 'win32') {
         output = execSync(`netstat -ano | findstr :${debugPort} | findstr LISTENING`, { encoding: 'utf-8' }).trim();
         const parts = output.split(/\s+/);
         output = parts[parts.length - 1];
       } else {
         // Linux
-        output = execSync(`lsof -i :${debugPort} -t 2>/dev/null || ss -tlnp | grep :${debugPort} | grep -oP 'pid=\\K\\d+'`, { encoding: 'utf-8' }).trim();
+        output = execSync(
+          `lsof -nP -iTCP:${debugPort} -sTCP:LISTEN -t 2>/dev/null || ss -H -ltnp | grep :${debugPort} | grep -oP 'pid=\\K\\d+'`,
+          { encoding: 'utf-8' },
+        ).trim();
       }
 
       const pids = output.split('\n').map(p => parseInt(p.trim(), 10)).filter(p => !isNaN(p));

--- a/tests/e2e/scenarios/network-disruption.e2e.ts
+++ b/tests/e2e/scenarios/network-disruption.e2e.ts
@@ -9,13 +9,18 @@
  * connection and fail pending/new calls within a bounded timeout.
  */
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { execSync } from 'child_process';
 import { MCPClient } from '../harness/mcp-client';
 import { ChromeController } from '../harness/chrome-controller';
-import { sleep } from '../harness/time-scale';
 
-const CHROME_PORT = 9222;
+const CHROME_PORT = 19_500 + (process.pid % 500);
+const USER_DATA_DIR = path.join(os.tmpdir(), `openchrome-network-disruption-${process.pid}`);
+
+function realSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 function getFixturePort(): number {
   const stateFile = path.join(process.cwd(), '.e2e-state.json');
@@ -58,6 +63,7 @@ describe('E2E: Network Disruption Recovery', () => {
     mcp = new MCPClient({
       timeoutMs: 60_000,
       env: { OPENCHROME_MAX_RECONNECT_ATTEMPTS: '0' }, // infinite reconnect
+      args: ['--port', String(CHROME_PORT), '--user-data-dir', USER_DATA_DIR],
     });
     await mcp.start();
     chrome = new ChromeController();
@@ -71,6 +77,7 @@ describe('E2E: Network Disruption Recovery', () => {
       frozenPids = [];
     }
     await mcp.stop();
+    fs.rmSync(USER_DATA_DIR, { recursive: true, force: true });
   }, 30_000);
 
   test('tool calls return errors during disruption and recover after', async () => {
@@ -112,7 +119,7 @@ describe('E2E: Network Disruption Recovery', () => {
         console.error(`[network-disruption] Step 3b OK: Tool call errored (disrupted) after ${(i + 1) * 2}s`);
         break;
       }
-      await sleep(2_000);
+      await realSleep(2_000);
     }
     expect(disrupted).toBe(true);
 
@@ -128,8 +135,13 @@ describe('E2E: Network Disruption Recovery', () => {
       const result = await mcp.callTool('navigate', { url: `http://localhost:${port}/site-b` }, 25_000);
       callReturned = true;
       const elapsed = Date.now() - callStart;
-      // Server auto-recovered by launching new Chrome — this is valid self-healing
-      console.error(`[network-disruption] Step 4: navigate succeeded in ${elapsed}ms (auto-recovery)`);
+      if (result.raw?.isError) {
+        expect(result.text).toContain('Chrome reconnection');
+        console.error(`[network-disruption] Step 4: Server rejected during reconnect in ${elapsed}ms`);
+      } else {
+        expect(result.text).toContain('tabId');
+        console.error(`[network-disruption] Step 4: navigate succeeded in ${elapsed}ms (auto-recovery)`);
+      }
       expect(elapsed).toBeLessThan(25_000);
     } catch (err) {
       callReturned = true;
@@ -160,7 +172,7 @@ describe('E2E: Network Disruption Recovery', () => {
       } catch {
         // Still reconnecting
       }
-      await sleep(2_000);
+      await realSleep(2_000);
     }
     if (!reconnected) {
       console.error('[network-disruption] Step 5b: Reconnect not confirmed via health, proceeding anyway');
@@ -184,7 +196,7 @@ describe('E2E: Network Disruption Recovery', () => {
         console.error(
           `[network-disruption] Step 6: Attempt ${attempt} failed: ${(err as Error).message}`,
         );
-        if (attempt < 5) await sleep(5_000);
+        if (attempt < 5) await realSleep(5_000);
       }
     }
     expect(recovered).toBe(true);

--- a/tests/e2e/scenarios/rate-limiter.e2e.ts
+++ b/tests/e2e/scenarios/rate-limiter.e2e.ts
@@ -37,7 +37,10 @@ describe('E2E-16: Rate limiter under flood', () => {
     // Step 1: Navigate to establish page context
     console.error('[e2e-16] Step 1: Navigate to page');
     const navResult = await server.callTool('navigate', { url: testUrl });
-    expect(navResult.text).toBeDefined();
+    expect(navResult.raw?.isError).not.toBe(true);
+    const tabIdMatch = navResult.text.match(/"tabId"\s*:\s*"([A-F0-9]{32})"/);
+    const tabId = tabIdMatch?.[1] ?? '';
+    expect(tabId).toBeTruthy();
     console.error('[e2e-16] Step 1 OK: Page loaded');
 
     await sleep(500);
@@ -51,6 +54,7 @@ describe('E2E-16: Rate limiter under flood', () => {
     for (let i = 0; i < 20; i++) {
       try {
         const result = await server.callTool('javascript_tool', {
+          tabId,
           code: `"flood-${i}"`,
         });
         // Check if the result indicates rate limiting (isError with rate limit message)
@@ -75,26 +79,20 @@ describe('E2E-16: Rate limiter under flood', () => {
     // Step 3: Expect some succeed, some rejected
     expect(successes).toBeGreaterThan(0);
     expect(rateLimited).toBeGreaterThan(0);
+    expect(errors).toBe(0);
     console.error('[e2e-16] Step 3 OK: Mix of successes and rate-limited responses');
 
     // Step 4: No hangs, no crashes — test reached this point
     console.error('[e2e-16] Step 4 OK: No hangs or crashes during flood');
 
-    // Step 5: Server still works after flood — wait for token refill then make a normal call
-    console.error('[e2e-16] Step 5: Waiting for rate limit recovery, then testing normal call');
-    await sleep(15000); // Wait generously for tokens to refill (10 RPM = 1 every 6s)
-
-    try {
-      const normalResult = await server.callTool('javascript_tool', {
-        code: '"post-flood-ok"',
-      });
-      // Accept either a successful result or a rate-limited response — server is alive
-      expect(normalResult.text).toBeDefined();
-      console.error(`[e2e-16] Step 5 OK: Post-flood call returned: ${normalResult.text.slice(0, 50)}`);
-    } catch (err) {
-      // If still rate-limited or recovering, that's acceptable — server didn't crash
-      console.error(`[e2e-16] Step 5: Post-flood call failed (acceptable): ${(err as Error).message.slice(0, 80)}`);
-    }
+    // Step 5: Wait for one real token refill (10 RPM = one every 6s), then
+    // verify a non-browser diagnostic succeeds without depending on Chrome.
+    console.error('[e2e-16] Step 5: Waiting for rate limit recovery, then testing diagnostic call');
+    await new Promise((resolve) => setTimeout(resolve, 6500));
+    const recoveryResult = await server.callTool('oc_profile_status', {});
+    expect(recoveryResult.raw?.isError).not.toBe(true);
+    expect(recoveryResult.text).not.toContain('Rate limit exceeded');
+    console.error('[e2e-16] Step 5 OK: Rate limiter accepted a post-refill diagnostic');
 
     // Step 6: Verify server health via HTTP
     console.error('[e2e-16] Step 6: Health check');

--- a/tests/e2e/scenarios/repeated-tool-loop.e2e.ts
+++ b/tests/e2e/scenarios/repeated-tool-loop.e2e.ts
@@ -2,8 +2,12 @@
  * E2E: repeated identical tool-call loop hints.
  */
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { MCPClient, MCPToolResult } from '../harness/mcp-client';
+
+const CHROME_PORT = 20_000 + (process.pid % 500);
+const USER_DATA_DIR = path.join(os.tmpdir(), `openchrome-repeated-loop-${process.pid}`);
 
 function getFixturePort(): number {
   const stateFile = path.join(process.cwd(), '.e2e-state.json');
@@ -30,12 +34,16 @@ describe('E2E: repeated identical tool-call loop hints', () => {
   let mcp: MCPClient;
 
   beforeAll(async () => {
-    mcp = new MCPClient({ timeoutMs: 60_000 });
+    mcp = new MCPClient({
+      timeoutMs: 60_000,
+      args: ['--port', String(CHROME_PORT), '--user-data-dir', USER_DATA_DIR],
+    });
     await mcp.start();
   }, 60_000);
 
   afterAll(async () => {
     await mcp.stop();
+    fs.rmSync(USER_DATA_DIR, { recursive: true, force: true });
   }, 30_000);
 
   test('warns, escalates, resets, and stays session-scoped', async () => {
@@ -46,25 +54,27 @@ describe('E2E: repeated identical tool-call loop hints', () => {
     const tabId = extractTabId(nav);
     expect(tabId).toBeTruthy();
 
-    const args = { sessionId: 'loop-a', tabId, query: 'definitely-missing-loop-target', waitForMs: 0 };
-    await mcp.callTool('find', args);
-    await mcp.callTool('find', args);
-    const third = await mcp.callTool('find', args);
+    // navigate is exempt from the broader same-tool-success rule, so identical
+    // effective args exercise the exact repeated-call detector end to end.
+    const args = { sessionId: 'loop-a', tabId, url };
+    await mcp.callTool('navigate', args);
+    await mcp.callTool('navigate', args);
+    const third = await mcp.callTool('navigate', args);
     expect(third.text).toContain('Repeated identical tool call detected');
     expect(third.raw._hintMeta).toMatchObject({ severity: 'warning', rule: 'repeated-identical-tool-call' });
 
-    await mcp.callTool('find', args);
-    const fifth = await mcp.callTool('find', args);
+    await mcp.callTool('navigate', args);
+    const fifth = await mcp.callTool('navigate', args);
     expect(fifth.text).toContain('Repeated identical tool call detected');
     expect(fifth.raw._hintMeta).toMatchObject({ severity: 'critical', rule: 'repeated-identical-tool-call' });
 
     await mcp.callTool('navigate', { sessionId: 'loop-a', tabId, url: `http://localhost:${port}/site-b` });
-    const afterReset = await mcp.callTool('find', args);
+    const afterReset = await mcp.callTool('navigate', args);
     expect((afterReset.raw._hintMeta as { rule?: string } | undefined)?.rule).not.toBe('repeated-identical-tool-call');
 
     const navB = await mcp.callTool('navigate', { sessionId: 'loop-b', url });
     const tabIdB = extractTabId(navB);
-    const otherSession = await mcp.callTool('find', { sessionId: 'loop-b', tabId: tabIdB, query: 'definitely-missing-loop-target', waitForMs: 0 });
+    const otherSession = await mcp.callTool('navigate', { sessionId: 'loop-b', tabId: tabIdB, url });
     expect((otherSession.raw._hintMeta as { rule?: string } | undefined)?.rule).not.toBe('repeated-identical-tool-call');
   }, 120_000);
 });

--- a/tests/integration/health-endpoint-gating.test.ts
+++ b/tests/integration/health-endpoint-gating.test.ts
@@ -80,25 +80,30 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-function allocatePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = net.createServer();
-    server.once('error', reject);
-    server.listen(0, '127.0.0.1', () => {
-      const address = server.address();
-      server.close((closeError) => {
-        if (closeError) {
-          reject(closeError);
-          return;
-        }
-        if (typeof address === 'object' && address !== null) {
-          resolve(address.port);
-        } else {
-          reject(new Error('ephemeral port allocation did not return an address'));
-        }
+async function allocateDistinctPorts(count: number): Promise<number[]> {
+  const reservations: net.Server[] = [];
+  try {
+    for (let i = 0; i < count; i++) {
+      const server = net.createServer();
+      reservations.push(server);
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', resolve);
       });
+    }
+
+    return reservations.map((server) => {
+      const address = server.address();
+      if (typeof address !== 'object' || address === null) {
+        throw new Error('ephemeral port allocation did not return an address');
+      }
+      return address.port;
     });
-  });
+  } finally {
+    await Promise.all(reservations.map((server) => new Promise<void>((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    })));
+  }
 }
 
 async function waitForLog(getLog: () => string, pattern: RegExp, timeoutMs: number): Promise<boolean> {
@@ -191,9 +196,7 @@ describeFn('health endpoint gating (issue #648)', () => {
 
   scenarios.forEach((scenario) => {
     test(scenario.name, async () => {
-      const healthPort = await allocatePort();
-      const chromePort = await allocatePort();
-      const httpPort = await allocatePort();
+      const [healthPort, chromePort, httpPort] = await allocateDistinctPorts(3);
       const env: NodeJS.ProcessEnv = {
         ...process.env,
         OPENCHROME_HEALTH_PORT: String(healthPort),
@@ -254,6 +257,15 @@ describeFn('health endpoint gating (issue #648)', () => {
         // after the SelfHealing log on those machines. Poll instead of guess.
         let probe: 'connected' | 'refused' | 'timeout' = 'refused';
         if (scenario.expectBound) {
+          const sawBoundLog = await waitForLog(
+            () => stderr,
+            new RegExp(`\\[HealthEndpoint\\] Health check: http://127\\.0\\.0\\.1:${healthPort}/health`),
+            10_000,
+          );
+          if (!sawBoundLog) {
+            throw new Error(`HealthEndpoint never confirmed its bound port ${healthPort}. stderr:\n${stderr}`);
+          }
+
           const deadline = Date.now() + 10_000;
           while (Date.now() < deadline) {
             probe = await probePort(healthPort, 300);


### PR DESCRIPTION
## Summary

- make the rate-limiter flood use a valid tab-bound browser tool and prove token refill with a non-browser diagnostic
- discover the Chrome debug-port listener instead of freezing or killing the MCP process connected to that port
- bound reconnect-gate waits with the existing 15-second reconnect timeout
- isolate disruption and repeated-loop Chrome instances on dedicated ports and profiles
- exercise the exact repeated-call detector with identical `navigate` calls
- make managed Chrome startup-tab reuse single-attempt per Browser so overlapping HTTP navigations cannot receive the same tab
- reserve health/chrome/http test ports simultaneously and wait for the child bind log before probing

## Failure evidence

Manual nightly run `30324728594` against merged PR #1577 failed in both lanes:

- `functional-http`: `rate-limiter.e2e.ts` omitted required `tabId`, so requests never reached the limiter
- `functional-stdio`: network disruption selected the MCP process instead of the Chrome listener; repeated-loop asserted a preempted lower-priority hint

Branch functional run `30325610680` proved the repaired stdio lane but exposed a real HTTP startup race: three concurrent navigations reused one startup tab before it was indexed. That race was fixed and exact-head run `30326722363` passed HTTP in 2m50s and stdio in 8m40s.

PR CI run `30326697305` then exposed an unrelated test-port race in `health-endpoint-gating.test.ts`: sequential ephemeral allocation could reuse the same port for the health and HTTP listeners, so the test read the transport `/health` payload instead of the self-healing endpoint. The test now reserves all three ports concurrently and requires the exact HealthEndpoint bind log before reading.

## Validation

- `npm run build`
- `npm run lint`
- `npm run lint:tier`
- 24 focused CDP/PID tests
- focused rate-limiter E2E: 10 successful calls, 10 rate-limited calls, zero unexpected errors, post-refill diagnostic accepted
- health endpoint gating: two concurrent passes, one `--detectOpenHandles` pass, one `jest.ci.config.js` pass
- independent focused code review: approved after the first target-claim design was rejected and replaced
- rebased onto `main` commit `90ab1f5f20ac2161bacc44f247184bcdf8a1a6cc`
- refreshed PR checks and exact-head functional run `30327273753` are in progress for `10e669596afd4c50d8c50cb9a7516d711c57a48c`

Local headed and headless Chrome processes exit independently on this workstation, so browser process scenarios are gated by Ubuntu Actions.

Tracking: #1571