### PR TITLE
Move process lifecycle helpers into core

### DIFF
--- a/src/chrome/launcher.ts
+++ b/src/chrome/launcher.ts
@@ -17,7 +17,7 @@ import { checkDebugPort, DebugPortTimeoutError, waitForDebugPort } from './launc
 import { ProfileManager } from './profile-manager';
 import type { ProfileType } from './profile-manager';
 import { writeMarker, removeMarker } from './ownership-marker';
-import { registerManagedChrome, unregisterManagedChrome } from '../utils/sync-shutdown';
+import { registerManagedChrome, unregisterManagedChrome } from '../core/process/sync-shutdown';
 import { classifyExit, ExitClassification, quiesceMs } from './exit-classifier';
 import { getLifecycleBus } from '../core/lifecycle';
 import type { ChromeExitReason } from '../core/lifecycle';

--- a/src/core/process/idle-timeout.ts
+++ b/src/core/process/idle-timeout.ts
@@ -21,7 +21,7 @@
  *    shutdown.
  */
 
-import { IdleState } from './idle-state';
+import { IdleState } from '../../utils/idle-state';
 
 /** Units accepted by `parseDuration` (see also issue #649 §3.2). */
 const DURATION_UNITS: Record<string, number> = {

--- a/src/core/process/sync-shutdown.ts
+++ b/src/core/process/sync-shutdown.ts
@@ -17,9 +17,9 @@
  * Best-effort: we never throw; failures are logged to stderr.
  */
 
-import { killProcessTree } from '../chrome/pid-manager';
-import { removeMarker } from '../chrome/ownership-marker';
-import { shouldKillChromeOnExit } from './session-resume-token';
+import { killProcessTree } from '../../chrome/pid-manager';
+import { removeMarker } from '../../chrome/ownership-marker';
+import { shouldKillChromeOnExit } from '../../utils/session-resume-token';
 
 const LOG_PREFIX = '[openchrome:sync-shutdown]';
 

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -41,7 +41,7 @@ import { SessionStatePersistence } from '../session/state-persistence';
 import { getLifecycleBus, type LifecycleEventBus } from './lifecycle';
 import { writePidFile, cleanOrphanedChromeProcesses } from '../chrome/pid-manager';
 import { installParentWatcher } from './process/parent-watcher';
-import { installIdleTimeout } from '../utils/idle-timeout';
+import { installIdleTimeout } from './process/idle-timeout';
 import { getIdleState } from '../utils/idle-state';
 import { getListenerErrorStats } from '../utils/safe-listener';
 import type { MCPServer } from '../mcp-server';

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { resolveWindowBoundsConfig } from './config/window-bounds';
 import { ToolTier } from './config/tool-tiers';
 import { writePidFile, cleanOrphanedChromeProcesses } from './chrome/pid-manager';
 import { installParentWatcher, ParentWatcherHandle } from './core/process/parent-watcher';
-import { installIdleTimeout, IdleTimeoutHandle, parseDuration } from './utils/idle-timeout';
+import { installIdleTimeout, IdleTimeoutHandle, parseDuration } from './core/process/idle-timeout';
 import { getIdleState } from './utils/idle-state';
 import { getVersion } from './version';
 import { bootstrapPilot, logActiveFlags } from './harness/flags';

--- a/src/transports/stdio.ts
+++ b/src/transports/stdio.ts
@@ -7,7 +7,7 @@
 import * as readline from 'readline';
 import { MCPResponse, MCPErrorCodes } from '../types/mcp';
 import { MCPTransport, TransportMessageContext } from './index';
-import { shutdownSyncBestEffort } from '../utils/sync-shutdown';
+import { shutdownSyncBestEffort } from '../core/process/sync-shutdown';
 
 const STANDALONE_STDOUT_CHUNK_CHARS = 16_384;
 

--- a/tests/core/process/idle-timeout.test.ts
+++ b/tests/core/process/idle-timeout.test.ts
@@ -3,8 +3,8 @@ import {
   installIdleTimeout,
   parseDuration,
   formatDuration,
-} from '../../src/utils/idle-timeout';
-import { createIdleState } from '../../src/utils/idle-state';
+} from '../../../src/core/process/idle-timeout';
+import { createIdleState } from '../../../src/utils/idle-state';
 
 describe('parseDuration', () => {
   test('accepts standard unit suffixes', () => {

--- a/tests/core/process/sync-shutdown.test.ts
+++ b/tests/core/process/sync-shutdown.test.ts
@@ -4,17 +4,17 @@ import {
   unregisterManagedChrome,
   listRegisteredManagedChromes,
   _resetForTesting,
-} from '../../src/utils/sync-shutdown';
+} from '../../../src/core/process/sync-shutdown';
 
-jest.mock('../../src/chrome/pid-manager', () => {
-  const actual = jest.requireActual('../../src/chrome/pid-manager');
+jest.mock('../../../src/chrome/pid-manager', () => {
+  const actual = jest.requireActual('../../../src/chrome/pid-manager');
   return {
     ...actual,
     killProcessTree: jest.fn(),
   };
 });
 
-import { killProcessTree } from '../../src/chrome/pid-manager';
+import { killProcessTree } from '../../../src/chrome/pid-manager';
 
 describe('sync-shutdown (#661 Phase 2)', () => {
   beforeEach(() => {

--- a/tests/integration/embedded-server.test.ts
+++ b/tests/integration/embedded-server.test.ts
@@ -182,7 +182,7 @@ jest.mock('../../src/utils/idle-state', () => ({
   getIdleState: jest.fn(() => ({})),
 }));
 
-jest.mock('../../src/utils/idle-timeout', () => ({
+jest.mock('../../src/core/process/idle-timeout', () => ({
   installIdleTimeout: jest.fn(() => ({ stop: jest.fn() })),
 }));
 


### PR DESCRIPTION
## Summary
- move idle-timeout and sync-shutdown from src/utils into src/core/process
- move their tests from tests/utils into tests/core/process
- update runtime imports in CLI, core server, stdio transport, and Chrome launcher

## Paperthin routing
- readchk: inspected lifecycle utility usage and boundaries
- macrothink: separated host process lifecycle from Chrome PID primitives
- reorder: placed host process helpers under src/core/process
- debloat: reduced src/utils by two more domain-owned modules
- sip: ran targeted lifecycle tests plus build/lint/tier/structure checks

## Verification
- npx jest --config jest.ci.config.js --runInBand --silent --runTestsByPath tests/core/process/idle-timeout.test.ts tests/core/process/sync-shutdown.test.ts tests/integration/embedded-server.test.ts tests/integration/idle-timeout.test.ts tests/integration/shutdown-reentrancy.test.ts
- npm run build
- npm run lint
- npm run lint:tier
- npm run lint:repo-structure
- git diff --check