### PR TITLE
Group runtime session tests under session folder

### DIFF
--- a/tests/session/manager-contracts.test.ts
+++ b/tests/session/manager-contracts.test.ts
@@ -14,7 +14,7 @@ const mockCdpClientInstance = {
   getBrowser: jest.fn().mockReturnValue({ targets: jest.fn().mockReturnValue([]) }),
 };
 
-jest.mock('../src/cdp/client', () => ({
+jest.mock('../../src/cdp/client', () => ({
   CDPClient: jest.fn().mockImplementation(() => mockCdpClientInstance),
   getCDPClient: jest.fn().mockReturnValue(mockCdpClientInstance),
   getCDPClientFactory: jest.fn().mockReturnValue({
@@ -25,26 +25,26 @@ jest.mock('../src/cdp/client', () => ({
   }),
 }));
 
-jest.mock('../src/cdp/connection-pool', () => ({
+jest.mock('../../src/cdp/connection-pool', () => ({
   CDPConnectionPool: jest.fn(),
   getCDPConnectionPool: jest.fn().mockReturnValue({}),
 }));
 
-jest.mock('../src/utils/request-queue', () => ({
+jest.mock('../../src/utils/request-queue', () => ({
   RequestQueueManager: jest.fn().mockImplementation(() => ({
     enqueue: jest.fn((_, fn) => fn()),
     deleteQueue: jest.fn(),
   })),
 }));
 
-jest.mock('../src/utils/ref-id-manager', () => ({
+jest.mock('../../src/utils/ref-id-manager', () => ({
   getRefIdManager: jest.fn(() => ({
     clearSessionRefs: jest.fn(),
     clearTargetRefs: jest.fn(),
   })),
 }));
 
-import { SessionManager } from '../src/session-manager';
+import { SessionManager } from '../../src/session-manager';
 
 function page(url: string) {
   return {

--- a/tests/session/manager-evict-target.test.ts
+++ b/tests/session/manager-evict-target.test.ts
@@ -12,7 +12,7 @@ const mockCdpClientInstance = {
   getBrowser: jest.fn().mockReturnValue({ targets: jest.fn().mockReturnValue([]) }),
 };
 
-jest.mock('../src/cdp/client', () => ({
+jest.mock('../../src/cdp/client', () => ({
   CDPClient: jest.fn().mockImplementation(() => mockCdpClientInstance),
   getCDPClient: jest.fn().mockReturnValue(mockCdpClientInstance),
   getCDPClientFactory: jest.fn().mockReturnValue({
@@ -23,27 +23,27 @@ jest.mock('../src/cdp/client', () => ({
   }),
 }));
 
-jest.mock('../src/cdp/connection-pool', () => ({
+jest.mock('../../src/cdp/connection-pool', () => ({
   CDPConnectionPool: jest.fn(),
   getCDPConnectionPool: jest.fn().mockReturnValue({}),
 }));
 
-jest.mock('../src/utils/request-queue', () => ({
+jest.mock('../../src/utils/request-queue', () => ({
   RequestQueueManager: jest.fn().mockImplementation(() => ({
     enqueue: jest.fn((_, fn) => fn()),
     deleteQueue: jest.fn(),
   })),
 }));
 
-jest.mock('../src/utils/ref-id-manager', () => ({
+jest.mock('../../src/utils/ref-id-manager', () => ({
   getRefIdManager: jest.fn(() => ({
     clearSessionRefs: jest.fn(),
     clearTargetRefs: jest.fn(),
   })),
 }));
 
-import { SessionManager } from '../src/session-manager';
-import { getMetricsCollector } from '../src/metrics/collector';
+import { SessionManager } from '../../src/session-manager';
+import { getMetricsCollector } from '../../src/metrics/collector';
 
 function counterValueFor(reason: string): number {
   const dump = getMetricsCollector().export();

--- a/tests/session/manager-target-creation.test.ts
+++ b/tests/session/manager-target-creation.test.ts
@@ -15,7 +15,7 @@ const mockCdpClientInstance = {
   send: jest.fn(),
 };
 
-jest.mock('../src/cdp/client', () => ({
+jest.mock('../../src/cdp/client', () => ({
   CDPClient: jest.fn().mockImplementation(() => mockCdpClientInstance),
   getCDPClient: jest.fn().mockReturnValue(mockCdpClientInstance),
   getCDPClientFactory: jest.fn().mockReturnValue({
@@ -26,26 +26,26 @@ jest.mock('../src/cdp/client', () => ({
   }),
 }));
 
-jest.mock('../src/cdp/connection-pool', () => ({
+jest.mock('../../src/cdp/connection-pool', () => ({
   CDPConnectionPool: jest.fn(),
   getCDPConnectionPool: jest.fn().mockReturnValue({}),
 }));
 
-jest.mock('../src/utils/request-queue', () => ({
+jest.mock('../../src/utils/request-queue', () => ({
   RequestQueueManager: jest.fn().mockImplementation(() => ({
     enqueue: jest.fn((_: string, fn: () => Promise<unknown>) => fn()),
     deleteQueue: jest.fn(),
   })),
 }));
 
-jest.mock('../src/utils/ref-id-manager', () => ({
+jest.mock('../../src/utils/ref-id-manager', () => ({
   getRefIdManager: jest.fn(() => ({
     clearSessionRefs: jest.fn(),
     clearTargetRefs: jest.fn(),
   })),
 }));
 
-import { SessionManager } from '../src/session-manager';
+import { SessionManager } from '../../src/session-manager';
 
 function createManager(maxTargetsPerWorker = 5): SessionManager {
   return new SessionManager(undefined, {

--- a/tests/session/state-persistence.test.ts
+++ b/tests/session/state-persistence.test.ts
@@ -1,9 +1,9 @@
 /// <reference types="jest" />
 
-import { SessionStatePersistence, PersistedSessionState } from '../src/session/state-persistence';
-import { writeFileAtomicSafe, readFileSafe } from '../src/utils/atomic-file';
+import { SessionStatePersistence, PersistedSessionState } from '../../src/session/state-persistence';
+import { writeFileAtomicSafe, readFileSafe } from '../../src/utils/atomic-file';
 
-jest.mock('../src/utils/atomic-file', () => ({
+jest.mock('../../src/utils/atomic-file', () => ({
   writeFileAtomicSafe: jest.fn().mockResolvedValue(undefined),
   readFileSafe: jest.fn(),
 }));


### PR DESCRIPTION
## Summary
- move runtime session-manager and session persistence tests from tests/ root into tests/session/
- update relative imports after the move
- leave extension-specific session-manager tests at the root for a later ownership pass

## Paperthin routing
- reorder: grouped tests by production ownership
- debloat: reduced tests/ root clutter without assertion rewrites
- sip: ran the moved test files and whitespace check

## Verification
- npm test -- --runTestsByPath tests/session/manager-contracts.test.ts tests/session/manager-evict-target.test.ts tests/session/manager-target-creation.test.ts tests/session/state-persistence.test.ts --runInBand --silent
- git diff --check