### PR TITLE
Group broker tests under broker folder

### DIFF
--- a/tests/broker/auto-elect.test.ts
+++ b/tests/broker/auto-elect.test.ts
@@ -12,7 +12,7 @@ import {
   shouldClientAutoConnect,
   defaultBrokerHttpPort,
   BROKER_HTTP_PORT_OFFSET,
-} from '../src/broker/auto-elect';
+} from '../../src/broker/auto-elect';
 
 describe('isAutoElectEnabled', () => {
   test('true by default for direct serve --auto-launch path', () => {

--- a/tests/broker/discovery.test.ts
+++ b/tests/broker/discovery.test.ts
@@ -8,7 +8,7 @@ import {
   readBrokerMetadata,
   removeBrokerMetadata,
   resolveLiveBrokerMetadata,
-} from '../src/broker/discovery';
+} from '../../src/broker/discovery';
 
 describe('broker discovery metadata', () => {
   let tmpDir: string;

--- a/tests/broker/lifecycle.test.ts
+++ b/tests/broker/lifecycle.test.ts
@@ -6,7 +6,7 @@ import {
   resetBrokerLifecycleForTest,
   setBrokerOwnerMode,
   shouldOcStopKeepChromeByDefault,
-} from '../src/broker/lifecycle';
+} from '../../src/broker/lifecycle';
 
 describe('broker lifecycle state', () => {
   beforeEach(() => resetBrokerLifecycleForTest());

--- a/tests/broker/proxy.test.ts
+++ b/tests/broker/proxy.test.ts
@@ -1,5 +1,5 @@
-import { BrokerProxyStdioBridge } from '../src/transports/broker-proxy';
-import type { BrokerMetadata } from '../src/broker/discovery';
+import { BrokerProxyStdioBridge } from '../../src/transports/broker-proxy';
+import type { BrokerMetadata } from '../../src/broker/discovery';
 
 const broker: BrokerMetadata = {
   schemaVersion: 1,


### PR DESCRIPTION
## Summary
- move root-level broker tests into tests/broker/
- update relative imports after the move

## Paperthin routing
- reorder: group tests by broker ownership
- debloat: reduce tests/ root clutter without assertion rewrites
- sip: run moved tests and whitespace check

## Verification
- npm test -- --runTestsByPath tests/broker/auto-elect.test.ts tests/broker/discovery.test.ts tests/broker/lifecycle.test.ts tests/broker/proxy.test.ts --runInBand --silent
- git diff --check