### PR TITLE
Move operation timeouts into core deadlines

### DIFF
--- a/docs/roadmap/issue-reliability-guarantee.md
+++ b/docs/roadmap/issue-reliability-guarantee.md
@@ -326,7 +326,7 @@ What survived rigorous re-verification:
   context: **D4** in `ssot-decisions.md`.
 
 - **L2 — Timeout/abort does not cancel the underlying CDP call.** On tool timeout or client
-  abort, `src/utils/with-timeout.ts` returns immediately and leaves the in-flight CDP command
+  abort, `src/core/deadline/with-timeout.ts` returns immediately and leaves the in-flight CDP command
   running (an "orphaned background call", acknowledged in that file's own doc comment). This is a
   *deliberate* trade-off in favour of never-hang, with an accepted residual "ghost effect" risk
   (the operation may complete after the error was returned). Promoted from a buried code comment

--- a/docs/roadmap/ssot-decisions.md
+++ b/docs/roadmap/ssot-decisions.md
@@ -216,7 +216,7 @@ only** and is **at-least-once**, not at-most-once:
 
 ## D5. Timeout / abort cancellation semantics
 
-Recorded 2026-06-02. Promotes the doc comment in `src/utils/with-timeout.ts` to a
+Recorded 2026-06-02. Promotes the doc comment in `src/core/deadline/with-timeout.ts` to a
 normative decision.
 
 **Decision.** On a tool-execution timeout or a client `AbortSignal`, OpenChrome

--- a/src/cdp/client.ts
+++ b/src/cdp/client.ts
@@ -29,7 +29,7 @@ import {
   DEFAULT_SESSION_INIT_MIN_ATTEMPT_MS,
 } from '../config/defaults';
 import { Budget, isLegacyBudgetMode } from '../core/deadline/budget';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { getMetricsCollector } from '../metrics/collector';
 import { OpenChromeConnectionError } from '../errors/connection';
 import { getStealthFingerprintDefenseScript, getStealthStackSanitizationScript } from '../stealth/fingerprint-defense';

--- a/src/core/deadline/with-timeout.ts
+++ b/src/core/deadline/with-timeout.ts
@@ -1,5 +1,5 @@
-import { OpenChromeTimeoutError } from '../errors/timeout';
-import { ToolContext, getRemainingBudget } from '../types/mcp';
+import { OpenChromeTimeoutError } from '../../errors/timeout';
+import { ToolContext, getRemainingBudget } from '../../types/mcp';
 
 /**
  * Race a promise against a timeout. Rejects with an OpenChromeTimeoutError if the timeout fires first.

--- a/src/core/page/ready-state.ts
+++ b/src/core/page/ready-state.ts
@@ -2,7 +2,7 @@ import type { Page } from 'puppeteer-core';
 import type { ToolContext } from '../../types/mcp';
 import { getRemainingBudget } from '../../types/mcp';
 import { isTimeoutError } from '../../errors/timeout';
-import { withTimeout } from '../../utils/with-timeout';
+import { withTimeout } from '../deadline/with-timeout';
 
 export interface PageReadyOptions {
   /** Maximum wall-clock wait in ms. Default: 5000. */

--- a/src/core/page/safe-title.ts
+++ b/src/core/page/safe-title.ts
@@ -8,7 +8,7 @@
 
 import type { Page } from 'puppeteer-core';
 import { DEFAULT_SAFE_TITLE_TIMEOUT_MS } from '../../config/defaults';
-import { withTimeout } from '../../utils/with-timeout';
+import { withTimeout } from '../deadline/with-timeout';
 
 export async function safeTitle(
   page: Page,

--- a/src/core/screenshot/guards.ts
+++ b/src/core/screenshot/guards.ts
@@ -2,7 +2,7 @@ import {
   MAX_CAPTURE_AREA_PIXELS,
   MAX_INLINE_IMAGE_PAYLOAD_BYTES,
 } from '../../config/defaults';
-import { withTimeout } from '../../utils/with-timeout';
+import { withTimeout } from '../deadline/with-timeout';
 
 export { MAX_CAPTURE_AREA_PIXELS, MAX_INLINE_IMAGE_PAYLOAD_BYTES };
 

--- a/src/dom/dom-delta.ts
+++ b/src/dom/dom-delta.ts
@@ -8,7 +8,7 @@
 
 import type { Page } from 'puppeteer-core';
 import { safeTitle } from '../core/page/safe-title';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 
 export interface DomDeltaOptions {
   /**

--- a/src/dom/dom-serializer.ts
+++ b/src/dom/dom-serializer.ts
@@ -4,7 +4,7 @@
 
 import type { Page } from 'puppeteer-core';
 import { MAX_OUTPUT_CHARS, DEFAULT_MAX_SERIALIZER_NODES } from '../config/defaults';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { formatAffordancePrefix } from './element-affordance';
 
 export interface DOMSerializerOptions {

--- a/src/dom/element-discovery.ts
+++ b/src/dom/element-discovery.ts
@@ -11,7 +11,7 @@ import { Page } from 'puppeteer-core';
 import { CDPClient } from '../cdp/client';
 import { FoundElement } from './element-finder';
 import { discoverShadowElements, DEEP_WALK_ELEMENTS_JS, getAllShadowRoots, querySelectorInShadowRoots } from './shadow-dom';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 
 /**
  * Optional circuit breaker interface for element discovery.

--- a/src/orchestration/plan-executor.ts
+++ b/src/orchestration/plan-executor.ts
@@ -22,7 +22,7 @@ import { evaluate } from '../contracts/evaluate';
 import type { EvalContext, NetworkLogEntry } from '../contracts/eval-context';
 import { evaluateTaskSignature, preflightAllowedTools } from '../contracts/task-signature';
 import type { TaskSignatureToolCallSummary } from '../contracts/task-signature';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 
 const SAFE_CONTRACT_MAX_RECOVERY_STEPS = 10;
 

--- a/src/tools/act.ts
+++ b/src/tools/act.ts
@@ -17,7 +17,7 @@ import { resolveElementsByAXTree, invalidateAXCache, AXResolvedElement } from '.
 import { getTargetId } from '../cdp/target-id';
 import { classifyOutcome, formatOutcomeLine } from '../recovery/ralph/outcome-classifier';
 import { humanMouseMove, humanType } from '../stealth/human-behavior';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { cleanupTags, DISCOVERY_TAG } from '../dom/element-discovery';
 import { parseInstruction, ParsedAction } from '../actions/action-parser';
 import { matchTemplate } from '../actions/action-templates';

--- a/src/tools/batch-paginate.ts
+++ b/src/tools/batch-paginate.ts
@@ -14,7 +14,7 @@ import { getSessionManager } from '../session-manager';
 import { getScreenshotScheduler } from '../cdp/screenshot-scheduler';
 import { DEFAULT_SCREENSHOT_QUALITY, DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS, DEFAULT_SCREENSHOT_TIMEOUT_MS, MAX_OUTPUT_CHARS } from '../config/defaults';
 import { withDomDelta } from '../dom/dom-delta';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { normalizeImageMimeType, makeImageContent, type SupportedImageMimeType } from '../core/screenshot/image-mime';
 
 const definition: MCPToolDefinition = {

--- a/src/tools/computer.ts
+++ b/src/tools/computer.ts
@@ -14,7 +14,7 @@ import { withDomDelta } from '../dom/dom-delta';
 import { generateVisualSummary } from '../core/page/visual-summary';
 import { AdaptiveScreenshot } from '../core/screenshot/adaptive';
 import { makeImageContent } from '../core/screenshot/image-mime';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { retryWithFallback } from '../utils/retry-with-fallback';
 import { detectPagination, type PaginationInfo } from './pagination-detector';
 import {

--- a/src/tools/crawl-sitemap.ts
+++ b/src/tools/crawl-sitemap.ts
@@ -12,7 +12,7 @@ import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } fro
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { MAX_OUTPUT_CHARS } from '../config/defaults';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import {
   normalizeUrl,
   parseSitemapXml,

--- a/src/tools/crawl.ts
+++ b/src/tools/crawl.ts
@@ -13,7 +13,7 @@ import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } fro
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { MAX_OUTPUT_CHARS } from '../config/defaults';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import {
   normalizeUrl,
   matchesScope,

--- a/src/tools/element-pick.ts
+++ b/src/tools/element-pick.ts
@@ -2,7 +2,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolContext, ToolHandler, throwIfAborted } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import {
   buildPickedElement,
   clampBoundingBox,

--- a/src/tools/extract-data.ts
+++ b/src/tools/extract-data.ts
@@ -6,7 +6,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { waitForPageReady } from '../core/page/ready-state';
 import { formatStaleRefError, getRefIdManager } from '../core/perception/ref-id-manager';
 import { extractMainContent, toMarkdown } from '../core/extract/html-to-markdown';

--- a/src/tools/file-upload.ts
+++ b/src/tools/file-upload.ts
@@ -11,7 +11,7 @@ import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getGlobalConfig } from '../config/global';
 import { DEFAULT_FILE_UPLOAD_TEMP_DIR } from '../config/defaults';
 import { getSessionManager } from '../session-manager';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 
 const OPENCHROME_FILE_UPLOAD_ROOTS_ENV = 'OPENCHROME_FILE_UPLOAD_ROOTS';
 const OPENCHROME_FILE_UPLOAD_TEMP_DIR_ENV = 'OPENCHROME_FILE_UPLOAD_TEMP_DIR';

--- a/src/tools/fill-form.ts
+++ b/src/tools/fill-form.ts
@@ -11,7 +11,7 @@ import { getSessionManager } from '../session-manager';
 import { getRefIdManager, formatStaleRefError, makeStaleRefError } from '../core/perception/ref-id-manager';
 import { DEFAULT_DOM_SETTLE_DELAY_MS, DEFAULT_FORM_SUBMIT_SETTLE_MS } from '../config/defaults';
 import { withDomDelta } from '../dom/dom-delta';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { discoverFormFields, FormField, FORM_FIELD_TAG } from '../dom/element-discovery';
 import { resolveElementsByAXTree, invalidateAXCache } from '../dom/ax-element-resolver';
 import { getTargetId } from '../cdp/target-id';

--- a/src/tools/find.ts
+++ b/src/tools/find.ts
@@ -7,7 +7,7 @@ import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } fro
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { getRefIdManager } from '../core/perception/ref-id-manager';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { discoverElements, cleanupTags, DISCOVERY_TAG } from '../dom/element-discovery';
 import { FoundElement, normalizeQuery, scoreElement, tokenizeQuery } from '../dom/element-finder';
 import { resolveElementsByAXTree } from '../dom/ax-element-resolver';

--- a/src/tools/inspect.ts
+++ b/src/tools/inspect.ts
@@ -12,7 +12,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { getAllShadowRoots, querySelectorInShadowRoots } from '../dom/shadow-dom';
 import { appendMetricsFooter, buildTextMetrics } from '../core/metrics/token-estimate';
 import { prependHeaderText } from './_shared/state-header';

--- a/src/tools/interact.ts
+++ b/src/tools/interact.ts
@@ -13,7 +13,7 @@ import { withDomDelta } from '../dom/dom-delta';
 import { DEFAULT_DOM_SETTLE_DELAY_MS, DEFAULT_SCREENSHOT_RACE_TIMEOUT_MS, DEFAULT_SCREENSHOT_TIMEOUT_MS } from '../config/defaults';
 import { FoundElement, normalizeQuery, scoreElement, tokenizeQuery } from '../dom/element-finder';
 import { discoverElements, getTaggedElementRect, cleanupTags, DISCOVERY_TAG } from '../dom/element-discovery';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { makeImageContent } from '../core/screenshot/image-mime';
 import { resolveElementsByAXTree, invalidateAXCache, MATCH_LEVEL_LABELS } from '../dom/ax-element-resolver';
 import { getTargetId } from '../cdp/target-id';

--- a/src/tools/javascript.ts
+++ b/src/tools/javascript.ts
@@ -7,7 +7,7 @@ import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, throwIfAborted 
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { assertDomainAllowed } from '../security/domain-guard';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { wrapMutatingHandler } from '../core/perception/snapshot-cache-helper';
 
 const definition: MCPToolDefinition = {

--- a/src/tools/lightweight-scroll.ts
+++ b/src/tools/lightweight-scroll.ts
@@ -11,7 +11,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { retryWithFallback } from '../utils/retry-with-fallback';
 import { humanScroll } from '../stealth/human-behavior';
 import { wrapMutatingHandler } from '../core/perception/snapshot-cache-helper';

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -17,7 +17,7 @@ import { isDynamicSkillsEnabled } from '../harness/flags';
 import { detectBlockingPage, BlockingInfo } from '../core/page/diagnostics';
 import { handleCaptcha } from '../captcha/handler';
 import { getSolverRegistry } from '../captcha/solver-registry';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { simulatePresence } from '../stealth/human-behavior';
 import { getHeadedFallback } from '../chrome/headed-fallback';
 import { getGlobalConfig } from '../config/global';

--- a/src/tools/oc-observe.ts
+++ b/src/tools/oc-observe.ts
@@ -25,7 +25,7 @@ import {
 } from '../types/mcp';
 import { getSessionManager } from '../session-manager';
 import { getRefIdManager } from '../core/perception/ref-id-manager';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import type { CDPClient } from '../cdp/client';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 

--- a/src/tools/oc-vitals.ts
+++ b/src/tools/oc-vitals.ts
@@ -4,7 +4,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { collectWebVitalsInPage, normalizeWebVitals, RawWebVitals } from '../core/perf/web-vitals-collector';
 
 const definition: MCPToolDefinition = {

--- a/src/tools/page-content.ts
+++ b/src/tools/page-content.ts
@@ -7,7 +7,7 @@ import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { MAX_OUTPUT_CHARS, DEFAULT_NAVIGATION_TIMEOUT_MS } from '../config/defaults';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { mergeHeaderJson, isStateHeaderEnabled } from './_shared/state-header';
 import { areBoundaryMarkersEnabled, wrapBoundaryMarker } from '../core/perception/boundary-markers';
 

--- a/src/tools/page-screenshot.ts
+++ b/src/tools/page-screenshot.ts
@@ -14,7 +14,7 @@ import {
   resolveViewportDimensions,
   validateCaptureArea,
 } from '../core/screenshot/guards';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { makeImageContent, type SupportedImageMimeType } from '../core/screenshot/image-mime';
 
 const FULL_PAGE_DIMENSION_TIMEOUT_MS = 5000;

--- a/src/tools/pagination-detector.ts
+++ b/src/tools/pagination-detector.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Page } from 'puppeteer-core';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 
 export interface PaginationInfo {
   type: 'numbered' | 'next_button' | 'load_more' | 'infinite_scroll' | 'cursor' | 'viewer' | 'none';

--- a/src/tools/performance-metrics.ts
+++ b/src/tools/performance-metrics.ts
@@ -6,7 +6,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolContext, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { buildPerformanceContractFacts } from '../contracts/contract-facts';
 import { redactSecretStringWithMetadata } from '../core/secrets/redactor';
 

--- a/src/tools/query-dom.ts
+++ b/src/tools/query-dom.ts
@@ -9,7 +9,7 @@ import { MCPServer } from '../mcp-server';
 import { MCPToolDefinition, MCPResult, ToolHandler, ToolContext, hasBudget } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { getAllShadowRoots, querySelectorInShadowRoots } from '../dom/shadow-dom';
 import { isSnapshotCacheEnabled } from '../core/perception/snapshot-cache-helper';
 import { getCurrentLoaderId, mintNodeRefSync } from '../core/perception/node-ref';

--- a/src/tools/read-page.ts
+++ b/src/tools/read-page.ts
@@ -13,7 +13,7 @@ import { serializeDOM } from '../dom';
 import { detectPagination, PaginationInfo } from './pagination-detector';
 import { MAX_OUTPUT_CHARS } from '../config/defaults';
 import { isFastProfile } from '../config/runtime-profile';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 import { SnapshotStore } from '../compression/snapshot-store';
 import { sanitizeContent } from '../security/content-sanitizer';
 import { appendMetricsFooter, buildTextMetrics } from '../core/metrics/token-estimate';

--- a/src/tools/storage.ts
+++ b/src/tools/storage.ts
@@ -7,7 +7,7 @@ import { MCPToolDefinition, MCPResult, ToolHandler } from '../types/mcp';
 import { TOOL_ANNOTATIONS } from '../types/tool-annotations';
 import { getSessionManager } from '../session-manager';
 import { assertDomainAllowed } from '../security/domain-guard';
-import { withTimeout } from '../utils/with-timeout';
+import { withTimeout } from '../core/deadline/with-timeout';
 
 const definition: MCPToolDefinition = {
   name: 'storage',

--- a/tests/core/deadline/with-timeout.test.ts
+++ b/tests/core/deadline/with-timeout.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="jest" />
-import { withTimeout } from '../../src/utils/with-timeout';
-import { OpenChromeTimeoutError } from '../../src/errors/timeout';
-import { ToolContext } from '../../src/types/mcp';
+import { withTimeout } from '../../../src/core/deadline/with-timeout';
+import { OpenChromeTimeoutError } from '../../../src/errors/timeout';
+import { ToolContext } from '../../../src/types/mcp';
 
 describe('withTimeout', () => {
   test('should resolve when promise completes before timeout', async () => {

--- a/tests/tools/act.test.ts
+++ b/tests/tools/act.test.ts
@@ -63,7 +63,7 @@ jest.mock('../../src/recovery/ralph/outcome-classifier', () => ({
 }));
 
 // Mock with-timeout — pass through
-jest.mock('../../src/utils/with-timeout', () => ({
+jest.mock('../../src/core/deadline/with-timeout', () => ({
   withTimeout: jest.fn().mockImplementation(async (promise: Promise<unknown>) => promise),
 }));
 
@@ -115,7 +115,7 @@ describe('ActTool', () => {
           `\u2713 ${verb} ${desc} ${ref} ${source}`
       ),
     }));
-    jest.doMock('../../src/utils/with-timeout', () => ({
+    jest.doMock('../../src/core/deadline/with-timeout', () => ({
       withTimeout: jest.fn().mockImplementation(async (promise: Promise<unknown>) => promise),
     }));
 

--- a/tests/tools/interact-opened-tabs.test.ts
+++ b/tests/tools/interact-opened-tabs.test.ts
@@ -33,7 +33,7 @@ jest.mock('../../src/dom/element-discovery', () => ({
 jest.mock('../../src/stealth/human-behavior', () => ({
   humanMouseMove: jest.fn().mockResolvedValue(undefined),
 }));
-jest.mock('../../src/utils/with-timeout', () => ({
+jest.mock('../../src/core/deadline/with-timeout', () => ({
   withTimeout: jest.fn().mockImplementation(async (promise: Promise<unknown>) => promise),
 }));
 jest.mock('../../src/core/perception/verify', () => ({

--- a/tests/tools/interact.coordinate.test.ts
+++ b/tests/tools/interact.coordinate.test.ts
@@ -90,7 +90,7 @@ jest.mock('../../src/recovery/ralph/circuit-breaker', () => ({
 }));
 
 // With-timeout mock — pass through
-jest.mock('../../src/utils/with-timeout', () => ({
+jest.mock('../../src/core/deadline/with-timeout', () => ({
   withTimeout: jest.fn().mockImplementation(async (promise: Promise<unknown>) => promise),
 }));
 
@@ -151,7 +151,7 @@ describe('interact tool — coordinate mode', () => {
     jest.mock('../../src/cdp/target-id', () => ({ getTargetId: jest.fn().mockReturnValue('mock-target') }));
     jest.mock('../../src/recovery/ralph/outcome-classifier', () => ({ classifyOutcome: jest.fn().mockReturnValue('SUCCESS'), formatOutcomeLine: jest.fn().mockReturnValue('✓ Clicked') }));
     jest.mock('../../src/recovery/ralph/circuit-breaker', () => ({ getCircuitBreaker: jest.fn().mockReturnValue({ check: jest.fn().mockReturnValue({ allowed: true }), recordElementFailure: jest.fn(), recordElementSuccess: jest.fn() }) }));
-    jest.mock('../../src/utils/with-timeout', () => ({ withTimeout: jest.fn().mockImplementation(async (p: Promise<unknown>) => p) }));
+    jest.mock('../../src/core/deadline/with-timeout', () => ({ withTimeout: jest.fn().mockImplementation(async (p: Promise<unknown>) => p) }));
     jest.mock('../../src/cdp/input', () => ({ dispatchCoordinateClick: jest.fn().mockResolvedValue(undefined) }));
 
     let capturedHandler: ((sessionId: string, args: Record<string, unknown>) => Promise<unknown>) | null = null;

--- a/tests/tools/performance-metrics-contract-facts.test.ts
+++ b/tests/tools/performance-metrics-contract-facts.test.ts
@@ -3,14 +3,14 @@
 jest.mock('../../src/session-manager', () => ({
   getSessionManager: jest.fn(),
 }));
-jest.mock('../../src/utils/with-timeout', () => ({
+jest.mock('../../src/core/deadline/with-timeout', () => ({
   withTimeout: jest.fn(async (promise: Promise<unknown>) => promise),
 }));
 
 import { getSessionManager } from '../../src/session-manager';
 import { registerPerformanceMetricsTool } from '../../src/tools/performance-metrics';
 import type { MCPToolDefinition, ToolContext, ToolHandler } from '../../src/types/mcp';
-import { withTimeout } from '../../src/utils/with-timeout';
+import { withTimeout } from '../../src/core/deadline/with-timeout';
 import {
   EMPTY_SECRET_STORE,
   makeSecretStore,


### PR DESCRIPTION
## Summary
- move deadline-aware withTimeout into src/core/deadline beside Budget
- update tool, DOM, CDP, and test imports to the new owner
- update current roadmap references that point to the timeout helper

## Notes
- src/tools/storage.ts had CRLF endings; path edits required line-ending normalization so git diff --check stays clean.

## Verification
- npm test -- --runTestsByPath tests/core/deadline/with-timeout.test.ts tests/tools/act.test.ts tests/tools/interact.coordinate.test.ts tests/tools/interact-opened-tabs.test.ts tests/tools/performance-metrics-contract-facts.test.ts tests/dom/dom-serializer-timeout.test.ts tests/core/screenshot/guards.test.ts --runInBand
- npm run build
- npm run lint
- npm run lint:tier
- npm run lint:repo-structure
- git diff --check