### PR TITLE
Clarify extraction ownership without collapsing domains

### DIFF
--- a/docs/dev/project-structure.md
+++ b/docs/dev/project-structure.md
@@ -73,6 +73,7 @@ belongs in `skills/` and `commands/`; do not fork equivalent copies under
 | `src/transports/` | MCP/HTTP transport surfaces and protocol adapters. |
 | `src/chrome/`, `src/cdp/`, `src/browser-state/` | Chrome process, PID/guardian cleanup, controller ownership, CDP, and browser state integration. |
 | `src/dom/` | DOM serialization, element discovery, AX resolution, shadow DOM traversal, and DOM-change feedback. |
+| `src/extraction/` | `extract_data` schema validation, extraction mode planning, semantic host payloads, and browser-side strategy script generation. Shared HTML-to-markdown and content filtering primitives live under `src/core/extract`. |
 | `src/session/` | session ownership, lease, snapshot, and lifecycle coordination. `src/session-manager.ts` is a compatibility re-export for existing imports; new code should import from `src/session/manager` or the nearest package entrypoint. |
 | `src/router/` | routing browser/tool commands to the correct target or tab. |
 | `src/observability/` | logging, redaction, and visual trajectory adapters. Request context lives under `src/core/observability` because metrics, security, transports, resources, and tools all share it. |
@@ -107,9 +108,8 @@ belongs in `skills/` and `commands/`; do not fork equivalent copies under
 Use this order for future structure work:
 
 1. Collapse duplicate ownership only after import graph inspection.
-2. Clarify `src/extraction` versus `src/core/extract`.
-3. Clarify `src/security` versus `src/core/secrets`.
-4. Clarify `src/harness`, `src/run-harness`, and `tests/harness`.
-5. Clarify `src/pilot/skill`, `src/core/skill`, and `src/resources/skill-graph`.
-6. Move any remaining single-file root modules into their owning folder when the
+2. Clarify `src/security` versus `src/core/secrets`.
+3. Clarify `src/harness`, `src/run-harness`, and `tests/harness`.
+4. Clarify `src/pilot/skill`, `src/core/skill`, and `src/resources/skill-graph`.
+5. Move any remaining single-file root modules into their owning folder when the
    import surface is small and tests can prove the move.

--- a/src/core/crawl/static-fetch.ts
+++ b/src/core/crawl/static-fetch.ts
@@ -7,8 +7,8 @@
  *   - isStaticSufficient(html, status, contentType): deterministic check used to
  *     decide whether the static response is good enough or the crawler must fall
  *     back to the CDP tab path.
- *   - getBodyText(html): regex-based extractor used when A1's extractMainContent
- *     is not yet available in the tree.
+ *   - getBodyText(html): regex-based extractor used when the shared core
+ *     extractor is not available.
  *
  * Zero new dependencies (Node 20+ built-in fetch / undici).
  *
@@ -253,7 +253,7 @@ async function readBodyWithCap(response: Response, maxBytes: number): Promise<st
 // ---------------------------------------------------------------------------
 
 interface ExtractMainContentFn {
-  (html: string, opts?: { onlyMainContent?: boolean }): string;
+  (html: string, opts?: { onlyMainContent?: boolean }): string | { html: string };
 }
 
 let cachedExtractMainContent: ExtractMainContentFn | null | undefined;
@@ -261,9 +261,9 @@ let cachedExtractMainContent: ExtractMainContentFn | null | undefined;
 function tryLoadA1Extractor(): ExtractMainContentFn | null {
   if (cachedExtractMainContent !== undefined) return cachedExtractMainContent;
   try {
-    // Resolve at runtime so A3 doesn't hard-depend on A1.
+    // Resolve at runtime so static fetch can still fall back in stripped builds.
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const mod = require('../core/extract/html-to-markdown');
+    const mod = require('../extract/html-to-markdown');
     if (mod && typeof mod.extractMainContent === 'function') {
       cachedExtractMainContent = mod.extractMainContent as ExtractMainContentFn;
       return cachedExtractMainContent;
@@ -276,7 +276,7 @@ function tryLoadA1Extractor(): ExtractMainContentFn | null {
 }
 
 /**
- * Regex-based body-text extractor used when A1's extractMainContent isn't
+ * Regex-based body-text extractor used when the shared core extractor is not
  * available. Strips <script>, <style>, all tags and collapses whitespace.
  *
  * Exported separately so it can be unit-tested independently of the dynamic
@@ -303,8 +303,8 @@ export function getBodyText(html: string): string {
 }
 
 /**
- * Extract body text using A1's extractor when present, otherwise the regex
- * fallback. Behavior is observable through the StaticBodyTextSource return.
+ * Extract body text using the shared core extractor when present, otherwise the
+ * regex fallback. Behavior is observable through the StaticBodyTextSource return.
  */
 export function extractBodyText(html: string): { text: string; source: 'a1' | 'fallback' } {
   const a1 = tryLoadA1Extractor();
@@ -312,6 +312,7 @@ export function extractBodyText(html: string): { text: string; source: 'a1' | 'f
     try {
       const out = a1(html, { onlyMainContent: false });
       if (typeof out === 'string') return { text: out, source: 'a1' };
+      return { text: getBodyText(out.html), source: 'a1' };
     } catch {
       // fall through to regex extractor
     }

--- a/tests/core/crawl/static-fetch.test.ts
+++ b/tests/core/crawl/static-fetch.test.ts
@@ -144,12 +144,12 @@ describe('getBodyText (regex fallback)', () => {
     expect(getBodyText('')).toBe('');
   });
 
-  test('extractBodyText falls back to regex when A1 extractor is absent', () => {
+  test('extractBodyText uses the core extractor when available', () => {
     __resetExtractorCacheForTests();
-    const html = '<html><body><p>plain content here</p></body></html>';
+    const html = '<html><body><p>plain content here</p><script>alert(1)</script></body></html>';
     const { text, source } = extractBodyText(html);
     expect(text).toBe('plain content here');
-    expect(source).toBe('fallback');
+    expect(source).toBe('a1');
   });
 });
 


### PR DESCRIPTION
## Summary
- document why src/extraction and src/core/extract remain separate owners
- fix static fetch lazy loading to resolve the shared core extract module from src/core/crawl
- add a regression assertion that static fetch uses the core extractor when available

## Architecture
- src/extraction owns extract_data schema, mode, semantic payload, and strategy generation
- src/core/extract owns shared HTML-to-markdown and content filtering primitives

## Verification
- npm test -- --runTestsByPath tests/core/crawl/static-fetch.test.ts tests/core/extract/html-to-markdown.test.ts tests/core/extract/content-filter.test.ts tests/core/extract/legacy-snapshot.test.ts tests/extraction/plan.test.ts tests/extraction/strategies.test.ts tests/tools/extract-data-modes.test.ts --runInBand
- npm run build
- npm run lint
- npm run lint:tier
- npm run lint:repo-structure
- git diff --check