### PR TITLE
Group MCP server tests under mcp folder

### DIFF
--- a/tests/mcp/progressive-disclosure.test.ts
+++ b/tests/mcp/progressive-disclosure.test.ts
@@ -1,21 +1,21 @@
 /// <reference types="jest" />
 
-import { createMockSessionManager } from './utils/mock-session';
+import { createMockSessionManager } from '../utils/mock-session';
 
-jest.mock('../src/cdp/client', () => ({
+jest.mock('../../src/cdp/client', () => ({
   getCDPClient: jest.fn(() => ({
     forceReconnect: jest.fn().mockResolvedValue(undefined),
     isConnected: jest.fn().mockReturnValue(false),
   })),
 }));
 
-jest.mock('../src/session-manager', () => ({
+jest.mock('../../src/session-manager', () => ({
   getSessionManager: jest.fn(),
 }));
 
-import { getSessionManager } from '../src/session-manager';
-import { MCPServer } from '../src/mcp-server';
-import { registerAllTools } from '../src/tools';
+import { getSessionManager } from '../../src/session-manager';
+import { MCPServer } from '../../src/mcp-server';
+import { registerAllTools } from '../../src/tools';
 
 interface TestResponse {
   result?: {

--- a/tests/mcp/server-abort-accounting.test.ts
+++ b/tests/mcp/server-abort-accounting.test.ts
@@ -1,8 +1,8 @@
 /// <reference types="jest" />
-import { MCPServer } from '../src/mcp-server';
-import { getMetricsCollector } from '../src/metrics/collector';
-import { runWithRequestContext } from '../src/observability/request-id';
-import { ClientDisconnectError } from '../src/errors/abort';
+import { MCPServer } from '../../src/mcp-server';
+import { getMetricsCollector } from '../../src/metrics/collector';
+import { runWithRequestContext } from '../../src/observability/request-id';
+import { ClientDisconnectError } from '../../src/errors/abort';
 
 describe('MCPServer aborted tool accounting', () => {
   test('records client disconnects as aborted metrics instead of generic errors', async () => {

--- a/tests/mcp/server-profile.test.ts
+++ b/tests/mcp/server-profile.test.ts
@@ -3,18 +3,18 @@
  * Tests for MCPServer _profile injection in tool responses
  */
 
-import { createMockSessionManager } from './utils/mock-session';
+import { createMockSessionManager } from '../utils/mock-session';
 
 const mockGetProfileState = jest.fn();
 const mockForceReconnect = jest.fn().mockResolvedValue(undefined);
 
-jest.mock('../src/cdp/client', () => ({
+jest.mock('../../src/cdp/client', () => ({
   getCDPClient: jest.fn(() => ({
     forceReconnect: mockForceReconnect,
   })),
 }));
 
-jest.mock('../src/chrome/launcher', () => ({
+jest.mock('../../src/chrome/launcher', () => ({
   getChromeLauncher: jest.fn(() => ({
     ensureChrome: jest.fn().mockResolvedValue({
       wsEndpoint: 'ws://127.0.0.1:9222/devtools/browser/test',
@@ -27,15 +27,15 @@ jest.mock('../src/chrome/launcher', () => ({
   })),
 }));
 
-jest.mock('../src/session-manager', () => ({
+jest.mock('../../src/session-manager', () => ({
   getSessionManager: jest.fn(),
 }));
 
-import { getSessionManager } from '../src/session-manager';
-import { getChromeLauncher } from '../src/chrome/launcher';
-import { setGlobalConfig } from '../src/config/global';
-import { MCPServer } from '../src/mcp-server';
-import { MCPRequest, MCPToolDefinition } from '../src/types/mcp';
+import { getSessionManager } from '../../src/session-manager';
+import { getChromeLauncher } from '../../src/chrome/launcher';
+import { setGlobalConfig } from '../../src/config/global';
+import { MCPServer } from '../../src/mcp-server';
+import { MCPRequest, MCPToolDefinition } from '../../src/types/mcp';
 
 interface MCPResultResponse {
   jsonrpc: string;

--- a/tests/mcp/server-shutdown.test.ts
+++ b/tests/mcp/server-shutdown.test.ts
@@ -6,14 +6,14 @@
 
 // Mock getChromePool to control pool instance count for timeout tests
 const mockGetInstances = jest.fn().mockReturnValue(new Map());
-jest.mock('../src/chrome/pool', () => ({
+jest.mock('../../src/chrome/pool', () => ({
   getChromePool: jest.fn(() => ({
     getInstances: mockGetInstances,
   })),
 }));
 
 // Mock CDP client
-jest.mock('../src/cdp/client', () => ({
+jest.mock('../../src/cdp/client', () => ({
   getCDPClient: jest.fn(() => ({
     isConnected: jest.fn().mockReturnValue(false),
     disconnect: jest.fn().mockResolvedValue(undefined),
@@ -22,14 +22,14 @@ jest.mock('../src/cdp/client', () => ({
 }));
 
 // Mock CDP connection pool
-jest.mock('../src/cdp/connection-pool', () => ({
+jest.mock('../../src/cdp/connection-pool', () => ({
   getCDPConnectionPool: jest.fn(() => ({
     shutdown: jest.fn().mockResolvedValue(undefined),
   })),
 }));
 
 // Mock Chrome launcher
-jest.mock('../src/chrome/launcher', () => ({
+jest.mock('../../src/chrome/launcher', () => ({
   ChromeLauncher: jest.fn(),
   getChromeLauncher: jest.fn(() => ({
     isConnected: jest.fn().mockReturnValue(false),
@@ -46,11 +46,11 @@ const mockSessionManager = {
 };
 
 // Mock session manager
-jest.mock('../src/session-manager', () => ({
+jest.mock('../../src/session-manager', () => ({
   getSessionManager: jest.fn(() => mockSessionManager),
 }));
 
-import { MCPServer } from '../src/mcp-server';
+import { MCPServer } from '../../src/mcp-server';
 
 describe('MCPServer shutdown robustness', () => {
   beforeEach(() => {
@@ -115,7 +115,7 @@ describe('MCPServer shutdown robustness', () => {
     });
 
     it('handles getChromePool throwing (pool not initialized)', async () => {
-      const poolMock = require('../src/chrome/pool');
+      const poolMock = require('../../src/chrome/pool');
       poolMock.getChromePool.mockImplementationOnce(() => {
         throw new Error('Pool not initialized');
       });

--- a/tests/mcp/server-tenant-metrics.test.ts
+++ b/tests/mcp/server-tenant-metrics.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="jest" />
-import { MCPServer } from '../src/mcp-server';
-import { getMetricsCollector } from '../src/metrics/collector';
-import { runWithRequestContext } from '../src/observability/request-id';
+import { MCPServer } from '../../src/mcp-server';
+import { getMetricsCollector } from '../../src/metrics/collector';
+import { runWithRequestContext } from '../../src/observability/request-id';
 
 describe('MCPServer tenant-aware metric emission', () => {
   test('emits tool metrics with tenant label from request context', async () => {

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -3,25 +3,25 @@
  * Tests for MCP Server
  */
 
-import { createMockSessionManager } from './utils/mock-session';
+import { createMockSessionManager } from '../utils/mock-session';
 
 // Mock CDP client for reconnection tests
 const mockForceReconnect = jest.fn().mockResolvedValue(undefined);
-jest.mock('../src/cdp/client', () => ({
+jest.mock('../../src/cdp/client', () => ({
   getCDPClient: jest.fn(() => ({
     forceReconnect: mockForceReconnect,
   })),
 }));
 
 // Mock the session manager
-jest.mock('../src/session-manager', () => ({
+jest.mock('../../src/session-manager', () => ({
   getSessionManager: jest.fn(),
 }));
 
-import { getSessionManager } from '../src/session-manager';
-import { MCPServer } from '../src/mcp-server';
-import { MCPRequest, MCPErrorCodes, MCPToolDefinition } from '../src/types/mcp';
-import { DEFAULT_TOOL_EXECUTION_TIMEOUT_MS, DEFAULT_RECONNECT_TIMEOUT_MS } from '../src/config/defaults';
+import { getSessionManager } from '../../src/session-manager';
+import { MCPServer } from '../../src/mcp-server';
+import { MCPRequest, MCPErrorCodes, MCPToolDefinition } from '../../src/types/mcp';
+import { DEFAULT_TOOL_EXECUTION_TIMEOUT_MS, DEFAULT_RECONNECT_TIMEOUT_MS } from '../../src/config/defaults';
 
 // Helper type for response with result
 interface MCPResultResponse {


### PR DESCRIPTION
## Summary
- move root-level MCP server tests into tests/mcp/
- update relative imports only

## Paperthin routing
- reorder: group tests by MCP protocol/server ownership
- debloat: reduce tests/ root clutter without assertion rewrites
- sip: run moved tests and whitespace check

## Verification
- npm test -- --runTestsByPath tests/mcp/server.test.ts tests/mcp/server-profile.test.ts tests/mcp/server-shutdown.test.ts tests/mcp/server-tenant-metrics.test.ts tests/mcp/server-abort-accounting.test.ts tests/mcp/progressive-disclosure.test.ts --runInBand --silent
- git diff --check