### PR TITLE
feat: defer ordinary auto-launch until first browser demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ openchrome setup --client codex        # Codex CLI (auto-elect topology)
 npx openchrome-mcp setup --client opencode   # OpenCode (auto-elect topology)
 ```
 
-Restart your MCP client. That's it — Chrome auto-launches on first tool call.
+Restart your MCP client. That's it — Chrome auto-launches on the first browser/CDP-requiring tool call. Protocol startup, tool discovery, and browser-free diagnostics stay launch-free.
+An already-open Chrome is reused only when it exposes the configured remote-debugging port; a normal Chrome without that CDP endpoint remains separate from the managed browser.
 
 **Updating is not configuration migration.** `npm install -g openchrome-mcp@latest`
 updates the OpenChrome binary, but it does not rewrite existing Claude Code,

--- a/scripts/verify/auto-elect-two-client-smoke.mjs
+++ b/scripts/verify/auto-elect-two-client-smoke.mjs
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
-import { spawn } from 'node:child_process';
-import { mkdtempSync, rmSync, readFileSync, readdirSync } from 'node:fs';
+import { execFileSync, spawn } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, readFileSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import net from 'node:net';
 
 const root = resolve(new URL('../..', import.meta.url).pathname);
 const entry = join(root, 'dist', 'index.js');
-const timeoutMs = Number(process.env.OPENCHROME_AUTO_ELECT_SMOKE_TIMEOUT_MS || 30000);
+const timeoutMs = Number(process.env.OPENCHROME_AUTO_ELECT_SMOKE_TIMEOUT_MS || 60000);
 
 function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
 
@@ -62,6 +62,22 @@ function jsonLines(text) {
   });
 }
 
+async function waitForRpc(child, id, label) {
+  return waitFor(label, () => jsonLines(child.stdoutText).find((message) => message.id === id));
+}
+
+function countMatches(text, pattern) {
+  return (text.match(pattern) || []).length;
+}
+
+function liveManagedChromeRootCount(port) {
+  if (process.platform === 'win32') return null;
+  const output = execFileSync('ps', ['-axo', 'command='], { encoding: 'utf8' });
+  return output.split('\n').filter((line) =>
+    line.includes(`--remote-debugging-port=${port}`) && !line.includes('--type='),
+  ).length;
+}
+
 async function terminate(children) {
   for (const child of children) {
     if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
@@ -75,13 +91,23 @@ async function terminate(children) {
 async function main() {
   const tmp = mkdtempSync(join(tmpdir(), 'openchrome-auto-elect-'));
   const userDataDir = join(tmp, 'profile');
+  const homeDir = join(tmp, 'home');
   const registryDir = join(tmp, 'brokers');
+  const lockDir = join(tmp, 'locks');
+  mkdirSync(homeDir, { recursive: true });
   const cdpPort = await allocPort();
   const httpPort = await allocPort();
   const env = {
+    HOME: homeDir,
     OPENCHROME_BROKER_REGISTRY_DIR: registryDir,
+    OPENCHROME_CONTROLLER_LOCK_DIR: lockDir,
     OPENCHROME_PPID_WATCH: '0',
     OPENCHROME_HEALTH_ENDPOINT: '0',
+    OPENCHROME_LOCK_HEARTBEAT_INTERVAL_MS: '1000',
+    OPENCHROME_LOCK_TAKEOVER_GRACE_MS: '2500',
+    OPENCHROME_LOCK_PROBE_ATTEMPTS: '1',
+    OPENCHROME_LOCK_PROBE_INTERVAL_MS: '0',
+    OPENCHROME_RECOVERY_LEDGER: '0',
   };
   const baseArgs = ['--auto-launch', '--headless', '--port', String(cdpPort), '--user-data-dir', userDataDir, '--http', String(httpPort), '--http-host', '127.0.0.1'];
   const children = [];
@@ -100,19 +126,88 @@ async function main() {
       } catch { return null; }
     });
     if (metadata.pid !== owner.pid) throw new Error(`metadata pid ${metadata.pid} != owner pid ${owner.pid}`);
+    if (/\[ChromeLauncher\] Launching Chrome/.test(owner.stderrText)) {
+      throw new Error(`owner launched Chrome before browser demand:\n${owner.stderrText}`);
+    }
+
+    const lockBeforeIdle = readOnlyMetadata(lockDir);
+    if (!lockBeforeIdle) throw new Error('controller lock metadata missing before idle window');
+    await sleep(3500);
+    const lockAfterIdle = readOnlyMetadata(lockDir);
+    if (!lockAfterIdle) throw new Error('controller lock metadata disappeared during lazy idle window');
+    if (Date.parse(lockAfterIdle.lastHeartbeatAt) <= Date.parse(lockBeforeIdle.lastHeartbeatAt)) {
+      throw new Error('lazy owner did not refresh controller heartbeat before browser demand');
+    }
 
     const client = start('client', baseArgs, env);
     children.push(client);
     await waitFor('surplus client broker attach', () => /auto-elect: attaching as broker client/.test(client.stderrText));
     sendRpc(client, 1, 'initialize');
-    await waitFor('proxied initialize response', () => jsonLines(client.stdoutText).some((m) => m.id === 1 && m.result?.serverInfo?.name === 'openchrome'));
+    const initialize = await waitForRpc(client, 1, 'proxied initialize response');
+    if (initialize.result?.serverInfo?.name !== 'openchrome') throw new Error(`unexpected initialize response: ${JSON.stringify(initialize)}`);
+    sendRpc(client, 2, 'tools/list');
+    const tools = await waitForRpc(client, 2, 'proxied tools/list response');
+    if (!Array.isArray(tools.result?.tools)) throw new Error(`unexpected tools/list response: ${JSON.stringify(tools)}`);
+    if (/\[ChromeLauncher\] Launching Chrome/.test(owner.stderrText)) throw new Error('tools/list triggered owner Chrome launch');
+    if (/\[ChromeLauncher\] Launching Chrome/.test(client.stderrText)) throw new Error('broker client launched Chrome before browser demand');
+
+    sendRpc(client, 3, 'tools/call', { name: 'tabs_context', arguments: { sessionId: 'lazy-a' } });
+    sendRpc(client, 4, 'tools/call', { name: 'tabs_context', arguments: { sessionId: 'lazy-b' } });
+    let firstUseA;
+    let firstUseB;
+    try {
+      [firstUseA, firstUseB] = await Promise.all([
+        waitForRpc(client, 3, 'first proxied browser response'),
+        waitForRpc(client, 4, 'second proxied browser response'),
+      ]);
+    } catch (error) {
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)}\n` +
+          `owner stderr:\n${owner.stderrText}\n` +
+          `client stderr:\n${client.stderrText}\n` +
+          `client stdout:\n${client.stdoutText}`,
+      );
+    }
+    if (firstUseA.error || firstUseA.result?.isError) {
+      throw new Error(`first browser call A failed: ${JSON.stringify(firstUseA)}\nowner stderr:\n${owner.stderrText}`);
+    }
+    if (firstUseB.error || firstUseB.result?.isError) {
+      throw new Error(`first browser call B failed: ${JSON.stringify(firstUseB)}\nowner stderr:\n${owner.stderrText}`);
+    }
+    await waitFor('owner Chrome ready after browser demand', () => /\[ChromeLauncher\] Chrome ready at/.test(owner.stderrText));
+    const ownerLaunchAttempts = countMatches(owner.stderrText, /\[ChromeLauncher\] Launching Chrome/g);
+    const clientLaunches = countMatches(client.stderrText, /\[ChromeLauncher\] Launching Chrome/g);
+    const firstDemandSignals = countMatches(owner.stderrText, /First browser\/CDP-requiring operation requested/g);
+    const coalescedConnects = countMatches(owner.stderrText, /Coalescing concurrent connect\(\) call/g);
+    const liveChromeRoots = liveManagedChromeRootCount(cdpPort);
+    if (ownerLaunchAttempts !== 1) throw new Error(`expected exactly one owner Chrome launch, saw ${ownerLaunchAttempts}\n${owner.stderrText}`);
+    if (clientLaunches !== 0) throw new Error(`broker client launched Chrome ${clientLaunches} time(s)\n${client.stderrText}`);
+    if (firstDemandSignals !== 1) throw new Error(`expected one first-demand transition, saw ${firstDemandSignals}\n${owner.stderrText}`);
+    if (coalescedConnects < 1) throw new Error(`concurrent first use did not coalesce\n${owner.stderrText}`);
+    if (liveChromeRoots !== null && liveChromeRoots !== 1) {
+      throw new Error(`expected one live managed Chrome root, saw ${liveChromeRoots}\n${owner.stderrText}`);
+    }
 
     const optedOut = start('optout', [...baseArgs, '--no-auto-elect'], env);
     children.push(optedOut);
     await waitFor('opt-out duplicate remediation', () => /Refusing to start a second direct controller/.test(optedOut.stderrText) || /Another OpenChrome controller/.test(optedOut.stderrText));
     if (/auto-elect: attaching as broker client/.test(optedOut.stderrText)) throw new Error('--no-auto-elect unexpectedly attached as broker client');
 
-    console.log(JSON.stringify({ ok: true, cdpPort, httpPort, ownerPid: owner.pid, brokerPid: metadata.pid, clientAttached: true, optOutPreservedFailFast: true }, null, 2));
+    console.log(JSON.stringify({
+      ok: true,
+      cdpPort,
+      httpPort,
+      ownerPid: owner.pid,
+      brokerPid: metadata.pid,
+      lazyOwnerRetainedThroughIdle: true,
+      clientAttachedBeforeChrome: true,
+      ownerLaunchAttempts,
+      clientLaunches,
+      firstDemandSignals,
+      coalescedConnects,
+      liveChromeRoots,
+      optOutPreservedFailFast: true,
+    }, null, 2));
   } finally {
     await terminate(children);
     rmSync(tmp, { recursive: true, force: true });

--- a/skills/openchrome/SKILL.md
+++ b/skills/openchrome/SKILL.md
@@ -41,7 +41,7 @@ openchrome setup               # Claude Code
 openchrome setup --client codex   # Codex CLI
 ```
 
-Restart your MCP client. Chrome auto-launches on the first tool call.
+Restart your MCP client. Chrome auto-launches on the first browser/CDP-requiring tool call; initialize, tools/list, and browser-free diagnostics do not launch it.
 
 ## First tool by intent
 

--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -80,6 +80,11 @@ export interface ConnectionEvent {
   error?: string;
 }
 
+export type InitialAutoLaunchFailureDisposition = 'consumed' | 'retryable';
+export type InitialAutoLaunchFailureHandler = (
+  error: unknown,
+) => InitialAutoLaunchFailureDisposition | void | Promise<InitialAutoLaunchFailureDisposition | void>;
+
 
 function parseEnvInt(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -129,6 +134,15 @@ export class CDPClient {
    * the probe's `false` and fail to launch.
    */
   private pendingConnectAutoLaunch: boolean | undefined = undefined;
+  /** True after an actual browser/CDP-requiring call requests managed launch semantics. */
+  private browserDemandStarted = false;
+  /** True after the first managed browser-demand connection succeeds. */
+  private initialAutoLaunchSucceeded = false;
+  /** Ensures startup ownership cleanup is invoked at most once for concurrent first use. */
+  private initialAutoLaunchFailureNotified = false;
+  /** Coalesces concurrent cleanup notifications without consuming retryable outcomes. */
+  private initialAutoLaunchFailureNotification: Promise<void> | null = null;
+  private initialAutoLaunchFailureHandler: InitialAutoLaunchFailureHandler | null = null;
   /** Invalidates stale async connection attempts that resolve after a reconnect. */
   private connectionGeneration = 0;
   /** Timestamp of last successful connection verification (heartbeat or active probe). */
@@ -178,6 +192,64 @@ export class CDPClient {
    */
   getConnectionState(): ConnectionState {
     return this.connectionState;
+  }
+
+  hasBrowserDemandStarted(): boolean {
+    return this.browserDemandStarted;
+  }
+
+  markManagedBrowserDemand(): void {
+    if (this.autoLaunch) {
+      this.beginManagedBrowserDemand();
+    }
+  }
+
+  setInitialAutoLaunchFailureHandler(handler: InitialAutoLaunchFailureHandler | null): void {
+    this.initialAutoLaunchFailureHandler = handler;
+  }
+
+  private beginManagedBrowserDemand(): void {
+    if (this.browserDemandStarted) return;
+    this.browserDemandStarted = true;
+    console.error(
+      `[CDPClient] First browser/CDP-requiring operation requested on port ${this.port}; ` +
+        'reusing a compatible endpoint when present, otherwise starting one managed Chrome. ' +
+        `A normal Chrome without --remote-debugging-port=${this.port} is not compatible and does not prevent the managed launch.`,
+    );
+  }
+
+  private async notifyInitialAutoLaunchFailure(error: unknown): Promise<void> {
+    if (
+      this.initialAutoLaunchSucceeded ||
+      this.initialAutoLaunchFailureNotified ||
+      !this.initialAutoLaunchFailureHandler
+    ) {
+      return;
+    }
+
+    if (this.initialAutoLaunchFailureNotification) {
+      await this.initialAutoLaunchFailureNotification;
+      return;
+    }
+
+    const notification = (async () => {
+      try {
+        const disposition = await this.initialAutoLaunchFailureHandler!(error);
+        if (disposition !== 'retryable') {
+          this.initialAutoLaunchFailureNotified = true;
+        }
+      } catch (handlerError) {
+        console.error('[CDPClient] Initial auto-launch failure handler failed:', handlerError);
+      }
+    })();
+    this.initialAutoLaunchFailureNotification = notification;
+    try {
+      await notification;
+    } finally {
+      if (this.initialAutoLaunchFailureNotification === notification) {
+        this.initialAutoLaunchFailureNotification = null;
+      }
+    }
   }
 
   /**
@@ -777,8 +849,6 @@ export class CDPClient {
           if (budget!.remaining() < DEFAULT_SESSION_INIT_MIN_ATTEMPT_MS) {
             budget!.requireRemaining(DEFAULT_SESSION_INIT_MIN_ATTEMPT_MS, 'connectInternal.post-attempt');
           }
-          // Invalidate launcher cache so next ensureChrome() re-checks via HTTP
-          launcher.invalidateInstance();
           // Backoff: up to 1s, but not more than the remaining budget minus one more attempt.
           const pauseMs = Math.max(0, Math.min(1000, budget!.remaining() - DEFAULT_SESSION_INIT_MIN_ATTEMPT_MS));
           console.error(`[CDPClient] connectInternal attempt ${attempt} failed (budget remaining=${budget!.remaining()}ms), retrying in ${pauseMs}ms: ${lastError.message}`);
@@ -787,9 +857,11 @@ export class CDPClient {
           }
         } else if (attempt < maxConnectRetries) {
           console.error(`[CDPClient] connectInternal attempt ${attempt}/${maxConnectRetries} failed, retrying in 1s: ${lastError.message}`);
-          // Invalidate launcher cache so next ensureChrome() re-checks via HTTP
-          launcher.invalidateInstance();
-          // Brief pause: TCP RST from the timeout needs time to reach Chrome's listener
+          // Keep the launcher instance so a transient Puppeteer/CDP attach
+          // failure retries the same Chrome endpoint instead of spawning a
+          // second managed browser. ensureChrome() still re-probes the cached
+          // endpoint on the next attempt and refreshes it if Chrome restarted.
+          // Brief pause: TCP RST from the timeout needs time to reach Chrome's listener.
           await new Promise(resolve => setTimeout(resolve, 1000));
         } else {
           throw lastError;
@@ -996,9 +1068,13 @@ export class CDPClient {
     // both end up with the same behavior coalesce, callers who would diverge
     // never silently inherit each other's choice.
     const effectiveAutoLaunch = autoLaunch ?? this.autoLaunch;
+    if (effectiveAutoLaunch) {
+      this.beginManagedBrowserDemand();
+    }
     if (this.browser && this.browser.isConnected()) {
       // Skip active probe if recently verified by heartbeat (avoids per-call overhead)
       if (Date.now() - this.lastVerifiedAt < DEFAULT_CONNECT_VERIFY_STALENESS_MS) {
+        if (effectiveAutoLaunch) this.initialAutoLaunchSucceeded = true;
         return;
       }
 
@@ -1018,17 +1094,23 @@ export class CDPClient {
           }),
         ]);
         this.lastVerifiedAt = Date.now();
+        if (effectiveAutoLaunch) this.initialAutoLaunchSucceeded = true;
         return;
       } catch {
         console.error('[CDPClient] Connection probe failed, reconnecting...');
-        // forceReconnect() internally pins connectInternal() to autoLaunch:false
-        // and does not accept an autoLaunch override; the caller's autoLaunch is
-        // intentionally NOT forwarded here. The probe-fail path therefore never
-        // auto-launches Chrome regardless of caller preference — Chrome must be
-        // re-attached by an explicit tool call, not by a heartbeat-triggered
-        // reconnect.
-        await this.forceReconnect({ budget });
-        return;
+        try {
+          // Heartbeat callers still omit autoLaunch and never reopen Chrome.
+          // An explicit browser-demand connect must preserve its managed-launch
+          // preference when a stale startup-probe attachment needs replacement.
+          await this.forceReconnect({ budget, autoLaunch: effectiveAutoLaunch });
+          if (effectiveAutoLaunch) this.initialAutoLaunchSucceeded = true;
+          return;
+        } catch (err) {
+          if (effectiveAutoLaunch) {
+            await this.notifyInitialAutoLaunchFailure(err);
+          }
+          throw err;
+        }
       }
     }
 
@@ -1065,10 +1147,14 @@ export class CDPClient {
         }
         this.lastVerifiedAt = Date.now();
         this.startHeartbeat();
+        if (effectiveAutoLaunch) this.initialAutoLaunchSucceeded = true;
         console.error('[CDPClient] Connected to Chrome');
       } catch (err) {
         if (this.isCurrentConnectionGeneration(generation)) {
           this.connectionState = 'disconnected';
+        }
+        if (effectiveAutoLaunch) {
+          await this.notifyInitialAutoLaunchFailure(err);
         }
         throw err;
       }
@@ -1095,8 +1181,9 @@ export class CDPClient {
    * post-reconnect operations from using orphaned page references that would
    * hang until protocolTimeout (30s).
    */
-  async forceReconnect(options?: { budget?: Budget }): Promise<void> {
+  async forceReconnect(options?: { budget?: Budget; autoLaunch?: boolean }): Promise<void> {
     const budget = options?.budget;
+    const autoLaunch = options?.autoLaunch ?? false;
     const generation = ++this.connectionGeneration;
     // Invalidate any in-flight connect() — we're replacing the connection entirely
     this.pendingConnect = null;
@@ -1131,9 +1218,9 @@ export class CDPClient {
     this.connectionState = 'reconnecting';
     this.lastVerifiedAt = 0;
     try {
-      // Do NOT auto-launch Chrome on heartbeat-triggered reconnect.
-      // If Chrome was closed, stay disconnected until the next tool call.
-      const connected = await this.connectInternal({ autoLaunch: false, budget, generation });
+      // Heartbeat-triggered callers omit autoLaunch and stay attach-only. An
+      // explicit first browser demand may opt into managed launch here.
+      const connected = await this.connectInternal({ autoLaunch, budget, generation });
       if (connected === false) {
         return;
       }

--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -13,7 +13,7 @@ import { DEFAULT_VIEWPORT, DEFAULT_CHROME_LAUNCH_TIMEOUT_MS, DEFAULT_RESTORE_LAS
 import type { WindowBoundsConfig } from '../config/window-bounds';
 import { getHeadedWindowArgs } from './launcher-window-args';
 import { findChromeHeadlessShell, findChromePath } from './launcher-chrome-paths';
-import { checkDebugPort, waitForDebugPort } from './launcher-debug-port';
+import { checkDebugPort, DebugPortTimeoutError, waitForDebugPort } from './launcher-debug-port';
 import { ProfileManager } from './profile-manager';
 import type { ProfileType } from './profile-manager';
 import { writeMarker, removeMarker } from './ownership-marker';
@@ -713,7 +713,15 @@ export class ChromeLauncher {
       diagnostics.push('  - Port conflict: another process is bound to port ' + port);
       diagnostics.push('  - Firewall/antivirus blocking localhost connections');
       diagnostics.push('  - Chrome 136+: requires --user-data-dir with --remote-debugging-port');
-      throw new Error(diagnostics.join('\n'));
+      const diagnosticMessage = diagnostics.join('\n');
+      if (err instanceof DebugPortTimeoutError) {
+        // Preserve the timeout type so startup policy can distinguish a slow,
+        // still-running Chrome from a terminal spawn failure while retaining
+        // the launcher diagnostics operators rely on.
+        err.message = diagnosticMessage;
+        throw err;
+      }
+      throw new Error(diagnosticMessage);
     }
     this.pendingProcess = null; // Success — no longer pending
 

--- a/src/chrome/startup-policy.ts
+++ b/src/chrome/startup-policy.ts
@@ -1,0 +1,18 @@
+export type ChromeStartupPolicy = 'disabled' | 'lazy' | 'eager';
+
+export function resolveChromeStartupPolicy(options: {
+  autoLaunch: boolean;
+  eagerStartup: boolean;
+}): ChromeStartupPolicy {
+  if (!options.autoLaunch) return 'disabled';
+  return options.eagerStartup ? 'eager' : 'lazy';
+}
+
+export function ownerHeartbeatRequiresChrome(
+  policy: ChromeStartupPolicy,
+  browserDemandStarted: boolean,
+): boolean {
+  if (policy === 'eager') return true;
+  if (policy === 'lazy') return browserDemandStarted;
+  return false;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,11 @@ import { getIdleState } from './utils/idle-state';
 import { getVersion } from './version';
 import { bootstrapPilot, logActiveFlags } from './harness/flags';
 import { ChromeProcessWatchdog } from './chrome/process-watchdog';
-import { releaseOwnerAfterStartupFailure, wireOwnerSelfRelease } from './chrome/owner-self-release';
+import {
+  releaseOwnerAfterStartupFailure,
+  wireOwnerSelfRelease,
+  type OwnerReleaseAttemptResult,
+} from './chrome/owner-self-release';
 import { TabHealthMonitor } from './cdp/tab-health-monitor';
 import { EventLoopMonitor, setGlobalEventLoopMonitor } from './watchdog/event-loop-monitor';
 import { HealthEndpoint, HealthData } from './watchdog/health-endpoint';
@@ -36,6 +40,7 @@ import { SessionStatePersistence } from './session-state-persistence';
 import { getCDPClient } from './cdp/client';
 import { getSessionManager } from './session-manager';
 import { getChromeLauncher } from './chrome/launcher';
+import { ownerHeartbeatRequiresChrome, resolveChromeStartupPolicy } from './chrome/startup-policy';
 import { ProfileManager } from './chrome/profile-manager';
 import { getBrowserStateManager } from './browser-state';
 import { getListenerErrorStats, installUnhandledRejectionSafetyNet } from './utils/safe-listener';
@@ -46,6 +51,7 @@ import {
   acquireControllerLockWithHealthCheck,
   formatDuplicateControllerMessage,
   startControllerHeartbeat,
+  type ControllerHeartbeatHandle,
   type ControllerLockHandle,
 } from './utils/controller-lock';
 import { fetchJsonVersion } from './chrome/devtools-info';
@@ -311,6 +317,14 @@ program
     }
     const transportMode = validModes.includes(rawMode) ? rawMode : 'stdio';
     const useHttp = transportMode === 'http' || transportMode === 'both';
+    const brokerOwner = Boolean(options.broker) || electBrokerOwner;
+    const startupPolicy = resolveChromeStartupPolicy({
+      autoLaunch,
+      // Ordinary stdio hosts and broker owners defer Chrome until browser
+      // demand. Standalone daemon transports keep the historical /ready
+      // contract that Chrome is available before traffic is admitted.
+      eagerStartup: Boolean(options.serverMode) || (useHttp && !brokerOwner),
+    });
     const lockUserDataDir = resolveControllerLockUserDataDir(userDataDir, useHeadlessShell);
 
     // #1359 P3a: the broker is the single CDP owner for a (port, userDataDir).
@@ -413,14 +427,7 @@ program
       }
     }
 
-    // #1474: while we own the lock, periodically refresh its heartbeat whenever
-    // our Chrome/CDP is reachable. This lets a contender distinguish a live
-    // owner that is briefly relaunching Chrome (heartbeat recent) from a true
-    // half-zombie (heartbeat stale beyond the grace), preventing split
-    // ownership during a legitimate relaunch.
-    const controllerHeartbeat = controllerLock
-      ? startControllerHeartbeat(controllerLock, async () => (await fetchJsonVersion(port)) !== null)
-      : null;
+    let controllerHeartbeat: ControllerHeartbeatHandle | null = null;
 
     process.on('exit', () => {
       try { controllerHeartbeat?.stop(); } catch { /* best-effort */ }
@@ -452,6 +459,7 @@ program
 
     console.error(`[openchrome] Chrome debugging port: ${port}`);
     console.error(`[openchrome] Auto-launch Chrome: ${autoLaunch}`);
+    console.error(`[openchrome] Chrome startup policy: ${startupPolicy}`);
     if (userDataDir) {
       console.error(`[openchrome] User data dir: ${userDataDir}`);
     }
@@ -634,6 +642,44 @@ program
 
     const server = getMCPServer();
     await registerAllTools(server);
+    const launcher = getChromeLauncher(port);
+    const cdpClient = getCDPClient();
+    const sessionManager = getSessionManager();
+
+    const releaseStartupOwnership = async (err: unknown): Promise<OwnerReleaseAttemptResult> => {
+      if (!controllerLock) return 'aborted';
+      return releaseOwnerAfterStartupFailure(err, {
+        releaseLock: () => {
+          if (options.broker || electBrokerOwner) removeBrokerMetadata(port, lockUserDataDir);
+          controllerLock?.release();
+          controllerLock = null;
+        },
+        exit: (code) => process.exit(code),
+        probeChromeReachable: async () => (await fetchJsonVersion(port)) !== null,
+      });
+    };
+
+    // Configure lazy first-use failure cleanup before any transport can accept
+    // a tool request. Matching concurrent first-use requests share one CDP
+    // connect promise, and CDPClient invokes this hook once for that attempt.
+    if (controllerLock && startupPolicy === 'lazy') {
+      cdpClient.setInitialAutoLaunchFailureHandler(async (err) => {
+        const result = await releaseStartupOwnership(err);
+        return result === 'inconclusive' ? 'retryable' : 'consumed';
+      });
+    }
+
+    // A lazy owner is healthy before browser demand even though no CDP endpoint
+    // exists yet. Once browser demand starts, heartbeat returns to the strict
+    // CDP reachability contract used for crash/relaunch ownership safety.
+    controllerHeartbeat = controllerLock
+      ? startControllerHeartbeat(controllerLock, async () => {
+          if (!ownerHeartbeatRequiresChrome(startupPolicy, cdpClient.hasBrowserDemandStarted())) {
+            return true;
+          }
+          return (await fetchJsonVersion(port)) !== null;
+        })
+      : null;
 
     // Dev-only hook: artificial delay for the tools component transition.
     // Gated: absent from production dist (see scripts/verify/A6-no-dev-hooks-in-dist.mjs).
@@ -725,6 +771,38 @@ program
     if (process.platform === 'win32') {
       process.on('SIGHUP', () => shutdown('SIGHUP'));
     }
+
+    // Modes with an explicit Chrome-ready startup contract enter this branch.
+    // Ordinary stdio and broker-owner `serve --auto-launch` remain lazy.
+    if (startupPolicy === 'eager') {
+      try {
+        await launcher.ensureChrome({ autoLaunch: true, port, userDataDir });
+      } catch (err) {
+        if (controllerLock) {
+          const releaseResult = await releaseStartupOwnership(err);
+          if (releaseResult === 'reachable') {
+            console.error('[openchrome] Chrome became reachable after the eager startup error; continuing startup.');
+          } else if (releaseResult === 'released') {
+            return;
+          } else {
+            console.error(
+              `[openchrome] Eager Chrome startup did not reach a ready state; refusing to open transports: ` +
+                `${err instanceof Error ? err.message : String(err)}`,
+            );
+            process.exit(1);
+            return;
+          }
+        } else {
+          console.error(
+            `[openchrome] Eager Chrome startup failed before transport startup: ` +
+              `${err instanceof Error ? err.message : String(err)}`,
+          );
+          process.exit(1);
+          return;
+        }
+      }
+    }
+
     // Resolve auth token: CLI flag takes precedence over env var.
     // Track which source supplied the token so the broker metadata can only
     // advertise `authTokenEnv` when the value actually lives in that env var
@@ -907,26 +985,6 @@ program
     }
 
     // ─── Self-Healing Module Wiring (#354) ──────────────────────────────────
-
-    const launcher = getChromeLauncher(port);
-    const cdpClient = getCDPClient();
-    const sessionManager = getSessionManager();
-
-    if (controllerLock && autoLaunch) {
-      launcher.ensureChrome({ autoLaunch: true, port, userDataDir }).catch((err: unknown) => {
-        releaseOwnerAfterStartupFailure(err, {
-          releaseLock: () => {
-            if (options.broker || electBrokerOwner) removeBrokerMetadata(port, lockUserDataDir);
-            controllerLock?.release();
-            controllerLock = null;
-          },
-          exit: (code) => process.exit(code),
-          probeChromeReachable: async () => (await fetchJsonVersion(port)) !== null,
-        }).catch((releaseErr: unknown) => {
-          console.error('[SelfHealing] Startup owner self-release failed:', releaseErr);
-        });
-      });
-    }
 
     // Readiness: wire chrome component via CDPClient connection events, then
     // proactively connect so daemon /ready probes can become ready before the

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -96,6 +96,7 @@ export { estimateOutputTokensFromChars, extractCacheStatus } from './mcp/output-
 import { estimateOutputTokensFromChars, extractCacheStatus } from './mcp/output-observability';
 import { isRunHarnessEnabled } from './run-harness/flags';
 import { extractRunId, getRunStore } from './run-harness/store';
+import { shouldInitializeBrowserSession } from './mcp/session-init-policy';
 
 function redactToolArgsForTelemetry(toolName: string, args: Record<string, unknown>): Record<string, unknown> {
   if (toolName === 'wait_for' && args.type === 'function' && typeof args.value === 'string') {
@@ -230,37 +231,6 @@ export function isConnectionError(error: unknown): boolean {
   const lowerMessage = message.toLowerCase();
   return patterns.some(pattern => lowerMessage.includes(pattern));
 }
-
-/** Lifecycle tools that must work even when the CDP connection is broken (e.g., after
- *  sleep/wake). Skip session initialization so recovery handlers can always run.
- *
- *  Task ledger tools (`oc_task_*`) are also listed here because they are pure
- *  ledger operations (or, for `oc_task_start`, just persist a meta row before
- *  background work begins). They never touch the browser themselves, so they
- *  must not trigger Chrome auto-launch on malformed input (#1034).
- *
- *  Run-harness tools (`oc_run_*`) and `oc_progress_status` are pure read /
- *  bookkeeping calls landed on develop after this PR branched — also skip. */
-const SKIP_SESSION_INIT_TOOLS = new Set([
-  'oc_stop',
-  'oc_reap_orphans',
-  'oc_profile_status',
-  'oc_session_snapshot',
-  'oc_session_resume',
-  'oc_journal',
-  'oc_task_start',
-  'oc_task_list',
-  'oc_task_get',
-  'oc_task_cancel',
-  'oc_task_wait',
-  'oc_task_update',
-  'oc_task_finish',
-  'oc_run_start',
-  'oc_run_status',
-  'oc_run_events',
-  'oc_run_finish',
-  'oc_progress_status',
-]);
 
 const RUN_HARNESS_LONG_TASK_TOOLS = new Set([
   'execute_plan',
@@ -1895,10 +1865,20 @@ export class MCPServer {
       }
     }
 
+    const requiresBrowserSession = shouldInitializeBrowserSession(toolName, substitutedArgs);
+    if (requiresBrowserSession) {
+      try {
+        getCDPClient().markManagedBrowserDemand();
+      } catch {
+        // CDP client may not be initialized yet; session initialization below
+        // still owns the actual connection attempt.
+      }
+    }
+
     // Reconnection wait — if Chrome is reconnecting, wait for it to complete
     // instead of rejecting immediately. This is server-level resilience, not orchestration.
     // Allow lifecycle tools that must work during disconnection (oc_stop, oc_session_resume, etc.)
-    if (!SKIP_SESSION_INIT_TOOLS.has(toolName)) try {
+    if (requiresBrowserSession) try {
       const cdpClient = getCDPClient();
       if (cdpClient.isReconnecting()) {
         console.error(`[MCPServer] Tool call "${toolName}" arrived during reconnection, waiting...`);
@@ -2003,7 +1983,7 @@ export class MCPServer {
       // Ensure session exists.
       // Use a longer timeout when autoLaunch is enabled because Chrome launch (up to 30s)
       // + puppeteer.connect (up to 15s) can exceed the default 30s session init timeout.
-      if (sessionId && !SKIP_SESSION_INIT_TOOLS.has(toolName)) {
+      if (sessionId && requiresBrowserSession) {
         const globalConfig = getGlobalConfig();
         const sessionInitTimeout = globalConfig.autoLaunch
           ? DEFAULT_SESSION_INIT_TIMEOUT_AUTO_LAUNCH_MS

--- a/src/mcp/session-init-policy.ts
+++ b/src/mcp/session-init-policy.ts
@@ -1,0 +1,122 @@
+/**
+ * Tools in this set must remain available without MCPServer eagerly creating
+ * a browser session. Most are diagnostics, lifecycle, orchestration metadata,
+ * or local artifact operations. A small number of lifecycle handlers may
+ * connect to Chrome themselves when their requested action requires it; the
+ * important contract here is that the generic pre-handler session bootstrap
+ * does not launch Chrome on their behalf.
+ */
+const SESSION_INIT_EXEMPT_TOOLS = new Set([
+  'expand_tools',
+
+  // Lifecycle and recovery surfaces that must work while CDP is unavailable.
+  'oc_stop',
+  'oc_reap_orphans',
+  'oc_profile_status',
+  'oc_session_snapshot',
+  'oc_session_resume',
+  'oc_journal',
+  'oc_checkpoint',
+
+  // Browser-free diagnostics and host integration.
+  'oc_connection_health',
+  'oc_doctor_report',
+  'oc_get_connection_info',
+  'oc_devtools_url',
+  'list_profiles',
+  'oc_normalize_action',
+  'oc_policy',
+  'oc_copy_to_clipboard',
+  'oc_open_host_settings',
+
+  // Local artifact, memory, and analysis operations.
+  'memory',
+  'image_qa',
+  'oc_assert',
+  'oc_diff',
+  'oc_evidence_bundle',
+  'oc_journal_compact',
+  'oc_output_fetch',
+  'oc_performance_analyze',
+  'oc_reflect',
+  'oc_skill_record',
+  'oc_skill_recall',
+  'oc_skill_export',
+  'oc_totp_generate',
+
+  // Recording metadata is local and can begin before the first browser call.
+  'oc_recording_start',
+  'oc_recording_stop',
+  'oc_recording_status',
+  'oc_recording_list',
+  'oc_recording_export',
+
+  // Persistent task/run ledgers never require Chrome directly.
+  'oc_task_start',
+  'oc_task_list',
+  'oc_task_get',
+  'oc_task_cancel',
+  'oc_task_wait',
+  'oc_task_update',
+  'oc_task_finish',
+  'oc_run_start',
+  'oc_run_status',
+  'oc_run_events',
+  'oc_run_finish',
+  'oc_progress_status',
+  'oc_task_run_start',
+  'oc_task_run_update',
+  'oc_task_run_checkpoint',
+  'oc_task_run_needs_help',
+  'oc_task_run_complete',
+  'oc_task_run_get',
+  'oc_task_run_list',
+
+  // Resumable crawl metadata. crawl_status is argument-sensitive below.
+  'crawl_start',
+  'crawl_cancel',
+
+  // Orchestration state and cleanup operate on existing workers/artifacts.
+  'workflow_status',
+  'workflow_collect',
+  'workflow_collect_partial',
+  'workflow_cleanup',
+  'worker_update',
+  'worker_complete',
+
+  // Lane inspection/cleanup must not create a new browser just to report or
+  // dispose existing state. oc_lane_create remains browser-requiring.
+  'oc_lane_list',
+  'oc_lane_get',
+  'oc_lane_close',
+
+  // Pilot-local control planes persist or mutate process-local state only.
+  'oc_credentials',
+  'oc_proxy_hook',
+  'oc_pilot_handoff_create',
+  'oc_pilot_handoff_redeem',
+]);
+
+function crawlStatusRequiresBrowser(args: Readonly<Record<string, unknown>>): boolean {
+  if (args.advance == null || !Number.isFinite(Number(args.advance))) {
+    // Match crawl_status's default-advance behavior: omitted/invalid values
+    // execute crawl work rather than acting as a read-only status call.
+    return true;
+  }
+  return Math.max(0, Math.floor(Number(args.advance))) > 0;
+}
+
+function workerRequiresBrowser(args: Readonly<Record<string, unknown>>): boolean {
+  // Missing required arguments are rejected before this policy is consulted.
+  // Unknown actions are handler errors and should not launch Chrome.
+  return args.action === 'create';
+}
+
+export function shouldInitializeBrowserSession(
+  toolName: string,
+  args: Readonly<Record<string, unknown>> = {},
+): boolean {
+  if (toolName === 'crawl_status') return crawlStatusRequiresBrowser(args);
+  if (toolName === 'worker') return workerRequiresBrowser(args);
+  return !SESSION_INIT_EXEMPT_TOOLS.has(toolName);
+}

--- a/tests/chrome/startup-policy.test.ts
+++ b/tests/chrome/startup-policy.test.ts
@@ -1,0 +1,29 @@
+import {
+  ownerHeartbeatRequiresChrome,
+  resolveChromeStartupPolicy,
+} from '../../src/chrome/startup-policy';
+
+describe('Chrome startup policy', () => {
+  test('normal --auto-launch is lazy', () => {
+    expect(resolveChromeStartupPolicy({ autoLaunch: true, eagerStartup: false })).toBe('lazy');
+  });
+
+  test('Chrome-ready daemon modes remain eager', () => {
+    expect(resolveChromeStartupPolicy({ autoLaunch: true, eagerStartup: true })).toBe('eager');
+  });
+
+  test('auto-launch off disables managed startup', () => {
+    expect(resolveChromeStartupPolicy({ autoLaunch: false, eagerStartup: false })).toBe('disabled');
+    expect(resolveChromeStartupPolicy({ autoLaunch: false, eagerStartup: true })).toBe('disabled');
+  });
+
+  test('lazy owners refresh lock heartbeat without Chrome until browser demand starts', () => {
+    expect(ownerHeartbeatRequiresChrome('lazy', false)).toBe(false);
+    expect(ownerHeartbeatRequiresChrome('lazy', true)).toBe(true);
+  });
+
+  test('eager owners always require Chrome health', () => {
+    expect(ownerHeartbeatRequiresChrome('eager', false)).toBe(true);
+    expect(ownerHeartbeatRequiresChrome('eager', true)).toBe(true);
+  });
+});

--- a/tests/integration/lazy-auto-launch.test.ts
+++ b/tests/integration/lazy-auto-launch.test.ts
@@ -1,0 +1,402 @@
+/// <reference types="jest" />
+
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import * as fs from 'fs';
+import * as net from 'net';
+import * as os from 'os';
+import * as path from 'path';
+
+import { OWNER_SELF_RELEASE_EXIT_CODE } from '../../src/chrome/owner-self-release';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const ENTRY = path.join(REPO_ROOT, 'dist', 'index.js');
+const HAS_BUILD = fs.existsSync(ENTRY);
+const describeFn = HAS_BUILD && process.platform !== 'win32' ? describe : describe.skip;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function allocatePort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('failed to allocate port');
+  await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  return address.port;
+}
+
+async function waitForLog(getLog: () => string, pattern: RegExp, timeoutMs = 20_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (pattern.test(getLog())) return;
+    await sleep(100);
+  }
+  throw new Error(`Timed out waiting for ${pattern}. stderr:\n${getLog()}`);
+}
+
+async function waitForExit(
+  child: ChildProcessWithoutNullStreams,
+  timeoutMs = 20_000,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return { code: child.exitCode, signal: child.signalCode };
+  }
+  return await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`child did not exit within ${timeoutMs}ms`)), timeoutMs);
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    });
+  });
+}
+
+async function terminate(child: ChildProcessWithoutNullStreams | null): Promise<void> {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+  child.kill('SIGTERM');
+  try {
+    await waitForExit(child, 5_000);
+  } catch {
+    child.kill('SIGKILL');
+    await waitForExit(child, 5_000).catch(() => undefined);
+  }
+}
+
+function jsonFileCount(dir: string): number {
+  if (!fs.existsSync(dir)) return 0;
+  return fs.readdirSync(dir).filter((name) => name.endsWith('.json')).length;
+}
+
+class StdioRpcClient {
+  private nextId = 1;
+  private buffer = '';
+  private pending = new Map<number, {
+    resolve: (value: Record<string, unknown>) => void;
+    reject: (error: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }>();
+
+  constructor(private readonly child: ChildProcessWithoutNullStreams) {
+    child.stdout.on('data', (chunk: Buffer) => {
+      this.buffer += chunk.toString('utf8');
+      const lines = this.buffer.split('\n');
+      this.buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        let message: Record<string, unknown>;
+        try {
+          message = JSON.parse(line) as Record<string, unknown>;
+        } catch {
+          continue;
+        }
+        const id = message.id;
+        if (typeof id !== 'number') continue;
+        const pending = this.pending.get(id);
+        if (!pending) continue;
+        clearTimeout(pending.timer);
+        this.pending.delete(id);
+        pending.resolve(message);
+      }
+    });
+    child.once('exit', (code, signal) => {
+      const error = new Error(`openchrome exited before RPC response (code=${code}, signal=${signal})`);
+      for (const pending of this.pending.values()) {
+        clearTimeout(pending.timer);
+        pending.reject(error);
+      }
+      this.pending.clear();
+    });
+  }
+
+  request(method: string, params: Record<string, unknown> = {}, timeoutMs = 15_000): Promise<Record<string, unknown>> {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Timed out waiting for ${method}`));
+      }, timeoutMs);
+      this.pending.set(id, { resolve, reject, timer });
+      this.child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+    });
+  }
+}
+
+describeFn('lazy --auto-launch process contract (#1528)', () => {
+  jest.setTimeout(60_000);
+
+  test('protocol and browser-free tools stay launch-free; first browser call launches once and releases failed owner', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-lazy-startup-'));
+    const home = path.join(tmp, 'home');
+    const userDataDir = path.join(tmp, 'profile');
+    const lockDir = path.join(tmp, 'locks');
+    const brokerDir = path.join(tmp, 'brokers');
+    const missingChrome = path.join(tmp, 'missing-chrome');
+    fs.mkdirSync(home, { recursive: true });
+    const [cdpPort, httpPort] = await Promise.all([allocatePort(), allocatePort()]);
+    let child: ChildProcessWithoutNullStreams | null = null;
+    let stderr = '';
+
+    try {
+      child = spawn(process.execPath, [
+        ENTRY,
+        'serve',
+        '--auto-launch',
+        '--headless',
+        '--port', String(cdpPort),
+        '--http', String(httpPort),
+        '--http-host', '127.0.0.1',
+        '--user-data-dir', userDataDir,
+        '--chrome-binary', missingChrome,
+      ], {
+        cwd: REPO_ROOT,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: {
+          ...process.env,
+          HOME: home,
+          OPENCHROME_CONTROLLER_LOCK_DIR: lockDir,
+          OPENCHROME_BROKER_REGISTRY_DIR: brokerDir,
+          OPENCHROME_PPID_WATCH: '0',
+          OPENCHROME_HEALTH_ENDPOINT: '0',
+          OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP: '1',
+          OPENCHROME_LOCK_HEARTBEAT_INTERVAL_MS: '1000',
+          OPENCHROME_MAX_RECONNECT_ATTEMPTS: '1',
+          OPENCHROME_PROCESS_WATCHDOG_INTERVAL_MS: '60000',
+          OPENCHROME_TAB_HEALTH_PROBE_INTERVAL_MS: '60000',
+          OPENCHROME_RECOVERY_LEDGER: '0',
+          CHROME_LAUNCH_TIMEOUT_MS: '1500',
+        },
+      });
+      child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
+      const rpc = new StdioRpcClient(child);
+
+      await waitForLog(() => stderr, /Broker metadata: .*\(auto-elected\)/);
+      expect(stderr).toContain('Chrome startup policy: lazy');
+      expect(stderr).not.toContain('[ChromeLauncher] Launching Chrome');
+      expect(child.exitCode).toBeNull();
+      expect(jsonFileCount(lockDir)).toBe(1);
+      expect(jsonFileCount(brokerDir)).toBe(1);
+
+      const initialize = await rpc.request('initialize', {
+        protocolVersion: '2024-11-05',
+        capabilities: { tools: { listChanged: true } },
+        clientInfo: { name: 'claude-code', version: 'test' },
+      });
+      expect(initialize.error).toBeUndefined();
+      expect((initialize.result as { serverInfo?: { name?: string } }).serverInfo?.name).toBe('openchrome');
+
+      const toolsList = await rpc.request('tools/list');
+      expect(toolsList.error).toBeUndefined();
+
+      const launchFreeCalls: Array<[string, Record<string, unknown>]> = [
+        ['expand_tools', { tier: '3' }],
+        ['oc_connection_health', {}],
+        ['oc_doctor_report', {}],
+        ['oc_get_connection_info', { host: 'openchrome' }],
+        ['list_profiles', { userDataDir }],
+        ['oc_normalize_action', { action: { type: 'click', x: 1, y: 1 } }],
+        ['oc_policy', { action: 'matrix' }],
+        ['oc_assert', {
+          contract: { kind: 'url', pattern: '^https://example\\.test/?$' },
+          evidence: { snapshot: { url: 'https://example.test' } },
+        }],
+        ['oc_devtools_url', {}],
+        ['memory', { action: 'query', domain: 'example.test' }],
+        ['workflow_status', {}],
+        ['worker', { action: 'list' }],
+      ];
+      for (const [name, args] of launchFreeCalls) {
+        const response = await rpc.request('tools/call', { name, arguments: args });
+        expect(response.error).toBeUndefined();
+        expect(response.result).toBeDefined();
+        expect(child.exitCode).toBeNull();
+      }
+
+      const crawlStart = await rpc.request('tools/call', {
+        name: 'crawl_start',
+        arguments: { url: 'https://example.test', max_pages: 1 },
+      });
+      const crawlStartContent = (crawlStart.result as { content?: Array<{ text?: string }> }).content;
+      const crawlPayload = JSON.parse(crawlStartContent?.[0]?.text ?? '{}') as { jobId?: string };
+      expect(crawlPayload.jobId).toBeDefined();
+
+      for (const [name, args] of [
+        ['crawl_status', { jobId: crawlPayload.jobId, advance: 0 }],
+        ['crawl_cancel', { jobId: crawlPayload.jobId }],
+      ] as Array<[string, Record<string, unknown>]>) {
+        const response = await rpc.request('tools/call', { name, arguments: args });
+        expect(response.error).toBeUndefined();
+        expect(response.result).toBeDefined();
+        expect(child.exitCode).toBeNull();
+      }
+
+      expect(stderr).not.toContain('[ChromeLauncher] Launching Chrome');
+      expect(stderr).not.toContain('First browser/CDP-requiring operation requested');
+
+      const navigateResponse = rpc.request('tools/call', {
+        name: 'navigate',
+        arguments: { url: 'about:blank' },
+      }).catch(() => null);
+      const exit = await waitForExit(child, 20_000);
+      await navigateResponse;
+
+      expect(exit.code).toBe(OWNER_SELF_RELEASE_EXIT_CODE);
+      expect((stderr.match(/\[ChromeLauncher\] Launching Chrome/g) ?? []).length).toBe(1);
+      expect((stderr.match(/First browser\/CDP-requiring operation requested/g) ?? []).length).toBe(1);
+      expect(stderr).toContain('Startup Chrome launch failed after controller lock acquisition');
+      expect(stderr).toContain('releasing controller lock and exiting');
+      expect(jsonFileCount(lockDir)).toBe(0);
+      expect(jsonFileCount(brokerDir)).toBe(0);
+    } finally {
+      await terminate(child);
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('--server-mode remains eager and attempts Chrome before opening the transport', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-eager-startup-'));
+    const home = path.join(tmp, 'home');
+    const lockDir = path.join(tmp, 'locks');
+    const userDataDir = path.join(tmp, 'profile');
+    const missingChrome = path.join(tmp, 'missing-chrome');
+    fs.mkdirSync(home, { recursive: true });
+    const cdpPort = await allocatePort();
+    let child: ChildProcessWithoutNullStreams | null = null;
+    let stderr = '';
+
+    try {
+      child = spawn(process.execPath, [
+        ENTRY,
+        'serve',
+        '--server-mode',
+        '--no-auto-elect',
+        '--port', String(cdpPort),
+        '--user-data-dir', userDataDir,
+        '--chrome-binary', missingChrome,
+      ], {
+        cwd: REPO_ROOT,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: {
+          ...process.env,
+          HOME: home,
+          OPENCHROME_CONTROLLER_LOCK_DIR: lockDir,
+          OPENCHROME_PPID_WATCH: '0',
+          OPENCHROME_HEALTH_ENDPOINT: '0',
+          OPENCHROME_RECOVERY_LEDGER: '0',
+          CHROME_LAUNCH_TIMEOUT_MS: '1500',
+        },
+      });
+      child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
+
+      const exit = await waitForExit(child, 20_000);
+      expect(exit.code).toBe(OWNER_SELF_RELEASE_EXIT_CODE);
+      expect(stderr).toContain('Chrome startup policy: eager');
+      expect(stderr).toContain('[ChromeLauncher] Launching Chrome');
+      expect(stderr).not.toContain('STDIO transport enabled');
+      expect(jsonFileCount(lockDir)).toBe(0);
+    } finally {
+      await terminate(child);
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('eager startup does not open a transport after an inconclusive debug-port timeout', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-eager-timeout-'));
+    const home = path.join(tmp, 'home');
+    const lockDir = path.join(tmp, 'locks');
+    const userDataDir = path.join(tmp, 'profile');
+    const slowChrome = path.join(tmp, 'slow-chrome.sh');
+    fs.mkdirSync(home, { recursive: true });
+    fs.writeFileSync(slowChrome, '#!/bin/sh\nsleep 5\n', { mode: 0o755 });
+    const cdpPort = await allocatePort();
+    let child: ChildProcessWithoutNullStreams | null = null;
+    let stderr = '';
+
+    try {
+      child = spawn(process.execPath, [
+        ENTRY,
+        'serve',
+        '--server-mode',
+        '--no-auto-elect',
+        '--port', String(cdpPort),
+        '--user-data-dir', userDataDir,
+        '--chrome-binary', slowChrome,
+      ], {
+        cwd: REPO_ROOT,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: {
+          ...process.env,
+          HOME: home,
+          OPENCHROME_CONTROLLER_LOCK_DIR: lockDir,
+          OPENCHROME_PPID_WATCH: '0',
+          OPENCHROME_HEALTH_ENDPOINT: '0',
+          OPENCHROME_RECOVERY_LEDGER: '0',
+          CHROME_LAUNCH_TIMEOUT_MS: '300',
+        },
+      });
+      child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
+
+      const exit = await waitForExit(child, 20_000);
+      expect(exit.code).not.toBe(0);
+      expect(stderr).toContain('Chrome debug port');
+      expect(stderr).toContain('Startup Chrome launch timed out; keeping ownership');
+      expect(stderr).not.toContain('STDIO transport enabled');
+      expect(jsonFileCount(lockDir)).toBe(0);
+    } finally {
+      await terminate(child);
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('standalone HTTP mode preserves Chrome-ready eager startup', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-http-eager-startup-'));
+    const home = path.join(tmp, 'home');
+    const lockDir = path.join(tmp, 'locks');
+    const userDataDir = path.join(tmp, 'profile');
+    const missingChrome = path.join(tmp, 'missing-chrome');
+    fs.mkdirSync(home, { recursive: true });
+    const [cdpPort, httpPort] = await Promise.all([allocatePort(), allocatePort()]);
+    let child: ChildProcessWithoutNullStreams | null = null;
+    let stderr = '';
+
+    try {
+      child = spawn(process.execPath, [
+        ENTRY,
+        'serve',
+        '--auto-launch',
+        '--no-auto-elect',
+        '--http', String(httpPort),
+        '--http-host', '127.0.0.1',
+        '--port', String(cdpPort),
+        '--user-data-dir', userDataDir,
+        '--chrome-binary', missingChrome,
+      ], {
+        cwd: REPO_ROOT,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: {
+          ...process.env,
+          HOME: home,
+          OPENCHROME_CONTROLLER_LOCK_DIR: lockDir,
+          OPENCHROME_PPID_WATCH: '0',
+          OPENCHROME_HEALTH_ENDPOINT: '0',
+          OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP: '1',
+          OPENCHROME_RECOVERY_LEDGER: '0',
+          CHROME_LAUNCH_TIMEOUT_MS: '1500',
+        },
+      });
+      child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
+
+      const exit = await waitForExit(child, 20_000);
+      expect(exit.code).toBe(OWNER_SELF_RELEASE_EXIT_CODE);
+      expect(stderr).toContain('Chrome startup policy: eager');
+      expect(stderr).toContain('[ChromeLauncher] Launching Chrome');
+      expect(stderr).not.toContain('HTTP transport enabled');
+      expect(jsonFileCount(lockDir)).toBe(0);
+    } finally {
+      await terminate(child);
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/mcp/session-init-policy.test.ts
+++ b/tests/mcp/session-init-policy.test.ts
@@ -1,0 +1,82 @@
+import { shouldInitializeBrowserSession } from '../../src/mcp/session-init-policy';
+
+describe('MCP browser session initialization policy', () => {
+  test.each([
+    'expand_tools',
+    'oc_connection_health',
+    'oc_doctor_report',
+    'oc_get_connection_info',
+    'oc_devtools_url',
+    'list_profiles',
+    'oc_normalize_action',
+    'oc_policy',
+    'oc_copy_to_clipboard',
+    'oc_open_host_settings',
+    'memory',
+    'image_qa',
+    'oc_assert',
+    'oc_diff',
+    'oc_evidence_bundle',
+    'oc_output_fetch',
+    'oc_performance_analyze',
+    'oc_reflect',
+    'oc_skill_record',
+    'oc_skill_recall',
+    'oc_skill_export',
+    'oc_totp_generate',
+    'oc_recording_start',
+    'oc_task_run_start',
+    'crawl_start',
+    'crawl_cancel',
+    'workflow_status',
+    'workflow_collect',
+    'workflow_collect_partial',
+    'workflow_cleanup',
+    'worker_update',
+    'worker_complete',
+    'oc_lane_list',
+    'oc_lane_get',
+    'oc_lane_close',
+    'oc_credentials',
+    'oc_proxy_hook',
+    'oc_pilot_handoff_create',
+    'oc_pilot_handoff_redeem',
+  ])('%s stays launch-free', (toolName) => {
+    expect(shouldInitializeBrowserSession(toolName)).toBe(false);
+  });
+
+  test.each([
+    'navigate',
+    'tabs_create',
+    'read_page',
+    'oc_vitals',
+    'oc_performance_insights',
+  ])('%s requires a browser session', (toolName) => {
+    expect(shouldInitializeBrowserSession(toolName)).toBe(true);
+  });
+
+  test('unknown tools default to browser-session initialization', () => {
+    expect(shouldInitializeBrowserSession('future_browser_tool')).toBe(true);
+  });
+
+  test.each([
+    [{ advance: 0 }, false],
+    [{ advance: -1 }, false],
+    [{ advance: '0' }, false],
+    [{ advance: 1 }, true],
+    [{ advance: '2' }, true],
+    [{}, true],
+    [{ advance: 'not-a-number' }, true],
+  ])('crawl_status args %j require browser=%s', (args, expected) => {
+    expect(shouldInitializeBrowserSession('crawl_status', args)).toBe(expected);
+  });
+
+  test.each([
+    ['create', true],
+    ['list', false],
+    ['delete', false],
+    ['unknown', false],
+  ])('worker action %s requires browser=%s', (action, expected) => {
+    expect(shouldInitializeBrowserSession('worker', { action })).toBe(expected);
+  });
+});

--- a/tests/src/cdp-connect-coalescing.test.ts
+++ b/tests/src/cdp-connect-coalescing.test.ts
@@ -55,6 +55,7 @@ function createMockBrowser(wsEndpoint = 'ws://localhost:9222/devtools/browser/ab
     on: jest.fn(),
     removeAllListeners: jest.fn(),
     disconnect: jest.fn().mockResolvedValue(undefined),
+    version: jest.fn().mockResolvedValue('Chrome/1'),
     targets: jest.fn().mockReturnValue([]),
     pages: jest.fn().mockResolvedValue([]),
   };
@@ -309,6 +310,169 @@ describe('CDPClient – connection coalescing', () => {
     expect(connectInternalSpy).toHaveBeenCalledTimes(1);
     stopHeartbeat(client);
   });
+
+  test('tracks browser demand only for managed auto-launch calls', async () => {
+    const client = new CDPClient({ port: 9222, autoLaunch: true });
+
+    jest.spyOn(client as any, 'connectInternal').mockImplementation(async () => {
+      (client as any).browser = createMockBrowser();
+      (client as any).connectionState = 'connected';
+    });
+
+    await client.connect({ autoLaunch: false });
+    expect(client.hasBrowserDemandStarted()).toBe(false);
+
+    await client.connect({ autoLaunch: true });
+    expect(client.hasBrowserDemandStarted()).toBe(true);
+    stopHeartbeat(client);
+  });
+
+  test('does not trust an unverified startup-probe attachment as successful first use', async () => {
+    const managedClient = new CDPClient({ port: 9222, autoLaunch: true });
+    const attachOnlyClient = new CDPClient({ port: 9223, autoLaunch: false });
+    const failureHandler = jest.fn().mockResolvedValue(undefined);
+    const logSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    managedClient.setInitialAutoLaunchFailureHandler(failureHandler);
+    (managedClient as any).browser = createMockBrowser();
+    (managedClient as any).connectionState = 'connected';
+
+    managedClient.markManagedBrowserDemand();
+    managedClient.markManagedBrowserDemand();
+    attachOnlyClient.markManagedBrowserDemand();
+
+    expect(managedClient.hasBrowserDemandStarted()).toBe(true);
+    expect(attachOnlyClient.hasBrowserDemandStarted()).toBe(false);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('normal Chrome without --remote-debugging-port=9222'));
+    logSpy.mockRestore();
+
+    (managedClient as any).browser = null;
+    (managedClient as any).connectionState = 'disconnected';
+    jest.spyOn(managedClient as any, 'connectInternal').mockRejectedValue(new Error('later reconnect failed'));
+
+    await expect(managedClient.connect()).rejects.toThrow('later reconnect failed');
+    expect(failureHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test('coalesced first-use failure invokes startup cleanup exactly once', async () => {
+    const client = new CDPClient({ port: 9222, autoLaunch: true });
+    const failureHandler = jest.fn().mockResolvedValue(undefined);
+    client.setInitialAutoLaunchFailureHandler(failureHandler);
+
+    jest.spyOn(client as any, 'connectInternal').mockRejectedValue(new Error('managed launch failed'));
+
+    const results = await Promise.allSettled(Array.from({ length: 5 }, () => client.connect()));
+
+    expect(results.every((result) => result.status === 'rejected')).toBe(true);
+    expect(client.hasBrowserDemandStarted()).toBe(true);
+    expect(failureHandler).toHaveBeenCalledTimes(1);
+    expect(failureHandler).toHaveBeenCalledWith(expect.objectContaining({ message: 'managed launch failed' }));
+  });
+
+  test('startup probe failure does not consume the managed first-use failure hook', async () => {
+    const client = new CDPClient({ port: 9222, autoLaunch: true });
+    const failureHandler = jest.fn().mockResolvedValue(undefined);
+    client.setInitialAutoLaunchFailureHandler(failureHandler);
+
+    const connectInternalSpy = jest.spyOn(client as any, 'connectInternal')
+      .mockRejectedValueOnce(new Error('startup probe found no Chrome'))
+      .mockRejectedValueOnce(new Error('managed launch failed'));
+
+    await expect(client.connect({ autoLaunch: false })).rejects.toThrow('startup probe found no Chrome');
+    expect(client.hasBrowserDemandStarted()).toBe(false);
+    expect(failureHandler).not.toHaveBeenCalled();
+
+    await expect(client.connect({ autoLaunch: true })).rejects.toThrow('managed launch failed');
+    expect(connectInternalSpy).toHaveBeenCalledTimes(2);
+    expect(failureHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test('retryable first-use cleanup can run again after an inconclusive launch timeout', async () => {
+    const client = new CDPClient({ port: 9222, autoLaunch: true });
+    const failureHandler = jest.fn()
+      .mockResolvedValueOnce('retryable')
+      .mockResolvedValueOnce('consumed');
+    client.setInitialAutoLaunchFailureHandler(failureHandler);
+
+    const connectInternalSpy = jest.spyOn(client as any, 'connectInternal')
+      .mockRejectedValueOnce(new Error('launch timed out'))
+      .mockRejectedValueOnce(new Error('terminal launch failure'));
+
+    await expect(client.connect()).rejects.toThrow('launch timed out');
+    await expect(client.connect()).rejects.toThrow('terminal launch failure');
+
+    expect(connectInternalSpy).toHaveBeenCalledTimes(2);
+    expect(failureHandler).toHaveBeenCalledTimes(2);
+  });
+
+  test('first browser demand replaces a stale startup-probe connection with managed launch', async () => {
+    const client = new CDPClient({ port: 9222, autoLaunch: true });
+    const staleBrowser = createMockBrowser('ws://stale');
+    staleBrowser.version.mockRejectedValue(new Error('stale startup probe'));
+    const managedBrowser = createMockBrowser('ws://managed');
+    const connectInternalSpy = jest.spyOn(client as any, 'connectInternal')
+      .mockImplementationOnce(async () => {
+        (client as any).browser = staleBrowser;
+        (client as any).connectionState = 'connected';
+      })
+      .mockImplementationOnce(async (options?: unknown) => {
+        expect((options as { autoLaunch?: boolean }).autoLaunch).toBe(true);
+        (client as any).browser = managedBrowser;
+        (client as any).connectionState = 'connected';
+      });
+
+    await client.connect({ autoLaunch: false });
+    (client as any).lastVerifiedAt = 0;
+    await client.connect({ autoLaunch: true });
+
+    expect(connectInternalSpy).toHaveBeenCalledTimes(2);
+    expect(staleBrowser.disconnect).toHaveBeenCalled();
+    expect((client as any).browser).toBe(managedBrowser);
+    stopHeartbeat(client);
+  });
+
+  test('failed managed reconnect after a stale startup probe invokes startup cleanup', async () => {
+    const client = new CDPClient({ port: 9222, autoLaunch: true });
+    const failureHandler = jest.fn().mockResolvedValue('consumed');
+    client.setInitialAutoLaunchFailureHandler(failureHandler);
+    const staleBrowser = createMockBrowser('ws://stale');
+    staleBrowser.version.mockRejectedValue(new Error('stale startup probe'));
+    const connectInternalSpy = jest.spyOn(client as any, 'connectInternal')
+      .mockImplementationOnce(async () => {
+        (client as any).browser = staleBrowser;
+        (client as any).connectionState = 'connected';
+      })
+      .mockRejectedValueOnce(new Error('managed reconnect failed'));
+
+    await client.connect({ autoLaunch: false });
+    (client as any).lastVerifiedAt = 0;
+    client.markManagedBrowserDemand();
+    await expect(client.connect({ autoLaunch: true })).rejects.toThrow('managed reconnect failed');
+
+    expect(connectInternalSpy.mock.calls[1][0]).toMatchObject({ autoLaunch: true });
+    expect(failureHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test('a successful managed first use suppresses later startup-failure cleanup', async () => {
+    const client = new CDPClient({ port: 9222, autoLaunch: true });
+    const failureHandler = jest.fn().mockResolvedValue(undefined);
+    client.setInitialAutoLaunchFailureHandler(failureHandler);
+
+    const connectInternalSpy = jest.spyOn(client as any, 'connectInternal')
+      .mockImplementationOnce(async () => {
+        (client as any).browser = createMockBrowser();
+        (client as any).connectionState = 'connected';
+      })
+      .mockRejectedValueOnce(new Error('later reconnect failed'));
+
+    await client.connect();
+    stopHeartbeat(client);
+    (client as any).browser = null;
+    (client as any).connectionState = 'disconnected';
+
+    await expect(client.connect()).rejects.toThrow('later reconnect failed');
+    expect(failureHandler).not.toHaveBeenCalled();
+  });
 });
 
 describe('CDPClient – puppeteer.connect timeout', () => {
@@ -362,6 +526,25 @@ describe('CDPClient – puppeteer.connect timeout', () => {
         protocolTimeout: expect.any(Number),
       })
     );
+  });
+
+  test('transient managed attach failure retries without invalidating the ready Chrome instance', async () => {
+    const client = new CDPClient({ port: 9222, autoLaunch: true });
+    const invalidateInstance = jest.fn();
+    const launcherMock = require('../../src/chrome/launcher');
+    launcherMock.getChromeLauncher.mockReturnValue({
+      ensureChrome: mockEnsureChrome,
+      invalidateInstance,
+    });
+    mockPuppeteerConnect
+      .mockRejectedValueOnce(new Error('Target.getBrowserContexts: Target closed'))
+      .mockResolvedValueOnce(createMockBrowser());
+
+    await (client as any).connectInternal({ autoLaunch: true });
+
+    expect(mockEnsureChrome).toHaveBeenCalledTimes(2);
+    expect(invalidateInstance).not.toHaveBeenCalled();
+    stopHeartbeat(client);
   });
 });
 


### PR DESCRIPTION
## Direction review

This is necessary for the real-Chrome lifecycle pillar in #1359: ordinary MCP startup should not create a surprise blank Chrome window, while explicit daemon/server modes must retain eager readiness. The implementation keeps OpenChrome a host-neutral MCP harness and changes no tool semantics after browser demand begins.

## What changed

- ordinary stdio and auto-elect owner startup stay browser-free until a browser/CDP-requiring tool arrives;
- explicit `--server-mode` and standalone HTTP remain eager;
- browser-free session-init policy is centralized and covered for contract, policy, discovery, recording, task, workflow, and local utility calls;
- concurrent first demand coalesces to one owner launch;
- transient attach retries reuse the same managed Chrome;
- failed or inconclusive first startup releases ownership without consuming retryable cleanup;
- a stale startup probe is actively verified before first-demand success is recorded.

## Verification

- `npm run build`
- 94 focused startup/CDP/process integration tests after rebasing onto current `main`
- three repeated two-client auto-elect smokes: owner launch attempts 1, client launches 0, first-demand signals 1, coalesced connects 1, live Chrome roots 1
- `lint:tier`, `lint:tool-schemas`, capability-map check, `git diff --check`
- independent code review: APPROVE

Closes #1528