### PR TITLE
Support the MCP 2026-07-28 protocol

### DIFF
--- a/.github/workflows/benchmark-reliability.yml
+++ b/.github/workflows/benchmark-reliability.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -20,7 +20,7 @@ jobs:
           # Main-branch full matrix keeps OS/Node smoke coverage, while the
           # expensive Ubuntu/Node 20 Jest suite runs as three parallel shards.
           - os: ubuntu-latest
-            node-version: 18
+            node-version: 24
             test-shard: ''
           - os: ubuntu-latest
             node-version: 20
@@ -35,7 +35,7 @@ jobs:
             node-version: 22
             test-shard: ''
           - os: macos-latest
-            node-version: 18
+            node-version: 24
             test-shard: ''
           - os: macos-latest
             node-version: 20
@@ -44,7 +44,7 @@ jobs:
             node-version: 22
             test-shard: ''
           - os: windows-latest
-            node-version: 18
+            node-version: 24
             test-shard: ''
           - os: windows-latest
             node-version: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           # CI wall-clock is bounded by the slowest shard instead of one long
           # serial test job.
           - os: ubuntu-latest
-            node-version: 18
+            node-version: 24
             test-shard: ''
           - os: ubuntu-latest
             node-version: 20

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ root so both hosts auto-discover it.
 | Topic | Link |
 |---|---|
 | Architecture & reliability layers | [`docs/architecture.md`](docs/architecture.md) |
+| MCP 2026-07-28 migration | [`docs/mcp-2026-07-28.md`](docs/mcp-2026-07-28.md) |
 | Getting started walkthrough | [`docs/getting-started.md`](docs/getting-started.md) |
 | Full tool catalogue | [`docs/agent/capability-map.md`](docs/agent/capability-map.md) |
 | CLI & playbook | [`docs/cli.md`](docs/cli.md) · [`docs/cli/playbook.md`](docs/cli/playbook.md) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,7 +88,7 @@ The contract that governs every PR landing on `develop`:
 
 ## Transport surfaces
 
-OpenChrome supports `stdio`, `http`, and `both` transport modes over the same deterministic MCP tool server. Use [`docs/getting-started/http-daemon.md`](getting-started/http-daemon.md) for the operator-focused HTTP daemon walkthrough, including multi-client topology, auth, `/health`, `/metrics`, and idle-timeout behavior. Use [`docs/transport-lifecycle.md`](transport-lifecycle.md) for stability commitments and deprecation policy.
+OpenChrome supports `stdio`, `http`, and `both` transport modes over the same deterministic MCP tool server. The official MCP SDK owns protocol negotiation and serves both the stateless `2026-07-28` revision and legacy clients; the OpenChrome dispatcher remains the shared browser-control core. Use [`docs/mcp-2026-07-28.md`](mcp-2026-07-28.md) for the protocol architecture and migration rationale, [`docs/getting-started/http-daemon.md`](getting-started/http-daemon.md) for the operator-focused HTTP daemon walkthrough, and [`docs/transport-lifecycle.md`](transport-lifecycle.md) for stability commitments and deprecation policy.
 
 ## Data flow for a typical agent loop
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ OpenChrome is an MCP server that enables multiple Claude Code sessions to contro
 
 ## Prerequisites
 
-- Node.js >= 18
+- Node.js >= 20
 - Google Chrome (stable or Chromium)
 
 ## Installation
@@ -189,7 +189,7 @@ This checks your entire environment in one pass and prints an actionable report:
 ```
 === openchrome doctor ===
 
-[  ok  ] Node.js version  v20.11.0 (required: >=18.0.0)
+[  ok  ] Node.js version  v20.11.0 (required: >=20.0.0)
 [  ok  ] ~/.openchrome/ writable  /Users/you/.openchrome
 [ fail ] Chrome binary  Chrome executable not found on this system
          Fix: Install Google Chrome, or set CHROME_PATH env var to the binary path

--- a/docs/getting-started/http-daemon.md
+++ b/docs/getting-started/http-daemon.md
@@ -1,9 +1,10 @@
 # HTTP Daemon Mode
 
 OpenChrome's HTTP transport turns the MCP server into a long-running daemon that
-multiple callers can reach concurrently over plain HTTP + JSON-RPC. This page is
-the single reference for operators who need a shared, persistent OpenChrome
-instance — for CI pipelines, multi-client setups, or dashboard integrations.
+multiple callers can reach concurrently over HTTP + JSON-RPC. It serves
+stateless MCP `2026-07-28` requests and retains the legacy sessionful path for
+older clients. This page is the single reference for operators who need a
+shared, persistent OpenChrome instance.
 
 For the 30-second quick-start, jump to [Copy-pasteable curl recipe](#copy-pasteable-curl-recipe).
 
@@ -76,9 +77,10 @@ All flags live in `src/index.ts`. Every env var listed here is read in the same 
 
 ## 3. Multi-client scenario
 
-Two MCP clients share one OpenChrome daemon. Each client issues independent
-`tools/list` and `tools/call` requests; the daemon multiplexes them over separate
-HTTP sessions.
+Two MCP clients share one OpenChrome daemon. Each modern client issues
+self-contained `tools/list` and `tools/call` POST requests. OpenChrome browser
+state is carried by explicit application `sessionId` and `tabId` values, not by
+an MCP transport session.
 
 ```
 ┌─────────────────────┐        HTTP + JSON-RPC       ┌──────────────────────────┐
@@ -105,8 +107,8 @@ HTTP sessions.
 Key properties of this setup:
 - **Single Chrome process**: all sessions share one browser; tabs are isolated per session.
 - **Concurrent requests**: the HTTP server handles multiple in-flight MCP requests.
-- **Independent lifecycles**: clients can connect and disconnect without restarting the daemon.
-- **Idle-timeout**: when all clients disconnect and no new sessions arrive within the idle window, the daemon exits cleanly (code 0).
+- **Independent lifecycles**: clients can make and cancel requests without restarting the daemon.
+- **Idle-timeout**: when OpenChrome has no browser sessions and no activity occurs within the idle window, the daemon exits cleanly (code 0).
 
 ---
 
@@ -127,7 +129,8 @@ Key properties of this setup:
   external health probes.
 - **`/api/tool-calls` and other dashboard endpoints**: these require the same
   bearer token as `/mcp`.
-- **Rate limiting**: the HTTP transport applies a per-session rate limiter (see
+- **Rate limiting**: the HTTP transport applies an authenticated-tenant or
+  application-session rate limiter (see
   `src/transports/http.ts`). Excessive requests are throttled with `429 Too Many Requests`.
 
 ---
@@ -185,8 +188,11 @@ daemon is up and accepting connections.
 curl -s \
   -X POST http://127.0.0.1:3100/mcp \
   -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
   -H "Authorization: Bearer mysecrettoken" \
-  --data '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+  -H "MCP-Protocol-Version: 2026-07-28" \
+  -H "Mcp-Method: tools/list" \
+  --data '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"curl","version":"1.0.0"}}}}'
 ```
 
 ```powershell
@@ -194,8 +200,14 @@ curl -s \
 Invoke-RestMethod `
   -Method POST `
   -Uri http://127.0.0.1:3100/mcp `
-  -Headers @{ "Content-Type" = "application/json"; "Authorization" = "Bearer mysecrettoken" } `
-  -Body '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+  -ContentType "application/json" `
+  -Headers @{
+    "Accept" = "application/json, text/event-stream"
+    "Authorization" = "Bearer mysecrettoken"
+    "MCP-Protocol-Version" = "2026-07-28"
+    "Mcp-Method" = "tools/list"
+  } `
+  -Body '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"powershell","version":"1.0.0"}}}}'
 ```
 
 Expected response shape (abbreviated):
@@ -205,16 +217,21 @@ Expected response shape (abbreviated):
   "jsonrpc": "2.0",
   "id": 1,
   "result": {
+    "resultType": "complete",
     "tools": [
       { "name": "navigate", "description": "..." },
       { "name": "read_page", "description": "..." }
-    ]
+    ],
+    "ttlMs": 30000,
+    "cacheScope": "private"
   }
 }
 ```
 
 The `tools` array will contain at least one entry. Substitute `mysecrettoken`
 with the token you passed to `--auth-token`, and `3100` with your chosen port.
+Legacy clients may continue to use `initialize`, `Mcp-Session-Id`, and the
+legacy SSE endpoints; protocol-era selection is automatic.
 
 ---
 
@@ -231,9 +248,9 @@ npx openchrome serve \
   --idle-timeout 90s
 ```
 
-After the last session closes (or if no session was ever opened), the daemon
-monitors for inactivity. Once 90 seconds pass with zero sessions, it logs a
-shutdown message to stderr and exits with code 0.
+After the last OpenChrome browser session closes (or if none was opened), the
+daemon monitors for inactivity. Once 90 seconds pass with zero sessions, it
+logs a shutdown message to stderr and exits with code 0.
 
 To observe this:
 
@@ -347,5 +364,7 @@ Either add `--auth-token` or keep `--http-host 127.0.0.1` (the default).
   table of `OPENCHROME_PPID_WATCH`, `OPENCHROME_HEALTH_ENDPOINT`, and related
   vars.
 - [Architecture overview](../architecture.md): transport layer in context.
+- [MCP 2026-07-28 migration](../mcp-2026-07-28.md): protocol behavior,
+  compatibility, and design rationale.
 - `src/transports/http.ts`: HTTP transport implementation, rate limiter, auth middleware.
 - `src/index.ts`: all CLI flag definitions (lines 92–97).

--- a/docs/mcp-2026-07-28.md
+++ b/docs/mcp-2026-07-28.md
@@ -142,6 +142,12 @@ the original `tools/call` with a new JSON-RPC ID and matching
 `inputResponses`. Current OpenChrome flows request at most one input and can
 deterministically re-run from the original arguments.
 
+Modern requests have no transport session, so URL and file-output tools refresh
+`roots/list` immediately before egress and scope the response to OpenChrome's
+explicit application `sessionId`. The first round therefore stops before any
+browser side effect, and the retry enforces the returned roots before dispatch.
+Tools without an egress candidate do not incur this extra round.
+
 Before adding a multi-stage or side-effecting MRTR flow, OpenChrome must add an
 opaque, integrity-protected `requestState` that records the completed stage and
 an idempotency key. This prevents duplicate browser actions when a retry lands

--- a/docs/mcp-2026-07-28.md
+++ b/docs/mcp-2026-07-28.md
@@ -1,0 +1,294 @@
+# MCP 2026-07-28 migration
+
+OpenChrome supports the final MCP `2026-07-28` revision through the official
+TypeScript SDK while retaining legacy MCP support during the transition.
+
+Primary references:
+
+- [MCP 2026-07-28 specification](https://modelcontextprotocol.io/specification/2026-07-28)
+- [MCP 2026-07-28 changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
+- [Streamable HTTP binding](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http)
+- [TypeScript SDK migration guide](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/migration/support-2026-07-28.md)
+
+## Decision
+
+The official SDK owns OpenChrome's protocol boundary. OpenChrome's existing
+`MCPServer` remains the application runtime for browser sessions, tools,
+resources, authorization, rate limiting, and observability.
+
+```text
+MCP client
+    |
+    | stdio or Streamable HTTP
+    v
+official MCP SDK
+  - protocol-era selection
+  - modern request envelope and HTTP header validation
+  - result metadata and cache hints
+  - subscriptions/listen
+  - cancellation and MRTR wire shapes
+    |
+    v
+OpenChrome SDK adapter
+  - request context
+  - authenticated principal and tenant
+  - client capabilities
+  - input_required bridge
+    |
+    v
+OpenChrome MCPServer
+  - explicit sessionId/tabId browser state
+  - tools, resources, policy, and CDP execution
+```
+
+This keeps protocol conformance in the upstream implementation while avoiding
+a rewrite of the mature browser-control core.
+
+## Protocol changes
+
+| Area | Legacy behavior | 2026-07-28 behavior | OpenChrome behavior |
+| --- | --- | --- | --- |
+| Startup | `initialize`, then `notifications/initialized` | No handshake | Both eras are accepted |
+| Discovery | Capabilities returned by `initialize` | Required `server/discover` method | Served by the official SDK |
+| Protocol metadata | Connection-scoped | Required in every request's `_meta` | Validated by the SDK |
+| HTTP session | `Mcp-Session-Id` | Removed | Never emitted or required for modern requests |
+| HTTP verbs | POST plus long-lived GET and DELETE | POST only | Modern GET/DELETE are rejected; legacy behavior remains |
+| HTTP routing | Body inspection | `MCP-Protocol-Version`, `Mcp-Method`, and conditional `Mcp-Name` headers | Header/body mismatches are rejected before dispatch |
+| Change events | Persistent GET SSE and resource subscribe methods | Filtered `subscriptions/listen` POST | Modern event bus plus legacy SSE compatibility |
+| Server-to-client requests | Server emits JSON-RPC requests | `input_required` result, then client retry | Sampling, elicitation, and roots calls are adapted to MRTR |
+| Utilities and logging | `ping`, `logging/setLevel`, roots-list change notification | Removed; log level moves into request `_meta` | SDK rejects removed methods and filters request-scoped log messages |
+| Results | No discriminator | Required `resultType` | Added by the SDK |
+| List/read caching | Client-specific convention | Required `ttlMs` and `cacheScope` | Explicit cache hints are configured |
+| Tool schemas | Draft-07-shaped subset in many implementations | JSON Schema 2020-12; arbitrary JSON output | Existing object schemas remain valid; broader authoring is follow-up work |
+| Missing resource | Commonly `-32002` | `-32602` Invalid Params | Updated to `-32602` with the URI in error data |
+| Extensions | Experimental features mixed into core | Negotiated reverse-DNS extension map | No extension is advertised until OpenChrome adopts one deliberately |
+| Runtime | OpenChrome previously supported Node 18 | SDK 2.x requires Node 20 | OpenChrome now requires Node 20 or newer |
+
+## Compatibility matrix
+
+| Transport | Modern client | Legacy client |
+| --- | --- | --- |
+| stdio | Starts with `server/discover`; every request has modern `_meta` | Starts with `initialize`; connection-scoped compatibility state is retained |
+| HTTP | Stateless POST requests handled by the SDK | Existing initialize/session/GET-SSE/DELETE path remains available |
+| `both` | Each transport negotiates independently | Each transport negotiates independently |
+
+For stdio, a dual-era client should probe with `server/discover`. For HTTP, the
+request envelope and `MCP-Protocol-Version` header identify the modern path.
+
+## OpenChrome state model
+
+The protocol is stateless, but Chrome is not. OpenChrome already models browser
+state explicitly:
+
+- `sessions/create` returns an application-level `sessionId`.
+- Tool calls carry `sessionId` and, where needed, `tabId`.
+- Tenant and API-key identity are resolved on every HTTP request.
+- Broker clients carry an explicit broker client ID.
+
+These are application handles, not MCP transport sessions. They remain valid
+and are the right model for the new protocol.
+
+This does not make a fleet of OpenChrome daemons automatically interchangeable.
+A browser session currently belongs to one daemon and its Chrome/CDP runtime.
+Round-robin deployment across multiple daemons still needs one of:
+
+- a shared session-to-owner registry and routing layer;
+- consistent routing based on an explicit OpenChrome session handle; or
+- a distributed browser-session backend.
+
+The migration removes MCP sticky-session requirements. It does not pretend
+that process-local browser state has disappeared.
+
+## Tool discovery
+
+Legacy clients keep OpenChrome's progressive disclosure behavior where their
+connection capabilities support `tools/list_changed`.
+
+Modern `tools/list` cannot vary as a side effect of hidden connection history.
+OpenChrome therefore returns the full authorization- and capability-filtered
+tool set on every modern request. The order remains deterministic, and the
+private cache hint reduces repeated schema transfer.
+
+If smaller modern tool surfaces are needed later, they should be selected by
+explicit configuration or a named server profile. They must not depend on
+which tool a connection happened to call earlier.
+
+## Cache policy
+
+| Method | `ttlMs` | Scope | Reason |
+| --- | ---: | --- | --- |
+| `server/discover` | 300000 | public | Product identity and protocol capabilities are stable |
+| `tools/list` | 30000 | private | Tool visibility can depend on authorization |
+| `resources/list` | 0 | private | Live browser sessions change frequently |
+| `resources/templates/list` | 60000 | private | Templates are stable but may be deployment-specific |
+| `resources/read` | 0 | private | Live browser state must not be reused |
+
+`list_changed` events complement these freshness hints; they do not replace
+them.
+
+## Multi-round-trip requests
+
+Modern MCP no longer allows an OpenChrome tool to push a JSON-RPC request to
+the client. The adapter converts existing calls as follows:
+
+| Existing call | Modern input request |
+| --- | --- |
+| `elicitation/create` | Form or URL elicitation in `inputRequests` |
+| `sampling/createMessage` | Sampling request in `inputRequests` |
+| `roots/list` | Roots request in `inputRequests` |
+
+The first tool call returns `resultType: "input_required"`. The client retries
+the original `tools/call` with a new JSON-RPC ID and matching
+`inputResponses`. Current OpenChrome flows request at most one input and can
+deterministically re-run from the original arguments.
+
+Before adding a multi-stage or side-effecting MRTR flow, OpenChrome must add an
+opaque, integrity-protected `requestState` that records the completed stage and
+an idempotency key. This prevents duplicate browser actions when a retry lands
+on another worker.
+
+## Subscriptions
+
+Modern clients open `subscriptions/listen` and select only the events they
+need:
+
+- `toolsListChanged`
+- `resourcesListChanged`
+- `resourceSubscriptions`
+
+The SDK acknowledges the subscription before publishing events and stamps
+each event with `io.modelcontextprotocol/subscriptionId`.
+
+Legacy `resources/subscribe`, `resources/unsubscribe`, `GET /mcp`, and
+`GET /mcp/sse` remain available only on the legacy path.
+
+## Security and operations
+
+- Existing bearer, API-key, JWT, tenant, CORS, and loopback protections run
+  before SDK dispatch.
+- Browser CORS preflight permits the required modern MCP routing headers.
+- Only the authenticated principal and normalized tenant/broker identifiers
+  enter SDK request context. Plaintext credentials are never copied there.
+- Modern request headers are checked against the JSON-RPC body before tool
+  dispatch, enabling safe gateway routing and method-level policy.
+- Modern requests ignore transport session IDs and never mint or echo one, so
+  a leaked `Mcp-Session-Id` cannot become an authorization surrogate.
+- `tools/list` and resource results use private caching whenever authorization
+  or live browser state can affect the response.
+- Concrete resource listings and modern resource change streams are
+  tenant-scoped; unresolved event ownership fails closed instead of
+  broadcasting a resource URI.
+
+No current OpenChrome schema declares `x-mcp-header`. Before introducing one,
+the server must add registry-aware validation for every declared
+`Mcp-Param-*` header, including Base64 sentinel decoding and exact body/header
+matching.
+
+The revision's OAuth issuer and Dynamic Client Registration changes primarily
+govern MCP clients and authorization servers. OpenChrome currently acts as a
+resource server with bearer, API-key, or JWT verification and does not expose
+an OAuth authorization or dynamic-registration flow. If that changes, issuer
+binding, `iss` validation, client `application_type`, and credential storage by
+issuer become release requirements rather than transport follow-ups.
+
+## Fit with OpenChrome
+
+The migration is a strong fit for OpenChrome's direction:
+
+1. Explicit state is already the product model. `sessionId` and `tabId` are
+   visible handles that agents can reason about and hand off.
+2. Per-request capabilities prevent one client's negotiated state from leaking
+   into another client in daemon mode.
+3. Method/name headers fit OpenChrome's existing auth, scope, rate-limit, and
+   audit boundaries.
+4. Cacheable deterministic discovery reduces repeated tool-schema cost.
+5. Filtered subscriptions fit live tab/resource updates without requiring one
+   global broadcast stream.
+6. Deprecating server-side Sampling reinforces OpenChrome principle P3: the
+   core should not acquire mandatory outbound LLM provider calls.
+
+There are two deliberate constraints:
+
+- Direct LLM provider integration does not belong in core. Optional sampling
+  refinements should move to host orchestration or an explicit pilot/companion
+  integration as legacy Sampling ages out.
+- The Tasks extension should not silently introduce background work into core.
+  Long-running crawl, recording, or replay jobs may adopt Tasks only behind an
+  explicit operator-controlled mode consistent with P1 and the pilot boundary.
+
+MCP Apps are a better near-term extension candidate. An opt-in element picker,
+recording inspector, or evidence viewer can present OpenChrome facts without
+moving model judgment into the server.
+
+## Follow-up roadmap
+
+### P0: protocol boundary
+
+- [x] Adopt `@modelcontextprotocol/server` and
+  `@modelcontextprotocol/node` 2.x.
+- [x] Support modern and legacy stdio negotiation.
+- [x] Add strict stateless modern HTTP while preserving legacy HTTP.
+- [x] Implement discovery, result metadata, cache hints, subscriptions, and
+  MRTR adaptation.
+- [x] Preserve auth, tenant, broker, cancellation, logging, and progress
+  context.
+- [x] Raise the runtime and CI floor to Node 20.
+
+### P1: complete the migration surface
+
+- [ ] Run the upstream MCP conformance suite in CI for both transports.
+- [ ] Expand internal schema types and validation from the current object
+  subset to bounded JSON Schema 2020-12.
+- [ ] Support non-object `outputSchema` and arbitrary JSON
+  `structuredContent`, including legacy result projection tests.
+- [ ] Add signed `requestState` before any multi-stage MRTR tool.
+- [ ] Propagate W3C `traceparent`, `tracestate`, and `baggage` into
+  OpenTelemetry spans.
+- [ ] Replace Roots-dependent policy with explicit tool parameters, resource
+  URIs, or server/session configuration.
+- [ ] Move structured remote logging to OpenTelemetry while keeping stderr for
+  stdio.
+
+### P2: extensions and scale
+
+- [ ] Evaluate MCP Apps for element picking and evidence inspection.
+- [ ] Evaluate Tasks for explicitly enabled long-running pilot operations.
+- [ ] Design a session-owner registry before claiming multi-daemon
+  round-robin browser control.
+- [ ] Define a legacy-protocol retirement window based on client adoption and
+  OpenChrome's transport lifecycle policy.
+
+## Verification
+
+The migration is covered by integration tests for:
+
+- HTTP discovery without initialize;
+- required result/cache metadata and absence of `Mcp-Session-Id`;
+- HTTP header/body mismatch rejection;
+- auth tenant and broker context propagation;
+- MRTR `input_required` and retry;
+- rejection of removed methods and modern GET/DELETE;
+- stdio modern discovery and filtered subscriptions;
+- stdio legacy initialize and server-to-client compatibility requests; and
+- the existing legacy Streamable HTTP path.
+
+Run the focused contract suite with:
+
+```bash
+npx jest \
+  tests/transports/http-modern-mcp.test.ts \
+  tests/transports/stdio-modern-mcp.test.ts \
+  tests/transports/http-streamable.test.ts \
+  --runInBand
+```
+
+Run all repository gates before release:
+
+```bash
+npm run build
+npm run lint
+npm run lint:tier
+npm run lint:tool-schemas
+npm run docs:capability-map:check
+npm test
+```

--- a/docs/mcp-2026-07-28.md
+++ b/docs/mcp-2026-07-28.md
@@ -143,10 +143,13 @@ the original `tools/call` with a new JSON-RPC ID and matching
 deterministically re-run from the original arguments.
 
 Modern requests have no transport session, so URL and file-output tools refresh
-`roots/list` immediately before egress and scope the response to OpenChrome's
-explicit application `sessionId`. The first round therefore stops before any
-browser side effect, and the retry enforces the returned roots before dispatch.
-Tools without an egress candidate do not incur this extra round.
+`roots/list` immediately before egress and enforce the parsed roots as
+request-local policy. OpenChrome's explicit application `sessionId` labels the
+policy scope, but modern roots are never written to a process-global session
+cache. The first round therefore stops before any browser side effect, and the
+retry enforces its own returned roots before dispatch. Tools without an egress
+candidate do not incur this extra round. Legacy roots remain connection-scoped
+and notification-refreshed.
 
 Before adding a multi-stage or side-effecting MRTR flow, OpenChrome must add an
 opaque, integrity-protected `requestState` that records the completed stage and

--- a/docs/resources-subscriptions.md
+++ b/docs/resources-subscriptions.md
@@ -6,12 +6,18 @@ OpenChrome advertises live MCP resources with:
 "resources": { "listChanged": true, "subscribe": true }
 ```
 
-Supported methods:
+Shared read methods:
 
 - `resources/list` — static resources plus currently concrete live session resources.
 - `resources/templates/list` — URI templates listed below.
 - `resources/read` — returns JSON content for a concrete URI.
-- `resources/subscribe` / `resources/unsubscribe` — per-MCP-session subscriptions for live update notifications.
+
+Subscription behavior depends on the negotiated protocol:
+
+- MCP `2026-07-28`: open `subscriptions/listen` with
+  `resourceSubscriptions` and/or `resourcesListChanged`.
+- Legacy MCP: use `resources/subscribe` / `resources/unsubscribe` for
+  per-MCP-session live updates.
 
 ## URI templates
 
@@ -25,7 +31,8 @@ Supported methods:
 
 ## Notifications
 
-A successful `resources/subscribe` causes future matching changes to emit:
+A successful modern listen request or legacy `resources/subscribe` causes
+future matching changes to emit:
 
 ```json
 {
@@ -37,14 +44,25 @@ A successful `resources/subscribe` causes future matching changes to emit:
 
 Session create/delete events also emit `notifications/resources/list_changed` so clients can refresh `resources/list`.
 
-Updates are coalesced per subscribed `(Mcp-Session-Id, uri)` with a 100 ms debounce. HTTP/SSE sends notifications only to the matching `Mcp-Session-Id`; stdio uses the single logical `stdio` session.
+Modern events are filtered by the `subscriptions/listen` request and carry
+`io.modelcontextprotocol/subscriptionId` in `_meta`. Legacy updates are
+coalesced per subscribed `(Mcp-Session-Id, uri)` with a 100 ms debounce.
+In HTTP daemon mode, each modern listen stream is also bound to the
+authenticated tenant. Concrete resource events are delivered only to matching
+tenant listeners; events whose ownership cannot be resolved are not
+broadcast.
 
 ## Limits and authz
 
-- Subscription cap defaults to 50 active URIs per MCP session.
+- The modern SDK caps active listen requests per connection and filters each
+  request to the advertised resource capabilities.
+- Concrete resources returned by `resources/list` are filtered to the current
+  tenant before cache metadata is added.
+- The legacy subscription cap defaults to 50 active URIs per MCP session.
 - Override with `OPENCHROME_RESOURCE_SUB_LIMIT` (bounded to `1..1000`).
 - Exceeding the cap returns JSON-RPC code `-32002` and message `subscription_limit_exceeded`.
 - Reads/subscribes for existing session-scoped resources require the caller tenant to own the session. Cross-tenant attempts return code `-32001` (`Forbidden`).
-- Disconnect / `DELETE /mcp` cleans up that MCP session's subscription set.
+- Modern HTTP stream closure cancels that listen request. Legacy disconnect or
+  `DELETE /mcp` cleans up the protocol session's subscription set.
 
 The existing `/dashboard/*` HTTP endpoint remains unchanged; these resources are additive.

--- a/docs/transport-lifecycle.md
+++ b/docs/transport-lifecycle.md
@@ -14,9 +14,9 @@ OpenChrome exposes three transport modes. The package CLI uses stdio by default,
 | Streamable HTTP daemon | `--http [port]` or `OPENCHROME_TRANSPORT=http` | **stable** | v1.0.0 | — | Long-running daemon serving multiple MCP clients over Streamable HTTP. Binds a local port; auth via bearer token or per-tenant API key. |
 | Dual (stdio + HTTP) | `OPENCHROME_TRANSPORT=both` | **stable** | v1.0.0 | — | Run stdio and HTTP simultaneously. Intended for dashboard integrations that need both a direct MCP pipe and an HTTP fan-out endpoint. |
 
-> **Note on SSE:** The `/mcp/sse` endpoint is the _notification delivery channel_ inside the HTTP transport — it is not a separate transport mode. When a client connects via `GET /mcp/sse`, it receives server-initiated notifications over a persistent SSE stream while issuing requests via `POST /mcp`. Operators should not conflate `/mcp/sse` with a distinct transport; the lifecycle of that endpoint is tied to the `http` transport above.
+> **Legacy SSE compatibility:** `GET /mcp` and `/mcp/sse` remain available for legacy MCP clients. MCP `2026-07-28` clients use a long-lived `subscriptions/listen` POST response instead.
 
-> **Streamable HTTP:** `--http` is OpenChrome's current Streamable HTTP transport surface. Use `POST /mcp` for JSON-RPC requests and `GET /mcp` or `GET /mcp/sse` for server-sent event streams.
+> **Streamable HTTP:** `--http` is OpenChrome's current Streamable HTTP transport surface. Modern clients use stateless `POST /mcp` requests only. See [MCP 2026-07-28 migration](mcp-2026-07-28.md).
 
 ---
 
@@ -126,12 +126,18 @@ OPENCHROME_ALLOW_UNAUTHENTICATED_HTTP=1 openchrome serve --auto-launch --http
 
 ### Streamable HTTP endpoint behavior
 
-`--http` starts OpenChrome's current Streamable HTTP transport. Clients issue JSON-RPC requests with `POST /mcp`. Clients that need server-initiated notifications can open `GET /mcp` or `GET /mcp/sse` as an SSE stream. No additional migration flag is required; the `http` transport selector remains stable and has no sunset date.
+`--http` starts OpenChrome's dual-era Streamable HTTP transport. MCP
+`2026-07-28` clients issue stateless JSON-RPC requests with `POST /mcp` and use
+`subscriptions/listen` for selected change notifications. Legacy clients can
+continue to initialize a protocol session and use `GET /mcp` or
+`GET /mcp/sse`. No additional migration flag is required; the `http`
+transport selector remains stable and has no sunset date.
 
 ---
 
 ## See also
 
 - [docs/auth.md](auth.md) — API key store, bearer tokens, OAuth
+- [docs/mcp-2026-07-28.md](mcp-2026-07-28.md) - modern MCP architecture and compatibility
 - [docs/roadmap/portability-harness-contract.md](roadmap/portability-harness-contract.md) — core/pilot tier split and portability principles
 - Issue [#839](https://github.com/shaun0927/openchrome/issues/839) — Streamable HTTP transport implementation history

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.12.9",
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/node": "^2.0.0",
+        "@modelcontextprotocol/server": "^2.0.0",
         "argon2": "^0.43.0",
         "cheerio": "1.0.0-rc.12",
         "commander": "^12.0.0",
@@ -47,7 +49,7 @@
         "typescript": "^5.4.0"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@apify/consts": {
@@ -1422,6 +1424,18 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -2104,6 +2118,70 @@
       "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
       "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/server": "^2.0.0",
+        "hono": "^4.11.4"
+      },
+      "peerDependenciesMeta": {
+        "hono": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5596,6 +5674,16 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/html-encoding-sniffer": {

--- a/package.json
+++ b/package.json
@@ -120,6 +120,8 @@
     "typescript": "^5.4.0"
   },
   "dependencies": {
+    "@modelcontextprotocol/node": "^2.0.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "argon2": "^0.43.0",
     "cheerio": "1.0.0-rc.12",
     "commander": "^12.0.0",
@@ -136,7 +138,7 @@
     "ip-address": "^10.1.1"
   },
   "engines": {
-    "node": ">=18.17.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "dist",

--- a/src/cli/doctor/checks/node-version.ts
+++ b/src/cli/doctor/checks/node-version.ts
@@ -8,13 +8,13 @@ import { join } from 'path';
 import type { CheckFn } from '../../doctor';
 
 function parseMinVersion(range: string): number | null {
-  // Handles ">=18.0.0", "^18", "18", etc.
+  // Handles ">=20.0.0", "^20", "20", etc.
   const match = range.match(/(\d+)/);
   return match ? parseInt(match[1], 10) : null;
 }
 
 export const checkNodeVersion: CheckFn = async () => {
-  let engineRange = '>=18.0.0';
+  let engineRange = '>=20.0.0';
   try {
     const pkg = JSON.parse(readFileSync(join(__dirname, '../../../../package.json'), 'utf8'));
     engineRange = pkg?.engines?.node ?? engineRange;
@@ -24,7 +24,7 @@ export const checkNodeVersion: CheckFn = async () => {
 
   const current = process.versions.node;
   const currentMajor = parseInt(current.split('.')[0], 10);
-  const minMajor = parseMinVersion(engineRange) ?? 18;
+  const minMajor = parseMinVersion(engineRange) ?? 20;
 
   if (currentMajor >= minMajor) {
     return {

--- a/src/dashboard/types.ts
+++ b/src/dashboard/types.ts
@@ -10,7 +10,12 @@ export interface DashboardConfig {
 
 export type ViewMode = 'activity' | 'sessions' | 'tabs' | 'connect';
 
-export type ToolCallResult = 'success' | 'error' | 'aborted' | 'pending';
+export type ToolCallResult =
+  | 'success'
+  | 'error'
+  | 'aborted'
+  | 'input_required'
+  | 'pending';
 
 export interface ToolCallEvent {
   id: string;

--- a/src/dashboard/views/main-view.ts
+++ b/src/dashboard/views/main-view.ts
@@ -148,9 +148,13 @@ export class MainView {
       status = showSpinner ? `${ANSI.cyan}${spinner}${ANSI.reset}` : `${ANSI.cyan}...${ANSI.reset}`;
     } else {
       duration = pad(formatDuration(call.duration || 0), 6);
-      status = call.result === 'success'
-        ? `${ANSI.green}\u2713${ANSI.reset}`
-        : `${ANSI.red}\u2717${ANSI.reset}`;
+      if (call.result === 'success') {
+        status = `${ANSI.green}\u2713${ANSI.reset}`;
+      } else if (call.result === 'input_required') {
+        status = `${ANSI.yellow}?${ANSI.reset}`;
+      } else {
+        status = `${ANSI.red}\u2717${ANSI.reset}`;
+      }
     }
 
     const prefix = call.result === 'pending' ? `${ANSI.cyan}\u25B6${ANSI.reset}` : ' ';

--- a/src/desktop/dashboard-state.ts
+++ b/src/desktop/dashboard-state.ts
@@ -13,7 +13,7 @@ export interface DashboardToolCall {
   toolName: string;
   sessionId: string;
   args: string;
-  status: 'running' | 'success' | 'error' | 'aborted';
+  status: 'running' | 'success' | 'error' | 'aborted' | 'input_required';
   startTime: number;
   endTime?: number;
   duration?: number;
@@ -128,7 +128,11 @@ export class DashboardState {
   /**
    * Record the end of a tool call.
    */
-  recordToolEnd(callId: string, status: 'success' | 'error' | 'aborted', error?: string): void {
+  recordToolEnd(
+    callId: string,
+    status: 'success' | 'error' | 'aborted' | 'input_required',
+    error?: string,
+  ): void {
     const call = this.activeCalls.get(callId);
     if (!call) return;
 
@@ -139,6 +143,10 @@ export class DashboardState {
       call.error = error;
     }
     this.activeCalls.delete(callId);
+
+    // An MRTR input_required response completes this protocol round without
+    // completing or failing the logical tool operation.
+    if (status === 'input_required') return;
 
     // Increment the monotonic Prometheus counter. `aborted` is folded into
     // `error` to match the dashboard's two-bucket exposition.

--- a/src/errors/mcp-input-required.ts
+++ b/src/errors/mcp-input-required.ts
@@ -1,0 +1,14 @@
+/**
+ * Internal control-flow error used to lift a legacy-style server-to-client
+ * request into a 2026-07-28 input_required result.
+ */
+export class McpInputRequiredError extends Error {
+  constructor(public readonly result: unknown) {
+    super('mcp_input_required');
+    this.name = 'McpInputRequiredError';
+  }
+}
+
+export function isMcpInputRequiredError(error: unknown): error is McpInputRequiredError {
+  return error instanceof McpInputRequiredError;
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -50,6 +50,7 @@ import { getMetricsCollector, withTenantLabel } from './metrics/collector';
 import { logAuditEntry, redactToolArgsForPersistence } from './security/audit-logger';
 import { assertFilePathAllowedBySessionRoots, assertUrlAllowedBySessionRoots, setSessionMcpRoots } from './security/mcp-roots';
 import { isClientDisconnect } from './errors/abort';
+import { isMcpInputRequiredError } from './errors/mcp-input-required';
 import { setLogSender, type LogLevel, logLevelSetErrorOrNull } from './utils/log';
 import { isAllowed, requiredScope } from './auth/scope-policy';
 import type { Principal } from './auth/api-key-types';
@@ -83,6 +84,7 @@ import {
   assertLiveResourceAccess,
   liveResourceDefinitions,
   readLiveResource,
+  parseLiveResourceUri,
   sessionStateUri,
   sessionTabsUri,
   journalUri,
@@ -677,6 +679,7 @@ export class MCPServer {
    * PR 2/4 does not ship with a cross-tenant access path.
    */
   private sessionTenants: Map<string, string> = new Map();
+  private deletingSessionTenants: Map<string, string> = new Map();
   /**
    * Timer that periodically reclaims idle rate-limit buckets. Required because
    * tenant-keyed buckets (used in api-key mode) are shared across sessions, so
@@ -730,6 +733,9 @@ export class MCPServer {
       this.sessionManager.addEventListener((event) => {
         if (event.type === 'session:deleting') {
           beginSessionRecorderDeletion(event.sessionId);
+          const tenantId = this.sessionManager.getSession(event.sessionId)?.tenantId
+            ?? this.sessionTenants.get(event.sessionId);
+          if (tenantId) this.deletingSessionTenants.set(event.sessionId, tenantId);
         } else if (event.type === 'session:deleted') {
           this.sessionTenants.delete(event.sessionId);
           getTaskDriftLedger().cleanupSession(event.sessionId);
@@ -791,6 +797,13 @@ export class MCPServer {
     // codebase will emit `notifications/message` to connected clients (at or
     // above the active level) AND mirror error-level events to stderr.
     setLogSender((level: LogLevel, logger: string, data: Record<string, unknown>) => {
+      const sdkLogger = currentRequestContext()?.logClient;
+      if (sdkLogger) {
+        void sdkLogger(level, logger, data).catch((error) => {
+          console.error('[MCPServer] request-scoped log notification failed:', error);
+        });
+        return;
+      }
       this.sendNotification('notifications/message', { level, logger, data });
     });
   }
@@ -860,6 +873,19 @@ export class MCPServer {
   }
 
   private getToolExposureState(sessionId = this.currentToolExposureSessionId()): ToolExposureState {
+    // The modern protocol has no protocol session in which hidden tool-list
+    // state can safely live. Expose the complete capability-filtered registry
+    // on every request; application state remains explicit in sessionId/tabId
+    // tool arguments.
+    if (currentRequestContext()?.protocolEra === 'modern') {
+      return {
+        exposedTier: 3,
+        selectedToolNames: new Set(),
+        selectedSchemaBytes: 0,
+        clientSupportsListChanged: false,
+        clientDetected: true,
+      };
+    }
     let state = this.toolExposureBySession.get(sessionId);
     if (!state) {
       state = {
@@ -872,6 +898,41 @@ export class MCPServer {
       this.toolExposureBySession.set(sessionId, state);
     }
     return state;
+  }
+
+  private configureToolExposureForClient(
+    state: ToolExposureState,
+    clientInfo?: { name?: string; version?: string },
+    clientCapabilities?: {
+      tools?: { listChanged?: boolean };
+      notifications?: { tools?: { listChanged?: boolean } };
+    },
+  ): void {
+    if (state.clientDetected) return;
+    state.clientDetected = true;
+
+    const rawName = clientInfo?.name ?? '';
+    const nameLower = rawName.toLowerCase();
+    const supportsToolListChanged = clientCapabilities?.tools?.listChanged === true
+      || clientCapabilities?.notifications?.tools?.listChanged === true;
+
+    if (this.options.initialToolTier) {
+      console.error(`[openchrome] Tool tier override: initialToolTier=${this.options.initialToolTier}, skipping client detection`);
+      return;
+    }
+
+    const isKnownClient = rawName !== '' && Array.from(PROGRESSIVE_DISCLOSURE_CLIENTS).some(known =>
+      nameLower.includes(known)
+    );
+    if (!isKnownClient && !supportsToolListChanged) {
+      state.exposedTier = 3;
+      state.clientSupportsListChanged = false;
+      console.error(`[openchrome] Client "${rawName || '(no clientInfo)'}" - progressive disclosure disabled, exposing all tools`);
+      return;
+    }
+
+    const source = supportsToolListChanged && !isKnownClient ? 'capability' : 'known-client';
+    console.error(`[openchrome] Client "${rawName || '(no clientInfo)'}" supports tool list changes (${source}) - progressive disclosure enabled`);
   }
 
   private sendToolListChanged(sessionId: string): void {
@@ -1014,11 +1075,23 @@ export class MCPServer {
   }
 
   private getCurrentClientCapabilities(): { roots?: object; sampling?: object; elicitation?: object } {
+    const requestCapabilities = currentRequestContext()?.clientCapabilities;
+    if (requestCapabilities) {
+      return {
+        ...(requestCapabilities.roots !== undefined ? { roots: requestCapabilities.roots } : {}),
+        ...(requestCapabilities.sampling !== undefined ? { sampling: requestCapabilities.sampling } : {}),
+        ...(requestCapabilities.elicitation !== undefined ? { elicitation: requestCapabilities.elicitation } : {}),
+      };
+    }
     const mcpSessionId = currentRequestContext()?.mcpSessionId;
     if (mcpSessionId) {
       return this.clientCapabilitiesBySession.get(mcpSessionId) ?? {};
     }
     return this.clientCapabilities;
+  }
+
+  private getCurrentRequestClient(): NonNullable<ToolContext['requestClient']> {
+    return currentRequestContext()?.requestClient ?? this.requestFromClient.bind(this);
   }
 
   /**
@@ -1081,12 +1154,20 @@ export class MCPServer {
     const send = (update: ToolProgress): void => {
       if (closed) return;
       try {
-        this.sendNotification('notifications/progress', {
+        const params = {
           progressToken,
           progress: update.progress,
           ...(update.total !== undefined ? { total: update.total } : {}),
           ...(update.message !== undefined ? { message: update.message } : {}),
-        });
+        };
+        const sdkNotifier = currentRequestContext()?.notifyClient;
+        if (sdkNotifier) {
+          void sdkNotifier('notifications/progress', params).catch((error) => {
+            console.error('[MCPServer] request-scoped progress notification failed:', error);
+          });
+        } else {
+          this.sendNotification('notifications/progress', params);
+        }
         lastEmittedAt = Date.now();
       } catch (err) {
         // Best-effort: a wedged transport must not break the parent tool call.
@@ -1152,9 +1233,7 @@ export class MCPServer {
    * in start().
    */
   wireRateLimiterCleanup(transport: MCPTransport): void {
-    if (typeof transport.sendToSession === 'function') {
-      this.sessionNotificationTransports.add(transport);
-    }
+    this.sessionNotificationTransports.add(transport);
     const cleanupConnectionState = (sessionId: string): void => {
       this.rejectPendingS2cRequestsForSession(sessionId, 's2c_aborted:connection_closed');
       this.clientCapabilitiesBySession.delete(sessionId);
@@ -1295,6 +1374,7 @@ export class MCPServer {
     try {
       return await this.handleRequest(request, principal, signal);
     } catch (error) {
+      if (isMcpInputRequiredError(error)) throw error;
       return {
         jsonrpc: '2.0' as const,
         id: request.id,
@@ -1473,6 +1553,7 @@ export class MCPServer {
         result,
       };
     } catch (error) {
+      if (isMcpInputRequiredError(error)) throw error;
       if (error instanceof ResourceRpcError) {
         return this.errorResponse(id, error.code, error.message, error.data);
       }
@@ -1483,9 +1564,13 @@ export class MCPServer {
 
 
   private async refreshSessionRoots(mcpSessionId: string): Promise<void> {
-    const caps = this.clientCapabilitiesBySession.get(mcpSessionId) ?? this.clientCapabilities;
+    const caps = this.getCurrentClientCapabilities();
     if (!caps.roots) return;
-    const roots = await this.requestFromClient<unknown>('roots/list', undefined, { timeoutMs: 250 });
+    const roots = await this.getCurrentRequestClient()<unknown>(
+      'roots/list',
+      undefined,
+      { timeoutMs: 250 },
+    );
     setSessionMcpRoots(mcpSessionId, roots);
   }
 
@@ -1552,37 +1637,9 @@ export class MCPServer {
       }
     }
 
-    // Detect client identity for progressive disclosure decisions
     const clientInfo = params?.clientInfo as { name?: string; version?: string } | undefined;
     const clientCapabilities = params?.capabilities as { tools?: { listChanged?: boolean }; notifications?: { tools?: { listChanged?: boolean } } } | undefined;
-    const rawName = clientInfo?.name ?? '';
-    const nameLower = rawName.toLowerCase();
-    const supportsToolListChanged = clientCapabilities?.tools?.listChanged === true
-      || clientCapabilities?.notifications?.tools?.listChanged === true;
-
-    // Idempotency: only detect client on first initialize (reconnects preserve state)
-    if (!exposureState.clientDetected) {
-      exposureState.clientDetected = true;
-
-      if (this.options.initialToolTier) {
-        console.error(`[openchrome] Tool tier override: initialToolTier=${this.options.initialToolTier}, skipping client detection`);
-      } else {
-        const isKnownClient = rawName !== '' && Array.from(PROGRESSIVE_DISCLOSURE_CLIENTS).some(known =>
-          nameLower.includes(known)
-        );
-
-        if (!isKnownClient && !supportsToolListChanged) {
-          // Unknown or absent client: expose all tools immediately (no progressive disclosure)
-          exposureState.exposedTier = 3;
-          exposureState.clientSupportsListChanged = false;
-          console.error(`[openchrome] Client "${rawName || '(no clientInfo)'}" — progressive disclosure disabled, exposing all tools`);
-        } else {
-          // Known/capable client: keep progressive disclosure enabled.
-          const source = supportsToolListChanged && !isKnownClient ? 'capability' : 'known-client';
-          console.error(`[openchrome] Client "${rawName || '(no clientInfo)'}" supports tool list changes (${source}) — progressive disclosure enabled`);
-        }
-      }
-    }
+    this.configureToolExposureForClient(exposureState, clientInfo, clientCapabilities);
 
     return {
       protocolVersion: '2024-11-05',
@@ -1620,6 +1677,12 @@ export class MCPServer {
    */
   private async handleToolsList(params?: Record<string, unknown>): Promise<MCPResult> {
     const exposureState = this.getToolExposureState();
+    const requestContext = currentRequestContext();
+    this.configureToolExposureForClient(
+      exposureState,
+      requestContext?.clientInfo,
+      requestContext?.clientCapabilities,
+    );
     // Signal the hint engine that this session has consumed tool descriptions,
     // so rules whose guidance is already embedded in description "When to
     // use / When NOT to use" blocks can suppress themselves without affecting
@@ -1689,7 +1752,12 @@ export class MCPServer {
     for (const resource of this.resources.values()) {
       resources.push(resource);
     }
-    resources.push(...liveResourceDefinitions(this.sessionManager));
+    resources.push(
+      ...liveResourceDefinitions(
+        this.sessionManager,
+        currentRequestContext()?.tenantId,
+      ),
+    );
     return { resources };
   }
 
@@ -1747,7 +1815,11 @@ export class MCPServer {
 
     const resource = this.resources.get(uri);
     if (!resource) {
-      throw new Error(`Unknown resource: ${uri}`);
+      throw new ResourceRpcError(
+        MCPErrorCodes.INVALID_PARAMS,
+        `Unknown resource: ${uri}`,
+        { uri },
+      );
     }
 
     // Get content based on resource type
@@ -1773,7 +1845,14 @@ export class MCPServer {
 
   private async tryReadLiveResource(uri: string): Promise<{ mimeType: string; text: string } | null> {
     if (!uri.startsWith('oc://')) return null;
-    return readLiveResource(this.sessionManager, uri);
+    try {
+      return await readLiveResource(this.sessionManager, uri);
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('Unknown resource:')) {
+        throw new ResourceRpcError(MCPErrorCodes.INVALID_PARAMS, error.message, { uri });
+      }
+      throw error;
+    }
   }
 
   /**
@@ -1814,8 +1893,10 @@ export class MCPServer {
           this.emitResourceUpdated(sessionStateUri(event.sessionId));
         }
         if (event.type === 'session:created' || event.type === 'session:deleted') {
-          this.emitResourceUpdated(sessionStateUri(event.sessionId));
-          this.emitResourcesListChanged();
+          const uri = sessionStateUri(event.sessionId);
+          const tenantId = this.resourceNotificationTenant(uri);
+          this.emitResourceUpdated(uri);
+          this.emitResourcesListChanged(tenantId);
         }
       });
     }
@@ -1827,8 +1908,13 @@ export class MCPServer {
           this.emitResourceUpdated(sessionStateUri(event.sessionId));
         }
         if (event.kind.startsWith('session:')) {
-          this.emitResourceUpdated(sessionStateUri(event.sessionId));
-          this.emitResourcesListChanged();
+          const uri = sessionStateUri(event.sessionId);
+          const tenantId = this.resourceNotificationTenant(uri);
+          this.emitResourceUpdated(uri);
+          this.emitResourcesListChanged(tenantId);
+          if (event.kind === 'session:destroy') {
+            this.deletingSessionTenants.delete(event.sessionId);
+          }
         }
       }
     });
@@ -1836,10 +1922,41 @@ export class MCPServer {
 
   private emitResourceUpdated(uri: string): void {
     this.resourceSubscriptions.emitUpdated(uri, this.transport);
+    const tenantId = this.resourceNotificationTenant(uri);
+    for (const transport of this.sessionNotificationTransports) {
+      transport.publishResourceUpdated?.(uri, tenantId);
+    }
   }
 
-  private emitResourcesListChanged(): void {
+  private emitResourcesListChanged(tenantId = currentRequestContext()?.tenantId): void {
     this.resourceSubscriptions.emitListChanged(this.transport);
+    for (const transport of this.sessionNotificationTransports) {
+      transport.publishResourcesChanged?.(tenantId);
+    }
+  }
+
+  private resourceNotificationTenant(uri: string): string | undefined {
+    const parsed = parseLiveResourceUri(uri);
+    if (
+      parsed?.id &&
+      (parsed.kind === 'session-tabs' ||
+        parsed.kind === 'session-state' ||
+        parsed.kind === 'journal')
+    ) {
+      return this.sessionManager.getSession(parsed.id)?.tenantId
+        ?? this.sessionTenants.get(parsed.id)
+        ?? this.deletingSessionTenants.get(parsed.id)
+        ?? currentRequestContext()?.tenantId;
+    }
+    return currentRequestContext()?.tenantId;
+  }
+
+  /** Publish a registry change to legacy clients and modern subscriptions. */
+  public emitListChanged(): void {
+    this.sendToolListChanged(STDIO_TOOL_EXPOSURE_SESSION);
+    for (const transport of this.sessionNotificationTransports) {
+      transport.publishToolsChanged?.();
+    }
   }
 
   /**
@@ -2376,7 +2493,7 @@ export class MCPServer {
           signal,
           principal,
           clientCapabilities: this.getCurrentClientCapabilities(),
-          requestClient: this.requestFromClient.bind(this),
+          requestClient: this.getCurrentRequestClient(),
           reportProgress,
         };
         let tid: ReturnType<typeof setTimeout>;
@@ -2416,7 +2533,7 @@ export class MCPServer {
               signal,
               principal,
               clientCapabilities: this.getCurrentClientCapabilities(),
-              requestClient: this.requestFromClient.bind(this),
+              requestClient: this.getCurrentRequestClient(),
               reportProgress,
             };
             let tid2: ReturnType<typeof setTimeout>;
@@ -2486,7 +2603,7 @@ export class MCPServer {
               signal,
               principal,
               clientCapabilities: this.getCurrentClientCapabilities(),
-              requestClient: this.requestFromClient.bind(this),
+              requestClient: this.getCurrentRequestClient(),
               reportProgress,
             };
             // Race the retry against the tool-execution timeout, exactly like the
@@ -2791,6 +2908,7 @@ export class MCPServer {
       this.recordToolOutputObservability(toolName, finalResult, requestId);
       return finalResult;
     } catch (error) {
+      if (isMcpInputRequiredError(error)) throw error;
       const message = formatError(error);
       const redactedMessage = redactSecretString(message);
       const abortReason = isClientDisconnect(error) ? 'client_disconnect' : null;
@@ -3769,6 +3887,7 @@ export class MCPServer {
     }
     this.sessionNotificationTransports.clear();
     this.toolExposureBySession.clear();
+    this.deletingSessionTenants.clear();
 
     // Scale timeout based on number of Chrome pool instances.
     // Each launcher.close() needs up to 5s for SIGTERM->SIGKILL escalation,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1522,7 +1522,7 @@ export class MCPServer {
           break;
 
         case 'tools/list':
-          result = await this.handleToolsList(params);
+          result = await this.handleToolsList(params, principal);
           break;
 
         case 'tools/call':
@@ -1724,10 +1724,17 @@ export class MCPServer {
     return this.capabilityFilter.has(capability ?? 'core');
   }
 
+  private isToolAllowedForPrincipal(toolName: string, principal?: Principal): boolean {
+    return !principal || isAllowed(toolName, principal.scopes);
+  }
+
   /**
    * Handle tools/list request
    */
-  private async handleToolsList(params?: Record<string, unknown>): Promise<MCPResult> {
+  private async handleToolsList(
+    params?: Record<string, unknown>,
+    principal?: Principal,
+  ): Promise<MCPResult> {
     const exposureState = this.getToolExposureState();
     const requestContext = currentRequestContext();
     if (
@@ -1756,6 +1763,7 @@ export class MCPServer {
       if (
         (tier <= exposureState.exposedTier || exposureState.selectedToolNames.has(registry.definition.name))
         && this.isCapabilityAllowed(registry.definition.capability)
+        && this.isToolAllowedForPrincipal(registry.definition.name, principal)
       ) {
         tools.push(registry.definition);
       }
@@ -1764,11 +1772,17 @@ export class MCPServer {
     // Add hint about additional tools when not fully expanded.
     // Only inject expand_tools if the client supports notifications/tools/list_changed —
     // otherwise there's no point since the client can't react to the notification.
-    if (exposureState.exposedTier < 3 && exposureState.clientSupportsListChanged && this.isCapabilityAllowed('core')) {
+    if (
+      exposureState.exposedTier < 3
+      && exposureState.clientSupportsListChanged
+      && this.isCapabilityAllowed('core')
+      && this.isToolAllowedForPrincipal('expand_tools', principal)
+    ) {
       const hiddenCount = Array.from(this.tools.values()).filter(
         r => getToolTier(r.definition.name) > exposureState.exposedTier &&
           !exposureState.selectedToolNames.has(r.definition.name) &&
-          this.isCapabilityAllowed(r.definition.capability)
+          this.isCapabilityAllowed(r.definition.capability) &&
+          this.isToolAllowedForPrincipal(r.definition.name, principal)
       ).length;
       if (hiddenCount > 0) {
         tools.push({

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -48,7 +48,14 @@ import { getGlobalConfig } from './config/global';
 import { getToolTier, ToolTier } from './config/tool-tiers';
 import { getMetricsCollector, withTenantLabel } from './metrics/collector';
 import { logAuditEntry, redactToolArgsForPersistence } from './security/audit-logger';
-import { assertFilePathAllowedBySessionRoots, assertUrlAllowedBySessionRoots, setSessionMcpRoots } from './security/mcp-roots';
+import {
+  assertFilePathAllowedByMcpRoots,
+  assertUrlAllowedByMcpRoots,
+  getSessionMcpRoots,
+  parseMcpRoots,
+  setSessionMcpRoots,
+  type ParsedMcpRoots,
+} from './security/mcp-roots';
 import { isClientDisconnect } from './errors/abort';
 import { isMcpInputRequiredError } from './errors/mcp-input-required';
 import { setLogSender, type LogLevel, logLevelSetErrorOrNull } from './utils/log';
@@ -1588,32 +1595,38 @@ export class MCPServer {
   }
 
 
-  private async refreshSessionRoots(rootScopeId: string): Promise<void> {
+  private async listCurrentClientRoots(): Promise<unknown | undefined> {
     const caps = this.getCurrentClientCapabilities();
-    if (!caps.roots) return;
-    const roots = await this.getCurrentRequestClient()<unknown>(
+    if (!caps.roots) return undefined;
+    return await this.getCurrentRequestClient()<unknown>(
       'roots/list',
       undefined,
       { timeoutMs: 250 },
     );
+  }
+
+  private async refreshSessionRoots(rootScopeId: string): Promise<void> {
+    const roots = await this.listCurrentClientRoots();
+    if (roots === undefined) return;
     setSessionMcpRoots(rootScopeId, roots);
   }
 
-  private async refreshModernRootsForTool(
-    sessionId: string,
+  private async modernRootsForTool(
     toolName: string,
     args: Record<string, unknown>,
-  ): Promise<void> {
-    if (currentRequestContext()?.protocolEra !== 'modern') return;
+  ): Promise<ParsedMcpRoots | undefined> {
+    if (currentRequestContext()?.protocolEra !== 'modern') return undefined;
     const hasEgressCandidate =
       extractNetworkRootCandidateUrls(toolName, args).length > 0
       || extractFileRootCandidatePaths(toolName, args).length > 0;
-    if (!hasEgressCandidate) return;
-    await this.refreshSessionRoots(sessionId);
+    if (!hasEgressCandidate) return undefined;
+    const roots = await this.listCurrentClientRoots();
+    return roots === undefined ? undefined : parseMcpRoots(roots);
   }
 
   private enforceNetworkRootsForTool(
-    mcpSessionId: string,
+    rootScopeId: string,
+    roots: ParsedMcpRoots | undefined,
     toolName: string,
     args: Record<string, unknown>,
   ): MCPResult | null {
@@ -1621,7 +1634,7 @@ export class MCPServer {
     if (urls.length === 0) return null;
     try {
       for (const url of urls) {
-        assertUrlAllowedBySessionRoots(mcpSessionId, url);
+        assertUrlAllowedByMcpRoots(roots, url, rootScopeId);
       }
       return null;
     } catch (error) {
@@ -1633,7 +1646,8 @@ export class MCPServer {
   }
 
   private enforceFileRootsForTool(
-    mcpSessionId: string,
+    rootScopeId: string,
+    roots: ParsedMcpRoots | undefined,
     toolName: string,
     args: Record<string, unknown>,
   ): MCPResult | null {
@@ -1641,7 +1655,7 @@ export class MCPServer {
     if (paths.length === 0) return null;
     try {
       for (const filePath of paths) {
-        assertFilePathAllowedBySessionRoots(mcpSessionId, filePath);
+        assertFilePathAllowedByMcpRoots(roots, filePath, rootScopeId);
       }
       return null;
     } catch (error) {
@@ -2276,10 +2290,13 @@ export class MCPServer {
     }
 
     const rootScopeId = currentRequestContext()?.mcpSessionId ?? sessionId;
-    await this.refreshModernRootsForTool(rootScopeId, toolName, substitutedArgs);
+    const roots = currentRequestContext()?.protocolEra === 'modern'
+      ? await this.modernRootsForTool(toolName, substitutedArgs)
+      : getSessionMcpRoots(rootScopeId);
 
     const rootsDenial = this.enforceNetworkRootsForTool(
       rootScopeId,
+      roots,
       toolName,
       substitutedArgs,
     );
@@ -2290,6 +2307,7 @@ export class MCPServer {
 
     const fileRootsDenial = this.enforceFileRootsForTool(
       rootScopeId,
+      roots,
       toolName,
       substitutedArgs,
     );

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -733,8 +733,10 @@ export class MCPServer {
       this.sessionManager.addEventListener((event) => {
         if (event.type === 'session:deleting') {
           beginSessionRecorderDeletion(event.sessionId);
-          const tenantId = this.sessionManager.getSession(event.sessionId)?.tenantId
-            ?? this.sessionTenants.get(event.sessionId);
+          const session = typeof this.sessionManager.getSession === 'function'
+            ? this.sessionManager.getSession(event.sessionId)
+            : undefined;
+          const tenantId = session?.tenantId ?? this.sessionTenants.get(event.sessionId);
           if (tenantId) this.deletingSessionTenants.set(event.sessionId, tenantId);
         } else if (event.type === 'session:deleted') {
           this.sessionTenants.delete(event.sessionId);
@@ -1222,6 +1224,29 @@ export class MCPServer {
     return { reporter, flush };
   }
 
+  private settleHeartbeatAfterToolCall(): void {
+    try {
+      const cdpClient = getCDPClient();
+      cdpClient.setHeartbeatMode?.('active');
+    } catch {
+      // CDP client may not be initialized.
+    }
+
+    if (this.heartbeatIdleTimer) {
+      clearTimeout(this.heartbeatIdleTimer);
+    }
+    this.heartbeatIdleTimer = setTimeout(() => {
+      try {
+        const cdpClient = getCDPClient();
+        cdpClient.setHeartbeatMode?.('idle');
+      } catch {
+        // CDP client may be disconnected.
+      }
+      this.heartbeatIdleTimer = null;
+    }, DEFAULT_HEARTBEAT_IDLE_TIMEOUT_MS);
+    this.heartbeatIdleTimer.unref?.();
+  }
+
   /**
    * Wire rate-limiter session cleanup into the given transport so that
    * bucket memory is freed immediately when a client sends DELETE /mcp.
@@ -1678,11 +1703,17 @@ export class MCPServer {
   private async handleToolsList(params?: Record<string, unknown>): Promise<MCPResult> {
     const exposureState = this.getToolExposureState();
     const requestContext = currentRequestContext();
-    this.configureToolExposureForClient(
-      exposureState,
-      requestContext?.clientInfo,
-      requestContext?.clientCapabilities,
-    );
+    if (
+      requestContext?.protocolEra === 'modern'
+      || requestContext?.clientInfo !== undefined
+      || requestContext?.clientCapabilities !== undefined
+    ) {
+      this.configureToolExposureForClient(
+        exposureState,
+        requestContext.clientInfo,
+        requestContext.clientCapabilities,
+      );
+    }
     // Signal the hint engine that this session has consumed tool descriptions,
     // so rules whose guidance is already embedded in description "When to
     // use / When NOT to use" blocks can suppress themselves without affecting
@@ -1943,7 +1974,10 @@ export class MCPServer {
         parsed.kind === 'session-state' ||
         parsed.kind === 'journal')
     ) {
-      return this.sessionManager.getSession(parsed.id)?.tenantId
+      const session = typeof this.sessionManager.getSession === 'function'
+        ? this.sessionManager.getSession(parsed.id)
+        : undefined;
+      return session?.tenantId
         ?? this.sessionTenants.get(parsed.id)
         ?? this.deletingSessionTenants.get(parsed.id)
         ?? currentRequestContext()?.tenantId;
@@ -1953,8 +1987,12 @@ export class MCPServer {
 
   /** Publish a registry change to legacy clients and modern subscriptions. */
   public emitListChanged(): void {
-    this.sendToolListChanged(STDIO_TOOL_EXPOSURE_SESSION);
+    const notification = {
+      jsonrpc: '2.0' as const,
+      method: 'notifications/tools/list_changed',
+    } as unknown as MCPResponse;
     for (const transport of this.sessionNotificationTransports) {
+      transport.send(notification);
       transport.publishToolsChanged?.();
     }
   }
@@ -2733,34 +2771,7 @@ export class MCPServer {
         // Best-effort recording
       }
 
-      // Transition from heavy back to active after tool completes
-      try {
-        const cdpClient = getCDPClient();
-        if (cdpClient.setHeartbeatMode) {
-          cdpClient.setHeartbeatMode('active');
-        }
-      } catch {
-        // CDP client may not be initialized
-      }
-
-      // Schedule heartbeat idle mode transition
-      if (this.heartbeatIdleTimer) {
-        clearTimeout(this.heartbeatIdleTimer);
-      }
-      this.heartbeatIdleTimer = setTimeout(() => {
-        try {
-          const cdpClient = getCDPClient();
-          if (cdpClient.setHeartbeatMode) {
-            cdpClient.setHeartbeatMode('idle');
-          }
-        } catch {
-          // CDP client may be disconnected
-        }
-        this.heartbeatIdleTimer = null;
-      }, DEFAULT_HEARTBEAT_IDLE_TIMEOUT_MS);
-      if (this.heartbeatIdleTimer.unref) {
-        this.heartbeatIdleTimer.unref();
-      }
+      this.settleHeartbeatAfterToolCall();
 
       const compressionConfig = getGlobalConfig().compression;
       const verbosity = compressionConfig?.verbosity ?? 'normal';
@@ -2908,7 +2919,46 @@ export class MCPServer {
       this.recordToolOutputObservability(toolName, finalResult, requestId);
       return finalResult;
     } catch (error) {
-      if (isMcpInputRequiredError(error)) throw error;
+      if (isMcpInputRequiredError(error)) {
+        this.activityTracker!.endCall(callId, 'input_required');
+        getDashboardState().recordToolEnd(callId, 'input_required');
+        this.emitResourceUpdated('oc://dashboard/state');
+
+        if (runHarnessId && !toolName.startsWith('oc_run_')) {
+          try {
+            const runStore = getRunStore();
+            const runTabId = typeof toolArgs.tabId === 'string' ? toolArgs.tabId : undefined;
+            const durationMs = Date.now() - toolStartTime;
+            runStore.appendToolFinished({
+              run_id: runHarnessId,
+              session_id: sessionId,
+              tab_id: runTabId,
+              tool: toolName,
+              args: telemetryToolArgs,
+              duration_ms: durationMs,
+              message: 'MCP client input required',
+              metadata: { stage: 'input_required' },
+            });
+            if (RUN_HARNESS_LONG_TASK_TOOLS.has(toolName)) {
+              runStore.appendRunEvent({
+                run_id: runHarnessId,
+                session_id: sessionId,
+                tab_id: runTabId,
+                kind: 'partial_result',
+                tool: toolName,
+                duration_ms: durationMs,
+                message: 'MCP client input required',
+                metadata: { stage: 'input_required' },
+              });
+            }
+          } catch {
+            // Best-effort run ledger; never alter MRTR behavior.
+          }
+        }
+
+        this.settleHeartbeatAfterToolCall();
+        throw error;
+      }
       const message = formatError(error);
       const redactedMessage = redactSecretString(message);
       const abortReason = isClientDisconnect(error) ? 'client_disconnect' : null;
@@ -2974,34 +3024,7 @@ export class MCPServer {
         // Best-effort recording
       }
 
-      // Transition from heavy back to active after tool completes
-      try {
-        const cdpClient = getCDPClient();
-        if (cdpClient.setHeartbeatMode) {
-          cdpClient.setHeartbeatMode('active');
-        }
-      } catch {
-        // CDP client may not be initialized
-      }
-
-      // Schedule heartbeat idle mode transition
-      if (this.heartbeatIdleTimer) {
-        clearTimeout(this.heartbeatIdleTimer);
-      }
-      this.heartbeatIdleTimer = setTimeout(() => {
-        try {
-          const cdpClient = getCDPClient();
-          if (cdpClient.setHeartbeatMode) {
-            cdpClient.setHeartbeatMode('idle');
-          }
-        } catch {
-          // CDP client may be disconnected
-        }
-        this.heartbeatIdleTimer = null;
-      }, DEFAULT_HEARTBEAT_IDLE_TIMEOUT_MS);
-      if (this.heartbeatIdleTimer.unref) {
-        this.heartbeatIdleTimer.unref();
-      }
+      this.settleHeartbeatAfterToolCall();
 
       // Append reconnection guidance for connection errors
       const displayMessage = isConnectionError(error)

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1588,7 +1588,7 @@ export class MCPServer {
   }
 
 
-  private async refreshSessionRoots(mcpSessionId: string): Promise<void> {
+  private async refreshSessionRoots(rootScopeId: string): Promise<void> {
     const caps = this.getCurrentClientCapabilities();
     if (!caps.roots) return;
     const roots = await this.getCurrentRequestClient()<unknown>(
@@ -1596,7 +1596,20 @@ export class MCPServer {
       undefined,
       { timeoutMs: 250 },
     );
-    setSessionMcpRoots(mcpSessionId, roots);
+    setSessionMcpRoots(rootScopeId, roots);
+  }
+
+  private async refreshModernRootsForTool(
+    sessionId: string,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<void> {
+    if (currentRequestContext()?.protocolEra !== 'modern') return;
+    const hasEgressCandidate =
+      extractNetworkRootCandidateUrls(toolName, args).length > 0
+      || extractFileRootCandidatePaths(toolName, args).length > 0;
+    if (!hasEgressCandidate) return;
+    await this.refreshSessionRoots(sessionId);
   }
 
   private enforceNetworkRootsForTool(
@@ -2262,8 +2275,11 @@ export class MCPServer {
       throw err;
     }
 
+    const rootScopeId = currentRequestContext()?.mcpSessionId ?? sessionId;
+    await this.refreshModernRootsForTool(rootScopeId, toolName, substitutedArgs);
+
     const rootsDenial = this.enforceNetworkRootsForTool(
-      currentRequestContext()?.mcpSessionId ?? sessionId,
+      rootScopeId,
       toolName,
       substitutedArgs,
     );
@@ -2273,7 +2289,7 @@ export class MCPServer {
     }
 
     const fileRootsDenial = this.enforceFileRootsForTool(
-      currentRequestContext()?.mcpSessionId ?? sessionId,
+      rootScopeId,
       toolName,
       substitutedArgs,
     );

--- a/src/mcp/sdk-adapter.ts
+++ b/src/mcp/sdk-adapter.ts
@@ -1,0 +1,461 @@
+import {
+  ProtocolError,
+  Server,
+  fromJsonSchema,
+  inputRequired,
+  type AuthInfo,
+  type CallToolResult,
+  type ClientCapabilities,
+  type EmptyResult,
+  type InputRequiredResult,
+  type ListResourceTemplatesResult,
+  type ListResourcesResult,
+  type ListToolsResult,
+  type ReadResourceResult,
+  type ServerContext,
+} from '@modelcontextprotocol/server';
+import type { Principal } from '../auth/api-key-types';
+import { McpInputRequiredError, isMcpInputRequiredError } from '../errors/mcp-input-required';
+import { PRINCIPAL_SYM } from '../middleware/auth';
+import {
+  generateRequestId,
+  normalizeRequestId,
+  runWithRequestContext,
+  type RequestContext,
+} from '../observability/request-id';
+import type { MCPResponse } from '../types/mcp';
+import type { TransportMessageContext } from '../transports';
+import { getVersion } from '../version';
+
+export const MODERN_MCP_PROTOCOL_VERSION = '2026-07-28';
+
+const CLIENT_CAPABILITIES_META_KEY = 'io.modelcontextprotocol/clientCapabilities';
+const CLIENT_INFO_META_KEY = 'io.modelcontextprotocol/clientInfo';
+const OPENCHROME_PRINCIPAL_KEY = 'openchromePrincipal';
+const OPENCHROME_TRANSPORT_CONTEXT_KEY = 'openchromeTransportContext';
+
+export type CoreMcpMessageHandler = (
+  message: Record<string, unknown>,
+  signal?: AbortSignal,
+  context?: TransportMessageContext,
+) => Promise<MCPResponse | null>;
+
+export interface SdkAdapterOptions {
+  era: 'legacy' | 'modern';
+  /** Connection-scoped identifier retained only for the legacy protocol era. */
+  mcpSessionId?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function sdkPrincipal(authInfo: AuthInfo | undefined): Principal | undefined {
+  const value = authInfo?.extra?.[OPENCHROME_PRINCIPAL_KEY];
+  if (!isRecord(value)) return undefined;
+  if (typeof value.tenantId !== 'string' || !Array.isArray(value.scopes) || typeof value.mode !== 'string') {
+    return undefined;
+  }
+  if (!value.scopes.every((scope) => typeof scope === 'string')) return undefined;
+  if (!['disabled', 'legacy', 'api-key', 'jwt'].includes(value.mode)) return undefined;
+  return value as unknown as Principal;
+}
+
+function sdkTransportContext(
+  authInfo: AuthInfo | undefined,
+): Pick<RequestContext, 'tenantId' | 'brokerClientId'> {
+  const value = authInfo?.extra?.[OPENCHROME_TRANSPORT_CONTEXT_KEY];
+  if (!isRecord(value)) return {};
+  return {
+    ...(typeof value.tenantId === 'string' ? { tenantId: value.tenantId } : {}),
+    ...(typeof value.brokerClientId === 'string'
+      ? { brokerClientId: value.brokerClientId }
+      : {}),
+  };
+}
+
+export function toSdkAuthInfo(
+  principal: Principal | undefined,
+  transportContext: Pick<RequestContext, 'tenantId' | 'brokerClientId'> = {},
+): AuthInfo | undefined {
+  if (!principal) return undefined;
+  return {
+    // Authentication has already happened in OpenChrome's middleware. Never
+    // duplicate the plaintext bearer/API key into the SDK context.
+    token: 'openchrome-authenticated',
+    clientId: principal.keyId ?? principal.tenantId,
+    scopes: [...principal.scopes],
+    extra: {
+      [OPENCHROME_PRINCIPAL_KEY]: { ...principal, scopes: [...principal.scopes] },
+      [OPENCHROME_TRANSPORT_CONTEXT_KEY]: transportContext,
+    },
+  };
+}
+
+function clientCapabilitiesFor(
+  server: Server,
+  ctx: ServerContext,
+  era: 'legacy' | 'modern',
+): ClientCapabilities | undefined {
+  if (era === 'modern') {
+    return (ctx.mcpReq.envelope as Record<string, unknown> | undefined)
+      ?.[CLIENT_CAPABILITIES_META_KEY] as ClientCapabilities | undefined;
+  }
+  return server.getClientCapabilities();
+}
+
+function clientInfoFor(
+  server: Server,
+  ctx: ServerContext,
+  era: 'legacy' | 'modern',
+): { name?: string; version?: string } | undefined {
+  const raw = era === 'modern'
+    ? (ctx.mcpReq.envelope as Record<string, unknown> | undefined)?.[CLIENT_INFO_META_KEY]
+    : server.getClientVersion();
+  if (!isRecord(raw)) return undefined;
+  return {
+    ...(typeof raw.name === 'string' ? { name: raw.name } : {}),
+    ...(typeof raw.version === 'string' ? { version: raw.version } : {}),
+  };
+}
+
+function inputRequestFor(method: string, params?: Record<string, unknown>) {
+  switch (method) {
+    case 'sampling/createMessage':
+      return inputRequired.createMessage((params ?? {}) as Parameters<typeof inputRequired.createMessage>[0]);
+    case 'elicitation/create': {
+      const message = typeof params?.message === 'string' ? params.message : 'OpenChrome requires user input.';
+      if (params?.mode === 'url' && typeof params.url === 'string') {
+        return inputRequired.elicitUrl({ message, url: params.url });
+      }
+      return inputRequired.elicit({
+        message,
+        requestedSchema: (params?.requestedSchema ?? {
+          type: 'object',
+          properties: {},
+        }) as Parameters<typeof inputRequired.elicit>[0]['requestedSchema'],
+      });
+    }
+    case 'roots/list':
+      return inputRequired.listRoots();
+    default:
+      throw new ProtocolError(-32601, `Unsupported input request method: ${method}`);
+  }
+}
+
+function requestClientFor(
+  ctx: ServerContext,
+  era: 'legacy' | 'modern',
+): NonNullable<RequestContext['requestClient']> {
+  let ordinal = 0;
+  return async <T>(
+    method: string,
+    params?: Record<string, unknown>,
+    options?: { timeoutMs?: number; signal?: AbortSignal },
+  ): Promise<T> => {
+    if (era === 'legacy') {
+      const requestOptions = {
+        ...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
+        ...(options?.signal !== undefined ? { requestSignal: options.signal } : {}),
+      };
+      switch (method) {
+        case 'sampling/createMessage':
+          return await ctx.mcpReq.send(
+            { method, params: params ?? {} },
+            requestOptions,
+          ) as T;
+        case 'elicitation/create':
+          return await ctx.mcpReq.send(
+            { method, params: params ?? {} },
+            requestOptions,
+          ) as T;
+        case 'roots/list':
+          return await ctx.mcpReq.send(
+            { method, ...(params ? { params } : {}) },
+            requestOptions,
+          ) as T;
+        default:
+          throw new ProtocolError(-32601, `Unsupported client request method: ${method}`);
+      }
+    }
+
+    ordinal++;
+    const key = `openchrome_${ordinal}_${method.replace(/[^A-Za-z0-9]+/g, '_')}`;
+    if (
+      ctx.mcpReq.inputResponses &&
+      Object.prototype.hasOwnProperty.call(ctx.mcpReq.inputResponses, key)
+    ) {
+      return ctx.mcpReq.inputResponses[key] as T;
+    }
+
+    throw new McpInputRequiredError(inputRequired({
+      inputRequests: { [key]: inputRequestFor(method, params) },
+    }));
+  };
+}
+
+function legacyServerRequestClient(
+  server: Server,
+): NonNullable<RequestContext['requestClient']> {
+  return async <T>(
+    method: string,
+    params?: Record<string, unknown>,
+    options?: { timeoutMs?: number; signal?: AbortSignal },
+  ): Promise<T> => {
+    const requestOptions = {
+      ...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
+      ...(options?.signal !== undefined ? { signal: options.signal } : {}),
+    };
+    switch (method) {
+      case 'sampling/createMessage':
+        return await server.createMessage(
+          (params ?? {}) as Parameters<typeof server.createMessage>[0],
+          requestOptions,
+        ) as T;
+      case 'elicitation/create':
+        return await server.elicitInput(
+          (params ?? {}) as Parameters<typeof server.elicitInput>[0],
+          requestOptions,
+        ) as T;
+      case 'roots/list':
+        return await server.listRoots(
+          params as Parameters<typeof server.listRoots>[0],
+          requestOptions,
+        ) as T;
+      default:
+        throw new ProtocolError(-32601, `Unsupported client request method: ${method}`);
+    }
+  };
+}
+
+function paramsWithMeta(
+  params: unknown,
+  ctx: ServerContext,
+): Record<string, unknown> | undefined {
+  const normalized = isRecord(params) ? { ...params } : {};
+  if (ctx.mcpReq._meta && Object.keys(ctx.mcpReq._meta).length > 0) {
+    normalized._meta = ctx.mcpReq._meta;
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function requestIdFor(ctx: ServerContext): string {
+  const header = ctx.http?.req?.headers.get('x-request-id');
+  return normalizeRequestId(header) ?? generateRequestId();
+}
+
+/**
+ * Adapt OpenChrome's mature tool/runtime core to the official MCP SDK wire
+ * boundary. The SDK owns negotiation, envelopes, result discrimination,
+ * standard HTTP headers, subscriptions, and protocol-era validation.
+ */
+export function createSdkServerAdapter(
+  messageHandler: CoreMcpMessageHandler,
+  options: SdkAdapterOptions,
+): Server {
+  const server = new Server(
+    { name: 'openchrome', version: getVersion() },
+    {
+      capabilities: {
+        tools: { listChanged: true },
+        resources: { listChanged: true, subscribe: true },
+        // Legacy clients can still use logging/setLevel. On modern requests
+        // the SDK applies io.modelcontextprotocol/logLevel per request and
+        // suppresses messages when it is absent.
+        logging: {},
+      },
+      instructions:
+        'Control Chrome with explicit OpenChrome sessionId and tabId handles. ' +
+        'Use tools/list for the available browser operations and resources/list for live state.',
+      cacheHints: {
+        'server/discover': { ttlMs: 300_000, cacheScope: 'public' },
+        'tools/list': { ttlMs: 30_000, cacheScope: 'private' },
+        'resources/list': { ttlMs: 0, cacheScope: 'private' },
+        'resources/templates/list': { ttlMs: 60_000, cacheScope: 'private' },
+        'resources/read': { ttlMs: 0, cacheScope: 'private' },
+      },
+    },
+  );
+
+  const dispatch = async (
+    method: string,
+    params: Record<string, unknown> | undefined,
+    ctx: ServerContext,
+  ): Promise<Record<string, unknown>> => {
+    const principal = sdkPrincipal(ctx.http?.authInfo);
+    const inheritedTransportContext = sdkTransportContext(ctx.http?.authInfo);
+    const tenantId = principal?.mode === 'api-key' || principal?.mode === 'jwt'
+      ? principal.tenantId
+      : inheritedTransportContext.tenantId ?? principal?.tenantId;
+    const capabilities = clientCapabilitiesFor(server, ctx, options.era);
+    const clientInfo = clientInfoFor(server, ctx, options.era);
+    const transportContext: TransportMessageContext = {
+      ...(options.mcpSessionId ? { mcpSessionId: options.mcpSessionId } : {}),
+      ...(tenantId ? { tenantId } : {}),
+      ...(inheritedTransportContext.brokerClientId
+        ? { brokerClientId: inheritedTransportContext.brokerClientId }
+        : {}),
+    };
+    const requestContext: RequestContext = {
+      requestId: requestIdFor(ctx),
+      ...(tenantId ? { tenantId } : {}),
+      ...(principal?.keyId ? { keyId: principal.keyId } : {}),
+      ...(options.mcpSessionId ? { mcpSessionId: options.mcpSessionId } : {}),
+      ...(inheritedTransportContext.brokerClientId
+        ? { brokerClientId: inheritedTransportContext.brokerClientId }
+        : {}),
+      protocolEra: options.era,
+      ...(clientInfo ? { clientInfo } : {}),
+      ...(capabilities
+        ? { clientCapabilities: capabilities as RequestContext['clientCapabilities'] }
+        : {}),
+      requestClient: requestClientFor(ctx, options.era),
+      notifyClient: async (notificationMethod, notificationParams) => {
+        await ctx.mcpReq.notify({
+          method: notificationMethod,
+          ...(notificationParams ? { params: notificationParams } : {}),
+        });
+      },
+      logClient: async (level, logger, data) => {
+        await ctx.mcpReq.log(
+          level as Parameters<typeof ctx.mcpReq.log>[0],
+          data,
+          logger,
+        );
+      },
+    };
+
+    const message: Record<PropertyKey, unknown> = {
+      jsonrpc: '2.0',
+      ...(ctx.mcpReq.id !== undefined ? { id: ctx.mcpReq.id } : {}),
+      method,
+      ...(params ? { params } : {}),
+    };
+    if (principal) {
+      message[PRINCIPAL_SYM] = principal;
+    }
+
+    const response = await runWithRequestContext(
+      requestContext,
+      () => messageHandler(
+        message as Record<string, unknown>,
+        ctx.mcpReq.signal,
+        transportContext,
+      ),
+    );
+    if (response === null) return {};
+    if (response.error) {
+      throw new ProtocolError(response.error.code, response.error.message, response.error.data);
+    }
+    return (response.result ?? {}) as Record<string, unknown>;
+  };
+
+  const legacyNotificationContext = (): RequestContext => ({
+    requestId: generateRequestId(),
+    ...(options.mcpSessionId ? { mcpSessionId: options.mcpSessionId } : {}),
+    protocolEra: 'legacy',
+    ...(server.getClientCapabilities()
+      ? { clientCapabilities: server.getClientCapabilities() as RequestContext['clientCapabilities'] }
+      : {}),
+    ...(server.getClientVersion()
+      ? { clientInfo: server.getClientVersion() }
+      : {}),
+    requestClient: legacyServerRequestClient(server),
+  });
+
+  const dispatchLegacyNotification = async (
+    method: string,
+    params?: Record<string, unknown>,
+  ): Promise<void> => {
+    await runWithRequestContext(
+      legacyNotificationContext(),
+      () => messageHandler(
+        {
+          jsonrpc: '2.0',
+          method,
+          ...(params ? { params } : {}),
+        },
+        undefined,
+        options.mcpSessionId ? { mcpSessionId: options.mcpSessionId } : undefined,
+      ),
+    );
+  };
+
+  server.setRequestHandler('tools/list', async (request, ctx) =>
+    await dispatch('tools/list', paramsWithMeta(request.params, ctx), ctx) as unknown as ListToolsResult,
+  );
+
+  server.setRequestHandler('tools/call', async (request, ctx) => {
+    try {
+      const result = await dispatch(
+        'tools/call',
+        paramsWithMeta(request.params, ctx),
+        ctx,
+      ) as unknown as CallToolResult;
+      return server.projectCallToolResult(result, undefined);
+    } catch (error) {
+      if (isMcpInputRequiredError(error)) {
+        return error.result as InputRequiredResult;
+      }
+      throw error;
+    }
+  });
+
+  server.setRequestHandler('resources/list', async (request, ctx) =>
+    await dispatch('resources/list', paramsWithMeta(request.params, ctx), ctx) as unknown as ListResourcesResult,
+  );
+  server.setRequestHandler('resources/templates/list', async (request, ctx) =>
+    await dispatch(
+      'resources/templates/list',
+      paramsWithMeta(request.params, ctx),
+      ctx,
+    ) as unknown as ListResourceTemplatesResult,
+  );
+  server.setRequestHandler('resources/read', async (request, ctx) =>
+    await dispatch('resources/read', paramsWithMeta(request.params, ctx), ctx) as unknown as ReadResourceResult,
+  );
+  if (options.era === 'legacy') {
+    server.setRequestHandler('resources/subscribe', async (request, ctx) =>
+      await dispatch(
+        'resources/subscribe',
+        paramsWithMeta(request.params, ctx),
+        ctx,
+      ) as unknown as EmptyResult,
+    );
+    server.setRequestHandler('resources/unsubscribe', async (request, ctx) =>
+      await dispatch(
+        'resources/unsubscribe',
+        paramsWithMeta(request.params, ctx),
+        ctx,
+      ) as unknown as EmptyResult,
+    );
+    server.setNotificationHandler(
+      'notifications/roots/list_changed',
+      async (notification) => {
+        await dispatchLegacyNotification(
+          'notifications/roots/list_changed',
+          notification.params,
+        );
+      },
+    );
+  }
+
+  // OpenChrome's explicit browser-session methods predate the modern MCP
+  // transport session removal and remain useful application-level extensions.
+  const extensionParams = fromJsonSchema<Record<string, unknown>>({});
+  for (const method of ['sessions/list', 'sessions/create', 'sessions/delete'] as const) {
+    server.setRequestHandler(
+      method,
+      { params: extensionParams },
+      async (params, ctx) => await dispatch(method, paramsWithMeta(params, ctx), ctx),
+    );
+  }
+
+  server.oninitialized = () => {
+    void dispatchLegacyNotification('notifications/initialized').catch((error) => {
+      console.error('[MCP SDK adapter] initialized notification failed:', error);
+    });
+  };
+
+  return server;
+}

--- a/src/observability/request-id.ts
+++ b/src/observability/request-id.ts
@@ -85,6 +85,29 @@ export interface RequestContext {
   mcpSessionId?: string;
   /** Broker stdio-proxy identity when this request arrived via --connect-broker. */
   brokerClientId?: string;
+  /** MCP protocol era selected by the SDK boundary for this request. */
+  protocolEra?: 'legacy' | 'modern';
+  /** Client identity carried by initialize (legacy) or the per-request envelope (modern). */
+  clientInfo?: { name?: string; version?: string };
+  /** Capabilities carried by initialize (legacy) or the per-request envelope (modern). */
+  clientCapabilities?: {
+    roots?: object;
+    sampling?: object;
+    elicitation?: object;
+    tools?: { listChanged?: boolean };
+    notifications?: { tools?: { listChanged?: boolean } };
+    [key: string]: unknown;
+  };
+  /** Request-related client call bridge supplied by the official MCP SDK. */
+  requestClient?: <T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    options?: { timeoutMs?: number; signal?: AbortSignal },
+  ) => Promise<T>;
+  /** Request-related notification bridge supplied by the official MCP SDK. */
+  notifyClient?: (method: string, params?: Record<string, unknown>) => Promise<void>;
+  /** Per-request structured logging bridge; the SDK enforces the requested level. */
+  logClient?: (level: string, logger: string, data: Record<string, unknown>) => Promise<void>;
 }
 
 const requestStore = new AsyncLocalStorage<RequestContext>();

--- a/src/resources/live-state.ts
+++ b/src/resources/live-state.ts
@@ -63,7 +63,10 @@ export const LIVE_RESOURCE_TEMPLATES: MCPResourceTemplateDefinition[] = [
   },
 ];
 
-export function liveResourceDefinitions(sessionManager: SessionManager): MCPResourceDefinition[] {
+export function liveResourceDefinitions(
+  sessionManager: SessionManager,
+  tenantId?: TenantId,
+): MCPResourceDefinition[] {
   const resources: MCPResourceDefinition[] = [
     {
       uri: 'oc://diagnostics/targets',
@@ -79,6 +82,12 @@ export function liveResourceDefinitions(sessionManager: SessionManager): MCPReso
     },
   ];
   for (const session of sessionManager.getAllSessionInfos()) {
+    if (
+      tenantId !== undefined &&
+      (session.tenantId ?? DEFAULT_TENANT_ID) !== tenantId
+    ) {
+      continue;
+    }
     resources.push({
       uri: sessionTabsUri(session.id),
       name: `openchrome-session-tabs-${session.id}`,

--- a/src/security/mcp-roots.ts
+++ b/src/security/mcp-roots.ts
@@ -83,14 +83,21 @@ export function clearAllSessionMcpRoots(): void {
 }
 
 export function assertUrlAllowedBySessionRoots(sessionId: string, url: string): void {
-  const roots = getSessionMcpRoots(sessionId);
+  assertUrlAllowedByMcpRoots(getSessionMcpRoots(sessionId), url, sessionId);
+}
+
+export function assertUrlAllowedByMcpRoots(
+  roots: ParsedMcpRoots | undefined,
+  url: string,
+  scopeId: string,
+): void {
   if (!roots || roots.network.length === 0) return;
   const host = extractHttpsHost(url);
   if (!host) return;
   const allowed = roots.network.some((root) => hostMatchesNetworkRoot(host, root));
   if (!allowed) {
     throw new Error(
-      `Access to URL host "${host}" is blocked by MCP roots narrowing for session "${sessionId}". ` +
+      `Access to URL host "${host}" is blocked by MCP roots narrowing for session "${scopeId}". ` +
       `Allowed network roots: ${roots.network.map((root) => root.uri).join(', ')}`,
     );
   }
@@ -106,13 +113,20 @@ export function isUrlAllowedBySessionRoots(sessionId: string, url: string): bool
 }
 
 export function assertFilePathAllowedBySessionRoots(sessionId: string, filePath: string): void {
-  const roots = getSessionMcpRoots(sessionId);
+  assertFilePathAllowedByMcpRoots(getSessionMcpRoots(sessionId), filePath, sessionId);
+}
+
+export function assertFilePathAllowedByMcpRoots(
+  roots: ParsedMcpRoots | undefined,
+  filePath: string,
+  scopeId: string,
+): void {
   if (!roots || roots.file.length === 0) return;
   const resolvedPath = path.resolve(expandHomePath(filePath));
   const allowed = roots.file.some((root) => isPathWithinRoot(resolvedPath, root.path));
   if (!allowed) {
     throw new Error(
-      `Access to file output path "${resolvedPath}" is blocked by MCP roots narrowing for session "${sessionId}". ` +
+      `Access to file output path "${resolvedPath}" is blocked by MCP roots narrowing for session "${scopeId}". ` +
       `Allowed file roots: ${roots.file.map((root) => root.uri).join(', ')}`,
     );
   }

--- a/src/tools/act.ts
+++ b/src/tools/act.ts
@@ -18,6 +18,7 @@ import { getTargetId } from '../utils/puppeteer-helpers';
 import { classifyOutcome, formatOutcomeLine } from '../utils/ralph/outcome-classifier';
 import { humanMouseMove, humanType } from '../stealth/human-behavior';
 import { withTimeout } from '../utils/with-timeout';
+import { isMcpInputRequiredError } from '../errors/mcp-input-required';
 import { cleanupTags, DISCOVERY_TAG } from '../utils/element-discovery';
 import { parseInstruction, ParsedAction } from '../actions/action-parser';
 import { matchTemplate } from '../actions/action-templates';
@@ -168,6 +169,7 @@ async function maybeRefineActionsWithSampling(
     if (!sampled) return { actions, decision: { used: false, supported: true, fallbackReason: 'invalid_sampling_response' } };
     return { actions: sampled, decision: { used: true, supported: true } };
   } catch (err) {
+    if (isMcpInputRequiredError(err)) throw err;
     // Map known transport/cancel signatures to closed-set reasons so we don't
     // leak raw transport text to clients in `_meta.sampling.fallbackReason`.
     const message = err instanceof Error ? err.message : String(err);

--- a/src/tools/cookies.ts
+++ b/src/tools/cookies.ts
@@ -7,6 +7,7 @@ import { MCPToolDefinition, MCPResult, ToolContext, ToolHandler } from '../types
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { assertDomainAllowed } from '../security/domain-guard';
+import { isMcpInputRequiredError } from '../errors/mcp-input-required';
 
 type CookieTier = 'auth' | 'functional' | 'tracking';
 
@@ -114,6 +115,7 @@ async function requireElicitationForDestructiveCookieAction(
       { timeoutMs: 30_000, signal: context.signal },
     );
   } catch (error) {
+    if (isMcpInputRequiredError(error)) throw error;
     const message = error instanceof Error ? error.message : String(error);
     const code = /timeout/i.test(message)
       ? 'elicitation_timeout'

--- a/src/tools/image-qa.ts
+++ b/src/tools/image-qa.ts
@@ -22,6 +22,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolContext, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { coerceSupportedImageMimeType, makeImageContent } from '../utils/image-mime';
+import { isMcpInputRequiredError } from '../errors/mcp-input-required';
 
 interface ImageQaScreenshot {
   /** Opaque in-memory reference produced by a sibling tool. */
@@ -213,6 +214,7 @@ const handler: ToolHandler = async (
       ...(response?.usage ? { usage: response.usage } : {}),
     });
   } catch (err) {
+    if (isMcpInputRequiredError(err)) throw err;
     const message = err instanceof Error ? err.message : String(err);
     return jsonResult({ status: 'error', reason: `sampling request failed: ${message}` });
   }
@@ -293,6 +295,7 @@ export async function runImageQaSampling(
       ...(response?.usage ? { usage: response.usage } : {}),
     };
   } catch (err) {
+    if (isMcpInputRequiredError(err)) throw err;
     const message = err instanceof Error ? err.message : String(err);
     return { status: 'error', reason: `sampling request failed: ${message}` };
   }

--- a/src/tools/oc-journal-compact.ts
+++ b/src/tools/oc-journal-compact.ts
@@ -25,6 +25,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolContext, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getTaskJournal, type JournalEntry } from '../journal/task-journal';
+import { isMcpInputRequiredError } from '../errors/mcp-input-required';
 
 type CompactStrategy = 'recent_k' | 'checkpoint_only' | 'sampling';
 
@@ -275,6 +276,7 @@ const handler: ToolHandler = async (
       strategy_used: 'sampling',
     });
   } catch (err) {
+    if (isMcpInputRequiredError(err)) throw err;
     const message = err instanceof Error ? err.message : String(err);
     return jsonResult({ status: 'error', reason: `sampling request failed: ${message}` });
   }

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -1,10 +1,10 @@
 /**
  * Streamable HTTP transport for MCP server.
  *
- * Implements MCP Streamable HTTP transport (spec 2025-03-26):
- * - POST /mcp: receives JSON-RPC request/notification, returns JSON-RPC response
- * - GET /health: basic health check (separate from the self-healing health endpoint)
- * - DELETE /mcp: session termination
+ * Implements a dual-era MCP Streamable HTTP boundary:
+ * - 2026-07-28: stateless POST requests and subscriptions/listen
+ * - Legacy: sessionful POST, GET/SSE notifications, and DELETE termination
+ * - GET /health: basic health check (separate from the self-healing endpoint)
  *
  * Key difference from stdio: client disconnect does NOT kill the server.
  * The HTTP server continues to accept new connections.
@@ -12,6 +12,16 @@
 
 import * as http from 'node:http';
 import * as crypto from 'node:crypto';
+import {
+  createMcpHandler,
+  isLegacyRequest,
+  type McpHttpHandler,
+} from '@modelcontextprotocol/server';
+import {
+  toNodeHandler,
+  toWebRequest,
+  type NodeMcpRequestHandler,
+} from '@modelcontextprotocol/node';
 import { MCPResponse, MCPErrorCodes } from '../types/mcp';
 import { ClientDisconnectError } from '../errors/abort';
 import { MCPTransport, TransportMessageContext } from './index';
@@ -61,6 +71,14 @@ import {
   handleDashboardSessions,
   handleDashboardToolCalls,
 } from './http/dashboard-routes';
+import {
+  createSdkServerAdapter,
+  toSdkAuthInfo,
+} from '../mcp/sdk-adapter';
+import {
+  runWithSubscriptionTenant,
+  TenantScopedServerEventBus,
+} from './http/tenant-event-bus';
 
 export { HTTP_TIMEOUTS } from './http/config';
 
@@ -88,6 +106,11 @@ export class HTTPTransport implements MCPTransport {
   private messageHandler:
     | ((msg: Record<string, unknown>, signal?: AbortSignal, context?: TransportMessageContext) => Promise<MCPResponse | null>)
     | null = null;
+  private modernHandler: McpHttpHandler | null = null;
+  private modernNodeHandler: NodeMcpRequestHandler | null = null;
+  private readonly modernEventBus = new TenantScopedServerEventBus((error) => {
+    console.error('[HTTPTransport] Modern subscription listener failed:', error);
+  });
   private port: number;
   private host: string;
   private authToken: string | undefined;
@@ -179,6 +202,22 @@ export class HTTPTransport implements MCPTransport {
     handler: (msg: Record<string, unknown>, signal?: AbortSignal, context?: TransportMessageContext) => Promise<MCPResponse | null>,
   ): void {
     this.messageHandler = handler;
+    this.modernHandler = createMcpHandler(
+      ({ era }) => createSdkServerAdapter(handler, { era }),
+      {
+        legacy: 'reject',
+        responseMode: 'auto',
+        bus: this.modernEventBus,
+        onerror: (error) => {
+          console.error('[HTTPTransport] MCP SDK error:', error);
+        },
+      },
+    );
+    this.modernNodeHandler = toNodeHandler(this.modernHandler, {
+      onerror: (error) => {
+        console.error('[HTTPTransport] MCP SDK Node adapter error:', error);
+      },
+    });
   }
 
   /**
@@ -208,6 +247,22 @@ export class HTTPTransport implements MCPTransport {
       }
     }
     return sent;
+  }
+
+  publishToolsChanged(): void {
+    this.modernHandler?.notify.toolsChanged();
+  }
+
+  publishResourcesChanged(tenantId?: string): void {
+    if (!tenantId) return;
+    this.modernEventBus.publishForTenant({ kind: 'resources_list_changed' }, tenantId);
+  }
+
+  publishResourceUpdated(uri: string, tenantId?: string): void {
+    // Resource payloads and concrete URIs are tenant-scoped. If ownership
+    // cannot be resolved, fail closed rather than broadcasting metadata.
+    if (!tenantId) return;
+    this.modernEventBus.publishForTenant({ kind: 'resource_updated', uri }, tenantId);
   }
 
   start(): void {
@@ -278,6 +333,12 @@ export class HTTPTransport implements MCPTransport {
     }
     this.sseConnections = [];
     this.sessionTenants.clear();
+    const modernHandler = this.modernHandler;
+    this.modernHandler = null;
+    this.modernNodeHandler = null;
+    if (modernHandler) {
+      await modernHandler.close();
+    }
 
     return new Promise((resolve) => {
       if (this.server) {
@@ -403,6 +464,10 @@ export class HTTPTransport implements MCPTransport {
       if (req.method === 'GET') {
         const tenantId = this.resolveRequestTenant(req, res);
         if (tenantId === null) return;
+        if (this.hasModernProtocolHeader(req)) {
+          this.forwardModernRequest(req, res, tenantId);
+          return;
+        }
         this.handleSSE(req, res, tenantId);
       } else {
         res.writeHead(405, { 'Allow': 'GET', 'Content-Type': 'application/json' });
@@ -422,12 +487,23 @@ export class HTTPTransport implements MCPTransport {
         case 'GET': {
           const tenantId = this.resolveRequestTenant(req, res);
           if (tenantId === null) return;
+          if (this.hasModernProtocolHeader(req)) {
+            this.forwardModernRequest(req, res, tenantId);
+            return;
+          }
           this.handleSSE(req, res, tenantId);
           return;
         }
-        case 'DELETE':
+        case 'DELETE': {
+          if (this.hasModernProtocolHeader(req)) {
+            const tenantId = this.resolveRequestTenant(req, res);
+            if (tenantId === null) return;
+            this.forwardModernRequest(req, res, tenantId);
+            return;
+          }
           this.handleDelete(req, res);
           return;
+        }
         default:
           res.writeHead(405, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Method not allowed' }));
@@ -438,6 +514,57 @@ export class HTTPTransport implements MCPTransport {
     // Unknown path
     res.writeHead(404, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: 'Not found' }));
+  }
+
+  private hasModernProtocolHeader(req: http.IncomingMessage): boolean {
+    const value = req.headers['mcp-protocol-version'];
+    const version = Array.isArray(value) ? value[0] : value;
+    return version === '2026-07-28';
+  }
+
+  private forwardModernRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    tenantId: TenantId,
+    parsedBody?: unknown,
+  ): void {
+    if (!this.modernNodeHandler) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        jsonrpc: '2.0',
+        id: 0,
+        error: { code: MCPErrorCodes.INTERNAL_ERROR, message: 'Modern MCP handler is not available' },
+      }));
+      return;
+    }
+    const principal = requestPrincipals.get(req);
+    const brokerClientId = normalizeBrokerClientId(
+      req.headers[BROKER_CLIENT_ID_HEADER.toLowerCase()],
+    );
+    const effectiveTenantId = principal?.mode === 'api-key' || principal?.mode === 'jwt'
+      ? principal.tenantId
+      : tenantId;
+    const authInfo = toSdkAuthInfo(principal, { tenantId, brokerClientId });
+    if (authInfo) {
+      (req as http.IncomingMessage & { auth?: typeof authInfo }).auth = authInfo;
+    }
+    void runWithSubscriptionTenant(
+      effectiveTenantId,
+      () => this.modernNodeHandler!(req, res, parsedBody),
+    ).catch((error) => {
+      console.error('[HTTPTransport] Modern MCP request failed:', error);
+      if (!res.headersSent) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          jsonrpc: '2.0',
+          id: 0,
+          error: {
+            code: MCPErrorCodes.INTERNAL_ERROR,
+            message: 'Modern MCP request failed',
+          },
+        }));
+      }
+    });
   }
 
   /**
@@ -477,7 +604,11 @@ export class HTTPTransport implements MCPTransport {
       throw err;
     }
 
-    const mcpSessionId = req.headers['mcp-session-id'] as string | undefined;
+    // MCP 2026-07-28 removed protocol sessions. A stale session header on a
+    // modern request must be ignored, including for tenant-binding checks.
+    const mcpSessionId = this.hasModernProtocolHeader(req)
+      ? undefined
+      : req.headers['mcp-session-id'] as string | undefined;
     if (mcpSessionId) {
       const bound = this.sessionTenants.get(mcpSessionId);
       if (bound !== undefined && bound !== tenantId) {
@@ -723,11 +854,42 @@ export class HTTPTransport implements MCPTransport {
         return;
       }
 
+      const principal = requestPrincipals.get(req);
+      const brokerClientId = normalizeBrokerClientId(
+        req.headers[BROKER_CLIENT_ID_HEADER.toLowerCase()],
+      );
+      let legacyRequest: boolean;
+      try {
+        const classificationRequest = await toWebRequest(
+          req,
+          parsed,
+          signal ? { signal } : undefined,
+        );
+        legacyRequest = await isLegacyRequest(classificationRequest, parsed);
+      } catch (error) {
+        console.error('[HTTPTransport] MCP request classification failed:', error);
+        const id = !Array.isArray(parsed) && typeof parsed === 'object' && parsed !== null
+          ? ((parsed as Record<string, unknown>).id ?? 0)
+          : 0;
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          jsonrpc: '2.0',
+          id,
+          error: {
+            code: MCPErrorCodes.INTERNAL_ERROR,
+            message: 'MCP request classification failed',
+          },
+        }));
+        return;
+      }
+      if (!legacyRequest) {
+        this.forwardModernRequest(req, res, tenantId, parsed);
+        return;
+      }
+
       // Correlation ID for this HTTP request — propagate into handler(s).
       const requestId = (req as http.IncomingMessage & { requestId?: string }).requestId
         || resolveRequestId(req.headers[REQUEST_ID_HEADER_LOWER]);
-      const principal = requestPrincipals.get(req);
-      const brokerClientId = normalizeBrokerClientId(req.headers[BROKER_CLIENT_ID_HEADER.toLowerCase()]);
 
       // Handle JSON-RPC batch (array of requests)
       if (Array.isArray(parsed)) {

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -368,6 +368,9 @@ export class HTTPTransport implements MCPTransport {
     const requestId = resolveRequestId(req.headers[REQUEST_ID_HEADER_LOWER]);
     res.setHeader(REQUEST_ID_HEADER, requestId);
     (req as http.IncomingMessage & { requestId?: string }).requestId = requestId;
+    // The modern SDK converts this IncomingMessage into a Fetch Request.
+    // Forward the canonical value so its request context reuses the same ID.
+    req.headers[REQUEST_ID_HEADER_LOWER] = requestId;
 
     // Handle CORS preflight
     if (req.method === 'OPTIONS') {

--- a/src/transports/http/cors.ts
+++ b/src/transports/http/cors.ts
@@ -68,8 +68,29 @@ export function applyCors(
     res.setHeader('Vary', 'Origin');
   }
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', `Content-Type, Mcp-Session-Id, Authorization, X-Tenant-Id, ${REQUEST_ID_HEADER}`);
-  res.setHeader('Access-Control-Expose-Headers', `Mcp-Session-Id, ${REQUEST_ID_HEADER}`);
+  res.setHeader(
+    'Access-Control-Allow-Headers',
+    [
+      'Content-Type',
+      'Mcp-Session-Id',
+      'Authorization',
+      'X-Tenant-Id',
+      REQUEST_ID_HEADER,
+      'MCP-Protocol-Version',
+      'Mcp-Method',
+      'Mcp-Name',
+    ].join(', '),
+  );
+  res.setHeader(
+    'Access-Control-Expose-Headers',
+    [
+      'Mcp-Session-Id',
+      REQUEST_ID_HEADER,
+      'MCP-Protocol-Version',
+      'Mcp-Method',
+      'Mcp-Name',
+    ].join(', '),
+  );
 
   const isMcpEndpoint = pathname === '/mcp' || pathname === '/mcp/sse';
   if (originValue && isMcpEndpoint && !sameOrigin && !corsAllowedOrigins.has(originValue)) {

--- a/src/transports/http/tenant-event-bus.ts
+++ b/src/transports/http/tenant-event-bus.ts
@@ -1,0 +1,65 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type {
+  ServerEvent,
+  ServerEventBus,
+} from '@modelcontextprotocol/server';
+
+const subscriptionTenantStore = new AsyncLocalStorage<string>();
+
+export function runWithSubscriptionTenant<T>(
+  tenantId: string,
+  callback: () => T,
+): T {
+  return subscriptionTenantStore.run(tenantId, callback);
+}
+
+interface TenantListener {
+  tenantId?: string;
+  listener: (event: ServerEvent) => void;
+}
+
+/**
+ * Keeps modern HTTP change streams inside the authenticated tenant that
+ * opened them. Global registry events can still be broadcast explicitly.
+ */
+export class TenantScopedServerEventBus implements ServerEventBus {
+  private readonly listeners = new Set<TenantListener>();
+
+  constructor(private readonly onerror?: (error: Error) => void) {}
+
+  publish(event: ServerEvent): void {
+    for (const entry of this.listeners) {
+      this.deliver(entry.listener, event);
+    }
+  }
+
+  publishForTenant(event: ServerEvent, tenantId: string): void {
+    for (const entry of this.listeners) {
+      if (entry.tenantId !== tenantId) continue;
+      this.deliver(entry.listener, event);
+    }
+  }
+
+  subscribe(listener: (event: ServerEvent) => void): () => void {
+    const entry: TenantListener = {
+      tenantId: subscriptionTenantStore.getStore(),
+      listener,
+    };
+    this.listeners.add(entry);
+    return () => {
+      this.listeners.delete(entry);
+    };
+  }
+
+  get listenerCount(): number {
+    return this.listeners.size;
+  }
+
+  private deliver(listener: (event: ServerEvent) => void, event: ServerEvent): void {
+    try {
+      listener(event);
+    } catch (error) {
+      this.onerror?.(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+}

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -43,6 +43,11 @@ export interface MCPTransport {
   /** Send to one logical MCP session when the transport supports it. */
   sendToSession?(sessionId: string, response: MCPResponse): boolean;
 
+  /** Publish modern subscription events without broadcasting to legacy SSE clients. */
+  publishToolsChanged?(): void;
+  publishResourcesChanged?(tenantId?: string): void;
+  publishResourceUpdated?(uri: string, tenantId?: string): void;
+
   /** Register cleanup for logical MCP session close/disconnect when supported. */
   onSessionClose?(handler: (sessionId: string) => void): void;
 
@@ -99,6 +104,6 @@ export function createTransport(mode: TransportMode, options?: TransportOptions)
     );
   }
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { StdioTransport } = require('./stdio');
-  return new StdioTransport();
+  const { SdkStdioTransport } = require('./sdk-stdio');
+  return new SdkStdioTransport();
 }

--- a/src/transports/sdk-stdio.ts
+++ b/src/transports/sdk-stdio.ts
@@ -1,0 +1,180 @@
+/**
+ * Dual-era stdio transport backed by the official MCP TypeScript SDK.
+ *
+ * The SDK owns opening-message negotiation: legacy clients initialize as
+ * before, while 2026-07-28 clients can start with server/discover and carry
+ * the required envelope on every request.
+ */
+
+import * as crypto from 'node:crypto';
+import { serveStdio, type StdioServerHandle } from '@modelcontextprotocol/server/stdio';
+import type { Server, Transport } from '@modelcontextprotocol/server';
+import {
+  createSdkServerAdapter,
+  type CoreMcpMessageHandler,
+} from '../mcp/sdk-adapter';
+import type { MCPResponse } from '../types/mcp';
+import type { MCPTransport } from './index';
+import { shutdownSyncBestEffort } from '../utils/sync-shutdown';
+
+type SessionCloseHandler = (sessionId: string) => void;
+
+export class SdkStdioTransport implements MCPTransport {
+  private messageHandler: CoreMcpMessageHandler | null = null;
+  private handle: StdioServerHandle | null = null;
+  private readonly servers = new Map<
+    string,
+    { server: Server; era: 'legacy' | 'modern'; legacySessionId?: string }
+  >();
+  private sessionCloseHandler: SessionCloseHandler | null = null;
+  private started = false;
+
+  constructor(private readonly wire?: Transport) {}
+
+  private readonly onStdinEnd = (): void => {
+    console.error('[SdkStdioTransport] stdin ended, shutting down...');
+    try { shutdownSyncBestEffort(); } catch { /* never throw at exit */ }
+    process.exit(0);
+  };
+
+  private readonly onStdinError = (): void => {
+    console.error('[SdkStdioTransport] stdin error, shutting down...');
+    try { shutdownSyncBestEffort(); } catch { /* never throw at exit */ }
+    process.exit(1);
+  };
+
+  onMessage(handler: CoreMcpMessageHandler): void {
+    this.messageHandler = handler;
+  }
+
+  onSessionClose(handler: SessionCloseHandler): void {
+    this.sessionCloseHandler = handler;
+  }
+
+  start(): void {
+    if (this.started) return;
+    if (!this.messageHandler) {
+      throw new Error('SdkStdioTransport requires a message handler before start()');
+    }
+    this.started = true;
+
+    this.handle = serveStdio(
+      ({ era }) => {
+        const key = crypto.randomUUID();
+        const legacySessionId = era === 'legacy' ? `stdio-${key}` : undefined;
+        const server = createSdkServerAdapter(this.messageHandler!, {
+          era,
+          ...(legacySessionId ? { mcpSessionId: legacySessionId } : {}),
+        });
+        this.servers.set(key, { server, era, legacySessionId });
+
+        const previousOnClose = server.onclose;
+        server.onclose = () => {
+          this.servers.delete(key);
+          if (legacySessionId) {
+            this.sessionCloseHandler?.(legacySessionId);
+          }
+          previousOnClose?.();
+        };
+        return server;
+      },
+      {
+        legacy: 'serve',
+        ...(this.wire ? { transport: this.wire } : {}),
+        onerror: (error) => {
+          console.error('[SdkStdioTransport] MCP SDK error:', error);
+        },
+      },
+    );
+
+    if (!this.wire) {
+      process.stdin.once('end', this.onStdinEnd);
+      process.stdin.once('error', this.onStdinError);
+    }
+  }
+
+  send(response: MCPResponse): void {
+    for (const { server, era } of this.servers.values()) {
+      if (era === 'legacy') {
+        this.sendNotification(server, response);
+      }
+    }
+  }
+
+  sendToSession(sessionId: string, response: MCPResponse): boolean {
+    for (const entry of this.servers.values()) {
+      if (entry.legacySessionId !== sessionId) continue;
+      this.sendNotification(entry.server, response);
+      return true;
+    }
+    return false;
+  }
+
+  publishToolsChanged(): void {
+    this.publishModern((server) => server.sendToolListChanged());
+  }
+
+  publishResourcesChanged(_tenantId?: string): void {
+    this.publishModern((server) => server.sendResourceListChanged());
+  }
+
+  publishResourceUpdated(uri: string, _tenantId?: string): void {
+    this.publishModern((server) => server.sendResourceUpdated({ uri }));
+  }
+
+  async close(): Promise<void> {
+    process.stdin.removeListener('end', this.onStdinEnd);
+    process.stdin.removeListener('error', this.onStdinError);
+    const handle = this.handle;
+    this.handle = null;
+    this.started = false;
+    if (handle) {
+      await handle.close();
+    }
+    this.servers.clear();
+  }
+
+  private sendNotification(server: Server, response: MCPResponse): void {
+    const notification = response as unknown as {
+      method?: string;
+      params?: Record<string, unknown>;
+    };
+    let pending: Promise<unknown> | undefined;
+    switch (notification.method) {
+      case 'notifications/tools/list_changed':
+        pending = server.sendToolListChanged();
+        break;
+      case 'notifications/resources/list_changed':
+        pending = server.sendResourceListChanged();
+        break;
+      case 'notifications/resources/updated':
+        if (typeof notification.params?.uri === 'string') {
+          pending = server.sendResourceUpdated({ uri: notification.params.uri });
+        }
+        break;
+      case 'notifications/message': {
+        const level = notification.params?.level;
+        if (typeof level === 'string') {
+          pending = server.sendLoggingMessage(
+            notification.params as Parameters<typeof server.sendLoggingMessage>[0],
+          );
+        }
+        break;
+      }
+      default:
+        break;
+    }
+    void pending?.catch((error) => {
+      console.error('[SdkStdioTransport] notification failed:', error);
+    });
+  }
+
+  private publishModern(send: (server: Server) => Promise<unknown>): void {
+    for (const entry of this.servers.values()) {
+      if (entry.era !== 'modern') continue;
+      void send(entry.server).catch((error) => {
+        console.error('[SdkStdioTransport] subscription event failed:', error);
+      });
+    }
+  }
+}

--- a/tests/cli/doctor/checks/node-version.test.ts
+++ b/tests/cli/doctor/checks/node-version.test.ts
@@ -12,7 +12,7 @@ describe('check: node-version', () => {
   });
 
   test('ok when current Node meets minimum', async () => {
-    // Current Node is always >= 18 in this project's CI
+    // Current Node is always >= 20 in this project's CI
     const result = await checkNodeVersion();
     expect(result.id).toBe('node-version');
     expect(result.title).toBe('Node.js version');

--- a/tests/cross-env/cursor-verification.test.ts
+++ b/tests/cross-env/cursor-verification.test.ts
@@ -413,14 +413,14 @@ suiteRunner('Cross-Env: Cursor IDE Verification (Issue #509)', () => {
       }
     });
 
-    test('Unknown client initializes with listChanged=false', async () => {
+    test('Unknown client sees the server list-change capability', async () => {
       const { response } = await sendAndReceive(unknownServer, 'initialize', {
         protocolVersion: '2024-11-05',
         capabilities: {},
         clientInfo: { name: 'unknown-editor', version: '1.0.0' },
       });
 
-      expect(response.result.capabilities.tools.listChanged).toBe(false);
+      expect(response.result.capabilities.tools.listChanged).toBe(true);
     });
 
     test('Unknown client gets all tools immediately (no expand_tools)', async () => {

--- a/tests/mcp-progressive-disclosure.test.ts
+++ b/tests/mcp-progressive-disclosure.test.ts
@@ -17,6 +17,7 @@ import { getSessionManager } from '../src/session-manager';
 import { MCPServer } from '../src/mcp-server';
 import { runWithRequestContext } from '../src/observability/request-id';
 import { registerAllTools } from '../src/tools';
+import type { Principal } from '../src/auth/api-key-types';
 import type { MCPResponse } from '../src/types/mcp';
 import type { MCPTransport } from '../src/transports';
 
@@ -152,6 +153,50 @@ describe('MCP progressive disclosure client detection', () => {
       'drag_drop',
       'workflow_init',
     ]));
+  });
+
+  test('modern tool discovery is filtered by the authenticated principal scopes', async () => {
+    const server = makeServer();
+    const readPrincipal: Principal = {
+      tenantId: 'tenant-read',
+      keyId: 'key-read',
+      scopes: ['read'],
+      mode: 'api-key',
+    };
+    const listed = await runWithRequestContext(
+      {
+        requestId: 'req-modern-read-scope',
+        protocolEra: 'modern',
+        tenantId: readPrincipal.tenantId,
+        keyId: readPrincipal.keyId,
+        clientInfo: { name: 'scoped-client', version: '1.0.0' },
+        clientCapabilities: { tools: { listChanged: true } },
+      },
+      () => server.handleRequest(
+        {
+          jsonrpc: '2.0',
+          id: 21,
+          method: 'tools/list',
+          params: {},
+        },
+        readPrincipal,
+      ),
+    ) as TestResponse;
+    const tools = (listed.result?.tools ?? []).map((tool) => tool.name);
+
+    expect(tools).toEqual(expect.arrayContaining([
+      'read_page',
+      'tabs_search',
+      'oc_connection_health',
+    ]));
+    for (const toolName of [
+      'navigate',
+      'workflow_init',
+      'oc_stop',
+      'expand_tools',
+    ]) {
+      expect(tools).not.toContain(toolName);
+    }
   });
 
   test('client detection is isolated between HTTP MCP sessions', async () => {

--- a/tests/mcp-progressive-disclosure.test.ts
+++ b/tests/mcp-progressive-disclosure.test.ts
@@ -225,4 +225,29 @@ describe('MCP progressive disclosure client detection', () => {
     const reset = await initializeAndList(server, 'opencode', {}, 'session-a');
     expect(reset.tools).not.toContain('drag_drop');
   });
+
+  test('global list changes reach legacy and modern clients on every transport', () => {
+    const transports = Array.from({ length: 2 }, () => ({
+      onMessage: jest.fn(),
+      send: jest.fn(),
+      publishToolsChanged: jest.fn(),
+      start: jest.fn(),
+      close: jest.fn().mockResolvedValue(undefined),
+    } satisfies MCPTransport));
+    const server = makeServer();
+    for (const transport of transports) {
+      server.wireRateLimiterCleanup(transport);
+    }
+
+    server.emitListChanged();
+
+    for (const transport of transports) {
+      expect(transport.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'notifications/tools/list_changed',
+        }),
+      );
+      expect(transport.publishToolsChanged).toHaveBeenCalledTimes(1);
+    }
+  });
 });

--- a/tests/mcp-progressive-disclosure.test.ts
+++ b/tests/mcp-progressive-disclosure.test.ts
@@ -127,6 +127,33 @@ describe('MCP progressive disclosure client detection', () => {
     expect(tools.length).toBeGreaterThanOrEqual(118);
   });
 
+  test('modern requests expose a stateless full tool surface', async () => {
+    const server = makeServer();
+    const listed = await runWithRequestContext(
+      {
+        requestId: 'req-modern',
+        protocolEra: 'modern',
+        clientInfo: { name: 'opencode', version: '1.0.0' },
+        clientCapabilities: { tools: { listChanged: true } },
+      },
+      () => server.handleRequest({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/list',
+        params: {},
+      }),
+    ) as TestResponse;
+    const tools = (listed.result?.tools ?? []).map((tool) => tool.name);
+
+    expect(tools).not.toContain('expand_tools');
+    expect(tools.length).toBeGreaterThanOrEqual(118);
+    expect(tools).toEqual(expect.arrayContaining([
+      'navigate',
+      'drag_drop',
+      'workflow_init',
+    ]));
+  });
+
   test('client detection is isolated between HTTP MCP sessions', async () => {
     const server = makeServer();
 

--- a/tests/mcp-server-result-accounting.test.ts
+++ b/tests/mcp-server-result-accounting.test.ts
@@ -48,11 +48,13 @@ import type { Principal } from '../src/auth/api-key-types';
 import { EMPTY_SECRET_STORE, makeSecretStore, setSecretStore } from '../src/core/secrets';
 import { getActivityTracker } from '../src/dashboard/activity-tracker';
 import { getDashboardState } from '../src/desktop/dashboard-state';
+import { McpInputRequiredError } from '../src/errors/mcp-input-required';
 import { getMetricsCollector } from '../src/metrics/collector';
 import { PRINCIPAL_SYM } from '../src/middleware/auth';
 import { logAuditEntry } from '../src/security/audit-logger';
 import { recordTaskToolCall } from '../src/core/task-ledger';
 import * as taskJournal from '../src/journal/task-journal';
+import * as runHarnessStore from '../src/run-harness/store';
 import { TABS_SEARCH_MAX_RESPONSE_BYTES } from '../src/config/defaults';
 
 describe('MCPServer returned-error accounting', () => {
@@ -196,6 +198,106 @@ describe('MCPServer returned-error accounting', () => {
       false,
       'invalid query',
     );
+  });
+
+  test('settles first-round tracking when a tool requires modern MCP input', async () => {
+    const sessionId = 'input-required-session';
+    server = new MCPServer({
+      getOrCreateSession: jest.fn().mockResolvedValue({ id: sessionId }),
+      addEventListener: jest.fn(),
+      cleanupAllSessions: jest.fn().mockResolvedValue(undefined),
+      getStats: jest.fn(() => ({ totalTargets: 0 })),
+      sessionCount: 0,
+    } as any);
+    const toolName = `input_required_accounting_${Date.now()}`;
+    const inputResult = {
+      resultType: 'input_required',
+      inputRequests: {
+        confirm: {
+          type: 'elicitation',
+          message: 'Continue?',
+        },
+      },
+    };
+    const runStore = {
+      appendToolStarted: jest.fn(),
+      appendToolFinished: jest.fn(),
+      appendRunEvent: jest.fn(),
+    };
+    jest.spyOn(runHarnessStore, 'getRunStore').mockReturnValue(runStore as any);
+    server.registerTool(
+      toolName,
+      jest.fn(() => {
+        throw new McpInputRequiredError(inputResult);
+      }),
+      {
+        name: toolName,
+        description: 'input required accounting test',
+        inputSchema: { type: 'object', properties: {} },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+      },
+    );
+
+    await expect(server.handleRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: toolName,
+        arguments: { run_id: 'run-input-required' },
+        sessionId,
+      },
+    } as any)).rejects.toMatchObject({ result: inputResult });
+
+    expect(
+      getActivityTracker().getActiveCalls()
+        .filter((call) => call.toolName === toolName),
+    ).toHaveLength(0);
+    expect(
+      getActivityTracker().getRecentCalls(20, sessionId)
+        .find((call) => call.toolName === toolName),
+    ).toMatchObject({ result: 'input_required' });
+    expect(
+      getDashboardState().getToolCalls(sessionId)
+        .find((call) => call.toolName === toolName),
+    ).toMatchObject({ status: 'input_required' });
+    expect(
+      getDashboardState().getToolCallTotals()
+        .filter((row) => row.toolName === toolName),
+    ).toHaveLength(0);
+    expect(logAuditEntry).not.toHaveBeenCalledWith(
+      toolName,
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(recordTaskToolCall).not.toHaveBeenCalled();
+    expect(journal.record).not.toHaveBeenCalled();
+    expect(runStore.appendToolStarted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        run_id: 'run-input-required',
+        tool: toolName,
+      }),
+    );
+    expect(runStore.appendToolFinished).toHaveBeenCalledWith(
+      expect.objectContaining({
+        run_id: 'run-input-required',
+        tool: toolName,
+        metadata: { stage: 'input_required' },
+      }),
+    );
+
+    const cdpClient = (jest.requireMock('../src/cdp/client') as {
+      getCDPClient: jest.Mock;
+    }).getCDPClient();
+    expect(cdpClient.setHeartbeatMode).toHaveBeenCalledWith('heavy');
+    expect(cdpClient.setHeartbeatMode).toHaveBeenCalledWith('active');
   });
 
   test('bounds and redacts returned error summaries before persistence', async () => {

--- a/tests/resources/live-state.test.ts
+++ b/tests/resources/live-state.test.ts
@@ -4,6 +4,7 @@ import {
   parseResourceSubscriptionLimit,
   ResourceRpcError,
   assertLiveResourceAccess,
+  liveResourceDefinitions,
   readLiveResource,
   RESOURCE_FORBIDDEN_CODE,
 } from '../../src/resources/live-state';
@@ -49,6 +50,27 @@ describe('live MCP resources (#872)', () => {
     } catch (err) {
       expect((err as ResourceRpcError).code).toBe(RESOURCE_FORBIDDEN_CODE);
     }
+  });
+
+  test('lists concrete session resources only for the current tenant', () => {
+    const sessionManager = {
+      getAllSessionInfos: () => [
+        { id: 'owned', tenantId: 'default' },
+        { id: 'other', tenantId: 'tenant-b' },
+      ],
+    } as any;
+
+    const uris = liveResourceDefinitions(sessionManager, 'default').map(
+      (resource) => resource.uri,
+    );
+    expect(uris).toEqual(expect.arrayContaining([
+      'oc://session/owned/tabs',
+      'oc://session/owned/state',
+    ]));
+    expect(uris).not.toEqual(expect.arrayContaining([
+      'oc://session/other/tabs',
+      'oc://session/other/state',
+    ]));
   });
 
   test('does not expose journal entries after the owner session is gone', async () => {

--- a/tests/transports/http-bearer-auth.test.ts
+++ b/tests/transports/http-bearer-auth.test.ts
@@ -224,11 +224,26 @@ describe('HTTP Bearer Token Auth', () => {
       expect(res.status).toBe(401);
     });
 
-    it('allows CORS preflight without Origin and includes Authorization header', async () => {
+    it('allows CORS preflight without Origin and includes auth and modern MCP headers', async () => {
       const res = await request('/mcp', 'OPTIONS');
       expect(res.status).toBe(204);
       const allowHeaders = res.headers['access-control-allow-headers'] as string;
-      expect(allowHeaders).toContain('Authorization');
+      for (const header of [
+        'Authorization',
+        'MCP-Protocol-Version',
+        'Mcp-Method',
+        'Mcp-Name',
+      ]) {
+        expect(allowHeaders).toContain(header);
+      }
+      const exposeHeaders = res.headers['access-control-expose-headers'] as string;
+      for (const header of [
+        'MCP-Protocol-Version',
+        'Mcp-Method',
+        'Mcp-Name',
+      ]) {
+        expect(exposeHeaders).toContain(header);
+      }
     });
   });
 

--- a/tests/transports/http-modern-mcp.test.ts
+++ b/tests/transports/http-modern-mcp.test.ts
@@ -325,6 +325,8 @@ describe('MCP 2026-07-28 HTTP boundary', () => {
       expect.objectContaining({ name: 'echo' }),
     ]));
     expect(response.headers['mcp-session-id']).toBeUndefined();
+    expect(response.headers['x-request-id']).toEqual(expect.any(String));
+    expect(contexts.at(-1)?.requestId).toBe(response.headers['x-request-id']);
   });
 
   test('preserves tenant and broker identity without a protocol session', async () => {

--- a/tests/transports/http-modern-mcp.test.ts
+++ b/tests/transports/http-modern-mcp.test.ts
@@ -1,0 +1,487 @@
+/// <reference types="jest" />
+
+import * as http from 'node:http';
+import {
+  currentRequestContext,
+  type RequestContext,
+} from '../../src/observability/request-id';
+import { HTTPTransport } from '../../src/transports/http';
+
+const TEST_PORT = 19879;
+const VERSION = '2026-07-28';
+
+function envelope(capabilities: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    'io.modelcontextprotocol/protocolVersion': VERSION,
+    'io.modelcontextprotocol/clientCapabilities': capabilities,
+    'io.modelcontextprotocol/clientInfo': { name: 'openchrome-modern-test', version: '1.0.0' },
+  };
+}
+
+function request(
+  body: Record<string, unknown>,
+  method: string,
+  name?: string,
+  extraHeaders: http.OutgoingHttpHeaders = {},
+): Promise<{ status: number; body: Record<string, unknown>; headers: http.IncomingHttpHeaders }> {
+  const serialized = JSON.stringify(body);
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port: TEST_PORT,
+        path: '/mcp',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+          'MCP-Protocol-Version': VERSION,
+          'Mcp-Method': method,
+          ...(name ? { 'Mcp-Name': name } : {}),
+          'Content-Length': Buffer.byteLength(serialized),
+          ...extraHeaders,
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => {
+          const raw = Buffer.concat(chunks).toString('utf8');
+          resolve({
+            status: res.statusCode ?? 0,
+            body: raw ? JSON.parse(raw) as Record<string, unknown> : {},
+            headers: res.headers,
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end(serialized);
+  });
+}
+
+function requestWithoutBody(
+  method: 'GET' | 'DELETE',
+  path = '/mcp',
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port: TEST_PORT,
+        path,
+        method,
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          'MCP-Protocol-Version': VERSION,
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => {
+          const raw = Buffer.concat(chunks).toString('utf8');
+          resolve({
+            status: res.statusCode ?? 0,
+            body: raw ? JSON.parse(raw) as Record<string, unknown> : {},
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+interface SubscriptionHarness {
+  messages: Array<Record<string, unknown>>;
+  waitFor: (
+    predicate: (message: Record<string, unknown>) => boolean,
+  ) => Promise<Record<string, unknown>>;
+  close: () => void;
+}
+
+function openResourceSubscription(
+  tenantId: string,
+  uri: string,
+): Promise<SubscriptionHarness> {
+  const serialized = JSON.stringify({
+    jsonrpc: '2.0',
+    id: `listen-${tenantId}`,
+    method: 'subscriptions/listen',
+    params: {
+      notifications: { resourceSubscriptions: [uri] },
+      _meta: envelope(),
+    },
+  });
+
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port: TEST_PORT,
+        path: '/mcp',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+          'MCP-Protocol-Version': VERSION,
+          'Mcp-Method': 'subscriptions/listen',
+          'X-Tenant-Id': tenantId,
+          'Content-Length': Buffer.byteLength(serialized),
+        },
+      },
+      (res) => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`Subscription returned HTTP ${res.statusCode}`));
+          res.resume();
+          return;
+        }
+
+        const messages: Array<Record<string, unknown>> = [];
+        const waiters: Array<{
+          predicate: (message: Record<string, unknown>) => boolean;
+          resolve: (message: Record<string, unknown>) => void;
+        }> = [];
+        let buffer = '';
+
+        res.setEncoding('utf8');
+        res.on('data', (chunk: string) => {
+          buffer += chunk;
+          while (buffer.includes('\n')) {
+            const newline = buffer.indexOf('\n');
+            const line = buffer.slice(0, newline).trim();
+            buffer = buffer.slice(newline + 1);
+            if (!line.startsWith('data:')) continue;
+            const message = JSON.parse(line.slice(5).trim()) as Record<string, unknown>;
+            messages.push(message);
+            const index = waiters.findIndex((waiter) => waiter.predicate(message));
+            if (index !== -1) {
+              const [waiter] = waiters.splice(index, 1);
+              waiter.resolve(message);
+            }
+          }
+        });
+
+        resolve({
+          messages,
+          waitFor: (predicate) => {
+            const existing = messages.find(predicate);
+            if (existing) return Promise.resolve(existing);
+            return new Promise((resolveMessage, rejectMessage) => {
+              const timer = setTimeout(
+                () => rejectMessage(
+                  new Error(`Timed out waiting for subscription message: ${JSON.stringify(messages)}`),
+                ),
+                3_000,
+              );
+              waiters.push({
+                predicate,
+                resolve: (message) => {
+                  clearTimeout(timer);
+                  resolveMessage(message);
+                },
+              });
+            });
+          },
+          close: () => res.destroy(),
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end(serialized);
+  });
+}
+
+describe('MCP 2026-07-28 HTTP boundary', () => {
+  let transport: HTTPTransport;
+  const calls: string[] = [];
+  const contexts: RequestContext[] = [];
+
+  beforeAll(async () => {
+    transport = new HTTPTransport(
+      TEST_PORT,
+      '127.0.0.1',
+      undefined,
+      { allowUnauthenticatedHttp: true },
+    );
+    transport.onMessage(async (message) => {
+      const method = String(message.method);
+      calls.push(method);
+      const context = currentRequestContext();
+      if (context) contexts.push({ ...context });
+      if (method === 'tools/list') {
+        return {
+          jsonrpc: '2.0',
+          id: message.id as number,
+          result: {
+            tools: [{
+              name: 'echo',
+              description: 'Echo test input',
+              inputSchema: {
+                type: 'object',
+                properties: { text: { type: 'string' } },
+              },
+              annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false,
+              },
+            }],
+          },
+        };
+      }
+      if (method === 'tools/call') {
+        const params = message.params as { name?: string } | undefined;
+        if (params?.name === 'confirm') {
+          const bridge = currentRequestContext()?.requestClient;
+          if (!bridge) throw new Error('requestClient bridge missing');
+          const answer = await bridge<{ action: string; content?: { confirm?: boolean } }>(
+            'elicitation/create',
+            {
+              message: 'Continue?',
+              requestedSchema: {
+                type: 'object',
+                properties: { confirm: { type: 'boolean' } },
+                required: ['confirm'],
+              },
+            },
+          );
+          return {
+            jsonrpc: '2.0',
+            id: message.id as number,
+            result: {
+              content: [{
+                type: 'text',
+                text: answer.action === 'accept' && answer.content?.confirm === true
+                  ? 'confirmed'
+                  : 'declined',
+              }],
+            },
+          };
+        }
+        return {
+          jsonrpc: '2.0',
+          id: message.id as number,
+          result: { content: [{ type: 'text', text: 'ok' }] },
+        };
+      }
+      return {
+        jsonrpc: '2.0',
+        id: message.id as number,
+        error: { code: -32601, message: `Unknown method: ${method}` },
+      };
+    });
+    transport.start();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  });
+
+  afterAll(async () => {
+    await transport.close();
+  });
+
+  test('serves server/discover without initialize', async () => {
+    const response = await request(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'server/discover',
+        params: { _meta: envelope() },
+      },
+      'server/discover',
+    );
+
+    expect(response.status).toBe(200);
+    const result = response.body.result as Record<string, unknown>;
+    expect(result.supportedVersions).toEqual([VERSION]);
+    expect(result.resultType).toBe('complete');
+    expect(result._meta).toMatchObject({
+      'io.modelcontextprotocol/serverInfo': {
+        name: 'openchrome',
+      },
+    });
+    expect(response.headers['mcp-session-id']).toBeUndefined();
+    expect(calls).not.toContain('server/discover');
+  });
+
+  test('serves cacheable requests statelessly with modern result metadata', async () => {
+    const response = await request(
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/list',
+        params: { _meta: envelope() },
+      },
+      'tools/list',
+    );
+
+    expect(response.status).toBe(200);
+    const result = response.body.result as Record<string, unknown>;
+    expect(result.resultType).toBe('complete');
+    expect(result.ttlMs).toBe(30_000);
+    expect(result.cacheScope).toBe('private');
+    expect(result.tools).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'echo' }),
+    ]));
+    expect(response.headers['mcp-session-id']).toBeUndefined();
+  });
+
+  test('preserves tenant and broker identity without a protocol session', async () => {
+    const legacyState = transport as unknown as {
+      sessionTenants: Map<string, string>;
+    };
+    legacyState.sessionTenants.set('stale-legacy-session', 'different-tenant');
+
+    const response = await request(
+      {
+        jsonrpc: '2.0',
+        id: 20,
+        method: 'tools/list',
+        params: { _meta: envelope() },
+      },
+      'tools/list',
+      undefined,
+      {
+        'X-Tenant-Id': 'tenant-modern',
+        'X-OpenChrome-Broker-Client-Id': 'broker-modern',
+        'Mcp-Session-Id': 'stale-legacy-session',
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(contexts.at(-1)).toMatchObject({
+      tenantId: 'tenant-modern',
+      brokerClientId: 'broker-modern',
+      protocolEra: 'modern',
+    });
+    expect(response.headers['mcp-session-id']).toBeUndefined();
+  });
+
+  test('rejects an Mcp-Name/header mismatch before dispatch', async () => {
+    const before = calls.length;
+    const response = await request(
+      {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'echo',
+          arguments: { text: 'hello' },
+          _meta: envelope(),
+        },
+      },
+      'tools/call',
+      'different-tool',
+    );
+
+    expect(response.status).toBe(400);
+    expect((response.body.error as { code: number }).code).toBe(-32020);
+    expect(calls).toHaveLength(before);
+  });
+
+  test('converts client requests into input_required and resumes on retry', async () => {
+    const capabilities = { elicitation: { form: {} } };
+    const first = await request(
+      {
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: {
+          name: 'confirm',
+          arguments: {},
+          _meta: envelope(capabilities),
+        },
+      },
+      'tools/call',
+      'confirm',
+    );
+
+    expect(first.status).toBe(200);
+    const firstResult = first.body.result as {
+      resultType: string;
+      inputRequests: Record<string, unknown>;
+    };
+    expect(firstResult.resultType).toBe('input_required');
+    const [responseKey] = Object.keys(firstResult.inputRequests);
+    expect(responseKey).toBe('openchrome_1_elicitation_create');
+
+    const second = await request(
+      {
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'tools/call',
+        params: {
+          name: 'confirm',
+          arguments: {},
+          inputResponses: {
+            [responseKey]: { action: 'accept', content: { confirm: true } },
+          },
+          _meta: envelope(capabilities),
+        },
+      },
+      'tools/call',
+      'confirm',
+    );
+
+    expect(second.status).toBe(200);
+    const secondResult = second.body.result as {
+      resultType: string;
+      content: Array<{ text: string }>;
+    };
+    expect(secondResult.resultType).toBe('complete');
+    expect(secondResult.content[0].text).toBe('confirmed');
+  });
+
+  test('keeps resource subscription events inside the authenticated tenant', async () => {
+    const uri = 'oc://session/shared-name/state';
+    const tenantA = await openResourceSubscription('tenant-a', uri);
+    const tenantB = await openResourceSubscription('tenant-b', uri);
+
+    try {
+      await tenantA.waitFor(
+        (message) => message.method === 'notifications/subscriptions/acknowledged',
+      );
+      await tenantB.waitFor(
+        (message) => message.method === 'notifications/subscriptions/acknowledged',
+      );
+
+      transport.publishResourceUpdated(uri, 'tenant-a');
+      await tenantA.waitFor(
+        (message) => message.method === 'notifications/resources/updated',
+      );
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(tenantB.messages).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ method: 'notifications/resources/updated' }),
+      ]));
+    } finally {
+      tenantA.close();
+      tenantB.close();
+    }
+  });
+
+  test('rejects removed methods and legacy HTTP verbs on the modern path', async () => {
+    const removed = await request(
+      {
+        jsonrpc: '2.0',
+        id: 30,
+        method: 'resources/subscribe',
+        params: {
+          uri: 'oc://sessions',
+          _meta: envelope(),
+        },
+      },
+      'resources/subscribe',
+    );
+    expect(removed.status).toBe(404);
+    expect((removed.body.error as { code: number }).code).toBe(-32601);
+
+    const get = await requestWithoutBody('GET');
+    expect(get.status).toBe(405);
+    const legacySseAlias = await requestWithoutBody('GET', '/mcp/sse');
+    expect(legacySseAlias.status).toBe(405);
+    const removeSession = await requestWithoutBody('DELETE');
+    expect(removeSession.status).toBe(405);
+  });
+});

--- a/tests/transports/http-tenant-event-bus.test.ts
+++ b/tests/transports/http-tenant-event-bus.test.ts
@@ -1,0 +1,30 @@
+import {
+  runWithSubscriptionTenant,
+  TenantScopedServerEventBus,
+} from '../../src/transports/http/tenant-event-bus';
+
+describe('modern HTTP tenant event bus', () => {
+  test('scopes resource events while retaining explicit global events', () => {
+    const bus = new TenantScopedServerEventBus();
+    const tenantA: string[] = [];
+    const tenantB: string[] = [];
+
+    runWithSubscriptionTenant('tenant-a', () => {
+      bus.subscribe((event) => tenantA.push(event.kind));
+    });
+    runWithSubscriptionTenant('tenant-b', () => {
+      bus.subscribe((event) => tenantB.push(event.kind));
+    });
+
+    bus.publishForTenant(
+      { kind: 'resource_updated', uri: 'oc://session/a/state' },
+      'tenant-a',
+    );
+    expect(tenantA).toEqual(['resource_updated']);
+    expect(tenantB).toEqual([]);
+
+    bus.publish({ kind: 'tools_list_changed' });
+    expect(tenantA).toEqual(['resource_updated', 'tools_list_changed']);
+    expect(tenantB).toEqual(['tools_list_changed']);
+  });
+});

--- a/tests/transports/stdio-modern-mcp.test.ts
+++ b/tests/transports/stdio-modern-mcp.test.ts
@@ -1,0 +1,249 @@
+/// <reference types="jest" />
+
+import { PassThrough } from 'node:stream';
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
+import { currentRequestContext } from '../../src/observability/request-id';
+import type { MCPResponse } from '../../src/types/mcp';
+import { SdkStdioTransport } from '../../src/transports/sdk-stdio';
+
+const VERSION = '2026-07-28';
+
+function envelope(): Record<string, unknown> {
+  return {
+    'io.modelcontextprotocol/protocolVersion': VERSION,
+    'io.modelcontextprotocol/clientCapabilities': {},
+    'io.modelcontextprotocol/clientInfo': { name: 'openchrome-stdio-test', version: '1.0.0' },
+  };
+}
+
+interface Harness {
+  transport: SdkStdioTransport;
+  input: PassThrough;
+  messages: Array<Record<string, unknown>>;
+  waitFor: (
+    predicate: (message: Record<string, unknown>) => boolean,
+  ) => Promise<Record<string, unknown>>;
+}
+
+function createHarness(
+  handler: (
+    message: Record<string, unknown>,
+    signal?: AbortSignal,
+    context?: { mcpSessionId?: string },
+  ) => Promise<MCPResponse | null>,
+): Harness {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const messages: Array<Record<string, unknown>> = [];
+  const waiters: Array<{
+    predicate: (message: Record<string, unknown>) => boolean;
+    resolve: (message: Record<string, unknown>) => void;
+  }> = [];
+  let buffer = '';
+
+  output.setEncoding('utf8');
+  output.on('data', (chunk: string) => {
+    buffer += chunk;
+    while (buffer.includes('\n')) {
+      const newline = buffer.indexOf('\n');
+      const line = buffer.slice(0, newline).trim();
+      buffer = buffer.slice(newline + 1);
+      if (!line) continue;
+      const message = JSON.parse(line) as Record<string, unknown>;
+      messages.push(message);
+      const index = waiters.findIndex((waiter) => waiter.predicate(message));
+      if (index !== -1) {
+        const [waiter] = waiters.splice(index, 1);
+        waiter.resolve(message);
+      }
+    }
+  });
+
+  const wire = new StdioServerTransport(input, output);
+  const transport = new SdkStdioTransport(wire);
+  transport.onMessage(handler);
+  transport.start();
+
+  return {
+    transport,
+    input,
+    messages,
+    waitFor: (predicate) => {
+      const existing = messages.find(predicate);
+      if (existing) return Promise.resolve(existing);
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error(`Timed out waiting for stdio message: ${JSON.stringify(messages)}`)),
+          3_000,
+        );
+        waiters.push({
+          predicate,
+          resolve: (message) => {
+            clearTimeout(timer);
+            resolve(message);
+          },
+        });
+      });
+    },
+  };
+}
+
+function write(input: PassThrough, message: Record<string, unknown>): void {
+  input.write(`${JSON.stringify(message)}\n`);
+}
+
+describe('MCP 2026-07-28 stdio boundary', () => {
+  test('negotiates modern discovery and routes filtered subscriptions', async () => {
+    const harness = createHarness(async (message) => {
+      if (message.method === 'tools/list') {
+        return {
+          jsonrpc: '2.0',
+          id: message.id as number,
+          result: { tools: [] },
+        };
+      }
+      return {
+        jsonrpc: '2.0',
+        id: message.id as number,
+        error: { code: -32601, message: 'Unknown method' },
+      };
+    });
+
+    try {
+      write(harness.input, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'server/discover',
+        params: { _meta: envelope() },
+      });
+      const discovery = await harness.waitFor((message) => message.id === 1);
+      expect(discovery.result).toMatchObject({
+        resultType: 'complete',
+        supportedVersions: [VERSION],
+      });
+
+      write(harness.input, {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'subscriptions/listen',
+        params: {
+          notifications: { toolsListChanged: true },
+          _meta: envelope(),
+        },
+      });
+      const acknowledged = await harness.waitFor(
+        (message) => message.method === 'notifications/subscriptions/acknowledged',
+      );
+      expect(acknowledged.params).toMatchObject({
+        notifications: { toolsListChanged: true },
+        _meta: { 'io.modelcontextprotocol/subscriptionId': 2 },
+      });
+
+      harness.transport.publishToolsChanged();
+      const changed = await harness.waitFor(
+        (message) => message.method === 'notifications/tools/list_changed',
+      );
+      expect(changed.params).toMatchObject({
+        _meta: { 'io.modelcontextprotocol/subscriptionId': 2 },
+      });
+    } finally {
+      await harness.transport.close();
+    }
+  });
+
+  test('keeps legacy initialize and connection-scoped ids working', async () => {
+    let observedSessionId: string | undefined;
+    let observedRoots: unknown;
+    let rootsCompletion: Promise<void> | undefined;
+    const harness = createHarness(async (message, _signal, context) => {
+      if (
+        message.method === 'notifications/initialized' ||
+        message.method === 'notifications/roots/list_changed'
+      ) {
+        const requestClient = currentRequestContext()?.requestClient;
+        if (!requestClient) throw new Error('Legacy SDK request bridge missing');
+        rootsCompletion = requestClient('roots/list').then((roots) => {
+          observedRoots = roots;
+        });
+        await rootsCompletion;
+        return null;
+      }
+      if (message.method === 'tools/list') {
+        observedSessionId = context?.mcpSessionId;
+        return {
+          jsonrpc: '2.0',
+          id: message.id as number,
+          result: { tools: [] },
+        };
+      }
+      return null;
+    });
+
+    try {
+      write(harness.input, {
+        jsonrpc: '2.0',
+        id: 10,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'legacy-test', version: '1.0.0' },
+        },
+      });
+      const initialized = await harness.waitFor((message) => message.id === 10);
+      expect(initialized.result).toMatchObject({
+        protocolVersion: '2025-03-26',
+        serverInfo: { name: 'openchrome' },
+      });
+
+      write(harness.input, {
+        jsonrpc: '2.0',
+        method: 'notifications/initialized',
+      });
+      const rootsRequest = await harness.waitFor(
+        (message) => message.method === 'roots/list',
+      );
+      write(harness.input, {
+        jsonrpc: '2.0',
+        id: rootsRequest.id as string | number,
+        result: { roots: [{ uri: 'file:///workspace', name: 'workspace' }] },
+      });
+      await rootsCompletion;
+      expect(observedRoots).toEqual({
+        roots: [{ uri: 'file:///workspace', name: 'workspace' }],
+      });
+
+      observedRoots = undefined;
+      rootsCompletion = undefined;
+      write(harness.input, {
+        jsonrpc: '2.0',
+        method: 'notifications/roots/list_changed',
+      });
+      const refreshedRootsRequest = await harness.waitFor(
+        (message) =>
+          message.method === 'roots/list' &&
+          message.id !== rootsRequest.id,
+      );
+      write(harness.input, {
+        jsonrpc: '2.0',
+        id: refreshedRootsRequest.id as string | number,
+        result: { roots: [{ uri: 'file:///updated', name: 'updated' }] },
+      });
+      await rootsCompletion;
+      expect(observedRoots).toEqual({
+        roots: [{ uri: 'file:///updated', name: 'updated' }],
+      });
+
+      write(harness.input, {
+        jsonrpc: '2.0',
+        id: 11,
+        method: 'tools/list',
+        params: {},
+      });
+      await harness.waitFor((message) => message.id === 11);
+      expect(observedSessionId).toMatch(/^stdio-/);
+    } finally {
+      await harness.transport.close();
+    }
+  });
+});

--- a/tests/unit/mcp-roots-server.test.ts
+++ b/tests/unit/mcp-roots-server.test.ts
@@ -5,7 +5,10 @@ import { MCPServer } from '../../src/mcp-server';
 import { McpInputRequiredError } from '../../src/errors/mcp-input-required';
 import { TOOL_ANNOTATIONS } from '../../src/types/tool-annotations';
 import type { MCPToolDefinition } from '../../src/types/mcp';
-import { runWithRequestContext } from '../../src/observability/request-id';
+import {
+  runWithRequestContext,
+  type RequestContext,
+} from '../../src/observability/request-id';
 import {
   clearAllSessionMcpRoots,
   getSessionMcpRoots,
@@ -22,6 +25,27 @@ const navigateDefinition: MCPToolDefinition = {
   },
   annotations: TOOL_ANNOTATIONS.navigate,
 };
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function mockedSessionManager() {
+  return {
+    getOrCreateSession: jest.fn().mockResolvedValue({ id: 'browser-session' }),
+    addEventListener: jest.fn(),
+    cleanupAllSessions: jest.fn().mockResolvedValue(undefined),
+    getStats: jest.fn(() => ({ totalTargets: 0 })),
+    sessionCount: 0,
+  } as any;
+}
 
 describe('MCPServer roots narrowing integration (#880)', () => {
   afterEach(() => clearAllSessionMcpRoots());
@@ -69,7 +93,7 @@ describe('MCPServer roots narrowing integration (#880)', () => {
     ]);
   });
 
-  test('requests modern roots before URL egress and scopes the retry to the application session', async () => {
+  test('requests modern roots before URL egress and keeps the retry request-scoped', async () => {
     const server = new MCPServer(undefined, { initialToolTier: 3 });
     const handler = jest.fn(async () => ({
       content: [{ type: 'text' as const, text: 'should not run' }],
@@ -122,12 +146,11 @@ describe('MCPServer roots narrowing integration (#880)', () => {
       undefined,
       { timeoutMs: 250 },
     );
-    expect(getSessionMcpRoots('browser-session-modern')?.network).toEqual([
-      expect.objectContaining({ host: 'allowed.example.com' }),
-    ]);
+    expect(getSessionMcpRoots('browser-session-modern')).toBeUndefined();
     expect(handler).not.toHaveBeenCalled();
     expect(response.result?.isError).toBe(true);
     expect(response.result?.content?.[0]?.text).toContain('MCP roots narrowing');
+    expect(response.result?.content?.[0]?.text).toContain('https://allowed.example.com');
   });
 
   test('refreshes modern roots before enforcing file-output egress', async () => {
@@ -178,10 +201,103 @@ describe('MCPServer roots narrowing integration (#880)', () => {
       undefined,
       { timeoutMs: 250 },
     );
-    expect(getSessionMcpRoots('browser-session-modern-file')?.file).toHaveLength(1);
+    expect(getSessionMcpRoots('browser-session-modern-file')).toBeUndefined();
     expect(handler).not.toHaveBeenCalled();
     expect(response.result?.isError).toBe(true);
     expect(response.result?.content?.[0]?.text).toContain('Allowed file roots');
+  });
+
+  test('isolates concurrent modern roots for the same application session', async () => {
+    const server = new MCPServer(mockedSessionManager(), { initialToolTier: 3 });
+    const handler = jest.fn(async () => ({
+      content: [{ type: 'text' as const, text: 'should not run' }],
+    }));
+    const rootsA = deferred<{ roots: Array<{ uri: string }> }>();
+    const rootsB = deferred<{ roots: Array<{ uri: string }> }>();
+    const requestClientA: NonNullable<RequestContext['requestClient']> =
+      async <T>(): Promise<T> => await rootsA.promise as T;
+    const requestClientB: NonNullable<RequestContext['requestClient']> =
+      async <T>(): Promise<T> => await rootsB.promise as T;
+    server.registerTool('navigate', handler, navigateDefinition);
+
+    const callNavigate = (
+      requestId: string,
+      url: string,
+      requestClient: NonNullable<RequestContext['requestClient']>,
+    ) => runWithRequestContext(
+      {
+        requestId,
+        protocolEra: 'modern',
+        clientCapabilities: { roots: {} },
+        requestClient,
+      },
+      () => server.handleRequest({
+        jsonrpc: '2.0',
+        id: requestId,
+        method: 'tools/call',
+        params: {
+          name: 'navigate',
+          arguments: {
+            sessionId: 'shared-browser-session',
+            url,
+          },
+        },
+      }),
+    );
+
+    const pendingA = callNavigate(
+      'req-modern-roots-a',
+      'https://b.example.com/path',
+      requestClientA,
+    );
+    const pendingB = callNavigate(
+      'req-modern-roots-b',
+      'https://a.example.com/path',
+      requestClientB,
+    );
+    rootsA.resolve({ roots: [{ uri: 'https://a.example.com' }] });
+    rootsB.resolve({ roots: [{ uri: 'https://b.example.com' }] });
+
+    const [responseA, responseB] = await Promise.all([pendingA, pendingB]);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(responseA.result?.content?.[0]?.text).toContain('https://a.example.com');
+    expect(responseB.result?.content?.[0]?.text).toContain('https://b.example.com');
+    expect(getSessionMcpRoots('shared-browser-session')).toBeUndefined();
+  });
+
+  test('does not inherit cached roots when a modern request omits the capability', async () => {
+    const server = new MCPServer(mockedSessionManager(), { initialToolTier: 3 });
+    const handler = jest.fn(async () => ({
+      content: [{ type: 'text' as const, text: 'executed' }],
+    }));
+    server.registerTool('navigate', handler, navigateDefinition);
+    setSessionMcpRoots('browser-session-stale', {
+      roots: [{ uri: 'https://stale.example.com' }],
+    });
+
+    const response = await runWithRequestContext(
+      {
+        requestId: 'req-modern-without-roots',
+        protocolEra: 'modern',
+      },
+      () => server.handleRequest({
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'navigate',
+          arguments: {
+            sessionId: 'browser-session-stale',
+            url: 'https://current.example.com/path',
+          },
+        },
+      }),
+    );
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(response.result?.isError).not.toBe(true);
+    expect(response.result?.content?.[0]?.text).toBe('executed');
   });
 
   test('rejects URL-egress tools before handler execution when MCP network roots exclude the host', async () => {

--- a/tests/unit/mcp-roots-server.test.ts
+++ b/tests/unit/mcp-roots-server.test.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import { pathToFileURL } from 'url';
 
 import { MCPServer } from '../../src/mcp-server';
+import { McpInputRequiredError } from '../../src/errors/mcp-input-required';
 import { TOOL_ANNOTATIONS } from '../../src/types/tool-annotations';
 import type { MCPToolDefinition } from '../../src/types/mcp';
 import { runWithRequestContext } from '../../src/observability/request-id';
@@ -66,6 +67,121 @@ describe('MCPServer roots narrowing integration (#880)', () => {
     expect(getSessionMcpRoots('mcp-session-a')?.network).toEqual([
       expect.objectContaining({ host: 'allowed.example.com' }),
     ]);
+  });
+
+  test('requests modern roots before URL egress and scopes the retry to the application session', async () => {
+    const server = new MCPServer(undefined, { initialToolTier: 3 });
+    const handler = jest.fn(async () => ({
+      content: [{ type: 'text' as const, text: 'should not run' }],
+    }));
+    const inputRequired = {
+      resultType: 'input_required' as const,
+      inputRequests: {
+        openchrome_1_roots_list: {
+          type: 'roots',
+        },
+      },
+    };
+    const requestClient = jest.fn()
+      .mockRejectedValueOnce(new McpInputRequiredError(inputRequired))
+      .mockResolvedValueOnce({
+        roots: [{ uri: 'https://allowed.example.com' }],
+      });
+    server.registerTool('navigate', handler, navigateDefinition);
+
+    const callNavigate = () => runWithRequestContext(
+      {
+        requestId: 'req-modern-roots',
+        protocolEra: 'modern',
+        clientCapabilities: { roots: {} },
+        requestClient,
+      },
+      () => server.handleRequest({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'navigate',
+          arguments: {
+            sessionId: 'browser-session-modern',
+            url: 'https://denied.example.com/path',
+          },
+        },
+      }),
+    );
+
+    await expect(callNavigate()).rejects.toMatchObject({ result: inputRequired });
+    expect(handler).not.toHaveBeenCalled();
+    expect(getSessionMcpRoots('browser-session-modern')).toBeUndefined();
+
+    const response = await callNavigate();
+
+    expect(requestClient).toHaveBeenNthCalledWith(
+      2,
+      'roots/list',
+      undefined,
+      { timeoutMs: 250 },
+    );
+    expect(getSessionMcpRoots('browser-session-modern')?.network).toEqual([
+      expect.objectContaining({ host: 'allowed.example.com' }),
+    ]);
+    expect(handler).not.toHaveBeenCalled();
+    expect(response.result?.isError).toBe(true);
+    expect(response.result?.content?.[0]?.text).toContain('MCP roots narrowing');
+  });
+
+  test('refreshes modern roots before enforcing file-output egress', async () => {
+    const server = new MCPServer(undefined, { initialToolTier: 3 });
+    const handler = jest.fn(async () => ({
+      content: [{ type: 'text' as const, text: 'should not run' }],
+    }));
+    const allowedOutput = path.resolve('tmp', 'modern-allowed-output');
+    const deniedOutput = path.resolve('tmp', 'modern-other-output', 'page.pdf');
+    const requestClient = jest.fn().mockResolvedValue({
+      roots: [{ uri: pathToFileURL(allowedOutput).href }],
+    });
+    server.registerTool('page_pdf', handler, {
+      name: 'page_pdf',
+      description: 'test pdf',
+      inputSchema: {
+        type: 'object',
+        properties: { tabId: { type: 'string' }, path: { type: 'string' } },
+        required: ['tabId'],
+      },
+      annotations: TOOL_ANNOTATIONS.page_pdf,
+    });
+
+    const response = await runWithRequestContext(
+      {
+        requestId: 'req-modern-file-roots',
+        protocolEra: 'modern',
+        clientCapabilities: { roots: {} },
+        requestClient,
+      },
+      () => server.handleRequest({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'page_pdf',
+          arguments: {
+            sessionId: 'browser-session-modern-file',
+            tabId: 'tab-a',
+            path: deniedOutput,
+          },
+        },
+      }),
+    );
+
+    expect(requestClient).toHaveBeenCalledWith(
+      'roots/list',
+      undefined,
+      { timeoutMs: 250 },
+    );
+    expect(getSessionMcpRoots('browser-session-modern-file')?.file).toHaveLength(1);
+    expect(handler).not.toHaveBeenCalled();
+    expect(response.result?.isError).toBe(true);
+    expect(response.result?.content?.[0]?.text).toContain('Allowed file roots');
   });
 
   test('rejects URL-egress tools before handler execution when MCP network roots exclude the host', async () => {

--- a/tests/unit/mcp-roots-server.test.ts
+++ b/tests/unit/mcp-roots-server.test.ts
@@ -5,7 +5,11 @@ import { MCPServer } from '../../src/mcp-server';
 import { TOOL_ANNOTATIONS } from '../../src/types/tool-annotations';
 import type { MCPToolDefinition } from '../../src/types/mcp';
 import { runWithRequestContext } from '../../src/observability/request-id';
-import { clearAllSessionMcpRoots, setSessionMcpRoots } from '../../src/security/mcp-roots';
+import {
+  clearAllSessionMcpRoots,
+  getSessionMcpRoots,
+  setSessionMcpRoots,
+} from '../../src/security/mcp-roots';
 
 const navigateDefinition: MCPToolDefinition = {
   name: 'navigate',
@@ -20,6 +24,49 @@ const navigateDefinition: MCPToolDefinition = {
 
 describe('MCPServer roots narrowing integration (#880)', () => {
   afterEach(() => clearAllSessionMcpRoots());
+
+  test('refreshes roots from the SDK request-scoped legacy bridge', async () => {
+    const server = new MCPServer(undefined, { initialToolTier: 3 });
+    const requestClientMock = jest.fn();
+    const requestClient = async <T>(
+      method: string,
+      params?: Record<string, unknown>,
+      options?: { timeoutMs?: number; signal?: AbortSignal },
+    ): Promise<T> => {
+      requestClientMock(method, params, options);
+      return {
+        roots: [{ uri: 'https://allowed.example.com' }],
+      } as unknown as T;
+    };
+
+    await runWithRequestContext(
+      {
+        requestId: 'req-roots-refresh',
+        mcpSessionId: 'mcp-session-a',
+        protocolEra: 'legacy',
+        clientCapabilities: { roots: {} },
+        requestClient,
+      },
+      () => server.handleMessage(
+        {
+          jsonrpc: '2.0',
+          method: 'notifications/initialized',
+        },
+        undefined,
+        { mcpSessionId: 'mcp-session-a' },
+      ),
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(requestClientMock).toHaveBeenCalledWith(
+      'roots/list',
+      undefined,
+      { timeoutMs: 250 },
+    );
+    expect(getSessionMcpRoots('mcp-session-a')?.network).toEqual([
+      expect.objectContaining({ host: 'allowed.example.com' }),
+    ]);
+  });
 
   test('rejects URL-egress tools before handler execution when MCP network roots exclude the host', async () => {
     const server = new MCPServer(undefined, { initialToolTier: 3 });


### PR DESCRIPTION
## Summary

- adopt the official MCP TypeScript SDK 2.x as OpenChrome's protocol boundary
- support MCP `2026-07-28` over stateless HTTP POST and dual-era stdio while preserving the legacy initialize/session/SSE path
- add `server/discover`, per-request metadata, cache hints, result discrimination, filtered subscriptions, and multi-round-trip `input_required` adaptation
- preserve OpenChrome's explicit browser `sessionId`/`tabId` model, auth scopes, tenant isolation, broker identity, rate limiting, cancellation, progress, and logging
- raise the runtime and CI floor to Node.js 20

## Why this fits OpenChrome

The new MCP revision removes protocol transport sessions, but OpenChrome already exposes browser state through explicit application handles. Keeping `sessionId` and `tabId` in tool arguments makes requests portable and auditable without confusing Chrome/CDP state with an MCP connection.

The official SDK now owns wire-level negotiation, header/body validation, cache metadata, subscriptions, and MRTR shapes. OpenChrome's mature runtime remains responsible for browser control and policy. This also preserves principle P3: deprecated server-side Sampling does not become a reason to add a mandatory outbound LLM provider to core.

Modern `tools/list` returns the complete deterministic authorization- and capability-filtered registry because hidden progressive-disclosure history cannot safely live in a stateless protocol. Legacy clients retain their current progressive disclosure behavior.

## Compatibility and security

- modern HTTP ignores stale `Mcp-Session-Id` values and never emits one
- modern GET/DELETE and `/mcp/sse` requests are rejected; legacy clients keep those routes
- method/name routing headers are validated by the SDK and included in browser CORS allow/expose lists
- authenticated principal, tenant, and broker context are rebuilt per request without copying plaintext credentials
- live resources and modern subscription events are tenant-scoped; unresolved resource ownership fails closed
- existing API-key, JWT, bearer, CORS, loopback, audit, and scope checks run before SDK dispatch
- legacy stdio/HTTP initialize, notifications, Roots, Sampling, elicitation, resource subscriptions, and session cleanup remain supported during migration

## Documentation

`docs/mcp-2026-07-28.md` records the architecture decision, protocol matrix, cache policy, MRTR behavior, security model, fit with OpenChrome, and phased roadmap.

References:

- https://modelcontextprotocol.io/specification/2026-07-28
- https://modelcontextprotocol.io/specification/2026-07-28/changelog
- https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http
- https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/migration/support-2026-07-28.md

## Validation

- `npm run build`
- `npm run lint -- --max-warnings=0`
- `npm run lint:tier`
- `npm run lint:tool-schemas` (80 baselined, 0 new)
- `npm run docs:capability-map:check`
- focused modern HTTP/stdio, legacy transport, auth/CORS, tenant event bus, resource, Roots, and progressive-disclosure suites
- `git diff --check`

A full local Windows run was not used as the final gate because the existing persistent-profile symlink case requires unavailable symlink privileges; the PR's Linux/Windows CI matrix remains authoritative.

## Follow-ups

- add the upstream MCP conformance suite to CI
- broaden internal schemas and structured content to the full bounded JSON Schema 2020-12 surface
- add integrity-protected `requestState` before introducing multi-stage or side-effecting MRTR flows
- evaluate MCP Apps for element picking/evidence inspection and Tasks only for explicitly enabled operator workflows
- design a session-owner registry before claiming round-robin multi-daemon browser-session portability