### PR TITLE
feat(contracts): resolve oc_assert contract IDs through the canonical registry

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -76,6 +76,30 @@ so an LLM can correct multiple mistakes at once. Malformed input is never
 silently accepted; the runtime refuses to evaluate an unvalidated DSL
 fragment.
 
+## Registered contract IDs
+
+`oc_assert` accepts either an inline assertion under `contract` or a registered
+template ID under `contract_id`. These fields are mutually exclusive. Passing
+both returns `verdict: "inconclusive"` with
+`error_code: "CONTRACT_ID_CONFLICT"` so hosts never have to infer precedence.
+
+Registered IDs resolve through the canonical default template registry exported
+from `src/contracts/templates`. That registry is the single source of truth for
+built-in outcome-contract templates and is populated from the built-in template
+catalog, currently `public-web.page-meta@1`.
+
+Lookup is closed-world:
+
+- malformed IDs return `error_code: "CONTRACT_ID_MALFORMED"`;
+- unknown IDs return `error_code: "CONTRACT_ID_UNKNOWN"`;
+- registered templates without an `assertions` tree return
+  `error_code: "CONTRACT_TEMPLATE_NO_ASSERTIONS"`.
+
+The existing inline assertion path is unchanged and remains the portable way to
+evaluate ad hoc assertions. Schema-only templates, such as
+`public-web.page-meta`, can be listed and used by schema-diff consumers, but
+they are not executable by `oc_assert` until they carry assertions.
+
 ## Per-assertion reference
 
 ### `url`

--- a/src/contracts/templates/index.ts
+++ b/src/contracts/templates/index.ts
@@ -14,7 +14,12 @@ export {
   InvalidTemplateError,
 } from './types';
 export type { TemplateListing } from './registry';
-export { TemplateRegistry } from './registry';
+export {
+  BUILT_IN_TEMPLATES,
+  TemplateRegistry,
+  createDefaultTemplateRegistry,
+  isValidTemplateId,
+} from './registry';
 
 // ── public-web template catalog (A2-PR2..5 of #1359) ──────────────────────
 export { PAGE_META_TEMPLATE } from './public-web/page-meta';

--- a/src/contracts/templates/registry.ts
+++ b/src/contracts/templates/registry.ts
@@ -20,6 +20,7 @@ import {
   InvalidTemplateError,
   OutcomeTemplate,
 } from './types';
+import { PAGE_META_TEMPLATE } from './public-web/page-meta';
 
 /** Result of a successful `list()` call — a frozen view of the registry. */
 export interface TemplateListing {
@@ -34,6 +35,10 @@ export interface TemplateListing {
 }
 
 const ID_PATTERN = /^[a-z0-9]+(?:[-.][a-z0-9]+)*$/;
+
+export function isValidTemplateId(id: string): boolean {
+  return ID_PATTERN.test(id);
+}
 
 /**
  * Recursively freeze a plain object or array so that the registry's stored
@@ -61,7 +66,7 @@ function validateTemplate(template: OutcomeTemplate): void {
   if (typeof template.id !== 'string' || template.id.length === 0) {
     throw new InvalidTemplateError('id must be a non-empty string');
   }
-  if (!ID_PATTERN.test(template.id)) {
+  if (!isValidTemplateId(template.id)) {
     throw new InvalidTemplateError(
       `id "${template.id}" must be dotted kebab-case (a-z0-9 separated by '-' or '.')`,
     );
@@ -174,4 +179,16 @@ export class TemplateRegistry {
     for (const versions of this.byId.values()) n += versions.size;
     return n;
   }
+}
+
+export const BUILT_IN_TEMPLATES: readonly OutcomeTemplate[] = [
+  PAGE_META_TEMPLATE,
+];
+
+export function createDefaultTemplateRegistry(): TemplateRegistry {
+  const registry = new TemplateRegistry();
+  for (const template of BUILT_IN_TEMPLATES) {
+    registry.register(template);
+  }
+  return registry;
 }

--- a/src/tools/oc-assert.ts
+++ b/src/tools/oc-assert.ts
@@ -7,11 +7,9 @@
  * action gating — those live in the pilot runtime (#749, #750).
  *
  * Design notes:
- *  - The DSL in src/contracts/ does not (yet) expose a contract-by-id
- *    registry. To keep this PR scoped, `oc_assert` accepts the Assertion
- *    inline under `contract`. `contract_id` is reserved as an optional
- *    forward-compatible field; today it surfaces a clear error if used
- *    without `contract`.
+ *  - `contract_id` resolves through the canonical outcome-template registry
+ *    in `src/contracts/templates`. The inline `contract` path remains
+ *    supported for callers that already send assertion DSL directly.
  *  - Evaluation is snapshot-driven: callers pre-capture the page state
  *    (url, dom text/count, network, screenshot bytes, dialog flag) and
  *    pass it in `evidence.snapshot`. Live browser plumbing belongs to
@@ -27,6 +25,11 @@ import { runImageQaSampling } from './image-qa';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { evaluate } from '../contracts/evaluate';
 import { validateAssertion } from '../contracts/validator';
+import {
+  TemplateRegistry,
+  createDefaultTemplateRegistry,
+  isValidTemplateId,
+} from '../contracts/templates';
 import { getActiveActionRecorder } from '../recording/action-recorder';
 import type { EvalContext, NetworkLogEntry } from '../contracts/eval-context';
 import { primaryFailureCategory } from '../failure/classifier';
@@ -39,6 +42,11 @@ import type {
 } from '../contracts/types';
 
 type Verdict = 'pass' | 'fail' | 'inconclusive';
+type OcAssertErrorCode =
+  | 'CONTRACT_ID_CONFLICT'
+  | 'CONTRACT_ID_MALFORMED'
+  | 'CONTRACT_ID_UNKNOWN'
+  | 'CONTRACT_TEMPLATE_NO_ASSERTIONS';
 
 interface FailedAssertion {
   name: string;
@@ -61,6 +69,7 @@ interface OcAssertOutput {
   evidence?: Evidence;
   validation_errors?: Array<{ path: string; message: string }>;
   inconclusive_reason?: string;
+  error_code?: OcAssertErrorCode;
 }
 
 interface SnapshotInput {
@@ -86,9 +95,8 @@ const definition: MCPToolDefinition = {
       contract_id: {
         type: 'string',
         description:
-          'Optional identifier for a registered contract. Reserved for ' +
-          'forward compatibility — currently no registry exists, so callers ' +
-          'must supply `contract` inline.',
+          'Optional identifier for a registered contract in the canonical ' +
+          'outcome-template registry. Mutually exclusive with `contract`.',
       },
       contract: {
         type: 'object',
@@ -328,24 +336,62 @@ function isInconclusive(evidence: Evidence): boolean {
   return typeof evidence.details.error === 'string';
 }
 
-const handler: ToolHandler = async (
+function createHandler(templateRegistry: TemplateRegistry): ToolHandler {
+  return async (
   sessionId: string,
   args: Record<string, unknown>,
   context?: ToolContext,
 ): Promise<MCPResult> => {
   const contractInline = args.contract;
-  const contractId = args.contract_id as string | undefined;
+  const contractIdArg = args.contract_id;
 
-  if (contractInline === undefined) {
-    if (contractId !== undefined) {
+  if (contractInline !== undefined && contractIdArg !== undefined) {
+    const output: OcAssertOutput = {
+      verdict: 'inconclusive',
+      error_code: 'CONTRACT_ID_CONFLICT',
+      inconclusive_reason:
+        '`contract` and `contract_id` are mutually exclusive; pass exactly one assertion source.',
+    };
+    return jsonResult(output);
+  }
+
+  let assertionSource = contractInline;
+
+  if (contractIdArg !== undefined) {
+    if (typeof contractIdArg !== 'string' || !isValidTemplateId(contractIdArg)) {
       const output: OcAssertOutput = {
         verdict: 'inconclusive',
+        error_code: 'CONTRACT_ID_MALFORMED',
         inconclusive_reason:
-          'contract_id lookup is not yet implemented; pass the assertion ' +
-          'inline via `contract`.',
+          'contract_id must be dotted kebab-case (a-z0-9 separated by "-" or ".").',
       };
       return jsonResult(output);
     }
+    const contractId = contractIdArg;
+
+    const template = templateRegistry.get(contractId);
+    if (!template) {
+      const output: OcAssertOutput = {
+        verdict: 'inconclusive',
+        error_code: 'CONTRACT_ID_UNKNOWN',
+        inconclusive_reason: `unknown contract_id: ${contractId}`,
+      };
+      return jsonResult(output);
+    }
+
+    if (!template.assertions) {
+      const output: OcAssertOutput = {
+        verdict: 'inconclusive',
+        error_code: 'CONTRACT_TEMPLATE_NO_ASSERTIONS',
+        inconclusive_reason: `registered contract_id has no assertions: ${contractId}`,
+      };
+      return jsonResult(output);
+    }
+
+    assertionSource = template.assertions;
+  }
+
+  if (assertionSource === undefined) {
     const output: OcAssertOutput = {
       verdict: 'inconclusive',
       inconclusive_reason: 'missing required field: `contract`',
@@ -353,7 +399,7 @@ const handler: ToolHandler = async (
     return jsonResult(output);
   }
 
-  const validation = validateAssertion(contractInline);
+  const validation = validateAssertion(assertionSource);
   if (!validation.ok) {
     const output: OcAssertOutput = {
       verdict: 'inconclusive',
@@ -424,7 +470,7 @@ const handler: ToolHandler = async (
   const recorder = getActiveActionRecorder(sessionId);
   if (recorder) {
     recorder.appendContractResult({
-      assertion: contractInline,
+      assertion: validation.value,
       verdict,
       details: result.evidence.details as Record<string, unknown> | undefined,
     }).catch((err: unknown) => {
@@ -432,8 +478,9 @@ const handler: ToolHandler = async (
     });
   }
 
-  return jsonResult(output);
-};
+    return jsonResult(output);
+  };
+}
 
 /**
  * Map an oc_assert failure to a structured, host-actionable failure category
@@ -504,6 +551,9 @@ function jsonResult(payload: OcAssertOutput): MCPResult {
   };
 }
 
-export function registerOcAssertTool(server: MCPServer): void {
-  server.registerTool('oc_assert', handler, definition);
+export function registerOcAssertTool(
+  server: MCPServer,
+  templateRegistry: TemplateRegistry = createDefaultTemplateRegistry(),
+): void {
+  server.registerTool('oc_assert', createHandler(templateRegistry), definition);
 }

--- a/tests/contracts/templates/registry.test.ts
+++ b/tests/contracts/templates/registry.test.ts
@@ -1,10 +1,13 @@
 /// <reference types="jest" />
 
 import {
+  BUILT_IN_TEMPLATES,
   DuplicateTemplateError,
   InvalidTemplateError,
   OutcomeTemplate,
   TemplateRegistry,
+  createDefaultTemplateRegistry,
+  isValidTemplateId,
 } from '../../../src/contracts/templates';
 
 function tpl(overrides: Partial<OutcomeTemplate> = {}): OutcomeTemplate {
@@ -72,6 +75,14 @@ describe('TemplateRegistry', () => {
     expect(() => r.register(tpl({ id: 'a-b' }))).not.toThrow();
     expect(() => r.register(tpl({ id: 'public-web.spa-hydrated' }))).not.toThrow();
     expect(() => r.register(tpl({ id: 'ns.sub.leaf' }))).not.toThrow();
+  });
+
+  test('isValidTemplateId mirrors registry id acceptance for lookup callers', () => {
+    expect(isValidTemplateId('public-web.page-meta')).toBe(true);
+    expect(isValidTemplateId('a-b.c')).toBe(true);
+    expect(isValidTemplateId('')).toBe(false);
+    expect(isValidTemplateId('NotKebabCase')).toBe(false);
+    expect(isValidTemplateId('../escape')).toBe(false);
   });
 
   test('rejects malformed version values', () => {
@@ -220,5 +231,20 @@ describe('TemplateRegistry', () => {
     };
     r.register(t);
     expect(r.get(t.id)).toEqual(t);
+  });
+
+  test('default registry is populated from the built-in template catalog', () => {
+    const expectedIds = BUILT_IN_TEMPLATES.map((template) => template.id).sort();
+    const registry = createDefaultTemplateRegistry();
+    expect(expectedIds).toContain('public-web.page-meta');
+    expect(registry.list().map((entry) => entry.id)).toEqual(expectedIds);
+  });
+
+  test('createDefaultTemplateRegistry returns an isolated populated registry', () => {
+    const r = createDefaultTemplateRegistry();
+    expect(r.has('public-web.page-meta')).toBe(true);
+    expect(r.unregister('public-web.page-meta')).toBe(1);
+    expect(r.has('public-web.page-meta')).toBe(false);
+    expect(createDefaultTemplateRegistry().has('public-web.page-meta')).toBe(true);
   });
 });

--- a/tests/core/contracts/oc-assert.test.ts
+++ b/tests/core/contracts/oc-assert.test.ts
@@ -13,9 +13,15 @@
  * (oc_evidence_bundle). It is asserted only by shape — not consumed.
  */
 
-import { registerOcAssertTool, deriveFailureCategory } from '../../../src/tools/oc-assert';
+import {
+  registerOcAssertTool,
+  deriveFailureCategory,
+} from '../../../src/tools/oc-assert';
+import * as fs from 'fs';
+import * as path from 'path';
 import type { MCPToolDefinition, MCPResult, ToolHandler } from '../../../src/types/mcp';
 import type { Evidence } from '../../../src/contracts/types';
+import { PAGE_META_TEMPLATE, TemplateRegistry } from '../../../src/contracts/templates';
 
 interface RegisteredTool {
   name: string;
@@ -44,12 +50,26 @@ async function invoke(
   return parseResult(result);
 }
 
-function setup(): { handler: ToolHandler; definition: MCPToolDefinition } {
+function setup(registry?: TemplateRegistry): { handler: ToolHandler; definition: MCPToolDefinition } {
   const server = new MockServer();
-  registerOcAssertTool(server as unknown as Parameters<typeof registerOcAssertTool>[0]);
+  registerOcAssertTool(
+    server as unknown as Parameters<typeof registerOcAssertTool>[0],
+    registry,
+  );
   const registered = server.tools.get('oc_assert');
   expect(registered).toBeDefined();
   return { handler: registered!.handler, definition: registered!.definition };
+}
+
+function registryWithUrlContract(): TemplateRegistry {
+  const registry = new TemplateRegistry();
+  registry.register({
+    id: 'test.url-pass',
+    version: 1,
+    description: 'test url contract',
+    assertions: { kind: 'url', pattern: '^https://example\\.com/registered$' },
+  });
+  return registry;
 }
 
 describe('oc_assert — registration', () => {
@@ -58,6 +78,21 @@ describe('oc_assert — registration', () => {
     expect(definition.name).toBe('oc_assert');
     expect(definition.inputSchema.type).toBe('object');
     expect(definition.description).toMatch(/Outcome Contract/);
+  });
+
+  test('core contract registry path does not import pilot modules', () => {
+    const files = [
+      '../../../src/tools/oc-assert.ts',
+      '../../../src/contracts/templates/index.ts',
+      '../../../src/contracts/templates/registry.ts',
+    ].map((relative) => path.resolve(__dirname, relative));
+
+    for (const file of files) {
+      const source = fs.readFileSync(file, 'utf8');
+      expect(source).not.toMatch(/from ['"].*\/pilot(?:\/|['"])/);
+      expect(source).not.toMatch(/import\(['"].*\/pilot(?:\/|['"])/);
+      expect(source).not.toMatch(/require\(['"].*\/pilot(?:\/|['"])\)/);
+    }
   });
 });
 
@@ -134,10 +169,77 @@ describe('oc_assert — verdicts', () => {
   });
 
   test('inconclusive: contract_id supplied without a registry', async () => {
+    const { handler } = setup(new TemplateRegistry());
+    const out = await invoke(handler, { contract_id: 'cart-visible' });
+    expect(out.verdict).toBe('inconclusive');
+    expect(out.error_code).toBe('CONTRACT_ID_UNKNOWN');
+    expect(out.inconclusive_reason).toMatch(/unknown contract_id/);
+  });
+
+  test('pass: known registered contract_id executes through the oc_assert evaluator', async () => {
+    const { handler } = setup(registryWithUrlContract());
+    const out = await invoke(handler, {
+      contract_id: 'test.url-pass',
+      evidence: { snapshot: { url: 'https://example.com/registered' } },
+    });
+    expect(out.verdict).toBe('pass');
+    expect(typeof out.evidence_handle).toBe('string');
+    expect((out.evidence as Evidence).assertion_kind).toBe('url');
+  });
+
+  test('fail: known registered contract_id does not silently fall back', async () => {
+    const { handler } = setup(registryWithUrlContract());
+    const out = await invoke(handler, {
+      contract_id: 'test.url-pass',
+      evidence: { snapshot: { url: 'https://example.com/other' } },
+    });
+    expect(out.verdict).toBe('fail');
+    expect(out.failure_category).toBe('POSTCONDITION_FAILED');
+  });
+
+  test('inconclusive: unknown contract_id returns stable closed-world error code', async () => {
+    const { handler } = setup(registryWithUrlContract());
+    const out = await invoke(handler, {
+      contract_id: 'test.unknown',
+      contract: undefined,
+      evidence: { snapshot: { url: 'https://example.com/registered' } },
+    });
+    expect(out.verdict).toBe('inconclusive');
+    expect(out.error_code).toBe('CONTRACT_ID_UNKNOWN');
+    expect(out.inconclusive_reason).toBe('unknown contract_id: test.unknown');
+  });
+
+  test('inconclusive: malformed contract_id returns stable error code', async () => {
     const { handler } = setup();
     const out = await invoke(handler, { contract_id: 'cart_visible' });
     expect(out.verdict).toBe('inconclusive');
-    expect(out.inconclusive_reason).toMatch(/contract_id/);
+    expect(out.error_code).toBe('CONTRACT_ID_MALFORMED');
+    expect(out.inconclusive_reason).toMatch(/dotted kebab-case/);
+  });
+
+  test('inconclusive: inline contract plus contract_id conflict is rejected explicitly', async () => {
+    const { handler } = setup();
+    const out = await invoke(handler, {
+      contract_id: 'test.url-pass',
+      contract: { kind: 'url', pattern: '.*' },
+      evidence: { snapshot: { url: 'https://example.com/registered' } },
+    });
+    expect(out.verdict).toBe('inconclusive');
+    expect(out.error_code).toBe('CONTRACT_ID_CONFLICT');
+    expect(out.inconclusive_reason).toMatch(/mutually exclusive/);
+  });
+
+  test('inconclusive: registered template without assertions fails closed', async () => {
+    const registry = new TemplateRegistry();
+    registry.register(PAGE_META_TEMPLATE);
+    const { handler } = setup(registry);
+    const out = await invoke(handler, {
+      contract_id: 'public-web.page-meta',
+      evidence: { snapshot: { url: 'https://example.com/' } },
+    });
+    expect(out.verdict).toBe('inconclusive');
+    expect(out.error_code).toBe('CONTRACT_TEMPLATE_NO_ASSERTIONS');
+    expect(out.inconclusive_reason).toMatch(/no assertions/);
   });
 
   test('inconclusive: schema validation failure surfaces errors', async () => {

--- a/tests/mcp/oc-assert-contract-registry.test.ts
+++ b/tests/mcp/oc-assert-contract-registry.test.ts
@@ -1,0 +1,48 @@
+/// <reference types="jest" />
+
+import { MCPServer } from '../../src/mcp-server';
+import { TemplateRegistry } from '../../src/contracts/templates';
+import { registerOcAssertTool } from '../../src/tools/oc-assert';
+import { createMockSessionManager } from '../utils/mock-session';
+import type { MCPRequest } from '../../src/types/mcp';
+
+function parseToolText(response: unknown): Record<string, unknown> {
+  const result = (response as { result?: { content?: Array<{ type: string; text?: string }> } })
+    .result;
+  const block = result?.content?.[0];
+  if (!block || block.type !== 'text' || typeof block.text !== 'string') {
+    throw new Error('expected tools/call text result');
+  }
+  return JSON.parse(block.text) as Record<string, unknown>;
+}
+
+describe('oc_assert contract_id registry lookup through MCP tools/call', () => {
+  test('known registered id reaches the actual oc_assert handler and evaluator', async () => {
+    const registry = new TemplateRegistry();
+    registry.register({
+      id: 'test.mcp-url-pass',
+      version: 1,
+      description: 'MCP registry lookup contract',
+      assertions: { kind: 'url', pattern: '^https://example\\.com/mcp$' },
+    });
+    const server = new MCPServer(createMockSessionManager() as never);
+    registerOcAssertTool(server, registry);
+
+    const request: MCPRequest = {
+      jsonrpc: '2.0',
+      id: 1570,
+      method: 'tools/call',
+      params: {
+        name: 'oc_assert',
+        arguments: {
+          contract_id: 'test.mcp-url-pass',
+          evidence: { snapshot: { url: 'https://example.com/mcp' } },
+        },
+      },
+    };
+
+    const out = parseToolText(await server.handleRequest(request));
+    expect(out.verdict).toBe('pass');
+    expect((out.evidence as { assertion_kind?: string }).assertion_kind).toBe('url');
+  });
+});


### PR DESCRIPTION
## Summary

- populate the canonical outcome-template registry from the built-in template catalog;
- resolve `oc_assert.contract_id` through that registry before normal assertion evaluation;
- reject inline/ID conflicts, malformed IDs, unknown IDs, and schema-only templates with stable closed-world error codes;
- preserve the existing inline assertion path and recorder behavior;
- document the canonical registry as the single source of truth.

## Direction fit

This advances the contract-verifiable evidence pillar in #1359 while preserving OpenChrome's host-neutral harness boundary. Contract selection remains caller-owned, evaluation stays deterministic and snapshot-driven, and core does not depend on pilot or a second registry.

## Verification

- `npm run build`
- `npx jest tests/contracts/templates/registry.test.ts tests/core/contracts/oc-assert.test.ts tests/mcp/oc-assert-contract-registry.test.ts --runInBand` — 3 suites, 50 tests passed
- `npm run lint:tier` — 0 dependency violations
- `git diff --check`
- independent code review: APPROVE, no findings

## Known boundary

The current built-in catalog includes `public-web.page-meta@1`, which is schema-only and therefore fails closed with `CONTRACT_TEMPLATE_NO_ASSERTIONS`. Executable templates use the same canonical registry as they are added; this PR does not invent new templates.

Closes #1570
