### PR TITLE
Clarify skill graph ownership

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -54,6 +54,30 @@ module.exports = {
       from: { path: '^src/core/' },
       to: { path: '^src/dashboard/' },
     },
+    {
+      name: 'core-must-not-import-resource-adapters',
+      severity: 'error',
+      comment:
+        'src/core/ owns storage and domain primitives; MCP resource presentation belongs outside core.',
+      from: { path: '^src/core/' },
+      to: { path: '^src/resources/' },
+    },
+    {
+      name: 'resources-must-not-import-pilot',
+      severity: 'error',
+      comment:
+        'MCP resources may present core state, but pilot executor and replay behavior stays in src/pilot/.',
+      from: { path: '^src/resources/' },
+      to: { path: '^src/pilot/' },
+    },
+    {
+      name: 'pilot-skill-must-not-import-resource-adapters',
+      severity: 'error',
+      comment:
+        'Pilot skill execution may read core skill storage, but MCP resource presentation must not feed executor behavior.',
+      from: { path: '^src/pilot/skill/' },
+      to: { path: '^src/resources/' },
+    },
   ],
   options: {
     tsConfig: { fileName: 'tsconfig.json' },

--- a/docs/dev/project-structure.md
+++ b/docs/dev/project-structure.md
@@ -67,7 +67,7 @@ belongs in `skills/` and `commands/`; do not fork equivalent copies under
 
 | Path | Responsibility |
 | --- | --- |
-| `src/core/` | domain primitives shared by runtime features: lifecycle, process liveness, request-scoped observability context, contracts, output, metrics collection and token estimates, tracing, crawl, deadline handling, filesystem persistence, secret loading/redaction/substitution, task-run, and task-ledger. |
+| `src/core/` | domain primitives shared by runtime features: lifecycle, process liveness, request-scoped observability context, contracts, output, metrics collection and token estimates, tracing, crawl, deadline handling, filesystem persistence, secret loading/redaction/substitution, task-run, task-ledger, and skill graph storage/types. |
 | `src/tools/` | MCP tool implementations and tool-local helpers. Tool code may call `src/core`, but core code should not import tools. |
 | `src/mcp/` | MCP server implementation, protocol ingress helpers, session-init policy, and MCP output accounting. `src/mcp-server.ts` is a compatibility re-export for existing imports. |
 | `src/transports/` | MCP/HTTP transport surfaces and protocol adapters. |
@@ -81,6 +81,7 @@ belongs in `skills/` and `commands/`; do not fork equivalent copies under
 | `src/harness/` | cross-tier feature-flag bootstrap only. It gates pilot families without importing `src/pilot`; stateful runtime ledgers belong under `src/core/task-ledger`, and opt-in run tooling belongs under `src/run-harness`. |
 | `src/run-harness/` | opt-in run tracking tools: run budgets, evidence capture, run store persistence, and MCP tool registration for run-level observability. |
 | `src/pilot/` | higher-level agent runtime features: skills, handoff, voting, credentials, curator, and automation runtime. |
+| `src/resources/` | MCP resource presentation adapters. Skill graph resources read from `src/core/skill` storage; resource adapters must not own graph mutation or pilot executor behavior. |
 | `src/hints/`, `src/recovery/`, `src/failure/` | guidance, recovery, and failure classification. |
 | `src/vision/`, `src/perception`-related core modules | visual and perception-oriented processing. |
 | `src/utils/` | approved cross-cutting leaf utilities only: formatting, logging, retry fallback, listener safety, and URL helpers. No subdirectories or stateful domain services. |
@@ -111,6 +112,5 @@ belongs in `skills/` and `commands/`; do not fork equivalent copies under
 Use this order for future structure work:
 
 1. Collapse duplicate ownership only after import graph inspection.
-2. Clarify `src/pilot/skill`, `src/core/skill`, and `src/resources/skill-graph`.
-3. Move any remaining single-file root modules into their owning folder when the
+2. Move any remaining single-file root modules into their owning folder when the
    import surface is small and tests can prove the move.

--- a/src/resources/skill-graph.ts
+++ b/src/resources/skill-graph.ts
@@ -16,7 +16,7 @@ import {
   SkillGraphStorage,
   defaultSkillGraphRootDir,
   type SkillGraphStorageOptions,
-} from '../core/skill/storage';
+} from '../core/skill';
 import type { MCPResourceDefinition } from './usage-guide';
 
 /** The URI prefix for all skill-graph resources. */


### PR DESCRIPTION
## Summary
- document core skill graph storage/types ownership under src/core
- document src/resources as MCP resource presentation adapters
- switch the skill-graph resource to import through the src/core/skill package boundary
- add dependency-cruiser guards preserving core/resource/pilot-skill direction
- remove the skill graph ownership item from the current cleanup backlog

## Lore
Constraint: import graph shows resources read core skill storage and pilot skill execution reads core storage, with no justified module move across the three owners.
Rejected: moving skill-graph resources into core | MCP resource presentation is an adapter and should not own storage mutation or pilot executor behavior.
Confidence: high
Scope-risk: narrow
Directive: Import skill graph storage through src/core/skill and keep resource adapters out of core and pilot skill execution.

## Tested
- npm test -- --runTestsByPath tests/core/skill/storage.test.ts tests/pilot/skill/executor.test.ts tests/pilot/skill/replay.test.ts tests/pilot/skill/flag-gating.test.ts tests/core/mcp/resources/skill-graph.test.ts tests/e2e/skill-resume/prime.test.ts tests/pilot/dynamic-skills/replay.test.ts tests/pilot/dynamic-skills/synthesizer.test.ts --runInBand
- npm run build
- npm run lint
- npm run lint:tier
- npm run lint:repo-structure
- git diff --check