### PR TITLE
test(cdp): align active-probe budget expectation

### DIFF
--- a/tests/src/cdp-active-probe.test.ts
+++ b/tests/src/cdp-active-probe.test.ts
@@ -258,7 +258,7 @@ describe('CDPClient – connect() active probe', () => {
 
     await client.connect({ budget });
 
-    expect(forceReconnectSpy).toHaveBeenCalledWith({ budget });
+    expect(forceReconnectSpy).toHaveBeenCalledWith({ budget, autoLaunch: false });
     stopHeartbeat(client);
   });
 


### PR DESCRIPTION
## Summary

- update the active-probe reconnect assertion to include the explicit `autoLaunch: false` contract already implemented on `main`
- keep the test strict instead of weakening it to partial argument matching

## Why

The full Jest suite currently fails on `main` because commit `51673b77` intentionally forwards `autoLaunch: false` during probe-triggered reconnects, while the test still expects only `{ budget }`. Production behavior is unchanged by this PR.

## Validation

- `npx jest tests/src/cdp-active-probe.test.ts --runInBand --silent`
- `npx jest tests/src/cdp-connect-coalescing.test.ts tests/chrome/startup-policy.test.ts --runInBand --silent`
- `git diff --check`
