### PR TITLE
Move deadline budgets into core

### DIFF
--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -28,7 +28,7 @@ import {
   DEFAULT_RECONNECT_DELAY_MS,
   DEFAULT_SESSION_INIT_MIN_ATTEMPT_MS,
 } from '../config/defaults';
-import { Budget, isLegacyBudgetMode } from '../utils/budget';
+import { Budget, isLegacyBudgetMode } from '../core/deadline/budget';
 import { withTimeout } from '../utils/with-timeout';
 import { getMetricsCollector } from '../metrics/collector';
 import { OpenChromeConnectionError } from '../errors/connection';

--- a/src/cdp/errors.ts
+++ b/src/cdp/errors.ts
@@ -3,7 +3,7 @@
  *
  * Callers use `instanceof` to distinguish structural failure modes from
  * generic Error instances. Kept in its own file to avoid circular imports
- * from `client.ts` and `../utils/budget.ts`.
+ * from `client.ts` and `../core/deadline/budget.ts`.
  */
 
 /**

--- a/src/core/deadline/budget.ts
+++ b/src/core/deadline/budget.ts
@@ -98,7 +98,7 @@ class BudgetImpl implements Budget {
 
   private throwExhausted(context: string): never {
     // Lazy import avoids circular deps with other cdp modules if they evolve.
-    const { SessionInitBudgetExhausted } = require('../cdp/errors') as typeof import('../cdp/errors');
+    const { SessionInitBudgetExhausted } = require('../../cdp/errors') as typeof import('../../cdp/errors');
     throw new SessionInitBudgetExhausted(context, this.label, this.elapsedMs(), this.totalMs);
   }
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -39,7 +39,7 @@ import { getChromeLauncher } from '../chrome/launcher';
 import { getChromePool } from '../chrome/pool';
 import { ToolManifest, ToolEntry, ToolCategory } from '../types/tool-manifest';
 import { DEFAULT_TOOL_EXECUTION_TIMEOUT_MS, DEFAULT_SESSION_INIT_TIMEOUT_MS, DEFAULT_SESSION_INIT_TIMEOUT_AUTO_LAUNCH_MS, DEFAULT_RECONNECT_TIMEOUT_MS, DEFAULT_OPERATION_GATE_TIMEOUT_MS, DEFAULT_HEARTBEAT_IDLE_TIMEOUT_MS, DEFAULT_RATE_LIMIT_RPM } from '../config/defaults';
-import { createBudget, isLegacyBudgetMode } from '../utils/budget';
+import { createBudget, isLegacyBudgetMode } from '../core/deadline/budget';
 import { SessionInitBudgetExhausted } from '../cdp/errors';
 import { getGlobalEventLoopMonitor } from '../watchdog/event-loop-monitor';
 import { getIdleState } from '../core/activity/idle-state';

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -44,7 +44,7 @@ import { getTenantManager, isStrictTenantIsolationEnabled } from '../tenant/regi
 import type { TenantManager } from '../tenant/manager';
 import { DEFAULT_TENANT_ID, type TenantId } from '../tenant/types';
 import { currentRequestContext } from '../observability/request-id';
-import { Budget, isLegacyBudgetMode } from '../utils/budget';
+import { Budget, isLegacyBudgetMode } from '../core/deadline/budget';
 import {
   DEFAULT_SESSION_INIT_BUDGET_LAUNCH_FRACTION,
   DEFAULT_SESSION_INIT_BUDGET_CONNECT_FRACTION,

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -80,7 +80,7 @@ export interface SessionCreateOptions {
   tenantId?: TenantId;
   /** Optional time budget for the underlying CDP connect path (A-3).
    *  Typed as `unknown` here to keep the shared types file free of a
-   *  dependency on the utils/budget module; consumers cast to `Budget`. */
+   *  dependency on the core/deadline/budget module; consumers cast to `Budget`. */
   budget?: unknown;
 }
 

--- a/tests/cdp/active-probe.test.ts
+++ b/tests/cdp/active-probe.test.ts
@@ -32,7 +32,7 @@ jest.mock('../../src/config/global', () => ({
 // ─── Imports ──────────────────────────────────────────────────────────────────
 
 import { CDPClient } from '../../src/cdp/client';
-import { createBudget } from '../../src/utils/budget';
+import { createBudget } from '../../src/core/deadline/budget';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/tests/cdp/session-init-budget.test.ts
+++ b/tests/cdp/session-init-budget.test.ts
@@ -41,7 +41,7 @@ jest.mock('../../src/config/defaults', () => {
 // ─── Imports ──────────────────────────────────────────────────────────────────
 
 import { CDPClient } from '../../src/cdp/client';
-import { createBudget } from '../../src/utils/budget';
+import { createBudget } from '../../src/core/deadline/budget';
 import { SessionInitBudgetExhausted } from '../../src/cdp/errors';
 
 const puppeteerMock = jest.requireMock('puppeteer-core') as { default: { connect: jest.Mock } };

--- a/tests/core/deadline/budget.test.ts
+++ b/tests/core/deadline/budget.test.ts
@@ -1,5 +1,5 @@
-import { createBudget, isLegacyBudgetMode } from '../../src/utils/budget';
-import { SessionInitBudgetExhausted } from '../../src/cdp/errors';
+import { createBudget, isLegacyBudgetMode } from '../../../src/core/deadline/budget';
+import { SessionInitBudgetExhausted } from '../../../src/cdp/errors';
 
 const tick = (ms: number) => new Promise((r) => setTimeout(r, ms));
 


### PR DESCRIPTION
## Summary
- move shared Budget primitive into src/core/deadline
- update CDP/session/MCP imports to the new owner
- move the budget unit test under tests/core/deadline

## Verification
- npm test -- --runTestsByPath tests/core/deadline/budget.test.ts tests/cdp/session-init-budget.test.ts tests/cdp/active-probe.test.ts --runInBand
- npm run build
- npm run lint
- npm run lint:tier
- npm run lint:repo-structure
- git diff --check