### PR TITLE
fix(crawl): preserve fit-markdown options in resumable crawl jobs

### DIFF
--- a/docs/recipes/fit-markdown.md
+++ b/docs/recipes/fit-markdown.md
@@ -40,6 +40,43 @@ For query-aware filtering:
 }
 ```
 
+## resumable crawl_start / crawl_status
+
+Persist the same Markdown projection contract when the host needs bounded,
+resumable progress:
+
+```json
+{
+  "url": "https://example.com",
+  "output_format": "markdown-clean",
+  "content_filter": "prune",
+  "return_raw": true,
+  "return_fit": true
+}
+```
+
+Use the returned `jobId` to advance and read pages:
+
+```json
+{
+  "jobId": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+  "advance": 5,
+  "includePages": true
+}
+```
+
+Filtered pages use `fit_markdown` as canonical `content`. Requested raw and fit
+aliases are returned by `crawl_status` without storing duplicate copies when an
+alias is identical to `content`.
+
+Projection options are ignored unless `output_format` is `markdown-clean`.
+Because raw Markdown can contain authenticated page content, `return_raw: true`
+does not read or write the shared `public` cache. Set `cache_scope` to `session`
+when raw projection caching is required.
+
+Resumable queries are limited to 2,048 characters. Credential-shaped query
+material is rejected instead of being written to the durable job log.
+
 Each filtered response includes `filter` metrics: raw/fit character counts,
 reduction ratio, sections seen/kept, filter type, and query when applicable.
 `bm25` requires a non-empty query and fails clearly instead of silently falling

--- a/src/core/crawl/job-store.ts
+++ b/src/core/crawl/job-store.ts
@@ -27,23 +27,31 @@ import * as path from 'node:path';
 
 import { acquireLock } from '../../utils/atomic-file';
 import { normalizeUrl } from '../../utils/crawl-utils';
+import type { ContentFilterMetrics, ContentFilterType } from '../extract/content-filter';
 import { redactValue } from '../trace/redactor';
 import type { CrawlCacheMetadata, CrawlCacheMode, CrawlCacheScope } from './content-cache';
+
+export type CrawledPageTextField = 'content' | 'raw_markdown' | 'fit_markdown';
+export const MAX_CRAWL_QUERY_CHARS = 2048;
 
 /** A page recorded in the job log (mirrors the legacy `crawl` tool shape). */
 export interface CrawledPage {
   url: string;
   title: string;
   content: string;
+  raw_markdown?: string;
+  fit_markdown?: string;
+  filter?: ContentFilterMetrics;
   depth: number;
   links_found: number;
   error?: string;
   /**
-   * Present and `true` when `content` was capped at `OC_CRAWL_PAGE_BYTES`
-   * (default 256 KiB). Absent when the page fit under the cap. Bounds the
-   * on-disk growth of a single job to a predictable size.
+   * Present when a shared fetch limit or `OC_CRAWL_PAGE_BYTES` capped content.
+   * Absent when every requested representation was preserved in full.
    */
   truncated?: boolean;
+  /** Text projections affected by a shared fetch or persistence limit. */
+  truncated_fields?: CrawledPageTextField[];
   cache?: CrawlCacheMetadata;
 }
 
@@ -58,6 +66,10 @@ export interface JobConfig {
   output_format: string;
   onlyMainContent?: boolean;
   includeLinks?: boolean;
+  content_filter?: ContentFilterType;
+  query?: string;
+  return_raw?: boolean;
+  return_fit?: boolean;
   respect_robots: boolean;
   delay_ms: number;
   concurrency: number;
@@ -210,6 +222,17 @@ function scrubUrlString(value: string): string {
   return typeof out === 'string' ? out : value;
 }
 
+export function assertPersistableCrawlQuery(query: string | undefined): void {
+  if (query === undefined) return;
+  if (query.length > MAX_CRAWL_QUERY_CHARS) {
+    throw new Error(`query must be at most ${MAX_CRAWL_QUERY_CHARS} characters`);
+  }
+  const redacted = redactValue(query);
+  if (typeof redacted !== 'string' || redacted !== query) {
+    throw new Error('query contains credential-like material that cannot be persisted safely');
+  }
+}
+
 /**
  * Defence-in-depth: even though the runner now scrubs `url`/`title`/`content`
  * up front (see `runner.ts`), every event is run through the credential
@@ -218,11 +241,20 @@ function scrubUrlString(value: string): string {
  *   - secrets that slip into fields the runner doesn't explicitly handle
  *     (e.g. an error `message` that quotes a Bearer token).
  *
- * The walker preserves shape (kind, t, depth, links_found, page.depth, …) —
- * only string leaves get pattern-scrubbed.
+ * The walker preserves operational shape while omitting per-page filter.query;
+ * the job header is the single durable source for that repeated value.
  */
 function scrubEvent(event: JobEvent): JobEvent {
-  return redactValue(event) as JobEvent;
+  let persistenceEvent = event;
+  if (event.kind === 'fetched' && event.page.filter?.query !== undefined) {
+    const filter = { ...event.page.filter };
+    delete filter.query;
+    persistenceEvent = {
+      ...event,
+      page: { ...event.page, filter },
+    };
+  }
+  return redactValue(persistenceEvent) as JobEvent;
 }
 
 /**
@@ -230,6 +262,7 @@ function scrubEvent(event: JobEvent): JobEvent {
  * write never produces a half-initialised job. Returns the freshly minted ULID.
  */
 export async function createJob(config: JobConfig): Promise<string> {
+  assertPersistableCrawlQuery(config.query);
   ensureRoot();
   const jobId = generateUlid();
   const file = jobFilePath(jobId);
@@ -237,7 +270,10 @@ export async function createJob(config: JobConfig): Promise<string> {
   // basic-auth `https://user:pass@host/` or a `?token=…` in a callback URL).
   // The runner sees the original `config.url` only in memory; on disk we
   // keep the scrubbed copy.
-  const safeConfig: JobConfig = { ...config, url: scrubUrlString(config.url) };
+  const safeConfig: JobConfig = {
+    ...config,
+    url: scrubUrlString(config.url),
+  };
   ORIGINAL_START_URLS.set(jobId, config.url);
   const header: HeaderRecord = { kind: 'header', config: safeConfig, createdAt: Date.now() };
   const line = JSON.stringify(header) + '\n';

--- a/src/core/crawl/runner.ts
+++ b/src/core/crawl/runner.ts
@@ -11,6 +11,8 @@
  * the next `advanceJob` call resumes from.
  */
 
+import { TextDecoder } from 'node:util';
+import { MAX_OUTPUT_CHARS } from '../../config/defaults';
 import type { ToolContext } from '../../types/mcp';
 import { hasBudget } from '../../types/mcp';
 import {
@@ -40,6 +42,7 @@ import {
   takeOriginalQueuedUrl,
   withJobLock,
   type CrawledPage,
+  type CrawledPageTextField,
   type JobState,
   type QueueEntry,
 } from './job-store';
@@ -77,15 +80,21 @@ function pageContentByteCap(): number {
 /**
  * Truncate a UTF-8 string to at most `maxBytes` bytes. Returns the original
  * string when already small enough plus a `truncated` flag. We cut on the
- * byte boundary then re-decode with `fatal: false` so the trailing partial
- * code-point (if any) is replaced with U+FFFD rather than producing invalid
- * UTF-8 in the JSONL line.
+ * byte boundary and back off until the slice ends on a complete code point.
  */
 function truncateUtf8(value: string, maxBytes: number): { value: string; truncated: boolean } {
   const buf = Buffer.from(value, 'utf8');
   if (buf.length <= maxBytes) return { value, truncated: false };
-  const slice = buf.subarray(0, maxBytes);
-  return { value: slice.toString('utf8'), truncated: true };
+  const decoder = new TextDecoder('utf-8', { fatal: true });
+  let end = maxBytes;
+  while (end > 0) {
+    try {
+      return { value: decoder.decode(buf.subarray(0, end)), truncated: true };
+    } catch {
+      end--;
+    }
+  }
+  return { value: '', truncated: true };
 }
 
 /**
@@ -96,6 +105,122 @@ function truncateUtf8(value: string, maxBytes: number): { value: string; truncat
 function scrubString(value: string): string {
   const out = redactValue(value);
   return typeof out === 'string' ? out : value;
+}
+
+const SHARED_OUTPUT_TRUNCATION_SUFFIX = '...[truncated]';
+
+function wasSharedOutputTruncated(value: string): boolean {
+  return value.length === MAX_OUTPUT_CHARS + SHARED_OUTPUT_TRUNCATION_SUFFIX.length &&
+    value.endsWith(SHARED_OUTPUT_TRUNCATION_SUFFIX);
+}
+
+function filterWithoutQuery(
+  filter: FetchOnePageResult['filter'],
+): FetchOnePageResult['filter'] {
+  if (!filter) return undefined;
+  const copy = { ...filter };
+  delete copy.query;
+  return copy;
+}
+
+interface PageProjectionOptions {
+  returnRaw: boolean;
+  projectFit: boolean;
+  includeFilter: boolean;
+}
+
+interface PreparedPage {
+  page: CrawledPage;
+  cachePage: FetchOnePageResult;
+  links: string[];
+}
+
+function preparePageForPersistence(
+  result: FetchOnePageResult,
+  byteCap: number,
+  options: PageProjectionOptions,
+): PreparedPage {
+  const safeResult = redactValue({
+    url: result.url,
+    title: result.title,
+    content: result.content,
+    raw_markdown: options.returnRaw ? result.raw_markdown : undefined,
+    filter: options.includeFilter ? filterWithoutQuery(result.filter) : undefined,
+    error: result.error,
+    _links: result._links ?? [],
+  }) as {
+    url: string;
+    title: string;
+    content: string;
+    raw_markdown?: string;
+    filter?: FetchOnePageResult['filter'];
+    error?: string;
+    _links: string[];
+  };
+
+  const distinctRaw =
+    options.returnRaw &&
+    safeResult.raw_markdown !== undefined &&
+    safeResult.raw_markdown !== safeResult.content
+      ? safeResult.raw_markdown
+      : undefined;
+  const contentBytes = Buffer.byteLength(safeResult.content, 'utf8');
+  const rawBytes = distinctRaw === undefined ? 0 : Buffer.byteLength(distinctRaw, 'utf8');
+
+  let contentBudget = byteCap;
+  let rawBudget = 0;
+  if (distinctRaw !== undefined) {
+    contentBudget = Math.min(contentBytes, Math.ceil(byteCap / 2));
+    rawBudget = Math.min(rawBytes, Math.floor(byteCap / 2));
+    let remaining = byteCap - contentBudget - rawBudget;
+    const contentRemainder = Math.min(Math.max(0, contentBytes - contentBudget), remaining);
+    contentBudget += contentRemainder;
+    remaining -= contentRemainder;
+    rawBudget += Math.min(Math.max(0, rawBytes - rawBudget), remaining);
+  }
+
+  const boundedContent = truncateUtf8(safeResult.content, contentBudget);
+  const boundedRaw = distinctRaw === undefined
+    ? undefined
+    : truncateUtf8(distinctRaw, rawBudget);
+  const truncatedFields = new Set<CrawledPageTextField>();
+  for (const field of result.truncated_fields ?? []) {
+    if (
+      field === 'content' ||
+      (field === 'raw_markdown' && options.returnRaw) ||
+      (field === 'fit_markdown' && options.projectFit)
+    ) {
+      truncatedFields.add(field);
+    }
+  }
+  const contentWasTruncated =
+    result.truncated === true ||
+    wasSharedOutputTruncated(result.content) ||
+    boundedContent.truncated;
+  if (contentWasTruncated) {
+    truncatedFields.add('content');
+    if (options.projectFit) truncatedFields.add('fit_markdown');
+    if (options.returnRaw && distinctRaw === undefined) truncatedFields.add('raw_markdown');
+  }
+  if (boundedRaw?.truncated) truncatedFields.add('raw_markdown');
+
+  const page: CrawledPage = {
+    url: safeResult.url,
+    title: safeResult.title,
+    content: boundedContent.value,
+    ...(boundedRaw !== undefined ? { raw_markdown: boundedRaw.value } : {}),
+    ...(safeResult.filter !== undefined ? { filter: safeResult.filter } : {}),
+    depth: result.depth,
+    links_found: result.links_found,
+    ...(contentWasTruncated ? { truncated: true } : {}),
+    ...(truncatedFields.size > 0 ? { truncated_fields: Array.from(truncatedFields) } : {}),
+    ...(safeResult.error !== undefined ? { error: safeResult.error } : {}),
+  };
+  const cachePage: FetchOnePageResult = {
+    ...page,
+    ...(safeResult._links.length > 0 ? { _links: safeResult._links } : {}),
+  };
+  return { page, cachePage, links: safeResult._links };
 }
 
 /**
@@ -238,10 +363,24 @@ export async function advanceJob(
   const outputFormat = state.config.output_format;
   const onlyMainContent = state.config.onlyMainContent;
   const includeLinks = state.config.includeLinks;
+  const usesMarkdownProjection = outputFormat === 'markdown-clean';
+  const contentFilter = usesMarkdownProjection
+    ? (state.config.content_filter ?? 'none')
+    : 'none';
+  const query = usesMarkdownProjection
+    ? state.config.query
+    : undefined;
+  const returnRaw = usesMarkdownProjection && state.config.return_raw === true;
+  const returnFit = usesMarkdownProjection &&
+    (state.config.return_fit ?? contentFilter !== 'none');
+  const projectFit = contentFilter !== 'none' && returnFit;
+  const includeFilter = usesMarkdownProjection &&
+    (contentFilter !== 'none' || returnRaw || returnFit);
   const delayMs = state.config.delay_ms;
   const respectRobots = state.config.respect_robots;
   const cacheMode = state.config.cache_mode ?? 'disabled';
   const cacheScope = state.config.cache_scope ?? 'public';
+  const rawMarkdownRequiresSessionScope = returnRaw && cacheScope === 'public';
   const cacheTtlMs = state.config.cache_ttl_ms;
   const crawlCache = new CrawlContentCache<FetchOnePageResult>();
   const robotsCache = new Map<string, RobotsRules | null>();
@@ -316,29 +455,52 @@ export async function advanceJob(
         engine: 'crawl_job',
         cacheScope,
         sessionFingerprint: sessionId,
-        dimensions: { onlyMainContent, includeLinks, scope, includePatterns, excludePatterns },
+        dimensions: {
+          onlyMainContent,
+          includeLinks,
+          scope,
+          includePatterns,
+          excludePatterns,
+          contentFilter,
+          query,
+          returnRaw,
+          returnFit,
+          pageByteCap: byteCap,
+        },
       });
 
       let result: FetchOnePageResult;
-      const cached = canReadCache(cacheMode) ? crawlCache.read(cacheKey, cacheTtlMs) : null;
+      let cacheMeta: CrawledPage['cache'];
+      const cached = canReadCache(cacheMode) && !rawMarkdownRequiresSessionScope
+        ? crawlCache.read(cacheKey, cacheTtlMs)
+        : null;
       if (cached && !cached.stale) {
         result = {
           ...cached.entry.page,
           depth: next.depth,
-          cache: crawlCache.metadata('hit', {
-            key: cacheKey,
-            scope: cacheScope,
-            hit: true,
-            createdAt: cached.entry.createdAt,
-            content_length: cached.entry.contentLength,
-          }),
+          _links: cached.entry.page._links ?? cached.entry.links,
         };
+        cacheMeta = crawlCache.metadata('hit', {
+          key: cacheKey,
+          scope: cacheScope,
+          hit: true,
+          createdAt: cached.entry.createdAt,
+          content_length: cached.entry.contentLength,
+        });
       } else try {
         result = await fetcher(
           sessionId,
           fetchUrl,
           next.depth,
-          { outputFormat, onlyMainContent, includeLinks },
+          {
+            outputFormat,
+            onlyMainContent,
+            includeLinks,
+            contentFilter,
+            query,
+            returnRaw,
+            returnFit,
+          },
           context,
         );
       } catch (err) {
@@ -368,11 +530,32 @@ export async function advanceJob(
       }
 
       const links = result._links ?? [];
+      const prepared = preparePageForPersistence(result, byteCap, {
+        returnRaw,
+        projectFit,
+        includeFilter,
+      });
       if (cacheMode !== 'disabled' && !(cached && !cached.stale)) {
         const cacheStatus = cacheMode === 'write_only' ? 'write_only' : cacheMode === 'bypass' ? 'bypass' : 'miss';
-        let cacheMeta = crawlCache.metadata(cacheStatus, { key: cacheKey, scope: cacheScope, hit: false, write: 'disabled' });
-        if (canWriteCache(cacheMode) && !result.error) {
-          const written = crawlCache.write({ key: cacheKey, sourceUrl: fetchUrl, finalUrl: result.url, page: result, links, cacheScope });
+        const writeBlockedReason = rawMarkdownRequiresSessionScope
+          ? 'raw-markdown-requires-session-scope'
+          : undefined;
+        cacheMeta = crawlCache.metadata(cacheStatus, {
+          key: cacheKey,
+          scope: cacheScope,
+          hit: false,
+          write: writeBlockedReason && canWriteCache(cacheMode) ? 'skipped' : 'disabled',
+          ...(writeBlockedReason ? { write_skipped_reason: writeBlockedReason } : {}),
+        });
+        if (canWriteCache(cacheMode) && !writeBlockedReason && !result.error) {
+          const written = crawlCache.write({
+            key: cacheKey,
+            sourceUrl: scrubString(fetchUrl),
+            finalUrl: prepared.page.url,
+            page: prepared.cachePage,
+            links: prepared.links,
+            cacheScope,
+          });
           cacheMeta = crawlCache.metadata(cacheStatus, {
             key: cacheKey,
             scope: cacheScope,
@@ -380,33 +563,17 @@ export async function advanceJob(
             write: written.stored ? 'stored' : 'skipped',
             write_skipped_reason: written.reason,
             createdAt: written.entry?.createdAt,
-            content_length: result.content.length,
+            content_length: prepared.page.content.length,
           });
         }
-        result.cache = cacheMeta;
       }
-      // Redact url/title/content before they hit disk: page bodies routinely
-      // contain Bearer tokens, JWTs, AWS keys, etc. The redactor also runs at
-      // the job-store boundary (defence-in-depth), but doing it here keeps
-      // the in-memory event tree consistent and lets the truncation step
-      // operate on the scrubbed text.
-      const safeUrl = scrubString(result.url);
-      const safeTitle = scrubString(result.title);
-      const scrubbedContent = scrubString(result.content);
-      const { value: cappedContent, truncated } = truncateUtf8(scrubbedContent, byteCap);
       const page: CrawledPage = {
-        url: safeUrl,
-        title: safeTitle,
-        content: cappedContent,
-        depth: result.depth,
-        links_found: result.links_found,
-        ...(truncated ? { truncated: true } : {}),
-        ...(result.error !== undefined ? { error: scrubString(result.error) } : {}),
-        ...(result.cache ? { cache: result.cache } : {}),
+        ...prepared.page,
+        ...(cacheMeta ? { cache: cacheMeta } : {}),
       };
       appendEventUnlocked(jobId, {
         kind: 'fetched',
-        url: safeUrl,
+        url: page.url,
         depth: next.depth,
         page,
         t: Date.now(),

--- a/src/tools/crawl-start.ts
+++ b/src/tools/crawl-start.ts
@@ -8,8 +8,14 @@
 import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
-import { createJob, type JobConfig } from '../core/crawl/job-store';
+import {
+  assertPersistableCrawlQuery,
+  createJob,
+  MAX_CRAWL_QUERY_CHARS,
+  type JobConfig,
+} from '../core/crawl/job-store';
 import { parseCrawlCacheMode, parseCrawlCacheScope } from '../core/crawl/content-cache';
+import type { ContentFilterType } from '../core/extract/content-filter';
 import { emitCrawlTrace } from '../core/crawl/trace-emit';
 
 const definition: MCPToolDefinition = {
@@ -17,8 +23,8 @@ const definition: MCPToolDefinition = {
   description:
     'Initialise a resumable crawl job. Returns { jobId, status: "pending" } ' +
     'immediately — performs NO network I/O. Drive progress with crawl_status' +
-    '({ jobId, advance: N }) which fetches up to N pages per call. Same args ' +
-    'as the legacy crawl tool. Use crawl_cancel to stop.',
+    '({ jobId, advance: N }) which fetches up to N pages per call. Supports ' +
+    'the crawl subset listed in this schema; use crawl_cancel to stop.',
   annotations: TOOL_ANNOTATIONS.crawl_start,
   inputSchema: {
     type: 'object',
@@ -32,6 +38,14 @@ const definition: MCPToolDefinition = {
       output_format: { type: 'string', enum: ['markdown', 'text', 'structured', 'markdown-clean'], description: 'Content format. Default: markdown' },
       onlyMainContent: { type: 'boolean', description: 'For markdown-clean, remove nav/footer/ads before conversion. Default: true' },
       includeLinks: { type: 'boolean', description: 'For markdown-clean, include link destinations in markdown. Default: true' },
+      content_filter: { type: 'string', enum: ['none', 'prune', 'bm25'], description: 'markdown-clean only: deterministic fit_markdown filter. Default: none.' },
+      query: {
+        type: 'string',
+        maxLength: MAX_CRAWL_QUERY_CHARS,
+        description: 'markdown-clean only: query terms required by content_filter="bm25".',
+      },
+      return_raw: { type: 'boolean', description: 'markdown-clean only: include raw_markdown in each returned page. Default: false.' },
+      return_fit: { type: 'boolean', description: 'markdown-clean only: include fit_markdown and use it as content. Defaults to true when filtering.' },
       respect_robots: { type: 'boolean', description: 'Whether to obey robots.txt. Default: true' },
       delay_ms: { type: 'number', description: 'Delay between page fetches (ms). Default: 1000' },
       concurrency: { type: 'number', description: 'Max parallel fetches. Default: 3' },
@@ -59,6 +73,30 @@ const handler: ToolHandler = async (
   }
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     return errorResult('url must use http or https scheme');
+  }
+
+  const outputFormat = (args.output_format as string) || 'markdown';
+  const usesMarkdownProjection = outputFormat === 'markdown-clean';
+  let contentFilter: ContentFilterType | undefined;
+  let query: string | undefined;
+  if (usesMarkdownProjection) {
+    try {
+      contentFilter = parseResumableContentFilter(args.content_filter);
+    } catch (err) {
+      return errorResult(err instanceof Error ? err.message : String(err));
+    }
+    if (args.query !== undefined && typeof args.query !== 'string') {
+      return errorResult('query must be a string');
+    }
+    query = args.query as string | undefined;
+    try {
+      assertPersistableCrawlQuery(query);
+    } catch (err) {
+      return errorResult(err instanceof Error ? err.message : String(err));
+    }
+    if (contentFilter === 'bm25' && !query?.trim()) {
+      return errorResult('content_filter="bm25" requires a non-empty query');
+    }
   }
 
   // Clamp `max_pages` to [1, 10_000]. The legacy crawl tool accepted up to
@@ -91,9 +129,19 @@ const handler: ToolHandler = async (
     scope: (args.scope as string) || `${parsed.origin}/**`,
     include_patterns: args.include_patterns as string[] | undefined,
     exclude_patterns: args.exclude_patterns as string[] | undefined,
-    output_format: (args.output_format as string) || 'markdown',
+    output_format: outputFormat,
     onlyMainContent: args.onlyMainContent !== false,
     includeLinks: args.includeLinks !== false,
+    content_filter: contentFilter,
+    query,
+    return_raw:
+      usesMarkdownProjection && typeof args.return_raw === 'boolean'
+        ? args.return_raw
+        : undefined,
+    return_fit:
+      usesMarkdownProjection && typeof args.return_fit === 'boolean'
+        ? args.return_fit
+        : undefined,
     respect_robots: args.respect_robots !== false,
     delay_ms: args.delay_ms != null ? Number(args.delay_ms) : 1000,
     concurrency:
@@ -127,6 +175,12 @@ const handler: ToolHandler = async (
     ...payload,
   };
 };
+
+function parseResumableContentFilter(value: unknown): ContentFilterType | undefined {
+  if (value === undefined) return undefined;
+  if (value === 'none' || value === 'prune' || value === 'bm25') return value;
+  throw new Error('content_filter must be one of none, prune, bm25');
+}
 
 function errorResult(message: string): MCPResult {
   return {

--- a/src/tools/crawl-status.ts
+++ b/src/tools/crawl-status.ts
@@ -10,7 +10,14 @@
 import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
-import { assertValidJobId, loadJob, isExpired, type JobState } from '../core/crawl/job-store';
+import {
+  assertValidJobId,
+  loadJob,
+  isExpired,
+  type CrawledPage,
+  type JobConfig,
+  type JobState,
+} from '../core/crawl/job-store';
 import { advanceJob, defaultAdvance, type AdvanceOptions } from '../core/crawl/runner';
 import { emitCrawlTrace } from '../core/crawl/trace-emit';
 
@@ -56,6 +63,41 @@ interface StatusResponse {
   pagesOmitted?: number;
   startedAt?: number;
   finishedAt?: number;
+}
+
+function projectPage(page: CrawledPage, config: JobConfig): CrawledPage {
+  const {
+    raw_markdown: storedRaw,
+    fit_markdown: storedFit,
+    filter: storedFilter,
+    truncated_fields: storedTruncatedFields,
+    ...base
+  } = page;
+  const usesMarkdownProjection = config.output_format === 'markdown-clean';
+  const visibleTruncatedFields = usesMarkdownProjection
+    ? storedTruncatedFields
+    : storedTruncatedFields?.filter((field) => field === 'content');
+  const returnRaw = usesMarkdownProjection && config.return_raw === true;
+  const returnFit =
+    usesMarkdownProjection &&
+    (config.content_filter ?? 'none') !== 'none' &&
+    (config.return_fit ?? true);
+  const normalizedQuery = config.query?.trim();
+  const visibleFilter = usesMarkdownProjection && storedFilter !== undefined
+    ? {
+        ...storedFilter,
+        ...(normalizedQuery ? { query: normalizedQuery } : {}),
+      }
+    : undefined;
+  return {
+    ...base,
+    ...(visibleTruncatedFields && visibleTruncatedFields.length > 0
+      ? { truncated_fields: visibleTruncatedFields }
+      : {}),
+    ...(visibleFilter ? { filter: visibleFilter } : {}),
+    ...(returnRaw ? { raw_markdown: storedRaw ?? page.content } : {}),
+    ...(returnFit ? { fit_markdown: storedFit ?? page.content } : {}),
+  };
 }
 
 let runnerOptionsOverride: AdvanceOptions | undefined;
@@ -140,11 +182,12 @@ const handler: ToolHandler = async (
   };
 
   if (includePages) {
+    const visiblePages = state.pages.length > max
+      ? state.pages.slice(0, max)
+      : state.pages;
+    response.pages = visiblePages.map((page) => projectPage(page, state.config));
     if (state.pages.length > max) {
-      response.pages = state.pages.slice(0, max);
       response.pagesOmitted = state.pages.length - max;
-    } else {
-      response.pages = state.pages;
     }
   }
 

--- a/src/tools/crawl.ts
+++ b/src/tools/crawl.ts
@@ -499,11 +499,21 @@ export interface FetchOnePageOptions {
   onlyMainContent?: boolean;
   /** When true, include outgoing links in the result for BFS expansion. */
   includeLinks?: boolean;
+  /** Deterministic markdown-clean content projection. */
+  contentFilter?: ContentFilterType;
+  /** Query terms used by the BM25 content filter. */
+  query?: string;
+  /** Include the pre-filter markdown projection. */
+  returnRaw?: boolean;
+  /** Include/use the filtered markdown projection. */
+  returnFit?: boolean;
 }
 
 /** Single-page crawl result plus transient links for BFS/job queue expansion. */
 export interface FetchOnePageResult extends CrawledPage {
   _links?: string[];
+  truncated?: boolean;
+  truncated_fields?: Array<'content' | 'raw_markdown' | 'fit_markdown'>;
 }
 
 /**
@@ -520,6 +530,10 @@ export async function fetchOnePage(
   const cleanOpts = {
     onlyMainContent: opts.onlyMainContent !== false,
     includeLinks: opts.includeLinks !== false,
+    contentFilter: opts.contentFilter,
+    query: opts.query,
+    returnRaw: opts.returnRaw,
+    returnFit: opts.returnFit,
   };
   return fetchPage(sessionId, url, depth, opts.outputFormat, cleanOpts, context) as Promise<FetchOnePageResult>;
 }

--- a/tests/core/crawl/job-store.test.ts
+++ b/tests/core/crawl/job-store.test.ts
@@ -60,6 +60,48 @@ describe('job-store: createJob + loadJob', () => {
     expect(typeof header.createdAt).toBe('number');
   });
 
+  test('createJob persists safe projection options without mutating operational patterns', async () => {
+    const scope = 'http://example.test/**?token=scope-value';
+    const includePatterns = ['http://example.test/docs/**?token=include-value'];
+    const excludePatterns = ['http://example.test/private/**?token=exclude-value'];
+    const jobId = await createJob(makeConfig({
+      output_format: 'markdown-clean',
+      content_filter: 'bm25',
+      query: 'enterprise pricing',
+      return_raw: true,
+      return_fit: true,
+      scope,
+      include_patterns: includePatterns,
+      exclude_patterns: excludePatterns,
+    }));
+    const header = JSON.parse(fs.readFileSync(jobFilePath(jobId), 'utf8').trim());
+    expect(header.config).toMatchObject({
+      output_format: 'markdown-clean',
+      content_filter: 'bm25',
+      query: 'enterprise pricing',
+      return_raw: true,
+      return_fit: true,
+      scope,
+      include_patterns: includePatterns,
+      exclude_patterns: excludePatterns,
+    });
+  });
+
+  test('createJob rejects unsafe or oversized queries before writing a job', async () => {
+    await expect(createJob(makeConfig({
+      output_format: 'markdown-clean',
+      content_filter: 'bm25',
+      query: 'token=super-secret-value',
+    }))).rejects.toThrow(/credential-like material/);
+    await expect(createJob(makeConfig({
+      output_format: 'markdown-clean',
+      content_filter: 'bm25',
+      query: 'x'.repeat(2049),
+    }))).rejects.toThrow(/at most 2048 characters/);
+    expect(fs.readdirSync(process.env.OC_JOBS_ROOT!).filter((name) => name.endsWith('.jsonl')))
+      .toEqual([]);
+  });
+
   test('loadJob replays empty state for a fresh job', async () => {
     const jobId = await createJob(makeConfig());
     const state = loadJob(jobId);
@@ -85,6 +127,17 @@ describe('job-store: createJob + loadJob', () => {
         url: 'http://example.test/a',
         title: 'A',
         content: 'hi',
+        raw_markdown: 'raw hi',
+        filter: {
+          type: 'prune',
+          raw_chars: 6,
+          fit_chars: 2,
+          reduction_ratio: 0.667,
+          sections_seen: 2,
+          sections_kept: 1,
+          query: 'enterprise pricing',
+        },
+        truncated_fields: ['raw_markdown'],
         depth: 0,
         links_found: 0,
       },
@@ -95,6 +148,26 @@ describe('job-store: createJob + loadJob', () => {
     expect(state.visited.has('http://example.test/a')).toBe(true);
     expect(state.pages).toHaveLength(1);
     expect(state.pages[0].title).toBe('A');
+    expect(state.pages[0].raw_markdown).toBe('raw hi');
+    expect(state.pages[0].filter?.type).toBe('prune');
+    expect(state.pages[0].filter?.query).toBeUndefined();
+    expect(state.pages[0].truncated_fields).toEqual(['raw_markdown']);
+  });
+
+  test('loads pre-option JSONL headers with legacy defaults', () => {
+    const jobId = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+    const header = {
+      kind: 'header',
+      config: makeConfig(),
+      createdAt: Date.now(),
+    };
+    fs.writeFileSync(jobFilePath(jobId), `${JSON.stringify(header)}\n`, 'utf8');
+
+    const state = loadJob(jobId);
+    expect(state.config.content_filter).toBeUndefined();
+    expect(state.config.query).toBeUndefined();
+    expect(state.config.return_raw).toBeUndefined();
+    expect(state.config.return_fit).toBeUndefined();
   });
 
   test('setStatus: terminal cancelled is sticky across later running events', async () => {

--- a/tests/core/crawl/runner.test.ts
+++ b/tests/core/crawl/runner.test.ts
@@ -14,13 +14,17 @@ import * as path from 'node:path';
 
 import {
   appendEvent,
+  clearJobRuntimeSecrets,
   createJob,
   jobFilePath,
   loadJob,
   setStatus,
   type JobConfig,
 } from '../../../src/core/crawl/job-store';
+import { CrawlContentCache } from '../../../src/core/crawl/content-cache';
 import { advanceJob } from '../../../src/core/crawl/runner';
+import { MAX_OUTPUT_CHARS } from '../../../src/config/defaults';
+import type { FetchOnePageResult } from '../../../src/tools/crawl';
 import { startFixtureServer, type FixtureServer } from '../../helpers/fixture-server';
 import { makeSpyFetcher, type SpyState } from '../../helpers/http-fetcher';
 
@@ -62,6 +66,8 @@ afterEach(async () => {
   delete process.env.OC_CRAWL_ADVANCE_DEFAULT;
   delete process.env.OC_CRAWL_STATUS_MAX_PAGES;
   delete process.env.OC_JOB_RETENTION_MS;
+  delete process.env.OC_CRAWL_PAGE_BYTES;
+  delete process.env.OPENCHROME_CRAWL_CACHE_DIR;
 });
 
 describe('runner: lifecycle integration', () => {
@@ -274,5 +280,354 @@ describe('runner: enqueue history is durable', () => {
     });
     const reloaded = loadJob(jobId);
     expect(reloaded.queue.length).toBe(1);
+  });
+});
+
+describe('runner: markdown projection persistence', () => {
+  test('does not read or write public cache entries when raw markdown is requested', async () => {
+    mkTmpRoot();
+    process.env.OC_CRAWL_PAGE_BYTES = '4096';
+    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crawl-raw-cache-test-'));
+    process.env.OPENCHROME_CRAWL_CACHE_DIR = cacheDir;
+    server = await startFixtureServer([{ name: 'a' }]);
+
+    const config = makeConfig({
+      url: server.url('a'),
+      max_pages: 1,
+      output_format: 'markdown-clean',
+      onlyMainContent: true,
+      includeLinks: true,
+      content_filter: 'none',
+      return_raw: true,
+      return_fit: false,
+      cache_mode: 'enabled',
+      cache_scope: 'public',
+    });
+    const cache = new CrawlContentCache<FetchOnePageResult>();
+    const cacheKey = cache.key({
+      url: config.url,
+      outputFormat: config.output_format,
+      engine: 'crawl_job',
+      cacheScope: 'public',
+      sessionFingerprint: 's',
+      dimensions: {
+        onlyMainContent: config.onlyMainContent,
+        includeLinks: config.includeLinks,
+        scope: config.scope,
+        includePatterns: config.include_patterns,
+        excludePatterns: config.exclude_patterns,
+        contentFilter: 'none',
+        query: undefined,
+        returnRaw: true,
+        returnFit: false,
+        pageByteCap: 4096,
+      },
+    });
+    expect(cache.write({
+      key: cacheKey,
+      sourceUrl: config.url,
+      finalUrl: config.url,
+      page: {
+        url: config.url,
+        title: 'Cached',
+        content: 'cached fit',
+        raw_markdown: 'cached raw',
+        depth: 0,
+        links_found: 0,
+        _links: [],
+      },
+      links: [],
+      cacheScope: 'public',
+    }).stored).toBe(true);
+
+    const jobId = await createJob(config);
+    let fetchCalls = 0;
+    const state = await advanceJob(jobId, 1, 's', undefined, {
+      fetcher: async (_sessionId, url, depth) => {
+        fetchCalls++;
+        return {
+          url,
+          title: 'Fresh',
+          content: 'fresh fit',
+          raw_markdown: 'fresh raw',
+          depth,
+          links_found: 0,
+          _links: [],
+        };
+      },
+    });
+
+    expect(fetchCalls).toBe(1);
+    expect(state.pages[0]).toMatchObject({
+      content: 'fresh fit',
+      raw_markdown: 'fresh raw',
+      cache: {
+        status: 'miss',
+        write: 'skipped',
+        write_skipped_reason: 'raw-markdown-requires-session-scope',
+      },
+    });
+    expect(cache.read(cacheKey)?.entry.page.content).toBe('cached fit');
+  });
+
+  test('keeps raw markdown caching available inside the session scope', async () => {
+    mkTmpRoot();
+    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crawl-session-raw-cache-test-'));
+    process.env.OPENCHROME_CRAWL_CACHE_DIR = cacheDir;
+    server = await startFixtureServer([{ name: 'a' }]);
+
+    const config = makeConfig({
+      url: server.url('a'),
+      max_pages: 1,
+      output_format: 'markdown-clean',
+      content_filter: 'none',
+      return_raw: true,
+      return_fit: false,
+      cache_mode: 'enabled',
+      cache_scope: 'session',
+    });
+    let fetchCalls = 0;
+    const fetcher = async (_sessionId: string, url: string, depth: number) => {
+      fetchCalls++;
+      return {
+        url,
+        title: 'A',
+        content: 'fit body',
+        raw_markdown: 'raw body',
+        depth,
+        links_found: 0,
+        _links: [],
+      };
+    };
+
+    await advanceJob(await createJob(config), 1, 's', undefined, { fetcher });
+    const cached = await advanceJob(await createJob(config), 1, 's', undefined, { fetcher });
+
+    expect(fetchCalls).toBe(1);
+    expect(cached.pages[0]).toMatchObject({
+      content: 'fit body',
+      raw_markdown: 'raw body',
+      cache: { status: 'hit', hit: true, scope: 'session' },
+    });
+  });
+
+  test('resumes with the persisted BM25 query after runtime state is cleared', async () => {
+    mkTmpRoot();
+    server = await startFixtureServer([{ name: 'a' }]);
+    const jobId = await createJob(makeConfig({
+      url: server.url('a'),
+      max_pages: 1,
+      output_format: 'markdown-clean',
+      content_filter: 'bm25',
+      query: 'enterprise pricing',
+      return_fit: true,
+    }));
+    clearJobRuntimeSecrets(jobId);
+    const queries: Array<string | undefined> = [];
+
+    await advanceJob(jobId, 1, 's', undefined, {
+      fetcher: async (_sessionId, url, depth, opts) => {
+        queries.push(opts.query);
+        return {
+          url,
+          title: 'A',
+          content: 'enterprise pricing',
+          fit_markdown: 'enterprise pricing',
+          filter: {
+            type: 'bm25',
+            raw_chars: 18,
+            fit_chars: 18,
+            reduction_ratio: 0,
+            sections_seen: 1,
+            sections_kept: 1,
+            query: opts.query,
+          },
+          depth,
+          links_found: 0,
+          _links: [],
+        };
+      },
+    });
+
+    expect(queries).toEqual(['enterprise pricing']);
+  });
+
+  test('separates cache entries by markdown projection options', async () => {
+    mkTmpRoot();
+    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crawl-cache-key-test-'));
+    process.env.OPENCHROME_CRAWL_CACHE_DIR = cacheDir;
+    server = await startFixtureServer([{ name: 'a' }]);
+
+    const base = {
+      url: server.url('a'),
+      max_pages: 1,
+      output_format: 'markdown-clean',
+      content_filter: 'bm25' as const,
+      return_fit: true,
+      cache_mode: 'write_only' as const,
+      cache_scope: 'session' as const,
+    };
+    const firstJob = await createJob(makeConfig({ ...base, query: 'alpha' }));
+    const secondJob = await createJob(makeConfig({ ...base, query: 'beta' }));
+    const fetcher = async (_sessionId: string, url: string, depth: number) => ({
+      url,
+      title: 'A',
+      content: 'fit body',
+      fit_markdown: 'fit body',
+      filter: {
+        type: 'bm25' as const,
+        raw_chars: 12,
+        fit_chars: 8,
+        reduction_ratio: 0.333,
+        sections_seen: 1,
+        sections_kept: 1,
+      },
+      depth,
+      links_found: 0,
+      _links: [],
+    });
+
+    await advanceJob(firstJob, 1, 's', undefined, { fetcher });
+    await advanceJob(secondJob, 1, 's', undefined, { fetcher });
+
+    expect(fs.readdirSync(cacheDir).filter((name) => name.endsWith('.json'))).toHaveLength(2);
+  });
+
+  test('separates cache entries by the effective page byte cap', async () => {
+    mkTmpRoot();
+    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crawl-byte-cap-key-test-'));
+    process.env.OPENCHROME_CRAWL_CACHE_DIR = cacheDir;
+    server = await startFixtureServer([{ name: 'a' }]);
+
+    const config = makeConfig({
+      url: server.url('a'),
+      max_pages: 1,
+      output_format: 'markdown',
+      onlyMainContent: true,
+      includeLinks: true,
+      cache_mode: 'enabled',
+      cache_scope: 'session',
+    });
+    let fetchCalls = 0;
+    const fetcher = async (_sessionId: string, url: string, depth: number) => {
+      fetchCalls++;
+      return {
+        url,
+        title: 'A',
+        content: 'x'.repeat(100),
+        depth,
+        links_found: 0,
+        _links: [],
+      };
+    };
+
+    process.env.OC_CRAWL_PAGE_BYTES = '16';
+    const first = await advanceJob(await createJob(config), 1, 's', undefined, { fetcher });
+    process.env.OC_CRAWL_PAGE_BYTES = '64';
+    const second = await advanceJob(await createJob(config), 1, 's', undefined, { fetcher });
+
+    expect(fetchCalls).toBe(2);
+    expect(Buffer.byteLength(first.pages[0].content, 'utf8')).toBe(16);
+    expect(Buffer.byteLength(second.pages[0].content, 'utf8')).toBe(64);
+    expect(fs.readdirSync(cacheDir).filter((name) => name.endsWith('.json'))).toHaveLength(2);
+  });
+
+  test('redacts and aggregate-bounds distinct content before cache and JSONL writes', async () => {
+    mkTmpRoot();
+    process.env.OC_CRAWL_PAGE_BYTES = '48';
+    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crawl-cache-test-'));
+    process.env.OPENCHROME_CRAWL_CACHE_DIR = cacheDir;
+    server = await startFixtureServer([{ name: 'a' }]);
+    const query = 'enterprise pricing '.repeat(80).trim();
+    const jobId = await createJob(makeConfig({
+      url: server.url('a'),
+      max_pages: 1,
+      output_format: 'markdown-clean',
+      content_filter: 'prune',
+      query,
+      return_raw: true,
+      return_fit: true,
+      cache_mode: 'write_only',
+      cache_scope: 'session',
+    }));
+
+    const state = await advanceJob(jobId, 1, 's', undefined, {
+      fetcher: async (_sessionId, url, depth) => ({
+        url,
+        title: 'token=super-secret-value',
+        content: `fit token=super-secret-value ${'가'.repeat(40)}`,
+        raw_markdown: `raw token=super-secret-value ${'나'.repeat(40)}`,
+        fit_markdown: `fit token=super-secret-value ${'가'.repeat(40)}`,
+        filter: {
+          type: 'prune',
+          raw_chars: 200,
+          fit_chars: 100,
+          reduction_ratio: 0.5,
+          sections_seen: 2,
+          sections_kept: 1,
+          query,
+        },
+        depth,
+        links_found: 0,
+        _links: [],
+      }),
+    });
+
+    const page = state.pages[0];
+    expect(JSON.stringify(page)).not.toContain('super-secret-value');
+    expect(page.filter?.query).toBeUndefined();
+    expect(Buffer.byteLength(page.content, 'utf8') + Buffer.byteLength(page.raw_markdown ?? '', 'utf8')).toBeLessThanOrEqual(48);
+    expect(page.truncated_fields).toEqual(expect.arrayContaining(['content', 'fit_markdown', 'raw_markdown']));
+
+    const cacheFiles = fs.readdirSync(cacheDir).filter((name) => name.endsWith('.json'));
+    expect(cacheFiles).toHaveLength(1);
+    const cached = fs.readFileSync(path.join(cacheDir, cacheFiles[0]), 'utf8');
+    expect(cached).not.toContain('super-secret-value');
+    const cachedEntry = JSON.parse(cached);
+    expect(cachedEntry.page.filter.query).toBeUndefined();
+    expect(Buffer.byteLength(cachedEntry.page.content, 'utf8') + Buffer.byteLength(cachedEntry.page.raw_markdown ?? '', 'utf8')).toBeLessThanOrEqual(48);
+
+    const jobLog = fs.readFileSync(jobFilePath(jobId), 'utf8');
+    expect(jobLog.split(query)).toHaveLength(2);
+  });
+
+  test('reports shared fetch truncation for canonical fit content', async () => {
+    mkTmpRoot();
+    process.env.OC_CRAWL_PAGE_BYTES = '100000';
+    server = await startFixtureServer([{ name: 'a' }]);
+    const jobId = await createJob(makeConfig({
+      url: server.url('a'),
+      max_pages: 1,
+      output_format: 'markdown-clean',
+      content_filter: 'prune',
+      return_fit: true,
+    }));
+    const cappedContent = `${'X'.repeat(MAX_OUTPUT_CHARS)}...[truncated]`;
+
+    const state = await advanceJob(jobId, 1, 's', undefined, {
+      fetcher: async (_sessionId, url, depth) => ({
+        url,
+        title: 'A',
+        content: cappedContent,
+        fit_markdown: `${'X'.repeat(MAX_OUTPUT_CHARS + 100)}`,
+        filter: {
+          type: 'prune',
+          raw_chars: MAX_OUTPUT_CHARS + 100,
+          fit_chars: MAX_OUTPUT_CHARS + 100,
+          reduction_ratio: 0,
+          sections_seen: 1,
+          sections_kept: 1,
+        },
+        depth,
+        links_found: 0,
+        _links: [],
+      }),
+    });
+
+    expect(state.pages[0]).toMatchObject({
+      content: cappedContent,
+      truncated: true,
+      truncated_fields: expect.arrayContaining(['content', 'fit_markdown']),
+    });
   });
 });

--- a/tests/core/crawl/tools.test.ts
+++ b/tests/core/crawl/tools.test.ts
@@ -21,7 +21,13 @@ import {
   _setAdvanceOptionsForTests,
 } from '../../../src/tools/crawl-status';
 import { registerCrawlCancelTool } from '../../../src/tools/crawl-cancel';
-import { jobFilePath, loadJob, type CrawledPage } from '../../../src/core/crawl/job-store';
+import {
+  appendEvent,
+  createJob,
+  jobFilePath,
+  loadJob,
+  type CrawledPage,
+} from '../../../src/core/crawl/job-store';
 import type {
   MCPToolDefinition,
   MCPResult,
@@ -116,6 +122,96 @@ describe('crawl_start', () => {
     const res = await crawlStart!('s', { url: 'file:///etc/passwd' });
     expect(res.isError).toBe(true);
   });
+
+  test('persists clean-markdown filter options for later advances', async () => {
+    mkTmpRoot();
+    server = await startFixtureServer([{ name: 'a' }]);
+    bootTools();
+
+    const body = parseResult(await crawlStart!('s', {
+      url: server.url('a'),
+      output_format: 'markdown-clean',
+      content_filter: 'prune',
+      query: 'enterprise pricing',
+      return_raw: true,
+      return_fit: false,
+    }));
+    const state = loadJob(body.jobId as string);
+    expect(state.config).toMatchObject({
+      output_format: 'markdown-clean',
+      content_filter: 'prune',
+      query: 'enterprise pricing',
+      return_raw: true,
+      return_fit: false,
+    });
+  });
+
+  test('rejects invalid filter and blank BM25 query before job creation', async () => {
+    const root = mkTmpRoot();
+    server = await startFixtureServer([{ name: 'a' }]);
+    bootTools();
+
+    const invalid = await crawlStart!('s', {
+      url: server.url('a'),
+      output_format: 'markdown-clean',
+      content_filter: 'unknown',
+    });
+    expect(invalid.isError).toBe(true);
+
+    const missingQuery = await crawlStart!('s', {
+      url: server.url('a'),
+      output_format: 'markdown-clean',
+      content_filter: 'bm25',
+      query: '   ',
+    });
+    expect(missingQuery.isError).toBe(true);
+    expect(fs.readdirSync(root).filter((name) => name.endsWith('.jsonl'))).toEqual([]);
+  });
+
+  test('ignores markdown projection options for non-clean output formats', async () => {
+    mkTmpRoot();
+    server = await startFixtureServer([{ name: 'a' }]);
+    bootTools();
+
+    const res = await crawlStart!('s', {
+      url: server.url('a'),
+      output_format: 'text',
+      content_filter: 'bm25',
+      query: '   ',
+      return_raw: true,
+      return_fit: true,
+    });
+    expect(res.isError).toBeUndefined();
+
+    const state = loadJob(parseResult(res).jobId as string);
+    expect(state.config.content_filter).toBeUndefined();
+    expect(state.config.query).toBeUndefined();
+    expect(state.config.return_raw).toBeUndefined();
+    expect(state.config.return_fit).toBeUndefined();
+  });
+
+  test('rejects unsafe and oversized clean-markdown queries before job creation', async () => {
+    const root = mkTmpRoot();
+    server = await startFixtureServer([{ name: 'a' }]);
+    bootTools();
+
+    const unsafe = await crawlStart!('s', {
+      url: server.url('a'),
+      output_format: 'markdown-clean',
+      content_filter: 'bm25',
+      query: 'token=super-secret-value',
+    });
+    const oversized = await crawlStart!('s', {
+      url: server.url('a'),
+      output_format: 'markdown-clean',
+      content_filter: 'bm25',
+      query: 'x'.repeat(2049),
+    });
+
+    expect(unsafe.isError).toBe(true);
+    expect(oversized.isError).toBe(true);
+    expect(fs.readdirSync(root).filter((name) => name.endsWith('.jsonl'))).toEqual([]);
+  });
 });
 
 describe('crawl_status', () => {
@@ -166,6 +262,33 @@ describe('crawl_status', () => {
     expect(body!.completed).toBe(5);
     expect((body!.pages as CrawledPage[]).length).toBe(5);
     expect(spy.calls.length).toBe(5);
+  });
+
+  test('keeps the legacy resumable page shape when projection options are omitted', async () => {
+    mkTmpRoot();
+    server = await startFixtureServer([{ name: 'a' }]);
+    bootTools();
+    const spy: SpyState = { calls: [] };
+    _setAdvanceOptionsForTests({ fetcher: makeSpyFetcher(spy) });
+
+    const start = parseResult(await crawlStart!('s', {
+      url: server.url('a'),
+      max_pages: 1,
+    }));
+    const body = parseResult(await crawlStatus!('s', {
+      jobId: start.jobId,
+      advance: 1,
+      includePages: true,
+    }));
+    const page = (body.pages as CrawledPage[])[0];
+
+    expect(Object.keys(page).sort()).toEqual([
+      'content',
+      'depth',
+      'links_found',
+      'title',
+      'url',
+    ]);
   });
 
   test('includePages caps at OC_CRAWL_STATUS_MAX_PAGES with pagesOmitted', async () => {
@@ -236,6 +359,135 @@ describe('crawl_status', () => {
     bootTools();
     const res = await crawlStatus!('s', { jobId: 'no-such-job', advance: 1 });
     expect(res.isError).toBe(true);
+  });
+
+  test('returns resumable raw/fit/filter parity without persisting duplicate fit content', async () => {
+    mkTmpRoot();
+    server = await startFixtureServer([{ name: 'a' }]);
+    bootTools();
+    const calls: Array<Record<string, unknown>> = [];
+    _setAdvanceOptionsForTests({
+      fetcher: async (_sessionId, url, depth, opts) => {
+        calls.push(opts as unknown as Record<string, unknown>);
+        return {
+          url,
+          title: 'A',
+          content: 'fit body',
+          raw_markdown: 'raw navigation\n\nfit body',
+          fit_markdown: 'fit body',
+          filter: {
+            type: 'prune',
+            raw_chars: 24,
+            fit_chars: 8,
+            reduction_ratio: 0.667,
+            sections_seen: 2,
+            sections_kept: 1,
+            query: 'enterprise pricing',
+          },
+          depth,
+          links_found: 0,
+          _links: [],
+        };
+      },
+    });
+
+    const start = parseResult(await crawlStart!('s', {
+      url: server.url('a'),
+      max_pages: 1,
+      output_format: 'markdown-clean',
+      content_filter: 'prune',
+      query: 'enterprise pricing',
+      return_raw: true,
+    }));
+    const body = parseResult(await crawlStatus!('s', {
+      jobId: start.jobId,
+      advance: 1,
+      includePages: true,
+    }));
+    const page = (body.pages as CrawledPage[])[0];
+
+    expect(calls).toEqual([
+      expect.objectContaining({
+        outputFormat: 'markdown-clean',
+        contentFilter: 'prune',
+        returnRaw: true,
+        returnFit: true,
+      }),
+    ]);
+    expect(page).toMatchObject({
+      content: 'fit body',
+      raw_markdown: 'raw navigation\n\nfit body',
+      fit_markdown: 'fit body',
+      filter: expect.objectContaining({
+        type: 'prune',
+        query: 'enterprise pricing',
+      }),
+    });
+
+    const stored = loadJob(start.jobId as string).pages[0];
+    expect(stored.raw_markdown).toBe('raw navigation\n\nfit body');
+    expect(stored.fit_markdown).toBeUndefined();
+    expect(stored.filter?.query).toBeUndefined();
+  });
+
+  test('does not reconstruct markdown aliases for legacy non-clean jobs', async () => {
+    mkTmpRoot();
+    server = await startFixtureServer([{ name: 'a' }]);
+    bootTools();
+    const url = server.url('a');
+    const jobId = await createJob({
+      url,
+      max_depth: 0,
+      max_pages: 1,
+      scope: `${new URL(url).origin}/**`,
+      output_format: 'text',
+      content_filter: 'prune',
+      query: 'ignored',
+      return_raw: true,
+      return_fit: true,
+      respect_robots: false,
+      delay_ms: 0,
+      concurrency: 1,
+    });
+    await appendEvent(jobId, {
+      kind: 'fetched',
+      url,
+      depth: 0,
+      page: {
+        url,
+        title: 'A',
+        content: 'plain text',
+        raw_markdown: 'raw markdown',
+        fit_markdown: 'fit markdown',
+        filter: {
+          type: 'prune',
+          raw_chars: 12,
+          fit_chars: 8,
+          reduction_ratio: 0.333,
+          sections_seen: 1,
+          sections_kept: 1,
+        },
+        depth: 0,
+        links_found: 0,
+        truncated_fields: ['content', 'raw_markdown', 'fit_markdown'],
+      },
+      t: Date.now(),
+    });
+
+    const body = parseResult(await crawlStatus!('s', {
+      jobId,
+      advance: 0,
+      includePages: true,
+    }));
+    const page = (body.pages as CrawledPage[])[0];
+
+    expect(page).toMatchObject({
+      content: 'plain text',
+      truncated_fields: ['content'],
+    });
+    expect(page.raw_markdown).toBeUndefined();
+    expect(page.fit_markdown).toBeUndefined();
+    expect(page.filter).toBeUndefined();
   });
 });
 

--- a/tests/helpers/http-fetcher.ts
+++ b/tests/helpers/http-fetcher.ts
@@ -9,6 +9,7 @@
 
 import * as http from 'node:http';
 import type { PageFetcher } from '../../src/core/crawl/runner';
+import type { FetchOnePageOptions } from '../../src/tools/crawl';
 
 interface FetchedHtml {
   title: string;
@@ -38,7 +39,7 @@ function parseHtml(html: string, baseUrl: string): FetchedHtml {
 }
 
 export interface SpyState {
-  calls: Array<{ url: string; depth: number }>;
+  calls: Array<{ url: string; depth: number; opts: FetchOnePageOptions }>;
   /** Optional hook to throw before the fetch resolves (process-death sim). */
   beforeReturn?: (url: string) => void;
   /** Optional artificial delay between fetches (ms). */
@@ -47,7 +48,7 @@ export interface SpyState {
 
 export function makeSpyFetcher(spy: SpyState): PageFetcher {
   return async (sessionId, url, depth, opts) => {
-    spy.calls.push({ url, depth });
+    spy.calls.push({ url, depth, opts: { ...opts } });
     const html = await new Promise<string>((resolve, reject) => {
       const req = http.get(url, (res) => {
         const chunks: Buffer[] = [];


### PR DESCRIPTION
## Summary

- carry `content_filter`, `query`, `return_raw`, and `return_fit` through `crawl_start -> crawl_status`
- preserve raw/fit/filter output parity while keeping the existing host-driven, no-background-work crawl model
- redact and aggregate-bound page projections before cache and JSONL persistence

## Direction

This adopts Firecrawl's transferable page-output contract, not its hosted infrastructure. OpenChrome remains host-neutral and real-Chrome based: `crawl_start` performs no network I/O, and each `crawl_status({ advance })` call owns a bounded unit of work.

No Firecrawl code was copied. This adds no hosted queue, background worker, webhook, proxy service, LLM call, provider credential, or dependency.

## Implementation

- extend resumable job config and page records with optional Markdown projection fields
- forward the effective clean-Markdown options through the shared `fetchOnePage` kernel
- persist distinct raw content only; reconstruct requested raw/fit aliases in `crawl_status`
- strip repeated `filter.query` from page/cache records and reconstruct it from the durable job header
- reject credential-shaped or over-2,048-character resumable queries before job creation
- keep projection options inert outside `output_format: "markdown-clean"`
- include projection dimensions and the effective `OC_CRAWL_PAGE_BYTES` value in cache identity
- disable public cache reads/writes when effective `return_raw` is enabled; session-scoped raw caching remains available
- surface `truncated_fields` for shared fetch limits and aggregate persistence limits
- retain old JSONL replay and the default resumable response shape

## Review decisions

Two independent adversarial passes found and closed additional boundary issues around pre-cache redaction, public raw-cache isolation, byte-cap cache identity, non-clean alias suppression, operational-pattern redaction, restart-safe BM25 queries, per-page query duplication, and shared-fetch truncation reporting.

A legacy cache-key fallback is intentionally rejected. Pre-change entries were produced before the new pre-cache redaction, projection identity, and aggregate byte-bound contract, so reusing them could serve incompatible or unsafe content. Existing files remain subject to normal cache pruning.

## Verification

- `70` focused crawl/content-filter tests passed
- `22` synchronous crawl compatibility tests passed, including byte-identical legacy snapshots
- `npm run build`
- `npm run lint -- --max-warnings=0`
- `npm run lint:tier`
- `npm run lint:tool-schemas`
- `npm run docs:capability-map:check`
- `git diff --check`

A prior full-suite run completed with `7,545` passing tests and one unrelated 10-second `computer` click timeout during the 36-minute run; that test passed independently in `372ms`.

Not tested: live real-site Chrome smoke.

Closes #1563
