### PR TITLE
Clarify security policy ownership

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -29,6 +29,15 @@ module.exports = {
       from: { path: '^src/core/' },
       to: { path: '^src/observability/' },
     },
+    {
+      name: 'core-must-not-import-security-policy-adapters',
+      severity: 'error',
+      comment:
+        'src/core/ owns reusable primitives, including secret loading/redaction/substitution, but must not ' +
+        'depend on top-level security policy adapters such as domain guards, MCP roots, audit logging, or content sanitization.',
+      from: { path: '^src/core/' },
+      to: { path: '^src/security/' },
+    },
   ],
   options: {
     tsConfig: { fileName: 'tsconfig.json' },

--- a/docs/dev/project-structure.md
+++ b/docs/dev/project-structure.md
@@ -67,7 +67,7 @@ belongs in `skills/` and `commands/`; do not fork equivalent copies under
 
 | Path | Responsibility |
 | --- | --- |
-| `src/core/` | domain primitives shared by runtime features: lifecycle, process liveness, request-scoped observability context, contracts, output, metrics collection and token estimates, tracing, crawl, deadline handling, filesystem persistence, task-run, and task-ledger. |
+| `src/core/` | domain primitives shared by runtime features: lifecycle, process liveness, request-scoped observability context, contracts, output, metrics collection and token estimates, tracing, crawl, deadline handling, filesystem persistence, secret loading/redaction/substitution, task-run, and task-ledger. |
 | `src/tools/` | MCP tool implementations and tool-local helpers. Tool code may call `src/core`, but core code should not import tools. |
 | `src/mcp/` | MCP server implementation, protocol ingress helpers, session-init policy, and MCP output accounting. `src/mcp-server.ts` is a compatibility re-export for existing imports. |
 | `src/transports/` | MCP/HTTP transport surfaces and protocol adapters. |
@@ -77,6 +77,7 @@ belongs in `skills/` and `commands/`; do not fork equivalent copies under
 | `src/session/` | session ownership, lease, snapshot, and lifecycle coordination. `src/session-manager.ts` is a compatibility re-export for existing imports; new code should import from `src/session/manager` or the nearest package entrypoint. |
 | `src/router/` | routing browser/tool commands to the correct target or tab. |
 | `src/observability/` | logging, redaction, and visual trajectory adapters. Request context lives under `src/core/observability` because metrics, security, transports, resources, and tools all share it. |
+| `src/security/` | runtime policy and untrusted-boundary enforcement: domain allow/block policy, MCP root narrowing, tool risk gates, audit logging adapters, and prompt-injection content sanitization. Secret value mechanics stay under `src/core/secrets`; `src/security` may use core primitives, but `src/core` must not import security policy adapters. |
 | `src/pilot/` | higher-level agent runtime features: skills, handoff, voting, credentials, curator, and automation runtime. |
 | `src/hints/`, `src/recovery/`, `src/failure/` | guidance, recovery, and failure classification. |
 | `src/vision/`, `src/perception`-related core modules | visual and perception-oriented processing. |
@@ -108,8 +109,7 @@ belongs in `skills/` and `commands/`; do not fork equivalent copies under
 Use this order for future structure work:
 
 1. Collapse duplicate ownership only after import graph inspection.
-2. Clarify `src/security` versus `src/core/secrets`.
-3. Clarify `src/harness`, `src/run-harness`, and `tests/harness`.
-4. Clarify `src/pilot/skill`, `src/core/skill`, and `src/resources/skill-graph`.
-5. Move any remaining single-file root modules into their owning folder when the
+2. Clarify `src/harness`, `src/run-harness`, and `tests/harness`.
+3. Clarify `src/pilot/skill`, `src/core/skill`, and `src/resources/skill-graph`.
+4. Move any remaining single-file root modules into their owning folder when the
    import surface is small and tests can prove the move.


### PR DESCRIPTION
## Summary
- document src/core/secrets as the owner of secret loading, redaction, and substitution primitives
- document src/security as the owner of runtime policy and untrusted-boundary enforcement
- add a dependency-cruiser guard preventing src/core from importing top-level security policy adapters
- remove the security/secrets item from the current cleanup backlog

## Lore
Constraint: import graph shows src/security depends on core observability while src/core has no production dependency on src/security.
Rejected: moving content sanitization into src/core | it is an untrusted-boundary policy adapter used by page/tool outputs, not a shared secret primitive.
Confidence: high
Scope-risk: narrow
Directive: Keep secret value mechanics in src/core/secrets and keep runtime security policy adapters out of src/core imports.

## Tested
- npm test -- --runTestsByPath tests/core/secrets/loader.test.ts tests/core/secrets/redactor.test.ts tests/core/secrets/substituter.test.ts tests/core/secrets/integration.test.ts tests/security/content-sanitizer.test.ts tests/security/domain-guard.test.ts tests/security/mcp-roots.test.ts tests/security/tool-risk-policy.test.ts tests/security/audit-redaction.test.ts tests/security/audit-logger-extended.test.ts --runInBand
- npm run build
- npm run lint
- npm run lint:tier
- npm run lint:repo-structure
- git diff --check