### PR TITLE
Guard the cleaned repository structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,10 @@ jobs:
         if: steps.changes.outputs.needs_src_lint == 'true'
         run: npm run lint
 
+      - name: Lint repository structure
+        if: steps.changes.outputs.needs_src_lint == 'true'
+        run: npm run lint:repo-structure
+
       - name: Lint tier boundary (core must not import pilot)
         if: steps.changes.outputs.needs_src_lint == 'true'
         run: npm run lint:tier

--- a/docs/dev/project-structure.md
+++ b/docs/dev/project-structure.md
@@ -42,6 +42,8 @@ Do not add ad hoc root folders for experiments, generated reports, worktrees,
 agent-local state, or one-off validation outputs. Put durable contributor
 documentation under `docs/`, runnable maintenance code under `scripts/`, and
 ignored local outputs under paths covered by `.gitignore`.
+`npm run lint:repo-structure` enforces the current `src/` root entry allow-list
+and prevents reintroducing the deprecated `tests/src` bucket.
 
 ## Package Publish Surface
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:e2e:external": "node --expose-gc node_modules/.bin/jest --config tests/e2e/jest.e2e-external.config.js",
     "test:coverage": "jest --coverage",
     "lint": "eslint src --ext .ts",
+    "lint:repo-structure": "node scripts/lint-repo-structure.mjs",
     "lint:tier": "depcruise --config .dependency-cruiser.cjs src",
     "lint:tool-schemas": "node dist/index.js serve --introspect-tools-list | node scripts/lint-tool-schemas.mjs -",
     "clean": "rimraf dist",

--- a/scripts/lint-repo-structure.mjs
+++ b/scripts/lint-repo-structure.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { cwd, exit } from 'node:process';
+
+const root = cwd();
+
+const allowedSrcRootFiles = new Set([
+  'index.ts',
+  'mcp-server.ts',
+  'session-manager.ts',
+  'version.ts',
+]);
+
+const errors = [];
+
+function listFiles(dir) {
+  return readdirSync(join(root, dir))
+    .filter((entry) => statSync(join(root, dir, entry)).isFile())
+    .sort();
+}
+
+for (const file of listFiles('src')) {
+  if (!allowedSrcRootFiles.has(file)) {
+    errors.push(
+      `src/${file} is a root source file without an approved entrypoint/shim role. ` +
+      'Move implementation code into an owning src/<domain>/ folder.',
+    );
+  }
+}
+
+try {
+  const testsSrc = statSync(join(root, 'tests', 'src'));
+  if (testsSrc.isDirectory()) {
+    errors.push('tests/src is not allowed. Put tests under the owning tests/<domain>/ folder.');
+  }
+} catch (error) {
+  if (error?.code !== 'ENOENT') {
+    throw error;
+  }
+}
+
+if (errors.length > 0) {
+  console.error('Repository structure check failed:');
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  exit(1);
+}
+
+console.log('Repository structure check passed.');


### PR DESCRIPTION
## Summary
- add npm run lint:repo-structure to enforce the cleaned src root allow-list
- fail if the deprecated tests/src bucket is reintroduced
- run the structure guard in the existing build-and-test fast gate
- document the guard in docs/dev/project-structure.md

## Paperthin routing
- readchk: verified current src root entries and absence of tests/src
- ssotize: keeps docs/dev/project-structure.md and CI policy aligned
- debloat/reorder: prevents cleaned root/test structure from drifting back
- sip: ran the new guard plus build/lint/tier checks

## Verification
- npm run lint:repo-structure
- npm run build
- npm run lint
- npm run lint:tier
- git diff --check