### PR TITLE
feat(cli): validate playbooks against registered MCP schemas

### DIFF
--- a/cli/playbook/index.ts
+++ b/cli/playbook/index.ts
@@ -29,6 +29,18 @@ function collectVar(value: string, previous: string[]): string[] {
   return previous;
 }
 
+function writeStdout(output: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    process.stdout.write(output, (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
 export function registerPlaybookCommand(program: Command): void {
   const playbook = program
     .command('playbook')
@@ -147,7 +159,7 @@ export function registerPlaybookCommand(program: Command): void {
       const result = await validatePlaybook(parsed, {
         varMap,
       });
-      process.stdout.write(formatValidationResult(result, options.json));
+      await writeStdout(formatValidationResult(result, options.json));
       process.exit(validationExitCode(result));
     } catch (err) {
       if (err instanceof VarError) {

--- a/cli/playbook/index.ts
+++ b/cli/playbook/index.ts
@@ -1,8 +1,7 @@
 /**
  * Playbook subcommand registration.
  *
- * Registers `oc playbook run <file> [--vars k=v] [--out PATH] [--reuse] [--json]`
- * onto the given Commander program.
+ * Registers playbook run and validation commands onto the given Commander program.
  *
  * Exit codes:
  *   0 — all steps + all asserts pass
@@ -17,7 +16,18 @@ import { loadPlaybook, ParseError } from './parse';
 import { buildVarMap, parseCliVars, VarError } from './vars';
 import { runPlaybook } from './run';
 import { writeReport } from './report';
-import { TransportError } from './stdio-client';
+import { TransportError as PlaybookTransportError } from './stdio-client';
+import {
+  formatValidationResult,
+  validatePlaybook,
+  validationExitCode,
+} from './validate';
+import { ToolManifestError } from './tool-manifest-client';
+
+function collectVar(value: string, previous: string[]): string[] {
+  previous.push(value);
+  return previous;
+}
 
 export function registerPlaybookCommand(program: Command): void {
   const playbook = program
@@ -27,7 +37,7 @@ export function registerPlaybookCommand(program: Command): void {
   playbook
     .command('run <file>')
     .description('Execute a playbook file against the MCP server.')
-    .option('--vars <k=v...>', 'Variable overrides (repeatable). CLI values override the vars: block.', (val: string, acc: string[]) => { acc.push(val); return acc; }, [] as string[])
+    .option('--vars <k=v...>', 'Variable overrides (repeatable). CLI values override the vars: block.', collectVar, [] as string[])
     .option('--out <path>', 'Write a Markdown report to this file.')
     .option('--reuse', 'Connect to an existing openchrome serve daemon instead of spawning a new one.', false)
     .option('--json', 'Output the full run report as JSON on stdout.', false)
@@ -67,7 +77,7 @@ export function registerPlaybookCommand(program: Command): void {
           varMap,
         });
       } catch (err) {
-        if (err instanceof TransportError) {
+        if (err instanceof PlaybookTransportError) {
           console.error(`[playbook] Transport error: ${err.message}`);
           process.exit(3);
         }
@@ -89,4 +99,67 @@ export function registerPlaybookCommand(program: Command): void {
 
       process.exit(result.summary.ok ? 0 : 1);
     });
+
+  const validate = playbook
+    .command('validate <file>')
+    .description('Validate a playbook against the registered MCP tool schemas without executing tools.')
+    .option('--vars <k=v...>', 'Variable overrides (repeatable). CLI values override the vars: block.', collectVar, [] as string[])
+    .option('--reuse', 'Reserved for session-scoped daemon validation; not supported yet.', false)
+    .option('--json', 'Output structured validation diagnostics as JSON.', false);
+
+  validate.exitOverride((error) => {
+    process.exit(error.exitCode === 0 ? 0 : 2);
+  });
+
+  validate.action(async (file: string, options: { vars: string[]; reuse: boolean; json: boolean }) => {
+    const filePath = path.resolve(file);
+
+    let parsed;
+    try {
+      parsed = loadPlaybook(filePath);
+    } catch (err) {
+      if (err instanceof ParseError) {
+        const lineInfo = err.line !== undefined ? ` (line ${err.line})` : '';
+        console.error(`[playbook] Parse error${lineInfo}: ${err.message}`);
+      } else {
+        console.error(`[playbook] Failed to load playbook: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      process.exit(2);
+    }
+
+    let cliVars: Record<string, string>;
+    try {
+      cliVars = parseCliVars(options.vars);
+    } catch (err) {
+      console.error(`[playbook] --vars error: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(2);
+    }
+
+    const varMap = buildVarMap(parsed.vars, cliVars);
+    try {
+      if (options.reuse === true || program.opts<{ reuse?: boolean }>().reuse === true) {
+        console.error(
+          '[playbook] --reuse is not supported for schema validation yet; ' +
+          'validate against the registered local manifest instead.',
+        );
+        process.exit(2);
+      }
+      const result = await validatePlaybook(parsed, {
+        varMap,
+      });
+      process.stdout.write(formatValidationResult(result, options.json));
+      process.exit(validationExitCode(result));
+    } catch (err) {
+      if (err instanceof VarError) {
+        console.error(`[playbook] Variable error: ${err.message}`);
+        process.exit(2);
+      }
+      if (err instanceof ToolManifestError) {
+        console.error(`[playbook] Manifest error: ${err.message}`);
+        process.exit(3);
+      }
+      console.error(`[playbook] Unexpected error: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(3);
+    }
+  });
 }

--- a/cli/playbook/run.ts
+++ b/cli/playbook/run.ts
@@ -5,7 +5,7 @@
  * are marked 'skipped'. Returns a structured RunResult.
  */
 
-import type { Playbook, Step } from './parse';
+import type { Playbook, Step, Verb } from './parse';
 import { expandStep } from './expand';
 import { substituteValue } from './vars';
 import { StdioMcpClient, TransportError } from './stdio-client';
@@ -46,7 +46,7 @@ export interface RunOptions {
   client?: Pick<StdioMcpClient, 'connect' | 'callTool' | 'disconnect'>;
 }
 
-const VERBS_THAT_CAN_REUSE_CURRENT_TAB = new Set<string>([
+const VERBS_THAT_CAN_REUSE_CURRENT_TAB = new Set<Verb>([
   'interact',
   'act',
   'fill_form',
@@ -56,14 +56,14 @@ const VERBS_THAT_CAN_REUSE_CURRENT_TAB = new Set<string>([
   'javascript_tool',
 ]);
 
-function maybeInjectCurrentTab(
-  step: Step,
+export function injectCurrentTab(
+  verb: Verb,
   args: Record<string, unknown>,
   currentTabId: string | undefined,
 ): Record<string, unknown> {
   if (
     currentTabId &&
-    VERBS_THAT_CAN_REUSE_CURRENT_TAB.has(step.verb) &&
+    VERBS_THAT_CAN_REUSE_CURRENT_TAB.has(verb) &&
     typeof args.tabId !== 'string'
   ) {
     return { ...args, tabId: currentTabId };
@@ -116,7 +116,7 @@ export async function runPlaybook(playbook: Playbook, options: RunOptions): Prom
 
       // Substitute vars in args
       const substitutedArgs = substituteValue(step.args, options.varMap, i) as Record<string, unknown>;
-      const callArgs = maybeInjectCurrentTab(step, substitutedArgs, currentTabId);
+      const callArgs = injectCurrentTab(step.verb, substitutedArgs, currentTabId);
 
       // Expand to MCP tool call
       const expanded = expandStep(step.verb, callArgs);

--- a/cli/playbook/schema-validator.ts
+++ b/cli/playbook/schema-validator.ts
@@ -1,0 +1,345 @@
+import { isDeepStrictEqual } from 'util';
+
+export type SchemaSeverity = 'error' | 'warning';
+
+export interface SchemaDiagnostic {
+  severity: SchemaSeverity;
+  code: string;
+  instancePath: string;
+  schemaPath: string;
+  message: string;
+}
+
+export type JsonSchema = boolean | Record<string, unknown>;
+
+const JSON_SCHEMA_TYPES = new Set([
+  'array',
+  'boolean',
+  'integer',
+  'null',
+  'number',
+  'object',
+  'string',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isSchema(value: unknown): value is JsonSchema {
+  return typeof value === 'boolean' || isRecord(value);
+}
+
+function appendPointer(base: string, token: string | number): string {
+  const escaped = String(token).replace(/~/g, '~0').replace(/\//g, '~1');
+  return `${base}/${escaped}`;
+}
+
+function diagnostic(
+  severity: SchemaSeverity,
+  code: string,
+  instancePath: string,
+  schemaPath: string,
+  message: string,
+): SchemaDiagnostic {
+  return { severity, code, instancePath, schemaPath, message };
+}
+
+function hasErrors(diagnostics: SchemaDiagnostic[]): boolean {
+  return diagnostics.some((entry) => entry.severity === 'error');
+}
+
+function schemaBranches(value: unknown): JsonSchema[] | undefined {
+  if (!Array.isArray(value) || !value.every(isSchema)) return undefined;
+  return value;
+}
+
+function matchesType(value: unknown, type: string): boolean {
+  switch (type) {
+    case 'array':
+      return Array.isArray(value);
+    case 'boolean':
+      return typeof value === 'boolean';
+    case 'integer':
+      return typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value);
+    case 'null':
+      return value === null;
+    case 'number':
+      return typeof value === 'number' && Number.isFinite(value);
+    case 'object':
+      return isRecord(value);
+    case 'string':
+      return typeof value === 'string';
+    default:
+      return false;
+  }
+}
+
+function validateNode(
+  value: unknown,
+  schema: JsonSchema,
+  instancePath: string,
+  schemaPath: string,
+): SchemaDiagnostic[] {
+  if (schema === true) return [];
+  if (schema === false) {
+    return [diagnostic(
+      'error',
+      'schema.false',
+      instancePath,
+      schemaPath,
+      'Value is rejected by the registered schema.',
+    )];
+  }
+
+  const diagnostics: SchemaDiagnostic[] = [];
+
+  const oneOf = schemaBranches(schema.oneOf);
+  if (oneOf) {
+    const branchResults = oneOf.map((branch, index) => validateNode(
+      value,
+      branch,
+      instancePath,
+      appendPointer(appendPointer(schemaPath, 'oneOf'), index),
+    ));
+    const passing = branchResults.filter((result) => !hasErrors(result));
+    if (passing.length !== 1) {
+      diagnostics.push(diagnostic(
+        'error',
+        'schema.one_of',
+        instancePath,
+        appendPointer(schemaPath, 'oneOf'),
+        'Value must match exactly one registered schema branch.',
+      ));
+    } else {
+      diagnostics.push(...passing[0].filter((entry) => entry.severity === 'warning'));
+    }
+  }
+
+  const anyOf = schemaBranches(schema.anyOf);
+  if (anyOf) {
+    const branchResults = anyOf.map((branch, index) => validateNode(
+      value,
+      branch,
+      instancePath,
+      appendPointer(appendPointer(schemaPath, 'anyOf'), index),
+    ));
+    const passing = branchResults.find((result) => !hasErrors(result));
+    if (!passing) {
+      diagnostics.push(diagnostic(
+        'error',
+        'schema.any_of',
+        instancePath,
+        appendPointer(schemaPath, 'anyOf'),
+        'Value must match at least one registered schema branch.',
+      ));
+    } else {
+      diagnostics.push(...passing.filter((entry) => entry.severity === 'warning'));
+    }
+  }
+
+  const allOf = schemaBranches(schema.allOf);
+  if (allOf) {
+    for (let index = 0; index < allOf.length; index++) {
+      diagnostics.push(...validateNode(
+        value,
+        allOf[index],
+        instancePath,
+        appendPointer(appendPointer(schemaPath, 'allOf'), index),
+      ));
+    }
+  }
+
+  const declaredTypes = typeof schema.type === 'string'
+    ? [schema.type]
+    : Array.isArray(schema.type)
+      ? schema.type.filter((entry): entry is string => typeof entry === 'string')
+      : [];
+  const supportedTypes = declaredTypes.filter((type) => JSON_SCHEMA_TYPES.has(type));
+  if (declaredTypes.length > 0 && !supportedTypes.some((type) => matchesType(value, type))) {
+    diagnostics.push(diagnostic(
+      'error',
+      'schema.type',
+      instancePath,
+      appendPointer(schemaPath, 'type'),
+      'Value has the wrong type for the registered schema.',
+    ));
+    return diagnostics;
+  }
+
+  if (Array.isArray(schema.enum) && !schema.enum.some((candidate) => isDeepStrictEqual(candidate, value))) {
+    diagnostics.push(diagnostic(
+      'error',
+      'schema.enum',
+      instancePath,
+      appendPointer(schemaPath, 'enum'),
+      'Value is not one of the allowed registered schema choices.',
+    ));
+  }
+
+  if (Object.prototype.hasOwnProperty.call(schema, 'const') && !isDeepStrictEqual(schema.const, value)) {
+    diagnostics.push(diagnostic(
+      'error',
+      'schema.const',
+      instancePath,
+      appendPointer(schemaPath, 'const'),
+      'Value does not match the registered schema constant.',
+    ));
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    if (typeof schema.minimum === 'number' && value < schema.minimum) {
+      diagnostics.push(diagnostic(
+        'error',
+        'schema.minimum',
+        instancePath,
+        appendPointer(schemaPath, 'minimum'),
+        'Number is below the registered schema minimum.',
+      ));
+    }
+    if (typeof schema.maximum === 'number' && value > schema.maximum) {
+      diagnostics.push(diagnostic(
+        'error',
+        'schema.maximum',
+        instancePath,
+        appendPointer(schemaPath, 'maximum'),
+        'Number exceeds the registered schema maximum.',
+      ));
+    }
+  }
+
+  if (typeof value === 'string') {
+    const length = [...value].length;
+    if (typeof schema.minLength === 'number' && length < schema.minLength) {
+      diagnostics.push(diagnostic(
+        'error',
+        'schema.min_length',
+        instancePath,
+        appendPointer(schemaPath, 'minLength'),
+        'String is shorter than the registered schema minimum length.',
+      ));
+    }
+    if (typeof schema.maxLength === 'number' && length > schema.maxLength) {
+      diagnostics.push(diagnostic(
+        'error',
+        'schema.max_length',
+        instancePath,
+        appendPointer(schemaPath, 'maxLength'),
+        'String exceeds the registered schema maximum length.',
+      ));
+    }
+    if (typeof schema.pattern === 'string') {
+      try {
+        if (!new RegExp(schema.pattern).test(value)) {
+          diagnostics.push(diagnostic(
+            'error',
+            'schema.pattern',
+            instancePath,
+            appendPointer(schemaPath, 'pattern'),
+            'String does not match the registered schema pattern.',
+          ));
+        }
+      } catch {
+        // Invalid schema patterns are outside playbook validation scope.
+      }
+    }
+  }
+
+  if (Array.isArray(value)) {
+    if (typeof schema.minItems === 'number' && value.length < schema.minItems) {
+      diagnostics.push(diagnostic(
+        'error',
+        'schema.min_items',
+        instancePath,
+        appendPointer(schemaPath, 'minItems'),
+        'Array has fewer items than the registered schema minimum.',
+      ));
+    }
+    if (typeof schema.maxItems === 'number' && value.length > schema.maxItems) {
+      diagnostics.push(diagnostic(
+        'error',
+        'schema.max_items',
+        instancePath,
+        appendPointer(schemaPath, 'maxItems'),
+        'Array has more items than the registered schema maximum.',
+      ));
+    }
+    if (isSchema(schema.items)) {
+      for (let index = 0; index < value.length; index++) {
+        diagnostics.push(...validateNode(
+          value[index],
+          schema.items,
+          appendPointer(instancePath, index),
+          appendPointer(schemaPath, 'items'),
+        ));
+      }
+    }
+  }
+
+  if (isRecord(value)) {
+    const properties = isRecord(schema.properties) ? schema.properties : {};
+    const required = Array.isArray(schema.required)
+      ? schema.required.filter((entry): entry is string => typeof entry === 'string')
+      : [];
+
+    for (const key of required) {
+      if (!Object.prototype.hasOwnProperty.call(value, key)) {
+        diagnostics.push(diagnostic(
+          'error',
+          'schema.required',
+          appendPointer(instancePath, key),
+          appendPointer(schemaPath, 'required'),
+          'Required property is missing from the expanded tool arguments.',
+        ));
+      }
+    }
+
+    for (const [key, propertySchema] of Object.entries(properties)) {
+      if (Object.prototype.hasOwnProperty.call(value, key) && isSchema(propertySchema)) {
+        diagnostics.push(...validateNode(
+          value[key],
+          propertySchema,
+          appendPointer(instancePath, key),
+          appendPointer(appendPointer(schemaPath, 'properties'), key),
+        ));
+      }
+    }
+
+    const extraKeys = Object.keys(value)
+      .filter((key) => !Object.prototype.hasOwnProperty.call(properties, key))
+      .sort();
+    for (const key of extraKeys) {
+      const additional = schema.additionalProperties;
+      if (additional === false) {
+        diagnostics.push(diagnostic(
+          'error',
+          'schema.additional_property',
+          appendPointer(instancePath, key),
+          appendPointer(schemaPath, 'additionalProperties'),
+          'Property is not allowed by the registered schema.',
+        ));
+      } else if (isSchema(additional) && additional !== true) {
+        diagnostics.push(...validateNode(
+          value[key],
+          additional,
+          appendPointer(instancePath, key),
+          appendPointer(schemaPath, 'additionalProperties'),
+        ));
+      } else {
+        diagnostics.push(diagnostic(
+          'warning',
+          'schema.additional_property_open',
+          appendPointer(instancePath, key),
+          appendPointer(schemaPath, 'additionalProperties'),
+          'Property is not declared by the registered schema, which allows additional properties.',
+        ));
+      }
+    }
+  }
+
+  return diagnostics;
+}
+
+export function validateValueAgainstSchema(value: unknown, schema: JsonSchema): SchemaDiagnostic[] {
+  return validateNode(value, schema, '', '');
+}

--- a/cli/playbook/tool-manifest-client.ts
+++ b/cli/playbook/tool-manifest-client.ts
@@ -1,0 +1,88 @@
+import { execFile } from 'child_process';
+import * as path from 'path';
+
+const MANIFEST_TIMEOUT_MS = 30_000;
+const MANIFEST_MAX_BUFFER = 8 * 1024 * 1024;
+
+export class ToolManifestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ToolManifestError';
+  }
+}
+
+export interface McpToolDefinition {
+  name: string;
+  inputSchema?: unknown;
+  [key: string]: unknown;
+}
+
+export interface ToolDefinitionSource {
+  listToolDefinitions(): Promise<McpToolDefinition[]>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function parseRegisteredToolManifest(output: string): McpToolDefinition[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output);
+  } catch (err) {
+    throw new ToolManifestError(
+      `Registered tool manifest is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new ToolManifestError('Registered tool manifest must be a JSON array.');
+  }
+
+  return parsed.map((entry, index) => {
+    if (!isRecord(entry) || typeof entry.name !== 'string' || entry.name.length === 0) {
+      throw new ToolManifestError(`Registered tool manifest entry ${index} is malformed.`);
+    }
+    return entry as McpToolDefinition;
+  });
+}
+
+function stderrTail(stderr: string): string {
+  return stderr.trim().split('\n').slice(-8).join('\n');
+}
+
+export class RegisteredToolManifestClient implements ToolDefinitionSource {
+  async listToolDefinitions(): Promise<McpToolDefinition[]> {
+    const serveEntry = path.join(__dirname, '..', '..', 'index.js');
+    return new Promise<McpToolDefinition[]>((resolve, reject) => {
+      execFile(
+        process.execPath,
+        [serveEntry, 'serve', '--introspect-tools-list'],
+        {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            OPENCHROME_PPID_WATCH: '0',
+            OPENCHROME_UPDATE_CHECK: '0',
+          },
+          maxBuffer: MANIFEST_MAX_BUFFER,
+          timeout: MANIFEST_TIMEOUT_MS,
+        },
+        (error, stdout, stderr) => {
+          if (error) {
+            const details = stderrTail(stderr);
+            reject(new ToolManifestError(
+              `Failed to read the registered tool manifest: ${error.message}${details ? `\n${details}` : ''}`,
+            ));
+            return;
+          }
+          try {
+            resolve(parseRegisteredToolManifest(stdout));
+          } catch (err) {
+            reject(err);
+          }
+        },
+      );
+    });
+  }
+}

--- a/cli/playbook/validate.ts
+++ b/cli/playbook/validate.ts
@@ -1,0 +1,183 @@
+import { expandStep } from './expand';
+import type { Playbook, Verb } from './parse';
+import { injectCurrentTab } from './run';
+import {
+  validateValueAgainstSchema,
+  type JsonSchema,
+  type SchemaSeverity,
+} from './schema-validator';
+import {
+  RegisteredToolManifestClient,
+  type McpToolDefinition,
+  type ToolDefinitionSource,
+} from './tool-manifest-client';
+import { substituteValue } from './vars';
+
+const VALIDATION_TAB_ID = '__openchrome_playbook_validation_tab__';
+
+export interface ValidationDiagnostic {
+  stepIndex: number;
+  id?: string;
+  verb: Verb;
+  tool: string;
+  severity: SchemaSeverity;
+  code: string;
+  instancePath: string;
+  schemaPath: string;
+  message: string;
+}
+
+export interface ValidationSummary {
+  ok: boolean;
+  total: number;
+  errors: number;
+  warnings: number;
+}
+
+export interface ValidationResult {
+  name: string | undefined;
+  diagnostics: ValidationDiagnostic[];
+  summary: ValidationSummary;
+}
+
+export interface ValidateOptions {
+  varMap: Record<string, string>;
+  source?: ToolDefinitionSource;
+}
+
+interface PreparedStep {
+  index: number;
+  id?: string;
+  verb: Verb;
+  tool: string;
+  callArgs: Record<string, unknown>;
+}
+
+function isSchema(value: unknown): value is JsonSchema {
+  return typeof value === 'boolean' || (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value)
+  );
+}
+
+function prepareSteps(playbook: Playbook, varMap: Record<string, string>): PreparedStep[] {
+  let currentTabId: string | undefined;
+  return playbook.steps.map((step, index) => {
+    const substitutedArgs = substituteValue(step.args, varMap, index) as Record<string, unknown>;
+    const callArgs = injectCurrentTab(step.verb, substitutedArgs, currentTabId);
+    const expanded = expandStep(step.verb, callArgs);
+    if (step.verb === 'navigate') {
+      currentTabId = VALIDATION_TAB_ID;
+    }
+    return {
+      index,
+      ...(step.id !== undefined ? { id: step.id } : {}),
+      verb: step.verb,
+      tool: expanded.tool,
+      callArgs: expanded.callArgs,
+    };
+  });
+}
+
+function missingToolDiagnostic(step: PreparedStep): ValidationDiagnostic {
+  return {
+    stepIndex: step.index,
+    ...(step.id !== undefined ? { id: step.id } : {}),
+    verb: step.verb,
+    tool: step.tool,
+    severity: 'error',
+    code: 'tool.missing',
+    instancePath: '',
+    schemaPath: '',
+    message: 'Expanded tool is not present in the registered MCP tool manifest.',
+  };
+}
+
+function missingSchemaDiagnostic(step: PreparedStep): ValidationDiagnostic {
+  return {
+    stepIndex: step.index,
+    ...(step.id !== undefined ? { id: step.id } : {}),
+    verb: step.verb,
+    tool: step.tool,
+    severity: 'error',
+    code: 'tool.schema_missing',
+    instancePath: '',
+    schemaPath: '',
+    message: 'Registered MCP tool definition does not expose an input schema.',
+  };
+}
+
+function indexDefinitions(definitions: McpToolDefinition[]): Map<string, McpToolDefinition> {
+  return new Map(definitions.map((definition) => [definition.name, definition]));
+}
+
+export async function validatePlaybook(
+  playbook: Playbook,
+  options: ValidateOptions,
+): Promise<ValidationResult> {
+  // Variable substitution intentionally finishes before manifest discovery.
+  const preparedSteps = prepareSteps(playbook, options.varMap);
+  const source = options.source ?? new RegisteredToolManifestClient();
+  const definitions = await source.listToolDefinitions();
+
+  const definitionsByName = indexDefinitions(definitions);
+  const diagnostics: ValidationDiagnostic[] = [];
+
+  for (const step of preparedSteps) {
+    const definition = definitionsByName.get(step.tool);
+    if (!definition) {
+      diagnostics.push(missingToolDiagnostic(step));
+      continue;
+    }
+    if (!isSchema(definition.inputSchema)) {
+      diagnostics.push(missingSchemaDiagnostic(step));
+      continue;
+    }
+
+    diagnostics.push(...validateValueAgainstSchema(step.callArgs, definition.inputSchema).map((entry) => ({
+      stepIndex: step.index,
+      ...(step.id !== undefined ? { id: step.id } : {}),
+      verb: step.verb,
+      tool: step.tool,
+      ...entry,
+    })));
+  }
+
+  const errors = diagnostics.filter((entry) => entry.severity === 'error').length;
+  const warnings = diagnostics.length - errors;
+  return {
+    name: playbook.name,
+    diagnostics,
+    summary: {
+      ok: errors === 0,
+      total: playbook.steps.length,
+      errors,
+      warnings,
+    },
+  };
+}
+
+export function validationExitCode(result: ValidationResult): 0 | 1 {
+  return result.summary.ok ? 0 : 1;
+}
+
+export function formatValidationResult(result: ValidationResult, json: boolean): string {
+  if (json) return `${JSON.stringify(result, null, 2)}\n`;
+
+  const status = result.summary.ok ? 'SCHEMA OK' : 'SCHEMA ERRORS';
+  const name = result.name ?? '(unnamed playbook)';
+  const lines = [
+    `[playbook] ${status} ${name}: ${result.summary.total} steps, ` +
+      `${result.summary.errors} errors, ${result.summary.warnings} warnings`,
+  ];
+  for (const entry of result.diagnostics) {
+    const location = entry.instancePath || '/';
+    const id = entry.id === undefined ? '' : ` [${entry.id}]`;
+    lines.push(
+      `[playbook] ${entry.severity.toUpperCase()} step ${entry.stepIndex}${id} ` +
+        `(${entry.verb} -> ${entry.tool}) ${location} ${entry.code}: ${entry.message}`,
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}

--- a/docs/cli/playbook.md
+++ b/docs/cli/playbook.md
@@ -1,6 +1,6 @@
 # oc playbook — Declarative YAML Scenario Runner
 
-`oc playbook run` executes a declarative YAML (or JSON) scenario file against the OpenChrome MCP server. Each step maps to exactly one MCP tool call; the runner is a thin client, not a new orchestration tier.
+`oc playbook run` executes a declarative YAML (or JSON) scenario file against the OpenChrome MCP server. `oc playbook validate` checks the same expanded calls against the current package's registered MCP tool schemas without executing browser actions or starting Chrome. The playbook layer remains a thin client, not a new orchestration tier.
 
 Inspired by [Midscene's YAML scripting](https://midscenejs.com/). Unlike Midscene, OpenChrome's substrate is deterministic, so each step carries an inline **Outcome Contract** assertion instead of an LLM judgement.
 
@@ -11,6 +11,9 @@ Inspired by [Midscene's YAML scripting](https://midscenejs.com/). Unlike Midscen
 ```bash
 # One-shot run (spawns a dedicated server child, then terminates it)
 oc playbook run tests/fixtures/playbook/sanity.yaml
+
+# Preflight against the registered MCP tool manifest; no Chrome/CDP startup
+oc playbook validate tests/fixtures/playbook/sanity.yaml
 
 # Reuse a running daemon
 oc playbook run sanity.yaml --reuse --json | jq '.summary'
@@ -59,9 +62,9 @@ steps:
       selector: h1
       pattern: ${heading}
   - interact:
-      ref: "More information…"
+      query: "More information…"
   - wait_for:
-      condition: "navigation"
+      type: "navigation"
   - assert:
       kind: url
       pattern: "iana\\.org"
@@ -72,14 +75,14 @@ steps:
   - javascript_tool:
       code: "document.title"
   - act:
-      action: "scroll down"
+      instruction: "scroll down"
 ```
 
 ## Stable step IDs
 
 Each step may include an optional author-supplied `id` alongside exactly one
-verb. IDs make reports and failure diagnostics stable when earlier steps are
-inserted or reordered.
+verb. IDs make reports and run/validation diagnostics stable when earlier steps
+are inserted or reordered.
 
 Rules:
 
@@ -102,12 +105,12 @@ the Markdown `ID` column appears only when at least one result carries an ID.
 | Verb | MCP tool | Key args | Notes |
 |------|----------|----------|-------|
 | `navigate` | `navigate` | `url` | Navigates the active tab |
-| `interact` | `interact` | `ref` | Clicks/activates an element by accessibility label |
-| `act` | `act` | `action` | Free-form action string (e.g. `"scroll down"`) |
+| `interact` | `interact` | `query` | Clicks/activates an element by human-readable target; use `ref` only for a snapshot ref ID |
+| `act` | `act` | `instruction` | Free-form action instruction (e.g. `"scroll down"`) |
 | `fill_form` | `fill_form` | `fields` | Fills multiple form fields at once |
-| `wait_for` | `wait_for` | `condition` | Waits for a condition (e.g. `"navigation"`, `"networkidle"`) |
+| `wait_for` | `wait_for` | `type`, `value` | Waits for a supported condition such as `navigation`, `selector`, `function`, or `url_match` |
 | `page_screenshot` | `page_screenshot` | `path` | Captures a screenshot to disk |
-| `read_page` | `read_page` | `mode` | Reads page content (`"ax"` for accessibility tree, `"html"` for raw HTML) |
+| `read_page` | `read_page` | `mode` | Reads page content (`"ax"`, `"dom"`, `"css"`, `"semantic"`, or `"markdown"`) |
 | `javascript_tool` | `javascript_tool` | `code` | Evaluates JavaScript in the page context and returns the result |
 | `assert` | `oc_assert` | `kind`, `pattern`, … | Inline Outcome Contract assertion; see [Assertions](#assertions) |
 
@@ -222,6 +225,23 @@ A `--continue-on-error` flag (to collect all failures before stopping) is tracke
 
 ---
 
+## Registered schema validation
+
+`oc playbook validate <file>` parses variables and expands all steps exactly like the runner, then invokes the existing registration-only `serve --introspect-tools-list` path once and validates the expanded arguments against each registered tool's `inputSchema`. It does not open an MCP session, issue `tools/call`, start Chrome, connect CDP, initialize runtime journals, write `.openchrome` state, or execute playbook actions.
+
+```bash
+oc playbook validate sanity.yaml
+oc playbook validate sanity.yaml --vars url=https://iana.org --json
+```
+
+Validation reports missing tools, required properties, wrong types, enum/combinator failures, object and array constraints, and open-schema warnings. Diagnostics include step indexes, optional stable IDs, paths, and schema locations, but never include substituted argument values. Warnings do not fail validation.
+
+This command proves **registered-schema conformance**, not that every tool call will succeed at runtime. Conditional rules implemented only by a tool handler, browser state, selector availability, authentication, or page content can still fail during `playbook run`.
+
+Validation exit codes are `0` for no schema errors, `1` for schema or missing-tool errors, `2` for usage/parse/variable errors, and `3` for manifest discovery or parsing failures.
+
+---
+
 ## Exit codes
 
 | Code | Meaning |
@@ -244,7 +264,16 @@ Options:
   --reuse        Connect to an existing `openchrome serve` daemon instead of
                  spawning a new one-shot server.
   --json         Print the full RunResult as JSON on stdout (see schema below).
+
+oc playbook validate <file> [options]
+
+Options:
+  --vars <k=v>   Variable override (repeatable). CLI values override the vars: block.
+  --reuse        Reserved for session-scoped daemon validation; exits with code 2.
+  --json         Print structured schema diagnostics as JSON on stdout.
 ```
+
+`validate` does not accept `--out` because validation produces diagnostics rather than a run report. Passing the global `--reuse` flag to validation exits with code `2`: daemon-aware validation is deferred until the session-scoped tool-disclosure contract is available on the release branch. Using the registered local manifest avoids mutating a shared daemon's tool visibility.
 
 ### JSON output schema (`--json`)
 
@@ -297,13 +326,15 @@ Dispatch is based on file extension (`.yaml`/`.yml` → YAML parser; `.json` →
 
 Without `--reuse`, the runner spawns its own `openchrome serve --server-mode` child process for the duration of the playbook and terminates it on completion.
 
-With `--reuse`, the runner connects to an existing daemon. The daemon socket path from issue #843 (`oc run`) will be wired here when that PR lands. Until then, `--reuse` falls through to one-shot spawn with a stderr warning.
+For `oc playbook run`, `--reuse` currently falls through to one-shot spawn with a stderr warning until the legacy runner transport is replaced.
+
+`oc playbook validate` intentionally does not reuse a daemon in this release. It reads the local registered manifest through the no-Chrome introspection path.
 
 ---
 
 ## Security caveats
 
-- **`${SECRET:NAME}` masking**: Until issue #834 (secrets layer) merges, secret values are passed through in plaintext. Under `--json` output, secret values will appear unmasked in the `args` field of each step.
+- **Run-report secret exposure**: Until issue #834 (secrets layer) merges, secret values are passed through in plaintext. `oc playbook run --json` includes those values unmasked in each step's `args` field. `oc playbook validate`, including `--json`, omits substituted argument values from diagnostics.
 - **Playbook files in version control**: Treat playbook files like code. Do not embed credentials in the `vars:` block; use `${SECRET:NAME}` references or supply values at runtime via `--vars`.
 - **Untrusted playbooks**: `javascript_tool` steps execute arbitrary JavaScript in the browser context. Only run playbook files from trusted sources.
 - **Scope**: The playbook runner is a client of the MCP server. It does not gain capabilities beyond what `openchrome serve` exposes.
@@ -318,3 +349,4 @@ With `--reuse`, the runner connects to an existing daemon. The daemon socket pat
 - Recording a playbook from a live session
 - Built-in Jest integration
 - Web UI for editing playbooks
+- Validation against a running daemon's session-scoped tool manifest

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,8 +145,8 @@ program
     if (options.introspectToolsList) {
       const { MCPServer } = await import('./mcp-server');
       const { registerAllTools } = await import('./tools');
-      const server = new MCPServer(undefined, { initialToolTier: 3 });
-      registerAllTools(server);
+      const server = new MCPServer(undefined, { initialToolTier: 3, manifestOnly: true });
+      registerAllTools(server, { runtimeSideEffects: false });
       const manifest = server.getToolManifest();
       const output = JSON.stringify(manifest.tools) + '\n';
       for (let offset = 0; offset < output.length; offset += 16_384) {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -414,6 +414,11 @@ export interface MCPServerOptions {
   dashboardRefreshInterval?: number;
   initialToolTier?: ToolTier;
   /**
+   * Registration-only mode for manifest introspection. Skips session wiring,
+   * resources, runtime telemetry, journals, and other persistent state.
+   */
+  manifestOnly?: boolean;
+  /**
    * Capability filter derived from --tools-only / --disable-tools CLI flags.
    * When set, only tools whose `capability` is in this set are exposed.
    * When undefined, all capabilities are exposed (default, P2-compliant).
@@ -520,7 +525,9 @@ export class MCPServer {
   private clientCapabilitiesBySession: Map<string, { roots?: object; sampling?: object; elicitation?: object }> = new Map();
 
   constructor(sessionManager?: SessionManager, options: MCPServerOptions = {}) {
-    this.sessionManager = sessionManager || getSessionManager();
+    this.sessionManager = sessionManager || (
+      options.manifestOnly ? {} as SessionManager : getSessionManager()
+    );
     this.options = options;
 
     if (options.initialToolTier) {
@@ -529,6 +536,10 @@ export class MCPServer {
 
     if (options.capabilityFilter) {
       this.capabilityFilter = options.capabilityFilter;
+    }
+
+    if (options.manifestOnly) {
+      return;
     }
 
     // Release the tenant binding as soon as the underlying session is

--- a/src/tools/fill-form.ts
+++ b/src/tools/fill-form.ts
@@ -841,9 +841,8 @@ const handler: ToolHandler = async (sessionId, args, context): Promise<MCPResult
 
 export function registerFillFormTool(server: MCPServer): void {
   // Snapshot-cache (#879): bump docEpoch after every successful fill.
-  const sm = getSessionManager();
   const wrapped = wrapMutatingHandler(handler, (sid, tid) =>
-    tid ? sm.getPage(sid, tid, undefined, 'fill_form') : Promise.resolve(null),
+    tid ? getSessionManager().getPage(sid, tid, undefined, 'fill_form') : Promise.resolve(null),
   );
   server.registerTool('fill_form', wrapped, definition);
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -382,7 +382,16 @@ function makeCapabilityInjectingProxy(server: MCPServer): MCPServer {
 }
 
 
-export function registerAllTools(server: MCPServer): void {
+export interface RegisterAllToolsOptions {
+  /** Skip startup timers, persistence cleanup, and session listeners. */
+  runtimeSideEffects?: boolean;
+}
+
+export function registerAllTools(
+  server: MCPServer,
+  options: RegisterAllToolsOptions = {},
+): void {
+  const runtimeSideEffects = options.runtimeSideEffects !== false;
   // Wrap the real server so every registerTool() call gets a capability tag.
   const proxy = makeCapabilityInjectingProxy(server);
 
@@ -550,13 +559,15 @@ export function registerAllTools(server: MCPServer): void {
 
   // P2 fix (#887): purge expired output handles every 5 minutes.
   // `.unref()` ensures the interval does not prevent clean process exit.
-  const _outputPurgeTimer = setInterval(() => {
-    const removed = getHandleStore().purgeExpired();
-    if (removed > 0) {
-      console.error(`[output-handles] Purged ${removed} expired handle(s)`);
-    }
-  }, 5 * 60 * 1000);
-  _outputPurgeTimer.unref();
+  if (runtimeSideEffects) {
+    const outputPurgeTimer = setInterval(() => {
+      const removed = getHandleStore().purgeExpired();
+      if (removed > 0) {
+        console.error(`[output-handles] Purged ${removed} expired handle(s)`);
+      }
+    }, 5 * 60 * 1000);
+    outputPurgeTimer.unref();
+  }
 
   // Async task ledger (#855) — persistent background task table
   registerOcTaskStartTool(server);
@@ -572,15 +583,17 @@ export function registerAllTools(server: MCPServer): void {
   // once at server start (issue #855 invariant #2) so a crash on a
   // previous boot transitions orphaned rows to FAILED before new
   // tasks are accepted. Best-effort: log and continue on failure.
-  setTaskStartupReapPromise(
-    getTaskStore()
-      .reapOrphans()
-      .then((reaped) => {
-        if (reaped.length > 0) {
-          console.error(`[task-ledger] Reaped ${reaped.length} orphaned task(s) at startup`);
-        }
-      }),
-  );
+  if (runtimeSideEffects) {
+    setTaskStartupReapPromise(
+      getTaskStore()
+        .reapOrphans()
+        .then((reaped) => {
+          if (reaped.length > 0) {
+            console.error(`[task-ledger] Reaped ${reaped.length} orphaned task(s) at startup`);
+          }
+        }),
+    );
+  }
 
   // Doctor report tool (#898) — read cached `openchrome doctor` output
   registerOcDoctorReportTool(proxy);
@@ -591,21 +604,23 @@ export function registerAllTools(server: MCPServer): void {
   if (process.env.OPENCHROME_PERF_INSIGHTS !== '0') {
     registerOcPerformanceInsightsTool(proxy);
     registerOcPerformanceAnalyzeTool(proxy);
-    // Wire session-scoped trace eviction once. The store keeps an
-    // in-memory map of session_id -> trace_ids; on session deletion we
-    // delete every trace file owned by that session.
-    const sm = getSessionManager();
-    const store = getPerfTraceStore();
-    sm.addEventListener((event) => {
-      if (event.type === 'session:deleted' && event.sessionId) {
-        const removed = store.evictSession(event.sessionId);
-        if (removed > 0) {
-          console.error(
-            `[PerfInsights] Evicted ${removed} trace handle(s) for session ${event.sessionId}`,
-          );
+    if (runtimeSideEffects) {
+      // Wire session-scoped trace eviction once. The store keeps an
+      // in-memory map of session_id -> trace_ids; on session deletion we
+      // delete every trace file owned by that session.
+      const sm = getSessionManager();
+      const store = getPerfTraceStore();
+      sm.addEventListener((event) => {
+        if (event.type === 'session:deleted' && event.sessionId) {
+          const removed = store.evictSession(event.sessionId);
+          if (removed > 0) {
+            console.error(
+              `[PerfInsights] Evicted ${removed} trace handle(s) for session ${event.sessionId}`,
+            );
+          }
         }
-      }
-    });
+      });
+    }
   }
   // Pilot-tier: user-supplied proxy hook (#874). Loaded lazily so v1.11
   // behaviour is byte-identical when the family is off — no code from

--- a/src/tools/javascript.ts
+++ b/src/tools/javascript.ts
@@ -450,9 +450,8 @@ export function registerJavascriptTool(server: MCPServer): void {
   // statically know whether the eval mutated the DOM, so we bump
   // docEpoch unconditionally on a successful eval. A subsequent
   // `read_page` therefore always recomputes.
-  const sm = getSessionManager();
   const wrapped = wrapMutatingHandler(handler, (sid, tid) =>
-    tid ? sm.getPage(sid, tid, undefined, 'javascript_tool') : Promise.resolve(null),
+    tid ? getSessionManager().getPage(sid, tid, undefined, 'javascript_tool') : Promise.resolve(null),
   );
   server.registerTool('javascript_tool', wrapped, definition);
 }

--- a/src/tools/lightweight-scroll.ts
+++ b/src/tools/lightweight-scroll.ts
@@ -374,9 +374,8 @@ const handler: ToolHandler = async (
 };
 
 export function registerLightweightScrollTool(server: MCPServer): void {
-  const sm = getSessionManager();
   const wrapped = wrapMutatingHandler(handler, (sid, tid) =>
-    tid ? sm.getPage(sid, tid, undefined, 'lightweight_scroll') : Promise.resolve(null),
+    tid ? getSessionManager().getPage(sid, tid, undefined, 'lightweight_scroll') : Promise.resolve(null),
   );
   server.registerTool('lightweight_scroll', wrapped, definition);
 }

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -1129,9 +1129,8 @@ export function registerNavigateTool(server: MCPServer): void {
   // Snapshot-cache (#879): bump docEpoch after a successful navigation
   // (loaderId change) so the next read recomputes against the new page.
   // Wrap the dynamic-skills `wrappedHandler` so both behaviours layer.
-  const sm = getSessionManager();
   const wrapped = wrapMutatingHandler(wrappedHandler, (sid, tid) =>
-    tid ? sm.getPage(sid, tid, undefined, 'navigate') : Promise.resolve(null),
+    tid ? getSessionManager().getPage(sid, tid, undefined, 'navigate') : Promise.resolve(null),
   );
   server.registerTool('navigate', wrapped, definition, { timeoutRecoverable: true });
 }

--- a/src/tools/page-reload.ts
+++ b/src/tools/page-reload.ts
@@ -98,9 +98,8 @@ const handler: ToolHandler = async (
 
 export function registerPageReloadTool(server: MCPServer): void {
   // Snapshot-cache (#879): bump docEpoch after a successful reload.
-  const sm = getSessionManager();
   const wrapped = wrapMutatingHandler(handler, (sid, tid) =>
-    tid ? sm.getPage(sid, tid) : Promise.resolve(null),
+    tid ? getSessionManager().getPage(sid, tid) : Promise.resolve(null),
   );
   server.registerTool('page_reload', wrapped, definition);
 }

--- a/src/tools/tabs-create.ts
+++ b/src/tools/tabs-create.ts
@@ -171,9 +171,8 @@ export function registerTabsCreateTool(server: MCPServer): void {
   // Snapshot-cache (#879): bump docEpoch defensively so a read against a
   // newly-created tab cannot inherit a stale entry from a recycled
   // target id.
-  const sm = getSessionManager();
   const wrapped = wrapMutatingHandler(handler, (sid, tid) =>
-    tid ? sm.getPage(sid, tid, undefined, 'tabs_create') : Promise.resolve(null),
+    tid ? getSessionManager().getPage(sid, tid, undefined, 'tabs_create') : Promise.resolve(null),
   );
   server.registerTool('tabs_create', wrapped, definition);
 }

--- a/tests/cli/playbook/expand.test.ts
+++ b/tests/cli/playbook/expand.test.ts
@@ -16,15 +16,15 @@ describe('expandStep', () => {
   });
 
   test('interact → interact tool, args pass-through', () => {
-    const result = expandStep('interact', { ref: 'Submit button' });
+    const result = expandStep('interact', { query: 'Submit button' });
     expect(result.tool).toBe('interact');
-    expect(result.callArgs).toEqual({ ref: 'Submit button' });
+    expect(result.callArgs).toEqual({ query: 'Submit button' });
   });
 
   test('act → act tool, args pass-through', () => {
-    const result = expandStep('act', { action: 'scroll down' });
+    const result = expandStep('act', { instruction: 'scroll down' });
     expect(result.tool).toBe('act');
-    expect(result.callArgs).toEqual({ action: 'scroll down' });
+    expect(result.callArgs).toEqual({ instruction: 'scroll down' });
   });
 
   test('fill_form → fill_form tool, args pass-through', () => {
@@ -34,9 +34,9 @@ describe('expandStep', () => {
   });
 
   test('wait_for → wait_for tool, args pass-through', () => {
-    const result = expandStep('wait_for', { condition: 'navigation' });
+    const result = expandStep('wait_for', { type: 'navigation' });
     expect(result.tool).toBe('wait_for');
-    expect(result.callArgs).toEqual({ condition: 'navigation' });
+    expect(result.callArgs).toEqual({ type: 'navigation' });
   });
 
   test('page_screenshot → page_screenshot tool, args pass-through', () => {

--- a/tests/cli/playbook/run.test.ts
+++ b/tests/cli/playbook/run.test.ts
@@ -66,7 +66,7 @@ const sanityPlaybook: Playbook = {
   steps: [
     { verb: 'navigate', args: { url: '${url}' } },
     { verb: 'assert', args: { kind: 'dom_text', selector: 'h1', pattern: 'Example' } },
-    { verb: 'interact', args: { ref: 'More information…' } },
+    { verb: 'interact', args: { query: 'More information…' } },
   ],
 };
 
@@ -75,7 +75,7 @@ const failFastPlaybook: Playbook = {
   steps: [
     { verb: 'navigate', args: { url: 'https://example.com' } },
     { verb: 'assert', args: { kind: 'url', pattern: 'WILL_NOT_MATCH' } },
-    { verb: 'interact', args: { ref: 'should be skipped' } },
+    { verb: 'interact', args: { query: 'should be skipped' } },
   ],
 };
 
@@ -113,7 +113,7 @@ describe('runPlaybook — call ordering', () => {
 
     // Step 2: interact → tool 'interact', args pass-through
     expect(calls[2].tool).toBe('interact');
-    expect(calls[2].args).toEqual({ ref: 'More information…' });
+    expect(calls[2].args).toEqual({ query: 'More information…' });
   });
 
   test('calls disconnect after run regardless of outcome', async () => {

--- a/tests/cli/playbook/schema-validator.test.ts
+++ b/tests/cli/playbook/schema-validator.test.ts
@@ -1,0 +1,191 @@
+/// <reference types="jest" />
+
+import { validateValueAgainstSchema } from '../../../cli/playbook/schema-validator';
+
+describe('validateValueAgainstSchema', () => {
+  test('validates required fields, primitive types, and integer semantics', () => {
+    const diagnostics = validateValueAgainstSchema(
+      { count: 1.5 },
+      {
+        type: 'object',
+        properties: {
+          url: { type: 'string' },
+          count: { type: 'integer' },
+        },
+        required: ['url', 'count'],
+        additionalProperties: false,
+      },
+    );
+
+    expect(diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'schema.required', instancePath: '/url', severity: 'error' }),
+      expect.objectContaining({ code: 'schema.type', instancePath: '/count', severity: 'error' }),
+    ]));
+  });
+
+  test('supports type arrays, enum, and const without echoing values', () => {
+    expect(validateValueAgainstSchema(null, { type: ['string', 'null'] })).toEqual([]);
+
+    const enumDiagnostics = validateValueAgainstSchema('private-token', {
+      type: 'string',
+      enum: ['public'],
+    });
+    const constDiagnostics = validateValueAgainstSchema('private-token', {
+      const: 'public',
+    });
+
+    expect(enumDiagnostics).toEqual([
+      expect.objectContaining({ code: 'schema.enum', severity: 'error' }),
+    ]);
+    expect(constDiagnostics).toEqual([
+      expect.objectContaining({ code: 'schema.const', severity: 'error' }),
+    ]);
+    expect(JSON.stringify([...enumDiagnostics, ...constDiagnostics])).not.toContain('private-token');
+  });
+
+  test('validates numeric and string bounds plus patterns', () => {
+    const diagnostics = validateValueAgainstSchema(
+      { score: 11, label: 'x' },
+      {
+        type: 'object',
+        properties: {
+          score: { type: 'number', minimum: 0, maximum: 10 },
+          label: { type: 'string', minLength: 2, maxLength: 4, pattern: '^[A-Z]+$' },
+        },
+        additionalProperties: false,
+      },
+    );
+
+    expect(diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      'schema.maximum',
+      'schema.min_length',
+      'schema.pattern',
+    ]);
+  });
+
+  test('validates array bounds and item schemas', () => {
+    const diagnostics = validateValueAgainstSchema(
+      [1, 2.5, 3],
+      {
+        type: 'array',
+        minItems: 1,
+        maxItems: 2,
+        items: { type: 'integer' },
+      },
+    );
+
+    expect(diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'schema.max_items', instancePath: '' }),
+      expect.objectContaining({ code: 'schema.type', instancePath: '/1' }),
+    ]));
+  });
+
+  test('warns for open additional properties', () => {
+    const diagnostics = validateValueAgainstSchema(
+      { known: 'ok', extra: 'allowed' },
+      {
+        type: 'object',
+        properties: { known: { type: 'string' } },
+      },
+    );
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'schema.additional_property_open',
+        instancePath: '/extra',
+        severity: 'warning',
+      }),
+    ]);
+  });
+
+  test('rejects closed additional properties', () => {
+    const diagnostics = validateValueAgainstSchema(
+      { extra: true },
+      {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+    );
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'schema.additional_property',
+        instancePath: '/extra',
+        severity: 'error',
+      }),
+    ]);
+  });
+
+  test('validates schema-valued additional properties', () => {
+    const diagnostics = validateValueAgainstSchema(
+      { first: 'ok', second: 2 },
+      {
+        type: 'object',
+        properties: {},
+        additionalProperties: { type: 'string' },
+      },
+    );
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({ code: 'schema.type', instancePath: '/second', severity: 'error' }),
+    ]);
+  });
+
+  test('supports oneOf, anyOf, and allOf', () => {
+    expect(validateValueAgainstSchema('Alpha', {
+      oneOf: [
+        { type: 'string', pattern: '^A' },
+        { type: 'number' },
+      ],
+    })).toEqual([]);
+
+    expect(validateValueAgainstSchema('Alpha', {
+      anyOf: [
+        { type: 'number' },
+        { type: 'string', minLength: 3 },
+      ],
+    })).toEqual([]);
+
+    expect(validateValueAgainstSchema('Alpha', {
+      allOf: [
+        { type: 'string' },
+        { minLength: 3 },
+        { maxLength: 8 },
+      ],
+    })).toEqual([]);
+
+    expect(validateValueAgainstSchema('Alpha', {
+      oneOf: [{ type: 'string' }, { minLength: 1 }],
+    })).toEqual([
+      expect.objectContaining({ code: 'schema.one_of', severity: 'error' }),
+    ]);
+
+    expect(validateValueAgainstSchema(false, {
+      anyOf: [{ type: 'string' }, { type: 'number' }],
+    })).toEqual([
+      expect.objectContaining({ code: 'schema.any_of', severity: 'error' }),
+    ]);
+
+    expect(validateValueAgainstSchema('Alpha', {
+      allOf: [
+        { type: 'string', minLength: 3 },
+        { pattern: '^Beta$' },
+      ],
+    })).toEqual([
+      expect.objectContaining({
+        code: 'schema.pattern',
+        schemaPath: '/allOf/1/pattern',
+        severity: 'error',
+      }),
+    ]);
+  });
+
+  test('ignores unsupported schema keywords', () => {
+    expect(validateValueAgainstSchema('anything', {
+      type: 'string',
+      format: 'uri-template',
+      unevaluatedProperties: false,
+    })).toEqual([]);
+  });
+});

--- a/tests/cli/playbook/tool-manifest-client.test.ts
+++ b/tests/cli/playbook/tool-manifest-client.test.ts
@@ -1,0 +1,35 @@
+/// <reference types="jest" />
+
+import {
+  ToolManifestError,
+  parseRegisteredToolManifest,
+} from '../../../cli/playbook/tool-manifest-client';
+
+describe('parseRegisteredToolManifest', () => {
+  test('preserves complete registered tool definitions', () => {
+    expect(parseRegisteredToolManifest(JSON.stringify([
+      {
+        name: 'navigate',
+        description: 'Navigate',
+        inputSchema: { type: 'object', properties: { url: { type: 'string' } } },
+      },
+    ]))).toEqual([
+      {
+        name: 'navigate',
+        description: 'Navigate',
+        inputSchema: { type: 'object', properties: { url: { type: 'string' } } },
+      },
+    ]);
+  });
+
+  test('rejects invalid JSON and non-array manifests', () => {
+    expect(() => parseRegisteredToolManifest('{')).toThrow(ToolManifestError);
+    expect(() => parseRegisteredToolManifest('{}')).toThrow(/JSON array/);
+  });
+
+  test('rejects malformed entries instead of converting them into missing tools', () => {
+    expect(() => parseRegisteredToolManifest(JSON.stringify([
+      { name: 42, inputSchema: {} },
+    ]))).toThrow(/entry 0 is malformed/);
+  });
+});

--- a/tests/cli/playbook/validate-cli.test.ts
+++ b/tests/cli/playbook/validate-cli.test.ts
@@ -14,6 +14,7 @@ function runValidate(args: string[], cwd = process.cwd()) {
     cwd,
     encoding: 'utf8',
     env: { ...process.env, OPENCHROME_UPDATE_CHECK: '0' },
+    maxBuffer: 16 * 1024 * 1024,
   });
 }
 
@@ -56,6 +57,33 @@ describeBuiltCli('oc playbook validate built CLI', () => {
     } finally {
       fs.chmodSync(readOnlyCwd, 0o755);
       fs.rmSync(readOnlyCwd, { recursive: true, force: true });
+    }
+  });
+
+  test('flushes large JSON validation reports before exiting', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-validate-large-'));
+    const filePath = path.join(tempDir, 'large-invalid.json');
+    try {
+      fs.writeFileSync(filePath, JSON.stringify({
+        name: 'large invalid report',
+        steps: Array.from({ length: 2_000 }, () => ({
+          wait_for: { condition: 'navigation' },
+        })),
+      }));
+
+      const result = runValidate([filePath, '--json']);
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(result.stdout.length).toBeGreaterThan(64 * 1024);
+      const report = JSON.parse(result.stdout) as {
+        diagnostics: unknown[];
+        summary: { total: number; ok: boolean };
+      };
+      expect(report.summary).toMatchObject({ total: 2_000, ok: false });
+      expect(report.diagnostics.length).toBeGreaterThan(2_000);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
     }
   });
 

--- a/tests/cli/playbook/validate-cli.test.ts
+++ b/tests/cli/playbook/validate-cli.test.ts
@@ -1,0 +1,73 @@
+/// <reference types="jest" />
+
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const DIST_CLI = path.join(process.cwd(), 'dist', 'cli', 'index.js');
+const FIXTURES = path.join(process.cwd(), 'tests', 'fixtures', 'playbook');
+const describeBuiltCli = fs.existsSync(DIST_CLI) ? describe : describe.skip;
+
+function runValidate(args: string[], cwd = process.cwd()) {
+  return spawnSync(process.execPath, [DIST_CLI, 'playbook', 'validate', ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, OPENCHROME_UPDATE_CHECK: '0' },
+  });
+}
+
+describeBuiltCli('oc playbook validate built CLI', () => {
+  test('returns 0 for schema-conforming playbooks without starting Chrome', () => {
+    const result = runValidate([path.join(FIXTURES, 'sanity.yaml'), '--json']);
+
+    expect(result.status).toBe(0);
+    const report = JSON.parse(result.stdout) as { summary: { ok: boolean; errors: number } };
+    expect(report.summary).toMatchObject({ ok: true, errors: 0 });
+    expect(result.stderr).not.toContain('Chrome debugging port');
+    expect(result.stderr).not.toContain('[CDPClient] Connected');
+  });
+
+  test('returns 1 with stable ids for registered-schema failures', () => {
+    const result = runValidate([path.join(FIXTURES, 'schema-invalid.yaml'), '--json']);
+
+    expect(result.status).toBe(1);
+    const report = JSON.parse(result.stdout) as {
+      diagnostics: Array<{ id?: string; code: string }>;
+      summary: { ok: boolean; errors: number };
+    };
+    expect(report.summary.ok).toBe(false);
+    expect(report.summary.errors).toBeGreaterThan(0);
+    expect(report.diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'wait_navigation', code: 'schema.required' }),
+      expect.objectContaining({ id: 'perform_action', code: 'schema.required' }),
+      expect.objectContaining({ id: 'read_html', code: 'schema.enum' }),
+    ]));
+  });
+
+  test('discovers the manifest without writing runtime state', () => {
+    const readOnlyCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-validate-readonly-'));
+    try {
+      fs.chmodSync(readOnlyCwd, 0o555);
+      const result = runValidate([path.join(FIXTURES, 'sanity.yaml'), '--json'], readOnlyCwd);
+
+      expect(result.status).toBe(0);
+      expect(fs.existsSync(path.join(readOnlyCwd, '.openchrome'))).toBe(false);
+    } finally {
+      fs.chmodSync(readOnlyCwd, 0o755);
+      fs.rmSync(readOnlyCwd, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
+    [[], /missing required argument 'file'/i],
+    [['--bogus'], /unknown option '--bogus'/i],
+    [[path.join(FIXTURES, 'sanity.yaml'), '--reuse'], /--reuse is not supported/i],
+    [['/tmp/openchrome-playbook-does-not-exist.yaml'], /cannot read file/i],
+  ])('returns 2 for usage or file errors: %j', (args, message) => {
+    const result = runValidate(args as string[]);
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(message as RegExp);
+  });
+});

--- a/tests/cli/playbook/validate.test.ts
+++ b/tests/cli/playbook/validate.test.ts
@@ -1,0 +1,259 @@
+/// <reference types="jest" />
+
+import type { Playbook } from '../../../cli/playbook/parse';
+import { VarError } from '../../../cli/playbook/vars';
+import {
+  formatValidationResult,
+  validatePlaybook,
+  validationExitCode,
+  type ValidateOptions,
+} from '../../../cli/playbook/validate';
+import type { McpToolDefinition } from '../../../cli/playbook/tool-manifest-client';
+
+const TOOL_DEFINITIONS: McpToolDefinition[] = [
+  tool('navigate', {
+    type: 'object',
+    properties: { url: { type: 'string' } },
+    required: ['url'],
+    additionalProperties: false,
+  }),
+  tool('interact', {
+    type: 'object',
+    properties: { tabId: { type: 'string' }, query: { type: 'string' } },
+    required: ['tabId', 'query'],
+    additionalProperties: false,
+  }),
+  tool('act', {
+    type: 'object',
+    properties: { tabId: { type: 'string' }, instruction: { type: 'string' } },
+    required: ['tabId', 'instruction'],
+    additionalProperties: false,
+  }),
+  tool('fill_form', {
+    type: 'object',
+    properties: {
+      tabId: { type: 'string' },
+      fields: { type: 'object', additionalProperties: { type: 'string' } },
+      refs: { type: 'object', additionalProperties: { type: 'string' } },
+    },
+    required: ['tabId'],
+    additionalProperties: false,
+  }),
+  tool('wait_for', {
+    type: 'object',
+    properties: {
+      tabId: { type: 'string' },
+      type: { type: 'string', enum: ['navigation', 'timeout'] },
+      value: { type: 'string' },
+    },
+    required: ['tabId', 'type'],
+    additionalProperties: false,
+  }),
+  tool('page_screenshot', {
+    type: 'object',
+    properties: { tabId: { type: 'string' }, path: { type: 'string' } },
+    required: ['tabId'],
+    additionalProperties: false,
+  }),
+  tool('read_page', {
+    type: 'object',
+    properties: {
+      tabId: { type: 'string' },
+      mode: { type: 'string', enum: ['ax', 'dom', 'css', 'semantic', 'markdown'] },
+    },
+    required: ['tabId'],
+    additionalProperties: false,
+  }),
+  tool('javascript_tool', {
+    type: 'object',
+    properties: { tabId: { type: 'string' }, code: { type: 'string' } },
+    required: ['tabId'],
+    additionalProperties: false,
+  }),
+  tool('oc_assert', {
+    type: 'object',
+    properties: { contract: { type: 'object', additionalProperties: true } },
+    required: ['contract'],
+    additionalProperties: false,
+  }),
+];
+
+function tool(name: string, inputSchema: Record<string, unknown>): McpToolDefinition {
+  return { name, inputSchema };
+}
+
+function makeSource(definitions: McpToolDefinition[] = TOOL_DEFINITIONS) {
+  const callTool = jest.fn();
+  const listToolDefinitions = jest.fn(async () => definitions);
+  const source = { listToolDefinitions, callTool };
+  return { source, listToolDefinitions, callTool };
+}
+
+const allVerbsPlaybook: Playbook = {
+  name: 'all verbs',
+  steps: [
+    { verb: 'navigate', args: { url: 'https://example.com' } },
+    { verb: 'interact', args: { query: 'More information' } },
+    { id: 'perform_action', verb: 'act', args: { instruction: 'scroll down' } },
+    { verb: 'fill_form', args: { fields: { name: 'OpenChrome' } } },
+    { verb: 'wait_for', args: { type: 'navigation' } },
+    { verb: 'page_screenshot', args: { path: '/tmp/page.png' } },
+    { verb: 'read_page', args: { mode: 'ax' } },
+    { verb: 'javascript_tool', args: { code: 'document.title' } },
+    { verb: 'assert', args: { kind: 'url', pattern: 'example\\.com' } },
+  ],
+};
+
+describe('validatePlaybook', () => {
+  test('expands all nine verbs, reads one manifest, calls no tools, and simulates tab reuse', async () => {
+    const mock = makeSource();
+
+    const result = await validatePlaybook(allVerbsPlaybook, {
+      varMap: {},
+      source: mock.source as ValidateOptions['source'],
+    });
+
+    expect(result.summary).toMatchObject({ ok: true, total: 9, errors: 0 });
+    expect(mock.listToolDefinitions).toHaveBeenCalledTimes(1);
+    expect(mock.callTool).not.toHaveBeenCalled();
+    expect(result.diagnostics.every((diagnostic) => diagnostic.instancePath !== '/tabId')).toBe(true);
+  });
+
+  test('reports tools missing from the registered manifest and preserves stable step ids', async () => {
+    const mock = makeSource(TOOL_DEFINITIONS.filter((definition) => definition.name !== 'act'));
+
+    const result = await validatePlaybook(allVerbsPlaybook, {
+      varMap: {},
+      source: mock.source as ValidateOptions['source'],
+    });
+
+    expect(result.summary.ok).toBe(false);
+    expect(result.diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        stepIndex: 2,
+        id: 'perform_action',
+        verb: 'act',
+        tool: 'act',
+        code: 'tool.missing',
+        severity: 'error',
+      }),
+    ]));
+  });
+
+  test('reports an implicit tab requirement before navigation and accepts an explicit tab', async () => {
+    const withoutTab = makeSource([TOOL_DEFINITIONS.find((definition) => definition.name === 'fill_form')!]);
+    const firstStep: Playbook = {
+      steps: [{ verb: 'fill_form', args: { fields: { name: 'OpenChrome' } } }],
+    };
+
+    const invalid = await validatePlaybook(firstStep, {
+      varMap: {},
+      source: withoutTab.source as ValidateOptions['source'],
+    });
+    expect(invalid.diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'schema.required', instancePath: '/tabId' }),
+    ]));
+
+    const withTab = makeSource([TOOL_DEFINITIONS.find((definition) => definition.name === 'fill_form')!]);
+    const explicitTab: Playbook = {
+      steps: [{ verb: 'fill_form', args: { tabId: 'existing-tab', fields: { name: 'OpenChrome' } } }],
+    };
+    const valid = await validatePlaybook(explicitTab, {
+      varMap: {},
+      source: withTab.source as ValidateOptions['source'],
+    });
+    expect(valid.summary.ok).toBe(true);
+  });
+
+  test('validates schema-valued refs entries', async () => {
+    const mock = makeSource([
+      TOOL_DEFINITIONS.find((definition) => definition.name === 'navigate')!,
+      TOOL_DEFINITIONS.find((definition) => definition.name === 'fill_form')!,
+    ]);
+    const playbook: Playbook = {
+      steps: [
+        { verb: 'navigate', args: { url: 'https://example.com' } },
+        { verb: 'fill_form', args: { refs: { ref_1: 42 } } },
+      ],
+    };
+
+    const result = await validatePlaybook(playbook, {
+      varMap: {},
+      source: mock.source as ValidateOptions['source'],
+    });
+
+    expect(result.diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'schema.type', instancePath: '/refs/ref_1' }),
+    ]));
+  });
+
+  test('substitutes variables before manifest discovery', async () => {
+    const mock = makeSource();
+    const playbook: Playbook = {
+      steps: [{ verb: 'navigate', args: { url: '${missing}' } }],
+    };
+
+    await expect(validatePlaybook(playbook, {
+      varMap: {},
+      source: mock.source as ValidateOptions['source'],
+    })).rejects.toThrow(VarError);
+
+    expect(mock.listToolDefinitions).not.toHaveBeenCalled();
+  });
+
+  test('propagates registered manifest discovery failures', async () => {
+    const mock = makeSource();
+    mock.listToolDefinitions.mockRejectedValueOnce(new Error('manifest failed'));
+
+    await expect(validatePlaybook(allVerbsPlaybook, {
+      varMap: {},
+      source: mock.source as ValidateOptions['source'],
+    })).rejects.toThrow('manifest failed');
+  });
+
+  test('never exposes substituted secret values in diagnostics or formatted output', async () => {
+    const stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const mock = makeSource([
+      tool('navigate', {
+        type: 'object',
+        properties: { url: { type: 'string', enum: ['https://allowed.example'] } },
+        required: ['url'],
+        additionalProperties: false,
+      }),
+    ]);
+    const playbook: Playbook = {
+      name: 'secret check',
+      steps: [{ verb: 'navigate', args: { url: '${SECRET:TOKEN}' } }],
+    };
+
+    const result = await validatePlaybook(playbook, {
+      varMap: { 'SECRET:TOKEN': 'super-secret-value' },
+      source: mock.source as ValidateOptions['source'],
+    });
+
+    expect(JSON.stringify(result)).not.toContain('super-secret-value');
+    expect(formatValidationResult(result, false)).not.toContain('super-secret-value');
+    expect(formatValidationResult(result, true)).not.toContain('super-secret-value');
+    stderrSpy.mockRestore();
+  });
+});
+
+describe('validation reporting', () => {
+  test('formats deterministic human and JSON output and maps exit codes', async () => {
+    const mock = makeSource(TOOL_DEFINITIONS.filter((definition) => definition.name !== 'act'));
+    const result = await validatePlaybook(allVerbsPlaybook, {
+      varMap: {},
+      source: mock.source as ValidateOptions['source'],
+    });
+
+    const human = formatValidationResult(result, false);
+    expect(human).toContain('SCHEMA ERRORS');
+    expect(human).toContain('step 2 [perform_action]');
+    expect(human).toContain('tool.missing');
+    expect(formatValidationResult(result, true)).toBe(`${JSON.stringify(result, null, 2)}\n`);
+    expect(validationExitCode(result)).toBe(1);
+
+    const valid = { ...result, diagnostics: [], summary: { ...result.summary, ok: true, errors: 0, warnings: 0 } };
+    expect(validationExitCode(valid)).toBe(0);
+  });
+});

--- a/tests/fixtures/playbook/fail-fast.yaml
+++ b/tests/fixtures/playbook/fail-fast.yaml
@@ -6,4 +6,4 @@ steps:
       kind: url
       pattern: "WILL_NOT_MATCH"
   - interact:
-      ref: "should be skipped"
+      query: "should be skipped"

--- a/tests/fixtures/playbook/sanity.json
+++ b/tests/fixtures/playbook/sanity.json
@@ -7,12 +7,12 @@
   "steps": [
     { "navigate": { "url": "${url}" } },
     { "assert": { "kind": "dom_text", "selector": "h1", "pattern": "${heading}" } },
-    { "interact": { "ref": "More information…" } },
-    { "wait_for": { "condition": "navigation" } },
+    { "interact": { "query": "More information…" } },
+    { "wait_for": { "type": "navigation" } },
     { "assert": { "kind": "url", "pattern": "iana\\.org" } },
     { "page_screenshot": { "path": "/tmp/sanity.png" } },
     { "read_page": { "mode": "ax" } },
     { "javascript_tool": { "code": "document.title" } },
-    { "act": { "action": "scroll down" } }
+    { "act": { "instruction": "scroll down" } }
   ]
 }

--- a/tests/fixtures/playbook/sanity.yaml
+++ b/tests/fixtures/playbook/sanity.yaml
@@ -10,9 +10,9 @@ steps:
       selector: h1
       pattern: ${heading}
   - interact:
-      ref: "More information…"
+      query: "More information…"
   - wait_for:
-      condition: "navigation"
+      type: "navigation"
   - assert:
       kind: url
       pattern: "iana\\.org"
@@ -23,4 +23,4 @@ steps:
   - javascript_tool:
       code: "document.title"
   - act:
-      action: "scroll down"
+      instruction: "scroll down"

--- a/tests/fixtures/playbook/schema-invalid.yaml
+++ b/tests/fixtures/playbook/schema-invalid.yaml
@@ -1,0 +1,14 @@
+name: intentionally stale schema fixture
+steps:
+  - id: open_home
+    navigate:
+      url: https://example.com
+  - id: wait_navigation
+    wait_for:
+      condition: navigation
+  - id: perform_action
+    act:
+      action: scroll down
+  - id: read_html
+    read_page:
+      mode: html

--- a/tests/tools/manifest-only-registration.test.ts
+++ b/tests/tools/manifest-only-registration.test.ts
@@ -1,0 +1,25 @@
+/// <reference types="jest" />
+
+describe('manifest-only tool registration', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  test('collects definitions without constructing the runtime session manager', () => {
+    jest.resetModules();
+    const sessionManager = require('../../src/session-manager') as typeof import('../../src/session-manager');
+    const getSessionManager = jest.spyOn(sessionManager, 'getSessionManager')
+      .mockImplementation(() => {
+        throw new Error('manifest registration must not construct runtime services');
+      });
+    const { MCPServer } = require('../../src/mcp-server') as typeof import('../../src/mcp-server');
+    const { registerAllTools } = require('../../src/tools') as typeof import('../../src/tools');
+
+    const server = new MCPServer(undefined, { initialToolTier: 3, manifestOnly: true });
+
+    expect(() => registerAllTools(server, { runtimeSideEffects: false })).not.toThrow();
+    expect(getSessionManager).not.toHaveBeenCalled();
+    expect(server.getToolNames()).toContain('navigate');
+  });
+});


### PR DESCRIPTION
## Summary

- add `oc playbook validate <file>` as a non-executing preflight for the existing nine playbook verbs;
- reuse the canonical parser, variable substitution, step expansion, and current-tab injection behavior;
- validate expanded arguments against the package's registered MCP `inputSchema` definitions;
- make `serve --introspect-tools-list` registration-only so validation starts no Chrome/CDP session and writes no runtime state;
- correct stale playbook examples for `interact`, `act`, `wait_for`, and `read_page`.

## Direction and clean-room boundary

This is a clean-room adaptation of one general Maxun principle: reusable workflows should be checked before execution.

OpenChrome remains a host-neutral MCP browser harness. This PR adds no planner, LLM call, workflow database, scheduler, recorder runtime, selector dialect, hosted API, or new MCP tool. Maxun is AGPL-3.0-or-later and OpenChrome is MIT; no Maxun source, workflow types, or runtime implementation was copied.

## Design

`oc playbook validate` invokes the existing `serve --introspect-tools-list` path once. That path now constructs the MCP server in `manifestOnly` mode and registers tools with runtime side effects disabled. It does not initialize session/resource wiring, cleanup timers, task reaping, trace listeners, Chrome, CDP, or an MCP transport.

Diagnostics contain step identity, tool/schema paths, severity, code, and a generic message. They intentionally omit substituted argument values so validation output does not disclose secrets.

Exit codes:

- `0`: no schema errors; warnings are allowed;
- `1`: missing registered tool or schema validation error;
- `2`: usage, file, parse, variable, or reserved `--reuse` error;
- `3`: manifest spawn, JSON, or envelope failure.

`validate --reuse` is explicitly reserved and exits `2`. Session-scoped daemon validation remains in #1578 because the isolation prerequisite from #1573 is currently on `develop`, not `main`.

## Scope limits

Validation proves registered-schema conformance only. Tool-handler conditional rules, browser state, selector availability, authentication, page content, and runtime postconditions can still fail during `playbook run`.

The dependency-free validator implements the schema subset used by the playbook tools: types, required/properties/additionalProperties, enum/const, oneOf/anyOf/allOf, items, numeric/string/array bounds, and patterns. Unknown keywords are ignored rather than reinterpreted.

## Validation

- `npm run build`
- `npx jest tests/cli/playbook --runInBand` — 10 suites, 108 tests
- `npm test -- --runInBand` — 637 suites passed, 7,693 tests passed (full local run before final base refresh)
- `npx jest tests/tools/manifest-only-registration.test.ts --runInBand` — 1 suite, 1 test
- latest-main integration slice — 14 suites, 163 tests
- large-report pipe regression — 2,000 invalid steps; pre-fix output stopped at 65,536 bytes, post-fix JSON parses completely
- GitHub CI on `44b38455` against `da831b69` — 7/7 build-and-test jobs plus E2E PR Smoke
- `npm run lint`
- `npm run lint:tier`
- `npm run lint:tool-schemas` — 0 new violations
- `npm run docs:capability-map:check`
- CLI source ESLint with `tsconfig.cli.json`
- playbook test ESLint — 0 errors, 2 pre-existing warnings
- built manifest smoke — 118 registered tools
- `git diff --check`

Closes #1568



