### PR TITLE
Group controller utility tests

### DIFF
--- a/tests/utils/controller-lock.test.ts
+++ b/tests/utils/controller-lock.test.ts
@@ -11,7 +11,7 @@ import {
   recordControllerHeartbeat,
   releaseControllerLock,
   startControllerHeartbeat,
-} from '../src/utils/controller-lock';
+} from '../../src/utils/controller-lock';
 
 describe('controller lock', () => {
   let tmpDir: string;

--- a/tests/utils/duplicate-controller-diagnostics.test.ts
+++ b/tests/utils/duplicate-controller-diagnostics.test.ts
@@ -9,8 +9,8 @@ import {
   parsePsOutput,
   scanMcpConfigRegistrations,
   summarizeDuplicateControllerDiagnostics,
-} from '../src/utils/duplicate-controller-diagnostics';
-import { acquireControllerLock } from '../src/utils/controller-lock';
+} from '../../src/utils/duplicate-controller-diagnostics';
+import { acquireControllerLock } from '../../src/utils/controller-lock';
 
 describe('duplicate controller diagnostics', () => {
   let tmpDir: string;


### PR DESCRIPTION
## Summary
- move controller lock and duplicate-controller diagnostics tests from tests/ root to tests/utils/
- update relative imports only

## Paperthin routing
- reorder: group tests by runtime utility ownership
- debloat: reduce tests/ root clutter without assertion rewrites
- sip: run moved tests and whitespace check

## Verification
- npm test -- --runTestsByPath tests/utils/controller-lock.test.ts tests/utils/duplicate-controller-diagnostics.test.ts --runInBand --silent
- git diff --check