### PR TITLE
Guard the remaining utility boundary

### DIFF
--- a/docs/dev/project-structure.md
+++ b/docs/dev/project-structure.md
@@ -42,8 +42,9 @@ Do not add ad hoc root folders for experiments, generated reports, worktrees,
 agent-local state, or one-off validation outputs. Put durable contributor
 documentation under `docs/`, runnable maintenance code under `scripts/`, and
 ignored local outputs under paths covered by `.gitignore`.
-`npm run lint:repo-structure` enforces the current `src/` root entry allow-list
-and prevents reintroducing the deprecated `tests/src` bucket.
+`npm run lint:repo-structure` enforces the current `src/` root entry allow-list,
+the approved `src/utils` leaf allow-list, the approved `tests/utils` shared
+helper allow-list, and prevents reintroducing the deprecated `tests/src` bucket.
 
 ## Package Publish Surface
 
@@ -66,7 +67,7 @@ belongs in `skills/` and `commands/`; do not fork equivalent copies under
 
 | Path | Responsibility |
 | --- | --- |
-| `src/core/` | domain primitives shared by runtime features: lifecycle, process liveness, contracts, output, metrics, tracing, crawl, task-run, and task-ledger. |
+| `src/core/` | domain primitives shared by runtime features: lifecycle, process liveness, contracts, output, metrics, tracing, crawl, deadline handling, filesystem persistence, task-run, and task-ledger. |
 | `src/tools/` | MCP tool implementations and tool-local helpers. Tool code may call `src/core`, but core code should not import tools. |
 | `src/mcp/` | MCP server implementation, protocol ingress helpers, session-init policy, and MCP output accounting. `src/mcp-server.ts` is a compatibility re-export for existing imports. |
 | `src/transports/` | MCP/HTTP transport surfaces and protocol adapters. |
@@ -77,7 +78,7 @@ belongs in `skills/` and `commands/`; do not fork equivalent copies under
 | `src/pilot/` | higher-level agent runtime features: skills, handoff, voting, credentials, curator, and automation runtime. |
 | `src/hints/`, `src/recovery/`, `src/failure/` | guidance, recovery, and failure classification. |
 | `src/vision/`, `src/perception`-related core modules | visual and perception-oriented processing. |
-| `src/utils/` | cross-cutting leaf utilities only. If a utility gains domain ownership, move it into the owning module. |
+| `src/utils/` | approved cross-cutting leaf utilities only: formatting, logging, retry fallback, listener safety, and URL helpers. No subdirectories or stateful domain services. |
 
 ## Test Layout
 

--- a/scripts/lint-repo-structure.mjs
+++ b/scripts/lint-repo-structure.mjs
@@ -12,12 +12,35 @@ const allowedSrcRootFiles = new Set([
   'version.ts',
 ]);
 
+const allowedSrcUtilsFiles = new Set([
+  'format-age.ts',
+  'format-error.ts',
+  'log.ts',
+  'retry-with-fallback.ts',
+  'safe-listener.ts',
+  'url-utils.ts',
+]);
+
+const allowedTestsUtilsFiles = new Set([
+  'mock-cdp.ts',
+  'mock-session.ts',
+  'retry-with-fallback.test.ts',
+  'safe-listener.test.ts',
+  'test-helpers.ts',
+]);
+
 const errors = [];
 
 function listFiles(dir) {
   return readdirSync(join(root, dir))
     .filter((entry) => statSync(join(root, dir, entry)).isFile())
     .sort();
+}
+
+function listEntries(dir) {
+  return readdirSync(join(root, dir))
+    .map((entry) => ({ entry, stat: statSync(join(root, dir, entry)) }))
+    .sort((a, b) => a.entry.localeCompare(b.entry));
 }
 
 for (const file of listFiles('src')) {
@@ -37,6 +60,38 @@ try {
 } catch (error) {
   if (error?.code !== 'ENOENT') {
     throw error;
+  }
+}
+
+for (const { entry, stat } of listEntries('src/utils')) {
+  if (stat.isDirectory()) {
+    errors.push(
+      `src/utils/${entry} is a utility subdirectory. ` +
+      'Move domain code into an owning src/<domain>/ folder.',
+    );
+    continue;
+  }
+  if (stat.isFile() && !allowedSrcUtilsFiles.has(entry)) {
+    errors.push(
+      `src/utils/${entry} is not an approved leaf utility. ` +
+      'Put domain-owned helpers under src/core, src/cdp, src/chrome, src/session, or src/tools.',
+    );
+  }
+}
+
+for (const { entry, stat } of listEntries('tests/utils')) {
+  if (stat.isDirectory()) {
+    errors.push(
+      `tests/utils/${entry} is a test utility subdirectory. ` +
+      'Move domain tests under the matching tests/<domain>/ folder.',
+    );
+    continue;
+  }
+  if (stat.isFile() && !allowedTestsUtilsFiles.has(entry)) {
+    errors.push(
+      `tests/utils/${entry} is not an approved shared test helper or utility test. ` +
+      'Mirror the owning production folder under tests/<domain>/.',
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- add src/utils and tests/utils allow-lists to repo-structure lint
- forbid utility subdirectories so domain code cannot re-accumulate under utils
- document the enforced utility boundary and new core fs/deadline ownership

## Verification
- npm run lint:repo-structure
- npm run build
- npm run lint
- npm run lint:tier
- git diff --check