### PR TITLE
fix(reliability): bound user JavaScript in the Chrome renderer

### DIFF
--- a/docs/roadmap/ssot-decisions.md
+++ b/docs/roadmap/ssot-decisions.md
@@ -230,6 +230,21 @@ cancellation (propagating the signal into specific CDP/Puppeteer calls and
 reconciling page state afterward) is a **future improvement, not part of the
 contract**.
 
+**Narrow best-effort exception.** User-supplied synchronous JavaScript sent by
+`javascript_tool` and `batch_execute` may pass the remaining tool budget to
+CDP `Runtime.evaluate.timeout`. The requested/default execution timeout is
+forwarded unchanged when the parent deadline has room for a small bounded
+response grace. If the parent deadline is tighter, the execution timeout is
+capped immediately before dispatch so Chrome can terminate CPU-bound evaluation
+and report the result before the caller-side guard wins. Session acquisition
+time is included in that calculation, and follow-up `Runtime.awaitPromise`
+formatting reuses the same absolute invocation deadline rather than starting a
+second timeout window. This does not roll back completed side
+effects or cancel unresolved promises, timers, fetches, workers, or other CDP
+operations. The general D5 contract therefore remains unchanged.
+`Runtime.evaluate.timeout` is an experimental CDP field; unsupported endpoints
+fail boundedly, with no fallback dispatch and no replay of user JavaScript.
+
 ---
 
 ## Still open

--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -29,9 +29,14 @@ import {
   DEFAULT_SESSION_INIT_MIN_ATTEMPT_MS,
 } from '../config/defaults';
 import { Budget, isLegacyBudgetMode } from '../utils/budget';
-import { withTimeout } from '../utils/with-timeout';
+import {
+  addTimeoutResponseGraceMs,
+  reserveTimeoutResponseGraceMs,
+  withTimeout,
+} from '../utils/with-timeout';
 import { getMetricsCollector } from '../metrics/collector';
 import { OpenChromeConnectionError } from '../errors/connection';
+import { OpenChromeTimeoutError } from '../errors/timeout';
 import { getStealthFingerprintDefenseScript, getStealthStackSanitizationScript } from '../stealth/fingerprint-defense';
 import { getIdleState } from '../utils/idle-state';
 import { assertDomainAllowed, isInternalBrowserUrl } from '../security/domain-guard';
@@ -68,6 +73,17 @@ export interface CDPClientOptions {
   heartbeatIntervalMs?: number;
   /** If true, auto-launch Chrome when not running (default: false) */
   autoLaunch?: boolean;
+}
+
+export interface CDPSendOptions {
+  /** Per-command guard. Overrides both Puppeteer's protocol timer and OpenChrome's send timer. */
+  timeoutMs?: number;
+  /** Absolute parent deadline shared by session acquisition and command dispatch. */
+  deadlineAt?: number;
+  /** Abort session acquisition or prevent dispatch after HTTP/request cancellation. */
+  signal?: AbortSignal;
+  /** Keep Runtime.evaluate's requested timeout exact when there is room, otherwise reserve response grace. */
+  reserveRuntimeEvaluateResponseGrace?: boolean;
 }
 
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
@@ -2289,8 +2305,26 @@ export class CDPClient {
   async send<T = unknown>(
     page: Page,
     method: string,
-    params?: Record<string, unknown>
+    params?: Record<string, unknown>,
+    options?: CDPSendOptions,
   ): Promise<T> {
+    const requestedTimeoutMs = options?.timeoutMs ?? DEFAULT_CDP_SEND_TIMEOUT_MS;
+    if (!Number.isFinite(requestedTimeoutMs) || requestedTimeoutMs <= 0) {
+      throw new Error('CDP send timeout must be a positive finite number');
+    }
+    if (options?.deadlineAt !== undefined && !Number.isFinite(options.deadlineAt)) {
+      throw new Error('CDP send deadline must be finite');
+    }
+    if (options?.signal?.aborted) {
+      throw options.signal.reason instanceof Error
+        ? options.signal.reason
+        : new Error(String(options.signal.reason ?? 'Aborted'));
+    }
+    const commandDeadlineAt = Date.now() + requestedTimeoutMs;
+    const effectiveDeadlineAt = options?.deadlineAt === undefined
+      ? commandDeadlineAt
+      : Math.min(commandDeadlineAt, options.deadlineAt);
+
     // Fail fast if the target is no longer valid (browser may have reconnected)
     const targetId = getTargetId(page.target());
     if (targetId && !this.targetIdIndex.has(targetId)) {
@@ -2302,10 +2336,62 @@ export class CDPClient {
       );
     }
 
-    const session = await this.getCDPSession(page);
+    const sessionWaitStartedAt = Date.now();
+    const sessionTimeoutMs = Math.max(0, effectiveDeadlineAt - sessionWaitStartedAt);
+    if (sessionTimeoutMs <= 0) {
+      throw new OpenChromeTimeoutError(`CDP ${method}`, 0, false, true);
+    }
+
+    let session: CDPSession;
+    try {
+      session = await withTimeout(
+        this.getCDPSession(page),
+        sessionTimeoutMs,
+        `CDP ${method} session acquisition`,
+        {
+          startTime: sessionWaitStartedAt,
+          deadlineMs: sessionTimeoutMs,
+          signal: options?.signal,
+        },
+      );
+    } catch (error) {
+      if (error instanceof OpenChromeTimeoutError) {
+        throw new OpenChromeTimeoutError(`CDP ${method}`, 0, false, true);
+      }
+      throw error;
+    }
+
+    if (options?.signal?.aborted) {
+      throw options.signal.reason instanceof Error
+        ? options.signal.reason
+        : new Error(String(options.signal.reason ?? 'Aborted'));
+    }
+
+    const timeoutMs = Math.max(0, effectiveDeadlineAt - Date.now());
+    if (timeoutMs <= 0) {
+      throw new OpenChromeTimeoutError(`CDP ${method}`, 0, false, true);
+    }
+
+    let commandParams = params;
+    if (
+      options?.reserveRuntimeEvaluateResponseGrace &&
+      method === 'Runtime.evaluate' &&
+      typeof params?.timeout === 'number'
+    ) {
+      const requestedExecutionTimeoutMs = params.timeout;
+      if (!Number.isFinite(requestedExecutionTimeoutMs) || requestedExecutionTimeoutMs <= 0) {
+        throw new Error('Runtime.evaluate timeout must be a positive finite number');
+      }
+      const requiredHostTimeoutMs = addTimeoutResponseGraceMs(requestedExecutionTimeoutMs);
+      const executionTimeoutMs = timeoutMs >= requiredHostTimeoutMs
+        ? requestedExecutionTimeoutMs
+        : reserveTimeoutResponseGraceMs(timeoutMs);
+      commandParams = { ...params, timeout: executionTimeoutMs };
+    }
+
     return withTimeout(
-      session.send(method as any, params as any) as Promise<T>,
-      DEFAULT_CDP_SEND_TIMEOUT_MS,
+      session.send(method as any, commandParams as any, { timeout: timeoutMs }) as Promise<T>,
+      timeoutMs,
       `CDP ${method}`
     );
   }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -213,6 +213,34 @@ function stringifyResultPayload(result: MCPResult): string {
 export function isConnectionError(error: unknown): boolean {
   if (error instanceof OpenChromeConnectionError) return true;
   const message = formatError(error);
+  const lowerMessage = message.toLowerCase();
+
+  // User-authored Runtime.evaluate and its follow-up Runtime.awaitPromise may
+  // report renderer timeouts, unsupported parameters, or stale remote objects
+  // as protocol errors. Only clearly connection-scoped variants may reconnect;
+  // every other error is non-retryable because replaying the whole tool can
+  // duplicate side effects that completed before result formatting failed.
+  const replaySensitiveRuntimeError = [
+    'protocol error (runtime.evaluate)',
+    'protocol error (runtime.awaitpromise)',
+  ].some(pattern => lowerMessage.includes(pattern));
+  if (replaySensitiveRuntimeError) {
+    const runtimeConnectionPatterns = [
+      'connection closed',
+      'session closed',
+      'target closed',
+      'target page, context or browser has been closed',
+      'websocket is not open',
+      'browser has disconnected',
+      'browser disconnected',
+      'execution context was destroyed',
+      'cannot find context with specified id',
+      'inspected target navigated or closed',
+      'cdpsession connection closed',
+    ];
+    return runtimeConnectionPatterns.some(pattern => lowerMessage.includes(pattern));
+  }
+
   const patterns = [
     'not connected to chrome',
     'call connect() first',
@@ -231,7 +259,6 @@ export function isConnectionError(error: unknown): boolean {
     'puppeteer.connect() timed out',
     'session initialization timed out',
   ];
-  const lowerMessage = message.toLowerCase();
   return patterns.some(pattern => lowerMessage.includes(pattern));
 }
 

--- a/src/tools/batch-execute.ts
+++ b/src/tools/batch-execute.ts
@@ -8,12 +8,32 @@
  */
 
 import { MCPServer } from '../mcp-server';
-import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
+import {
+  MCPToolDefinition,
+  MCPResult,
+  ToolContext,
+  ToolHandler,
+  getRemainingBudget,
+  throwIfAborted,
+} from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
-import { formatCDPResult, CDPEvalResult } from './javascript';
+import {
+  CDPEvalResult,
+  formatCDPResult,
+  JavascriptCDPSendOptions,
+  normalizeJavascriptTimeoutMs,
+} from './javascript';
 import { getMetricsCollector } from '../metrics/collector';
 import { LruTtlCache } from '../core/idempotency/lru';
+import { OpenChromeTimeoutError } from '../errors/timeout';
+import {
+  addTimeoutResponseGraceMs,
+  getEffectiveTimeoutMs,
+  getRemainingTimeoutMs,
+  getTimeoutDeadlineAt,
+  withTimeout,
+} from '../utils/with-timeout';
 
 const definition: MCPToolDefinition = {
   name: 'batch_execute',
@@ -172,7 +192,8 @@ function createLimiter(concurrency: number) {
 
 const handler: ToolHandler = async (
   sessionId: string,
-  args: Record<string, unknown>
+  args: Record<string, unknown>,
+  context?: ToolContext,
 ): Promise<MCPResult> => {
   const tasks = args.tasks as BatchTask[];
   const concurrency = (args.concurrency as number) || 10;
@@ -207,41 +228,108 @@ const handler: ToolHandler = async (
   const idempotencyCache = getIdempotencyCache(sessionId);
   let aborted = false;
 
+  const throwIfDeadlineExceeded = (label: string): void => {
+    if (context && getRemainingBudget(context) <= 0) {
+      throw new OpenChromeTimeoutError(label, 0, false, true);
+    }
+  };
+
+  const runInterItemDelay = async (delayMs: number): Promise<void> => {
+    const boundedDelayMs = Math.max(0, delayMs);
+    if (boundedDelayMs === 0) return;
+    throwIfAborted(context);
+    throwIfDeadlineExceeded('batch_execute inter-item wait');
+    let delayTimer: ReturnType<typeof setTimeout> | undefined;
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        delayTimer = setTimeout(resolve, boundedDelayMs);
+      }),
+      boundedDelayMs + 1,
+      'batch_execute inter-item wait',
+      context,
+    ).finally(() => {
+      if (delayTimer) clearTimeout(delayTimer);
+    });
+    throwIfAborted(context);
+    throwIfDeadlineExceeded('batch_execute inter-item wait');
+  };
+
   const runWaitSpec = async (task: BatchTask, spec: WaitForSpec | undefined): Promise<BatchTaskResult['wait'] | undefined> => {
     if (!spec) return undefined;
     const waitStart = Date.now();
     const timeout = spec.timeout ?? 30000;
-    const page = await sessionManager.getPage(sessionId, task.tabId, undefined, 'batch_execute.wait');
-    if (!page) return { success: false, elapsedMs: Date.now() - waitStart, type: spec.type, error: `Tab ${task.tabId} not found` };
     try {
+      throwIfAborted(context);
+      throwIfDeadlineExceeded('batch_execute inter-item wait');
+      const page = await sessionManager.getPage(sessionId, task.tabId, undefined, 'batch_execute.wait');
+      if (!page) return { success: false, elapsedMs: Date.now() - waitStart, type: spec.type, error: `Tab ${task.tabId} not found` };
+      throwIfAborted(context);
+      throwIfDeadlineExceeded('batch_execute inter-item wait');
+      const effectiveTimeoutMs = getEffectiveTimeoutMs(timeout, context);
+      if (effectiveTimeoutMs <= 0) {
+        throw new OpenChromeTimeoutError('batch_execute inter-item wait', 0, false, true);
+      }
+
       switch (spec.type) {
         case 'selector':
           if (!spec.value) throw new Error('value is required for selector wait');
-          await page.waitForSelector(spec.value, { timeout, visible: spec.visible ?? false });
+          await withTimeout(
+            page.waitForSelector(spec.value, { timeout: effectiveTimeoutMs, visible: spec.visible ?? false }),
+            timeout,
+            'batch_execute selector wait',
+            context,
+          );
           break;
         case 'selector_hidden':
           if (!spec.value) throw new Error('value is required for selector_hidden wait');
-          await page.waitForSelector(spec.value, { timeout, hidden: true });
+          await withTimeout(
+            page.waitForSelector(spec.value, { timeout: effectiveTimeoutMs, hidden: true }),
+            timeout,
+            'batch_execute selector_hidden wait',
+            context,
+          );
           break;
         case 'function':
           if (!spec.value) throw new Error('value is required for function wait');
-          await page.waitForFunction(spec.value, { timeout, polling: Math.min(5000, Math.max(50, Math.floor(spec.pollIntervalMs ?? 200))) });
+          await withTimeout(
+            page.waitForFunction(spec.value, {
+              timeout: effectiveTimeoutMs,
+              polling: Math.min(5000, Math.max(50, Math.floor(spec.pollIntervalMs ?? 200))),
+            }),
+            timeout,
+            'batch_execute function wait',
+            context,
+          );
           break;
         case 'url_match':
           if (!spec.value) throw new Error('value is required for url_match wait');
-          await page.waitForFunction((pattern: string) => {
-            try { return new RegExp(pattern).test(window.location.href); } catch { return window.location.href.includes(pattern); }
-          }, { timeout }, spec.value);
+          await withTimeout(
+            page.waitForFunction((pattern: string) => {
+              try { return new RegExp(pattern).test(window.location.href); } catch { return window.location.href.includes(pattern); }
+            }, { timeout: effectiveTimeoutMs }, spec.value),
+            timeout,
+            'batch_execute url_match wait',
+            context,
+          );
           break;
         case 'navigation':
-          await page.waitForNavigation({ timeout, waitUntil: 'domcontentloaded' });
+          await withTimeout(
+            page.waitForNavigation({ timeout: effectiveTimeoutMs, waitUntil: 'domcontentloaded' }),
+            timeout,
+            'batch_execute navigation wait',
+            context,
+          );
           break;
-        case 'timeout':
-          await new Promise((resolve) => setTimeout(resolve, Math.min(60000, Math.max(0, parseInt(spec.value || String(timeout), 10)))));
+        case 'timeout': {
+          const delayMs = Math.min(60000, Math.max(0, parseInt(spec.value || String(timeout), 10)));
+          await runInterItemDelay(delayMs);
           break;
+        }
         default:
           throw new Error(`Unknown wait type ${(spec as { type?: string }).type}`);
       }
+      throwIfAborted(context);
+      throwIfDeadlineExceeded('batch_execute inter-item wait');
       return { success: true, elapsedMs: Date.now() - waitStart, type: spec.type };
     } catch (error) {
       return { success: false, elapsedMs: Date.now() - waitStart, type: spec.type, error: error instanceof Error ? error.message : String(error) };
@@ -252,28 +340,31 @@ const handler: ToolHandler = async (
     const taskStart = Date.now();
     const workerId = task.workerId || task.tabId;
 
-    if (aborted) {
-      const skipped: BatchTaskResult = {
-        tabId: task.tabId,
-        workerId,
-        success: false,
-        error: 'Aborted due to failFast',
-        durationMs: 0,
-        skipped: 'failfast-skip',
-      };
-      recordBatchItemMetric('failfast-skip');
-      return skipped;
-    }
-
-    if (task.idempotencyKey) {
-      const cached = idempotencyCache.get(task.idempotencyKey);
-      if (cached?.success) {
-        recordBatchItemMetric('skipped');
-        return { ...cached, skipped: 'idempotent' };
-      }
-    }
-
     try {
+      throwIfAborted(context);
+      throwIfDeadlineExceeded('batch_execute');
+
+      if (aborted) {
+        const skipped: BatchTaskResult = {
+          tabId: task.tabId,
+          workerId,
+          success: false,
+          error: 'Aborted due to failFast',
+          durationMs: 0,
+          skipped: 'failfast-skip',
+        };
+        recordBatchItemMetric('failfast-skip');
+        return skipped;
+      }
+
+      if (task.idempotencyKey) {
+        const cached = idempotencyCache.get(task.idempotencyKey);
+        if (cached?.success) {
+          recordBatchItemMetric('skipped');
+          return { ...cached, skipped: 'idempotent' };
+        }
+      }
+
       const page = await sessionManager.getPage(sessionId, task.tabId, undefined, 'batch_execute');
       if (!page) {
         const failed: BatchTaskResult = {
@@ -287,21 +378,34 @@ const handler: ToolHandler = async (
         return failed;
       }
 
-      const timeout = task.timeout || 30000;
+      const timeout = normalizeJavascriptTimeoutMs(task.timeout);
+      const commandTimeoutMs = addTimeoutResponseGraceMs(timeout);
+      const effectiveTimeoutMs = getEffectiveTimeoutMs(commandTimeoutMs, context);
+      if (effectiveTimeoutMs <= 0) {
+        throw new OpenChromeTimeoutError('batch_execute', 0, false, true);
+      }
+      throwIfAborted(context);
+      const invocationDeadlineAt = getTimeoutDeadlineAt(commandTimeoutMs, context);
+      const sendOptions: JavascriptCDPSendOptions = {
+        timeoutMs: commandTimeoutMs,
+        deadlineAt: invocationDeadlineAt,
+        signal: context?.signal,
+        reserveRuntimeEvaluateResponseGrace: true,
+      };
 
       // Execute via CDP Runtime.evaluate with full await support
-      let tid: ReturnType<typeof setTimeout>;
-      const cdpResult = await Promise.race([
+      const cdpResult = await withTimeout(
         cdpClient.send<CDPEvalResult>(page, 'Runtime.evaluate', {
           expression: task.script,
           returnByValue: false,
           awaitPromise: true,
           userGesture: true,
-        }).finally(() => clearTimeout(tid)),
-        new Promise<never>((_, reject) => {
-          tid = setTimeout(() => reject(new Error(`Timeout after ${timeout}ms`)), timeout);
-        }),
-      ]);
+          timeout,
+        }, sendOptions),
+        commandTimeoutMs,
+        'batch_execute',
+        context,
+      );
 
       if (cdpResult.exceptionDetails) {
         const errorMsg =
@@ -321,7 +425,16 @@ const handler: ToolHandler = async (
       }
 
       // Format result value using shared formatter (same as javascript_tool)
-      const resultValue = await formatCDPResult(cdpResult.result, cdpClient, page);
+      const formattingTimeoutMs = getRemainingTimeoutMs(invocationDeadlineAt);
+      if (formattingTimeoutMs <= 0) {
+        throw new OpenChromeTimeoutError('batch_execute Promise resolution', 0, false, true);
+      }
+      const resultValue = await withTimeout(
+        formatCDPResult(cdpResult.result, cdpClient, page, 0, sendOptions),
+        formattingTimeoutMs,
+        'batch_execute Promise resolution',
+        context,
+      );
 
       // Parse JSON result back if possible
       let data: unknown = resultValue;
@@ -362,9 +475,17 @@ const handler: ToolHandler = async (
     for (let i = 0; i < tasks.length; i++) {
       const task = tasks[i];
       const result = await executeTask(task);
-      if (i < tasks.length - 1 && !result.skipped) {
-        if (typeof task.interItemWaitMs === 'number') {
-          await new Promise((resolve) => setTimeout(resolve, Math.max(0, task.interItemWaitMs!)));
+      if (i < tasks.length - 1 && !result.skipped && !context?.signal?.aborted) {
+        try {
+          if (typeof task.interItemWaitMs === 'number') {
+            await runInterItemDelay(task.interItemWaitMs);
+          }
+        } catch (error) {
+          result.success = false;
+          result.error = `inter-item wait failed: ${error instanceof Error ? error.message : String(error)}`;
+          recordBatchItemMetric('err');
+          results.push(result);
+          break;
         }
         const wait = await runWaitSpec(task, task.interItemWaitFor);
         if (wait) {

--- a/src/tools/javascript.ts
+++ b/src/tools/javascript.ts
@@ -7,8 +7,27 @@ import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, throwIfAborted 
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { assertDomainAllowed } from '../security/domain-guard';
-import { withTimeout } from '../utils/with-timeout';
+import { OpenChromeTimeoutError } from '../errors/timeout';
+import {
+  addTimeoutResponseGraceMs,
+  getEffectiveTimeoutMs,
+  getRemainingTimeoutMs,
+  getTimeoutDeadlineAt,
+  withTimeout,
+} from '../utils/with-timeout';
 import { wrapMutatingHandler } from '../utils/snapshot-cache-helper';
+
+export const DEFAULT_JAVASCRIPT_TIMEOUT_MS = 30_000;
+
+export function normalizeJavascriptTimeoutMs(value: unknown): number {
+  if (value === undefined || value === null || value === 0) {
+    return DEFAULT_JAVASCRIPT_TIMEOUT_MS;
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    throw new Error('timeout must be a positive finite number');
+  }
+  return value;
+}
 
 const definition: MCPToolDefinition = {
   name: 'javascript_tool',
@@ -53,6 +72,13 @@ export interface CDPEvalResult {
   };
 }
 
+export interface JavascriptCDPSendOptions {
+  timeoutMs?: number;
+  deadlineAt?: number;
+  signal?: AbortSignal;
+  reserveRuntimeEvaluateResponseGrace?: boolean;
+}
+
 /**
  * Interface for the CDP client needed by formatCDPResult to do lazy value fetching.
  */
@@ -60,7 +86,8 @@ export interface CDPSender {
   send<T = unknown>(
     page: unknown,
     method: string,
-    params?: Record<string, unknown>
+    params?: Record<string, unknown>,
+    options?: JavascriptCDPSendOptions,
   ): Promise<T>;
 }
 
@@ -169,7 +196,8 @@ export async function formatCDPResult(
   evalResult: CDPEvalResult['result'],
   cdpClient?: CDPSender,
   page?: unknown,
-  promiseDepth = 0
+  promiseDepth = 0,
+  sendOptions?: JavascriptCDPSendOptions,
 ): Promise<string> {
   const { type, subtype, value, description, className, objectId } = evalResult;
 
@@ -205,14 +233,13 @@ export async function formatCDPResult(
       }
 
       try {
-        const awaited = await cdpClient.send<CDPEvalResult>(
-          page,
-          'Runtime.awaitPromise',
-          {
-            promiseObjectId: objectId,
-            returnByValue: false,
-          }
-        );
+        const awaitParams = {
+          promiseObjectId: objectId,
+          returnByValue: false,
+        };
+        const awaited = await (sendOptions
+          ? cdpClient.send<CDPEvalResult>(page, 'Runtime.awaitPromise', awaitParams, sendOptions)
+          : cdpClient.send<CDPEvalResult>(page, 'Runtime.awaitPromise', awaitParams));
         releasePromise();
 
         if (awaited.exceptionDetails) {
@@ -223,7 +250,7 @@ export async function formatCDPResult(
           throw new Error(`Runtime.awaitPromise rejected: ${errorMsg}`);
         }
 
-        return formatCDPResult(awaited.result, cdpClient, page, promiseDepth + 1);
+        return formatCDPResult(awaited.result, cdpClient, page, promiseDepth + 1, sendOptions);
       } catch (error) {
         releasePromise();
         throw new Error(`Runtime.awaitPromise failed: ${error instanceof Error ? error.message : String(error)}`);
@@ -295,16 +322,15 @@ export async function formatCDPResult(
   // Plain objects and arrays: lazy-fetch via CDP callFunctionOn to serialize
   if (type === 'object' && objectId && cdpClient && page) {
     try {
-      const serialized = await cdpClient.send<{ result: { value?: unknown } }>(
-        page,
-        'Runtime.callFunctionOn',
-        {
-          objectId,
-          functionDeclaration:
-            'function() { try { return JSON.stringify(this, null, 2); } catch(e) { return String(this); } }',
-          returnByValue: true,
-        }
-      );
+      const serializeParams = {
+        objectId,
+        functionDeclaration:
+          'function() { try { return JSON.stringify(this, null, 2); } catch(e) { return String(this); } }',
+        returnByValue: true,
+      };
+      const serialized = await (sendOptions
+        ? cdpClient.send<{ result: { value?: unknown } }>(page, 'Runtime.callFunctionOn', serializeParams, sendOptions)
+        : cdpClient.send<{ result: { value?: unknown } }>(page, 'Runtime.callFunctionOn', serializeParams));
       releaseObject(cdpClient, page, objectId);
       if (serialized.result?.value !== undefined) {
         return String(serialized.result.value);
@@ -356,7 +382,6 @@ const handler: ToolHandler = async (
   throwIfAborted(context);
   const tabId = args.tabId as string;
   const code = (args.code as string) || (args.text as string);
-  const timeout = (args.timeout as number) || 30000;
 
   const sessionManager = getSessionManager();
 
@@ -382,6 +407,7 @@ const handler: ToolHandler = async (
   }
 
   try {
+    const timeout = normalizeJavascriptTimeoutMs(args.timeout);
     const page = await sessionManager.getPage(sessionId, tabId, undefined, 'javascript_tool');
     if (!page) {
       const available = await sessionManager.getAvailableTargets(sessionId);
@@ -398,6 +424,19 @@ const handler: ToolHandler = async (
     assertDomainAllowed(page.url());
 
     const cdpClient = sessionManager.getCDPClient();
+    const commandTimeoutMs = addTimeoutResponseGraceMs(timeout);
+    const effectiveTimeoutMs = getEffectiveTimeoutMs(commandTimeoutMs, context);
+    if (effectiveTimeoutMs <= 0) {
+      throw new OpenChromeTimeoutError('javascript_tool', 0, false, true);
+    }
+    throwIfAborted(context);
+    const invocationDeadlineAt = getTimeoutDeadlineAt(commandTimeoutMs, context);
+    const sendOptions: JavascriptCDPSendOptions = {
+      timeoutMs: commandTimeoutMs,
+      deadlineAt: invocationDeadlineAt,
+      signal: context?.signal,
+      reserveRuntimeEvaluateResponseGrace: true,
+    };
 
     const cdpResult = await withTimeout(
       cdpClient.send<CDPEvalResult>(page, 'Runtime.evaluate', {
@@ -406,8 +445,9 @@ const handler: ToolHandler = async (
         awaitPromise: true,
         userGesture: true,
         replMode: true,
-      }),
-      timeout,
+        timeout,
+      }, sendOptions),
+      commandTimeoutMs,
       'javascript_tool',
       context,
     );
@@ -427,7 +467,16 @@ const handler: ToolHandler = async (
       };
     }
 
-    const output = await formatCDPResult(cdpResult.result, cdpClient, page);
+    const formattingTimeoutMs = getRemainingTimeoutMs(invocationDeadlineAt);
+    if (formattingTimeoutMs <= 0) {
+      throw new OpenChromeTimeoutError('javascript_tool Promise resolution', 0, false, true);
+    }
+    const output = await withTimeout(
+      formatCDPResult(cdpResult.result, cdpClient, page, 0, sendOptions),
+      formattingTimeoutMs,
+      'javascript_tool Promise resolution',
+      context,
+    );
 
     return {
       content: [{ type: 'text', text: output }],

--- a/src/utils/with-timeout.ts
+++ b/src/utils/with-timeout.ts
@@ -1,6 +1,46 @@
 import { OpenChromeTimeoutError } from '../errors/timeout';
 import { ToolContext, getRemainingBudget } from '../types/mcp';
 
+export const MAX_TIMEOUT_RESPONSE_GRACE_MS = 250;
+
+export function getTimeoutResponseGraceMs(ms: number): number {
+  if (!Number.isFinite(ms) || ms <= 1) return 0;
+  return Math.min(
+    MAX_TIMEOUT_RESPONSE_GRACE_MS,
+    Math.max(1, Math.ceil(ms * 0.2)),
+  );
+}
+
+/** Host-side wait budget that lets a bounded inner operation report its timeout. */
+export function addTimeoutResponseGraceMs(ms: number): number {
+  return ms + getTimeoutResponseGraceMs(ms);
+}
+
+/** Inner operation budget when the outer deadline leaves no separate response grace. */
+export function reserveTimeoutResponseGraceMs(outerMs: number): number {
+  if (!Number.isFinite(outerMs) || outerMs <= 0) return 0;
+  if (outerMs <= 1) return 1;
+  return Math.max(1, Math.floor(outerMs - getTimeoutResponseGraceMs(outerMs)));
+}
+
+export function getEffectiveTimeoutMs(ms: number, context?: ToolContext): number {
+  return context
+    ? Math.min(ms, getRemainingBudget(context))
+    : ms;
+}
+
+/** One absolute deadline shared by every phase of a bounded operation. */
+export function getTimeoutDeadlineAt(ms: number, context?: ToolContext): number {
+  const operationDeadlineAt = Date.now() + ms;
+  return context
+    ? Math.min(operationDeadlineAt, context.startTime + context.deadlineMs)
+    : operationDeadlineAt;
+}
+
+export function getRemainingTimeoutMs(deadlineAt: number): number {
+  return Math.max(0, deadlineAt - Date.now());
+}
+
 /**
  * Race a promise against a timeout. Rejects with an OpenChromeTimeoutError if the timeout fires first.
  *
@@ -14,9 +54,7 @@ import { ToolContext, getRemainingBudget } from '../types/mcp';
  *    blocked by an orphaned background CDP call.
  */
 export function withTimeout<T>(promise: Promise<T>, ms: number, label = 'Operation', context?: ToolContext): Promise<T> {
-  const effectiveMs = context
-    ? Math.min(ms, getRemainingBudget(context))
-    : ms;
+  const effectiveMs = getEffectiveTimeoutMs(ms, context);
 
   if (effectiveMs <= 0) {
     return Promise.reject(new OpenChromeTimeoutError(label, 0, false, true));

--- a/tests/cdp/client-contracts.test.ts
+++ b/tests/cdp/client-contracts.test.ts
@@ -30,6 +30,10 @@ jest.mock('../../src/utils/ref-id-manager', () => ({
 }));
 
 import { CDPClient } from '../../src/cdp/client';
+import {
+  addTimeoutResponseGraceMs,
+  reserveTimeoutResponseGraceMs,
+} from '../../src/utils/with-timeout';
 
 type MockPage = {
   target: jest.Mock;
@@ -138,6 +142,219 @@ describe('CDPClient target/page contracts (#687 Wave 4 prereq)', () => {
 
     await expect(client.getCDPSession(page as never)).rejects.toThrow(/stale-target.*no longer valid/);
     await expect(client.send(page as never, 'Runtime.evaluate', {})).rejects.toThrow(/stale-target.*no longer valid/);
+  });
+
+  it('applies a per-command timeout to Puppeteer and the OpenChrome send guard', async () => {
+    const page = makePage('timed-target');
+    const browser = makeBrowser([page]);
+    const client = connectedClient(browser);
+    await client.rebuildTargetIdIndex();
+
+    await client.send(page as never, 'Runtime.evaluate', { expression: '21 * 2' }, { timeoutMs: 750 });
+
+    const session = await page.createCDPSession.mock.results[0].value;
+    expect(session.send).toHaveBeenCalledTimes(1);
+    const [method, params, options] = session.send.mock.calls[0];
+    expect(method).toBe('Runtime.evaluate');
+    expect(params).toEqual({ expression: '21 * 2' });
+    expect(options.timeout).toBeGreaterThan(0);
+    expect(options.timeout).toBeLessThanOrEqual(750);
+  });
+
+  it('recomputes Runtime.evaluate budgets after delayed CDP session acquisition', async () => {
+    jest.useFakeTimers({ now: 10_000 });
+    try {
+      const page = makePage('delayed-session-target');
+      const browser = makeBrowser([page]);
+      const client = connectedClient(browser);
+      await client.rebuildTargetIdIndex();
+
+      const session = {
+        send: jest.fn().mockResolvedValue({ result: { type: 'number', value: 42 } }),
+        detach: jest.fn().mockResolvedValue(undefined),
+      };
+      let resolveSession!: (value: typeof session) => void;
+      page.createCDPSession.mockImplementationOnce(() => new Promise((resolve) => {
+        resolveSession = resolve;
+      }) as never);
+
+      const deadlineAt = Date.now() + 1_000;
+      const sendPromise = client.send(
+        page as never,
+        'Runtime.evaluate',
+        { expression: '21 * 2', timeout: 5_000 },
+        {
+          timeoutMs: addTimeoutResponseGraceMs(5_000),
+          deadlineAt,
+          reserveRuntimeEvaluateResponseGrace: true,
+        },
+      );
+
+      await jest.advanceTimersByTimeAsync(400);
+      resolveSession(session);
+      await jest.advanceTimersByTimeAsync(0);
+      await sendPromise;
+
+      expect(session.send).toHaveBeenCalledWith(
+        'Runtime.evaluate',
+        {
+          expression: '21 * 2',
+          timeout: reserveTimeoutResponseGraceMs(600),
+        },
+        { timeout: 600 },
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not dispatch after the parent deadline expires during session acquisition', async () => {
+    jest.useFakeTimers({ now: 20_000 });
+    try {
+      const page = makePage('expired-session-target');
+      const browser = makeBrowser([page]);
+      const client = connectedClient(browser);
+      await client.rebuildTargetIdIndex();
+
+      const session = {
+        send: jest.fn().mockResolvedValue({}),
+        detach: jest.fn().mockResolvedValue(undefined),
+      };
+      let resolveSession!: (value: typeof session) => void;
+      page.createCDPSession.mockImplementationOnce(() => new Promise((resolve) => {
+        resolveSession = resolve;
+      }) as never);
+
+      const sendPromise = client.send(
+        page as never,
+        'Runtime.evaluate',
+        { expression: 'window.__shouldNotRun = true', timeout: 5_000 },
+        {
+          timeoutMs: addTimeoutResponseGraceMs(5_000),
+          deadlineAt: Date.now() + 1_000,
+          reserveRuntimeEvaluateResponseGrace: true,
+        },
+      );
+      let outcome: { status: 'fulfilled' } | { status: 'rejected'; error: unknown } | undefined;
+      void sendPromise.then(
+        () => { outcome = { status: 'fulfilled' }; },
+        (error: unknown) => { outcome = { status: 'rejected', error }; },
+      );
+
+      await jest.advanceTimersByTimeAsync(1_001);
+      const outcomeBeforeSessionResolution = outcome;
+      resolveSession(session);
+      await jest.advanceTimersByTimeAsync(0);
+      await sendPromise.catch(() => undefined);
+
+      expect(outcomeBeforeSessionResolution).toMatchObject({
+        status: 'rejected',
+        error: {
+          name: 'OpenChromeTimeoutError',
+          deadline: true,
+        },
+      });
+      expect(session.send).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not dispatch after the command timeout expires during session acquisition', async () => {
+    jest.useFakeTimers({ now: 30_000 });
+    try {
+      const page = makePage('command-timeout-session-target');
+      const browser = makeBrowser([page]);
+      const client = connectedClient(browser);
+      await client.rebuildTargetIdIndex();
+
+      const session = {
+        send: jest.fn().mockResolvedValue({}),
+        detach: jest.fn().mockResolvedValue(undefined),
+      };
+      let resolveSession!: (value: typeof session) => void;
+      page.createCDPSession.mockImplementationOnce(() => new Promise((resolve) => {
+        resolveSession = resolve;
+      }) as never);
+
+      const sendPromise = client.send(
+        page as never,
+        'Runtime.evaluate',
+        { expression: 'window.__shouldNotRun = true', timeout: 250 },
+        {
+          timeoutMs: 300,
+          deadlineAt: Date.now() + 5_000,
+          reserveRuntimeEvaluateResponseGrace: true,
+        },
+      );
+      let outcome: { status: 'fulfilled' } | { status: 'rejected'; error: unknown } | undefined;
+      void sendPromise.then(
+        () => { outcome = { status: 'fulfilled' }; },
+        (error: unknown) => { outcome = { status: 'rejected', error }; },
+      );
+
+      await jest.advanceTimersByTimeAsync(301);
+      const outcomeBeforeSessionResolution = outcome;
+      resolveSession(session);
+      await jest.advanceTimersByTimeAsync(0);
+      await sendPromise.catch(() => undefined);
+
+      expect(outcomeBeforeSessionResolution).toMatchObject({
+        status: 'rejected',
+        error: {
+          name: 'OpenChromeTimeoutError',
+          deadline: true,
+        },
+      });
+      expect(session.send).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not dispatch after cancellation during session acquisition', async () => {
+    const page = makePage('aborted-session-target');
+    const browser = makeBrowser([page]);
+    const client = connectedClient(browser);
+    await client.rebuildTargetIdIndex();
+
+    const session = {
+      send: jest.fn().mockResolvedValue({}),
+      detach: jest.fn().mockResolvedValue(undefined),
+    };
+    let resolveSession!: (value: typeof session) => void;
+    page.createCDPSession.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveSession = resolve;
+    }) as never);
+    const controller = new AbortController();
+
+    const sendPromise = client.send(
+      page as never,
+      'Runtime.evaluate',
+      { expression: 'window.__shouldNotRun = true', timeout: 5_000 },
+      {
+        timeoutMs: addTimeoutResponseGraceMs(5_000),
+        signal: controller.signal,
+        reserveRuntimeEvaluateResponseGrace: true,
+      },
+    );
+    let outcome: { status: 'fulfilled' } | { status: 'rejected'; error: unknown } | undefined;
+    void sendPromise.then(
+      () => { outcome = { status: 'fulfilled' }; },
+      (error: unknown) => { outcome = { status: 'rejected', error }; },
+    );
+
+    controller.abort(new Error('client disconnected'));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const outcomeBeforeSessionResolution = outcome;
+    resolveSession(session);
+    await sendPromise.catch(() => undefined);
+
+    expect(outcomeBeforeSessionResolution).toMatchObject({
+      status: 'rejected',
+      error: { message: 'client disconnected' },
+    });
+    expect(session.send).not.toHaveBeenCalled();
   });
 
   it('createPage indexes new pages, configures defenses, and removes the index on navigation failure', async () => {

--- a/tests/headed/headed-tool-interop.test.ts
+++ b/tests/headed/headed-tool-interop.test.ts
@@ -361,6 +361,10 @@ describe('Headed Tool Interop (#485)', () => {
           returnByValue: false,
           awaitPromise: true,
         }),
+        expect.objectContaining({
+          timeoutMs: 30_250,
+          reserveRuntimeEvaluateResponseGrace: true,
+        }),
       );
     });
 

--- a/tests/integration/javascript-renderer-timeout.test.ts
+++ b/tests/integration/javascript-renderer-timeout.test.ts
@@ -1,0 +1,200 @@
+/// <reference types="jest" />
+
+jest.mock('../../src/session-manager', () => ({ getSessionManager: jest.fn() }));
+
+import * as fs from 'fs';
+import type { Browser, CDPSession, Page } from 'puppeteer-core';
+
+import { CDPClient } from '../../src/cdp/client';
+import { isConnectionError } from '../../src/mcp-server';
+import { getSessionManager } from '../../src/session-manager';
+import { registerJavascriptTool } from '../../src/tools/javascript';
+import type { MCPResult, ToolContext, ToolHandler } from '../../src/types/mcp';
+import { getTargetId } from '../../src/utils/puppeteer-helpers';
+import { withTimeout } from '../../src/utils/with-timeout';
+
+const puppeteerModule = jest.requireActual<typeof import('puppeteer-core')>('puppeteer-core');
+const puppeteer = puppeteerModule.default;
+
+const REAL_CHROME = process.env.OPENCHROME_REAL_CHROME === '1';
+
+interface RuntimeEvaluateValueResult {
+  result: { value?: unknown };
+}
+
+function getResultText(result: MCPResult): string {
+  return result.content?.[0]?.text ?? '';
+}
+
+function findChromeExecutable(): string | null {
+  if (process.env.OPENCHROME_TEST_CHROME) {
+    return process.env.OPENCHROME_TEST_CHROME;
+  }
+  const candidates = process.platform === 'darwin'
+    ? [
+        '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
+      ]
+    : process.platform === 'win32'
+      ? [
+          `${process.env.PROGRAMFILES ?? ''}\\Google\\Chrome\\Application\\chrome.exe`,
+          `${process.env['PROGRAMFILES(X86)'] ?? ''}\\Google\\Chrome\\Application\\chrome.exe`,
+        ]
+      : [
+          '/usr/bin/google-chrome',
+          '/usr/bin/google-chrome-stable',
+          '/usr/bin/chromium',
+          '/usr/bin/chromium-browser',
+        ];
+
+  return candidates.find((candidate) => candidate && fs.existsSync(candidate)) ?? null;
+}
+
+(REAL_CHROME ? describe : describe.skip)(
+  'Runtime.evaluate renderer timeout - real Chrome',
+  () => {
+    let browser: Browser;
+    let page: Page;
+    let cdpClient: CDPClient;
+    let managedSession: CDPSession;
+    let targetId: string;
+    let javascriptHandler: ToolHandler;
+
+    const runJavascript = (
+      code: string,
+      timeout: number,
+      context: ToolContext = { startTime: Date.now(), deadlineMs: 2_000 },
+    ): Promise<MCPResult> => javascriptHandler(
+      'live-session',
+      { tabId: targetId, code, timeout },
+      context,
+    );
+
+    beforeAll(async () => {
+      const executablePath = findChromeExecutable();
+      if (!executablePath) {
+        throw new Error('OPENCHROME_REAL_CHROME=1 but no Chrome executable was found');
+      }
+
+      browser = await puppeteer.launch({
+        executablePath,
+        headless: true,
+        args: ['--no-sandbox'],
+      });
+      page = await browser.newPage();
+      cdpClient = new CDPClient();
+      targetId = getTargetId(page.target());
+      cdpClient.indexExternalPage(targetId, page);
+      managedSession = await cdpClient.getCDPSession(page);
+
+      const liveSessionManager = {
+        getPage: jest.fn(async (_sessionId: string, requestedTargetId: string) => (
+          requestedTargetId === targetId ? page : null
+        )),
+        getAvailableTargets: jest.fn(async () => [{ tabId: targetId, url: page.url(), title: 'live test' }]),
+        getCDPClient: jest.fn(() => cdpClient),
+      };
+      (getSessionManager as jest.Mock).mockReturnValue(liveSessionManager);
+
+      registerJavascriptTool({
+        registerTool: (name: string, handler: ToolHandler) => {
+          if (name === 'javascript_tool') javascriptHandler = handler;
+        },
+      } as never);
+    }, 30_000);
+
+    afterAll(async () => {
+      await managedSession?.detach().catch(() => {});
+      const chromeProcess = browser?.process();
+      let closeTimer: ReturnType<typeof setTimeout>;
+      try {
+        await Promise.race([
+          browser?.close(),
+          new Promise<never>((_, reject) => {
+            closeTimer = setTimeout(() => reject(new Error('browser.close timed out')), 5_000);
+          }),
+        ]).finally(() => clearTimeout(closeTimer));
+      } catch {
+        chromeProcess?.kill('SIGKILL');
+      }
+    }, 15_000);
+
+    test('terminates a synchronous runaway expression and preserves same-tab recovery', async () => {
+      const callerTimeoutMs = 250;
+      const started = Date.now();
+      const timeoutResult = await runJavascript(
+        'globalThis.__openchromePartialEffect = 1;\nwhile (true) {}',
+        callerTimeoutMs,
+      );
+      const timeoutText = getResultText(timeoutResult);
+
+      expect(timeoutResult.isError).toBe(true);
+      expect(timeoutText).toContain('Protocol error (Runtime.evaluate)');
+      expect(isConnectionError(timeoutText)).toBe(false);
+      expect(Date.now() - started).toBeLessThan(2_000);
+
+      const recovery = await runJavascript('21 * 2', 1_000);
+      expect(recovery.isError).toBeUndefined();
+      expect(getResultText(recovery)).toBe('42');
+
+      const partialEffect = await runJavascript('globalThis.__openchromePartialEffect', 1_000);
+      expect(getResultText(partialEffect)).toBe('1');
+      await runJavascript('delete globalThis.__openchromePartialEffect', 1_000);
+    });
+
+    test('returns through the host timeout without claiming Promise cancellation', async () => {
+      const callerTimeoutMs = 250;
+      const started = Date.now();
+      const rescueSession = await page.createCDPSession();
+      try {
+        const timeoutResult = await runJavascript(
+          'new Promise((resolve) => { globalThis.__openchromeResolvePending = resolve; })',
+          callerTimeoutMs,
+        );
+        const timeoutText = getResultText(timeoutResult);
+
+        expect(timeoutResult.isError).toBe(true);
+        expect(timeoutText).toMatch(/timed out|deadline exceeded/i);
+        expect(isConnectionError(timeoutText)).toBe(false);
+        expect(Date.now() - started).toBeLessThan(2_000);
+
+        const probe = await withTimeout(
+          rescueSession.send('Runtime.evaluate', {
+            expression: 'typeof globalThis.__openchromeResolvePending',
+            returnByValue: true,
+          }) as Promise<RuntimeEvaluateValueResult>,
+          500,
+          'pending Promise live probe',
+        ).then(
+          (value) => ({ status: 'visible' as const, value }),
+          (error) => ({ status: 'blocked' as const, error }),
+        );
+
+        if (probe.status === 'visible') {
+          expect(probe.value.result.value).toBe('function');
+          await withTimeout(
+            rescueSession.send('Runtime.evaluate', {
+              expression: 'globalThis.__openchromeResolvePending(42); delete globalThis.__openchromeResolvePending; true',
+              returnByValue: true,
+            }),
+            1_000,
+            'pending Promise resolver cleanup',
+          );
+        } else {
+          expect(String(probe.error)).toMatch(/timed out/i);
+          await withTimeout(
+            rescueSession.send('Runtime.terminateExecution'),
+            1_000,
+            'pending Promise terminate cleanup',
+          );
+        }
+      } finally {
+        await rescueSession.detach();
+      }
+
+      const recovery = await runJavascript('6 * 7', 1_000);
+      expect(recovery.isError).toBeUndefined();
+      expect(getResultText(recovery)).toBe('42');
+    });
+  },
+);

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -649,10 +649,44 @@ describe('MCPServer', () => {
       expect(response.result!.content![0].text).not.toContain('/mcp');
     });
 
+    test.each([
+      'Protocol error (Runtime.evaluate): Execution was terminated',
+      'Protocol error (Runtime.evaluate): Internal error',
+      'Protocol error (Runtime.evaluate): Invalid parameters Failed to deserialize params.timeout',
+      'Runtime.awaitPromise failed: Protocol error (Runtime.awaitPromise): Internal error',
+      'Runtime.awaitPromise failed: Protocol error (Runtime.awaitPromise): Could not find object with given id',
+    ])('does not reconnect or replay user JavaScript for %s', async (errorText) => {
+      const handler = jest.fn().mockResolvedValue({
+        content: [{ type: 'text', text: `JavaScript execution error: ${errorText}` }],
+        isError: true,
+      });
+      const definition: MCPToolDefinition = {
+        name: 'runtime_evaluate_error_tool',
+        description: 'Runtime.evaluate error',
+        inputSchema: { type: 'object' as const, properties: {}, required: [] },
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+      };
+      server.registerTool('runtime_evaluate_error_tool', handler, definition);
+
+      const response = (await server.handleRequest({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'runtime_evaluate_error_tool', arguments: {} },
+      })) as MCPResultResponse;
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(mockForceReconnect).not.toHaveBeenCalled();
+      expect(response.result!.isError).toBe(true);
+      expect(response.result!.content![0].text).toContain(errorText);
+    });
+
     test('detects various connection error patterns', async () => {
       const connectionErrors = [
         'Not connected to Chrome. Call connect() first.',
         'Protocol error (Runtime.callFunctionOn): Session closed.',
+        'Protocol error (Runtime.evaluate): Session closed.',
+        'Protocol error (Runtime.awaitPromise): Session closed.',
         'WebSocket is not open: readyState 3 (CLOSED)',
         'Navigation failed because browser has disconnected',
         'Execution context was destroyed',

--- a/tests/tools/batch-execute-idempotency.test.ts
+++ b/tests/tools/batch-execute-idempotency.test.ts
@@ -5,6 +5,7 @@ jest.mock('../../src/session-manager', () => ({ getSessionManager: jest.fn() }))
 import { MCPServer } from '../../src/mcp-server';
 import { getSessionManager } from '../../src/session-manager';
 import { clearBatchIdempotencyCachesForTests, registerBatchExecuteTool } from '../../src/tools/batch-execute';
+import { addTimeoutResponseGraceMs } from '../../src/utils/with-timeout';
 
 const mockSend = jest.fn();
 const page = {
@@ -55,6 +56,29 @@ describe('batch_execute idempotency and inter-item waits', () => {
     expect(mockSend).toHaveBeenCalledTimes(1);
   });
 
+  test('an aborted request does not return a cached idempotent success', async () => {
+    const handler = makeHandler();
+    const args = {
+      concurrency: 1,
+      tasks: [{ tabId: 'tab-1', script: 'window.count++', idempotencyKey: 'step-aborted' }],
+    };
+
+    const first = parse(await handler('session-1', args));
+    const controller = new AbortController();
+    controller.abort(new Error('client disconnected'));
+    const second = parse(await handler(
+      'session-1',
+      args,
+      { startTime: Date.now(), deadlineMs: 5_000, signal: controller.signal },
+    ));
+
+    expect(first.results[0]).toMatchObject({ success: true, data: { value: 'ran' } });
+    expect(second.results[0]).toMatchObject({ success: false });
+    expect(second.results[0].error).toContain('client disconnected');
+    expect(second.results[0].skipped).toBeUndefined();
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
   test('failed prior run is not cached', async () => {
     mockSend
       .mockResolvedValueOnce({ exceptionDetails: { text: 'boom' }, result: { type: 'undefined' } })
@@ -68,6 +92,223 @@ describe('batch_execute idempotency and inter-item waits', () => {
     expect(first.results[0].success).toBe(false);
     expect(second.results[0]).toMatchObject({ success: true, data: { value: 'retry-ok' } });
     expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+
+  test('forwards each task timeout with renderer response grace', async () => {
+    const handler = makeHandler();
+
+    await handler('session-1', {
+      concurrency: 1,
+      tasks: [
+        { tabId: 'tab-1', script: '1', timeout: 250 },
+        { tabId: 'tab-1', script: '2', timeout: 500 },
+      ],
+    });
+
+    expect(mockSend).toHaveBeenNthCalledWith(
+      1,
+      page,
+      'Runtime.evaluate',
+      expect.objectContaining({ expression: '1', timeout: 250 }),
+      expect.objectContaining({
+        timeoutMs: addTimeoutResponseGraceMs(250),
+        reserveRuntimeEvaluateResponseGrace: true,
+      }),
+    );
+    expect(mockSend).toHaveBeenNthCalledWith(
+      2,
+      page,
+      'Runtime.evaluate',
+      expect.objectContaining({ expression: '2', timeout: 500 }),
+      expect.objectContaining({
+        timeoutMs: addTimeoutResponseGraceMs(500),
+        reserveRuntimeEvaluateResponseGrace: true,
+      }),
+    );
+  });
+
+  test('caps a task timeout to the remaining parent budget', async () => {
+    const handler = makeHandler();
+
+    const startTime = Date.now() - 750;
+    await handler(
+      'session-1',
+      { concurrency: 1, tasks: [{ tabId: 'tab-1', script: '1', timeout: 5_000 }] },
+      { startTime, deadlineMs: 1_000 },
+    );
+
+    const params = mockSend.mock.calls[0][2];
+    const options = mockSend.mock.calls[0][3];
+    expect(params.timeout).toBe(5_000);
+    expect(options).toMatchObject({
+      timeoutMs: addTimeoutResponseGraceMs(5_000),
+      deadlineAt: startTime + 1_000,
+      reserveRuntimeEvaluateResponseGrace: true,
+    });
+  });
+
+  test('shares one task timeout window with Runtime.awaitPromise formatting', async () => {
+    jest.useFakeTimers({ now: 10_000 });
+    try {
+      const handler = makeHandler();
+      mockSend
+        .mockImplementationOnce(() => new Promise((resolve) => {
+          setTimeout(() => resolve({
+            result: {
+              type: 'object',
+              subtype: 'promise',
+              className: 'Promise',
+              description: 'Promise',
+              objectId: 'pending-batch-promise',
+            },
+          }), 250);
+        }))
+        .mockImplementationOnce(() => new Promise(() => {}));
+
+      let settled = false;
+      const resultPromise = handler('session-1', {
+        concurrency: 1,
+        tasks: [{ tabId: 'tab-1', script: 'new Promise(() => {})', timeout: 250 }],
+      }).then((result: unknown) => {
+        settled = true;
+        return parse(result);
+      });
+
+      await jest.advanceTimersByTimeAsync(299);
+      expect(settled).toBe(false);
+      await jest.advanceTimersByTimeAsync(2);
+
+      const result = await resultPromise;
+      expect(result.results[0]).toMatchObject({ success: false });
+      expect(result.results[0].error).toContain('Promise resolution timed out');
+      expect(mockSend).toHaveBeenCalledTimes(2);
+      expect(mockSend.mock.calls[0][3].deadlineAt).toBe(10_300);
+      expect(mockSend.mock.calls[1][3].deadlineAt).toBe(10_300);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('does not dispatch tasks when the request is already aborted', async () => {
+    const handler = makeHandler();
+    const controller = new AbortController();
+    controller.abort(new Error('client disconnected'));
+
+    const result = parse(await handler(
+      'session-1',
+      {
+        concurrency: 2,
+        tasks: [
+          { tabId: 'tab-1', script: 'window.__first = true' },
+          { tabId: 'tab-1', script: 'window.__second = true' },
+        ],
+      },
+      { startTime: Date.now(), deadlineMs: 5_000, signal: controller.signal },
+    ));
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results.every((item: { success: boolean }) => item.success === false)).toBe(true);
+    expect(result.results[0].error).toContain('client disconnected');
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  test('stops queued tasks when the request aborts during execution', async () => {
+    const handler = makeHandler();
+    const controller = new AbortController();
+    mockSend.mockReturnValueOnce(new Promise(() => {}));
+
+    const resultPromise = handler(
+      'session-1',
+      {
+        concurrency: 1,
+        tasks: [
+          { tabId: 'tab-1', script: 'while (true) {}' },
+          { tabId: 'tab-1', script: 'window.__shouldNotRun = true' },
+        ],
+      },
+      { startTime: Date.now(), deadlineMs: 5_000, signal: controller.signal },
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    controller.abort(new Error('client disconnected'));
+
+    const result = parse(await resultPromise);
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]).toMatchObject({ success: false });
+    expect(result.results[1]).toMatchObject({ success: false });
+    expect(result.results[1].error).toContain('client disconnected');
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not dispatch a queued task after the shared parent deadline expires', async () => {
+    jest.useFakeTimers({ now: 10_000 });
+    try {
+      const handler = makeHandler();
+      mockSend
+        .mockImplementationOnce(() => new Promise(() => {}))
+        .mockImplementationOnce(() => new Promise(() => {}));
+
+      const resultPromise = handler(
+        'session-1',
+        {
+          concurrency: 2,
+          tasks: [
+            { tabId: 'tab-1', script: '1', timeout: 5_000 },
+            { tabId: 'tab-1', script: '2', timeout: 5_000 },
+            { tabId: 'tab-1', script: '3', timeout: 5_000 },
+          ],
+        },
+        { startTime: Date.now(), deadlineMs: 1_000 },
+      );
+
+      await jest.advanceTimersByTimeAsync(0);
+      expect(mockSend).toHaveBeenCalledTimes(2);
+      await jest.advanceTimersByTimeAsync(1_001);
+
+      const result = parse(await resultPromise);
+      expect(mockSend).toHaveBeenCalledTimes(2);
+      expect(result.results[2]).toMatchObject({ success: false });
+      expect(result.results[2].error).toContain('deadline exceeded');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('does not dispatch a task after the parent budget is exhausted', async () => {
+    const handler = makeHandler();
+
+    const result = parse(await handler(
+      'session-1',
+      { concurrency: 1, tasks: [{ tabId: 'tab-1', script: 'window.__shouldNotRun = true' }] },
+      { startTime: Date.now() - 2_000, deadlineMs: 1_000 },
+    ));
+
+    expect(result.results[0]).toMatchObject({ success: false });
+    expect(result.results[0].error).toContain('deadline exceeded');
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  test('rejects a negative task timeout without dispatching or caching it', async () => {
+    const handler = makeHandler();
+    const args = {
+      concurrency: 1,
+      tasks: [{
+        tabId: 'tab-1',
+        script: 'window.__shouldNotRun = true',
+        timeout: -1,
+        idempotencyKey: 'invalid-timeout',
+      }],
+    };
+
+    const first = parse(await handler('session-1', args));
+    const second = parse(await handler('session-1', args));
+
+    expect(first.results[0]).toMatchObject({ success: false });
+    expect(first.results[0].error).toContain('positive finite number');
+    expect(second.results[0]).toMatchObject({ success: false });
+    expect(second.results[0].skipped).toBeUndefined();
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
   test('does not add package dependencies for idempotency support', () => {
@@ -102,6 +343,72 @@ describe('batch_execute idempotency and inter-item waits', () => {
     expect(result.results[0].wait).toMatchObject({ success: true, type: 'function' });
     expect(page.waitForFunction).toHaveBeenCalledWith('window.__ready === true', { timeout: 30000, polling: 100 });
     expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+
+  test('aborts an in-flight inter-item delay without starting the next task', async () => {
+    const handler = makeHandler();
+    const controller = new AbortController();
+
+    const resultPromise = handler(
+      'session-1',
+      {
+        concurrency: 1,
+        tasks: [
+          { tabId: 'tab-1', script: 'click()', interItemWaitMs: 10_000 },
+          { tabId: 'tab-1', script: 'read()' },
+        ],
+      },
+      { startTime: Date.now(), deadlineMs: 30_000, signal: controller.signal },
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    controller.abort(new Error('client disconnected'));
+
+    const result = parse(await resultPromise);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toMatchObject({ success: false });
+    expect(result.results[0].error).toContain('client disconnected');
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  test('caps interItemWaitFor to the remaining parent deadline', async () => {
+    jest.useFakeTimers({ now: 10_000 });
+    try {
+      const handler = makeHandler();
+      page.waitForFunction.mockImplementationOnce(() => new Promise(() => {}));
+
+      const resultPromise = handler(
+        'session-1',
+        {
+          concurrency: 1,
+          tasks: [
+            {
+              tabId: 'tab-1',
+              script: 'click()',
+              interItemWaitFor: { type: 'function', value: 'window.__ready === true', timeout: 30_000 },
+            },
+            { tabId: 'tab-1', script: 'read()' },
+          ],
+        },
+        { startTime: Date.now(), deadlineMs: 100 },
+      );
+
+      await jest.advanceTimersByTimeAsync(0);
+      expect(page.waitForFunction).toHaveBeenCalledWith(
+        'window.__ready === true',
+        expect.objectContaining({ timeout: 100 }),
+      );
+      await jest.advanceTimersByTimeAsync(101);
+
+      const result = parse(await resultPromise);
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0]).toMatchObject({ success: false });
+      expect(result.results[0].error).toContain('deadline exceeded');
+      expect(mockSend).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test('failed interItemWaitFor stops before the next sibling starts', async () => {

--- a/tests/tools/javascript.test.ts
+++ b/tests/tools/javascript.test.ts
@@ -16,6 +16,7 @@ import {
   formatCDPResult,
   JAVASCRIPT_HELPER_INJECTION,
 } from '../../src/tools/javascript';
+import { addTimeoutResponseGraceMs } from '../../src/utils/with-timeout';
 
 describe('JavaScriptTool', () => {
   let mockSessionManager: ReturnType<typeof createMockSessionManager>;
@@ -30,10 +31,22 @@ describe('JavaScriptTool', () => {
 
     const { registerJavascriptTool } = await import('../../src/tools/javascript');
 
-    const tools: Map<string, { handler: (sessionId: string, args: Record<string, unknown>) => Promise<unknown> }> = new Map();
+    const tools: Map<string, {
+      handler: (
+        sessionId: string,
+        args: Record<string, unknown>,
+        context?: { startTime: number; deadlineMs: number; signal?: AbortSignal },
+      ) => Promise<unknown>;
+    }> = new Map();
     const mockServer = {
       registerTool: (name: string, handler: unknown) => {
-        tools.set(name, { handler: handler as (sessionId: string, args: Record<string, unknown>) => Promise<unknown> });
+        tools.set(name, {
+          handler: handler as (
+            sessionId: string,
+            args: Record<string, unknown>,
+            context?: { startTime: number; deadlineMs: number; signal?: AbortSignal },
+          ) => Promise<unknown>,
+        });
       },
     };
 
@@ -75,7 +88,12 @@ describe('JavaScriptTool', () => {
           returnByValue: false,
           awaitPromise: true,
           userGesture: true,
-        })
+          timeout: 30000,
+        }),
+        expect.objectContaining({
+          timeoutMs: addTimeoutResponseGraceMs(30000),
+          reserveRuntimeEvaluateResponseGrace: true,
+        }),
       );
 
       expect(result.content[0].text).toBe('42');
@@ -481,7 +499,8 @@ describe('JavaScriptTool', () => {
       expect(mockSessionManager.mockCDPClient.send).toHaveBeenCalledWith(
         expect.anything(),
         'Runtime.evaluate',
-        expect.objectContaining({ awaitPromise: true })
+        expect.objectContaining({ awaitPromise: true }),
+        expect.objectContaining({ reserveRuntimeEvaluateResponseGrace: true }),
       );
 
       expect(result.isError).toBeUndefined();
@@ -503,7 +522,8 @@ describe('JavaScriptTool', () => {
       expect(mockSessionManager.mockCDPClient.send).toHaveBeenCalledWith(
         expect.anything(),
         'Runtime.evaluate',
-        expect.objectContaining({ awaitPromise: true })
+        expect.objectContaining({ awaitPromise: true }),
+        expect.objectContaining({ reserveRuntimeEvaluateResponseGrace: true }),
       );
 
       expect(result.isError).toBeUndefined();
@@ -525,7 +545,8 @@ describe('JavaScriptTool', () => {
       expect(mockSessionManager.mockCDPClient.send).toHaveBeenCalledWith(
         expect.anything(),
         'Runtime.evaluate',
-        expect.objectContaining({ awaitPromise: true })
+        expect.objectContaining({ awaitPromise: true }),
+        expect.objectContaining({ reserveRuntimeEvaluateResponseGrace: true }),
       );
 
       expect(result.isError).toBeUndefined();
@@ -559,6 +580,45 @@ describe('JavaScriptTool', () => {
         returnByValue: false,
       });
       expect(mockSender.send).toHaveBeenCalledWith({}, 'Runtime.releaseObject', { objectId: 'promise-1' });
+    });
+
+    test('threads the caller guard into Runtime.awaitPromise', async () => {
+      const controller = new AbortController();
+      const sendOptions = {
+        timeoutMs: 300,
+        deadlineAt: Date.now() + 1_000,
+        signal: controller.signal,
+        reserveRuntimeEvaluateResponseGrace: true,
+      };
+      const mockSender = {
+        send: jest.fn()
+          .mockResolvedValueOnce({ result: { type: 'number', value: 42, description: '42' } })
+          .mockResolvedValue({}),
+      };
+
+      await expect(formatCDPResult(
+        {
+          type: 'object',
+          subtype: 'promise',
+          className: 'Promise',
+          description: 'Promise',
+          objectId: 'promise-guarded',
+        },
+        mockSender,
+        {},
+        0,
+        sendOptions,
+      )).resolves.toBe('42');
+
+      expect(mockSender.send).toHaveBeenCalledWith(
+        {},
+        'Runtime.awaitPromise',
+        {
+          promiseObjectId: 'promise-guarded',
+          returnByValue: false,
+        },
+        sendOptions,
+      );
     });
 
     test('resolves Promise remote object to object output', async () => {
@@ -663,6 +723,125 @@ describe('JavaScriptTool', () => {
   });
 
   describe('Timeout', () => {
+    test('reserves response grace inside a custom timeout', async () => {
+      const handler = await getJavascriptHandler();
+
+      mockSessionManager.mockCDPClient.send.mockResolvedValueOnce({
+        result: { type: 'number', value: 42, description: '42' },
+      });
+
+      await handler(testSessionId, {
+        tabId: testTargetId,
+        text: '21 * 2',
+        timeout: 250,
+      });
+
+      expect(mockSessionManager.mockCDPClient.send).toHaveBeenCalledWith(
+        expect.anything(),
+        'Runtime.evaluate',
+        expect.objectContaining({ timeout: 250 }),
+        expect.objectContaining({
+          timeoutMs: addTimeoutResponseGraceMs(250),
+          reserveRuntimeEvaluateResponseGrace: true,
+        }),
+      );
+    });
+
+    test('threads the absolute parent deadline to the CDP dispatch guard', async () => {
+      const handler = await getJavascriptHandler();
+
+      mockSessionManager.mockCDPClient.send.mockResolvedValueOnce({
+        result: { type: 'number', value: 42, description: '42' },
+      });
+
+      const startTime = Date.now() - 750;
+      await handler(
+        testSessionId,
+        { tabId: testTargetId, text: '21 * 2', timeout: 5_000 },
+        { startTime, deadlineMs: 1_000 },
+      );
+
+      const params = mockSessionManager.mockCDPClient.send.mock.calls[0][2];
+      const options = mockSessionManager.mockCDPClient.send.mock.calls[0][3];
+      expect(params.timeout).toBe(5_000);
+      expect(options).toMatchObject({
+        timeoutMs: addTimeoutResponseGraceMs(5_000),
+        deadlineAt: startTime + 1_000,
+        reserveRuntimeEvaluateResponseGrace: true,
+      });
+    });
+
+    test('shares one timeout window with Runtime.awaitPromise formatting', async () => {
+      const handler = await getJavascriptHandler();
+      jest.useFakeTimers({ now: 10_000 });
+      try {
+        mockSessionManager.mockCDPClient.send
+          .mockImplementationOnce(() => new Promise((resolve) => {
+            setTimeout(() => resolve({
+              result: {
+                type: 'object',
+                subtype: 'promise',
+                className: 'Promise',
+                description: 'Promise',
+                objectId: 'pending-promise',
+              },
+            }), 250);
+          }))
+          .mockImplementationOnce(() => new Promise(() => {}));
+
+        let settled = false;
+        const resultPromise = handler(testSessionId, {
+          tabId: testTargetId,
+          text: 'new Promise(() => {})',
+          timeout: 250,
+        }).then((result) => {
+          settled = true;
+          return result as { content: Array<{ type: string; text: string }>; isError?: boolean };
+        });
+
+        await jest.advanceTimersByTimeAsync(299);
+        expect(settled).toBe(false);
+        await jest.advanceTimersByTimeAsync(2);
+
+        const result = await resultPromise;
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain('Promise resolution timed out');
+        expect(mockSessionManager.mockCDPClient.send).toHaveBeenCalledTimes(2);
+        expect(mockSessionManager.mockCDPClient.send.mock.calls[0][3].deadlineAt).toBe(10_300);
+        expect(mockSessionManager.mockCDPClient.send.mock.calls[1][3].deadlineAt).toBe(10_300);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    test('does not dispatch JavaScript after the parent budget is exhausted', async () => {
+      const handler = await getJavascriptHandler();
+
+      const result = await handler(
+        testSessionId,
+        { tabId: testTargetId, text: 'window.__shouldNotRun = true', timeout: 5_000 },
+        { startTime: Date.now() - 2_000, deadlineMs: 1_000 },
+      ) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('deadline exceeded');
+      expect(mockSessionManager.mockCDPClient.send).not.toHaveBeenCalled();
+    });
+
+    test('rejects a negative timeout without dispatching JavaScript', async () => {
+      const handler = await getJavascriptHandler();
+
+      const result = await handler(testSessionId, {
+        tabId: testTargetId,
+        text: 'window.__shouldNotRun = true',
+        timeout: -1,
+      }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('positive finite number');
+      expect(mockSessionManager.mockCDPClient.send).not.toHaveBeenCalled();
+    });
+
     test('handles timeout', async () => {
       const handler = await getJavascriptHandler();
 

--- a/tests/utils/with-timeout.test.ts
+++ b/tests/utils/with-timeout.test.ts
@@ -1,9 +1,83 @@
 /// <reference types="jest" />
-import { withTimeout } from '../../src/utils/with-timeout';
+import {
+  addTimeoutResponseGraceMs,
+  getEffectiveTimeoutMs,
+  getRemainingTimeoutMs,
+  getTimeoutDeadlineAt,
+  getTimeoutResponseGraceMs,
+  reserveTimeoutResponseGraceMs,
+  withTimeout,
+} from '../../src/utils/with-timeout';
 import { OpenChromeTimeoutError } from '../../src/errors/timeout';
 import { ToolContext } from '../../src/types/mcp';
 
 describe('withTimeout', () => {
+  describe('response grace helpers', () => {
+    test('preserves the requested inner timeout when the host budget adds grace', () => {
+      expect(getTimeoutResponseGraceMs(250)).toBe(50);
+      expect(addTimeoutResponseGraceMs(250)).toBe(300);
+      expect(addTimeoutResponseGraceMs(30_000)).toBe(30_250);
+    });
+
+    test('reserves bounded response time inside a tighter outer deadline', () => {
+      expect(reserveTimeoutResponseGraceMs(600)).toBe(480);
+      expect(reserveTimeoutResponseGraceMs(1)).toBe(1);
+      expect(reserveTimeoutResponseGraceMs(0)).toBe(0);
+    });
+  });
+
+  describe('getEffectiveTimeoutMs', () => {
+    test('returns the requested timeout without a ToolContext', () => {
+      expect(getEffectiveTimeoutMs(5_000)).toBe(5_000);
+    });
+
+    test('caps the timeout to the remaining ToolContext budget', () => {
+      const context: ToolContext = {
+        startTime: Date.now() - 750,
+        deadlineMs: 1_000,
+      };
+
+      const effective = getEffectiveTimeoutMs(5_000, context);
+      expect(effective).toBeGreaterThan(0);
+      expect(effective).toBeLessThanOrEqual(250);
+    });
+
+    test('returns zero when the ToolContext budget is exhausted', () => {
+      const context: ToolContext = {
+        startTime: Date.now() - 2_000,
+        deadlineMs: 1_000,
+      };
+
+      expect(getEffectiveTimeoutMs(5_000, context)).toBe(0);
+    });
+  });
+
+  describe('absolute timeout deadlines', () => {
+    test('shares one deadline across sequential phases', () => {
+      jest.useFakeTimers({ now: 10_000 });
+      try {
+        const deadlineAt = getTimeoutDeadlineAt(300);
+        expect(deadlineAt).toBe(10_300);
+        jest.advanceTimersByTime(250);
+        expect(getRemainingTimeoutMs(deadlineAt)).toBe(50);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    test('uses the earlier parent deadline', () => {
+      jest.useFakeTimers({ now: 20_000 });
+      try {
+        expect(getTimeoutDeadlineAt(5_000, {
+          startTime: 19_500,
+          deadlineMs: 1_000,
+        })).toBe(20_500);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+
   test('should resolve when promise completes before timeout', async () => {
     const result = await withTimeout(Promise.resolve('ok'), 1000, 'test');
     expect(result).toBe('ok');


### PR DESCRIPTION
Closes #1561

## Why

Obscura v0.1.11 / `e78b5e60261599a850c053eaecc2de92625496d7` exposes a useful reliability invariant: returning a timeout to the caller is not equivalent to stopping synchronous JavaScript that is still occupying the runtime.

This PR absorbs that invariant at OpenChrome's existing real-Chrome boundary. It does **not** adopt Obscura's embedded Rust/V8 engine, custom browser/CDP server, anti-detect direction, or tracker-blocking policy. OpenChrome remains a host-neutral MCP harness over the user's real Chrome.

## What changed

- Send the existing `javascript_tool` and per-item `batch_execute` timeout as Chrome's experimental `Runtime.evaluate.timeout`.
- Preserve the `30000ms` default and positive custom values when the parent deadline has room for bounded response grace.
- Share one absolute invocation deadline across CDP session acquisition, `Runtime.evaluate`, `Runtime.awaitPromise`, and object result formatting.
- Reject session acquisition promptly on timeout or request abort, and never dispatch after the deadline or cancellation.
- Recompute queued batch-item budgets when each item starts; bound and clean up inter-item waits.
- Treat non-connection `Runtime.evaluate` and `Runtime.awaitPromise` protocol failures as non-retryable so user JavaScript is never replayed after partial side effects.
- Document the narrow best-effort exception in the SSOT while retaining the general cancellation contract.
- Add unit, interop, idempotency, recovery, and gated real-Chrome regression coverage.

## Behavioral boundary

Guaranteed:

- CPU-bound synchronous evaluation is given a renderer execution budget.
- Caller latency remains bounded by host/Puppeteer guards.
- The same tab remains usable after Chrome terminates a runaway expression.
- Unsupported/experimental CDP behavior fails boundedly without fallback dispatch or replay.

Not guaranteed:

- rollback of side effects completed before termination;
- cancellation of unresolved Promises, timers, fetches, workers, or listeners;
- generalized cancellation for unrelated CDP operations.

## Review findings resolved

Independent review blocked earlier drafts until these cases were fixed:

- host timeout could beat the renderer watchdog;
- delayed or hung CDP session acquisition could outlive the deadline or abort;
- `Runtime.evaluate` and `Runtime.awaitPromise` protocol errors could reconnect and replay JavaScript;
- formatting could start a second timeout window;
- batch inter-item waits ignored deadline/abort and leaked delay timers;
- live tests did not initially exercise the actual tool path or asynchronous limitation strongly enough.

Final independent review of `origin/develop...HEAD`: **APPROVE**, with zero medium-or-higher findings.

## Verification

- Focused Jest: **146/146 passed**
- Real Chrome `150.0.7871.187`: **2/2 passed**
  - synchronous runaway terminated in about **258ms** and the same tab returned `42` afterward;
  - unresolved Promise returned through the host timeout in about **308ms** without claiming cancellation;
  - partial side effects remained observable and cleanup was explicit.
- `npm run build`
- `npm run lint:changed -- --base origin/develop`
- `npm run lint:tier`
- `npm run lint:tool-schemas` (`0` new violations)
- `npm run docs:capability-map:check`
- `git diff --check origin/develop...HEAD`

The full Jest suite was not rerun after the final session-acquisition guard and stale headed assertion updates; their focused suites pass, and GitHub CI is the merge authority.
