### PR TITLE
feat(distribution): publish self-contained CLI binaries

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,186 @@
+name: Standalone CLI
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - '.github/workflows/cli-release.yml'
+      - '.github/workflows/desktop-release.yml'
+      - 'cli/**'
+      - 'src/index.ts'
+      - 'src/mcp-server.ts'
+      - 'src/transports/stdio.ts'
+      - 'src/version.ts'
+      - 'scripts/build-standalone-cli.cjs'
+      - 'scripts/verify-standalone-browser-smoke.cjs'
+      - 'scripts/verify-standalone-cli.cjs'
+      - 'scripts/standalone/**'
+      - 'desktop/scripts/build-sidecar.js'
+      - 'tests/cli/**'
+      - 'tests/scripts/standalone-build.test.ts'
+      - 'tests/transports/stdio-standalone.test.ts'
+      - 'package.json'
+      - 'package-lock.json'
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: standalone-cli-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: '20'
+  BUN_VERSION: '1.3.14'
+
+jobs:
+  build:
+    name: Build and certify (${{ matrix.platform_name }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15
+            target: aarch64-apple-darwin
+            platform_name: macos-arm64
+            live_smoke: true
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+            platform_name: macos-x64
+            live_smoke: false
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            platform_name: windows-x64
+            live_smoke: false
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            platform_name: linux-x64
+            live_smoke: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Setup Bun ${{ env.BUN_VERSION }}
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build canonical npm entrypoints
+        run: npm run build
+
+      - name: Build standalone executable
+        shell: bash
+        run: |
+          TAG_ARG=()
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            TAG_ARG=(--tag "${GITHUB_REF_NAME}")
+          fi
+          node scripts/build-standalone-cli.cjs \
+            --target "${{ matrix.target }}" \
+            --output-dir "artifacts/standalone/${{ matrix.platform_name }}" \
+            "${TAG_ARG[@]}"
+
+      - name: Verify npm and standalone CLI parity without Node in PATH
+        shell: bash
+        run: |
+          BINARY=$(find "artifacts/standalone/${{ matrix.platform_name }}" -maxdepth 1 -type f \
+            ! -name '*.sha256' ! -name '*.json' | head -1)
+          node scripts/verify-standalone-cli.cjs \
+            --binary "$BINARY" \
+            --expected-target "${{ matrix.target }}"
+
+      - name: Install Chrome for live standalone smoke
+        if: matrix.live_smoke
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@e574b4b3a21156ab45dd6b5f67e884fd26eed829 # v2.1.2
+        with:
+          chrome-version: 131.0.6778.87
+
+      - name: Verify standalone navigate and read_page against real Chrome
+        if: matrix.live_smoke
+        shell: bash
+        env:
+          OPENCHROME_TEST_CHROME: ${{ steps.setup-chrome.outputs.chrome-path }}
+        run: |
+          BINARY=$(find "artifacts/standalone/${{ matrix.platform_name }}" -maxdepth 1 -type f \
+            ! -name '*.sha256' ! -name '*.json' | head -1)
+          node scripts/verify-standalone-browser-smoke.cjs \
+            --binary "$BINARY" \
+            --chrome "$OPENCHROME_TEST_CHROME" \
+            | tee "artifacts/standalone/${{ matrix.platform_name }}/standalone-live-smoke.json"
+
+      - name: Upload certified standalone assets
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: standalone-${{ matrix.platform_name }}
+          path: |
+            artifacts/standalone/${{ matrix.platform_name }}/openchrome-*
+            artifacts/standalone/${{ matrix.platform_name }}/standalone-live-smoke.json
+            !artifacts/standalone/${{ matrix.platform_name }}/*.metafile.json
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Attach standalone assets to GitHub Release
+    if: github.ref_type == 'tag'
+    needs: build
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Download certified assets
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: standalone-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Verify local release checksums
+        shell: bash
+        run: |
+          cd release-assets
+          for checksum in *.sha256; do
+            sha256sum -c "$checksum"
+          done
+
+      - name: Publish standalone release assets
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          files: |
+            release-assets/openchrome-*
+          fail_on_unmatched_files: true
+
+      - name: Verify uploaded release checksums
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          mkdir downloaded
+          gh release download "${GITHUB_REF_NAME}" --dir downloaded --pattern 'openchrome-*'
+          cd downloaded
+          for checksum in *.sha256; do
+            sha256sum -c "$checksum"
+          done

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -143,36 +143,25 @@ jobs:
         run: npm install
         working-directory: desktop
 
+      - name: Build canonical npm entrypoints
+        run: npm run build
+
       # -----------------------------------------------------------------------
       # Build the MCP server sidecar binary for each target platform.
       # The binary is placed where Tauri's externalBin config expects it.
       # -----------------------------------------------------------------------
       - name: Install Bun (for sidecar compilation)
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Build sidecar binary
         shell: bash
         run: |
-          mkdir -p desktop/src-tauri/binaries
-
-          # Compile the openchrome server into a self-contained binary.
-          # The output name must match the externalBin entry in tauri.conf.json
-          # and include the target triple so Tauri can resolve it at runtime.
-          bun build src/index.ts \
-            --compile \
-            --target=${{ matrix.bun_target }} \
-            --outfile desktop/src-tauri/binaries/openchrome-sidecar-${{ matrix.target }}
-
-          # Windows: Bun may or may not append .exe; ensure .exe suffix exists.
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            if [[ ! -f "desktop/src-tauri/binaries/openchrome-sidecar-${{ matrix.target }}.exe" ]]; then
-              mv "desktop/src-tauri/binaries/openchrome-sidecar-${{ matrix.target }}" \
-                 "desktop/src-tauri/binaries/openchrome-sidecar-${{ matrix.target }}.exe"
-            fi
-          fi
-
+          node scripts/build-standalone-cli.cjs \
+            --kind sidecar \
+            --target "${{ matrix.target }}" \
+            --output-dir desktop/src-tauri/binaries
           echo "Sidecar binary:"
           ls -lh desktop/src-tauri/binaries/
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ openchrome setup --client codex        # Codex CLI (auto-elect topology)
 npx openchrome-mcp setup --client opencode   # OpenCode (auto-elect topology)
 ```
 
+Certified releases may also include optional self-contained executables for
+macOS, Windows, and Linux. They require Chrome but not a separate Node.js/npm
+runtime. Pin the release and verify its SHA-256 before use:
+[`docs/getting-started/standalone-cli.md`](docs/getting-started/standalone-cli.md).
+
 Restart your MCP client. That's it — Chrome auto-launches on the first browser/CDP-requiring tool call. Protocol startup, tool discovery, and browser-free diagnostics stay launch-free.
 An already-open Chrome is reused only when it exposes the configured remote-debugging port; a normal Chrome without that CDP endpoint remains separate from the managed browser.
 

--- a/cli/build-info.ts
+++ b/cli/build-info.ts
@@ -1,0 +1,35 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface OpenChromeBuildInfo {
+  version: string;
+  sourceCommit: string;
+  target: string;
+  bundler: string;
+  standalone: boolean;
+}
+
+function packageVersion(): string {
+  const candidates = [
+    path.join(__dirname, '..', 'package.json'),
+    path.join(__dirname, '..', '..', 'package.json'),
+  ];
+  for (const packageJsonPath of candidates) {
+    try {
+      return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).version as string;
+    } catch {
+      // Try the source-tree and compiled-layout candidates in order.
+    }
+  }
+  return 'unknown';
+}
+
+export function getBuildInfo(): OpenChromeBuildInfo {
+  return {
+    version: process.env.OPENCHROME_BUILD_VERSION || packageVersion(),
+    sourceCommit: process.env.OPENCHROME_BUILD_COMMIT || 'unknown',
+    target: process.env.OPENCHROME_BUILD_TARGET || `${process.platform}-${process.arch}`,
+    bundler: process.env.OPENCHROME_BUILD_BUNDLER || `node-${process.version}`,
+    standalone: process.env.OPENCHROME_STANDALONE_BINARY === '1',
+  };
+}

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -54,6 +54,7 @@ import { registerPlaybookCommand } from './playbook/index';
 import { registerReplayCommand } from './replay';
 import { registerRunCommand } from './run';
 import { getClaudeCliCommand, getClaudeExecFileOptions, shouldUseClaudeCliShell } from './claude-cli';
+import { getBuildInfo } from './build-info';
 
 const program = new Command();
 
@@ -130,19 +131,19 @@ async function loadVaultStore() {
 }
 
 // Package info - from dist/cli/ go up two levels to root
-const packageJsonPath = path.join(__dirname, '..', '..', 'package.json');
-let version = '0.1.0';
-try {
-  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-  version = packageJson.version;
-} catch {
-  // Use default version
-}
+const version = getBuildInfo().version;
 
 program
   .name('openchrome')
   .description('MCP server for parallel Claude Code browser sessions via CDP')
   .version(version);
+
+program
+  .command('build-info')
+  .description('Print embedded OpenChrome build provenance as JSON')
+  .action(() => {
+    process.stdout.write(`${JSON.stringify(getBuildInfo(), null, 2)}\n`);
+  });
 
 
 const vault = program

--- a/cli/playbook/stdio-client.ts
+++ b/cli/playbook/stdio-client.ts
@@ -15,6 +15,7 @@
 import { spawn, ChildProcess } from 'child_process';
 import * as path from 'path';
 import * as readline from 'readline';
+import { resolveServeInvocation } from '../serve-invocation';
 
 export class TransportError extends Error {
   constructor(message: string) {
@@ -70,8 +71,9 @@ export class StdioMcpClient {
 
     // Resolve the serve entry — from dist/cli/playbook/ go up three levels to root.
     const serveEntry = path.join(__dirname, '..', '..', '..', 'dist', 'index.js');
+    const invocation = resolveServeInvocation(serveEntry, ['--server-mode']);
 
-    this.child = spawn(process.execPath, [serveEntry, 'serve', '--server-mode'], {
+    this.child = spawn(invocation.command, invocation.args, {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 

--- a/cli/playbook/tool-manifest-client.ts
+++ b/cli/playbook/tool-manifest-client.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'child_process';
 import * as path from 'path';
+import { resolveServeInvocation } from '../serve-invocation';
 
 const MANIFEST_TIMEOUT_MS = 30_000;
 const MANIFEST_MAX_BUFFER = 8 * 1024 * 1024;
@@ -54,10 +55,11 @@ function stderrTail(stderr: string): string {
 export class RegisteredToolManifestClient implements ToolDefinitionSource {
   async listToolDefinitions(): Promise<McpToolDefinition[]> {
     const serveEntry = path.join(__dirname, '..', '..', 'index.js');
+    const invocation = resolveServeInvocation(serveEntry, ['--introspect-tools-list']);
     return new Promise<McpToolDefinition[]>((resolve, reject) => {
       execFile(
-        process.execPath,
-        [serveEntry, 'serve', '--introspect-tools-list'],
+        invocation.command,
+        invocation.args,
         {
           encoding: 'utf8',
           env: {

--- a/cli/run-stdio-client.ts
+++ b/cli/run-stdio-client.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess } from 'child_process';
 import * as path from 'path';
 import * as readline from 'readline';
+import { resolveServeInvocation } from './serve-invocation';
 
 export class TransportError extends Error {
   constructor(message: string) {
@@ -43,7 +44,8 @@ export class StdioRunClient {
     }
 
     const serveEntry = path.join(__dirname, '..', 'index.js');
-    this.child = spawn(process.execPath, [serveEntry, 'serve', '--server-mode'], {
+    const invocation = resolveServeInvocation(serveEntry, ['--server-mode']);
+    this.child = spawn(invocation.command, invocation.args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, OPENCHROME_PPID_WATCH: '0' },
     });

--- a/cli/serve-invocation.ts
+++ b/cli/serve-invocation.ts
@@ -1,0 +1,23 @@
+import * as path from 'path';
+
+export interface ServeInvocation {
+  command: string;
+  args: string[];
+}
+
+export function resolveServeInvocation(
+  compiledServeEntry: string,
+  serveArgs: readonly string[] = [],
+): ServeInvocation {
+  if (process.env.OPENCHROME_STANDALONE_BINARY === '1') {
+    return {
+      command: process.execPath,
+      args: ['serve', ...serveArgs],
+    };
+  }
+
+  return {
+    command: process.execPath,
+    args: [path.resolve(compiledServeEntry), 'serve', ...serveArgs],
+  };
+}

--- a/desktop/scripts/build-sidecar.js
+++ b/desktop/scripts/build-sidecar.js
@@ -1,54 +1,19 @@
 #!/usr/bin/env node
-/**
- * Build the OpenChrome sidecar binary for the current platform.
- * Uses `pkg` to bundle the Node.js server into a standalone executable.
- */
-const { execSync } = require("child_process");
-const path = require("path");
-const fs = require("fs");
-const os = require("os");
+'use strict';
 
-const repoRoot = path.resolve(__dirname, "..", "..");
-const binDir = path.resolve(__dirname, "..", "src-tauri", "binaries");
-const entryPoint = path.resolve(repoRoot, "dist", "cli", "index.js");
+const path = require('path');
+const { spawnSync } = require('child_process');
 
-function getTauriTarget() {
-  const p = os.platform(), a = os.arch();
-  if (p === "darwin" && a === "arm64") return "aarch64-apple-darwin";
-  if (p === "darwin" && a === "x64") return "x86_64-apple-darwin";
-  if (p === "win32" && a === "x64") return "x86_64-pc-windows-msvc";
-  if (p === "linux" && a === "x64") return "x86_64-unknown-linux-gnu";
-  throw new Error(`Unsupported platform: ${p}-${a}`);
-}
-
+const repoRoot = path.resolve(__dirname, '..', '..');
 const args = process.argv.slice(2);
-const targetIdx = args.indexOf("--target");
-const target = targetIdx !== -1 ? args[targetIdx + 1] : getTauriTarget();
+const command = [
+  path.join(repoRoot, 'scripts', 'build-standalone-cli.cjs'),
+  '--kind',
+  'sidecar',
+  '--output-dir',
+  path.join(repoRoot, 'desktop', 'src-tauri', 'binaries'),
+  ...args,
+];
 
-const pkgTargets = {
-  "aarch64-apple-darwin": "node18-macos-arm64",
-  "x86_64-apple-darwin": "node18-macos-x64",
-  "x86_64-pc-windows-msvc": "node18-win-x64",
-  "x86_64-unknown-linux-gnu": "node18-linux-x64",
-};
-const pkgTarget = pkgTargets[target];
-if (!pkgTarget) { console.error(`Unknown target: ${target}`); process.exit(1); }
-if (!fs.existsSync(entryPoint)) {
-  console.error("Run 'npm run build' in repo root first."); process.exit(1);
-}
-
-fs.mkdirSync(binDir, { recursive: true });
-const ext = target.includes("windows") ? ".exe" : "";
-const outputPath = path.resolve(binDir, `openchrome-sidecar-${target}${ext}`);
-
-console.error(`Building sidecar: ${target} -> ${outputPath}`);
-try {
-  execSync(`npx pkg "${entryPoint}" --target ${pkgTarget} --output "${outputPath}" --compress GZip`, {
-    cwd: repoRoot, stdio: "inherit",
-  });
-  if (!target.includes("windows")) fs.chmodSync(outputPath, 0o755);
-  console.error("Sidecar built successfully");
-} catch (err) {
-  console.error("Failed to build sidecar:", err.message);
-  process.exit(1);
-}
+const result = spawnSync(process.execPath, command, { cwd: repoRoot, stdio: 'inherit' });
+process.exit(result.status ?? 1);

--- a/desktop/src-tauri/binaries/README.md
+++ b/desktop/src-tauri/binaries/README.md
@@ -18,18 +18,19 @@ cd desktop
 npm run build:sidecar
 ```
 
-The script (`desktop/scripts/build-sidecar.js`) uses `pkg` to bundle
-`dist/cli/index.js` into a standalone executable and writes it here with the
-correct Tauri target suffix, e.g. `openchrome-sidecar-aarch64-apple-darwin`.
+The script (`desktop/scripts/build-sidecar.js`) delegates to the canonical
+root standalone builder. Bun bundles both `dist/cli/index.js` and
+`dist/index.js` into one executable, then writes it here with the correct
+Tauri target suffix, e.g. `openchrome-sidecar-aarch64-apple-darwin`.
 
 ## Supported platforms
 
-| Tauri target                    | pkg target           |
+| Tauri target                    | Bun target           |
 |---------------------------------|----------------------|
-| `aarch64-apple-darwin`          | `node18-macos-arm64` |
-| `x86_64-apple-darwin`           | `node18-macos-x64`   |
-| `x86_64-pc-windows-msvc`        | `node18-win-x64`     |
-| `x86_64-unknown-linux-gnu`      | `node18-linux-x64`   |
+| `aarch64-apple-darwin`          | `bun-darwin-arm64`  |
+| `x86_64-apple-darwin`           | `bun-darwin-x64`    |
+| `x86_64-pc-windows-msvc`        | `bun-windows-x64`   |
+| `x86_64-unknown-linux-gnu`      | `bun-linux-x64`     |
 
-Cross-compilation is not supported by `pkg`; build on each target platform
-natively, or use CI runners for each OS.
+Release certification still runs each executable on its native target runner,
+even though Bun can produce cross-target executables.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ OpenChrome is an MCP server that enables multiple Claude Code sessions to contro
 
 ## Prerequisites
 
-- Node.js >= 18
+- Node.js >= 18 for the npm installation path
 - Google Chrome (stable or Chromium)
 
 ## Installation
@@ -12,6 +12,11 @@ OpenChrome is an MCP server that enables multiple Claude Code sessions to contro
 ```bash
 npm install -g openchrome-mcp
 ```
+
+Certified releases may instead provide a self-contained executable that does
+not require Node.js. Pin the release asset and verify its SHA-256 as documented
+in [Standalone OpenChrome CLI](getting-started/standalone-cli.md). Chrome is not
+included in the executable.
 
 ## Quick Start
 

--- a/docs/getting-started/standalone-cli.md
+++ b/docs/getting-started/standalone-cli.md
@@ -1,0 +1,94 @@
+# Standalone OpenChrome CLI
+
+OpenChrome releases may include optional self-contained CLI executables. These
+artifacts run the same MCP and command surfaces as the npm package without a
+separately installed Node.js or npm runtime.
+
+The standalone CLI is additive:
+
+- npm remains the broadest installation path;
+- the desktop app continues to use the same sidecar build pipeline;
+- Chrome or Chromium is not bundled;
+- only assets present on a specific release are certified for that release.
+
+## Certified asset names
+
+| Platform | Asset |
+| --- | --- |
+| macOS Apple Silicon | `openchrome-macos-arm64` |
+| macOS Intel | `openchrome-macos-x64` |
+| Windows x64 | `openchrome-windows-x64.exe` |
+| Linux x64 | `openchrome-linux-x64` |
+
+Every executable has a sibling `.sha256` file and `.metadata.json` file. The
+metadata records the OpenChrome version, source commit, target triple, Bun
+version, byte size, and SHA-256 digest.
+
+## macOS or Linux
+
+Pin the release version. Do not download from a moving `latest` URL in host
+configuration or automation.
+
+```bash
+VERSION=1.13.0 # Example: choose a release that lists standalone assets.
+ASSET=openchrome-macos-arm64 # or openchrome-macos-x64 / openchrome-linux-x64
+BASE="https://github.com/shaun0927/openchrome/releases/download/v${VERSION}"
+
+curl -fL "${BASE}/${ASSET}" -o openchrome
+curl -fL "${BASE}/${ASSET}.sha256" -o "${ASSET}.sha256"
+chmod +x openchrome
+
+# The checksum file names the release asset, so verify from a temporary copy.
+cp openchrome "${ASSET}"
+shasum -a 256 -c "${ASSET}.sha256"  # Linux may use: sha256sum -c
+rm "${ASSET}"
+
+./openchrome --version
+./openchrome build-info
+./openchrome config --client codex
+```
+
+If the chosen release does not contain the named asset, use the npm package for
+that host instead of downloading an artifact from another version.
+
+## Windows PowerShell
+
+```powershell
+$Version = "1.13.0" # Example: choose a release that lists standalone assets.
+$Asset = "openchrome-windows-x64.exe"
+$Base = "https://github.com/shaun0927/openchrome/releases/download/v$Version"
+
+Invoke-WebRequest "$Base/$Asset" -OutFile $Asset
+Invoke-WebRequest "$Base/$Asset.sha256" -OutFile "$Asset.sha256"
+
+$Expected = (Get-Content "$Asset.sha256").Split(" ")[0].ToLowerInvariant()
+$Actual = (Get-FileHash $Asset -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($Actual -ne $Expected) { throw "OpenChrome checksum mismatch" }
+
+.\openchrome-windows-x64.exe --version
+.\openchrome-windows-x64.exe build-info
+.\openchrome-windows-x64.exe config --client codex
+```
+
+## MCP configuration
+
+Use the absolute verified executable path in MCP host configuration:
+
+```json
+{
+  "mcpServers": {
+    "openchrome": {
+      "command": "/absolute/path/to/openchrome",
+      "args": ["serve", "--auto-launch", "--minimal"]
+    }
+  }
+}
+```
+
+The release workflow certifies command help, config output, full/minimal tool
+manifests, and an MCP `initialize` plus `tools/list` handshake with `PATH`
+cleared. On macOS arm64 and Linux x64 it also runs `doctor`, navigates to a
+controlled local fixture in the Chrome build pinned by the repository's
+Puppeteer runtime, reads the page back through MCP, and verifies managed Chrome
+shutdown. These checks prove the executable does not locate Node.js at runtime;
+normal browser calls still require a supported Chrome or Chromium installation.

--- a/package.json
+++ b/package.json
@@ -80,7 +80,10 @@
     "bench:api-key-readiness": "ts-node tests/benchmark/benchmark-readiness.ts --api-key-only",
     "lint:skill-tools": "node scripts/lint-skill-tool-refs.mjs skills/openchrome/SKILL.md",
     "verify:auto-elect-smoke": "node scripts/verify/auto-elect-two-client-smoke.mjs",
-    "verify:parallel-auto-elect": "node scripts/verify/parallel-auto-elect.mjs --clients=3"
+    "verify:parallel-auto-elect": "node scripts/verify/parallel-auto-elect.mjs --clients=3",
+    "build:standalone": "node scripts/build-standalone-cli.cjs",
+    "verify:standalone": "node scripts/verify-standalone-cli.cjs",
+    "verify:standalone:browser": "node scripts/verify-standalone-browser-smoke.cjs"
   },
   "keywords": [
     "openchrome",

--- a/scripts/build-standalone-cli.cjs
+++ b/scripts/build-standalone-cli.cjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { execFileSync, spawnSync } = require('child_process');
+const {
+  PINNED_BUN_VERSION,
+  resolveTarget,
+  outputName,
+} = require('./standalone/targets.cjs');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function usage() {
+  process.stdout.write(`Usage: node scripts/build-standalone-cli.cjs [options]\n\n` +
+    `Options:\n` +
+    `  --target <target>       Tauri triple, Bun target, or platform name\n` +
+    `  --kind <kind>           standalone (default) or sidecar\n` +
+    `  --output-dir <path>     Output directory (default: artifacts/standalone)\n` +
+    `  --tag <vX.Y.Z>          Fail unless the tag matches package.json\n` +
+    `  --bun-bin <path>        Bun executable (default: bun)\n` +
+    `  --help                  Show this help\n`);
+}
+
+function parseArgs(argv) {
+  const options = {
+    kind: 'standalone',
+    outputDir: path.join(repoRoot, 'artifacts', 'standalone'),
+    bunBin: process.env.BUN_BIN || 'bun',
+  };
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === '--help') return { ...options, help: true };
+    if (arg === '--target') options.target = argv[++index];
+    else if (arg === '--kind') options.kind = argv[++index];
+    else if (arg === '--output-dir') options.outputDir = path.resolve(argv[++index]);
+    else if (arg === '--tag') options.tag = argv[++index];
+    else if (arg === '--bun-bin') options.bunBin = argv[++index];
+    else throw new Error(`Unknown option: ${arg}`);
+  }
+  if (!['standalone', 'sidecar'].includes(options.kind)) {
+    throw new Error(`Unknown build kind: ${options.kind}`);
+  }
+  return options;
+}
+
+function sha256(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function sourceCommit() {
+  if (/^[0-9a-f]{40}$/i.test(process.env.GITHUB_SHA || '')) return process.env.GITHUB_SHA;
+  return execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repoRoot, encoding: 'utf8' }).trim();
+}
+
+function ensureCanonicalBuild() {
+  for (const relativePath of ['dist/index.js', 'dist/cli/index.js']) {
+    if (!fs.existsSync(path.join(repoRoot, relativePath))) {
+      throw new Error(`Missing ${relativePath}; run npm run build before standalone compilation.`);
+    }
+  }
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    usage();
+    return;
+  }
+
+  const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+  const version = packageJson.version;
+  if (options.tag && options.tag !== `v${version}`) {
+    throw new Error(`Release tag ${options.tag} does not match package.json version v${version}.`);
+  }
+
+  ensureCanonicalBuild();
+  const target = resolveTarget(options.target);
+  const bunVersion = execFileSync(options.bunBin, ['--version'], { encoding: 'utf8' }).trim();
+  if (bunVersion !== PINNED_BUN_VERSION) {
+    throw new Error(`Bun ${PINNED_BUN_VERSION} is required; found ${bunVersion}.`);
+  }
+
+  fs.mkdirSync(options.outputDir, { recursive: true });
+  const assetName = outputName(target, options.kind);
+  const outputPath = path.join(options.outputDir, assetName);
+  const metafilePath = `${outputPath}.metafile.json`;
+  const commit = sourceCommit();
+  const bundler = `bun-${bunVersion}`;
+  const env = {
+    ...process.env,
+    OPENCHROME_BUILD_VERSION: version,
+    OPENCHROME_BUILD_COMMIT: commit,
+    OPENCHROME_BUILD_TARGET: target.target,
+    OPENCHROME_BUILD_BUNDLER: bundler,
+  };
+
+  const buildArgs = [
+    'build',
+    path.join(repoRoot, 'scripts', 'standalone', 'entry.cjs'),
+    '--compile',
+    `--target=${target.bunTarget}`,
+    `--outfile=${outputPath}`,
+    `--metafile=${metafilePath}`,
+    '--env=OPENCHROME_BUILD_*',
+    '--no-compile-autoload-dotenv',
+    '--no-compile-autoload-bunfig',
+    '--no-compile-autoload-package-json',
+  ];
+  if (target.extension === '.exe') {
+    buildArgs.push('--windows-title=OpenChrome', `--windows-version=${version}.0`, '--windows-description=OpenChrome MCP CLI');
+  }
+
+  const build = spawnSync(options.bunBin, buildArgs, { cwd: repoRoot, env, stdio: 'inherit' });
+  if (build.status !== 0) throw new Error(`Bun compilation failed with exit ${build.status}.`);
+  if (target.extension !== '.exe') fs.chmodSync(outputPath, 0o755);
+
+  const digest = sha256(outputPath);
+  const checksumPath = `${outputPath}.sha256`;
+  fs.writeFileSync(checksumPath, `${digest}  ${assetName}\n`);
+  const metadata = {
+    schemaVersion: 1,
+    version,
+    sourceCommit: commit,
+    target: target.target,
+    platformName: target.platformName,
+    bunTarget: target.bunTarget,
+    bundler,
+    asset: assetName,
+    sizeBytes: fs.statSync(outputPath).size,
+    sha256: digest,
+  };
+  const metadataPath = `${outputPath}.metadata.json`;
+  fs.writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify({ outputPath, checksumPath, metadataPath, metadata })}\n`);
+}
+
+function cleanupBunTemps() {
+  for (const name of fs.readdirSync(repoRoot)) {
+    if (/^\.[0-9a-f]+-[0-9a-f]+\.bun-build$/i.test(name)) {
+      fs.unlinkSync(path.join(repoRoot, name));
+    }
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`[standalone-build] ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+} finally {
+  cleanupBunTemps();
+}

--- a/scripts/standalone/entry.cjs
+++ b/scripts/standalone/entry.cjs
@@ -1,0 +1,15 @@
+'use strict';
+
+process.env.OPENCHROME_STANDALONE_BINARY = '1';
+process.env.OPENCHROME_UPDATE_CHECK = process.env.OPENCHROME_UPDATE_CHECK || '0';
+
+const args = process.argv.slice(2);
+const fullCliCommands = new Set(['serve', 'check', 'doctor', 'verify', 'info']);
+const routeToFullCli = fullCliCommands.has(args[0])
+  || (args[0] === 'help' && fullCliCommands.has(args[1]));
+
+if (routeToFullCli) {
+  require('../../dist/index.js');
+} else {
+  require('../../dist/cli/index.js');
+}

--- a/scripts/standalone/targets.cjs
+++ b/scripts/standalone/targets.cjs
@@ -1,0 +1,76 @@
+'use strict';
+
+const PINNED_BUN_VERSION = '1.3.14';
+
+const TARGETS = Object.freeze({
+  'aarch64-apple-darwin': Object.freeze({
+    target: 'aarch64-apple-darwin',
+    bunTarget: 'bun-darwin-arm64',
+    platformName: 'macos-arm64',
+    standaloneAsset: 'openchrome-macos-arm64',
+    extension: '',
+  }),
+  'x86_64-apple-darwin': Object.freeze({
+    target: 'x86_64-apple-darwin',
+    bunTarget: 'bun-darwin-x64',
+    platformName: 'macos-x64',
+    standaloneAsset: 'openchrome-macos-x64',
+    extension: '',
+  }),
+  'x86_64-pc-windows-msvc': Object.freeze({
+    target: 'x86_64-pc-windows-msvc',
+    bunTarget: 'bun-windows-x64',
+    platformName: 'windows-x64',
+    standaloneAsset: 'openchrome-windows-x64.exe',
+    extension: '.exe',
+  }),
+  'x86_64-unknown-linux-gnu': Object.freeze({
+    target: 'x86_64-unknown-linux-gnu',
+    bunTarget: 'bun-linux-x64',
+    platformName: 'linux-x64',
+    standaloneAsset: 'openchrome-linux-x64',
+    extension: '',
+  }),
+});
+
+const ALIASES = new Map();
+for (const value of Object.values(TARGETS)) {
+  ALIASES.set(value.target, value.target);
+  ALIASES.set(value.bunTarget, value.target);
+  ALIASES.set(value.platformName, value.target);
+}
+
+function currentTarget(platform = process.platform, arch = process.arch) {
+  const key = `${platform}-${arch}`;
+  const mapping = {
+    'darwin-arm64': 'aarch64-apple-darwin',
+    'darwin-x64': 'x86_64-apple-darwin',
+    'win32-x64': 'x86_64-pc-windows-msvc',
+    'linux-x64': 'x86_64-unknown-linux-gnu',
+  };
+  const target = mapping[key];
+  if (!target) throw new Error(`Unsupported standalone target: ${key}`);
+  return target;
+}
+
+function resolveTarget(input) {
+  const target = input ? ALIASES.get(input) : currentTarget();
+  if (!target || !TARGETS[target]) {
+    throw new Error(`Unknown target: ${input || '(current platform)'}`);
+  }
+  return TARGETS[target];
+}
+
+function outputName(target, kind) {
+  if (kind === 'standalone') return target.standaloneAsset;
+  if (kind === 'sidecar') return `openchrome-sidecar-${target.target}${target.extension}`;
+  throw new Error(`Unknown build kind: ${kind}`);
+}
+
+module.exports = {
+  PINNED_BUN_VERSION,
+  TARGETS,
+  currentTarget,
+  resolveTarget,
+  outputName,
+};

--- a/scripts/verify-standalone-browser-smoke.cjs
+++ b/scripts/verify-standalone-browser-smoke.cjs
@@ -1,0 +1,345 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const http = require('http');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+const readline = require('readline');
+const { spawn, spawnSync } = require('child_process');
+
+const REQUEST_TIMEOUT_MS = 60_000;
+const STARTUP_TIMEOUT_MS = 60_000;
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === '--binary') options.binary = path.resolve(argv[++index]);
+    else if (arg === '--chrome') options.chrome = path.resolve(argv[++index]);
+    else if (arg === '--help') options.help = true;
+    else throw new Error(`Unknown option: ${arg}`);
+  }
+  return options;
+}
+
+function findChrome(explicitPath) {
+  const candidates = [
+    explicitPath,
+    process.env.OPENCHROME_TEST_CHROME,
+    process.env.CHROME_PATH,
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    process.env.PROGRAMFILES && path.join(process.env.PROGRAMFILES, 'Google', 'Chrome', 'Application', 'chrome.exe'),
+    process.env['PROGRAMFILES(X86)'] && path.join(process.env['PROGRAMFILES(X86)'], 'Google', 'Chrome', 'Application', 'chrome.exe'),
+  ].filter(Boolean);
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve(server.address().port);
+    });
+  });
+}
+
+async function freePort() {
+  const server = net.createServer();
+  const port = await listen(server);
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+async function freeOpenChromePort() {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const port = await freePort();
+    const hasPidCollision = Array.from({ length: 5 }, (_, offset) => port + offset).some((candidate) => (
+      fs.existsSync(path.join(os.tmpdir(), `openchrome-${candidate}.pid`)) ||
+      fs.existsSync(path.join(os.tmpdir(), `openchrome-chrome-${candidate}.pid`))
+    ));
+    if (!hasPidCollision) return port;
+  }
+  throw new Error('Could not reserve a CDP port without stale OpenChrome PID metadata.');
+}
+
+function waitForLog(getLog, pattern, child) {
+  return new Promise((resolve, reject) => {
+    const startedAt = Date.now();
+    const timer = setInterval(() => {
+      if (pattern.test(getLog())) {
+        clearInterval(timer);
+        resolve();
+        return;
+      }
+      if (child.exitCode !== null) {
+        clearInterval(timer);
+        reject(new Error(`OpenChrome exited before readiness (code ${child.exitCode}).`));
+        return;
+      }
+      if (Date.now() - startedAt >= STARTUP_TIMEOUT_MS) {
+        clearInterval(timer);
+        reject(new Error(`Timed out waiting for OpenChrome readiness.\n${getLog().split('\n').slice(-20).join('\n')}`));
+      }
+    }, 100);
+    timer.unref();
+  });
+}
+
+function waitForExit(child, timeoutMs = 15_000) {
+  if (child.exitCode !== null) return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Timed out waiting for OpenChrome shutdown.')), timeoutMs);
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    });
+  });
+}
+
+async function waitForPortClosed(port) {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(`http://127.0.0.1:${port}/json/version`, { signal: AbortSignal.timeout(500) });
+    } catch {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Managed Chrome still responds on CDP port ${port} after oc_stop.`);
+}
+
+class StdioRpcClient {
+  constructor(child, stderrTail) {
+    if (!child.stdin || !child.stdout) throw new Error('Failed to open MCP stdio pipes.');
+    this.child = child;
+    this.stderrTail = stderrTail;
+    this.pending = new Map();
+    this.nextId = 1;
+    this.rl = readline.createInterface({ input: child.stdout, crlfDelay: Infinity });
+    this.rl.on('line', (line) => {
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        return;
+      }
+      const waiter = this.pending.get(message.id);
+      if (!waiter) return;
+      this.pending.delete(message.id);
+      waiter.resolve(message);
+    });
+    child.once('exit', (code, signal) => {
+      for (const waiter of this.pending.values()) {
+        waiter.reject(new Error(
+          `OpenChrome exited during ${waiter.label} (code=${code}, signal=${signal}).\n${this.stderrTail()}`,
+        ));
+      }
+      this.pending.clear();
+    });
+  }
+
+  request(method, params, label = method) {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Timed out waiting for ${label}.\n${this.stderrTail()}`));
+      }, REQUEST_TIMEOUT_MS);
+      this.pending.set(id, {
+        label,
+        resolve: (message) => {
+          clearTimeout(timer);
+          if (message.error) reject(new Error(`${label} failed: ${message.error.message}`));
+          else resolve(message.result);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      });
+      this.child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`);
+    });
+  }
+
+  notify(method, params) {
+    this.child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method, params })}\n`);
+  }
+
+  close() {
+    this.rl.close();
+  }
+}
+
+function toolTexts(result, name) {
+  if (!result || result.isError) throw new Error(`${name} returned an MCP tool error: ${JSON.stringify(result)}`);
+  const texts = (result.content || [])
+    .filter((item) => item && item.type === 'text' && typeof item.text === 'string')
+    .map((item) => item.text);
+  if (texts.length === 0) throw new Error(`${name} returned no text content.`);
+  return texts;
+}
+
+function parseJson(value, label) {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    throw new Error(`${label} returned invalid JSON: ${error instanceof Error ? error.message : String(error)}; payload=${value.slice(0, 1000)}`);
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write('Usage: node scripts/verify-standalone-browser-smoke.cjs --binary <path> [--chrome <path>]\n');
+    return;
+  }
+  if (!options.binary || !fs.existsSync(options.binary)) throw new Error('--binary must name an existing executable.');
+  const chrome = findChrome(options.chrome);
+  if (!chrome) throw new Error('Chrome was not found; pass --chrome or set OPENCHROME_TEST_CHROME.');
+
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-standalone-live-'));
+  const home = path.join(tmp, 'home');
+  const userDataDir = path.join(tmp, 'chrome-profile');
+  const lockDir = path.join(tmp, 'locks');
+  const brokerDir = path.join(tmp, 'brokers');
+  for (const dir of [home, userDataDir, lockDir, brokerDir]) fs.mkdirSync(dir, { recursive: true });
+
+  const fixtureBody = '<!doctype html><html><head><title>Standalone CLI live smoke</title></head><body><main><h1>Standalone CLI live smoke</h1><button id="fixture-ready">Fixture ready</button></main></body></html>';
+  let fixtureRequests = 0;
+  const fixtureServer = http.createServer((_request, response) => {
+    fixtureRequests++;
+    response.writeHead(200, {
+      'content-type': 'text/html; charset=utf-8',
+      'cache-control': 'no-store',
+      'content-length': Buffer.byteLength(fixtureBody),
+      connection: 'close',
+    });
+    response.end(fixtureBody);
+  });
+  const fixturePort = await listen(fixtureServer);
+  const fixtureUrl = `http://127.0.0.1:${fixturePort}/`;
+  const fixtureProbe = await fetch(fixtureUrl);
+  if (!fixtureProbe.ok || !(await fixtureProbe.text()).includes('Fixture ready')) {
+    throw new Error('Controlled fixture preflight failed.');
+  }
+  const cdpPort = await freeOpenChromePort();
+  const systemPath = process.platform === 'win32'
+    ? 'C:\\Windows\\System32;C:\\Windows'
+    : '/usr/bin:/bin:/usr/sbin:/sbin';
+  const cleanEnv = {
+    ...process.env,
+    PATH: systemPath,
+    HOME: home,
+    CHROME_PATH: chrome,
+    OPENCHROME_TEST_CHROME: chrome,
+    OPENCHROME_UPDATE_CHECK: '0',
+    OPENCHROME_PPID_WATCH: '0',
+    OPENCHROME_AUTO_ELECT: '0',
+    OPENCHROME_HEALTH_ENDPOINT: '0',
+    OPENCHROME_RECOVERY_LEDGER: '0',
+    OPENCHROME_CONTROLLER_LOCK_DIR: lockDir,
+    OPENCHROME_BROKER_REGISTRY_DIR: brokerDir,
+    OPENCHROME_PROCESS_WATCHDOG_INTERVAL_MS: '60000',
+    OPENCHROME_TAB_HEALTH_PROBE_INTERVAL_MS: '60000',
+  };
+
+  const doctor = spawnSync(options.binary, [
+    'doctor', '--json',
+    '--check', 'chrome-binary',
+    '--check', 'home-writable',
+  ], { encoding: 'utf8', env: cleanEnv, timeout: 30_000 });
+  if (doctor.status !== 0) {
+    throw new Error(`Standalone doctor failed (${doctor.status}): ${doctor.stderr || doctor.stdout}`);
+  }
+  const doctorReport = parseJson(doctor.stdout, 'doctor --json');
+
+  let child;
+  let rpc;
+  let stderr = '';
+  try {
+    child = spawn(options.binary, [
+      'serve',
+      '--auto-launch',
+      '--headless',
+      '--no-auto-elect',
+      '--port', String(cdpPort),
+      '--user-data-dir', userDataDir,
+      '--chrome-binary', chrome,
+    ], { stdio: ['pipe', 'pipe', 'pipe'], env: cleanEnv, detached: process.platform !== 'win32' });
+    child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+    rpc = new StdioRpcClient(child, () => stderr.split('\n').slice(-20).join('\n'));
+
+    await waitForLog(() => stderr, /STDIO transport enabled/, child);
+    await rpc.request('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'openchrome-standalone-live-smoke', version: '1' },
+    });
+    rpc.notify('notifications/initialized');
+
+    const navigateResult = await rpc.request('tools/call', {
+      name: 'navigate',
+      arguments: { url: fixtureUrl, autoFallback: false },
+    }, 'navigate controlled fixture');
+    const navigatePayload = parseJson(toolTexts(navigateResult, 'navigate controlled fixture')[0], 'navigate controlled fixture');
+    if (!navigatePayload.tabId || navigatePayload.url !== fixtureUrl) {
+      throw new Error(`navigate did not return the controlled fixture target: ${JSON.stringify(navigatePayload)}`);
+    }
+
+    const readResult = await rpc.request('tools/call', {
+      name: 'read_page',
+      arguments: { tabId: navigatePayload.tabId, mode: 'dom', depth: 4, filter: 'all' },
+    });
+    const readText = toolTexts(readResult, 'read_page').join('\n');
+    if (!readText.includes('Standalone CLI live smoke') || !readText.includes('Fixture ready')) {
+      throw new Error(`read_page did not contain the controlled fixture markers: ${readText.slice(0, 1000)}`);
+    }
+
+    child.stdin.end();
+    const exit = await waitForExit(child);
+    if (exit.code !== 0) throw new Error(`OpenChrome exited with code ${exit.code} signal ${exit.signal}.`);
+    await waitForPortClosed(cdpPort);
+
+    const chromeVersion = spawnSync(chrome, ['--version'], { encoding: 'utf8', timeout: 10_000 });
+    process.stdout.write(`${JSON.stringify({
+      ok: true,
+      binary: options.binary,
+      chrome: chromeVersion.stdout.trim() || chrome,
+      fixtureUrl,
+      tabId: navigatePayload.tabId,
+      fixtureRequests,
+      doctorSummary: doctorReport.summary,
+      readBytes: Buffer.byteLength(readText),
+      cleanShutdown: true,
+    }, null, 2)}\n`);
+  } finally {
+    rpc?.close();
+    if (child && child.exitCode === null) {
+      child.kill('SIGTERM');
+      try {
+        await waitForExit(child, 5_000);
+      } catch {
+        child.kill('SIGKILL');
+      }
+    }
+    await new Promise((resolve) => fixtureServer.close(resolve));
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    try {
+      fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
+    } catch (error) {
+      console.error(`[standalone-live-smoke] Temporary cleanup warning: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(`[standalone-live-smoke] ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/scripts/verify-standalone-browser-smoke.cjs
+++ b/scripts/verify-standalone-browser-smoke.cjs
@@ -266,14 +266,17 @@ async function main() {
   try {
     child = spawn(options.binary, [
       'serve',
-      '--auto-launch',
-      '--headless',
+      '--server-mode',
       '--no-auto-elect',
       '--port', String(cdpPort),
       '--user-data-dir', userDataDir,
       '--chrome-binary', chrome,
     ], { stdio: ['pipe', 'pipe', 'pipe'], env: cleanEnv, detached: process.platform !== 'win32' });
-    child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+    child.stderr.on('data', (chunk) => {
+      const text = chunk.toString();
+      stderr += text;
+      if (process.env.OPENCHROME_STANDALONE_DEBUG === '1') process.stderr.write(text);
+    });
     rpc = new StdioRpcClient(child, () => stderr.split('\n').slice(-20).join('\n'));
 
     await waitForLog(() => stderr, /STDIO transport enabled/, child);
@@ -322,6 +325,9 @@ async function main() {
   } finally {
     rpc?.close();
     if (child && child.exitCode === null) {
+      if (process.env.OPENCHROME_STANDALONE_DEBUG === '1') {
+        console.error('[standalone-live-smoke] Cleanup is sending SIGTERM to OpenChrome');
+      }
       child.kill('SIGTERM');
       try {
         await waitForExit(child, 5_000);

--- a/scripts/verify-standalone-cli.cjs
+++ b/scripts/verify-standalone-cli.cjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const readline = require('readline');
+const { spawn, spawnSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === '--binary') options.binary = path.resolve(argv[++index]);
+    else if (arg === '--expected-target') options.expectedTarget = argv[++index];
+    else if (arg === '--help') options.help = true;
+    else throw new Error(`Unknown option: ${arg}`);
+  }
+  return options;
+}
+
+function normalize(output) {
+  return output.replace(/\r\n/g, '\n').replace(/[ \t]+$/gm, '').trim();
+}
+
+function run(command, args, cleanPath = false) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: cleanPath ? '' : process.env.PATH,
+      OPENCHROME_UPDATE_CHECK: '0',
+      OPENCHROME_PPID_WATCH: '0',
+    },
+    timeout: 60_000,
+  });
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed (${result.status}): ${result.stderr || result.stdout}`);
+  }
+  return normalize(result.stdout);
+}
+
+function hash(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+async function listTools(command, prefixArgs, minimal, cleanPath) {
+  const port = String(20_000 + Math.floor(Math.random() * 20_000));
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-standalone-parity-'));
+  const args = [
+    ...prefixArgs,
+    'serve',
+    '--port',
+    port,
+    '--user-data-dir',
+    userDataDir,
+    ...(minimal ? ['--minimal'] : []),
+  ];
+  const child = spawn(command, args, {
+    cwd: repoRoot,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      PATH: cleanPath ? '' : process.env.PATH,
+      OPENCHROME_UPDATE_CHECK: '0',
+      OPENCHROME_PPID_WATCH: '0',
+    },
+  });
+  if (!child.stdin || !child.stdout) throw new Error('Failed to open MCP stdio pipes.');
+  const rl = readline.createInterface({ input: child.stdout, crlfDelay: Infinity });
+  const pending = new Map();
+  let stderr = '';
+  let readyResolve;
+  const ready = new Promise((resolve) => { readyResolve = resolve; });
+  child.stderr?.on('data', (chunk) => {
+    stderr += chunk.toString();
+    if (stderr.includes('STDIO transport enabled')) readyResolve();
+  });
+  rl.on('line', (line) => {
+    try {
+      const message = JSON.parse(line);
+      const waiter = pending.get(message.id);
+      if (waiter) {
+        pending.delete(message.id);
+        waiter(message);
+      }
+    } catch {
+      // Ignore non-JSON diagnostic output.
+    }
+  });
+
+  let nextId = 1;
+  let readinessTimer;
+  const prepareRequest = (method, params) => {
+    const id = nextId++;
+    const promise = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`Timed out waiting for ${method}. ${stderr.split('\n').slice(-8).join('\n')}`));
+      }, 30_000);
+      pending.set(id, (message) => {
+        clearTimeout(timer);
+        if (message.error) reject(new Error(`${method} failed: ${message.error.message}`));
+        else resolve(message.result);
+      });
+    });
+    return {
+      line: `${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`,
+      promise,
+    };
+  };
+
+  try {
+    await Promise.race([
+      ready,
+      new Promise((_, reject) => {
+        readinessTimer = setTimeout(
+          () => reject(new Error(`Timed out waiting for stdio readiness. ${stderr.split('\n').slice(-8).join('\n')}`)),
+          30_000,
+        );
+      }),
+    ]);
+    if (readinessTimer) {
+      clearTimeout(readinessTimer);
+      readinessTimer = undefined;
+    }
+    const initialize = prepareRequest('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'openchrome-standalone-parity', version: '1' },
+    });
+    const toolsList = prepareRequest('tools/list', {});
+    child.stdin.write(
+      initialize.line +
+      `${JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })}\n` +
+      toolsList.line,
+    );
+    await initialize.promise;
+    const result = await toolsList.promise;
+    return (result.tools || []).map((tool) => tool.name).sort();
+  } finally {
+    if (readinessTimer) clearTimeout(readinessTimer);
+    rl.close();
+    child.stdin.end();
+    if (!child.killed) child.kill('SIGTERM');
+    await new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL');
+        resolve();
+      }, 3_000);
+      child.once('exit', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write('Usage: node scripts/verify-standalone-cli.cjs --binary <path> [--expected-target <triple>]\n');
+    return;
+  }
+  if (!options.binary || !fs.existsSync(options.binary)) throw new Error('--binary must name an existing executable.');
+
+  const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+  const nodeCli = path.join(repoRoot, 'dist', 'cli', 'index.js');
+  const nodeServer = path.join(repoRoot, 'dist', 'index.js');
+  const binaryCommand = options.binary;
+
+  const commandPairs = [
+    { name: 'version', node: [nodeCli, '--version'], binary: ['--version'] },
+    { name: 'serve-help', node: [nodeServer, 'serve', '--help'], binary: ['serve', '--help'] },
+    { name: 'check-help', node: [nodeServer, 'check', '--help'], binary: ['check', '--help'] },
+    { name: 'doctor-help', node: [nodeServer, 'doctor', '--help'], binary: ['doctor', '--help'] },
+    { name: 'config-codex', node: [nodeCli, 'config', '--client', 'codex'], binary: ['config', '--client', 'codex'] },
+    { name: 'setup-help', node: [nodeCli, 'setup', '--help'], binary: ['setup', '--help'] },
+    { name: 'run-help', node: [nodeCli, 'run', '--help'], binary: ['run', '--help'] },
+    { name: 'playbook-help', node: [nodeCli, 'playbook', '--help'], binary: ['playbook', '--help'] },
+  ];
+  const commandHashes = {};
+  for (const pair of commandPairs) {
+    const expected = run(process.execPath, pair.node);
+    const actual = run(binaryCommand, pair.binary, true);
+    if (actual !== expected) throw new Error(`${pair.name} output differs between npm and standalone CLI.`);
+    commandHashes[pair.name] = hash(actual);
+  }
+
+  const validationDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openchrome-standalone-validation-'));
+  const validationPath = path.join(validationDir, 'playbook.json');
+  try {
+    fs.writeFileSync(validationPath, `${JSON.stringify({
+      name: 'standalone CLI self-spawn validation',
+      steps: [{ navigate: { url: 'https://example.com' } }],
+    }, null, 2)}\n`);
+    const expected = run(process.execPath, [
+      nodeCli,
+      'playbook',
+      'validate',
+      validationPath,
+      '--json',
+    ]);
+    const actual = run(binaryCommand, [
+      'playbook',
+      'validate',
+      validationPath,
+      '--json',
+    ], true);
+    if (actual !== expected) throw new Error('playbook validate output differs between npm and standalone CLI.');
+    commandHashes['playbook-validate'] = hash(actual);
+  } finally {
+    fs.rmSync(validationDir, { recursive: true, force: true });
+  }
+
+  if (run(binaryCommand, ['--version'], true) !== packageJson.version) {
+    throw new Error('Standalone --version does not match package.json.');
+  }
+
+  const buildInfo = JSON.parse(run(binaryCommand, ['build-info'], true));
+  if (!buildInfo.standalone || buildInfo.version !== packageJson.version) {
+    throw new Error('Standalone build-info is missing embedded version/provenance.');
+  }
+  if (options.expectedTarget && buildInfo.target !== options.expectedTarget) {
+    throw new Error(`Standalone target ${buildInfo.target} does not match ${options.expectedTarget}.`);
+  }
+
+  const manifestHashes = {};
+  for (const minimal of [false, true]) {
+    const args = ['serve', ...(minimal ? ['--minimal'] : []), '--introspect-tools-list'];
+    const expected = run(process.execPath, [nodeServer, ...args]);
+    const actual = run(binaryCommand, args, true);
+    if (actual !== expected) throw new Error(`${minimal ? 'minimal' : 'full'} introspection manifest differs.`);
+    manifestHashes[minimal ? 'minimal' : 'full'] = hash(actual);
+
+    const nodeTools = await listTools(process.execPath, [nodeServer], minimal, false);
+    const binaryTools = await listTools(binaryCommand, [], minimal, true);
+    if (JSON.stringify(binaryTools) !== JSON.stringify(nodeTools)) {
+      throw new Error(`${minimal ? 'minimal' : 'full'} MCP tools/list differs.`);
+    }
+  }
+
+  process.stdout.write(`${JSON.stringify({
+    ok: true,
+    binary: options.binary,
+    buildInfo,
+    commandHashes,
+    manifestHashes,
+  }, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  console.error(`[standalone-verify] ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -562,6 +562,14 @@ export class ChromeLauncher {
       console.error('[ChromeLauncher] Running in headless mode (no visible window)');
     }
 
+    // A fresh Chrome for Testing profile can block on macOS Keychain setup in
+    // non-interactive CI, leaving the process alive without opening its CDP port.
+    // Keep this test-only credential store away from user-owned real profiles.
+    if (process.platform === 'darwin' && process.env.CI && headless && profileType !== 'real') {
+      args.push('--use-mock-keychain');
+      console.error('[ChromeLauncher] macOS CI detected: using mock keychain for headless managed Chrome');
+    }
+
     // CI/Docker environments require --no-sandbox (Chrome won't start otherwise)
     if (process.env.CI || process.env.DOCKER) {
       args.push('--no-sandbox', '--disable-setuid-sandbox');

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,10 +151,15 @@ program
     if (options.introspectToolsList) {
       const { MCPServer } = await import('./mcp-server');
       const { registerAllTools } = await import('./tools');
-      const server = new MCPServer(undefined, { initialToolTier: 3, manifestOnly: true });
+      if (options.minimal && options.allTools) {
+        console.error('[openchrome] --minimal and --all-tools are mutually exclusive');
+        process.exitCode = 2;
+        return;
+      }
+      const initialToolTier: ToolTier = options.minimal ? 1 : 3;
+      const server = new MCPServer(undefined, { initialToolTier, manifestOnly: true });
       registerAllTools(server, { runtimeSideEffects: false });
-      const manifest = server.getToolManifest();
-      const output = JSON.stringify(manifest.tools) + '\n';
+      const output = JSON.stringify(server.getVisibleToolDefinitions()) + '\n';
       for (let offset = 0; offset < output.length; offset += 16_384) {
         const chunk = output.slice(offset, offset + 16_384);
         if (!process.stdout.write(chunk)) {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1363,19 +1363,8 @@ export class MCPServer {
     return this.capabilityFilter.has(capability ?? 'core');
   }
 
-  /**
-   * Handle tools/list request
-   */
-  private async handleToolsList(params?: Record<string, unknown>): Promise<MCPResult> {
-    // Signal the hint engine that this session has consumed tool descriptions,
-    // so rules whose guidance is already embedded in description "When to
-    // use / When NOT to use" blocks can suppress themselves without affecting
-    // other browser sessions that have not requested tools/list yet.
-    const sessionId = (params?.sessionId || 'default') as string;
-    if (this.hintEngine) {
-      this.hintEngine.markToolsListServed(sessionId);
-    }
-
+  /** Return the tool definitions visible at the current configured tier. */
+  getVisibleToolDefinitions(): MCPToolDefinition[] {
     const tools: MCPToolDefinition[] = [];
     for (const registry of this.tools.values()) {
       const tier = getToolTier(registry.definition.name);
@@ -1384,9 +1373,6 @@ export class MCPServer {
       }
     }
 
-    // Add hint about additional tools when not fully expanded.
-    // Only inject expand_tools if the client supports notifications/tools/list_changed —
-    // otherwise there's no point since the client can't react to the notification.
     if (this.exposedTier < 3 && this.clientSupportsListChanged && this.isCapabilityAllowed('core')) {
       const hiddenCount = Array.from(this.tools.values()).filter(
         r => getToolTier(r.definition.name) > this.exposedTier &&
@@ -1412,7 +1398,23 @@ export class MCPServer {
       }
     }
 
-    return { tools };
+    return tools;
+  }
+
+  /**
+   * Handle tools/list request
+   */
+  private async handleToolsList(params?: Record<string, unknown>): Promise<MCPResult> {
+    // Signal the hint engine that this session has consumed tool descriptions,
+    // so rules whose guidance is already embedded in description "When to
+    // use / When NOT to use" blocks can suppress themselves without affecting
+    // other browser sessions that have not requested tools/list yet.
+    const sessionId = (params?.sessionId || 'default') as string;
+    if (this.hintEngine) {
+      this.hintEngine.markToolsListServed(sessionId);
+    }
+
+    return { tools: this.getVisibleToolDefinitions() };
   }
 
   /**

--- a/src/transports/stdio.ts
+++ b/src/transports/stdio.ts
@@ -9,11 +9,24 @@ import { MCPResponse, MCPErrorCodes } from '../types/mcp';
 import { MCPTransport, TransportMessageContext } from './index';
 import { shutdownSyncBestEffort } from '../utils/sync-shutdown';
 
+const STANDALONE_STDOUT_CHUNK_CHARS = 16_384;
+
+interface StdioOutput {
+  write(chunk: string, callback?: (error?: Error | null) => void): boolean;
+}
+
 export class StdioTransport implements MCPTransport {
   private rl: readline.Interface | null = null;
+  private standaloneBuffer = '';
+  private standaloneInput: NodeJS.ReadableStream | null = null;
+  private standaloneDataHandler: ((chunk: string | Buffer) => void) | null = null;
+  private standaloneMessageQueue: Promise<void> = Promise.resolve();
+  private standaloneOutputQueue: Promise<void> = Promise.resolve();
   private messageHandler:
     | ((msg: Record<string, unknown>, signal?: AbortSignal, context?: TransportMessageContext) => Promise<MCPResponse | null>)
     | null = null;
+
+  constructor(private readonly output: StdioOutput = process.stdout) {}
 
   onMessage(
     handler: (msg: Record<string, unknown>, signal?: AbortSignal, context?: TransportMessageContext) => Promise<MCPResponse | null>,
@@ -23,86 +36,167 @@ export class StdioTransport implements MCPTransport {
 
   send(response: MCPResponse): void {
     // stdout is the MCP JSON-RPC channel in stdio mode
-    console.log(JSON.stringify(response));
+    if (process.env.OPENCHROME_STANDALONE_BINARY === '1') {
+      void this.enqueueStandaloneResponse(response).catch((error) => {
+        console.error(`[StdioTransport] Failed to write standalone response: ${this.errorMessage(error)}`);
+      });
+      return;
+    }
+    this.output.write(`${JSON.stringify(response)}\n`);
   }
 
-  start(): void {
-    this.rl = readline.createInterface({
-      input: process.stdin,
-      // Do NOT set output to process.stdout — stdout is the MCP JSON-RPC channel.
-      // Setting it risks protocol corruption if readline writes internally (prompts, echoes).
-      terminal: false,
-    });
-
-    this.rl.on('line', (line) => {
-      if (!line.trim()) return;
-
-      let parsed: Record<string, unknown>;
-      try {
-        parsed = JSON.parse(line) as Record<string, unknown>;
-      } catch (error) {
-        const errorResponse: MCPResponse = {
-          jsonrpc: '2.0',
-          id: 0,
-          error: {
-            code: MCPErrorCodes.PARSE_ERROR,
-            message: error instanceof Error ? error.message : 'Parse error',
-          },
-        };
-        this.send(errorResponse);
-        return;
-      }
-
-      if (!this.messageHandler) {
-        console.error('[StdioTransport] No message handler registered, dropping message');
-        return;
-      }
-
-      this.messageHandler(parsed)
-        .then((response) => {
-          if (response) {
-            this.send(response);
+  start(input: NodeJS.ReadableStream = process.stdin): void {
+    if (process.env.OPENCHROME_STANDALONE_BINARY === '1') {
+      this.standaloneInput = input;
+      this.standaloneDataHandler = (chunk: string | Buffer) => {
+        this.standaloneBuffer += chunk.toString();
+        let newlineIndex = this.standaloneBuffer.indexOf('\n');
+        while (newlineIndex >= 0) {
+          const line = this.standaloneBuffer.slice(0, newlineIndex).replace(/\r$/, '');
+          this.standaloneBuffer = this.standaloneBuffer.slice(newlineIndex + 1);
+          if (process.env.OPENCHROME_STANDALONE_DEBUG === '1') {
+            console.error(`[StdioTransport] standalone enqueue: ${line.slice(0, 160)}`);
           }
-        })
-        .catch((error) => {
-          const id = (parsed.id as string | number) ?? 0;
-          const errorResponse: MCPResponse = {
-            jsonrpc: '2.0',
-            id,
-            error: {
-              code: MCPErrorCodes.INTERNAL_ERROR,
-              message: error instanceof Error ? error.message : 'Internal error',
-            },
-          };
-          this.send(errorResponse);
-        });
-    });
-
-    this.rl.on('close', () => {
-      console.error('[StdioTransport] stdin closed (readline), shutting down...');
-      // #661 Phase 2: synchronous best-effort kill before process.exit so we
-      // don't orphan Chrome when the parent agent disconnects.
-      try { shutdownSyncBestEffort(); } catch { /* never throw at exit */ }
-      process.exit(0);
-    });
+          const handled = this.standaloneMessageQueue.then(() => this.handleLine(line));
+          this.standaloneMessageQueue = handled.catch((error) => {
+            console.error(`[StdioTransport] Failed to handle standalone message: ${this.errorMessage(error)}`);
+          });
+          newlineIndex = this.standaloneBuffer.indexOf('\n');
+        }
+      };
+      input.on('data', this.standaloneDataHandler);
+    } else {
+      const rl = readline.createInterface({
+        input,
+        // Do NOT set output to process.stdout — stdout is the MCP JSON-RPC channel.
+        // Setting it risks protocol corruption if readline writes internally (prompts, echoes).
+        terminal: false,
+      });
+      this.rl = rl;
+      rl.on('line', (line) => { void this.handleLine(line); });
+      rl.on('close', () => {
+        console.error('[StdioTransport] stdin closed (readline), shutting down...');
+        try { shutdownSyncBestEffort(); } catch { /* never throw at exit */ }
+        process.exit(0);
+      });
+    }
 
     // Belt-and-suspenders: monitor stdin directly for EOF/error.
     // When a parent process dies without cleanly closing the pipe,
     // readline may not fire 'close'. Listening on the raw stream
     // catches these edge cases.
-    process.stdin.on('end', () => {
+    input.on('end', () => {
       console.error('[StdioTransport] stdin ended, shutting down...');
       try { shutdownSyncBestEffort(); } catch { /* never throw at exit */ }
       process.exit(0);
     });
-    process.stdin.on('error', () => {
+    input.on('error', () => {
       console.error('[StdioTransport] stdin error, shutting down...');
       try { shutdownSyncBestEffort(); } catch { /* never throw at exit */ }
       process.exit(0);
     });
   }
 
+  private async handleLine(line: string): Promise<void> {
+    if (!line.trim()) return;
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(line) as Record<string, unknown>;
+    } catch (error) {
+      const errorResponse: MCPResponse = {
+        jsonrpc: '2.0',
+        id: 0,
+        error: {
+          code: MCPErrorCodes.PARSE_ERROR,
+          message: error instanceof Error ? error.message : 'Parse error',
+        },
+      };
+      await this.sendHandledResponse(errorResponse);
+      return;
+    }
+
+    if (!this.messageHandler) {
+      console.error('[StdioTransport] No message handler registered, dropping message');
+      return;
+    }
+
+    let response: MCPResponse | null;
+    try {
+      if (process.env.OPENCHROME_STANDALONE_DEBUG === '1') {
+        console.error(`[StdioTransport] standalone handle start: ${String(parsed.method || '(response)')}`);
+      }
+      response = await this.messageHandler(parsed);
+    } catch (error) {
+      const id = (parsed.id as string | number) ?? 0;
+      response = {
+        jsonrpc: '2.0',
+        id,
+        error: {
+          code: MCPErrorCodes.INTERNAL_ERROR,
+          message: error instanceof Error ? error.message : 'Internal error',
+        },
+      };
+    }
+
+    if (response) {
+      await this.sendHandledResponse(response);
+    }
+    if (process.env.OPENCHROME_STANDALONE_DEBUG === '1') {
+      console.error(`[StdioTransport] standalone handle done: ${String(parsed.method || '(response)')}`);
+    }
+  }
+
+  private sendHandledResponse(response: MCPResponse): Promise<void> {
+    if (process.env.OPENCHROME_STANDALONE_BINARY === '1') {
+      return this.enqueueStandaloneResponse(response);
+    }
+    this.send(response);
+    return Promise.resolve();
+  }
+
+  private enqueueStandaloneResponse(response: MCPResponse): Promise<void> {
+    const line = `${JSON.stringify(response)}\n`;
+    const responseId = String(response.id ?? '(notification)');
+    const write = this.standaloneOutputQueue.then(async () => {
+      if (process.env.OPENCHROME_STANDALONE_DEBUG === '1') {
+        console.error(`[StdioTransport] standalone write start: id=${responseId} bytes=${Buffer.byteLength(line)}`);
+      }
+      for (let offset = 0; offset < line.length; offset += STANDALONE_STDOUT_CHUNK_CHARS) {
+        await this.writeChunk(line.slice(offset, offset + STANDALONE_STDOUT_CHUNK_CHARS));
+      }
+      if (process.env.OPENCHROME_STANDALONE_DEBUG === '1') {
+        console.error(`[StdioTransport] standalone write done: id=${responseId}`);
+      }
+    });
+    this.standaloneOutputQueue = write.catch(() => undefined);
+    return write;
+  }
+
+  private writeChunk(chunk: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.output.write(chunk, (error?: Error | null) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+  }
+
+  private errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+
   async close(): Promise<void> {
+    await this.standaloneMessageQueue.catch(() => undefined);
+    await this.standaloneOutputQueue.catch(() => undefined);
+    if (this.standaloneInput && this.standaloneDataHandler) {
+      this.standaloneInput.removeListener('data', this.standaloneDataHandler);
+      this.standaloneInput = null;
+      this.standaloneDataHandler = null;
+      this.standaloneBuffer = '';
+      this.standaloneMessageQueue = Promise.resolve();
+      this.standaloneOutputQueue = Promise.resolve();
+    }
     if (this.rl) {
       this.rl.close();
       this.rl = null;

--- a/src/version.ts
+++ b/src/version.ts
@@ -9,6 +9,10 @@ let _version: string | null = null;
 
 export function getVersion(): string {
   if (!_version) {
+    if (process.env.OPENCHROME_BUILD_VERSION) {
+      _version = process.env.OPENCHROME_BUILD_VERSION;
+      return _version;
+    }
     try {
       const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
       _version = pkg.version;

--- a/tests/chrome/launcher-launch.test.ts
+++ b/tests/chrome/launcher-launch.test.ts
@@ -166,6 +166,8 @@ function startDelayedFakeChromeServer(delayMs: number): Promise<{ port: number; 
 
 describe('ChromeLauncher launch timeout fix (issue #171)', () => {
   const savedEnv = process.env.CHROME_LAUNCH_TIMEOUT_MS;
+  const savedCi = process.env.CI;
+  const savedPlatform = process.platform;
 
   afterEach(() => {
     if (savedEnv === undefined) {
@@ -173,6 +175,12 @@ describe('ChromeLauncher launch timeout fix (issue #171)', () => {
     } else {
       process.env.CHROME_LAUNCH_TIMEOUT_MS = savedEnv;
     }
+    if (savedCi === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = savedCi;
+    }
+    Object.defineProperty(process, 'platform', { value: savedPlatform });
     delete process.env.OPENCHROME_LAUNCH_MODE;
     mockSpawn.mockReset();
   });
@@ -321,6 +329,33 @@ describe('ChromeLauncher launch timeout fix (issue #171)', () => {
       await expect(
         launcher.ensureChrome({ autoLaunch: true })
       ).rejects.toThrow(/Exit code: 1|exited with code 1/);
+    }, 15000);
+  });
+
+  describe('macOS CI headless launch', () => {
+    it('uses the mock keychain for a managed profile', async () => {
+      const fakeChrome = await startDelayedFakeChromeServer(5_000);
+      try {
+        Object.defineProperty(process, 'platform', { value: 'darwin' });
+        process.env.CI = 'true';
+        process.env.OPENCHROME_LAUNCH_MODE = 'isolated';
+        process.env.CHROME_LAUNCH_TIMEOUT_MS = '1';
+
+        const proc = createMockProcess();
+        mockSpawn.mockReturnValue(proc as any);
+
+        const launcher = new ChromeLauncher(fakeChrome.port);
+        await expect(launcher.ensureChrome({
+          autoLaunch: true,
+          headless: true,
+          userDataDir: '/tmp/openchrome-macos-ci-profile',
+        })).rejects.toThrow(/not available after/);
+
+        const args = mockSpawn.mock.calls[0][1] as string[];
+        expect(args).toContain('--use-mock-keychain');
+      } finally {
+        await fakeChrome.close();
+      }
     }, 15000);
   });
 

--- a/tests/cli/build-info.test.ts
+++ b/tests/cli/build-info.test.ts
@@ -1,0 +1,37 @@
+import { getBuildInfo } from '../../cli/build-info';
+
+describe('CLI build provenance', () => {
+  const original = { ...process.env };
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in original)) delete process.env[key];
+    }
+    Object.assign(process.env, original);
+  });
+
+  test('uses embedded standalone metadata when present', () => {
+    process.env.OPENCHROME_STANDALONE_BINARY = '1';
+    process.env.OPENCHROME_BUILD_VERSION = '9.8.7';
+    process.env.OPENCHROME_BUILD_COMMIT = 'a'.repeat(40);
+    process.env.OPENCHROME_BUILD_TARGET = 'x86_64-unknown-linux-gnu';
+    process.env.OPENCHROME_BUILD_BUNDLER = 'bun-1.3.14';
+
+    expect(getBuildInfo()).toEqual({
+      version: '9.8.7',
+      sourceCommit: 'a'.repeat(40),
+      target: 'x86_64-unknown-linux-gnu',
+      bundler: 'bun-1.3.14',
+      standalone: true,
+    });
+  });
+
+  test('keeps npm execution backward compatible', () => {
+    delete process.env.OPENCHROME_STANDALONE_BINARY;
+    delete process.env.OPENCHROME_BUILD_VERSION;
+    const info = getBuildInfo();
+    expect(info.version).toMatch(/^\d+\.\d+\.\d+/);
+    expect(info.standalone).toBe(false);
+    expect(info.bundler).toContain('node-');
+  });
+});

--- a/tests/cli/entrypoint-parity.test.ts
+++ b/tests/cli/entrypoint-parity.test.ts
@@ -3,9 +3,18 @@ import fs from 'fs';
 import path from 'path';
 
 const DIST_WRAPPER = path.join(process.cwd(), 'dist', 'cli', 'index.js');
+const DIST_SERVER = path.join(process.cwd(), 'dist', 'index.js');
 
 function runWrapper(args: string[]) {
   return spawnSync(process.execPath, [DIST_WRAPPER, ...args], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: { ...process.env, OPENCHROME_UPDATE_CHECK: '0' },
+  });
+}
+
+function runServer(args: string[]) {
+  return spawnSync(process.execPath, [DIST_SERVER, ...args], {
     cwd: process.cwd(),
     encoding: 'utf8',
     env: { ...process.env, OPENCHROME_UPDATE_CHECK: '0' },
@@ -50,5 +59,17 @@ describe('CLI entrypoint parity', () => {
     expect(source).not.toContain("process.on('SIGHUP'");
     expect(source).toContain("child.on('exit', (code, signal)");
     expect(source).toContain('SIGNAL_EXIT_CODES');
+  });
+
+  test('full and minimal introspection expose different deterministic surfaces', () => {
+    const full = runServer(['serve', '--introspect-tools-list']);
+    const minimal = runServer(['serve', '--minimal', '--introspect-tools-list']);
+    expect(full.status).toBe(0);
+    expect(minimal.status).toBe(0);
+    const fullTools = JSON.parse(full.stdout) as Array<{ name: string }>;
+    const minimalTools = JSON.parse(minimal.stdout) as Array<{ name: string }>;
+    expect(fullTools.length).toBeGreaterThan(minimalTools.length);
+    expect(fullTools.some((tool) => tool.name === 'expand_tools')).toBe(false);
+    expect(minimalTools.some((tool) => tool.name === 'expand_tools')).toBe(true);
   });
 });

--- a/tests/cli/serve-invocation.test.ts
+++ b/tests/cli/serve-invocation.test.ts
@@ -1,0 +1,29 @@
+import path from 'path';
+import { resolveServeInvocation } from '../../cli/serve-invocation';
+
+describe('standalone serve invocation', () => {
+  const original = process.env.OPENCHROME_STANDALONE_BINARY;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.OPENCHROME_STANDALONE_BINARY;
+    else process.env.OPENCHROME_STANDALONE_BINARY = original;
+  });
+
+  test('npm CLI spawns the compiled server entry through Node', () => {
+    delete process.env.OPENCHROME_STANDALONE_BINARY;
+    const invocation = resolveServeInvocation('dist/index.js', ['--server-mode']);
+    expect(invocation).toEqual({
+      command: process.execPath,
+      args: [path.resolve('dist/index.js'), 'serve', '--server-mode'],
+    });
+  });
+
+  test('standalone CLI self-spawns without a script path', () => {
+    process.env.OPENCHROME_STANDALONE_BINARY = '1';
+    const invocation = resolveServeInvocation('/missing/dist/index.js', ['--minimal']);
+    expect(invocation).toEqual({
+      command: process.execPath,
+      args: ['serve', '--minimal'],
+    });
+  });
+});

--- a/tests/scripts/standalone-build.test.ts
+++ b/tests/scripts/standalone-build.test.ts
@@ -1,0 +1,63 @@
+import fs from 'fs';
+import path from 'path';
+import { execFileSync } from 'child_process';
+
+const targets = require('../../scripts/standalone/targets.cjs') as {
+  PINNED_BUN_VERSION: string;
+  TARGETS: Record<string, { bunTarget: string; standaloneAsset: string }>;
+  resolveTarget: (input: string) => { target: string; standaloneAsset: string };
+  outputName: (target: { target: string; standaloneAsset: string; extension: string }, kind: string) => string;
+};
+
+describe('standalone CLI build contract', () => {
+  test('pins Bun and covers the certified release matrix', () => {
+    expect(targets.PINNED_BUN_VERSION).toBe('1.3.14');
+    expect(Object.keys(targets.TARGETS).sort()).toEqual([
+      'aarch64-apple-darwin',
+      'x86_64-apple-darwin',
+      'x86_64-pc-windows-msvc',
+      'x86_64-unknown-linux-gnu',
+    ]);
+  });
+
+  test.each([
+    ['macos-arm64', 'openchrome-macos-arm64'],
+    ['macos-x64', 'openchrome-macos-x64'],
+    ['windows-x64', 'openchrome-windows-x64.exe'],
+    ['linux-x64', 'openchrome-linux-x64'],
+  ])('maps %s to release asset %s', (alias, expected) => {
+    expect(targets.resolveTarget(alias).standaloneAsset).toBe(expected);
+  });
+
+  test('sidecar naming stays compatible with Tauri externalBin', () => {
+    const target = targets.resolveTarget('windows-x64') as { target: string; standaloneAsset: string; extension: string };
+    expect(targets.outputName(target, 'sidecar')).toBe('openchrome-sidecar-x86_64-pc-windows-msvc.exe');
+  });
+
+  test('build script documents fail-closed target, tag, and output controls', () => {
+    const script = path.join(process.cwd(), 'scripts', 'build-standalone-cli.cjs');
+    const output = execFileSync(process.execPath, [script, '--help'], { encoding: 'utf8' });
+    expect(output).toContain('--target <target>');
+    expect(output).toContain('--tag <vX.Y.Z>');
+    expect(output).toContain('--output-dir <path>');
+  });
+
+  test('desktop and release workflows share the canonical builder', () => {
+    const desktopScript = fs.readFileSync(path.join(process.cwd(), 'desktop', 'scripts', 'build-sidecar.js'), 'utf8');
+    const desktopWorkflow = fs.readFileSync(path.join(process.cwd(), '.github', 'workflows', 'desktop-release.yml'), 'utf8');
+    const cliWorkflow = fs.readFileSync(path.join(process.cwd(), '.github', 'workflows', 'cli-release.yml'), 'utf8');
+    expect(desktopScript).toContain('build-standalone-cli.cjs');
+    expect(desktopWorkflow).toContain('build-standalone-cli.cjs');
+    expect(desktopWorkflow).toContain('npm run build');
+    expect(desktopWorkflow.indexOf('npm run build')).toBeLessThan(
+      desktopWorkflow.indexOf('build-standalone-cli.cjs'),
+    );
+    expect(cliWorkflow).toContain('build-standalone-cli.cjs');
+    expect(cliWorkflow).toContain('macos-15-intel');
+    expect(cliWorkflow).toContain("bun-version: ${{ env.BUN_VERSION }}");
+    expect(cliWorkflow).toContain('verify-standalone-browser-smoke.cjs');
+    expect(cliWorkflow).toContain('browser-actions/setup-chrome@e574b4b3a21156ab45dd6b5f67e884fd26eed829');
+    expect(cliWorkflow).toContain('chrome-version: 131.0.6778.87');
+    expect(cliWorkflow).toContain("'src/transports/stdio.ts'");
+  });
+});

--- a/tests/transports/stdio-standalone.test.ts
+++ b/tests/transports/stdio-standalone.test.ts
@@ -1,0 +1,64 @@
+import { PassThrough } from 'stream';
+import { StdioTransport } from '../../src/transports/stdio';
+
+describe('standalone stdio transport buffering', () => {
+  const originalStandalone = process.env.OPENCHROME_STANDALONE_BINARY;
+
+  afterEach(() => {
+    if (originalStandalone === undefined) delete process.env.OPENCHROME_STANDALONE_BINARY;
+    else process.env.OPENCHROME_STANDALONE_BINARY = originalStandalone;
+  });
+
+  test('preserves multiple JSON-RPC lines delivered in one stdin chunk', async () => {
+    process.env.OPENCHROME_STANDALONE_BINARY = '1';
+    const input = new PassThrough();
+    const transport = new StdioTransport();
+    const seen: Array<Record<string, unknown>> = [];
+    transport.onMessage(async (message) => {
+      if (message.method === 'notifications/initialized') {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      seen.push(message);
+      return null;
+    });
+    transport.start(input);
+
+    input.write(
+      `${JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })}\n` +
+      `${JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} })}\n`,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(seen.map((message) => message.method)).toEqual([
+      'notifications/initialized',
+      'tools/list',
+    ]);
+    await transport.close();
+  });
+
+  test('flushes large responses as one complete JSON line under backpressure', async () => {
+    process.env.OPENCHROME_STANDALONE_BINARY = '1';
+    const chunks: string[] = [];
+    const output = {
+      write: (chunk: string, callback?: (error?: Error | null) => void) => {
+        chunks.push(chunk);
+        setImmediate(() => callback?.());
+        return false;
+      },
+    };
+    const transport = new StdioTransport(output);
+    const response = {
+      jsonrpc: '2.0' as const,
+      id: 2,
+      result: { tools: [{ name: 'large', description: 'x'.repeat(80_000) }] },
+    };
+
+    transport.send(response);
+    await transport.close();
+
+    expect(chunks.length).toBeGreaterThan(1);
+    const line = chunks.join('');
+    expect(line.endsWith('\n')).toBe(true);
+    expect(JSON.parse(line)).toEqual(response);
+  });
+});


### PR DESCRIPTION
## Summary

- compile the canonical OpenChrome CLI and server entrypoints into one self-contained Bun executable
- reuse the same pinned builder for Tauri sidecars and standalone release assets
- publish macOS arm64/x64, Windows x64, and Linux x64 binaries with SHA-256 and provenance metadata
- enforce npm/standalone parity for command output, nested `playbook validate` self-spawn, full/minimal manifests, and batched stdio initialization
- run real Chrome 131 fixture navigation, `read_page`, and clean shutdown on macOS arm64 and Linux x64
- document pinned downloads and checksum verification while keeping npm as the broadest installation path

## Direction and guardrails

This is an additive packaging improvement, not a native-core rewrite. It adds no dependency, does not bundle Chrome, does not deprecate npm, and keeps the desktop app on the same canonical command wiring.

The release builder fails closed on:

- unsupported targets
- a Bun version other than `1.3.14`
- a release tag that does not match `package.json`
- missing canonical `dist/index.js` or `dist/cli/index.js` builds
- any npm/standalone command, tool-manifest, stdio, or browser-free self-spawn drift

## Validation

Local verification on the final commit `9748514d`:

- `npm run build`
- all 649 Jest suites covered through the three CI shards plus the 10 CI-excluded suites: 7,802 passed, 98 skipped, 0 failed
- `npm run lint`
- `npm run lint:tier`
- `npm run lint:tool-schemas`
- `npm run docs:capability-map:check`
- `actionlint .github/workflows/cli-release.yml`
- compiled macOS arm64 standalone command and nested `playbook validate` parity
- full/minimal introspection and MCP `tools/list` parity
- batched `initialize` + `notifications/initialized` + `tools/list` stdio regression

Final local artifact:

- asset: `openchrome-macos-arm64`
- SHA-256: `6e79583a74dd9fbb0e824f89ed3c2cdbb746b786c2913f61e5d81b3db7c1fd9a`
- embedded source commit: `9748514da06df7b19fcbdcffe339a66e2e4524a8`

The PR workflow supplies the remaining native-platform and pinned Chrome 131 live evidence. The live browser smoke uses a Node-free system PATH so Chrome can access required operating-system utilities while the standalone executable remains independent of Node/npm.

Closes #1555
