### PR TITLE
Group chrome root tests

### DIFF
--- a/tests/chrome/owner-self-release.test.ts
+++ b/tests/chrome/owner-self-release.test.ts
@@ -5,8 +5,8 @@ import {
   releaseOwnerAfterStartupFailure,
   releaseOwnerIfChromeUnreachable,
   wireOwnerSelfRelease,
-} from '../src/chrome/owner-self-release';
-import { DebugPortTimeoutError } from '../src/chrome/launcher-debug-port';
+} from '../../src/chrome/owner-self-release';
+import { DebugPortTimeoutError } from '../../src/chrome/launcher-debug-port';
 
 const flush = () => new Promise((resolve) => setImmediate(resolve));
 

--- a/tests/chrome/profile-state.test.ts
+++ b/tests/chrome/profile-state.test.ts
@@ -9,18 +9,18 @@ beforeEach(() => {
 
 describe('ChromeLauncher ProfileState', () => {
   test('ChromeLauncher class is exported and instantiable', async () => {
-    const launcher = await import('../src/chrome/launcher');
+    const launcher = await import('../../src/chrome/launcher');
     expect(launcher.ChromeLauncher).toBeDefined();
   });
 
   test('getProfileState method exists on ChromeLauncher instance', () => {
-    const { ChromeLauncher } = jest.requireActual('../src/chrome/launcher') as typeof import('../src/chrome/launcher');
+    const { ChromeLauncher } = jest.requireActual('../../src/chrome/launcher') as typeof import('../../src/chrome/launcher');
     const instance = new ChromeLauncher(9222);
     expect(typeof instance.getProfileState).toBe('function');
   });
 
   test('default profile state is real with extensions', () => {
-    const { ChromeLauncher } = jest.requireActual('../src/chrome/launcher') as typeof import('../src/chrome/launcher');
+    const { ChromeLauncher } = jest.requireActual('../../src/chrome/launcher') as typeof import('../../src/chrome/launcher');
     const instance = new ChromeLauncher(9222);
     const state = instance.getProfileState();
     expect(state.type).toBe('real');
@@ -30,7 +30,7 @@ describe('ChromeLauncher ProfileState', () => {
   });
 
   test('getProfileState returns a copy (not reference)', () => {
-    const { ChromeLauncher } = jest.requireActual('../src/chrome/launcher') as typeof import('../src/chrome/launcher');
+    const { ChromeLauncher } = jest.requireActual('../../src/chrome/launcher') as typeof import('../../src/chrome/launcher');
     const instance = new ChromeLauncher(9222);
     const state1 = instance.getProfileState();
     const state2 = instance.getProfileState();
@@ -39,7 +39,7 @@ describe('ChromeLauncher ProfileState', () => {
   });
 
   test('ProfileType union includes all expected values', () => {
-    const { ChromeLauncher } = jest.requireActual('../src/chrome/launcher') as typeof import('../src/chrome/launcher');
+    const { ChromeLauncher } = jest.requireActual('../../src/chrome/launcher') as typeof import('../../src/chrome/launcher');
     const instance = new ChromeLauncher(9222);
     const state = instance.getProfileState();
     const validTypes = ['real', 'persistent', 'temp', 'explicit'];
@@ -47,14 +47,14 @@ describe('ChromeLauncher ProfileState', () => {
   });
 
   test('default profileState has no userDataDir', () => {
-    const { ChromeLauncher } = jest.requireActual('../src/chrome/launcher') as typeof import('../src/chrome/launcher');
+    const { ChromeLauncher } = jest.requireActual('../../src/chrome/launcher') as typeof import('../../src/chrome/launcher');
     const instance = new ChromeLauncher(9222);
     const state = instance.getProfileState();
     expect(state.userDataDir).toBeUndefined();
   });
 
   test('multiple instances have independent profile states', () => {
-    const { ChromeLauncher } = jest.requireActual('../src/chrome/launcher') as typeof import('../src/chrome/launcher');
+    const { ChromeLauncher } = jest.requireActual('../../src/chrome/launcher') as typeof import('../../src/chrome/launcher');
     const instance1 = new ChromeLauncher(9222);
     const instance2 = new ChromeLauncher(9223);
     const state1 = instance1.getProfileState();
@@ -65,7 +65,7 @@ describe('ChromeLauncher ProfileState', () => {
   });
 
   test('getChromeLauncher returns an instance with getProfileState', () => {
-    const { getChromeLauncher } = jest.requireActual('../src/chrome/launcher') as typeof import('../src/chrome/launcher');
+    const { getChromeLauncher } = jest.requireActual('../../src/chrome/launcher') as typeof import('../../src/chrome/launcher');
     const launcher = getChromeLauncher(9299);
     expect(typeof launcher.getProfileState).toBe('function');
     const state = launcher.getProfileState();


### PR DESCRIPTION
## Summary
- move Chrome owner self-release and profile state tests into tests/chrome/
- update relative imports only

## Paperthin routing
- reorder: group tests by Chrome runtime ownership
- debloat: reduce tests/ root clutter without assertion rewrites
- sip: run moved tests and whitespace check

## Verification
- npm test -- --runTestsByPath tests/chrome/owner-self-release.test.ts tests/chrome/profile-state.test.ts --runInBand --silent
- git diff --check