### PR TITLE
Group extension tests under extension folder

### DIFF
--- a/tests/extension/cdp-pool.test.ts
+++ b/tests/extension/cdp-pool.test.ts
@@ -4,7 +4,7 @@
  * Tests for CDPConnectionPool
  */
 
-import { CDPConnectionPool } from '../extension/src/cdp-pool';
+import { CDPConnectionPool } from '../../extension/src/cdp-pool';
 
 describe('CDPConnectionPool', () => {
   let pool: CDPConnectionPool;

--- a/tests/extension/ref-id-manager.test.ts
+++ b/tests/extension/ref-id-manager.test.ts
@@ -3,7 +3,7 @@
  * Tests for RefIdManager
  */
 
-import { RefIdManager, getRefIdManager } from '../extension/src/ref-id-manager';
+import { RefIdManager, getRefIdManager } from '../../extension/src/ref-id-manager';
 
 describe('RefIdManager', () => {
   let manager: RefIdManager;

--- a/tests/extension/request-queue.test.ts
+++ b/tests/extension/request-queue.test.ts
@@ -3,7 +3,7 @@
  * Tests for RequestQueue
  */
 
-import { RequestQueue, RequestQueueManager } from '../extension/src/request-queue';
+import { RequestQueue, RequestQueueManager } from '../../extension/src/request-queue';
 
 describe('RequestQueue', () => {
   let queue: RequestQueue;

--- a/tests/extension/session-manager.test.ts
+++ b/tests/extension/session-manager.test.ts
@@ -4,10 +4,10 @@
  * Tests for SessionManager
  */
 
-import { SessionManager } from '../extension/src/session-manager';
-import { TabGroupManager } from '../extension/src/tab-group-manager';
-import { CDPConnectionPool } from '../extension/src/cdp-pool';
-import { RequestQueueManager } from '../extension/src/request-queue';
+import { SessionManager } from '../../extension/src/session-manager';
+import { TabGroupManager } from '../../extension/src/tab-group-manager';
+import { CDPConnectionPool } from '../../extension/src/cdp-pool';
+import { RequestQueueManager } from '../../extension/src/request-queue';
 
 describe('SessionManager', () => {
   let sessionManager: SessionManager;

--- a/tests/extension/tab-group-manager.test.ts
+++ b/tests/extension/tab-group-manager.test.ts
@@ -4,7 +4,7 @@
  * Tests for TabGroupManager
  */
 
-import { TabGroupManager } from '../extension/src/tab-group-manager';
+import { TabGroupManager } from '../../extension/src/tab-group-manager';
 
 describe('TabGroupManager', () => {
   let manager: TabGroupManager;


### PR DESCRIPTION
## Summary
- move extension-only root tests into tests/extension/
- update relative imports only

## Paperthin routing
- reorder: group tests by extension ownership
- debloat: reduce tests/ root clutter without assertion rewrites
- sip: run moved tests and whitespace check

## Verification
- npm test -- --runTestsByPath tests/extension/cdp-pool.test.ts tests/extension/ref-id-manager.test.ts tests/extension/request-queue.test.ts tests/extension/session-manager.test.ts tests/extension/tab-group-manager.test.ts --runInBand --silent
- git diff --check