### PR TITLE
Group session target helper tests

### DIFF
--- a/tests/session/target-command-queue.test.ts
+++ b/tests/session/target-command-queue.test.ts
@@ -1,4 +1,4 @@
-import { TargetQueueCancelledError, TargetQueueManager } from '../src/session/target-command-queue';
+import { TargetQueueCancelledError, TargetQueueManager } from '../../src/session/target-command-queue';
 
 describe('TargetQueueManager', () => {
   test('serializes commands for the same target', async () => {

--- a/tests/session/target-creation-ledger.test.ts
+++ b/tests/session/target-creation-ledger.test.ts
@@ -2,7 +2,7 @@ import {
   TargetCreationLedger,
   sanitizeTargetTitle,
   sanitizeTargetUrl,
-} from '../src/session/target-creation-ledger';
+} from '../../src/session/target-creation-ledger';
 
 describe('TargetCreationLedger', () => {
   test('reports only ready children created after the cursor in deterministic order', () => {

--- a/tests/session/target-lease-registry.test.ts
+++ b/tests/session/target-lease-registry.test.ts
@@ -1,4 +1,4 @@
-import { TargetLeaseConflictError, TargetLeaseRegistry } from '../src/session/target-lease-registry';
+import { TargetLeaseConflictError, TargetLeaseRegistry } from '../../src/session/target-lease-registry';
 
 describe('TargetLeaseRegistry', () => {
   test('acquires and snapshots leases with ownership metadata', () => {


### PR DESCRIPTION
## Summary
- move target queue, target creation ledger, and target lease registry tests into tests/session/
- update relative imports only

## Paperthin routing
- reorder: group tests by session ownership
- debloat: reduce tests/ root clutter without assertion rewrites
- sip: run moved tests and whitespace check

## Verification
- npm test -- --runTestsByPath tests/session/target-command-queue.test.ts tests/session/target-creation-ledger.test.ts tests/session/target-lease-registry.test.ts --runInBand --silent
- git diff --check