### PR TITLE
bench: add a fail-closed browser-rs-mcp competitor adapter

### DIFF
--- a/benchmark/COMPETITORS.md
+++ b/benchmark/COMPETITORS.md
@@ -33,9 +33,17 @@ they are not reproducible here. See Epic #1254 "Non-goals".
 | Playwright | `playwright` | `1.60.0` | — | 2026-05-18 smoke runtime | #A #C #D #E |
 | Puppeteer | `puppeteer-core` / `rebrowser-puppeteer-core` | `23.10.3` | — | 2026-05-18 smoke runtime | #C #D #E #F |
 | playwright-mcp | `@playwright/mcp` | `0.0.75` | `8116437ffcfee1309cebc07dd30cee37720d2d19` | 2026-05-15 | #A #B #F #1299-future-live |
+| browser-rs-mcp | external binary `browser-rs` via `BROWSER_RS_BIN` | `0.1.13` | `6efa54fe428f1203967a9c760a27d0647d5474ee` | 2026-07-27 release asset, Apache-2.0, SHA-256: linux-x64 `ae0e4f5d2a4e6a90a0f050c50a55fcb86aab7cdda7d1ea2fec1aa54a321e3f1c`; macos-arm64 `618c75dc4f9c3297ba85d4e1ddaa9aaf67a671bc8abb393e1f64523dc084b310` | #A diagnostic smoke only |
 | browser-use | `browser-use` (PyPI) | `0.12.6` | `329c67f069427e928ff81ad52415efdca7692007` | 2026-05-15 | #A #B #D #E |
 | Crawlee | `crawlee` | `3.16.0` | `6c9cd2ff7e7d89ce7685e67f3f919f3cce0fa7a4` | 2026-05-15 | #A #C |
 | Online-Mind2Web | HuggingFace dataset `osunlp/Online-Mind2Web` (CC-BY 4.0) | dataset commit `7ab0fc3b5e0420f6a74c4e0f0faebc1f3eddb0c1` | `7ab0fc3b5e0420f6a74c4e0f0faebc1f3eddb0c1` | TBD-by-runner-PR | #B (future — Part 2 of #1427) |
+
+The `browser-rs-mcp` diagnostic adapter is stdio-only. Before a live row it
+resolves `BROWSER_RS_BIN` to one canonical executable and uses that exact path
+for version, digest, and process launch. It also requires a discoverable
+Chrome/Chromium (or a live configured CDP endpoint), rejects locked browser-rs
+profiles, and rejects `--port` / `AB_HTTP` because those settings switch the
+competitor to HTTP instead of the benchmark's MCP stdio contract.
 
 ## Tokenizer
 

--- a/benchmark/COMPETITORS.md
+++ b/benchmark/COMPETITORS.md
@@ -40,10 +40,17 @@ they are not reproducible here. See Epic #1254 "Non-goals".
 
 The `browser-rs-mcp` diagnostic adapter is stdio-only. Before a live row it
 resolves `BROWSER_RS_BIN` to one canonical executable and uses that exact path
-for version, digest, and process launch. It also requires a discoverable
-Chrome/Chromium (or a live configured CDP endpoint), rejects locked browser-rs
-profiles, and rejects `--port` / `AB_HTTP` because those settings switch the
-competitor to HTTP instead of the benchmark's MCP stdio contract.
+for digest, version, and process launch, with SHA-256 verified before the
+binary is executed. It also forwards the exact approved Chrome/profile through
+browser-rs' `AB_CHROME` / `AB_PROFILE` contract, rejects locked profiles, and
+rejects `--port` / `AB_HTTP` because those settings switch the competitor to
+HTTP instead of the benchmark's MCP stdio contract.
+
+Pinned browser-rs v0.1.13 reduces `--connect <url>` to a local port before it
+attaches. The adapter therefore accepts only an explicit `127.0.0.1` CDP
+endpoint (or a numeric local port), probes that exact endpoint, and rejects
+remote hosts, alternate protocols, credentials, and paths instead of risking
+a smoke run against an unrelated local Chrome.
 
 ## Tokenizer
 

--- a/tests/benchmark/adapters/browser-rs-mcp-adapter.test.ts
+++ b/tests/benchmark/adapters/browser-rs-mcp-adapter.test.ts
@@ -5,6 +5,8 @@ import {
   BROWSER_RS_PIN,
   BrowserRsMcpAdapter,
   BrowserRsMcpTransport,
+  SubprocessBrowserRsMcpTransport,
+  browserRsSpawnEnv,
   preflightBrowserRsBinary,
 } from './browser-rs-mcp-adapter';
 import { MCPToolResult } from '../benchmark-runner';
@@ -141,6 +143,7 @@ describe('preflightBrowserRsBinary', () => {
     profileConflict: () => false,
     execVersion: () => 'browser-rs 0.1.13',
     hashFile: () => goodSha,
+    resolveChromeVersion: () => 'Google Chrome 150.0.7871.187',
   };
 
   test('reports unsupported platform before binary checks', () => {
@@ -171,14 +174,16 @@ describe('preflightBrowserRsBinary', () => {
   });
 
   test('fails closed on SHA mismatch', () => {
+    const execVersion = jest.fn(() => 'browser-rs 0.1.13');
     const result = preflightBrowserRsBinary({
       ...runnableDefaults,
       binaryPath: '/tmp/browser-rs',
-      execVersion: () => 'browser-rs 0.1.13',
+      execVersion,
       hashFile: () => '0'.repeat(64),
     });
     expect(result.status).toBe('sha_mismatch');
     expect(result.expectedSha256).toBe(goodSha);
+    expect(execVersion).not.toHaveBeenCalled();
   });
 
   test('accepts the pinned version and platform digest', () => {
@@ -194,6 +199,7 @@ describe('preflightBrowserRsBinary', () => {
     expect(result.binaryPath).toBe('/canonical/browser-rs');
     expect(result.command).toEqual(['/canonical/browser-rs']);
     expect(result.chromePath).toBe('/canonical/google-chrome');
+    expect(result.chromeVersion).toBe('Google Chrome 150.0.7871.187');
   });
 
   test('uses the same canonical binary path for version, digest, and execution metadata', () => {
@@ -214,8 +220,8 @@ describe('preflightBrowserRsBinary', () => {
     expect(result.status).toBe('ok');
     expect(result.command).toEqual(['/opt/browser-rs/bin/browser-rs']);
     expect(observed).toEqual([
-      'version:/opt/browser-rs/bin/browser-rs',
       'hash:/opt/browser-rs/bin/browser-rs',
+      'version:/opt/browser-rs/bin/browser-rs',
     ]);
   });
 
@@ -234,7 +240,7 @@ describe('preflightBrowserRsBinary', () => {
       ...runnableDefaults,
       binaryPath: '/tmp/browser-rs',
       execVersion: () => 'browser-rs 0.1.12',
-      hashFile: () => '0'.repeat(64),
+      hashFile: () => goodSha,
       resolveChrome: () => null,
     });
     expect(result.status).toBe('version_mismatch');
@@ -267,16 +273,40 @@ describe('preflightBrowserRsBinary', () => {
       ...runnableDefaults,
       binaryPath: '/tmp/browser-rs',
       args: ['--connect', '9222'],
-      connectProbe: () => false,
+      connectProbe: (target) => ({
+        ok: false,
+        endpoint: target.endpoint,
+        browserVersion: '',
+        message: 'unavailable',
+      }),
     });
     expect(result.status).toBe('port_conflict');
     expect(result.connectPort).toBe(9222);
   });
 
+  test('rejects a remote CDP URL that browser-rs would silently replace with loopback', () => {
+    const connectProbe = jest.fn();
+    const result = preflightBrowserRsBinary({
+      ...runnableDefaults,
+      binaryPath: '/tmp/browser-rs',
+      args: ['--connect', 'http://chrome.internal:9333'],
+      connectProbe,
+    });
+    expect(result.status).toBe('port_conflict');
+    expect(result.connectEndpoint).toBe('http://chrome.internal:9333/');
+    expect(result.message).toContain('discards the --connect host');
+    expect(connectProbe).not.toHaveBeenCalled();
+  });
+
   test('uses a configured CDP URL without requiring local Chrome or a profile', () => {
     const resolveChrome = jest.fn(() => null);
     const profileConflict = jest.fn(() => true);
-    const connectProbe = jest.fn(() => true);
+    const connectProbe = jest.fn((target) => ({
+      ok: true,
+      endpoint: target.endpoint,
+      browserVersion: 'Chrome/150.0.7871.187',
+      message: 'ok',
+    }));
     const result = preflightBrowserRsBinary({
       ...runnableDefaults,
       binaryPath: '/tmp/browser-rs',
@@ -287,11 +317,88 @@ describe('preflightBrowserRsBinary', () => {
     });
     expect(result.status).toBe('ok');
     expect(result.connectPort).toBe(9222);
+    expect(result.connectEndpoint).toBe('http://127.0.0.1:9222/');
+    expect(result.chromeVersion).toBe('Chrome/150.0.7871.187');
     expect(result.command).toEqual(['/canonical/browser-rs', '--connect', 'http://127.0.0.1:9222']);
     expect(result.chromePath).toBe('');
     expect(result.profilePath).toBe('');
-    expect(connectProbe).toHaveBeenCalledWith(9222);
+    expect(connectProbe).toHaveBeenCalledWith(expect.objectContaining({
+      endpoint: 'http://127.0.0.1:9222/',
+      probeUrl: 'http://127.0.0.1:9222/json/version',
+      port: 9222,
+    }));
     expect(resolveChrome).not.toHaveBeenCalled();
     expect(profileConflict).not.toHaveBeenCalled();
+  });
+
+  test('builds subprocess env from the exact Chrome, profile, and CDP target approved by preflight', () => {
+    const env = browserRsSpawnEnv({
+      status: 'ok',
+      binaryPath: '/canonical/browser-rs',
+      command: ['/canonical/browser-rs', '--connect', 'http://127.0.0.1:9333'],
+      platformKey: 'linux-x64',
+      expectedVersion: '0.1.13',
+      actualVersion: '0.1.13',
+      expectedSha256: goodSha,
+      actualSha256: goodSha,
+      asset: 'browser-rs-linux-x64',
+      commit: BROWSER_RS_PIN.commit,
+      chromePath: '/canonical/google-chrome',
+      chromeVersion: 'Google Chrome 150.0.7871.187',
+      profilePath: '/canonical/browser-rs-profile',
+      connectPort: 9333,
+      connectEndpoint: 'http://127.0.0.1:9333/',
+      message: 'ok',
+    }, { PATH: '/usr/bin' });
+    expect(env).toMatchObject({
+      PATH: '/usr/bin',
+      AB_CHROME: '/canonical/google-chrome',
+      AB_PROFILE: '/canonical/browser-rs-profile',
+      AB_CONNECT: '9333',
+    });
+  });
+});
+
+describe('SubprocessBrowserRsMcpTransport lifecycle', () => {
+  test('drains large stderr output while completing MCP initialization', async () => {
+    const fixture = [
+      "const readline=require('readline');",
+      "const rl=readline.createInterface({input:process.stdin});",
+      "rl.on('line',line=>{const msg=JSON.parse(line);",
+      "if(msg.method==='initialize')process.stdout.write(JSON.stringify({jsonrpc:'2.0',id:msg.id,result:{}})+'\\n');",
+      "if(msg.method==='tools/list')process.stdout.write(JSON.stringify({jsonrpc:'2.0',id:msg.id,result:{tools:[{name:'browser_navigate'}]}})+'\\n');});",
+      "process.stderr.write('x'.repeat(1024*1024));",
+    ].join('');
+    const transport = new SubprocessBrowserRsMcpTransport(process.execPath, ['-e', fixture], 2000);
+    const adapter = new BrowserRsMcpAdapter({ transport, startupTimeoutMs: 2000 });
+    await adapter.setup();
+    expect(adapter.toolCount).toBe(1);
+    await adapter.teardown();
+  });
+
+  test('applies startupTimeoutMs through the initialize handshake', async () => {
+    const transport = new SubprocessBrowserRsMcpTransport(
+      process.execPath,
+      ['-e', 'process.stdin.resume()'],
+      5000,
+    );
+    const adapter = new BrowserRsMcpAdapter({ transport, startupTimeoutMs: 75 });
+    const started = Date.now();
+    await expect(adapter.setup()).rejects.toThrow(/startup timed out after 75ms/);
+    expect(Date.now() - started).toBeLessThan(1000);
+    await expect(adapter.teardown()).resolves.toBeUndefined();
+  });
+
+  test('does not wait for a call timeout when the child exits before teardown', async () => {
+    const transport = new SubprocessBrowserRsMcpTransport(
+      process.execPath,
+      ['-e', 'setTimeout(() => process.exit(7), 20); process.stdin.resume()'],
+      5000,
+    );
+    const adapter = new BrowserRsMcpAdapter({ transport, startupTimeoutMs: 2000 });
+    const started = Date.now();
+    await expect(adapter.setup()).rejects.toThrow(/exited with code 7/);
+    await expect(adapter.teardown()).resolves.toBeUndefined();
+    expect(Date.now() - started).toBeLessThan(1000);
   });
 });

--- a/tests/benchmark/adapters/browser-rs-mcp-adapter.test.ts
+++ b/tests/benchmark/adapters/browser-rs-mcp-adapter.test.ts
@@ -1,0 +1,296 @@
+/// <reference types="jest" />
+
+import {
+  BROWSER_RS_PIN,
+  BrowserRsMcpAdapter,
+  BrowserRsMcpTransport,
+  preflightBrowserRsBinary,
+} from './browser-rs-mcp-adapter';
+import { MCPToolResult } from '../benchmark-runner';
+
+function makeMockTransport(opts: { navigate?: string; snapshot?: string; tools?: number } = {}): {
+  transport: BrowserRsMcpTransport;
+  log: Array<{ tool: string; args: Record<string, unknown> }>;
+  initialized: () => boolean;
+  listed: () => boolean;
+  stopped: () => boolean;
+} {
+  const log: Array<{ tool: string; args: Record<string, unknown> }> = [];
+  let initialized = false;
+  let listed = false;
+  let stopped = false;
+
+  const transport: BrowserRsMcpTransport = {
+    command: ['browser-rs'],
+    async start() {},
+    async initialize() {
+      initialized = true;
+    },
+    async listTools() {
+      listed = true;
+      return Array.from({ length: opts.tools ?? 64 }, (_, i) => ({ name: `browser_tool_${i}` }));
+    },
+    async callTool(toolName, args): Promise<MCPToolResult> {
+      log.push({ tool: toolName, args });
+      switch (toolName) {
+        case 'browser_navigate':
+          return { content: [{ type: 'text', text: opts.navigate ?? 'page p1\nurl http://x/p\n\n- page:\n  - heading "Fixture"' }] };
+        case 'browser_snapshot':
+          return { content: [{ type: 'text', text: opts.snapshot ?? 'page p1\n\n- page:\n  - heading "Fixture"' }] };
+        case 'browser_close_page':
+          return { content: [{ type: 'text', text: 'closed p1' }] };
+        default:
+          return { content: [{ type: 'text', text: `unsupported ${toolName}` }], isError: true };
+      }
+    },
+    async stop() {
+      stopped = true;
+    },
+  };
+
+  return { transport, log, initialized: () => initialized, listed: () => listed, stopped: () => stopped };
+}
+
+describe('BrowserRsMcpAdapter', () => {
+  test('conforms to the LibraryAdapter identity contract', () => {
+    const adapter = new BrowserRsMcpAdapter({ transport: makeMockTransport().transport });
+    expect(adapter.name).toBe('browser-rs-mcp');
+    expect(adapter.kind).toBe('mcp');
+    expect(adapter.mode).toBe('a11y-snapshot-stdio');
+    expect(adapter.version).toBe(BROWSER_RS_PIN.version);
+  });
+
+  test('setup initializes MCP and records the descriptive tool count', async () => {
+    const mock = makeMockTransport({ tools: 64 });
+    const adapter = new BrowserRsMcpAdapter({ transport: mock.transport });
+    await adapter.setup();
+    expect(mock.initialized()).toBe(true);
+    expect(mock.listed()).toBe(true);
+    expect(adapter.toolCount).toBe(64);
+  });
+
+  test('tabs_create navigates and exposes browser-rs page id as tabId', async () => {
+    const mock = makeMockTransport();
+    const adapter = new BrowserRsMcpAdapter({ transport: mock.transport });
+    await adapter.setup();
+    const result = await adapter.callTool('tabs_create', { url: 'http://127.0.0.1/p' });
+    expect(result.isError).toBeFalsy();
+    expect(JSON.parse(result.content[0].text as string)).toEqual({ tabId: 'p1' });
+    expect(mock.log).toEqual([{ tool: 'browser_navigate', args: { url: 'http://127.0.0.1/p' } }]);
+  });
+
+  test('read_page snapshots the selected page id', async () => {
+    const mock = makeMockTransport({ snapshot: 'page p1\n\n- page:\n  - button "Save"' });
+    const adapter = new BrowserRsMcpAdapter({ transport: mock.transport });
+    await adapter.setup();
+    const created = await adapter.callTool('tabs_create', { url: 'http://x/p' });
+    const tabId = JSON.parse(created.content[0].text as string).tabId;
+    const read = await adapter.callTool('read_page', { tabId });
+    expect(read.isError).toBeFalsy();
+    expect(read.content[0].text).toContain('button "Save"');
+    expect(mock.log.map((entry) => entry.tool)).toEqual(['browser_navigate', 'browser_snapshot']);
+    expect(mock.log[1].args).toEqual({ page: 'p1' });
+  });
+
+  test('tabs_close closes the browser-rs page and clears adapter state', async () => {
+    const mock = makeMockTransport();
+    const adapter = new BrowserRsMcpAdapter({ transport: mock.transport });
+    await adapter.setup();
+    const created = await adapter.callTool('tabs_create', { url: 'http://x/p' });
+    const tabId = JSON.parse(created.content[0].text as string).tabId;
+    const closed = await adapter.callTool('tabs_close', { tabId });
+    expect(closed.isError).toBeFalsy();
+    expect(mock.log.at(-1)).toEqual({ tool: 'browser_close_page', args: { page: 'p1' } });
+    const readAfterClose = await adapter.callTool('read_page', { tabId });
+    expect(readAfterClose.isError).toBe(true);
+  });
+
+  test('teardown stops the transport and is idempotent', async () => {
+    const mock = makeMockTransport();
+    const adapter = new BrowserRsMcpAdapter({ transport: mock.transport });
+    await adapter.setup();
+    await adapter.teardown();
+    await expect(adapter.teardown()).resolves.toBeUndefined();
+    expect(mock.stopped()).toBe(true);
+  });
+
+  test('callTool before setup returns an error result', async () => {
+    const adapter = new BrowserRsMcpAdapter({ transport: makeMockTransport().transport });
+    const result = await adapter.callTool('read_page', { tabId: 'p1' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('setup() was not called');
+  });
+
+  test('unsupported tools return an error result', async () => {
+    const adapter = new BrowserRsMcpAdapter({ transport: makeMockTransport().transport });
+    await adapter.setup();
+    const result = await adapter.callTool('act', { instruction: 'click' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('unsupported tool');
+  });
+});
+
+describe('preflightBrowserRsBinary', () => {
+  const goodSha = BROWSER_RS_PIN.platforms['linux-x64'].sha256;
+  const runnableDefaults = {
+    platform: 'linux' as const,
+    arch: 'x64' as const,
+    resolveBinary: () => '/canonical/browser-rs',
+    resolveChrome: () => '/canonical/google-chrome',
+    profileConflict: () => false,
+    execVersion: () => 'browser-rs 0.1.13',
+    hashFile: () => goodSha,
+  };
+
+  test('reports unsupported platform before binary checks', () => {
+    const result = preflightBrowserRsBinary({
+      env: { BROWSER_RS_BIN: '/tmp/browser-rs' },
+      platform: 'win32',
+      arch: 'x64',
+    });
+    expect(result.status).toBe('unsupported_platform');
+    expect(result.platformKey).toBe('win32-x64');
+  });
+
+  test('reports missing binary when BROWSER_RS_BIN is absent', () => {
+    const result = preflightBrowserRsBinary({ env: {}, platform: 'linux', arch: 'x64' });
+    expect(result.status).toBe('missing_binary');
+    expect(result.message).toContain('BROWSER_RS_BIN');
+  });
+
+  test('fails closed on version mismatch', () => {
+    const result = preflightBrowserRsBinary({
+      ...runnableDefaults,
+      binaryPath: '/tmp/browser-rs',
+      execVersion: () => 'browser-rs 0.1.12',
+      hashFile: () => goodSha,
+    });
+    expect(result.status).toBe('version_mismatch');
+    expect(result.actualVersion).toBe('0.1.12');
+  });
+
+  test('fails closed on SHA mismatch', () => {
+    const result = preflightBrowserRsBinary({
+      ...runnableDefaults,
+      binaryPath: '/tmp/browser-rs',
+      execVersion: () => 'browser-rs 0.1.13',
+      hashFile: () => '0'.repeat(64),
+    });
+    expect(result.status).toBe('sha_mismatch');
+    expect(result.expectedSha256).toBe(goodSha);
+  });
+
+  test('accepts the pinned version and platform digest', () => {
+    const result = preflightBrowserRsBinary({
+      ...runnableDefaults,
+      binaryPath: '/tmp/browser-rs',
+      execVersion: () => 'browser-rs 0.1.13',
+      hashFile: () => goodSha,
+    });
+    expect(result.status).toBe('ok');
+    expect(result.asset).toBe('browser-rs-linux-x64');
+    expect(result.actualSha256).toBe(goodSha);
+    expect(result.binaryPath).toBe('/canonical/browser-rs');
+    expect(result.command).toEqual(['/canonical/browser-rs']);
+    expect(result.chromePath).toBe('/canonical/google-chrome');
+  });
+
+  test('uses the same canonical binary path for version, digest, and execution metadata', () => {
+    const observed: string[] = [];
+    const result = preflightBrowserRsBinary({
+      ...runnableDefaults,
+      binaryPath: 'browser-rs',
+      resolveBinary: () => '/opt/browser-rs/bin/browser-rs',
+      execVersion: (binaryPath) => {
+        observed.push(`version:${binaryPath}`);
+        return 'browser-rs 0.1.13';
+      },
+      hashFile: (binaryPath) => {
+        observed.push(`hash:${binaryPath}`);
+        return goodSha;
+      },
+    });
+    expect(result.status).toBe('ok');
+    expect(result.command).toEqual(['/opt/browser-rs/bin/browser-rs']);
+    expect(observed).toEqual([
+      'version:/opt/browser-rs/bin/browser-rs',
+      'hash:/opt/browser-rs/bin/browser-rs',
+    ]);
+  });
+
+  test('reports missing Chrome before starting browser-rs', () => {
+    const result = preflightBrowserRsBinary({
+      ...runnableDefaults,
+      binaryPath: '/tmp/browser-rs',
+      resolveChrome: () => null,
+    });
+    expect(result.status).toBe('chrome_missing');
+    expect(result.message).toContain('AB_CHROME');
+  });
+
+  test('does not hide a pin mismatch behind a missing Chrome runtime', () => {
+    const result = preflightBrowserRsBinary({
+      ...runnableDefaults,
+      binaryPath: '/tmp/browser-rs',
+      execVersion: () => 'browser-rs 0.1.12',
+      hashFile: () => '0'.repeat(64),
+      resolveChrome: () => null,
+    });
+    expect(result.status).toBe('version_mismatch');
+    expect(result.actualVersion).toBe('0.1.12');
+  });
+
+  test('fails closed when the browser-rs profile has Chrome lock artifacts', () => {
+    const result = preflightBrowserRsBinary({
+      ...runnableDefaults,
+      binaryPath: '/tmp/browser-rs',
+      env: { HOME: '/tmp/home' },
+      profileConflict: () => true,
+    });
+    expect(result.status).toBe('profile_conflict');
+    expect(result.profilePath).toBe('/tmp/home/.browser-rs/profile');
+  });
+
+  test('rejects HTTP mode because the benchmark adapter requires MCP stdio', () => {
+    const result = preflightBrowserRsBinary({
+      ...runnableDefaults,
+      binaryPath: '/tmp/browser-rs',
+      args: ['--port', '9321'],
+    });
+    expect(result.status).toBe('port_conflict');
+    expect(result.message).toContain('stdio');
+  });
+
+  test('rejects an unavailable configured CDP connect port', () => {
+    const result = preflightBrowserRsBinary({
+      ...runnableDefaults,
+      binaryPath: '/tmp/browser-rs',
+      args: ['--connect', '9222'],
+      connectProbe: () => false,
+    });
+    expect(result.status).toBe('port_conflict');
+    expect(result.connectPort).toBe(9222);
+  });
+
+  test('uses a configured CDP URL without requiring local Chrome or a profile', () => {
+    const resolveChrome = jest.fn(() => null);
+    const profileConflict = jest.fn(() => true);
+    const connectProbe = jest.fn(() => true);
+    const result = preflightBrowserRsBinary({
+      ...runnableDefaults,
+      binaryPath: '/tmp/browser-rs',
+      args: ['--connect', 'http://127.0.0.1:9222'],
+      resolveChrome,
+      profileConflict,
+      connectProbe,
+    });
+    expect(result.status).toBe('ok');
+    expect(result.connectPort).toBe(9222);
+    expect(result.command).toEqual(['/canonical/browser-rs', '--connect', 'http://127.0.0.1:9222']);
+    expect(result.chromePath).toBe('');
+    expect(result.profilePath).toBe('');
+    expect(connectProbe).toHaveBeenCalledWith(9222);
+    expect(resolveChrome).not.toHaveBeenCalled();
+    expect(profileConflict).not.toHaveBeenCalled();
+  });
+});

--- a/tests/benchmark/adapters/browser-rs-mcp-adapter.test.ts
+++ b/tests/benchmark/adapters/browser-rs-mcp-adapter.test.ts
@@ -1,5 +1,6 @@
 /// <reference types="jest" />
 
+import path from 'node:path';
 import {
   BROWSER_RS_PIN,
   BrowserRsMcpAdapter,
@@ -248,7 +249,7 @@ describe('preflightBrowserRsBinary', () => {
       profileConflict: () => true,
     });
     expect(result.status).toBe('profile_conflict');
-    expect(result.profilePath).toBe('/tmp/home/.browser-rs/profile');
+    expect(result.profilePath).toBe(path.join('/tmp/home', '.browser-rs', 'profile'));
   });
 
   test('rejects HTTP mode because the benchmark adapter requires MCP stdio', () => {

--- a/tests/benchmark/adapters/browser-rs-mcp-adapter.ts
+++ b/tests/benchmark/adapters/browser-rs-mcp-adapter.ts
@@ -66,6 +66,20 @@ export interface BrowserRsPlatformPin {
   sha256: string;
 }
 
+export interface BrowserRsConnectTarget {
+  argument: string;
+  endpoint: string;
+  probeUrl: string;
+  port: number;
+}
+
+export interface BrowserRsCdpProbeResult {
+  ok: boolean;
+  endpoint: string;
+  browserVersion: string;
+  message: string;
+}
+
 export type BrowserRsPreflightStatus =
   | 'ok'
   | 'missing_binary'
@@ -88,8 +102,10 @@ export interface BrowserRsPreflightResult {
   asset: string;
   commit: string;
   chromePath: string;
+  chromeVersion: string;
   profilePath: string;
   connectPort?: number;
+  connectEndpoint?: string;
   message: string;
 }
 
@@ -114,6 +130,8 @@ export const BROWSER_RS_PIN = {
 
 const DEFAULT_CALL_TIMEOUT_MS = 30000;
 const DEFAULT_STARTUP_TIMEOUT_MS = 15000;
+const STOP_GRACE_MS = 500;
+const STDERR_TAIL_CHARS = 16_384;
 
 function textResult(text: string): MCPToolResult {
   return { content: [{ type: 'text', text }] };
@@ -133,6 +151,20 @@ function joinText(result: MCPToolResult): string {
 function extractVersion(output: string): string {
   const match = output.match(/\b(\d+\.\d+\.\d+)\b/);
   return match?.[1] ?? '';
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 export function browserRsPlatformKey(platform = process.platform, arch = process.arch): string {
@@ -212,25 +244,45 @@ function optionValue(args: readonly string[], names: readonly string[]): string 
   return undefined;
 }
 
-function configuredConnectPort(args: readonly string[], env: NodeJS.ProcessEnv): number | undefined {
-  const raw = optionValue(args, ['--connect', '--cdp-endpoint']) ?? env.AB_CONNECT;
-  if (!raw) return undefined;
-  const numericPort = /^\d+$/.test(raw) ? Number(raw) : undefined;
-  let urlPort: number | undefined;
-  if (numericPort === undefined) {
-    try {
-      const parsed = new URL(raw.includes('://') ? raw : `http://${raw}`);
-      const inferred = parsed.port || (parsed.protocol === 'https:' || parsed.protocol === 'wss:' ? '443' : '80');
-      urlPort = Number(inferred);
-    } catch {
-      urlPort = undefined;
-    }
+function parseConnectTarget(raw: string): BrowserRsConnectTarget | null {
+  if (/^\d+$/.test(raw)) {
+    const port = Number(raw);
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) return null;
+    const endpoint = `http://127.0.0.1:${port}`;
+    return { argument: raw, endpoint, probeUrl: `${endpoint}/json/version`, port };
   }
-  const port = numericPort ?? urlPort;
-  if (port === undefined || !Number.isInteger(port) || port <= 0 || port > 65535) {
-    return undefined;
+
+  if (!raw.includes('://')) return null;
+  try {
+    const parsed = new URL(raw);
+    const port = Number(parsed.port);
+    if (!parsed.port || !Number.isInteger(port) || port <= 0 || port > 65535) return null;
+    const probe = new URL(parsed.toString());
+    const basePath = probe.pathname.replace(/\/$/, '');
+    probe.pathname = basePath.endsWith('/json/version') ? basePath : `${basePath}/json/version`;
+    return {
+      argument: raw,
+      endpoint: parsed.toString(),
+      probeUrl: probe.toString(),
+      port,
+    };
+  } catch {
+    return null;
   }
-  return port;
+}
+
+function pinnedConnectCompatibilityError(target: BrowserRsConnectTarget): string | null {
+  const endpoint = new URL(target.endpoint);
+  if (endpoint.protocol !== 'http:') {
+    return `browser-rs v${BROWSER_RS_PIN.version} reduces --connect to a local HTTP port; protocol ${endpoint.protocol} cannot be preserved`;
+  }
+  if (endpoint.hostname !== '127.0.0.1') {
+    return `browser-rs v${BROWSER_RS_PIN.version} discards the --connect host and attaches through 127.0.0.1; refusing endpoint ${target.endpoint}`;
+  }
+  if (endpoint.username || endpoint.password || endpoint.search || endpoint.hash || !['', '/'].includes(endpoint.pathname)) {
+    return `browser-rs v${BROWSER_RS_PIN.version} discards --connect credentials, path, query, or fragment; refusing endpoint ${target.endpoint}`;
+  }
+  return null;
 }
 
 function configuredProfilePath(args: readonly string[], env: NodeJS.ProcessEnv): string {
@@ -252,20 +304,51 @@ function profileHasLock(profilePath: string): boolean {
   });
 }
 
-function probeCdpPort(port: number): boolean {
+function probeCdpEndpoint(target: BrowserRsConnectTarget): BrowserRsCdpProbeResult {
   const script = [
-    "const http=require('http');",
-    'const port=Number(process.argv[1]);',
-    "const req=http.get({hostname:'127.0.0.1',port,path:'/json/version',timeout:1000},res=>{",
+    "const endpoint=new URL(process.argv[1]);",
+    "const client=require(endpoint.protocol==='https:'?'https':'http');",
+    'const req=client.get(endpoint,{timeout:1000},res=>{',
     "let body='';res.on('data',c=>body+=c);res.on('end',()=>{",
-    "try{const value=JSON.parse(body);process.exit(res.statusCode===200&&typeof value.webSocketDebuggerUrl==='string'?0:1)}catch{process.exit(1)}})});",
+    "try{const value=JSON.parse(body);if(res.statusCode!==200||typeof value.webSocketDebuggerUrl!=='string'||typeof value.Browser!=='string')process.exit(1);process.stdout.write(JSON.stringify({browserVersion:value.Browser}));}catch{process.exit(1)}})});",
     'req.on(\'error\',()=>process.exit(1));req.on(\'timeout\',()=>{req.destroy();process.exit(1)});',
   ].join('');
   try {
-    execFileSync(process.execPath, ['-e', script, String(port)], { timeout: 2000, stdio: 'ignore' });
-    return true;
+    const output = execFileSync(process.execPath, ['-e', script, target.probeUrl], {
+      encoding: 'utf8',
+      timeout: 2000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const parsed = JSON.parse(output) as { browserVersion?: unknown };
+    if (typeof parsed.browserVersion !== 'string' || parsed.browserVersion.length === 0) {
+      throw new Error('CDP version response did not identify the browser');
+    }
+    return {
+      ok: true,
+      endpoint: target.endpoint,
+      browserVersion: parsed.browserVersion,
+      message: 'compatible CDP endpoint',
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      endpoint: target.endpoint,
+      browserVersion: '',
+      message: `CDP probe failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+function executableVersion(executablePath: string): string | null {
+  try {
+    const output = execFileSync(executablePath, ['--version'], {
+      encoding: 'utf8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+    return output || null;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -279,8 +362,9 @@ export function preflightBrowserRsBinary(options: {
   hashFile?: (binaryPath: string) => string;
   resolveBinary?: (binaryPath: string) => string;
   resolveChrome?: (env: NodeJS.ProcessEnv, platform: NodeJS.Platform) => string | null;
+  resolveChromeVersion?: (chromePath: string) => string | null;
   profileConflict?: (profilePath: string) => boolean;
-  connectProbe?: (port: number) => boolean;
+  connectProbe?: (target: BrowserRsConnectTarget) => BrowserRsCdpProbeResult;
 } = {}): BrowserRsPreflightResult {
   const env = options.env ?? process.env;
   const requestedBinaryPath = options.binaryPath ?? env.BROWSER_RS_BIN ?? '';
@@ -300,6 +384,7 @@ export function preflightBrowserRsBinary(options: {
     asset: pin?.asset ?? '',
     commit: BROWSER_RS_PIN.commit,
     chromePath: '',
+    chromeVersion: '',
     profilePath: '',
   };
 
@@ -323,43 +408,43 @@ export function preflightBrowserRsBinary(options: {
   }
   const resolvedBase = { ...base, binaryPath, command: [binaryPath, ...args] };
 
+  let actualSha256 = '';
+  try {
+    actualSha256 = options.hashFile ? options.hashFile(binaryPath) : sha256File(binaryPath);
+  } catch (err) {
+    return { ...resolvedBase, status: 'sha_mismatch', message: `browser-rs SHA-256 check failed: ${(err as Error).message}` };
+  }
+
+  if (actualSha256 !== pin.sha256) {
+    return {
+      ...resolvedBase,
+      actualSha256,
+      status: 'sha_mismatch',
+      message: `browser-rs SHA-256 mismatch: expected ${pin.sha256}, got ${actualSha256}`,
+    };
+  }
+  const digestBase = { ...resolvedBase, actualSha256 };
+
   let versionOutput = '';
   try {
     versionOutput = options.execVersion
       ? options.execVersion(binaryPath)
       : execFileSync(binaryPath, ['--version'], { encoding: 'utf8', timeout: 3000, stdio: ['ignore', 'pipe', 'pipe'] });
   } catch (err) {
-    return { ...resolvedBase, status: 'missing_binary', message: `browser-rs --version failed: ${(err as Error).message}` };
+    return { ...digestBase, status: 'missing_binary', message: `verified browser-rs --version failed: ${(err as Error).message}` };
   }
 
   const actualVersion = extractVersion(versionOutput);
   if (actualVersion !== BROWSER_RS_PIN.version) {
     return {
-      ...resolvedBase,
+      ...digestBase,
       actualVersion,
       status: 'version_mismatch',
       message: `browser-rs version mismatch: expected ${BROWSER_RS_PIN.version}, got ${actualVersion || 'unknown'}`,
     };
   }
 
-  let actualSha256 = '';
-  try {
-    actualSha256 = options.hashFile ? options.hashFile(binaryPath) : sha256File(binaryPath);
-  } catch (err) {
-    return { ...resolvedBase, actualVersion, status: 'sha_mismatch', message: `browser-rs SHA-256 check failed: ${(err as Error).message}` };
-  }
-
-  if (actualSha256 !== pin.sha256) {
-    return {
-      ...resolvedBase,
-      actualVersion,
-      actualSha256,
-      status: 'sha_mismatch',
-      message: `browser-rs SHA-256 mismatch: expected ${pin.sha256}, got ${actualSha256}`,
-    };
-  }
-
-  const identityBase = { ...resolvedBase, actualVersion, actualSha256 };
+  const identityBase = { ...digestBase, actualVersion };
   if (optionValue(args, ['--port']) !== undefined || env.AB_HTTP) {
     return {
       ...identityBase,
@@ -368,45 +453,77 @@ export function preflightBrowserRsBinary(options: {
     };
   }
 
-  const connectPort = configuredConnectPort(args, env);
-  if ((optionValue(args, ['--connect', '--cdp-endpoint']) ?? env.AB_CONNECT) && connectPort === undefined) {
-    return { ...identityBase, status: 'port_conflict', message: 'browser-rs connect port is invalid' };
+  const connectValue = optionValue(args, ['--connect', '--cdp-endpoint']) ?? env.AB_CONNECT;
+  const connectTarget = connectValue ? parseConnectTarget(connectValue) : null;
+  if (connectValue && !connectTarget) {
+    return { ...identityBase, status: 'port_conflict', message: `browser-rs connect target is invalid: ${connectValue}` };
   }
-  if (connectPort !== undefined && !(options.connectProbe ?? probeCdpPort)(connectPort)) {
+  if (connectTarget) {
+    const incompatibility = pinnedConnectCompatibilityError(connectTarget);
+    if (incompatibility) {
+      return {
+        ...identityBase,
+        connectPort: connectTarget.port,
+        connectEndpoint: connectTarget.endpoint,
+        status: 'port_conflict',
+        message: incompatibility,
+      };
+    }
+    const probe = (options.connectProbe ?? probeCdpEndpoint)(connectTarget);
+    if (!probe.ok) {
+      return {
+        ...identityBase,
+        connectPort: connectTarget.port,
+        connectEndpoint: connectTarget.endpoint,
+        status: 'port_conflict',
+        message: `browser-rs connect endpoint ${connectTarget.endpoint} is unavailable: ${probe.message}`,
+      };
+    }
     return {
       ...identityBase,
-      connectPort,
-      status: 'port_conflict',
-      message: `browser-rs connect port ${connectPort} does not expose a compatible CDP endpoint`,
+      status: 'ok',
+      connectPort: connectTarget.port,
+      connectEndpoint: connectTarget.endpoint,
+      chromeVersion: probe.browserVersion,
+      message: 'browser-rs binary, configured CDP endpoint, version, and SHA-256 match the pinned benchmark contract',
     };
   }
 
   let chromePath = '';
+  let chromeVersion = '';
   let profilePath = '';
-  if (connectPort === undefined) {
-    chromePath = (options.resolveChrome ?? resolveBrowserRsChrome)(env, platform) ?? '';
-    if (!chromePath) {
-      return {
-        ...identityBase,
-        status: 'chrome_missing',
-        message: 'Chrome/Chromium is required for browser-rs live smoke; set AB_CHROME to a canonical executable path',
-      };
-    }
-    profilePath = configuredProfilePath(args, env);
-    if (!profilePath) {
-      return { ...identityBase, chromePath, status: 'profile_conflict', message: 'browser-rs profile path could not be resolved' };
-    }
-    if ((options.profileConflict ?? profileHasLock)(profilePath)) {
-      return {
-        ...identityBase,
-        chromePath,
-        profilePath,
-        status: 'profile_conflict',
-        message: `browser-rs profile is already locked: ${profilePath}`,
-      };
-    }
+  chromePath = (options.resolveChrome ?? resolveBrowserRsChrome)(env, platform) ?? '';
+  if (!chromePath) {
+    return {
+      ...identityBase,
+      status: 'chrome_missing',
+      message: 'Chrome/Chromium is required for browser-rs live smoke; set AB_CHROME to a canonical executable path',
+    };
   }
-  const environmentBase = { ...identityBase, chromePath, profilePath, connectPort };
+  profilePath = configuredProfilePath(args, env);
+  if (!profilePath) {
+    return { ...identityBase, chromePath, status: 'profile_conflict', message: 'browser-rs profile path could not be resolved' };
+  }
+  if ((options.profileConflict ?? profileHasLock)(profilePath)) {
+    return {
+      ...identityBase,
+      chromePath,
+      profilePath,
+      status: 'profile_conflict',
+      message: `browser-rs profile is already locked: ${profilePath}`,
+    };
+  }
+  chromeVersion = (options.resolveChromeVersion ?? executableVersion)(chromePath) ?? '';
+  if (!chromeVersion) {
+    return {
+      ...identityBase,
+      chromePath,
+      profilePath,
+      status: 'chrome_missing',
+      message: `Chrome version probe failed for approved executable: ${chromePath}`,
+    };
+  }
+  const environmentBase = { ...identityBase, chromePath, chromeVersion, profilePath };
 
   return {
     ...environmentBase,
@@ -415,10 +532,22 @@ export function preflightBrowserRsBinary(options: {
   };
 }
 
-class SubprocessBrowserRsMcpTransport implements BrowserRsMcpTransport {
+export function browserRsSpawnEnv(
+  preflight: BrowserRsPreflightResult,
+  env: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const spawnEnv = { ...env };
+  if (preflight.chromePath) spawnEnv.AB_CHROME = preflight.chromePath;
+  if (preflight.profilePath) spawnEnv.AB_PROFILE = preflight.profilePath;
+  if (preflight.connectPort !== undefined) spawnEnv.AB_CONNECT = String(preflight.connectPort);
+  return spawnEnv;
+}
+
+export class SubprocessBrowserRsMcpTransport implements BrowserRsMcpTransport {
   private process: ChildProcess | null = null;
   private requestId = 0;
   private buffer = '';
+  private stderrTail = '';
   private readonly pending = new Map<
     number,
     { resolve: (r: MCPResponse) => void; reject: (e: Error) => void; timer: NodeJS.Timeout }
@@ -430,24 +559,22 @@ class SubprocessBrowserRsMcpTransport implements BrowserRsMcpTransport {
     private readonly binaryPath: string,
     args: readonly string[],
     private readonly callTimeoutMs: number,
-    private readonly startupTimeoutMs: number,
+    private readonly env: NodeJS.ProcessEnv = process.env,
   ) {
     this.command = [binaryPath, ...args];
   }
 
   async start(): Promise<void> {
+    if (this.process) throw new Error('browser-rs process already started');
     return new Promise((resolve, reject) => {
-      this.process = spawn(this.binaryPath, this.command.slice(1), { stdio: ['pipe', 'pipe', 'pipe'] });
+      const child = spawn(this.binaryPath, this.command.slice(1), {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: this.env,
+      });
+      this.process = child;
       let settled = false;
-      const startupTimer = setTimeout(() => {
-        if (!settled) {
-          settled = true;
-          reject(new Error(`browser-rs startup timed out after ${this.startupTimeoutMs}ms`));
-        }
-      }, this.startupTimeoutMs);
-      startupTimer.unref();
 
-      this.process.stdout?.on('data', (data: Buffer) => {
+      child.stdout?.on('data', (data: Buffer) => {
         this.buffer += data.toString();
         const lines = this.buffer.split('\n');
         this.buffer = lines.pop() || '';
@@ -467,31 +594,35 @@ class SubprocessBrowserRsMcpTransport implements BrowserRsMcpTransport {
         }
       });
 
-      this.process.on('error', (err) => {
-        if (!settled) {
-          settled = true;
-          clearTimeout(startupTimer);
-          reject(err);
-        }
+      child.stderr?.on('data', (data: Buffer) => {
+        this.stderrTail = `${this.stderrTail}${data.toString()}`.slice(-STDERR_TAIL_CHARS);
       });
-      this.process.on('exit', (code) => {
-        for (const [, slot] of this.pending) {
-          clearTimeout(slot.timer);
-          slot.reject(new Error(`browser-rs exited with code ${code}`));
-        }
-        this.pending.clear();
-        if (!settled) {
-          settled = true;
-          clearTimeout(startupTimer);
-          reject(new Error(`browser-rs exited with code ${code} before startup`));
-        }
+      child.stdin?.on('error', (error) => {
+        this.rejectPending(this.diagnosticError(`browser-rs stdin failed: ${error.message}`));
       });
 
-      setImmediate(() => {
+      child.once('spawn', () => {
         if (!settled) {
           settled = true;
-          clearTimeout(startupTimer);
           resolve();
+        }
+      });
+      child.once('error', (error) => {
+        if (this.process === child) this.process = null;
+        const failure = this.diagnosticError(`browser-rs process error: ${error.message}`);
+        this.rejectPending(failure);
+        if (!settled) {
+          settled = true;
+          reject(failure);
+        }
+      });
+      child.once('exit', (code, signal) => {
+        if (this.process === child) this.process = null;
+        const failure = this.diagnosticError(`browser-rs exited with code ${code} signal ${signal}`);
+        this.rejectPending(failure);
+        if (!settled) {
+          settled = true;
+          reject(failure);
         }
       });
     });
@@ -523,25 +654,25 @@ class SubprocessBrowserRsMcpTransport implements BrowserRsMcpTransport {
   }
 
   async stop(): Promise<void> {
-    try {
-      if (this.process?.stdin) await this.send('shutdown', {});
-    } catch {
-      // Best-effort graceful shutdown; process cleanup below is authoritative.
+    const child = this.process;
+    this.process = null;
+    this.rejectPending(new Error('browser-rs transport stopped'));
+    if (!child || child.exitCode !== null || child.signalCode !== null) return;
+
+    if (child.stdin && !child.stdin.destroyed && child.stdin.writable) {
+      try { child.stdin.end(); } catch { /* process cleanup below is authoritative */ }
     }
-    for (const [, slot] of this.pending) {
-      clearTimeout(slot.timer);
-      slot.reject(new Error('browser-rs transport stopped'));
-    }
-    this.pending.clear();
-    if (this.process) {
-      this.process.stdin?.end();
-      this.process.kill();
-      this.process = null;
-    }
+    if (await this.waitForExit(child, STOP_GRACE_MS)) return;
+    try { child.kill('SIGTERM'); } catch { /* process may have exited between checks */ }
+    if (await this.waitForExit(child, STOP_GRACE_MS)) return;
+    try { child.kill('SIGKILL'); } catch { /* process may have exited between checks */ }
+    await this.waitForExit(child, STOP_GRACE_MS);
   }
 
   private send(method: string, params?: Record<string, unknown>): Promise<MCPResponse> {
-    if (!this.process?.stdin) {
+    const child = this.process;
+    const input = child?.stdin;
+    if (!child || child.exitCode !== null || child.signalCode !== null || !input || input.destroyed || !input.writable) {
       return Promise.reject(new Error('browser-rs process not started'));
     }
     const id = ++this.requestId;
@@ -555,16 +686,58 @@ class SubprocessBrowserRsMcpTransport implements BrowserRsMcpTransport {
       }, this.callTimeoutMs);
       timer.unref();
       this.pending.set(id, { resolve, reject, timer });
-      this.process!.stdin!.write(JSON.stringify(req) + '\n');
+      input.write(`${JSON.stringify(req)}\n`, (error?: Error | null) => {
+        if (!error) return;
+        const slot = this.pending.get(id);
+        if (!slot) return;
+        clearTimeout(slot.timer);
+        this.pending.delete(id);
+        slot.reject(this.diagnosticError(`browser-rs "${method}" write failed: ${error.message}`));
+      });
     });
   }
 
   private sendNotification(method: string, params?: Record<string, unknown>): Promise<void> {
-    if (!this.process?.stdin) {
+    const child = this.process;
+    const input = child?.stdin;
+    if (!child || child.exitCode !== null || child.signalCode !== null || !input || input.destroyed || !input.writable) {
       return Promise.reject(new Error('browser-rs process not started'));
     }
-    this.process.stdin.write(JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n');
-    return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      input.write(`${JSON.stringify({ jsonrpc: '2.0', method, params })}\n`, (error?: Error | null) => {
+        if (error) reject(this.diagnosticError(`browser-rs "${method}" write failed: ${error.message}`));
+        else resolve();
+      });
+    });
+  }
+
+  private rejectPending(error: Error): void {
+    for (const [, slot] of this.pending) {
+      clearTimeout(slot.timer);
+      slot.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  private diagnosticError(message: string): Error {
+    const diagnostics = this.stderrTail.trim();
+    return new Error(diagnostics ? `${message}\nbrowser-rs stderr tail:\n${diagnostics}` : message);
+  }
+
+  private waitForExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
+    if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(true);
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        child.removeListener('exit', onExit);
+        resolve(false);
+      }, timeoutMs);
+      timer.unref();
+      const onExit = () => {
+        clearTimeout(timer);
+        resolve(true);
+      };
+      child.once('exit', onExit);
+    });
   }
 }
 
@@ -605,17 +778,25 @@ export class BrowserRsMcpAdapter implements MCPAdapter {
         preflight.binaryPath,
         this.args,
         this.callTimeoutMs,
-        this.startupTimeoutMs,
+        browserRsSpawnEnv(preflight),
       );
     } else {
       this.transport = this.injectedTransport;
     }
 
-    await this.transport.start();
-    await this.transport.initialize();
-    const tools = await this.transport.listTools();
-    this.toolCountValue = tools.length;
-    this.setupFinishedAt = Date.now();
+    try {
+      await withTimeout((async () => {
+        await this.transport!.start();
+        await this.transport!.initialize();
+      })(), this.startupTimeoutMs, 'browser-rs startup');
+      const tools = await this.transport.listTools();
+      this.toolCountValue = tools.length;
+      this.setupFinishedAt = Date.now();
+    } catch (error) {
+      await this.transport.stop().catch(() => undefined);
+      this.transport = null;
+      throw error;
+    }
   }
 
   async teardown(): Promise<void> {

--- a/tests/benchmark/adapters/browser-rs-mcp-adapter.ts
+++ b/tests/benchmark/adapters/browser-rs-mcp-adapter.ts
@@ -1,0 +1,708 @@
+/**
+ * browser-rs-mcp competitor adapter for the competitive benchmark suite (#1554).
+ *
+ * This adapter treats browser-rs as an externally supplied MCP stdio binary.
+ * It does not download, vendor, or import browser-rs internals. Live runs must
+ * provide BROWSER_RS_BIN, and setup fails closed unless the binary reports the
+ * pinned version and its SHA-256 matches the pinned release asset for the
+ * current platform.
+ */
+
+import { spawn, execFileSync, ChildProcess } from 'child_process';
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { MCPAdapter, MCPToolResult } from '../benchmark-runner';
+
+interface MCPRequest {
+  jsonrpc: '2.0';
+  id: number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface MCPResponse {
+  jsonrpc: '2.0';
+  id: number;
+  result?: {
+    content?: Array<{ type: string; text?: string; data?: string }>;
+    tools?: BrowserRsMcpTool[];
+    isError?: boolean;
+  };
+  error?: { code: number; message: string };
+}
+
+export interface BrowserRsMcpTool {
+  name: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+}
+
+export interface BrowserRsMcpTransport {
+  start(): Promise<void>;
+  initialize(): Promise<void>;
+  listTools(): Promise<BrowserRsMcpTool[]>;
+  callTool(toolName: string, args: Record<string, unknown>): Promise<MCPToolResult>;
+  stop(): Promise<void>;
+  readonly command: readonly string[];
+}
+
+export interface BrowserRsMcpAdapterOptions {
+  /** Path to the maintainer-supplied browser-rs binary. Defaults to BROWSER_RS_BIN. */
+  binaryPath?: string;
+  /** Extra CLI arguments. The benchmark default uses browser-rs' stdio mode with no flags. */
+  args?: readonly string[];
+  /** Per-call timeout in ms (default 30s). */
+  callTimeoutMs?: number;
+  /** Startup timeout in ms (default 15s). */
+  startupTimeoutMs?: number;
+  /** Injected transport for deterministic tests. Skips subprocess construction and binary preflight. */
+  transport?: BrowserRsMcpTransport;
+}
+
+export interface BrowserRsPlatformPin {
+  asset: string;
+  sha256: string;
+}
+
+export type BrowserRsPreflightStatus =
+  | 'ok'
+  | 'missing_binary'
+  | 'unsupported_platform'
+  | 'version_mismatch'
+  | 'sha_mismatch'
+  | 'chrome_missing'
+  | 'profile_conflict'
+  | 'port_conflict';
+
+export interface BrowserRsPreflightResult {
+  status: BrowserRsPreflightStatus;
+  binaryPath: string;
+  command: readonly string[];
+  platformKey: string;
+  expectedVersion: string;
+  actualVersion: string;
+  expectedSha256: string;
+  actualSha256: string;
+  asset: string;
+  commit: string;
+  chromePath: string;
+  profilePath: string;
+  connectPort?: number;
+  message: string;
+}
+
+export const BROWSER_RS_PIN = {
+  library: 'browser-rs-mcp',
+  binary: 'browser-rs',
+  version: '0.1.13',
+  commit: '6efa54fe428f1203967a9c760a27d0647d5474ee',
+  license: 'Apache-2.0',
+  measuredAt: '2026-07-27 release asset',
+  platforms: {
+    'linux-x64': {
+      asset: 'browser-rs-linux-x64',
+      sha256: 'ae0e4f5d2a4e6a90a0f050c50a55fcb86aab7cdda7d1ea2fec1aa54a321e3f1c',
+    },
+    'darwin-arm64': {
+      asset: 'browser-rs-macos-arm64',
+      sha256: '618c75dc4f9c3297ba85d4e1ddaa9aaf67a671bc8abb393e1f64523dc084b310',
+    },
+  } satisfies Record<string, BrowserRsPlatformPin>,
+} as const;
+
+const DEFAULT_CALL_TIMEOUT_MS = 30000;
+const DEFAULT_STARTUP_TIMEOUT_MS = 15000;
+
+function textResult(text: string): MCPToolResult {
+  return { content: [{ type: 'text', text }] };
+}
+
+function errorResult(message: string): MCPToolResult {
+  return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+function joinText(result: MCPToolResult): string {
+  return (result.content || [])
+    .map((entry) => (typeof entry.text === 'string' ? entry.text : ''))
+    .filter((text) => text.length > 0)
+    .join('\n');
+}
+
+function extractVersion(output: string): string {
+  const match = output.match(/\b(\d+\.\d+\.\d+)\b/);
+  return match?.[1] ?? '';
+}
+
+export function browserRsPlatformKey(platform = process.platform, arch = process.arch): string {
+  return `${platform}-${arch}`;
+}
+
+export function browserRsPlatformPin(platform = process.platform, arch = process.arch): BrowserRsPlatformPin | null {
+  const key = browserRsPlatformKey(platform, arch);
+  return (BROWSER_RS_PIN.platforms as Record<string, BrowserRsPlatformPin | undefined>)[key] ?? null;
+}
+
+export function sha256File(path: string): string {
+  return createHash('sha256').update(fs.readFileSync(path)).digest('hex');
+}
+
+function commandCandidates(command: string, env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string[] {
+  const pathEntries = (env.PATH ?? '').split(path.delimiter).filter(Boolean);
+  if (platform !== 'win32') return pathEntries.map((entry) => path.join(entry, command));
+  const extensions = (env.PATHEXT ?? '.EXE;.CMD;.BAT;.COM').split(';').filter(Boolean);
+  return pathEntries.flatMap((entry) => extensions.map((extension) => path.join(entry, `${command}${extension}`)));
+}
+
+function canonicalExecutable(
+  value: string,
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+  cwd = process.cwd(),
+): string {
+  const candidates = path.isAbsolute(value) || value.includes(path.sep)
+    ? [path.resolve(cwd, value)]
+    : commandCandidates(value, env, platform);
+  for (const candidate of candidates) {
+    try {
+      const canonical = fs.realpathSync(candidate);
+      const stat = fs.statSync(canonical);
+      if (!stat.isFile()) continue;
+      if (platform !== 'win32') fs.accessSync(canonical, fs.constants.X_OK);
+      return canonical;
+    } catch {
+      // Keep looking through PATH candidates.
+    }
+  }
+  throw new Error(`executable not found or not runnable: ${value}`);
+}
+
+function resolveBrowserRsChrome(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string | null {
+  const explicit = env.AB_CHROME ?? env.OPENCHROME_BENCH_CHROME_PATH ?? env.CHROME_PATH;
+  if (explicit) {
+    try { return canonicalExecutable(explicit, env, platform); } catch { return null; }
+  }
+  const candidates = platform === 'darwin'
+    ? [
+        '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        '/Applications/Chromium.app/Contents/MacOS/Chromium',
+      ]
+    : platform === 'win32'
+      ? [
+          env['PROGRAMFILES(X86)'] && path.join(env['PROGRAMFILES(X86)'], 'Google', 'Chrome', 'Application', 'chrome.exe'),
+          env.PROGRAMFILES && path.join(env.PROGRAMFILES, 'Google', 'Chrome', 'Application', 'chrome.exe'),
+          env.LOCALAPPDATA && path.join(env.LOCALAPPDATA, 'Google', 'Chrome', 'Application', 'chrome.exe'),
+        ].filter((candidate): candidate is string => Boolean(candidate))
+      : ['google-chrome-stable', 'google-chrome', 'chromium', 'chromium-browser'];
+  for (const candidate of candidates) {
+    try { return canonicalExecutable(candidate, env, platform); } catch { /* continue */ }
+  }
+  return null;
+}
+
+function optionValue(args: readonly string[], names: readonly string[]): string | undefined {
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    for (const name of names) {
+      if (arg === name) return args[index + 1];
+      if (arg.startsWith(`${name}=`)) return arg.slice(name.length + 1);
+    }
+  }
+  return undefined;
+}
+
+function configuredConnectPort(args: readonly string[], env: NodeJS.ProcessEnv): number | undefined {
+  const raw = optionValue(args, ['--connect', '--cdp-endpoint']) ?? env.AB_CONNECT;
+  if (!raw) return undefined;
+  const numericPort = /^\d+$/.test(raw) ? Number(raw) : undefined;
+  let urlPort: number | undefined;
+  if (numericPort === undefined) {
+    try {
+      const parsed = new URL(raw.includes('://') ? raw : `http://${raw}`);
+      const inferred = parsed.port || (parsed.protocol === 'https:' || parsed.protocol === 'wss:' ? '443' : '80');
+      urlPort = Number(inferred);
+    } catch {
+      urlPort = undefined;
+    }
+  }
+  const port = numericPort ?? urlPort;
+  if (port === undefined || !Number.isInteger(port) || port <= 0 || port > 65535) {
+    return undefined;
+  }
+  return port;
+}
+
+function configuredProfilePath(args: readonly string[], env: NodeJS.ProcessEnv): string {
+  const configured = optionValue(args, ['--user-data-dir', '--profile']) ?? env.AB_PROFILE;
+  if (configured) return path.resolve(configured);
+  const home = env.HOME ?? env.USERPROFILE ?? os.homedir();
+  return home ? path.join(home, '.browser-rs', 'profile') : '';
+}
+
+function profileHasLock(profilePath: string): boolean {
+  if (!profilePath) return false;
+  return ['SingletonLock', 'SingletonSocket', 'SingletonCookie'].some((name) => {
+    try {
+      fs.lstatSync(path.join(profilePath, name));
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function probeCdpPort(port: number): boolean {
+  const script = [
+    "const http=require('http');",
+    'const port=Number(process.argv[1]);',
+    "const req=http.get({hostname:'127.0.0.1',port,path:'/json/version',timeout:1000},res=>{",
+    "let body='';res.on('data',c=>body+=c);res.on('end',()=>{",
+    "try{const value=JSON.parse(body);process.exit(res.statusCode===200&&typeof value.webSocketDebuggerUrl==='string'?0:1)}catch{process.exit(1)}})});",
+    'req.on(\'error\',()=>process.exit(1));req.on(\'timeout\',()=>{req.destroy();process.exit(1)});',
+  ].join('');
+  try {
+    execFileSync(process.execPath, ['-e', script, String(port)], { timeout: 2000, stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function preflightBrowserRsBinary(options: {
+  binaryPath?: string;
+  args?: readonly string[];
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  arch?: NodeJS.Architecture;
+  execVersion?: (binaryPath: string) => string;
+  hashFile?: (binaryPath: string) => string;
+  resolveBinary?: (binaryPath: string) => string;
+  resolveChrome?: (env: NodeJS.ProcessEnv, platform: NodeJS.Platform) => string | null;
+  profileConflict?: (profilePath: string) => boolean;
+  connectProbe?: (port: number) => boolean;
+} = {}): BrowserRsPreflightResult {
+  const env = options.env ?? process.env;
+  const requestedBinaryPath = options.binaryPath ?? env.BROWSER_RS_BIN ?? '';
+  const args = options.args ?? [];
+  const platform = options.platform ?? process.platform;
+  const platformKey = browserRsPlatformKey(platform, options.arch ?? process.arch);
+  const pin = browserRsPlatformPin(platform, options.arch ?? process.arch);
+  let binaryPath = requestedBinaryPath;
+  const base = {
+    binaryPath,
+    command: binaryPath ? [binaryPath, ...args] : [],
+    platformKey,
+    expectedVersion: BROWSER_RS_PIN.version,
+    actualVersion: '',
+    expectedSha256: pin?.sha256 ?? '',
+    actualSha256: '',
+    asset: pin?.asset ?? '',
+    commit: BROWSER_RS_PIN.commit,
+    chromePath: '',
+    profilePath: '',
+  };
+
+  if (!pin) {
+    return { ...base, status: 'unsupported_platform', message: `browser-rs has no pinned release asset for ${platformKey}` };
+  }
+  if (!requestedBinaryPath) {
+    return { ...base, status: 'missing_binary', message: 'BROWSER_RS_BIN is required for browser-rs live smoke' };
+  }
+
+  try {
+    binaryPath = options.resolveBinary
+      ? options.resolveBinary(requestedBinaryPath)
+      : canonicalExecutable(requestedBinaryPath, env, platform);
+  } catch (err) {
+    return {
+      ...base,
+      status: 'missing_binary',
+      message: `browser-rs binary path is not a canonical runnable file: ${(err as Error).message}`,
+    };
+  }
+  const resolvedBase = { ...base, binaryPath, command: [binaryPath, ...args] };
+
+  let versionOutput = '';
+  try {
+    versionOutput = options.execVersion
+      ? options.execVersion(binaryPath)
+      : execFileSync(binaryPath, ['--version'], { encoding: 'utf8', timeout: 3000, stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (err) {
+    return { ...resolvedBase, status: 'missing_binary', message: `browser-rs --version failed: ${(err as Error).message}` };
+  }
+
+  const actualVersion = extractVersion(versionOutput);
+  if (actualVersion !== BROWSER_RS_PIN.version) {
+    return {
+      ...resolvedBase,
+      actualVersion,
+      status: 'version_mismatch',
+      message: `browser-rs version mismatch: expected ${BROWSER_RS_PIN.version}, got ${actualVersion || 'unknown'}`,
+    };
+  }
+
+  let actualSha256 = '';
+  try {
+    actualSha256 = options.hashFile ? options.hashFile(binaryPath) : sha256File(binaryPath);
+  } catch (err) {
+    return { ...resolvedBase, actualVersion, status: 'sha_mismatch', message: `browser-rs SHA-256 check failed: ${(err as Error).message}` };
+  }
+
+  if (actualSha256 !== pin.sha256) {
+    return {
+      ...resolvedBase,
+      actualVersion,
+      actualSha256,
+      status: 'sha_mismatch',
+      message: `browser-rs SHA-256 mismatch: expected ${pin.sha256}, got ${actualSha256}`,
+    };
+  }
+
+  const identityBase = { ...resolvedBase, actualVersion, actualSha256 };
+  if (optionValue(args, ['--port']) !== undefined || env.AB_HTTP) {
+    return {
+      ...identityBase,
+      status: 'port_conflict',
+      message: 'browser-rs --port/AB_HTTP selects HTTP mode and conflicts with the stdio benchmark adapter',
+    };
+  }
+
+  const connectPort = configuredConnectPort(args, env);
+  if ((optionValue(args, ['--connect', '--cdp-endpoint']) ?? env.AB_CONNECT) && connectPort === undefined) {
+    return { ...identityBase, status: 'port_conflict', message: 'browser-rs connect port is invalid' };
+  }
+  if (connectPort !== undefined && !(options.connectProbe ?? probeCdpPort)(connectPort)) {
+    return {
+      ...identityBase,
+      connectPort,
+      status: 'port_conflict',
+      message: `browser-rs connect port ${connectPort} does not expose a compatible CDP endpoint`,
+    };
+  }
+
+  let chromePath = '';
+  let profilePath = '';
+  if (connectPort === undefined) {
+    chromePath = (options.resolveChrome ?? resolveBrowserRsChrome)(env, platform) ?? '';
+    if (!chromePath) {
+      return {
+        ...identityBase,
+        status: 'chrome_missing',
+        message: 'Chrome/Chromium is required for browser-rs live smoke; set AB_CHROME to a canonical executable path',
+      };
+    }
+    profilePath = configuredProfilePath(args, env);
+    if (!profilePath) {
+      return { ...identityBase, chromePath, status: 'profile_conflict', message: 'browser-rs profile path could not be resolved' };
+    }
+    if ((options.profileConflict ?? profileHasLock)(profilePath)) {
+      return {
+        ...identityBase,
+        chromePath,
+        profilePath,
+        status: 'profile_conflict',
+        message: `browser-rs profile is already locked: ${profilePath}`,
+      };
+    }
+  }
+  const environmentBase = { ...identityBase, chromePath, profilePath, connectPort };
+
+  return {
+    ...environmentBase,
+    status: 'ok',
+    message: 'browser-rs binary, Chrome/profile preflight, version, and SHA-256 match the pinned benchmark contract',
+  };
+}
+
+class SubprocessBrowserRsMcpTransport implements BrowserRsMcpTransport {
+  private process: ChildProcess | null = null;
+  private requestId = 0;
+  private buffer = '';
+  private readonly pending = new Map<
+    number,
+    { resolve: (r: MCPResponse) => void; reject: (e: Error) => void; timer: NodeJS.Timeout }
+  >();
+
+  readonly command: readonly string[];
+
+  constructor(
+    private readonly binaryPath: string,
+    args: readonly string[],
+    private readonly callTimeoutMs: number,
+    private readonly startupTimeoutMs: number,
+  ) {
+    this.command = [binaryPath, ...args];
+  }
+
+  async start(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.process = spawn(this.binaryPath, this.command.slice(1), { stdio: ['pipe', 'pipe', 'pipe'] });
+      let settled = false;
+      const startupTimer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          reject(new Error(`browser-rs startup timed out after ${this.startupTimeoutMs}ms`));
+        }
+      }, this.startupTimeoutMs);
+      startupTimer.unref();
+
+      this.process.stdout?.on('data', (data: Buffer) => {
+        this.buffer += data.toString();
+        const lines = this.buffer.split('\n');
+        this.buffer = lines.pop() || '';
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const response = JSON.parse(line) as MCPResponse;
+            const slot = this.pending.get(response.id);
+            if (slot) {
+              clearTimeout(slot.timer);
+              this.pending.delete(response.id);
+              slot.resolve(response);
+            }
+          } catch {
+            // MCP stdout should be JSON-only. Ignore stray lines defensively.
+          }
+        }
+      });
+
+      this.process.on('error', (err) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(startupTimer);
+          reject(err);
+        }
+      });
+      this.process.on('exit', (code) => {
+        for (const [, slot] of this.pending) {
+          clearTimeout(slot.timer);
+          slot.reject(new Error(`browser-rs exited with code ${code}`));
+        }
+        this.pending.clear();
+        if (!settled) {
+          settled = true;
+          clearTimeout(startupTimer);
+          reject(new Error(`browser-rs exited with code ${code} before startup`));
+        }
+      });
+
+      setImmediate(() => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(startupTimer);
+          resolve();
+        }
+      });
+    });
+  }
+
+  async initialize(): Promise<void> {
+    const response = await this.send('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'openchrome-benchmark', version: '1.0.0' },
+    });
+    if (response.error) throw new Error(`browser-rs initialize failed: ${response.error.message}`);
+    await this.sendNotification('notifications/initialized');
+  }
+
+  async listTools(): Promise<BrowserRsMcpTool[]> {
+    const response = await this.send('tools/list', {});
+    if (response.error) throw new Error(`browser-rs tools/list failed: ${response.error.message}`);
+    return response.result?.tools ?? [];
+  }
+
+  async callTool(toolName: string, args: Record<string, unknown>): Promise<MCPToolResult> {
+    const response = await this.send('tools/call', { name: toolName, arguments: args });
+    if (response.error) {
+      return errorResult(`browser-rs ${toolName} failed: ${response.error.message}`);
+    }
+    const result = response.result || {};
+    return { content: result.content || [], isError: result.isError };
+  }
+
+  async stop(): Promise<void> {
+    try {
+      if (this.process?.stdin) await this.send('shutdown', {});
+    } catch {
+      // Best-effort graceful shutdown; process cleanup below is authoritative.
+    }
+    for (const [, slot] of this.pending) {
+      clearTimeout(slot.timer);
+      slot.reject(new Error('browser-rs transport stopped'));
+    }
+    this.pending.clear();
+    if (this.process) {
+      this.process.stdin?.end();
+      this.process.kill();
+      this.process = null;
+    }
+  }
+
+  private send(method: string, params?: Record<string, unknown>): Promise<MCPResponse> {
+    if (!this.process?.stdin) {
+      return Promise.reject(new Error('browser-rs process not started'));
+    }
+    const id = ++this.requestId;
+    const req: MCPRequest = { jsonrpc: '2.0', id, method, params };
+    return new Promise<MCPResponse>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (this.pending.has(id)) {
+          this.pending.delete(id);
+          reject(new Error(`browser-rs "${method}" timed out after ${this.callTimeoutMs}ms`));
+        }
+      }, this.callTimeoutMs);
+      timer.unref();
+      this.pending.set(id, { resolve, reject, timer });
+      this.process!.stdin!.write(JSON.stringify(req) + '\n');
+    });
+  }
+
+  private sendNotification(method: string, params?: Record<string, unknown>): Promise<void> {
+    if (!this.process?.stdin) {
+      return Promise.reject(new Error('browser-rs process not started'));
+    }
+    this.process.stdin.write(JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n');
+    return Promise.resolve();
+  }
+}
+
+export class BrowserRsMcpAdapter implements MCPAdapter {
+  readonly name = 'browser-rs-mcp';
+  readonly mode = 'a11y-snapshot-stdio';
+  readonly kind = 'mcp' as const;
+  readonly version = BROWSER_RS_PIN.version;
+
+  private readonly binaryPath?: string;
+  private readonly args: readonly string[];
+  private readonly callTimeoutMs: number;
+  private readonly startupTimeoutMs: number;
+  private readonly injectedTransport?: BrowserRsMcpTransport;
+
+  private transport: BrowserRsMcpTransport | null = null;
+  private pageId: string | null = null;
+  private toolCountValue = 0;
+  private lastPreflightValue: BrowserRsPreflightResult | null = null;
+  private setupStartedAt = 0;
+  private setupFinishedAt = 0;
+
+  constructor(options: BrowserRsMcpAdapterOptions = {}) {
+    this.binaryPath = options.binaryPath;
+    this.args = options.args ?? [];
+    this.callTimeoutMs = options.callTimeoutMs ?? DEFAULT_CALL_TIMEOUT_MS;
+    this.startupTimeoutMs = options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS;
+    this.injectedTransport = options.transport;
+  }
+
+  async setup(): Promise<void> {
+    this.setupStartedAt = Date.now();
+    if (!this.injectedTransport) {
+      const preflight = preflightBrowserRsBinary({ binaryPath: this.binaryPath, args: this.args });
+      this.lastPreflightValue = preflight;
+      if (preflight.status !== 'ok') throw new Error(preflight.message);
+      this.transport = new SubprocessBrowserRsMcpTransport(
+        preflight.binaryPath,
+        this.args,
+        this.callTimeoutMs,
+        this.startupTimeoutMs,
+      );
+    } else {
+      this.transport = this.injectedTransport;
+    }
+
+    await this.transport.start();
+    await this.transport.initialize();
+    const tools = await this.transport.listTools();
+    this.toolCountValue = tools.length;
+    this.setupFinishedAt = Date.now();
+  }
+
+  async teardown(): Promise<void> {
+    if (this.transport) {
+      await this.transport.stop();
+      this.transport = null;
+    }
+    this.pageId = null;
+    this.toolCountValue = 0;
+    this.setupStartedAt = 0;
+    this.setupFinishedAt = 0;
+  }
+
+  async callTool(toolName: string, args: Record<string, unknown>): Promise<MCPToolResult> {
+    if (!this.transport) {
+      return errorResult('BrowserRsMcpAdapter: setup() was not called');
+    }
+    try {
+      switch (toolName) {
+        case 'tabs_create':
+          return await this.createTab(args);
+        case 'read_page':
+          return await this.readPage(args);
+        case 'tabs_close':
+          return await this.closeTab(args);
+        default:
+          return errorResult(`BrowserRsMcpAdapter: unsupported tool "${toolName}"`);
+      }
+    } catch (err) {
+      return errorResult(`BrowserRsMcpAdapter: ${toolName} failed: ${(err as Error).message}`);
+    }
+  }
+
+  get toolCount(): number {
+    return this.toolCountValue;
+  }
+
+  get command(): readonly string[] {
+    return this.transport?.command ?? [];
+  }
+
+  get lastPreflight(): BrowserRsPreflightResult | null {
+    return this.lastPreflightValue;
+  }
+
+  get setupDurationMs(): number {
+    return this.setupFinishedAt > this.setupStartedAt ? this.setupFinishedAt - this.setupStartedAt : 0;
+  }
+
+  private async createTab(args: Record<string, unknown>): Promise<MCPToolResult> {
+    const url = typeof args.url === 'string' ? args.url : '';
+    const result = await (this.transport as BrowserRsMcpTransport).callTool('browser_navigate', { url });
+    if (result.isError) return result;
+    const text = joinText(result);
+    const pageId = parsePageId(text);
+    if (!pageId) {
+      return errorResult('BrowserRsMcpAdapter: browser_navigate returned no page id');
+    }
+    this.pageId = pageId;
+    return textResult(JSON.stringify({ tabId: pageId }));
+  }
+
+  private async readPage(args: Record<string, unknown>): Promise<MCPToolResult> {
+    const tabId = typeof args.tabId === 'string' ? args.tabId : '';
+    const page = tabId || this.pageId;
+    if (!page || page !== this.pageId) {
+      return errorResult(`BrowserRsMcpAdapter: unknown tabId "${tabId}"`);
+    }
+    const result = await (this.transport as BrowserRsMcpTransport).callTool('browser_snapshot', { page });
+    if (result.isError) return result;
+    return textResult(joinText(result));
+  }
+
+  private async closeTab(args: Record<string, unknown>): Promise<MCPToolResult> {
+    const tabId = typeof args.tabId === 'string' ? args.tabId : '';
+    if (!this.pageId || tabId !== this.pageId) {
+      return errorResult(`BrowserRsMcpAdapter: unknown tabId "${tabId}"`);
+    }
+    const result = await (this.transport as BrowserRsMcpTransport).callTool('browser_close_page', { page: this.pageId });
+    if (result.isError) return result;
+    const closed = this.pageId;
+    this.pageId = null;
+    return textResult(JSON.stringify({ closed }));
+  }
+}
+
+function parsePageId(text: string): string {
+  const match = text.match(/^page\s+([^\s]+)/m);
+  return match?.[1] ?? '';
+}

--- a/tests/benchmark/adapters/index.ts
+++ b/tests/benchmark/adapters/index.ts
@@ -40,6 +40,8 @@ export {
 
 export {
   BROWSER_RS_PIN,
+  BrowserRsCdpProbeResult,
+  BrowserRsConnectTarget,
   BrowserRsMcpAdapter,
   BrowserRsMcpAdapterOptions,
   BrowserRsMcpTool,

--- a/tests/benchmark/adapters/index.ts
+++ b/tests/benchmark/adapters/index.ts
@@ -39,6 +39,19 @@ export {
 } from './playwright-mcp-adapter';
 
 export {
+  BROWSER_RS_PIN,
+  BrowserRsMcpAdapter,
+  BrowserRsMcpAdapterOptions,
+  BrowserRsMcpTool,
+  BrowserRsMcpTransport,
+  BrowserRsPreflightResult,
+  BrowserRsPreflightStatus,
+  browserRsPlatformKey,
+  browserRsPlatformPin,
+  preflightBrowserRsBinary,
+} from './browser-rs-mcp-adapter';
+
+export {
   CrawleeAdapter,
   CrawleeAdapterOptions,
   CrawleeExtractor,

--- a/tests/benchmark/run-competitor-smoke.test.ts
+++ b/tests/benchmark/run-competitor-smoke.test.ts
@@ -4,6 +4,7 @@ import type { MCPAdapter, MCPToolResult } from './benchmark-runner';
 import packageJson from '../../package.json';
 import {
   AdapterSpec,
+  browserRsArgsForSharedCdp,
   parseSmokeArgs,
   runCompetitorSmokeMatrix,
   runOne,
@@ -43,9 +44,17 @@ describe('competitor smoke matrix', () => {
     expect(opts.timeoutMs).toBe(30000);
   });
 
+  test('maps the shared benchmark CDP endpoint to browser-rs stdio connect args', () => {
+    expect(browserRsArgsForSharedCdp(' http://127.0.0.1:9222 ')).toEqual([
+      '--connect',
+      'http://127.0.0.1:9222',
+    ]);
+    expect(browserRsArgsForSharedCdp(undefined)).toEqual([]);
+  });
+
   test('runs no-Chrome OpenChrome stub and Crawlee rows while explicitly skipping live competitors', async () => {
     const rows = await runCompetitorSmokeMatrix(parseSmokeArgs(['--library=all', '--timeout-ms=30000']));
-    expect(rows.map((row) => row.library).sort()).toEqual(['Crawlee', 'OpenChrome', 'Playwright', 'Puppeteer', 'browser-use', 'playwright-mcp'].sort());
+    expect(rows.map((row) => row.library).sort()).toEqual(['Crawlee', 'OpenChrome', 'Playwright', 'Puppeteer', 'browser-rs-mcp', 'browser-use', 'playwright-mcp'].sort());
     expect(rows.find((row) => row.library === 'OpenChrome')?.status).toBe('passed');
     expect(rows.find((row) => row.library === 'Crawlee')?.status).toBe('passed');
     const playwright = rows.find((row) => row.library === 'Playwright');
@@ -54,8 +63,100 @@ describe('competitor smoke matrix', () => {
     expect(playwright?.version).toMatch(/^[0-9]+\.[0-9]+\.[0-9]+/);
     expect(playwright?.versionPinned).toBe(true);
     expect(rows.find((row) => row.library === 'OpenChrome')?.version).toBe(packageJson.version);
+    const browserRs = rows.find((row) => row.library === 'browser-rs-mcp');
+    expect(browserRs?.status).toBe('skipped');
+    expect(browserRs?.skipCategory).toBe('not_requested');
+    expect(browserRs?.version).toBe('0.1.13');
+    expect(browserRs?.commit).toBe('6efa54fe428f1203967a9c760a27d0647d5474ee');
+    expect(browserRs?.chromeVersion).toBeTruthy();
+    expect(browserRs?.os).toBeTruthy();
+    if (browserRs?.expectedSha256) {
+      expect(browserRs.expectedSha256).toMatch(/^[a-f0-9]{64}$/);
+    }
     expect(rows.every((row) => row.sameTaskContract)).toBe(true);
   }, 30000);
+
+  test('emits a structured browser-rs skip when live smoke is requested without BROWSER_RS_BIN', async () => {
+    const previous = process.env.BROWSER_RS_BIN;
+    delete process.env.BROWSER_RS_BIN;
+    try {
+      const rows = await runCompetitorSmokeMatrix(parseSmokeArgs(['--library=browser-rs-mcp', '--include-live=true', '--timeout-ms=5000']));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].library).toBe('browser-rs-mcp');
+      expect(rows[0].status).toBe('skipped');
+      expect(['dependency_missing', 'unsupported_platform']).toContain(rows[0].skipCategory);
+      if (rows[0].skipCategory === 'dependency_missing') {
+        expect(rows[0].skipReason).toContain('BROWSER_RS_BIN');
+      }
+      expect(rows[0].commit).toBe('6efa54fe428f1203967a9c760a27d0647d5474ee');
+    } finally {
+      if (previous === undefined) delete process.env.BROWSER_RS_BIN;
+      else process.env.BROWSER_RS_BIN = previous;
+    }
+  });
+
+  test('fails the browser-rs row closed when external preflight reports a pin mismatch', async () => {
+    const spec: AdapterSpec = {
+      library: 'browser-rs-mcp',
+      mode: 'a11y-snapshot-stdio',
+      liveRequired: true,
+      externalPreflight: () => ({
+        status: 'version_mismatch',
+        binaryPath: '/tmp/browser-rs',
+        command: ['/tmp/browser-rs'],
+        platformKey: 'linux-x64',
+        expectedVersion: '0.1.13',
+        actualVersion: '0.1.12',
+        expectedSha256: 'a'.repeat(64),
+        actualSha256: 'a'.repeat(64),
+        asset: 'browser-rs-linux-x64',
+        commit: '6efa54fe428f1203967a9c760a27d0647d5474ee',
+        chromePath: '/tmp/chrome',
+        profilePath: '/tmp/browser-rs-profile',
+        message: 'browser-rs version mismatch: expected 0.1.13, got 0.1.12',
+      }),
+      adapterFactory: () => fakeAdapter({ content: [{ type: 'text', text: 'should not run' }] }),
+    };
+    const row = await runOne(spec, 'http://example.local/', { includeLive: true, library: 'browser-rs-mcp', timeoutMs: 5000 });
+    expect(row.status).toBe('failed');
+    expect(row.skipCategory).toBe('none');
+    expect(row.failure).toContain('version mismatch');
+    expect(row.actualSha256).toBe('a'.repeat(64));
+  });
+
+  test('reports browser-rs Chrome/profile/port preflight failures as structured runtime skips', async () => {
+    for (const status of ['chrome_missing', 'profile_conflict', 'port_conflict'] as const) {
+      const spec: AdapterSpec = {
+        library: 'browser-rs-mcp',
+        mode: 'a11y-snapshot-stdio',
+        liveRequired: true,
+        externalPreflight: () => ({
+          status,
+          binaryPath: '/tmp/browser-rs',
+          command: ['/tmp/browser-rs'],
+          platformKey: 'linux-x64',
+          expectedVersion: '0.1.13',
+          actualVersion: '',
+          expectedSha256: 'a'.repeat(64),
+          actualSha256: '',
+          asset: 'browser-rs-linux-x64',
+          commit: '6efa54fe428f1203967a9c760a27d0647d5474ee',
+          chromePath: '',
+          profilePath: '/tmp/browser-rs-profile',
+          message: `${status} preflight`,
+        }),
+        adapterFactory: () => fakeAdapter({ content: [{ type: 'text', text: 'should not run' }] }),
+      };
+      const row = await runOne(spec, 'http://example.local/', {
+        includeLive: true,
+        library: 'browser-rs-mcp',
+        timeoutMs: 5000,
+      });
+      expect(row.status).toBe('skipped');
+      expect(row.skipCategory).toBe('runtime_missing');
+      expect(row.skipReason).toContain(status);
+    }
+  });
 
   test('demotes a three-calls-succeeded row to failed when read_page returns empty payload', async () => {
     const spec = specOf(fakeAdapter({ content: [{ type: 'text', text: '' }] }));

--- a/tests/benchmark/run-competitor-smoke.test.ts
+++ b/tests/benchmark/run-competitor-smoke.test.ts
@@ -10,14 +10,17 @@ import {
   runOne,
 } from './run-competitor-smoke';
 
-function fakeAdapter(read: MCPToolResult): MCPAdapter {
+function fakeAdapter(
+  read: MCPToolResult,
+  close: MCPToolResult = { content: [{ type: 'text', text: 'ok' }] },
+): MCPAdapter {
   return {
     name: 'fake',
     mode: 'fake',
     async callTool(tool: string): Promise<MCPToolResult> {
       if (tool === 'tabs_create') return { content: [{ type: 'text', text: JSON.stringify({ tabId: 'tab-1' }) }] };
       if (tool === 'read_page') return read;
-      if (tool === 'tabs_close') return { content: [{ type: 'text', text: 'ok' }] };
+      if (tool === 'tabs_close') return close;
       throw new Error(`unexpected tool ${tool}`);
     },
   };
@@ -87,6 +90,7 @@ describe('competitor smoke matrix', () => {
       expect(['dependency_missing', 'unsupported_platform']).toContain(rows[0].skipCategory);
       if (rows[0].skipCategory === 'dependency_missing') {
         expect(rows[0].skipReason).toContain('BROWSER_RS_BIN');
+        expect(rows[0].dependencyAvailable).toBe(false);
       }
       expect(rows[0].commit).toBe('6efa54fe428f1203967a9c760a27d0647d5474ee');
     } finally {
@@ -112,6 +116,7 @@ describe('competitor smoke matrix', () => {
         asset: 'browser-rs-linux-x64',
         commit: '6efa54fe428f1203967a9c760a27d0647d5474ee',
         chromePath: '/tmp/chrome',
+        chromeVersion: 'Google Chrome 150.0.7871.187',
         profilePath: '/tmp/browser-rs-profile',
         message: 'browser-rs version mismatch: expected 0.1.13, got 0.1.12',
       }),
@@ -142,6 +147,7 @@ describe('competitor smoke matrix', () => {
           asset: 'browser-rs-linux-x64',
           commit: '6efa54fe428f1203967a9c760a27d0647d5474ee',
           chromePath: '',
+          chromeVersion: '',
           profilePath: '/tmp/browser-rs-profile',
           message: `${status} preflight`,
         }),
@@ -172,5 +178,58 @@ describe('competitor smoke matrix', () => {
     expect(row.status).toBe('passed');
     expect(row.payloadChars).toBeGreaterThan(0);
     expect(row.failure).toBe('');
+  });
+
+  test('fails the row when tabs_close returns an MCP tool error', async () => {
+    const spec = specOf(fakeAdapter(
+      { content: [{ type: 'text', text: '<html><body>hi</body></html>' }] },
+      { content: [{ type: 'text', text: 'close rejected' }], isError: true },
+    ));
+    const row = await runOne(spec, 'http://example.local/', { includeLive: false, library: 'all', timeoutMs: 5000 });
+    expect(row.status).toBe('failed');
+    expect(row.failure).toContain('close rejected');
+  });
+
+  test('preserves verified browser-rs evidence when a live tool call fails', async () => {
+    const preflight = {
+      status: 'ok' as const,
+      binaryPath: '/canonical/browser-rs',
+      command: ['/canonical/browser-rs', '--connect', 'http://127.0.0.1:9333'],
+      platformKey: 'linux-x64',
+      expectedVersion: '0.1.13',
+      actualVersion: '0.1.13',
+      expectedSha256: 'a'.repeat(64),
+      actualSha256: 'a'.repeat(64),
+      asset: 'browser-rs-linux-x64',
+      commit: '6efa54fe428f1203967a9c760a27d0647d5474ee',
+      chromePath: '',
+      chromeVersion: 'Chrome/150.0.7871.187',
+      profilePath: '',
+      connectPort: 9333,
+      connectEndpoint: 'http://127.0.0.1:9333/',
+      message: 'ok',
+    };
+    const spec: AdapterSpec = {
+      library: 'browser-rs-mcp',
+      mode: 'a11y-snapshot-stdio',
+      liveRequired: true,
+      externalPreflight: () => preflight,
+      adapterFactory: () => fakeAdapter({
+        content: [{ type: 'text', text: 'snapshot rejected' }],
+        isError: true,
+      }),
+    };
+    const row = await runOne(spec, 'http://example.local/', {
+      includeLive: true,
+      library: 'browser-rs-mcp',
+      timeoutMs: 5000,
+    });
+    expect(row.status).toBe('failed');
+    expect(row.binaryPath).toBe('/canonical/browser-rs');
+    expect(row.versionSource).toBe('external-binary');
+    expect(row.command).toEqual(preflight.command);
+    expect(row.actualSha256).toBe('a'.repeat(64));
+    expect(row.connectEndpoint).toBe('http://127.0.0.1:9333/');
+    expect(row.chromeVersion).toBe('Chrome/150.0.7871.187');
   });
 });

--- a/tests/benchmark/run-competitor-smoke.ts
+++ b/tests/benchmark/run-competitor-smoke.ts
@@ -73,6 +73,7 @@ export interface CompetitorSmokeRow {
   chromePath?: string;
   profilePath?: string;
   connectPort?: number;
+  connectEndpoint?: string;
   chromeVersion?: string;
   os?: string;
   toolCount?: number;
@@ -280,6 +281,7 @@ export async function runOne(spec: AdapterSpec, url: string, options: Competitor
   }
 
   const externalPreflight = spec.externalPreflight?.();
+  const externalMetadata = externalPreflight ? rowMetadataForBrowserRs(externalPreflight) : {};
   if (externalPreflight && externalPreflight.status !== 'ok') {
     const skipCategory = externalPreflight.status === 'unsupported_platform'
       ? 'unsupported_platform'
@@ -290,7 +292,8 @@ export async function runOne(spec: AdapterSpec, url: string, options: Competitor
         : 'none';
     return {
       ...base,
-      ...rowMetadataForBrowserRs(externalPreflight),
+      ...externalMetadata,
+      dependencyAvailable: externalPreflight.status !== 'missing_binary',
       status: skipCategory === 'none' ? 'failed' : 'skipped',
       skipCategory,
       durationMs: 0,
@@ -321,8 +324,10 @@ export async function runOne(spec: AdapterSpec, url: string, options: Competitor
     const tabId = parseTabId(create.content?.[0]?.text);
     const read = await withTimeout(adapter.callTool('read_page', { tabId }), options.timeoutMs, `${spec.library} read_page`);
     if (read.isError) throw new Error(read.content?.[0]?.text ?? 'read_page failed');
-    await withTimeout(adapter.callTool('tabs_close', { tabId }), options.timeoutMs, `${spec.library} tabs_close`);
+    const close = await withTimeout(adapter.callTool('tabs_close', { tabId }), options.timeoutMs, `${spec.library} tabs_close`);
+    if (close.isError) throw new Error(close.content?.[0]?.text ?? 'tabs_close failed');
     const payload = read.content?.map((entry) => entry.text ?? '').join('\n') ?? '';
+    const runtimeMetadata = { ...externalMetadata, ...adapterMetadata(adapter) };
     // Sanity gate: an adapter that returns the all-three-calls-succeeded shape
     // but ships an empty payload is not actually evidence that the library can
     // observe a page — it just means none of the three calls *threw*. The
@@ -338,6 +343,7 @@ export async function runOne(spec: AdapterSpec, url: string, options: Competitor
         payloadChars: 0,
         skipReason: '',
         failure: 'empty_payload: read_page returned no text content',
+        ...runtimeMetadata,
       };
     }
     return {
@@ -348,7 +354,7 @@ export async function runOne(spec: AdapterSpec, url: string, options: Competitor
       payloadChars: payload.length,
       skipReason: '',
       failure: '',
-      ...adapterMetadata(adapter),
+      ...runtimeMetadata,
     };
   } catch (err) {
     return {
@@ -359,6 +365,8 @@ export async function runOne(spec: AdapterSpec, url: string, options: Competitor
       payloadChars: 0,
       skipReason: '',
       failure: err instanceof Error ? err.message : String(err),
+      ...externalMetadata,
+      ...adapterMetadata(adapter),
     };
   } finally {
     await adapter.teardown?.().catch(() => undefined);
@@ -383,6 +391,8 @@ function rowMetadataForBrowserRsPin(environment?: Pick<EnvironmentMetadata, 'chr
 
 function rowMetadataForBrowserRs(preflight: BrowserRsPreflightResult): Partial<CompetitorSmokeRow> {
   return {
+    version: preflight.actualVersion || preflight.expectedVersion,
+    versionSource: preflight.actualVersion ? 'external-binary' : 'benchmark-registry',
     commit: preflight.commit,
     license: BROWSER_RS_PIN.license,
     binaryPath: preflight.binaryPath,
@@ -394,16 +404,19 @@ function rowMetadataForBrowserRs(preflight: BrowserRsPreflightResult): Partial<C
     chromePath: preflight.chromePath,
     profilePath: preflight.profilePath,
     connectPort: preflight.connectPort,
+    connectEndpoint: preflight.connectEndpoint,
+    chromeVersion: preflight.chromeVersion,
   };
 }
 
 function adapterMetadata(adapter: MCPAdapter): Partial<CompetitorSmokeRow> {
   if (adapter instanceof BrowserRsMcpAdapter) {
+    const preflight = adapter.lastPreflight;
     return {
-      command: adapter.command,
+      ...(preflight ? rowMetadataForBrowserRs(preflight) : {}),
+      command: adapter.command.length > 0 ? adapter.command : preflight?.command,
       toolCount: adapter.toolCount,
       adapterSetupMs: adapter.setupDurationMs,
-      actualSha256: adapter.lastPreflight?.actualSha256,
     };
   }
   return {};

--- a/tests/benchmark/run-competitor-smoke.ts
+++ b/tests/benchmark/run-competitor-smoke.ts
@@ -14,29 +14,36 @@ import { spawnSync } from 'child_process';
 
 import { MCPAdapter } from './benchmark-runner';
 import { buildResultEnvelope, assertValidResultEnvelope } from './utils/result-envelope';
-import { captureEnvironment } from './utils/environment';
+import { captureEnvironment, EnvironmentMetadata } from './utils/environment';
 import { startStaticFixtureServer } from './fixtures/static-server';
 import {
   BrowserUseAdapter,
+  BROWSER_RS_PIN,
+  BrowserRsMcpAdapter,
+  BrowserRsPreflightResult,
+  browserRsPlatformKey,
+  browserRsPlatformPin,
   CrawleeAdapter,
   OpenChromeRealAdapter,
   OpenChromeStubAdapter,
   PlaywrightAdapter,
   PlaywrightMcpAdapter,
   PuppeteerAdapter,
+  preflightBrowserRsBinary,
 } from './adapters';
 
 const OUTPUT_PATH = path.join(process.cwd(), 'benchmark', 'results', 'competitor-smoke.json');
 
-export type SmokeLibrary = 'openchrome' | 'playwright' | 'puppeteer' | 'crawlee' | 'playwright-mcp' | 'browser-use' | 'all';
+export type SmokeLibrary = 'openchrome' | 'playwright' | 'puppeteer' | 'crawlee' | 'playwright-mcp' | 'browser-rs-mcp' | 'browser-use' | 'all';
 export type SmokeStatus = 'passed' | 'failed' | 'skipped';
-export type SmokeSkipCategory = 'none' | 'not_requested' | 'dependency_missing' | 'runtime_missing' | 'not_wired';
-export type SmokeVersionSource = 'package-json' | 'node-resolution' | 'python-importlib' | 'benchmark-registry' | 'unknown';
+export type SmokeSkipCategory = 'none' | 'not_requested' | 'dependency_missing' | 'runtime_missing' | 'unsupported_platform' | 'not_wired';
+export type SmokeVersionSource = 'package-json' | 'node-resolution' | 'python-importlib' | 'benchmark-registry' | 'external-binary' | 'unknown';
 
 export interface CompetitorSmokeOptions {
   includeLive: boolean;
   library: SmokeLibrary;
   timeoutMs: number;
+  rowEnvironment?: Pick<EnvironmentMetadata, 'chromeVersion' | 'os'>;
 }
 
 export interface CompetitorSmokeRow {
@@ -55,6 +62,21 @@ export interface CompetitorSmokeRow {
   payloadChars: number;
   skipReason: string;
   failure: string;
+  commit?: string;
+  license?: string;
+  binaryPath?: string;
+  command?: readonly string[];
+  platformKey?: string;
+  expectedSha256?: string;
+  actualSha256?: string;
+  releaseAsset?: string;
+  chromePath?: string;
+  profilePath?: string;
+  connectPort?: number;
+  chromeVersion?: string;
+  os?: string;
+  toolCount?: number;
+  adapterSetupMs?: number;
 }
 
 export interface AdapterSpec {
@@ -62,6 +84,7 @@ export interface AdapterSpec {
   mode: string;
   liveRequired: boolean;
   packageName?: string;
+  externalPreflight?: () => BrowserRsPreflightResult;
   adapterFactory: () => MCPAdapter;
 }
 
@@ -71,7 +94,7 @@ interface VersionInfo {
   dependencyAvailable: boolean;
 }
 
-const LIBRARIES: readonly Exclude<SmokeLibrary, 'all'>[] = ['openchrome', 'playwright', 'puppeteer', 'crawlee', 'playwright-mcp', 'browser-use'];
+const LIBRARIES: readonly Exclude<SmokeLibrary, 'all'>[] = ['openchrome', 'playwright', 'puppeteer', 'crawlee', 'playwright-mcp', 'browser-rs-mcp', 'browser-use'];
 
 const REGISTRY_PINNED_VERSIONS: Readonly<Record<string, string>> = {
   OpenChrome: readRepoVersion(),
@@ -79,6 +102,7 @@ const REGISTRY_PINNED_VERSIONS: Readonly<Record<string, string>> = {
   Puppeteer: '23.10.3',
   Crawlee: '3.16.0',
   'playwright-mcp': '0.0.75',
+  'browser-rs-mcp': BROWSER_RS_PIN.version,
   'browser-use': '0.12.6',
 };
 
@@ -113,6 +137,11 @@ export function parseSmokeArgs(argv: string[]): CompetitorSmokeOptions {
   return { includeLive, library, timeoutMs };
 }
 
+export function browserRsArgsForSharedCdp(cdpEndpoint: string | undefined): readonly string[] {
+  const endpoint = cdpEndpoint?.trim();
+  return endpoint ? ['--connect', endpoint] : [];
+}
+
 function specs(options: CompetitorSmokeOptions): AdapterSpec[] {
   const requested = options.library === 'all' ? LIBRARIES : [options.library];
   // Every CDP-based adapter in the 6-way smoke attaches to the *operator's*
@@ -122,6 +151,7 @@ function specs(options: CompetitorSmokeOptions): AdapterSpec[] {
   // and (b) avoids the failure mode where two adapters race to launch their
   // own Chromium against an identical default user-data-dir.
   const cdpEndpoint = process.env.OPENCHROME_BENCH_CDP_ENDPOINT;
+  const browserRsArgs = browserRsArgsForSharedCdp(cdpEndpoint);
   const all: Record<Exclude<SmokeLibrary, 'all'>, AdapterSpec> = {
     openchrome: options.includeLive
       ? { library: 'OpenChrome', mode: 'dom-live', liveRequired: true, adapterFactory: () => new OpenChromeRealAdapter({ mode: 'dom', cdpEndpoint }) }
@@ -130,6 +160,13 @@ function specs(options: CompetitorSmokeOptions): AdapterSpec[] {
     puppeteer: { library: 'Puppeteer', mode: 'raw-html-cdp', liveRequired: true, packageName: 'puppeteer-core', adapterFactory: () => new PuppeteerAdapter({ browserURL: cdpEndpoint }) },
     crawlee: { library: 'Crawlee', mode: 'cheerio-text', liveRequired: false, packageName: 'crawlee', adapterFactory: () => new CrawleeAdapter() },
     'playwright-mcp': { library: 'playwright-mcp', mode: 'native-mcp', liveRequired: true, packageName: '@playwright/mcp', adapterFactory: () => new PlaywrightMcpAdapter({ serverPath: process.env.PLAYWRIGHT_MCP_SERVER_PATH, cdpEndpoint }) },
+    'browser-rs-mcp': {
+      library: 'browser-rs-mcp',
+      mode: 'a11y-snapshot-stdio',
+      liveRequired: true,
+      externalPreflight: () => preflightBrowserRsBinary({ binaryPath: process.env.BROWSER_RS_BIN, args: browserRsArgs }),
+      adapterFactory: () => new BrowserRsMcpAdapter({ binaryPath: process.env.BROWSER_RS_BIN, args: browserRsArgs }),
+    },
     'browser-use': { library: 'browser-use', mode: 'python-bridge', liveRequired: true, adapterFactory: () => new BrowserUseAdapter({ bridgeScriptPath: process.env.BROWSER_USE_BRIDGE_SCRIPT, python: process.env.BROWSER_USE_PYTHON }) },
   };
   return requested.map((library) => all[library]);
@@ -195,6 +232,9 @@ function versionInfoFor(spec: AdapterSpec): VersionInfo {
   if (spec.library === 'OpenChrome') {
     return { version: readRepoVersion(), source: 'package-json', dependencyAvailable: true };
   }
+  if (spec.library === 'browser-rs-mcp') {
+    return { version: BROWSER_RS_PIN.version, source: 'benchmark-registry', dependencyAvailable: true };
+  }
   if (spec.library === 'browser-use') return browserUseVersion();
   if (spec.packageName) return packageVersion(spec.packageName);
   return { version: REGISTRY_PINNED_VERSIONS[spec.library] ?? 'unknown', source: 'benchmark-registry', dependencyAvailable: false };
@@ -213,6 +253,7 @@ function parseTabId(text: string | undefined): string {
 
 export async function runOne(spec: AdapterSpec, url: string, options: CompetitorSmokeOptions): Promise<CompetitorSmokeRow> {
   const versionInfo = versionInfoFor(spec);
+  const staticMetadata = spec.library === 'browser-rs-mcp' ? rowMetadataForBrowserRsPin(options.rowEnvironment) : {};
   const base = {
     library: spec.library,
     mode: spec.mode,
@@ -223,6 +264,7 @@ export async function runOne(spec: AdapterSpec, url: string, options: Competitor
     versionPinned: isPinnedVersion(versionInfo.version),
     dependencyAvailable: versionInfo.dependencyAvailable,
     sameTaskContract: true,
+    ...staticMetadata,
   };
 
   if (spec.liveRequired && !options.includeLive) {
@@ -234,6 +276,27 @@ export async function runOne(spec: AdapterSpec, url: string, options: Competitor
       payloadChars: 0,
       skipReason: 'live competitor omitted; pass --include-live with required runtime/credentials',
       failure: '',
+    };
+  }
+
+  const externalPreflight = spec.externalPreflight?.();
+  if (externalPreflight && externalPreflight.status !== 'ok') {
+    const skipCategory = externalPreflight.status === 'unsupported_platform'
+      ? 'unsupported_platform'
+      : externalPreflight.status === 'missing_binary'
+        ? 'dependency_missing'
+        : ['chrome_missing', 'profile_conflict', 'port_conflict'].includes(externalPreflight.status)
+          ? 'runtime_missing'
+        : 'none';
+    return {
+      ...base,
+      ...rowMetadataForBrowserRs(externalPreflight),
+      status: skipCategory === 'none' ? 'failed' : 'skipped',
+      skipCategory,
+      durationMs: 0,
+      payloadChars: 0,
+      skipReason: skipCategory === 'none' ? '' : externalPreflight.message,
+      failure: skipCategory === 'none' ? externalPreflight.message : '',
     };
   }
 
@@ -285,6 +348,7 @@ export async function runOne(spec: AdapterSpec, url: string, options: Competitor
       payloadChars: payload.length,
       skipReason: '',
       failure: '',
+      ...adapterMetadata(adapter),
     };
   } catch (err) {
     return {
@@ -301,6 +365,50 @@ export async function runOne(spec: AdapterSpec, url: string, options: Competitor
   }
 }
 
+function rowMetadataForBrowserRsPin(environment?: Pick<EnvironmentMetadata, 'chromeVersion' | 'os'>): Partial<CompetitorSmokeRow> {
+  const pin = browserRsPlatformPin();
+  return {
+    commit: BROWSER_RS_PIN.commit,
+    license: BROWSER_RS_PIN.license,
+    binaryPath: process.env.BROWSER_RS_BIN ?? '',
+    command: process.env.BROWSER_RS_BIN ? [process.env.BROWSER_RS_BIN] : [],
+    platformKey: browserRsPlatformKey(),
+    expectedSha256: pin?.sha256 ?? '',
+    actualSha256: '',
+    releaseAsset: pin?.asset ?? '',
+    chromeVersion: environment?.chromeVersion ?? 'unknown',
+    os: environment?.os ?? 'unknown',
+  };
+}
+
+function rowMetadataForBrowserRs(preflight: BrowserRsPreflightResult): Partial<CompetitorSmokeRow> {
+  return {
+    commit: preflight.commit,
+    license: BROWSER_RS_PIN.license,
+    binaryPath: preflight.binaryPath,
+    command: preflight.command,
+    platformKey: preflight.platformKey,
+    expectedSha256: preflight.expectedSha256,
+    actualSha256: preflight.actualSha256,
+    releaseAsset: preflight.asset,
+    chromePath: preflight.chromePath,
+    profilePath: preflight.profilePath,
+    connectPort: preflight.connectPort,
+  };
+}
+
+function adapterMetadata(adapter: MCPAdapter): Partial<CompetitorSmokeRow> {
+  if (adapter instanceof BrowserRsMcpAdapter) {
+    return {
+      command: adapter.command,
+      toolCount: adapter.toolCount,
+      adapterSetupMs: adapter.setupDurationMs,
+      actualSha256: adapter.lastPreflight?.actualSha256,
+    };
+  }
+  return {};
+}
+
 function readRepoVersion(): string {
   try {
     const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
@@ -310,12 +418,12 @@ function readRepoVersion(): string {
   }
 }
 
-export async function runCompetitorSmokeMatrix(options: CompetitorSmokeOptions): Promise<CompetitorSmokeRow[]> {
+export async function runCompetitorSmokeMatrix(options: CompetitorSmokeOptions, environment = captureEnvironment()): Promise<CompetitorSmokeRow[]> {
   const server = await startStaticFixtureServer();
   try {
     const url = server.url('small');
     const rows: CompetitorSmokeRow[] = [];
-    for (const spec of specs(options)) rows.push(await runOne(spec, url, options));
+    for (const spec of specs(options)) rows.push(await runOne(spec, url, { ...options, rowEnvironment: environment }));
     return rows;
   } finally {
     await server.close();
@@ -340,11 +448,12 @@ function formatReport(rows: readonly CompetitorSmokeRow[]): string {
 
 export async function main(argv = process.argv.slice(2)): Promise<void> {
   const options = parseSmokeArgs(argv);
-  const rows = await runCompetitorSmokeMatrix(options);
+  const environment = captureEnvironment();
+  const rows = await runCompetitorSmokeMatrix(options, environment);
   const competitors = rows.map((row) => ({ name: row.library, version: row.version }));
   const envelope = buildResultEnvelope({
     axis: 'foundation',
-    environment: captureEnvironment(),
+    environment,
     competitors,
     results: rows,
   });


### PR DESCRIPTION
## Direction review

This remains benchmark infrastructure under Pillar E of #1359. It does not add browser-rs to OpenChrome runtime code, vendor its internals, or promote a diagnostic smoke into a product or performance claim.

## What changed

- pins browser-rs-mcp v0.1.13, commit, Apache-2.0 license, release assets, and platform SHA-256 values;
- canonicalizes the supplied executable and verifies its SHA-256 before any `--version` execution;
- binds preflight and subprocess launch to the same approved Chrome/profile/CDP inputs through `AB_CHROME`, `AB_PROFILE`, and normalized `AB_CONNECT`;
- probes the exact configured local CDP endpoint and rejects remote/protocol/path inputs that pinned v0.1.13 would silently reduce to an unrelated loopback port;
- consumes bounded stderr diagnostics, enforces startup timeout through MCP initialization, and terminates exited/stalled children without call-timeout delays;
- fails the smoke row when `tabs_close` returns `isError: true`;
- preserves canonical command, verified digest, actual Chrome version, endpoint, and tool/setup metadata on passed, failed, and empty-payload rows.

## Verification

- `npm run build`
- `npm run lint`
- 73 benchmark suites: 641 passed, 1 skipped, 0 failed
- 35 focused browser-rs adapter/smoke tests
- official macOS arm64 release asset verified before execution:
  - expected/release/actual SHA-256: `618c75dc4f9c3297ba85d4e1ddaa9aaf67a671bc8abb393e1f64523dc084b310`
  - reported version after verification: `browser-rs 0.1.13`
- live dedicated Chrome for Testing `131.0.6778.87` smoke:
  - `tabs_create -> read_page -> tabs_close` passed
  - 64 tools, 5,720 payload characters, 198 ms row duration
  - exact canonical binary, digest, Chrome version, and CDP endpoint recorded
  - browser-rs and dedicated Chrome/CDP processes were absent after teardown

## Known unrelated gap

`npx tsc -p tsconfig.test.json --noEmit` remains blocked by pre-existing `chrome.tabs.TabChangeInfo` and `WebVoyagerLibrary` errors outside this diff. Canonical build and all benchmark tests pass.

Closes #1554