### PR TITLE
Keep snapshot cache wiring with perception

### DIFF
--- a/src/core/perception/snapshot-cache-helper.ts
+++ b/src/core/perception/snapshot-cache-helper.ts
@@ -20,8 +20,8 @@
  */
 
 import type { Page } from 'puppeteer-core';
-import type { ToolContext } from '../types/mcp';
-import { isCoreFeatureEnabled } from '../harness/flags';
+import type { ToolContext } from '../../types/mcp';
+import { isCoreFeatureEnabled } from '../../harness/flags';
 import {
   getSnapshotCacheForTarget,
   disposeSnapshotCacheForTarget,
@@ -30,8 +30,8 @@ import {
   type SnapshotCacheKey,
   type SnapshotKind,
   type SnapshotViewportRect,
-} from '../core/perception/snapshot-cache';
-import { getTargetId } from '../cdp/target-id';
+} from './snapshot-cache';
+import { getTargetId } from '../../cdp/target-id';
 
 const FLAG_ENV_VAR = 'OPENCHROME_SNAPSHOT_CACHE';
 

--- a/src/tools/fill-form.ts
+++ b/src/tools/fill-form.ts
@@ -19,7 +19,7 @@ import { normalizeQuery } from '../dom/element-finder';
 import { humanType, humanMouseMove } from '../stealth/human-behavior';
 import { isPilotEnabled } from '../harness/flags';
 import { detectLoginOutcome, LoginDetectResult } from './login-detector';
-import { wrapMutatingHandler } from '../utils/snapshot-cache-helper';
+import { wrapMutatingHandler } from '../core/perception/snapshot-cache-helper';
 import { coerceVerifyMode, runVerify, VERIFY_FIELD_SCHEMA } from '../core/perception/verify';
 import { captureBackendNodeReplayStep, capturePageReplayStep, shouldCaptureReplayArtifact } from './_shared/replay-recorder';
 import { appendReturnAfterState, parseReturnAfterState, RETURN_AFTER_STATE_SCHEMA } from './_shared/return-after-state';

--- a/src/tools/javascript.ts
+++ b/src/tools/javascript.ts
@@ -8,7 +8,7 @@ import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { assertDomainAllowed } from '../security/domain-guard';
 import { withTimeout } from '../utils/with-timeout';
-import { wrapMutatingHandler } from '../utils/snapshot-cache-helper';
+import { wrapMutatingHandler } from '../core/perception/snapshot-cache-helper';
 
 const definition: MCPToolDefinition = {
   name: 'javascript_tool',

--- a/src/tools/lightweight-scroll.ts
+++ b/src/tools/lightweight-scroll.ts
@@ -14,7 +14,7 @@ import { getSessionManager } from '../session-manager';
 import { withTimeout } from '../utils/with-timeout';
 import { retryWithFallback } from '../utils/retry-with-fallback';
 import { humanScroll } from '../stealth/human-behavior';
-import { wrapMutatingHandler } from '../utils/snapshot-cache-helper';
+import { wrapMutatingHandler } from '../core/perception/snapshot-cache-helper';
 
 const definition: MCPToolDefinition = {
   name: 'lightweight_scroll',

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -23,7 +23,7 @@ import { getHeadedFallback } from '../chrome/headed-fallback';
 import { getGlobalConfig } from '../config/global';
 import { autoRecallForUrl } from '../core/skill-memory/auto-recall';
 import type { Page } from 'puppeteer-core';
-import { wrapMutatingHandler } from '../utils/snapshot-cache-helper';
+import { wrapMutatingHandler } from '../core/perception/snapshot-cache-helper';
 import { captureNavigationReplayStep, shouldCaptureReplayArtifact } from './_shared/replay-recorder';
 import { getBrowserLane, recordLaneToolCall, resolveLaneForTool } from '../core/browser-lanes';
 

--- a/src/tools/page-reload.ts
+++ b/src/tools/page-reload.ts
@@ -8,7 +8,7 @@ import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { safeTitle } from '../core/page/safe-title';
 import { DEFAULT_NAVIGATION_TIMEOUT_MS } from '../config/defaults';
-import { wrapMutatingHandler } from '../utils/snapshot-cache-helper';
+import { wrapMutatingHandler } from '../core/perception/snapshot-cache-helper';
 
 const definition: MCPToolDefinition = {
   name: 'page_reload',

--- a/src/tools/query-dom.ts
+++ b/src/tools/query-dom.ts
@@ -11,7 +11,7 @@ import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { withTimeout } from '../utils/with-timeout';
 import { getAllShadowRoots, querySelectorInShadowRoots } from '../dom/shadow-dom';
-import { isSnapshotCacheEnabled } from '../utils/snapshot-cache-helper';
+import { isSnapshotCacheEnabled } from '../core/perception/snapshot-cache-helper';
 import { getCurrentLoaderId, mintNodeRefSync } from '../core/perception/node-ref';
 import { decodeCursor, encodeCursor, paginate } from '../mcp/pagination';
 

--- a/src/tools/tabs-activate.ts
+++ b/src/tools/tabs-activate.ts
@@ -12,7 +12,7 @@ import {
   type ToolHandler,
 } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
-import { wrapMutatingHandler } from '../utils/snapshot-cache-helper';
+import { wrapMutatingHandler } from '../core/perception/snapshot-cache-helper';
 
 const DEFAULT_ACTIVATION_DEADLINE_MS = 5000;
 const MAX_ACTIVATION_ATTEMPTS = 3;

--- a/src/tools/tabs-create.ts
+++ b/src/tools/tabs-create.ts
@@ -14,7 +14,7 @@ import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { safeTitle } from '../core/page/safe-title';
 import { assertDomainAllowed, DomainPolicyError } from '../security/domain-guard';
-import { wrapMutatingHandler } from '../utils/snapshot-cache-helper';
+import { wrapMutatingHandler } from '../core/perception/snapshot-cache-helper';
 import { autoRecallForUrl } from '../core/skill-memory/auto-recall';
 import {
   DEFAULT_CONTEXT_NAME,

--- a/tests/core/perception/snapshot-cache.test.ts
+++ b/tests/core/perception/snapshot-cache.test.ts
@@ -12,7 +12,7 @@
  *   5. Any uncertainty (stale epoch, ttl expiry) returns a forced miss.
  *
  * The test suite does NOT pull in the host-side CDP wiring; that lives in
- * `src/utils/snapshot-cache-helper.ts` and is verified by integration tests.
+ * `src/core/perception/snapshot-cache-helper.ts` and is verified by integration tests.
  */
 
 import {
@@ -20,7 +20,7 @@ import {
   type SnapshotCacheKey,
   type SnapshotKind,
 } from '../../../src/core/perception/snapshot-cache';
-import { getCacheForPage } from '../../../src/utils/snapshot-cache-helper';
+import { getCacheForPage } from '../../../src/core/perception/snapshot-cache-helper';
 
 function makeKey(
   cache: SnapshotCache,


### PR DESCRIPTION
## Summary
- move snapshot cache page wiring from generic utils into src/core/perception
- update mutating tool wrappers and query-dom cache flag import to the new owner
- update the perception cache test comment/import

## Verification
- npm test -- --runTestsByPath tests/core/perception/snapshot-cache.test.ts tests/tools/navigate.test.ts tests/tools/tabs-activate.test.ts tests/tools/fill-form.verify.test.ts tests/tools/tabs-create.auto-recall.test.ts --runInBand
- npm run build
- npm run lint
- npm run lint:tier
- npm run lint:repo-structure
- git diff --check