### PR TITLE
Move controller ownership helpers into chrome

### DIFF
--- a/docs/dev/project-structure.md
+++ b/docs/dev/project-structure.md
@@ -70,7 +70,7 @@ belongs in `skills/` and `commands/`; do not fork equivalent copies under
 | `src/tools/` | MCP tool implementations and tool-local helpers. Tool code may call `src/core`, but core code should not import tools. |
 | `src/mcp/` | MCP server implementation, protocol ingress helpers, session-init policy, and MCP output accounting. `src/mcp-server.ts` is a compatibility re-export for existing imports. |
 | `src/transports/` | MCP/HTTP transport surfaces and protocol adapters. |
-| `src/chrome/`, `src/cdp/`, `src/browser-state/` | Chrome process, CDP, and browser state integration. |
+| `src/chrome/`, `src/cdp/`, `src/browser-state/` | Chrome process, controller ownership, CDP, and browser state integration. |
 | `src/session/` | session ownership, lease, snapshot, and lifecycle coordination. `src/session-manager.ts` is a compatibility re-export for existing imports; new code should import from `src/session/manager` or the nearest package entrypoint. |
 | `src/router/` | routing browser/tool commands to the correct target or tab. |
 | `src/pilot/` | higher-level agent runtime features: skills, handoff, voting, credentials, curator, and automation runtime. |

--- a/src/broker/discovery.ts
+++ b/src/broker/discovery.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { getVersion } from '../version';
-import { controllerLockKey, isPidAlive, normalizeControllerUserDataDir } from '../utils/controller-lock';
+import { controllerLockKey, isPidAlive, normalizeControllerUserDataDir } from '../chrome/controller-lock';
 
 export interface BrokerIdentity {
   port: number;

--- a/src/chrome/controller-lock.ts
+++ b/src/chrome/controller-lock.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { getVersion } from '../version';
-import { fetchJsonVersion } from '../chrome/devtools-info';
+import { fetchJsonVersion } from './devtools-info';
 import { DEFAULT_CHROME_LAUNCH_TIMEOUT_MS } from '../config/defaults';
 
 export interface ControllerLockIdentity {

--- a/src/chrome/duplicate-controller-diagnostics.ts
+++ b/src/chrome/duplicate-controller-diagnostics.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
-import { ProfileManager } from '../chrome/profile-manager';
+import { ProfileManager } from './profile-manager';
 import { getControllerLockPath, isPidAlive, normalizeControllerUserDataDir } from './controller-lock';
 
 export interface OpenChromeProcessInfo {

--- a/src/cli/doctor/checks/duplicate-controllers.ts
+++ b/src/cli/doctor/checks/duplicate-controllers.ts
@@ -6,7 +6,7 @@
 import * as os from 'os';
 import * as path from 'path';
 import type { CheckFn } from '../../doctor';
-import { getCurrentControllerTopology, summarizeDuplicateControllerDiagnostics } from '../../../utils/duplicate-controller-diagnostics';
+import { getCurrentControllerTopology, summarizeDuplicateControllerDiagnostics } from '../../../chrome/duplicate-controller-diagnostics';
 
 function displayPath(filePath: string): string {
   const homes = [os.homedir()];

--- a/src/cli/doctor/runtime-diagnostics.ts
+++ b/src/cli/doctor/runtime-diagnostics.ts
@@ -1,7 +1,7 @@
 import * as os from 'os';
 import { readBrokerMetadata } from '../../broker/discovery';
-import { getCurrentControllerTopology } from '../../utils/duplicate-controller-diagnostics';
-import { isPidAlive } from '../../utils/controller-lock';
+import { getCurrentControllerTopology } from '../../chrome/duplicate-controller-diagnostics';
+import { isPidAlive } from '../../chrome/controller-lock';
 
 export type ActiveRuntimePath =
   | 'direct-owner'

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,9 +53,9 @@ import {
   startControllerHeartbeat,
   type ControllerHeartbeatHandle,
   type ControllerLockHandle,
-} from './utils/controller-lock';
+} from './chrome/controller-lock';
 import { fetchJsonVersion } from './chrome/devtools-info';
-import { getCurrentControllerTopology } from './utils/duplicate-controller-diagnostics';
+import { getCurrentControllerTopology } from './chrome/duplicate-controller-diagnostics';
 import { isAutoElectEnabled, shouldElectBrokerOwner, shouldClientAutoConnect, defaultBrokerHttpPort } from './broker/auto-elect';
 import { removeBrokerMetadata } from './broker/discovery';
 import {

--- a/src/tools/connection-health.ts
+++ b/src/tools/connection-health.ts
@@ -7,7 +7,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getCDPClient } from '../cdp/client';
-import { getCurrentControllerTopology } from '../utils/duplicate-controller-diagnostics';
+import { getCurrentControllerTopology } from '../chrome/duplicate-controller-diagnostics';
 import { getBrokerLifecycleSnapshot } from '../broker/lifecycle';
 
 const definition: MCPToolDefinition = {

--- a/src/transports/broker-proxy.ts
+++ b/src/transports/broker-proxy.ts
@@ -2,7 +2,7 @@ import * as readline from 'readline';
 import type { BrokerMetadata } from '../broker/discovery';
 import { readBrokerMetadata } from '../broker/discovery';
 import { MCPErrorCodes, MCPResponse } from '../types/mcp';
-import { isPidAlive } from '../utils/controller-lock';
+import { isPidAlive } from '../chrome/controller-lock';
 
 /**
  * Exit code a re-electing client uses when it detects its broker owner has died.

--- a/src/transports/duplicate-controller-error-server.ts
+++ b/src/transports/duplicate-controller-error-server.ts
@@ -23,7 +23,7 @@
 import * as readline from 'readline';
 import { getVersion } from '../version';
 import { MCPErrorCodes, type MCPResponse } from '../types/mcp';
-import type { DuplicateControllerError } from '../utils/controller-lock';
+import type { DuplicateControllerError } from '../chrome/controller-lock';
 
 /** Server-defined JSON-RPC error code surfaced for the conflict. */
 export const DUPLICATE_CONTROLLER_ERROR_CODE = -32000;

--- a/tests/chrome/controller-lock.test.ts
+++ b/tests/chrome/controller-lock.test.ts
@@ -11,7 +11,7 @@ import {
   recordControllerHeartbeat,
   releaseControllerLock,
   startControllerHeartbeat,
-} from '../../src/utils/controller-lock';
+} from '../../src/chrome/controller-lock';
 
 describe('controller lock', () => {
   let tmpDir: string;

--- a/tests/chrome/duplicate-controller-diagnostics.test.ts
+++ b/tests/chrome/duplicate-controller-diagnostics.test.ts
@@ -9,8 +9,8 @@ import {
   parsePsOutput,
   scanMcpConfigRegistrations,
   summarizeDuplicateControllerDiagnostics,
-} from '../../src/utils/duplicate-controller-diagnostics';
-import { acquireControllerLock } from '../../src/utils/controller-lock';
+} from '../../src/chrome/duplicate-controller-diagnostics';
+import { acquireControllerLock } from '../../src/chrome/controller-lock';
 
 describe('duplicate controller diagnostics', () => {
   let tmpDir: string;

--- a/tests/cli/doctor/checks/duplicate-controllers.test.ts
+++ b/tests/cli/doctor/checks/duplicate-controllers.test.ts
@@ -3,9 +3,9 @@ import { withPrescriptiveFields } from '../../../../src/cli/doctor';
 import {
   getCurrentControllerTopology,
   summarizeDuplicateControllerDiagnostics,
-} from '../../../../src/utils/duplicate-controller-diagnostics';
+} from '../../../../src/chrome/duplicate-controller-diagnostics';
 
-jest.mock('../../../../src/utils/duplicate-controller-diagnostics', () => ({
+jest.mock('../../../../src/chrome/duplicate-controller-diagnostics', () => ({
   getCurrentControllerTopology: jest.fn(),
   summarizeDuplicateControllerDiagnostics: jest.fn(),
 }));

--- a/tests/cli/doctor/runtime-diagnostics.test.ts
+++ b/tests/cli/doctor/runtime-diagnostics.test.ts
@@ -1,18 +1,18 @@
 import * as os from 'os';
 
-jest.mock('../../../src/utils/duplicate-controller-diagnostics', () => ({
+jest.mock('../../../src/chrome/duplicate-controller-diagnostics', () => ({
   getCurrentControllerTopology: jest.fn(),
 }));
 jest.mock('../../../src/broker/discovery', () => ({
   readBrokerMetadata: jest.fn(),
 }));
-jest.mock('../../../src/utils/controller-lock', () => ({
+jest.mock('../../../src/chrome/controller-lock', () => ({
   isPidAlive: jest.fn(),
 }));
 
-const { getCurrentControllerTopology } = jest.requireMock('../../../src/utils/duplicate-controller-diagnostics') as { getCurrentControllerTopology: jest.Mock };
+const { getCurrentControllerTopology } = jest.requireMock('../../../src/chrome/duplicate-controller-diagnostics') as { getCurrentControllerTopology: jest.Mock };
 const { readBrokerMetadata } = jest.requireMock('../../../src/broker/discovery') as { readBrokerMetadata: jest.Mock };
-const { isPidAlive } = jest.requireMock('../../../src/utils/controller-lock') as { isPidAlive: jest.Mock };
+const { isPidAlive } = jest.requireMock('../../../src/chrome/controller-lock') as { isPidAlive: jest.Mock };
 import { classifyRuntimePath, collectDoctorDiagnostics, displayPath } from '../../../src/cli/doctor/runtime-diagnostics';
 
 describe('doctor runtime diagnostics', () => {

--- a/tests/tools/connection-health.test.ts
+++ b/tests/tools/connection-health.test.ts
@@ -19,7 +19,7 @@ jest.mock('../../src/session-manager', () => ({
   getSessionManager: jest.fn(),
 }));
 
-jest.mock('../../src/utils/duplicate-controller-diagnostics', () => ({
+jest.mock('../../src/chrome/duplicate-controller-diagnostics', () => ({
   getCurrentControllerTopology: jest.fn(() => ({
     role: 'owner',
     port: 9222,

--- a/tests/transports/duplicate-controller-error-server.test.ts
+++ b/tests/transports/duplicate-controller-error-server.test.ts
@@ -3,7 +3,7 @@ import {
   DUPLICATE_CONTROLLER_ERROR_CODE,
   DuplicateControllerErrorServer,
 } from '../../src/transports/duplicate-controller-error-server';
-import { DuplicateControllerError, type ControllerLockMetadata } from '../../src/utils/controller-lock';
+import { DuplicateControllerError, type ControllerLockMetadata } from '../../src/chrome/controller-lock';
 
 function makeServer(): DuplicateControllerErrorServer {
   const owner: ControllerLockMetadata = {


### PR DESCRIPTION
## Summary
- move controller-lock and duplicate-controller-diagnostics from src/utils into src/chrome
- move their tests from tests/utils into tests/chrome
- update callers and docs to treat controller ownership as Chrome-domain behavior

## Paperthin routing
- readchk: inspected import surface and module responsibilities first
- macrothink: separated controller ownership from broader process/PID cleanup
- reorder: moved a coherent ownership group into src/chrome
- debloat: reduced src/utils by two domain-owned modules without shims
- sip: ran targeted tests plus build/lint/tier/structure checks

## Verification
- npx jest --config jest.ci.config.js --runInBand --silent --runTestsByPath tests/chrome/controller-lock.test.ts tests/chrome/duplicate-controller-diagnostics.test.ts tests/cli/doctor/runtime-diagnostics.test.ts tests/cli/doctor/checks/duplicate-controllers.test.ts tests/tools/connection-health.test.ts tests/transports/duplicate-controller-error-server.test.ts
- npm run build
- npm run lint
- npm run lint:tier
- npm run lint:repo-structure
- git diff --check